### PR TITLE
fix(1447): URL-encode the registry id in get_server — all registry mcp installs 404'd

### DIFF
--- a/src/reyn/registry/client.py
+++ b/src/reyn/registry/client.py
@@ -22,6 +22,7 @@ by the search response (e.g. ``"io.github.foo/bar-mcp"``).
 from __future__ import annotations
 
 import os
+import urllib.parse
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -293,10 +294,15 @@ class RegistryClient:
             return server_json_from_raw(srv)
 
         last_error: RegistryError | None = None
+        # #1447: registry IDs are reverse-DNS and always contain "/" (e.g.
+        # io.github.foo/bar). The "/" MUST be percent-encoded or it injects extra
+        # path segments → the registry 404s. (Mirrors safe/mcp/registry.py:246;
+        # this parallel impl had the encoding gap → every registry install 404'd.)
+        encoded_name = urllib.parse.quote(server_name, safe="")
         for base in _base_urls():
             try:
                 data = await self._get(
-                    f"/v0.1/servers/{server_name}/versions/latest",
+                    f"/v0.1/servers/{encoded_name}/versions/latest",
                     base_url=base,
                 )
             except RegistryError as exc:

--- a/tests/test_registry_get_server_encode_1447.py
+++ b/tests/test_registry_get_server_encode_1447.py
@@ -1,0 +1,54 @@
+"""Tier 2: #1447 — registry get_server percent-encodes the reverse-DNS id.
+
+Registry IDs are reverse-DNS (e.g. ``io.github.foo/bar``) and always contain
+``/``. ``get_server`` built ``/v0.1/servers/{id}/versions/latest`` without
+encoding, so the ``/`` split into extra path segments → the registry 404'd →
+every registry-based ``mcp install`` failed (#221 dogfood). This pins the URL
+shape (network-free: the real HTTP ``_get`` is captured, not called).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.registry.client import RegistryClient
+
+
+class _CapturedPath(Exception):
+    """Sentinel raised after the URL path is captured (short-circuits the call;
+    not a RegistryError, so get_server's retry loop doesn't swallow it)."""
+
+
+def _captured_get_path(server_id: str, monkeypatch) -> str:
+    captured: dict[str, str] = {}
+
+    async def _recording_get(self, path, base_url=None, params=None):
+        captured["path"] = path
+        raise _CapturedPath
+
+    # Use a unique id per call so the response cache can't short-circuit _get.
+    monkeypatch.setattr(RegistryClient, "_get", _recording_get)
+    with pytest.raises(_CapturedPath):
+        asyncio.run(RegistryClient().get_server(server_id))
+    return captured["path"]
+
+
+def test_get_server_percent_encodes_reverse_dns_id(monkeypatch):
+    """Tier 2: #1447 — a reverse-DNS id (with '/') is percent-encoded into ONE
+    path segment. Falsifiable: drop the quote() and the raw '/' id appears."""
+    path = _captured_get_path("io.github.test1447/encode-probe-xyz", monkeypatch)
+    assert "io.github.test1447%2Fencode-probe-xyz" in path
+    # the raw '/'-bearing id must NOT appear (that was the 404 bug)
+    assert "io.github.test1447/encode-probe-xyz" not in path
+    # still the right endpoint shape
+    assert path.startswith("/v0.1/servers/")
+    assert path.endswith("/versions/latest")
+
+
+def test_get_server_plain_id_has_no_encoded_slash(monkeypatch):
+    """Tier 2: #1447 — an id with no '/' is unaffected (encoding is a no-op for
+    it) — the fix doesn't mangle plain ids."""
+    path = _captured_get_path("plainid-no-slash-1447", monkeypatch)
+    assert "plainid-no-slash-1447" in path
+    assert "%2F" not in path


### PR DESCRIPTION
**[e2e-coder]** — surfaced by the #221 dogfood; lead-confirmed to fix. One-line encode + audit + falsifiable URL-shape test.

## Bug
`registry/client.py:get_server` built `/v0.1/servers/{server_name}/versions/latest` **without percent-encoding**. Registry IDs are reverse-DNS (`io.github.foo/bar`) and always contain `/`, so the `/` injected extra path segments → registry 404 → **every** registry-based `mcp install` (chat + CLI, via `op_runtime/mcp_install.py:219`) was broken.

## Primary evidence (real registry server `ai.smithery/arjunkmrm-time`)
```
RAW     …/servers/ai.smithery/arjunkmrm-time/versions/latest    → 404
ENCODED …/servers/ai.smithery%2Farjunkmrm-time/versions/latest  → 200
```
Post-fix `get_server("ai.smithery/arjunkmrm-time")` resolves (live-verified).

## Fix + completeness audit
- `urllib.parse.quote(server_name, safe="")` before the path interpolation (mirrors `safe/mcp/registry.py:246`, the sibling impl that *did* encode).
- **Audit** of registry/client.py path-segment methods: `search` is safe (query-param, httpx-encoded); `get_server` was the only path-segment gap.

## Test plan (network-free — the real HTTP `_get` is captured, not called — Tier 2)
- [x] reverse-DNS id → percent-encoded into one path segment; raw `/`-id absent; endpoint shape preserved (`test_get_server_percent_encodes_reverse_dns_id`) — **verified falsifiable** (drop quote → fails)
- [x] plain id unaffected (no spurious `%2F`)
- [x] live: `get_server` resolves the real `ai.smithery/arjunkmrm-time` (was 404)
- [x] 387 registry tests pass; `ruff` + `tier_audit --strict` clean

## Follow-up (separate track, noted on #1447)
Two registry-lookup impls (`safe/mcp/registry.py` [encodes] + `registry/client.py` [had the gap]) = the parallel-path single-seam theme; canonicalize to one.

Refs #1447 #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)