### PR TITLE
feat(1533): Phase-2 2a-1 — derived branch-registry (branch_id + list_branches)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -37,11 +37,14 @@ from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.anchor_store import AnchorStore
 from reyn.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.events.snapshot_generations import (
+    Branch,
     RewindBeyondRetentionError,
     RewindIntoAbandonedError,
     SnapshotGenerationStore,
     active_rewind_target,
+    branch_ids_for,
     is_active_seq,
+    list_branches,
     reconstruct,
 )
 from reyn.events.snapshot_generations import rewind as _append_rewind_record
@@ -484,13 +487,20 @@ class AgentRegistry:
         finally:
             self._rewind_in_progress = False
 
-    def list_rewind_points(self) -> list[dict]:
-        """Enumerate the active rewind targets for the time-travel UI (1f).
+    def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
+        """Enumerate rewind targets for the time-travel UI (1f / Phase-2 fork).
 
-        Returns one row per snapshot-generation boundary on the **active**
-        branch, ascending by seq::
+        Returns one row per snapshot-generation boundary, ascending by seq::
 
-            [{"seq": int, "ts": str, "kind": str}, ...]
+            [{"seq": int, "ts": str, "kind": str, "anchor": str, "branch_id": int}, ...]
+
+        Default (``include_abandoned=False``) keeps only **active-branch** boundaries
+        (Phase-1 1f timeline). Phase-2 fork UX passes ``include_abandoned=True`` to
+        get every branch's boundaries (the tree), each tagged with its
+        ``branch_id`` (#1533 2a→2b). **`branch_id` is the lineage-correct membership
+        source** — group rows by it (a branch's `[fork_point, head]` *range*
+        physically contains its abandoned children's seqs, so range-intersection
+        over-includes; the substrate segment-map resolves true ownership).
 
         ``seq`` is the WAL boundary the user can ``rewind_to``. ``ts`` and
         ``kind`` are read from the WAL entry at that seq (the EventStore /
@@ -513,12 +523,12 @@ class AgentRegistry:
         if self._state_log is None:
             return []
 
-        # Union of generation boundary seqs across every known agent, keeping
-        # only seqs on the active branch.
+        # Union of generation boundary seqs across every known agent. Default =
+        # active branch only (1f); include_abandoned = all branches (Phase-2 tree).
         seqs: set[int] = set()
         for name in self.list_names():
             for s in self._store_for(name).seqs():
-                if is_active_seq(self._state_log, s):
+                if include_abandoned or is_active_seq(self._state_log, s):
                     seqs.add(s)
         if not seqs:
             return []
@@ -532,6 +542,8 @@ class AgentRegistry:
                 wal_at[s] = entry
 
         anchors = self.anchor_store
+        # #1533 2a→2b: lineage-correct branch membership per checkpoint seq.
+        branch_of = branch_ids_for(self._state_log, sorted(seqs))
         rows: list[dict] = []
         for s in sorted(seqs):
             entry = wal_at.get(s, {})
@@ -543,8 +555,23 @@ class AgentRegistry:
                 # existing consumers ignore it; the timeline widget renders it as
                 # a 2nd dim line. Keyed by the same WAL seq → trivial lookup.
                 "anchor": anchors.get(s) if anchors is not None else "",
+                # #1533 2a→2b: the branch this checkpoint belongs to (group by this).
+                "branch_id": branch_of.get(s, 0),
             })
         return rows
+
+    def list_branches(self) -> "list[Branch]":
+        """The derived branch tree for the fork UX (#1533 Phase-2 2a / D8).
+
+        ``[Branch(branch_id, fork_point_seq, head_seq, parent_branch_id,
+        is_active)]`` derived from the reset-record chain (no stored registry).
+        Tree topology (nesting/active); per-branch checkpoint *membership* comes
+        from ``list_rewind_points(include_abandoned=True)`` rows' ``branch_id``.
+        Empty when there is no WAL.
+        """
+        if self._state_log is None:
+            return []
+        return list_branches(self._state_log)
 
     @property
     def workspace_store(self) -> WorkspaceVersionStore | None:

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -19,6 +19,7 @@ written atomically with the same tmp→fsync→rename discipline as
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 from reyn.events.agent_snapshot import AgentSnapshot
@@ -167,6 +168,84 @@ def active_rewind_target(state_log: StateLog) -> int | None:
     if not records:
         return None
     return max(records, key=lambda t: t[0])[1]
+
+
+# ── Phase-2 fork: derived branch tree (ADR-0038 D8, #1533) ─────────────────────
+#
+# Grounded in the SAME abandoned-interval machinery as is_active (inherits the
+# 1b-1e correctness), NOT a fresh segment walk. Branch identity:
+#   - the **active** branch (id 0) = the current live lineage = every is_active seq
+#     (undo continues the active branch; the rewound-past content is NOT root, it's
+#     a dead branch — distinguishing undo from a "new branch" was the subtlety
+#     e2e's over-include repro exposed);
+#   - each **abandoned interval** (N, R) = a dead branch (id R, forked at N) holding
+#     the rewound-past content.
+# Range-intersection over `[fork_point, head]` over-includes (an active parent's
+# range physically spans its abandoned children); membership is interval-resolved.
+
+ACTIVE_BRANCH_ID = 0
+
+
+@dataclass(frozen=True)
+class Branch:
+    """One node of the derived branch tree (ADR-0038 D8 Phase-2 fork)."""
+
+    branch_id: int            # 0 = the active live branch; else the reset-record R that orphaned it
+    fork_point_seq: int       # where it diverges; active = 0
+    head_seq: int             # highest seq owned (active = WAL head; dead = R-1)
+    parent_branch_id: int | None  # branch owning fork_point; active = None
+    is_active: bool
+
+
+def _branch_of_seq(seq: int, abandoned: list[tuple[int, int]]) -> int:
+    """Owning branch_id of ``seq``: 0 (active) if not abandoned, else the R of the
+    tightest abandoned interval ``(N, R)`` containing it (innermost fork = max N)."""
+    best: tuple[int, int] | None = None
+    for (n, r) in abandoned:
+        if n < seq < r and (best is None or n > best[0]):
+            best = (n, r)
+    return ACTIVE_BRANCH_ID if best is None else best[1]
+
+
+def branch_ids_for(state_log: StateLog, seqs: "list[int]") -> dict[int, int]:
+    """Map each seq → its owning branch_id (lineage-correct membership, #1533 2a→2b).
+
+    ``is_active`` seqs → the active branch (0); a rewound-past seq → the dead branch
+    (the reset-record ``R`` that abandoned it). NOT range-intersection (an active
+    parent's ``[fork_point, head]`` range physically spans its abandoned children,
+    so a naive intersect over-includes — e2e's repro). Grounded in the proven
+    ``_abandoned_intervals`` (inherits 1b-1e correctness). ``list_rewind_points``
+    tags each row with this so the UX groups by branch_id.
+    """
+    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    return {s: _branch_of_seq(s, abandoned) for s in seqs}
+
+
+def list_branches(state_log: StateLog) -> list[Branch]:
+    """Derive the branch tree (#1533 Phase-2 2a / D8).
+
+    The active branch (id 0) = the live lineage (all is_active seqs). Each abandoned
+    interval ``(N, R)`` = a dead branch (id R) forked at N, with ``parent`` = the
+    branch owning N (active or an enclosing dead branch → nesting). Returns the
+    active branch first, then dead branches ascending by id. Empty WAL → [].
+    """
+    head = state_log.current_seq
+    if head <= 0:
+        return []
+    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    out: list[Branch] = [Branch(
+        branch_id=ACTIVE_BRANCH_ID, fork_point_seq=0, head_seq=head,
+        parent_branch_id=None, is_active=True,
+    )]
+    for (n, r) in sorted(abandoned, key=lambda t: t[1]):  # ascending by R (dead-branch id)
+        out.append(Branch(
+            branch_id=r,
+            fork_point_seq=n,
+            head_seq=r - 1,                       # top of the rewound-past content (N, R)
+            parent_branch_id=_branch_of_seq(n, abandoned),  # branch owning the fork point (nesting)
+            is_active=False,
+        ))
+    return out
 
 
 async def rewind(

--- a/tests/test_branch_registry_2a.py
+++ b/tests/test_branch_registry_2a.py
@@ -1,0 +1,210 @@
+"""Tier 2: OS invariant — Phase-2 derived branch tree (#1533 2a, ADR-0038 D8).
+
+Real `StateLog` (no mocks). The branch tree + per-checkpoint branch membership are
+DERIVED from the reset-record chain via the proven `_abandoned_intervals`
+machinery (inherits 1b-1e correctness) — no stored registry, no per-entry
+branch_id. Load-bearing case: the over-include repro (an active branch's
+`[fork_point, head]` range physically spans its abandoned children, so naive
+range-intersection mis-groups; branch_id membership separates them lineage-correctly).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.events.snapshot_generations import (
+    ACTIVE_BRANCH_ID,
+    branch_ids_for,
+    list_branches,
+    rewind,
+)
+from reyn.events.state_log import StateLog
+
+
+async def _put(log: StateLog, text: str) -> int:
+    return await log.append(
+        "inbox_put", target="a", msg_id=text, msg_kind="user", payload={"text": text},
+    )
+
+
+# ── branch_ids_for: lineage-correct membership (the over-include repro) ────────
+
+
+@pytest.mark.asyncio
+async def test_branch_membership_over_include_repro(tmp_path):
+    """Tier 2: rewind-then-continue — abandoned checkpoint is NOT grouped with active.
+
+    The load-bearing case (e2e build-first catch): root 1..10 {checkpoints 3,6,9},
+    rewind to 6 (abandons 7-10), continue {12}. The active branch's range [0,13]
+    physically CONTAINS the abandoned 9, so a naive range-intersection over-includes
+    it. branch_ids_for resolves true membership: 3,6,12 → active(0); 9 → the dead
+    branch (the reset-record R that abandoned it).
+    """
+    log = StateLog(tmp_path / "wal")
+    for i in range(1, 11):                      # seq 1..10
+        await _put(log, f"m{i}")
+    r = await rewind(log, target_n=6)           # seq 11 — abandons (6, 11) = 7..10
+    await _put(log, "m12")                      # seq 12
+    await _put(log, "m13")                      # seq 13
+
+    ids = branch_ids_for(log, [3, 6, 9, 12])
+    assert ids[3] == ACTIVE_BRANCH_ID           # active (<=6, on the live line)
+    assert ids[6] == ACTIVE_BRANCH_ID           # the rewind target is active
+    assert ids[12] == ACTIVE_BRANCH_ID          # post-rewind continuation = active
+    assert ids[9] == r                          # abandoned → the dead branch (id = R)
+    assert ids[9] != ACTIVE_BRANCH_ID           # NOT mixed into the active group
+
+    # group-by-branch_id (the UX consumption) yields lineage-correct lists.
+    groups: dict[int, list[int]] = {}
+    for seq, bid in ids.items():
+        groups.setdefault(bid, []).append(seq)
+    assert sorted(groups[ACTIVE_BRANCH_ID]) == [3, 6, 12]
+    assert groups[r] == [9]
+
+
+@pytest.mark.asyncio
+async def test_no_rewind_all_active(tmp_path):
+    """Tier 2: with no rewind, every checkpoint is on the active branch (0)."""
+    log = StateLog(tmp_path / "wal")
+    for i in range(1, 4):
+        await _put(log, f"m{i}")
+    assert branch_ids_for(log, [1, 2, 3]) == {1: 0, 2: 0, 3: 0}
+
+
+# ── list_branches: tree topology ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_branches_single_undo(tmp_path):
+    """Tier 2: one rewind → active branch + one dead branch forked at the target."""
+    log = StateLog(tmp_path / "wal")
+    for i in range(1, 11):
+        await _put(log, f"m{i}")
+    r = await rewind(log, target_n=6)
+    await _put(log, "m12")
+    head = log.current_seq
+
+    branches = list_branches(log)
+    active = next(b for b in branches if b.is_active)
+    dead = [b for b in branches if not b.is_active]
+    assert active.branch_id == ACTIVE_BRANCH_ID and active.fork_point_seq == 0
+    assert active.head_seq == head and active.parent_branch_id is None
+    # exactly one dead branch, and it is the orphaning reset-record R.
+    assert {b.branch_id for b in dead} == {r}
+    only = dead[0]
+    assert only.fork_point_seq == 6        # forked at the rewind target
+    assert only.head_seq == r - 1          # top of the rewound-past content
+    assert only.parent_branch_id == ACTIVE_BRANCH_ID   # fork point is on the active line
+
+
+@pytest.mark.asyncio
+async def test_list_branches_nested_dead_branches_parent_edges(tmp_path):
+    """Tier 2: nested rewinds → dead branches with correct parent nesting.
+
+    a(1) b(2) | rewind→1 (abandons 2) | c(4) d(5) | rewind→4 (abandons 5).
+    Two dead branches; the second's fork point (4) is on the active line → parent
+    is the active branch (this exercises parent = branch-owning-the-fork-point).
+    """
+    log = StateLog(tmp_path / "wal")
+    await _put(log, "a")                    # seq 1
+    await _put(log, "b")                    # seq 2
+    r1 = await rewind(log, target_n=1)      # seq 3 — abandons (1,3) = {2}
+    await _put(log, "c")                    # seq 4
+    await _put(log, "d")                    # seq 5
+    r2 = await rewind(log, target_n=4)      # seq 6 — abandons (4,6) = {5}
+
+    branches = list_branches(log)
+    by_id = {b.branch_id: b for b in branches}
+    assert by_id[ACTIVE_BRANCH_ID].is_active
+    assert by_id[r1].fork_point_seq == 1 and by_id[r1].head_seq == r1 - 1
+    assert by_id[r2].fork_point_seq == 4 and by_id[r2].head_seq == r2 - 1
+    # both fork points (1 and 4) are on the active line → parent = active.
+    assert by_id[r1].parent_branch_id == ACTIVE_BRANCH_ID
+    assert by_id[r2].parent_branch_id == ACTIVE_BRANCH_ID
+    assert not by_id[r1].is_active and not by_id[r2].is_active
+
+
+@pytest.mark.asyncio
+async def test_empty_wal_no_branches(tmp_path):
+    """Tier 2: empty WAL → no branches."""
+    log = StateLog(tmp_path / "wal")
+    assert list_branches(log) == []
+
+
+@pytest.mark.asyncio
+async def test_derivation_robust_without_supersedes(tmp_path):
+    """Tier 2: the tree is correct though rewind() never set supersedes (Q2).
+
+    These rewinds omit `supersedes` (default None) — proving the derivation uses
+    only always-present (R, target_n) + the interval machinery, not supersedes.
+    """
+    log = StateLog(tmp_path / "wal")
+    for i in range(1, 6):
+        await _put(log, f"m{i}")
+    r = await rewind(log, target_n=2)       # supersedes NOT passed
+    branches = list_branches(log)
+    dead = [b for b in branches if not b.is_active]
+    assert {b.branch_id for b in dead} == {r}   # exactly the orphaning record
+    assert dead[0].fork_point_seq == 2
+
+
+# ── registry list_rewind_points: branch_id + include_abandoned wiring ─────────
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_branch_id_and_include_abandoned(tmp_path):
+    """Tier 2: list_rewind_points tags rows with branch_id; include_abandoned gates.
+
+    Wires the 2a→2b contract: default = active-branch checkpoints only (1f); with
+    include_abandoned, dead-branch checkpoints appear, each carrying its branch_id
+    so the UX groups by it (no range-intersection).
+    """
+    from reyn.chat.profile import AgentProfile
+    from reyn.chat.registry import AgentRegistry
+    from reyn.events.agent_snapshot import AgentSnapshot
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+
+    async def put(text):
+        return await state_log.append(
+            "inbox_put", target="alpha", msg_id=text, msg_kind="user", payload={},
+        )
+
+    def record_gen(seq):
+        snap = AgentSnapshot.empty("alpha")
+        snap.applied_seq = seq
+        reg._store_for("alpha").record(snap)
+
+    for i in range(1, 11):                  # seq 1..10
+        await put(f"m{i}")
+    for s in (3, 6, 9):                      # checkpoints on root
+        record_gen(s)
+    r = await rewind(state_log, target_n=6)  # seq 11 — abandons 7..10 (incl gen@9)
+    await put("m12")                         # seq 12
+    record_gen(12)
+
+    # default: active branch only — abandoned gen@9 filtered out (1f behaviour).
+    active_rows = reg.list_rewind_points()
+    active_seqs = {row["seq"] for row in active_rows}
+    assert 9 not in active_seqs
+    assert {3, 6, 12} <= active_seqs
+    assert all("branch_id" in row for row in active_rows)              # field present
+    assert all(row["branch_id"] == ACTIVE_BRANCH_ID for row in active_rows)
+
+    # include_abandoned: dead-branch gen@9 appears, tagged with its branch_id.
+    all_rows = reg.list_rewind_points(include_abandoned=True)
+    by_seq = {row["seq"]: row for row in all_rows}
+    assert 9 in by_seq
+    assert by_seq[9]["branch_id"] == r                                 # dead branch
+    assert by_seq[3]["branch_id"] == ACTIVE_BRANCH_ID
+    assert by_seq[12]["branch_id"] == ACTIVE_BRANCH_ID
+
+    # reg.list_branches(): active + the dead branch.
+    branches = reg.list_branches()
+    assert any(b.is_active and b.branch_id == ACTIVE_BRANCH_ID for b in branches)
+    assert any(b.branch_id == r and not b.is_active and b.fork_point_seq == 6 for b in branches)


### PR DESCRIPTION
**[dogfood-coder]** — #1533 Phase-2 substrate, increment 2a-1 (ADR-0038 D8 git-like fork foundation). Lead deep-review = APPROVE (branch-精読, Phase-1 同 rigor); opening for CI-green merge.

## What

The branch tree and per-checkpoint branch membership are **derived** from the reset-record chain via the proven `_abandoned_intervals` machinery (inherits 1b-1e correctness) — no stored registry, no persisted per-entry `branch_id` field.

`snapshot_generations.py`:
- `Branch(branch_id, fork_point_seq, head_seq, parent_branch_id, is_active)`
- `branch_ids_for(state_log, seqs)` — `is_active → 0` (active live branch); else the reset-record `R` of the tightest abandoned interval that orphaned the seq (= dead branch). `_branch_of_seq` uses `n < seq < r` & max-`n` so nested forks resolve correctly and the target `N` / reset-record `R` are excluded.
- `list_branches(state_log)` — active branch (head first) + one dead branch per abandoned interval, with parent edges (the branch owning the fork point); empty WAL → `[]`.

`registry.py` (additive):
- `list_rewind_points(include_abandoned=False)` now tags each row with `branch_id`; `include_abandoned` lifts the active-only filter (Phase-1 1f default preserved).
- `reg.list_branches()` wrapper.

## Why branch_id, not range-intersection (the load-bearing case)

An active branch's `[fork_point, head]` range **physically contains** its abandoned children's seqs, so naive range-intersection over-includes them (e2e build-first catch). `branch_id` membership resolves true lineage: in the keystone repro — root 1..10 {checkpoints 3,6,9} → rewind to 6 → continue {12} — `3,6,12 → active(0)` and `9 → the dead branch R`, never mixed.

## Test plan

Tier 2 real-instance tests (no mocks), `tests/test_branch_registry_2a.py`:

- [x] `test_branch_membership_over_include_repro` — load-bearing keystone (substrate-side mirror of e2e's UX repro = defense-in-depth)
- [x] `test_list_branches_single_undo` / `..._nested_dead_branches_parent_edges` (parent edges + nesting) / `..._empty_wal`
- [x] `test_derivation_robust_without_supersedes` (Q2 — derivation uses only always-present `(R, target_n)` + interval machinery)
- [x] `test_list_rewind_points_branch_id_and_include_abandoned` (1f-preserving default + tagged abandoned rows + `reg.list_branches()`)
- [x] `test_no_rewind_all_active`
- [x] `python -m pytest tests/test_branch_registry_2a.py -W error::RuntimeWarning` → 7 passed
- [x] tier-audit → 7/7 OK; ruff clean
- [x] 122 adjacent rewind/snapshot/anchor/registry tests pass (additive, no regression)

Consumes: e2e's 2b `build_branch_tree_rows` groups by `branch_id` (shape confirmed matching). Unblocks: 2a-2 `checkout(seq)` unified primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)