### PR TITLE
feat(1533): Stage 1a — snapshot generations + PITR reconstruct(N) foundation

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -25,12 +25,13 @@ Architecture choice (= per the design doc):
     that narrows the tool catalogue to the step's allowed tools and
     swaps the system prompt for a step-specific template. The phase
     LLM caller is untouched; we don't introduce a third caller.
-  - **No skill abstraction reuse for MVP.** Plan is transient (= one
-    chat turn), not persistable. Lifting plan onto skills (= plan as
-    stdlib skill, persisted via skill_resume infra) is a later
-    migration when resume / replay become hard requirements.
-  - **In-memory plan artifact.** No workspace persistence in MVP.
-    Plan steps emit ``plan_*`` events for audit (= P6).
+  - **Plan not on the skill abstraction.** Plan does not reuse the skill
+    machinery; lifting plan onto skills (= plan as stdlib skill) remains a
+    possible later migration.
+  - **Plan artifact is workspace-persisted (since ADR-0023 Phase 2).** The
+    original MVP kept the plan in-memory only; ADR-0023 promoted it to a
+    workspace-persisted decomposition (``write_plan_decomposition``, P5 SSoT)
+    with crash-resume via ``PlanSnapshot`` + ``plan_*`` WAL / audit events (P6).
 
 P7-clean: this module contains no skill-specific strings. Step names
 and descriptions come entirely from the LLM-emitted plan; the OS only

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -1,0 +1,119 @@
+"""Snapshot generations + PITR reconstruct (ADR-0038 Stage 1a).
+
+A :class:`SnapshotGenerationStore` retains full :class:`AgentSnapshot`
+generations keyed by the boundary WAL ``seq`` at which each was cut (turn /
+plan-step / phase). Point-in-time reconstruction of any seq ``N`` is then:
+
+    reconstruct(N) = nearest generation with applied_seq <= N
+                     + forward-replay of WAL entries in (gen.applied_seq, N]
+
+via :meth:`AgentSnapshot.apply_events`. Crash recovery is the special case
+``reconstruct(head)``.
+
+Generations are **additive** to the existing single ``snapshot.json`` (Stage 1a
+introduces no behavior change): the most-recent generation equals the current
+snapshot. Each generation is a full snapshot (ADR-0038 D1 — full, not delta),
+written atomically with the same tmp→fsync→rename discipline as
+``AgentSnapshot.save``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+_GEN_RE = re.compile(r"^gen-(\d+)\.json$")
+
+
+class SnapshotGenerationStore:
+    """Directory of full ``AgentSnapshot`` generations keyed by boundary seq.
+
+    Layout: ``<generations_dir>/gen-<seq>.json`` — one full snapshot per
+    boundary. Reuses ``AgentSnapshot.save``/``load`` (atomic write, schema
+    versioned).
+    """
+
+    def __init__(self, agent_name: str, generations_dir: Path) -> None:
+        self._agent_name = agent_name
+        self._dir = Path(generations_dir)
+
+    def _path_for(self, seq: int) -> Path:
+        return self._dir / f"gen-{seq}.json"
+
+    def record(self, snapshot: AgentSnapshot) -> Path:
+        """Persist ``snapshot`` as the generation at ``snapshot.applied_seq``.
+
+        Idempotent for a given seq (re-recording overwrites atomically). The
+        seq key is the snapshot's ``applied_seq`` — the boundary at which the
+        generation was cut.
+        """
+        path = self._path_for(snapshot.applied_seq)
+        snapshot.save(path)  # tmp → fsync → rename
+        return path
+
+    def seqs(self) -> list[int]:
+        """Sorted list of generation boundary seqs present on disk."""
+        if not self._dir.is_dir():
+            return []
+        out: list[int] = []
+        for child in self._dir.iterdir():
+            m = _GEN_RE.match(child.name)
+            if m:
+                out.append(int(m.group(1)))
+        out.sort()
+        return out
+
+    def nearest_at_or_below(self, n: int) -> int | None:
+        """Highest generation seq ``<= n``, or ``None`` if there is none."""
+        candidates = [s for s in self.seqs() if s <= n]
+        return candidates[-1] if candidates else None
+
+    def load(self, seq: int) -> AgentSnapshot:
+        """Load the generation at ``seq`` (raises if absent / schema-mismatch)."""
+        return AgentSnapshot.load(self._agent_name, self._path_for(seq))
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Drop generations with seq < ``min_keep_seq``. Returns count dropped.
+
+        Used by the retention policy (ADR-0038 D5, Stage 1e) to GC generations
+        outside the coarse retention window. Stage 1a ships the primitive;
+        wiring lands with the retention policy.
+        """
+        dropped = 0
+        for s in self.seqs():
+            if s < min_keep_seq:
+                self._path_for(s).unlink(missing_ok=True)
+                dropped += 1
+        return dropped
+
+
+def reconstruct(
+    agent_name: str,
+    store: SnapshotGenerationStore,
+    state_log: StateLog,
+    target_seq: int,
+) -> AgentSnapshot:
+    """Reconstruct ``agent_name``'s state as-of WAL ``target_seq`` (PITR).
+
+    = nearest generation ``<= target_seq`` (or empty if none) + forward-replay
+    of WAL entries in ``(base.applied_seq, target_seq]``. The returned
+    snapshot's ``applied_seq`` is the highest seq ``<= target_seq`` whose effects
+    affected this agent (``<= target_seq`` always).
+
+    Crash recovery is ``reconstruct(head)`` where ``head = state_log.current_seq``.
+    """
+    base_seq = store.nearest_at_or_below(target_seq)
+    base = store.load(base_seq) if base_seq is not None else AgentSnapshot.empty(agent_name)
+
+    # Forward-replay the WAL delta, bounded above by target_seq. apply_events
+    # already skips seq <= base.applied_seq; we additionally cap at target_seq so
+    # reconstruction is point-in-time, not head.
+    delta = [
+        entry
+        for entry in state_log.iter_from(base.applied_seq + 1)
+        if isinstance(entry.get("seq"), int) and entry["seq"] <= target_seq
+    ]
+    base.apply_events(delta)
+    return base

--- a/tests/test_snapshot_generations.py
+++ b/tests/test_snapshot_generations.py
@@ -1,0 +1,117 @@
+"""Tier 2: OS invariant — PITR reconstruct(N) equals a full WAL replay to N.
+
+ADR-0038 Stage 1a. Real `StateLog` + real `AgentSnapshot` (no mocks): the
+generation store + `reconstruct` must rebuild the exact same state whether it
+starts from a snapshot generation or from empty + full WAL. Crash recovery is
+the `reconstruct(head)` special case.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.events.state_log import StateLog
+
+AGENT = "alpha"
+
+
+async def _build_wal(tmp_path: Path) -> StateLog:
+    """A WAL exercising several agent-affecting kinds for AGENT (+ noise)."""
+    log = StateLog(tmp_path / "state.wal")
+    await log.append("inbox_put", target=AGENT, msg_id="m1", msg_kind="user",
+                     payload={"text": "a"})            # seq 1
+    await log.append("inbox_put", target="other", msg_id="x1", msg_kind="user",
+                     payload={})                        # seq 2 (different agent)
+    await log.append("chain_register", agent=AGENT, chain_id="c1",
+                     origin_agent=AGENT, origin_depth=0,
+                     original_request="r", waiting_on=["beta"])  # seq 3
+    await log.append("inbox_put", target=AGENT, msg_id="m2", msg_kind="user",
+                     payload={"text": "b"})            # seq 4
+    await log.append("inbox_consume", target=AGENT, msg_id="m1")  # seq 5
+    await log.append("chain_resolve", agent=AGENT, chain_id="c1")  # seq 6
+    return log
+
+
+def _full_replay(log: StateLog, target_seq: int) -> AgentSnapshot:
+    """Ground truth: empty snapshot + every WAL entry with seq <= target_seq."""
+    snap = AgentSnapshot.empty(AGENT)
+    snap.apply_events(
+        [e for e in log.iter_from(1)
+         if isinstance(e.get("seq"), int) and e["seq"] <= target_seq]
+    )
+    return snap
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_matches_full_replay_at_every_seq(tmp_path):
+    """Tier 2: for every target N, reconstruct(N) == full-replay-to-N.
+
+    Generations are cut at boundary seqs 1 and 4; reconstruct must agree with a
+    from-empty replay regardless of which generation it bases on.
+    """
+    log = await _build_wal(tmp_path)
+    store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
+    # Cut generations at two boundaries (full replays to those seqs).
+    store.record(_full_replay(log, 1))
+    store.record(_full_replay(log, 4))
+
+    for n in range(0, 7):
+        got = reconstruct(AGENT, store, log, n)
+        expected = _full_replay(log, n)
+        assert got == expected, f"reconstruct({n}) diverged from full replay"
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_head_is_crash_recovery(tmp_path):
+    """Tier 2: reconstruct(head) == full replay to current_seq (crash recovery)."""
+    log = await _build_wal(tmp_path)
+    store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
+    store.record(_full_replay(log, 4))
+    head = log.current_seq
+    assert reconstruct(AGENT, store, log, head) == _full_replay(log, head)
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_with_no_generations_uses_empty_base(tmp_path):
+    """Tier 2: empty store ⇒ reconstruct replays from empty + full WAL delta."""
+    log = await _build_wal(tmp_path)
+    store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
+    assert store.seqs() == []
+    head = log.current_seq
+    assert reconstruct(AGENT, store, log, head) == _full_replay(log, head)
+
+
+@pytest.mark.asyncio
+async def test_generation_base_is_used_not_just_empty(tmp_path):
+    """Tier 2: a generation at seq 4 is the base for reconstruct(5).
+
+    Recording a generation whose applied_seq is 4 must make it the
+    `nearest_at_or_below(5)` base — and the result still matches full replay.
+    """
+    log = await _build_wal(tmp_path)
+    store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
+    store.record(_full_replay(log, 1))
+    store.record(_full_replay(log, 4))
+    assert store.nearest_at_or_below(5) == 4
+    assert store.nearest_at_or_below(3) == 1
+    assert store.nearest_at_or_below(0) is None
+    assert reconstruct(AGENT, store, log, 5) == _full_replay(log, 5)
+
+
+@pytest.mark.asyncio
+async def test_prune_below_drops_old_generations(tmp_path):
+    """Tier 2: prune_below GCs generations below the floor (retention primitive)."""
+    log = await _build_wal(tmp_path)
+    store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
+    store.record(_full_replay(log, 1))
+    store.record(_full_replay(log, 4))
+    store.record(_full_replay(log, 6))
+    assert store.seqs() == [1, 4, 6]
+    dropped = store.prune_below(4)
+    assert dropped == 1
+    assert store.seqs() == [4, 6]
+    # Surviving generations still reconstruct correctly.
+    assert reconstruct(AGENT, store, log, 6) == _full_replay(log, 6)


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Phase 1, **Stage 1a (first increment)**. Additive, **NO behavior change** — the PITR foundation that later stages build on. Per-stage reviewable; keystone (reset-record honor) is isolated in Stage 1b.

## What
- **`SnapshotGenerationStore`** (`events/snapshot_generations.py`): retains **full** AgentSnapshot generations keyed by boundary seq (`gen-<seq>.json`, atomic write reusing `AgentSnapshot.save`). API: `record` / `seqs` / `nearest_at_or_below` / `load` / `prune_below` (retention primitive, wired in Stage 1e).
- **`reconstruct(name, store, state_log, target_seq)`**: PITR = nearest generation `<= N` (or empty) + forward-replay of WAL entries in `(base.applied_seq, N]` via the existing `AgentSnapshot.apply_events`. **Crash recovery = `reconstruct(head)` special case** (matches the ADR D1 unification).
- **planner.py doc-fix**: the stale `:32` "in-memory plan artifact / no workspace persistence in MVP" comment (docs-maintainer-confirmed stale) → ADR-0023 Phase 2 persists the decomposition.

## Why this scope
SnapshotJournal persists a *single* `snapshot.json` on every state change; generations need coarser **boundary** cuts. This PR lands the **machinery** (store + reconstruct) as an independently-testable, no-behavior-change unit. The **boundary-recording wiring** (cut a generation at turn/plan-step/phase boundaries) + routing `restore_all` through `reconstruct(head)` is the **next 1a increment** — kept separate so this PR stays tight.

## Tests (Tier 2, real instances, no mocks)
`reconstruct(N) == full-replay-to-N` at every seq · `reconstruct(head)` = crash recovery · empty-store base · generation-as-base (`nearest_at_or_below`) · `prune_below`. **5 passed.** ruff clean.

## Test plan
- [x] PITR invariant: reconstruct(N) == full replay to N (real StateLog + AgentSnapshot)
- [x] reconstruct(head) == current crash-recovery semantics
- [x] no behavior change (additive module; existing snapshot.json path untouched)
- [x] ruff clean
- [ ] lead per-stage review → merge → Stage 1a part-2 (boundary recording + restore_all unify), then Stage 1b (keystone — approach to be shared first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)