### PR TITLE
fix(183/#1375 D10): glob returns files only, filtered in-backend (#1384)

### DIFF
--- a/src/reyn/environment/backend.py
+++ b/src/reyn/environment/backend.py
@@ -96,11 +96,19 @@ class EnvironmentBackend(Protocol):
         ...
 
     def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
-        """Expand a glob pattern.
+        """Expand a glob pattern, returning matching FILES only.
 
         When ``root`` is ``None``, ``pattern`` is an absolute pattern matched
         recursively. Otherwise ``pattern`` is matched relative to ``root``.
-        Returns all matches (files AND directories); the caller filters.
+
+        Directories are excluded: each backend filters to files in its own
+        environment, symmetric with :meth:`grep` (#1375 D10). The contract was
+        narrowed from "all matches; caller filters" because a host-side file
+        filter cannot stat a container backend's paths — so the only sound place
+        for the filter is the environment that produced the matches. The sole
+        consumer (``Workspace.glob_files``) wants files only. If a directory
+        glob is ever needed, add a separate path (e.g. ``glob_dirs``) rather than
+        widening this one back to a mixed result.
         """
         ...
 

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -143,13 +143,18 @@ _STAT = (
     "  print(json.dumps({'size':st.st_size,'mtime':st.st_mtime,'ctime':st.st_ctime,"
     "'is_dir':os.path.isdir(p),'is_file':os.path.isfile(p),'mode':oct(st.st_mode & 0o777)}))\n"
 )
+# Returns matching FILES only (directories excluded), filtered in-container —
+# symmetric with _GREP's `f.is_file()` below. The Workspace consumer
+# (glob_files) wants files only, and a host-side filter cannot stat container
+# paths (#1375 D10), so the file-filter must run in the same environment as the
+# match. See backend.glob's Protocol docstring for the contract rationale.
 _GLOB = (
-    "import sys,glob,json,os\n"
+    "import sys,glob,json,os,pathlib\n"
     "pat=sys.argv[1]; root=sys.argv[2]\n"
     "if root:\n"
-    "  import pathlib; res=[str(x) for x in pathlib.Path(root).glob(pat)]\n"
+    "  res=[str(x) for x in pathlib.Path(root).glob(pat) if x.is_file()]\n"
     "else:\n"
-    "  res=glob.glob(pat,recursive=True)\n"
+    "  res=[p for p in glob.glob(pat,recursive=True) if os.path.isfile(p)]\n"
     "print(json.dumps(res))\n"
 )
 # grep: argv = pattern, flags, root, glob_or_'', file_type_or_'', output_mode,

--- a/src/reyn/environment/host_backend.py
+++ b/src/reyn/environment/host_backend.py
@@ -67,11 +67,16 @@ class HostBackend:
         }
 
     def glob(self, pattern: str, *, root: Path | None = None) -> list[Path]:
+        # Files only (directories excluded), symmetric with the container
+        # backend and grep — each backend filters in its own environment so the
+        # Workspace consumer never has to (#1375 D10). In-process this is the
+        # same filesystem the caller would have checked, so it is behaviour-
+        # preserving here; it is the load-bearing filter for the container case.
         if root is None:
             # Absolute pattern (recursive) — matches the legacy abs-path branch.
-            return [Path(p) for p in _glob.glob(pattern, recursive=True)]
+            return [Path(p) for p in _glob.glob(pattern, recursive=True) if Path(p).is_file()]
         # Relative pattern matched under root — matches the legacy rel branch.
-        return list(root.glob(pattern))
+        return [p for p in root.glob(pattern) if p.is_file()]
 
     def grep(
         self,

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -225,20 +225,20 @@ class Workspace:
                     raise PermissionError(
                         f"glob not permitted: {pattern!r} (outside project, no read permission)"
                     )
-            # Filter for files BEFORE applying max_results; otherwise a glob
-            # whose first max_results matches are directories (common at the
-            # project root: .claude, .git, .github, .reyn, .venv, ...) silently
-            # truncates the file list to ~zero.
-            raw = sorted(str(m) for m in self._backend.glob(pattern))
-            files = [m for m in raw if Path(m).is_file()]
+            # The backend returns files only — directories are excluded in the
+            # backend's own environment (#1375 D10), so capping at max_results
+            # here cannot silently truncate the file list to ~zero behind leading
+            # directories. Re-applying a host-side ``is_file()`` filter would be
+            # the D10 bug: it stats a container backend's paths against the host
+            # filesystem (where they do not exist) and drops everything.
+            files = sorted(str(m) for m in self._backend.glob(pattern))
             return files[:max_results]
 
-        # Same fix for the relative-path branch: filter to files first, then
-        # cap at max_results.
+        # Relative-path branch: backend is already files-only (#1375 D10);
+        # relativize and cap.
         ws_matches = sorted(self._backend.glob(pattern, root=self.base_dir))
-        files_only = [m for m in ws_matches if m.is_file()]
         result = []
-        for m in files_only[:max_results]:
+        for m in ws_matches[:max_results]:
             try:
                 result.append(str(m.relative_to(self.base_dir)))
             except ValueError:

--- a/tests/test_glob_files_only_1375_d10.py
+++ b/tests/test_glob_files_only_1375_d10.py
@@ -1,0 +1,84 @@
+"""Tier 2: #1375 D10 — glob returns files only, filtered in the backend.
+
+D10 was a general OS bug: ``EnvironmentBackend.glob`` returned files AND
+directories and the Workspace filtered to files host-side with
+``Path(m).is_file()``. Under the container backend that host-side filter stats
+*container* paths against the *host* filesystem (where they do not exist), so
+every match was dropped and glob returned nothing in-container.
+
+The fix narrows the backend ``glob`` contract to "files only" and moves the
+file-filter into each backend's own environment (symmetric with ``grep``). The
+host path is behaviour-preserving (same filesystem); the container path is
+proven by the faithful in-container re-smoke (no container is faked in a unit —
+see [[feedback_fake_backend_unit_misses_real_integration]]).
+
+This file pins the moved contract on the surface a unit CAN exercise:
+
+  (a) HostBackend.glob excludes directories that match the pattern — the
+      files-only contract that used to live in the caller now lives in the
+      backend (both the relative-root and absolute-recursive branches);
+  (b) Workspace.glob_files returns only files end-to-end, and a directory whose
+      name matches the pattern does not occupy a max_results slot (the
+      leading-directory truncation the old host-side filter guarded against is
+      now guaranteed by construction).
+
+No mocks: real HostBackend / Workspace instances, public surfaces only.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.environment.host_backend import HostBackend
+from reyn.events.events import EventLog
+from reyn.workspace.workspace import Workspace
+
+
+def test_host_backend_glob_relative_excludes_directories(tmp_path: Path) -> None:
+    """Tier 2: relative-root glob returns files only, not matching dirs."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "mod.py").write_text("x = 1\n")
+    (tmp_path / "pkg" / "sub").mkdir()  # a directory matching `pkg/*`
+    (tmp_path / "pkg" / "sub" / "deep.py").write_text("y = 2\n")
+
+    matches = HostBackend().glob("pkg/*", root=tmp_path)
+    names = {p.name for p in matches}
+    assert names == {"mod.py"}, names  # `sub` (a dir) is excluded
+    assert all(p.is_file() for p in matches)
+
+
+def test_host_backend_glob_absolute_excludes_directories(tmp_path: Path) -> None:
+    """Tier 2: absolute recursive glob (root=None) returns files only."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "f.py").write_text("x = 1\n")
+    (tmp_path / "a" / "d").mkdir()  # a directory matched by **/*
+
+    matches = HostBackend().glob(str(tmp_path / "**" / "*"))
+    assert matches, "expected at least the file to match"
+    assert all(p.is_file() for p in matches)
+    assert (tmp_path / "a" / "d") not in matches  # the dir is excluded
+    assert (tmp_path / "a" / "f.py") in matches
+
+
+def test_glob_files_returns_files_only(tmp_path: Path) -> None:
+    """Tier 2: Workspace.glob_files excludes a dir whose name matches."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    (tmp_path / "foo.txt").write_text("hi\n")
+    (tmp_path / "foo_dir").mkdir()  # name matches `foo*` but is a directory
+
+    assert ws.glob_files("foo*") == ["foo.txt"]
+
+
+def test_glob_files_directory_does_not_consume_max_results_slot(tmp_path: Path) -> None:
+    """Tier 2: leading dirs never truncate the file list (now by construction).
+
+    The old host-side filter existed because a glob whose first matches were
+    directories could truncate the file list to ~zero under max_results. With
+    the backend pre-filtering to files, the one file surfaces even when many
+    matching directories sort ahead of it and max_results is tight.
+    """
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    for i in range(5):
+        (tmp_path / f"item_{i}_dir").mkdir()  # 5 dirs sort before the file
+    (tmp_path / "item_z.txt").write_text("payload\n")
+
+    assert ws.glob_files("item_*", max_results=1) == ["item_z.txt"]


### PR DESCRIPTION
**[e2e-coder]** — #1375 D10 OS-fix (closes #1384). General glob-correctness bug surfaced by the #183 weak-model SWE-bench probe; lead-coder design-approved (Option A, single-consumer fork grep-verified).

## Problem
`Workspace.glob_files(...)` returns an empty list under the **docker `EnvironmentBackend`** for any pattern, even with matching files in the container.

**Root**: `backend.glob` returned files **and** directories; `Workspace.glob_files` filtered to files **host-side** with `Path(m).is_file()` (`workspace.py:233,239`). Under the container backend the backend returns *container* paths, and the host-side `is_file()` stats them against the *host* filesystem (where they do not exist) → every match dropped → empty. Asymmetric with `grep`, whose container `_GREP` already filters `f.is_file()` **in-container** (`container_backend.py:162`).

## Fix (4-edit symmetric, lead-approved shape)
Narrow the `backend.glob` contract to **files only**, filtered in each backend's own environment (symmetric with grep, single-responsibility):
1. `_GLOB` script filters `is_file()` in-container (mirror `_GREP`).
2. `HostBackend.glob` filters `is_file()` (behaviour-preserving in-process; load-bearing for the container case).
3. `EnvironmentBackend.glob` Protocol docstring narrowed + rationale (future dir-glob → add `glob_dirs`, do not widen back).
4. `Workspace.glob_files` drops both host-side `is_file()` filters; cap/relativize unchanged.

**Single consumer** of `backend.glob()` = `Workspace.glob_files` (grep-verified by lead-coder: every other `.glob(` hit is raw `pathlib.Path.glob`), so narrowing breaks no caller.

## Verification
- **Tier-2 unit** (`tests/test_glob_files_only_1375_d10.py`, 4 tests): host backend dir-exclusion (relative + absolute branches) + `glob_files` files-only + leading-dir no-truncation. Real `HostBackend`/`Workspace`, public surface, falsifiable (a dir matching the pattern must not appear).
- **Container path** proven by the faithful **in-container re-smoke** (no container faked in a unit — [[feedback_fake_backend_unit_misses_real_integration]]).

## Follow-up
Unblocks the #1375 **D7 → real-glob** simplification: the grep-with-glob workaround (`pattern: "."`) and its empty-file caveat in `explore.md`/`plan.md` can revert to the real glob op once this lands. Tracked, low priority.

## Test plan
- [x] `pytest tests/test_glob_files_only_1375_d10.py tests/test_environment_backend_1115_stage1.py tests/test_workspace_glob_stdlib_perm.py -q` (13 passed)
- [x] `ruff check` (clean)
- [x] `scripts/test_tier_audit.py --strict` (0 errors)
- [x] full `pytest -q` from rootdir: **6996 passed**, 2 failed — both (`test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`, `test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`) are **pre-existing, not-my-diff**: verified they reproduce on clean `origin/main` and neither references glob/backend/workspace (local-env-dependent — HTML-parse / docker-image).
- [x] faithful in-container re-smoke (live 13236 container, **pre-merge**): `backend.glob('**/*.py')` → 921 files-only; OLD host-side filter on those → 0 (D10 bug reproduced); NEW `glob_files` → 20 files; D7 case `**/*table*` → 10 files; all results files-in-container. **Docker glob path proven >0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
