### PR TITLE
test(1527): Landlock subprocess-cancel — code-inspect + skipif-gated live test

### DIFF
--- a/src/reyn/sandbox/backends/landlock.py
+++ b/src/reyn/sandbox/backends/landlock.py
@@ -285,11 +285,14 @@ class LandlockBackend:
             return await loop.run_in_executor(None, _run_blocking)
 
         # #1470: cancel-aware path — Popen in executor + asyncio.wait race.
-        # ⚠ Linux-only, untested on macOS dev env; logic mirrors SeatbeltBackend
-        # (verified on macOS). Needs Linux CI / contributor verification before this
-        # path can be considered confirmed. Worst-case: if cancel does not work,
-        # behaviour degrades to pre-#1470 (subprocess runs to completion) — no
-        # regression beyond the cooperative-cancel latency that already existed.
+        # ⚠ Linux-only; logic mirrors SeatbeltBackend (verified on macOS) — the
+        # cancel block + `_kill_proc_group` (SIGTERM-pg → SIGKILL grace) are a
+        # faithful mirror (code-inspected, #1527). LIVE-confirmed by
+        # ``tests/test_subprocess_cancel_1470.py::test_landlock_cancel_kills_subprocess``
+        # when run on a Linux 5.13+ host with the landlock LSM (skipif-gated; the
+        # CI Noop default + macOS e2e don't exercise it). Worst-case if cancel does
+        # not work: behaviour degrades to pre-#1470 (subprocess runs to completion)
+        # — no regression beyond the cooperative-cancel latency that already existed.
         try:
             proc = await loop.run_in_executor(
                 None,

--- a/tests/test_subprocess_cancel_1470.py
+++ b/tests/test_subprocess_cancel_1470.py
@@ -164,6 +164,56 @@ async def test_seatbelt_cancel_none_equivalence() -> None:
     assert not result.cancelled
 
 
+# ── 3b Process-group kill (Linux Landlock, if available) — #1527 ─────────────
+# The Landlock cancel path mirrors SeatbeltBackend (verified on macOS) but was
+# untested on Linux: CI lacks the Landlock LSM (Noop default) and e2e is macOS.
+# These run ONLY on Linux 5.13+ with the landlock package + LSM available (skipped
+# elsewhere, incl. the macOS dev env). The cancel logic + `_kill_proc_group`
+# (SIGTERM-pg → SIGKILL grace) are a faithful Seatbelt mirror (code-inspected,
+# #1527); these pin the process-group kill of the landlock-wrapped child live
+# where Landlock actually exists.
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="LandlockBackend is Linux-only")
+@pytest.mark.asyncio
+async def test_landlock_cancel_kills_subprocess() -> None:
+    """Tier 2: LandlockBackend — cancel_event kills the landlock-wrapped child's
+    process group, returning cancelled=True (the #1527 untested path)."""
+    from reyn.sandbox.backends.landlock import LandlockBackend  # noqa: PLC0415
+
+    backend = LandlockBackend()
+    if not backend.available():
+        pytest.skip("Landlock LSM not available (needs Linux 5.13+ + landlock pkg)")
+
+    event = asyncio.Event()
+    event.set()  # pre-set so the cancel path is taken immediately
+
+    result = await backend.run(
+        ["/bin/sleep", "60"], _POLICY, cancel_event=event
+    )
+    assert result.cancelled                       # killed, not run-to-completion
+    assert result.returncode != 0
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="LandlockBackend is Linux-only")
+@pytest.mark.asyncio
+async def test_landlock_cancel_none_equivalence() -> None:
+    """Tier 2: LandlockBackend cancel_event=None → normal completion (Popen-equiv,
+    no-regression guard for the cancel-aware path)."""
+    from reyn.sandbox.backends.landlock import LandlockBackend  # noqa: PLC0415
+
+    backend = LandlockBackend()
+    if not backend.available():
+        pytest.skip("Landlock LSM not available (needs Linux 5.13+ + landlock pkg)")
+
+    result = await backend.run(
+        ["/bin/echo", "landlock_ok"], _POLICY, cancel_event=None
+    )
+    assert result.returncode == 0
+    assert b"landlock_ok" in result.stdout
+    assert not result.cancelled
+
+
 # ── 4 P6 + P5 via op_runtime handler ─────────────────────────────────────────
 
 


### PR DESCRIPTION
**[dogfood-coder]** — #1470/#1526 follow-up (lead-assigned leftover). The Landlock backend's cancel path was honestly-marked **untested** (CI lacks the Landlock LSM → Noop default; e2e is macOS; logic mirrors the verified Seatbelt).

## ⚠ Honest scope: this is NOT a "verified" claim from my env
This dev env is **macOS** — Landlock is **Linux-only**, so I **cannot live-run** the Landlock path here (the skipif-gated tests SKIP on macOS, and the Noop-default CI skips them too). Per the optional-dep/real-env-verify discipline, a skipped test is **zero live verification** — so the deliverable is: **(a) code-inspection** + **(b) a ready skipif-gated test artifact** for a Linux+Landlock run. The **load-bearing live verification is a Linux 5.13+ / Landlock-LSM run** (Landlock-CI or a Linux contributor).

## (a) Code-inspection — the Landlock cancel path is a faithful Seatbelt mirror
`backends/landlock.py:288-375` vs the verified `seatbelt.py`:
- `start_new_session=True` → child in its own process group ✓
- `cancel_task = wait(cancel_event)` + `asyncio.wait(FIRST_COMPLETED, timeout)` ✓
- on cancel → `_kill_proc_group(proc)` = `os.killpg(os.getpgid(proc.pid), SIGTERM)` → SIGKILL after grace — **byte-identical** to Seatbelt's helper ✓
- `returncode=-SIGTERM`, `cancelled=True` ✓
- Only Landlock delta = the additive `preexec_fn=_build_preexec(ruleset)` (runs after `setsid`) — does **not** affect the process-group kill (which targets the landlock-wrapped child's group). ✓

So the process-group kill correctly covers the landlock-wrapped child; the logic is sound by inspection.

## (b) Test artifact
`tests/test_subprocess_cancel_1470.py` — two skipif-gated Landlock tests mirroring the Seatbelt ones:
- `test_landlock_cancel_kills_subprocess` — cancel_event set → killed, `cancelled=True` (the #1527 path)
- `test_landlock_cancel_none_equivalence` — cancel=None → normal completion (no-regression)
- Gated: `skipif(sys.platform != "linux")` + `LandlockBackend.available()` runtime skip → **SKIP on macOS/CI-Noop, RUN on Linux+Landlock**.
- Updated the `landlock.py` inline note to point at the test as the live-verify artifact.

## Test plan
- [x] tests SKIP cleanly on macOS (this env): `2 skipped` (honest — not run here)
- [x] file's other 9 cancel tests pass; tier-audit clean; ruff clean
- [x] (skipped — needs a Linux 5.13+ / Landlock-LSM env; #1527 stays open until a Landlock-env run) live run of the 2 Landlock tests → the actual #1527 confirmation

**Recommendation:** merge the artifact + code-inspection; flip the issue to "confirmed" only after a Landlock-env run of the 2 tests (Landlock-CI / Linux contributor). Worst-case remains no-regression (pre-#1470). I can't provide the live run from macOS — flagging for whoever has the Landlock env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)