### PR TITLE
docs(time-travel): mark Phase 2d web surface as landed (#1574)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -257,7 +257,7 @@ mindmap
 
 #### Time-Travel / Rewind (Resume)
 
-User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c) are production; Phase 2d (web surface) is in-progress. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: ADR-0038 (PR #1536, pending merge). Change ledger: #1533.
+User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2d) are production. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: ADR-0038 (PR #1536, pending merge). Change ledger: #1533.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
@@ -276,7 +276,7 @@ User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c) 
 | Deterministic CI live-fork gate | `test_live_fork_gate.py` — Phase-2 fork / checkout deterministic gate (#1564) | — |
 | tmux live e2e | P1 undo + P2 fork-switch verified on real terminal (#1533 tui-coder ledger / #1549) | — |
 | Phase 2c: fork-then-edit | New branch on edit via `ctrl+t` | [How-to: rewind](guide/for-users/time-travel.md) |
-| Phase 2d: web surface ⏳ | `/rewind` picker over WebSocket / A2A (in-progress) | — |
+| Phase 2d: web surface | `/rewind` picker over WebSocket / A2A; web edit via `AskUserMessage` UX (original message presented for edit + submit) | [How-to: rewind](guide/for-users/time-travel.md) |
 
 #### Event System (P6)
 | Feature | Description | Documentation |

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -257,7 +257,7 @@ mindmap
 
 #### Time-Travel / Rewind (Resume)
 
-User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2d) are production. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: ADR-0038 (PR #1536, pending merge). Change ledger: #1533.
+User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2d) are production. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: [ADR-0038](deep-dives/decisions/0038-user-facing-time-travel-rewind.md). Change ledger: #1533.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|

--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -56,7 +56,7 @@ user experience applies; the substrate is container-side.
 |---------|--------|
 | `/rewind` with in-turn edit (`ctrl+t`) to create a new fork-and-edit branch | ✅ Phase 2c, landed |
 | Retention window config (`retention: keep_generations: N`) to GC old checkpoints | ⏳ ADR-0038 Stage 1e — designed, not yet wired |
-| `/rewind` picker over WebSocket / A2A web surface | ⏳ Phase 2d, in-progress |
+| `/rewind` picker over WebSocket / A2A web surface; web edit via `AskUserMessage` UX | ✅ Phase 2d, landed (#1574) |
 
 ## See also
 

--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -44,6 +44,10 @@ After any rewind or fork, the picker switches to a **tree view** showing all bra
 - Selecting a seq on the **current branch**: undo (rewinds the current branch).
 - Selecting a seq on an **inactive branch**: fork-switch (activates that branch).
 
+## Web edit (Phase 2d)
+
+When using Reyn through the web interface (WebSocket / A2A), `/rewind` opens the same checkpoint picker. After selecting a checkpoint to branch from, the web edit flow presents the original message for you to retype your edited version and submit — inline prefill is not supported in the web surface, so you enter the replacement text directly. Submitting creates a new fork from the rewound checkpoint.
+
 ## Container mode
 
 When using the container environment backend (`--container`), the workspace


### PR DESCRIPTION
**[docs-maintainer]** — Phase 2d (#1574, 14:00Z) status flip.

## Changes

- `docs/feature-map.md`: narrative updated to "Phase 1 and Phase 2 (2a/2b/2c/2d) are production"; Phase 2d table row ⏳→✅ with `AskUserMessage` UX note + doc link.
- `docs/guide/for-users/time-travel.md`: 2d Pending row ⏳→✅ landed (#1574).
- Retention config row: unchanged ⏳ (not yet wired).

All Phase-2 stages now production. Concurrent-live-fork remains out-of-scope.

## Test plan

- [x] No mermaid touched (no render-check needed)
- [x] Page drop: zero (no pages removed)
- [x] `AskUserMessage` UX description is lead-coder-provided ("inline prefill not possible → original message presented for edit + submit") — please verify wording is accurate for the #1574 impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)