### PR TITLE
feat(187): reyn run-once — one-shot agent invocation (replaces REPL-scripting for faithful SWE)

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -475,7 +475,7 @@ def build_swe_task_prompt(instance: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def run_reyn_chat_in_container(
+def run_reyn_once_in_container(
     instance: dict[str, Any],
     *,
     image: str,
@@ -484,26 +484,33 @@ def run_reyn_chat_in_container(
     timeout: int = 600,
     docker_runner=None,
     container_name: str | None = None,
+    max_iterations: int = 80,
 ) -> dict[str, Any]:
-    """#187: solve the SWE task with the GENERAL AGENT (``reyn chat`` / RouterLoop),
-    NOT the swe_bench skill. The held-out test_patch is never given to the agent
-    (it is not in the task prompt); the model_patch is the in-container
-    ``git diff HEAD`` after the agent finishes editing the working tree.
+    """#187: solve the SWE task with the GENERAL AGENT via ``reyn run-once``, NOT
+    the swe_bench skill. The held-out test_patch is never given to the agent (it is
+    not in the task prompt); the model_patch is the in-container ``git diff HEAD``
+    after the agent finishes editing the working tree.
 
     Lifecycle mirrors :func:`run_reyn_in_container` (start container, provision the
-    reyn venv, teardown always), but invokes ``reyn chat --env-backend=docker
-    --container <name> --grant-file-write`` in scripted mode (the SWE task piped to
-    stdin) instead of ``reyn run swe_bench``.
+    reyn venv, teardown always), but invokes ``reyn run-once --env-backend=docker
+    --container <name> --grant-file-write --exclude-tools web__search,web__fetch``
+    with the WHOLE SWE task piped to stdin as ONE message.
+
+    ``reyn run-once`` reads the entire stdin as a single user turn (not the REPL's
+    line-by-line read, which fragmented the 439-line task into 439 turns — the
+    #1401 root cause) and drives the agent to completion via send_to_agent_impl
+    (the same scoped chat session, no fresh unscoped build). --max-iterations is
+    raised (default 80) so the autonomous agent can explore→edit→verify.
     """
     import uuid
 
     runner = docker_runner or _default_docker_runner
     instance_id = instance["instance_id"]
-    name = container_name or f"reyn_swebench_chat_{instance_id}_{uuid.uuid4().hex[:8]}"
+    name = container_name or f"reyn_swebench_once_{instance_id}_{uuid.uuid4().hex[:8]}"
     reyn_root = str(_reyn_repo_root())
 
     print(
-        f"[swe_bench_runner] (chat/#187) docker run image={image} name={name} "
+        f"[swe_bench_runner] (once/#187) docker run image={image} name={name} "
         f"(instance={instance_id})",
         file=sys.stderr,
     )
@@ -540,32 +547,39 @@ def run_reyn_chat_in_container(
                 "error": f"venv provisioning failed (rc={prov.returncode}): {(prov.stderr or '')[:400]}",
             }
 
-        # Invoke the GENERAL AGENT (reyn chat) with the SWE task via stdin. The
+        # Invoke the GENERAL AGENT via `reyn run-once`, piping the WHOLE SWE task
+        # to stdin as ONE message (run-once reads the entire stdin as a single user
+        # turn — not the REPL's line-by-line read that fragmented the task). The
         # scoped --grant-file-write lets the agent edit the in-container repo
-        # working tree non-interactively (sandbox ∩ bounds it to repo_dir). NO
-        # test_patch is in the task (held out; the harness scores externally).
+        # working tree (sandbox ∩ bounds it to repo_dir); --exclude-tools hides web.
+        # --state-dir keeps reyn's OS state host-side so it never lands on (and
+        # pollutes) the in-container repo `git diff HEAD`. NO test_patch is in the
+        # task (held out; the harness scores externally).
         task = build_swe_task_prompt(instance)
-        chat_cmd = [
-            "reyn", "chat",
-            "--cui",
+        state_dir = f"/tmp/reyn_once_state_{instance_id}_{name[-8:]}"
+        once_cmd = [
+            "reyn", "run-once",
             "--env-backend=docker",
             "--container", name,
             "--repo-dir", repo_dir,
+            "--state-dir", state_dir,
             "--grant-file-write",
             # #187 faithful-eval: the agent solves from the issue + repo ONLY. Hide
             # web tools so it cannot web-search/fetch the gold PR/solution (the
             # benchmark answer) — matching SWE-agent/OpenHands (no web in-bench). The
             # exec network path is already sandbox-gated off; web is the only leak.
             "--exclude-tools", "web__search,web__fetch",
+            # autonomous SWE needs many tool rounds (explore→edit→verify) > chat's 5.
+            "--max-iterations", str(max_iterations),
         ]
         run_env = {**os.environ, "REYN_HARNESS_PYTHON": _CONTAINER_HARNESS_PYTHON}
         print(
-            f"[swe_bench_runner] running: {' '.join(chat_cmd)} (instance={instance_id})",
+            f"[swe_bench_runner] running: {' '.join(once_cmd)} (instance={instance_id})",
             file=sys.stderr,
         )
         try:
             subprocess.run(
-                chat_cmd,
+                once_cmd,
                 input=task,
                 capture_output=True,
                 text=True,
@@ -574,7 +588,7 @@ def run_reyn_chat_in_container(
             )
         except subprocess.TimeoutExpired:
             print(
-                f"[swe_bench_runner] chat timed out after {timeout}s — extracting diff",
+                f"[swe_bench_runner] run-once timed out after {timeout}s — extracting diff",
                 file=sys.stderr,
             )
 
@@ -741,8 +755,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
         if getattr(args, "agent_mode", "skill") == "chat":
-            # #187: solve with the general agent (reyn chat), not the skill.
-            result = run_reyn_chat_in_container(
+            # #187: solve with the general agent via `reyn run-once`, not the skill.
+            result = run_reyn_once_in_container(
                 instance,
                 image=args.image,
                 repo_dir=args.repo_dir,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1273,6 +1273,7 @@ class ChatSession:
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
+        router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -1305,6 +1306,12 @@ class ChatSession:
         # SWE-eval excludes web__search/web__fetch so the agent solves from the
         # repo + issue, not a web lookup of the gold solution.
         self._exclude_tools = frozenset(exclude_tools or ())
+        # #187: per-message tool-call budget for the MAIN chat RouterLoop. The
+        # interactive default (5) suits a human turn; an autonomous one-shot run
+        # (`reyn chat --once` for SWE) needs far more (explore→edit→verify rounds),
+        # so the one-shot path constructs the session with a higher value. Bounded
+        # either way — the loop stops at the cap (finite) or when the agent ends.
+        self._router_max_iterations = int(router_max_iterations)
         # FP-0017 follow-up: declarative sandbox config (reyn.yaml `sandbox:`).
         # Plumbed through to spawned Agents so sandboxed_exec backend selection
         # honors the operator's declared policy.
@@ -5489,7 +5496,8 @@ class ChatSession:
             1,
         )
         loop = RouterLoop(
-            host=self._router_host, chain_id=chain_id, max_iterations=5,
+            host=self._router_host, chain_id=chain_id,
+            max_iterations=self._router_max_iterations,
             budget=self._budget_tracker,
             # #187: hide excluded tools (e.g. web for faithful SWE-eval) from the
             # MAIN agent loop's LLM-visible catalog (same hook the sub-loops use).

--- a/src/reyn/cli/commands/__init__.py
+++ b/src/reyn/cli/commands/__init__.py
@@ -22,6 +22,7 @@ from . import mcp as mcp
 from . import memory as memory
 from . import permissions as permissions
 from . import run as run
+from . import run_once as run_once
 from . import secret as secret
 from . import skill as skill
 from . import skills as skills
@@ -30,4 +31,4 @@ from . import topology as topology
 from . import web as web
 
 # Order is the order shown in `reyn --help`.
-ALL = [init, config, skills, skill, run, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood, embeddings]
+ALL = [init, config, skills, skill, run, run_once, chat, agent, topology, eval, lint, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood, embeddings]

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -20,6 +20,13 @@ from reyn.llm.llm import run_async
 from ..common_args import add_common_args
 from ..session import Session
 
+# #187: send_to_agent_impl timeout for the one-shot (`reyn run-once`) drive. The
+# autonomous SWE agent may iterate for many minutes; the external bound is the
+# caller's process timeout (the SWE runner's subprocess timeout). On timeout the
+# agent's in-container edits persist (partial reply), so the caller still extracts
+# the model_patch via `git diff`.
+_ONCE_SEND_TIMEOUT = 3600.0
+
 
 def register(sub) -> None:
     p = sub.add_parser("chat", help="Start an interactive chat session")
@@ -364,6 +371,10 @@ def run(args: argparse.Namespace) -> None:
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
+            # #187: per-message tool-call budget. Interactive chat keeps 5; the
+            # one-shot autonomous path (`reyn run-once`) raises it (explore→edit→
+            # verify needs many rounds). --max-iterations unset → 5 (unchanged).
+            router_max_iterations=int(getattr(args, "max_iterations", None) or 5),
             # #1289: same backend instance to both seams (single-shared-sandbox).
             environment_backend=env_backend,
             sandbox_backend=env_backend,
@@ -443,6 +454,22 @@ def run(args: argparse.Namespace) -> None:
                 if not await _safe_restore():
                     sys.exit(1)
             await registry.attach(name)
+            # #187: one-shot mode (`reyn run-once`). The scoped session built above
+            # (grant / exclude_tools / env_backend / high router_max_iterations) is
+            # now ATTACHED in the registry. Instead of the line-by-line REPL, read
+            # the WHOLE stdin as a single user message and drive the agent to
+            # completion via send_to_agent_impl — the same programmatic drive MCP /
+            # A2A use (registry.get_or_load returns this attached scoped session, no
+            # fresh unscoped build), then print the final reply and exit.
+            if getattr(args, "once", False):
+                from reyn.mcp_server import send_to_agent_impl
+                message = sys.stdin.read()
+                result = await send_to_agent_impl(
+                    registry, agent_name=name, message=message,
+                    timeout=_ONCE_SEND_TIMEOUT,
+                )
+                sys.stdout.write((result.get("reply", "") or "") + "\n")
+                return
             await run_repl(registry, renderer=renderer)
 
         run_async(_main_cui())

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -28,6 +28,29 @@ from ..session import Session
 _ONCE_SEND_TIMEOUT = 3600.0
 
 
+async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> str:
+    """#187 one-shot drive: read the WHOLE *instream* (default stdin) as a SINGLE
+    user message and drive the agent to completion via ``send_to_agent_impl``,
+    returning the final reply.
+
+    This is the structural fix for the #1401 line-fragmentation bug: the WHOLE
+    stdin becomes ONE message (one ``send`` call), NOT one message per line (the
+    REPL's line-by-line ``readline``). ``instream`` / ``send`` are injectable so
+    the whole-message-not-fragmented behavior is testable with a recording double
+    (no mock); production uses ``sys.stdin`` + the real ``send_to_agent_impl``.
+    """
+    if instream is None:
+        instream = sys.stdin
+    if send is None:
+        from reyn.mcp_server import send_to_agent_impl as send
+    message = instream.read()
+    result = await send(
+        agent_registry, agent_name=agent_name, message=message,
+        timeout=_ONCE_SEND_TIMEOUT,
+    )
+    return result.get("reply", "") or ""
+
+
 def register(sub) -> None:
     p = sub.add_parser("chat", help="Start an interactive chat session")
     p.add_argument(
@@ -462,13 +485,8 @@ def run(args: argparse.Namespace) -> None:
             # A2A use (registry.get_or_load returns this attached scoped session, no
             # fresh unscoped build), then print the final reply and exit.
             if getattr(args, "once", False):
-                from reyn.mcp_server import send_to_agent_impl
-                message = sys.stdin.read()
-                result = await send_to_agent_impl(
-                    registry, agent_name=name, message=message,
-                    timeout=_ONCE_SEND_TIMEOUT,
-                )
-                sys.stdout.write((result.get("reply", "") or "") + "\n")
+                reply = await _run_once(registry, name)
+                sys.stdout.write(reply + "\n")
                 return
             await run_repl(registry, renderer=renderer)
 

--- a/src/reyn/cli/commands/run_once.py
+++ b/src/reyn/cli/commands/run_once.py
@@ -1,0 +1,78 @@
+"""`reyn run-once [agent]` — one-shot, non-interactive agent invocation.
+
+#187: drive the general agent (RouterLoop) on a SINGLE prompt read WHOLE from
+stdin (not line-by-line), to completion (n tool_calls → 1 stop), print the final
+reply, then exit. Conceptually distinct from interactive `reyn chat`: a one-shot
+batch entry for programmatic / eval use (the SWE-bench runner pipes the whole
+task as one message).
+
+Reuses `reyn chat`'s scoped session construction (grant / exclude-tools /
+env-backend / registry) by delegating to ``chat.run`` with ``once=True`` — the
+construction path is shared, only the final drive differs (``send_to_agent_impl``
+instead of the line-by-line REPL). This is why the line-fragmentation bug (the
+REPL read stdin a line at a time) does not recur here, and why the scoped
+capabilities are inherited rather than re-ported (a transport/delivery change,
+not a construction change).
+"""
+from __future__ import annotations
+
+import argparse
+
+from reyn.cli.env_backend import register_env_backend_args
+
+from ..common_args import add_common_args
+from . import chat as _chat
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "run-once",
+        help="Run the general agent once on a stdin prompt, print the reply, exit",
+        description=(
+            "One-shot, non-interactive agent invocation. Reads the WHOLE stdin as a "
+            "single user message, drives the agent to completion, prints the final "
+            "reply, exits. For programmatic / eval use (e.g. SWE-bench)."
+        ),
+    )
+    p.add_argument(
+        "agent_name", nargs="?", default=None,
+        help="Agent to drive (default: 'default').",
+    )
+    # Shared scoped surface — identical flags/help to `reyn chat` / `reyn run`.
+    register_env_backend_args(p)
+    p.add_argument(
+        "--grant-file-write", dest="grant_file_write", action="store_true",
+        default=False,
+        help=(
+            "Grant file.read+file.write at the resolver layer (the non-interactive "
+            "agent edits its working tree without a prompt; bounded by the sandbox "
+            "write-paths ∩). Same as `reyn chat --grant-file-write`."
+        ),
+    )
+    p.add_argument(
+        "--exclude-tools", dest="exclude_tools", default=None, metavar="NAMES",
+        help=(
+            "Comma-separated tool names to hide from the agent's LLM-visible "
+            "catalog (e.g. 'web__search,web__fetch'). Same as `reyn chat "
+            "--exclude-tools`."
+        ),
+    )
+    p.add_argument(
+        "--max-iterations", dest="max_iterations", type=int, default=80, metavar="N",
+        help=(
+            "Per-message tool-call budget for the autonomous loop (default 80). "
+            "Higher than interactive chat (5) so the agent can iterate "
+            "explore→edit→verify to completion."
+        ),
+    )
+    add_common_args(p)
+    # One-shot is always the plain-console (non-TUI) path with the one-shot drive.
+    p.set_defaults(func=run, once=True, cui=True)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Delegate to ``chat.run`` with ``once=True`` (set via ``set_defaults``).
+
+    The one-shot branch in ``chat.run`` (after the registry attach) reads the
+    whole stdin and drives ``send_to_agent_impl`` instead of ``run_repl``."""
+    _chat.run(args)

--- a/tests/test_chat_exclude_tools_187.py
+++ b/tests/test_chat_exclude_tools_187.py
@@ -87,6 +87,6 @@ def test_swe_runner_excludes_web_tools_in_chat_path() -> None:
         Path(__file__).resolve().parent.parent / "scripts" / "swe_bench_runner.py"
     ).read_text(encoding="utf-8")
     assert '"--exclude-tools", "web__search,web__fetch"' in src, (
-        "run_reyn_chat_in_container must pass --exclude-tools web__search,web__fetch "
-        "to reyn chat so the agent cannot web-look-up the gold solution (faithful eval)."
+        "run_reyn_once_in_container must pass --exclude-tools web__search,web__fetch "
+        "to reyn run-once so the agent cannot web-look-up the gold solution (faithful eval)."
     )

--- a/tests/test_run_once_187.py
+++ b/tests/test_run_once_187.py
@@ -1,0 +1,152 @@
+"""Tier 2: #187 — `reyn run-once` one-shot agent invocation (replaces REPL scripting).
+
+#187 solves SWE with the general agent. The scripted REPL path read stdin
+line-by-line (repl.py), fragmenting the 439-line task into 439 turns (#1401 root
+cause). `reyn run-once` reads the WHOLE stdin as ONE message and drives the agent
+to completion via send_to_agent_impl — the same programmatic drive MCP/A2A use,
+NOT the REPL. It reuses `reyn chat`'s scoped session construction (delegates to
+chat.run with once=True), so the scoped capabilities are inherited, not re-ported
+(a delivery change, not a construction change).
+
+Per lead's R1-R3, scoping must be ACTIVE on the one-shot path (the construction is
+reused, but verified — see also the seam: send_to_agent_impl → _get_session →
+registry.get_or_load returns the attached scoped session, mcp_server.py:87 +
+registry.py:755, so the same scoped factory output is driven):
+- R1 in-container execution: the docker backend builds an in-container argv.
+- R2 web-disable: the real catalog filter drops web tools.
+- R3 withholding: the piped task carries no held-out test_patch.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_CHAT_PY = (
+    Path(__file__).resolve().parent.parent / "src" / "reyn" / "cli" / "commands" / "chat.py"
+)
+_RUNNER = Path(__file__).resolve().parent.parent / "scripts" / "swe_bench_runner.py"
+
+
+def _run_once_parser() -> argparse.ArgumentParser:
+    from reyn.cli.commands import run_once
+
+    p = argparse.ArgumentParser()
+    run_once.register(p.add_subparsers())
+    return p
+
+
+# ── the new surface ───────────────────────────────────────────────────────────
+
+def test_run_once_parser_defaults_and_scoped_flags() -> None:
+    """Tier 2: `reyn run-once` sets one-shot defaults (once/cui) + a high
+    max_iterations, and accepts the scoped flags it inherits from chat."""
+    p = _run_once_parser()
+    a = p.parse_args([
+        "run-once", "--env-backend=docker", "--container", "c1",
+        "--repo-dir", "/testbed", "--grant-file-write",
+        "--exclude-tools", "web__search,web__fetch", "--max-iterations", "80",
+    ])
+    # one-shot mode markers (drive the chat.run once-branch, plain console)
+    assert a.once is True
+    assert a.cui is True
+    # scoped capabilities (inherited from chat's construction)
+    assert a.env_backend == "docker" and a.container == "c1" and a.repo_dir == "/testbed"
+    assert a.grant_file_write is True
+    assert a.exclude_tools == "web__search,web__fetch"
+    assert a.max_iterations == 80
+
+
+def test_run_once_default_iterations_exceeds_interactive_chat() -> None:
+    """Tier 2: run-once defaults max_iterations far above interactive chat's 5
+    (autonomous SWE needs many explore→edit→verify rounds). chat.run maps an
+    unset value to 5 (interactive unchanged)."""
+    a = _run_once_parser().parse_args(["run-once"])
+    assert a.max_iterations == 80
+    # interactive chat has no such flag → the factory uses 5 (see chat.py).
+    assert "or 5)" in _CHAT_PY.read_text(encoding="utf-8")
+
+
+def test_run_once_delegates_to_chat_run() -> None:
+    """Tier 2: run-once is a thin delegate to chat.run (shared construction)."""
+    from reyn.cli.commands import chat, run_once
+
+    assert run_once.run.__module__ == "reyn.cli.commands.run_once"
+    # the delegate calls chat.run (same construction path, only the drive differs)
+    assert "chat" in run_once.run.__doc__.lower() or chat.run is not None
+
+
+# ── the anti-fragmentation guard (the bug this replaces) ──────────────────────
+
+def test_one_shot_reads_whole_stdin_not_line_by_line() -> None:
+    """Tier 2: the one-shot branch reads the WHOLE stdin as one message
+    (`sys.stdin.read()`), NOT the REPL's line-by-line `readline`. This is the
+    structural fix for the #1401 line-fragmentation bug."""
+    src = _CHAT_PY.read_text(encoding="utf-8")
+    # the once-branch drives send_to_agent_impl with the whole stdin
+    assert "send_to_agent_impl" in src
+    assert "sys.stdin.read()" in src
+
+
+# ── R1: in-container execution ────────────────────────────────────────────────
+
+def test_docker_backend_routes_ops_in_container() -> None:
+    """Tier 2: the REAL DockerEnvironmentBackend (the backend chat's factory builds
+    for --env-backend=docker, inherited by run-once) builds an in-container
+    `docker exec <container>` argv; a stdin op keeps `-i` open (the #1356/#1363
+    detail a fake backend dropped)."""
+    from reyn.environment.container_backend import DockerEnvironmentBackend
+    from reyn.sandbox.backend import SandboxResult
+
+    captured: dict = {}
+
+    def _capture(argv, stdin=None):
+        captured["argv"] = argv
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+    be = DockerEnvironmentBackend(container="c1", repo_dir="/testbed", fs_runner=_capture)
+    be.read_bytes(Path("/testbed/astropy/io/ascii/html.py"))
+    assert captured["argv"][:2] == ["docker", "exec"]
+    assert "c1" in captured["argv"]
+    be.write_bytes(Path("/testbed/x.py"), b"data")
+    assert "-i" in captured["argv"]
+
+
+# ── R2: web-disable survival ──────────────────────────────────────────────────
+
+def test_exclude_tools_filter_drops_web() -> None:
+    """Tier 2: the real RouterLoop catalog filter (which the scoped session feeds
+    via exclude_tools) drops web tools while keeping the repo-editing tools."""
+    from reyn.chat.router_loop import _apply_tool_exclusions
+
+    catalog = [
+        {"type": "function", "function": {"name": n}}
+        for n in ("web__search", "web__fetch", "file__write", "exec__sandboxed_exec")
+    ]
+    names = {
+        t["function"]["name"]
+        for t in _apply_tool_exclusions(catalog, frozenset({"web__search", "web__fetch"}))
+    }
+    assert "web__search" not in names and "web__fetch" not in names
+    assert {"file__write", "exec__sandboxed_exec"} <= names
+
+
+# ── R3: withholding ───────────────────────────────────────────────────────────
+
+def test_runner_pipes_withheld_task_to_run_once() -> None:
+    """Tier 2: the faithful runner pipes the task (problem_statement+hints, NO
+    test_patch) to `reyn run-once` stdin as the one message; the model_patch is
+    the in-container git diff (the held-out test_patch never reaches the agent)."""
+    sys.path.insert(0, str(_RUNNER.parent))
+    import swe_bench_runner as r
+
+    prompt = r.build_swe_task_prompt({
+        "instance_id": "x__y-1", "repo": "x/y", "base_commit": "deadbeef",
+        "problem_statement": "BUG: foo drops bar.",
+        "hints_text": "look at foo.py",
+        "test_patch": "+def test_secret(): SECRET_EVAL",
+    })
+    assert "SECRET_EVAL" not in prompt and "test_patch" not in prompt
+    runner_src = _RUNNER.read_text(encoding="utf-8")
+    assert '"reyn", "run-once"' in runner_src  # invoked via run-once
+    assert "input=task" in runner_src           # the whole task on stdin (one message)

--- a/tests/test_run_once_187.py
+++ b/tests/test_run_once_187.py
@@ -78,14 +78,39 @@ def test_run_once_delegates_to_chat_run() -> None:
 
 # ── the anti-fragmentation guard (the bug this replaces) ──────────────────────
 
-def test_one_shot_reads_whole_stdin_not_line_by_line() -> None:
-    """Tier 2: the one-shot branch reads the WHOLE stdin as one message
-    (`sys.stdin.read()`), NOT the REPL's line-by-line `readline`. This is the
-    structural fix for the #1401 line-fragmentation bug."""
-    src = _CHAT_PY.read_text(encoding="utf-8")
-    # the once-branch drives send_to_agent_impl with the whole stdin
-    assert "send_to_agent_impl" in src
-    assert "sys.stdin.read()" in src
+def test_one_shot_delivers_whole_stdin_as_one_message() -> None:
+    """Tier 2: behavioral — a multi-line stdin is delivered to the agent as ONE
+    message (one `send` call, whole string, no line-splitting) — the structural fix
+    for the #1401 line-fragmentation bug (the REPL read stdin line-by-line, making
+    each line a separate turn). Uses a recording `send` double (no mock); pins the
+    raison d'être of this PR before the expensive N-run."""
+    import asyncio
+    import io
+
+    from reyn.cli.commands import chat
+
+    multi_line = "This repo @ <commit> has this issue:\n## Issue\nline A\nline B\n"
+    captured: dict = {}
+
+    async def _recording_send(registry, *, agent_name, message, timeout):
+        captured["calls"] = captured.get("calls", 0) + 1
+        captured["message"] = message
+        captured["agent"] = agent_name
+        return {"reply": "done", "partial": False, "agent": agent_name}
+
+    reply = asyncio.run(
+        chat._run_once(
+            object(), "default",
+            instream=io.StringIO(multi_line),
+            send=_recording_send,
+        )
+    )
+    # exactly ONE message carrying the WHOLE multi-line text, not N line-fragments
+    assert captured["calls"] == 1, "the whole task must be ONE message, not one-per-line"
+    assert captured["message"] == multi_line, "the multi-line task must arrive unsplit"
+    assert "\n" in captured["message"]  # newlines preserved (not fragmented)
+    assert captured["agent"] == "default"
+    assert reply == "done"
 
 
 # ── R1: in-container execution ────────────────────────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — #187 root fix for the line-fragmentation bug. Owner-directed redirect (A2A-server approach dropped; web/A2A parity → #1402).

## Root cause (#1401)
The scripted `reyn chat` path drives the **human REPL**, which reads stdin **line-by-line** (`repl.py:51` `readline` → `:85` `submit_user_text` per line). The 439-line SWE task arrived as **439 separate user turns** — the agent never received it coherently (edit=0, empty model_patch; sandbox_2 primary evidence: 377 chatter-rounds). Owner's framing (correct): driving a human-conversation UI as a programmatic API is the wrong abstraction; line-fragmentation is the symptom.

## Fix: `reyn run-once`
A one-shot, non-interactive subcommand that reads the **WHOLE stdin as one message** and drives the agent to completion via `send_to_agent_impl` (the same programmatic drive MCP/A2A use — **no REPL**), prints the final reply, exits.

It **reuses `reyn chat`'s scoped session construction** by delegating to `chat.run` with `once=True` (branch at the registry-attach point). This is a **transport/delivery change, not a construction change** — A2A/MCP/run-once are transports; `ChatSession.__init__` already accepts `environment_backend`/`exclude_tools`/etc. So #1398 grant + #1400 exclude-tools + env-backend are **inherited, not re-ported**.

**Seam-confirm (lead's flow-trace-first req)**: `send_to_agent_impl → _get_session → registry.get_or_load` returns the **attached scoped session** (`mcp_server.py:87` + `registry.py:755` `session = self._factory(profile)`) — the scoped factory's output is what's driven, so scoping is **active on the one-shot path** (no fresh unscoped build = no web/A2A-style gap).

## Changes
- `chat/session.py` — `ChatSession.router_max_iterations` (default **5** = interactive unchanged); the MAIN RouterLoop uses it (was hardcoded 5). The one cross-cutting param the autonomous loop needs.
- `cli/commands/chat.py` — one-shot branch (whole stdin → `send_to_agent_impl` → reply → exit) + factory threads `router_max_iterations`.
- `cli/commands/run_once.py` (new) — the `reyn run-once` subcommand: scoped flags via the shared `register_env_backend_args`, `--max-iterations` default **80**, `once`/`cui` defaults, delegates to `chat.run`. Registered in `commands/__init__.py`.
- `scripts/swe_bench_runner.py` — `run_reyn_once_in_container` (pipes the whole task to `reyn run-once`, `--state-dir` host-side so OS state doesn't pollute the in-container `git diff`, `--max-iterations 80`). The #1399 REPL invocation is removed (no throwaway).
- tests — run-once surface; **anti-fragmentation guard** (whole `sys.stdin.read()`, not `readline`); **R1** in-container `docker exec` argv (real backend, incl. the `-i` stdin detail #1356/#1363 missed); **R2** web-disable via the real catalog filter; **R3** withholding.

## Test plan
- [x] `pytest tests/test_run_once_187.py -q` (7) + chat-exclude (3) = 10 passed
- [x] broad regression `-k "chat or cli or swe_bench or router_loop or run_once or exclude"` — 1874 passed
- [x] `ruff check .` clean; `test_tier_audit --strict` on changed tests — 0 violations
- [x] full `pytest -q` (rootdir) — 7034 passed, 10 skipped, 3 xfailed; **2 pre-existing failures** (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::...inline_content`) verified **identical on a clean origin/main worktree** (env/library quirks; neither imports this PR's modules)

After merge: gates sandbox_2's web-disabled **run-once N-run** = the #187 empirical proof (4-axis analyzer is path-independent; invocation swaps to run-once). A2A-server WIP preserved on `187-a2a-runner@d3880a70` for #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)