### PR TITLE
docs(#1512): Direction-B impl-ahead doc additions

### DIFF
--- a/docs/concepts/architecture/architecture.md
+++ b/docs/concepts/architecture/architecture.md
@@ -226,7 +226,7 @@ layers, each owning one depth-level of skill execution:
 
 | Layer | Module | Responsibility |
 |---|---|---|
-| 1 (top) | `run_orchestrator.py` *(planned, Component D)* | Phase sequence + transitions + rollback + lifecycle |
+| 1 (top) | `run_orchestrator.py` | Phase sequence + transitions + rollback + lifecycle |
 | 2 | `phase_executor.py` | Act/decide loop for one phase + retry |
 | 3 | `llm_call_recorder.py` | One LLM call + WAL recording + budget enforcement |
 | state | `run_state.py` | Mutable run-scope state threaded through layers 1-3 |

--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -33,6 +33,8 @@ Chat-specific flags:
 | `--banner` | off | Show the ASCII-art startup banner (gradient REYN logo + agent / model info). |
 | `--eager-embedding-build` | off | Await action embedding index build synchronously on the first turn (pays ~2–5 s once so `search_actions` is immediately available). |
 | `--allow-unsafe-python` | off | Enable `mode: unsafe` Python preprocessor steps. `--allow-untrusted-python` is a legacy alias. |
+| `--grant-file-write` | off | Grant `file.read`/`file.write` at the resolver layer for this session, scoped to the sandbox write zone. For non-interactive/scripted use — when you know the agent will need to edit the working tree and want to avoid the per-skill permission prompt. |
+| `--exclude-tools NAMES` | — | Comma-separated tool names to hide from the agent's LLM-visible catalog (e.g. `web__search,web__fetch`). The tools still exist and still run if the agent calls them by name; they are just not offered to the model's discovery surface this session. |
 | `--connect <WS_URL>` | off | Connect to a remote `reyn web` server over WebSocket (e.g. `--connect ws://localhost:8080`). The positional `agent_name` selects which agent on the server. Requires `pip install reyn[web]`. Right panel features that need local file access render in "remote — limited" v1 mode. |
 
 ## Agent workspace

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -35,6 +35,7 @@ reyn run [OPTIONS] [SKILL] [INPUT]
 | `--events` | Print the full event log after execution. |
 | `--strict` | Enforce required fields at every nesting depth (default: top-level only). |
 | `--allow-unsafe-python` | Enable unsafe-mode Python preprocessor steps (no AST sandbox). `--allow-untrusted-python` is a legacy alias for backwards compatibility. |
+| `--grant-file-write` | Grant `file.write` at the resolver layer, bounded by the sandbox write zone. Enables editing the working tree in a single `reyn run` invocation without a per-skill approval prompt. |
 
 ## Examples
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -271,6 +271,30 @@ plan:
 | `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older step_results are compacted. `null` derives the threshold from `ComputedBudgets` (= `step_results_ratio × main_pool`). |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out, mirrors `chat.compaction.use_chars4_estimate`). |
 
+## `phase` block
+
+Per-phase runtime settings.
+
+```yaml
+phase:
+  act_results_compaction:
+    recent_act_turns_raw: 5
+    control_ir_results_ratio: 0.50
+    summarize_older_threshold_tokens: null
+    use_chars4_estimate: false
+```
+
+### `phase.act_results_compaction` fields
+
+Controls how the act-loop's accumulated `control_ir_results` are compacted when they approach the context budget. Sibling to `plan.step_compaction` (planner step) and `chat.compaction` (conversation history).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `recent_act_turns_raw` | int | `5` | Keep the last N act-turn results verbatim; compact older ones. Higher than `plan.step_compaction.recent_step_results_raw` (= 3) because phase ops carry specific structured data (paths, line numbers, exit codes) the LLM needs for planning next ops. |
+| `control_ir_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the `control_ir_results` portion of the act-loop context. Sibling to `chat.compaction.component_weights["body"]`. |
+| `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older results are compacted. `null` derives the threshold from `control_ir_results_ratio × main_pool` (via `ComputedBudgets`). |
+| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation (latency opt-out). |
+
 ## `web` block
 
 SSL settings for `web_fetch` and the MCP package registry.

--- a/docs/reference/runtime/context-frame.md
+++ b/docs/reference/runtime/context-frame.md
@@ -37,9 +37,19 @@ The Context Frame is the read-only payload the OS hands to the LLM at each phase
   "available_control_ops": [
     {"kind": "read_file", "description": "...", "example": { ... }}
   ],
-  "output_language": "en"
+  "output_language": "en",
+  "model": "standard",
+  "model_resolved": "openai/gpt-4o",
+  "op_catalog": [],
+  "current_datetime": "2026-06-10T12:00:00+09:00",
+  "control_ir_results": [],
+  "remaining_act_turns": 10,
+  "act_turn_reasoning": [],
+  "context_size_signal": null
 }
 ```
+
+Fields marked `(act-loop)` appear in op-loop phases. `act_turn_reasoning` and `context_size_signal` are omitted from the JSON when empty / null respectively.
 
 ## Fields
 
@@ -90,6 +100,34 @@ The set of Control IR op kinds the LLM may emit, with descriptions and examples.
 ### `output_language`
 
 Target language for natural-language output. From `reyn.yaml` or `--output-language`.
+
+### `model`, `model_resolved`
+
+`model` — the model class name (e.g. `standard`) or raw LiteLLM string configured for this phase. `model_resolved` — the resolved LiteLLM string actually used (e.g. `openai/gpt-4o`). Present for transparency; normal phases do not need to reference these.
+
+### `op_catalog`
+
+Full catalog of every Control IR op kind the OS can dispatch in this run, regardless of the current phase's `allowed_ops`. This differs from `available_control_ops` (which lists only ops allowed for the current phase). Populated for all phases but consulted only by meta-skills (`skill_builder`, `skill_improver`, `skill_importer`) that need to emit correct `allowed_ops` values in phase frontmatter they generate.
+
+### `current_datetime`
+
+ISO-8601 datetime of the phase invocation. Lets the LLM reason about time-relative instructions without external tool calls.
+
+### `control_ir_results` (act-loop)
+
+Results from Control IR ops executed on previous act-loop turns within this phase visit (file read content, ask_user answers, shell output, etc.). Empty on the first LLM call for a phase visit. Each entry is the raw result dict from the op executor.
+
+### `act_turn_reasoning` (act-loop, conditional)
+
+Inline reasoning text the model emitted on prior act-loop turns. Carried forward to maintain reasoning continuity across turns. Omitted from the JSON when empty (weak models that emit no inline content, json-mode act loop, or first turn).
+
+### `remaining_act_turns` (act-loop)
+
+How many more act turns the LLM may emit before it must produce a decide (transition/finish/abort) turn. `0` means this call is the mandatory decide turn — the LLM must not emit any ops. `null` means no act-turn cap on this phase.
+
+### `context_size_signal` (conditional)
+
+OS-injected header describing available token budget when the context window is filling. Omitted when the window is ample. When present, the LLM should prefer compact responses and avoid requesting large file reads.
 
 ## What's NOT in the frame
 

--- a/docs/reference/stdlib/skill_search.md
+++ b/docs/reference/stdlib/skill_search.md
@@ -1,0 +1,47 @@
+---
+type: reference
+topic: stdlib
+audience: [human, agent]
+applies_to: [skill_search]
+---
+
+# `skill_search`
+
+Search a public skills registry for skills relevant to a natural-language capability request.
+
+## Entry
+
+`search`
+
+## Final output
+
+`skill_candidate_list` — list of skill candidates with `name`, `source_url` (raw URL to `SKILL.md`), and `description`. Empty list when no relevant skills are found or the registry is unreachable without a cache.
+
+## How it composes
+
+A single `search` phase. A `registry_fetch.py:fetch_registry_results` preprocessor (safe mode, 30 s timeout) queries the skills registry deterministically and injects results into the artifact before the LLM call. The LLM then filters and ranks candidates by relevance to the request — it does not re-fetch anything.
+
+## Caveats
+
+- Requires `http.get` permission for `api.github.com` and `raw.githubusercontent.com` (declared in `skill.md`).
+- Registry override is not currently supported — `safe` mode disallows `os` module access, so `REYN_SKILL_REGISTRY_URL` cannot be read. The skill always uses `github.com/anthropics/skills`. To use a non-default registry, declare `mode: unsafe` or wait for the safe-mode env-var support to land.
+- Results come from the preprocessor, not LLM knowledge; if the registry is unreachable and no cache exists, the candidate list is empty.
+
+## Usage
+
+```bash
+reyn run skill_search "PDF summarization"
+reyn run skill_search "GitHub integration"
+reyn run skill_search "spreadsheet generation"
+```
+
+Pairs with `skill_importer` for the install step: the `source_url` in each candidate feeds directly into `skill_importer`.
+
+## Source
+
+[`src/reyn/stdlib/skills/skill_search/skill.md`](https://github.com/tya5/reyn/blob/main/src/reyn/stdlib/skills/skill_search/skill.md)
+
+## See also
+
+- [Reference: skill_importer](skill_importer.md) — install a skill from a registry URL
+- [Reference: direct_llm](direct_llm.md) — single-phase skill for general queries


### PR DESCRIPTION
**[tui-coder]** — Direction-B doc additions: impl has features not yet documented.

## Changes

- **`context-frame.md`**: 7 undocumented ContextFrame fields added:
  - `model`, `model_resolved` (model class + resolved LiteLLM string)
  - `op_catalog` (full catalog for meta-skills like skill_builder/skill_improver)
  - `current_datetime` (ISO-8601 at phase invocation)
  - `control_ir_results`, `act_turn_reasoning`, `remaining_act_turns` (act-loop volatile fields)
  - `context_size_signal` (token budget signal, omitted when null)
- **`reyn-yaml.md`**: new `phase` block — `phase.act_results_compaction` (`PhaseActResultsCompactionConfig`: `recent_act_turns_raw` / `control_ir_results_ratio` / `summarize_older_threshold_tokens` / `use_chars4_estimate`)
- **`chat.md`**: `--grant-file-write` and `--exclude-tools NAMES` flags (verified in `src/reyn/cli/chat.py`)
- **`run.md`**: `--grant-file-write` flag (verified in `src/reyn/cli/run.py`)
- **`architecture.md`**: removed stale `*(planned, Component D)*` from `run_orchestrator.py` row — file exists at `src/reyn/kernel/run_orchestrator.py` and is imported in `runtime.py:29`
- **`skill_search.md`**: new stdlib skill doc — preprocessor-driven registry search; env-var override (`REYN_SKILL_REGISTRY_URL`) documented as unsupported in safe mode (registry_fetch.py dropped it per FP-0042 Phase 3 drift-fix; docs-maintainer audit confirmed)

## Impl verification

All claims verified against source before documenting. No new drift introduced.

- `ContextFrame` fields: `src/reyn/models.py`
- `PhaseActResultsCompactionConfig`: `src/reyn/kernel/compaction/`
- `--grant-file-write`/`--exclude-tools`: `src/reyn/cli/chat.py`, `src/reyn/cli/run.py`
- `run_orchestrator.py` existence: `src/reyn/kernel/run_orchestrator.py` + `runtime.py:29`
- `skill_search` env-var drop: `src/reyn/stdlib/skills/skill_search/registry_fetch.py` (docs-maintainer audit)

## Test plan

- [x] (skipped — doc-only PR, no code changed)

## Tier self-check

- [x] Doc-only — no test changes, no Tier rules apply