### PR TITLE
feat(1593): 3-arm Interpretation match — the single-owned OS-loop seam (PR-3+PR-4 ride)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -3120,20 +3120,51 @@ class RouterLoop:
         return tool_results
 
     async def _run_scheme_tool_round(self, llm_response) -> "tuple[list[dict], list[dict]]":
-        """Route one tool-call round through the active scheme (#1593), byte-identical
-        to the former ``dedupe → gather(_execute_tool)``. Returns ``(tool_calls,
-        tool_results)`` in the original (deduped) order for the downstream loop:
+        """Route one tool-call round through the active scheme (#1593) by dispatching
+        on the scheme's ``Interpretation`` (the tagged union). Returns ``(tool_calls,
+        tool_results)`` in the original (deduped) order for the downstream loop.
 
-        interpret (resolve) → OS exclude-gate (pre-dispatch) → execute (dispatch
-        survivors) → format_feedback. Universal emits only ``Execute``; the exclude
-        gate produces the same ``tool_excluded`` error result **in place** (not a
-        drop), so order + tool_call_id alignment are preserved."""
-        from reyn.tools.scheme import ExecContext, Execute, ExecutionResult
+        Three arms, **single-owned here** so PR-3 (CodeAct / ``CodeBlock``) and PR-4
+        (retrieval / ``RePresent``) ride one generalized match instead of two
+        competing patches of this load-bearing OS-loop seam (#1593 seam arbitration):
+
+          - ``Execute``   → today's path (resolve → OS exclude-gate pre-dispatch →
+            dispatch survivors → ``format_feedback``), **byte-identical** to the former
+            ``dedupe → gather(_execute_tool)``. Universal-category emits only this.
+          - ``CodeBlock`` → CodeAct (PR-3): the snippet runs in a sandboxed subprocess
+            whose only world-effect path is the permission-proxy, which re-enters the
+            SAME exclude + ``dispatch_tool`` + permission gate per call. Body in
+            ``_run_codeblock_round`` (PR-3 S2/S3).
+          - ``RePresent`` → retrieval (PR-4): bounded re-present loop. PR-4 owns this
+            arm body + the refinement contract; unreached by any PR-3-era scheme.
+        """
+        from reyn.tools.scheme import CodeBlock, Execute, RePresent
 
         interp = self._scheme.interpret(
             llm_response, tool_catalog=self._catalog, ops=self,
         )
-        assert isinstance(interp, Execute), "universal-category emits only Execute"
+        match interp:
+            case Execute():
+                return await self._run_execute_round(interp)
+            case CodeBlock():
+                return await self._run_codeblock_round(interp)
+            case RePresent():
+                # PR-4 owns this arm (bounded re-present loop) + the refinement
+                # contract. No PR-3-era scheme (universal / enumerate-all / CodeAct)
+                # emits RePresent, so this is genuinely unreached until PR-4 lands.
+                raise AssertionError("RePresent not reached — PR-4 owns this arm")
+            case _:
+                raise AssertionError(
+                    f"unknown Interpretation: {type(interp).__name__}"
+                )
+
+    async def _run_execute_round(self, interp) -> "tuple[list[dict], list[dict]]":
+        """The ``Execute`` arm — **byte-identical** to the former
+        ``_run_scheme_tool_round`` body. The OS exclude-gate produces the same
+        ``tool_excluded`` error result **in place** (not a drop), so order +
+        ``tool_call_id`` alignment are preserved across the dispatch."""
+        from reyn.tools.scheme import ExecContext, Execute, ExecutionResult
+
         actions = interp.actions
         tool_calls = [a["tc"] for a in actions]
 
@@ -3155,6 +3186,15 @@ class RouterLoop:
             ExecutionResult(tool_results=results), ops=self,
         )
         return tool_calls, tool_results
+
+    async def _run_codeblock_round(self, interp) -> "tuple[list[dict], list[dict]]":
+        """The ``CodeBlock`` arm — CodeAct (PR-3). The snippet runs in a sandboxed
+        subprocess (S2 ``CodeActRunner``: duplex socketpair + concurrent parent
+        service loop) where the only world-effect path is the permission-proxy — each
+        proxied call re-enters the SAME OS exclude + ``dispatch_tool`` + permission
+        gate (P5), so a CodeAct call is gated ≥ a JSON call. Body lands in PR-3
+        S2/S3; the match arm is wired here so the seam structure is single-owned."""
+        raise NotImplementedError("CodeAct CodeBlock execute — PR-3 S2/S3")
 
     def _maybe_salvage_qualified_direct_call(
         self, name: str, args: dict,

--- a/tests/test_scheme_interpretation_match_1593.py
+++ b/tests/test_scheme_interpretation_match_1593.py
@@ -1,0 +1,88 @@
+"""Tier 2: the #1593 PR-3 S1 three-arm ``Interpretation`` match in the OS loop.
+
+``_run_scheme_tool_round`` dispatches on the scheme's ``Interpretation`` tagged
+union (Execute / CodeBlock / RePresent). PR-3 single-owns this generalization so
+PR-3 (CodeAct) and PR-4 (retrieval) ride one match, not two competing patches of
+the same OS-loop seam. This test pins the routing invariant:
+
+  - Execute   → ``_run_execute_round`` → ``(tool_calls, tool_results)`` (the
+                byte-identical today-path; also covered end-to-end by the 22 exclude
+                / universal-scheme tests).
+  - CodeBlock → ``_run_codeblock_round`` (CodeAct body lands in PR-3 S2/S3).
+  - RePresent → AssertionError (PR-4 owns the arm; unreached by any PR-3-era scheme).
+
+No mocks: ``_FakeScheme`` is a real object implementing the ToolUseScheme surface
+(a Fake, per testing.ja.md), emitting a chosen Interpretation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.tools.scheme import (
+    CodeBlock,
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    RePresent,
+)
+
+
+class _FakeScheme:
+    """A real (non-mock) ToolUseScheme that emits a fixed ``Interpretation`` from
+    ``interpret`` — exercises the OS-loop match without driving a full LLM round.
+    ``execute`` / ``format_feedback`` are the trivial identity used by the Execute
+    arm with an empty action list."""
+
+    def __init__(self, interp: object) -> None:
+        self._interp = interp
+
+    def build_presentation(self, available: object, layer_ctx: object, ops: object):
+        raise AssertionError("build_presentation not exercised by this test")
+
+    def interpret(self, llm_response: object, *, tool_catalog: dict, ops: object):
+        return self._interp
+
+    async def execute(self, interp: object, exec_ctx: ExecContext, ops: object):
+        return ExecutionResult(tool_results=[])
+
+    def format_feedback(self, exec_result: ExecutionResult, ops: object):
+        return exec_result.tool_results
+
+
+class _MinimalHost:
+    """Construction-only host. ``RouterLoop.__init__`` stores ``host`` and resolves
+    the scheme without calling any host method, so a bare object suffices for a
+    match-routing test (verified against the __init__ body)."""
+
+
+def _loop_with_scheme(interp: object) -> RouterLoop:
+    loop = RouterLoop(host=_MinimalHost(), chain_id="t", max_iterations=1)
+    loop._scheme = _FakeScheme(interp)  # the active scheme under test
+    loop._catalog = {}
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_execute_arm_routes_and_returns() -> None:
+    """Tier 2: Execute interp routes to the (byte-identical) execute round."""
+    loop = _loop_with_scheme(Execute(actions=[]))
+    tool_calls, tool_results = await loop._run_scheme_tool_round(object())
+    assert tool_calls == []
+    assert tool_results == []
+
+
+@pytest.mark.asyncio
+async def test_codeblock_arm_routes_to_codeact_body() -> None:
+    """Tier 2: CodeBlock interp routes to the CodeAct arm (PR-3 S2/S3 body)."""
+    loop = _loop_with_scheme(CodeBlock(code="x = 1"))
+    with pytest.raises(NotImplementedError):
+        await loop._run_scheme_tool_round(object())
+
+
+@pytest.mark.asyncio
+async def test_represent_arm_unreached_until_pr4() -> None:
+    """Tier 2: RePresent interp is unreached until PR-4 owns the arm."""
+    loop = _loop_with_scheme(RePresent(refinement=None))
+    with pytest.raises(AssertionError, match="RePresent not reached"):
+        await loop._run_scheme_tool_round(object())


### PR DESCRIPTION
**[dogfood-coder]** — the single-owned OS-loop seam both PR-3 (CodeAct/`CodeBlock`) and PR-4 (retrieval/`RePresent`) ride. Landed standalone (seam-first decoupling, same pattern as catalog_entries #1598) so each PR rebases on `main` and fills its arm without blocking the other — and PR-4 step 2 unblocks immediately.

## What
Generalizes `_run_scheme_tool_round` from `assert isinstance(interp, Execute)` to a 3-arm tagged-union `match` on the scheme's `Interpretation` (the PR-1 protocol union — OS-level vocabulary, not scheme-specific, so the explicit cases are P7-clean):
- **`Execute`** → `_run_execute_round` — **byte-identical** extraction of the former body (in-place `tool_excluded` error result preserves order + `tool_call_id` alignment). The only arm reachable today (universal-category emits only `Execute`).
- **`CodeBlock`** → `_run_codeblock_round` — NotImplementedError stub; **PR-3** fills it (CodeAct).
- **`RePresent`** → `raise AssertionError("RePresent not reached")` — **PR-4** fills it (retrieval bounded loop).

Both new arms are unreached dead code at this commit (no scheme emits `CodeBlock`/`RePresent` on main yet), so this is byte-identical for all current behavior.

## Single-ownership
This PR owns the match structure. PR-3 adds the `CodeBlock` body + registers CodeAct; PR-4 adds the `RePresent` body + registers retrieval. One seam, no competing patches (the #1593 seam arbitration).

## Test plan
- [x] `tests/test_scheme_interpretation_match_1593.py` — 3 Tier-2 routing tests (Execute routes + returns; CodeBlock → NotImplementedError; RePresent → AssertionError), real Fake scheme, no mocks.
- [x] Execute byte-identical: the 22 exclude/universal regression tests (187 / 1406 / run_once / tool_use_scheme) unchanged-pass.
- [x] `python -m pytest tests/test_scheme_interpretation_match_1593.py tests/test_chat_exclude_tools_187.py tests/test_exclude_execution_block_1406.py tests/test_run_once_187.py tests/test_tool_use_scheme_1593.py -W error::RuntimeWarning` → 25 passed.

## Tier-rule self-check
- [x] Test docstrings declare Tier (`Tier 2: ...`).
- [x] No Tier-4; no mocks (real Fake ToolUseScheme).
- [x] No invariant weakening (Execute byte-identical; the routing test pins the new dispatch).
- [x] No algorithm-level pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)