### PR TITLE
feat(1452): encoding-aware file ops — shared text codec, edit round-trip, grep, write

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "textual>=0.50",         # default TUI mode (PR-cli-2)
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
+    "charset-normalizer>=3.0",  # #1452 file__read encoding detection (MIT, pure-python)
 ]
 
 [project.urls]

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -159,6 +159,16 @@ _GLOB = (
 )
 # grep: argv = pattern, flags, root, glob_or_'', file_type_or_'', output_mode,
 #       head_limit_or_'-1', context_before, context_after
+#
+# #1452 encoding note (deliberate scope boundary): this grep runs as a
+# stdlib-only python script in the TARGET container, where REYN's
+# charset-normalizer dependency is not guaranteed to exist. So it keeps
+# ``read_text('utf-8','replace')`` — legacy-encoding detection (SJIS / EUC-JP /
+# UTF-16) and the binary-skip ladder are HOST-only (host_backend.py via
+# workspace/text_codec). In-container grep therefore matches UTF-8 content
+# faithfully but may replacement-char a non-UTF-8 file's bytes. Acceptable: the
+# faithful-SWE container path is for source repos (overwhelmingly UTF-8), and
+# adding charset-normalizer to arbitrary target images is out of scope.
 _GREP = (
     "import sys,re,json,os,pathlib\n"
     "pat,flags,root,g,ft,mode,hl,cb,ca=sys.argv[1:10]\n"

--- a/src/reyn/environment/host_backend.py
+++ b/src/reyn/environment/host_backend.py
@@ -14,6 +14,20 @@ from pathlib import Path
 from typing import Any, Pattern
 
 from reyn.environment.backend import GrepResult
+from reyn.workspace.text_codec import decode_text_or_none
+
+
+def _grep_decode(path: Path) -> str | None:
+    """#1452: decode a file for grep via the shared codec ladder. Binary files
+    return None (skipped — the old ``errors="replace"`` turned binary into
+    replacement chars that SILENTLY missed patterns); SJIS / EUC-JP / UTF-16 /
+    etc. are decoded so their content is actually searchable."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    text, _enc = decode_text_or_none(data)
+    return text
 
 
 class HostBackend:
@@ -103,20 +117,20 @@ class HostBackend:
         if output_mode == "files_with_matches":
             matched: list[Path] = []
             for f in candidates:
-                try:
-                    if regex.search(f.read_text(encoding="utf-8", errors="replace")):
-                        matched.append(f)
-                except OSError:
-                    continue
+                text = _grep_decode(f)
+                if text is None:
+                    continue  # #1452: binary (or unreadable) — skip, don't garble
+                if regex.search(text):
+                    matched.append(f)
             return GrepResult(output_mode="files_with_matches", files=matched)
 
         if output_mode == "count":
             total = 0
             for f in candidates:
-                try:
-                    total += len(regex.findall(f.read_text(encoding="utf-8", errors="replace")))
-                except OSError:
+                text = _grep_decode(f)
+                if text is None:
                     continue
+                total += len(regex.findall(text))
             return GrepResult(output_mode="count", count=total)
 
         matches: list[dict] = []
@@ -124,10 +138,10 @@ class HostBackend:
         for f in candidates:
             if done:
                 break
-            try:
-                lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
-            except OSError:
-                continue
+            text = _grep_decode(f)
+            if text is None:
+                continue  # #1452: binary (or unreadable) — skip
+            lines = text.splitlines()
             for i, line in enumerate(lines):
                 if not regex.search(line):
                     continue

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -1,13 +1,13 @@
 """file kind handler — read/write/glob/grep/delete/edit/regenerate_index/mkdir/move/stat."""
 from __future__ import annotations
 
-import codecs
 import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Literal
 
 from reyn.schemas.models import FileIROp
+from reyn.workspace.text_codec import decode_text_or_none, encode_text
 
 from . import register
 from .context import OpContext
@@ -44,11 +44,6 @@ def _image_mime_for_path(path: str) -> str | None:
 # LLM's "did you mean X" narration looks the same across both surfaces.
 _NOT_FOUND_SUGGESTIONS_LIMIT = 8
 
-# #1449: head bytes sampled for the NUL-byte binary sniff. A NUL never occurs in
-# valid UTF-8 text, so its presence in the head is a cheap, false-positive-free
-# binary signal; the full UTF-8 decode (below) catches the rest.
-_BINARY_SNIFF_BYTES = 8192
-
 
 def _binary_skipped_result(ctx: OpContext, path: str, byte_size: int) -> dict:
     """#1449: structured result for a NON-image binary read — the bytes are NOT
@@ -69,53 +64,6 @@ def _binary_skipped_result(ctx: OpContext, path: str, byte_size: int) -> dict:
         "byte_size": byte_size,
         "content": "",
     }
-
-
-# #1452: BOM signatures, checked BEFORE the NUL-sniff (UTF-16/32 ASCII text is
-# NUL-heavy). UTF-32 is listed before UTF-16 because BOM_UTF32_LE starts with
-# BOM_UTF16_LE's bytes — the longer signature must match first.
-_BOM_ENCODINGS: tuple[tuple[bytes, str], ...] = (
-    (codecs.BOM_UTF8, "utf-8-sig"),
-    (codecs.BOM_UTF32_LE, "utf-32"),
-    (codecs.BOM_UTF32_BE, "utf-32"),
-    (codecs.BOM_UTF16_LE, "utf-16"),
-    (codecs.BOM_UTF16_BE, "utf-16"),
-)
-
-
-def _decode_text_or_none(raw: bytes) -> tuple[str | None, str | None]:
-    """#1452 decode ladder. Returns ``(text, encoding)`` for text, or
-    ``(None, None)`` for a non-text (binary) payload.
-
-    ``encoding`` is ``None`` on the plain-UTF-8 fast path (so the common-case
-    result shape is unchanged); it names the codec when a BOM or a
-    charset-normalizer detection was used. Ladder order is load-bearing:
-
-    1. **BOM first** — UTF-16/32 ASCII text is NUL-heavy and would be mis-rejected
-       by the NUL-sniff below; the codecs strip the BOM on decode.
-    2. **UTF-8 strict** — the dominant case; fast path, no detection cost.
-    3. **NUL-sniff** — a NUL byte (no BOM, not UTF-8) → binary fast-reject.
-    4. **charset-normalizer** — best-guess for legacy encodings (SJIS, EUC-JP,
-       latin-1, …); no confident match → binary (the #1449 safe fallback).
-    """
-    for bom, enc in _BOM_ENCODINGS:
-        if raw.startswith(bom):
-            try:
-                return raw.decode(enc), enc
-            except (UnicodeDecodeError, LookupError):
-                return None, None
-    try:
-        return raw.decode("utf-8"), None
-    except UnicodeDecodeError:
-        pass
-    if b"\x00" in raw[:_BINARY_SNIFF_BYTES]:
-        return None, None
-    from charset_normalizer import from_bytes
-
-    match = from_bytes(raw).best()
-    if match is None:
-        return None, None
-    return str(match), match.encoding
 
 
 async def _read_image_file(op: FileIROp, ctx: OpContext, *, mime_type: str) -> dict:
@@ -279,9 +227,29 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
             )
 
     if op.op == "write":
+        # #1452: write authors NEW content (the author is now the LLM), so it
+        # writes UTF-8 — UNLIKE edit, which preserves a file's existing encoding
+        # in place. (Rationale-backed asymmetry, owner-vetoable: full replacement
+        # vs partial edit. Preserving a legacy encoding on write would surface
+        # not-representable errors for the common case of adding emoji/unicode.)
+        # When OVERWRITING a non-UTF-8 file, surface a note that the encoding
+        # changed. The pre-read is best-effort (skipped if read is denied).
+        _prev_enc: str | None = None
+        try:
+            _prev_bytes, _existed = ctx.workspace.read_file_bytes(op.path)
+            if _existed:
+                _, _prev_enc = decode_text_or_none(_prev_bytes)
+        except PermissionError:
+            pass
         ctx.workspace.write_file(op.path, op.content or "")
         ctx.events.emit("tool_executed", op="write_file", path=op.path)
-        return {"kind": "file", "op": "write", "path": op.path, "status": "ok"}
+        result: dict = {"kind": "file", "op": "write", "path": op.path, "status": "ok"}
+        if _prev_enc:
+            result["encoding_note"] = (
+                f"overwrote a {_prev_enc}-encoded file; the new content is written "
+                "as UTF-8."
+            )
+        return result
 
     if op.op == "read":
         # Issue #365: image extensions → binary path with media-size gate.
@@ -312,7 +280,7 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         # load-bearing: the BOM check runs BEFORE the NUL-sniff because UTF-16/32
         # ASCII text is NUL-heavy and would be mis-rejected as binary. Returns
         # (None, None) for a non-text payload (→ the structured binary marker).
-        content, _detected_encoding = _decode_text_or_none(raw_bytes)
+        content, _detected_encoding = decode_text_or_none(raw_bytes)
         if content is None:
             return _binary_skipped_result(ctx, op.path, len(raw_bytes))
         # `encoding` is surfaced ONLY when a non-UTF-8 codec was used (BOM or
@@ -567,7 +535,7 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
     if op.new_string is None:
         return {"kind": "file", "op": "edit", "status": "error", "error": "new_string is required"}
 
-    content, found = ctx.workspace.read_file(op.path)
+    raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
     if not found:
         suggestions = _nearby_files(ctx.workspace, op.path)
         return {
@@ -577,6 +545,17 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
             "status": "not_found",
             "error": f"file not found: {op.path}",
             "suggestions": suggestions,
+        }
+
+    # #1452: decode via the shared codec ladder so a non-UTF-8 text file can be
+    # edited in place (encoding preserved on write-back below). A binary file
+    # cannot be edited as text.
+    content, _encoding = decode_text_or_none(raw_bytes)
+    if content is None:
+        return {
+            "kind": "file", "op": "edit", "path": op.path, "status": "error",
+            "binary": True,
+            "error": "binary file — cannot edit as text (its bytes were not loaded).",
         }
 
     count = content.count(op.old_string)
@@ -589,7 +568,22 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
 
     new_content = content.replace(op.old_string, op.new_string) if op.replace_all \
         else content.replace(op.old_string, op.new_string, 1)
-    ctx.workspace.write_file(op.path, new_content)
+    # #1452: re-encode with the file's ORIGINAL encoding (BOM restored for
+    # utf-8-sig/utf-16/utf-32). If the edit isn't representable in that codec
+    # (e.g. an emoji written into a Shift-JIS file), ERROR and leave the file
+    # untouched — never silently transcode the whole file to UTF-8.
+    encoded = encode_text(new_content, _encoding)
+    if encoded is None:
+        return {
+            "kind": "file", "op": "edit", "path": op.path, "status": "error",
+            "encoding": _encoding or "utf-8",
+            "error": (
+                f"the edit is not representable in the file's encoding "
+                f"({_encoding or 'utf-8'}) — file left unchanged. Some new "
+                "characters cannot be encoded there."
+            ),
+        }
+    ctx.workspace.write_file_bytes(op.path, encoded)
     replacements = count if op.replace_all else 1
     ctx.events.emit("tool_executed", op="edit_file", path=op.path, replacements=replacements)
     # #1418: an additive, show-not-judge preview of the changed region so the
@@ -601,6 +595,7 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
     return {
         "kind": "file", "op": "edit", "path": op.path, "status": "ok",
         "replacements": replacements, "preview": preview,
+        **({"encoding": _encoding} if _encoding else {}),
     }
 
 

--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -1,6 +1,7 @@
 """file kind handler — read/write/glob/grep/delete/edit/regenerate_index/mkdir/move/stat."""
 from __future__ import annotations
 
+import codecs
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -68,6 +69,53 @@ def _binary_skipped_result(ctx: OpContext, path: str, byte_size: int) -> dict:
         "byte_size": byte_size,
         "content": "",
     }
+
+
+# #1452: BOM signatures, checked BEFORE the NUL-sniff (UTF-16/32 ASCII text is
+# NUL-heavy). UTF-32 is listed before UTF-16 because BOM_UTF32_LE starts with
+# BOM_UTF16_LE's bytes — the longer signature must match first.
+_BOM_ENCODINGS: tuple[tuple[bytes, str], ...] = (
+    (codecs.BOM_UTF8, "utf-8-sig"),
+    (codecs.BOM_UTF32_LE, "utf-32"),
+    (codecs.BOM_UTF32_BE, "utf-32"),
+    (codecs.BOM_UTF16_LE, "utf-16"),
+    (codecs.BOM_UTF16_BE, "utf-16"),
+)
+
+
+def _decode_text_or_none(raw: bytes) -> tuple[str | None, str | None]:
+    """#1452 decode ladder. Returns ``(text, encoding)`` for text, or
+    ``(None, None)`` for a non-text (binary) payload.
+
+    ``encoding`` is ``None`` on the plain-UTF-8 fast path (so the common-case
+    result shape is unchanged); it names the codec when a BOM or a
+    charset-normalizer detection was used. Ladder order is load-bearing:
+
+    1. **BOM first** — UTF-16/32 ASCII text is NUL-heavy and would be mis-rejected
+       by the NUL-sniff below; the codecs strip the BOM on decode.
+    2. **UTF-8 strict** — the dominant case; fast path, no detection cost.
+    3. **NUL-sniff** — a NUL byte (no BOM, not UTF-8) → binary fast-reject.
+    4. **charset-normalizer** — best-guess for legacy encodings (SJIS, EUC-JP,
+       latin-1, …); no confident match → binary (the #1449 safe fallback).
+    """
+    for bom, enc in _BOM_ENCODINGS:
+        if raw.startswith(bom):
+            try:
+                return raw.decode(enc), enc
+            except (UnicodeDecodeError, LookupError):
+                return None, None
+    try:
+        return raw.decode("utf-8"), None
+    except UnicodeDecodeError:
+        pass
+    if b"\x00" in raw[:_BINARY_SNIFF_BYTES]:
+        return None, None
+    from charset_normalizer import from_bytes
+
+    match = from_bytes(raw).best()
+    if match is None:
+        return None, None
+    return str(match), match.encoding
 
 
 async def _read_image_file(op: FileIROp, ctx: OpContext, *, mime_type: str) -> dict:
@@ -259,17 +307,18 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "suggestions": suggestions,
                 "content": "",
             }
-        # #1449 non-image binary guard: a NUL byte in the head sample, or bytes
-        # that are not valid UTF-8, mean a non-text payload — return a structured
-        # marker instead of dumping garbled bytes. Detection is NUL-byte +
-        # UTF-8-decode-failure ONLY, deliberately NOT a printable-ratio test
-        # (which false-positives on valid multibyte unicode — #1449 owner caution).
-        if b"\x00" in raw_bytes[:_BINARY_SNIFF_BYTES]:
+        # #1452 decode ladder (extends the #1449 binary guard): BOM → UTF-8 fast
+        # path → NUL-sniff binary-reject → charset-normalizer detection. Order is
+        # load-bearing: the BOM check runs BEFORE the NUL-sniff because UTF-16/32
+        # ASCII text is NUL-heavy and would be mis-rejected as binary. Returns
+        # (None, None) for a non-text payload (→ the structured binary marker).
+        content, _detected_encoding = _decode_text_or_none(raw_bytes)
+        if content is None:
             return _binary_skipped_result(ctx, op.path, len(raw_bytes))
-        try:
-            content = raw_bytes.decode("utf-8")
-        except UnicodeDecodeError:
-            return _binary_skipped_result(ctx, op.path, len(raw_bytes))
+        # `encoding` is surfaced ONLY when a non-UTF-8 codec was used (BOM or
+        # charset-normalizer); the plain-UTF-8 fast path keeps the result shape
+        # byte-identical (no `encoding` field) for the common case.
+        _enc_field = {"encoding": _detected_encoding} if _detected_encoding else {}
         explicit_bounded = op.offset is not None or op.limit is not None
         if explicit_bounded:
             # Caller asked for an explicit window — honor it verbatim.
@@ -284,6 +333,7 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "path": op.path,
                 "status": "ok",
                 "content": content,
+                **_enc_field,
             }
 
         # #1209 (1) read-bounding, bound-only-when-over: an UNBOUNDED read whose
@@ -317,6 +367,7 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "total_lines": len(all_lines),
                 "next_offset": len(shown),
                 "total_chars": len(content),
+                **_enc_field,
             }
         ctx.events.emit("tool_executed", op="read_file", path=op.path)
         return {
@@ -325,6 +376,7 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
             "path": op.path,
             "status": "ok",
             "content": content,
+            **_enc_field,
         }
 
     if op.op == "glob":

--- a/src/reyn/workspace/text_codec.py
+++ b/src/reyn/workspace/text_codec.py
@@ -1,0 +1,85 @@
+"""#1452: single-source text codec — decode/encode ladder for file ops.
+
+`file__read` / `grep` / `file__edit` / `write_file` all need to turn raw bytes
+into text (and back) without (a) dumping garbled binary into context, (b)
+silently mis-decoding legacy encodings (SJIS / EUC-JP / UTF-16) to replacement
+chars, or (c) silently transcoding a non-UTF-8 file on edit. This module is the
+ONE place that decides — extracted so every consumer shares it (the extract-the-
+seam pattern, cf. #1446's op-context bridge).
+
+Decode ladder (`decode_text_or_none`): BOM → UTF-8 fast-path → NUL-sniff binary
+reject → charset-normalizer detection. Re-encode (`encode_text`) round-trips
+through the detected codec (restoring a BOM for utf-8-sig/utf-16/utf-32), and
+returns None when the text is not representable (→ the caller errors instead of
+corrupting the file).
+"""
+from __future__ import annotations
+
+import codecs
+
+# Head bytes sampled for the NUL-byte binary sniff. A NUL never occurs in valid
+# UTF-8/legacy text, so its presence (after the BOM + UTF-8 checks) is a cheap,
+# false-positive-free binary signal.
+_BINARY_SNIFF_BYTES = 8192
+
+# BOM signatures, checked BEFORE the NUL-sniff (UTF-16/32 ASCII text is NUL-heavy
+# and would be mis-rejected). UTF-32 is listed before UTF-16 because BOM_UTF32_LE
+# starts with BOM_UTF16_LE's bytes — the longer signature must match first.
+_BOM_ENCODINGS: tuple[tuple[bytes, str], ...] = (
+    (codecs.BOM_UTF8, "utf-8-sig"),
+    (codecs.BOM_UTF32_LE, "utf-32"),
+    (codecs.BOM_UTF32_BE, "utf-32"),
+    (codecs.BOM_UTF16_LE, "utf-16"),
+    (codecs.BOM_UTF16_BE, "utf-16"),
+)
+
+
+def decode_text_or_none(raw: bytes) -> tuple[str | None, str | None]:
+    """Return ``(text, encoding)`` for a text payload, or ``(None, None)`` for
+    binary.
+
+    ``encoding`` is ``None`` on the plain-UTF-8 fast path (so the common-case
+    result shape is unchanged); it names the codec when a BOM or a
+    charset-normalizer detection was used. Ladder order is load-bearing:
+
+    1. **BOM first** — UTF-16/32 ASCII text is NUL-heavy and would be mis-rejected
+       by the NUL-sniff below; the codecs strip the BOM on decode.
+    2. **UTF-8 strict** — the dominant case; fast path, no detection cost.
+    3. **NUL-sniff** — a NUL byte (no BOM, not UTF-8) → binary fast-reject.
+    4. **charset-normalizer** — best-guess for legacy encodings (SJIS, EUC-JP,
+       latin-1, …); no confident match → binary (the safe fallback).
+    """
+    for bom, enc in _BOM_ENCODINGS:
+        if raw.startswith(bom):
+            try:
+                return raw.decode(enc), enc
+            except (UnicodeDecodeError, LookupError):
+                return None, None
+    try:
+        return raw.decode("utf-8"), None
+    except UnicodeDecodeError:
+        pass
+    if b"\x00" in raw[:_BINARY_SNIFF_BYTES]:
+        return None, None
+    from charset_normalizer import from_bytes
+
+    match = from_bytes(raw).best()
+    if match is None:
+        return None, None
+    return str(match), match.encoding
+
+
+def encode_text(text: str, encoding: str | None) -> bytes | None:
+    """Re-encode ``text`` with ``encoding`` (as detected by
+    :func:`decode_text_or_none`), preserving a BOM where the codec implies one
+    (``utf-8-sig`` / ``utf-16`` / ``utf-32`` re-add it). ``encoding=None`` (the
+    UTF-8 fast path) → plain UTF-8.
+
+    Returns ``None`` when ``text`` is not representable in ``encoding`` (e.g. an
+    emoji written into a Shift-JIS file) — the caller MUST then error and leave
+    the file untouched rather than silently transcode it (#1452).
+    """
+    try:
+        return text.encode(encoding or "utf-8")
+    except (UnicodeEncodeError, LookupError):
+        return None

--- a/src/reyn/workspace/workspace.py
+++ b/src/reyn/workspace/workspace.py
@@ -162,6 +162,16 @@ class Workspace:
         self._backend.write_bytes(path, content.encode("utf-8"))
         self._events.emit("workspace_updated", path=str(path))
 
+    def write_file_bytes(self, path_str: str, data: bytes) -> None:
+        """Write raw bytes into the project (#1452 — the write-side mirror of
+        ``read_file_bytes``). Used by file__edit / write to persist content
+        already encoded in the file's detected codec (preserving a non-UTF-8
+        encoding + BOM on in-place edits). Same write-zone gating as
+        ``write_file``. Raises PermissionError if denied."""
+        path = self._resolve_write(path_str)
+        self._backend.write_bytes(path, data)
+        self._events.emit("workspace_updated", path=str(path))
+
     def delete_file(self, path_str: str) -> bool:
         """Delete a file from the project. Returns True if deleted, False if not found."""
         path = self._resolve_write(path_str)

--- a/tests/test_file_read_binary_retire_rtr_1449.py
+++ b/tests/test_file_read_binary_retire_rtr_1449.py
@@ -55,12 +55,14 @@ def test_non_image_binary_is_guarded_not_dumped(tmp_path, monkeypatch):
     assert "not text-loadable" in result["error"]
 
 
-def test_invalid_utf8_binary_is_guarded(tmp_path, monkeypatch):
-    """Tier 2: #1449 — bytes that are not valid UTF-8 (no NUL) also route to the
-    binary guard, not a lossy decode."""
+def test_undetectable_non_utf8_bytes_are_guarded(tmp_path, monkeypatch):
+    """Tier 2: #1449/#1452 — non-UTF-8 bytes with no confident charset detection
+    (and no NUL) route to the binary guard, not a lossy decode. (#1452 update:
+    *detectable* legacy encodings like latin-1 are now decoded as text — see
+    test_file_read_encoding_1452; only undetectable bytes hit this guard.)"""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "latin.bin").write_bytes(b"caf\xe9 not utf8 \xff\xfe")
-    result = _read(tmp_path, "latin.bin")
+    (tmp_path / "rand.bin").write_bytes(bytes(range(0, 256)) * 4)
+    result = _read(tmp_path, "rand.bin")
     assert result["status"] == "error"
     assert result["binary"] is True
 

--- a/tests/test_file_read_encoding_1452.py
+++ b/tests/test_file_read_encoding_1452.py
@@ -1,0 +1,119 @@
+"""Tier 2: #1452 — file__read decode ladder (charset-normalizer).
+
+Follow-up to #1449's binary guard: non-UTF-8 *text* (SJIS / EUC-JP / UTF-16) is
+decoded and returned as text with a detected `encoding` field, instead of being
+rejected as binary. The decode ladder is BOM → UTF-8 fast-path → NUL-sniff →
+charset-normalizer; genuine binary still routes to the binary-skipped marker,
+and plain UTF-8 is byte-identical (no `encoding` field).
+
+Real Workspace + real op_runtime / registry — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.permissions.permissions import PermissionResolver
+from reyn.tools import get_default_registry
+from reyn.tools.dispatch import invoke_tool
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.workspace import Workspace
+
+_JP = "こんにちは、世界。これはテスト文書です。\n複数行あります。\n"
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    events = EventLog()
+    return ToolContext(
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={"file.read": "allow", "file.write": "allow"},
+            project_root=tmp_path,
+            interactive=False,
+        ),
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _read(tmp_path: Path, rel: str) -> dict:
+    return asyncio.run(invoke_tool(get_default_registry(), "read_file", {"path": rel}, _ctx(tmp_path)))
+
+
+# ── non-UTF-8 text is decoded (not binary-rejected) + carries encoding ──────
+
+
+def test_shift_jis_text_is_decoded_with_encoding(tmp_path, monkeypatch):
+    """Tier 2: #1452 — a Shift-JIS Japanese file reads as TEXT (the content
+    round-trips) with a detected `encoding`, not the #1449 binary marker."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sjis.txt").write_bytes(_JP.encode("shift_jis"))
+    result = _read(tmp_path, "sjis.txt")
+    assert result["status"] == "ok"
+    assert result.get("binary") is not True
+    assert result["content"] == _JP
+    assert result.get("encoding"), "non-UTF-8 read must surface the detected encoding"
+
+
+def test_euc_jp_text_is_decoded(tmp_path, monkeypatch):
+    """Tier 2: #1452 — EUC-JP Japanese decodes to text with an encoding field."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "euc.txt").write_bytes(_JP.encode("euc-jp"))
+    result = _read(tmp_path, "euc.txt")
+    assert result["status"] == "ok"
+    assert result["content"] == _JP
+    assert result.get("encoding")
+
+
+def test_utf16_bom_text_decoded_bom_checked_before_nul_sniff(tmp_path, monkeypatch):
+    """Tier 2: #1452 — UTF-16 (BOM) text decodes correctly. This pins the
+    load-bearing ladder order: UTF-16 ASCII text is NUL-heavy, so the BOM check
+    MUST precede the NUL-sniff or it would be mis-rejected as binary."""
+    monkeypatch.chdir(tmp_path)
+    ascii_heavy = "plain ascii line one\nplain ascii line two\n"  # NUL-heavy in UTF-16
+    (tmp_path / "u16.txt").write_bytes(ascii_heavy.encode("utf-16"))  # includes BOM
+    result = _read(tmp_path, "u16.txt")
+    assert result["status"] == "ok"
+    assert result.get("binary") is not True
+    assert result["content"] == ascii_heavy
+    assert "16" in (result.get("encoding") or "")
+
+
+# ── plain UTF-8 fast path unchanged (no encoding field) ─────────────────────
+
+
+def test_plain_utf8_is_fast_path_no_encoding_field(tmp_path, monkeypatch):
+    """Tier 2: #1452 — plain UTF-8 (incl. multibyte) keeps the byte-identical
+    result shape with NO `encoding` field (the common-case fast path)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "u8.txt").write_text(_JP, encoding="utf-8")
+    result = _read(tmp_path, "u8.txt")
+    assert result["status"] == "ok"
+    assert result["content"] == _JP
+    assert "encoding" not in result, "plain UTF-8 must not carry an encoding field"
+
+
+# ── genuine binary still rejected ───────────────────────────────────────────
+
+
+def test_png_binary_still_skipped(tmp_path, monkeypatch):
+    """Tier 2: #1452 — a non-image binary (PNG bytes named .dat) still routes to
+    the binary-skipped marker (NUL-sniff), not a garbled decode."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "blob.dat").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xfe")
+    result = _read(tmp_path, "blob.dat")
+    assert result["status"] == "error"
+    assert result["binary"] is True
+    assert result["content"] == ""
+
+
+def test_undetectable_bytes_fall_back_to_binary(tmp_path, monkeypatch):
+    """Tier 2: #1452 — bytes with no confident charset-normalizer match (and no
+    BOM / not UTF-8 / NUL present) fall back to the safe binary marker."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "rand.dat").write_bytes(bytes(range(0, 256)) * 4)
+    result = _read(tmp_path, "rand.dat")
+    assert result["status"] == "error"
+    assert result["binary"] is True

--- a/tests/test_file_read_encoding_1452.py
+++ b/tests/test_file_read_encoding_1452.py
@@ -117,3 +117,109 @@ def test_undetectable_bytes_fall_back_to_binary(tmp_path, monkeypatch):
     result = _read(tmp_path, "rand.dat")
     assert result["status"] == "error"
     assert result["binary"] is True
+
+
+# ── edit/write encoding round-trip (the critical corruption-prevention) ─────
+
+
+def _edit(tmp_path, args):
+    return asyncio.run(invoke_tool(get_default_registry(), "edit_file", args, _ctx(tmp_path)))
+
+
+# Rich enough JP content that charset-normalizer detects a stable SJIS-family
+# codec (short/ambiguous content can be mis-detected — that's a real caveat, and
+# the impl handles it safely: a mis-decode just means old_string isn't found, an
+# error, never a corrupting write).
+_SJIS_DOC = "これは日本語のテスト文書です。\n設定: value = 旧\n複数行の内容があります。\n"
+
+
+def test_sjis_edit_round_trips_encoding_preserved(tmp_path, monkeypatch):
+    """Tier 2: #1452 — editing a Shift-JIS file preserves its encoding (writes
+    back in that codec, not silently UTF-8) and leaves bytes outside the edit
+    span unchanged. The corruption the unconditional UTF-8 write would cause."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "s.txt").write_bytes(_SJIS_DOC.encode("shift_jis"))
+    result = _edit(tmp_path, {"path": "s.txt", "old_string": "旧", "new_string": "新"})
+    assert result["status"] == "ok"
+    enc = result.get("encoding")
+    assert enc  # surfaced: a non-UTF-8 codec was preserved
+    back = (tmp_path / "s.txt").read_bytes()
+    # round-trips in the detected codec, and the edit landed.
+    assert back.decode(enc) == _SJIS_DOC.replace("旧", "新")
+    # the bytes are NOT UTF-8 (the encoding was preserved, not transcoded).
+    assert back != _SJIS_DOC.replace("旧", "新").encode("utf-8")
+
+
+def test_utf16_edit_preserves_bom_and_encoding(tmp_path, monkeypatch):
+    """Tier 2: #1452 — editing a UTF-16 (BOM) file preserves the BOM + codec."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "u16.txt").write_bytes("alpha\nbeta\n".encode("utf-16"))
+    result = _edit(tmp_path, {"path": "u16.txt", "old_string": "beta", "new_string": "gamma"})
+    assert result["status"] == "ok"
+    back = (tmp_path / "u16.txt").read_bytes()
+    assert back.decode("utf-16") == "alpha\ngamma\n"
+    assert back.startswith(b"\xff\xfe") or back.startswith(b"\xfe\xff")  # BOM preserved
+
+
+def test_emoji_into_sjis_errors_and_leaves_file_untouched(tmp_path, monkeypatch):
+    """Tier 2: #1452 — an edit not representable in the file's encoding (emoji →
+    Shift-JIS) ERRORS and leaves the file byte-for-byte unchanged (no silent
+    transcode to UTF-8). The critical no-corruption guarantee."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "s.txt").write_bytes(_SJIS_DOC.encode("shift_jis"))
+    before = (tmp_path / "s.txt").read_bytes()
+    result = _edit(tmp_path, {"path": "s.txt", "old_string": "旧", "new_string": "🎉"})
+    assert result["status"] == "error"
+    assert (tmp_path / "s.txt").read_bytes() == before  # untouched
+
+
+def test_edit_binary_errors(tmp_path, monkeypatch):
+    """Tier 2: #1452 — editing a binary file errors (cannot decode as text)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "b.dat").write_bytes(b"\x00\x01\x02\xff\xfebinary")
+    result = _edit(tmp_path, {"path": "b.dat", "old_string": "x", "new_string": "y"})
+    assert result["status"] == "error"
+    assert result.get("binary") is True
+
+
+def test_write_overwrite_sjis_becomes_utf8_with_note(tmp_path, monkeypatch):
+    """Tier 2: #1452 — write (full replacement) of an existing Shift-JIS file
+    writes UTF-8 and surfaces an encoding_note (the edit/write asymmetry)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "s.txt").write_bytes("古い内容\n".encode("shift_jis"))
+    result = asyncio.run(invoke_tool(
+        get_default_registry(), "write_file",
+        {"path": "s.txt", "content": "new content 🎉\n"}, _ctx(tmp_path),
+    ))
+    assert result["status"] == "ok"
+    assert result.get("encoding_note")  # noted the SJIS→UTF-8 change
+    assert (tmp_path / "s.txt").read_bytes() == "new content 🎉\n".encode("utf-8")
+
+
+# ── grep across encodings (backend-seam wiring) ─────────────────────────────
+
+
+def _grep(tmp_path, pattern):
+    return asyncio.run(invoke_tool(
+        get_default_registry(), "grep_files", {"path": ".", "pattern": pattern}, _ctx(tmp_path),
+    ))
+
+
+def test_grep_matches_pattern_in_sjis_file(tmp_path, monkeypatch):
+    """Tier 2: #1452 — grep finds a pattern inside a Shift-JIS file (the backend
+    decode now goes through the codec; the old utf-8-replace silently missed it)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "doc.txt").write_bytes("検索対象 TARGET_TOKEN です\n".encode("shift_jis"))
+    result = _grep(tmp_path, "TARGET_TOKEN")
+    assert result["status"] == "ok"
+    assert result.get("match_count", len(result.get("matches", []))) >= 1
+
+
+def test_grep_skips_binary_file(tmp_path, monkeypatch):
+    """Tier 2: #1452 — grep skips a binary file rather than matching against
+    replacement-char garbage."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "b.dat").write_bytes(b"\x00\x01TARGET_TOKEN\x02\xff")
+    result = _grep(tmp_path, "TARGET_TOKEN")
+    assert result["status"] == "ok"
+    assert result.get("match_count", len(result.get("matches", []))) == 0


### PR DESCRIPTION
**[e2e-coder]** — #1452 (owner directive), #1450/#1449 follow-up. Expanded scope (owner's 2 refinements: shared codec extract + the critical edit/write round-trip + grep backend seam). charset-normalizer added to core deps.

## Single-source codec (`workspace/text_codec.py`)
`decode_text_or_none` (BOM → UTF-8 fast-path → NUL-sniff → charset-normalizer; **BOM-before-NUL** load-bearing for NUL-heavy UTF-16/32) + `encode_text` (re-encode in the detected codec, BOM restored, **None when not representable**). One seam, all consumers agree (extract-the-seam, cf. #1446).

## Consumers
- **read**: non-UTF-8 → text + `encoding`; binary → #1449 marker; plain UTF-8 byte-identical (no field).
- **edit (CRITICAL round-trip)**: decode → str edit → re-encode SAME codec via new `Workspace.write_file_bytes`. **Errors leave the file UNTOUCHED**: binary-edit / new_string not representable (emoji→SJIS) — never the silent whole-file UTF-8 transcode `write_file`'s unconditional `encode("utf-8")` would cause.
- **write (overwrite)**: UTF-8 + `encoding_note` if overwriting non-UTF-8. **Rationale-backed asymmetry vs edit (owner-vetoable)**: write re-authors (author=LLM→UTF-8); edit is in-place (preserve).
- **grep (backend seam, host_backend.py)**: the 3 `read_text(utf-8,replace)` sites decode via the codec → binary skip + SJIS/UTF-16 search (fixes the silent replacement-char miss). **Container grep**: documented host-only detection (charset-normalizer not guaranteed in target images).

## Audit EXCLUDE (confirmed out of domain)
sandboxed_exec output / web_fetch (httpx charset) / reyn_src·memory·skill·compiler (reyn-authored UTF-8).

## Test plan (real Workspace + op_runtime, no mocks — Tier 2)
- [x] read: SJIS/EUC-JP/UTF-16(BOM) → text+encoding; plain UTF-8 byte-identical no field; PNG/random → binary (UTF-16 case pins BOM-before-NUL)
- [x] **edit round-trip**: SJIS edit preserves codec + span-outside bytes; UTF-16 BOM preserved; **emoji→SJIS errors + file untouched**; binary edit errors
- [x] write SJIS→UTF-8 + encoding_note
- [x] grep matches SJIS pattern / skips binary
- [x] (#1449 invalid-utf8 test updated — detectable legacy encodings are now text per this PR)
- [x] 1007 file/grep/workspace regression green; ruff + tier-audit clean. No catalog change → no replay re-record.

Note: charset-normalizer detection is content-dependent — very short/ambiguous non-UTF-8 can mis-detect; the impl handles it safely (mis-decode → old_string-not-found error, never a corrupting write).

Refs #1452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)