### PR TITLE
feat(1454) PR-B: completion class/name unification + shared name-position validation

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -58,6 +58,17 @@ models:
 
 `models:` の各エントリはクラス名を LiteLLM モデル文字列 **または** per-class LLM パラメータを宣言する dict にマップします。
 
+### モデルクラス と モデル名 — 解決ルール
+
+config には2種類の位置があり、逆のルールに従います。同じルールが補完側 `models:` ブロック **と** `embedding.classes:` ブロックの両方に適用されます。
+
+- **クラス位置**（クラスへの *参照*）：`model`、per-agent / per-phase / per-op のモデル上書き、`embedding_class`。これらは **closed-world** — 値は `models:` / `embedding.classes:` に存在するクラス（または組み込み tier: `light` / `standard` / `strong`）を指さなければなりません。既知クラスでない値は、リテラルモデルとして黙って素通しされません：
+  - オペレータ config（reyn.yaml の `model:`）は後方互換のリテラル素通しを維持（`openai/gpt-4o` を直接書ける）；
+  - **skill/op 由来**のモデル（`op.model`）が既知クラスでない場合は **reject** され、runtime モデルにフォールバック（警告1件）します。これにより skill・LLM 由来の文字列が proxy config を迂回できません — モデル選択の単一の真実源は proxy config です。
+- **名前位置**（モデルの *定義*）：`models:` / `embedding.classes:` エントリ内の `model:` 値。名前は `provider/model`（例：`openai/gpt-4o`、`sentence-transformers/all-MiniLM-L6-v2`）であるべきです。`/` のない bare 名は許容されます（一部の LiteLLM 文字列は bare）が、ロード時に **警告** します — 解決が誤ルートする場合は prefix を追加してください。
+
+一言で：**`_class` / tier 位置はクラス名（closed-world）、`model` 位置は `provider/model`（検証付き）。どちらも受け付ける位置はない。**
+
 ### str 形式 — リテラル（後方互換）
 
 str 値に **`/` が含まれる** 場合、LiteLLM モデル文字列として直接使用されます：

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -59,6 +59,17 @@ models:
 
 Each entry under `models:` maps a class name to a LiteLLM model string **or** a dict that declares per-class LLM parameters.
 
+### Model classes vs model names — the resolution rule
+
+Two kinds of position appear in config, and they follow opposite rules. The same rule applies to the completion `models:` block **and** the `embedding.classes:` block.
+
+- **Class position** (a *reference* to a class): `model`, per-agent / per-phase / per-op model overrides, `embedding_class`. These are **closed-world** — the value must name a class that exists in `models:` / `embedding.classes:` (or a built-in tier: `light` / `standard` / `strong`). A value that is not a known class is **not** silently treated as a literal model:
+  - operator config (`model:` in reyn.yaml) keeps a backward-compatible literal passthrough (you may put `openai/gpt-4o` directly);
+  - a **skill/op-supplied** model (`op.model`) that is not a known class is **rejected** and falls back to the runtime model (one warning), so a skill- or LLM-authored string cannot bypass the proxy config — the proxy config is the single source of truth for model selection.
+- **Name position** (the *definition* of a model): the `model:` value inside a `models:` / `embedding.classes:` entry. A name should be `provider/model` (e.g. `openai/gpt-4o`, `sentence-transformers/all-MiniLM-L6-v2`). A bare name with no `/` is accepted (some LiteLLM strings are bare) but **warns** at load — add the prefix if resolution misroutes.
+
+In one line: **a `_class` / tier position takes a class name (closed-world); a `model` position takes `provider/model` (validated). No position accepts both.**
+
 ### str form — literal (backward compatible)
 
 If a str value **contains `/`**, it is treated as a literal LiteLLM model string:

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -616,6 +616,23 @@ def _parse_embedding_classes(raw: dict[str, Any]) -> dict[str, EmbeddingClassSpe
                 f"embedding.classes.{name} must be a str or dict, "
                 f"got {type(value).__name__}"
             )
+    # #1454 PR-B: name-position validation. A ``model`` value is a NAME
+    # position, which should be ``provider/model`` (the `/`-prefix invariant —
+    # all builtin defaults comply). WARN (not error) for a bare name: litellm
+    # may accept some bare strings, so bare usage is degraded-but-allowed,
+    # flagged so a misroute is diagnosable. (Class positions are closed-world;
+    # name positions allow the prefixed literal — the unified class/name rule.)
+    for _name, _spec in result.items():
+        if "/" not in _spec.model:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "embedding.classes.%s model %r has no provider prefix ('/') — "
+                "a model position should be 'provider/model' (e.g. "
+                "'openai/text-embedding-3-small'). Treating as a bare LiteLLM "
+                "name; add the prefix if embedding resolution misroutes.",
+                _name, _spec.model,
+            )
     return result
 
 

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -151,6 +151,39 @@ class ModelResolver:
         """
         return name in self._resolved
 
+    def resolve_class_or_fallback(
+        self, requested: str | None, fallback: str | None, *, where: str = "",
+    ) -> str:
+        """Resolve a CLASS-TYPED model selection (op/skill-supplied) closed-world.
+
+        #1454 PR-B (the unified class/name rule): a class-typed position is
+        closed-world — a ``requested`` value that is NOT a known class is NOT
+        passed through as a literal LiteLLM model (that would let a
+        skill-authored / LLM-injected string bypass the proxy config, which is
+        the single source of truth for model selection). Returns ``requested``
+        only when it is a known class; otherwise logs ONE decision-enabling
+        warning and returns the trusted ``fallback``.
+
+        This is the "standard gate" promotion of :meth:`is_known_class` — every
+        op/skill-supplied model field (``op.model``) routes through here rather
+        than each call site re-implementing the guard. Operator-config model
+        references (``cfg.model`` etc., from reyn.yaml) deliberately do NOT use
+        this gate: literal LiteLLM strings there are an intentional
+        backward-compat passthrough (see :meth:`resolve`).
+        """
+        if requested and not self.is_known_class(requested):
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "%s: model %r is not a known model class — ignoring and using "
+                "%r instead. Use a model class (e.g. light / standard / strong, "
+                "or one defined in reyn.yaml models:) so the proxy config stays "
+                "the single source of truth.",
+                where or "model selection", requested, fallback or "standard",
+            )
+            return fallback or "standard"
+        return requested or fallback or "standard"
+
     # ------------------------------------------------------------------
     # Internal resolution helpers
     # ------------------------------------------------------------------

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -134,6 +134,26 @@ class ModelResolver:
                     name, self._namespace[name], frozenset()
                 )
 
+        # #1454 PR-B: name-position validation. The resolved ``model`` is a NAME
+        # position, which should be ``provider/model`` (the `/`-prefix invariant
+        # — all builtin defaults comply). WARN (not error) for a bare name:
+        # litellm may accept some bare strings, so bare usage is
+        # degraded-but-allowed, flagged so a misroute is diagnosable. (Class
+        # positions — tier references — are closed-world via
+        # resolve_class_or_fallback; this is the name-position leg of the same
+        # unified class/name rule, shared with embedding.classes[*].model.)
+        for _name, _spec in self._resolved.items():
+            if "/" not in _spec.model:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "models.%s model %r has no provider prefix ('/') — a model "
+                    "position should be 'provider/model' (e.g. 'openai/gpt-4o'). "
+                    "Treating as a bare LiteLLM name; add the prefix if "
+                    "resolution misroutes.",
+                    _name, _spec.model,
+                )
+
     def resolve(self, name: str) -> ModelSpec:
         """Return the ModelSpec for name. Pass through as a no-kwargs ModelSpec if not in namespace."""
         if name in self._resolved:

--- a/src/reyn/op_runtime/judge_output.py
+++ b/src/reyn/op_runtime/judge_output.py
@@ -102,10 +102,16 @@ async def handle(
         }
 
     # ── 2. Resolve model string ───────────────────────────────────────────────
-    model_class = op.model or ctx.model or "standard"
+    # op.model is a class-typed (skill-supplied) field → closed-world gate
+    # (#1454 PR-B): a non-class value falls back to the runtime model rather
+    # than passing through as a literal LiteLLM string that bypasses the proxy.
     if ctx.resolver is not None:
+        model_class = ctx.resolver.resolve_class_or_fallback(
+            op.model, ctx.model, where="judge_output",
+        )
         resolved_model = ctx.resolver.resolve(model_class).model
     else:
+        model_class = op.model or ctx.model or "standard"
         resolved_model = model_class
 
     # ── 3. Build LLM messages ────────────────────────────────────────────────

--- a/src/reyn/op_runtime/run_skill.py
+++ b/src/reyn/op_runtime/run_skill.py
@@ -142,21 +142,16 @@ async def handle(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor
         if hasattr(sub_skill, "source_path") and sub_skill.source_path:
             skill_md_path_for_hash = Path(sub_skill.source_path)
 
-    # Model class resolution: op.model is only honoured when it is a known model
-    # class in the resolver mapping (e.g. "light", "standard", "strong").
-    # Literal LiteLLM strings (e.g. "gpt-3.5-turbo") injected by the LLM are
-    # rejected here and fall back to the runtime model, because the proxy config
-    # (reyn.yaml models:) is the single source of truth for model selection.
-    # This prevents LLM-hallucinated model strings from bypassing the proxy.
-    if op.model and ctx.resolver and not ctx.resolver.is_known_class(op.model):
-        _log.warning(
-            "run_skill: op.model %r is not a known model class — ignoring and "
-            "inheriting runtime model %r instead. Use a model class (light / "
-            "standard / strong) defined in reyn.yaml models:.",
-            op.model,
-            ctx.model,
+    # Model class resolution: op.model is a class-typed (skill-supplied) field,
+    # so it is closed-world — only honoured when it is a known model class
+    # (light / standard / strong, or one in reyn.yaml models:). A literal
+    # LiteLLM string (e.g. "gpt-3.5-turbo") injected by the LLM is rejected and
+    # falls back to the runtime model, keeping the proxy config the single
+    # source of truth. #1454 PR-B: the guard is the shared resolver gate.
+    if ctx.resolver is not None:
+        model = ctx.resolver.resolve_class_or_fallback(
+            op.model, ctx.model, where="run_skill",
         )
-        model = ctx.model or "standard"
     else:
         model = op.model or ctx.model or "standard"
 

--- a/tests/test_embedding_config.py
+++ b/tests/test_embedding_config.py
@@ -400,3 +400,19 @@ class TestDefaultImmutability:
         _build_embedding_config({})
         _build_embedding_config({"batch_size": 50})
         assert set(_DEFAULT_EMBEDDING_CLASSES) == original_keys
+
+
+def test_bare_embedding_model_name_warns_prefixed_does_not(caplog):
+    """Tier 2: #1454 PR-B — embedding.classes[*].model is a name position; a
+    value lacking a '/' provider prefix warns at parse (degraded-but-allowed),
+    a prefixed value is silent. Shared name-position leg of the class/name rule."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.config"):
+        _parse_embedding_classes({"bare": {"model": "all-MiniLM-L6-v2"}})
+    assert any("no provider prefix" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="reyn.config"):
+        _parse_embedding_classes({"ok": {"model": "openai/text-embedding-3-small"}})
+    assert not any("no provider prefix" in r.message for r in caplog.records)

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -204,3 +204,38 @@ def test_extends_backward_compat_slash_str_with_builtin_loaded():
     assert r.resolve("light").model == "openai/gemini-2.5-flash-lite"
     assert r.resolve("light").kwargs == {}
     assert r.resolve("standard").model == "openai/gpt-4o"
+
+
+# ── #1454 PR-B: resolve_class_or_fallback (the closed-world class gate) ──────
+
+
+def test_resolve_class_or_fallback_known_class_is_honoured():
+    """Tier 2: #1454 — a requested value that IS a known class is returned."""
+    r = ModelResolver({"strong": "openai/gpt-4o"}, builtin={})
+    assert r.resolve_class_or_fallback("strong", "standard", where="t") == "strong"
+
+
+def test_resolve_class_or_fallback_unknown_falls_back():
+    """Tier 2: #1454 — a non-class value (e.g. an LLM-injected literal model
+    string) is rejected and the trusted fallback is returned (closed-world:
+    op/skill-supplied class-typed fields never pass through as a name)."""
+    r = ModelResolver({"standard": "openai/gpt-4o"}, builtin={})
+    assert r.resolve_class_or_fallback(
+        "gpt-3.5-turbo", "standard", where="t",
+    ) == "standard"
+    # even a provider-prefixed literal is rejected here — class position only
+    assert r.resolve_class_or_fallback(
+        "openai/gpt-4o", "standard", where="t",
+    ) == "standard"
+
+
+def test_resolve_class_or_fallback_none_requested_uses_fallback():
+    """Tier 2: #1454 — no requested class → the fallback is used as-is."""
+    r = ModelResolver({"standard": "openai/gpt-4o"}, builtin={})
+    assert r.resolve_class_or_fallback(None, "standard", where="t") == "standard"
+
+
+def test_resolve_class_or_fallback_none_everywhere_defaults_standard():
+    """Tier 2: #1454 — requested and fallback both absent → 'standard'."""
+    r = ModelResolver({}, builtin={})
+    assert r.resolve_class_or_fallback(None, None, where="t") == "standard"

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -239,3 +239,19 @@ def test_resolve_class_or_fallback_none_everywhere_defaults_standard():
     """Tier 2: #1454 — requested and fallback both absent → 'standard'."""
     r = ModelResolver({}, builtin={})
     assert r.resolve_class_or_fallback(None, None, where="t") == "standard"
+
+
+def test_bare_model_name_warns_prefixed_does_not(caplog):
+    """Tier 2: #1454 PR-B — a name position (models[*].model) lacking a '/'
+    provider prefix warns at load (degraded-but-allowed); a prefixed name is
+    silent. The class/name unified rule's name-position leg."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver({"bare": {"model": "gpt-4o-mini"}}, builtin={})
+    assert any("no provider prefix" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        ModelResolver({"ok": {"model": "openai/gpt-4o"}}, builtin={})
+    assert not any("no provider prefix" in r.message for r in caplog.records)


### PR DESCRIPTION
**[e2e-coder]** — #1454 PR-B: completion-side class/name unification + the shared name-position rule. Refs #1454. Follows PR-A (#1457, merged).

## The unified rule (now enforced on BOTH sides)
A `_class`/tier position takes a **class name** (closed-world); a `model` position takes **`provider/model`** (validated). No position accepts both. Resolution happens once at the boundary.

## (1/2) Promote `is_known_class` to the standard class gate
Completion's `ModelResolver.resolve()` keeps an intentional literal-string passthrough (backward-compat for `cfg.model = "openai/gpt-4o"` from reyn.yaml — operator-trusted). But a **skill/op-supplied** model (`op.model`) is class-typed and must be closed-world, so an LLM/skill-authored string can't bypass the proxy config.

- New `ModelResolver.resolve_class_or_fallback(requested, fallback, where=)` — the shared gate (honours a known class, else one decision-enabling warning + the trusted fallback). Promotes the previously opt-in `is_known_class` guard to a first-class resolver capability.
- `run_skill.py`: refactored its inline guard to the shared gate (behaviour preserved).
- `judge_output.py`: **GAP closed** — it resolved `op.model` UNGATED (an LLM-injected literal would reach LiteLLM); now routes through the gate.
- `_resolve_reference` (extends targets) already validated membership — unchanged.

Audited all `op.model` readers: exactly run_skill + judge_output. Operator-config paths (`cfg.model`, router/agent/cron/eval) deliberately keep the literal passthrough (name position, not class).

## (2/2) Name-position `/`-prefix validation (e) + spec doc
- A `model:` value lacking `/` WARNS at load (degraded-but-allowed — some LiteLLM strings are bare; builtin defaults all comply). Applied at BOTH parse points: `ModelResolver.__init__` (completion) and `_parse_embedding_classes` (embedding). This is (e) from #1454, integrated here so both sides land together.
- Unified rule documented once for both sides in `docs/reference/config/reyn-yaml.md` (+ `.ja`).

## Notes
- Completion side has **no live bug** (fixed light/standard/strong trio, no user-replaceable registry) — this is prophylactic hardening of the same chain PR-A fixed live on the embedding side.
- 5th-leg HF-download refinement tracked separately in #1458 (sequenced after this).

## Test plan
- [x] 4 `resolve_class_or_fallback` cases + bare-name-warns tests (completion + embedding)
- [x] `pytest -k 'model_resolver or run_skill or judge_output or embedding or config'` → 570 passed
- [x] `ruff check` clean; `test_tier_audit.py --strict` on changed test files → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
