### PR TITLE
feat(1401): port scoped capabilities to the A2A server path (PR-A of #187 capstone)

### DIFF
--- a/src/reyn/cli/commands/web.py
+++ b/src/reyn/cli/commands/web.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from reyn.cli.env_backend import build_environment_backend, register_env_backend_args
+
 
 def register(sub) -> None:
     p = sub.add_parser(
@@ -72,7 +74,86 @@ def register(sub) -> None:
             "デプロイで有効化。"
         ),
     )
+    # #1401: scoped capabilities for the A2A server path — symmetric with
+    # `reyn chat`. Lets a headless `reyn web` (the faithful SWE-eval A2A host)
+    # run agent file/exec ops in a per-instance container, scope out tools (e.g.
+    # web for faithful eval), and grant repo file-write. Threaded as the
+    # env-backend INSTANCE (no env-var rebuild) via web/deps; see run().
+    register_env_backend_args(p)  # --env-backend / --container
+    p.add_argument(
+        "--grant-file-write",
+        action="store_true",
+        default=False,
+        dest="grant_file_write",
+        help=(
+            "agent に file.read/write を resolver 層で許可 "
+            "(sandbox write_paths ∩ env-backend repo zone で bound)。"
+            " headless/scripted SWE で repo を編集させる場合に有効化 "
+            "(`reyn chat --grant-file-write` と同等)。"
+        ),
+    )
+    p.add_argument(
+        "--exclude-tools",
+        dest="exclude_tools",
+        default=None,
+        metavar="NAMES",
+        help=(
+            "LLM の visible catalog から隠すツール名 (カンマ区切り、例 "
+            "web__search,web__fetch)。faithful eval の web-leak 抑止に "
+            "(`reyn chat --exclude-tools` と同等)。"
+        ),
+    )
     p.set_defaults(func=run)
+
+
+def _apply_cli_scoped_overrides(args: argparse.Namespace) -> None:
+    """#1401: build the env-backend INSTANCE (CLI process) + thread it, the
+    workspace dirs, exclude-tools, and the file-write grant to the A2A session
+    factory via web/deps' module-global holder. No-op when no scoped flag is
+    set (a plain `reyn web` stays byte-identical).
+
+    Detects scoped intent from the args BEFORE ``build_environment_backend``
+    (which may LAUNCH a container) so the --reload guard fires without side
+    effects. --reload spawns a worker subprocess the parent's module-global
+    cannot reach (silent no-op) → fail loud instead.
+    """
+    grant = bool(getattr(args, "grant_file_write", False))
+    exclude_raw = getattr(args, "exclude_tools", None)
+    scoped_intent = (
+        getattr(args, "env_backend", "host") != "host"
+        or grant
+        or bool(exclude_raw)
+    )
+    if not scoped_intent:
+        return
+    if getattr(args, "reload", False):
+        print(
+            "Error: --reload is incompatible with the scoped capability flags "
+            "(--env-backend=docker / --grant-file-write / --exclude-tools). The "
+            "uvicorn reload worker is a subprocess the CLI-set overrides cannot "
+            "reach (silent no-op). Run without --reload for a scoped server.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    from reyn.web import deps as _web_deps
+
+    env_backend, wb, ws, env_cleanup = build_environment_backend(args)
+    if env_cleanup is not None:
+        import atexit
+        atexit.register(env_cleanup)
+    exclude_tools = frozenset(
+        t.strip() for t in (exclude_raw or "").split(",") if t.strip()
+    ) or None
+    _web_deps.set_cli_scoped_overrides(
+        _web_deps.CliScopedOverrides(
+            environment_backend=env_backend,
+            workspace_base_dir=wb,
+            workspace_state_dir=ws,
+            exclude_tools=exclude_tools,
+            grant_file_write=grant,
+        )
+    )
 
 
 def run(args: argparse.Namespace) -> None:
@@ -106,6 +187,10 @@ def run(args: argparse.Namespace) -> None:
     # `reyn chat --eager-embedding-build` (= B25-S5-1).
     if getattr(args, "eager_embedding_build", False):
         os.environ["REYN_WEB_EAGER_EMBEDDING_BUILD"] = "1"
+
+    # #1401: thread the scoped capabilities to the A2A server path (before
+    # uvicorn.run so the lazy session factory / perm resolver read them).
+    _apply_cli_scoped_overrides(args)
 
     uvicorn.run(
         "reyn.web.server:app",

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -124,14 +124,25 @@ def _get_perm_resolver():
         from reyn.permissions.permissions import PermissionResolver
         config = _load_config()
         root = _get_project_root()
-        perm_config = getattr(config, "permissions", {}) or {}
+        # Copy so the #1401 grant setdefault below never mutates the shared config.
+        perm_config = dict(getattr(config, "permissions", {}) or {})
         # Mirror the CLI path: unsafe python steps require an explicit opt-in.
         # In the web gateway (non-interactive) the equivalent of --allow-unsafe-python
         # is python.unsafe: allow in reyn.yaml / reyn.local.yaml permissions.
         unsafe_python_allowed = perm_config.get("python.unsafe") == "allow"
+        # #1401: --grant-file-write grants file.read/write at the resolver layer
+        # (mirrors `reyn chat`/run.py/eval). Bounded by the sandbox write_paths ∩
+        # the env-backend repo zone. setdefault preserves explicit operator config.
+        _ov = get_cli_scoped_overrides()
+        if _ov.grant_file_write:
+            perm_config.setdefault("file.read", "allow")
+            perm_config.setdefault("file.write", "allow")
         _perm_resolver = PermissionResolver(
             config_permissions=perm_config,
             project_root=root,
+            # #1401/#1414: anchor the default file-zone on the container repo root
+            # under a container env-backend (None for host → project_root default).
+            file_zone_root=_ov.workspace_base_dir,
             # Web gateway: non-interactive. Permission prompts become denials
             # unless pre-approved in reyn.yaml / .reyn/approvals.yaml.
             interactive=False,
@@ -194,6 +205,63 @@ def _wire_external_outbox_interceptor(session, routing) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #1401: CLI-scoped capability overrides (env-backend / exclude-tools / grant)
+# ---------------------------------------------------------------------------
+# `reyn web` with the scoped flags builds the env-backend INSTANCE in the CLI
+# process and threads it here as a module-global (NOT an env-var: an instance
+# can't ride a string, and rebuilding it app-side would double-build/attach the
+# container = re-introducing the very drift class #1402/#1412 rooted). The lazy
+# process-global session factory + perm resolver read it; they are NOT
+# request-scoped, so app.state — read via Request in handlers — does not fit
+# (using a module-global is a factory-shape decision, not ignoring a seam).
+# Only set under no-reload (same process); --reload is guarded at the CLI.
+from contextlib import contextmanager  # noqa: E402
+from dataclasses import dataclass  # noqa: E402
+
+
+@dataclass(frozen=True)
+class CliScopedOverrides:
+    """The `reyn web` scoped capability overrides (#1401). All defaults = the
+    pre-#1401 web/A2A behaviour (no env-backend, no exclude, no grant)."""
+
+    environment_backend: object | None = None  # FS+exec backend INSTANCE (single-shared)
+    workspace_base_dir: object | None = None   # container repo root (Path | None)
+    workspace_state_dir: object | None = None  # host-side OS state dir (Path | None)
+    exclude_tools: "frozenset | None" = None   # tool names hidden from the LLM catalog
+    grant_file_write: bool = False             # grant file.read/write at the resolver
+
+
+_cli_scoped: "CliScopedOverrides | None" = None
+
+
+def set_cli_scoped_overrides(overrides: "CliScopedOverrides | None") -> None:
+    """Set/clear the CLI-scoped overrides. `reyn web` run() calls this ONCE
+    before uvicorn.run (no-reload). Resetting the cached lazy singletons here
+    keeps the next perm-resolver / registry build pick the new overrides up."""
+    global _cli_scoped, _perm_resolver, _registry
+    _cli_scoped = overrides
+    _perm_resolver = None
+    _registry = None
+
+
+def get_cli_scoped_overrides() -> "CliScopedOverrides":
+    return _cli_scoped or CliScopedOverrides()
+
+
+@contextmanager
+def cli_scoped_overrides(overrides: "CliScopedOverrides"):
+    """Test isolation: apply the overrides for the block, restore after
+    (incl. the cached perm-resolver / registry singletons)."""
+    global _cli_scoped, _perm_resolver, _registry
+    prev = (_cli_scoped, _perm_resolver, _registry)
+    set_cli_scoped_overrides(overrides)
+    try:
+        yield
+    finally:
+        _cli_scoped, _perm_resolver, _registry = prev
+
+
+# ---------------------------------------------------------------------------
 # AgentRegistry  (process-shared)
 # ---------------------------------------------------------------------------
 
@@ -240,6 +308,7 @@ def _get_registry():
 
         def _session_factory(profile: AgentProfile) -> ChatSession:
             registry = registry_ref[0]
+            _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -271,20 +340,20 @@ def _get_registry():
                 action_retrieval_config=config.action_retrieval,
                 embedding_config=config.embedding,
                 eager_embedding_build=_eager_embedding_build,
-                # #1402: scoped capability surface, passed EXPLICITLY (required by
-                # build_scoped_chat_session). These are the A2A factory's current
-                # behaviour — defaults that document the gaps the divergence
-                # revealed, NOT new capabilities (behavior-preserving refactor).
-                # A consumer that needs one (e.g. an A2A SWE runner: #1401) flips
-                # the relevant default to a real value in one line.
-                allowed_mcp=None,  # gap: A2A lacks per-profile MCP gating (was omitted → None)
+                # #1401: the 3 scoped capabilities, filled from the CLI override
+                # holder (env-backend INSTANCE → both FS+exec seams = single-shared
+                # sandbox #1200; container-rooting; exclude-tools). Default None =
+                # the pre-#1401 web/A2A behaviour, so a plain `reyn web` is
+                # byte-identical. allowed_mcp / agent_id / router_max_iterations
+                # remain the #1431 item-2 gaps (separate capability decision).
+                allowed_mcp=None,
                 agent_id=None,
-                exclude_tools=None,
+                exclude_tools=_scoped.exclude_tools,
                 router_max_iterations=5,
-                environment_backend=None,  # gap: A2A lacks env-backend / container-rooting
-                sandbox_backend=None,
-                workspace_base_dir=None,
-                workspace_state_dir=None,
+                environment_backend=_scoped.environment_backend,
+                sandbox_backend=_scoped.environment_backend,
+                workspace_base_dir=_scoped.workspace_base_dir,
+                workspace_state_dir=_scoped.workspace_state_dir,
             )
             s.load_history()
             # FP-0041 #489 PR-D2.5: external transport outbox interceptor.

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -1,0 +1,160 @@
+"""Tier 2: #1401 — `reyn web` scoped capabilities reach the A2A server path.
+
+PR-A ports the 3 scoped capabilities `reyn chat` has (#1289/#1398/#1400) to the
+A2A/`reyn web` path so a headless SWE-eval server runs agent file/exec ops in a
+per-instance container, scopes out tools (web for faithful eval), and grants
+repo file-write. The env-backend INSTANCE is threaded (not an env-var string —
+rebuilding it app-side would double-build the container, re-opening the drift
+class #1402/#1412 rooted) via web/deps' module-global holder.
+
+Observable invariants (no private-state asserts):
+
+- the CLI override holder is contextmanager-isolated (set/reset, incl. the
+  cached perm-resolver / registry singletons) — no cross-test leak;
+- a plain `reyn web` (no scoped flag) is a no-op (byte-identical pre-#1401);
+- each scoped flag + `--reload` fails loud (the module-global can't cross
+  uvicorn's reload-worker subprocess — silent-no-op footgun);
+- the holder's values round-trip to the construction: web/deps' factory passes
+  them to `build_scoped_chat_session` (the #1402-documented None-default fill),
+  and the perm resolver applies the grant + file_zone anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+import pytest
+
+from reyn.cli.commands.web import _apply_cli_scoped_overrides
+from reyn.web import deps
+from reyn.web.deps import (
+    CliScopedOverrides,
+    cli_scoped_overrides,
+    get_cli_scoped_overrides,
+    set_cli_scoped_overrides,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+
+def _ns(**kw) -> argparse.Namespace:
+    base = dict(
+        env_backend="host", container=None, repo_dir=None,
+        grant_file_write=False, exclude_tools=None, reload=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# Holder + contextmanager isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scoped_overrides_contextmanager_isolation():
+    """Tier 2: #1401 — the contextmanager applies overrides for the block then
+    restores (incl. the cached perm-resolver/registry singletons), so the
+    override never leaks across tests."""
+    set_cli_scoped_overrides(None)
+    assert get_cli_scoped_overrides().exclude_tools is None
+    ov = CliScopedOverrides(exclude_tools=frozenset({"web__search"}), grant_file_write=True)
+    with cli_scoped_overrides(ov):
+        g = get_cli_scoped_overrides()
+        assert g.exclude_tools == frozenset({"web__search"})
+        assert g.grant_file_write is True
+    assert get_cli_scoped_overrides().exclude_tools is None
+    assert get_cli_scoped_overrides().grant_file_write is False
+
+
+# ---------------------------------------------------------------------------
+# CLI helper behaviour (no-op / --reload guard / holder threading)
+# ---------------------------------------------------------------------------
+
+
+def test_no_scoped_flag_is_noop():
+    """Tier 2: #1401 — a plain `reyn web` (host backend, no flags) sets no
+    override = byte-identical pre-#1401 behaviour."""
+    set_cli_scoped_overrides(None)
+    _apply_cli_scoped_overrides(_ns())
+    assert get_cli_scoped_overrides() == CliScopedOverrides()
+
+
+@pytest.mark.parametrize("scoped_kw", [
+    {"env_backend": "docker"},
+    {"grant_file_write": True},
+    {"exclude_tools": "web__search,web__fetch"},
+])
+def test_reload_guard_blocks_each_scoped_flag(scoped_kw):
+    """Tier 2: #1401 — each scoped flag + --reload fails loud (SystemExit), not a
+    silent no-op. The guard fires BEFORE build_environment_backend so no
+    container is launched by this test."""
+    set_cli_scoped_overrides(None)
+    with pytest.raises(SystemExit):
+        _apply_cli_scoped_overrides(_ns(reload=True, **scoped_kw))
+
+
+def test_exclude_and_grant_thread_to_holder():
+    """Tier 2: #1401 — --exclude-tools (comma-split) + --grant-file-write thread
+    to the holder for the factory / resolver to read. No container launch on the
+    exclude/grant-only path (env_backend stays None)."""
+    set_cli_scoped_overrides(None)
+    try:
+        _apply_cli_scoped_overrides(
+            _ns(exclude_tools="web__search, web__fetch", grant_file_write=True)
+        )
+        g = get_cli_scoped_overrides()
+        assert g.exclude_tools == frozenset({"web__search", "web__fetch"})
+        assert g.grant_file_write is True
+        assert g.environment_backend is None
+    finally:
+        set_cli_scoped_overrides(None)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip wiring (the holder's values reach the construction)
+# ---------------------------------------------------------------------------
+
+
+def _deps_tree() -> ast.AST:
+    return ast.parse((_SRC / "web" / "deps.py").read_text(encoding="utf-8"))
+
+
+def _scoped_attr(value: ast.AST | None, attr: str) -> bool:
+    return (
+        isinstance(value, ast.Attribute)
+        and value.attr == attr
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "_scoped"
+    )
+
+
+def test_factory_threads_holder_to_build_scoped_chat_session():
+    """Tier 2: #1401 — web/deps' _session_factory passes the holder's scoped
+    fields (NOT None) to build_scoped_chat_session — the round-trip fill of the
+    #1402-documented gaps. The env-backend instance feeds BOTH FS+exec seams
+    (single-shared sandbox #1200). Falsifiable: revert any to None → fails."""
+    calls = [
+        n for n in ast.walk(_deps_tree())
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "build_scoped_chat_session"
+    ]
+    assert calls, "no build_scoped_chat_session call in web/deps.py"
+    kw = {k.arg: k.value for k in calls[0].keywords if k.arg}
+    assert _scoped_attr(kw.get("exclude_tools"), "exclude_tools")
+    assert _scoped_attr(kw.get("environment_backend"), "environment_backend")
+    assert _scoped_attr(kw.get("sandbox_backend"), "environment_backend")
+    assert _scoped_attr(kw.get("workspace_base_dir"), "workspace_base_dir")
+    assert _scoped_attr(kw.get("workspace_state_dir"), "workspace_state_dir")
+
+
+def test_perm_resolver_threads_grant_and_file_zone():
+    """Tier 2: #1401 — _get_perm_resolver applies the --grant-file-write grant
+    (file.read/write setdefault) and anchors file_zone_root on the holder's
+    container repo root. Wiring guard for the resolver-layer port (the grant
+    EFFECT is covered by the shared chat/eval grant path)."""
+    src = (_SRC / "web" / "deps.py").read_text(encoding="utf-8")
+    assert 'perm_config.setdefault("file.read", "allow")' in src
+    assert 'perm_config.setdefault("file.write", "allow")' in src
+    assert "file_zone_root=_ov.workspace_base_dir" in src

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -169,9 +169,9 @@ def _web_can_write(target: str, sandbox: "SandboxPolicy", *, grant: bool, ws) ->
 
 
 def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
-    """Tier 2 R1: the --grant-file-write holder flag ACTUALLY gates file.write on
-    the REAL web perm resolver. Differential (the falsification pair): grant=True
-    allows an in-repo write, grant=False denies it. Not a source string-grep."""
+    """Tier 2: R1 — the --grant-file-write holder flag ACTUALLY gates file.write
+    on the REAL web perm resolver. Differential (the falsification pair):
+    grant=True allows an in-repo write, grant=False denies it. Not a string-grep."""
     (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "container_repo"
@@ -182,10 +182,10 @@ def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
 
 
 def test_file_zone_root_from_holder_anchors_default_zone(tmp_path, monkeypatch):
-    """Tier 2 R1: file_zone_root receives the holder's container repo root (#1414)
-    at RUNTIME. Differential (no grant): a write into <repo>/.reyn (the default
-    write zone anchored on file_zone_root) is allowed when ws_base_dir=repo, but
-    DENIED when the holder has no ws_base_dir (zone anchors on the host root)."""
+    """Tier 2: R1 — file_zone_root receives the holder's container repo root
+    (#1414) at RUNTIME. Differential (no grant): a write into <repo>/.reyn (the
+    default write zone anchored on file_zone_root) is allowed when ws_base_dir=
+    repo, but DENIED when the holder has no ws_base_dir (zone anchors on host)."""
     (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / "container_repo"

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -27,6 +27,8 @@ from pathlib import Path
 import pytest
 
 from reyn.cli.commands.web import _apply_cli_scoped_overrides
+from reyn.permissions.permissions import PermissionDecl
+from reyn.sandbox.policy import SandboxPolicy
 from reyn.web import deps
 from reyn.web.deps import (
     CliScopedOverrides,
@@ -149,12 +151,45 @@ def test_factory_threads_holder_to_build_scoped_chat_session():
     assert _scoped_attr(kw.get("workspace_state_dir"), "workspace_state_dir")
 
 
-def test_perm_resolver_threads_grant_and_file_zone():
-    """Tier 2: #1401 — _get_perm_resolver applies the --grant-file-write grant
-    (file.read/write setdefault) and anchors file_zone_root on the holder's
-    container repo root. Wiring guard for the resolver-layer port (the grant
-    EFFECT is covered by the shared chat/eval grant path)."""
-    src = (_SRC / "web" / "deps.py").read_text(encoding="utf-8")
-    assert 'perm_config.setdefault("file.read", "allow")' in src
-    assert 'perm_config.setdefault("file.write", "allow")' in src
-    assert "file_zone_root=_ov.workspace_base_dir" in src
+# ---------------------------------------------------------------------------
+# Real-resolver enforcement (R1): the holder grant + file_zone actually GATE
+# ---------------------------------------------------------------------------
+
+
+def _web_can_write(target: str, sandbox: "SandboxPolicy", *, grant: bool, ws) -> bool:
+    """Build the REAL web `_get_perm_resolver()` under the holder and check
+    whether ``require_file_write`` permits ``target`` (no None resolver)."""
+    with cli_scoped_overrides(CliScopedOverrides(grant_file_write=grant, workspace_base_dir=ws)):
+        resolver = deps._get_perm_resolver()
+        try:
+            resolver.require_file_write(PermissionDecl(), target, "default", sandbox_policy=sandbox)
+            return True
+        except PermissionError:
+            return False
+
+
+def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
+    """Tier 2 R1: the --grant-file-write holder flag ACTUALLY gates file.write on
+    the REAL web perm resolver. Differential (the falsification pair): grant=True
+    allows an in-repo write, grant=False denies it. Not a source string-grep."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    repo = tmp_path / "container_repo"
+    sandbox = SandboxPolicy(write_paths=[str(repo)])
+    target = str(repo / "src" / "x.py")
+    assert _web_can_write(target, sandbox, grant=True, ws=repo) is True
+    assert _web_can_write(target, sandbox, grant=False, ws=repo) is False
+
+
+def test_file_zone_root_from_holder_anchors_default_zone(tmp_path, monkeypatch):
+    """Tier 2 R1: file_zone_root receives the holder's container repo root (#1414)
+    at RUNTIME. Differential (no grant): a write into <repo>/.reyn (the default
+    write zone anchored on file_zone_root) is allowed when ws_base_dir=repo, but
+    DENIED when the holder has no ws_base_dir (zone anchors on the host root)."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    repo = tmp_path / "container_repo"
+    sandbox = SandboxPolicy(write_paths=[str(repo)])
+    default_zone_target = str(repo / ".reyn" / "x.yaml")
+    assert _web_can_write(default_zone_target, sandbox, grant=False, ws=repo) is True
+    assert _web_can_write(default_zone_target, sandbox, grant=False, ws=None) is False


### PR DESCRIPTION
**[e2e-coder]** — #1401 PR-A: port the 3 scoped capabilities (env-backend / exclude-tools / grant-write) to the A2A / `reyn web` server path.

PR-A of the #187 capstone (owner GO, lead design-approved). PR-B (next) swaps the SWE runner REPL→A2A `message/send`.

## Problem

The A2A / `reyn web` path had **none** of the scoped capabilities #1289/#1398/#1400 gave `reyn chat`: web/deps' session factory passed only `sandbox_config` — no env-backend instance, no exclude-tools, no file-write grant (the #1402 single-source migration documented these as explicit `None` defaults). For a faithful SWE eval that means tools run **host-side** (not the per-instance container → no real model_patch), the agent **can't edit the repo**, and the **web-disable #1400 closed reopens**.

## PR-A (the consumer #1402 set up)

- **`reyn web` CLI**: `--env-backend`/`--container` (`register_env_backend_args`) + `--grant-file-write` + `--exclude-tools`, symmetric with `reyn chat`.
- **`_apply_cli_scoped_overrides(args)`**: builds the env-backend **INSTANCE** in the CLI process and threads it (+ workspace dirs, exclude-tools, grant) to web/deps via a module-global holder. The instance is threaded, **not** rebuilt app-side from a string — that would double-build/attach the container, re-opening the drift class #1402/#1412 rooted (the `string_vs_instance` pin). **`--reload` is guarded** (its worker subprocess can't read the parent's module-global → fail loud, not a silent no-op).
- **web/deps.py**: a `CliScopedOverrides` holder + contextmanager (test isolation — resets the cached perm-resolver/registry singletons); `_get_perm_resolver` applies the grant + `file_zone_root=ws_base_dir` (#1414); `_session_factory` **fills the #1402-documented `None` defaults** (environment_backend + sandbox_backend = the single-shared instance #1200, exclude_tools, workspace dirs) via the same `build_scoped_chat_session`.

## Mechanism note (lead-endorsed)

Module-global holder, **not** `app.state`: the session factory is a **process-global closure** (built in `_get_registry`'s lazy singleton, not request-scoped), so `app.state` — read via `Request` in handlers — doesn't fit. This is the instance version of the existing `REYN_WEB_*` env-var pattern (a factory-shape decision, not ignoring a seam). `allowed_mcp`/`agent_id`/`router_max_iterations` remain the #1431 item-2 gaps.

## Test plan

- [x] `tests/test_web_scoped_capabilities_1401.py` (9) — contextmanager isolation (singleton-reset); plain-`reyn web` no-op (behavior-preserving); **--reload guard per scoped flag**; holder threading (comma-split, no-container path); **factory round-trip wiring** (holder → `build_scoped_chat_session`, not None); **R1 real-resolver enforcement** — `_get_perm_resolver()` build + falsification pair: grant=True→file.write allow / grant=False→deny, and file_zone_root=repo→default-zone allow / None→deny (not a string-grep).
- [x] Existing web/A2A tests (`test_fp0001_a2a_endpoints` / `test_web_python_unsafe_config` / `web/test_a2a`) — 29 pass, unchanged.
- [x] `pytest -q` full suite — 2 pre-existing unrelated failures only (swebench env / web_fetch BeautifulSoup); zero new breakage.
- [x] `ruff check` + `scripts/test_tier_audit.py --strict` clean.

Refs #1401 #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
