### PR TITLE
fix(183): docker exec -i for stdin-carrying container exec (harness request)

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -343,8 +343,15 @@ class DockerEnvironmentBackend:
         # ``bash -lc 'exec "$@"' reyn-exec <argv>`` passes argv as positional
         # params ($1..), NOT spliced into the script text, so there is no
         # shell-injection / quoting surface (``"$@"`` re-exec is argv-faithful).
+        # `-i` keeps stdin open through `docker exec` so a process that reads
+        # stdin (the python-step harness reads its JSON request there) receives
+        # it — without `-i`, docker exec drops the host-piped stdin and the
+        # in-container process sees EOF ("harness received empty stdin"). Mirrors
+        # the `_py` FS-helper above; only when stdin is provided (sandboxed_exec
+        # passes none → unchanged).
         exec_argv = [
-            self.docker_bin, "exec", "-w", self.repo_dir, self.container,
+            self.docker_bin, "exec", *(["-i"] if stdin is not None else []),
+            "-w", self.repo_dir, self.container,
             "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
         ]
         return await self._runner(exec_argv, stdin=stdin, timeout=policy.timeout_seconds)

--- a/tests/test_container_backend_1115_stage2.py
+++ b/tests/test_container_backend_1115_stage2.py
@@ -172,6 +172,49 @@ def test_run_is_login_shell_docker_exec_no_bridge(tmp_path: Path) -> None:
         assert bridge_token not in joined, f"bridge step {bridge_token!r} must be absent"
 
 
+def test_run_adds_i_flag_only_when_stdin_provided(tmp_path: Path) -> None:
+    """Tier 2: run() builds `docker exec -i` when stdin is provided, so the
+    in-container process receives it — the python-step harness reads its JSON
+    request on stdin, and without `-i` docker exec drops the host-piped stdin so
+    the harness sees EOF ("harness received empty stdin"; the #183 re-smoke bug).
+    Falsification pair: with no stdin (sandboxed_exec) there is no `-i` (unchanged).
+
+    The fake-backend unit (test_python_step_os_sandbox_1352b) recorded a backend
+    that never docker-execs, so it could not catch this argv-construction gap —
+    the real e2e re-smoke did; this pins it.
+    """
+    calls: list[list[str]] = []
+
+    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+        calls.append(argv)
+        return SandboxResult(returncode=0, stdout=b"ok", stderr=b"")
+
+    import asyncio
+
+    be = DockerEnvironmentBackend(
+        container="testc", repo_dir="/testbed", runner=_record_runner,
+    )
+
+    # with stdin → `-i` immediately after "exec" (so docker forwards stdin)
+    asyncio.run(
+        be.run(
+            ["python", "-m", "reyn.kernel._python_harness"],
+            SandboxPolicy(timeout_seconds=30),
+            stdin=b'{"req": 1}',
+        )
+    )
+    [with_stdin] = calls
+    assert with_stdin[:3] == ["docker", "exec", "-i"], (
+        f"a stdin-carrying exec must use `docker exec -i`: {with_stdin}"
+    )
+
+    # falsification: no stdin → no `-i` (sandboxed_exec path unchanged)
+    calls.clear()
+    asyncio.run(be.run(["pytest", "-x"], SandboxPolicy(timeout_seconds=30)))
+    [no_stdin] = calls
+    assert "-i" not in no_stdin, f"a stdin-less exec must NOT use `-i`: {no_stdin}"
+
+
 def test_run_argv_passed_as_positional_params_not_interpolated(tmp_path: Path) -> None:
     """Tier 2: (b/argv-safe) shell-special chars in argv survive verbatim — the
     login-shell wrapper forwards them as positional params, never interpolated.


### PR DESCRIPTION
**[e2e-coder]** — #183: `docker exec -i` for stdin-carrying container exec, so the #1356-routed python-step harness receives its request. lead-coder GO'd (general bug fix, mirrors `_py`); full + Tier review.

## The bug (caught by the e2e re-smoke)

`DockerEnvironmentBackend.run()` built its `docker exec` argv **without `-i`**. The host async runner pipes stdin to the `docker exec` process (`proc.communicate(input=stdin)`), but **without `-i`, docker exec does not forward stdin to the in-container process** → a process reading stdin sees EOF. The python-step harness (#1356-routed into the container) reads its JSON request on stdin → it failed with `ValueError: harness received empty stdin`.

The sibling FS-helper `_py` (same file) **already** does `*(["-i"] if stdin is not None else [])`; `run()` just missed it.

## Why the existing unit didn't catch it

`tests/test_python_step_os_sandbox_1352b.py` records a **fake backend that never docker-execs**, so the argv-construction gap was invisible. The **#183 end-to-end re-smoke** caught it (real `docker run` on cached astropy-13453): the harness ran reyn under the in-container 3.11 venv (**0 ModuleNotFound** — the venv/`REYN_HARNESS_PYTHON` mechanism works) but got empty stdin.

## Fix

Add `*(["-i"] if stdin is not None else [])` to `run()`'s exec_argv (mirrors `_py`). General correctness — no skill coupling; the no-stdin path (sandboxed_exec) is byte-unchanged.

## Test plan

- [x] `test_run_adds_i_flag_only_when_stdin_provided` (Tier 2, real `DockerEnvironmentBackend` + injected recording runner): asserts `docker exec -i` with stdin; **falsification pair** — no stdin → no `-i`
- [x] existing `test_run_is_login_shell_docker_exec_no_bridge` still pins the no-stdin argv (unchanged)
- [x] `ruff` + `test_tier_audit --strict` clean; container_backend tests (7) pass
- [x] full `pytest -q` from rootdir — 6933 passed (only the pre-existing env-local web_fetch fail, CI-green, untouched)

## Next (per #183 no-confounded-number)

After merge → **re-run the e2e re-smoke** (the harness now receives its request → runs the swe_bench text-prep in the in-container venv, primary evidence) → re-smoke PASS → 5 Class A non-confounded run.

Refs #183 #1352
