### PR TITLE
fix(183/#1375 D2): explore file-candidate scaffolding — pre-grep gold files

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
+++ b/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
@@ -202,3 +202,57 @@ def extract_problem_symbols(data: Mapping[str, Any]) -> list[dict]:
                     "symbol_re": r"def\s+\w*" + re.escape(sym) + r"\w*\s*\(",
                 })
     return out
+
+
+# ── #1375 D2: explore-layer file-candidate scaffolding ──────────────────────
+# The explore phase (weak model) greps/reads to find which files to edit, but
+# misses the gold files (astropy-13398: gold in builtin_frames/*, explore looked
+# at transformations.py / baseframe.py). These two steps pre-grep the problem
+# statement's code-symbols across the repo and surface the strongest candidate
+# files so explore SEES the gold files in context — the explore-layer analogue
+# of the plan region-surfacing (#1366 / D1). Deterministic, P5; explore stays
+# LLM-driven but no longer blind. Uses problem_statement only (NOT test_patch),
+# same legitimate-input basis as D1.
+
+#: how many candidate files to surface (bounded — explore reads its own beyond).
+_MAX_CANDIDATE_FILES = 8
+#: a symbol matching this few files is "specific" — a strong signal even alone
+#: (e.g. an exact method name) — so its match outranks incidental co-occurrence.
+_SPECIFIC_FILE_THRESHOLD = 2
+_SPECIFIC_BONUS = 3.0
+
+
+def extract_explore_symbols(data: Mapping[str, Any]) -> list[dict]:
+    """Return ``[{symbol, symbol_re}, ...]`` for a repo-wide grep — the symbols
+    the iterate step greps across the repo (path is the repo root, a constant in
+    the op, so no per-symbol file here). Empty when no symbol is extractable."""
+    return [
+        {"symbol": s, "symbol_re": re.escape(s)}
+        for s in _rank_symbols(_problem_statement(data))
+    ]
+
+
+def rank_candidate_files(data: Mapping[str, Any]) -> dict:
+    """Rank the repo-grepped files by symbol co-occurrence + specificity into
+    ``_candidate_files`` (write back with ``into: data``).
+
+    Each entry of ``_symbol_files`` is one symbol's ``files_with_matches`` grep
+    result (``{"files": [...]}``). A file scores 1 per matching symbol, plus a
+    bonus when the matching symbol is *specific* (matches <= ``_SPECIFIC_FILE_THRESHOLD``
+    files repo-wide) — so a gold file named by a single exact symbol (e.g.
+    ``itrs_to_observed_mat``) outranks an incidental file matched by several
+    common symbols (lead-coder's co-occurrence + specificity refinement)."""
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    results = inner.get("_symbol_files") or []
+
+    scores: dict[str, float] = {}
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        files = [f for f in (r.get("files") or []) if isinstance(f, str) and f]
+        weight = 1.0 + (_SPECIFIC_BONUS if 1 <= len(files) <= _SPECIFIC_FILE_THRESHOLD else 0.0)
+        for f in files:
+            scores[f] = scores.get(f, 0.0) + weight
+
+    ranked = sorted(scores, key=lambda f: (-scores[f], f))[:_MAX_CANDIDATE_FILES]
+    return {**inner, "_candidate_files": ranked}

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -6,6 +6,45 @@ role: analyst
 model_class: standard
 allowed_ops: [read_file, write_file, edit_file, delete_file, glob_files, grep_files, sandboxed_exec]
 max_act_turns: 20
+# #1375 D2 — deterministic file-candidate scaffolding (explore-layer analogue of
+# the plan region-surfacing #1366). BEFORE the LLM enters this phase, the OS
+# pre-greps the problem_statement's code-symbols across the repo and surfaces the
+# strongest candidate files (ranked by symbol co-occurrence + specificity) into
+# `_candidate_files`, so the weak explore model SEES the gold files in context
+# instead of missing them (astropy-13398: gold in builtin_frames/* that explore
+# overlooked). Deterministic (P5), never LLM-mutated. `extract_explore_symbols`
+# yields the symbols; the iterate greps each across the repo (files_with_matches);
+# `rank_candidate_files` ranks the matched files.
+preprocessor:
+  - type: python
+    module: ./extract_problem_symbols.py
+    function: extract_explore_symbols
+    mode: safe
+    into: data._explore_symbols
+    output_schema:
+      type: array
+  - type: iterate
+    over: data._explore_symbols
+    apply:
+      type: run_op
+      op:
+        kind: file
+        op: grep
+        path: "."
+        pattern: "__placeholder__"
+        output_mode: files_with_matches
+      args_from:
+        pattern: "_iter.item.symbol_re"
+      on_error: skip
+    into: data._symbol_files
+    on_error: skip
+  - type: python
+    module: ./extract_problem_symbols.py
+    function: rank_candidate_files
+    mode: safe
+    into: data
+    output_schema:
+      type: object
 ---
 
 Understand the problem by reading the `problem_statement` and finding the
@@ -42,6 +81,19 @@ cannot find them, recheck the prompt's input-artifact block before aborting.
 Read `data.problem_statement` from the input artifact. This is the GitHub
 issue text describing the bug to fix. If `data.hints_text` is non-empty,
 use it as additional guidance for where to look.
+
+## Step 1.5 — Start from the pre-fetched candidate files
+
+The OS has already grepped the problem statement's code-symbols across the repo
+and placed the strongest candidate files into `data._candidate_files` (ranked by
+how many problem-symbols they contain, with rare/specific symbols weighted
+higher). These are the files most likely to contain the bug — **read these
+first** and treat them as the leading candidates for `relevant_files`. They are
+deterministically derived, so a file here is a real match, not a guess.
+
+`_candidate_files` is a starting point, not a limit: if the problem statement
+points elsewhere, still follow it (Step 2). When `_candidate_files` is empty
+(the problem statement named no greppable symbols), fall back to Step 2 grep.
 
 ## Step 2 — Locate relevant code with grep
 

--- a/src/reyn/stdlib/skills/swe_bench/skill.md
+++ b/src/reyn/stdlib/skills/swe_bench/skill.md
@@ -83,6 +83,18 @@ permissions:
       function: extract_problem_symbols
       mode: safe
       timeout: 5
+    # #1375 D2: explore-layer file-candidate scaffolding — extract problem-symbols
+    # then (after a repo-wide iterate-grep) rank the matched files by symbol
+    # co-occurrence + specificity so explore sees the gold files. Mode: safe —
+    # uses only re + json (PURE_STDLIB_ALLOWLIST), pure data transforms.
+    - module: ./extract_problem_symbols.py
+      function: extract_explore_symbols
+      mode: safe
+      timeout: 5
+    - module: ./extract_problem_symbols.py
+      function: rank_candidate_files
+      mode: safe
+      timeout: 5
     # #1366 follow-up: bounds the plan-time region volume (drops no-match +
     # too-generic high-count regions, caps total) so a common symbol's giant grep
     # result cannot bloat the plan context. Mode: safe — pure data transform.

--- a/tests/test_explore_candidate_files_1375.py
+++ b/tests/test_explore_candidate_files_1375.py
@@ -1,0 +1,146 @@
+"""Tier 2: OS/skill invariant — #1375 D2 explore file-candidate scaffolding.
+
+The explore phase (weak model) misses the gold files (astropy-13398: gold in
+builtin_frames/* that explore overlooked). The D2 preprocessor pre-greps the
+problem statement's code-symbols across the repo and surfaces the strongest
+candidate files into ``_candidate_files`` (ranked by symbol co-occurrence +
+specificity), so explore SEES the gold files. Explore-layer analogue of the plan
+region-surfacing (#1366).
+
+Pins:
+  - ``extract_explore_symbols`` yields the problem-statement code-symbols;
+  - ``rank_candidate_files`` ranks by co-occurrence AND specificity — a file named
+    by a single RARE symbol (an exact method name) outranks an incidental file
+    matched by several COMMON symbols (lead-coder's refinement);
+  - the real explore preprocessor (real Workspace + skill + op_runtime grep)
+    surfaces the gold file into ``_candidate_files``.
+
+Real Workspace + real skill loaded from disk + real grep; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from reyn.compiler.loader import load_dsl_skill
+from reyn.events.events import EventLog
+from reyn.kernel.preprocessor_executor import PreprocessorExecutor
+from reyn.permissions.permissions import PermissionResolver
+from reyn.sandbox import NoopBackend
+from reyn.workspace.workspace import Workspace
+
+SWE_BENCH_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "reyn" / "stdlib" / "skills" / "swe_bench"
+)
+
+
+def _fns():
+    sys.path.insert(0, str(SWE_BENCH_DIR))
+    try:
+        from extract_problem_symbols import (
+            extract_explore_symbols,
+            rank_candidate_files,
+        )
+    finally:
+        sys.path.pop(0)
+    return extract_explore_symbols, rank_candidate_files
+
+
+def test_extract_explore_symbols_yields_problem_symbols() -> None:
+    """Tier 2: extract_explore_symbols returns the problem-statement code-symbols."""
+    extract_explore_symbols, _ = _fns()
+    syms = extract_explore_symbols(
+        {"data": {"problem_statement": "the `rotation_matrix` and `itrs_to_observed_mat` are wrong"}}
+    )
+    names = {s["symbol"] for s in syms}
+    assert "rotation_matrix" in names and "itrs_to_observed_mat" in names
+    for s in syms:  # each carries a regex-escaped pattern for the grep
+        assert "symbol_re" in s
+
+
+def test_rank_specificity_beats_incidental_cooccurrence() -> None:
+    """Tier 2: a gold file named by a single RARE symbol outranks an incidental
+    file matched by several COMMON symbols (co-occurrence + specificity).
+
+    This is the astropy-13398 shape: `itrs_to_observed_mat` (exact gold method)
+    matches only the gold file, while common symbols match many decoys.
+    """
+    _, rank_candidate_files = _fns()
+    gold = "astropy/coordinates/builtin_frames/itrs_observed_transforms.py"
+    symbol_files = [
+        {"files": [gold]},                         # a SPECIFIC symbol → 1 file (gold)
+        {"files": ["x.py", "y.py", "z.py", "w.py"]},  # a COMMON symbol → 4 decoys
+        {"files": ["x.py", "y.py", "z.py", "w.py"]},  # another COMMON symbol → same decoys
+    ]
+    out = rank_candidate_files({"data": {"_symbol_files": symbol_files}})
+    assert out["_candidate_files"][0] == gold, (
+        f"the specific-symbol gold file must rank first, got {out['_candidate_files']}"
+    )
+
+
+def test_rank_cooccurrence_orders_multi_symbol_files() -> None:
+    """Tier 2: among equally-(non)specific files, more symbol co-occurrence ranks higher."""
+    _, rank_candidate_files = _fns()
+    # all symbols are common (match 3 files) so no specificity bonus; the file
+    # matched by MORE symbols (co-occurrence) wins.
+    symbol_files = [
+        {"files": ["a.py", "b.py", "c.py"]},
+        {"files": ["a.py", "d.py", "e.py"]},
+        {"files": ["a.py", "f.py", "g.py"]},
+    ]
+    out = rank_candidate_files({"data": {"_symbol_files": symbol_files}})
+    assert out["_candidate_files"][0] == "a.py", out["_candidate_files"]
+
+
+def test_rank_empty_when_no_symbol_files() -> None:
+    """Tier 2: no _symbol_files → empty _candidate_files (graceful; explore greps)."""
+    _, rank_candidate_files = _fns()
+    assert rank_candidate_files({"data": {}})["_candidate_files"] == []
+
+
+def test_explore_preprocessor_surfaces_gold_candidate(tmp_path: Path) -> None:
+    """Tier 2: the REAL explore preprocessor (real grep over a tmp repo) surfaces
+    the gold file — named by a specific symbol — at the top of _candidate_files,
+    above decoys named by common symbols.
+    """
+    skill = load_dsl_skill(SWE_BENCH_DIR / "skill.md")
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={"python.safe": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    ws = Workspace(events=events, base_dir=tmp_path, permission_resolver=resolver)
+    # gold file: contains the rare/specific method name; decoys: only a common word
+    ws.write_file("pkg/builtin/gold.py", "def itrs_to_observed_mat(self):\n    return rotation_matrix\n")
+    ws.write_file("pkg/decoy1.py", "rotation_matrix = 1\n")
+    ws.write_file("pkg/decoy2.py", "rotation_matrix = 2\n")
+    ws.write_file("pkg/decoy3.py", "rotation_matrix = 3\n")
+
+    artifact = {
+        "type": "swe_bench_input",
+        "data": {
+            "instance_id": "x__y-1",
+            "problem_statement": "the `itrs_to_observed_mat` transform using `rotation_matrix` is wrong",
+        },
+    }
+    executor = PreprocessorExecutor(
+        skill=skill,
+        workspace=ws,
+        model="standard",
+        events=events,
+        subscribers=[],
+        resolver=None,
+        permission_resolver=resolver,
+        sandbox_backend=NoopBackend(),
+    )
+    result, _usage = asyncio.run(
+        executor.run(skill.phases["explore"], artifact, output_language=None)
+    )
+    candidates = result["data"].get("_candidate_files") or []
+    assert candidates, "explore preprocessor produced no _candidate_files"
+    assert candidates[0].endswith("gold.py"), (
+        f"the gold file (specific symbol itrs_to_observed_mat) must rank first; got {candidates}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1375 D2 (design-reviewed + approved by lead-coder). Explore-layer analogue of the plan region-surfacing (#1366/D1).

## Defect (primary-evidence, #1375 D2)
The explore phase (weak model) misses the gold files (astropy-13398: gold in `builtin_frames/*` — explore looked at `transformations.py`/`baseframe.py`/`matrix_utilities.py`, **0 overlap**; the plan then anchored a method in an unexplored file → not_locatable → empty patch).

## Fix
An explore preprocessor deterministically pre-greps the problem_statement's code-symbols across the repo and surfaces the strongest candidate files into `_candidate_files` so the weak explore model SEES the gold files in context.
- `extract_explore_symbols` — problem-statement code-symbols (reuses D1 `_rank_symbols`; problem_statement only, NOT test_patch — same leakage basis).
- iterate-grep each symbol across the repo (`files_with_matches`).
- `rank_candidate_files` — rank by symbol co-occurrence + **specificity** (a file named by a single rare symbol outranks an incidental file matched by several common symbols — lead-coder's refinement). Bounded to top-N.
- `explore.md` Step 1.5: "read these candidate files first" (scaffolding, not a limit; empty → fall back to own grep).

## Verified (real enforcement docker env, astropy-13398)
**Measured WIN** — explore went from wrong-directory/0-gold to:
- `relevant_files` now in the right directory (`builtin_frames/`) and **found a gold file (`builtin_frames/itrs.py`)**; produced a **12776-char patch** (vs old empty/replan-loop).
- The directory foothold worked: explore used `_candidate_files` (incl. `builtin_frames/__init__.py`) as a starting point and navigated to the gold area.

## Honest scope boundary (measured → tracked as a SEPARATE defect D7, NOT in this PR)
D2 helps when the problem names **existing** code symbols (the 13453-class: `formats`/`write` exist → gold surfaced). It does **not** surface files when the problem names symbols the patch **adds** (astropy-13398's exact gold method `itrs_to_observed_mat` matches **0 files** repo-wide — it's added by the fix → ungreppable; the specific gold transform files weren't in `_candidate_files`). New-symbol file-finding needs a non-symbol source (traceback frames / error-strings / import-graph) — a distinct, single-responsibility defect (D7), filed in #1375, not bolted onto D2.

## Test plan
- [x] `pytest tests/test_explore_candidate_files_1375.py` — 5 passed: specificity beats incidental co-occurrence; co-occurrence orders multi-symbol files; empty graceful; the **real** explore preprocessor (real grep over a tmp repo) surfaces the gold file at top of `_candidate_files`.
- [x] `ruff check` + `test_tier_audit.py --strict` — clean.
- [x] Real enforcement-env astropy-13398: explore reaches `builtin_frames/`, finds gold `itrs.py`, produces a patch (measured win); scope boundary (new-symbol) documented as D7.

Efficacy at the resolve level is for the cleaner N≥3 re-run after D6 (confound) + D2 land — not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)