### PR TITLE
feat(1533): Phase-2 2a-2 — checkout(seq) unified primitive (rewind_to = active-node case)

### DIFF
--- a/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a2-checkout-design.md
+++ b/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a2-checkout-design.md
@@ -1,0 +1,86 @@
+# #1533 2a-2 — `checkout(seq)` unified primitive (design draft)
+
+**Status**: IMPLEMENTED on `feat/1533-2a2-checkout` (2a-1 merged in #1558). Author: dogfood-coder.
+**Depends on**: 2a-1 branch-registry (`branch_ids_for` / `list_branches`, abandoned-interval-grounded). Refactors `rewind_to`.
+
+> Landed: substrate `checkout(state_log, *, target_seq)` (unconditional) + `rewind` guarded-delegate; registry `checkout(seq)` + `rewind_to` thin wrapper; `_abandoned_intervals` docstring updated. Tests: `tests/test_registry_checkout_2a2.py` (full-path runtime + two-substrate round-trip + equivalence + preserved-guard). The interval-layer caveat below is now closed by the real-instance integration tests.
+
+## Goal
+
+One primitive `checkout(seq)` that subsumes Phase-1 `rewind_to` (active-branch
+undo) and Phase-2 fork/branch-switch (jump to *any* seq, including an abandoned
+branch's). `rewind_to` becomes the **active-node special case** of `checkout`.
+
+## The load-bearing distinction (the real substrate work)
+
+My first read assumed checkout-to-a-fork would need **new lineage-aware
+reconstruction** (walk active root → fork point → target branch segment), because
+today's `rewind_to` path reconstructs along the **active** branch
+(`reconstruct` / `_restore_workspace_active` honor `is_active_seq`). **That
+assumption was wrong** — verified below.
+
+The key property: `reconstruct`, `_materialize_rewind`, and
+`_restore_workspace_active` all recompute `is_active` **fresh from the full
+reset-record chain on every call**. So the moment a checkout's reset-record is
+appended, `is_active` *already describes the post-checkout active branch* — the
+existing machinery is automatically lineage-correct with no change.
+
+## Open question — RESOLVED by primary-evidence verification
+
+**Reset-record semantics for branch-switch.** Candidates were (1) a single
+reset-record `(R, target_n)` with the guard lifted, vs (2) an explicit
+branch-pointer field. **(1) is correct and needs NO new persisted field** —
+verified by exercising the production `_abandoned_intervals` / `branch_ids_for`
+on a real `StateLog` (all transitions inspected directly, not extrapolated):
+
+```
+root 1..10, rewind→6, continue {12,13}:
+  abandoned=[(6,11)]   active=[1..6,11,12,13]
+checkout→9  (abandoned target, guard lifted, record (14,9)):
+  abandoned=[(9,14)]   active=[1..9,14]           # 7,8,9 revived; 12,13 → dead branch 14
+  branch_ids: 6→0  9→0  7→0  12→14  13→14          # prior (6,11) subsumed (11 ∈ (9,14))
+checkout-back→12 (record (15,12)):
+  abandoned=[(12,15),(6,11)]  active=[1..6,11,12,15]
+  branch_ids: 6→0  12→0  9→11  11→0                # (6,11) RESURRECTS; 12 lineage = 1..6,11,12
+```
+
+The checkout-back case (where naive schemes break) composes correctly: the
+latest-first walk subsumes the intervening record when its R falls inside a newer
+interval, and *resurrects* an older abandonment when the subsuming record is
+itself later abandoned. `N < R` always holds (target is a real prior seq), so no
+degenerate interval. **No `is_active` flip-flag, no branch-pointer field needed.**
+
+**Caveat (scope of this verification):** this confirms the *interval-composition
+layer* (`is_active` / `branch_ids_for`). The full registry.checkout path
+(`reconstruct` + workspace restore + session re-adopt) is expected-correct *by
+derivation* (all recompute `is_active`) but is **not yet** exercised end-to-end —
+that needs the real-instance integration test (below) as primary evidence.
+
+## Proposed shape (simplified by the finding)
+
+```
+async def checkout(self, seq: int) -> dict:
+    # = rewind_to body MINUS the is_active_seq guard (retention guard kept).
+    #   all-cancel / all-quiesce / single reset-record / _materialize_rewind —
+    #   all unchanged; they recompute is_active from the post-checkout chain.
+
+async def rewind_to(self, target_n: int) -> dict:
+    # thin Phase-1 wrapper: is_active_seq(target_n) guard
+    #   (RewindIntoAbandonedError) → delegate to checkout(target_n).
+```
+
+The guard moves OUT of the shared core into the `rewind_to` wrapper; Phase-1
+callers keep `RewindIntoAbandonedError` on an abandoned target. The
+`_abandoned_intervals` docstring's "Phase-1 active-target guard" premise note
+must be updated (guard-lifted composition is still well-defined, per above).
+
+## Test plan (2a-2)
+
+- checkout to active seq == rewind_to (behavioral equivalence; existing 1c tests).
+- checkout to abandoned seq → reconstructs target-branch content (the dead
+  branch's snapshot), abandons prior active head; `list_branches` reflects the
+  swap.
+- round-trip: A→fork B→checkout back to A→checkout B again (N-way, no leakage).
+- workspace substrate follows the target lineage (not active) — real git store.
+- retention guard shared with rewind_to.
+- `-W error::RuntimeWarning`, tier-audit first-line `"""Tier 2: ..."""`.

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -47,7 +47,7 @@ from reyn.events.snapshot_generations import (
     list_branches,
     reconstruct,
 )
-from reyn.events.snapshot_generations import rewind as _append_rewind_record
+from reyn.events.snapshot_generations import checkout as _append_reset_record
 from reyn.events.state_log import StateLog
 from reyn.events.workspace_version_store import WorkspaceVersionStore
 
@@ -411,54 +411,54 @@ class AgentRegistry:
             name, self._dir / name / "state" / "generations",
         )
 
-    async def rewind_to(self, target_n: int) -> dict:
-        """Global consistent-cut rewind to WAL seq ``target_n`` (ADR-0038 1c-2).
+    async def checkout(self, seq: int) -> dict:
+        """Global consistent-cut checkout to ANY WAL ``seq`` (ADR-0038 D8 Phase-2).
+
+        The unified time-travel primitive: jump the whole world's active cut to
+        ``seq`` — whether ``seq`` is on the live branch (= undo, the ``rewind_to``
+        special case) or on an abandoned/dead branch (= branch-switch / fork
+        revival). Unlike ``rewind_to`` there is **no active-target guard**: a
+        target on a dead branch is allowed and revives that lineage.
+
+        This needs no new persisted field and no lineage-walk: a single
+        guard-lifted reset-record ``(R, seq)`` composes correctly through the
+        latest-first ``_abandoned_intervals`` machinery (a newer record subsumes
+        an intervening one when its R falls inside the new interval, and an older
+        abandonment resurrects when the subsuming record is itself later
+        abandoned). Because ``reconstruct`` / ``_materialize_rewind`` /
+        ``_restore_workspace_active`` all recompute ``is_active`` from the full
+        chain, both substrates follow the *target's* lineage automatically.
 
         Architecture-enforced global cut (D2): one global single-seq WAL + one
-        workspace SSoT means a single reset-record rewinds *every* agent
-        atomically. Sequence:
+        workspace SSoT ⇒ one reset-record moves *every* agent atomically:
 
-          1. validate ``target_n`` is on the active branch (1b guard) BEFORE
-             disrupting any live work — a bad target must not cancel turns.
+          1. retention guard — reject a target truncated out of the WAL (1e).
           2. all-cancel  — ``cancel_inflight`` on every loaded session.
           3. all-quiesce — ``await_quiescent`` on every loaded session (1c-1):
-             stop-world THEN settle, so no cross-session straggler appends past
-             the reset-record.
-          4. append ONE global rewind reset-record (fsync'd before any
-             reconstruct — the crash-mid-rewind idempotence keystone, 1b).
-          5. reconstruct every KNOWN agent as-of-N (honoring is_active) and
-             persist a **self-contained** snapshot at ``applied_seq = R`` so
-             ``restore_all`` replays only post-rewind (> R) entries and never
-             needs the abandoned segment — correct-or-absent without a
-             floor-clamp (is_active-honoring restore_all + retention = 1e).
-             Loaded sessions are reset (``reset_for_rewind``) then re-adopt the
-             reconstructed snapshot; unloaded agents are reconstructed on disk
-             only (next load reflects the rewound state — partial-honor).
+             stop-world THEN settle, so no straggler appends past the record.
+          4. append ONE global reset-record (fsync'd before any reconstruct —
+             the crash-mid-rewind idempotence keystone, 1b).
+          5. reconstruct every KNOWN agent as-of the target lineage (honoring the
+             recomputed is_active) + persist a **self-contained** snapshot at
+             ``applied_seq = R`` (``restore_all`` replays only > R); loaded
+             sessions reset (``reset_for_rewind``) + re-adopt; the workspace is
+             restored to the nearest active generation ``<= seq``.
 
         ``_rewind_in_progress`` gates compaction for the whole window.
-
-        Raises ``RewindIntoAbandonedError`` if ``target_n`` is on an abandoned
-        branch (switching branches is a Phase-2 fork, not Phase-1 undo).
         """
         if self._state_log is None:
-            raise RuntimeError("rewind_to requires a state log")
-        # 1. validate up front (no live work touched yet).
-        if not is_active_seq(self._state_log, target_n):
-            raise RewindIntoAbandonedError(
-                f"rewind target seq {target_n} is on an abandoned branch — "
-                "Phase-1 undo only rewinds to a seq on the active timeline."
-            )
+            raise RuntimeError("checkout requires a state log")
         # 1e (D5): bounded by retention — reject targets truncated out of the WAL.
         # Guard on the PHYSICAL oldest kept seq (not the policy floor): under a
         # live policy nothing is truncated between turns, so recent history stays
-        # rewindable; only genuinely-truncated history is rejected.
+        # reachable; only genuinely-truncated history is rejected.
         oldest = next(iter(self._state_log.iter_from(1)), None)
         oldest_seq = oldest.get("seq") if oldest else None
-        if oldest_seq is not None and target_n < oldest_seq:
+        if oldest_seq is not None and seq < oldest_seq:
             raise RewindBeyondRetentionError(
-                f"checkpoint seq {target_n} is outside the retained WAL (oldest "
+                f"checkpoint seq {seq} is outside the retained WAL (oldest "
                 f"kept = {oldest_seq}) — it has been truncated. Configure a deeper "
-                "retention window to rewind this far back."
+                "retention window to reach this far back."
             )
 
         self._rewind_in_progress = True
@@ -472,20 +472,43 @@ class AgentRegistry:
                 await session.await_quiescent()
             # 4. single global reset-record; supersedes = prior active head (audit).
             prior_head = self._state_log.current_seq
-            reset_seq = await _append_rewind_record(
-                self._state_log, target_n=target_n, supersedes=prior_head,
+            reset_seq = await _append_reset_record(
+                self._state_log, target_seq=seq, supersedes=prior_head,
             )
-            # 5. materialise both substrates as-of-N (runtime snapshots + workspace).
+            # 5. materialise both substrates along the target lineage.
             agents = await self._materialize_rewind(
-                reconstruct_seq=reset_seq, workspace_at_or_below=target_n,
+                reconstruct_seq=reset_seq, workspace_at_or_below=seq,
             )
             return {
-                "target_n": target_n,
+                "target_n": seq,
                 "reset_seq": reset_seq,
                 "agents": agents,
             }
         finally:
             self._rewind_in_progress = False
+
+    async def rewind_to(self, target_n: int) -> dict:
+        """Phase-1 undo: the active-node special case of ``checkout`` (ADR-0038 1c-2).
+
+        Thin wrapper — validates ``target_n`` is on the **active branch** up front
+        (so a bad target never cancels live work), then delegates to ``checkout``.
+        The active-target guard lives HERE, not in the shared core: Phase-1 undo
+        only rewinds along the live timeline, while ``checkout`` lifts it for
+        Phase-2 branch-switch.
+
+        Raises ``RewindIntoAbandonedError`` if ``target_n`` is on an abandoned
+        branch (switching branches is a Phase-2 fork, not Phase-1 undo — use
+        ``checkout``).
+        """
+        if self._state_log is None:
+            raise RuntimeError("rewind_to requires a state log")
+        if not is_active_seq(self._state_log, target_n):
+            raise RewindIntoAbandonedError(
+                f"rewind target seq {target_n} is on an abandoned branch — "
+                "Phase-1 undo only rewinds to a seq on the active timeline "
+                "(use checkout for a Phase-2 branch-switch)."
+            )
+        return await self.checkout(target_n)
 
     def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
         """Enumerate rewind targets for the time-travel UI (1f / Phase-2 fork).

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -129,9 +129,15 @@ def _abandoned_intervals(rewinds: list[tuple[int, int]]) -> list[tuple[int, int]
 
     Resolved **latest-first** (descending by R): a rewind ``(R, N)`` abandons
     ``(N, R)`` *unless* ``R`` itself is already abandoned by a later rewind — i.e.
-    the rewind sits on an already-abandoned branch, so its undo is moot. With the
-    Phase-1 active-target guard, each rewind targets a then-active seq, so the
-    composition is well-defined (subsuming and partial nesting both fall out).
+    the record sits on an already-abandoned branch, so it is moot (subsumed).
+
+    The composition is well-defined for **both** Phase-1 undo (active target) and
+    Phase-2 ``checkout`` (target on a dead branch — guard lifted): ``N < R`` always
+    holds (the target is a real prior seq), so no degenerate interval; a later
+    record subsumes an intervening one when its ``R`` falls inside the new
+    interval, and an older abandonment *resurrects* when the subsuming record is
+    itself later abandoned (the checkout-back case). Subsuming and partial nesting
+    both fall out of the single latest-first pass.
     """
     abandoned: list[tuple[int, int]] = []
 
@@ -248,19 +254,38 @@ def list_branches(state_log: StateLog) -> list[Branch]:
     return out
 
 
+async def checkout(
+    state_log: StateLog, *, target_seq: int, supersedes: int | None = None,
+) -> int:
+    """Append a reset-record to ``target_seq`` UNCONDITIONALLY (Phase-2 D8 fork).
+
+    The unified time-travel primitive: no active-target guard, so it can switch
+    the active cut to a seq on a *dead* branch (branch-switch / fork revival).
+    ``rewind`` is the active-target-guarded special case (Phase-1 undo).
+
+    Append-only: the just-left future is retained as an inactive branch (P6 / WAL
+    stay append-only); ``is_active`` is re-derived from the full reset-record
+    chain, so a single record ``(R, target_seq)`` flips the active lineage via the
+    latest-first ``_abandoned_intervals`` composition — no new persisted field.
+    The reset-record is fsync'd by ``StateLog.append`` *before* any
+    reconstruction — the crash-mid-rewind idempotence keystone.
+
+    ``supersedes`` is **audit-only** (records the prior active pointer for the
+    branch-tree audit trail); ``is_active`` derivation does not depend on it.
+    """
+    return await state_log.append(
+        REWIND_KIND, target_n=int(target_seq), supersedes=supersedes,
+    )
+
+
 async def rewind(
     state_log: StateLog, *, target_n: int, supersedes: int | None = None,
 ) -> int:
-    """Append a rewind reset-record after validating ``target_n`` is active (Phase 1).
+    """Phase-1 undo: ``checkout`` guarded to an **active** target.
 
-    Append-only: the abandoned future is retained as an inactive branch (P6 /
-    WAL stay append-only); reconstruction honors the active pointer. The
-    reset-record is fsync'd by ``StateLog.append`` *before* any reconstruction —
-    the crash-mid-rewind idempotence keystone.
-
-    ``supersedes`` is **audit-only** (records the prior active pointer for the
-    branch-tree audit trail); ``is_active`` derivation walks all rewind records and
-    does not depend on it.
+    Validates ``target_n`` is on the active branch, then delegates to
+    ``checkout``. The guard lives here (not in ``checkout``) — Phase-1 undo only
+    rewinds along the live timeline; Phase-2 ``checkout`` lifts it.
 
     Raises ``RewindIntoAbandonedError`` when ``target_n`` is on an abandoned branch.
     """
@@ -269,11 +294,9 @@ async def rewind(
         raise RewindIntoAbandonedError(
             f"rewind target seq {target_n} is on an abandoned branch — switching "
             "to an abandoned branch is a Phase-2 fork, not supported by Phase-1 "
-            "undo. Rewind only to a seq on the active timeline."
+            "undo (use checkout). Rewind only to a seq on the active timeline."
         )
-    return await state_log.append(
-        REWIND_KIND, target_n=int(target_n), supersedes=supersedes,
-    )
+    return await checkout(state_log, target_seq=target_n, supersedes=supersedes)
 
 
 def reconstruct(

--- a/tests/test_registry_checkout_2a2.py
+++ b/tests/test_registry_checkout_2a2.py
@@ -1,0 +1,182 @@
+"""Tier 2: OS invariant — AgentRegistry.checkout(seq) unified time-travel primitive.
+
+ADR-0038 D8 Phase-2 fork (#1533 2a-2). `checkout(seq)` generalises `rewind_to`:
+it jumps the global consistent-cut to ANY seq — including one on an abandoned
+(dead) branch (branch-switch / fork revival) — whereas Phase-1 `rewind_to` only
+undoes to an active-branch seq. `rewind_to` is now the active-node special case
+(a thin wrapper that keeps the `RewindIntoAbandonedError` guard, then delegates).
+
+The load-bearing case is the full-path round-trip (abandoned → checkout →
+continue → checkout-back) exercised through the REAL registry: reconstruct +
+workspace restore + session re-adopt. It proves the elegant property verified at
+the interval layer — because `reconstruct` / `_materialize_rewind` /
+`_restore_workspace_active` all recompute `is_active` from the full reset-record
+chain, a single guard-lifted reset-record expresses branch-switch with no new
+persisted field, and both substrates follow the *target's* lineage.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import RewindIntoAbandonedError, rewind
+from reyn.events.state_log import StateLog
+
+_needs_git = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user", payload={"text": text},
+    )
+
+
+def _snap_path(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name / "state" / "snapshot.json"
+
+
+def _inbox_ids(tmp_path: Path, name: str) -> list[str]:
+    return [m["id"] for m in AgentSnapshot.load(name, _snap_path(tmp_path, name)).inbox]
+
+
+# ── load-bearing: full-path branch-switch round-trip (runtime substrate) ───────
+
+
+@pytest.mark.asyncio
+async def test_checkout_back_revives_lineage_runtime(tmp_path):
+    """Tier 2: abandoned→checkout→continue→checkout-back drives the runtime substrate.
+
+    The load-bearing N-way lineage case through the REAL registry (reconstruct +
+    snapshot persist + on-disk state). Both checkout targets are on a DEAD branch
+    (the lifted guard), and the inbox reconstructs along the TARGET's lineage each
+    time — never the prior active one. Pure runtime (no git) so the lineage
+    assertion stands without a workspace dependency.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    await _put(log, "alpha", "a1")          # seq 1
+    await _put(log, "alpha", "a2")          # seq 2
+    await reg.rewind_to(1)                   # seq 3 = R1 — undo, abandons {2}
+    await _put(log, "alpha", "a3")          # seq 4 (active continuation)
+    assert _inbox_ids(tmp_path, "alpha") == ["a1"]   # post-rewind active = [a1] (a3 not yet materialised on disk)
+
+    # checkout to seq 2 (ABANDONED — a2's dead branch): revives a2, abandons a3.
+    res2 = await reg.checkout(2)
+    assert res2["target_n"] == 2
+    assert _inbox_ids(tmp_path, "alpha") == ["a1", "a2"]   # target lineage, NOT [a1,a3]
+    # self-contained snapshot pinned to the new reset-record (same invariant as rewind).
+    assert AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha")).applied_seq == res2["reset_seq"]
+
+    # checkout BACK to seq 4 (now abandoned — a3's lineage): revives a3, re-abandons a2.
+    res4 = await reg.checkout(4)
+    assert res4["target_n"] == 4
+    assert _inbox_ids(tmp_path, "alpha") == ["a1", "a3"]   # lineage swapped back, no a2 leakage
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_checkout_back_revives_lineage_two_substrate(tmp_path):
+    """Tier 2: the SAME round-trip drives BOTH substrates (workspace + runtime).
+
+    Workspace (real shadow-git) and runtime snapshot both follow the target
+    branch on each checkout — `_restore_workspace_active` honours the recomputed
+    `is_active`, so the file content tracks the revived lineage (v2 then v3),
+    never the just-left active one.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    ws = reg.workspace_store
+    code = tmp_path / "code.py"
+
+    code.write_text("v1", encoding="utf-8")
+    await _put(log, "alpha", "a1")          # seq 1
+    await ws.capture(1)
+    code.write_text("v2", encoding="utf-8")
+    await _put(log, "alpha", "a2")          # seq 2
+    await ws.capture(2)
+
+    await reg.rewind_to(1)                    # seq 3 — undo to v1 / [a1]
+    assert code.read_text(encoding="utf-8") == "v1"
+
+    code.write_text("v3", encoding="utf-8")
+    await _put(log, "alpha", "a3")          # seq 4
+    await ws.capture(4)                       # active continuation = v3 / [a1,a3]
+
+    # checkout to the abandoned a2 lineage → workspace v2, inbox [a1,a2].
+    await reg.checkout(2)
+    assert code.read_text(encoding="utf-8") == "v2"
+    assert _inbox_ids(tmp_path, "alpha") == ["a1", "a2"]
+
+    # checkout back to the (now abandoned) a3 lineage → workspace v3, inbox [a1,a3].
+    await reg.checkout(4)
+    assert code.read_text(encoding="utf-8") == "v3"
+    assert _inbox_ids(tmp_path, "alpha") == ["a1", "a3"]
+
+
+# ── rewind_to = active-node special case (equivalence + preserved guard) ───────
+
+
+@pytest.mark.asyncio
+async def test_checkout_to_active_seq_equals_rewind_to(tmp_path):
+    """Tier 2: checkout(active_seq) == rewind_to(active_seq) (the undo special case).
+
+    With no abandoned branch, checkout to an active seq is exactly an undo — same
+    consistent-cut, same self-contained snapshot, same surviving inbox.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")          # seq 1
+    await _put(log, "alpha", "a2")          # seq 2
+
+    res = await reg.checkout(1)               # active target → undo semantics
+    assert res["target_n"] == 1
+    assert _inbox_ids(tmp_path, "alpha") == ["a1"]   # a2 abandoned, as rewind_to(1) would
+    assert AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha")).applied_seq == res["reset_seq"]
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_still_rejects_abandoned_after_refactor(tmp_path):
+    """Tier 2: rewind_to wrapper preserves the Phase-1 abandoned-target guard.
+
+    Refactoring rewind_to into a thin wrapper over checkout must NOT drop its
+    guard — Phase-1 undo still rejects an abandoned target (only the unified
+    checkout lifts it). Regression lock on the wrapper.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a")           # seq 1
+    await _put(log, "alpha", "b")           # seq 2
+    await rewind(log, target_n=1)            # seq 3 — abandons seq 2
+
+    with pytest.raises(RewindIntoAbandonedError):
+        await reg.rewind_to(2)               # abandoned target — undo still rejects
+
+    # but checkout to the same abandoned seq is ALLOWED (the lifted guard).
+    res = await reg.checkout(2)
+    assert res["target_n"] == 2
+    assert _inbox_ids(tmp_path, "alpha") == ["a", "b"]   # a2 lineage revived


### PR DESCRIPTION
**[dogfood-coder]** — #1533 Phase-2 substrate 2a-2 (ADR-0038 D8 fork), off merged main (#1558 base). Load-bearing test written **first** (TDD), then impl. Opening for deep review per the agreed flow.

## What

`checkout(seq)` is the unified time-travel primitive: jump the global consistent-cut to **any** seq — active-branch (= undo) or a **dead branch** (= branch-switch / fork revival). `rewind_to` becomes the active-node special case: a thin wrapper that keeps the `RewindIntoAbandonedError` guard, then delegates.

**Substrate** (`snapshot_generations.py`):
- `checkout(state_log, *, target_seq, supersedes=None)` — appends a reset-record **unconditionally** (no active-target guard).
- `rewind(...)` → guarded special case (validate active → delegate to `checkout`); same parallel structure as the registry layer.
- `_abandoned_intervals` docstring updated for the guard-lifted composition.

**Registry** (`registry.py`):
- `checkout(seq)` = the `rewind_to` body **minus** the active-target guard (retention guard + all-cancel/quiesce + single reset-record + `_materialize_rewind` all kept).
- `rewind_to(target_n)` = thin Phase-1 wrapper (`is_active_seq` guard → `checkout`).

## Why no new field / no lineage-walk (verified, corrected my own draft)

I'd drafted 2a-2 assuming checkout-to-a-fork needs new lineage-aware reconstruction. **Verified wrong** on a real StateLog: `reconstruct` / `_materialize_rewind` / `_restore_workspace_active` all recompute `is_active` from the full reset-record chain, so a single guard-lifted record `(R, seq)` flips the active lineage via the latest-first `_abandoned_intervals` composition — and both substrates follow the target lineage automatically. `N < R` always (target is a real prior seq) → no degenerate interval; checkout-back resurrects the older abandonment. The earlier interval-layer caveat is now **closed by the real-instance integration tests** below.

## Test plan

`tests/test_registry_checkout_2a2.py` (Tier 2, real-instance, no mocks):

- [x] `test_checkout_back_revives_lineage_runtime` — **load-bearing** full-path round-trip (abandoned→checkout→continue→checkout-back) through the REAL registry (reconstruct + snapshot persist); inbox lineage swaps with no leakage
- [x] `test_checkout_back_revives_lineage_two_substrate` — SAME round-trip on BOTH substrates (real shadow-git): workspace file (v2→v3) + inbox both follow the target branch
- [x] `test_checkout_to_active_seq_equals_rewind_to` — undo equivalence
- [x] `test_rewind_to_still_rejects_abandoned_after_refactor` — wrapper preserves the guard; checkout allows the same abandoned target
- [x] `python -m pytest tests/test_registry_checkout_2a2.py -W error::RuntimeWarning` → 4 passed
- [x] tier-audit clean; ruff clean
- [x] 514 adjacent rewind/snapshot/branch/registry/checkout tests pass

Unblocks: 2a-3 (act-turn runtime-only + deferral sub-issue); e2e's 2b checkout dispatcher consumes `reg.checkout(seq)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)