### PR TITLE
fix(#1383 D12): scoped read-grant for OS-offloaded artifacts (agent can read its own offloaded artifact)

### DIFF
--- a/src/reyn/context_builder.py
+++ b/src/reyn/context_builder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from reyn.schemas.models import (
     CandidateOutput,
@@ -204,6 +204,7 @@ def offload_control_ir_result(
     events: Any = None,
     phase: str | None = None,
     cap: int = MAX_CONTROL_IR_RESULT_INLINE_BYTES,
+    on_offload_ref: Callable[[str], None] | None = None,
 ) -> dict:
     """Offload an oversized control_ir_result to a workspace scratch file.
 
@@ -248,6 +249,10 @@ def offload_control_ir_result(
     inline["_offload_status"] = "truncated"
     inline["_offload_total_chars"] = size_chars
     ref_path = offload_result.path_ref
+    # #1383 (D12): the inline carries `_offload_ref` = ref_path the LLM may
+    # file.read for the full content → grant a scoped read on it.
+    if on_offload_ref is not None:
+        on_offload_ref(ref_path)
     large_fields = _oversized_fields(result)
 
     if events is not None:
@@ -270,6 +275,7 @@ def maybe_offload_control_ir_results(
     events: Any = None,
     phase: str | None = None,
     cap: int = MAX_CONTROL_IR_RESULT_INLINE_BYTES,
+    on_offload_ref: Callable[[str], None] | None = None,
 ) -> list[dict]:
     """Apply per-result offload to all control_ir_results that exceed *cap*.
 
@@ -281,7 +287,8 @@ def maybe_offload_control_ir_results(
     if offload_dir is None:
         return control_ir_results
     return [
-        offload_control_ir_result(r, i, offload_dir, events=events, phase=phase, cap=cap)
+        offload_control_ir_result(r, i, offload_dir, events=events, phase=phase, cap=cap,
+                                  on_offload_ref=on_offload_ref)
         for i, r in enumerate(control_ir_results)
     ]
 
@@ -292,6 +299,7 @@ def maybe_ref_artifact(
     *,
     events: Any = None,
     phase: str | None = None,
+    on_offload_ref: Callable[[str], None] | None = None,
 ) -> dict:
     """
     Return the artifact as-is if small-or-medium, or an artifact_ref pointer if large.
@@ -304,6 +312,11 @@ def maybe_ref_artifact(
     The LLM can read artifact_ref paths via a file op. The inline-boost path
     keeps mid-size artifacts (e.g. SWE-bench task inputs, ~8–28KB) directly
     visible in the prompt so the LLM does not need a round-trip file read.
+
+    ``on_offload_ref(ref_path)`` (#1383 D12) is invoked when an artifact_ref is
+    emitted, so the OS can register a scoped read-grant: the LLM is told to read
+    ``ref_path`` (often a state-dir path outside the default read zone), so it
+    MUST be readable. Without this, the agent is told to read a path it is denied.
     """
     if artifact_path is None:
         return artifact
@@ -322,6 +335,9 @@ def maybe_ref_artifact(
                 artifact_path=artifact_path,
             )
         return artifact
+    # artifact_ref: the LLM will be instructed to read ref_path → grant it.
+    if on_offload_ref is not None:
+        on_offload_ref(artifact_path)
     return {
         "type": "artifact_ref",
         "artifact_type": artifact.get("type", "unknown"),
@@ -353,6 +369,7 @@ def build_frame(
     offload_dir: Path | None = None,
     context_size_signal: str | None = None,  # #1176 B1 — pre-rendered, tail field
     act_turn_reasoning: list[str] | None = None,  # #1212 reasoning-continuity
+    on_offload_ref: Callable[[str], None] | None = None,  # #1383 D12 scoped read-grant
 ) -> ContextFrame:
     allowed_next = [c.next_phase for c in candidates]
     current_visit = visit_counts.get(phase_name, 1)
@@ -375,13 +392,15 @@ def build_frame(
         events=events,
         phase=phase_name,
         cap=inline_cap,
+        on_offload_ref=on_offload_ref,
     )
 
     frame = ContextFrame(
         current_phase=phase_name,
         current_phase_role=phase.role,
         instructions=phase.instructions,
-        input_artifact=maybe_ref_artifact(artifact, artifact_path, events=events, phase=phase_name),
+        input_artifact=maybe_ref_artifact(artifact, artifact_path, events=events, phase=phase_name,
+                                           on_offload_ref=on_offload_ref),
         execution=ExecutionState(
             path=list(history)[-10:],
             current_visit=current_visit,

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -591,6 +591,10 @@ class OSRuntime:
             remaining_act_turns=remaining_act_turns,
             offload_dir=offload_dir,
             context_size_signal=context_size_signal,
+            # #1383 (D12): when build_frame offloads an artifact to a state-dir
+            # path and hands the LLM a readable ref, register a scoped read-grant
+            # on that exact path so the agent can read what it is told to read.
+            on_offload_ref=(self._perm.grant_offload_read if self._perm else None),
         )
 
     # ── Phase entry + phase execution ─────────────────────────────────────────

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -376,6 +376,14 @@ class PermissionResolver:
         self._approvals_path = self._project_root / ".reyn" / "approvals.yaml"
         self._session: dict[str, bool] = {}
         self._saved: dict[str, bool] = self._load_saved()
+        # #1383 (D12): scoped read-grants for OS-offloaded artifacts. When the OS
+        # offloads an artifact to a state-dir path and hands the agent an
+        # `artifact_ref` / `_offload_ref` pointing there, that path is outside the
+        # default read zone (CWD) — the agent would be told to read a path it is
+        # then denied. The offload-emit registers the EXACT path here (not the
+        # whole state-dir → least-privilege); the read gate consults it. Resolved
+        # absolute paths only; exact-match (no prefix grant).
+        self._offload_read_paths: set[str] = set()
         if trusted_python_allowed is not None:
             unsafe_python_allowed = trusted_python_allowed
         self._unsafe_python_allowed = unsafe_python_allowed
@@ -610,6 +618,26 @@ class PermissionResolver:
     # Backwards-compatible alias used by older write-class call sites.
     def _is_path_approved(self, path: str, skill_name: str) -> bool:
         return self._is_path_approved_for(path, skill_name, "file.write")
+
+    def _resolve_for_offload(self, path: str) -> str:
+        """Resolve ``path`` to an absolute string (same convention as the gate)."""
+        p = Path(path).expanduser()
+        return str((self._project_root / p).resolve() if not p.is_absolute() else p.resolve())
+
+    def grant_offload_read(self, path: str) -> None:
+        """Register a scoped read-grant for an OS-offloaded artifact path (#1383 D12).
+
+        Called by the offload-emit layer (``context_builder`` artifact_ref /
+        offload_value) the moment a state-dir path is handed to the agent as a
+        readable ref. Grants read on EXACTLY this path (resolved) — not the
+        containing dir — so least-privilege holds. The read gate
+        (:meth:`require_file_read`) consults :meth:`_is_offload_read_granted`.
+        """
+        self._offload_read_paths.add(self._resolve_for_offload(path))
+
+    def _is_offload_read_granted(self, path: str) -> bool:
+        """True if ``path`` was registered via :meth:`grant_offload_read` (exact match)."""
+        return self._resolve_for_offload(path) in self._offload_read_paths
 
     def _is_host_approved_for(
         self, host: str, skill_name: str, kind: str = "http.get",
@@ -975,8 +1003,13 @@ class PermissionResolver:
         )
 
         def _approved(axis: object, value: object) -> bool:
-            return self._is_config_approved("file.read") or self._is_path_approved_for(
-                str(value), skill_name, "file.read"
+            return (
+                self._is_config_approved("file.read")
+                or self._is_path_approved_for(str(value), skill_name, "file.read")
+                # #1383 (D12): an artifact the OS offloaded to this agent is
+                # readable by it (exact-path scoped grant), even though the
+                # state-dir path is outside the default read zone.
+                or self._is_offload_read_granted(str(value))
             )
 
         if EffectivePermission([

--- a/tests/test_offload_read_grant_1383.py
+++ b/tests/test_offload_read_grant_1383.py
@@ -1,0 +1,122 @@
+"""Tier 2c: scoped read-grant for OS-offloaded artifacts (#1383 D12).
+
+The OS offloads a large artifact to a state-dir path and hands the agent an
+`artifact_ref` / `_offload_ref` pointing there, instructing it (llm.py) to
+`file.read` that path. But the path is outside the default read zone (CWD /
+project_root), so without a grant the agent is told to read a path it is then
+denied — the #183/#1375 swe_bench loop's astropy-13236 burned its act budget
+retrying the denied read and aborted.
+
+Fix: the offload-emit registers a scoped read-grant on EXACTLY that path
+(`grant_offload_read`), consulted by the read gate. These tests pin:
+  - the grant admits the exact path but NOT a sibling (least-privilege),
+  - the register→check seam (no grant → still denied = the grant is what passes),
+  - the emit→grant→check chain end-to-end for BOTH emit points
+    (maybe_ref_artifact + offload_control_ir_result),
+  - the AgentLayer grant still ∩-intersects the SandboxLayer.
+
+No mocks: a real PermissionResolver with project_root ≠ the offloaded path.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.context_builder import maybe_ref_artifact, offload_control_ir_result
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.policy import SandboxPolicy
+
+
+def _resolver(project_root: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False
+    )
+
+
+def _out_of_zone(tmp_path: Path) -> tuple[PermissionResolver, Path, Path]:
+    """A resolver whose project_root is `proj`, plus an offload path OUTSIDE it."""
+    proj = (tmp_path / "proj").resolve()
+    proj.mkdir(parents=True)
+    state = (tmp_path / "state").resolve()  # state-dir, outside the read zone
+    state.mkdir(parents=True)
+    offloaded = state / "v01_input.json"
+    offloaded.write_text("{}")
+    return _resolver(proj), offloaded, state
+
+
+def test_out_of_zone_read_denied_without_grant(tmp_path: Path) -> None:
+    """Tier 2c: baseline — an out-of-zone offload path is denied with no grant (the 13236 bug)."""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    with pytest.raises(PermissionError):
+        r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+
+
+def test_grant_offload_read_allows_exact_path(tmp_path: Path) -> None:
+    """Tier 2c: after grant_offload_read, the exact out-of-zone path is readable."""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    r.grant_offload_read(str(offloaded))
+    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
+
+
+def test_grant_is_exact_scoped_not_sibling(tmp_path: Path) -> None:
+    """Tier 2c: the grant is exact-path scoped — a SIBLING in the same dir stays denied
+    (least-privilege: granting one offloaded artifact does NOT open the state-dir)."""
+    r, offloaded, state = _out_of_zone(tmp_path)
+    r.grant_offload_read(str(offloaded))
+    sibling = state / "other_secret.json"
+    sibling.write_text("{}")
+    with pytest.raises(PermissionError):
+        r.require_file_read(PermissionDecl(), str(sibling), "swe_bench")
+
+
+def test_register_reaches_check_seam(tmp_path: Path) -> None:
+    """Tier 2c: register→check wiring falsification — the SAME resolver instance that
+    registered the grant is the one the read gate consults. Without the register the
+    read fails; with it, it passes. (A grant stored where the check never reads it
+    would leave this denied = unwired bug.)"""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    # before register: denied
+    with pytest.raises(PermissionError):
+        r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+    # register on this instance → the check (same instance) now passes
+    r.grant_offload_read(str(offloaded))
+    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+
+
+def test_emit_artifact_ref_registers_grant_end_to_end(tmp_path: Path) -> None:
+    """Tier 2c: the artifact_ref emit point (maybe_ref_artifact) → grant → check chain.
+    A large artifact emits an artifact_ref AND the path becomes readable via the grant."""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    big = {"type": "swe_bench_input", "data": {"problem_statement": "x" * 200_000}}
+    out = maybe_ref_artifact(
+        big, str(offloaded), on_offload_ref=r.grant_offload_read
+    )
+    assert out["type"] == "artifact_ref"  # large → offloaded to a ref
+    # the emit registered the grant → the agent can read what it was told to read
+    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+
+
+def test_emit_control_ir_offload_registers_grant_end_to_end(tmp_path: Path) -> None:
+    """Tier 2c: the generic offload emit point (offload_control_ir_result) → grant → check.
+    Covers the second of the two exhaustive emit points."""
+    r, _, state = _out_of_zone(tmp_path)
+    big_result = {"content": "y" * 200_000}
+    inline = offload_control_ir_result(
+        big_result, 0, state, cap=1024, on_offload_ref=r.grant_offload_read
+    )
+    ref_path = inline["_offload_ref"]
+    r.require_file_read(PermissionDecl(), str(ref_path), "swe_bench")  # granted → no raise
+
+
+def test_offload_grant_still_intersects_sandbox(tmp_path: Path) -> None:
+    """Tier 2c: the AgentLayer offload grant is conjunctive-∩ with the SandboxLayer —
+    a sandbox that restricts reads to other paths still denies the offloaded path."""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    r.grant_offload_read(str(offloaded))
+    # SandboxLayer with a non-empty read allowlist that excludes the offloaded path
+    policy = SandboxPolicy(read_paths=[str(tmp_path / "elsewhere")])
+    with pytest.raises(PermissionError):
+        r.require_file_read(
+            PermissionDecl(), str(offloaded), "swe_bench", sandbox_policy=policy
+        )


### PR DESCRIPTION
**[dogfood-coder]** — #1383 D12: scoped read-grant for OS-offloaded artifacts. Lead design-review **APPROVE** (#1383 design comment).

## Why

The OS offloads a large artifact to a state-dir path and hands the agent an `artifact_ref`/`_offload_ref`; `llm.py:626` instructs the agent to `file.read` that path — but it is outside the default read zone (CWD/project_root), so `permissions.py` `require_file_read` **denies** it. **The system tells the agent to read a path it then forbids.** In the #183/#1375 swe_bench loop, `astropy-13236` (67.5KB input → offloaded) burned all 20 explore act-turns retrying the denied read → `"Act turn budget exhausted. Cannot read input artifact"` → abort, **0/3 rounds** (N=3, primary evidence).

## Fix (scoped, least-privilege)

The **offload-emit** registers a read-grant on **exactly** the offloaded path; the read gate consults it.

- `PermissionResolver`: `_offload_read_paths` set + `grant_offload_read(path)` + `_is_offload_read_granted`; `require_file_read`'s `_approved` gains an OR-branch. **Exact-path scoped** (NOT the containing state-dir) → least-privilege. AgentLayer grant → conjunctive-∩ with SandboxLayer preserved.
- `context_builder`: an `on_offload_ref(ref_path)` callback threaded through `build_frame` to **both** emit points.
- `runtime`: the OSRuntime `build_frame` caller passes `self._perm.grant_offload_read`.

### Architectural completeness (the two emit points are exhaustive — not "I found two")

The LLM reads only the `ContextFrame`. `build_frame` (context_builder) is its **sole assembly**. The only places `build_frame` hands the LLM a *readable path ref* are:
1. `maybe_ref_artifact` → `artifact_ref` (large input artifact)
2. `offload_control_ir_result` (via `maybe_offload_control_ir_results`) → `_offload_ref` (large control_ir result)

(`_offload_ref` at L178 in the preview-strategy is the *internal* callback of `offload_value` — not a separate LLM-facing emit.) Both flow through the single `on_offload_ref` callback. **Invariant**: any future LLM-readable ref must also flow through `build_frame` → it is auto-covered by the same callback. No partial coverage.

## Verification

- **register→check seam falsification**: `test_register_reaches_check_seam` — on the SAME resolver instance, read is denied *before* `grant_offload_read` and allowed *after*. Proves the registered grant actually reaches the gate (a grant stored where the check never reads it would leave this denied = unwired bug).
- **production-wiring identity** (the unit instance-identity ↔ production): the `permission_resolver` passed into `OSRuntime.__init__` is threaded to BOTH `self._perm` (the register site, `runtime.py` build_frame `on_offload_ref=self._perm.grant_offload_read`) AND the op-runtime / `OpContext.permission_resolver` (the check site, `op_runtime/file.py:177 ctx.permission_resolver.require_file_read`). One instance → the grant registered at build_frame time is the one the file-read op consults.
- **scoped two-faced (real resolver, no mocks)**: granted exact path → ALLOW; a **sibling in the same state-dir** → still DENY (least-privilege); a restrictive **SandboxLayer** still denies the granted path (∩ preserved).
- **emit→grant→check end-to-end for BOTH points**: `maybe_ref_artifact` + `offload_control_ir_result`.

## Test plan

- [x] `ruff` — pass
- [x] `test_tier_audit --strict` — exit 0
- [x] `pytest tests/test_offload_read_grant_1383.py` — 7 passed
- [x] affected callers — `-k "permission or context_builder or 1316/1335/1199 or offload"` — 258 passed
- [ ] full suite `pytest` (serial) — (local run + CI)
- [ ] (after merge) 13236 re-run: the denied-read loop / abort is gone (N≥3, variance-robust). Resolve vs next-layer is a separate question (not claimed here — prediction-vs-result).

Scope: general OS permission fix (sibling of #1375-D10), additive (new set + 1 OR-branch + an optional None-default callback), existing read-zone/approval paths unchanged.

Refs #1383 #1375 #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
