### PR TITLE
feat(safety): #1496 router_cap axis — limit-deny → force-close wrap-up (site C)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -3101,7 +3101,7 @@ class ChatSession:
         try:
             await self._run_router_loop(text, chain_id)
         except RouterCapExceeded as exc:
-            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
+            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id, user_text=text)
             return
         except Exception as exc:
             # #187 B1 instrument: a mid-work router-loop exception (e.g. the final
@@ -3386,12 +3386,68 @@ class ChatSession:
     # ── router ──────────────────────────────────────────────────────────────────
 
     async def _emit_router_cap_exhausted_user(
-        self, exc: "RouterCapExceeded", *, chain_id: str,
+        self, exc: "RouterCapExceeded", *, chain_id: str, user_text: str = "",
+        _llm_caller: "Any | None" = None,  # Tier 2 test seam: scripted-fake injection
     ) -> None:
         """User-facing fallback when the per-turn router cap is reached.
-        Emits a structured error + a polite agent reply on the outbox so
-        the chat loop recovers cleanly. The underlying event was already
-        emitted by `_check_and_increment_router_cap`."""
+
+        #1496 (site C): attempt a force-close wrap-up so the LLM can
+        summarize what was accomplished before the turn ends. Uses the
+        session's accumulated history (not run_loop's local messages —
+        router_cap fires BEFORE run_loop starts). Falls back to the
+        original canned error + hardcoded reply if wrap-up fails or
+        produces no text.
+        """
+        # #1496: emit audit event + attempt LLM wrap-up
+        self._chat_events.emit(
+            "limit_denied",
+            kind="router_cap",
+            count=exc.count,
+            cap=exc.cap,
+            chain_id=chain_id,
+        )
+        try:
+            from reyn.chat.router_loop import RouterLoop
+            history = self._history_buffer.build_history()
+            messages: list[dict] = [
+                *history,
+                *(
+                    [{"role": "user", "content": user_text}]
+                    if user_text else []
+                ),
+            ]
+            _temp_loop = RouterLoop(
+                host=self._router_host, chain_id=chain_id, llm_caller=_llm_caller,
+            )
+            _resolved = self._router_host.resolve_model(self.model)
+            _reason = (
+                f"router cap exhausted ({exc.count}/{exc.cap})"
+                f"{'; last reason: ' + exc.last_reason if exc.last_reason else ''}"
+            )
+            _wrapup = await _temp_loop._force_close_call_with_retry(
+                messages, resolved_model=_resolved, reason=_reason,
+            )
+            if _wrapup.content:
+                await self._put_outbox(OutboxMessage(
+                    kind="agent",
+                    text=_wrapup.content,
+                    meta={
+                        "chain_id": chain_id,
+                        "limit_stopped": True,
+                        "limit_kind": "router_cap",
+                    },
+                ))
+                self._append_history(ChatMessage(
+                    role="assistant",
+                    content=_wrapup.content,
+                    ts=_now_iso(),
+                    meta={"chain_id": chain_id, "source": "router_cap_exhausted_wrap_up"},
+                ))
+                return
+        except Exception:  # noqa: BLE001 — wrap-up failed; degrade to canned reply
+            pass
+
+        # Fallback: original canned error + hardcoded reply
         await self._put_outbox(OutboxMessage(
             kind="error",
             text=(
@@ -4420,7 +4476,7 @@ class ChatSession:
         try:
             await self._run_router_loop(injected_text, chain_id)
         except RouterCapExceeded as exc:
-            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
+            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id, user_text=injected_text)
             return
         except Exception as exc:
             await self._put_outbox(OutboxMessage(

--- a/tests/test_limit_deny_force_close_plan_phase_1496.py
+++ b/tests/test_limit_deny_force_close_plan_phase_1496.py
@@ -1,0 +1,179 @@
+"""Tier 2: #1496 plan/phase axes — limit-deny → force-close wrap-up.
+
+Plan axis (site I: step_max_iterations) and phase axis (sites A/F:
+max_act_turns / phase_seconds) share RouterLoop.run_loop() and inherit
+the limit-deny force-close path from the chat axis (#1497).
+
+These tests verify axis-specific behavior:
+- forced_close_result set on host (plan: step output collection;
+  phase: checkpoint persistence) when wrap-up produces text
+- forced_close_result NOT set when wrap-up produces no text (guard)
+
+_PlanStepHost.put_outbox captures text in _captured_text (not an
+outbox list). PhaseRouterLoopHost.put_outbox is a no-op.
+
+No mocks. _PlanStepHost and PhaseRouterLoopHost are real instances.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.chat.planner import Plan, PlanStep, _PlanStepHost
+from reyn.chat.router_loop import RouterLoop
+from reyn.config import OnLimitConfig
+from reyn.kernel.phase_router_host import PhaseRouterLoopHost
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import FakeEventLog, FakeRouterHost, _ScriptedLLM, text_result
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _tool_exhauster(n: int) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": f"tc_{n}", "type": "function",
+            "function": {"name": "_exhauster", "arguments": json.dumps({"n": n})},
+        }],
+        finish_reason="tool_calls",
+        usage=_USAGE,
+    )
+
+
+# ── Plan axis ─────────────────────────────────────────────────────────────────
+
+
+def _plan_host(parent: FakeRouterHost) -> _PlanStepHost:
+    step = PlanStep(id="s1", description="test step", tools=())
+    plan = Plan(goal="g", steps=(step,))
+    return _PlanStepHost(
+        plan=plan, step=step, prior_results={}, parent=parent,
+        turn_budget_engine=None,  # no cumulative force-close; limit-deny only
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_step_limit_deny_sets_forced_close_result() -> None:
+    """Tier 2: #1496 plan axis — limit-deny force-close sets forced_close_result
+    on _PlanStepHost so the planner can use the consolidation as step output."""
+    parent = FakeRouterHost()
+    host = _plan_host(parent)
+    on_limit = OnLimitConfig(mode="unattended")
+
+    # exhaust + wrap-up text on the force-close call
+    llm = _ScriptedLLM([_tool_exhauster(0), text_result("plan step done; files at /out")])
+    loop = RouterLoop(
+        host=host, chain_id="chain-plan", max_iterations=1,
+        llm_caller=llm, on_limit=on_limit,
+    )
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "execute step"}],
+        tools=[], _univ_enabled=False,
+    )
+
+    # forced_close_result set with wrap-up content
+    fc = host.forced_close_result
+    assert fc is not None, "forced_close_result must be set after limit-deny wrap-up"
+    assert getattr(fc, "content", None) == "plan step done; files at /out"
+
+    # _PlanStepHost captures agent text in captured_text (not outbox list)
+    assert host.captured_text == "plan step done; files at /out"
+
+    # limit_denied event on parent.events (plan step delegates to parent)
+    limit_ev = [e for e in parent.events.emitted if e.get("type") == "limit_denied"]
+    (ev,) = limit_ev
+    assert ev["kind"] == "max_iterations"
+
+
+@pytest.mark.asyncio
+async def test_plan_step_limit_deny_no_fc_result_when_wrap_up_empty() -> None:
+    """Tier 2: #1496 plan axis — forced_close_result NOT set when wrap-up
+    returns no text (empty-checkpoint guard prevents spurious re-entry)."""
+    parent = FakeRouterHost()
+    host = _plan_host(parent)
+    on_limit = OnLimitConfig(mode="unattended")
+
+    # exhaust only; scripted LLM returns tool call on wrap-up → content=None
+    llm = _ScriptedLLM([_tool_exhauster(0)])
+    loop = RouterLoop(
+        host=host, chain_id="chain-plan-empty", max_iterations=1,
+        llm_caller=llm, on_limit=on_limit,
+    )
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "execute step"}],
+        tools=[], _univ_enabled=False,
+    )
+
+    # forced_close_result NOT set — would trigger empty checkpoint re-entry
+    assert host.forced_close_result is None
+    assert host.captured_text == ""  # no agent text captured
+
+
+# ── Phase axis ────────────────────────────────────────────────────────────────
+
+
+def _phase_host() -> PhaseRouterLoopHost:
+    return PhaseRouterLoopHost(
+        control_ir_executor=None,
+        events=FakeEventLog(),
+        phase="act",
+        decl=None,
+        allowed_ops=None,
+        default_sandbox_policy=None,
+        agent_name="agent",
+        agent_role="assistant",
+        output_language="en",
+        resolve_model_fn=lambda n: n,
+        turn_budget_engine=None,  # no cumulative force-close; limit-deny only
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_limit_deny_sets_forced_close_result() -> None:
+    """Tier 2: #1496 phase axis — limit-deny force-close sets forced_close_result
+    on PhaseRouterLoopHost for checkpoint persistence."""
+    host = _phase_host()
+    on_limit = OnLimitConfig(mode="unattended")
+
+    llm = _ScriptedLLM([_tool_exhauster(0), text_result("phase done; artifact at /ws/out")])
+    loop = RouterLoop(
+        host=host, chain_id="chain-phase", max_iterations=1,
+        llm_caller=llm, on_limit=on_limit,
+    )
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "execute phase"}],
+        tools=[], _univ_enabled=False,
+    )
+
+    fc = host.forced_close_result
+    assert fc is not None
+    assert getattr(fc, "content", None) == "phase done; artifact at /ws/out"
+
+    # limit_denied event on host.events (phase host owns events directly)
+    limit_ev = [e for e in host.events.emitted if e.get("type") == "limit_denied"]
+    (ev,) = limit_ev
+    assert ev["kind"] == "max_iterations"
+    # PhaseRouterLoopHost.put_outbox is a no-op; don't check outbox
+
+
+@pytest.mark.asyncio
+async def test_phase_limit_deny_no_fc_result_when_wrap_up_empty() -> None:
+    """Tier 2: #1496 phase axis — forced_close_result NOT set when wrap-up is
+    empty (prevents empty-consolidation checkpoint and spurious phase re-entry)."""
+    host = _phase_host()
+    on_limit = OnLimitConfig(mode="unattended")
+
+    llm = _ScriptedLLM([_tool_exhauster(0)])
+    loop = RouterLoop(
+        host=host, chain_id="chain-phase-empty", max_iterations=1,
+        llm_caller=llm, on_limit=on_limit,
+    )
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "execute phase"}],
+        tools=[], _univ_enabled=False,
+    )
+
+    assert host.forced_close_result is None

--- a/tests/test_limit_deny_force_close_router_cap_1496.py
+++ b/tests/test_limit_deny_force_close_router_cap_1496.py
@@ -1,0 +1,156 @@
+"""Tier 2: #1496 router_cap axis — limit-deny → force-close wrap-up (site C).
+
+Site C fires in ``_emit_router_cap_exhausted_user`` BEFORE ``run_loop`` starts
+(router cap is checked per-turn entry). History comes from the session's
+``_history_buffer.build_history()``, not run_loop's local messages.
+
+A temporary ``RouterLoop`` is constructed with the session's ``_router_host``
+and ``chain_id``; ``_llm_caller`` is a Tier-2 test seam for injecting a
+scripted fake without mocking.
+
+Tests verify:
+- ``limit_denied`` event emitted with ``kind="router_cap"``
+- Force-close wrap-up text → OutboxMessage with ``limit_stopped=True``
+  and ``limit_kind="router_cap"``
+- No force-close text → fallback canned error + agent reply (no limit_stopped)
+
+No mocks. _ScriptedLLM is a real fake (not AsyncMock/MagicMock).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.budget.budget import BudgetTracker, CostConfig
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import _ScriptedLLM, text_result
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _make_session(tmp_path: Path, cap: int = 3) -> ChatSession:
+    safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=cap))
+    return ChatSession(
+        agent_name="test_cap_agent",
+        budget_tracker=BudgetTracker(CostConfig()),
+        safety=safety,
+    )
+
+
+def _exc(count: int = 3, cap: int = 3) -> RouterCapExceeded:
+    return RouterCapExceeded(count=count, cap=cap, last_reason="loop_reason")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _drain(session: ChatSession) -> list[OutboxMessage]:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+# ── 1. limit_denied event emitted (with wrap-up text) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_cap_limit_denied_event_emitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: #1496 site C — limit_denied event with kind=router_cap is
+    emitted when the per-turn router cap is exhausted."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    emitted: list[dict] = []
+    orig_emit = session._chat_events.emit
+
+    def capture(name, **kw):
+        emitted.append({"type": name, **kw})
+        return orig_emit(name, **kw)
+
+    session._chat_events.emit = capture  # type: ignore[assignment]
+
+    llm = _ScriptedLLM([text_result("wrap-up summary here")])
+    await session._emit_router_cap_exhausted_user(
+        _exc(3, 3), chain_id="chain-cap", _llm_caller=llm,
+    )
+
+    limit_evs = [e for e in emitted if e["type"] == "limit_denied"]
+    (ev,) = limit_evs
+    assert ev["kind"] == "router_cap"
+    assert ev["count"] == 3
+    assert ev["cap"] == 3
+
+
+# ── 2. wrap-up text → OutboxMessage with limit_stopped=True ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_cap_force_close_wrap_up_emits_limit_stopped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: #1496 site C — when force-close wrap-up produces text, an
+    agent OutboxMessage with limit_stopped=True and limit_kind=router_cap
+    is emitted (no fallback canned error)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    llm = _ScriptedLLM([text_result("cap reached; completed steps 1-3")])
+    await session._emit_router_cap_exhausted_user(
+        _exc(3, 3), chain_id="chain-cap-wrapup", _llm_caller=llm,
+    )
+
+    msgs = _drain(session)
+    agent_msgs = [m for m in msgs if m.kind == "agent"]
+    (agent_msg,) = agent_msgs
+    assert agent_msg.text == "cap reached; completed steps 1-3"
+    meta = agent_msg.meta or {}
+    assert meta.get("limit_stopped") is True
+    assert meta.get("limit_kind") == "router_cap"
+
+    # No error message — canned fallback must NOT fire
+    assert not any(m.kind == "error" for m in msgs)
+
+
+# ── 3. no wrap-up text → fallback canned reply ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_cap_fallback_when_wrap_up_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: #1496 site C — when wrap-up produces no text (empty content),
+    the original canned error + agent fallback reply is emitted instead."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    llm = _ScriptedLLM([LLMToolCallResult(
+        content=None, tool_calls=[], finish_reason="stop", usage=_USAGE,
+    )])
+    await session._emit_router_cap_exhausted_user(
+        _exc(3, 3), chain_id="chain-cap-empty", _llm_caller=llm,
+    )
+
+    msgs = _drain(session)
+    kinds = [m.kind for m in msgs]
+    # canned fallback fires → error + agent
+    assert "error" in kinds, f"expected error msg; got {kinds}"
+    assert "agent" in kinds, f"expected agent fallback; got {kinds}"
+
+    # none of the agent messages should carry limit_stopped
+    agent_msgs = [m for m in msgs if m.kind == "agent"]
+    for m in agent_msgs:
+        assert not (m.meta or {}).get("limit_stopped"), (
+            f"limit_stopped must not be set on canned fallback; got {m.meta}"
+        )


### PR DESCRIPTION
**[e2e-coder]** — #1495 FP-0005 wave: router_cap axis (site C), final axis.

## Summary

- Rewrites `_emit_router_cap_exhausted_user` to attempt a force-close wrap-up before falling back to the canned error reply
- Site C distinction: fires BEFORE `run_loop` starts (at `_check_cap`), so history comes from `self._history_buffer.build_history()` (session-accumulated), not run_loop's local messages
- Adds `_llm_caller` Tier-2 test seam (consistent with `RouterLoop.__init__`)
- Adds 3 Tier-2 tests in `tests/test_limit_deny_force_close_router_cap_1496.py`

**Implementation path (`_emit_router_cap_exhausted_user`):**
1. Emit `limit_denied` event (`kind="router_cap"`, count, cap) — audit trail
2. Build `messages` from `_history_buffer.build_history()` + optional `user_text`
3. Create temp `RouterLoop(host=self._router_host, chain_id=chain_id)`
4. Call `_force_close_call_with_retry(messages, reason="router cap exhausted (N/cap)...")`
5. If `_wrapup.content`: emit agent `OutboxMessage(meta={limit_stopped:True, limit_kind:"router_cap"})` + append history, return
6. Except / empty: fallback to canned error + `_ROUTER_RETRY_EXHAUSTED_MSG` reply

**Uniform across all 5 sites (H/I/A/F/C)**: all limit-deny paths now attempt LLM wrap-up before canned fallback, completing the #1495 wave.

## Test plan

- [x] `python -m pytest tests/test_limit_deny_force_close_router_cap_1496.py -q` → 3 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_limit_deny_force_close_router_cap_1496.py` → 0 errors
- [x] `ruff check src/reyn/chat/session.py tests/test_limit_deny_force_close_router_cap_1496.py` → all checks passed
- [x] Full `python -m pytest -q --timeout=30` → 7002 passed, 4 failed (all pre-existing: 2 known + 2 devcontainer infra)
- [ ] sandbox_2 live: limit-hit → wrap-up text visible (pattern proven in #1497; light verify only)

Closes #1496
Refs #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)