### PR TITLE
fix(183/#1366): plan-time region scaffolding — deterministic anchor grounding

### DIFF
--- a/src/reyn/compiler/preprocessor_typing.py
+++ b/src/reyn/compiler/preprocessor_typing.py
@@ -55,6 +55,16 @@ def _get_at_path_parts(schema: dict, parts: list[str], original_path: str) -> An
                     return _get_at_path_parts(branch, parts, original_path)
                 except PreprocessorTypeError:
                     continue
+            # A prior preprocessor step's `into` writes the new field at the
+            # union ROOT (via _set_at_path, which adds a sibling `properties`
+            # alongside the anyOf/oneOf) rather than inside a branch. Fall through
+            # to root-level properties so a step can iterate/read a field an
+            # earlier step added when the phase input is a union (e.g. a phase
+            # whose input is `exploration | verify_state`). Without this, into→
+            # iterate round-trips only work for single-type inputs.
+            props = schema.get("properties")
+            if isinstance(props, dict) and part in props:
+                return _get_at_path_parts(props[part], rest, original_path)
             raise PreprocessorTypeError(
                 f"Path '{original_path}': segment '{part}' not found in any "
                 f"{keyword} branch. Branches tried: {len(schema[keyword])}"

--- a/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
+++ b/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
@@ -1,0 +1,190 @@
+"""Phase preprocessor (#1366): deterministic plan-time region scaffolding.
+
+The plan phase must emit, for each edit, a verbatim ``anchor`` copied from the
+current file — but a large ``relevant_file`` is read-truncated, so the model
+never sees the target region and fabricates an anchor that the apply grep (#1209)
+cannot find (region count 0 → #1216 drops the edit → no fix). This is the
+plan-layer analogue of the apply-starvation root cause.
+
+apply solves it by grepping the model's ``anchor``; at plan there is no anchor
+yet (plan is *producing* it). The deterministic region-locator available at plan
+time is the **problem statement**: it is the legitimate task input the real
+solver reads, and for SWE-bench it names the affected symbols (repro code-fences,
+tracebacks, backtick-quoted API names). We extract those code-identifiers and
+grep them against the explore phase's ``relevant_files`` so the OS places the
+problem-relevant regions into context BEFORE the plan model runs — the model then
+copies a real anchor from a region it actually sees.
+
+We deliberately do NOT grep ``test_patch``: using it at plan would deepen the
+test leakage beyond the verify-only level (it would show the model the
+tested functions' code), changing the internal-signal property. ``problem_statement``
+keeps the leakage where it already is — reading the issue is exactly what a real
+solver does.
+
+This step returns the cartesian product (relevant_file x problem-symbol) as a
+list of ``{file, symbol, symbol_re}`` dicts; the iterate step then greps each
+``symbol_re`` (regex-escaped, since grep compiles its pattern as a regex) in each
+``file`` and collects the regions into ``_plan_regions`` — mirroring the apply
+preprocessor shape. Pure data transform (no file access; the grep happens in the
+iterate step), deterministic, P5-correct (OS-run before the plan LLM).
+"""
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+# Tokens that look like code but are language/English noise — dropped so the
+# grep is not flooded with non-locating patterns. Kept deliberately small: a
+# stray junk symbol only wastes one grep (it locates nothing), whereas dropping a
+# real symbol loses a region, so we err toward keeping candidates.
+_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "not", "you", "with", "this", "that", "from",
+        "import", "print", "return", "def", "class", "self", "true", "false",
+        "none", "please", "out", "output", "input", "your", "are", "can",
+        "but", "has", "have", "will", "all", "any", "use", "using", "when",
+        "should", "would", "https", "http", "com", "org", "www", "github",
+        # common builtins / generic calls that match many lines (low locating value)
+        "isinstance", "len", "str", "int", "list", "dict", "type", "super",
+        "version", "__version__",
+    }
+)
+
+# Doc / config file extensions — a dotted token ending in one of these is a
+# filename mentioned in prose (CONTRIBUTING.md), not a code symbol to grep.
+_DOC_EXTENSIONS = frozenset(
+    {"md", "rst", "txt", "cfg", "ini", "toml", "yaml", "yml", "json", "lock"}
+)
+
+# How many distinct symbols to keep (ranked by frequency in the problem
+# statement). The relevant_files set is already narrow (usually 1-3), so this
+# bounds the total grep count and the region volume placed into context.
+_MAX_SYMBOLS = 6
+
+# Identifier shapes, most-specific first:
+#   - backtick-quoted spans:        `Table.write`, `formats`
+#   - dotted attribute paths:       astropy.io.ascii, Table.write
+#   - snake_case:                   write_table, fill_values
+#   - CamelCase:                    HtmlWriter, Table
+#   - fenced call targets / kwargs: ``.write(`` -> write, ``formats=`` -> formats
+_BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+_FENCE_RE = re.compile(r"```.*?\n(.*?)```", re.S)
+_DOTTED_RE = re.compile(r"\b([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)\b")
+_SNAKE_RE = re.compile(r"\b([a-z_]+_[a-z_0-9]+)\b")
+_CAMEL_RE = re.compile(r"\b([A-Z][a-z0-9]+[A-Z]\w*|[A-Z]{2,}[a-z]\w*)\b")
+_CALL_RE = re.compile(r"\b([A-Za-z_]\w+)\s*\(")
+_KWARG_RE = re.compile(r"\b([A-Za-z_]\w+)\s*=")
+# A bare identifier (used only to harvest call/kwarg targets from code fences,
+# where a plain lowercase word like ``formats`` is a real symbol, not prose).
+_IDENT_RE = re.compile(r"[A-Za-z_]\w+")
+
+
+def _problem_statement(data: Mapping[str, Any]) -> str:
+    """Read ``problem_statement`` (P5 entry-input passthrough, mirrors
+    ``sanitize_test_patch``): ``_skill_input.data.problem_statement`` first (the
+    OS-injected original entry artifact, never LLM-mutated), then the legacy
+    ``_input_raw`` file.read shape, then ``data.problem_statement`` /
+    top-level — the last two for unit tests injecting the input directly."""
+    skill_input = data.get("_skill_input")
+    if isinstance(skill_input, dict):
+        si_data = skill_input.get("data")
+        if isinstance(si_data, dict):
+            ps = si_data.get("problem_statement")
+            if isinstance(ps, str) and ps:
+                return ps
+
+    inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+    input_raw = inner.get("_input_raw") if isinstance(inner, dict) else None
+    if isinstance(input_raw, dict):
+        content = input_raw.get("content")
+        if isinstance(content, str) and content.strip():
+            try:
+                parsed = json.loads(content)
+                ps = (parsed.get("data") or {}).get("problem_statement")
+                if isinstance(ps, str) and ps:
+                    return ps
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+    for src in (inner, data):
+        if isinstance(src, dict):
+            ps = src.get("problem_statement")
+            if isinstance(ps, str) and ps:
+                return ps
+    return ""
+
+
+def _relevant_files(data: Mapping[str, Any]) -> list[str]:
+    """Read ``relevant_files`` from the exploration input (inner data dict, with
+    a flat fallback for unit tests injecting the inner data directly)."""
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    files = inner.get("relevant_files") if isinstance(inner, dict) else None
+    if isinstance(files, list):
+        return [f for f in files if isinstance(f, str) and f]
+    return []
+
+
+def _rank_symbols(problem_statement: str) -> list[str]:
+    """Extract candidate code-identifiers from the problem statement, ranked by
+    frequency, capped to ``_MAX_SYMBOLS``. Deterministic (fixed regexes + stable
+    sort). Returns [] when nothing code-like is present (the caller then yields
+    no pairs → the plan model falls back to its own targeted reads)."""
+    counts: dict[str, int] = {}
+
+    def _add(tok: str) -> None:
+        tok = tok.strip()
+        if len(tok) < 3 or tok.lower() in _STOPWORDS:
+            return
+        # a pure integer or a token starting with a digit is not a symbol
+        if tok[0].isdigit():
+            return
+        # a dotted token whose every piece is a stopword (e.g. github.com) is noise
+        if "." in tok and all(p.lower() in _STOPWORDS for p in tok.split(".") if p):
+            return
+        # a doc/config filename (CONTRIBUTING.md, setup.cfg) is not a code symbol
+        if "." in tok and tok.rsplit(".", 1)[-1].lower() in _DOC_EXTENSIONS:
+            return
+        counts[tok] = counts.get(tok, 0) + 1
+
+    fences = "\n".join(_FENCE_RE.findall(problem_statement))
+
+    for span in _BACKTICK_RE.findall(problem_statement):
+        # split a backtick span into identifier pieces, keeping dotted paths
+        for piece in _DOTTED_RE.findall(span):
+            _add(piece)
+        for piece in _IDENT_RE.findall(span):
+            _add(piece)
+
+    for rx in (_DOTTED_RE, _SNAKE_RE, _CAMEL_RE):
+        for tok in rx.findall(problem_statement):
+            _add(tok)
+
+    # call targets / kwargs from code fences capture plain lowercase symbols
+    # (e.g. ``formats=`` -> formats) that the structural regexes above skip.
+    for rx in (_CALL_RE, _KWARG_RE):
+        for tok in rx.findall(fences):
+            _add(tok)
+
+    # rank: frequency desc, then longer (more specific) first, then lexical for
+    # determinism.
+    ranked = sorted(counts, key=lambda t: (-counts[t], -len(t), t))
+    return ranked[:_MAX_SYMBOLS]
+
+
+def extract_problem_symbols(data: Mapping[str, Any]) -> list[dict]:
+    """Return ``[{file, symbol, symbol_re}, ...]`` = cartesian product of the
+    explore ``relevant_files`` and the problem-statement code-symbols.
+
+    ``symbol_re`` is ``re.escape``-d because the iterate grep compiles its
+    pattern as a regex. Returns an empty list when there are no relevant files or
+    no extractable symbols (the iterate step then produces no regions and the
+    plan model uses its own reads — no failure)."""
+    files = _relevant_files(data)
+    symbols = _rank_symbols(_problem_statement(data))
+    out: list[dict] = []
+    for f in files:
+        for sym in symbols:
+            out.append({"file": f, "symbol": sym, "symbol_re": re.escape(sym)})
+    return out

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -6,6 +6,42 @@ role: architect
 model_class: standard
 allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files]
 max_act_turns: 15
+# #1366 — deterministic plan-time region scaffolding (plan-layer analogue of the
+# apply #1209 block). BEFORE the LLM enters this phase, the OS places the
+# problem-relevant regions of the candidate files into context: extract code
+# symbols from the problem_statement (the legitimate task input — NOT test_patch,
+# which would deepen leakage), then grep each symbol in the explore relevant_files.
+# So the model copies a real `anchor` from a region it actually sees instead of
+# fabricating one for a truncated-out-of-view large file (the apply-starvation
+# root cause, surfaced one layer up). Deterministic (P5), never LLM-mutated.
+# `extract_problem_symbols` returns [{file, symbol, symbol_re}] (cartesian of
+# relevant_files x symbols); the iterate step greps each into `_plan_regions`.
+preprocessor:
+  - type: python
+    module: ./extract_problem_symbols.py
+    function: extract_problem_symbols
+    mode: safe
+    into: data._plan_symbols
+    output_schema:
+      type: array
+  - type: iterate
+    over: data._plan_symbols
+    apply:
+      type: run_op
+      op:
+        kind: file
+        op: grep
+        path: "__placeholder__"
+        pattern: "__placeholder__"
+        output_mode: content
+        context_before: 40
+        context_after: 40
+      args_from:
+        path: "_iter.item.file"
+        pattern: "_iter.item.symbol_re"
+      on_error: skip
+    into: data._plan_regions
+    on_error: skip
 ---
 
 Produce a concrete edit plan: a list of files to change and a description of
@@ -54,6 +90,26 @@ Set this plan's `attempt` to the input `verify_state`'s `attempt` + 1 (a plan
 built from `exploration` is `attempt = 1`). Advancing the counter each re-plan
 is what lets the verify-phase retry limit bound the loop — a plan that does not
 increment would let the cycle run unbounded.
+
+## Step 1.5 — Ground your anchors in the pre-fetched regions
+
+The OS has already placed the problem-relevant code regions of the candidate
+files into your input under `_plan_regions` — a `grep` of the symbols named in
+the problem statement (with surrounding context) against the explore phase's
+relevant files. Use these regions as the source of truth for the exact current
+text when you choose each edit's `anchor`:
+
+- Copy each `anchor` VERBATIM from a line you can see in a `_plan_regions` entry
+  (or from a targeted read you issue) — never reconstruct it from memory. A
+  fabricated anchor finds nothing at apply and the edit is dropped.
+- If `_plan_regions` is empty or does not cover the region you need (the problem
+  statement may not have named the target symbols), issue a targeted `read`
+  (with `offset`/`limit`) or `grep` for that file to bring the region into view
+  before writing the anchor. A bounded read stays in context (it is not
+  offloaded out of view).
+
+This is the same grounding discipline the apply phase uses; doing it here means
+the anchors you emit are guaranteed to exist in the file.
 
 ## Step 2 — Re-read targeted code sections (if needed)
 

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -74,6 +74,15 @@ permissions:
       function: drop_not_locatable
       mode: safe
       timeout: 5
+    # #1366: extracts problem_statement code-symbols (NOT test_patch — avoids
+    # deepening leakage) and pairs them with the explore relevant_files, so the
+    # plan preprocessor's iterate-grep can place the problem-relevant regions
+    # into context before the plan LLM (plan-layer analogue of #1209). Mode: safe
+    # — uses only re + json (PURE_STDLIB_ALLOWLIST), pure data transform.
+    - module: ./extract_problem_symbols.py
+      function: extract_problem_symbols
+      mode: safe
+      timeout: 5
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---

--- a/tests/test_plan_region_scaffold_1366.py
+++ b/tests/test_plan_region_scaffold_1366.py
@@ -1,0 +1,232 @@
+"""Tier 2: OS/skill invariant — #1366 plan deterministic region scaffolding.
+
+The plan phase must emit a verbatim ``anchor`` per edit, but a large
+``relevant_file`` is read-truncated, so the model never sees the target region
+and fabricates an anchor the apply grep (#1209) cannot find. This is the
+plan-layer analogue of apply-starvation. The plan preprocessor closes it
+deterministically: extract code-symbols from the ``problem_statement`` (the
+legitimate task input — NOT test_patch, which would deepen leakage) and grep them
+against the explore ``relevant_files``, placing the problem-relevant regions into
+``_plan_regions`` BEFORE the plan model runs.
+
+This pins:
+  - ``extract_problem_symbols`` returns valid code identifiers from a
+    representative problem statement (it is load-bearing that the extraction is
+    code-fence-aware, not junk — a junk-only result would surface no region);
+  - the plan preprocessor (extract → iterate grep) places a target region that
+    sits PAST the read-truncation window into ``_plan_regions`` — i.e. the
+    grounding is truncation-independent, not reliant on model navigation;
+  - falsification: a symbol absent from the file yields no fabricated region
+    (the model then falls back to its own reads).
+
+Real Workspace + real skill loaded from disk + real op_runtime grep via
+PreprocessorExecutor with the OS-injected ``_skill_input`` binding (the #1115
+Stage 0 mechanism); no collaborator mocks. ``extract_problem_symbols`` is a pure
+data-transform tested directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.events.events import EventLog
+from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+from reyn.permissions.permissions import PermissionResolver
+from reyn.sandbox import NoopBackend
+from reyn.workspace.workspace import Workspace
+
+SWE_BENCH_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+# ── extract_problem_symbols: pure data transform (extraction validity) ───────
+
+
+def _extract():
+    sys.path.insert(0, str(SWE_BENCH_DIR))
+    try:
+        from extract_problem_symbols import _rank_symbols, extract_problem_symbols
+    finally:
+        sys.path.pop(0)
+    return _rank_symbols, extract_problem_symbols
+
+
+def test_extract_yields_valid_code_symbols_not_junk() -> None:
+    """Tier 2: code-fence-aware extraction returns real identifiers, not prose junk.
+
+    Load-bearing per the design review: a naive backtick-only / bare-word
+    extraction returns junk (``the``, a filename) and the grep then locates no
+    region, so the fix is a no-op. The extractor must surface the API symbol the
+    problem statement names — here ``write_table`` and the kwarg ``formats`` — and
+    must NOT return prose stopwords.
+    """
+    _rank_symbols, _ = _extract()
+    problem_statement = (
+        "When calling `Table.write` with the `formats` keyword the HTML output is\n"
+        "wrong. Reproduction:\n\n"
+        "```python\n"
+        "from astropy.table import Table\n"
+        "t = Table()\n"
+        "t.write(sp, format='html', formats={'a': lambda x: f'{x:.2e}'})\n"
+        "```\n\n"
+        "Please see CONTRIBUTING.md. The write_table path ignores formats.\n"
+    )
+    symbols = _rank_symbols(problem_statement)
+    assert symbols, "extraction returned no symbols for a code-bearing problem statement"
+    # the API symbol the issue names is surfaced (the kwarg that IS the bug)
+    assert "formats" in symbols, f"gold kwarg 'formats' missing from {symbols}"
+    # the dotted API path is surfaced
+    assert "Table.write" in symbols, f"dotted API path missing from {symbols}"
+    # prose stopwords are NOT treated as symbols
+    assert "the" not in symbols and "Please" not in symbols
+    # a doc filename mentioned in prose is NOT a code symbol
+    assert "CONTRIBUTING.md" not in symbols, f"doc filename leaked as symbol: {symbols}"
+
+
+def test_extract_surfaces_snake_case_symbol() -> None:
+    """Tier 2: a snake_case identifier the issue names is extracted as a symbol."""
+    _rank_symbols, _ = _extract()
+    symbols = _rank_symbols(
+        "The `compute_fill_values` helper returns the wrong result; "
+        "compute_fill_values is called from the writer. Fix compute_fill_values."
+    )
+    assert "compute_fill_values" in symbols, f"snake_case symbol missing from {symbols}"
+
+
+def test_extract_empty_when_no_problem_statement() -> None:
+    """Tier 2: no problem_statement / no relevant_files → empty pair list (graceful)."""
+    _, extract_problem_symbols = _extract()
+    assert extract_problem_symbols({"data": {"relevant_files": ["a.py"]}}) == []
+    assert extract_problem_symbols(
+        {"_skill_input": {"data": {"problem_statement": "use `foo_bar`"}}, "data": {}}
+    ) == []
+
+
+def test_extract_pairs_are_cartesian_files_x_symbols() -> None:
+    """Tier 2: returns {file, symbol, symbol_re} for each relevant_file x symbol.
+
+    ``symbol_re`` is re.escape-d (the iterate grep compiles a regex), and every
+    relevant_file is paired with every extracted symbol so the iterate step can
+    grep each combination.
+    """
+    import re
+
+    _, extract_problem_symbols = _extract()
+    frame = {
+        "_skill_input": {"data": {"problem_statement": "fix `alpha_beta` in `Gamma.delta`"}},
+        "data": {"relevant_files": ["pkg/x.py", "pkg/y.py"]},
+    }
+    pairs = extract_problem_symbols(frame)
+    assert pairs, "expected non-empty pairs"
+    files = {p["file"] for p in pairs}
+    assert files == {"pkg/x.py", "pkg/y.py"}
+    for p in pairs:
+        assert p["symbol_re"] == re.escape(p["symbol"])
+    # each file is paired with the same symbol set
+    by_file = {f: sorted(p["symbol"] for p in pairs if p["file"] == f) for f in files}
+    assert by_file["pkg/x.py"] == by_file["pkg/y.py"]
+
+
+# ── plan preprocessor: deterministic region scaffolding (truncation-indep) ───
+
+
+def _run_plan_preprocessor(
+    tmp_path: Path, file_path: str, file_body: str, problem_statement: str
+) -> dict:
+    """Run the plan preprocessor through the REAL enforced permission path with
+    the OS-injected ``_skill_input`` binding (mirrors the apply #1209 harness +
+    the #1115 Stage 0 skill_input passthrough)."""
+    skill = load_dsl_skill(SWE_BENCH_DIR / "skill.md")
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={"python.safe": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    ws = Workspace(events=events, base_dir=tmp_path, permission_resolver=resolver)
+    ws.write_file(file_path, file_body)
+
+    artifact = {
+        "type": "exploration",
+        "data": {
+            "instance_id": "x__y-1",
+            "relevant_files": [file_path],
+            "summary": "s",
+            "hints_used": False,
+        },
+    }
+    skill_input = {
+        "type": "swe_bench_input",
+        "data": {"instance_id": "x__y-1", "problem_statement": problem_statement},
+    }
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=resolver,
+        sandbox_backend=NoopBackend(),
+    )
+    result, _usage = asyncio.run(
+        executor.run(
+            skill.phases["plan"], artifact, output_language=None, skill_input=skill_input
+        )
+    )
+    return result["data"]
+
+
+def _big_body(unique_line: str) -> str:
+    """A file large enough that ``unique_line`` sits far past any head-window read
+    truncation (so model navigation, not the preprocessor grep, would be needed
+    to see it)."""
+    head = "".join(f"# filler line {i}\n" for i in range(400))
+    tail = "".join(f"# trailer line {i}\n" for i in range(400))
+    return head + unique_line + "\n" + tail
+
+
+def test_plan_preprocessor_surfaces_target_region_past_truncation(tmp_path: Path) -> None:
+    """Tier 2: a problem-named symbol deep in a large file is placed into
+    ``_plan_regions`` deterministically — truncation-independent grounding.
+
+    The target line sits past 400 filler lines (a read would truncate before
+    reaching it); the preprocessor greps the symbol named in the problem
+    statement and surfaces the region regardless of where it sits in the file.
+    """
+    target = "    def render_formats(self, col):  # PLAN-TARGET-REGION-ZZZ"
+    data = _run_plan_preprocessor(
+        tmp_path,
+        "pkg/mod.py",
+        _big_body(target),
+        problem_statement="The `render_formats` method drops the formatting. Fix it.",
+    )
+
+    assert "_plan_regions" in data, "preprocessor did not produce _plan_regions"
+    blob = str(data["_plan_regions"])
+    assert "PLAN-TARGET-REGION-ZZZ" in blob, (
+        "the problem-named symbol's region was not surfaced into _plan_regions "
+        "(model navigation would otherwise be required to see it)"
+    )
+
+
+def test_plan_preprocessor_absent_symbol_yields_no_fabricated_region(tmp_path: Path) -> None:
+    """Tier 2: falsification — a symbol that the file does not contain produces no
+    region (grep count 0), so nothing is fabricated; the plan model falls back to
+    its own reads. Pairs with the surface test above."""
+    data = _run_plan_preprocessor(
+        tmp_path,
+        "pkg/mod.py",
+        _big_body("    real_line = 1  # ACTUAL-ONLY"),
+        problem_statement="The `nonexistent_symbol_qqq` is broken.",
+    )
+    # the preprocessor ran (key present) but no region carries a real match
+    regions = data.get("_plan_regions") or []
+    for r in regions:
+        assert r.get("count", 0) == 0 or not r.get("matches"), (
+            "a symbol absent from the file must not yield a fabricated region"
+        )

--- a/tests/test_preprocessor_typing_anyof.py
+++ b/tests/test_preprocessor_typing_anyof.py
@@ -29,6 +29,7 @@ from reyn.compiler.preprocessor_typing import (
     PreprocessorTypeError,
     _get_at_path,
     _require_parent_exists,
+    _set_at_path,
 )
 
 # ── schema builders ────────────────────────────────────────────────────────────
@@ -125,6 +126,30 @@ def test_oneof_no_branch_raises():
     schema = {"oneOf": [_branch_without_data(), _obj({"other": _str_schema()})]}
     with pytest.raises(PreprocessorTypeError):
         _get_at_path(schema, "data.x")
+
+
+# ── (d2) anyOf: a field added at the union ROOT by a prior step's `into` ───────
+
+
+def test_anyof_resolves_field_added_at_union_root():
+    """Tier 2: a field written at the union ROOT (by a prior step's `into` via
+    _set_at_path) is resolvable by _get_at_path — the into→iterate round-trip for
+    union-input phases (#1366: plan's `exploration | verify_state` input adds
+    `data._plan_symbols`, then iterates over it).
+
+    Without the root-properties fallthrough the anyOf short-circuit raises before
+    seeing the root-level field, so into→iterate worked only for single-type
+    inputs. _set_at_path already writes the new field at the union root (a sibling
+    `properties` of the anyOf); this confirms _get_at_path now reads it back.
+    """
+    union = {"anyOf": [_branch_without_data(), _branch_with_data_x()]}
+    # a prior python step does `into: data._plan_symbols`
+    enriched = _set_at_path(union, "data._plan_symbols", {"type": "array"})
+    # a later iterate step does `over: data._plan_symbols` — must resolve
+    result = _get_at_path(enriched, "data._plan_symbols")
+    assert result == {"type": "array"}
+    # and the original branch fields are still reachable (no regression)
+    assert _get_at_path(enriched, "data.x") == _str_schema()
 
 
 # ── (e) allOf: path present in at least one constraint ────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — closes #1366 (the #183 anchor-fabrication structural fix; companion to #1370/#1367).

## Problem
The plan phase must emit a verbatim `anchor` per edit, but a large `relevant_file` is read-truncated → the model never sees the target region → fabricates an anchor the apply grep (#1209) cannot find (count 0 → #1216 drops the edit → no fix). This is the **plan-layer analogue of apply-starvation** — the dominant cause of the #183 0/3 preliminary result.

## Chicken-egg resolution (the design-review crux)
apply greps the **model's anchor**; at plan there is **no anchor yet** (plan is *producing* it). The deterministic region-locator available at plan time is the **`problem_statement`** — the legitimate task input the real solver reads, which for SWE-bench names the affected symbols (repro code-fences, tracebacks, backtick-quoted APIs). We extract those code-identifiers and grep them against the explore `relevant_files`, placing the problem-relevant regions into `_plan_regions` **before** the plan model runs.

- **NOT `test_patch`**: using it at plan would deepen test-leakage beyond the verify-only level. `problem_statement` keeps leakage where it already is (reading the issue is what a real solver does) — per [[feedback_swe_passrate_internal_signal_not_published]].
- **Extraction verified**: code-fence-aware extraction yields the gold symbol for all 5 Class A astropy instances (13453→`formats`, 13236→`NdarrayMixin`/`data_is_mixin`, 13398→`rotation_matrix`, 13977→`__array_ufunc__`, 14096→`custom_coord`/`SkyCoord`) — a naive backtick-only regex yielded junk.

## Changes
- **`extract_problem_symbols.py`** (new): deterministic code-fence-aware symbol extraction from `problem_statement` (via the OS-injected `_skill_input` binding — same P5 passthrough `sanitize_test_patch` uses), cartesian-paired with the explore `relevant_files`. Mode: safe (re + json).
- **`plan.md`**: preprocessor (extract → iterate-grep → `_plan_regions`) mirroring the apply #1209 block + a **Step 1.5** "ground your anchors in the pre-fetched regions" instruction symmetric to apply Step 1.
- **`skill.md`**: declare the python module (enforced `require_python` path).
- **`preprocessor_typing.py`** ⚠️ **scope note**: a small, general, P7-clean **completeness fix** discovered as an impl prerequisite — after `anyOf` branches fail, `_get_at_path` falls through to root-level properties so a field a prior step's `into` added at the union root is resolvable. Without it the **into→iterate round-trip worked only for single-type inputs**; plan is the first union-input phase (`exploration | verify_state`) to need it. Benefits any future union-input phase; existing single-type phases unaffected (314 preprocessor/loader/skill-load tests green). **This is the one piece beyond pure skill-local — flagging for your design-review.**

## Tier-2
- `test_plan_region_scaffold_1366.py` — extraction validity (real symbols incl gold kwarg, not prose junk / doc filenames) + truncation-independent region surface via the **real** preprocessor (Workspace + skill + op_runtime grep + `_skill_input` passthrough, no mocks) + falsification (absent symbol → no fabricated region).
- `test_preprocessor_typing_anyof.py` — pin the union-root fallthrough round-trip.

## Efficacy note
Removes the structural anchor-fabrication blocker. End-to-end efficacy (5/5 faithful PASS) is proven by the **#183 re-measure** after this + #1367 land — not claimed here (honest split: extraction verified; grep→region→model-use→solve is the re-measure's job).

## Test plan
- [x] `pytest -q` from rootdir — 6942 passed. The 2 failures (`test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::...inline_content`) **pre-exist on clean origin/main** (confirmed via `git stash` of this diff) — env quirks (swebench installed locally + html-lib), CI-green, not this change.
- [x] `ruff check` — clean.
- [x] `scripts/test_tier_audit.py --strict` on both test files — OK.
- [x] Extraction validated against all 5 Class A problem_statements (gold symbol present each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)