### PR TITLE
feat(1560): per-step act-turn workspace capture — content-log (PR-1, capture)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -279,11 +279,13 @@ Cost knobs for the time-travel (rewind/resume) feature (#1582).
 ```yaml
 time_travel:
   workspace_capture: true   # default; false = runtime-only rewind
+  act_turn_capture: false   # opt-in; true = per-step (act-turn) workspace capture
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `workspace_capture` | bool | `true` | When `true`, every checkpoint boundary (turn / plan-step) captures the workspace into a shadow-git generation so a rewind restores repo files too. This is time-travel's **largest** constant cost — a `git add -A` + commit per boundary (in container mode, a `docker exec` per boundary). Set to `false` for **runtime-only rewind**: rewind/checkout restore agent + conversation state but **not** repo files — a documented escape for large workspaces, container runs, or no-file-rewind use. Run-level (read at startup; not a mid-session toggle). |
+| `act_turn_capture` | bool | `false` | Opt-in **per-step** (act-turn) workspace capture. When `true`, each skill-run op (`step_completed`) also snapshots the workspace as a cheap `write-tree` (no commit) into an op-content-log, so a rewind can land *mid-skill-run*, not just at turn/plan-step boundaries. High-frequency (per op), so opt-in by default. A no-op when `workspace_capture` is `false` (the per-step capture rides the same shadow store). |
 
 ## `phase` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -349,6 +349,12 @@
 # -----------------------------------------------------------------------------
 # time_travel:
 #   workspace_capture: true
+#   # act_turn_capture (default false): opt-in per-step capture. When true, each
+#   # skill-run op (step_completed) also snapshots the workspace (a cheap
+#   # write-tree) so a rewind can land mid-skill-run, not just at turn/plan-step
+#   # boundaries. High-frequency (per op) → opt-in. No-op when workspace_capture
+#   # is false.
+#   act_turn_capture: false
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -215,6 +215,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
             session_factory=_session_factory,
             state_log=state_log,
             workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
+            act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
         )
         registry_ref.append(registry)
         _REGISTRY = registry

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -50,6 +50,7 @@ from reyn.events.snapshot_generations import (
 )
 from reyn.events.snapshot_generations import checkout as _append_reset_record
 from reyn.events.state_log import StateLog
+from reyn.events.workspace_op_content_log import WorkspaceOpContentLog
 from reyn.events.workspace_version_store import WorkspaceVersionStore
 
 from .profile import PROFILE_FILENAME, AgentProfile
@@ -116,6 +117,7 @@ class AgentRegistry:
         environment_backend: "object | None" = None,
         workspace_state_dir: "Path | None" = None,
         workspace_capture: bool = True,
+        act_turn_capture: bool = False,
     ) -> None:
         """
         session_factory: returns a configured ChatSession given an AgentProfile.
@@ -172,6 +174,17 @@ class AgentRegistry:
         # coherent by construction. Run-level (construction-time), like
         # retention_policy — not a mid-session toggle.
         self._workspace_capture = workspace_capture
+        # #1560: opt-in per-step (act-turn) workspace capture (default off). When
+        # on, a generic post-append observer on the WAL captures a write-tree
+        # snapshot at each ``step_completed`` into the op-content-log, so act-turn
+        # rewind can restore mid-skill-run workspace state (restore = PR-2). The
+        # callback is registered ONLY when on, so default users pay zero per-append
+        # cost (the WAL's observer list stays empty). Gated additionally by the
+        # Tier-1 workspace store (off / None → no-op).
+        self._act_turn_capture = act_turn_capture
+        self._op_content_log: "WorkspaceOpContentLog | None" = None
+        if act_turn_capture and state_log is not None:
+            state_log.register_post_append(self._on_wal_append_capture)
         # #1547: per-checkpoint anchor text (rewind-timeline preview). One global
         # store keyed by WAL seq; lazily built. None when no WAL.
         self._anchor_store: AnchorStore | None = None
@@ -699,6 +712,41 @@ class AgentRegistry:
                 self._project_root, host_git_dir, git_runner=runner,
             )
         return WorkspaceVersionStore(self._project_root, host_git_dir)
+
+    @property
+    def op_content_log(self) -> "WorkspaceOpContentLog | None":
+        """The op-granular (act-turn) content log (#1560), lazily built.
+
+        ``None`` when act-turn capture is off or there is no WAL. Lives beside the
+        shadow git-dir (under ``--state-dir`` when set, #1557) — the same root as
+        the boundary generations, so the persistence switch covers both.
+        """
+        if not self._act_turn_capture or self._state_log is None:
+            return None
+        if self._op_content_log is None:
+            root = self._workspace_state_dir or (self._project_root / ".reyn")
+            self._op_content_log = WorkspaceOpContentLog(root / "op-content-log.jsonl")
+        return self._op_content_log
+
+    async def _on_wal_append_capture(self, kind: str, seq: int, fields: dict) -> None:
+        """Generic WAL post-append observer: per-step act-turn workspace capture.
+
+        Fires only for ``step_completed`` (the act-turn step boundary, whose seq is
+        ``CommittedStep.seq``). Gated by the Tier-1 workspace store: when workspace
+        capture is off (``workspace_store is None``), this is a no-op too (one
+        switch). Captures a bare ``write-tree`` snapshot and records ``(seq,
+        tree_sha)``. Best-effort — runs on the swallow-safe observer path, so any
+        failure here never affects the WAL append (the store/log already swallow).
+        """
+        if kind != "step_completed":
+            return
+        ws = self.workspace_store
+        log = self.op_content_log
+        if ws is None or log is None:
+            return
+        tree_sha = await ws.capture_tree()
+        if tree_sha is not None:
+            log.append(seq, tree_sha)
 
     @property
     def anchor_store(self) -> AnchorStore | None:

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -446,6 +446,7 @@ def run(args: argparse.Namespace) -> None:
         environment_backend=env_backend,   # #1544: container shadow-git runs via this
         workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
         workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
+        act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
     )
 
     name = args.agent_name or DEFAULT_AGENT_NAME

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -493,6 +493,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             environment_backend=env_backend,   # #1544: container shadow-git
             workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
             workspace_capture=config.time_travel.workspace_capture,  # #1582 opt-out
+            act_turn_capture=config.time_travel.act_turn_capture,  # #1560 opt-in
         )
         _reg_cell.append(reg)
         return reg

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -444,6 +444,7 @@ def run_serve(args: argparse.Namespace) -> None:
         session_factory=_session_factory,
         state_log=state_log,
         workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
+        act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
     )
 
     timeout = float(getattr(args, "timeout", 60.0) or 60.0)

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1603,14 +1603,21 @@ class TimeTravelConfig:
     """
 
     workspace_capture: bool = True
+    # #1560 — opt-in per-step (act-turn) workspace capture (default OFF). When on,
+    # each `step_completed` inside a skill run records a write-tree snapshot in the
+    # op-content-log so act-turn rewind can restore mid-run workspace state. High
+    # frequency (per op), so opt-in by default per the perf policy. Gated by
+    # `workspace_capture` (the Tier-1 store) — off there ⇒ this is a no-op too.
+    act_turn_capture: bool = False
 
 
 def _build_time_travel_config(raw: object) -> TimeTravelConfig:
     """Parse ``time_travel:`` from reyn.yaml. None / missing / empty → defaults.
 
-    ``workspace_capture`` accepts a bool; a missing key keeps the default
-    (``true``). A non-mapping block or non-bool value is a config error (fail
-    loud rather than silently mis-defaulting a cost/durability knob).
+    Each known key accepts a bool; a missing key keeps its default
+    (``workspace_capture`` true, ``act_turn_capture`` false). A non-mapping block
+    or non-bool value is a config error (fail loud rather than silently
+    mis-defaulting a cost/durability knob).
     """
     if raw is None:
         return TimeTravelConfig()
@@ -1618,15 +1625,21 @@ def _build_time_travel_config(raw: object) -> TimeTravelConfig:
         raise ValueError(
             f"time_travel must be a mapping, got {type(raw).__name__}"
         )
-    if "workspace_capture" not in raw:
-        return TimeTravelConfig()
-    val = raw["workspace_capture"]
-    if not isinstance(val, bool):
-        raise ValueError(
-            "time_travel.workspace_capture must be a bool, got "
-            f"{type(val).__name__}"
-        )
-    return TimeTravelConfig(workspace_capture=val)
+
+    def _bool(key: str, default: bool) -> bool:
+        if key not in raw:
+            return default
+        val = raw[key]
+        if not isinstance(val, bool):
+            raise ValueError(
+                f"time_travel.{key} must be a bool, got {type(val).__name__}"
+            )
+        return val
+
+    return TimeTravelConfig(
+        workspace_capture=_bool("workspace_capture", True),
+        act_turn_capture=_bool("act_turn_capture", False),
+    )
 
 
 @dataclass

--- a/src/reyn/events/state_log.py
+++ b/src/reyn/events/state_log.py
@@ -89,6 +89,12 @@ class StateLog:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = asyncio.Lock()
         self._counter = self._scan_max_seq()
+        # Generic post-append observers (#1560). Each is invoked AFTER a durable
+        # append (post-fsync, outside the lock) with `(kind, seq, fields)`. The
+        # WAL stays workspace/feature-agnostic (P7) — observers carry all domain
+        # knowledge. Empty by default → zero cost on the append path; a registrant
+        # (e.g. the registry's act-turn workspace capture) opts in explicitly.
+        self._post_append_cbs: list = []
 
     @property
     def path(self) -> Path:
@@ -127,7 +133,38 @@ class StateLog:
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())
-            return seq
+        # Post-append observers fire AFTER the durable write and OUTSIDE the lock
+        # (#1560): durability is already secured, so a slow/failing observer
+        # neither weakens crash-recovery nor serializes other appends. Best-effort
+        # — failures are swallowed, so the append's result is never blocked.
+        await self._fire_post_append(kind, seq, fields)
+        return seq
+
+    def register_post_append(self, cb) -> None:
+        """Register a generic post-append observer ``cb(kind, seq, fields)``.
+
+        Invoked after each durable append (post-fsync, outside the lock). The WAL
+        passes only WAL vocabulary — observers own all domain knowledge (P7). Used
+        by the registry's opt-in act-turn workspace capture (#1560); unregistered
+        by default so the append path stays zero-cost.
+        """
+        self._post_append_cbs.append(cb)
+
+    async def _fire_post_append(self, kind: str, seq: int, fields: dict) -> None:
+        """Invoke each post-append observer, swallowing failures (best-effort).
+
+        A raising / hanging-then-failing observer must never fail or corrupt the
+        append — the WAL entry is already durable. Each callback is isolated.
+        """
+        for cb in self._post_append_cbs:
+            try:
+                await cb(kind, seq, fields)
+            except Exception as e:  # noqa: BLE001 — never let an observer fail the append
+                import logging
+                logging.getLogger(__name__).warning(
+                    "StateLog post-append observer failed (kind=%s seq=%s): %s",
+                    kind, seq, e,
+                )
 
     def _needs_lead_newline(self) -> bool:
         if not self._path.is_file():

--- a/src/reyn/events/workspace_op_content_log.py
+++ b/src/reyn/events/workspace_op_content_log.py
@@ -1,0 +1,89 @@
+"""Append-only op-granular workspace content log (ADR-0038 #1560 act-turn).
+
+The per-boundary shadow-git generations (``WorkspaceVersionStore``) capture the
+workspace at turn / plan-step boundaries. Act-turn rewind targets a finer seq —
+a ``step_completed`` boundary *inside* a skill run — below the nearest boundary
+generation. This log fills that gap: when the opt-in ``time_travel.act_turn_capture``
+is on, each ``step_completed`` records ``(op_seq, tree_sha)`` where ``tree_sha`` is
+a bare ``write-tree`` snapshot in the shadow store's object set (no commit/tag).
+
+``op_seq`` is the WAL seq of the ``step_completed`` event (= ``CommittedStep.seq``),
+so one rewind ``target_seq`` restores both the runtime memo (≤ K) and the workspace
+tree (≤ K). Restore (read the latest entry ≤ target → ``read-tree``) is wired in
+PR-2; this module is the capture-side log.
+
+Recovery state (keyed by WAL seq), so it lives beside the shadow git-dir (routed
+under ``--state-dir`` with it, #1557) — **not** the audit EventStore.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class WorkspaceOpContentLog:
+    """Append-only ``(op_seq, tree_sha)`` JSONL log beside the shadow git-dir.
+
+    Append is best-effort (a failed line never breaks the caller — it is on the
+    swallow-safe post-append observer path). Reads tolerate torn/garbage lines
+    (skipped), mirroring the WAL replay tolerance.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, op_seq: int, tree_sha: str) -> None:
+        """Append one ``{op_seq, tree_sha}`` entry. Best-effort (logs + swallows)."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps({"op_seq": int(op_seq), "tree_sha": str(tree_sha)}) + "\n"
+            with self._path.open("a", encoding="utf-8") as f:
+                f.write(line)
+        except Exception as e:  # noqa: BLE001 — never fail the caller (observer path)
+            logger.warning(
+                "op-content-log append failed (op_seq=%s): %s", op_seq, e,
+            )
+
+    def entries(self) -> list[dict]:
+        """All ``{op_seq, tree_sha}`` entries in file order; [] if absent. Garbage
+        lines are skipped (torn-write tolerance, like WAL replay)."""
+        if not self._path.is_file():
+            return []
+        out: list[dict] = []
+        with self._path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and "op_seq" in rec and "tree_sha" in rec:
+                    out.append(rec)
+        return out
+
+    def latest_tree_at_or_below(self, seq: int) -> str | None:
+        """The ``tree_sha`` of the highest ``op_seq <= seq`` (None if none).
+
+        Restore-side convenience (PR-2 reads this); is_active resolution is the
+        caller's responsibility (the log itself is branch-agnostic — capture is
+        always current-branch, lineage is resolved at restore)."""
+        best_seq = -1
+        best_sha: str | None = None
+        for rec in self.entries():
+            s = rec.get("op_seq")
+            if isinstance(s, int) and best_seq < s <= seq:
+                best_seq = s
+                best_sha = rec.get("tree_sha")
+        return best_sha
+
+
+__all__ = ["WorkspaceOpContentLog"]

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -185,6 +185,25 @@ class WorkspaceVersionStore:
         except GitUnavailable:
             return self._degrade("capture", seq)
 
+    async def capture_tree(self) -> str | None:
+        """Capture the current workspace as a bare **tree** object (#1560 act-turn).
+
+        ``add -A`` + ``write-tree`` — a content-addressed tree snapshot with **no
+        commit and no tag**, so it is much cheaper than :meth:`capture` (the
+        per-boundary generation) yet fully coherent (multi-file, deletions, renames
+        are all captured; git dedups unchanged subtrees/blobs). Used by the opt-in
+        per-step act-turn content log: a caller records ``(op_seq, tree_sha)`` and
+        later restores via ``read-tree`` of the tree. Returns the tree sha, or
+        ``None`` when git is unavailable (degrade) — best-effort, never raises.
+        """
+        try:
+            await self._ensure_repo()
+            await self._git(["add", "-A"])
+            out = await self._git(["write-tree"])
+            return out.strip() or None
+        except GitUnavailable:
+            return self._degrade("capture_tree", None)
+
     async def restore_at_or_below(self, seq: int) -> str | None:
         """Restore to the nearest generation with **raw** tag-seq <= ``seq``.
 

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -382,6 +382,7 @@ def _get_registry():
             workspace_state_dir=get_cli_scoped_overrides().workspace_state_dir,
             # #1582: time-travel workspace-capture opt-out (reyn.yaml config).
             workspace_capture=config.time_travel.workspace_capture,
+            act_turn_capture=config.time_travel.act_turn_capture,  # #1560 opt-in
         )
         registry_ref.append(registry)
         _registry = registry

--- a/tests/test_act_turn_capture_1560.py
+++ b/tests/test_act_turn_capture_1560.py
@@ -1,0 +1,157 @@
+"""Tier 2: opt-in per-step (act-turn) workspace capture (#1560 PR-1, capture side).
+
+`time_travel.act_turn_capture: true` registers a generic post-append observer on
+the WAL; on each `step_completed` it captures a `write-tree` snapshot into the
+op-content-log keyed by the step seq (= `CommittedStep.seq`). The mechanism's
+three load-bearing properties are pinned here:
+
+- **P7**: the `StateLog` observer is workspace-agnostic — it passes only
+  `(kind, seq, fields)`; all workspace knowledge lives in the registry callback.
+- **Never-block**: a failing observer can never fail/corrupt the WAL append
+  (the entry is durable pre-observer; failures are swallowed).
+- **Gating**: capture only when `act_turn_capture` is on (else the callback is
+  never even registered — zero per-append cost) AND `workspace_store` is present
+  (the Tier-1 #1584 gate) AND `kind == step_completed`.
+
+Restore (read the log → `read-tree`) is PR-2. Real StateLog + AgentRegistry +
+shadow git; no mocks.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.config import TimeTravelConfig, _build_time_travel_config
+from reyn.events.state_log import StateLog
+
+# ── config ─────────────────────────────────────────────────────────────────
+
+
+def test_config_act_turn_capture_parse() -> None:
+    """Tier 2: act_turn_capture parses the NON-default (True) + defaults False;
+    non-bool is a loud error. workspace_capture default unaffected."""
+    assert _build_time_travel_config({"act_turn_capture": True}).act_turn_capture is True
+    assert _build_time_travel_config(None).act_turn_capture is False
+    assert _build_time_travel_config({}).act_turn_capture is False
+    assert TimeTravelConfig().act_turn_capture is False
+    # both keys independently parsed
+    cfg = _build_time_travel_config({"workspace_capture": False, "act_turn_capture": True})
+    assert cfg.workspace_capture is False and cfg.act_turn_capture is True
+    with pytest.raises(ValueError):
+        _build_time_travel_config({"act_turn_capture": "yes"})
+
+
+# ── StateLog generic observer (P7 + never-block) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_statelog_observer_receives_wal_vocab_only(tmp_path) -> None:
+    """Tier 2: P7 — a registered observer is called with only `(kind, seq, fields)`,
+    pure WAL vocabulary, no workspace coupling in StateLog."""
+    log = StateLog(tmp_path / "wal.jsonl")
+    seen: list = []
+
+    async def cb(kind, seq, fields):
+        seen.append((kind, seq, fields))
+
+    log.register_post_append(cb)
+    seq = await log.append("inbox_consume", target="a", msg_id="m1")
+    assert seen == [("inbox_consume", seq, {"target": "a", "msg_id": "m1"})]
+
+
+@pytest.mark.asyncio
+async def test_statelog_observer_failure_never_blocks_append(tmp_path) -> None:
+    """Tier 2: never-block — a raising observer cannot fail or corrupt the append;
+    the returned seq is correct and the entry is durably readable."""
+    log = StateLog(tmp_path / "wal.jsonl")
+
+    async def boom(kind, seq, fields):
+        raise RuntimeError("capture exploded")
+
+    log.register_post_append(boom)
+    seq = await log.append("inbox_consume", target="a", msg_id="m1")
+    assert seq == 1                                          # append succeeded
+    persisted = [e["seq"] for e in log.iter_from(1)]
+    assert seq in persisted                                 # entry persisted intact
+
+
+@pytest.mark.asyncio
+async def test_statelog_no_observer_is_default(tmp_path) -> None:
+    """Tier 2: with no observer registered the append path is unchanged."""
+    log = StateLog(tmp_path / "wal.jsonl")
+    s1 = await log.append("inbox_consume", target="a", msg_id="m1")
+    s2 = await log.append("inbox_consume", target="a", msg_id="m2")
+    assert (s1, s2) == (1, 2)
+    assert len(list(log.iter_from(1))) == 2
+
+
+# ── registry capture gating ────────────────────────────────────────────────
+
+
+def _make_registry(tmp_path: Path, *, act_turn_capture: bool, workspace_capture: bool = True) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile):  # not exercised by these capture tests
+        raise AssertionError("factory must not be called")
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+        workspace_capture=workspace_capture, act_turn_capture=act_turn_capture,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_act_turn_off_no_capture(tmp_path) -> None:
+    """Tier 2: default off → no op-content-log, and a `step_completed` append
+    produces no capture. (The WAL observer is not even registered when off — a
+    zero-per-append-cost optimization, visible in the registry constructor; here
+    we pin the observable contract: off ⇒ no capture path.)"""
+    reg = _make_registry(tmp_path, act_turn_capture=False)
+    assert reg.op_content_log is None
+    await reg.state_log.append("step_completed", run_id="r1", op_kind="file_write")
+    assert reg.op_content_log is None   # still no capture log
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for write-tree")
+async def test_act_turn_on_captures_tree_per_step(tmp_path) -> None:
+    """Tier 2: act_turn_capture on + workspace present → a `step_completed` append
+    records a `(op_seq, tree_sha)` op-content-log entry keyed by that seq."""
+    reg = _make_registry(tmp_path, act_turn_capture=True)
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+
+    seq = await reg.state_log.append("step_completed", run_id="r1", op_kind="file_write")
+
+    captured = {e["op_seq"]: e["tree_sha"] for e in reg.op_content_log.entries()}
+    assert seq in captured                                 # the step was captured
+    assert captured[seq]                                   # keyed to a real tree object
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for write-tree")
+async def test_act_turn_on_but_workspace_off_is_noop(tmp_path) -> None:
+    """Tier 2: Tier-1 gate — act_turn_capture on but workspace_capture off →
+    workspace_store is None → no capture (one switch governs both)."""
+    reg = _make_registry(tmp_path, act_turn_capture=True, workspace_capture=False)
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+
+    await reg.state_log.append("step_completed", run_id="r1", op_kind="file_write")
+    assert reg.op_content_log.entries() == []             # no capture (workspace off)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("git") is None, reason="git required for write-tree")
+async def test_non_step_completed_is_not_captured(tmp_path) -> None:
+    """Tier 2: only `step_completed` triggers capture — other WAL kinds don't."""
+    reg = _make_registry(tmp_path, act_turn_capture=True)
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+
+    await reg.state_log.append("step_started", run_id="r1", op_kind="file_write")
+    await reg.state_log.append("inbox_consume", target="alpha", msg_id="m1")
+    assert reg.op_content_log.entries() == []


### PR DESCRIPTION
**[e2e-coder]** — per-step act-turn workspace capture: content-log (#1560 PR-1, capture side)

Opt-in per-step workspace capture so act-turn rewind can land *mid-skill-run*, not just at turn/plan-step boundaries. `time_travel.act_turn_capture: true` (default **off** — high frequency, per the perf policy) registers a generic post-append WAL observer; on each `step_completed` it captures a cheap `write-tree` snapshot into an op-content-log keyed by the step seq (`= CommittedStep.seq`), so one rewind target restores both the runtime memo[≤K] and the workspace tree[≤K].

**Boundaries**: restore (`plan_for_act_turn_rewind` → read the log → `read-tree`/`checkout-index`, with is_active) = **PR-2 (sandbox_2 co-build)**; retention (prune the log + gc trees) = **PR-3**.

## Design (joint with sandbox_2, lead layering sign-off)

Resolved the capture-wiring fork to **B-observer / AgentRegistry subscriber** (#1560 issuecomment-4700113788). The three load-bearing properties lead signed off on:

- **Dispatcher purity / P7**: the capture is *not* wired into the low-level dispatcher (which has no workspace reach). `StateLog` gains a generic `register_post_append(cb)` — `cb(kind, seq, fields)`, pure WAL vocabulary, zero workspace knowledge. All workspace logic lives in the registry callback.
- **WAL durability sacrosanct (never-block)**: observers fire **after** the fsync'd append and **outside** the lock, each swallow-wrapped — a slow/failing capture can never weaken crash recovery, serialize other appends, or fail the append's result (owner's "don't weaken crash").
- **Zero default cost**: the callback is registered **only** when `act_turn_capture` is on (lead's refinement), so default users keep an empty observer list — the append path is byte-identical to before. Capture is additionally gated by the Tier-1 #1584 `workspace_store` (off/None ⇒ no-op; one switch governs both).

## Changes

- `StateLog`: `register_post_append` + post-fsync/outside-lock/swallow firing.
- `WorkspaceVersionStore.capture_tree`: `add -A` + `write-tree` (no commit/tag), reusing D9's content-addressed object store.
- `WorkspaceOpContentLog` (new): append-only `(op_seq, tree_sha)` JSONL beside the shadow git-dir, under `--state-dir` (#1557); torn-line tolerant.
- `AgentRegistry`: `act_turn_capture` run-level param + conditional observer registration + `op_content_log` property + the gated capture callback.
- `config`: `TimeTravelConfig.act_turn_capture: bool = False` + parser + Option-A threading across all 5 chat-path sites. Docs (config-mirror #1056): example + reyn-yaml.md.

## Test plan

- [x] `tests/test_act_turn_capture_1560.py` (Tier 2, no mocks): config parse round-trip (NON-default `True` + independent keys + non-bool error); **StateLog observer** — P7 (wal-vocab-only), **never-block** (raising cb → append still returns the seq + entry persisted), no-observer-default unchanged; **registry** — off → no capture; on → `(seq, tree_sha)` per `step_completed`; **Tier-1 gate** (workspace off → no-op); non-`step_completed` kinds don't capture.
- [x] `pytest -k "config or registry or rewind or workspace or state_log or act_turn or 1560 or mirror"` → 952 passed / 2 skipped; `ruff` clean; `test_tier_audit.py --strict` clean; all 10 source files `py_compile` OK.

@lead-coder + @sandbox_2 — co-review (lead: layering / never-block; sandbox_2: substrate + the op-content-log PR-2 will restore against).

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
