### PR TITLE
docs(readme): remove defensive negation on skill — present positively

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The LLM picks the chunking strategy from a closed candidate set (P4); the chunk 
 
 ### Write a reusable workflow (skill)
 
-When you want a repeatable, validated procedure rather than open-ended chat, write it as a **skill** — a typed phase graph the OS checks at every transition. This is one feature of the agent, not the headline: a minimal skill is three small files under `reyn/local/my_skill/` (an input artifact schema, a phase with instructions, and a `skill.md` graph), then run it with a natural-language goal:
+When you want a repeatable, validated procedure rather than open-ended chat, write it as a **skill** — a typed phase graph the OS checks at every transition. This is one feature of the agent: a minimal skill is three small files under `reyn/local/my_skill/` (an input artifact schema, a phase with instructions, and a `skill.md` graph), then run it with a natural-language goal:
 
 ```bash
 reyn run my_skill "Summarize AI trends in education."


### PR DESCRIPTION
**[dogfood-coder]** — owner cross-cutting review (companion to #1528). Remove the defensive negation on Skill: owner — "nobody thinks Skill is the agent's headline, so no need to assert it isn't." Present Skill positively as one of many features.

README.md:82: `This is one feature of the agent, **not the headline**:` → `This is one feature of the agent:`

Follow-up to merged #1517 (same negation appeared there). The companion #1528 removes the two JA equivalents ("headline ではない") in reyn-differentiators.md.

## Test plan
- [x] (doc-only) no code/test change
- [x] negation removed; positive framing kept
- [x] file SET = 1
- [ ] lead review → owner confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)