### PR TITLE
docs(positioning): feature-differentiation map + skill de-emphasis audit (#256)

### DIFF
--- a/docs/deep-dives/research/positioning/reyn-differentiators.md
+++ b/docs/deep-dives/research/positioning/reyn-differentiators.md
@@ -16,6 +16,36 @@ reframe: general-agent positioning (2026-06-13、README #1517 + feature-map.md m
 
 ---
 
+## 構造的差別化の核 — OS は定数、skill は来ては去る
+
+個別の機能差別化（§2 以降）はすべて、ひとつの構造的な賭けから派生する:
+
+> **OS が定数であり、skill は来ては去る。** agent loop の制御・検証・記録・回復は
+> すべて OS 層の不変の contract であり、ドメインの振る舞い（skill）はその上に乗る
+> 純粋なデータにすぎない。新しい能力を足すのに OS コードは一切変わらない。
+
+これが他の self-hosted agent との最大の違いである。競合では agent の振る舞いと
+ランタイムが密結合しており、能力を足すとはコードを書くこと（= ランタイムの変更）に
+等しい。Reyn では:
+
+- **境界が構造で保証される（P1–P8）**: phase は次の phase も出力 schema も親 skill も
+  知らない。skill は遷移グラフと最終出力 schema だけを宣言する。OS は phase 名・
+  artifact 型・field 名のような skill 固有の文字列をコードに一切含まない（P7 検出
+  ルール）。新 skill = `skill.md` を足すだけ、OS は不変。
+- **意思決定が制約される（P3/P4）**: LLM は OS が提示した候補セットの中からのみ選ぶ。
+  任意の遷移・ツールを発明できない。hallucination は副作用の前に reject される。
+- **状態が単一の真実源を持つ（P5/P6）**: phase 間のすべての値は workspace を通り、
+  すべての状態変化は append-only の event log に記録される。in-memory state は
+  workspace に landing するまで信用されない。これが permission enforcement と
+  crash recovery を構造的に可能にする。
+
+つまり Reyn の差別化は「ある機能を持つこと」ではなく、**振る舞いが OS によって
+検証・記録・制約される構造そのもの**である。skill はその構造の上の一機能であって、
+見出しではない。詳細は [phase-vs-skill-vs-os](../../../concepts/architecture/phase-vs-skill-vs-os.md) /
+[principles](../../../concepts/architecture/principles.md) 参照。
+
+---
+
 ## 1. 競合との違い — Reyn は別の賭けをする
 
 Reyn は self-hosted の open-source general agent（OpenClaw / Hermes と同カテゴリ）だが、
@@ -72,6 +102,43 @@ self-hosted agent loop の各機能について、OpenClaw / Hermes 等の gener
 - **Skill architecture（差別化の1機能）** — Hermes 等の emergent auto-skill に対し、Reyn の skill
   は explicit / typed / validated。OS が各遷移を検証する reviewable / versioned な phase graph。
   predictable over emergent。**ある事ではなく、検証される事**が差別化。
+
+---
+
+## 機能グループ別 差別化マップ (scannable)
+
+[`feature-map.md`](../../../feature-map.md) の機能グループ単位で「何が Reyn を差別化するか」を
+1 行で示す。§2 が能力タイプ別の prose、こちらは機能グループ別の早見表。実装状況の
+source of truth は feature-map.md（このマップは差別化の articulation であり inventory ではない）。
+
+| 機能グループ | 差別化の核 (1 行) | 主たる対比軸 |
+|---|---|---|
+| **Phase Engine** | OS が act/decide loop を駆動し、LLM は OS 提示の候補からのみ次 phase を選ぶ (P3/P4) | vs free-running agent |
+| **LLM Validation** | 全出力を `{control, artifact, control_ir}` schema で毎回検証し violation は実行拒否 | vs 型ヒント / constrained decoding 頼み |
+| **Workspace (P5)** | phase 間の全データが workspace 経由・permission-gated IO | vs app-managed in-memory state |
+| **Crash Recovery** | WAL forward-replay で自動 crash recovery、SaaS なし | vs 非 durable checkpoint / 手動 resume |
+| **Time-Travel / Rewind** | user 起点の point-in-time rewind + branch、両 substrate を atomic に巻き戻し、append-only（履歴非破壊）| 競合に同等機能ほぼ無し |
+| **Event System (P6)** | 全状態変化を append-only event log に強制記録、replay 可能 | vs SaaS 依存の可観測性（append-only 保証なし）|
+| **Chat Compaction** | head+tail+LLM summary を budget 化、monotonic overflow-shrink retry | vs naive truncation / 無制限肥大 |
+| **Plan Mode** | OS-governed 分解、永続・per-step resumable（完了 step は LLM コストなく replay）| vs in-prompt ad-hoc task loop |
+| **Control IR Ops** | 全副作用が宣言的 op 経由・permission gate 対象 | vs 直接 tool 実行 |
+| **DSL** | skill/phase/artifact を typed・OS-validated な宣言として定義 | vs コードとしての agent 定義 |
+| **Permissions** | per-capability 宣言 + 4-layer JIT 承認 + `.reyn/` write zone | vs 最小限 gating |
+| **Safety / limit** | limit 到達で graceful force-close → 最終 wrap-up turn → operator 判断 | vs hard-stop / runaway |
+| **Budget & Cost** | token/USD cap を per-agent/chain/model で refuse-on-exceed | vs 事後観測のみ |
+| **Memory & RAG** | indexing strategy を `skill.md` で宣言する RAG *framework* + credential-free local embedding | vs 固定 memory 機能 |
+| **MCP** | client（外部消費）かつ server（自 agent 公開）、stdio server は Seatbelt 下 | vs 一方向のみ |
+| **Web & Protocol** | 標準プロトコル（MCP / A2A sync+async+webhook / REST/WS）に意図的 scope | vs 広い per-app 統合（競合の強み）|
+| **Intervention** | surface 非依存の `ask_user` / permission ルーティング（TUI/CLI/web/MCP 同一）| vs surface 固有の HITL |
+| **Multi-Agent** | topology-gated 委譲 + hop-depth cap + `chain_id` 監査伝播 | vs free-form 委譲 |
+| **Sandbox** | OS-level sandbox backend（Seatbelt / Landlock + seccomp）+ 明示的 `SandboxPolicy` | vs unsandboxed tool 実行 |
+| **Environment** | OS + permission + audit を host に残し、repo FS のみ container 化（⚗ Stage 2 MVP）| vs container に丸ごと委譲 |
+| **Credentials / Identity** | per-skill credential scoping（Confused Deputy 緩和）+ `agent_id` の全 event 伝播 | vs agent 単位の共有資格情報 |
+| **Skill architecture（差別化の1機能）** | explicit / typed / OS-validated な phase graph、各遷移を OS が検証 | vs emergent auto-skill |
+
+> **読み方**: この表のどの行も独立した「機能」ではなく、すべて「構造的差別化の核」
+> （OS-constant / skills-come-and-go）の系である。skill 行はその構造の上の一機能として
+> 意図的に末尾に置いている — 見出しではない。
 
 ---
 

--- a/docs/deep-dives/research/positioning/skill-deemphasis-audit.md
+++ b/docs/deep-dives/research/positioning/skill-deemphasis-audit.md
@@ -1,0 +1,75 @@
+---
+title: Skill de-emphasis audit (user-facing positioning)
+last_updated: 2026-06-14
+status: proposal
+audience: [maintainer]
+---
+
+# Skill de-emphasis audit
+
+**Positioning principle (owner)**: in user-facing positioning, "skill" is an
+*internal mechanism*, not a headline. The user-facing subject should be the
+**capability / outcome** ("what you can do"), with skill mentioned as the
+how, not the what. (This applies the spirit of `project_swe_skill_minimize_not_strengthen`
+— skill is a means, not the product — to user-facing docs.)
+
+This doc is a **proposal**: an audit of where user-facing docs currently lead
+with "skill" as a headline, plus a reframe plan. Per positioning being
+owner-principle territory, **no reframe is applied unilaterally** — this is for
+owner + lead-coder review before any edit lands.
+
+## Scope
+
+**In scope** (user-facing): `README.md`, `docs/guide/for-users/`,
+`docs/guide/getting-started/`, user-facing `docs/concepts/`.
+
+**Out of scope** (audience is skill authors / internal — "skill" is the correct
+subject there): `docs/guide/for-skill-authors/`, `docs/reference/`,
+`docs/deep-dives/decisions/`, the `concepts/skills/` mechanism docs.
+
+## Headline finding
+
+**The high-leverage user-facing surfaces are already skill-de-emphasized.** The
+prior general-agent positioning reframe (README rewrite) did the heavy lifting:
+
+- `README.md` tagline leads with *"Self-hosted general agent — every decision
+  constrained, auditable, replayable"*. The "Why Reyn" section leads with the
+  OS-enforced-contract bet and the four guarantees (P3/P4, P5/P6, cost,
+  credentials). Skill is **not** a headline; it appears only as one capability
+  example (`### Write a reusable workflow (skill)` — already workflow-first).
+- `docs/guide/for-users/index.md` leads with *"no skill authoring"* and a
+  capability table ("What you can do in chat"). It explicitly frames skill as
+  internal: *"Reyn routes your request to the right built-in skill automatically
+  — you don't choose which one."* — skill as plumbing, exactly the desired framing.
+
+So this audit is **not** a large rewrite. It confirms the surface is mostly
+clean and flags a small number of lower-leverage residuals for owner judgment.
+
+## Candidates (file → current → judgment)
+
+| Location | Current | Judgment | Suggested reframe (if any) |
+|---|---|---|---|
+| `README.md:80` | `### Write a reusable workflow (skill)` | **Keep** | Already workflow-first; "(skill)" as the parenthetical mechanism is correct. No change. |
+| `guide/for-users/index.md` | capability-table + "routes to the right built-in skill automatically" | **Keep** | Model example of the desired framing. No change. |
+| `guide/getting-started/03-your-first-skill.md` (title "Your first skill") | tutorial title leads with "skill" | **Borderline / low priority** | This tutorial *teaches skill authoring*, so the audience is transitioning into authors — "skill" is arguably correct. Optional: "Your first reusable workflow" with "(skill)" subtitle, to keep the capability-first voice for readers still in the user funnel. Owner call. |
+| `guide/for-users/work-with-files.md:111` (`## What the skill cannot do`) | section header names "the skill" | **Low priority** | Reframe to "What this cannot do" / "Limitations" — the user cares about the capability boundary, not that a skill implements it. |
+
+## Recommendation
+
+1. **No action required on the two high-leverage surfaces** (README, for-users
+   index) — they already embody the principle; cite them as the reference voice.
+2. **Optional, owner-judgment reframes** for the two low-leverage residuals
+   above (getting-started title, work-with-files header). Each is a one-line
+   change; neither is a positioning risk if left as-is.
+3. **Standing guidance** for future user-facing docs (worth a short note in the
+   docs style guide): lead sections with the *capability/outcome*; mention skill
+   as the mechanism in a parenthetical or a "how it works" aside, never as the
+   section's subject.
+
+If owner approves any of the optional reframes, I'll apply them as a separate
+small PR (one line each), keeping this audit doc as the rationale record.
+
+## Related
+
+- [reyn-differentiators.md](reyn-differentiators.md) — the OS-constant / skills-come-and-go lead differentiator (skill as one feature, not the headline)
+- [phase-vs-skill-vs-os.md](../../../concepts/architecture/phase-vs-skill-vs-os.md) — the structural basis (OS-constant)


### PR DESCRIPTION
**[docs-maintainer]** — positioning task #256, **proposal-first** (positioning is owner-principle territory; this is a draft for owner + lead-coder review, no unilateral rewrite).

## Part 1 — Feature-differentiation map (`reyn-differentiators.md`)

Two additive sections:
1. **「構造的差別化の核 — OS は定数、skill は来ては去る」** (after 核心テーゼ) — fronts the OS-constant / skills-come-and-go bet as THE lead differentiator from which all per-feature callouts derive (P1–P8, P3/P4, P5/P6). Skill explicitly framed as one feature on top, not the headline.
2. **「機能グループ別 差別化マップ (scannable)」** (table, after §2) — one differentiator line per feature-map.md group + primary vs-competitor axis. Scannable companion to §2's prose. Skill row intentionally last ("one feature, not the headline").

## Part 2 — Skill de-emphasis audit (`skill-deemphasis-audit.md`, new)

Audit of user-facing docs for skill-as-headline vs capability/outcome framing.
**Honest finding**: the high-leverage surfaces (README, for-users index) are
*already* de-emphasized by the prior general-agent reframe. Audit flags only 2
low-leverage residuals (getting-started title, work-with-files header) as
**owner-judgment optional** one-line reframes. No reframe applied — proposal only.

## Notes

- Both files are `deep-dives/research/positioning/` (internal research), not user-facing.
- No mermaid added. Part 1 additive only (existing sections untouched; final section numbering is owner's call).
- All Part 2 file:line claims verified against current origin/main.

## Test plan

- [x] Internal links resolve (phase-vs-skill-vs-os, principles, feature-map, competitive)
- [x] Part 2 audit claims verified against primary source (README:80, for-users/index, getting-started/03, work-with-files:111)
- [x] No unilateral user-facing reframe (proposal-only, owner-principle territory)
- [x] Page drop: zero
- [ ] owner + lead-coder positioning review

🤖 Generated with [Claude Code](https://claude.com/claude-code)