### PR TITLE
docs(187): weak-model discovery + selection reliability design (universal-catalog)

### DIFF
--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -134,12 +134,27 @@ list (省略 / `[]` 渡しで全 visible category)。 `filter` は
 短い description を持つ; 長い description は意図的に出さず、 一覧を
 コンパクトに保つ。
 
+**weak-model landing 設計** では、 category で絞った結果は各 item の
+完全な `description` と `input_schema` を運ぶ (= `qualified_name` +
+`description` + `input_schema` の3点)。 これにより common flow は
+`list_actions` → `invoke_action` の2段になり、 間の `describe_action`
+が不要になる。
+[Weak-model discovery + selection reliability](#weak-model-discovery-selection-reliability)
+参照。
+
 ### `describe_action(action_name) → {qualified_name, description, input_schema, metadata}`
 
 1 つの action の long description、 完全な input schema (= 元 tool の
 `parameters`)、 metadata (`target_tool_name`, `category`, `purity`) を
 返す。 未知の name に対しては §D12 の structured error response (下記
 参照)。
+
+weak-model landing 設計では `describe_action` は **common critical path
+から外れる** — `list_actions` が絞った category について description +
+schema を既に返すため。 edge case 用にのみ残す: 単一名 lookup、 もしくは
+全 schema を list 結果に inline すると無駄になるほど大きい category。
+[Weak-model discovery + selection reliability](#weak-model-discovery-selection-reliability)
+参照。
 
 ### `invoke_action(action_name, args) → <target の result>`
 
@@ -245,6 +260,109 @@ prefix 内に留まる (= 2 回目以降の request は warm cache を hit)。
 Tier 2 invariant が section の bullet 一覧を `CATEGORIES` tuple に
 pin しているので、 master taxonomy への将来の追加が SP と乖離する場合は
 test が落ちる。
+
+## Weak-model discovery + selection reliability
+
+discover→invoke loop は LLM がそれを *使う* 意志の分だけしか機能しない。
+strong model (`router_model: strong`) は category 一覧から action を柔軟
+に discover / select でき、 追加の足場は要らない。 weak / small model
+(`router_model: light`) は 2 つの信頼できる failure mode を示し、 catalog
+はこれを **構造的に** 解く — weak 対応が strong の柔軟性を損なわない形で:
+
+1. **Satisficing** — より適した action (`file__edit`) を discover せず、
+   見えている hot-list action (`file__write`) を「十分」として invoke する。
+2. **Discovery-skip** — 能動的に `list_actions` を呼ばず、 training prior
+   から action 名を推測する (しばしば malformed: `file.write`,
+   `file__read_file`)。
+
+*Status: no-names system prompt と `file__edit` cross-reference は出荷済;
+`list_actions` が schema を返す点と tier-gated mandate は合意済の landing
+設計 (実装進行中)。 以下の各 lever は `gemini-2.5-flash-lite` に対し
+patch + live で reliable N で検証済。*
+
+### No-names catalog
+
+action 名は **ただ 1 箇所** — `list_actions` の結果 — にのみ現れる。
+system prompt (category を capability で記述し、 action 名は載せない) や
+他のあらゆる tool の description には存在しない。 これは 2 つの目的に資する:
+
+- **Scalability** — LLM 可視の tool 一覧と system prompt が action 数に
+  対し O(1) に保たれる; 200-action surface でも 20-action と同じ prompt
+  コスト。
+- **真に未知の action の強制 discovery** — 名前が model の記憶し得る
+  どこにも存在しないとき、 それを得る唯一の手段は `list_actions` の呼び
+  出しになる。 真に未知の action ではこれが確実に fire する (非推測な
+  obscure skill で `list_actions` 16/16 を観測)。
+
+  注意 — 名前隠蔽が discovery を強制するのは *未知* action のみ。 training
+  で **既知** の概念 (`file__read` / `file__write`) では、 weak model は
+  概念を recall し、 正確な名前を discover せず malformed な近似を emit
+  する。 既知 action の *選択* は名前隠蔽ではなく、 下記の機械的 mandate
+  で扱う。
+
+### `list_actions` が name + description + schema を返す
+
+`list_actions(category=[…])` が bounded set に絞ったとき、 各 item は
+**3点セット** — `qualified_name` / `description` / `input_schema` — を運ぶ:
+
+- **`description`** は model が正しい action を *選ぶ* ための材料; model は
+  読めない action を選べない (tool description の慣例的役割)。
+- **`input_schema`** は選んだ action を正しい引数で *invoke* するための形。
+
+絞った結果が両方を運ぶため、 common flow は **2 段 — `list_actions` →
+`invoke_action`** — で、 間に `describe_action` を挟まない。 コンパクト
+さは *category-narrowing* (聞いた category の schema だけ来る) で保たれ、
+schema を全体的に省くことでは保たない。
+
+検証 (schema → invocation 軸): `list_actions` 結果に schema を注入すると、
+受動的な `describe_action` 呼び出しが 14→0、 引数正答が 0→12 (/20) に
+なった — list に schema があれば weak model は別の describe round-trip
+なしに正しく invoke する。 description → selection 軸は tool description
+の慣例的役割 (読めない action は選べない) であり、 description は別途
+測定した lever ではなく設計根拠として運ぶ。
+
+### 機械的 mandate (tier-gated)
+
+weak model は **機械的・無条件の手続き mandate には従う** が **推論ベース
+の推奨は無視する**。 *説明する* cross-reference (「partial edit には
+`file__edit` を推奨」) は無視され (0/20 が従う)、 無条件 mandate (「edit は
+`file__write` でなく `file__edit` を使わ MUST」) は従われる (edit 3 /
+write 1)。
+
+そのため router は一連の機械的 system-prompt mandate を model tier で
+gate する (`router_model: light` → on; `strong` → off):
+
+- **`list_actions`-first** — 最初の tool 呼び出しは、 何かを read / write
+  / edit する前に MUST `list_actions`。
+- **`file__edit`-MUST** — partial / surgical edit は `file__write` でなく
+  `file__edit` を使う。
+
+mandate を効かせるのは 2 つの性質:
+
+1. **明示的 action 列挙の wording。** mandate が covers する具体操作を
+   名指す (「read / write / edit する前に」) と 25-55% compliance; 一般的
+   表現 (「他の tool の前に」) は 0-10%。
+2. **Constraint reinforcement。** mandate を system prompt 中に ~3× 反復
+   すると compliance が ~36% から **~75-85%** に上がる (matched-pair で
+   検証、 distribution overlap なし)。 反復は small model が推論途中で
+   指示を取りこぼす goal-displacement に対抗する。
+
+### 天井
+
+明示列挙 wording + 3× reinforcement で `list_actions`-first mandate は
+**~75-85% の weak-model compliance** に達する。 これが実用的な prompting
+天井: 残り ~15-25% は prompting だけでは閉じない alignment fragility で、
+さらに狭めるには fine-tuning が要り scope 外。 strong model は mandate を
+off で走り影響を受けない。
+
+### 統一原理
+
+> weak model は **真に未知の** action を **自力 discover** し、 **機械的
+> mandate に従う**; **training 既知** の名前では **recall して flail** し、
+> **推論ベースの推奨を無視する**。 ゆえに catalog は名前を隠し (未知
+> discovery を強制)、 description + schema を絞った list に載せ (describe
+> round-trip を除去)、 機械的 mandate を weak tier で gate する (既知
+> action の選択を解く) — strong model は無制約のまま。
 
 ## Default-on (PR-3b-iv)
 

--- a/docs/concepts/tools-integrations/universal-catalog.md
+++ b/docs/concepts/tools-integrations/universal-catalog.md
@@ -139,12 +139,25 @@ case-insensitive substring match against `qualified_name` and
 `qualified_name` and a short description; long descriptions are
 deliberately omitted so the listing stays compact.
 
+In the **weak-model landing design**, a narrowed-category result instead
+carries each item's full `description` and `input_schema` (the triple
+`qualified_name` + `description` + `input_schema`), so the common flow is
+`list_actions` → `invoke_action` with no intervening `describe_action`. See
+[Weak-model discovery + selection reliability](#weak-model-discovery-selection-reliability).
+
 ### `describe_action(action_name) → {qualified_name, description, input_schema, metadata}`
 
 Returns the long description, full input schema (= the underlying
 tool's `parameters`), and metadata (`target_tool_name`, `category`,
 `purity`) for one action. On an unknown name, returns a structured
 error response per §D12 (see below).
+
+Under the weak-model landing design, `describe_action` is **off the common
+critical path** — `list_actions` already returns descriptions + schemas for
+the narrowed category. It is retained for edge cases only: a single-name
+lookup, or a category large enough that inlining every schema into the list
+result would be wasteful. See
+[Weak-model discovery + selection reliability](#weak-model-discovery-selection-reliability).
 
 ### `invoke_action(action_name, args) → <target's result>`
 
@@ -252,6 +265,116 @@ warm cache).
 A Tier 2 invariant pins the section's bullet list to the `CATEGORIES`
 tuple so future additions to the master taxonomy cannot drift from the
 SP without the test failing.
+
+## Weak-model discovery + selection reliability
+
+The discover→invoke loop is only as good as the LLM's willingness to *use*
+it. Strong models (`router_model: strong`) discover and select actions
+flexibly from the category list and need no extra scaffolding. Weak / small
+models (`router_model: light`) exhibit two reliable failure modes that the
+catalog addresses **structurally**, so weak-model support never costs
+strong-model flexibility:
+
+1. **Satisficing** — the model invokes a visible hot-list action
+   (`file__write`) instead of discovering a better-fit one (`file__edit`),
+   because the hot action is "good enough".
+2. **Discovery-skip** — the model does not proactively call `list_actions`;
+   it guesses an action name from training priors, often malformed
+   (`file.write`, `file__read_file`).
+
+*Status: the no-names system prompt and the `file__edit` cross-reference are
+shipped; `list_actions` returning schemas and the tier-gated mandates are the
+agreed landing design (implementation in progress). Every lever below is
+patch- and live-verified against `gemini-2.5-flash-lite` at reliable N.*
+
+### No-names catalog
+
+Action names appear in **exactly one place**: the `list_actions` result.
+They are absent from the system prompt (which describes *categories* by
+capability, never action names) and from every other tool's description.
+This serves two ends:
+
+- **Scalability** — the LLM-visible tool list and system prompt stay O(1)
+  in the number of actions; a 200-action surface costs the same prompt as a
+  20-action one.
+- **Forced discovery of genuinely-unknown actions** — when a name exists
+  nowhere the model could have memorised it, the only way to obtain it is to
+  call `list_actions`. For genuinely-unknown actions this fires reliably
+  (observed 16/16 `list_actions` for an obscure, non-guessable skill).
+
+  Caveat — name-hiding forces discovery only for *unknown* actions. For
+  training-**known** concepts (`file__read` / `file__write`) the weak model
+  recalls the concept and emits a malformed approximation rather than
+  discovering the exact name. Known-action *selection* is handled by the
+  mechanical mandate below, not by name-hiding.
+
+### `list_actions` returns name + description + schema
+
+When `list_actions(category=[…])` narrows to a bounded set, each item carries
+the **full triple** — `qualified_name`, `description`, and `input_schema`:
+
+- **`description`** is what lets the model *select* the right action; a model
+  cannot pick an action it cannot read (the conventional role of a tool
+  description).
+- **`input_schema`** is what lets the model *invoke* it with correct args.
+
+Because the narrowed result carries both, the common flow is **two steps —
+`list_actions` → `invoke_action`** — with no intervening `describe_action`.
+Compactness is preserved by *category-narrowing* (schemas come only for the
+category you asked about), not by omitting schemas globally.
+
+Verified (schema → invocation axis): injecting schemas into the
+`list_actions` result drove reactive `describe_action` calls 14→0 and
+argument-correctness 0→12 (of 20) — with schemas in the list, the weak model
+invokes correctly without a separate describe round-trip. The description →
+selection axis is the conventional tool-description role (a model cannot
+select an action it cannot read), so the description is carried on
+design grounds rather than as a separately measured lever.
+
+### Mechanical mandate (tier-gated)
+
+Weak models **obey mechanical, unconditional procedural mandates** but
+**ignore reasoning-based recommendations**. A cross-reference that *explains*
+("for a partial edit, prefer `file__edit`") is ignored (0/20 followed it); an
+unconditional mandate ("edits MUST use `file__edit`, NOT `file__write`") is
+followed (edit 3 / write 1).
+
+The router therefore gates a set of mechanical system-prompt mandates on the
+model tier (`router_model: light` → on; `strong` → off):
+
+- **`list_actions`-first** — the first tool call MUST be `list_actions`
+  before reading, writing, or editing anything.
+- **`file__edit`-MUST** — partial / surgical edits must use `file__edit`,
+  not `file__write`.
+
+Two properties make the mandate land:
+
+1. **Explicit-action-enumeration wording.** Naming the concrete operations
+   the mandate covers ("before reading, writing, or editing anything")
+   produces 25-55% compliance; a generic phrasing ("before any other tool")
+   produces 0-10%.
+2. **Constraint reinforcement.** Repeating the mandate ~3× across the system
+   prompt lifts compliance from ~36% to **~75-85%** (matched-pair verified,
+   no distribution overlap). Repetition counters the goal-displacement that
+   makes small models drop an instruction mid-reasoning.
+
+### The ceiling
+
+Explicit-enumeration wording + 3× reinforcement reaches **~75-85% weak-model
+compliance** on the `list_actions`-first mandate. This is the practical
+prompting ceiling: the residual ~15-25% is alignment fragility that prompting
+alone does not close — narrowing it further would need fine-tuning, which is
+out of scope. Strong models run with the mandates off and are unaffected.
+
+### Unifying principle
+
+> A weak model **self-discovers genuinely-unknown** actions and **obeys
+> mechanical mandates**; it **recalls-and-flails on training-known** names and
+> **ignores reasoning-based recommendations**. The catalog therefore hides
+> names (forcing unknown-discovery), puts descriptions + schemas on the
+> narrowed list (removing the describe round-trip), and gates mechanical
+> mandates on the weak tier (fixing known-action selection) — while leaving
+> strong models unconstrained.
 
 ## Default-on (PR-3b-iv)
 


### PR DESCRIPTION
**[lead-coder]** — Owner explicitly asked to document the finalized weak/strong action-discovery + selection design so it is not lost before implementation ("設計フィックスしたらドキュメント化しておいてね"). This captures it in the canonical universal-catalog concept doc (en + ja).

## What this documents

A new **`## Weak-model discovery + selection reliability`** section + forward-notes on the `list_actions` / `describe_action` wrapper descriptions:

1. **`list_actions` returns name + description + schema** for a narrowed category → `describe_action` is off the common critical path (retained for edge cases: single-name lookup / very large category). Common flow becomes `list_actions` → `invoke_action`. Compactness preserved by category-narrowing, not by omitting schemas globally.
2. **No-names catalog** — action names appear in exactly one place (`list_actions` output): scalability (O(1) prompt) + forced discovery of genuinely-unknown actions. Caveat: name-hiding forces discovery only for *unknown* actions; *known*-action selection is handled by the mechanical mandate.
3. **Tier-gated mechanical mandate** (`router_model: light` → on / `strong` → off): `list_actions`-first + `file__edit`-MUST. Two properties make it land — explicit-action-enumeration wording (25-55% vs 0-10% generic) + 3× constraint-reinforcement (~36% → ~75-85%).
4. **Ceiling** (~75-85% = prompting ceiling; residual is alignment fragility, fine-tuning out of scope) + **unifying principle** (weak self-discovers unknown / obeys mechanical mandates / recalls-flails on known names / ignores reasoning).

## Provenance (honest split)

- **Patch- + live-verified** against `gemini-2.5-flash-lite` at reliable N: schema→invocation (describe 14→0, args 0→12), no-names unknown-discovery (16/16), cross-ref reasoning vs mechanical mandate (0/20 vs edit3/write1), constraint-reinforcement (W1 1× 25-55% vs W1 3× ~75-85%, matched-pair no-overlap; lead independently dual-verified 17/20).
- **Conventional design grounds** (not separately measured): description→selection (a model cannot select an action it cannot read).

## Status framing

The section marks which parts are shipped (no-names SP, `file__edit` cross-ref) vs landing design (list-returns-schema, tier-gated mandates — impl in progress). Markers come out as implementation lands.

## Test plan

- [x] `mkdocs build` — my new section's self-anchor links resolve cleanly (fixed `+`-in-heading slug: `weak-model-discovery-selection-reliability`, single hyphen).
- [x] Change scope confined to `universal-catalog.{md,ja.md}` (verified `git diff --name-only`).
- [x] (skipped — pre-existing) `mkdocs build --strict` aborts on one unrelated pre-existing warning (`sandbox-vs-permission.md` → `permission-model.md` not found among docs files); not touched by this PR. Numerous pre-existing cross-language anchor INFO lines likewise unrelated.
- [x] No `PR#`/`#issue` history refs inline (no-history-refs doc gate); matches doc's existing §D-tag style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)