### PR TITLE
fix(1533/1550): /rewind menu scrolled-up status-hint parity

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2355,6 +2355,13 @@ class ReynTUIApp(App):
                 menu.remove()
             except Exception:
                 pass
+            # Clear the scrolled-up "⏪ rewind menu below ↓" cue (#1550) so it
+            # doesn't linger after the picker is gone. Mirrors the
+            # intervention_resolved hide_status on both answer paths.
+            try:
+                self.query_one("#conversation", ConversationView).hide_status()
+            except Exception:
+                pass
 
     def _open_rewind_menu(self) -> None:
         """Open the inline /rewind checkpoint picker.

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -2281,6 +2281,15 @@ class ConversationView(Widget):
         """
         from .rewind_menu import RewindMenuWidget
         self._consume_empty_hint()
+        # Parity with mount_intervention (#1550): when the user has scrolled up
+        # to read history, the menu renders at the tail where they can't see it.
+        # Surface a "⏪ rewind menu below ↓" cue (same mechanism as the
+        # intervention "⚑ … below ↓" hint) so they know the picker is waiting.
+        # At the tail, a bare hide_status suffices — the widget is visible.
+        if self._scroll_ctrl.user_scrolled:
+            self.show_status("⏪ rewind menu below ↓", kind="general")
+        else:
+            self.hide_status()
         widget = RewindMenuWidget(points, rel_time_fn=rel_time_fn)
         self.mount(widget)
         if not self._scroll_ctrl.user_scrolled:

--- a/tests/cli/test_rewind_menu_scroll_hint_1550.py
+++ b/tests/cli/test_rewind_menu_scroll_hint_1550.py
@@ -1,0 +1,112 @@
+"""Tier 2: /rewind menu scrolled-up status-hint parity (#1550).
+
+When the user has scrolled up to read history, the rewind picker renders at the
+tail where they can't see it — so ``mount_rewind_menu`` surfaces a
+``⏪ rewind menu below ↓`` cue on the StickyStatus, parity with how
+``mount_intervention`` surfaces ``⚑ intervention below ↓``. At the tail the cue
+is suppressed (the widget is visible). Dismissing the picker clears the cue.
+
+Public-surface only — ``StickyStatus.snapshot()`` (active/body) + the real
+mounted DOM via the ``run_test`` pilot. No private-state asserts, no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+from textual.widgets import RichLog
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.sticky_status import StickyStatus
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None, agent_name="test-agent", model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _points() -> list[dict]:
+    return [{"seq": i, "ts": "", "kind": "turn"} for i in range(3)]
+
+
+def _fill_log(log: RichLog, n: int) -> None:
+    for i in range(n):
+        log.write(Text(f"line {i}"))
+
+
+@pytest.mark.asyncio
+async def test_scrolled_up_mount_shows_rewind_cue() -> None:
+    """Tier 2: scrolled-up + mount_rewind_menu → StickyStatus shows the
+    "rewind menu below ↓" cue (parity with the intervention below-cue)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        _fill_log(log, 60)
+        await pilot.pause()
+        assert log.max_scroll_y > 5, "test setup: need scrollback"
+
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        await pilot.pause()
+        assert conv.user_scrolled is True
+
+        conv.mount_rewind_menu(_points())
+        await pilot.pause()
+
+        snap = sticky.snapshot()
+        assert snap["active"] is True
+        assert "rewind menu below" in snap["body"].lower()
+
+
+@pytest.mark.asyncio
+async def test_at_tail_mount_shows_no_cue() -> None:
+    """Tier 2: following the tail → no below-cue (the widget is visible)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        assert conv.user_scrolled is False
+
+        conv.mount_rewind_menu(_points())
+        await pilot.pause()
+
+        # No rewind cue while at the tail (hide_status path).
+        snap = sticky.snapshot()
+        assert "rewind menu below" not in snap["body"].lower()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_clears_rewind_cue() -> None:
+    """Tier 2: dismissing the picker clears the scrolled-up cue (no lingering)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 10)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        log = conv.query_one(RichLog)
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        _fill_log(log, 60)
+        await pilot.pause()
+        log.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        await pilot.pause()
+
+        app._rewind_menu = conv.mount_rewind_menu(_points())
+        await pilot.pause()
+        assert "rewind menu below" in sticky.snapshot()["body"].lower()
+
+        app._dismiss_rewind_menu()
+        await pilot.pause()
+        assert sticky.snapshot()["active"] is False


### PR DESCRIPTION
**[e2e-coder]** — Fixes #1550 (tui-coder live-e2e re-cross-review finding, non-blocking polish on the merged 1f /rewind menu).

## Problem
When the user has scrolled up to read history, the `/rewind` picker mounts at the tail where they can't see it. `mount_intervention` surfaces a `⚑ intervention below ↓` cue in that case; `mount_rewind_menu` had no equivalent, so the menu could open unnoticed.

## Fix (reuses the existing `show_status` mechanism — no new machinery)
- `mount_rewind_menu`: when `_scroll_ctrl.user_scrolled`, `show_status("⏪ rewind menu below ↓")`; else `hide_status` (at the tail the widget is visible). Exact parity with `mount_intervention`.
- `_dismiss_rewind_menu`: `hide_status` so the cue clears on Esc / Enter and never lingers (mirrors `intervention_resolved`'s `hide_status` on both answer paths).

Per [[feedback_existing_mechanism_grep_before_new_fix]]: reuses `show_status`/`hide_status`, no parallel mechanism.

## Files
- `src/reyn/chat/tui/widgets/conversation.py` — `mount_rewind_menu` scrolled-up cue
- `src/reyn/chat/tui/app.py` — `_dismiss_rewind_menu` clears the cue

## Test plan
- [x] `pytest tests/cli/test_rewind_menu_scroll_hint_1550.py` — 3 passed (run_test pilot harness, real mounted DOM, `StickyStatus.snapshot()` public surface)
- [x] `pytest tests/cli/test_conv_new_below_indicator.py tests/cli/test_tui_smoke.py tests/cli/test_conv_clear_sweeps_intervention_widgets.py tests/test_*rewind*` — 60 passed (no regression)
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations

Pure UX discoverability polish — the key-driven flow itself passed live e2e (8/8, #1549) and is unchanged. Refs #1533.