### PR TITLE
docs(time-travel): drop history refs from user-doc pending table

### DIFF
--- a/docs/guide/for-users/time-travel.md
+++ b/docs/guide/for-users/time-travel.md
@@ -93,8 +93,8 @@ This adds a cheaper **per-op** workspace snapshot (one per skill-run step, not j
 | Feature | Status |
 |---------|--------|
 | `/rewind` with in-turn edit (`ctrl+t`) to create a new fork-and-edit branch | ✅ Phase 2c, landed |
-| Retention window config (`retention: keep_generations: N`) to GC old checkpoints | ⏳ ADR-0038 Stage 1e — designed, not yet wired |
-| `/rewind` picker over WebSocket / A2A web surface; web edit via `AskUserMessage` UX | ✅ Phase 2d, landed (#1574) |
+| Retention window config (`retention: keep_generations: N`) to GC old checkpoints | ⏳ designed, not yet wired |
+| `/rewind` picker over WebSocket / A2A web surface; web edit via `AskUserMessage` UX | ✅ Phase 2d, landed |
 
 ## See also
 


### PR DESCRIPTION
**[docs-maintainer]** — low-pri cleanup flagged by lead-coder on the #1592 merge.

## Problem

The pending-features table in `guide/for-users/time-travel.md` carried inline history refs (`ADR-0038 Stage 1e`, `(#1574)`) — pre-existing from the Phase-2d status update (#1575), not from #1592. User docs should not inline ADR / PR / issue refs (`feedback_no_history_refs_in_user_docs`).

## Fix

- `⏳ ADR-0038 Stage 1e — designed, not yet wired` → `⏳ designed, not yet wired`
- `✅ Phase 2d, landed (#1574)` → `✅ Phase 2d, landed`

(Kept the "Phase 2d" roadmap label per lead-coder's suggested wording; only the ADR/PR/issue refs removed.)

## Test plan

- [x] grep confirms zero `ADR-`/`#NNN`/`FP-`/`Stage N` remaining in the file
- [x] Status meaning preserved (designed-not-wired / landed)
- [x] Page drop: zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)