### PR TITLE
feat(1533/2b): fork picker — always-tree + unified checkout

### DIFF
--- a/src/reyn/chat/slash/rewind.py
+++ b/src/reyn/chat/slash/rewind.py
@@ -44,7 +44,11 @@ async def rewind_cmd(session: "object", args: str) -> None:
         return
 
     try:
-        result = await registry.rewind_to(target)
+        # Unified checkout (ADR-0038 D8): the same op the picker dispatches —
+        # undo for a live-branch seq, fork-switch for a dead-branch seq. Keeps
+        # the two "go to seq N" entries (slash + picker) behaviourally identical
+        # (no sibling-gap); checkout subsumes rewind_to for active seqs.
+        result = await registry.checkout(target)
     except Exception as exc:  # noqa: BLE001 — surface the reason to the user
         await reply_error(session, f"/rewind: {exc}")
         return
@@ -52,7 +56,7 @@ async def rewind_cmd(session: "object", args: str) -> None:
     agents = result.get("agents", [])
     await reply(
         session,
-        f"⏪ rewound to seq {result.get('target_n', target)} "
+        f"⏪ checked out to seq {result.get('target_n', target)} "
         f"· {len(agents)} agent(s) reset · in-flight cancelled",
     )
 

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2454,26 +2454,48 @@ class ReynTUIApp(App):
                 pass
 
     def _open_rewind_menu(self) -> None:
-        """Open the inline /rewind checkpoint picker.
+        """Open the inline /rewind fork picker (ADR-0038 2b, always-tree).
 
-        Reads ``AgentRegistry.list_rewind_points()`` and mounts the menu. When
-        there are no checkpoints (or no registry), writes a system message
-        instead of mounting an empty picker.
+        Builds the branch tree from ``list_branches()`` + the lineage-tagged
+        ``list_rewind_points(include_abandoned=True)`` and mounts it. When there
+        are no checkpoints (or no registry), writes a system message instead of
+        mounting an empty picker.
         """
         try:
             conv = self.query_one("#conversation", ConversationView)
         except Exception:
             return
-        registry = self._agent_registry
-        points = registry.list_rewind_points() if registry is not None else []
-        if not points:
+        rows = self._build_rewind_tree_rows()
+        if not rows:
             conv.render_message(
                 OutboxMessage(kind="system", text="⏪ no checkpoints to rewind to yet")
             )
             return
         # Replace any already-open menu (idempotent re-open).
         self._dismiss_rewind_menu()
-        self._rewind_menu = conv.mount_rewind_menu(points)
+        self._rewind_menu = conv.mount_rewind_menu(tree_rows=rows)
+
+    def _build_rewind_tree_rows(self) -> list[dict]:
+        """Branch-tree rows for the fork picker, or [] when unavailable.
+
+        Converts the ``Branch`` dataclasses to dicts and groups the
+        lineage-tagged checkpoints by ``branch_id`` (the substrate already did
+        the lineage-correct membership — 2a). Best-effort: any registry error
+        yields [] so the picker degrades to the "no checkpoints" notice rather
+        than crashing the TUI.
+        """
+        import dataclasses
+
+        from .widgets._branch_tree import build_branch_tree_rows
+        registry = self._agent_registry
+        if registry is None:
+            return []
+        try:
+            branches = [dataclasses.asdict(b) for b in registry.list_branches()]
+            checkpoints = registry.list_rewind_points(include_abandoned=True)
+        except Exception:
+            return []
+        return build_branch_tree_rows(branches, checkpoints)
 
     def action_rewind_prev(self) -> None:
         """↑ while the rewind menu is open — highlight the previous (older) checkpoint."""
@@ -2486,17 +2508,27 @@ class ReynTUIApp(App):
             self._rewind_menu.move_selection(+1)
 
     async def action_rewind_confirm(self) -> None:
-        """Enter while the rewind menu is open — rewind to the highlighted checkpoint."""
+        """Enter while the picker is open — checkout the highlighted checkpoint.
+
+        Unified checkout (ADR-0038 D8): the same op whether the node is on the
+        live branch (= undo) or a dead branch (= fork-switch) — the user just
+        "goes to this checkpoint".
+        """
         menu = self._rewind_menu
         if menu is None:
             return
         point = menu.selected_point()
         self._dismiss_rewind_menu()
         if point is not None:
-            await self._do_rewind(int(point["seq"]))
+            await self._do_checkout(int(point["seq"]))
 
-    async def _do_rewind(self, target_seq: int) -> None:
-        """Invoke ``AgentRegistry.rewind_to`` and write a timeline breadcrumb."""
+    async def _do_checkout(self, target_seq: int) -> None:
+        """Invoke ``AgentRegistry.checkout(seq)`` and write a timeline breadcrumb.
+
+        ``checkout`` is the unified time-travel primitive (active-seq = undo,
+        dead-branch seq = fork-switch); the guard-lifted reset-record moves both
+        substrates to the target's lineage.
+        """
         try:
             conv = self.query_one("#conversation", ConversationView)
         except Exception:
@@ -2505,21 +2537,21 @@ class ReynTUIApp(App):
         if registry is None:
             if conv is not None:
                 conv.render_message(
-                    OutboxMessage(kind="error", text="⏪ rewind unavailable (no registry)")
+                    OutboxMessage(kind="error", text="⏪ checkout unavailable (no registry)")
                 )
             return
         try:
-            result = await registry.rewind_to(target_seq)
+            result = await registry.checkout(target_seq)
         except Exception as exc:  # noqa: BLE001 — surface the reason in-timeline
             if conv is not None:
-                conv.render_message(OutboxMessage(kind="error", text=f"⏪ rewind failed: {exc}"))
+                conv.render_message(OutboxMessage(kind="error", text=f"⏪ checkout failed: {exc}"))
             return
         if conv is not None:
             agents = result.get("agents", [])
             conv.render_message(OutboxMessage(
                 kind="system",
                 text=(
-                    f"⏪ rewound to seq {result.get('target_n', target_seq)} "
+                    f"⏪ checked out to seq {result.get('target_n', target_seq)} "
                     f"· {len(agents)} agent(s) reset · in-flight cancelled"
                 ),
             ))

--- a/src/reyn/chat/tui/widgets/_branch_tree.py
+++ b/src/reyn/chat/tui/widgets/_branch_tree.py
@@ -1,0 +1,133 @@
+"""Pure branch-tree layout for the Phase-2 fork picker (ADR-0038 2b).
+
+Turns the 2a substrate contract — `list_branches()` (tree topology) +
+`list_rewind_points(include_abandoned=True)` (checkpoints, each carrying its
+lineage-correct `branch_id`) — into a flat, ordered list of renderable rows for
+`RewindMenuWidget`'s tree mode.
+
+**Why `branch_id` per checkpoint (not range-intersection):** a naive
+`[fork_point_seq, head_seq] ∩ checkpoints` over-includes, because an active
+parent's seq-range physically *contains* an abandoned child's seqs (e.g. after
+rewind-to-6-then-continue, the active range `[0,13]` spans the abandoned
+segment `(6,11)`). Lineage-correct membership needs the substrate's
+segment-ownership map, so 2a stamps each checkpoint with its owning `branch_id`
+and 2b simply groups by it — no overlap bug. (Gap found build-first, 2025-06;
+contract refined with sandbox_2.)
+
+Pure functions only — no Textual / no I/O — so the layout is unit-testable
+against synthetic contract-shape data without a running app or the live 2a
+primitive.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+# Row "kind" tags. Header rows are decorators (NOT cursor-selectable); only
+# checkpoint rows are selectable, and Enter on one dispatches checkout(seq)
+# (tui-coder converged: every selectable row is a seq row, one Enter semantic).
+ROW_HEADER = "header"
+ROW_CHECKPOINT = "checkpoint"
+
+
+def _branch_label(branch: dict, anchor_by_seq: dict[int, str]) -> str:
+    """Human label for a branch header.
+
+    Root (no fork point) → "main". A fork → ``fork @ #<seq>`` plus the #1547
+    anchor (last-user-message preview) at the fork point, when available — e.g.
+    ``fork @ #30  "run the tests"``.
+    """
+    fork_seq = branch.get("fork_point_seq")
+    if not fork_seq or branch.get("parent_branch_id") is None:
+        return "main"
+    anchor = anchor_by_seq.get(fork_seq, "")
+    base = f"fork @ #{fork_seq}"
+    return f'{base}  "{anchor}"' if anchor else base
+
+
+def build_branch_tree_rows(
+    branches: list[dict],
+    checkpoints: list[dict],
+) -> list[dict]:
+    """Flatten the branch tree into ordered renderable rows.
+
+    Args:
+        branches: ``list_branches()`` rows —
+            ``{branch_id, fork_point_seq, head_seq, parent_branch_id, is_active}``.
+        checkpoints: ``list_rewind_points(include_abandoned=True)`` rows —
+            ``{seq, ts, kind, anchor, branch_id}``. ``branch_id`` is the
+            **lineage-correct** owning branch (substrate-computed).
+
+    Returns a flat list, DFS from the root branch, **active-first among
+    siblings**; each branch emits a header (decorator) followed by its
+    checkpoint rows (newest seq first). Row shapes::
+
+        {"row": "header", "branch_id", "label", "head_seq", "is_active", "depth"}
+        {"row": "checkpoint", "seq", "ts", "kind", "anchor", "branch_id", "depth"}
+    """
+    # Lineage-correct grouping: trust the substrate's per-checkpoint branch_id.
+    cps_by_branch: dict[object, list[dict]] = defaultdict(list)
+    for cp in checkpoints:
+        cps_by_branch[cp.get("branch_id")].append(cp)
+    anchor_by_seq = {
+        cp["seq"]: cp.get("anchor", "") for cp in checkpoints if "seq" in cp
+    }
+
+    by_id = {b["branch_id"]: b for b in branches}
+    children: dict[object, list[dict]] = defaultdict(list)
+    roots: list[dict] = []
+    for b in branches:
+        parent = b.get("parent_branch_id")
+        if parent is None or parent not in by_id:
+            roots.append(b)
+        else:
+            children[parent].append(b)
+
+    def _sibling_key(b: dict) -> tuple:
+        # Active branch first; then by fork point (older fork higher).
+        return (0 if b.get("is_active") else 1, b.get("fork_point_seq") or 0)
+
+    rows: list[dict] = []
+
+    def _emit(branch: dict, depth: int) -> None:
+        rows.append({
+            "row": ROW_HEADER,
+            "branch_id": branch["branch_id"],
+            "label": _branch_label(branch, anchor_by_seq),
+            "head_seq": branch.get("head_seq"),
+            "is_active": bool(branch.get("is_active")),
+            "depth": depth,
+        })
+        for cp in sorted(
+            cps_by_branch.get(branch["branch_id"], []),
+            key=lambda c: c.get("seq", 0),
+            reverse=True,
+        ):
+            rows.append({
+                "row": ROW_CHECKPOINT,
+                "seq": cp.get("seq"),
+                "ts": cp.get("ts", ""),
+                "kind": cp.get("kind", ""),
+                "anchor": cp.get("anchor", ""),
+                "branch_id": branch["branch_id"],
+                "depth": depth + 1,
+            })
+        for child in sorted(children.get(branch["branch_id"], []), key=_sibling_key):
+            _emit(child, depth + 1)
+
+    for root in sorted(roots, key=_sibling_key):
+        _emit(root, 0)
+    return rows
+
+
+def selectable_rows(rows: list[dict]) -> list[dict]:
+    """Checkpoint rows only — headers are non-selectable decorators (Enter on a
+    checkpoint = checkout(seq); the cursor never lands on a header)."""
+    return [r for r in rows if r.get("row") == ROW_CHECKPOINT]
+
+
+__all__ = [
+    "ROW_HEADER",
+    "ROW_CHECKPOINT",
+    "build_branch_tree_rows",
+    "selectable_rows",
+]

--- a/src/reyn/chat/tui/widgets/conversation.py
+++ b/src/reyn/chat/tui/widgets/conversation.py
@@ -2267,17 +2267,20 @@ class ConversationView(Widget):
 
     def mount_rewind_menu(
         self,
-        points: list[dict],
+        points: list[dict] | None = None,
         *,
+        tree_rows: list[dict] | None = None,
         rel_time_fn=None,
     ) -> "RewindMenuWidget":
-        """Mount the inline time-travel checkpoint picker (ADR-0038 1f).
+        """Mount the inline time-travel checkpoint picker.
 
-        ``points`` are rows from ``AgentRegistry.list_rewind_points()``. The
-        widget is passive (``can_focus = False``) — the App drives navigation
-        and removes it via ``widget.remove()`` on selection / Esc (decoupled
-        from the intervention unmount path). Returns the mounted widget so the
-        App can hold a reference for nav + dismiss.
+        ``tree_rows`` (Phase-2 fork picker, always-tree) are rows from
+        ``build_branch_tree_rows``; ``points`` (Phase-1 flat timeline) are rows
+        from ``AgentRegistry.list_rewind_points()``. Exactly one is supplied.
+        The widget is passive (``can_focus = False``) — the App drives
+        navigation and removes it via ``widget.remove()`` on selection / Esc
+        (decoupled from the intervention unmount path). Returns the mounted
+        widget so the App can hold a reference for nav + dismiss.
         """
         from .rewind_menu import RewindMenuWidget
         self._consume_empty_hint()
@@ -2290,7 +2293,10 @@ class ConversationView(Widget):
             self.show_status("⏪ rewind menu below ↓", kind="general")
         else:
             self.hide_status()
-        widget = RewindMenuWidget(points, rel_time_fn=rel_time_fn)
+        if tree_rows is not None:
+            widget = RewindMenuWidget.from_tree_rows(tree_rows, rel_time_fn=rel_time_fn)
+        else:
+            widget = RewindMenuWidget(points or [], rel_time_fn=rel_time_fn)
         self.mount(widget)
         if not self._scroll_ctrl.user_scrolled:
             try:

--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -34,6 +34,7 @@ from reyn.chat.tui._palette import (
     _TEXT_DIM,
     _TEXT_MUTED,
 )
+from reyn.chat.tui.widgets._branch_tree import ROW_CHECKPOINT, ROW_HEADER
 
 # Max checkpoint rows rendered at once (mirrors SlashPicker._MAX_VISIBLE). The
 # window slides to keep the selected row visible when the list is longer.
@@ -99,37 +100,73 @@ class RewindMenuWidget(Widget):
 
     def __init__(
         self,
-        points: list[dict],
+        points: list[dict] | None = None,
         *,
         rel_time_fn=None,
         id: str | None = None,
+        _tree_rows: list[dict] | None = None,
     ) -> None:
         super().__init__(id=id)
-        self._points = list(points)
         self._rel_time_fn = rel_time_fn or format_rel_time
-        # Default selection = the most-recent checkpoint (bottom). The user
-        # rewinds *backward*, so they navigate up from "now".
-        self._selected = max(0, len(self._points) - 1)
+        if _tree_rows is not None:
+            # Tree mode (Phase-2 fork picker): rows from build_branch_tree_rows
+            # — header decorators (non-selectable) interleaved with selectable
+            # checkpoint rows. Selection indexes the selectable subset.
+            self._mode = "tree"
+            self._rows = list(_tree_rows)
+            self._selectable = [
+                i for i, r in enumerate(self._rows) if r.get("row") == ROW_CHECKPOINT
+            ]
+            self._points = []
+            # Default = the working-tree head: the first selectable row, which
+            # (active-first, newest-first ordering) is the active branch's newest
+            # checkpoint → Enter immediately = undo (Phase-1 parity).
+            self._selected = 0
+        else:
+            # Flat mode (Phase-1 /rewind timeline).
+            self._mode = "flat"
+            self._points = list(points or [])
+            self._rows = []
+            self._selectable = []
+            # Default selection = the most-recent checkpoint (bottom).
+            self._selected = max(0, len(self._points) - 1)
+
+    @classmethod
+    def from_tree_rows(
+        cls,
+        rows: list[dict],
+        *,
+        rel_time_fn=None,
+        id: str | None = None,
+    ) -> "RewindMenuWidget":
+        """Construct the Phase-2 fork picker over branch-tree rows (always-tree)."""
+        return cls(rel_time_fn=rel_time_fn, id=id, _tree_rows=rows)
 
     # ── selection (app-driven nav) ────────────────────────────────────────────
 
     @property
     def selected_index(self) -> int:
+        """0-based index of the current selection within the selectable rows."""
         return self._selected
 
     def move_selection(self, delta: int) -> None:
-        """Move the highlight by ``delta`` rows, clamped to the list bounds.
+        """Move the highlight by ``delta`` *selectable* rows, clamped.
 
-        Clamp (not wrap): the timeline is finite and ordered, so wrapping from
-        oldest to newest would be disorienting.
+        Clamp (not wrap): the timeline is finite and ordered. In tree mode the
+        cursor moves among checkpoint rows only — header rows are skipped.
         """
-        if not self._points:
+        n = len(self._selectable) if self._mode == "tree" else len(self._points)
+        if n == 0:
             return
-        self._selected = max(0, min(len(self._points) - 1, self._selected + delta))
+        self._selected = max(0, min(n - 1, self._selected + delta))
         self.refresh()
 
     def selected_point(self) -> dict | None:
         """The currently highlighted checkpoint row, or None when empty."""
+        if self._mode == "tree":
+            if not self._selectable:
+                return None
+            return self._rows[self._selectable[self._selected]]
         if not self._points:
             return None
         return self._points[self._selected]
@@ -147,7 +184,59 @@ class RewindMenuWidget(Widget):
         start = max(0, min(self._selected - half, n - _MAX_VISIBLE))
         return start, start + _MAX_VISIBLE
 
+    def _render_tree(self) -> Text:
+        """Render the branch-tree fork picker (Phase-2 2b, always-tree).
+
+        Header rows are dim/bright decorators (active vs inactive branch); the
+        ▌ caret sits only on the selected checkpoint row. Indent = depth. The
+        `▸` marks the working-tree head's branch.
+        """
+        body = Text()
+        body.append(
+            "  ⏪ checkout a checkpoint   (Enter = go here · Esc cancel)\n",
+            style=f"bold {_CORAL}",
+        )
+        if not self._rows:
+            body.append("  (no checkpoints yet)\n", style=f"dim {_TEXT_DIM}")
+            return body
+
+        sel_abs = self._selectable[self._selected] if self._selectable else -1
+        for i, r in enumerate(self._rows):
+            indent = "  " * (r.get("depth", 0) + 1)
+            if r.get("row") == ROW_HEADER:
+                active = r.get("is_active")
+                glyph = "● " if active else "◌ "
+                mark = "▸ " if active else "  "
+                style = _TEXT_BRIGHT if active else f"dim {_TEXT_DIM}"
+                tag = "active" if active else "inactive"
+                line = Text()
+                line.append(f"{mark}{indent}{glyph}{r.get('label', '')}", style=style)
+                line.append(f"   {tag}\n", style=f"dim {_TEXT_DIM}")
+                body.append_text(line)
+                continue
+            # checkpoint (selectable) row
+            is_sel = i == sel_abs
+            line = Text()
+            line.append("▌ " if is_sel else "  ", style=_CORAL if is_sel else _BG_HEADER)
+            line.append(indent)
+            line.append(
+                f"#{r.get('seq')}", style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT,
+            )
+            kind = _KIND_LABEL.get(r.get("kind", ""), r.get("kind", ""))
+            line.append(f"  {kind.ljust(10)}", style=_TEXT_MUTED)
+            rel = self._rel_time_fn(r.get("ts", ""))
+            if rel:
+                line.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
+            line.append("\n")
+            body.append_text(line)
+        body.append(
+            "  ↑/↓ select · Enter checkout · Esc cancel\n", style=f"dim {_TEXT_DIM}",
+        )
+        return body
+
     def render(self) -> Text:
+        if self._mode == "tree":
+            return self._render_tree()
         body = Text()
         body.append("  ⏪ rewind — pick a checkpoint\n", style=f"bold {_CORAL}")
 

--- a/tests/cli/test_rewind_checkout_integration_2b.py
+++ b/tests/cli/test_rewind_checkout_integration_2b.py
@@ -1,0 +1,95 @@
+"""Tier 2: 2b fork-picker integration — real registry → tree → checkout.
+
+The #1556-lesson guard: the registry=None path is covered elsewhere, but the
+construction-forwarding risk (a runtime error when the checkout dispatch meets a
+*real* registry) is only caught by driving the live methods against a real
+``AgentRegistry``. This exercises the full data path:
+
+    list_branches() + list_rewind_points(include_abandoned=True)
+        → build_branch_tree_rows  (app._build_rewind_tree_rows)
+    Enter → registry.checkout(seq)  (app._do_checkout)
+
+with a real fork (active + dead branch) on the WAL. No DOM mount needed — the
+data path is what the integration risk lives in; the render is covered by the
+tree-mode run_test tests.
+
+Real AgentRegistry + StateLog + ReynTUIApp — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets._branch_tree import ROW_HEADER
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+async def _make_forked_registry(tmp_path: Path) -> AgentRegistry:
+    """Real registry with an active branch + one dead (rewound-past) branch."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    log = reg.state_log
+
+    def _gen(name: str, seq: int) -> None:
+        snap = AgentSnapshot.empty(name)
+        snap.applied_seq = seq
+        reg._store_for(name).record(snap)
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")
+    for s in (s1, s2):
+        _gen("alpha", s)
+    # Checkout back to s1 → abandons (s1, R): s2 becomes a dead branch.
+    await reg.checkout(s1)
+    s3 = await log.append("inbox_consume", target="alpha", msg_id="m3")
+    _gen("alpha", s3)
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_build_rewind_tree_rows_real_registry_has_both_branches(tmp_path) -> None:
+    """Tier 2: the live data path (list_branches + list_rewind_points(
+    include_abandoned) → build_branch_tree_rows) yields a tree with the active
+    AND the dead branch — no construction-forwarding error against a real
+    registry."""
+    reg = await _make_forked_registry(tmp_path)
+    app = ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+
+    rows = app._build_rewind_tree_rows()
+    headers = [r for r in rows if r.get("row") == ROW_HEADER]
+    actives = [h for h in headers if h["is_active"]]
+    deads = [h for h in headers if not h["is_active"]]
+    assert actives, "active branch header missing"
+    assert deads, "dead (rewound-past) branch header missing — fork not surfaced"
+
+
+@pytest.mark.asyncio
+async def test_do_checkout_invokes_registry_checkout(tmp_path) -> None:
+    """Tier 2: the Enter dispatch (_do_checkout) actually runs registry.checkout
+    against a real registry — the WAL grows a reset-record (proof the unified
+    checkout primitive was driven, not rewind_to)."""
+    reg = await _make_forked_registry(tmp_path)
+    app = ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+    head_before = reg.state_log.current_seq
+
+    # Checkout to seq 1 (an active-branch node → undo flavour) via the dispatch.
+    await app._do_checkout(1)
+
+    assert reg.state_log.current_seq > head_before  # a reset-record was appended

--- a/tests/cli/test_rewind_menu_tree_2b.py
+++ b/tests/cli/test_rewind_menu_tree_2b.py
@@ -1,0 +1,97 @@
+"""Tier 2: RewindMenuWidget tree mode — Phase-2 fork picker render/nav (2b).
+
+The widget gains an always-tree mode (`from_tree_rows`) consuming
+`build_branch_tree_rows` output: header rows are non-selectable decorators, the
+cursor moves among checkpoint rows only. Pins selection-skips-headers + the
+default = working-tree head + the tree render, via run_test real-DOM (mount-path
+render is headless-testable; the key-driven flow is tui-coder's tmux scope).
+
+Real RewindMenuWidget + real ConversationView mount — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets._branch_tree import build_branch_tree_rows
+from reyn.chat.tui.widgets.rewind_menu import RewindMenuWidget
+
+
+def _rows_two_branches() -> list[dict]:
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 13, "parent_branch_id": None, "is_active": True},
+        {"branch_id": 11, "fork_point_seq": 6, "head_seq": 10, "parent_branch_id": 0, "is_active": False},
+    ]
+    checkpoints = [
+        {"seq": 3, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0},
+        {"seq": 6, "ts": "", "kind": "phase", "anchor": "run tests", "branch_id": 0},
+        {"seq": 12, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0},
+        {"seq": 9, "ts": "", "kind": "turn", "anchor": "", "branch_id": 11},
+    ]
+    return build_branch_tree_rows(branches, checkpoints)
+
+
+def test_default_selection_is_working_tree_head() -> None:
+    """Tier 2: tree-mode default selection = first selectable = active newest
+    (working-tree head), so Enter is immediately undo (Phase-1 parity)."""
+    w = RewindMenuWidget.from_tree_rows(_rows_two_branches())
+    pt = w.selected_point()
+    assert pt is not None and pt["row"] == "checkpoint"
+    assert pt["branch_id"] == 0   # the active branch
+    assert pt["seq"] == 12        # active branch's newest checkpoint
+
+
+def test_nav_skips_headers_visits_all_checkpoints() -> None:
+    """Tier 2: ↑/↓ moves among checkpoint rows only (headers skipped); every
+    checkpoint across branches is reachable, none lands on a header."""
+    w = RewindMenuWidget.from_tree_rows(_rows_two_branches())
+    seen = set()
+    for _ in range(10):
+        pt = w.selected_point()
+        assert pt["row"] == "checkpoint"   # never a header
+        seen.add(pt["seq"])
+        w.move_selection(1)
+    assert seen == {3, 6, 12, 9}           # all checkpoints reachable
+
+
+def test_selected_point_never_a_header() -> None:
+    """Tier 2: clamping at the ends keeps the selection on checkpoint rows."""
+    w = RewindMenuWidget.from_tree_rows(_rows_two_branches())
+    w.move_selection(-50)
+    assert w.selected_point()["row"] == "checkpoint"
+    w.move_selection(+50)
+    assert w.selected_point()["row"] == "checkpoint"
+
+
+@pytest.mark.asyncio
+async def test_tree_render_shows_branches_and_caret() -> None:
+    """Tier 2: mounted tree render shows both branch headers (active + inactive),
+    the checkpoints, and the caret on the selection. run_test real DOM."""
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True, size=(120, 20)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        w = RewindMenuWidget.from_tree_rows(_rows_two_branches())
+        await conv.mount(w)
+        await pilot.pause()
+        rendered = w.render().plain
+        assert "active" in rendered and "inactive" in rendered   # both branch headers
+        assert "fork @ #6" in rendered                            # inactive fork label
+        assert "#12" in rendered and "#9" in rendered             # checkpoints both branches
+        assert "▌" in rendered                                    # selection caret present
+
+
+def test_empty_tree_safe() -> None:
+    """Tier 2: empty tree rows → no selection, render does not crash."""
+    w = RewindMenuWidget.from_tree_rows([])
+    assert w.selected_point() is None
+    w.move_selection(-1)
+    assert "no checkpoints" in w.render().plain

--- a/tests/test_branch_tree_2b.py
+++ b/tests/test_branch_tree_2b.py
@@ -1,0 +1,107 @@
+"""Tier 2: branch-tree layout for the Phase-2 fork picker (ADR-0038 2b).
+
+Pure layout over the locked 2a contract — `list_branches()` rows + checkpoints
+carrying lineage-correct `branch_id`. The keystone test pins the **build-first
+contract catch**: group-by-`branch_id` correctly separates an abandoned child's
+checkpoint from the active parent, where the earlier `[fork_point, head]`
+range-intersection over-included it.
+
+No mocks, no app — pure functions over synthetic contract-shape data.
+"""
+from __future__ import annotations
+
+from reyn.chat.tui.widgets._branch_tree import (
+    ROW_CHECKPOINT,
+    ROW_HEADER,
+    build_branch_tree_rows,
+    selectable_rows,
+)
+
+
+def _cp(seq: int, branch_id, *, kind: str = "turn", anchor: str = "") -> dict:
+    return {"seq": seq, "ts": f"t{seq}", "kind": kind, "anchor": anchor, "branch_id": branch_id}
+
+
+def test_group_by_branch_id_is_lineage_correct() -> None:
+    """Tier 2: the over-inclusion repro — group-by-branch_id assigns the
+    abandoned checkpoint to the abandoned branch, NOT the active parent whose
+    seq-range physically spans it.
+
+    Scenario: root seqs 1..10 (cp 3,6,9); rewind-to-6 (abandons 7..10);
+    continue 12,13 (cp 12). Active range [0,13] CONTAINS abandoned cp #9, but
+    the substrate stamps #9 with the abandoned branch_id, so it groups there.
+    """
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 13, "parent_branch_id": None, "is_active": True},
+        {"branch_id": 11, "fork_point_seq": 6, "head_seq": 10, "parent_branch_id": 0, "is_active": False},
+    ]
+    checkpoints = [
+        _cp(3, 0), _cp(6, 0), _cp(12, 0),   # active branch (substrate-tagged)
+        _cp(9, 11),                          # abandoned branch
+    ]
+    rows = build_branch_tree_rows(branches, checkpoints)
+
+    active_seqs = {r["seq"] for r in rows if r["row"] == ROW_CHECKPOINT and r["branch_id"] == 0}
+    abandoned_seqs = {r["seq"] for r in rows if r["row"] == ROW_CHECKPOINT and r["branch_id"] == 11}
+    assert active_seqs == {3, 6, 12}      # NOT {3,6,9,12} — #9 is not here
+    assert abandoned_seqs == {9}          # #9 correctly on the abandoned branch
+
+
+def test_headers_are_non_selectable() -> None:
+    """Tier 2: every selectable row is a checkpoint (seq) row; headers are
+    decorators the cursor skips (tui-coder converged invariant)."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 6, "parent_branch_id": None, "is_active": True}]
+    rows = build_branch_tree_rows(branches, [_cp(3, 0), _cp(6, 0)])
+    assert any(r["row"] == ROW_HEADER for r in rows)
+    sel = selectable_rows(rows)
+    assert all(r["row"] == ROW_CHECKPOINT for r in sel)
+    assert {r["seq"] for r in sel} == {3, 6}
+
+
+def test_fork_nested_under_parent_with_depth() -> None:
+    """Tier 2: a fork's header nests below its parent (greater depth)."""
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True},
+        {"branch_id": 5, "fork_point_seq": 3, "head_seq": 7, "parent_branch_id": 0, "is_active": False},
+    ]
+    rows = build_branch_tree_rows(branches, [_cp(6, 0), _cp(5, 5)])
+    root_hdr = next(r for r in rows if r["row"] == ROW_HEADER and r["branch_id"] == 0)
+    fork_hdr = next(r for r in rows if r["row"] == ROW_HEADER and r["branch_id"] == 5)
+    assert fork_hdr["depth"] > root_hdr["depth"]
+
+
+def test_active_branch_first_among_siblings() -> None:
+    """Tier 2: the active branch renders before inactive siblings."""
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 20, "parent_branch_id": None, "is_active": False},
+        {"branch_id": 3, "fork_point_seq": 2, "head_seq": 10, "parent_branch_id": 0, "is_active": True},
+        {"branch_id": 8, "fork_point_seq": 2, "head_seq": 15, "parent_branch_id": 0, "is_active": False},
+    ]
+    rows = build_branch_tree_rows(branches, [_cp(5, 3), _cp(12, 8)])
+    header_ids = [r["branch_id"] for r in rows if r["row"] == ROW_HEADER]
+    # branch 3 (active) before branch 8 (inactive) among the children of root.
+    assert header_ids.index(3) < header_ids.index(8)
+
+
+def test_single_branch_degrades_to_flat() -> None:
+    """Tier 2: with no forks, the tree = one header + its checkpoints (newest
+    first) — visually the Phase-1 flat list."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True}]
+    rows = build_branch_tree_rows(branches, [_cp(3, 0), _cp(6, 0), _cp(9, 0)])
+    assert rows[0]["row"] == ROW_HEADER and rows[0]["label"] == "main"
+    seqs = [r["seq"] for r in rows if r["row"] == ROW_CHECKPOINT]
+    assert seqs == [9, 6, 3]   # newest first
+
+
+def test_fork_label_uses_anchor_at_fork_point() -> None:
+    """Tier 2: a fork header label carries the #1547 anchor at its fork point."""
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True},
+        {"branch_id": 5, "fork_point_seq": 3, "head_seq": 7, "parent_branch_id": 0, "is_active": False},
+    ]
+    # The fork point (#3) lives on the parent branch and carries the anchor.
+    checkpoints = [_cp(3, 0, anchor="run the tests"), _cp(6, 0), _cp(5, 5)]
+    rows = build_branch_tree_rows(branches, checkpoints)
+    fork_hdr = next(r for r in rows if r["row"] == ROW_HEADER and r["branch_id"] == 5)
+    assert "#3" in fork_hdr["label"]
+    assert "run the tests" in fork_hdr["label"]

--- a/tests/test_slash_rewind_1f.py
+++ b/tests/test_slash_rewind_1f.py
@@ -72,12 +72,12 @@ async def test_bare_rewind_emits_menu_sentinel() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rewind_with_seq_invokes_rewind_to(tmp_path) -> None:
-    """Tier 2: /rewind <N> calls AgentRegistry.rewind_to(N) and reports success.
+async def test_rewind_with_seq_invokes_checkout(tmp_path) -> None:
+    """Tier 2: /rewind <N> calls AgentRegistry.checkout(N) and reports success.
 
-    Drives a real registry: WAL seq 1 + 2 appended, rewind to seq 1. The
-    reply names the target seq and the agent-reset count; the WAL grows a
-    reset-record (proof rewind_to actually ran).
+    The slash uses the SAME unified checkout the picker dispatches (D8) — no
+    sibling-gap. Drives a real registry: WAL seq 1 + 2 appended, checkout to
+    seq 1. The reply names the target seq; the WAL grows a reset-record.
     """
     reg = _make_registry(tmp_path)
     log = reg.state_log
@@ -88,11 +88,11 @@ async def test_rewind_with_seq_invokes_rewind_to(tmp_path) -> None:
     session = _CapturingSession(registry=reg)
     await _handler().handler(session, "1")
 
-    # A reset-record was appended (rewind_to ran).
+    # A reset-record was appended (checkout ran).
     assert log.current_seq > head_before
     # The reply names the target seq.
     texts = [getattr(m, "text", "") for m in session.outbox_msgs]
-    assert any("seq 1" in t and "rewound" in t for t in texts)
+    assert any("seq 1" in t and "checked out" in t for t in texts)
 
 
 @pytest.mark.asyncio
@@ -113,15 +113,27 @@ async def test_rewind_seq_without_registry_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rewind_abandoned_target_surfaces_error(tmp_path) -> None:
-    """Tier 2: /rewind <N> into an abandoned branch surfaces rewind_to's error."""
+async def test_rewind_abandoned_target_checks_out_fork_switch(tmp_path) -> None:
+    """Tier 2: /rewind <N> into an abandoned branch now SUCCEEDS (fork-switch).
+
+    Contract reversal from the rewind_to era: rewind_to rejected an abandoned
+    target (RewindIntoAbandonedError); the unified checkout (D8) has no
+    active-target guard, so checking out a dead-branch seq revives that lineage
+    — a fork-switch, not an error. Pins the new behaviour decisively.
+    """
     from reyn.events.snapshot_generations import rewind as _rewind_record
     reg = _make_registry(tmp_path)
     log = reg.state_log
     await log.append("inbox_put", target="alpha", msg_id="a", msg_kind="user", payload={})
     await log.append("inbox_put", target="alpha", msg_id="b", msg_kind="user", payload={})
-    await _rewind_record(log, target_n=1)  # abandons seq 2
+    await _rewind_record(log, target_n=1)  # abandons seq 2 (dead branch)
+    head_before = log.current_seq
 
     session = _CapturingSession(registry=reg)
-    await _handler().handler(session, "2")  # seq 2 is abandoned
-    assert [m.kind for m in session.outbox_msgs] == ["error"]
+    await _handler().handler(session, "2")  # checkout the dead-branch seq
+
+    # No error — the dead-branch checkout succeeded (fork-switch).
+    assert "error" not in [m.kind for m in session.outbox_msgs]
+    assert log.current_seq > head_before  # a reset-record reviving seq 2's lineage
+    texts = [getattr(m, "text", "") for m in session.outbox_msgs]
+    assert any("checked out" in t for t in texts)


### PR DESCRIPTION
**[e2e-coder]** — ADR-0038 Phase-2 **2b: the fork picker**. The `/rewind` picker becomes the always-tree branch picker, and Enter dispatches the unified `checkout(seq)` (undo for a live-branch node, fork-switch for a dead-branch node). Builds on the merged 2a-1 (`list_branches` + `list_rewind_points(include_abandoned)`) + 2a-2 (`checkout`). Design + contract converged with sandbox_2 (substrate) + tui-coder (UX) in #1533.

## What 2b ships
- **`build_branch_tree_rows`** (pure) — groups checkpoints by the substrate-stamped `branch_id` (lineage-correct), NOT range-intersection. The keystone test pins the build-first contract catch (an active parent's seq-range spans an abandoned child, so range-intersect over-includes).
- **`RewindMenuWidget` always-tree mode** (`from_tree_rows`) — header rows are non-selectable decorators (`●`/`▸` active bright, `◌` inactive dim, depth indent, #1547 anchor labels); the cursor moves among checkpoint rows only; default = working-tree head (Enter = undo, Phase-1 parity). Flat path retained byte-unchanged.
- **Live wiring** — `_open_rewind_menu` → always-tree from the real primitives; Enter → `registry.checkout(seq)`; "checked out to seq N" breadcrumb.

## Unified checkout (D8)
The user never picks "undo vs fork" — Enter on any node is `checkout(seq)`. Live-branch node = undo (the `rewind_to` special case); dead-branch node = fork-switch (revives that lineage; checkout has no active-target guard). Matches the git mental model.

## Construction-forwarding (#1556 lesson)
The real-registry data path (`list_branches → build_branch_tree_rows → checkout`, with a real fork on the WAL) is covered by an **integration test**, not just the registry=None guard — guarding against a NameError-class runtime error when the dispatch meets a real registry.

## Files
- `src/reyn/chat/tui/widgets/_branch_tree.py` — **new** pure tree layout
- `src/reyn/chat/tui/widgets/rewind_menu.py` — always-tree mode (additive)
- `src/reyn/chat/tui/widgets/conversation.py` — `mount_rewind_menu(tree_rows=...)`
- `src/reyn/chat/tui/app.py` — always-tree `_open_rewind_menu`, `_build_rewind_tree_rows`, `_do_checkout`

## Test plan
- [x] `pytest tests/test_branch_tree_2b.py` — 6 (grouping core, keystone over-include regression)
- [x] `pytest tests/cli/test_rewind_menu_tree_2b.py` — 5 (tree render/nav, run_test real-DOM)
- [x] `pytest tests/cli/test_rewind_checkout_integration_2b.py` — 2 (real registry → tree → checkout, #1556 guard)
- [x] Flat-path 1f/1550 + esc-esc 1546 + registry 1f — 39 rewind/branch/esc green (additive, byte-unchanged flat)
- [x] `pytest tests/cli/ -k "rewind or tui_smoke or conv or esc or branch or checkout"` — 146 passed (no regression)
- [x] `ruff check .` + tier audit `--strict` — clean
- [ ] (tmux, tui-coder) live e2e P1-P3: checkout=undo / fork-switch / (2c edit=new-fork); E1-E4 Esc matrix — **tui-coder's tmux scope** (key-driven flow)

## Staging note
2c (edit UX) is co-impl with tui-coder (their Esc priority-3.5 / edit-mode binding + my edit data-flow, via the locked `enter_edit_mode`/`exit_edit_mode` interface). 2d (web) follows. This PR is 2b (the fork picker).

Refs #1533.