### PR TITLE
feat(183): runs_in:os — keep OS-orchestration python steps on the host (#1356 root-fix)

### DIFF
--- a/src/reyn/kernel/preprocessor_executor.py
+++ b/src/reyn/kernel/preprocessor_executor.py
@@ -603,6 +603,9 @@ class PreprocessorExecutor:
                 sandbox_write_paths=sandbox_write_paths,
                 sandbox_backend=self._sandbox_backend,
                 sandbox_policy=self._agent_sandbox_policy,
+                # #183 root-fix: OS-orchestration steps (runs_in:os) never route to
+                # the exec backend — they run in the host framework process.
+                runs_in=getattr(step, "runs_in", "sandbox"),
             )
         except PythonStepError as exc:
             self._events.emit(

--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -94,6 +94,7 @@ class PythonRunner:
         sandbox_write_paths: list[str] | None = None,
         sandbox_backend: "SandboxBackend | None" = None,
         sandbox_policy: dict | None = None,
+        runs_in: str = "sandbox",
     ) -> Any:
         """Execute `function` in `module` against `artifact`.
 
@@ -148,8 +149,13 @@ class PythonRunner:
         # #1352-B: route through the OS sandbox backend when one is configured
         # (real + available + not noop). Falls back to a direct subprocess for
         # noop / None (unchanged behavior — standard chat runs python unsandboxed).
+        # #183 root-fix: an OS-orchestration step (`runs_in: os`) is never routed
+        # to the exec backend — it is reyn framework code (pure artifact-transform)
+        # that runs in the host process, not in the agent's sandbox/container
+        # (whose repo python can't host reyn). `sandbox` (default) preserves #1356.
         use_backend = (
-            sandbox_backend is not None
+            runs_in != "os"
+            and sandbox_backend is not None
             and getattr(sandbox_backend, "name", None) not in (None, "noop")
             and sandbox_backend.available()
         )

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -50,6 +50,20 @@ class PythonStep(BaseModel):
     function: str             # function name within the module
     into: str                 # dot path in artifact where the return value is placed
     output_schema: dict[str, Any]  # JSON Schema of the function's return value
+    # #183 / #1352-B root-fix: which substrate this step runs on.
+    #   "sandbox" (default) — when a real exec backend is configured (container /
+    #     Seatbelt / Landlock), the harness subprocess routes through it (#1356):
+    #     for steps whose FS effects must hit the agent's shared substrate.
+    #   "os" — OS-orchestration: a deterministic, pure artifact-transform step
+    #     (in-memory input → output value, no FS/network) runs in the framework
+    #     HOST process and is NEVER routed to the exec backend. This is the
+    #     industry model (SWE-agent / OpenHands: no framework code in the agent
+    #     container — the swebench image's repo conda python can't host reyn).
+    #     Containment is unchanged: the safe-mode AST restriction + reyn.safe.file
+    #     path-gating apply on host identically; "os" only selects WHERE the
+    #     already-bounded compute runs. Default stays "sandbox" so #1356's
+    #     sandboxing intent is preserved for general / agent-authored steps.
+    runs_in: Literal["os", "sandbox"] = "sandbox"
 
 
 class RunOpStep(BaseModel):

--- a/src/reyn/stdlib/skills/swe_bench/phases/apply.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/apply.md
@@ -18,6 +18,7 @@ preprocessor:
     module: ./escape_anchors.py
     function: escape_anchors
     mode: safe
+    runs_in: os   # #183: OS-orchestration text-prep (pure transform) — host, never the agent container
     into: data.edits
     output_schema:
       type: array
@@ -48,6 +49,7 @@ preprocessor:
     module: ./drop_not_locatable.py
     function: drop_not_locatable
     mode: safe
+    runs_in: os   # #183: OS-orchestration text-prep (pure transform) — host, never the agent container
     into: data
     output_schema:
       type: object

--- a/src/reyn/stdlib/skills/swe_bench/phases/report.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/report.md
@@ -23,6 +23,7 @@ preprocessor:
     module: ./parse_test_targets.py
     function: parse_test_targets
     mode: safe
+    runs_in: os   # #183: OS-orchestration text-prep (pure transform) — host, never the agent container
     into: data._revert_cmds
     output_schema:
       type: array

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -28,6 +28,7 @@ preprocessor:
     module: ./sanitize_test_patch.py
     function: sanitize_test_patch
     mode: safe
+    runs_in: os   # #183: OS-orchestration text-prep (pure transform) — host, never the agent container
     into: data.test_patch
     output_schema:
       type: string
@@ -40,6 +41,7 @@ preprocessor:
     module: ./parse_test_targets.py
     function: parse_test_targets
     mode: safe
+    runs_in: os   # #183: OS-orchestration text-prep (pure transform) — host, never the agent container
     into: data._revert_cmds
     output_schema:
       type: array

--- a/tests/test_python_step_runs_in_os_183.py
+++ b/tests/test_python_step_runs_in_os_183.py
@@ -1,0 +1,152 @@
+"""Tier 2: #183 root-fix — `runs_in: os` keeps OS-orchestration python steps host.
+
+#1356 routes a python step's harness subprocess through a configured exec backend
+(container / Seatbelt / Landlock). For an OS-orchestration step (pure
+artifact-transform reyn framework code), that is over-binding: the agent's
+sandbox/container (e.g. a swebench image's repo conda python) cannot host reyn.
+
+The root-fix adds a general `PythonStep.runs_in` axis:
+  - `sandbox` (default) — preserves #1356 (route to the backend when real).
+  - `os` — never routed; runs in the host framework process.
+
+Containment is unchanged on `os`: the safe-mode AST restriction + reyn.safe.file
+path-gating apply identically on host (see the security-floor test).
+
+No mocks of real collaborators: a real `_RecordingBackend` (SandboxBackend
+interface) + real `PythonRunner` + real harness subprocess + real
+`load_dsl_skill`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.python_runner import PythonRunner, PythonStepError
+from reyn.sandbox.backend import SandboxResult
+
+
+class _RecordingBackend:
+    """Real (non-mock) SandboxBackend stand-in — records run() calls + returns a
+    canned harness-success payload (routing observable without OS isolation)."""
+
+    name = "seatbelt"  # a real backend (not "noop")
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None) -> SandboxResult:
+        self.calls.append({"argv": list(argv)})
+        payload = {"ok": True, "result": {"echoed": "ok"}}
+        return SandboxResult(returncode=0, stdout=json.dumps(payload).encode(), stderr=b"")
+
+
+def _write_module(skill_dir: Path, body: str) -> None:
+    (skill_dir / "mod.py").write_text(body, encoding="utf-8")
+
+
+# ── load-from-disk wiring (parser → model) ──────────────────────────────────
+
+
+def test_loader_wires_runs_in_from_disk() -> None:
+    """Tier 2: `runs_in` flows frontmatter→parser→model on a real disk load; the
+    swe_bench text-prep python steps are `os`, an undeclared step defaults `sandbox`."""
+    from reyn.compiler.loader import load_dsl_skill
+    from reyn.schemas.models import PythonStep
+
+    skill = load_dsl_skill(
+        Path(__file__).parent.parent
+        / "src" / "reyn" / "stdlib" / "skills" / "swe_bench" / "skill.md"
+    )
+    py_steps = [
+        s for phase in skill.phases.values()
+        for s in phase.preprocessor if isinstance(s, PythonStep)
+    ]
+    assert py_steps, "swe_bench must have python preprocessor steps"
+    assert all(s.runs_in == "os" for s in py_steps), (
+        f"all swe_bench text-prep steps must declare runs_in:os; got "
+        f"{[(s.module, s.runs_in) for s in py_steps]}"
+    )
+    # an undeclared step defaults to sandbox (#1356 preserved by default)
+    default = PythonStep(
+        type="python", module="./x.py", function="f", into="data.x",
+        output_schema={"type": "object"},
+    )
+    assert default.runs_in == "sandbox"
+
+
+# ── routing gate: os skips the backend / sandbox routes (falsification pair) ──
+
+
+@pytest.mark.asyncio
+async def test_runs_in_os_skips_backend(tmp_path: Path) -> None:
+    """Tier 2: a `runs_in: os` step is NOT routed through the exec backend — it
+    runs in the host process (real direct subprocess), returning its result; the
+    backend is never called."""
+    _write_module(tmp_path, "def go(artifact):\n    return {'host': True}\n")
+    backend = _RecordingBackend()
+    runner = PythonRunner()
+
+    result = await runner.run(
+        skill_dir=tmp_path, module="./mod.py", function="go", mode="safe",
+        artifact={"data": {}}, timeout=30,
+        sandbox_backend=backend, sandbox_policy={"network": False},
+        runs_in="os",
+    )
+
+    assert backend.calls == [], "runs_in:os must NOT route to the exec backend"
+    assert result == {"host": True}, "the host direct subprocess produced the result"
+
+
+@pytest.mark.asyncio
+async def test_default_sandbox_still_routes_to_backend(tmp_path: Path) -> None:
+    """Tier 2: falsification — the default (`runs_in: sandbox`) step STILL routes
+    through the exec backend with a real backend; #1356 is preserved, not reversed."""
+    _write_module(tmp_path, "def go(artifact):\n    return {'echoed': 'ok'}\n")
+    backend = _RecordingBackend()
+    runner = PythonRunner()
+
+    result = await runner.run(
+        skill_dir=tmp_path, module="./mod.py", function="go", mode="safe",
+        artifact={"data": {}}, timeout=30,
+        sandbox_backend=backend, sandbox_policy={"network": False},
+        # runs_in defaults to "sandbox"
+    )
+
+    assert backend.calls, "default step must route through backend.run (#1356)"
+    assert "reyn.kernel._python_harness" in backend.calls[0]["argv"]
+    assert result == {"echoed": "ok"}
+
+
+# ── security floor: os does not weaken the safe.file gate ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runs_in_os_safe_file_still_path_gated(tmp_path: Path) -> None:
+    """Tier 2: security floor — a `runs_in: os` step running on the host is still
+    bound by reyn.safe.file's path gate; a write outside the forwarded
+    file_write_paths is DENIED (host-run does not bypass containment)."""
+    out_of_zone = tmp_path / "denied" / "evil.txt"
+    _write_module(
+        tmp_path,
+        "from reyn.safe import file as _f\n"
+        f"def go(artifact):\n"
+        f"    _f.write({str(out_of_zone)!r}, 'x')\n"
+        f"    return {{'wrote': True}}\n",
+    )
+    runner = PythonRunner()
+
+    with pytest.raises(PythonStepError):
+        await runner.run(
+            skill_dir=tmp_path, module="./mod.py", function="go", mode="safe",
+            artifact={"data": {}}, timeout=30,
+            allowed_modules=["reyn.safe.file"],
+            # grant a DIFFERENT dir only; the write target is out of zone
+            file_write_paths=[str(tmp_path / "allowed")],
+            runs_in="os",
+        )
+    assert not out_of_zone.exists(), "the out-of-zone write must not have landed"


### PR DESCRIPTION
**[e2e-coder]** — #183 prep: `runs_in: os` root-fix so OS-orchestration python steps stay on the host. lead-coder design-APPROVED (#183 issuecomment-4631051833); this is the impl. lead-coder PR-review.

## Why

#1356 routes a python step's harness subprocess through a configured exec backend. For an **OS-orchestration** step (pure artifact-transform reyn framework code) that over-binds: the agent container can't host reyn. **Primary evidence** (real `docker run`, cached swebench astropy-13453): `/testbed` conda python = **3.9.20** (reyn needs `>=3.11`); base 3.11 lacks reyn's deps → `python -m reyn.kernel._python_harness` can't run in-image. Industry model: SWE-agent ("no framework code in the container"), OpenHands (separate baked layer). #1356 (today) regressed the proven pre-#1356 faithful path (journal 2026-06-01: 5 Class A astropy ran faithfully via `reyn run --env-backend=docker`, python-steps-host + pytest-in-/testbed).

## What (root-fix, P7-clean, general)

- `PythonStep.runs_in: "os" | "sandbox"` (default `sandbox` — **#1356 preserved**). `os` = OS-orchestration; the harness runs in the host framework process, never routed to the exec backend.
- python_runner gate: `use_backend = runs_in != "os" and <existing #1356 conditions>`.
- Full loader-path wiring: frontmatter → parser (raw dict) → model → preprocessor_executor → python_runner.
- swe_bench's 5 text-prep steps (`sanitize_test_patch` / `parse_test_targets` ×2 / `escape_anchors` / `drop_not_locatable` — all verified pure-compute) declare `runs_in: os`.
- **Containment unchanged on `os`**: safe-mode AST + reyn.safe.file path-gating apply identically on host.

## Test plan

`tests/test_python_step_runs_in_os_183.py` (Tier 2, no mocks — real RecordingBackend + real PythonRunner + real harness subprocess + real `load_dsl_skill`):

- [x] **load-from-disk wiring**: `runs_in` flows frontmatter→parser→model on a real skill load; swe_bench steps = `os`, undeclared default = `sandbox` ([[feedback_wire_full_frontmatter_to_runtime_path]])
- [x] **runs_in:os skips backend**: host direct run, backend never called; **falsification-confirmed** (test fails when the gate condition is removed)
- [x] **falsification — default still routes**: default (`sandbox`) step STILL routes through `backend.run` (#1356 preserved, not reversed)
- [x] **security floor**: a `runs_in:os` step's `reyn.safe.file` write outside the forwarded `file_write_paths` is DENIED on host (containment not weakened)
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` clean
- [x] full `pytest -q` from rootdir — 6929 passed (only the pre-existing env-local web_fetch fail, CI-green, untouched)

## Not in this PR

Per the #183 "no confounded number" invariant: the **re-smoke** (the swe_bench steps execute under `--env-backend=docker` on astropy-13453) + the 5 Class A run come **after** merge.

Refs #183 #1352
