### PR TITLE
feat(1533): AnchorStore full-message capture — unblocks 2c edit-prefill

### DIFF
--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -73,7 +73,7 @@ class SnapshotJournal:
         """
         self._anchor_store = anchor_store
 
-    async def cut_generation(self, anchor: str = "") -> None:
+    async def cut_generation(self, anchor: str = "", full_message: str = "") -> None:
         """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a/1d).
 
         Called at user-facing checkpoint boundaries (turn / plan-step) — a
@@ -87,6 +87,9 @@ class SnapshotJournal:
         ``anchor`` (#1547): the truncated last user message for the rewind-timeline
         preview, captured against the same boundary seq. Empty / no anchor store →
         skipped (turn boundaries pass it; plan-step / phase cuts leave it empty).
+        ``full_message`` (#1533 2c): the full original user message for the
+        edit-prefill, persisted alongside the truncated anchor (turn boundaries
+        only — same as ``anchor``).
         """
         if self._generation_store is None or self._state_log is None:
             return
@@ -94,7 +97,9 @@ class SnapshotJournal:
         if self._workspace_store is not None:
             await self._workspace_store.capture(self._snapshot.applied_seq)
         if self._anchor_store is not None and anchor:
-            self._anchor_store.capture(self._snapshot.applied_seq, anchor)
+            self._anchor_store.capture(
+                self._snapshot.applied_seq, anchor, full=full_message,
+            )
 
     # ── public read access ────────────────────────────────────────────────
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -5062,7 +5062,10 @@ class ChatSession:
         await self._loop_driver.run_turn(user_text, chain_id)
         # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
         # user message is this checkpoint's anchor for the rewind-timeline preview.
-        await self._journal.cut_generation(anchor=_truncate_anchor(user_text))
+        # #1533 2c: the FULL message is persisted alongside (edit-prefill source).
+        await self._journal.cut_generation(
+            anchor=_truncate_anchor(user_text), full_message=user_text,
+        )
 
     async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
         """Forwarding → RouterLoopDriver._run_with_shrink (PR-3)."""

--- a/src/reyn/events/anchor_store.py
+++ b/src/reyn/events/anchor_store.py
@@ -34,20 +34,36 @@ def truncate_anchor(text: str, *, limit: int = _DEFAULT_LIMIT) -> str:
 class AnchorStore:
     """Maps a WAL checkpoint seq → its anchor text (truncated last user message).
 
-    JSON-backed (``{seq: text}``); anchors are tiny and bounded by the retention
-    window. ``get`` returns ``""`` for an unknown seq so callers can slot the
-    field in unconditionally.
+    JSON-backed; each entry is ``{"anchor": <truncated display>, "full": <full
+    original user message>}``. The truncated ``anchor`` drives the rewind-timeline
+    preview (1f); the ``full`` message is the source for the 2c edit-prefill (a
+    truncated re-run would lose the original tail = correctness, #1533 2c). Both
+    are captured at ``cut_generation`` time, where the full message is in hand —
+    robust vs fragile after-the-fact WAL/history mining. Entries are tiny and
+    bounded by the retention window.
+
+    ``get`` / ``get_full`` return ``""`` for an unknown seq so callers can slot the
+    field in unconditionally. **Back-compatible**: a pre-2c file stores ``{seq:
+    <str>}``; such values load as ``{"anchor": <str>, "full": ""}`` so the display
+    still works and the edit-prefill degrades to empty (manual re-type).
     """
 
     def __init__(self, path: Path) -> None:
         self._path = Path(path)
-        self._anchors: dict[int, str] | None = None
+        self._anchors: dict[int, dict[str, str]] | None = None
 
-    def _load(self) -> dict[int, str]:
+    @staticmethod
+    def _normalize(value: object) -> dict[str, str]:
+        """Coerce a stored value to ``{"anchor", "full"}`` (legacy str → full="")."""
+        if isinstance(value, dict):
+            return {"anchor": str(value.get("anchor", "")), "full": str(value.get("full", ""))}
+        return {"anchor": str(value), "full": ""}   # pre-2c str value
+
+    def _load(self) -> dict[int, dict[str, str]]:
         if self._anchors is None:
             try:
                 raw = json.loads(self._path.read_text(encoding="utf-8"))
-                self._anchors = {int(k): str(v) for k, v in raw.items()}
+                self._anchors = {int(k): self._normalize(v) for k, v in raw.items()}
             except FileNotFoundError:
                 self._anchors = {}
             except (OSError, ValueError) as e:
@@ -70,16 +86,31 @@ class AnchorStore:
         )
         tmp.replace(self._path)
 
-    def capture(self, seq: int, text: str) -> None:
-        """Record the anchor ``text`` for checkpoint ``seq`` (idempotent overwrite)."""
+    def capture(self, seq: int, text: str, *, full: str = "") -> None:
+        """Record the anchor for checkpoint ``seq`` (idempotent overwrite).
+
+        ``text`` = truncated display anchor (required — empty → no-op, so non-turn
+        checkpoints store nothing). ``full`` = the full original user message for
+        the 2c edit-prefill (defaults empty for callers that have only the anchor).
+        """
         if not text:
             return
-        self._load()[int(seq)] = text
+        self._load()[int(seq)] = {"anchor": text, "full": full}
         self._save()
 
     def get(self, seq: int) -> str:
-        """Return the anchor for ``seq``, or ``""`` when none is recorded."""
-        return self._load().get(int(seq), "")
+        """Return the truncated display anchor for ``seq``, or ``""`` when none."""
+        entry = self._load().get(int(seq))
+        return entry["anchor"] if entry else ""
+
+    def get_full(self, seq: int) -> str:
+        """Return the full original message for ``seq`` (2c edit-prefill source).
+
+        ``""`` when none recorded or when the entry predates 2c (legacy str value)
+        — the edit-prefill then degrades to empty (manual re-type).
+        """
+        entry = self._load().get(int(seq))
+        return entry["full"] if entry else ""
 
     def prune_below(self, min_keep_seq: int) -> int:
         """Drop anchors with seq < ``min_keep_seq`` (Stage 1e retention GC)."""

--- a/tests/test_anchor_full_message_2c.py
+++ b/tests/test_anchor_full_message_2c.py
@@ -1,0 +1,109 @@
+"""Tier 2: OS invariant — AnchorStore full-message capture for edit-prefill (#1533 2c).
+
+The rewind-timeline anchor (truncated ~80c) is for *display*; the 2c edit flow
+needs the **full** original user message to prefill + re-run (truncated re-run
+would lose the original tail = correctness bug). The full message is in hand at
+`cut_generation` time, so it is persisted additively alongside the truncated
+anchor (robust vs fragile after-the-fact WAL/history mining). Turn checkpoints
+only (plan-step/phase pass no user message). Back-compatible: legacy str-valued
+anchor files load with full = "" (edit-prefill degrades to empty = manual re-type).
+
+Real AnchorStore + SnapshotJournal (no mocks); mirrors tests/test_anchor_text_1547.py.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.chat.services.snapshot_journal import SnapshotJournal
+from reyn.events.anchor_store import AnchorStore
+from reyn.events.snapshot_generations import SnapshotGenerationStore
+from reyn.events.state_log import StateLog
+
+# ── AnchorStore: full alongside truncated ─────────────────────────────────────
+
+
+def test_capture_stores_full_and_truncated_independently(tmp_path):
+    """Tier 2: capture(anchor, full) → get = truncated display, get_full = full original."""
+    store = AnchorStore(tmp_path / "anchors.json")
+    full = "fix the parser bug in the tokenizer and also " + ("x" * 100)
+    store.capture(10, "fix the parser bug…", full=full)
+
+    assert store.get(10) == "fix the parser bug…"   # truncated display unchanged
+    assert store.get_full(10) == full               # full original recovered
+
+
+def test_get_full_unknown_seq_is_empty(tmp_path):
+    """Tier 2: get_full for an unrecorded seq returns "" (slot-in-unconditionally)."""
+    store = AnchorStore(tmp_path / "anchors.json")
+    store.capture(10, "hi", full="hi there")
+    assert store.get_full(99) == ""
+
+
+def test_full_persists_across_instances(tmp_path):
+    """Tier 2: the full message is durable — a fresh store over the same path reads it."""
+    AnchorStore(tmp_path / "a.json").capture(5, "kept", full="kept in full glory")
+    assert AnchorStore(tmp_path / "a.json").get_full(5) == "kept in full glory"
+
+
+def test_legacy_str_valued_file_degrades_get_full_to_empty(tmp_path):
+    """Tier 2: a pre-2c anchors file (str values) loads with get intact, get_full = "".
+
+    Back-compat: old files store ``{seq: truncated_str}``. The truncated display
+    must still work (``get``); ``get_full`` degrades to "" (edit-prefill empty =
+    manual re-type, acceptable) rather than crashing.
+    """
+    path = tmp_path / "anchors.json"
+    path.write_text(json.dumps({"7": "legacy truncated text"}), encoding="utf-8")
+    store = AnchorStore(path)
+    assert store.get(7) == "legacy truncated text"   # display still works
+    assert store.get_full(7) == ""                    # no full in legacy → degrade
+
+
+def test_prune_drops_full_with_the_entry(tmp_path):
+    """Tier 2: prune_below drops the whole entry (truncated + full) below the floor."""
+    store = AnchorStore(tmp_path / "anchors.json")
+    store.capture(10, "a", full="a-full")
+    store.capture(20, "b", full="b-full")
+    store.prune_below(20)
+    assert store.get(10) == "" and store.get_full(10) == ""   # 10 gone entirely
+    assert store.get_full(20) == "b-full"                      # 20 retained
+
+
+# ── cut_generation threads full_message ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cut_generation_captures_full_message(tmp_path):
+    """Tier 2: cut_generation(anchor, full_message) records both under the boundary seq."""
+    log = StateLog(tmp_path / "wal")
+    seq = await log.append("inbox_put", target="a", msg_id="m", msg_kind="user", payload={})
+    journal = SnapshotJournal(
+        agent_name="a", snapshot_path=tmp_path / "snap.json", state_log=log,
+        generation_store=SnapshotGenerationStore("a", tmp_path / "gens"),
+    )
+    anchors = AnchorStore(tmp_path / "anchors.json")
+    journal.set_anchor_store(anchors)
+    journal.snapshot.applied_seq = seq
+
+    await journal.cut_generation(anchor="trunc…", full_message="the full original message")
+    assert anchors.get(seq) == "trunc…"
+    assert anchors.get_full(seq) == "the full original message"
+
+
+@pytest.mark.asyncio
+async def test_cut_generation_no_anchor_captures_nothing(tmp_path):
+    """Tier 2: a no-anchor cut (plan-step/phase) stores neither truncated nor full."""
+    log = StateLog(tmp_path / "wal")
+    seq = await log.append("inbox_put", target="a", msg_id="m", msg_kind="user", payload={})
+    journal = SnapshotJournal(
+        agent_name="a", snapshot_path=tmp_path / "snap.json", state_log=log,
+        generation_store=SnapshotGenerationStore("a", tmp_path / "gens"),
+    )
+    anchors = AnchorStore(tmp_path / "anchors.json")
+    journal.set_anchor_store(anchors)
+    journal.snapshot.applied_seq = seq
+
+    await journal.cut_generation()               # no anchor (non-turn checkpoint)
+    assert anchors.get(seq) == "" and anchors.get_full(seq) == ""


### PR DESCRIPTION
**[dogfood-coder]** — 2c foundational dependency (e2e flow-trace catch; AnchorStore is my #1547 domain). Small additive substrate change so e2e's 2c edit-prefill has the full original message. Lead fyi'd + independently directed the same fix.

## Problem (verified against code)

`session.py:5065` does `cut_generation(anchor=_truncate_anchor(user_text))` — only the truncated ~80c is persisted; the full `user_text` (in hand at the same line) is discarded. The 2c edit flow must prefill + re-run the **full original** (a truncated re-run loses the original tail = correctness). After-the-fact WAL/history mining is fragile (compaction drops history / direct-chat messages don't map cleanly to a checkpoint seq / AgentSnapshot has no history) — so capture-time persist is the robust source.

## Change (additive, back-compatible)

- **AnchorStore**: per-seq entry → `{"anchor": <truncated display>, "full": <full original>}`. `capture(seq, text, *, full="")` (full additive); `get(seq)` **unchanged** (truncated); new **`get_full(seq)`** (2c prefill source). Pre-2c files (`{seq: str}`) load as `{"anchor": str, "full": ""}` via `_normalize` — display still works, `get_full` degrades to `""` (manual re-type). `prune_below` drops the whole entry.
- **Wiring** (turn checkpoints only — plan-step/phase pass no anchor → no full): `cut_generation(anchor="", full_message="")` → `capture(..., full=full_message)`; `session._run_router_loop` passes `full_message=user_text`.

## Contract for e2e 2c

`registry.anchor_store.get_full(seq) -> str` → InputBar prefill (locked + confirmed with e2e).

## Test plan

`tests/test_anchor_full_message_2c.py` (Tier 2, real AnchorStore + SnapshotJournal):

- [x] full/truncated round-trip; `get_full` unknown = `""`; durability across instances
- [x] **legacy str-valued file degrades** `get_full` to `""` (back-compat); `get` intact
- [x] `prune_below` drops the whole entry; `cut_generation` threads `full_message`; no-anchor stores nothing
- [x] `python -m pytest tests/test_anchor_full_message_2c.py -W error::RuntimeWarning` → 7 passed
- [x] tier-audit clean; ruff clean
- [x] 133 adjacent anchor/rewind/gate/journal tests pass — **existing #1547 tests unchanged = back-compat proof**

🤖 Generated with [Claude Code](https://claude.com/claude-code)