### PR TITLE
docs: dogfood_trace.py discoverability pointers at point-of-need

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ and run the checklist below before continuing:
   `eval`, `skill_improver`) for live examples
 - **ContextFrame / Output schemas**: `src/reyn/models.py`
 - **Op catalog and dispatch**: `src/reyn/op_runtime/`
+- **LLM trace analysis**: `docs/reference/dogfood-tracing.md` — `scripts/dogfood_trace.py --mode llm-payloads` is the canonical entry point for inspecting LLM payloads; do not hand-parse JSONL.
 
 ## Goal
 

--- a/docs/deep-dives/contributing/dogfood-discipline.ja.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.ja.md
@@ -171,6 +171,8 @@ See: `feedback_minimize_speculation.md`
 
 discipline: **LLM の挙動を疑った瞬間、LLM への input payload と output を観測できるかを確認します。** infra が存在しなければ、仮説を立てる前にそれを作ります。
 
+Reyn では、payload 観測の canonical ツールは `scripts/dogfood_trace.py` です。まず `--mode llm-payloads` を実行してください — batch 内の全 LLM call が何を受け取り何を出力したかのタイムラインが得られます。モード一覧は [LLM Payload Tracing](../../reference/dogfood-tracing.md) を参照してください。
+
 **概念例。** Finding に「router が skill 名を誤って識別している」と書かれています。4 つの仮説が提案されます: (a) enum 制約が欠落している; (b) skill description が truncate されている; (c) prompt rule が意図せず削除された; (d) モデルが類似コンテキストで見た名前を hallucinate する。観測 infra なしでは 4 つすべてがもっともらしく、comprehensive fix が 4 つすべてに対処します。観測 infra (実際の system prompt を dump し、enum を確認し、payload を replay) があれば、4 つのうち 3 つを数分で除去できます。正しい fix は確認された原因のみを対象にします。
 
 観測 infra を作った後、以前の仮説をすべて retroactive に verify します。 Reyn batch 7 での実例: 新しいツールを使って 4 つの過去仮説を評価したところ、1.5 件が否定されました。これらの仮説に基づく fix は wrong-layer になるところでした。

--- a/docs/deep-dives/contributing/dogfood-discipline.md
+++ b/docs/deep-dives/contributing/dogfood-discipline.md
@@ -171,6 +171,8 @@ See: `feedback_minimize_speculation.md`
 
 The discipline: **when you first suspect LLM behavior, ask whether you can observe the LLM's input payload and output.** If the infrastructure to do so does not exist, build it before forming hypotheses.
 
+In Reyn, the canonical tool for payload inspection is `scripts/dogfood_trace.py`. Start with `--mode llm-payloads` for a full timeline of what each LLM call received and produced across the batch. See [LLM Payload Tracing](../../reference/dogfood-tracing.md) for the complete mode reference.
+
 **Conceptual example.** A finding states "the router is misidentifying skill names." Four hypotheses are proposed: (a) enum constraints are missing; (b) skill descriptions are truncated; (c) a prompt rule was inadvertently removed; (d) the model hallucinates names it has seen in similar contexts. Without observation infrastructure, all four are plausible and a comprehensive fix addresses all four. With observation infrastructure (dump the actual system prompt, inspect the enum, replay the payload), three of the four can be eliminated in minutes. The correct fix targets only the confirmed cause.
 
 After building observation infrastructure, retroactively verify all previous hypotheses. The historical pattern from Reyn's batch 7: 4 prior hypotheses were evaluated retroactively with the new tooling, and 1.5 were refuted — meaning fixes based on those hypotheses would have been wrong-layer.


### PR DESCRIPTION
**[docs-maintainer]** — discoverability fix for `scripts/dogfood_trace.py`.

## Problem

`dogfood_trace.py` is already documented in `dogfood-discipline.md §4` and `docs/reference/dogfood-tracing.md`, but agents/developers encountering a trace analysis need do not reliably find these docs. They default to hand-parsing raw JSONL instead.

## Fix

Two pointer additions only — no content duplication:

1. **`CLAUDE.md` "When in doubt — read these"** (after `Op catalog and dispatch`): names `dogfood-tracing.md` and `--mode llm-payloads` as canonical; adds "do not hand-parse JSONL" directive. CLAUDE.md is every agent's first-read, making this the highest-leverage placement.

2. **`dogfood-discipline.md` Principle 4** (+ JA mirror): adds concrete tool pointer immediately after the "observe the LLM's input payload" discipline statement, completing the principle→tool navigation chain.

## Review gates

- [x] Principle-only — no #issue/PR/FP inline (grep: 0 matches)
- [x] Pointer-only — content lives in dogfood-tracing.md; no duplication
- [x] EN/JA mirror: dogfood-discipline.ja.md Principle 4 updated; CLAUDE.md has no JA mirror (EN only)
- [x] Page-drop: 0

## Test plan

- [x] `git grep` for history refs in added lines: 0 matches
- [x] Link target `../../reference/dogfood-tracing.md` verified to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)