### PR TITLE
fix(1609): propagate parent reyn tree to the CodeActRunner harness subprocess PYTHONPATH

### DIFF
--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -29,7 +29,26 @@ import signal
 import socket
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any, Awaitable, Callable
+
+
+def _harness_subprocess_env() -> dict[str, str]:
+    """Env for the harness subprocess with the PARENT process's reyn tree propagated
+    onto PYTHONPATH (#1609). Without this, ``python -m reyn.kernel._codeact_harness``
+    resolves ``reyn`` from the spawned interpreter's default ``sys.path`` — which in a
+    multi-worktree editable-install dev env can point at a DIFFERENT worktree lacking
+    this harness module (``No module named reyn.kernel._codeact_harness``). Prepending
+    this process's reyn tree makes the subprocess resolve the SAME tree. Production
+    (single reyn install) is unaffected — same path either way. (``REYN_HARNESS_PYTHON``
+    still overrides the *interpreter*; this fixes the *module-resolution* default.)"""
+    import reyn  # noqa: PLC0415
+
+    tree = str(Path(reyn.__file__).resolve().parent.parent)  # dir containing the reyn pkg
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = tree + (os.pathsep + existing if existing else "")
+    return env
 
 # A dispatch callback: (name, args) -> the dispatch_tool result envelope
 # ({"status": "ok", "data": ...} | {"status": "error", "error": {...}}). The
@@ -107,6 +126,7 @@ class CodeActRunner:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=cwd,
+                env=_harness_subprocess_env(),  # #1609: parent reyn tree on PYTHONPATH
                 start_new_session=True,
             )
         except OSError as exc:

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -193,3 +193,35 @@ async def test_seatbelt_real_runner_round_trip() -> None:
     assert out["ok"] is True, out
     assert out["result"] == 42
     assert seen == [("m", {"n": 41})]
+
+
+# ── #1609: harness subprocess PYTHONPATH propagation (multi-worktree drift) ───
+
+
+def test_harness_subprocess_env_prepends_reyn_tree() -> None:
+    """Tier 2: #1609 — the harness subprocess env prepends THIS process's reyn tree
+    to PYTHONPATH, so `python -m reyn.kernel._codeact_harness` resolves the SAME tree
+    (fixes the multi-worktree editable-install import-drift). Single-tree prod is
+    unaffected (same path)."""
+    import os
+    from pathlib import Path
+
+    import reyn
+    from reyn.kernel.codeact_runner import _harness_subprocess_env
+
+    tree = str(Path(reyn.__file__).resolve().parent.parent)
+    env = _harness_subprocess_env()
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == tree  # parent tree resolved first
+
+
+def test_harness_subprocess_env_preserves_existing_pythonpath(monkeypatch) -> None:
+    """Tier 2: #1609 — an existing PYTHONPATH is preserved (appended after the tree),
+    not clobbered."""
+    import os
+
+    monkeypatch.setenv("PYTHONPATH", "/some/existing/path")
+    from reyn.kernel.codeact_runner import _harness_subprocess_env
+
+    parts = _harness_subprocess_env()["PYTHONPATH"].split(os.pathsep)
+    assert "/some/existing/path" in parts
+    assert parts[-1] == "/some/existing/path"  # appended after the prepended tree


### PR DESCRIPTION
**[dogfood-coder]** — closes #1609 (issue owner: e2e-coder, who surfaced it; fix in my `codeact_runner.py`).

## Problem (dev-env only; CI / production unaffected)
`CodeActRunner` spawns `python -m reyn.kernel._codeact_harness`. In a **multi-worktree editable-install** dev setup, the spawned interpreter's default `sys.path` can resolve `reyn` to a *different* worktree's tree — one lacking PR-3's new harness module → `No module named reyn.kernel._codeact_harness` (the #1605 import-drift class, surfaced in the runner subprocess by e2e's secondary worktree). Single-tree CI and production are unaffected (one reyn install).

## Fix
The runner now passes `env=_harness_subprocess_env()` to the Popen — prepending **this** process's reyn tree (`Path(reyn.__file__).parent.parent`) to `PYTHONPATH`, so the subprocess resolves the SAME tree as the parent. Existing `PYTHONPATH` preserved (appended after). `REYN_HARNESS_PYTHON` still overrides the *interpreter*; this fixes the *module-resolution* default. Mirrors `python_runner`'s tree-consistency intent.

## Test plan
- [x] `test_harness_subprocess_env_prepends_reyn_tree` — parent tree resolved first.
- [x] `test_harness_subprocess_env_preserves_existing_pythonpath` — existing PYTHONPATH appended, not clobbered.
- [x] 11 runner tests green (incl. the real-subprocess round-trips now under `env=`); ruff + strict tier-audit clean.
- [ ] (e2e) — verify the real drift resolution on the secondary worktree (the natural reproducer): the round-trip resolves `reyn.kernel._codeact_harness` WITHOUT needing `REYN_HARNESS_PYTHON`/`PYTHONPATH` set manually.

## Tier-rule self-check
- [x] Tier declared; behavior-pinned (tree-prepend / preservation), not format-pinned; no mocks (real env dict).

@e2e-coder — your verify is the load-bearing proof (your env reproduces the drift). Ping when checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)