### PR TITLE
fix(1442): mcp install targets the resolved project root, not cwd (3 layers)

### DIFF
--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -188,6 +188,14 @@ def register(sub) -> None:
         ),
     )
     install.add_argument(
+        "--project", dest="project", default=None, metavar="PATH",
+        help=(
+            "Project root containing reyn.yaml. Defaults to the closest "
+            "ancestor with a reyn.yaml, or the current directory. #1442: "
+            "without this, install resolved the target cwd-only."
+        ),
+    )
+    install.add_argument(
         "--scope",
         choices=_VALID_SCOPES,
         default="local",
@@ -520,6 +528,41 @@ def run_search(args: argparse.Namespace) -> None:
 # run_install
 # ---------------------------------------------------------------------------
 
+def _resolve_install_project_root(project_arg: str | None) -> Path:
+    """#1442 Layer A: resolve the install target project root, fail loud.
+
+    --project overrides; otherwise the closest reyn.yaml ancestor of cwd. When
+    neither yields a project (no --project and no reyn.yaml from cwd), exit with
+    an actionable message rather than silently writing into a non-project cwd
+    (the #1442 defect). Mirrors the `reyn mcp refresh` / `serve` resolution.
+    """
+    from reyn.config import _find_project_root
+
+    if project_arg:
+        project_root = Path(project_arg).resolve()
+    else:
+        found = _find_project_root(Path.cwd())
+        if found is None:
+            print(
+                "error: no reyn.yaml found from the current directory; pass "
+                "--project <path-to-project-root>. (mcp install writes the "
+                "server config under the project's .reyn/ — it will not guess "
+                "a non-project cwd.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        project_root = found
+
+    if not (project_root / "reyn.yaml").exists():
+        print(
+            f"error: {project_root}/reyn.yaml not found. "
+            "Run `reyn init` there or pass a different --project path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return project_root
+
+
 def run_install(args: argparse.Namespace) -> None:
     """Install an MCP server — thin wrapper over the mcp_install skill.
 
@@ -597,6 +640,12 @@ def run_install(args: argparse.Namespace) -> None:
     if non_interactive:
         os.environ["REYN_MCP_INSTALL_AUTO_APPROVE"] = "1"
 
+    # #1442 Layer A: resolve the project root ONCE (install was cwd-only +
+    # lacked --project, asymmetric with serve/list/refresh). --project overrides;
+    # else the closest reyn.yaml from cwd. Fail loud rather than silently writing
+    # into a non-project cwd. Threaded to both install paths below.
+    project_root = _resolve_install_project_root(getattr(args, "project", None))
+
     # ── Source mode: bypass skill, go direct to IR op handler ─────────────────
     if source:
         _run_install_from_source(
@@ -605,6 +654,7 @@ def run_install(args: argparse.Namespace) -> None:
             pre_env=pre_env,
             non_interactive=non_interactive,
             extra_args=extra_args,
+            project_root=project_root,
         )
         return
 
@@ -615,7 +665,7 @@ def run_install(args: argparse.Namespace) -> None:
     import json
 
     from reyn.agent import Agent
-    from reyn.config import _find_project_root, load_config, load_project_context
+    from reyn.config import load_config, load_project_context
     from reyn.llm.llm import run_async as _run_async
     from reyn.llm.model_resolver import ModelResolver
     from reyn.permissions.permissions import PermissionResolver
@@ -626,7 +676,11 @@ def run_install(args: argparse.Namespace) -> None:
     from ..logger_factory import make_logger
 
     config = load_config()
-    project_root = _find_project_root(Path.cwd())
+    # #1442 Layer A: root the agent's workspace at the resolved project_root so
+    # the mcp_install op handler writes there, not cwd. Mirrors `reyn mcp
+    # refresh` (os.chdir to project_root); the agent's cwd-defaulted workspace
+    # then base_dir-roots at it (paired with the handler base_dir fix, Layer B).
+    os.chdir(project_root)
 
     try:
         skill_dir, skill_root = _resolve_skill_path_raw("mcp_install")
@@ -711,17 +765,22 @@ def _run_install_from_source(
     pre_env: dict[str, str],
     non_interactive: bool,
     extra_args: list[str] | None = None,
+    *,
+    project_root: Path,
 ) -> None:
     """Install an MCP server directly from a ``--source`` specifier.
 
     Bypasses the mcp_install skill and the registry fetch, going directly
     to the IR op handler.  The permission gate, credential flow, and config
     write are all identical to the registry path (reusing the same handler).
+
+    #1442 Layer A: ``project_root`` is the run_install-resolved root (--project
+    or the closest reyn.yaml), no longer re-derived cwd-only here.
     """
     import asyncio
     import json
 
-    from reyn.config import _find_project_root, load_config
+    from reyn.config import load_config
     from reyn.events.events import EventLog
     from reyn.op_runtime.context import OpContext
     from reyn.op_runtime.mcp_install import handle as _mcp_install_handle
@@ -730,7 +789,6 @@ def _run_install_from_source(
     from reyn.user_intervention import StdinInterventionBus
 
     config = load_config()
-    project_root = _find_project_root(Path.cwd())
 
     perm_config = getattr(config, "permissions", {}) or {}
     perm_resolver = PermissionResolver(
@@ -741,7 +799,10 @@ def _run_install_from_source(
     )
 
     events = EventLog()
-    workspace = type("Workspace", (), {"root": str(project_root or Path.cwd())})()
+    # #1442 Layer B: expose ``base_dir`` (the canonical Workspace attribute the
+    # handler reads — op_runtime/file.py uses ctx.workspace.base_dir), not the
+    # legacy ``root`` the handler special-cased. project_root is now always set.
+    workspace = type("Workspace", (), {"base_dir": str(project_root)})()
     bus = StdinInterventionBus()
 
     # #571 collapse arc Phase 5: explicit list axes replace the

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -90,6 +90,19 @@ def _scope_to_path(scope: str, project_root: Path) -> Path:
     return project_root / ".reyn" / "mcp.yaml"
 
 
+def _resolve_write_root(workspace: object) -> Path:
+    """#1442 Layer B: the project root the install writes under.
+
+    Resolved from the workspace's CANONICAL ``base_dir`` (the attribute the real
+    Workspace exposes and op_runtime/file.py reads), with ``root`` as a fallback
+    for the CLI source stub, and cwd as the last resort. The handler previously
+    checked only ``root`` — which the real Workspace lacks — so any agent /
+    registry install silently fell back to cwd, writing into the wrong tree.
+    """
+    root = getattr(workspace, "base_dir", None) or getattr(workspace, "root", None)
+    return Path(root) if root is not None else Path.cwd()
+
+
 def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
     """Build the mcp.servers.<name> config dict from a ServerPackage raw dict.
 
@@ -238,9 +251,7 @@ async def handle(
     # ``require_mcp_install`` per-server prompt is removed; per-server
     # granularity is enforced at call time via the existing
     # ``permissions.mcp: [<server>]`` gate.
-    project_root = Path.cwd()
-    if hasattr(ctx.workspace, "root"):
-        project_root = Path(ctx.workspace.root)
+    project_root = _resolve_write_root(ctx.workspace)
     config_path = _scope_to_path(op.scope, project_root)
     if ctx.permission_resolver is not None:
         # #1352-C: thread the agent/operator sandbox policy (SandboxLayer ∩),

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -197,6 +197,11 @@ async def _handle_mcp_install_registry(
     decl.secret_write = ["*"]
 
     op_ctx = OpContext(
+        # #1442 Layer C: OpContext.workspace is REQUIRED; omitting it raised
+        # TypeError, crashing agent-invoked `mcp install`. Thread the caller's
+        # workspace so the handler resolves the write root from its base_dir
+        # (Layer B) instead of cwd.
+        workspace=getattr(ctx, "workspace", None),
         skill_name="mcp__install_registry",
         run_id=None,
         permission_decl=decl,
@@ -332,6 +337,10 @@ async def _handle_mcp_install_package(
     decl.secret_write = ["*"]
 
     op_ctx = OpContext(
+        # #1442 Layer C: required workspace (see _handle_mcp_install_registry) —
+        # thread the caller's so the agent-invoked package install doesn't crash
+        # and the handler roots the write at base_dir, not cwd.
+        workspace=getattr(ctx, "workspace", None),
         skill_name="mcp__install_package",
         run_id=None,
         permission_decl=decl,

--- a/tests/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/test_mcp_install_ux_fixes_318_319_320.py
@@ -209,6 +209,10 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path) -> None:
     if reyn_bin is None:
         import pytest
         pytest.skip("reyn executable not on PATH for subprocess invocation")
+    # #1442: install now resolves a project root and fails loud outside one
+    # (error-not-silent-cwd), so give tmp_path a reyn.yaml — the #320 /tmp-args
+    # warning fires inside the source install, past project resolution.
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
     result = subprocess.run(
         [
             reyn_bin, "mcp", "install",

--- a/tests/test_mcp_install_workspace_1442.py
+++ b/tests/test_mcp_install_workspace_1442.py
@@ -1,0 +1,131 @@
+"""Tier 2: #1442 — mcp install targets the resolved project root, not cwd.
+
+Three independent defects let `mcp install` write to (or crash on) the wrong
+workspace:
+
+- **A (CLI source):** no `--project` flag + cwd-only resolution → silent wrong
+  target. `_resolve_install_project_root` adds `--project` + fail-loud.
+- **B (handler attribute):** the handler read `ctx.workspace.root`, but the real
+  Workspace exposes `.base_dir` → it silently fell back to cwd.
+  `_resolve_write_root` reads the canonical `base_dir` (with `.root`/cwd
+  fallbacks).
+- **C (agent path crash):** the agent verbs built `OpContext` without the
+  required `workspace` → TypeError. They now thread `ctx.workspace`.
+
+Real Workspace / real verbs; the only injected double is a recording coroutine
+for the network-doing install handler (the sanctioned op-seam) — no mocks.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.cli.commands.mcp import _resolve_install_project_root, register
+from reyn.events.events import EventLog
+from reyn.op_runtime.mcp_install import _resolve_write_root
+from reyn.tools.mcp_verbs import (
+    _handle_mcp_install_package,
+    _handle_mcp_install_registry,
+)
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.workspace import Workspace
+
+# ── Layer A: --project + resolve-once + fail-loud ───────────────────────────
+
+
+def test_resolve_project_root_from_explicit_project(tmp_path):
+    """Tier 2: #1442 A — --project resolves to that root (not cwd)."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    assert _resolve_install_project_root(str(tmp_path)) == tmp_path.resolve()
+
+
+def test_resolve_project_root_fails_loud_when_no_project(tmp_path, monkeypatch):
+    """Tier 2: #1442 A — no --project and no reyn.yaml from cwd → loud exit, not a
+    silent cwd write."""
+    monkeypatch.chdir(tmp_path)  # no reyn.yaml here
+    with pytest.raises(SystemExit):
+        _resolve_install_project_root(None)
+
+
+def test_install_parser_exposes_project_flag():
+    """Tier 2: #1442 A — the install subcommand accepts --project (symmetric with
+    serve/list/refresh)."""
+    p = argparse.ArgumentParser(prog="reyn")
+    register(p.add_subparsers(dest="cmd"))
+    args = p.parse_args(["mcp", "install", "--project", "/tmp/x", "io.github.foo/bar"])
+    assert args.project == "/tmp/x"
+
+
+# ── Layer B: handler resolves the real Workspace base_dir ───────────────────
+
+
+def test_resolve_write_root_uses_real_workspace_base_dir(tmp_path):
+    """Tier 2: #1442 B — a REAL Workspace (base_dir != cwd) resolves to its
+    base_dir, not cwd. This is the bug the `.root`-only check caused."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    assert _resolve_write_root(ws) == tmp_path.resolve()
+    assert _resolve_write_root(ws) != Path.cwd()
+
+
+def test_resolve_write_root_fallbacks(tmp_path):
+    """Tier 2: #1442 B — base_dir preferred; legacy `.root` stub still works;
+    None → cwd (safe last resort)."""
+    assert _resolve_write_root(type("W", (), {"base_dir": str(tmp_path)})()) == tmp_path
+    assert _resolve_write_root(type("W", (), {"root": str(tmp_path)})()) == tmp_path
+    assert _resolve_write_root(None) == Path.cwd()
+
+
+# ── Layer C: agent verbs thread the workspace (no TypeError crash) ───────────
+
+
+def _ctx_with_workspace(ws) -> ToolContext:
+    return ToolContext(
+        events=EventLog(),
+        permission_resolver=None,
+        workspace=ws,
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _drive_verb(verb, args, ws, monkeypatch):
+    """Drive a real mcp_verbs install verb with a recording handler seam; return
+    the OpContext the verb built (the #1442-C crash site)."""
+    captured: dict = {}
+
+    async def _recording_handle(op, op_ctx, *, caller):
+        captured["op_ctx"] = op_ctx
+        return {"installed": True, "caller": caller}
+
+    monkeypatch.setattr("reyn.op_runtime.mcp_install.handle", _recording_handle)
+    result = asyncio.run(verb(args, _ctx_with_workspace(ws)))
+    return result, captured
+
+
+def test_agent_install_registry_threads_workspace_no_crash(tmp_path, monkeypatch):
+    """Tier 2: #1442 C — agent-invoked registry install builds the OpContext WITH
+    the caller's workspace (was a TypeError crash: required field omitted). The
+    threaded workspace then resolves to its real base_dir, not cwd."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    result, captured = _drive_verb(
+        _handle_mcp_install_registry, {"server_id": "io.github.foo/bar"}, ws, monkeypatch
+    )
+    assert result["status"] == "ok"  # no crash
+    assert captured["op_ctx"].workspace is ws  # threaded (the C fix)
+    assert _resolve_write_root(captured["op_ctx"].workspace) == tmp_path.resolve()
+
+
+def test_agent_install_package_threads_workspace_no_crash(tmp_path, monkeypatch):
+    """Tier 2: #1442 C — same for the package verb (the second OpContext site)."""
+    ws = Workspace(events=EventLog(), base_dir=tmp_path)
+    result, captured = _drive_verb(
+        _handle_mcp_install_package,
+        {"kind": "npm", "identifier": "bar-mcp"},
+        ws,
+        monkeypatch,
+    )
+    assert result["status"] == "ok"
+    assert captured["op_ctx"].workspace is ws


### PR DESCRIPTION
**[e2e-coder]** — #1442 (owner-reported). Design lead-approved (3-layer consolidated). Single PR.

## Three primary-evidence-verified defects
- **A — CLI source path**: `install` had no `--project` (asymmetric w/ serve/list/refresh) + `_find_project_root(cwd)`-only → silent wrong target outside a project. Fix: `--project` + `_resolve_install_project_root` (mirrors `mcp refresh`) + **fail-loud**; resolved root threaded to source (stub) + registry (`os.chdir`).
- **B — handler attribute mismatch**: handler read `ctx.workspace.root`, but the real `Workspace` exposes `.base_dir` (the canonical attr `op_runtime/file.py` reads) → `hasattr(.root)` False → silent cwd fallback. Fix: `_resolve_write_root` reads `base_dir` (→ `.root` stub → cwd fallbacks); stub aligned to `base_dir`.
- **C — agent path crash**: `mcp_install_registry`/`mcp_install_package` (mcp_verbs.py) built `OpContext` **without the required `workspace`** → `TypeError`. **Agent-invoked `mcp install` crashed** — the most likely owner symptom. Fix: both sites thread `workspace=getattr(ctx, "workspace", None)`.

## How found
The caller-audit discipline (grep all of the handler's call-sites) surfaced Layer C; runtime checks confirmed the real Workspace has no `.root` (B) and that the OpContext omission raises (C). The investigation corrected my own earlier wrong claim that "the agent path resolves correctly" — verified via primary evidence before implementing.

## Test plan (real Workspace / real verbs; only the network install handler is a recording-coroutine seam — Tier 2)
- [x] **A**: `_resolve_install_project_root` resolves `--project`; fails loud with no project; install parser exposes `--project`
- [x] **B**: `_resolve_write_root` on a REAL Workspace (base_dir != cwd) → base_dir; base_dir/`.root`/None→cwd fallbacks
- [x] **C**: driving BOTH agent verbs threads `ctx.workspace` (no TypeError) + resolves the real base_dir (`test_agent_install_{registry,package}_threads_workspace_no_crash`)
- [x] updated the #320 `/tmp`-args UX test to run in a valid project (install now correctly rejects a non-project cwd)
- [x] `pytest -k mcp` 480 pass; `ruff` + `tier_audit --strict` clean

cc sandbox_2 (owner symptom likely Layer C agent crash).

Refs #1442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)