### PR TITLE
feat(1533): predecessor_turn_checkpoint — lineage-correct turn predecessor (2c edit dep)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -44,6 +44,7 @@ from reyn.events.snapshot_generations import (
     active_rewind_target,
     branch_ids_for,
     is_active_seq,
+    lineage_predecessor,
     list_branches,
     reconstruct,
 )
@@ -595,6 +596,41 @@ class AgentRegistry:
         if self._state_log is None:
             return []
         return list_branches(self._state_log)
+
+    def predecessor_turn_checkpoint(self, seq: int) -> int | None:
+        """The lineage-correct prior **turn** checkpoint of ``seq`` (#1533 2c edit).
+
+        The 2c edit flow re-runs an edited turn from the state before it: checkout
+        this predecessor, then submit the edit (a new fork). The result is the
+        immediately-prior checkpoint that is a **turn** (plan-step / phase cuts are
+        skipped — ``record_plan_step_completed`` cuts intra-turn checkpoints, but an
+        edit must return to the prior *turn*) AND on ``seq``'s **lineage** (its branch
+        + ancestors back to the fork-point — so a forked branch's first turn resolves
+        to the parent's fork-point turn, not a same-branch-only miss).
+
+        ``None`` when there is no prior turn (``seq`` is the first turn = genesis):
+        the UX disables first-turn edit. Genesis-checkout is intentionally NOT
+        offered — there is no captured pre-turn-1 workspace version, so it would be
+        workspace-incoherent (coherent genesis = a future session-start capture).
+        """
+        if self._state_log is None:
+            return None
+        # Checkpoint seqs = generation boundaries across every known agent (all
+        # branches — the lineage walk may cross to a parent/ancestor branch).
+        cps: set[int] = set()
+        for name in self.list_names():
+            cps.update(self._store_for(name).seqs())
+        if not cps:
+            return None
+        # Turn-kind filter via the WAL entry kind at each boundary (one pass;
+        # reuses _rewind_point_kind for consistency with list_rewind_points — the
+        # audit EventStore is not consulted, WAL/audit stay decoupled).
+        turn_cps: list[int] = []
+        for entry in self._state_log.iter_from(1):
+            s = entry.get("seq")
+            if isinstance(s, int) and s in cps and _rewind_point_kind(entry.get("kind", "")) == "turn":
+                turn_cps.append(s)
+        return lineage_predecessor(self._state_log, turn_cps, seq)
 
     @property
     def workspace_store(self) -> WorkspaceVersionStore | None:

--- a/src/reyn/events/snapshot_generations.py
+++ b/src/reyn/events/snapshot_generations.py
@@ -254,6 +254,47 @@ def list_branches(state_log: StateLog) -> list[Branch]:
     return out
 
 
+def lineage_predecessor(
+    state_log: StateLog, candidates: "list[int]", target: int,
+) -> int | None:
+    """The greatest candidate seq strictly below ``target`` on ``target``'s lineage.
+
+    "Lineage" = ``target``'s branch + its ancestor branches back through each
+    fork-point (the active path one would see if checked out to ``target``). Walks
+    the derived branch tree (``parent_branch_id`` + ``fork_point_seq``), so when
+    ``target`` is the FIRST checkpoint on a forked branch the predecessor correctly
+    resolves to the PARENT branch's checkpoint at the fork-point — a same-branch-only
+    max would miss it (the over-include sibling trap, #1533 2c). ``None`` when no
+    ancestor candidate exists (e.g. ``target`` is the first checkpoint = genesis).
+
+    ``candidates`` is the caller-filtered set (e.g. turn-kind checkpoint seqs);
+    this function only resolves lineage ordering, staying kind-agnostic (P7).
+    """
+    cand = [int(c) for c in candidates]
+    if not cand:
+        return None
+    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    by_id = {b.branch_id: b for b in list_branches(state_log)}
+    cur: int | None = _branch_of_seq(int(target), abandoned)
+    cutoff = int(target)            # collect candidates strictly below this on `cur`
+    best: int | None = None
+    seen: set[int] = set()
+    while cur is not None and cur not in seen:
+        seen.add(cur)
+        for s in cand:
+            if s < cutoff and _branch_of_seq(s, abandoned) == cur:
+                if best is None or s > best:
+                    best = s
+        branch = by_id.get(cur)
+        if branch is None or branch.parent_branch_id is None:
+            break                   # reached the active root — done
+        # Jump to the parent at the fork-point: its checkpoints up to and including
+        # fork_point are `target`'s ancestors (anything after is a divergent line).
+        cutoff = branch.fork_point_seq + 1
+        cur = branch.parent_branch_id
+    return best
+
+
 async def checkout(
     state_log: StateLog, *, target_seq: int, supersedes: int | None = None,
 ) -> int:

--- a/tests/test_predecessor_turn_checkpoint_2c.py
+++ b/tests/test_predecessor_turn_checkpoint_2c.py
@@ -1,0 +1,141 @@
+"""Tier 2: OS invariant — lineage-correct turn-checkpoint predecessor (#1533 2c).
+
+The 2c edit flow re-runs an edited turn from the state *before* it: checkout the
+turn's predecessor, then submit the edit (a new fork). The predecessor must be
+the immediately-prior **TURN** checkpoint along the target's **lineage** (its
+branch + ancestor branches back to the fork-point) — two subtleties:
+
+  - **turn-kind only**: `record_plan_step_completed` cuts intra-turn plan-step
+    checkpoints; a plan-bearing turn's naive predecessor would be a mid-turn
+    plan-step. Edit must return to the prior *turn*, so plan-step/phase are skipped.
+  - **lineage, not same-branch-max**: when the target is the FIRST checkpoint on a
+    forked branch, its predecessor is on the PARENT branch at the fork-point — a
+    same-branch-only max would miss it (the over-include sibling trap). Computed
+    from the branch-registry (parent_branch_id + fork_point chain), substrate-side.
+
+First turn (no prior turn) → None → UX disables edit (genesis = (b): no pre-turn-1
+workspace capture, so genesis-checkout would be workspace-incoherent).
+
+Real AgentRegistry + StateLog + generation stores (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.snapshot_generations import rewind
+from reyn.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+async def _turn_cp(reg: AgentRegistry, text: str) -> int:
+    """A TURN-kind checkpoint: a WAL entry whose kind maps to 'turn' + a gen."""
+    seq = await reg.state_log.append(
+        "inbox_consume", target="alpha", msg_id=text, msg_kind="user", payload={},
+    )
+    return _record_gen(reg, seq)
+
+
+async def _plan_step_cp(reg: AgentRegistry) -> int:
+    """A PLAN-STEP-kind checkpoint (must be skipped by predecessor_turn_checkpoint)."""
+    seq = await reg.state_log.append(
+        "plan_step_completed", target="alpha", payload={},
+    )
+    return _record_gen(reg, seq)
+
+
+def _record_gen(reg: AgentRegistry, seq: int) -> int:
+    snap = AgentSnapshot.empty("alpha")
+    snap.applied_seq = seq
+    reg._store_for("alpha").record(snap)
+    return seq
+
+
+# ── turn-kind filter ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_predecessor_skips_plan_step_to_prior_turn(tmp_path):
+    """Tier 2: a plan-step checkpoint between two turns is skipped — predecessor = prior TURN."""
+    reg = _make_registry(tmp_path)
+    t1 = await _turn_cp(reg, "turn1")
+    await _plan_step_cp(reg)                 # intra-turn plan-step (must be skipped)
+    t2 = await _turn_cp(reg, "turn2")
+
+    assert reg.predecessor_turn_checkpoint(t2) == t1   # NOT the plan-step between them
+
+
+@pytest.mark.asyncio
+async def test_predecessor_linear_prior_turn(tmp_path):
+    """Tier 2: linear history — predecessor is the immediately-prior turn checkpoint."""
+    reg = _make_registry(tmp_path)
+    t1 = await _turn_cp(reg, "t1")
+    t2 = await _turn_cp(reg, "t2")
+    t3 = await _turn_cp(reg, "t3")
+
+    assert reg.predecessor_turn_checkpoint(t3) == t2
+    assert reg.predecessor_turn_checkpoint(t2) == t1
+
+
+# ── first turn → None (genesis = (b)) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_turn_has_no_predecessor(tmp_path):
+    """Tier 2: the first turn has no prior turn → None (UX disables first-turn edit)."""
+    reg = _make_registry(tmp_path)
+    t1 = await _turn_cp(reg, "only")
+    assert reg.predecessor_turn_checkpoint(t1) is None
+
+
+@pytest.mark.asyncio
+async def test_first_turn_none_even_with_leading_plan_step(tmp_path):
+    """Tier 2: a plan-step before the first turn is not a turn predecessor → still None."""
+    reg = _make_registry(tmp_path)
+    await _plan_step_cp(reg)                  # not a turn
+    t1 = await _turn_cp(reg, "first-turn")
+    assert reg.predecessor_turn_checkpoint(t1) is None
+
+
+# ── lineage: cross-fork-point ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_fork_point_predecessor_is_parent_fork_point_turn(tmp_path):
+    """Tier 2: a dead-branch's first turn → predecessor is the PARENT branch's fork-point turn.
+
+    Active turns t1,t2,t3; rewind to t2 (abandons t3's branch — t3 becomes a dead
+    branch forked at t2). predecessor_turn_checkpoint(t3) must walk the lineage to
+    the parent and return t2 (the fork-point turn), NOT a same-branch-only None.
+    """
+    reg = _make_registry(tmp_path)
+    t1 = await _turn_cp(reg, "t1")
+    t2 = await _turn_cp(reg, "t2")
+    t3 = await _turn_cp(reg, "t3")           # will be abandoned by the rewind to t2
+    await rewind(reg.state_log, target_n=t2)  # t3 now on a dead branch forked at t2
+
+    # t3 is the first (only) turn on the dead branch → predecessor = parent fork-point turn t2.
+    assert reg.predecessor_turn_checkpoint(t3) == t2
+    # sanity: t2's own predecessor is still t1 (active lineage).
+    assert reg.predecessor_turn_checkpoint(t2) == t1
+
+
+@pytest.mark.asyncio
+async def test_empty_or_no_state_log_returns_none(tmp_path):
+    """Tier 2: no checkpoints → None (slot-in-unconditionally for the UX gate)."""
+    reg = _make_registry(tmp_path)
+    assert reg.predecessor_turn_checkpoint(5) is None


### PR DESCRIPTION
**[dogfood-coder]** — the last 2c substrate dependency (e2e flow-trace catch + tui-coder turn-kind refinement; 3-coder + lead converged). Small additive, off main (#1565 merged). Opening for review.

## What

The 2c edit flow re-runs an edited turn from the state before it: `checkout(predecessor)` → submit the edit (a new fork). `registry.predecessor_turn_checkpoint(seq) -> int | None` returns the immediately-prior checkpoint that is:

- **turn-kind only** — `record_plan_step_completed` cuts intra-turn plan-step checkpoints; a plan-bearing turn's naive predecessor would be a mid-turn plan-step, but edit must return to the prior **turn**. plan-step/phase skipped (reuses `_rewind_point_kind`, consistent with `list_rewind_points`).
- **lineage-correct** — when the target is the FIRST checkpoint on a forked branch, its predecessor is on the **parent** branch at the fork-point; a same-branch-only max would miss it (the over-include sibling trap). Computed from the branch tree (`parent_branch_id` + `fork_point` chain), substrate-side, so the UX never re-derives lineage.

`snapshot_generations.lineage_predecessor(state_log, candidates, target)` = pure lineage walk (kind-agnostic, P7); the registry method filters to turn-kind + delegates.

## Genesis = (b) (3-coder + lead concur)

First turn → **None** → UX disables first-turn edit (tui gates ctrl+e off on None; e2e rejects gracefully). **Not** a genesis-checkout sentinel: there's no captured pre-turn-1 workspace version (captures are at turn boundaries seq≥1), so genesis-checkout would reset runtime to empty but leave the workspace incoherent = half-correct fork. `checkout(0)` already raises `RewindBeyondRetentionError`; the UX gates on None before calling checkout. Coherent genesis (session-start capture) = future, sibling of #1560. **Retention guard untouched.**

## Test plan

`tests/test_predecessor_turn_checkpoint_2c.py` (Tier 2, real AgentRegistry + StateLog + gen stores):

- [x] **plan-step between two turns skipped** → predecessor = prior TURN (tui's catch)
- [x] linear prior-turn; first turn → None (+ leading plan-step still None)
- [x] **cross-fork-point** → parent's fork-point turn (lineage walk, not same-branch miss)
- [x] empty → None
- [x] `python -m pytest ... -W error::RuntimeWarning` → 6 passed
- [x] tier-audit clean; ruff clean
- [x] 515 adjacent branch/rewind/checkout/snapshot/anchor/registry tests pass

With this + `get_full` (#1565, merged), both 2c substrate deps are landed → e2e's cohesive 2c build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)