### PR TITLE
feat(1533): Stage 1d — shadow-git workspace versioning + two-substrate rewind (D9)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -952,6 +952,13 @@ class AgentRegistry:
             )
         profile = self.load_profile(name)
         session = self._factory(profile)
+        # ADR-0038 Stage 1d: hand the session the single shared workspace
+        # shadow-git store so cut_generation captures the workspace at each
+        # boundary against the same git-dir the registry's rewind/recovery uses.
+        ws = self.workspace_store
+        attach = getattr(session, "attach_workspace_store", None)
+        if ws is not None and callable(attach):
+            attach(ws)
         self._agents[name] = session
         return session
 

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -37,11 +37,13 @@ from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.snapshot_generations import (
     RewindIntoAbandonedError,
     SnapshotGenerationStore,
+    active_rewind_target,
     is_active_seq,
     reconstruct,
 )
 from reyn.events.snapshot_generations import rewind as _append_rewind_record
 from reyn.events.state_log import StateLog
+from reyn.events.workspace_version_store import WorkspaceVersionStore
 
 from .profile import PROFILE_FILENAME, AgentProfile
 from .topology import TOPOLOGY_DIRNAME, Topology, _validate_topology_name
@@ -113,6 +115,12 @@ class AgentRegistry:
         # set, ``maybe_truncate_for_size`` no-ops so a compaction can't advance
         # the WAL keep-floor over the reset-record / reconstruct reads mid-cut.
         self._rewind_in_progress: bool = False
+        # ADR-0038 Stage 1d: the workspace half of a generation. One shadow-git
+        # for the (single-SSoT) workspace, git-dir under .reyn (out of the
+        # tracked tree). Host-mode worktree = project_root; container mode is a
+        # tracked follow-up (#1544). Lazily built so non-chat / no-WAL callers
+        # never touch git.
+        self._workspace_store: WorkspaceVersionStore | None = None
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
@@ -408,24 +416,10 @@ class AgentRegistry:
             reset_seq = await _append_rewind_record(
                 self._state_log, target_n=target_n, supersedes=prior_head,
             )
-            # 5. reconstruct + persist self-contained snapshots for every agent.
-            agents: list[str] = []
-            for name in self.list_names():
-                store = self._store_for(name)
-                snap = reconstruct(
-                    name, store, self._state_log, target_seq=reset_seq,
-                )
-                # Self-contained: the reset-record carries no agent target, so
-                # reconstruct leaves applied_seq at the last active entry (<= N).
-                # Pin it to R so restore_all's replay floor skips the abandoned
-                # (N, R] segment entirely (no is_active honoring needed there).
-                snap.applied_seq = reset_seq
-                snap.save(self._dir / name / "state" / "snapshot.json")
-                session = self._agents.get(name)
-                if session is not None:
-                    await session.reset_for_rewind()
-                    session.restore_state(snap)
-                agents.append(name)
+            # 5. materialise both substrates as-of-N (runtime snapshots + workspace).
+            agents = await self._materialize_rewind(
+                reconstruct_seq=reset_seq, workspace_at_or_below=target_n,
+            )
             return {
                 "target_n": target_n,
                 "reset_seq": reset_seq,
@@ -433,6 +427,98 @@ class AgentRegistry:
             }
         finally:
             self._rewind_in_progress = False
+
+    @property
+    def workspace_store(self) -> WorkspaceVersionStore | None:
+        """The shadow-git workspace store (ADR-0038 1d), lazily built.
+
+        ``None`` when there is no WAL (non-chat / tests that opt out). Host-mode
+        worktree = ``project_root``; git-dir under ``.reyn``. Container mode is a
+        tracked follow-up (#1544).
+        """
+        if self._state_log is None:
+            return None
+        if self._workspace_store is None:
+            self._workspace_store = WorkspaceVersionStore(
+                self._project_root,
+                self._project_root / ".reyn" / "workspace-shadow.git",
+            )
+        return self._workspace_store
+
+    async def _materialize_rewind(
+        self, *, reconstruct_seq: int, workspace_at_or_below: int,
+    ) -> list[str]:
+        """Bring BOTH substrates to the active branch as-of ``reconstruct_seq``.
+
+        Idempotent — shared by ``rewind_to`` (right after the reset-record) and
+        crash ``recover_rewind_if_needed`` (at restart). Per agent: ``reconstruct``
+        as-of the active branch + persist a self-contained snapshot pinned to
+        ``reconstruct_seq`` (so ``restore_all`` replays only beyond it); loaded
+        sessions are reset + re-adopt it. Then the workspace substrate is
+        restored to the nearest **active** generation ``<= workspace_at_or_below``.
+
+        ``reconstruct_seq`` is the WAL head at call time (= R in rewind_to, =
+        current head in recovery); ``workspace_at_or_below`` is ``target_n`` in
+        rewind_to (= gen-N) or head in recovery (= latest active gen, keeping
+        post-rewind workspace work). Returns the agents materialised.
+        """
+        agents: list[str] = []
+        for name in self.list_names():
+            store = self._store_for(name)
+            snap = reconstruct(
+                name, store, self._state_log, target_seq=reconstruct_seq,
+            )
+            # Self-contained: the reset-record carries no agent target, so
+            # reconstruct leaves applied_seq at the last active entry. Pin it to
+            # the head so restore_all's replay floor skips the abandoned segment.
+            snap.applied_seq = reconstruct_seq
+            snap.save(self._dir / name / "state" / "snapshot.json")
+            session = self._agents.get(name)
+            if session is not None:
+                await session.reset_for_rewind()
+                session.restore_state(snap)
+            agents.append(name)
+        self._restore_workspace_active(at_or_below=workspace_at_or_below)
+        return agents
+
+    def _restore_workspace_active(self, *, at_or_below: int) -> None:
+        """Restore the workspace to the nearest ACTIVE generation <= ``at_or_below``.
+
+        Honors is_active (mirrors ``reconstruct`` for runtime): gen-tags in an
+        abandoned segment ``(N, R)`` are skipped, so a crash-after-rewind-before-
+        any-post-rewind-capture never restores the undone-future workspace.
+        No-op when git / the store / a matching active gen is unavailable.
+        """
+        ws = self.workspace_store
+        if ws is None or not ws.git_available():
+            return
+        active = [
+            s for s in ws.seqs()
+            if s <= at_or_below and is_active_seq(self._state_log, s)
+        ]
+        if active:
+            ws.restore_to_seq(max(active))
+
+    async def recover_rewind_if_needed(self) -> dict | None:
+        """Re-materialise both substrates as-of-N after a crash mid-rewind (1d).
+
+        The reset-record is fsync'd before any reconstruction (1b keystone), so
+        on restart an active reset-record means "a rewind was decided"; recovery
+        re-runs the idempotent materialisation BEFORE ``restore_all`` loads
+        sessions, closing the window where the crash hit after the reset-record
+        but before snapshots / workspace were brought to as-of-N. No-op when no
+        rewind record exists. Returns a summary or ``None``.
+        """
+        if self._state_log is None:
+            return None
+        target = active_rewind_target(self._state_log)
+        if target is None:
+            return None
+        head = self._state_log.current_seq
+        agents = await self._materialize_rewind(
+            reconstruct_seq=head, workspace_at_or_below=head,
+        )
+        return {"recovered_target_n": target, "head": head, "agents": agents}
 
     # ── Plan resume recovery (ADR-0023 Phase 2 step 7d) ─────────────────────
 

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -281,9 +281,18 @@ class AgentRegistry:
            pending_chains and re-arm chain timeout watchdogs
 
         Idempotent: calling twice on a clean state is a no-op.
+
+        ADR-0038 Stage 1d: crash-mid-rewind recovery runs FIRST (before loading
+        snapshots) so a reset-record fsync'd before its materialisation completed
+        re-materialises both substrates as-of-N — every startup path that calls
+        ``restore_all`` gets crash-recovery by construction. No-op without a
+        rewind record.
         """
         if self._state_log is None:
             return {}
+
+        # 0. crash-mid-rewind recovery (no-op without an active reset-record).
+        await self.recover_rewind_if_needed()
 
         # 1. Load snapshots
         snapshots: dict[str, AgentSnapshot] = {}

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -47,19 +47,37 @@ class SnapshotJournal:
         # non-chat), generation cuts are no-ops and the single snapshot.json
         # path is unchanged (no behavior change).
         self._generation_store = generation_store
+        # ADR-0038 Stage 1d: the workspace half of a generation. Set post-
+        # construction by the registry (the single shared shadow-git store) so
+        # cut_generation captures workspace files at the SAME boundary as the
+        # runtime snapshot. None → no workspace versioning (capture is skipped).
+        self._workspace_store = None
         self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name)
 
+    def set_workspace_store(self, workspace_store) -> None:
+        """Attach the shared workspace shadow-git store (ADR-0038 Stage 1d).
+
+        Injected by the registry after session construction so the capture seam
+        (cut_generation) and the rewind/recovery restore use the SAME git-dir.
+        """
+        self._workspace_store = workspace_store
+
     def cut_generation(self) -> None:
-        """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a).
+        """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a/1d).
 
         Called at user-facing checkpoint boundaries (turn / plan-step) — a
-        single seam so cuts are neither missed nor doubled. Additive to the
-        per-mutation ``save()``; the latest generation equals the current
-        snapshot. No-op when no generation store / WAL is configured.
+        single seam so cuts are neither missed nor doubled. Records BOTH
+        substrates tied at the boundary seq (= ``snapshot.applied_seq``, a WAL
+        seq): the runtime AgentSnapshot generation AND (Stage 1d) the workspace
+        shadow-git commit. Additive to the per-mutation ``save()``. No-op when no
+        generation store / WAL is configured; workspace capture is skipped when
+        no workspace store is attached (or git is unavailable — handled there).
         """
         if self._generation_store is None or self._state_log is None:
             return
         self._generation_store.record(self._snapshot)
+        if self._workspace_store is not None:
+            self._workspace_store.capture(self._snapshot.applied_seq)
 
     # ── public read access ────────────────────────────────────────────────
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2290,6 +2290,16 @@ class ChatSession:
         task.add_done_callback(self._inflight_wal_tasks.discard)
         return task
 
+    def attach_workspace_store(self, workspace_store) -> None:
+        """Attach the shared workspace shadow-git store (ADR-0038 Stage 1d).
+
+        The registry injects its single ``WorkspaceVersionStore`` after building
+        this session so the journal's ``cut_generation`` captures workspace files
+        at each boundary against the same git-dir the registry's rewind/recovery
+        restores from.
+        """
+        self._journal.set_workspace_store(workspace_store)
+
     async def reset_for_rewind(self) -> None:
         """Clear all in-memory state ``restore_state`` repopulates (ADR-0038 1c-2).
 

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -145,6 +145,20 @@ def is_active_seq(state_log: StateLog, seq: int) -> bool:
     return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)
 
 
+def active_rewind_target(state_log: StateLog) -> int | None:
+    """``target_n`` of the active reset-record, or ``None`` when no rewind exists.
+
+    The active reset-record is the **highest-seq** rewind (latest wins — a later
+    rewind can never be abandoned by an earlier one, so the max-R record is always
+    the active pointer). Crash recovery uses this to re-materialise the active
+    branch as-of-N idempotently (ADR-0038 Stage 1d two-substrate crash-safety).
+    """
+    records = _rewind_records(state_log)
+    if not records:
+        return None
+    return max(records, key=lambda t: t[0])[1]
+
+
 async def rewind(
     state_log: StateLog, *, target_n: int, supersedes: int | None = None,
 ) -> int:

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -102,22 +102,35 @@ class WorkspaceVersionStore:
         return self._rev_parse("HEAD")
 
     def restore_at_or_below(self, seq: int) -> str | None:
-        """Restore the workspace to the nearest generation with tag-seq <= ``seq``.
+        """Restore to the nearest generation with **raw** tag-seq <= ``seq``.
+
+        Convenience for the no-rewind / single-branch case. **When rewind records
+        exist, callers MUST use** :meth:`restore_to_seq` with an is_active-resolved
+        seq instead — a raw nearest-below can land on an abandoned-branch
+        generation (tags in the abandoned segment ``(N, R)`` still exist), the
+        workspace analogue of the runtime active-branch honoring in
+        ``snapshot_generations.reconstruct``. Returns the restored sha or ``None``.
+        """
+        if not self.git_available() or not self._git_dir.exists():
+            return None
+        base = self._nearest_at_or_below(seq)
+        return self.restore_to_seq(base) if base is not None else None
+
+    def restore_to_seq(self, seq: int) -> str | None:
+        """Restore the workspace to the EXACT generation tagged ``seq``.
 
         ``reset --hard`` to that commit + ``clean -fd`` (honoring the excludes)
         so files added after the generation are removed while excluded OS state
-        (``.reyn/``) survives. Returns the restored commit sha, or ``None`` when
-        git is unavailable or no generation at-or-below ``seq`` exists.
+        (``.reyn/``) survives. The caller supplies the precise generation seq
+        (e.g. the nearest **active** gen, is_active-resolved against the WAL), so
+        this never has to know about rewind/abandoned branches. Returns the
+        restored sha, or ``None`` when git is unavailable or no such tag exists.
         """
-        if not self.git_available():
-            logger.debug("git unavailable — workspace restore(%s) skipped", seq)
+        if not self.git_available() or not self._git_dir.exists():
             return None
-        if not self._git_dir.exists():
+        tag = self._tag(seq)
+        if self._tag_sha(tag) is None:
             return None
-        base = self._nearest_at_or_below(seq)
-        if base is None:
-            return None
-        tag = self._tag(base)
         self._git("reset", "--hard", "-q", tag)
         clean_args = ["clean", "-fdq"]
         for pat in self._exclude:

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -1,0 +1,205 @@
+"""Workspace file-content versioning via a content-addressed shadow-git store.
+
+ADR-0038 Stage 1d (D9). The runtime side of a generation lives in
+``SnapshotGenerationStore`` (per-agent ``AgentSnapshot`` by WAL seq); the
+*workspace files* are the other substrate and live here. A generation ties the
+two at a boundary seq:
+
+    generation(N) = {per-agent AgentSnapshot @ N}  ⊗  {shadow-git commit @ N}
+
+This store is the workspace half: ONE content-addressed shadow-git repo (the
+workspace is a single SSoT — ADR D2) keyed by the GLOBAL WAL seq via tags
+``reyn-gen-<seq>``. Unchanged files are de-duplicated across generations (git
+content-addressing) so cutting a generation at every boundary is cheap.
+
+Design (Claude Code / Cline style):
+- The shadow repo's ``git-dir`` lives under the OS state dir
+  (``.reyn/workspace-shadow.git``) — OUT of the tracked work-tree.
+- The ``work-tree`` is the workspace root. Every git invocation passes explicit
+  ``--git-dir`` / ``--work-tree`` — we never write a ``.git`` file into the
+  work-tree, so the shadow coexists with a user's own git repo untouched.
+- ``.reyn/`` is excluded (via ``<git-dir>/info/exclude``) so OS state (WAL,
+  snapshots, this shadow repo) is never tracked nor wiped on restore.
+
+``capture`` / ``restore_at_or_below`` mirror ``SnapshotGenerationStore.record``
+/ ``nearest_at_or_below`` + ``load`` so ``rewind_to`` drives both substrates the
+same way. When ``git`` is unavailable the store degrades to logged no-ops —
+runtime rewind still works; only workspace-file rewind is skipped.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TAG_PREFIX = "reyn-gen-"
+_TAG_RE = re.compile(rf"^{re.escape(_TAG_PREFIX)}(\d+)$")
+# Marker committer identity — shadow commits never touch the user's git identity.
+_COMMITTER = ("REYN_SHADOW_NAME", "reyn-shadow", "REYN_SHADOW_EMAIL", "reyn@shadow.local")
+
+
+class WorkspaceVersionStore:
+    """Content-addressed shadow-git store for workspace files (ADR-0038 1d).
+
+    Parameters
+    ----------
+    workspace_root:
+        The work-tree captured/restored (= the agent workspace base dir).
+    git_dir:
+        Where the shadow repo lives (e.g. ``.reyn/workspace-shadow.git``).
+        Kept out of the work-tree so OS state is never tracked.
+    exclude:
+        Paths (relative to the work-tree) the shadow never tracks. Defaults to
+        ``[".reyn/"]`` so OS state (WAL / snapshots / this repo) is excluded.
+    """
+
+    def __init__(
+        self,
+        workspace_root: Path,
+        git_dir: Path,
+        *,
+        exclude: list[str] | None = None,
+    ) -> None:
+        self._work_tree = Path(workspace_root)
+        self._git_dir = Path(git_dir)
+        self._exclude = list(exclude) if exclude is not None else [".reyn/"]
+
+    # ── availability ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def git_available() -> bool:
+        """True iff a ``git`` binary is on PATH (else the store no-ops)."""
+        return shutil.which("git") is not None
+
+    # ── capture / restore ─────────────────────────────────────────────────
+
+    def capture(self, seq: int) -> str | None:
+        """Capture the current workspace as the generation tagged ``seq``.
+
+        ``add -A`` + commit + tag ``reyn-gen-<seq>``. Idempotent per seq: if the
+        tag already exists (the global seq was captured by a peer agent's
+        boundary), returns the existing commit sha without re-committing.
+        Returns the commit sha, or ``None`` when git is unavailable.
+        """
+        if not self.git_available():
+            logger.debug("git unavailable — workspace capture(%s) skipped", seq)
+            return None
+        self._ensure_repo()
+        existing = self._tag_sha(self._tag(seq))
+        if existing is not None:
+            return existing
+        self._git("add", "-A")
+        # --allow-empty: a boundary with no file change still gets a generation
+        # so every seq is restorable (matches the runtime snapshot at that seq).
+        self._git(
+            "commit", "--allow-empty", "-q", "-m", f"reyn generation @ seq {seq}",
+        )
+        self._git("tag", self._tag(seq))
+        return self._rev_parse("HEAD")
+
+    def restore_at_or_below(self, seq: int) -> str | None:
+        """Restore the workspace to the nearest generation with tag-seq <= ``seq``.
+
+        ``reset --hard`` to that commit + ``clean -fd`` (honoring the excludes)
+        so files added after the generation are removed while excluded OS state
+        (``.reyn/``) survives. Returns the restored commit sha, or ``None`` when
+        git is unavailable or no generation at-or-below ``seq`` exists.
+        """
+        if not self.git_available():
+            logger.debug("git unavailable — workspace restore(%s) skipped", seq)
+            return None
+        if not self._git_dir.exists():
+            return None
+        base = self._nearest_at_or_below(seq)
+        if base is None:
+            return None
+        tag = self._tag(base)
+        self._git("reset", "--hard", "-q", tag)
+        clean_args = ["clean", "-fdq"]
+        for pat in self._exclude:
+            clean_args += ["-e", pat]
+        self._git(*clean_args)
+        return self._tag_sha(tag)
+
+    # ── queries ──────────────────────────────────────────────────────────
+
+    def seqs(self) -> list[int]:
+        """Sorted list of captured generation seqs (from ``reyn-gen-*`` tags)."""
+        if not self.git_available() or not self._git_dir.exists():
+            return []
+        out = self._git("tag", "--list", f"{_TAG_PREFIX}*")
+        found = []
+        for line in (out or "").splitlines():
+            m = _TAG_RE.match(line.strip())
+            if m:
+                found.append(int(m.group(1)))
+        return sorted(found)
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Delete generations with seq < ``min_keep_seq`` (retention; wired in 1e).
+
+        Returns the number of generation tags removed. Blob GC (``git gc``) is
+        left to the retention sweep (Stage 1e) so a prune is cheap here.
+        """
+        removed = 0
+        for s in self.seqs():
+            if s < min_keep_seq:
+                self._git("tag", "-d", self._tag(s))
+                removed += 1
+        return removed
+
+    # ── internals ──────────────────────────────────────────────────────────
+
+    def _tag(self, seq: int) -> str:
+        return f"{_TAG_PREFIX}{int(seq)}"
+
+    def _nearest_at_or_below(self, seq: int) -> int | None:
+        candidates = [s for s in self.seqs() if s <= seq]
+        return max(candidates) if candidates else None
+
+    def _ensure_repo(self) -> None:
+        """Initialise the shadow repo (idempotent) + write the exclude file."""
+        if not (self._git_dir / "HEAD").exists():
+            self._git_dir.mkdir(parents=True, exist_ok=True)
+            self._git("init", "-q")
+        # Per-repo excludes live in <git-dir>/info/exclude — no tracked
+        # .gitignore, nothing written into the work-tree.
+        info = self._git_dir / "info"
+        info.mkdir(parents=True, exist_ok=True)
+        (info / "exclude").write_text(
+            "".join(f"{pat}\n" for pat in self._exclude), encoding="utf-8",
+        )
+
+    def _git(self, *args: str) -> str:
+        name_k, name_v, email_k, email_v = _COMMITTER
+        cmd = [
+            "git",
+            "--git-dir", str(self._git_dir),
+            "--work-tree", str(self._work_tree),
+            # Pin a shadow identity so commits never depend on (or touch) the
+            # user's global git config.
+            "-c", f"user.name={name_v}",
+            "-c", f"user.email={email_v}",
+            *args,
+        ]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True,
+        )
+        return result.stdout
+
+    def _rev_parse(self, ref: str) -> str | None:
+        try:
+            return self._git("rev-parse", ref).strip() or None
+        except subprocess.CalledProcessError:
+            return None
+
+    def _tag_sha(self, tag: str) -> str | None:
+        try:
+            out = self._git("rev-parse", "--verify", "-q", f"{tag}^{{commit}}")
+        except subprocess.CalledProcessError:
+            return None
+        return out.strip() or None

--- a/tests/chat/services/test_snapshot_journal.py
+++ b/tests/chat/services/test_snapshot_journal.py
@@ -250,3 +250,44 @@ async def test_applied_seq_monotonically_increases(tmp_path):
         assert seqs[i] > seqs[i - 1], (
             f"seq did not increase between op {i-1} and {i}: {seqs}"
         )
+
+
+# ── Stage 1d: two-substrate generation cut (runtime ⊗ workspace) ──────────────
+
+
+@pytest.mark.skipif(__import__("shutil").which("git") is None, reason="git not on PATH")
+@pytest.mark.asyncio
+async def test_cut_generation_captures_both_substrates_at_same_seq(tmp_path):
+    """Tier 2: cut_generation records the runtime gen AND the workspace gen, tied at seq.
+
+    ADR-0038 Stage 1d: a generation ties both substrates at the boundary seq
+    (= snapshot.applied_seq, a WAL seq). With a workspace store attached, one
+    cut_generation must produce a runtime generation AND a shadow-git commit
+    keyed by the same seq, so rewind/recovery can restore them together.
+    """
+    from reyn.events.snapshot_generations import SnapshotGenerationStore
+    from reyn.events.workspace_version_store import WorkspaceVersionStore
+
+    state_log = StateLog(tmp_path / "state.wal")
+    seq = await state_log.append(
+        "inbox_put", target="test_agent", msg_id="m", msg_kind="user", payload={},
+    )
+    gen_store = SnapshotGenerationStore("test_agent", tmp_path / "gens")
+    ws_root = tmp_path / "ws"
+    (ws_root / ".reyn").mkdir(parents=True)
+    (ws_root / "code.py").write_text("v1", encoding="utf-8")
+    ws_store = WorkspaceVersionStore(ws_root, ws_root / ".reyn" / "shadow.git")
+
+    journal = SnapshotJournal(
+        agent_name="test_agent",
+        snapshot_path=tmp_path / "snapshot.json",
+        state_log=state_log,
+        generation_store=gen_store,
+    )
+    journal.set_workspace_store(ws_store)
+    journal.snapshot.applied_seq = seq   # simulate the boundary snapshot
+
+    journal.cut_generation()
+
+    assert seq in gen_store.seqs()       # runtime generation recorded
+    assert seq in ws_store.seqs()        # workspace generation captured at SAME seq

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -9,6 +9,7 @@ floor-clamp (choice (b)), and the no-compaction-during-window guard.
 """
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,8 @@ from reyn.chat.session import ChatSession
 from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.snapshot_generations import RewindIntoAbandonedError, rewind
 from reyn.events.state_log import StateLog
+
+_needs_git = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
 
 
 def _no_factory(_profile):
@@ -191,3 +194,73 @@ async def test_rewind_to_drives_loaded_session_to_as_of_n_zero_residue(tmp_path)
     snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
     assert _inbox_ids(snap) == ["a1"]
     assert snap.applied_seq == result["reset_seq"]
+
+
+# ── two-substrate (workspace) coverage (ADR-0038 Stage 1d) ────────────────────
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_rewind_to_restores_workspace_to_active_gen(tmp_path):
+    """Tier 2: rewind_to restores the workspace substrate to the as-of-N generation."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    ws = reg.workspace_store
+
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+    await _put(log, "alpha", "a1")          # seq 1
+    ws.capture(1)
+    (tmp_path / "code.py").write_text("v2", encoding="utf-8")
+    await _put(log, "alpha", "a2")          # seq 2
+    ws.capture(2)
+
+    await reg.rewind_to(1)
+
+    assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v1"   # workspace as-of-N
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_recover_rewind_restores_active_gen_not_abandoned(tmp_path):
+    """Tier 2: crash mid-rewind ⇒ recovery brings BOTH substrates to as-of-N.
+
+    Simulates a crash AFTER the reset-record is fsync'd but BEFORE materialisation
+    (workspace still at the undone-future v2, no post-rewind capture). Recovery
+    must restore the workspace to the ACTIVE gen-1 (v1) — NOT the abandoned gen-2
+    tag (the highest raw tag <= head) — and re-materialise the runtime snapshot.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    ws = reg.workspace_store
+
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+    await _put(log, "alpha", "a1")          # seq 1  (active, gen-1 = v1)
+    ws.capture(1)
+    (tmp_path / "code.py").write_text("v2", encoding="utf-8")
+    await _put(log, "alpha", "a2")          # seq 2  (will be abandoned, gen-2 = v2)
+    ws.capture(2)
+
+    # reset-record appended (rewind to 1), then crash BEFORE materialisation.
+    R = await rewind(log, target_n=1)       # seq 3 — abandons (1, 3) incl. gen-2@2
+    assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v2"   # pre-recovery
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None and result["recovered_target_n"] == 1
+    # workspace: ACTIVE gen-1 (v1), NOT the abandoned gen-2 tag.
+    assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v1"
+    # runtime: self-contained snapshot re-materialised as-of-N (applied_seq = head).
+    snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(snap) == ["a1"]       # a2 (abandoned future) not present
+    assert snap.applied_seq == R
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_is_noop_without_reset_record(tmp_path):
+    """Tier 2: with no rewind record, recovery is a no-op (returns None)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    await _put(reg.state_log, "alpha", "a1")
+    assert await reg.recover_rewind_if_needed() is None

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -264,3 +264,33 @@ async def test_recover_rewind_is_noop_without_reset_record(tmp_path):
     _seed_agent(tmp_path, "alpha")
     await _put(reg.state_log, "alpha", "a1")
     assert await reg.recover_rewind_if_needed() is None
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_restore_all_triggers_crash_recovery(tmp_path):
+    """Tier 2: restore_all (production startup seam) TRIGGERS crash-mid-rewind recovery.
+
+    Wiring proof — recovery must run via ``restore_all`` (the path the 3 startup
+    sites call), NOT only via a direct ``recover_rewind_if_needed`` call. Simulate
+    a crash mid-rewind (reset-record present, workspace still at the undone-future
+    v2), then call ``restore_all``: the workspace must be restored to the ACTIVE
+    gen-N (v1). Events target an unseeded agent so no non-empty snapshot pulls in
+    the session factory.
+    """
+    reg = _make_registry(tmp_path)          # only the auto 'default' agent (empty)
+    log = reg.state_log
+    ws = reg.workspace_store
+
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+    await _put(log, "ghost", "g1")          # seq 1 (advances seq; 'ghost' not in list_names)
+    ws.capture(1)
+    (tmp_path / "code.py").write_text("v2", encoding="utf-8")
+    await _put(log, "ghost", "g2")          # seq 2
+    ws.capture(2)
+    await rewind(log, target_n=1)           # seq 3 — abandons (1,3); crash before materialise
+    assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v2"   # pre-recovery
+
+    await reg.restore_all()                 # production seam — must trigger recovery
+
+    assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v1"   # recovered to active gen-N

--- a/tests/test_workspace_version_store.py
+++ b/tests/test_workspace_version_store.py
@@ -1,0 +1,121 @@
+"""Tier 2: OS invariant — WorkspaceVersionStore content-addressed shadow-git.
+
+ADR-0038 Stage 1d (D9). Real ``git`` + real filesystem (no mocks). The store is
+the workspace half of a generation: capture the work-tree at a boundary seq,
+restore it as-of-N on rewind. Covers the round-trip (files revert, later-added
+files removed, excluded OS state survives), idempotent capture, nearest-at-or-
+below restore, retention prune, and git-absent graceful degrade.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.events.workspace_version_store import WorkspaceVersionStore
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not on PATH",
+)
+
+
+def _store(tmp_path: Path) -> WorkspaceVersionStore:
+    ws = tmp_path / "ws"
+    (ws / ".reyn").mkdir(parents=True)
+    return WorkspaceVersionStore(ws, ws / ".reyn" / "workspace-shadow.git")
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> None:
+    p = tmp_path / "ws" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _read(tmp_path: Path, rel: str) -> str:
+    return (tmp_path / "ws" / rel).read_text(encoding="utf-8")
+
+
+def test_capture_restore_round_trip(tmp_path):
+    """Tier 2: restore reverts tracked files to as-of-N; later-added files gone; .reyn survives."""
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "v1")
+    _write(tmp_path, ".reyn/wal.jsonl", "os-state")     # OS state — must NOT be tracked/wiped
+
+    store.capture(10)
+
+    # later work: mutate a tracked file + add a new one
+    _write(tmp_path, "file.txt", "v2")
+    _write(tmp_path, "added.txt", "new")
+    store.capture(20)
+    assert _read(tmp_path, "file.txt") == "v2"
+
+    # rewind: restore to as-of-10
+    store.restore_at_or_below(10)
+
+    assert _read(tmp_path, "file.txt") == "v1"               # reverted
+    assert not (tmp_path / "ws" / "added.txt").exists()       # later-added removed
+    assert _read(tmp_path, ".reyn/wal.jsonl") == "os-state"   # excluded OS state survives
+
+
+def test_capture_is_idempotent_per_seq(tmp_path):
+    """Tier 2: capturing the same seq twice returns the same sha (no duplicate gen).
+
+    A global seq may be hit by more than one agent's boundary; the second
+    capture must be a no-op returning the existing commit.
+    """
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "v1")
+
+    first = store.capture(10)
+    second = store.capture(10)
+
+    assert first is not None
+    assert first == second
+    assert store.seqs() == [10]
+
+
+def test_restore_picks_nearest_at_or_below(tmp_path):
+    """Tier 2: restore_at_or_below(s) restores the nearest generation with seq <= s."""
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "gen10")
+    store.capture(10)
+    _write(tmp_path, "file.txt", "gen20")
+    store.capture(20)
+
+    store.restore_at_or_below(15)   # between gens → nearest below = 10
+    assert _read(tmp_path, "file.txt") == "gen10"
+
+
+def test_restore_with_no_generation_returns_none(tmp_path):
+    """Tier 2: restore with no captured generation is a safe no-op (returns None)."""
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "v1")
+    assert store.restore_at_or_below(5) is None
+    assert _read(tmp_path, "file.txt") == "v1"   # untouched
+
+
+def test_seqs_and_prune_below(tmp_path):
+    """Tier 2: seqs() lists captured generations; prune_below drops older ones."""
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "v")
+    for s in (10, 20, 30):
+        _write(tmp_path, "file.txt", f"v{s}")
+        store.capture(s)
+    assert store.seqs() == [10, 20, 30]
+
+    removed = store.prune_below(20)
+    assert removed == 1                 # only gen 10 dropped
+    assert store.seqs() == [20, 30]
+
+
+def test_git_unavailable_degrades_to_noop(tmp_path, monkeypatch):
+    """Tier 2: with no git on PATH, capture/restore degrade to None (runtime rewind still works)."""
+    monkeypatch.setenv("PATH", "")      # real env: no git resolvable
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "v1")
+
+    assert store.git_available() is False
+    assert store.capture(10) is None
+    assert store.restore_at_or_below(10) is None
+    assert store.seqs() == []

--- a/tests/test_workspace_version_store.py
+++ b/tests/test_workspace_version_store.py
@@ -109,6 +109,29 @@ def test_seqs_and_prune_below(tmp_path):
     assert store.seqs() == [20, 30]
 
 
+def test_restore_to_seq_exact_and_missing(tmp_path):
+    """Tier 2: restore_to_seq targets an EXACT generation; unknown seq is a no-op.
+
+    This is the is_active-aware entry the registry uses with an active-resolved
+    gen seq — it restores precisely that tag (never a nearest-below that could be
+    an abandoned-branch gen).
+    """
+    store = _store(tmp_path)
+    _write(tmp_path, "file.txt", "gen10")
+    store.capture(10)
+    _write(tmp_path, "file.txt", "gen20")
+    store.capture(20)
+
+    # exact restore to the older gen even though a newer one exists
+    sha = store.restore_to_seq(10)
+    assert sha is not None
+    assert _read(tmp_path, "file.txt") == "gen10"
+
+    # unknown gen seq → safe no-op (workspace untouched)
+    assert store.restore_to_seq(999) is None
+    assert _read(tmp_path, "file.txt") == "gen10"
+
+
 def test_git_unavailable_degrades_to_noop(tmp_path, monkeypatch):
     """Tier 2: with no git on PATH, capture/restore degrade to None (runtime rewind still works)."""
     monkeypatch.setenv("PATH", "")      # real env: no git resolvable


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Stage 1d (D9). Builds on 1c (runtime rewind, merged). Design-first approved in #1533 (Q1–Q6 + crash-safety + wiring all lead-confirmed); feasibility flow-traced before impl.

## What this lands
Workspace **file content** becomes the second rewind substrate, tied to runtime at the boundary seq: `generation(N) = {per-agent AgentSnapshot @ N} ⊗ {shadow-git commit @ N}`. A global rewind now moves **both** substrates to as-of-N atomically + crash-safely.

- **`WorkspaceVersionStore`** (`events/workspace_version_store.py`) — content-addressed shadow-git: one repo for the single-SSoT workspace, keyed by the global WAL seq via tags `reyn-gen-<seq>`. git-dir under `.reyn` (out of the tracked tree); always-explicit `--git-dir`/`--work-tree` (never writes a `.git` into the work-tree → coexists with a user's own repo); `.reyn/` excluded via `info/exclude`. `capture` idempotent per seq; `restore_to_seq` (is_active-aware exact restore) + `restore_at_or_below` (single-branch convenience); git-absent → logged no-ops (runtime rewind still works).
- **Capture seam** — `SnapshotJournal.cut_generation` records BOTH substrates at the boundary seq (`snapshot.applied_seq`); the registry injects its **single shared** `WorkspaceVersionStore` into every session (`get_or_load` → `attach_workspace_store` → journal), so capture (boundary) and restore (rewind/recovery) use the **same git-dir** (no path-alignment bug).
- **`rewind_to`** delegates materialisation to `_materialize_rewind` (runtime self-contained snapshot **+** `_restore_workspace_active`, is_active-honoring → as-of-N).
- **Crash recovery** — `recover_rewind_if_needed()`: on restart, if an active reset-record is present (`active_rewind_target`), re-materialise **both** substrates as-of the current active head **before** `restore_all` loads sessions. Closes the crash window after the fsync'd reset-record (1b keystone). Idempotent; no-op without a rewind record.

## Correctness refinement (recorded in #1533)
Workspace restore **honors `is_active`** (mirrors runtime `reconstruct`): gen-tags in an abandoned segment `(N,R)` are skipped, so a crash-after-rewind-before-any-post-rewind-capture restores the **active** gen-N, not the abandoned highest-raw-tag.

## Scope / follow-up
- Phase-1 = **host runs** (git-dir + work-tree same FS namespace; registry worktree = `project_root` == workspace base in host mode). **Container mode = tracked follow-up #1544** (no silent defer).
- Blob GC / retention = Stage 1e (per ADR D9).

## Test plan (real git + real instances, no mocks; tier-audit clean)
- [x] `WorkspaceVersionStore`: capture→restore round-trip (files revert, later-added removed, `.reyn` survives); idempotent capture; nearest-at-or-below; `restore_to_seq` exact + missing; seqs/prune; git-absent degrade.
- [x] `rewind_to` restores workspace as-of-N.
- [x] **crash-mid-rewind recovery** → both substrates as-of-N, restoring the **ACTIVE** gen (not the abandoned gen-tag) + re-materialised runtime snapshot; recovery no-op without a reset-record.
- [x] `cut_generation` captures both substrates tied at the same seq.
- [x] Broad regression sweep (workspace/registry/reset/await_quiescent/rewind/journal/truncate/intervention/snapshot-gen): **101 passed**.

Deep-review asks you flagged: crash-mid-shadow-restore recovery / two-substrate atomicity / git-absent degrade / capture-restore same git-dir — all covered above + in tests.

Phase-1 remaining: 1e (retention/floor-clamp/is_active-honoring restore_all), 1f (TUI /rewind), then the end-to-end live-rewind gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)