### PR TITLE
feat(1533): Stage 1e — retention 2-window + floor-clamp + generation GC (D5)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -34,7 +34,9 @@ from typing import Callable
 logger = logging.getLogger(__name__)
 
 from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.events.snapshot_generations import (
+    RewindBeyondRetentionError,
     RewindIntoAbandonedError,
     SnapshotGenerationStore,
     active_rewind_target,
@@ -88,6 +90,7 @@ class AgentRegistry:
         *,
         session_factory: Callable[[AgentProfile], "object"],
         state_log: StateLog | None = None,
+        retention_policy: RetentionPolicy | None = None,
     ) -> None:
         """
         session_factory: returns a configured ChatSession given an AgentProfile.
@@ -97,6 +100,9 @@ class AgentRegistry:
             disabled (tests / non-chat invocation). Owned by the caller; the
             registry just hands it to each constructed session and uses it
             during `restore_all()`.
+        retention_policy: ADR-0038 Stage 1e (D5) retention window. ``None`` →
+            live (current behaviour, no deeper retention). When deeper, clamps the
+            truncation floor + GCs generations/blobs to the configured window.
         """
         self._dir = project_root / ".reyn" / "agents"
         self._dir.mkdir(parents=True, exist_ok=True)
@@ -115,6 +121,8 @@ class AgentRegistry:
         # set, ``maybe_truncate_for_size`` no-ops so a compaction can't advance
         # the WAL keep-floor over the reset-record / reconstruct reads mid-cut.
         self._rewind_in_progress: bool = False
+        # ADR-0038 Stage 1e (D5): retention window. None → live (current).
+        self._retention_policy = retention_policy or RetentionPolicy()
         # ADR-0038 Stage 1d: the workspace half of a generation. One shadow-git
         # for the (single-SSoT) workspace, git-dir under .reyn (out of the
         # tracked tree). Host-mode worktree = project_root; container mode is a
@@ -409,6 +417,18 @@ class AgentRegistry:
             raise RewindIntoAbandonedError(
                 f"rewind target seq {target_n} is on an abandoned branch — "
                 "Phase-1 undo only rewinds to a seq on the active timeline."
+            )
+        # 1e (D5): bounded by retention — reject targets truncated out of the WAL.
+        # Guard on the PHYSICAL oldest kept seq (not the policy floor): under a
+        # live policy nothing is truncated between turns, so recent history stays
+        # rewindable; only genuinely-truncated history is rejected.
+        oldest = next(iter(self._state_log.iter_from(1)), None)
+        oldest_seq = oldest.get("seq") if oldest else None
+        if oldest_seq is not None and target_n < oldest_seq:
+            raise RewindBeyondRetentionError(
+                f"checkpoint seq {target_n} is outside the retained WAL (oldest "
+                f"kept = {oldest_seq}) — it has been truncated. Configure a deeper "
+                "retention window to rewind this far back."
             )
 
         self._rewind_in_progress = True
@@ -761,7 +781,28 @@ class AgentRegistry:
         # Stamp success so throttle gates the next attempt. (We don't gate
         # on dropped==0 — even a no-op rewrite resets the throttle window.)
         self._last_truncation_ts = now
+        # ADR-0038 Stage 1e (D5): GC generations + workspace blobs on the SAME
+        # boundary (Q3 piggyback). prune_below(floor) drops only what is below the
+        # (retention-clamped) WAL floor — generations >= floor stay reconstructable,
+        # so this never drops rewind history within the retention window.
+        self._prune_generations_below(floor)
         return stats
+
+    def _prune_generations_below(self, floor: int) -> None:
+        """Drop snapshot + workspace generations below ``floor`` (Stage 1e GC).
+
+        ``floor`` is the truncation floor (already retention-clamped), so a
+        generation at-or-above it stays reconstructable. Defensive — never raises
+        into the truncation hot path.
+        """
+        try:
+            for name in self.list_names():
+                self._store_for(name).prune_below(floor)
+            ws = self.workspace_store
+            if ws is not None and ws.git_available():
+                ws.prune_below(floor)
+        except Exception as e:  # noqa: BLE001 — defensive; never fail caller
+            logger.warning("Stage 1e generation GC failed (floor=%d): %s", floor, e)
 
     async def maybe_truncate_for_size(
         self, *, threshold_bytes: int | None = None,
@@ -884,7 +925,36 @@ class AgentRegistry:
     _LONG_AWAIT_THRESHOLD_SEC: float = 300.0
 
     def compute_truncate_floor(self) -> int:
-        """Return the lowest seq that MUST remain in the WAL.
+        """Lowest seq that must remain in the WAL, clamped by the retention policy.
+
+        ``= min(live_floor, retention_floor)``. **Live policy → ``live_floor``
+        unchanged** (the in-memory fast path below; no disk reads — preserves
+        PR-N7). Only the **opt-in deeper** policy reads generation seqs (bounded
+        disk) to clamp the floor down so the retention window stays
+        reconstructable (ADR-0038 Stage 1e, D5).
+        """
+        live_floor = self._compute_live_floor()
+        if self._retention_policy.is_live or live_floor <= 0:
+            return live_floor
+        return compute_retention_floor(
+            self._retention_policy,
+            live_floor=live_floor,
+            checkpoint_seqs=self._checkpoint_seqs(),
+        )
+
+    def _checkpoint_seqs(self) -> list[int]:
+        """Global checkpoint (generation) seqs — union across agents' gen stores.
+
+        Disk-backed (gen-dir glob); called ONLY on the non-live retention path so
+        the default floor computation stays in-memory (PR-N7).
+        """
+        seqs: set[int] = set()
+        for name in self.list_names():
+            seqs.update(self._store_for(name).seqs())
+        return sorted(seqs)
+
+    def _compute_live_floor(self) -> int:
+        """Return the lowest seq that MUST remain in the WAL (live floor).
 
         ``floor = min(全 active session applied_seq, 全 active skill
         last_phase_applied_seq, 全 active plan last_step_applied_seq) + 1``

--- a/src/reyn/events/retention.py
+++ b/src/reyn/events/retention.py
@@ -1,0 +1,85 @@
+"""Retention policy + truncation floor clamp (ADR-0038 Stage 1e, D5).
+
+Two retention windows: a fine **WAL** window and a coarse **generation** window.
+The user-facing knob is generation-count (`keep_generations` = "undo back N
+checkpoints"); the WAL fine-window is *derived* (keep WAL back to the oldest
+retained generation's base). `keep_duration` / `keep_bytes` are optional
+secondary axes. **Default = live**: no deeper retention, the floor is the current
+live floor (`min(watermark)+1`) — fully backward compatible.
+
+The clamp consolidates the retention knobs into one policy and guarantees the
+compaction floor never rises past what `reconstruct` needs for any *retained*
+point — the concrete form of the Stage 1c-1 `maybe_truncate` caveat.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """How deep rewind/reconstruct can reach (ADR-0038 D5).
+
+    ``keep_generations`` is the primary, user-facing axis ("undo back N
+    checkpoints"). ``None`` on every field = **live** (current behaviour, no
+    deeper retention). ``keep_duration_secs`` / ``keep_bytes`` are optional
+    secondary axes a config may set; generation-count stays the clean primary.
+    """
+
+    keep_generations: int | None = None
+    keep_duration_secs: float | None = None
+    keep_bytes: int | None = None
+
+    @property
+    def is_live(self) -> bool:
+        """True when no deeper retention is configured (current behaviour)."""
+        return (
+            self.keep_generations is None
+            and self.keep_duration_secs is None
+            and self.keep_bytes is None
+        )
+
+    @classmethod
+    def from_config(cls, cfg: dict | None) -> "RetentionPolicy":
+        """Build from a reyn.yaml ``retention:`` block (or ``None`` → live)."""
+        if not cfg:
+            return cls()
+        return cls(
+            keep_generations=cfg.get("keep_generations"),
+            keep_duration_secs=cfg.get("keep_duration_secs"),
+            keep_bytes=cfg.get("keep_bytes"),
+        )
+
+
+def compute_retention_floor(
+    policy: RetentionPolicy,
+    *,
+    live_floor: int,
+    checkpoint_seqs: list[int],
+) -> int:
+    """Lowest seq that must remain so the retention window is reconstructable.
+
+    ``floor = min(live_floor, oldest_retained_generation_base)``. **Live policy →
+    ``live_floor``** (no clamp). With ``keep_generations = N``, the oldest
+    retained checkpoint is the N-th most recent in ``checkpoint_seqs`` (its seq is
+    the gen base WAL replay starts from); the floor is clamped *down* to it so the
+    last N checkpoints stay reconstructable.
+
+    **Rewind records are retained automatically** (no separate floor term): a
+    rewind record at seq ``R`` abandons ``(N, R)``; for it to affect a retained
+    seq ``S >= floor`` we need ``N < S < R``, hence ``R > S >= floor`` — so any
+    rewind record whose abandoned interval touches the retained window has
+    ``R >= floor`` and is kept (its ``target_n`` rides in the record's data).
+    Rewind records below the floor only abandon intervals entirely below it, so
+    dropping them cannot corrupt ``is_active`` for retained points. (This is why
+    Q2's "oldest in-window rewind record" term is subsumed by the gen-base term;
+    the reconstructability invariant test pins it.)
+    """
+    if policy.is_live or policy.keep_generations is None:
+        return live_floor
+    gens = sorted(checkpoint_seqs)
+    if not gens:
+        return live_floor
+    n = max(1, policy.keep_generations)
+    oldest_retained = gens[-n] if len(gens) >= n else gens[0]
+    return min(live_floor, oldest_retained)

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -104,6 +104,16 @@ class RewindIntoAbandonedError(Exception):
     """
 
 
+class RewindBeyondRetentionError(Exception):
+    """Rewind target is older than the retained WAL (ADR-0038 Stage 1e, D5).
+
+    Rewind is bounded by the retention window — history truncated below the
+    WAL's oldest kept seq cannot be reconstructed. Raised with a decision-enabling
+    message (set retention deeper) rather than failing silently or reconstructing
+    a partial state.
+    """
+
+
 def _rewind_records(state_log: StateLog) -> list[tuple[int, int]]:
     """All rewind reset-records as ``(R, target_n)`` (R = the record's own seq)."""
     out: list[tuple[int, int]] = []

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -294,3 +294,93 @@ async def test_restore_all_triggers_crash_recovery(tmp_path):
     await reg.restore_all()                 # production seam — must trigger recovery
 
     assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v1"   # recovered to active gen-N
+
+
+# ── Stage 1e: retention clamp + GC + window guard ─────────────────────────────
+
+
+class _WatermarkShim:
+    """Minimal session exposing iter_applied_seqs (the floor-calc public surface)."""
+
+    def __init__(self, seqs: list[int]) -> None:
+        self._seqs = seqs
+
+    def iter_applied_seqs(self, *, now_ts: float, long_await_threshold: float) -> list[int]:
+        return list(self._seqs)
+
+
+@pytest.mark.asyncio
+async def test_compute_truncate_floor_clamped_by_retention(tmp_path):
+    """Tier 2: a deeper retention policy clamps the truncate floor below the live floor."""
+    from reyn.chat.registry import AgentRegistry
+    from reyn.events.retention import RetentionPolicy
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+        retention_policy=RetentionPolicy(keep_generations=2),
+    )
+    _seed_agent(tmp_path, "alpha")
+    reg._agents["alpha"] = _WatermarkShim([10])         # live floor = 11
+
+    store = reg._store_for("alpha")                      # record 3 checkpoints
+    for s in (1, 2, 3):
+        snap = AgentSnapshot.empty("alpha")
+        snap.applied_seq = s
+        store.record(snap)
+
+    # keep last 2 gens (2, 3) → oldest retained = 2 → floor = min(11, 2) = 2.
+    assert reg.compute_truncate_floor() == 2
+
+
+@pytest.mark.asyncio
+async def test_live_policy_floor_unchanged(tmp_path):
+    """Tier 2: default (live) policy applies NO clamp — floor stays the live floor."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )  # default policy = live
+    _seed_agent(tmp_path, "alpha")
+    reg._agents["alpha"] = _WatermarkShim([10])
+    store = reg._store_for("alpha")
+    for s in (1, 2, 3):
+        snap = AgentSnapshot.empty("alpha")
+        snap.applied_seq = s
+        store.record(snap)
+
+    assert reg.compute_truncate_floor() == 11            # min(watermark)+1, no clamp
+
+
+@pytest.mark.asyncio
+async def test_truncate_gcs_generations_below_floor(tmp_path):
+    """Tier 2: generation GC drops gens below the floor (retained gens stay)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    store = reg._store_for("alpha")
+    for s in (1, 2, 3):
+        snap = AgentSnapshot.empty("alpha")
+        snap.applied_seq = s
+        store.record(snap)
+    assert store.seqs() == [1, 2, 3]
+
+    reg._prune_generations_below(3)
+
+    kept = reg._store_for("alpha").seqs()
+    assert kept == [3]                                   # 1, 2 GC'd; 3 (>= floor) kept
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_rejects_target_truncated_out_of_wal(tmp_path):
+    """Tier 2: rewinding to a seq below the retained WAL raises (decision-enabling, Q4)."""
+    from reyn.events.snapshot_generations import RewindBeyondRetentionError
+
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a")          # seq 1
+    await _put(log, "alpha", "b")          # seq 2
+    await _put(log, "alpha", "c")          # seq 3
+    await log.truncate_below(3)            # drop seq 1, 2; oldest kept = 3
+
+    with pytest.raises(RewindBeyondRetentionError):
+        await reg.rewind_to(2)             # seq 2 truncated → outside retention window

--- a/tests/test_retention_floor.py
+++ b/tests/test_retention_floor.py
@@ -1,0 +1,160 @@
+"""Tier 2: OS invariant — retention policy + truncation floor clamp (ADR-0038 1e).
+
+Real `StateLog` + `SnapshotGenerationStore` + `reconstruct` (no mocks). The clamp
+guarantees the compaction floor never rises past what `reconstruct` needs for any
+retained checkpoint — the concrete form of the 1c-1 `maybe_truncate` caveat. The
+load-bearing test is the **reconstructability invariant**: every checkpoint inside
+the retention window is still reconstructable after a clamped truncate, including
+across a rewind (abandoned-segment) boundary.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.retention import RetentionPolicy, compute_retention_floor
+from reyn.events.snapshot_generations import (
+    SnapshotGenerationStore,
+    reconstruct,
+    rewind,
+)
+from reyn.events.state_log import StateLog
+
+AGENT = "alpha"
+
+
+async def _put(log: StateLog, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=AGENT, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def _ids(snap: AgentSnapshot) -> list[str]:
+    return [m["id"] for m in snap.inbox]
+
+
+# ── RetentionPolicy ──────────────────────────────────────────────────────────
+
+
+def test_default_policy_is_live():
+    """Tier 2: default policy = live (no deeper retention); any axis set = not live."""
+    assert RetentionPolicy().is_live is True
+    assert RetentionPolicy(keep_generations=3).is_live is False
+    assert RetentionPolicy(keep_duration_secs=10.0).is_live is False
+
+
+def test_from_config():
+    """Tier 2: from_config(None/{}) = live; a config block sets the axes."""
+    assert RetentionPolicy.from_config(None).is_live is True
+    assert RetentionPolicy.from_config({}).is_live is True
+    p = RetentionPolicy.from_config({"keep_generations": 5})
+    assert p.keep_generations == 5 and p.is_live is False
+
+
+# ── compute_retention_floor ──────────────────────────────────────────────────
+
+
+def test_live_policy_returns_live_floor_unchanged():
+    """Tier 2: live policy applies no clamp — backward compatible."""
+    assert compute_retention_floor(
+        RetentionPolicy(), live_floor=42, checkpoint_seqs=[10, 20, 30],
+    ) == 42
+
+
+def test_keep_generations_clamps_down_to_oldest_retained():
+    """Tier 2: keep last N checkpoints → floor clamps to the N-th most recent."""
+    # gens at 10/20/30, keep last 2 → oldest retained = 20 → floor min(99, 20) = 20.
+    assert compute_retention_floor(
+        RetentionPolicy(keep_generations=2), live_floor=99,
+        checkpoint_seqs=[10, 20, 30],
+    ) == 20
+
+
+def test_fewer_generations_than_window_keeps_all():
+    """Tier 2: with fewer checkpoints than N, the oldest is retained."""
+    assert compute_retention_floor(
+        RetentionPolicy(keep_generations=5), live_floor=99,
+        checkpoint_seqs=[10, 20],
+    ) == 10
+
+
+def test_no_generations_falls_back_to_live_floor():
+    """Tier 2: with no checkpoints recorded, the floor stays at the live floor."""
+    assert compute_retention_floor(
+        RetentionPolicy(keep_generations=2), live_floor=42, checkpoint_seqs=[],
+    ) == 42
+
+
+def test_clamp_never_exceeds_live_floor():
+    """Tier 2: floor is min(live_floor, retained) — never keeps less than live."""
+    # retained gen 30 > live_floor 5 → floor stays at live 5 (don't truncate live state).
+    assert compute_retention_floor(
+        RetentionPolicy(keep_generations=1), live_floor=5,
+        checkpoint_seqs=[30],
+    ) == 5
+
+
+# ── reconstructability invariant (the load-bearing test) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retained_checkpoints_reconstructable_after_clamped_truncate(tmp_path):
+    """Tier 2: every retained checkpoint reconstructs after a clamped truncate.
+
+    Build 3 checkpoints; keep last 2; truncate the WAL at the clamped floor; then
+    each retained checkpoint must still reconstruct correctly even though older WAL
+    entries are gone (the generation base bakes them in).
+    """
+    log = StateLog(tmp_path / "wal")
+    store = SnapshotGenerationStore(AGENT, tmp_path / "gens")
+
+    await _put(log, "a")                                   # seq 1
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @1
+    await _put(log, "b")                                   # seq 2
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @2
+    await _put(log, "c")                                   # seq 3
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @3
+
+    floor = compute_retention_floor(
+        RetentionPolicy(keep_generations=2), live_floor=log.current_seq + 1,
+        checkpoint_seqs=store.seqs(),
+    )
+    assert floor == 2                                       # keep gens @2, @3
+    await log.truncate_below(floor)                         # drops seq 1
+
+    # retained checkpoints still reconstruct correctly (gen base bakes truncated history)
+    assert _ids(reconstruct(AGENT, store, log, 2)) == ["a", "b"]
+    assert _ids(reconstruct(AGENT, store, log, 3)) == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_retained_checkpoints_reconstructable_across_rewind(tmp_path):
+    """Tier 2: the clamp keeps rewind records that affect retained points (is_active).
+
+    A rewind abandons a segment; the rewind record sits ABOVE the retained floor
+    (its seq > any retained abandoned seq), so the clamped truncate keeps it and
+    is_active stays derivable — the retained checkpoint reconstructs on the active
+    branch.
+    """
+    log = StateLog(tmp_path / "wal")
+    store = SnapshotGenerationStore(AGENT, tmp_path / "gens")
+
+    await _put(log, "a")                                   # seq 1
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @1
+    await _put(log, "b")                                   # seq 2 (will be abandoned)
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @2
+    await rewind(log, target_n=1)                          # seq 3 — abandons (1,3) incl b
+    await _put(log, "d")                                   # seq 4 (active, new branch)
+    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @4
+
+    floor = compute_retention_floor(
+        RetentionPolicy(keep_generations=2), live_floor=log.current_seq + 1,
+        checkpoint_seqs=store.seqs(),                       # [1, 2, 4]
+    )
+    # keep last 2 checkpoints (2, 4); the rewind record @3 sits within [floor, head]
+    assert floor == 2
+    await log.truncate_below(floor)
+
+    # active-branch reconstruct at head: a (kept) + d (post-rewind), b abandoned.
+    assert _ids(reconstruct(AGENT, store, log, log.current_seq)) == ["a", "d"]


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 Stage 1e (D5). Builds on 1d (merged). Design-first Q1–Q5 + the Q2 interval argument lead-confirmed in #1533.

## What this lands
Bounds how deep rewind/reconstruct can reach + GCs out-of-window history, implementing the 1c-1 `maybe_truncate` caveat concretely.

- **`RetentionPolicy`** (`events/retention.py`) — `keep_generations` primary ("undo back N checkpoints") + optional `keep_duration_secs` / `keep_bytes`; **default = live** (current behaviour, backward compatible). `from_config(reyn.yaml block)`.
- **`compute_retention_floor` = `min(live_floor, oldest_retained_generation_base)`** — clamps the compaction floor *down* to keep the last N checkpoints reconstructable. **Rewind records are auto-retained** (no separate term): a record at `R` abandons `(N,R)`; to affect a retained `S ≥ floor` needs `N<S<R` ⟹ `R>S≥floor`, so it's kept — Q2's "in-window rewind record" term is **subsumed** by the gen-base term (lead independently verified the interval argument).
- **Registry clamp** — `compute_truncate_floor = min(live_floor, retention_floor)`; the existing in-memory floor calc is factored into `_compute_live_floor` so the **default/live path stays byte-identical + disk-free** (PR-N7 preserved); only the opt-in deeper policy reads generation seqs (bounded disk).
- **Generation GC** — piggybacks on `truncate_wal_if_eligible` (Q3 single seam): `_prune_generations_below(floor)` drops snapshot + workspace generations below the (clamped) WAL floor; gens `≥ floor` stay reconstructable, so GC never drops rewind history within the window.
- **Rewind-bounded-by-window guard** — `rewind_to` raises `RewindBeyondRetentionError` (decision-enabling, Q4) for a target below the WAL's **physical** oldest kept seq (not the policy floor — so under a live policy recent untruncated history stays rewindable).
- **Abandoned-branch** (Q5): the clamped floor + prune drop out-of-window abandoned WAL/blobs; within-window retained.

## Test plan (real-instance, no mocks; tier-audit clean; 93-test sweep green)
- [x] `RetentionPolicy` is_live / from_config.
- [x] `compute_retention_floor`: live=unchanged / keep-N clamp / fewer-than-N / no-gens / never-exceeds-live.
- [x] **Reconstructability invariant** (load-bearing): retained checkpoints reconstruct after a clamped truncate, **including across a rewind** (abandoned-segment) boundary.
- [x] Registry: deeper policy clamps the floor below live; **live policy = floor unchanged** (no regression); GC drops gens below floor / keeps ≥floor; `rewind_to` rejects a truncated-out target.
- [x] Existing truncate / rewind / restore_all / intervention-restore / plan suites green.

Deep-review asks you flagged: across-rewind reconstructability invariant test (verify it actually exercises "each retained gen reconstructs across rewind") / GC doesn't drop rewind history / window guard — all covered above.

Phase-1 remaining: **1f** (TUI `/rewind`) → end-to-end live-rewind gate. Coordination: e2e #1547 anchor-text additive `cut_generation` field (my domain) — will sequence the generation-record shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)