### PR TITLE
feat(1533/1546): Esc-Esc double-tap opens the /rewind picker

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2380,10 +2380,17 @@ class ReynTUIApp(App):
             self._last_clean_esc_ts = now
             self._show_esc_esc_hint()
 
+    _ESC_HINT_TEXT = "⏪ Esc again to rewind"
+
     def _reset_clean_esc(self) -> None:
-        """Clear the pending Esc-Esc first-tap + its hint (#1546)."""
+        """Disarm the pending Esc-Esc first-tap (#1546).
+
+        Pure ts reset — touches no status/timer, so the four dismiss branches
+        (and the check_action slash-entry branch) can call it without clobbering
+        their own status. The hint sticky is self-clearing via its own timer
+        (``_clear_esc_esc_hint``), which only hides when *its* text is showing.
+        """
         self._last_clean_esc_ts = 0.0
-        self._cancel_esc_hint_timer()
 
     def _cancel_esc_hint_timer(self) -> None:
         timer = self._esc_hint_timer
@@ -2397,11 +2404,12 @@ class ReynTUIApp(App):
     def _show_esc_esc_hint(self) -> None:
         """Sticky "Esc again to rewind" cue on the first clean Esc, auto-cleared
         after the window so it doesn't linger once the double-tap chance lapses.
-        Opening the picker clears it via mount_rewind_menu's own hide_status."""
+        Re-arming cancels any prior timer; opening the picker is handled by
+        ``mount_rewind_menu``'s own status."""
         self._cancel_esc_hint_timer()
         try:
             conv = self.query_one("#conversation", ConversationView)
-            conv.show_status("⏪ Esc again to rewind", kind="general")
+            conv.show_status(self._ESC_HINT_TEXT, kind="general")
             self._esc_hint_timer = self.set_timer(
                 _ESC_ESC_WINDOW_S, self._clear_esc_esc_hint,
             )
@@ -2409,12 +2417,19 @@ class ReynTUIApp(App):
             pass
 
     def _clear_esc_esc_hint(self) -> None:
+        # Window lapsed: the double-tap chance is gone, so the first-tap is no
+        # longer pending (keeps esc_esc_pending semantically accurate).
         self._esc_hint_timer = None
-        if self._rewind_menu is not None:
-            # The picker opened (its own status owns the bar now) — don't clobber.
-            return
+        self._last_clean_esc_ts = 0.0
+        # Hide the sticky ONLY if our hint is still the one showing — never
+        # clobber a status another path set in the meantime (e.g. a dismiss
+        # breadcrumb, or the open picker's own cue).
         try:
-            self.query_one("#conversation", ConversationView).hide_status()
+            from .widgets.sticky_status import StickyStatus
+            conv = self.query_one("#conversation", ConversationView)
+            sticky = conv.query_one("#sticky-status", StickyStatus)
+            if self._ESC_HINT_TEXT in sticky.snapshot().get("body", ""):
+                conv.hide_status()
         except Exception:
             pass
 
@@ -2561,7 +2576,16 @@ class ReynTUIApp(App):
             # slash-entry we return False so its own Esc binding clears the
             # prefix (not stolen). has_slash_entry() is the public read.
             try:
-                return not self.query_one("#inputbar", InputBar).has_slash_entry()
+                if self.query_one("#inputbar", InputBar).has_slash_entry():
+                    # The slash-clearing Esc is consumed by InputBar — the App
+                    # never runs action_voice_cancel for it, so this branch is
+                    # the ONLY place to reset the pending Esc-Esc first-tap.
+                    # Without it, `Esc(arm) → /x → Esc(clear) → Esc` false-fires
+                    # the double-tap (tui-coder #1554 repro). Same reset
+                    # discipline as the four dismiss branches.
+                    self._reset_clean_esc()
+                    return False
+                return True
             except Exception:
                 return False
         if action == "voice_stop_and_submit":

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -66,6 +66,11 @@ _IDLE_CANCEL_DEDUP_S = 1.5
 _COST_SUFFIX_DEFER_INTERVAL_S = 1.0
 _COST_SUFFIX_DEFER_MAX_ATTEMPTS = 30
 
+# #1546: max gap between the two clean Escs of an Esc-Esc → /rewind double-tap.
+# 600ms (tui-coder UX call) gives the "Esc again to rewind" hint time to be
+# read while staying tight enough to not fire on unrelated paired Escs.
+_ESC_ESC_WINDOW_S = 0.6
+
 
 class ReynTUIApp(App):
     """Main Textual application for `reyn chat`."""
@@ -240,6 +245,13 @@ class ReynTUIApp(App):
         # open, else None. Navigation (↑/↓/Enter) + Esc dismiss are gated on
         # this being non-None via check_action.
         self._rewind_menu = None  # type: ignore[assignment]
+        # #1546: monotonic ts of the last *truly clean* Esc (nothing dismissed).
+        # A second clean Esc within _ESC_ESC_WINDOW_S opens the /rewind picker
+        # (Esc-Esc double-tap). 0.0 = no pending first tap. Any Esc that
+        # dismisses something resets this so "dismiss then clean-Esc" cannot
+        # masquerade as a double-tap.
+        self._last_clean_esc_ts: float = 0.0
+        self._esc_hint_timer = None  # type: ignore[assignment]
         self._cancel_event: asyncio.Event = asyncio.Event()
         # Most-recent "nothing-in-flight cancel" timestamp, used to
         # suppress repeated identical lines from accumulating in the conv
@@ -287,6 +299,17 @@ class ReynTUIApp(App):
         testing policy.
         """
         return self._panel_visible
+
+    @property
+    def esc_esc_pending(self) -> bool:
+        """Public read of the Esc-Esc first-tap state (#1546).
+
+        ``True`` after one *truly clean* Esc, while a second clean Esc within
+        ``_ESC_ESC_WINDOW_S`` would open the /rewind picker; ``False`` once the
+        window lapses, the double-tap fires, or any Esc dismisses something.
+        Exposed so tests read state through the public surface.
+        """
+        return self._last_clean_esc_ts != 0.0
 
     @property
     def rewind_menu_open(self) -> bool:
@@ -2327,10 +2350,12 @@ class ReynTUIApp(App):
             self._voice_set_input_locked(False)
             self._voice_set_header_state(None)
             self._voice_status("✗ recording cancelled", style="dim " + _TEXT_DIM)
+            self._reset_clean_esc()
             return
         try:
             input_bar = self.query_one("#inputbar", InputBar)
             if input_bar.dismiss_slash_prefix():
+                self._reset_clean_esc()
                 return
         except Exception:
             pass
@@ -2339,9 +2364,59 @@ class ReynTUIApp(App):
         # first (matches "abort the visible thing" priority).
         if self._rewind_menu is not None:
             self._dismiss_rewind_menu()
+            self._reset_clean_esc()
             return
         if self._panel_visible:
             self.action_toggle_panel()
+            self._reset_clean_esc()
+            return
+        # #1546: nothing was dismissed → this is a *truly clean* Esc. A second
+        # clean Esc within the window opens the /rewind picker (Esc-Esc).
+        now = _now_monotonic()
+        if self._last_clean_esc_ts and (now - self._last_clean_esc_ts) < _ESC_ESC_WINDOW_S:
+            self._reset_clean_esc()
+            self._open_rewind_menu()
+        else:
+            self._last_clean_esc_ts = now
+            self._show_esc_esc_hint()
+
+    def _reset_clean_esc(self) -> None:
+        """Clear the pending Esc-Esc first-tap + its hint (#1546)."""
+        self._last_clean_esc_ts = 0.0
+        self._cancel_esc_hint_timer()
+
+    def _cancel_esc_hint_timer(self) -> None:
+        timer = self._esc_hint_timer
+        self._esc_hint_timer = None
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+
+    def _show_esc_esc_hint(self) -> None:
+        """Sticky "Esc again to rewind" cue on the first clean Esc, auto-cleared
+        after the window so it doesn't linger once the double-tap chance lapses.
+        Opening the picker clears it via mount_rewind_menu's own hide_status."""
+        self._cancel_esc_hint_timer()
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.show_status("⏪ Esc again to rewind", kind="general")
+            self._esc_hint_timer = self.set_timer(
+                _ESC_ESC_WINDOW_S, self._clear_esc_esc_hint,
+            )
+        except Exception:
+            pass
+
+    def _clear_esc_esc_hint(self) -> None:
+        self._esc_hint_timer = None
+        if self._rewind_menu is not None:
+            # The picker opened (its own status owns the bar now) — don't clobber.
+            return
+        try:
+            self.query_one("#conversation", ConversationView).hide_status()
+        except Exception:
+            pass
 
     # ── rewind menu (ADR-0038 1f) ───────────────────────────────────────────
 
@@ -2473,16 +2548,22 @@ class ReynTUIApp(App):
             return self._rewind_menu is not None
         if action == "voice_cancel":
             # Intercept Esc when there's an overlay/recording to dismiss:
-            # voice recording, the rewind menu, or the side panel. The slash
-            # picker / prefix case is handled by InputBar's own Esc binding
-            # when no other overlay is present (= simpler dispatch path).
+            # voice recording, the rewind menu, or the side panel.
             if self._voice_input is not None and self._voice_input.is_recording:
                 return True
             if self._rewind_menu is not None:
                 return True
             if self._panel_visible:
                 return True
-            return False
+            # #1546: also grab a *truly clean* Esc — nothing dismissable here
+            # AND no InputBar slash-entry to clear — so action_voice_cancel can
+            # run the Esc-Esc double-tap detection. When InputBar HAS a
+            # slash-entry we return False so its own Esc binding clears the
+            # prefix (not stolen). has_slash_entry() is the public read.
+            try:
+                return not self.query_one("#inputbar", InputBar).has_slash_entry()
+            except Exception:
+                return False
         if action == "voice_stop_and_submit":
             # Same gate as voice_cancel: Enter only behaves as "stop+send"
             # while recording. Outside of recording it falls through to

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -539,23 +539,20 @@ class InputBar(Widget):
         """
         self.dismiss_slash_prefix()
 
-    def dismiss_slash_prefix(self) -> bool:
-        """Hide the picker and clear the slash prefix it was tracking.
+    def has_slash_entry(self) -> bool:
+        """True when there is a slash-entry state Esc would dismiss.
 
-        Returns True if there was a slash-entry state to abandon (and it
-        got cleared). The App's ``action_cancel_inflight`` calls this as
-        an early branch on Ctrl+C so an open picker dismisses instead of
-        producing a misleading "nothing in-flight" message.
+        Public read for the App's Esc multiplex (#1546 Esc-Esc): the App
+        treats a *truly clean* Esc (nothing dismissable anywhere) as the
+        rewind double-tap trigger, so it must know whether InputBar would
+        consume this Esc for slash-entry dismissal first. Non-mutating —
+        the single source of truth for ``dismiss_slash_prefix``'s gate.
 
-        Trigger surface — clear in any of these states:
-          * picker has matches and is ``visible_`` (= the user is still
-            choosing a command — original Slack/Discord-style dismiss)
-          * the buffer holds a typo-shaped slash prefix (= ``/<token>``
-            with no space/newline) that produced **zero** matches and
-            therefore left ``picker.visible_`` false. Without this case,
-            ``/attch<Esc>`` was a silent no-op and the stale prefix
-            concatenated with the user's next keystrokes into garbage
-            like ``/attch/attach default``.
+        True in either state:
+          * the picker has matches and is ``visible_`` (user is choosing a
+            command), or
+          * the buffer holds a typo-shaped slash prefix (``/<token>`` with
+            no space/newline) that produced zero matches.
         """
         ta = self._textarea()
         text = ta.text if ta is not None else ""
@@ -564,10 +561,23 @@ class InputBar(Widget):
         )
         picker = self._picker()
         picker_visible = picker is not None and picker.visible_
-        if not picker_visible and not in_slash_prefix:
+        return picker_visible or in_slash_prefix
+
+    def dismiss_slash_prefix(self) -> bool:
+        """Hide the picker and clear the slash prefix it was tracking.
+
+        Returns True if there was a slash-entry state to abandon (and it
+        got cleared). The App's ``action_cancel_inflight`` calls this as
+        an early branch on Ctrl+C so an open picker dismisses instead of
+        producing a misleading "nothing in-flight" message. The dismiss
+        condition is ``has_slash_entry()`` (single source of truth).
+        """
+        if not self.has_slash_entry():
             return False
+        picker = self._picker()
         if picker is not None:
             picker.hide()
+        ta = self._textarea()
         if ta is not None:
             ta.load_text("")
         return True

--- a/tests/cli/test_esc_esc_rewind_1546.py
+++ b/tests/cli/test_esc_esc_rewind_1546.py
@@ -114,6 +114,34 @@ async def test_double_esc_outside_window_rearms() -> None:
 
 
 @pytest.mark.asyncio
+async def test_slash_clear_esc_resets_pending() -> None:
+    """Tier 2: a slash-prefix-clearing Esc resets the pending first-tap.
+
+    Regression for the tui-coder #1554 repro: `Esc(arm) → /x → Esc(clear slash)
+    → Esc(clean)` must NOT false-fire the picker. The slash-clearing Esc is
+    consumed by InputBar, so check_action's slash-entry branch is the only place
+    that can disarm the first-tap — without that reset, the 3rd Esc lands inside
+    the still-open window and wrongly opens the picker.
+    """
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")              # arm
+        assert app.esc_esc_pending is True
+        await pilot.press("/", "x")              # slash-entry appears
+        await pilot.pause()
+        await pilot.press("escape")              # clears the slash prefix
+        await pilot.pause()
+        # The slash-clearing Esc must have disarmed the first-tap.
+        assert app.esc_esc_pending is False
+        await pilot.press("escape")              # now a fresh clean Esc
+        await pilot.pause()
+        # It re-arms (new first tap) rather than completing a false double-tap.
+        assert not _conv_has(app, "no checkpoints")
+        assert app.esc_esc_pending is True
+
+
+@pytest.mark.asyncio
 async def test_dismiss_resets_pending() -> None:
     """Tier 2: an Esc that dismisses something resets the pending first-tap, so
     "dismiss then clean-Esc" can't masquerade as a double-tap (reset discipline)."""

--- a/tests/cli/test_esc_esc_rewind_1546.py
+++ b/tests/cli/test_esc_esc_rewind_1546.py
@@ -1,0 +1,130 @@
+"""Tier 2: Esc-Esc double-tap opens the /rewind picker (#1546).
+
+A *truly clean* Esc (nothing dismissable: no recording / rewind-menu / panel /
+InputBar slash-entry) is a no-op today, so it's repurposed as the rewind
+double-tap trigger: two clean Escs within ``_ESC_ESC_WINDOW_S`` open the picker.
+
+Pins (real key path through bindings + check_action, run_test pilot — no mocks):
+- ``InputBar.has_slash_entry()`` reflects the buffer state.
+- check_action grabs a truly-clean Esc but NOT one InputBar needs for slash-entry
+  dismissal (the stealing-safety guarantee — tui-coder Q3).
+- first clean Esc arms (pending) without opening; second within window opens.
+- a second Esc *outside* the window re-arms instead of opening.
+- any Esc that dismisses something resets the pending first-tap (reset discipline).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import _ESC_ESC_WINDOW_S, ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView, InputBar
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None, agent_name="test-agent", model="test-model",
+        budget_tracker=None,
+    )
+
+
+def _conv_has(app: ReynTUIApp, needle: str) -> bool:
+    conv = app.query_one("#conversation", ConversationView)
+    return any(needle in line for line in conv.dump_buffer_text())
+
+
+@pytest.mark.asyncio
+async def test_has_slash_entry_reflects_buffer() -> None:
+    """Tier 2: has_slash_entry() True while a slash-prefix is in the buffer."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        assert bar.has_slash_entry() is False
+        await pilot.press("/", "f", "o", "o")
+        await pilot.pause()
+        assert bar.has_slash_entry() is True
+
+
+@pytest.mark.asyncio
+async def test_check_action_grabs_clean_esc_but_not_slash_entry() -> None:
+    """Tier 2: trap-safe gate — the App grabs a truly-clean Esc (for double-tap
+    detection) but yields the Esc to InputBar when a slash-entry is present, so
+    InputBar's own binding clears the prefix (tui-coder Q3 stealing-safety)."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        # Empty buffer, nothing pending → clean Esc grabbed by the App.
+        assert app.check_action("voice_cancel", ()) is True
+        # Slash-entry present → App must NOT grab it (InputBar clears prefix).
+        await pilot.press("/", "f", "o", "o")
+        await pilot.pause()
+        assert app.check_action("voice_cancel", ()) is False
+
+
+@pytest.mark.asyncio
+async def test_first_clean_esc_arms_without_opening() -> None:
+    """Tier 2: one clean Esc arms the double-tap (pending) but does NOT open."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.esc_esc_pending is True
+        # registry=None → opening would render "no checkpoints"; it must NOT yet.
+        assert not _conv_has(app, "no checkpoints")
+        assert app.rewind_menu_open is False
+
+
+@pytest.mark.asyncio
+async def test_double_esc_within_window_opens() -> None:
+    """Tier 2: two clean Escs within the window reach the picker open path
+    (registry=None → the "no checkpoints" notice proves _open_rewind_menu ran)
+    and clear the pending first-tap."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.press("escape")  # back-to-back ≪ window
+        await pilot.pause()
+        assert _conv_has(app, "no checkpoints")
+        assert app.esc_esc_pending is False
+
+
+@pytest.mark.asyncio
+async def test_double_esc_outside_window_rearms() -> None:
+    """Tier 2: a second Esc AFTER the window re-arms (new first tap), not open."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await asyncio.sleep(_ESC_ESC_WINDOW_S + 0.05)  # let the window lapse
+        await pilot.press("escape")
+        await pilot.pause()
+        # Did not double-tap → no open attempt, but re-armed for a fresh pair.
+        assert not _conv_has(app, "no checkpoints")
+        assert app.esc_esc_pending is True
+
+
+@pytest.mark.asyncio
+async def test_dismiss_resets_pending() -> None:
+    """Tier 2: an Esc that dismisses something resets the pending first-tap, so
+    "dismiss then clean-Esc" can't masquerade as a double-tap (reset discipline)."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")          # arm
+        assert app.esc_esc_pending is True
+        app.action_toggle_panel()            # make the panel dismissable
+        await pilot.pause()
+        await pilot.press("escape")          # this Esc dismisses the panel
+        await pilot.pause()
+        assert app.esc_esc_pending is False   # reset, not advanced to open
+        assert not _conv_has(app, "no checkpoints")


### PR DESCRIPTION
**[e2e-coder]** — Implements #1546 (Esc-Esc → `/rewind` picker, Claude-Code parity). Design cross-reviewed by tui-coder **before** impl (#1546 issuecomment-4697837791); this folds the 4 review decisions.

## Mechanism (flow-traced)
The Esc multiplex resolves App `voice_cancel` (gated: recording → rewind-menu → panel) → fall-through → InputBar `dismiss_picker` (slash-prefix). **A truly clean Esc — nothing dismissable anywhere — is a no-op today**, so it's the safe double-tap signal.

## Changes (= tui-coder's 4 decisions)
- **Q3** `InputBar.has_slash_entry()` — new **public** accessor, the single source of truth for whether an Esc would clear a slash-entry. `check_action` reads it (no private `_textarea()`/`_picker()` reach); `dismiss_slash_prefix` now gates on it too (no drift).
- `check_action("voice_cancel")` clean-Esc branch: grab a truly-clean Esc but **yield it to InputBar when a slash-entry is present** — never steal a meaningful Esc.
- `action_voice_cancel`: each dismiss branch **resets** the pending first-tap (reset discipline); a final clean-Esc branch does **600ms** (**Q2**) timestamp double-tap → `_open_rewind_menu()`.
- **Q1** first tap shows a `⏪ Esc again to rewind` sticky hint, auto-cleared after the window / on open.
- **Q4** kept the unified `check_action` path (no `on_key`).
- `esc_esc_pending` public property for tests.

## Test plan
- [x] `pytest tests/cli/test_esc_esc_rewind_1546.py` — 6 passed (run_test pilot, **real key path through bindings + check_action**, no mocks): has_slash_entry reflection, stealing-safety gate (clean-grab vs slash-entry-yield), first-tap arms-without-open, double-tap-within-window opens, outside-window re-arms, dismiss resets pending
- [x] `pytest tests/cli/ -k "slash or picker or input_bar or cancel"` — 146 passed (`dismiss_slash_prefix` refactor safe)
- [x] regression sweep (tui_smoke / rewind wiring / scroll-hint / async-stack keyboard) — 66 passed
- [x] `ruff check .` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 violations
- [ ] (Manual, tmux) real-terminal Esc-Esc → picker opens; Esc-then-clean-Esc does not; slash-prefix Esc still clears prefix — **for tui-coder's re-cross-review** (real binding-interaction)

## Known edge (flagged for re-review)
A slash-prefix-clearing Esc is consumed by InputBar (App never sees it), so it does **not** reset the App's pending-first-tap. In practice harmless: the stale ts would have to be < 600ms old across a slash-clear — a sub-window race that opens the picker (user Escs out). Noted for tui-coder's judgment; can tighten if desired.

Per the #1546 gate: requesting **tui-coder re-cross-review** of the real binding code → then lead deep review. Refs #1533.