### PR TITLE
feat(1533): Stage 1a part-2 — boundary generation-recording (single journal seam)

### DIFF
--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -9,6 +9,7 @@ import uuid
 from pathlib import Path
 
 from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import SnapshotGenerationStore
 from reyn.events.state_log import StateLog
 
 
@@ -37,11 +38,28 @@ class SnapshotJournal:
         agent_name: str,
         snapshot_path: Path,
         state_log: StateLog | None,
+        generation_store: SnapshotGenerationStore | None = None,
     ) -> None:
         self._agent_name = agent_name
         self._snapshot_path = Path(snapshot_path)
         self._state_log = state_log
+        # ADR-0038 Stage 1a: PITR generation store. When None (tests /
+        # non-chat), generation cuts are no-ops and the single snapshot.json
+        # path is unchanged (no behavior change).
+        self._generation_store = generation_store
         self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name)
+
+    def cut_generation(self) -> None:
+        """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a).
+
+        Called at user-facing checkpoint boundaries (turn / plan-step) — a
+        single seam so cuts are neither missed nor doubled. Additive to the
+        per-mutation ``save()``; the latest generation equals the current
+        snapshot. No-op when no generation store / WAL is configured.
+        """
+        if self._generation_store is None or self._state_log is None:
+            return
+        self._generation_store.record(self._snapshot)
 
     # ── public read access ────────────────────────────────────────────────
 
@@ -361,6 +379,8 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self.save()
+        # ADR-0038 Stage 1a: plan-step boundary = a user-facing checkpoint.
+        self.cut_generation()
         return seq
 
     async def record_plan_step_failed(

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -53,6 +53,7 @@ from reyn.config import (  # noqa: F401
 from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.event_store import EventStore
 from reyn.events.events import EventLog
+from reyn.events.snapshot_generations import SnapshotGenerationStore
 from reyn.events.state_log import StateLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.permissions.permissions import PermissionResolver
@@ -1488,10 +1489,15 @@ class ChatSession:
         self._snapshot_path = snapshot_path or (
             Path(".reyn") / "agents" / self.agent_name / "state" / "snapshot.json"
         )
+        # ADR-0038 Stage 1a: PITR generation store, kept beside snapshot.json.
+        self._generation_store = SnapshotGenerationStore(
+            self.agent_name, self._snapshot_path.parent / "generations",
+        )
         self._journal = SnapshotJournal(
             agent_name=self.agent_name,
             snapshot_path=self._snapshot_path,
             state_log=state_log,
+            generation_store=self._generation_store,
         )
         # Track state_log directly for skill resume (PR-skill-resume): the
         # journal owns it for inbox / chain mutations, but skills launched
@@ -4886,6 +4892,8 @@ class ChatSession:
     ) -> None:
         """Forwarding → RouterLoopDriver.run_turn (PR-3)."""
         await self._loop_driver.run_turn(user_text, chain_id)
+        # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint.
+        self._journal.cut_generation()
 
     async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
         """Forwarding → RouterLoopDriver._run_with_shrink (PR-3)."""

--- a/tests/test_snapshot_generation_recording.py
+++ b/tests/test_snapshot_generation_recording.py
@@ -60,7 +60,7 @@ async def test_plan_step_boundary_cuts_generation(tmp_path):
 
 @pytest.mark.asyncio
 async def test_reconstruct_head_equals_live_snapshot(tmp_path):
-    """Tier 2 (parity): reconstruct(head) from the store == the live snapshot.
+    """Tier 2: reconstruct(head) from the store == the live snapshot (parity).
 
     A generation is cut, then more state lands past it; reconstructing head must
     fold the post-generation WAL delta back to exactly the live snapshot — the

--- a/tests/test_snapshot_generation_recording.py
+++ b/tests/test_snapshot_generation_recording.py
@@ -1,0 +1,88 @@
+"""Tier 2: SnapshotJournal cuts PITR generations at boundaries (single seam).
+
+ADR-0038 Stage 1a part-2. Real `SnapshotJournal` + `StateLog` +
+`SnapshotGenerationStore` (no mocks): generation cuts happen only at the
+boundary seams (turn via `cut_generation`, plan-step via
+`record_plan_step_completed`), the latest generation equals the live snapshot,
+and `reconstruct(head)` from the store reproduces the live snapshot (the
+invariant crash recovery relies on). Absent a store, cuts are a no-op (no
+behavior change to the single ``snapshot.json`` path).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.services.snapshot_journal import SnapshotJournal
+from reyn.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.events.state_log import StateLog
+
+AGENT = "alpha"
+
+
+def _journal(tmp_path: Path, *, with_store: bool = True):
+    log = StateLog(tmp_path / "state.wal")
+    store = (
+        SnapshotGenerationStore(AGENT, tmp_path / "generations")
+        if with_store else None
+    )
+    journal = SnapshotJournal(
+        agent_name=AGENT,
+        snapshot_path=tmp_path / "snapshot.json",
+        state_log=log,
+        generation_store=store,
+    )
+    return log, store, journal
+
+
+@pytest.mark.asyncio
+async def test_cut_generation_records_current_snapshot(tmp_path):
+    """Tier 2: cut_generation() records exactly the current snapshot as a gen."""
+    log, store, journal = _journal(tmp_path)
+    await journal.append_inbox(kind="user", payload={"text": "hi"})
+    assert store.seqs() == []          # state change alone does not cut
+    journal.cut_generation()           # turn boundary
+    seq = journal.snapshot.applied_seq
+    assert store.seqs() == [seq]
+    assert store.load(seq) == journal.snapshot
+
+
+@pytest.mark.asyncio
+async def test_plan_step_boundary_cuts_generation(tmp_path):
+    """Tier 2: record_plan_step_completed cuts a generation at the step boundary."""
+    log, store, journal = _journal(tmp_path)
+    await journal.record_plan_step_completed(
+        plan_id="p1", step_id="s1", content_len=5,
+    )
+    assert journal.snapshot.applied_seq in store.seqs()
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_head_equals_live_snapshot(tmp_path):
+    """Tier 2 (parity): reconstruct(head) from the store == the live snapshot.
+
+    A generation is cut, then more state lands past it; reconstructing head must
+    fold the post-generation WAL delta back to exactly the live snapshot — the
+    crash-recovery invariant (reconstruct(head)).
+    """
+    log, store, journal = _journal(tmp_path)
+    await journal.append_inbox(kind="user", payload={"text": "a"})
+    journal.cut_generation()
+    await journal.append_inbox(kind="user", payload={"text": "b"})  # past the gen
+    rebuilt = reconstruct(AGENT, store, log, log.current_seq)
+    assert rebuilt == journal.snapshot
+
+
+@pytest.mark.asyncio
+async def test_no_store_is_noop_no_behavior_change(tmp_path):
+    """Tier 2: without a generation store, cut_generation is a no-op.
+
+    The single ``snapshot.json`` path is unchanged (no behavior change) — this
+    is the tests / non-chat configuration.
+    """
+    log, store, journal = _journal(tmp_path, with_store=False)
+    assert store is None
+    await journal.append_inbox(kind="user", payload={"text": "x"})
+    journal.cut_generation()  # must not raise
+    assert (tmp_path / "snapshot.json").is_file()


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Phase 1, **Stage 1a part-2**. Additive, **NO behavior change**. Builds on the merged part-1 PITR foundation (#1537). Scoping approved by lead (turn + plan-step cuts + parity; phase deferred + tracked).

## What — single journal seam (no scatter)
PITR generations are cut at user-facing checkpoint boundaries through **one** seam in `SnapshotJournal` (lead steer: generation-cut is a persistence concern → belongs in the journal):
- **`SnapshotJournal.cut_generation()`** — records the current snapshot as a generation; gets an optional `generation_store` (None ⇒ no-op, single `snapshot.json` path unchanged).
- **plan-step boundary**: cut inside `record_plan_step_completed` (journal-internal).
- **turn boundary**: `ChatSession` constructs the store (beside `snapshot.json`) + calls `cut_generation()` after `RouterLoopDriver.run_turn` returns — the session owns the journal, so it's a single session→journal call (no orchestrator scatter).

## Deferred (tracked in #1533): phase-boundary cut
`phase_completed` is a **kernel** event that doesn't reach the chat journal; the chat `forwarder.on_phase_completed` is **display-only** (routing a cut there would mix display↔persistence). Routing the kernel phase event → chat journal needs its own cross-layer plumbing design → own increment (also ADR-D6-Phase-2-adjacent / finer-than-user-facing). Full rationale + scope-when-picked-up in [#1533 comment](https://github.com/tya5/reyn/issues/1533#issuecomment-4696888558).

## Tests (Tier 2, real journal + StateLog + store, no mocks)
cut records the current snapshot · plan-step boundary cuts · **reconstruct(head) == live snapshot** (crash-recovery parity) · no-store no-op. **9 generation tests pass; 16 existing journal/session/resume tests unchanged** (no regression).

## Test plan
- [x] generations cut only at boundary seams (turn / plan-step), not per-state-change
- [x] reconstruct(head) from the store == live snapshot (the crash-recovery invariant)
- [x] no behavior change: no-store ⇒ no-op; single snapshot.json path untouched; existing resume tests green
- [x] ruff clean
- [ ] lead per-stage review → merge → Stage 1b (reset-record-honor keystone — approach shared first, nested + crash-mid-rewind test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)