### PR TITLE
feat(1533/2c): edit-and-retry — ctrl+t edit-mode + new-fork submit (co-authored)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2664,6 +2664,32 @@ class ReynTUIApp(App):
                 ),
             ))
 
+    def _prefill_edit(self, seq: int) -> None:
+        """Load checkpoint ``seq``'s FULL user message into the InputBar (2c).
+
+        The data-flow's pre-fill — the co-impl seam ``action_edit_checkpoint``
+        calls via ``getattr``. Fetches the full original message from the
+        AnchorStore (``get_full`` — NOT the truncated display anchor, so the
+        edited re-run preserves the whole message; #1533) and replaces the
+        InputBar buffer. Best-effort: no message / no registry / no store →
+        no-op (the edit-mode flag + banner are set by ``enter_edit_mode``
+        regardless; only the text population is conditional).
+        """
+        registry = self._agent_registry
+        store = getattr(registry, "anchor_store", None) if registry is not None else None
+        if store is None:
+            return
+        try:
+            full = store.get_full(seq)
+        except Exception:
+            return
+        if not full:
+            return
+        try:
+            self.query_one("#inputbar", InputBar).set_text(full)
+        except Exception:
+            pass
+
     def _voice_config(self):
         """Best-effort fetch of the user's voice config block."""
         try:

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -139,13 +139,16 @@ class ReynTUIApp(App):
         Binding("up", "rewind_prev", "Rewind: prev checkpoint", priority=True, show=False),
         Binding("down", "rewind_next", "Rewind: next checkpoint", priority=True, show=False),
         Binding("enter", "rewind_confirm", "Rewind: select checkpoint", priority=True, show=False),
-        # ADR-0038 2c: edit the selected checkpoint's input. ``ctrl+e`` (not bare
-        # ``e``): the picker is can_focus=False so the InputBar is always focused
-        # and SWALLOWS printable keys before any app priority binding — only
-        # non-printable chords (like the ↑/↓/Enter nav above) reach the app
-        # binding. Gated (check_action) to fire only while the picker is open AND
-        # not already editing.
-        Binding("ctrl+e", "edit_checkpoint", "Rewind: edit checkpoint input", priority=True, show=False),
+        # ADR-0038 2c: edit the selected checkpoint's input. ``ctrl+t`` — NOT bare
+        # ``e`` (the can_focus=False picker keeps the InputBar focused, which
+        # swallows printable keys), and NOT ``ctrl+e`` (the focused Textual
+        # TextArea binds ctrl+e → cursor_line_end and consumes it in a real
+        # terminal — verified in tmux that ctrl+e never reaches this binding,
+        # though run_test gave a false positive). ``ctrl+t`` is unbound by the
+        # TextArea / InputBar / App, so the app priority binding wins (same as the
+        # ctrl+b panel binding). Gated (check_action) to fire only while the
+        # picker is open AND not already editing.
+        Binding("ctrl+t", "edit_checkpoint", "Rewind: edit checkpoint input", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
         # Wave-4 AR5: keyboard scroll for the conv log. RichLog has
         # ``can_focus=False`` (intentional — prevents inadvertent
@@ -2552,12 +2555,12 @@ class ReynTUIApp(App):
     _EDIT_BANNER = "✎ editing checkpoint #{seq} — Enter to fork · Esc to cancel"
 
     def action_edit_checkpoint(self) -> None:
-        """``ctrl+e`` while the picker is open — edit the highlighted checkpoint.
+        """``ctrl+t`` while the picker is open — edit the highlighted checkpoint.
 
         Enters edit-mode on the selected checkpoint's seq, then hands off to the
         2c data-flow's pre-fill (loads the FULL user message of that turn into
         the InputBar). Gated by ``check_action`` to fire only while the picker is
-        open AND not already editing; otherwise the binding is inert (``ctrl+e``
+        open AND not already editing; otherwise the binding is inert (``ctrl+t``
         is non-printable, so nothing is typed when it doesn't fire).
         """
         menu = self._rewind_menu
@@ -2723,9 +2726,9 @@ class ReynTUIApp(App):
             except Exception:
                 return False
         if action in {"rewind_prev", "rewind_next", "rewind_confirm", "edit_checkpoint"}:
-            # ADR-0038 1f: navigation keys (+ 2c's ``ctrl+e`` edit) are live only
+            # ADR-0038 1f: navigation keys (+ 2c's ``ctrl+t`` edit) are live only
             # while the /rewind picker is mounted. Otherwise ↑/↓/Enter fall
-            # through to the InputBar (history / submit); ``ctrl+e`` is inert.
+            # through to the InputBar (history / submit); ``ctrl+t`` is inert.
             #
             # ADR-0038 2c: ...AND not while editing. During edit-mode the picker
             # stays mounted but its nav is suspended so ↑/↓/Enter reach the

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -139,6 +139,13 @@ class ReynTUIApp(App):
         Binding("up", "rewind_prev", "Rewind: prev checkpoint", priority=True, show=False),
         Binding("down", "rewind_next", "Rewind: next checkpoint", priority=True, show=False),
         Binding("enter", "rewind_confirm", "Rewind: select checkpoint", priority=True, show=False),
+        # ADR-0038 2c: edit the selected checkpoint's input. ``ctrl+e`` (not bare
+        # ``e``): the picker is can_focus=False so the InputBar is always focused
+        # and SWALLOWS printable keys before any app priority binding — only
+        # non-printable chords (like the ↑/↓/Enter nav above) reach the app
+        # binding. Gated (check_action) to fire only while the picker is open AND
+        # not already editing.
+        Binding("ctrl+e", "edit_checkpoint", "Rewind: edit checkpoint input", priority=True, show=False),
         Binding("ctrl+backslash", "screenshot", "Screenshot", priority=True, show=False),
         # Wave-4 AR5: keyboard scroll for the conv log. RichLog has
         # ``can_focus=False`` (intentional — prevents inadvertent
@@ -245,6 +252,12 @@ class ReynTUIApp(App):
         # open, else None. Navigation (↑/↓/Enter) + Esc dismiss are gated on
         # this being non-None via check_action.
         self._rewind_menu = None  # type: ignore[assignment]
+        # ADR-0038 2c: the checkpoint seq being edited while the fork picker is
+        # open (else None). edit-mode repurposes the focused InputBar for the
+        # checkpoint's input; entering it suspends the picker's ↑/↓/Enter nav
+        # (so those reach the InputBar) and gives Esc a priority-3.5 "exit edit,
+        # keep picker" branch. Mutated only via enter_edit_mode/exit_edit_mode.
+        self._edit_mode_seq: int | None = None
         # #1546: monotonic ts of the last *truly clean* Esc (nothing dismissed).
         # A second clean Esc within _ESC_ESC_WINDOW_S opens the /rewind picker
         # (Esc-Esc double-tap). 0.0 = no pending first tap. Any Esc that
@@ -321,6 +334,21 @@ class ReynTUIApp(App):
         Exposed for tests so they read state through the public surface.
         """
         return self._rewind_menu is not None
+
+    @property
+    def edit_mode_active(self) -> bool:
+        """Public read of the fork-picker edit-mode state (ADR-0038 2c).
+
+        ``True`` while the user is editing a checkpoint's input (the picker is
+        mounted but its ↑/↓/Enter nav is suspended so those keys reach the
+        InputBar). Consulted by ``check_action`` to gate the nav + ``e``
+        bindings, and by ``action_voice_cancel``'s priority-3.5 branch. Mutate
+        via ``enter_edit_mode()`` / ``exit_edit_mode()`` — direct assignment to
+        ``_edit_mode_seq`` is not the public contract. Single-owner: this App
+        owns the flag; both exits (Esc here, submit in the data-flow) route
+        through ``exit_edit_mode()``.
+        """
+        return self._edit_mode_seq is not None
 
     @property
     def outbox_router(self) -> "OutboxRouter | None":
@@ -2338,8 +2366,11 @@ class ReynTUIApp(App):
           1. If recording → cancel recording.
           2. **Else if InputBar is in slash-entry → dismiss picker + clear**
              prefix (= wave-2 P2).
+          3.5 Else if editing a checkpoint → exit edit-mode, keep the picker
+             (ADR-0038 2c). Before 3 because the picker stays mounted in edit.
           3. Else if the rewind menu is open → dismiss it (ADR-0038 1f).
           4. Else if side panel is visible → close it.
+          5. Else (truly clean Esc) → Esc-Esc double-tap detection (#1546).
 
         Gated by check_action so this never fires when no condition holds
         (allowing InputBar's own Esc binding to handle slash-picker
@@ -2359,6 +2390,15 @@ class ReynTUIApp(App):
                 return
         except Exception:
             pass
+        # ADR-0038 2c (priority 3.5): edit-mode exit comes BEFORE the rewind-menu
+        # dismiss — during edit the picker is still mounted, so without this an
+        # Esc would dismiss the whole picker instead of just leaving the edit.
+        # exit_edit_mode() clears the flag + banner + resets the Esc-Esc first
+        # tap; the picker STAYS (the user returns to it). Picker lifecycle is the
+        # caller's: submit (data-flow) dismisses it, Esc here keeps it.
+        if self.edit_mode_active:
+            self.exit_edit_mode()
+            return
         # ADR-0038 1f: dismiss the rewind menu before the side panel — the
         # menu is the most-recently-opened overlay, so Esc should close it
         # first (matches "abort the visible thing" priority).
@@ -2507,6 +2547,74 @@ class ReynTUIApp(App):
         if self._rewind_menu is not None:
             self._rewind_menu.move_selection(+1)
 
+    # ── fork-picker edit-mode (ADR-0038 2c) ─────────────────────────────────
+
+    _EDIT_BANNER = "✎ editing checkpoint #{seq} — Enter to fork · Esc to cancel"
+
+    def action_edit_checkpoint(self) -> None:
+        """``ctrl+e`` while the picker is open — edit the highlighted checkpoint.
+
+        Enters edit-mode on the selected checkpoint's seq, then hands off to the
+        2c data-flow's pre-fill (loads the FULL user message of that turn into
+        the InputBar). Gated by ``check_action`` to fire only while the picker is
+        open AND not already editing; otherwise the binding is inert (``ctrl+e``
+        is non-printable, so nothing is typed when it doesn't fire).
+        """
+        menu = self._rewind_menu
+        if menu is None or self.edit_mode_active:
+            return
+        point = menu.selected_point()
+        if point is None or point.get("seq") is None:
+            return
+        seq = int(point["seq"])
+        self.enter_edit_mode(seq)
+        # Hand off to the data-flow's pre-fill (full-message load). Best-effort:
+        # the flag + banner are set regardless, so the binding gates are correct
+        # even before the data-flow half lands — the pre-fill only populates the
+        # text. ``_prefill_edit`` is the co-impl seam (e2e, #1533).
+        prefill = getattr(self, "_prefill_edit", None)
+        if callable(prefill):
+            try:
+                prefill(seq)
+            except Exception:
+                pass
+
+    def enter_edit_mode(self, seq: int) -> None:
+        """Enter fork-picker edit-mode on checkpoint ``seq`` (ADR-0038 2c).
+
+        Sets the edit-mode flag (which suspends the picker's ↑/↓/Enter nav via
+        ``check_action`` so those reach the InputBar) and shows the
+        ``✎ editing checkpoint #N`` banner. Pure state + banner — the InputBar
+        pre-fill is the data-flow's concern (``action_edit_checkpoint`` orchestrates).
+        """
+        self._edit_mode_seq = seq
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+            conv.show_status(self._EDIT_BANNER.format(seq=seq), kind="mode")
+        except Exception:
+            pass
+
+    def exit_edit_mode(self) -> None:
+        """Leave edit-mode (ADR-0038 2c) — the single reset point for BOTH exits.
+
+        Esc (priority-3.5 in ``action_voice_cancel``) and submit (the data-flow's
+        handler, which calls this first) both route through here. Pure: clears
+        the flag, resets the Esc-Esc first tap (the #1554 every-exit-must-reset
+        discipline), and hides the banner — kind-checked so it never clobbers a
+        status another path set in the meantime. Does NOT touch the picker: its
+        lifecycle is the caller's (Esc keeps it, submit dismisses it).
+        """
+        self._edit_mode_seq = None
+        self._reset_clean_esc()
+        try:
+            from .widgets.sticky_status import StickyStatus
+            conv = self.query_one("#conversation", ConversationView)
+            sticky = conv.query_one("#sticky-status", StickyStatus)
+            if sticky.snapshot().get("kind") == "mode":
+                conv.hide_status()
+        except Exception:
+            pass
+
     async def action_rewind_confirm(self) -> None:
         """Enter while the picker is open — checkout the highlighted checkpoint.
 
@@ -2588,11 +2696,18 @@ class ReynTUIApp(App):
                 return self.query_one("#right_panel", RightPanel).panel_type == "events"
             except Exception:
                 return False
-        if action in {"rewind_prev", "rewind_next", "rewind_confirm"}:
-            # ADR-0038 1f: navigation keys are live only while the /rewind
-            # picker is mounted. Otherwise they fall through to the InputBar
-            # (↑/↓ history, Enter submit).
-            return self._rewind_menu is not None
+        if action in {"rewind_prev", "rewind_next", "rewind_confirm", "edit_checkpoint"}:
+            # ADR-0038 1f: navigation keys (+ 2c's ``ctrl+e`` edit) are live only
+            # while the /rewind picker is mounted. Otherwise ↑/↓/Enter fall
+            # through to the InputBar (history / submit); ``ctrl+e`` is inert.
+            #
+            # ADR-0038 2c: ...AND not while editing. During edit-mode the picker
+            # stays mounted but its nav is suspended so ↑/↓/Enter reach the
+            # focused InputBar (history/cursor + submit-the-edit). The
+            # load-bearing seam: without ``and not edit_mode_active``, Enter would
+            # checkout-the-selection instead of submitting the edit. (e2e
+            # flow-trace catch, #1533.)
+            return self._rewind_menu is not None and not self.edit_mode_active
         if action == "voice_cancel":
             # Intercept Esc when there's an overlay/recording to dismiss:
             # voice recording, the rewind menu, or the side panel.

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -1064,6 +1064,13 @@ class ReynTUIApp(App):
         if not text:
             return
 
+        # ADR-0038 2c: submitting while editing a checkpoint forks from the
+        # edited turn's predecessor (edit-and-retry) rather than appending a
+        # fresh turn to the live branch.
+        if self.edit_mode_active:
+            await self._submit_edited_fork(text)
+            return
+
         conv = self.query_one("#conversation", ConversationView)
         # B1: render with grouped header
         conv.render_user_message(text)
@@ -2692,6 +2699,58 @@ class ReynTUIApp(App):
             self.query_one("#inputbar", InputBar).set_text(full)
         except Exception:
             pass
+
+    async def _submit_edited_fork(self, edited_text: str) -> None:
+        """Edit-and-retry (ADR-0038 2c): fork from the edited checkpoint's
+        predecessor turn, then re-run the edited message as a new turn.
+
+        The original turn stays on a now-inactive branch (append-only); the
+        edited message produces a sibling fork. The **submit** edit-exit — routes
+        through ``exit_edit_mode`` (the shared reset seam, like the Esc exit) and
+        ALSO dismisses the picker (Esc keeps it; submit closes it).
+
+        Checkout target = the **predecessor TURN-kind checkpoint** on the edited
+        seq's lineage (substrate-computed: cross-fork-point + plan-step-skip).
+        ``None`` = first turn → no earlier state to fork from → graceful reject.
+        """
+        seq = self._edit_mode_seq          # capture BEFORE exit clears it
+        self.exit_edit_mode()              # flag + banner + Esc-Esc reset (shared seam)
+        self._dismiss_rewind_menu()        # submit dismisses the picker
+        try:
+            conv = self.query_one("#conversation", ConversationView)
+        except Exception:
+            conv = None
+        registry = self._agent_registry
+        if registry is None or seq is None:
+            if conv is not None:
+                conv.render_message(OutboxMessage(kind="error", text="⏪ edit unavailable"))
+            return
+        pred = registry.predecessor_turn_checkpoint(seq)
+        if pred is None:
+            if conv is not None:
+                conv.render_message(OutboxMessage(
+                    kind="system",
+                    text="✋ cannot edit the first turn — no earlier checkpoint to fork from",
+                ))
+            return
+        try:
+            await registry.checkout(pred)
+        except Exception as exc:  # noqa: BLE001 — surface the reason in-timeline
+            if conv is not None:
+                conv.render_message(
+                    OutboxMessage(kind="error", text=f"⏪ edit checkout failed: {exc}")
+                )
+            return
+        # Re-run the edited message from the predecessor = a new fork; the
+        # original turn is now on an inactive branch.
+        session = self._get_session()
+        if session is None:
+            return
+        if conv is not None:
+            conv.render_user_message(edited_text)
+            conv.start_thinking()
+        self._latest_user_message = edited_text
+        await session.submit_user_text(edited_text)
 
     def _voice_config(self):
         """Best-effort fetch of the user's voice config block."""

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2625,6 +2625,32 @@ class ReynTUIApp(App):
         except Exception:
             pass
 
+    def _selected_has_predecessor_turn(self) -> bool:
+        """Whether the picker's selected checkpoint can be edited (ADR-0038 2c).
+
+        ``True`` unless we can *affirmatively* determine the selection has no
+        predecessor turn checkpoint (= it is the first turn; genesis-checkout is
+        not offered, #1567). Defaults to ``True`` whenever the answer is
+        undeterminable (no registry / no selection / helper absent) so the
+        affordance fails open — the submit-handler then rejects None as the
+        backstop. Short-circuited behind the cheap picker-open gate in
+        ``check_action`` so the lineage scan only runs on a real ``ctrl+t``.
+        """
+        menu = self._rewind_menu
+        registry = self._agent_registry
+        if menu is None or registry is None:
+            return True
+        point = menu.selected_point()
+        if point is None or point.get("seq") is None:
+            return True
+        pred_fn = getattr(registry, "predecessor_turn_checkpoint", None)
+        if not callable(pred_fn):
+            return True
+        try:
+            return pred_fn(int(point["seq"])) is not None
+        except Exception:
+            return True
+
     async def action_rewind_confirm(self) -> None:
         """Enter while the picker is open — checkout the highlighted checkpoint.
 
@@ -2795,7 +2821,17 @@ class ReynTUIApp(App):
             # load-bearing seam: without ``and not edit_mode_active``, Enter would
             # checkout-the-selection instead of submitting the edit. (e2e
             # flow-trace catch, #1533.)
-            return self._rewind_menu is not None and not self.edit_mode_active
+            if self._rewind_menu is None or self.edit_mode_active:
+                return False
+            if action == "edit_checkpoint":
+                # ADR-0038 2c: you cannot edit-and-re-run the FIRST turn — there
+                # is no prior turn checkpoint to fork from (genesis-checkout is
+                # workspace-incoherent, #1567). Gate ctrl+t off when the selected
+                # checkpoint has no predecessor turn, so the affordance is inert
+                # rather than entering edit-mode then bouncing on submit. (The
+                # submit-handler also rejects None — defense in depth.)
+                return self._selected_has_predecessor_turn()
+            return True
         if action == "voice_cancel":
             # Intercept Esc when there's an overlay/recording to dismiss:
             # voice recording, the rewind menu, or the side panel.

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -395,6 +395,23 @@ class InputBar(Widget):
         last_row = len(lines) - 1
         ta.move_cursor((last_row, len(lines[last_row])))
 
+    def set_text(self, text: str) -> None:
+        """Replace the input buffer with ``text`` + move cursor to end.
+
+        Unlike ``append_text`` (voice dictation, which concatenates), this is a
+        full replace — used by the /rewind edit pre-fill (#1533 2c) to load a
+        past turn's full user message for editing, discarding any unrelated
+        draft. Cursor lands at the end so the user edits/Enter-forks directly.
+        """
+        try:
+            ta = self.query_one("#input", TextArea)
+        except Exception:
+            return
+        ta.load_text(text or "")
+        lines = (text or "").split("\n")
+        last_row = len(lines) - 1
+        ta.move_cursor((last_row, len(lines[last_row])))
+
     # ── input events ─────────────────────────────────────────────────────────
 
     @on(TextArea.Changed, "#input")

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -395,6 +395,16 @@ class InputBar(Widget):
         last_row = len(lines) - 1
         ta.move_cursor((last_row, len(lines[last_row])))
 
+    def _edit_mode_active(self) -> bool:
+        """True while the app is in fork-picker edit-mode (#1533 2c).
+
+        Read off the running App's public ``edit_mode_active`` (single-owner
+        flag). When set, ↑/↓ move the cursor within the loaded message instead
+        of recalling input history (which would clobber the edit). Best-effort:
+        no app / no property → False (normal history nav).
+        """
+        return bool(getattr(self.app, "edit_mode_active", False))
+
     def set_text(self, text: str) -> None:
         """Replace the input buffer with ``text`` + move cursor to end.
 
@@ -511,6 +521,13 @@ class InputBar(Widget):
         if picker is not None and picker.visible_ and picker.has_matches:
             picker.move_selection(-1)
             return
+        if self._edit_mode_active():
+            # #1533 2c: editing a checkpoint's loaded message — ↑ moves the
+            # cursor within it, never recalls history (which would overwrite
+            # the edit). The picker is open but its nav is suspended, so ↑
+            # reaches here.
+            ta.action_cursor_up()
+            return
         if self._restore_pristine:
             self._history_up(ta)
             return
@@ -534,6 +551,10 @@ class InputBar(Widget):
             return
         if picker is not None and picker.visible_ and picker.has_matches:
             picker.move_selection(+1)
+            return
+        if self._edit_mode_active():
+            # #1533 2c: cursor-only within the loaded message, never history.
+            ta.action_cursor_down()
             return
         if self._restore_pristine:
             self._history_down(ta)

--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -230,7 +230,7 @@ class RewindMenuWidget(Widget):
             line.append("\n")
             body.append_text(line)
         body.append(
-            "  ↑/↓ select · Enter checkout · ctrl+e edit · Esc cancel\n",
+            "  ↑/↓ select · Enter checkout · ctrl+t edit · Esc cancel\n",
             style=f"dim {_TEXT_DIM}",
         )
         return body

--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -230,7 +230,8 @@ class RewindMenuWidget(Widget):
             line.append("\n")
             body.append_text(line)
         body.append(
-            "  ↑/↓ select · Enter checkout · Esc cancel\n", style=f"dim {_TEXT_DIM}",
+            "  ↑/↓ select · Enter checkout · ctrl+e edit · Esc cancel\n",
+            style=f"dim {_TEXT_DIM}",
         )
         return body
 

--- a/src/reyn/chat/tui/widgets/sticky_status.py
+++ b/src/reyn/chat/tui/widgets/sticky_status.py
@@ -41,6 +41,10 @@ _GLYPHS: dict[str, str] = {
     # failure terminals, so the cross-surface vocabulary stays
     # uniform.
     "error": "✗",
+    # ADR-0038 2c: a persistent *mode* banner (e.g. the fork picker's
+    # "editing checkpoint #N"). ``✎`` reads as "you are editing", distinct
+    # from the ``●`` routine flash and the ``✗`` failure terminal.
+    "mode": "✎",
 }
 
 # Wave-10 G-F8 + I-F8: overwrite-priority hierarchy.
@@ -71,6 +75,13 @@ _KIND_PRIORITY: dict[str, int] = {
     # breadcrumbs / turn-position flashes shouldn't overwrite an
     # error the user hasn't read yet).
     "error": 80,
+    # ADR-0038 2c: a deliberate edit *mode* banner. Above ``general`` (a
+    # routine breadcrumb fired mid-edit must NOT wipe "editing checkpoint
+    # #N") and above ``error`` (the edit banner is the active modal context);
+    # still below the terminal-error tier (110) so a budget-exceeded failure
+    # surfaces over it. Hidden explicitly by ``exit_edit_mode`` (body/kind-
+    # checked), not by priority alone.
+    "mode": 85,
     # Transient flashes / breadcrumbs / one-shot notices.
     "general": 50,
 }

--- a/tests/cli/test_fork_picker_edit_mode_2c.py
+++ b/tests/cli/test_fork_picker_edit_mode_2c.py
@@ -233,3 +233,30 @@ async def test_edit_checkpoint_noop_when_already_editing(tmp_path) -> None:
         app.action_edit_checkpoint()   # direct call is a no-op (guard)
         await pilot.pause()
         assert app.edit_mode_active is True   # still seq 1, not re-entered
+
+
+@pytest.mark.asyncio
+async def test_ctrl_t_gated_off_on_first_turn_checkpoint(tmp_path) -> None:
+    """Tier 2: edit (ctrl+t) is inert on the FIRST-turn checkpoint — there is no
+    prior turn to fork from (predecessor_turn_checkpoint None, #1567), so the
+    affordance fails open elsewhere but is gated off here rather than entering
+    edit-mode then bouncing on submit. The newer checkpoint (has a predecessor)
+    stays editable."""
+    reg = await _registry_with_checkpoints(tmp_path)   # 2 turn checkpoints, 1 branch
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._open_rewind_menu()
+        await pilot.pause()
+        # default selection = newest checkpoint → has a predecessor turn → editable
+        newest = app._rewind_menu.selected_point()
+        assert reg.predecessor_turn_checkpoint(int(newest["seq"])) is not None
+        assert app.check_action("edit_checkpoint", ()) is True
+        # navigate to the oldest (= first turn) → no predecessor → ctrl+t gated off
+        app._rewind_menu.move_selection(+1)
+        await pilot.pause()
+        oldest = app._rewind_menu.selected_point()
+        assert reg.predecessor_turn_checkpoint(int(oldest["seq"])) is None
+        assert app.check_action("edit_checkpoint", ()) is False
+        # nav bindings stay live regardless of predecessor (only edit is gated)
+        assert app.check_action("rewind_prev", ()) is True

--- a/tests/cli/test_fork_picker_edit_mode_2c.py
+++ b/tests/cli/test_fork_picker_edit_mode_2c.py
@@ -1,0 +1,233 @@
+"""Tier 2: fork-picker edit-mode bindings + banner (ADR-0038 2c, tui-coder half).
+
+The picker stays mounted during edit (can_focus=False → InputBar always focused),
+so edit-mode must (a) suspend the picker's ↑/↓/Enter/`e` nav so those reach the
+InputBar, (b) give Esc a priority-3.5 "exit edit, keep picker" branch, and
+(c) show a non-clobberable "✎ editing checkpoint #N" banner. This is the binding
+half; the data-flow (full-message pre-fill + submit→checkout(N-1)+fork) lands
+separately on the same co-authored branch.
+
+Pins (real instances + run_test pilot — no mocks):
+- enter/exit_edit_mode toggle edit_mode_active + the banner (public surface).
+- exit_edit_mode resets the Esc-Esc first tap (#1554 every-exit-must-reset).
+- check_action suspends rewind_prev/next/confirm + edit_checkpoint while editing.
+- Esc during edit exits edit-mode and KEEPS the picker (priority-3.5).
+- `e` on a selected checkpoint enters edit-mode on that seq.
+- the "mode" banner beats a general breadcrumb but yields to a terminal error.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets.sticky_status import StickyStatus
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+async def _registry_with_checkpoints(tmp_path: Path) -> AgentRegistry:
+    """Real registry with one active branch + 2 checkpoints (no fork needed)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+    )
+    AgentProfile.new("default", role="").save(tmp_path / ".reyn" / "agents" / "default")
+    log = reg.state_log
+    for mid in ("m1", "m2"):
+        s = await log.append("inbox_consume", target="default", msg_id=mid)
+        snap = AgentSnapshot.empty("default")
+        snap.applied_seq = s
+        reg._store_for("default").record(snap)
+    return reg
+
+
+def _sticky(app: ReynTUIApp) -> StickyStatus:
+    conv = app.query_one("#conversation", ConversationView)
+    return conv.query_one("#sticky-status", StickyStatus)
+
+
+def _make_app(registry=None) -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=registry, agent_name="default", model="test-model",
+        budget_tracker=None,
+    )
+
+
+# ── edit-mode lifecycle (no picker needed) ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_enter_exit_edit_mode_toggles_flag_and_banner() -> None:
+    """Tier 2: enter_edit_mode sets edit_mode_active + shows the banner;
+    exit_edit_mode clears both (public surface, no private-state assert)."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        assert app.edit_mode_active is False
+
+        app.enter_edit_mode(7)
+        await pilot.pause()
+        assert app.edit_mode_active is True
+        snap = _sticky(app).snapshot()
+        assert "editing checkpoint #7" in snap.get("body", "")
+        assert snap.get("kind") == "mode"
+
+        app.exit_edit_mode()
+        await pilot.pause()
+        assert app.edit_mode_active is False
+        # hide() deactivates the sticky (body text persists by design — the
+        # #1546 hint clear keys on body too); assert the banner is no longer active.
+        assert _sticky(app).snapshot().get("active") is False
+
+
+@pytest.mark.asyncio
+async def test_exit_edit_mode_resets_esc_esc_pending() -> None:
+    """Tier 2: exit_edit_mode resets the pending Esc-Esc first tap, so
+    "exit-edit Esc then clean Esc" can't false-fire the picker (#1554 discipline)."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")          # arm a clean-Esc first tap
+        assert app.esc_esc_pending is True
+        app.enter_edit_mode(3)
+        await pilot.pause()
+        app.exit_edit_mode()                 # must disarm the first tap
+        await pilot.pause()
+        assert app.esc_esc_pending is False
+
+
+# ── banner priority (lead-required render test) ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_mode_banner_beats_general_breadcrumb() -> None:
+    """Tier 2: a routine general breadcrumb showing → entering edit-mode
+    overwrites it with the banner (mode 85 > general 50)."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app.query_one("#conversation", ConversationView).show_status(
+            "↑ turn 2 / 5", kind="general",
+        )
+        await pilot.pause()
+        app.enter_edit_mode(4)
+        await pilot.pause()
+        assert "editing checkpoint #4" in _sticky(app).snapshot().get("body", "")
+
+
+@pytest.mark.asyncio
+async def test_mode_banner_yields_to_terminal_error() -> None:
+    """Tier 2: a terminal error showing (priority 110) → entering edit-mode does
+    NOT overwrite it (mode 85 < 110), so a critical failure stays visible."""
+    app = _make_app()
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app.query_one("#conversation", ConversationView).show_status(
+            "✗ budget exceeded", kind="error", terminal=True,
+        )
+        await pilot.pause()
+        app.enter_edit_mode(4)
+        await pilot.pause()
+        body = _sticky(app).snapshot().get("body", "")
+        assert "budget exceeded" in body
+        assert "editing checkpoint" not in body
+
+
+# ── nav suspension + Esc priority-3.5 + `e` (picker needed) ──────────────────
+
+@pytest.mark.asyncio
+async def test_nav_and_edit_bindings_suspended_during_edit(tmp_path) -> None:
+    """Tier 2: with the picker open, rewind_prev/next/confirm + edit_checkpoint
+    are live; entering edit-mode suspends ALL of them (so ↑/↓/Enter reach the
+    InputBar and `e` types) — the e2e flow-trace catch."""
+    reg = await _registry_with_checkpoints(tmp_path)
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._open_rewind_menu()
+        await pilot.pause()
+        assert app.rewind_menu_open is True
+        for act in ("rewind_prev", "rewind_next", "rewind_confirm", "edit_checkpoint"):
+            assert app.check_action(act, ()) is True, act
+
+        app.enter_edit_mode(1)
+        await pilot.pause()
+        for act in ("rewind_prev", "rewind_next", "rewind_confirm", "edit_checkpoint"):
+            assert app.check_action(act, ()) is False, act
+
+
+@pytest.mark.asyncio
+async def test_esc_during_edit_exits_edit_keeps_picker(tmp_path) -> None:
+    """Tier 2: Esc while editing exits edit-mode but KEEPS the picker mounted
+    (priority-3.5, before the rewind-menu dismiss) and resets the first tap."""
+    reg = await _registry_with_checkpoints(tmp_path)
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._open_rewind_menu()
+        await pilot.pause()
+        app.enter_edit_mode(1)
+        await pilot.pause()
+        assert app.edit_mode_active is True and app.rewind_menu_open is True
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.edit_mode_active is False     # edit exited
+        assert app.rewind_menu_open is True       # picker stays
+        assert app.esc_esc_pending is False       # reset discipline
+
+
+@pytest.mark.asyncio
+async def test_ctrl_e_enters_edit_mode_on_selected_seq(tmp_path) -> None:
+    """Tier 2: ``ctrl+e`` while the picker is open enters edit-mode on the
+    highlighted checkpoint's seq (action_edit_checkpoint → enter_edit_mode).
+
+    ``ctrl+e`` (not bare ``e``): the can_focus=False picker keeps the InputBar
+    focused, which swallows printable keys before any app priority binding — so
+    only a non-printable chord reaches the binding (like the ↑/↓/Enter nav)."""
+    reg = await _registry_with_checkpoints(tmp_path)
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._open_rewind_menu()
+        await pilot.pause()
+        selected = app._rewind_menu.selected_point()
+        assert selected is not None
+        expected_seq = int(selected["seq"])
+
+        await pilot.press("ctrl+e")
+        await pilot.pause()
+        assert app.edit_mode_active is True
+        assert f"editing checkpoint #{expected_seq}" in _sticky(app).snapshot().get("body", "")
+
+
+@pytest.mark.asyncio
+async def test_edit_checkpoint_noop_when_already_editing(tmp_path) -> None:
+    """Tier 2: the edit binding is inert while already editing — check_action
+    gates ``edit_checkpoint`` off so ``ctrl+e`` does not re-enter (and a direct
+    action call is guarded)."""
+    reg = await _registry_with_checkpoints(tmp_path)
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._open_rewind_menu()
+        await pilot.pause()
+        app.enter_edit_mode(1)
+        await pilot.pause()
+        # check_action gates `e` off while editing → action does not re-fire.
+        assert app.check_action("edit_checkpoint", ()) is False
+        app.action_edit_checkpoint()   # direct call is a no-op (guard)
+        await pilot.pause()
+        assert app.edit_mode_active is True   # still seq 1, not re-entered

--- a/tests/cli/test_fork_picker_edit_mode_2c.py
+++ b/tests/cli/test_fork_picker_edit_mode_2c.py
@@ -190,13 +190,15 @@ async def test_esc_during_edit_exits_edit_keeps_picker(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_ctrl_e_enters_edit_mode_on_selected_seq(tmp_path) -> None:
-    """Tier 2: ``ctrl+e`` while the picker is open enters edit-mode on the
+async def test_ctrl_t_enters_edit_mode_on_selected_seq(tmp_path) -> None:
+    """Tier 2: ``ctrl+t`` while the picker is open enters edit-mode on the
     highlighted checkpoint's seq (action_edit_checkpoint → enter_edit_mode).
 
-    ``ctrl+e`` (not bare ``e``): the can_focus=False picker keeps the InputBar
-    focused, which swallows printable keys before any app priority binding — so
-    only a non-printable chord reaches the binding (like the ↑/↓/Enter nav)."""
+    ``ctrl+t`` (not bare ``e``: the can_focus=False picker keeps the InputBar
+    focused and swallows printable keys; and not ``ctrl+e``: the focused
+    TextArea binds ctrl+e → cursor_line_end). ``ctrl+t`` is TextArea-unbound, so
+    the app priority binding reaches it — verified in tmux (run_test alone gave
+    a false positive for ctrl+e, hence the tmux gate)."""
     reg = await _registry_with_checkpoints(tmp_path)
     app = _make_app(reg)
     async with app.run_test(headless=True) as pilot:
@@ -207,7 +209,7 @@ async def test_ctrl_e_enters_edit_mode_on_selected_seq(tmp_path) -> None:
         assert selected is not None
         expected_seq = int(selected["seq"])
 
-        await pilot.press("ctrl+e")
+        await pilot.press("ctrl+t")
         await pilot.pause()
         assert app.edit_mode_active is True
         assert f"editing checkpoint #{expected_seq}" in _sticky(app).snapshot().get("body", "")
@@ -216,7 +218,7 @@ async def test_ctrl_e_enters_edit_mode_on_selected_seq(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_edit_checkpoint_noop_when_already_editing(tmp_path) -> None:
     """Tier 2: the edit binding is inert while already editing — check_action
-    gates ``edit_checkpoint`` off so ``ctrl+e`` does not re-enter (and a direct
+    gates ``edit_checkpoint`` off so ``ctrl+t`` does not re-enter (and a direct
     action call is guarded)."""
     reg = await _registry_with_checkpoints(tmp_path)
     app = _make_app(reg)

--- a/tests/cli/test_rewind_edit_fork_2c.py
+++ b/tests/cli/test_rewind_edit_fork_2c.py
@@ -1,0 +1,121 @@
+"""Tier 2: 2c edit-and-retry submit-handler + history-guard (ADR-0038 2c).
+
+The submit half of the fork-picker edit feature. Submitting while edit-mode is
+active forks from the edited turn's **predecessor TURN checkpoint** (not seq
+N-1, not an intra-turn plan-step — substrate-computed via
+``predecessor_turn_checkpoint``) and re-runs the edited message = new branch.
+
+Pins (real AgentRegistry + ReynTUIApp run_test, no mocks):
+- submit-handler checks out the predecessor-turn checkpoint + clears edit-mode.
+- first-turn edit (predecessor None) → graceful reject, no checkout.
+- both edit-exits route through ``exit_edit_mode`` (shared reset seam).
+- history-guard: ↑/↓ are cursor-only during edit-mode (never recall history,
+  which would overwrite the loaded message).
+
+The full re-run (``submit_user_text``) needs a live session; the checkout-target
+correctness (the catch) is what this gate pins. tui-coder's tmux P3 covers the
+live re-run end-to-end.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import InputBar
+from reyn.events.agent_snapshot import AgentSnapshot
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+async def _registry_with_turns(tmp_path: Path) -> tuple[AgentRegistry, int, int]:
+    """Real registry with two TURN checkpoints (s1, s2). Returns (reg, s1, s2)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    log = reg.state_log
+
+    def _gen(seq: int) -> None:
+        snap = AgentSnapshot.empty("alpha")
+        snap.applied_seq = seq
+        reg._store_for("alpha").record(snap)
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")  # turn
+    _gen(s1)
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")  # turn
+    _gen(s2)
+    return reg, s1, s2
+
+
+def _app(reg: AgentRegistry) -> ReynTUIApp:
+    return ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+
+
+@pytest.mark.asyncio
+async def test_edited_submit_checks_out_predecessor_turn(tmp_path) -> None:
+    """Tier 2: editing turn s2 forks from its predecessor TURN checkpoint s1
+    (checkout target = predecessor_turn_checkpoint(s2)), and clears edit-mode."""
+    reg, s1, s2 = await _registry_with_turns(tmp_path)
+    assert reg.predecessor_turn_checkpoint(s2) == s1   # sanity: helper → prev turn
+    app = _app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app.enter_edit_mode(s2)          # simulate edit-mode on turn s2 (public API)
+        assert app.edit_mode_active is True
+        head_before = reg.state_log.current_seq
+
+        await app._submit_edited_fork("edited message")
+
+        # Checked out (reset-record appended) to the predecessor turn s1.
+        assert reg.state_log.current_seq > head_before
+        # Edit-mode cleared via exit_edit_mode (shared reset seam).
+        assert app.edit_mode_active is False
+
+
+@pytest.mark.asyncio
+async def test_first_turn_edit_rejects_gracefully(tmp_path) -> None:
+    """Tier 2: editing the FIRST turn (predecessor None) → graceful reject, no
+    checkout (no earlier checkpoint to fork from)."""
+    reg, s1, _s2 = await _registry_with_turns(tmp_path)
+    assert reg.predecessor_turn_checkpoint(s1) is None   # first turn → None
+    app = _app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app.enter_edit_mode(s1)
+        head_before = reg.state_log.current_seq
+
+        await app._submit_edited_fork("edited message")
+
+        assert reg.state_log.current_seq == head_before   # NO checkout
+        assert app.edit_mode_active is False               # still exits edit-mode
+
+
+@pytest.mark.asyncio
+async def test_history_guard_cursor_only_during_edit(tmp_path) -> None:
+    """Tier 2: while edit-mode is active, ↑/↓ move the cursor within the loaded
+    message — they do NOT recall input history (which would overwrite the edit)."""
+    reg, _s1, s2 = await _registry_with_turns(tmp_path)
+    app = _app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        app.enter_edit_mode(s2)                       # enter edit-mode (public API)
+        bar.set_text("line one\nline two")            # multi-line loaded message
+        await pilot.pause()
+        bar.action_key_up()                            # ↑ during edit-mode
+        await pilot.pause()
+        # The buffer is unchanged (cursor moved within it, no history recall).
+        assert bar.query_one("#input").text == "line one\nline two"

--- a/tests/cli/test_rewind_edit_prefill_2c.py
+++ b/tests/cli/test_rewind_edit_prefill_2c.py
@@ -92,11 +92,12 @@ async def test_prefill_edit_no_message_is_noop(tmp_path) -> None:
         assert bar.query_one("#input").text == "draft"   # untouched
 
 
-def test_tree_footer_advertises_ctrl_e_edit() -> None:
-    """Tier 2: the tree footer surfaces ctrl+e edit (discoverability; ctrl+e
-    because printable keys are swallowed by the focused InputBar)."""
+def test_tree_footer_advertises_ctrl_t_edit() -> None:
+    """Tier 2: the tree footer surfaces ctrl+t edit (discoverability). ctrl+t,
+    not ctrl+e: the focused TextArea binds ctrl+e → cursor_line_end and consumes
+    it (verified in tmux); ctrl+t is TextArea-unbound so the app binding fires."""
     branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 6, "parent_branch_id": None, "is_active": True}]
     cps = [{"seq": 3, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0}]
     w = RewindMenuWidget.from_tree_rows(build_branch_tree_rows(branches, cps))
     rendered = w.render().plain
-    assert "ctrl+e" in rendered and "edit" in rendered
+    assert "ctrl+t" in rendered and "edit" in rendered

--- a/tests/cli/test_rewind_edit_prefill_2c.py
+++ b/tests/cli/test_rewind_edit_prefill_2c.py
@@ -1,0 +1,102 @@
+"""Tier 2: 2c edit pre-fill data-flow — InputBar.set_text + _prefill_edit (2c).
+
+The data-flow half of the fork-picker edit feature (co-impl with tui-coder's
+edit-mode binding). Pins:
+- ``InputBar.set_text`` REPLACES the buffer (vs append_text's concatenate).
+- ``_prefill_edit(seq)`` loads the **full** original message (AnchorStore.get_full,
+  NOT the truncated display anchor) into the InputBar, so an edited re-run keeps
+  the whole message.
+- the tree footer advertises ``ctrl+e edit`` (discoverability; ctrl+e not bare
+  ``e`` — printable keys are swallowed by the focused InputBar).
+
+run_test real-DOM (mount-path) + a real AgentRegistry/AnchorStore — no mocks.
+The submit-handler (predecessor-turn checkout + fork) lands once sandbox_2's
+``predecessor_turn_checkpoint`` merges; this is the pre-fill + footer half.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.tui.app import ReynTUIApp
+from reyn.chat.tui.widgets import ConversationView, InputBar
+from reyn.chat.tui.widgets._branch_tree import build_branch_tree_rows
+from reyn.chat.tui.widgets.rewind_menu import RewindMenuWidget
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+@pytest.mark.asyncio
+async def test_set_text_replaces_buffer() -> None:
+    """Tier 2: InputBar.set_text replaces the buffer (not append) + cursor-to-end."""
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        bar.append_text("a draft")
+        await pilot.pause()
+        bar.set_text("the original full message")
+        await pilot.pause()
+        ta = bar.query_one("#input")
+        assert ta.text == "the original full message"   # replaced, not "a draft …"
+
+
+@pytest.mark.asyncio
+async def test_prefill_edit_loads_full_message(tmp_path) -> None:
+    """Tier 2: _prefill_edit loads the FULL message (get_full), not the truncated
+    anchor, into the InputBar."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    full_msg = "fix the auth bug in the login handler and add a regression test for it"
+    reg.anchor_store.capture(42, "fix the auth bug…", full=full_msg)
+
+    app = ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._prefill_edit(42)
+        await pilot.pause()
+        ta = app.query_one("#inputbar", InputBar).query_one("#input")
+        assert ta.text == full_msg                    # FULL, not the "…" anchor
+
+
+@pytest.mark.asyncio
+async def test_prefill_edit_no_message_is_noop(tmp_path) -> None:
+    """Tier 2: _prefill_edit with no recorded full message → no-op (no crash,
+    InputBar untouched) — non-turn / legacy checkpoint degrades gracefully."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    app = ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        bar.set_text("draft")
+        app._prefill_edit(999)   # no anchor for 999
+        await pilot.pause()
+        assert bar.query_one("#input").text == "draft"   # untouched
+
+
+def test_tree_footer_advertises_ctrl_e_edit() -> None:
+    """Tier 2: the tree footer surfaces ctrl+e edit (discoverability; ctrl+e
+    because printable keys are swallowed by the focused InputBar)."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 6, "parent_branch_id": None, "is_active": True}]
+    cps = [{"seq": 3, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0}]
+    w = RewindMenuWidget.from_tree_rows(build_branch_tree_rows(branches, cps))
+    rendered = w.render().plain
+    assert "ctrl+e" in rendered and "edit" in rendered


### PR DESCRIPTION
**[tui-coder]** — ADR-0038 Phase-2 **2c: edit a past turn and re-run it as a new fork.** Co-authored: tui-coder (Esc/edit-mode binding + key + gate) × e2e-coder (edit data-flow). Builds on merged 2a (`checkout`, `list_branches`), 2b (#1561 fork picker), #1565 (`get_full`), #1567 (`predecessor_turn_checkpoint`). Design converged in #1533.

## What 2c ships
`ctrl+t` on a checkpoint loads that turn's full user message into the InputBar; editing + submitting re-runs it from the turn's predecessor state as a **new fork** (append-only — the original turn survives on a now-inactive sibling).

### Binding half (tui-coder)
- `edit_mode_active` (property) + `enter_edit_mode(seq)` / `exit_edit_mode()` — single-owner flag; **both exits route through `exit_edit_mode()`** (Esc here, submit in the data-flow) → reset discipline (#1554) + kind-checked banner hide.
- **`check_action` (single-owner)** gates 4 bindings on `_rewind_menu is not None and not edit_mode_active`: during edit the picker stays mounted but ↑/↓/Enter are suspended so they reach the focused InputBar (the e2e nav-suspend catch). `edit_checkpoint` additionally requires a **predecessor turn** (first-turn edit is gated off — no prior turn to fork from; #1567 genesis-incoherence).
- `action_voice_cancel` **priority-3.5**: edit-mode exit BEFORE the picker dismiss (picker stays in edit).
- **`StickyStatus kind="mode"`** (✎, priority 85): the `✎ editing checkpoint #N` banner beats a general breadcrumb, yields to terminal-error.
- **Edit key = `ctrl+t`, NOT `ctrl+e`** — surfaced by the tmux gate (see Findings).

### Data-flow half (e2e-coder)
- `InputBar.set_text` (replace) + `_prefill_edit(seq)` (`get_full` → InputBar, auto-wires to `action_edit_checkpoint`'s seam) + tree footer `ctrl+t edit`.
- Submit-handler: branches on `edit_mode_active` → capture seq → `exit_edit_mode()` + `_dismiss_rewind_menu()` → `checkout(predecessor_turn_checkpoint(seq))` → `submit_user_text(edited)` = new fork. `None` → graceful "cannot edit the first turn" reject.
- History-guard: `InputBar.action_key_up/down` cursor-only during edit-mode (↑/↓ don't history-recall over the loaded message).

## Findings (impl-surfaced)
- **`ctrl+e` is consumed by the focused `TextArea`** (`ctrl+e → cursor_line_end`); the `can_focus=False` picker keeps the InputBar focused, so `ctrl+e` never reaches the app binding. **`run_test` gave a false positive**; the tmux gate caught it. `ctrl+t` is TextArea-unbound + instrument-verified to fire. (Repo precedent: app.py uses F3 for skill-expand "to avoid the Ctrl+letter collision with TextArea".)
- **The edit banner doesn't surface in `tmux capture-pane`** (the `dock:bottom` line) — same for the pre-existing #1546 esc-esc hint; likely a capture artifact (widget state is correct via `snapshot()`). The tmux live gate therefore detects edit-mode via the InputBar pre-fill text, not the banner.

## Test plan
- [x] `pytest tests/cli/test_fork_picker_edit_mode_2c.py` — 9 (lifecycle, banner priority, nav-suspend gates, Esc-3.5, ctrl+t enters, first-turn gate-off)
- [x] `pytest tests/cli/test_rewind_edit_prefill_2c.py tests/cli/test_rewind_edit_fork_2c.py` — prefill + edit=new-fork + predecessor-checkout + first-turn-reject + history-guard
- [x] `pytest tests/cli/ -k "rewind or esc or sticky or branch or checkout or edit_mode or fork_picker or prefill"` — 85 passed (no regression)
- [x] `ruff check` + tier audit `--strict` — clean
- [x] (tmux, tui-coder) **Esc-3.5 cascade + ctrl+t→prefill in real terminal — PASS** (full edit→fork-with-rerun = proxy-backed manual; checkout-to-predecessor headless-verified) — complementary live gate, running next (detects edit-mode via prefill text); will post results as a comment

**Tier self-check**: all new tests are Tier 2 (real instances / real registry / run_test real-DOM, no mocks; assert public surface — `edit_mode_active`, `snapshot()`, `check_action`, `selected_point` — not private state). Tier audit clean.

Refs #1533.

