### PR TITLE
feat(1533/2d): web edit-fork — ✎ edit a turn as a new fork (2d-3)

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -835,16 +835,25 @@ async def _render_rewind_picker(session) -> None:
         await cl.Message(content="⏪ no rewind points yet").send()
         return
 
-    actions = [
-        cl.Action(
+    # Each checkpoint gets a checkout (↩) action; turn checkpoints ALSO get an
+    # edit (✎) action (ADR-0038 2d-3 decision A) — clicking it re-runs an edited
+    # version as a new fork. First-turn edit is rejected on click (decision B),
+    # not filtered here, so the spec builder stays pure.
+    actions = []
+    for spec in specs:
+        actions.append(cl.Action(
             name="rewind_checkout",
-            label=spec["label"],
+            label=f"↩ {spec['label']}",
             payload={"seq": spec["seq"]},
-        )
-        for spec in specs
-    ]
+        ))
+        if spec.get("editable"):
+            actions.append(cl.Action(
+                name="rewind_edit",
+                label=f"✎ edit #{spec['seq']}",
+                payload={"seq": spec["seq"]},
+            ))
     await cl.Message(
-        content="⏪ **Rewind** — pick a point to return to (a fork point reopens that branch):",
+        content="⏪ **Rewind** — ↩ returns to a point (a fork point reopens that branch); ✎ edits a turn as a new fork:",
         actions=actions,
     ).send()
 
@@ -862,6 +871,47 @@ async def on_rewind_checkout(action: "cl.Action") -> None:
     registry = await _get_or_build_registry()
     result = await handle_rewind_checkout(registry, seq)
     await cl.Message(content=result).send()
+
+
+@cl.action_callback("rewind_edit")
+async def on_rewind_edit(action: "cl.Action") -> None:
+    """Handle an edit (✎) picker button: prompt for an edited message, then
+    re-run it from the turn's predecessor = a new fork (ADR-0038 2d-3).
+
+    Thin glue — ``resolve_edit_target`` (genesis reject + full-original lookup)
+    and ``handle_rewind_edit_submit`` (checkout(predecessor) → submit) are
+    chainlit-free. Chainlit has no input pre-fill, so the original message is
+    shown in the prompt and the user retypes the edited version (owner-accepted
+    UX). The agent response flows back through the existing repl_outbox drain.
+    """
+    from reyn.chainlit_app.rewind_actions import (
+        handle_rewind_edit_submit,
+        resolve_edit_target,
+    )
+
+    seq = (action.payload or {}).get("seq")
+    registry = await _get_or_build_registry()
+    info = resolve_edit_target(registry, seq)
+    if not info["can_edit"]:
+        await cl.Message(content=f"✋ {info['reason']}").send()
+        return
+
+    prompt = "✎ Edit your message, then send to fork from here"
+    if info["original"]:
+        prompt += f" (original below):\n\n> {info['original']}"
+    reply = await cl.AskUserMessage(content=prompt, timeout=600).send()
+    if reply is None:
+        await cl.Message(content="✎ edit cancelled").send()
+        return
+    # ``AskUserMessage`` returns a step dict; the typed text is under "output".
+    edited = (reply.get("output") if isinstance(reply, dict) else None) or ""
+    if not edited.strip():
+        await cl.Message(content="✎ edit cancelled (empty)").send()
+        return
+
+    result = await handle_rewind_edit_submit(registry, info["fork_target"], edited)
+    if result:  # non-empty = an error/notice; success drains via repl_outbox
+        await cl.Message(content=result).send()
 
 
 async def _clear_chainlit_thread() -> None:

--- a/src/reyn/chainlit_app/rewind_actions.py
+++ b/src/reyn/chainlit_app/rewind_actions.py
@@ -128,10 +128,13 @@ async def handle_rewind_edit_submit(registry, fork_target: int, edited: str) -> 
     (checkout(predecessor) → submit); only the prompt shell differs
     (cl.AskUserMessage vs InputBar edit-mode).
 
-    **Re-fetches the session AFTER checkout**: ``checkout`` cancels in-flight work
-    and *reconstructs* the agent session, so a session captured before the call is
-    stale — the edited turn must submit on the freshly-reconstructed session (the
-    TUI mirror re-fetches via ``_get_session()`` for the same reason).
+    **Submit MUST follow checkout (ordering invariant)**: ``checkout`` →
+    ``reset_for_rewind`` *drains the session inbox* (session.py), so a message
+    submitted *before* checkout would be discarded. We submit after. The session
+    is mutated in-place (not reconstructed — ``_agents[name]`` is not reassigned),
+    so ``attached_session()`` returns the same object a pre-call capture would;
+    the re-fetch is defensive (and mirrors TUI 2c's ``_get_session()``-after-
+    checkout), not identity-critical.
 
     Returns an empty string on success — the agent response flows through the
     existing repl_outbox → cl.Message drain. A checkout failure / missing

--- a/src/reyn/chainlit_app/rewind_actions.py
+++ b/src/reyn/chainlit_app/rewind_actions.py
@@ -31,6 +31,11 @@ def build_rewind_action_specs(
     #1547 preview; an inactive (dead-branch) node is tagged ``(fork)`` so the
     operator sees a checkout there is a fork-switch (vs an active-branch undo).
     Only checkpoint rows become actions; header rows are decorators.
+
+    ``editable`` = the row is a **turn** checkpoint → the glue also renders an
+    edit (✎) action for it (ADR-0038 2d-3 decision A; non-turn rows get
+    checkout-only). The genesis first-turn case is *not* filtered here (kept pure)
+    — it is rejected on click by ``resolve_edit_target`` (decision B).
     """
     rows = build_branch_tree_rows(branches, checkpoints)
     active_by_branch = {
@@ -56,6 +61,7 @@ def build_rewind_action_specs(
             "label": label,
             "branch_id": r.get("branch_id"),
             "is_active": is_active,
+            "editable": kind == "turn",
         })
     return specs
 
@@ -82,4 +88,71 @@ async def handle_rewind_checkout(registry, seq: int) -> str:
     )
 
 
-__all__ = ["build_rewind_action_specs", "handle_rewind_checkout"]
+def resolve_edit_target(registry, seq: int) -> dict:
+    """Resolve the web edit-fork inputs for ``seq`` (ADR-0038 2d-3, chainlit-free).
+
+    Returns ``{can_edit, original, fork_target, reason}``:
+
+    - ``fork_target`` = ``predecessor_turn_checkpoint(seq)`` — the lineage-correct
+      prior **turn** checkpoint (cross-fork-point + plan-step-skip). The edit
+      re-runs from *before* the edited turn, so this is the checkout target.
+    - ``original`` = ``anchor_store.get_full(seq)`` — the full original message to
+      show in the prompt (Chainlit has no input pre-fill; the user retypes).
+    - ``can_edit`` = False with a ``reason`` when there is no prior turn (genesis):
+      the glue rejects the click rather than rendering a dead prompt (decision B —
+      keeps the spec builder pure; matches the TUI 2c first-turn backstop).
+
+    Mirrors the resolution half of TUI 2c ``_submit_edited_fork`` (app.py) — same
+    substrate, surface-agnostic.
+    """
+    if registry is None:
+        return {"can_edit": False, "original": "", "fork_target": None,
+                "reason": "edit unavailable (no registry)"}
+    fork_target = registry.predecessor_turn_checkpoint(seq)
+    if fork_target is None:
+        return {"can_edit": False, "original": "", "fork_target": None,
+                "reason": "cannot edit the first turn — no earlier checkpoint to fork from"}
+    anchors = registry.anchor_store
+    original = anchors.get_full(seq) if anchors is not None else ""
+    return {"can_edit": True, "original": original, "fork_target": fork_target,
+            "reason": ""}
+
+
+async def handle_rewind_edit_submit(registry, fork_target: int, edited: str) -> str:
+    """Re-run an edited message from ``fork_target`` = a new fork (ADR-0038 2d-3).
+
+    The 2c substrate path, surface-agnostic: ``checkout(fork_target)`` rewinds to
+    the state before the edited turn, then ``submit_user_text(edited)`` re-runs the
+    edited message — producing a sibling fork while the original turn stays on a
+    now-inactive branch (append-only). Identical to TUI 2c ``_submit_edited_fork``
+    (checkout(predecessor) → submit); only the prompt shell differs
+    (cl.AskUserMessage vs InputBar edit-mode).
+
+    **Re-fetches the session AFTER checkout**: ``checkout`` cancels in-flight work
+    and *reconstructs* the agent session, so a session captured before the call is
+    stale — the edited turn must submit on the freshly-reconstructed session (the
+    TUI mirror re-fetches via ``_get_session()`` for the same reason).
+
+    Returns an empty string on success — the agent response flows through the
+    existing repl_outbox → cl.Message drain. A checkout failure / missing
+    collaborator surfaces its reason as a message rather than raising into the glue.
+    """
+    if registry is None or fork_target is None:
+        return "⏪ edit unavailable"
+    try:
+        await registry.checkout(fork_target)
+    except Exception as exc:  # noqa: BLE001 — surface the reason to the user
+        return f"⏪ edit checkout failed: {exc}"
+    session = registry.attached_session()
+    if session is None:
+        return "⏪ edit unavailable (no session)"
+    await session.submit_user_text(edited)
+    return ""
+
+
+__all__ = [
+    "build_rewind_action_specs",
+    "handle_rewind_checkout",
+    "resolve_edit_target",
+    "handle_rewind_edit_submit",
+]

--- a/tests/cli/test_chainlit_rewind_glue_2d.py
+++ b/tests/cli/test_chainlit_rewind_glue_2d.py
@@ -35,3 +35,11 @@ def test_rewind_checkout_callback_registered():
     fn = getattr(chainlit_app, "on_rewind_checkout", None)
     assert fn is not None, "app.py must define on_rewind_checkout"
     assert inspect.iscoroutinefunction(fn)
+
+
+def test_rewind_edit_callback_registered():
+    """Tier 1: the ``rewind_edit`` action callback exists as an async handler
+    (= the picker's ✎ edit buttons name=\"rewind_edit\" have a target). 2d-3."""
+    fn = getattr(chainlit_app, "on_rewind_edit", None)
+    assert fn is not None, "app.py must define on_rewind_edit"
+    assert inspect.iscoroutinefunction(fn)

--- a/tests/test_rewind_actions_2d.py
+++ b/tests/test_rewind_actions_2d.py
@@ -20,6 +20,7 @@ if str(_SRC) not in sys.path:
 from reyn.chainlit_app.rewind_actions import (
     build_rewind_action_specs,
     handle_rewind_checkout,
+    resolve_edit_target,
 )
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
@@ -47,6 +48,25 @@ def test_action_specs_label_active_vs_fork() -> None:
     assert "deploy fix" in by_seq[12]["label"] and "(fork)" not in by_seq[12]["label"]
     assert by_seq[9]["is_active"] is False
     assert "(fork)" in by_seq[9]["label"] and "try other" in by_seq[9]["label"]
+
+
+def test_action_specs_editable_only_on_turns() -> None:
+    """Tier 2: turn checkpoints are editable (glue renders the ✎ action);
+    non-turn (plan-step) checkpoints are checkout-only (decision A)."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True}]
+    cps = [
+        {"seq": 8, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0},
+        {"seq": 5, "ts": "", "kind": "plan_step", "anchor": "", "branch_id": 0},
+    ]
+    by_seq = {s["seq"]: s for s in build_rewind_action_specs(branches, cps)}
+    assert by_seq[8]["editable"] is True
+    assert by_seq[5]["editable"] is False
+
+
+def test_resolve_edit_target_no_registry() -> None:
+    """Tier 2: resolve_edit_target with no registry → can_edit False, no raise."""
+    info = resolve_edit_target(None, 5)
+    assert info["can_edit"] is False and info["fork_target"] is None
 
 
 def test_action_specs_only_checkpoints() -> None:

--- a/tests/test_web_edit_fork_gate_2d.py
+++ b/tests/test_web_edit_fork_gate_2d.py
@@ -1,0 +1,163 @@
+"""Tier 2: OS invariant — the 2d web edit path inherits 2c fork semantics
+(ADR-0038 2d-3, #1533).
+
+The 2d-3 merge-critical gating, lead-required. The web edit glue is thin; what
+must be proven is that the chainlit-free ``resolve_edit_target`` +
+``handle_rewind_edit_submit`` — driven through a session acquired via the web
+``get_or_load`` seam — produce the SAME fork semantics as TUI 2c
+``_submit_edited_fork`` (not merely share function names). Three invariants:
+
+- **edit = new fork**: the edited message runs as a new active branch.
+- **original = inactive**: the original turn lands on a now-abandoned branch.
+- **lineage cross-fork-point**: editing a forked branch's FIRST turn resolves the
+  fork target to the PARENT's fork-point turn (not None, not a same-branch miss).
+
+Plus the genesis guard (first turn → reject, decision B). Real AgentRegistry +
+ChatSession + StateLog + git; a no-LLM ``_FakeTurnDriver`` drives the real
+``_run_router_loop`` so genuine ``cut_generation`` / fork records fire. No mocks.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chainlit_app.rewind_actions import (
+    handle_rewind_edit_submit,
+    resolve_edit_target,
+)
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.events.snapshot_generations import is_active_seq
+from reyn.events.state_log import StateLog
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+_WS_FILE = "code.py"
+
+
+class _FakeTurnDriver:
+    """No-LLM driver: writes the turn's workspace file (keyed by user_text) +
+    appends a runtime inbox marker, so the real ``_run_router_loop`` runs and its
+    genuine ``cut_generation`` / fork records fire. Only the write is simulated."""
+
+    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+        self._session = session
+        self._ws = ws_root
+        self._content = content
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        (self._ws / _WS_FILE).write_text(self._content[user_text], encoding="utf-8")
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> ChatSession:
+        snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
+        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_web_edit_makes_new_fork_original_inactive(tmp_path) -> None:
+    """Tier 2: editing turn B (web path) re-runs from B's predecessor (A) as a new
+    fork — the edited turn is active, the original B is on an abandoned branch,
+    and the workspace reflects the edited content."""
+    reg = _make_registry(tmp_path)
+    session = await reg.attach("alpha")           # web path (attach → get_or_load auto-attach)
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(
+        session, tmp_path, {"A": "vA", "B": "vB", "B-edited": "vB2"},
+    )
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    await session._run_router_loop("B", "c1")
+    seq_b = session.current_snapshot.applied_seq
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vB"
+
+    # Resolve the edit target for B: predecessor TURN = A.
+    info = resolve_edit_target(reg, seq_b)
+    assert info["can_edit"] is True
+    assert info["fork_target"] == seq_a
+
+    # Submit the edited message = checkout(A) → enqueue "B-edited" on the
+    # reset-in-place attached session. checkout already reverted the workspace +
+    # abandoned B before the new turn runs.
+    result = await handle_rewind_edit_submit(reg, info["fork_target"], "B-edited")
+    assert result == ""                                            # success drains via outbox
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vA"   # checked out to A
+    assert not is_active_seq(reg.state_log, seq_b)                 # original B abandoned
+
+    # Drain the inbox through the real consumer (the production web loop does
+    # this) → the edited turn re-runs from A = a new active fork. checkout
+    # re-queued the reset snapshot's inbox markers, so drain rather than a single
+    # step (the markers dispatch as no-ops; the "user" submission runs the turn).
+    while session.inbox.qsize() > 0:
+        await session.run_one_iteration()
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vB2"   # edited turn ran
+    assert is_active_seq(reg.state_log, session.current_snapshot.applied_seq)  # new fork active
+    assert not is_active_seq(reg.state_log, seq_b)                 # original B still abandoned
+
+
+@pytest.mark.asyncio
+async def test_web_edit_cross_fork_point_resolves_parent_turn(tmp_path) -> None:
+    """Tier 2: editing a FORKED branch's first turn resolves the fork target to
+    the PARENT's fork-point turn (lineage cross-fork-point) — not None, not a
+    same-branch miss. Mirrors the 2c predecessor cross-fork case on the web path."""
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(
+        session, tmp_path, {"A": "vA", "B": "vB", "C": "vC"},
+    )
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    await session._run_router_loop("B", "c1")
+
+    # Fork: rewind to A, then run C → C is the FIRST turn of a new branch off A.
+    await reg.checkout(seq_a)
+    await session._run_router_loop("C", "c1")
+    seq_c = session.current_snapshot.applied_seq
+
+    info = resolve_edit_target(reg, seq_c)
+    assert info["can_edit"] is True
+    # C is its branch's first turn, but the lineage predecessor crosses the
+    # fork point back to the parent's turn A — NOT None, NOT same-branch.
+    assert info["fork_target"] == seq_a
+
+
+@pytest.mark.asyncio
+async def test_web_edit_first_turn_rejected(tmp_path) -> None:
+    """Tier 2: the first turn has no earlier turn to fork from → resolve rejects
+    (decision B reject-on-click), the glue never reaches checkout/submit."""
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "vA"})
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+
+    info = resolve_edit_target(reg, seq_a)
+    assert info["can_edit"] is False
+    assert info["fork_target"] is None
+    assert "first turn" in info["reason"]


### PR DESCRIPTION
**[e2e-coder]** — web edit-fork: ✎ edit a turn as a new fork (ADR-0038 Phase-2 2d-3)

Completes Phase-2 web time-travel: on top of the merged 2d-2 picker (#1573), each **turn** checkpoint gets an ✎ edit action next to its ↩ checkout. Clicking it prompts for an edited message and re-runs it as a new fork — the web analog of TUI 2c edit-and-retry, reusing the identical substrate.

## What

- The picker renders ✎ `edit #<seq>` for every turn checkpoint (decision A); non-turn (plan-step) rows stay checkout-only.
- Clicking ✎ → `cl.AskUserMessage` shows the original full message (Chainlit has no input pre-fill, so the user retypes — owner-accepted UX) → on submit, `checkout(predecessor_turn_checkpoint(seq))` → `submit_user_text(edited)` = a new fork. The original turn stays on a now-inactive branch (append-only).
- First-turn edit (no prior turn) is rejected on click (decision B), keeping the spec builder pure.

## How (chainlit_app split — logic chainlit-free + CI-tested, thin glue real-env verified)

- `rewind_actions.py` (no `import chainlit`):
  - `resolve_edit_target` — `predecessor_turn_checkpoint` + `anchor_store.get_full` (None-guarded); genesis → `can_edit=False`.
  - `handle_rewind_edit_submit` — `checkout(fork_target)` → submit (ordering invariant: `checkout`→`reset_for_rewind` *drains the session inbox*, so a submit *before* checkout would be discarded — submit follows). `attached_session()` is re-fetched defensively (mirrors TUI 2c), but `checkout` mutates the session in-place — not reconstructed — so it's the same object (sandbox_2-verified, docstring corrected in `1c3f1829`).
  - `build_rewind_action_specs` gains `editable` (= turn-kind) so the glue renders ✎ only on turn rows.
- `app.py` glue (thin): ✎ `cl.Action` per editable spec; `@cl.action_callback("rewind_edit")` → resolve → `AskUserMessage` → submit.

## Peer review (PR = contract)

- **lead-coder — branch-review PASS** (code+semantics) with a docstring fix-before-merge (done, `1c3f1829`): the **submit-after-checkout ordering invariant** is correct — `checkout`→`reset_for_rewind` drains the inbox, so a submit must follow checkout. The `attached_session()` re-fetch is a **defensive no-op** (`checkout` mutates the session in-place; `_agents[name]` is not reassigned), not identity-critical — both sandbox_2 and lead primary-verified this, correcting my initial "stale-session reconstruction" rationale. The gating test proves the fork semantics on the **real attach path** (a mock would not exercise the real `checkout`/inbox interaction) — exactly why lead required it.
- **sandbox_2 — flow-trace substrate-review PASS** ("Build it"): substrate reuse correct (2a/4a/4b identical to TUI 2c); both flags addressed — anchor_store None-guard + explicit cross-fork-point test. (Branch substrate second-review pending.)
- **tui-coder — chainlit live-verify PASS** (real chainlit 2.11.1): glue test 3/3 unguarded (incl. `on_rewind_edit` wiring); **design-decision-C confirmed** — `cl.AskUserMessage().send()` returns a `StepDict` (TypedDict → dict) with the typed text under `"output"`, and `None` on timeout/dismiss; the glue's `if reply is None` + `isinstance(reply, dict)` guards handle both (no AttributeError into the browser).

## Test plan

CI-tested (chainlit-free):
- [x] `tests/test_web_edit_fork_gate_2d.py` — Tier 2 (lead-required gating): the web path **inherits** 2c fork semantics, not just shares names. **new-fork + original-inactive** (edit B → re-run from A; `is_active_seq(B)=False`; edited turn active) + **lineage cross-fork-point** (edit a forked branch's first turn → `fork_target` = parent fork-point) + **genesis reject**. Real `attach` web path + real `cut_generation`, no mocks.
- [x] `tests/test_rewind_actions_2d.py` — editable-only-on-turns + `resolve_edit_target` no-registry guard.
- [x] `pytest -q` (rebased on main) green; `ruff check` clean; `test_tier_audit.py --strict` clean; `py_compile` OK; 98 rewind-regression pass.

Real-env (chainlit installed — tui-coder, chainlit 2.11.1):
- [x] `tests/cli/test_chainlit_rewind_glue_2d.py` unguarded — 3/3 (incl. `on_rewind_edit`) + 6/6 deep `on_rewind_edit` runtime smoke + design-C confirmed end-to-end. Verified by tui-coder in real chainlit 2.11.1 (issuecomment-4698720186).
- [x] (skipped — framework boundary: the browser `AskUserMessage` round-trip [prompt shown → user types → response] + the LLM re-run are playwright/manual scope, not reyn glue. The reyn glue is verified by tui-coder's 6/6 `on_rewind_edit` runtime smoke, and `test_web_edit_fork_gate_2d` gates the fork semantics on the real path.) Smoke: turn checkpoint shows ✎ edit → click → `AskUserMessage` prompt with the original → type edited → forks.

Refs #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
