### PR TITLE
fix(permissions): anchor default zone to project_root, not hardcoded cwd (#1316)

### DIFF
--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -100,9 +100,15 @@ class AgentLayer:
         decl: "PermissionDecl",
         *,
         approval_check: "Any" = None,
+        project_root: "Any" = None,
     ) -> None:
         self._decl = decl
         self._approval_check = approval_check
+        # #1316: the project root the default zones are anchored to. None →
+        # Path.cwd() inside the zone fns (historical). Passing the resolver's
+        # _project_root makes the zone base match the approvals base (so a
+        # project_root ≠ cwd does not diverge zone vs approval evaluation).
+        self._project_root = project_root
 
     def _approved(self, axis: CapabilityAxis, value: Any) -> bool:
         return bool(self._approval_check and self._approval_check(axis, value))
@@ -112,13 +118,13 @@ class AgentLayer:
         if axis is CapabilityAxis.FILE_READ:
             # #1199 S3.1c-1: decl-less — zone OR approved (no decl auto-grant).
             return (
-                _in_default_read_zone(str(value))
+                _in_default_read_zone(str(value), self._project_root)
                 or self._approved(axis, value)
             )
         if axis is CapabilityAxis.FILE_WRITE:
             # #1199 S3.1c-1: decl-less — zone OR approved (no decl auto-grant).
             return (
-                _in_default_write_zone(str(value))
+                _in_default_write_zone(str(value), self._project_root)
                 or self._approved(axis, value)
             )
         if axis is CapabilityAxis.NETWORK_HOST:
@@ -254,11 +260,14 @@ class EffectivePermission:
         sandbox_policy: "SandboxPolicy | None" = None,
         profile: "AgentProfile | None" = None,
         approval_check: "Any" = None,
+        project_root: "Any" = None,
     ) -> "EffectivePermission":
         """Build from the inputs (zone + approvals folded into the agent
-        layer; ② grant-back-safe). Build per op-context (Q3)."""
+        layer; ② grant-back-safe). Build per op-context (Q3).
+
+        #1316: ``project_root`` anchors the default zones (None → cwd)."""
         return cls([
-            AgentLayer(decl, approval_check=approval_check),
+            AgentLayer(decl, approval_check=approval_check, project_root=project_root),
             SandboxLayer(sandbox_policy),
             ProfileLayer(profile),
         ])

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -107,9 +107,13 @@ def _expand(path_str: str) -> Path:
     return Path(path_str).expanduser().resolve()
 
 
-def _is_canonical_protected_write(path_str: str) -> bool:
-    """Return True if ``path_str`` resolves to one of the #571 protected paths."""
-    base = Path.cwd()
+def _is_canonical_protected_write(path_str: str, base: "Path | None" = None) -> bool:
+    """Return True if ``path_str`` resolves to one of the #571 protected paths.
+
+    #1316: ``base`` is the project root the default zones are anchored to.
+    ``None`` → ``Path.cwd()`` (the historical default; callers that set a
+    project_root ≠ cwd must pass it so the zone base matches approvals)."""
+    base = base or Path.cwd()
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
     for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
@@ -118,7 +122,7 @@ def _is_canonical_protected_write(path_str: str) -> bool:
     return False
 
 
-def _in_default_write_zone(path_str: str) -> bool:
+def _in_default_write_zone(path_str: str, base: "Path | None" = None) -> bool:
     """Return True if path falls within a default-granted write zone (.reyn/ or reyn/).
 
     Exception: canonical protected paths (see
@@ -129,9 +133,9 @@ def _in_default_write_zone(path_str: str) -> bool:
     ``.reyn/cron.yaml`` were removed from this set (protect-at-use — their
     downstream use-gate makes the config carve-out redundant).
     """
-    if _is_canonical_protected_write(path_str):
+    base = base or Path.cwd()
+    if _is_canonical_protected_write(path_str, base):
         return False
-    base = Path.cwd()
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
     for zone in _DEFAULT_WRITE_ZONES:
@@ -143,9 +147,11 @@ def _in_default_write_zone(path_str: str) -> bool:
     return False
 
 
-def _in_default_read_zone(path_str: str) -> bool:
-    """Return True if path falls within the default-granted read zone (CWD)."""
-    base = Path.cwd()
+def _in_default_read_zone(path_str: str, base: "Path | None" = None) -> bool:
+    """Return True if path falls within the default-granted read zone (the project
+    root). #1316: ``base`` defaults to ``Path.cwd()`` (historical) — pass the
+    resolver's ``_project_root`` so the read zone matches the approvals base."""
+    base = base or Path.cwd()
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
     try:
@@ -736,7 +742,7 @@ class PermissionResolver:
             scope = entry.get("scope", "just_path")
             if not path:
                 continue
-            if _in_default_write_zone(path):
+            if _in_default_write_zone(path, self._project_root):
                 continue
             if self._is_config_approved("file.write"):
                 continue
@@ -752,7 +758,7 @@ class PermissionResolver:
             scope = entry.get("scope", "just_path")
             if not path:
                 continue
-            if _in_default_read_zone(path):
+            if _in_default_read_zone(path, self._project_root):
                 continue
             if self._is_config_approved("file.read"):
                 continue
@@ -974,7 +980,7 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved),
+            AgentLayer(decl, approval_check=_approved, project_root=self._project_root),
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_READ, path):
             return
@@ -1026,7 +1032,7 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved),
+            AgentLayer(decl, approval_check=_approved, project_root=self._project_root),
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_WRITE, path):
             return
@@ -1286,7 +1292,8 @@ class PermissionResolver:
             )
 
         return EffectivePermission([
-            AgentLayer(PermissionDecl(), approval_check=_approved)
+            AgentLayer(PermissionDecl(), approval_check=_approved,
+                       project_root=self._project_root)
         ]).allows(CapabilityAxis.FILE_READ, path)
 
     def is_write_allowed(self, path: str, skill_name: str = "") -> bool:
@@ -1315,7 +1322,8 @@ class PermissionResolver:
             )
 
         return EffectivePermission([
-            AgentLayer(PermissionDecl(), approval_check=_approved)
+            AgentLayer(PermissionDecl(), approval_check=_approved,
+                       project_root=self._project_root)
         ]).allows(CapabilityAxis.FILE_WRITE, path)
 
     async def require_mcp(

--- a/tests/test_1199_s31c1_swebench_only.py
+++ b/tests/test_1199_s31c1_swebench_only.py
@@ -29,8 +29,14 @@ _STAR_WRITE = PermissionDecl(file_write=[{"path": "*", "scope": "recursive"}])
 
 
 def _out_of_zone(tmp_path: Path) -> str:
-    # tmp_path is outside the repo cwd → outside the default read/write zone.
-    return str(tmp_path / "outside" / "f.txt")
+    # #1316: the resolver's project_root IS tmp_path (see _make_resolver), and the
+    # default READ zone is "any path under project_root" — so a path UNDER tmp_path
+    # is in-zone. A genuinely out-of-zone path (out of both the read zone = under
+    # project_root and the write zone = project_root/.reyn|reyn) must live OUTSIDE
+    # project_root. (Pre-#1316 the zone fns hardcoded cwd, so a tmp_path-internal
+    # path looked out-of-zone only because tmp_path != cwd — that divergence is the
+    # bug #1316 fixes.) A sibling of project_root is outside it.
+    return str(tmp_path.parent / "out_of_zone_sibling" / "f.txt")
 
 
 def test_non_interactive_declared_unapproved_read_denies_with_message(tmp_path: Path) -> None:

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -205,25 +205,28 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_permission_gate_undeclared_raises(tmp_path):
-    """Tier 2: mcp_install op raises PermissionError when file.write not declared.
+def test_mcp_yaml_write_is_default_granted_protect_at_use(tmp_path):
+    """Tier 2: #571 protect-at-use / #1316 — writing the mcp install target
+    ``.reyn/mcp.yaml`` needs NO explicit file.write declaration: it sits in the
+    default project write zone (removed from the protected carve-out because
+    writing it is inert without ``require_mcp`` at call time; the install-side
+    grant is ``permissions.mcp``, the use-side gate is ``require_mcp``). The
+    carved-out ``.reyn/approvals.yaml`` still requires an explicit grant.
 
-    #571 collapse arc Phase 5: the legacy ``mcp_install: true`` bool
-    axis was removed; the op handler now gates via
-    ``require_file_write`` on ``.reyn/mcp.yaml``. A skill that
-    declares neither the explicit file.write entry nor the (now
-    removed) bool axis fails the gate.
-    """
-    resolver = _make_resolver(tmp_path)
-    decl = PermissionDecl()  # nothing declared
-    bus = _AutoApproveInterventionBus()
-    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-
-    op = MCPInstallIROp(kind="mcp_install", server_id="io.github.example/server-x")
-
-    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-        with pytest.raises(PermissionError, match="not approved"):
-            _run(mcp_install_handle(op, ctx, "control_ir"))
+    (Pre-#1316, an mcp test with project_root ≠ cwd saw the mcp.yaml write DENIED
+    via the cwd-zone divergence — that latent bug is fixed; production
+    cwd=project_root always default-granted it, so this is production-faithful,
+    not a loosening.)"""
+    resolver = _make_resolver(tmp_path)  # project_root = tmp_path
+    # mcp.yaml under project_root/.reyn = default write zone → granted (no decl)
+    resolver.require_file_write(
+        PermissionDecl(), str(tmp_path / ".reyn" / "mcp.yaml"), "mcp_install_test"
+    )
+    # contrast: the approval store IS carved out → still needs an explicit grant
+    with pytest.raises(PermissionError):
+        resolver.require_file_write(
+            PermissionDecl(), str(tmp_path / ".reyn" / "approvals.yaml"), "t"
+        )
 
 
 def test_permission_gate_passes_with_explicit_decl(tmp_path, monkeypatch):
@@ -488,31 +491,6 @@ def test_event_emitted_on_success(tmp_path, monkeypatch):
     assert "env_keys_set" in evt.data
     assert isinstance(evt.data["env_keys_set"], list)
 
-
-def test_no_event_on_permission_denied(tmp_path):
-    """Tier 2: No mcp_server_installed event when permission gate rejects.
-
-    The event is only emitted after a successful install (P6 — only emit on
-    actual state change). #571 Phase 5: the rejection now comes from
-    ``require_file_write`` when ``.reyn/mcp.yaml`` is not declared.
-    """
-    resolver = _make_resolver(tmp_path)
-    decl = PermissionDecl()  # missing required file.write declaration
-    bus = _AutoApproveInterventionBus()
-    ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
-
-    op = MCPInstallIROp(
-        kind="mcp_install",
-        server_id="io.github.example/server-x",
-        scope="local",
-    )
-
-    with _patch_registry_get(_FILESYSTEM_SERVER_RESPONSE):
-        with pytest.raises(PermissionError):
-            _run(mcp_install_handle(op, ctx, "control_ir"))
-
-    install_events = [e for e in ctx.events.all() if e.type == "mcp_server_installed"]
-    assert install_events == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_perm_zone_base_1316.py
+++ b/tests/test_perm_zone_base_1316.py
@@ -1,0 +1,62 @@
+"""Tier 2: default permission zone is anchored to the resolver's project_root (#1316).
+
+Latent divergence (surfaced in S3.3 mount design): the module-level zone fns
+(`_in_default_write_zone` / `_in_default_read_zone`) hardcoded `Path.cwd()` as the
+base, while approvals + path-approval use `self._project_root`. When project_root
+≠ cwd (project-root discovery, mount-mode, or an eval harness that anchors the
+workspace at a repo like /testbed), the zone evaluated against cwd while approvals
+evaluated against project_root → a write under the project's OWN `.reyn/` default
+zone could be denied. #1316 threads project_root into the zone fns so both bases
+match.
+
+No mocks: a real PermissionResolver with project_root ≠ cwd.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _resolver(project_root: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False
+    )
+
+
+def test_write_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
+    """Tier 2: #1316 reproduce-first — a write under project_root/.reyn (the
+    project's default write zone) is granted when project_root ≠ cwd. FAILS pre-fix
+    (zone used cwd → the path was not in the cwd zone → PermissionError, diverging
+    from where approvals are anchored)."""
+    base = (tmp_path / "proj").resolve()
+    (base / ".reyn").mkdir(parents=True)
+    r = _resolver(base)
+    # under project_root/.reyn = default write zone → granted (no raise)
+    r.require_file_write(PermissionDecl(), str(base / ".reyn" / "scratch.txt"), "t")
+
+
+def test_read_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
+    """Tier 2: #1316 — a read under project_root (the default read zone) is granted
+    when project_root ≠ cwd. FAILS pre-fix (zone used cwd)."""
+    base = (tmp_path / "proj").resolve()
+    base.mkdir(parents=True)
+    r = _resolver(base)
+    r.require_file_read(PermissionDecl(), str(base / "src" / "module.py"), "t")
+
+
+def test_protected_path_carveout_also_anchored_to_project_root(tmp_path: Path) -> None:
+    """Tier 2: #1316 — the canonical protected-write carve-out (approvals.yaml) is
+    evaluated against project_root too, so project_root/.reyn/approvals.yaml is
+    NOT default-zone-granted (must go through the gated approval flow) even when
+    project_root ≠ cwd."""
+    import pytest
+
+    base = (tmp_path / "proj").resolve()
+    (base / ".reyn").mkdir(parents=True)
+    r = _resolver(base)
+    # the approval store under project_root is carved out → not default-granted
+    with pytest.raises(PermissionError):
+        r.require_file_write(
+            PermissionDecl(), str(base / ".reyn" / "approvals.yaml"), "t"
+        )


### PR DESCRIPTION
**[dogfood-coder]** — sandbox/mount backlog, #1316 (bounded cleanup, sandbox-model consistency). Refs #1316.

## Change

Latent divergence (surfaced in S3.3 mount design): the module-level zone fns (`_in_default_write_zone` / `_in_default_read_zone` / `_is_canonical_protected_write`) hardcoded `Path.cwd()` as the base, while approvals + path-approval use `self._project_root`. Both default to cwd → coincide today, but when **project_root ≠ cwd** (project-root discovery, mount-mode, or a subdir launch) the zone evaluated against cwd while approvals evaluated against project_root → a path under the project’s own default zone could be mis-judged.

Fix: the zone fns take a `base` param (None → cwd, backward-compat); `AgentLayer` gains `project_root` and threads it into the FILE_READ/FILE_WRITE zone checks; `EffectivePermission.of`, `require_file_read/write`, `is_read/write_allowed`, and the direct zone calls all pass `self._project_root`. The two bases now match.

## swe_bench-relevance (calibrated — NOT a live blocker)

LATENT. The agent `PermissionResolver._project_root = _find_project_root(cwd-at-construction) = cwd` under normal eval launch → no divergence; `eval_benchmark`’s `os.chdir` is the **swebench grader** (scoped, project-tree-external temp), not the agent resolver. This is the **preventive** fix the mount-mode / project-root-discovery direction needs (issue origin). lead confirmed: not a swe_bench live blocker.

## Security (lead-confirmed)

No production behavior change: `cwd=project_root` in production → mcp.yaml etc. default-granted both pre/post. **No loosening — divergence-only fix** (subdir/mount).

## Test plan

- [x] **3 reproduce-first** (project_root ≠ cwd → project_root/.reyn write + a read under project_root granted; pre-fix the cwd-anchored zone denied them; carve-out anchored to project_root)
- [x] **full suite 6904 passed / 0 failed**. It surfaced 4 tests that RELIED on the cwd-divergence bug for their deny assertions — **corrected, not rote-greened** (lead co-signed): `s31c1._out_of_zone` returned a project_root-INTERNAL path (in the read zone) → made genuinely external; `mcp_install` "undeclared raises" tests pinned divergence-bug behavior (`.reyn/mcp.yaml` is default-granted by protect-at-use; security = `require_mcp` at use + `permissions.mcp` at install) → rewritten to assert the default-grant + the `approvals.yaml` carve-out contrast; the unreachable no-event-on-permission-denied test removed.
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)