### PR TITLE
fix(1576): restore per-checkpoint #1547 anchor in the tree /rewind picker

### DIFF
--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -229,6 +229,16 @@ class RewindMenuWidget(Widget):
                 line.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
             line.append("\n")
             body.append_text(line)
+            # #1547 (restored for tree mode, #1576): per-checkpoint anchor
+            # (truncated last user message) as a dim line under the row, so the
+            # user can tell "which turn was this?" per checkpoint — not only at
+            # fork-point headers. Aligned past the caret + depth indent. Additive:
+            # empty anchor → omitted (parity with the old flat render).
+            anchor = r.get("anchor", "")
+            if anchor:
+                body.append(
+                    f"  {indent}  {anchor}\n", style=f"dim {_TEXT_DIM}",
+                )
         body.append(
             "  ↑/↓ select · Enter checkout · ctrl+t edit · Esc cancel\n",
             style=f"dim {_TEXT_DIM}",

--- a/tests/cli/test_rewind_menu_tree_2b.py
+++ b/tests/cli/test_rewind_menu_tree_2b.py
@@ -95,3 +95,27 @@ def test_empty_tree_safe() -> None:
     assert w.selected_point() is None
     w.move_selection(-1)
     assert "no checkpoints" in w.render().plain
+
+
+def test_tree_render_shows_per_checkpoint_anchor() -> None:
+    """Tier 2: the #1547 per-checkpoint anchor renders as a dim line UNDER its
+    checkpoint row in tree mode (#1576 regression fix) — not only at fork-point
+    branch headers. Single branch (no fork header), so the anchor can only
+    surface via the per-row render; FAILS before the fix."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True}]
+    cps = [{"seq": 5, "ts": "", "kind": "turn", "anchor": "fix the auth bug", "branch_id": 0}]
+    w = RewindMenuWidget.from_tree_rows(build_branch_tree_rows(branches, cps))
+    rendered = w.render().plain
+    assert "fix the auth bug" in rendered          # per-checkpoint anchor, not a header
+    assert "#5" in rendered                          # ...under its checkpoint row
+
+
+def test_tree_render_omits_empty_anchor() -> None:
+    """Tier 2: a checkpoint with no anchor renders no dim anchor line (additive —
+    parity with the old flat render)."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": 9, "parent_branch_id": None, "is_active": True}]
+    cps = [{"seq": 5, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0}]
+    w = RewindMenuWidget.from_tree_rows(build_branch_tree_rows(branches, cps))
+    lines = [ln for ln in w.render().plain.splitlines() if ln.strip()]
+    # header + #5 row + footer hint = 3 non-empty lines; no extra anchor line.
+    assert sum(1 for ln in lines if "#5" in ln) == 1


### PR DESCRIPTION
**[tui-coder]** — Closes #1576. Restores the #1547 per-checkpoint anchor preview in the tree `/rewind` picker — a live UX regression since #1561 (the always-tree picker), surfaced during the #1563 flat-removal assessment.

## Regression
Flat mode rendered the truncated last-user-message as a dim line under *each* checkpoint row (the #1547 "which turn was this?" cue). The always-tree `_render_tree` (#1561) showed the anchor **only at fork-point branch headers** (`fork @ #N "anchor"`) — so picking among same-branch checkpoints, the per-row preview was gone.

## Fix
`_render_tree`'s checkpoint-row branch now emits the anchor as a dim line under the row (the tree row dict already carries `anchor` from `build_branch_tree_rows` ← `list_rewind_points`), aligned past the caret + depth indent. Additive: empty anchor omitted (parity with the old flat render). Fork-point headers keep their label anchor; non-fork checkpoints now show theirs too.

## Test plan
- [x] `pytest tests/cli/test_rewind_menu_tree_2b.py` — 7 (incl. `test_tree_render_shows_per_checkpoint_anchor` on a **single-branch** fixture, so the anchor can only surface per-row, not via a fork header → **fails before the fix**; + `test_tree_render_omits_empty_anchor`)
- [x] `pytest` rewind/tree/anchor/flat suites (tree_2b + fork_picker_2c + scroll_hint_1550 + widget_1f + anchor_1547 + wiring_1f + prefill_2c) — 42 passed (flat 1f/1547 untouched; fix is additive)
- [x] **tmux live-verify** — seed `anchor_store` + `/rewind` → the per-checkpoint anchor is visible in the live tree picker (full path: `list_rewind_points` → `build_branch_tree_rows` → `_render_tree`)
- [x] `ruff check` + tier audit `--strict` — clean

**Tier self-check**: Tier 2, public surface (`render().plain`), no mocks; the key test is falsifiable by construction (single-branch → no fork header to carry the anchor).

Discovered alongside the sibling gap #1577 (tree has no scroll window) — filed separately, lower priority. Flat-mode removal (#1563) sequenced after this per lead (low-pri dead-code hygiene, no user-visible gain). Refs #1533, #1563.
