### PR TITLE
feat(1533/2c-cancel): edit-cancel restores the pre-edit draft (co-authored)

### DIFF
--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -2411,6 +2411,10 @@ class ReynTUIApp(App):
         # caller's: submit (data-flow) dismisses it, Esc here keeps it.
         if self.edit_mode_active:
             self.exit_edit_mode()
+            # #1571: Esc-cancel = full undo of the pre-fill — restore whatever
+            # draft the user had before ctrl+t (the prod call-site for the
+            # data-flow's _restore_pre_edit_input; exit_edit_mode stays pure).
+            self._restore_pre_edit_input()
             return
         # ADR-0038 1f: dismiss the rewind menu before the side panel — the
         # menu is the most-recently-opened overlay, so Esc should close it

--- a/src/reyn/chat/tui/app.py
+++ b/src/reyn/chat/tui/app.py
@@ -268,6 +268,9 @@ class ReynTUIApp(App):
         # masquerade as a double-tap.
         self._last_clean_esc_ts: float = 0.0
         self._esc_hint_timer = None  # type: ignore[assignment]
+        # #1533 2c: the InputBar draft saved before an edit pre-fill replaces it,
+        # restored on Esc-cancel (full undo). Discarded on submit (committed).
+        self._pre_edit_input: str = ""
         self._cancel_event: asyncio.Event = asyncio.Event()
         # Most-recent "nothing-in-flight cancel" timestamp, used to
         # suppress repeated identical lines from accumulating in the conv
@@ -2722,9 +2725,29 @@ class ReynTUIApp(App):
         if not full:
             return
         try:
-            self.query_one("#inputbar", InputBar).set_text(full)
+            inputbar = self.query_one("#inputbar", InputBar)
+            # Save the pre-edit draft so Esc-cancel can restore it (the pre-fill
+            # replaces the buffer; #1533 2c full-undo). Only saved when we
+            # actually replace (full present), so a no-op pre-fill never
+            # clobbers a stored draft.
+            self._pre_edit_input = inputbar.current_text()
+            inputbar.set_text(full)
         except Exception:
             pass
+
+    def _restore_pre_edit_input(self) -> None:
+        """Restore the pre-edit draft on Esc-cancel from edit-mode (#1533 2c).
+
+        Cancel = full undo of the pre-fill: the loaded checkpoint message is
+        replaced by whatever draft the user had before ``ctrl+t``. Called by the
+        Esc-cancel path (NOT submit — submit consumes the edited text and the
+        normal submit flow clears the buffer). Keeps ``exit_edit_mode`` pure
+        (it never touches the InputBar; the text lifecycle is this surface)."""
+        try:
+            self.query_one("#inputbar", InputBar).set_text(self._pre_edit_input)
+        except Exception:
+            pass
+        self._pre_edit_input = ""
 
     async def _submit_edited_fork(self, edited_text: str) -> None:
         """Edit-and-retry (ADR-0038 2c): fork from the edited checkpoint's
@@ -2740,6 +2763,9 @@ class ReynTUIApp(App):
         ``None`` = first turn → no earlier state to fork from → graceful reject.
         """
         seq = self._edit_mode_seq          # capture BEFORE exit clears it
+        self._pre_edit_input = ""          # submit commits the edit — discard the
+                                           # saved draft so a later cancel can't
+                                           # restore a stale message.
         self.exit_edit_mode()              # flag + banner + Esc-Esc reset (shared seam)
         self._dismiss_rewind_menu()        # submit dismisses the picker
         try:

--- a/src/reyn/chat/tui/widgets/input_bar.py
+++ b/src/reyn/chat/tui/widgets/input_bar.py
@@ -405,6 +405,17 @@ class InputBar(Widget):
         """
         return bool(getattr(self.app, "edit_mode_active", False))
 
+    def current_text(self) -> str:
+        """Return the current input buffer text (public read).
+
+        Used to save a pre-edit draft before the /rewind edit pre-fill replaces
+        it (#1533 2c), so Esc-cancel can restore it. ``""`` if no TextArea.
+        """
+        try:
+            return self.query_one("#input", TextArea).text
+        except Exception:
+            return ""
+
     def set_text(self, text: str) -> None:
         """Replace the input buffer with ``text`` + move cursor to end.
 

--- a/tests/cli/test_fork_picker_edit_mode_2c.py
+++ b/tests/cli/test_fork_picker_edit_mode_2c.py
@@ -29,7 +29,7 @@ if str(_SRC) not in sys.path:
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
 from reyn.chat.tui.app import ReynTUIApp
-from reyn.chat.tui.widgets import ConversationView
+from reyn.chat.tui.widgets import ConversationView, InputBar
 from reyn.chat.tui.widgets.sticky_status import StickyStatus
 from reyn.events.agent_snapshot import AgentSnapshot
 from reyn.events.state_log import StateLog
@@ -260,3 +260,32 @@ async def test_ctrl_t_gated_off_on_first_turn_checkpoint(tmp_path) -> None:
         assert app.check_action("edit_checkpoint", ()) is False
         # nav bindings stay live regardless of predecessor (only edit is gated)
         assert app.check_action("rewind_prev", ()) is True
+
+
+@pytest.mark.asyncio
+async def test_esc_cancel_restores_pre_edit_draft(tmp_path) -> None:
+    """Tier 2: Esc-cancel from edit-mode restores the pre-edit draft (full undo
+    of the pre-fill) — the binding path (action_voice_cancel priority-3.5) calls
+    _restore_pre_edit_input, the prod call-site for the data-flow's restore. #1571.
+
+    Wire test (verify-live-dispatch): drives the real Esc key, not the restore
+    method directly, so it pins that the binding actually reaches it."""
+    reg = await _registry_with_checkpoints(tmp_path)
+    app = _make_app(reg)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        bar.set_text("my unfinished draft")
+        app._open_rewind_menu()
+        await pilot.pause()
+        seq = int(app._rewind_menu.selected_point()["seq"])
+        reg.anchor_store.capture(seq, "anchor…", full="the loaded checkpoint message")
+        app.action_edit_checkpoint()       # enter edit-mode + prefill (saves draft)
+        await pilot.pause()
+        assert app.edit_mode_active is True
+        assert bar.current_text() == "the loaded checkpoint message"   # prefilled
+        await pilot.press("escape")        # Esc-cancel via the binding path
+        await pilot.pause()
+        assert app.edit_mode_active is False                # edit exited
+        assert app.rewind_menu_open is True                 # picker kept (priority-3.5)
+        assert bar.current_text() == "my unfinished draft"  # draft restored (full undo)

--- a/tests/cli/test_rewind_edit_prefill_2c.py
+++ b/tests/cli/test_rewind_edit_prefill_2c.py
@@ -92,6 +92,30 @@ async def test_prefill_edit_no_message_is_noop(tmp_path) -> None:
         assert bar.query_one("#input").text == "draft"   # untouched
 
 
+@pytest.mark.asyncio
+async def test_prefill_saves_draft_and_restore_recovers_it(tmp_path) -> None:
+    """Tier 2: prefill saves the pre-edit draft; _restore_pre_edit_input recovers
+    it (Esc-cancel = full undo of the pre-fill). #1533 2c-cancel follow-up."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    reg.anchor_store.capture(7, "anchor…", full="the full original message")
+
+    app = ReynTUIApp(registry=reg, agent_name="alpha", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar = app.query_one("#inputbar", InputBar)
+        bar.set_text("my unfinished draft")          # pre-edit draft
+        app._prefill_edit(7)                           # replaces with the full message
+        await pilot.pause()
+        assert bar.current_text() == "the full original message"
+        app._restore_pre_edit_input()                  # Esc-cancel restore
+        await pilot.pause()
+        assert bar.current_text() == "my unfinished draft"   # draft recovered
+
+
 def test_tree_footer_advertises_ctrl_t_edit() -> None:
     """Tier 2: the tree footer surfaces ctrl+t edit (discoverability). ctrl+t,
     not ctrl+e: the focused TextArea binds ctrl+e → cursor_line_end and consumes

--- a/tests/cli/test_rewind_edit_prefill_2c.py
+++ b/tests/cli/test_rewind_edit_prefill_2c.py
@@ -6,8 +6,9 @@ edit-mode binding). Pins:
 - ``_prefill_edit(seq)`` loads the **full** original message (AnchorStore.get_full,
   NOT the truncated display anchor) into the InputBar, so an edited re-run keeps
   the whole message.
-- the tree footer advertises ``ctrl+e edit`` (discoverability; ctrl+e not bare
-  ``e`` — printable keys are swallowed by the focused InputBar).
+- the tree footer advertises ``ctrl+t edit`` (discoverability; ctrl+t not
+  ``ctrl+e`` — the focused TextArea binds ctrl+e → cursor_line_end and consumes
+  it, verified in tmux; ctrl+t is TextArea-unbound so the app binding fires).
 
 run_test real-DOM (mount-path) + a real AgentRegistry/AnchorStore — no mocks.
 The submit-handler (predecessor-turn checkout + fork) lands once sandbox_2's


### PR DESCRIPTION
**[tui-coder]** — Closes #1571. ADR-0038 2c follow-up: **Esc-cancel from edit-mode = full undo of the pre-fill** — restore whatever draft the user had before `ctrl+t`. Co-authored: e2e-coder (restore data-flow) × tui-coder (Esc-cancel binding call-site). Non-blocker follow-up to the merged #1570.

## Behaviour
`ctrl+t` loads a checkpoint's message into the InputBar (saving the user's current draft). If the user **submits**, the edit commits (new fork) and the saved draft is discarded. If the user **Esc-cancels**, the loaded message is replaced back with their original draft (full undo).

## Halves
- **Data-flow (e2e)**: `_prefill_edit` saves `_pre_edit_input = current_text()` before replacing; `_restore_pre_edit_input()` writes it back + clears; submit discards it. `InputBar.current_text()`.
- **Binding (tui-coder)**: the Esc-cancel path (`action_voice_cancel` priority-3.5, after `exit_edit_mode()`) calls `_restore_pre_edit_input()` — the **prod call-site** so the data-flow's restore method doesn't land unwired ([[feedback_new_method_needs_production_callsite_before_done]]). `exit_edit_mode` stays pure (InputBar text lifecycle is the data-flow's surface; the binding just invokes it).

## Test plan
- [x] `pytest tests/cli/test_fork_picker_edit_mode_2c.py tests/cli/test_rewind_edit_prefill_2c.py` — 15 (incl. `test_esc_cancel_restores_pre_edit_draft`, a **wire test** driving the real Esc key → restore, + e2e's `test_prefill_saves_draft_and_restore_recovers_it`)
- [x] `pytest tests/cli/ -k "edit_mode or fork_picker or prefill or esc or rewind"` — 53 passed (no regression)
- [x] `ruff check` — clean
- [x] (tmux) **Esc-cancel → draft restore in a real terminal** — PASS: draft typed → `ctrl+t` prefill replaces it → Esc-cancel restores the draft + clears the loaded message

**Tier self-check**: Tier 2 (real registry/AnchorStore, run_test real-DOM, no mocks; the new test asserts via the real Esc key path + public `current_text()`/`edit_mode_active`, not private state). The wire test is the key add — it pins the binding→restore dispatch, not just the restore method in isolation.

Refs #1533, #1571.
