### PR TITLE
fix(183): minimize swe_bench cheat-skill prose — offload context-incoherence (#1393) + verify apply-loop (#1206)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -104,12 +104,6 @@ object contains every field you need. The input shape is:
 }
 ```
 
-All six fields are present in the prompt's artifact section that the OS
-gives you (= no need to grep / search / probe to find them). Read them
-directly from `data.*` — do NOT abort with "problem_statement missing"
-before reading the artifact, because the fields ARE there. If you genuinely
-cannot find them, recheck the prompt's input-artifact block before aborting.
-
 ## Step 1 — Read the problem statement
 
 Read `data.problem_statement` from the input artifact. This is the GitHub

--- a/src/reyn/stdlib/skills/swe_bench/phases/explore.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/explore.md
@@ -104,6 +104,10 @@ object contains every field you need. The input shape is:
 }
 ```
 
+Read each field from `data.*`. If the input is large the OS offloads it
+(`type: artifact_ref`) and hands you a `ref_path` to read first — read that
+rather than aborting with "field missing".
+
 ## Step 1 — Read the problem statement
 
 Read `data.problem_statement` from the input artifact. This is the GitHub
@@ -145,13 +149,8 @@ entire repository.
 ## Step 4 — Inspect the test_patch to understand expected behavior
 
 Read `data.test_patch` from the input artifact to understand what the tests
-expect the fixed code to do.  This is a unified diff string that has been
-present in the input from Step 1 — you do NOT need to issue any op to access
-it. The value lives at `data.test_patch` in the same input artifact as
-`data.problem_statement`.
-
-This gives a precise specification: the fix must make those tests pass. Do
-NOT apply the test_patch now — that happens in verify.
+expect the fixed code to do.  This gives a precise specification: the fix must
+make those tests pass. Do NOT apply the test_patch now — that happens in verify.
 
 ## Step 5 — Record exploration findings
 

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -142,6 +142,10 @@ The input is either:
   the exploration artifact saved to the workspace by the earlier explore
   phase.
 
+Read the input artifact's `data` fields directly. If the input was offloaded
+(`type: artifact_ref`), read its `ref_path` first rather than aborting with
+"input missing".
+
 You may need to
 refer back to the original SWE-bench input fields (`problem_statement`,
 `test_patch`) for context — those were carried into the workspace by the

--- a/src/reyn/stdlib/skills/swe_bench/phases/plan.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/plan.md
@@ -142,9 +142,7 @@ The input is either:
   the exploration artifact saved to the workspace by the earlier explore
   phase.
 
-In both cases the fields are present in the prompt's input-artifact block
-(= the OS injects the artifact data structurally — no need to abort with
-"exploration missing" before reading the prompt). You may ALSO need to
+You may need to
 refer back to the original SWE-bench input fields (`problem_statement`,
 `test_patch`) for context — those were carried into the workspace by the
 explore phase and can be re-read via a file op against the exploration

--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -83,50 +83,29 @@ the fix is correct.
 
 ## Step 1 — Apply the test_patch
 
-The `data.test_patch` field in the input is a unified diff. The
-verify-phase preprocessor has already normalized it deterministically
-(= CRLF → LF, BOM stripped, trailing newline ensured) so `git apply`
-operates on a clean diff.
-
-Write the sanitized diff to a temp file (e.g. `.reyn/swe_bench_test.patch`)
-then apply with robust flags:
+`data.test_patch` is a unified diff; the verify-phase preprocessor has already
+normalized it (CRLF → LF, BOM stripped, trailing newline). Write it to a temp
+file (e.g. `.reyn/swe_bench_test.patch`) and run `git apply` **exactly once**:
 
 ```
 git apply --3way --recount --whitespace=fix .reyn/swe_bench_test.patch
 ```
 
-The flags layer second-line defenses on top of the preprocessor:
-`--3way` enables merge-style recovery on context drift, `--recount`
-tolerates off-by-N context line counts, and `--whitespace=fix`
-forgives trailing-space drift.
-
-Apply the test_patch **once** — do not re-apply it. A second apply of an
-already-applied patch returns non-zero ("patch does not apply") purely
-because the patch is *already in the tree* (idempotency), NOT because it
-failed to apply; reading that second non-zero as an apply failure is a
-mis-diagnosis.
-
-If `git apply` returns non-zero, FIRST determine whether the patch is
-**already applied** before treating it as a failure — reverse-check it:
+**Do NOT run `git apply` a second time.** If the first apply returns non-zero,
+do NOT re-apply it — instead check whether the patch is already in the tree:
 
 ```
 git apply --reverse --check .reyn/swe_bench_test.patch
 ```
 
-If the reverse-check succeeds (returncode 0), the test_patch is already in
-the tree — **proceed to Step 2 and run the tests**; do NOT set
-`tests_passed = false`. Only a patch that is **neither applicable nor
-already-applied** (the `--reverse --check` also returns non-zero) is a
-genuine verify execution failure (not a test failure): set
-`tests_passed = false` and record the failure in `failure_summary`
-(= include the exact stderr from git apply, NOT a vague "patch failed"
-summary). The tests could not be evaluated, so this is not a pass.
+- The reverse-check succeeds (returncode 0) → the patch is already applied →
+  proceed to Step 2 and run the tests.
+- The reverse-check is also non-zero → the patch is genuinely not applicable →
+  set `tests_passed = false` with the exact git stderr in `failure_summary`
+  (the tests could not be run, so this is not a pass).
 
-**Do NOT skip the test_patch** — an unapplied test patch means tests
-can't be evaluated; that's NOT a pass. The schema invariant
-(`oneOf` on `swe_bench_result`) rejects `tests_passed=true` with an
-empty patch, but an unapplied test_patch could still produce a
-mis-attributed `tests_passed=true` if the LLM bypasses Step 1.
+Either way, move on after this single check — never re-apply. Never skip the
+test_patch: unapplied tests cannot be evaluated and are not a pass.
 
 ## Step 2 — Run the tests
 

--- a/tests/test_swe_bench_verify_idempotency_1206.py
+++ b/tests/test_swe_bench_verify_idempotency_1206.py
@@ -70,6 +70,28 @@ def test_verify_md_step1_carries_idempotency_distinction() -> None:
     )
 
 
+def test_verify_md_step1_forbids_reapply() -> None:
+    """Tier 2: verify.md Step 1 unambiguously forbids re-applying (9th-defect driver).
+
+    The 9th-defect driver (astropy-13398/13453) was the model re-applying
+    ``git apply`` and misreading the second rc=1 (idempotency) as a failure,
+    looping. The minimized Step 1 targets that driver by making non-re-application
+    explicit — apply exactly once; on a non-zero apply, reverse-check ONCE, never
+    re-apply — so a model following it cannot enter the re-apply loop. Pin that the
+    apply-once / do-not-re-apply instruction is present (the prompt-side driver fix
+    exists). Behavioural driver-removal is verified by the 13398 faithful re-run,
+    not here (prose-presence is necessary, not sufficient).
+    """
+    lowered = _VERIFY_MD.read_text(encoding="utf-8").lower()
+    assert "exactly once" in lowered, (
+        "verify.md Step 1 must instruct applying the test_patch exactly once."
+    )
+    assert "do not re-apply" in lowered or "never re-apply" in lowered, (
+        "verify.md Step 1 must explicitly forbid re-applying git apply — the "
+        "9th-defect re-apply→misread-rc=1 loop driver."
+    )
+
+
 # ── (b) idiom-correctness (deterministic, no LLM) ────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — owner-directed minimization of the swe_bench cheat-skill prose (closes #1393, refs #1206). The #183 weak-model probe surfaced two skill-instruction defects under the "cognition floor"; per owner direction (the skill is fundamentally a cheat → **minimize / delete confusing prose, do NOT add op-ification or OS machinery**), these are fixed by deletion. Design-reviewed + approved by lead-coder (P1 gap-check + P2 driver-targeted form).

## P1 — offload context-incoherence (8th defect, #1393)
`explore.md` + `plan.md` asserted unconditionally *"the fields are present… read `data.*` directly… do NOT abort"*. **False when the input is offloaded** (`type=artifact_ref`, `data={}`): the weak model obeyed the inline-assertion, treated field names as file paths, and never read the ref → derailed (= astropy-13236 r2, originally mis-attributed to cognition; **retracted**). Deleted both assertions.
**Gap-check (verified):** the OS already covers offload — `llm.py:626-630` instructs reading `ref_path` via a read op when `input_artifact.type == "artifact_ref"`. So deleting the skill's contradiction leaves the OS explanation to take over — no gap, no new machinery. The inline case stays covered by Step 1.

## P2 — verify apply-loop (9th defect, refs #1206)
`verify.md` Step 1's ~46-line idempotency case-split let the weak model **re-apply `git apply` and misread the second rc=1 (idempotency) as a failure, looping** (apply×11 / ×34, pytest never run). Minimized to a **driver-targeted** form: apply **exactly once**, **do NOT re-apply**, and on a non-zero apply do a **single terminal** reverse-check (already-applied → proceed; genuine-fail → `tests_passed=false`). The load-bearing reverse-check is **kept** (the #1206 already-applied rc=1 is real — the preprocessor revert skips new-file test_patches); only verbose explanation / schema-invariant prose is cut.

## ⚠️ Driver-removal is EMPIRICAL (honest note, per lead-coder)
Prose-shortening is **necessary, not sufficient**. The minimized form makes non-re-application unambiguous so a model *following* it cannot loop — but whether the weak model now follows it is verified by the **13398/13236 faithful re-run** (model no longer misread-retries), NOT by prose length. **If the weak model re-applies despite the crystal-clear "do NOT re-apply", that is a finding** (minimization alone insufficient = a machinery-vs-owner-direction tension) to escalate to lead/owner — I will not pre-empt with op-ification.

## Verification
- [x] `tests/test_swe_bench_verify_idempotency_1206.py` (3): keeps (a) reverse-check text-presence + (b) deterministic idiom-correctness (already-applied vs genuine-fail), **gains** the apply-once / do-not-re-apply invariant (P2 driver fix).
- [x] swe_bench skill loads + all 3 phase frontmatters parse; 20 swe_bench skill tests pass; ruff + tier clean.
- [ ] CI pytest 3.11/3.12
- [ ] (post-merge, behavioural) sandbox_2 faithful re-run: 13398 re-apply→misread loop gone + 13236 (P1 incoherence resolved → reads ref → reaches task).

## Test plan
- [x] `pytest tests/test_swe_bench_verify_idempotency_1206.py -q` (3 passed) + ruff + tier audit (clean)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)