### PR TITLE
feat(1481): DockerEnvironmentBackend.get_environment_info — in-container env probe

### DIFF
--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -545,8 +545,9 @@ class RouterHostAdapter:
             (degrade, don't guess — returning host darwin/zsh for a linux
             container would repeat the #1477 host-value-leak pattern)
 
-        Container probe (uname -sr + $SHELL + .git check) is a follow-up
-        tracked in #1481; this PR establishes the correct omission semantics.
+        Container probe (#1481): ``DockerEnvironmentBackend.get_environment_info``
+        collects platform/os_version/shell/is_git_repo from INSIDE the container.
+        The omission semantics above still hold when a probe sub-field fails.
         """
         import datetime
         import os
@@ -575,8 +576,13 @@ class RouterHostAdapter:
                 result["os_version"] = backend_info.get("os_version", "")
                 if backend_info.get("shell"):
                     result["shell"] = backend_info["shell"]
-                cwd_path = Path(self.get_cwd())
-                result["is_git_repo"] = (cwd_path / ".git").exists()
+                # #1481: is_git_repo from the IN-CONTAINER probe — NOT a host-path
+                # check. ``get_cwd()`` returns the container ``repo_dir``, so
+                # ``(repo_dir / ".git").exists()`` on the host tests the wrong (or
+                # absent) path — a #1477-class host/container frame mismatch. Use
+                # the backend's value; omit when the probe didn't supply it.
+                if "is_git_repo" in backend_info:
+                    result["is_git_repo"] = bool(backend_info["is_git_repo"])
             # else: non-host backend without probe → omit platform/shell/git
         else:
             # Host backend or no backend: derive from local environment.

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -205,6 +205,27 @@ _GREP = (
     "print(json.dumps(out))\n"
 )
 
+# #1481: probe the CONTAINER environment for the SP Environment section. Each
+# field is independently guarded so a single failure omits only that key (the
+# degrade contract) — OS family / kernel / shell / .git all come from inside the
+# container, never the host.
+_ENV_INFO = (
+    "import sys,os,json,platform\n"
+    "repo=sys.argv[1] if len(sys.argv)>1 else os.getcwd()\n"
+    "out={}\n"
+    "try: out['platform']=platform.system().lower()\n"
+    "except Exception: pass\n"
+    "try: out['os_version']=platform.release()\n"
+    "except Exception: pass\n"
+    "sh=os.environ.get('SHELL','')\n"
+    "if sh: out['shell']=sh\n"
+    # os.path.exists (not isdir) for host parity: a git worktree's .git is a
+    # FILE (a gitdir pointer), which isdir would mis-judge as not-a-repo.
+    "try: out['is_git_repo']=os.path.exists(os.path.join(repo,'.git'))\n"
+    "except Exception: pass\n"
+    "print(json.dumps(out))\n"
+)
+
 
 class DockerEnvironmentBackend:
     """Repo FS + exec inside a Docker container (dual-Protocol, bridge-free)."""
@@ -316,6 +337,31 @@ class DockerEnvironmentBackend:
             count=int(data.get("count", 0)),
             matches=[{**m, "path": Path(m["path"])} for m in data.get("matches", [])],
         )
+
+    # ── Environment info (#1481 — in-container probe for SP Environment) ───────
+
+    def get_environment_info(self) -> dict:
+        """Probe the CONTAINER environment for the SP Environment section (#1481).
+
+        Runs a single ``python3 -c`` in-container (via the sync FS runner) to
+        collect ``platform`` / ``os_version`` / ``shell`` / ``is_git_repo`` from
+        the container OS — NOT the host. The host adapter's non-host branch
+        (router_host_adapter.get_environment_info) consumes these.
+
+        Degrade contract (#1477 host-value-leak prevention): a probe that fails
+        is OMITTED from the result — never back-filled with a host value (e.g.
+        showing host ``darwin`` / ``zsh`` for a Linux container). A full exec
+        failure (no container / docker error) returns ``{}`` so the adapter
+        omits every host-derived field rather than guessing.
+        """
+        res = self._py(_ENV_INFO, self.repo_dir)
+        if not self._ok(res):
+            return {}
+        try:
+            info = json.loads(res.stdout.decode("utf-8", "replace"))
+        except (ValueError, UnicodeDecodeError):
+            return {}
+        return info if isinstance(info, dict) else {}
 
     # ── SandboxBackend (exec, async — plain container exec, NO bridge) ─────────
 

--- a/tests/test_container_env_info_1481.py
+++ b/tests/test_container_env_info_1481.py
@@ -1,0 +1,89 @@
+"""Tier 2: #1481 — DockerEnvironmentBackend.get_environment_info() in-container probe.
+
+The probe runs a single ``python3 -c`` INSIDE the container (via the sync
+``fs_runner``) and returns platform/os_version/shell/is_git_repo from the
+CONTAINER OS — feeding the host adapter's non-host branch. Degrade contract
+(#1477 host-value-leak prevention): a sub-field the probe doesn't supply is
+OMITTED; a full exec failure (or malformed output) returns ``{}`` so the adapter
+omits every host-derived field rather than guessing host values.
+
+No mocks — a real-construct fake ``fs_runner`` (callable returning SandboxResult).
+The fs_runner injection is the documented seam for testing docker-exec paths
+without a live daemon.
+"""
+from __future__ import annotations
+
+import json
+
+# isort: off
+# Intentional order (NOT alphabetical): pre-load the leaf the host_backend↔
+# workspace pair needs, so importing container_backend (which transitively
+# touches host_backend) doesn't hit a partial-init circular import when this
+# module is collected first. The existing container-backend suite relies on
+# collection order for the same reason.
+from reyn.workspace.text_codec import decode_text_or_none  # noqa: F401
+from reyn.environment.container_backend import DockerEnvironmentBackend, _ENV_INFO
+from reyn.sandbox.backend import SandboxResult
+# isort: on
+
+
+def _backend(fs_runner) -> DockerEnvironmentBackend:
+    return DockerEnvironmentBackend(
+        container="c", repo_dir="/testbed", fs_runner=fs_runner,
+    )
+
+
+def test_env_info_happy_path_returns_all_fields() -> None:
+    """Tier 2: a successful in-container probe surfaces all four fields verbatim."""
+    payload = {
+        "platform": "linux", "os_version": "5.15.0-generic",
+        "shell": "/bin/bash", "is_git_repo": True,
+    }
+
+    def runner(argv, stdin=None):
+        return SandboxResult(returncode=0, stdout=json.dumps(payload).encode(), stderr=b"")
+
+    assert _backend(runner).get_environment_info() == payload
+
+
+def test_env_info_exec_failure_returns_empty_dict() -> None:
+    """Tier 2: a docker-exec failure → {} → adapter omits all host-derived fields."""
+    def runner(argv, stdin=None):
+        return SandboxResult(returncode=1, stdout=b"", stderr=b"docker exec failed")
+
+    assert _backend(runner).get_environment_info() == {}
+
+
+def test_env_info_partial_probe_omits_missing_keys() -> None:
+    """Tier 2: a sub-field the probe omits (e.g. no $SHELL) is absent — never host-filled."""
+    payload = {"platform": "linux", "os_version": "5.15.0", "is_git_repo": False}  # no shell
+
+    def runner(argv, stdin=None):
+        return SandboxResult(returncode=0, stdout=json.dumps(payload).encode(), stderr=b"")
+
+    info = _backend(runner).get_environment_info()
+    assert "shell" not in info
+    assert info["platform"] == "linux"
+    assert info["is_git_repo"] is False
+
+
+def test_env_info_malformed_output_degrades_to_empty() -> None:
+    """Tier 2: non-JSON probe output → {} (defensive degrade, no crash)."""
+    def runner(argv, stdin=None):
+        return SandboxResult(returncode=0, stdout=b"not json at all", stderr=b"")
+
+    assert _backend(runner).get_environment_info() == {}
+
+
+def test_env_info_probe_passes_repo_dir_and_script_as_argv() -> None:
+    """Tier 2: the probe passes the script + repo_dir as argv (not interpolated)
+    — the in-container .git check targets the CONTAINER repo path, inject-safe."""
+    seen: dict = {}
+
+    def runner(argv, stdin=None):
+        seen["argv"] = argv
+        return SandboxResult(returncode=0, stdout=b"{}", stderr=b"")
+
+    _backend(runner).get_environment_info()
+    assert "/testbed" in seen["argv"]          # repo_dir passed as argv
+    assert _ENV_INFO in seen["argv"]           # script passed verbatim, not spliced

--- a/tests/test_sp_environment_sysinfo_1479.py
+++ b/tests/test_sp_environment_sysinfo_1479.py
@@ -28,18 +28,27 @@ from tests.test_router_host_adapter_invariants import _make_adapter
 class _FakeContainerBackendWithInfo:
     """ContainerBackend with get_environment_info() — the future-ready path."""
 
-    def __init__(self, repo_dir: str, platform: str, os_version: str, shell: str) -> None:
+    def __init__(
+        self, repo_dir: str, platform: str, os_version: str, shell: str,
+        is_git_repo: bool | None = None,
+    ) -> None:
         self.repo_dir = repo_dir
         self._platform = platform
         self._os_version = os_version
         self._shell = shell
+        # #1481: a real container backend probes .git IN-container. None =
+        # the probe omitted it (degrade) → adapter omits is_git_repo.
+        self._is_git_repo = is_git_repo
 
     def get_environment_info(self) -> dict:
-        return {
+        info = {
             "platform": self._platform,
             "os_version": self._os_version,
             "shell": self._shell,
         }
+        if self._is_git_repo is not None:
+            info["is_git_repo"] = self._is_git_repo
+        return info
 
 
 class _FakeHostBackend:
@@ -125,15 +134,15 @@ def test_env_info_no_backend_derives_from_platform_module(tmp_path: Path) -> Non
 
 
 def test_env_info_git_repo_detection_true(tmp_path: Path) -> None:
-    """Tier 2: #1479 — is_git_repo=True when .git exists at the agent-visible cwd.
+    """Tier 2: #1481 — is_git_repo reflects the backend's IN-CONTAINER probe.
 
-    Uses a container backend with repo_dir=tmp_path so get_cwd() returns
-    tmp_path, then creates tmp_path/.git to make the git check return True.
+    The container backend probes .git inside the container (repo_dir lives in
+    the container, not on the host), so is_git_repo comes from the backend's
+    get_environment_info — NOT a host-path check on the adapter side.
     """
-    (tmp_path / ".git").mkdir()
-    # Container backend: repo_dir=str(tmp_path) → get_cwd() returns tmp_path
     backend = _FakeContainerBackendWithInfo(
-        repo_dir=str(tmp_path), platform="linux", os_version="5.15.0", shell="/bin/bash"
+        repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
+        shell="/bin/bash", is_git_repo=True,
     )
     adapter = _make_adapter(
         agent_workspace_dir=tmp_path / "agents" / "test",
@@ -144,14 +153,10 @@ def test_env_info_git_repo_detection_true(tmp_path: Path) -> None:
 
 
 def test_env_info_git_repo_detection_false(tmp_path: Path) -> None:
-    """Tier 2: #1479 — is_git_repo=False when .git does not exist at cwd.
-
-    Uses a container backend pointing at tmp_path/no_git (no .git there).
-    """
-    no_git_dir = tmp_path / "no_git"
-    no_git_dir.mkdir()
+    """Tier 2: #1481 — is_git_repo=False when the in-container probe says so."""
     backend = _FakeContainerBackendWithInfo(
-        repo_dir=str(no_git_dir), platform="linux", os_version="5.15.0", shell="/bin/bash"
+        repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
+        shell="/bin/bash", is_git_repo=False,
     )
     adapter = _make_adapter(
         agent_workspace_dir=tmp_path / "agents" / "test",
@@ -159,6 +164,21 @@ def test_env_info_git_repo_detection_false(tmp_path: Path) -> None:
     )
     info = adapter.get_environment_info()
     assert info.get("is_git_repo") is False
+
+
+def test_env_info_git_repo_omitted_when_probe_degrades(tmp_path: Path) -> None:
+    """Tier 2: #1481 — is_git_repo OMITTED when the container probe doesn't
+    supply it (degrade) — NOT back-filled from a host-path .git check."""
+    backend = _FakeContainerBackendWithInfo(
+        repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
+        shell="/bin/bash", is_git_repo=None,
+    )
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+    )
+    info = adapter.get_environment_info()
+    assert "is_git_repo" not in info
 
 
 # ── 2. SP rendering ───────────────────────────────────────────────────────────


### PR DESCRIPTION
**[dogfood-coder]** — #1481 container env-info probe (cost:SMALL follow-up to #1479).

## What
`DockerEnvironmentBackend.get_environment_info()` probes **platform / os_version / shell / is_git_repo** from INSIDE the container (single `python3 -c` via the sync `fs_runner`), feeding the host adapter's non-host branch (which now uses these instead of omitting).

## Degrade contract (#1477 host-value-leak prevention) held
- probe-failed sub-field → OMITTED (never host-filled); full exec failure / malformed JSON → `{}`.
- platform/os_version from the container OS (linux), not host darwin/zsh.

## ⚠ Adapter change — spec expected NONE (flagging for your review)
Auto-pickup holds for platform/os_version/shell. But **is_git_repo needed a 1-line adapter fix**: `get_cwd()` returns the container `repo_dir`, so the prior `(repo_dir/.git).exists()` host-path check tested the wrong/absent path for a real container (a #1477-class host/container frame mismatch — e.g. a SWE-bench image's `/testbed` isn't on the host). Now is_git_repo comes from the in-container probe; omitted on degrade. **Revert this 1-line if you prefer is_git_repo stay host-path-checked + the backend field unused.**

## Tests
- 5 Tier-2 backend-method (injected `fs_runner`, no docker): happy / exec-fail→`{}` / partial-omit / malformed→`{}` / argv-safety (script + repo_dir passed as argv, inject-safe).
- #1479 git tests updated to the in-container-probe source + an omit-on-degrade case.

## Test plan
- [x] new #1481 tests pass (standalone + in-suite, 5 passed)
- [x] #1479 tests pass (updated, 16 passed)
- [x] broader regression green (140 passed: router_system_prompt + sp_environment + adapter + container)
- [ ] CI full suite + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)