### PR TITLE
feat(safety): naming unification — safety.loop.max_router_iterations YAML knob

### DIFF
--- a/docs/concepts/runtime/safety.md
+++ b/docs/concepts/runtime/safety.md
@@ -38,8 +38,8 @@ the current configured value, and which config key to change.
 | Agent hops | `safety.loop.max_agent_hops` | 3 | ✅ | yes |
 | Phase wall-clock | `safety.timeout.phase_seconds` | 0 (off) | ✅ | yes |
 | Chain wait | `safety.timeout.chain_seconds` | 60 | ✅ | yes |
-| Router iterations | `router_max_iterations` _(ChatSession param)_ | 5 / 80 | ❌ → ✅ _(pending)_ | partial |
-| Plan step iterations | `plan.step_max_iterations` | 5 | ❌ → ✅ _(pending)_ | partial |
+| Router iterations | `safety.loop.max_router_iterations` | 5 | ✅ | partial |
+| Plan step iterations | `plan.step_max_iterations` | 5 | ✅ | partial |
 | LLM call timeout | `safety.timeout.llm_call_seconds` | 60 | ❌ auto-retry/abort | — |
 | Media cap | `multimodal.max_bytes` | 5 MB | ❌ auto-degrade | — |
 | Summary body cap | `chat.compaction.body_token_cap` | 1500 | ❌ auto-truncate | — |
@@ -89,14 +89,12 @@ safety:
     max_phase_visits: 25
     max_router_calls_per_turn: 3
     max_agent_hops: 3
+    max_router_iterations: 5   # max LLM tool-call iterations per user turn (CLI --max-iterations overrides)
     plan_invalid_retries: 1
   timeout:
     phase_seconds: 0.0         # 0 = disabled
     chain_seconds: 60.0
     llm_call_seconds: 60.0
-
-# Router iterations — ChatSession constructor parameter (default 5 interactive / 80 run-once).
-# Not a safety.loop key; configured per deployment context.
 
 plan:
   step_max_iterations: 5       # max RouterLoop iterations per plan step

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -191,6 +191,7 @@ safety:
     max_phase_visits: 25         # ランごとの Phase あたりの上限; 0 = 無制限 (--max-phase-visits)
     max_act_turns_per_phase: 10  # Phase 訪問内の LLM ↔ op ラリー数; 0 = 無制限
     max_router_calls_per_turn: 3 # ユーザーターンごとのチャットルーター呼び出し数
+    max_router_iterations: 5    # ユーザーターンごとの LLM ツール呼び出しイテレーション数 (CLI --max-iterations で上書き可)
     max_agent_hops: 3            # 最大委譲深度
   timeout:
     llm_call_seconds: 60         # 呼び出しごとの HTTP タイムアウト (--llm-timeout)
@@ -210,6 +211,7 @@ safety:
 | `safety.loop.max_phase_visits` | int | `25` | `--max-phase-visits` | ランごとの任意の単一 Phase への再訪問上限。`0` = 無制限。 |
 | `safety.loop.max_act_turns_per_phase` | int | `10` | — | 1 回の Phase 訪問内で許可される LLM ↔ op ラリー数。`0` = 無制限。 |
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | ユーザーターンごとのチャットルーター呼び出し数。`0` = 無制限。 |
+| `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | ユーザーターンごとの LLM ツール呼び出しイテレーション上限。CLI `--max-iterations` が指定された場合はそちらが優先。`reyn run-once` のデフォルトは 80。 |
 | `safety.loop.max_agent_hops` | int | `3` | — | 最大委譲深度（ユーザー → A → B → C = 3 ホップ）。 |
 | `safety.loop.plan_invalid_retries` | int | `1` | — | ルーターが malformed な `plan()` ツール呼び出しを emit した時、エラー + 「内側クォートをエスケープ」 ヒントを user-role directive として追加して LLM に再 emit させる。`0` で無効化。`1`（デフォルト）でチャットターンごとに 1 回の directive 駆動訂正を許可。 |
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -199,6 +199,7 @@ safety:
     max_phase_visits: 25       # cap per phase per run; 0 = unlimited (--max-phase-visits)
     max_act_turns_per_phase: 10  # LLM ↔ op volleys per phase visit; 0 = unlimited
     max_router_calls_per_turn: 3 # chat-router calls per user turn
+    max_router_iterations: 5   # LLM tool-call iterations per user turn (CLI --max-iterations overrides)
     max_agent_hops: 3          # maximum delegation depth
   timeout:
     llm_call_seconds: 60       # per-call HTTP timeout (--llm-timeout)
@@ -218,6 +219,7 @@ safety:
 | `safety.loop.max_phase_visits` | int | `25` | `--max-phase-visits` | Cap on revisits to any single phase per run. `0` = unlimited. |
 | `safety.loop.max_act_turns_per_phase` | int | `10` | — | LLM ↔ op volleys allowed inside one phase visit. `0` = unlimited. |
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | Chat-router invocations per user turn. `0` = unlimited. |
+| `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | Maximum LLM tool-call iterations per user turn. CLI `--max-iterations` overrides when provided; `reyn run-once` uses CLI default of 80. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
 | `safety.loop.plan_invalid_retries` | int | `1` | — | When the router emits a malformed `plan()` tool call, append the error + an "escape inner quotes" hint and let the LLM re-emit. `0` disables; `1` (default) allows one directive-driven correction per chat turn. |
 | `safety.loop.skill_calls_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) spawn cap. `hard_limit` + `warn_ratio` sub-fields. Hybrid: loop-detection semantics, budget-style user approval on hit. |

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -439,6 +439,7 @@
 #     max_act_turns_per_phase: 10
 #     max_phase_visits: 25
 #     max_router_calls_per_turn: 3
+#     max_router_iterations: 5  # max LLM tool-call iterations per user turn; CLI --max-iterations overrides
 #     max_agent_hops: 3
 #     # plan() tool call parse-error self-correction (B51 NF-W6-3). 0 = disable.
 #     plan_invalid_retries: 1

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -200,7 +200,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # container-rooting. Fill = 1-line follow-up when a consumer needs it.
                 eager_embedding_build=False,
                 exclude_tools=None,
-                router_max_iterations=5,
+                router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: interactive UI = byte-identical
                 environment_backend=None,
                 sandbox_backend=None,

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2594,7 +2594,7 @@ class RouterLoop:
             text=(
                 f"Router loop exceeded max iterations ({self.max_iterations}). "
                 f"Configure safety.on_limit.mode=interactive or auto_extend to "
-                f"extend, or increase router_max_iterations."
+                f"extend, or increase safety.loop.max_router_iterations."
             ),
             meta={"chain_id": self.chain_id},
         )

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -404,10 +404,13 @@ def run(args: argparse.Namespace) -> None:
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
-            # #187: per-message tool-call budget. Interactive chat keeps 5; the
-            # one-shot autonomous path (`reyn run-once`) raises it (explore→edit→
-            # verify needs many rounds). --max-iterations unset → 5 (unchanged).
-            router_max_iterations=int(getattr(args, "max_iterations", None) or 5),
+            # #187: per-message tool-call budget. Interactive chat uses
+            # safety.loop.max_router_iterations (default 5); the one-shot
+            # autonomous path raises it via --max-iterations (CLI wins).
+            router_max_iterations=int(
+                getattr(args, "max_iterations", None)
+                or session_cfg.config.safety.loop.max_router_iterations
+            ),
             # #1439 Fix #1: run-once pipes stdin (no TTY) → the SP proceeds with an
             # assumption instead of asking a clarifying question nobody can answer
             # (13398). Interactive `reyn chat` (TTY) → False = byte-identical. Same

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -478,7 +478,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,
-                router_max_iterations=5,
+                router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: dogfood driver = byte-identical (run-once-only fix)
                 workspace_base_dir=ws_base_dir,
                 workspace_state_dir=ws_state_dir,

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -428,7 +428,7 @@ def run_serve(args: argparse.Namespace) -> None:
             # (behavior-preserving). Fill = 1-line follow-up when a consumer needs it.
             agent_id=None,
             exclude_tools=None,
-            router_max_iterations=5,
+            router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
             non_interactive=False,  # #1439 Fix #1: stdio-MCP byte-identical (run-once-only fix)
             environment_backend=None,  # gap: MCP-serve lacks env-backend / container-rooting
             sandbox_backend=None,

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -215,12 +215,18 @@ class LoopConfig:
         skill_tokens_per_chain:
             Per-(chain, skill) token cap with warn semantics.
             ``hard_limit=None`` = unlimited (default).
+        max_router_iterations:
+            Maximum LLM tool-call iterations per chat-router invocation
+            (= per user turn). ``0`` = unlimited. CLI ``--max-iterations``
+            overrides this when provided. Run-once / autonomous contexts
+            typically set this higher (e.g. 80) via CLI.
     """
 
     max_act_turns_per_phase: int = 10
     max_phase_visits: int = 25
     max_router_calls_per_turn: int = 3
     max_agent_hops: int = 3
+    max_router_iterations: int = 5
     skill_calls_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
     skill_tokens_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
 
@@ -2502,6 +2508,9 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
         max_agent_hops=int(loop_raw.get(
             "max_agent_hops", loop_defaults.max_agent_hops,
+        )),
+        max_router_iterations=int(loop_raw.get(
+            "max_router_iterations", loop_defaults.max_router_iterations,
         )),
         skill_calls_per_chain=_build_cost_limit(
             loop_raw.get("skill_calls_per_chain")

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -359,7 +359,7 @@ def _get_registry():
                 allowed_mcp=None,
                 agent_id=None,
                 exclude_tools=_scoped.exclude_tools,
-                router_max_iterations=5,
+                router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: A2A byte-identical (run-once-only fix). A2A-non-interactive = documented follow-up (cf factory module doc)
                 environment_backend=_scoped.environment_backend,
                 sandbox_backend=_scoped.environment_backend,

--- a/tests/test_run_once_187.py
+++ b/tests/test_run_once_187.py
@@ -58,13 +58,14 @@ def test_run_once_parser_defaults_and_scoped_flags() -> None:
 
 
 def test_run_once_default_iterations_exceeds_interactive_chat() -> None:
-    """Tier 2: run-once defaults max_iterations far above interactive chat's 5
-    (autonomous SWE needs many explore→edit→verify rounds). chat.run maps an
-    unset value to 5 (interactive unchanged)."""
+    """Tier 2: run-once defaults max_iterations far above interactive chat's
+    safety.loop.max_router_iterations (default 5). chat.run falls back to the
+    config key (not a hardcoded 5) so the interactive default is operator-tunable
+    while run-once always overrides via --max-iterations."""
     a = _run_once_parser().parse_args(["run-once"])
     assert a.max_iterations == 80
-    # interactive chat has no such flag → the factory uses 5 (see chat.py).
-    assert "or 5)" in _CHAT_PY.read_text(encoding="utf-8")
+    # interactive chat falls back to safety.loop.max_router_iterations (config key)
+    assert "safety.loop.max_router_iterations" in _CHAT_PY.read_text(encoding="utf-8")
 
 
 def test_run_once_delegates_to_chat_run() -> None:

--- a/tests/test_safety_max_iterations_fp0005.py
+++ b/tests/test_safety_max_iterations_fp0005.py
@@ -9,7 +9,7 @@ Invariants pinned:
 3. When the bus answers NO (user refused), the loop stops with a
    decision-enabling error message (mentions config key to change).
 4. When on_limit=None (legacy path), flat-abort error is still decision-enabling
-   (mentions router_max_iterations config key).
+   (mentions safety.loop.max_router_iterations config key).
 5. When bus=None (interactive mode, no bus wired), handle_limit_exceeded
    returns no_bus → decision-enabling error (not silent abort).
 6. When mode=unattended, no ask dispatched, immediate abort with error.
@@ -196,14 +196,14 @@ async def test_max_iterations_no_bus_decision_enabling_error() -> None:
 @pytest.mark.asyncio
 async def test_max_iterations_no_on_limit_legacy_decision_enabling() -> None:
     """Tier 2: FP-0005 — on_limit=None legacy path: error message is
-    decision-enabling (mentions router_max_iterations config key)."""
+    decision-enabling (mentions safety.loop.max_router_iterations config key)."""
     host = _LimitHost(bus=None)
 
     await _exhaust_loop(host, n_exhaust=1, max_iterations=1, on_limit=None)
 
     error_msgs = [m for m in host.outbox if m["kind"] == "error"]
     (err,) = error_msgs
-    assert "router_max_iterations" in err["text"]
+    assert "max_router_iterations" in err["text"]
 
 
 # ── 5. Unattended mode → immediate abort, no ask ─────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — safety wave final item: naming unification PR.

## Summary

Adds \`safety.loop.max_router_iterations\` as the canonical YAML config key for the router iteration limit, replacing hardcoded \`5\` across all deployment surfaces.

**What changed:**
- \`LoopConfig.max_router_iterations: int = 5\` — new field, YAML key \`safety.loop.max_router_iterations\`
- All callers (\`deps.py\`, \`app.py\`, \`mcp.py\`, \`dogfood.py\`, \`chat.py\`) now read from \`config.safety.loop.max_router_iterations\`
- CLI \`--max-iterations\` continues to override the config value when provided; \`reyn run-once\` CLI default of 80 is unchanged
- Decision-enabling error message updated: \`safety.loop.max_router_iterations\` (was \`router_max_iterations\`)
- Docs: \`safety.md\` limit inventory (router iterations row: ❌ pending → ✅), config reference YAML, \`reyn-yaml.md\` (en + ja), \`reyn.local.yaml.example\`

## Naming convention audit

All \`safety.loop\` fields follow the canonical \`max_*\` form for counts:

| Field | YAML key |
|---|---|
| \`max_act_turns_per_phase\` | \`safety.loop.max_act_turns_per_phase\` |
| \`max_phase_visits\` | \`safety.loop.max_phase_visits\` |
| \`max_router_calls_per_turn\` | \`safety.loop.max_router_calls_per_turn\` |
| \`max_agent_hops\` | \`safety.loop.max_agent_hops\` |
| **\`max_router_iterations\`** _(new)_ | **\`safety.loop.max_router_iterations\`** |

\`safety.timeout\` uses \`*_seconds\` for all time-based fields.

## Compat (owner veto format, per FP-0004 precedent)

**This PR (additive-only):** New YAML key \`safety.loop.max_router_iterations\`. No existing \`reyn.yaml\` has this key → zero breakage. No rename of existing keys.

**Deferred question — owner decision:** \`plan.step_max_iterations\` is a loop-detection limit that arguably belongs under \`safety.loop\`. Two options:
1. **Keep as-is** at \`plan.step_max_iterations\` — different scope (plan step vs chat router), different owner concern, existing YAMLs use it
2. **Add alias** at \`safety.loop.step_max_iterations\` with compat reader that accepts both — mirrors FP-0004's approach; deprecate old path in a later release

Proposal: option 2 in a follow-up PR. No change in this PR.

## Full suite verbatim

```
FAILED tests/test_eval_benchmark_tier1_swebench.py::test_swebench_missing_honest_skip
FAILED tests/test_web_fetch_preview_path_ref.py::test_legacy_no_media_store_path_returns_inline_content
2 failed, 6993 passed, 10 skipped, 3 xfailed, 5 warnings in 281.67s (0:04:41)
```

Both failures pre-existing on \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)