### PR TITLE
feat(183): provision an in-container reyn venv for faithful swe_bench (scripts/, OS-change-free)

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -34,12 +34,86 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 # Required keys every SWE-bench instance must carry.
 _REQUIRED_FIELDS = ("instance_id", "repo", "base_commit", "problem_statement")
+
+# ── reyn-in-container venv provisioning (#183 / #1356 honored) ────────────────
+#
+# #1356 routes a python preprocessor step's harness subprocess through the
+# sandbox backend — for `--env-backend=docker` that is a `docker exec` INTO the
+# swebench instance image. The image's testbed conda python is repo-pinned
+# (e.g. astropy = 3.9) and reyn needs >=3.11, so the harness cannot run there.
+# Per the owner directive we provision a python3.11 venv WITH reyn inside the
+# container (OpenHands-style: framework python separate from the repo env), and
+# point the harness at it via REYN_HARNESS_PYTHON (the only OS-side change — a
+# general 1-line env override in PythonRunner; this script is OS-change-free).
+# pytest (sandboxed_exec) stays on the testbed conda — the agent's repo tests
+# need the repo env, not the venv.
+#
+# Recipe (primary-evidence: real `docker run` on astropy-13453):
+#   - base python3.11 already in the image (`/opt/miniconda3/bin/python3.11`);
+#   - the container reaches PyPI (no wheelhouse needed) — `pip install` works;
+#   - `pip install -e` on the :ro reyn mount FAILS (editable build can't write
+#     to read-only source) → install reyn's deps explicitly + put reyn itself on
+#     the path via a `.pth` to the bind-mounted source (no PYTHONPATH threading,
+#     so container_backend.run is untouched). Deps are version-pinned by
+#     reyn's own pyproject (read at runtime — no hardcoded drift).
+_CONTAINER_REYN_MOUNT = "/reyn"            # host reyn repo, bind-mounted :ro
+_CONTAINER_VENV = "/opt/reyn-venv"
+_CONTAINER_PY311 = "/opt/miniconda3/bin/python3.11"
+_CONTAINER_HARNESS_PYTHON = f"{_CONTAINER_VENV}/bin/python"
+# reyn's pyproject lists test/lint tooling alongside runtime deps; the harness
+# needs only the runtime set, so these dev tools are skipped (faster setup).
+_DEV_ONLY_DEPS = frozenset(
+    {"pytest", "pytest-cov", "pytest-xdist", "pytest-asyncio", "ruff", "mypy", "pre-commit"}
+)
+
+
+def _reyn_repo_root() -> Path:
+    """The host reyn repo root (this script lives in <root>/scripts/)."""
+    return Path(__file__).resolve().parent.parent
+
+
+def reyn_runtime_deps(pyproject_text: str) -> list[str]:
+    """Parse reyn's runtime dependencies from pyproject text (dev tools dropped).
+
+    Pure (text in → list out) so it is unit-testable without the file or tomllib
+    version specifics. Version pins are preserved verbatim from pyproject.
+    """
+    import tomllib
+
+    data = tomllib.loads(pyproject_text)
+    out = []
+    for dep in data.get("project", {}).get("dependencies", []):
+        # strip the version/extras to get the bare distribution name for the filter
+        name = dep.split(">=")[0].split("==")[0].split("[")[0].split("<")[0].strip()
+        if name.lower() not in _DEV_ONLY_DEPS:
+            out.append(dep)
+    return out
+
+
+def provision_command(deps: list[str]) -> str:
+    """The `bash -lc` body that builds the in-container reyn venv (pure → str).
+
+    Builds a python3.11 venv, installs reyn's runtime deps (version-pinned), and
+    puts reyn itself on sys.path via a `.pth` to the bind-mounted source — so
+    `<venv>/bin/python -m reyn.kernel._python_harness` imports reyn with no
+    PYTHONPATH threading. Each dep is shell-quoted (version specs contain `>`)."""
+    deps_arg = " ".join(shlex.quote(d) for d in deps)
+    return (
+        "set -e; "
+        f"{_CONTAINER_PY311} -m venv {_CONTAINER_VENV}; "
+        f"{_CONTAINER_VENV}/bin/pip install --quiet {deps_arg}; "
+        f"echo {_CONTAINER_REYN_MOUNT}/src "
+        f"> \"$({_CONTAINER_VENV}/bin/python -c 'import site; print(site.getsitepackages()[0])')/reyn.pth\""
+    )
 
 
 # ── pure helpers (testable without subprocess) ──────────────────────────────
@@ -179,6 +253,7 @@ def run_reyn(
     *,
     reyn_cmd: list[str] | None = None,
     timeout: int = 600,
+    env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Shell out to ``reyn run swe_bench`` and return a result dict.
 
@@ -210,6 +285,7 @@ def run_reyn(
             capture_output=True,
             text=True,
             timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         return {"ok": False, "error": f"timeout after {timeout}s"}
@@ -291,9 +367,17 @@ def run_reyn_in_container(
         f"[swe_bench_runner] docker run image={image} name={name} (instance={instance_id})",
         file=sys.stderr,
     )
+    reyn_root = str(_reyn_repo_root())
     try:
         start = runner(
-            [docker_bin, "run", "-d", "--name", name, image, "sleep", "infinity"],
+            # #183: bind-mount the host reyn repo :ro so the in-container venv can
+            # put reyn on its path (.pth → /reyn/src); the harness imports reyn
+            # there. The repo's own files stay at repo_dir (/testbed), untouched.
+            [
+                docker_bin, "run", "-d", "--name", name,
+                "-v", f"{reyn_root}:{_CONTAINER_REYN_MOUNT}:ro",
+                image, "sleep", "infinity",
+            ],
             timeout=300,
         )
     except (OSError, subprocess.SubprocessError) as exc:
@@ -305,6 +389,21 @@ def run_reyn_in_container(
         }
 
     try:
+        # #183: provision the python3.11 venv with reyn inside the container so the
+        # #1356-routed python-step harness can run (the testbed conda is repo-pinned
+        # < 3.11). pytest stays on the testbed conda. Requires container→PyPI access.
+        deps = reyn_runtime_deps((_reyn_repo_root() / "pyproject.toml").read_text())
+        print(f"[swe_bench_runner] provisioning reyn venv in {name} ({len(deps)} deps)", file=sys.stderr)
+        prov = runner(
+            [docker_bin, "exec", name, "bash", "-lc", provision_command(deps)],
+            timeout=600,
+        )
+        if getattr(prov, "returncode", 1) != 0:
+            return {
+                "ok": False,
+                "error": f"venv provisioning failed (rc={prov.returncode}): {(prov.stderr or '')[:400]}",
+            }
+
         base = reyn_base if reyn_base is not None else ["reyn", "run", "swe_bench"]
         full_cmd = [
             *base,
@@ -313,7 +412,10 @@ def run_reyn_in_container(
             "--repo-dir", repo_dir,
             "--state-dir", host_state,
         ]
-        return run_reyn(instance, reyn_cmd=full_cmd, timeout=timeout)
+        # #183: point the #1356 harness subprocess at the in-container venv python
+        # (read by PythonRunner's REYN_HARNESS_PYTHON override — the only OS change).
+        run_env = {**os.environ, "REYN_HARNESS_PYTHON": _CONTAINER_HARNESS_PYTHON}
+        return run_reyn(instance, reyn_cmd=full_cmd, timeout=timeout, env=run_env)
     finally:
         try:
             rm = runner([docker_bin, "rm", "-f", name], timeout=120)

--- a/tests/test_swe_bench_runner_venv_183.py
+++ b/tests/test_swe_bench_runner_venv_183.py
@@ -1,0 +1,149 @@
+"""Tier 1/2: #183 — swe_bench_runner provisions an in-container reyn venv.
+
+#1356 routes a python preprocessor step's harness subprocess through the sandbox
+backend; for `--env-backend=docker` that is a `docker exec` into the swebench
+image, whose testbed conda python is repo-pinned (< reyn's 3.11). So the runner
+provisions a python3.11 venv WITH reyn inside the container (OS-change-free,
+scripts/-isolated) and points the harness at it via REYN_HARNESS_PYTHON.
+
+Pure helpers are text-in/text-out (Tier 1). The container integration uses the
+existing injected docker_runner + a real reyn shim (Tier 2, no mocks).
+
+Primary-evidence note (not a unit test): the exact `provision_command` was run in
+a real swebench astropy-13453 container — the venv built and
+`/opt/reyn-venv/bin/python -m reyn.kernel._python_harness` imported + executed.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from scripts.swe_bench_runner import (
+    provision_command,
+    reyn_runtime_deps,
+    run_reyn_in_container,
+)
+
+_INSTANCE = {
+    "instance_id": "astropy__astropy-13453",
+    "repo": "astropy/astropy",
+    "base_commit": "abc123",
+    "problem_statement": "Fix a bug.",
+}
+
+
+# ── Tier 1: pure helpers ─────────────────────────────────────────────────────
+
+
+def test_reyn_runtime_deps_drops_dev_tools_keeps_runtime_with_pins() -> None:
+    """Tier 1: runtime deps keep their pyproject version pins; test/lint tooling
+    (pytest / ruff / mypy / pre-commit) is dropped (the harness doesn't need it)."""
+    pyproject = (
+        "[project]\n"
+        'dependencies = [\n'
+        '  "litellm>=1.0",\n'
+        '  "pydantic>=2.0",\n'
+        '  "pytest>=8.0",\n'
+        '  "ruff",\n'
+        '  "mypy",\n'
+        '  "pytest-asyncio>=0.23",\n'
+        '  "numpy>=1.24",\n'
+        ']\n'
+    )
+    deps = reyn_runtime_deps(pyproject)
+    assert "litellm>=1.0" in deps and "pydantic>=2.0" in deps and "numpy>=1.24" in deps
+    assert not any(
+        d.split(">=")[0].split("[")[0].strip() in {"pytest", "ruff", "mypy", "pytest-asyncio"}
+        for d in deps
+    ), f"dev tools must be dropped: {deps}"
+
+
+def test_provision_command_builds_venv_pip_and_pth() -> None:
+    """Tier 1: the provision body creates a 3.11 venv, pip-installs the deps
+    (each shell-quoted — version specs contain `>`), and puts reyn on the path via
+    a .pth to the bind-mounted source (no PYTHONPATH threading)."""
+    cmd = provision_command(["litellm>=1.0", "pydantic>=2.0"])
+    assert "python3.11 -m venv /opt/reyn-venv" in cmd
+    assert "/opt/reyn-venv/bin/pip install" in cmd
+    # version specs are shell-quoted so bash does not treat `>` as a redirect
+    assert "'litellm>=1.0'" in cmd and "'pydantic>=2.0'" in cmd
+    assert "reyn.pth" in cmd and "/reyn/src" in cmd
+
+
+# ── Tier 2: container integration (injected docker_runner + reyn shim) ────────
+
+
+class _RecordingDocker:
+    """Injectable docker runner — records argv, returns a configurable result."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, *, timeout=180):
+        self.calls.append(list(argv))
+        return types.SimpleNamespace(returncode=0, stdout="cid123\n", stderr="")
+
+
+def _patch_emitting_reyn(tmp_path: Path, env_out: Path):
+    """A reyn shim that records REYN_HARNESS_PYTHON from its env + prints a patch."""
+    script = tmp_path / "rec_reyn.py"
+    script.write_text(
+        "import sys, os, json\n"
+        f"open({str(env_out)!r}, 'w').write(os.environ.get('REYN_HARNESS_PYTHON', ''))\n"
+        "print('=== Final Output ===')\n"
+        "print(json.dumps({'patch': 'diff --git a/f b/f\\n'}))\n",
+        encoding="utf-8",
+    )
+    return [sys.executable, str(script)]
+
+
+def test_container_mounts_reyn_and_provisions_venv(tmp_path: Path) -> None:
+    """Tier 2: docker run bind-mounts the reyn repo :ro, and a `docker exec`
+    provisions the venv (the harness's python substrate) before reyn runs."""
+    docker = _RecordingDocker()
+    reyn_base = _patch_emitting_reyn(tmp_path, tmp_path / "hp.txt")
+
+    run_reyn_in_container(
+        _INSTANCE,
+        image="swebench/sweb.eval.x86_64.astropy:latest",
+        repo_dir="/testbed",
+        state_dir=str(tmp_path / "state"),
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    run_call = next(c for c in docker.calls if c[:2] == ["docker", "run"])
+    # the reyn repo is bind-mounted read-only at /reyn
+    assert any(a.startswith("-v") or a == "-v" for a in run_call)
+    assert any(a.endswith(":/reyn:ro") for a in run_call), f"missing :ro reyn mount: {run_call}"
+
+    exec_call = next((c for c in docker.calls if c[:2] == ["docker", "exec"]), None)
+    assert exec_call is not None, "a docker exec must provision the venv"
+    body = exec_call[-1]
+    assert "python3.11 -m venv /opt/reyn-venv" in body and "reyn.pth" in body
+    # provisioning precedes the teardown
+    exec_idx = docker.calls.index(exec_call)
+    rm_idx = next(i for i, c in enumerate(docker.calls) if c[:3] == ["docker", "rm", "-f"])
+    assert exec_idx < rm_idx
+
+
+def test_container_points_harness_at_venv_python(tmp_path: Path) -> None:
+    """Tier 2: reyn is invoked with REYN_HARNESS_PYTHON = the in-container venv
+    python, so the #1356 harness routes to the 3.11 venv (the only OS-side hook)."""
+    env_out = tmp_path / "hp.txt"
+    docker = _RecordingDocker()
+    reyn_base = _patch_emitting_reyn(tmp_path, env_out)
+
+    run_reyn_in_container(
+        _INSTANCE,
+        image="img:latest",
+        repo_dir="/testbed",
+        state_dir=str(tmp_path / "state"),
+        reyn_base=reyn_base,
+        timeout=30,
+        docker_runner=docker,
+    )
+
+    assert env_out.read_text().strip() == "/opt/reyn-venv/bin/python"


### PR DESCRIPTION
**[e2e-coder]** — #183 faithful-run prep, **scripts/-only (OS-change-free)**: provision an in-container reyn venv so the #1356-routed python-step harness can run in the swebench image. lead-coder design-APPROVED (#183 issuecomment chain); PR-review by lead-coder.

## Why

`reyn run swe_bench --env-backend=docker` routes the python-step harness via `docker exec` into the swebench image (#1356). That image's testbed conda python is repo-pinned (astropy = **3.9.20**) and reyn needs `>=3.11` → the harness can't run there. Owner directive (OpenHands-style): provision a **python3.11 venv with reyn** in the container, separate from the testbed conda; point the harness at it via `REYN_HARNESS_PYTHON`. pytest (`sandboxed_exec`) stays the testbed conda.

## Scope — P7 hard constraint honored

**No OS / `src/reyn/` change in this PR.** All provisioning is in `scripts/swe_bench_runner.py`. The single OS-side hook — a 1-line general `REYN_HARNESS_PYTHON` override in `PythonRunner` (no swe_bench string) — is **owner-pending** and lands separately; until then this provisioning is inert at the harness boundary (the runner sets the env, the OS doesn't read it yet).

## What

`run_reyn_in_container`: `docker run -d -v <repo>:/reyn:ro` → `docker exec` venv provision (`python3.11 -m venv` + pip-install reyn's runtime deps from its **own pyproject** [version-pinned, no drift; dev tooling skipped] + a `.pth` to `/reyn/src` so reyn imports with no PYTHONPATH threading) → `reyn run --env-backend=docker` with `REYN_HARNESS_PYTHON=/opt/reyn-venv/bin/python` → teardown.

## Primary evidence (real `docker run`, cached astropy-13453)

- base `python3.11` in the image; container reaches PyPI (no wheelhouse); `pip install -e` on `:ro` fails → deps-pip + `.pth`.
- the **exact generated `provision_command`** builds a venv where `/opt/reyn-venv/bin/python -m reyn.kernel._python_harness` imports + executes (ran a real `parse_test_targets` → `[]`).

## Test plan

`tests/test_swe_bench_runner_venv_183.py` (Tier 1/2, no mocks — pure helpers + injected docker_runner + real reyn shim):
- [x] runtime-deps parse (pins kept / dev tools dropped); `provision_command` shape (venv + shell-quoted pip + `.pth`)
- [x] container bind-mounts reyn `:ro` + `docker exec` provisions the venv before teardown
- [x] reyn receives `REYN_HARNESS_PYTHON` = the in-container venv python
- [x] existing `test_swe_bench_runner*` (21) still pass; `ruff` + `test_tier_audit --strict` clean
- [x] full `pytest -q` from rootdir — 6929 passed (only the pre-existing env-local web_fetch fail, CI-green, untouched)

## Next (not this PR)

The 1-line `PythonRunner` `REYN_HARNESS_PYTHON` env-knob (owner OK pending) → **end-to-end re-smoke** (harness runs a text-prep step in the in-container venv under the integrated path) → 5 Class A non-confounded run. Per #183: **no run until the re-smoke passes**.

Refs #183
