### PR TITLE
feat(1418): edit_file show-not-judge context preview of the changed region

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -82,6 +82,14 @@ Each is a distinct op kind with its own schema; there is no `op` sub-field.
 
 Permission scopes are configured per-op kind. See `reference/config/permissions.md`.
 
+A successful `edit_file` result additionally carries a `preview` (str, #1418): a
+numbered-line view (`<lineno>\t<text>`, 1-based) of the changed region — the
+lines around where `new_string` landed (±3 by default), so the agent can SEE
+*what* changed and at what indentation, not just `{status, replacements}`. It is
+**show-not-judge** (numbered lines only — no syntax check or validity verdict),
+**language-agnostic** (pure line slicing), and bounded (capped height). For
+`replace_all` it shows the first changed region; the count is in `replacements`.
+
 ### The coarse `file` execution backend (not phase-emittable)
 
 The fine kinds above are the only file ops a phase advertises to (and accepts

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -424,6 +424,49 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
             "matches": matches, "count": len(matches)}
 
 
+def _changed_region_preview(
+    new_content: str,
+    start_offset: int,
+    new_len: int,
+    *,
+    context_lines: int = 3,
+    max_lines: int = 40,
+) -> str:
+    """A numbered-line view of the changed region for an edit result (#1418).
+
+    **show-not-judge**: renders the lines around where ``new_string`` landed as
+    1-based ``<lineno>\\t<text>`` only — NO syntax check, NO validity verdict, no
+    encoding of "correct". The agent self-assesses (e.g. notices it inserted at
+    indent 0 while the surrounding body is indent 8).
+
+    **language-agnostic**: pure line slicing, no language parsing — works on any
+    text file, not just Python.
+
+    **bounded-by-construction**: capped at ``max_lines`` so a large multi-line
+    insert cannot bloat the result.
+
+    ``start_offset`` is the char offset (in ``new_content``) where the change
+    begins — i.e. ``content.index(old_string)``, which is identical in the old
+    and new content because the prefix is unchanged. ``new_len`` is
+    ``len(new_string)`` (0 for a deletion, which then shows the surrounding
+    context at the seam).
+    """
+    lines = new_content.split("\n")
+    total = len(lines)
+    start_line = new_content.count("\n", 0, start_offset)
+    end_line = new_content.count("\n", 0, start_offset + new_len)
+    lo = max(0, start_line - context_lines)
+    hi = min(total - 1, end_line + context_lines)
+    truncated = False
+    if hi - lo + 1 > max_lines:
+        hi = lo + max_lines - 1
+        truncated = True
+    rendered = "\n".join(f"{i + 1}\t{lines[i]}" for i in range(lo, hi + 1))
+    if truncated:
+        rendered += "\n…\t(preview truncated)"
+    return rendered
+
+
 def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
     if op.old_string is None:
         return {"kind": "file", "op": "edit", "status": "error", "error": "old_string is required"}
@@ -455,7 +498,16 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
     ctx.workspace.write_file(op.path, new_content)
     replacements = count if op.replace_all else 1
     ctx.events.emit("tool_executed", op="edit_file", path=op.path, replacements=replacements)
-    return {"kind": "file", "op": "edit", "path": op.path, "status": "ok", "replacements": replacements}
+    # #1418: an additive, show-not-judge preview of the changed region so the
+    # agent can SEE what landed (and at what indent), not just the count. For
+    # replace_all this shows the first changed region; the count is in
+    # ``replacements``.
+    start_offset = content.index(op.old_string)
+    preview = _changed_region_preview(new_content, start_offset, len(op.new_string))
+    return {
+        "kind": "file", "op": "edit", "path": op.path, "status": "ok",
+        "replacements": replacements, "preview": preview,
+    }
 
 
 def regenerate_index_impl(

--- a/tests/test_edit_file_preview_1418.py
+++ b/tests/test_edit_file_preview_1418.py
@@ -1,0 +1,167 @@
+"""Tier 2: #1418 — edit_file returns a show-not-judge context preview.
+
+After a successful `edit_file`, the result carries a `preview` (additive to
+`{status, replacements}`): a 1-based numbered-line view of the changed region so
+the agent can SEE what landed and at what indentation. The guardrails are
+behavioral, so the tests are too (real Workspace + op_runtime, no mocks):
+
+- **show-not-judge**: the preview is numbered lines only — no syntax check, no
+  validity verdict. A wrong-indent edit surfaces the real indent; a syntactically
+  broken edit still yields a plain numbered view, never a judgment.
+- **language-agnostic**: pure line slicing → works on a non-Python file.
+- **bounded-by-construction**: a large multi-line insert is capped.
+- edges: `replace_all` shows the first region (count stays in `replacements`);
+  an empty `new_string` (deletion) shows the surrounding seam context.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.permissions.permissions import PermissionResolver
+from reyn.tools import get_default_registry
+from reyn.tools.dispatch import invoke_tool
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.workspace import Workspace
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={"file.read": "allow", "file.write": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return ToolContext(
+        events=events,
+        permission_resolver=_resolver(tmp_path),
+        workspace=ws,
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _edit(tmp_path, args: dict) -> dict:
+    return asyncio.run(invoke_tool(get_default_registry(), "edit_file", args, _ctx(tmp_path)))
+
+
+# ── show-not-judge ──────────────────────────────────────────────────────────
+
+
+def test_preview_shows_new_line_at_actual_indent_in_context(tmp_path, monkeypatch):
+    """Tier 2: #1418 — a wrong-indent edit surfaces the new line at its ACTUAL
+    indent inside the surrounding (still-indented) context, so the agent can
+    self-notice the mismatch. The preview shows it; it never flags it."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "m.py").write_text(
+        "def f():\n        a = 1\n        b = 2\n        c = 3\n        return a\n"
+    )
+    result = _edit(
+        tmp_path,
+        {"path": "m.py", "old_string": "        b = 2", "new_string": "b = 2  # bad indent"},
+    )
+    assert result["status"] == "ok"
+    preview = result["preview"]
+    # The new line landed at indent 0 (line 3) ...
+    assert "3\tb = 2  # bad indent" in preview
+    # ... while the surrounding lines are still indent-8 — the contrast is visible.
+    assert "        a = 1" in preview
+    assert "        c = 3" in preview
+
+
+def test_preview_has_no_validity_verdict(tmp_path, monkeypatch):
+    """Tier 2: #1418 — show-not-judge: even a syntactically broken edit yields a
+    plain numbered view (status stays ok — the op does not judge validity), with
+    no verdict word in the preview."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "m.py").write_text("x = 1\ny = 2\nz = 3\n")
+    result = _edit(
+        tmp_path,
+        {"path": "m.py", "old_string": "y = 2", "new_string": "y = (  "},  # broken
+    )
+    assert result["status"] == "ok"
+    preview = result["preview"].lower()
+    for verdict in ("error", "invalid", "syntax", "warning", "valid", "correct"):
+        assert verdict not in preview, f"preview must not judge validity ({verdict!r} present)"
+
+
+# ── language-agnostic ───────────────────────────────────────────────────────
+
+
+def test_preview_works_on_non_python_file(tmp_path, monkeypatch):
+    """Tier 2: #1418 — language-agnostic: a Markdown (non-Python) edit gets the
+    same numbered-region view. No parser that could reject non-Python is run."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "README.md").write_text("# Title\n\nold paragraph\n\n## Section\n")
+    result = _edit(
+        tmp_path,
+        {"path": "README.md", "old_string": "old paragraph", "new_string": "new paragraph"},
+    )
+    assert result["status"] == "ok"
+    assert "3\tnew paragraph" in result["preview"]
+
+
+# ── 1-based numbering ───────────────────────────────────────────────────────
+
+
+def test_preview_line_numbers_are_1_based(tmp_path, monkeypatch):
+    """Tier 2: #1418 — preview line numbers are 1-based and match the file's
+    actual line positions (the changed line and its neighbors)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("L1\nL2\nL3\nL4\nL5\nL6\nL7\n")
+    preview = _edit(tmp_path, {"path": "f.txt", "old_string": "L4", "new_string": "X4"})["preview"]
+    assert "4\tX4" in preview
+    assert "1\tL1" in preview
+    assert "7\tL7" in preview
+
+
+# ── edges ───────────────────────────────────────────────────────────────────
+
+
+def test_preview_replace_all_shows_first_region_count_in_replacements(tmp_path, monkeypatch):
+    """Tier 2: #1418 — replace_all shows the FIRST changed region in the preview;
+    the total count stays in `replacements` (a far second occurrence is outside
+    the first region's window)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("a\nTODO\nb\nc\nd\ne\nf\nTODO\ng\n")
+    result = _edit(
+        tmp_path,
+        {"path": "f.txt", "old_string": "TODO", "new_string": "DONE", "replace_all": True},
+    )
+    assert result["status"] == "ok"
+    assert result["replacements"] == 2
+    preview = result["preview"]
+    assert "2\tDONE" in preview        # first region shown
+    assert "8\tDONE" not in preview    # far second occurrence not in the window
+
+
+def test_preview_deletion_shows_surrounding_context(tmp_path, monkeypatch):
+    """Tier 2: #1418 — an empty new_string (deletion) shows the surrounding
+    context at the seam where the text was removed."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("one\ntwo\nDELETE_ME\nthree\nfour\n")
+    result = _edit(tmp_path, {"path": "f.txt", "old_string": "DELETE_ME\n", "new_string": ""})
+    assert result["status"] == "ok"
+    preview = result["preview"]
+    assert "DELETE_ME" not in preview  # the deleted text is gone
+    assert "two" in preview            # surrounding lines frame the seam
+    assert "three" in preview
+
+
+def test_preview_multiline_insert_is_bounded(tmp_path, monkeypatch):
+    """Tier 2: #1418 — bounded-by-construction: a large multi-line insert is
+    truncated, not rendered in full, so the preview cannot bloat the result."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_text("head\nANCHOR\ntail\n")
+    big = "\n".join(f"line{i}" for i in range(200))
+    result = _edit(tmp_path, {"path": "f.txt", "old_string": "ANCHOR", "new_string": big})
+    assert result["status"] == "ok"
+    preview = result["preview"]
+    assert "line0" in preview          # the start of the region is shown ...
+    assert "line199" not in preview    # ... but the far tail is truncated, not full
+    assert "preview truncated" in preview


### PR DESCRIPTION
**[e2e-coder]** — #1418 (owner GO 2026-06-08, design B lead-reviewed). General-UX track, landed after the #187 capstone build. Single localized PR.

## What
`_execute_edit` returned only `{status, replacements}` — no view of the result. Adds an **additive** `preview` field: a 1-based numbered-line view (`<lineno>\t<text>`) of the changed region (±3 lines around where `new_string` landed), so the agent can SEE *what* changed and at what indentation, not just the count.

This is the deny-message-decision-enabling principle applied to edits (make the result informative → agent self-assesses), structurally satisfying the verify-feedback leg of context-adequacy.

## Guardrails (the non-cheat boundary, per design B)
- **show-not-judge** — numbered lines only. NO syntax check, NO validity verdict, no "correct" encoding. The agent self-assesses (e.g. notices indent-0 insert into an indent-8 body); the OS never judges.
- **language-agnostic** — pure line slicing (`_changed_region_preview`), no `ast.parse`/linter (rejected as language-specific = overfit).
- **bounded-by-construction** — capped height (~40 lines) so a large multi-line insert cannot bloat the result.
- **edges** — `replace_all` shows the first changed region (count stays in `replacements`); empty `new_string` (deletion) shows the surrounding seam.

## Non-breaking / sync
- `{status, replacements}` retained; `preview` is purely additive. No strict-schema consumer exists (the only `replacements` grep hit in src is `dogfood/publish.py`, an unrelated string-tuple list). Existing edit-op + dispatch tests pass unchanged.
- The result is a plain dict (not a Pydantic model) and the file-op result isn't in `OP_KIND_MODEL_MAP` (which maps **input** IR classes) → no model to sync. `control-ir.md` File-ops section gets a note on the new field (CLAUDE.md doc-sync rule).

## Test plan (real Workspace + op_runtime, no mocks — Tier 2)
- [x] wrong-indent edit → preview shows the new line at its actual indent in surrounding context (`test_preview_shows_new_line_at_actual_indent_in_context`)
- [x] no validity verdict in preview, even on a broken edit (`test_preview_has_no_validity_verdict` — show-not-judge)
- [x] non-Python (Markdown) file works (`test_preview_works_on_non_python_file` — language-agnostic)
- [x] 1-based line numbers match actual positions (`test_preview_line_numbers_are_1_based`)
- [x] replace_all → first region in preview, count in `replacements` (`test_preview_replace_all_shows_first_region_count_in_replacements`)
- [x] deletion → surrounding seam context (`test_preview_deletion_shows_surrounding_context`)
- [x] large multi-line insert truncated, not full (`test_preview_multiline_insert_is_bounded` — bounded-by-construction, behavioral not line-count)
- [x] `pytest -q` new file (7) + edit-op regression (test_file_edit_registry / not_found_suggestions / fine_grained_dispatch / phase_dispatch / universal_dispatch) = 57 pass; `ruff check` clean; `test_tier_audit --strict` 0 errors

Refs #1418 #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)