### PR TITLE
fix(1443): wire non_interactive into the LIVE chat-router SP path (#1440 followup — was a no-op)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1265,6 +1265,7 @@ class RouterLoop:
         router_model: str = "light",  # config tier (light = intent classification)
         budget: Any = None,  # BudgetTracker | None — process-shared cost tracker
         system_prompt_override: str | None = None,
+        non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from ChatSession.
         exclude_tools: set[str] | None = None,
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
@@ -1291,6 +1292,13 @@ class RouterLoop:
         # of a plan") instead of the full chat router prompt. The host facade
         # still controls the tool catalog narrowing.
         self._system_prompt_override = system_prompt_override
+        # #1440 followup: run-once (no interactive user) → the LIVE chat-router SP
+        # (built at the build_system_prompt call below) must omit the "ask ONE
+        # clarifying question" directive. The original #1440 wired only the
+        # session-side _build_router_system_prompt (override/budget path), missing
+        # this live path → run-once still dead-stopped (13398). Threaded from
+        # ChatSession._non_interactive via the constructor.
+        self._non_interactive = bool(non_interactive)
         # Tool names to drop from the catalog (= post-build filter). Used by
         # plan executor to pass ``{"plan"}`` so plan steps cannot recursively
         # call plan (= prevents unbounded nesting). Discovered 2026-05-07:
@@ -1655,6 +1663,7 @@ class RouterLoop:
                 # router path reaches build_system_prompt — the phase op-loop
                 # uses system_prompt_override, so this does not touch it.
                 discovery_mandate=tier_wants_discovery_mandate(self.router_model),
+                non_interactive=self._non_interactive,  # #1440 followup: live-path wiring
             )
         # ChatSession._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -5503,6 +5503,11 @@ class ChatSession:
             host=self._router_host, chain_id=chain_id,
             max_iterations=self._router_max_iterations,
             budget=self._budget_tracker,
+            # #1440 followup: thread the run-once autonomy flag to the LIVE
+            # chat-router SP path (router_loop build_system_prompt). The original
+            # #1440 wired only _build_router_system_prompt; this reaches the path
+            # run-once actually renders. ChatSession._non_interactive set by #1440.
+            non_interactive=self._non_interactive,
             # #187: hide excluded tools (e.g. web for faithful SWE-eval) from the
             # MAIN agent loop's LLM-visible catalog (same hook the sub-loops use).
             exclude_tools=self._exclude_tools,

--- a/tests/test_router_loop_non_interactive_live_1443.py
+++ b/tests/test_router_loop_non_interactive_live_1443.py
@@ -1,0 +1,141 @@
+"""Tier 3a: #1443 — run-once autonomy reaches the LIVE chat-router SP path.
+
+#1440 added `non_interactive` to `build_system_prompt` and wired it into the
+session-side `_build_router_system_prompt` (override/budget path) — but the LIVE
+chat-router SP that `reyn run-once` actually renders is built separately inside
+`RouterLoop.run()` (router_loop.py), which omitted the flag → run-once still
+rendered the "ask ONE clarifying question" directive and dead-stopped (13398).
+The original #1440 test called `build_system_prompt` directly, so it unit-passed
+while the live path stayed broken.
+
+This test drives `RouterLoop.run()` with a recording `call_llm_tools` and asserts
+on the system message the loop ACTUALLY builds — exercising the live path the
+#1440 unit test missed. sandbox_2's local-patch preview independently confirmed
+the same live effect (`echo x | reyn run-once` renders the proceed-line, the
+clarifying line gone).
+
+Real RouterLoop + real `build_system_prompt`; the only injected double is a
+recording coroutine for `call_llm_tools` (the Tier-3 LLM-replay seam) — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=2)
+_CLARIFY = "ask ONE"
+_PROCEED = "no interactive user to ask"
+
+
+class _FakeEventLog:
+    def __init__(self) -> None:
+        self.emitted: list[dict] = []
+
+    def emit(self, type: str, **data) -> None:
+        self.emitted.append({"type": type, **data})
+
+
+class _FakeRouterHost:
+    """Minimal real RouterLoopHost — enough for RouterLoop.run() to build the
+    live SP and reach the first call_llm_tools."""
+
+    agent_name: str = "test-agent"
+    agent_role: str = "test role"
+    output_language: str = "en"
+
+    def __init__(self) -> None:
+        self._events = _FakeEventLog()
+        self.outbox: list[dict] = []
+
+    @property
+    def events(self) -> _FakeEventLog:
+        return self._events
+
+    def get_universal_wrappers_enabled(self) -> bool:
+        return True
+
+    def get_action_usage_tracker(self):  # type: ignore[return]
+        return None
+
+    def get_action_embedding_index(self):  # type: ignore[return]
+        return None
+
+    def get_embedding_provider(self):  # type: ignore[return]
+        return None
+
+    def get_embedding_model_class(self):  # type: ignore[return]
+        return None
+
+    def get_action_retrieval_config(self):  # type: ignore[return]
+        return None
+
+    def list_available_skills(self) -> list[dict]:
+        return []
+
+    def list_available_agents(self) -> list[dict]:
+        return []
+
+    def get_memory_index(self) -> dict:
+        return {"status": "not_found", "content": ""}
+
+    def get_file_permissions(self) -> dict | None:
+        return None
+
+    def get_mcp_servers(self) -> list[dict]:
+        return []
+
+    def get_web_fetch_allowed(self) -> bool:
+        return False
+
+    def get_project_context(self) -> str:
+        return ""
+
+    def resolve_model(self, name: str) -> str:
+        return "fake-model"
+
+    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+        self.outbox.append({"kind": kind, "text": text, "meta": meta})
+
+
+def _live_system_prompt(*, non_interactive: bool, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Drive RouterLoop.run() and return the system message it actually built."""
+    captured: dict[str, str] = {}
+
+    async def _recording_call_llm_tools(**kwargs: object) -> LLMToolCallResult:
+        messages = kwargs.get("messages") or []
+        if messages and messages[0].get("role") == "system":
+            captured["sp"] = messages[0]["content"]
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+        )
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _recording_call_llm_tools)
+    loop = RouterLoop(
+        host=_FakeRouterHost(), chain_id="chain-1443", non_interactive=non_interactive,
+    )
+    asyncio.run(loop.run("hello", []))
+    assert "sp" in captured, "the live router path did not build a system prompt"
+    return captured["sp"]
+
+
+def test_run_once_live_router_sp_proceeds_not_clarifies(monkeypatch):
+    """Tier 3a: #1443 — a non_interactive RouterLoop's LIVE rendered SP omits the
+    clarifying-question directive and carries the proceed directive. This is the
+    path `reyn run-once` renders; the #1440 unit test never exercised it."""
+    sp = _live_system_prompt(non_interactive=True, monkeypatch=monkeypatch)
+    assert _CLARIFY not in sp, "live run-once SP must not tell the agent to ask a clarifying question"
+    assert _PROCEED in sp
+
+
+def test_interactive_live_router_sp_keeps_clarifying(monkeypatch):
+    """Tier 3a: #1443 — the interactive default LIVE SP keeps the clarifying
+    directive (byte-compatible). The differential proves the flag threads through
+    RouterLoop into the live build_system_prompt call, not just the session path."""
+    sp = _live_system_prompt(non_interactive=False, monkeypatch=monkeypatch)
+    assert _CLARIFY in sp
+    assert _PROCEED not in sp


### PR DESCRIPTION
**[e2e-coder]** — #1443 (#1440 live-path no-op followup). Design lead-GREEN-LIT, sandbox_2 local-patch preview verified the live effect. Production general-agent path.

## Problem
#1440 wired `non_interactive` into `build_system_prompt` and the session-side `_build_router_system_prompt` (override/budget path) — but the LIVE chat-router SP `reyn run-once` renders is built in `RouterLoop.run()` (router_loop.py:1618), which **omitted** the flag → run-once still rendered "ask ONE clarifying question" → 13398 dead-stop persisted. `build_system_prompt` has exactly **2** call sites; #1440 wired one. The #1440 test called `build_system_prompt` directly → unit-passed while the live path stayed broken (same class as the #1439 envelope miss: unit-pass ≠ live-path reached).

## Fix (3-point wiring, mirrors discovery_mandate)
- `RouterLoop.__init__` gains `non_interactive: bool = False` + `self._non_interactive`
- the live `build_system_prompt` call passes `non_interactive=self._non_interactive`
- `ChatSession`'s `RouterLoop(...)` threads `non_interactive=self._non_interactive` (value #1440 set from `not sys.stdin.isatty()`)

## Primary evidence
- **sandbox_2 local-patch preview** (cited): `echo x | reyn run-once` renders the proceed-line, clarifying line GONE → non_interactive reaches the live 1623 path.
- **Falsification**: with the live kwarg removed, the new live-path test FAILS (the clarifying line returns). Restored → passes.

## Test plan (real RouterLoop + real build_system_prompt; only the LLM seam is a recording coroutine — Tier 3a)
- [x] **LIVE-PATH** `RouterLoop.run()` (non_interactive=True) → rendered system message omits clarifying, has proceed (`test_run_once_live_router_sp_proceeds_not_clarifies`) — the test #1440 lacked
- [x] interactive default (False) → clarifying present (differential proves threading through RouterLoop)
- [x] **completeness**: exactly 2 `build_system_prompt` call sites, both honor `non_interactive`; all `RouterLoop(...)` sites pass args by keyword (no positional shift) — verified planner ×3 / phase_executor / session / tests
- [x] regression: caller-module suites (force_close / empty_stop_retry / empty_stop_uniform / turn_completed) 21 pass; #1439 unit SP test still green; ruff + tier-audit clean
- [ ] sandbox_2 full re-run (post-merge live confirmation)

Refs #1443 #1440 #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)