### PR TITLE
feat(1593): catalog_entries(ctx) — flat generic action projection (SchemeOps substrate)

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1009,6 +1009,55 @@ def _describe_one(
     return {"description": description, "input_schema": input_schema}
 
 
+def catalog_entries(ctx: ToolContext) -> list[dict[str, Any]]:
+    """Every usable action as a FLAT generic tool-schema dict
+    ``{name, description, parameters}`` — the #1593 ``SchemeOps.catalog_entries``
+    projection a scheme presents however it likes (enumerate-all flat, CodeAct
+    code-API, retrieval subset). Exposes the **actions**, not the 13-category
+    hierarchy (the P7 boundary: the catalog structure stays universal-internal;
+    what crosses is a flat action list any scheme can render).
+
+    Single-source: built from the SAME ``_enumerate_category`` (availability-gated
+    on ``ctx.router_state``) + ``_describe_one`` (description + input_schema) that
+    ``list_actions`` / ``describe_action`` use, so all agree BY CONSTRUCTION
+    (#1455 list ≡ describe), no logic fork.
+
+    Schema-completeness bar (CodeAct is the strictest consumer — it renders each
+    entry as a Python function signature, so a missing schema = an unusable
+    code-API): every returned entry carries a non-None ``parameters`` object —
+    unresolvable actions are dropped, and an action with no declared input schema
+    gets the empty-but-valid ``{"type": "object", "properties": {}}`` (a valid
+    no-arg signature) rather than ``None``.
+
+    Deterministic ``name`` sort (stable ``tools=`` ordering → replay-fixture
+    stability). **Pass a ``ToolContext`` with ``router_state`` populated** or the
+    resource categories (skills / agents / mcp_servers / …) enumerate empty and
+    only static categories survive (the "usable this session" semantics).
+    """
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    entries: list[dict[str, Any]] = []
+    for category in CATEGORIES:
+        for item in _enumerate_category(category, ctx):
+            qualified_name = item["qualified_name"]
+            one = _describe_one(qualified_name, ctx, registry)
+            if one is None:
+                # Unresolvable action (no registry target) — not a usable entry.
+                continue
+            parameters = one.get("input_schema")
+            if not isinstance(parameters, dict):
+                # Completeness bar: a valid no-arg signature, never None.
+                parameters = {"type": "object", "properties": {}}
+            entries.append({
+                "name": qualified_name,
+                "description": one.get("description") or "",
+                "parameters": parameters,
+            })
+    entries.sort(key=lambda entry: entry["name"])
+    return entries
+
+
 async def _handle_describe_action(
     args: Mapping[str, Any], ctx: ToolContext,
 ) -> ToolResult:

--- a/tests/test_catalog_entries_1593.py
+++ b/tests/test_catalog_entries_1593.py
@@ -1,0 +1,110 @@
+"""Tier 1: #1593 catalog_entries — flat generic action-projection contract.
+
+``catalog_entries(ctx)`` is the substrate behind ``SchemeOps.catalog_entries``:
+every usable action as a flat ``{name, description, parameters}`` dict (the actions
+exposed, the 13-category structure hidden = the P7 boundary). It is built from the
+SAME ``_enumerate_category`` + ``_describe_one`` machinery ``list_actions`` /
+``describe_action`` use, so all agree BY CONSTRUCTION (#1455 list ≡ describe).
+
+Pins: flat shape + schema-completeness bar (``parameters`` never None) + name sort
++ availability-gating on ``router_state`` + the single-source invariant vs
+``describe_action``.
+
+Real ToolContext + RouterCallerState with a stub host; no mocks of collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import _handle_describe_action, catalog_entries
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeHost:
+    """Minimal host whose list_available_skills returns the D2-full catalogue
+    shape (input_schema per entry) so resource-category enrichment resolves."""
+
+    def __init__(self, skills):
+        self._skills = skills
+
+    def list_available_skills(self):
+        return list(self._skills)
+
+
+_SKILL = {
+    "name": "code_review",
+    "description": "Review a code diff and report issues.",
+    "input_fields": ["diff", "focus"],
+    "input_schema": {
+        "type": "object",
+        "properties": {"diff": {"type": "string"}, "focus": {"type": "string"}},
+        "required": ["diff"],
+    },
+    "input_wrapped": True,
+}
+
+
+def _ctx(skills=None) -> ToolContext:
+    sk = skills or []
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            host=_FakeHost(sk), available_skills=sk, mcp_servers=None,
+        ),
+    )
+
+
+def test_flat_shape_and_completeness_bar():
+    """Tier 1: every entry is exactly {name, description, parameters}, parameters a dict (never None)."""
+    entries = catalog_entries(_ctx())
+    assert entries, "static categories alone should yield entries"
+    for e in entries:
+        assert set(e) == {"name", "description", "parameters"}, f"flat generic shape: {e}"
+        assert isinstance(e["name"], str) and "__" in e["name"], f"name is qualified: {e['name']}"
+        assert isinstance(e["parameters"], dict), f"completeness bar (never None): {e['name']}"
+        assert isinstance(e["description"], str)
+
+
+def test_sorted_by_name():
+    """Tier 1: deterministic name sort (stable tools= ordering → replay-fixture stability)."""
+    names = [e["name"] for e in catalog_entries(_ctx())]
+    assert names == sorted(names)
+
+
+def test_resource_categories_gated_on_router_state():
+    """Tier 1: a skill in router_state surfaces skill__X with its input_schema as parameters."""
+    entries = catalog_entries(_ctx(skills=[_SKILL]))
+    by_name = {e["name"]: e for e in entries}
+    assert "skill__code_review" in by_name, "resource category enumerated from router_state"
+    params = by_name["skill__code_review"]["parameters"]
+    assert params.get("properties", {}).keys() >= {"diff", "focus"}, "skill input_schema projected"
+
+
+def test_empty_router_state_keeps_static_drops_resources():
+    """Tier 1: without router_state skills, resource cats drop; static cats survive ("usable" semantics)."""
+    entries = catalog_entries(_ctx(skills=[]))
+    names = {e["name"] for e in entries}
+    assert any(n.startswith("file__") for n in names), "static categories survive"
+    assert not any(n.startswith("skill__") for n in names), "no skills → no skill__ entries"
+
+
+def test_single_source_invariant_vs_describe_action():
+    """Tier 1: #1455 — catalog_entries' description/parameters for an action == describe_action's
+    description/input_schema (both via the shared _describe_one), by construction."""
+    ctx = _ctx(skills=[_SKILL])
+    by_name = {e["name"]: e for e in catalog_entries(ctx)}
+    for name in ("file__edit", "skill__code_review"):
+        entry = by_name[name]
+        described = asyncio.run(_handle_describe_action({"action_name": name}, ctx))
+        # Both actions carry a real dict schema, so the completeness bar is a no-op
+        # here and equality holds directly.
+        assert entry["description"] == described["description"], f"{name}: description single-source"
+        assert entry["parameters"] == described["input_schema"], f"{name}: schema single-source"


### PR DESCRIPTION
**[dogfood-coder]** — the substrate behind `SchemeOps.catalog_entries` (#1593), unblocking PR-2 (enumerate-all) and PR-3 (CodeAct), built to e2e's finalized contract + the CodeAct completeness floor.

## What
`universal_catalog.catalog_entries(ctx)` → `list[{name, description, parameters}]`: every **usable action** as a flat generic tool-schema dict. Actions are exposed; the 13-category structure stays universal-internal (the **P7 boundary** — a scheme presents the actions however it likes: enumerate-all flat, CodeAct code-API, retrieval subset).

## Single-source (#1455 list ≡ describe, no fork)
Built from the SAME machinery `list_actions` / `describe_action` use:
- `_enumerate_category(cat, ctx)` per `CATEGORIES` — availability-gated on `ctx.router_state` (resource cats: skills/agents/mcp; static cats via `_OPERATION_RULES`).
- `_describe_one(qn, ctx, registry)` — description + input_schema (the SAME `describe_action` returns).

## Schema-completeness floor (strictest-consumer = the union bar, built once)
CodeAct renders each entry as a Python function signature, so a missing schema = an unusable code-API. Every entry carries a **non-None `parameters`**: unresolvable actions are dropped; a no-arg action gets the empty-but-valid `{type:object, properties:{}}`. Built to the CodeAct/PR-3 + enumerate-all/PR-2 union bar in one pass → no later churn (feedback_completeness_for_gate_routing_fixes).

Name-sorted for deterministic `tools=` ordering (replay-fixture stability).

## Test plan
- [x] 5 Tier-1 contract tests (`tests/test_catalog_entries_1593.py`): flat shape + completeness bar (parameters never None) + name sort + router_state gating (resource cats drop without it; static survive) + single-source invariant vs `describe_action`.
- [x] #1455 list/describe regression intact (`test_list_actions_returns_schema_187.py` green).
- [x] `python -m pytest tests/test_catalog_entries_1593.py tests/test_list_actions_returns_schema_187.py -W error::RuntimeWarning` → 10 passed.

## Consumers (separate PRs)
- PR-2 (tui): `ops.catalog_entries()` adapter → this, building a router-state `ToolContext` (correctness caveat-1) + mapping each → `{type:function, function:{name, description, parameters}}`.
- PR-3 (me, CodeAct): renders these as a code-API.

## Tier-rule self-check
- [x] Each test docstring's first line declares its Tier (`Tier 1: ...`).
- [x] No Tier-4 tests; no mocks (real `ToolContext` + `RouterCallerState` + stub host).
- [x] No invariant weakening (additive function; #1455 invariant strengthened with an explicit catalog_entries≡describe test).
- [x] No algorithm-level pins (asserts on contract shape + set membership, not ordering internals beyond the documented name-sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)