### PR TITLE
feat(1582): time_travel.workspace_capture opt-out — runtime-only rewind (PR-1)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -39,6 +39,7 @@ models:
 | `events` | map | Audit-log rotation policy for chat-session event files. See below. |
 | `skill_search` | map | BM25 skill pre-filter settings. See below. |
 | `skill_resume` | map | Resume policy for ambiguous steps on restart. See below. |
+| `time_travel` | map | Time-travel (rewind/resume) cost knobs. See below. |
 | `self_improvement` | map | `skill_improver` apply-gate and version cap. See below. |
 | `mcp` | map | MCP server definitions and `search_threshold`. See below. |
 | `python` | map | Python preprocessor additional allowed-modules. See below. |
@@ -270,6 +271,19 @@ plan:
 | `step_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the step_results portion of the next step's sys_prompt. Sibling to `chat.compaction.component_weights` body allocation. |
 | `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older step_results are compacted. `null` derives the threshold from `ComputedBudgets` (= `step_results_ratio × main_pool`). |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out, mirrors `chat.compaction.use_chars4_estimate`). |
+
+## `time_travel` block
+
+Cost knobs for the time-travel (rewind/resume) feature (#1582).
+
+```yaml
+time_travel:
+  workspace_capture: true   # default; false = runtime-only rewind
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `workspace_capture` | bool | `true` | When `true`, every checkpoint boundary (turn / plan-step) captures the workspace into a shadow-git generation so a rewind restores repo files too. This is time-travel's **largest** constant cost — a `git add -A` + commit per boundary (in container mode, a `docker exec` per boundary). Set to `false` for **runtime-only rewind**: rewind/checkout restore agent + conversation state but **not** repo files — a documented escape for large workspaces, container runs, or no-file-rewind use. Run-level (read at startup; not a mid-session toggle). |
 
 ## `phase` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -337,6 +337,21 @@
 
 
 # -----------------------------------------------------------------------------
+# time_travel: cost knobs for the time-travel (rewind/resume) feature (#1582).
+#
+# workspace_capture (default true): when true, every checkpoint boundary (turn /
+# plan-step) captures the workspace into a shadow-git generation so a rewind can
+# restore the repo files too. This is time-travel's LARGEST constant cost (a
+# ``git add -A`` + commit per boundary; in container mode a ``docker exec`` per
+# boundary). Set to false for "runtime-only rewind": rewind/checkout restore the
+# agent + conversation state but NOT repo files — a documented escape for large
+# workspaces / container runs / no-file-rewind use. Run-level (read at startup).
+# -----------------------------------------------------------------------------
+# time_travel:
+#   workspace_capture: true
+
+
+# -----------------------------------------------------------------------------
 # plan_resume_raw: how the resume coordinator treats
 # interrupted plan-mode runs on restart. Parsed lazily by the coordinator,
 # so the shape lives in ``reyn.plan`` rather than here. Set to a dict only

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -214,6 +214,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
             project_root=project_root,
             session_factory=_session_factory,
             state_log=state_log,
+            workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
         )
         registry_ref.append(registry)
         _REGISTRY = registry

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -115,6 +115,7 @@ class AgentRegistry:
         retention_policy: RetentionPolicy | None = None,
         environment_backend: "object | None" = None,
         workspace_state_dir: "Path | None" = None,
+        workspace_capture: bool = True,
     ) -> None:
         """
         session_factory: returns a configured ChatSession given an AgentProfile.
@@ -163,6 +164,14 @@ class AgentRegistry:
         # OS-state set, alongside events/artifacts — one persistence switch) rather
         # than at project_root/.reyn. None → default project_root/.reyn location.
         self._workspace_state_dir = workspace_state_dir
+        # #1582: time-travel cost opt-out. False → "runtime-only rewind": the
+        # workspace store is never built/attached, so cut_generation skips the
+        # per-boundary shadow-git capture (the largest constant cost) while the
+        # runtime substrate (AgentSnapshot generations + WAL) is untouched. The
+        # existing None-guards (attach / capture / restore / prune) make this
+        # coherent by construction. Run-level (construction-time), like
+        # retention_policy — not a mid-session toggle.
+        self._workspace_capture = workspace_capture
         # #1547: per-checkpoint anchor text (rewind-timeline preview). One global
         # store keyed by WAL seq; lazily built. None when no WAL.
         self._anchor_store: AnchorStore | None = None
@@ -642,10 +651,14 @@ class AgentRegistry:
     def workspace_store(self) -> WorkspaceVersionStore | None:
         """The shadow-git workspace store (ADR-0038 1d), lazily built.
 
-        ``None`` when there is no WAL (non-chat / tests that opt out). Host-mode
-        worktree = ``project_root``; git-dir under ``.reyn``. Container mode is a
-        tracked follow-up (#1544).
+        ``None`` when there is no WAL (non-chat / tests that opt out), OR when
+        ``workspace_capture`` is disabled (#1582 runtime-only rewind — the opt-out
+        for the per-boundary shadow-git capture cost). Host-mode worktree =
+        ``project_root``; git-dir under ``.reyn`` (or ``--state-dir``, #1557).
+        Container mode is a tracked follow-up (#1544).
         """
+        if not self._workspace_capture:
+            return None
         if self._state_log is None:
             return None
         if self._workspace_store is None:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -445,6 +445,7 @@ def run(args: argparse.Namespace) -> None:
         state_log=state_log,
         environment_backend=env_backend,   # #1544: container shadow-git runs via this
         workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
+        workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
     )
 
     name = args.agent_name or DEFAULT_AGENT_NAME

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -492,6 +492,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             state_log=None,
             environment_backend=env_backend,   # #1544: container shadow-git
             workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
+            workspace_capture=config.time_travel.workspace_capture,  # #1582 opt-out
         )
         _reg_cell.append(reg)
         return reg

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -443,6 +443,7 @@ def run_serve(args: argparse.Namespace) -> None:
         project_root=project_root,
         session_factory=_session_factory,
         state_log=state_log,
+        workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
     )
 
     timeout = float(getattr(args, "timeout", 60.0) or 60.0)

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1582,6 +1582,54 @@ def _build_action_retrieval_config(raw: object) -> ActionRetrievalConfig:
 
 
 @dataclass
+class TimeTravelConfig:
+    """``time_travel:`` — time-travel (rewind/resume) cost knobs (#1582).
+
+    ADR-0038 ships time-travel always-on. ``workspace_capture`` is the opt-out
+    for its **largest** constant cost: the per-boundary shadow-git capture
+    (``git add -A`` + commit + tag at every turn / plan-step; in container mode a
+    ``docker exec`` per boundary). Setting it ``false`` selects **runtime-only
+    rewind** — the registry attaches no workspace store, so ``cut_generation``
+    skips the workspace capture while the runtime substrate (AgentSnapshot
+    generations + WAL) is untouched. Rewind/checkout then restore agent /
+    conversation state but NOT repo files (same framing as act-turn rewind).
+
+    Default ``true`` (capture-on): the full-fidelity rewind UX stays the default;
+    opt-out is a first-class documented escape for large workspaces / container
+    runs / no-file-rewind use. Run-level (read at registry construction) — not a
+    mid-session toggle, which would leave captured-while-on generations
+    non-restorable after a flip-off. Extensible block (the #1560 op-granular tier
+    is intended to ride sibling keys here).
+    """
+
+    workspace_capture: bool = True
+
+
+def _build_time_travel_config(raw: object) -> TimeTravelConfig:
+    """Parse ``time_travel:`` from reyn.yaml. None / missing / empty → defaults.
+
+    ``workspace_capture`` accepts a bool; a missing key keeps the default
+    (``true``). A non-mapping block or non-bool value is a config error (fail
+    loud rather than silently mis-defaulting a cost/durability knob).
+    """
+    if raw is None:
+        return TimeTravelConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"time_travel must be a mapping, got {type(raw).__name__}"
+        )
+    if "workspace_capture" not in raw:
+        return TimeTravelConfig()
+    val = raw["workspace_capture"]
+    if not isinstance(val, bool):
+        raise ValueError(
+            "time_travel.workspace_capture must be a bool, got "
+            f"{type(val).__name__}"
+        )
+    return TimeTravelConfig(workspace_capture=val)
+
+
+@dataclass
 class ReynConfig:
     model: str = field(
         default="standard",
@@ -1694,6 +1742,10 @@ class ReynConfig:
     # Skill resume policy (PR-skill-resume) — how to handle ambiguous
     # steps on restart.
     skill_resume: SkillResumeConfig = field(default_factory=SkillResumeConfig)
+    # #1582 — time-travel cost knobs. ``time_travel.workspace_capture: false``
+    # selects runtime-only rewind (skip the per-boundary shadow-git capture, the
+    # largest constant cost). Default-on (full-fidelity rewind). Extensible block.
+    time_travel: TimeTravelConfig = field(default_factory=TimeTravelConfig)
     # Plan resume policy (ADR-0023 Phase 2) — how the resume coordinator
     # treats interrupted plan-mode runs on restart. Loaded as a raw dict
     # and parsed lazily by the coordinator (= keeps PlanResumeConfig in
@@ -2186,6 +2238,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         events=_build_events_config(merged.get("events")),
         cost=cost,
         skill_resume=_build_skill_resume_config(merged.get("skill_resume")),
+        time_travel=_build_time_travel_config(merged.get("time_travel")),
         plan_resume_raw=(
             merged.get("plan_resume")
             if isinstance(merged.get("plan_resume"), dict) else None

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -380,6 +380,8 @@ def _get_registry():
             environment_backend=get_cli_scoped_overrides().environment_backend,
             # #1557 gap-#1: shadow git-dir under --state-dir (same accessor scope).
             workspace_state_dir=get_cli_scoped_overrides().workspace_state_dir,
+            # #1582: time-travel workspace-capture opt-out (reyn.yaml config).
+            workspace_capture=config.time_travel.workspace_capture,
         )
         registry_ref.append(registry)
         _registry = registry

--- a/tests/test_workspace_capture_optout_1582.py
+++ b/tests/test_workspace_capture_optout_1582.py
@@ -1,0 +1,151 @@
+"""Tier 2: OS invariant — workspace-capture opt-out = runtime-only rewind (#1582).
+
+`time_travel.workspace_capture: false` selects runtime-only rewind: the registry
+attaches NO workspace store, so `cut_generation` skips the per-boundary shadow-git
+capture (the largest constant cost) while the runtime substrate (AgentSnapshot
+generations + WAL) stays intact + consistent-cut-coherent. The existing
+None-guards (attach / capture / restore) make this coherent by construction —
+these tests pin that the gate flips the behavior and runtime rewind still works.
+
+Non-default round-trip (feedback_roundtrip_test_nondefault_value): the opt-out
+(`False`, the NON-default) is exercised end-to-end — gate off → no workspace gen
++ rewind reverts runtime but NOT the workspace; default (`True`) → workspace gen
+present. Real AgentRegistry + ChatSession + StateLog; a no-LLM `_FakeTurnDriver`
+drives the real `_run_router_loop` so genuine `cut_generation` fires. No mocks.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.config import TimeTravelConfig, _build_time_travel_config
+from reyn.events.snapshot_generations import is_active_seq
+from reyn.events.state_log import StateLog
+
+_WS_FILE = "code.py"
+
+
+class _FakeTurnDriver:
+    """No-LLM driver: writes the turn's workspace file + appends a runtime inbox
+    marker so the real `_run_router_loop` runs and its genuine `cut_generation`
+    fires. Only the file write is simulated."""
+
+    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+        self._session = session
+        self._ws = ws_root
+        self._content = content
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        (self._ws / _WS_FILE).write_text(self._content[user_text], encoding="utf-8")
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+def _make_registry(tmp_path: Path, *, workspace_capture: bool) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> ChatSession:
+        snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
+        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+        workspace_capture=workspace_capture,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+# ── config layer (round-trip, non-default) ────────────────────────────────
+
+
+def test_config_parse_non_default_and_default() -> None:
+    """Tier 2: time_travel.workspace_capture parses the NON-default (False) and
+    defaults to True when absent; a non-bool is a loud config error."""
+    assert _build_time_travel_config({"workspace_capture": False}).workspace_capture is False
+    assert _build_time_travel_config(None).workspace_capture is True
+    assert _build_time_travel_config({}).workspace_capture is True
+    assert TimeTravelConfig().workspace_capture is True
+    with pytest.raises(ValueError):
+        _build_time_travel_config({"workspace_capture": "no"})
+
+
+# ── registry gate ──────────────────────────────────────────────────────────
+
+
+def test_gate_off_no_workspace_store(tmp_path) -> None:
+    """Tier 2: workspace_capture=False → the registry attaches NO workspace store
+    (the property gate returns None) → cut_generation has nothing to capture."""
+    reg = _make_registry(tmp_path, workspace_capture=False)
+    assert reg.workspace_store is None
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for capture")
+def test_gate_on_builds_workspace_store(tmp_path) -> None:
+    """Tier 2: default (True) → the workspace store is built (contrast control)."""
+    reg = _make_registry(tmp_path, workspace_capture=True)
+    assert reg.workspace_store is not None
+
+
+# ── end-to-end: runtime-only rewind coherence (the non-default path) ───────
+
+
+@pytest.mark.asyncio
+async def test_optout_rewind_reverts_runtime_not_workspace(tmp_path) -> None:
+    """Tier 2: with capture OFF, a turn's cut_generation records the runtime
+    generation but NO workspace generation; a rewind reverts the runtime
+    substrate (inbox markers) while the workspace file is left as-is — coherent
+    runtime-only rewind. This is the consistent-cut-without-workspace invariant."""
+    reg = _make_registry(tmp_path, workspace_capture=False)
+    session = await reg.attach("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "vA", "B": "vB"})
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    await session._run_router_loop("B", "c1")
+
+    # No workspace substrate captured (store is None).
+    assert reg.workspace_store is None
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vB"
+
+    # Runtime checkout still works (consistent-cut on the runtime substrate alone).
+    await reg.checkout(seq_a)
+    markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
+    assert markers == ["A"]                                  # runtime reverted
+    assert is_active_seq(reg.state_log, seq_a)               # cut landed on the runtime substrate
+    # Workspace NOT reverted (no workspace store to restore) — runtime-only.
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vB"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for capture")
+async def test_default_captures_workspace_generation(tmp_path) -> None:
+    """Tier 2: default (capture ON) — contrast control: a turn's cut_generation
+    DOES capture a workspace generation at the boundary seq (the cost the opt-out
+    removes), and a rewind reverts the workspace too."""
+    reg = _make_registry(tmp_path, workspace_capture=True)
+    session = await reg.attach("alpha")
+    session.register_intervention_listener("test")
+    session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "vA", "B": "vB"})
+
+    await session._run_router_loop("A", "c1")
+    seq_a = session.current_snapshot.applied_seq
+    await session._run_router_loop("B", "c1")
+
+    assert reg.workspace_store is not None
+    assert seq_a in await reg.workspace_store.seqs()         # workspace gen captured
+    await reg.checkout(seq_a)
+    assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vA"  # workspace reverted too


### PR DESCRIPTION
**[e2e-coder]** — `time_travel.workspace_capture` opt-out: runtime-only rewind (#1582 Tier-1, PR-1)

Owner-approved cost lever. Time-travel's **largest** constant cost is the per-boundary workspace shadow-git capture (`git add -A`+commit+tag at every turn / plan-step; a `docker exec` per boundary in container mode). `time_travel.workspace_capture: false` selects **runtime-only rewind** — no workspace store is attached, so `cut_generation` skips the workspace capture while the runtime substrate (AgentSnapshot generations + WAL) is untouched. Rewind/checkout then restore agent + conversation state but not repo files (same framing as act-turn rewind).

## The mechanism is clean by construction

The flow-trace headline: every workspace seam **already** guards on `workspace_store is None` — attach (`registry.py:1256`), capture (`snapshot_journal.py:97`), restore (`_restore_workspace_active`, `registry.py:733`), prune (`registry.py:1014`). sandbox_2 substrate-verified the consistent-cut is purely runtime (`reconstruct` has zero workspace refs; the only `_materialize_rewind` workspace touch is the None-guarded restore). So `workspace_store=None` → coherent runtime-only rewind, and the entire lever is **gating the `workspace_store` property to None**. No new coherence code.

## What

- **config.py**: `TimeTravelConfig(workspace_capture: bool = True)` + `_build_time_travel_config` parser + `ReynConfig.time_travel` field + `load_config` wiring. Extensible block — #1560 (Tier-3 per-step capture) rides a sibling key here later.
- **registry.py**: `workspace_capture: bool = True` construction param (**run-level**, like `retention_policy` — not a mid-session toggle, which would orphan captured-while-on generations) gating the `workspace_store` property.
- **Option-A threading**: `config.time_travel.workspace_capture` → all **5** chat-path `AgentRegistry` sites (`cli/commands/chat.py`, `chainlit_app/app.py`, `web/deps.py`, `cli/commands/mcp.py`, `cli/commands/dogfood.py`). (Audited every site; the `_no_factory` non-chat sites have no `state_log` so the store is already None.)
- **Docs** (required by the #1056 config-mirror CI guard, so in this PR): `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md`.

## Decisions (locked by lead/owner)

key = `time_travel.workspace_capture` · threading = Option A · default = **capture-on** (opt-out first-class). Tier-2 WAL durability was **owner-rejected** ("don't weaken crash recovery") and is out of scope.

## Test plan

- [x] `tests/test_workspace_capture_optout_1582.py` (Tier 2, no mocks): config parse **round-trip incl. the NON-default `False`** + loud non-bool error (`feedback_roundtrip_test_nondefault_value`); gate off → `workspace_store is None`, default → built; **end-to-end runtime-only** — capture off → a turn records the runtime generation but **no** workspace generation + a rewind reverts the runtime substrate (inbox markers + `is_active`) while the workspace file is **left as-is** (the consistent-cut-without-workspace invariant, sandbox_2's co-review point); contrast control — default ON captures the workspace gen + reverts files.
- [x] `pytest -k "config or registry or rewind or workspace or 1582"` → 912 passed / 2 skipped (incl. the #1056 mirror guard now green for the new field); `ruff check` clean; `test_tier_audit.py --strict` clean; all 7 source files `py_compile` OK.

Design endorsed: lead (mechanism) + sandbox_2 (substrate consistent-cut). **PR-2** = the narrative opt-out / cost-rationale doc. **Sequencing**: #1560 (Tier-3 per-step) is owner-GO'd to build *after* this lands (shared `time_travel` block + cut_generation path).

Refs #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
