### PR TITLE
feat(1593) PR-4 follow-up: or-[] guard on RePresent arm (sandbox_2 co-vet note, post-merge)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2051,12 +2051,17 @@ class RouterLoop:
                         f"({_MAX_REPRESENT_ROUNDS} rounds) — the active scheme is not "
                         "terminating its re-present loop"
                     )
+                # ``or []`` guard (sandbox_2 co-vet): retrieval always RePresents off
+                # a tool_call (the search), but the arm is GENERIC — a future scheme
+                # could re-present off assistant text (no tool_call), in which case
+                # there is simply nothing to synthetic-answer.
+                _re_tool_calls = result.tool_calls or []
                 messages.append({
                     "role": "assistant",
                     "content": result.content or "",
-                    "tool_calls": result.tool_calls,
+                    "tool_calls": _re_tool_calls,
                 })
-                for _tc in result.tool_calls:
+                for _tc in _re_tool_calls:
                     messages.append({
                         "role": "tool",
                         "tool_call_id": _tc["id"],

--- a/tests/test_represent_arm_1593.py
+++ b/tests/test_represent_arm_1593.py
@@ -154,6 +154,58 @@ async def test_represent_round_appends_ack_swaps_tools_and_requeries(monkeypatch
     assert any(e["type"] == "router_represent_round" for e in host.events.emitted)
 
 
+class _TextRepresentScheme:
+    """A scheme that re-presents off assistant TEXT (no tool_call) the first turn,
+    then PlainText — pins that the generic OS arm handles a RePresent with no
+    tool_call to answer (sandbox_2 ``or []`` robustness note)."""
+
+    name = "text-represent"
+
+    def __init__(self) -> None:
+        self.represented = False
+
+    async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
+        sp_params = {"universal_wrappers_enabled": False, "search_actions_enabled": False}
+        return Presentation(llm_tools_payload=[_matched_tool()], sp_params=sp_params,
+                            candidates=("matched_action",))
+
+    def interpret(self, llm_response, *, tool_catalog, ops):
+        if not self.represented:
+            self.represented = True
+            return RePresent(refinement={"q": "x"})   # off text — no tool_call
+        return PlainText()
+
+    async def execute(self, interp, exec_ctx, ops):
+        return ExecutionResult(tool_results=[])
+
+    def format_feedback(self, result, ops):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_represent_without_tool_call_does_not_error(monkeypatch):
+    """Tier 3a: the generic arm handles a RePresent emitted off assistant text (no
+    tool_call) — nothing to synthetic-answer, just re-present + ``continue``. Pins
+    the ``or []`` guard so the arm stays generic for non-retrieval RePresent schemes."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    loop._scheme = _TextRepresentScheme()
+
+    scripted = _CapturingScriptedLLM([
+        text_result("I need different tools"),   # → RePresent (off text)
+        text_result("done"),                     # → PlainText → exit
+    ])
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", scripted)
+
+    messages = [{"role": "user", "content": "go"}]
+    await loop.run_loop(messages, [_search_tool()], False)   # no exception
+
+    assert scripted.call_count == 2
+    # No synthetic tool-response was appended (there was no tool_call to answer).
+    assert not any(m.get("content") == _REPRESENT_ACK for m in messages)
+    assert host.outbox and host.outbox[-1]["text"] == "done"
+
+
 @pytest.mark.asyncio
 async def test_represent_backstop_raises_on_nonconverging_scheme(monkeypatch):
     """Tier 3a: the defensive backstop — a scheme that NEVER converges (always


### PR DESCRIPTION
**[e2e-coder]** — small follow-up to #1603 (merged): the `or []` robustness guard on the OS RePresent arm + its test.

## Context (merge race — low impact)
sandbox_2's #1603 seam co-vet was **PASS with one non-blocking robustness note** (`for _tc in result.tool_calls` → guard `or []` for a future text-driven RePresent scheme). I pushed the fix (091e9b0c) ~47s **after** lead merged #1603 (108699f9), so it didn't make the merge. This lands it cleanly off current main.

**No production risk in merged #1603**: the OS arm is generic, but the only RePresent scheme today (retrieval) always re-presents off a `search_actions` tool_call, so `result.tool_calls` is never None and the merged arm works correctly. This guard is **forward-robustness** for a future scheme that re-presents off assistant *text* (no tool_call).

## Change
- `chat/router_loop.py` — `_re_tool_calls = result.tool_calls or []`; the assistant-message append + the synthetic-`_REPRESENT_ACK` loop both use it. When a RePresent carries no tool_call, there is simply nothing to synthetic-answer (the re-present + `continue` still happen).
- `tests/test_represent_arm_1593.py` — `test_represent_without_tool_call_does_not_error` (Tier 3a): a Fake scheme that RePresents off text drives the arm without error and appends no `_REPRESENT_ACK`.

## Test plan
- [x] `tests/test_represent_arm_1593.py` → 3 passed (the 2 existing arm tests + the new no-tool-call one).
- [x] `ruff check` + `test_tier_audit.py --strict` on changed files → clean.

Cherry-picked from 091e9b0c onto current main (108699f9). lead fast review + merge per the merge-race plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
