### PR TITLE
feat(187): Stage B — list_actions returns name+description+schema (selection-grade)

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -826,6 +826,24 @@ async def _handle_list_actions(
     total = len(items)
     page = items[offset:offset + limit]
 
+    # Stage B (#187): on a NARROWED (category-filtered) browse, enrich each page
+    # item with the SAME full description + input_schema describe_action returns
+    # — via the shared _describe_one, so list ≡ describe BY CONSTRUCTION — giving
+    # the LLM selection-grade detail (name + description + schema) without a
+    # separate describe_action round-trip (which weak models rarely make). This
+    # inherits the schema-blind-hallucination protection the removed ARS block
+    # used to provide. Bounded: only the narrowed view (valid_filter non-empty)
+    # is enriched and the page is limit-capped, so the unfiltered alphabetical
+    # browse stays compact for breadth scanning.
+    if valid_filter:
+        from reyn.tools import get_default_registry
+        _registry = get_default_registry()
+        enriched: list[dict[str, Any]] = []
+        for it in page:
+            one = _describe_one(it["qualified_name"], ctx, _registry)
+            enriched.append({**it, **one} if one is not None else it)
+        page = enriched
+
     response: dict[str, Any] = {"items": page, "total": total}
     if _should_inject_hidden_state_hint(ctx.router_state):
         response["hint"] = _HIDDEN_STATE_HINT
@@ -922,6 +940,50 @@ async def _handle_search_actions(
     return {"items": results, "total": len(results)}
 
 
+def _describe_one(
+    qualified_name: str, ctx: ToolContext, registry: Any,
+) -> "dict[str, Any] | None":
+    """Resolve ``{description, input_schema}`` for one qualified action.
+
+    The shared selection-grade core of ``describe_action`` AND ``list_actions``'
+    enriched items, so the two return the SAME description + schema for a given
+    action BY CONSTRUCTION (list ≡ describe). Returns ``None`` when the name
+    doesn't resolve or has no registry target (the caller skips / errors as it
+    sees fit). Intentionally returns ONLY description + input_schema — the
+    describe_action metadata block and the B41 post-call directive stay in
+    ``describe_action`` and are not carried into ``list_actions`` items.
+
+    Per-resource description/schema (``_resource_description`` /
+    ``_resource_input_schema``) win over the dispatcher target's generic
+    fields; the target ``.description`` / ``.parameters`` are the fallback for
+    operation-category actions (file__edit, exec__sandboxed_exec, …).
+    """
+    from reyn.tools.universal_dispatch import (
+        UnknownActionError,
+        resolve_describe_action,
+    )
+
+    try:
+        resolved = resolve_describe_action(qualified_name)
+    except UnknownActionError:
+        return None
+    target = registry.lookup(resolved.target_tool_name)
+    if target is None:
+        return None
+
+    resource_schema = _resource_input_schema(qualified_name, ctx, registry)
+    input_schema = (
+        resource_schema if resource_schema is not None
+        else dict(target.parameters)
+    )
+    resource_desc = _resource_description(qualified_name, ctx, registry)
+    description = (
+        resource_desc if resource_desc is not None
+        else target.description
+    )
+    return {"description": description, "input_schema": input_schema}
+
+
 async def _handle_describe_action(
     args: Mapping[str, Any], ctx: ToolContext,
 ) -> ToolResult:
@@ -971,34 +1033,19 @@ async def _handle_describe_action(
             f"this in production, the target may be a future-PR op)",
         ))
 
-    # D2-full: prefer the per-resource schema over the dispatcher schema.
-    # Falls back to ``target.parameters`` for operation categories and any
-    # resource category we couldn't resolve from router_state.
-    resource_schema = _resource_input_schema(qualified_name, ctx, registry)
-    input_schema = (
-        resource_schema if resource_schema is not None
-        else dict(target.parameters)
-    )
-
-    # B42-NF-W7-1: prefer the per-resource description over the dispatcher's
-    # generic description (= ``invoke_skill`` / ``delegate_to_agent`` /
-    # ``call_mcp_tool`` instruction text). Without this, describe_action on
-    # a skill__/agent.peer__/mcp.tool__ resource returns the dispatcher's
-    # "how to invoke a skill" wording instead of the resource's actual
-    # description — the LLM has nothing meaningful to relay and empty-stops
-    # on pronoun-followups like "tell me more about the simplest one"
-    # (N=10 trace replay: 9/10 empty → 0/10 empty after substituting the
-    # actual skill.md description).
-    resource_desc = _resource_description(qualified_name, ctx, registry)
-    description = (
-        resource_desc if resource_desc is not None
-        else target.description
-    )
+    # D2-full / B42-NF-W7-1: description + input_schema come from the shared
+    # _describe_one core (per-resource fields win over the dispatcher target's
+    # generic ones, falling back to target.parameters/.description for
+    # operation categories), so describe_action and list_actions' enriched
+    # items agree BY CONSTRUCTION. ``one`` is non-None here — the resolve +
+    # registry lookup above already succeeded, so _describe_one's same
+    # resolution does too.
+    one = _describe_one(qualified_name, ctx, registry) or {}
 
     return {
         "qualified_name": qualified_name,
-        "description": description,
-        "input_schema": input_schema,
+        "description": one.get("description"),
+        "input_schema": one.get("input_schema"),
         "metadata": {
             "target_tool_name": resolved.target_tool_name,
             "category": target.category,

--- a/tests/test_list_actions_returns_schema_187.py
+++ b/tests/test_list_actions_returns_schema_187.py
@@ -1,0 +1,129 @@
+"""Tier 1: #187 Stage B — list_actions returns selection-grade items.
+
+When the browse is narrowed to a category, each list_actions item carries the
+full ``description`` + ``input_schema`` that describe_action returns (name +
+description + schema), so the model can SELECT an action without a separate
+describe_action round-trip — which weak models rarely make. This inherits the
+schema-blind-hallucination protection the removed ARS block provided. The
+unfiltered alphabetical browse stays compact (breadth scan). The shared
+``_describe_one`` core guarantees ``list ≡ describe`` BY CONSTRUCTION.
+
+Real ToolContext + RouterCallerState with a stub host; no mocks of collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.tools import get_default_registry
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import (
+    _describe_one,
+    _handle_describe_action,
+    _handle_list_actions,
+)
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeHost:
+    """Minimal host: list_available_skills returns the D2-full catalogue shape
+    (input_schema per entry) so resource-category enrichment resolves."""
+
+    def __init__(self, skills):
+        self._skills = skills
+
+    def list_available_skills(self):
+        return list(self._skills)
+
+
+_SKILL = {
+    "name": "code_review",
+    "description": "Review a code diff and report issues.",
+    "input_fields": ["diff", "focus"],
+    "input_schema": {
+        "type": "object",
+        "properties": {"diff": {"type": "string"}, "focus": {"type": "string"}},
+        "required": ["diff"],
+    },
+    "input_wrapped": True,
+}
+
+
+def _ctx(skills=None) -> ToolContext:
+    sk = skills or []
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        # available_skills feeds list_actions enumeration; host.list_available_skills
+        # feeds describe_action / _describe_one resolution — set both so list ≡ describe.
+        router_state=RouterCallerState(
+            host=_FakeHost(sk), available_skills=sk, mcp_servers=None,
+        ),
+    )
+
+
+def _list(ctx: ToolContext, **args) -> dict:
+    return asyncio.run(_handle_list_actions(args, ctx))
+
+
+def _describe(ctx: ToolContext, name: str) -> dict:
+    return asyncio.run(_handle_describe_action({"action_name": name}, ctx))
+
+
+def test_narrowed_list_item_carries_description_and_schema():
+    """Tier 1: a category-narrowed list_actions item carries full description + input_schema."""
+    ctx = _ctx()
+    items = _list(ctx, category=["file"])["items"]
+    fe = next(i for i in items if i["qualified_name"] == "file__edit")
+    assert fe.get("description"), "narrowed item must carry a full description"
+    assert fe.get("input_schema", {}).get("properties"), "narrowed item must carry input_schema"
+
+
+def test_static_op_and_resource_both_enriched():
+    """Tier 1: both a static op (file__edit) and a resource (skill__X) get input_schema."""
+    ctx = _ctx(skills=[_SKILL])
+    file_items = _list(ctx, category=["file"])["items"]
+    fe = next(i for i in file_items if i["qualified_name"] == "file__edit")
+    assert fe["input_schema"]["properties"], "static op must carry its parameters schema"
+
+    skill_items = _list(ctx, category=["skill"])["items"]
+    sk = next(i for i in skill_items if i["qualified_name"] == "skill__code_review")
+    assert set(sk["input_schema"]["properties"]) == {"diff", "focus"}, (
+        "resource (skill) must carry its per-resource schema, not the dispatcher envelope"
+    )
+
+
+def test_unfiltered_browse_stays_compact():
+    """Tier 1: the unfiltered (all-category) browse omits input_schema — compact breadth scan."""
+    ctx = _ctx()
+    items = _list(ctx)["items"]
+    assert items, "expected a non-empty browse page"
+    assert all("input_schema" not in i for i in items), (
+        "the unfiltered browse must stay compact (no per-item schema)"
+    )
+
+
+def test_list_equals_describe_by_construction():
+    """Tier 1: ★load-bearing invariant — a narrowed list item's description +
+    input_schema EQUAL describe_action's for the same action (shared _describe_one).
+    Guards against future drift if either path bypasses the helper."""
+    ctx = _ctx(skills=[_SKILL])
+    for cat, name in [("file", "file__edit"), ("skill", "skill__code_review")]:
+        item = next(
+            i for i in _list(ctx, category=[cat])["items"]
+            if i["qualified_name"] == name
+        )
+        d = _describe(ctx, name)
+        assert item["description"] == d["description"], f"{name}: description must match describe_action"
+        assert item["input_schema"] == d["input_schema"], f"{name}: input_schema must match describe_action"
+
+
+def test_describe_one_returns_none_for_unresolvable():
+    """Tier 1: _describe_one returns None for an unresolvable name — so list_actions
+    skips enrichment for such an item gracefully (keeps short_description, no crash)."""
+    assert _describe_one("bogus_category__nope", _ctx(), get_default_registry()) is None


### PR DESCRIPTION
**[e2e-coder]** — #187 weak/strong action-discovery, **Stage B of 3** (B→A→C). Owner-GO'd; design patch/live-verified (universal-catalog.md, #1421). Flow-trace-first seam map approved by lead. sandbox_2 reviews.

## Why
The Set-A capstone showed weak models under-explore the discoverable catalog and don't make the `describe_action` round-trip (describe 1/10 in the weak-verify). Stage B makes `list_actions` itself **selection-grade**: when the browse is narrowed to a category, each item carries the full `description` + `input_schema` `describe_action` returns (name + description + schema). This:
- moves the schema onto the path the model already uses (no separate describe round-trip), and
- **inherits the schema-blind-hallucination protection the ARS block provided** — which is what makes Stage A (the ARS removal, held branch 45428f82) safe to land.

## Change (`tools/universal_catalog.py`)
- `_describe_one(qualified_name, ctx, registry) -> {description, input_schema} | None` — the **shared selection-grade core** (per-resource fields win over the dispatcher target's generic ones, falling back to `target.parameters`/`.description` for operation categories like file__edit/exec). Returns `None` for unresolvable names.
- `_handle_describe_action` refactored to use `_describe_one` (DRY).
- `_handle_list_actions` enriches each page item via `_describe_one` **only when category-narrowed** (`valid_filter` non-empty) with graceful skip on `None`. **Bounded**: narrowed view + limit-capped page; the unfiltered alphabetical browse stays compact for breadth scanning.

## Test plan (Tier 1 contract, real ToolContext, no mocks)
- [x] narrowed item carries full `description` + `input_schema`
- [x] static op (file__edit) AND resource (skill__X) both enriched
- [x] unfiltered browse stays compact (no per-item schema)
- [x] `_describe_one` returns `None` for an unresolvable name (→ graceful skip)
- [x] ★**`list ≡ describe` by construction** — narrowed item's description + input_schema EQUAL `describe_action`'s for the same action (shared `_describe_one`); guards future helper-bypass drift
- [x] `ruff check` + `test_tier_audit.py --strict` → clean / 0 errors
- [x] full `pytest -q` → 6887 passed (only the 2 known local-env quirks fail: swebench-installed, web_fetch extraction-lib)

Replay note: the change is runtime-response-only (not the `tools[]` request key), so replay fixtures are unaffected (259 catalog/describe/list/replay cluster tests pass).

## Next
Stage A (rebase 45428f82 onto B → ARS removal, now safe because B delivers schema) → Stage C (tier-gated mechanical SP mandate, parameterized light=ON/strong=OFF).

Refs #187
🤖 Generated with [Claude Code](https://claude.com/claude-code)