### PR TITLE
feat(187): uniform always-on "resume" empty-stop retry at every RouterLoop site

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -48,7 +48,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from reyn.chat.router_loop import RouterLoop, RouterLoopHost
+from reyn.chat.router_loop import (
+    EMPTY_STOP_RETRY_DIRECTIVE,
+    RouterLoop,
+    RouterLoopHost,
+)
 from reyn.llm.pricing import TokenUsage
 
 if TYPE_CHECKING:
@@ -110,23 +114,11 @@ _PLAN_STEP_FORCE_CLOSE_CONTINUE_TEMPLATE = (
     "--- Consolidation of work so far ---\n{consolidation}"
 )
 
-# B42-NF-W6-1: continuation directive passed to RouterLoop's empty-stop
-# retry path. RouterLoop only consults this when the
-# ``REYN_EMPTY_STOP_RETRY=1`` env var is set, so the production code wires
-# the directive in unconditionally but no runtime behaviour changes
-# unless the operator opts in. The wording follows the existing plan-step
-# system prompt voice ("report what this step found") and adds an
-# explicit imperative trailer that trace-patch-replay confirmed flips
-# the post-tool empty-stop attractor (= 0/10 → 10/10 narration recovery
-# on the W6-S1 plan step). Cross-provider issue (= documented for Gemini,
-# Claude, GPT) — see Anthropic handling-stop-reasons docs + Hermes-agent
-# #9400 for prior art.
-_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE = (
-    "Now write your step report. Summarise the relevant content from the "
-    "tool result above in 2-5 paragraphs, citing concrete details (file "
-    "paths, header names, function names, line numbers, exact values). "
-    "Do not call another tool. Write the report text now."
-)
+# B42-NF-W6-1 / #187: the plan-step empty-stop continuation directive is now the
+# SHARED uniform ``EMPTY_STOP_RETRY_DIRECTIVE`` ("resume") imported from
+# router_loop.py (see its definition for the owner no-per-site-differentiation
+# decision). The old plan-step "write your step report / do not call another
+# tool" directive was retired (unevidenced differentiation + anti-invoke framing).
 
 
 # B51 NF-W6-3 fix: directive template for the plan_invalid self-correction
@@ -1135,10 +1127,11 @@ async def execute_plan(
                 # 3 plan invocations because steps re-emitted plan).
                 exclude_tools={"plan"},
                 memo_provider=memo_provider,
-                # B42-NF-W6-1: directive used when ``REYN_EMPTY_STOP_RETRY=1``
-                # is set (= operator opt-in). Production wiring lands in the
-                # codebase but no default behaviour change.
-                empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
+                # #187: empty-stop retry — shared uniform "resume" directive +
+                # always-on (owner decision; env-gate retired, no per-site
+                # differentiation).
+                empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+                empty_stop_retry_auto=True,
             )
             # FP-0031-C: auto-retry on transient step failures.
             # FP-0031-D: when retry budget is exhausted, ask the user via
@@ -1211,7 +1204,10 @@ async def execute_plan(
                             system_prompt_override=sys_prompt,
                             exclude_tools={"plan"},
                             memo_provider=memo_provider,
-                            empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
+                            # #187: empty-stop retry — shared uniform "resume"
+                            # directive + always-on (owner decision).
+                            empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+                            empty_stop_retry_auto=True,
                         )
                         continue  # re-enter — does NOT consume the FP-0031 attempt budget
                     step_succeeded = True
@@ -1262,7 +1258,10 @@ async def execute_plan(
                             memo_provider=memo_provider,
                             # B42-NF-W6-1: same directive as the initial
                             # sub_loop construction above.
-                            empty_stop_retry_directive=_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE,
+                            # #187: empty-stop retry — shared uniform "resume"
+                            # directive + always-on (owner decision).
+                            empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+                            empty_stop_retry_auto=True,
                         )
                         continue
                     # FP-0031-D: retry budget exhausted — ask user for extension.

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -141,6 +141,18 @@ _SPAWN_ACK_TOOL_DIRECTIVE = (
 )
 
 
+# #187: the SINGLE empty-stop retry continuation directive, shared UNIFORMLY by
+# every RouterLoop construction site (chat / plan-step / agent op-loop). owner
+# decision (2026-06-07): do NOT build per-site/per-tier directive differentiation
+# without evidence — a content-neutral "resume" re-enters the loop and lets the
+# model continue (tool-call OR reply) on its own. Real-task: a content-less empty
+# stop is 67% premature; "resume" recovers the next action (invoke 11/12). The
+# previous per-site directives (chat "write your reply" / plan "step report") were
+# unevidenced differentiation — and the chat one's "Do not call another tool"
+# was itself anti-invoke. Iterate per-site ONLY if a measured problem appears.
+EMPTY_STOP_RETRY_DIRECTIVE = "resume"
+
+
 def _strip_frontmatter(content: str) -> str:
     """Remove a leading YAML frontmatter block (``---\\n...\\n---\\n``) from
     a memory file's text and return the body alone.
@@ -1254,6 +1266,7 @@ class RouterLoop:
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
+        empty_stop_retry_auto: bool = False,  # #187: agent-path always-on (no env opt-in)
         plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
     ):
@@ -1310,6 +1323,16 @@ class RouterLoop:
         # process — the directive plumbing lands in the codebase but no
         # default runtime behaviour change.
         self._empty_stop_retry_directive = empty_stop_retry_directive
+        # #187: agent-path (phase_executor) opt-in that enables the empty-stop
+        # retry WITHOUT requiring the ``REYN_EMPTY_STOP_RETRY`` env var. The
+        # agent op-loop must keep invoking tools to make progress, so a
+        # post-tool empty stop is a dead-end there (real-task: 67% empty-stop)
+        # — unlike the chat router, where "observe + surface" is acceptable.
+        # The chat / plan-executor construction sites leave this False so their
+        # behaviour stays env-gated (no regression). The gate below fires when
+        # this flag OR the env var is set. always-on-agent vs env-gated is an
+        # owner balance knob switchable by the phase_executor call-site value.
+        self._empty_stop_retry_auto = empty_stop_retry_auto
         # B51 NF-W6-3: plan_invalid self-correction retry cap. When the
         # ``plan`` tool returns ``{status:error, error:{kind:
         # plan_invalid}}`` (= the LLM's ``steps_json`` failed JSON
@@ -2407,7 +2430,10 @@ class RouterLoop:
                 if (
                     self._empty_stop_retry_directive
                     and _empty_stop_retries < 1
-                    and os.environ.get("REYN_EMPTY_STOP_RETRY") == "1"
+                    and (
+                        self._empty_stop_retry_auto
+                        or os.environ.get("REYN_EMPTY_STOP_RETRY") == "1"
+                    )
                 ):
                     _empty_stop_retries += 1
                     messages.append({

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1266,7 +1266,7 @@ class RouterLoop:
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
-        empty_stop_retry_auto: bool = False,  # #187: agent-path always-on (no env opt-in)
+        empty_stop_retry_auto: bool = False,  # #187: always-on (no env opt-in); all prod sites pass True
         plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
     ):
@@ -1323,15 +1323,17 @@ class RouterLoop:
         # process — the directive plumbing lands in the codebase but no
         # default runtime behaviour change.
         self._empty_stop_retry_directive = empty_stop_retry_directive
-        # #187: agent-path (phase_executor) opt-in that enables the empty-stop
-        # retry WITHOUT requiring the ``REYN_EMPTY_STOP_RETRY`` env var. The
-        # agent op-loop must keep invoking tools to make progress, so a
-        # post-tool empty stop is a dead-end there (real-task: 67% empty-stop)
-        # — unlike the chat router, where "observe + surface" is acceptable.
-        # The chat / plan-executor construction sites leave this False so their
-        # behaviour stays env-gated (no regression). The gate below fires when
-        # this flag OR the env var is set. always-on-agent vs env-gated is an
-        # owner balance knob switchable by the phase_executor call-site value.
+        # #187: enable the empty-stop retry WITHOUT requiring the
+        # ``REYN_EMPTY_STOP_RETRY`` env var. owner decision (2026-06-07):
+        # UNIFORM always-on at every production RouterLoop site (chat /
+        # plan-step / agent op-loop all pass ``True``) — the env opt-in is
+        # retired. A content-less empty stop is a dead-end the loop must
+        # recover from (real-task: 67% premature). The gate below fires when
+        # this flag OR the env var is set. The default stays ``False`` only so
+        # direct/test construction can exercise the env-gated path; it is NOT a
+        # per-site agent-on/chat-off knob (that site-appropriate design was
+        # retracted). If a measured problem later motivates per-site
+        # divergence, this flag is the switch — but uniform-first by default.
         self._empty_stop_retry_auto = empty_stop_retry_auto
         # B51 NF-W6-3: plan_invalid self-correction retry cap. When the
         # ``plan`` tool returns ``{status:error, error:{kind:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -242,29 +242,12 @@ class RouterCapExceeded(Exception):
 DEFAULT_CHAT_CHANNEL_ID = "tui"
 
 
-# B43-NF-W6-1: continuation directive injected when the top-level chat
-# router LLM produces an empty stop after a tool round (= same attractor
-# as the plan-step case PR #265 closed at the planner.py sub_loop
-# construction sites). The chat router runs the full user-facing
-# conversation, so the directive references "the user's question" rather
-# than the plan-step's "step report". RouterLoop reads
-# ``REYN_EMPTY_STOP_RETRY=1`` from the environment at runtime; this
-# constant is plumbed in unconditionally but only kicks in when the env
-# var is set (= same opt-in mechanic as PR #265).
-#
-# Trace-patch-replay verified (= B43 W6-S2 top-level router post-plan
-# narration call): baseline N=10 = 6/10 EMPTY_STOP (60% trigger rate),
-# patched N=10 = 0/10 empty + 10/10 substantive (169-1485 chars).
-# Cross-provider documented attractor — Anthropic ``handling-stop-
-# reasons`` docs explicitly recommend continuation prompts "as a last
-# resort". Lead-coder review heuristic applied: this wires the third
-# (and last) RouterLoop construction site — planner.py has the other
-# two for plan-step sub_loops.
-_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE = (
-    "Now write your reply to the user. Summarise the relevant content "
-    "from the tool result above and address the user's question. Do "
-    "not call another tool. Write the reply text now."
-)
+# B43-NF-W6-1 / #187: the chat router's empty-stop continuation directive is
+# now the SHARED uniform ``EMPTY_STOP_RETRY_DIRECTIVE`` ("resume") from
+# router_loop.py — see its definition for the owner decision (no per-site
+# differentiation). Imported function-locally at the construction site below
+# (session→router_loop is a function-local import to avoid the module-level
+# cycle: router_loop imports from session).
 
 
 @dataclass(frozen=True)
@@ -5539,7 +5522,7 @@ class ChatSession:
         """
         # FP-0005: now async (consults safety.on_limit on hit).
         await self._check_and_increment_router_cap(user_text)
-        from reyn.chat.router_loop import RouterLoop
+        from reyn.chat.router_loop import EMPTY_STOP_RETRY_DIRECTIVE, RouterLoop
         # B51 NF-W6-3: plan_invalid self-correction cap, sourced from
         # safety.loop.plan_invalid_retries (default 1). When set to 0
         # the retry is disabled and the LLM sees the plain tool error.
@@ -5555,10 +5538,15 @@ class ChatSession:
             # #187: hide excluded tools (e.g. web for faithful SWE-eval) from the
             # MAIN agent loop's LLM-visible catalog (same hook the sub-loops use).
             exclude_tools=self._exclude_tools,
-            # B43-NF-W6-1: chat router empty-stop retry. Same opt-in
-            # mechanic as PR #265's plan-step wiring — directive plumbed
-            # unconditionally, runtime gated by ``REYN_EMPTY_STOP_RETRY=1``.
-            empty_stop_retry_directive=_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE,
+            # B43-NF-W6-1 / #187: chat router empty-stop retry. owner decision —
+            # always-on (env-gate retired) + the SHARED uniform "resume"
+            # directive (no per-site differentiation). The old chat-specific
+            # "write your reply / do not call another tool" directive was
+            # retired: it was unevidenced differentiation and its anti-invoke
+            # framing was itself suspect. "resume" lets the model continue
+            # (reply OR tool-call) on its own.
+            empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+            empty_stop_retry_auto=True,
             plan_invalid_retries=_plan_invalid_retries_cap,
         )
         # PR-N3: pre-frame context-overflow guard.

--- a/src/reyn/kernel/phase_executor.py
+++ b/src/reyn/kernel/phase_executor.py
@@ -524,7 +524,7 @@ class PhaseExecutor:
         """
         import json as _json
 
-        from reyn.chat.router_loop import RouterLoop
+        from reyn.chat.router_loop import EMPTY_STOP_RETRY_DIRECTIVE, RouterLoop
         from reyn.kernel.phase_router_host import PhaseRouterLoopHost
         from reyn.services.turn_budget import try_build_default_turn_budget_engine
 
@@ -632,6 +632,16 @@ class PhaseExecutor:
             llm_caller=self._llm_caller.make_phase_llm_caller(
                 phase=phase, state=state,
             ),
+            # #187: wire the agent-path empty-stop retry. Without this the
+            # retry mechanism (router_loop.py) was unreachable on the agent
+            # op-loop — the directive defaulted to None here, so a post-tool
+            # empty stop dead-ended (real-task: 67% empty-stop). The shared
+            # uniform "resume" directive + ``auto=True`` make it always-on for
+            # the agent path (owner decision), firing without the
+            # ``REYN_EMPTY_STOP_RETRY`` env opt-in. Same directive + policy as
+            # the chat / plan-step sites (no per-site differentiation).
+            empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+            empty_stop_retry_auto=True,
         )
         # Drive the SHARED op-execution loop. Op results thread into ``messages``
         # as native tool-role turns; the model signals end_turn by emitting no

--- a/tests/test_chat_router_empty_stop_directive_wired.py
+++ b/tests/test_chat_router_empty_stop_directive_wired.py
@@ -1,46 +1,36 @@
-"""Tier 2: ChatSession wires the empty-stop retry directive into the
-top-level chat router's RouterLoop (B43-NF-W6-1 fix).
+"""Tier 2: ChatSession wires the empty-stop retry into the chat router's
+RouterLoop — now the SHARED uniform ``"resume"`` directive, always-on (#187).
 
 Pinned invariants:
 
-- ``_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE`` exists in ``reyn.chat.session``
-  as a non-empty string referencing "user" and "tool result" (= the chat
-  router's narration-after-tool contract).
-- It is **distinct** from the plan-step directive in
-  ``reyn.chat.planner._PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE`` (= plan-step
-  says "step report"; chat router says "reply to the user"). The wording
-  divergence matches the per-call-site voice and prevents accidental
-  reuse of the plan-step text in the user-facing path.
 - ``ChatSession._handle_user_message`` constructs ``RouterLoop`` with
-  ``empty_stop_retry_directive=`` set to the chat-router constant — pinned
-  via a real ``CapturingRouterLoop`` subclass injected through
-  ``pytest.monkeypatch`` (= module-attribute setup, not fake-collaborator
-  mocking per testing.ja.md).
+  ``empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE`` (the single shared
+  "resume" directive — NOT a chat-specific string) AND
+  ``empty_stop_retry_auto=True`` (always-on; the ``REYN_EMPTY_STOP_RETRY`` env
+  opt-in is retired). Pinned via a real ``CapturingRouterLoop`` subclass
+  injected through ``pytest.monkeypatch`` (= module-attribute setup, not
+  fake-collaborator mocking per testing.ja.md).
 
-References:
-- PR #265 (merged): plan-step empty-stop retry — same opt-in mechanic on
-  ``REYN_EMPTY_STOP_RETRY=1``, wired only on planner.py:868 + planner.py:955.
-- B43-NF-W6-1: trace-patch-replay on the W6-S2 top-level router empty stop
-  confirmed structural (= baseline 6/10 empty → patched 0/10 empty).
-- Lead-coder review heuristic "new mechanism must cover every entry path":
-  3 RouterLoop construction sites total. This test pins the third
-  (session.py) is wired identically to the planner sites already
-  pinned by ``test_router_loop_post_tool_user_directive`` /
-  ``test_router_loop_empty_stop_retry``.
+History (#187 owner decision, 2026-06-07): the previous chat-specific directive
+(B43-NF-W6-1: "Now write your reply to the user … Do not call another tool.")
+was RETIRED. It was unevidenced per-site differentiation, and its anti-invoke
+framing ("do not call another tool") was itself suspect — chat models also
+tool-call. All sites (chat / plan-step / agent op-loop) now use the single
+content-neutral ``EMPTY_STOP_RETRY_DIRECTIVE`` = "resume". The cross-site
+uniform-wiring invariant is pinned in
+``test_empty_stop_retry_uniform_187``; this file pins the chat site's wiring
+behaviourally (driving the real ChatSession construction).
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from reyn.chat import router_loop as rl
-from reyn.chat.session import (
-    _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE,
-    ChatSession,
-)
+from reyn.chat.router_loop import EMPTY_STOP_RETRY_DIRECTIVE
+from reyn.chat.session import ChatSession
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 
@@ -74,83 +64,37 @@ def _make_session(tmp_path: Path) -> ChatSession:
 
 
 # ---------------------------------------------------------------------------
-# Constant shape
-# ---------------------------------------------------------------------------
-
-
-def test_chat_router_directive_is_non_empty_string():
-    """Tier 2: the directive must be a non-empty string — empty would defeat
-    the retry path's purpose (= injecting nothing is equivalent to no
-    retry)."""
-    assert isinstance(_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE, str)
-    assert _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE.strip()
-
-
-def test_chat_router_directive_references_user_and_tool_result():
-    """Tier 2: directive content references the chat-router contract —
-    'user' (= the actual user, not the planner) and 'tool result' (= the
-    prior tool response the LLM must narrate)."""
-    directive = _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE.lower()
-    assert "user" in directive
-    assert "tool result" in directive
-
-
-def test_chat_router_directive_distinct_from_plan_step_directive():
-    """Tier 2: must not accidentally reuse the plan-step wording. The
-    plan-step directive says "step report"; the chat router says "reply"."""
-    from reyn.chat.planner import _PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE
-    assert (
-        _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE
-        != _PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE
-    )
-    # Concrete voice markers
-    assert "step report" not in _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE.lower()
-    assert "reply" in _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE.lower()
-
-
-# ---------------------------------------------------------------------------
-# Wiring pin — ChatSession constructs RouterLoop with the directive set
+# Wiring pin — ChatSession constructs RouterLoop with the shared directive
 # ---------------------------------------------------------------------------
 
 
 class _CapturingRouterLoop(rl.RouterLoop):
     """Real subclass that records the kwargs every RouterLoop construction
     receives. Used in place of the production RouterLoop via
-    ``monkeypatch.setattr`` so the test observes ChatSession's
-    construction call without mocking the type contract."""
+    ``monkeypatch.setattr`` so the test observes ChatSession's construction
+    call without mocking the type contract."""
 
     last_kwargs: dict[str, Any] = {}
 
     def __init__(self, **kwargs: Any):
-        # Snapshot all kwargs the caller passed before forwarding.
         _CapturingRouterLoop.last_kwargs = dict(kwargs)
         super().__init__(**kwargs)
 
 
 @pytest.mark.asyncio
-async def test_chat_session_passes_directive_to_router_loop(monkeypatch, tmp_path):
-    """Tier 2c: ``ChatSession._handle_user_message`` wires directive to ``RouterLoop`` (B43-NF-W6-1).
+async def test_chat_session_passes_shared_resume_directive_always_on(monkeypatch, tmp_path):
+    """Tier 2c: ``ChatSession._handle_user_message`` wires the SHARED
+    ``EMPTY_STOP_RETRY_DIRECTIVE`` ("resume") + ``empty_stop_retry_auto=True``
+    to ``RouterLoop`` (#187 uniform always-on).
 
-    ``ChatSession._handle_user_message`` constructs its ``RouterLoop``
-    with ``empty_stop_retry_directive=_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE``.
-
-    Without this wiring, the env-var-gated retry path remains dormant at
-    the chat-router layer (= PR #265 only covered the planner sub_loop
-    sites). N=10 trace-patch-replay on the W6-S2 top-level empty stop
-    showed baseline 6/10 → patched 0/10, confirming the directive
-    propagation is the load-bearing change. Pin both the kwarg's presence
-    AND its identity against the module-level constant.
-    """
+    Without this wiring the chat router would either miss the retry or carry a
+    chat-specific directive (the retired per-site differentiation). Pin both the
+    kwarg's presence AND its identity against the shared module-level constant,
+    plus the always-on flag (env-gate retired)."""
     monkeypatch.chdir(tmp_path)
-    # Replace the RouterLoop import inside session.py with the capturing
-    # subclass. session._handle_user_message does ``from
-    # reyn.chat.router_loop import RouterLoop`` inside the function, so
-    # the module-level patch is what gets observed.
+    # session._handle_user_message does ``from reyn.chat.router_loop import
+    # RouterLoop`` inside the function, so the module-level patch is observed.
     monkeypatch.setattr(rl, "RouterLoop", _CapturingRouterLoop)
-
-    # Replace the LLM caller with a scripted text reply so the run
-    # completes without network. We use a single text_result to exit the
-    # loop after one iteration — sufficient to capture the construction.
     scripted = _ScriptedLLM([_text_result("ok")])
     monkeypatch.setattr(rl, "call_llm_tools", scripted)
 
@@ -159,42 +103,14 @@ async def test_chat_session_passes_directive_to_router_loop(monkeypatch, tmp_pat
 
     await session._handle_user_message("hello", chain_id="chain-test-b44")
 
-    # The capturing subclass recorded the kwargs from the construction.
     captured = _CapturingRouterLoop.last_kwargs
-    assert "empty_stop_retry_directive" in captured, (
-        "ChatSession must pass empty_stop_retry_directive to RouterLoop "
-        "(= B43-NF-W6-1 wiring). Got kwargs: " + str(list(captured.keys()))
+    assert captured.get("empty_stop_retry_directive") == EMPTY_STOP_RETRY_DIRECTIVE, (
+        "ChatSession must pass the shared EMPTY_STOP_RETRY_DIRECTIVE, not an "
+        "inlined or chat-specific string. Got: "
+        + repr(captured.get("empty_stop_retry_directive"))
     )
-    assert (
-        captured["empty_stop_retry_directive"]
-        == _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE
-    ), (
-        "ChatSession must pass the canonical chat-router directive, not "
-        "an inlined or accidentally-renamed string. Pinning identity "
-        "against _CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE catches both "
-        "accidental copy-edits and re-use of the plan-step directive."
-    )
-
-
-@pytest.mark.asyncio
-async def test_chat_session_directive_is_distinct_from_plan_step_at_wire(
-    monkeypatch, tmp_path,
-):
-    """Tier 2: regression guard — the directive ChatSession passes is
-    NOT the plan-step constant. Catches accidental copy-paste of the
-    planner wiring (= which would say "step report" to actual users)."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(rl, "RouterLoop", _CapturingRouterLoop)
-    scripted = _ScriptedLLM([_text_result("ok")])
-    monkeypatch.setattr(rl, "call_llm_tools", scripted)
-
-    session = _make_session(tmp_path)
-    session.is_attached = True
-    await session._handle_user_message("hello", chain_id="chain-b44-distinct")
-
-    captured = _CapturingRouterLoop.last_kwargs
-    from reyn.chat.planner import _PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE
-    assert (
-        captured["empty_stop_retry_directive"]
-        != _PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE
+    assert captured.get("empty_stop_retry_auto") is True, (
+        "ChatSession must pass empty_stop_retry_auto=True (#187 always-on; the "
+        "REYN_EMPTY_STOP_RETRY env opt-in is retired). Got kwargs: "
+        + str(sorted(captured))
     )

--- a/tests/test_empty_stop_retry_uniform_187.py
+++ b/tests/test_empty_stop_retry_uniform_187.py
@@ -1,0 +1,144 @@
+"""Tier 2: #187 — the empty-stop retry is UNIFORM and always-on at every site.
+
+owner decision (2026-06-07): a content-less empty stop (finish_reason=stop, no
+content, no tool_calls) is recovered by a single content-neutral ``"resume"``
+continuation turn, applied UNIFORMLY at all RouterLoop construction sites
+(chat / plan-step / agent op-loop) — no per-site or per-tier directive
+differentiation. The previous per-site directives (chat "write your reply" /
+plan "step report", both ending "Do not call another tool") were unevidenced
+differentiation, and that anti-invoke framing was itself suspect on the agent
+path (real-task: a content-less stop is 67% premature; "resume" recovers the
+next action — invoke 11/12). Iterate per-site ONLY on measured evidence.
+
+Pinned invariants:
+
+- The single shared ``EMPTY_STOP_RETRY_DIRECTIVE`` is verbatim ``"resume"``.
+- Every RouterLoop(...) construction in the three threading modules
+  (session.py / planner.py / phase_executor.py) passes BOTH
+  ``empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE`` (the shared name,
+  not an inlined string or a reintroduced per-site constant) AND
+  ``empty_stop_retry_auto=True`` (always-on; env-gate retired). Verified by AST
+  so a later refactor that drops the kwarg, inlines a literal, or reintroduces
+  per-site differentiation fails loudly — the same construction-wiring-guard
+  genre as ``test_routerloop_convergence_entrypoint_parity_1092``.
+
+The behavioural proof (auto=True fires the retry WITHOUT the env var) lives in
+``test_router_loop_empty_stop_retry.test_auto_flag_fires_retry_without_env_var``;
+the live chat-construction proof lives in
+``test_chat_router_empty_stop_directive_wired``. This file pins the static
+uniform-wiring invariant across all three sites.
+
+References:
+- #1402 autonomous-construction class: phase_executor reuses chat-shaped
+  construction; the agent-path directive was previously dropped (None) → the
+  retry was unreachable on the agent op-loop (construction-forwarding gap).
+- #1092↔#187 reconciliation: agent op-loop content-less-stop = premature
+  empty-stop; nudge-once is bounded so op-loop convergence + FD2 finish are
+  preserved (a legitimate clean end emits content or is FD2-terminated).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import reyn.chat.planner as planner_mod
+import reyn.chat.session as session_mod
+import reyn.kernel.phase_executor as pe_mod
+from reyn.chat.router_loop import EMPTY_STOP_RETRY_DIRECTIVE
+
+_DIRECTIVE_NAME = "EMPTY_STOP_RETRY_DIRECTIVE"
+_WIRING_MODULES = (session_mod, planner_mod, pe_mod)
+
+
+# ---------------------------------------------------------------------------
+# Directive content — verbatim "resume"
+# ---------------------------------------------------------------------------
+
+
+def test_shared_directive_is_verbatim_resume() -> None:
+    """Tier 2: #187 — the single shared empty-stop directive is verbatim
+    ``"resume"`` (content-neutral, the patch-verified winner). Pin the exact
+    string: elaboration is a separate patch-verify experiment, not the landing
+    default, and per-site content is forbidden by the owner decision."""
+    assert EMPTY_STOP_RETRY_DIRECTIVE == "resume"
+
+
+# ---------------------------------------------------------------------------
+# Cross-site construction-wiring invariant (AST) — uniform + always-on
+# ---------------------------------------------------------------------------
+
+
+def _routerloop_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "RouterLoop"
+    ]
+
+
+def _wires_uniform_empty_stop(call: ast.Call) -> bool:
+    """True if this RouterLoop(...) passes the shared directive name +
+    empty_stop_retry_auto=True (uniform always-on)."""
+    kw = {k.arg: k.value for k in call.keywords if k.arg}
+    directive = kw.get("empty_stop_retry_directive")
+    auto = kw.get("empty_stop_retry_auto")
+    directive_ok = (
+        isinstance(directive, ast.Name) and directive.id == _DIRECTIVE_NAME
+    )
+    auto_ok = isinstance(auto, ast.Constant) and auto.value is True
+    return directive_ok and auto_ok
+
+
+def test_every_routerloop_site_wires_uniform_resume_always_on() -> None:
+    """Tier 2: #187 — every RouterLoop construction in session.py / planner.py /
+    phase_executor.py passes ``empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE``
+    AND ``empty_stop_retry_auto=True``. Falsifiable: drop the kwarg, inline a
+    literal, or reintroduce a per-site constant at any site → this fails, naming
+    the offending module. Guards both the construction-forwarding gap (agent
+    path was None) and the owner no-per-site-differentiation decision."""
+    offenders: list[str] = []
+    for mod in _WIRING_MODULES:
+        # Read the ACTUAL loaded module file (not a guessed path) so the test
+        # tracks editable-install / worktree drift faithfully.
+        tree = ast.parse(Path(mod.__file__).read_text(encoding="utf-8"))
+        calls = _routerloop_calls(tree)
+        if not calls:
+            offenders.append(f"{mod.__name__}: no RouterLoop(...) construction found")
+            continue
+        for call in calls:
+            if not _wires_uniform_empty_stop(call):
+                offenders.append(
+                    f"{mod.__name__}:{getattr(call, 'lineno', '?')} "
+                    "RouterLoop(...) does not pass "
+                    "empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE + "
+                    "empty_stop_retry_auto=True"
+                )
+    assert not offenders, (
+        "every RouterLoop construction site must wire the uniform always-on "
+        "empty-stop retry (#187 owner decision). Offenders: " + str(offenders)
+    )
+
+
+def test_no_per_site_directive_constants_reintroduced() -> None:
+    """Tier 2: #187 — the retired per-site directive constants must NOT be
+    reintroduced (owner: no per-site differentiation). A new
+    ``_*_EMPTY_STOP_RETRY_DIRECTIVE`` assignment anywhere in src is a regression
+    toward the differentiation the uniform decision removed."""
+    src = Path(session_mod.__file__).resolve().parents[1]
+    retired = (
+        "_CHAT_ROUTER_EMPTY_STOP_RETRY_DIRECTIVE",
+        "_PLAN_STEP_EMPTY_STOP_RETRY_DIRECTIVE",
+        "_AGENT_EMPTY_STOP_RETRY_DIRECTIVE",
+    )
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id in retired:
+                offenders.append(f"{py.relative_to(src.parent)}:{node.lineno}")
+    assert not offenders, (
+        "retired per-site empty-stop directive constants reintroduced "
+        f"(use the shared EMPTY_STOP_RETRY_DIRECTIVE instead): {sorted(set(offenders))}"
+    )

--- a/tests/test_router_loop_empty_stop_retry.py
+++ b/tests/test_router_loop_empty_stop_retry.py
@@ -9,6 +9,11 @@ Pinned invariants:
 - When the env var is unset, the directive is plumbed in but ignored — the
   loop falls through to the existing "observe + surface" path (= no behaviour
   change for the default chat-router policy).
+- #187: when ``empty_stop_retry_auto=True`` (= the agent-path always-on flag
+  set by phase_executor), the retry fires WITHOUT the env var. The directive
+  gate still holds (auto replaces the env opt-in, it does not fabricate a
+  missing directive). chat / plan-step sites leave auto False so they stay
+  env-gated (no regression).
 - When the directive is None, the env var is also ignored — no retry attempt
   even with the env var set.
 - Retries are bounded at 1 per turn: a second empty-stop in the same turn
@@ -67,12 +72,14 @@ def _make_loop(
     directive: str | None,
     *,
     llm_caller,
+    auto: bool = False,
 ) -> RouterLoop:
     return RouterLoop(
         host=host,
         chain_id="chain-empty-stop-test",
         max_iterations=5,
         empty_stop_retry_directive=directive,
+        empty_stop_retry_auto=auto,
         llm_caller=llm_caller,
     )
 
@@ -148,6 +155,52 @@ async def test_no_retry_when_directive_is_none(monkeypatch):
     host = FakeRouterHost()
     scripted = _ScriptedLLM([_empty_stop_result()])
     loop = _make_loop(host, None, llm_caller=scripted)  # no directive
+
+    await loop.run("test", [])
+
+    assert scripted.call_count == 1
+    assert host.outbox[0]["meta"]["source"] == "router_empty_response"
+
+
+# ---------------------------------------------------------------------------
+# #187: agent-path always-on flag — retry fires WITHOUT the env var
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_flag_fires_retry_without_env_var(monkeypatch):
+    """Tier 2: #187 — ``empty_stop_retry_auto=True`` fires the retry with the
+    ``REYN_EMPTY_STOP_RETRY`` env var UNSET. This is the agent-path always-on
+    path (phase_executor sets auto=True): the agent op-loop must recover from a
+    post-tool empty stop without an operator opt-in, because a dead-ended agent
+    cannot make progress (real-task: 67% empty-stop). Mirror of
+    ``test_retry_path_injects_user_msg_when_env_var_set`` with env unset + auto.
+    """
+    monkeypatch.delenv("REYN_EMPTY_STOP_RETRY", raising=False)
+    host = FakeRouterHost()
+    scripted = _ScriptedLLM([_empty_stop_result(), text_result("recovered")])
+    loop = _make_loop(host, "resume", llm_caller=scripted, auto=True)
+
+    await loop.run("test", [])
+
+    # Two LLM calls (= 1 initial + 1 retry) even though the env var is unset.
+    assert scripted.call_count == 2
+    (only,) = host.outbox
+    assert only["text"] == "recovered"
+    emitted = [e["type"] for e in host._events.emitted]
+    assert "router_empty_response_retry_injected" in emitted
+
+
+@pytest.mark.asyncio
+async def test_auto_flag_still_requires_directive(monkeypatch):
+    """Tier 2: #187 — auto=True with directive None does NOT retry. The
+    ``auto`` flag replaces only the env opt-in; it does not fabricate a
+    missing directive (= the directive gate still holds). Guards against
+    auto accidentally widening the gate to a no-content retry."""
+    monkeypatch.delenv("REYN_EMPTY_STOP_RETRY", raising=False)
+    host = FakeRouterHost()
+    scripted = _ScriptedLLM([_empty_stop_result()])
+    loop = _make_loop(host, None, llm_caller=scripted, auto=True)
 
     await loop.run("test", [])
 

--- a/tests/test_routerloop_convergence_inloop_compaction_1092.py
+++ b/tests/test_routerloop_convergence_inloop_compaction_1092.py
@@ -102,7 +102,21 @@ class _NReadsThenStop:
                 "id": f"c{i}", "type": "function",
                 "function": {"name": "read_file", "arguments": json.dumps({"path": "notes.txt"})},
             }])
-        return _tool_result([])
+        # #1092↔#187 reconciliation: a clean op-loop end emits CONTENT (a final
+        # assistant message). A content-LESS stop is now (correctly) treated as a
+        # premature empty-stop glitch and nudged once by the #187 agent-path
+        # resume retry — which would inject an extra "resume" turn and corrupt
+        # this per-op growth measurement (the terminal delta would be the small
+        # resume turn, not a full op-result). The content-less terminator was an
+        # incidental simplification; the LOAD-BEARING assertion is the LINEAR
+        # per-op delta (≈ full op-result size — the unbounded result accumulation
+        # the C-4b hook closes), NOT the terminator's content-ness. A content-
+        # bearing clean end preserves the measurement while avoiding the (correct)
+        # empty-stop nudge.
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+        )
 
 
 def _finish_llm():

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -55,10 +55,20 @@ def _skill() -> Skill:
 def _patch_llms(monkeypatch, tools_calls: list, decide_calls: list) -> None:
     async def _tools(*a, **k):  # noqa: ANN002, ANN003
         tools_calls.append(1)
-        # No tool_calls → the op-loop reaches end_turn immediately; the converged
-        # path then post-pends the FD2 json decide (separate ``call``).
+        # No tool_calls → the op-loop reaches end_turn; the converged path then
+        # post-pends the FD2 json decide (separate ``call``).
+        # #1092↔#187 reconciliation: a clean op-loop end emits CONTENT (a final
+        # assistant message). A content-LESS stop is now (correctly) treated as a
+        # premature empty-stop glitch and nudged once (#187 agent-path resume —
+        # real-task: 67% premature, resume recovers invoke 11/12). The content-less
+        # terminator here was an incidental simplification; the LOAD-BEARING
+        # assertion is gate-threading (the converged op-loop is reached, the single
+        # call_llm_tools gives tools_calls == [1]), NOT the terminator's
+        # content-ness. A content-bearing clean end preserves that intent while
+        # avoiding the (correct) empty-stop nudge that the content-less shape now
+        # triggers.
         return LLMToolCallResult(
-            content=None, tool_calls=[], finish_reason="stop",
+            content="done", tool_calls=[], finish_reason="stop",
             usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
         )
 


### PR DESCRIPTION
**[e2e-coder]** — #187 empty-stop fix: uniform always-on "resume" retry at every RouterLoop site.

## Problem (real-task measured)

On the real-task phase op-loop (`code_review`), the agent hit **33% direct-invoke / ~67% empty-stop** after a tool-call round. An empty stop (finish_reason=stop, no content, no tool_calls) **dead-ends the agent** — it must keep invoking tools to make progress.

Two coupled defects (flow-trace + lead-coder primary verification):

1. **Construction-forwarding gap** (the #1410 base_dir / B3 permission-zone / #1419 exec-seam recurring class): `phase_executor.py`'s `RouterLoop(...)` never passed `empty_stop_retry_directive` → defaulted `None` → the retry mechanism was **structurally unreachable on the agent path**.
2. **Content-semantics, not role** (the lever): the existing retry site already appends `{"role":"user", …}`. The 1/12-vs-11/12 swing is directive *content* — a content-neutral `"resume"` turn re-enters the loop and lets the model continue (real-task: resume recovers the next action 11/12).

## Fix — uniform, always-on, single shared directive (owner decision)

- `router_loop.py`: new `empty_stop_retry_auto: bool = False` flag. The retry gate becomes `directive set AND retries<1 AND (auto OR REYN_EMPTY_STOP_RETRY==1)`.
- **Single shared `EMPTY_STOP_RETRY_DIRECTIVE = "resume"`** (router_loop.py), used UNIFORMLY at all 5 RouterLoop construction sites (chat ×1 / plan-step ×3 / agent op-loop ×1), each with `empty_stop_retry_auto=True` (always-on; env-gate retired).
- **Retired the 3 per-site directives** (chat "write your reply…", plan "step report…", both ending "Do not call another tool"). Per owner: no unevidenced per-site/per-tier differentiation — and the chat directive's anti-invoke framing ("do not call another tool") was itself suspect (chat models also tool-call). Policy: **first uniform, iterate per-site only on measured evidence**.

`"resume"` is verbatim/patch-verified; not paraphrased.

## #1092 ↔ #187 reconciliation (arbitrated with lead, Option A)

The #1092 convergence op-loop signals "done" by emitting no tool_calls; a *content-less* such stop is structurally identical to the empty-stop attractor. Reconciliation:

- A content-less stop on the agent op-loop is **67% premature** (real data) — treating it as a glitch worth one nudge is correct. FD2 is the true terminator but FD2 = *decide-next*, not *invoke-recovery*, so the empty-stop retry is functionally distinct (narrowing-to-FD2 would leave the 67% unrecovered).
- The nudge is **1-bounded**, so op-loop convergence + FD2 finish are preserved (post-nudge content-less → op-loop end → FD2).
- A **legitimate clean end emits content** (or is FD2-terminated). The two #1092 convergence stubs used a content-less terminator as an incidental simplification; updated to content-bearing clean ends. Their load-bearing assertions (gate-threading `[1]` reach / linear per-op growth) are unchanged — articulated in each test.

## Test plan

- [x] `tests/test_router_loop_empty_stop_retry.py` — `+test_auto_flag_fires_retry_without_env_var` (auto=True fires retry, env UNSET) + `+test_auto_flag_still_requires_directive`. Existing env-gated-default tests still pass (auto defaults False).
- [x] `tests/test_empty_stop_retry_uniform_187.py` (new) — shared directive == "resume"; cross-site AST invariant (all 3 modules pass `EMPTY_STOP_RETRY_DIRECTIVE` + `auto=True`, falsifiable); regression guard against reintroducing per-site constants.
- [x] `tests/test_chat_router_empty_stop_directive_wired.py` — rewritten: chat wires the shared resume directive + always-on (behavioral, drives real ChatSession). Retired the now-invalid per-site distinctness tests.
- [x] `tests/test_routerloop_convergence_{threading,inloop_compaction}_1092.py` — content-bearing clean-end terminators (intent-preservation articulated).
- [x] `pytest -q` full suite — **2 failed / 6857 passed** under uniform-resume. Both failures are **pre-existing, unrelated** (`test_swebench_missing_honest_skip` = env; `test_web_fetch_preview_path_ref` = BeautifulSoup heading extraction) — proven by stash-on-clean-`origin/main` (both fail there too; the 2 #1092 convergence tests PASS clean). **Uniform-resume added zero new failures across all 6857 — no chat/plan replay-fixture drift.**
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` clean.
- [ ] sandbox_2 **production-flow** verify (op-loop + FD2 full path, NOT patch-replay): uniform resume at all 3 sites recovers invoke + FD2 interaction healthy + legitimate completion harmless. **Merge gate.**

## Test coverage migration (B43 file -126/+42)

`test_chat_router_empty_stop_directive_wired.py` shrinks by ~126/+42 lines. This is a **coverage migration**, not a coverage loss (same shape as a Stage A deletion):

- **Removed** (now obsolete): the per-site distinctness assertions — `test_chat_router_directive_references_user_and_tool_result`, `test_chat_router_directive_distinct_from_plan_step_directive`, `test_chat_session_directive_is_distinct_from_plan_step_at_wire`, `test_chat_router_directive_is_non_empty_string`. They pinned the **retired** per-site-differentiation design (chat "reply" ≠ plan "step report"), which the owner uniform-resume decision deliberately removes. Keeping them would pin a contract that no longer exists.
- **Retained + updated**: the behavioral chat-construction proof (`test_chat_session_passes_shared_resume_directive_always_on`) — drives the real `ChatSession` and asserts it wires the shared `EMPTY_STOP_RETRY_DIRECTIVE` + `auto=True`.
- **New coverage replacing it**: `test_empty_stop_retry_uniform_187.py` pins the shared directive content + the cross-site uniform-wiring AST invariant (all 3 modules) + a regression guard against reintroducing per-site constants — strictly stronger than the deleted per-site assertions.

## Notes

- #1402 autonomous-construction lens: phase_executor reused chat-shaped construction → the agent-path directive was dropped.
- chat/plan behavior change: directive `"write your reply"`/`"step report"` → `"resume"` + env-gate → always-on. Replay-fixture drift checked + articulated above.

Refs #187. Companion to Stage B (#1422) + Stage A (#1423); precedes Stage C (the empty-stop fix covers the empty-stop Stage C's forced-`list_actions` could induce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
