### PR TITLE
fix(#1388 D12 follow-up): offload read-grant covers is_read_allowed (Workspace gate) — closure symmetry

### DIFF
--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -639,6 +639,19 @@ class PermissionResolver:
         """True if ``path`` was registered via :meth:`grant_offload_read` (exact match)."""
         return self._resolve_for_offload(path) in self._offload_read_paths
 
+    def _read_base_approved(self, path: str) -> bool:
+        """Read-approval shared by BOTH read gates (#1383 follow-up).
+
+        The op-runtime gate (:meth:`require_file_read`) and the Workspace gate
+        (:meth:`is_read_allowed`) are documented to make the SAME decision. The
+        config grant + offload grant are the part they MUST agree on, so they
+        live here — a single source both gates call, so the offload-grant
+        decision cannot diverge (the merged D12 bug: only one gate had it). The
+        per-skill path-approval term differs (is_read_allowed guards it on a
+        non-empty skill_name) and stays inline in each gate.
+        """
+        return self._is_config_approved("file.read") or self._is_offload_read_granted(path)
+
     def _is_host_approved_for(
         self, host: str, skill_name: str, kind: str = "http.get",
     ) -> bool:
@@ -1003,13 +1016,10 @@ class PermissionResolver:
         )
 
         def _approved(axis: object, value: object) -> bool:
-            return (
-                self._is_config_approved("file.read")
-                or self._is_path_approved_for(str(value), skill_name, "file.read")
-                # #1383 (D12): an artifact the OS offloaded to this agent is
-                # readable by it (exact-path scoped grant), even though the
-                # state-dir path is outside the default read zone.
-                or self._is_offload_read_granted(str(value))
+            # #1383: config + offload grant via the shared base (kept in sync with
+            # is_read_allowed); per-skill path-approval inline.
+            return self._read_base_approved(str(value)) or self._is_path_approved_for(
+                str(value), skill_name, "file.read"
             )
 
         if EffectivePermission([
@@ -1319,7 +1329,12 @@ class PermissionResolver:
         )
 
         def _approved(axis: object, value: object) -> bool:
-            return self._is_config_approved("file.read") or (
+            # #1383 follow-up: config + offload grant via the shared base (same
+            # source as require_file_read → the offload decision cannot diverge;
+            # the merged D12 bug was this gate lacking the offload grant, leaving
+            # astropy-13236 denied at Workspace._resolve_read). Per-skill
+            # path-approval inline (guarded on a non-empty skill_name here).
+            return self._read_base_approved(str(value)) or (
                 bool(skill_name)
                 and self._is_path_approved_for(str(value), skill_name, "file.read")
             )

--- a/tests/test_offload_read_grant_1383.py
+++ b/tests/test_offload_read_grant_1383.py
@@ -120,3 +120,82 @@ def test_offload_grant_still_intersects_sandbox(tmp_path: Path) -> None:
         r.require_file_read(
             PermissionDecl(), str(offloaded), "swe_bench", sandbox_policy=policy
         )
+
+
+# ── #1383 follow-up: the Workspace read gate (is_read_allowed) must honor the
+# grant too — the op-runtime gate (require_file_read) passing alone left
+# astropy-13236 still aborting at Workspace._resolve_read ("outside project").
+
+def test_is_read_allowed_honors_offload_grant(tmp_path: Path) -> None:
+    """Tier 2c: is_read_allowed (the Workspace read gate's resolver method) honors the
+    offload grant — denied before, allowed after, on the same instance."""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    assert r.is_read_allowed(str(offloaded), "swe_bench") is False  # before grant
+    r.grant_offload_read(str(offloaded))
+    assert r.is_read_allowed(str(offloaded), "swe_bench") is True  # after grant
+
+
+def test_both_read_gates_in_sync_for_offload_grant(tmp_path: Path) -> None:
+    """Tier 2c: the two read gates make the SAME decision for an offloaded path —
+    require_file_read (op-runtime) and is_read_allowed (Workspace) both admit it
+    after the grant. (The follow-up restores the symmetry the merged D12 broke by
+    patching only require_file_read.)"""
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    r.grant_offload_read(str(offloaded))
+    # op-runtime gate
+    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
+    # Workspace gate
+    assert r.is_read_allowed(str(offloaded), "swe_bench") is True
+
+
+def test_read_gates_symmetric_granted_and_nongranted(tmp_path: Path) -> None:
+    """Tier 2c: symmetry-invariant (falsifies future divergence) — for BOTH a
+    granted offload path AND a non-granted out-of-zone path, require_file_read and
+    is_read_allowed return the SAME admit/deny. They share `_read_base_approved`
+    for the config+offload decision, so neither can drift on the offload axis."""
+    r, offloaded, state = _out_of_zone(tmp_path)
+    nongranted = state / "not_granted.json"
+
+    def _require_ok(p: Path) -> bool:
+        try:
+            r.require_file_read(PermissionDecl(), str(p), "swe_bench")
+            return True
+        except PermissionError:
+            return False
+
+    # non-granted out-of-zone: both DENY (symmetric)
+    assert _require_ok(nongranted) is False
+    assert r.is_read_allowed(str(nongranted), "swe_bench") is False
+    # granted: both ALLOW (symmetric)
+    r.grant_offload_read(str(offloaded))
+    assert _require_ok(offloaded) is True
+    assert r.is_read_allowed(str(offloaded), "swe_bench") is True
+
+
+def test_is_read_allowed_grant_is_exact_scoped(tmp_path: Path) -> None:
+    """Tier 2c: is_read_allowed's offload grant is exact-path scoped — a sibling in the
+    same state-dir stays disallowed (least-privilege, matching the op-runtime gate)."""
+    r, offloaded, state = _out_of_zone(tmp_path)
+    r.grant_offload_read(str(offloaded))
+    sibling = state / "other_secret.json"
+    assert r.is_read_allowed(str(sibling), "swe_bench") is False
+
+
+def test_workspace_read_gate_honors_offload_grant_end_to_end(tmp_path: Path) -> None:
+    """Tier 2c: end-to-end through the real Workspace — `Workspace.read_file` of an
+    offloaded out-of-zone path raises 'outside project' before the grant and succeeds
+    after (this is the exact gate-2 that left 13236 aborting)."""
+    from reyn.events.events import EventLog
+    from reyn.workspace.workspace import Workspace
+
+    r, offloaded, _ = _out_of_zone(tmp_path)
+    offloaded.write_text("INPUT-CONTENT")
+    base = (tmp_path / "proj").resolve()
+    ws = Workspace(
+        EventLog(), permission_resolver=r, skill_name="swe_bench", base_dir=base
+    )
+    with pytest.raises(PermissionError):
+        ws.read_file(str(offloaded))  # gate-2: outside project, no grant
+    r.grant_offload_read(str(offloaded))
+    content, found = ws.read_file(str(offloaded))
+    assert found and content == "INPUT-CONTENT"


### PR DESCRIPTION
**[dogfood-coder]** — completes #1383 (D12). Lead-approved self-drive (#1383 follow-up) — caught by the 13236 D12-fixed re-run (verify-first stopped a premature "D12 done").

## Why

The merged D12 (#1383) added the offload read-grant to `require_file_read` (op-runtime gate) but NOT to `is_read_allowed` (Workspace gate). The 13236 re-run still aborted: the denial moved from `require_file_read`'s "default read zone" to `Workspace._resolve_read`'s **"outside project"**. Production input-reads route through the Workspace gate → the offloaded artifact stayed unreadable → act-budget exhaustion → abort, unchanged.

## Check-side completeness (full enumeration, per review steer)

Read-permission check methods = **exactly two**:
- `require_file_read` — op-runtime (`op_runtime/file.py:177`, `index_query.py:83`) — covered by #1383.
- `is_read_allowed` — Workspace (`_resolve_read` → `read_file`/`read_file_bytes`/`stat_path`/`grep`; `glob_files`) — covered here.

No third gate → no patch-2-find-3.

## Fix (structural root, not symptom-patch)

The config + offload grant (the decision both gates are documented to share) is extracted to a shared **`_read_base_approved(path)`** that BOTH `_approved` closures call → the offload decision **cannot diverge** again (that divergence was the #1383 bug). The per-skill path-approval term stays inline (legitimately different — `is_read_allowed` guards it on a non-empty `skill_name`).

## Verification

- **symmetry-invariant test**: for a granted offload path AND a non-granted out-of-zone path, `require_file_read` and `is_read_allowed` return the SAME admit/deny — falsifies future drift.
- `is_read_allowed` honors the grant (denied→allowed, same instance); exact-path scoped (sibling stays denied).
- **Workspace end-to-end** (real Workspace, no mocks): `read_file` of an offloaded out-of-zone path raises "outside project" before the grant, returns the content after — the exact gate-2 that left 13236 aborting.

## Test plan

- [x] `ruff` — pass
- [x] `test_tier_audit --strict` — exit 0
- [x] `pytest tests/test_offload_read_grant_1383.py` — 12 passed
- [x] affected callers (`-k permission/context_builder/workspace/offload/1316/1335/1199`) — 322 passed
- [ ] full suite (serial) — local + CI
- [ ] (after merge) 13236 re-run: abort gone + input-read ALLOW at BOTH gates → true resolve-headroom (N≥3 for the variance part).

Deterministic gap (a missing code branch) → N=1 + code inspection + full read-gate enumeration. Sibling of #1375-D10; general OS permission invariant.

Refs #1388 #1383 #1375 #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
