### PR TITLE
feat(1533): Phase-2 2a-3 — act-turn runtime-only rewind (final 2a substrate stage)

### DIFF
--- a/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a3-act-turn-design.md
+++ b/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a3-act-turn-design.md
@@ -1,0 +1,78 @@
+# #1533 2a-3 — act-turn runtime-only rewind (design)
+
+**Status**: IMPLEMENTED on `feat/1533-2a3-act-turn` (off merged main, 2a-2 in #1559).
+Author: dogfood-coder. Final 2a substrate stage. Lead scope (D6 Phase-2):
+act-turn-granularity runtime-only rewind + UX framing + coherent-workspace deferral sub-issue.
+
+> Landed: `SkillResumeCoordinator.plan_for_act_turn_rewind(*, snapshot, wal_events, target_seq)` — truncates `committed_steps`/`ambiguous_steps` at `target_seq` (reuse `SkillResumeAnalyzer`, runtime-only by construction). Tests: `tests/test_act_turn_rewind_2a3.py`. Coherent-workspace deferral tracked as #1560.
+
+## What act-turn rewind is (and why it's a distinct path)
+
+Phase-1 `checkout(seq)` rewinds at **boundary** granularity (turn / phase /
+plan-step) — it reconstructs the *agent* snapshot (inbox replay) + workspace.
+But a mid-turn **step** within a skill run is not agent-snapshot state; it's
+skill-run execution state (current phase + which committed steps within it). The
+agent reconstruct can't reach it.
+
+ADR-0038 D6: act-turn is **not a durable checkpoint** (ADR-0002 rejected mid-act
+state on volume grounds) but **is reachable** via `snapshot(step-start) +
+CommittedStep memo` **0-token Ghost-Replay**. That machinery already exists for
+crash-resume:
+
+- `SkillResumeAnalyzer.analyze(snapshot, wal_events)` → `ResumePlan` with
+  `committed_steps` (each `CommittedStep` carries its `seq` + recorded `result`).
+- `OSRuntime.run(resume_plan=plan)` → `dispatch_tool` consults
+  `resume_plan.committed_steps` via `_lookup_memoized_step` (op_invocation_id +
+  args_hash): a match returns the recorded result with **no re-execution**
+  (0-token), so steps replay as ghosts; unmemoized steps execute normally.
+
+## The insight: act-turn rewind = truncate the memo at the target seq
+
+To rewind a run to act-turn boundary **K** (a `CommittedStep.seq`): build the
+ResumePlan, then **keep only `committed_steps` with `seq <= K`**. On relaunch,
+steps ≤ K Ghost-Replay (0-token), steps > K fall out of the memo and re-execute.
+That *is* the rewind — no new replay engine, pure reuse of the analyzer + the
+existing dispatch memo. Runtime-only by construction (it touches only the memo /
+skill-run state, never the workspace).
+
+## Proposed surface
+
+`SkillResumeCoordinator.plan_for_act_turn_rewind(*, snapshot, wal_events,
+target_seq) -> ResumePlan`:
+- analyze → full plan, then `replace(plan, committed_steps=[c for c in
+  committed_steps if c.seq <= target_seq])`.
+- ambiguous_steps similarly bounded (`started_seq <= target_seq`) — a start after
+  K is not part of the rewound-to state.
+- returned plan feeds the existing `OSRuntime.run(resume_plan=...)` launch path
+  (no new runtime wiring; the relaunch seam is unchanged).
+
+(API home = the coordinator, beside `decide_for_plan` — it's the resume-plan
+shaping layer. Open to analyzer instead if lead prefers; flagged below.)
+
+## Runtime-only — explicit UX framing / documented limitation
+
+Act-turn rewind restores **runtime/skill-execution state only**. The workspace is
+**NOT** rewound to mid-act-turn coherence: file ops performed *within* the
+act-turn are not content-versioned per-step (the shadow-git blob store D9 captures
+at boundary generations, not per-op). So after an act-turn rewind the workspace
+reflects the last **boundary** generation ≤ the enclosing turn, not the precise
+mid-step file state. This is surfaced to the user as a documented limitation
+(act-turn rewind = "re-run from step K with memoized history", not "the repo as it
+was mid-step K").
+
+## Deferral → tracked sub-issue (like #1557)
+
+**Coherent act-turn workspace** (file content rewound to mid-step precision)
+requires a **per-file-op content log** (every file mutation captured as a blob,
+not just boundary snapshots). That's a substantial substrate addition, explicitly
+deferred by lead. Tracked as a sub-issue of #1533 (NOT `wait_owner_iv` — it's a
+tracking issue, not a user-intervention request).
+
+## Test plan (TDD, real-instance)
+
+- truncate-at-K: a run with committed steps at seqs {.., K, ..} → plan' has
+  exactly `committed_steps` with seq ≤ K; later steps dropped (→ they re-execute).
+- ambiguous bounded by target_seq.
+- target at/after the last step = full plan (no-op rewind); target before the
+  first step = empty memo (full re-execution from phase start).
+- real `SkillResumeAnalyzer` + real WAL events (no mocks); first-line `"""Tier 2: ..."""`.

--- a/src/reyn/skill/skill_resume_coordinator.py
+++ b/src/reyn/skill/skill_resume_coordinator.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from reyn.config import SkillResumeConfig
     from reyn.events.state_log import StateLog
     from reyn.skill.skill_registry import SkillRegistry
+    from reyn.skill.skill_snapshot import SkillSnapshot
 
 
 ResumeAction = Literal["resume", "retry", "skip", "discard", "prompt_required"]
@@ -166,6 +167,45 @@ class SkillResumeCoordinator:
             plan=result_plan,
             action=action,
             ambiguous_steps=list(plan.ambiguous_steps),
+        )
+
+    def plan_for_act_turn_rewind(
+        self,
+        *,
+        snapshot: "SkillSnapshot",
+        wal_events: Iterable[dict],
+        target_seq: int,
+    ) -> ResumePlan:
+        """Resume plan rewound to act-turn boundary ``target_seq`` (ADR-0038 D6 Phase-2).
+
+        Act-turn granularity is *reachable* (not durable): rewinding a skill run
+        to a mid-turn step K = truncating the 0-token Ghost-Replay memo at K. We
+        analyze the full run, then keep only the ``committed_steps`` with
+        ``seq <= target_seq`` (they Ghost-Replay on relaunch via the dispatch memo)
+        and drop the later ones (they fall out of the memo and re-execute) — that
+        is the rewind. ``ambiguous_steps`` are bounded the same way (a step started
+        after K is not part of the rewound-to state).
+
+        **Runtime-only by construction**: this only shapes a ``ResumePlan`` (the
+        skill-run / memo layer) — it never touches the workspace. The workspace is
+        NOT rewound to mid-act-turn coherence (file ops within an act-turn are not
+        per-op content-versioned; the shadow-git blob store captures at boundary
+        generations). UX framing: act-turn rewind = "re-run from step K with
+        memoized history", not "the repo as it was mid-step K". Coherent
+        act-turn-workspace rewind (per-file-op content log) is a tracked deferral.
+
+        The returned plan feeds the existing ``OSRuntime.run(resume_plan=...)``
+        launch path unchanged — no new runtime wiring.
+        """
+        plan = self._analyzer.analyze(snapshot=snapshot, wal_events=wal_events)
+        return replace(
+            plan,
+            committed_steps=[
+                c for c in plan.committed_steps if c.seq <= target_seq
+            ],
+            ambiguous_steps=[
+                a for a in plan.ambiguous_steps if a.started_seq <= target_seq
+            ],
         )
 
     async def apply_decisions(

--- a/tests/test_act_turn_rewind_2a3.py
+++ b/tests/test_act_turn_rewind_2a3.py
@@ -1,0 +1,119 @@
+"""Tier 2: OS invariant — act-turn runtime-only rewind (#1533 2a-3, ADR-0038 D6).
+
+Act-turn granularity is reachable (not durable) via `snapshot(step-start) +
+CommittedStep memo` 0-token Ghost-Replay. Rewinding a skill run to an act-turn
+boundary K = truncating the resume memo at K: keep only `committed_steps` with
+`seq <= K` (they Ghost-Replay) and drop later ones (they re-execute). Pure reuse
+of `SkillResumeAnalyzer` + the existing dispatch memo — runtime-only by
+construction (touches only the resume plan / skill-run state, never the workspace).
+
+Real `SkillResumeAnalyzer` (no mocks); synthetic SkillSnapshot + WAL event dicts,
+mirroring tests/test_skill_resume_analyzer.py.
+"""
+from __future__ import annotations
+
+from reyn.skill.skill_resume_coordinator import SkillResumeCoordinator
+from reyn.skill.skill_snapshot import SkillSnapshot
+
+
+def _snap(run_id: str = "r1", phase: str = "draft") -> SkillSnapshot:
+    s = SkillSnapshot.empty(run_id, "demo", {"x": 1})
+    s.current_phase = phase
+    return s
+
+
+def _completed(*, seq: int, oid: str, phase: str = "draft") -> dict:
+    return {
+        "seq": seq, "kind": "step_completed", "op_invocation_id": oid,
+        "op_kind": "file", "phase": phase, "args_hash": f"h{oid}",
+        "result": {"ok": True, "oid": oid},
+    }
+
+
+def _started(*, seq: int, oid: str, phase: str = "draft") -> dict:
+    return {
+        "seq": seq, "kind": "step_started", "op_invocation_id": oid,
+        "op_kind": "file", "phase": phase, "args_hash": f"h{oid}",
+        "args": {"op": "write"},
+    }
+
+
+def _committed_seqs(plan) -> list[int]:
+    return sorted(c.seq for c in plan.committed_steps)
+
+
+# ── memo truncation at the act-turn boundary ──────────────────────────────────
+
+
+def test_rewind_truncates_committed_steps_at_target_seq():
+    """Tier 2: rewind to K keeps committed steps with seq <= K, drops the rest.
+
+    Three world-purity steps committed at seqs 2, 4, 6 (each its own committed
+    step — no started pairing). Rewind to K=4 → the memo retains {2, 4}; step 6
+    falls out, so on relaunch it re-executes (the act-turn rewind). Steps 2,4
+    remain memoized (0-token Ghost-Replay).
+    """
+    coord = SkillResumeCoordinator()
+    snap = _snap()
+    events = [
+        _completed(seq=2, oid="a"),
+        _completed(seq=4, oid="b"),
+        _completed(seq=6, oid="c"),
+    ]
+
+    plan = coord.plan_for_act_turn_rewind(
+        snapshot=snap, wal_events=events, target_seq=4,
+    )
+
+    assert _committed_seqs(plan) == [2, 4]      # 6 dropped → re-executes
+    # the surviving memo carries the recorded results (Ghost-Replay payload intact).
+    by_oid = {c.op_invocation_id: c for c in plan.committed_steps}
+    assert by_oid["a"].result == {"ok": True, "oid": "a"}
+    assert "c" not in by_oid
+    # identity preserved (run/phase) — same run, just a shorter memo.
+    assert plan.run_id == "r1" and plan.current_phase == "draft"
+
+
+def test_rewind_target_at_or_after_last_step_is_full_memo():
+    """Tier 2: target >= the last committed seq keeps the whole memo (no-op rewind)."""
+    coord = SkillResumeCoordinator()
+    events = [_completed(seq=2, oid="a"), _completed(seq=5, oid="b")]
+
+    plan = coord.plan_for_act_turn_rewind(
+        snapshot=_snap(), wal_events=events, target_seq=99,
+    )
+    assert _committed_seqs(plan) == [2, 5]
+
+
+def test_rewind_target_before_first_step_empties_memo():
+    """Tier 2: target below the first committed seq → empty memo (full re-exec from phase start)."""
+    coord = SkillResumeCoordinator()
+    events = [_completed(seq=4, oid="a"), _completed(seq=6, oid="b")]
+
+    plan = coord.plan_for_act_turn_rewind(
+        snapshot=_snap(), wal_events=events, target_seq=1,
+    )
+    assert plan.committed_steps == []
+
+
+def test_rewind_bounds_ambiguous_steps_by_target_seq():
+    """Tier 2: an ambiguous (unpaired started) after K is dropped from the rewound plan.
+
+    A started@3 never completes (ambiguous). Rewinding to K=2 must drop it — a
+    step started after the rewind point is not part of the rewound-to state. A
+    started@1 (also unpaired, <= K) is retained for the operator decision.
+    """
+    coord = SkillResumeCoordinator()
+    events = [
+        _started(seq=1, oid="early"),    # ambiguous, <= K → kept
+        _completed(seq=2, oid="done"),   # committed, <= K → kept
+        _started(seq=3, oid="late"),     # ambiguous, > K → dropped
+    ]
+
+    plan = coord.plan_for_act_turn_rewind(
+        snapshot=_snap(), wal_events=events, target_seq=2,
+    )
+
+    assert _committed_seqs(plan) == [2]
+    amb_seqs = sorted(a.started_seq for a in plan.ambiguous_steps)
+    assert amb_seqs == [1]                       # late@3 dropped


### PR DESCRIPTION
**[dogfood-coder]** — #1533 Phase-2 substrate 2a-3 (ADR-0038 D6), off merged main. Approach endorsed by lead (coordinator API home agreed); TDD test-first; opening for deep review. **This completes the 2a substrate (1a–1f + 2a-1/2a-2/2a-3).**

## What

Act-turn granularity is *reachable* (not durable) via `snapshot(step-start) + CommittedStep memo` 0-token Ghost-Replay. Rewinding a skill run to a mid-turn step K = **truncating the resume memo at K**.

`SkillResumeCoordinator.plan_for_act_turn_rewind(*, snapshot, wal_events, target_seq) -> ResumePlan`:
- analyze the run (reuse `SkillResumeAnalyzer`), then keep only `committed_steps` with `seq <= target_seq` (they Ghost-Replay via the existing dispatch `_lookup_memoized_step`) and drop the later ones (they fall out of the memo → re-execute). That **is** the rewind. `ambiguous_steps` bounded the same way.
- **runtime-only by construction**: shapes only a `ResumePlan` (skill-run / memo layer), never touches the workspace. Feeds the existing `OSRuntime.run(resume_plan=...)` launch path unchanged — no new runtime wiring, no new replay engine.

API home = coordinator (plan-shaping layer, beside `decide_for_plan`); analyzer stays raw-analysis focused (lead-agreed).

## Runtime-only — documented limitation + deferral

The workspace is **NOT** rewound to mid-act-turn coherence (file ops within an act-turn aren't per-op content-versioned; D9 blob store captures at boundary generations). UX framing: act-turn rewind = "re-run from step K with memoized history", not "the repo as it was mid-step K". Coherent act-turn-workspace rewind (per-file-op content log) is a tracked deferral: **#1560** (plain tracking, sibling of #1557).

## Test plan

`tests/test_act_turn_rewind_2a3.py` (Tier 2, real `SkillResumeAnalyzer`, no mocks):

- [x] `test_rewind_truncates_committed_steps_at_target_seq` — keep seq ≤ K, drop the rest; surviving memo carries recorded results
- [x] `test_rewind_target_at_or_after_last_step_is_full_memo` — no-op rewind
- [x] `test_rewind_target_before_first_step_empties_memo` — full re-exec from phase start
- [x] `test_rewind_bounds_ambiguous_steps_by_target_seq` — ambiguous after K dropped
- [x] `python -m pytest tests/test_act_turn_rewind_2a3.py -W error::RuntimeWarning` → 4 passed
- [x] tier-audit clean; ruff clean
- [x] 346 adjacent resume/skill/memo tests pass

After merge: 2a substrate complete; axis shifts to 2b/2c/2d UX (e2e + tui-coder); I move to substrate-completion review support + the Phase-2 e2e live gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)