### PR TITLE
test(1533): Phase-1 live-rewind gate (A) — both substrates revert as-of-N

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -2310,6 +2310,17 @@ class ChatSession:
         """
         self._journal.set_anchor_store(anchor_store)
 
+    @property
+    def current_snapshot(self) -> "AgentSnapshot":
+        """Read-only view of the live in-memory AgentSnapshot (ADR-0038).
+
+        Public accessor over the journal's snapshot so callers (e.g. the
+        live-rewind gate) can assert the live session reflects as-of-N AFTER a
+        global rewind — ``reset_for_rewind`` + ``restore_state`` update this live
+        snapshot via ``journal.install``, a wiring distinct from the on-disk save.
+        """
+        return self._journal.snapshot
+
     async def reset_for_rewind(self) -> None:
         """Clear all in-memory state ``restore_state`` repopulates (ADR-0038 1c-2).
 

--- a/tests/test_live_rewind_gate.py
+++ b/tests/test_live_rewind_gate.py
@@ -1,0 +1,122 @@
+"""Tier 2: OS invariant — Phase-1 end-to-end live-rewind gate (ADR-0038, #1533).
+
+Real `AgentRegistry` + `ChatSession` + `StateLog` + real git (no mocks). The unit
+tests cover each piece (await_quiescent, rewind_to, WorkspaceVersionStore, the
+cut_generation capture wiring); THIS gate proves the **composition** end-to-end —
+that a live session's turn-boundary auto-capture and a subsequent global rewind
+revert **both substrates** (runtime AgentSnapshot + workspace files) to as-of-N.
+
+Critically, the gate drives the **real production boundary** ``_run_router_loop``
+via a Fake (no-LLM) loop_driver, so the **genuine** ``cut_generation`` call-site
+fires — calling ``cut_generation`` directly would give the gate the very wiring
+blind-spot it exists to catch (if ``_run_router_loop`` ever stops calling it, a
+direct-call gate stays green). The ONLY simulated part is the op's file-write.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+_WORKSPACE_FILE = "code.py"
+
+
+class _FakeTurnDriver:
+    """No-LLM loop_driver: each turn writes the workspace file for that turn +
+    appends a runtime inbox entry. Substitutes for ``RouterLoopDriver`` so the
+    real ``_run_router_loop`` runs (and its genuine ``cut_generation`` fires)
+    without an LLM. The only simulated effect is the file write (the op effect).
+    """
+
+    def __init__(self, session: ChatSession, workspace_root: Path, content_by_turn: dict[str, str]):
+        self._session = session
+        self._ws = workspace_root
+        self._content = content_by_turn
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        # simulated op effect: the turn writes a workspace file.
+        (self._ws / _WORKSPACE_FILE).write_text(self._content[user_text], encoding="utf-8")
+        # a real runtime mutation so the snapshot differs turn-to-turn.
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    # cancel protocol the rewind's cancel_inflight drives (no live turn here → no-op).
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+def _turn_markers(snap: AgentSnapshot) -> list[str]:
+    return [m["payload"]["turn"] for m in snap.inbox]
+
+
+@pytest.mark.asyncio
+async def test_live_rewind_reverts_both_substrates_to_as_of_n(tmp_path):
+    """Tier 2: a live session's auto-capture → global rewind reverts BOTH substrates.
+
+    Drives the real ``_run_router_loop`` twice (turn A writes file v1, turn B writes
+    v2), so the genuine ``cut_generation`` auto-captures runtime + workspace at each
+    boundary. ``rewind_to`` the turn-A checkpoint must revert:
+      - workspace: ``code.py`` on disk back to v1
+      - runtime (disk): the persisted snapshot is as-of-A
+      - runtime (live in-memory): the loaded session reflects as-of-A
+    The runtime disk + live assertions are SEPARATE wirings (the on-disk save vs
+    ``reset_for_rewind`` + ``restore_state``'s ``journal.install``); a disk-only
+    assert would miss a stale live session, which would corrupt the next turn.
+    """
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
+
+    session = ChatSession(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
+    session.register_intervention_listener("test")
+    # production wiring: the registry injects its single shared stores.
+    session.attach_workspace_store(reg.workspace_store)
+    session.attach_anchor_store(reg.anchor_store)
+    reg._agents["alpha"] = session
+    # swap the no-LLM driver in; the rest of _run_router_loop (incl cut_generation) is real.
+    session._loop_driver = _FakeTurnDriver(
+        session, tmp_path, {"turn A": "v1", "turn B": "v2"},
+    )
+
+    # turn A → file v1 + runtime [A]; genuine cut_generation auto-captures @ seqA.
+    await session._run_router_loop("turn A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    # turn B → file v2 + runtime [A, B]; auto-captures @ seqB.
+    await session._run_router_loop("turn B", "c1")
+
+    # pre-rewind sanity: both substrates advanced to B.
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v2"
+    assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]
+    # the auto-capture actually fired (else the gate would be vacuous).
+    assert seq_a in reg.workspace_store.seqs()
+
+    # ── global rewind to the turn-A checkpoint ──
+    await reg.rewind_to(seq_a)
+
+    # workspace substrate: real file reverted to v1.
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v1"
+    # runtime substrate, DISK location: persisted snapshot is as-of-A.
+    assert _turn_markers(AgentSnapshot.load("alpha", snap_path)) == ["turn A"]
+    # runtime substrate, LIVE IN-MEMORY location: the loaded session is as-of-A
+    # (reset_for_rewind + restore_state's journal.install — distinct from the save).
+    assert _turn_markers(session.current_snapshot) == ["turn A"]


### PR DESCRIPTION
**[dogfood-coder]** — ADR-0038 #1533, gate (A) of 2 (the deterministic CI gate). Builds on the merged Phase-1 (1a–1f + #1547). Shape design-first-locked with lead in #1533.

## What this proves
The unit tests cover each piece (`await_quiescent`, `rewind_to`, `WorkspaceVersionStore`, the `cut_generation` capture wiring). This gate proves the **composition** the units don't: a live session's turn-boundary **auto-capture** + a global **rewind** revert **both substrates** (runtime `AgentSnapshot` + workspace files) to as-of-N.

## Why it's faithful (lead's Q2)
Drives the **real production boundary `_run_router_loop`** via a Fake (no-LLM) `loop_driver`, so the **genuine `cut_generation` call-site fires**. Calling `cut_generation` directly would give the gate the very wiring blind-spot it exists to catch (if `_run_router_loop` ever stops calling it, a direct-call gate stays green — `feedback_new_method_needs_production_callsite_before_done`). The ONLY simulated part is the op's file-write.

## Both substrates × both locations (lead's completeness refine)
The on-disk save and the live `reset_for_rewind` + `restore_state` (`journal.install`) are **separate wirings**; a disk-only assert would miss a stale live session — the worst case (corrupts the next turn). So after `rewind_to`:
- **workspace**: `code.py` on disk reverted to v1
- **runtime DISK**: `AgentSnapshot.load(snap_path)` is as-of-A
- **runtime LIVE in-memory**: `session.current_snapshot` is as-of-A
- + a **vacuity guard** (the auto-capture seq is actually in `workspace_store.seqs()` — a no-capture would otherwise vacuously pass).

Adds `session.current_snapshot` — a thin public accessor over `journal.snapshot` (no `_journal` reach) for the live assertion.

## Test plan
- [x] `tests/test_live_rewind_gate.py` Tier 2, real-instance (the Fake driver is an LLMReplay-style fake of the `loop_driver`, not a collaborator mock); `@skipif` no git.
- [x] tier-audit clean; 84-test rewind/retention/journal/session sweep green.

Gate (B) (tmux live-UX, S1+S2+S4+S5) is e2e-spec'd / tui-coder-executed; **both green → Phase-1 of #1533 done.** I support tui-coder on (B)'s boundary-capture faithfulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)