### PR TITLE
test(1533): Phase-2 e2e live-fork gate (production-wiring composition)

### DIFF
--- a/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-phase2-e2e-live-gate-design.md
+++ b/docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-phase2-e2e-live-gate-design.md
@@ -1,0 +1,73 @@
+# #1533 Phase-2 e2e live gate (design)
+
+**Status**: design-first, pending lead review (then impl). Author: dogfood-coder.
+The Phase-2 (A)-equivalent of the Phase-1 deterministic gate
+(`tests/test_live_rewind_gate.py`).
+
+## The scope question (lead): does a session-level gate add value over 2a-2?
+
+**Yes — different blind-spot.** Precisely:
+
+- **2a-2's `test_checkout_back_revives_lineage_two_substrate`** proves checkout /
+  checkout-back **correctness** on both substrates (workspace v2→v3 + inbox), but
+  the captures are **manually constructed** (`_put` + `ws.capture(seq)`). It does
+  not drive the production turn loop.
+- The **Phase-1 gate** proves real-turn `_run_router_loop` → genuine
+  `cut_generation` auto-capture → `rewind_to` (undo) reverts both substrates. It
+  stops at undo — no fork, no post-rewind continue.
+
+The Phase-2 gate closes the **composition** the other two don't:
+**(real `_run_router_loop` cut_generation auto-capture) × (checkout branch-switch
+to an abandoned seq + a post-fork *continue* turn through the real loop +
+checkout-back)**. New wiring it exercises that nothing else does:
+
+1. captures come from **genuine** turns (if `_run_router_loop` ever stops calling
+   `cut_generation`, a manual-capture test stays green — the Phase-1 gate's
+   rationale, extended to fork);
+2. the session is **live-usable after a rewind** — a real turn runs *through the
+   production loop* on the new active branch post-undo (the Phase-1 gate never
+   drives a turn after rewind; fork UX depends on "fork, then keep working");
+3. **checkout to an abandoned seq** revives a lineage whose captures were
+   real-turn-produced (not hand-built), and a subsequent checkout-back follows
+   the post-fork-continue lineage.
+
+So: 2a-2 = checkout correctness (unit-of-substrate); Phase-2 gate = production
+wiring composition (end-to-end). Both needed; neither subsumes the other.
+
+## Gate scenario (mirrors the Phase-1 gate structure)
+
+Real `AgentRegistry` + `ChatSession` + `StateLog` + real git; `_FakeTurnDriver`
+(no-LLM) swapped in so the genuine `_run_router_loop` + `cut_generation` fire; the
+only simulated effect is the per-turn file write (same as Phase-1).
+
+```
+turn A  → file v1, runtime [A], genuine cut_generation @ seqA
+turn B  → file v2, runtime [A,B], cut_generation @ seqB
+rewind_to(seqA)            # undo → B's branch becomes abandoned (a dead branch)
+turn C  → file v3, runtime [A,C], cut_generation @ seqC   # REAL turn on the post-undo active branch
+checkout(seqB)             # branch-switch to the abandoned B lineage
+  → assert workspace == v2, runtime == [A,B]              # fork revived from real captures
+checkout(seqC)             # checkout-back to the C lineage
+  → assert workspace == v3, runtime == [A,C]
+```
+
+Assertions on **both substrates** at each checkout (workspace file on disk +
+runtime: on-disk snapshot AND live in-memory session — the two distinct wirings
+the Phase-1 gate already separates).
+
+## Open sub-question for lead
+
+- **act-turn (2a-3) in the gate?** The act-turn rewind path
+  (`plan_for_act_turn_rewind`) is runtime-only and feeds `OSRuntime.run(resume_plan=)`
+  — a *different* launch seam than the turn-boundary `checkout`. I lean **keep the
+  Phase-2 gate to the boundary-granularity fork/checkout-back full-path** (the
+  (A)-equivalent), and cover act-turn rewind separately if a live gate is wanted
+  (it has no workspace substrate, so it isn't a "both-substrate" composition).
+  Flag if you want act-turn folded into this gate.
+
+## Plan
+
+Design → #1533 comment → lead review/lock → impl (`tests/test_live_fork_gate.py`
+or extend `test_live_rewind_gate.py`), real-instance, `-W error::RuntimeWarning`,
+tier-audit first-line `"""Tier 2: ..."""`. (B) tmux live UX = tui-coder (P1-P3
+after 2b); I stay on the deterministic (A)-equivalent.

--- a/tests/test_live_fork_gate.py
+++ b/tests/test_live_fork_gate.py
@@ -1,0 +1,140 @@
+"""Tier 2: OS invariant — Phase-2 end-to-end live-fork gate (ADR-0038 D8, #1533).
+
+The Phase-2 (A)-equivalent of `test_live_rewind_gate.py`. Real `AgentRegistry` +
+`ChatSession` + `StateLog` + real git (no mocks). 2a-2's two-substrate test proves
+checkout *correctness* with manually-built captures; THIS gate proves the
+**production-wiring composition**: a genuine `_run_router_loop` turn's
+`cut_generation` auto-capture × Phase-2 `checkout` (branch-switch to an abandoned
+seq) × a **post-rewind continue turn driven through the real loop** ×
+checkout-back. Both substrates (runtime inbox + workspace shadow-git) must follow
+the fork lineage at each step.
+
+The genuine-new coverage over the Phase-1 gate: the Phase-1 gate stops at undo —
+it never drives a turn *after* a rewind. Fork UX is "fork, then keep working", so
+driving turn C through the real loop on the post-undo branch (and then reviving
+the abandoned branch + checking back out) is the composition that neither 2a-2
+(manual captures) nor the Phase-1 gate (undo-only) exercises.
+
+As in the Phase-1 gate, a `_FakeTurnDriver` (no-LLM) is swapped in so the real
+`_run_router_loop` runs and its genuine `cut_generation` fires; the ONLY simulated
+part is the op's file-write.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+_WORKSPACE_FILE = "code.py"
+
+
+class _FakeTurnDriver:
+    """No-LLM loop_driver: each turn writes the workspace file for that turn +
+    appends a runtime inbox entry. Substitutes for ``RouterLoopDriver`` so the
+    real ``_run_router_loop`` runs (and its genuine ``cut_generation`` fires)
+    without an LLM. The only simulated effect is the file write (the op effect).
+    """
+
+    def __init__(self, session: ChatSession, workspace_root: Path, content_by_turn: dict[str, str]):
+        self._session = session
+        self._ws = workspace_root
+        self._content = content_by_turn
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        (self._ws / _WORKSPACE_FILE).write_text(self._content[user_text], encoding="utf-8")
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+def _turn_markers(snap: AgentSnapshot) -> list[str]:
+    return [m["payload"]["turn"] for m in snap.inbox]
+
+
+@pytest.mark.asyncio
+async def test_live_fork_checkout_back_follows_lineage_both_substrates(tmp_path):
+    """Tier 2: real-turn captures × checkout branch-switch × post-fork continue.
+
+    turn A (v1) → turn B (v2) → rewind_to(A) → turn C (v3, REAL turn on the
+    post-undo active branch) → checkout(seqB) revives the abandoned B lineage →
+    checkout(seqC) switches back. Each checkout asserts BOTH substrates follow the
+    target lineage: workspace file on disk + runtime (on-disk snapshot AND live
+    in-memory session — the two distinct wirings the Phase-1 gate separates).
+    """
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
+
+    session = ChatSession(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
+    session.register_intervention_listener("test")
+    session.attach_workspace_store(reg.workspace_store)
+    session.attach_anchor_store(reg.anchor_store)
+    reg._agents["alpha"] = session
+    session._loop_driver = _FakeTurnDriver(
+        session, tmp_path, {"turn A": "v1", "turn B": "v2", "turn C": "v3"},
+    )
+
+    # turn A → file v1 + runtime [A]; genuine cut_generation @ seqA.
+    await session._run_router_loop("turn A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    # turn B → file v2 + runtime [A, B]; auto-captures @ seqB.
+    await session._run_router_loop("turn B", "c1")
+    seq_b = session.current_snapshot.applied_seq
+
+    # pre-fork sanity: both substrates at B, both checkpoints captured.
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v2"
+    assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]
+    ws_seqs = await reg.workspace_store.seqs()
+    assert {seq_a, seq_b} <= set(ws_seqs)
+
+    # ── undo to A: B's branch becomes abandoned (a dead branch) ──
+    await reg.rewind_to(seq_a)
+    assert _turn_markers(session.current_snapshot) == ["turn A"]
+
+    # ── turn C: a REAL turn through the production loop on the post-undo branch ──
+    # (genuine new coverage — the session must be live-usable after a rewind).
+    await session._run_router_loop("turn C", "c1")
+    seq_c = session.current_snapshot.applied_seq
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v3"
+    assert _turn_markers(session.current_snapshot) == ["turn A", "turn C"]
+    assert seq_b not in _active_workspace_seqs(reg, await reg.workspace_store.seqs())
+
+    # ── checkout(seqB): branch-switch — revive the abandoned B lineage ──
+    await reg.checkout(seq_b)
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v2"   # workspace follows B
+    assert _turn_markers(AgentSnapshot.load("alpha", snap_path)) == ["turn A", "turn B"]  # disk
+    assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]    # live in-memory
+
+    # ── checkout(seqC): switch back to the C lineage ──
+    await reg.checkout(seq_c)
+    assert (tmp_path / _WORKSPACE_FILE).read_text(encoding="utf-8") == "v3"   # workspace follows C
+    assert _turn_markers(AgentSnapshot.load("alpha", snap_path)) == ["turn A", "turn C"]  # disk
+    assert _turn_markers(session.current_snapshot) == ["turn A", "turn C"]    # live in-memory
+
+
+def _active_workspace_seqs(reg: AgentRegistry, ws_seqs) -> set[int]:
+    """The workspace generation seqs currently on the active branch."""
+    from reyn.events.snapshot_generations import is_active_seq
+    return {s for s in ws_seqs if is_active_seq(reg.state_log, s)}


### PR DESCRIPTION
**[dogfood-coder]** — Phase-2 deterministic e2e live gate (ADR-0038 D8), design lead-locked on #1533. The (A)-equivalent of the Phase-1 `test_live_rewind_gate.py`; off latest main (2a substrate + 2b all merged).

## What it proves (and why it's not redundant)

- **2a-2** `test_checkout_back_revives_lineage_two_substrate` = checkout/checkout-back **correctness** with manually-built captures (`_put` + `ws.capture`).
- **Phase-1 gate** = real `_run_router_loop` → genuine `cut_generation` → `rewind_to` (undo) reverts both substrates; stops at undo.

This gate closes the **production-wiring composition** neither covers: *(genuine `_run_router_loop` cut_generation auto-capture) × (checkout branch-switch to an abandoned seq + a post-rewind continue turn through the real loop + checkout-back)*. The **genuine new coverage**: the session is **live-usable after a rewind** — fork UX is "fork, then keep working", which the Phase-1 gate (undo-only) never exercises.

## Scenario (lead-locked; `_FakeTurnDriver`, genuine loop + cut_generation, only the file-write simulated)

```
turn A → file v1, runtime [A], cut_generation @ seqA
turn B → file v2, runtime [A,B], cut_generation @ seqB
rewind_to(seqA)            # undo → B becomes a dead branch
turn C → file v3, runtime [A,C], cut_generation @ seqC   # REAL turn on the post-undo active branch
checkout(seqB)  → assert workspace v2, runtime [A,B]     # branch-switch revives the abandoned lineage
checkout(seqC)  → assert workspace v3, runtime [A,C]     # checkout-back
```

Both substrates asserted at each checkout: workspace file on disk + runtime (on-disk snapshot AND live in-memory session — the two distinct wirings the Phase-1 gate separates).

`act-turn` (2a-3) deliberately **not** folded in (lead-agreed): runtime-only, different launch seam, no workspace substrate — covered by its own 4 Tier-2 tests. (B) tmux live UX = tui-coder P1-P3.

## Test plan

- [x] `test_live_fork_checkout_back_follows_lineage_both_substrates` — the full scenario
- [x] `python -m pytest tests/test_live_fork_gate.py -W error::RuntimeWarning` → 1 passed
- [x] tier-audit clean; ruff clean
- [x] passes alongside Phase-1 gate + 2a-2 + rewind_to suites (19 green)

This is the Phase-2 deterministic CI gate. With it, the 2a substrate + its end-to-end composition are both pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)