### PR TITLE
refactor(1412): single-source the chat-router OpContext construction (build_router_op_context)

### DIFF
--- a/src/reyn/chat/router_op_context.py
+++ b/src/reyn/chat/router_op_context.py
@@ -1,0 +1,133 @@
+"""#1412: single-source the chat-router OpContext construction.
+
+Two hosts built the ``skill_name="chat_router"`` OpContext with ~95% identical
+code: ``ChatSession._make_router_op_context`` (session.py) and
+``RouterHostAdapter.make_router_op_context`` (services/router_host_adapter.py).
+They drifted — #1410/#1411 threaded ``base_dir`` to one and lagged the other
+(the #187 wrong-FS class). This factory is the single source for the common
+construction (PermissionDecl with the #571 axes, the canonical ``.reyn/`` write
+paths + session-approval, the Workspace FS root, the OpContext).
+
+**Behavior-preserving** (#1412 lead decision): the fields that legitimately
+differ per host — ``agent_id`` / ``intervention_bus`` / ``multimodal_config`` /
+``media_store`` / ``compact_now`` / ``run_id`` — are caller-supplied params, so
+each host passes its CURRENT values (incl. ``None`` where it doesn't wire one).
+The divergence the single-sourcing makes explicit (e.g. RouterHostAdapter never
+wires ``agent_id``) is surfaced for a follow-up classification, NOT folded here
+(same "root-fix surfaces a latent gap" pattern as #1402 -> #1431).
+
+Which-ops trace (#1412): ChatSession's impl serves file ops (``_file_op``) +
+MCP ops (which wire ``intervention_bus`` POST-HOC on the returned ctx), so its
+``intervention_bus=None`` at construction is a wiring-style difference, not a
+missing capability; media/multimodal/compact ops go via the registry /
+RouterHostAdapter path. The lone capability-gap candidate is RouterHostAdapter's
+unset ``agent_id`` (registry-dispatched memory ops lose agent-scope) — a
+follow-up to classify drift-vs-intentional.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Canonical OS mutation paths the chat router declares + session-approves so
+# LLM-emitted mcp_install / index_drop / mcp_drop_server ops pass the uniform
+# permission gates without per-op prompts (#571 collapse arc).
+_CANONICAL_WRITE_PATHS = (
+    ".reyn/mcp.yaml",
+    ".reyn/cron.yaml",
+    ".reyn/index/sources.yaml",
+)
+
+
+def build_router_op_context(
+    *,
+    events: Any,
+    permission_resolver: Any,
+    file_permissions: dict | None,
+    mcp_servers: list[dict] | None,
+    mcp_servers_flat: list[dict],
+    allowed_mcp: list[str] | None,
+    workspace_base_dir: Any,  # Path | None — #187 container repo root
+    workspace_state_dir: Any,  # Path | None — host-side OS state dir
+    environment_backend: Any,  # FS seam backend instance (#1200 PR-F1)
+    sandbox_backend: Any,  # exec seam backend instance (#1200 PR-F2)
+    sandbox_policy: Any,  # raw policy → resolve_sandbox_policy here (#1339)
+    # ── per-host fields (caller-supplied; behavior-preserving) ─────────────
+    agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
+    intervention_bus: Any = None,  # ChatSession wires post-hoc; RouterHostAdapter inline
+    multimodal_config: Any = None,  # #364
+    media_store: Any = None,  # #383
+    compact_now: Any = None,  # #272/#1128
+    run_id: str | None = None,  # chat router is outside run scope (#FP-0021)
+) -> Any:
+    """Build the chat-router OpContext (the single source for both hosts).
+
+    The PermissionDecl + canonical-path approval + Workspace + OpContext are
+    identical across hosts; per-host fields are passed explicitly. See module
+    docstring for the drift-class + behavior-preserving rationale."""
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+    from reyn.sandbox.policy import resolve_sandbox_policy
+    from reyn.workspace.workspace import Workspace
+
+    file_perms = file_permissions or {}
+    servers = mcp_servers or []
+
+    file_read = [{"path": p, "scope": "recursive"} for p in file_perms.get("read", [])]
+    file_write = [{"path": p, "scope": "recursive"} for p in file_perms.get("write", [])]
+    mcp_names = [s["name"] for s in servers]
+
+    # #571 collapse arc Phase 5: explicit list axes for the canonical mutations.
+    file_write = list(file_write) + [
+        {"path": p, "scope": "just_path"} for p in _CANONICAL_WRITE_PATHS
+    ]
+    decl = PermissionDecl(
+        file_read=file_read,
+        file_write=file_write,
+        mcp=mcp_names,
+        allowed_mcp=allowed_mcp,
+        # #571 Phase 7: wildcard http.get (per-host 4-layer prompt at runtime) +
+        # the MCP registry host specifically (mcp_install startup_guard pre-approval).
+        http_get=[
+            {"host": "registry.modelcontextprotocol.io"},
+            {"host": "*"},
+        ],
+        # #571 Phase 6: wildcard secret.write (operator per-value prompt is the gate).
+        secret_write=["*"],
+    )
+    # Session-approve the canonical OS mutation paths so require_file_write passes
+    # silently for LLM-emitted ops. Skipped when no resolver (ad-hoc test ctx).
+    if permission_resolver is not None:
+        for canonical in _CANONICAL_WRITE_PATHS:
+            permission_resolver.session_approve_path(canonical, "chat_router", "file.write")
+
+    workspace = Workspace(
+        events=events,
+        permission_resolver=permission_resolver,
+        skill_name="chat_router",
+        # #187: chat OpContext FS root = the container repo root with a container
+        # env-backend (e.g. /testbed); state_dir stays host-side. None → cwd default.
+        base_dir=workspace_base_dir,
+        state_dir=workspace_state_dir,
+        environment_backend=environment_backend,
+    )
+    return OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=decl,
+        permission_resolver=permission_resolver,
+        skill_name="chat_router",
+        mcp_servers=mcp_servers_flat,
+        run_id=run_id,
+        agent_id=agent_id,
+        intervention_bus=intervention_bus,
+        multimodal_config=multimodal_config,
+        media_store=media_store,
+        compact_now=compact_now,
+        sandbox_backend=sandbox_backend,
+        # #1339: resolve the operator-or-default sandbox policy (was None → the
+        # op_runtime handler fell back to LLM-set op fields = sandbox-escape gap).
+        default_sandbox_policy=resolve_sandbox_policy(
+            sandbox_policy,
+            write_paths=[str(workspace.base_dir)],
+        ),
+    )

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -1411,93 +1411,33 @@ class RouterHostAdapter:
         is populated from the agent's effective permissions so that op_runtime
         layer permission checks actually gate access.
         """
-        from reyn.op_runtime.context import OpContext
-        from reyn.permissions.permissions import PermissionDecl
-        from reyn.sandbox.policy import resolve_sandbox_policy
-        from reyn.workspace.workspace import Workspace
+        from reyn.chat.router_op_context import build_router_op_context
 
-        file_perms = self._get_file_permissions_for_router() or {}
-        mcp_servers = self._get_mcp_servers_for_router() or []
-
-        file_read = [{"path": p, "scope": "recursive"} for p in file_perms.get("read", [])]
-        file_write = [{"path": p, "scope": "recursive"} for p in file_perms.get("write", [])]
-        mcp_names = [s["name"] for s in mcp_servers]
-
-        # #571 collapse arc Phase 5: explicit list axes replace the
-        # former mcp_install / index_drop bool axes. See ChatSession's
-        # _make_router_op_context for the matching pattern.
-        file_write = list(file_write) + [
-            {"path": ".reyn/mcp.yaml", "scope": "just_path"},
-            {"path": ".reyn/cron.yaml", "scope": "just_path"},
-            {"path": ".reyn/index/sources.yaml", "scope": "just_path"},
-        ]
-        decl = PermissionDecl(
-            file_read=file_read,
-            file_write=file_write,
-            mcp=mcp_names,
-            allowed_mcp=self._allowed_mcp,
-            # #571 Phase 7: wildcard http.get + specific MCP registry —
-            # see ChatSession's matching pattern.
-            http_get=[
-                {"host": "registry.modelcontextprotocol.io"},
-                {"host": "*"},
-            ],
-            # #571 Phase 6: wildcard secret.write — see ChatSession.
-            secret_write=["*"],
-        )
-        if self._perm is not None:
-            for canonical in (".reyn/mcp.yaml", ".reyn/cron.yaml", ".reyn/index/sources.yaml"):
-                self._perm.session_approve_path(canonical, "chat_router", "file.write")
-
-        workspace = Workspace(
-            events=self._events,
-            permission_resolver=self._perm,
-            skill_name="chat_router",
-            # #187: this is the LIVE op-context factory the registry file-dispatch
-            # uses (router_loop.py op_context_factory=host.make_router_op_context).
-            # With a container env-backend the agent's repo lives in the container
-            # (e.g. /testbed), so base_dir must be that container repo root and the
-            # FS backend must be the docker instance — otherwise file__read/grep/
-            # glob/edit (and the sandbox write_paths below) resolve against the host
-            # cwd. None (host backend) → cwd default, unchanged.
-            base_dir=self._workspace_base_dir,
-            state_dir=self._workspace_state_dir,
-            environment_backend=self._environment_backend,
-        )
-        # FP-0022 fix (#53): wire intervention_bus so handlers that need
-        # the 4-layer approval flow (web_fetch, mcp install / drop) can
-        # progress past their ``intervention_bus is None`` defensive
-        # guard. The config-deny check inside require_web_fetch fires
-        # before the bus is touched, so leaving the bus None is still
-        # safe for the deny path — but we wire a real bus when one is
-        # available so the interactive (Layer 4) path also works.
+        # #1412: single-sourced via build_router_op_context (shared with
+        # ChatSession). RouterHostAdapter wires intervention_bus inline (via the
+        # factory) + media/multimodal/compact (the registry-dispatch path serves
+        # web/media ops). agent_id is unset here (registry-dispatch lacks one) —
+        # a #1412 follow-up gap candidate, preserved behaviorally.
         bus = (
             self._intervention_bus_factory()
             if self._intervention_bus_factory is not None
             else None
         )
-        return OpContext(
-            workspace=workspace,
+        return build_router_op_context(
             events=self._events,
-            permission_decl=decl,
             permission_resolver=self._perm,
-            skill_name="chat_router",
-            mcp_servers=self._mcp_servers_flat(),
-            intervention_bus=bus,
-            # Issue #364: gate config for router-initiated binary ops.
-            multimodal_config=self._multimodal_config,
-            # Issue #383 PR-C: shared MediaStore for path-ref save/read.
-            media_store=self._media_store,
-            # #272/#1128: voluntary-compaction capability for the compact op.
-            compact_now=self._compact_now,
-            # #187 exec-seam: the exec backend INSTANCE so sandboxed_exec runs
-            # in the container repo (/testbed), not the host seatbelt fallback.
+            file_permissions=self._get_file_permissions_for_router(),
+            mcp_servers=self._get_mcp_servers_for_router(),
+            mcp_servers_flat=self._mcp_servers_flat(),
+            allowed_mcp=self._allowed_mcp,
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
+            environment_backend=self._environment_backend,
             sandbox_backend=self._sandbox_backend_instance,
-            # #1339 / sandbox-model completion: resolve the operator-or-default
-            # sandbox policy onto the router OpContext (was None → the handler
-            # fell back to LLM-set op fields = the sandbox-escape gap).
-            default_sandbox_policy=resolve_sandbox_policy(
-                self._sandbox_policy,
-                write_paths=[str(workspace.base_dir)],
-            ),
+            sandbox_policy=self._sandbox_policy,
+            agent_id=None,
+            intervention_bus=bus,
+            multimodal_config=self._multimodal_config,
+            media_store=self._media_store,
+            compact_now=self._compact_now,
         )

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -4760,101 +4760,30 @@ class ChatSession:
         that op_runtime layer permission checks actually gate access rather than
         silently allowing everything through an empty decl.
         """
-        from reyn.op_runtime.context import OpContext
-        from reyn.permissions.permissions import PermissionDecl
-        from reyn.sandbox.policy import resolve_sandbox_policy
-        from reyn.workspace.workspace import Workspace
+        from reyn.chat.router_op_context import build_router_op_context
 
-        file_perms = self._get_file_permissions_for_router() or {}
-        mcp_servers = self._get_mcp_servers_for_router() or []
-
-        # Convert flat path strings to the {path, scope} dict format used by PermissionDecl
-        file_read = [{"path": p, "scope": "recursive"} for p in file_perms.get("read", [])]
-        file_write = [{"path": p, "scope": "recursive"} for p in file_perms.get("write", [])]
-        mcp_names = [s["name"] for s in mcp_servers]
-
-        # #571 collapse arc Phase 5: the legacy ``mcp_install`` /
-        # ``index_drop`` bool axes are replaced with the explicit list
-        # axes the corresponding op handlers now consume. The chat
-        # router declares the canonical mutation paths + the registry
-        # host so LLM-emitted mcp_install / index_drop / mcp_drop_server
-        # ops pass the OS's uniform permission gates without per-op
-        # prompts (= operator-level config / session approvals carry
-        # the authorisation).
-        file_write = list(file_write) + [
-            {"path": ".reyn/mcp.yaml", "scope": "just_path"},
-            {"path": ".reyn/cron.yaml", "scope": "just_path"},
-            {"path": ".reyn/index/sources.yaml", "scope": "just_path"},
-        ]
-        decl = PermissionDecl(
-            file_read=file_read,
-            file_write=file_write,
-            mcp=mcp_names,
+        # #1412: single-sourced via build_router_op_context (shared with
+        # RouterHostAdapter). ChatSession wires intervention_bus POST-HOC on the
+        # returned ctx (the MCP-op caller), so it is None at construction here;
+        # media/multimodal/compact ops go via the registry / RouterHostAdapter
+        # path (None here) — behavior-preserving.
+        return build_router_op_context(
+            events=self._chat_events,
+            permission_resolver=self._perm,
+            file_permissions=self._get_file_permissions_for_router(),
+            mcp_servers=self._get_mcp_servers_for_router(),
+            mcp_servers_flat=self._mcp_servers_flat(),
             allowed_mcp=self._allowed_mcp,
-            # #571 Phase 7: wildcard http.get authorises LLM-driven
-            # ``web_fetch`` ops to any host via a per-host 4-layer
-            # prompt at runtime — unifies the safe.http + web_fetch
-            # paths under a single ``http.get`` axis. The MCP registry
-            # host is also listed specifically so mcp_install's
-            # startup_guard pre-approves it without an extra prompt.
-            http_get=[
-                {"host": "registry.modelcontextprotocol.io"},
-                {"host": "*"},
-            ],
-            # #571 Phase 6: wildcard secret.write authorises LLM-emitted
-            # mcp_install ops to save runtime-determined ``isSecret`` env
-            # vars from the registry — the actual security gate is the
-            # operator's per-value prompt at op-execution time.
-            secret_write=["*"],
-        )
-        # Session-approve the canonical OS mutation paths so the runtime
-        # require_file_write check passes silently for LLM-emitted ops
-        # in the chat router context. Skipped when no resolver is wired
-        # (= ad-hoc test contexts that pass permission_resolver=None).
-        if self._perm is not None:
-            for canonical in (".reyn/mcp.yaml", ".reyn/cron.yaml", ".reyn/index/sources.yaml"):
-                self._perm.session_approve_path(canonical, "chat_router", "file.write")
-
-        workspace = Workspace(
-            events=self._chat_events,
-            permission_resolver=self._perm,
-            skill_name="chat_router",
-            # #187: the chat OpContext FS root. With a container env-backend the
-            # agent's repo lives in the container (e.g. /testbed), so base_dir must
-            # be that container repo root — the partner of the backend below.
-            # Otherwise file__read/grep/glob resolve relative to the host cwd (the
-            # reyn repo) and the agent never sees the target tree. state_dir stays
-            # host-side (decoupled) so OS state survives container death + does not
-            # pollute the in-container git diff. None → Workspace's cwd default.
-            base_dir=self._workspace_base_dir,
-            state_dir=self._workspace_state_dir,
-            # #1200 PR-F1 (FS seam): run chat file ops on the agent's
-            # EnvironmentBackend instance (None → Workspace's HostBackend default).
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
             environment_backend=self._environment_backend,
-        )
-        return OpContext(
-            workspace=workspace,
-            events=self._chat_events,
-            permission_decl=decl,
-            permission_resolver=self._perm,
-            skill_name="chat_router",
-            mcp_servers=self._mcp_servers_flat(),
-            run_id=None,  # FP-0021: chat router is outside run scope
-            agent_id=self._agent_id,  # FP-0016 E
-            # #1200 PR-F2 (exec seam): run chat sandboxed_exec on the agent's
-            # SandboxBackend instance (None → get_default_backend, unchanged).
             sandbox_backend=self._sandbox_backend,
-            # #1339 / sandbox-model completion: resolve the operator-or-default
-            # sandbox policy onto the chat OpContext (was None → the op_runtime
-            # handler fell back to the LLM-set op fields = the sandbox-escape
-            # gap). Always a concrete policy now → the LLM cannot set the sandbox
-            # axes via sandboxed_exec.
-            default_sandbox_policy=resolve_sandbox_policy(
+            sandbox_policy=(
                 self._sandbox_config.policy
                 if getattr(self, "_sandbox_config", None) is not None
-                else None,
-                write_paths=[str(workspace.base_dir)],
+                else None
             ),
+            agent_id=self._agent_id,
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_router_op_context_single_source_1412.py
+++ b/tests/test_router_op_context_single_source_1412.py
@@ -1,0 +1,84 @@
+"""Tier 2: #1412 — the chat-router OpContext is built from a single source.
+
+``ChatSession._make_router_op_context`` and
+``RouterHostAdapter.make_router_op_context`` built the
+``skill_name="chat_router"`` OpContext with ~95% identical code and drifted
+(#1410/#1411 threaded base_dir to one, lagged the other — the #187 wrong-FS
+class). The fix routes both through ``build_router_op_context``
+(reyn/chat/router_op_context.py).
+
+Pinned invariants (src-wide AST, the #1402 sole-construction pattern):
+
+- An ``OpContext(..., skill_name="chat_router", ...)`` is constructed ONLY in
+  ``router_op_context.py`` anywhere in ``src/reyn``. A second chat-router
+  OpContext construction re-opens the drift class → this fails, naming
+  file:line (incl. hidden sites).
+- Both hosts delegate to ``build_router_op_context`` (positive guard — the
+  chokepoint is used, not bypassed).
+
+Cf. [[feedback_multi_callsite_wiring_audit]] / #1402 src-wide invariant.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_FACTORY_REL = "chat/router_op_context.py"
+
+
+def _chat_router_opcontext_sites() -> list[str]:
+    sites: list[str] = []
+    for py in sorted(_SRC.rglob("*.py")):
+        rel = str(py.relative_to(_SRC))
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "OpContext"
+            ):
+                continue
+            for kw in node.keywords:
+                if (
+                    kw.arg == "skill_name"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value == "chat_router"
+                ):
+                    sites.append(f"{rel}:{node.lineno}")
+    return sites
+
+
+def _calls_named(rel: str, name: str) -> int:
+    tree = ast.parse((_SRC / rel).read_text(encoding="utf-8"))
+    return sum(
+        1
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == name
+    )
+
+
+def test_chat_router_opcontext_built_only_in_factory() -> None:
+    """Tier 2: #1412 — the chat_router OpContext is constructed ONLY in
+    router_op_context.py; both hosts route through build_router_op_context so
+    a new capability reaches both paths by construction. Falsifiable: a second
+    inline chat-router OpContext construction fails this, naming file:line."""
+    sites = _chat_router_opcontext_sites()
+    offenders = [s for s in sites if not s.startswith(_FACTORY_REL + ":")]
+    assert sites, "no OpContext(skill_name='chat_router') found at all (factory missing?)"
+    assert not offenders, (
+        "OpContext(skill_name='chat_router') built outside router_op_context.py "
+        "— re-opens the #1412 drift class; route through build_router_op_context: "
+        f"{offenders}"
+    )
+
+
+def test_both_hosts_delegate_to_build_router_op_context() -> None:
+    """Tier 2: #1412 — ChatSession and RouterHostAdapter both call
+    build_router_op_context (positive guard: the chokepoint is used)."""
+    for rel in ("chat/session.py", "chat/services/router_host_adapter.py"):
+        assert _calls_named(rel, "build_router_op_context") >= 1, (
+            f"{rel} must delegate to build_router_op_context (#1412 single-source)"
+        )


### PR DESCRIPTION
**[e2e-coder]** — #1412: single-source the chat-router OpContext construction.

## Problem (drift class)

`ChatSession._make_router_op_context` (session.py) and `RouterHostAdapter.make_router_op_context` (services/router_host_adapter.py) built the `skill_name="chat_router"` OpContext with **~95% identical code** and drifted — #1410/#1411 threaded `base_dir` to one and lagged the other (the #187 wrong-FS class). Same construction-forwarding-gap class as #1402 / #1431 / #1414 / #1419.

## Fix

Both now route through **`build_router_op_context`** (`reyn/chat/router_op_context.py`): the common PermissionDecl (#571 axes), the canonical `.reyn/` write paths + session-approval, the Workspace FS root, and the OpContext. A **src-wide AST invariant** pins `OpContext(skill_name='chat_router')` is constructed **ONLY** in `router_op_context.py` (the #1402 sole-construction pattern — catches hidden/future sites).

## Behavior-preserving + which-ops trace

The fields that legitimately differ per host (`agent_id` / `intervention_bus` / `multimodal_config` / `media_store` / `compact_now` / `run_id`) are caller-supplied params, so each host passes its **current** values (incl. `None`). Trace evidence:
- **ChatSession**'s impl serves file ops (`_file_op`) + MCP ops; the MCP caller wires `intervention_bus` **post-hoc** on the returned ctx, so `None` at construction is a *wiring-style* difference, not a missing capability. Media/multimodal/compact ops go via the registry / RouterHostAdapter path.
- **RouterHostAdapter** wires those inline. Its one surfaced gap candidate is the **unset `agent_id`** (registry-dispatched memory ops lose agent-scope) — a **follow-up** to classify drift-vs-intentional, NOT folded here (same "root-fix surfaces a latent gap" pattern as #1402 → #1431).

## Test plan

- [x] `tests/test_router_op_context_single_source_1412.py` — src-wide sole-construction invariant + both-hosts-delegate (2 pass).
- [x] Behavior-preservation: `test_router_opcontext_basedir_live_187` (the #1410/#1411 base_dir live test), `test_1200_3axis_uniformity`, `test_router_host_adapter_invariants`, mcp/planner — 81 pass on the fresh base (incl. #1414 file-zone tests; #1414's change is upstream in the permission computation, not the OpContext construction).
- [x] `pytest -q` full suite — 2 pre-existing unrelated failures only (swebench env / web_fetch); zero new breakage.
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` clean.

Refs #1412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)