### PR TITLE
fix(183): reyn run --grant-file-write — resolver grant ∩ sandbox-bound write

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -419,6 +419,13 @@ def run_reyn_in_container(
             "--container", name,
             "--repo-dir", repo_dir,
             "--state-dir", host_state,
+            # #183: grant file.write so the apply phase can edit the repo working
+            # tree. The grant is bounded by the sandbox write_paths (= the
+            # in-container repo_dir) via the resolver's SandboxLayer ∩, so it
+            # scopes to the repo, not globally. Without it a non-interactive run
+            # leaves the skill's declared file.write "declared-but-not-granted"
+            # and apply aborts ("outside the allowed write zone").
+            "--grant-file-write",
         ]
         # #183: point the #1356 harness subprocess at the in-container venv python
         # (read by PythonRunner's REYN_HARNESS_PYTHON override — the only OS change).

--- a/src/reyn/cli/commands/run.py
+++ b/src/reyn/cli/commands/run.py
@@ -75,6 +75,21 @@ def register(sub) -> None:
                        "Enable unsafe-mode Python preprocessor steps (no AST sandboxing). "
                        "Safe-mode python steps run without this flag. Off by default."
                    ))
+    # #183: grant file.write at the resolver layer for this run. The grant is
+    # scoped by the SandboxLayer (∩) to the run's sandbox write_paths (= the
+    # workspace base_dir / repo working tree), so this enables editing the
+    # working tree (e.g. a docker --repo-dir checkout) WITHOUT widening writes
+    # outside the sandbox zone. Mirrors the eval path's grant on the `reyn run`
+    # path. Off by default — the skill's declared file.write stays
+    # "declared-but-not-granted" in a non-interactive run without it.
+    p.add_argument("--grant-file-write",
+                   dest="grant_file_write",
+                   action="store_true",
+                   help=(
+                       "Grant file.write at the resolver layer (bounded by the "
+                       "sandbox write zone). Enables editing the working tree in a "
+                       "non-interactive run. Off by default."
+                   ))
     # #1289: shared --env-backend / container args (host / docker attach|launch).
     register_env_backend_args(p)
     p.set_defaults(func=run)
@@ -99,6 +114,17 @@ def run(args: argparse.Namespace) -> None:
     # (= no silent "ja" default) — the project targets a global audience.
     output_language = session.output_language_for(args)
     safety = session.safety_for(args)
+
+    # #183: --grant-file-write grants file.write at the resolver layer. The
+    # SandboxLayer (∩) still bounds writes to the sandbox write_paths (= the
+    # workspace base_dir / repo working tree), so the effective grant is scoped
+    # to the working tree, not global. Mirrors the eval path's
+    # `permissions.setdefault("file.write", "allow")` on the `reyn run` path so a
+    # non-interactive run can edit the working tree (its declared file.write is
+    # otherwise "declared-but-not-granted"). setdefault preserves any explicit
+    # operator setting in reyn.yaml.
+    if getattr(args, "grant_file_write", False):
+        session.config.permissions.setdefault("file.write", "allow")
 
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
     # Stdlib skills ship with the Reyn team's code and are trusted by

--- a/tests/test_run_grant_file_write_183.py
+++ b/tests/test_run_grant_file_write_183.py
@@ -79,5 +79,7 @@ def test_run_parser_exposes_grant_file_write_flag() -> None:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers()
     register(sub)
-    assert parser.parse_args(["run", "swe_bench", "--grant-file-write", "{}"]).grant_file_write is True
-    assert parser.parse_args(["run", "swe_bench", "{}"]).grant_file_write is False
+    # NB: no trailing positional — a stray positional after the skill name is
+    # rejected by Python 3.11 argparse (3.12 tolerates intermixed positionals).
+    assert parser.parse_args(["run", "swe_bench", "--grant-file-write"]).grant_file_write is True
+    assert parser.parse_args(["run", "swe_bench"]).grant_file_write is False

--- a/tests/test_run_grant_file_write_183.py
+++ b/tests/test_run_grant_file_write_183.py
@@ -1,0 +1,83 @@
+"""Tier 2: OS invariant — `reyn run --grant-file-write` resolver ∩ sandbox grant.
+
+#183: a non-interactive `reyn run` leaves a skill's declared ``file.write`` as
+"declared-but-not-granted", so the apply phase cannot edit the working tree
+(astropy-13453 aborted: "outside the allowed write zone"). The
+``--grant-file-write`` flag grants ``file.write`` at the resolver (AgentLayer),
+and the SandboxLayer (∩) bounds it to the run's ``write_paths`` (= the repo
+working tree) — so the effective grant is scoped to the working tree, NOT global.
+
+These pin the security-critical ∩ with a REAL PermissionResolver + real
+SandboxPolicy (never a None resolver, per the enforcement-test rule):
+  - grant + sandbox[repo] → a write under the repo is ALLOWED;
+  - the SAME grant → a write OUTSIDE the sandbox zone (e.g. /etc) is DENIED
+    (the SandboxLayer ∩ does the scoping, not the resolver grant);
+  - WITHOUT the grant (opt-out / flag absent) → even an in-repo write is DENIED
+    (the declared-but-not-granted state = the #183 bug the flag fixes);
+  - the `reyn run` arg parser exposes `--grant-file-write` (dest=grant_file_write).
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.policy import SandboxPolicy
+
+_REPO = "/testbed"
+_DECL = PermissionDecl()
+
+
+def _resolver(*, granted: bool) -> PermissionResolver:
+    """A REAL resolver (non-interactive). ``granted`` mirrors what
+    --grant-file-write injects: config_permissions['file.write'] = 'allow'."""
+    config = {"file.write": "allow"} if granted else {}
+    return PermissionResolver(
+        config_permissions=config,
+        project_root=Path("/tmp"),
+        interactive=False,
+    )
+
+
+def _can_write(resolver: PermissionResolver, path: str) -> bool:
+    sandbox = SandboxPolicy(write_paths=[_REPO])
+    try:
+        resolver.require_file_write(_DECL, path, "swe_bench", sandbox_policy=sandbox)
+        return True
+    except PermissionError:
+        return False
+
+
+def test_grant_allows_in_repo_write() -> None:
+    """Tier 2: grant + sandbox[repo] → an in-repo write is allowed (apply can edit)."""
+    assert _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
+
+
+def test_grant_still_denies_outside_sandbox_zone() -> None:
+    """Tier 2: the SandboxLayer ∩ scopes the grant — a write OUTSIDE write_paths
+    (e.g. /etc) is DENIED even with the resolver grant. This is the scoping that
+    makes the blanket resolver-`allow` safe: scope comes from the sandbox, not a
+    (non-functional) scoped resolver config."""
+    assert _can_write(_resolver(granted=True), "/etc/passwd") is False
+
+
+def test_no_grant_denies_in_repo_write() -> None:
+    """Tier 2: opt-out (flag absent → no grant) → even an in-repo write is DENIED.
+
+    This is the #183 bug the flag fixes: a declared-but-not-granted file.write in
+    a non-interactive run. Falsification pair for the grant test above."""
+    assert _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
+
+
+def test_run_parser_exposes_grant_file_write_flag() -> None:
+    """Tier 2: `reyn run` registers --grant-file-write (dest=grant_file_write),
+    default False — the wiring that toggles the grant injection."""
+    from reyn.cli.commands.run import register
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    register(sub)
+    assert parser.parse_args(["run", "swe_bench", "--grant-file-write", "{}"]).grant_file_write is True
+    assert parser.parse_args(["run", "swe_bench", "{}"]).grant_file_write is False


### PR DESCRIPTION
**[e2e-coder]** — the 4th and final binding-layer fix for the #183 faithful path (mechanism design-reviewed + approved by lead-coder).

## Problem
A non-interactive `reyn run` leaves a skill's *declared* `file.write` as **"declared-but-not-granted"**, so the apply phase cannot edit the working tree (astropy-13453 aborted at apply: "outside the allowed write zone"). This was the binding constraint **exposed once #1371 region-surfacing made anchors locatable** enough to attempt a real write (earlier failures masked it).

## Empirical finding (reshaped the design)
- A scoped resolver config `file.write: [{path,scope}]` is a **DECLARATION**, not a grant — denied non-interactively (= the bug itself).
- The working grant is resolver `file.write: "allow"` **∩ the SandboxLayer `write_paths`** — **the sandbox provides the scoping**. Verified: with `write_paths=[/testbed]`, a grant allows `/testbed` writes but **DENIES `/etc`**; without the grant even `/testbed` is denied.

So scope=/testbed is satisfied by the sandbox ∩ (lead-coder owned this req#1 reframe), exactly the existing `eval_benchmark.py:743` mechanism.

## Fix
A generic opt-in **`reyn run --grant-file-write`** flag → sets `config_permissions["file.write"]="allow"` for that run (mirrors the eval path, generalized to the `reyn run` path). The existing sandbox `write_paths` (= workspace base_dir / repo working tree, `runtime.py:181`) bounds it. The swe_bench faithful runner passes the flag so apply can edit the repo.

- **P7-clean** (generic "grant writes within the sandbox zone", not swe_bench-specific), **no skill.md / reyn.yaml change**, sandbox layer untouched (it does the scoping), **off by default** (other runs unaffected).

## Verified (real enforcement docker env, astropy-13453)
With grant + prune (#1372): **0 write permission-denials** (vs the prior "outside write zone" abort), a `write_file` op executed, graceful completion — **the write barrier is removed**. (The remaining empty patch that run was a `not_locatable` plan — a separate weak-model plan-quality issue, run-variable, not the grant; the full 5/5 measures that.)

## Test plan
- [x] `pytest tests/test_run_grant_file_write_183.py` — 4 passed: real `PermissionResolver` + real `SandboxPolicy` (no None resolver) pin the ∩ (grant+sandbox→/testbed allowed, /etc denied, opt-out→denied) + flag exposed.
- [x] `ruff check` + `test_tier_audit.py --strict` — clean.
- [x] Real enforcement-env astropy-13453: write-denial removed, apply no longer aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)