### PR TITLE
feat(1560): act-turn op-tree retention via gc-root refs (PR-3) — #1560 complete

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -746,10 +746,12 @@ class AgentRegistry:
             return
         tree_sha = await ws.capture_tree()
         if tree_sha is not None:
-            log.append(seq, tree_sha)
-            # #1560 PR-3: pin the tree as a gc-root while in-window (the bare
-            # write-tree is otherwise unreachable → auto-gc'd). Dropped at prune.
+            # #1560 PR-3: pin the tree as a gc-root BEFORE logging it (the bare
+            # write-tree is otherwise unreachable → auto-gc'd). Ref-before-append
+            # gives the strict invariant "logged ⇒ gc-protected": any entry the
+            # restore reads is guaranteed to have a surviving tree. Dropped at prune.
             await ws.ref_op_tree(seq, tree_sha)
+            log.append(seq, tree_sha)
 
     async def restore_workspace_to_act_turn(self, target_seq: int) -> str | None:
         """Restore the workspace to the act-turn (per-op) state as-of ``target_seq``.

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -747,6 +747,9 @@ class AgentRegistry:
         tree_sha = await ws.capture_tree()
         if tree_sha is not None:
             log.append(seq, tree_sha)
+            # #1560 PR-3: pin the tree as a gc-root while in-window (the bare
+            # write-tree is otherwise unreachable → auto-gc'd). Dropped at prune.
+            await ws.ref_op_tree(seq, tree_sha)
 
     async def restore_workspace_to_act_turn(self, target_seq: int) -> str | None:
         """Restore the workspace to the act-turn (per-op) state as-of ``target_seq``.
@@ -1129,6 +1132,14 @@ class AgentRegistry:
             ws = self.workspace_store
             if ws is not None:
                 await ws.prune_below(floor)
+            # #1560 PR-3: act-turn op-content-log GC on the same boundary — drop
+            # entries below the floor + unref the out-window op-trees (so auto-gc
+            # reclaims them, the same bounded lifecycle generations get).
+            op_log = self.op_content_log
+            if op_log is not None:
+                op_log.prune_below(floor)                   # WorkspaceOpContentLog (sync)
+                if ws is not None:
+                    await ws.unref_op_trees_below(floor)
             # #1547: anchors GC'd on the same boundary as generations/blobs.
             anchors = self.anchor_store
             if anchors is not None:

--- a/src/reyn/events/workspace_op_content_log.py
+++ b/src/reyn/events/workspace_op_content_log.py
@@ -70,6 +70,29 @@ class WorkspaceOpContentLog:
                     out.append(rec)
         return out
 
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Drop entries with ``op_seq < min_keep_seq`` (#1560 PR-3 retention).
+
+        Index-only, mirroring the generation prune (``tag -d``): rewrite the JSONL
+        keeping only entries ``>= min_keep_seq``. The gc-root refs for the dropped
+        op-trees are removed separately by
+        ``WorkspaceVersionStore.unref_op_trees_below``, after which git auto-gc
+        reclaims the out-window trees. Returns the count dropped. Best-effort: a
+        rewrite failure logs + leaves the log intact (caller runs on retention)."""
+        entries = self.entries()
+        kept = [e for e in entries if int(e.get("op_seq", -1)) >= min_keep_seq]
+        removed = len(entries) - len(kept)
+        if removed <= 0:
+            return 0
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            body = "".join(json.dumps(e) + "\n" for e in kept)
+            self._path.write_text(body, encoding="utf-8")
+        except Exception as e:  # noqa: BLE001 — never fail the retention pass
+            logger.warning("op-content-log prune failed (floor=%s): %s", min_keep_seq, e)
+            return 0
+        return removed
+
     def latest_tree_at_or_below(self, seq: int) -> str | None:
         """The ``tree_sha`` of the highest ``op_seq <= seq`` (None if none).
 

--- a/src/reyn/events/workspace_version_store.py
+++ b/src/reyn/events/workspace_version_store.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 
 _TAG_PREFIX = "reyn-gen-"
 _TAG_RE = re.compile(rf"^{re.escape(_TAG_PREFIX)}(\d+)$")
+# #1560 PR-3: ref namespace that keeps per-op (act-turn) ``write-tree`` snapshots
+# reachable (gc-roots) while in-window. Unlike generations (commit-chained off
+# HEAD, so auto-gc-protected for free), a bare tree object is unreachable and
+# would be auto-gc'd; a ref pins it. Dropped at prune → out-window auto-gc reclaims.
+_OP_REF_PREFIX = "refs/reyn-op/"
+_OP_REF_RE = re.compile(rf"^{re.escape(_OP_REF_PREFIX)}(\d+)$")
 # Marker committer identity — shadow commits never touch the user's git identity.
 _SHADOW_NAME = "reyn-shadow"
 _SHADOW_EMAIL = "reyn@shadow.local"
@@ -203,6 +209,52 @@ class WorkspaceVersionStore:
             return out.strip() or None
         except GitUnavailable:
             return self._degrade("capture_tree", None)
+
+    async def ref_op_tree(self, op_seq: int, tree_sha: str) -> None:
+        """Pin a per-op ``write-tree`` snapshot as a gc-root (#1560 PR-3).
+
+        ``update-ref refs/reyn-op/<op_seq> <tree_sha>`` so the otherwise-unreachable
+        tree survives git auto-gc while it is in-window. The op-content-log still
+        holds ``tree_sha`` as the restore key; this ref is purely gc-protection,
+        dropped by :meth:`unref_op_trees_below` at retention. Best-effort: a failure
+        is swallowed (the caller runs on the swallow-safe WAL post-append path)."""
+        try:
+            await self._ensure_repo()
+            await self._git(["update-ref", f"{_OP_REF_PREFIX}{int(op_seq)}", tree_sha])
+        except GitUnavailable:
+            self._degrade("ref_op_tree", op_seq)
+        except subprocess.CalledProcessError as e:
+            logger.warning("ref_op_tree failed (op_seq=%s): %s", op_seq, e)
+
+    async def unref_op_trees_below(self, min_keep_seq: int) -> int:
+        """Drop op-tree gc-roots with seq < ``min_keep_seq`` (#1560 PR-3 retention).
+
+        ``update-ref -d`` each ``refs/reyn-op/<seq>`` below the floor, so the now-
+        unreachable out-window op-trees become eligible for git's auto-gc (the same
+        bounded-lifecycle model generations get via their commit chain). Returns the
+        number of refs dropped. Mirrors :meth:`prune_below` for generation tags."""
+        try:
+            removed = 0
+            for s in await self._op_ref_seqs():
+                if s < min_keep_seq:
+                    await self._git(
+                        ["update-ref", "-d", f"{_OP_REF_PREFIX}{s}"], check=False,
+                    )
+                    removed += 1
+            return removed
+        except GitUnavailable:
+            return self._degrade("unref_op_trees", min_keep_seq) or 0
+
+    async def _op_ref_seqs(self) -> list[int]:
+        """Sorted op-tree ref seqs (from ``refs/reyn-op/*``); [] if none/degraded."""
+        out = await self._git(["for-each-ref", "--format=%(refname)", _OP_REF_PREFIX],
+                               check=False)
+        found = []
+        for line in (out or "").splitlines():
+            m = _OP_REF_RE.match(line.strip())
+            if m:
+                found.append(int(m.group(1)))
+        return sorted(found)
 
     async def restore_at_or_below(self, seq: int) -> str | None:
         """Restore to the nearest generation with **raw** tag-seq <= ``seq``.

--- a/tests/test_act_turn_retention_1560.py
+++ b/tests/test_act_turn_retention_1560.py
@@ -1,0 +1,129 @@
+"""Tier 2: act-turn op-tree retention via gc-root refs (#1560 PR-3).
+
+The per-op `write-tree` snapshots (PR-1) are bare tree objects — unreachable, so
+git auto-gc would reclaim them even in-window and break restore. PR-3 pins each as
+a gc-root (`refs/reyn-op/<op_seq>`) while in-window, drops the ref at retention,
+and lets auto-gc reclaim the now-unreachable out-window trees (the same bounded
+lifecycle generations get via their commit chain). These pin the load-bearing
+property: **in-window op-trees survive `git gc`; out-window ones (ref dropped) are
+reclaimed**. Real git + AgentRegistry + store, no mocks.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.events.state_log import StateLog
+from reyn.events.workspace_op_content_log import WorkspaceOpContentLog
+from reyn.events.workspace_version_store import _OP_REF_PREFIX, WorkspaceVersionStore
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git required")
+
+
+def _git(git_dir: Path, work_tree: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "--git-dir", str(git_dir), "--work-tree", str(work_tree), *args],
+        capture_output=True, text=True,
+    )
+
+
+# ── store: ref gc-protection (the correctness floor) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_op_ref_protects_tree_from_gc(tmp_path) -> None:
+    """Tier 2: a ref'd op-tree survives an aggressive `git gc --prune=now`
+    (in-window protection); the bare unreffed tree would be reclaimed."""
+    git_dir = tmp_path / ".reyn" / "workspace-shadow.git"
+    store = WorkspaceVersionStore(tmp_path, git_dir)
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+
+    tree = await store.capture_tree()
+    await store.ref_op_tree(100, tree)
+    assert _git(git_dir, tmp_path, "rev-parse", f"{_OP_REF_PREFIX}100").stdout.strip() == tree
+
+    _git(git_dir, tmp_path, "gc", "--prune=now")                 # aggressive gc
+    assert _git(git_dir, tmp_path, "cat-file", "-t", tree).stdout.strip() == "tree"  # survived
+
+
+@pytest.mark.asyncio
+async def test_unref_below_then_gc_reclaims_out_window(tmp_path) -> None:
+    """Tier 2: unref_op_trees_below drops out-window refs → those trees become
+    unreachable + auto-gc reclaims them, while in-window refs (+ trees) survive."""
+    git_dir = tmp_path / ".reyn" / "workspace-shadow.git"
+    store = WorkspaceVersionStore(tmp_path, git_dir)
+
+    (tmp_path / "code.py").write_text("old", encoding="utf-8")
+    tree_old = await store.capture_tree()
+    await store.ref_op_tree(100, tree_old)
+    (tmp_path / "code.py").write_text("new", encoding="utf-8")
+    tree_new = await store.capture_tree()
+    await store.ref_op_tree(200, tree_new)
+
+    dropped = await store.unref_op_trees_below(150)             # floor between 100 and 200
+    assert dropped == 1
+    assert _git(git_dir, tmp_path, "rev-parse", "--verify", f"{_OP_REF_PREFIX}100").returncode != 0
+    assert _git(git_dir, tmp_path, "rev-parse", f"{_OP_REF_PREFIX}200").stdout.strip() == tree_new
+
+    _git(git_dir, tmp_path, "gc", "--prune=now")
+    assert _git(git_dir, tmp_path, "cat-file", "-t", tree_old).returncode != 0   # reclaimed
+    assert _git(git_dir, tmp_path, "cat-file", "-t", tree_new).stdout.strip() == "tree"  # kept
+
+
+@pytest.mark.asyncio
+async def test_generation_prune_unaffected(tmp_path) -> None:
+    """Tier 2: generation prune (tag -d) still works alongside the op-ref additions
+    — the existing boundary-generation retention is unchanged."""
+    git_dir = tmp_path / ".reyn" / "workspace-shadow.git"
+    store = WorkspaceVersionStore(tmp_path, git_dir)
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+    await store.capture(50)
+    assert 50 in await store.seqs()
+    await store.prune_below(100)
+    assert 50 not in await store.seqs()                         # gen-tag pruned as before
+
+
+# ── op-content-log entry prune ─────────────────────────────────────────────
+
+
+def test_op_content_log_prune_below(tmp_path) -> None:
+    """Tier 2: entry-drop keeps only op_seq >= floor (index half of retention)."""
+    log = WorkspaceOpContentLog(tmp_path / "op-content-log.jsonl")
+    log.append(100, "a")
+    log.append(200, "b")
+    log.append(300, "c")
+    assert log.prune_below(200) == 1
+    assert [e["op_seq"] for e in log.entries()] == [200, 300]
+
+
+# ── registry: capture observer pins the ref end-to-end ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capture_observer_pins_op_ref(tmp_path) -> None:
+    """Tier 2: with act_turn_capture on, a `step_completed` append records the
+    op-content-log entry AND pins the gc-root ref (the full capture wiring)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile):
+        raise AssertionError("factory must not be called")
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+        workspace_capture=True, act_turn_capture=True,
+    )
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    (tmp_path / "code.py").write_text("v1", encoding="utf-8")
+
+    seq = await state_log.append("step_completed", run_id="r1", op_kind="file_write")
+
+    captured = {e["op_seq"]: e["tree_sha"] for e in reg.op_content_log.entries()}
+    assert seq in captured                                      # entry recorded
+    git_dir = tmp_path / ".reyn" / "workspace-shadow.git"
+    ref = _git(git_dir, tmp_path, "rev-parse", f"{_OP_REF_PREFIX}{seq}")
+    assert ref.returncode == 0 and ref.stdout.strip() == captured[seq]   # ref pins the tree


### PR DESCRIPTION
**[e2e-coder]** — act-turn op-tree retention (#1560 PR-3, the final piece)

Retention for the per-step op-content-log — closes #1560 (capture #1586 + restore #1589 + this).

## The problem (e2e flow-trace surfaced it)

The per-op `write-tree` snapshots (PR-1) are **bare tree objects** = unreachable. The shadow repo runs git's default `gc.auto`, so **auto-gc would reclaim in-window op-trees and break act-turn restore**. Generations don't have this problem — they're commit-*chained* off HEAD, so auto-gc-safe for free. Op-trees aren't.

## The fix — gc-root refs (parity, lead + sandbox_2 converged)

Pin each in-window op-tree as a gc-root ref; drop it at retention; let auto-gc reclaim the now-unreachable out-window trees — the same bounded lifecycle generations get. (`gc.auto=0` was considered and **rejected** as too blunt: it kills repacking + leaves both substrates unbounded, and generations are already chain-protected. The asymmetry is the real issue; refs fix it at the correctness floor.)

- `WorkspaceVersionStore.ref_op_tree(op_seq, tree_sha)` — `update-ref refs/reyn-op/<seq>`, degrade-safe; `unref_op_trees_below(floor)` — `update-ref -d`, mirroring the generation `prune_below` (tag -d). `gc.auto` left at default (relied on for reclamation, not disabled).
- `WorkspaceOpContentLog.prune_below(floor)` — entry-drop (index half).
- `AgentRegistry`: capture observer pins the ref after `capture_tree`; `_prune_generations_below` adds the entry-prune + unref on the same retention boundary. **Restore unchanged** (the ref is purely gc-protection; restore reads `tree_sha` from the log entry).

## Test plan

- [x] `tests/test_act_turn_retention_1560.py` (Tier 2, real git, no mocks): **in-window op-tree survives `git gc --prune=now`** (ref protects it); **unref-below + gc reclaims the out-window tree** (in-window kept); op-content-log entry-prune; generation prune (tag -d) unaffected; capture observer pins the ref end-to-end.
- [x] `pytest -k "registry or workspace or retention or act_turn or 1560 or state_log or rewind"` → 612 passed / 2 skipped (PR-1/PR-2 act-turn tests green with the ref addition); `ruff` clean; `test_tier_audit.py --strict` clean; `py_compile` OK.

No config/docs changes — `act_turn_capture` config + threading landed in PR-1.

@lead-coder + @sandbox_2 — co-review. **#1560 complete** with this (2a-3 gap fully closed: capture + restore + retention).

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)