### PR TITLE
feat(cli): activate per-frontend container-chat — chat + dogfood build/pass the agent backend (#1289)

### DIFF
--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -11,6 +11,10 @@ import shutil
 import sys
 from pathlib import Path
 
+from reyn.cli.env_backend import (
+    build_environment_backend,
+    register_env_backend_args,
+)
 from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
@@ -107,6 +111,8 @@ def register(sub) -> None:
             "local file access render in 'remote — limited' v1 mode."
         ),
     )
+    # #1289: per-frontend container-chat — same --env-backend surface as `reyn run`.
+    register_env_backend_args(p)
     add_common_args(p)
     p.set_defaults(func=run)
 
@@ -278,6 +284,15 @@ def run(args: argparse.Namespace) -> None:
 
     project_context = load_project_context(session_cfg.config, project_root)
 
+    # #1289: build the agent-level EnvironmentBackend (host / docker attach|launch)
+    # and pass the SAME instance to BOTH ChatSession seams (FS environment_backend
+    # + exec sandbox_backend) — the #1200 single-shared-sandbox invariant. A
+    # launched container is torn down at process exit.
+    env_backend, _ws_base_dir, _ws_state_dir, env_cleanup = build_environment_backend(args)
+    if env_cleanup is not None:
+        import atexit
+        atexit.register(env_cleanup)
+
     def _session_factory(profile: AgentProfile):
         # Captured CLI defaults — registry doesn't need to know them.
         s = ChatSession(
@@ -305,6 +320,9 @@ def run(args: argparse.Namespace) -> None:
             embedding_config=session_cfg.config.embedding,
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
+            # #1289: same backend instance to both seams (single-shared-sandbox).
+            environment_backend=env_backend,
+            sandbox_backend=env_backend,
         )
         s.load_history()
         return s

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -23,6 +23,11 @@ import json
 import sys
 from pathlib import Path
 
+from reyn.cli.env_backend import (
+    build_environment_backend,
+    register_env_backend_args,
+)
+
 
 def register(sub) -> None:
     p = sub.add_parser(
@@ -78,6 +83,8 @@ def register(sub) -> None:
                            "Override the LiteLLM model id used for "
                            "interpretation (default: openai/gemini-2.5-flash-lite)."
                        ))
+    # #1289: per-frontend container-chat — same --env-backend surface as `reyn run`.
+    register_env_backend_args(run_p)
     run_p.set_defaults(func=run_run)
 
     # --- coverage ---
@@ -295,7 +302,14 @@ def run_run(args: argparse.Namespace) -> None:
     scenario_set = load_scenario_set(str(set_yaml))
 
     # Build the live-LLM runner_fn (injected seam for the real agent path)
-    live_runner_fn = _build_live_runner(args.agent)
+    # #1289: build the agent-level EnvironmentBackend and pass the SAME instance
+    # to both ChatSession seams (FS + exec) via _build_live_runner (single-shared
+    # sandbox, #1200). A launched container is torn down at process exit.
+    _env_backend, _wb, _ws, _env_cleanup = build_environment_backend(args)
+    if _env_cleanup is not None:
+        import atexit
+        atexit.register(_env_cleanup)
+    live_runner_fn = _build_live_runner(args.agent, env_backend=_env_backend)
 
     try:
         from reyn.dogfood.runner import run_scenario_set
@@ -338,7 +352,7 @@ def run_run(args: argparse.Namespace) -> None:
     print(f"  results → {run_dir / 'summary.json'}")
 
 
-def _build_live_runner(agent_name: str):
+def _build_live_runner(agent_name: str, *, env_backend=None):
     """Return an async runner_fn that drives the chat router via send_to_agent_impl.
 
     Reuses the same path as MCP / web A2A: build a minimal AgentRegistry +
@@ -444,6 +458,9 @@ def _build_live_runner(agent_name: str):
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,
+                # #1289: same backend instance to both seams (single-shared-sandbox).
+                environment_backend=env_backend,
+                sandbox_backend=env_backend,
             )
             s.load_history()
             return s

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -6,6 +6,10 @@ import json
 import sys
 from pathlib import Path
 
+from reyn.cli.env_backend import (
+    build_environment_backend,
+    register_env_backend_args,
+)
 from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
@@ -71,53 +75,8 @@ def register(sub) -> None:
                        "Enable unsafe-mode Python preprocessor steps (no AST sandboxing). "
                        "Safe-mode python steps run without this flag. Off by default."
                    ))
-    # FP-0008 #1115 Stage 2: route the repo filesystem + command execution
-    # through a container EnvironmentBackend instead of the host. Generic (any
-    # skill); the OS stays on the host, only the repo FS + exec cross into the
-    # container. Used e.g. for faithful in-container benchmarking.
-    p.add_argument("--env-backend", dest="env_backend",
-                   choices=["host", "docker"], default="host",
-                   help=(
-                       "Where the repo filesystem and commands execute: 'host' "
-                       "(default, no isolation change) or 'docker'. For docker, "
-                       "either attach to a running container (--container/--repo-dir) "
-                       "or, if --container is omitted, reyn LAUNCHES a mount-mode "
-                       "container (workspace bind-mounted, security-hardened)."
-                   ))
-    p.add_argument("--container", dest="container", default=None, metavar="NAME",
-                   help=(
-                       "Running container name/id to ATTACH to (--env-backend=docker). "
-                       "Omit to have reyn launch a new mount-mode container instead."
-                   ))
-    p.add_argument("--repo-dir", dest="repo_dir", default=None, metavar="PATH",
-                   help=(
-                       "In-container absolute path of the repo working tree "
-                       "(e.g. /repo) for --env-backend=docker ATTACH mode. Relative "
-                       "paths resolve against this; commands run with it as cwd."
-                   ))
-    p.add_argument("--image", dest="image", default=None, metavar="IMAGE",
-                   help=(
-                       "Container image for --env-backend=docker LAUNCH mode "
-                       "(when --container is omitted). Defaults to a sensible "
-                       "generic base; override per task."
-                   ))
-    p.add_argument("--mount", dest="mounts", action="append", default=None,
-                   metavar="host:container[:rw|ro]",
-                   help=(
-                       "Additional bind mount for docker LAUNCH mode (repeatable). "
-                       "The workspace root is always mounted at /workspace."
-                   ))
-    p.add_argument("--keep-container", dest="keep_container", action="store_true",
-                   help=(
-                       "Do not tear down a reyn-launched container after the run "
-                       "(persistent reuse). Default: launched containers are removed."
-                   ))
-    p.add_argument("--state-dir", dest="state_dir", default=None, metavar="PATH",
-                   help=(
-                       "Host-side directory for OS state/artifacts (events, "
-                       "offload, artifact handles), kept off the routed repo FS. "
-                       "Recommended with --env-backend=docker so state stays on the host."
-                   ))
+    # #1289: shared --env-backend / container args (host / docker attach|launch).
+    register_env_backend_args(p)
     p.set_defaults(func=run)
 
 
@@ -154,7 +113,7 @@ def run(args: argparse.Namespace) -> None:
     project_root = _find_project_root(Path.cwd())
     project_context = load_project_context(session.config, project_root)
     logger = make_logger()
-    env_backend, ws_base_dir, ws_state_dir, env_cleanup = _build_environment_backend(args)
+    env_backend, ws_base_dir, ws_state_dir, env_cleanup = build_environment_backend(args)
     # #997 dir2: the permission/runtime bundle (permission_resolver, mcp_servers,
     # python_allowed_modules, prompt_cache_enabled, sandbox_config, resolver) is
     # derived from config inside Agent.from_config — a caller cannot omit it (the
@@ -225,122 +184,6 @@ def run(args: argparse.Namespace) -> None:
 
     if not result.ok:
         sys.exit(2)
-
-
-def _build_environment_backend(args: argparse.Namespace, *, launcher=None):
-    """Build the EnvironmentBackend + workspace dirs + optional cleanup.
-
-    Returns ``(backend, workspace_base_dir, workspace_state_dir, cleanup)``:
-
-    - host (default): ``(None, None, None, None)`` — identity HostBackend.
-    - docker ATTACH (``--container`` given): a ``DockerEnvironmentBackend`` over
-      the existing container; base_dir = the in-container ``--repo-dir``; no
-      cleanup (the operator owns the container).
-    - docker LAUNCH (``--container`` omitted): reyn launches a mount-mode
-      container (workspace bind-mounted at ``/workspace``, security-hardened);
-      base_dir = ``/workspace``; ``cleanup`` tears it down after the run unless
-      ``--keep-container``.
-
-    Generic — no skill-specific knowledge (P7). Image / mount / security are
-    agent-level operator config (#1326), independent of phase sandbox-policy.
-    """
-    backend_kind = getattr(args, "env_backend", "host")
-    if backend_kind == "host":
-        return None, None, None, None
-
-    if backend_kind == "docker":
-        from reyn.environment import DockerEnvironmentBackend
-        container = getattr(args, "container", None)
-        state_dir = getattr(args, "state_dir", None)
-        state_path = Path(state_dir) if state_dir else None
-
-        if container:
-            # ATTACH mode: existing operator-owned container (no teardown).
-            repo_dir = getattr(args, "repo_dir", None)
-            if not repo_dir:
-                print(
-                    "Error: --env-backend=docker with --container requires --repo-dir.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            if state_path is None:
-                # baked-repo model: no bind mount, so OS state cannot be made
-                # coherent with the in-container repo FS. Warn that state will
-                # land on the repo FS (lost on container death) unless host-side.
-                print(
-                    "Warning: --env-backend=docker --container without --state-dir: "
-                    "OS state (events/artifacts) will live on the in-container repo "
-                    "FS and is lost on container death. Pass --state-dir for a "
-                    "host-side state directory.",
-                    file=sys.stderr,
-                )
-            backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
-            return backend, Path(repo_dir), state_path, None
-
-        # LAUNCH mode: reyn starts a mount-mode container (#1324).
-        from reyn.config import _find_project_root
-        from reyn.environment.container_launcher import (
-            DEFAULT_IMAGE,
-            WORKSPACE_DEST_DEFAULT,
-            ContainerLauncher,
-            LaunchConfig,
-            load_devcontainer_config,
-            parse_mount_spec,
-        )
-        # _find_project_root returns None when no reyn.yaml is found up the tree;
-        # fall back to cwd so the mount source + state_dir are a real host path
-        # (NOT the bogus "None/.reyn" that str(None) would produce). The global
-        # cwd-vs-project_root resolution refinement is #1316 (separate slice).
-        project_root = _find_project_root(Path.cwd())
-        workspace_root = str(project_root if project_root is not None else Path.cwd())
-        try:
-            cli_mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
-        except ValueError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
-        keep = bool(getattr(args, "keep_container", False))
-        # #1324 (b) devcontainer awareness: a workspace devcontainer.json seeds
-        # the launch defaults; explicit CLI flags override it. build-based
-        # devcontainers are not yet supported → warn + use the default image.
-        dc = load_devcontainer_config(workspace_root)
-        if dc is not None and dc.build_based:
-            print(
-                "Warning: build-based devcontainer (dockerFile/build) is not yet "
-                "supported; using the default image.",
-                file=sys.stderr,
-            )
-        cli_image = getattr(args, "image", None)
-        dc_image = dc.image if (dc is not None and not dc.build_based) else None
-        config = LaunchConfig(
-            workspace_root=workspace_root,
-            image=cli_image or dc_image or DEFAULT_IMAGE,
-            mounts=cli_mounts or (dc.mounts if dc is not None else []),
-            persistent=keep,
-            setup_command=(dc.setup_command if dc is not None else None),
-            user=(dc.user if dc is not None else None),
-        )
-        launcher = launcher or ContainerLauncher()
-        try:
-            container_id = launcher.launch(config)
-        except RuntimeError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
-        print(f"launched container : {container_id} (image={config.image})")
-        backend = DockerEnvironmentBackend(
-            container=container_id, repo_dir=WORKSPACE_DEST_DEFAULT
-        )
-        cleanup = None if keep else (lambda: launcher.teardown(container_id))
-        # part2 (slice-2): in the workspace-mount model the host workspace_root is
-        # bind-mounted at /workspace, so the OS state dir defaults to the HOST
-        # workspace_root/.reyn — that same dir appears in-container at
-        # /workspace/.reyn, keeping OS index/approvals and the agent FS coherent
-        # (the bind-mount's purpose). An explicit --state-dir still wins.
-        launch_state_path = state_path or (Path(workspace_root) / ".reyn")
-        return backend, Path(WORKSPACE_DEST_DEFAULT), launch_state_path, cleanup
-
-    # argparse `choices` prevents this, but stay defensive.
-    print(f"Error: unknown --env-backend '{backend_kind}'.", file=sys.stderr)
-    sys.exit(1)
 
 
 def _read_input(args: argparse.Namespace) -> str:

--- a/src/reyn/cli/env_backend.py
+++ b/src/reyn/cli/env_backend.py
@@ -1,0 +1,183 @@
+"""Shared CLI helper: --env-backend arg registration + EnvironmentBackend build.
+
+#1289: per-frontend container-chat activation. `reyn run` (the Agent/OSRuntime
+entry) originally owned the `--env-backend` args + builder; chat / dogfood now
+reuse the SAME helper so any CLI frontend can launch/attach a container and pass
+the resulting backend uniformly. The single-shared-sandbox invariant (#1200) is
+the caller's: pass the ONE built backend instance to BOTH `environment_backend`
+(FS seam) and `sandbox_backend` (exec seam) so chat / planner / phase share it.
+
+Generic — no skill-specific knowledge (P7). Image / mount / security are
+agent-level operator config (#1326), independent of phase sandbox-policy.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def register_env_backend_args(p: argparse.ArgumentParser) -> None:
+    """Register the shared --env-backend / container args on a CLI subparser.
+
+    Frontends (`run`, `chat`, `dogfood`) call this so the flag surface + help is
+    identical everywhere; :func:`build_environment_backend` consumes them.
+    """
+    p.add_argument("--env-backend", dest="env_backend",
+                   choices=["host", "docker"], default="host",
+                   help=(
+                       "Where the repo filesystem and commands execute: 'host' "
+                       "(default, no isolation change) or 'docker'. For docker, "
+                       "either attach to a running container (--container/--repo-dir) "
+                       "or, if --container is omitted, reyn LAUNCHES a mount-mode "
+                       "container (workspace bind-mounted, security-hardened)."
+                   ))
+    p.add_argument("--container", dest="container", default=None, metavar="NAME",
+                   help=(
+                       "Running container name/id to ATTACH to (--env-backend=docker). "
+                       "Omit to have reyn launch a new mount-mode container instead."
+                   ))
+    p.add_argument("--repo-dir", dest="repo_dir", default=None, metavar="PATH",
+                   help=(
+                       "In-container absolute path of the repo working tree "
+                       "(e.g. /repo) for --env-backend=docker ATTACH mode. Relative "
+                       "paths resolve against this; commands run with it as cwd."
+                   ))
+    p.add_argument("--image", dest="image", default=None, metavar="IMAGE",
+                   help=(
+                       "Container image for --env-backend=docker LAUNCH mode "
+                       "(when --container is omitted). Defaults to a sensible "
+                       "generic base; override per task."
+                   ))
+    p.add_argument("--mount", dest="mounts", action="append", default=None,
+                   metavar="host:container[:rw|ro]",
+                   help=(
+                       "Additional bind mount for docker LAUNCH mode (repeatable). "
+                       "The workspace root is always mounted at /workspace."
+                   ))
+    p.add_argument("--keep-container", dest="keep_container", action="store_true",
+                   help=(
+                       "Do not tear down a reyn-launched container after the run "
+                       "(persistent reuse). Default: launched containers are removed."
+                   ))
+    p.add_argument("--state-dir", dest="state_dir", default=None, metavar="PATH",
+                   help=(
+                       "Host-side directory for OS state/artifacts (events, "
+                       "offload, artifact handles), kept off the routed repo FS. "
+                       "Recommended with --env-backend=docker so state stays on the host."
+                   ))
+
+
+def build_environment_backend(args: argparse.Namespace, *, launcher=None):
+    """Build the EnvironmentBackend + workspace dirs + optional cleanup.
+
+    Returns ``(backend, workspace_base_dir, workspace_state_dir, cleanup)``:
+
+    - host (default): ``(None, None, None, None)`` — identity HostBackend.
+    - docker ATTACH (``--container`` given): a ``DockerEnvironmentBackend`` over
+      the existing container; base_dir = the in-container ``--repo-dir``; no
+      cleanup (the operator owns the container).
+    - docker LAUNCH (``--container`` omitted): reyn launches a mount-mode
+      container (workspace bind-mounted at ``/workspace``, security-hardened);
+      base_dir = ``/workspace``; ``cleanup`` tears it down after the run unless
+      ``--keep-container``.
+
+    Generic — no skill-specific knowledge (P7). Image / mount / security are
+    agent-level operator config (#1326), independent of phase sandbox-policy.
+    """
+    backend_kind = getattr(args, "env_backend", "host")
+    if backend_kind == "host":
+        return None, None, None, None
+
+    if backend_kind == "docker":
+        from reyn.environment import DockerEnvironmentBackend
+        container = getattr(args, "container", None)
+        state_dir = getattr(args, "state_dir", None)
+        state_path = Path(state_dir) if state_dir else None
+
+        if container:
+            # ATTACH mode: existing operator-owned container (no teardown).
+            repo_dir = getattr(args, "repo_dir", None)
+            if not repo_dir:
+                print(
+                    "Error: --env-backend=docker with --container requires --repo-dir.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if state_path is None:
+                # baked-repo model: no bind mount, so OS state cannot be made
+                # coherent with the in-container repo FS. Warn that state will
+                # land on the repo FS (lost on container death) unless host-side.
+                print(
+                    "Warning: --env-backend=docker --container without --state-dir: "
+                    "OS state (events/artifacts) will live on the in-container repo "
+                    "FS and is lost on container death. Pass --state-dir for a "
+                    "host-side state directory.",
+                    file=sys.stderr,
+                )
+            backend = DockerEnvironmentBackend(container=container, repo_dir=repo_dir)
+            return backend, Path(repo_dir), state_path, None
+
+        # LAUNCH mode: reyn starts a mount-mode container (#1324).
+        from reyn.config import _find_project_root
+        from reyn.environment.container_launcher import (
+            DEFAULT_IMAGE,
+            WORKSPACE_DEST_DEFAULT,
+            ContainerLauncher,
+            LaunchConfig,
+            load_devcontainer_config,
+            parse_mount_spec,
+        )
+        # _find_project_root returns None when no reyn.yaml is found up the tree;
+        # fall back to cwd so the mount source + state_dir are a real host path
+        # (NOT the bogus "None/.reyn" that str(None) would produce).
+        project_root = _find_project_root(Path.cwd())
+        workspace_root = str(project_root if project_root is not None else Path.cwd())
+        try:
+            cli_mounts = [parse_mount_spec(m) for m in (getattr(args, "mounts", None) or [])]
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        keep = bool(getattr(args, "keep_container", False))
+        # #1324 (b) devcontainer awareness: a workspace devcontainer.json seeds
+        # the launch defaults; explicit CLI flags override it. build-based
+        # devcontainers are not yet supported → warn + use the default image.
+        dc = load_devcontainer_config(workspace_root)
+        if dc is not None and dc.build_based:
+            print(
+                "Warning: build-based devcontainer (dockerFile/build) is not yet "
+                "supported; using the default image.",
+                file=sys.stderr,
+            )
+        cli_image = getattr(args, "image", None)
+        dc_image = dc.image if (dc is not None and not dc.build_based) else None
+        config = LaunchConfig(
+            workspace_root=workspace_root,
+            image=cli_image or dc_image or DEFAULT_IMAGE,
+            mounts=cli_mounts or (dc.mounts if dc is not None else []),
+            persistent=keep,
+            setup_command=(dc.setup_command if dc is not None else None),
+            user=(dc.user if dc is not None else None),
+        )
+        launcher = launcher or ContainerLauncher()
+        try:
+            container_id = launcher.launch(config)
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"launched container : {container_id} (image={config.image})")
+        backend = DockerEnvironmentBackend(
+            container=container_id, repo_dir=WORKSPACE_DEST_DEFAULT
+        )
+        cleanup = None if keep else (lambda: launcher.teardown(container_id))
+        # part2 (slice-2): in the workspace-mount model the host workspace_root is
+        # bind-mounted at /workspace, so the OS state dir defaults to the HOST
+        # workspace_root/.reyn — that same dir appears in-container at
+        # /workspace/.reyn, keeping OS index/approvals and the agent FS coherent.
+        # An explicit --state-dir still wins.
+        launch_state_path = state_path or (Path(workspace_root) / ".reyn")
+        return backend, Path(WORKSPACE_DEST_DEFAULT), launch_state_path, cleanup
+
+    # argparse `choices` prevents this, but stay defensive.
+    print(f"Error: unknown --env-backend '{backend_kind}'.", file=sys.stderr)
+    sys.exit(1)

--- a/tests/test_1289_frontend_container_chat.py
+++ b/tests/test_1289_frontend_container_chat.py
@@ -1,0 +1,68 @@
+"""Tier 2: per-frontend container-chat activation (#1289).
+
+#1200 wired ChatSession's two seams (FS Workspace + exec OpContext) to a single
+injected backend (verified in test_1200_*). #1289 ACTIVATES that at the CLI
+frontends: a shared `reyn.cli.env_backend` helper registers the `--env-backend`
+args + builds the EnvironmentBackend; `reyn chat` / `reyn dogfood` (like `reyn
+run`) build it and pass the SAME instance to BOTH ChatSession seams.
+
+These pin the shared-helper surface + the frontend-activation contract (the same
+instance reaches both seams = the #1200 single-shared-sandbox review-gate that any
+frontend must uphold). No mocks: a real argparse parser + real ChatSession +
+a real backend instance.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from reyn.chat.session import ChatSession
+from reyn.cli.env_backend import build_environment_backend, register_env_backend_args
+from reyn.environment.host_backend import HostBackend
+from reyn.events.state_log import StateLog
+
+
+def test_register_env_backend_args_surface() -> None:
+    """Tier 2: the shared helper registers the full --env-backend arg surface
+    (so every frontend exposes the identical flags)."""
+    p = argparse.ArgumentParser()
+    register_env_backend_args(p)
+    ns = p.parse_args([])
+    # defaults = host identity (no container)
+    assert ns.env_backend == "host"
+    assert ns.container is None
+    assert ns.repo_dir is None
+    # the docker knobs parse
+    ns2 = p.parse_args([
+        "--env-backend", "docker", "--container", "c1", "--repo-dir", "/repo",
+        "--image", "img", "--mount", "a:b", "--keep-container", "--state-dir", "/s",
+    ])
+    assert ns2.env_backend == "docker" and ns2.container == "c1"
+    assert ns2.repo_dir == "/repo" and ns2.keep_container is True
+
+
+def test_build_environment_backend_host_is_identity() -> None:
+    """Tier 2: env_backend=host → (None, None, None, None) = the HostBackend
+    identity path (no container, no cleanup) — frontends stay byte-identical
+    unless --env-backend=docker is passed."""
+    ns = argparse.Namespace(env_backend="host")
+    assert build_environment_backend(ns) == (None, None, None, None)
+
+
+def test_frontend_contract_same_instance_reaches_both_seams(tmp_path: Path) -> None:
+    """Tier 2: ★#1289 activation gate — the frontend contract (pass the ONE built
+    backend as BOTH environment_backend + sandbox_backend, as chat.py/dogfood.py
+    do) reaches the FS seam (Workspace) AND the exec seam (OpContext) as the SAME
+    object. This is the #1200 single-shared-sandbox invariant the activation must
+    uphold (a frontend wiring different instances = reject)."""
+    one = HostBackend()  # stands in for a built DockerEnvironmentBackend
+    session = ChatSession(
+        agent_name="b",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        environment_backend=one,   # FS seam (what the frontend passes)
+        sandbox_backend=one,       # exec seam — SAME instance
+    )
+    ctx = session._make_router_op_context()
+    assert ctx.workspace.backend is one    # FS seam
+    assert ctx.sandbox_backend is one      # exec seam — same instance

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import pytest
 
-from reyn.cli.commands.run import _build_environment_backend
+from reyn.cli.env_backend import (
+    build_environment_backend as _build_environment_backend,
+)
 
 
 def _args(**kw) -> argparse.Namespace:


### PR DESCRIPTION
**[dogfood-coder]** — owner HIGH, #1289 (#1200 follow-up). lead-approved scope: **CLI-now + web-defer**. Refs #1289 #1200.

## Change

#1200 wired ChatSession’s two seams (FS Workspace + exec OpContext) to a single injected backend; **#1289 ACTIVATES it at the CLI frontends** — the concrete consumer (`reyn chat --container`, `reyn dogfood … --container`).

- **New shared `reyn/cli/env_backend.py`**: `register_env_backend_args` (the `--env-backend` / `--container` / `--repo-dir` / `--image` / `--mount` / `--keep-container` / `--state-dir` surface) + `build_environment_backend` (host / docker-attach / docker-launch), moved verbatim from `cli/commands/run.py` so every frontend shares one helper (no cross-command import).
- **run.py**: uses the shared helper (behavior unchanged).
- **chat.py + dogfood.py**: register the args, build the backend, pass the **SAME instance** to BOTH `environment_backend` (FS) and `sandbox_backend` (exec) — the #1200 single-shared-sandbox invariant; a launched container is torn down at process exit (atexit).
- **web / chainlit**: deferred (legit YAGNI — no concrete web-container consumer; the issue scopes them config-driven IF/when needed). lead-confirmed.

## Test plan

- [x] `test_1289_frontend_container_chat`: arg-surface + host-identity (the shared helper) + ★the **frontend-activation gate** (the one built backend reaches FS + exec seams as the SAME object = the #1199 reject-different-wiring review-gate the activation must uphold)
- [x] existing `test_run_container_backend_flags` import re-pointed to the shared module (27 affected-subset pass)
- [x] **full suite 6907 passed / 0 failed**
- [x] `ruff` clean; `test_tier_audit.py --strict` 0 errors

## Follow-up

web/chainlit container-chat (config-driven) — deferred YAGNI; extend when a concrete web-container consumer appears (owner aware via lead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)