### PR TITLE
feat(1593 PR-2): enumerate-all tool-use scheme (flat-native-JSON baseline)

### DIFF
--- a/src/reyn/chainlit_app/app.py
+++ b/src/reyn/chainlit_app/app.py
@@ -192,6 +192,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 multimodal_config=session_cfg.config.multimodal,
                 tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
                 action_retrieval_config=session_cfg.config.action_retrieval,
+                chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
                 embedding_config=session_cfg.config.embedding,
                 agent_id=session_cfg.config.agent.id,
                 # #1402: scoped surface passed EXPLICITLY (required by

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -45,9 +45,15 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
     from reyn.tools.schemes.universal_category import UniversalCategoryScheme
 
-    if get_scheme(DEFAULT_SCHEME_NAME) is None:
-        register_scheme(UniversalCategoryScheme())
-        register_scheme(EnumerateAllScheme())  # #1593 PR-2 (lazy, idempotent)
+    # Register each built-in independently + idempotently (keyed on the scheme's
+    # OWN .name → P7-clean, no scheme-literal in OS code). A single guard on the
+    # default's absence would couple enumerate-all's registration to universal
+    # NOT being registered yet — so anything that registers universal first (a
+    # direct register_scheme caller, a test) would leave enumerate-all absent and
+    # silently fall back to default. Per-scheme guard avoids that sibling gap.
+    for _builtin in (UniversalCategoryScheme(), EnumerateAllScheme()):  # #1593 PR-2
+        if get_scheme(_builtin.name) is None:
+            register_scheme(_builtin)
     # Unknown / unconfigured name → default (universal-category) — byte-identical.
     return get_scheme(name or DEFAULT_SCHEME_NAME) or get_scheme(DEFAULT_SCHEME_NAME)
 
@@ -1654,7 +1660,7 @@ class RouterLoop:
         # use build_tools with the catalog wrappers). PR-2/3 schemes shape tools=
         # differently. The OS still projects _catalog from the payload + builds the
         # (monolithic) SP from sp_params below.
-        _pres = self._scheme.build_presentation(
+        _pres = await self._scheme.build_presentation(
             {"skills_for_tools": skills_for_tools, "hot_list_aliases": _hot_list_aliases},
             {
                 "phase_op_catalog": _phase_op_catalog,
@@ -3052,18 +3058,41 @@ class RouterLoop:
             compact_visible=layer_ctx["ctx_signal_present"],
         )
 
-    def catalog_entries(self) -> list[dict]:
+    async def catalog_entries(self) -> list[dict]:
         """SchemeOps.catalog_entries (#1593 PR-2): every usable catalog action as
         a flat callable tool schema (qualified ``<category>__<entry>`` name).
 
-        PENDING sandbox_2's ``universal_catalog.catalog_entries(ctx)`` substrate
-        (the non-paginated all-entries→schemas projection extracted from
-        ``_handle_list_actions``, #1455 list≡describe invariant). Once it lands,
-        this builds a router-state ``ToolContext`` (resource categories —
-        skills/agents/mcp — silently drop without router_state) and maps each
-        entry → ``{type: function, function: {name, description, parameters}}``.
-        Returns [] until then (enumerate-all degrades to base_tools-only)."""
-        return []
+        Consumes sandbox_2's ``universal_catalog.catalog_entries(ctx)`` substrate
+        (#1598: the all-entries→schemas projection, single-source with
+        list/describe via ``_enumerate_category`` + ``_describe_one``, #1455
+        invariant; name-sorted; ``parameters`` never None). Async because the
+        complete caller-state is built async (caveat-1: a ``ToolContext`` WITHOUT
+        ``router_state`` drops the resource categories — skills/agents/mcp — and
+        the rag manifest fetch is the genuine await). Maps each generic entry →
+        the OpenAI ``{type: function, function: {name, description, parameters}}``
+        shape so the flat tools= is uniform with ``base_tools``."""
+        from reyn.tools import universal_catalog
+        from reyn.tools.types import ToolContext
+
+        rs = await self._build_router_caller_state()  # caveat-1: populated router_state
+        tool_ctx = ToolContext(
+            events=self.host.events,
+            permission_resolver=getattr(self.host, "permission_resolver", None),
+            workspace=getattr(self.host, "workspace", None),
+            caller_kind="router",
+            router_state=rs,
+        )
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": entry["name"],
+                    "description": entry["description"],
+                    "parameters": entry["parameters"],
+                },
+            }
+            for entry in universal_catalog.catalog_entries(tool_ctx)
+        ]
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
         """SchemeOps.resolve: dedupe + #229 salvage → actions carrying the original

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -42,10 +42,13 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     defaulting to universal-category — PR-1 byte-identical. Per-layer config
     (``tool_use:{chat,step,phase}``) passes the selected name here."""
     from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme, register_scheme
+    from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
     from reyn.tools.schemes.universal_category import UniversalCategoryScheme
 
     if get_scheme(DEFAULT_SCHEME_NAME) is None:
         register_scheme(UniversalCategoryScheme())
+        register_scheme(EnumerateAllScheme())  # #1593 PR-2 (lazy, idempotent)
+    # Unknown / unconfigured name → default (universal-category) — byte-identical.
     return get_scheme(name or DEFAULT_SCHEME_NAME) or get_scheme(DEFAULT_SCHEME_NAME)
 
 
@@ -1318,6 +1321,7 @@ class RouterLoop:
         plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
         on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
+        scheme_name: "str | None" = None,  # #1593 PR-2: per-layer tool-use scheme (None → universal default; the construction site resolves config.tool_use.<layer>)
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1416,7 +1420,7 @@ class RouterLoop:
         # behaviour, behind the protocol) for every layer → byte-identical. Per-layer
         # config selection (tool_use:{chat,step,phase}) plugs in here; with all
         # layers defaulting to universal-category it is byte-identical today.
-        self._scheme = _resolve_tool_use_scheme()
+        self._scheme = _resolve_tool_use_scheme(scheme_name)
 
     @property
     def total_usage(self) -> TokenUsage:

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -3028,6 +3028,39 @@ class RouterLoop:
             },
         )
 
+    def base_tools(self, available, layer_ctx) -> list[dict]:
+        """SchemeOps.base_tools (#1593 PR-2): the prior-shape base tools —
+        ``build_tools`` with the universal wrappers OFF. The common base a
+        self-contained scheme starts from (enumerate-all adds ``catalog_entries``
+        on top instead of the wrappers). The phase layer's op-catalog is its base."""
+        phase_op_catalog = layer_ctx.get("phase_op_catalog")
+        if phase_op_catalog is not None:
+            return list(phase_op_catalog)
+        return build_tools(
+            available["skills_for_tools"],
+            self.host.list_available_agents(),
+            file_permissions=self.host.get_file_permissions(),
+            mcp_servers=self.host.get_mcp_servers(),
+            web_fetch_allowed=self.host.get_web_fetch_allowed(),
+            universal_wrappers_enabled=False,
+            search_actions_visible=False,
+            hot_list_aliases=available["hot_list_aliases"],
+            compact_visible=layer_ctx["ctx_signal_present"],
+        )
+
+    def catalog_entries(self) -> list[dict]:
+        """SchemeOps.catalog_entries (#1593 PR-2): every usable catalog action as
+        a flat callable tool schema (qualified ``<category>__<entry>`` name).
+
+        PENDING sandbox_2's ``universal_catalog.catalog_entries(ctx)`` substrate
+        (the non-paginated all-entries→schemas projection extracted from
+        ``_handle_list_actions``, #1455 list≡describe invariant). Once it lands,
+        this builds a router-state ``ToolContext`` (resource categories —
+        skills/agents/mcp — silently drop without router_state) and maps each
+        entry → ``{type: function, function: {name, description, parameters}}``.
+        Returns [] until then (enumerate-all degrades to base_tools-only)."""
+        return []
+
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
         """SchemeOps.resolve: dedupe + #229 salvage → actions carrying the original
         ``tc`` + the resolved effective ``name``/``args``. The OS exclude-gates these

--- a/src/reyn/chat/scoped_session_factory.py
+++ b/src/reyn/chat/scoped_session_factory.py
@@ -64,6 +64,7 @@ def build_scoped_chat_session(
     action_retrieval_config: Any,  # ActionRetrievalConfig | None
     embedding_config: Any,  # EmbeddingConfig | None
     tool_calls_op_loop_skills: list[str] | None,  # #1212 op-loop gate
+    chat_tool_use_scheme: str,  # #1593 PR-2 config.tool_use.chat — chat-layer ToolUseScheme name (UNIFORM: every frontend resolves the same reyn.yaml value)
     # ── common base (pass-through; session identity/infra, not a drift surface) ──
     **base: Any,
 ) -> ChatSession:
@@ -86,5 +87,6 @@ def build_scoped_chat_session(
         action_retrieval_config=action_retrieval_config,
         embedding_config=embedding_config,
         tool_calls_op_loop_skills=tool_calls_op_loop_skills,
+        chat_tool_use_scheme=chat_tool_use_scheme,
         **base,
     )

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -55,6 +55,7 @@ class RouterLoopDriver:
         limit_checkpoint_fn: Callable,  # async; ChatSession._handle_chat_limit_checkpoint
         next_seq_fn: Callable[[], int], # ChatSession._next_seq reader
         append_history_fn: Callable,    # ChatSession._append_history
+        chat_scheme_name: "str | None" = None,  # #1593 PR-2: chat-layer ToolUseScheme name → RouterLoop(scheme_name=); None → universal default
     ) -> None:
         self._router_host = router_host
         self._safety = safety
@@ -74,6 +75,7 @@ class RouterLoopDriver:
         self._limit_checkpoint_fn = limit_checkpoint_fn
         self._next_seq_fn = next_seq_fn
         self._append_history_fn = append_history_fn
+        self._chat_scheme_name = chat_scheme_name  # #1593 PR-2
         # #1468: per-turn cooperative cancellation flag + asyncio.Event for
         # deep-cancel propagation into running subprocess ops (#1470).
         self._turn_cancel_requested: bool = False
@@ -336,6 +338,8 @@ class RouterLoopDriver:
         )
         loop = RouterLoop(
             host=self._router_host, chain_id=chain_id,
+            # #1593 PR-2: select the chat-layer tool-use scheme (None → universal).
+            scheme_name=self._chat_scheme_name,
             max_iterations=self._router_max_iterations,
             budget=self._budget_tracker,
             # #1440 followup: thread the run-once autonomy flag to the LIVE

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1179,6 +1179,11 @@ class ChatSession:
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
+        # #1593 PR-2: the chat-layer tool-use scheme name (config.tool_use.chat).
+        # Threaded → RouterLoopDriver → RouterLoop(scheme_name=) so the chat
+        # router resolves the selected ToolUseScheme. Default "universal-category"
+        # keeps today's behaviour (the factory passes the resolved config value).
+        chat_tool_use_scheme: str = "universal-category",
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
@@ -1297,6 +1302,8 @@ class ChatSession:
         # constructs an off-flag ActionRetrievalConfig so existing chat
         # behaviour is preserved when callers don't pass one.
         self._action_retrieval = action_retrieval_config or ActionRetrievalConfig()
+        # #1593 PR-2: chat-layer scheme name → passed to RouterLoopDriver below.
+        self._chat_tool_use_scheme = chat_tool_use_scheme
         # B25-S5-1 fix: when True, RouterLoop awaits the embedding index build
         # synchronously on the first turn (= Turn 1 blocks for ~2-5s) so the
         # search_actions wrapper is visible to the LLM from the very first
@@ -2005,6 +2012,7 @@ class ChatSession:
             limit_checkpoint_fn=self._handle_chat_limit_checkpoint,
             next_seq_fn=lambda: self._next_seq,
             append_history_fn=self._append_history,
+            chat_scheme_name=self._chat_tool_use_scheme,  # #1593 PR-2
         )
 
         # session.py refactor PR-4 (FP-0019 series final): SkillPlanGlue owns

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -400,6 +400,7 @@ def run(args: argparse.Namespace) -> None:
             multimodal_config=session_cfg.config.multimodal,
             tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
+            chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -464,6 +464,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,
+                chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
                 # #1289: same backend instance to both seams (single-shared-sandbox).
                 environment_backend=env_backend,
                 sandbox_backend=env_backend,

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -421,6 +421,7 @@ def run_serve(args: argparse.Namespace) -> None:
             multimodal_config=session_cfg.config.multimodal,
             tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,
+            chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
             # #1402: scoped capability surface, passed EXPLICITLY (required by
             # build_scoped_chat_session). The stdio-MCP factory's current

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -130,6 +130,22 @@ class SchemeOps(Protocol):
     async def dispatch(self, actions: list[dict]) -> list[dict]: ...
     def feedback(self, tool_results: list[dict]) -> list[dict]: ...
 
+    # Building blocks for SELF-CONTAINED schemes (#1593 PR-2) — a non-delegating
+    # scheme composes its own presentation from these instead of calling the
+    # whole-universal ``present``. The router (host-context holder) provides them
+    # so schemes stay P7-clean. Additive → universal's delegation is unchanged
+    # (no PR-1 regression).
+    def base_tools(self, available: Any, layer_ctx: Any) -> list[dict]:
+        """The prior-shape base tools (``build_tools`` with wrappers OFF): the
+        common base every scheme starts from (skills/agents/mcp/file/web)."""
+        ...
+
+    def catalog_entries(self) -> list[dict]:
+        """Every usable catalog action across all categories projected to a flat,
+        directly-callable tool schema (qualified ``<category>__<entry>`` name) —
+        what enumerate-all adds on top of ``base_tools`` instead of the wrappers."""
+        ...
+
 
 @runtime_checkable
 class ToolUseScheme(Protocol):

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -140,10 +140,14 @@ class SchemeOps(Protocol):
         common base every scheme starts from (skills/agents/mcp/file/web)."""
         ...
 
-    def catalog_entries(self) -> list[dict]:
+    async def catalog_entries(self) -> list[dict]:
         """Every usable catalog action across all categories projected to a flat,
         directly-callable tool schema (qualified ``<category>__<entry>`` name) —
-        what enumerate-all adds on top of ``base_tools`` instead of the wrappers."""
+        what enumerate-all adds on top of ``base_tools`` instead of the wrappers.
+
+        Async (#1593 PR-2 seam call): enumerating the live catalog requires the
+        async-built router caller-state (resource categories — skills/agents/mcp/
+        rag — drop without it; the rag manifest fetch is the genuine await)."""
         ...
 
 
@@ -157,8 +161,13 @@ class ToolUseScheme(Protocol):
 
     name: str
 
-    def build_presentation(self, available: Any, layer_ctx: Any, ops: "SchemeOps") -> Presentation:
-        """Build the ``tools=`` payload + SP-shaping inputs for the layer."""
+    async def build_presentation(self, available: Any, layer_ctx: Any, ops: "SchemeOps") -> Presentation:
+        """Build the ``tools=`` payload + SP-shaping inputs for the layer.
+
+        Async (#1593 PR-2 seam call): presentation is I/O for every non-trivial
+        scheme — enumerate-all awaits the live catalog, and PR-4 retrieval runs a
+        per-round embedding query — so the contract is async even though PR-1
+        universal's body stays a sync delegation (it just isn't awaited)."""
         ...
 
     def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: "SchemeOps") -> Interpretation:

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -44,12 +44,14 @@ class EnumerateAllScheme:
 
     name = "enumerate-all"
 
-    def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
+    async def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
         # Self-contained presentation (e2e-agreed seam, #1593): compose the flat
         # tools= from the router's building-block ops — the prior-shape base tools
         # + every catalog action flat (no universal wrappers / no discovery). The
         # router holds host context + catalog, so the scheme stays P7-clean.
-        flat_tools = list(ops.base_tools(available, layer_ctx)) + list(ops.catalog_entries())
+        # catalog_entries is async (the live-catalog enumeration awaits the
+        # router caller-state / rag manifest); base_tools stays sync.
+        flat_tools = list(ops.base_tools(available, layer_ctx)) + list(await ops.catalog_entries())
         # Prior-shape (no wrapper-chain) SP — the existing gate yields the minimal
         # tool-use instructions enumerate-all wants; no build_system_prompt change
         # (the fragment-extraction the earlier plan floated is unnecessary).

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -1,0 +1,88 @@
+"""EnumerateAllScheme — flat-native-JSON tool-use scheme (#1593 PR-2).
+
+The simple, deterministic **baseline** scheme: present *every* usable tool flatly
+in ``tools=`` (no universal category-wrapper discovery indirection) + a minimal
+SP, and dispatch by name. Per the #1593 competitor research this is a fine
+small-toolset baseline (max determinism, maps onto reyn's constrained
+``candidate_outputs``) — it is **not** the weak-model fix (flat JSON is weakest
+for weak models; CodeAct/PR-3 is the evidence-winner). Selected per-layer via
+``tool_use: {chat/step/phase}``.
+
+Unlike ``UniversalCategoryScheme`` (which delegates *all four* methods to the
+router ``SchemeOps``, byte-identical), enumerate-all is the first **self-contained**
+scheme: its presentation differs (flat catalog enumeration vs the 4 wrappers), so
+``build_presentation`` is genuinely its own. The other three reuse the shared
+substrate:
+
+- ``interpret``       → ``ops.resolve`` (the names are qualified ``<category>__<entry>``
+  so the existing resolution/dedupe → effective names works unchanged) → ``Execute``.
+- ``execute``         → ``ops.dispatch`` (the pure-OS ``dispatch_tool`` / permission
+  substrate, P5 — identical to universal).
+- ``format_feedback`` → ``ops.feedback`` (the basic tool_result formatting, a JSON-
+  scheme shared base — confirmed reuse, lead #1593).
+
+SP: returns ``sp_params{"universal_wrappers_enabled": False}`` → the router's
+``build_system_prompt`` emits the prior-shape (no wrapper-chain) tool-use SP. No
+``build_system_prompt`` surgery (the fragment-extraction the earlier plan floated
+is unnecessary — the existing gate yields the minimal SP), so PR-2 stays under
+``schemes/`` + config and does not collide with PR-3's parallel SP work.
+"""
+from __future__ import annotations
+
+from reyn.tools.scheme import (
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    Interpretation,
+    Presentation,
+    SchemeOps,
+)
+
+
+class EnumerateAllScheme:
+    """Flat-native-JSON baseline tool-use scheme (#1593 PR-2)."""
+
+    name = "enumerate-all"
+
+    def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
+        # NOTE (seam co-vet w/ e2e): a self-contained scheme needs the *building
+        # blocks* PR-1's seam doesn't yet expose — host context (agents /
+        # file_permissions / mcp_servers for the base tools) + the full catalog
+        # entry set (all 13 categories → flat tool schemas). ``available`` only
+        # carries {skills_for_tools, hot_list_aliases}; ``ops`` only offers the
+        # whole-universal ``present``. Pending the seam extension (see #1593 impl
+        # plan), the flat tools= is assembled by ``_build_flat_tools``.
+        flat_tools = self._build_flat_tools(available, layer_ctx, ops)
+        # Prior-shape (no wrapper-chain) SP — the existing gate yields the minimal
+        # tool-use instructions enumerate-all wants; no build_system_prompt change.
+        sp_params = {
+            "universal_wrappers_enabled": False,
+            "search_actions_enabled": bool(layer_ctx.get("search_visible", False)),
+        }
+        return Presentation(llm_tools_payload=flat_tools, sp_params=sp_params)
+
+    def _build_flat_tools(self, available, layer_ctx, ops: SchemeOps) -> list[dict]:
+        # PENDING seam extension (#1593 PR-2 impl plan, e2e co-vet): project every
+        # usable tool to a flat OpenAI tool dict named by its qualified
+        # ``<category>__<entry>`` (so ops.resolve/dispatch route it unchanged) +
+        # the base tools. Needs an ops building-block accessor (base-tools +
+        # catalog-entries) or a richer ``available``. Stub returns [] until the
+        # seam is agreed; conformance tests assert the method/contract shape.
+        return []
+
+    def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
+        # Flat (qualified) names resolve through the shared resolution (dedupe +
+        # salvage/unwrap → effective names) so the OS exclude-gates pre-dispatch.
+        actions = ops.resolve(llm_response, tool_catalog)
+        return Execute(actions=actions)
+
+    async def execute(self, interp: Interpretation, exec_ctx: ExecContext, ops: SchemeOps) -> ExecutionResult:
+        assert isinstance(interp, Execute), "enumerate-all emits only Execute"
+        results = await ops.dispatch(interp.actions)
+        return ExecutionResult(tool_results=results)
+
+    def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
+        return ops.feedback(result.tool_results)
+
+
+__all__ = ["EnumerateAllScheme"]

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -45,30 +45,19 @@ class EnumerateAllScheme:
     name = "enumerate-all"
 
     def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
-        # NOTE (seam co-vet w/ e2e): a self-contained scheme needs the *building
-        # blocks* PR-1's seam doesn't yet expose — host context (agents /
-        # file_permissions / mcp_servers for the base tools) + the full catalog
-        # entry set (all 13 categories → flat tool schemas). ``available`` only
-        # carries {skills_for_tools, hot_list_aliases}; ``ops`` only offers the
-        # whole-universal ``present``. Pending the seam extension (see #1593 impl
-        # plan), the flat tools= is assembled by ``_build_flat_tools``.
-        flat_tools = self._build_flat_tools(available, layer_ctx, ops)
+        # Self-contained presentation (e2e-agreed seam, #1593): compose the flat
+        # tools= from the router's building-block ops — the prior-shape base tools
+        # + every catalog action flat (no universal wrappers / no discovery). The
+        # router holds host context + catalog, so the scheme stays P7-clean.
+        flat_tools = list(ops.base_tools(available, layer_ctx)) + list(ops.catalog_entries())
         # Prior-shape (no wrapper-chain) SP — the existing gate yields the minimal
-        # tool-use instructions enumerate-all wants; no build_system_prompt change.
+        # tool-use instructions enumerate-all wants; no build_system_prompt change
+        # (the fragment-extraction the earlier plan floated is unnecessary).
         sp_params = {
             "universal_wrappers_enabled": False,
             "search_actions_enabled": bool(layer_ctx.get("search_visible", False)),
         }
         return Presentation(llm_tools_payload=flat_tools, sp_params=sp_params)
-
-    def _build_flat_tools(self, available, layer_ctx, ops: SchemeOps) -> list[dict]:
-        # PENDING seam extension (#1593 PR-2 impl plan, e2e co-vet): project every
-        # usable tool to a flat OpenAI tool dict named by its qualified
-        # ``<category>__<entry>`` (so ops.resolve/dispatch route it unchanged) +
-        # the base tools. Needs an ops building-block accessor (base-tools +
-        # catalog-entries) or a richer ``available``. Stub returns [] until the
-        # seam is agreed; conformance tests assert the method/contract shape.
-        return []
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
         # Flat (qualified) names resolve through the shared resolution (dedupe +

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -39,8 +39,11 @@ class UniversalCategoryScheme:
 
     name = "universal-category"
 
-    def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
+    async def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
         # ops.present → today's build_tools (or the phase op-catalog) + SP params.
+        # #1593 PR-2 seam: build_presentation is async (enumerate-all/PR-4 do I/O),
+        # but universal's body is unchanged — ops.present stays sync and is NOT
+        # awaited, so the tools=/sp_params bytes are byte-identical to PR-1.
         return ops.present(available, layer_ctx)
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -338,6 +338,7 @@ def _get_registry():
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,
+                chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
                 embedding_config=config.embedding,
                 eager_embedding_build=_eager_embedding_build,
                 # #1401: the 3 scoped capabilities, filled from the CLI override

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -116,3 +116,29 @@ def test_format_feedback_delegates_to_ops() -> None:
     s = EnumerateAllScheme()
     msgs = s.format_feedback(ExecutionResult(tool_results=[{"name": "git__commit"}]), _FakeOps())
     assert msgs == [{"role": "tool", "content": "git__commit"}]
+
+
+def test_per_layer_config_nondefault_selects_enumerate_all() -> None:
+    """Tier 2: a NON-default ``tool_use: {chat: enumerate-all}`` resolves the chat
+    layer to EnumerateAllScheme, while the default stays universal-category
+    (byte-identical) and a chat-only override leaves step/phase untouched.
+
+    Pins the config→selection seam at its public surfaces: the per-layer config
+    dataclass (``ToolUseConfig``), the scheme resolver (``_resolve_tool_use_scheme``),
+    and the scheme's public ``.name`` — NOT a running router or private state. The
+    config value is what each frontend threads (chat_tool_use_scheme) through the
+    factory → ChatSession → RouterLoopDriver → RouterLoop(scheme_name=)."""
+    from reyn.chat.router_loop import _resolve_tool_use_scheme
+    from reyn.config import _build_tool_use_config
+
+    # Default (None / missing tool_use:) → all layers universal-category.
+    default_cfg = _build_tool_use_config(None)
+    assert default_cfg.chat == "universal-category"
+    assert _resolve_tool_use_scheme(default_cfg.chat).name == "universal-category"
+
+    # NON-default chat layer → enumerate-all; sibling layers keep the default.
+    cfg = _build_tool_use_config({"chat": "enumerate-all"})
+    assert cfg.chat == "enumerate-all"
+    assert cfg.step == "universal-category"    # chat-only override is per-layer
+    assert cfg.phase == "universal-category"
+    assert _resolve_tool_use_scheme(cfg.chat).name == "enumerate-all"

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -1,0 +1,118 @@
+"""Tier 2: EnumerateAllScheme conformance — the flat-native-JSON scheme (#1593 PR-2).
+
+enumerate-all is the first SELF-CONTAINED ToolUseScheme: its presentation is its
+own (flat catalog enumeration vs universal's wrappers), while interpret / execute /
+format_feedback delegate to the shared router SchemeOps. These pin the 4-method
+contract + the presentation composition (base_tools + catalog_entries flat + the
+prior-shape SP params), without a running router.
+
+Uses a hand-written ``_FakeOps`` (a protocol-conforming Fake with explicit
+return values — NOT a MagicMock; per testing.ja.md "use real instances or a
+Fake"), so the test asserts the SCHEME's delegation/composition, not the router's
+substrate (which has its own tests).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.tools.scheme import (
+    Execute,
+    ExecutionResult,
+    Presentation,
+    SchemeOps,
+    ToolUseScheme,
+)
+from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
+
+
+class _FakeOps:
+    """Protocol-conforming Fake SchemeOps with deterministic returns (not a mock)."""
+
+    def __init__(self) -> None:
+        self.dispatched: list[dict] | None = None
+
+    def present(self, available, layer_ctx) -> Presentation:  # universal-only; unused here
+        return Presentation(llm_tools_payload=[{"function": {"name": "WRAPPER"}}])
+
+    def base_tools(self, available, layer_ctx) -> list[dict]:
+        return [{"function": {"name": "file__read"}}]
+
+    def catalog_entries(self) -> list[dict]:
+        return [{"function": {"name": "git__commit"}}, {"function": {"name": "web__fetch"}}]
+
+    def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
+        return [{"tc": llm_response, "name": "git__commit", "args": {}}]
+
+    async def dispatch(self, actions: list[dict]) -> list[dict]:
+        self.dispatched = actions
+        return [{"name": a["name"], "ok": True} for a in actions]
+
+    def feedback(self, tool_results: list[dict]) -> list[dict]:
+        return [{"role": "tool", "content": tr["name"]} for tr in tool_results]
+
+
+def test_enumerate_all_conforms_to_protocol() -> None:
+    """Tier 2: EnumerateAllScheme satisfies the ToolUseScheme protocol + names itself."""
+    s = EnumerateAllScheme()
+    assert isinstance(s, ToolUseScheme)
+    assert s.name == "enumerate-all"
+
+
+def test_build_presentation_is_base_plus_catalog_flat() -> None:
+    """Tier 2: presentation = base_tools + catalog_entries, flat (no universal
+    wrappers / no discovery). The scheme composes the router building blocks."""
+    s = EnumerateAllScheme()
+    pres = s.build_presentation(
+        {"skills_for_tools": [], "hot_list_aliases": []}, {"search_visible": False}, _FakeOps(),
+    )
+    names = [t["function"]["name"] for t in pres.llm_tools_payload]
+    assert names == ["file__read", "git__commit", "web__fetch"]   # base then catalog, flat
+    assert "WRAPPER" not in names                                   # NOT via ops.present
+
+
+def test_build_presentation_sp_params_disable_wrappers() -> None:
+    """Tier 2: SP params drive the prior-shape (no wrapper-chain) minimal SP —
+    no build_system_prompt surgery (the existing gate yields enumerate-all's SP)."""
+    s = EnumerateAllScheme()
+    pres = s.build_presentation(
+        {"skills_for_tools": [], "hot_list_aliases": []}, {"search_visible": True}, _FakeOps(),
+    )
+    assert pres.sp_params["universal_wrappers_enabled"] is False
+    assert pres.sp_params["search_actions_enabled"] is True   # follows layer search_visible
+
+
+def test_interpret_resolves_to_execute() -> None:
+    """Tier 2: interpret delegates to ops.resolve → Execute carrying resolved
+    effective-name actions (qualified names route through the shared resolution)."""
+    s = EnumerateAllScheme()
+    interp = s.interpret("llm-resp", tool_catalog={}, ops=_FakeOps())
+    assert isinstance(interp, Execute)
+    assert interp.actions[0]["name"] == "git__commit"
+
+
+@pytest.mark.asyncio
+async def test_execute_dispatches_via_ops() -> None:
+    """Tier 2: execute runs the resolved actions through ops.dispatch (the OS
+    permission/dispatch substrate, P5) and returns an ExecutionResult."""
+    s = EnumerateAllScheme()
+    ops = _FakeOps()
+    interp = Execute(actions=[{"name": "git__commit", "args": {}}])
+    res = await s.execute(interp, None, ops)
+    assert isinstance(res, ExecutionResult)
+    assert ops.dispatched == interp.actions               # dispatched the resolved actions
+    assert res.tool_results[0] == {"name": "git__commit", "ok": True}
+
+
+def test_format_feedback_delegates_to_ops() -> None:
+    """Tier 2: format_feedback delegates to ops.feedback (the shared JSON
+    tool_result formatting — enumerate-all reuses universal's base)."""
+    s = EnumerateAllScheme()
+    msgs = s.format_feedback(ExecutionResult(tool_results=[{"name": "git__commit"}]), _FakeOps())
+    assert msgs == [{"role": "tool", "content": "git__commit"}]

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -44,7 +44,7 @@ class _FakeOps:
     def base_tools(self, available, layer_ctx) -> list[dict]:
         return [{"function": {"name": "file__read"}}]
 
-    def catalog_entries(self) -> list[dict]:
+    async def catalog_entries(self) -> list[dict]:
         return [{"function": {"name": "git__commit"}}, {"function": {"name": "web__fetch"}}]
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
@@ -65,11 +65,13 @@ def test_enumerate_all_conforms_to_protocol() -> None:
     assert s.name == "enumerate-all"
 
 
-def test_build_presentation_is_base_plus_catalog_flat() -> None:
+@pytest.mark.asyncio
+async def test_build_presentation_is_base_plus_catalog_flat() -> None:
     """Tier 2: presentation = base_tools + catalog_entries, flat (no universal
-    wrappers / no discovery). The scheme composes the router building blocks."""
+    wrappers / no discovery). The scheme composes the router building blocks
+    (catalog_entries awaited — #1593 PR-2 async seam)."""
     s = EnumerateAllScheme()
-    pres = s.build_presentation(
+    pres = await s.build_presentation(
         {"skills_for_tools": [], "hot_list_aliases": []}, {"search_visible": False}, _FakeOps(),
     )
     names = [t["function"]["name"] for t in pres.llm_tools_payload]
@@ -77,11 +79,12 @@ def test_build_presentation_is_base_plus_catalog_flat() -> None:
     assert "WRAPPER" not in names                                   # NOT via ops.present
 
 
-def test_build_presentation_sp_params_disable_wrappers() -> None:
+@pytest.mark.asyncio
+async def test_build_presentation_sp_params_disable_wrappers() -> None:
     """Tier 2: SP params drive the prior-shape (no wrapper-chain) minimal SP —
     no build_system_prompt surgery (the existing gate yields enumerate-all's SP)."""
     s = EnumerateAllScheme()
-    pres = s.build_presentation(
+    pres = await s.build_presentation(
         {"skills_for_tools": [], "hot_list_aliases": []}, {"search_visible": True}, _FakeOps(),
     )
     assert pres.sp_params["universal_wrappers_enabled"] is False

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -62,6 +62,7 @@ _REQUIRED_SCOPED = frozenset({
     "action_retrieval_config",
     "embedding_config",
     "tool_calls_op_loop_skills",
+    "chat_tool_use_scheme",  # #1593 PR-2 per-layer chat scheme selector
 })
 
 

--- a/tests/test_tool_use_scheme_1593.py
+++ b/tests/test_tool_use_scheme_1593.py
@@ -73,10 +73,13 @@ def test_universal_conforms_to_protocol() -> None:
 # ── delegation seam + Execute-only invariant ─────────────────────────────────
 
 
-def test_universal_build_presentation_delegates() -> None:
-    """Tier 2: build_presentation delegates to ops.present (the router's logic)."""
+@pytest.mark.asyncio
+async def test_universal_build_presentation_delegates() -> None:
+    """Tier 2: build_presentation delegates to ops.present (the router's logic).
+    Async seam (#1593 PR-2) but universal's body stays a sync delegation — the
+    awaited result equals the unchanged ops.present output (byte-identical)."""
     ops = _RecordingOps()
-    pres = UniversalCategoryScheme().build_presentation({}, {}, ops)
+    pres = await UniversalCategoryScheme().build_presentation({}, {}, ops)
     assert "present" in ops.calls
     assert pres.llm_tools_payload == [{"t": 1}] and pres.sp_params == {"x": True}
 


### PR DESCRIPTION
**[tui-coder]** — PR-2 of #1593 (pluggable tool-use schemes). Builds the first **self-contained** `ToolUseScheme` on PR-1's abstraction (#1597), proving the seam supports a non-delegating scheme + per-layer selectability.

## What lands

**`EnumerateAllScheme`** (flat-native-JSON baseline): present *every* usable tool flatly in `tools=` (no universal category-wrapper discovery) + a minimal SP, dispatch by qualified name. Per the #1593 competitor research this is the deterministic small-toolset baseline — explicitly **not** the weak-model fix (flat JSON is weakest for weak models; CodeAct/PR-3 is the evidence-winner). Selected per-layer via `tool_use: {chat/step/phase}`.

### Pieces
1. **Scheme** (`tools/schemes/enumerate_all.py`): `build_presentation` = `base_tools + catalog_entries` flat (its own presentation); `interpret`/`execute`/`format_feedback` reuse the shared `SchemeOps` substrate (qualified names route through the existing resolution → exclude-gate → dispatch).
2. **Building-block ops** (`SchemeOps.base_tools` + `catalog_entries`): generic, P7-clean accessors a self-contained scheme composes (vs the whole-universal `present`). Additive → universal's delegation unchanged.
3. **Async presentation seam** (e2e protocol call, issuecomment-4700815694): `build_presentation` + `catalog_entries` + `execute` are **async**; `present`/`base_tools`/`interpret`/`format_feedback` stay **sync**. Universal's `build_presentation` is an async wrapper returning the unchanged sync `ops.present` (not awaited) → **byte-identical**. Rationale: presentation is I/O for every non-trivial scheme; PR-4 retrieval's per-round embedding query can't be served by a pre-cached rs.
4. **catalog_entries body** (consumes sandbox_2's #1598 substrate): adapter awaits the rag-populated `router_state` (caveat-1) → calls the sync `universal_catalog.catalog_entries(ctx)` → maps generic `{name,description,parameters}` → OpenAI tool shape.
5. **Selectability** (`config.tool_use.chat` → RouterLoop): threaded through the #1402 drift-guard factory as a **required** param → all 5 frontends (chat-CLI / MCP / A2A / chainlit / dogfood) resolve the same value → `ChatSession` → `RouterLoopDriver` → `RouterLoop(scheme_name=)`. #1402 invariant pins the new param across every callsite.
6. **Registration fix**: the lazy guard coupled enumerate-all's registration to universal being absent → silent fallback if universal registered first. Now per-scheme idempotent guard keyed on `scheme.name` (P7-clean).

## P-compliance
- **P7**: no scheme-name literals in OS code (guard uses `_builtin.name` / `DEFAULT_SCHEME_NAME`; grep-0 verified). Substrate exposes a flat action list, not the category hierarchy.
- Default stays `universal-category` everywhere → today's behaviour byte-identical.

## Test plan
- [x] byte-identical / golden-shape gate (lead-mandated): **169 passed, 1 xfailed** — replay fixtures exercise the universal path through `await build_presentation → ops.present` (tools=/SP bytes unchanged).
- [x] PR-2 conformance (6) + per-layer NON-default selectability (1): green.
- [x] #1402 factory invariant + web/dogfood scoped (14) + #1598 substrate: green.
- [x] `router_loop` (36) + `router_tools` (20): green.
- [x] ruff + tier-audit (13 OK / 0 warn / 0 err) clean.
- [x] all 5 frontends import OK.
- [x] (skipped — live LLM run is e2e-coder's co-vet scope) end-to-end `reyn chat` with `tool_use: {chat: enumerate-all}` driving a real flat-tools turn.

## Tier self-check
1 new + 3 async-converted Tier-2 tests; `"Tier 2:"` docstrings; public-surface asserts (`scheme.name`, `Presentation` payload, config dataclass); no MagicMock / private-state / format-pin.

## Co-vet requested
@e2e-coder (seam owner) — 4-method contract + building-block accessors + async layering + selectability. cc lead-coder review.

Open question for co-vet: `catalog_entries` builds rs once per `build_presentation` call (once/turn for PR-2). Cross-round rs caching (e2e's "once build + cache") is deferred as a PR-4 concern (PR-4's per-round presentation is where redundancy would appear) — flagging in case you want it pulled forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
