### PR TITLE
feat(1477): sandbox-aware get_cwd — backend.repo_dir over os.getcwd()

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -507,15 +507,23 @@ class RouterHostAdapter:
         return self._project_context or ""
 
     def get_cwd(self) -> str:
-        """Current working directory the agent process is running from.
+        """Agent-visible working directory for the SP Environment section.
 
-        Threaded into the router's system prompt so unqualified user
-        references like "this repo" / "this code" / "the codebase" map
-        to the project at this path. Without it the LLM falls back to
-        its training prior ("please share the repository URL") even when
-        the user is obviously inside a checked-out repo.
+        Backend-aware: when an environment backend is configured (e.g.
+        DockerEnvironmentBackend), the agent sees the in-container path
+        (backend.repo_dir) rather than the host cwd — these diverge when
+        the repo is mounted inside a container at a different path. Without
+        this fix the SP shows the host path but the actual FS/exec ops run
+        against the container repo_dir (frame mismatch + host path leak).
+
+        Resolution order (getattr-guarded for forward compat):
+        1. backend.repo_dir  — ContainerBackend (e.g. DockerEnvironmentBackend)
+        2. os.getcwd()       — HostBackend or no backend
         """
         import os
+        repo_dir = getattr(self._environment_backend, "repo_dir", None)
+        if repo_dir:
+            return str(repo_dir)
         return os.getcwd()
 
     def get_universal_wrappers_enabled(self) -> bool:

--- a/tests/test_cwd_sandbox_aware_1477.py
+++ b/tests/test_cwd_sandbox_aware_1477.py
@@ -1,0 +1,78 @@
+"""Tier 2: #1477 — RouterHostAdapter.get_cwd() is sandbox-aware.
+
+When an environment backend is configured (e.g. DockerEnvironmentBackend),
+get_cwd() returns the in-container path (backend.repo_dir) rather than the
+host's os.getcwd(). Without this fix, the SP Environment section shows the
+host path while FS/exec ops run against the container repo_dir — a frame
+mismatch that leaks host paths into the agent's context.
+
+No mocks. Real-construct fakes (pure subclass, no MagicMock).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from tests.test_router_host_adapter_invariants import _make_adapter
+
+# ── Real fake backends ───────────────────────────────────────────────────────
+
+
+class _FakeContainerBackend:
+    """Real fake for DockerEnvironmentBackend: exposes repo_dir only."""
+
+    def __init__(self, repo_dir: str) -> None:
+        self.repo_dir = repo_dir
+
+
+class _FakeHostBackend:
+    """Real fake for HostBackend: no repo_dir attribute."""
+    pass
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+def test_get_cwd_with_container_backend_returns_repo_dir(tmp_path: Path) -> None:
+    """Tier 2: #1477 — when environment_backend has repo_dir (ContainerBackend),
+    get_cwd() returns the container path, not the host cwd."""
+    container_path = "/testbed"
+    backend = _FakeContainerBackend(repo_dir=container_path)
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    assert adapter.get_cwd() == container_path
+
+
+def test_get_cwd_with_host_backend_returns_os_getcwd(tmp_path: Path) -> None:
+    """Tier 2: #1477 — when environment_backend has no repo_dir (HostBackend),
+    get_cwd() falls back to os.getcwd() — existing behaviour preserved."""
+    backend = _FakeHostBackend()
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    assert adapter.get_cwd() == os.getcwd()
+
+
+def test_get_cwd_with_no_backend_returns_os_getcwd(tmp_path: Path) -> None:
+    """Tier 2: #1477 — when no environment_backend is set (None), get_cwd()
+    returns os.getcwd() — backward-compat for host-only sessions."""
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+    )
+    assert adapter.get_cwd() == os.getcwd()
+
+
+def test_get_cwd_container_differs_from_host(tmp_path: Path) -> None:
+    """Tier 2: #1477 — falsification pair: container path != host cwd.
+    Confirms the fix actually changes the value (not a no-op)."""
+    container_path = "/testbed"
+    backend = _FakeContainerBackend(repo_dir=container_path)
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    assert adapter.get_cwd() == container_path
+    assert adapter.get_cwd() != os.getcwd()

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -110,6 +110,7 @@ def _make_adapter(
     agent_replies_list: "list[str] | None" = None,
     resolver: ModelResolver | None = None,
     turn_budget_engine: object = None,
+    environment_backend: object = None,  # #1477: optional for sandbox-cwd tests
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -164,6 +165,7 @@ def _make_adapter(
         delegation_tracker=lambda: _delegations,
         agent_replies_tracker=lambda: _replies,
         turn_budget_engine=turn_budget_engine,
+        environment_backend=environment_backend,
     )
 
 


### PR DESCRIPTION
**[e2e-coder]**

## Summary

`RouterHostAdapter.get_cwd()` was returning `os.getcwd()` (host path) unconditionally. For docker environment sessions this means the SP Environment section shows the host path while FS/exec ops run against `backend.repo_dir` (the container path) — a frame mismatch + host path leak.

Fix: check `self._environment_backend.repo_dir` first (getattr-guarded):
1. `backend.repo_dir` → ContainerBackend (DockerEnvironmentBackend)
2. `os.getcwd()` → HostBackend / no backend (existing behaviour preserved)

Same pattern as #1411 FS wiring.

## Replay fixtures

FakeRouterHost has no `get_cwd` → cwd is empty → Environment section skipped in all fixture keys → **no re-record needed** (confirmed: 16 passed, 2 xfailed).

## Full suite result

`2 failed (pre-existing, confirmed on main), 6975 passed, 10 skipped, 3 xfailed, 278s`

Pre-existing: `test_swebench_missing_honest_skip` (HF auth flake) + `test_legacy_no_media_store_path_returns_inline_content` (content mismatch).

## Test plan

- [x] `pytest tests/test_cwd_sandbox_aware_1477.py` — 4 passed (tier-audit clean)
- [x] `pytest tests/test_replay_skill_router.py tests/test_replay_multi_hop.py` — 16 passed, 2 xfailed
- [x] `pytest tests/ -q` (full suite) — 2 failed (pre-existing), 6975 passed, 278s
- [x] `ruff check .` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)