### PR TITLE
feat(#187): add scoped `reyn chat --grant-file-write` (chat↔run symmetry)

### DIFF
--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -69,6 +69,24 @@ def register(sub) -> None:
             "Safe-mode python steps run without this flag. Off by default."
         ),
     )
+    # #187: scoped file grant for the agent, symmetric with `reyn run
+    # --grant-file-write` (run.py:85). Grants file.read/file.write at the
+    # resolver layer; the effective scope is bounded by the sandbox write_paths
+    # ∩ (the env-backend's repo/workspace zone), so a non-interactive / scripted
+    # agent can edit a working tree without a permission prompt but cannot escape
+    # it. General capability (any chat session), not skill-specific — unlike a
+    # skill run, a chat agent has no skill declaring `file.read`, so the flag
+    # grants both read and write (mirrors the eval path, eval_benchmark.py:742).
+    p.add_argument(
+        "--grant-file-write",
+        dest="grant_file_write",
+        action="store_true",
+        help=(
+            "Grant file.read/file.write at the resolver layer for this session, "
+            "scoped to the sandbox write zone. For non-interactive / scripted "
+            "agent runs that edit a working tree without a permission prompt."
+        ),
+    )
     p.add_argument(
         "--banner",
         action="store_true",
@@ -272,6 +290,14 @@ def run(args: argparse.Namespace) -> None:
     budget_tracker.load_state(budget_state_path)
     budget_tracker.set_state_path(budget_state_path)
     perm_config = getattr(session_cfg.config, "permissions", {}) or {}
+    # #187: --grant-file-write grants file.read/write at the resolver layer
+    # (mirrors `reyn run` run.py:126 + the eval swe_bench path
+    # eval_benchmark.py:742). The grant is bounded by the sandbox write_paths ∩
+    # (env-backend repo zone), so the effective scope is the working tree, not
+    # global. setdefault preserves any explicit operator setting.
+    if getattr(args, "grant_file_write", False):
+        perm_config.setdefault("file.read", "allow")
+        perm_config.setdefault("file.write", "allow")
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
     # Single PermissionResolver shared across agents (per the PR10 decision:
     # `.reyn/approvals.yaml` is process-wide).

--- a/tests/test_chat_grant_file_write_187.py
+++ b/tests/test_chat_grant_file_write_187.py
@@ -1,0 +1,96 @@
+"""Tier 2: OS invariant — `reyn chat --grant-file-write` resolver ∩ sandbox grant.
+
+#187: solving SWE with the general agent (RouterLoop / `reyn chat`) in a
+non-interactive / scripted container run needs the agent to edit the repo
+working tree without a permission prompt. `reyn chat` gained a scoped
+`--grant-file-write` flag, symmetric with `reyn run` (test_run_grant_file_write_183).
+
+Unlike `reyn run` (where the skill declares `file.read`), a chat agent has NO
+skill, so the chat flag grants BOTH `file.read` AND `file.write` (the eval
+swe_bench path, eval_benchmark.py:742, does the same). The SandboxLayer (∩)
+bounds the write to the env-backend's `write_paths` (= the repo working tree), so
+the blanket resolver `allow` is scoped to the working tree, NOT global.
+
+Pins with a REAL PermissionResolver + real SandboxPolicy (never a None resolver,
+per the enforcement-test rule):
+  - chat grant injects file.read AND file.write = 'allow';
+  - grant + sandbox[repo] → an in-repo write is ALLOWED;
+  - the SAME grant → a write OUTSIDE the sandbox zone is DENIED (∩ scopes it);
+  - WITHOUT the grant → an in-repo write is DENIED (the prompt-less default);
+  - `reyn chat` exposes `--grant-file-write` (dest=grant_file_write).
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.sandbox.policy import SandboxPolicy
+
+_REPO = "/testbed"
+_DECL = PermissionDecl()
+
+
+def _chat_grant_config(*, granted: bool) -> dict:
+    """Mirror what `reyn chat --grant-file-write` injects into config_permissions
+    (chat.py): setdefault file.read AND file.write to 'allow'."""
+    config: dict = {}
+    if granted:
+        config.setdefault("file.read", "allow")
+        config.setdefault("file.write", "allow")
+    return config
+
+
+def _resolver(*, granted: bool) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=_chat_grant_config(granted=granted),
+        project_root=Path("/tmp"),
+        interactive=False,
+    )
+
+
+def _can_write(resolver: PermissionResolver, path: str) -> bool:
+    sandbox = SandboxPolicy(write_paths=[_REPO])
+    try:
+        resolver.require_file_write(_DECL, path, "default", sandbox_policy=sandbox)
+        return True
+    except PermissionError:
+        return False
+
+
+def test_chat_grant_injects_read_and_write() -> None:
+    """Tier 2: the chat grant injects BOTH file.read and file.write (no skill
+    declares read for a chat agent, unlike `reyn run`)."""
+    config = _chat_grant_config(granted=True)
+    assert config.get("file.read") == "allow"
+    assert config.get("file.write") == "allow"
+
+
+def test_chat_grant_allows_in_repo_write() -> None:
+    """Tier 2: chat grant + sandbox[repo] → an in-repo write is allowed (agent edits)."""
+    assert _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
+
+
+def test_chat_grant_still_denies_outside_sandbox_zone() -> None:
+    """Tier 2: the SandboxLayer ∩ scopes the chat grant — a write OUTSIDE write_paths
+    (e.g. /etc) is DENIED even with the resolver grant (scope from the sandbox, not
+    the blanket resolver allow). Same safety as `reyn run --grant-file-write`."""
+    assert _can_write(_resolver(granted=True), "/etc/passwd") is False
+
+
+def test_chat_no_grant_denies_in_repo_write() -> None:
+    """Tier 2: flag absent → no grant → even an in-repo write is DENIED (the
+    non-interactive prompt-less default). Falsification pair for the grant test."""
+    assert _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
+
+
+def test_chat_parser_exposes_grant_file_write_flag() -> None:
+    """Tier 2: `reyn chat` registers --grant-file-write (dest=grant_file_write),
+    default False — symmetric with `reyn run`."""
+    from reyn.cli.commands.chat import register
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    register(sub)
+    assert parser.parse_args(["chat", "--grant-file-write"]).grant_file_write is True
+    assert parser.parse_args(["chat"]).grant_file_write is False


### PR DESCRIPTION
**[e2e-coder]** — #187 stage-1 part 1 (the general-OS prerequisite for the general-agent SWE wiring; design surface #1397, owner-confirmed direction, lead-approved (a)). Triple-endorsed (lead + e2e + sandbox_2).

## What
Add `--grant-file-write` to `reyn chat`, **symmetric with `reyn run --grant-file-write`** (run.py:85). #187 (solve SWE with the general agent / RouterLoop) needs a non-interactive / scripted `reyn chat --env-backend=docker --container` agent to edit a repo working tree without a permission prompt.

## Why it's a general OS change (not SWE-specific → not the owner-forbidden change)
chat↔run symmetry: chat gains the same scoped file-write grant capability run already has — usable by **any** chat session, not SWE-limited. lead confirmed this is general (allowed).

## Mechanism (sandbox_2-verified, D12 domain)
- Grant = `config.permissions.setdefault("file.read"/"file.write","allow")` at the resolver layer (identical to run.py:126 + eval_benchmark.py:742). Chat grants **both read+write** (a chat agent has no skill declaring `file.read`, unlike `reyn run`).
- **Scoping is the SandboxLayer ∩**, not the resolver: the blanket `allow` is bounded to the env-backend's `write_paths` (= repo working tree), so the agent edits the repo but **cannot escape** it. Same safety as `reyn run --grant-file-write`.
- exec needs no config key (`exec__sandboxed_exec` auto-exposed by the D14 visibility gate when `--env-backend=docker` provides a sandbox_backend).

## Verification
- [x] `tests/test_chat_grant_file_write_187.py` (5 Tier-2, mirrors test_run_grant_file_write_183): flag exposed; grant injects read+write; ∩ scopes in-repo write ALLOW vs out-of-zone DENY; no-grant denies in-repo write. Real PermissionResolver + SandboxPolicy (no None resolver).
- [x] 16 related tests pass (chat-grant + run-grant + chat-cli-flags); ruff + tier clean.
- [ ] CI pytest 3.11/3.12

## Test plan
- [x] `pytest tests/test_chat_grant_file_write_187.py tests/test_run_grant_file_write_183.py -q` + ruff + tier (clean)
- [ ] CI green

**Note**: this is stage-1 **part 1** (the chat flag). **Part 2** (the `run_reyn_chat_in_container` runner wiring that uses this flag to invoke the general agent on a SWE task, + the docker smoke-test) follows as a separate PR — splitting the general-OS flag from the SWE-specific harness wiring keeps both focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)