### PR TITLE
doc(#1511 #1513): stdlib Direction-A phantom fixes + stale content

### DIFF
--- a/docs/reference/cli/common-flags.ja.md
+++ b/docs/reference/cli/common-flags.ja.md
@@ -36,7 +36,6 @@ applies_to: [reyn run, reyn eval, reyn chat]
 
 | フラグ | 利用可能 | デフォルト | 説明 |
 |------|---------|---------|-------------|
-| `--allow-shell` | `run` | オフ | `shell` Control IR op を有効にする。サブプロセスを呼び出す Skill に必要。 |
 | `--allow-unsafe-python` | `run`、`chat` | オフ | `mode: unsafe` の Python preprocessor ステップを許可（AST サンドボックスなし）。`--allow-untrusted-python` はレガシーエイリアス。safe モードのステップはこれなしで動作します。 |
 | `--strict` | `run` | オフ | すべてのネスト深さで必須フィールドを検証します（デフォルト: トップレベルのみ）。 |
 

--- a/docs/reference/cli/common-flags.md
+++ b/docs/reference/cli/common-flags.md
@@ -36,7 +36,6 @@ All limits are read from `reyn.yaml`'s `safety:` block by default and can be ove
 
 | Flag | Available on | Default | Description |
 |------|--------------|---------|-------------|
-| `--allow-shell` | `run` | off | Enable the `shell` Control IR op. Required for skills that invoke sub-processes. |
 | `--allow-unsafe-python` | `run`, `chat` | off | Allow `mode: unsafe` Python preprocessor steps (no AST sandbox). Safe-mode steps run without this. `--allow-untrusted-python` is a legacy alias. |
 | `--strict` | `run` | off | Validate required fields at every nesting depth (default: top level only). |
 

--- a/docs/reference/cli/run.ja.md
+++ b/docs/reference/cli/run.ja.md
@@ -34,7 +34,6 @@ reyn run [OPTIONS] [SKILL] [INPUT]
 | `--max-phase-visits N` | ランごとの単一 Phase 再訪問の上限。`0` = 無制限。デフォルト `25`。 |
 | `--events` | 実行後に完全なイベントログを表示。 |
 | `--strict` | すべてのネスト深さで必須フィールドを強制します（デフォルト: トップレベルのみ）。 |
-| `--allow-shell` | `shell` Control IR op を有効にする。デフォルトはオフ。 |
 | `--allow-unsafe-python` | unsafe モードの Python preprocessor ステップを有効にする（AST サンドボックスなし）。`--allow-untrusted-python` は後方互換性のためのレガシーエイリアスです。 |
 
 ## 例
@@ -61,12 +60,6 @@ echo "summarize this text" | reyn run direct_llm
 
 ```bash
 reyn run direct_llm "..." --events
-```
-
-シェルアクセスが必要なメタ Skill を実行:
-
-```bash
-reyn run skill_improver "improve my_skill" --allow-shell
 ```
 
 ## 関連情報

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -34,7 +34,6 @@ reyn run [OPTIONS] [SKILL] [INPUT]
 | `--max-phase-visits N` | Cap on single-phase revisits per run. `0` = unlimited. Default `25`. |
 | `--events` | Print the full event log after execution. |
 | `--strict` | Enforce required fields at every nesting depth (default: top-level only). |
-| `--allow-shell` | Enable the `shell` Control IR op. Off by default. |
 | `--allow-unsafe-python` | Enable unsafe-mode Python preprocessor steps (no AST sandbox). `--allow-untrusted-python` is a legacy alias for backwards compatibility. |
 
 ## Examples
@@ -61,12 +60,6 @@ Replay events afterwards:
 
 ```bash
 reyn run direct_llm "..." --events
-```
-
-Run a meta-skill that needs shell access:
-
-```bash
-reyn run skill_improver "improve my_skill" --allow-shell
 ```
 
 ## See also

--- a/docs/reference/config/permissions.ja.md
+++ b/docs/reference/config/permissions.ja.md
@@ -51,8 +51,6 @@ permissions:
 
 この Phase で `shell` Control IR op を有効にするには `true`。デフォルトはオフ。
 
-`shell: true` でも、ランタイムの起動に `--allow-shell` が必要です。そうでなければ op は `shell_not_allowed` を発行します。
-
 ### `mcp`、`tool`
 
 Phase が呼び出せる MCP サーバー名 / 名前付きツール ID のリスト。

--- a/docs/reference/config/permissions.md
+++ b/docs/reference/config/permissions.md
@@ -57,8 +57,6 @@ permissions:
 
 `true` to enable the `shell` Control IR op for this phase. Off by default.
 
-Even with `shell: true`, the runtime requires `--allow-shell` at startup; otherwise the op emits `shell_not_allowed`.
-
 ### `mcp`, `tool`
 
 List of MCP server names / named tool ids the phase may call.

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -51,7 +51,6 @@ models:
 | `plan_resume_raw` | マップ | プランモードのレジューム ポリシーの raw dict。プランコーディネーターが遅延パース。 |
 | `prompt_cache_enabled` | bool | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
 | `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。デフォルト `REYN.md`。 |
-| `shell_allowed` | bool | `shell` op を事前承認（呼び出しごとのゲートを skip）。デフォルト `false`。 |
 | `api_base` | 文字列 | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
 
 ## `models` ブロック

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -51,7 +51,6 @@ models:
 | `plan_resume_raw` | map | Raw resume-policy dict for plan-mode runs. Parsed lazily by the plan coordinator. |
 | `prompt_cache_enabled` | bool | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
 | `project_context_path` | string | Markdown file injected into every phase system prompt. Default `REYN.md`. |
-| `shell_allowed` | bool | Pre-approve the `shell` op so it is not gated per-call. Default `false`. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
 | `tool_calls_op_loop_skills` | list | **Transitional.** Skill names opted into the native-tools op-loop — the phase act-loop drives the shared `RouterLoop.run_loop` (the converged op-loop, #1092): ops are emitted as native `tool_calls`, run through the shared executor, and threaded as native tool-role message-history. Default empty = all skills use json-mode (unchanged). Removed once the op-loop becomes the default. (#1092 PR-C-3 merged the former separate `routerloop_convergence_skills` gate into this one — the converged path is now the op-loop's implementation.) |
 

--- a/docs/reference/stdlib/index_docs.md
+++ b/docs/reference/stdlib/index_docs.md
@@ -19,7 +19,7 @@ Build a searchable semantic index over a path glob.
 
 ## How it composes
 
-Two-stage execution. Phase `strategy` (LLM): a preprocessor runs `gather_samples` (up to 5 file excerpts) and `cost_preflight` (chunk count + estimated cost), then the LLM decides the chunking strategy (`boundary`, `max_chunk_size_tokens`, overlap, etc.) or aborts if `threshold_exceeded` is true. Skill.postprocessor (deterministic, no LLM): `extract_and_split` globs files and splits them into chunks, `write_chunks_with_lock` writes `chunks.jsonl` under an advisory source lock, the `embed` op embeds via LiteLLM, and `index_write` persists to `SqliteIndexBackend`.
+Two-stage execution. Phase `strategy` (LLM): a preprocessor runs `gather_samples` (up to 5 file excerpts) and `cost_preflight` (chunk count + estimated cost), then the LLM decides the chunking strategy (`boundary`, `max_chunk_size_tokens`, overlap, etc.) or aborts if `threshold_exceeded` is true. Skill.postprocessor (deterministic, no LLM): `extract_and_split` globs files and enumerates chunks, `write_chunks_with_lock` acquires a source advisory lock, reads each file, splits into chunks per strategy, and streams them into `reyn.safe.embed_index` for provider-direct embedding and indexing into `SqliteIndexBackend`. No intermediate file is written.
 
 ## Caveats
 

--- a/docs/reference/stdlib/skill_router.ja.md
+++ b/docs/reference/stdlib/skill_router.ja.md
@@ -9,52 +9,15 @@ applies_to: [skill_router]
 
 ユーザー（またはピア agent）の発話を、適切な Skill・agent・直接返答へルーティングします。`reyn chat` が毎ターン使用します。
 
-## Phase
+## 実装
 
-router は **2 Phase** のワークフローとして動作します:
+router はネイティブツールを用いた `RouterLoop` として実装されており（通常の skill ディレクトリと LLM Phase 遷移グラフではありません）、毎ターン会話履歴と利用可能なディスパッチパス（Skill 実行・agent デリゲーション・直接返答）を表すネイティブツールセットを受け取り、LLM がツールを選択してターンが解決されるまでループします。
 
-1. **`classify`** — インテント（chitchat / memory_recall / stable_knowledge / clarification / task / fresh_lookup）を判定し、`routing_decision` で終了するか `match` へ引き渡します。
-2. **`match`** — `task` および `fresh_lookup` インテントに対し、特定の Skill（またはピア agent）へディスパッチするか、`web_research` へ遷移します。
-
-classify Phase は**メモリ書き込み**も担当します。毎ターン新しい発話を検査し、ユーザー／フィードバック／プロジェクト／参照情報を永続化するために `file/write` op を発行することがあります。メモリの読み込みは ChatSession が事前にマージします（[concepts/memory](../../concepts/data-retrieval/memory.md) を参照）。
-
-## エントリー artifact: `chat_routing_request`
-
-ChatSession が毎ターン構築します。主なフィールド:
-
-| フィールド | 出所 | 説明 |
-|-----------|------|------|
-| `user_message` | inbox payload | ルーティング対象の最新発話 |
-| `chat_id` | session | agent 自身の名前（classify がメモリパス構築時に使用） |
-| `history_path` | session | `history.jsonl` へのパス。classify preprocessor がスライスします |
-| `compaction` | config | ヒストリースライスの head/tail サイズ |
-| `available_skills` | session | プロジェクト + stdlib カタログ（router/compactor を除外）。`profile.allowed_skills` が設定されている場合はフィルタリング済み |
-| `available_agents` | registry | Topology ルールで到達可能な他の agent — `[{name, role}, ...]` |
-| `memory_index` | session | 共有 + agent レイヤーをマージ済み（`{status, content}`）。`content` は `(shared)` と `(agent: <name>)` セクションを含む Markdown |
-
-## 最終出力: `routing_decision`
-
-| フィールド | 型 | 役割 |
-|-----------|---|------|
-| `reply_text` | string（任意） | ユーザーに直接表示するテキスト — 中間通知または最終回答 |
-| `skills_to_run` | array（任意） | 今ターン実行するプロジェクト / stdlib Skill |
-| `messages_to_agents` | array（任意） | ピア agent へのデリゲーション — `[{to, request}, ...]` |
-
-ChatSession は空でない配列をそれぞれディスパッチします。`reply_text` はユーザー起点のチェーンでは即座にユーザーへ届きます。agent 起点のチェーン（ピア agent がこのリクエストを受信した場合）では、`messages_to_agents` が空でないとき router の `reply_text` は全デリゲートが応答するまで保留される [deferred reply](../../concepts/multi-agent/multi-agent.md#deferred-reply) に入ります。
-
-## Skill 選択ガイダンス
-
-`match` Phase が優先する選択:
-
-- **特定の Skill** — `routing.examples.positive` が明確に一致する場合。明確に定義されたタスクに適しています。
-- **agent デリゲーション** — `available_agents` にリクエストに合う `role` を持つピアがいる場合。
-- **直接返答** — どちらにも当てはまらずリクエストが小さい場合（または `confidence < 0.6` で clarification が発火する場合）。
-
-同じ decision で Skill と agent の両方を選ぶことはできません — どちらか一方のブランチを選択してください。
+メモリ書き込み（ユーザー／フィードバック／プロジェクト／参照情報の永続化）はループ内で LLM が `file/write` op を発行したときに行われます。メモリの読み込みはループ実行前に ChatSession が事前にマージします（[concepts/memory](../../concepts/data-retrieval/memory.md) を参照）。
 
 ## ソース
 
-[`src/reyn/chat/session.py`](https://github.com/tya5/reyn/blob/main/src/reyn/chat/session.py) — 通常の skill ディレクトリではなく、組み込みシステム skill として実装されています
+[`src/reyn/chat/router_loop.py`](https://github.com/tya5/reyn/blob/main/src/reyn/chat/router_loop.py) — 通常の skill ディレクトリではなく、組み込みシステム skill として実装されています
 
 ## 関連情報
 

--- a/docs/reference/stdlib/skill_router.md
+++ b/docs/reference/stdlib/skill_router.md
@@ -9,52 +9,15 @@ applies_to: [skill_router]
 
 Route a single user (or peer-agent) utterance to an appropriate skill, agent, or direct reply. Used by `reyn chat` on every turn.
 
-## Phases
+## Implementation
 
-The router runs as a **two-phase** workflow:
+The router is implemented as a native-tools `RouterLoop` (not a regular skill directory with LLM phase transitions). On each turn `RouterLoop` receives the conversation history and a set of native tools representing the available dispatch paths (skill execution, agent delegation, direct reply). The LLM picks one or more tools; the loop runs until the turn is resolved.
 
-1. **`classify`** — pick the intent (chitchat / memory_recall / stable_knowledge / clarification / task / fresh_lookup) and either finish with `routing_decision` or hand off to `match`.
-2. **`match`** — for `task` and `fresh_lookup` intents, dispatch to a specific skill (or peer agent), or transition to `web_research`.
-
-The classify phase also handles **memory writes**: every turn it inspects the new utterance and may emit `file/write` ops to persist user / feedback / project / reference facts. Memory reads are pre-merged by ChatSession (see [concepts/memory](../../concepts/data-retrieval/memory.md)).
-
-## Entry artifact: `chat_routing_request`
-
-ChatSession constructs this on every turn. Selected fields:
-
-| Field | Origin | Description |
-|-------|--------|-------------|
-| `user_message` | inbox payload | The latest utterance to route |
-| `chat_id` | session | The agent's own name (used by classify when building memory paths) |
-| `history_path` | session | Path to `history.jsonl`, sliced by the classify preprocessor |
-| `compaction` | config | Window-first token-budget compaction policy (`component_weights` / `section_weights`) |
-| `available_skills` | session | Project + stdlib catalogue (router/compactor excluded), filtered by `profile.allowed_skills` if set |
-| `available_agents` | registry | Other agents reachable via topology rules — `[{name, role}, ...]` |
-| `memory_index` | session | Pre-merged shared + agent layers (`{status, content}`); `content` is markdown with `(shared)` and `(agent: <name>)` sections |
-
-## Final output: `routing_decision`
-
-| Field | Type | Purpose |
-|-------|------|---------|
-| `reply_text` | string (optional) | Text shown directly to the user — interim acknowledgement or final answer |
-| `skills_to_run` | array (optional) | Project / stdlib skills to spawn this turn |
-| `messages_to_agents` | array (optional) | Delegations to peer agents — `[{to, request}, ...]` |
-
-ChatSession dispatches each non-empty array. `reply_text` reaches the user immediately for user-initiated chains. For agent-initiated chains (a peer agent received this request), the chain enters [deferred reply](../../concepts/multi-agent/multi-agent.md#deferred-reply) when `messages_to_agents` is non-empty: the router's `reply_text` is held until every delegate responds.
-
-## Skill selection guidance
-
-The `match` phase prefers:
-
-- **A specific skill** with a clear `routing.examples.positive` match — narrow well-defined tasks
-- **Agent delegation** when `available_agents` shows a peer whose `role` matches the request better than any skill
-- **Direct reply** when neither fits cleanly and the request is small (or `confidence < 0.6` triggers clarification)
-
-Never both a skill AND an agent in the same decision — pick one branch.
+Memory writes (persisting user / feedback / project / reference facts) happen inside the loop when the LLM emits `file/write` ops. Memory reads are pre-merged by ChatSession before the loop runs (see [concepts/memory](../../concepts/data-retrieval/memory.md)).
 
 ## Source
 
-[`src/reyn/chat/session.py`](https://github.com/tya5/reyn/blob/main/src/reyn/chat/session.py) — implemented as a built-in system skill, not a regular skill directory
+[`src/reyn/chat/router_loop.py`](https://github.com/tya5/reyn/blob/main/src/reyn/chat/router_loop.py) — implemented as a built-in system skill, not a regular skill directory
 
 ## See also
 

--- a/docs/reference/stdlib/word_stats_demo.md
+++ b/docs/reference/stdlib/word_stats_demo.md
@@ -19,7 +19,7 @@ Demo skill showing the `python` preprocessor step pattern. Produces a short comm
 
 ## How it composes
 
-A single `review` phase. The `stats.py` preprocessor (safe mode, 5 s timeout) runs deterministically before the LLM, injecting `char_count`, `word_count`, `line_count`, `longest_line_chars`, and `estimated_tokens` into `data.stats`. The LLM writes commentary citing the exact values — it does not recount anything.
+A single `review` phase. The `stats.py:compute_text_stats` preprocessor (safe mode, 5 s timeout) runs deterministically before the LLM, replacing `data` with `{"text": ..., "stats": {"char_count", "word_count", "line_count", "longest_line_chars", "estimated_tokens"}}`. The LLM writes commentary citing the exact values — it does not recount anything.
 
 ## Caveats
 


### PR DESCRIPTION
**[tui-coder]** — Direction-A doc fixes from the doc↔impl audit (phantom content + stale descriptions). Doc-only PR, 12 files.

## Summary

### #1511 — skill_router.md: phantom classify/match architecture

The doc described a two-phase `classify` → `match` workflow with artifacts `chat_routing_request` and `routing_decision`, none of which exist in `src/reyn/`. Grep evidence: `grep -rn "chat_routing_request\|routing_decision\|classify_phase\|match_phase" src/reyn/chat/` → 0 results.

The actual router is `RouterLoop` in `src/reyn/chat/router_loop.py` using native tool_use. Removed the phantom Phases, Entry artifact, Final output, and Skill selection guidance sections. Fixed source link `session.py` → `router_loop.py`. Same fix in `.ja.md`.

### #1513 — phantom flags/fields (0 hits in src/reyn/)

- **`shell_allowed`** in `reyn-yaml.md` / `.ja.md` — `grep -rn "shell_allowed" src/reyn/` → 0 results
- **`--allow-shell`** in `common-flags.md`, `run.md`, `permissions.md` (+ `.ja.md` counterparts) — `grep -rn "allow.shell\|allow_shell" src/reyn/` → 0 results

### #1513 — index_docs.md stale postprocessor

The postprocessor description referenced:
- `write_chunks_with_lock` writing a `chunks.jsonl` intermediate file — removed in FP-0042 / #1303 Stage I
- a separate `embed` op — folded into `write_chunks_with_lock`
- a separate `index_write` op — folded into `write_chunks_with_lock`

Updated to reflect current one-step streaming into `reyn.safe.embed_index`.

### #1513 — word_stats_demo.md incorrect `into` path

Doc said the preprocessor injects "into `data.stats`" but `review.md` declares `into: data`. The `compute_text_stats` function returns `{"text": ..., "stats": {...}}` which replaces all of `data`. Both `data.text` and `data.stats` are set.

## Files changed

- `docs/reference/stdlib/skill_router.md` / `.ja.md` — phantom section removal + source link fix
- `docs/reference/config/reyn-yaml.md` / `.ja.md` — remove `shell_allowed` row
- `docs/reference/config/permissions.md` / `.ja.md` — remove `--allow-shell` sentence
- `docs/reference/cli/common-flags.md` / `.ja.md` — remove `--allow-shell` row
- `docs/reference/cli/run.md` / `.ja.md` — remove `--allow-shell` row + example
- `docs/reference/stdlib/index_docs.md` — fix stale postprocessor description
- `docs/reference/stdlib/word_stats_demo.md` — fix `into` path description

## Test plan

- [x] (skipped — doc-only change, no code paths)

## Tier self-check

Doc-only PR. No tests added. No Tier rules apply.

Closes #1511
Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
