### PR TITLE
fix(183/#1206): restore anti-false-pass guard in verify.md (apply ≠ pass)

### DIFF
--- a/src/reyn/stdlib/skills/swe_bench/phases/verify.md
+++ b/src/reyn/stdlib/skills/swe_bench/phases/verify.md
@@ -104,8 +104,10 @@ git apply --reverse --check .reyn/swe_bench_test.patch
   set `tests_passed = false` with the exact git stderr in `failure_summary`
   (the tests could not be run, so this is not a pass).
 
-Either way, move on after this single check — never re-apply. Never skip the
-test_patch: unapplied tests cannot be evaluated and are not a pass.
+Either way, move on to Step 2 (run the tests) after this single check — never
+re-apply. Applying the test_patch is NOT a pass on its own: you must still run
+the tests. Never skip the test_patch — unapplied tests cannot be evaluated and
+are not a pass.
 
 ## Step 2 — Run the tests
 
@@ -149,7 +151,10 @@ the test files applied when it produces the final diff.
 
 ## Step 4 — Evaluate the outcome
 
-Inspect the test runner's exit code and output and record the verdict:
+Inspect the test runner's exit code and output and record the verdict.
+`tests_passed = true` requires that you actually ran the tests in Step 2 and
+pytest exited 0 — **applying the test_patch is NOT a pass on its own**. If you
+did not run the tests, you cannot report a pass.
 
 - Exit code 0, all tests collected and passed → `tests_passed = true`,
   `failure_summary = ""`.

--- a/tests/test_swe_bench_verify_idempotency_1206.py
+++ b/tests/test_swe_bench_verify_idempotency_1206.py
@@ -92,6 +92,28 @@ def test_verify_md_step1_forbids_reapply() -> None:
     )
 
 
+def test_verify_md_guards_against_apply_equals_pass() -> None:
+    """Tier 2: verify.md guards against the 'apply = pass' false-pass shortcut.
+
+    sandbox_2's behavioural N=3 on the minimized verify.md found the model
+    reporting tests_passed=true with pytest run 0 times — apply-success conflated
+    with test-pass, Step 2 (run the tests) skipped. The minimization had over-cut
+    the anti-false-pass guard, and removing the apply-loop exposed the latent
+    shortcut. The minimal guard must be present: applying the test_patch is NOT a
+    pass on its own, and tests_passed=true requires an actual test run. Behavioural
+    removal of the false-pass is confirmed by the 13398 faithful re-run, not here.
+    """
+    lowered = _VERIFY_MD.read_text(encoding="utf-8").lower()
+    assert "not a pass on its own" in lowered, (
+        "verify.md must state that applying the test_patch is NOT a pass on its "
+        "own (the 'apply = pass' false-pass guard)."
+    )
+    assert "actually ran the tests" in lowered or "pytest exited 0" in lowered, (
+        "verify.md must require actually running the tests (real pytest exit) "
+        "before reporting tests_passed=true — not infer a pass from apply success."
+    )
+
+
 # ── (b) idiom-correctness (deterministic, no LLM) ────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — follow-up to the #1394 verify.md minimization (refs #1206). lead-coder-dispatched after sandbox_2's behavioural N=3 re-run. A **minimization-family wording fix, NO machinery** (the 9th-defect driver is already gone; this restores a load-bearing guard the minimization over-cut).

## What the re-run found
sandbox_2's behavioural N=3 on the merged #1394 confirmed the P2 fix **worked** — 13398's re-apply→misread-rc=1 loop is **GONE** (the minimization succeeded). But it exposed a **NEW false-pass**: the model reported `tests_passed=true` with **pytest run 0 times** — conflating apply-success with test-pass and skipping Step 2. My minimization had **over-cut the anti-false-pass guard** (the deleted schema-invariant note), and removing the apply-loop surfaced the latent shortcut. Same over-cut pattern as the anti-abort steer in #1394 — this time caught by the **behavioural net**, not a unit test (exactly the empirical-acceptance value).

## Fix
- **Step 1** now ends *"move on **to Step 2 (run the tests)**"* (not *"move on after this single check"*) — so apply-completion is not read as "done".
- **Step 4** restores the minimal guard: `tests_passed = true` requires actually running the tests in Step 2 and pytest exiting 0 — **applying the test_patch is NOT a pass on its own**.

No op-ification (the driver is gone; this is a wording fix restoring a load-bearing guard, same class as #1394's anti-abort restoration).

## Verification
- [x] `tests/test_swe_bench_verify_idempotency_1206.py` gains an apply≠pass guard-presence test (alongside the kept reverse-check + idiom-correctness + apply-once invariants). 11 tests pass.
- [x] ruff + tier audit clean; verify.md frontmatter parses.
- [ ] CI pytest 3.11/3.12
- [ ] (post-merge, behavioural) sandbox_2 faithful re-run: 13398 false-pass gone — pytest actually runs, `tests_passed` tracks the real pytest exit.

## Test plan
- [x] `pytest tests/test_swe_bench_verify_idempotency_1206.py tests/test_swe_bench_skill_pr_g_field_access.py -q` (11 passed) + ruff + tier (clean)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)