### PR TITLE
feat(1533/1f): TUI /rewind time-travel checkpoint picker (Phase-1 label-only)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -50,6 +50,23 @@ from .topology import TOPOLOGY_DIRNAME, Topology, _validate_topology_name
 
 DEFAULT_AGENT_NAME = "default"
 
+# ADR-0038 1f: WAL-entry-kind → rewind-point boundary label. All inputs are
+# OS-level ``WAL_EVENT_KINDS`` (P7-safe — no skill/domain strings). The three
+# output labels are the D6 Phase-1 granularity (turn / plan-step / phase).
+_REWIND_PLAN_STEP_KINDS = frozenset({
+    "step_completed", "step_failed",
+    "plan_step_completed", "plan_step_failed",
+})
+
+
+def _rewind_point_kind(wal_kind: str) -> str:
+    """Map a WAL entry kind to a rewind-point boundary label (turn / plan-step / phase)."""
+    if wal_kind == "skill_phase_advanced":
+        return "phase"
+    if wal_kind in _REWIND_PLAN_STEP_KINDS:
+        return "plan-step"
+    return "turn"
+
 # PR13: synthesized auto-network topology. Members = every known agent
 # that does NOT belong to any user-declared topology. Computed on demand
 # (no caching — registry state mutates and stale caches are a footgun).
@@ -436,6 +453,63 @@ class AgentRegistry:
             }
         finally:
             self._rewind_in_progress = False
+
+    def list_rewind_points(self) -> list[dict]:
+        """Enumerate the active rewind targets for the time-travel UI (1f).
+
+        Returns one row per snapshot-generation boundary on the **active**
+        branch, ascending by seq::
+
+            [{"seq": int, "ts": str, "kind": str}, ...]
+
+        ``seq`` is the WAL boundary the user can ``rewind_to``. ``ts`` and
+        ``kind`` are read from the WAL entry at that seq (the EventStore /
+        audit log is a *separate* log and is intentionally not consulted —
+        WAL and audit stay decoupled). ``kind`` is an OS-level execution
+        boundary derived from the WAL entry kind (P7-safe — all source kinds
+        live in ``WAL_EVENT_KINDS``, none are skill/domain strings):
+
+          - ``skill_phase_advanced``                      → ``phase``
+          - ``step_completed`` / ``step_failed`` /
+            ``plan_step_completed`` / ``plan_step_failed`` → ``plan-step``
+          - anything else (``inbox_consume``, …)           → ``turn``
+
+        Generations are per-agent but keyed by the single global WAL seq, so
+        the union across known agents is the global rewind-point set. Abandoned
+        (rewound-past) boundaries are filtered out via ``is_active_seq``.
+
+        Empty when there is no WAL or no generations.
+        """
+        if self._state_log is None:
+            return []
+
+        # Union of generation boundary seqs across every known agent, keeping
+        # only seqs on the active branch.
+        seqs: set[int] = set()
+        for name in self.list_names():
+            for s in self._store_for(name).seqs():
+                if is_active_seq(self._state_log, s):
+                    seqs.add(s)
+        if not seqs:
+            return []
+
+        # One pass over the WAL to map boundary seq → (ts, kind). The audit
+        # EventStore is NOT consulted — keeping WAL and audit decoupled.
+        wal_at: dict[int, dict] = {}
+        for entry in self._state_log.iter_from(1):
+            s = entry.get("seq")
+            if isinstance(s, int) and s in seqs:
+                wal_at[s] = entry
+
+        rows: list[dict] = []
+        for s in sorted(seqs):
+            entry = wal_at.get(s, {})
+            rows.append({
+                "seq": s,
+                "ts": entry.get("ts", ""),
+                "kind": _rewind_point_kind(entry.get("kind", "")),
+            })
+        return rows
 
     @property
     def workspace_store(self) -> WorkspaceVersionStore | None:

--- a/src/reyn/chat/slash/__init__.py
+++ b/src/reyn/chat/slash/__init__.py
@@ -251,6 +251,7 @@ from reyn.chat.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.chat.slash import plan as _plan_mod  # noqa: E402, F401
 from reyn.chat.slash import quit as _quit_mod  # noqa: E402, F401
 from reyn.chat.slash import reset as _reset_mod  # noqa: E402, F401
+from reyn.chat.slash import rewind as _rewind_mod  # noqa: E402, F401
 from reyn.chat.slash import save as _save_mod  # noqa: E402, F401
 from reyn.chat.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.chat.slash import skills as _skills_mod  # noqa: E402, F401

--- a/src/reyn/chat/slash/rewind.py
+++ b/src/reyn/chat/slash/rewind.py
@@ -1,0 +1,60 @@
+"""``/rewind`` — time-travel to an earlier checkpoint (ADR-0038 1f).
+
+Two forms:
+
+- ``/rewind``      → opens the inline checkpoint picker (RewindMenuWidget). The
+  handler emits a ``__rewind_menu__`` sentinel that ``app_outbox`` routes to
+  the App, which reads ``AgentRegistry.list_rewind_points()`` and mounts the
+  menu. This mirrors how ``/quit`` emits ``__quit__`` — the registry stays the
+  single source of truth for slash dispatch while the App owns the TUI surface.
+
+- ``/rewind <N>``  → rewinds directly to WAL seq ``N`` via
+  ``AgentRegistry.rewind_to`` (scriptable + testable without the TUI). Invalid
+  / out-of-range targets surface a decision-enabling error.
+"""
+from __future__ import annotations
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.chat.slash import reply, reply_error, slash
+
+
+@slash(
+    "rewind",
+    summary="Time-travel to an earlier checkpoint (no arg = pick from a menu)",
+    usage="/rewind [seq]",
+)
+async def rewind_cmd(session: "object", args: str) -> None:
+    arg = (args or "").strip()
+
+    # Bare /rewind → open the picker via the TUI (sentinel routed by app_outbox).
+    if not arg:
+        await session._put_outbox(OutboxMessage(kind="__rewind_menu__", text=""))
+        return
+
+    # /rewind <N> → direct rewind to WAL seq N.
+    try:
+        target = int(arg)
+    except ValueError:
+        await reply_error(session, f"/rewind: expected a checkpoint seq (integer), got {arg!r}")
+        return
+
+    registry = getattr(session, "_registry", None)
+    if registry is None:
+        await reply_error(session, "/rewind: no agent registry attached (rewind unavailable)")
+        return
+
+    try:
+        result = await registry.rewind_to(target)
+    except Exception as exc:  # noqa: BLE001 — surface the reason to the user
+        await reply_error(session, f"/rewind: {exc}")
+        return
+
+    agents = result.get("agents", [])
+    await reply(
+        session,
+        f"⏪ rewound to seq {result.get('target_n', target)} "
+        f"· {len(agents)} agent(s) reset · in-flight cancelled",
+    )
+
+
+__all__ = ["rewind_cmd"]

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -36,6 +36,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.theme import Theme
 
+from reyn.chat.outbox import OutboxMessage
 from reyn.chat.tui._palette import (
     _BORDER_DIM,
     _CORAL,
@@ -124,8 +125,15 @@ class ReynTUIApp(App):
         # so plain Enter in the input bar still does its normal submit.
         Binding("enter", "voice_stop_and_submit", "Voice send", priority=True, show=False),
         # Esc multiplexes: cancel voice recording / close right panel /
-        # close slash picker — see ``action_voice_cancel``.
+        # close slash picker / dismiss rewind menu — see ``action_voice_cancel``.
         Binding("escape", "voice_cancel", "Cancel / close", priority=True, show=False),
+        # ADR-0038 1f: rewind-menu navigation. Priority + check_action-gated to
+        # when the /rewind picker is open, so plain ↑/↓/Enter fall through to
+        # the InputBar (history recall / submit) at all other times — same
+        # gating discipline as ``voice_stop_and_submit`` (Enter) above.
+        Binding("up", "rewind_prev", "Rewind: prev checkpoint", priority=True, show=False),
+        Binding("down", "rewind_next", "Rewind: next checkpoint", priority=True, show=False),
+        Binding("enter", "rewind_confirm", "Rewind: select checkpoint", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
         # Wave-4 AR5: keyboard scroll for the conv log. RichLog has
         # ``can_focus=False`` (intentional — prevents inadvertent
@@ -228,6 +236,10 @@ class ReynTUIApp(App):
         # can reach the find-cycle state living on the router.
         self._outbox_router = None  # type: ignore[assignment]
         self._panel_visible = False
+        # ADR-0038 1f: the mounted RewindMenuWidget while the /rewind picker is
+        # open, else None. Navigation (↑/↓/Enter) + Esc dismiss are gated on
+        # this being non-None via check_action.
+        self._rewind_menu = None  # type: ignore[assignment]
         self._cancel_event: asyncio.Event = asyncio.Event()
         # Most-recent "nothing-in-flight cancel" timestamp, used to
         # suppress repeated identical lines from accumulating in the conv
@@ -275,6 +287,17 @@ class ReynTUIApp(App):
         testing policy.
         """
         return self._panel_visible
+
+    @property
+    def rewind_menu_open(self) -> bool:
+        """Public read of the /rewind picker visibility state (ADR-0038 1f).
+
+        ``True`` while the inline RewindMenuWidget is mounted, ``False``
+        otherwise. Mutate via ``_open_rewind_menu()`` / ``_dismiss_rewind_menu()``
+        — direct assignment to ``_rewind_menu`` is not the public contract.
+        Exposed for tests so they read state through the public surface.
+        """
+        return self._rewind_menu is not None
 
     @property
     def outbox_router(self) -> "OutboxRouter | None":
@@ -2285,13 +2308,15 @@ class ReynTUIApp(App):
         )
 
     def action_voice_cancel(self) -> None:
-        """Esc — cancel voice recording, dismiss slash picker, or close panel.
+        """Esc — cancel voice recording, dismiss slash picker, dismiss rewind
+        menu, or close panel.
 
         Priority:
           1. If recording → cancel recording.
           2. **Else if InputBar is in slash-entry → dismiss picker + clear**
              prefix (= wave-2 P2).
-          3. Else if side panel is visible → close it.
+          3. Else if the rewind menu is open → dismiss it (ADR-0038 1f).
+          4. Else if side panel is visible → close it.
 
         Gated by check_action so this never fires when no condition holds
         (allowing InputBar's own Esc binding to handle slash-picker
@@ -2309,8 +2334,98 @@ class ReynTUIApp(App):
                 return
         except Exception:
             pass
+        # ADR-0038 1f: dismiss the rewind menu before the side panel — the
+        # menu is the most-recently-opened overlay, so Esc should close it
+        # first (matches "abort the visible thing" priority).
+        if self._rewind_menu is not None:
+            self._dismiss_rewind_menu()
+            return
         if self._panel_visible:
             self.action_toggle_panel()
+
+    # ── rewind menu (ADR-0038 1f) ───────────────────────────────────────────
+
+    def _dismiss_rewind_menu(self) -> None:
+        """Unmount the rewind picker, if mounted. Decoupled from the
+        intervention unmount path — a plain ``widget.remove()`` + state clear."""
+        menu = self._rewind_menu
+        self._rewind_menu = None
+        if menu is not None:
+            try:
+                menu.remove()
+            except Exception:
+                pass
+
+    def _open_rewind_menu(self) -> None:
+        """Open the inline /rewind checkpoint picker.
+
+        Reads ``AgentRegistry.list_rewind_points()`` and mounts the menu. When
+        there are no checkpoints (or no registry), writes a system message
+        instead of mounting an empty picker.
+        """
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            return
+        registry = self._agent_registry
+        points = registry.list_rewind_points() if registry is not None else []
+        if not points:
+            conv.render_message(
+                OutboxMessage(kind="system", text="⏪ no checkpoints to rewind to yet")
+            )
+            return
+        # Replace any already-open menu (idempotent re-open).
+        self._dismiss_rewind_menu()
+        self._rewind_menu = conv.mount_rewind_menu(points)
+
+    def action_rewind_prev(self) -> None:
+        """↑ while the rewind menu is open — highlight the previous (older) checkpoint."""
+        if self._rewind_menu is not None:
+            self._rewind_menu.move_selection(-1)
+
+    def action_rewind_next(self) -> None:
+        """↓ while the rewind menu is open — highlight the next (newer) checkpoint."""
+        if self._rewind_menu is not None:
+            self._rewind_menu.move_selection(+1)
+
+    async def action_rewind_confirm(self) -> None:
+        """Enter while the rewind menu is open — rewind to the highlighted checkpoint."""
+        menu = self._rewind_menu
+        if menu is None:
+            return
+        point = menu.selected_point()
+        self._dismiss_rewind_menu()
+        if point is not None:
+            await self._do_rewind(int(point["seq"]))
+
+    async def _do_rewind(self, target_seq: int) -> None:
+        """Invoke ``AgentRegistry.rewind_to`` and write a timeline breadcrumb."""
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            conv = None
+        registry = self._agent_registry
+        if registry is None:
+            if conv is not None:
+                conv.render_message(
+                    OutboxMessage(kind="error", text="⏪ rewind unavailable (no registry)")
+                )
+            return
+        try:
+            result = await registry.rewind_to(target_seq)
+        except Exception as exc:  # noqa: BLE001 — surface the reason in-timeline
+            if conv is not None:
+                conv.render_message(OutboxMessage(kind="error", text=f"⏪ rewind failed: {exc}"))
+            return
+        if conv is not None:
+            agents = result.get("agents", [])
+            conv.render_message(OutboxMessage(
+                kind="system",
+                text=(
+                    f"⏪ rewound to seq {result.get('target_n', target_seq)} "
+                    f"· {len(agents)} agent(s) reset · in-flight cancelled"
+                ),
+            ))
 
     def _voice_config(self):
         """Best-effort fetch of the user's voice config block."""
@@ -2344,12 +2459,19 @@ class ReynTUIApp(App):
                 return self.query_one("#right_panel", RightPanel).panel_type == "events"
             except Exception:
                 return False
+        if action in {"rewind_prev", "rewind_next", "rewind_confirm"}:
+            # ADR-0038 1f: navigation keys are live only while the /rewind
+            # picker is mounted. Otherwise they fall through to the InputBar
+            # (↑/↓ history, Enter submit).
+            return self._rewind_menu is not None
         if action == "voice_cancel":
             # Intercept Esc when there's an overlay/recording to dismiss:
-            # voice recording or the side panel. The slash picker / prefix
-            # case is handled by InputBar's own Esc binding when no other
-            # overlay is present (= simpler dispatch path).
+            # voice recording, the rewind menu, or the side panel. The slash
+            # picker / prefix case is handled by InputBar's own Esc binding
+            # when no other overlay is present (= simpler dispatch path).
             if self._voice_input is not None and self._voice_input.is_recording:
+                return True
+            if self._rewind_menu is not None:
                 return True
             if self._panel_visible:
                 return True

--- a/src/reyn/chat/tui/app_outbox.py
+++ b/src/reyn/chat/tui/app_outbox.py
@@ -238,6 +238,7 @@ class OutboxRouter:
         self.HANDLERS: dict[str, Callable[..., str | None]] = {
             "__end__":                  self._on_end,
             "__quit__":                 self._on_quit,
+            "__rewind_menu__":          self._on_rewind_menu,
             "__attach_request__":       self._on_attach_request,
             "__matrix__":               self._on_matrix,
             "__donut__":                self._on_donut,
@@ -456,6 +457,19 @@ class OutboxRouter:
         graceful teardown + WAL flush).
         """
         self._app.call_later(self._app.action_quit_tui)
+
+    def _on_rewind_menu(
+        self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,
+    ) -> None:
+        """`__rewind_menu__` — bare ``/rewind`` slash; open the inline
+        time-travel checkpoint picker (ADR-0038 1f).
+
+        Mirrors the ``__quit__`` sentinel routing: the slash command stays in
+        the registry (single source of truth + palette/`/help` visibility)
+        while the App owns the TUI surface. The App reads
+        ``AgentRegistry.list_rewind_points()`` and mounts the menu.
+        """
+        self._app.call_later(self._app._open_rewind_menu)
 
     def _on_attach_request(
         self, msg: OutboxMessage, conv: ConversationView, header: ReynHeader,

--- a/src/reyn/chat/tui/widgets/__init__.py
+++ b/src/reyn/chat/tui/widgets/__init__.py
@@ -18,6 +18,7 @@ from .conversation import ConversationView
 from .header import ReynHeader
 from .input_bar import InputBar
 from .intervention import InterventionWidget
+from .rewind_menu import RewindMenuWidget
 from .right_panel import PANEL_TYPES, RightPanel
 from .streaming_row import StreamingRow
 
@@ -26,6 +27,7 @@ __all__ = [
     "ConversationView",
     "InputBar",
     "InterventionWidget",
+    "RewindMenuWidget",
     "StreamingRow",
     "RightPanel",
     "PANEL_TYPES",

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -2265,6 +2265,31 @@ class ConversationView(Widget):
                 pass
         return widget
 
+    def mount_rewind_menu(
+        self,
+        points: list[dict],
+        *,
+        rel_time_fn=None,
+    ) -> "RewindMenuWidget":
+        """Mount the inline time-travel checkpoint picker (ADR-0038 1f).
+
+        ``points`` are rows from ``AgentRegistry.list_rewind_points()``. The
+        widget is passive (``can_focus = False``) — the App drives navigation
+        and removes it via ``widget.remove()`` on selection / Esc (decoupled
+        from the intervention unmount path). Returns the mounted widget so the
+        App can hold a reference for nav + dismiss.
+        """
+        from .rewind_menu import RewindMenuWidget
+        self._consume_empty_hint()
+        widget = RewindMenuWidget(points, rel_time_fn=rel_time_fn)
+        self.mount(widget)
+        if not self._scroll_ctrl.user_scrolled:
+            try:
+                widget.scroll_visible()
+            except Exception:
+                pass
+        return widget
+
     # ── cost suffix (A4) ──────────────────────────────────────────────────────
 
     def render_cost_suffix(

--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -1,0 +1,193 @@
+"""RewindMenuWidget — inline time-travel checkpoint picker (ADR-0038 1f).
+
+Mounts inside ConversationView (not a modal dialog), like InterventionWidget.
+Renders the rewind-point timeline from ``AgentRegistry.list_rewind_points()``
+— one row per snapshot-generation boundary (``seq · ⏱ rel-time · kind``) — and
+lets the user pick a checkpoint to rewind to.
+
+Design (per tui-coder 1f UI-fit cross-review):
+- **``can_focus = False``** — the widget never steals focus; the InputBar stays
+  focused so the user can always type or Esc out. Navigation is app-driven:
+  the App intercepts ↑/↓/Enter (gated to menu-open) and calls
+  ``move_selection`` / ``selected_point``; Esc dismiss is handled by the App's
+  ``action_voice_cancel`` (Esc is a ``priority`` app binding, so it never
+  reaches the widget). See ``app.py``.
+- **Scroll window** — the list can hold 20+ checkpoints, so only ``_MAX_VISIBLE``
+  rows render at once, windowed around the selection (mirrors SlashPicker).
+- **Unmount** is decoupled from the intervention path — the App removes the
+  widget via ``widget.remove()`` after a selection or Esc.
+
+This is a passive render + selection-state widget; the rewind itself (calling
+``AgentRegistry.rewind_to``) is orchestrated by the App, which owns the registry.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from rich.text import Text
+from textual.widget import Widget
+
+from reyn.chat.tui._palette import (
+    _BG_HEADER,
+    _CORAL,
+    _TEXT_BRIGHT,
+    _TEXT_DIM,
+    _TEXT_MUTED,
+)
+
+# Max checkpoint rows rendered at once (mirrors SlashPicker._MAX_VISIBLE). The
+# window slides to keep the selected row visible when the list is longer.
+_MAX_VISIBLE = 8
+
+
+def format_rel_time(ts: str) -> str:
+    """Best-effort relative-time string for a WAL ISO timestamp.
+
+    WAL entries carry ``ts`` as ``datetime.now().isoformat()``. Returns an
+    empty string when the value is missing / unparseable / in the future so
+    the row layout stays intact.
+    """
+    if not ts:
+        return ""
+    try:
+        when = datetime.fromisoformat(ts)
+    except (TypeError, ValueError):
+        return ""
+    now = datetime.now(when.tzinfo) if when.tzinfo else datetime.now()
+    delta = (now - when).total_seconds()
+    if delta < 0:
+        return ""
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    return f"{int(delta // 86400)}d ago"
+
+# kind → short glyph/label for the row's boundary type column.
+_KIND_LABEL = {
+    "turn": "turn",
+    "plan-step": "plan-step",
+    "phase": "phase",
+}
+
+
+class RewindMenuWidget(Widget):
+    """Inline checkpoint picker for ``/rewind``.
+
+    Args:
+        points:          Rows from ``AgentRegistry.list_rewind_points()`` —
+                         each ``{"seq": int, "ts": str, "kind": str}``,
+                         ascending by seq.
+        rel_time_fn:     Optional ``(ts: str) -> str`` formatter for the
+                         relative-time column (e.g. "2m ago"). Defaults to
+                         showing the raw ts (tests inject a deterministic fn).
+    """
+
+    can_focus = False  # trap 2: never steal focus from the InputBar.
+
+    DEFAULT_CSS = f"""
+    RewindMenuWidget {{
+        background: {_BG_HEADER};
+        border-left: thick {_CORAL};
+        padding: 0 1;
+        height: auto;
+        margin: 1 0 0 0;
+    }}
+    """
+
+    def __init__(
+        self,
+        points: list[dict],
+        *,
+        rel_time_fn=None,
+        id: str | None = None,
+    ) -> None:
+        super().__init__(id=id)
+        self._points = list(points)
+        self._rel_time_fn = rel_time_fn or format_rel_time
+        # Default selection = the most-recent checkpoint (bottom). The user
+        # rewinds *backward*, so they navigate up from "now".
+        self._selected = max(0, len(self._points) - 1)
+
+    # ── selection (app-driven nav) ────────────────────────────────────────────
+
+    @property
+    def selected_index(self) -> int:
+        return self._selected
+
+    def move_selection(self, delta: int) -> None:
+        """Move the highlight by ``delta`` rows, clamped to the list bounds.
+
+        Clamp (not wrap): the timeline is finite and ordered, so wrapping from
+        oldest to newest would be disorienting.
+        """
+        if not self._points:
+            return
+        self._selected = max(0, min(len(self._points) - 1, self._selected + delta))
+        self.refresh()
+
+    def selected_point(self) -> dict | None:
+        """The currently highlighted checkpoint row, or None when empty."""
+        if not self._points:
+            return None
+        return self._points[self._selected]
+
+    # ── rendering ─────────────────────────────────────────────────────────────
+
+    def _visible_window(self) -> tuple[int, int]:
+        """Return ``(start, end)`` row indices to render, keeping the selection
+        visible within a ``_MAX_VISIBLE``-row window."""
+        n = len(self._points)
+        if n <= _MAX_VISIBLE:
+            return 0, n
+        # Center the selection where possible, then clamp to the ends.
+        half = _MAX_VISIBLE // 2
+        start = max(0, min(self._selected - half, n - _MAX_VISIBLE))
+        return start, start + _MAX_VISIBLE
+
+    def render(self) -> Text:
+        body = Text()
+        body.append("  ⏪ rewind — pick a checkpoint\n", style=f"bold {_CORAL}")
+
+        if not self._points:
+            body.append("  (no checkpoints yet)\n", style=f"dim {_TEXT_DIM}")
+            return body
+
+        n = len(self._points)
+        start, end = self._visible_window()
+
+        if start > 0:
+            body.append(f"  ↑ {start} earlier…\n", style=f"dim {_TEXT_DIM}")
+
+        # Width for the seq column so kinds/times align.
+        seq_w = max((len(f"#{p['seq']}") for p in self._points), default=3)
+
+        for i in range(start, end):
+            p = self._points[i]
+            is_sel = i == self._selected
+            row = Text()
+            row.append("▌ " if is_sel else "  ", style=_CORAL if is_sel else _BG_HEADER)
+            seq_label = f"#{p['seq']}".ljust(seq_w)
+            row.append(seq_label, style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT)
+            row.append("  ")
+            kind = _KIND_LABEL.get(p.get("kind", ""), p.get("kind", ""))
+            row.append(kind.ljust(10), style=_TEXT_MUTED)
+            rel = self._rel_time_fn(p.get("ts", ""))
+            if rel:
+                row.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
+            row.append("\n")
+            body.append_text(row)
+
+        if end < n:
+            body.append(f"  ↓ {n - end} later…\n", style=f"dim {_TEXT_DIM}")
+
+        body.append(
+            "  ↑/↓ select · Enter rewind · Esc cancel\n",
+            style=f"dim {_TEXT_DIM}",
+        )
+        return body
+
+
+__all__ = ["RewindMenuWidget"]

--- a/tests/test_app_rewind_menu_wiring_1f.py
+++ b/tests/test_app_rewind_menu_wiring_1f.py
@@ -1,0 +1,78 @@
+"""Tier 2: ReynTUIApp rewind-menu wiring — check_action gating + nav (1f).
+
+The /rewind picker navigation (↑/↓/Enter) is app-driven via priority bindings
+gated by ``check_action`` on ``_rewind_menu`` being mounted, so plain ↑/↓/Enter
+fall through to the InputBar at all other times (trap 1 — the same gating
+discipline as voice_stop_and_submit). Esc dismiss is multiplexed through
+``check_action("voice_cancel")``.
+
+These pin the gate truth-table + the nav/dismiss orchestration without a
+running Textual event loop (ReynTUIApp constructs cheaply; check_action and the
+nav actions don't need a mounted DOM).
+
+Real ReynTUIApp + real RewindMenuWidget — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets.rewind_menu import RewindMenuWidget
+
+
+def _points(n: int) -> list[dict]:
+    return [{"seq": i, "ts": "", "kind": "turn"} for i in range(n)]
+
+
+def test_nav_actions_gated_off_when_menu_closed() -> None:
+    """Tier 2: trap 1 — ↑/↓/Enter are inert until the picker is open, so they
+    fall through to the InputBar (history / submit) the rest of the time."""
+    app = ReynTUIApp()
+    assert app.rewind_menu_open is False
+    for action in ("rewind_prev", "rewind_next", "rewind_confirm"):
+        assert app.check_action(action, ()) is False
+
+
+def test_nav_actions_gated_on_when_menu_open() -> None:
+    """Tier 2: trap 1 — ↑/↓/Enter become live once the picker is mounted."""
+    app = ReynTUIApp()
+    app._rewind_menu = RewindMenuWidget(_points(3))
+    for action in ("rewind_prev", "rewind_next", "rewind_confirm"):
+        assert app.check_action(action, ()) is True
+
+
+def test_esc_gate_includes_open_menu() -> None:
+    """Tier 2: trap 1 — Esc (voice_cancel) fires while the menu is open so the
+    priority Esc binding can dismiss it (the widget never sees Esc itself)."""
+    app = ReynTUIApp()
+    assert app.check_action("voice_cancel", ()) is False  # nothing to dismiss
+    app._rewind_menu = RewindMenuWidget(_points(2))
+    assert app.check_action("voice_cancel", ()) is True
+
+
+def test_nav_actions_move_selection() -> None:
+    """Tier 2: action_rewind_prev/next drive the mounted widget's selection."""
+    app = ReynTUIApp()
+    menu = RewindMenuWidget(_points(4))  # selection starts at 3 (bottom)
+    app._rewind_menu = menu
+    app.action_rewind_prev()
+    assert menu.selected_index == 2
+    app.action_rewind_next()
+    assert menu.selected_index == 3
+
+
+def test_dismiss_clears_menu_state() -> None:
+    """Tier 2: trap 4 — dismiss clears the menu state (decoupled unmount)."""
+    app = ReynTUIApp()
+    app._rewind_menu = RewindMenuWidget(_points(2))
+    assert app.rewind_menu_open is True
+    app._dismiss_rewind_menu()
+    assert app.rewind_menu_open is False
+    # Idempotent — dismissing again is a no-op, not a crash.
+    app._dismiss_rewind_menu()
+    assert app.rewind_menu_open is False

--- a/tests/test_registry_list_rewind_points_1f.py
+++ b/tests/test_registry_list_rewind_points_1f.py
@@ -1,0 +1,134 @@
+"""Tier 2: OS invariant — AgentRegistry.list_rewind_points (ADR-0038 1f).
+
+The time-travel UI (Stage 1f) enumerates rewind targets via this method. Each
+row is one snapshot-generation boundary on the active branch:
+``{"seq", "ts", "kind"}``. ``kind`` (turn / plan-step / phase) is derived from
+the WAL entry kind at that seq — an OS-level execution boundary (P7-safe). The
+audit EventStore is intentionally NOT consulted (WAL and audit stay decoupled).
+
+Pins:
+- boundary seqs come from the generation store (not every WAL seq);
+- ts + kind are read from the WAL entry at each boundary seq;
+- WAL kind → label mapping (skill_phase_advanced→phase, step_*→plan-step,
+  else→turn);
+- abandoned (rewound-past) boundaries are filtered out (is_active_seq);
+- rows are ascending by seq.
+
+Real AgentRegistry + StateLog + on-disk generations — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry, _rewind_point_kind
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import rewind
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _record_gen(reg: AgentRegistry, name: str, seq: int) -> None:
+    """Persist a generation for ``name`` cut at boundary ``seq``."""
+    snap = AgentSnapshot.empty(name)
+    snap.applied_seq = seq
+    reg._store_for(name).record(snap)
+
+
+# ── unit: kind mapping ────────────────────────────────────────────────────────
+
+
+def test_rewind_point_kind_mapping() -> None:
+    """Tier 2: WAL entry kind → boundary label (turn / plan-step / phase)."""
+    assert _rewind_point_kind("skill_phase_advanced") == "phase"
+    assert _rewind_point_kind("step_completed") == "plan-step"
+    assert _rewind_point_kind("step_failed") == "plan-step"
+    assert _rewind_point_kind("plan_step_completed") == "plan-step"
+    assert _rewind_point_kind("plan_step_failed") == "plan-step"
+    assert _rewind_point_kind("inbox_consume") == "turn"
+    assert _rewind_point_kind("") == "turn"
+
+
+# ── integration: enumeration ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_reads_ts_and_kind_from_wal(tmp_path) -> None:
+    """Tier 2: each boundary seq → {seq, ts, kind} read from the WAL entry.
+
+    Generations cut at seqs 1 (inbox_consume→turn), 2 (step_completed→plan-step),
+    3 (skill_phase_advanced→phase). The returned rows carry the WAL ts + the
+    derived kind, ascending by seq.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    s2 = await log.append("step_completed", run_id="r1", step="s")
+    s3 = await log.append("skill_phase_advanced", run_id="r1", phase="p")
+    for s in (s1, s2, s3):
+        _record_gen(reg, "alpha", s)
+
+    rows = reg.list_rewind_points()
+
+    assert [r["seq"] for r in rows] == [s1, s2, s3]  # ascending
+    assert [r["kind"] for r in rows] == ["turn", "plan-step", "phase"]
+    # ts is the WAL entry's timestamp — non-empty ISO string for each.
+    assert all(r["ts"] for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_only_generation_boundaries(tmp_path) -> None:
+    """Tier 2: only seqs with a recorded generation appear (not every WAL seq)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    await log.append("inbox_consume", target="alpha", msg_id="m1")  # seq 1, NO gen
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")  # seq 2, gen
+    _record_gen(reg, "alpha", s2)
+
+    rows = reg.list_rewind_points()
+    assert [r["seq"] for r in rows] == [s2]
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_filters_abandoned(tmp_path) -> None:
+    """Tier 2: boundaries on an abandoned branch are excluded (is_active_seq)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")
+    for s in (s1, s2):
+        _record_gen(reg, "alpha", s)
+    await rewind(log, target_n=s1)  # abandons (s1, R) — s2 is now inactive
+
+    rows = reg.list_rewind_points()
+    seqs = [r["seq"] for r in rows]
+    assert s1 in seqs
+    assert s2 not in seqs  # abandoned boundary filtered out
+
+
+def test_list_rewind_points_empty_without_wal(tmp_path) -> None:
+    """Tier 2: no WAL → empty list (no crash)."""
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory)
+    assert reg.list_rewind_points() == []

--- a/tests/test_rewind_menu_widget_1f.py
+++ b/tests/test_rewind_menu_widget_1f.py
@@ -1,0 +1,76 @@
+"""Tier 2: OS invariant — RewindMenuWidget selection + scroll-window (1f).
+
+The time-travel checkpoint picker is a passive, app-driven widget
+(``can_focus = False``): the App drives navigation via ``move_selection`` and
+reads the choice via ``selected_point``. These pin the selection-state surface
++ the long-list scroll window (trap 3) without needing a running Textual app.
+
+Real RewindMenuWidget — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.chat.tui.widgets.rewind_menu import _MAX_VISIBLE, RewindMenuWidget
+
+
+def _points(n: int) -> list[dict]:
+    return [{"seq": i, "ts": f"2026-06-13T00:00:0{i}", "kind": "turn"} for i in range(n)]
+
+
+def test_default_selection_is_most_recent() -> None:
+    """Tier 2: selection defaults to the most-recent checkpoint (bottom row)."""
+    w = RewindMenuWidget(_points(4))
+    assert w.selected_index == 3
+    assert w.selected_point()["seq"] == 3
+
+
+def test_move_selection_clamps_not_wraps() -> None:
+    """Tier 2: ↑/↓ clamp at the list bounds (finite timeline, no wrap)."""
+    w = RewindMenuWidget(_points(3))  # selection starts at index 2
+    w.move_selection(-1)
+    assert w.selected_index == 1
+    w.move_selection(-5)              # clamp at 0, no wrap to bottom
+    assert w.selected_index == 0
+    w.move_selection(+9)              # clamp at top, no wrap to 0
+    assert w.selected_index == 2
+
+
+def test_can_focus_is_false() -> None:
+    """Tier 2: trap 2 — the widget never steals focus from the InputBar."""
+    assert RewindMenuWidget(_points(2)).can_focus is False
+
+
+def test_empty_points_safe() -> None:
+    """Tier 2: empty timeline → no selection, render does not crash."""
+    w = RewindMenuWidget([])
+    assert w.selected_point() is None
+    w.move_selection(-1)  # no-op, no crash
+    assert "no checkpoints" in w.render().plain
+
+
+def test_scroll_window_keeps_selection_visible() -> None:
+    """Tier 2: trap 3 — with 20+ checkpoints only _MAX_VISIBLE render, windowed
+    around the selection — both the selected row and the overflow markers show."""
+    w = RewindMenuWidget(_points(20))  # selection starts at 19 (bottom)
+    rendered = w.render().plain
+    # Only a window of rows is shown, not all 20.
+    shown_rows = [ln for ln in rendered.splitlines() if "#" in ln and "earlier" not in ln]
+    assert len(shown_rows) <= _MAX_VISIBLE
+    # The selected (bottom) row is visible; an "earlier…" overflow marker shows.
+    assert "#19" in rendered
+    assert "earlier" in rendered
+
+    # Navigate to the top — the window slides; "later…" overflow now shows.
+    w.move_selection(-19)
+    rendered_top = w.render().plain
+    assert "#0" in rendered_top
+    assert "later" in rendered_top
+
+
+def test_render_shows_kind_and_reltime() -> None:
+    """Tier 2: each row renders the kind label + a relative-time column."""
+    pts = [{"seq": 5, "ts": "2026-06-13T00:00:00", "kind": "phase"}]
+    w = RewindMenuWidget(pts, rel_time_fn=lambda ts: "2m ago")
+    rendered = w.render().plain
+    assert "#5" in rendered
+    assert "phase" in rendered
+    assert "2m ago" in rendered

--- a/tests/test_slash_rewind_1f.py
+++ b/tests/test_slash_rewind_1f.py
@@ -1,0 +1,127 @@
+"""Tier 2: /rewind slash command — time-travel dispatch (ADR-0038 1f).
+
+Two forms:
+- ``/rewind``     → emits the ``__rewind_menu__`` sentinel (app_outbox routes
+  it to the App, which opens the inline picker). Mirrors ``/quit``→``__quit__``.
+- ``/rewind <N>`` → calls ``AgentRegistry.rewind_to(N)`` directly and surfaces
+  the result (scriptable + TUI-free).
+
+Real AgentRegistry + StateLog for the ``<N>`` path (no mocks); a light session
+stub captures the outbox for the sentinel + error paths.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.slash import REGISTRY
+from reyn.events.state_log import StateLog
+
+
+class _CapturingSession:
+    """Minimal session: captures outbox messages, holds an optional registry."""
+
+    def __init__(self, registry=None) -> None:
+        self.agent_name = "test"
+        self._registry = registry
+        self.outbox_msgs: list = []
+
+    async def _put_outbox(self, msg) -> None:
+        self.outbox_msgs.append(msg)
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+def _handler():
+    cmd = REGISTRY.get("rewind")
+    assert cmd is not None
+    return cmd
+
+
+def test_rewind_is_registered() -> None:
+    """Tier 2: /rewind is in the registry with the seq usage hint."""
+    cmd = _handler()
+    assert "seq" in cmd.usage.lower()
+
+
+@pytest.mark.asyncio
+async def test_bare_rewind_emits_menu_sentinel() -> None:
+    """Tier 2: bare /rewind emits the __rewind_menu__ sentinel (opens the picker)."""
+    session = _CapturingSession()
+    await _handler().handler(session, "")
+    assert [m.kind for m in session.outbox_msgs] == ["__rewind_menu__"]
+
+
+@pytest.mark.asyncio
+async def test_rewind_with_seq_invokes_rewind_to(tmp_path) -> None:
+    """Tier 2: /rewind <N> calls AgentRegistry.rewind_to(N) and reports success.
+
+    Drives a real registry: WAL seq 1 + 2 appended, rewind to seq 1. The
+    reply names the target seq and the agent-reset count; the WAL grows a
+    reset-record (proof rewind_to actually ran).
+    """
+    reg = _make_registry(tmp_path)
+    log = reg.state_log
+    await log.append("inbox_put", target="alpha", msg_id="a", msg_kind="user", payload={})
+    await log.append("inbox_put", target="alpha", msg_id="b", msg_kind="user", payload={})
+    head_before = log.current_seq
+
+    session = _CapturingSession(registry=reg)
+    await _handler().handler(session, "1")
+
+    # A reset-record was appended (rewind_to ran).
+    assert log.current_seq > head_before
+    # The reply names the target seq.
+    texts = [getattr(m, "text", "") for m in session.outbox_msgs]
+    assert any("seq 1" in t and "rewound" in t for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_rewind_non_integer_arg_errors() -> None:
+    """Tier 2: /rewind <non-int> surfaces a decision-enabling error, no crash."""
+    session = _CapturingSession()
+    await _handler().handler(session, "abc")
+    assert [m.kind for m in session.outbox_msgs] == ["error"]
+    assert "abc" in session.outbox_msgs[0].text
+
+
+@pytest.mark.asyncio
+async def test_rewind_seq_without_registry_errors() -> None:
+    """Tier 2: /rewind <N> with no registry attached → error (not a crash)."""
+    session = _CapturingSession(registry=None)
+    await _handler().handler(session, "5")
+    assert [m.kind for m in session.outbox_msgs] == ["error"]
+
+
+@pytest.mark.asyncio
+async def test_rewind_abandoned_target_surfaces_error(tmp_path) -> None:
+    """Tier 2: /rewind <N> into an abandoned branch surfaces rewind_to's error."""
+    from reyn.events.snapshot_generations import rewind as _rewind_record
+    reg = _make_registry(tmp_path)
+    log = reg.state_log
+    await log.append("inbox_put", target="alpha", msg_id="a", msg_kind="user", payload={})
+    await log.append("inbox_put", target="alpha", msg_id="b", msg_kind="user", payload={})
+    await _rewind_record(log, target_n=1)  # abandons seq 2
+
+    session = _CapturingSession(registry=reg)
+    await _handler().handler(session, "2")  # seq 2 is abandoned
+    assert [m.kind for m in session.outbox_msgs] == ["error"]


### PR DESCRIPTION
**[e2e-coder]**

ADR-0038 Stage 1f — the user-facing TUI surface for time-travel rewind. Design-first approved by lead-coder ([#1533 comment](https://github.com/tya5/reyn/issues/1533#issuecomment-4697634616)) with Phase-1 = label-only confirmed + tui-coder's 4 UI-fit traps reflected.

## OS enumerator (P7-safe)
`AgentRegistry.list_rewind_points()` → `[{seq, ts, kind}]`, one row per generation boundary on the **active** branch.
- `seq`/`ts`/`kind` read from the **WAL entry** at each boundary seq — the audit EventStore is **not** consulted, keeping WAL and audit decoupled (`project_wal_vs_audit_event_separation`).
- `kind` ∈ `{turn, plan-step, phase}` derived from the WAL entry kind; all source kinds live in `WAL_EVENT_KINDS` (no skill/domain strings — **P7-verified**).

## TUI surface — tui-coder's 4 mandatory traps
1. **Esc dismiss** — `check_action("voice_cancel")` gate extended to the open menu + `action_voice_cancel` dismisses it before the side panel. (Esc is a `priority` app binding, so it never reaches the passive widget — the App must own dismiss.)
2. **`can_focus = False`** — `RewindMenuWidget` never steals focus from the InputBar; nav is app-driven.
3. **Scroll window** — own render with a `_MAX_VISIBLE`-row window for 20+ checkpoints (mirrors SlashPicker).
4. **Decoupled unmount** — `widget.remove()` in the dismiss path, not the intervention `iv_id`/focus-return path.

↑/↓/Enter are app-level priority bindings gated by `check_action` on the menu being open, so they fall through to the InputBar (history/submit) otherwise — the same gating discipline as `voice_stop_and_submit`.

## Trigger
- `/rewind` (bare) → `__rewind_menu__` sentinel routed by `app_outbox` to open the picker (mirrors `/quit`→`__quit__`; registry stays the single source of truth).
- `/rewind <N>` → `AgentRegistry.rewind_to(N)` direct (scriptable, TUI-free).

## Phase-1 scope
Label-only timeline (seq · rel-time · kind). Per-checkpoint message **preview is Phase-2** (#1547) — assessed as needing a cut-time anchor capture, not an audit-log mine (coordinated with sandbox_2; the `{seq,ts,kind}` shape leaves room for an additive `anchor` field).

## Files
- `src/reyn/chat/registry.py` — `list_rewind_points()` + `_rewind_point_kind()`
- `src/reyn/chat/tui/widgets/rewind_menu.py` — **new** `RewindMenuWidget` + `format_rel_time`
- `src/reyn/chat/tui/widgets/conversation.py` — `mount_rewind_menu()`
- `src/reyn/chat/tui/app.py` — nav bindings, `check_action` gates, Esc dismiss, `_open_rewind_menu`/`_do_rewind`, `rewind_menu_open` property
- `src/reyn/chat/tui/app_outbox.py` — `__rewind_menu__` handler
- `src/reyn/chat/slash/rewind.py` — **new** `/rewind` command

## Test plan
- [x] `pytest tests/test_registry_list_rewind_points_1f.py tests/test_rewind_menu_widget_1f.py tests/test_slash_rewind_1f.py tests/test_app_rewind_menu_wiring_1f.py` — 22 passed
- [x] `pytest tests/cli/ tests/test_slash_*.py tests/test_registry_rewind_to.py` — 1181+ passed (no regression)
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict <4 new files>` — 0 violations
- [x] Production caller verified: `list_rewind_points()` called at `app.py:_open_rewind_menu` (not test-only)
- [ ] (Manual, TUI) `reyn chat` → `/rewind` opens picker, ↑/↓ navigate, Enter rewinds, Esc dismisses — **deferred to tui-coder's impl re-cross-review** (real-terminal e2e via tmux MCP; headless harness can't drive the full mounted-DOM key path)

## Design note for review
↑/↓/Enter nav is routed through **app-level gated bindings** (not widget `on_key`) because trap 2 (`can_focus=False`) means the widget can't receive keys directly — this matches the passive SlashPicker model + the proven `voice_stop_and_submit` gating. Flagging for tui-coder's re-cross-review in case widget-focus nav is preferred.

Follow-ups: #1546 (Esc-Esc trigger), #1547 (Phase-2 preview). Refs #1533.