### PR TITLE
feat(1341): build-based devcontainer support via build-on-demand

### DIFF
--- a/docs/guide/for-users/configure-sandbox.ja.md
+++ b/docs/guide/for-users/configure-sandbox.ja.md
@@ -134,6 +134,17 @@ reyn run my_skill --env-backend=docker --container my-container --repo-dir /work
 
 `--image` を省略した場合、reyn は現在のプラットフォーム向けにビルドされたバンドルベースイメージを使用します。カスタムイメージを使用するには `--image` を渡すか、`reyn.yaml` でデフォルトを設定してください（[`reyn.yaml` リファレンス](../../reference/config/reyn-yaml.md)参照）。
 
+### devcontainer.json
+
+ワークスペースに `devcontainer.json`（`.devcontainer/devcontainer.json` または `.devcontainer.json`）がある場合、reyn は最小サブセット（`image` / `postCreateCommand` / `mounts` / `remoteUser`）を読み取って起動のデフォルトに反映します。明示的な `--image` は常に devcontainer より優先されます。
+
+- **image ベース**（`image: ...`）— そのまま起動。
+- **build ベース**（`dockerFile` / `build`）— reyn が Dockerfile を**オンデマンドでビルド**（`docker build`）して起動します。ビルド済みイメージは内容ハッシュでタグ付けされ、Dockerfile / build args / target が変わったときのみ再ビルドされます。`build.args` と `build.context` に対応。
+- **compose ベース**（`dockerComposeFile`）— 非対応（ランチャーは単一コンテナ）。警告を出してデフォルトイメージにフォールバックします。
+
+!!! warning "ビルドはワークスペースの Dockerfile をホストで実行します"
+    build ベース devcontainer のビルドは、その Dockerfile の `RUN` ステップを**ビルド時にホストの Docker デーモン上で**実行します。これは reyn のランタイムサンドボックスでは保護されません（network-off / non-root / read-only-rootfs は*実行中*コンテナに適用され、`docker build` には適用されません）。これは VS Code の「Reopen in Container」と同じ信頼モデルです。信頼できるワークスペースの build ベース devcontainer のみ使用してください。reyn はビルドをログ出力します。`--env-backend=docker` がオプトインです。
+
 ## 関連ドキュメント
 
 - [コンセプト: サンドボックスとパーミッション](../../concepts/architecture/sandbox-vs-permission.md) — 両者が直交する理由

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -150,6 +150,30 @@ When `--image` is omitted, reyn uses a bundled base image built for the current
 platform. To use a custom image, pass `--image` or set the default in `reyn.yaml`
 (see [`reyn.yaml` reference](../../reference/config/reyn-yaml.md)).
 
+### devcontainer.json
+
+If the workspace ships a `devcontainer.json` (`.devcontainer/devcontainer.json`
+or `.devcontainer.json`), reyn reads a minimal subset to seed the launch:
+`image`, `postCreateCommand`, `mounts`, and `remoteUser`. An explicit `--image`
+always overrides the devcontainer.
+
+- **Image-based** (`image: ...`) — launched directly.
+- **Build-based** (`dockerFile` / `build`) — reyn **builds the Dockerfile on
+  demand** (`docker build`) and launches the result. The built image is tagged
+  by content hash, so it is rebuilt only when the Dockerfile / build args /
+  target change. `build.args` and `build.context` are honored.
+- **Compose-based** (`dockerComposeFile`) — not supported (the launcher is
+  single-container); reyn warns and falls back to the default image.
+
+!!! warning "Build runs the workspace Dockerfile on your host"
+    Building a build-based devcontainer runs that Dockerfile's `RUN` steps on
+    your host Docker daemon at **build time** — these are **not** confined by
+    reyn's runtime sandbox (the network-off / non-root / read-only-rootfs flags
+    apply to the *running* container, not to `docker build`). This is the same
+    trust model as VS Code's "Reopen in Container": only use build-based
+    devcontainers from workspaces you trust. reyn logs the build for visibility;
+    `--env-backend=docker` is the opt-in.
+
 ## See also
 
 - [Concepts: Sandbox and permissions](../../concepts/architecture/sandbox-vs-permission.md) — why sandbox and permissions are orthogonal

--- a/src/reyn/cli/env_backend.py
+++ b/src/reyn/cli/env_backend.py
@@ -123,8 +123,10 @@ def build_environment_backend(args: argparse.Namespace, *, launcher=None):
         from reyn.environment.container_launcher import (
             DEFAULT_IMAGE,
             WORKSPACE_DEST_DEFAULT,
+            BuildSpec,
             ContainerLauncher,
             LaunchConfig,
+            _devcontainer_image_tag,
             load_devcontainer_config,
             parse_mount_spec,
         )
@@ -139,21 +141,44 @@ def build_environment_backend(args: argparse.Namespace, *, launcher=None):
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
         keep = bool(getattr(args, "keep_container", False))
-        # #1324 (b) devcontainer awareness: a workspace devcontainer.json seeds
-        # the launch defaults; explicit CLI flags override it. build-based
-        # devcontainers are not yet supported → warn + use the default image.
+        # #1324 (b) devcontainer awareness + #1341 build-based support: a workspace
+        # devcontainer.json seeds the launch defaults; an explicit --image overrides.
+        # - dockerFile/build (buildable) → build the image on demand (#1341).
+        # - dockerComposeFile (multi-service) → out of scope → warn + default image.
         dc = load_devcontainer_config(workspace_root)
-        if dc is not None and dc.build_based:
-            print(
-                "Warning: build-based devcontainer (dockerFile/build) is not yet "
-                "supported; using the default image.",
-                file=sys.stderr,
-            )
         cli_image = getattr(args, "image", None)
-        dc_image = dc.image if (dc is not None and not dc.build_based) else None
+        build_spec = None
+        dc_image = None
+        if dc is not None:
+            if cli_image:
+                pass  # explicit --image wins → skip the devcontainer image/build
+            elif dc.buildable:
+                # #1341: build-based devcontainer → build on demand. The image is
+                # a content-addressed tag; the launcher builds it (inspect-then-
+                # build) + logs the build (security: the workspace Dockerfile runs
+                # on the host daemon at build time — same trust as VS Code "Reopen
+                # in Container"; the runtime container still gets all reyn flags).
+                build_spec = BuildSpec(
+                    dockerfile=dc.dockerfile,  # type: ignore[arg-type]  # buildable ⇒ not None
+                    context=dc.build_context,  # type: ignore[arg-type]
+                    build_args=dc.build_args,
+                    target=dc.build_target,
+                )
+                dc_image = _devcontainer_image_tag(build_spec)
+            elif dc.build_based:
+                # compose / non-buildable → single-container launcher can't run it.
+                print(
+                    "Warning: compose-based devcontainer (dockerComposeFile) is "
+                    "not supported (single-container launcher); using the default "
+                    "image.",
+                    file=sys.stderr,
+                )
+            else:
+                dc_image = dc.image  # plain image-based devcontainer
         config = LaunchConfig(
             workspace_root=workspace_root,
             image=cli_image or dc_image or DEFAULT_IMAGE,
+            build=build_spec,
             mounts=cli_mounts or (dc.mounts if dc is not None else []),
             persistent=keep,
             setup_command=(dc.setup_command if dc is not None else None),

--- a/src/reyn/environment/container_launcher.py
+++ b/src/reyn/environment/container_launcher.py
@@ -35,9 +35,11 @@ mechanism here is independent of whether the default is published or bundled.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -60,6 +62,30 @@ DEFAULT_IMAGE = REYN_BASE_IMAGE
 def _reyn_base_dockerfile() -> Path:
     """Path to the bundled reyn base Dockerfile (shipped as package data)."""
     return Path(__file__).parent / "reyn_base.Dockerfile"
+
+
+def _devcontainer_image_tag(spec: "BuildSpec") -> str:
+    """#1341: a content-addressed local tag for a build-based devcontainer image.
+
+    The hash covers the Dockerfile *contents* + sorted build args + target — the
+    inputs that change the built image (F2: content-addressed + inspect-then-build).
+    A changed Dockerfile/args/target yields a new tag → an inspect-miss → rebuild;
+    an unchanged spec reuses the existing tag (no rebuild). NOTE: a context-only
+    change (e.g. a COPY'd file edited without touching the Dockerfile) keeps the
+    same tag — a documented minor staleness limit, matching the VS Code model
+    (which also keys rebuilds on the Dockerfile/args, not arbitrary context edits).
+    Falls back to hashing the Dockerfile *path* if the file is unreadable.
+    """
+    h = hashlib.sha256()
+    try:
+        h.update(Path(spec.dockerfile).read_bytes())
+    except OSError:
+        h.update(spec.dockerfile.encode("utf-8"))
+    for k in sorted(spec.build_args):
+        h.update(f"\0{k}={spec.build_args[k]}".encode())
+    if spec.target:
+        h.update(f"\0target={spec.target}".encode())
+    return f"reyn-dc-{h.hexdigest()[:12]}:local"
 
 # Fixed in-container mount destination for the workspace (override-able via
 # LaunchConfig.workspace_dest). The agent's repo_dir resolves here.
@@ -106,6 +132,25 @@ def parse_mount_spec(raw: str) -> MountSpec:
 
 
 @dataclass
+class BuildSpec:
+    """A build-on-demand spec for a build-based devcontainer (#1341).
+
+    dockerfile:  absolute path to the devcontainer Dockerfile.
+    context:     absolute path to the build context dir.
+    build_args:  ``build.args`` → ``--build-arg k=v`` (str values only).
+    target:      optional ``build.target`` multi-stage target.
+
+    When a ``LaunchConfig`` carries a ``build``, the launcher builds the image
+    on demand (content-addressed tag, inspect-then-build) instead of pulling.
+    """
+
+    dockerfile: str
+    context: str
+    build_args: dict[str, str] = field(default_factory=dict)
+    target: str | None = None
+
+
+@dataclass
 class LaunchConfig:
     """Operator-level config for launching a mount-mode container.
 
@@ -114,6 +159,10 @@ class LaunchConfig:
         global cwd-vs-project_root fix is #1316, out of scope here).
     workspace_dest: in-container mount target for workspace_root.
     image / setup_command: the default generic image + a runtime extension hook.
+    build: a #1341 build-on-demand spec — when set, the launcher builds
+        ``image`` from this Dockerfile (build-based devcontainer) rather than
+        relying on ``docker run`` to pull it. ``image`` then holds the
+        content-addressed build tag (see ``_devcontainer_image_tag``).
     mounts: additional user bind mounts.
     network: outbound network (default off — the exfiltration gate).
     user: non-root ``uid[:gid]``; defaults to the host operator's ids so mounted
@@ -126,6 +175,7 @@ class LaunchConfig:
     workspace_dest: str = WORKSPACE_DEST_DEFAULT
     image: str = DEFAULT_IMAGE
     setup_command: str | None = None
+    build: BuildSpec | None = None
     mounts: list[MountSpec] = field(default_factory=list)
     network: bool = False
     user: str | None = None
@@ -154,8 +204,18 @@ class DevcontainerConfig:
                     postStartCommand is every-start and intentionally NOT mapped).
     mounts:         devcontainer ``mounts`` (bind mounts only).
     user:           devcontainer ``remoteUser`` / ``containerUser``.
-    build_based:    True if the devcontainer is dockerFile/build/compose-based
-                    (not yet supported → caller falls back to the default image).
+    build_based:    True if the devcontainer is dockerFile/build/compose-based.
+    dockerfile:     #1341 — resolved absolute path to the devcontainer Dockerfile
+                    (``dockerFile`` legacy or ``build.dockerfile``), or None for a
+                    non-buildable (``dockerComposeFile``) devcontainer.
+    build_context:  #1341 — resolved absolute build context dir.
+    build_args:     #1341 — ``build.args`` (str values).
+    build_target:   #1341 — ``build.target`` multi-stage target.
+
+    A dockerFile/build devcontainer is **buildable** (``buildable`` True →
+    build-on-demand, #1341); ``dockerComposeFile`` is build_based but NOT
+    buildable (multi-service is out of scope → caller warns + falls back to the
+    default image).
     """
 
     image: str | None = None
@@ -163,6 +223,16 @@ class DevcontainerConfig:
     mounts: list[MountSpec] = field(default_factory=list)
     user: str | None = None
     build_based: bool = False
+    dockerfile: str | None = None
+    build_context: str | None = None
+    build_args: dict[str, str] = field(default_factory=dict)
+    build_target: str | None = None
+
+    @property
+    def buildable(self) -> bool:
+        """True if this devcontainer can be built on demand (#1341): build_based
+        AND a Dockerfile was resolved (i.e. dockerFile/build, not compose-only)."""
+        return self.build_based and self.dockerfile is not None
 
 
 def _strip_jsonc(text: str) -> str:
@@ -204,10 +274,56 @@ def _parse_devcontainer_mount(m: Any) -> MountSpec | None:
     return MountSpec(host=str(src), container=str(tgt), mode=mode)
 
 
-def _map_devcontainer(data: Mapping[str, Any]) -> DevcontainerConfig:
-    cfg = DevcontainerConfig()
-    if data.get("dockerFile") or data.get("build") or data.get("dockerComposeFile"):
+def _map_devcontainer_build(
+    data: Mapping[str, Any], devcontainer_dir: Path, cfg: DevcontainerConfig
+) -> None:
+    """#1341: map a build-based devcontainer's build spec onto ``cfg``.
+
+    Sets ``build_based`` for any of dockerFile / build / dockerComposeFile.
+    For the buildable forms (legacy top-level ``dockerFile`` [+ ``context``] or
+    the ``build`` object ``{dockerfile, context, args, target}``) resolves the
+    Dockerfile + context relative to the devcontainer.json location (per the
+    devcontainer spec) and captures args/target. ``dockerComposeFile`` is
+    build_based but left non-buildable (dockerfile stays None) — multi-service
+    is out of scope for the single-container launcher.
+    """
+    build = data.get("build")
+    dockerfile_rel = context_rel = target = None
+    args: dict[str, str] = {}
+    if isinstance(build, Mapping):
+        df = build.get("dockerfile")
+        if isinstance(df, str):
+            dockerfile_rel = df
+        ctx = build.get("context")
+        if isinstance(ctx, str):
+            context_rel = ctx
+        tgt = build.get("target")
+        if isinstance(tgt, str):
+            target = tgt
+        ba = build.get("args")
+        if isinstance(ba, Mapping):
+            args = {str(k): str(v) for k, v in ba.items()}
+    elif isinstance(data.get("dockerFile"), str):  # legacy top-level form
+        dockerfile_rel = data["dockerFile"]
+        ctx = data.get("context")
+        if isinstance(ctx, str):
+            context_rel = ctx
+
+    if data.get("dockerFile") or build or data.get("dockerComposeFile"):
         cfg.build_based = True
+    if dockerfile_rel:  # buildable (dockerFile/build) — resolve relative to the json dir
+        cfg.dockerfile = str((devcontainer_dir / dockerfile_rel).resolve())
+        cfg.build_context = str((devcontainer_dir / (context_rel or ".")).resolve())
+        cfg.build_args = args
+        cfg.build_target = target
+    # dockerComposeFile (or build without a dockerfile) → build_based, non-buildable.
+
+
+def _map_devcontainer(
+    data: Mapping[str, Any], devcontainer_dir: Path
+) -> DevcontainerConfig:
+    cfg = DevcontainerConfig()
+    _map_devcontainer_build(data, devcontainer_dir, cfg)
     img = data.get("image")
     if isinstance(img, str):
         cfg.image = img
@@ -242,7 +358,9 @@ def load_devcontainer_config(workspace_root: str) -> DevcontainerConfig | None:
             except (json.JSONDecodeError, OSError, ValueError):
                 return None
             if isinstance(data, Mapping):
-                return _map_devcontainer(data)
+                # #1341: pass the devcontainer.json's directory so build-based
+                # dockerfile/context paths resolve relative to it (spec).
+                return _map_devcontainer(data, p.parent)
             return None
     return None
 
@@ -315,7 +433,14 @@ class ContainerLauncher:
             if existing:
                 return existing
 
-        self.ensure_image(config.image)
+        # #1341: a build-based devcontainer builds its image on demand (the tag
+        # is content-addressed); everything else uses ensure_image (reyn-base
+        # on-demand / docker-run pull). A generous build timeout (apt layers),
+        # independent of the shorter launch/run timeout.
+        if config.build is not None:
+            self._build_devcontainer_image(config)
+        else:
+            self.ensure_image(config.image)
         argv = build_docker_run_argv(config, docker_bin=self.docker_bin)
         res = self._runner(argv, timeout=timeout)
         if res.returncode != 0:
@@ -348,22 +473,72 @@ class ContainerLauncher:
         """
         if image != REYN_BASE_IMAGE:
             return
-        inspect = self._runner(
+        if self._image_present(image, timeout=timeout):
+            return  # already built
+        df = _reyn_base_dockerfile()
+        self._docker_build(
+            image, str(df), str(df.parent),
+            timeout=timeout, err_label="reyn base image build",
+        )
+
+    def _build_devcontainer_image(self, config: LaunchConfig, *, timeout: int = 600) -> None:
+        """#1341: build a build-based devcontainer image on demand (inspect-then-build).
+
+        No-op if the content-addressed tag (``config.image``) is already present.
+        SECURITY (documented): a `docker build` runs the **workspace-authored**
+        Dockerfile's RUN steps on the host docker daemon — NOT inside reyn's
+        runtime sandbox (the network-off / non-root / read-only-rootfs flags
+        apply to ``docker run``, not ``docker build``; builds typically need
+        network). The trust model is identical to VS Code "Reopen in Container"
+        building the workspace Dockerfile: the operator already opted in via
+        ``--env-backend=docker`` on a workspace they chose. The *runtime*
+        container still gets all reyn security flags. We log the build for
+        transparency (no extra confirmation prompt — the opt-in is the gate).
+        """
+        spec = config.build
+        if spec is None:
+            return
+        if self._image_present(config.image, timeout=timeout):
+            return  # content-addressed tag already built → reuse (F2)
+        print(
+            f"reyn: building devcontainer image {config.image} from "
+            f"{spec.dockerfile} (workspace Dockerfile runs on the host docker "
+            f"daemon at build time)",
+            file=sys.stderr,
+        )
+        self._docker_build(
+            config.image, spec.dockerfile, spec.context,
+            build_args=spec.build_args, target=spec.target,
+            timeout=timeout, err_label="devcontainer image build",
+        )
+
+    def _image_present(self, image: str, *, timeout: int) -> bool:
+        """True if ``docker image inspect`` succeeds (image locally present)."""
+        res = self._runner(
             [self.docker_bin, "image", "inspect", image], timeout=timeout
         )
-        if inspect.returncode == 0:
-            return  # already built
-        dockerfile = _reyn_base_dockerfile()
-        res = self._runner(
-            [
-                self.docker_bin, "build", "-t", image,
-                "-f", str(dockerfile), str(dockerfile.parent),
-            ],
-            timeout=timeout,
-        )
+        return res.returncode == 0
+
+    def _docker_build(
+        self, tag: str, dockerfile: str, context: str, *,
+        build_args: dict[str, str] | None = None, target: str | None = None,
+        timeout: int = 600, err_label: str = "image build",
+    ) -> None:
+        """Shared ``docker build`` primitive (reyn-base + #1341 devcontainer).
+
+        ``docker build -t <tag> -f <dockerfile> [--build-arg k=v ...]
+        [--target t] <context>``. Raises ``RuntimeError`` on non-zero exit.
+        """
+        argv = [self.docker_bin, "build", "-t", tag, "-f", str(dockerfile)]
+        for k, v in (build_args or {}).items():
+            argv += ["--build-arg", f"{k}={v}"]
+        if target:
+            argv += ["--target", target]
+        argv.append(str(context))
+        res = self._runner(argv, timeout=timeout)
         if res.returncode != 0:
             raise RuntimeError(
-                f"reyn base image build failed (rc={res.returncode}): "
+                f"{err_label} failed (rc={res.returncode}): "
                 f"{res.stderr.decode(errors='replace')[:400]}"
             )
 

--- a/tests/test_devcontainer_build_1341.py
+++ b/tests/test_devcontainer_build_1341.py
@@ -1,0 +1,211 @@
+"""Tier 2: #1341 — build-based devcontainer support (build-on-demand).
+
+Pins the launcher-level contract for building a build-based devcontainer image:
+- ``_map_devcontainer`` extracts the build spec (dockerFile legacy + build object
+  forms) and resolves paths relative to the devcontainer.json dir; compose is
+  build_based but NOT buildable (out of scope).
+- ``_devcontainer_image_tag`` is content-addressed (deterministic; changes on
+  Dockerfile content / build_args / target).
+- ``_docker_build`` emits the expected ``docker build`` argv.
+- ``launch()`` builds (inspect-then-build) before run for a build config, skips
+  the build when the tag is already present, and surfaces build failures.
+
+Uses a real injectable fake runner (no mocks), mirroring test_container_launcher.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.environment.container_launcher import (
+    REYN_BASE_IMAGE,
+    BuildSpec,
+    ContainerLauncher,
+    LaunchConfig,
+    _devcontainer_image_tag,
+    _map_devcontainer,
+    load_devcontainer_config,
+)
+from reyn.sandbox.backend import SandboxResult
+
+
+class _FakeRunner:
+    """Records argv calls; returns scripted SandboxResults in order (no mocks)."""
+
+    def __init__(self, results: list[SandboxResult]) -> None:
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, *, stdin=None, timeout=None) -> SandboxResult:
+        self.calls.append(list(argv))
+        if self._results:
+            return self._results.pop(0)
+        return SandboxResult(returncode=0, stdout=b"", stderr=b"")
+
+
+def _ok(stdout: bytes = b"") -> SandboxResult:
+    return SandboxResult(returncode=0, stdout=stdout, stderr=b"")
+
+
+def _err(stderr: bytes = b"boom") -> SandboxResult:
+    return SandboxResult(returncode=1, stdout=b"", stderr=stderr)
+
+
+# ─── _map_devcontainer: build-spec extraction ─────────────────────────────────
+
+
+def test_map_object_build_extracts_spec(tmp_path) -> None:
+    """Tier 2: #1341 — `build` object form extracts dockerfile/context/args/target,
+    resolved relative to the devcontainer dir; buildable=True."""
+    data = {
+        "build": {
+            "dockerfile": "Dockerfile",
+            "context": "..",
+            "args": {"VARIANT": "3.12", "X": 1},
+            "target": "dev",
+        }
+    }
+    cfg = _map_devcontainer(data, tmp_path)
+    assert cfg.build_based is True
+    assert cfg.buildable is True
+    assert cfg.dockerfile == str((tmp_path / "Dockerfile").resolve())
+    assert cfg.build_context == str((tmp_path / "..").resolve())
+    assert cfg.build_args == {"VARIANT": "3.12", "X": "1"}  # values coerced to str
+    assert cfg.build_target == "dev"
+
+
+def test_map_legacy_dockerfile(tmp_path) -> None:
+    """Tier 2: #1341 — legacy top-level `dockerFile` (+ optional `context`) form."""
+    cfg = _map_devcontainer({"dockerFile": "build/Dockerfile", "context": "."}, tmp_path)
+    assert cfg.buildable is True
+    assert cfg.dockerfile == str((tmp_path / "build/Dockerfile").resolve())
+    assert cfg.build_context == str((tmp_path / ".").resolve())
+
+
+def test_map_compose_is_build_based_not_buildable(tmp_path) -> None:
+    """Tier 2: #1341 — dockerComposeFile is build_based but NOT buildable (out of
+    scope for the single-container launcher → caller warns + falls back)."""
+    cfg = _map_devcontainer({"dockerComposeFile": "docker-compose.yml"}, tmp_path)
+    assert cfg.build_based is True
+    assert cfg.buildable is False
+    assert cfg.dockerfile is None
+
+
+def test_map_image_based_not_build_based(tmp_path) -> None:
+    """Tier 2: #1341 — a plain image devcontainer stays non-build."""
+    cfg = _map_devcontainer({"image": "python:3.12-slim"}, tmp_path)
+    assert cfg.build_based is False
+    assert cfg.buildable is False
+    assert cfg.image == "python:3.12-slim"
+
+
+def test_load_resolves_relative_to_devcontainer_dir(tmp_path) -> None:
+    """Tier 2: #1341 — paths resolve relative to the .devcontainer/ location."""
+    dc_dir = tmp_path / ".devcontainer"
+    dc_dir.mkdir()
+    (dc_dir / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    (dc_dir / "devcontainer.json").write_text('{"build": {"dockerfile": "Dockerfile"}}')
+    cfg = load_devcontainer_config(str(tmp_path))
+    assert cfg is not None and cfg.buildable
+    assert cfg.dockerfile == str((dc_dir / "Dockerfile").resolve())
+
+
+# ─── content-addressed tag ────────────────────────────────────────────────────
+
+
+def test_image_tag_deterministic_and_content_addressed(tmp_path) -> None:
+    """Tier 2: #1341 — tag is deterministic for the same inputs and changes when
+    the Dockerfile content / build_args / target change (F2)."""
+    df = tmp_path / "Dockerfile"
+    df.write_text("FROM python:3.12-slim\n")
+    spec = BuildSpec(dockerfile=str(df), context=str(tmp_path))
+    t0 = _devcontainer_image_tag(spec)
+    assert t0.startswith("reyn-dc-") and t0.endswith(":local")
+    assert _devcontainer_image_tag(spec) == t0  # deterministic
+    # content change → new tag
+    df.write_text("FROM python:3.12-slim\nRUN echo hi\n")
+    assert _devcontainer_image_tag(spec) != t0
+    # args / target change → new tag
+    base = BuildSpec(dockerfile=str(df), context=str(tmp_path))
+    assert _devcontainer_image_tag(
+        BuildSpec(dockerfile=str(df), context=str(tmp_path), build_args={"A": "1"})
+    ) != _devcontainer_image_tag(base)
+    assert _devcontainer_image_tag(
+        BuildSpec(dockerfile=str(df), context=str(tmp_path), target="dev")
+    ) != _devcontainer_image_tag(base)
+
+
+# ─── _docker_build argv + launch build-order ──────────────────────────────────
+
+
+def test_docker_build_argv(tmp_path) -> None:
+    """Tier 2: #1341 — _docker_build emits `docker build -t tag -f df
+    --build-arg k=v --target t context`."""
+    fake = _FakeRunner([_ok()])
+    launcher = ContainerLauncher(runner=fake)
+    launcher._docker_build(
+        "reyn-dc-abc:local", "/ws/.devcontainer/Dockerfile", "/ws/.devcontainer",
+        build_args={"VARIANT": "3.12"}, target="dev",
+    )
+    (argv,) = fake.calls
+    assert argv[:5] == ["docker", "build", "-t", "reyn-dc-abc:local", "-f"]
+    assert argv[5] == "/ws/.devcontainer/Dockerfile"
+    assert "--build-arg" in argv and "VARIANT=3.12" in argv
+    assert "--target" in argv and "dev" in argv
+    assert argv[-1] == "/ws/.devcontainer"  # context last
+
+
+def test_launch_builds_before_run(tmp_path) -> None:
+    """Tier 2: #1341 — a build config drives inspect(miss)→build→run, in order;
+    image is the content-addressed tag."""
+    df = tmp_path / "Dockerfile"
+    df.write_text("FROM python:3.12-slim\n")
+    spec = BuildSpec(dockerfile=str(df), context=str(tmp_path))
+    tag = _devcontainer_image_tag(spec)
+    cfg = LaunchConfig(workspace_root=str(tmp_path), image=tag, build=spec)
+    # inspect(miss=rc1) → build(ok) → run(ok, cid)
+    fake = _FakeRunner([_err(), _ok(), _ok(b"cid123\n")])
+    launcher = ContainerLauncher(runner=fake)
+    cid = launcher.launch(cfg)
+    assert cid == "cid123"
+    verbs = [c[1] for c in fake.calls]
+    assert verbs[:3] == ["image", "build", "run"]  # inspect → build → run
+    assert "-t" in fake.calls[1] and tag in fake.calls[1]
+
+
+def test_launch_skips_build_when_image_present(tmp_path) -> None:
+    """Tier 2: #1341 — inspect-hit → reuse (no build), straight to run (F2 cache)."""
+    spec = BuildSpec(dockerfile=str(tmp_path / "Dockerfile"), context=str(tmp_path))
+    cfg = LaunchConfig(workspace_root=str(tmp_path), image="reyn-dc-x:local", build=spec)
+    fake = _FakeRunner([_ok(), _ok(b"cid\n")])  # inspect(hit) → run
+    ContainerLauncher(runner=fake).launch(cfg)
+    verbs = [c[1] for c in fake.calls]
+    assert verbs == ["image", "run"]  # no build
+    assert all(c[1] != "build" for c in fake.calls)
+
+
+def test_launch_build_failure_raises(tmp_path) -> None:
+    """Tier 2: #1341 — a failed build surfaces as RuntimeError (no silent run)."""
+    spec = BuildSpec(dockerfile=str(tmp_path / "Dockerfile"), context=str(tmp_path))
+    cfg = LaunchConfig(workspace_root=str(tmp_path), image="reyn-dc-x:local", build=spec)
+    fake = _FakeRunner([_err(), _err(b"no such file")])  # inspect(miss) → build(fail)
+    with pytest.raises(RuntimeError, match="devcontainer image build failed"):
+        ContainerLauncher(runner=fake).launch(cfg)
+
+
+def test_ensure_image_reyn_base_still_builds(tmp_path) -> None:
+    """Tier 2: #1341 DRY-refactor regression — ensure_image(REYN_BASE_IMAGE) still
+    inspect-then-builds via the shared _docker_build."""
+    fake = _FakeRunner([_err(), _ok()])  # inspect(miss) → build(ok)
+    ContainerLauncher(runner=fake).ensure_image(REYN_BASE_IMAGE)
+    verbs = [c[1] for c in fake.calls]
+    assert verbs == ["image", "build"]
+    assert "-t" in fake.calls[1] and REYN_BASE_IMAGE in fake.calls[1]
+
+
+def test_ensure_image_noop_for_other_image(tmp_path) -> None:
+    """Tier 2: a non-base image is left to docker run to pull (ensure_image no-op)."""
+    fake = _FakeRunner([])
+    ContainerLauncher(runner=fake).ensure_image("python:3.12-slim")
+    assert fake.calls == []  # no inspect, no build

--- a/tests/test_devcontainer_build_e2e_1341.py
+++ b/tests/test_devcontainer_build_e2e_1341.py
@@ -1,0 +1,133 @@
+"""Tier 2c: #1341 build-based devcontainer — REAL docker build + launch.
+
+The unit tests (``test_devcontainer_build_1341``) pin the build ARGV + tag +
+inspect-then-build order against an injectable runner, but are blind to whether
+a real ``docker build`` actually produces a *working* image from the constructed
+argv — the same gap that hid the #1356→#1363 docker-exec argv bug (units green,
+real-daemon re-smoke caught it; lead pin: fake_backend_unit_misses_real_integration).
+This test closes it: a minimal build-based devcontainer is built on demand by the
+REAL ``ContainerLauncher`` and launched, and we assert the Dockerfile's RUN marker
+is present in the running container (proving the BUILT image — not the default —
+was used). Content-addressed rebuild-on-change is exercised against the daemon too.
+
+Skipped when no Docker daemon is reachable (CI-safe; runs on native Linux docker).
+Uses ``python:3.12-slim`` (fast public pull). Containers/images use unique tags
++ are always cleaned up in a finally (xdist-safe; no leaks).
+"""
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from reyn.environment.container_backend import DockerEnvironmentBackend
+from reyn.environment.container_launcher import (
+    BuildSpec,
+    ContainerLauncher,
+    LaunchConfig,
+    _devcontainer_image_tag,
+    load_devcontainer_config,
+)
+
+_DOCKER_AVAILABLE = DockerEnvironmentBackend(
+    container="_probe", repo_dir="/"
+).available()
+
+pytestmark = [
+    pytest.mark.docker,
+    pytest.mark.skipif(
+        not _DOCKER_AVAILABLE, reason="no reachable Docker daemon (docker info failed)"
+    ),
+]
+
+
+def _write_build_devcontainer(ws: Path, marker: str, *, extra_run: str = "") -> None:
+    """Write a workspace with a build-based devcontainer (minimal Dockerfile)."""
+    dc = ws / ".devcontainer"
+    dc.mkdir(parents=True, exist_ok=True)
+    (ws / ".reyn").mkdir(exist_ok=True)
+    body = (
+        "FROM python:3.12-slim\n"
+        f"RUN echo {marker} > /built_marker.txt\n"
+        f"{extra_run}"
+    )
+    (dc / "Dockerfile").write_text(body)
+    (dc / "devcontainer.json").write_text('{"build": {"dockerfile": "Dockerfile"}}')
+
+
+def _exec(container_id: str, *cmd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", "exec", container_id, *cmd],
+        capture_output=True, timeout=60, check=False,
+    )
+
+
+def _rmi(tag: str) -> None:
+    subprocess.run(["docker", "rmi", "-f", tag], capture_output=True,
+                   timeout=60, check=False)
+
+
+def test_build_based_devcontainer_builds_and_runs(tmp_path: Path) -> None:
+    """Tier 2c: #1341 — a build-based devcontainer is REALLY built + launched, and
+    the Dockerfile's RUN marker is present in the container (proves the built image
+    was used, end-to-end through the constructed `docker build` argv)."""
+    ws = tmp_path / "ws"
+    marker = f"built-{uuid.uuid4().hex[:8]}"
+    _write_build_devcontainer(ws, marker)
+
+    dc = load_devcontainer_config(str(ws))
+    assert dc is not None and dc.buildable
+    spec = BuildSpec(dockerfile=dc.dockerfile, context=dc.build_context,
+                     build_args=dc.build_args, target=dc.build_target)
+    tag = _devcontainer_image_tag(spec)
+    config = LaunchConfig(workspace_root=str(ws), image=tag, build=spec)
+
+    launcher = ContainerLauncher()
+    container_id = launcher.launch(config, timeout=600)
+    try:
+        # the built image carries the Dockerfile's RUN marker
+        res = _exec(container_id, "cat", "/built_marker.txt")
+        assert res.returncode == 0, res.stderr.decode(errors="replace")
+        assert res.stdout.decode().strip() == marker
+        # the content-addressed image tag actually exists locally
+        inspect = subprocess.run(
+            ["docker", "image", "inspect", tag],
+            capture_output=True, timeout=60, check=False,
+        )
+        assert inspect.returncode == 0
+    finally:
+        launcher.teardown(container_id)
+        _rmi(tag)
+
+
+def test_rebuild_on_dockerfile_change(tmp_path: Path) -> None:
+    """Tier 2c: #1341 — changing the Dockerfile yields a new content-addressed tag
+    and a freshly-built image (F2 rebuild-on-change), live against the daemon."""
+    ws = tmp_path / "ws"
+    m1 = f"v1-{uuid.uuid4().hex[:8]}"
+    _write_build_devcontainer(ws, m1)
+    dc = load_devcontainer_config(str(ws))
+    spec1 = BuildSpec(dockerfile=dc.dockerfile, context=dc.build_context)
+    tag1 = _devcontainer_image_tag(spec1)
+    launcher = ContainerLauncher()
+    cid1 = launcher.launch(LaunchConfig(workspace_root=str(ws), image=tag1, build=spec1), timeout=600)
+    try:
+        assert _exec(cid1, "cat", "/built_marker.txt").stdout.decode().strip() == m1
+    finally:
+        launcher.teardown(cid1)
+
+    # change the Dockerfile → new tag → rebuild
+    m2 = f"v2-{uuid.uuid4().hex[:8]}"
+    _write_build_devcontainer(ws, m2)
+    spec2 = BuildSpec(dockerfile=dc.dockerfile, context=dc.build_context)
+    tag2 = _devcontainer_image_tag(spec2)
+    assert tag2 != tag1, "changed Dockerfile must yield a new content-addressed tag"
+    cid2 = launcher.launch(LaunchConfig(workspace_root=str(ws), image=tag2, build=spec2), timeout=600)
+    try:
+        assert _exec(cid2, "cat", "/built_marker.txt").stdout.decode().strip() == m2
+    finally:
+        launcher.teardown(cid2)
+        _rmi(tag1)
+        _rmi(tag2)

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -255,9 +255,10 @@ def test_docker_launch_cli_image_overrides_devcontainer(tmp_path, monkeypatch) -
     assert cfg.image == "cli:override"
 
 
-def test_docker_launch_build_based_devcontainer_warns(tmp_path, monkeypatch, capsys) -> None:
-    """Tier 2: #1324b — a build-based devcontainer warns + falls back to the default
-    image (build-based support is a tracked follow-up)."""
+def test_docker_launch_build_based_devcontainer_builds(tmp_path, monkeypatch, capsys) -> None:
+    """Tier 2: #1341 — a build-based (dockerFile/build) devcontainer is BUILT on
+    demand: the LaunchConfig carries a BuildSpec + a content-addressed image tag
+    (no warn, no default-image fallback). Supersedes the #1324b warn behavior."""
     from reyn.environment.container_launcher import DEFAULT_IMAGE
 
     _write_devcontainer(tmp_path, '{"build": {"dockerfile": "Dockerfile"}}')
@@ -265,5 +266,34 @@ def test_docker_launch_build_based_devcontainer_warns(tmp_path, monkeypatch, cap
     fake = _FakeLauncher()
     _build_environment_backend(_args(env_backend="docker"), launcher=fake)
     (cfg,) = fake.launched
+    assert cfg.build is not None, "build-based devcontainer must carry a BuildSpec"
+    assert cfg.image.startswith("reyn-dc-") and cfg.image != DEFAULT_IMAGE
+    assert cfg.build.dockerfile.endswith("Dockerfile")
+    assert "not yet supported" not in capsys.readouterr().err
+
+
+def test_docker_launch_compose_devcontainer_warns(tmp_path, monkeypatch, capsys) -> None:
+    """Tier 2: #1341 — a compose-based devcontainer (dockerComposeFile) is OUT of
+    scope for the single-container launcher → warn + default-image fallback."""
+    from reyn.environment.container_launcher import DEFAULT_IMAGE
+
+    _write_devcontainer(tmp_path, '{"dockerComposeFile": "docker-compose.yml"}')
+    monkeypatch.chdir(tmp_path)
+    fake = _FakeLauncher()
+    _build_environment_backend(_args(env_backend="docker"), launcher=fake)
+    (cfg,) = fake.launched
+    assert cfg.build is None
     assert cfg.image == DEFAULT_IMAGE
-    assert "build-based devcontainer" in capsys.readouterr().err
+    assert "compose-based devcontainer" in capsys.readouterr().err
+
+
+def test_docker_launch_cli_image_overrides_build_devcontainer(tmp_path, monkeypatch) -> None:
+    """Tier 2: #1341 — an explicit --image wins over a build-based devcontainer
+    (no build; the operator's image is used as-is)."""
+    _write_devcontainer(tmp_path, '{"build": {"dockerfile": "Dockerfile"}}')
+    monkeypatch.chdir(tmp_path)
+    fake = _FakeLauncher()
+    _build_environment_backend(_args(env_backend="docker", image="my/img:tag"), launcher=fake)
+    (cfg,) = fake.launched
+    assert cfg.build is None
+    assert cfg.image == "my/img:tag"


### PR DESCRIPTION
**[dogfood-coder]** — #1341 build-based devcontainer support (#1324 follow-up b). Design-first, lead-reviewed (forks F1/F2/F3 confirmed) before impl.

## Problem
A build-based devcontainer (`dockerFile` / `build`) was flagged and fell back to the default image with "not yet supported". This PR builds the Dockerfile on demand and launches the result — completing industry-standard devcontainer alignment.

## Design (confirmed forks)
- **F1 launch-internal build** — the launcher owns image lifecycle (`ensure_image`-symmetric, injectable-runner testable). `LaunchConfig.build: BuildSpec | None`; `launch()` builds (inspect-then-build) when set, else `ensure_image`.
- **F2 content-addressed tag** — `reyn-dc-<sha8(Dockerfile + build_args + target)>:local`. Changed inputs → new tag → inspect-miss → rebuild; unchanged → reuse (no separate rebuild policy). Context-only edits keep the tag (documented minor limit; matches VS Code's Dockerfile/args-driven rebuild).
- **F3 compose out of scope** — `dockerComposeFile` (multi-service) → warn + default-image fallback (single-container launcher).

`build.args` / `build.context` honored; explicit `--image` overrides; paths resolve relative to the devcontainer.json dir (spec). `_docker_build` is a shared primitive (`ensure_image` refactored onto it, DRY).

## Security boundary (documented)
`docker build` runs the **workspace-authored** Dockerfile's `RUN` steps on the host docker daemon at **build time** — NOT inside reyn's runtime sandbox (network-off / non-root / read-only-rootfs apply to `docker run`, not `docker build`; builds need network). Trust model = identical to VS Code "Reopen in Container". The runtime container still gets all reyn flags. Documented in: code docstring (`_build_devcontainer_image`), user doc (`configure-sandbox.md` + `.ja.md`, with a warning admonition), and a build-time stderr log for transparency. `--env-backend=docker` is the opt-in (no extra confirmation prompt — per lead).

## Test plan
- [x] `tests/test_devcontainer_build_1341.py` (new, 12 tests) — `_map_devcontainer` build-spec extraction (object `build` + legacy `dockerFile`); compose = build_based but non-buildable; path resolution; content-addressed tag (deterministic + changes on content/args/target); `_docker_build` argv; `launch()` inspect→build→run order; build-skip-when-present; build-failure → RuntimeError; `ensure_image` DRY-refactor regression.
- [x] `tests/test_run_container_backend_flags_1115.py` (updated) — build-based **builds** (BuildSpec + tag, supersedes the old warn); compose **warns** + fallback; CLI `--image` overrides build.
- [x] `pytest -k "container or mount or devcontainer or env_backend or 1324 or 1332"` — 110 passed / 7 docker-skipped / 0 fail.
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` clean (12/12 OK).
- [x] live-docker e2e (`tests/test_devcontainer_build_e2e_1341.py`, #1332 skip-if-no-docker pattern) — REAL `docker build` + launch: the Dockerfile RUN marker is present in the running container (built image used end-to-end) + rebuild-on-change yields a new content tag. **2 passed in 26.64s** (Docker 29.2.1). Closes the fake_backend_unit_misses_real_integration gate.

Refs #1341, #1324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)