### PR TITLE
refactor(sandbox): retire shell-gating plumbing — --allow-shell / permissions.shell / shell_allowed (#1352-L3)

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -46,7 +46,6 @@ class Agent:
         strict: bool = False,
         subscribers: list[Callable] | None = None,
         intervention_bus: RequestBus | None = None,
-        shell_allowed: bool = False,
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,
         safety: "SafetyConfig | None" = None,
@@ -80,7 +79,6 @@ class Agent:
         self.strict = strict
         self._subscribers = list(subscribers or [])
         self._intervention_bus = intervention_bus
-        self._shell_allowed = shell_allowed
         # #1212: skills opted into the native-tools op-loop (config-driven gate,
         # threaded to OSRuntime so the op-loop is reachable on the real run path).
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
@@ -134,7 +132,6 @@ class Agent:
         cls,
         config: "ReynConfig",
         *,
-        shell_allowed: bool,
         model: str | None = None,
         safety: "SafetyConfig | None" = None,
         resolver: ModelResolver | None = None,
@@ -162,12 +159,11 @@ class Agent:
         Construction-time prevention of the FP-0008 / #1133 wiring-gap class:
         the permission/runtime bundle that direct callers historically
         hand-listed (and sometimes omitted — e.g. ``eval benchmark`` shipped
-        without ``permission_resolver`` / ``shell_allowed``, so a phase that
-        declared ``shell`` got the op filtered to nothing and the LLM
-        hallucinated a fake schema) is derived here from ``config`` once. A
-        caller need only decide ``shell_allowed`` (+ any per-invocation extras);
-        it **cannot** forget ``permission_resolver`` / ``mcp_servers`` /
-        ``python_allowed_modules`` / ``prompt_cache_enabled`` / ``sandbox_config``.
+        without ``permission_resolver``, so a declared op got filtered to
+        nothing and the LLM hallucinated a fake schema) is derived here from
+        ``config`` once. The caller **cannot** forget ``permission_resolver`` /
+        ``mcp_servers`` / ``python_allowed_modules`` / ``prompt_cache_enabled`` /
+        ``sandbox_config``.
 
         ``model`` / ``safety`` / ``resolver`` default to the config-derived value
         but accept an override (e.g. ``reyn run`` passes an args-aware
@@ -183,8 +179,6 @@ class Agent:
         from reyn.config import _find_project_root
 
         perm_config = dict(getattr(config, "permissions", {}) or {})
-        if shell_allowed and "shell" not in perm_config:
-            perm_config["shell"] = "allow"
         permission_resolver = PermissionResolver(
             config_permissions=perm_config,
             project_root=_find_project_root(Path.cwd()),
@@ -196,7 +190,6 @@ class Agent:
             strict=strict,
             subscribers=subscribers,
             intervention_bus=intervention_bus,
-            shell_allowed=shell_allowed,
             resolver=resolver if resolver is not None else ModelResolver(config.models),
             permission_resolver=permission_resolver,
             safety=safety if safety is not None else config.safety,
@@ -288,7 +281,6 @@ class Agent:
             subscribers=[store] + self._subscribers,
             intervention_bus=self._intervention_bus,
             run_id=self.run_id,
-            shell_allowed=self._shell_allowed,
             resolver=self._resolver,
             permission_resolver=self._permission_resolver,
             safety=self._safety,

--- a/src/reyn/cli/commands/config.py
+++ b/src/reyn/cli/commands/config.py
@@ -77,7 +77,6 @@ def _show() -> None:
         "models":          config.models,
         "api_base":        config.api_base or "(not set)",
         "output_language": config.output_language or "(not set — chat router skips language directive; phase paths default to ja)",
-        "shell_allowed":   config.shell_allowed,
         "permissions":     config.permissions,
         "mcp":             config.mcp if config.mcp else "(not configured)",
     }

--- a/src/reyn/cli/commands/cron.py
+++ b/src/reyn/cli/commands/cron.py
@@ -290,10 +290,9 @@ def _build_runner():
         logger = make_logger()
 
         # #997 dir2: config-derived permission/runtime bundle wired by
-        # Agent.from_config (cron jobs run unattended → shell_allowed=False).
+        # Agent.from_config (cron jobs run unattended).
         agent = Agent.from_config(
             config,
-            shell_allowed=False,
             model=resolved,
             resolver=resolver,
             strict=False,

--- a/src/reyn/cli/commands/eval.py
+++ b/src/reyn/cli/commands/eval.py
@@ -275,7 +275,6 @@ def _run_case(
     # #997 dir2: config-derived permission/runtime bundle via from_config.
     agent = Agent.from_config(
         session.config,
-        shell_allowed=False,
         model=model,
         resolver=session.resolver,
         safety=session.safety_for(argparse.Namespace()),
@@ -848,7 +847,6 @@ def _run_spec_case(
     # #997 dir2: config-derived permission/runtime bundle via from_config.
     agent = Agent.from_config(
         session.config,
-        shell_allowed=False,
         model=model,
         resolver=session.resolver,
         safety=session.safety_for(args),

--- a/src/reyn/cli/commands/eval_benchmark.py
+++ b/src/reyn/cli/commands/eval_benchmark.py
@@ -359,15 +359,6 @@ def register_benchmark(eval_sub) -> None:
         help="Model override (default: from reyn.yaml)",
     )
     p.add_argument(
-        "--allow-shell", dest="allow_shell", action="store_true",
-        help=(
-            "Enable the 'shell' Control IR op for every task in this batch. "
-            "Required when the target skill declares `permissions.shell: true` "
-            "(e.g. `swe_bench`, which checks out repos + runs tests). "
-            "Off by default for safety; matches `reyn run --allow-shell`."
-        ),
-    )
-    p.add_argument(
         "--allow-unsafe-python", "--allow-untrusted-python",
         dest="allow_unsafe_python", action="store_true",
         help=(
@@ -679,7 +670,6 @@ async def _run_single_task(
     session,
     run_dir: Path,
     semaphore: asyncio.Semaphore,
-    shell_allowed: bool = False,
     unsafe_python: bool = False,
     python_allowed_modules: list[str] | None = None,
     clone_task_repo: bool = False,
@@ -687,9 +677,9 @@ async def _run_single_task(
 ) -> dict:
     """Run a single task under the semaphore; return a result record.
 
-    ``shell_allowed`` + ``unsafe_python`` are derived once at batch start
-    (= from ``--allow-shell`` / ``--allow-unsafe-python``) and threaded through
-    every task; ``Agent.from_config`` then derives the permission_resolver (and
+    ``unsafe_python`` is derived once at batch start (= from
+    ``--allow-unsafe-python``) and threaded through every task;
+    ``Agent.from_config`` then derives the permission_resolver (and
     the rest of the runtime bundle) per task so the Agent's op_catalog exposes
     the shell op uniformly (#997 dir2 — the benchmark cannot omit the bundle).
     Without this, the LLM doesn't see ``shell`` in the catalog and hallucinates
@@ -733,9 +723,9 @@ async def _run_single_task(
                 # mcp_servers, python_allowed_modules, prompt_cache_enabled,
                 # sandbox_config, resolver) is derived from config inside
                 # from_config — the benchmark cannot omit it (this WAS the FP-0008
-                # gap: a missing permission_resolver/shell_allowed left shell out
+                # gap: a missing permission_resolver left a declared op out
                 # of the catalog, the LLM hallucinated a fake schema). The
-                # permission resolver is derived per task from shell_allowed +
+                # permission resolver is derived per task from
                 # unsafe_python (identical to the prior batch-built one, which used
                 # the same _build_permission_resolver). interactive=False: a
                 # benchmark subprocess is non-interactive.
@@ -747,7 +737,7 @@ async def _run_single_task(
                 # swe_bench's file.read/write: "*") needs a config-grant to be
                 # approved without an interactive prompt. Scope it to the
                 # benchmark's isolated workspace (same procedure as the
-                # shell_allowed / unsafe_python pre-approvals above). setdefault
+                # unsafe_python pre-approvals above). setdefault
                 # preserves any explicit operator setting.
                 session.config.permissions.setdefault("file.read", "allow")
                 session.config.permissions.setdefault("file.write", "allow")
@@ -775,7 +765,6 @@ async def _run_single_task(
                     )
                 agent = Agent.from_config(
                     session.config,
-                    shell_allowed=shell_allowed,
                     model=model,
                     resolver=session.resolver,
                     safety=session.safety_for(argparse.Namespace()),
@@ -928,13 +917,12 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
     session = session_mod.Session.from_args(args)
     model = getattr(args, "model", None) or session.config.model
 
-    # Derive shell_allowed + unsafe_python once at batch start and thread them
+    # Derive unsafe_python once at batch start and thread it
     # through every task; Agent.from_config derives the permission_resolver (+
     # the rest of the runtime bundle) per task (#997 dir2). Without the right
-    # shell_allowed the Agent's OS runtime keeps `shell` out of the op_catalog
+    # the Agent's OS runtime keeps undeclared ops out of the op_catalog
     # and the LLM hallucinates a fake schema on every retry — see
     # _run_single_task docstring.
-    shell_allowed = session.shell_allowed_for(args)
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
     clone_task_repo = bool(getattr(args, "clone_task_repo", False))
 
@@ -1020,7 +1008,6 @@ async def _run_benchmark_async(args: argparse.Namespace) -> None:
                 session=session,
                 run_dir=run_dir,
                 semaphore=semaphore,
-                shell_allowed=shell_allowed,
                 unsafe_python=unsafe_python,
                 clone_task_repo=clone_task_repo,
                 verify_tier=verify_tier,

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -660,7 +660,6 @@ def run_install(args: argparse.Namespace) -> None:
     # #997 dir2: config-derived permission/runtime bundle wired by from_config.
     agent = Agent.from_config(
         config,
-        shell_allowed=False,
         resolver=resolver,
         strict=False,
         subscribers=[logger],

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -61,12 +61,6 @@ def register(sub) -> None:
                        "Enable strict schema validation: enforce required fields at every nesting depth. "
                        "Default (lenient) only enforces required at the top level of each artifact."
                    ))
-    p.add_argument("--allow-shell", dest="allow_shell", action="store_true",
-                   help=(
-                       "Enable the 'shell' Control IR op, which allows the LLM to execute shell commands. "
-                       "Required for meta-apps that invoke sub-processes (e.g. app_improver). "
-                       "Off by default for safety."
-                   ))
     # FP-0014: --allow-untrusted-python renamed → --allow-unsafe-python.
     # Both flags target the same dest so legacy invocations keep working
     # during the Track A → B transition. New code should use the new flag.
@@ -145,7 +139,6 @@ def run(args: argparse.Namespace) -> None:
     # naturally. Reyn explicitly does not fall back to a regional default
     # (= no silent "ja" default) — the project targets a global audience.
     output_language = session.output_language_for(args)
-    shell_allowed = session.shell_allowed_for(args)
     safety = session.safety_for(args)
 
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
@@ -170,7 +163,6 @@ def run(args: argparse.Namespace) -> None:
     # passed here.
     agent = Agent.from_config(
         session.config,
-        shell_allowed=shell_allowed,
         model=model,
         safety=safety,
         resolver=session.resolver,
@@ -418,13 +410,11 @@ def _parse_cli_input(raw: str, *, default_type: str | None = None) -> dict:
     return parsed
 
 
-def _build_permission_resolver(config, shell_allowed: bool, unsafe_python: bool = False):
+def _build_permission_resolver(config, unsafe_python: bool = False):
     from reyn.config import _find_project_root
     from reyn.permissions.permissions import PermissionResolver
     project_root = _find_project_root(Path.cwd())
     perm_config = getattr(config, "permissions", {}) or {}
-    if shell_allowed and "shell" not in perm_config:
-        perm_config = dict(perm_config, shell="allow")
     return PermissionResolver(
         config_permissions=perm_config,
         project_root=project_root,

--- a/src/reyn/cli/session.py
+++ b/src/reyn/cli/session.py
@@ -83,5 +83,3 @@ class Session:
     def limits_for(self, args: argparse.Namespace) -> SafetyConfig:
         return self.safety_for(args)
 
-    def shell_allowed_for(self, args: argparse.Namespace) -> bool:
-        return bool(getattr(args, "allow_shell", False)) or self.config.shell_allowed

--- a/src/reyn/cli/templates.py
+++ b/src/reyn/cli/templates.py
@@ -16,7 +16,6 @@ models:
   strong:   openai/gpt-4o
 
 # output_language: en          # en | ja | zh | ...
-# shell_allowed: false         # allow 'shell' Control IR op (meta-apps only)
 
 # ───────────────────────────────────────────────────────────────────────────
 # Pre-approved permissions for chat / skill ops.

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1576,10 +1576,6 @@ class ReynConfig:
         default=None,
         metadata={"desc": "Language code injected into the context frame for all LLM outputs."},
     )
-    shell_allowed: bool = field(
-        default=False,
-        metadata={"desc": "Allow the shell Control IR op globally. Equivalent to --allow-shell on every run."},
-    )
     models: dict[str, str | dict] = field(
         default_factory=dict,
         metadata={"desc": "Map of model class names to LiteLLM model strings."},
@@ -2020,7 +2016,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     # skip the language directive) from "user explicitly set it" (= str,
     # router prompt enforces it strictly). See `ReynConfig.output_language`.
     merged: dict = {"model": "standard",
-                    "shell_allowed": False, "models": {}, "permissions": {},
+                    "models": {}, "permissions": {},
                     "mcp": {}}
 
     # User global
@@ -2104,7 +2100,6 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     return ReynConfig(
         model=str(merged.get("model", "standard")),
         output_language=output_language,
-        shell_allowed=bool(merged.get("shell_allowed", False)),
         models={
             str(k): (v if isinstance(v, dict) else str(v))
             for k, v in (merged.get("models") or {}).items()

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -83,7 +83,6 @@ class ControlIRExecutor:
         workspace: Workspace,
         events: EventLog,
         intervention_bus: RequestBus | None = None,
-        shell_allowed: bool = False,
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,
         max_phase_visits: int = 25,
@@ -108,7 +107,6 @@ class ControlIRExecutor:
         self._budget_tracker = budget_tracker
         self._intervention_bus = intervention_bus
         self._max_phase_visits = max_phase_visits
-        self._shell_allowed = shell_allowed
         self._resolver = resolver or ModelResolver({})
         self._perm = permission_resolver
         self._skill_name = skill_name
@@ -229,7 +227,7 @@ class ControlIRExecutor:
 
         These specs flow into ContextFrame.available_control_ops; the LLM picks
         from this list when emitting `control_ir`. Op kinds are filtered per
-        runtime config (shell_allowed, mcp_servers configured) and per phase by
+        runtime config (mcp_servers configured) and per phase by
         ``allowed_ops`` in ``build_frame``.
         """
         return [
@@ -251,10 +249,8 @@ class ControlIRExecutor:
                     "required": True,
                 },
             ),
-            # #1352-A: the deprecated `shell` op (raw subprocess) was removed;
-            # use `sandboxed_exec` below. `self._shell_allowed` plumbing is left
-            # in place (now harmless-dead — it gates nothing) pending the layer-3
-            # follow-up that retires the --allow-shell flag + permissions.shell.
+            # #1352-A/L3: the deprecated `shell` op (raw subprocess) was removed;
+            # use `sandboxed_exec` below.
             ControlIROpSpec(
                 kind="sandboxed_exec",
                 description=(
@@ -370,7 +366,6 @@ class ControlIRExecutor:
             max_phase_visits=self._max_phase_visits,
             sub_state_dir_override=None,
             state_dir_strategy="control_ir",
-            shell_allowed=self._shell_allowed,
             mcp_servers=self._mcp_servers,
             mcp_clients=self._mcp_clients,
             intervention_bus=self._intervention_bus,

--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -166,7 +166,6 @@ class PreprocessorExecutor:
             state_dir_strategy="preprocessor",
             preprocessor_phase_name=phase.name,
             preprocessor_step_index=step_index,
-            shell_allowed=True,  # gating handled by permission_resolver.require_shell
             mcp_servers={},
             mcp_clients={},
             intervention_bus=None,  # ask_user is forbidden in preprocessor

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -60,7 +60,6 @@ class OSRuntime:
         subscribers: list[Callable] | None = None,
         intervention_bus: "RequestBus | None" = None,
         run_id: str | None = None,
-        shell_allowed: bool = False,
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,
         safety: "SafetyConfig | None" = None,
@@ -191,7 +190,6 @@ class OSRuntime:
         self.control_ir_executor = ControlIRExecutor(
             self.workspace, self.events,
             intervention_bus=intervention_bus,
-            shell_allowed=shell_allowed,
             resolver=self._resolver,
             permission_resolver=permission_resolver,
             max_phase_visits=self._max_phase_visits,
@@ -505,8 +503,8 @@ class OSRuntime:
             if _PHASE_TOOL_NAME_ALIAS.get(op.kind, op.kind) in allowed
         ]
         # #997: wiring-gap detection. A phase that declares an op in allowed_ops
-        # which the executor does NOT advertise (e.g. `shell` while
-        # shell_allowed=False, `mcp` with no servers configured) has that op
+        # which the executor does NOT advertise (e.g. `mcp` with no servers
+        # configured) has that op
         # filtered to nothing — the LLM sees the phase instruction referencing
         # the op but no schema, and hallucinates a fake one (the FP-0008 / #1133
         # failure class). Surface it as a P6 event so the trace tool catches the

--- a/src/reyn/op_runtime/context.py
+++ b/src/reyn/op_runtime/context.py
@@ -55,8 +55,7 @@ class OpContext:
     preprocessor_phase_name: str = ""
     preprocessor_step_index: int = 0
 
-    # Shell / MCP
-    shell_allowed: bool = False
+    # MCP
     mcp_servers: dict = field(default_factory=dict)
     # Mutable cache for MCP HTTP clients keyed by server name
     mcp_clients: dict = field(default_factory=dict)

--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -132,8 +132,6 @@ class AgentLayer:
                 any(e.get("host") in (value, "*") for e in d.http_get)
                 or self._approved(axis, value)
             )
-        if axis is CapabilityAxis.SUBPROCESS:
-            return bool(d.shell)
         if axis is CapabilityAxis.MCP:
             # #1199 S3.1b: faithful to require_mcp (permissions.py:1248+1253) —
             # the per-skill grant (``decl.mcp``) AND the per-skill allowlist
@@ -160,7 +158,10 @@ class AgentLayer:
             return any(
                 (p.module, p.function) == tuple(value) for p in d.python
             )
-        # SKILL / ENV: the decl does not constrain → ⊤.
+        # SKILL / ENV / SUBPROCESS: the decl does not constrain → ⊤.
+        # (#1352-L3: the shell-permission SUBPROCESS gate was retired with the
+        # shell op; subprocess is now bounded by SandboxLayer.allow_subprocess
+        # at the sandboxed_exec seam, not the AgentLayer.)
         return True
 
 

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -8,7 +8,6 @@ Default grants (no declaration needed):
 Outside the defaults → the skill must declare the path AND the user must approve:
   file.read:  [{path: <path>, scope: just_path|recursive}]   (paths outside CWD)
   file.write: [{path: <path>, scope: just_path|recursive}]
-  shell      — declare permissions.shell: true
   mcp        — declare permissions.mcp: [server_name, ...]
   tool       — declare permissions.tool: [tool_name, ...]
 
@@ -24,7 +23,6 @@ Approval keys are skill-scoped to prevent external skill privilege escalation:
 
 Config pre-approval (reyn.yaml / reyn.local.yaml):
   permissions:
-    shell: allow
     file.write: allow   # grants all write-class ops for all skills
 """
 from __future__ import annotations
@@ -188,7 +186,6 @@ class PythonPermission:
 class PermissionDecl:
     """Permissions declared in a skill's frontmatter `permissions:` block."""
 
-    shell: bool = False
     mcp: list[str] = field(default_factory=list)
     tool: list[str] = field(default_factory=list)
     # Read-class ops outside CWD. Each entry: {"path": str, "scope": "just_path" | "recursive"}
@@ -337,7 +334,6 @@ class PermissionDecl:
                     stacklevel=3,
                 )
         return cls(
-            shell=bool(d.get("shell", False)),
             mcp=_normalize_paths(d.get("mcp")),
             tool=_normalize_paths(d.get("tool")),
             file_read=cls._parse_path_list(d.get("file.read")),
@@ -1321,34 +1317,6 @@ class PermissionResolver:
         return EffectivePermission([
             AgentLayer(PermissionDecl(), approval_check=_approved)
         ]).allows(CapabilityAxis.FILE_WRITE, path)
-
-    async def require_shell(
-        self, decl: PermissionDecl, cmd: str, bus: "RequestBus | None",
-    ) -> None:
-        # #1199 S3.1b-2c: the static shell authority (decl.shell) flows through the
-        # unified model (SUBPROCESS axis). Byte-identical; the _approve prompt
-        # remains the separate runtime gate.
-        from reyn.permissions.effective import (
-            AgentLayer,
-            CapabilityAxis,
-            EffectivePermission,
-        )
-
-        if not EffectivePermission([AgentLayer(decl)]).allows(
-            CapabilityAxis.SUBPROCESS, None
-        ):
-            raise PermissionError(
-                f"shell access not declared in skill permissions. "
-                f"Add `permissions:\\n  shell: true` to the skill.md frontmatter."
-                f" (cmd: {cmd!r})"
-            )
-        if not await self._approve(
-            "shell",
-            f"shell command: {cmd!r}",
-            bus,
-            user_prompt="Allow running this shell command?",
-        ):
-            raise PermissionError(f"shell access denied (cmd: {cmd!r})")
 
     async def require_mcp(
         self, decl: PermissionDecl, server: str, bus: RequestBus,

--- a/src/reyn/stdlib/skills/skill_improver/skill.md
+++ b/src/reyn/stdlib/skills/skill_improver/skill.md
@@ -125,7 +125,7 @@ required_credentials: []
 
 Copies the target skill to a temp work directory (`.reyn/skill_improver_work/<name>/`), then iteratively improves it: runs eval, plans DSL changes, applies them, and re-evaluates. On success (`score_threshold_met`), copies the improved files back to the original location. On any other stop condition (regression, stagnation, cap reached), the original skill is left untouched.
 
-`skill_improver` invokes the `eval` and `eval_builder` skills via the `run_skill` Control IR op (no `--allow-shell` needed).
+`skill_improver` invokes the `eval` and `eval_builder` skills via the `run_skill` Control IR op.
 
 ## Phase flow
 

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -200,7 +200,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         max_phase_visits=25,
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
-        shell_allowed=False,
         mcp_servers={},
         mcp_clients={},
         intervention_bus=getattr(phase_op_ctx, "intervention_bus", None),

--- a/src/reyn/tools/lint.py
+++ b/src/reyn/tools/lint.py
@@ -88,7 +88,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         max_phase_visits=25,
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
-        shell_allowed=False,
         mcp_servers={},
         mcp_clients={},
         intervention_bus=getattr(phase_op_ctx, "intervention_bus", None),

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -288,7 +288,6 @@ async def _handle_call_mcp_tool(
             max_phase_visits=25,
             sub_state_dir_override=None,
             state_dir_strategy="control_ir",
-            shell_allowed=False,
             mcp_servers={},
             mcp_clients={},
             intervention_bus=None,

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -118,7 +118,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         max_phase_visits=25,
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
-        shell_allowed=False,
         mcp_servers={},
         mcp_clients={},
         intervention_bus=None,

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -94,7 +94,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         max_phase_visits=25,
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
-        shell_allowed=False,
         mcp_servers={},
         mcp_clients={},
         intervention_bus=None,

--- a/src/reyn/web/server.py
+++ b/src/reyn/web/server.py
@@ -65,7 +65,6 @@ def _make_cron_runner():
         # empty ModelResolver() default) so class-name model resolution works.
         agent = Agent.from_config(
             cfg,
-            shell_allowed=False,
             interactive=False,
             project_context=project_context,
             caller="cron",

--- a/tests/test_1199_effective_permission.py
+++ b/tests/test_1199_effective_permission.py
@@ -26,25 +26,25 @@ AX = CapabilityAxis
 
 
 def test_capability_permitted_iff_all_layers_permit() -> None:
-    """Tier 2: subprocess is permitted only when BOTH the agent grant AND the
-    sandbox cap allow it — a single layer's deny vetoes."""
-    decl = PermissionDecl(shell=True)                      # agent grants subprocess
-    # agent grants + sandbox allows → permitted
+    """Tier 2: the SUBPROCESS capability is gated by the sandbox cap.
+
+    #1352-L3: the agent-side shell-permission gate (``decl.shell`` on the
+    AgentLayer SUBPROCESS axis) was retired with the shell op — subprocess is
+    now bounded by ``SandboxLayer.allow_subprocess`` at the sandboxed_exec seam,
+    so the AgentLayer no longer constrains SUBPROCESS (⊤). The sandbox cap still
+    vetoes. (The agent-veto / conjunctive-∩ falsification is exercised on a
+    still-agent-gated axis — FILE_WRITE — in the falsification test below.)"""
+    decl = PermissionDecl()
+    # sandbox allows → permitted (AgentLayer ⊤ for SUBPROCESS)
     eff = EffectivePermission.of(
         decl=decl, sandbox_policy=SandboxPolicy(allow_subprocess=True)
     )
     assert eff.allows(AX.SUBPROCESS, None) is True
-    # agent grants but sandbox caps it → denied (sandbox vetoes)
+    # sandbox caps it → denied (sandbox vetoes)
     eff2 = EffectivePermission.of(
         decl=decl, sandbox_policy=SandboxPolicy(allow_subprocess=False)
     )
     assert eff2.allows(AX.SUBPROCESS, None) is False
-    # sandbox would allow but agent never granted → denied (agent vetoes)
-    eff3 = EffectivePermission.of(
-        decl=PermissionDecl(shell=False),
-        sandbox_policy=SandboxPolicy(allow_subprocess=True),
-    )
-    assert eff3.allows(AX.SUBPROCESS, None) is False
 
 
 # ── ★the non-negotiable falsification ─────────────────────────────────────────

--- a/tests/test_1199_s31b2c_oprt_gates.py
+++ b/tests/test_1199_s31b2c_oprt_gates.py
@@ -45,12 +45,3 @@ def test_require_secret_write_cutover_reproduces_logic(tmp_path: Path) -> None:
         r.require_secret_write(PermissionDecl(), "K")                      # undeclared → raise
 
 
-def test_require_shell_gate_denies_when_undeclared(tmp_path: Path) -> None:
-    """Tier 2: require_shell's model gate (SUBPROCESS = decl.shell) denies before
-    the _approve prompt when shell is not declared. (The shell=True + _approve flow
-    is covered by the broad permission suite.)"""
-    import asyncio
-
-    r = _make_resolver(tmp_path)
-    with pytest.raises(PermissionError, match="not declared"):
-        asyncio.run(r.require_shell(PermissionDecl(shell=False), "ls", None))

--- a/tests/test_agent_from_config_wiring_997.py
+++ b/tests/test_agent_from_config_wiring_997.py
@@ -27,37 +27,22 @@ from reyn.config import ReynConfig
 def test_from_config_model_defaults_to_config() -> None:
     """Tier 2: from_config(config) uses config.model when no override is given."""
     cfg = ReynConfig(model="standard")
-    agent = Agent.from_config(cfg, shell_allowed=False, interactive=False)
+    agent = Agent.from_config(cfg, interactive=False)
     assert agent.model == "standard"
 
 
 def test_from_config_model_override_wins() -> None:
     """Tier 2: an explicit model override replaces the config default."""
     cfg = ReynConfig(model="standard")
-    agent = Agent.from_config(cfg, shell_allowed=False, model="strong", interactive=False)
+    agent = Agent.from_config(cfg, model="strong", interactive=False)
     assert agent.model == "strong"
 
-
-def test_from_config_constructs_in_both_shell_modes() -> None:
-    """Tier 2: the perm-resolver derivation runs for both shell modes without a caller resolver.
-
-    shell_allowed=True exercises the shell pre-approval branch (config_permissions
-    gains ``shell: allow``); shell_allowed=False the plain path. A caller supplies
-    neither permission_resolver nor the rest of the bundle — the factory derives
-    it. Construction succeeding for both proves the gap-prone wiring is produced
-    internally (the FP-0008 caller could not).
-    """
-    cfg = ReynConfig(model="standard")
-    for shell_allowed in (True, False):
-        agent = Agent.from_config(cfg, shell_allowed=shell_allowed, interactive=False)
-        assert isinstance(agent, Agent)
-        assert agent.caller == "direct"
 
 
 def test_from_config_caller_override() -> None:
     """Tier 2: a non-default caller (validated by Agent.__init__) is forwarded."""
     cfg = ReynConfig(model="standard")
     agent = Agent.from_config(
-        cfg, shell_allowed=False, caller="agents/reviewer", interactive=False
+        cfg, caller="agents/reviewer", interactive=False
     )
     assert agent.caller == "agents/reviewer"

--- a/tests/test_config_cascade.py
+++ b/tests/test_config_cascade.py
@@ -117,7 +117,7 @@ def test_no_warning_when_dot_reyn_config_absent(tmp_path, monkeypatch, capsys):
 def test_reyn_local_yaml_still_loaded(tmp_path, monkeypatch):
     """Tier 2: reyn.local.yaml is loaded and overrides reyn.yaml (3-layer cascade intact)."""
     reyn_yaml = tmp_path / "reyn.yaml"
-    _write_yaml(reyn_yaml, {"model": "standard", "shell_allowed": False})
+    _write_yaml(reyn_yaml, {"model": "standard"})
 
     local_yaml = tmp_path / "reyn.local.yaml"
     _write_yaml(local_yaml, {"model": "strong"})
@@ -130,7 +130,6 @@ def test_reyn_local_yaml_still_loaded(tmp_path, monkeypatch):
     assert cfg.model == "strong", (
         f"Expected 'strong' from reyn.local.yaml, got {cfg.model!r}."
     )
-    assert cfg.shell_allowed is False  # reyn.yaml value preserved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_schema_enforcement_1056.py
+++ b/tests/test_config_schema_enforcement_1056.py
@@ -93,7 +93,6 @@ _MIGRATED_DESC_KEYS = (
     "models",
     "api_base",
     "output_language",
-    "shell_allowed",
     "permissions",
 )
 

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -38,7 +38,6 @@ def _make_benchmark_args(
     limit: int | None = None,
     resume: bool = False,
     model: str | None = None,
-    allow_shell: bool = False,
     allow_unsafe_python: bool = False,
     clone_task_repo: bool = False,
 ) -> argparse.Namespace:
@@ -50,7 +49,6 @@ def _make_benchmark_args(
     ns.limit = limit
     ns.resume = resume
     ns.model = model
-    ns.allow_shell = allow_shell
     ns.allow_unsafe_python = allow_unsafe_python
     ns.clone_task_repo = clone_task_repo
     ns.eval_cmd = "benchmark"
@@ -94,9 +92,6 @@ def benchmark_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
         def safety_for(self, args):
             return SafetyConfig()
-
-        def shell_allowed_for(self, args):
-            return False
 
     monkeypatch.setattr(session_mod, "Session", _StubSession)
 
@@ -149,8 +144,7 @@ def test_benchmark_parses() -> None:
     assert args.concurrency == 8
     assert args.limit == 50
     assert args.resume is True
-    # Permission-flag defaults (= off, matching reyn run)
-    assert args.allow_shell is False
+    # Permission-flag default (= off, matching reyn run)
     assert args.allow_unsafe_python is False
 
 
@@ -169,10 +163,8 @@ def test_benchmark_parses_allow_flags() -> None:
         "eval", "benchmark", "swe_bench",
         "--tasks", "tasks.jsonl",
         "--output", "results/",
-        "--allow-shell",
         "--allow-unsafe-python",
     ])
-    assert args.allow_shell is True
     assert args.allow_unsafe_python is True
 
 
@@ -429,7 +421,7 @@ def test_single_task_failure_no_abort(
 
     async def _stub_run_single_task(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
+        unsafe_python=False, python_allowed_modules=None,
         clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         nonlocal call_count
@@ -482,101 +474,6 @@ def test_single_task_failure_no_abort(
 # ── test 12: --allow-shell propagates to per-task runner ──────────────────────
 
 
-def test_allow_shell_propagates_to_single_task(
-    benchmark_workspace, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Tier 2: --allow-shell flag reaches _run_single_task as ``shell_allowed=True``.
-
-    Pins the FP-0008 PR-D fix (= 2026-05-28 calibration block root cause).
-    Without the propagation, the Agent's op_catalog omits shell + the LLM
-    hallucinates a fake shell schema → every retry fails → batch reports
-    100% error with $0.00 cost.
-
-    Verifies the wiring at the per-task layer: when ``--allow-shell`` is
-    set on the namespace, ``_run_single_task`` is called with
-    ``shell_allowed=True``. The reverse (= flag absent → ``shell_allowed=False``)
-    is the default-off path.
-    """
-    # Override the stub Session to honor the actual allow_shell flag
-    # (= the workspace fixture defaults to always-False; we want truth-following)
-    from reyn.cli import session as session_mod
-    from reyn.cli.commands import eval_benchmark as bm
-    from reyn.config import ReynConfig, SafetyConfig
-    from reyn.llm.model_resolver import ModelResolver
-
-    class _TruthfulSession:
-        config = ReynConfig()
-        resolver = ModelResolver({})
-
-        @classmethod
-        def from_args(cls, _args):
-            return cls()
-
-        def model_for(self, args):
-            return "standard", "standard"
-
-        def output_language_for(self, args):
-            return None
-
-        def safety_for(self, args):
-            return SafetyConfig()
-
-        def shell_allowed_for(self, args):
-            return bool(getattr(args, "allow_shell", False))
-
-    monkeypatch.setattr(session_mod, "Session", _TruthfulSession)
-
-    captured: dict = {}
-
-    async def _capture_shell_allowed(
-        task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
-        clone_task_repo=False, verify_tier="no_faithful_env",
-    ):
-        async with semaphore:
-            captured["shell_allowed"] = shell_allowed
-            return {"instance_id": instance_id, "cost_usd": 0.0}
-
-    monkeypatch.setattr(bm, "_run_single_task", _capture_shell_allowed)
-
-    tasks_path = benchmark_workspace.write_tasks([{"instance_id": "t1"}])
-    output_dir = tmp_path / "bench_output_shell"
-
-    # Case A: --allow-shell set → shell_allowed=True reaches the runner
-    args_on = _make_benchmark_args(
-        skill_name="test_skill",
-        tasks_path=str(tasks_path),
-        output_dir=str(output_dir),
-        concurrency=1,
-        allow_shell=True,
-    )
-    asyncio.run(bm._run_benchmark_async(args_on))
-    assert captured["shell_allowed"] is True, (
-        "Expected shell_allowed=True to reach _run_single_task when --allow-shell is set"
-    )
-    # #997 dir2: the permission_resolver is no longer passed to _run_single_task
-    # — Agent.from_config derives it per task from shell_allowed (+ unsafe_python).
-    # That the bundle is wired (not omittable) is covered by the from_config
-    # factory tests + the AST omit-pin; here we pin the shell_allowed propagation.
-
-    # Case B: --allow-shell absent → shell_allowed=False is the default
-    captured.clear()
-    output_dir_b = tmp_path / "bench_output_no_shell"
-    args_off = _make_benchmark_args(
-        skill_name="test_skill",
-        tasks_path=str(tasks_path),
-        output_dir=str(output_dir_b),
-        concurrency=1,
-        allow_shell=False,
-    )
-    asyncio.run(bm._run_benchmark_async(args_off))
-    assert captured["shell_allowed"] is False, (
-        "Expected shell_allowed=False when --allow-shell is not set"
-    )
-
-
-# ── test 13: --clone-task-repo flag parses + propagates ──────────────────────
-
 
 def test_benchmark_parses_clone_task_repo_flag() -> None:
     """Tier 2: '--clone-task-repo' parses to truthy on args (FP-0008 PR-E)."""
@@ -620,7 +517,7 @@ def test_clone_task_repo_propagates_to_single_task(
 
     async def _capture_clone_flag(
         task, instance_id, skill, skill_root, model, session, run_dir, semaphore,
-        shell_allowed=False, unsafe_python=False, python_allowed_modules=None,
+        unsafe_python=False, python_allowed_modules=None,
         clone_task_repo=False, verify_tier="no_faithful_env",
     ):
         async with semaphore:

--- a/tests/test_op_exposure_invariant_997.py
+++ b/tests/test_op_exposure_invariant_997.py
@@ -66,7 +66,7 @@ _UNCONDITIONAL_OPS = {
 
 
 def _executor(
-    tmp_path: Path, *, shell_allowed: bool = False, mcp_servers: dict | None = None
+    tmp_path: Path, *, mcp_servers: dict | None = None
 ) -> ControlIRExecutor:
     events = EventLog()
     ws = Workspace(events=events)
@@ -77,7 +77,6 @@ def _executor(
             config_permissions={}, project_root=tmp_path, interactive=False
         ),
         skill_name="t",
-        shell_allowed=shell_allowed,
         mcp_servers=mcp_servers,
     )
 
@@ -113,16 +112,14 @@ def test_mcp_advertised_iff_servers_configured(
 
 
 @pytest.mark.parametrize(
-    "shell_allowed, mcp_servers",
+    "mcp_servers",
     [
-        (False, None),
-        (True, None),
-        (False, {"servers": {"gh": {"type": "http", "url": "http://x"}}}),
-        (True, {"servers": {"gh": {"type": "http", "url": "http://x"}}}),
+        None,
+        {"servers": {"gh": {"type": "http", "url": "http://x"}}},
     ],
 )
 def test_unconditional_ops_always_advertised(
-    tmp_path: Path, shell_allowed: bool, mcp_servers: dict | None
+    tmp_path: Path, mcp_servers: dict | None
 ) -> None:
     """Tier 2: the flag-independent ops are always advertised (incl. sandboxed_exec = #1133).
 
@@ -130,11 +127,11 @@ def test_unconditional_ops_always_advertised(
     the unconditional Tier-3 + core ops must stay in the catalog. The original bug
     was sandboxed_exec silently absent from the spec list.
     """
-    kinds = _kinds(_executor(tmp_path, shell_allowed=shell_allowed, mcp_servers=mcp_servers))
+    kinds = _kinds(_executor(tmp_path, mcp_servers=mcp_servers))
     missing = _UNCONDITIONAL_OPS - kinds
     assert not missing, (
         f"unconditional ops missing from op catalog: {sorted(missing)} "
-        f"(shell_allowed={shell_allowed}, mcp={bool(mcp_servers)})"
+        f"(mcp={bool(mcp_servers)})"
     )
 
 

--- a/tests/test_permission_prompt_phrasing.py
+++ b/tests/test_permission_prompt_phrasing.py
@@ -79,24 +79,7 @@ async def test_require_web_fetch_prompt_is_natural(tmp_path) -> None:
     assert "web.fetch" not in iv.prompt
 
 
-# ── 2. require_shell uses natural prompt ─────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_require_shell_prompt_is_natural(tmp_path) -> None:
-    """Tier 2: require_shell passes a natural-language user_prompt."""
-    r = _resolver(tmp_path)
-    bus = _RecordingBus(answer_id="no")
-    try:
-        await r.require_shell(PermissionDecl(shell=True), "ls -la", bus)
-    except PermissionError:
-        pass
-    (iv,) = bus.captured  # exactly one intervention requested
-    assert iv.prompt == "Allow running this shell command?"
-    assert "ls -la" in iv.detail
-
-
-# ── 3. End-to-end announce: meta.prompt carries natural phrasing ────────
+# ── 2. End-to-end announce: meta.prompt carries natural phrasing ────────
 
 
 async def _capture_announce(iv: UserIntervention) -> OutboxMessage:

--- a/tests/test_routerloop_convergence_replay_1092.py
+++ b/tests/test_routerloop_convergence_replay_1092.py
@@ -153,7 +153,7 @@ def test_converged_op_loop_records_and_replays_deterministically(tmp_path, monke
         tool_calls_op_loop_skills=[_SKILL_NAME], prompt_cache_enabled=False,
     )
     agent = Agent.from_config(
-        config, shell_allowed=False, model=_MODEL, subscribers=[sink.append],
+        config, model=_MODEL, subscribers=[sink.append],
     )
     result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
 

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -94,7 +94,7 @@ def test_from_config_gate_reaches_converged_op_loop(tmp_path, monkeypatch) -> No
 
     config = ReynConfig(tool_calls_op_loop_skills=[_SKILL_NAME])
     agent = Agent.from_config(
-        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+        config, model="stub/model", subscribers=[sink.append],
     )
     result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
 
@@ -121,7 +121,7 @@ def test_from_config_unlisted_skill_no_convergence(tmp_path, monkeypatch) -> Non
 
     config = ReynConfig(tool_calls_op_loop_skills=[])  # nothing opted in
     agent = Agent.from_config(
-        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+        config, model="stub/model", subscribers=[sink.append],
     )
     result = asyncio.run(agent.run(_skill(), {"type": "input", "data": {}}))
 
@@ -185,7 +185,7 @@ def test_converged_op_loop_dispatches_phase_op_not_unknown_tool(tmp_path, monkey
     )
     config = ReynConfig(tool_calls_op_loop_skills=[_SKILL_NAME])
     agent = Agent.from_config(
-        config, shell_allowed=False, model="stub/model", subscribers=[sink.append],
+        config, model="stub/model", subscribers=[sink.append],
     )
     result = asyncio.run(agent.run(skill, {"type": "input", "data": {}}))
 
@@ -272,7 +272,7 @@ def test_converged_decide_frame_information_equivalent_to_json_op_loop(tmp_path,
         final_output_name="result",
     )
     config = ReynConfig(tool_calls_op_loop_skills=[_SKILL_NAME])
-    agent = Agent.from_config(config, shell_allowed=False, model="stub/model")
+    agent = Agent.from_config(config, model="stub/model")
     result = asyncio.run(agent.run(skill, {"type": "input", "data": {}}))
 
     assert result.ok, f"run must complete; got {result.status}"

--- a/tests/test_sandboxed_exec_advertised_1133.py
+++ b/tests/test_sandboxed_exec_advertised_1133.py
@@ -25,7 +25,7 @@ from reyn.schemas.models import SandboxedExecIROp
 from reyn.workspace.workspace import Workspace
 
 
-def _executor(tmp_path: Path, *, shell_allowed: bool = False) -> ControlIRExecutor:
+def _executor(tmp_path: Path) -> ControlIRExecutor:
     events = EventLog()
     ws = Workspace(events=events)
     return ControlIRExecutor(
@@ -35,7 +35,6 @@ def _executor(tmp_path: Path, *, shell_allowed: bool = False) -> ControlIRExecut
             config_permissions={}, project_root=tmp_path, interactive=False
         ),
         skill_name="t",
-        shell_allowed=shell_allowed,
     )
 
 
@@ -50,12 +49,6 @@ def test_sandboxed_exec_is_advertised(tmp_path: Path) -> None:
         "available_ops() must advertise sandboxed_exec — without it a phase that "
         "lists it in allowed_ops gets the op filtered to nothing."
     )
-
-
-def test_sandboxed_exec_advertised_regardless_of_shell_allowed(tmp_path: Path) -> None:
-    """Tier 2: sandboxed_exec is advertised even when shell is off (it is not the shell op)."""
-    assert _spec(_executor(tmp_path, shell_allowed=False), "sandboxed_exec") is not None
-    assert _spec(_executor(tmp_path, shell_allowed=True), "sandboxed_exec") is not None
 
 
 def test_sandboxed_exec_description_requires_argv_list_not_command_string(tmp_path: Path) -> None:

--- a/tests/test_skill_permissions_explicit.py
+++ b/tests/test_skill_permissions_explicit.py
@@ -85,12 +85,6 @@ def test_explicit_skill_permissions_mcp() -> None:
     assert skill.permissions.mcp == ["override"]
 
 
-def test_explicit_skill_permissions_shell_true() -> None:
-    """Tier 2: Explicit skill.permissions.shell=True propagates."""
-    skill = _build(["a", "b"], skill_permissions={"shell": True})
-    assert skill.permissions.shell is True
-
-
 def test_explicit_skill_permissions_python_used_directly() -> None:
     """Tier 2: Explicit skill.permissions.python is used verbatim."""
     skill = _build(
@@ -121,6 +115,5 @@ def test_explicit_skill_permissions_file_write() -> None:
 def test_no_skill_permissions_yields_empty_decl() -> None:
     """Tier 2: Absent skill.permissions → empty PermissionDecl (no phase fallback)."""
     skill = _build(["a", "b"], skill_permissions=None)
-    assert skill.permissions.shell is False
     assert skill.permissions.mcp == []
     assert skill.permissions.tool == []

--- a/tests/test_swe_bench_sandboxed_exec_migration_1115.py
+++ b/tests/test_swe_bench_sandboxed_exec_migration_1115.py
@@ -51,14 +51,6 @@ def test_exec_phases_use_sandboxed_exec() -> None:
         )
 
 
-def test_skill_no_longer_declares_shell_permission() -> None:
-    """Tier 2: skill.permissions.shell is removed (no phase emits kind: shell)."""
-    skill = _skill()
-    assert skill.permissions.shell is False, (
-        "swe_bench.permissions.shell must be removed after the sandboxed_exec "
-        "migration — no phase emits the shell op."
-    )
-
 
 def test_no_phase_body_embeds_control_ir_shell_json() -> None:
     """Tier 2: no phase body embeds a Control-IR shell JSON literal (P8 cleanup).

--- a/tests/test_tier3_op_description_positive_frame.py
+++ b/tests/test_tier3_op_description_positive_frame.py
@@ -64,7 +64,6 @@ def _assert_no_misleading_caveat(description: str, op_name: str) -> None:
 def _build_executor(
     tmp_path: Path,
     *,
-    shell_allowed: bool = False,
     mcp_servers: dict | None = None,
 ):
     """Construct a minimal ControlIRExecutor under tmp_path (no global state)."""
@@ -80,7 +79,6 @@ def _build_executor(
     return ControlIRExecutor(
         workspace=workspace,
         events=events,
-        shell_allowed=shell_allowed,
         mcp_servers=mcp_servers,
     )
 
@@ -127,7 +125,6 @@ def test_no_tier3_op_uses_skill_author_phrasing(tmp_path: Path) -> None:
     """
     executor = _build_executor(
         tmp_path,
-        shell_allowed=True,
         mcp_servers={"servers": {"x": {"transport": "stdio"}}},
     )
     skill_author_phrases = ("phase.allowed_ops", "skill.permissions")

--- a/tests/test_tool_opcontext_bridge_permission_decl.py
+++ b/tests/test_tool_opcontext_bridge_permission_decl.py
@@ -98,7 +98,6 @@ def _shell_legacy_ctx(ctx: ToolContext) -> OpContext:
     before calling handle_shell — we want the OpContext, not the
     result of executing a real command.
     """
-    from reyn.tools.shell import _handle as shell_handle  # noqa: F401
     # We can't intercept the legacy_ctx mid-call without monkeypatching
     # handle_shell. Use the same construction logic as the real bridge.
     phase_op_ctx = (
@@ -165,10 +164,7 @@ async def test_tool_bridge_preserves_decl_from_phase_state(
     # Patch the canonical op_runtime entry point each tool delegates to.
     # Each Tool wrapper does `from reyn.op_runtime.<x> import handle as handle_X`
     # inside its _handle function — patch the source module's `handle`.
-    if tool_module_name == "reyn.tools.shell":
-        import reyn.op_runtime.shell as op_mod
-        monkeypatch.setattr(op_mod, "handle", _capture)
-    elif tool_module_name == "reyn.tools.lint":
+    if tool_module_name == "reyn.tools.lint":
         import reyn.op_runtime.lint as op_mod
         monkeypatch.setattr(op_mod, "handle", _capture)
     elif tool_module_name == "reyn.tools.web_search":
@@ -176,7 +172,7 @@ async def test_tool_bridge_preserves_decl_from_phase_state(
         from reyn.op_runtime import web as op_mod
         monkeypatch.setattr(op_mod, "handle_web_search", _capture)
 
-    skill_decl = PermissionDecl(shell=True, mcp=["github"])
+    skill_decl = PermissionDecl(mcp=["github"])
     phase_state = _build_phase_state(skill_decl)
     tool_ctx = _build_tool_ctx_with_phase(phase_state, tmp_path)
 
@@ -231,7 +227,7 @@ async def test_read_tool_result_bridge_preserves_decl(
     from reyn.tools import read_tool_result as rtr_mod
 
     # Replicate the bridge construction (rs path is None → fallback)
-    skill_decl = PermissionDecl(shell=True)
+    skill_decl = PermissionDecl(mcp=["github"])
     phase_state = _build_phase_state(skill_decl)
     tool_ctx = _build_tool_ctx_with_phase(phase_state, tmp_path)
 
@@ -286,7 +282,6 @@ def test_file_legacy_ctx_no_phase_returns_empty_decl(tmp_path: Path) -> None:
 
     legacy_ctx = _build_legacy_op_context(tool_ctx)
     assert legacy_ctx.permission_decl == PermissionDecl()
-    assert legacy_ctx.permission_decl.shell is False
 
 
 # ── 5. negative-shape audit: no hardcoded `PermissionDecl()` in bridge code ─


### PR DESCRIPTION
**[dogfood-coder]** — sandbox-coverage audit residual **L3** (final shell retirement), #1352. owner GO ("それももちろん除去"). Refs #1352 (tracking comment 4629628818).

## Change

With the `shell` op removed (#1352-A / #1355), its entire gating chain is dead code. This retires it end-to-end:

- **CLI**: `--allow-shell` flag (run + eval benchmark), `CLISession.shell_allowed_for`, `_build_permission_resolver`’s `shell_allowed` param + the `perm_config["shell"]` graft.
- **config**: `ReynConfig.shell_allowed` field (+ `reyn config` display, templates).
- **plumbing**: the `shell_allowed` param threaded through Agent → OSRuntime → ControlIRExecutor → PreprocessorExecutor, and `OpContext.shell_allowed`.
- **permission model**: `PermissionResolver.require_shell`, `PermissionDecl.shell`, and the AgentLayer SUBPROCESS branch (`bool(d.shell)`) that existed only for it.
- **docs**: control-ir.md residual, dispatcher/validator hints, tool/web/cron pass-throughs.

## ★ Semantic delta (the one behavioral change, not just dead-code)

The **SUBPROCESS** capability axis was `(AgentLayer ∩ SandboxLayer)`; it is now **SandboxLayer-only**. The AgentLayer side (`decl.shell`) existed solely to gate the shell op — `sandboxed_exec` never used it (it is bounded by `SandboxLayer.allow_subprocess` at its own seam). **No live capability changes**: subprocess for sandboxed_exec is still gated by the operator/agent sandbox policy. `AgentLayer.allows(SUBPROCESS)` now returns ⊤ (the decl does not constrain it), consistent with SKILL / ENV. Reflected in `test_1199_effective_permission`.

## Test plan

- [x] all `shell_allowed` / `require_shell` / `PermissionDecl.shell` / `config.shell_allowed` / `--allow-shell` refs removed from src (grep clean); `ruff` clean
- [x] **full suite 6900 passed / 0 failed** (three iterations surfaced + fixed the scattered test refs — `#1355`-style: `-k`-filtered runs would have hidden them, #1350 lesson)
- [x] obsolete shell tests removed (require_shell prompt/gate, shell-mode, regardless-of-shell, explicit-shell-true, allow-shell-propagates); SUBPROCESS-axis test updated; `PermissionDecl(shell=)` → mcp/empty
- [x] `test_tier_audit.py --strict` 0 errors

## Wave complete

L3 is the final piece of #1352. With it the **sandbox-model wave is complete**: exec (#1347) + MCP (#1345/#1348/#1349) + python steps (#1356) all operator-policy / OS-sandbox when a backend is configured; in-process file/http conjunctive-∩ (#1313 confirmed); chat-phase symmetric (#1354); MCP network single-source (#1348); the deprecated `shell` op + its gating fully retired (#1355 + L3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)