### PR TITLE
fix(D6): recover LLM JSON with invalid backslash-escapes (envelope robustness)

### DIFF
--- a/src/reyn/llm/json_parse.py
+++ b/src/reyn/llm/json_parse.py
@@ -13,6 +13,58 @@ def _repair_trailing_commas(text: str) -> str:
     return _TRAILING_COMMA_RE.sub(r"\1", text)
 
 
+# Valid JSON string escape characters following a backslash (RFC 8259):
+# \" \\ \/ \b \f \n \r \t \uXXXX. Anything else is an invalid escape.
+_VALID_ESCAPE_CHARS = '"\\/bfnrtu'
+
+
+def _escape_invalid_backslashes(text: str) -> str:
+    """Escape lone backslashes inside JSON strings that aren't valid escapes.
+
+    LLMs frequently emit a bare ``\\`` inside a free-text string value — a regex
+    (``\\d``), a Windows path (``C:\\Users``), a LaTeX/diff snippet — which is an
+    invalid JSON escape and makes ``json.loads`` reject the whole (otherwise
+    valid) object. This walks the text tracking in-string state and consumes
+    escapes **pairwise**: a valid escape (``\\\\``, ``\\n``, ``\\uXXXX`` …) is
+    kept as-is, a lone ``\\`` before any other char is doubled to ``\\\\``.
+
+    Pairwise consumption is what makes an already-valid ``\\\\d`` (escaped
+    backslash + ``d``) survive unchanged — a naive regex that doubles every
+    "backslash not followed by an escape char" would corrupt it. ``\\uXXXX``
+    with non-hex digits is left untouched (rare; out of scope — it still raises).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        c = text[i]
+        if not in_string:
+            if c == '"':
+                in_string = True
+            out.append(c)
+            i += 1
+        elif c == '"':
+            in_string = False
+            out.append(c)
+            i += 1
+        elif c == "\\":
+            nxt = text[i + 1] if i + 1 < n else ""
+            if nxt in _VALID_ESCAPE_CHARS:
+                # Valid escape — keep the pair intact (this preserves \\, \n, …).
+                out.append(c)
+                out.append(nxt)
+                i += 2
+            else:
+                # Lone/invalid backslash — escape it so the string stays valid.
+                out.append("\\\\")
+                i += 1
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
 def loads_lenient(
     text: str,
     *,
@@ -22,16 +74,19 @@ def loads_lenient(
 
     Tier 1: strict json.loads.
     Tier 2: trailing-comma repair, then json.loads.
-    Tier 3: json.JSONDecoder().raw_decode() — extracts the leading
-            complete JSON value and discards trailing garbage (the
-            13977 failure: a valid object followed by extra data).
+    Tier 3: invalid-backslash-escape repair (+ trailing-comma), then
+            json.loads (the 13453 failure: a bare ``\\`` in a free-text
+            value — regex / path / diff snippet — breaking the escape).
+    Tier 4: json.JSONDecoder().raw_decode() on the repaired text —
+            extracts the leading complete JSON value and discards trailing
+            garbage (the 13977 failure: a valid object followed by extra data).
 
-    ``on_raw_decode(discarded_len, head)`` is invoked when Tier 3 fires
+    ``on_raw_decode(discarded_len, head)`` is invoked when Tier 4 fires
     (= observability; never silent-recover). ``discarded_len`` is the
     byte length of the discarded trailing portion; ``head`` is the first
     ~80 chars of the discarded portion for log context.
 
-    Raises json.JSONDecodeError when even Tier 3 cannot extract a
+    Raises json.JSONDecodeError when even Tier 4 cannot extract a
     leading value (= genuinely malformed from the first char).
     """
     try:
@@ -44,10 +99,17 @@ def loads_lenient(
     except json.JSONDecodeError:
         pass
 
-    # Tier 3: raw_decode the leading value, discard trailing garbage.
-    # raw_decode requires the value to start at index 0, so strip leading
-    # whitespace (json.loads already handles this for tiers 1 and 2).
-    stripped = text.lstrip()
+    # Tier 3: escape lone backslashes in strings (+ trailing-comma), then parse.
+    repaired = _escape_invalid_backslashes(_repair_trailing_commas(text))
+    try:
+        return json.loads(repaired)
+    except json.JSONDecodeError:
+        pass
+
+    # Tier 4: raw_decode the leading value of the repaired text, discard trailing
+    # garbage. raw_decode requires the value to start at index 0, so strip leading
+    # whitespace (json.loads already handles this for tiers 1–3).
+    stripped = repaired.lstrip()
     obj, end = json.JSONDecoder().raw_decode(stripped)
     # raw_decode raises JSONDecodeError itself if the leading value is
     # malformed — that propagates, preserving the "genuinely malformed" contract.

--- a/tests/test_llm_json_decode_capture_1135.py
+++ b/tests/test_llm_json_decode_capture_1135.py
@@ -83,9 +83,10 @@ async def test_call_llm_emits_json_decode_failed_event(monkeypatch) -> None:
     """Tier 2: a JSON-decode failure in call_llm emits llm_output_json_decode_failed with the raw.
 
     Drives the real call_llm path; litellm.acompletion is a real async stub
-    returning content with an invalid `\\q` escape (unparseable after repair).
-    Asserts the additive event fires with failure_kind + error + raw_output, and
-    that the run still raises (behavior preserved).
+    returning genuinely malformed JSON (an unclosed object) — unrecoverable by
+    every lenient tier including the D6 invalid-escape repair, so the failure
+    path still fires. Asserts the additive event fires with failure_kind + error
+    + raw_output, and that the run still raises (behavior preserved).
     """
     import litellm
 
@@ -94,7 +95,9 @@ async def test_call_llm_emits_json_decode_failed_event(monkeypatch) -> None:
     from reyn.schemas.models import ContextFrame
     from reyn.testing.replay import REPLAY_DATETIME
 
-    bad = '{"type": "act", "ops": [{"path": "x\\q"}]}'  # invalid \q escape → JSONDecodeError
+    # Unclosed object (missing final `}`): genuinely malformed, so neither the
+    # escape-repair (D6) nor raw_decode can recover a complete leading value.
+    bad = '{"type": "act", "ops": [{"path": "x"}]'  # unclosed → JSONDecodeError
     monkeypatch.setattr(litellm, "acompletion", _ScriptedBadJSON(bad))
 
     events = EventLog()

--- a/tests/test_llm_json_loads_lenient.py
+++ b/tests/test_llm_json_loads_lenient.py
@@ -124,6 +124,72 @@ class TestGenuinelyMalformedRaises:
             loads_lenient('{"a": 1')
 
 
+class TestInvalidEscapeRepair:
+    def test_lone_backslash_invalid_escape_recovers(self):
+        """Tier 2: a bare backslash (invalid JSON escape) in a string value is repaired (D6/13453)."""
+        invalid = '{"v": "a\\db"}'  # JSON source: single backslash before d = invalid escape
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(invalid)
+        assert loads_lenient(invalid) == {"v": "a\\db"}  # value = a, backslash, d, b
+
+    def test_valid_escaped_backslash_unchanged(self):
+        """Tier 2: an already-valid escaped backslash (\\\\d) is NOT corrupted — decisive falsification."""
+        valid = '{"v": "a\\\\db"}'  # JSON source: a\\db (escaped backslash) = value a\db
+        assert loads_lenient(valid) == json.loads(valid)
+        assert loads_lenient(valid) == {"v": "a\\db"}
+
+    def test_regex_in_reason_summary_recovers(self):
+        """Tier 2: the 13453 pattern — a regex backslash in a free-text reason.summary — parses."""
+        invalid = '{"control": {"reason": {"summary": "the \\d+ pattern matched"}}}'
+        result = loads_lenient(invalid)
+        assert result["control"]["reason"]["summary"] == "the \\d+ pattern matched"
+
+    def test_multiple_invalid_escapes_in_one_string(self):
+        """Tier 2: several lone backslashes in one value all get repaired."""
+        invalid = '{"v": "\\d and \\w and \\s"}'
+        assert loads_lenient(invalid) == {"v": "\\d and \\w and \\s"}
+
+    def test_valid_escapes_preserved(self):
+        """Tier 2: valid escapes (\\n \\t \\" \\uXXXX) survive the repair pass unchanged."""
+        valid = '{"a": "line1\\nline2\\ttab", "b": "quote\\"here", "c": "\\u00e9"}'
+        assert loads_lenient(valid) == json.loads(valid)
+
+    def test_invalid_escape_does_not_fire_raw_decode_callback(self):
+        """Tier 2: escape-repair (Tier 3) does NOT fire on_raw_decode — that is Tier 4 only."""
+        calls: list = []
+        loads_lenient('{"v": "a\\db"}', on_raw_decode=lambda n, h: calls.append(n))
+        assert calls == []
+
+    def test_combined_invalid_escape_and_trailing_comma(self):
+        """Tier 2: a value with BOTH an invalid escape and a trailing comma recovers."""
+        text = '{"v": "a\\db",}'
+        assert loads_lenient(text) == {"v": "a\\db"}
+
+    def test_backslash_only_repaired_inside_strings(self):
+        """Tier 2: a valid object whose string holds backslashes parses; structure is untouched."""
+        invalid = '{"k1": "\\path\\here", "k2": [1, 2], "k3": true}'
+        assert loads_lenient(invalid) == {"k1": "\\path\\here", "k2": [1, 2], "k3": True}
+
+    def test_13453_escaped_single_quote_decision_recovers(self):
+        """Tier 2: the real 13453 failure — Python-style \\' escaped single quotes (invalid JSON
+        escape) inside a free-text value break strict parse; the decision still recovers."""
+        # The model wrote ...'AttributeError: \'HTML\' object...' — \' is an invalid JSON escape.
+        # Double-quoted Python string: \\' -> the JSON source bytes \' (backslash + quote).
+        raw = (
+            "{\"type\": \"decide\", "
+            "\"control\": {\"type\": \"transition\", \"next_phase\": \"plan\"}, "
+            "\"artifact\": {\"data\": {\"failure_summary\": "
+            "\"got \\'AttributeError\\' on \\'_set_col_formats\\'\"}}}"
+        )
+        assert "\\'" in raw  # the invalid escape is present in the JSON source
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(raw)
+        obj = loads_lenient(raw)
+        assert obj["type"] == "decide"
+        assert obj["control"]["next_phase"] == "plan"
+        assert "AttributeError" in obj["artifact"]["data"]["failure_summary"]
+
+
 class TestObservabilityOnlyOnTier3:
     def test_callback_not_called_for_tier1(self):
         """Tier 2: callback is never called when Tier 1 (strict) succeeds."""


### PR DESCRIPTION
**[dogfood-coder]** — D6: recover LLM JSON output with invalid backslash-escapes (envelope-layer robustness). Lead design-review **APPROVE + bounded・self-drive** (#1375 issuecomment-4636629504).

## Why (root cause, flow-traced)

Discovered in the swe_bench structural-defect loop (#1375 / #183). Instance **astropy-13453** was killed by `LLM returned invalid JSON after repair and retry. Error: Invalid \escape` — but the raw response was a **structurally valid transition decision** (`{"type":"decide","control":{...next_phase:"plan"}}`); its `reason.summary` / `failure_summary` held Python-style escaped quotes `\'HTML\'` (and similar `\d` / `C:\…` patterns), which are invalid JSON escapes. = **envelope-layer parsing gap, NOT weak-model cognition.**

`loads_lenient` (`json_parse.py`) had tiers strict / trailing-comma / raw_decode — none handle invalid escapes — and `call_llm`'s "repair and retry" is an **LLM re-call** (not programmatic), so a weak model just re-emits the same invalid escape → abort.

## What

Additive **char-level invalid-escape sanitizer** tier in `loads_lenient`: walks the text tracking in-string state, consumes escapes **pairwise** — a valid escape (`\\`, `\n`, `\uXXXX`, …) is kept intact, a lone backslash before any other char is doubled to `\\`. Pairwise consumption is what keeps an already-valid `\\d` (escaped backslash + `d`) from being corrupted — a naive "double every backslash not followed by an escape char" regex would break it.

- General OS-layer: `loads_lenient`'s **two callers** (`llm.py` LLM-output parse + `compaction/engine.py`) both benefit; P7-clean, skill-agnostic.
- **Additive tier** (tiers 1–3 unchanged, fires only on their failure) → regression-safe.
- Forks per design-review: F1 scanner (not regex) / F2 independent tier / F3 malformed `\uXXXX` out-of-scope (documented, still raises).

## Verified

- **real-env smoke**: the actual 13453 raw response (1076 chars, the run-killer) now parses via `loads_lenient` → `type=decide, next_phase=plan, failure_summary intact`; strict `json.loads` still fails with the exact `Invalid \escape: line 18 column 249` (the run's recorded error).
- **Tier-2 falsification** (`test_llm_json_loads_lenient.py`, +9 tests): the decisive `\\d`-not-corrupted pin + valid-escape preservation (`\n`/`\t`/`\"`/`\uXXXX`) + invalid `\d`/regex/multi-escape recovery + combined escape+trailing-comma + the 13453 escaped-single-quote pattern.
- `test_llm_json_decode_capture_1135` retargeted to an **unclosed object** (genuinely unrecoverable by all tiers incl. D6) so the failure-path event (`llm_output_json_decode_failed`) still fires.

## Test plan

- [x] `ruff check` — pass
- [x] `test_tier_audit --strict` — exit 0
- [x] `pytest tests/test_llm_json_loads_lenient.py` — 28 passed (incl. 13453 real-pattern smoke)
- [x] affected callers — `pytest -k "compaction or json_parse or loads_lenient or json_decode"` — 182 passed
- [x] real 13453 raw response parses via loads_lenient (strict still fails)
- [ ] full suite `pytest -n auto` — (local run + CI on this PR)

Note (prediction vs result): this recovers the JSON-escape **structural** failure mode. Whether 13453 then **resolves** is a separate question, measured only after D6 lands + N≥3 re-runs (coordinated with e2e) — not claimed here.

Refs #1375 #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
