### PR TITLE
feat(tui): web-page-summary shape-sniff card (#1154 Phase 2c)

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/chat/tui/widgets/right_panel/tool_result_viewers.py
@@ -6,15 +6,18 @@ consults this to render ``tool_returned`` / ``tool_executed`` results richer
 than the generic YAML fallback — the first slice of the Jupyter-style
 content-type → viewer vision in #1154.
 
-Design (lead-ratified #1154 Phase 1):
+Design (lead-ratified #1154 Phase 1–2):
   - keyed by ``content_type`` / ``mimeType`` (the fields file/web/mcp op
-    results already carry); no shape-sniff yet.
+    results already carry); explicit type wins, then a shape-sniff pass.
   - Phase 1 viewers: markdown (rendered) + CSV/table. Phase 2a adds a JSON
     viewer (formatted + syntax-highlighted); Phase 2b adds an image metadata
-    card (mime / size / source — avoids dumping the base64 blob). Unknown
-    types → ``render_tool_result`` returns ``None`` so the caller falls back
-    to the existing YAML preview (degrade, never hide content).
-  - Phase 3 (deferred): LLM-generated viewer templates for novel types.
+    card (mime / size / source — avoids dumping the base64 blob); Phase 2c
+    adds a shape-sniffed web-page-summary card (web-fetch HTML preview, which
+    carries no content_type but a distinctive field set). Unknown / unmatched
+    → ``render_tool_result`` returns ``None`` so the caller falls back to the
+    existing YAML preview (degrade, never hide content).
+  - Phase 3 (deferred): LLM-generated viewer templates for novel types;
+    email-card deferred until a real in-repo email result producer exists.
 
 This module is intentionally pure (dict in → Rich renderable | None) so it
 is testable in isolation without the Textual app.
@@ -160,24 +163,80 @@ def _viewer_image(result: dict) -> RenderableType | None:
     return table
 
 
-def render_tool_result(result: Any) -> RenderableType | None:
-    """Pick a content-type viewer for ``result`` (or ``None`` for fallback).
+# Shape-sniff (Phase 2c): some results carry no ``content_type`` but have a
+# distinctive field set. The web-fetch HTML preview (web.py ``_generate_web_
+# fetch_preview``) returns ``{title, outline, first_paragraph, link_count,
+# content_chars}``. We require ALL of these distinctive keys to match — a
+# single-field sniff (e.g. just ``title``) would false-positive on unrelated
+# results, so precision comes from the combination.
+_WEB_SUMMARY_KEYS = ("title", "outline", "first_paragraph", "link_count")
+_MAX_OUTLINE_ROWS = 12
 
-    ``None`` when ``result`` is not a dict, carries no recognizable
-    content-type, or the matched viewer has nothing to render — the caller
+
+def _looks_like_web_summary(result: dict) -> bool:
+    """True when *result* carries the full web-page-summary field set."""
+    return all(k in result for k in _WEB_SUMMARY_KEYS)
+
+
+def _viewer_web_summary(result: dict) -> RenderableType | None:
+    """Card for a web-fetch HTML page summary (Phase 2c, shape-sniffed).
+
+    Renders the distilled page (title / first paragraph / heading outline /
+    link count) — far more readable than the raw nested dict. Returns the
+    card; the dispatcher only calls this once the shape has matched.
+    """
+    table = Table(show_header=False, box=None, expand=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+
+    title = result.get("title")
+    if isinstance(title, str) and title:
+        table.add_row("title", title)
+
+    para = result.get("first_paragraph")
+    if isinstance(para, str) and para:
+        table.add_row("summary", para)
+
+    outline = result.get("outline")
+    if isinstance(outline, list) and outline:
+        rows = [str(h) for h in outline[:_MAX_OUTLINE_ROWS] if str(h).strip()]
+        extra = len(outline) - len(rows)
+        if rows:
+            joined = "\n".join(rows)
+            if extra > 0:
+                joined += f"\n… {extra} more"
+            table.add_row("outline", joined)
+
+    links = result.get("link_count")
+    if isinstance(links, int):
+        table.add_row("links", str(links))
+
+    table.caption = "🌐  web page summary"
+    return table
+
+
+def render_tool_result(result: Any) -> RenderableType | None:
+    """Pick a viewer for ``result`` (or ``None`` for the YAML fallback).
+
+    Explicit ``content_type`` / MIME wins; when none matches, a shape-sniff
+    pass handles results that carry a distinctive field set but no content
+    type (web-page summary). ``None`` when ``result`` is not a dict, nothing
+    matches, or the matched viewer has nothing to render — the caller then
     falls back to the generic YAML preview.
     """
     if not isinstance(result, dict):
         return None
     ct = _content_type_of(result)
-    if not ct:
-        return None
-    if "markdown" in ct or ct.endswith("/md"):
-        return _viewer_markdown(result)
-    if "csv" in ct or "tab-separated" in ct:
-        return _viewer_csv(result)
-    if "json" in ct:
-        return _viewer_json(result)
-    if ct.startswith("image/"):
-        return _viewer_image(result)
+    if ct:
+        if "markdown" in ct or ct.endswith("/md"):
+            return _viewer_markdown(result)
+        if "csv" in ct or "tab-separated" in ct:
+            return _viewer_csv(result)
+        if "json" in ct:
+            return _viewer_json(result)
+        if ct.startswith("image/"):
+            return _viewer_image(result)
+    # No explicit content-type match → shape-sniff distinctive field sets.
+    if _looks_like_web_summary(result):
+        return _viewer_web_summary(result)
     return None

--- a/tests/cli/test_tool_result_viewers_1154.py
+++ b/tests/cli/test_tool_result_viewers_1154.py
@@ -167,6 +167,51 @@ def test_image_card_does_not_dump_base64_blob() -> None:
     assert "image/png" in text
 
 
+# ── web-page-summary shape-sniff card (Phase 2c) ─────────────────────────────
+
+
+def _web_summary_result(**over: object) -> dict:
+    """A web-fetch HTML preview result (web.py _generate_web_fetch_preview shape)."""
+    base = {
+        "title": "Example Page",
+        "outline": ["H1: Welcome", "H2: Details"],
+        "first_paragraph": "An example page.",
+        "link_count": 7,
+        "content_chars": 1234,
+    }
+    base.update(over)
+    return base
+
+
+def test_web_summary_shape_renders_card() -> None:
+    """Tier 2: a no-content_type result with the full web-summary shape → card."""
+    out = render_tool_result(_web_summary_result())
+    assert isinstance(out, Table), f"expected a Table card; got {type(out)!r}"
+    text = _render_to_text(out)
+    assert "Example Page" in text, "card should show the page title"
+    assert "Welcome" in text, "card should show the heading outline"
+    assert "7" in text, "card should show the link count"
+
+
+def test_web_summary_partial_shape_not_sniffed() -> None:
+    """Tier 2: precision — a partial field set must NOT shape-sniff as web summary."""
+    # title + first_paragraph present but outline + link_count missing → None.
+    assert render_tool_result({"title": "X", "first_paragraph": "y"}) is None
+
+
+def test_web_summary_single_title_field_not_sniffed() -> None:
+    """Tier 2: precision — a lone common field (title) must not false-positive."""
+    assert render_tool_result({"title": "Just a title"}) is None
+
+
+def test_web_summary_outline_capped_with_overflow() -> None:
+    """Tier 2: a long outline is capped with an overflow indicator."""
+    out = render_tool_result(_web_summary_result(outline=[f"H2: item {i}" for i in range(30)]))
+    assert isinstance(out, Table)
+    text = _render_to_text(out)
+    assert "more" in text, "capped outline should show an overflow indicator"
+
+
 # ── wire: _show_event_in_preview routes tool events through the viewer ───────
 # These exercise the integration seam the pure tests above cannot: an event's
 # emit kwargs are nested under ``data`` (events.py ``Event(type=, data=)``),


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 2c（expand）: registry 初の **shape-sniff viewer** = web-page-summary card。lead ruling (a) 通り email-card を defer して web-summary に swap。**stacked on #1377（Phase 2b）**。

## Why（lead ruling (a)、primary-evidence-backed）
当初計画の email-card は **in-repo producer 不在**（grep: email result を produce する op 無し、外部 MCP 仮想）→ field invent + dead code + false-positive risk ゆえ lead が defer 裁定。代わりに **web.py の `text/html` fetch** が返す `{title, outline, first_paragraph, link_count, content_chars}`（`_generate_web_fetch_preview`、実 producer・実 fields、inspect 済）= **content_type を持たない result を shape-sniff で dispatch** する Phase 2c の value を grounded に実現。

## What changed（123 行、2 file）
- **`tool_result_viewers.py`**:
  - `_looks_like_web_summary(result)` = `title`+`outline`+`first_paragraph`+`link_count` **全 4 固有 field 合致**で sniff（lead 設計 note: 1-field sniff は false-positive ゆえ複数固有 field の合致で precise に）。
  - `_viewer_web_summary(result)` card = title / summary(first_paragraph) / outline(capped 12 + overflow) / link count。
  - `render_tool_result` restructure: **explicit content-type 優先 → 無 match なら shape-sniff → None**（flat YAML fallback 維持、Phase 1 設計「explicit type 優先 + 無い時 shape-sniff」を実装）。
- **test 4**: full shape → card（title/outline/link 表示）/ **partial shape（title+first_paragraph のみ）→ None** / **lone title field → None**（precision）/ outline cap + overflow。

## Verification（Opus 自前 + 2 軸 falsification、lead note 準拠）
- ruff clean / tier-audit **22/22 ✓ exit 0**
- **falsification 2 軸**:
  - dispatch: shape-sniff branch 除去 → web-summary card test FAIL
  - **precision**: sniff を 1-field(`"title" in result`)に弱める → partial/lone-title test FAIL（= multi-field 合致が false-positive を防ぐことを実証）
  - 復元 → 4 pass
- regression smoke: `test_tui_smoke` + `test_events_tab_chain_isolate` = **48 passed**（既存 content-type dispatch・preview・events 不変）

## Scope / 後続
- **email-card は defer**（real email result producer 出現まで、docstring に記載）。
- **Phase 3**（defer）: LLM-generated viewer template、#393 と調整。
- P7 非該当: registry は TUI-internal。

## Tier self-check
Tier 2（pure-fn 戻り値 + Console capture で card 内容 assert、private-state 不参照、format-pin なし、docstring 各行 `Tier 2:` 宣言）。dispatch + shape-sniff precision の両 seam を falsification で実証。

## Test plan
- [x] ruff / tier-audit 22/22 exit 0 / 22 test pass
- [x] falsification 2 軸（dispatch 除去 + sniff 1-field 化 → 各 test FAIL → 復元）
- [x] precision: partial shape / lone title → None（false-positive 防止を test 化）
- [x] regression smoke 48 passed（既存 dispatch・preview・events 不変）
- [x] stacked base = #1377 branch（同 file registry 拡張、2b merge 後 main auto-retarget）
- [ ] (skipped — pure + content-assert + precision falsification で behavior pin 済) 実機で web fetch（HTML page）→ events tab preview で page-summary card、別 shape result で YAML fallback を目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
