### PR TITLE
feat(1593): PR-3 — CodeAct tool-use scheme (sandboxed code-API, completes the 4-scheme abstraction)

### DIFF
--- a/docs/deep-dives/journal/1593-pr3-codeact-staging-design.md
+++ b/docs/deep-dives/journal/1593-pr3-codeact-staging-design.md
@@ -1,0 +1,223 @@
+# #1593 PR-3 — CodeAct scheme: staging design (pre-build, for design-review)
+
+**Author:** dogfood-coder · **Status:** design-review gate (lead + e2e seam co-vet) · **Base:** `feat/1593-pr3-codeact` off `f093d3f2` (PR-1 merged)
+
+Owner has **security-signed-off** the CodeAct model (`既存再利用の方向で confirm`). This
+doc is the **build-front gate** lead required: *flow-trace-first (load-bearing OS-core)
+→ staging → design-review → build*. Security model + correspondence table are settled
+(#1593 issuecomment-4700512872 + addenda); this doc adds the two build-phase decisions
+the flow-trace surfaced and the single-owned shared seam lead flagged.
+
+---
+
+## 1. Flow-trace (primary evidence — load-bearing OS-core seams PR-3 rides)
+
+Traced on the merged base. Each seam read directly (not inferred):
+
+### Seam 1 — `sandboxed_exec` op handler (`op_runtime/sandboxed_exec.py`)
+```
+handle(op, ctx, caller):
+  backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)   # FP-0008 C7#2
+  policy  = SandboxPolicy(**ctx.default_sandbox_policy)  if set              # #1326 operator WINS over op
+            else SandboxPolicy(network/read/write/allow_subprocess/.../timeout from op)
+  cwd     = ctx.workspace.base_dir
+  emit sandboxed_exec_started (ACTUAL enforced policy values, #1339)         # P6
+  result  = await backend.run(argv, policy, cwd=cwd, cancel_event=ctx.cancel_event)
+  emit sandboxed_exec_completed | sandboxed_exec_cancelled (#1470)           # P6
+  return {kind, status, backend, returncode, stdout, stderr, truncated}
+```
+**Reuse for PR-3:** the SandboxBackend selection + `#1326` operator-policy-wins + the
+P6 event shape + cancel_event plumbing are all directly reusable.
+
+### Seam 2 — `python_runner` + `_python_harness` (the subprocess harness)
+- `PythonRunner.run(...)` builds a **JSON request** (`module_path`, `function`, `mode`,
+  `artifact`, `allowed_modules`, `file_read_paths`, `file_write_paths`, `http_hosts`,
+  `sandbox_write_paths`) → `argv = [py, -m, reyn.kernel._python_harness]`.
+- Backend route (#1352-B): `sandbox_backend` real+available+not-noop → `_run_via_backend`
+  (harness argv through `backend.run`, OS-sandboxed) else `_run_direct` (unsandboxed).
+- **Both paths use `subprocess.run(..., capture_output=True)` / `backend.run` →
+  single-shot**: stdin in, stdout captured *after the child exits*. There is **no
+  interleaved read during execution**.
+- Harness (`_python_harness.main`): `_read_request()` (stdin once) → `_exec_user_module`
+  (AST-validate in `safe` mode + restricted `__builtins__` via `_build_restricted_builtins`)
+  → push static permission contexts (`reyn.safe.file/http/embed_index._set_*_context`
+  from the forwarded allowlists) → `fn(deepcopy(artifact))` → `_write_response()` (stdout
+  once) → exit.
+
+**Two structural facts that drive PR-3:**
+1. **The harness is a pure one-shot** — request in, result out, no parent callback. (As
+   lead's correspondence states: this is *why* the permission-proxy IPC is the only new
+   mechanism.)
+2. **The existing `safe.*` gating is "push static allowlist, then run"** — paths/hosts
+   known up-front, self-gated *in the child*. This model **cannot express dynamic
+   tool-call gating** (the tool + args aren't pre-declarable; the gate is the parent's
+   `permission_resolver`, which lives in the parent OS per P5).
+
+### Seam 3 — `dispatch_tool` (the parent gate — `dispatch/dispatcher.py`)
+```
+dispatch_tool(*, name, args, ctx: DispatchContext, invoker, op_invocation_id=None) -> dict
+  → {status:"ok", data:...} | {status:"error", error:{kind, message}}
+  kinds: unknown_tool | invalid_args | permission_denied | exception
+  emits P6: tool_called / tool_returned / tool_failed (+ result/args_hash for resume-replay)
+  PermissionError inside invoker → "permission_denied"
+```
+**This is the gate the permission-proxy calls.** The child never holds permission
+authority; every effect round-trips to this parent function (P5 preserved unchanged).
+
+---
+
+## 2. Build-phase decision A — IPC transport (resolves my prior open question)
+
+My prior design (#1593) left an open question: *"IPC mechanism: stdin/stdout JSON-RPC
+over the existing harness pipe vs a socket — lean JSON-RPC over the existing pipe."*
+
+**The flow-trace falsifies the "existing pipe" lean.** The harness stdin/stdout pipe is
+consumed **single-shot** by `subprocess.run(capture_output=True)` / `backend.run` — stdout
+is read only *after* the child exits. Real CodeAct interleaves computation with
+**synchronous mid-execution `tool()` calls**, so it needs a **duplex channel live during
+execution**. The existing one-shot pipe cannot carry it.
+
+**Recommendation: a dedicated duplex side-channel (socketpair), serviced concurrently.**
+```
+parent: parent_sock, child_sock = socket.socketpair()
+        launch harness via Popen(pass_fds=[child_sock.fileno()],  # inherited, NOT stdin/stdout
+                                  env={REYN_CODEACT_CTRL_FD: <n>})
+        await asyncio.gather(
+            _wait_child(proc),                  # collects final stdout/stderr/returncode
+            _service_control_socket(parent_sock))   # loop: read {tool,args} → dispatch_tool → write result
+child:  tool(name, **args): marshal {tool,args} over fd → block on reply → return result.data
+                            (the ONLY world-effect path; raw internals absent from namespace)
+```
+**Why a dedicated CodeAct execution path, NOT extending `backend.run`:** the single-shot
+`backend.run` is load-bearing for `sandboxed_exec` + python preprocessor steps. Adding a
+duplex-callback arm to that Protocol forces every backend (seatbelt/landlock/noop) to grow
+a concurrent-service surface — destabilizing the stable interface for a single consumer.
+A dedicated `CodeActRunner` **reuses** SandboxPolicy + the profile/`pass_fds` spawn
+helpers + the harness namespace-injection pattern, while **localizing** the duplex
+complexity. (Sandbox compatibility: an inherited socket fd survives Seatbelt — inherited
+fds are usable by default — and Landlock — its rules govern *filesystem* paths, not an
+already-open socket. The fd is the single, audited hole; it carries **only** marshalled
+tool-call requests, each re-gated by the parent's exclude + permission + `dispatch_tool`
+pipeline.)
+
+> **Design-review question 1 (lead):** confirm the dedicated `CodeActRunner` (duplex
+> socketpair + concurrent parent service loop, reusing policy/profile/harness-namespace)
+> over extending `SandboxBackend.run` with a callback arm. This is the load-bearing
+> transport decision; everything else is wiring.
+
+---
+
+## 3. Build-phase decision B — the 3-arm match (lead's single-ownership flag)
+
+Lead flagged: my Execute-only note is the **shared seam** between PR-3 (CodeBlock) and
+PR-4 (RePresent). To avoid a 3-way conflict / double-patch, **PR-3 single-owns** the
+clean generalization of `_run_scheme_tool_round` from the current
+`assert isinstance(interp, Execute)` to a **3-arm tagged-union match**:
+
+```python
+interp = self._scheme.interpret(llm_response, tool_catalog=self._catalog, ops=self)
+match interp:
+    case Execute():    # today's path — byte-identical (resolve→exclude-gate→dispatch→feedback)
+        ...
+    case CodeBlock():  # PR-3 CodeAct — run via CodeActRunner; each proxied call re-enters
+                       #   the SAME OS exclude+permission+dispatch_tool pipeline (per-call)
+        ...
+    case RePresent():  # PR-4 — bounded re-present loop
+        ...
+```
+**RePresent arm ownership — AGREED with e2e** (seam arbitration, #1593 issuecomment-4700737708 §2 + broker 04:54): PR-3 lands the **3-arm match structure only**; the RePresent **contract is owned entirely by PR-4**, so PR-3 does **not** pre-shape the RePresent field signature (avoids guessing the field shape). PR-3's RePresent arm is the minimal unreached-assert:
+```python
+case RePresent():
+    # PR-4 owns the body + the RePresent contract. No PR-3-era scheme
+    # (universal / enumerate-all / CodeAct) emits RePresent, so this is
+    # genuinely unreachable until PR-4 lands the retrieval scheme.
+    raise AssertionError("RePresent not reached (PR-4)")
+```
+PR-4 then replaces this arm body (single-arm, single-file change — zero structural churn,
+no later-overwrite) with the bounded re-present loop. e2e's committed contract for PR-4:
+`interp.refinement.candidates: Iterable[hashable]` (the scheme's current candidate set);
+the arm loops `present → LLM → interpret` accumulating a monotonic `presented`/`seen` set
+until convergence. **Bounded-by-construction** (monotonic `seen` over a finite action
+space — no magic retry cap). e2e seam-expert co-vets PR-3's 4-method + exec_ctx coherence
+when the PR opens.
+
+> **Design-review question 2 (e2e): AGREED** — 3-arm match + `RePresent` =
+> `raise AssertionError("RePresent not reached")` stub in PR-3; PR-4 owns the contract +
+> body. Boundary accepted (this doc reflects it).
+
+---
+
+## 4. CodeAct scheme — the 4 `ToolUseScheme` methods (security model unchanged)
+
+| Method | CodeAct behavior |
+|---|---|
+| `build_presentation` | render permission-eligible tools as a **code-API** (Python fn signatures + docstrings) in the SP; **excluded tools omitted** (#1400 mirror, defense-in-depth); `llm_tools_payload` native-minimal/empty. |
+| `interpret` | extract the `CodeBlock` from the LLM response (tagged union, already in PR-1 IF). |
+| `execute` | run the script via `CodeActRunner` (Decision A) under the CodeAct SandboxPolicy; the namespace exposes **only** the permission-proxy shims. |
+| `format_feedback` | stdout / return value / tracebacks → LLM. |
+
+**Per-call gate (the real boundary, unchanged from owner-signed model):** each in-code
+`tool()` call IPCs to the parent → enters the **same OS pre-execute pipeline** PR-1
+establishes: **exclude-gate on the resolved effective name** (`_excluded_result`,
+pre-dispatch) → `dispatch_tool` (permission via `permission_resolver`, Control IR, P5) →
+P6 `tool_called/returned/failed` + WAL `step_*` (so act-turn rewind + audit are unchanged).
+A CodeAct call is gated **≥** a JSON call: same exclude + permission gate **+** sandbox
+containment.
+
+---
+
+## 5. Existing-mechanism correspondence (owner sign-off material — settled)
+
+| CodeAct element | Existing mechanism REUSED | New? |
+|---|---|---|
+| Sandbox isolation | `sandboxed_exec` SandboxBackend (Landlock/Seatbelt/Noop), `#1326` operator-policy-wins | reuse |
+| Code execution | `python_runner` + `_python_harness` (timeout, crash-iso, restricted `__builtins__`/allowlist) | reuse + inject shims |
+| Permission gate | `dispatch_tool` → `permission_resolver.require_*` (P5/Control IR) | reuse |
+| Exclude gate (#1406/#187) | PR-1 OS pre-execute exclude gate (`_excluded_result`) — proxy calls re-enter it | reuse |
+| Fail-closed | Landlock/Seatbelt availability gate (no unsandboxed CodeAct fallback) | reuse |
+| Audit / time-travel | per-proxied-call P6 + WAL `step_*` via parent `dispatch_tool` | reuse |
+| **Permission-proxy IPC callback** | — (harness is one-shot today) | **NEW (the only one)** |
+
+**SandboxPolicy defaults** for CodeAct: `network=False`, `allow_subprocess=False`,
+`write_paths`=workspace, `timeout` — the safe baseline, **operator-overridable** via the
+existing `sandbox.policy` mechanism (configured policy wins, same as `sandboxed_exec`). No
+new policy surface. **Fail-closed**: CodeAct *unavailable* (not degraded-to-unsafe) when
+the sandbox is unavailable.
+
+---
+
+## 6. Build staging (post-design-review; WIP-push at each step)
+
+1. **S1 — 3-arm match (single-owned seam, decision B).** Generalize `_run_scheme_tool_round`
+   to `match interp: Execute | CodeBlock | RePresent`. Execute arm byte-identical; RePresent
+   arm = e2e-agreed stub; CodeBlock arm wired to `CodeActScheme.execute`. *Tier-2 invariant:
+   Execute path unchanged (the 22-test regression + golden-shape stay green).*
+2. **S2 — CodeActRunner (decision A, the new mechanism).** socketpair + `pass_fds` spawn +
+   concurrent `_service_control_socket` → parent exclude+`dispatch_tool` per request.
+   Reuse SandboxPolicy/profile/harness-namespace. *Tier-2: proxied call re-enters the OS
+   gate (exclude + permission), per-call, pre-dispatch.*
+3. **S3 — CodeActScheme (4 methods).** build_presentation code-API (excluded omitted) /
+   interpret CodeBlock / execute via CodeActRunner / format_feedback. Register via
+   `register_scheme` (P7 polymorphic; no OS name-branching).
+4. **S4 — config + docs.** `reyn.yaml` scheme selector + SandboxPolicy override doc;
+   `control-ir.md` sync if a new op kind appears (none expected — reuses `dispatch_tool`).
+
+**Test posture (per testing.ja.md):** Tier-2 OS-invariant (Execute byte-identical;
+proxied-call gate re-entry; fail-closed when sandbox unavailable) + Tier-3 LLMReplay for
+the CodeAct round shape. **No mocks** — real SandboxBackend (skipif on platform for the
+real-sandbox path, honest-scope per the optional-dep/real-env discipline), real
+`dispatch_tool` + `permission_resolver`. The duplex IPC is verified with a real socketpair
++ real harness child (no fake channel).
+
+---
+
+## 7. Design-review asks (lead + e2e)
+
+- **Q1 (lead):** dedicated `CodeActRunner` (duplex socketpair + concurrent service) over
+  extending `SandboxBackend.run` — confirm (§2).
+- **Q2 (e2e): AGREED** (broker 04:54) — 3-arm match + `RePresent` unreached-assert stub in
+  PR-3; PR-4 owns the `interp.refinement.candidates` contract + bounded-loop body (§3).
+- **Q3 (lead):** SandboxPolicy default/override + fail-closed posture confirmed as settled
+  (§5) — re-confirm no change from the owner sign-off.
+
+No build code until Q1/Q2 clear. WIP-pushed for review.

--- a/docs/deep-dives/journal/1593-pr3-codeact-staging-design.md
+++ b/docs/deep-dives/journal/1593-pr3-codeact-staging-design.md
@@ -100,10 +100,26 @@ already-open socket. The fd is the single, audited hole; it carries **only** mar
 tool-call requests, each re-gated by the parent's exclude + permission + `dispatch_tool`
 pipeline.)
 
+**Empirical verification of the load-bearing claim (primary evidence, not asserted).**
+The transport rests on *"an inherited socketpair fd survives the sandbox even with network
+denied."* Probed directly on macOS/Seatbelt: a unix `socketpair` child fd, passed via
+`Popen(pass_fds=...)` through `sandbox-exec -f <profile>` where the profile is
+`(deny default)` **+** `(deny network*)` (the CodeAct posture), completes a **full duplex
+round-trip** (child→parent `PING`, parent→child `PONG`, child rc=0). ⇒ the AF_UNIX control
+channel is **not** caught by Seatbelt's `network*` filter (it is not a network socket),
+so the control hole stays open **while actual network exfiltration stays blocked** —
+exactly the "single audited hole" property. *Honest scope:* **Seatbelt verified (N=1,
+direct round-trip)**; **Landlock inferred** (Landlock LSM governs filesystem path access,
+not already-open socket fds, so the property is expected to hold — but **not empirically
+verified** without a Linux+Landlock env; live-verify pending, same posture as #1527). The
+probe is reproducible (`/tmp/codeact_fd_probe.py` shape) and becomes a Tier-2 skipif-gated
+test in S2.
+
 > **Design-review question 1 (lead):** confirm the dedicated `CodeActRunner` (duplex
 > socketpair + concurrent parent service loop, reusing policy/profile/harness-namespace)
 > over extending `SandboxBackend.run` with a callback arm. This is the load-bearing
-> transport decision; everything else is wiring.
+> transport decision; everything else is wiring. **The fd-survival premise is now
+> Seatbelt-verified (primary evidence); Landlock live-verify pending a Linux env.**
 
 ---
 

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -42,6 +42,7 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     defaulting to universal-category — PR-1 byte-identical. Per-layer config
     (``tool_use:{chat,step,phase}``) passes the selected name here."""
     from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme, register_scheme
+    from reyn.tools.schemes.codeact import CodeActScheme
     from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
     from reyn.tools.schemes.retrieval import RetrievalScheme
     from reyn.tools.schemes.universal_category import UniversalCategoryScheme
@@ -52,7 +53,12 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
     # NOT being registered yet — so anything that registers universal first (a
     # direct register_scheme caller, a test) would leave enumerate-all absent and
     # silently fall back to default. Per-scheme guard avoids that sibling gap.
-    for _builtin in (UniversalCategoryScheme(), EnumerateAllScheme(), RetrievalScheme()):  # #1593 PR-2/4
+    for _builtin in (
+        UniversalCategoryScheme(),
+        EnumerateAllScheme(),  # #1593 PR-2
+        RetrievalScheme(),  # #1593 PR-4
+        CodeActScheme(),  # #1593 PR-3 — selectable via tool_use=codeact (not default)
+    ):
         if get_scheme(_builtin.name) is None:
             register_scheme(_builtin)
     # Unknown / unconfigured name → default (universal-category) — byte-identical.

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2053,7 +2053,7 @@ class RouterLoop:
                 if _cb_append is not None:
                     _cb_append(
                         role="assistant", content=_cb_content,
-                        meta={"chain_id": self.chain_id, "source": "router_codeact_turn"},
+                        meta={"chain_id": self.chain_id, "source": "router_codeblock_turn"},
                     )
                 for _cb_msg in cb_feedback:
                     messages.append(_cb_msg)
@@ -2061,7 +2061,7 @@ class RouterLoop:
                         _cb_append(
                             role=_cb_msg.get("role", "user"),
                             content=_cb_msg.get("content", ""),
-                            meta={"chain_id": self.chain_id, "source": "router_codeact_turn"},
+                            meta={"chain_id": self.chain_id, "source": "router_codeblock_turn"},
                         )
                 continue
             if isinstance(interp, RePresent):

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1683,7 +1683,14 @@ class RouterLoop:
         # accumulated `presented` set. Stashed on self (RouterLoop is per-run state,
         # like self._catalog) — NOT the scheme (a registered singleton).
         _scheme_available = {
-            "skills_for_tools": skills_for_tools, "hot_list_aliases": _hot_list_aliases,
+            "skills_for_tools": skills_for_tools,
+            "hot_list_aliases": _hot_list_aliases,
+            # #1593 PR-3: the session exclude-set so a scheme presenting actions
+            # outside tools= (CodeAct's code-API) omits excluded ones — presentation
+            # parity with the JSON path (the OS applies _apply_tool_exclusions to
+            # tools= below; sp_fragment schemes self-omit). Stashed too, so a
+            # RePresent re-present keeps it.
+            "exclude_tools": self._exclude_tools,
         }
         _scheme_layer_ctx = {
             "phase_op_catalog": _phase_op_catalog,
@@ -2023,9 +2030,34 @@ class RouterLoop:
                 result, tool_catalog=self._catalog, ops=self,
             )
             if isinstance(interp, CodeBlock):
-                raise NotImplementedError(
-                    "CodeAct CodeBlock arm — PR-3 fills _run_codeblock_round"
-                )
+                # #1593 PR-3 CodeAct (design (a)): run the snippet in the sandboxed
+                # CodeActRunner — each in-code tool() call re-enters the SAME exclude
+                # + dispatch_tool + permission gate per call (so a CodeAct call is
+                # gated >= a JSON call) — then append the [assistant: code] turn + the
+                # scheme's format_feedback message(s) and loop. Separate path from the
+                # Execute zip (a CodeBlock turn has no tool_calls): the scheme OWNS the
+                # feedback message shape, the OS only appends (no synthetic tool_call =
+                # provider-safe). Documented contract divergence (Execute →
+                # tool_results-for-zip / CodeBlock → messages-for-append); unification
+                # is a tracked follow-up, out of PR-3 scope.
+                cb_feedback = await self._run_codeblock_round(interp)
+                _cb_content = result.content or ""
+                messages.append({"role": "assistant", "content": _cb_content})
+                _cb_append = getattr(host, "append_history_entry", None)
+                if _cb_append is not None:
+                    _cb_append(
+                        role="assistant", content=_cb_content,
+                        meta={"chain_id": self.chain_id, "source": "router_codeact_turn"},
+                    )
+                for _cb_msg in cb_feedback:
+                    messages.append(_cb_msg)
+                    if _cb_append is not None:
+                        _cb_append(
+                            role=_cb_msg.get("role", "user"),
+                            content=_cb_msg.get("content", ""),
+                            meta={"chain_id": self.chain_id, "source": "router_codeact_turn"},
+                        )
+                continue
             if isinstance(interp, RePresent):
                 # #1593 PR-4: the generic OS RePresent mechanism (ratified seam). The
                 # scheme classified the LLM output as a re-present request (e.g. a
@@ -3290,14 +3322,40 @@ class RouterLoop:
         )
         return tool_calls, tool_results
 
-    async def _run_codeblock_round(self, interp) -> "tuple[list[dict], list[dict]]":
-        """The ``CodeBlock`` arm — CodeAct (PR-3). The snippet runs in a sandboxed
-        subprocess (S2 ``CodeActRunner``: duplex socketpair + concurrent parent
-        service loop) where the only world-effect path is the permission-proxy — each
-        proxied call re-enters the SAME OS exclude + ``dispatch_tool`` + permission
-        gate (P5), so a CodeAct call is gated ≥ a JSON call. Body lands in PR-3
-        S2/S3; the match arm is wired here so the seam structure is single-owned."""
-        raise NotImplementedError("CodeAct CodeBlock execute — PR-3 S2/S3")
+    async def _run_codeblock_round(self, interp) -> "list[dict]":
+        """The ``CodeBlock`` arm body — run the CodeAct snippet via the scheme's
+        ``execute`` under the OS per-call gate + sandbox, and return the scheme's
+        ``format_feedback`` message(s) for the loop to append (design (a)).
+
+        ``_os_gate`` is the SAME gate the Execute path uses, per in-code ``tool()``
+        call: ``_excluded_result`` (exclude, pre-dispatch, resolved effective name) →
+        ``_dispatch_resolved`` (``dispatch_tool`` → permission_resolver, P5). The
+        snippet runs in the sandboxed subprocess (``CodeActRunner`` via
+        ``exec_ctx.sandbox``, fail-closed); the scheme orchestrates, the OS gates."""
+        from reyn.sandbox import get_default_backend  # noqa: PLC0415
+        from reyn.tools.scheme import ExecContext  # noqa: PLC0415
+
+        async def _os_gate(name: str, args: dict) -> dict:
+            excluded = self._excluded_result(name, args)
+            if excluded is not None:
+                return excluded
+            return await self._dispatch_resolved(name, args)
+
+        # CodeAct-safe default policy (operator-overridable in S4 via the host's
+        # configured sandbox policy); the backend auto-selects per platform and the
+        # runner is fail-closed when no real sandbox is available.
+        sandbox = get_default_backend(getattr(self.host, "sandbox_config", None))
+        exec_ctx = ExecContext(
+            tool_catalog=self._catalog,
+            sandbox=sandbox,
+            extra={
+                "dispatch": _os_gate,
+                "sandbox_policy": getattr(self.host, "default_sandbox_policy", None)
+                or {"network": False, "allow_subprocess": False, "env_passthrough": ["PATH"]},
+            },
+        )
+        exec_res = await self._scheme.execute(interp, exec_ctx, ops=self)
+        return self._scheme.format_feedback(exec_res, ops=self)
 
     def _maybe_salvage_qualified_direct_call(
         self, name: str, args: dict,

--- a/src/reyn/kernel/_codeact_harness.py
+++ b/src/reyn/kernel/_codeact_harness.py
@@ -1,0 +1,182 @@
+"""Child-process entry point for a CodeAct snippet (#1593 PR-3).
+
+Invoked as ``python -m reyn.kernel._codeact_harness`` inside the sandbox. Unlike
+``_python_harness`` (a pure one-shot function runner), CodeAct code interleaves
+computation with **synchronous tool calls** mid-execution, so this harness opens a
+**duplex control channel** to the parent: the only world-effect path exposed to the
+snippet is a ``tool(name, **args)`` shim that round-trips each call to the parent,
+where the SAME OS exclude + ``dispatch_tool`` + permission gate runs it (P5). The
+snippet never holds permission authority or reaches Reyn internals directly.
+
+Wire format (newline-delimited JSON over the inherited control fd)
+------------------------------------------------------------------
+Request (stdin, single JSON object):
+    {
+      "code":            "<the snippet>",
+      "control_fd":      <int>,                # inherited AF_UNIX socketpair fd
+      "allowed_modules": ["json", ...]         # safe-mode import allowlist
+    }
+
+Control channel (duplex, during execution):
+    child → parent:  {"op": "tool_call", "name": "<qualified>", "args": {...}}\\n
+    parent → child:  {"op": "result", "result": {...}}\\n     # dispatch_tool envelope
+
+Response (stdout, single JSON object):
+    {"ok": true,  "result": <JSON>}                          # snippet completed
+    {"ok": false, "error": "<message>", "kind": "<class>"}   # snippet raised
+
+The control fd survives the OS sandbox (an inherited AF_UNIX socketpair is not a
+``network*`` socket — verified on Seatbelt under ``(deny default)+(deny network*)``);
+it is the single, audited hole, carrying only marshalled tool calls the parent
+re-gates. Direct FS-write / network / subprocess remain blocked by the sandbox.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import socket
+import sys
+import traceback
+from typing import Any
+
+# Reuse the existing safe-mode validator + restricted builtins (#1593
+# correspondence: harness restricted-namespace mechanism reused; CodeAct only
+# adds the permission-proxy shim on top).
+from reyn.kernel._python_harness import (
+    _build_restricted_builtins,
+    _validate_safe_ast,
+)
+
+
+class _ControlChannel:
+    """Newline-delimited JSON duplex channel to the parent over the inherited fd."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._buf = b""
+
+    def call(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Send one request and block for the single-line reply."""
+        self._sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+        return self._recv_line()
+
+    def _recv_line(self) -> dict[str, Any]:
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                raise _ControlChannelClosed(
+                    "parent closed the CodeAct control channel mid-call"
+                )
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return json.loads(line.decode("utf-8"))
+
+
+class _ControlChannelClosed(RuntimeError):
+    """The parent hung up the control channel before replying."""
+
+
+def _make_tool_shim(channel: _ControlChannel):
+    """Build the ``tool(name, **args)`` callable injected into the snippet namespace.
+
+    Marshals ``(name, args)`` to the parent, which runs the OS exclude +
+    ``dispatch_tool`` + permission gate, and returns the result envelope's payload.
+    A ``status == "error"`` envelope is raised as ``ToolError`` so the snippet can
+    try/except it the way it would a normal Python call (permission_denied /
+    tool_excluded / unknown_tool surface here)."""
+
+    def tool(name: str, **args: Any) -> Any:
+        reply = channel.call({"op": "tool_call", "name": name, "args": args})
+        result = reply.get("result", {})
+        if isinstance(result, dict) and result.get("status") == "error":
+            err = result.get("error", {}) or {}
+            raise ToolError(
+                err.get("message", "tool call failed"),
+                kind=err.get("kind", "error"),
+                name=name,
+            )
+        # dispatch_tool success envelope is {"status": "ok", "data": <value>}.
+        if isinstance(result, dict) and "data" in result:
+            return result["data"]
+        return result
+
+    return tool
+
+
+class ToolError(RuntimeError):
+    """Raised inside a CodeAct snippet when a proxied tool call returns an error
+    envelope (permission_denied / tool_excluded / unknown_tool / exception)."""
+
+    def __init__(self, message: str, *, kind: str = "error", name: str = "") -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.name = name
+
+
+def _exec_codeact(
+    code: str, channel: _ControlChannel, allowed_modules: frozenset[str],
+) -> Any:
+    """Validate + exec the snippet with the restricted builtins + the tool shim.
+
+    Returns the snippet's ``result`` binding if it defines one, else None. The
+    snippet affects the world ONLY through ``tool(...)`` (the parent-gated proxy);
+    the restricted builtins block ``open`` / ``eval`` / ``__import__`` of
+    non-allowlisted modules (defense-in-depth on top of the sandbox)."""
+    tree = ast.parse(code, filename="<codeact>")
+    _validate_safe_ast(tree, allowed_modules)
+    builtins_dict = _build_restricted_builtins(allowed_modules)
+
+    namespace: dict[str, Any] = {
+        "__builtins__": builtins_dict,
+        "__name__": "__reyn_codeact__",
+        "tool": _make_tool_shim(channel),
+    }
+    compiled = compile(tree, filename="<codeact>", mode="exec")
+    exec(compiled, namespace)  # noqa: S102 — sandboxed subprocess + restricted ns
+    return namespace.get("result")
+
+
+def _read_request() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw:
+        raise ValueError("codeact harness received empty stdin")
+    return json.loads(raw)
+
+
+def _write_response(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, default=str))
+    sys.stdout.flush()
+
+
+def main() -> int:
+    sock: socket.socket | None = None
+    try:
+        req = _read_request()
+        code = str(req["code"])
+        control_fd = int(req["control_fd"])
+        allowed_modules = frozenset(req.get("allowed_modules") or [])
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=control_fd)
+        channel = _ControlChannel(sock)
+
+        result = _exec_codeact(code, channel, allowed_modules)
+        _write_response({"ok": True, "result": result})
+        return 0
+    except Exception as exc:  # noqa: BLE001 — surface every failure as a response
+        _write_response({
+            "ok": False,
+            "kind": type(exc).__name__,
+            "error": str(exc),
+            "traceback": traceback.format_exc(limit=20),
+        })
+        return 1
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -1,0 +1,197 @@
+"""Parent-side orchestrator for a CodeAct snippet (#1593 PR-3, S2).
+
+Runs the model's snippet in a subprocess (``reyn.kernel._codeact_harness``) and
+services its duplex permission-proxy: each ``tool(name, **args)`` the snippet calls
+round-trips over an inherited AF_UNIX socketpair to ``dispatch`` here in the parent
+— the SAME OS exclude + ``dispatch_tool`` + permission gate (P5). The snippet holds
+no permission authority and cannot reach Reyn internals; the socket is the single,
+audited hole carrying only marshalled tool calls.
+
+Why a dedicated runner (not ``SandboxBackend.run``): ``run`` is single-shot
+(``subprocess.run`` capture — stdout read only after exit), but CodeAct needs a
+duplex channel **live during execution**. The runner does its own
+``Popen(pass_fds=...)`` so the socketpair fd is inherited, and services the channel
+concurrently with the child. The OS sandbox is applied by reusing the backend's
+profile builder (S2b: Seatbelt ``_build_sbpl_profile`` + ``sandbox-exec`` wrapper;
+S2c: Landlock preexec ruleset) — the inherited socketpair fd survives both (an
+AF_UNIX socketpair is not a ``network*`` socket; verified on Seatbelt under
+``(deny default)+(deny network*)``).
+
+This module is the S2a core: the protocol + service loop + the direct (no-sandbox)
+spawn. The sandbox-wrapping spawn lands in S2b/S2c.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+from typing import Any, Awaitable, Callable
+
+# A dispatch callback: (name, args) -> the dispatch_tool result envelope
+# ({"status": "ok", "data": ...} | {"status": "error", "error": {...}}). The
+# CodeAct scheme (S3) supplies one that runs the OS exclude gate + dispatch_tool;
+# tests supply a real callback (no mocks).
+DispatchFn = Callable[[str, dict], Awaitable[dict]]
+
+
+class CodeActRunner:
+    """Run a CodeAct snippet with a duplex permission-proxy to the parent gate.
+
+    Stateless aside from ``python_executable``; one runner serves many snippets.
+    """
+
+    def __init__(self, python_executable: str | None = None) -> None:
+        self.python_executable = (
+            python_executable
+            or os.environ.get("REYN_HARNESS_PYTHON")
+            or sys.executable
+        )
+
+    async def run(
+        self,
+        *,
+        code: str,
+        dispatch: DispatchFn,
+        allowed_modules: list[str] | None = None,
+        timeout: float = 30.0,
+        cwd: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute ``code`` in the CodeAct harness; service its tool() proxy via
+        ``dispatch``. Returns the harness response dict
+        (``{ok: True, result}`` | ``{ok: False, kind, error, traceback?}``), plus a
+        ``status`` field (``ok`` | ``error`` | ``timeout``) for the scheme layer.
+
+        S2a: direct (no-sandbox) spawn. S2b/S2c wrap the spawn in the OS sandbox.
+        """
+        parent_sock, child_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        child_fd = child_sock.fileno()
+        os.set_inheritable(child_fd, True)
+
+        request = {
+            "code": code,
+            "control_fd": child_fd,
+            "allowed_modules": list(allowed_modules or []),
+        }
+        argv = [self.python_executable, "-m", "reyn.kernel._codeact_harness"]
+
+        try:
+            proc = subprocess.Popen(  # noqa: S603 — fixed argv, sandbox wrap in S2b
+                argv,
+                pass_fds=[child_fd],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=cwd,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            child_sock.close()
+            parent_sock.close()
+            return {"ok": False, "status": "error", "kind": "SpawnError", "error": str(exc)}
+
+        # The child inherited its own copy of the fd; the parent keeps only its end.
+        child_sock.close()
+
+        loop = asyncio.get_running_loop()
+        parent_sock.setblocking(False)
+        service_task = asyncio.create_task(self._service(parent_sock, dispatch, loop))
+
+        # ``communicate(input=...)`` writes the request to stdin (the child reads it
+        # fully before touching the control channel), then reads stdout/stderr +
+        # waits. It runs in an executor thread, so the ``service_task`` services the
+        # control channel concurrently on the event loop while the child blocks on a
+        # mid-execution tool() call.
+        request_bytes = json.dumps(request).encode("utf-8")
+        comm_future = loop.run_in_executor(
+            None, lambda: proc.communicate(input=request_bytes),
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(comm_future, timeout=timeout)
+        except asyncio.TimeoutError:
+            await _kill_proc_group(proc, loop)
+            return {
+                "ok": False, "status": "timeout",
+                "kind": "Timeout", "error": f"codeact timed out after {timeout}s",
+            }
+        finally:
+            service_task.cancel()
+            try:
+                parent_sock.close()
+            except OSError:
+                pass
+
+        return self._parse_response(stdout_b, stderr_b, proc.returncode)
+
+    async def _service(
+        self, sock: socket.socket, dispatch: DispatchFn, loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Service the control channel until the child closes it (EOF). Each
+        ``tool_call`` is gated by ``dispatch`` (the parent's exclude + dispatch_tool
+        + permission pipeline) and the result envelope is sent back."""
+        buf = b""
+        while True:
+            try:
+                chunk = await loop.sock_recv(sock, 65536)
+            except (ConnectionError, OSError):
+                return
+            if not chunk:
+                return  # child closed the channel — snippet finished
+            buf += chunk
+            while b"\n" in buf:
+                line, _, buf = buf.partition(b"\n")
+                if not line:
+                    continue
+                req = json.loads(line.decode("utf-8"))
+                if req.get("op") != "tool_call":
+                    continue
+                result = await dispatch(req.get("name", ""), req.get("args", {}) or {})
+                reply = json.dumps({"op": "result", "result": result}).encode("utf-8")
+                try:
+                    await loop.sock_sendall(sock, reply + b"\n")
+                except (ConnectionError, OSError):
+                    return
+
+    def _parse_response(
+        self, stdout_b: bytes, stderr_b: bytes, returncode: int | None,
+    ) -> dict[str, Any]:
+        stdout_text = (stdout_b or b"").decode("utf-8", errors="replace")
+        if not stdout_text.strip():
+            stderr_text = (stderr_b or b"").decode("utf-8", errors="replace")
+            return {
+                "ok": False, "status": "error", "kind": "Crash",
+                "error": f"codeact harness produced no output (rc={returncode}): "
+                         f"{stderr_text.strip()[:300]}",
+            }
+        try:
+            payload = json.loads(stdout_text)
+        except json.JSONDecodeError:
+            return {
+                "ok": False, "status": "error", "kind": "MalformedResponse",
+                "error": f"codeact harness returned malformed JSON: {stdout_text[:300]}",
+            }
+        payload["status"] = "ok" if payload.get("ok") else "error"
+        return payload
+
+
+async def _kill_proc_group(
+    proc: subprocess.Popen, loop: asyncio.AbstractEventLoop, grace_seconds: float = 2.0,
+) -> None:
+    """SIGTERM the process group, then SIGKILL after grace if still alive (mirrors
+    the SeatbeltBackend cancel kill — covers the wrapper + child under the sandbox)."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return
+    try:
+        await asyncio.wait_for(
+            loop.run_in_executor(None, proc.wait), timeout=grace_seconds,
+        )
+    except (asyncio.TimeoutError, Exception):
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass

--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -56,17 +56,39 @@ class CodeActRunner:
         *,
         code: str,
         dispatch: DispatchFn,
+        sandbox_backend: Any = None,
+        sandbox_policy: dict | None = None,
         allowed_modules: list[str] | None = None,
         timeout: float = 30.0,
         cwd: str | None = None,
+        allow_unsandboxed: bool = False,
     ) -> dict[str, Any]:
         """Execute ``code`` in the CodeAct harness; service its tool() proxy via
         ``dispatch``. Returns the harness response dict
         (``{ok: True, result}`` | ``{ok: False, kind, error, traceback?}``), plus a
-        ``status`` field (``ok`` | ``error`` | ``timeout``) for the scheme layer.
+        ``status`` field (``ok`` | ``error`` | ``timeout`` | ``sandbox_unavailable``)
+        for the scheme layer.
 
-        S2a: direct (no-sandbox) spawn. S2b/S2c wrap the spawn in the OS sandbox.
+        **Fail-closed** (owner-signed): CodeAct runs ONLY under an available OS
+        sandbox (Seatbelt / Landlock). When no real backend is available the run is
+        refused (``sandbox_unavailable``), never silently downgraded to an
+        unsandboxed subprocess. ``allow_unsandboxed=True`` is a **test-only** escape
+        for exercising the transport/proxy core without a sandbox; production callers
+        (the CodeAct scheme) never set it.
+
+        S2b wires the Seatbelt wrap (reusing ``_build_sbpl_profile``); S2c wires
+        Landlock.
         """
+        base_argv = [self.python_executable, "-m", "reyn.kernel._codeact_harness"]
+        argv, cleanup, spawn_error = self._resolve_sandbox_spawn(
+            base_argv, sandbox_backend, sandbox_policy, timeout, allow_unsandboxed,
+        )
+        if spawn_error is not None:
+            return {
+                "ok": False, "status": "sandbox_unavailable",
+                "kind": "SandboxUnavailable", "error": spawn_error,
+            }
+
         parent_sock, child_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
         child_fd = child_sock.fileno()
         os.set_inheritable(child_fd, True)
@@ -76,10 +98,9 @@ class CodeActRunner:
             "control_fd": child_fd,
             "allowed_modules": list(allowed_modules or []),
         }
-        argv = [self.python_executable, "-m", "reyn.kernel._codeact_harness"]
 
         try:
-            proc = subprocess.Popen(  # noqa: S603 — fixed argv, sandbox wrap in S2b
+            proc = subprocess.Popen(  # noqa: S603 — fixed argv, sandbox-wrapped above
                 argv,
                 pass_fds=[child_fd],
                 stdin=subprocess.PIPE,
@@ -91,6 +112,8 @@ class CodeActRunner:
         except OSError as exc:
             child_sock.close()
             parent_sock.close()
+            if cleanup is not None:
+                cleanup()
             return {"ok": False, "status": "error", "kind": "SpawnError", "error": str(exc)}
 
         # The child inherited its own copy of the fd; the parent keeps only its end.
@@ -123,8 +146,81 @@ class CodeActRunner:
                 parent_sock.close()
             except OSError:
                 pass
+            if cleanup is not None:
+                cleanup()
 
         return self._parse_response(stdout_b, stderr_b, proc.returncode)
+
+    def _resolve_sandbox_spawn(
+        self,
+        base_argv: list[str],
+        sandbox_backend: Any,
+        sandbox_policy: dict | None,
+        timeout: float,
+        allow_unsandboxed: bool,
+    ) -> tuple[list[str] | None, Callable[[], None] | None, str | None]:
+        """Resolve the spawn argv + a cleanup callable for the active sandbox, or an
+        error string (fail-closed). Returns ``(argv, cleanup, error)``; exactly one
+        of ``argv`` / ``error`` is non-None.
+
+        - Seatbelt (available): wrap ``base_argv`` with ``sandbox-exec -f <profile>``
+          using the REUSED ``_build_sbpl_profile`` (the inherited socketpair fd
+          survives — an AF_UNIX socketpair is not a ``network*`` socket).
+        - Landlock (available): S2c (preexec ruleset) — not yet wired → fail-closed.
+        - noop / None / unavailable: fail-closed unless ``allow_unsandboxed`` (a
+          test-only escape for the transport/proxy core).
+        """
+        name = getattr(sandbox_backend, "name", None)
+        available = bool(sandbox_backend is not None and sandbox_backend.available())
+
+        if sandbox_backend is None or name in (None, "noop") or not available:
+            if allow_unsandboxed:
+                return base_argv, None, None
+            return None, None, (
+                "CodeAct requires an available OS sandbox backend (Seatbelt / "
+                "Landlock); none available — refusing to run unsandboxed (fail-closed)."
+            )
+
+        from reyn.sandbox import SandboxPolicy  # noqa: PLC0415
+
+        policy_dict = dict(sandbox_policy or {})
+        policy_dict["timeout_seconds"] = timeout
+        policy = SandboxPolicy(**policy_dict)
+
+        if name == "seatbelt":
+            import tempfile  # noqa: PLC0415
+
+            from reyn.sandbox.backends.seatbelt import (  # noqa: PLC0415
+                _build_sbpl_profile,
+            )
+
+            profile_text = _build_sbpl_profile(policy)
+            try:
+                fh = tempfile.NamedTemporaryFile(
+                    suffix=".sb", mode="w", delete=False, encoding="utf-8",
+                )
+                fh.write(profile_text)
+                fh.close()
+            except OSError as exc:
+                return None, None, f"CodeAct: failed to write Seatbelt profile: {exc}"
+
+            def _cleanup() -> None:
+                try:
+                    os.unlink(fh.name)
+                except OSError:
+                    pass
+
+            return ["sandbox-exec", "-f", fh.name, *base_argv], _cleanup, None
+
+        if name == "landlock":
+            return None, None, (
+                "CodeAct Landlock wrap is S2c (pending Linux+Landlock env "
+                "verification) — not yet available (fail-closed)."
+            )
+
+        return None, None, (
+            f"CodeAct does not support sandbox backend {name!r} yet (fail-closed)."
+        )
 
     async def _service(
         self, sock: socket.socket, dispatch: DispatchFn, loop: asyncio.AbstractEventLoop,

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -22,6 +22,7 @@ permission internals — it orchestrates, the OS gates (P3/P7).
 """
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -74,6 +75,17 @@ def _extract_code(llm_response: Any) -> str:
     return content.strip()
 
 
+def _format_codeact_observation(out: dict) -> str:
+    """Render a ``CodeActRunner`` result envelope as the user-role observation text
+    the model reads after its code turn (success result, or the error/kind on
+    failure / timeout / sandbox-unavailable)."""
+    if out.get("ok"):
+        body = json.dumps(out.get("result"), default=str, ensure_ascii=False)
+        return f"[codeact result]\n{body}"
+    kind = out.get("kind", "Error")
+    return f"[codeact {kind}]\n{out.get('error', '')}"
+
+
 class CodeActScheme:
     """CodeAct scheme (#1593 PR-3). Own logic (not delegating)."""
 
@@ -102,6 +114,13 @@ class CodeActScheme:
         Presentation-level omission is deferred to a follow-up (it needs the exclude
         set, which the OS applies post-presentation to ``tools=`` today)."""
         entries = await ops.catalog_entries()
+        # Presentation parity with the JSON path (#1400): omit excluded actions from
+        # the code-API too, so CodeAct's presentation is not looser than JSON tools=
+        # ("CodeAct >= JSON" on the presentation face, not just the per-call gate).
+        # The OS supplies the session exclude-set via ``available``.
+        exclude = (available or {}).get("exclude_tools") or frozenset()
+        if exclude:
+            entries = [e for e in entries if e.get("name") not in exclude]
         return Presentation(
             llm_tools_payload=[],
             sp_params={
@@ -145,6 +164,14 @@ class CodeActScheme:
         return ExecutionResult(tool_results=[out])
 
     def format_feedback(self, exec_result: ExecutionResult, ops: Any) -> list[dict]:
-        """The runner result envelope(s) become the loop's tool_results unchanged;
-        the CodeBlock arm shapes them into the LLM feedback message (S3 wiring)."""
-        return exec_result.tool_results
+        """Shape the CodeAct execution result(s) as loop-appendable feedback
+        **messages** — a user-role 'observation' carrying the snippet's result /
+        stdout / error (the CodeAct ReAct-style observation turn). The OS loop's
+        CodeBlock arm appends these verbatim after the [assistant: code] turn (it owns
+        no CodeAct message shape — P7). NOTE the documented divergence: the Execute
+        path's format_feedback returns tool_results (for the zip); CodeAct returns
+        messages (for direct append)."""
+        return [
+            {"role": "user", "content": _format_codeact_observation(out)}
+            for out in exec_result.tool_results
+        ]

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -26,11 +26,39 @@ import re
 from typing import Any
 
 from reyn.kernel.codeact_runner import CodeActRunner
-from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult
+from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, Presentation
 
 # A fenced ```python ... ``` (or bare ``` ... ```) block — how the CodeAct LLM
 # emits its snippet in the message content.
 _FENCE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
+
+
+def _render_code_api(entries: list[dict]) -> str:
+    """Render flat ``{name, description, parameters}`` action entries as a CodeAct
+    *code-API*: a reference list of the actions the model invokes via the
+    ``tool(...)`` proxy. Pure presentation — the model reads it; it is NOT executed
+    Python. The arg names come from each entry's JSON-schema ``parameters.properties``
+    (CodeAct's strictest-consumer schema-completeness floor guarantees a dict)."""
+    lines = [
+        "## CodeAct — write a Python script (not JSON tool calls)",
+        "",
+        "Write a Python snippet. Call any available action with "
+        "``tool('<name>', <arg>=<value>, ...)`` — it returns the action's result, or "
+        "raises if the action is denied / excluded / unknown. Assign your final answer "
+        "to a variable named ``result``. The standard library is available; "
+        "filesystem / network / subprocess are sandboxed.",
+        "",
+        "Available actions:",
+    ]
+    for entry in entries:
+        name = entry.get("name", "")
+        params = entry.get("parameters") or {}
+        arg_names = list((params.get("properties") or {}).keys())
+        sig = ", ".join(arg_names)
+        desc_raw = (entry.get("description") or "").strip()
+        desc = desc_raw.splitlines()[0] if desc_raw else ""
+        lines.append(f"- tool('{name}'{', ' + sig if sig else ''}) — {desc}".rstrip(" —"))
+    return "\n".join(lines)
 
 
 def _extract_code(llm_response: Any) -> str:
@@ -54,15 +82,33 @@ class CodeActScheme:
     def __init__(self, runner: CodeActRunner | None = None) -> None:
         self._runner = runner or CodeActRunner()
 
-    async def build_presentation(self, available: Any, layer_ctx: Any, ops: Any):
-        # S3b: render ops.catalog_entries() as a code-API (excluded omitted) + the
-        # "write a script calling these functions" SP; llm_tools_payload native-
-        # minimal. ASYNC per the e2e seam decision (#1593 issuecomment-4700815694):
-        # catalog_entries is async for rag/source completeness + PR-4 dynamic search.
-        # Blocked on the SchemeOps.catalog_entries async adapter (tui PR-2 / e2e);
-        # not wired until CodeAct is a selectable scheme (tui's per-layer selection).
-        raise NotImplementedError(
-            "CodeActScheme.build_presentation — S3b (needs async SchemeOps.catalog_entries)"
+    async def build_presentation(
+        self, available: Any, layer_ctx: Any, ops: Any,
+    ) -> Presentation:
+        """Render the permission-eligible actions as a CodeAct *code-API* in the
+        ``sp_fragment`` (#1601 channel) — each action a callable the model invokes via
+        the ``tool(name, **args)`` proxy. No JSON ``tools=`` (``llm_tools_payload``
+        empty): the model writes a Python snippet in its content, not tool calls.
+
+        ``ops.catalog_entries()`` is async (the SchemeOps adapter ensures the
+        rag/source-populated context — e2e Option A: adapter owns the rs-ensure
+        await; my ``universal_catalog.catalog_entries`` substrate stays sync). The
+        ``sp_params`` named gates are both off (CodeAct expresses its whole tool-use
+        SP through the free-form fragment, not the universal named gates).
+
+        Excluded-tool *omission from the code-API* is defense-in-depth, NOT the safety
+        boundary: the real gate is the per-call exclude + ``dispatch_tool`` re-entry
+        in ``execute`` (a code call to an excluded action is rejected at dispatch).
+        Presentation-level omission is deferred to a follow-up (it needs the exclude
+        set, which the OS applies post-presentation to ``tools=`` today)."""
+        entries = await ops.catalog_entries()
+        return Presentation(
+            llm_tools_payload=[],
+            sp_params={
+                "universal_wrappers_enabled": False,
+                "search_actions_enabled": False,
+            },
+            sp_fragment=_render_code_api(entries),
         )
 
     def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: Any) -> CodeBlock:

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -1,0 +1,104 @@
+"""CodeActScheme — the CodeAct tool-use scheme (#1593 PR-3).
+
+Unlike universal-category (which delegates to the router's existing JSON tool
+logic), CodeAct implements its own scheme logic: the LLM writes a Python snippet
+and tool calls happen as **in-code ``tool()`` calls**, each round-tripping through
+the sandboxed ``CodeActRunner`` to the OS per-call gate (exclude + ``dispatch_tool``
++ permission, P5). A CodeAct call is therefore gated **>=** a JSON call (same gate
++ sandbox containment).
+
+The 4 ToolUseScheme methods:
+  - ``build_presentation`` → render the permission-eligible actions as a *code-API*
+    (function signatures from ``ops.catalog_entries()``, excluded omitted). **S3b**
+    — depends on the ``SchemeOps.catalog_entries`` adapter (e2e); stubbed here.
+  - ``interpret`` → extract the ``CodeBlock`` from the LLM response.
+  - ``execute`` → run the snippet via ``CodeActRunner`` with the OS-provided per-call
+    gate (``exec_ctx``) under ``exec_ctx.sandbox`` (fail-closed).
+  - ``format_feedback`` → the runner result envelope back to the loop.
+
+The OS gate + sandbox are provided via ``ExecContext`` (the OS assembles them in the
+router's CodeBlock arm); the scheme never assembles a DispatchContext or reaches
+permission internals — it orchestrates, the OS gates (P3/P7).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from reyn.kernel.codeact_runner import CodeActRunner
+from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult
+
+# A fenced ```python ... ``` (or bare ``` ... ```) block — how the CodeAct LLM
+# emits its snippet in the message content.
+_FENCE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_code(llm_response: Any) -> str:
+    """Pull the snippet from the LLM response: the first fenced code block in the
+    content, else the whole content (the model may emit bare code). Empty when
+    there is nothing to run (``execute`` then no-ops)."""
+    content = getattr(llm_response, "content", None) or ""
+    if not isinstance(content, str):
+        return ""
+    match = _FENCE_RE.search(content)
+    if match:
+        return match.group(1)
+    return content.strip()
+
+
+class CodeActScheme:
+    """CodeAct scheme (#1593 PR-3). Own logic (not delegating)."""
+
+    name: str = "codeact"
+
+    def __init__(self, runner: CodeActRunner | None = None) -> None:
+        self._runner = runner or CodeActRunner()
+
+    async def build_presentation(self, available: Any, layer_ctx: Any, ops: Any):
+        # S3b: render ops.catalog_entries() as a code-API (excluded omitted) + the
+        # "write a script calling these functions" SP; llm_tools_payload native-
+        # minimal. ASYNC per the e2e seam decision (#1593 issuecomment-4700815694):
+        # catalog_entries is async for rag/source completeness + PR-4 dynamic search.
+        # Blocked on the SchemeOps.catalog_entries async adapter (tui PR-2 / e2e);
+        # not wired until CodeAct is a selectable scheme (tui's per-layer selection).
+        raise NotImplementedError(
+            "CodeActScheme.build_presentation — S3b (needs async SchemeOps.catalog_entries)"
+        )
+
+    def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: Any) -> CodeBlock:
+        """Extract the snippet as a ``CodeBlock`` (the OS-loop's CodeBlock arm runs
+        ``execute``). No resolution/dedup here — CodeAct tool calls are resolved +
+        gated per call inside ``execute`` (via the OS gate), not up front."""
+        return CodeBlock(code=_extract_code(llm_response))
+
+    async def execute(
+        self, interp: CodeBlock, exec_ctx: ExecContext, ops: Any,
+    ) -> ExecutionResult:
+        """Run the snippet in the sandbox; proxy each in-code ``tool()`` call through
+        the OS per-call gate. ``exec_ctx.extra['dispatch']`` is the OS-provided gate
+        (exclude + ``dispatch_tool`` + permission) — the scheme never builds it. The
+        sandbox is ``exec_ctx.sandbox`` (fail-closed: no sandbox → the runner refuses
+        unless a test sets the runner-level escape)."""
+        dispatch = (exec_ctx.extra or {}).get("dispatch")
+        if dispatch is None:
+            raise ValueError(
+                "CodeActScheme.execute requires exec_ctx.extra['dispatch'] "
+                "(the OS per-call exclude + dispatch_tool gate)"
+            )
+        extra = exec_ctx.extra or {}
+        out = await self._runner.run(
+            code=interp.code,
+            dispatch=dispatch,
+            sandbox_backend=exec_ctx.sandbox,
+            sandbox_policy=extra.get("sandbox_policy"),
+            allowed_modules=extra.get("allowed_modules"),
+            timeout=extra.get("timeout", 30.0),
+            cwd=extra.get("cwd"),
+            allow_unsandboxed=extra.get("allow_unsandboxed", False),
+        )
+        return ExecutionResult(tool_results=[out])
+
+    def format_feedback(self, exec_result: ExecutionResult, ops: Any) -> list[dict]:
+        """The runner result envelope(s) become the loop's tool_results unchanged;
+        the CodeBlock arm shapes them into the LLM feedback message (S3 wiring)."""
+        return exec_result.tool_results

--- a/tests/test_codeact_coexistence_1593.py
+++ b/tests/test_codeact_coexistence_1593.py
@@ -155,9 +155,9 @@ async def test_codeblock_arm_full_round_then_plaintext_exit(monkeypatch) -> None
     # CodeBlock arm appended the [assistant: code] turn + the observation message
     # (NOT via the Execute zip — no tool message / tool_call_id).
     roles = [(h["role"], h["source"]) for h in host.history]
-    assert ("assistant", "router_codeact_turn") in roles
-    assert ("user", "router_codeact_turn") in roles
-    obs = next(h for h in host.history if h["source"] == "router_codeact_turn" and h["role"] == "user")
+    assert ("assistant", "router_codeblock_turn") in roles
+    assert ("user", "router_codeblock_turn") in roles
+    obs = next(h for h in host.history if h["source"] == "router_codeblock_turn" and h["role"] == "user")
     assert "computed" in obs["content"]  # the scheme's observation reached the loop
     # PlainText round 2 exited via the terminal text-reply path.
     assert any("final answer" in o["text"] for o in host.outbox)

--- a/tests/test_codeact_coexistence_1593.py
+++ b/tests/test_codeact_coexistence_1593.py
@@ -1,0 +1,163 @@
+"""Tier 2: #1593 PR-3 — CodeBlock arm coexists with the Execute path (design (a)).
+
+Drives the real ``RouterLoop.run`` with a CodeAct scheme over two LLM rounds:
+  round 1 → ``CodeBlock`` (the snippet) → the OS CodeBlock arm runs it via
+    ``_run_codeblock_round`` and appends the **[assistant: code]** turn + the
+    scheme's ``format_feedback`` observation message (a SEPARATE path from the
+    Execute zip — no tool_calls, no synthetic tool_call), then ``continue``;
+  round 2 → ``PlainText`` → the terminal text-reply path emits the final answer.
+
+This pins the CodeBlock append sequence end-to-end. The Execute path is unchanged
+(byte-identical) and covered by the broad router suite — so the two interpretation
+arms coexist without breaking each other (separate inline ``case`` arms).
+
+Real RouterLoop + a real Fake host / Fake scheme / real-coroutine call_llm_tools —
+no mocks (per testing.ja.md).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.tools.scheme import (
+    CodeBlock,
+    ExecutionResult,
+    PlainText,
+    Presentation,
+)
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+class _FakeHost:
+    """A real Fake RouterLoopHost — the subset run()/run_loop touch. Records
+    history entries + outbox so the test can assert the CodeBlock turn sequence."""
+
+    agent_name = "test-agent"
+    agent_role = "tester"
+    output_language = "en"
+
+    def __init__(self) -> None:
+        self.outbox: list[dict] = []
+        self.history: list[dict] = []
+        self._events = _FakeEvents()
+
+    @property
+    def events(self) -> _FakeEvents:
+        return self._events
+
+    # context / catalog inputs (all empty — the CodeAct scheme ignores them)
+    def list_available_skills(self) -> list[dict]:
+        return []
+
+    def list_available_agents(self) -> list[dict]:
+        return []
+
+    def get_memory_index(self) -> dict:
+        return {"status": "not_found", "content": ""}
+
+    def get_file_permissions(self):
+        return None
+
+    def get_mcp_servers(self) -> list[dict]:
+        return []
+
+    def get_web_fetch_allowed(self) -> bool:
+        return False
+
+    def get_project_context(self) -> str:
+        return ""
+
+    def get_universal_wrappers_enabled(self) -> bool:
+        return False
+
+    def get_action_usage_tracker(self):
+        return None
+
+    def get_action_embedding_index(self):
+        return None
+
+    def get_embedding_provider(self):
+        return None
+
+    def get_embedding_model_class(self):
+        return None
+
+    def get_action_retrieval_config(self):
+        from reyn.config import ActionRetrievalConfig
+        return ActionRetrievalConfig(hot_list_n=0)
+
+    def resolve_model(self, name: str) -> str:
+        return "fake-model"
+
+    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+        self.outbox.append({"kind": kind, "text": text, "meta": meta})
+
+    def append_history_entry(self, *, role: str, content: str, meta: dict, **kw) -> None:
+        self.history.append({"role": role, "content": content, "source": meta.get("source")})
+
+
+class _FakeCodeActScheme:
+    """A real Fake CodeAct scheme: round 1 → CodeBlock, round 2 → PlainText. execute
+    returns a canned result; format_feedback shapes the observation message (the real
+    CodeActScheme's shape) the OS CodeBlock arm appends."""
+
+    name = "codeact"
+
+    def __init__(self) -> None:
+        self._round = 0
+
+    async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
+        return Presentation(
+            llm_tools_payload=[],
+            sp_params={"universal_wrappers_enabled": False, "search_actions_enabled": False},
+            sp_fragment="code-api",
+        )
+
+    def interpret(self, llm_response, *, tool_catalog, ops):
+        self._round += 1
+        return CodeBlock(code="result = tool('m')") if self._round == 1 else PlainText()
+
+    async def execute(self, interp, exec_ctx, ops) -> ExecutionResult:
+        return ExecutionResult(tool_results=[{"ok": True, "status": "ok", "result": "computed"}])
+
+    def format_feedback(self, exec_result, ops) -> list[dict]:
+        return [{"role": "user", "content": "[codeact result]\ncomputed"}]
+
+
+def _result(content: str) -> LLMToolCallResult:
+    return LLMToolCallResult(content=content, tool_calls=[], usage=None, finish_reason="stop")
+
+
+@pytest.mark.asyncio
+async def test_codeblock_arm_full_round_then_plaintext_exit(monkeypatch) -> None:
+    """Tier 2: a CodeBlock round appends [assistant: code] + the observation message
+    (separate from the Execute zip), then a PlainText round exits via the text-reply
+    path — the CodeBlock arm drives a full round end-to-end and coexists with Execute."""
+    host = _FakeHost()
+    loop = RouterLoop(host=host, chain_id="c", max_iterations=5, system_prompt_override="SP")
+    loop._scheme = _FakeCodeActScheme()
+
+    turns = [_result("```python\nresult = tool('m')\n```"), _result("the final answer")]
+
+    async def _fake_call_llm_tools(**kwargs) -> LLMToolCallResult:
+        return turns.pop(0)
+
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _fake_call_llm_tools)
+    await loop.run("hello", [])
+
+    # CodeBlock arm appended the [assistant: code] turn + the observation message
+    # (NOT via the Execute zip — no tool message / tool_call_id).
+    roles = [(h["role"], h["source"]) for h in host.history]
+    assert ("assistant", "router_codeact_turn") in roles
+    assert ("user", "router_codeact_turn") in roles
+    obs = next(h for h in host.history if h["source"] == "router_codeact_turn" and h["role"] == "user")
+    assert "computed" in obs["content"]  # the scheme's observation reached the loop
+    # PlainText round 2 exited via the terminal text-reply path.
+    assert any("final answer" in o["text"] for o in host.outbox)

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -1,0 +1,88 @@
+"""Tier 2: #1593 PR-3 S2a — CodeActRunner duplex permission-proxy round-trip.
+
+The CodeAct snippet's ``tool(name, **args)`` calls must round-trip to the parent
+``dispatch`` (the OS exclude + dispatch_tool + permission gate), error envelopes
+must surface inside the snippet as ToolError, and the final ``result`` returns. The
+reused restricted namespace blocks raw builtins (defense-in-depth on top of the
+sandbox).
+
+Real subprocess + real AF_UNIX socketpair + a real (non-mock) ``dispatch`` callback
+— no fakes of the channel. The sandbox wrap is S2b (Seatbelt) / S2c (Landlock);
+this pins the transport + proxy core that survives inside the sandbox.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.kernel.codeact_runner import CodeActRunner
+
+
+@pytest.mark.asyncio
+async def test_tool_call_round_trips_to_parent_dispatch() -> None:
+    """Tier 2: snippet tool() → parent dispatch → result; dispatch sees (name, args)."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": {"echoed": args}}
+
+    runner = CodeActRunner()
+    code = "r = tool('file__read', path='a.txt')\nresult = r['echoed']['path']"
+    out = await runner.run(code=code, dispatch=dispatch)
+    assert out["ok"] is True, out
+    assert out["result"] == "a.txt"
+    assert seen == [("file__read", {"path": "a.txt"})]
+
+
+@pytest.mark.asyncio
+async def test_multiple_sequential_tool_calls() -> None:
+    """Tier 2: several mid-execution tool() calls each round-trip, in order."""
+
+    async def dispatch(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": args.get("n", 0) * 2}
+
+    runner = CodeActRunner()
+    code = "result = [tool('m', n=i) for i in range(3)]"
+    out = await runner.run(code=code, dispatch=dispatch)
+    assert out["ok"] is True, out
+    assert out["result"] == [0, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_error_envelope_raises_tool_error_in_snippet() -> None:
+    """Tier 2: a dispatch error envelope (permission_denied) surfaces as ToolError."""
+
+    async def dispatch(name: str, args: dict) -> dict:
+        return {"status": "error", "error": {"kind": "permission_denied", "message": "no-write"}}
+
+    runner = CodeActRunner()
+    code = "tool('file__write', path='x')"
+    out = await runner.run(code=code, dispatch=dispatch)
+    assert out["ok"] is False
+    assert out["kind"] == "ToolError"
+    assert "no-write" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_pure_compute_snippet_returns_without_dispatch() -> None:
+    """Tier 2: a snippet with no tool() call returns its result; dispatch untouched."""
+
+    async def dispatch(name: str, args: dict) -> dict:
+        raise AssertionError("dispatch must not be called for a pure-compute snippet")
+
+    runner = CodeActRunner()
+    out = await runner.run(code="result = sum(range(5))", dispatch=dispatch)
+    assert out["ok"] is True, out
+    assert out["result"] == 10
+
+
+@pytest.mark.asyncio
+async def test_restricted_namespace_blocks_raw_open() -> None:
+    """Tier 2: the reused safe-mode namespace rejects open() (defense-in-depth)."""
+
+    async def dispatch(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": None}
+
+    runner = CodeActRunner()
+    out = await runner.run(code="result = open('/etc/passwd').read()", dispatch=dispatch)
+    assert out["ok"] is False  # safe-mode AST/builtins blocks the open reference

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -12,6 +12,8 @@ this pins the transport + proxy core that survives inside the sandbox.
 """
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from reyn.kernel.codeact_runner import CodeActRunner
@@ -28,7 +30,7 @@ async def test_tool_call_round_trips_to_parent_dispatch() -> None:
 
     runner = CodeActRunner()
     code = "r = tool('file__read', path='a.txt')\nresult = r['echoed']['path']"
-    out = await runner.run(code=code, dispatch=dispatch)
+    out = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is True, out
     assert out["result"] == "a.txt"
     assert seen == [("file__read", {"path": "a.txt"})]
@@ -43,7 +45,7 @@ async def test_multiple_sequential_tool_calls() -> None:
 
     runner = CodeActRunner()
     code = "result = [tool('m', n=i) for i in range(3)]"
-    out = await runner.run(code=code, dispatch=dispatch)
+    out = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is True, out
     assert out["result"] == [0, 2, 4]
 
@@ -57,7 +59,7 @@ async def test_error_envelope_raises_tool_error_in_snippet() -> None:
 
     runner = CodeActRunner()
     code = "tool('file__write', path='x')"
-    out = await runner.run(code=code, dispatch=dispatch)
+    out = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is False
     assert out["kind"] == "ToolError"
     assert "no-write" in out["error"]
@@ -71,7 +73,7 @@ async def test_pure_compute_snippet_returns_without_dispatch() -> None:
         raise AssertionError("dispatch must not be called for a pure-compute snippet")
 
     runner = CodeActRunner()
-    out = await runner.run(code="result = sum(range(5))", dispatch=dispatch)
+    out = await runner.run(code="result = sum(range(5))", dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is True, out
     assert out["result"] == 10
 
@@ -84,5 +86,69 @@ async def test_restricted_namespace_blocks_raw_open() -> None:
         return {"status": "ok", "data": None}
 
     runner = CodeActRunner()
-    out = await runner.run(code="result = open('/etc/passwd').read()", dispatch=dispatch)
+    out = await runner.run(code="result = open('/etc/passwd').read()", dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is False  # safe-mode AST/builtins blocks the open reference
+
+
+# ── S2b: fail-closed gate + the real OS sandbox (Seatbelt) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_when_no_sandbox_backend() -> None:
+    """Tier 2: no sandbox + not allow_unsandboxed → refused (sandbox_unavailable),
+    NOT silently run unsandboxed (the owner-signed fail-closed posture)."""
+
+    async def dispatch(name: str, args: dict) -> dict:
+        raise AssertionError("must not run the snippet when fail-closed")
+
+    runner = CodeActRunner()
+    out = await runner.run(code="result = 1", dispatch=dispatch)  # no backend, no escape
+    assert out["ok"] is False
+    assert out["status"] == "sandbox_unavailable"
+    assert out["kind"] == "SandboxUnavailable"
+
+
+@pytest.mark.asyncio
+async def test_noop_backend_is_fail_closed() -> None:
+    """Tier 2: a noop backend (no real isolation) is treated as no-sandbox → refused."""
+    from reyn.sandbox.noop_backend import NoopBackend  # noqa: PLC0415
+
+    async def dispatch(name: str, args: dict) -> dict:
+        raise AssertionError("must not run under noop")
+
+    runner = CodeActRunner()
+    out = await runner.run(code="result = 1", dispatch=dispatch, sandbox_backend=NoopBackend())
+    assert out["status"] == "sandbox_unavailable"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="SeatbeltBackend macOS only")
+@pytest.mark.asyncio
+async def test_seatbelt_real_runner_round_trip() -> None:
+    """Tier 2: the permission-proxy round-trip works through the REAL CodeActRunner
+    under an actual Seatbelt sandbox (fd-survival re-verified via the runner path,
+    not a standalone probe). Network is denied by the default policy; the AF_UNIX
+    control fd still round-trips."""
+    from reyn.sandbox.backends.seatbelt import SeatbeltBackend  # noqa: PLC0415
+
+    backend = SeatbeltBackend()
+    if not backend.available():
+        pytest.skip("sandbox-exec not available")
+
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": {"n": args.get("n", 0) + 1}}
+
+    runner = CodeActRunner()
+    code = "result = tool('m', n=41)['n']"
+    out = await runner.run(
+        code=code,
+        dispatch=dispatch,
+        sandbox_backend=backend,
+        sandbox_policy={"network": False, "env_passthrough": ["PATH"]},
+        timeout=30,
+    )
+    assert out["ok"] is True, out
+    assert out["result"] == 42
+    assert seen == [("m", {"n": 41})]

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -37,10 +37,14 @@ async def test_tool_call_round_trips_to_parent_dispatch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_multiple_sequential_tool_calls() -> None:
-    """Tier 2: several mid-execution tool() calls each round-trip, in order."""
+async def test_gate_reenters_every_call_not_once() -> None:
+    """Tier 2: the per-call gate re-entry invariant — N in-code tool() calls invoke
+    the gate (exclude + dispatch) N times (EVERY call, not once/cached). This is the
+    "CodeAct call >= JSON call" property: each proxied call is gated like a JSON one."""
+    gate_calls: list[tuple[str, dict]] = []
 
     async def dispatch(name: str, args: dict) -> dict:
+        gate_calls.append((name, args))
         return {"status": "ok", "data": args.get("n", 0) * 2}
 
     runner = CodeActRunner()
@@ -48,6 +52,43 @@ async def test_multiple_sequential_tool_calls() -> None:
     out = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
     assert out["ok"] is True, out
     assert out["result"] == [0, 2, 4]
+    # The gate fired once PER call (3x), in order — not deduped, not cached.
+    assert gate_calls == [("m", {"n": 0}), ("m", {"n": 1}), ("m", {"n": 2})]
+
+
+@pytest.mark.asyncio
+async def test_exclude_gate_blocks_per_call_mixed() -> None:
+    """Tier 2: an excluded tool is rejected on EVERY call (mid a sequence of allowed
+    calls), exactly as the JSON-path #1406/#187 pre-dispatch exclude gate would —
+    the gate re-enters per call, so exclude is enforced per call (not once)."""
+    seen: list[str] = []
+    excluded = {"web__search"}
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append(name)
+        # Mirror the OS pre-dispatch exclude gate on the resolved effective name.
+        if name in excluded:
+            return {"status": "error", "error": {"kind": "tool_excluded", "message": "excluded"}}
+        return {"status": "ok", "data": "ok"}
+
+    runner = CodeActRunner()
+    # allowed, excluded (caught), allowed — the snippet try/excepts the ToolError.
+    code = (
+        "out = [tool('file__read', p=1)]\n"
+        "try:\n"
+        "    tool('web__search', q='x')\n"
+        "except Exception as e:\n"
+        "    out.append('blocked:' + type(e).__name__)\n"
+        "out.append(tool('file__read', p=2))\n"
+        "result = out"
+    )
+    res = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
+    assert res["ok"] is True, res
+    # tool() returns the success envelope's `data` ("ok"); the excluded call raised
+    # ToolError, caught by the snippet → "blocked:ToolError".
+    assert res["result"] == ["ok", "blocked:ToolError", "ok"]
+    # The gate was consulted for EACH call including the excluded one (per-call).
+    assert seen == ["file__read", "web__search", "file__read"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -1,0 +1,92 @@
+"""Tier 2: #1593 PR-3 S3a — CodeActScheme (interpret + execute glue + feedback).
+
+CodeAct is own-logic (not delegating). This pins:
+  - interpret extracts the snippet (fenced or bare) as a CodeBlock.
+  - execute threads the OS per-call gate (exec_ctx.extra['dispatch']) + sandbox into
+    the CodeActRunner and wraps the result — and REQUIRES the gate (no silent
+    ungated run).
+  - format_feedback passes the runner envelope(s) through.
+
+The per-call gate RE-ENTRY invariant (N calls → N gate invocations, exclude
+per-call) is pinned at the runner level in test_codeact_runner_1593.py (the gate is
+the dispatch callback execute forwards). Here we use a real Fake runner (records
+what execute forwarded) — no mocks; build_presentation is S3b (async, e2e adapter).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult
+from reyn.tools.schemes.codeact import CodeActScheme
+
+
+class _FakeRunner:
+    """Records the args execute forwards; returns a canned envelope. A real Fake
+    (implements ``run``), not a mock."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def run(self, **kwargs) -> dict:
+        self.calls.append(kwargs)
+        return {"ok": True, "status": "ok", "result": "ran"}
+
+
+def test_interpret_extracts_fenced_code() -> None:
+    """Tier 2: interpret pulls the fenced ```python block as the CodeBlock."""
+    resp = SimpleNamespace(content="here:\n```python\nresult = tool('m')\n```\nthanks")
+    interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
+    assert isinstance(interp, CodeBlock)
+    assert interp.code.strip() == "result = tool('m')"
+
+
+def test_interpret_bare_content_when_no_fence() -> None:
+    """Tier 2: interpret falls back to the whole content when there is no fence."""
+    resp = SimpleNamespace(content="result = 1 + 1")
+    interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
+    assert interp.code == "result = 1 + 1"
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_gate_and_sandbox_into_runner() -> None:
+    """Tier 2: execute forwards the OS gate (exec_ctx.extra['dispatch']) + the
+    sandbox + code into the runner, and wraps the envelope in ExecutionResult."""
+    runner = _FakeRunner()
+    scheme = CodeActScheme(runner=runner)
+
+    async def gate(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": None}
+
+    sentinel_sandbox = object()
+    exec_ctx = ExecContext(
+        sandbox=sentinel_sandbox,
+        extra={"dispatch": gate, "sandbox_policy": {"network": False}, "timeout": 12},
+    )
+    res = await scheme.execute(CodeBlock(code="result = tool('m')"), exec_ctx, ops=None)
+
+    assert isinstance(res, ExecutionResult)
+    assert res.tool_results == [{"ok": True, "status": "ok", "result": "ran"}]
+    forwarded = runner.calls[0]
+    assert forwarded["dispatch"] is gate           # the OS gate is threaded through
+    assert forwarded["sandbox_backend"] is sentinel_sandbox
+    assert forwarded["code"] == "result = tool('m')"
+    assert forwarded["sandbox_policy"] == {"network": False}
+    assert forwarded["timeout"] == 12
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_the_os_gate() -> None:
+    """Tier 2: execute refuses to run without the OS gate (no silent ungated run)."""
+    scheme = CodeActScheme(runner=_FakeRunner())
+    exec_ctx = ExecContext(sandbox=object(), extra={})  # no 'dispatch'
+    with pytest.raises(ValueError, match="dispatch"):
+        await scheme.execute(CodeBlock(code="x = 1"), exec_ctx, ops=None)
+
+
+def test_format_feedback_passthrough() -> None:
+    """Tier 2: format_feedback returns the runner envelopes unchanged."""
+    scheme = CodeActScheme(runner=_FakeRunner())
+    results = [{"ok": True, "result": 1}]
+    assert scheme.format_feedback(ExecutionResult(tool_results=results), ops=None) == results

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -5,12 +5,15 @@ CodeAct is own-logic (not delegating). This pins:
   - execute threads the OS per-call gate (exec_ctx.extra['dispatch']) + sandbox into
     the CodeActRunner and wraps the result — and REQUIRES the gate (no silent
     ungated run).
-  - format_feedback passes the runner envelope(s) through.
+  - format_feedback shapes each runner envelope into a user-role observation message
+    (the CodeBlock arm's append shape; the documented Execute/CodeBlock divergence).
+  - build_presentation renders the actions as a code-API in sp_fragment (no JSON
+    tools=), with excluded actions omitted (presentation parity with JSON).
 
 The per-call gate RE-ENTRY invariant (N calls → N gate invocations, exclude
 per-call) is pinned at the runner level in test_codeact_runner_1593.py (the gate is
-the dispatch callback execute forwards). Here we use a real Fake runner (records
-what execute forwarded) — no mocks; build_presentation is S3b (async, e2e adapter).
+the dispatch callback execute forwards). Real Fake runner / Fake SchemeOps (record
+what's forwarded) — no mocks.
 """
 from __future__ import annotations
 
@@ -85,11 +88,23 @@ async def test_execute_requires_the_os_gate() -> None:
         await scheme.execute(CodeBlock(code="x = 1"), exec_ctx, ops=None)
 
 
-def test_format_feedback_passthrough() -> None:
-    """Tier 2: format_feedback returns the runner envelopes unchanged."""
+def test_format_feedback_shapes_observation_message() -> None:
+    """Tier 2: format_feedback shapes each runner envelope into a user-role
+    observation message (the CodeAct ReAct observation turn) — result on success,
+    error/kind on failure — for the loop's CodeBlock arm to append (not raw
+    tool_results; the documented Execute/CodeBlock divergence)."""
     scheme = CodeActScheme(runner=_FakeRunner())
-    results = [{"ok": True, "result": 1}]
-    assert scheme.format_feedback(ExecutionResult(tool_results=results), ops=None) == results
+    ok = scheme.format_feedback(
+        ExecutionResult(tool_results=[{"ok": True, "result": 42}]), ops=None,
+    )
+    assert ok[0]["role"] == "user"
+    assert "42" in ok[0]["content"]
+    err = scheme.format_feedback(
+        ExecutionResult(tool_results=[{"ok": False, "kind": "ToolError", "error": "denied"}]),
+        ops=None,
+    )
+    assert err[0]["role"] == "user"
+    assert "denied" in err[0]["content"]
 
 
 # ── S3b: build_presentation (code-API render into sp_fragment) ────────────────
@@ -129,3 +144,15 @@ async def test_build_presentation_includes_arg_names() -> None:
     """Tier 2: an action's schema arg names appear in its code-API signature."""
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
     assert "path" in pres.sp_fragment  # file__read's parameters.properties key
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_omits_excluded_actions() -> None:
+    """Tier 2: presentation parity (#1400) — an excluded action is omitted from the
+    code-API (CodeAct presentation not looser than JSON tools=). The OS supplies the
+    exclude-set via available['exclude_tools']."""
+    pres = await CodeActScheme().build_presentation(
+        {"exclude_tools": frozenset({"web__fetch"})}, {}, _CatalogOps(),
+    )
+    assert "file__read" in pres.sp_fragment   # kept
+    assert "web__fetch" not in pres.sp_fragment  # excluded → omitted

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -156,3 +156,18 @@ async def test_build_presentation_omits_excluded_actions() -> None:
     )
     assert "file__read" in pres.sp_fragment   # kept
     assert "web__fetch" not in pres.sp_fragment  # excluded → omitted
+
+
+# ── S4: registration + selectability ─────────────────────────────────────────
+
+
+def test_codeact_scheme_registered_and_selectable() -> None:
+    """Tier 2: CodeActScheme is registered under 'codeact' and resolves by name
+    (selectable via tool_use=codeact); universal stays the default (not codeact)."""
+    from reyn.chat.router_loop import _resolve_tool_use_scheme
+
+    selected = _resolve_tool_use_scheme("codeact")
+    assert selected.name == "codeact"
+    assert isinstance(selected, CodeActScheme)
+    # Default is unchanged (universal-category), not codeact.
+    assert _resolve_tool_use_scheme(None).name == "universal-category"

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -90,3 +90,42 @@ def test_format_feedback_passthrough() -> None:
     scheme = CodeActScheme(runner=_FakeRunner())
     results = [{"ok": True, "result": 1}]
     assert scheme.format_feedback(ExecutionResult(tool_results=results), ops=None) == results
+
+
+# ── S3b: build_presentation (code-API render into sp_fragment) ────────────────
+
+
+class _CatalogOps:
+    """A real Fake SchemeOps exposing the async ``catalog_entries`` adapter (#1599)."""
+
+    async def catalog_entries(self) -> list[dict]:
+        return [
+            {"name": "file__read", "description": "Read a file.",
+             "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}},
+            {"name": "web__fetch", "description": "Fetch a URL.\nSecond line ignored.",
+             "parameters": {"type": "object", "properties": {}}},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_renders_code_api_into_sp_fragment() -> None:
+    """Tier 2: build_presentation renders the actions as a code-API in sp_fragment
+    (no JSON tools=); behavior-pinned (action names + tool() proxy instruction
+    present), not format-pinned."""
+    pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
+    # No JSON tools= — CodeAct presents via the SP fragment, model writes a snippet.
+    assert pres.llm_tools_payload == []
+    # The actions surface in the code-API + the tool() proxy is instructed.
+    assert "file__read" in pres.sp_fragment
+    assert "web__fetch" in pres.sp_fragment
+    assert "tool(" in pres.sp_fragment
+    # The named SP gates are off (CodeAct expresses tool-use via the fragment).
+    assert pres.sp_params.get("universal_wrappers_enabled") is False
+    assert pres.sp_params.get("search_actions_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_includes_arg_names() -> None:
+    """Tier 2: an action's schema arg names appear in its code-API signature."""
+    pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
+    assert "path" in pres.sp_fragment  # file__read's parameters.properties key


### PR DESCRIPTION
**[dogfood-coder]** — the 4th `ToolUseScheme` (#1593), completing the abstraction (universal-category / enumerate-all / retrieval / **CodeAct**). The LLM writes a Python snippet; tool calls happen as in-code `tool()` calls, each re-entering the SAME OS exclude + `dispatch_tool` + permission gate as a JSON call. Owner security-signed-off the model (existing-mechanism reuse); builds on the merged loop-unify (#1602), sp_fragment (#1601), catalog_entries (#1598).

## Architecture (reuses proven infra; one new mechanism)
```
LLM code → sandboxed subprocess (CodeActRunner: Seatbelt/Landlock SandboxPolicy, fail-closed)
            │  direct FS-write / network / subprocess / unbounded-time = BLOCKED by the sandbox
            └─ tool(name, **args) ──duplex socketpair──> PARENT os_gate:
                  _excluded_result (exclude, pre-dispatch) → _dispatch_resolved (dispatch_tool → permission_resolver, P5)
```
The **only new mechanism** = the permission-proxy IPC callback (the harness was one-shot; CodeAct needs synchronous mid-execution tool() calls). Everything else reuses existing infra: SandboxBackend (`sandboxed_exec`), the `_python_harness` restricted-namespace pattern, `dispatch_tool`/`permission_resolver`, the PR-1 exclude gate.

## Pieces
- **S2a/S2b** `CodeActRunner` + `_codeact_harness` — duplex socketpair permission-proxy + Seatbelt wrap (reuses `_build_sbpl_profile`) + fail-closed (no real sandbox → refused).
- **S3a** `CodeActScheme` — interpret (extract CodeBlock) / execute (run via runner under the OS gate) / format_feedback (observation message).
- **S3b** `build_presentation` — renders the code-API into `sp_fragment` (excluded omitted).
- **CodeBlock arm** — the OS-loop `case CodeBlock` (design (a)): `_run_codeblock_round` → [assistant: code] + observation append, separate from the Execute zip.
- **S4** — registered + selectable (`tool_use=codeact`); universal default unchanged.

## Security-review axes (per lead)
- **Fail-closed** — no real backend (None/noop/unavailable) → `sandbox_unavailable`, never a silent unsandboxed run. `allow_unsandboxed` is a test-only escape (production never sets it). *Tests: `test_fail_closed_when_no_sandbox_backend`, `test_noop_backend_is_fail_closed`.*
- **Per-call gate re-entry** ("CodeAct ≥ JSON") — N in-code `tool()` calls → N gate invocations (every call, not once); excluded blocked per-call mid-sequence. *Tests: `test_gate_reenters_every_call_not_once`, `test_exclude_gate_blocks_per_call_mixed`.*
- **fd boundary** — the inherited AF_UNIX socketpair is the single audited channel; carries only marshalled tool calls (each re-gated). Survives Seatbelt under `(deny default)+(deny network*)` — *verified via the real runner: `test_seatbelt_real_runner_round_trip` (macOS).*
- **format_feedback divergence** — Execute → tool_results-for-zip / CodeBlock → messages-for-append. Documented-debt (lead-accepted); unification = lead's tracked follow-up, out of PR-3 scope.
- **exclude-parity** — code-API omits excluded actions (#1400 parity), so CodeAct presentation isn't looser than JSON tools= (the per-call gate is the real enforcement; this closes the presentation face). *Test: `test_build_presentation_omits_excluded_actions`.*
- **Landlock honest-scope** — Seatbelt verified live (macOS); Landlock wrap is **fail-closed/deferred** (the landlock backend itself is unvalidated; same posture as #1527, live-verify pending a Linux env).

## Test plan
- [x] CodeActRunner (8): round-trip / sequential gate-reentry / exclude-per-call / pure-compute / restricted-ns / fail-closed×2 / real Seatbelt round-trip (macOS).
- [x] CodeActScheme (9): interpret / execute-gate-thread / requires-gate / format_feedback observation / build_presentation render+args+exclude-omission / S4 selectability.
- [x] CodeBlock-arm coexistence (1, Tier 2, run()-level) — CodeBlock seq vs Execute zip.
- [x] Execute/PlainText routing byte-identical (broad router suite green); 62 PR-3 + guard tests green; ruff + strict tier-audit clean.

## Tier-rule self-check
- [x] Each test docstring declares its Tier; no Tier-4 (strict-audit clean, behavior-pinned not format-pinned); no mocks (real subprocess/socketpair + Fake host/scheme/SchemeOps); no invariant weakening (Execute byte-identical guard).

@lead-coder — security-critical full review (the 6 axes above). @e2e-coder — seam co-vet (CodeBlock arm + the 4-method IF). CodeAct is registered-but-not-default ⇒ zero production risk until a config opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)