### PR TITLE
docs(events): replace stale 'Future checkpoint/resume' with WAL/ReplayEngine split

### DIFF
--- a/docs/concepts/runtime/events.md
+++ b/docs/concepts/runtime/events.md
@@ -15,7 +15,7 @@ There is no separate logger, tracer, or telemetry hook. The same channel powers:
 - **Live debug output.** Console reporters subscribe to the event stream and render each event as it arrives.
 - **Replay.** `reyn events <log_file>` re-renders a saved log to the console without re-invoking the LLM.
 - **Eval analytics.** Eval reports aggregate event data (token usage, phase counts, validation errors) per case.
-- **Future checkpoint/resume.** A complete event log is, by construction, a complete description of execution. Resume from N is a matter of replaying the log up to event N.
+- **Time-travel debugging and crash recovery (both implemented).** `ReplayEngine` provides read-only step-by-step inspection of any past run. Crash recovery uses the WAL (`.reyn/state/wal.jsonl`) as its substrate — not the audit log. User-facing rewind/resume (PITR + global rewind) is a separate design tracked in [#1533](https://github.com/tya5/reyn/issues/1533).
 
 If the OS is the only mutator (P3) and every mutation emits an event, the log is sufficient. There's no "what else happened" to chase down.
 


### PR DESCRIPTION
**[docs-maintainer]** — events.md L18 stale "Future" 表記の修正。

## Summary

- `docs/concepts/runtime/events.md` L18 の「Future checkpoint/resume」bullet を実態に合わせて更新。
- `ReplayEngine` による time-travel debugging（read-only inspect）と WAL による crash recovery は共に実装済み。
- 旧表記は audit event log を resume substrate と混同していた（conflation 除去）。crash recovery は EventStore ではなく WAL (`.reyn/state/wal.jsonl`) を substrate とする。
- User-facing rewind/resume（PITR + global rewind）の包括設計は #1533 へ参照リンク。

## Changed files

- `docs/concepts/runtime/events.md` — 1行変更

## Test plan

- [x] 1行のみ変更確認済み
- [x] Page drop ゼロ
- [ ] lead-coder review

🤖 Generated with [Claude Code](https://claude.com/claude-code)