### PR TITLE
fix(1417): exec D14 visibility gate keys off injected backend, not config string

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -210,6 +210,28 @@ _TOOL_FAILED_FALLBACK_MSG: dict[str, str] = {
 }
 
 
+def _exec_gate_backend_name(sandbox_backend: Any, sandbox_config: Any) -> str | None:
+    """#1417: resolve the ``exec`` D14 visibility-gate backend name.
+
+    The ``exec`` category is gated on the ACTUAL exec backend, not the reyn.yaml
+    config string. When a sandbox backend INSTANCE is injected (e.g.
+    ``--env-backend=docker`` → ``DockerEnvironmentBackend.name == "docker"``),
+    its ``.name`` is the gate value — so ``exec`` stays discoverable even with a
+    ``sandbox.backend = noop`` config (the construction-forwarding-gap: the
+    config string is NOT the live injected instance, and the instance is what
+    actually executes via ``sandboxed_exec``). With no injected instance, fall
+    back to the config string (``auto`` / host-default behaviour unchanged).
+
+    A defensive ``getattr`` keeps an instance without a ``name`` from raising
+    (degrades to None → exec hidden, the safe direction).
+    """
+    if sandbox_backend is not None:
+        return getattr(sandbox_backend, "name", None)
+    if sandbox_config is not None:
+        return sandbox_config.backend
+    return None
+
+
 class RouterCapExceeded(Exception):
     """Raised when a user turn (or top-level agent_request) drives more
     skill_router invocations than the configured cap. Caught by handlers,
@@ -1827,10 +1849,20 @@ class ChatSession:
             ),
             action_retrieval_config=self._action_retrieval,
             # FP-0034 Phase 2: sandbox backend for exec D14 visibility gate.
-            # None when sandbox_config is None (= noop assumed).
-            sandbox_backend=(
-                self._sandbox_config.backend if self._sandbox_config is not None
-                else None
+            # #1417: gate on the INJECTED backend's real capability, not the
+            # reyn.yaml config STRING. The exec capability comes from the
+            # injected ``self._sandbox_backend`` instance (the SAME object used
+            # for actual exec at line 1847 / sandboxed_exec.py: ``ctx.sandbox_
+            # backend or get_default_backend(...)``); both injected types expose
+            # ``.name`` (DockerEnvironmentBackend.name="docker" / SandboxBackend
+            # .name). Without this, ``sandbox.backend=noop`` config + an injected
+            # exec backend (``--env-backend=docker``) would HIDE exec from
+            # discovery even though sandboxed_exec is functionally available
+            # (the construction-forwarding-gap: config string ≠ live instance).
+            # No injected instance → fall back to the config string (auto /
+            # host-default behaviour unchanged).
+            sandbox_backend=_exec_gate_backend_name(
+                self._sandbox_backend, self._sandbox_config
             ),
             # #187: the FS env-backend instance + container repo root + host-side
             # state dir for the LIVE router OpContext Workspace (the registry

--- a/tests/test_exec_gate_injected_backend_1417.py
+++ b/tests/test_exec_gate_injected_backend_1417.py
@@ -1,0 +1,114 @@
+"""Tier 2: #1417 — the exec D14 visibility gate keys off the INJECTED sandbox
+backend instance, not the reyn.yaml config string.
+
+Construction-forwarding-gap fix: ``sandbox.backend=noop`` config + an injected
+exec backend (``--env-backend=docker``) must still expose ``exec`` in
+``list_actions(category=["exec"])`` because ``sandboxed_exec`` is functionally
+available via the injected instance. Pins ``_exec_gate_backend_name`` (the
+derivation) + ``visible_categories`` (the gate consuming it).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from reyn.chat.session import _exec_gate_backend_name
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import (
+    _enumerate_category,
+    is_exec_available,
+    visible_categories,
+)
+
+
+def _router_ctx(sandbox_backend: str | None) -> ToolContext:
+    """A minimal router ToolContext carrying the exec D14 gate value (the value
+    session threads via _exec_gate_backend_name → RouterCallerState.sandbox_backend)."""
+    return ToolContext(
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(sandbox_backend=sandbox_backend),
+    )
+
+
+@dataclass
+class _FakeBackend:
+    """A sandbox/env backend instance exposing ``.name`` (like DockerEnvironment
+    Backend.name='docker' / SandboxBackend.name='noop'|'seatbelt'|...)."""
+
+    name: str
+
+
+@dataclass
+class _FakeSandboxConfig:
+    backend: str
+
+
+# ─── _exec_gate_backend_name: instance precedence over config string ──────────
+
+
+def test_injected_instance_wins_over_noop_config() -> None:
+    """Tier 2: #1417 — an injected docker backend + noop config → gate sees the
+    instance ('docker'), not the config string ('noop'). The filed bug."""
+    val = _exec_gate_backend_name(_FakeBackend(name="docker"), _FakeSandboxConfig(backend="noop"))
+    assert val == "docker"
+    assert is_exec_available(sandbox_backend=val) is True
+    assert "exec" in visible_categories(sandbox_backend=val)
+
+
+def test_injected_noop_instance_hidden() -> None:
+    """Tier 2: #1417 — an injected noop backend → 'noop' → exec hidden, even if
+    the config string says otherwise (instance is the truth)."""
+    val = _exec_gate_backend_name(_FakeBackend(name="noop"), _FakeSandboxConfig(backend="docker"))
+    assert val == "noop"
+    assert is_exec_available(sandbox_backend=val) is False
+    assert "exec" not in visible_categories(sandbox_backend=val)
+
+
+def test_no_instance_falls_back_to_config() -> None:
+    """Tier 2: #1417 — no injected instance → config string (auto/host-default
+    behaviour unchanged)."""
+    assert _exec_gate_backend_name(None, _FakeSandboxConfig(backend="docker")) == "docker"
+    assert _exec_gate_backend_name(None, _FakeSandboxConfig(backend="noop")) == "noop"
+    assert _exec_gate_backend_name(None, _FakeSandboxConfig(backend="auto")) == "auto"
+    assert _exec_gate_backend_name(None, None) is None
+
+
+def test_no_instance_noop_config_hidden_and_auto_visible() -> None:
+    """Tier 2: #1417 — config-only path: noop hidden, auto visible (unchanged)."""
+    noop_val = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="noop"))
+    auto_val = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="auto"))
+    assert "exec" not in visible_categories(sandbox_backend=noop_val)
+    assert "exec" in visible_categories(sandbox_backend=auto_val)
+
+
+def test_instance_without_name_degrades_to_hidden() -> None:
+    """Tier 2: #1417 — a defensive: an injected instance lacking ``.name`` →
+    None → exec hidden (the safe direction), never an AttributeError."""
+    class _NoName:
+        pass
+
+    val = _exec_gate_backend_name(_NoName(), _FakeSandboxConfig(backend="noop"))
+    assert val is None
+    assert is_exec_available(sandbox_backend=val) is False
+
+
+# ─── integration: the real list_actions exec-gate handler honors the value ────
+
+
+def test_enumerate_exec_visible_with_docker_gate() -> None:
+    """Tier 2: #1417 — the real `_enumerate_category('exec', ...)` handler returns
+    exec__sandboxed_exec when the threaded gate value is a real backend ('docker',
+    the value _exec_gate_backend_name derives from an injected docker instance even
+    under noop config). Exercises the actual list_actions exec-gate path."""
+    gate = _exec_gate_backend_name(_FakeBackend(name="docker"), _FakeSandboxConfig(backend="noop"))
+    actions = _enumerate_category("exec", _router_ctx(gate))
+    assert [a["qualified_name"] for a in actions] == ["exec__sandboxed_exec"]
+
+
+def test_enumerate_exec_hidden_with_noop_gate() -> None:
+    """Tier 2: #1417 — the handler returns [] (exec hidden) when the gate is noop
+    (no injected instance + noop config)."""
+    gate = _exec_gate_backend_name(None, _FakeSandboxConfig(backend="noop"))
+    assert _enumerate_category("exec", _router_ctx(gate)) == []


### PR DESCRIPTION
**[dogfood-coder]** — #1417 exec D14 visibility gate: config-string → injected-backend. Design-first, lead-reviewed (F-min confirmed). Construction-forwarding-gap class (#1402 family — same shape as base_dir #1410/#1411, permission-zone #1415 B3, phase_executor #1424).

## Problem
The `exec` D14 gate (`is_exec_available`, `universal_catalog.py:183`, `!= "noop"`) was fed the reyn.yaml **config string** (`session.py`), but the real exec capability comes from the **injected** `self._sandbox_backend` instance (`--env-backend=docker`, used at `sandboxed_exec.py:30` = `ctx.sandbox_backend or get_default_backend(...)`). So `sandbox.backend=noop` config **+** an injected docker backend would **hide** `exec` from `list_actions(category=["exec"])` even though `sandboxed_exec` is functionally available — undiscoverable.

## Fix (F-min, lead-confirmed)
New `_exec_gate_backend_name(instance, config)`: gate value = the injected instance's `.name` when present (both types expose it — `DockerEnvironmentBackend.name="docker"` / `SandboxBackend.name`), else the config string. `session.py:1832` threads it. `is_exec_available` + the 4-layer string threading (the single source → `RouterCallerState.sandbox_backend` → the `_enumerate_category("exec")` handler) are **unchanged**.
- noop config + docker instance → `"docker"` → exec **visible** (fixes the bug)
- noop config + no instance → `"noop"` → hidden; auto / host-default → unchanged

**F-resolved** (gate==exec-resolution full single-source incl `get_default_backend` platform fallback) is an independent enhancement beyond the filed bug → follow-up note (not this PR).

## Test plan
- [x] `tests/test_exec_gate_injected_backend_1417.py` — 5 unit (instance precedence over noop config / injected-noop hidden / no-instance config fallback / auto unchanged / no-`.name` defensive→hidden) + 2 **handler-integration** (the REAL `_enumerate_category("exec")` path returns `exec__sandboxed_exec` for a docker gate, `[]` for noop — exercises the actual list_actions exec-gate consuming `RouterCallerState.sandbox_backend`).
- [x] `ruff` + `scripts/test_tier_audit.py --strict` clean.
- [x] 194 catalog / exec / backend-injection-threading regression passed.
- [ ] (assessment — your call) live-docker full-run: I argue it's **marginal for #1417** vs #1341. #1341's gate guarded a real `docker build` argv that could fail on the daemon; #1417 is **daemon-independent derivation logic** (an injected instance's `.name="docker"` is identical with/without a live daemon). The real integration risk = the value reaching the handler, now covered by the **handler-integration tests** (real `_enumerate_category`) + code-read single-source threading (`session→adapter:325→get_sandbox_backend:572→RouterCallerState→handler:606`). I have local docker and will add a literal live `list_actions(category=["exec"])` run under noop-config+`--env-backend=docker` if you want it — flagging the cost/value rather than silently skipping.

Refs #1417, #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)