### PR TITLE
feat(1593): scheme-owned Presentation.sp_fragment SP channel (seam-completion)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1725,6 +1725,12 @@ class RouterLoop:
                 # configured + index ready); False there means the SP and tools=
                 # both exclude search_actions, eliminating the N5 hallucination.
                 search_actions_enabled=_pres.sp_params["search_actions_enabled"],
+                # #1593: free-form scheme-owned tool-use SP. Empty for the
+                # named-gate schemes (universal-category / enumerate-all) ⇒ the
+                # SP is byte-identical; a divergent scheme (CodeAct code-API /
+                # retrieval search-SP) supplies its own tool-use text here and
+                # the OS appends it verbatim (P7 — no scheme concepts in the OS).
+                scheme_sp_fragment=_pres.sp_fragment,
                 # #272/#1128: OS-injected context-size signal (header), computed
                 # once above. Rendered LAST in the SP (most volatile section →
                 # preserves the cached prefix above it); None when ample.

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -72,6 +72,7 @@ def build_system_prompt(
     universal_wrappers_enabled: bool = False,  # FP-0034 PR-3b-v
     cwd: str | None = None,
     search_actions_enabled: bool = True,  # FP-0034 §D14 — default True preserves byte-compat
+    scheme_sp_fragment: str = "",  # #1593 — free-form scheme-owned tool-use SP; OS appends verbatim (P7), default "" = byte-identical named-gate path
     context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
     discovery_mandate: bool = False,  # #187 Stage C — weak-tier list_actions-first mandate (3x)
     non_interactive: bool = False,  # #1439 Fix #1 — run-once (no TTY): no user to ask, proceed instead of clarifying
@@ -568,6 +569,18 @@ def build_system_prompt(
             f"  - Always reply in language: {output_language}."
             "  Do NOT switch language even for error messages or clarifying questions."
         )
+
+    # ── 13b. Scheme-owned SP fragment (#1593) ────────────────────────────────
+    # A tool-use scheme whose tool-use instructions are genuinely new content
+    # (e.g. CodeAct's rendered fn-signature code-API, retrieval's search-tool SP)
+    # supplies them here as free-form text. The OS appends it verbatim and does
+    # NOT interpret it (P7: the OS has no notion of "code-API" / "search-SP").
+    # Empty default ⇒ universal-category / enumerate-all (named-gate schemes) are
+    # byte-identical. Placed before the volatile context-size signal so the
+    # scheme's tool-use SP sits with the rest of the cached prefix.
+    if scheme_sp_fragment:
+        parts.append("")
+        parts.append(scheme_sp_fragment)
 
     # ── 14. Context-size signal (#272/#1128) ─────────────────────────────────
     # OS-injected, pre-rendered by the caller (router_loop / phase runtime) from

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -41,13 +41,23 @@ class ToolUseLayer(str, Enum):
 class Presentation:
     """What a scheme shows the LLM: the ``tools=`` payload + SP-shaping inputs.
 
-    PR-1: ``sp_params`` carries the parameters that drive the (still monolithic)
-    ``build_system_prompt`` — byte-identical. PR-2 (enumerate-all) introduces a
-    scheme-owned SP *fragment* once a scheme needs a divergent prompt.
+    Two channels shape the system prompt, deliberately separated:
+
+    - ``sp_params`` — **named gates** the OS-owned ``build_system_prompt`` already
+      understands (``universal_wrappers_enabled`` / ``search_actions_enabled`` …).
+      universal-category and enumerate-all express their whole SP shape through
+      these → their build is byte-identical (default ``sp_fragment=""``).
+    - ``sp_fragment`` — **free-form, scheme-owned** SP text the OS appends verbatim
+      without interpreting it (P7: the OS must not know "code-API" or "search-SP").
+      A scheme reaches for this only when its tool-use instructions are genuinely
+      new content that no named gate can express — CodeAct (rendered fn-signature
+      code-API) is the first consumer; retrieval's search-tool SP shares the same
+      single channel. Empty by default ⇒ the named-gate path is untouched.
     """
 
     llm_tools_payload: list[dict]
     sp_params: dict[str, Any] = field(default_factory=dict)
+    sp_fragment: str = ""
 
 
 # ── Interpretation: the tagged union the OS loop dispatches on ──────────────

--- a/tests/test_scheme_sp_fragment_1593.py
+++ b/tests/test_scheme_sp_fragment_1593.py
@@ -1,0 +1,100 @@
+"""Tier 2: #1593 — the scheme-owned ``Presentation.sp_fragment`` SP channel.
+
+A tool-use scheme shapes the system prompt through two deliberately separate
+channels (see ``Presentation``):
+
+  - ``sp_params`` — named gates ``build_system_prompt`` already understands
+    (``universal_wrappers_enabled`` / ``search_actions_enabled`` …). The
+    named-gate schemes (universal-category, enumerate-all) express their whole
+    SP through these, leaving ``sp_fragment`` empty.
+  - ``sp_fragment`` — free-form, scheme-owned tool-use SP text the OS appends
+    **verbatim** without interpreting it (P7: the OS has no notion of
+    "code-API" / "search-SP"). CodeAct / retrieval are the first consumers.
+
+This file pins the OS-side contract of that second channel:
+
+  1. Empty fragment (the default) ⇒ the SP is byte-identical to the call with
+     no fragment argument at all — the named-gate path is untouched.
+  2. A non-empty fragment appears verbatim in the rendered SP.
+  3. The fragment is appended (OS-agnostic): the OS does not transform, prefix,
+     or wrap it — what the scheme wrote is what lands.
+  4. The fragment sits before the volatile context-size signal (so the
+     scheme's tool-use SP stays in the cached prefix, not after the tail).
+
+No mocks. Tests call ``build_system_prompt`` with real arguments.
+"""
+from __future__ import annotations
+
+from reyn.chat.router_system_prompt import build_system_prompt
+
+
+def _sp(*, scheme_sp_fragment: str = "", context_size_signal: str | None = None) -> str:
+    return build_system_prompt(
+        agent_name="test",
+        agent_role="tester",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        scheme_sp_fragment=scheme_sp_fragment,
+        context_size_signal=context_size_signal,
+    )
+
+
+# ── 1. Empty fragment = byte-identical named-gate path ───────────────────────
+
+
+def test_empty_fragment_leaves_named_gate_sp_unchanged() -> None:
+    """Tier 2: #1593 — default ``sp_fragment=""`` renders an SP equal to the call
+    that passes no fragment argument; the named-gate schemes (universal-category
+    / enumerate-all) are therefore unchanged by this seam. This is a permanent
+    contract (the empty channel is invisible), not a refactor-equivalence check."""
+    without_arg = build_system_prompt(
+        agent_name="test",
+        agent_role="tester",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+    )
+    with_empty = _sp(scheme_sp_fragment="")
+    assert with_empty == without_arg, (
+        "empty sp_fragment must leave the SP byte-identical to the named-gate path"
+    )
+
+
+# ── 2. Non-empty fragment appears verbatim ───────────────────────────────────
+
+
+def test_non_empty_fragment_appears_in_sp() -> None:
+    """Tier 2: #1593 — a scheme's free-form tool-use SP lands verbatim in the SP."""
+    fragment = "## Code API\nCall tools by writing Python: `result = file__read(path=...)`."
+    sp = _sp(scheme_sp_fragment=fragment)
+    assert fragment in sp, "the scheme sp_fragment must appear verbatim in the SP"
+
+
+def test_fragment_is_not_transformed_by_the_os() -> None:
+    """Tier 2: #1593 — the OS appends the fragment verbatim (P7): it does not
+    interpret, re-wrap, or strip the scheme's text. A fragment that mentions a
+    scheme-specific concept the OS has no name for survives untouched."""
+    fragment = "SEARCH-PARADIGM-SENTINEL: emit search_actions(query=...) then call a match."
+    sp = _sp(scheme_sp_fragment=fragment)
+    assert "SEARCH-PARADIGM-SENTINEL: emit search_actions(query=...) then call a match." in sp
+
+
+# ── 3. Placement: before the volatile context-size signal ────────────────────
+
+
+def test_fragment_precedes_context_size_signal() -> None:
+    """Tier 2: #1593 — the fragment is rendered before the (LAST-placed)
+    context-size signal, so the scheme's tool-use SP sits with the cached
+    prefix rather than after the most-volatile tail section."""
+    fragment = "FRAGMENT-SENTINEL-XYZ"
+    signal = "CONTEXT-SIGNAL-SENTINEL"
+    sp = _sp(scheme_sp_fragment=fragment, context_size_signal=signal)
+    assert fragment in sp and signal in sp
+    assert sp.index(fragment) < sp.index(signal), (
+        "the scheme fragment must precede the context-size signal in the SP"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #1593 shared seam: the scheme-owned `Presentation.sp_fragment` SP channel.

## Why (answers lead's Issue-2 radar item directly)

PR-1 defined `build_presentation → Presentation`, but **PR-2 (enumerate-all) expressed its whole SP through named gates** (`universal_wrappers_enabled` / `search_actions_enabled` in `sp_params`) — so the *free-form scheme-owned* SP channel the `Presentation` docstring anticipated was **never actually wired into `build_system_prompt`**. This is therefore a **real seam-completion**, not a no-op:

- **CodeAct (PR-3 S3b)** is the first scheme whose tool-use instructions are genuinely *new SP content* — the rendered Python fn-signature code-API (`tools=` empty). No named gate can express that.
- **Retrieval (PR-4)** shares the same need for its search-tool SP.

Putting either scheme's rendering inside `build_system_prompt` would be a **P7 violation** (the OS would learn "code-API" / "search-SP"). The fix is one opaque channel the OS appends without interpreting.

## The two-channel contract (now documented on `Presentation`)

| channel | meaning | who reads it |
|---|---|---|
| `sp_params` | **named gates** the OS already understands (`universal_wrappers_enabled` …) | `build_system_prompt` interprets each key |
| `sp_fragment` | **free-form, scheme-owned** tool-use SP text | OS appends **verbatim**, never interprets (P7) |

`sp_fragment: str = ""` default ⇒ the named-gate schemes (universal-category / enumerate-all) are **byte-identical**.

## Changes

- `tools/scheme.py` — `Presentation.sp_fragment: str = ""` (+ the two-channel docstring).
- `chat/router_system_prompt.py` — `build_system_prompt` gains `scheme_sp_fragment: str = ""`; appended verbatim **before** the volatile context-size signal (so the scheme's tool-use SP stays in the cached prefix). Empty ⇒ byte-identical.
- `chat/router_loop.py` — `run()` threads `_pres.sp_fragment` into the `build_system_prompt` call.

## Ownership (lead Issue-2 a/b/c)

- **(a) real seam-completion?** Yes — `sp_fragment` wiring was unexercised by PR-2.
- **(b) owner?** Me (e2e-coder) — `Presentation` is my PR-1 protocol. sandbox_2 co-vets.
- **(c) `sp_fragment` vs `sp_params`?** The table above — named gates vs opaque verbatim text.

## Unblocks

CodeAct `build_presentation` (PR-3 S3b): `await ops.catalog_entries()` → render fn-signature code-API into `sp_fragment` (excluded omitted). PR-4 retrieval search-SP shares the channel (single-source).

## Test plan

- [x] `tests/test_scheme_sp_fragment_1593.py` — 4 Tier-2 (real `build_system_prompt`, no mocks): empty fragment = SP equal to no-fragment call (named-gate path unchanged); non-empty appears verbatim; OS does not transform it; placed before the context-size signal. **4 passed.**
- [x] Scheme/router/SP regression — `pytest -k "scheme or router_system or sp_minim or enumerate"` → **72 passed, 1 skipped**.
- [x] Full suite `pytest -q` from rootdir → **7268 passed** (the 2 fails — `test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref` — are pre-existing local-env failures, fail on clean origin/main too; CI's clean env passes them, not this diff).
- [x] `ruff check .` on changed files → clean. `test_tier_audit.py --strict` → 4 OK, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
