### PR TITLE
feat(1560): PR-2 — act-turn workspace restore (coherent with memo truncation)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -748,6 +748,47 @@ class AgentRegistry:
         if tree_sha is not None:
             log.append(seq, tree_sha)
 
+    async def restore_workspace_to_act_turn(self, target_seq: int) -> str | None:
+        """Restore the workspace to the act-turn (per-op) state as-of ``target_seq``.
+
+        The workspace half of an act-turn rewind (#1560 PR-2), the coherent
+        counterpart to ``SkillResumeCoordinator.plan_for_act_turn_rewind`` (which
+        truncates the runtime memo at ``target_seq``). Because the op-content-log is
+        keyed by ``op_seq == CommittedStep.seq``, the SAME ``target_seq`` restores
+        both substrates: runtime memo[≤K] (coordinator) ⊗ workspace tree[≤K] (here).
+
+        Lineage resolution is the caller's job (the op-content-log is branch-agnostic
+        — capture is always current-branch): pick the latest op-tree with
+        ``op_seq <= target_seq`` that is **is_active** (skipping abandoned-interval
+        op-trees, mirroring ``_restore_workspace_active`` for generations), then
+        ``read-tree`` it. Falls back to the nearest **boundary** generation
+        (``_restore_workspace_active``) when no active op-tree ``<= target_seq``
+        exists (act-turn capture was off for that span / pre-feature). No-op when
+        act-turn capture or the workspace store is disabled (Tier-1 #1582 / no WAL).
+        Returns the restored tree sha (op-tree path) or ``None``.
+        """
+        if self._state_log is None:
+            return None
+        log = self.op_content_log
+        ws = self.workspace_store
+        if log is None or ws is None:
+            return None
+        # is_active-honoring: the branch-agnostic op-content-log may hold op-trees
+        # from abandoned intervals; skip them (same lineage rule as the boundary
+        # restore) and take the latest active op-tree at-or-below the target.
+        active = [
+            e for e in log.entries()
+            if int(e["op_seq"]) <= target_seq
+            and is_active_seq(self._state_log, int(e["op_seq"]))
+        ]
+        if active:
+            tree_sha = max(active, key=lambda e: int(e["op_seq"]))["tree_sha"]
+            return await ws.restore_tree(tree_sha)
+        # boundary fallback: no act-turn op-tree on the active lineage <= target →
+        # the nearest active generation (today's behaviour) — strictly additive.
+        await self._restore_workspace_active(at_or_below=target_seq)
+        return None
+
     @property
     def anchor_store(self) -> AnchorStore | None:
         """The per-checkpoint anchor store (#1547), lazily built. None w/o WAL."""

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -235,6 +235,30 @@ class WorkspaceVersionStore:
         except GitUnavailable:
             return self._degrade("restore", seq)
 
+    async def restore_tree(self, tree_sha: str) -> str | None:
+        """Restore the work-tree to a bare **tree** object (#1560 act-turn restore).
+
+        The inverse of :meth:`capture_tree`: ``read-tree <sha>`` (load the tree into
+        the index) + ``checkout-index -a -f`` (write the index out to the work-tree,
+        overwriting) + ``clean -fdq`` (honoring the excludes — drop work-tree files
+        not in the tree). Restores the exact mid-act-turn work-tree content for a
+        tree captured by ``capture_tree``. The caller supplies an is_active-resolved
+        ``tree_sha`` from the op-content-log (lineage is the caller's concern; the
+        store just materializes the tree). Returns ``tree_sha``, or ``None`` when
+        git is unavailable (degrade — never raises).
+        """
+        try:
+            await self._ensure_repo()
+            await self._git(["read-tree", tree_sha])
+            await self._git(["checkout-index", "-a", "-f"])
+            clean_args = ["clean", "-fdq"]
+            for pat in self._exclude:
+                clean_args += ["-e", pat]
+            await self._git(clean_args)
+            return tree_sha
+        except GitUnavailable:
+            return self._degrade("restore_tree", None)
+
     # ── queries ──────────────────────────────────────────────────────────
 
     async def seqs(self) -> list[int]:

--- a/tests/test_act_turn_restore_1560.py
+++ b/tests/test_act_turn_restore_1560.py
@@ -1,0 +1,134 @@
+"""Tier 2: OS invariant — act-turn workspace restore (#1560 PR-2, restore half).
+
+PR-1 captures a per-op `write-tree` into the op-content-log keyed by
+`op_seq == CommittedStep.seq` on each `step_completed`. PR-2 is the restore
+counterpart: `AgentRegistry.restore_workspace_to_act_turn(target_seq)` reads the
+op-content-log (is_active-filtered) + `read-tree`s the latest active tree
+`≤ target_seq`, with a boundary-generation fallback.
+
+The load-bearing assertion (closes the 2a-3 runtime-only gap): because both the
+runtime memo (`plan_for_act_turn_rewind` truncates `committed_steps ≤ target`) and
+the workspace op-content-log are keyed by the SAME `op_seq == CommittedStep.seq`, a
+single `target_seq` restores BOTH substrates coherently — memo[≤K] ⊗ tree[≤K].
+
+Real AgentRegistry + StateLog + real git + the genuine PR-1 capture observer (the
+`step_completed` append fires it — no mock); only the per-step file write (the op
+effect) is simulated, live-fork-gate style.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.snapshot_generations import is_active_seq, rewind
+from reyn.events.state_log import StateLog
+from reyn.skill.skill_resume_coordinator import SkillResumeCoordinator
+from reyn.skill.skill_snapshot import SkillSnapshot
+
+_WS_FILE = "code.py"
+_needs_git = pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+
+
+def _make_registry(tmp_path: Path, *, act_turn_capture: bool, workspace_capture: bool = True) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda _p: (_ for _ in ()).throw(AssertionError("no factory")),
+        state_log=state_log,
+        workspace_capture=workspace_capture,
+        act_turn_capture=act_turn_capture,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+async def _step(reg: AgentRegistry, tmp_path: Path, *, content: str, oid: str, run_id: str = "r1") -> int:
+    """Simulate an op: write the workspace file, then append step_completed (which
+    fires the genuine PR-1 capture observer → write-tree into the op-content-log)."""
+    (tmp_path / _WS_FILE).write_text(content, encoding="utf-8")
+    return await reg.state_log.append(
+        "step_completed", target="alpha", run_id=run_id, phase="p",
+        op_kind="file", op_invocation_id=oid, args_hash=f"h{oid}", result={"ok": True},
+    )
+
+
+def _file(tmp_path: Path) -> str:
+    return (tmp_path / _WS_FILE).read_text(encoding="utf-8")
+
+
+# ── core: workspace tree[≤K] coherent with memo[≤K] at one target_seq ─────────
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_act_turn_restore_coherent_with_memo_truncation(tmp_path):
+    """Tier 2: restore to step K reverts the workspace to tree[≤K], coherent with
+    the runtime memo[≤K] (plan_for_act_turn_rewind) — same target_seq, both substrates."""
+    reg = _make_registry(tmp_path, act_turn_capture=True)
+    k1 = await _step(reg, tmp_path, content="v1", oid="o1")
+    k2 = await _step(reg, tmp_path, content="v2", oid="o2")
+    k3 = await _step(reg, tmp_path, content="v3", oid="o3")
+    assert _file(tmp_path) == "v3"                          # head
+
+    # workspace half: restore to act-turn step K2.
+    await reg.restore_workspace_to_act_turn(k2)
+    assert _file(tmp_path) == "v2"                          # tree[≤K2]
+
+    # runtime half: the SAME target_seq truncates the memo to ≤ K2 (k3 dropped).
+    snap = SkillSnapshot.empty("r1", "demo", {})
+    wal = [e for e in reg.state_log.iter_from(1) if e.get("run_id") == "r1"]
+    plan = SkillResumeCoordinator().plan_for_act_turn_rewind(
+        snapshot=snap, wal_events=wal, target_seq=k2,
+    )
+    memo_seqs = sorted(c.seq for c in plan.committed_steps)
+    assert memo_seqs == [k1, k2]                            # memo[≤K2] — coherent with tree[≤K2]
+
+
+# ── lineage: is_active-honoring (abandoned op-trees skipped) ──────────────────
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_act_turn_restore_skips_abandoned_optree(tmp_path):
+    """Tier 2: an op-tree on an abandoned interval is skipped (is_active filter).
+
+    Capture k1(v1), k2(v2); rewind to k1 (abandons k2); capture k_post(v3) on the
+    new active branch. Restoring at-or-below the head must pick the ACTIVE k_post
+    (v3), NOT the abandoned k2 (v2) — even though k2 < k_post."""
+    reg = _make_registry(tmp_path, act_turn_capture=True)
+    k1 = await _step(reg, tmp_path, content="v1", oid="o1")
+    k2 = await _step(reg, tmp_path, content="v2", oid="o2")
+    await rewind(reg.state_log, target_n=k1)               # abandons (k1, R) ∋ k2
+    assert not is_active_seq(reg.state_log, k2)             # k2 now abandoned
+    k_post = await _step(reg, tmp_path, content="v3", oid="o3")
+    assert is_active_seq(reg.state_log, k_post)
+
+    await reg.restore_workspace_to_act_turn(k_post)
+    assert _file(tmp_path) == "v3"                          # active k_post, NOT abandoned k2's v2
+
+
+# ── boundary fallback + no-op ─────────────────────────────────────────────────
+
+
+@_needs_git
+@pytest.mark.asyncio
+async def test_act_turn_restore_falls_back_when_no_optree_below_target(tmp_path):
+    """Tier 2: no act-turn op-tree ≤ target → boundary fallback (no op-tree restore)."""
+    reg = _make_registry(tmp_path, act_turn_capture=True)
+    k1 = await _step(reg, tmp_path, content="v1", oid="o1")
+    # target below the first op-tree → no op-tree ≤ target → fallback path (no
+    # boundary generation captured here either → no-op, returns None, no crash).
+    out = await reg.restore_workspace_to_act_turn(k1 - 1)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_act_turn_restore_noop_when_capture_off(tmp_path):
+    """Tier 2: act_turn_capture=False → no op-content-log → restore is a no-op."""
+    reg = _make_registry(tmp_path, act_turn_capture=False)
+    assert reg.op_content_log is None
+    assert await reg.restore_workspace_to_act_turn(5) is None


### PR DESCRIPTION
**[dogfood-coder]** — #1560 PR-2 (restore half), the counterpart to PR-1's per-op capture (#1586, merged) + 2a-3's `plan_for_act_turn_rewind` (runtime memo truncation). **Closes the 2a-3 runtime-only gap.** Off main (#1586 merged).

## What

Because both the op-content-log (PR-1) and the resume memo (2a-3) are keyed by **`op_seq == CommittedStep.seq`**, **one `target_seq` restores both substrates coherently** — runtime memo[≤K] ⊗ workspace tree[≤K].

- **`WorkspaceVersionStore.restore_tree(tree_sha)`** — inverse of `capture_tree`: `read-tree <sha>` + `checkout-index -a -f` + `clean -fdq` (honoring excludes). Materializes a bare tree (no commit/tag); degrade-safe (GitUnavailable → None, never raises).
- **`AgentRegistry.restore_workspace_to_act_turn(target_seq)`** — the workspace half of an act-turn rewind. **is_active-honoring** (the op-content-log is branch-agnostic — capture is always current-branch, so the caller filters abandoned-interval op-trees, mirroring `_restore_workspace_active`) → `read-tree` the latest **active** op-tree `≤ target_seq`; **boundary-generation fallback** when none. **No-op** when act-turn capture / workspace store is off (Tier-1 #1582 / no WAL).

Built **into the act-turn-rewind path** (not wiring an existing caller — `plan_for_act_turn_rewind` has no production caller yet; this is foundational readiness for when act-turn rewind is UI-exposed, owner-confirmed framing). The integration test drives `plan_for_act_turn_rewind` + the restore directly and asserts coherence.

## Test plan

`tests/test_act_turn_restore_1560.py` (Tier 2, real AgentRegistry + StateLog + real git + the **genuine PR-1 capture observer** — `step_completed` append fires it, no mock; only the per-step file write is simulated):

- [x] **coherence** — restore to K → workspace tree[≤K] (`v2`) AND `plan_for_act_turn_rewind(target=K)` memo[≤K] (`[k1,k2]`, k3 dropped) at the **same** target_seq (the keystone closing 2a-3)
- [x] **is_active** — an abandoned-interval op-tree is skipped (active `k_post`/`v3` picked, not abandoned `k2`/`v2`)
- [x] boundary fallback when no op-tree ≤ target; no-op when capture off
- [x] `python -m pytest ... -W error::RuntimeWarning` → 4 passed
- [x] tier-audit clean; ruff clean
- [x] 617 adjacent workspace/registry/rewind/checkout/act-turn/capture tests pass

Tier self-check: docstrings declare Tier; no Tier-4 violations; no invariant weakening; audit 0. With PR-1 (#1586) + this, the #1560 core (capture + coherent restore) is in; PR-3 = retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)