### PR TITLE
fix(187): root the LIVE router OpContext on the container repo (#1410 patched the wrong method)

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -164,6 +164,14 @@ class RouterHostAdapter:
         # the exec category (= noop / no sandbox configured).
         sandbox_backend: str | None = None,
         sandbox_policy: dict | None = None,
+        # #187: the FS EnvironmentBackend INSTANCE (docker for in-container repos)
+        # + the container repo root + host-side state dir, for the router OpContext
+        # Workspace. Distinct from ``sandbox_backend`` (a STRING for the exec D14
+        # gate). Without these the LIVE file-op dispatch built a host-cwd Workspace
+        # (the #187 wrong-FS defect: file ops on the reyn repo, not /testbed).
+        environment_backend: Any = None,
+        workspace_base_dir: Path | None = None,
+        workspace_state_dir: Path | None = None,
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
         # ChatSession passes the session-scoped tracker; None when wrappers are
         # off or hot_list_n == 0.
@@ -303,6 +311,9 @@ class RouterHostAdapter:
         self._embedding_model_class = embedding_model_class
         # FP-0034 Phase 2
         self._sandbox_backend = sandbox_backend
+        self._environment_backend = environment_backend
+        self._workspace_base_dir = workspace_base_dir
+        self._workspace_state_dir = workspace_state_dir
         # #1339 / sandbox-model completion: the operator's reyn.yaml
         # sandbox.policy (dict | None) used to resolve the concrete agent-level
         # policy onto the router OpContext (None → the default policy).
@@ -1429,6 +1440,16 @@ class RouterHostAdapter:
             events=self._events,
             permission_resolver=self._perm,
             skill_name="chat_router",
+            # #187: this is the LIVE op-context factory the registry file-dispatch
+            # uses (router_loop.py op_context_factory=host.make_router_op_context).
+            # With a container env-backend the agent's repo lives in the container
+            # (e.g. /testbed), so base_dir must be that container repo root and the
+            # FS backend must be the docker instance — otherwise file__read/grep/
+            # glob/edit (and the sandbox write_paths below) resolve against the host
+            # cwd. None (host backend) → cwd default, unchanged.
+            base_dir=self._workspace_base_dir,
+            state_dir=self._workspace_state_dir,
+            environment_backend=self._environment_backend,
         )
         # FP-0022 fix (#53): wire intervention_bus so handlers that need
         # the 4-layer approval flow (web_fetch, mcp install / drop) can

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1849,6 +1849,12 @@ class ChatSession:
                 self._sandbox_config.backend if self._sandbox_config is not None
                 else None
             ),
+            # #187: the FS env-backend instance + container repo root + host-side
+            # state dir for the LIVE router OpContext Workspace (the registry
+            # file-dispatch factory). Same source as the chat OpContext (#1410).
+            environment_backend=self._environment_backend,
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
             # #1339 / sandbox-model completion: thread the operator sandbox
             # policy so make_router_op_context resolves a concrete agent-level
             # policy onto the router OpContext (closes the chat-factory wiring gap).

--- a/tests/test_router_opcontext_basedir_live_187.py
+++ b/tests/test_router_opcontext_basedir_live_187.py
@@ -1,0 +1,50 @@
+"""Tier 2: #187 — the LIVE router OpContext factory roots file ops on the container repo.
+
+Follow-up to #1410, which patched the WRONG method. The registry file-op dispatch
+uses ``op_context_factory = getattr(host, "make_router_op_context")``
+(router_loop.py), and the chat host is ``RouterHostAdapter`` — so the LIVE factory
+is ``RouterHostAdapter.make_router_op_context``. #1410 instead patched the parallel
+``ChatSession._make_router_op_context`` (used only by the legacy ``_file_op`` /
+``_mcp_call_tool`` callbacks); the two impls had drifted, and #1410's test was green
+on the legacy seam while live file ops still ran on the host cwd (astropy 0/6).
+
+This test exercises the LIVE factory (``session._router_host.make_router_op_context``
+— the exact method the dispatch resolves) so a regression to host-cwd on the live
+path fails here. (Lesson: verify the live dispatch impl, not a parallel seam.)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.chat.session import ChatSession
+from reyn.environment.container_backend import DockerEnvironmentBackend
+
+
+def test_live_op_context_roots_on_container_repo(tmp_path) -> None:
+    """Tier 2: with a docker env-backend + container base_dir, the LIVE op-context
+    factory (RouterHostAdapter.make_router_op_context) builds a Workspace rooted on
+    the container repo (/testbed) over the docker backend — so file__read/grep/glob/
+    edit resolve in-container, not on the host reyn cwd."""
+    backend = DockerEnvironmentBackend(container="c1", repo_dir="/testbed")
+    s = ChatSession(
+        agent_name="t", environment_backend=backend,
+        workspace_base_dir=Path("/testbed"), workspace_state_dir=tmp_path,
+    )
+    # THE live factory: router_loop dispatch uses op_context_factory =
+    # getattr(host, "make_router_op_context"); host is this adapter.
+    ctx = s._router_host.make_router_op_context()
+    assert ctx.workspace.base_dir == Path("/testbed"), (
+        "live router file ops must root on the container repo, not the host cwd "
+        "(the #1410 miss: this LIVE factory still defaulted to cwd)"
+    )
+    # the exec sandbox write_paths derive from workspace.base_dir → container-scoped too
+    assert "/testbed" in str(ctx.default_sandbox_policy)
+
+
+def test_live_op_context_host_default_unchanged() -> None:
+    """Tier 2: no env-backend / base_dir (host backend / interactive chat) → the live
+    factory keeps the host cwd default (the fix only takes effect under a container
+    base_dir)."""
+    s = ChatSession(agent_name="t")
+    ctx = s._router_host.make_router_op_context()
+    assert ctx.workspace.base_dir == Path.cwd()


### PR DESCRIPTION
**[e2e-coder]** — real fix for the #187 wrong-FS defect (sandbox_2 N=6 live trace + lead canonical verify caught #1410 patched the wrong method). lead+sandbox_2 root-cause confirmed.

## What #1410 missed
The registry file-op dispatch uses `op_context_factory = getattr(host, "make_router_op_context")` (router_loop.py), and the chat host is `RouterHostAdapter` → the **LIVE** factory is `RouterHostAdapter.make_router_op_context` (router_host_adapter.py:1428), which built `Workspace(events, perm, skill_name)` with **no base_dir + no environment_backend** → host cwd + HostBackend. #1410 instead patched the **parallel** `ChatSession._make_router_op_context` (used only by the legacy `_file_op` / `_mcp_call_tool` callbacks). The two impls had drifted; #1410's unit test was **green on the legacy seam** while live file ops still ran on the host (astropy read 0/6, edit 0/6). sandbox_2's in-method debug print proved the ChatSession method never fired live.

## Fix (the LIVE path)
`RouterHostAdapter` gains `environment_backend` / `workspace_base_dir` / `workspace_state_dir` params, threaded from `ChatSession` (same source as #1410); `make_router_op_context` now builds the Workspace with `base_dir` / `state_dir` / `environment_backend`. File ops + the exec sandbox `write_paths` (derived from `workspace.base_dir`) now root on `/testbed`.

## Test — exercises the LIVE path (the lesson from the #1410 miss)
`tests/test_router_opcontext_basedir_live_187.py` calls **`session._router_host.make_router_op_context()`** — the exact factory the dispatch resolves — and asserts `Workspace.base_dir == /testbed` (+ sandbox write_paths container-scoped); host-default unchanged. A regression to host-cwd on the live path fails here. (Verify the live dispatch impl, not a parallel seam.)

## Single-sourcing (lead's drift-prevention #2) — presented for review, not bundled
The two `make_router_op_context` impls produce **divergent OpContexts** (ChatSession's: run_id/agent_id/sandbox_backend; the adapter's: intervention_bus/media_store/compact_now/multimodal_config) for their different callers — so consolidation needs careful reconciliation, not a 1-line delegate. This parallel-construction drift is the **#1402 shared-builder theme** (now the 2nd instance: base_dir forwarding + these two methods). Recommend a focused shared `build_chat_router_workspace` helper (the drifted construction) and/or folding into #1402. Your call on scope.

## Test plan
- [x] live-path test (2): roots /testbed; host-default unchanged; tier 0; ruff clean
- [x] no-regression `-k "router_host or workspace_basedir or chat or run_once or opcontext or fs_seam"` — 284 passed

After merge: live file ops root on /testbed → sandbox_2 re-runs step-3 (the true ③→① read at last). The #1409 retire is confirmed-worked (invoke_action(skill) unreached); #202 only if still 0/6 after THIS lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)