### PR TITLE
feat(tui): content-type-aware tool-result viewers in events preview (#1154 Phase 1)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/chat/tui/widgets/right_panel/__init__.py
@@ -1184,6 +1184,20 @@ class RightPanel(Widget):
         idx = max(0, min(len(self._events_visible) - 1, self._events_cursor))
         ev = self._events_visible[idx]
         title = f"event #{idx} · {ev.get('type', '?')}"
+        # #1154 Phase 1: content-type-aware viewer for tool-result events.
+        # When a tool_returned / tool_executed result carries a recognized
+        # content-type (markdown / CSV), render it via the dedicated viewer;
+        # otherwise fall back to the generic YAML preview (degrade, never
+        # hide content).
+        if ev.get("type") in ("tool_returned", "tool_executed"):
+            from .tool_result_viewers import render_tool_result
+            # Event emit kwargs are nested under ``data`` (events.py
+            # ``Event(type=, data=)``), so the op result dict lives at
+            # ``data["result"]`` — not the event's top level.
+            viewed = render_tool_result((ev.get("data") or {}).get("result"))
+            if viewed is not None:
+                pane.show_text(title, viewed)
+                return
         pane.show_text(title, self._render_as_yaml(ev))
 
     def _memory_move(self, delta: int) -> None:

--- a/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
@@ -1,0 +1,107 @@
+"""Content-type-aware viewers for tool results (#1154 Phase 1).
+
+A small registry mapping a tool result's content-type / MIME to a Rich
+renderable. The Right Panel events-tab preview (``_show_event_in_preview``)
+consults this to render ``tool_returned`` / ``tool_executed`` results richer
+than the generic YAML fallback — the first slice of the Jupyter-style
+content-type → viewer vision in #1154.
+
+Design (lead-ratified #1154 Phase 1):
+  - keyed by ``content_type`` / ``mimeType`` (the fields file/web/mcp op
+    results already carry); no shape-sniff yet.
+  - Phase 1 viewers: markdown (rendered) + CSV/table. Unknown types →
+    ``render_tool_result`` returns ``None`` so the caller falls back to the
+    existing YAML preview (degrade, never hide content).
+  - Phase 3 (deferred): LLM-generated viewer templates for novel types.
+
+This module is intentionally pure (dict in → Rich renderable | None) so it
+is testable in isolation without the Textual app.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import RenderableType
+from rich.markdown import Markdown as RichMarkdown
+from rich.table import Table
+
+# Cap rows rendered in a preview table — a 10k-row CSV result must not blow
+# up the preview pane. Past the cap the table shows a "… N more rows" footer.
+_MAX_TABLE_ROWS = 50
+
+
+def _content_type_of(result: dict) -> str:
+    """Best-effort lowercase content-type / MIME string from a result dict.
+
+    Checks the explicit fields op results carry (``content_type`` on
+    file/web, ``mimeType`` on mcp/media blocks). Returns ``""`` when no
+    type is discoverable — the caller then falls back to YAML.
+    """
+    for key in ("content_type", "mimeType", "mime_type", "media_type"):
+        v = result.get(key)
+        if isinstance(v, str) and v:
+            return v.lower()
+    blocks = result.get("media_blocks")
+    if isinstance(blocks, list) and blocks and isinstance(blocks[0], dict):
+        m = blocks[0].get("mimeType") or blocks[0].get("mime_type")
+        if isinstance(m, str) and m:
+            return m.lower()
+    return ""
+
+
+def _result_text(result: dict) -> str:
+    """Best-effort textual payload from a result dict (content/text/body)."""
+    for key in ("content", "text", "body"):
+        v = result.get(key)
+        if isinstance(v, str) and v:
+            return v
+    return ""
+
+
+def _viewer_markdown(result: dict) -> RenderableType | None:
+    text = _result_text(result)
+    if not text:
+        return None
+    return RichMarkdown(text)
+
+
+def _viewer_csv(result: dict) -> RenderableType | None:
+    text = _result_text(result)
+    if not text:
+        return None
+    rows = [ln.split(",") for ln in text.splitlines() if ln.strip()]
+    if not rows:
+        return None
+    header = [c.strip() for c in rows[0]]
+    if not header:
+        return None
+    table = Table(show_header=True, header_style="bold", expand=False)
+    for col in header:
+        table.add_column(col)
+    body = rows[1:]
+    for r in body[:_MAX_TABLE_ROWS]:
+        cells = [c.strip() for c in r][: len(header)]
+        cells += [""] * (len(header) - len(cells))  # pad ragged rows
+        table.add_row(*cells)
+    if len(body) > _MAX_TABLE_ROWS:
+        table.caption = f"… {len(body) - _MAX_TABLE_ROWS} more rows"
+    return table
+
+
+def render_tool_result(result: Any) -> RenderableType | None:
+    """Pick a content-type viewer for ``result`` (or ``None`` for fallback).
+
+    ``None`` when ``result`` is not a dict, carries no recognizable
+    content-type, or the matched viewer has nothing to render — the caller
+    falls back to the generic YAML preview.
+    """
+    if not isinstance(result, dict):
+        return None
+    ct = _content_type_of(result)
+    if not ct:
+        return None
+    if "markdown" in ct or ct.endswith("/md"):
+        return _viewer_markdown(result)
+    if "csv" in ct or "tab-separated" in ct:
+        return _viewer_csv(result)
+    return None

--- a/tests/cli/test_tool_result_viewers_1154.py
+++ b/tests/cli/test_tool_result_viewers_1154.py
@@ -1,0 +1,179 @@
+"""Tier 2: content-type → viewer registry for tool results (#1154 Phase 1).
+
+``render_tool_result(result)`` maps a tool result dict's content-type /
+MIME to a Rich renderable (markdown / CSV-table in Phase 1), or returns
+``None`` so the Right Panel events-tab preview falls back to its generic
+YAML rendering. These pin the dispatch + the fallback contract via the
+pure module's public return value (no Textual app needed).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from rich.markdown import Markdown as RichMarkdown
+from rich.table import Table
+
+from reyn.chat.tui.widgets.right_panel.tool_result_viewers import render_tool_result
+
+# ── dispatch: recognized content-types route to a viewer ─────────────────────
+
+
+def test_markdown_content_type_returns_markdown_renderable() -> None:
+    """Tier 2: a text/markdown result renders via the markdown viewer."""
+    out = render_tool_result({"content_type": "text/markdown", "content": "# Title\n\nbody"})
+    assert isinstance(out, RichMarkdown), f"expected RichMarkdown; got {type(out)!r}"
+
+
+def test_csv_content_type_returns_table() -> None:
+    """Tier 2: a text/csv result renders via the table viewer with columns."""
+    out = render_tool_result({"content_type": "text/csv", "content": "name,age\nalice,30\nbob,25"})
+    assert isinstance(out, Table), f"expected Table; got {type(out)!r}"
+    headers = [str(c.header) for c in out.columns]
+    assert headers == ["name", "age"], f"expected CSV header → table columns; got {headers}"
+
+
+def test_mimetype_key_also_detected() -> None:
+    """Tier 2: the ``mimeType`` field (mcp/media) is detected like content_type."""
+    out = render_tool_result({"mimeType": "text/markdown", "content": "**bold**"})
+    assert isinstance(out, RichMarkdown)
+
+
+def test_media_blocks_mimetype_detected() -> None:
+    """Tier 2: a media_blocks[0].mimeType surfaces the content-type."""
+    out = render_tool_result({
+        "media_blocks": [{"type": "text", "mimeType": "text/markdown"}],
+        "content": "# md",
+    })
+    assert isinstance(out, RichMarkdown)
+
+
+# ── fallback: anything unrecognized → None (caller renders YAML) ─────────────
+
+
+def test_unknown_content_type_returns_none() -> None:
+    """Tier 2: an unregistered content-type returns None → YAML fallback."""
+    assert render_tool_result({"content_type": "application/json", "content": "{}"}) is None
+
+
+def test_no_content_type_returns_none() -> None:
+    """Tier 2: a result with no content-type field returns None → fallback."""
+    assert render_tool_result({"status": "ok", "path": "/tmp/x"}) is None
+
+
+def test_non_dict_returns_none() -> None:
+    """Tier 2: a non-dict result (str / None) returns None → fallback."""
+    assert render_tool_result("plain string") is None
+    assert render_tool_result(None) is None
+
+
+def test_markdown_empty_content_returns_none() -> None:
+    """Tier 2: recognized type but empty payload → None (nothing to render)."""
+    assert render_tool_result({"content_type": "text/markdown", "content": ""}) is None
+
+
+# ── table viewer details ─────────────────────────────────────────────────────
+
+
+def test_csv_ragged_rows_padded_not_crashing() -> None:
+    """Tier 2: a CSV row shorter than the header is padded, not a crash."""
+    out = render_tool_result({"content_type": "text/csv", "content": "a,b,c\n1,2\n3,4,5"})
+    assert isinstance(out, Table)
+    headers = [str(c.header) for c in out.columns]
+    assert headers == ["a", "b", "c"], f"ragged CSV should keep header columns; got {headers}"
+
+
+def test_csv_caps_rows_with_overflow_caption() -> None:
+    """Tier 2: a CSV past the row cap renders a bounded table + overflow caption."""
+    lines = ["h"] + [str(i) for i in range(200)]
+    out = render_tool_result({"content_type": "text/csv", "content": "\n".join(lines)})
+    assert isinstance(out, Table)
+    assert out.caption and "more rows" in str(out.caption)
+
+
+# ── wire: _show_event_in_preview routes tool events through the viewer ───────
+# These exercise the integration seam the pure tests above cannot: an event's
+# emit kwargs are nested under ``data`` (events.py ``Event(type=, data=)``),
+# so the result dict lives at ``ev["data"]["result"]``. A wire reading the
+# wrong key silently never fires the viewer (always YAML) — these guard that.
+
+
+def _capture_preview_renderable(pane: object) -> list:
+    """Wrap a real preview pane's show_text to record the renderable it gets."""
+    captured: list = []
+    original = pane.show_text  # type: ignore[attr-defined]
+
+    def _spy(title: str, renderable: object) -> None:
+        captured.append(renderable)
+        original(title, renderable)
+
+    pane.show_text = _spy  # type: ignore[attr-defined]
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_wire_tool_returned_md_event_renders_via_viewer() -> None:
+    """Tier 2: a tool_returned event with a markdown result → viewer fires.
+
+    Guards the data-nesting seam: the result dict is at ev["data"]["result"],
+    so a wire reading ev["result"] would fall back to YAML (regression).
+    """
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+    from reyn.chat.tui.widgets.right_panel.shells import _PreviewPane
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        pane = panel.query_one("#preview-pane", _PreviewPane)
+        captured = _capture_preview_renderable(pane)
+
+        panel._events_visible = [
+            {"type": "tool_returned",
+             "data": {"result": {"content_type": "text/markdown", "content": "# Hi"}}},
+        ]
+        panel._events_cursor = 0
+        panel._show_event_in_preview(pane)
+        await pilot.pause()
+
+        assert captured, "preview pane received no renderable"
+        assert isinstance(captured[-1], RichMarkdown), (
+            f"markdown tool result should render via the viewer; "
+            f"got {type(captured[-1])!r} (wire likely read the wrong result key)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wire_unknown_type_event_falls_back_to_yaml() -> None:
+    """Tier 2: a tool_returned event with no recognized type → YAML fallback."""
+    from reyn.chat.tui.app import ReynTUIApp
+    from reyn.chat.tui.widgets import RightPanel
+    from reyn.chat.tui.widgets.right_panel.shells import _PreviewPane
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one(RightPanel)
+        pane = panel.query_one("#preview-pane", _PreviewPane)
+        captured = _capture_preview_renderable(pane)
+
+        panel._events_visible = [
+            {"type": "tool_returned",
+             "data": {"result": {"content_type": "application/json", "content": "{}"}}},
+        ]
+        panel._events_cursor = 0
+        panel._show_event_in_preview(pane)
+        await pilot.pause()
+
+        assert captured, "preview pane received no renderable"
+        assert not isinstance(captured[-1], RichMarkdown), (
+            "unrecognized content-type should fall back to the YAML preview, "
+            "not the markdown viewer"
+        )


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 1（foundation）: content-type → viewer registry + 既存 preview-pane への plug。lead-ratify 済 scope（Q1 preview-pane 流用 / Q2 content_type・mimeType keying / Q3 LLM-template phase3 defer / Q4 phase1 = table+md+YAML fallback）。

## Why（#1154 Phase 1、flow-trace → lead ratify）
tool result の richer 表示の foundation。Right Panel events-tab の preview は従来 result を**一律 YAML** で描画 → 構造を持つ result（markdown / CSV）も生 YAML。content-type を持つ result（file/web の `content_type`、mcp/media の `mimeType`）を dedicated viewer で描画し、未登録 type は YAML fallback（degrade、壊さない）。Jupyter-style content-type→viewer vision（#1154）の最初の slice。

## What changed（300 行、3 file）
- **新 pure module `tool_result_viewers.py`**: `render_tool_result(result) -> RenderableType | None`。content-type 検出（`content_type`/`mimeType`/`mime_type`/`media_type` + `media_blocks[0].mimeType`、lowercase）→ registry dispatch。Phase1 viewer = markdown（`RichMarkdown`）+ CSV（`Rich Table`、`_MAX_TABLE_ROWS=50` cap + "… N more rows" caption、ragged row pad）。**非 dict / content-type 無し / 未登録 type / 空 payload → `None`**（caller が YAML fallback）。app 不要の pure 関数（dict in → renderable | None）。
- **wire `_show_event_in_preview`**（right_panel/`__init__.py`）: `tool_returned`/`tool_executed` event を registry 経由で描画、`None` なら従来 `_render_as_yaml(ev)` に fallback。

## flow-trace で catch した load-bearing seam（commit 前 verify）
emit kwargs は **`data` nested**（`events.py` `Event(type=, data=)` + `events_tab._event_hint` の `d = ev.get("data")`）→ result dict は `ev["data"]["result"]`、event top-level ではない。当初 wire が `ev.get("result")` だと viewer **永遠に非発火 silent-dead**（YAML 常勝）になる gap を commit 前 grep verify で発見・修正。pure-module test では原理的に catch 不能ゆえ harness wire test を追加（下記 falsification 参照）。

## Tests（12、Tier 2、public surface + falsification）
`tests/cli/test_tool_result_viewers_1154.py`:
- **pure module 10**: md content_type→`RichMarkdown` / csv→`Table`（header columns で assert、`len()` format-pin 不使用）/ `mimeType`・`media_blocks` 検出 / 未登録 type・content-type 無し・非 dict・空 payload → `None` / ragged row pad / row cap + overflow caption。
- **harness wire 2**（Textual `run_test`、real `_PreviewPane.show_text` を method-reassign で renderable capture = mock-lib 不使用）: `tool_returned` md event → viewer 発火（`RichMarkdown`）/ 未登録 type → YAML fallback（非 `RichMarkdown`）。

## Verification（Opus 自前 impl + 独立 falsification）
- ruff clean / tier-audit **12/12 ✓ exit 0**（`len()` 違反 2 件は header-content assert に置換して解消）
- **falsification 2 seam**:
  - dispatch: `render_tool_result` を return None 化 → md/csv 系 6 test FAIL、復元 → 12 pass
  - **wire data-nesting**: `ev["data"]["result"]` を `ev.get("result")` に戻す → md wire test FAIL、復元 → pass = silent-dead gap の真の regression guard
- regression smoke: `test_tui_smoke` + `test_events_tab_chain_isolate` = **48 passed**（preview/events 既存挙動不変）

## Scope / 後続（lead-ratify 通り）
- **Phase 2**（別 PR）: image / email-card / JSON-tree viewer 追加。
- **Phase 3**（defer）: LLM-generated viewer template。registry foundation の効果測定後 + #393（reply-embedded `{{toolref}}`、別 mechanism）と調整して重複回避。
- P7 非該当: registry は TUI-internal、OS code に skill-specific string を持ち込まない。

## Tier self-check
Tier 2（pure-fn の戻り値 + harness は `show_text` renderable の public capture で assert、private-state 不参照、format-pin なし、docstring 各行 `Tier 2:` 宣言）。両 load-bearing seam（dispatch + wire data-nesting）を falsification で実証。

## Test plan
- [x] ruff / tier-audit 12/12 exit 0 / 12 test pass
- [x] falsification 2 seam（dispatch return-None + wire data-nesting revert→fail→復元）
- [x] regression smoke 48 passed（preview/events 不変）
- [ ] (skipped — harness wire test が tool_returned→viewer 発火 / 未登録→YAML fallback を behavior-level に pin + falsification 済、reviewer 環境の目視は substantive にカバー) 実機で events tab → markdown/CSV result を持つ tool 実行 → preview で rich 描画、未登録 type で YAML fallback を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
