### PR TITLE
feat(1466): file__write success — bytes_written + previous_size_bytes

### DIFF
--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -235,15 +235,23 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         # When OVERWRITING a non-UTF-8 file, surface a note that the encoding
         # changed. The pre-read is best-effort (skipped if read is denied).
         _prev_enc: str | None = None
+        _prev_size: int | None = None  # #1466: bytes of the file before overwrite
         try:
             _prev_bytes, _existed = ctx.workspace.read_file_bytes(op.path)
             if _existed:
                 _, _prev_enc = decode_text_or_none(_prev_bytes)
+                _prev_size = len(_prev_bytes)  # zero extra I/O — reuse the encoding pre-read
         except PermissionError:
             pass
-        ctx.workspace.write_file(op.path, op.content or "")
+        _content = op.content or ""
+        ctx.workspace.write_file(op.path, _content)
         ctx.events.emit("tool_executed", op="write_file", path=op.path)
-        result: dict = {"kind": "file", "op": "write", "path": op.path, "status": "ok"}
+        result: dict = {
+            "kind": "file", "op": "write", "path": op.path, "status": "ok",
+            "bytes_written": len(_content.encode("utf-8")),
+        }
+        if _prev_size is not None:
+            result["previous_size_bytes"] = _prev_size
         if _prev_enc:
             result["encoding_note"] = (
                 f"overwrote a {_prev_enc}-encoded file; the new content is written "

--- a/tests/test_write_size_feedback_1466.py
+++ b/tests/test_write_size_feedback_1466.py
@@ -1,0 +1,131 @@
+"""Tier 2: #1466 — file__write success includes size feedback.
+
+write-success result gains ``bytes_written`` (always) and
+``previous_size_bytes`` (overwrite only). New-file writes carry only
+``bytes_written``; no content preview (token-bloat avoidance).
+
+Zero extra I/O: ``previous_size_bytes`` reuses the #1452 encoding
+pre-read (``read_file_bytes`` already called before the write).
+
+Real Workspace + real op_runtime / registry — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.events.events import EventLog
+from reyn.permissions.permissions import PermissionResolver
+from reyn.tools import get_default_registry
+from reyn.tools.dispatch import invoke_tool
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.workspace.workspace import Workspace
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    events = EventLog()
+    return ToolContext(
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={"file.read": "allow", "file.write": "allow"},
+            project_root=tmp_path,
+            interactive=False,
+        ),
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _write(tmp_path: Path, args: dict) -> dict:
+    return asyncio.run(invoke_tool(
+        get_default_registry(), "write_file", args, _ctx(tmp_path),
+    ))
+
+
+# ── 1. New file — bytes_written only ────────────────────────────────────────
+
+
+def test_new_file_has_bytes_written() -> None:
+    """Tier 2: #1466 — writing a new file returns bytes_written (UTF-8 byte count
+    of the written content). No previous_size_bytes on a new file."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        from pathlib import Path
+        tmp = Path(td)
+        content = "hello world\n"
+        result = _write(tmp, {"path": "new.txt", "content": content})
+        assert result["status"] == "ok"
+        assert result["bytes_written"] == len(content.encode("utf-8"))
+        assert "previous_size_bytes" not in result
+
+
+def test_new_file_bytes_written_multibyte() -> None:
+    """Tier 2: #1466 — bytes_written reflects UTF-8 byte count, not char count.
+    Non-ASCII content has bytes_written > len(content)."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        from pathlib import Path
+        tmp = Path(td)
+        content = "こんにちは\n"  # 5 chars, 16 bytes UTF-8
+        result = _write(tmp, {"path": "jp.txt", "content": content})
+        assert result["status"] == "ok"
+        assert result["bytes_written"] == len(content.encode("utf-8"))
+        assert result["bytes_written"] > len(content)
+        assert "previous_size_bytes" not in result
+
+
+# ── 2. Overwrite — both bytes_written and previous_size_bytes ────────────────
+
+
+def test_overwrite_has_both_size_fields(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #1466 — overwriting an existing file returns both bytes_written
+    (new size) and previous_size_bytes (old size). Regression pin: both fields
+    must be present and be exact byte counts."""
+    monkeypatch.chdir(tmp_path)
+    old_content = "old content here\n"
+    (tmp_path / "f.txt").write_bytes(old_content.encode("utf-8"))
+    new_content = "new content\n"
+    result = _write(tmp_path, {"path": "f.txt", "content": new_content})
+    assert result["status"] == "ok"
+    assert result["bytes_written"] == len(new_content.encode("utf-8"))
+    assert result["previous_size_bytes"] == len(old_content.encode("utf-8"))
+
+
+def test_overwrite_no_content_preview(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #1466 — write result must NOT include a content preview (token
+    bloat avoidance; size numbers alone are the signal)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "f.txt").write_bytes(b"old")
+    result = _write(tmp_path, {"path": "f.txt", "content": "new\n"})
+    assert result["status"] == "ok"
+    assert "content" not in result
+    assert "preview" not in result
+
+
+# ── 3. Other shape regression pins ──────────────────────────────────────────
+
+
+def test_write_result_core_fields_present(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #1466 — the core result shape (kind/op/path/status) is unchanged
+    by the size-feedback addition."""
+    monkeypatch.chdir(tmp_path)
+    result = _write(tmp_path, {"path": "x.txt", "content": "abc"})
+    assert result["kind"] == "file"
+    assert result["op"] == "write"
+    assert result["path"] == "x.txt"
+    assert result["status"] == "ok"
+
+
+def test_overwrite_size_differential(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: #1466 — falsification pair: after a large→small overwrite,
+    previous_size_bytes > bytes_written (the shrink is visible in the result)."""
+    monkeypatch.chdir(tmp_path)
+    large = "x" * 1000
+    small = "y" * 10
+    (tmp_path / "f.txt").write_bytes(large.encode("utf-8"))
+    result = _write(tmp_path, {"path": "f.txt", "content": small})
+    assert result["status"] == "ok"
+    assert result["previous_size_bytes"] == 1000
+    assert result["bytes_written"] == 10
+    assert result["previous_size_bytes"] > result["bytes_written"]


### PR DESCRIPTION
**[e2e-coder]**

## Summary

- `file__write` success result now includes `bytes_written` (UTF-8 byte count of written content, always present) and `previous_size_bytes` (byte count before overwrite, overwrite only)
- New-file writes carry `bytes_written` only — no `previous_size_bytes`
- No content preview added (token-bloat avoidance; size numbers alone are the signal per show-don't-judge principle)
- Zero extra I/O: `previous_size_bytes` reuses the #1452 encoding pre-read (`read_file_bytes` was already called before the write for `encoding_note` detection)

## Motivation

write-success was a bland `{"kind":"file","op":"write","path":"...","status":"ok"}` with zero size information — asymmetric with `edit`'s #1418 preview. 79-122KB whole-file overwrites passed silently with no signal. Adding byte counts surfaces the size fact without adding judgment or directives (corpus-proven structural enabler for the overwrite-satisfaction pattern).

## Replay fixtures

No fixtures contained write op results — no re-recording needed.

## Test plan

- [x] `pytest tests/test_write_size_feedback_1466.py` — 6 passed
- [x] `pytest -q` (full suite) — all passed
- [x] `ruff check .` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)