### PR TITLE
fix(187): thread the exec sandbox backend instance into the LIVE router OpContext — 10th defect

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -172,6 +172,18 @@ class RouterHostAdapter:
         environment_backend: Any = None,
         workspace_base_dir: Path | None = None,
         workspace_state_dir: Path | None = None,
+        # #187 exec-seam (10th defect): the SandboxBackend INSTANCE for exec
+        # EXECUTION (docker for in-container repos). Distinct from the
+        # ``sandbox_backend`` STRING above (which only drives the D14 exec
+        # visibility gate): the op handler (op_runtime/sandboxed_exec) reads
+        # ``ctx.sandbox_backend`` (the instance) and falls back to the host
+        # seatbelt backend when it is None. Without threading this, the LIVE
+        # router's exec ran on the host (``No such file or directory:
+        # '/testbed'``), so the agent's verify loop always failed. Parallel to
+        # ``environment_backend`` for FS (#1411) — the legacy
+        # ``ChatSession._make_router_op_context`` already passes it; the live
+        # adapter omitted it (the same live-vs-legacy seam gap as #1410/#1411).
+        sandbox_backend_instance: Any = None,
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
         # ChatSession passes the session-scoped tracker; None when wrappers are
         # off or hot_list_n == 0.
@@ -311,6 +323,7 @@ class RouterHostAdapter:
         self._embedding_model_class = embedding_model_class
         # FP-0034 Phase 2
         self._sandbox_backend = sandbox_backend
+        self._sandbox_backend_instance = sandbox_backend_instance
         self._environment_backend = environment_backend
         self._workspace_base_dir = workspace_base_dir
         self._workspace_state_dir = workspace_state_dir
@@ -1477,6 +1490,9 @@ class RouterHostAdapter:
             media_store=self._media_store,
             # #272/#1128: voluntary-compaction capability for the compact op.
             compact_now=self._compact_now,
+            # #187 exec-seam: the exec backend INSTANCE so sandboxed_exec runs
+            # in the container repo (/testbed), not the host seatbelt fallback.
+            sandbox_backend=self._sandbox_backend_instance,
             # #1339 / sandbox-model completion: resolve the operator-or-default
             # sandbox policy onto the router OpContext (was None → the handler
             # fell back to LLM-set op fields = the sandbox-escape gap).

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1855,6 +1855,13 @@ class ChatSession:
             environment_backend=self._environment_backend,
             workspace_base_dir=self._workspace_base_dir,
             workspace_state_dir=self._workspace_state_dir,
+            # #187 exec-seam (10th defect): the exec backend INSTANCE so the LIVE
+            # router's sandboxed_exec runs in the container repo, not the host
+            # seatbelt fallback. Same instance the legacy _make_router_op_context
+            # passes (4824); chat.py injects the SAME docker backend at both FS +
+            # exec seams (#1289 single-shared-sandbox). Distinct from the D14
+            # STRING above.
+            sandbox_backend_instance=self._sandbox_backend,
             # #1339 / sandbox-model completion: thread the operator sandbox
             # policy so make_router_op_context resolves a concrete agent-level
             # policy onto the router OpContext (closes the chat-factory wiring gap).

--- a/tests/test_router_opcontext_basedir_live_187.py
+++ b/tests/test_router_opcontext_basedir_live_187.py
@@ -48,3 +48,34 @@ def test_live_op_context_host_default_unchanged() -> None:
     s = ChatSession(agent_name="t")
     ctx = s._router_host.make_router_op_context()
     assert ctx.workspace.base_dir == Path.cwd()
+
+
+def test_live_op_context_threads_exec_sandbox_backend(tmp_path) -> None:
+    """Tier 2: #187 exec-seam (10th defect) — the LIVE op-context factory carries the
+    injected sandbox_backend INSTANCE so ``sandboxed_exec`` runs in the container repo,
+    not the host seatbelt fallback.
+
+    Root: ``sandboxed_exec`` reads ``ctx.sandbox_backend or get_default_backend(...)``;
+    the live ``RouterHostAdapter.make_router_op_context`` omitted ``sandbox_backend=``
+    on its OpContext → None → host seatbelt → exec hit ``/testbed not found`` → the
+    agent's verify loop always failed. The legacy ``ChatSession._make_router_op_context``
+    passed it; this is the same live-vs-legacy seam gap as #1410/#1411 (3rd instance).
+    """
+    backend = DockerEnvironmentBackend(container="c1", repo_dir="/testbed")
+    s = ChatSession(
+        agent_name="t", environment_backend=backend, sandbox_backend=backend,
+        workspace_base_dir=Path("/testbed"), workspace_state_dir=tmp_path,
+    )
+    ctx = s._router_host.make_router_op_context()
+    assert ctx.sandbox_backend is backend, (
+        "live router exec must run on the injected sandbox backend (the container), "
+        "not the None→host-seatbelt fallback (the #187 exec-seam defect)"
+    )
+
+
+def test_live_op_context_no_sandbox_backend_default_unchanged() -> None:
+    """Tier 2: no sandbox_backend → ctx.sandbox_backend is None → ``sandboxed_exec``
+    falls back to the host default backend (host / interactive behavior unchanged)."""
+    s = ChatSession(agent_name="t")
+    ctx = s._router_host.make_router_op_context()
+    assert ctx.sandbox_backend is None


### PR DESCRIPTION
**[e2e-coder]** — #187 10th structural defect (the exec-seam analog of #1410/#1411). Root-caused by sandbox_2 (primary evidence), confirmed by lead. Opening for code-review.

## What surfaced it
After the exec-dispatch fix let the agent's exec calls dispatch (3/3, via the 3411 `__`-route), sandbox_2's Set C v2 showed exec running on the **host seatbelt backend, not docker /testbed**:
```
{"backend":"seatbelt","returncode":-1,"stderr":"[Errno 2] No such file or directory: '/testbed'"}  (3/3)
```
So the agent's **real** verify attempts (verify intent is genuine — it reached exec) always failed → it could never see its edit broke → no self-correct. This refines the #202 picture again: the failure is **structural** (exec backend mis-wired), not under-exploration.

## Root cause
`op_runtime/sandboxed_exec` selects `ctx.sandbox_backend or get_default_backend(...)`. The **live** `RouterHostAdapter.make_router_op_context` **omitted** `sandbox_backend=` on its OpContext → `None` → host seatbelt. The **legacy** `ChatSession._make_router_op_context` (session.py:4824) passes it. Same live-vs-legacy seam gap as #1410/#1411 — **3rd instance** (base_dir → env_backend → now the exec backend instance).

## The type nuance (lead flagged)
The adapter's existing `sandbox_backend` (str) drives only the D14 exec **visibility** gate — a naive `sandbox_backend=self._sandbox_backend` mirror would be a type mismatch (`OpContext.sandbox_backend` is a `SandboxBackend` instance). The exec **execution** needs the *instance*. chat.py injects the same docker `env_backend` at both the FS and exec seams (#1289 single-shared-sandbox invariant), so `ChatSession._sandbox_backend` is that exec-capable instance.

## Fix
Thread the instance via a **distinct** `sandbox_backend_instance` param into the adapter → forward to `OpContext.sandbox_backend` (parallel to how #1411 threaded `environment_backend`/`base_dir`). Host / interactive default (no instance → `None` → host backend) unchanged.

## Test plan
- [x] live-path test (`session._router_host.make_router_op_context()`, the dispatch the router actually uses): injected backend → `ctx.sandbox_backend is` that backend; none → `None`. **Verified fail pre-fix (None), pass post-fix.**
- [x] clusters (`-k "router_host or sandboxed_exec or router_opcontext or sandbox_policy or op_context or 1411 or 1410"`) → 63 passed
- [x] `ruff check` (changed files) → clean
- [x] `scripts/test_tier_audit.py --strict` → 0 errors
- [ ] full `pytest -q` from rootdir (running)
- [ ] live (sandbox_2): Set C v3 — exec runs in /testbed (`backend != seatbelt`, no `/testbed not found`) → the agent's verify loop can finally complete

## Structural follow-up
The deeper fix — unifying the two op-context builders (`make_router_op_context` vs `_make_router_op_context`) so seams can't keep diverging — is the **#1412** single-source theme; this 3rd divergence is more evidence for it (per lead's whack-a-mole concern). Folded there, not bundled here.

Refs #187, #1412
🤖 Generated with [Claude Code](https://claude.com/claude-code)