### PR TITLE
fix(183/#1390 L3): route state_dir reads host-side, not through repo backend

### DIFF
--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -43,6 +43,15 @@ class Workspace:
         # resolution, and event emission stay here; the backend does only IO on
         # the absolute paths this class resolves.
         self._backend: "EnvironmentBackend" = environment_backend or HostBackend()
+        # #1390 L3: a host backend for state_dir reads. state_dir storage is
+        # host-side (store_artifact writes directly host-side, bypassing the repo
+        # backend), so reads of state_dir paths must mirror that split — they stay
+        # host-side, not routed through the repo/container backend (under the
+        # docker backend a host state_dir path does not exist in-container). A
+        # fresh HostBackend reads reyn's own process FS = where store_artifact
+        # wrote. When self._backend is already a HostBackend (non-docker), this is
+        # the same environment, so routing is behaviour-preserving there.
+        self._state_backend: "EnvironmentBackend" = HostBackend()
         self.base_dir = base_dir.resolve() if base_dir is not None else Path.cwd()
         # FP-0008 #1115 Stage 0: state_dir is host-side and decoupled from
         # base_dir. Default = base_dir/.reyn (backward-compat). A caller that
@@ -92,6 +101,23 @@ class Workspace:
             return resolved
         raise PermissionError(f"read not permitted: {path_str!r} (outside project)")
 
+    def _read_backend_for(self, resolved_path: Path) -> "EnvironmentBackend":
+        """Backend for reading ``resolved_path`` — the single state_dir routing
+        seam (#1390 L3).
+
+        A read whose RESOLVED path is under ``state_dir`` (e.g. an OS-offloaded
+        artifact the agent is told to ``file.read``, ``llm.py``) stays host-side;
+        every other read goes to the repo backend. ``state_dir`` is ``.resolve()``
+        d at construction (``/tmp`` ↔ ``/private/tmp`` normalised), so callers
+        MUST pass a resolved path (``_resolve_read`` output) — a raw path would
+        mis-compare and wrongly route a state_dir read to the container backend
+        (the bug this fixes). Every backend-read site routes through here so no
+        site can silently miss the split (completeness by construction).
+        """
+        if resolved_path.is_relative_to(self.state_dir):
+            return self._state_backend
+        return self._backend
+
     def _resolve_write(self, path_str: str) -> Path:
         p = Path(path_str).expanduser()
         if p.is_absolute():
@@ -111,7 +137,7 @@ class Workspace:
     def read_file(self, path_str: str) -> tuple[str, bool]:
         """Read a file. Returns (content, found). Raises PermissionError if denied."""
         path = self._resolve_read(path_str)
-        data = self._backend.read_bytes(path)
+        data = self._read_backend_for(path).read_bytes(path)
         if data is None:
             return "", False
         return data.decode("utf-8"), True
@@ -125,7 +151,7 @@ class Workspace:
         denied by the workspace policy.
         """
         path = self._resolve_read(path_str)
-        data = self._backend.read_bytes(path)
+        data = self._read_backend_for(path).read_bytes(path)
         if data is None:
             return b"", False
         return data, True
@@ -188,7 +214,7 @@ class Workspace:
         string, e.g. ``"0o644"``). Gated by ``_resolve_read``.
         """
         path = self._resolve_read(path_str)
-        return self._backend.stat(path)
+        return self._read_backend_for(path).stat(path)
 
     def glob_files(self, pattern: str, max_results: int = 50) -> list[str]:
         """
@@ -231,12 +257,18 @@ class Workspace:
             # directories. Re-applying a host-side ``is_file()`` filter would be
             # the D10 bug: it stats a container backend's paths against the host
             # filesystem (where they do not exist) and drops everything.
-            files = sorted(str(m) for m in self._backend.glob(pattern))
+            # #1390 L3: route by the resolved glob root — a state_dir-rooted glob
+            # stays host-side (same split as read_file), repo globs hit the repo
+            # backend. (glob_files permits state_dir roots above.)
+            files = sorted(str(m) for m in self._read_backend_for(resolved_root).glob(pattern))
             return files[:max_results]
 
         # Relative-path branch: backend is already files-only (#1375 D10);
-        # relativize and cap.
-        ws_matches = sorted(self._backend.glob(pattern, root=self.base_dir))
+        # relativize and cap. base_dir is never under state_dir, so this routes to
+        # the repo backend (the #1390 L3 seam, uniformly applied).
+        ws_matches = sorted(
+            self._read_backend_for(self.base_dir).glob(pattern, root=self.base_dir)
+        )
         result = []
         for m in ws_matches[:max_results]:
             try:
@@ -266,7 +298,9 @@ class Workspace:
         relativizes for presentation. See [[environment.backend]] module docs.
         """
         root = self._resolve_read(path_str)
-        return self._backend.grep(
+        # #1390 L3: a state_dir-rooted grep stays host-side (same split as
+        # read_file); repo greps hit the repo backend.
+        return self._read_backend_for(root).grep(
             root,
             regex,
             glob=glob,

--- a/tests/test_state_dir_read_routing_1390.py
+++ b/tests/test_state_dir_read_routing_1390.py
@@ -1,0 +1,145 @@
+"""Tier 2: #1390 L3 — state_dir reads route host-side, not through the repo backend.
+
+state_dir storage is host-side (``store_artifact`` writes directly host-side,
+bypassing the repo backend). The READ side must mirror that split: a read whose
+resolved path is under ``state_dir`` (e.g. an OS-offloaded artifact the agent is
+told to ``file.read``) stays host-side, while repo reads go to the repo backend.
+Under the docker env-backend the repo backend is the *container*, so without this
+split a host state_dir path is read in-container (where it does not exist) →
+not_found → the offloaded-input read fails (the #183 13236 L3 abort).
+
+This file pins the routing split on the public surface with a real recording
+backend (a Fake, not a mock — per testing policy):
+
+  (a) a read whose resolved path is under state_dir is served host-side — the
+      injected repo backend records NO read for it, yet the host content comes
+      back (the offloaded-artifact case);
+  (b) a base_dir (repo) read DOES route to the injected repo backend;
+  (c) resolution-robustness: an UNRESOLVED state_dir path (a symlink form, the
+      /tmp ↔ /private/tmp case) still routes host-side, because the seam runs on
+      the resolved path and state_dir is resolved at construction.
+
+No mocks: real HostBackend / Workspace + a hand-written recording Fake.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.environment.host_backend import HostBackend
+from reyn.events.events import EventLog
+from reyn.permissions.permissions import PermissionResolver
+from reyn.workspace.workspace import Workspace
+
+
+class _RecordingRepoBackend:
+    """A real EnvironmentBackend standing in for the repo (e.g. container)
+    backend: it records which reads it served and delegates IO to a wrapped
+    HostBackend. A Fake (test double), not a mock."""
+
+    name = "recording-repo"
+
+    def __init__(self) -> None:
+        self._inner = HostBackend()
+        self.reads: list[str] = []
+
+    def read_bytes(self, path: Path) -> bytes | None:
+        self.reads.append(str(path))
+        return self._inner.read_bytes(path)
+
+    def write_bytes(self, path: Path, data: bytes) -> None:
+        self._inner.write_bytes(path, data)
+
+    def delete(self, path: Path) -> bool:
+        return self._inner.delete(path)
+
+    def mkdir(self, path: Path, *, parents: bool = True) -> bool:
+        return self._inner.mkdir(path, parents=parents)
+
+    def move(self, src: Path, dst: Path) -> bool:
+        return self._inner.move(src, dst)
+
+    def stat(self, path: Path):
+        self.reads.append(str(path))
+        return self._inner.stat(path)
+
+    def glob(self, pattern: str, *, root: Path | None = None):
+        self.reads.append(pattern)
+        return self._inner.glob(pattern, root=root)
+
+    def grep(self, root, regex, **kwargs):
+        self.reads.append(str(root))
+        return self._inner.grep(root, regex, **kwargs)
+
+
+def _ws(tmp_path: Path, backend, state_dir: Path, *, grant: Path | None = None) -> Workspace:
+    repo = (tmp_path / "repo").resolve()
+    repo.mkdir(exist_ok=True)
+    # Real PermissionResolver — in production the D12 offload grant (#1383/#1389)
+    # permits the out-of-zone state_dir read BEFORE the L3 routing seam runs. The
+    # grant mirrors that so the read reaches the routing under test.
+    perm = PermissionResolver(config_permissions={}, project_root=repo, interactive=False)
+    if grant is not None:
+        perm.grant_offload_read(str(grant))
+    return Workspace(
+        events=EventLog(),
+        base_dir=repo,
+        state_dir=state_dir,
+        permission_resolver=perm,
+        skill_name="swe_bench",
+        environment_backend=backend,
+    )
+
+
+def test_state_dir_read_served_host_side_not_repo_backend(tmp_path: Path) -> None:
+    """Tier 2: a state_dir read bypasses the repo backend (host-side)."""
+    backend = _RecordingRepoBackend()
+    state_dir = tmp_path / "state"
+    # an offloaded artifact the OS wrote host-side under state_dir
+    art = state_dir / "artifacts" / "offload.json"
+    art.parent.mkdir(parents=True, exist_ok=True)
+    art.write_text('{"big": "input"}')
+    ws = _ws(tmp_path, backend, state_dir, grant=art)
+
+    content, found = ws.read_file(str(art))
+    assert found and content == '{"big": "input"}'
+    # the repo backend must NOT have been asked to read it (it would read the
+    # path in its own environment — the container, where it does not exist)
+    assert backend.reads == [], backend.reads
+
+
+def test_repo_read_routes_to_repo_backend(tmp_path: Path) -> None:
+    """Tier 2: a base_dir (repo) read DOES route to the repo backend."""
+    backend = _RecordingRepoBackend()
+    ws = _ws(tmp_path, backend, tmp_path / "state")
+
+    src = ws.base_dir / "mod.py"
+    src.write_text("x = 1\n")
+
+    content, found = ws.read_file("mod.py")
+    assert found and content == "x = 1\n"
+    assert str(src.resolve()) in backend.reads  # repo backend served it
+
+
+def test_unresolved_state_dir_path_still_routes_host_side(tmp_path: Path) -> None:
+    """Tier 2: an unresolved (symlinked) state_dir path routes host-side.
+
+    The /tmp ↔ /private/tmp case (lead-coder's resolution-robustness condition):
+    state_dir is resolved at construction and the seam runs on the resolved read
+    path, so a state_dir path given in unresolved (symlink) form still lands
+    host-side rather than mis-routing to the repo backend.
+    """
+    real_state = tmp_path / "real_state"
+    real_state.mkdir()
+    link_state = tmp_path / "link_state"
+    link_state.symlink_to(real_state)
+
+    backend = _RecordingRepoBackend()
+    art = real_state / "offload.json"
+    art.write_text("payload")
+    # state_dir passed via the symlink — Workspace .resolve()s it to real_state
+    ws = _ws(tmp_path, backend, link_state, grant=art)
+
+    # read via the UNRESOLVED symlink form of the path
+    content, found = ws.read_file(str(link_state / "offload.json"))
+    assert found and content == "payload"
+    assert backend.reads == [], backend.reads  # routed host-side despite symlink form


### PR DESCRIPTION
**[e2e-coder]** — closes #1390. L3 of the #183 13236 abort (sibling of #1387 gate-1 / #1389 gate-2). Design-reviewed + approved by lead-coder (1 condition) and sandbox_2 (load-bearing check) on #1390.

## Problem
After #1387+#1389 closed the permission 2-gate, 13236 STILL aborts at explore: the offloaded input artifact exists host-side in `state_dir` (88KB), permission passes, yet `read_file` returns **not_found** ×20. Root: `read_file` routed through `self._backend` = the **container** backend under the docker env-backend, so the host `state_dir` path was read in-container (where it doesn't exist).

## Fix — single routing seam (completeness by construction)
`state_dir` storage is host-side (`store_artifact` writes directly host-side, `workspace.py:301-305`); the read side must mirror the split. Add `_read_backend_for(resolved_path)`: under `state_dir` → `HostBackend`, else the repo backend. **All** backend-read sites route through it — `read_file` / `read_file_bytes` / `stat` / `glob` (×2) / `grep` — so no site can silently miss the split (the L2 check-side-gap lesson).

- **lead-coder's condition (resolved path)**: the seam runs on the `_resolve_read` output; `state_dir` is `.resolve()`'d (`:53`), so `/tmp`↔`/private/tmp` normalises on both sides.
- **Behaviour-preserving** for non-docker (self._backend is already a HostBackend).
- **Complements** `resolve_artifact_handle` (higher-level by-ref host-serve) — this enforces the same invariant for the agent's *direct* `file.read` of an offloaded path (`llm.py`), which bypasses the handle.
- **Writes out of scope**: `store_artifact` already writes state_dir host-side; agent writes to state_dir aren't a flow.

## Verification
- [x] Tier-2 `tests/test_state_dir_read_routing_1390.py` (3): state_dir read bypasses the (recording) repo backend / repo read hits it / **resolution-robustness** (unresolved symlink-form state_dir path still routes host-side). Real `Workspace` + real `PermissionResolver` with the D12 offload grant (no mocks).
- [x] 767 related tests (workspace/permission/backend/offload/op_runtime/runtime/agent) pass, no regression.
- [x] ruff + tier audit clean.
- [ ] full `pytest -q` from rootdir
- [ ] (post-merge) sandbox_2 faithful re-smoke: 13236 not_found gone → abort resolved → plan reached (N=3); before-baseline = not_found 19-20, 3/3 abort.

## Test plan
- [x] `pytest tests/test_state_dir_read_routing_1390.py tests/test_offload_read_grant_1383.py tests/test_environment_backend_1115_stage1.py tests/test_glob_files_only_1375_d10.py -q` (25 passed)
- [x] `ruff check` + `test_tier_audit.py --strict` (clean)
- [ ] CI pytest 3.11/3.12 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)