### PR TITLE
docs(time-travel): concept + architecture + how-to guide (#1533)

### DIFF
--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -74,7 +74,7 @@ All WAL events share a **global single sequence namespace**. A consistent-cut re
 
 ### Append-only reset-record and branch state
 
-When rewind commits, a **reset-record** is written to the WAL at the target seq. The branch registry derives branch state from this chain: a seq between a reset-record at R and the next reset-record (or current tip) belongs to the interval `[R, next_R)`. Abandoned intervals — seqs that were reachable before a rewind but are now beyond the current tip — form the inactive branches in the branch tree.
+When rewind commits, a **reset-record** is appended to the WAL at its own new seq **R** (distinct from the rewind target **N**). The record carries `target_n=N`. The open interval `(N, R)` — seqs that existed between the rewind target and the reset-record itself — is marked **abandoned** (dead-branch id=R). Active seqs are the complement: every seq not in any abandoned interval on the current branch chain. The branch registry derives branch state from the chain of reset-records: each record's `target_n` and `id=R` define one abandoned interval.
 
 ### Branch registry
 
@@ -82,12 +82,14 @@ The branch registry tracks all fork lineages: when a fork-switch creates a new b
 
 ### checkout primitive
 
-`checkout(seq)` is the unified primitive:
+`checkout(seq)` is the **core primitive** for all rewind and fork-switch operations. `rewind_to` is a thin wrapper that adds an `is_active` guard around `checkout`.
 
-- If seq is on the **active branch** (seq ≤ current tip): undo — rewinds the active branch to seq.
-- If seq is on an **inactive branch** (in an abandoned interval): fork-switch — activates that branch at seq, leaving the current branch as a new abandoned interval.
+- If `is_active_seq(seq)` is true: undo — rewinds the current branch to seq.
+- If `is_active_seq(seq)` is false (seq is in an abandoned interval): fork-switch — activates the abandoned branch at seq, leaving the current branch tip as a new abandoned interval.
 
-The implementation uses the `rewind_to` path with a minus-guard to prevent rewinding past the branch's own origin.
+`is_active_seq` is **not** equivalent to `seq ≤ tip` — a seq can be ≤ the current tip but still be in an abandoned interval from a prior rewind. Activeness is derived from the reset-record chain, not from position relative to tip.
+
+At rewind and fork-switch, both the runtime reconstruct and the workspace restore honor `is_active` (following the correct fork-lineage path for the target branch).
 
 ### Shadow-git workspace versioning
 

--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -1,0 +1,145 @@
+---
+type: concept
+topic: architecture
+audience: [human, agent]
+---
+
+# Time-Travel: Rewind and Resume
+
+Reyn's time-travel system lets you rewind the agent to any past checkpoint and
+optionally branch from there. It is a separate feature from [crash recovery](../../concepts/skills/skill-resume.md) — the two use different mechanisms and serve different purposes.
+
+> **Crash recovery** (`ReplayEngine` / WAL) automatically restores the agent after an unexpected failure — it is transparent to the user and replays forward to where the run stopped. **Time-travel** is an intentional, user-initiated rewind to an earlier point, with the option to fork a new branch of history.
+
+## Concepts
+
+### Checkpoints
+
+A checkpoint marks a boundary between agent states. Reyn creates checkpoints at:
+
+- **Turn boundaries** — after the LLM finishes its response turn.
+- **Plan-step boundaries** — after each plan step completes.
+- **Phase boundaries** — after each OS phase transition within a skill run.
+
+Each checkpoint has a monotonically increasing **sequence number** (seq). The seq is the global clock used to address all time-travel operations.
+
+### Rewind
+
+`/rewind` rewinds the agent to a past checkpoint. Both substrates are rewound atomically:
+
+1. **Runtime substrate** — the agent's conversation state and skill-run execution memo are restored to the snapshot at the target seq.
+2. **Workspace substrate** — the workspace files are restored to the shadow-git `as-of-N` state at that seq.
+
+The rewind is **atomic**: either both substrates revert or neither does. There is no intermediate state where the conversation is at seq K while the files are at seq K+5.
+
+### Append-only history
+
+Reyn never rewrites history. When you rewind to seq R:
+
+- A **reset-record** is appended at seq R on the current branch, marking it as the new tip.
+- The commit history before R is preserved.
+- Conversation turns and workspace states beyond R become **abandoned** on the current branch — they are accessible via the branch tree, not erased.
+
+This means rewind is always recoverable: you can navigate back to an abandoned future by switching branches.
+
+### Branching
+
+After a rewind you can fork from that point instead of overwriting the current branch:
+
+- **Undo (active-branch checkout)** — rewinding within the current branch; the branch timeline moves back to seq R.
+- **Fork-switch (inactive-branch checkout)** — switching to an existing abandoned branch at a different seq. The branch registry tracks all branches by lineage.
+
+The `checkout(seq)` primitive implements both: if the target seq is on the active branch it is an undo; if it is on an abandoned branch it is a fork-switch.
+
+### Act-turn rewind
+
+For finer granularity, within a live skill run you can rewind to an **act-turn boundary** (a step within the current turn) without touching the workspace. This is a runtime-only operation using the Ghost-Replay mechanism: the committed-step memo is truncated at the target seq, and on relaunch steps before the target replay as ghosts (0 tokens, recorded results replayed), while steps after the target re-execute. The workspace reflects the last boundary generation, not mid-step file state.
+
+---
+
+## Architecture
+
+### PITR snapshot and WAL-diff reconstruct
+
+Each checkpoint stores an **AgentSnapshot** — a point-in-time snapshot of the agent's conversation state (inbox, message history, plan state). At rewind time:
+
+1. The snapshot at or before the target seq is located.
+2. The WAL (`StateLog`, `.reyn/state/wal.jsonl`) events between the snapshot and the target seq are applied as a diff — replaying only the delta, not the full history.
+
+The WAL is a **synchronous-durability log** (fsync'd per append), separate from the P6 audit event log. See [Events](events.md) for the WAL vs audit-event distinction.
+
+### Global single-seq WAL and consistent-cut
+
+All WAL events share a **global single sequence namespace**. A consistent-cut rewind at seq N is well-defined: "the state of every substrate at the moment before seq N+1 was written". The global seq makes the cut precise — there is no per-substrate clock to reconcile.
+
+### Append-only reset-record and branch state
+
+When rewind commits, a **reset-record** is written to the WAL at the target seq. The branch registry derives branch state from this chain: a seq between a reset-record at R and the next reset-record (or current tip) belongs to the interval `[R, next_R)`. Abandoned intervals — seqs that were reachable before a rewind but are now beyond the current tip — form the inactive branches in the branch tree.
+
+### Branch registry
+
+The branch registry tracks all fork lineages: when a fork-switch creates a new branch from an abandoned interval, the registry records the origin seq and the new branch identity. The picker UI reads from the registry to render the tree view.
+
+### checkout primitive
+
+`checkout(seq)` is the unified primitive:
+
+- If seq is on the **active branch** (seq ≤ current tip): undo — rewinds the active branch to seq.
+- If seq is on an **inactive branch** (in an abandoned interval): fork-switch — activates that branch at seq, leaving the current branch as a new abandoned interval.
+
+The implementation uses the `rewind_to` path with a minus-guard to prevent rewinding past the branch's own origin.
+
+### Shadow-git workspace versioning
+
+The workspace substrate uses a **shadow git repository** for content-addressed versioning. At each boundary seq, the current file tree is committed as a shadow-git generation. Rewinding to seq N restores the workspace to the shadow-git commit corresponding to the largest generation ≤ N. This makes workspace rewind O(changed files) rather than a full replay of all file operations.
+
+Container-mode: when the container environment backend is active, the shadow-git `as-of-N` restore operates inside the container filesystem.
+
+### Act-turn Ghost-Replay
+
+Act-turn rewind (intra-turn granularity) uses `SkillResumeCoordinator.plan_for_act_turn_rewind`: the `SkillResumeAnalyzer` builds the full `ResumePlan`, then `committed_steps` are filtered to `seq ≤ target_seq`. On relaunch via `OSRuntime.run(resume_plan=...)`, steps in the memo replay as ghosts (0 LLM tokens); steps beyond the cutoff re-execute. This reuses the existing crash-resume dispatch path — no new runtime wiring.
+
+### 2-substrate generation at boundary seq
+
+At every checkpoint boundary, Reyn generates a **paired generation**:
+
+```
+AgentSnapshot  (runtime substrate)
+    ⊗
+shadow-git commit  (workspace substrate)
+    at  boundary seq N
+```
+
+This pair is the unit that `checkout(seq)` restores atomically. The pairing is by seq: the snapshot and the shadow-git commit carry the same seq tag, so rewind can locate both with one lookup.
+
+### WAL vs audit-event separation
+
+The WAL (`StateLog`, `.reyn/state/wal.jsonl`) and the P6 audit event log (`EventStore`, `.reyn/events/<run_id>.jsonl`) are **separate logs with different contracts**:
+
+| | WAL (StateLog) | Audit log (EventStore) |
+|--|--|--|
+| Purpose | Crash recovery and time-travel reconstruct | Audit trail and replay |
+| Durability | fsync per append (synchronous) | Rotation-based (not per-append fsync) |
+| Lifecycle | Truncatable after snapshot | Append-only, rotation-based |
+| Unification | **Prohibited** — sync durability requirements differ | — |
+
+Do not conflate or merge the two logs. See [Events](events.md) for details.
+
+---
+
+## Relationship to crash recovery
+
+| | Crash recovery | Time-travel |
+|--|--|--|
+| Trigger | Automatic on unexpected failure | User-initiated (`/rewind`) |
+| Direction | Forward-replay to resume | Backward to a past checkpoint |
+| Workspace | Not rewound | Rewound to as-of-N |
+| Branching | None | Fork / branch tree |
+| Mechanism | `SkillResumeAnalyzer` + WAL forward-replay | PITR snapshot + WAL-diff + shadow-git |
+| Design | [ADR-0002](../../deep-dives/decisions/) | [ADR-0038 draft](https://github.com/tya5/reyn/pull/1536) |
+
+## See also
+
+- [Crash Recovery / Skill Resume](../../concepts/skills/skill-resume.md)
+- [Events and the WAL](events.md)
+- [How to use rewind](../../guide/for-users/time-travel.md)

--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -34,11 +34,11 @@ The rewind is **atomic**: either both substrates revert or neither does. There i
 
 ### Append-only history
 
-Reyn never rewrites history. When you rewind to seq R:
+Reyn never rewrites history. When you rewind to a past checkpoint (seq **N**):
 
-- A **reset-record** is appended at seq R on the current branch, marking it as the new tip.
-- The commit history before R is preserved.
-- Conversation turns and workspace states beyond R become **abandoned** on the current branch — they are accessible via the branch tree, not erased.
+- A reset-record is appended at a **new seq R** (beyond the current tip) carrying target **N**; that record becomes the new tip, and the agent state is restored **as-of-N**.
+- History before N is preserved.
+- Turns and workspace states in **`(N, R)`** become **abandoned** on the current branch — reachable via the branch tree, not erased.
 
 This means rewind is always recoverable: you can navigate back to an abandoned future by switching branches.
 

--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -136,7 +136,7 @@ Do not conflate or merge the two logs. See [Events](events.md) for details.
 | Workspace | Not rewound | Rewound to as-of-N |
 | Branching | None | Fork / branch tree |
 | Mechanism | `SkillResumeAnalyzer` + WAL forward-replay | PITR snapshot + WAL-diff + shadow-git |
-| Design | [ADR-0002](../../deep-dives/decisions/) | [ADR-0038 draft](https://github.com/tya5/reyn/pull/1536) |
+| Design | [ADR-0002](../../deep-dives/decisions/0002-forward-replay-resume.md) | [ADR-0038 draft](https://github.com/tya5/reyn/pull/1536) |
 
 ## See also
 

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -275,7 +275,7 @@ User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b) are
 | Deterministic CI rewind gate | `test_live_rewind_gate.py` — Phase-1 rewind deterministic gate (#1553) | — |
 | Deterministic CI live-fork gate | `test_live_fork_gate.py` — Phase-2 fork / checkout deterministic gate (#1564) | — |
 | tmux live e2e | P1 undo + P2 fork-switch verified on real terminal (#1533 tui-coder ledger / #1549) | — |
-| Phase 2c: fork-then-edit ⏳ | New branch on edit (in-progress) | — |
+| Phase 2c: fork-then-edit | New branch on edit via `ctrl+t` | [How-to: rewind](guide/for-users/time-travel.md) |
 | Phase 2d: web surface ⏳ | `/rewind` picker over WebSocket / A2A (in-progress) | — |
 
 #### Event System (P6)

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -257,7 +257,7 @@ mindmap
 
 #### Time-Travel / Rewind (Resume)
 
-User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b) are production; Phase 2c (fork-then-edit) and 2d (web surface) are in-progress. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: ADR-0038 (PR #1536, pending merge). Change ledger: #1533.
+User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c) are production; Phase 2d (web surface) is in-progress. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: ADR-0038 (PR #1536, pending merge). Change ledger: #1533.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -261,17 +261,17 @@ User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b) are
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
-| `/rewind` picker | Interactive checkpoint timeline (seq / timestamp / kind columns); Esc-Esc double-tap shortcut | — |
-| Per-checkpoint anchor preview | Each picker row shows a rendered scroll-hint anchor (#1547) | — |
-| PITR reconstruct | Point-in-time snapshot + WAL-diff reconstruction to target seq | [Crash Recovery](concepts/skills/skill-resume.md) |
-| Consistent-cut rewind | Both substrates (runtime state + workspace shadow-git `as-of-N`) rewound atomically | — |
-| Append-only reset-record | Undo appends a reset-record at seq R; history before R is preserved on the current branch (no destructive rewrite) | — |
-| Retention window + GC | Configurable checkpoint retention window; stale snapshots GC'd automatically | — |
-| Branch registry | Abandoned-interval lineage: each fork receives a registry entry with origin seq | — |
-| `checkout(seq)` unified primitive | Active-branch seq → undo; inactive-branch seq → fork-switch. One primitive for both directions | — |
-| Multi-fork tree UX | Always-tree picker with per-branch anchor labels (#1547 integration) | — |
-| Act-turn runtime-only rewind | Ghost-Replay memo truncate for rewind within an in-flight turn (no substrate round-trip) | — |
-| Container-mode shadow-git | Shadow-git `as-of-N` rewind supported inside the container environment backend | — |
+| `/rewind` picker | Interactive checkpoint timeline (seq / timestamp / kind columns); Esc-Esc double-tap shortcut | [How-to: rewind](guide/for-users/time-travel.md) |
+| Per-checkpoint anchor preview | Each picker row shows a rendered scroll-hint anchor (#1547) | [How-to: rewind](guide/for-users/time-travel.md) |
+| PITR reconstruct | Point-in-time snapshot + WAL-diff reconstruction to target seq | [Time-Travel concepts](concepts/runtime/time-travel.md) · [Crash Recovery](concepts/skills/skill-resume.md) |
+| Consistent-cut rewind | Both substrates (runtime state + workspace shadow-git `as-of-N`) rewound atomically | [Time-Travel concepts](concepts/runtime/time-travel.md) |
+| Append-only reset-record | Undo appends a reset-record at seq R; history before R is preserved on the current branch (no destructive rewrite) | [Time-Travel concepts](concepts/runtime/time-travel.md) |
+| Retention window + GC | Configurable checkpoint retention window; stale snapshots GC'd automatically | [How-to: rewind](guide/for-users/time-travel.md) |
+| Branch registry | Abandoned-interval lineage: each fork receives a registry entry with origin seq | [Time-Travel concepts](concepts/runtime/time-travel.md) |
+| `checkout(seq)` unified primitive | Active-branch seq → undo; inactive-branch seq → fork-switch. One primitive for both directions | [Time-Travel concepts](concepts/runtime/time-travel.md) |
+| Multi-fork tree UX | Always-tree picker with per-branch anchor labels (#1547 integration) | [How-to: rewind](guide/for-users/time-travel.md) |
+| Act-turn runtime-only rewind | Ghost-Replay memo truncate for rewind within an in-flight turn (no substrate round-trip) | [Time-Travel concepts](concepts/runtime/time-travel.md) |
+| Container-mode shadow-git | Shadow-git `as-of-N` rewind supported inside the container environment backend | [How-to: rewind](guide/for-users/time-travel.md) |
 | Deterministic CI rewind gate | `test_live_rewind_gate.py` — Phase-1 rewind deterministic gate (#1553) | — |
 | Deterministic CI live-fork gate | `test_live_fork_gate.py` — Phase-2 fork / checkout deterministic gate (#1564) | — |
 | tmux live e2e | P1 undo + P2 fork-switch verified on real terminal (#1533 tui-coder ledger / #1549) | — |

--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -1,0 +1,77 @@
+---
+type: guide
+topic: time-travel
+audience: [human]
+---
+
+# How to rewind and branch
+
+Reyn's time-travel lets you rewind to a past checkpoint and optionally branch
+from that point. This guide covers the available commands and UI.
+
+For how it works under the hood, see [Time-Travel concepts](../../concepts/runtime/time-travel.md).
+
+## Open the rewind picker
+
+```
+/rewind
+```
+
+This opens an interactive checkpoint timeline in the TUI. Each row shows:
+
+| Column | Description |
+|--------|-------------|
+| seq | Global sequence number of the checkpoint |
+| time | Timestamp when the checkpoint was created |
+| kind | Boundary type: `turn` / `plan-step` / `phase` |
+
+Navigate with **↑ / ↓**, select with **Enter**. Press **Esc** to close without rewinding.
+
+**Shortcut**: double-tap **Esc Esc** from anywhere in the TUI to open the picker directly.
+
+## Rewind to a specific seq
+
+```
+/rewind <N>
+```
+
+Rewinds directly to seq N without opening the picker. Both the conversation state and workspace files are restored to their state at seq N.
+
+## Navigate the branch tree
+
+After any rewind or fork, the picker switches to a **tree view** showing all branches. Each branch is labeled with its anchor checkpoint. Use ↑ / ↓ + Enter to select a checkpoint on any branch — active or abandoned.
+
+- Selecting a seq on the **current branch**: undo (rewinds the current branch).
+- Selecting a seq on an **inactive branch**: fork-switch (activates that branch).
+
+## Configuration
+
+### Retention window
+
+By default Reyn retains all checkpoints. To limit retention:
+
+```yaml
+# reyn.yaml
+skill_resume:
+  checkpoint_retention_turns: 50   # keep the last N turn boundaries
+```
+
+Checkpoints older than the retention window are GC'd automatically. Adjust based on your storage budget.
+
+## Container mode
+
+When using the container environment backend (`--container`), the workspace
+rewind operates on the container filesystem via shadow-git `as-of-N` — the same
+user experience applies; the substrate is container-side.
+
+## Pending features
+
+| Feature | Status |
+|---------|--------|
+| `/rewind` with in-turn edit (`ctrl+e` / `ctrl+t`) to create a new fork-and-edit branch | ⏳ Phase 2c, in-progress |
+| `/rewind` picker over WebSocket / A2A web surface | ⏳ Phase 2d, in-progress |
+
+## See also
+
+- [Time-Travel concepts and architecture](../../concepts/runtime/time-travel.md)
+- [Crash recovery and skill resume](../../concepts/skills/skill-resume.md) — different from rewind; automatic, forward-only

--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -54,7 +54,7 @@ user experience applies; the substrate is container-side.
 
 | Feature | Status |
 |---------|--------|
-| `/rewind` with in-turn edit (`ctrl+t` / F-key) to create a new fork-and-edit branch | ⏳ Phase 2c, in-progress |
+| `/rewind` with in-turn edit (`ctrl+t`) to create a new fork-and-edit branch | ✅ Phase 2c, landed |
 | Retention window config (`retention: keep_generations: N`) to GC old checkpoints | ⏳ ADR-0038 Stage 1e — designed, not yet wired |
 | `/rewind` picker over WebSocket / A2A web surface | ⏳ Phase 2d, in-progress |
 

--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -44,20 +44,6 @@ After any rewind or fork, the picker switches to a **tree view** showing all bra
 - Selecting a seq on the **current branch**: undo (rewinds the current branch).
 - Selecting a seq on an **inactive branch**: fork-switch (activates that branch).
 
-## Configuration
-
-### Retention window
-
-By default Reyn retains all checkpoints. To limit retention:
-
-```yaml
-# reyn.yaml
-skill_resume:
-  checkpoint_retention_turns: 50   # keep the last N turn boundaries
-```
-
-Checkpoints older than the retention window are GC'd automatically. Adjust based on your storage budget.
-
 ## Container mode
 
 When using the container environment backend (`--container`), the workspace
@@ -68,7 +54,8 @@ user experience applies; the substrate is container-side.
 
 | Feature | Status |
 |---------|--------|
-| `/rewind` with in-turn edit (`ctrl+e` / `ctrl+t`) to create a new fork-and-edit branch | ⏳ Phase 2c, in-progress |
+| `/rewind` with in-turn edit (`ctrl+t` / F-key) to create a new fork-and-edit branch | ⏳ Phase 2c, in-progress |
+| Retention window config (`retention: keep_generations: N`) to GC old checkpoints | ⏳ ADR-0038 Stage 1e — designed, not yet wired |
 | `/rewind` picker over WebSocket / A2A web surface | ⏳ Phase 2d, in-progress |
 
 ## See also

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
           - guide/for-users/index.md
           - Using Reyn:
               - guide/for-users/chat-and-web-ui.md
+              - guide/for-users/time-travel.md
               - guide/for-users/manage-permissions.md
               - guide/for-users/configure-sandbox.md
               - guide/for-users/ask-user-mid-phase.md
@@ -221,6 +222,7 @@ nav:
       - Runtime:
           - concepts/runtime/workspace.md
           - concepts/runtime/events.md
+          - concepts/runtime/time-travel.md
           - concepts/runtime/permission-model.md
           - concepts/runtime/sandbox.md
           - concepts/runtime/secret-handling.md


### PR DESCRIPTION
**[docs-maintainer]** — Time-travel doc suite, per lead-coder dispatch.

## Summary

- `docs/concepts/runtime/time-travel.md` — concept (what it is: checkpoints, rewind, append-only history, branching) + architecture (PITR reconstruct, WAL-diff, global single-seq, reset-record, branch registry, checkout primitive, shadow-git, act-turn Ghost-Replay, WAL vs audit-event separation, 2-substrate generation)
- `docs/guide/for-users/time-travel.md` — how-to (/rewind, /rewind N, branch tree, retention config, container mode, pending features table)
- `mkdocs.yml` — nav entries added under Runtime concepts + Using Reyn guide
- `docs/feature-map.md` — Time-Travel rows linked to new docs (replacing `—`)

## Accuracy review needed (sandbox_2 + lead-coder)

- Architecture section: ADR-0038 (PR #1536, pending merge) is the canonical source. Please verify: PITR snapshot / AgentSnapshot structure, shadow-git content-address scheme, branch registry lineage derivation, checkout minus-guard, `plan_for_act_turn_rewind` seam.
- `skill_resume.checkpoint_retention_turns` config key in how-to guide — verify this is the actual config path or correct to the real key.
- crash-recovery vs time-travel distinction table — verify ADR-0002 citation is correct doc location.

## Test plan

- [x] `mkdocs build --strict` — new nav entries resolve, no broken links (internal cross-refs use relative paths)
- [x] No mermaid added in these docs (no bracket-node render risk per [[feedback_mermaid_render_check_on_doc_pr]])
- [x] feature-map links resolve to new files ✅
- [x] Page drop: zero (additions only)
- [ ] Accuracy review: lead-coder deep-review + sandbox_2 substrate-author review

🤖 Generated with [Claude Code](https://claude.com/claude-code)