### PR TITLE
docs(testing): clarify Tier 2c — only LLM may be faked in integration tests

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -56,7 +56,12 @@ Two sub-categories:
 - **Tier 2c — Multi-component integration (e2e)**: a single test exercises
   several modules to verify end-to-end behavior of an invariant. Uses
   real instances throughout; LLM is faked via a stub real callable
-  (NOT via `LLMReplay` — that path is Tier 3). Examples:
+  (NOT via `LLMReplay` — that path is Tier 3). **The LLM is the only
+  collaborator that may be faked.** Replacing a non-LLM collaborator
+  (e.g. a backend, a launcher, an external service) with a fake
+  exercises only the caller's logic — the collaborator's own construction
+  and behavior remain unverified. Integration of such collaborators is
+  proven only by tests that run the real thing. Examples:
   - "Crash mid-skill → restart → resume → completes" (`test_resume_e2e.py`)
   - "Schema mismatch → CLI exits cleanly with `--reset` hint"
   - "BudgetTracker cap enforced across crash + restart"


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder GO、e2e-coder pin `feedback_fake_backend_unit_misses_real_integration` からの docs drift 修正。

## Summary

`testing.md` Tier 2c に sub-note を追加。現行の「real instances throughout; LLM is faked」は「LLM 以外も fake で OK」と誤読され得るため明示。

- LLM のみ fake 可能
- 非 LLM collaborator（backend/launcher 等）を fake すると caller logic のみ検証、collaborator 自身の construction は不可視
- そのような collaborator の integration は real backend test でのみ証明

**`[[feedback_no_history_refs_in_user_docs]]` 遵守** — #/PR/FP inline なし ✅

**変更ページ:** removed 0 / added 0（deep-dives/contributing/ への追記のみ）

## Test plan

- [ ] Tier 2c のサブノートが 3 文で表示されること
- [ ] 既存の Tier 1/2a/2b/3 記述が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)