### PR TITLE
feat(183): REYN_HARNESS_PYTHON — operator override for the harness interpreter

### DIFF
--- a/src/reyn/python_runner.py
+++ b/src/reyn/python_runner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -73,10 +74,22 @@ class PythonRunner:
     """
 
     def __init__(self, python_executable: str | None = None) -> None:
-        # Default to the same interpreter reyn itself is running under;
-        # this means whatever venv the user has activated for reyn is also
-        # what the user code runs against (consistent imports / 3rd-party).
-        self.python_executable = python_executable or sys.executable
+        # Which interpreter runs the harness subprocess. Resolution order:
+        #   1. the explicit ``python_executable`` argument (caller override);
+        #   2. the ``REYN_HARNESS_PYTHON`` environment variable — an operator
+        #      override for the reyn-runtime python that runs ``_python_harness``;
+        #      useful whenever the harness must run under a different interpreter
+        #      than the one reyn is launched with (e.g. a backend whose default
+        #      interpreter cannot host reyn, so a separate reyn-capable venv is
+        #      provisioned and pointed at here);
+        #   3. otherwise the same interpreter reyn itself is running under, so
+        #      whatever venv the user activated for reyn is also what user code
+        #      runs against (consistent imports / 3rd-party).
+        self.python_executable = (
+            python_executable
+            or os.environ.get("REYN_HARNESS_PYTHON")
+            or sys.executable
+        )
 
     async def run(
         self,

--- a/tests/test_python_runner_harness_python_env.py
+++ b/tests/test_python_runner_harness_python_env.py
@@ -1,0 +1,34 @@
+"""Tier 2: PythonRunner resolves the harness interpreter (REYN_HARNESS_PYTHON).
+
+The harness subprocess (`reyn.kernel._python_harness`) runs under a resolvable
+interpreter: an explicit constructor arg, else the ``REYN_HARNESS_PYTHON``
+operator override, else ``sys.executable``. The override lets the harness run
+under a reyn-capable interpreter that differs from the one reyn was launched with
+(e.g. a backend whose default python cannot host reyn).
+
+Real PythonRunner (no mocks); env controlled via monkeypatch.
+"""
+from __future__ import annotations
+
+import sys
+
+from reyn.python_runner import PythonRunner
+
+
+def test_env_var_sets_harness_python(monkeypatch) -> None:
+    """Tier 2: with REYN_HARNESS_PYTHON set and no explicit arg, the runner uses it."""
+    monkeypatch.setenv("REYN_HARNESS_PYTHON", "/opt/reyn-venv/bin/python")
+    assert PythonRunner().python_executable == "/opt/reyn-venv/bin/python"
+
+
+def test_unset_falls_back_to_sys_executable(monkeypatch) -> None:
+    """Tier 2: falsification — with REYN_HARNESS_PYTHON unset, the default is
+    unchanged (sys.executable); the override is opt-in, not a behavior shift."""
+    monkeypatch.delenv("REYN_HARNESS_PYTHON", raising=False)
+    assert PythonRunner().python_executable == sys.executable
+
+
+def test_explicit_arg_takes_precedence_over_env(monkeypatch) -> None:
+    """Tier 2: an explicit python_executable arg wins over the env override."""
+    monkeypatch.setenv("REYN_HARNESS_PYTHON", "/opt/reyn-venv/bin/python")
+    assert PythonRunner("/explicit/python").python_executable == "/explicit/python"


### PR DESCRIPTION
**[e2e-coder]** — #183 option A: the 1-line OS-side hook — `REYN_HARNESS_PYTHON` operator override for the harness interpreter. lead-coder full-review (OS change). owner-GO'd (the venv-in-container approach).

## Why

`PythonRunner` runs the `_python_harness` subprocess under `sys.executable`. When #1356 routes the harness through a backend whose default interpreter can't host reyn (the swebench image's repo conda python is < reyn's `requires-python` 3.11), the harness needs a separate reyn-capable interpreter. The companion scripts PR (#1361) provisions a python3.11 venv with reyn inside the container; this override points the harness at it.

## What (general, 1-line resolution)

`PythonRunner.__init__` resolution order:
1. explicit `python_executable` arg (caller override);
2. **`REYN_HARNESS_PYTHON` env var** (operator override) — new;
3. `sys.executable` (unchanged default).

**General — no swe_bench / backend string.** An operator override of the reyn-runtime python that runs the harness. **Opt-in**: unset → behavior identical to before (`sys.executable`), so #1356 and all existing runs are unaffected.

## Test plan

`tests/test_python_runner_harness_python_env.py` (Tier 2, real `PythonRunner`, no mocks; env via `monkeypatch`):
- [x] env set + no arg → harness python = the env value
- [x] **falsification**: env unset → `sys.executable` (default unchanged — opt-in, not a behavior shift)
- [x] explicit arg takes precedence over the env
- [x] `ruff` + `test_tier_audit --strict` clean
- [x] full `pytest -q` from rootdir — 6928 passed (only the pre-existing env-local web_fetch fail, CI-green, untouched)

## Sequence

This + the scripts PR (#1361) land together (both green). Then: **end-to-end re-smoke** (swe_bench_runner → venv → `REYN_HARNESS_PYTHON` → harness runs a real text-prep in the in-container venv, primary evidence, 1 astropy instance) → 5 Class A non-confounded run. Per #183: **no run until the re-smoke passes**.

Refs #183
