### PR TITLE
docs: add feature-map.md cross-references to CLAUDE.md and README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ and run the checklist below before continuing:
 - **ContextFrame / Output schemas**: `src/reyn/models.py`
 - **Op catalog and dispatch**: `src/reyn/op_runtime/`
 - **LLM trace analysis**: `docs/reference/dogfood-tracing.md` — `scripts/dogfood_trace.py --mode llm-payloads` is the canonical entry point for inspecting LLM payloads; do not hand-parse JSONL.
+- **Full feature inventory**: `docs/feature-map.md` — every implemented feature grouped by subsystem, each linked to its reference/concept doc (impl-extracted; impl↔doc mirror).
 
 ## Goal
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Built with MkDocs Material; English + Japanese (translation in progress).
 | How-to | [/docs/guide/for-skill-authors/](https://tya5.github.io/reyn/docs/guide/for-skill-authors/validate-artifacts/) | [docs/guide/for-skill-authors/](docs/guide/for-skill-authors/) |
 | Reference | [/docs/reference/](https://tya5.github.io/reyn/docs/reference/cli/run/) | [docs/reference/](docs/reference/) |
 | Concepts | [/docs/concepts/](https://tya5.github.io/reyn/docs/concepts/principles/) | [docs/concepts/](docs/concepts/) |
+| Feature inventory | — | [docs/feature-map.md](docs/feature-map.md) |
 
 Build and serve locally:
 


### PR DESCRIPTION
**[e2e-coder]** — feature-map.md discovability cross-references (owner-directed, self-driven dispatch).

## Summary

- **CLAUDE.md** `## When in doubt — read these (Tier 2)` — added `docs/feature-map.md` entry as "Full feature inventory"
- **README.md** Documentation table — added Feature inventory row pointing to `docs/feature-map.md`

Link only (no content dependency); merge-order-independent with the sandbox_2 feature-map.md revision PR.

## Changed files

- `CLAUDE.md` (+1 line)
- `README.md` (+1 line)

## Test plan

- [x] `ruff check .` — passed (doc-only, no Python changes)
- [x] Pre-existing collection errors (5 tests, `ModuleNotFoundError: No module named 'tests'`) confirmed present on base `main` before this branch — not caused by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)