### PR TITLE
feat(1557): gap-#1 — route shadow git-dir under --state-dir (coherence fix)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -114,6 +114,7 @@ class AgentRegistry:
         state_log: StateLog | None = None,
         retention_policy: RetentionPolicy | None = None,
         environment_backend: "object | None" = None,
+        workspace_state_dir: "Path | None" = None,
     ) -> None:
         """
         session_factory: returns a configured ChatSession given an AgentProfile.
@@ -157,6 +158,11 @@ class AgentRegistry:
         # backend.run with the container path context (the work-tree is
         # container-side; host git can't reach it).
         self._environment_backend = environment_backend
+        # ADR-0038 #1557 (gap-#1): host-side OS-state dir (--state-dir). When set,
+        # the shadow git-dir lives under it (a first-class member of the persisted
+        # OS-state set, alongside events/artifacts — one persistence switch) rather
+        # than at project_root/.reyn. None → default project_root/.reyn location.
+        self._workspace_state_dir = workspace_state_dir
         # #1547: per-checkpoint anchor text (rewind-timeline preview). One global
         # store keyed by WAL seq; lazily built. None when no WAL.
         self._anchor_store: AnchorStore | None = None
@@ -657,8 +663,15 @@ class AgentRegistry:
         visible in-container. (Attach/baked mode has no bind-mount → host FS and
         container git diverge → degrades; attach-mode persistence is a tracked
         follow-up, #1544 checklist.)
+
+        #1557 gap-#1: the host git-dir is routed under ``workspace_state_dir``
+        (``--state-dir``) when provided, so the workspace-version history persists
+        alongside the rest of the host-side OS state (one switch); otherwise it
+        defaults to ``project_root/.reyn``. (Container persistence *modes* — bind-
+        mount injection / attach-sync — remain the deferred #1557 follow-up.)
         """
-        host_git_dir = self._project_root / ".reyn" / "workspace-shadow.git"
+        host_git_root = self._workspace_state_dir or (self._project_root / ".reyn")
+        host_git_dir = host_git_root / "workspace-shadow.git"
         backend = self._environment_backend
         if backend is not None and getattr(backend, "name", "") == "container":
             from reyn.events.workspace_version_store import _ContainerGitRunner

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -444,6 +444,7 @@ def run(args: argparse.Namespace) -> None:
         session_factory=_session_factory,
         state_log=state_log,
         environment_backend=env_backend,   # #1544: container shadow-git runs via this
+        workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
     )
 
     name = args.agent_name or DEFAULT_AGENT_NAME

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -491,6 +491,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             session_factory=_session_factory,
             state_log=None,
             environment_backend=env_backend,   # #1544: container shadow-git
+            workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
         )
         _reg_cell.append(reg)
         return reg

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -378,6 +378,8 @@ def _get_registry():
             # #1544: container shadow-git. ``_scoped`` is local to the session
             # factory above; fetch the overrides at this scope via the accessor.
             environment_backend=get_cli_scoped_overrides().environment_backend,
+            # #1557 gap-#1: shadow git-dir under --state-dir (same accessor scope).
+            workspace_state_dir=get_cli_scoped_overrides().workspace_state_dir,
         )
         registry_ref.append(registry)
         _registry = registry

--- a/tests/test_workspace_state_dir_routing_1557.py
+++ b/tests/test_workspace_state_dir_routing_1557.py
@@ -1,0 +1,69 @@
+"""Tier 2: OS invariant — shadow git-dir routes under --state-dir (#1557 gap-#1).
+
+#1544 follow-up coherence fix: the shadow-git workspace-version store's git-dir
+is part of the persisted OS-state set. When ``--state-dir`` (workspace_state_dir)
+is provided, the shadow git-dir lives under it (alongside events/artifacts) — one
+persistence switch — instead of always at ``project_root/.reyn``. Additive: with
+no state-dir, the default location is unchanged.
+
+Behavioral assertion (no private-state): ``capture`` creates the git-dir on disk
+at the configured location, so the filesystem proves where it was routed. Real
+AgentRegistry + WorkspaceVersionStore + git (no mocks).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.registry import AgentRegistry
+from reyn.events.state_log import StateLog
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+@pytest.mark.asyncio
+async def test_shadow_git_dir_routes_under_state_dir_when_set(tmp_path):
+    """Tier 2: with workspace_state_dir set, the shadow git-dir lives under it."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    state = tmp_path / "host-state"
+    state.mkdir()
+    state_log = StateLog(proj / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=proj,
+        session_factory=_no_factory,
+        state_log=state_log,
+        workspace_state_dir=state,
+    )
+
+    (proj / "code.py").write_text("v1", encoding="utf-8")
+    await reg.workspace_store.capture(1)
+
+    assert (state / "workspace-shadow.git" / "HEAD").exists()        # routed under --state-dir
+    assert not (proj / ".reyn" / "workspace-shadow.git").exists()    # NOT at the default
+
+
+@pytest.mark.asyncio
+async def test_shadow_git_dir_defaults_under_project_root(tmp_path):
+    """Tier 2: with no workspace_state_dir, the default git-dir location is unchanged."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    state_log = StateLog(proj / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=proj,
+        session_factory=_no_factory,
+        state_log=state_log,
+    )  # no workspace_state_dir
+
+    (proj / "code.py").write_text("v1", encoding="utf-8")
+    await reg.workspace_store.capture(1)
+
+    assert (proj / ".reyn" / "workspace-shadow.git" / "HEAD").exists()   # default unchanged


### PR DESCRIPTION
**[dogfood-coder]** — #1557 gap-#1, the settled additive coherence fix you authorized (lead drive directive). **NOT** the deferred persistence modes (B launch-bind-mount / A attach-sync) — those stay deferred per the spec + owner's 後回し lean.

## What

The shadow-git workspace-version store's git-dir was hardcoded at `project_root/.reyn/workspace-shadow.git`, decoupled from the rest of the host-side OS state. This makes it a **first-class member of the persisted OS-state set**: when `--state-dir` (`workspace_state_dir`) is provided, the shadow git-dir lives under it (alongside events/artifacts) — **one persistence switch** — else the default location is unchanged.

- **`AgentRegistry`**: new `workspace_state_dir: Path | None = None` param; `_build_workspace_store` routes `host_git_dir = (workspace_state_dir or project_root/.reyn) / "workspace-shadow.git"`. **Additive** — default behaviour byte-identical when unset.
- **Threaded** from the registry-construction sites carrying a `--state-dir`: `chat.py` (primary `reyn chat`), `web/deps.py` (via the `get_cli_scoped_overrides()` accessor — #1556-safe scope, mirrors `environment_backend`), `dogfood.py` (consistency; no-op there as `state_log=None` → no workspace store). `mcp` / `chainlit` pass `--state-dir=None` → default `None`, unchanged.

## Scope note

This is the **structural coherence fix** (git-dir location). Full attach/baked container-mode rewind **persistence** (launch-time bind-mount injection / attach-sync) remains the deferred #1557 follow-up — the spec's Option B (design-ready, fast-pickup on demand) / A.

## Test plan

`tests/test_workspace_state_dir_routing_1557.py` (Tier 2, real-instance, **behavioral via `capture`** — no private-state assertion):

- [x] `test_shadow_git_dir_routes_under_state_dir_when_set` — with `--state-dir`, the git-dir is created under it + **not** at the default
- [x] `test_shadow_git_dir_defaults_under_project_root` — unset → default `project_root/.reyn` unchanged
- [x] `python -m pytest ... -W error::RuntimeWarning` → 2 passed
- [x] tier-audit clean; ruff clean
- [x] 555 adjacent registry/workspace/rewind/checkout/1544 tests pass (additive, no regression)

Tier rule self-check: docstring first line declares Tier; no Tier-4 violations; no invariant weakening; audit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)