### PR TITLE
fix(1454) PR-A: embedding class/name resolution — close the dangling-class chain

### DIFF
--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -2002,6 +2002,45 @@ def _parse_mcp_search_threshold(raw_mcp: object) -> int:
         return _default
 
 
+def _reconcile_embedding_class(cfg: "ReynConfig") -> None:
+    """#1454 (c)+(d): a class-typed field is closed-world.
+
+    ``action_retrieval.embedding_class`` names an entry in
+    ``embedding.classes``. If it names a class with no such entry — the
+    builtin ``local-mini`` default when the user REPLACED ``embedding.classes``
+    (config.py: user classes override the builtin registry), or a typo — the
+    alias can never resolve. Degrade semantic ``search_actions`` to off (None)
+    with one decision-enabling log, rather than letting the dangling alias
+    reach the embedding backend where it surfaces as a misleading "model not
+    found" naming the alias (the owner-reported HF-blocked-company failure).
+
+    Same graceful-degrade family as the missing-extras path; an opt-out-able
+    auxiliary feature must never crash a zero-config session.
+    """
+    import logging
+
+    ec = cfg.action_retrieval.embedding_class
+    if not ec or ec in cfg.embedding.classes:
+        return
+    known = ", ".join(sorted(cfg.embedding.classes)) or "(none)"
+    if ec == ActionRetrievalConfig().embedding_class:
+        detail = (
+            f"the default embedding class {ec!r} has no entry in your "
+            f"embedding.classes — add it under embedding.classes, or set "
+            f"action_retrieval.embedding_class: null to silence this"
+        )
+    else:
+        detail = (
+            f"action_retrieval.embedding_class={ec!r} has no entry in "
+            f"embedding.classes (typo?) — add the class or set it to null"
+        )
+    logging.getLogger(__name__).warning(
+        "Semantic search_actions disabled: %s. Known classes: %s.",
+        detail, known,
+    )
+    cfg.action_retrieval.embedding_class = None
+
+
 def load_config(cwd: Path | None = None) -> ReynConfig:
     """Load and merge config from all sources. CLI flags are applied by the caller."""
     cwd = (cwd or Path.cwd()).resolve()
@@ -2097,7 +2136,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     safety_raw = merged.get("safety") if isinstance(merged.get("safety"), dict) else {}
     safety = _build_safety_config(safety_raw)
     cost = _build_cost_config(merged.get("cost"))
-    return ReynConfig(
+    _cfg = ReynConfig(
         model=str(merged.get("model", "standard")),
         output_language=output_language,
         models={
@@ -2145,6 +2184,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             merged.get("external_transports"),
         ),
     )
+    _reconcile_embedding_class(_cfg)
+    return _cfg
 
 
 def _build_external_transports_config(raw: object):

--- a/src/reyn/embedding/router_provider.py
+++ b/src/reyn/embedding/router_provider.py
@@ -114,8 +114,18 @@ class RoutingEmbeddingProvider:
 
     # ── Internal dispatch ──────────────────────────────────────────────────
 
-    def _backend_for(self, model: str) -> Any:
-        """Pick the right backend for the resolved-model string."""
+    def _route(self, model: str) -> "tuple[Any, str]":
+        """Resolve the class alias ONCE at this boundary, pick the backend by
+        the resolved name, and return ``(backend, resolved_model)``.
+
+        #1454 (a): the alias→model resolution happens exactly here. Callers
+        pass the RESOLVED model to the backend, never the raw class alias —
+        the previous ``_backend_for`` resolved only to *select* the backend
+        and then handed the unresolved alias to ``backend.embed(...)``, so a
+        class name like ``local-mini`` reached LiteLLM verbatim (→ "model not
+        found" naming the alias). Single resolution point = no dual-resolution
+        drift; downstream sees only model names.
+        """
         from reyn.embedding.sentence_transformers_provider import _PREFIX
         resolved = _resolve_via_classes(self._classes, model)
         if resolved.startswith(_PREFIX):
@@ -127,13 +137,14 @@ class RoutingEmbeddingProvider:
                     config=self._config,
                     event_sink=self._event_sink,
                 )
-            return self._st
-        return self._litellm
+            return self._st, resolved
+        return self._litellm, resolved
 
     # ── EmbeddingProvider protocol ─────────────────────────────────────────
 
     async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
-        return await self._backend_for(model).embed(texts, model)
+        backend, resolved = self._route(model)
+        return await backend.embed(texts, resolved)
 
     def estimate_tokens(self, texts: list[str]) -> int:
         # Token estimation is provider-agnostic in practice (both backends
@@ -143,7 +154,8 @@ class RoutingEmbeddingProvider:
         return self._litellm.estimate_tokens(texts)
 
     def get_dimension(self, model: str) -> int:
-        return self._backend_for(model).get_dimension(model)
+        backend, resolved = self._route(model)
+        return backend.get_dimension(resolved)
 
 
 __all__ = ["RoutingEmbeddingProvider"]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -38,7 +38,7 @@ verification 1-9.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final, Mapping
+from typing import TYPE_CHECKING, Any, Collection, Final, Mapping
 
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
@@ -167,17 +167,35 @@ def is_valid_qualified_name(qualified_name: str) -> bool:
 # ── D14 visibility gating helpers ──────────────────────────────────────────
 
 
-def is_search_available(*, action_retrieval_embedding_class: str | None) -> bool:
+def is_search_available(
+    *,
+    action_retrieval_embedding_class: str | None,
+    embedding_class_names: "Collection[str] | None" = None,
+) -> bool:
     """Return True iff ``search_actions`` should be exposed to the LLM.
 
-    Per FP-0034 §D14, ``search_actions`` is only visible when an
-    embedding class is configured for action retrieval (= reyn.yaml
-    ``action_retrieval.embedding_class`` resolves to a real entry in
-    ``embedding.classes``). Callers (= router_tools.py in PR-3) pass
-    the resolved embedding class name (or None) here to decide whether
-    to include SEARCH_ACTIONS in tools=.
+    Per FP-0034 §D14, ``search_actions`` is only visible when an embedding
+    class is configured for action retrieval AND that class is a real entry
+    in ``embedding.classes`` (a class-typed field is closed-world).
+
+    #1454: the primary membership reconciliation happens upstream at config
+    load (``_reconcile_embedding_class`` degrades a dangling class to None +
+    logs once). By the time this is called the value is normally already
+    clean, so the ``bool()`` check suffices. ``embedding_class_names`` is the
+    belt-and-suspenders leg: when a caller passes the known class names, a
+    non-member class returns False here too (closed-world enforced at the
+    visibility boundary, not just at config load). No logging here — the single
+    actionable log lives in the config-load reconciliation to avoid double
+    surfacing.
     """
-    return bool(action_retrieval_embedding_class)
+    if not action_retrieval_embedding_class:
+        return False
+    if (
+        embedding_class_names is not None
+        and action_retrieval_embedding_class not in embedding_class_names
+    ):
+        return False
+    return True
 
 
 def is_exec_available(*, sandbox_backend: str | None) -> bool:

--- a/tests/test_config_schema_enforcement_1056.py
+++ b/tests/test_config_schema_enforcement_1056.py
@@ -47,6 +47,10 @@ from reyn.config_schema import (
 # itself is still live-walk-derived — this only overrides the candidate VALUE.
 _VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {
     "skill_resume.default": "skip",  # validated against SKILL_RESUME_POLICIES, coerces
+    # #1454: embedding_class is closed-world — a class not in embedding.classes
+    # degrades to None at load (graceful). "standard" is a real builtin class
+    # (!= the "local-mini" default), so it survives the membership check.
+    "action_retrieval.embedding_class": "standard",
 }
 
 

--- a/tests/test_embedding_class_reconciliation_1454.py
+++ b/tests/test_embedding_class_reconciliation_1454.py
@@ -1,0 +1,77 @@
+"""Tier 2: #1454 (c)+(d) — dangling embedding_class reconciliation.
+
+A class-typed field is closed-world: ``action_retrieval.embedding_class`` must
+name an entry in ``embedding.classes``. When it doesn't — the builtin
+``local-mini`` default surviving after the user REPLACED ``embedding.classes``
+(the owner-reported HF-blocked-company case), or a typo — the alias can never
+resolve. ``_reconcile_embedding_class`` degrades semantic search to off (None)
+rather than letting the dangling alias reach the embedding backend (where it
+surfaces as a misleading "model not found" naming the alias).
+
+Real config dataclasses, no mocks.
+"""
+from __future__ import annotations
+
+from reyn.config import (
+    ActionRetrievalConfig,
+    EmbeddingClassSpec,
+    EmbeddingConfig,
+    ReynConfig,
+    _reconcile_embedding_class,
+)
+
+
+def _cfg(*, embedding_class: str | None, classes: dict) -> ReynConfig:
+    return ReynConfig(
+        embedding=EmbeddingConfig(classes=classes),
+        action_retrieval=ActionRetrievalConfig(embedding_class=embedding_class),
+    )
+
+
+def test_dangling_default_class_degrades_to_none():
+    """Tier 2: #1454 — the builtin 'local-mini' default with NO entry in
+    user-replaced embedding.classes degrades to None (search off), not error."""
+    cfg = _cfg(
+        embedding_class="local-mini",  # the un-overridden default
+        classes={"company-proxy": EmbeddingClassSpec(model="openai/internal")},
+    )
+    assert cfg.action_retrieval.embedding_class == "local-mini"
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class is None
+
+
+def test_explicit_dangling_class_degrades_to_none():
+    """Tier 2: #1454 — an explicit class (typo) with no entry also degrades to
+    None (closed-world: non-membership → graceful degrade, not crash)."""
+    cfg = _cfg(
+        embedding_class="standrad",  # typo for 'standard'
+        classes={"standard": EmbeddingClassSpec(model="openai/text-embedding-3-small")},
+    )
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class is None
+
+
+def test_valid_member_class_is_unchanged():
+    """Tier 2: #1454 — a class that IS in embedding.classes is left intact."""
+    cfg = _cfg(
+        embedding_class="standard",
+        classes={"standard": EmbeddingClassSpec(model="openai/text-embedding-3-small")},
+    )
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class == "standard"
+
+
+def test_none_class_is_noop():
+    """Tier 2: #1454 — embedding_class already None (opt-out) stays None."""
+    cfg = _cfg(embedding_class=None, classes={})
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class is None
+
+
+def test_default_classes_keep_local_mini_resolvable():
+    """Tier 2: #1454 — the zero-config default (builtin classes intact, which
+    include local-mini) is NOT degraded: local-mini resolves normally."""
+    cfg = ReynConfig()  # full defaults: builtin embedding.classes incl local-mini
+    assert cfg.action_retrieval.embedding_class == "local-mini"
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class == "local-mini"

--- a/tests/test_embedding_router_provider.py
+++ b/tests/test_embedding_router_provider.py
@@ -153,8 +153,10 @@ def test_class_name_resolving_to_st_routes_to_st_backend() -> None:
     provider = _make_provider(litellm, st)
 
     _run(provider.embed(["hi"], "local-mini"))
-    assert len(st.embed_calls) == 1
-    assert st.embed_calls[0][1] == "sentence-transformers/all-MiniLM-L6-v2"
+    # Behaviour: the ST backend was called with the RESOLVED model (one call).
+    assert [m for _texts, m in st.embed_calls] == [
+        "sentence-transformers/all-MiniLM-L6-v2"
+    ]
     assert not litellm.embed_calls
 
 

--- a/tests/test_embedding_router_provider.py
+++ b/tests/test_embedding_router_provider.py
@@ -110,13 +110,18 @@ def test_openai_model_routes_to_litellm() -> None:
 
 
 def test_class_name_resolving_to_openai_routes_to_litellm() -> None:
-    """Tier 2: class name 'standard' → openai/* → LiteLLM backend."""
+    """Tier 2: class name 'standard' → openai/* → LiteLLM backend.
+
+    #1454 (a): the backend receives the RESOLVED model string
+    ('openai/text-embedding-3-small'), NOT the class alias 'standard' —
+    resolution happens once at the routing boundary, downstream sees names."""
     litellm = _FakeBackend("litellm")
     st = _FakeBackend("st", dim=384)
     provider = _make_provider(litellm, st)
 
     _run(provider.embed(["hello"], "standard"))
-    assert litellm.embed_calls and litellm.embed_calls[0][1] == "standard"
+    assert litellm.embed_calls
+    assert litellm.embed_calls[0][1] == "openai/text-embedding-3-small"
     assert not st.embed_calls
 
 
@@ -137,14 +142,19 @@ def test_st_prefix_model_routes_to_sentence_transformers_backend() -> None:
 
 
 def test_class_name_resolving_to_st_routes_to_st_backend() -> None:
-    """Tier 2: class name 'local-mini' → sentence-transformers/* → ST backend."""
+    """Tier 2: class name 'local-mini' → sentence-transformers/* → ST backend.
+
+    #1454 (a): the ST backend receives the RESOLVED model string
+    ('sentence-transformers/all-MiniLM-L6-v2'), NOT the class alias
+    'local-mini'. Passing the alias through was the bug — it reached LiteLLM
+    verbatim in the dangling-class case and surfaced as "model not found"."""
     litellm = _FakeBackend("litellm")
     st = _FakeBackend("st", dim=384)
     provider = _make_provider(litellm, st)
 
     _run(provider.embed(["hi"], "local-mini"))
-    n_st_calls = len(st.embed_calls)
-    assert n_st_calls == 1 and st.embed_calls[0][1] == "local-mini"
+    assert len(st.embed_calls) == 1
+    assert st.embed_calls[0][1] == "sentence-transformers/all-MiniLM-L6-v2"
     assert not litellm.embed_calls
 
 
@@ -152,13 +162,16 @@ def test_class_name_resolving_to_st_routes_to_st_backend() -> None:
 
 
 def test_get_dimension_routes_to_st_for_st_prefix() -> None:
-    """Tier 2: get_dimension(local-mini) consults the ST backend."""
+    """Tier 2: get_dimension(local-mini) consults the ST backend.
+
+    #1454 (a): get_dimension follows the same single-resolution boundary —
+    the ST backend is queried with the RESOLVED model, not the alias."""
     litellm = _FakeBackend("litellm")
     st = _FakeBackend("st", dim=384)
     provider = _make_provider(litellm, st)
 
     assert provider.get_dimension("local-mini") == 384
-    assert st.dimension_calls == ["local-mini"]
+    assert st.dimension_calls == ["sentence-transformers/all-MiniLM-L6-v2"]
     assert not litellm.dimension_calls
 
 

--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -312,6 +312,28 @@ def test_is_search_available_predicate(
     ) is expected
 
 
+def test_is_search_available_membership_belt_and_suspenders() -> None:
+    """Tier 2: #1454 (b) — when the known class names are supplied, a class
+    NOT among them returns False (closed-world enforced at the visibility
+    boundary too, not just at config-load reconciliation)."""
+    classes = {"standard", "local-mini"}
+    # member → available
+    assert is_search_available(
+        action_retrieval_embedding_class="standard",
+        embedding_class_names=classes,
+    ) is True
+    # non-member (dangling) → hidden, even though the string is truthy
+    assert is_search_available(
+        action_retrieval_embedding_class="company-proxy",
+        embedding_class_names=classes,
+    ) is False
+    # None class stays False regardless of membership set
+    assert is_search_available(
+        action_retrieval_embedding_class=None,
+        embedding_class_names=classes,
+    ) is False
+
+
 @pytest.mark.parametrize(
     "backend, expected",
     [


### PR DESCRIPTION
**[e2e-coder]** — #1454 PR-A: embedding class/name resolution (the dangling-class chain). Refs #1454.

## Owner's bug → root cause
Zero-config reyn errored "local-mini not found" for semantic search the user never configured (HF-blocked company). Sharpened root cause = a **class/name resolution chain**, not the HF download:
custom `embedding.classes` REPLACES the builtin registry → builtin `local-mini` default dangles → resolution passes the unknown alias through unchanged → reaches LiteLLM as `model="local-mini"` → "not found" naming the alias.

## Unified principle (closed-world)
A class-typed field never falls through as a name (non-membership → graceful degrade, not crash); resolution happens ONCE at the boundary so downstream sees only model names.

## Layered fix (c primary → a defense-in-depth → b belt-and-suspenders)
- **(a)** `RoutingEmbeddingProvider._route()` resolves the class alias ONCE and passes the **resolved** model to the backend (was: resolved only to *select* the backend, then handed the raw alias to `backend.embed` → the dangling alias hit LiteLLM).
- **(c) [primary]** `_reconcile_embedding_class()` at config load: a dangling `embedding_class` degrades to `None` → gates off both the index build AND visibility via `_model_class=None`.
- **(d)** one decision-enabling log naming BOTH config keys, default-vs-typo wording.
- **(b)** `is_search_available` honours its closed-world docstring (optional `embedding_class_names` enforces membership at the visibility boundary too).

## Scope notes (for your arbitration)
- **(e) deferred to PR-B**: the `/`-prefix validation on `classes[*].model` folds into PR-B's unified name-position validation (applied once to both embedding + completion). Doing it embedding-only here would be a partial version of PR-B's explicit scope.
- **5th leg (HF-download-failure degrade) — NEW finding**: `_build_action_embedding_index_background` (router_loop.py:2946) **already swallows all exceptions** → emits `action_index_build_failed` → next turn `is_ready()` False → search stays hidden. So the download-failure path **already degrades gracefully (no crash)**. The 5th leg is therefore a *refinement* (cache the failure across sessions + a user-facing decision-enabling message instead of a raw event), not a crash-fix. **Proposing it as a small follow-up** rather than blocking PR-A — (a-d) is the actual root-cause fix for the owner's reported symptom. Your call.

## Tests (537 config/embedding/router/catalog green, ruff clean)
- router_provider: 3 rewritten to pin the new contract (backend receives the RESOLVED model, not the alias).
- `test_embedding_class_reconciliation_1454` (5 new): dangling-default → None, explicit-typo → None, valid member unchanged, None no-op, builtin-defaults keep local-mini resolvable.
- `is_search_available` membership (1 new).
- schema-enforcement: override for the now closed-world `embedding_class`.

## Test plan
- [x] `pytest -q -k 'config or embedding or router_provider or action_retrieval or universal_catalog or action_embedding'` → 537 passed
- [x] `ruff check` on changed files → clean
- [ ] (reviewer) confirm the 5th-leg-as-follow-up scoping call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
