### PR TITLE
fix(183): bind-mount the reyn repo at its host path so in-container module paths resolve

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -65,7 +65,13 @@ _REQUIRED_FIELDS = ("instance_id", "repo", "base_commit", "problem_statement")
 #     the path via a `.pth` to the bind-mounted source (no PYTHONPATH threading,
 #     so container_backend.run is untouched). Deps are version-pinned by
 #     reyn's own pyproject (read at runtime — no hardcoded drift).
-_CONTAINER_REYN_MOUNT = "/reyn"            # host reyn repo, bind-mounted :ro
+# The reyn repo is bind-mounted at its OWN host path inside the container
+# (`-v <repo>:<repo>:ro`) so host-absolute paths are valid in the container: the
+# python step module path the OS hands the harness is the host skill_dir path
+# (e.g. <repo>/src/reyn/stdlib/skills/swe_bench/escape_anchors.py), and the venv
+# `.pth` points at <repo>/src — both resolve in-container only at the same path.
+# (Mounting at a fixed /reyn would translate paths and break the host-absolute
+# module path the harness loads.)
 _CONTAINER_VENV = "/opt/reyn-venv"
 _CONTAINER_PY311 = "/opt/miniconda3/bin/python3.11"
 _CONTAINER_HARNESS_PYTHON = f"{_CONTAINER_VENV}/bin/python"
@@ -99,11 +105,12 @@ def reyn_runtime_deps(pyproject_text: str) -> list[str]:
     return out
 
 
-def provision_command(deps: list[str]) -> str:
+def provision_command(deps: list[str], reyn_src: str) -> str:
     """The `bash -lc` body that builds the in-container reyn venv (pure → str).
 
     Builds a python3.11 venv, installs reyn's runtime deps (version-pinned), and
-    puts reyn itself on sys.path via a `.pth` to the bind-mounted source — so
+    puts reyn itself on sys.path via a `.pth` to ``reyn_src`` (the bind-mounted
+    source, at its host-absolute path inside the container) — so
     `<venv>/bin/python -m reyn.kernel._python_harness` imports reyn with no
     PYTHONPATH threading. Each dep is shell-quoted (version specs contain `>`)."""
     deps_arg = " ".join(shlex.quote(d) for d in deps)
@@ -111,7 +118,7 @@ def provision_command(deps: list[str]) -> str:
         "set -e; "
         f"{_CONTAINER_PY311} -m venv {_CONTAINER_VENV}; "
         f"{_CONTAINER_VENV}/bin/pip install --quiet {deps_arg}; "
-        f"echo {_CONTAINER_REYN_MOUNT}/src "
+        f"echo {shlex.quote(reyn_src)} "
         f"> \"$({_CONTAINER_VENV}/bin/python -c 'import site; print(site.getsitepackages()[0])')/reyn.pth\""
     )
 
@@ -370,12 +377,13 @@ def run_reyn_in_container(
     reyn_root = str(_reyn_repo_root())
     try:
         start = runner(
-            # #183: bind-mount the host reyn repo :ro so the in-container venv can
-            # put reyn on its path (.pth → /reyn/src); the harness imports reyn
-            # there. The repo's own files stay at repo_dir (/testbed), untouched.
+            # #183: bind-mount the host reyn repo :ro at its OWN host path so the
+            # in-container venv can put reyn on its path (.pth → <repo>/src) AND
+            # the harness can load the python step module by the host-absolute path
+            # the OS hands it. The repo's own files stay at repo_dir (/testbed).
             [
                 docker_bin, "run", "-d", "--name", name,
-                "-v", f"{reyn_root}:{_CONTAINER_REYN_MOUNT}:ro",
+                "-v", f"{reyn_root}:{reyn_root}:ro",
                 image, "sleep", "infinity",
             ],
             timeout=300,
@@ -395,7 +403,7 @@ def run_reyn_in_container(
         deps = reyn_runtime_deps((_reyn_repo_root() / "pyproject.toml").read_text())
         print(f"[swe_bench_runner] provisioning reyn venv in {name} ({len(deps)} deps)", file=sys.stderr)
         prov = runner(
-            [docker_bin, "exec", name, "bash", "-lc", provision_command(deps)],
+            [docker_bin, "exec", name, "bash", "-lc", provision_command(deps, f"{reyn_root}/src")],
             timeout=600,
         )
         if getattr(prov, "returncode", 1) != 0:

--- a/tests/test_swe_bench_runner_venv_183.py
+++ b/tests/test_swe_bench_runner_venv_183.py
@@ -63,12 +63,13 @@ def test_provision_command_builds_venv_pip_and_pth() -> None:
     """Tier 1: the provision body creates a 3.11 venv, pip-installs the deps
     (each shell-quoted — version specs contain `>`), and puts reyn on the path via
     a .pth to the bind-mounted source (no PYTHONPATH threading)."""
-    cmd = provision_command(["litellm>=1.0", "pydantic>=2.0"])
+    cmd = provision_command(["litellm>=1.0", "pydantic>=2.0"], "/host/repo/src")
     assert "python3.11 -m venv /opt/reyn-venv" in cmd
     assert "/opt/reyn-venv/bin/pip install" in cmd
     # version specs are shell-quoted so bash does not treat `>` as a redirect
     assert "'litellm>=1.0'" in cmd and "'pydantic>=2.0'" in cmd
-    assert "reyn.pth" in cmd and "/reyn/src" in cmd
+    # the .pth points at the reyn source at its host-absolute path (same-path mount)
+    assert "reyn.pth" in cmd and "/host/repo/src" in cmd
 
 
 # ── Tier 2: container integration (injected docker_runner + reyn shim) ────────
@@ -115,9 +116,12 @@ def test_container_mounts_reyn_and_provisions_venv(tmp_path: Path) -> None:
     )
 
     run_call = next(c for c in docker.calls if c[:2] == ["docker", "run"])
-    # the reyn repo is bind-mounted read-only at /reyn
-    assert any(a.startswith("-v") or a == "-v" for a in run_call)
-    assert any(a.endswith(":/reyn:ro") for a in run_call), f"missing :ro reyn mount: {run_call}"
+    # the reyn repo is bind-mounted read-only at its OWN host path (same-path
+    # mount) so host-absolute paths (module + .pth) resolve inside the container
+    mount = run_call[run_call.index("-v") + 1]
+    src, dst, mode = mount.rsplit(":", 2)
+    assert src == dst, f"reyn must be same-path mounted (host==container): {mount}"
+    assert mode == "ro", f"reyn mount must be read-only: {mount}"
 
     exec_call = next((c for c in docker.calls if c[:2] == ["docker", "exec"]), None)
     assert exec_call is not None, "a docker exec must provision the venv"


### PR DESCRIPTION
**[e2e-coder]** — #183 follow-up (scripts-only): same-path mount so the in-container harness can load the python-step module. lead-coder GO'd; light review (scripts-only, no OS change).

## The bug (caught by the e2e re-smoke, post `-i` fix)

With `-i` (#1363) the harness received its request (empty-stdin = 0, ModuleNotFound = 0 → the venv works), but `escape_anchors` then failed: `FileNotFoundError: <repo>/src/reyn/stdlib/skills/swe_bench/escape_anchors.py`. The OS hands the harness a **host-absolute** module path (skill_dir-resolved); the harness runs **in the container**, where that host path didn't exist — the repo was mounted at a fixed `/reyn`.

## Fix (scripts-only)

Bind-mount the reyn repo at its **own host path** (`-v <repo>:<repo>:ro`) — the standard SWE-agent/OpenHands same-path container mount — so host-absolute paths (the module + the venv `.pth`, now `<repo>/src`) resolve in the container.

## Proactive scan (same bug class — primary evidence)

Per lead-coder's request, scanned for other "host-absolute path invalid in container" assumptions:
- the swe_bench text-prep steps are all **pure-compute** (no `reyn.safe`/FS) → the forwarded `file_read/write_paths` are unused → `module_path` was the only host-path that bit them;
- `sandboxed_exec` runs under the container's `-w /testbed` (host cwd ignored);
- the harness output returns via **stdout** (not a path).
→ no other same-class assumption remains for the swe_bench path.

## Test plan

- [x] `provision_command(deps, reyn_src)` — `.pth` points at the host-absolute src; container test asserts a **same-path** read-only mount (host == container)
- [x] 4 venv tests pass; `ruff` + `test_tier_audit --strict` clean
- [x] **e2e re-smoke re-run (primary evidence)**: the harness loads the module + runs the text-prep to completion in the in-container venv (validated before this PR)
- [x] full `pytest -q` from rootdir — 6933 passed (only the pre-existing env-local web_fetch fail, CI-green, untouched)

## Next

re-smoke PASS → 5 Class A non-confounded run (pre-staged). Per #183: no run until the re-smoke fully passes.

Refs #183
