### PR TITLE
feat(tui): image tool-result metadata card (#1154 Phase 2b)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
@@ -10,9 +10,10 @@ Design (lead-ratified #1154 Phase 1):
   - keyed by ``content_type`` / ``mimeType`` (the fields file/web/mcp op
     results already carry); no shape-sniff yet.
   - Phase 1 viewers: markdown (rendered) + CSV/table. Phase 2a adds a JSON
-    viewer (formatted + syntax-highlighted). Unknown types →
-    ``render_tool_result`` returns ``None`` so the caller falls back to the
-    existing YAML preview (degrade, never hide content).
+    viewer (formatted + syntax-highlighted); Phase 2b adds an image metadata
+    card (mime / size / source — avoids dumping the base64 blob). Unknown
+    types → ``render_tool_result`` returns ``None`` so the caller falls back
+    to the existing YAML preview (degrade, never hide content).
   - Phase 3 (deferred): LLM-generated viewer templates for novel types.
 
 This module is intentionally pure (dict in → Rich renderable | None) so it
@@ -59,6 +60,16 @@ def _result_text(result: dict) -> str:
         if isinstance(v, str) and v:
             return v
     return ""
+
+
+def _human_bytes(n: int) -> str:
+    """A compact human-readable byte size (e.g. 12.3 KB)."""
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{n} B"
 
 
 def _viewer_markdown(result: dict) -> RenderableType | None:
@@ -108,6 +119,47 @@ def _viewer_json(result: dict) -> RenderableType | None:
         return None
 
 
+def _viewer_image(result: dict) -> RenderableType | None:
+    """Metadata card for an image result (Phase 2b).
+
+    A terminal preview can't raster the image, and the raw result carries a
+    large base64 ``data`` blob — so YAML fallback would spew that blob. This
+    card summarizes the useful metadata (mime / size / source) instead, which
+    is strictly more readable than the raw dump. Always returns a renderable
+    (never None) when dispatched, since the content-type alone is informative.
+    """
+    blocks = result.get("media_blocks")
+    block = (
+        blocks[0]
+        if isinstance(blocks, list) and blocks and isinstance(blocks[0], dict)
+        else {}
+    )
+    mime = _content_type_of(result) or "image"
+    table = Table(show_header=False, box=None, expand=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    table.add_row("type", mime)
+
+    size = result.get("size_bytes")
+    if not isinstance(size, int):
+        data = block.get("data")
+        if isinstance(data, str) and data:
+            size = (len(data) * 3) // 4  # approx decoded bytes from base64 len
+    if isinstance(size, int):
+        table.add_row("size", _human_bytes(size))
+
+    source = result.get("path") or result.get("url")
+    if isinstance(source, str) and source:
+        table.add_row("source", source)
+
+    n_blocks = len([b for b in (blocks or []) if isinstance(b, dict)])
+    if n_blocks > 1:
+        table.add_row("blocks", str(n_blocks))
+
+    table.caption = "🖼  image not rendered inline (terminal preview)"
+    return table
+
+
 def render_tool_result(result: Any) -> RenderableType | None:
     """Pick a content-type viewer for ``result`` (or ``None`` for fallback).
 
@@ -126,4 +178,6 @@ def render_tool_result(result: Any) -> RenderableType | None:
         return _viewer_csv(result)
     if "json" in ct:
         return _viewer_json(result)
+    if ct.startswith("image/"):
+        return _viewer_image(result)
     return None

--- a/tests/cli/test_tool_result_viewers_1154.py
+++ b/tests/cli/test_tool_result_viewers_1154.py
@@ -117,6 +117,56 @@ def test_json_empty_content_returns_none() -> None:
     assert render_tool_result({"content_type": "application/json", "content": ""}) is None
 
 
+# ── image metadata card (Phase 2b) ───────────────────────────────────────────
+
+
+def _render_to_text(renderable: object, width: int = 120) -> str:
+    import io
+
+    from rich.console import Console
+
+    buf = io.StringIO()
+    Console(file=buf, width=width).print(renderable)
+    return buf.getvalue()
+
+
+def test_image_via_media_blocks_returns_card_with_mime() -> None:
+    """Tier 2: a file-shape image result (mime in media_blocks) → metadata card."""
+    out = render_tool_result({
+        "kind": "file", "path": "pic.png", "content": "",
+        "media_blocks": [{"type": "image", "data": "QUJD", "mimeType": "image/png"}],
+    })
+    assert isinstance(out, Table), f"expected a Table card; got {type(out)!r}"
+    text = _render_to_text(out)
+    assert "image/png" in text, "card should show the image mime type"
+
+
+def test_image_web_shape_shows_size_and_source() -> None:
+    """Tier 2: a web-shape image result → card surfaces size + source url."""
+    out = render_tool_result({
+        "content_type": "image/jpeg", "size_bytes": 2048, "url": "https://ex/i.jpg",
+        "media_blocks": [{"type": "image", "data": "QUJD", "mimeType": "image/jpeg"}],
+    })
+    assert isinstance(out, Table)
+    text = _render_to_text(out)
+    assert "image/jpeg" in text
+    assert "https://ex/i.jpg" in text, "card should show the source url"
+    assert "KB" in text or "2.0" in text, "card should show a human-readable size"
+
+
+def test_image_card_does_not_dump_base64_blob() -> None:
+    """Tier 2: the card omits the base64 data blob (the YAML-fallback pitfall)."""
+    blob = "BASE64BLOBABCDEF" * 64
+    out = render_tool_result({
+        "content_type": "image/png", "path": "big.png",
+        "media_blocks": [{"type": "image", "data": blob, "mimeType": "image/png"}],
+    })
+    assert isinstance(out, Table)
+    text = _render_to_text(out)
+    assert blob not in text, "image card must not spew the base64 data blob"
+    assert "image/png" in text
+
+
 # ── wire: _show_event_in_preview routes tool events through the viewer ───────
 # These exercise the integration seam the pure tests above cannot: an event's
 # emit kwargs are nested under ``data`` (events.py ``Event(type=, data=)``),


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 2b（expand）: image viewer を registry に追加。**stacked on #1374（Phase 2a）** — 同 `tool_result_viewers.py` の registry 拡張ゆえ base を 2a branch に設定（#1374 merge 後に GitHub が main へ auto-retarget）。

## Why（#1154 Phase 2b）
image result は terminal で raster 描画できず、raw result は**巨大な base64 `data` blob** を持つ（file.py の `media_blocks[].data`、web.py 同様）。→ 現状の YAML fallback は **base64 blob を preview pane に spew** する。metadata card（mime / size / source）に置換すれば raw dump より strictly readable。

## flow-trace（image result の実 shape、field を invent せず実体確認）
- **file.py `_read_image_file`**: `{"kind":"file","path":...,"content":"","media_blocks":[{"type":"image","data":<b64>,"mimeType":...}]}` — top-level `content_type` 無し、mime は `media_blocks[0].mimeType`（Phase 1 の `_content_type_of` が既に拾う ✓）。
- **web.py**: `content_type` image/… + `size_bytes` + media_block。
→ card は両 shape をカバー（mime 必ず有り、size/source は best-effort）。

## What changed（107 行、2 file）
- **`tool_result_viewers.py`**: `_viewer_image(result)` + `_human_bytes` helper + `ct.startswith("image/")` dispatch branch。card = Rich Table（type / size / source / blocks）+ "image not rendered inline" caption。size は `size_bytes` 優先・無ければ base64 data 長から概算。**常に card 返す（None 不要）** — content-type だけでも YAML より informative。
- **test 3**: media_blocks 経由 mime → card / web-shape → size+source surface / **base64 blob を dump しない regression guard**（Console capture で blob 不在を assert = この PR の核心 value）。

## Verification（Opus 自前 + falsification）
- ruff clean / tier-audit **18/18 ✓ exit 0**
- **falsification**: `image/` dispatch branch 除去 → image 3 test FAIL、復元 → 3 pass = 真の guard
- regression smoke: `test_tui_smoke` + `test_events_tab_chain_isolate` = **48 passed**（preview/events 不変）

## Scope / 後続
- **Phase 2c**（別 PR）: email-card viewer（from・subject・body の shape-sniff card）。
- **Phase 3**（defer）: LLM-generated viewer template、#393 と調整。
- P7 非該当: registry は TUI-internal。

## Tier self-check
Tier 2（pure-fn 戻り値 + Console 出力 text で card 内容 / blob 不在を assert、private-state 不参照、format-pin なし、docstring 各行 `Tier 2:` 宣言）。image dispatch + base64-not-dumped の両 seam を falsification / content-assert で実証。

## Test plan
- [x] ruff / tier-audit 18/18 exit 0 / 18 test pass
- [x] image dispatch falsification（branch 除去→3 fail→復元）
- [x] base64-not-dumped regression guard（Console capture で blob 不在 assert）
- [x] regression smoke 48 passed（preview/events 不変）
- [x] stacked base = #1374 branch（同 file registry 拡張ゆえ、2a merge 後 main auto-retarget）
- [ ] (skipped — pure + content-assert test が card 描画 / base64 非 dump を behavior-level pin + falsification 済) 実機で events tab → image result を持つ tool（file_read 画像 / web fetch 画像）実行 → preview で metadata card（base64 spew なし）を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
