### PR TITLE
feat(#187): general-agent SWE runner path (run_reyn_chat_in_container)

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -447,6 +447,157 @@ def run_reyn_in_container(
             )
 
 
+# ── #187: general-agent (reyn chat / RouterLoop) SWE path ────────────────────
+
+
+def build_swe_task_prompt(instance: dict[str, Any]) -> str:
+    """#187: a minimal, de-prescribed SWE task for the general agent.
+
+    No procedure ("reproduce → verify → …") — the agent has tools (read / edit /
+    grep / glob / sandboxed_exec) and decides how. NO test_patch (it is held out;
+    the harness scores externally from the dataset). The agent fixes the issue in
+    the working tree; the model_patch is the resulting ``git diff HEAD``.
+    """
+    repo = instance.get("repo", "")
+    base = instance.get("base_commit", "")
+    issue = (instance.get("problem_statement", "") or "").strip()
+    hints = (instance.get("hints_text", "") or "").strip()
+    lines = [
+        f"This repository ({repo}, checked out at commit {base}) has the following "
+        "open GitHub issue. Fix it in the working tree. You have file and shell "
+        "tools; how you investigate and verify the fix is your judgment.",
+        "",
+        "## Issue",
+        issue,
+    ]
+    if hints:
+        lines += ["", "## Hints", hints]
+    return "\n".join(lines)
+
+
+def run_reyn_chat_in_container(
+    instance: dict[str, Any],
+    *,
+    image: str,
+    repo_dir: str = "/testbed",
+    docker_bin: str = "docker",
+    timeout: int = 600,
+    docker_runner=None,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    """#187: solve the SWE task with the GENERAL AGENT (``reyn chat`` / RouterLoop),
+    NOT the swe_bench skill. The held-out test_patch is never given to the agent
+    (it is not in the task prompt); the model_patch is the in-container
+    ``git diff HEAD`` after the agent finishes editing the working tree.
+
+    Lifecycle mirrors :func:`run_reyn_in_container` (start container, provision the
+    reyn venv, teardown always), but invokes ``reyn chat --env-backend=docker
+    --container <name> --grant-file-write`` in scripted mode (the SWE task piped to
+    stdin) instead of ``reyn run swe_bench``.
+    """
+    import uuid
+
+    runner = docker_runner or _default_docker_runner
+    instance_id = instance["instance_id"]
+    name = container_name or f"reyn_swebench_chat_{instance_id}_{uuid.uuid4().hex[:8]}"
+    reyn_root = str(_reyn_repo_root())
+
+    print(
+        f"[swe_bench_runner] (chat/#187) docker run image={image} name={name} "
+        f"(instance={instance_id})",
+        file=sys.stderr,
+    )
+    try:
+        start = runner(
+            [
+                docker_bin, "run", "-d", "--name", name,
+                "-v", f"{reyn_root}:{reyn_root}:ro",
+                image, "sleep", "infinity",
+            ],
+            timeout=300,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"ok": False, "error": f"docker run error: {exc}"}
+    if start.returncode != 0:
+        return {
+            "ok": False,
+            "error": f"docker run failed (rc={start.returncode}): {(start.stderr or '')[:400]}",
+        }
+
+    try:
+        deps = reyn_runtime_deps((_reyn_repo_root() / "pyproject.toml").read_text())
+        print(
+            f"[swe_bench_runner] provisioning reyn venv in {name} ({len(deps)} deps)",
+            file=sys.stderr,
+        )
+        prov = runner(
+            [docker_bin, "exec", name, "bash", "-lc", provision_command(deps, f"{reyn_root}/src")],
+            timeout=600,
+        )
+        if getattr(prov, "returncode", 1) != 0:
+            return {
+                "ok": False,
+                "error": f"venv provisioning failed (rc={prov.returncode}): {(prov.stderr or '')[:400]}",
+            }
+
+        # Invoke the GENERAL AGENT (reyn chat) with the SWE task via stdin. The
+        # scoped --grant-file-write lets the agent edit the in-container repo
+        # working tree non-interactively (sandbox ∩ bounds it to repo_dir). NO
+        # test_patch is in the task (held out; the harness scores externally).
+        task = build_swe_task_prompt(instance)
+        chat_cmd = [
+            "reyn", "chat",
+            "--cui",
+            "--env-backend=docker",
+            "--container", name,
+            "--repo-dir", repo_dir,
+            "--grant-file-write",
+        ]
+        run_env = {**os.environ, "REYN_HARNESS_PYTHON": _CONTAINER_HARNESS_PYTHON}
+        print(
+            f"[swe_bench_runner] running: {' '.join(chat_cmd)} (instance={instance_id})",
+            file=sys.stderr,
+        )
+        try:
+            subprocess.run(
+                chat_cmd,
+                input=task,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=run_env,
+            )
+        except subprocess.TimeoutExpired:
+            print(
+                f"[swe_bench_runner] chat timed out after {timeout}s — extracting diff",
+                file=sys.stderr,
+            )
+
+        # model_patch = the agent's edits, as the in-container `git diff HEAD`.
+        diff = runner(
+            [docker_bin, "exec", name, "git", "-C", repo_dir, "diff", "HEAD"],
+            timeout=120,
+        )
+        patch = getattr(diff, "stdout", "") if getattr(diff, "returncode", 1) == 0 else ""
+        if isinstance(patch, bytes):
+            patch = patch.decode("utf-8", "replace")
+        return {"ok": True, "patch": patch}
+    finally:
+        try:
+            rm = runner([docker_bin, "rm", "-f", name], timeout=120)
+            if getattr(rm, "returncode", 0) != 0:
+                print(
+                    f"[swe_bench_runner] WARN teardown rm -f {name} rc={rm.returncode}: "
+                    f"{(rm.stderr or '')[:200]}",
+                    file=sys.stderr,
+                )
+        except (OSError, subprocess.SubprocessError) as exc:
+            print(
+                f"[swe_bench_runner] WARN teardown rm -f {name} raised: {exc}",
+                file=sys.stderr,
+            )
+
+
 # ── CLI entry point ──────────────────────────────────────────────────────────
 
 
@@ -526,6 +677,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--docker-bin", dest="docker_bin", default="docker", metavar="BIN",
         help="Docker CLI binary for --env-backend=docker (default: docker).",
     )
+    # #187: solve with the general agent (`reyn chat` / RouterLoop) instead of the
+    # swe_bench skill — the non-cheat path (no test_patch; the agent iterates with
+    # its tools). Requires --env-backend=docker. The skill path stays the default
+    # (non-destructive; both coexist until the general-agent path is dogfood-proven).
+    p.add_argument(
+        "--agent-mode", dest="agent_mode", choices=["skill", "chat"], default="skill",
+        help=(
+            "Solver: 'skill' (default, `reyn run swe_bench`) or 'chat' (#187, the "
+            "general agent `reyn chat` — no test_patch, the agent iterates). "
+            "'chat' requires --env-backend=docker."
+        ),
+    )
 
     return p
 
@@ -572,15 +735,31 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-        result = run_reyn_in_container(
-            instance,
-            image=args.image,
-            repo_dir=args.repo_dir,
-            state_dir=args.state_dir,
-            docker_bin=args.docker_bin,
-            reyn_base=reyn_cmd,
-            timeout=args.timeout,
+        if getattr(args, "agent_mode", "skill") == "chat":
+            # #187: solve with the general agent (reyn chat), not the skill.
+            result = run_reyn_chat_in_container(
+                instance,
+                image=args.image,
+                repo_dir=args.repo_dir,
+                docker_bin=args.docker_bin,
+                timeout=args.timeout,
+            )
+        else:
+            result = run_reyn_in_container(
+                instance,
+                image=args.image,
+                repo_dir=args.repo_dir,
+                state_dir=args.state_dir,
+                docker_bin=args.docker_bin,
+                reyn_base=reyn_cmd,
+                timeout=args.timeout,
+            )
+    elif getattr(args, "agent_mode", "skill") == "chat":
+        print(
+            "Error: --agent-mode=chat requires --env-backend=docker.",
+            file=sys.stderr,
         )
+        return 1
     else:
         result = run_reyn(instance, reyn_cmd=reyn_cmd, timeout=args.timeout)
 

--- a/tests/test_swe_bench_runner_chat_187.py
+++ b/tests/test_swe_bench_runner_chat_187.py
@@ -1,0 +1,85 @@
+"""Tier 2: #187 — the general-agent (reyn chat) SWE runner path withholds test_patch.
+
+#187 solves SWE with the general agent (`reyn chat` / RouterLoop) instead of the
+swe_bench skill. The held-out evaluation `test_patch` must NEVER reach the agent
+(test-leakage = the cheat); the harness scores it externally from the dataset.
+
+The in-container agent loop itself needs docker (= sandbox_2's faithful dogfood,
+not a unit). What IS unit-testable here:
+  (a) the SWE task prompt withholds test_patch and carries the issue + base_commit;
+  (b) the prompt is minimal / de-prescribed (no rigid "reproduce → verify" steps —
+      re-introducing a procedure would be the phase-graph over-specialization the
+      pivot removed);
+  (c) the runner exposes `--agent-mode {skill,chat}` (default skill = the old
+      path stays, non-destructive) and `chat` requires `--env-backend=docker`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import swe_bench_runner as r  # noqa: E402
+
+_INSTANCE = {
+    "instance_id": "astropy__astropy-13453",
+    "repo": "astropy/astropy",
+    "base_commit": "abc123def456",
+    "problem_statement": "BUG: Table.write(format='html') drops the formats kwarg.",
+    "hints_text": "Look at astropy/io/ascii/html.py near the write method.",
+    "test_patch": (
+        "diff --git a/astropy/io/ascii/tests/test_html.py ...\n"
+        "+def test_formats_kwarg_applied(): SECRET_EVAL_ASSERTION"
+    ),
+}
+
+
+def test_swe_task_prompt_withholds_test_patch() -> None:
+    """Tier 2: the agent's SWE task prompt does NOT contain the held-out test_patch."""
+    prompt = r.build_swe_task_prompt(_INSTANCE)
+    assert "SECRET_EVAL_ASSERTION" not in prompt, "the held-out test_patch must not leak into the agent prompt"
+    assert "test_patch" not in prompt, "do not mention test_patch (held out; the harness scores it)"
+
+
+def test_swe_task_prompt_carries_issue_and_base_commit() -> None:
+    """Tier 2: the prompt carries the legitimate task inputs (issue + base_commit)."""
+    prompt = r.build_swe_task_prompt(_INSTANCE)
+    assert "Table.write(format='html') drops the formats kwarg" in prompt
+    assert "abc123def456" in prompt  # base_commit
+    assert "astropy/astropy" in prompt  # repo
+
+
+def test_swe_task_prompt_is_minimal_no_rigid_procedure() -> None:
+    """Tier 2: the prompt is de-prescribed — no rigid 'Step 1 / reproduce / verify'
+    procedure (that would re-introduce the phase-graph over-specialization the pivot
+    removed). The agent decides how; the prompt just states the task + that it has tools."""
+    lowered = r.build_swe_task_prompt(_INSTANCE).lower()
+    # No numbered procedure / prescribed verify method.
+    assert "step 1" not in lowered
+    assert "reproduce the" not in lowered  # not prescribing a reproduction procedure
+    # It does hand the agent agency over the 'how'.
+    assert "your judgment" in lowered
+
+
+def test_runner_exposes_agent_mode_flag_default_skill() -> None:
+    """Tier 2: --agent-mode {skill,chat}, default 'skill' (old path stays, non-destructive)."""
+    p = r.build_parser()
+    assert p.parse_args(["--input", "/dev/null"]).agent_mode == "skill"
+    assert p.parse_args(["--input", "/dev/null", "--agent-mode", "chat"]).agent_mode == "chat"
+
+
+def test_agent_mode_chat_requires_docker(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Tier 2: --agent-mode=chat without --env-backend=docker exits 1 (the general
+    agent needs the per-instance container)."""
+    import json
+
+    inst_file = tmp_path / "inst.json"
+    inst_file.write_text(json.dumps(_INSTANCE), encoding="utf-8")
+    rc = r.main(["--input", str(inst_file), "--agent-mode", "chat"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "requires --env-backend=docker" in err


### PR DESCRIPTION
**[e2e-coder]** — #187 stage-1 **part 2** (the SWE runner wiring; uses the chat `--grant-file-write` flag landed in #1398). Solves a SWE-bench task with the **general agent** (`reyn chat` / RouterLoop) instead of the swe_bench skill. The old skill path is **UNTOUCHED** (non-destructive — default `--agent-mode=skill`).

## What
- `--agent-mode {skill,chat}` (default `skill`). `chat` requires `--env-backend=docker`.
- **`run_reyn_chat_in_container`**: mirrors `run_reyn_in_container`'s lifecycle (start container, provision the reyn venv, teardown always), but invokes `reyn chat --env-backend=docker --container <name> --repo-dir <dir> --grant-file-write --cui` in scripted mode (the SWE task piped to stdin). RouterLoop iterates with its tools (read/edit/grep/glob/sandboxed_exec); **model_patch = in-container `git diff HEAD`** (the agent doesn't emit model_patch like the skill).
- **`build_swe_task_prompt`**: minimal, de-prescribed — *"this repo @ base_commit has this issue; fix it; how you verify is your judgment"* + problem_statement (+ hints). **NO test_patch** (held out; the harness scores externally). No rigid reproduce/verify procedure.
- `REYN_LLM_TRACE_DUMP` propagates via `run_env` for the dogfood trace.

## Review points (lead)
- (a) scripted invocation passes the SWE task + extracts git diff — clean.
- (b) withholding: `build_swe_task_prompt` never includes test_patch (Tier-2 verified).
- (c) non-destructive: old skill path is the default, untouched.

## Verification
- [x] `tests/test_swe_bench_runner_chat_187.py` (5 Tier-2): prompt withholds test_patch / carries issue+base_commit / minimal-no-rigid-procedure / --agent-mode default skill / chat-requires-docker.
- [x] ruff + tier clean.
- [ ] CI pytest 3.11/3.12.
- [ ] smoke-test (in-container chat-path on one instance → produces a diff + trace) — running; trace calibrates sandbox_2's dogfood analysis.
- [ ] (post-merge) sandbox_2 faithful dogfood = #187 empirical proof (flash-lite SWE loop → resolving diff / frame-leak-closed / useful iteration / ACI-gap, N variance-robust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)