### PR TITLE
feat(safety): Fix A+B — FP-0005 max_iterations checkpoint + decision-enabling errors

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -1132,6 +1132,9 @@ async def execute_plan(
                 # differentiation).
                 empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
                 empty_stop_retry_auto=True,
+                # FP-0005: wire safety.on_limit so step_max_iterations exhaustion
+                # routes through handle_limit_exceeded instead of flat-aborting.
+                on_limit=on_limit,
             )
             # FP-0031-C: auto-retry on transient step failures.
             # FP-0031-D: when retry budget is exhausted, ask the user via

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -698,6 +698,13 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     # op_runtime with the same gating the legacy router branches had.
     def make_router_op_context(self) -> Any: ...
 
+    # Safety-limit intervention bus factory (FP-0005 extension).
+    # Returns the current RequestBus for handle_limit_exceeded interactive
+    # mode, or None when no bus is wired (headless / test stubs).
+    # getattr-guarded in run_loop — hosts that don't implement it degrade
+    # to unattended (no ask, decision-enabling message instead).
+    def make_intervention_bus(self) -> "Any | None": ...
+
     # Resolve router model (config "router" → real model id)
     def resolve_model(self, name: str) -> str: ...
 
@@ -1296,6 +1303,7 @@ class RouterLoop:
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
         empty_stop_retry_auto: bool = False,  # #187: always-on (no env opt-in); all prod sites pass True
         plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
+        on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
     ):
         self.host = host
@@ -1387,6 +1395,7 @@ class RouterLoop:
         # testing.ja.md hard rule that forbids ``MagicMock / AsyncMock /
         # patch``. Production callers leave this as ``None``.
         self._llm_caller = llm_caller
+        self._on_limit = on_limit  # FP-0005 max_iterations checkpoint config
         self._catalog: dict[str, dict] = {}  # populated per run()
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
@@ -1782,7 +1791,11 @@ class RouterLoop:
         # (default 1 = one correction attempt per chat turn).
         _plan_invalid_retries: int = 0
 
-        for _iteration in range(self.max_iterations):
+        # FP-0005 max_iterations checkpoint: outer while allows re-entry after
+        # an approved extension. _loop_cancelled tracks cancel-break vs exhaustion.
+        _loop_cancelled = False
+        while True:
+         for _iteration in range(self.max_iterations):
             # #1468: cooperative turn-cancel checkpoint. Checked BEFORE the LLM
             # call so a cancel_inflight() fired between tool iterations stops the
             # chain at the next boundary (= after the current tool completes, not
@@ -1791,6 +1804,7 @@ class RouterLoop:
             _cancel_fn = getattr(host, "_is_turn_cancel_requested", None)
             if callable(_cancel_fn) and _cancel_fn():
                 host.events.emit("turn_cancelled", chain_id=self.chain_id)
+                _loop_cancelled = True
                 break
             resolved_model = host.resolve_model(self.router_model)
             # #1092 PR-C-5 (2): per-turn phase wall-clock budget enforcement. A phase
@@ -2549,10 +2563,39 @@ class RouterLoop:
             )
             return self._total_usage
 
-        # max_iterations exhausted
+         # end of inner for loop
+         if _loop_cancelled:
+            break  # cancelled: exit outer while, emit error below
+
+         # max_iterations exhausted — FP-0005 checkpoint
+         if self._on_limit is not None:
+            from reyn.safety.limit_handler import handle_limit_exceeded as _hle
+            _bus = getattr(self.host, "make_intervention_bus", lambda: None)()
+            _dec = await _hle(
+                bus=_bus,
+                on_limit=self._on_limit,
+                kind="max_iterations",
+                run_id=self.chain_id,
+                prompt=(
+                    f"Router hit the iteration limit ({self.max_iterations}). "
+                    "Allow more iterations?"
+                ),
+                detail=f"chain_id={self.chain_id}",
+                extension_amount=float(self.max_iterations),
+            )
+            if _dec.allow_continue:
+                self.max_iterations += int(_dec.extension)
+                continue  # re-enter inner for loop with extended limit
+         break  # no extension granted or no on_limit — exit outer while
+
+        # max_iterations exhausted (or cancelled)
         await self.host.put_outbox(
             kind="error",
-            text=f"Router loop exceeded max iterations ({self.max_iterations}).",
+            text=(
+                f"Router loop exceeded max iterations ({self.max_iterations}). "
+                f"Configure safety.on_limit.mode=interactive or auto_extend to "
+                f"extend, or increase router_max_iterations."
+            ),
             meta={"chain_id": self.chain_id},
         )
         return self._total_usage

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -1527,3 +1527,14 @@ class RouterHostAdapter:
             media_store=self._media_store,
             compact_now=self._compact_now,
         )
+
+    def make_intervention_bus(self) -> "Any | None":
+        """Return the current intervention bus for safety-limit checkpoints.
+
+        Called by RouterLoop when max_iterations is reached and
+        safety.on_limit.mode=interactive. Returns None when no bus is
+        wired (headless / test stubs) → limit degrades to unattended.
+        """
+        if self._intervention_bus_factory is None:
+            return None
+        return self._intervention_bus_factory()

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -334,11 +334,9 @@ class RouterLoopDriver:
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
             empty_stop_retry_auto=True,
             plan_invalid_retries=_plan_invalid_retries_cap,
-            # FP-0005: on_limit NOT threaded here yet — router max_iterations
-            # wiring is deferred until sandbox_2 validates the planner step
-            # path (step_max_iterations via session.py). The outer-while
-            # mechanism + make_intervention_bus protocol are in place; Tier-2
-            # tests prove the wiring via direct RouterLoop construction.
+            # FP-0005: wire safety.on_limit so max_iterations exhaustion routes
+            # through handle_limit_exceeded instead of flat-aborting.
+            on_limit=getattr(self._safety, "on_limit", None),
         )
         # PR-N3: pre-frame context-overflow guard.
         await self._budget_advisor.maybe_force_compact(new_msg_text=user_text)

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -334,6 +334,11 @@ class RouterLoopDriver:
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
             empty_stop_retry_auto=True,
             plan_invalid_retries=_plan_invalid_retries_cap,
+            # FP-0005: on_limit NOT threaded here yet — router max_iterations
+            # wiring is deferred until sandbox_2 validates the planner step
+            # path (step_max_iterations via session.py). The outer-while
+            # mechanism + make_intervention_bus protocol are in place; Tier-2
+            # tests prove the wiring via direct RouterLoop construction.
         )
         # PR-N3: pre-frame context-overflow guard.
         await self._budget_advisor.maybe_force_compact(new_msg_text=user_text)

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -309,12 +309,22 @@ def _get_registry():
         def _session_factory(profile: AgentProfile) -> ChatSession:
             registry = registry_ref[0]
             _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
+            # FP-0005: A2A peer sessions cannot surface RouterLoop checkpoint
+            # asks via A2AInterventionBus (follow-up #1493: wire via
+            # A2AInterventionBus.on_dispatch to mirror input-required).
+            # Until then, force on_limit=unattended so max_iterations
+            # exhaustion aborts gracefully (decision-enabling error) instead
+            # of hanging on an unreachable TUI intervention ask.
+            import dataclasses as _dc
+
+            from reyn.config import OnLimitConfig as _OLC
+            _a2a_safety = _dc.replace(config.safety, on_limit=_OLC(mode="unattended"))
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,
                 permission_resolver=perm_resolver,
-                safety=config.safety,
+                safety=_a2a_safety,
                 mcp_servers=config.mcp,
                 output_language=output_language,
                 prompt_cache_enabled=config.prompt_cache_enabled,

--- a/tests/test_safety_max_iterations_fp0005.py
+++ b/tests/test_safety_max_iterations_fp0005.py
@@ -1,0 +1,226 @@
+"""Tier 2: FP-0005 max_iterations checkpoint wiring in RouterLoop.
+
+Invariants pinned:
+
+1. When max_iterations is exhausted and on_limit is wired (interactive mode),
+   handle_limit_exceeded is called — NOT a flat abort.
+2. When the bus answers YES, extension applied and loop continues for extension
+   more iterations before hitting the next limit (or completing).
+3. When the bus answers NO (user refused), the loop stops with a
+   decision-enabling error message (mentions config key to change).
+4. When on_limit=None (legacy path), flat-abort error is still decision-enabling
+   (mentions router_max_iterations config key).
+5. When bus=None (interactive mode, no bus wired), handle_limit_exceeded
+   returns no_bus → decision-enabling error (not silent abort).
+6. When mode=unattended, no ask dispatched, immediate abort with error.
+
+Loop exhaustion mechanism: script the LLM to return an unknown tool call
+(not invoke_skill, not in registry) each iteration. dispatch_tool returns
+unknown_tool error; the loop adds it to messages and continues. After
+max_iterations calls the limit fires.
+
+No mocks. RouterLoop is driven via llm_caller= injection. RequestBus is
+a real subclass (not MagicMock) per no-mock policy.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.config import OnLimitConfig
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+from tests.test_router_loop import FakeRouterHost, _ScriptedLLM, text_result
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _loop_exhauster(n: int) -> LLMToolCallResult:
+    """LLMToolCallResult with one unknown tool call — makes the loop iterate
+    without early return (dispatch_tool returns unknown_tool error, loop
+    adds the error to messages and continues)."""
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": f"tc_{n}",
+            "type": "function",
+            "function": {
+                "name": "_test_loop_exhauster",
+                "arguments": json.dumps({"n": n}),
+            },
+        }],
+        finish_reason="tool_calls",
+        usage=_EMPTY_USAGE,
+    )
+
+
+# ── Fake RequestBus ───────────────────────────────────────────────────────────
+
+
+class _FakeRequestBus:
+    """Real RequestBus subclass (non-mock) that records asks and returns
+    a pre-scripted choice."""
+
+    def __init__(self, answer_choice_id: str) -> None:
+        self._answer = answer_choice_id
+        self.asks: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._answer, choice_id=self._answer)
+
+
+# ── Host with make_intervention_bus ──────────────────────────────────────────
+
+
+class _LimitHost(FakeRouterHost):
+    """FakeRouterHost that exposes make_intervention_bus() for FP-0005."""
+
+    def __init__(self, bus: "_FakeRequestBus | None" = None) -> None:
+        super().__init__()
+        self._bus = bus
+
+    def make_intervention_bus(self) -> "_FakeRequestBus | None":
+        return self._bus
+
+
+def _loop(
+    host: _LimitHost,
+    llm: _ScriptedLLM,
+    max_iterations: int,
+    on_limit: "OnLimitConfig | None" = None,
+) -> RouterLoop:
+    return RouterLoop(
+        host=host,
+        chain_id="chain-limit-test",
+        max_iterations=max_iterations,
+        llm_caller=llm,
+        on_limit=on_limit,
+    )
+
+
+async def _exhaust_loop(
+    host: _LimitHost,
+    n_exhaust: int,
+    max_iterations: int,
+    on_limit: "OnLimitConfig | None" = None,
+    extra_after: "list[LLMToolCallResult] | None" = None,
+) -> None:
+    """Run the loop with n_exhaust unknown-tool calls to hit the limit,
+    then optionally extra results after an extension."""
+    script = [_loop_exhauster(i) for i in range(n_exhaust)]
+    if extra_after:
+        script.extend(extra_after)
+    llm = _ScriptedLLM(script)
+    loop = _loop(host, llm, max_iterations=max_iterations, on_limit=on_limit)
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        _univ_enabled=False,
+    )
+
+
+# ── 1. Bus=YES → extension applied, loop continues ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_interactive_yes_extends_loop() -> None:
+    """Tier 2: FP-0005 — when max_iterations exhausted and bus answers YES,
+    handle_limit_exceeded called, extension applied, loop produces agent reply."""
+    bus = _FakeRequestBus(answer_choice_id="yes")
+    host = _LimitHost(bus=bus)
+    on_limit = OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0)
+
+    # max_iterations=2: exhaust 2 iterations → ask → YES → 2 more → text reply
+    await _exhaust_loop(
+        host,
+        n_exhaust=2,          # exhaust first limit
+        max_iterations=2,
+        on_limit=on_limit,
+        extra_after=[_loop_exhauster(99), text_result("done after extension")],
+    )
+
+    # Bus was asked exactly once (first exhaustion)
+    (ask,) = bus.asks  # unpack-assertion: exactly 1 ask
+    assert "max_iterations" in ask.kind
+    # Loop continued: agent reply emitted (not an error)
+    agent_msgs = [m for m in host.outbox if m["kind"] == "agent"]
+    (agent_msg,) = agent_msgs
+    assert agent_msg["text"] == "done after extension"
+
+
+# ── 2. Bus=NO → decision-enabling error message ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_interactive_no_emits_decision_enabling_error() -> None:
+    """Tier 2: FP-0005 — when max_iterations exhausted and bus answers NO,
+    error message is decision-enabling (mentions what to configure)."""
+    bus = _FakeRequestBus(answer_choice_id="no")
+    host = _LimitHost(bus=bus)
+    on_limit = OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0)
+
+    await _exhaust_loop(host, n_exhaust=2, max_iterations=2, on_limit=on_limit)
+
+    (ask,) = bus.asks
+    assert "max_iterations" in ask.kind
+    error_msgs = [m for m in host.outbox if m["kind"] == "error"]
+    (err,) = error_msgs
+    # Decision-enabling: mentions config key
+    assert "router_max_iterations" in err["text"] or "on_limit" in err["text"]
+
+
+# ── 3. Bus=None (interactive mode) → decision-enabling error ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_no_bus_decision_enabling_error() -> None:
+    """Tier 2: FP-0005 — bus=None + interactive mode → no_bus path →
+    decision-enabling error, NOT silent abort."""
+    host = _LimitHost(bus=None)
+    on_limit = OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0)
+
+    await _exhaust_loop(host, n_exhaust=1, max_iterations=1, on_limit=on_limit)
+
+    error_msgs = [m for m in host.outbox if m["kind"] == "error"]
+    (err,) = error_msgs
+    assert "router_max_iterations" in err["text"] or "on_limit" in err["text"]
+
+
+# ── 4. on_limit=None → legacy flat-abort is decision-enabling ────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_no_on_limit_legacy_decision_enabling() -> None:
+    """Tier 2: FP-0005 — on_limit=None legacy path: error message is
+    decision-enabling (mentions router_max_iterations config key)."""
+    host = _LimitHost(bus=None)
+
+    await _exhaust_loop(host, n_exhaust=1, max_iterations=1, on_limit=None)
+
+    error_msgs = [m for m in host.outbox if m["kind"] == "error"]
+    (err,) = error_msgs
+    assert "router_max_iterations" in err["text"]
+
+
+# ── 5. Unattended mode → immediate abort, no ask ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_unattended_no_ask() -> None:
+    """Tier 2: FP-0005 — unattended mode: no ask dispatched, immediate error."""
+    bus = _FakeRequestBus(answer_choice_id="yes")  # would answer yes if asked
+    host = _LimitHost(bus=bus)
+    on_limit = OnLimitConfig(mode="unattended")
+
+    await _exhaust_loop(host, n_exhaust=1, max_iterations=1, on_limit=on_limit)
+
+    # Bus NOT asked
+    assert not bus.asks
+    # Error was emitted
+    error_msgs = [m for m in host.outbox if m["kind"] == "error"]
+    (err,) = error_msgs
+    assert "router_max_iterations" in err["text"] or "on_limit" in err["text"]

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -220,7 +220,8 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
     peer_session = ChatSession(agent_name="peer_agent")
     registry.register("peer_agent", peer_session)
 
-    session = _make_session(tmp_path, registry=registry)
+    session = _make_session(tmp_path, registry=registry,
+                            on_limit=OnLimitConfig(mode="unattended"))
     session.is_attached = True
 
     # Round 1: router asks to delegate; round 2 is never reached in this test
@@ -279,7 +280,8 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     registry = _FakeRegistry()
     registry.register("peer_agent", peer_session)
 
-    session = _make_session(tmp_path, registry=registry)
+    session = _make_session(tmp_path, registry=registry,
+                            on_limit=OnLimitConfig(mode="unattended"))
     session.is_attached = True
 
     # Phase 1: router delegates to peer_agent.


### PR DESCRIPTION
**[e2e-coder]** — safety framework wave impl PR (Fix A + Fix B, chat + planner + A2A axes).

## Summary

**Fix A** — wire \`max_iterations\` exhaustion through \`handle_limit_exceeded\` (FP-0005 bypass cluster):

- \`RouterLoop.run_loop()\`: outer \`while True:\` wraps the inner \`for _iteration in range(self.max_iterations):\` loop. \`_loop_cancelled\` sentinel distinguishes cancel-break from exhaustion. After exhaustion: if \`_on_limit is not None\`, calls \`handle_limit_exceeded(bus=make_intervention_bus(), ...)\`. On approval: extends \`max_iterations\` and \`continue\`s. On refusal/no-bus/unattended: \`break\` → decision-enabling error.
- \`RouterLoopHost\` protocol: \`make_intervention_bus() -> Any | None\` (P7-clean; getattr-guarded so old hosts degrade to no-ask).
- \`RouterHostAdapter\`: implements \`make_intervention_bus()\` returning the session's bus factory result or None.
- \`RouterLoopDriver\`: threads \`on_limit=getattr(self._safety, "on_limit", None)\` to \`RouterLoop\`.
- \`planner.py\`: threads \`on_limit=on_limit\` to each step's \`RouterLoop\` so \`step_max_iterations\` exhaustion routes through \`handle_limit_exceeded\`.
- \`web/deps.py\` \`_session_factory\`: A2A peer sessions force \`on_limit=OnLimitConfig(mode="unattended")\` — A2A cannot surface RouterLoop checkpoint asks via \`A2AInterventionBus\` (no input-required mirror path). Graceful degrade: decision-enabling error instead of infinite hang. Follow-up: #1493.

Tests that use \`ChatSession\` + a delegate stub that never returns text must declare \`OnLimitConfig(mode="unattended")\` on their session — the designed CI escape hatch. Two tests in \`test_session_invariants.py\` updated.

**Fix B** — decision-enabling error messages:
- Before: \`"Router loop exceeded max iterations (N)."\`
- After: \`"Router loop exceeded max iterations (N). Configure safety.on_limit.mode=interactive or auto_extend to extend, or increase router_max_iterations."\`

## Owner-veto item (朝の判断用)

\`ask_timeout_seconds=0.0\` (= wait forever) is the current default in \`OnLimitConfig\`. The combination \`mode=interactive + ask_timeout_seconds=0.0\` hangs silently in "bus wired but no human" contexts (放置 web session / scripted A2A). **Proposal**: change default to a finite value (e.g. \`600s\` → timeout → partial-state abort). Not changed in this PR — owner decision required.

## Runtime knob for max_iterations

**No YAML knob exists for \`router_max_iterations\`** — hardcoded at 5 in \`web/deps.py\` and \`ChatSession\` default. The naming unification PR will add \`safety.loop.max_router_iterations\` as a proper config key. sandbox_2 gate uses \`step_max_iterations\` (YAML: \`safety.loop.step_max_iterations\`, already configurable) for the live test.

## Tier-2 tests (\`tests/test_safety_max_iterations_fp0005.py\`, 5 tests)

| # | Scenario | Invariant |
|---|----------|-----------|
| 1 | \`bus=YES\` | extension applied, loop continues, agent reply emitted |
| 2 | \`bus=NO\` | decision-enabling error |
| 3 | \`bus=None\` (interactive mode, no bus) | \`no_bus\` path → decision-enabling error |
| 4 | \`on_limit=None\` | legacy flat-abort → decision-enabling error |
| 5 | \`unattended\` | no ask dispatched, immediate error |

No mocks. \`_FakeRequestBus\` is a real \`RequestBus\` subclass. Loop exhaustion: unknown tool \`_test_loop_exhauster\` → \`dispatch_tool\` returns \`unknown_tool\` error → loop iterates until limit.

## chain_seconds watchdog (noting, scope-out)

sandbox_2 pre-stage observed short A2A tasks complete before watchdog fires. No bug; flagged for async-path visibility audit in a separate follow-up.

## Gate

- **Unit**: 5 Tier-2 tests ✅, ruff ✅, full suite 2 failed (pre-existing) / 6994 passed in 317.33s ✅
- **sandbox_2 live**: \`step_max_iterations\` forced low → \`input-required\` surface → approve → continuation (pending PR landing)

## Full suite verbatim

```
FAILED tests/test_eval_benchmark_tier1_swebench.py::test_swebench_missing_honest_skip
FAILED tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content
2 failed, 6994 passed, 10 skipped, 3 xfailed, 5 warnings in 317.33s (0:05:17)
```

Both failures confirmed pre-existing on \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)