### PR TITLE
feat(1479): SP Environment — date/platform/shell/git (competitor-aligned, backend-aware)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1434,6 +1434,11 @@ class RouterLoop:
         # content stays unchanged for cached fixtures.
         _cwd_getter = getattr(host, "get_cwd", None)
         _cwd_str = _cwd_getter() if _cwd_getter else None
+        # #1479: system info (date/platform/shell/git). Same getattr-fallback:
+        # FakeRouterHost has no get_environment_info → None → fields absent →
+        # fixture SP keys unaffected.
+        _env_info_getter = getattr(host, "get_environment_info", None)
+        _environment_info = _env_info_getter() if callable(_env_info_getter) else None
         # FP-0034 Phase 2 step 1: D14 visibility gate for search_actions.
         # Only show search_actions when (a) wrappers are on, (b) the
         # operator configured an embedding model class, AND (c) the
@@ -1698,6 +1703,8 @@ class RouterLoop:
                 # N>0 produced actual alias functions (hot_list_n > 0 opt-in);
                 # False (new default) renders the "no pre-loaded actions" variant.
                 has_hot_list_aliases=bool(_hot_list_aliases),
+                # #1479: system info (date/platform/shell/git).
+                environment_info=_environment_info,
             )
         # ChatSession._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -76,6 +76,7 @@ def build_system_prompt(
     discovery_mandate: bool = False,  # #187 Stage C — weak-tier list_actions-first mandate (3x)
     non_interactive: bool = False,  # #1439 Fix #1 — run-once (no TTY): no user to ask, proceed instead of clarifying
     has_hot_list_aliases: bool = False,  # True when hot_list_n>0 produced direct-alias functions
+    environment_info: "dict | None" = None,  # #1479: date/platform/shell/git from get_environment_info()
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
@@ -310,20 +311,37 @@ def build_system_prompt(
     # prior ("please share the repository URL") even when the user is
     # obviously inside a checked-out repo. P7: no skill-specific strings,
     # only environment facts and routing hints to existing categories.
-    if cwd:
+    if cwd or environment_info:
         parts.append("## Environment")
         parts.append("")
-        parts.append(f"cwd: {cwd}")
+        if cwd:
+            parts.append(f"cwd: {cwd}")
+        # #1479: system info — backend-derived, competitor-aligned.
+        # Fields absent from environment_info are omitted (degrade, don't guess).
+        if environment_info:
+            if "date" in environment_info:
+                parts.append(f"date: {environment_info['date']}")
+            _plat = environment_info.get("platform", "")
+            _ver = environment_info.get("os_version", "")
+            if _plat and _ver:
+                parts.append(f"platform: {_plat} {_ver}")
+            elif _plat:
+                parts.append(f"platform: {_plat}")
+            if environment_info.get("shell"):
+                parts.append(f"shell: {environment_info['shell']}")
+            if "is_git_repo" in environment_info:
+                parts.append(f"git repo: {'yes' if environment_info['is_git_repo'] else 'no'}")
         parts.append("")
-        parts.append(
-            "When the user refers to \"this repo\", \"this code\", \"the codebase\","
-            " \"this project\", \"ここ\", or any other unqualified reference to"
-            " surrounding source, interpret it as the project at the cwd above."
-            " Do NOT ask for a repository URL or path — discover the contents"
-            " with `list_actions(category=['file'])` → `invoke_action(file__list, ...)`"
-            " → `invoke_action(file__read, ...)` within the cwd's read scope."
-        )
-        parts.append("")
+        if cwd:
+            parts.append(
+                "When the user refers to \"this repo\", \"this code\", \"the codebase\","
+                " \"this project\", \"ここ\", or any other unqualified reference to"
+                " surrounding source, interpret it as the project at the cwd above."
+                " Do NOT ask for a repository URL or path — discover the contents"
+                " with `list_actions(category=['file'])` → `invoke_action(file__list, ...)`"
+                " → `invoke_action(file__read, ...)` within the cwd's read scope."
+            )
+            parts.append("")
 
     # ── 3.5. Universal catalog (FP-0034 §D9, opt-in via action_retrieval) ────
     # When the operator has enabled the universal catalog (= reyn.yaml

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -529,22 +529,24 @@ class RouterHostAdapter:
     def get_environment_info(self) -> dict:
         """System metadata for the SP Environment section (#1479).
 
-        Returns a dict with the subset of fields that can be determined:
-          - ``date``        — today's date ISO-8601 (always; host-clock)
-          - ``platform``    — OS family lower-cased ("linux", "darwin", …)
-          - ``os_version``  — kernel/OS release string
-          - ``shell``       — default shell executable (path or name)
+        Always returns:
+          - ``date``       — today ISO-8601 (host-clock, universal)
+
+        Returns additionally when the backend is absent or is a HostBackend
+        (no ``repo_dir`` — same marker as #1477):
+          - ``platform``   — OS family lower-cased ("linux", "darwin", …)
+          - ``os_version`` — kernel/OS release string
+          - ``shell``      — default shell executable
           - ``is_git_repo`` — bool; True when a .git entry exists at cwd
 
-        Resolution order (getattr-guarded for forward compat with future
-        ContainerBackend.get_environment_info() probe):
-        1. backend.get_environment_info() — if the backend implements it
-           (ContainerBackend will probe the container and return its
-           platform/shell; this method then merges with the host date).
-        2. Local platform module + os.environ — HostBackend / no backend.
+        When a non-host backend is present (``repo_dir`` set = container):
+          - If backend implements ``get_environment_info()`` → use those values
+          - If not implemented → omit platform/os_version/shell/is_git_repo
+            (degrade, don't guess — returning host darwin/zsh for a linux
+            container would repeat the #1477 host-value-leak pattern)
 
-        Fields absent from the backend's dict are filled from the local
-        fallback; unknown/None fields are omitted (degrade, don't guess).
+        Container probe (uname -sr + $SHELL + .git check) is a follow-up
+        tracked in #1481; this PR establishes the correct omission semantics.
         """
         import datetime
         import os
@@ -552,32 +554,39 @@ class RouterHostAdapter:
         from pathlib import Path
 
         backend = self._environment_backend
-        backend_info: dict = {}
-        _info_fn = getattr(backend, "get_environment_info", None)
-        if callable(_info_fn):
-            try:
-                backend_info = _info_fn() or {}
-            except Exception:
-                backend_info = {}
-
         result: dict = {"date": datetime.date.today().isoformat()}
 
-        # platform / os_version: backend first (container-aware), then host
-        if "platform" not in backend_info:
-            backend_info["platform"] = _platform.system().lower()
-        if "os_version" not in backend_info:
-            backend_info["os_version"] = _platform.release()
-        if "shell" not in backend_info:
-            backend_info["shell"] = os.environ.get("SHELL", "")
+        # Determine whether this is a non-host (container) backend.
+        # Same marker as get_cwd() (#1477): presence of repo_dir signals
+        # a container backend whose agent-visible environment differs from host.
+        _is_non_host_backend = bool(getattr(backend, "repo_dir", None))
 
-        result["platform"] = backend_info["platform"]
-        result["os_version"] = backend_info["os_version"]
-        if backend_info.get("shell"):
-            result["shell"] = backend_info["shell"]
-
-        # Git repo check: .git entry at the agent-visible cwd
-        cwd_path = Path(self.get_cwd())
-        result["is_git_repo"] = (cwd_path / ".git").exists()
+        if _is_non_host_backend:
+            # Non-host backend: only use values the backend explicitly provides.
+            # If it doesn't implement get_environment_info(), omit all host-derived
+            # fields — showing host platform/shell for a container = wrong context.
+            _info_fn = getattr(backend, "get_environment_info", None)
+            if callable(_info_fn):
+                try:
+                    backend_info = _info_fn() or {}
+                except Exception:
+                    backend_info = {}
+                result["platform"] = backend_info.get("platform", "")
+                result["os_version"] = backend_info.get("os_version", "")
+                if backend_info.get("shell"):
+                    result["shell"] = backend_info["shell"]
+                cwd_path = Path(self.get_cwd())
+                result["is_git_repo"] = (cwd_path / ".git").exists()
+            # else: non-host backend without probe → omit platform/shell/git
+        else:
+            # Host backend or no backend: derive from local environment.
+            result["platform"] = _platform.system().lower()
+            result["os_version"] = _platform.release()
+            _shell = os.environ.get("SHELL", "")
+            if _shell:
+                result["shell"] = _shell
+            cwd_path = Path(self.get_cwd())
+            result["is_git_repo"] = (cwd_path / ".git").exists()
 
         return result
 

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -526,6 +526,61 @@ class RouterHostAdapter:
             return str(repo_dir)
         return os.getcwd()
 
+    def get_environment_info(self) -> dict:
+        """System metadata for the SP Environment section (#1479).
+
+        Returns a dict with the subset of fields that can be determined:
+          - ``date``        — today's date ISO-8601 (always; host-clock)
+          - ``platform``    — OS family lower-cased ("linux", "darwin", …)
+          - ``os_version``  — kernel/OS release string
+          - ``shell``       — default shell executable (path or name)
+          - ``is_git_repo`` — bool; True when a .git entry exists at cwd
+
+        Resolution order (getattr-guarded for forward compat with future
+        ContainerBackend.get_environment_info() probe):
+        1. backend.get_environment_info() — if the backend implements it
+           (ContainerBackend will probe the container and return its
+           platform/shell; this method then merges with the host date).
+        2. Local platform module + os.environ — HostBackend / no backend.
+
+        Fields absent from the backend's dict are filled from the local
+        fallback; unknown/None fields are omitted (degrade, don't guess).
+        """
+        import datetime
+        import os
+        import platform as _platform
+        from pathlib import Path
+
+        backend = self._environment_backend
+        backend_info: dict = {}
+        _info_fn = getattr(backend, "get_environment_info", None)
+        if callable(_info_fn):
+            try:
+                backend_info = _info_fn() or {}
+            except Exception:
+                backend_info = {}
+
+        result: dict = {"date": datetime.date.today().isoformat()}
+
+        # platform / os_version: backend first (container-aware), then host
+        if "platform" not in backend_info:
+            backend_info["platform"] = _platform.system().lower()
+        if "os_version" not in backend_info:
+            backend_info["os_version"] = _platform.release()
+        if "shell" not in backend_info:
+            backend_info["shell"] = os.environ.get("SHELL", "")
+
+        result["platform"] = backend_info["platform"]
+        result["os_version"] = backend_info["os_version"]
+        if backend_info.get("shell"):
+            result["shell"] = backend_info["shell"]
+
+        # Git repo check: .git entry at the agent-visible cwd
+        cwd_path = Path(self.get_cwd())
+        result["is_git_repo"] = (cwd_path / ".git").exists()
+
+        return result
+
     def get_universal_wrappers_enabled(self) -> bool:
         """Return whether FP-0034 universal catalog wrappers are enabled.
 

--- a/tests/test_sp_environment_sysinfo_1479.py
+++ b/tests/test_sp_environment_sysinfo_1479.py
@@ -47,6 +47,18 @@ class _FakeHostBackend:
     pass
 
 
+class _FakeContainerBackendNoInfo:
+    """ContainerBackend without get_environment_info() — probe not yet implemented.
+
+    This is the current state of DockerEnvironmentBackend. repo_dir signals
+    it is a non-host backend; absence of get_environment_info means the
+    platform/shell should be OMITTED (not filled from host values).
+    """
+
+    def __init__(self, repo_dir: str) -> None:
+        self.repo_dir = repo_dir
+
+
 # ── 1. get_environment_info() on RouterHostAdapter ────────────────────────────
 
 
@@ -81,6 +93,24 @@ def test_env_info_container_backend_uses_backend_values(tmp_path: Path) -> None:
     assert info["platform"] == "linux"
     assert info["os_version"] == "5.15.0"
     assert info["shell"] == "/bin/bash"
+
+
+def test_env_info_container_backend_no_probe_omits_platform_shell(tmp_path: Path) -> None:
+    """Tier 2: #1479 — non-host backend without get_environment_info() must NOT
+    fill platform/shell from the host. Omit them instead (degrade, don't guess).
+    Only date is always present. This pins the fix against the #1477-pattern
+    regression: showing host darwin/zsh for a linux container = wrong context.
+    """
+    backend = _FakeContainerBackendNoInfo(repo_dir="/testbed")
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    info = adapter.get_environment_info()
+    assert "date" in info, "date must always be present (clock-derived)"
+    assert "platform" not in info, "platform must be absent when container probe not available"
+    assert "os_version" not in info, "os_version must be absent"
+    assert "shell" not in info, "shell must be absent"
 
 
 def test_env_info_no_backend_derives_from_platform_module(tmp_path: Path) -> None:

--- a/tests/test_sp_environment_sysinfo_1479.py
+++ b/tests/test_sp_environment_sysinfo_1479.py
@@ -1,0 +1,201 @@
+"""Tier 2: #1479 — SP Environment section: system info (date/platform/shell/git).
+
+Competitor-aligned fields added to ## Environment:
+- date:     today (ISO-8601, always; host-clock)
+- platform: OS family + kernel release (backend-derived, container-aware)
+- shell:    default shell (backend-derived)
+- git repo: yes/no (.git presence at cwd)
+
+Backend resolution: getattr-guarded — ContainerBackend future-ready;
+HostBackend / no backend falls back to local platform module.
+
+FakeRouterHost has no get_environment_info → field absent → fixture keys
+unaffected (confirmed in replay note).
+
+No mocks. Real-construct fakes.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reyn.chat.router_system_prompt import build_system_prompt
+from tests.test_router_host_adapter_invariants import _make_adapter
+
+# ── Fake backends ─────────────────────────────────────────────────────────────
+
+
+class _FakeContainerBackendWithInfo:
+    """ContainerBackend with get_environment_info() — the future-ready path."""
+
+    def __init__(self, repo_dir: str, platform: str, os_version: str, shell: str) -> None:
+        self.repo_dir = repo_dir
+        self._platform = platform
+        self._os_version = os_version
+        self._shell = shell
+
+    def get_environment_info(self) -> dict:
+        return {
+            "platform": self._platform,
+            "os_version": self._os_version,
+            "shell": self._shell,
+        }
+
+
+class _FakeHostBackend:
+    """HostBackend: no repo_dir, no get_environment_info."""
+    pass
+
+
+# ── 1. get_environment_info() on RouterHostAdapter ────────────────────────────
+
+
+def test_env_info_host_backend_derives_from_platform_module(tmp_path: Path) -> None:
+    """Tier 2: #1479 — host backend path: platform/os_version/shell derived
+    from local platform module + os.environ. date always present."""
+    import platform
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=_FakeHostBackend(),
+    )
+    info = adapter.get_environment_info()
+    assert "date" in info, "date must always be present (host-clock)"
+    assert info["platform"] == platform.system().lower()
+    assert info["os_version"] == platform.release()
+
+
+def test_env_info_container_backend_uses_backend_values(tmp_path: Path) -> None:
+    """Tier 2: #1479 — container backend path: platform/os_version/shell come
+    from backend.get_environment_info() (container's linux, not host's darwin)."""
+    backend = _FakeContainerBackendWithInfo(
+        repo_dir="/testbed",
+        platform="linux",
+        os_version="5.15.0",
+        shell="/bin/bash",
+    )
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    info = adapter.get_environment_info()
+    assert info["platform"] == "linux"
+    assert info["os_version"] == "5.15.0"
+    assert info["shell"] == "/bin/bash"
+
+
+def test_env_info_no_backend_derives_from_platform_module(tmp_path: Path) -> None:
+    """Tier 2: #1479 — no backend: same as host backend (fallback to platform)."""
+    import platform
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+    )
+    info = adapter.get_environment_info()
+    assert info["platform"] == platform.system().lower()
+    assert "date" in info
+
+
+def test_env_info_git_repo_detection_true(tmp_path: Path) -> None:
+    """Tier 2: #1479 — is_git_repo=True when .git exists at the agent-visible cwd.
+
+    Uses a container backend with repo_dir=tmp_path so get_cwd() returns
+    tmp_path, then creates tmp_path/.git to make the git check return True.
+    """
+    (tmp_path / ".git").mkdir()
+    # Container backend: repo_dir=str(tmp_path) → get_cwd() returns tmp_path
+    backend = _FakeContainerBackendWithInfo(
+        repo_dir=str(tmp_path), platform="linux", os_version="5.15.0", shell="/bin/bash"
+    )
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    info = adapter.get_environment_info()
+    assert info.get("is_git_repo") is True
+
+
+def test_env_info_git_repo_detection_false(tmp_path: Path) -> None:
+    """Tier 2: #1479 — is_git_repo=False when .git does not exist at cwd.
+
+    Uses a container backend pointing at tmp_path/no_git (no .git there).
+    """
+    no_git_dir = tmp_path / "no_git"
+    no_git_dir.mkdir()
+    backend = _FakeContainerBackendWithInfo(
+        repo_dir=str(no_git_dir), platform="linux", os_version="5.15.0", shell="/bin/bash"
+    )
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    info = adapter.get_environment_info()
+    assert info.get("is_git_repo") is False
+
+
+# ── 2. SP rendering ───────────────────────────────────────────────────────────
+
+
+def _sp_with_env(**kw) -> str:
+    return build_system_prompt(
+        agent_name="test",
+        agent_role="tester",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+        **kw,
+    )
+
+
+def test_sp_renders_date_when_environment_info_set() -> None:
+    """Tier 2: #1479 — environment_info with date renders in ## Environment."""
+    sp = _sp_with_env(environment_info={"date": "2026-06-11", "is_git_repo": True})
+    assert "## Environment" in sp
+    assert "date: 2026-06-11" in sp
+
+
+def test_sp_renders_platform_and_version() -> None:
+    """Tier 2: #1479 — platform + os_version render as 'platform: linux 5.15.0'."""
+    sp = _sp_with_env(
+        environment_info={"date": "2026-06-11", "platform": "linux", "os_version": "5.15.0"}
+    )
+    assert "platform: linux 5.15.0" in sp
+
+
+def test_sp_renders_shell() -> None:
+    """Tier 2: #1479 — shell renders in ## Environment when present."""
+    sp = _sp_with_env(
+        environment_info={"date": "2026-06-11", "shell": "/bin/zsh"}
+    )
+    assert "shell: /bin/zsh" in sp
+
+
+def test_sp_renders_git_repo_yes() -> None:
+    """Tier 2: #1479 — is_git_repo=True renders as 'git repo: yes'."""
+    sp = _sp_with_env(environment_info={"date": "2026-06-11", "is_git_repo": True})
+    assert "git repo: yes" in sp
+
+
+def test_sp_renders_git_repo_no() -> None:
+    """Tier 2: #1479 — is_git_repo=False renders as 'git repo: no'."""
+    sp = _sp_with_env(environment_info={"date": "2026-06-11", "is_git_repo": False})
+    assert "git repo: no" in sp
+
+
+def test_sp_environment_section_absent_when_neither_cwd_nor_info() -> None:
+    """Tier 2: #1479 — ## Environment section absent when both cwd and
+    environment_info are None (FakeRouterHost replay path → fixtures unaffected)."""
+    sp = _sp_with_env()  # no cwd, no environment_info
+    assert "## Environment" not in sp
+
+
+def test_sp_omits_empty_shell() -> None:
+    """Tier 2: #1479 — shell field absent when empty string (degrade, don't guess)."""
+    sp = _sp_with_env(environment_info={"date": "2026-06-11", "shell": ""})
+    assert "shell:" not in sp
+
+
+def test_sp_platform_only_without_version() -> None:
+    """Tier 2: #1479 — platform renders even without os_version (graceful degrade)."""
+    sp = _sp_with_env(environment_info={"date": "2026-06-11", "platform": "linux"})
+    assert "platform: linux" in sp
+    # Must not try to render 'linux ' with trailing space
+    assert "platform: linux \n" not in sp or "platform: linux" in sp


### PR DESCRIPTION
**[e2e-coder]**

## Summary

Four system info fields added to `## Environment` in `build_system_prompt`, competitor-aligned (Claude Code / Codex CLI / aider):
- `date:` — today ISO-8601 (host-clock, always present)
- `platform:` — OS family + kernel release (backend-derived, container-aware)
- `shell:` — default shell executable
- `git repo: yes/no` — `.git` presence at agent-visible cwd

**Backend-aware** (#1477 pattern): `RouterHostAdapter.get_environment_info()` checks `backend.get_environment_info()` via getattr-guard (ContainerBackend future-ready — when it adds the method, it will return the container's linux/shell). Falls back to `platform` module + `os.environ`.

**Degrade policy**: missing/None fields omitted from SP (don't guess).

## Fixture stability

`FakeRouterHost` has no `get_environment_info` → `_environment_info = None` → all fields absent from fixture SP keys → **no re-record needed**. Confirmed: 16 router replays passed, 2 xfailed.

## Full suite result

`2 failed (pre-existing), 6988 passed, 10 skipped, 3 xfailed, 281s`

Pre-existing: `test_swebench_missing_honest_skip` (HF auth flake) + `test_legacy_no_media_store_path_returns_inline_content`.

## Test plan

- [x] `pytest tests/test_sp_environment_sysinfo_1479.py` — 13 passed (tier-audit clean)
- [x] `pytest tests/test_replay_skill_router.py tests/test_replay_multi_hop.py` — 16 passed, 2 xfailed
- [x] `pytest tests/ -q` (full suite) — 2 failed (pre-existing), 6988 passed, 281s
- [x] `ruff check .` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)