### PR TITLE
docs(runtime): Direction-B doc-followup — safety.md #1496 force-close + events.md catalog

### DIFF
--- a/docs/concepts/runtime/safety.md
+++ b/docs/concepts/runtime/safety.md
@@ -55,20 +55,41 @@ Rows marked ❌ have autonomous behaviour that does not require operator input.
 limit hit
   │
   ├─ mode=unattended  ──► allow=False, reason="unattended"
-  │                       caller → decision-enabling outbox error
   │
   ├─ mode=auto_extend ──► within budget  → allow=True,  reason="auto_extended"
   │                       budget exhausted → allow=False, reason="unattended"
   │
   └─ mode=interactive
         ├─ bus=None   ──► allow=False, reason="no_bus"
-        │                 caller → decision-enabling outbox error (not silent)
         └─ bus present ──► UserIntervention dispatched
               ├─ yes  ──► allow=True,  reason="user_approved"
               └─ no   ──► allow=False, reason="user_refused"
+
+every allow=False path ──► force-close wrap-up (#1496)
+      emit `limit_denied` event (kind = max_iterations | router_cap)
+      → one final tool-less LLM turn summarizing what was accomplished
+          ├─ wrap-up has text ──► outbox kind="agent",
+          │                        meta.limit_stopped=True, meta.limit_kind=<kind>
+          └─ wrap-up fails/empty ──► decision-enabling outbox error (fallback)
 ```
 
-**Decision-enabling error message contract** (all `allow=False` paths):
+**Force-close wrap-up on deny (#1496).** A denied limit no longer goes
+straight to a canned error. The OS first emits a `limit_denied` event
+(audit truth, P6) and gives the LLM one final **tool-less** turn to
+summarize what was accomplished before the turn ends. The stop cause is
+injected into that wrap-up's system prompt (the steady-state SP stays
+cause-neutral; the cause is not appended as a trailing user message
+because some providers reject a user turn immediately after a
+`tool_result`). When the wrap-up produces text it is delivered as an
+ordinary `kind="agent"` outbox message carrying a structured
+`meta.limit_stopped=True` + `meta.limit_kind` marker — the UI reads the
+marker to indicate a forced stop without a competing prose block. For
+phase/plan hosts the wrap-up is also handed back for checkpoint
+persistence (`record_force_close`); chat hosts no-op that hook.
+
+**Decision-enabling error message contract** — emitted only on the
+**fallback** path (the wrap-up call raised or produced no text). All
+`allow=False` paths still degrade to a message containing:
 1. What limit was hit and its current configured value
 2. The config key to increase, or the `safety.on_limit.mode` to set for
    interactive or auto-extend behaviour

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -89,6 +89,7 @@ Each Control IR op kind emits its own event:
 | `skill_resolve_completed` | `skill_resolve` op — `name`, `resolved: bool`, `source: "local"\|"project"\|"stdlib"\|null` |
 | `control_ir_skipped`, `control_ir_failed`, `control_ir_validation_error` | dispatch failures (`control_ir_skipped` reasons include `shell_not_allowed`, `handler_not_implemented`, `not_allowed_in_phase`) |
 | `permission_denied` | When an op is denied by the resolver |
+| `control_ir_offload_pruned` | Offloaded Control IR results were pruned from the in-memory frame after persistence. Payload: `count` (number pruned). |
 
 ## Credentials and OAuth
 
@@ -119,6 +120,7 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 | `user_message_received` | A new user turn enters the runtime. Carries `chain_id` (the uuid minted by `submit_user_text` and propagated through any agent-to-agent messages this turn produces) |
 | `user_intervention_received` | An `ask_user` op got its answer |
 | `chat_started`, `chat_stopped` | Chat session lifecycle |
+| `turn_cancelled` | A user turn was cancelled mid-router-loop (e.g. `/cancel` or a new submission supersedes the running turn). Payload: `chain_id`. |
 
 ## Skill spawning (chat)
 
@@ -126,6 +128,7 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 |------|------|
 | `skill_run_spawned` | A skill was launched from a router decision (`run_id`, `skill`) |
 | `skill_spawn_refused` | `_spawn_skill` rejected a skill not in the agent's `allowed_skills`. Payload: `reason="allowlist"`, `skill`, `agent` |
+| `skill_node_started` | A skill-graph node began executing (sub-skill node in a composite skill graph). Payload: `node` (node id), `skill_path`. |
 
 ## Agent-to-agent messaging
 
@@ -151,6 +154,40 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 | Kind | Payload fields | Emitted when |
 |------|---------------|--------------|
 | `skill_rolled_back` | `skill: str`, `from_version: int`, `to_version: int`, `reason: str` (default `"user rollback via CLI"`) | A `reyn skill rollback` invocation restores a prior version. Written to `.reyn/events/direct/cli/<YYYY-MM-DD>.jsonl`. See [Reference: CLI — `reyn skill rollback`](../cli/skill.md). |
+
+## Memory
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `memory_saved` | The `memory` tool persisted a memory file to a layer | `layer`, `slug`, `path` |
+| `memory_deleted` | The `memory` tool deleted a memory file | `layer`, `slug`, `path` |
+
+## Compaction and context budget
+
+These fire on chat turns as the context-budget advisor and compaction
+controller evaluate whether history needs summarising. Most carry a
+"checked but did not compact" outcome — they are high-frequency and
+mostly informational.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `compaction_check` | The compaction gate ran for a turn. `outcome` records the decision — e.g. `too_few_turns`, `below_min_batch`, `pre_frame_overflow`, `already_running`, `forced_sync`, `forced_sync_no_turns`. Some outcomes also carry `turns`, `head`, `tail`. | `outcome`, plus outcome-specific fields |
+| `compaction_failed` | A compaction attempt raised. | `error` |
+| `compact_op_unavailable` | The `compact` Control IR op was dispatched in a context where no compaction engine is wired. | `run_id`, `phase` |
+| `summary_resummarize_failed` | Re-summarising an existing summary (nested compaction) raised. | `error` |
+| `budget_reset` | The chat budget gateway reset its per-window accounting. | `before` (prior accumulated value) |
+
+## Safety limits
+
+See [Concepts: safety framework](../../concepts/runtime/safety.md) for the
+intervention flow and force-close wrap-up.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `limit_denied` | A safety limit was denied (no extension granted) and the OS is about to attempt the `#1496` force-close wrap-up. | `kind` (`max_iterations` \| `router_cap`), `chain_id`, plus `limit` (router iterations) or `count`/`cap` (router cap) |
+
+`loop_limit_exceeded` and `phase_budget_exceeded` (see [Lifecycle
+events](#lifecycle-events)) cover phase-visit and wall-clock limits.
 
 ## Replay
 


### PR DESCRIPTION
**[dogfood-coder]** — Direction-B (impl-ahead-of-doc) doc-fixes from the bidirectional doc-vs-impl audit. Doc-only; closes #1507 and #1508. These are the two gaps where I hold primary emit-site evidence (I gated the #1495 safety wave), so I'm fastest/most-accurate to write them; the broader mechanical config/CLI/op-kind sweep is with tui-coder.

## safety.md (#1507) — intervention-flow missed #1496 force-close
The diagram + prose still described `allow=False → decision-enabling outbox error`. #1496 inserted a **force-close wrap-up** on every deny path:
- emit `limit_denied` event (P6 audit truth)
- one final **tool-less** LLM turn summarizing what was accomplished (cause injected into the wrap-up SP, not a trailing user turn — providers reject a user turn after a `tool_result`)
- delivered as `kind="agent"` with `meta.limit_stopped=True` + `meta.limit_kind`
- the canned decision-enabling error is now the **fallback** (wrap-up raised/empty)

Primary evidence: `chat/router_loop.py:2605-2650` (max_iterations), `chat/session.py:3402-3450` (router_cap).

## events.md (#1508) — "every state change" catalog missing 11 events
Added with verified emit sites + payload fields:
| event | site |
|---|---|
| `memory_saved` / `memory_deleted` | `tools/memory.py:509,568` |
| `turn_cancelled` | `chat/router_loop.py:1806` |
| `compaction_check` / `compaction_failed` | `chat/services/context_budget_advisor.py:199`, `compaction_controller.py:238` |
| `compact_op_unavailable` | `op_runtime/compact.py:41` |
| `summary_resummarize_failed` | `services/compaction/engine.py:835` |
| `budget_reset` | `chat/services/budget_gateway.py:219` |
| `skill_node_started` | `skill/skill_node_runner.py:108` |
| `control_ir_offload_pruned` | `kernel/runtime.py:128` |
| `limit_denied` | `chat/session.py:3402` + `router_loop.py:2611` (the #1496 event) |

## Test plan
- [x] (skipped — doc-only, no code/test change) impl behavior unchanged
- [x] every documented event/field cross-checked against its live emit site (grep evidence above)
- [x] `meta.limit_stopped` / `meta.limit_kind` / wrap-up `kind="agent"` verified against the #1496 deny blocks
- [ ] Visual: mkdocs renders both pages (markdown tables + anchors) — reviewer spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)