### PR TITLE
fix(187): advertise file__edit (surgical) in the router hot list — 9th defect

### DIFF
--- a/src/reyn/chat/router_tools.py
+++ b/src/reyn/chat/router_tools.py
@@ -261,7 +261,7 @@ def build_tools(
       B1 invoke_skill, B2 delegate_to_agent,
       B3 remember_shared, B4 remember_agent, B5 forget_memory,
       C1 list_directory, C2 read_file (when any file scope),
-      C3 write_file, C4 delete_file (only when write scope),
+      C3 write_file, C3b edit_file, C4 delete_file (only when write scope),
       D1 list_mcp_servers, D2 list_mcp_tools, D3 call_mcp_tool, D4 describe_mcp_tool (when mcp configured).
 
     Internally collects ToolSpec objects (= single source of truth for name,
@@ -511,6 +511,25 @@ def build_tools(
                     description=_write_file_rendered["function"]["description"],
                     parameters=_write_file_rendered["function"]["parameters"],
                     dispatch_kind=_write_file_def.dispatch_kind,
+                ))
+
+            # ── C3b: edit_file ───────────────────────────────────────────
+            # #187 9th defect: edit_file (surgical old_string/new_string) EXISTS
+            # and is dispatchable but was never advertised in the hot list — so
+            # the LLM only saw whole-file write_file and, on a truncated read of
+            # a large file, overwrote the file with the partial content it had
+            # (a destructive non-resolving diff). Surfacing the surgical edit
+            # lets the agent patch by anchor (no full-file read needed). It is a
+            # write-class op, so it lives inside the write-scope block alongside
+            # write_file/delete_file and completes read/write/edit/delete.
+            _edit_file_def = _registry.lookup("edit_file")
+            if _edit_file_def is not None and _edit_file_def.gates.router == "allow":
+                _edit_file_rendered = _edit_file_def.render_for_router()
+                specs.append(ToolSpec(
+                    name=_edit_file_rendered["function"]["name"],
+                    description=_edit_file_rendered["function"]["description"],
+                    parameters=_edit_file_rendered["function"]["parameters"],
+                    dispatch_kind=_edit_file_def.dispatch_kind,
                 ))
 
             # ── C4: delete_file ──────────────────────────────────────────

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -93,9 +93,9 @@ def _max_object_nesting(params: dict) -> int:
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 
-FILE_TOOL_NAMES = {"list_directory", "read_file", "write_file", "delete_file"}
+FILE_TOOL_NAMES = {"list_directory", "read_file", "write_file", "edit_file", "delete_file"}
 FILE_READ_TOOL_NAMES = {"list_directory", "read_file"}
-FILE_WRITE_TOOL_NAMES = {"write_file", "delete_file"}
+FILE_WRITE_TOOL_NAMES = {"write_file", "edit_file", "delete_file"}
 MCP_TOOL_NAMES = {"list_mcp_servers", "list_mcp_tools", "call_mcp_tool"}
 
 SAMPLE_MCP_SERVERS = [{"name": "fs", "description": "Filesystem MCP server"}]
@@ -259,11 +259,12 @@ def test_file_read_only_tools_present():
     assert "list_directory" in names, "list_directory missing with read scope"
     assert "read_file" in names, "read_file missing with read scope"
     assert "write_file" not in names, "write_file must be absent with read-only scope"
+    assert "edit_file" not in names, "edit_file (write-class) must be absent with read-only scope"
     assert "delete_file" not in names, "delete_file must be absent with read-only scope"
 
 
 def test_file_full_tools_present():
-    """Tier 2: Both read and write scope → all 4 file tools present."""
+    """Tier 2: Both read and write scope → all 5 file tools present."""
     tools = build_tools(
         SAMPLE_SKILLS,
         SAMPLE_AGENTS,
@@ -272,6 +273,26 @@ def test_file_full_tools_present():
     names = set(_tool_names(tools))
     missing = FILE_TOOL_NAMES - names
     assert not missing, f"Missing file tools with full permissions: {missing}"
+
+
+def test_edit_file_advertised_in_hot_list_with_write_scope():
+    """Tier 2: #187 9th defect — edit_file (surgical) is advertised in the hot list.
+
+    edit_file existed and was dispatchable, but build_tools never surfaced it, so
+    the LLM only saw whole-file write_file and on a truncated read overwrote the
+    file with partial content (destructive non-resolving diff). This pins that the
+    surgical edit tool is in the advertised catalog whenever write scope is
+    granted — the SWE-agent ACI thesis (the edit tool is the critical SWE tool).
+    """
+    tools = build_tools(
+        SAMPLE_SKILLS,
+        SAMPLE_AGENTS,
+        file_permissions={"read": ["src"], "write": ["out"]},
+    )
+    names = _tool_names(tools)
+    assert "edit_file" in names, (
+        f"edit_file must be advertised with write scope (the #187 ACI gap); got: {names}"
+    )
 
 
 # ── MCP tool permission-gating tests ──────────────────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — #187 9th defect (last-mile). After B3 (#1415) let the general agent land its **first git diff of the arc**, the diff was **destructive** (5 insertions / **211 deletions**, non-resolving). This surfaces the surgical edit tool so the next diff can be **resolving**. Design-first per lead; opening for code-review.

## Root cause (sandbox_2 primary evidence, lead + I cross-checked)
- `file__read` came back **truncated** — the agent got 8396 of 17668 chars of `html.py`.
- The surgical **`edit_file` / `file__edit`** tool was **not advertised** in the router hot list, so the LLM only saw whole-file `write_file` → it wrote back the partial content it had read → **deleted the ~9KB it never saw**.

`edit_file` already exists and is dispatchable end-to-end — `op_runtime/file.py` `_execute_edit` (surgical `old_string`/`new_string`), registry `edit_file → EditFileIROp`, `universal_dispatch` `file__edit → edit_file`, `ToolDefinition EDIT_FILE` with `gates.router="allow"`, registered in `tools/__init__.py`. The **only** gap: `build_tools` had no lookup block for it (a pure hot-list omission).

## Fix
Add the `edit_file` block to `build_tools`, inside the write-scope branch alongside `write_file`/`delete_file` (edit is write-class), completing **read/write/edit/delete**. Surgical edit patches by anchor — no full-file read — so it sidesteps the read-truncation that caused the destructive rewrite. **SWE-agent ACI thesis**: the edit tool is *the* critical SWE tool; its absence (while write was present) was the ACI gap.

## FP-0034 philosophy alignment (per lead's review gate)
`edit_file` is a **general file primitive** (not skill-specific), **predictable** (always present with write scope, like its siblings), **provider-agnostic**, and **cache-stable** (fixed position in the file block). The omission was the inconsistency; including it makes the file-op set complete.

## Test plan
- [x] `pytest tests/test_router_tools.py tests/test_router_tools_invariants.py tests/test_router_tools_universal_wrappers.py -q` → 46 passed
- [x] live check: `build_tools(..., file_permissions={read,write})` catalog = `[list_directory, read_file, write_file, edit_file, delete_file]`
- [x] catalog/router/dispatch clusters (`-k "router_tools or build_tools or catalog or hot_list or universal_dispatch or tool_catalog"`) → 335 passed
- [x] `ruff check` (changed files) → clean
- [x] `scripts/test_tier_audit.py --strict` → 0 errors
- [ ] full `pytest -q` from rootdir (running)
- [ ] live (sandbox_2): the agent picks `file__edit` → **resolving** diff (anchor-patch, no truncation)

## Next
On merge → sandbox_2 re-runs 13453: does the agent now use `file__edit` and produce the **first RESOLVING diff** of the arc — the capability payoff.

Refs #187
🤖 Generated with [Claude Code](https://claude.com/claude-code)