### PR TITLE
feat(1533): Stage 1c-2 — AgentRegistry.rewind_to global consistent-cut orchestration

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -34,6 +34,13 @@ from typing import Callable
 logger = logging.getLogger(__name__)
 
 from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import (
+    RewindIntoAbandonedError,
+    SnapshotGenerationStore,
+    is_active_seq,
+    reconstruct,
+)
+from reyn.events.snapshot_generations import rewind as _append_rewind_record
 from reyn.events.state_log import StateLog
 
 from .profile import PROFILE_FILENAME, AgentProfile
@@ -102,6 +109,10 @@ class AgentRegistry:
         # WAL truncation throttle (skill resume design). monotonic ts of last
         # successful truncation attempt; ``None`` means no throttle is active.
         self._last_truncation_ts: float | None = None
+        # ADR-0038 Stage 1c-2: set for the duration of a global rewind. While
+        # set, ``maybe_truncate_for_size`` no-ops so a compaction can't advance
+        # the WAL keep-floor over the reset-record / reconstruct reads mid-cut.
+        self._rewind_in_progress: bool = False
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
@@ -327,6 +338,101 @@ class AgentRegistry:
                 )
 
         return snapshots
+
+    # ── Global rewind (ADR-0038 Stage 1c-2, D2 consistent-cut) ──────────────
+
+    def _store_for(self, name: str) -> SnapshotGenerationStore:
+        """Return the snapshot-generation store for ``name``.
+
+        Reuses the live session's store when the agent is loaded (so an
+        in-flight session and the rewind path share one view of the
+        generations dir); otherwise constructs one over the on-disk path.
+        """
+        session = self._agents.get(name)
+        store = getattr(session, "_generation_store", None)
+        if isinstance(store, SnapshotGenerationStore):
+            return store
+        return SnapshotGenerationStore(
+            name, self._dir / name / "state" / "generations",
+        )
+
+    async def rewind_to(self, target_n: int) -> dict:
+        """Global consistent-cut rewind to WAL seq ``target_n`` (ADR-0038 1c-2).
+
+        Architecture-enforced global cut (D2): one global single-seq WAL + one
+        workspace SSoT means a single reset-record rewinds *every* agent
+        atomically. Sequence:
+
+          1. validate ``target_n`` is on the active branch (1b guard) BEFORE
+             disrupting any live work — a bad target must not cancel turns.
+          2. all-cancel  — ``cancel_inflight`` on every loaded session.
+          3. all-quiesce — ``await_quiescent`` on every loaded session (1c-1):
+             stop-world THEN settle, so no cross-session straggler appends past
+             the reset-record.
+          4. append ONE global rewind reset-record (fsync'd before any
+             reconstruct — the crash-mid-rewind idempotence keystone, 1b).
+          5. reconstruct every KNOWN agent as-of-N (honoring is_active) and
+             persist a **self-contained** snapshot at ``applied_seq = R`` so
+             ``restore_all`` replays only post-rewind (> R) entries and never
+             needs the abandoned segment — correct-or-absent without a
+             floor-clamp (is_active-honoring restore_all + retention = 1e).
+             Loaded sessions are reset (``reset_for_rewind``) then re-adopt the
+             reconstructed snapshot; unloaded agents are reconstructed on disk
+             only (next load reflects the rewound state — partial-honor).
+
+        ``_rewind_in_progress`` gates compaction for the whole window.
+
+        Raises ``RewindIntoAbandonedError`` if ``target_n`` is on an abandoned
+        branch (switching branches is a Phase-2 fork, not Phase-1 undo).
+        """
+        if self._state_log is None:
+            raise RuntimeError("rewind_to requires a state log")
+        # 1. validate up front (no live work touched yet).
+        if not is_active_seq(self._state_log, target_n):
+            raise RewindIntoAbandonedError(
+                f"rewind target seq {target_n} is on an abandoned branch — "
+                "Phase-1 undo only rewinds to a seq on the active timeline."
+            )
+
+        self._rewind_in_progress = True
+        try:
+            sessions = list(self._agents.values())
+            # 2. all-cancel (stop-world).
+            for session in sessions:
+                await session.cancel_inflight()
+            # 3. all-quiesce (settle every WAL-append task).
+            for session in sessions:
+                await session.await_quiescent()
+            # 4. single global reset-record; supersedes = prior active head (audit).
+            prior_head = self._state_log.current_seq
+            reset_seq = await _append_rewind_record(
+                self._state_log, target_n=target_n, supersedes=prior_head,
+            )
+            # 5. reconstruct + persist self-contained snapshots for every agent.
+            agents: list[str] = []
+            for name in self.list_names():
+                store = self._store_for(name)
+                snap = reconstruct(
+                    name, store, self._state_log, target_seq=reset_seq,
+                )
+                # Self-contained: the reset-record carries no agent target, so
+                # reconstruct leaves applied_seq at the last active entry (<= N).
+                # Pin it to R so restore_all's replay floor skips the abandoned
+                # (N, R] segment entirely (no is_active honoring needed there).
+                snap.applied_seq = reset_seq
+                snap.save(self._dir / name / "state" / "snapshot.json")
+                session = self._agents.get(name)
+                if session is not None:
+                    await session.reset_for_rewind()
+                    session.restore_state(snap)
+                agents.append(name)
+            return {
+                "target_n": target_n,
+                "reset_seq": reset_seq,
+                "agents": agents,
+            }
+        finally:
+            self._rewind_in_progress = False
 
     # ── Plan resume recovery (ADR-0023 Phase 2 step 7d) ─────────────────────
 
@@ -585,6 +691,12 @@ class AgentRegistry:
         advanced, etc.).
         """
         if self._state_log is None:
+            return None
+        # ADR-0038 Stage 1c-2: no compaction during a global rewind — it would
+        # risk advancing the keep-floor over the reset-record / reconstruct WAL
+        # reads. Compaction resumes (against the new active state) once the
+        # rewind clears the flag.
+        if self._rewind_in_progress:
             return None
         threshold = (
             threshold_bytes if threshold_bytes is not None

--- a/src/reyn/chat/services/chain_manager.py
+++ b/src/reyn/chat/services/chain_manager.py
@@ -291,6 +291,17 @@ class ChainManager:
         """
         await self.cancel_and_join_timers()
 
+    async def reset(self) -> None:
+        """Drop all chain state + watchdogs (ADR-0038 Stage 1c-2 rewind).
+
+        Cancels+joins every timeout watchdog and clears the pending-chain map.
+        After this the manager holds no chains and no armed timers — the global
+        rewind path re-populates via ``restore()`` from the reconstructed
+        snapshot, leaving no pre-rewind residue. Idempotent.
+        """
+        await self.cancel_and_join_timers()
+        self._chains.clear()
+
     async def _chain_timeout_watch(
         self,
         chain_id: str,

--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -143,6 +143,23 @@ class InterventionRegistry:
         """Return True iff the registry was constructed with enforce_listener_presence=True."""
         return self._enforce_listener_presence
 
+    def clear(self) -> None:
+        """Drop all active + stalled interventions (ADR-0038 Stage 1c-2 rewind).
+
+        Cancels each pending iv future (their awaiters are already cancelled by
+        the rewind's ``cancel_inflight``, so this just releases the handles) and
+        clears the active / ordering / stalled collections. Listener
+        registration (``_listeners``) is intentionally preserved — the attached
+        channel survives a rewind. The rewind path re-populates via ``restore()``
+        from the reconstructed snapshot, leaving no pre-rewind residue.
+        """
+        for iv in (*self._active.values(), *self._stalled.values()):
+            if iv.future is not None and not iv.future.done():
+                iv.future.cancel()
+        self._active.clear()
+        self._order.clear()
+        self._stalled.clear()
+
     # ── Stalled queue operations (issue #268 Phase 1) ────────────────────────
 
     def mark_stalled(self, iv_id: str) -> bool:

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2290,6 +2290,56 @@ class ChatSession:
         task.add_done_callback(self._inflight_wal_tasks.discard)
         return task
 
+    async def reset_for_rewind(self) -> None:
+        """Clear all in-memory state ``restore_state`` repopulates (ADR-0038 1c-2).
+
+        Called in the global-rewind path **after** ``await_quiescent`` (every
+        WAL-append task settled) and **before** ``restore_state(reconstructed)``.
+        Its clear-scope EXACTLY mirrors ``restore_state``'s set-scope so that
+        re-adopting the reconstructed snapshot leaves ZERO pre-rewind residue —
+        a single missed holder would be stale state on the rewound branch.
+
+        ``journal.install`` (inside restore_state) replaces the AgentSnapshot
+        *data* wholesale; this clears the separate in-memory holders that
+        restore_state writes into, mapped to AgentSnapshot fields:
+
+            inbox                          → self.inbox (drain queue)
+            pending_chains                 → self._chains (reset: timers + chains)
+            outstanding_interventions      → self._interventions (clear)
+                                             + self._restore_intervention_tasks
+            buffered_intervention_answers  → self._buffered_intervention_answers
+            active_skill_run_ids           → self.running_skills (+ started_at / chain)
+            active_plan_ids                → self.running_plans
+
+        The running_*/_inflight_wal_tasks task handles are already settled by
+        await_quiescent; this drops the (now-done) handles so the rewound
+        session starts clean.
+        """
+        # inbox (AgentSnapshot.inbox)
+        while True:
+            try:
+                self.inbox.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        # pending_chains
+        await self._chains.reset()
+        # outstanding_interventions + restore watcher tasks
+        self._interventions.clear()
+        restore_tasks = getattr(self, "_restore_intervention_tasks", None)
+        if restore_tasks:
+            for t in restore_tasks:
+                if not t.done():
+                    t.cancel()
+            self._restore_intervention_tasks = []
+        # buffered_intervention_answers
+        self._buffered_intervention_answers.clear()
+        # active_skill_run_ids / active_plan_ids live mirrors (handles settled)
+        self.running_skills.clear()
+        self.running_skills_started_at.clear()
+        self.running_skills_chain.clear()
+        self.running_plans.clear()
+        self._inflight_wal_tasks.clear()
+
     @property
     def pending_user_images(self) -> list[dict]:
         """Read-only accessor for the per-session image upload queue.

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -15,6 +15,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
 from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.snapshot_generations import RewindIntoAbandonedError, rewind
 from reyn.events.state_log import StateLog
@@ -151,3 +152,42 @@ async def test_rewind_to_gates_compaction_during_window(tmp_path):
     reg._rewind_in_progress = True
     result = await reg.maybe_truncate_for_size(threshold_bytes=1)
     assert result is None                  # gated — no compaction during rewind
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_drives_loaded_session_to_as_of_n_zero_residue(tmp_path):
+    """Tier 2: rewind_to drives a REAL loaded session through the full path.
+
+    A real ChatSession (aligned to the registry's on-disk paths) is injected; the
+    user-facing rewind cancels + quiesces it, reconstructs as-of-N, clears live
+    in-memory residue (reset_for_rewind), and re-adopts the as-of-N snapshot
+    (restore_state). Post-rewind the session reflects as-of-N with zero pre-rewind
+    residue — and its on-disk snapshot is the self-contained recovery artifact.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    session = ChatSession(
+        agent_name="alpha", state_log=log,
+        snapshot_path=_snap_path(tmp_path, "alpha"),
+    )
+    session.register_intervention_listener("test")
+    reg._agents["alpha"] = session
+
+    await _put(log, "alpha", "a1")         # seq 1 (kept by rewind to 1)
+    await _put(log, "alpha", "a2")         # seq 2 (abandoned)
+    # live in-memory residue that ONLY reset_for_rewind can clear (no WAL append):
+    session.inbox.put_nowait(("user", {"text": "OLD-residue"}))
+
+    result = await reg.rewind_to(1)
+
+    # the live session reflects as-of-N (a1), OLD residue gone.
+    drained = []
+    while not session.inbox.empty():
+        drained.append(session.inbox.get_nowait())
+    assert drained == [("user", {"text": "a1"})]
+
+    # on-disk snapshot for the loaded agent is as-of-N + self-contained (applied_seq=R).
+    snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(snap) == ["a1"]
+    assert snap.applied_seq == result["reset_seq"]

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -1,0 +1,153 @@
+"""Tier 2: OS invariant — AgentRegistry.rewind_to global consistent-cut rewind.
+
+ADR-0038 Stage 1c-2 (D2). Real `AgentRegistry` + `StateLog` + on-disk agents
+(no mocks). One global single-seq WAL + one workspace SSoT ⇒ a single
+reset-record rewinds every agent atomically. Covers: active-target validation,
+multi-agent consistent-cut reconstruct, the **self-contained** snapshot
+(applied_seq = R) that makes restore_all correct-or-absent without a
+floor-clamp (choice (b)), and the no-compaction-during-window guard.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import RewindIntoAbandonedError, rewind
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    """Create the on-disk profile so list_names() includes the agent."""
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def _snap_path(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name / "state" / "snapshot.json"
+
+
+def _inbox_ids(snap: AgentSnapshot) -> list[str]:
+    return [m["id"] for m in snap.inbox]
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_rejects_abandoned_target(tmp_path):
+    """Tier 2: rewinding into an abandoned segment is rejected up front (1b guard)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a")          # seq 1
+    await _put(log, "alpha", "b")          # seq 2
+    await rewind(log, target_n=1)          # seq 3 — abandons seq 2
+
+    with pytest.raises(RewindIntoAbandonedError):
+        await reg.rewind_to(2)             # seq 2 is on an abandoned branch
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_reconstructs_all_agents_as_of_n(tmp_path):
+    """Tier 2: rewind_to reconstructs EVERY agent as-of-N (global consistent-cut).
+
+    Two agents with interleaved appends; rewind_to(2) cuts the whole world back
+    to seq 2 — each agent's on-disk snapshot reflects only its <=2 work, and is
+    pinned to applied_seq = R (the reset-record) so it is self-contained.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")         # seq 1 (<=2, kept)
+    await _put(log, "beta", "b1")          # seq 2 (<=2, kept)
+    await _put(log, "alpha", "a2")         # seq 3 (>2, abandoned)
+    await _put(log, "beta", "b2")          # seq 4 (>2, abandoned)
+
+    result = await reg.rewind_to(2)
+    R = result["reset_seq"]
+
+    assert result["target_n"] == 2
+    # consistent-cut covers EVERY known agent (incl. the auto-created default).
+    assert {"alpha", "beta"} <= set(result["agents"])
+
+    alpha = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    beta = AgentSnapshot.load("beta", _snap_path(tmp_path, "beta"))
+    assert _inbox_ids(alpha) == ["a1"]     # a2 abandoned
+    assert _inbox_ids(beta) == ["b1"]      # b2 abandoned
+    # self-contained: replay floor is R, not N.
+    assert alpha.applied_seq == R
+    assert beta.applied_seq == R
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_snapshot_self_contained_for_restore_all(tmp_path):
+    """Tier 2: the persisted snapshot makes restore_all correct WITHOUT is_active.
+
+    restore_all replays forward from snapshot.applied_seq (no is_active honoring).
+    Because rewind_to pins applied_seq = R, restore_all's replay starts past the
+    abandoned (N, R] segment — so post-rewind work is kept and the abandoned
+    future is never resurrected, even though restore_all doesn't know about
+    rewind records. This is the correctness basis for choice (b).
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")         # seq 1 (kept)
+    await _put(log, "alpha", "a2")         # seq 2 (abandoned by rewind to 1)
+
+    result = await reg.rewind_to(1)
+    R = result["reset_seq"]
+
+    # New active-branch work after the rewind.
+    await _put(log, "alpha", "a3")         # seq R+1
+
+    # Simulate restore_all's algorithm: load the self-contained snapshot, then
+    # replay forward from applied_seq + 1 (NO is_active honoring).
+    saved = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert saved.applied_seq == R
+    saved.apply_events(list(log.iter_from(saved.applied_seq + 1)))
+
+    assert _inbox_ids(saved) == ["a1", "a3"]   # a2 (abandoned, <R) never replayed
+
+    # Idempotent: replaying again from a fresh load yields the same state.
+    again = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    again.apply_events(list(log.iter_from(again.applied_seq + 1)))
+    assert _inbox_ids(again) == ["a1", "a3"]
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_gates_compaction_during_window(tmp_path):
+    """Tier 2: while a rewind is in progress, maybe_truncate_for_size no-ops.
+
+    The guard returns None BEFORE the size/floor logic — proven by passing a
+    1-byte threshold (the WAL exceeds it, so a non-guarded call would proceed
+    past the threshold check) and still getting None while the flag is set.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    for i in range(5):
+        await _put(log, "alpha", f"m{i}")
+
+    reg._rewind_in_progress = True
+    result = await reg.maybe_truncate_for_size(threshold_bytes=1)
+    assert result is None                  # gated — no compaction during rewind

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -1,0 +1,89 @@
+"""Tier 2: ChatSession.reset_for_rewind — pre-rewind in-memory residue clearing.
+
+ADR-0038 Stage 1c-2. Real `ChatSession` + `StateLog` (no mocks). The global
+rewind path calls ``reset_for_rewind()`` after ``await_quiescent`` and before
+``restore_state(reconstructed)``; its clear-scope must EXACTLY mirror
+``restore_state``'s set-scope so re-adopting the reconstructed snapshot leaves
+ZERO pre-rewind residue (a single missed holder = stale state on the rewound
+branch).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.session import ChatSession
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+def _session(tmp_path: Path, log: StateLog, *, agent: str = "alpha") -> ChatSession:
+    session = ChatSession(
+        agent_name=agent, state_log=log, snapshot_path=tmp_path / "snap.json",
+    )
+    session.register_intervention_listener("test")
+    return session
+
+
+@pytest.mark.asyncio
+async def test_reset_for_rewind_then_restore_state_zero_residue(tmp_path):
+    """Tier 2: reset_for_rewind + restore_state leaves ONLY the new snapshot.
+
+    Populate every in-memory holder restore_state writes into with OLD markers,
+    then reset_for_rewind + restore_state(a snapshot carrying only NEW state).
+    The session's public views must reflect only the new snapshot — no OLD
+    residue in inbox / chains / interventions / buffered answers / running tasks.
+    """
+    log = StateLog(tmp_path / "wal")
+    session = _session(tmp_path, log)
+
+    # ── populate pre-rewind live state (OLD markers) ──
+    session.inbox.put_nowait(("user", {"text": "OLD"}))
+    await session._chains.register(
+        chain_id="OLD-chain", from_user=True, depth=0,
+        original_text="old", sender=None,
+    )
+    session._buffered_intervention_answers["OLD-run"] = InterventionAnswer(text="OLD")
+    old_iv = UserIntervention(kind="ask_user", prompt="OLD?")
+    session._interventions._stalled[old_iv.id] = old_iv
+    done_skill = asyncio.create_task(asyncio.sleep(0))
+    session.running_skills["OLD-skill"] = done_skill
+    await asyncio.sleep(0)  # let the dummy skill task settle (post-quiescent state)
+
+    # ── reset, then adopt a reconstructed snapshot carrying only NEW state ──
+    await session.reset_for_rewind()
+
+    new_snap = AgentSnapshot.empty("alpha")
+    new_snap.inbox = [{"id": "NEW", "kind": "user", "payload": {"text": "NEW"}}]
+    session.restore_state(new_snap)
+
+    # ── public views reflect ONLY the new snapshot — zero OLD residue ──
+    chain_ids = session._chains.all_chain_ids()
+    assert chain_ids == []                                  # OLD-chain cleared
+    assert session.list_stalled_interventions() == []       # OLD iv cleared
+    assert session.buffered_intervention_answers == {}       # OLD buffered cleared
+    assert session.running_skills == {}                      # OLD skill handle dropped
+    # inbox: OLD drained by reset; NEW re-queued by restore_state from the snapshot.
+    drained = []
+    while not session.inbox.empty():
+        drained.append(session.inbox.get_nowait())
+    assert drained == [("user", {"text": "NEW"})]
+
+
+@pytest.mark.asyncio
+async def test_reset_for_rewind_is_idempotent_on_clean_session(tmp_path):
+    """Tier 2: reset_for_rewind on an already-empty session is a safe no-op."""
+    log = StateLog(tmp_path / "wal")
+    session = _session(tmp_path, log)
+
+    await session.reset_for_rewind()  # nothing populated — must not raise
+
+    chain_ids = session._chains.all_chain_ids()
+    assert chain_ids == []
+    assert session.list_stalled_interventions() == []
+    assert session.buffered_intervention_answers == {}
+    assert session.running_skills == {}
+    assert session.inbox.empty()

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -73,6 +73,32 @@ async def test_reset_for_rewind_then_restore_state_zero_residue(tmp_path):
     assert drained == [("user", {"text": "NEW"})]
 
 
+def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
+    """Tier 2: by-construction drift guard — clear-scope covers EVERY snapshot field.
+
+    reset_for_rewind clears the in-memory mirror of each AgentSnapshot field that
+    restore_state repopulates. This pin maps every field to its reset disposition;
+    adding/removing an AgentSnapshot field breaks it, forcing the author to make
+    the new field's disposition explicit. A missed mirror would be silent stale
+    residue on the rewound branch — so drift must not pass silently.
+    """
+    disposition = {
+        "agent_name": "identity — unchanged by rewind (same agent)",
+        "applied_seq": "replaced wholesale by journal.install (no separate holder)",
+        "inbox": "session.inbox drained",
+        "pending_chains": "session._chains.reset()",
+        "active_skill_run_ids": "session.running_skills (+ started_at / chain) cleared",
+        "active_plan_ids": "session.running_plans cleared",
+        "outstanding_interventions": "session._interventions.clear() + restore tasks",
+        "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
+    }
+    assert set(disposition) == set(AgentSnapshot.__dataclass_fields__), (
+        "AgentSnapshot fields changed — update reset_for_rewind (and this map) so "
+        "the new/removed field's in-memory-mirror disposition is explicit; a "
+        "missed holder is silent stale residue on the rewound branch."
+    )
+
+
 @pytest.mark.asyncio
 async def test_reset_for_rewind_is_idempotent_on_clean_session(tmp_path):
     """Tier 2: reset_for_rewind on an already-empty session is a safe no-op."""


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Stage 1c-2. Builds on 1c-1 (await_quiescent, #1541 merged). Lead pre-authorized impl on the design-first Q1–Q5 answers in #1533.

## What this lands
`AgentRegistry.rewind_to(target_n)` — the D2 global consistent-cut orchestration:
1. validate `target_n` active (1b guard) **before** disrupting live work
2. all-cancel (`cancel_inflight`) every loaded session — stop-world
3. all-quiesce (`await_quiescent`, 1c-1) every loaded session — then settle
4. append **one** global rewind reset-record (fsync'd before reconstruct — crash-mid-rewind idempotence keystone)
5. reconstruct every known agent as-of-N (honoring `is_active`) + persist a **self-contained** snapshot; loaded sessions are `reset_for_rewind()` then re-adopt it; unloaded agents are reconstructed on disk (partial-honor).

Supporting primitives: `session.reset_for_rewind()`, `ChainManager.reset()`, `InterventionRegistry.clear()`, registry `_rewind_in_progress` compaction guard.

## Design decisions (lead-reviewed Q1–Q5, #1533)
- **Q1 `reset_for_rewind()`**: clears the in-memory holders `restore_state` repopulates (inbox / `_chains` / `_interventions`+restore-tasks / `_buffered` / `running_*` / `_inflight_wal_tasks`), mapped **1:1 to AgentSnapshot fields** so re-adopting the reconstructed snapshot leaves **zero pre-rewind residue**. Keeps `restore_state`'s crash-recovery merge semantics untouched (vs riskier `replace=True`).
- **Q2 = (b)**: the reset-record carries **no agent target**, so `reconstruct` leaves `applied_seq` at the last active entry (≤N); `rewind_to` pins `applied_seq = R` → the snapshot is **self-contained**, so `restore_all`'s forward-replay floor is R, skipping the abandoned `(N,R]` segment **without `is_active` honoring** (correct-or-absent). The floor-clamp + `is_active`-honoring `restore_all` + 2-window retention are deferred to **Stage 1e** (the "honor-but-droppable" middle is forbidden — avoided). `_rewind_in_progress` gates compaction for the window; post-window compaction is harmless against self-contained snapshots.
- **Q3** all-cancel-then-all-quiesce (true global cut). **Q4** `rewind_to(seq)`; TUI turn→seq mapping = 1f caller's job. **Q5** reuse a loaded session's `_generation_store`, else build over `.reyn/agents/<name>/state/generations`.

## Test plan (real-instance, no mocks; tier-audit clean; 110-test sweep green)
- [x] `reset_for_rewind`: reset+restore_state **zero-residue** (OLD markers gone across inbox/chains/interventions/buffered/running; only NEW snapshot remains); idempotent on a clean session.
- [x] `rewind_to`: rejects abandoned target; reconstructs **all** agents as-of-N (multi-agent consistent-cut, `applied_seq=R`); self-contained snapshot survives a `restore_all`-style forward replay (**choice-(b) keystone**, idempotent); compaction gated during the window.
- [x] Regression sweep (registry/session/chain/intervention/truncate/snapshot-generations/rewind): **110 passed**.

## Known coverage boundary (needs your call)
`rewind_to`'s **loaded-session path** (`reset_for_rewind` + `restore_state` invoked *inside* `rewind_to`) is covered **piecewise** (reset_for_rewind unit + on-disk partial-honor at the registry level), not as one real-session-injected integration test — that needs a real session factory. Is a full integration test merge-blocking, or acceptable as a fast-follow?

Closes part of #1533 Phase-1 (Stage 1c-2). Next: 1d (shadow-git D9) / 1e (retention + floor-clamp + is_active-honoring restore_all) / 1f (TUI /rewind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)