### PR TITLE
fix(1406): exclude_tools execution-level block (closes #187 4th faithfulness leak)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2901,6 +2901,33 @@ class RouterLoop:
         if name not in self._catalog and "__" in name:
             name, args = self._maybe_salvage_qualified_direct_call(name, args)
 
+        # #1406: execution-level exclude enforcement. ``exclude_tools`` is not just
+        # an advertisement filter (#1400 ``_apply_tool_exclusions`` hides excluded
+        # tools from ``tools[]`` / ``self._catalog``) — the LLM can still call an
+        # excluded tool by name, which the #229 salvage rewrites to
+        # ``invoke_action(action_name=<excluded>)`` (or it is called as
+        # ``invoke_action`` directly), and ``universal_dispatch`` then resolves and
+        # EXECUTES it (the #187 N=3 web__search leak). Compute the effective
+        # resolved action — unwrap ``invoke_action`` — and reject if excluded.
+        # Covers all three bypass paths (native direct / salvaged / direct
+        # invoke_action). Catalog filter (#1400) stays as the hide layer
+        # (defense-in-depth). A distinct ``tool_excluded`` kind + decision-enabling
+        # message lets the model adjust ([[deny-message-decision-enabling]]).
+        if self._exclude_tools:
+            effective = args.get("action_name") if name == "invoke_action" else name
+            if effective in self._exclude_tools:
+                return {
+                    "status": "error",
+                    "error": {
+                        "kind": "tool_excluded",
+                        "message": (
+                            f"tool {effective!r} is excluded this session and not "
+                            "available; do not call it (directly or via "
+                            "invoke_action)."
+                        ),
+                    },
+                }
+
         # #1092 PR-C-2.5: phase-mode op-dispatch WAL memoization. A phase host
         # returns the per-phase resume wiring; chat hosts don't implement the hook
         # (getattr → None), so the chat dispatch path below is byte-identical

--- a/tests/test_exclude_execution_block_1406.py
+++ b/tests/test_exclude_execution_block_1406.py
@@ -1,0 +1,95 @@
+"""Tier 2: #1406 — exclude_tools is enforced at EXECUTION, not just the catalog.
+
+The #187 N=3 verdict found `web__search` executing despite #1400's catalog filter:
+the LLM called it by name, the #229 salvage rewrote it to
+`invoke_action(action_name=web__search)`, and universal_dispatch resolved + executed
+it (the catalog gate checks the `invoke_action` wrapper, not the inner action). This
+pins the execution-level block on the REAL dispatch path (`RouterLoop._execute_tool`),
+which the catalog-advertisement unit (#1400) could not catch — covering all three
+bypass shapes and asserting the excluded tool's handler is never invoked.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from reyn.chat.router_loop import RouterLoop
+
+
+class _Events:
+    def __init__(self) -> None:
+        self.emitted: list[tuple] = []
+
+    def emit(self, *a, **k) -> None:  # dispatch_tool emits tool_called/failed
+        self.emitted.append((a, k))
+
+
+class _MiniHost:
+    """Minimal real host for driving _execute_tool (no mock). The excluded path
+    returns before dispatch; the non-excluded path reaches dispatch_tool, which
+    needs only events + agent_name."""
+
+    agent_name = "t"
+
+    def __init__(self) -> None:
+        self.events = _Events()
+        self.web_search_calls: list[dict] = []
+
+    async def web_search(self, **kw) -> dict:  # would run IF the tool executed
+        self.web_search_calls.append(kw)
+        return {"kind": "web_search", "results": ["LEAKED GOLD"]}
+
+
+def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
+    return asyncio.run(
+        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+    )
+
+
+def test_excluded_tool_blocked_at_execution_all_paths() -> None:
+    """Tier 2: an excluded tool is rejected on the real dispatch path via every
+    call shape, and its handler never runs."""
+    host = _MiniHost()
+    loop = RouterLoop(
+        host=host, chain_id="t", max_iterations=5,
+        exclude_tools={"web__search", "web__fetch"},
+    )
+
+    # (a) native direct call by name; (b) is the salvaged form of (a) — same path;
+    # (c) direct invoke_action(action_name=<excluded>).
+    r_native = _exec(loop, "web__search", {"query": "site:github.com gold patch?"})
+    r_wrapped = _exec(
+        loop, "invoke_action",
+        {"action_name": "web__search", "args": {"query": "gold?"}},
+    )
+    for r in (r_native, r_wrapped):
+        assert r["status"] == "error"
+        assert r["error"]["kind"] == "tool_excluded", r
+        # decision-enabling message names the tool + says don't call it
+        assert "web__search" in r["error"]["message"]
+
+    # the excluded tool's handler must NEVER have executed (no gold leak)
+    assert host.web_search_calls == [], "excluded tool executed despite the block"
+
+
+def test_non_excluded_tool_not_blocked_by_exclude_logic() -> None:
+    """Tier 2: the block is targeted — a non-excluded tool is not rejected as
+    `tool_excluded` (it falls through to normal dispatch; here unknown_tool since
+    the test catalog is empty, which is NOT the exclude path)."""
+    host = _MiniHost()
+    loop = RouterLoop(
+        host=host, chain_id="t", max_iterations=5, exclude_tools={"web__search"},
+    )
+    r = _exec(loop, "file__read", {"path": "/testbed/x.py"})
+    excluded = r.get("status") == "error" and r.get("error", {}).get("kind") == "tool_excluded"
+    assert not excluded, "a non-excluded tool must not be rejected by the exclude block"
+
+
+def test_no_exclusion_set_is_inert() -> None:
+    """Tier 2: with no exclude_tools, the execution-block adds nothing (no false
+    rejection) — interactive sessions are unaffected."""
+    host = _MiniHost()
+    loop = RouterLoop(host=host, chain_id="t", max_iterations=5)  # exclude_tools default
+    r = _exec(loop, "invoke_action", {"action_name": "web__search", "args": {}})
+    excluded = r.get("status") == "error" and r.get("error", {}).get("kind") == "tool_excluded"
+    assert not excluded


### PR DESCRIPTION
**[e2e-coder]** — #1406, owner-GO'd as #187 experiment-sequence step 1 (design APPROVED on the issue). Removes the web-leak confound before the faithful re-run.

## Root cause (#187 N=3, code-verified)
`exclude_tools` (#1400) filters only the advertised `tools[]` / `self._catalog`. The LLM called `web__search` by name → not in the post-exclude catalog + has `__` → the #229 salvage `_maybe_salvage_qualified_direct_call` resolved it via `universal_dispatch` and rewrote to `invoke_action(action_name="web__search")` → `_execute_tool` dispatched `invoke_action` (in the catalog) → `dispatch_tool`'s `name in ctx.tool_catalog` gate passed (it sees the **wrapper**, not the inner `web__search`) → executed (`status:ok`). Same bypass for a direct `invoke_action(action_name=web__search)`.

## Fix
In `RouterLoop._execute_tool`, after the salvage rewrite, compute the **effective resolved action** (unwrap `invoke_action`) and reject with a distinct `tool_excluded` error if excluded — **before** dispatch. Covers all three bypass paths (native direct / #229-salvaged / direct `invoke_action`). The #1400 catalog filter stays as the advertisement layer (defense-in-depth: hide + block). Deny is decision-enabling (names the tool, says don't call it). P7-clean (`exclude_tools` is caller data); no-exclusion sessions are inert.

## Test plan
- [x] `pytest tests/test_exclude_execution_block_1406.py -q` — 3 passed: all 3 bypass shapes reject on the **real** `_execute_tool` path + the excluded handler **never executes** (no gold leak) + a non-excluded tool falls through + inert when unset
- [x] tier audit 0; ruff clean
- [x] no-regression `-k "router_loop or exclude or routing_decided or universal"` — 366 passed

This is the real-dispatch-path test the catalog-only #1400 unit could not provide. Pairs with the swe_bench skill retire (the other confound) → then sandbox_2's faithful re-run (③→① test: does direct-edit emerge?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)