### PR TITLE
feat(1593): ToolUseScheme plugin abstraction — foundation, ZERO behavior change (PR-1)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -40,6 +40,7 @@ models:
 | `skill_search` | map | BM25 skill pre-filter settings. See below. |
 | `skill_resume` | map | Resume policy for ambiguous steps on restart. See below. |
 | `time_travel` | map | Time-travel (rewind/resume) cost knobs. See below. |
+| `tool_use` | map | Per-layer tool-use scheme selector (chat/step/phase). See below. |
 | `self_improvement` | map | `skill_improver` apply-gate and version cap. See below. |
 | `mcp` | map | MCP server definitions and `search_threshold`. See below. |
 | `python` | map | Python preprocessor additional allowed-modules. See below. |
@@ -286,6 +287,25 @@ time_travel:
 |-----|------|---------|-------------|
 | `workspace_capture` | bool | `true` | When `true`, every checkpoint boundary (turn / plan-step) captures the workspace into a shadow-git generation so a rewind restores repo files too. This is time-travel's **largest** constant cost — a `git add -A` + commit per boundary (in container mode, a `docker exec` per boundary). Set to `false` for **runtime-only rewind**: rewind/checkout restore agent + conversation state but **not** repo files — a documented escape for large workspaces, container runs, or no-file-rewind use. Run-level (read at startup; not a mid-session toggle). |
 | `act_turn_capture` | bool | `false` | Opt-in **per-step** (act-turn) workspace capture. When `true`, each skill-run op (`step_completed`) also snapshots the workspace as a cheap `write-tree` (no commit) into an op-content-log, so a rewind can land *mid-skill-run*, not just at turn/plan-step boundaries. High-frequency (per op), so opt-in by default. A no-op when `workspace_capture` is `false` (the per-step capture rides the same shadow store). |
+
+## `tool_use` block
+
+Per-layer tool-use scheme selector (#1593). Each layer picks a registered `ToolUseScheme` by name — generalizing the binary `universal_wrappers_enabled` toggle into a pluggable, per-layer mechanism.
+
+```yaml
+tool_use:
+  chat: universal-category    # default
+  step: universal-category    # default
+  phase: universal-category   # default
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `chat` | string | `universal-category` | Tool-use scheme for the top-level chat layer. Set to another registered scheme (e.g. `enumerate-all`) to change how tools are presented to / dispatched from the LLM at that layer. |
+| `step` | string | `universal-category` | Tool-use scheme for the plan/skill step layer. |
+| `phase` | string | `universal-category` | Tool-use scheme for the OS phase layer. |
+
+Defaults preserve today's behaviour (all `universal-category`). A scheme owns how the `tools=` payload is built, the SP tool-use instructions, how an LLM response is interpreted, and how it is dispatched — so swapping a layer's scheme changes the whole tool-use loop for that layer without OS changes.
 
 ## `phase` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -358,6 +358,20 @@
 
 
 # -----------------------------------------------------------------------------
+# tool_use: the tool-use scheme per layer (#1593). Each of chat / step / phase
+# selects a registered ToolUseScheme by name — generalizing the binary
+# universal_wrappers_enabled toggle into a pluggable, per-layer scheme. Default
+# all "universal-category" (today's behaviour). Future schemes (enumerate-all,
+# codeact) are selected by setting a layer to that name — e.g. chat=enumerate-all
+# (weak-model-friendly at the top level) while step/phase stay universal-category.
+# -----------------------------------------------------------------------------
+# tool_use:
+#   chat: universal-category
+#   step: universal-category
+#   phase: universal-category
+
+
+# -----------------------------------------------------------------------------
 # plan_resume_raw: how the resume coordinator treats
 # interrupted plan-mode runs on restart. Parsed lazily by the coordinator,
 # so the shape lives in ``reyn.plan`` rather than here. Set to a dict only

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -36,6 +36,19 @@ if TYPE_CHECKING:
     from reyn.config import SkillSearchConfig
 
 
+def _resolve_tool_use_scheme(name: "str | None" = None):
+    """Return the active ``ToolUseScheme`` (#1593). Registers the built-in
+    universal-category scheme on first use (idempotent) and resolves by name,
+    defaulting to universal-category — PR-1 byte-identical. Per-layer config
+    (``tool_use:{chat,step,phase}``) passes the selected name here."""
+    from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme, register_scheme
+    from reyn.tools.schemes.universal_category import UniversalCategoryScheme
+
+    if get_scheme(DEFAULT_SCHEME_NAME) is None:
+        register_scheme(UniversalCategoryScheme())
+    return get_scheme(name or DEFAULT_SCHEME_NAME) or get_scheme(DEFAULT_SCHEME_NAME)
+
+
 # ---------------------------------------------------------------------------
 # Empty-response detection (Option F — ADR-0021)
 # ---------------------------------------------------------------------------
@@ -1399,6 +1412,11 @@ class RouterLoop:
         self._catalog: dict[str, dict] = {}  # populated per run()
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
+        # #1593: the active tool-use scheme. PR-1 = universal-category (the shipped
+        # behaviour, behind the protocol) for every layer → byte-identical. Per-layer
+        # config selection (tool_use:{chat,step,phase}) plugs in here; with all
+        # layers defaulting to universal-category it is byte-identical today.
+        self._scheme = _resolve_tool_use_scheme()
 
     @property
     def total_usage(self) -> TokenUsage:
@@ -1951,11 +1969,12 @@ class RouterLoop:
                 # observed). invoke_skill is sync but NOT idempotent
                 # from a cost perspective; deduping is safe because
                 # same args → same deterministic result.
-                tool_calls = self._dedupe_tool_calls_round(result.tool_calls)
-                # parallel execute all tool calls (deduped)
-                tool_results = await asyncio.gather(*[
-                    self._execute_tool(tc) for tc in tool_calls
-                ])
+                # #1593: route the round through the active tool-use scheme
+                # (interpret → OS exclude-gate → execute → format_feedback).
+                # Byte-identical to the former dedupe→gather(_execute_tool): universal
+                # delegates back to the router's SchemeOps; returns (tool_calls,
+                # tool_results) in the original deduped order.
+                tool_calls, tool_results = await self._run_scheme_tool_round(result)
                 # Detect async-deferred dispatches via the canonical
                 # registry (router_tools.get_dispatch_kind() →
                 # ToolDefinition.dispatch_kind).  Async tools'
@@ -2968,6 +2987,74 @@ class RouterLoop:
             ctx=dctx,
             invoker=functools.partial(self._invoke_router_tool, name),
         )
+
+    # ── #1593 SchemeOps adapter ─────────────────────────────────────────────
+    # The router IS the ``SchemeOps`` a *delegating* scheme calls. PR-1's
+    # UniversalCategoryScheme delegates here, so the seam is byte-identical (no
+    # universal-category logic is physically relocated). PR-2/3 schemes implement
+    # their own logic instead of delegating.
+
+    def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
+        """SchemeOps.resolve: dedupe + #229 salvage → actions carrying the original
+        ``tc`` + the resolved effective ``name``/``args``. The OS exclude-gates these
+        (on the effective name) before dispatch."""
+        deduped = self._dedupe_tool_calls_round(llm_response.tool_calls)
+        actions: list[dict] = []
+        for tc in deduped:
+            name, args = self._resolve_tool_call(tc)
+            actions.append({"tc": tc, "name": name, "args": args})
+        return actions
+
+    async def dispatch(self, actions: list[dict]) -> list[dict]:
+        """SchemeOps.dispatch: run the resolved (exclude-cleared) actions in parallel
+        via the OS dispatch substrate (the former gather of _execute_tool's dispatch
+        half)."""
+        return await asyncio.gather(*[
+            self._dispatch_resolved(a["name"], a["args"]) for a in actions
+        ])
+
+    def feedback(self, tool_results: list[dict]) -> list[dict]:
+        """SchemeOps.feedback: PR-1 identity — the OS loop's existing feedback
+        assembly (op-specific plan/invoke_skill + media + message building) consumes
+        ``tool_results`` unchanged. A non-universal scheme (PR-2/3) transforms here."""
+        return tool_results
+
+    async def _run_scheme_tool_round(self, llm_response) -> "tuple[list[dict], list[dict]]":
+        """Route one tool-call round through the active scheme (#1593), byte-identical
+        to the former ``dedupe → gather(_execute_tool)``. Returns ``(tool_calls,
+        tool_results)`` in the original (deduped) order for the downstream loop:
+
+        interpret (resolve) → OS exclude-gate (pre-dispatch) → execute (dispatch
+        survivors) → format_feedback. Universal emits only ``Execute``; the exclude
+        gate produces the same ``tool_excluded`` error result **in place** (not a
+        drop), so order + tool_call_id alignment are preserved."""
+        from reyn.tools.scheme import ExecContext, Execute, ExecutionResult
+
+        interp = self._scheme.interpret(
+            llm_response, tool_catalog=self._catalog, ops=self,
+        )
+        assert isinstance(interp, Execute), "universal-category emits only Execute"
+        actions = interp.actions
+        tool_calls = [a["tc"] for a in actions]
+
+        results: list = [None] * len(actions)
+        to_dispatch: list[tuple[int, dict]] = []
+        for i, a in enumerate(actions):
+            ex = self._excluded_result(a["name"], a["args"])
+            if ex is not None:
+                results[i] = ex
+            else:
+                to_dispatch.append((i, a))
+
+        exec_res = await self._scheme.execute(
+            Execute(actions=[a for _, a in to_dispatch]), ExecContext(), ops=self,
+        )
+        for (i, _), r in zip(to_dispatch, exec_res.tool_results):
+            results[i] = r
+        tool_results = self._scheme.format_feedback(
+            ExecutionResult(tool_results=results), ops=self,
+        )
+        return tool_calls, tool_results
 
     def _maybe_salvage_qualified_direct_call(
         self, name: str, args: dict,

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1644,24 +1644,23 @@ class RouterLoop:
         # the window is ample (then compact stays hidden + the SP header is
         # omitted); non-None when filling (compact tool + header appear together).
         _ctx_signal = _render_context_size_signal_for_host(host)
-        if _phase_op_catalog is not None:
-            # #1092 PR-A (FD1): phase op catalog REPLACES chat-discovery. The
-            # chat-discovery setup above ran on the phase host's stubs
-            # (empty skills/agents/mcp, universal off) — harmless; its build_tools
-            # result is discarded here in favor of the op catalog.
-            tools = list(_phase_op_catalog)
-        else:
-            tools = build_tools(
-                skills_for_tools,
-                host.list_available_agents(),
-                file_permissions=host.get_file_permissions(),
-                mcp_servers=host.get_mcp_servers(),
-                web_fetch_allowed=host.get_web_fetch_allowed(),
-                universal_wrappers_enabled=_univ_enabled,
-                search_actions_visible=_search_visible,
-                hot_list_aliases=_hot_list_aliases,
-                compact_visible=_ctx_signal is not None,
-            )
+        # #1593: build the presentation via the active scheme (tools= payload + SP
+        # params). Universal delegates to the router's `present` op → byte-identical
+        # (the phase op-catalog REPLACES build_tools for the phase layer; chat/step
+        # use build_tools with the catalog wrappers). PR-2/3 schemes shape tools=
+        # differently. The OS still projects _catalog from the payload + builds the
+        # (monolithic) SP from sp_params below.
+        _pres = self._scheme.build_presentation(
+            {"skills_for_tools": skills_for_tools, "hot_list_aliases": _hot_list_aliases},
+            {
+                "phase_op_catalog": _phase_op_catalog,
+                "univ_enabled": _univ_enabled,
+                "search_visible": _search_visible,
+                "ctx_signal_present": _ctx_signal is not None,
+            },
+            ops=self,
+        )
+        tools = _pres.llm_tools_payload
         # #187 STEP 1c (owner principle): actions are enumerated ONLY by
         # list_actions, and their schemas ONLY by describe_action. The former
         # ARS block (B37/B38) inlined the whole session action catalog into
@@ -1701,7 +1700,9 @@ class RouterLoop:
                 # Hosts without get_universal_wrappers_enabled (= FakeRouterHost
                 # in LLMReplay tests) default to False so SP byte content stays
                 # unchanged for cached fixtures.
-                universal_wrappers_enabled=_univ_enabled,
+                # #1593: the scheme owns the SP-shaping params (PR-1 parameterizes
+                # the monolithic build_system_prompt; identical values to _univ_enabled).
+                universal_wrappers_enabled=_pres.sp_params["universal_wrappers_enabled"],
                 cwd=_cwd_str,
                 # FP-0034 §D14: propagate the search_actions D14 visibility gate
                 # into the SP so the wrapper enumeration matches tools=.
@@ -1713,7 +1714,7 @@ class RouterLoop:
                 # truth derived from is_search_available() (= embedding_class
                 # configured + index ready); False there means the SP and tools=
                 # both exclude search_actions, eliminating the N5 hallucination.
-                search_actions_enabled=_search_visible if _univ_enabled else True,
+                search_actions_enabled=_pres.sp_params["search_actions_enabled"],
                 # #272/#1128: OS-injected context-size signal (header), computed
                 # once above. Rendered LAST in the SP (most volatile section →
                 # preserves the cached prefix above it); None when ample.
@@ -2993,6 +2994,39 @@ class RouterLoop:
     # UniversalCategoryScheme delegates here, so the seam is byte-identical (no
     # universal-category logic is physically relocated). PR-2/3 schemes implement
     # their own logic instead of delegating.
+
+    def present(self, available, layer_ctx):
+        """SchemeOps.present: today's universal-category presentation — the phase
+        op-catalog (when the phase layer supplies one) OR ``build_tools`` with the
+        catalog wrappers, plus the SP-shaping params (``universal_wrappers_enabled`` /
+        ``search_actions_enabled``) the monolithic ``build_system_prompt`` consumes
+        (PR-1 parameterizes the SP; PR-2 extracts a scheme-owned fragment)."""
+        from reyn.tools.scheme import Presentation
+
+        phase_op_catalog = layer_ctx.get("phase_op_catalog")
+        univ = layer_ctx["univ_enabled"]
+        search_visible = layer_ctx["search_visible"]
+        if phase_op_catalog is not None:
+            tools = list(phase_op_catalog)
+        else:
+            tools = build_tools(
+                available["skills_for_tools"],
+                self.host.list_available_agents(),
+                file_permissions=self.host.get_file_permissions(),
+                mcp_servers=self.host.get_mcp_servers(),
+                web_fetch_allowed=self.host.get_web_fetch_allowed(),
+                universal_wrappers_enabled=univ,
+                search_actions_visible=search_visible,
+                hot_list_aliases=available["hot_list_aliases"],
+                compact_visible=layer_ctx["ctx_signal_present"],
+            )
+        return Presentation(
+            llm_tools_payload=tools,
+            sp_params={
+                "universal_wrappers_enabled": univ,
+                "search_actions_enabled": search_visible if univ else True,
+            },
+        )
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
         """SchemeOps.resolve: dedupe + #229 salvage → actions carrying the original

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2864,6 +2864,19 @@ class RouterLoop:
         and dispatch via the wrapper path so the user-visible behavior
         matches what the LLM intended.
         """
+        name, args = self._resolve_tool_call(tc)
+
+        excluded = self._excluded_result(name, args)
+        if excluded is not None:
+            return excluded
+        return await self._dispatch_resolved(name, args)
+
+    def _resolve_tool_call(self, tc: dict) -> "tuple[str, dict]":
+        """#1593: name + args + #229 salvage → the effective ``(name, args)``.
+
+        **Resolution only** (no dispatch), so the scheme's ``interpret`` runs it and
+        the OS exclude-gates the result BEFORE ``execute`` — preserving the #1406/#187
+        pre-dispatch order across the scheme split (byte-identical)."""
         name = tc["function"]["name"]
         try:
             args = json.loads(tc["function"]["arguments"])
@@ -2872,19 +2885,22 @@ class RouterLoop:
 
         if name not in self._catalog and "__" in name:
             name, args = self._maybe_salvage_qualified_direct_call(name, args)
+        return name, args
 
-        # #1406: execution-level exclude enforcement. ``exclude_tools`` is not just
-        # an advertisement filter (#1400 ``_apply_tool_exclusions`` hides excluded
-        # tools from ``tools[]`` / ``self._catalog``) — the LLM can still call an
-        # excluded tool by name, which the #229 salvage rewrites to
-        # ``invoke_action(action_name=<excluded>)`` (or it is called as
-        # ``invoke_action`` directly), and ``universal_dispatch`` then resolves and
-        # EXECUTES it (the #187 N=3 web__search leak). Compute the effective
-        # resolved action — unwrap ``invoke_action`` — and reject if excluded.
-        # Covers all three bypass paths (native direct / salvaged / direct
-        # invoke_action). Catalog filter (#1400) stays as the hide layer
-        # (defense-in-depth). A distinct ``tool_excluded`` kind + decision-enabling
-        # message lets the model adjust ([[deny-message-decision-enabling]]).
+    def _excluded_result(self, name: str, args: dict) -> "dict | None":
+        """#1406/#187: the **pre-dispatch** exclude gate. Returns the
+        ``tool_excluded`` error result when the effective op is excluded, else None.
+
+        ``exclude_tools`` is not just an advertisement filter (#1400
+        ``_apply_tool_exclusions`` hides excluded tools from ``tools[]`` /
+        ``self._catalog``) — the LLM can still call an excluded tool by name, which
+        the #229 salvage rewrites to ``invoke_action(action_name=<excluded>)`` (or it
+        is called as ``invoke_action`` directly), and ``universal_dispatch`` then
+        resolves and EXECUTES it (the #187 N=3 web__search leak). Compute the
+        effective resolved action — unwrap ``invoke_action`` — and reject if excluded.
+        Covers all three bypass paths (native direct / salvaged / direct
+        invoke_action). The ``tool_excluded`` kind + decision-enabling message lets
+        the model adjust ([[deny-message-decision-enabling]])."""
         if self._exclude_tools:
             effective = args.get("action_name") if name == "invoke_action" else name
             if effective in self._exclude_tools:
@@ -2899,7 +2915,13 @@ class RouterLoop:
                         ),
                     },
                 }
+        return None
 
+    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+        """#1593: dispatch a resolved, exclude-cleared tool call via the OS substrate
+        (DispatchContext / phase-memo / ``dispatch_tool`` — P5). The pure-OS dispatch
+        half of the former ``_execute_tool``; the scheme's ``execute`` orchestrates
+        calls to it (it never sees the DispatchContext / phase-memo)."""
         # #1092 PR-C-2.5: phase-mode op-dispatch WAL memoization. A phase host
         # returns the per-phase resume wiring; chat hosts don't implement the hook
         # (getattr → None), so the chat dispatch path below is byte-identical

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1643,6 +1643,49 @@ def _build_time_travel_config(raw: object) -> TimeTravelConfig:
 
 
 @dataclass
+class ToolUseConfig:
+    """``tool_use:`` — the tool-use scheme per layer (#1593).
+
+    Each layer (chat / step / phase) selects a registered ``ToolUseScheme`` by name,
+    generalizing the binary ``action_retrieval.universal_wrappers_enabled`` toggle
+    into a pluggable, per-layer scheme selector. Defaults = ``universal-category``
+    for all three (today's behaviour). Future schemes (``enumerate-all``,
+    ``codeact``) are selected by setting a layer to their name.
+    """
+
+    chat: str = "universal-category"
+    step: str = "universal-category"
+    phase: str = "universal-category"
+
+
+def _build_tool_use_config(raw: object) -> ToolUseConfig:
+    """Parse ``tool_use:`` from reyn.yaml. None / missing / empty → all-universal.
+
+    Each layer key accepts a scheme name (string); a missing key keeps the default.
+    A non-mapping block or non-string value is a config error (fail loud)."""
+    if raw is None:
+        return ToolUseConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(f"tool_use must be a mapping, got {type(raw).__name__}")
+
+    def _name(key: str, default: str) -> str:
+        if key not in raw:
+            return default
+        val = raw[key]
+        if not isinstance(val, str) or not val:
+            raise ValueError(
+                f"tool_use.{key} must be a non-empty scheme name, got {val!r}"
+            )
+        return val
+
+    return ToolUseConfig(
+        chat=_name("chat", "universal-category"),
+        step=_name("step", "universal-category"),
+        phase=_name("phase", "universal-category"),
+    )
+
+
+@dataclass
 class ReynConfig:
     model: str = field(
         default="standard",
@@ -1759,6 +1802,9 @@ class ReynConfig:
     # selects runtime-only rewind (skip the per-boundary shadow-git capture, the
     # largest constant cost). Default-on (full-fidelity rewind). Extensible block.
     time_travel: TimeTravelConfig = field(default_factory=TimeTravelConfig)
+    # #1593 — per-layer tool-use scheme selector (chat/step/phase). Default all
+    # universal-category (today's behaviour); generalizes universal_wrappers_enabled.
+    tool_use: ToolUseConfig = field(default_factory=ToolUseConfig)
     # Plan resume policy (ADR-0023 Phase 2) — how the resume coordinator
     # treats interrupted plan-mode runs on restart. Loaded as a raw dict
     # and parsed lazily by the coordinator (= keeps PlanResumeConfig in
@@ -2252,6 +2298,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         cost=cost,
         skill_resume=_build_skill_resume_config(merged.get("skill_resume")),
         time_travel=_build_time_travel_config(merged.get("time_travel")),
+        tool_use=_build_tool_use_config(merged.get("tool_use")),
         plan_resume_raw=(
             merged.get("plan_resume")
             if isinstance(merged.get("plan_resume"), dict) else None

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -1,0 +1,167 @@
+"""Tool-use scheme abstraction (#1593) — pluggable tool presentation + dispatch.
+
+The OS owns the **tool-use loop** (build presentation → call LLM → interpret →
+execute → feed back → repeat). A **scheme** owns *how* tools are shown to the LLM
+and *how* an LLM response becomes executed actions. Adding a competitor scheme
+(enumerate-all, CodeAct, retrieval) = implement this protocol + register by name;
+the OS never changes (P7 — the OS holds no scheme-specific concepts: no
+``qualified_name``, no ``catalog``, no "code block").
+
+A scheme provides four things, per the locked #1593 design:
+
+1. ``build_presentation`` → the ``tools=`` payload + the SP-shaping inputs.
+2. ``interpret``          → normalize the LLM output into a tagged ``Interpretation``
+                            (``Execute`` / ``RePresent`` / ``CodeBlock``).
+3. ``execute``            → run the interpretation (permission-gated).
+4. ``format_feedback``    → turn results into the next round's LLM message(s).
+
+PR-1 ships the full interface (all three ``Interpretation`` tags) but only the
+``UniversalCategoryScheme`` (the current behaviour, moved behind the protocol),
+which emits only ``Execute`` — so behaviour is byte-identical. enumerate-all (PR-2)
+and CodeAct (PR-3) add ``RePresent`` / ``CodeBlock`` paths.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class ToolUseLayer(str, Enum):
+    """The layer a router loop runs for — each independently scheme-selectable
+    (``tool_use: {chat, step, phase}``). The phase layer's op-catalog presentation
+    is the phase scheme; chat/step default to universal-category."""
+
+    CHAT = "chat"
+    STEP = "step"
+    PHASE = "phase"
+
+
+@dataclass
+class Presentation:
+    """What a scheme shows the LLM: the ``tools=`` payload + SP-shaping inputs.
+
+    PR-1: ``sp_params`` carries the parameters that drive the (still monolithic)
+    ``build_system_prompt`` — byte-identical. PR-2 (enumerate-all) introduces a
+    scheme-owned SP *fragment* once a scheme needs a divergent prompt.
+    """
+
+    llm_tools_payload: list[dict]
+    sp_params: dict[str, Any] = field(default_factory=dict)
+
+
+# ── Interpretation: the tagged union the OS loop dispatches on ──────────────
+
+
+@dataclass
+class Execute:
+    """The LLM asked to run tool calls. ``actions`` carry **resolved effective
+    names** (the scheme's ``interpret`` does salvage / unwrap), so the OS can
+    apply its exclude policy *before* dispatch (pre-execute gate)."""
+
+    actions: list[dict]
+
+
+@dataclass
+class RePresent:
+    """The LLM's output is a refinement request (e.g. a retrieval search) — the OS
+    re-calls ``build_presentation`` with the refinement and re-queries the LLM. Not
+    emitted by universal-category (PR-1); used by a retrieval scheme (future)."""
+
+    refinement: Any
+
+
+@dataclass
+class CodeBlock:
+    """The LLM wrote a code snippet (CodeAct) — ``execute`` runs it in a sandbox
+    exposing only permission-approved functions. Not emitted in PR-1; CodeAct is
+    PR-3."""
+
+    code: str
+
+
+Interpretation = Execute | RePresent | CodeBlock
+
+
+@dataclass
+class ExecutionResult:
+    """The outcome of executing an ``Interpretation`` — per-action tool results
+    (JSON-serialisable dicts), consumed by ``format_feedback`` and by the OS loop's
+    scheme-agnostic op-specific handling (plan / invoke_skill)."""
+
+    tool_results: list[dict]
+
+
+@dataclass
+class ExecContext:
+    """What ``execute`` needs from the OS to dispatch — the permission resolver +
+    op handlers (so P5 governs every effect, unchanged), the OS-held tool-catalog
+    projection (read by universal dispatch / salvage), and the sandbox (CodeAct).
+    The OS assembles this from the running host; schemes never reach past it."""
+
+    permission_resolver: Any = None
+    op_handlers: Any = None
+    tool_catalog: dict = field(default_factory=dict)
+    sandbox: Any = None
+    extra: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class ToolUseScheme(Protocol):
+    """The pluggable tool-use scheme contract. The OS calls only these four; it
+    holds no scheme-specific strings (P7). Schemes are selected per-layer by name
+    from the registry."""
+
+    name: str
+
+    def build_presentation(self, available: Any, layer_ctx: Any) -> Presentation:
+        """Build the ``tools=`` payload + SP-shaping inputs for the layer."""
+        ...
+
+    def interpret(self, llm_response: Any, *, tool_catalog: dict) -> Interpretation:
+        """Normalize the LLM output into a tagged ``Interpretation`` (resolution +
+        any de-dup happen here; for JSON schemes → ``Execute`` with resolved
+        effective names)."""
+        ...
+
+    async def execute(self, interp: Interpretation, exec_ctx: ExecContext) -> ExecutionResult:
+        """Run the interpretation (permission-gated via ``exec_ctx``)."""
+        ...
+
+    def format_feedback(self, result: ExecutionResult) -> list[dict]:
+        """Turn results into the next round's LLM message(s)."""
+        ...
+
+
+# ── registry (name → scheme) ────────────────────────────────────────────────
+
+_SCHEMES: dict[str, ToolUseScheme] = {}
+
+
+def register_scheme(scheme: ToolUseScheme) -> None:
+    """Register a scheme by its ``name``. Idempotent (last wins)."""
+    _SCHEMES[scheme.name] = scheme
+
+
+def get_scheme(name: str) -> "ToolUseScheme | None":
+    """Look up a registered scheme by name (None if absent)."""
+    return _SCHEMES.get(name)
+
+
+def registered_scheme_names() -> list[str]:
+    """Sorted names of registered schemes (introspection / tests)."""
+    return sorted(_SCHEMES)
+
+
+# The default scheme name — universal-category, preserving today's behaviour when
+# no per-layer config overrides it. The OS holds the *name* string (a config key),
+# not scheme logic, so this stays P7-clean.
+DEFAULT_SCHEME_NAME = "universal-category"
+
+
+__all__ = [
+    "ToolUseLayer", "Presentation", "Execute", "RePresent", "CodeBlock",
+    "Interpretation", "ExecutionResult", "ExecContext", "ToolUseScheme",
+    "register_scheme", "get_scheme", "registered_scheme_names",
+    "DEFAULT_SCHEME_NAME",
+]

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -107,28 +107,55 @@ class ExecContext:
 
 
 @runtime_checkable
+class SchemeOps(Protocol):
+    """Router-provided tool-use operations a **delegating** scheme calls.
+
+    PR-1's ``UniversalCategoryScheme`` delegates to these (the router binds its
+    existing universal-category logic) so the seam lands **byte-identical** — zero
+    logic is physically moved. PR-2 (enumerate-all) / PR-3 (CodeAct) implement their
+    own scheme logic instead of delegating, which is what proves the abstraction.
+    Each op is the OS-substrate side of one scheme method:
+
+    - ``present``  → today's ``build_tools`` + SP params (or the phase op-catalog).
+    - ``resolve``  → dedupe + salvage/unwrap → actions carrying **effective names**
+      (so the OS can exclude-gate pre-dispatch).
+    - ``dispatch`` → per-action ``dispatch_tool`` (DispatchContext / phase-memo /
+      permission — the pure-OS substrate, P5).
+    - ``feedback`` → the basic tool_result→message formatting (op-specific plan /
+      invoke_skill handling stays in the OS loop, around this).
+    """
+
+    def present(self, available: Any, layer_ctx: Any) -> Presentation: ...
+    def resolve(self, llm_response: Any, tool_catalog: dict) -> list[dict]: ...
+    async def dispatch(self, actions: list[dict]) -> list[dict]: ...
+    def feedback(self, tool_results: list[dict]) -> list[dict]: ...
+
+
+@runtime_checkable
 class ToolUseScheme(Protocol):
     """The pluggable tool-use scheme contract. The OS calls only these four; it
     holds no scheme-specific strings (P7). Schemes are selected per-layer by name
-    from the registry."""
+    from the registry. ``ops`` is the OS-substrate binding — a delegating scheme
+    (PR-1 universal) uses it; a self-contained scheme (enumerate-all/CodeAct) ignores
+    it."""
 
     name: str
 
-    def build_presentation(self, available: Any, layer_ctx: Any) -> Presentation:
+    def build_presentation(self, available: Any, layer_ctx: Any, ops: "SchemeOps") -> Presentation:
         """Build the ``tools=`` payload + SP-shaping inputs for the layer."""
         ...
 
-    def interpret(self, llm_response: Any, *, tool_catalog: dict) -> Interpretation:
+    def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: "SchemeOps") -> Interpretation:
         """Normalize the LLM output into a tagged ``Interpretation`` (resolution +
-        any de-dup happen here; for JSON schemes → ``Execute`` with resolved
-        effective names)."""
+        de-dup happen here; for JSON schemes → ``Execute`` with resolved effective
+        names)."""
         ...
 
-    async def execute(self, interp: Interpretation, exec_ctx: ExecContext) -> ExecutionResult:
-        """Run the interpretation (permission-gated via ``exec_ctx``)."""
+    async def execute(self, interp: Interpretation, exec_ctx: ExecContext, ops: "SchemeOps") -> ExecutionResult:
+        """Run the interpretation (permission-gated via ``exec_ctx`` / ``ops``)."""
         ...
 
-    def format_feedback(self, result: ExecutionResult) -> list[dict]:
+    def format_feedback(self, result: ExecutionResult, ops: "SchemeOps") -> list[dict]:
         """Turn results into the next round's LLM message(s)."""
         ...
 
@@ -161,7 +188,7 @@ DEFAULT_SCHEME_NAME = "universal-category"
 
 __all__ = [
     "ToolUseLayer", "Presentation", "Execute", "RePresent", "CodeBlock",
-    "Interpretation", "ExecutionResult", "ExecContext", "ToolUseScheme",
+    "Interpretation", "ExecutionResult", "ExecContext", "ToolUseScheme", "SchemeOps",
     "register_scheme", "get_scheme", "registered_scheme_names",
     "DEFAULT_SCHEME_NAME",
 ]

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -1,0 +1,64 @@
+"""UniversalCategoryScheme — the current tool-use behaviour behind the protocol (#1593 PR-1).
+
+The FP-0034 universal-category scheme (catalog wrappers → discover → call by
+qualified name) is reyn's shipped tool-use. PR-1 moves it *behind* the
+``ToolUseScheme`` protocol **without changing behaviour**: this scheme **delegates**
+each method to the router-provided ``SchemeOps`` (which binds the existing
+``build_tools`` / resolution / ``dispatch_tool`` / feedback logic). Delegation keeps
+PR-1 byte-identical — zero logic is physically relocated — while establishing the
+seam (``router_loop.run`` calls the four methods). PR-2 (enumerate-all) and PR-3
+(CodeAct) implement their own scheme logic instead of delegating, which is what
+exercises the abstraction.
+
+The resolution (dedupe + salvage/unwrap → effective names) lands in ``interpret``
+so the OS can exclude-gate **pre-dispatch** (preserving the #1406/#187 order);
+``execute`` orchestrates the OS dispatch substrate; ``format_feedback`` produces the
+basic tool_result messages (the op-specific plan / invoke_skill handling stays in
+the OS loop, around it). Universal emits only ``Execute`` — never ``RePresent`` /
+``CodeBlock`` — so the loop's other tag paths are unreached in PR-1.
+"""
+from __future__ import annotations
+
+from reyn.tools.scheme import (
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    Interpretation,
+    Presentation,
+    SchemeOps,
+)
+
+
+class UniversalCategoryScheme:
+    """The shipped universal-category tool-use, behind the ``ToolUseScheme`` protocol.
+
+    PR-1: a thin delegator over ``SchemeOps`` (byte-identical seam). The logic itself
+    is the router's existing universal-category code, reached via ``ops`` — so every
+    call produces identical bytes to the pre-refactor inline path.
+    """
+
+    name = "universal-category"
+
+    def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
+        # ops.present → today's build_tools (or the phase op-catalog) + SP params.
+        return ops.present(available, layer_ctx)
+
+    def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
+        # ops.resolve = dedupe + salvage/unwrap → actions with effective names; the
+        # OS exclude-gates these pre-execute. Universal always yields Execute.
+        actions = ops.resolve(llm_response, tool_catalog)
+        return Execute(actions=actions)
+
+    async def execute(self, interp: Interpretation, exec_ctx: ExecContext, ops: SchemeOps) -> ExecutionResult:
+        # Only Execute is emitted by this scheme; the OS loop never routes a
+        # RePresent / CodeBlock here in PR-1. Dispatch via the OS substrate (ops),
+        # which carries the DispatchContext / phase-memo / permission (P5) path.
+        assert isinstance(interp, Execute), "universal-category emits only Execute"
+        results = await ops.dispatch(interp.actions)
+        return ExecutionResult(tool_results=results)
+
+    def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
+        return ops.feedback(result.tool_results)
+
+
+__all__ = ["UniversalCategoryScheme"]

--- a/tests/test_tool_use_scheme_1593.py
+++ b/tests/test_tool_use_scheme_1593.py
@@ -1,0 +1,120 @@
+"""Tier 2: tool-use scheme abstraction (#1593 PR-1).
+
+PR-1 moves universal-category behind the ``ToolUseScheme`` protocol with **zero
+behaviour change** — the byte-identical proof is the *existing* tool-use / LLMReplay
+suites passing unchanged (incl. the exclude regressions
+``test_chat_exclude_tools_187`` / ``test_exclude_execution_block_1406`` /
+``test_run_once_187``). These tests pin the new abstraction surface itself: the
+registry, the protocol conformance, the per-layer config, the delegation seam, and
+the Execute-only invariant of universal-category. Real types, no mocks (a recording
+Fake ``SchemeOps`` exercises the delegation).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import ToolUseConfig, _build_tool_use_config
+from reyn.tools.scheme import (
+    DEFAULT_SCHEME_NAME,
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    Presentation,
+    ToolUseScheme,
+    get_scheme,
+    register_scheme,
+    registered_scheme_names,
+)
+from reyn.tools.schemes.universal_category import UniversalCategoryScheme
+
+
+class _RecordingOps:
+    """A recording Fake ``SchemeOps`` — lets us exercise the delegating scheme
+    without a full router. Real callables, no mock framework."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def present(self, available, layer_ctx) -> Presentation:
+        self.calls.append("present")
+        return Presentation(llm_tools_payload=[{"t": 1}], sp_params={"x": True})
+
+    def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
+        self.calls.append("resolve")
+        return [{"tc": tc, "name": tc["name"], "args": {}} for tc in llm_response]
+
+    async def dispatch(self, actions: list[dict]) -> list[dict]:
+        self.calls.append("dispatch")
+        return [{"status": "ok", "for": a["name"]} for a in actions]
+
+    def feedback(self, tool_results: list[dict]) -> list[dict]:
+        self.calls.append("feedback")
+        return tool_results
+
+
+# ── registry ────────────────────────────────────────────────────────────────
+
+
+def test_registry_register_get_resolve() -> None:
+    """Tier 2: register a scheme by name, look it up, and the default name resolves."""
+    register_scheme(UniversalCategoryScheme())
+    assert DEFAULT_SCHEME_NAME == "universal-category"
+    s = get_scheme(DEFAULT_SCHEME_NAME)
+    assert s is not None and s.name == "universal-category"
+    assert DEFAULT_SCHEME_NAME in registered_scheme_names()
+    assert get_scheme("no-such-scheme") is None
+
+
+def test_universal_conforms_to_protocol() -> None:
+    """Tier 2: UniversalCategoryScheme satisfies the ToolUseScheme protocol."""
+    assert isinstance(UniversalCategoryScheme(), ToolUseScheme)
+
+
+# ── delegation seam + Execute-only invariant ─────────────────────────────────
+
+
+def test_universal_build_presentation_delegates() -> None:
+    """Tier 2: build_presentation delegates to ops.present (the router's logic)."""
+    ops = _RecordingOps()
+    pres = UniversalCategoryScheme().build_presentation({}, {}, ops)
+    assert "present" in ops.calls
+    assert pres.llm_tools_payload == [{"t": 1}] and pres.sp_params == {"x": True}
+
+
+def test_universal_interpret_emits_execute_only() -> None:
+    """Tier 2: universal-category always yields Execute (never RePresent/CodeBlock),
+    carrying the ops-resolved actions — the OS exclude-gates these pre-dispatch."""
+    ops = _RecordingOps()
+    interp = UniversalCategoryScheme().interpret(
+        [{"name": "a"}, {"name": "b"}], tool_catalog={}, ops=ops,
+    )
+    assert isinstance(interp, Execute)
+    assert [x["name"] for x in interp.actions] == ["a", "b"]
+    assert "resolve" in ops.calls
+
+
+@pytest.mark.asyncio
+async def test_universal_execute_and_feedback_round_trip() -> None:
+    """Tier 2: execute delegates dispatch, format_feedback delegates feedback."""
+    ops = _RecordingOps()
+    scheme = UniversalCategoryScheme()
+    res = await scheme.execute(Execute(actions=[{"name": "a"}]), ExecContext(), ops)
+    assert res.tool_results == [{"status": "ok", "for": "a"}]
+    fb = scheme.format_feedback(ExecutionResult(tool_results=res.tool_results), ops)
+    assert fb == res.tool_results
+    assert ops.calls.count("dispatch") == 1 and ops.calls.count("feedback") == 1
+
+
+# ── per-layer config ─────────────────────────────────────────────────────────
+
+
+def test_tool_use_config_per_layer_and_defaults() -> None:
+    """Tier 2: per-layer scheme selection parses (NON-default) + defaults to
+    universal-category; a non-string value is a loud error."""
+    assert _build_tool_use_config(None) == ToolUseConfig()
+    assert ToolUseConfig().chat == "universal-category"
+    cfg = _build_tool_use_config({"chat": "enumerate-all"})
+    assert cfg.chat == "enumerate-all"
+    assert cfg.step == "universal-category" and cfg.phase == "universal-category"
+    with pytest.raises(ValueError):
+        _build_tool_use_config({"chat": 123})


### PR DESCRIPTION
**[e2e-coder]** — ToolUseScheme plugin abstraction: foundation, ZERO behavior change (#1593 PR-1)

Moves reyn's tool-use behind a pluggable `ToolUseScheme` protocol so competitor schemes (enumerate-all PR-2, CodeAct PR-3) plug in with zero OS change (P7). PR-1 is the **load-bearing seam** — the full interface + registry + per-layer config + universal-category moved behind the protocol, **byte-identical** (universal is the only scheme + default).

Design: flow-traced → joint boundary-nail with sandbox_2 → lead-approved (#1593 thread).

## The seam

The whole `router_loop` tool-use path now routes through the active scheme:

```
scheme.build_presentation → tools= + SP params
  → call_llm_tools → scheme.interpret → OS exclude-gate (pre-dispatch)
  → scheme.execute → scheme.format_feedback → repeat
```

`UniversalCategoryScheme` **delegates** each method to a router-provided `SchemeOps` binding (the existing build_tools / dedupe+salvage / dispatch_tool / feedback logic) — so the seam lands byte-identical (no universal logic physically relocated). PR-2/3 schemes implement their own logic instead of delegating, which exercises the abstraction.

## What

- **`tools/scheme.py`** — `ToolUseScheme` Protocol (4 methods) + `Presentation{llm_tools_payload, sp_params}` + `Interpretation = Execute|RePresent|CodeBlock` (all three ship) + `ExecutionResult` + `ExecContext` + `ToolUseLayer` + `SchemeOps` + a name→scheme registry. P7-clean.
- **`tools/schemes/universal_category.py`** — `UniversalCategoryScheme` (delegating).
- **`config.py`** — `tool_use:{chat,step,phase}` per-layer selector (default all `universal-category`) + parser + mirror docs.
- **`router_loop.py`** — split `_execute_tool` → `_resolve_tool_call` (salvage) / `_excluded_result` (the #1406/#187 **pre-dispatch** exclude gate) / `_dispatch_resolved` (DispatchContext/phase-memo/dispatch_tool, P5); the router implements `SchemeOps`; `run()` routes presentation + each tool-call round through the scheme. `_catalog`/`_tool_names` stay OS-held projections (force-close needs `_tool_names`).

The exclude is **pre-dispatch** (sandbox_2's correctness catch): resolution → `interpret`, the OS exclude-gate → between interpret and execute, dispatch → `execute`. Same resolve→exclude→dispatch order, relocated — the bypass coverage (#1406/#187, 3 paths) is preserved.

## Test plan (byte-identical = the merge gate)

- [x] **Existing tool-use / LLMReplay suites pass unchanged** — verified across the refactor: 1268 replay/chat/router/universal/tool/dispatch/system_prompt/build_tools tests green; plus the explicit exclude regressions **`test_chat_exclude_tools_187`, `test_exclude_execution_block_1406`, `test_run_once_187` pass unchanged** (the resolve→exclude→dispatch order proof).
- [x] `tests/test_tool_use_scheme_1593.py` (Tier 2, no mocks; a recording Fake SchemeOps): registry register/get/resolve, protocol conformance, the delegation seam, the **Execute-only invariant** of universal-category, per-layer config parse incl. NON-default + non-string error.
- [x] Full suite (`pytest -q` rootdir) green; `ruff` clean; `test_tier_audit.py --strict` clean; all modules `py_compile` OK.

PR-1 lands the seam → **PR-2 (enumerate-all, tui-coder)** + **PR-3 (CodeAct, sandbox_2)** cascade on the interface. The SP-fragment *extraction* (deferred from PR-1's parameterize) is PR-2's, on a seam already agreed with tui-coder (PR-1=parameterize / PR-2=extract).

Refs #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)
