### PR TITLE
fix(1431): root dogfood chat workspace on the container repo (#187 wrong-FS class)

### DIFF
--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -309,7 +309,13 @@ def run_run(args: argparse.Namespace) -> None:
     if _env_cleanup is not None:
         import atexit
         atexit.register(_env_cleanup)
-    live_runner_fn = _build_live_runner(args.agent, env_backend=_env_backend)
+    # #1431: thread the env-backend's PARTNER container repo root (_wb) + host-side
+    # state dir (_ws) so dogfood's chat file ops root on the CONTAINER repo (e.g.
+    # /testbed), not the host cwd — the #187 wrong-FS class (#1410 base_dir sibling),
+    # surfaced by the #1402 migration making the dropped workspace dirs explicit.
+    live_runner_fn = _build_live_runner(
+        args.agent, env_backend=_env_backend, ws_base_dir=_wb, ws_state_dir=_ws,
+    )
 
     try:
         from reyn.dogfood.runner import run_scenario_set
@@ -352,7 +358,7 @@ def run_run(args: argparse.Namespace) -> None:
     print(f"  results → {run_dir / 'summary.json'}")
 
 
-def _build_live_runner(agent_name: str, *, env_backend=None):
+def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, ws_state_dir=None):
     """Return an async runner_fn that drives the chat router via send_to_agent_impl.
 
     Reuses the same path as MCP / web A2A: build a minimal AgentRegistry +
@@ -462,20 +468,19 @@ def _build_live_runner(agent_name: str, *, env_backend=None):
                 environment_backend=env_backend,
                 sandbox_backend=env_backend,
                 # #1402: scoped surface passed EXPLICITLY (required by
-                # build_scoped_chat_session). These are dogfood's current
-                # behaviour (behavior-preserving). ★ NOTE the workspace-rooting
-                # gap: dogfood roots env_backend but passes workspace_base_dir=
-                # None — so chat file ops root on host cwd, not the container
-                # repo (the #187 wrong-FS class chat.py fixes via ws_base_dir).
-                # _wb/_ws ARE available here (build_environment_backend) → a
-                # 1-line follow-up can fill them; preserved as None for now.
+                # build_scoped_chat_session).
+                # #1431: workspace rooted on the CONTAINER repo via the
+                # env-backend's _wb/_ws (threaded through _build_live_runner) —
+                # fixes the #187 wrong-FS class (file ops were rooting on host
+                # cwd while env_backend pointed at the container). chat.py uses
+                # the same ws_base_dir/ws_state_dir pattern.
                 embedding_config=None,  # gap: dogfood omitted embedding_config (had action_retrieval but not its sibling) → preserved as None
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,
                 router_max_iterations=5,
-                workspace_base_dir=None,  # gap: not rooted on the container repo (see note)
-                workspace_state_dir=None,
+                workspace_base_dir=ws_base_dir,
+                workspace_state_dir=ws_state_dir,
             )
             s.load_history()
             return s

--- a/tests/test_dogfood_workspace_rooting_1431.py
+++ b/tests/test_dogfood_workspace_rooting_1431.py
@@ -1,0 +1,83 @@
+"""Tier 2: #1431 — dogfood roots the chat workspace on the container repo.
+
+dogfood builds an EnvironmentBackend (DockerEnvironmentBackend for a container
+agent) and threads it to the chat session as ``environment_backend`` — but it
+passed ``workspace_base_dir=None``, so chat file ops (file__read/grep/glob/edit)
+rooted on the HOST cwd while the exec/diff seam pointed at the container repo.
+That FS disagreement is the #187 wrong-FS class (#1410 base_dir sibling); the
+#1402 single-source migration made the dropped workspace dirs explicit and
+visible. Fix: thread the env-backend's PARTNER container repo root (``_wb``) +
+host-side state dir (``_ws``) from the CLI entry through ``_build_live_runner``
+into the session construction.
+
+This is a construction-wiring invariant (the fix is a thread, and the downstream
+workspace_base_dir -> OpContext FS root is already covered by the chat.py path).
+Falsifiable: revert any link of the thread → this fails, naming the gap.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_DOGFOOD = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "reyn" / "cli" / "commands" / "dogfood.py"
+)
+
+
+def _tree() -> ast.AST:
+    return ast.parse(_DOGFOOD.read_text(encoding="utf-8"))
+
+
+def _kw_value(call: ast.Call, name: str) -> ast.AST | None:
+    for k in call.keywords:
+        if k.arg == name:
+            return k.value
+    return None
+
+
+def test_factory_threads_workspace_dirs_not_none() -> None:
+    """Tier 2: #1431 — dogfood's build_scoped_chat_session call passes
+    workspace_base_dir / workspace_state_dir as the threaded ws_base_dir /
+    ws_state_dir names, NOT ``None`` (which rooted file ops on the host cwd =
+    the #187 wrong-FS bug)."""
+    calls = [
+        n for n in ast.walk(_tree())
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "build_scoped_chat_session"
+    ]
+    assert calls, "no build_scoped_chat_session(...) call in dogfood.py"
+    call = calls[0]
+    base = _kw_value(call, "workspace_base_dir")
+    state = _kw_value(call, "workspace_state_dir")
+    assert isinstance(base, ast.Name) and base.id == "ws_base_dir", (
+        "dogfood must pass workspace_base_dir=ws_base_dir (the container repo "
+        "root), not None — else chat file ops root on the host cwd (#187 wrong-FS)"
+    )
+    assert isinstance(state, ast.Name) and state.id == "ws_state_dir"
+
+
+def test_cli_passes_env_backend_workspace_dirs_to_runner() -> None:
+    """Tier 2: #1431 — the dogfood CLI entry threads the env-backend's _wb/_ws
+    into _build_live_runner (so the session factory closure can root the
+    workspace on the container repo). Pins the full thread, not just the leaf."""
+    runner_calls = [
+        n for n in ast.walk(_tree())
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "_build_live_runner"
+    ]
+    assert runner_calls, "no _build_live_runner(...) call in dogfood.py"
+    # At least one call threads both ws_base_dir and ws_state_dir from _wb/_ws.
+    def _threads(c: ast.Call) -> bool:
+        wb = _kw_value(c, "ws_base_dir")
+        ws = _kw_value(c, "ws_state_dir")
+        return (
+            isinstance(wb, ast.Name) and wb.id == "_wb"
+            and isinstance(ws, ast.Name) and ws.id == "_ws"
+        )
+    assert any(_threads(c) for c in runner_calls), (
+        "the dogfood CLI must call _build_live_runner(..., ws_base_dir=_wb, "
+        "ws_state_dir=_ws) so the workspace is rooted on the container repo"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1431 item 1: dogfood roots the chat workspace on the container repo.

## Bug (surfaced by #1402)

dogfood builds an `EnvironmentBackend` (Docker for a container agent) and threads it to the chat session as `environment_backend` — but passed `workspace_base_dir=None`, so chat file ops (`file__read/grep/glob/edit`) rooted on the **host cwd** while the exec/diff seam pointed at the **container repo**. That FS disagreement is the **#187 wrong-FS class** (#1410 base_dir sibling).

The #1402 single-source migration **surfaced** it: making the dropped workspace dirs explicit (`workspace_base_dir=None`) exposed the gap by construction.

## Fix

Thread the env-backend's PARTNER container repo root (`_wb`) + host-side state dir (`_ws`) — already computed by `build_environment_backend` at the CLI entry — through `_build_live_runner` into the session construction, mirroring the `chat.py` `ws_base_dir`/`ws_state_dir` pattern. **Behavior-change**: dogfood chat file ops now root on the container repo (e.g. `/testbed`).

## Test plan

- [x] `tests/test_dogfood_workspace_rooting_1431.py` — construction-wiring invariant for the full thread (CLI → `_build_live_runner` → factory; falsifiable — revert any link → fails).
- [x] dogfood tests (169) pass; `pytest -q` full suite — 2 pre-existing unrelated failures only (swebench env / web_fetch BeautifulSoup), zero new breakage.
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` clean.

Refs #1431 (item 1 of the #1402-surfaced gaps; A2A/mcp/chainlit env-backend + per-profile-MCP-gating remain capability-decision follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)