### PR TITLE
feat(#1505): PR-A — async require_file_write/read + JIT ask + config deny

### DIFF
--- a/src/reyn/op_runtime/file.py
+++ b/src/reyn/op_runtime/file.py
@@ -208,22 +208,22 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         _sandbox = _sandbox_policy_from_ctx(ctx)
         if op.op in _WRITE_OPS:
             write_target = op.output_path if op.op == "regenerate_index" and op.output_path else op.path
-            ctx.permission_resolver.require_file_write(
+            await ctx.permission_resolver.require_file_write(
                 ctx.permission_decl, _resolve_for_gate(ctx, write_target), ctx.skill_name,
-                sandbox_policy=_sandbox,
+                sandbox_policy=_sandbox, bus=ctx.intervention_bus,
             )
             # move also writes to dest_path — gate both source (= the file
             # being effectively deleted) and dest (= the file being created).
             if op.op == "move" and op.dest_path:
-                ctx.permission_resolver.require_file_write(
+                await ctx.permission_resolver.require_file_write(
                     ctx.permission_decl, _resolve_for_gate(ctx, op.dest_path), ctx.skill_name,
-                    sandbox_policy=_sandbox,
+                    sandbox_policy=_sandbox, bus=ctx.intervention_bus,
                 )
         elif op.op in _READ_OPS:
             # read / glob / grep / stat — gate against read scope
-            ctx.permission_resolver.require_file_read(
+            await ctx.permission_resolver.require_file_read(
                 ctx.permission_decl, _resolve_for_gate(ctx, op.path), ctx.skill_name,
-                sandbox_policy=_sandbox,
+                sandbox_policy=_sandbox, bus=ctx.intervention_bus,
             )
 
     if op.op == "write":

--- a/src/reyn/op_runtime/index_drop.py
+++ b/src/reyn/op_runtime/index_drop.py
@@ -53,7 +53,7 @@ async def handle(
     if ctx.permission_resolver is not None:
         sandbox_policy = sandbox_policy_from_ctx(ctx)
         sources_yaml = workspace_root / ".reyn" / "index" / "sources.yaml"
-        ctx.permission_resolver.require_file_write(
+        await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(sources_yaml), ctx.skill_name,
             sandbox_policy=sandbox_policy,
         )
@@ -62,7 +62,7 @@ async def handle(
         # sandbox write_paths cap (S3.1c-2 ∩). The SQLite/dir removal stays
         # host-direct; the gate fires before backend.drop opens/removes it.
         source_dir = workspace_root / ".reyn" / "index" / op.source
-        ctx.permission_resolver.require_file_write(
+        await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(source_dir), ctx.skill_name,
             sandbox_policy=sandbox_policy,
         )

--- a/src/reyn/op_runtime/index_query.py
+++ b/src/reyn/op_runtime/index_query.py
@@ -80,7 +80,7 @@ async def handle(
     # hole where a sandbox read_paths cap could not constrain index reads.
     if ctx.permission_resolver is not None:
         db_path = workspace_root / ".reyn" / "index" / op.source / "index.db"
-        ctx.permission_resolver.require_file_read(
+        await ctx.permission_resolver.require_file_read(
             ctx.permission_decl, str(db_path), ctx.skill_name,
             sandbox_policy=sandbox_policy_from_ctx(ctx),
         )

--- a/src/reyn/op_runtime/mcp_drop_server.py
+++ b/src/reyn/op_runtime/mcp_drop_server.py
@@ -220,7 +220,7 @@ async def handle(
     if ctx.permission_resolver is not None:
         # #1352-C: thread the agent/operator sandbox policy (SandboxLayer ∩),
         # same as op_runtime/file.py — was missing here (permission-only gap).
-        ctx.permission_resolver.require_file_write(
+        await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.skill_name,
             sandbox_policy=_sandbox_policy_from_ctx(ctx),
         )

--- a/src/reyn/op_runtime/mcp_install.py
+++ b/src/reyn/op_runtime/mcp_install.py
@@ -269,7 +269,7 @@ async def handle(
         # same as op_runtime/file.py — was missing here, so the write/http gates
         # ran permission-only (SandboxLayer ⊤). None → ⊤ (unchanged).
         _sandbox = _sandbox_policy_from_ctx(ctx)
-        ctx.permission_resolver.require_file_write(
+        await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.skill_name,
             sandbox_policy=_sandbox,
         )

--- a/src/reyn/permissions/permissions.py
+++ b/src/reyn/permissions/permissions.py
@@ -991,35 +991,36 @@ class PermissionResolver:
 
     # ── Public check methods ──────────────────────────────────────────────────
 
-    def require_file_read(
+    async def require_file_read(
         self,
         decl: PermissionDecl,
         path: str,
         skill_name: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
+        bus: "RequestBus | None" = None,
     ) -> None:
         """
         Raise PermissionError if read/glob/grep access to path is not allowed.
         Default zone (CWD and below) is always granted.
-        Outside CWD, the path must have been approved at startup or via config.
+        Outside CWD: ask via ``bus`` when provided (JIT prompt, mirrors
+        ``require_http_get``); deny when bus=None (non-interactive).
 
-        #1199 S3.1c-1: this gate is **decl-less** (zone OR approved) — the same
-        decision ``is_read_allowed`` makes (divergence resolved). A skill's
-        declared path is NOT auto-granted; it must be in the default zone or
-        approved (interactively at startup, or via config). A non-interactive
-        declared-but-unapproved path therefore denies — the operator pre-approves
-        (reyn.yaml ``permissions.file.read: allow``) or runs interactively.
+        Config ``file.read: deny`` overrides even the default zone.
 
-        #1199 S3.1c-2: ``sandbox_policy`` (the phase ``default_sandbox_policy``,
-        passed by the op handler) folds in the SandboxLayer ∩ — the path must
-        ALSO fall within the policy's ``read_paths`` caps. ``None`` (the OS's own
-        in-process ops / non-sandboxed callers) → SandboxLayer is ⊤ (unchanged).
-        ProfileLayer is omitted: it constrains only skill/mcp, never files (⊤).
+        #1505: async-ified + JIT ask — outside-zone access now prompts the
+        user at gate time (bus≠None) instead of hard-denying. bus=None
+        (non-interactive / eval) preserves the prior deny behavior.
+
+        #1199 S3.1c-1: decl-less (zone OR approved). #1199 S3.1c-2:
+        SandboxLayer ∩ for sandbox_policy path caps.
         """
-        # #1199 S3.1c-1/-2: decl-less AgentLayer ∩ SandboxLayer (zone OR approved,
-        # then narrowed by the sandbox path caps). Approvals fold INSIDE the agent
-        # layer (② grant-back-safe).
+        # Config-tier deny always wins — overrides even the default zone.
+        if self._is_config_denied("file.read"):
+            raise PermissionError(
+                f"read from '{path}' denied by config (file.read: deny)."
+            )
+
         from reyn.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
@@ -1039,41 +1040,51 @@ class PermissionResolver:
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_READ, path):
             return
+
+        # JIT ask: outside zone, not yet approved. Mirrors require_http_get wildcard path.
+        if bus is not None:
+            if await self._prompt_file_access(path, "just_path", skill_name, "file.read", bus):
+                return
+
         raise PermissionError(
             f"read from '{path}' was not approved (declared but not granted).\n"
-            f"Why: it is outside the default read zone (CWD) and has no approval; "
-            f"the skill's declaration alone does not auto-grant it.\n"
+            f"Why: it is outside the default read zone (CWD) and has no approval.\n"
             f"Options:\n"
             f"  - pre-approve in reyn.yaml: permissions.file.read: allow (or the "
             f"specific path), then re-run; or\n"
-            f"  - run interactively so the startup guard can prompt for approval."
+            f"  - run interactively — a prompt will appear at the time of access."
         )
 
-    def require_file_write(
+    async def require_file_write(
         self,
         decl: PermissionDecl,
         path: str,
         skill_name: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
+        bus: "RequestBus | None" = None,
     ) -> None:
         """
         Raise PermissionError if write/edit/delete access to path is not allowed.
         Default zone (.reyn/, reyn/) is always granted.
-        Outside the default zone, the path must have been approved at startup.
+        Outside the default zone: ask via ``bus`` when provided (JIT prompt,
+        mirrors ``require_http_get``); deny when bus=None (non-interactive).
 
-        #1199 S3.1c-1: decl-less (zone OR approved) — the same decision
-        ``is_write_allowed`` makes (divergence resolved). A declared path is not
-        auto-granted; a non-interactive declared-but-unapproved path denies (the
-        operator pre-approves via reyn.yaml or runs interactively).
+        Config ``file.write: deny`` overrides even the default zone.
 
-        #1199 S3.1c-2: ``sandbox_policy`` folds in the SandboxLayer ∩ — the path
-        must ALSO fall within the policy's ``write_paths`` caps. ``None`` → ⊤
-        (unchanged). ProfileLayer omitted (⊤ for files).
+        #1505: async-ified + JIT ask — outside-zone writes now prompt the
+        user at gate time (bus≠None) instead of hard-denying. bus=None
+        (non-interactive / eval) preserves the prior deny behavior.
+
+        #1199 S3.1c-1: decl-less (zone OR approved). #1199 S3.1c-2:
+        SandboxLayer ∩ for sandbox_policy path caps.
         """
-        # #1199 S3.1c-1/-2: decl-less AgentLayer ∩ SandboxLayer (zone OR approved,
-        # then narrowed by the sandbox path caps). Approvals fold INSIDE the agent
-        # layer (② grant-back-safe).
+        # Config-tier deny always wins — overrides even the default zone.
+        if self._is_config_denied("file.write"):
+            raise PermissionError(
+                f"write to '{path}' denied by config (file.write: deny)."
+            )
+
         from reyn.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
@@ -1091,14 +1102,20 @@ class PermissionResolver:
             SandboxLayer(sandbox_policy),
         ]).allows(CapabilityAxis.FILE_WRITE, path):
             return
+
+        # JIT ask: outside zone, not yet approved. Mirrors require_http_get wildcard path.
+        if bus is not None:
+            if await self._prompt_file_access(path, "just_path", skill_name, "file.write", bus):
+                return
+
         raise PermissionError(
             f"write to '{path}' was not approved (declared but not granted).\n"
             f"Why: it is outside the default write zone (.reyn/, reyn/) and has no "
-            f"approval; the skill's declaration alone does not auto-grant it.\n"
+            f"approval.\n"
             f"Options:\n"
             f"  - pre-approve in reyn.yaml: permissions.file.write: allow (or the "
             f"specific path), then re-run; or\n"
-            f"  - run interactively so the startup guard can prompt for approval."
+            f"  - run interactively — a prompt will appear at the time of access."
         )
 
     async def require_http_get(

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -231,7 +231,7 @@ async def _gate(ctx: ToolContext, job_name: str) -> None:
     ctx.permission_resolver.session_approve_path(
         cron_yaml_path, "cron", "file.write",
     )
-    ctx.permission_resolver.require_file_write(decl, cron_yaml_path, "cron")
+    await ctx.permission_resolver.require_file_write(decl, cron_yaml_path, "cron")
 
 
 # ── Handlers ─────────────────────────────────────────────────────────

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -435,7 +435,7 @@ async def _handle_mcp_install_local(
     decl.file_write = [{"path": ".reyn/mcp.yaml"}]
     resolver = getattr(rs, "permission_resolver", None) if rs is not None else None
     if resolver is not None:
-        resolver.require_file_write(decl, str(config_path), "mcp__install_local")
+        await resolver.require_file_write(decl, str(config_path), "mcp__install_local")
 
     entry: dict[str, Any] = {
         "type": "stdio",

--- a/tests/test_1199_s31c2_full_intersection.py
+++ b/tests/test_1199_s31c2_full_intersection.py
@@ -23,7 +23,8 @@ from tests.test_permissions import _make_resolver
 # ── file gates: SandboxLayer ∩ (path caps) ───────────────────────────────────
 
 
-def test_sandbox_cap_restricts_in_zone_write(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_sandbox_cap_restricts_in_zone_write(tmp_path: Path) -> None:
     """Tier 2: a sandbox write_paths cap DENIES even an in-zone write — the ∩
     narrows (sandbox restrict-only over the AgentLayer zone grant)."""
     r = _make_resolver(tmp_path)
@@ -31,27 +32,30 @@ def test_sandbox_cap_restricts_in_zone_write(tmp_path: Path) -> None:
     # caps writes to /sandboxed → ∩ denies.
     policy = SandboxPolicy(write_paths=["/sandboxed"])
     with pytest.raises(PermissionError):
-        r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s", sandbox_policy=policy)
+        await r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s", sandbox_policy=policy)
 
 
-def test_sandbox_allow_all_permits(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_sandbox_allow_all_permits(tmp_path: Path) -> None:
     """Tier 2: write_paths=['/'] (= swe_bench's allow-all policy) → in-zone write
     passes (the no-current-blast-radius case)."""
     r = _make_resolver(tmp_path)
-    r.require_file_write(
+    await r.require_file_write(
         PermissionDecl(), ".reyn/x.txt", "s",
         sandbox_policy=SandboxPolicy(write_paths=["/"]),
     )  # no raise
 
 
-def test_no_sandbox_policy_unchanged(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_no_sandbox_policy_unchanged(tmp_path: Path) -> None:
     """Tier 2: sandbox_policy=None → SandboxLayer ⊤ — the gate behaves exactly as
     pre-S3.1c-2 (in-zone write passes; non-sandboxed callers unaffected)."""
     r = _make_resolver(tmp_path)
-    r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s")  # no raise
+    await r.require_file_write(PermissionDecl(), ".reyn/x.txt", "s")  # no raise
 
 
-def test_sandbox_falsification_removing_layer_regrants(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_sandbox_falsification_removing_layer_regrants(tmp_path: Path) -> None:
     """Tier 2: ★∩-falsification — the SAME in-zone write the sandbox DENIES is
     ALLOWED once the SandboxLayer is dropped (sandbox_policy=None). Proves the
     SandboxLayer is load-bearing (over-grant if removed)."""
@@ -59,17 +63,18 @@ def test_sandbox_falsification_removing_layer_regrants(tmp_path: Path) -> None:
     path = ".reyn/x.txt"
     capped = SandboxPolicy(write_paths=["/sandboxed"])  # does not cover .reyn/
     with pytest.raises(PermissionError):
-        r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=capped)
+        await r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=capped)
     # drop the SandboxLayer → re-granted by the zone baseline (the over-grant).
-    r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=None)  # no raise
+    await r.require_file_write(PermissionDecl(), path, "s", sandbox_policy=None)  # no raise
 
 
-def test_sandbox_read_cap_restricts(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_sandbox_read_cap_restricts(tmp_path: Path) -> None:
     """Tier 2: the read gate folds the SandboxLayer too (read_paths cap)."""
     r = _make_resolver(tmp_path)
     capped = SandboxPolicy(read_paths=["/sandboxed"])  # excludes cwd
     with pytest.raises(PermissionError):
-        r.require_file_read(PermissionDecl(), "src/reyn/x.py", "s", sandbox_policy=capped)
+        await r.require_file_read(PermissionDecl(), "src/reyn/x.py", "s", sandbox_policy=capped)
 
 
 # ── http gate: SandboxLayer ∩ (network) ──────────────────────────────────────

--- a/tests/test_chat_grant_file_write_187.py
+++ b/tests/test_chat_grant_file_write_187.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import pytest
+
 from reyn.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.sandbox.policy import SandboxPolicy
 
@@ -49,10 +51,10 @@ def _resolver(*, granted: bool) -> PermissionResolver:
     )
 
 
-def _can_write(resolver: PermissionResolver, path: str) -> bool:
+async def _can_write(resolver: PermissionResolver, path: str) -> bool:
     sandbox = SandboxPolicy(write_paths=[_REPO])
     try:
-        resolver.require_file_write(_DECL, path, "default", sandbox_policy=sandbox)
+        await resolver.require_file_write(_DECL, path, "default", sandbox_policy=sandbox)
         return True
     except PermissionError:
         return False
@@ -66,22 +68,25 @@ def test_chat_grant_injects_read_and_write() -> None:
     assert config.get("file.write") == "allow"
 
 
-def test_chat_grant_allows_in_repo_write() -> None:
+@pytest.mark.asyncio
+async def test_chat_grant_allows_in_repo_write() -> None:
     """Tier 2: chat grant + sandbox[repo] → an in-repo write is allowed (agent edits)."""
-    assert _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
+    assert await _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
 
 
-def test_chat_grant_still_denies_outside_sandbox_zone() -> None:
+@pytest.mark.asyncio
+async def test_chat_grant_still_denies_outside_sandbox_zone() -> None:
     """Tier 2: the SandboxLayer ∩ scopes the chat grant — a write OUTSIDE write_paths
     (e.g. /etc) is DENIED even with the resolver grant (scope from the sandbox, not
     the blanket resolver allow). Same safety as `reyn run --grant-file-write`."""
-    assert _can_write(_resolver(granted=True), "/etc/passwd") is False
+    assert await _can_write(_resolver(granted=True), "/etc/passwd") is False
 
 
-def test_chat_no_grant_denies_in_repo_write() -> None:
+@pytest.mark.asyncio
+async def test_chat_no_grant_denies_in_repo_write() -> None:
     """Tier 2: flag absent → no grant → even an in-repo write is DENIED (the
     non-interactive prompt-less default). Falsification pair for the grant test."""
-    assert _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
+    assert await _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
 
 
 def test_chat_parser_exposes_grant_file_write_flag() -> None:

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -205,7 +205,8 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_yaml_write_is_default_granted_protect_at_use(tmp_path):
+@pytest.mark.asyncio
+async def test_mcp_yaml_write_is_default_granted_protect_at_use(tmp_path):
     """Tier 2: #571 protect-at-use / #1316 — writing the mcp install target
     ``.reyn/mcp.yaml`` needs NO explicit file.write declaration: it sits in the
     default project write zone (removed from the protected carve-out because
@@ -219,12 +220,12 @@ def test_mcp_yaml_write_is_default_granted_protect_at_use(tmp_path):
     not a loosening.)"""
     resolver = _make_resolver(tmp_path)  # project_root = tmp_path
     # mcp.yaml under project_root/.reyn = default write zone → granted (no decl)
-    resolver.require_file_write(
+    await resolver.require_file_write(
         PermissionDecl(), str(tmp_path / ".reyn" / "mcp.yaml"), "mcp_install_test"
     )
     # contrast: the approval store IS carved out → still needs an explicit grant
     with pytest.raises(PermissionError):
-        resolver.require_file_write(
+        await resolver.require_file_write(
             PermissionDecl(), str(tmp_path / ".reyn" / "approvals.yaml"), "t"
         )
 

--- a/tests/test_offload_read_grant_1383.py
+++ b/tests/test_offload_read_grant_1383.py
@@ -45,21 +45,24 @@ def _out_of_zone(tmp_path: Path) -> tuple[PermissionResolver, Path, Path]:
     return _resolver(proj), offloaded, state
 
 
-def test_out_of_zone_read_denied_without_grant(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_out_of_zone_read_denied_without_grant(tmp_path: Path) -> None:
     """Tier 2c: baseline — an out-of-zone offload path is denied with no grant (the 13236 bug)."""
     r, offloaded, _ = _out_of_zone(tmp_path)
     with pytest.raises(PermissionError):
-        r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+        await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
 
 
-def test_grant_offload_read_allows_exact_path(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_grant_offload_read_allows_exact_path(tmp_path: Path) -> None:
     """Tier 2c: after grant_offload_read, the exact out-of-zone path is readable."""
     r, offloaded, _ = _out_of_zone(tmp_path)
     r.grant_offload_read(str(offloaded))
-    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
+    await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
 
 
-def test_grant_is_exact_scoped_not_sibling(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_grant_is_exact_scoped_not_sibling(tmp_path: Path) -> None:
     """Tier 2c: the grant is exact-path scoped — a SIBLING in the same dir stays denied
     (least-privilege: granting one offloaded artifact does NOT open the state-dir)."""
     r, offloaded, state = _out_of_zone(tmp_path)
@@ -67,10 +70,11 @@ def test_grant_is_exact_scoped_not_sibling(tmp_path: Path) -> None:
     sibling = state / "other_secret.json"
     sibling.write_text("{}")
     with pytest.raises(PermissionError):
-        r.require_file_read(PermissionDecl(), str(sibling), "swe_bench")
+        await r.require_file_read(PermissionDecl(), str(sibling), "swe_bench")
 
 
-def test_register_reaches_check_seam(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_register_reaches_check_seam(tmp_path: Path) -> None:
     """Tier 2c: register→check wiring falsification — the SAME resolver instance that
     registered the grant is the one the read gate consults. Without the register the
     read fails; with it, it passes. (A grant stored where the check never reads it
@@ -78,13 +82,14 @@ def test_register_reaches_check_seam(tmp_path: Path) -> None:
     r, offloaded, _ = _out_of_zone(tmp_path)
     # before register: denied
     with pytest.raises(PermissionError):
-        r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+        await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
     # register on this instance → the check (same instance) now passes
     r.grant_offload_read(str(offloaded))
-    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+    await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
 
 
-def test_emit_artifact_ref_registers_grant_end_to_end(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_emit_artifact_ref_registers_grant_end_to_end(tmp_path: Path) -> None:
     """Tier 2c: the artifact_ref emit point (maybe_ref_artifact) → grant → check chain.
     A large artifact emits an artifact_ref AND the path becomes readable via the grant."""
     r, offloaded, _ = _out_of_zone(tmp_path)
@@ -94,10 +99,11 @@ def test_emit_artifact_ref_registers_grant_end_to_end(tmp_path: Path) -> None:
     )
     assert out["type"] == "artifact_ref"  # large → offloaded to a ref
     # the emit registered the grant → the agent can read what it was told to read
-    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
+    await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")
 
 
-def test_emit_control_ir_offload_registers_grant_end_to_end(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_emit_control_ir_offload_registers_grant_end_to_end(tmp_path: Path) -> None:
     """Tier 2c: the generic offload emit point (offload_control_ir_result) → grant → check.
     Covers the second of the two exhaustive emit points."""
     r, _, state = _out_of_zone(tmp_path)
@@ -106,10 +112,11 @@ def test_emit_control_ir_offload_registers_grant_end_to_end(tmp_path: Path) -> N
         big_result, 0, state, cap=1024, on_offload_ref=r.grant_offload_read
     )
     ref_path = inline["_offload_ref"]
-    r.require_file_read(PermissionDecl(), str(ref_path), "swe_bench")  # granted → no raise
+    await r.require_file_read(PermissionDecl(), str(ref_path), "swe_bench")  # granted → no raise
 
 
-def test_offload_grant_still_intersects_sandbox(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_offload_grant_still_intersects_sandbox(tmp_path: Path) -> None:
     """Tier 2c: the AgentLayer offload grant is conjunctive-∩ with the SandboxLayer —
     a sandbox that restricts reads to other paths still denies the offloaded path."""
     r, offloaded, _ = _out_of_zone(tmp_path)
@@ -117,7 +124,7 @@ def test_offload_grant_still_intersects_sandbox(tmp_path: Path) -> None:
     # SandboxLayer with a non-empty read allowlist that excludes the offloaded path
     policy = SandboxPolicy(read_paths=[str(tmp_path / "elsewhere")])
     with pytest.raises(PermissionError):
-        r.require_file_read(
+        await r.require_file_read(
             PermissionDecl(), str(offloaded), "swe_bench", sandbox_policy=policy
         )
 
@@ -135,7 +142,8 @@ def test_is_read_allowed_honors_offload_grant(tmp_path: Path) -> None:
     assert r.is_read_allowed(str(offloaded), "swe_bench") is True  # after grant
 
 
-def test_both_read_gates_in_sync_for_offload_grant(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_both_read_gates_in_sync_for_offload_grant(tmp_path: Path) -> None:
     """Tier 2c: the two read gates make the SAME decision for an offloaded path —
     require_file_read (op-runtime) and is_read_allowed (Workspace) both admit it
     after the grant. (The follow-up restores the symmetry the merged D12 broke by
@@ -143,12 +151,13 @@ def test_both_read_gates_in_sync_for_offload_grant(tmp_path: Path) -> None:
     r, offloaded, _ = _out_of_zone(tmp_path)
     r.grant_offload_read(str(offloaded))
     # op-runtime gate
-    r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
+    await r.require_file_read(PermissionDecl(), str(offloaded), "swe_bench")  # no raise
     # Workspace gate
     assert r.is_read_allowed(str(offloaded), "swe_bench") is True
 
 
-def test_read_gates_symmetric_granted_and_nongranted(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_read_gates_symmetric_granted_and_nongranted(tmp_path: Path) -> None:
     """Tier 2c: symmetry-invariant (falsifies future divergence) — for BOTH a
     granted offload path AND a non-granted out-of-zone path, require_file_read and
     is_read_allowed return the SAME admit/deny. They share `_read_base_approved`
@@ -156,19 +165,19 @@ def test_read_gates_symmetric_granted_and_nongranted(tmp_path: Path) -> None:
     r, offloaded, state = _out_of_zone(tmp_path)
     nongranted = state / "not_granted.json"
 
-    def _require_ok(p: Path) -> bool:
+    async def _require_ok(p: Path) -> bool:
         try:
-            r.require_file_read(PermissionDecl(), str(p), "swe_bench")
+            await r.require_file_read(PermissionDecl(), str(p), "swe_bench")
             return True
         except PermissionError:
             return False
 
     # non-granted out-of-zone: both DENY (symmetric)
-    assert _require_ok(nongranted) is False
+    assert await _require_ok(nongranted) is False
     assert r.is_read_allowed(str(nongranted), "swe_bench") is False
     # granted: both ALLOW (symmetric)
     r.grant_offload_read(str(offloaded))
-    assert _require_ok(offloaded) is True
+    assert await _require_ok(offloaded) is True
     assert r.is_read_allowed(str(offloaded), "swe_bench") is True
 
 

--- a/tests/test_perm_zone_base_1316.py
+++ b/tests/test_perm_zone_base_1316.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from reyn.permissions.permissions import PermissionDecl, PermissionResolver
 
 
@@ -24,7 +26,8 @@ def _resolver(project_root: Path) -> PermissionResolver:
     )
 
 
-def test_write_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_write_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
     """Tier 2: #1316 reproduce-first — a write under project_root/.reyn (the
     project's default write zone) is granted when project_root ≠ cwd. FAILS pre-fix
     (zone used cwd → the path was not in the cwd zone → PermissionError, diverging
@@ -33,30 +36,30 @@ def test_write_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
     (base / ".reyn").mkdir(parents=True)
     r = _resolver(base)
     # under project_root/.reyn = default write zone → granted (no raise)
-    r.require_file_write(PermissionDecl(), str(base / ".reyn" / "scratch.txt"), "t")
+    await r.require_file_write(PermissionDecl(), str(base / ".reyn" / "scratch.txt"), "t")
 
 
-def test_read_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_read_zone_anchored_to_project_root_not_cwd(tmp_path: Path) -> None:
     """Tier 2: #1316 — a read under project_root (the default read zone) is granted
     when project_root ≠ cwd. FAILS pre-fix (zone used cwd)."""
     base = (tmp_path / "proj").resolve()
     base.mkdir(parents=True)
     r = _resolver(base)
-    r.require_file_read(PermissionDecl(), str(base / "src" / "module.py"), "t")
+    await r.require_file_read(PermissionDecl(), str(base / "src" / "module.py"), "t")
 
 
-def test_protected_path_carveout_also_anchored_to_project_root(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_protected_path_carveout_also_anchored_to_project_root(tmp_path: Path) -> None:
     """Tier 2: #1316 — the canonical protected-write carve-out (approvals.yaml) is
     evaluated against project_root too, so project_root/.reyn/approvals.yaml is
     NOT default-zone-granted (must go through the gated approval flow) even when
     project_root ≠ cwd."""
-    import pytest
-
     base = (tmp_path / "proj").resolve()
     (base / ".reyn").mkdir(parents=True)
     r = _resolver(base)
     # the approval store under project_root is carved out → not default-granted
     with pytest.raises(PermissionError):
-        r.require_file_write(
+        await r.require_file_write(
             PermissionDecl(), str(base / ".reyn" / "approvals.yaml"), "t"
         )

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -70,16 +70,18 @@ def test_other_reyn_paths_still_in_default_zone(tmp_path, monkeypatch):
         assert _is_canonical_protected_write(rel) is False
 
 
-def test_require_file_write_rejects_canonical_without_decl(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_require_file_write_rejects_canonical_without_decl(tmp_path, monkeypatch):
     """Tier 2: require_file_write raises for protected path without explicit decl."""
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     decl = PermissionDecl()  # no axes set
     with pytest.raises(PermissionError, match="was not approved"):
-        resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
+        await resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
 
 
-def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
     """Tier 2: #1199 security fix — a broad-zone file.write to the persisted approval
     store (.reyn/approvals.yaml) is DENIED without an explicit decl, closing the
     approval-injection persistence attack (a direct write would otherwise bypass the
@@ -91,12 +93,13 @@ def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     with pytest.raises(PermissionError, match="was not approved"):
-        resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
+        await resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
     # contrast: a non-protected .reyn/ path is NOT denied (in default zone).
-    resolver.require_file_write(PermissionDecl(), ".reyn/scratch/notes.txt", "skill_x")
+    await resolver.require_file_write(PermissionDecl(), ".reyn/scratch/notes.txt", "skill_x")
 
 
-def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, monkeypatch):
     """Tier 2: require_file_write passes when path was approved at startup_guard time.
 
     Phase 2 does not change require_file_write semantics — declaration alone
@@ -110,7 +113,7 @@ def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, m
     )
     resolver.session_approve_path(".reyn/index/sources.yaml", "skill_x", "file.write")
     # Should not raise — startup_guard's session approval covers the path.
-    resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
+    await resolver.require_file_write(decl, ".reyn/index/sources.yaml", "skill_x")
 
 
 # ── legacy bool-axis keys are removed (#571 Phase 5) ───────────────────────────
@@ -247,7 +250,8 @@ def test_canonical_protected_lists_stay_in_sync():
     assert _CANONICAL_PROTECTED_WRITE_PATHS == safe_paths
 
 
-def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch):
     """Tier 2: realignment — .reyn/mcp.yaml and .reyn/cron.yaml are removed from the
     carve-out (protect-at-use), so a broad-zone write to them is ALLOWED on both
     enforcement paths. Safety holds downstream: using a server passes require_mcp
@@ -271,12 +275,12 @@ def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch):
         # permissions.py path: no explicit decl needed — now in the default zone.
         assert _in_default_write_zone(rel) is True
         assert _is_canonical_protected_write(rel) is False
-        resolver.require_file_write(PermissionDecl(), rel, "skill_x")
+        await resolver.require_file_write(PermissionDecl(), rel, "skill_x")
         # safe.file enforcement path: broad-zone prefix match is enough now.
         safe_file._check_write(str(tmp_path / rel))
 
     # contrast: approvals.yaml remains protected on both paths.
     with pytest.raises(PermissionError, match="was not approved"):
-        resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
+        await resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
     with pytest.raises(PermissionError, match="canonical protected path"):
         safe_file._check_write(str(tmp_path / ".reyn" / "approvals.yaml"))

--- a/tests/test_require_file_jit_ask_1505.py
+++ b/tests/test_require_file_jit_ask_1505.py
@@ -1,0 +1,202 @@
+"""Tier 2: #1505 PR-A — require_file_write/read JIT ask + config deny.
+
+require_file_write and require_file_read are now async and accept a
+``bus: RequestBus | None`` parameter, mirroring require_http_get (FP-0022).
+
+Behaviour under test:
+- bus≠None + outside zone + unapproved → JIT prompt fires, approval persists
+- bus≠None + outside zone + user denies → PermissionError after prompt
+- bus=None + outside zone → PermissionError (non-interactive, no prompt)
+- config ``file.write: deny`` / ``file.read: deny`` → PermissionError even
+  for default-zone paths (config deny overrides zone)
+- default-zone paths still pass silently (regression guard)
+
+No mocks. Real PermissionResolver + _FakeBus (non-mock fake).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.intervention_choices import JUST_PATH, YES
+from reyn.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _FakeBus:
+    """Real RequestBus-compatible fake that pre-answers with a scripted choice."""
+
+    def __init__(self, choice: str) -> None:
+        self._choice = choice
+        self.asks: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._choice, choice_id=self._choice)
+
+
+def _resolver(
+    tmp_path: Path,
+    *,
+    config: dict | None = None,
+    interactive: bool = True,
+) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config or {},
+        project_root=tmp_path,
+        interactive=interactive,
+    )
+
+
+# ── require_file_write JIT ask ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_file_write_jit_ask_fires_and_approves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — require_file_write with bus≠None prompts JIT and
+    approves when user answers YES; no PermissionError raised."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    bus = _FakeBus(YES)
+    outside_path = str(tmp_path / "junk" / "README.md")
+
+    # Must not raise — user said yes
+    await r.require_file_write(PermissionDecl(), outside_path, "skill_x", bus=bus)
+
+    # Prompt was shown exactly once
+    (ask,) = bus.asks
+    assert "README.md" in ask.prompt or "README.md" in ask.detail
+
+
+@pytest.mark.asyncio
+async def test_file_write_jit_ask_persist_approves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — JUST_PATH answer persists approval; second call passes
+    without prompting (non-default value: JUST_PATH ≠ default YES)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    outside_path = str(tmp_path / "output" / "result.txt")
+
+    # First call: user picks JUST_PATH (persists)
+    bus1 = _FakeBus(JUST_PATH)
+    await r.require_file_write(PermissionDecl(), outside_path, "skill_x", bus=bus1)
+    (ask,) = bus1.asks  # exactly one prompt fired
+
+    # Second call: already approved — no prompt
+    bus2 = _FakeBus("never_called")
+    await r.require_file_write(PermissionDecl(), outside_path, "skill_x", bus=bus2)
+    assert not bus2.asks
+
+
+@pytest.mark.asyncio
+async def test_file_write_jit_ask_deny_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — user denies JIT prompt → PermissionError raised."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    bus = _FakeBus("no")
+    outside_path = str(tmp_path / "denied" / "file.txt")
+
+    with pytest.raises(PermissionError, match="was not approved"):
+        await r.require_file_write(PermissionDecl(), outside_path, "skill_x", bus=bus)
+
+    # Prompt still fired (user was asked and said no)
+    (ask,) = bus.asks
+
+
+@pytest.mark.asyncio
+async def test_file_write_bus_none_denies_outside_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — bus=None + outside zone → PermissionError (no prompt,
+    non-interactive / eval context behaviour preserved)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path, interactive=False)
+    outside_path = str(tmp_path / "junk" / "README.md")
+
+    with pytest.raises(PermissionError, match="was not approved"):
+        await r.require_file_write(PermissionDecl(), outside_path, "skill_x", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_file_write_default_zone_passes_silently(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — .reyn/ zone write still passes without bus or prompt
+    (regression guard: JIT ask must not break default-zone behaviour)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    # No bus, in default zone → must not raise
+    await r.require_file_write(PermissionDecl(), ".reyn/scratch/notes.txt", "skill_x")
+
+
+# ── require_file_write config deny ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_file_write_config_deny_blocks_default_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — file.write: deny in config denies even .reyn/ zone writes
+    (config deny overrides the default zone — mirrors require_http_get)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path, config={"file.write": "deny"})
+
+    with pytest.raises(PermissionError, match="denied by config"):
+        await r.require_file_write(PermissionDecl(), ".reyn/scratch/notes.txt", "skill_x")
+
+
+@pytest.mark.asyncio
+async def test_file_write_config_deny_blocks_outside_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — file.write: deny also blocks outside-zone writes
+    (no prompt even when bus is provided)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path, config={"file.write": "deny"})
+    bus = _FakeBus(YES)  # would approve if asked
+
+    with pytest.raises(PermissionError, match="denied by config"):
+        await r.require_file_write(PermissionDecl(), str(tmp_path / "out.txt"), "skill_x", bus=bus)
+
+    # Bus was NOT consulted — config deny short-circuits before any prompt
+    assert not bus.asks
+
+
+# ── require_file_read JIT ask ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_file_read_jit_ask_fires_and_approves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — require_file_read with bus≠None prompts JIT and
+    approves when user answers YES; no PermissionError raised."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    bus = _FakeBus(YES)
+    outside_path = str(Path("/tmp") / "external_data.json")
+
+    await r.require_file_read(PermissionDecl(), outside_path, "skill_x", bus=bus)
+
+    (ask,) = bus.asks
+    assert "external_data.json" in ask.prompt or "external_data.json" in ask.detail
+
+
+@pytest.mark.asyncio
+async def test_file_read_bus_none_denies_outside_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — require_file_read bus=None + outside zone → PermissionError."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path, interactive=False)
+    outside_path = str(Path("/tmp") / "external.json")
+
+    with pytest.raises(PermissionError, match="was not approved"):
+        await r.require_file_read(PermissionDecl(), outside_path, "skill_x", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_file_read_config_deny_blocks_cwd_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — file.read: deny in config denies even CWD-zone reads."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path, config={"file.read": "deny"})
+
+    with pytest.raises(PermissionError, match="denied by config"):
+        await r.require_file_read(PermissionDecl(), str(tmp_path / "src" / "main.py"), "skill_x")
+
+
+@pytest.mark.asyncio
+async def test_file_read_default_zone_passes_silently(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #1505 — CWD-zone read passes without bus (regression guard)."""
+    monkeypatch.chdir(tmp_path)
+    r = _resolver(tmp_path)
+    await r.require_file_read(PermissionDecl(), str(tmp_path / "README.md"), "skill_x")

--- a/tests/test_reyn_local_example_benchmark_permissions.py
+++ b/tests/test_reyn_local_example_benchmark_permissions.py
@@ -42,7 +42,8 @@ def _out_of_zone_path(tmp_path: Path) -> str:
     return str(tmp_path / "workspace" / "patch_target.py")
 
 
-def test_flat_config_shape_clears_require_file_write(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_flat_config_shape_clears_require_file_write(tmp_path: Path) -> None:
     """Tier 2: a PermissionResolver built from the DOCUMENTED flat shape
     (``file.write: allow``) clears ``require_file_write`` for an
     out-of-zone path without raising.
@@ -58,10 +59,11 @@ def test_flat_config_shape_clears_require_file_write(tmp_path: Path) -> None:
     )
     decl = PermissionDecl()  # empty — no per-path declaration
     # Must NOT raise: config grant covers the write-class kind.
-    resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+    await resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
 
 
-def test_nested_glob_shape_does_not_clear_require_file_write(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_nested_glob_shape_does_not_clear_require_file_write(tmp_path: Path) -> None:
     """Tier 2: the WRONG nested-glob shape (``file.write: {"*": allow}``)
     does NOT clear ``require_file_write`` — it raises PermissionError.
 
@@ -78,10 +80,11 @@ def test_nested_glob_shape_does_not_clear_require_file_write(tmp_path: Path) -> 
     )
     decl = PermissionDecl()
     with pytest.raises(PermissionError):
-        resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+        await resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
 
 
-def test_nested_to_string_shape_also_clears(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_nested_to_string_shape_also_clears(tmp_path: Path) -> None:
     """Tier 2: the alternate nested-to-string shape (``file: {write: allow}``)
     also clears — documenting that the loader accepts both the flat
     dotted-key and the nested-to-string forms (but NOT the glob dict).
@@ -92,7 +95,7 @@ def test_nested_to_string_shape_also_clears(tmp_path: Path) -> None:
         interactive=False,
     )
     decl = PermissionDecl()
-    resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
+    await resolver.require_file_write(decl, _out_of_zone_path(tmp_path), "swe_bench")
 
 
 def test_example_documents_flat_file_write_allow() -> None:

--- a/tests/test_run_grant_file_write_183.py
+++ b/tests/test_run_grant_file_write_183.py
@@ -41,34 +41,37 @@ def _resolver(*, granted: bool) -> PermissionResolver:
     )
 
 
-def _can_write(resolver: PermissionResolver, path: str) -> bool:
+async def _can_write(resolver: PermissionResolver, path: str) -> bool:
     sandbox = SandboxPolicy(write_paths=[_REPO])
     try:
-        resolver.require_file_write(_DECL, path, "swe_bench", sandbox_policy=sandbox)
+        await resolver.require_file_write(_DECL, path, "swe_bench", sandbox_policy=sandbox)
         return True
     except PermissionError:
         return False
 
 
-def test_grant_allows_in_repo_write() -> None:
+@pytest.mark.asyncio
+async def test_grant_allows_in_repo_write() -> None:
     """Tier 2: grant + sandbox[repo] → an in-repo write is allowed (apply can edit)."""
-    assert _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
+    assert await _can_write(_resolver(granted=True), f"{_REPO}/astropy/io/ascii/html.py") is True
 
 
-def test_grant_still_denies_outside_sandbox_zone() -> None:
+@pytest.mark.asyncio
+async def test_grant_still_denies_outside_sandbox_zone() -> None:
     """Tier 2: the SandboxLayer ∩ scopes the grant — a write OUTSIDE write_paths
     (e.g. /etc) is DENIED even with the resolver grant. This is the scoping that
     makes the blanket resolver-`allow` safe: scope comes from the sandbox, not a
     (non-functional) scoped resolver config."""
-    assert _can_write(_resolver(granted=True), "/etc/passwd") is False
+    assert await _can_write(_resolver(granted=True), "/etc/passwd") is False
 
 
-def test_no_grant_denies_in_repo_write() -> None:
+@pytest.mark.asyncio
+async def test_no_grant_denies_in_repo_write() -> None:
     """Tier 2: opt-out (flag absent → no grant) → even an in-repo write is DENIED.
 
     This is the #183 bug the flag fixes: a declared-but-not-granted file.write in
     a non-interactive run. Falsification pair for the grant test above."""
-    assert _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
+    assert await _can_write(_resolver(granted=False), f"{_REPO}/astropy/io/ascii/html.py") is False
 
 
 def test_run_parser_exposes_grant_file_write_flag() -> None:

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -156,19 +156,20 @@ def test_factory_threads_holder_to_build_scoped_chat_session():
 # ---------------------------------------------------------------------------
 
 
-def _web_can_write(target: str, sandbox: "SandboxPolicy", *, grant: bool, ws) -> bool:
+async def _web_can_write(target: str, sandbox: "SandboxPolicy", *, grant: bool, ws) -> bool:
     """Build the REAL web `_get_perm_resolver()` under the holder and check
     whether ``require_file_write`` permits ``target`` (no None resolver)."""
     with cli_scoped_overrides(CliScopedOverrides(grant_file_write=grant, workspace_base_dir=ws)):
         resolver = deps._get_perm_resolver()
         try:
-            resolver.require_file_write(PermissionDecl(), target, "default", sandbox_policy=sandbox)
+            await resolver.require_file_write(PermissionDecl(), target, "default", sandbox_policy=sandbox)
             return True
         except PermissionError:
             return False
 
 
-def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
     """Tier 2: R1 — the --grant-file-write holder flag ACTUALLY gates file.write
     on the REAL web perm resolver. Differential (the falsification pair):
     grant=True allows an in-repo write, grant=False denies it. Not a string-grep."""
@@ -177,11 +178,12 @@ def test_grant_file_write_gates_real_in_repo_write(tmp_path, monkeypatch):
     repo = tmp_path / "container_repo"
     sandbox = SandboxPolicy(write_paths=[str(repo)])
     target = str(repo / "src" / "x.py")
-    assert _web_can_write(target, sandbox, grant=True, ws=repo) is True
-    assert _web_can_write(target, sandbox, grant=False, ws=repo) is False
+    assert await _web_can_write(target, sandbox, grant=True, ws=repo) is True
+    assert await _web_can_write(target, sandbox, grant=False, ws=repo) is False
 
 
-def test_file_zone_root_from_holder_anchors_default_zone(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_file_zone_root_from_holder_anchors_default_zone(tmp_path, monkeypatch):
     """Tier 2: R1 — file_zone_root receives the holder's container repo root
     (#1414) at RUNTIME. Differential (no grant): a write into <repo>/.reyn (the
     default write zone anchored on file_zone_root) is allowed when ws_base_dir=
@@ -191,5 +193,5 @@ def test_file_zone_root_from_holder_anchors_default_zone(tmp_path, monkeypatch):
     repo = tmp_path / "container_repo"
     sandbox = SandboxPolicy(write_paths=[str(repo)])
     default_zone_target = str(repo / ".reyn" / "x.yaml")
-    assert _web_can_write(default_zone_target, sandbox, grant=False, ws=repo) is True
-    assert _web_can_write(default_zone_target, sandbox, grant=False, ws=None) is False
+    assert await _web_can_write(default_zone_target, sandbox, grant=False, ws=repo) is True
+    assert await _web_can_write(default_zone_target, sandbox, grant=False, ws=None) is False


### PR DESCRIPTION
**[e2e-coder]** — #1505 PR-A implementation

## Summary

- `require_file_write` and `require_file_read` were sync and hard-denied any path outside the default zone. This PR async-ifies both and wires in the JIT prompt mechanism (`_prompt_file_access`), mirroring the existing `require_http_get` pattern (#1022, FP-0022).
- Adds `bus: RequestBus | None` parameter to both gates; wires `bus=ctx.intervention_bus` in `op_runtime/file.py` (the LLM-driven file handler). Five other call sites in `op_runtime/` + `tools/` write exclusively to `.reyn/` (default zone) and receive `bus=None`.
- Adds config `file.read: deny` / `file.write: deny` support (first check, overrides even the default zone).

**Symmetric gate inventory (9 gates audited):**
| Gate | State |
|---|---|
| `require_file_read` | async-ified (this PR) |
| `require_file_write` | async-ified (this PR) |
| `require_http_get` | already async+JIT (unchanged) |
| `require_mcp` | already async+JIT (unchanged) |
| `require_python` | already async+JIT (unchanged) |
| `require_tool` | already async+JIT (unchanged) |
| `require_media_load` | already async+JIT (unchanged) |
| `require_web_fetch` | already async+JIT (unchanged) |
| `require_secret_write` | intentionally excluded — no default-zone analogy; JIT ask on undeclared secrets is a coercion attack surface (deny-on-undeclared is correct) |

## Behaviour

| Path | bus | Result |
|---|---|---|
| `.reyn/` write | any | passes silently (default zone) |
| `./` read | any | passes silently (default zone) |
| outside zone | `bus` provided | JIT prompt; JUST_PATH persists via `session_approve_path` |
| outside zone | `bus=None` | PermissionError (eval / CI / non-interactive) |
| any | config `file.write: deny` / `file.read: deny` | PermissionError (config overrides zone) |

## Files changed

- `src/reyn/permissions/permissions.py` — async + `bus` + config deny + JIT ask
- `src/reyn/op_runtime/file.py` — `await` + `bus=ctx.intervention_bus`
- `src/reyn/op_runtime/{index_drop,index_query,mcp_drop_server,mcp_install}.py`, `src/reyn/tools/{cron,mcp_verbs}.py` — mechanical `await`, `bus=None`
- `tests/test_require_file_jit_ask_1505.py` — 11 new Tier-2 contract tests
- 9 existing test files — converted sync `require_file_*` calls to async

## Test plan

- [x] `pytest tests/test_require_file_jit_ask_1505.py` — 11 new Tier-2 tests pass
- [x] Full `pytest -q` from rootdir — 7027 passed, 2 known pre-existing failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path_returns_inline_content`)
- [x] `ruff check .` — 0 errors
- [x] `scripts/test_tier_audit.py --strict` on all 10 changed test files — 84 tests, 0 Tier-4 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)