### PR TITLE
fix(183/#1367): lazy package __init__ — harness cold-import 533ms→22ms

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -1,5 +1,46 @@
-from reyn.agent import Agent
-from reyn.kernel.runtime import RunResult
-from reyn.schemas.models import Phase, Skill, SkillGraph
+"""reyn — Agent OS public API (lazy-loaded top-level names).
+
+The package's public names are resolved lazily via PEP 562 ``__getattr__`` so
+that importing a *submodule* — notably ``reyn.kernel._python_harness``, the
+python preprocessor-step child entry point — does NOT eagerly pull the
+agent / llm / httpx chain in through this ``__init__``.
+
+This extends the FP-0008 C4 lazy-litellm fix (which made ``import litellm``
+lazy) one layer down: the harness path now imports only what it needs
+(allowlist + stdlib), so its cold import stays well under the python-step
+timeout. The eager chain (``Agent`` -> ``llm`` -> ``httpx``) cost ~0.5s, which
+under the in-container venv path on an emulated host inflated past the ~5s
+step timeout and aborted steps. ``from reyn import Agent`` / ``reyn.Agent``
+still work — they trigger the lazy load on first access.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # import-cost-free hints for type checkers / IDEs
+    from reyn.agent import Agent
+    from reyn.kernel.runtime import RunResult
+    from reyn.schemas.models import Phase, Skill, SkillGraph
 
 __all__ = ["Skill", "Phase", "SkillGraph", "Agent", "RunResult"]
+
+_LAZY_ATTRS = {
+    "Agent": "reyn.agent",
+    "RunResult": "reyn.kernel.runtime",
+    "Phase": "reyn.schemas.models",
+    "Skill": "reyn.schemas.models",
+    "SkillGraph": "reyn.schemas.models",
+}
+
+
+def __getattr__(name: str):
+    import importlib
+
+    module_path = _LAZY_ATTRS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_path), name)
+
+
+def __dir__():
+    return sorted(__all__)

--- a/src/reyn/kernel/__init__.py
+++ b/src/reyn/kernel/__init__.py
@@ -1,14 +1,29 @@
-"""kernel — OS runtime engine (P3: context build, LLM call, validation, transitions)."""
-from .control_ir_executor import ControlIRExecutor
-from .normalizer import (
-    ControlIRValidationError,
-    NormalizationError,
-    NormalizationResult,
-    normalize,
-)
-from .preprocessor_executor import PreprocessorExecutor
-from .runtime import LoopLimitExceededError, OSRuntime, RunResult
-from .validation import ValidationError, validate_output
+"""kernel — OS runtime engine (P3: context build, LLM call, validation, transitions).
+
+Public names are resolved lazily (PEP 562 ``__getattr__``) so that importing a
+kernel *submodule* — notably ``reyn.kernel._python_harness``, the python
+preprocessor-step child entry point — does not eagerly pull the runtime / llm
+chain in through this ``__init__``. See ``reyn/__init__.py`` for the rationale
+(FP-0008 C4 lazy-import line extended to the package surface). ``from
+reyn.kernel import OSRuntime`` / ``reyn.kernel.OSRuntime`` still work via the
+lazy load on first access; submodule imports (``from reyn.kernel.normalizer
+import ...``) are unaffected.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # import-cost-free hints for type checkers / IDEs
+    from .control_ir_executor import ControlIRExecutor
+    from .normalizer import (
+        ControlIRValidationError,
+        NormalizationError,
+        NormalizationResult,
+        normalize,
+    )
+    from .preprocessor_executor import PreprocessorExecutor
+    from .runtime import LoopLimitExceededError, OSRuntime, RunResult
+    from .validation import ValidationError, validate_output
 
 __all__ = [
     "OSRuntime", "RunResult", "LoopLimitExceededError",
@@ -17,3 +32,30 @@ __all__ = [
     "ControlIRExecutor",
     "PreprocessorExecutor",
 ]
+
+_LAZY_ATTRS = {
+    "ControlIRExecutor": ".control_ir_executor",
+    "ControlIRValidationError": ".normalizer",
+    "NormalizationError": ".normalizer",
+    "NormalizationResult": ".normalizer",
+    "normalize": ".normalizer",
+    "PreprocessorExecutor": ".preprocessor_executor",
+    "LoopLimitExceededError": ".runtime",
+    "OSRuntime": ".runtime",
+    "RunResult": ".runtime",
+    "ValidationError": ".validation",
+    "validate_output": ".validation",
+}
+
+
+def __getattr__(name: str):
+    import importlib
+
+    submodule = _LAZY_ATTRS.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(submodule, __name__), name)
+
+
+def __dir__():
+    return sorted(__all__)

--- a/tests/test_python_harness_no_litellm_import.py
+++ b/tests/test_python_harness_no_litellm_import.py
@@ -38,6 +38,73 @@ def test_harness_import_does_not_load_litellm():
     )
 
 
+def test_harness_import_does_not_load_agent_llm_chain():
+    """Tier 2: fresh subprocess import of harness leaves the agent/llm/httpx chain out.
+
+    #1367 — the C4 lazy-litellm fix removed litellm from the harness path, but
+    ``reyn/__init__`` and ``reyn/kernel/__init__`` still eager-imported
+    ``Agent -> llm -> httpx`` (~0.5s), which under the in-container venv path on
+    an emulated host inflated past the ~5s step timeout. The package __init__s
+    are now PEP 562-lazy, so importing the harness must NOT transitively load
+    ``reyn.agent`` / ``reyn.llm`` / ``httpx``. This is the structural invariant
+    (robust to host speed); the timing guard below is a coarse backstop.
+    """
+    code = (
+        "import reyn.kernel._python_harness; import sys; "
+        "leaked = [m for m in ('reyn.agent', 'reyn.llm', 'reyn.llm.llm', 'httpx') "
+        "          if m in sys.modules]; "
+        "assert not leaked, 'harness import eagerly loaded heavy chain: ' + str(leaked)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"harness import loaded the agent/llm/httpx chain (or failed).\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
+def test_lazy_public_api_still_resolves():
+    """Tier 2: PEP 562-lazy __init__ still exposes the public names on access.
+
+    Falsification guard for the lazy refactor: ``from reyn import Agent`` and
+    ``from reyn.kernel import OSRuntime`` must still resolve (now triggering the
+    lazy load), and an unknown attribute must raise AttributeError — proving the
+    laziness did not silently drop the public surface.
+    """
+    code = "\n".join(
+        [
+            "import reyn",
+            "from reyn import Agent, RunResult, Phase, Skill, SkillGraph",
+            "from reyn.kernel import OSRuntime, validate_output, normalize",
+            "names = (Agent, RunResult, Phase, Skill, SkillGraph,",
+            "         OSRuntime, validate_output, normalize)",
+            "assert all(x is not None for x in names), 'a public name resolved to None'",
+            "raised = False",
+            "try:",
+            "    reyn.DoesNotExist",
+            "except AttributeError:",
+            "    raised = True",
+            "assert raised, 'unknown attr did not raise AttributeError'",
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"lazy public API did not resolve correctly.\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+
+
 def test_harness_import_time_is_below_ceiling():
     """Tier 2: harness import completes well under the preprocessor timeout ceiling.
 


### PR DESCRIPTION
**[e2e-coder]** — closes #1367 (structural fix for the #183 in-container venv harness timeout).

## Problem
The C4 fix (#1083) made `import litellm` lazy (harness cold-import 10.6s→0.44s). But `reyn/__init__` and `reyn/kernel/__init__` still **eager-imported the `Agent → llm → httpx` + runtime chain (~0.5s residual)**. Under the new #183 in-container venv path on an emulated (colima x86) host, that residual ×~10 inflated past the **~5s python-step timeout**, aborting **2/5 Class A instances** (astropy-13236, astropy-13977) — the faithful path only functioned in 3/5.

## Root fix (not a timeout raise)
Next layer of the same lazy strategy as #1083: make both package `__init__`s **PEP 562-lazy** (`__getattr__`), so importing a submodule — notably `reyn.kernel._python_harness` — pulls only the allowlist + stdlib, never the agent/llm/httpx chain.

- **Measured: 533ms → 22ms (24×)** cold-import; `reyn.agent`/`reyn.llm`/`httpx` no longer in `sys.modules` after harness import.
- Public surface **unchanged**: `from reyn import Agent` / `from reyn.kernel import OSRuntime` resolve via lazy load on first access.
- **Generalizes** to all cold-start paths (CLI etc.), P7-clean (no swe_bench-specific code) — per generalize-for-reyn discipline.
- Safe: 0 `from reyn.kernel import` consumers, 0 `from . import` inside kernel, no import-time registration side-effects (all verified pre-impl).

## Tier-2 (extends `tests/test_python_harness_no_litellm_import.py`)
- `test_harness_import_does_not_load_agent_llm_chain` — structural invariant (heavy chain absent from `sys.modules`), robust to host speed unlike the timing ceiling.
- `test_lazy_public_api_still_resolves` — falsification: public names still resolve via lazy load + unknown attr raises `AttributeError` (laziness dropped nothing).

## Efficacy note
This removes the **timeout-abort** structural blocker. The end-to-end efficacy (all 5/5 Class A receiving a faithful trial) is proven by the **#183 5/5 re-measure** after this + #1366 land — not claimed here (honest split).

## Test plan
- [x] `pytest -q` from rootdir — 6935 passed, 10 skipped, 3 xfailed. The 2 failures (`test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::...inline_content`) **pre-exist on clean origin/main** (confirmed via `git stash` of this diff) — env quirks (swebench installed locally + html-lib), CI-green, not this change.
- [x] `ruff check .` — clean.
- [x] `scripts/test_tier_audit.py --strict` on the changed test — 4/4 OK.
- [x] Real cold-import measurement: 533ms → 22ms; heavy chain not leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)