### PR TITLE
feat(1439): Fix #2 (2/2) — status-aware g12 signal (no "task complete" on errored tool) [REPLAY-GATED]

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -308,6 +308,46 @@ def _dump_llm_response(request_id: str | None, payload: dict) -> None:
 
 _G12_SIGNAL_TEXT = "(answered) — task complete; reply to user or chain another tool"
 
+# #1439 Fix #2: the trailing-tool result was an ERROR. The success text above
+# asserts "task complete" unconditionally, so an errored exec carried "task
+# complete" → the agent narrated error-as-success (14096). The error cell drops
+# "complete" and signals the failure + a continuation nudge (decision-enabling).
+# Only the error cell changes; the success text is byte-identical so the
+# empty-stop-tuned envelope (#1424) recovery on the common success path is
+# unchanged by construction (replay-gate narrows to the error cell).
+_G12_SIGNAL_ERROR_TEXT = (
+    "(tool error) — the tool call did NOT succeed; inspect the error and decide"
+    " the next step before continuing (do not report success)"
+)
+
+# Tool-result status values (JSON `status` field) that mean the call failed.
+# Sourced from the op_runtime envelopes (error / denied / not_found) + a generic
+# "failed". Anything else (ok / absent / non-JSON / unparseable) is the success
+# cell = byte-identical signal.
+_G12_ERROR_STATUSES = frozenset({"error", "denied", "not_found", "failed"})
+
+
+def _trailing_tool_is_error(content: str) -> bool:
+    """#1439 Fix #2: True iff a JSON tool result carries an explicit error status.
+
+    Conservative by design: only valid JSON with ``status`` in
+    ``_G12_ERROR_STATUSES`` counts as an error. A non-JSON body, an unparseable
+    ``{``-prefixed string (the existing string-surgery path handles those), a
+    missing ``status``, or ``status: "ok"`` all return False → the success cell
+    (byte-identical signal). This keeps the error path narrow so the replay-gate
+    risk is bounded to genuinely-errored trailing tools.
+    """
+    if not content.startswith("{"):
+        return False
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    status = parsed.get("status")
+    return isinstance(status, str) and status.lower() in _G12_ERROR_STATUSES
+
 
 def _g12_signal_enabled() -> bool:
     """Return True unless `REYN_G12_SIGNAL` env var explicitly disables it.
@@ -355,6 +395,11 @@ def _apply_g12_signal(messages: list[dict]) -> list[dict]:
     content = last.get("content")
     if not isinstance(content, str):
         return messages
+    # #1439 Fix #2: status-aware signal text. An errored trailing tool result
+    # gets the error signal (no "task complete"); everything else keeps the
+    # byte-identical success signal. The embed STRUCTURE is unchanged — only the
+    # injected text differs — so all structural branches below are preserved.
+    signal = _G12_SIGNAL_ERROR_TEXT if _trailing_tool_is_error(content) else _G12_SIGNAL_TEXT
     new_last = dict(last)
     if content.startswith("{"):
         inner = content[1:]
@@ -362,13 +407,13 @@ def _apply_g12_signal(messages: list[dict]) -> list[dict]:
         # separator comma, otherwise the output would have a trailing
         # `, }` which fails JSON parse.
         if inner.lstrip().startswith("}"):
-            new_last["content"] = f'{{"_g12_signal": "{_G12_SIGNAL_TEXT}"{inner}'
+            new_last["content"] = f'{{"_g12_signal": "{signal}"{inner}'
         else:
             new_last["content"] = (
-                f'{{"_g12_signal": "{_G12_SIGNAL_TEXT}", {inner}'
+                f'{{"_g12_signal": "{signal}", {inner}'
             )
     else:
-        new_last["content"] = f"{_G12_SIGNAL_TEXT}\n\n{content}"
+        new_last["content"] = f"{signal}\n\n{content}"
     return messages[:-1] + [new_last]
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -327,15 +327,29 @@ _G12_SIGNAL_ERROR_TEXT = (
 _G12_ERROR_STATUSES = frozenset({"error", "denied", "not_found", "failed"})
 
 
-def _trailing_tool_is_error(content: str) -> bool:
-    """#1439 Fix #2: True iff a JSON tool result carries an explicit error status.
+def _is_g12_error_status(status: object) -> bool:
+    """True iff ``status`` is an explicit error value (str in _G12_ERROR_STATUSES)."""
+    return isinstance(status, str) and status.lower() in _G12_ERROR_STATUSES
 
-    Conservative by design: only valid JSON with ``status`` in
-    ``_G12_ERROR_STATUSES`` counts as an error. A non-JSON body, an unparseable
-    ``{``-prefixed string (the existing string-surgery path handles those), a
-    missing ``status``, or ``status: "ok"`` all return False → the success cell
-    (byte-identical signal). This keeps the error path narrow so the replay-gate
-    risk is bounded to genuinely-errored trailing tools.
+
+def _trailing_tool_is_error(content: str) -> bool:
+    """#1439 Fix #2: True iff a JSON tool result carries an explicit error status
+    — at the **dispatch level (top-level) OR the op level (nested under data)**.
+
+    The production envelope nests the op status: ``dispatch_tool`` wraps every
+    successful dispatch as ``{"status": "ok", "data": <op_result>}`` (dispatcher.py
+    :84-97, confirmed router_loop.py:1913), so an op-execution error (file/grep
+    failure, exec returncode≠0 — incl. the 14096 case) lives at ``data.status``
+    while the top-level stays ``ok``. Only a *dispatch*-level failure (tool-not-
+    found / perm-deny / dispatch exception) sets the top-level ``status`` to error.
+    We check both: top-level first, then one level into ``data``.
+
+    Conservative by design: only valid JSON with an explicit error status (at
+    either level) counts. A non-JSON body, an unparseable ``{``-prefixed string
+    (the existing string-surgery path handles those), a missing status, or
+    ``ok`` at both levels → False → the success cell (byte-identical signal). This
+    keeps the error path narrow so the replay-gate risk is bounded to genuinely-
+    errored trailing tools.
     """
     if not content.startswith("{"):
         return False
@@ -345,8 +359,15 @@ def _trailing_tool_is_error(content: str) -> bool:
         return False
     if not isinstance(parsed, dict):
         return False
-    status = parsed.get("status")
-    return isinstance(status, str) and status.lower() in _G12_ERROR_STATUSES
+    # Dispatch-level error (top-level status) — rare.
+    if _is_g12_error_status(parsed.get("status")):
+        return True
+    # Op-execution error nested under the dispatch wrapper's ``data`` — the
+    # common case (and 14096). Recurse exactly one level.
+    data = parsed.get("data")
+    if isinstance(data, dict) and _is_g12_error_status(data.get("status")):
+        return True
+    return False
 
 
 def _g12_signal_enabled() -> bool:

--- a/tests/test_g12_signal_contract.py
+++ b/tests/test_g12_signal_contract.py
@@ -305,3 +305,42 @@ def test_absent_and_non_json_status_use_success_cell() -> None:
     plain = _apply_g12_signal([{"role": "tool", "content": "just text"}])[-1]["content"]
     assert plain.startswith("(answered)")
     assert "task complete" in plain
+
+
+# ── 6b. #1439 Fix #2: the PRODUCTION envelope nests op status under `data` ──
+# dispatch_tool wraps every successful dispatch as {"status":"ok","data":<op>},
+# so op-execution errors (the 14096 case) are at data.status while top-level is
+# "ok". The replay-gate (sandbox_2) caught that a top-level-only check is a no-op
+# on this envelope. These pin the nested detection on the REAL shapes.
+
+
+def test_nested_op_error_under_data_is_detected() -> None:
+    """Tier 2: #1439 Fix #2 — the production envelope {"status":"ok","data":
+    {...,"status":"error"}} (op-execution error nested under the dispatch wrapper)
+    routes to the error cell — no "task complete". This is the 14096 case the
+    top-level-only check missed; the replay-gate's primary evidence."""
+    # The exact 14096 shape: an errored sandboxed_exec nested under data.
+    content = (
+        '{"status": "ok", "data": {"kind": "sandboxed_exec", "status": "error",'
+        ' "returncode": 1, "stderr": "boom"}}'
+    )
+    signal = _signal_of(content)
+    assert "complete" not in signal.lower(), "nested op error must not claim completion"
+    assert "error" in signal.lower()
+    assert "next step" in signal.lower()
+
+
+@pytest.mark.parametrize("op_status", ["error", "denied", "not_found", "failed"])
+def test_nested_op_error_statuses_route_to_error_cell(op_status: str) -> None:
+    """Tier 2: #1439 Fix #2 — every op error status nested under data (the
+    wrapped envelope) is detected, not just top-level dispatch errors."""
+    content = f'{{"status": "ok", "data": {{"kind": "file", "status": "{op_status}"}}}}'
+    assert "complete" not in _signal_of(content).lower()
+
+
+def test_nested_ok_under_data_uses_success_cell() -> None:
+    """Tier 2: #1439 Fix #2 — the dominant production success shape
+    {"status":"ok","data":{...,"status":"ok"}} keeps the byte-identical success
+    signal (nested ok must NOT false-trigger the error cell)."""
+    content = '{"status": "ok", "data": {"kind": "file", "status": "ok", "data": {}}}'
+    assert "task complete" in _signal_of(content)

--- a/tests/test_g12_signal_contract.py
+++ b/tests/test_g12_signal_contract.py
@@ -249,3 +249,59 @@ def test_realistic_polluted_history_post_tool_shape() -> None:
     # No role=user "(answered)" message exists
     user_answered = [m for m in result if m.get("role") == "user" and m.get("content") == "(answered)"]
     assert user_answered == []
+
+
+# ── 6. #1439 Fix #2: status-aware signal (error must NOT say "task complete") ──
+
+
+def _signal_of(tool_content: str) -> str:
+    """Apply the signal to a trailing tool result and return the embedded
+    `_g12_signal` text (real helper, no mocks)."""
+    msgs = [
+        {"role": "assistant", "tool_calls": [{"id": "abc"}]},
+        {"role": "tool", "content": tool_content},
+    ]
+    return json.loads(_apply_g12_signal(msgs)[-1]["content"])["_g12_signal"]
+
+
+@pytest.mark.parametrize("err_status", ["error", "denied", "not_found", "failed"])
+def test_errored_trailing_tool_signal_does_not_claim_complete(err_status: str) -> None:
+    """Tier 2: #1439 Fix #2 — an errored trailing tool result must NOT carry a
+    "task complete" / "complete" signal (the 14096 error-as-success root). The
+    error signal still carries a continuation nudge (decision-enabling), and the
+    embed stays valid JSON with original fields intact."""
+    content = f'{{"status": "{err_status}", "error": "boom"}}'
+    signal = _signal_of(content)
+    assert "complete" not in signal.lower(), f"{err_status} signal must not assert completion"
+    # Decision-enabling: it names the failure + nudges a next step.
+    assert "error" in signal.lower()
+    assert "next step" in signal.lower()
+    # Structure preserved: still valid JSON, original fields intact.
+    parsed = json.loads(_apply_g12_signal(
+        [{"role": "tool", "content": content}]
+    )[-1]["content"])
+    assert parsed["status"] == err_status
+    assert parsed["error"] == "boom"
+
+
+def test_success_vs_error_signal_differential() -> None:
+    """Tier 2: #1439 Fix #2 — the falsification pair. A status=ok trailing tool
+    keeps the byte-identical "task complete" success signal; a status=error one
+    gets the no-completion error signal. Same code path, status-driven branch."""
+    ok_signal = _signal_of('{"status": "ok", "data": 1}')
+    err_signal = _signal_of('{"status": "error", "error": "x"}')
+    assert "task complete" in ok_signal          # success cell unchanged
+    assert "complete" not in err_signal.lower()   # error cell suppresses it
+    assert ok_signal != err_signal
+
+
+def test_absent_and_non_json_status_use_success_cell() -> None:
+    """Tier 2: #1439 Fix #2 — conservative boundary: a missing status, an
+    unparseable `{`-string, and plain-text content all fall to the success cell
+    (byte-identical signal), so the error path is narrow (replay-gate bound)."""
+    # status absent → success
+    assert "task complete" in _signal_of('{"data": 5}')
+    # plain-text content → success (prefix form)
+    plain = _apply_g12_signal([{"role": "tool", "content": "just text"}])[-1]["content"]
+    assert plain.startswith("(answered)")
+    assert "task complete" in plain


### PR DESCRIPTION
**[e2e-coder]** — #1439 Fix #2 (design lead-approved). ⚠️ **REPLAY-GATED merge** (see below). Production general-agent path. Independent of Fix #1 (PR (1/2)).

## Problem (lead source-verified)
`_apply_g12_signal` (`llm/llm.py:322`) injected `_G12_SIGNAL_TEXT = "(answered) — task complete; …"` into the trailing tool message **unconditionally**, no status check → an errored exec carried "task complete" → agent narrated error-as-success (14096).

## Fix — 2 cells (decision-enabling)
- **success cell** (status ok / absent / non-JSON / unparseable) → **byte-identical** `_G12_SIGNAL_TEXT`. The #1424 empty-stop-tuned recovery on the common success path is unchanged **by construction**.
- **error cell** (parsed JSON `status` ∈ {error,denied,not_found,failed}) → `_G12_SIGNAL_ERROR_TEXT`, drops "complete", names the failure + nudges a next step.
- `_trailing_tool_is_error` is conservative: only valid JSON + explicit error status routes to the error cell. Embed **structure** untouched (all structural branches preserved).

## ⚠️ REPLAY-GATE (hard merge precondition)
Touches the empty-stop-tuned envelope (`llm/llm.py:1184-1217`). Because the **success path is byte-identical**, the gate narrows to the error cell: **sandbox_2 trace-patch-replays the reworded signal and confirms success-cell empty-stop recovery ≥ #1424 baseline before this merges.** Do not merge until sandbox_2 posts the replay-gate green.

## Test plan (real `_apply_g12_signal`, no mocks — Tier 2)
- [x] error status (×4: error/denied/not_found/failed) → no "complete" + continuation nudge + structure preserved (`test_errored_trailing_tool_signal_does_not_claim_complete`)
- [x] success-vs-error differential = falsification pair (`test_success_vs_error_signal_differential`)
- [x] absent / non-JSON status → success cell, byte-identical (`test_absent_and_non_json_status_use_success_cell`)
- [x] existing success contract (status=ok :76/:241) unchanged = pinned green (要件1: no reword, lead-retracted)
- [x] `pytest -q` g12 contract (28) + `ruff` + `tier_audit --strict` green
- [ ] **REPLAY-GATE — sandbox_2: success-cell empty-stop recovery ≥ #1424 baseline** (merge precondition)

Refs #1439 #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)