### PR TITLE
feat(1439): Fix #1 (1/2) — autonomy-mode SP signal for run-once (no clarifying-question dead-stop)

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -201,6 +201,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 eager_embedding_build=False,
                 exclude_tools=None,
                 router_max_iterations=5,
+                non_interactive=False,  # #1439 Fix #1: interactive UI = byte-identical
                 environment_backend=None,
                 sandbox_backend=None,
                 workspace_base_dir=None,

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -74,6 +74,7 @@ def build_system_prompt(
     search_actions_enabled: bool = True,  # FP-0034 §D14 — default True preserves byte-compat
     context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
     discovery_mandate: bool = False,  # #187 Stage C — weak-tier list_actions-first mandate (3x)
+    non_interactive: bool = False,  # #1439 Fix #1 — run-once (no TTY): no user to ask, proceed instead of clarifying
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
@@ -287,8 +288,17 @@ def build_system_prompt(
         " per-target action directly without decomposition — it loses"
         " the iteration shape and gets stuck on the first item.",
         "",
-        "**Ambiguous or missing essential information** → ask ONE"
-        " clarifying question instead of guessing.",
+        # #1439 Fix #1: in run-once (no interactive user), asking a clarifying
+        # question is a structural dead-end (nobody answers → the agent stalls,
+        # 13398). Interactive default is byte-identical.
+        (
+            "**Ambiguous or missing essential information** → there is no"
+            " interactive user to ask; state your best assumption and proceed"
+            " (do NOT stop to ask a clarifying question)."
+            if non_interactive else
+            "**Ambiguous or missing essential information** → ask ONE"
+            " clarifying question instead of guessing."
+        ),
         "",
     ])
 

--- a/src/reyn/chat/scoped_session_factory.py
+++ b/src/reyn/chat/scoped_session_factory.py
@@ -52,6 +52,7 @@ def build_scoped_chat_session(
     exclude_tools: "frozenset[str] | set[str] | None",  # #1400 tool names hidden + execution-blocked
     agent_id: str | None,  # FP-0016 agent-id-scoped memory
     router_max_iterations: int,  # #187 per-message tool-call budget
+    non_interactive: bool,  # #1439 Fix #1: run-once (no TTY) → SP proceeds instead of asking a clarifying question. Per-frontend: chat-CLI = not isatty(); A2A/MCP/chainlit/dogfood = False (interactive byte-identical)
     eager_embedding_build: bool,  # build the action embedding index up-front
     allowed_mcp: list[str] | None,  # per-profile MCP allow-list
     # ── per-session config (required: should be UNIFORM across factories) ──
@@ -77,6 +78,7 @@ def build_scoped_chat_session(
         exclude_tools=exclude_tools,
         agent_id=agent_id,
         router_max_iterations=router_max_iterations,
+        non_interactive=non_interactive,
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
         sandbox_config=sandbox_config,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1281,6 +1281,7 @@ class ChatSession:
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
+        non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -1319,6 +1320,11 @@ class ChatSession:
         # so the one-shot path constructs the session with a higher value. Bounded
         # either way — the loop stops at the cap (finite) or when the agent ends.
         self._router_max_iterations = int(router_max_iterations)
+        # #1439 Fix #1: in run-once (no interactive user) the router SP must not
+        # tell the agent to "ask ONE clarifying question" (nobody answers → dead
+        # stop, 13398). Threaded to build_system_prompt below. Default False =
+        # interactive byte-identical.
+        self._non_interactive = bool(non_interactive)
         # FP-0017 follow-up: declarative sandbox config (reyn.yaml `sandbox:`).
         # Plumbed through to spawned Agents so sandboxed_exec backend selection
         # honors the operator's declared policy.
@@ -5220,6 +5226,7 @@ class ChatSession:
             project_context=self._router_host.get_project_context(),
             indexed_sources_section=None,
             universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
+            non_interactive=self._non_interactive,  # #1439 Fix #1
         )
 
     def _cap_tool_result(self, content_str: str) -> str:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -408,6 +408,11 @@ def run(args: argparse.Namespace) -> None:
             # one-shot autonomous path (`reyn run-once`) raises it (explore→edit→
             # verify needs many rounds). --max-iterations unset → 5 (unchanged).
             router_max_iterations=int(getattr(args, "max_iterations", None) or 5),
+            # #1439 Fix #1: run-once pipes stdin (no TTY) → the SP proceeds with an
+            # assumption instead of asking a clarifying question nobody can answer
+            # (13398). Interactive `reyn chat` (TTY) → False = byte-identical. Same
+            # isatty() signal already feeds perm_resolver (interactive=) + use_tui.
+            non_interactive=not sys.stdin.isatty(),
             # #1289: same backend instance to both seams (single-shared-sandbox).
             environment_backend=env_backend,
             sandbox_backend=env_backend,

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -479,6 +479,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 agent_id=None,
                 exclude_tools=None,
                 router_max_iterations=5,
+                non_interactive=False,  # #1439 Fix #1: dogfood driver = byte-identical (run-once-only fix)
                 workspace_base_dir=ws_base_dir,
                 workspace_state_dir=ws_state_dir,
             )

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -421,6 +421,7 @@ def run_serve(args: argparse.Namespace) -> None:
             agent_id=None,
             exclude_tools=None,
             router_max_iterations=5,
+            non_interactive=False,  # #1439 Fix #1: stdio-MCP byte-identical (run-once-only fix)
             environment_backend=None,  # gap: MCP-serve lacks env-backend / container-rooting
             sandbox_backend=None,
             workspace_base_dir=None,

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -350,6 +350,7 @@ def _get_registry():
                 agent_id=None,
                 exclude_tools=_scoped.exclude_tools,
                 router_max_iterations=5,
+                non_interactive=False,  # #1439 Fix #1: A2A byte-identical (run-once-only fix). A2A-non-interactive = documented follow-up (cf factory module doc)
                 environment_backend=_scoped.environment_backend,
                 sandbox_backend=_scoped.environment_backend,
                 workspace_base_dir=_scoped.workspace_base_dir,

--- a/tests/test_router_sp_non_interactive_1439.py
+++ b/tests/test_router_sp_non_interactive_1439.py
@@ -1,0 +1,59 @@
+"""Tier 2: #1439 Fix #1 — autonomy-mode router SP signal (run-once path).
+
+`build_system_prompt` renders "ask ONE clarifying question instead of guessing"
+for the interactive router. In run-once (piped stdin, no TTY) there is no user
+to answer, so that directive is a structural dead-end (the agent stalls asking,
+13398). The `non_interactive` flag swaps that one directive for a proceed-with-
+assumption directive; everything else (and the whole interactive SP) is unchanged.
+
+Real `build_system_prompt`, no mocks.
+"""
+from __future__ import annotations
+
+from reyn.chat.router_system_prompt import build_system_prompt
+
+_CLARIFY = "ask ONE"
+_PROCEED = "no interactive user to ask"
+
+
+def _sp(*, non_interactive: bool) -> str:
+    return build_system_prompt(
+        agent_name="chat",
+        agent_role="general agent",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+        non_interactive=non_interactive,
+    )
+
+
+def test_interactive_default_keeps_clarifying_question() -> None:
+    """Tier 2: #1439 Fix #1 — the default (interactive) SP keeps the "ask ONE
+    clarifying question" directive = byte-identical to pre-#1439 behaviour."""
+    sp = _sp(non_interactive=False)
+    assert _CLARIFY in sp
+    assert _PROCEED not in sp
+
+
+def test_non_interactive_replaces_clarifying_with_proceed() -> None:
+    """Tier 2: #1439 Fix #1 — non_interactive (run-once) omits the clarifying-
+    question directive and instead tells the agent to proceed with an assumption
+    (no user to ask). This is the 13398 dead-stop fix."""
+    sp = _sp(non_interactive=True)
+    assert _CLARIFY not in sp, "run-once SP must not tell the agent to ask a clarifying question"
+    assert _PROCEED in sp
+    # show-not-judge of the directive: it tells it to proceed, not to stop.
+    assert "proceed" in sp.lower()
+
+
+def test_default_param_is_interactive() -> None:
+    """Tier 2: #1439 Fix #1 — omitting the param defaults to interactive
+    (byte-identical), so every existing caller is unaffected."""
+    default_sp = build_system_prompt(
+        agent_name="chat",
+        agent_role="general agent",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+    )
+    assert default_sp == _sp(non_interactive=False)

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -53,6 +53,7 @@ _REQUIRED_SCOPED = frozenset({
     "exclude_tools",
     "agent_id",
     "router_max_iterations",
+    "non_interactive",  # #1439 Fix #1: run-once SP autonomy flag (per-frontend scoped)
     "eager_embedding_build",
     "allowed_mcp",
     # per-session config (should be UNIFORM across factories)


### PR DESCRIPTION
**[e2e-coder]** — #1439 Fix #1 (design lead-approved). Split from Fix #2 (replay-gated) so this clean/independent fix isn't gated. Production general-agent path.

## Problem (lead source-verified)
run-once (piped stdin, no TTY) renders the interactive router SP, whose "ask ONE clarifying question instead of guessing" (`router_system_prompt.py:290-291`) is a structural dead-end with no user to answer → the agent stalls asking (13398, with maximal context = not a discovery gap).

## Fix
- `build_system_prompt(..., non_interactive: bool = False)` — swaps **only** that one directive for a proceed-with-assumption directive (mirror the `discovery_mandate` plumbing, #187 Stage C). Interactive default = byte-identical.
- Signal source = the **existing** `sys.stdin.isatty()` already feeding `perm_resolver(interactive=)` + `use_tui` — no new detection.
- Threaded as a **required** scoped param through the #1402 single-source factory (completeness-by-construction, the construction-forwarding-gap discipline). Per-frontend:
  - chat-CLI / run-once → `not sys.stdin.isatty()` (the fix; interactive TTY → False)
  - A2A / stdio-MCP / chainlit / dogfood → `False` (byte-identical; A2A-non-interactive = documented follow-up)

## Test plan (real `build_system_prompt`, no mocks — Tier 2)
- [x] `non_interactive=True` → SP omits clarifying directive, adds proceed directive (`test_non_interactive_replaces_clarifying_with_proceed`)
- [x] default (False) → keeps clarifying directive = byte-identical (`test_interactive_default_keeps_clarifying_question`)
- [x] omitted param → defaults to interactive (`test_default_param_is_interactive`)
- [x] factory invariant: `non_interactive` in `_REQUIRED_SCOPED`, all 5 frontends pass it (`test_scoped_session_factory_invariant_1402`)
- [x] `pytest -q` (114 SP/session/frontend/g12 regression) + `ruff` + `tier_audit --strict` all green

Refs #1439 #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)