### PR TITLE
feat(1593) PR-4: retrieval scheme + OS RePresent convergence arm

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -88,6 +88,23 @@ _EMPTY_RESPONSE_MSG: dict[str, str] = {
 # W3 S1); this deterministic OS message carries the same UX guarantee
 # (= "/tasks" hint) without LLM composition, so the race condition does
 # not re-emerge.  P7-clean: no skill names, no qualified action names.
+# #1593 PR-4: the OS-generic synthetic tool-response the RePresent arm appends for
+# an intercepted re-present tool_call (a retrieval search). The scheme's interpret
+# turned the tool_call into a RePresent (it is never dispatched), but the message
+# history still needs every tool_call answered — this is that answer. P7-clean:
+# OS-level vocabulary, no "search" / scheme concept; the new tools= payload + the
+# scheme's sp_fragment carry the actual re-presentation meaning to the LLM.
+_REPRESENT_ACK = (
+    "The available tools have been updated based on your request. "
+    "The tools you can now call are listed above."
+)
+# Defensive backstop for the RePresent loop (#1593 PR-4). The REAL bound is
+# convergence-by-construction (the scheme's monotonic ``presented`` on a finite
+# catalog + its terminal-search-drop forcing Execute); this valve only fires for a
+# misbehaving scheme that never terminates its re-present loop, well above any
+# realistic search-refine sequence. The outer max_iterations is the ultimate cap.
+_MAX_REPRESENT_ROUNDS = 64
+
 _SPAWN_ACK_MSG: dict[str, str] = {
     "ja": (
         "スキルをバックグラウンドで実行しています。"
@@ -1661,15 +1678,23 @@ class RouterLoop:
         # use build_tools with the catalog wrappers). PR-2/3 schemes shape tools=
         # differently. The OS still projects _catalog from the payload + builds the
         # (monolithic) SP from sp_params below.
+        # #1593 PR-4: capture the build_presentation inputs so the OS RePresent arm
+        # (run_loop) can re-call build_presentation with a refinement + the
+        # accumulated `presented` set. Stashed on self (RouterLoop is per-run state,
+        # like self._catalog) — NOT the scheme (a registered singleton).
+        _scheme_available = {
+            "skills_for_tools": skills_for_tools, "hot_list_aliases": _hot_list_aliases,
+        }
+        _scheme_layer_ctx = {
+            "phase_op_catalog": _phase_op_catalog,
+            "univ_enabled": _univ_enabled,
+            "search_visible": _search_visible,
+            "ctx_signal_present": _ctx_signal is not None,
+        }
+        self._scheme_available = _scheme_available
+        self._scheme_layer_ctx = _scheme_layer_ctx
         _pres = await self._scheme.build_presentation(
-            {"skills_for_tools": skills_for_tools, "hot_list_aliases": _hot_list_aliases},
-            {
-                "phase_op_catalog": _phase_op_catalog,
-                "univ_enabled": _univ_enabled,
-                "search_visible": _search_visible,
-                "ctx_signal_present": _ctx_signal is not None,
-            },
-            ops=self,
+            _scheme_available, _scheme_layer_ctx, ops=self,
         )
         tools = _pres.llm_tools_payload
         # #187 STEP 1c (owner principle): actions are enumerated ONLY by
@@ -1826,6 +1851,13 @@ class RouterLoop:
         # message list. Bounded by ``self._plan_invalid_max_retries``
         # (default 1 = one correction attempt per chat turn).
         _plan_invalid_retries: int = 0
+        # #1593 PR-4: OS RePresent convergence state (per-turn loop-locals — NOT
+        # scheme self-state; schemes are registered singletons). ``_represented``
+        # is the monotonic accumulator of every candidate the scheme has presented
+        # this turn, threaded into build_presentation so the scheme self-determines
+        # convergence. ``_represent_rounds`` feeds the defensive backstop.
+        _represented: set = set()
+        _represent_rounds: int = 0
 
         # FP-0005 max_iterations checkpoint: outer while allows re-entry after
         # an approved extension. _loop_cancelled tracks cancel-break vs exhaustion.
@@ -1995,12 +2027,64 @@ class RouterLoop:
                     "CodeAct CodeBlock arm — PR-3 fills _run_codeblock_round"
                 )
             if isinstance(interp, RePresent):
-                # PR-4 step-2 fills this inline (synthetic tool-response + tools-swap
-                # + ``continue``); the loop-locals (tools / self._catalog / messages)
-                # are in scope here for that. Unreached until retrieval is selectable.
-                raise AssertionError(
-                    "RePresent not reached — PR-4 step-2 owns this inline arm"
+                # #1593 PR-4: the generic OS RePresent mechanism (ratified seam). The
+                # scheme classified the LLM output as a re-present request (e.g. a
+                # retrieval search). The OS, generically (no scheme concepts — P7):
+                #   1. records the assistant turn + a synthetic tool-response for each
+                #      intercepted tool_call (OpenAI requires every tool_call answered);
+                #   2. re-calls build_presentation with the refinement + the
+                #      accumulated ``presented`` set (an OS loop-local, NOT scheme
+                #      self-state — schemes are registered singletons);
+                #   3. swaps the advertised tools + the dispatch ``_catalog`` mirror;
+                #   4. accumulates ``presented`` and re-enters the main iteration via
+                #      ``continue`` (budget / compaction / force-close / memo all keep
+                #      applying — no inner LLM loop).
+                # Convergence is the SCHEME's: it self-determines terminal from
+                # ``presented`` + drops the search tool → the next turn can only
+                # Execute. Bounded by construction (monotonic ``presented`` on a
+                # finite catalog). The round counter is a defensive valve for a
+                # non-converging scheme, never the bound; max_iterations is the cap.
+                _represent_rounds += 1
+                if _represent_rounds > _MAX_REPRESENT_ROUNDS:
+                    raise RuntimeError(
+                        "RePresent did not converge within the defensive backstop "
+                        f"({_MAX_REPRESENT_ROUNDS} rounds) — the active scheme is not "
+                        "terminating its re-present loop"
+                    )
+                messages.append({
+                    "role": "assistant",
+                    "content": result.content or "",
+                    "tool_calls": result.tool_calls,
+                })
+                for _tc in result.tool_calls:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": _tc["id"],
+                        "content": _REPRESENT_ACK,
+                    })
+                _represent_layer_ctx = {
+                    **(getattr(self, "_scheme_layer_ctx", None) or {}),
+                    "refinement": interp.refinement,
+                    "presented": tuple(_represented),
+                }
+                _re_pres = await self._scheme.build_presentation(
+                    getattr(self, "_scheme_available", None) or {},
+                    _represent_layer_ctx,
+                    ops=self,
                 )
+                tools = _apply_tool_exclusions(
+                    _re_pres.llm_tools_payload, self._exclude_tools,
+                )
+                self._catalog = {t["function"]["name"]: t for t in tools}
+                self._tool_names = frozenset(self._catalog.keys())
+                _represented |= set(_re_pres.candidates)
+                host.events.emit(
+                    "router_represent_round",
+                    chain_id=self.chain_id,
+                    round=_represent_rounds,
+                    presented_count=len(_represented),
+                )
+                continue
             if isinstance(interp, Execute):
                 # B28-Q2: count non-empty tool_call rounds for chat_turn_completed_inline.
                 _tool_calls_attempted += 1

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -43,6 +43,7 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     (``tool_use:{chat,step,phase}``) passes the selected name here."""
     from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme, register_scheme
     from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
+    from reyn.tools.schemes.retrieval import RetrievalScheme
     from reyn.tools.schemes.universal_category import UniversalCategoryScheme
 
     # Register each built-in independently + idempotently (keyed on the scheme's
@@ -51,7 +52,7 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     # NOT being registered yet — so anything that registers universal first (a
     # direct register_scheme caller, a test) would leave enumerate-all absent and
     # silently fall back to default. Per-scheme guard avoids that sibling gap.
-    for _builtin in (UniversalCategoryScheme(), EnumerateAllScheme()):  # #1593 PR-2
+    for _builtin in (UniversalCategoryScheme(), EnumerateAllScheme(), RetrievalScheme()):  # #1593 PR-2/4
         if get_scheme(_builtin.name) is None:
             register_scheme(_builtin)
     # Unknown / unconfigured name → default (universal-category) — byte-identical.
@@ -3126,6 +3127,25 @@ class RouterLoop:
             }
             for entry in universal_catalog.catalog_entries(tool_ctx)
         ]
+
+    async def search_actions(self, query: str, *, top_k: int = 10) -> list[str]:
+        """SchemeOps.search_actions (#1593 PR-4): rank usable actions by semantic
+        match to ``query`` → matched qualified names. Reuses the FP-0034
+        ``ActionEmbeddingIndex`` (the same substrate the ``search_actions`` tool uses);
+        ``query`` awaits the embedding of the dynamic query (the reason presentation
+        is async). Returns ``[]`` when the index / provider is unavailable (degrade)."""
+        index = self.host.get_action_embedding_index()
+        provider = self.host.get_embedding_provider()
+        model_class = self.host.get_embedding_model_class()
+        if index is None or provider is None:
+            return []
+        try:
+            results = await index.query(query, provider, model_class, top_k=top_k)
+        except Exception as e:  # noqa: BLE001 — search is best-effort presentation aid
+            import logging
+            logging.getLogger(__name__).warning("search_actions failed: %s", e)
+            return []
+        return [r["qualified_name"] for r in results if r.get("qualified_name")]
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
         """SchemeOps.resolve: dedupe + #229 salvage → actions carrying the original

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -58,6 +58,11 @@ class Presentation:
     llm_tools_payload: list[dict]
     sp_params: dict[str, Any] = field(default_factory=dict)
     sp_fragment: str = ""
+    # #1593 PR-4: the scheme's current candidate set (hashable ids) — the OS reads
+    # this on the RePresent loop to detect convergence (``new = candidates - seen``;
+    # empty ⇒ stop). Default empty: schemes that never RePresent (universal /
+    # enumerate-all) leave it untouched, so it is inert for them.
+    candidates: tuple = field(default_factory=tuple)
 
 
 # ── Interpretation: the tagged union the OS loop dispatches on ──────────────
@@ -175,6 +180,14 @@ class SchemeOps(Protocol):
         Async (#1593 PR-2 seam call): enumerating the live catalog requires the
         async-built router caller-state (resource categories — skills/agents/mcp/
         rag — drop without it; the rag manifest fetch is the genuine await)."""
+        ...
+
+    async def search_actions(self, query: str, *, top_k: int = 10) -> list[str]:
+        """Rank usable actions by semantic match to ``query`` → matched qualified
+        action names (#1593 PR-4 retrieval). Reuses ``ActionEmbeddingIndex.query``
+        (embeds the dynamic query — async, the reason presentation is async). Returns
+        ``[]`` when the index/provider is unavailable (degrade). A generic search
+        building block — the OS holds no "retrieval" concept (P7)."""
         ...
 
 

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -1,0 +1,123 @@
+"""RetrievalScheme — RAG-over-tools, the scheme that exercises ``RePresent`` (#1593 PR-4).
+
+Instead of presenting the whole catalog, retrieval presents a **search tool** (+ the
+prior-shape base); the LLM searches, the OS re-presents the matched actions as
+callable tools, the LLM calls one. This is the namespace/retrieval paradigm for huge
+tool sets (no full-catalog token cost; the search narrows before the call), and it is
+the **only** scheme that uses the ``interpret → RePresent`` loop-back — proving the
+last unreached path of the PR-1 abstraction.
+
+Split (lead-approved design): ``interpret`` is a **pure classifier** (a ``search_actions``
+call → ``RePresent({query})`` with NO search I/O; any other call → ``Execute``).
+``build_presentation`` (async) owns the search I/O — given a refinement query it runs
+``ops.search_actions`` (embeds the dynamic query → async) and presents the matched
+catalog subset, exposing the matches as ``Presentation.candidates`` so the OS detects
+convergence (`new = candidates - seen`; empty ⇒ terminal). The OS RePresent loop is
+**bounded by construction** (monotonic ``seen`` on a finite action space + a terminal
+present that drops the search tool → guaranteed ``Execute`` exit). ``execute`` /
+``format_feedback`` reuse the universal dispatch substrate (``ops.dispatch`` /
+``ops.feedback``) — retrieval differs only in presentation + the RePresent round.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.tools.scheme import (
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    Interpretation,
+    Presentation,
+    RePresent,
+    SchemeOps,
+)
+
+_SEARCH_TOOL_NAME = "search_actions"
+
+
+def _search_tool_schema() -> dict:
+    """The presentable ``search_actions`` tool (name + query). The *call* is
+    intercepted by ``interpret`` → ``RePresent`` (never dispatched), so this only
+    needs to advertise the search affordance to the LLM."""
+    return {
+        "type": "function",
+        "function": {
+            "name": _SEARCH_TOOL_NAME,
+            "description": (
+                "Search for the tools you need by a natural-language query; the "
+                "matching tools are then presented for you to call directly."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "What you want to do, in natural language.",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+class RetrievalScheme:
+    """RAG-over-tools tool-use scheme (#1593 PR-4) — the ``RePresent`` exemplar."""
+
+    name = "retrieval"
+
+    async def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
+        base = list(ops.base_tools(available, layer_ctx))
+        sp_params = {
+            "universal_wrappers_enabled": False,
+            "search_actions_enabled": bool(layer_ctx.get("search_visible", False)),
+        }
+        refinement = layer_ctx.get("refinement")
+        if not refinement:
+            # Initial presentation: the base + the search tool (no catalog flood).
+            return Presentation(
+                llm_tools_payload=base + [_search_tool_schema()], sp_params=sp_params,
+            )
+        # Refined presentation: run the search (the async, dynamic-query I/O) and
+        # present the matched catalog subset (∪ everything already presented).
+        query = refinement.get("query", "")
+        matched = await ops.search_actions(query) if query else []
+        seen = set(layer_ctx.get("presented") or ())
+        keep = set(matched) | seen
+        catalog = await ops.catalog_entries()
+        matched_tools = [
+            t for t in catalog if t.get("function", {}).get("name") in keep
+        ]
+        tools = base + matched_tools
+        # Terminal present drops the search tool → the LLM must Execute (no re-search)
+        # → guarantees a non-RePresent exit (the OS convergence step).
+        if not layer_ctx.get("terminal", False):
+            tools = tools + [_search_tool_schema()]
+        return Presentation(
+            llm_tools_payload=tools, sp_params=sp_params, candidates=tuple(matched),
+        )
+
+    def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
+        # Pure classifier (no I/O): a search call → RePresent(query); the search I/O
+        # itself runs in build_presentation. Any other call → Execute (reuse the
+        # shared resolution so the OS exclude-gates pre-dispatch).
+        calls = getattr(llm_response, "tool_calls", None) or []
+        for tc in calls:
+            if tc.get("function", {}).get("name") == _SEARCH_TOOL_NAME:
+                try:
+                    args = json.loads(tc["function"].get("arguments", "{}"))
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    args = {}
+                return RePresent(refinement={"query": args.get("query", "")})
+        return Execute(actions=ops.resolve(llm_response, tool_catalog))
+
+    async def execute(self, interp: Interpretation, exec_ctx: ExecContext, ops: SchemeOps) -> ExecutionResult:
+        assert isinstance(interp, Execute), "retrieval routes RePresent via the OS loop"
+        results = await ops.dispatch(interp.actions)
+        return ExecutionResult(tool_results=results)
+
+    def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
+        return ops.feedback(result.tool_results)
+
+
+__all__ = ["RetrievalScheme"]

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -109,6 +109,11 @@ class RetrievalScheme:
         # present the matched catalog subset (∪ everything already presented).
         query = refinement.get("query", "")
         matched = await ops.search_actions(query) if query else []
+        # ``presented`` = the OS loop-local accumulator of every candidate shown so
+        # far this turn, threaded in by the OS RePresent arm (#1593 ratified seam:
+        # the accumulator is an OS loop-local, NOT scheme self-state — schemes are
+        # registered singletons, so per-turn self-state would collide across
+        # concurrent turns). The SCHEME self-determines convergence from it.
         seen = set(layer_ctx.get("presented") or ())
         keep = set(matched) | seen
         catalog = await ops.catalog_entries()
@@ -116,9 +121,14 @@ class RetrievalScheme:
             t for t in catalog if t.get("function", {}).get("name") in keep
         ]
         tools = base + matched_tools
-        # Terminal present drops the search tool → the LLM must Execute (no re-search)
-        # → guarantees a non-RePresent exit (the OS convergence step).
-        terminal = bool(layer_ctx.get("terminal", False))
+        # Convergence is the scheme's decision (the OS arm holds no convergence
+        # logic): the search yielded nothing NEW beyond what is already presented
+        # ⇒ terminal. A terminal present drops the search tool → the LLM can only
+        # Execute (no re-search) → guarantees a non-RePresent exit. Bounded by
+        # construction: ``seen`` grows monotonically over a finite action space, so
+        # ``new`` empties in finite rounds.
+        new = set(matched) - seen
+        terminal = not new
         if not terminal:
             tools = tools + [_search_tool_schema()]
         return Presentation(

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -27,6 +27,7 @@ from reyn.tools.scheme import (
     Execute,
     ExecutionResult,
     Interpretation,
+    PlainText,
     Presentation,
     RePresent,
     SchemeOps,
@@ -137,10 +138,15 @@ class RetrievalScheme:
         )
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
-        # Pure classifier (no I/O): a search call → RePresent(query); the search I/O
-        # itself runs in build_presentation. Any other call → Execute (reuse the
-        # shared resolution so the OS exclude-gates pre-dispatch).
+        # Pure classifier (no I/O): NO tool calls → PlainText (the model answered
+        # without searching/calling = done; the OS routes it to the terminal
+        # text-reply path — #1593 loop-unify binds this for every scheme). A search
+        # call → RePresent(query); the search I/O itself runs in build_presentation.
+        # Any other call → Execute (reuse the shared resolution so the OS
+        # exclude-gates pre-dispatch).
         calls = getattr(llm_response, "tool_calls", None) or []
+        if not calls:
+            return PlainText()
         for tc in calls:
             if tc.get("function", {}).get("name") == _SEARCH_TOOL_NAME:
                 try:

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -35,6 +35,32 @@ from reyn.tools.scheme import (
 _SEARCH_TOOL_NAME = "search_actions"
 
 
+def _search_sp(*, terminal: bool) -> str:
+    """The retrieval scheme's own tool-use instructions, supplied through the
+    ``Presentation.sp_fragment`` channel (#1601). Retrieval runs with
+    ``universal_wrappers_enabled=False`` — the OS's named-gate "## Action
+    categories" block is off — so without this fragment the LLM would see the
+    ``search_actions`` tool with no usage guidance. P7: the search paradigm is
+    the scheme's concept, so its SP text lives here, not in the OS.
+
+    ``terminal`` (= convergence reached, the search tool was dropped) flips the
+    instruction from "search first" to "call one of the presented matches"."""
+    if terminal:
+        return (
+            "## Finding tools\n"
+            "The tools matching your search are now available above. Call the "
+            "one that fits the request directly."
+        )
+    return (
+        "## Finding tools\n"
+        "You are not shown the full tool catalog up front. To act, first call "
+        "`search_actions(query=...)` with a natural-language description of what "
+        "you need; the matching tools are then presented for you to call "
+        "directly. Search before you act, and refine the query if the first "
+        "matches do not fit."
+    )
+
+
 def _search_tool_schema() -> dict:
     """The presentable ``search_actions`` tool (name + query). The *call* is
     intercepted by ``interpret`` → ``RePresent`` (never dispatched), so this only
@@ -77,6 +103,7 @@ class RetrievalScheme:
             # Initial presentation: the base + the search tool (no catalog flood).
             return Presentation(
                 llm_tools_payload=base + [_search_tool_schema()], sp_params=sp_params,
+                sp_fragment=_search_sp(terminal=False),
             )
         # Refined presentation: run the search (the async, dynamic-query I/O) and
         # present the matched catalog subset (∪ everything already presented).
@@ -91,10 +118,12 @@ class RetrievalScheme:
         tools = base + matched_tools
         # Terminal present drops the search tool → the LLM must Execute (no re-search)
         # → guarantees a non-RePresent exit (the OS convergence step).
-        if not layer_ctx.get("terminal", False):
+        terminal = bool(layer_ctx.get("terminal", False))
+        if not terminal:
             tools = tools + [_search_tool_schema()]
         return Presentation(
             llm_tools_payload=tools, sp_params=sp_params, candidates=tuple(matched),
+            sp_fragment=_search_sp(terminal=terminal),
         )
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:

--- a/tests/test_represent_arm_1593.py
+++ b/tests/test_represent_arm_1593.py
@@ -1,0 +1,178 @@
+"""Tier 3a: the OS RePresent arm in run_loop (#1593 PR-4) — the generic re-present
+mechanism, exercised with a generic Fake RePresent scheme (NOT retrieval, so the
+test does not depend on an embedding index — the arm is scheme-agnostic by design).
+
+The arm, when the active scheme's ``interpret`` returns ``RePresent``:
+  1. records the assistant turn + a synthetic tool-response (``_REPRESENT_ACK``)
+     for each intercepted tool_call (OpenAI requires every tool_call answered),
+  2. re-calls ``build_presentation`` with the refinement + the OS loop-local
+     ``presented`` accumulator,
+  3. swaps the advertised ``tools`` (+ the dispatch ``_catalog`` mirror),
+  4. ``continue``s the main iteration (re-query) — so the next LLM turn sees the
+     re-presented tools.
+Convergence is the SCHEME's (it self-determines terminal); the OS arm holds a
+defensive round backstop (``_MAX_REPRESENT_ROUNDS``) that fires only for a scheme
+that never terminates. These pin both.
+
+No mocks — a real Fake scheme + the real ``_ScriptedLLM`` Fake (testing.ja.md).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import _MAX_REPRESENT_ROUNDS, _REPRESENT_ACK
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.tools.scheme import (
+    Execute,
+    ExecutionResult,
+    PlainText,
+    Presentation,
+    RePresent,
+)
+from tests.test_router_loop import FakeRouterHost, make_loop, text_result, tool_result
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _search_tool() -> dict:
+    return {"type": "function", "function": {"name": "search", "description": "",
+                                             "parameters": {"type": "object", "properties": {}}}}
+
+
+def _matched_tool() -> dict:
+    return {"type": "function", "function": {"name": "matched_action", "description": "",
+                                             "parameters": {"type": "object", "properties": {}}}}
+
+
+class _FakeRepresentScheme:
+    """A minimal scheme that emits RePresent on a ``search`` call (so the OS arm
+    runs) and PlainText otherwise. ``build_presentation`` presents the search tool
+    initially and a matched tool (+ candidates) on refinement, converging when the
+    match is already in ``presented``."""
+
+    name = "fake-represent"
+
+    def __init__(self, *, never_converge: bool = False) -> None:
+        self.never_converge = never_converge
+        self.represent_calls: list[Any] = []
+
+    async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
+        sp_params = {"universal_wrappers_enabled": False, "search_actions_enabled": False}
+        refinement = layer_ctx.get("refinement")
+        if not refinement:
+            return Presentation(llm_tools_payload=[_search_tool()], sp_params=sp_params)
+        self.represent_calls.append({
+            "refinement": refinement, "presented": layer_ctx.get("presented"),
+        })
+        if self.never_converge:
+            # Always advertise a fresh candidate → the OS accumulator keeps growing
+            # but the scheme never drops the search tool (a misbehaving scheme).
+            tag = f"action_{len(self.represent_calls)}"
+            return Presentation(
+                llm_tools_payload=[_matched_tool(), _search_tool()],
+                sp_params=sp_params, candidates=(tag,),
+            )
+        return Presentation(
+            llm_tools_payload=[_matched_tool()], sp_params=sp_params,
+            candidates=("matched_action",),
+        )
+
+    def interpret(self, llm_response, *, tool_catalog, ops):
+        calls = getattr(llm_response, "tool_calls", None) or []
+        if not calls:
+            return PlainText()
+        for tc in calls:
+            if tc["function"]["name"] == "search":
+                return RePresent(refinement={"query": "x"})
+        return Execute(actions=[])
+
+    async def execute(self, interp, exec_ctx, ops):
+        return ExecutionResult(tool_results=[])
+
+    def format_feedback(self, result, ops):
+        return []
+
+
+class _CapturingScriptedLLM:
+    """A scripted LLM Fake that records the ``messages`` and ``tools`` each call saw
+    (so the test can assert the re-presentation reached the next LLM turn)."""
+
+    def __init__(self, script: list[LLMToolCallResult]) -> None:
+        self._script = list(script)
+        self.call_count = 0
+        self.tools_per_call: list[list[dict]] = []
+        self.messages_per_call: list[list[dict]] = []
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.tools_per_call.append(list(kwargs.get("tools") or []))
+        self.messages_per_call.append([dict(m) for m in (kwargs.get("messages") or [])])
+        result = self._script[self.call_count]
+        self.call_count += 1
+        return result
+
+
+@pytest.mark.asyncio
+async def test_represent_round_appends_ack_swaps_tools_and_requeries(monkeypatch):
+    """Tier 3a: a RePresent round appends the synthetic ack + swaps tools, and the
+    NEXT LLM turn sees the re-presented tools — then a no-tool-call (PlainText)
+    reply exits the loop. Pins the full re-present → re-query → exit cycle."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    scheme = _FakeRepresentScheme()
+    loop._scheme = scheme
+
+    scripted = _CapturingScriptedLLM([
+        tool_result([{"name": "search", "id": "s1"}]),   # → RePresent
+        text_result("here is your answer"),              # → PlainText → exit
+    ])
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", scripted)
+
+    messages = [{"role": "user", "content": "find a tool for me"}]
+    await loop.run_loop(messages, [_search_tool()], False)
+
+    # Re-queried once after the re-present.
+    assert scripted.call_count == 2
+    # build_presentation was re-called with the refinement + the (empty-on-first)
+    # presented accumulator.
+    assert scheme.represent_calls == [{"refinement": {"query": "x"}, "presented": ()}]
+    # The synthetic ack answers the intercepted search tool_call in the history.
+    assert any(
+        m.get("role") == "tool" and m.get("content") == _REPRESENT_ACK
+        and m.get("tool_call_id") == "s1"
+        for m in messages
+    )
+    # The SECOND LLM turn saw the re-presented (swapped) tools — matched_action, not
+    # the original search tool.
+    second_tool_names = {t["function"]["name"] for t in scripted.tools_per_call[1]}
+    assert second_tool_names == {"matched_action"}
+    # The loop exited via the PlainText text-reply path.
+    assert host.outbox and host.outbox[-1]["text"] == "here is your answer"
+    # A P6 audit event was emitted for the re-present round.
+    assert any(e["type"] == "router_represent_round" for e in host.events.emitted)
+
+
+@pytest.mark.asyncio
+async def test_represent_backstop_raises_on_nonconverging_scheme(monkeypatch):
+    """Tier 3a: the defensive backstop — a scheme that NEVER converges (always
+    RePresents, never drops the search tool) + an LLM that always re-searches is
+    stopped at ``_MAX_REPRESENT_ROUNDS`` with a clear error, rather than looping
+    unboundedly. (Normal schemes converge by construction; this valve is for a
+    misbehaving one.)"""
+    host = FakeRouterHost()
+    # max_iterations above the backstop so the backstop (not iteration exhaustion)
+    # is what fires.
+    loop = make_loop(host, max_iterations=_MAX_REPRESENT_ROUNDS + 50)
+    loop._scheme = _FakeRepresentScheme(never_converge=True)
+
+    always_search = tool_result([{"name": "search", "id": "s1"}])
+    scripted = _CapturingScriptedLLM([always_search] * (_MAX_REPRESENT_ROUNDS + 10))
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", scripted)
+
+    messages = [{"role": "user", "content": "loop forever"}]
+    with pytest.raises(RuntimeError, match="did not converge"):
+        await loop.run_loop(messages, [_search_tool()], False)
+    # Stopped at the backstop, not after unbounded rounds.
+    assert scripted.call_count == _MAX_REPRESENT_ROUNDS + 1

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -98,6 +98,32 @@ async def test_terminal_presentation_drops_search_tool(tmp_path) -> None:
     assert _SEARCH_TOOL_NAME not in names                 # search dropped → must Execute
 
 
+@pytest.mark.asyncio
+async def test_initial_presentation_supplies_search_sp_fragment(tmp_path) -> None:
+    """Tier 2: #1601 channel — retrieval runs with universal_wrappers_enabled=False
+    (named-gate SP off), so it MUST supply its own search-tool instructions through
+    Presentation.sp_fragment, else the LLM sees search_actions with no guidance."""
+    ops = _FakeOps()
+    pres = await RetrievalScheme().build_presentation({}, {}, ops)
+    assert pres.sp_params["universal_wrappers_enabled"] is False   # named-gate SP off
+    assert pres.sp_fragment                                        # scheme supplies its own
+    assert _SEARCH_TOOL_NAME in pres.sp_fragment                   # tells the LLM to search first
+
+
+@pytest.mark.asyncio
+async def test_terminal_presentation_sp_fragment_reflects_dropped_search(tmp_path) -> None:
+    """Tier 2: when the presentation is terminal (search tool dropped), the
+    sp_fragment flips from "search first" to "call one of the presented matches"
+    — the SP and the tools= stay consistent (no dangling search instruction)."""
+    ops = _FakeOps(matches=["file__write"], catalog=[_tool("file__write")])
+    pres = await RetrievalScheme().build_presentation(
+        {}, {"refinement": {"query": "edit"}, "terminal": True}, ops,
+    )
+    assert pres.sp_fragment                                        # still guided
+    assert _SEARCH_TOOL_NAME not in pres.sp_fragment               # no "call search_actions" — it's gone
+    assert "available" in pres.sp_fragment.lower()                 # "matching tools are now available"
+
+
 def test_interpret_search_call_is_represent_pure() -> None:
     """Tier 2: a search call → RePresent(query), with NO search I/O in interpret
     (pure classifier — the search runs in build_presentation)."""

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -86,16 +86,32 @@ async def test_refined_presentation_runs_search_and_exposes_candidates(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_terminal_presentation_drops_search_tool(tmp_path) -> None:
-    """Tier 2: a terminal presentation drops the search tool → the LLM can only
-    Execute (no re-search) → guarantees the OS RePresent loop exits."""
+async def test_convergence_drops_search_tool(tmp_path) -> None:
+    """Tier 2: the SCHEME self-determines terminal (#1593 ratified seam — the OS arm
+    holds no convergence logic). When the search yields nothing NEW beyond what the
+    OS already threaded in via ``presented`` (matched ⊆ presented ⇒ new == ∅), the
+    presentation is terminal: it drops the search tool → the LLM can only Execute
+    (no re-search) → the OS RePresent loop exits."""
     ops = _FakeOps(matches=["file__write"], catalog=[_tool("file__write")])
     pres = await RetrievalScheme().build_presentation(
-        {}, {"refinement": {"query": "edit"}, "terminal": True}, ops,
+        {}, {"refinement": {"query": "edit"}, "presented": ("file__write",)}, ops,
     )
     names = {t["function"]["name"] for t in pres.llm_tools_payload}
     assert "file__write" in names
-    assert _SEARCH_TOOL_NAME not in names                 # search dropped → must Execute
+    assert _SEARCH_TOOL_NAME not in names                 # converged → search dropped → must Execute
+
+
+@pytest.mark.asyncio
+async def test_new_matches_keep_search_tool(tmp_path) -> None:
+    """Tier 2: the contrast — a search that yields a match NOT yet presented
+    (new != ∅) is non-terminal: the search tool stays so the LLM may refine again.
+    Pins that the terminal decision is the scheme's, driven by new-vs-presented."""
+    ops = _FakeOps(matches=["file__read"], catalog=[_tool("file__read"), _tool("file__write")])
+    pres = await RetrievalScheme().build_presentation(
+        {}, {"refinement": {"query": "read"}, "presented": ("file__write",)}, ops,
+    )
+    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    assert _SEARCH_TOOL_NAME in names                     # file__read is new → not converged → search stays
 
 
 @pytest.mark.asyncio
@@ -112,12 +128,12 @@ async def test_initial_presentation_supplies_search_sp_fragment(tmp_path) -> Non
 
 @pytest.mark.asyncio
 async def test_terminal_presentation_sp_fragment_reflects_dropped_search(tmp_path) -> None:
-    """Tier 2: when the presentation is terminal (search tool dropped), the
+    """Tier 2: when the presentation converges to terminal (search tool dropped), the
     sp_fragment flips from "search first" to "call one of the presented matches"
     — the SP and the tools= stay consistent (no dangling search instruction)."""
     ops = _FakeOps(matches=["file__write"], catalog=[_tool("file__write")])
     pres = await RetrievalScheme().build_presentation(
-        {}, {"refinement": {"query": "edit"}, "terminal": True}, ops,
+        {}, {"refinement": {"query": "edit"}, "presented": ("file__write",)}, ops,
     )
     assert pres.sp_fragment                                        # still guided
     assert _SEARCH_TOOL_NAME not in pres.sp_fragment               # no "call search_actions" — it's gone

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -1,0 +1,130 @@
+"""Tier 2: RetrievalScheme — the RePresent-exemplar scheme (#1593 PR-4, scheme side).
+
+These pin the scheme's 4 methods in isolation (a recording Fake SchemeOps — real
+callables, no mocks): the search-tool-first initial presentation, the refined
+presentation (run search → matched subset + candidates), the terminal presentation
+(search tool dropped → forces Execute), and the **pure** interpret classifier
+(search call → RePresent(query) with NO search I/O; other call → Execute). The OS
+RePresent convergence loop (which consumes Presentation.candidates) is exercised
+end-to-end when it lands in the dispatch RePresent arm (PR-3-sequenced).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.tools.scheme import ExecContext, Execute, ExecutionResult, RePresent
+from reyn.tools.schemes.retrieval import _SEARCH_TOOL_NAME, RetrievalScheme
+
+
+class _Resp:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+def _call(name, **args):
+    import json
+    return {"function": {"name": name, "arguments": json.dumps(args)}}
+
+
+class _FakeOps:
+    """Recording Fake SchemeOps — base/catalog/search return fixtures; the dispatch
+    path delegates are identity-ish."""
+
+    def __init__(self, matches=None, catalog=None):
+        self._matches = matches or []
+        self._catalog = catalog or []
+        self.calls = []
+
+    def base_tools(self, available, layer_ctx):
+        return [{"type": "function", "function": {"name": "respond"}}]
+
+    async def search_actions(self, query, *, top_k=10):
+        self.calls.append(("search", query))
+        return list(self._matches)
+
+    async def catalog_entries(self):
+        return list(self._catalog)
+
+    def resolve(self, llm_response, tool_catalog):
+        return [{"tc": tc, "name": tc["function"]["name"], "args": {}} for tc in llm_response.tool_calls]
+
+    async def dispatch(self, actions):
+        return [{"status": "ok", "for": a["name"]} for a in actions]
+
+    def feedback(self, tool_results):
+        return tool_results
+
+
+def _tool(name):
+    return {"type": "function", "function": {"name": name, "description": "", "parameters": {}}}
+
+
+@pytest.mark.asyncio
+async def test_initial_presentation_shows_search_tool(tmp_path) -> None:
+    """Tier 2: with no refinement, retrieval presents base + the search tool (NOT
+    the whole catalog) — the narrowing-before-call posture."""
+    ops = _FakeOps()
+    pres = await RetrievalScheme().build_presentation({}, {}, ops)
+    names = [t["function"]["name"] for t in pres.llm_tools_payload]
+    assert _SEARCH_TOOL_NAME in names and "respond" in names
+    assert ops.calls == []                                # no search yet (no refinement)
+
+
+@pytest.mark.asyncio
+async def test_refined_presentation_runs_search_and_exposes_candidates(tmp_path) -> None:
+    """Tier 2: given a refinement query, build_presentation runs the search and
+    presents the matched catalog subset + the search tool, exposing the matches as
+    Presentation.candidates (the OS convergence signal)."""
+    ops = _FakeOps(matches=["file__write", "file__read"], catalog=[_tool("file__write"), _tool("file__read"), _tool("web__fetch")])
+    pres = await RetrievalScheme().build_presentation({}, {"refinement": {"query": "edit a file"}}, ops)
+    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    assert {"file__write", "file__read"} <= names         # matched subset presented
+    assert "web__fetch" not in names                      # unmatched NOT presented
+    assert _SEARCH_TOOL_NAME in names                     # search stays (non-terminal)
+    assert pres.candidates == ("file__write", "file__read")  # candidates for OS convergence
+    assert ops.calls == [("search", "edit a file")]       # the dynamic query ran
+
+
+@pytest.mark.asyncio
+async def test_terminal_presentation_drops_search_tool(tmp_path) -> None:
+    """Tier 2: a terminal presentation drops the search tool → the LLM can only
+    Execute (no re-search) → guarantees the OS RePresent loop exits."""
+    ops = _FakeOps(matches=["file__write"], catalog=[_tool("file__write")])
+    pres = await RetrievalScheme().build_presentation(
+        {}, {"refinement": {"query": "edit"}, "terminal": True}, ops,
+    )
+    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    assert "file__write" in names
+    assert _SEARCH_TOOL_NAME not in names                 # search dropped → must Execute
+
+
+def test_interpret_search_call_is_represent_pure() -> None:
+    """Tier 2: a search call → RePresent(query), with NO search I/O in interpret
+    (pure classifier — the search runs in build_presentation)."""
+    ops = _FakeOps()
+    interp = RetrievalScheme().interpret(
+        _Resp([_call(_SEARCH_TOOL_NAME, query="edit a file")]), tool_catalog={}, ops=ops,
+    )
+    assert isinstance(interp, RePresent)
+    assert interp.refinement == {"query": "edit a file"}
+    assert ops.calls == []                                # interpret did NOT search (pure)
+
+
+def test_interpret_tool_call_is_execute() -> None:
+    """Tier 2: a non-search tool call → Execute (reuses the shared resolution so the
+    OS exclude-gates pre-dispatch)."""
+    interp = RetrievalScheme().interpret(
+        _Resp([_call("file__write", path="x")]), tool_catalog={}, ops=_FakeOps(),
+    )
+    assert isinstance(interp, Execute)
+    assert [a["name"] for a in interp.actions] == ["file__write"]
+
+
+@pytest.mark.asyncio
+async def test_execute_and_feedback_delegate() -> None:
+    """Tier 2: execute/format_feedback reuse the universal dispatch substrate."""
+    ops = _FakeOps()
+    scheme = RetrievalScheme()
+    res = await scheme.execute(Execute(actions=[{"name": "file__write"}]), ExecContext(), ops)
+    assert res.tool_results == [{"status": "ok", "for": "file__write"}]
+    assert scheme.format_feedback(ExecutionResult(tool_results=res.tool_results), ops) == res.tool_results

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -162,6 +162,16 @@ def test_interpret_tool_call_is_execute() -> None:
     assert [a["name"] for a in interp.actions] == ["file__write"]
 
 
+def test_interpret_no_tool_call_is_plaintext() -> None:
+    """Tier 2: NO tool calls → PlainText — the model answered without searching
+    (#1593 loop-unify binds PlainText as the terminal text-reply for every scheme).
+    Without this, the loop-unified OS would route an empty-actions Execute through
+    the tool path instead of the text reply."""
+    from reyn.tools.scheme import PlainText
+    interp = RetrievalScheme().interpret(_Resp([]), tool_catalog={}, ops=_FakeOps())
+    assert isinstance(interp, PlainText)
+
+
 @pytest.mark.asyncio
 async def test_execute_and_feedback_delegate() -> None:
     """Tier 2: execute/format_feedback reuse the universal dispatch substrate."""


### PR DESCRIPTION
**[e2e-coder]** — #1593 PR-4: the **retrieval** tool-use scheme + the **OS RePresent convergence arm** (the last unreached `Interpretation` arm).

Retrieval is RAG-over-tools: instead of presenting the whole catalog, it presents a **search tool**; the LLM searches, the OS re-presents the matched actions as callable tools, the LLM calls one. This proves the `interpret → RePresent` loop-back — the last path of the PR-1 abstraction no prior scheme exercised.

## Division (ratified #1593 seam — issuecomment-4700940600)

- **OS RePresent arm = pure generic mechanism** (no convergence logic, P7 — works for any RePresent scheme):
  1. records the assistant turn + a synthetic tool-response (`_REPRESENT_ACK`, OS-generic ack) for each intercepted tool_call — the scheme turned it into a RePresent (never dispatched) but OpenAI requires every tool_call answered;
  2. re-calls `build_presentation` with the refinement + the OS loop-local `presented` accumulator;
  3. swaps `tools` + the dispatch `_catalog` mirror;
  4. `continue`s the main iteration (budget/compaction/force-close/memo all keep applying — no inner LLM loop).
  - `_MAX_REPRESENT_ROUNDS` defensive backstop (valve, not the bound).
- **Convergence = the SCHEME's** (retrieval.py): `build_presentation` reads the OS-threaded `presented`, computes `new = matched - presented`, self-determines `terminal = (new == ∅)`, drops the search tool on terminal → forces Execute.

### Why `presented` is an OS loop-local (the seam-owner correction lead ratified)
Schemes are registered **singletons** (`scheme.py`: `_SCHEMES[name] = scheme`, `get_scheme` returns the shared instance), so per-turn `seen`/`presented` as scheme self-state would **collide across concurrent turns/sessions**. The accumulator lives as an OS loop-local; the scheme is a pure `(refinement, presented) → Presentation` function.

**Bounded by construction:** monotonic `presented` on a finite catalog + the scheme's terminal-search-drop → guaranteed Execute exit. Not a magic retry cap.

## Changes
- `tools/schemes/retrieval.py` — `RetrievalScheme`: search-tool-first presentation; `interpret` = pure classifier (search → RePresent, no-call → PlainText, else Execute); search-SP via `Presentation.sp_fragment` (dogfoods #1601 — retrieval runs `universal_wrappers_enabled=False`, so the named-gate SP is off); scheme self-determined terminal.
- `tools/scheme.py` — `Presentation.candidates` (the OS convergence signal).
- `chat/router_loop.py` — `search_actions` SchemeOps adapter (`ActionEmbeddingIndex.query`, async); `RetrievalScheme` registration; the inline RePresent arm + `run()` stash + `_REPRESENT_ACK`/`_MAX_REPRESENT_ROUNDS`.

## Test plan
- [x] `tests/test_represent_arm_1593.py` — 2 Tier-3a (generic Fake RePresent scheme — the arm is scheme-agnostic, tested without retrieval's embedding index): full re-present→ack+tools-swap→re-query→PlainText-exit cycle; the defensive backstop raising on a non-converging scheme. **Real Fakes, no mocks.**
- [x] `tests/test_retrieval_scheme_1593.py` — 11 Tier-2 (recording Fake SchemeOps): search-tool-first presentation, refined search→matched+candidates, scheme-self-determined convergence (matched ⊆ presented ⇒ search dropped) + the new-match contrast, search-SP via sp_fragment (+ terminal flip), interpret search→RePresent (pure) / tool→Execute / no-call→PlainText, execute/feedback delegate.
- [x] Broad scheme/router/interpret/represent/enumerate/retrieval regression → **622 passed**.
- [x] Full suite `pytest -q` rootdir → **7283 passed** (the 2 fails — `test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref` — are pre-existing local-env failures, fail on clean origin/main too; CI's clean env passes them, not this diff).
- [x] `ruff check` + `test_tier_audit.py --strict` on changed files → clean.
- [x] (deferred → tracked in #1604) live-LLM retrieval run on a real model + embedding index. Retrieval is **not a production-selectable scheme yet** (config defaults to universal-category), so this is a pre-*enablement* gate, not pre-merge; the arm + scheme are fully proven via Fakes. Needs a configured embedding class.

## Sequencing
Built on #1602 (loop-unify, merged) per shared-dependency-first. The RePresent arm fills the inline `case RePresent` #1602 reserved as `raise`. sandbox_2 co-vets the arm + `Presentation.candidates`; lead byte-identical/architecture review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

