### PR TITLE
feat(1533/2d): web /rewind fork picker — cl.Action tree + checkout (2d-1+2d-2)

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -785,6 +785,16 @@ async def _on_message(message: cl.Message) -> None:
     # (including unknown slashes, which get a hint on the outbox).
     text = message.content or ""
     if is_slash(text):
+        # Bare ``/rewind`` (no seq arg) gets the web-native picker: a
+        # branch tree rendered as ``cl.Action`` buttons instead of the
+        # TUI's keyboard-driven menu (Chainlit has no focusable list
+        # widget). ``/rewind <N>`` keeps flowing through the shared slash
+        # dispatcher → ``registry.checkout`` (parity with CUI/TUI). The
+        # picker's buttons call back into the same ``checkout`` path, so
+        # both surfaces converge on one substrate. (ADR-0038 2d-2)
+        if text.strip() == "/rewind":
+            await _render_rewind_picker(session)
+            return
         await session._maybe_handle_slash(text)
         # Chainlit-side cleanup: when reyn just wiped its own history,
         # remove the corresponding rendered messages from the browser
@@ -795,6 +805,63 @@ async def _on_message(message: cl.Message) -> None:
         return
 
     await session.submit_user_text(text)
+
+
+async def _render_rewind_picker(session) -> None:
+    """Render the branch tree as ``cl.Action`` buttons (web /rewind picker).
+
+    Thin glue (ADR-0038 2d-2): all shaping lives in the chainlit-free
+    ``rewind_actions`` module — this only gathers branches/checkpoints
+    from the registry, hands them to ``build_rewind_action_specs``, and
+    emits one ``cl.Action`` per checkpoint. The button click is handled
+    by ``on_rewind_checkout`` below, which calls back into the shared
+    ``checkout`` substrate. Best-effort: a registry/empty-history miss
+    degrades to a plain message rather than raising into the browser.
+    """
+    from dataclasses import asdict
+
+    from reyn.chainlit_app.rewind_actions import build_rewind_action_specs
+
+    try:
+        registry = await _get_or_build_registry()
+        branches = [asdict(b) for b in registry.list_branches()]
+        checkpoints = registry.list_rewind_points(include_abandoned=True)
+    except Exception as exc:  # noqa: BLE001 - surface, don't crash the thread
+        await cl.Message(content=f"⏪ rewind unavailable: {exc}").send()
+        return
+
+    specs = build_rewind_action_specs(branches, checkpoints)
+    if not specs:
+        await cl.Message(content="⏪ no rewind points yet").send()
+        return
+
+    actions = [
+        cl.Action(
+            name="rewind_checkout",
+            label=spec["label"],
+            payload={"seq": spec["seq"]},
+        )
+        for spec in specs
+    ]
+    await cl.Message(
+        content="⏪ **Rewind** — pick a point to return to (a fork point reopens that branch):",
+        actions=actions,
+    ).send()
+
+
+@cl.action_callback("rewind_checkout")
+async def on_rewind_checkout(action: "cl.Action") -> None:
+    """Handle a rewind-picker button: checkout the chosen seq.
+
+    Thin glue — the ``checkout`` + confirmation text live in the
+    chainlit-free ``handle_rewind_checkout``. (ADR-0038 2d-2)
+    """
+    from reyn.chainlit_app.rewind_actions import handle_rewind_checkout
+
+    seq = (action.payload or {}).get("seq")
+    registry = await _get_or_build_registry()
+    result = await handle_rewind_checkout(registry, seq)
+    await cl.Message(content=result).send()
 
 
 async def _clear_chainlit_thread() -> None:

--- a/src/reyn/chainlit_app/rewind_actions.py
+++ b/src/reyn/chainlit_app/rewind_actions.py
@@ -1,0 +1,85 @@
+"""Chainlit-free logic for the /rewind fork picker web surface (ADR-0038 2d-2).
+
+The web analog of the TUI fork picker: bare ``/rewind`` in Chainlit renders the
+branch tree as a message with a checkout action per checkpoint. This module is
+**chainlit-free** (no ``import chainlit``) so the logic is unit-testable without
+the chainlit runtime; the thin ``cl.Message`` / ``cl.Action`` glue lives in
+``app.py`` and consumes these specs.
+
+Reuses the pure ``build_branch_tree_rows`` (TUI 2b) — one tree-grouping source
+across TUI + web (lead-approved cross-surface reuse).
+"""
+from __future__ import annotations
+
+from reyn.chat.tui.widgets._branch_tree import (
+    ROW_CHECKPOINT,
+    build_branch_tree_rows,
+)
+
+
+def build_rewind_action_specs(
+    branches: list[dict],
+    checkpoints: list[dict],
+) -> list[dict]:
+    """Branch-tree rows → per-checkpoint checkout-action specs (pure).
+
+    Each spec drives one ``cl.Action`` in the web picker::
+
+        {"seq": int, "label": str, "branch_id": <id>, "is_active": bool}
+
+    ``label`` = ``#<seq> · <kind>[ · <anchor>][ (fork)]`` — the anchor is the
+    #1547 preview; an inactive (dead-branch) node is tagged ``(fork)`` so the
+    operator sees a checkout there is a fork-switch (vs an active-branch undo).
+    Only checkpoint rows become actions; header rows are decorators.
+    """
+    rows = build_branch_tree_rows(branches, checkpoints)
+    active_by_branch = {
+        r["branch_id"]: bool(r.get("is_active"))
+        for r in rows
+        if r.get("row") != ROW_CHECKPOINT
+    }
+    specs: list[dict] = []
+    for r in rows:
+        if r.get("row") != ROW_CHECKPOINT:
+            continue
+        seq = r["seq"]
+        kind = r.get("kind", "")
+        anchor = r.get("anchor", "")
+        is_active = active_by_branch.get(r.get("branch_id"), True)
+        label = f"#{seq} · {kind}"
+        if anchor:
+            label += f" · {anchor}"
+        if not is_active:
+            label += "  (fork)"
+        specs.append({
+            "seq": seq,
+            "label": label,
+            "branch_id": r.get("branch_id"),
+            "is_active": is_active,
+        })
+    return specs
+
+
+async def handle_rewind_checkout(registry, seq: int) -> str:
+    """Checkout to ``seq`` (the unified primitive: active = undo, dead-branch =
+    fork-switch) and return a confirmation line for the web surface.
+
+    Mirrors the TUI ``_do_checkout`` breadcrumb. Errors surface their reason
+    (retention / unknown seq) as a message rather than raising into the glue.
+    """
+    if registry is None:
+        return "⏪ checkout unavailable (no registry)"
+    if seq is None:
+        return "⏪ checkout unavailable (no seq in action)"
+    try:
+        result = await registry.checkout(seq)
+    except Exception as exc:  # noqa: BLE001 — surface the reason to the user
+        return f"⏪ checkout failed: {exc}"
+    agents = result.get("agents", [])
+    return (
+        f"⏪ checked out to seq {result.get('target_n', seq)} "
+        f"· {len(agents)} agent(s) reset · in-flight cancelled"
+    )
+
+
+__all__ = ["build_rewind_action_specs", "handle_rewind_checkout"]

--- a/tests/cli/test_chainlit_rewind_glue_2d.py
+++ b/tests/cli/test_chainlit_rewind_glue_2d.py
@@ -1,0 +1,37 @@
+"""Tier 1: chainlit /rewind picker glue wiring (ADR-0038 2d-2).
+
+The branch-tree → action-spec shaping and the checkout handler are
+chainlit-free and CI-tested in ``tests/test_rewind_actions_2d.py``; this
+file pins only the thin ``cl.*`` glue in ``chainlit_app.app`` — that the
+module imports under a real chainlit install and exposes the picker
+renderer + the ``rewind_checkout`` action callback. It is
+``importorskip``-guarded, so it skips in environments without the
+``chainlit`` extra (= reyn CI) and runs unguarded where chainlit is
+installed (tui-coder real-env verify). The interactive bare-/rewind →
+tree → checkout UI flow itself is a manual Test-plan smoke.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+pytest.importorskip("chainlit")
+
+from reyn.chainlit_app import app as chainlit_app  # noqa: E402
+
+
+def test_render_rewind_picker_is_async_glue():
+    """Tier 1: the picker renderer ships as an async function (it awaits
+    ``cl.Message(...).send()``)."""
+    fn = getattr(chainlit_app, "_render_rewind_picker", None)
+    assert fn is not None, "app.py must define _render_rewind_picker"
+    assert inspect.iscoroutinefunction(fn)
+
+
+def test_rewind_checkout_callback_registered():
+    """Tier 1: the ``rewind_checkout`` action callback exists as an async
+    handler (= the picker buttons name=\"rewind_checkout\" have a target)."""
+    fn = getattr(chainlit_app, "on_rewind_checkout", None)
+    assert fn is not None, "app.py must define on_rewind_checkout"
+    assert inspect.iscoroutinefunction(fn)

--- a/tests/test_rewind_actions_2d.py
+++ b/tests/test_rewind_actions_2d.py
@@ -1,0 +1,96 @@
+"""Tier 2: chainlit-free /rewind web action logic (ADR-0038 2d-2).
+
+`build_rewind_action_specs` (branch-tree rows → per-checkpoint cl.Action specs)
+and `handle_rewind_checkout` (seq → registry.checkout → confirmation) are
+chainlit-free so they're unit-testable without the chainlit runtime; the thin
+`cl.Message`/`cl.Action` glue (app.py) consumes them and is verified in a real
+chainlit env (tui-coder, importorskip-guarded). Real AgentRegistry — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chainlit_app.rewind_actions import (
+    build_rewind_action_specs,
+    handle_rewind_checkout,
+)
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.state_log import StateLog
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+def test_action_specs_label_active_vs_fork() -> None:
+    """Tier 2: each checkpoint → an action spec; active node label is plain,
+    an inactive (dead-branch) node is tagged (fork) + the #1547 anchor shows."""
+    branches = [
+        {"branch_id": 0, "fork_point_seq": 0, "head_seq": 13, "parent_branch_id": None, "is_active": True},
+        {"branch_id": 11, "fork_point_seq": 6, "head_seq": 10, "parent_branch_id": 0, "is_active": False},
+    ]
+    cps = [
+        {"seq": 12, "ts": "", "kind": "turn", "anchor": "deploy fix", "branch_id": 0},
+        {"seq": 9, "ts": "", "kind": "turn", "anchor": "try other", "branch_id": 11},
+    ]
+    specs = build_rewind_action_specs(branches, cps)
+    by_seq = {s["seq"]: s for s in specs}
+    assert by_seq[12]["is_active"] is True
+    assert "deploy fix" in by_seq[12]["label"] and "(fork)" not in by_seq[12]["label"]
+    assert by_seq[9]["is_active"] is False
+    assert "(fork)" in by_seq[9]["label"] and "try other" in by_seq[9]["label"]
+
+
+def test_action_specs_only_checkpoints() -> None:
+    """Tier 2: header (branch decorator) rows never become actions — only seq rows."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 6, "parent_branch_id": None, "is_active": True}]
+    cps = [{"seq": 3, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0}]
+    specs = build_rewind_action_specs(branches, cps)
+    assert [s["seq"] for s in specs] == [3]
+
+
+@pytest.mark.asyncio
+async def test_handle_checkout_invokes_registry(tmp_path) -> None:
+    """Tier 2: handle_rewind_checkout runs registry.checkout(seq) + returns a
+    confirmation naming the seq (non-default round-trip: WAL grows)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    log = reg.state_log
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    await log.append("inbox_consume", target="alpha", msg_id="m2")
+    head_before = log.current_seq
+
+    msg = await handle_rewind_checkout(reg, s1)
+
+    assert log.current_seq > head_before          # checkout ran
+    assert "checked out" in msg and f"seq {s1}" in msg
+
+
+@pytest.mark.asyncio
+async def test_handle_checkout_no_registry() -> None:
+    """Tier 2: handle_rewind_checkout with no registry → graceful message."""
+    msg = await handle_rewind_checkout(None, 5)
+    assert "unavailable" in msg
+
+
+@pytest.mark.asyncio
+async def test_handle_checkout_no_seq(tmp_path) -> None:
+    """Tier 2: a button payload missing ``seq`` → graceful message, never a
+    ``checkout(None)`` raise into the browser thread."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    msg = await handle_rewind_checkout(reg, None)
+    assert "unavailable" in msg

--- a/tests/test_rewind_web_2d.py
+++ b/tests/test_rewind_web_2d.py
@@ -1,0 +1,80 @@
+"""Tier 2: 2d web surface — `/rewind <N>` checkout via the Chainlit slash path.
+
+The Chainlit glue (``app.py:787`` — ``if is_slash(text): session._maybe_handle_slash``)
+routes ALL slashes to the same dispatcher the TUI uses, so ``/rewind <N>`` reaches
+``slash/rewind.py`` → ``registry.checkout(N)`` with no web-specific code. This pins
+that path with a **non-default-seq round-trip** (per
+feedback_roundtrip_test_nondefault_value): checkout to an EARLIER seq (not the
+head, not a no-op) and verify the active branch actually moved there — so an
+unwired / no-op checkout can't silent-pass.
+
+(The bare-`/rewind` tree picker for web is 2d-2 — a Chainlit cl.Action surface,
+separate.) Real AgentRegistry + real slash handler — no mocks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chainlit_app.slash_route import is_slash
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.slash import REGISTRY
+from reyn.events.snapshot_generations import is_active_seq
+from reyn.events.state_log import StateLog
+
+
+class _CapturingSession:
+    def __init__(self, registry) -> None:
+        self.agent_name = "alpha"
+        self._registry = registry
+        self.outbox_msgs: list = []
+
+    async def _put_outbox(self, msg) -> None:
+        self.outbox_msgs.append(msg)
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+def test_chainlit_recognises_rewind_as_slash() -> None:
+    """Tier 2: the Chainlit is_slash gate (app.py:787) routes /rewind to the
+    shared dispatcher — so /rewind <N> reaches the same handler as the TUI."""
+    assert is_slash("/rewind 5") is True
+    assert is_slash("/rewind") is True
+    assert is_slash("not a slash") is False
+
+
+@pytest.mark.asyncio
+async def test_rewind_seq_checkout_round_trip_nondefault(tmp_path) -> None:
+    """Tier 2: /rewind <N> (Chainlit path) checks out to a NON-DEFAULT earlier
+    seq — the active branch moves to N and the later seq is abandoned. A no-op /
+    unwired checkout would leave the head active and FAIL this.
+    """
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    log = reg.state_log
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")  # head
+    assert is_active_seq(log, s1) and is_active_seq(log, s2)   # both active pre-rewind
+
+    # Drive the slash handler exactly as the Chainlit glue does
+    # (is_slash → session._maybe_handle_slash → REGISTRY → rewind handler).
+    session = _CapturingSession(registry=reg)
+    await REGISTRY.get("rewind").handler(session, str(s1))   # /rewind <s1>, non-default
+
+    # Round-trip: the active branch moved to s1; s2 (the former head) is abandoned.
+    assert is_active_seq(log, s1) is True
+    assert is_active_seq(log, s2) is False
+    texts = [getattr(m, "text", "") for m in session.outbox_msgs]
+    assert any("checked out" in t and f"seq {s1}" in t for t in texts)

--- a/tests/test_web_rewind_attach_seam_2d.py
+++ b/tests/test_web_rewind_attach_seam_2d.py
@@ -1,0 +1,116 @@
+"""Tier 2: OS invariant — 2d web checkout restores BOTH substrates via the
+registry attach-seam (ADR-0038 2d-2, #1533).
+
+The 2d merge-critical gating. The web/Chainlit session is acquired via
+``registry.attach`` → ``get_or_load`` (registry.py), which **auto-attaches** the
+shared workspace shadow-git + anchor stores. This gate proves that auto-attach
+makes a web-path-acquired session's ``checkout`` restore the **workspace**
+(not just runtime) — i.e. the web session is NOT runtime-only.
+
+Distinct from ``test_live_fork_gate`` (which builds ``ChatSession`` directly and
+attaches the stores MANUALLY): here NO manual ``attach_*`` call is made — the
+``get_or_load`` seam does it. If the seam didn't auto-attach (the #1556-class
+web-construction bug), the workspace would NOT revert on checkout and this test
+would fail. Real AgentRegistry + ChatSession + StateLog + git, no mocks; a
+no-LLM ``_FakeTurnDriver`` drives the real ``_run_router_loop`` so genuine
+``cut_generation`` fires (only the file write is simulated).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.events.state_log import StateLog
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+_WS_FILE = "code.py"
+
+
+class _FakeTurnDriver:
+    """No-LLM driver: writes the turn's workspace file + appends a runtime inbox
+    marker, so the real ``_run_router_loop`` runs and its genuine
+    ``cut_generation`` fires. Only the file write is simulated."""
+
+    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+        self._session = session
+        self._ws = ws_root
+        self._content = content
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        (self._ws / _WS_FILE).write_text(self._content[user_text], encoding="utf-8")
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_web_path_session_checkout_restores_workspace(tmp_path) -> None:
+    """Tier 2: a session acquired via get_or_load (the web attach-seam) restores
+    the WORKSPACE on checkout — proving the seam auto-attached the workspace
+    store (no manual attach). The #1556-class runtime-only bug fails this."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> ChatSession:
+        snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
+        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+
+    # WEB acquisition path: get_or_load auto-attaches workspace + anchor stores.
+    # NO manual attach_workspace_store / attach_anchor_store here — that is the
+    # whole point (the seam wires them).
+    session = reg.get_or_load("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "v1", "B": "v2"})
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    await session._run_router_loop("B", "c1")
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "v2"   # pre-checkout
+
+    # Web checkout (the unified primitive) to seq A → BOTH substrates revert.
+    await reg.checkout(seq_a)
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "v1"   # WORKSPACE reverted
+    markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
+    assert markers == ["A"]                                            # runtime reverted
+
+
+@pytest.mark.asyncio
+async def test_web_path_session_records_anchor_for_picker(tmp_path) -> None:
+    """Tier 2: the get_or_load seam auto-attaches the anchor store too, so a web
+    turn's cut_generation records the rewind-timeline anchor (the picker's
+    preview + the edit pre-fill source). Empty anchor store = #1556-class bug."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> ChatSession:
+        snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
+        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    session = reg.get_or_load("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "v1"})
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+
+    # The anchor store (auto-attached) recorded this boundary — the picker can
+    # show a preview / the edit pre-fill has a source. (Anchor text comes from
+    # the turn's user_text via cut_generation; non-empty proves the attach.)
+    assert reg.anchor_store.get(seq_a) != "" or reg.anchor_store.get_full(seq_a) != ""

--- a/tests/test_web_rewind_attach_seam_2d.py
+++ b/tests/test_web_rewind_attach_seam_2d.py
@@ -110,7 +110,10 @@ async def test_web_path_session_records_anchor_for_picker(tmp_path) -> None:
     await session._run_router_loop("A", "c1")
     seq_a = session.current_snapshot.applied_seq
 
-    # The anchor store (auto-attached) recorded this boundary — the picker can
-    # show a preview / the edit pre-fill has a source. (Anchor text comes from
-    # the turn's user_text via cut_generation; non-empty proves the attach.)
-    assert reg.anchor_store.get(seq_a) != "" or reg.anchor_store.get_full(seq_a) != ""
+    # The anchor store (auto-attached) recorded this boundary — both the
+    # picker's truncated preview (get) AND the edit pre-fill's full source
+    # (get_full) come from the turn's user_text via cut_generation, which now
+    # persists both. Asserting both non-empty proves the attach end-to-end
+    # (a #1556-class runtime-only acquisition would leave both empty).
+    assert reg.anchor_store.get(seq_a) != ""
+    assert reg.anchor_store.get_full(seq_a) != ""


### PR DESCRIPTION
**[e2e-coder]** — web `/rewind` fork picker (ADR-0038 Phase-2 2d-1 + 2d-2)

Brings the time-travel rewind picker to the Chainlit web surface, at parity with the TUI fork picker (2b). Bundles **2d-1** (`/rewind <N>` slash-path verify) + **2d-2** (bare `/rewind` → branch-tree picker + checkout). **2d-3 (web-edit) is deliberately NOT in this PR** — it is still in flow-trace/design (#1533), so this lands the core picker independently.

## What

- **Bare `/rewind`** in Chainlit renders the branch tree as a `cl.Message` with one `cl.Action` per checkpoint. Clicking checks out to that seq — the unified `registry.checkout` primitive (active branch = undo, dead branch = fork-switch), identical substrate to TUI 2b. Dead-branch nodes are tagged `(fork)`; the #1547 anchor shows in the label.
- **`/rewind <N>`** keeps flowing through the shared slash dispatcher → `registry.checkout` (unchanged; 2d-1 pins it).

## How (chainlit_app split — established adapter pattern, lead-confirmed)

All shaping is **chainlit-free + CI-tested**; only the thin `cl.*` glue lives in `app.py` (real-env verified):

- `src/reyn/chainlit_app/rewind_actions.py` (NEW, no `import chainlit`):
  - `build_rewind_action_specs` — branch-tree rows → per-checkpoint action specs. Reuses the pure `build_branch_tree_rows` from 2b → **one tree-grouping source across TUI + web**.
  - `handle_rewind_checkout` — seq → `checkout` → confirmation breadcrumb. None-registry / None-seq degrade gracefully (never raise into the browser thread).
- `src/reyn/chainlit_app/app.py` (thin glue): bare-`/rewind` intercept → `_render_rewind_picker`; `@cl.action_callback("rewind_checkout")` → `handle_rewind_checkout`.

## Peer review (PR = contract — captured here from the pre-PR substrate/design gate)

- **lead-coder — deep-review PASS** (d63efe15): pure logic + single tree source + unified checkout primitive + fork tag + #1547 anchor label clean; glue thin (no logic leak); attach-seam guard genuine (real web path, not a fake) — the #1556-class structural guard, web analog of #1564.
- **sandbox_2 (dogfood-coder) — substrate-review PASS** (3 pieces): (1) `handle_rewind_checkout` reads `{target_n, agents}` matching the `checkout` return exactly (registry.py:484-486), breadcrumb accurate; (2) `test_web_rewind_attach_seam_2d` is the requested web analog of `test_live_fork_gate` — `get_or_load` web path (no manual attach), genuine `cut_generation`, asserts workspace + runtime + anchor revert; (3) `build_rewind_action_specs` substrate-consistent. The optional nit (assert both anchor `get` + `get_full`) is applied in 99ed948a.

## Test plan

CI-tested (chainlit-free):
- [x] `tests/test_rewind_actions_2d.py` — Tier 2, 5 tests: label active-vs-(fork) + anchor; only checkpoint rows become actions; checkout invokes registry (non-default WAL round-trip); no-registry / no-seq guards.
- [x] `tests/test_web_rewind_attach_seam_2d.py` — Tier 2, 2 tests: the #1556-class merge guard. `get_or_load` auto-attaches workspace + anchor → web checkout reverts both substrates + records the picker anchor (both `get` + `get_full`).
- [x] `pytest -q` (rootdir) green; `ruff check .` clean; `scripts/test_tier_audit.py --strict` clean; `app.py` `py_compile` OK.

Real-env (chainlit installed — tui-coder, chainlit 2.11.1):
- [x] `tests/cli/test_chainlit_rewind_glue_2d.py` run **unguarded** (importorskip skips it in reyn CI) — 2 Tier-1 glue-wiring asserts pass.
- [x] Smoke: bare `/rewind` → branch tree of `cl.Action` buttons (label `#seq · kind · anchor`, dead-branch `(fork)`) → click → checkout confirmation message.
- [x] Smoke: `/rewind <N>` path still checks out via the slash dispatcher (unchanged).

Refs #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

