### PR TITLE
fix(feature-map): fix mermaid mindmap breakage from (seq) node syntax

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -48,7 +48,7 @@ mindmap
         /rewind picker
         Consistent-cut rewind
         Branch registry
-        checkout(seq) primitive
+        checkout-seq primitive
         Multi-fork UX
         Live-fork gate
       📜 Event System P6


### PR DESCRIPTION
**[docs-maintainer]** — Hotfix for #1566 regression reported by owner.

## Problem

`checkout(seq) primitive` in the mindmap block uses `(seq)` which mermaid interprets as a rounded-node shape specifier, causing a parse error and breaking the Visual overview render.

## Fix

`checkout(seq) primitive` → `checkout-seq primitive` (mindmap node only)

The feature index table row retains `checkout(seq)` — tables are not mermaid syntax.

Checked all other mindmap lines for parentheses: only `root((Reyn<br/>Agent OS))` remains, which is the intentional circle syntax.

## Test plan

- [x] Only `root((Reyn...))` has brackets in the mindmap (grep verified)
- [x] Feature index table unchanged — `checkout(seq)` preserved there
- [x] Page drop: zero (one word changed in mindmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)