### PR TITLE
docs(time-travel): cost-tuning how-to (workspace_capture / act_turn_capture)

### DIFF
--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -54,6 +54,40 @@ When using the container environment backend (`--container`), the workspace
 rewind operates on the container filesystem via shadow-git `as-of-N` — the same
 user experience applies; the substrate is container-side.
 
+## Tuning time-travel cost
+
+Time-travel is on by default. Its largest constant cost is the **workspace shadow-git capture** that runs at every checkpoint boundary (every turn and plan-step) so a rewind can restore your repo files. You can tune this in `reyn.yaml` under the `time_travel` block. For the full per-key reference see [`reyn.yaml` § time_travel](../../reference/config/reyn-yaml.md#time_travel-block); for *why* it costs what it does, see [Cost and the runtime-only opt-out](../../concepts/runtime/time-travel.md#cost-and-the-runtime-only-opt-out).
+
+### Opt out of file rewind (`workspace_capture: false`)
+
+```yaml
+# reyn.yaml
+time_travel:
+  workspace_capture: false   # default is true
+```
+
+This selects **runtime-only rewind**: `/rewind`, the fork picker, branching, and checkout all still work and restore your **agent + conversation state**, but the **working tree is left untouched** (repo files are not snapshotted or rewound).
+
+When it's worth it:
+
+- your workspace is **large** — the per-boundary `git add -A` stats the whole tree;
+- you run in a **container** — each capture is a `docker exec` round-trip;
+- you only ever rewind to **re-run from a past point**, never to inspect the repo *as it was* there.
+
+This is the same fidelity act-turn rewind already gives ("re-run from here", not "the repo as it was here"). Crash recovery is **unaffected** — it rides the WAL, not the workspace capture. The setting is **read at startup** (run-level), not a mid-session toggle.
+
+### Opt in to per-step capture (`act_turn_capture: true`) — advanced
+
+```yaml
+# reyn.yaml
+time_travel:
+  act_turn_capture: true   # default is false
+```
+
+This adds a cheaper **per-op** workspace snapshot (one per skill-run step, not just per turn/plan-step). It is **off by default** and **high-frequency** (one capture per op).
+
+**Honest status**: enabling it today gives **no user-visible rewind benefit** — the picker does not yet expose a way to land a rewind *mid-skill-run*, so the extra per-step snapshots are foundational groundwork for a future capability, not something you can currently navigate to. Leave it off unless you specifically want that groundwork captured ahead of time. It is also a **no-op when `workspace_capture: false`** (the per-step capture rides the same workspace store).
+
 ## Pending features
 
 | Feature | Status |


### PR DESCRIPTION
**[docs-maintainer]** — opt-in/out user-doc per owner instruction (via lead-coder dispatch).

## Summary

Adds a `## Tuning time-travel cost` section to `guide/for-users/time-travel.md`. The config reference (`reyn.yaml § time_travel`) and concept (cost section) were already complete; the gap was a user-facing how-to. This fills it.

- **`workspace_capture: false`** (opt-out, real working feature) — runtime-only rewind: agent/conversation state rewinds, repo files don't. When-to-use (large workspace / container / re-run-only), crash-recovery-unaffected note, run-level (startup) note.
- **`act_turn_capture: true`** (opt-in, advanced) — per-step capture with **honest framing**: enabling it today gives *no user-visible rewind benefit* (picker doesn't expose mid-skill-run landing yet); foundational groundwork, default-off, no-op when `workspace_capture: false`.

Links to reference (what each key does) + concept (why it costs). No table duplication.

## Verification note

Premise-verified against current `origin/main` (`b09cf996`) before writing: `time_travel` block keys confirmed in config.py (15 hits), reyn-yaml.md (L275-288), concept cost section (L132). (First pass hit a stale remote-tracking ref from a partial `git fetch origin main`; resolved with full `git fetch origin`.)

## Test plan

- [x] Anchor links resolve: `#time_travel-block` (reyn-yaml) + `#cost-and-the-runtime-only-opt-out` (concept) — both match existing headers
- [x] No history refs in the new section (user doc — grep clean)
- [x] No mermaid added
- [x] No reference-table duplication (guide = how/when, reference = what)
- [x] Page drop: zero (addition only)
- [ ] lead-coder review of act_turn_capture honest framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)