### PR TITLE
fix(183/#1375 D1): region-surfacing surfaces gold sites — def-grep + proximity-rank

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
+++ b/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
@@ -187,4 +187,18 @@ def extract_problem_symbols(data: Mapping[str, Any]) -> list[dict]:
     for f in files:
         for sym in symbols:
             out.append({"file": f, "symbol": sym, "symbol_re": re.escape(sym)})
+            # #1375 D1: also grep the METHOD DEFINITION whose name contains the
+            # symbol (e.g. `formats` -> `def _set_col_formats`, `write` -> `def
+            # write`). The plain symbol grep matches many incidental lines (early
+            # docstrings/imports) and the gold fix often lives inside a method the
+            # problem statement names only obliquely; the def-grep surfaces that
+            # method's body precisely (astropy-13453: `def write` @~340 carries
+            # the gold `_set_col_formats()` site, which the plain `write` matches
+            # missed). Skip dotted symbols (a method name has no dot).
+            if "." not in sym:
+                out.append({
+                    "file": f,
+                    "symbol": f"{sym} (def)",
+                    "symbol_re": r"def\s+\w*" + re.escape(sym) + r"\w*\s*\(",
+                })
     return out

--- a/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
+++ b/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
@@ -64,12 +64,39 @@ def prune_plan_regions(data: Mapping[str, Any]) -> dict:
     # non-specific high-count symbol.
     valid.sort(key=lambda r: r["count"])
 
+    # #1375 D1: within a region, select which matches to keep by PROXIMITY to
+    # other symbols' matches in the same file, not by first-N. The gold fix site
+    # tends to cluster where several problem-symbols co-occur (a method that
+    # references multiple of them), whereas the dropped junk matches are isolated
+    # early lines (module docstring / imports). Keeping the co-located matches
+    # surfaces the gold region; first-N kept only the early lines (astropy-13453:
+    # plain `write` matched @[2,5,15] — all early — and dropped the gold @349).
+    # `all_marks` = every match's (file, line) across the (count-sorted) regions,
+    # tagged with the region index so a region's own matches are excluded.
+    all_marks: list[tuple[str, int, int]] = []
+    for i, r in enumerate(valid):
+        for m in r.get("matches") or []:
+            p, ln = _match_path(m), _match_line(m)
+            if p is not None and ln is not None:
+                all_marks.append((p, ln, i))
+
+    def _proximity(m: Any, region_index: int) -> float:
+        """Min distance from this match to any OTHER region's match in the same
+        file. inf when isolated (no co-occurring symbol nearby) → ranked last."""
+        p, ln = _match_path(m), _match_line(m)
+        if p is None or ln is None:
+            return float("inf")
+        dists = [abs(ln - L) for (P, L, R) in all_marks if P == p and R != region_index]
+        return min(dists) if dists else float("inf")
+
     kept: list[Any] = []
     total = 0
-    for region in valid:
+    for i, region in enumerate(valid):
         matches = region.get("matches")
         if isinstance(matches, list) and len(matches) > _MAX_MATCHES_PER_REGION:
-            region = {**region, "matches": matches[:_MAX_MATCHES_PER_REGION]}
+            # keep the matches closest to other symbols' matches (gold cluster)
+            ranked = sorted(matches, key=lambda m: _proximity(m, i))
+            region = {**region, "matches": ranked[:_MAX_MATCHES_PER_REGION]}
         size = len(json.dumps(region))
         if total + size > _MAX_TOTAL_CHARS:
             break  # PRIMARY bound reached — output is bounded by construction
@@ -77,3 +104,21 @@ def prune_plan_regions(data: Mapping[str, Any]) -> dict:
         kept.append(region)
 
     return {**inner, "_plan_regions": kept}
+
+
+def _match_line(m: Any) -> int | None:
+    """A grep match's 1-based line number (the data stores it as a string)."""
+    if isinstance(m, dict):
+        try:
+            return int(m.get("line_number"))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _match_path(m: Any) -> str | None:
+    """A grep match's file path (each match carries its own ``path``)."""
+    if isinstance(m, dict):
+        p = m.get("path")
+        return p if isinstance(p, str) and p else None
+    return None

--- a/tests/test_plan_region_scaffold_1366.py
+++ b/tests/test_plan_region_scaffold_1366.py
@@ -118,6 +118,43 @@ def test_prune_drops_no_match_and_prioritizes_specific_over_generic() -> None:
     )
 
 
+def test_prune_keeps_proximal_gold_match_over_early_isolated() -> None:
+    """Tier 2: #1375 D1 — within a region the prune keeps matches by PROXIMITY to
+    other symbols' matches, not first-N — so a LATE gold match co-located with
+    another symbol survives while early isolated junk is dropped.
+
+    This is the astropy-13453 failure: the plain `write` symbol matched early
+    lines [2,5,15] (module docstring/imports) AND the gold `write()` method @349;
+    first-N kept [2,5,15] and dropped @349. Here another symbol matches @348
+    (co-located with the gold @349), so proximity-rank must keep @349.
+    """
+    prune_plan_regions, _ = _prune()
+    f = "astropy/io/ascii/html.py"
+    # the gold symbol's region: 3 early isolated junk matches + the gold @349
+    gold_region = {
+        "count": 4,
+        "matches": [
+            {"path": f, "line_number": "2", "content": "module docstring"},
+            {"path": f, "line_number": "5", "content": "import"},
+            {"path": f, "line_number": "15", "content": "import"},
+            {"path": f, "line_number": "349", "content": "self.data._set_col_formats()"},
+        ],
+    }
+    # a DIFFERENT symbol matches @348 — adjacent to the gold @349 (the cluster)
+    neighbor_region = {
+        "count": 1,
+        "matches": [{"path": f, "line_number": "348", "content": "cols = ..."}],
+    }
+    out = prune_plan_regions({"data": {"_plan_regions": [gold_region, neighbor_region]}})
+    kept_gold = [r for r in out["_plan_regions"] if r["count"] == 4][0]
+    kept_lines = {int(m["line_number"]) for m in kept_gold["matches"]}
+    # _MAX_MATCHES_PER_REGION caps to 3; the gold @349 (dist 1 to @348) must be kept
+    assert 349 in kept_lines, (
+        f"the proximal gold match @349 must survive (got {sorted(kept_lines)}); "
+        "first-N selection would have dropped it for the early isolated lines"
+    )
+
+
 def test_extract_yields_valid_code_symbols_not_junk() -> None:
     """Tier 2: code-fence-aware extraction returns real identifiers, not prose junk.
 
@@ -187,9 +224,17 @@ def test_extract_pairs_are_cartesian_files_x_symbols() -> None:
     assert pairs, "expected non-empty pairs"
     files = {p["file"] for p in pairs}
     assert files == {"pkg/x.py", "pkg/y.py"}
+    # plain-symbol pairs carry the re.escape'd pattern; #1375 D1 also adds a
+    # method-definition pair per non-dotted symbol (`<sym> (def)` -> `def ...`).
     for p in pairs:
-        assert p["symbol_re"] == re.escape(p["symbol"])
-    # each file is paired with the same symbol set
+        if p["symbol"].endswith(" (def)"):
+            assert p["symbol_re"].startswith(r"def\s+"), f"def-pair pattern: {p}"
+        else:
+            assert p["symbol_re"] == re.escape(p["symbol"])
+    # a def-pair exists for the non-dotted symbol, not for the dotted one
+    defs = {p["symbol"] for p in pairs if p["symbol"].endswith(" (def)")}
+    assert "alpha_beta (def)" in defs and "Gamma.delta (def)" not in defs
+    # each file is paired with the same pair set
     by_file = {f: sorted(p["symbol"] for p in pairs if p["file"] == f) for f in files}
     assert by_file["pkg/x.py"] == by_file["pkg/y.py"]
 


### PR DESCRIPTION
**[e2e-coder]** — #1375 D1 (design-reviewed + approved by lead-coder). First fix from the #183 probe-defect loop.

## Defect (primary-evidence, #1375 D1)
The #1366 region-surfacing **dropped the gold fix site** for astropy-13453: the prune kept the FIRST 3 matches of a symbol (early file lines) and dropped later gold-site matches. `write` matched @[2,5,15] (module docstring/imports); the gold `write()` method @349 was dropped; `_set_col_formats`/`formats` never surfaced. The plan model edited the only thing it was shown (a docstring @289) → wrong location. Root-caused from model-diff vs gold-diff.

## Fix (two complementary, bounded-by-construction preserved)
1. **def-grep** (`extract_problem_symbols`): for each non-dotted symbol also grep the METHOD DEFINITION whose name contains it (`def\s+\w*<sym>\w*\s*\(`). The plain symbol grep matches incidental early lines; the def-grep surfaces the target method body precisely.
2. **proximity-rank** (`prune_plan_regions`): within a region, keep matches by PROXIMITY to other symbols' matches in the same file (gold sites cluster where several problem-symbols co-occur), not first-N. Each grep match carries its own `path` + `line_number`, so a late gold match co-located with a neighbor survives while early isolated junk is dropped.

The total size budget is unchanged — only match *selection* changes, so the context stays bounded by construction.

## Verified (real enforcement docker env, astropy-13453)
- `_plan_regions` now surfaces the gold region: `def\s+\w*write\w*\s*\(` matched **line 342 (the `write()` method)** carrying the gold @349; `def _set_col_formats` also surfaces. (Old run surfaced only the docstring @289.)
- The model now **edits the right location**: `write()` method area, patch_len **1843** (vs the old 725-char docstring edit), files_edited = `html.py`. (Whether the patch fully resolves is for the 5-Class-A re-probe; the structural region-surfacing gap is fixed.)

## Test plan
- [x] `pytest tests/test_plan_region_scaffold_1366.py` — 10 passed, incl. the realistic proximity case (a late gold match co-located with a neighbor survives over early isolated lines) + def-pair generation (non-dotted only).
- [x] `ruff check` + `test_tier_audit.py --strict` — clean.
- [x] Real enforcement-env astropy-13453: gold `write()`/`_set_col_formats` region surfaces; model edits the right location.

## Note (lead-coder)
proximity+def is a heuristic, not a guarantee. If the iterative re-probe shows remaining gold-drop cases, a more structural region-request mechanism is the next-layer candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)