### PR TITLE
fix(183/#1375 D7→real-glob): revert grep-glob workaround to real glob op

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -50,27 +50,25 @@ preprocessor:
     into: data._filename_tokens
     output_schema:
       type: array
-  # NB: uses grep with a `glob` file-filter (not the `glob` op) because the glob
-  # op's results are filtered host-side and return nothing under the docker
-  # EnvironmentBackend (#1375 D10); grep filters in-container. A match-anything
-  # pattern (`.`) makes files_with_matches return every file matching the glob.
-  # CAVEAT: `.` requires a non-empty line, so this MISSES 0-byte / blank files
-  # (e.g. an empty `__init__.py`) — adequate for finding non-empty source files by
-  # name (the fix-site files we want), but not a general file-finder. Reverting to
-  # the real `glob` op once #1375 D10 is fixed removes this caveat.
+  # Real `glob` op (D7's original intent), unblocked by the #1375 D10 fix that
+  # made glob filter to files IN the backend's own environment — so it now
+  # returns matches under the docker EnvironmentBackend instead of nothing. The
+  # token's `glob` (e.g. `**/*itrs*`) becomes the op's `path` (the glob pattern).
+  # Unlike the earlier grep-with-glob workaround, the glob op matches by NAME so
+  # it also finds 0-byte / blank files (e.g. an empty `__init__.py`). The per-glob
+  # `max_results` cap (default 50) is robust: a specific signal token (`itrs`)
+  # matches few files, so the fix-site file is never capped out (rank_candidate_files
+  # weights specificity and bounds the final set anyway).
   - type: iterate
     over: data._filename_tokens
     apply:
       type: run_op
       op:
         kind: file
-        op: grep
-        path: "."
-        glob: "__placeholder__"
-        pattern: "."
-        output_mode: files_with_matches
+        op: glob
+        path: "__placeholder__"
       args_from:
-        glob: "_iter.item.glob"
+        path: "_iter.item.glob"
       on_error: skip
     into: data._filename_files
     on_error: skip

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -58,24 +58,20 @@ preprocessor:
     into: data._filename_tokens
     output_schema:
       type: array
-  # grep with a `glob` file-filter (not the `glob` op — its results are filtered
-  # host-side and return nothing under the docker backend, #1375 D10); `.` matches
-  # any line so files_with_matches returns every file matching the glob. CAVEAT:
-  # `.` misses 0-byte/blank files (e.g. empty `__init__.py`) — adequate for
-  # non-empty source filename-finding; removed when D10 lets us use the glob op.
+  # Real `glob` op (unblocked by the #1375 D10 fix that made glob filter to files
+  # in-backend, so it returns matches under the docker backend). The token's glob
+  # (e.g. `**/*itrs*`) becomes the op's `path`. Matches by NAME, so it also finds
+  # 0-byte/blank files (empty `__init__.py`) the grep-with-glob workaround missed.
   - type: iterate
     over: data._filename_tokens
     apply:
       type: run_op
       op:
         kind: file
-        op: grep
-        path: "."
-        glob: "__placeholder__"
-        pattern: "."
-        output_mode: files_with_matches
+        op: glob
+        path: "__placeholder__"
       args_from:
-        glob: "_iter.item.glob"
+        path: "_iter.item.glob"
       on_error: skip
     into: data._filename_files
     on_error: skip

--- a/tests/test_glob_files_only_1375_d10.py
+++ b/tests/test_glob_files_only_1375_d10.py
@@ -82,3 +82,19 @@ def test_glob_files_directory_does_not_consume_max_results_slot(tmp_path: Path) 
     (tmp_path / "item_z.txt").write_text("payload\n")
 
     assert ws.glob_files("item_*", max_results=1) == ["item_z.txt"]
+
+
+def test_glob_files_matches_empty_file_by_name(tmp_path: Path) -> None:
+    """Tier 2: #1375 D7 — glob matches an EMPTY (0-byte) file by name.
+
+    The swe_bench D7 filename-finding (explore/plan preprocessors) reverted from
+    a grep-with-glob workaround to the real glob op once this D10 fix landed. The
+    distinguishing property the revert relies on: glob matches by NAME, so a
+    0-byte file (e.g. an empty package ``__init__.py``) is found — the
+    grep-with-glob workaround required a non-empty line and silently missed it.
+    """
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("")  # 0-byte, name-only match
+
+    assert ws.glob_files("**/__init__.py") == ["pkg/__init__.py"]


### PR DESCRIPTION
**[e2e-coder]** — #1375 D7→real-glob follow-up (unblocked by the merged D10 fix #1385). Small, lead-coder pre-approved as a tracked follow-up.

## What
D7 filename-finding used a grep-with-glob workaround (`op: grep, glob: <g>, pattern: "."`) because the glob op returned nothing under the docker backend (the D10 bug). Now that **D10 is fixed** (glob filters files in-backend, #1385 merged), revert both the `explore` and `plan` preprocessors to the **real `glob` op** — the token's glob (e.g. `**/*itrs*`) becomes the op's `path`.

## Why it matters
The workaround's `pattern: "."` required a **non-empty line**, so it silently **missed 0-byte / blank files** — e.g. an empty package `__init__.py`. The real glob op matches by **name**, so those are now found. This removes the empty-file caveat the workaround comments documented.

## Verification
- [x] `tests/test_glob_files_only_1375_d10.py` +1 case: an empty (0-byte) `__init__.py` is found via `glob_files("**/__init__.py")` — the property the revert relies on (5 passed).
- [x] phase YAML parses; D7 glob-op iterate wired (`path` from `_iter.item.glob`) in both explore.md + plan.md.
- [x] 21 D7/region tests + 35 swe_bench skill tests pass (no skill-load regression).
- [x] ruff + tier audit clean.
- [x] in-container glob path already proven by the D10 faithful re-smoke (921 files-only; D7 case `**/*table*` → 10).

## Test plan
- [x] `pytest tests/test_glob_files_only_1375_d10.py tests/test_explore_candidate_files_1375.py tests/test_plan_region_scaffold_1366.py -q` (26 passed)
- [x] `ruff check` + `test_tier_audit.py --strict` (clean)
- [ ] CI pytest 3.11/3.12 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)