### PR TITLE
fix(1414): anchor default file-zone on workspace_base_dir under container backend

### DIFF
--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -182,6 +182,11 @@ class Agent:
         permission_resolver = PermissionResolver(
             config_permissions=perm_config,
             project_root=_find_project_root(Path.cwd()),
+            # #1414: under a container backend the file zone anchors on the
+            # in-container repo (workspace_base_dir = base_dir, #1410/#1411),
+            # while approvals stay host-side. None (host) → defaults to
+            # project_root (byte-identical).
+            file_zone_root=workspace_base_dir,
             interactive=sys.stdin.isatty() if interactive is None else interactive,
             unsafe_python_allowed=unsafe_python,
         )

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -346,14 +346,9 @@ def run(args: argparse.Namespace) -> None:
     _exclude_tools = frozenset(
         t.strip() for t in (getattr(args, "exclude_tools", None) or "").split(",") if t.strip()
     )
-    # Single PermissionResolver shared across agents (per the PR10 decision:
-    # `.reyn/approvals.yaml` is process-wide).
-    perm_resolver = PermissionResolver(
-        config_permissions=perm_config,
-        project_root=project_root,
-        interactive=sys.stdin.isatty(),
-        unsafe_python_allowed=unsafe_python,
-    )
+    # #1414: the single PermissionResolver is constructed BELOW, after
+    # build_environment_backend, because it needs ``ws_base_dir`` for the
+    # container file-zone anchor (file_zone_root). It isn't used before then.
 
     project_context = load_project_context(session_cfg.config, project_root)
 
@@ -365,6 +360,21 @@ def run(args: argparse.Namespace) -> None:
     if env_cleanup is not None:
         import atexit
         atexit.register(env_cleanup)
+
+    # Single PermissionResolver shared across agents (per the PR10 decision:
+    # `.reyn/approvals.yaml` is process-wide). #1414: the default file
+    # read/write zone anchors on ``ws_base_dir`` (the container repo root under a
+    # container backend) so a non-grant write into the container repo's own
+    # `.reyn`/`reyn` default zone is permitted; approvals.yaml stays host-side
+    # (``project_root``). ws_base_dir is None for a host backend → file_zone_root
+    # defaults to project_root (host / interactive byte-identical).
+    perm_resolver = PermissionResolver(
+        config_permissions=perm_config,
+        project_root=project_root,
+        file_zone_root=ws_base_dir,
+        interactive=sys.stdin.isatty(),
+        unsafe_python_allowed=unsafe_python,
+    )
 
     def _session_factory(profile: AgentProfile):
         # Captured CLI defaults — registry doesn't need to know them.

--- a/src/reyn/permissions/effective.py
+++ b/src/reyn/permissions/effective.py
@@ -100,15 +100,17 @@ class AgentLayer:
         decl: "PermissionDecl",
         *,
         approval_check: "Any" = None,
-        project_root: "Any" = None,
+        file_zone_root: "Any" = None,
     ) -> None:
         self._decl = decl
         self._approval_check = approval_check
-        # #1316: the project root the default zones are anchored to. None →
-        # Path.cwd() inside the zone fns (historical). Passing the resolver's
-        # _project_root makes the zone base match the approvals base (so a
-        # project_root ≠ cwd does not diverge zone vs approval evaluation).
-        self._project_root = project_root
+        # #1316/#1414: the root the default file zones are anchored to. None →
+        # Path.cwd() inside the zone fns (historical). This is the FILE-ZONE
+        # root only — under a container backend (#1414) it is the in-container
+        # repo root (workspace_base_dir), which may DIVERGE from the host-side
+        # approvals base (the resolver passes ``_file_zone_root``, defaulting to
+        # the host ``_project_root`` so host/interactive stays byte-identical).
+        self._file_zone_root = file_zone_root
 
     def _approved(self, axis: CapabilityAxis, value: Any) -> bool:
         return bool(self._approval_check and self._approval_check(axis, value))
@@ -118,13 +120,13 @@ class AgentLayer:
         if axis is CapabilityAxis.FILE_READ:
             # #1199 S3.1c-1: decl-less — zone OR approved (no decl auto-grant).
             return (
-                _in_default_read_zone(str(value), self._project_root)
+                _in_default_read_zone(str(value), self._file_zone_root)
                 or self._approved(axis, value)
             )
         if axis is CapabilityAxis.FILE_WRITE:
             # #1199 S3.1c-1: decl-less — zone OR approved (no decl auto-grant).
             return (
-                _in_default_write_zone(str(value), self._project_root)
+                _in_default_write_zone(str(value), self._file_zone_root)
                 or self._approved(axis, value)
             )
         if axis is CapabilityAxis.NETWORK_HOST:
@@ -260,14 +262,15 @@ class EffectivePermission:
         sandbox_policy: "SandboxPolicy | None" = None,
         profile: "AgentProfile | None" = None,
         approval_check: "Any" = None,
-        project_root: "Any" = None,
+        file_zone_root: "Any" = None,
     ) -> "EffectivePermission":
         """Build from the inputs (zone + approvals folded into the agent
         layer; ② grant-back-safe). Build per op-context (Q3).
 
-        #1316: ``project_root`` anchors the default zones (None → cwd)."""
+        #1316/#1414: ``file_zone_root`` anchors the default file zones (None →
+        cwd). Distinct from the host approvals base under a container backend."""
         return cls([
-            AgentLayer(decl, approval_check=approval_check, project_root=project_root),
+            AgentLayer(decl, approval_check=approval_check, file_zone_root=file_zone_root),
             SandboxLayer(sandbox_policy),
             ProfileLayer(profile),
         ])

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -369,9 +369,21 @@ class PermissionResolver:
         # FP-0014 compat: accept the legacy keyword name during the Track A → B
         # transition. New callers should use `unsafe_python_allowed`.
         trusted_python_allowed: bool | None = None,
+        # #1414: the default file read/write ZONE anchor. Distinct from
+        # ``project_root`` (= the host-side approvals/config base). Under a
+        # container backend the agent's file ops target the in-container repo
+        # (base_dir=/testbed, #1410/#1411), so the zone must anchor there while
+        # approvals.yaml stays host-side. ``None`` → defaults to ``project_root``
+        # so host / interactive behaviour is byte-identical.
+        file_zone_root: Path | None = None,
     ) -> None:
         self._config = config_permissions or {}
         self._project_root = (project_root or Path.cwd()).resolve()
+        # #1414: zone anchor (container repo root under a container backend);
+        # falls back to the host project_root (host-default byte-identical).
+        self._file_zone_root = (
+            Path(file_zone_root).resolve() if file_zone_root else self._project_root
+        )
         self._interactive = interactive
         self._approvals_path = self._project_root / ".reyn" / "approvals.yaml"
         self._session: dict[str, bool] = {}
@@ -783,7 +795,7 @@ class PermissionResolver:
             scope = entry.get("scope", "just_path")
             if not path:
                 continue
-            if _in_default_write_zone(path, self._project_root):
+            if _in_default_write_zone(path, self._file_zone_root):  # #1414
                 continue
             if self._is_config_approved("file.write"):
                 continue
@@ -799,7 +811,7 @@ class PermissionResolver:
             scope = entry.get("scope", "just_path")
             if not path:
                 continue
-            if _in_default_read_zone(path, self._project_root):
+            if _in_default_read_zone(path, self._file_zone_root):  # #1414
                 continue
             if self._is_config_approved("file.read"):
                 continue
@@ -1023,7 +1035,7 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved, project_root=self._project_root),
+            AgentLayer(decl, approval_check=_approved, file_zone_root=self._file_zone_root),  # #1414
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_READ, path):
             return
@@ -1075,7 +1087,7 @@ class PermissionResolver:
             )
 
         if EffectivePermission([
-            AgentLayer(decl, approval_check=_approved, project_root=self._project_root),
+            AgentLayer(decl, approval_check=_approved, file_zone_root=self._file_zone_root),  # #1414
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_WRITE, path):
             return
@@ -1341,7 +1353,7 @@ class PermissionResolver:
 
         return EffectivePermission([
             AgentLayer(PermissionDecl(), approval_check=_approved,
-                       project_root=self._project_root)
+                       file_zone_root=self._file_zone_root)  # #1414
         ]).allows(CapabilityAxis.FILE_READ, path)
 
     def is_write_allowed(self, path: str, skill_name: str = "") -> bool:
@@ -1371,7 +1383,7 @@ class PermissionResolver:
 
         return EffectivePermission([
             AgentLayer(PermissionDecl(), approval_check=_approved,
-                       project_root=self._project_root)
+                       file_zone_root=self._file_zone_root)  # #1414
         ]).allows(CapabilityAxis.FILE_WRITE, path)
 
     async def require_mcp(

--- a/tests/test_permission_file_zone_anchor_1414.py
+++ b/tests/test_permission_file_zone_anchor_1414.py
@@ -1,0 +1,69 @@
+"""Tier 2: #1414 — the default file read/write ZONE anchors on file_zone_root
+(container repo root under a container backend), distinct from the host-side
+approvals/config base (project_root).
+
+Permission-layer parallel of the #1410 base_dir(container)-vs-state_dir(host)
+split: a non-grant container run can write into the container repo's own
+`.reyn`/`reyn` default zone while approvals.yaml stays host-side. Host /
+interactive behaviour is byte-identical (file_zone_root defaults to project_root).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.permissions import PermissionDecl
+from reyn.permissions.effective import (
+    AgentLayer,
+    CapabilityAxis,
+    EffectivePermission,
+)
+from reyn.permissions.permissions import PermissionResolver
+
+_HOST = Path("/host/proj")
+_CONTAINER = Path("/testbed")
+
+
+# ─── PermissionResolver: zone anchors on file_zone_root, approvals on project_root ──
+
+
+def test_container_file_zone_allows_container_reyn_write() -> None:
+    """Tier 2: #1414 — file_zone_root=/testbed lets a non-grant run write into
+    /testbed/.reyn (the container default zone). (The approvals/config base stays
+    host-side by construction — anchored on project_root, untouched by the fix.)"""
+    r = PermissionResolver({}, project_root=_HOST, file_zone_root=_CONTAINER)
+    assert r.is_write_allowed("/testbed/.reyn/scratch.txt") is True
+    assert r.is_read_allowed("/testbed/src/mod.py") is True  # read zone = whole repo
+
+
+def test_host_default_zone_unchanged() -> None:
+    """Tier 2: #1414 — no file_zone_root → the zone behaves exactly as before
+    (anchored on project_root): host/.reyn writeable, a /testbed path is NOT in
+    the host zone (public-behaviour parity, no private-state assert)."""
+    r = PermissionResolver({}, project_root=_HOST)  # no file_zone_root
+    assert r.is_write_allowed("/host/proj/.reyn/scratch.txt") is True
+    assert r.is_write_allowed("/testbed/.reyn/scratch.txt") is False  # outside host zone
+
+
+def test_container_does_not_widen_host_zone() -> None:
+    """Tier 2: #1414 — with a container file_zone_root, a HOST-side .reyn write is
+    NOT in the (container) zone (the zone moved, it didn't union)."""
+    r = PermissionResolver({}, project_root=_HOST, file_zone_root=_CONTAINER)
+    assert r.is_write_allowed("/host/proj/.reyn/scratch.txt") is False
+
+
+# ─── AgentLayer / EffectivePermission.of consume file_zone_root ───────────────
+
+
+def test_agent_layer_file_zone_root() -> None:
+    """Tier 2: #1414 — AgentLayer's zone uses file_zone_root (renamed from
+    project_root; it was only ever the zone base)."""
+    layer = AgentLayer(PermissionDecl(), file_zone_root=_CONTAINER)
+    assert layer.allows(CapabilityAxis.FILE_WRITE, "/testbed/.reyn/x") is True
+    assert layer.allows(CapabilityAxis.FILE_READ, "/testbed/src/x.py") is True
+    assert layer.allows(CapabilityAxis.FILE_WRITE, "/host/proj/.reyn/x") is False
+
+
+def test_effective_of_file_zone_root() -> None:
+    """Tier 2: #1414 — EffectivePermission.of threads file_zone_root to AgentLayer."""
+    eff = EffectivePermission.of(decl=PermissionDecl(), file_zone_root=_CONTAINER)
+    assert eff.allows(CapabilityAxis.FILE_WRITE, "/testbed/.reyn/x") is True


### PR DESCRIPTION
**[dogfood-coder]** — #1414 permission default file-zone anchor: host-cwd → workspace_base_dir under container. Design-first, lead-reviewed (#1410-parallel split, scope + AgentLayer-rename confirmed). #187 container-FS / base_dir #1410/#1411 family.

## Problem
The default file read/write ZONE (`_in_default_{read,write}_zone`, via AgentLayer at effective.py:121/127) was anchored on `PermissionResolver._project_root` = the HOST project root. Under a container backend (base_dir=/testbed) a non-grant write into the container repo's own `.reyn`/`reyn` default zone was denied (zone = `host/.reyn`). Latent: the SWE path uses `--grant-file-write` (config-bypasses the AgentLayer zone), so it only bites a **non-grant interactive container** run.

## Fix (#1410-parallel split, lead-confirmed)
Add `file_zone_root` to PermissionResolver, distinct from `project_root`:
- file-operation zone (read/write anchor) → `file_zone_root`
- approvals.yaml base + config → `project_root` (host, **unchanged**)

`file_zone_root` **defaults to `project_root`** → host / interactive byte-identical. Threaded from `workspace_base_dir` (the existing single-source `ws_base_dir`: Workspace base_dir + sandbox write_paths) at the resolver construction sites — `cli/commands/chat.py` (moved below `build_environment_backend` so `ws_base_dir` is available; it isn't used before then) + `agent.py`. Renamed `AgentLayer` / `EffectivePermission.of` `project_root`→`file_zone_root` (**completeness-verified**: all 5 callers are zone-use — effective.py:270 + permissions.py:1026/1078/1344/1374 — zero test callers).

**Scope:** path-resolution (permissions.py:597/625) OUT — handled by #1410/B3 (op-handler resolves paths; the zone checks receive absolute container paths). Confirmed with lead.

## Test plan
- [x] `tests/test_permission_file_zone_anchor_1414.py` — container zone allows `/testbed/.reyn` write + `/testbed` read; host-default zone unchanged (`host/.reyn` yes, `/testbed` no); container zone doesn't widen the host zone; `AgentLayer` + `EffectivePermission.of` consume `file_zone_root`.
- [x] `ruff` + `scripts/test_tier_audit.py --strict` clean (public-behaviour asserts, no private-state).
- [x] 200 permission / effective / agent / chat regression passed (rename + file_zone_root no-break).
- [ ] (assessment — agreed marginal) live-docker: permission-LOGIC = path-zone comparison, daemon-independent (per the #1417 precedent lead accepted); the unit suite covers it. No real container needed.

## Acceptance
- Non-grant container run writes to `/testbed/.reyn/...` (container default zone); approvals.yaml stays host-side.
- Host / interactive byte-identical (file_zone_root defaults to project_root).

Refs #1414, #1410, #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)