### PR TITLE
feat(1533): Stage 1b keystone — rewind reset-record + active-pointer honor

### DIFF
--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -89,31 +89,130 @@ class SnapshotGenerationStore:
         return dropped
 
 
+# ── rewind / branch model (ADR-0038 Stage 1b — keystone) ────────────────────
+
+REWIND_KIND = "rewind"
+
+
+class RewindIntoAbandonedError(Exception):
+    """Phase-1 rewind target is on an abandoned branch.
+
+    Phase-1 undo moves HEAD along the *active* timeline. Targeting a seq inside
+    an abandoned segment means switching to an abandoned branch — that is a
+    Phase-2 *fork* (branch checkout), not Phase-1 undo, so it is rejected with a
+    decision-enabling message.
+    """
+
+
+def _rewind_records(state_log: StateLog) -> list[tuple[int, int]]:
+    """All rewind reset-records as ``(R, target_n)`` (R = the record's own seq)."""
+    out: list[tuple[int, int]] = []
+    for e in state_log.iter_from(1):
+        if e.get("kind") == REWIND_KIND and isinstance(e.get("seq"), int):
+            out.append((e["seq"], int(e["target_n"])))
+    return out
+
+
+def _abandoned_intervals(rewinds: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Open intervals ``(target_n, R)`` abandoned by the rewind chain.
+
+    Resolved **latest-first** (descending by R): a rewind ``(R, N)`` abandons
+    ``(N, R)`` *unless* ``R`` itself is already abandoned by a later rewind — i.e.
+    the rewind sits on an already-abandoned branch, so its undo is moot. With the
+    Phase-1 active-target guard, each rewind targets a then-active seq, so the
+    composition is well-defined (subsuming and partial nesting both fall out).
+    """
+    abandoned: list[tuple[int, int]] = []
+
+    def _is_abandoned(s: int) -> bool:
+        return any(lo < s < hi for (lo, hi) in abandoned)
+
+    for (R, N) in sorted(rewinds, key=lambda t: t[0], reverse=True):
+        if _is_abandoned(R):
+            continue
+        abandoned.append((N, R))
+    return abandoned
+
+
+def _make_is_active(abandoned: list[tuple[int, int]]):
+    def is_active(seq: int) -> bool:
+        return not any(lo < seq < hi for (lo, hi) in abandoned)
+    return is_active
+
+
+def is_active_seq(state_log: StateLog, seq: int) -> bool:
+    """True if ``seq`` is on the current active branch (not in any abandoned segment)."""
+    return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)
+
+
+async def rewind(
+    state_log: StateLog, *, target_n: int, supersedes: int | None = None,
+) -> int:
+    """Append a rewind reset-record after validating ``target_n`` is active (Phase 1).
+
+    Append-only: the abandoned future is retained as an inactive branch (P6 /
+    WAL stay append-only); reconstruction honors the active pointer. The
+    reset-record is fsync'd by ``StateLog.append`` *before* any reconstruction —
+    the crash-mid-rewind idempotence keystone.
+
+    ``supersedes`` is **audit-only** (records the prior active pointer for the
+    branch-tree audit trail); ``is_active`` derivation walks all rewind records and
+    does not depend on it.
+
+    Raises ``RewindIntoAbandonedError`` when ``target_n`` is on an abandoned branch.
+    """
+    is_active = _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
+    if not is_active(target_n):
+        raise RewindIntoAbandonedError(
+            f"rewind target seq {target_n} is on an abandoned branch — switching "
+            "to an abandoned branch is a Phase-2 fork, not supported by Phase-1 "
+            "undo. Rewind only to a seq on the active timeline."
+        )
+    return await state_log.append(
+        REWIND_KIND, target_n=int(target_n), supersedes=supersedes,
+    )
+
+
 def reconstruct(
     agent_name: str,
     store: SnapshotGenerationStore,
     state_log: StateLog,
     target_seq: int,
 ) -> AgentSnapshot:
-    """Reconstruct ``agent_name``'s state as-of WAL ``target_seq`` (PITR).
+    """Reconstruct ``agent_name``'s state as-of WAL ``target_seq`` (PITR), on the
+    **active branch**.
 
-    = nearest generation ``<= target_seq`` (or empty if none) + forward-replay
-    of WAL entries in ``(base.applied_seq, target_seq]``. The returned
-    snapshot's ``applied_seq`` is the highest seq ``<= target_seq`` whose effects
-    affected this agent (``<= target_seq`` always).
+    = nearest **active** generation ``<= target_seq`` (or empty if none) +
+    forward-replay of the **active** WAL entries in ``(base.applied_seq,
+    target_seq]`` (Stage 1b: entries in abandoned segments are skipped, generations
+    cut on an abandoned branch are not used as the base).
 
-    Crash recovery is ``reconstruct(head)`` where ``head = state_log.current_seq``.
+    With no rewind records every seq is active, so this is identical to the
+    Stage-1a behavior (backward compatible). Crash recovery is
+    ``reconstruct(head)`` where ``head = state_log.current_seq`` — which, after a
+    rewind, yields the current active-branch state (and collapses to as-of-N when
+    the rewind reset-record is itself head).
     """
-    base_seq = store.nearest_at_or_below(target_seq)
+    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    is_active = _make_is_active(abandoned)
+
+    # Base = nearest ACTIVE generation <= target_seq (never an abandoned-branch
+    # generation); empty if none.
+    base_seq = next(
+        (s for s in reversed(store.seqs()) if s <= target_seq and is_active(s)),
+        None,
+    )
     base = store.load(base_seq) if base_seq is not None else AgentSnapshot.empty(agent_name)
 
-    # Forward-replay the WAL delta, bounded above by target_seq. apply_events
-    # already skips seq <= base.applied_seq; we additionally cap at target_seq so
-    # reconstruction is point-in-time, not head.
+    # Replay the ACTIVE WAL delta, bounded above by target_seq. apply_events skips
+    # seq <= base.applied_seq; we additionally cap at target_seq (point-in-time)
+    # and skip abandoned-branch entries (active-path honoring).
     delta = [
         entry
         for entry in state_log.iter_from(base.applied_seq + 1)
-        if isinstance(entry.get("seq"), int) and entry["seq"] <= target_seq
+        if isinstance(entry.get("seq"), int)
+        and entry["seq"] <= target_seq
+        and is_active(entry["seq"])
     ]
     base.apply_events(delta)
     return base

--- a/src/reyn/events/state_log.py
+++ b/src/reyn/events/state_log.py
@@ -73,6 +73,11 @@ WAL_EVENT_KINDS = (
     "plan_step_started",
     "plan_step_completed",
     "plan_step_failed",
+    # NEW (ADR-0038 Stage 1b) — user-facing time-travel rewind reset-record.
+    # Append-only compensating record: moves the active pointer to ``target_n``;
+    # the abandoned future is retained as an inactive branch (reconstruct honors
+    # the active path). A non-state marker — apply_events no-ops it.
+    "rewind",
 )
 
 

--- a/tests/test_rewind_reset_record.py
+++ b/tests/test_rewind_reset_record.py
@@ -1,0 +1,162 @@
+"""Tier 2: OS invariant — rewind reset-record + active-pointer honor (keystone).
+
+ADR-0038 Stage 1b. Real `StateLog` + `AgentSnapshot` + `SnapshotGenerationStore`
+(no mocks). rewind is an append-only compensating record; reconstruct honors the
+active branch (skips abandoned segments, never bases on an abandoned-branch
+generation). Covers the correctness keystone: crash-mid-rewind idempotence,
+post-rewind work preservation, both nested shapes (subsuming / partial), and the
+Phase-1 active-target guard.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import (
+    RewindIntoAbandonedError,
+    SnapshotGenerationStore,
+    is_active_seq,
+    reconstruct,
+    rewind,
+)
+from reyn.events.state_log import StateLog
+
+AGENT = "alpha"
+
+
+async def _put(log: StateLog, text: str) -> int:
+    """Append an inbox_put for AGENT (msg_id == text for easy assertion)."""
+    return await log.append(
+        "inbox_put", target=AGENT, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def _inbox_ids(snap: AgentSnapshot) -> list[str]:
+    return [m["id"] for m in snap.inbox]
+
+
+def _empty_store(tmp_path: Path) -> SnapshotGenerationStore:
+    return SnapshotGenerationStore(AGENT, tmp_path / "generations")
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_skips_abandoned_after_rewind(tmp_path):
+    """Tier 2: a rewind abandons the undone future; reconstruct(head) skips it."""
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")          # seq 1
+    await _put(log, "b")          # seq 2
+    await _put(log, "c")          # seq 3
+    await rewind(log, target_n=1)  # seq 4 — undo back to 1 (abandons 2,3)
+    assert is_active_seq(log, 1) and not is_active_seq(log, 2) and not is_active_seq(log, 3)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(snap) == ["a"]   # b, c undone
+
+
+@pytest.mark.asyncio
+async def test_post_rewind_work_yields_current_state(tmp_path):
+    """Tier 2 (refinement): reconstruct(head) keeps work done AFTER the rewind.
+
+    reconstruct(active-pointer-target) would lose 'd' — reconstruct(head)+is_active
+    keeps it (active = ≤N ∪ (R, head]).
+    """
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")          # seq 1
+    await _put(log, "b")          # seq 2
+    await rewind(log, target_n=1)  # seq 3 — abandons 2
+    await _put(log, "d")          # seq 4 — new work on the active branch
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(snap) == ["a", "d"]   # b undone, d kept
+
+
+@pytest.mark.asyncio
+async def test_crash_mid_rewind_idempotent(tmp_path):
+    """Tier 2 (keystone): crash mid-rewind ⇒ restore yields as-of-N, idempotently.
+
+    Reset-record is fsync'd before reconstruction; with head == the rewind record
+    (no new work yet), reconstruct(head) collapses to as-of-N and never resurrects
+    the abandoned future — twice over (idempotent).
+    """
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")          # seq 1
+    await _put(log, "b")          # seq 2
+    await rewind(log, target_n=1)  # seq 3 = head; crash here, no new work
+    first = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    second = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(first) == ["a"]          # b (abandoned future) not resurrected
+    assert first == second                     # idempotent
+
+
+@pytest.mark.asyncio
+async def test_nested_rewind_subsuming(tmp_path):
+    """Tier 2 (nested shape a): a 2nd rewind further back subsumes the 1st."""
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")           # seq 1
+    await _put(log, "b")           # seq 2
+    await rewind(log, target_n=1)  # seq 3 — abandons 2
+    await _put(log, "c")           # seq 4
+    await rewind(log, target_n=1)  # seq 5 — back to 1 again, subsumes the 1st rewind
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(snap) == ["a"]   # b and c both undone
+
+
+@pytest.mark.asyncio
+async def test_nested_rewind_partial(tmp_path):
+    """Tier 2 (nested shape b): a 2nd rewind on the new branch does NOT subsume.
+
+    Exercises the non-trivial 'skip rewinds on abandoned branches' path NOT
+    firing for the 1st rewind (it stays active), so both abandoned segments hold.
+    """
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")           # seq 1
+    await _put(log, "b")           # seq 2
+    await rewind(log, target_n=1)  # seq 3 — abandons 2
+    await _put(log, "c")           # seq 4 (active, new branch)
+    await _put(log, "d")           # seq 5 (active, new branch)
+    await rewind(log, target_n=4)  # seq 6 — undo back to 4 (abandons 5), keeps c
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(snap) == ["a", "c"]   # b abandoned (1st), d abandoned (2nd)
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_abandoned_seq_rejected(tmp_path):
+    """Tier 2 (Phase-1 guard): rewinding into an abandoned segment is rejected."""
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")           # seq 1
+    await _put(log, "b")           # seq 2
+    await rewind(log, target_n=1)  # seq 3 — seq 2 now abandoned
+    with pytest.raises(RewindIntoAbandonedError):
+        await rewind(log, target_n=2)   # seq 2 is on an abandoned branch → Phase-2 fork
+
+
+@pytest.mark.asyncio
+async def test_no_rewind_is_backward_compatible(tmp_path):
+    """Tier 2: with no rewind records every seq is active (Stage-1a behavior)."""
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")
+    await _put(log, "b")
+    assert is_active_seq(log, 1) and is_active_seq(log, 2)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    assert _inbox_ids(snap) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_abandoned_branch_generation_not_used_as_base(tmp_path):
+    """Tier 2: a generation cut on the abandoned branch is not used as the base.
+
+    Reconstruct must pick the nearest ACTIVE generation; an abandoned-branch gen
+    (whose seq is inside the abandoned segment) is skipped so its contaminated
+    state never leaks into the active reconstruction.
+    """
+    log = StateLog(tmp_path / "wal")
+    store = _empty_store(tmp_path)
+    await _put(log, "a")           # seq 1
+    await _put(log, "b")           # seq 2
+    # Cut a generation on what will become the abandoned branch (applied_seq 2).
+    store.record(reconstruct(AGENT, store, log, 2))
+    assert store.seqs() == [2]
+    await rewind(log, target_n=1)  # seq 3 — abandons 2 (incl. the gen at seq 2)
+    snap = reconstruct(AGENT, store, log, log.current_seq)
+    assert _inbox_ids(snap) == ["a"]   # the abandoned gen@2 (with 'b') is not the base

--- a/tests/test_rewind_reset_record.py
+++ b/tests/test_rewind_reset_record.py
@@ -57,7 +57,7 @@ async def test_reconstruct_skips_abandoned_after_rewind(tmp_path):
 
 @pytest.mark.asyncio
 async def test_post_rewind_work_yields_current_state(tmp_path):
-    """Tier 2 (refinement): reconstruct(head) keeps work done AFTER the rewind.
+    """Tier 2: reconstruct(head) keeps work done AFTER the rewind (refinement).
 
     reconstruct(active-pointer-target) would lose 'd' — reconstruct(head)+is_active
     keeps it (active = ≤N ∪ (R, head]).
@@ -73,7 +73,7 @@ async def test_post_rewind_work_yields_current_state(tmp_path):
 
 @pytest.mark.asyncio
 async def test_crash_mid_rewind_idempotent(tmp_path):
-    """Tier 2 (keystone): crash mid-rewind ⇒ restore yields as-of-N, idempotently.
+    """Tier 2: crash mid-rewind ⇒ restore yields as-of-N, idempotently (keystone).
 
     Reset-record is fsync'd before reconstruction; with head == the rewind record
     (no new work yet), reconstruct(head) collapses to as-of-N and never resurrects
@@ -91,7 +91,7 @@ async def test_crash_mid_rewind_idempotent(tmp_path):
 
 @pytest.mark.asyncio
 async def test_nested_rewind_subsuming(tmp_path):
-    """Tier 2 (nested shape a): a 2nd rewind further back subsumes the 1st."""
+    """Tier 2: a 2nd rewind further back subsumes the 1st (nested shape a)."""
     log = StateLog(tmp_path / "wal")
     await _put(log, "a")           # seq 1
     await _put(log, "b")           # seq 2
@@ -104,7 +104,7 @@ async def test_nested_rewind_subsuming(tmp_path):
 
 @pytest.mark.asyncio
 async def test_nested_rewind_partial(tmp_path):
-    """Tier 2 (nested shape b): a 2nd rewind on the new branch does NOT subsume.
+    """Tier 2: a 2nd rewind on the new branch does NOT subsume (nested shape b).
 
     Exercises the non-trivial 'skip rewinds on abandoned branches' path NOT
     firing for the 1st rewind (it stays active), so both abandoned segments hold.
@@ -122,7 +122,7 @@ async def test_nested_rewind_partial(tmp_path):
 
 @pytest.mark.asyncio
 async def test_rewind_to_abandoned_seq_rejected(tmp_path):
-    """Tier 2 (Phase-1 guard): rewinding into an abandoned segment is rejected."""
+    """Tier 2: rewinding into an abandoned segment is rejected (Phase-1 guard)."""
     log = StateLog(tmp_path / "wal")
     await _put(log, "a")           # seq 1
     await _put(log, "b")           # seq 2


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Phase 1, **Stage 1b — the correctness keystone** (isolated PR, deep review welcome). The rewind/branch model + active-path honoring. **Backward-compatible**: no rewind records ⇒ every seq active ⇒ identical to Stage 1a.

## The keystone logic
- **`rewind` WAL kind** (registered): append-only compensating record `{target_n, supersedes}` (supersedes = audit-only). Abandoned future retained as an inactive branch — P6/WAL stay append-only.
- **`is_active` derivation**: rewind records resolved **latest-first** (descending by R); `(R,N)` abandons `(N,R)` unless `R` itself is already abandoned (skip rewinds on abandoned branches). Nesting composes, no special case.
- **`reconstruct` honors the active branch**: nearest **ACTIVE** generation ≤N base (never an abandoned-branch gen) + active-filtered WAL delta. **Crash recovery = reconstruct(head)+is_active** — current active-branch state, collapsing to as-of-N when the rewind record is head (crash-mid-rewind idempotence; reset-record fsync'd before reconstruct).
- **Phase-1 guard**: `rewind()` rejects `target_n` on an abandoned branch (`RewindIntoAbandonedError`, decision-enabling) — that's a Phase-2 fork.

## Tests (Tier 2, real instances, no mocks) — 8 pass
abandoned skip · **post-rewind work kept** (the refinement we caught) · **crash-mid-rewind idempotent** · **nested subsuming** (shape a) · **nested partial** (shape b — exercises skip-abandoned-rewinds NOT firing) · guard rejection · backward-compat · abandoned-branch-gen not used as base. Plus 17 generation + 25 state_log/wal + 17 resume tests green (no regression).

## ⚠ Deferred (sequencing finding) — wiring `restore_all` to honor rewinds
The keystone lands the **logic + proof**. Wiring live `AgentRegistry.restore_all` to honor rewinds is deferred because it has a real dependency chain:
1. **Reconstruct needs a *generation* base, not snapshot.json** — snapshot.json is branch-unaware and can bake in abandoned-future state; only a clean generation gives a correct active base.
2. ∴ it depends on **Stage 1e retention** guaranteeing a base generation exists *below the WAL truncation floor* — else reconstruct-from-empty after truncation loses state (the WAL no longer holds the truncated entries).
3. And rewinds aren't user-reachable until **Stage 1c** (global-cut entry + TUI).
**Harmless until then**: no rewind records exist pre-1c, so restore_all's current snapshot.json path is correct today. The rewire lands with 1c/1e (when rewinds are reachable + retention guarantees gen coverage).

## Test plan
- [x] crash-mid-rewind idempotence (head=R ⇒ as-of-N, twice)
- [x] post-rewind work preserved (reconstruct(head)+is_active ≠ reconstruct(target))
- [x] nested both shapes (subsuming + partial)
- [x] Phase-1 active-target guard rejects abandoned-branch rewind
- [x] nearest-ACTIVE generation base (abandoned-branch gen skipped)
- [x] backward-compat + no regression (17 gen + 25 wal + 17 resume green)
- [ ] lead deep review (keystone) → merge → restore_all-honor wiring lands with Stage 1c/1e

🤖 Generated with [Claude Code](https://claude.com/claude-code)