### PR TITLE
fix(183/#1375 D8+D9): region scaffolding on re-plan + candidate hygiene

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
+++ b/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
@@ -229,6 +229,29 @@ def extract_problem_symbols(data: Mapping[str, Any]) -> list[dict]:
 
 #: how many candidate files to surface (bounded — explore reads its own beyond).
 _MAX_CANDIDATE_FILES = 8
+#: #1375 D9 — the repo-wide grep matches the WHOLE tree including .git/ (binary
+#: pack files) and other non-source paths; surfacing those as candidates is noise
+#: and an unreadable .git pack as a "candidate" can make the explore model abort
+#: ("input artifact could not be read"). Drop non-source paths from candidates.
+#: excluded by EXACT path-component match (not substring) so a real source path
+#: like ``astropy/_build_utils/x.py`` is NOT false-dropped by ``build``.
+_NON_SOURCE_DIRS = frozenset({
+    ".git", ".tox", ".eggs", "node_modules", "build", "dist",
+    ".mypy_cache", "__pycache__", ".pytest_cache",
+})
+_NON_SOURCE_SUFFIXES = (".pack", ".idx", ".pyc", ".pyo", ".so", ".o", ".png",
+                        ".jpg", ".jpeg", ".gif", ".pdf", ".zip", ".gz")
+
+
+def _is_source_candidate(path: str) -> bool:
+    """True when ``path`` is a plausible source file (not .git/binary/cache).
+
+    Directory exclusion is by EXACT path component (``build`` matches a ``build/``
+    dir but not ``_build_utils/``), so real source files are never false-dropped.
+    """
+    if any(part in _NON_SOURCE_DIRS for part in path.split("/")):
+        return False
+    return not path.lower().endswith(_NON_SOURCE_SUFFIXES)
 #: a symbol matching this few files is "specific" — a strong signal even alone
 #: (e.g. an exact method name) — so its match outranks incidental co-occurrence.
 _SPECIFIC_FILE_THRESHOLD = 2
@@ -262,7 +285,10 @@ def rank_candidate_files(data: Mapping[str, Any]) -> dict:
     for r in results:
         if not isinstance(r, dict):
             continue
-        files = [f for f in (r.get("files") or []) if isinstance(f, str) and f]
+        files = [
+            f for f in (r.get("files") or [])
+            if isinstance(f, str) and f and _is_source_candidate(f)  # D9: drop .git/binary
+        ]
         weight = 1.0 + (_SPECIFIC_BONUS if 1 <= len(files) <= _SPECIFIC_FILE_THRESHOLD else 0.0)
         for f in files:
             scores[f] = scores.get(f, 0.0) + weight

--- a/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
+++ b/src/reyn/stdlib/skills/swe_bench/extract_problem_symbols.py
@@ -117,10 +117,23 @@ def _problem_statement(data: Mapping[str, Any]) -> str:
 
 
 def _relevant_files(data: Mapping[str, Any]) -> list[str]:
-    """Read ``relevant_files`` from the exploration input (inner data dict, with
-    a flat fallback for unit tests injecting the inner data directly)."""
+    """Read the files to region-surface: ``relevant_files`` from the exploration
+    input, else (#1375 D8) the re-derived ``_candidate_files``.
+
+    On a re-plan the plan input is ``verify_state``, which has NO
+    ``relevant_files`` (only the explore-phase output carries them). Without a
+    fallback, the region-surfacing produces 0 regions on EVERY re-plan — the model
+    flies blind through the whole verify→plan revision loop (astropy-13453: 13 of
+    14 plan iterations had no regions). D8 re-derives candidate files
+    deterministically from the problem_statement (the D2 explore-scaffolding repo
+    grep, run as preprocessor steps before this) into ``_candidate_files``, so the
+    re-plan gets the same gold-region scaffolding as the first plan."""
     inner = data.get("data") if isinstance(data.get("data"), dict) else data
-    files = inner.get("relevant_files") if isinstance(inner, dict) else None
+    if not isinstance(inner, dict):
+        return []
+    files = inner.get("relevant_files")
+    if not isinstance(files, list) or not files:
+        files = inner.get("_candidate_files")  # D8: re-derived fallback (re-plan)
     if isinstance(files, list):
         return [f for f in files if isinstance(f, str) and f]
     return []

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -16,7 +16,46 @@ max_act_turns: 15
 # root cause, surfaced one layer up). Deterministic (P5), never LLM-mutated.
 # `extract_problem_symbols` returns [{file, symbol, symbol_re}] (cartesian of
 # relevant_files x symbols); the iterate step greps each into `_plan_regions`.
+# #1375 D8 — re-derive candidate files on re-plan. A re-plan's input is
+# `verify_state`, which has NO `relevant_files` (only explore's output carries
+# them), so the region scaffolding below produced 0 regions on EVERY re-plan and
+# the model flew blind through the whole verify→plan revision loop (astropy-13453:
+# 13/14 plan iterations had no regions). These first 3 steps re-derive candidate
+# files deterministically from the problem_statement (the same D2 explore repo
+# grep): extract symbols -> grep each across the repo (files_with_matches) -> rank
+# by co-occurrence+specificity into `_candidate_files`. `extract_problem_symbols`
+# then uses `relevant_files` (first plan) OR `_candidate_files` (re-plan), so a
+# re-plan gets the same gold-region scaffolding as the first plan.
 preprocessor:
+  - type: python
+    module: ./extract_problem_symbols.py
+    function: extract_explore_symbols
+    mode: safe
+    into: data._explore_symbols
+    output_schema:
+      type: array
+  - type: iterate
+    over: data._explore_symbols
+    apply:
+      type: run_op
+      op:
+        kind: file
+        op: grep
+        path: "."
+        pattern: "__placeholder__"
+        output_mode: files_with_matches
+      args_from:
+        pattern: "_iter.item.symbol_re"
+      on_error: skip
+    into: data._symbol_files
+    on_error: skip
+  - type: python
+    module: ./extract_problem_symbols.py
+    function: rank_candidate_files
+    mode: safe
+    into: data
+    output_schema:
+      type: object
   - type: python
     module: ./extract_problem_symbols.py
     function: extract_problem_symbols

--- a/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
+++ b/src/reyn/stdlib/skills/swe_bench/prune_plan_regions.py
@@ -103,7 +103,17 @@ def prune_plan_regions(data: Mapping[str, Any]) -> dict:
         total += size
         kept.append(region)
 
-    return {**inner, "_plan_regions": kept}
+    # #1375 D8: drop the plan-time intermediates so the plan model's context
+    # carries only the final `_plan_regions` (the anchor-grounding material).
+    # `_explore_symbols` / `_symbol_files` / `_candidate_files` / `_plan_symbols`
+    # are scaffolding the preprocessor used to BUILD the regions (and on the first
+    # plan `_candidate_files` is computed but unused); leaving them in context is
+    # noise for the plan model.
+    pruned = {k: v for k, v in inner.items()
+              if k not in ("_explore_symbols", "_symbol_files",
+                           "_candidate_files", "_plan_symbols")}
+    pruned["_plan_regions"] = kept
+    return pruned
 
 
 def _match_line(m: Any) -> int | None:

--- a/tests/test_explore_candidate_files_1375.py
+++ b/tests/test_explore_candidate_files_1375.py
@@ -144,3 +144,27 @@ def test_explore_preprocessor_surfaces_gold_candidate(tmp_path: Path) -> None:
     assert candidates[0].endswith("gold.py"), (
         f"the gold file (specific symbol itrs_to_observed_mat) must rank first; got {candidates}"
     )
+
+
+def test_rank_excludes_git_and_binary_candidates() -> None:
+    """Tier 2: #1375 D9 — the repo-wide grep matches .git/ (binary pack files) and
+    other non-source paths; those must be dropped from _candidate_files (an
+    unreadable .git pack as a candidate made the explore model abort)."""
+    _, rank_candidate_files = _fns()
+    symbol_files = [
+        {"files": [
+            ".git/objects/pack/pack-abc.pack",   # binary git pack — drop
+            "astropy/io/ascii/html.py",          # source — keep
+            "astropy/_build_utils/helper.py",     # source ('build' is a SUBSTRING,
+                                                  # not a path component) — KEEP
+            "build/lib/x.py",                     # build/ dir component — drop
+            "docs/_static/logo.png",              # binary — drop
+            "__pycache__/mod.cpython-311.pyc",    # cache — drop
+        ]},
+    ]
+    out = rank_candidate_files({"data": {"_symbol_files": symbol_files}})
+    cands = set(out["_candidate_files"])
+    assert cands == {"astropy/io/ascii/html.py", "astropy/_build_utils/helper.py"}, (
+        f"only source survives, and a 'build' SUBSTRING (not component) is not "
+        f"false-dropped: {cands}"
+    )

--- a/tests/test_plan_region_scaffold_1366.py
+++ b/tests/test_plan_region_scaffold_1366.py
@@ -418,11 +418,15 @@ def test_replan_rederives_regions_without_relevant_files(tmp_path: Path) -> None
         tmp_path, "pkg/mod.py", _big_body(target),
         problem_statement="The `render_special` method drops formatting. Fix it.",
     )
-    # candidate files were re-derived (no relevant_files on the verify_state input)
-    assert data.get("_candidate_files"), "D8 must re-derive _candidate_files on re-plan"
+    # _plan_regions>0 on a verify_state input (which has NO relevant_files) can
+    # only happen via re-derived candidates — that IS the D8 evidence.
     blob = str(data.get("_plan_regions") or [])
     assert "REPLAN-TARGET-XYZ" in blob, (
         "on a re-plan, the target region must be re-derived + surfaced (was 0 before D8)"
+    )
+    # the plan-time intermediates are stripped — only _plan_regions reaches the model
+    assert "_candidate_files" not in data and "_symbol_files" not in data, (
+        "plan intermediates must be stripped from the model context"
     )
 
 

--- a/tests/test_plan_region_scaffold_1366.py
+++ b/tests/test_plan_region_scaffold_1366.py
@@ -364,3 +364,76 @@ def test_plan_preprocessor_absent_symbol_yields_no_fabricated_region(tmp_path: P
         assert r.get("count", 0) == 0 or not r.get("matches"), (
             "a symbol absent from the file must not yield a fabricated region"
         )
+
+
+def _run_plan_preprocessor_replan(
+    tmp_path: Path, file_path: str, file_body: str, problem_statement: str
+) -> dict:
+    """Run the plan preprocessor on a RE-PLAN input (``verify_state``, which has
+    NO ``relevant_files``) — D8 must re-derive candidate files from the repo."""
+    skill = load_dsl_skill(SWE_BENCH_DIR / "skill.md")
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={"python.safe": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+    ws = Workspace(events=events, base_dir=tmp_path, permission_resolver=resolver)
+    ws.write_file(file_path, file_body)
+    # verify_state: the re-plan input — note NO relevant_files
+    artifact = {
+        "type": "verify_state",
+        "data": {
+            "instance_id": "x__y-1",
+            "tests_passed": False,
+            "attempt": 2,
+            "failure_summary": "the fix did not work",
+        },
+    }
+    skill_input = {
+        "type": "swe_bench_input",
+        "data": {"instance_id": "x__y-1", "problem_statement": problem_statement},
+    }
+    executor = PreprocessorExecutor(
+        skill=skill, workspace=ws, model="standard", events=events, subscribers=[],
+        resolver=None, permission_resolver=resolver, sandbox_backend=NoopBackend(),
+    )
+    result, _usage = asyncio.run(
+        executor.run(skill.phases["plan"], artifact, output_language=None, skill_input=skill_input)
+    )
+    return result["data"]
+
+
+def test_replan_rederives_regions_without_relevant_files(tmp_path: Path) -> None:
+    """Tier 2: #1375 D8 — on a re-plan (verify_state, no relevant_files) the plan
+    preprocessor RE-DERIVES candidate files from the problem_statement (repo grep)
+    and still surfaces the target region into _plan_regions.
+
+    Before D8, a verify_state input gave extract_problem_symbols 0 files -> 0
+    regions on EVERY re-plan (astropy-13453: 13/14 plan iterations blind). The
+    re-derive (D2 mechanism) restores the scaffolding.
+    """
+    target = "    def render_special(self, col):  # REPLAN-TARGET-XYZ"
+    data = _run_plan_preprocessor_replan(
+        tmp_path, "pkg/mod.py", _big_body(target),
+        problem_statement="The `render_special` method drops formatting. Fix it.",
+    )
+    # candidate files were re-derived (no relevant_files on the verify_state input)
+    assert data.get("_candidate_files"), "D8 must re-derive _candidate_files on re-plan"
+    blob = str(data.get("_plan_regions") or [])
+    assert "REPLAN-TARGET-XYZ" in blob, (
+        "on a re-plan, the target region must be re-derived + surfaced (was 0 before D8)"
+    )
+
+
+def test_replan_no_symbol_yields_empty_graceful(tmp_path: Path) -> None:
+    """Tier 2: D8 falsification — a re-plan whose problem_statement names no
+    greppable symbol re-derives no candidates and surfaces no region (graceful;
+    the model falls back to its own reads), never an error."""
+    data = _run_plan_preprocessor_replan(
+        tmp_path, "pkg/mod.py", _big_body("    x = 1  # ACTUAL"),
+        problem_statement="the behavior is wrong",  # no code symbols
+    )
+    regions = data.get("_plan_regions") or []
+    for r in regions:
+        assert r.get("count", 0) == 0 or not r.get("matches")


### PR DESCRIPTION
**[e2e-coder]** — #1375 D8 (+D9, +strip), design-reviewed + approved by lead-coder. Highest-ROI fix this cycle: amplifies the already-landed D1+D2 across the whole re-plan loop.

## D8 — re-derive region scaffolding on re-plan (HIGH)
**Defect** (primary-evidence, cleaner re-run, sandbox_2 symptom + my root): D1/D2 scaffolding was silently disabled on every re-plan. A re-plan's plan input is `verify_state`, which has **no `relevant_files`** → `extract_problem_symbols` got 0 files → `_plan_regions=0` on EVERY re-plan. astropy-13453: v01 (exploration) had `_plan_regions=3`, **v02–v013 (13 re-plans) all 0** — the model flew blind through the whole verify→plan revision loop, exactly when fixing a failed edit. (Reconciled to D8-alone: sandbox_2 confirmed v01 context_built held the 3 regions, so it is purely the re-plan disable.)

**Fix (option B, re-derive — not carry)**: on a `verify_state` re-plan the plan preprocessor re-derives candidate files deterministically from the `problem_statement` via the SAME D2 explore repo-grep, and `extract_problem_symbols` falls back to `_candidate_files` when `relevant_files` is absent. No schema carry, no state-dir access (`problem_statement` is always in `_skill_input`), reuses the landed D2 mechanism, and fixes D2's `_candidate_files`-on-re-plan by the same root.

## D9 — drop .git/binary/non-source from candidate files (HIGH)
The repo-wide grep (`path="."`) matched the WHOLE tree including `.git/objects/pack/*.pack` (binary), `build/`, `__pycache__`. Offering an unreadable `.git` pack as a "candidate" **made the weak explore model abort** ("input artifact could not be read") — measured: 13453 baseline aborted at explore 2/3 rounds + the D8 smoke. `rank_candidate_files` now keeps only plausible source files; directory exclusion is **by exact path component** so a real path like `astropy/_build_utils/x.py` is never false-dropped.

## D8 follow-up — strip plan intermediates
D8 left `_explore_symbols`/`_symbol_files`/`_candidate_files`/`_plan_symbols` in the plan model's context (scaffolding used to build the regions; noise for the model, which needs only `_plan_regions`). `prune_plan_regions` now strips them.

## Verification
- **18 Tier-2** (real Workspace + skill + op_runtime grep, no mocks): D8 re-derive (verify_state input → `_plan_regions>0`, was 0; + intermediates stripped); D9 source-filter (drop .git/binary/cache, **keep `_build_utils/`** falsification); D8 first/re-plan + bounded + proximity + specificity invariants. ruff + tier-audit clean.
- **Real-env smoke (astropy-13453)**: D9 confirmed — the explore-abort is GONE (run reaches plan); D1+D2 first-plan work (v01 `_plan_regions=3`). D8's *re-plan* efficacy is **variance-blocked for a single smoke** (the run aborts before entering the verify→plan loop), so per the variance lesson its real-env efficacy is measured by the **amplified N≥3 re-run** (across 15 runs some 13453 re-plan → `_plan_regions>0` vs baseline 0) — lead-coder-agreed; that re-run is the next step.

## Test plan
- [x] `pytest tests/test_plan_region_scaffold_1366.py tests/test_explore_candidate_files_1375.py` — 18 passed.
- [x] `ruff check` + `test_tier_audit.py --strict` — clean.
- [x] Real-env 13453: D9 explore-abort gone; first-plan regions present. (D8 re-plan efficacy → amplified N≥3 re-run, per the variance-robust method.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)