### PR TITLE
fix(183/#1366): bound plan-time _plan_regions volume (context-bloat hotfix)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -42,6 +42,18 @@ preprocessor:
       on_error: skip
     into: data._plan_regions
     on_error: skip
+  # #1366 follow-up: bound the region volume. A common symbol matches hundreds of
+  # lines (e.g. `Column`); with context each grep result is huge, so the raw
+  # `_plan_regions` can reach megabytes and overwhelm the plan model's context
+  # (it then aborts). This drops no-match (count 0) and too-generic (count > max)
+  # regions and caps the total, keeping only precise, size-bounded locators.
+  - type: python
+    module: ./prune_plan_regions.py
+    function: prune_plan_regions
+    mode: safe
+    into: data
+    output_schema:
+      type: object
 ---
 
 Produce a concrete edit plan: a list of files to change and a description of

--- a/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
+++ b/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
@@ -1,0 +1,79 @@
+"""Phase preprocessor (#1366 follow-up): bound the plan-time region volume.
+
+The plan preprocessor greps each problem-statement symbol against the explore
+``relevant_files`` and collects the grepped regions into ``_plan_regions``. But a
+common symbol (e.g. ``Column`` in astropy/table/table.py) matches *hundreds* of
+lines, and with surrounding context each such grep result is enormous — the raw
+``_plan_regions`` reached ~6 MB on astropy-13236, overwhelming the plan model's
+context so it aborts. That defeats the whole purpose (the truncation fix) by
+re-introducing context bloat at the plan layer.
+
+This step runs AFTER the iterate-grep and makes the surfaced volume **bounded by
+construction** (the [[feedback_bounded_by_construction_pattern]]):
+
+  * **Primary bound = a size budget.** Each region's ``matches`` are capped to
+    ``_MAX_MATCHES_PER_REGION`` and regions are added only while the running total
+    stays under ``_MAX_TOTAL_CHARS``. So ``_plan_regions`` is *always* small,
+    whatever the grep counts — the context cannot bloat regardless of input.
+  * **Secondary signal = match count, used only to RANK.** A region with fewer
+    matches is a more *specific* locator (the symbol pinpoints a place), so we add
+    regions in ascending-count order: the precise locators (the gold target
+    regions) are surfaced first and a non-specific high-count region (``Column``
+    everywhere) is naturally crowded out by the budget rather than by a magic
+    threshold. ``count == 0`` (symbol absent) is dropped as a validity filter
+    (a no-match region has no locating value), not as the bound.
+
+When everything is dropped (all symbols absent) or the budget is tiny,
+``_plan_regions`` ends up small/empty and the plan model falls back to its own
+targeted reads (graceful, the same as the no-symbol case). Pure data transform
+(no file access; sandboxed python-step), deterministic, never LLM-mutated; writes
+the whole inner data via ``into: data``.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+# PRIMARY bound (bounded-by-construction): the total serialized size of the
+# surfaced _plan_regions never exceeds this — the context is small whatever the
+# grep counts are.
+_MAX_TOTAL_CHARS = 40000
+# PRIMARY bound: per-region cap on how many matches are kept (a few sample
+# regions ground an anchor; the model can issue a targeted read for more).
+_MAX_MATCHES_PER_REGION = 3
+
+
+def prune_plan_regions(data: Mapping[str, Any]) -> dict:
+    """Return the inner data dict with ``_plan_regions`` bounded by a size budget,
+    precise (low-match-count) regions prioritized (write back with ``into: data``).
+
+    Receives the FULL artifact (regions at ``data["data"]["_plan_regions"]`` with a
+    flat fallback for unit tests, mirroring the other swe_bench preprocessors)."""
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    regions = inner.get("_plan_regions") or []
+
+    # validity filter: a region must have at least one match to locate anything.
+    valid = [
+        r
+        for r in regions
+        if isinstance(r, dict) and isinstance(r.get("count"), int) and r["count"] >= 1
+    ]
+    # SECONDARY signal: rank by specificity — fewer matches = more precise locator,
+    # surfaced first so the gold target regions win the size budget over a
+    # non-specific high-count symbol.
+    valid.sort(key=lambda r: r["count"])
+
+    kept: list[Any] = []
+    total = 0
+    for region in valid:
+        matches = region.get("matches")
+        if isinstance(matches, list) and len(matches) > _MAX_MATCHES_PER_REGION:
+            region = {**region, "matches": matches[:_MAX_MATCHES_PER_REGION]}
+        size = len(json.dumps(region))
+        if total + size > _MAX_TOTAL_CHARS:
+            break  # PRIMARY bound reached — output is bounded by construction
+        total += size
+        kept.append(region)
+
+    return {**inner, "_plan_regions": kept}

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -83,6 +83,13 @@ permissions:
       function: extract_problem_symbols
       mode: safe
       timeout: 5
+    # #1366 follow-up: bounds the plan-time region volume (drops no-match +
+    # too-generic high-count regions, caps total) so a common symbol's giant grep
+    # result cannot bloat the plan context. Mode: safe — pure data transform.
+    - module: ./prune_plan_regions.py
+      function: prune_plan_regions
+      mode: safe
+      timeout: 5
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---

--- a/tests/test_plan_region_scaffold_1366.py
+++ b/tests/test_plan_region_scaffold_1366.py
@@ -55,6 +55,69 @@ def _extract():
     return _rank_symbols, extract_problem_symbols
 
 
+def _prune():
+    sys.path.insert(0, str(SWE_BENCH_DIR))
+    try:
+        from prune_plan_regions import _MAX_TOTAL_CHARS, prune_plan_regions
+    finally:
+        sys.path.pop(0)
+    return prune_plan_regions, _MAX_TOTAL_CHARS
+
+
+def test_prune_is_bounded_by_construction_total_size() -> None:
+    """Tier 2: the surfaced _plan_regions size is bounded by construction — the
+    total never exceeds the size budget, whatever the input grep counts.
+
+    This is the #1366 regression the original synthetic single-match tests missed:
+    on astropy-13236 `Column` matched 228 lines → raw _plan_regions reached ~6MB →
+    the plan model aborted. The size budget (primary bound), not a magic count
+    threshold, guarantees a small context.
+    """
+    import json as _json
+
+    prune_plan_regions, max_total = _prune()
+    # a pathological input: one huge high-count region + many large low-count ones
+    regions = [{"count": 228, "matches": [{"content": "Column " * 200}] * 228}]
+    regions += [{"count": 2, "matches": [{"content": "x" * 4000}]} for _ in range(50)]
+    out = prune_plan_regions({"data": {"_plan_regions": regions}})
+    total = len(_json.dumps(out["_plan_regions"]))
+    assert total <= max_total, f"total _plan_regions must be <= budget {max_total}, got {total}"
+
+
+def test_prune_drops_no_match_and_prioritizes_specific_over_generic() -> None:
+    """Tier 2: count is a SECONDARY ranking signal — a no-match region (count 0) is
+    dropped (validity), and precise low-count locators are surfaced ahead of a
+    non-specific high-count symbol when the budget is contended.
+
+    Realistic mixed distribution (lead-coder guidance #3): a common symbol
+    (high match-count, e.g. `Column`) + specific symbols (low count, the gold
+    targets). The specific ones must survive; the generic one is crowded out by the
+    size budget, not a hard threshold. Mirrors drop_not_locatable's spirit.
+    """
+    prune_plan_regions, max_total = _prune()
+    # Size the precise locators so the two of them ~fill the budget; the generic
+    # high-count region (sorted last) is then crowded out. This mirrors the real
+    # astropy-13236 distribution where ±context regions are ~13KB each so only the
+    # first couple by ascending count fit.
+    big = int(max_total * 0.45)  # each specific ~45% of budget → two ~fill it
+    specific_a = {"count": 1, "matches": [{"content": "N" * big}]}      # gold
+    specific_b = {"count": 2, "matches": [{"content": "d" * big}]}      # gold
+    absent = {"count": 0, "matches": []}
+    generic = {"count": 228, "matches": [{"content": "Column " * 400}] * 228}
+    out = prune_plan_regions(
+        {"data": {"_plan_regions": [generic, absent, specific_a, specific_b]}}
+    )
+    kept_counts = [r["count"] for r in out["_plan_regions"]]
+    assert 0 not in kept_counts, "a no-match region must be dropped (validity filter)"
+    # the precise locators are surfaced; the generic high-count symbol is crowded out
+    assert 1 in kept_counts and 2 in kept_counts, (
+        f"specific (gold) locators must survive, got {kept_counts}"
+    )
+    assert 228 not in kept_counts, (
+        f"the non-specific high-count symbol must be crowded out by the budget, got {kept_counts}"
+    )
+
+
 def test_extract_yields_valid_code_symbols_not_junk() -> None:
     """Tier 2: code-fence-aware extraction returns real identifiers, not prose junk.
 
@@ -211,6 +274,32 @@ def test_plan_preprocessor_surfaces_target_region_past_truncation(tmp_path: Path
     assert "PLAN-TARGET-REGION-ZZZ" in blob, (
         "the problem-named symbol's region was not surfaced into _plan_regions "
         "(model navigation would otherwise be required to see it)"
+    )
+
+
+def test_plan_preprocessor_bounds_volume_for_common_symbol(tmp_path: Path) -> None:
+    """Tier 2: a problem-named symbol that matches MANY lines does NOT bloat
+    _plan_regions — the prune step caps the volume (the #1366 regression: on
+    astropy-13236 `Column` matched 228 lines → ~6MB _plan_regions → plan aborted).
+
+    Builds a file where `Column` appears on hundreds of lines, names it in the
+    problem statement, runs the full real preprocessor, and asserts the resulting
+    _plan_regions stays small (the generic high-count region is dropped).
+    """
+    import json as _json
+
+    body = "".join(f"class Column{i}:  # Column usage line {i}\n" for i in range(300))
+    data = _run_plan_preprocessor(
+        tmp_path,
+        "pkg/mod.py",
+        body,
+        problem_statement="The `Column` class is broken in the writer.",
+    )
+    regions = data.get("_plan_regions") or []
+    total = len(_json.dumps(regions))
+    assert total < 60000, (
+        f"_plan_regions must stay bounded for a high-count symbol (got {total} chars); "
+        "the prune step should have dropped the too-generic region"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — hotfix for a regression my merged #1366 introduced, caught by the faithful in-container re-measure.

## Regression (P0, caught by the re-measure)
#1366 surfaced problem-statement-symbol grep regions into `_plan_regions` but did **not bound the volume**. A common symbol (e.g. `Column` in `astropy/table/table.py`) matches hundreds of lines; with ±context each grep result is huge — `_plan_regions` reached **~6 MB** on astropy-13236, overwhelming the plan model's context so it **aborted** ("Failed to read the exploration artifact"). All 5 Class A instances aborted at plan in the enforcement-profile in-container run. The #1366 Tier-2 used synthetic single-match files, so no high-match-count symbol was ever exercised — an overfit-self-check gap.

## Fix (forward, bounded-by-construction)
A deterministic `prune_plan_regions` preprocessor step after the iterate-grep:
- **PRIMARY bound = size budget**: per-region matches capped + regions added only while the running total stays under `_MAX_TOTAL_CHARS`. `_plan_regions` is **always small whatever the grep counts** — the context cannot bloat by construction (not a magic count threshold, per lead-coder's guidance).
- **SECONDARY = match count, ranking only**: fewer matches = more specific locator, surfaced first, so the gold target regions win the budget and a non-specific high-count symbol is crowded out. `count==0` (absent) dropped as a validity filter.

## Verified (real enforcement docker env, astropy-13236)
- `_plan_regions`: **6061 KB → 27 KB**; bloat-abort resolved.
- **Gold region preserved**: the specific `NdarrayMixin` region is KEPT, generic `Column` dropped (prune removes noise, not efficacy).
- **Region-surfacing efficacy proven**: the plan model now grounds a real anchor (`data_is_mixin`/`NdarrayMixin`) → `edit_located` went **0 (pre-#1366) → 1** for 13236.

## Honest scope note (not claimed fixed by this PR)
13236 still does not produce a patch: with 1/4 anchors locatable, the 3 not_locatable edits trigger a **plan↔apply replan loop** → identical re-plan → the #1204 loop guard aborts. This is a **deeper, separate failure mode** (weak model can't produce a fully-locatable multi-edit plan even with region-surfacing), adjacent to the pre-existing apply-starvation class — NOT a prune regression. Tracking/classifying separately via the full 5/5 re-measure; this PR's scope is strictly the bloat regression.

## Test plan
- [x] `pytest tests/test_plan_region_scaffold_1366.py` — 9 passed (incl. the realistic mixed match-count distribution the original missed: bounded-by-construction total + specific surfaced + generic crowded out).
- [x] `ruff check` + `test_tier_audit.py --strict` — clean.
- [x] Real enforcement-env astropy-13236 re-verify: 6MB→27KB, plan no longer aborts, gold region kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)