### PR TITLE
fix(187): root chat file ops on the container repo base_dir (5th structural defect)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1255,6 +1255,8 @@ class ChatSession:
         # workspace's own default) → unchanged behaviour. The sibling exec seam
         # (sandbox_backend string via sandbox_config) already flows agent-level.
         environment_backend: "EnvironmentBackend | None" = None,
+        workspace_base_dir: "Path | None" = None,  # #187: chat OpContext FS root — the container repo root (e.g. /testbed) when env-backend routes the repo into a container; None → host cwd
+        workspace_state_dir: "Path | None" = None,  # #187: host-side OS state dir, decoupled from a container base_dir (survives container death)
         # #1200 PR-F2 (exec seam): the agent's SandboxBackend INSTANCE, set on the
         # chat router OpContext so sandboxed_exec runs on the SAME backend as the
         # OSRuntime path (sandboxed_exec.py: `ctx.sandbox_backend or
@@ -1320,6 +1322,15 @@ class ChatSession:
         # (passed to the router Workspace in make_router_op_context). None →
         # HostBackend default.
         self._environment_backend = environment_backend
+        # #187: the chat OpContext Workspace's FS root + host-side state dir. With
+        # a container env-backend the agent's repo lives in the container, so
+        # base_dir must be the container repo root (the partner of the backend
+        # returned by build_environment_backend) — otherwise file__read/grep/glob
+        # resolve against the host cwd (the reyn repo) and the agent never sees
+        # the target tree (the #187 step-3 empty-FS defect: 0/134 reads, grep
+        # hitting reyn's own tests/venv).
+        self._workspace_base_dir = workspace_base_dir
+        self._workspace_state_dir = workspace_state_dir
         # #1200 PR-F2: agent SandboxBackend instance for the chat exec seam (set
         # on the router OpContext). None → get_default_backend. The INSTANCE, not
         # the sandbox_config.backend STRING (exec-tool gating).
@@ -4760,6 +4771,15 @@ class ChatSession:
             events=self._chat_events,
             permission_resolver=self._perm,
             skill_name="chat_router",
+            # #187: the chat OpContext FS root. With a container env-backend the
+            # agent's repo lives in the container (e.g. /testbed), so base_dir must
+            # be that container repo root — the partner of the backend below.
+            # Otherwise file__read/grep/glob resolve relative to the host cwd (the
+            # reyn repo) and the agent never sees the target tree. state_dir stays
+            # host-side (decoupled) so OS state survives container death + does not
+            # pollute the in-container git diff. None → Workspace's cwd default.
+            base_dir=self._workspace_base_dir,
+            state_dir=self._workspace_state_dir,
             # #1200 PR-F1 (FS seam): run chat file ops on the agent's
             # EnvironmentBackend instance (None → Workspace's HostBackend default).
             environment_backend=self._environment_backend,

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -361,7 +361,7 @@ def run(args: argparse.Namespace) -> None:
     # and pass the SAME instance to BOTH ChatSession seams (FS environment_backend
     # + exec sandbox_backend) — the #1200 single-shared-sandbox invariant. A
     # launched container is torn down at process exit.
-    env_backend, _ws_base_dir, _ws_state_dir, env_cleanup = build_environment_backend(args)
+    env_backend, ws_base_dir, ws_state_dir, env_cleanup = build_environment_backend(args)
     if env_cleanup is not None:
         import atexit
         atexit.register(env_cleanup)
@@ -401,6 +401,13 @@ def run(args: argparse.Namespace) -> None:
             # #1289: same backend instance to both seams (single-shared-sandbox).
             environment_backend=env_backend,
             sandbox_backend=env_backend,
+            # #187: forward the env-backend's PARTNER container repo root + host-side
+            # state dir to the chat OpContext Workspace, so file__read/grep/glob/edit
+            # root on the container repo (e.g. /testbed) — not the host reyn cwd.
+            # Without this the agent's file ops + the exec/diff seam disagree on the
+            # FS (the #187 step-3 wrong-FS defect). None (host backend) → cwd default.
+            workspace_base_dir=ws_base_dir,
+            workspace_state_dir=ws_state_dir,
         )
         # #187 session-isolation: a fresh/stateless run (`reyn run-once`) does NOT
         # rehydrate the agent's persisted conversation history. `load_history()` is

--- a/tests/test_workspace_basedir_docker_187.py
+++ b/tests/test_workspace_basedir_docker_187.py
@@ -1,0 +1,81 @@
+"""Tier 2: #187 — the chat OpContext Workspace roots file ops on the CONTAINER repo.
+
+5th structural defect (sandbox_2 step-3, primary evidence): run-once
+--env-backend=docker had the agent's file ops (read/grep/glob/edit) rooted on the
+HOST reyn cwd, not the in-container repo (/testbed) — the env-backend was forwarded
+to the Workspace but its PARTNER container base_dir was discarded
+(``_ws_base_dir``), so the Workspace defaulted ``base_dir=Path.cwd()``. The agent's
+FS ops and the exec/``git diff`` seam then disagreed on the filesystem (astropy
+reads 0/134; grep matched reyn's own tests/venv; model_patch empty).
+
+Round-trip acceptance (lead's load-bearing check): a write must land where
+``git diff -C /testbed HEAD`` (the model_patch extraction) looks — i.e. file ops
+must resolve to ``/testbed`` IN the container. Otherwise the agent edits host-side
+and the patch is empty even when it "fixes" the file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.environment.container_backend import DockerEnvironmentBackend
+from reyn.sandbox.backend import SandboxResult
+from reyn.workspace.workspace import Workspace
+
+
+class _Events:
+    def emit(self, *a, **k) -> None:  # Workspace emits op events
+        pass
+
+
+def _recording_docker(captured: list) -> DockerEnvironmentBackend:
+    """A real DockerEnvironmentBackend whose fs_runner records the docker-exec
+    argv (no real daemon) — so we can assert the in-container target path."""
+
+    def _run(argv, stdin=None):
+        captured.append({"argv": argv, "stdin": stdin})
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+    return DockerEnvironmentBackend(container="c1", repo_dir="/testbed", fs_runner=_run)
+
+
+def test_read_resolves_to_container_repo_not_host(tmp_path) -> None:
+    """Tier 2: with base_dir=/testbed + a docker backend, a relative file read
+    resolves to /testbed/<path> and executes IN the container (not the host cwd).
+    state_dir is host-side (tmp_path) — decoupled from the container base_dir, as
+    the real fix forwards it (else the OS would write under the in-container repo)."""
+    captured: list = []
+    ws = Workspace(
+        events=_Events(), base_dir=Path("/testbed"), state_dir=tmp_path,
+        environment_backend=_recording_docker(captured),
+    )
+    ws.read_file("astropy/io/ascii/html.py")
+    argv = captured[-1]["argv"]
+    assert argv[:2] == ["docker", "exec"] and "c1" in argv
+    assert "/testbed/astropy/io/ascii/html.py" in " ".join(argv), (
+        "read must target the container repo path, not the host cwd"
+    )
+
+
+def test_write_lands_in_container_repo_round_trip(tmp_path) -> None:
+    """Tier 2: round-trip — a write resolves to /testbed/<path> in the container —
+    where `git diff -C /testbed HEAD` (the model_patch extraction) looks. The
+    in-container `docker exec -i` keeps stdin open for the write payload."""
+    captured: list = []
+    ws = Workspace(
+        events=_Events(), base_dir=Path("/testbed"), state_dir=tmp_path,
+        environment_backend=_recording_docker(captured),
+    )
+    ws.write_file("astropy/io/ascii/html.py", "fixed = True\n")
+    argv = captured[-1]["argv"]
+    assert "c1" in argv
+    assert "/testbed/astropy/io/ascii/html.py" in " ".join(argv), (
+        "write must land in the container repo (where git diff looks), not host"
+    )
+    assert "-i" in argv, "an in-container write keeps `docker exec -i` open for stdin"
+
+
+def test_no_base_dir_defaults_to_host_cwd() -> None:
+    """Tier 2: no base_dir (host backend / interactive chat) → cwd default,
+    unchanged. The fix only takes effect when a container base_dir is forwarded."""
+    ws = Workspace(events=_Events())
+    assert ws.base_dir == Path.cwd()


### PR DESCRIPTION
**[e2e-coder]** — #187 5th structural defect (sandbox_2 step-3 trace → my OS fix → sandbox_2 re-verify). Pure-plumbing, lead+sandbox_2 verified scope.

## Defect (primary evidence)
run-once `--env-backend=docker`: **exec runs in-container but file ops (read/grep/glob/edit) rooted on the HOST reyn cwd**, not the in-container repo (`/testbed`). `file__read` astropy paths not_found 134/134; `file__grep` 0 astropy matches (all hits = reyn's own tests/venv → base_dir = host cwd). The agent never saw the target tree → it thrashed an empty FS. **This invalidates step-3's behavior reading (FS-thrashing, not reasoning) — not weak-model.**

## Root cause — construction-forwarding gap (same class as #1401/#1406)
`build_environment_backend` returns the container repo `base_dir` (attach mode, `env_backend.py:119` → `/testbed`), but:
- `chat.py` captured it as `_ws_base_dir` — underscore-**discarded**, never forwarded;
- the chat OpContext `Workspace` (`session.py:4759`) got `environment_backend=` but no `base_dir=` → defaulted `Path.cwd()` (the host reyn repo).

The backend was forwarded; its **partner** container base_dir was not.

## Fix (pure plumbing — no /workspace-vs-/testbed layout change; attach mode already returns /testbed)
- `ChatSession` gains `workspace_base_dir` / `workspace_state_dir` params.
- `chat.py` forwards `build_environment_backend`'s base_dir + host-side state_dir.
- the Workspace is built with `base_dir=` / `state_dir=`.

File ops now resolve to `/testbed` **in the container** (where exec + `git diff` operate); state_dir stays **host-side** (decoupled — survives container death, doesn't pollute the in-container diff). Host backend (no base_dir) → cwd default, unchanged.

## Test plan
- [x] `tests/test_workspace_basedir_docker_187.py` (3): read resolves to `/testbed` in-container; **write round-trip** (lands at `/testbed` where `git diff -C /testbed HEAD` looks — lead's load-bearing acceptance, `docker exec -i` for stdin); host-default unchanged
- [x] tier audit 0; ruff clean
- [x] no-regression `-k "workspace or chat or run_once or state_dir_read or 1200 or fs_seam or 1390"` — 312 passed

After merge: file ops + exec/diff agree on `/testbed` → sandbox_2 re-runs step-3 against the correct root = the true ③→① capability read (the #1409 retire already confirmed-worked: `invoke_action(skill)` unreached 6/6). #202 (model-axis) only if still 0/6 after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)