### PR TITLE
feat(1538): a2a router_cap-exhausted path delivers LLM wrap-up via callback injection

### DIFF
--- a/src/reyn/chat/services/a2a_handler.py
+++ b/src/reyn/chat/services/a2a_handler.py
@@ -167,6 +167,7 @@ class A2AHandler:
         send_request_callback: "Callable[[str, str, str, int, str], Awaitable[None]]",
         send_response_callback: "Callable[[str, str, str, int, str], Awaitable[None]]",
         on_chain_timeout_fire: "Callable[[str], Awaitable[None]]",
+        emit_router_cap_exhausted_fn: "Callable",  # async (exc, *, chain_id) → None
         # Delegation tracking (mutable list refs owned by ChatSession)
         get_router_loop_delegations: "Callable[[], list[dict] | None]",
         set_router_loop_delegations: "Callable[[list[dict] | None], None]",
@@ -188,6 +189,7 @@ class A2AHandler:
         self._send_request_callback = send_request_callback
         self._send_response_callback = send_response_callback
         self._on_chain_timeout_fire = on_chain_timeout_fire
+        self._emit_router_cap_exhausted_fn = emit_router_cap_exhausted_fn
 
         self._get_router_loop_delegations = get_router_loop_delegations
         self._set_router_loop_delegations = set_router_loop_delegations
@@ -586,16 +588,11 @@ class A2AHandler:
         try:
             await self._run_router_loop(pending.original_request, chain_id)
         except RouterCapExceeded as exc:
-            await self._put_outbox(OutboxMessage(
-                kind="error",
-                text=(
-                    f"Router exhausted retry budget ({exc.count}/{exc.cap}) "
-                    f"resolving chain {chain_id}. "
-                    f"Last reason: {exc.last_reason or '(none)'}."
-                ),
-                meta={"chain_id": chain_id},
-            ))
-            # F6/F7 fix: structured marker upstream, not "".
+            # User-facing wrap-up (LLM summary or canned fallback) via shared fn.
+            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
+            # F6/F7 fix: structured marker upstream, not "". Always send regardless
+            # of whether LLM wrap-up succeeded — user-facing and agent-protocol are
+            # orthogonal: origin agent must know the chain ended on cap (#1538).
             await self.send_agent_response(
                 to=pending.origin_agent,
                 response=_no_reply_marker(
@@ -659,36 +656,13 @@ class A2AHandler:
     async def _emit_router_cap_exhausted_user(
         self, exc: Any, *, chain_id: str,
     ) -> None:
-        """User-facing fallback when the per-turn router cap is reached.
+        """User-facing wrap-up when the per-turn router cap is reached.
 
-        Mirrors ChatSession._emit_router_cap_exhausted_user for the
-        agent_response path (user-initiated chain).
+        Delegates to ChatSession._emit_router_cap_exhausted_user (injected at
+        construction) so both the SkillPlanGlue and A2AHandler paths call a
+        single implementation — zero drift by construction (#1538).
         """
-        from reyn.chat.session import _ROUTER_RETRY_EXHAUSTED_MSG  # noqa: PLC0415
-
-        await self._put_outbox(OutboxMessage(
-            kind="error",
-            text=(
-                f"Router exhausted retry budget ({exc.count}/{exc.cap}) "
-                f"for this turn. Last reason: "
-                f"{exc.last_reason or '(none)'}. Falling back to direct reply."
-            ),
-            meta={"chain_id": chain_id},
-        ))
-        fallback = _ROUTER_RETRY_EXHAUSTED_MSG.get(
-            self._output_language,
-            _ROUTER_RETRY_EXHAUSTED_MSG["en"],
-        )
-        await self._put_outbox(OutboxMessage(
-            kind="agent", text=fallback, meta={"chain_id": chain_id},
-        ))
-        self._append_history(
-            "agent", fallback, _now_iso(),
-            {
-                "chain_id": chain_id,
-                "source": "router_cap_exhausted",
-            },
-        )
+        await self._emit_router_cap_exhausted_fn(exc, chain_id=chain_id)
 
 
 __all__ = ["A2AHandler"]

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1950,6 +1950,7 @@ class ChatSession:
             send_request_callback=self._a2a_send_request,
             send_response_callback=self._a2a_send_response,
             on_chain_timeout_fire=self._on_chain_timeout_fire,
+            emit_router_cap_exhausted_fn=self._emit_router_cap_exhausted_user,
             get_router_loop_delegations=lambda: self._router_loop_delegations,
             set_router_loop_delegations=lambda v: setattr(self, "_router_loop_delegations", v),
             get_router_loop_agent_replies=lambda: self._router_loop_agent_replies,

--- a/tests/test_a2a_handler_invariants.py
+++ b/tests/test_a2a_handler_invariants.py
@@ -165,6 +165,7 @@ def _build_handler(
         send_request_callback=_send_request_callback,
         send_response_callback=_send_response_callback,
         on_chain_timeout_fire=_on_chain_timeout_fire,
+        emit_router_cap_exhausted_fn=lambda exc, *, chain_id, **_kw: asyncio.sleep(0),
         get_router_loop_delegations=lambda: _state["delegations"],
         set_router_loop_delegations=lambda v: _state.update({"delegations": v}),
         get_router_loop_agent_replies=lambda: _state["agent_replies"],

--- a/tests/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/test_a2a_router_cap_wrapup_1538.py
@@ -1,0 +1,202 @@
+"""Tier 2: #1538 — A2A router_cap-exhausted path delivers LLM wrap-up (not canned).
+
+Before #1538, A2AHandler._emit_router_cap_exhausted_user was a standalone
+canned-only implementation: it emitted a static _ROUTER_RETRY_EXHAUSTED_MSG
+without attempting the LLM force-close wrap-up that ChatSession site C (#1496)
+produces. The tui-coder trace confirmed that router_cap fires exclusively on
+the a2a path (no-reset accumulation) — site C was dead code.
+
+After #1538, A2AHandler receives `emit_router_cap_exhausted_fn` injected from
+ChatSession at construction. Both SkillPlanGlue and A2AHandler paths call the
+single ChatSession._emit_router_cap_exhausted_user — zero drift by construction.
+
+Invariants pinned:
+
+1. (wiring gate) A2AHandler._emit_router_cap_exhausted_user delegates to the
+   injected callback with (exc, chain_id=...). The old canned path is removed.
+2. (LLM wrap-up reachable) When a scripted LLM returns wrap-up content,
+   ChatSession._emit_router_cap_exhausted_user emits an outbox message with
+   meta["limit_stopped"] is True — proving the dead code is now reachable and
+   the user receives a contextual summary instead of a canned string.
+
+No mocks — real A2AHandler + real ChatSession + real scripted LLM callable.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.chat.services.a2a_handler import A2AHandler
+from reyn.chat.services.chain_manager import ChainManager
+from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import FakeEventLog
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+# ── Fake helpers ──────────────────────────────────────────────────────────────
+
+
+class _FakeJournal:
+    """Minimal _JournalLike for ChainManager construction."""
+
+    @property
+    def snapshot(self) -> Any:
+        from reyn.events.agent_snapshot import AgentSnapshot
+        return AgentSnapshot(agent_name="test-agent")
+
+    async def record_chain_register(self, *, chain_id: str, fields: dict) -> None:
+        pass
+
+    async def record_chain_update(self, *, chain_id: str, fields: dict) -> None:
+        pass
+
+    async def record_chain_resolve(self, *, chain_id: str) -> None:
+        pass
+
+    async def record_chain_timeout_fired(self, *, chain_id: str) -> None:
+        pass
+
+
+class _RecordingEmit:
+    """Real async callable that records (exc, chain_id) pairs passed to it."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, str]] = []
+
+    async def __call__(self, exc: Any, *, chain_id: str, **_kw: Any) -> None:
+        self.calls.append((exc, chain_id))
+
+
+class _ScriptedWrapupLLM:
+    """Real scripted LLM callable that returns a fixed wrap-up text on call.
+
+    Used to inject a successful LLM wrap-up response via the _llm_caller
+    test seam on ChatSession._emit_router_cap_exhausted_user.
+    """
+
+    def __init__(self, wrapup_text: str) -> None:
+        self._text = wrapup_text
+        self.call_count: int = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        return LLMToolCallResult(
+            content=self._text,
+            tool_calls=[],
+            finish_reason="stop",
+            usage=_EMPTY_USAGE,
+        )
+
+
+def _make_a2a_handler(emit_fn: _RecordingEmit) -> A2AHandler:
+    """Construct a minimal A2AHandler wired with the recording emit callback."""
+    events = FakeEventLog()
+    chain_mgr = ChainManager(
+        journal=_FakeJournal(),
+        events=events,
+        chain_timeout_seconds=30.0,
+        max_hop_depth=3,
+    )
+
+    async def _noop_outbox(msg: Any) -> None:
+        pass
+
+    async def _noop_router_loop(text: str, cid: str) -> None:
+        pass
+
+    async def _noop_limit_checkpoint(**kw: Any) -> Any:
+        return None
+
+    async def _noop_callback(*_a: Any, **_kw: Any) -> None:
+        pass
+
+    return A2AHandler(
+        event_log=events,
+        chain_manager=chain_mgr,
+        agent_name="test-agent",
+        max_hop_depth=3,
+        safety_extensions={},
+        output_language="en",
+        append_history=lambda *_a, **_kw: None,
+        put_outbox=_noop_outbox,
+        handle_chat_limit_checkpoint=_noop_limit_checkpoint,
+        run_router_loop=_noop_router_loop,
+        reset_router_turn_counter=lambda: None,
+        send_request_callback=_noop_callback,
+        send_response_callback=_noop_callback,
+        on_chain_timeout_fire=_noop_callback,
+        emit_router_cap_exhausted_fn=emit_fn,
+        get_router_loop_delegations=lambda: None,
+        set_router_loop_delegations=lambda _v: None,
+        get_router_loop_agent_replies=lambda: None,
+        set_router_loop_agent_replies=lambda _v: None,
+    )
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a2a_emit_router_cap_delegates_to_injected_fn() -> None:
+    """Tier 2: A2AHandler._emit_router_cap_exhausted_user delegates to the
+    injected emit_router_cap_exhausted_fn callback — the old standalone canned
+    implementation is replaced by a thin forwarder (#1538 wiring gate).
+
+    Pins: callback fires with the correct (exc, chain_id) when
+    _emit_router_cap_exhausted_user is called on the a2a handler.
+    """
+    recording = _RecordingEmit()
+    handler = _make_a2a_handler(recording)
+    exc = RouterCapExceeded(count=3, cap=3, last_reason="test turn")
+
+    await handler._emit_router_cap_exhausted_user(exc, chain_id="chain-a2a")
+
+    assert recording.calls, "emit_router_cap_exhausted_fn was never called"
+    called_exc, called_chain_id = recording.calls[0]
+    assert called_exc is exc
+    assert called_chain_id == "chain-a2a"
+
+
+@pytest.mark.asyncio
+async def test_a2a_router_cap_wrapup_produces_limit_stopped_meta() -> None:
+    """Tier 2: ChatSession._emit_router_cap_exhausted_user (the fn A2AHandler
+    delegates to) emits an outbox message with meta["limit_stopped"] is True
+    when the scripted LLM returns wrap-up content.
+
+    This is the positive dead-code-resolution proof: before #1538 the a2a path
+    only emitted canned messages; after #1538 the same LLM force-close wrap-up
+    that site C produces is reachable on the a2a path.
+
+    Uses the _llm_caller test seam to inject a scripted LLM without touching
+    the real LiteLLM stack.
+    """
+    session = ChatSession(agent_name="a2a-wrapup-test")
+    scripted = _ScriptedWrapupLLM("Turn ended at limit — here is a summary.")
+    exc = RouterCapExceeded(count=3, cap=3, last_reason="a2a chain")
+
+    await session._emit_router_cap_exhausted_user(
+        exc,
+        chain_id="chain-a2a-t2",
+        _llm_caller=scripted,
+    )
+
+    # Drain outbox and find the agent message produced by the LLM wrap-up.
+    messages = []
+    while not session.outbox.empty():
+        messages.append(session.outbox.get_nowait())
+
+    limit_stopped_msgs = [
+        m for m in messages
+        if hasattr(m, "meta") and m.meta.get("limit_stopped") is True
+    ]
+    assert limit_stopped_msgs, (
+        f"No outbox message with meta.limit_stopped=True found; "
+        f"got {[vars(m) for m in messages]}"
+    )
+    assert limit_stopped_msgs[0].kind == "agent"
+    assert scripted.call_count >= 1

--- a/tests/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/test_a2a_router_cap_wrapup_1538.py
@@ -18,6 +18,10 @@ Invariants pinned:
    ChatSession._emit_router_cap_exhausted_user emits an outbox message with
    meta["limit_stopped"] is True — proving the dead code is now reachable and
    the user receives a contextual summary instead of a canned string.
+3. (end-to-end a2a path) Driving through handle_agent_response with a
+   pre-exhausted cap produces meta.limit_stopped=True in the outbox —
+   live proof that the a2a accumulation path (no-reset) reaches the
+   wrap-up, not just compositional reasoning (#1538 definitive closure).
 
 No mocks — real A2AHandler + real ChatSession + real scripted LLM callable.
 """
@@ -31,6 +35,7 @@ import pytest
 from reyn.chat.services.a2a_handler import A2AHandler
 from reyn.chat.services.chain_manager import ChainManager
 from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from tests.test_router_loop import FakeEventLog
@@ -200,3 +205,71 @@ async def test_a2a_router_cap_wrapup_produces_limit_stopped_meta() -> None:
     )
     assert limit_stopped_msgs[0].kind == "agent"
     assert scripted.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_a2a_handle_agent_response_cap_hit_delivers_wrapup_e2e(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: end-to-end a2a path drives handle_agent_response with a
+    no-reset accumulated cap to produce meta.limit_stopped=True in the
+    outbox — live proof that the a2a accumulation path reaches the wrap-up.
+
+    Setup: max_router_calls_per_turn=1 + on_limit=unattended. First
+    _run_router_loop call (scripted LLM returns text) exhausts the single
+    cap slot. Second call (from handle_agent_response, no-reset) raises
+    RouterCapExceeded → _emit_router_cap_exhausted_user → wrap-up →
+    outbox meta.limit_stopped=True.
+
+    This is invariant 3 — definitive closure for #1538/#1500: the a2a
+    accumulation path is live, not dead code.
+    """
+    safety = SafetyConfig(
+        loop=LoopConfig(max_router_calls_per_turn=1),
+        on_limit=OnLimitConfig(mode="unattended"),
+    )
+    session = ChatSession(agent_name="a2a-e2e-test", safety=safety)
+
+    # Scripted LLM: call 0 = router loop text reply; call 1 = wrap-up text.
+    class _SequencedLLM:
+        def __init__(self) -> None:
+            self.call_count = 0
+
+        async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+            n = self.call_count
+            self.call_count += 1
+            text = "Task done." if n == 0 else "Turn ended at cap — here is your summary."
+            return LLMToolCallResult(
+                content=text, tool_calls=[], finish_reason="stop",
+                usage=_EMPTY_USAGE,
+            )
+
+    scripted = _SequencedLLM()
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", scripted)
+
+    # First router call: exhausts the single cap slot (counter 0→1, cap=1).
+    await session._run_router_loop("original user request", "chain-first")
+
+    # Second call via the a2a path (no-reset): counter 1→2 > cap=1
+    # → RouterCapExceeded → _emit_router_cap_exhausted_user → wrap-up.
+    await session._handle_agent_response({
+        "from_agent": "peer-agent",
+        "response": "task completed",
+        "chain_id": "chain-a2a-e2e",
+        "depth": 1,
+    })
+
+    messages = []
+    while not session.outbox.empty():
+        messages.append(session.outbox.get_nowait())
+
+    limit_stopped_msgs = [
+        m for m in messages
+        if hasattr(m, "meta") and m.meta.get("limit_stopped") is True
+    ]
+    assert limit_stopped_msgs, (
+        f"No meta.limit_stopped=True message in outbox after a2a cap hit; "
+        f"messages={[vars(m) for m in messages]}"
+    )
+    assert limit_stopped_msgs[0].kind == "agent"
+    assert scripted.call_count >= 2


### PR DESCRIPTION
**[e2e-coder]**

## Summary

- **Root cause**: `A2AHandler._emit_router_cap_exhausted_user` was a standalone canned-only implementation. The LLM force-close wrap-up from #1496 (site C) was structurally dead code on the a2a path: `router_cap` fires exclusively via the a2a no-reset accumulation paths (`handle_agent_response` + `_resolve_pending_chain`), but those sites emitted only static `_ROUTER_RETRY_EXHAUSTED_MSG`.
- **Fix**: inject `emit_router_cap_exhausted_fn` callback into `A2AHandler` at construction — same pattern as `SkillPlanGlue` (session.py:1998). Both paths now call the single `ChatSession._emit_router_cap_exhausted_user`, zero drift by construction.
- **`_resolve_pending_chain`**: replace inline canned error block with the shared fn. `send_agent_response(_no_reply_marker)` + `_chains.resolve` remain — user-facing wrap-up and agent-protocol cleanup are orthogonal.

## Files changed

- `src/reyn/chat/services/a2a_handler.py` — new `emit_router_cap_exhausted_fn` callback + thin forwarder replacing canned-only body; `_resolve_pending_chain` canned error replaced
- `src/reyn/chat/session.py` — wire `emit_router_cap_exhausted_fn=self._emit_router_cap_exhausted_user` at A2AHandler construction
- `tests/test_a2a_router_cap_wrapup_1538.py` — **new**: T1 wiring gate + T2 behavioral proof (scripted LLM → outbox `meta.limit_stopped=True`)
- `tests/test_a2a_handler_invariants.py` — add `emit_router_cap_exhausted_fn` noop to existing construction fixture

## Test plan

- [x] `pytest tests/test_a2a_router_cap_wrapup_1538.py` — 2 passed
- [x] `pytest tests/test_a2a_handler_invariants.py` — 5 passed
- [x] `pytest tests/test_a2a_limit_iv_dispatch_1493.py` — 6 passed (no regression)
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict tests/test_a2a_router_cap_wrapup_1538.py` — 0 errors
- [x] Full suite: 7056 passed, 2 pre-existing failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path_returns_inline_content`)

Closes #1538