### PR TITLE
fix(1442): route mcp_verbs through the single-source op-context bridge (chat write-location residual)

### DIFF
--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.op_context_bridge import (
+    build_legacy_op_context as _build_legacy_op_context,
+)
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # Descriptions must be byte-identical to the ToolSpec.description literals in
@@ -198,48 +201,6 @@ _GLOB_FILES_PARAMETERS: dict[str, Any] = {
     },
     "required": ["pattern"],
 }
-
-
-def _build_legacy_op_context(ctx: ToolContext) -> Any:
-    """Build an OpContext for op_runtime delegation.
-
-    Preferred (= router-side production, ADR-0026 Phase 3.5): use the
-    ``ctx.router_state.op_context_factory`` callable bound by
-    RouterLoop. The factory yields the same OpContext the legacy router
-    branches received — populated PermissionDecl (= operator file/mcp
-    declarations), Workspace with ``skill_name="chat_router"``, and the
-    flattened MCP servers map.
-
-    Fallback (= phase-side dispatch, test sites): synthesize a minimal
-    OpContext from ToolContext fields with ``PermissionDecl()`` empty.
-    The fallback is documented as M3 transitional in ADR-0026 Open Q #7;
-    callers that need real permission gating must populate
-    ``router_state.op_context_factory`` (router) or supply
-    ``phase_state.op_context`` (phase) when those wirings land.
-    """
-    rs = ctx.router_state
-    if rs is not None and rs.op_context_factory is not None:
-        return rs.op_context_factory()
-
-    from reyn.op_runtime.context import OpContext
-    from reyn.permissions.permissions import PermissionDecl
-
-    # Propagate the active phase's PermissionDecl via phase_state.op_context
-    # (FP-0008 Tool→OpContext bridge fix 2026-05-28).
-    phase_op_ctx = (
-        ctx.phase_state.op_context if ctx.phase_state is not None else None
-    )
-    return OpContext(
-        workspace=ctx.workspace,
-        events=ctx.events,
-        permission_decl=(
-            phase_op_ctx.permission_decl
-            if phase_op_ctx is not None
-            else PermissionDecl()
-        ),
-        permission_resolver=ctx.permission_resolver,
-        skill_name="",
-    )
 
 
 async def _handle_read(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -157,10 +157,10 @@ async def _handle_mcp_install_registry(
     mcp__install_package or mcp__install_local instead. Secret handling
     matches the registry-aware contract — see module docstring.
     """
-    from reyn.op_runtime.context import OpContext
     from reyn.op_runtime.mcp_install import handle as mcp_install_handle
     from reyn.permissions.permissions import PermissionDecl
     from reyn.schemas.models import MCPInstallIROp
+    from reyn.tools.op_context_bridge import build_legacy_op_context
 
     server_id = str(args.get("server_id") or "")
     if not server_id:
@@ -196,22 +196,14 @@ async def _handle_mcp_install_registry(
     decl.http_get = [{"host": "registry.modelcontextprotocol.io"}]
     decl.secret_write = ["*"]
 
-    op_ctx = OpContext(
-        # #1442 Layer C: OpContext.workspace is REQUIRED; omitting it raised
-        # TypeError, crashing agent-invoked `mcp install`. Thread the caller's
-        # workspace so the handler resolves the write root from its base_dir
-        # (Layer B) instead of cwd.
-        workspace=getattr(ctx, "workspace", None),
-        skill_name="mcp__install_registry",
-        run_id=None,
-        permission_decl=decl,
-        permission_resolver=getattr(
-            getattr(ctx, "router_state", None), "permission_resolver", None,
-        ),
-        events=getattr(ctx, "events", None),
-        intervention_bus=None,
-        media_store=None,
-    )
+    # #1442 follow-up: get the OpContext from the SINGLE-SOURCE bridge (the same
+    # one file/compact/recall/web_fetch/sandboxed_exec use), not a hand-built one.
+    # On the chat-router path this yields the real Workspace rooted at the agent's
+    # workspace_base_dir; hand-building from ctx.workspace (None there) wrote the
+    # config to cwd. Only the install-specific decl + skill_name are overridden.
+    op_ctx = build_legacy_op_context(ctx)
+    op_ctx.permission_decl = decl
+    op_ctx.skill_name = "mcp__install_registry"
 
     result = await mcp_install_handle(op, op_ctx, caller="control_ir")
     return {"status": "ok", "data": result}
@@ -291,10 +283,10 @@ async def _handle_mcp_install_package(
     then delegates to op_runtime/mcp_install with ``server_id=""`` so the
     registry HTTP path is skipped.
     """
-    from reyn.op_runtime.context import OpContext
     from reyn.op_runtime.mcp_install import handle as mcp_install_handle
     from reyn.permissions.permissions import PermissionDecl
     from reyn.schemas.models import MCPInstallIROp
+    from reyn.tools.op_context_bridge import build_legacy_op_context
 
     kind = str(args.get("kind") or "")
     identifier = str(args.get("identifier") or "")
@@ -336,21 +328,11 @@ async def _handle_mcp_install_package(
     decl.file_write = [{"path": ".reyn/mcp.yaml"}]
     decl.secret_write = ["*"]
 
-    op_ctx = OpContext(
-        # #1442 Layer C: required workspace (see _handle_mcp_install_registry) —
-        # thread the caller's so the agent-invoked package install doesn't crash
-        # and the handler roots the write at base_dir, not cwd.
-        workspace=getattr(ctx, "workspace", None),
-        skill_name="mcp__install_package",
-        run_id=None,
-        permission_decl=decl,
-        permission_resolver=getattr(
-            getattr(ctx, "router_state", None), "permission_resolver", None,
-        ),
-        events=getattr(ctx, "events", None),
-        intervention_bus=None,
-        media_store=None,
-    )
+    # #1442 follow-up: single-source bridge (see _handle_mcp_install_registry) —
+    # real Workspace on the chat path; override only the install-specific fields.
+    op_ctx = build_legacy_op_context(ctx)
+    op_ctx.permission_decl = decl
+    op_ctx.skill_name = "mcp__install_package"
 
     result = await mcp_install_handle(op, op_ctx, caller="control_ir")
     return {"status": "ok", "data": result}

--- a/src/reyn/tools/op_context_bridge.py
+++ b/src/reyn/tools/op_context_bridge.py
@@ -1,0 +1,64 @@
+"""Single-source Tool→OpContext bridge for op_runtime delegation.
+
+Tool handlers that delegate to an ``op_runtime`` handler need an
+:class:`~reyn.op_runtime.context.OpContext`. The router binds the real one
+(populated ``PermissionDecl``, a real ``Workspace`` rooted at the agent's
+``workspace_base_dir``, the flattened MCP map) via
+``ctx.router_state.op_context_factory``; phase / test callers fall back to a
+minimal synthesis.
+
+This bridge is the ONE place that resolves that — extracted from
+``tools/file.py`` (#1442) so every delegating tool shares it. A tool that
+hand-builds its own ``OpContext`` from ``ctx.workspace`` instead (mcp_verbs did,
+pre-#1442) gets ``ctx.workspace`` which is ``None`` on the chat-router path →
+the op silently resolves cwd instead of the agent workspace. Routing all such
+tools through this single bridge keeps them at parity with file ops by
+construction.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.tools.types import ToolContext
+
+
+def build_legacy_op_context(ctx: "ToolContext") -> Any:
+    """Build an OpContext for op_runtime delegation.
+
+    Preferred (= router-side production, ADR-0026 Phase 3.5): use the
+    ``ctx.router_state.op_context_factory`` callable bound by RouterLoop. The
+    factory yields the same OpContext the legacy router branches received —
+    populated PermissionDecl (= operator file/mcp declarations), a real
+    Workspace (rooted at the agent's ``workspace_base_dir``), and the flattened
+    MCP servers map.
+
+    Fallback (= phase-side dispatch, test sites): synthesize a minimal OpContext
+    from ToolContext fields with ``PermissionDecl()`` empty. The fallback is
+    documented as M3 transitional in ADR-0026 Open Q #7; callers that need real
+    permission gating must populate ``router_state.op_context_factory`` (router)
+    or supply ``phase_state.op_context`` (phase) when those wirings land.
+    """
+    rs = ctx.router_state
+    if rs is not None and rs.op_context_factory is not None:
+        return rs.op_context_factory()
+
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    # Propagate the active phase's PermissionDecl via phase_state.op_context
+    # (FP-0008 Tool→OpContext bridge fix 2026-05-28).
+    phase_op_ctx = (
+        ctx.phase_state.op_context if ctx.phase_state is not None else None
+    )
+    return OpContext(
+        workspace=ctx.workspace,
+        events=ctx.events,
+        permission_decl=(
+            phase_op_ctx.permission_decl
+            if phase_op_ctx is not None
+            else PermissionDecl()
+        ),
+        permission_resolver=ctx.permission_resolver,
+        skill_name="",
+    )

--- a/tests/test_mcp_install_workspace_1442.py
+++ b/tests/test_mcp_install_workspace_1442.py
@@ -129,3 +129,55 @@ def test_agent_install_package_threads_workspace_no_crash(tmp_path, monkeypatch)
     )
     assert result["status"] == "ok"
     assert captured["op_ctx"].workspace is ws
+
+
+# ── #1442 follow-up: chat path uses the op_context_factory's REAL workspace ──
+# On the chat-router path ctx.workspace is None (RouterHostAdapter exposes no
+# .workspace); the real Workspace comes from ctx.router_state.op_context_factory
+# (the single-source bridge). The verb must use that, not cwd.
+
+
+def test_chat_path_uses_factory_workspace_not_cwd(tmp_path, monkeypatch):
+    """Tier 2: #1442 follow-up — when ctx.workspace is None but the router binds
+    op_context_factory (the chat reality), the verb resolves the factory's REAL
+    Workspace (agent base_dir), NOT cwd. Falsifiable: the pre-fix hand-build from
+    ctx.workspace=None resolved cwd."""
+    from reyn.op_runtime.context import OpContext
+    from reyn.permissions.permissions import PermissionDecl
+
+    real_ws = Workspace(events=EventLog(), base_dir=tmp_path)
+
+    def _factory():
+        # the single-source factory yields a real Workspace + operator decl
+        return OpContext(
+            workspace=real_ws, events=EventLog(), permission_decl=PermissionDecl(),
+        )
+
+    rs = RouterCallerState()
+    rs.op_context_factory = _factory
+    ctx = ToolContext(
+        events=EventLog(),
+        permission_resolver=None,
+        workspace=None,  # ← the chat-router reality (host has no .workspace)
+        caller_kind="router",
+        router_state=rs,
+    )
+
+    captured: dict = {}
+
+    async def _rec(op, op_ctx, *, caller):
+        captured["op_ctx"] = op_ctx
+        return {"installed": True}
+
+    monkeypatch.setattr("reyn.op_runtime.mcp_install.handle", _rec)
+    result = asyncio.run(_handle_mcp_install_registry({"server_id": "io.x/y"}, ctx))
+
+    assert result["status"] == "ok"
+    op_ctx = captured["op_ctx"]
+    # The op_ctx came from the factory → real Workspace, resolves the agent root.
+    assert op_ctx.workspace is real_ws
+    assert _resolve_write_root(op_ctx.workspace) == tmp_path.resolve()
+    assert _resolve_write_root(op_ctx.workspace) != Path.cwd()
+    # the install-specific decl was overridden onto the factory's ctx.
+    assert op_ctx.permission_decl.file_write == [{"path": ".reyn/mcp.yaml"}]
+    assert op_ctx.skill_name == "mcp__install_registry"


### PR DESCRIPTION
**[e2e-coder]** — #1442 5th-gap follow-up. Design lead-approved (single-source, option **(a) extract**). Non-urgent (the crash was fixed by #1445); this is the chat write-location residual.

## Root (LIVE-confirmed on a real ChatSession, not inference)
`RouterHostAdapter` exposes no public `.workspace`, so `router_loop:3146` builds `ToolContext(workspace=getattr(host,"workspace",None))` = **None**. #1445 threaded that None (no crash) → handler `_resolve_write_root(None)` → **cwd**. The real Workspace (rooted at the agent's `workspace_base_dir`) is reached via `ctx.router_state.op_context_factory()` — the bridge **file / compact / recall / web_fetch / sandboxed_exec all use**. mcp_verbs was the **lone op** hand-building its OpContext from `ctx.workspace`, bypassing it — possible only because the bridge was private to `tools/file.py`.

## Fix (single-source — extract, not inline, so no 2nd copy drifts)
- extract the bridge → `tools/op_context_bridge.py:build_legacy_op_context` (factory-first → real Workspace; fallback minimal — behavior identical);
- `file.py` imports it under the same name (its 7 call sites unchanged, byte-identical behavior);
- both mcp install verbs use it, overriding only the install-specific `permission_decl` + `skill_name` (`make_router_op_context` → fresh mutable OpContext → safe). `workspace_base_dir` is encapsulated in the factory → parity with file ops **by construction**.

## Test plan (real verbs; only the network install handler is a recording seam — Tier 2)
- [x] chat reality (`ctx.workspace=None` + `router_state.op_context_factory` bound) → verb resolves the factory's real Workspace base_dir, **not cwd** (`test_chat_path_uses_factory_workspace_not_cwd`) — **verified falsifiable** (reverting the wiring → fails)
- [x] #1445's no-router fallback tests still pass (through the bridge's fallback branch) — backward-compatible
- [x] file-op + mcp regression (606) green; `ruff` + `tier_audit --strict` clean
- [ ] (note) `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content` fails **on clean origin/main too** (markdown-extraction assertion, unrelated to this PR — verified by stash) — pre-existing, flagging not introducing

## Optional follow-up (not this PR, per your steer)
A by-construction invariant binding chat OpContext construction to the bridge only (cf. #1402 src-wide invariant) — ends this bypass class. Also: compact/recall/web_fetch/sandboxed_exec still **inline** `op_context_factory()` rather than calling the shared bridge; unifying them is the same follow-up.

Refs #1442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)