### PR TITLE
feat(1533/#1547): per-checkpoint anchor-text preview on the rewind timeline

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -34,6 +34,7 @@ from typing import Callable
 logger = logging.getLogger(__name__)
 
 from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.anchor_store import AnchorStore
 from reyn.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.events.snapshot_generations import (
     RewindBeyondRetentionError,
@@ -146,6 +147,9 @@ class AgentRegistry:
         # tracked follow-up (#1544). Lazily built so non-chat / no-WAL callers
         # never touch git.
         self._workspace_store: WorkspaceVersionStore | None = None
+        # #1547: per-checkpoint anchor text (rewind-timeline preview). One global
+        # store keyed by WAL seq; lazily built. None when no WAL.
+        self._anchor_store: AnchorStore | None = None
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
@@ -521,6 +525,7 @@ class AgentRegistry:
             if isinstance(s, int) and s in seqs:
                 wal_at[s] = entry
 
+        anchors = self.anchor_store
         rows: list[dict] = []
         for s in sorted(seqs):
             entry = wal_at.get(s, {})
@@ -528,6 +533,10 @@ class AgentRegistry:
                 "seq": s,
                 "ts": entry.get("ts", ""),
                 "kind": _rewind_point_kind(entry.get("kind", "")),
+                # #1547: per-checkpoint preview anchor ("" when none). Additive —
+                # existing consumers ignore it; the timeline widget renders it as
+                # a 2nd dim line. Keyed by the same WAL seq → trivial lookup.
+                "anchor": anchors.get(s) if anchors is not None else "",
             })
         return rows
 
@@ -547,6 +556,17 @@ class AgentRegistry:
                 self._project_root / ".reyn" / "workspace-shadow.git",
             )
         return self._workspace_store
+
+    @property
+    def anchor_store(self) -> AnchorStore | None:
+        """The per-checkpoint anchor store (#1547), lazily built. None w/o WAL."""
+        if self._state_log is None:
+            return None
+        if self._anchor_store is None:
+            self._anchor_store = AnchorStore(
+                self._project_root / ".reyn" / "generation-anchors.json",
+            )
+        return self._anchor_store
 
     async def _materialize_rewind(
         self, *, reconstruct_seq: int, workspace_at_or_below: int,
@@ -875,6 +895,10 @@ class AgentRegistry:
             ws = self.workspace_store
             if ws is not None and ws.git_available():
                 ws.prune_below(floor)
+            # #1547: anchors GC'd on the same boundary as generations/blobs.
+            anchors = self.anchor_store
+            if anchors is not None:
+                anchors.prune_below(floor)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("Stage 1e generation GC failed (floor=%d): %s", floor, e)
 
@@ -1112,6 +1136,12 @@ class AgentRegistry:
         attach = getattr(session, "attach_workspace_store", None)
         if ws is not None and callable(attach):
             attach(ws)
+        # #1547: hand the session the shared anchor store so cut_generation
+        # records the rewind-timeline preview text at each boundary.
+        anchors = self.anchor_store
+        attach_anchor = getattr(session, "attach_anchor_store", None)
+        if anchors is not None and callable(attach_anchor):
+            attach_anchor(anchors)
         self._agents[name] = session
         return session
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -52,6 +52,9 @@ class SnapshotJournal:
         # cut_generation captures workspace files at the SAME boundary as the
         # runtime snapshot. None → no workspace versioning (capture is skipped).
         self._workspace_store = None
+        # #1547: per-checkpoint anchor text (truncated last user message). Set
+        # post-construction by the registry. None → no anchor capture.
+        self._anchor_store = None
         self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name)
 
     def set_workspace_store(self, workspace_store) -> None:
@@ -62,7 +65,15 @@ class SnapshotJournal:
         """
         self._workspace_store = workspace_store
 
-    def cut_generation(self) -> None:
+    def set_anchor_store(self, anchor_store) -> None:
+        """Attach the shared per-checkpoint anchor store (#1547).
+
+        Injected by the registry so the capture seam (cut_generation) and the
+        timeline surface (list_rewind_points) share one store keyed by WAL seq.
+        """
+        self._anchor_store = anchor_store
+
+    def cut_generation(self, anchor: str = "") -> None:
         """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a/1d).
 
         Called at user-facing checkpoint boundaries (turn / plan-step) — a
@@ -72,12 +83,18 @@ class SnapshotJournal:
         shadow-git commit. Additive to the per-mutation ``save()``. No-op when no
         generation store / WAL is configured; workspace capture is skipped when
         no workspace store is attached (or git is unavailable — handled there).
+
+        ``anchor`` (#1547): the truncated last user message for the rewind-timeline
+        preview, captured against the same boundary seq. Empty / no anchor store →
+        skipped (turn boundaries pass it; plan-step / phase cuts leave it empty).
         """
         if self._generation_store is None or self._state_log is None:
             return
         self._generation_store.record(self._snapshot)
         if self._workspace_store is not None:
             self._workspace_store.capture(self._snapshot.applied_seq)
+        if self._anchor_store is not None and anchor:
+            self._anchor_store.capture(self._snapshot.applied_seq, anchor)
 
     # ── public read access ────────────────────────────────────────────────
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -51,6 +51,7 @@ from reyn.config import (  # noqa: F401
     SandboxConfig,
 )
 from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.anchor_store import truncate_anchor as _truncate_anchor
 from reyn.events.event_store import EventStore
 from reyn.events.events import EventLog
 from reyn.events.snapshot_generations import SnapshotGenerationStore
@@ -2299,6 +2300,15 @@ class ChatSession:
         restores from.
         """
         self._journal.set_workspace_store(workspace_store)
+
+    def attach_anchor_store(self, anchor_store) -> None:
+        """Attach the shared per-checkpoint anchor store (#1547).
+
+        The registry injects its single ``AnchorStore`` so the journal's
+        ``cut_generation`` records the rewind-timeline preview text against the
+        same boundary seq the registry's ``list_rewind_points`` surfaces.
+        """
+        self._journal.set_anchor_store(anchor_store)
 
     async def reset_for_rewind(self) -> None:
         """Clear all in-memory state ``restore_state`` repopulates (ADR-0038 1c-2).
@@ -5039,8 +5049,9 @@ class ChatSession:
     ) -> None:
         """Forwarding → RouterLoopDriver.run_turn (PR-3)."""
         await self._loop_driver.run_turn(user_text, chain_id)
-        # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint.
-        self._journal.cut_generation()
+        # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
+        # user message is this checkpoint's anchor for the rewind-timeline preview.
+        self._journal.cut_generation(anchor=_truncate_anchor(user_text))
 
     async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
         """Forwarding → RouterLoopDriver._run_with_shrink (PR-3)."""

--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -179,6 +179,13 @@ class RewindMenuWidget(Widget):
                 row.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
             row.append("\n")
             body.append_text(row)
+            # #1547: per-checkpoint anchor (truncated last user message) as a 2nd
+            # dim line, aligned under the kind column. Additive — empty = omitted.
+            anchor = p.get("anchor", "")
+            if anchor:
+                body.append(
+                    f"{' ' * (4 + seq_w)}{anchor}\n", style=f"dim {_TEXT_DIM}",
+                )
 
         if end < n:
             body.append(f"  ↓ {n - end} later…\n", style=f"dim {_TEXT_DIM}")

--- a/src/reyn/events/anchor_store.py
+++ b/src/reyn/events/anchor_store.py
@@ -1,0 +1,85 @@
+"""Per-checkpoint anchor-text store for the rewind timeline (ADR-0038 #1547).
+
+The TUI ``/rewind`` timeline (1f) shows each checkpoint as ``seq · rel-time ·
+kind``. This store adds the *content* anchor — the truncated last user message
+at that checkpoint — captured at ``cut_generation`` time (the ``history_buffer``
+holds it in-memory, so it is cheap, robust, and survives independent of audit-log
+rotation). It is the **correct source** (vs mining the audit EventStore, which has
+no WAL seq and would need a cross-log join — see #1547 rationale).
+
+One global store keyed by the single global WAL seq (the same key the timeline +
+generations use), so surfacing an anchor is a trivial seq lookup with no cross-log
+correlation. Additive-only: nothing in the 1a–1e generation contract changes.
+``prune_below`` is GC'd on the same boundary as Stage 1e retention.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT = 80
+
+
+def truncate_anchor(text: str, *, limit: int = _DEFAULT_LIMIT) -> str:
+    """Collapse to a single line + truncate to ``limit`` chars (ellipsis if cut)."""
+    one_line = " ".join(text.split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: limit - 1].rstrip() + "…"
+
+
+class AnchorStore:
+    """Maps a WAL checkpoint seq → its anchor text (truncated last user message).
+
+    JSON-backed (``{seq: text}``); anchors are tiny and bounded by the retention
+    window. ``get`` returns ``""`` for an unknown seq so callers can slot the
+    field in unconditionally.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._anchors: dict[int, str] | None = None
+
+    def _load(self) -> dict[int, str]:
+        if self._anchors is None:
+            try:
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
+                self._anchors = {int(k): str(v) for k, v in raw.items()}
+            except FileNotFoundError:
+                self._anchors = {}
+            except (OSError, ValueError) as e:
+                logger.warning("anchor store load failed (%s): %s", self._path, e)
+                self._anchors = {}
+        return self._anchors
+
+    def _save(self) -> None:
+        anchors = self._load()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps({str(k): v for k, v in anchors.items()}),
+            encoding="utf-8",
+        )
+
+    def capture(self, seq: int, text: str) -> None:
+        """Record the anchor ``text`` for checkpoint ``seq`` (idempotent overwrite)."""
+        if not text:
+            return
+        self._load()[int(seq)] = text
+        self._save()
+
+    def get(self, seq: int) -> str:
+        """Return the anchor for ``seq``, or ``""`` when none is recorded."""
+        return self._load().get(int(seq), "")
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Drop anchors with seq < ``min_keep_seq`` (Stage 1e retention GC)."""
+        anchors = self._load()
+        drop = [s for s in anchors if s < min_keep_seq]
+        for s in drop:
+            del anchors[s]
+        if drop:
+            self._save()
+        return len(drop)

--- a/src/reyn/events/anchor_store.py
+++ b/src/reyn/events/anchor_store.py
@@ -58,10 +58,17 @@ class AnchorStore:
     def _save(self) -> None:
         anchors = self._load()
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(
+        # Atomic tmp+rename: a torn write must never wipe ALL anchors (this store
+        # is rewritten every turn, so torn-write risk is higher than a once-written
+        # profile, and _load degrades a corrupt file to {} → the next save would
+        # overwrite with {}). fsync is intentionally omitted — anchors are
+        # preview-tier, not sync-durability-critical (WAL/audit separation intent).
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(
             json.dumps({str(k): v for k, v in anchors.items()}),
             encoding="utf-8",
         )
+        tmp.replace(self._path)
 
     def capture(self, seq: int, text: str) -> None:
         """Record the anchor ``text`` for checkpoint ``seq`` (idempotent overwrite)."""

--- a/tests/test_anchor_text_1547.py
+++ b/tests/test_anchor_text_1547.py
@@ -1,0 +1,126 @@
+"""Tier 2: OS invariant — per-checkpoint anchor-text preview (#1547).
+
+Real AnchorStore + SnapshotJournal + AgentRegistry + RewindMenuWidget (no mocks).
+The anchor (truncated last user message) is captured at cut_generation, keyed by
+WAL seq, surfaced additively by list_rewind_points, and rendered as a 2nd dim line.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.services.snapshot_journal import SnapshotJournal
+from reyn.chat.tui.widgets.rewind_menu import RewindMenuWidget
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.anchor_store import AnchorStore, truncate_anchor
+from reyn.events.snapshot_generations import SnapshotGenerationStore
+from reyn.events.state_log import StateLog
+
+
+# ── truncate_anchor ──────────────────────────────────────────────────────────
+
+
+def test_truncate_anchor_collapses_and_truncates():
+    """Tier 2: anchor collapses whitespace to one line + truncates with ellipsis."""
+    assert truncate_anchor("  hello   world\n") == "hello world"
+    long = "x" * 200
+    out = truncate_anchor(long, limit=80)
+    assert out.endswith("…")            # truncation marker appended
+    assert len(out) < len(long)         # actually shortened (behavioral, not a size pin)
+
+
+# ── AnchorStore ──────────────────────────────────────────────────────────────
+
+
+def test_anchor_store_capture_get_prune(tmp_path):
+    """Tier 2: capture/get round-trip; unknown seq = ""; prune drops below floor."""
+    store = AnchorStore(tmp_path / "anchors.json")
+    store.capture(10, "first")
+    store.capture(20, "second")
+    assert store.get(10) == "first"
+    assert store.get(20) == "second"
+    assert store.get(99) == ""              # unknown → empty
+    store.capture(30, "")                    # empty text → no-op
+    assert store.get(30) == ""
+
+    removed = store.prune_below(20)
+    assert removed == 1                      # seq 10 dropped
+    assert store.get(10) == "" and store.get(20) == "second"
+
+
+def test_anchor_store_persists_across_instances(tmp_path):
+    """Tier 2: anchors are durable — a fresh store over the same path reads them."""
+    AnchorStore(tmp_path / "a.json").capture(5, "kept")
+    assert AnchorStore(tmp_path / "a.json").get(5) == "kept"
+
+
+# ── cut_generation capture ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cut_generation_captures_anchor(tmp_path):
+    """Tier 2: cut_generation(anchor=...) records it under the boundary seq; no anchor = no capture."""
+    log = StateLog(tmp_path / "wal")
+    seq = await log.append("inbox_put", target="a", msg_id="m", msg_kind="user", payload={})
+    journal = SnapshotJournal(
+        agent_name="a", snapshot_path=tmp_path / "snap.json", state_log=log,
+        generation_store=SnapshotGenerationStore("a", tmp_path / "gens"),
+    )
+    anchors = AnchorStore(tmp_path / "anchors.json")
+    journal.set_anchor_store(anchors)
+    journal.snapshot.applied_seq = seq
+
+    journal.cut_generation(anchor="rewind me here")
+    assert anchors.get(seq) == "rewind me here"
+
+    # a later cut with no anchor (e.g. plan-step) leaves the slot empty.
+    seq2 = await log.append("inbox_put", target="a", msg_id="n", msg_kind="user", payload={})
+    journal.snapshot.applied_seq = seq2
+    journal.cut_generation()                 # no anchor
+    assert anchors.get(seq2) == ""
+
+
+# ── list_rewind_points surfacing ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_surfaces_anchor(tmp_path):
+    """Tier 2: list_rewind_points adds the anchor field additively (per WAL seq)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+
+    seq = await state_log.append(
+        "inbox_put", target="alpha", msg_id="m", msg_kind="user", payload={},
+    )
+    snap = AgentSnapshot.empty("alpha")
+    snap.applied_seq = seq
+    reg._store_for("alpha").record(snap)             # a generation at this seq
+    reg.anchor_store.capture(seq, "what's the weather")
+
+    rows = reg.list_rewind_points()
+    row = next(r for r in rows if r["seq"] == seq)
+    assert row["anchor"] == "what's the weather"     # surfaced additively
+    assert set(row) >= {"seq", "ts", "kind", "anchor"}
+
+
+# ── widget render ────────────────────────────────────────────────────────────
+
+
+def test_widget_renders_anchor_dim_line():
+    """Tier 2: RewindMenuWidget renders the anchor as a 2nd line; empty = omitted."""
+    with_anchor = RewindMenuWidget(
+        [{"seq": 1, "ts": "", "kind": "turn", "anchor": "fix the parser bug"}],
+    )
+    assert "fix the parser bug" in with_anchor.render().plain
+
+    # additive: a row without an anchor renders exactly as before (no extra line).
+    without = RewindMenuWidget([{"seq": 1, "ts": "", "kind": "turn", "anchor": ""}])
+    assert "fix the parser bug" not in without.render().plain

--- a/tests/test_anchor_text_1547.py
+++ b/tests/test_anchor_text_1547.py
@@ -19,7 +19,6 @@ from reyn.events.anchor_store import AnchorStore, truncate_anchor
 from reyn.events.snapshot_generations import SnapshotGenerationStore
 from reyn.events.state_log import StateLog
 
-
 # ── truncate_anchor ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**[dogfood-coder]** — #1547 (Phase-2 of the time-travel `/rewind` timeline). Builds on 1f Phase-1 (#1549, merged). Contract design-locked with e2e-coder in #1533 / broker.

## What this lands
Each rewind checkpoint now shows its **content anchor** — the truncated last user message — so the timeline reads `#seq · kind · rel-time` + a dim preview line, à la Claude Code's `/rewind`.

**Correct source** (vs mining the audit EventStore): captured at `cut_generation` from the in-memory turn context. The audit `Event` has no WAL seq and would need a cross-log join — rejected per #1547 rationale, respecting `project_wal_vs_audit_event_separation`.

- **`AnchorStore`** (`events/anchor_store.py`) — one global JSON store keyed by WAL seq (same key as the timeline + generations → trivial lookup, no cross-log). `capture(seq, text)` / `get(seq)→""` / `prune_below(floor)` + `truncate_anchor()` (single-line, ~80c, ellipsis).
- **Capture seam** — `cut_generation(anchor="")` records it against the boundary seq; the session passes `truncate_anchor(user_text)` at the turn boundary. Plan-step/phase cuts pass none (timeline still shows seq/ts/kind). **Additive** — no change to the 1a–1e generation contract.
- **Registry** — lazy `anchor_store` (parallel to `workspace_store`), injected per session via `get_or_load → attach_anchor_store`; `list_rewind_points` adds `row["anchor"]` (only active seqs surfaced via the `is_active` filter → stale-branch anchors never read); anchors GC'd on the same `prune_below` boundary as 1e retention.
- **TUI** — `RewindMenuWidget.render()` shows the anchor as a 2nd dim line under the kind column (e2e-authorized; matches the rel-time dim-line idiom). Empty anchor = unchanged render.

## Coordination (e2e-coder)
Contract locked: `list_rewind_points` 3-key shape `{seq, ts, kind}` + additive `anchor`; I own the registry anchor line + this atomic Phase-2 PR (incl. the ~3-line widget render change, e2e-authorized). e2e's widget behavior is unchanged when anchor is `""`.

## Test plan (real-instance, no mocks; tier-audit clean; 92-test sweep green)
- [x] `truncate_anchor` (collapse + truncate + ellipsis, behavioral).
- [x] `AnchorStore` capture/get/`""`-on-unknown/prune_below/cross-instance persistence.
- [x] `cut_generation` captures the anchor at the boundary seq; no-anchor cut leaves it empty.
- [x] `list_rewind_points` surfaces `anchor` additively (per WAL seq).
- [x] `RewindMenuWidget` renders the anchor dim line; empty anchor = omitted (additive).
- [x] All 1f / rewind / retention / journal suites green.

Completes the time-travel `/rewind` UX (Phase-1 1a–1f + this preview). Next on my side: the Phase-1 end-to-end live-rewind gate (design-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)