### PR TITLE
feat(tui): JSON tool-result viewer + never-hide-content fallback guard (#1154 Phase 2a)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
@@ -9,7 +9,8 @@ content-type → viewer vision in #1154.
 Design (lead-ratified #1154 Phase 1):
   - keyed by ``content_type`` / ``mimeType`` (the fields file/web/mcp op
     results already carry); no shape-sniff yet.
-  - Phase 1 viewers: markdown (rendered) + CSV/table. Unknown types →
+  - Phase 1 viewers: markdown (rendered) + CSV/table. Phase 2a adds a JSON
+    viewer (formatted + syntax-highlighted). Unknown types →
     ``render_tool_result`` returns ``None`` so the caller falls back to the
     existing YAML preview (degrade, never hide content).
   - Phase 3 (deferred): LLM-generated viewer templates for novel types.
@@ -19,9 +20,11 @@ is testable in isolation without the Textual app.
 """
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from rich.console import RenderableType
+from rich.json import JSON as RichJSON
 from rich.markdown import Markdown as RichMarkdown
 from rich.table import Table
 
@@ -88,6 +91,23 @@ def _viewer_csv(result: dict) -> RenderableType | None:
     return table
 
 
+def _viewer_json(result: dict) -> RenderableType | None:
+    """Syntax-highlighted, indented JSON (Phase 2a).
+
+    Parses the text payload and renders via ``rich.json.JSON`` (formats +
+    highlights). Returns ``None`` when there's nothing to render or the
+    payload isn't valid JSON — the caller then falls back to YAML, which
+    still shows the raw event (degrade, never hide content).
+    """
+    text = _result_text(result)
+    if not text:
+        return None
+    try:
+        return RichJSON(text)
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+
 def render_tool_result(result: Any) -> RenderableType | None:
     """Pick a content-type viewer for ``result`` (or ``None`` for fallback).
 
@@ -104,4 +124,6 @@ def render_tool_result(result: Any) -> RenderableType | None:
         return _viewer_markdown(result)
     if "csv" in ct or "tab-separated" in ct:
         return _viewer_csv(result)
+    if "json" in ct:
+        return _viewer_json(result)
     return None

--- a/tests/cli/test_tool_result_viewers_1154.py
+++ b/tests/cli/test_tool_result_viewers_1154.py
@@ -17,6 +17,7 @@ _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+from rich.json import JSON as RichJSON
 from rich.markdown import Markdown as RichMarkdown
 from rich.table import Table
 
@@ -59,7 +60,7 @@ def test_media_blocks_mimetype_detected() -> None:
 
 def test_unknown_content_type_returns_none() -> None:
     """Tier 2: an unregistered content-type returns None → YAML fallback."""
-    assert render_tool_result({"content_type": "application/json", "content": "{}"}) is None
+    assert render_tool_result({"content_type": "application/x-unknown-binary", "content": "x"}) is None
 
 
 def test_no_content_type_returns_none() -> None:
@@ -95,6 +96,25 @@ def test_csv_caps_rows_with_overflow_caption() -> None:
     out = render_tool_result({"content_type": "text/csv", "content": "\n".join(lines)})
     assert isinstance(out, Table)
     assert out.caption and "more rows" in str(out.caption)
+
+
+# ── JSON viewer (Phase 2a) ───────────────────────────────────────────────────
+
+
+def test_json_content_type_returns_json_renderable() -> None:
+    """Tier 2: an application/json result renders via the JSON viewer."""
+    out = render_tool_result({"content_type": "application/json", "content": '{"a": 1, "b": [2, 3]}'})
+    assert isinstance(out, RichJSON), f"expected RichJSON; got {type(out)!r}"
+
+
+def test_json_invalid_payload_returns_none() -> None:
+    """Tier 2: an application/json result with non-JSON text → None → fallback."""
+    assert render_tool_result({"content_type": "application/json", "content": "not json {{{"}) is None
+
+
+def test_json_empty_content_returns_none() -> None:
+    """Tier 2: an application/json result with no payload → None → fallback."""
+    assert render_tool_result({"content_type": "application/json", "content": ""}) is None
 
 
 # ── wire: _show_event_in_preview routes tool events through the viewer ───────
@@ -151,8 +171,17 @@ async def test_wire_tool_returned_md_event_renders_via_viewer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wire_unknown_type_event_falls_back_to_yaml() -> None:
-    """Tier 2: a tool_returned event with no recognized type → YAML fallback."""
+async def test_wire_unknown_type_event_falls_back_and_shows_content() -> None:
+    """Tier 2: an unrecognized content-type → YAML fallback that still shows content.
+
+    The "never hide content" guard: when no viewer matches, the preview
+    must fall back to the generic YAML render of the event — and that
+    render must still surface the result payload, not an empty pane.
+    """
+    import io
+
+    from rich.console import Console
+
     from reyn.chat.tui.app import ReynTUIApp
     from reyn.chat.tui.widgets import RightPanel
     from reyn.chat.tui.widgets.right_panel.shells import _PreviewPane
@@ -166,14 +195,21 @@ async def test_wire_unknown_type_event_falls_back_to_yaml() -> None:
 
         panel._events_visible = [
             {"type": "tool_returned",
-             "data": {"result": {"content_type": "application/json", "content": "{}"}}},
+             "data": {"result": {"content_type": "application/x-unknown-binary",
+                                 "note": "ZZZSENTINEL"}}},
         ]
         panel._events_cursor = 0
         panel._show_event_in_preview(pane)
         await pilot.pause()
 
         assert captured, "preview pane received no renderable"
-        assert not isinstance(captured[-1], RichMarkdown), (
-            "unrecognized content-type should fall back to the YAML preview, "
-            "not the markdown viewer"
+        # No viewer should have matched (not markdown / not JSON).
+        assert not isinstance(captured[-1], (RichMarkdown, RichJSON)), (
+            "unrecognized content-type should fall back to the YAML preview"
+        )
+        # …and the fallback must still surface the payload (never hide content).
+        buf = io.StringIO()
+        Console(file=buf, width=120).print(captured[-1])
+        assert "ZZZSENTINEL" in buf.getvalue(), (
+            "YAML fallback must still render the result payload, not hide it"
         )


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 2a（expand）: JSON viewer を content-type registry に追加。Phase 1（#1369 merged）の段階導入通り、registry に viewer 1 種追加 + flat fallback 維持。lead review comment の minor（unknown type → fallback の "never hide content" regression-guard 強化）も同梱。

## Why（#1154 Phase 2a、lead-ratify 段階導入）
Phase 1 は markdown / CSV。JSON は tool result の最も汎用な構造 payload（`application/json`）で、生 YAML より formatted + syntax-highlighted の方が読める。registry に最小追加。

## What changed（66 行、2 file）
- **`tool_result_viewers.py`**: `_viewer_json(result)` 追加（`rich.json.JSON` で format + highlight）+ `"json" in ct` dispatch branch。**invalid JSON / 空 payload → `None`**（caller が YAML fallback、degrade never hide）。`json.JSONDecodeError`/`ValueError`/`TypeError` を握って None。
- **test**: JSON pure 3（valid→`RichJSON` / invalid→None / 空→None）。
- **lead minor 反映**: `test_wire_unknown_type_event_falls_back_and_shows_content` = 未登録 type の wire fallback で、YAML render が **payload を実際に surface する**ことを Console 出力 capture で assert（`ZZZSENTINEL` in rendered = never-hide-content の behavior-level guard）。

## stale test retarget（JSON が認識 type に変わったため）
Phase 1 の `test_unknown_content_type_returns_none` と unknown-type wire test は `application/json` を "unknown" sentinel に使っていた。Phase 2a で JSON が**認識される**ようになったため、両 test を真に未登録の `application/x-unknown-binary` に retarget（さもないと "unknown→None" を主張する test が JSON viewer 発火で trivially pass = false guard になる）。

## Verification（Opus 自前 + falsification）
- ruff clean / tier-audit **15/15 ✓ exit 0**
- **falsification**: `"json" in ct` dispatch branch を除去 → `test_json_content_type_returns_json_renderable` FAIL、復元 → 3 pass = 真の guard
- regression smoke: `test_tui_smoke` + `test_events_tab_chain_isolate` = **48 passed**（preview/events 不変）

## Scope / 後続
- **Phase 2b/2c**（別 PR）: image viewer（mime + media_blocks、terminal なので metadata/placeholder 描画）/ email-card viewer（from・subject・body の shape-sniff card）。
- **Phase 3**（defer）: LLM-generated viewer template、#393 と調整。
- P7 非該当: registry は TUI-internal。

## Tier self-check
Tier 2（pure-fn 戻り値 + wire は `show_text` renderable capture / Console 出力 text で assert、private-state 不参照、format-pin なし、docstring 各行 `Tier 2:` 宣言）。JSON dispatch + never-hide-content の両 seam を falsification / content-assert で実証。

## Test plan
- [x] ruff / tier-audit 15/15 exit 0 / 15 test pass
- [x] JSON dispatch falsification（branch 除去→fail→復元）
- [x] never-hide-content fallback（Console capture で payload 実在 assert）
- [x] stale test retarget（application/json → x-unknown-binary、JSON 認識化に伴う false-guard 修正）
- [x] regression smoke 48 passed（preview/events 不変）
- [ ] (skipped — pure + harness wire test が JSON 描画 / fallback content-preservation を behavior-level pin + falsification 済) 実機で events tab → JSON result を持つ tool 実行 → preview で formatted JSON、未登録 type で payload 込み YAML fallback を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
