### PR TITLE
fix(187): B3 — resolve file-op path against workspace base_dir before the permission gate

### DIFF
--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -150,6 +150,31 @@ def _read_inline_cap(ctx: OpContext) -> int:
     return control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.skill_name)
 
 
+def _resolve_for_gate(ctx: OpContext, path_str: str) -> str:
+    """Resolve a file-op path against the workspace base_dir so the permission
+    gate checks the SAME absolute target the op will actually read/write.
+
+    #187 B3: the handler previously passed the raw (often relative) op.path to
+    ``require_file_*``; the gate's SandboxLayer then resolved it with
+    ``Path(path).resolve()`` against the HOST process cwd — not the workspace
+    base_dir. Under a container backend (base_dir=/testbed) a relative repo
+    write like ``astropy/io/ascii/html.py`` was therefore checked against the
+    host cwd, fell outside the sandbox ``write_paths`` cap (``[/testbed]``), and
+    was DENIED — even though ``Workspace.write_file`` resolves that same path
+    against /testbed and would land it there. Resolving here closes the base
+    mismatch (the Workspace already documents that the gate operates on the
+    absolute paths it resolves). Behaviour-preserving for the host case
+    (base_dir == cwd → the identical absolute path).
+    """
+    ws = getattr(ctx, "workspace", None)
+    if ws is None:
+        return path_str
+    p = Path(path_str).expanduser()
+    if p.is_absolute():
+        return str(p.resolve())
+    return str((ws.base_dir / p).resolve())
+
+
 async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:
     # Permission check (single point for both frontends). For
     # `regenerate_index` the file actually written is `output_path`, not
@@ -162,20 +187,20 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         if op.op in _WRITE_OPS:
             write_target = op.output_path if op.op == "regenerate_index" and op.output_path else op.path
             ctx.permission_resolver.require_file_write(
-                ctx.permission_decl, write_target, ctx.skill_name,
+                ctx.permission_decl, _resolve_for_gate(ctx, write_target), ctx.skill_name,
                 sandbox_policy=_sandbox,
             )
             # move also writes to dest_path — gate both source (= the file
             # being effectively deleted) and dest (= the file being created).
             if op.op == "move" and op.dest_path:
                 ctx.permission_resolver.require_file_write(
-                    ctx.permission_decl, op.dest_path, ctx.skill_name,
+                    ctx.permission_decl, _resolve_for_gate(ctx, op.dest_path), ctx.skill_name,
                     sandbox_policy=_sandbox,
                 )
         elif op.op in _READ_OPS:
             # read / glob / grep / stat — gate against read scope
             ctx.permission_resolver.require_file_read(
-                ctx.permission_decl, op.path, ctx.skill_name,
+                ctx.permission_decl, _resolve_for_gate(ctx, op.path), ctx.skill_name,
                 sandbox_policy=_sandbox,
             )
 

--- a/tests/test_op_runtime_file_b3_basedir_resolve_187.py
+++ b/tests/test_op_runtime_file_b3_basedir_resolve_187.py
@@ -1,0 +1,108 @@
+"""Tier 2: #187 B3 — the file-op handler resolves the path against the workspace
+base_dir BEFORE the permission gate (in-container write-lands).
+
+B3 root cause (deterministic, primary-evidence repro): under a container backend
+(``base_dir=/testbed``) the agent's relative repo write (``astropy/io/...``) was
+passed RAW to ``require_file_write``; the gate's SandboxLayer resolved it with
+``Path(path).resolve()`` against the HOST process cwd — not /testbed — so it fell
+outside the sandbox ``write_paths`` cap (``[/testbed]``) and was DENIED, even
+though ``Workspace.write_file`` resolves the same path against /testbed and lands
+it there. ``--grant-file-write`` (config file.write=allow) already bypasses the
+AgentLayer zone, so the SandboxLayer ∩ on the relative-vs-cwd mismatch was the
+real denier (NOT the project_root zone anchor).
+
+The fix resolves the path against ``ctx.workspace.base_dir`` before the gate, so
+the permission check sees the SAME absolute target the write/read will hit. These
+tests pin the round-trip (granted AND lands), the load-bearing sandbox cap
+(falsification), and read/write symmetry — with real instances (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.events.events import EventLog
+from reyn.op_runtime.context import OpContext
+from reyn.op_runtime.file import handle
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.schemas.models import FileIROp
+from reyn.workspace.workspace import Workspace
+
+
+def _ctx(tmp_path: Path, base_dir: Path, *, write_cap: Path, read_cap: Path) -> OpContext:
+    """An OpContext mirroring the run-once-in-container scoping: workspace rooted
+    on a non-cwd base_dir, config file.write/read=allow (--grant-file-write),
+    project_root on the HOST, and a sandbox capping paths to the container repo.
+    """
+    events = EventLog()
+    ws = Workspace(events, base_dir=base_dir, state_dir=tmp_path / "state")
+    resolver = PermissionResolver(
+        config_permissions={"file.write": "allow", "file.read": "allow"},
+        project_root=tmp_path / "host",  # host anchor ≠ base_dir (the B3 condition)
+        interactive=False,
+    )
+    return OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        default_sandbox_policy={
+            "write_paths": [str(write_cap)],
+            "read_paths": [str(read_cap)],
+            "network": False,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_b3_relative_write_resolves_against_base_dir_and_lands(tmp_path):
+    """Tier 2: a relative repo write under a non-cwd base_dir is GRANTED and lands (#187 B3).
+
+    Pre-fix the raw relative path resolved against host cwd → outside the
+    sandbox write_paths=[base_dir] cap → denied. Resolving against base_dir
+    first makes the gate check /testbed/astropy/... — granted — and the write
+    lands under base_dir (round-trip / write-lands, the #1410 lesson).
+    """
+    testbed = tmp_path / "testbed"
+    (testbed / "astropy" / "io").mkdir(parents=True)
+    ctx = _ctx(tmp_path, testbed, write_cap=testbed, read_cap=testbed)
+
+    op = FileIROp(kind="file", op="write", path="astropy/io/html.py", content="X = 1\n")
+    res = await handle(op, ctx, "control_ir")
+
+    assert res["status"] == "ok"
+    # write-lands: the file is under the workspace base_dir, not the host cwd.
+    assert (testbed / "astropy" / "io" / "html.py").read_text() == "X = 1\n"
+
+
+@pytest.mark.asyncio
+async def test_b3_sandbox_write_cap_still_load_bearing(tmp_path):
+    """Tier 2: ★falsification — when the sandbox write cap does NOT cover the
+    base_dir, the same relative write is DENIED. Proves the resolution targets
+    base_dir (not a trivially-always-grant) and the SandboxLayer ∩ is intact.
+    """
+    testbed = tmp_path / "testbed"
+    (testbed / "astropy" / "io").mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"  # cap excludes the workspace base_dir
+    ctx = _ctx(tmp_path, testbed, write_cap=elsewhere, read_cap=testbed)
+
+    op = FileIROp(kind="file", op="write", path="astropy/io/html.py", content="X = 1\n")
+    with pytest.raises(PermissionError):
+        await handle(op, ctx, "control_ir")
+
+
+@pytest.mark.asyncio
+async def test_b3_relative_read_resolves_against_base_dir(tmp_path):
+    """Tier 2: read/write symmetry — a relative read under a tight read_paths cap
+    on the base_dir is GRANTED (the read gate also resolves against base_dir).
+    """
+    testbed = tmp_path / "testbed"
+    (testbed / "astropy").mkdir(parents=True)
+    (testbed / "astropy" / "io.py").write_text("data = 2\n")
+    ctx = _ctx(tmp_path, testbed, write_cap=testbed, read_cap=testbed)
+
+    op = FileIROp(kind="file", op="read", path="astropy/io.py")
+    res = await handle(op, ctx, "control_ir")
+
+    assert res.get("status") != "denied"
+    # the content read is the file under base_dir (resolved correctly).
+    assert "data = 2" in str(res)


### PR DESCRIPTION
**[e2e-coder]** — #187 B3 (8th defect, the SWE edit-blocker). Root cause confirmed by lead (ran repro + source cross-check, arbiter GO) and sandbox_2 (independent verify). Opening for code-review → merge.

## What B1 unblocked, then B3 blocked
After the B1 empty-choices fix (#1413), the general agent **reached `file__write` for the first time** in the #187 arc — but the write was **DENIED**.

## Root cause (flow-trace + deterministic repro — corrected an initial localization)
The file-op handler (`op_runtime/file.py`) passed the **raw relative** `op.path` to `require_file_write`. The gate's `SandboxLayer._path_under` then did `Path(path).resolve()` against the **host process cwd** — not the workspace base_dir. Under a container backend (`base_dir=/testbed`) a relative repo write like `astropy/io/ascii/html.py` was checked against the host cwd, fell outside the sandbox `write_paths` cap (`[/testbed]`), and was denied — even though `Workspace.write_file` resolves the same path against /testbed and lands it there.

Key correction: `--grant-file-write` (config file.write=allow) **already bypasses the AgentLayer zone** via `_is_config_approved`, so the `SandboxLayer ∩` on the relative-vs-cwd mismatch was the real denier — **NOT** the `project_root` zone anchor (the static denial text *"outside the default write zone"* misled the first read). The read/write asymmetry (reads worked) is explained: `read_paths=[]` (broad → sandbox ⊤) vs `write_paths=[/testbed]` (tight).

Deterministic repro (pure permission decision, no container) — both lead and sandbox_2 ran it:
```
RAW relative  astropy/io/ascii/html.py        → DENIED  (exact prod message)
workspace-resolved /testbed/astropy/...         → GRANTED
```

## Fix (focused, lead-directed)
Resolve `op.path` against `ctx.workspace.base_dir` in the handler **before** the gate, so the permission check sees the same absolute target the write/read will hit. **Read + write symmetric** (`require_file_read` also passed the raw path). Behaviour-preserving for the host case (`base_dir == cwd` → identical absolute path). Aligns with `Workspace`'s documented design (the gate operates on the absolute paths it resolves).

## Round-trip gate (the #1410 write-lands lesson)
`test_b3_relative_write_resolves_against_base_dir_and_lands`: a relative write under a non-cwd base_dir is **granted AND lands** under base_dir (not host cwd). Plus a falsification (sandbox cap excluding base_dir still denies → the cap stays load-bearing) and read/write symmetry. Real instances, no mocks. **Verified the tests fail pre-fix (exact B3 denial) and pass post-fix.**

## Scope note
The latent host-anchored **default file-zone** (only manifests in a non-grant *interactive* container run — NOT the `--grant-file-write` SWE path) is tracked separately in **#1414** to keep this fix focused.

## Test plan
- [x] `pytest tests/test_op_runtime_file_b3_basedir_resolve_187.py -q` → 3 passed; verified fail pre-fix (stash), pass post-fix
- [x] file-op/permission/sandbox/workspace/control_ir clusters (`-k "op_runtime or permission or workspace or control_ir or s31 or sandbox or file_"`) → 614 passed, 3 skipped
- [x] `ruff check` (changed files) → clean
- [x] `scripts/test_tier_audit.py --strict` (new test) → 0 errors
- [ ] full `pytest -q` from rootdir (running)
- [ ] live round-trip (sandbox_2): `file__write astropy/.../html.py` → granted + `git -C /testbed diff` shows it

## Next
On merge → sandbox_2 re-runs 13453 (the live round-trip gate): **does the agent now land an actual edit + produce a diff** — the first of the #187 arc, the capability core.

Refs #187
🤖 Generated with [Claude Code](https://claude.com/claude-code)