### PR TITLE
feat(1544): increment-1/2 — async-ify WorkspaceVersionStore git-exec (host, behavior unchanged)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -601,26 +601,27 @@ class AgentRegistry:
                 await session.reset_for_rewind()
                 session.restore_state(snap)
             agents.append(name)
-        self._restore_workspace_active(at_or_below=workspace_at_or_below)
+        await self._restore_workspace_active(at_or_below=workspace_at_or_below)
         return agents
 
-    def _restore_workspace_active(self, *, at_or_below: int) -> None:
+    async def _restore_workspace_active(self, *, at_or_below: int) -> None:
         """Restore the workspace to the nearest ACTIVE generation <= ``at_or_below``.
 
         Honors is_active (mirrors ``reconstruct`` for runtime): gen-tags in an
         abandoned segment ``(N, R)`` are skipped, so a crash-after-rewind-before-
-        any-post-rewind-capture never restores the undone-future workspace.
-        No-op when git / the store / a matching active gen is unavailable.
+        any-post-rewind-capture never restores the undone-future workspace. Git
+        absence degrades at exec time inside the store (#1544 — no git_available()
+        pre-gate, which would test the host PATH meaninglessly in container mode).
         """
         ws = self.workspace_store
-        if ws is None or not ws.git_available():
+        if ws is None:
             return
         active = [
-            s for s in ws.seqs()
+            s for s in await ws.seqs()
             if s <= at_or_below and is_active_seq(self._state_log, s)
         ]
         if active:
-            ws.restore_to_seq(max(active))
+            await ws.restore_to_seq(max(active))
 
     async def recover_rewind_if_needed(self) -> dict | None:
         """Re-materialise both substrates as-of-N after a crash mid-rewind (1d).
@@ -879,26 +880,27 @@ class AgentRegistry:
         # boundary (Q3 piggyback). prune_below(floor) drops only what is below the
         # (retention-clamped) WAL floor — generations >= floor stay reconstructable,
         # so this never drops rewind history within the retention window.
-        self._prune_generations_below(floor)
+        await self._prune_generations_below(floor)
         return stats
 
-    def _prune_generations_below(self, floor: int) -> None:
+    async def _prune_generations_below(self, floor: int) -> None:
         """Drop snapshot + workspace generations below ``floor`` (Stage 1e GC).
 
         ``floor`` is the truncation floor (already retention-clamped), so a
         generation at-or-above it stays reconstructable. Defensive — never raises
-        into the truncation hot path.
+        into the truncation hot path. Workspace GC degrades at exec time inside
+        the store (#1544 — no host-PATH git_available pre-gate).
         """
         try:
             for name in self.list_names():
-                self._store_for(name).prune_below(floor)
+                self._store_for(name).prune_below(floor)   # SnapshotGenerationStore (sync)
             ws = self.workspace_store
-            if ws is not None and ws.git_available():
-                ws.prune_below(floor)
+            if ws is not None:
+                await ws.prune_below(floor)
             # #1547: anchors GC'd on the same boundary as generations/blobs.
             anchors = self.anchor_store
             if anchors is not None:
-                anchors.prune_below(floor)
+                anchors.prune_below(floor)                  # AnchorStore (sync)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("Stage 1e generation GC failed (floor=%d): %s", floor, e)
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -73,7 +73,7 @@ class SnapshotJournal:
         """
         self._anchor_store = anchor_store
 
-    def cut_generation(self, anchor: str = "") -> None:
+    async def cut_generation(self, anchor: str = "") -> None:
         """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a/1d).
 
         Called at user-facing checkpoint boundaries (turn / plan-step) — a
@@ -92,7 +92,7 @@ class SnapshotJournal:
             return
         self._generation_store.record(self._snapshot)
         if self._workspace_store is not None:
-            self._workspace_store.capture(self._snapshot.applied_seq)
+            await self._workspace_store.capture(self._snapshot.applied_seq)
         if self._anchor_store is not None and anchor:
             self._anchor_store.capture(self._snapshot.applied_seq, anchor)
 
@@ -415,7 +415,7 @@ class SnapshotJournal:
         self._snapshot.applied_seq = seq
         self.save()
         # ADR-0038 Stage 1a: plan-step boundary = a user-facing checkpoint.
-        self.cut_generation()
+        await self.cut_generation()
         return seq
 
     async def record_plan_step_failed(

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -5062,7 +5062,7 @@ class ChatSession:
         await self._loop_driver.run_turn(user_text, chain_id)
         # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
         # user message is this checkpoint's anchor for the rewind-timeline preview.
-        self._journal.cut_generation(anchor=_truncate_anchor(user_text))
+        await self._journal.cut_generation(anchor=_truncate_anchor(user_text))
 
     async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
         """Forwarding → RouterLoopDriver._run_with_shrink (PR-3)."""

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -1,7 +1,7 @@
 """Workspace file-content versioning via a content-addressed shadow-git store.
 
-ADR-0038 Stage 1d (D9). The runtime side of a generation lives in
-``SnapshotGenerationStore`` (per-agent ``AgentSnapshot`` by WAL seq); the
+ADR-0038 Stage 1d (D9) + #1544 (container mode). The runtime side of a generation
+lives in ``SnapshotGenerationStore`` (per-agent ``AgentSnapshot`` by WAL seq); the
 *workspace files* are the other substrate and live here. A generation ties the
 two at a boundary seq:
 
@@ -9,25 +9,21 @@ two at a boundary seq:
 
 This store is the workspace half: ONE content-addressed shadow-git repo (the
 workspace is a single SSoT — ADR D2) keyed by the GLOBAL WAL seq via tags
-``reyn-gen-<seq>``. Unchanged files are de-duplicated across generations (git
-content-addressing) so cutting a generation at every boundary is cheap.
+``reyn-gen-<seq>``.
 
-Design (Claude Code / Cline style):
-- The shadow repo's ``git-dir`` lives under the OS state dir
-  (``.reyn/workspace-shadow.git``) — OUT of the tracked work-tree.
-- The ``work-tree`` is the workspace root. Every git invocation passes explicit
-  ``--git-dir`` / ``--work-tree`` — we never write a ``.git`` file into the
-  work-tree, so the shadow coexists with a user's own git repo untouched.
-- ``.reyn/`` is excluded (via ``<git-dir>/info/exclude``) so OS state (WAL,
-  snapshots, this shadow repo) is never tracked nor wiped on restore.
-
-``capture`` / ``restore_at_or_below`` mirror ``SnapshotGenerationStore.record``
-/ ``nearest_at_or_below`` + ``load`` so ``rewind_to`` drives both substrates the
-same way. When ``git`` is unavailable the store degrades to logged no-ops —
-runtime rewind still works; only workspace-file rewind is skipped.
+**Git execution is delegated to a runner** (#1544) so the same store works on the
+host (a ``subprocess`` runner) and inside a container (a ``backend.run`` /
+``docker exec`` runner — the work-tree is container-side, so host git cannot reach
+it). The runner owns the ``--git-dir`` / ``--work-tree`` path context for its
+environment; the store builds bare git args. Git methods are **async** because the
+container runner is async (every call-site is already in an async context — see
+#1544 enumeration). **git-absence degrades at exec time** (the runner raises;
+methods log-once + no-op) — checking ``shutil.which`` would test the *host* PATH,
+which is meaningless for a container.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import shutil
@@ -39,22 +35,65 @@ logger = logging.getLogger(__name__)
 _TAG_PREFIX = "reyn-gen-"
 _TAG_RE = re.compile(rf"^{re.escape(_TAG_PREFIX)}(\d+)$")
 # Marker committer identity — shadow commits never touch the user's git identity.
-_COMMITTER = ("REYN_SHADOW_NAME", "reyn-shadow", "REYN_SHADOW_EMAIL", "reyn@shadow.local")
+_SHADOW_NAME = "reyn-shadow"
+_SHADOW_EMAIL = "reyn@shadow.local"
+
+
+class GitUnavailable(Exception):
+    """The git binary is absent in the runner's environment (degrade signal)."""
+
+
+class _HostGitRunner:
+    """Runs git on the host via ``subprocess`` (the default, behavior-preserving).
+
+    Owns the host ``--git-dir`` / ``--work-tree`` path context. Raises
+    ``GitUnavailable`` when the git binary is missing so the store degrades.
+    """
+
+    def __init__(self, git_dir: Path, work_tree: Path) -> None:
+        self._git_dir = Path(git_dir)
+        self._work_tree = Path(work_tree)
+
+    async def run(self, args: list[str], *, check: bool = True) -> tuple[int, str]:
+        cmd = [
+            "git",
+            "--git-dir", str(self._git_dir),
+            "--work-tree", str(self._work_tree),
+            "-c", f"user.name={_SHADOW_NAME}",
+            "-c", f"user.email={_SHADOW_EMAIL}",
+            *args,
+        ]
+        try:
+            # Inline (blocking) subprocess — same as the pre-#1544 host behavior
+            # (host git already ran sync inside the async turn loop, briefly).
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError as e:  # git binary absent on the host
+            raise GitUnavailable("git binary not found on host PATH") from e
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, cmd, result.stdout, result.stderr,
+            )
+        return result.returncode, result.stdout
 
 
 class WorkspaceVersionStore:
-    """Content-addressed shadow-git store for workspace files (ADR-0038 1d).
+    """Content-addressed shadow-git store for workspace files (ADR-0038 1d, #1544).
 
     Parameters
     ----------
     workspace_root:
-        The work-tree captured/restored (= the agent workspace base dir).
+        The work-tree captured/restored (host path; for the host runner also the
+        git ``--work-tree``).
     git_dir:
-        Where the shadow repo lives (e.g. ``.reyn/workspace-shadow.git``).
-        Kept out of the work-tree so OS state is never tracked.
+        Where the shadow repo lives (e.g. ``.reyn/workspace-shadow.git``). The
+        store does its small FS surface (init dir + ``info/exclude``) here.
     exclude:
-        Paths (relative to the work-tree) the shadow never tracks. Defaults to
-        ``[".reyn/"]`` so OS state (WAL / snapshots / this repo) is excluded.
+        Paths (relative to the work-tree) the shadow never tracks. Default
+        ``[".reyn/"]`` so OS state is never tracked nor wiped on restore.
+    git_runner:
+        Executes git in the target environment (default: a host ``subprocess``
+        runner). A container runner (#1544) runs ``backend.run`` with the
+        container path context.
     """
 
     def __init__(
@@ -63,88 +102,90 @@ class WorkspaceVersionStore:
         git_dir: Path,
         *,
         exclude: list[str] | None = None,
+        git_runner: "object | None" = None,
     ) -> None:
         self._work_tree = Path(workspace_root)
         self._git_dir = Path(git_dir)
         self._exclude = list(exclude) if exclude is not None else [".reyn/"]
+        self._runner = git_runner or _HostGitRunner(self._git_dir, self._work_tree)
+        self._warned_unavailable = False
 
     # ── availability ──────────────────────────────────────────────────────
 
     @staticmethod
-    def git_available() -> bool:
-        """True iff a ``git`` binary is on PATH (else the store no-ops)."""
+    def host_git_available() -> bool:
+        """Host-only fast-path: is a ``git`` binary on the host PATH?
+
+        Convenience for host callers; NOT the correctness gate (container git
+        presence is checked at exec time — see module docstring). Container mode
+        degrades when the runner raises ``GitUnavailable``.
+        """
         return shutil.which("git") is not None
 
     # ── capture / restore ─────────────────────────────────────────────────
 
-    def capture(self, seq: int) -> str | None:
+    async def capture(self, seq: int) -> str | None:
         """Capture the current workspace as the generation tagged ``seq``.
 
         ``add -A`` + commit + tag ``reyn-gen-<seq>``. Idempotent per seq: if the
-        tag already exists (the global seq was captured by a peer agent's
-        boundary), returns the existing commit sha without re-committing.
-        Returns the commit sha, or ``None`` when git is unavailable.
+        tag already exists, returns the existing sha without re-committing.
+        Returns the commit sha, or ``None`` when git is unavailable (degrade).
         """
-        if not self.git_available():
-            logger.debug("git unavailable — workspace capture(%s) skipped", seq)
-            return None
-        self._ensure_repo()
-        existing = self._tag_sha(self._tag(seq))
-        if existing is not None:
-            return existing
-        self._git("add", "-A")
-        # --allow-empty: a boundary with no file change still gets a generation
-        # so every seq is restorable (matches the runtime snapshot at that seq).
-        self._git(
-            "commit", "--allow-empty", "-q", "-m", f"reyn generation @ seq {seq}",
-        )
-        self._git("tag", self._tag(seq))
-        return self._rev_parse("HEAD")
+        try:
+            await self._ensure_repo()
+            existing = await self._tag_sha(self._tag(seq))
+            if existing is not None:
+                return existing
+            await self._git(["add", "-A"])
+            # --allow-empty: a no-change boundary still gets a generation so every
+            # seq is restorable (matches the runtime snapshot at that seq).
+            await self._git(
+                ["commit", "--allow-empty", "-q", "-m", f"reyn generation @ seq {seq}"],
+            )
+            await self._git(["tag", self._tag(seq)])
+            return await self._rev_parse("HEAD")
+        except GitUnavailable:
+            return self._degrade("capture", seq)
 
-    def restore_at_or_below(self, seq: int) -> str | None:
+    async def restore_at_or_below(self, seq: int) -> str | None:
         """Restore to the nearest generation with **raw** tag-seq <= ``seq``.
 
         Convenience for the no-rewind / single-branch case. **When rewind records
         exist, callers MUST use** :meth:`restore_to_seq` with an is_active-resolved
-        seq instead — a raw nearest-below can land on an abandoned-branch
-        generation (tags in the abandoned segment ``(N, R)`` still exist), the
-        workspace analogue of the runtime active-branch honoring in
-        ``snapshot_generations.reconstruct``. Returns the restored sha or ``None``.
+        seq — a raw nearest-below can land on an abandoned-branch generation.
         """
-        if not self.git_available() or not self._git_dir.exists():
-            return None
-        base = self._nearest_at_or_below(seq)
-        return self.restore_to_seq(base) if base is not None else None
+        base = await self._nearest_at_or_below(seq)
+        return await self.restore_to_seq(base) if base is not None else None
 
-    def restore_to_seq(self, seq: int) -> str | None:
+    async def restore_to_seq(self, seq: int) -> str | None:
         """Restore the workspace to the EXACT generation tagged ``seq``.
 
-        ``reset --hard`` to that commit + ``clean -fd`` (honoring the excludes)
-        so files added after the generation are removed while excluded OS state
-        (``.reyn/``) survives. The caller supplies the precise generation seq
-        (e.g. the nearest **active** gen, is_active-resolved against the WAL), so
-        this never has to know about rewind/abandoned branches. Returns the
-        restored sha, or ``None`` when git is unavailable or no such tag exists.
+        ``reset --hard`` + ``clean -fd`` (honoring the excludes) so files added
+        after the generation are removed while excluded OS state (``.reyn/``)
+        survives. The caller supplies the precise (is_active-resolved) seq. Returns
+        the restored sha, or ``None`` when git is unavailable / no such tag.
         """
-        if not self.git_available() or not self._git_dir.exists():
-            return None
-        tag = self._tag(seq)
-        if self._tag_sha(tag) is None:
-            return None
-        self._git("reset", "--hard", "-q", tag)
-        clean_args = ["clean", "-fdq"]
-        for pat in self._exclude:
-            clean_args += ["-e", pat]
-        self._git(*clean_args)
-        return self._tag_sha(tag)
+        try:
+            tag = self._tag(seq)
+            if await self._tag_sha(tag) is None:
+                return None
+            await self._git(["reset", "--hard", "-q", tag])
+            clean_args = ["clean", "-fdq"]
+            for pat in self._exclude:
+                clean_args += ["-e", pat]
+            await self._git(clean_args)
+            return await self._tag_sha(tag)
+        except GitUnavailable:
+            return self._degrade("restore", seq)
 
     # ── queries ──────────────────────────────────────────────────────────
 
-    def seqs(self) -> list[int]:
-        """Sorted list of captured generation seqs (from ``reyn-gen-*`` tags)."""
-        if not self.git_available() or not self._git_dir.exists():
-            return []
-        out = self._git("tag", "--list", f"{_TAG_PREFIX}*")
+    async def seqs(self) -> list[int]:
+        """Sorted captured generation seqs (from ``reyn-gen-*`` tags); [] if degraded."""
+        try:
+            out = await self._git(["tag", "--list", f"{_TAG_PREFIX}*"], check=False)
+        except GitUnavailable:
+            return self._degrade("seqs", None) or []
         found = []
         for line in (out or "").splitlines():
             m = _TAG_RE.match(line.strip())
@@ -152,67 +193,65 @@ class WorkspaceVersionStore:
                 found.append(int(m.group(1)))
         return sorted(found)
 
-    def prune_below(self, min_keep_seq: int) -> int:
-        """Delete generations with seq < ``min_keep_seq`` (retention; wired in 1e).
-
-        Returns the number of generation tags removed. Blob GC (``git gc``) is
-        left to the retention sweep (Stage 1e) so a prune is cheap here.
-        """
-        removed = 0
-        for s in self.seqs():
-            if s < min_keep_seq:
-                self._git("tag", "-d", self._tag(s))
-                removed += 1
-        return removed
+    async def prune_below(self, min_keep_seq: int) -> int:
+        """Delete generations with seq < ``min_keep_seq`` (Stage 1e retention GC)."""
+        try:
+            removed = 0
+            for s in await self.seqs():
+                if s < min_keep_seq:
+                    await self._git(["tag", "-d", self._tag(s)], check=False)
+                    removed += 1
+            return removed
+        except GitUnavailable:
+            return self._degrade("prune", min_keep_seq) or 0
 
     # ── internals ──────────────────────────────────────────────────────────
+
+    def _degrade(self, op: str, seq: "int | None"):
+        if not self._warned_unavailable:
+            logger.warning(
+                "git unavailable in workspace-version runner — workspace "
+                "versioning disabled (op=%s seq=%s); rewind = runtime-only", op, seq,
+            )
+            self._warned_unavailable = True
+        return None
 
     def _tag(self, seq: int) -> str:
         return f"{_TAG_PREFIX}{int(seq)}"
 
-    def _nearest_at_or_below(self, seq: int) -> int | None:
-        candidates = [s for s in self.seqs() if s <= seq]
+    async def _nearest_at_or_below(self, seq: int) -> int | None:
+        candidates = [s for s in await self.seqs() if s <= seq]
         return max(candidates) if candidates else None
 
-    def _ensure_repo(self) -> None:
-        """Initialise the shadow repo (idempotent) + write the exclude file."""
+    async def _ensure_repo(self) -> None:
+        """Initialise the shadow repo (idempotent) + write the exclude file.
+
+        The small FS surface (dir + ``info/exclude``) runs on the host git-dir
+        path — in container mount-mode that path is the bind-mount source, so the
+        write is visible in-container; ``git init`` runs through the runner.
+        """
         if not (self._git_dir / "HEAD").exists():
             self._git_dir.mkdir(parents=True, exist_ok=True)
-            self._git("init", "-q")
-        # Per-repo excludes live in <git-dir>/info/exclude — no tracked
-        # .gitignore, nothing written into the work-tree.
+            await self._git(["init", "-q"])
         info = self._git_dir / "info"
         info.mkdir(parents=True, exist_ok=True)
         (info / "exclude").write_text(
             "".join(f"{pat}\n" for pat in self._exclude), encoding="utf-8",
         )
 
-    def _git(self, *args: str) -> str:
-        name_k, name_v, email_k, email_v = _COMMITTER
-        cmd = [
-            "git",
-            "--git-dir", str(self._git_dir),
-            "--work-tree", str(self._work_tree),
-            # Pin a shadow identity so commits never depend on (or touch) the
-            # user's global git config.
-            "-c", f"user.name={name_v}",
-            "-c", f"user.email={email_v}",
-            *args,
-        ]
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, check=True,
-        )
-        return result.stdout
+    async def _git(self, args: list[str], *, check: bool = True) -> str:
+        _, out = await self._runner.run(args, check=check)
+        return out
 
-    def _rev_parse(self, ref: str) -> str | None:
+    async def _rev_parse(self, ref: str) -> str | None:
         try:
-            return self._git("rev-parse", ref).strip() or None
-        except subprocess.CalledProcessError:
-            return None
-
-    def _tag_sha(self, tag: str) -> str | None:
-        try:
-            out = self._git("rev-parse", "--verify", "-q", f"{tag}^{{commit}}")
+            out = await self._git(["rev-parse", ref])
         except subprocess.CalledProcessError:
             return None
         return out.strip() or None
+
+    async def _tag_sha(self, tag: str) -> str | None:
+        rc, out = await self._runner.run(
+            ["rev-parse", "--verify", "-q", f"{tag}^{{commit}}"], check=False,
+        )
+        return out.strip() if rc == 0 and out.strip() else None

--- a/tests/chat/services/test_snapshot_journal.py
+++ b/tests/chat/services/test_snapshot_journal.py
@@ -287,7 +287,7 @@ async def test_cut_generation_captures_both_substrates_at_same_seq(tmp_path):
     journal.set_workspace_store(ws_store)
     journal.snapshot.applied_seq = seq   # simulate the boundary snapshot
 
-    journal.cut_generation()
+    await journal.cut_generation()
 
-    assert seq in gen_store.seqs()       # runtime generation recorded
-    assert seq in ws_store.seqs()        # workspace generation captured at SAME seq
+    assert seq in gen_store.seqs()        # runtime generation recorded (sync gen store)
+    assert seq in await ws_store.seqs()   # workspace generation captured at SAME seq

--- a/tests/test_anchor_text_1547.py
+++ b/tests/test_anchor_text_1547.py
@@ -72,13 +72,13 @@ async def test_cut_generation_captures_anchor(tmp_path):
     journal.set_anchor_store(anchors)
     journal.snapshot.applied_seq = seq
 
-    journal.cut_generation(anchor="rewind me here")
+    await journal.cut_generation(anchor="rewind me here")
     assert anchors.get(seq) == "rewind me here"
 
     # a later cut with no anchor (e.g. plan-step) leaves the slot empty.
     seq2 = await log.append("inbox_put", target="a", msg_id="n", msg_kind="user", payload={})
     journal.snapshot.applied_seq = seq2
-    journal.cut_generation()                 # no anchor
+    await journal.cut_generation()           # no anchor
     assert anchors.get(seq2) == ""
 
 

--- a/tests/test_live_rewind_gate.py
+++ b/tests/test_live_rewind_gate.py
@@ -108,7 +108,7 @@ async def test_live_rewind_reverts_both_substrates_to_as_of_n(tmp_path):
     assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v2"
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]
     # the auto-capture actually fired (else the gate would be vacuous).
-    assert seq_a in reg.workspace_store.seqs()
+    assert seq_a in await reg.workspace_store.seqs()
 
     # ── global rewind to the turn-A checkpoint ──
     await reg.rewind_to(seq_a)

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -210,10 +210,10 @@ async def test_rewind_to_restores_workspace_to_active_gen(tmp_path):
 
     (tmp_path / "code.py").write_text("v1", encoding="utf-8")
     await _put(log, "alpha", "a1")          # seq 1
-    ws.capture(1)
+    await ws.capture(1)
     (tmp_path / "code.py").write_text("v2", encoding="utf-8")
     await _put(log, "alpha", "a2")          # seq 2
-    ws.capture(2)
+    await ws.capture(2)
 
     await reg.rewind_to(1)
 
@@ -237,10 +237,10 @@ async def test_recover_rewind_restores_active_gen_not_abandoned(tmp_path):
 
     (tmp_path / "code.py").write_text("v1", encoding="utf-8")
     await _put(log, "alpha", "a1")          # seq 1  (active, gen-1 = v1)
-    ws.capture(1)
+    await ws.capture(1)
     (tmp_path / "code.py").write_text("v2", encoding="utf-8")
     await _put(log, "alpha", "a2")          # seq 2  (will be abandoned, gen-2 = v2)
-    ws.capture(2)
+    await ws.capture(2)
 
     # reset-record appended (rewind to 1), then crash BEFORE materialisation.
     R = await rewind(log, target_n=1)       # seq 3 — abandons (1, 3) incl. gen-2@2
@@ -284,10 +284,10 @@ async def test_restore_all_triggers_crash_recovery(tmp_path):
 
     (tmp_path / "code.py").write_text("v1", encoding="utf-8")
     await _put(log, "ghost", "g1")          # seq 1 (advances seq; 'ghost' not in list_names)
-    ws.capture(1)
+    await ws.capture(1)
     (tmp_path / "code.py").write_text("v2", encoding="utf-8")
     await _put(log, "ghost", "g2")          # seq 2
-    ws.capture(2)
+    await ws.capture(2)
     await rewind(log, target_n=1)           # seq 3 — abandons (1,3); crash before materialise
     assert (tmp_path / "code.py").read_text(encoding="utf-8") == "v2"   # pre-recovery
 
@@ -363,7 +363,7 @@ async def test_truncate_gcs_generations_below_floor(tmp_path):
         store.record(snap)
     assert store.seqs() == [1, 2, 3]
 
-    reg._prune_generations_below(3)
+    await reg._prune_generations_below(3)
 
     kept = reg._store_for("alpha").seqs()
     assert kept == [3]                                   # 1, 2 GC'd; 3 (>= floor) kept

--- a/tests/test_snapshot_generation_recording.py
+++ b/tests/test_snapshot_generation_recording.py
@@ -42,7 +42,7 @@ async def test_cut_generation_records_current_snapshot(tmp_path):
     log, store, journal = _journal(tmp_path)
     await journal.append_inbox(kind="user", payload={"text": "hi"})
     assert store.seqs() == []          # state change alone does not cut
-    journal.cut_generation()           # turn boundary
+    await journal.cut_generation()           # turn boundary
     seq = journal.snapshot.applied_seq
     assert store.seqs() == [seq]
     assert store.load(seq) == journal.snapshot
@@ -68,7 +68,7 @@ async def test_reconstruct_head_equals_live_snapshot(tmp_path):
     """
     log, store, journal = _journal(tmp_path)
     await journal.append_inbox(kind="user", payload={"text": "a"})
-    journal.cut_generation()
+    await journal.cut_generation()
     await journal.append_inbox(kind="user", payload={"text": "b"})  # past the gen
     rebuilt = reconstruct(AGENT, store, log, log.current_seq)
     assert rebuilt == journal.snapshot
@@ -84,5 +84,5 @@ async def test_no_store_is_noop_no_behavior_change(tmp_path):
     log, store, journal = _journal(tmp_path, with_store=False)
     assert store is None
     await journal.append_inbox(kind="user", payload={"text": "x"})
-    journal.cut_generation()  # must not raise
+    await journal.cut_generation()  # must not raise
     assert (tmp_path / "snapshot.json").is_file()

--- a/tests/test_workspace_version_store.py
+++ b/tests/test_workspace_version_store.py
@@ -1,10 +1,12 @@
 """Tier 2: OS invariant — WorkspaceVersionStore content-addressed shadow-git.
 
-ADR-0038 Stage 1d (D9). Real ``git`` + real filesystem (no mocks). The store is
-the workspace half of a generation: capture the work-tree at a boundary seq,
-restore it as-of-N on rewind. Covers the round-trip (files revert, later-added
-files removed, excluded OS state survives), idempotent capture, nearest-at-or-
-below restore, retention prune, and git-absent graceful degrade.
+ADR-0038 Stage 1d (D9) + #1544 (async git-exec for container support). Real
+``git`` + real filesystem (no mocks). The store is the workspace half of a
+generation: capture the work-tree at a boundary seq, restore it as-of-N on
+rewind. Git methods are async (#1544 — the container runner is async); git-absence
+degrades at exec time. Covers the round-trip (files revert, later-added files
+removed, excluded OS state survives), idempotent capture, nearest-at-or-below
+restore, retention prune, and git-absent graceful degrade.
 """
 from __future__ import annotations
 
@@ -36,29 +38,31 @@ def _read(tmp_path: Path, rel: str) -> str:
     return (tmp_path / "ws" / rel).read_text(encoding="utf-8")
 
 
-def test_capture_restore_round_trip(tmp_path):
+@pytest.mark.asyncio
+async def test_capture_restore_round_trip(tmp_path):
     """Tier 2: restore reverts tracked files to as-of-N; later-added files gone; .reyn survives."""
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "v1")
     _write(tmp_path, ".reyn/wal.jsonl", "os-state")     # OS state — must NOT be tracked/wiped
 
-    store.capture(10)
+    await store.capture(10)
 
     # later work: mutate a tracked file + add a new one
     _write(tmp_path, "file.txt", "v2")
     _write(tmp_path, "added.txt", "new")
-    store.capture(20)
+    await store.capture(20)
     assert _read(tmp_path, "file.txt") == "v2"
 
     # rewind: restore to as-of-10
-    store.restore_at_or_below(10)
+    await store.restore_at_or_below(10)
 
     assert _read(tmp_path, "file.txt") == "v1"               # reverted
     assert not (tmp_path / "ws" / "added.txt").exists()       # later-added removed
     assert _read(tmp_path, ".reyn/wal.jsonl") == "os-state"   # excluded OS state survives
 
 
-def test_capture_is_idempotent_per_seq(tmp_path):
+@pytest.mark.asyncio
+async def test_capture_is_idempotent_per_seq(tmp_path):
     """Tier 2: capturing the same seq twice returns the same sha (no duplicate gen).
 
     A global seq may be hit by more than one agent's boundary; the second
@@ -67,49 +71,53 @@ def test_capture_is_idempotent_per_seq(tmp_path):
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "v1")
 
-    first = store.capture(10)
-    second = store.capture(10)
+    first = await store.capture(10)
+    second = await store.capture(10)
 
     assert first is not None
     assert first == second
-    assert store.seqs() == [10]
+    assert await store.seqs() == [10]
 
 
-def test_restore_picks_nearest_at_or_below(tmp_path):
+@pytest.mark.asyncio
+async def test_restore_picks_nearest_at_or_below(tmp_path):
     """Tier 2: restore_at_or_below(s) restores the nearest generation with seq <= s."""
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "gen10")
-    store.capture(10)
+    await store.capture(10)
     _write(tmp_path, "file.txt", "gen20")
-    store.capture(20)
+    await store.capture(20)
 
-    store.restore_at_or_below(15)   # between gens → nearest below = 10
+    await store.restore_at_or_below(15)   # between gens → nearest below = 10
     assert _read(tmp_path, "file.txt") == "gen10"
 
 
-def test_restore_with_no_generation_returns_none(tmp_path):
+@pytest.mark.asyncio
+async def test_restore_with_no_generation_returns_none(tmp_path):
     """Tier 2: restore with no captured generation is a safe no-op (returns None)."""
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "v1")
-    assert store.restore_at_or_below(5) is None
+    assert await store.restore_at_or_below(5) is None
     assert _read(tmp_path, "file.txt") == "v1"   # untouched
 
 
-def test_seqs_and_prune_below(tmp_path):
+@pytest.mark.asyncio
+async def test_seqs_and_prune_below(tmp_path):
     """Tier 2: seqs() lists captured generations; prune_below drops older ones."""
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "v")
     for s in (10, 20, 30):
         _write(tmp_path, "file.txt", f"v{s}")
-        store.capture(s)
-    assert store.seqs() == [10, 20, 30]
+        await store.capture(s)
+    assert await store.seqs() == [10, 20, 30]
 
-    removed = store.prune_below(20)
+    removed = await store.prune_below(20)
     assert removed == 1                 # only gen 10 dropped
-    assert store.seqs() == [20, 30]
+    assert await store.seqs() == [20, 30]
 
 
-def test_restore_to_seq_exact_and_missing(tmp_path):
+@pytest.mark.asyncio
+async def test_restore_to_seq_exact_and_missing(tmp_path):
     """Tier 2: restore_to_seq targets an EXACT generation; unknown seq is a no-op.
 
     This is the is_active-aware entry the registry uses with an active-resolved
@@ -118,27 +126,32 @@ def test_restore_to_seq_exact_and_missing(tmp_path):
     """
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "gen10")
-    store.capture(10)
+    await store.capture(10)
     _write(tmp_path, "file.txt", "gen20")
-    store.capture(20)
+    await store.capture(20)
 
     # exact restore to the older gen even though a newer one exists
-    sha = store.restore_to_seq(10)
+    sha = await store.restore_to_seq(10)
     assert sha is not None
     assert _read(tmp_path, "file.txt") == "gen10"
 
     # unknown gen seq → safe no-op (workspace untouched)
-    assert store.restore_to_seq(999) is None
+    assert await store.restore_to_seq(999) is None
     assert _read(tmp_path, "file.txt") == "gen10"
 
 
-def test_git_unavailable_degrades_to_noop(tmp_path, monkeypatch):
-    """Tier 2: with no git on PATH, capture/restore degrade to None (runtime rewind still works)."""
+@pytest.mark.asyncio
+async def test_git_unavailable_degrades_to_noop(tmp_path, monkeypatch):
+    """Tier 2: with no git on PATH, git-exec degrades at exec time to no-ops.
+
+    #1544: degrade is exec-time (the runner raises GitUnavailable when the binary
+    is missing), NOT a host-PATH pre-gate — so it's correct for container mode too.
+    """
     monkeypatch.setenv("PATH", "")      # real env: no git resolvable
     store = _store(tmp_path)
     _write(tmp_path, "file.txt", "v1")
 
-    assert store.git_available() is False
-    assert store.capture(10) is None
-    assert store.restore_at_or_below(10) is None
-    assert store.seqs() == []
+    assert store.host_git_available() is False   # host fast-path reflects it
+    assert await store.capture(10) is None        # exec-time degrade
+    assert await store.restore_at_or_below(10) is None
+    assert await store.seqs() == []


### PR DESCRIPTION
**[dogfood-coder]** — **increment 1 of 2** for #1544 (shadow-git container mode). Design-first-locked in #1544 (architecture / scope / runner-shape / Q-async strategy (i) / git-absence (b), all lead-approved); increment-1 deep-reviewed + approved.

This increment is the **async boundary move only — host behavior is byte-unchanged**. It lands first so increment-2's diff is purely the container runner (easier review; staging de-risk).

## What this lands (host async-ification)
Prepares `WorkspaceVersionStore` for a container git runner (`backend.run`/docker-exec, inherently async) without a sync/async impedance mismatch.

- **`WorkspaceVersionStore`**: git delegated to an injected runner (default `_HostGitRunner` = `subprocess` **inline** — same blocking behavior as today, where host git already ran sync inside the async turn loop). `capture` / `restore_to_seq` / `restore_at_or_below` / `seqs` / `prune_below` + internals are **async**.
- **git-absence degrades at EXEC time** via `GitUnavailable` (lead's (b)) — `git_available`→`host_git_available`, a host fast-path only, **not** the correctness gate (`shutil.which` tests the host PATH, meaningless for a container). `_degrade` logs once (no spam).
- **Async boundary** (enumerated call-site table in #1544): 3 sync wrappers become async — `journal.cut_generation`, `registry._restore_workspace_active` / `_prune_generations_below` — and the 4 call-sites (all already async) `await`: `_run_router_loop`, `record_plan_step_completed`, `_materialize_rewind`, `truncate_wal_if_eligible`. The `git_available()` pre-gate is removed from the registry wrappers (exec-time degrade replaces it).
- `SnapshotGenerationStore` + `AnchorStore` stay **sync** (host-only JSON/files; no container exec) — disambiguated with inline comments at the mixed call-sites.

## Test plan
- [x] `WorkspaceVersionStore` tests async-ified + awaited; git-absent test asserts the **exec-time** degrade (empty PATH → `GitUnavailable` → no-op), not a pre-gate.
- [x] All cross-store call-sites awaited; `SnapshotGenerationStore`/`AnchorStore` left sync (verified distinct).
- [x] **`-W error::RuntimeWarning`** confirms no un-awaited coroutine (caught + fixed 2 missed awaits during dev).
- [x] 137 tests green across workspace / registry / rewind / retention / journal / chat / session; tier-audit + ruff clean.

**increment-2 (stacks after merge)**: `_ContainerGitRunner` (`backend.run` docker-exec + container `--git-dir`/`--work-tree` path context) + `AgentRegistry` `environment_backend` wiring + real-docker round-trip test `@skipif` + container git-absent degrade test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)