### PR TITLE
fix(187): B1 empty-choices router-loop crash + swallow instrument + A did-you-mean

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3055,6 +3055,26 @@ class ChatSession:
             await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
             return
         except Exception as exc:
+            # #187 B1 instrument: a mid-work router-loop exception (e.g. the final
+            # call_llm raising after litellm's internal retries) was swallowed into a
+            # classified outbox summary, silently terminating the turn — for an
+            # autonomous run-once this ends the agent mid-edit with no diagnosable
+            # trace (req=resp+1, no logged response). Surface the FULL exception
+            # (stderr traceback + a P6 event) so the root error is primary-evidence
+            # for the fix; the classified summary still goes to the outbox unchanged.
+            logger.exception(
+                "router loop terminated by unhandled exception (chain_id=%s)",
+                chain_id,
+            )
+            try:
+                self._chat_events.emit(
+                    "router_loop_terminated_by_exception",
+                    chain_id=chain_id,
+                    error_type=type(exc).__name__,
+                    error=repr(exc)[:500],
+                )
+            except Exception:  # noqa: BLE001 — instrumentation must never break the path
+                pass
             await self._put_outbox(OutboxMessage(
                 kind="error", text=classify_router_error(exc),
                 meta={"chain_id": chain_id},

--- a/src/reyn/dispatch/dispatcher.py
+++ b/src/reyn/dispatch/dispatcher.py
@@ -123,8 +123,18 @@ async def dispatch_tool(
 
     # 1. Name validation
     if name not in ctx.tool_catalog:
+        # #187 A (deny-message-decision-enabling): suggest the closest catalog tool
+        # so the LLM can self-correct a near-miss instead of stalling. The #187
+        # dogfood saw the agent guess `source__grep` (from the source__* namespace)
+        # → unknown_tool → deterministic stop. A "did you mean <X>?" hint names a
+        # real, callable tool from the same catalog.
+        import difflib
+        _suggestions = difflib.get_close_matches(
+            name, list(ctx.tool_catalog), n=1, cutoff=0.6,
+        )
+        _hint = f" Did you mean {_suggestions[0]!r}?" if _suggestions else ""
         return _error(ctx, name, "unknown_tool",
-                      f"Tool {name!r} not in catalog")
+                      f"Tool {name!r} not in catalog.{_hint}")
 
     # 2. Argument validation against parameters schema
     schema = (

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -449,6 +449,20 @@ _LLM_RETRY_BASE_S: float = 2.0     # first backoff: 2s → 4s → 8s (capped at 
 _LLM_RETRY_MAX_BACKOFF_S: float = 16.0
 
 
+class EmptyLLMResponseError(Exception):
+    """The LLM returned a 200 response with an empty ``choices`` list.
+
+    Not an API-level error — litellm neither raises nor retries it — yet the
+    downstream ``response.choices[0]`` access would IndexError and silently
+    crash the router loop mid-task (#187 B1: gemini-2.5-flash-lite via the
+    LiteLLM proxy intermittently returns this 200+empty shape, killing the
+    turn before the agent edits). Raised by ``_llm_call_with_retry`` so the
+    same backoff machinery retries it (the condition is transient), and on
+    exhaustion the caller sees this named error instead of a cryptic
+    IndexError.
+    """
+
+
 def _get_retryable_litellm_exceptions() -> tuple:
     """Return the tuple of retryable litellm exceptions, loading litellm lazily.
 
@@ -474,6 +488,9 @@ def _is_retryable_exc(exc: BaseException) -> bool:
     Also catches httpx transport-level errors that LiteLLM may not wrap when
     the request fails before reaching the provider's HTTP response logic.
     """
+    if isinstance(exc, EmptyLLMResponseError):
+        # #187 B1: 200 + choices=[] is a transient provider condition — retry.
+        return True
     if isinstance(exc, _get_retryable_litellm_exceptions()):
         return True
     if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout)):
@@ -509,7 +526,19 @@ async def _llm_call_with_retry(
     last_exc: BaseException | None = None
     for attempt in range(_LLM_RETRY_MAX_ATTEMPTS):
         try:
-            return await coro_fn()
+            response = await coro_fn()
+            # #187 B1 root fix: an empty `choices` list is a transient provider
+            # condition — not an API error, so litellm neither raises nor retries
+            # it, yet the downstream `response.choices[0]` access IndexErrors and
+            # silently kills the router loop mid-task. Raise a named retryable
+            # error so the SAME backoff machinery retries it (covers both
+            # call_llm and call_llm_tools, the two choices[0] callsites), and on
+            # exhaustion the caller sees a clear error instead of an IndexError.
+            if not getattr(response, "choices", None):
+                raise EmptyLLMResponseError(
+                    f"LLM returned a 200 response with empty choices (model={model!r})"
+                )
+            return response
         except BaseException as exc:
             if not _is_retryable_exc(exc):
                 raise

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -62,14 +62,47 @@ def test_unknown_tool_returns_error_kind_and_emits_failed_event():
             name="bogus", args={}, ctx=ctx,
             invoker=_unused_invoker,
         )
-        assert result == {"status": "error",
-                          "error": {"kind": "unknown_tool",
-                                    "message": "Tool 'bogus' not in catalog"}}
+        # #187 A: message names the unknown tool; no close match in this catalog
+        # so no "Did you mean" hint is appended (kind/structure unchanged).
+        assert result["status"] == "error"
+        assert result["error"]["kind"] == "unknown_tool"
+        assert "Tool 'bogus' not in catalog" in result["error"]["message"]
+        assert "Did you mean" not in result["error"]["message"]
         # Failed event emitted, no called/returned events
         types = [e[0] for e in ev.events]
         assert "tool_failed" in types
         assert "tool_called" not in types
         assert "tool_returned" not in types
+    asyncio.run(main())
+
+
+def test_unknown_tool_suggests_close_match():
+    """Tier 2: a near-miss tool name yields a 'Did you mean <X>?' hint (#187 A).
+
+    The #187 dogfood saw the agent guess a non-catalog name (`source__grep`)
+    from a real namespace cue, hit unknown_tool, and deterministically stop.
+    The deny message now names the closest real catalog tool so the LLM can
+    self-correct instead of stalling. The suggestion must be an actual catalog
+    member (deny-message-decision-enabling).
+    """
+    async def main():
+        catalog = {
+            "source__read": {"function": {"name": "source__read"}},
+            "source__list": {"function": {"name": "source__list"}},
+            "exec__sandboxed_exec": {"function": {"name": "exec__sandboxed_exec"}},
+        }
+        ctx, _ev = make_ctx(catalog=catalog)
+        result = await dispatch_tool(
+            name="source__grep", args={}, ctx=ctx,
+            invoker=_unused_invoker,
+        )
+        assert result["status"] == "error"
+        assert result["error"]["kind"] == "unknown_tool"
+        msg = result["error"]["message"]
+        assert "Did you mean" in msg
+        # The suggested name must be a real catalog member, not a fabrication.
+        suggested = [name for name in catalog if repr(name) in msg]
+        assert suggested, f"suggestion must name a catalog tool; got: {msg!r}"
     asyncio.run(main())
 
 

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -25,6 +25,15 @@ FP-0008 PR-Q v8:
    Raw httpx.ConnectError and httpx.ReadTimeout are retried (= transport-level
    errors LiteLLM may not wrap).
 
+9. test_empty_choices_retried_then_succeed   (#187 B1)
+   A 200 response with choices=[] on attempt 1 → retried as a transient
+   condition, succeeds on attempt 2. No IndexError, no crash.
+
+10. test_empty_choices_exhausted_raises_named_error   (#187 B1)
+   choices=[] on every attempt → raises the named EmptyLLMResponseError
+   (NOT a cryptic IndexError from response.choices[0]); exhausted event
+   emitted. Pins the real proxy failure-mode shape.
+
 No real network calls — tests use a counter-based async callable stub that
 fails K times then succeeds (real instance, no unittest.mock).
 asyncio.sleep is monkeypatched to a no-op so tests run at full speed.
@@ -40,6 +49,7 @@ from reyn.llm.llm import (
     _LLM_RETRY_BASE_S,
     _LLM_RETRY_MAX_ATTEMPTS,
     _LLM_RETRY_MAX_BACKOFF_S,
+    EmptyLLMResponseError,
     _backoff_s,
     _is_retryable_exc,
     _llm_call_with_retry,
@@ -102,6 +112,51 @@ def _fake_response(content: str = '{"ok": true}') -> object:
         usage = None
 
     return _Response()
+
+
+def _fake_empty_response() -> object:
+    """A 200-shaped response with an empty ``choices`` list.
+
+    This is the real failure shape the LiteLLM proxy intermittently returns
+    for gemini-2.5-flash-lite (#187 B1) — a successful response object whose
+    ``choices`` is empty, so ``response.choices[0]`` would IndexError.
+    """
+    class _Response:
+        choices: list = []
+        usage = None
+
+    return _Response()
+
+
+class _ReturnEmptyThenValidCallable:
+    """Zero-arg async callable: returns an empty-choices response for the
+    first ``empty_count`` calls, then a valid response.
+
+    Models the transient 200+empty-choices condition (a RETURNED value, not a
+    raised exception). Real instance — no mock machinery.
+    """
+
+    def __init__(self, empty_count: int, valid_response: object) -> None:
+        self._empty_count = empty_count
+        self._valid = valid_response
+        self.call_count: int = 0
+
+    async def __call__(self) -> object:
+        self.call_count += 1
+        if self.call_count <= self._empty_count:
+            return _fake_empty_response()
+        return self._valid
+
+
+class _AlwaysEmptyCallable:
+    """Zero-arg async callable that always returns an empty-choices response."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def __call__(self) -> object:
+        self.call_count += 1
+        return _fake_empty_response()
 
 
 # ---------------------------------------------------------------------------
@@ -389,3 +444,65 @@ async def test_event_log_none_no_crash(monkeypatch):
     result = await _llm_call_with_retry(stub, "model-y", None)
     assert result is resp
     assert stub.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 9: empty choices (200 + choices=[]) retried, succeeds on retry  (#187 B1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_choices_retried_then_succeed(monkeypatch):
+    """Tier 2: retry wrapper — a 200 + empty-choices response is retried (#187 B1).
+
+    The LiteLLM proxy intermittently returns a successful response object with
+    choices=[] for gemini-2.5-flash-lite. Downstream response.choices[0] would
+    IndexError and silently kill the router loop mid-task. Invariant: empty
+    choices is treated as a transient condition and retried; the next non-empty
+    response is returned, with no IndexError.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    log = _make_event_log()
+    valid = _fake_response()
+    stub = _ReturnEmptyThenValidCallable(empty_count=1, valid_response=valid)
+
+    result = await _llm_call_with_retry(stub, "model-empty", log)
+    assert result is valid
+    assert stub.call_count == 2
+
+    retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+    assert retry_events, "empty choices must emit a llm_call_retry event"
+    assert retry_events[0].data["error_kind"] == "EmptyLLMResponseError"
+    assert not any(e.type == "llm_call_retry_exhausted" for e in log.all())
+
+
+# ---------------------------------------------------------------------------
+# Test 10: empty choices exhausted → named error, NOT IndexError  (#187 B1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_choices_exhausted_raises_named_error(monkeypatch):
+    """Tier 2: retry wrapper — persistent empty choices raises a named error (#187 B1).
+
+    Invariant: when every attempt returns choices=[], the wrapper raises the
+    explicit EmptyLLMResponseError after exhausting retries — NOT a cryptic
+    IndexError from response.choices[0] that the swallow handler would classify
+    opaquely. The exhausted event is emitted with the named error kind.
+    """
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    log = _make_event_log()
+    stub = _AlwaysEmptyCallable()
+
+    with pytest.raises(EmptyLLMResponseError):
+        await _llm_call_with_retry(stub, "model-empty-always", log)
+
+    assert stub.call_count == _LLM_RETRY_MAX_ATTEMPTS
+
+    exhausted = [e for e in log.all() if e.type == "llm_call_retry_exhausted"]
+    assert exhausted, "persistent empty choices must emit llm_call_retry_exhausted"
+    assert exhausted[0].data["error_kind"] == "EmptyLLMResponseError"

--- a/tests/test_router_loop_swallow_instrument_187.py
+++ b/tests/test_router_loop_swallow_instrument_187.py
@@ -1,0 +1,57 @@
+"""Tier 2: #187 B1 — the router-loop swallow handler surfaces the exception.
+
+Before #187 B1, a mid-turn router-loop exception (e.g. the final call_llm
+raising after retries — root cause: 200 + empty choices) was swallowed at
+``_handle_user_message``'s ``except Exception`` into a classified outbox
+summary and a graceful return, silently terminating the turn with no
+diagnosable trace (req=resp+1, no logged response).
+
+This test confirms the instrument: when ``_run_router_loop`` raises, the
+handler emits a ``router_loop_terminated_by_exception`` P6 event carrying the
+error type + repr, so any future swallowed loop error is primary-evidence
+(deny-message principle: surface, don't silently swallow). The classified
+outbox message still goes out unchanged — the instrument is additive.
+
+The failure is injected with a real async stub (a Fake that raises) — no
+MagicMock — and the assertion reads the public EventLog surface
+(``_chat_events.all()``), not private state.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chat.session import ChatSession
+
+
+@pytest.mark.asyncio
+async def test_swallowed_router_loop_exception_emits_p6_event():
+    """Tier 2: a mid-turn router-loop exception emits router_loop_terminated_by_exception (#187 B1).
+
+    Invariant: the swallow handler does not silently swallow — it emits a P6
+    event with the error type + repr so the root error is recoverable from the
+    event log even when the outbox only carries a classified summary.
+    """
+    s = ChatSession(agent_name="t")
+
+    async def _raise_mid_work(text: str, chain_id: str) -> None:
+        # Stand-in for the real mid-work crash (final call_llm raising after
+        # retries). A real async callable — a Fake, not a mock.
+        raise RuntimeError("simulated final-call crash")
+
+    s._run_router_loop = _raise_mid_work  # inject the failure at the loop seam
+
+    # Must not propagate — the handler swallows-but-surfaces.
+    await s._handle_user_message("hello", chain_id="c-test")
+
+    terminated = [
+        e for e in s._chat_events.all()
+        if e.type == "router_loop_terminated_by_exception"
+    ]
+    assert terminated, (
+        "swallow handler must emit router_loop_terminated_by_exception so the "
+        "root error is primary-evidence, not silently swallowed"
+    )
+    ev = terminated[0]
+    assert ev.data["chain_id"] == "c-test"
+    assert ev.data["error_type"] == "RuntimeError"
+    assert "simulated final-call crash" in ev.data["error"]


### PR DESCRIPTION
**[e2e-coder]** — #187 Stall B1 (edit-blocker) root fix + instrument + Stall A. Design pre-approved by lead-coder; opening for code-review → merge.

## B1 root cause (sandbox_2 traceback, primary evidence)
The LiteLLM proxy intermittently returns a **200 with an empty `choices` list** for `gemini-2.5-flash-lite`. It's not an API error → litellm neither raises nor retries it → `response.choices[0]` (`llm.py` `call_llm` / `call_llm_tools`) **IndexErrors**, which the router-loop handler swallows → the turn silently dies mid-work (`req=resp+1`, no logged response) → **edit 0/6**. This is a **general OS reliability bug** affecting all agents/runs, surfaced by the #187 SWE arc — not SWE-specific.

Full stack: `session.py:3053 _run_router_loop` → `loop.run` → `router_loop.py:2044 await _llm(...)` → `llm.py:1255 response.choices[0]` (unguarded).

## Changes
**B1 root fix (`llm.py`)** — single retry chokepoint:
- new `EmptyLLMResponseError`; `_is_retryable_exc` treats it as transient.
- `_llm_call_with_retry` raises it on empty `choices` so the **existing backoff/retry machinery** retries (the condition is transient). Covers **both** `choices[0]` callsites (`call_llm` line 1022 + `call_llm_tools` line 1255) at one point. On exhaustion: a **named** error, not a cryptic `IndexError`.

**B1 instrument (`session.py` swallow handler)** — `logger.exception` (stderr traceback) + P6 event `router_loop_terminated_by_exception` (error type + repr). Any future swallowed loop error is now primary-evidence (deny-message principle: surface, don't silently swallow). The classified outbox summary is unchanged — the instrument is additive.

**A — did-you-mean (`dispatcher.py`)** — the `unknown_tool` deny message appends a `difflib` `"Did you mean <X>?"` hint naming the **closest real catalog tool** (cutoff 0.6), so a near-miss guess (the #187 `source__grep` → deterministic stop) can self-correct. Deny-message-decision-enabling.

## Review points (lead's 3)
1. **empty-choices enters retry path** → `test_empty_choices_retried_then_succeed` (200+`choices=[]` → retry → returns next valid, no IndexError) + `test_empty_choices_exhausted_raises_named_error` (always empty → `EmptyLLMResponseError`, not IndexError; exhausted event). Real failure shape.
2. **instrument P6 event actually fires** → `test_swallowed_router_loop_exception_emits_p6_event` asserts the event on the public `_chat_events.all()` surface (failure injected via a real async stub — no MagicMock). Also trace-confirmed: sandbox_2's temp instrument at the identical 3057 swallow point captured the full traceback.
3. **did-you-mean proposes only real catalog members** → `test_unknown_tool_suggests_close_match` asserts the suggestion is an actual catalog key; the existing exact-message test updated to the new `"...catalog.{hint}"` contract (non-breaking: kind/structure unchanged, hint absent when no close match).

## Test plan
- [x] `pytest tests/test_llm_call_retry.py tests/test_dispatcher.py tests/test_router_loop_swallow_instrument_187.py -q` → 21 passed
- [x] `ruff check` (src + changed tests) → clean
- [x] `scripts/test_tier_audit.py --strict` (3 changed/new test files) → 0 errors
- [x] full `pytest -q` from rootdir → 2 pre-existing failures only (`test_swebench_missing_honest_skip` = swebench installed in local venv so the missing-path guard mis-fires; `test_web_fetch_preview_path_ref` = HTML-extraction lib version) — both **not-my-diff** (identical with my diff stashed; HEAD == origin/main) and local-env-only (pass in CI; b565f5e5/#1411 merged green)

## Next
On merge → sandbox_2 re-runs 13453 (max-iter 80): confirm loop completes (`req=resp+1` gone / uses the turn budget / reaches edit+diff). If read-thrash persists, B2 (navigation ACI) — staged, design-first.

Refs #187
🤖 Generated with [Claude Code](https://claude.com/claude-code)