### PR TITLE
test(1587): de-flake Esc-Esc-pending timing tests (deterministic clock)

### DIFF
--- a/tests/cli/test_esc_esc_rewind_1546.py
+++ b/tests/cli/test_esc_esc_rewind_1546.py
@@ -14,7 +14,6 @@ Pins (real key path through bindings + check_action, run_test pilot — no mocks
 """
 from __future__ import annotations
 
-import asyncio
 import sys
 from pathlib import Path
 
@@ -24,8 +23,20 @@ _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from reyn.chat.tui.app import _ESC_ESC_WINDOW_S, ReynTUIApp
+import reyn.chat.tui.app as app_mod
+from reyn.chat.tui.app import ReynTUIApp
 from reyn.chat.tui.widgets import ConversationView, InputBar
+
+
+@pytest.fixture(autouse=True)
+def _wide_esc_window(monkeypatch):
+    """De-flake (#1587): make the Esc-Esc window huge so the real auto-clear
+    ``set_timer`` never fires during a (sub-second) test — removing the
+    wall-clock race that let a slow 3.11 run zero the pending state mid-test.
+    The production window behaviour is unchanged (same monotonic-ts logic, just
+    a value the test controls); tests that need the window to *lapse* advance a
+    faked ``_now_monotonic`` past it instead of sleeping real time."""
+    monkeypatch.setattr(app_mod, "_ESC_ESC_WINDOW_S", 1_000_000.0)
 
 
 def _make_app() -> ReynTUIApp:
@@ -99,14 +110,22 @@ async def test_double_esc_within_window_opens() -> None:
 
 
 @pytest.mark.asyncio
-async def test_double_esc_outside_window_rearms() -> None:
-    """Tier 2: a second Esc AFTER the window re-arms (new first tap), not open."""
+async def test_double_esc_outside_window_rearms(monkeypatch) -> None:
+    """Tier 2: a second Esc AFTER the window re-arms (new first tap), not open.
+
+    Deterministic clock (#1587): the window lapse is simulated by advancing a
+    faked ``_now_monotonic`` past the window — no real ``asyncio.sleep`` (which
+    raced 3.11's timer scheduling at the old +0.05 margin)."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(app_mod, "_now_monotonic", lambda: clock["t"])
     app = _make_app()
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
-        await pilot.press("escape")
-        await asyncio.sleep(_ESC_ESC_WINDOW_S + 0.05)  # let the window lapse
-        await pilot.press("escape")
+        await pilot.press("escape")          # arm at t=1000
+        assert app.esc_esc_pending is True
+        # Advance PAST the window deterministically (no wall-clock sleep).
+        clock["t"] += app_mod._ESC_ESC_WINDOW_S + 1.0
+        await pilot.press("escape")          # 2nd Esc now lands outside the window
         await pilot.pause()
         # Did not double-tap → no open attempt, but re-armed for a fresh pair.
         assert not _conv_has(app, "no checkpoints")

--- a/tests/cli/test_fork_picker_edit_mode_2c.py
+++ b/tests/cli/test_fork_picker_edit_mode_2c.py
@@ -26,6 +26,7 @@ _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+import reyn.chat.tui.app as app_mod
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
 from reyn.chat.tui.app import ReynTUIApp
@@ -94,9 +95,14 @@ async def test_enter_exit_edit_mode_toggles_flag_and_banner() -> None:
 
 
 @pytest.mark.asyncio
-async def test_exit_edit_mode_resets_esc_esc_pending() -> None:
+async def test_exit_edit_mode_resets_esc_esc_pending(monkeypatch) -> None:
     """Tier 2: exit_edit_mode resets the pending Esc-Esc first tap, so
-    "exit-edit Esc then clean Esc" can't false-fire the picker (#1554 discipline)."""
+    "exit-edit Esc then clean Esc" can't false-fire the picker (#1554 discipline).
+
+    #1587: the window is widened so the real auto-clear ``set_timer`` can't fire
+    mid-test (a slow 3.11 run zeroed the pending state before the first assert);
+    this test pins the *reset-on-exit* path, not the timer-driven lapse."""
+    monkeypatch.setattr(app_mod, "_ESC_ESC_WINDOW_S", 1_000_000.0)
     app = _make_app()
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — Closes #1587. De-flakes the recurring Esc-Esc-pending timing flake (1-of-~7200, **3.11-only**, re-run passes, PR-diff-untouched). Testing policy: NEVER pin wall-clock timing.

## Root cause
Two wall-clock dependencies in the tests vs the `_ESC_ESC_WINDOW_S` (0.6s, monotonic-ts) window:
1. The real auto-clear `set_timer(_ESC_ESC_WINDOW_S, _clear_esc_esc_hint)` fires after 0.6s and zeroes `_last_clean_esc_ts`. On a slow 3.11 run the test crossed 0.6s **before** its `assert esc_esc_pending is True` → the timer had already cleared it.
2. `test_double_esc_outside_window_rearms` used `asyncio.sleep(_ESC_ESC_WINDOW_S + 0.05)` — the +0.05 margin raced 3.11's timer scheduling.

## Fix — pure test-side (no production change)
The production monotonic-ts window logic is **unchanged**; the tests just stop depending on real elapsed time:
- **`test_esc_esc_rewind_1546.py`**: an autouse fixture widens `_ESC_ESC_WINDOW_S` to `1e6` so the real auto-clear timer fires at ~1e6 s (never during a sub-second test → the pending state isn't zeroed mid-test) and back-to-back Escs are always within-window. `test_double_esc_outside_window_rearms` advances a **faked `_now_monotonic`** past the window (deterministic lapse) instead of sleeping.
- **`test_fork_picker_edit_mode_2c.py::test_exit_edit_mode_resets_esc_esc_pending`**: same window-widen so the timer can't pre-empt the reset-on-exit assertion.

## Test plan
- [x] `pytest tests/cli/test_esc_esc_rewind_1546.py tests/cli/test_fork_picker_edit_mode_2c.py` — 17 passed
- [x] **20× local loop** of the two previously-flaky tests — 0 failures (deterministic by construction: timer at 1e6 s never fires sub-second; re-arm uses a fully faked clock)
- [x] `ruff check` + tier audit `--strict` — clean
- [x] `git status` — **2 test files only, zero production diff** (confirms "production timing logic stays")

**Tier self-check**: Tier 2, public surface (`esc_esc_pending`, `check_action`, conv buffer); the de-flake removes the implicit wall-clock pin (testing-policy "NEVER pin timing"), it doesn't add one. Refs #1546, #1554.
