### PR TITLE
feat(security): route python step subprocess through the OS sandbox backend (#1352-B)

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -585,8 +585,12 @@ class PreprocessorExecutor:
         )
 
         try:
-            result = await asyncio.to_thread(
-                self._python_runner.run,
+            # #1352-B: python_runner.run is async + routes the harness subprocess
+            # through the OS sandbox backend when one is configured (real backend
+            # → Seatbelt/Landlock/container; noop/None → direct subprocess, which
+            # run() runs in a thread internally). The agent/operator sandbox
+            # policy supplies the OS caps (write-tight to the workspace).
+            result = await self._python_runner.run(
                 skill_dir=Path(self._skill.skill_dir),
                 module=step.module,
                 function=step.function,
@@ -598,6 +602,8 @@ class PreprocessorExecutor:
                 file_write_paths=file_write_paths,
                 http_hosts=http_hosts,
                 sandbox_write_paths=sandbox_write_paths,
+                sandbox_backend=self._sandbox_backend,
+                sandbox_policy=self._agent_sandbox_policy,
             )
         except PythonStepError as exc:
             self._events.emit(

--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -15,11 +15,15 @@ SystemExit in the child terminates the child, not reyn itself.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.sandbox.backend import SandboxBackend
 
 
 class PythonStepError(RuntimeError):
@@ -74,7 +78,7 @@ class PythonRunner:
         # what the user code runs against (consistent imports / 3rd-party).
         self.python_executable = python_executable or sys.executable
 
-    def run(
+    async def run(
         self,
         *,
         skill_dir: Path,
@@ -88,6 +92,8 @@ class PythonRunner:
         file_write_paths: list[str] | None = None,
         http_hosts: list[str] | None = None,
         sandbox_write_paths: list[str] | None = None,
+        sandbox_backend: "SandboxBackend | None" = None,
+        sandbox_policy: dict | None = None,
     ) -> Any:
         """Execute `function` in `module` against `artifact`.
 
@@ -105,6 +111,16 @@ class PythonRunner:
         #571 collapse arc Phase 3: ``http_hosts`` mirrors the same wiring
         for ``reyn.safe.http.*`` per-host gating. Empty = no HTTP via
         safe.http.
+
+        #1352-B: when ``sandbox_backend`` is a real backend (available, not
+        noop), the harness subprocess is routed through ``backend.run`` so it
+        executes under an OS sandbox (Seatbelt / Landlock / container) — the
+        same model as ``sandboxed_exec``. The harness's Python-level
+        restricted-builtins stay (defense-in-depth, both layers); any subprocess
+        the step spawns (incl. ``reyn.api.unsafe.shell``) is transitively
+        contained. ``noop`` / ``None`` → today's direct (unsandboxed) subprocess.
+        ``sandbox_policy`` (the agent/operator policy dict) supplies the OS caps;
+        its ``timeout_seconds`` is overridden by this step's ``timeout``.
         """
         module_abs = _resolve_module_path(skill_dir, module)
 
@@ -126,34 +142,46 @@ class PythonRunner:
         if sandbox_write_paths is not None:
             request["sandbox_write_paths"] = list(sandbox_write_paths)
 
-        try:
-            proc = subprocess.run(
-                [self.python_executable, "-m", "reyn.kernel._python_harness"],
-                input=json.dumps(request, ensure_ascii=False),
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+        argv = [self.python_executable, "-m", "reyn.kernel._python_harness"]
+        stdin_text = json.dumps(request, ensure_ascii=False)
+
+        # #1352-B: route through the OS sandbox backend when one is configured
+        # (real + available + not noop). Falls back to a direct subprocess for
+        # noop / None (unchanged behavior — standard chat runs python unsandboxed).
+        use_backend = (
+            sandbox_backend is not None
+            and getattr(sandbox_backend, "name", None) not in (None, "noop")
+            and sandbox_backend.available()
+        )
+        if use_backend:
+            stdout_text, returncode, stderr_text, timed_out = await self._run_via_backend(
+                sandbox_backend, argv, stdin_text, sandbox_policy, timeout, str(skill_dir),
             )
-        except subprocess.TimeoutExpired as exc:
+        else:
+            stdout_text, returncode, stderr_text, timed_out = await asyncio.to_thread(
+                self._run_direct, argv, stdin_text, timeout,
+            )
+
+        if timed_out:
             raise PythonStepError(
                 f"python step {module}:{function} timed out after {timeout}s",
                 kind="Timeout",
-            ) from exc
+            )
 
-        if not proc.stdout:
+        if not stdout_text:
             # Harness printed nothing (likely crashed before its handler).
             raise PythonStepError(
                 f"python step {module}:{function} crashed: "
-                f"exit={proc.returncode}, stderr={proc.stderr.strip()[:200]}",
+                f"exit={returncode}, stderr={stderr_text.strip()[:200]}",
                 kind="Crash",
             )
 
         try:
-            payload = json.loads(proc.stdout)
+            payload = json.loads(stdout_text)
         except json.JSONDecodeError as exc:
             raise PythonStepError(
                 f"python step {module}:{function} returned malformed JSON: "
-                f"{proc.stdout[:200]}",
+                f"{stdout_text[:200]}",
                 kind="MalformedResponse",
             ) from exc
 
@@ -169,3 +197,52 @@ class PythonRunner:
             kind=kind,
             traceback=traceback,
         )
+
+    def _run_direct(
+        self, argv: list[str], stdin_text: str, timeout: int,
+    ) -> tuple[str, int, str, bool]:
+        """Direct (unsandboxed) harness subprocess — the noop / None path.
+
+        Returns ``(stdout, returncode, stderr, timed_out)``. Synchronous; the
+        caller runs it via ``asyncio.to_thread``. Unchanged behavior from before
+        #1352-B (standard chat runs python steps unsandboxed)."""
+        try:
+            proc = subprocess.run(
+                argv,
+                input=stdin_text,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return "", -1, "", True
+        return proc.stdout, proc.returncode, proc.stderr, False
+
+    async def _run_via_backend(
+        self,
+        backend: "SandboxBackend",
+        argv: list[str],
+        stdin_text: str,
+        sandbox_policy: dict | None,
+        timeout: int,
+        cwd: str,
+    ) -> tuple[str, int, str, bool]:
+        """OS-sandboxed harness subprocess — the real-backend path (#1352-B).
+
+        Builds a SandboxPolicy from the agent/operator policy dict (overriding
+        ``timeout_seconds`` with this step's ``timeout``) and routes the harness
+        argv through ``backend.run`` (Seatbelt / Landlock / container — uniform
+        interface). Returns ``(stdout, returncode, stderr, timed_out)``; the
+        backend signals timeout/kill via ``returncode == -1``."""
+        from reyn.sandbox import SandboxPolicy
+
+        policy_dict = dict(sandbox_policy or {})
+        policy_dict["timeout_seconds"] = timeout
+        policy = SandboxPolicy(**policy_dict)
+
+        result = await backend.run(
+            argv, policy, stdin=stdin_text.encode("utf-8"), cwd=cwd,
+        )
+        stdout_text = result.stdout.decode("utf-8", errors="replace")
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        return stdout_text, result.returncode, stderr_text, result.returncode == -1

--- a/tests/test_1326_sandbox_policy_agent_level.py
+++ b/tests/test_1326_sandbox_policy_agent_level.py
@@ -184,7 +184,8 @@ class _RecordingPythonRunner:
     def __init__(self) -> None:
         self.sandbox_write_paths: Any = "UNSET"
 
-    def run(self, *, sandbox_write_paths=None, **kwargs):
+    async def run(self, *, sandbox_write_paths=None, **kwargs):
+        # #1352-B: PythonRunner.run is async now; the Fake mirrors the signature.
         self.sandbox_write_paths = sandbox_write_paths
         return {}  # validated against the step's permissive output_schema
 

--- a/tests/test_python_step_os_sandbox_1352b.py
+++ b/tests/test_python_step_os_sandbox_1352b.py
@@ -1,0 +1,117 @@
+"""Tier 2: python step routes through the OS sandbox backend (#1352-B).
+
+The audit (#1352) found python preprocessor/postprocessor steps ran with only
+restricted-builtins + a soft write_paths cap — no OS sandbox. Owner directive:
+python steps must run under the sandbox (file-sharing substrate). PythonRunner.run
+now routes the `_python_harness` subprocess through `SandboxBackend.run` when a
+real backend is configured (Seatbelt / Landlock / container — same model as
+sandboxed_exec); noop / None falls back to a direct subprocess (unchanged).
+
+No mocks of real collaborators: a real `_RecordingBackend` implementing the
+SandboxBackend interface (name + available + run) captures the routed argv +
+policy and returns a canned harness-success result (it stands in for the OS
+backend without actually applying isolation, which is platform-specific).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.python_runner import PythonRunner
+from reyn.sandbox.backend import SandboxResult
+
+
+class _RecordingBackend:
+    """Real (non-mock) SandboxBackend stand-in: records run() args, returns a
+    canned harness-success payload so the routing is observable without applying
+    platform-specific isolation."""
+
+    name = "seatbelt"  # pretend a real backend (not "noop")
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None) -> SandboxResult:
+        self.calls.append({"argv": list(argv), "policy": policy, "stdin": stdin, "cwd": cwd})
+        payload = {"ok": True, "result": {"echoed": "ok"}}
+        return SandboxResult(
+            returncode=0,
+            stdout=json.dumps(payload).encode("utf-8"),
+            stderr=b"",
+        )
+
+
+def _write_safe_module(skill_dir: Path) -> None:
+    """A trivial safe-mode module (re/json only) — its body never runs here
+    (the recording backend short-circuits), it only needs to resolve."""
+    (skill_dir / "mod.py").write_text(
+        "def go(artifact):\n    return {'echoed': 'ok'}\n", encoding="utf-8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_python_step_routes_through_sandbox_backend(tmp_path: Path) -> None:
+    """Tier 2: #1352-B reproduce-first — with a real backend, the harness
+    subprocess is routed through backend.run (OS sandbox), carrying the agent
+    policy (write_paths) + the per-step timeout. FAILS pre-B (run was sync +
+    ignored sandbox_backend → direct subprocess; backend.run never called)."""
+    _write_safe_module(tmp_path)
+    backend = _RecordingBackend()
+    runner = PythonRunner()
+
+    result = await runner.run(
+        skill_dir=tmp_path,
+        module="./mod.py",
+        function="go",
+        mode="safe",
+        artifact={"data": {}},
+        timeout=30,
+        sandbox_backend=backend,
+        sandbox_policy={"write_paths": [str(tmp_path)], "network": False},
+    )
+
+    # routed through the OS backend (not a direct subprocess)
+    assert backend.calls, "harness must be routed through backend.run"
+    call = backend.calls[0]
+    # the harness module is the routed command (behavioral, not arg-format pin)
+    assert "reyn.kernel._python_harness" in call["argv"]
+    # agent policy caps reached the backend; per-step timeout overrode policy
+    assert call["policy"].write_paths == [str(tmp_path)]
+    assert call["policy"].network is False
+    assert call["policy"].timeout_seconds == 30
+    # the harness JSON request was passed on stdin
+    assert call["stdin"] is not None
+    # the canned harness result is parsed + returned
+    assert result == {"echoed": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_noop_backend_falls_back_to_direct_subprocess(tmp_path: Path) -> None:
+    """Tier 2: #1352-B — a noop backend (or None) does NOT route through backend.run;
+    the direct (unsandboxed) subprocess path is used (unchanged behavior). The
+    recording backend's run must never be called."""
+
+    class _NoopRecording(_RecordingBackend):
+        name = "noop"
+
+    _write_safe_module(tmp_path)
+    backend = _NoopRecording()
+    runner = PythonRunner()
+
+    result = await runner.run(
+        skill_dir=tmp_path,
+        module="./mod.py",
+        function="go",
+        mode="safe",
+        artifact={"data": {}},
+        timeout=30,
+        sandbox_backend=backend,
+        sandbox_policy={"write_paths": [str(tmp_path)]},
+    )
+    assert not backend.calls  # noop → not routed through the backend
+    assert result == {"echoed": "ok"}  # ran via the real direct subprocess

--- a/tests/test_swe_bench_c6_v2_revert_via_sandboxed_exec.py
+++ b/tests/test_swe_bench_c6_v2_revert_via_sandboxed_exec.py
@@ -123,8 +123,10 @@ def test_parse_test_targets_safe_mode_no_violation() -> None:
         },
     }
     # Must not raise — especially not PythonStepError(kind='SafeModeViolation').
+    # #1352-B: PythonRunner.run is async now (routes through the sandbox backend
+    # when configured; here no backend → direct subprocess path).
     try:
-        result = runner.run(
+        result = asyncio.run(runner.run(
             skill_dir=_SKILL_ROOT,
             module="./parse_test_targets.py",
             function="parse_test_targets",
@@ -132,7 +134,7 @@ def test_parse_test_targets_safe_mode_no_violation() -> None:
             artifact=artifact,
             timeout=30,
             allowed_modules=[],
-        )
+        ))
     except PythonStepError as exc:
         pytest.fail(
             f"PythonRunner(mode='safe') raised PythonStepError — this reproduces the v1 regression.\n"


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-coverage audit residual **B** (the last core residual), #1352. lead approved approach (design-first). permission layer UNCHANGED — sandbox layer only. Refs #1352.

## Change

The audit found python preprocessor/postprocessor steps ran with only restricted-builtins + a soft `write_paths` cap — **no OS sandbox**, unlike `sandboxed_exec`. Owner directive: python steps must run under the sandbox (the file-sharing execution substrate — python runs under OS isolation / in the container, seeing shared `/workspace`).

`PythonRunner.run` is now **async** and routes the `_python_harness` subprocess through **`SandboxBackend.run(argv, policy, stdin, cwd)`** when a real backend is configured (Seatbelt / Landlock / container — the uniform interface `sandboxed_exec` uses; `container_backend.run` is a `docker exec` into the repo mount = owner’s file-sharing model). `noop` / `None` → direct (unsandboxed) subprocess (unchanged for standard chat; gating parity with sandboxed_exec / MCP).

- agent/operator policy (#1352-#1 concrete default, write-tight to workspace) supplies the OS caps; per-step timeout overrides `policy.timeout_seconds`.
- harness restricted-builtins KEPT (defense-in-depth, both layers); any subprocess the step spawns (incl. `reyn.api.unsafe.shell`) is **transitively contained**.
- helpers `_run_via_backend` (await backend.run, SandboxResult→payload) / `_run_direct` (subprocess, via the caller’s `to_thread`); `preprocessor_executor` `to_thread(run)` → `await run(..., sandbox_backend, sandbox_policy)`; postprocessor inherits via the delegate.
- async-ripple (contained, 1 prod call site): test_swe_bench_c6 `runner.run`→`asyncio.run`; test_1326 `_RecordingPythonRunner.run`→async.

## Test plan

- [x] **reproduce-first**: `test_python_step_routes_through_sandbox_backend` — real backend → harness routed through `backend.run` carrying the policy caps + per-step timeout; FAILS pre-B (`run` was sync + ignored `sandbox_backend`)
- [x] `test_noop_backend_falls_back_to_direct_subprocess` — noop → `backend.run` never called, real harness runs (direct path intact)
- [x] **full suite: 6911 passed, 8 skipped, 3 xfailed, 0 failed** (the impact confirmation — all skills’ python steps)
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

## Wave

Last core residual of #1352. With this: exec (#1347) + MCP (#1345/#1348/#1349) + **python steps** all run operator-policy / OS-sandbox when a backend is configured. owner ratifying the `noop=unsandboxed` gating posture (consistent across surfaces). Follow-up: **L3** (retire the now-dead `--allow-shell` / `permissions.shell` / `shell_allowed`) — owner GO confirmed, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)