### PR TITLE
feat(1577): scroll window for the tree /rewind picker

### DIFF
--- a/src/reyn/chat/tui/widgets/rewind_menu.py
+++ b/src/reyn/chat/tui/widgets/rewind_menu.py
@@ -37,6 +37,11 @@ from reyn.chat.tui._palette import (
 )
 from reyn.chat.tui.widgets._branch_tree import ROW_CHECKPOINT, ROW_HEADER
 
+# Max tree rows (headers + checkpoints) rendered at once (#1577 — mirrors
+# SlashPicker / the old flat window). The window slides to keep the selected
+# checkpoint visible; the selected branch's header is pinned when it scrolls off.
+_MAX_VISIBLE = 8
+
 
 def format_rel_time(ts: str) -> str:
     """Best-effort relative-time string for a WAL ISO timestamp.
@@ -156,12 +161,74 @@ class RewindMenuWidget(Widget):
 
     # ── rendering ─────────────────────────────────────────────────────────────
 
+    def _visible_window(self) -> tuple[int, int, "int | None"]:
+        """``(start, end, pinned_header_idx)`` over ``self._rows`` (#1577).
+
+        Keeps the selected checkpoint within a ``_MAX_VISIBLE``-row window
+        (headers + checkpoints counted). When the selected checkpoint's branch
+        header is scrolled above the window, its index is returned as
+        ``pinned_header_idx`` so the branch context stays visible at the top.
+        """
+        n = len(self._rows)
+        if n <= _MAX_VISIBLE:
+            return 0, n, None
+        sel_abs = self._selectable[self._selected] if self._selectable else 0
+        half = _MAX_VISIBLE // 2
+        start = max(0, min(sel_abs - half, n - _MAX_VISIBLE))
+        end = start + _MAX_VISIBLE
+        # The selected checkpoint's branch header = nearest header at/above it.
+        pinned: int | None = None
+        for j in range(sel_abs, -1, -1):
+            if self._rows[j].get("row") == ROW_HEADER:
+                pinned = j if j < start else None
+                break
+        return start, end, pinned
+
+    def _append_row(self, body: Text, i: int, r: dict, sel_abs: int) -> None:
+        """Render one tree row (branch header decorator, or a selectable
+        checkpoint row + its #1547 anchor line) into ``body``."""
+        indent = "  " * (r.get("depth", 0) + 1)
+        if r.get("row") == ROW_HEADER:
+            active = r.get("is_active")
+            glyph = "● " if active else "◌ "
+            mark = "▸ " if active else "  "
+            style = _TEXT_BRIGHT if active else f"dim {_TEXT_DIM}"
+            tag = "active" if active else "inactive"
+            line = Text()
+            line.append(f"{mark}{indent}{glyph}{r.get('label', '')}", style=style)
+            line.append(f"   {tag}\n", style=f"dim {_TEXT_DIM}")
+            body.append_text(line)
+            return
+        # checkpoint (selectable) row
+        is_sel = i == sel_abs
+        line = Text()
+        line.append("▌ " if is_sel else "  ", style=_CORAL if is_sel else _BG_HEADER)
+        line.append(indent)
+        line.append(
+            f"#{r.get('seq')}", style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT,
+        )
+        kind = _KIND_LABEL.get(r.get("kind", ""), r.get("kind", ""))
+        line.append(f"  {kind.ljust(10)}", style=_TEXT_MUTED)
+        rel = self._rel_time_fn(r.get("ts", ""))
+        if rel:
+            line.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
+        line.append("\n")
+        body.append_text(line)
+        # #1547 (restored for tree, #1576): per-checkpoint anchor (truncated last
+        # user message) as a dim line under the row, so the user can tell "which
+        # turn was this?" per checkpoint. Additive: empty anchor → omitted.
+        anchor = r.get("anchor", "")
+        if anchor:
+            body.append(f"  {indent}  {anchor}\n", style=f"dim {_TEXT_DIM}")
+
     def render(self) -> Text:
         """Render the branch-tree fork picker (Phase-2 2b, always-tree).
 
         Header rows are dim/bright decorators (active vs inactive branch); the
         ▌ caret sits only on the selected checkpoint row. Indent = depth. The
-        `▸` marks the working-tree head's branch.
+        `▸` marks the working-tree head's branch. Long trees are windowed
+        (#1577) around the selection with ``↑/↓ N more`` markers, keeping the
+        selected branch's header pinned for context.
         """
         body = Text()
         body.append(
@@ -173,44 +240,22 @@ class RewindMenuWidget(Widget):
             return body
 
         sel_abs = self._selectable[self._selected] if self._selectable else -1
-        for i, r in enumerate(self._rows):
-            indent = "  " * (r.get("depth", 0) + 1)
-            if r.get("row") == ROW_HEADER:
-                active = r.get("is_active")
-                glyph = "● " if active else "◌ "
-                mark = "▸ " if active else "  "
-                style = _TEXT_BRIGHT if active else f"dim {_TEXT_DIM}"
-                tag = "active" if active else "inactive"
-                line = Text()
-                line.append(f"{mark}{indent}{glyph}{r.get('label', '')}", style=style)
-                line.append(f"   {tag}\n", style=f"dim {_TEXT_DIM}")
-                body.append_text(line)
-                continue
-            # checkpoint (selectable) row
-            is_sel = i == sel_abs
-            line = Text()
-            line.append("▌ " if is_sel else "  ", style=_CORAL if is_sel else _BG_HEADER)
-            line.append(indent)
-            line.append(
-                f"#{r.get('seq')}", style=f"bold {_CORAL}" if is_sel else _TEXT_BRIGHT,
-            )
-            kind = _KIND_LABEL.get(r.get("kind", ""), r.get("kind", ""))
-            line.append(f"  {kind.ljust(10)}", style=_TEXT_MUTED)
-            rel = self._rel_time_fn(r.get("ts", ""))
-            if rel:
-                line.append(f"  {rel}", style=f"dim {_TEXT_DIM}")
-            line.append("\n")
-            body.append_text(line)
-            # #1547 (restored for tree mode, #1576): per-checkpoint anchor
-            # (truncated last user message) as a dim line under the row, so the
-            # user can tell "which turn was this?" per checkpoint — not only at
-            # fork-point headers. Aligned past the caret + depth indent. Additive:
-            # empty anchor → omitted (parity with the old flat render).
-            anchor = r.get("anchor", "")
-            if anchor:
-                body.append(
-                    f"  {indent}  {anchor}\n", style=f"dim {_TEXT_DIM}",
-                )
+        n = len(self._rows)
+        start, end, pinned = self._visible_window()
+
+        # Pinned branch header (scrolled above the window) keeps branch context.
+        if pinned is not None:
+            self._append_row(body, pinned, self._rows[pinned], sel_abs)
+        if start > 0:
+            hidden = start - (1 if pinned is not None else 0)
+            if hidden > 0:
+                body.append(f"  ↑ {hidden} earlier…\n", style=f"dim {_TEXT_DIM}")
+
+        for i in range(start, end):
+            self._append_row(body, i, self._rows[i], sel_abs)
+
+        if end < n:
+            body.append(f"  ↓ {n - end} later…\n", style=f"dim {_TEXT_DIM}")
         body.append(
             "  ↑/↓ select · Enter checkout · ctrl+t edit · Esc cancel\n",
             style=f"dim {_TEXT_DIM}",

--- a/tests/cli/test_rewind_menu_tree_2b.py
+++ b/tests/cli/test_rewind_menu_tree_2b.py
@@ -22,7 +22,7 @@ if str(_SRC) not in sys.path:
 from reyn.chat.tui.app import ReynTUIApp
 from reyn.chat.tui.widgets import ConversationView
 from reyn.chat.tui.widgets._branch_tree import build_branch_tree_rows
-from reyn.chat.tui.widgets.rewind_menu import RewindMenuWidget
+from reyn.chat.tui.widgets.rewind_menu import _MAX_VISIBLE, RewindMenuWidget
 
 
 def _rows_two_branches() -> list[dict]:
@@ -137,3 +137,45 @@ def test_tree_render_shows_kind_and_reltime() -> None:
     )
     rendered = w.render().plain
     assert "#5" in rendered and "phase" in rendered and "2m ago" in rendered
+
+
+def _tall_single_branch(n: int) -> list[dict]:
+    """Tree rows for one active branch with ``n`` checkpoints (newest-first)."""
+    branches = [{"branch_id": 0, "fork_point_seq": 0, "head_seq": n,
+                 "parent_branch_id": None, "is_active": True}]
+    cps = [{"seq": i, "ts": "", "kind": "turn", "anchor": "", "branch_id": 0}
+           for i in range(n)]
+    return build_branch_tree_rows(branches, cps)
+
+
+def test_tree_window_caps_visible_rows() -> None:
+    """Tier 2: #1577 — a long tree windows to <=_MAX_VISIBLE rows with a
+    '↓ N later' overflow marker — not all 30 rows render."""
+    w = RewindMenuWidget.from_tree_rows(_tall_single_branch(30))
+    rendered = w.render().plain
+    cp_rows = [ln for ln in rendered.splitlines()
+               if "#" in ln and "later" not in ln and "earlier" not in ln]
+    assert len(cp_rows) <= _MAX_VISIBLE          # windowed, not 30
+    assert "later" in rendered                    # overflow marker (selection at top)
+
+
+def test_tree_window_keeps_selection_visible_and_pins_header() -> None:
+    """Tier 2: #1577 — navigating deep keeps the selected checkpoint visible and
+    pins its branch header (context) with an '↑ earlier' marker."""
+    w = RewindMenuWidget.from_tree_rows(_tall_single_branch(30))
+    w.move_selection(25)                          # deep into the list
+    sel = w.selected_point()
+    rendered = w.render().plain
+    assert f"#{sel['seq']}" in rendered           # selected checkpoint visible
+    assert "▌" in rendered                         # caret rendered
+    assert "main" in rendered                      # branch header pinned (context)
+    assert "earlier" in rendered                   # overflow-above marker
+
+
+def test_small_tree_no_window() -> None:
+    """Tier 2: #1577 — a tree within _MAX_VISIBLE renders fully, no markers."""
+    w = RewindMenuWidget.from_tree_rows(_tall_single_branch(3))
+    rendered = w.render().plain
+    assert "earlier" not in rendered and "later" not in rendered
+    for i in range(3):
+        assert f"#{i}" in rendered


### PR DESCRIPTION
**[tui-coder]** — Closes #1577. Adds a scroll window to the tree `/rewind` picker — the gap found during the #1563 assessment (the always-tree render dropped the flat path's 8-row window, so many checkpoints overflowed the inline picker).

## Fix (tree-aware windowing)
- `_visible_window` keeps the selected checkpoint within a `_MAX_VISIBLE`-row window (headers + checkpoints), with `↑ N earlier… / ↓ N later…` overflow markers (references the old flat window logic lead pointed to).
- **Branch context preserved**: when the selected checkpoint's branch header scrolls above the window, it's **pinned** at the top — the tree never degrades to orphaned checkpoints without their branch label. (This is the one tree-specific design choice; flat had no headers.)
- `_append_row` extracted so the pinned header + windowed rows share one render path (header decorator / checkpoint + #1547 anchor).

## Design note (alternatives considered)
Windows over `_rows` (the flat header+checkpoint list) around the selection + pin the selected branch's header — the simplest model matching flat's behaviour while keeping branch context. Per-branch sub-windowing (window each branch's checkpoints independently) was heavier and unnecessary for the typical few-branch case. Happy to revisit if you prefer a different model.

## Test plan
- [x] `pytest tests/cli/test_rewind_menu_tree_2b.py` — 12 (incl. window-caps-rows + keeps-selection-visible-and-pins-header + small-tree-no-window)
- [x] `pytest` rewind/tree/anchor/esc/branch/fork_picker suites — 70 passed (small trees < window render fully → existing tests unaffected)
- [x] **tmux smoke** — a 30-checkpoint tree windows in the live picker (bounded rows + `↓ N later` marker, no layout overflow)
- [x] `ruff check` + tier audit `--strict` — clean

**Tier self-check**: Tier 2, public surface (`render().plain`, `move_selection`, `selected_point`); window assertions are structural (≤ `_MAX_VISIBLE`, marker presence), not exact-format pins. Refs #1533, #1563.
