### PR TITLE
feat(1608) Stage-1: unify format_feedback to appendable-messages contract (P7, byte-identical)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2030,6 +2030,7 @@ class RouterLoop:
             from reyn.tools.scheme import (  # noqa: PLC0415
                 CodeBlock,
                 Execute,
+                ExecutionResult,
                 RePresent,
             )
             interp = self._scheme.interpret(
@@ -2525,112 +2526,23 @@ class RouterLoop:
                             meta={"chain_id": self.chain_id, "source": "spawn_ack"},
                         )
                         return self._total_usage
-                # No delegation — accumulate messages for next iteration.
-                # Use deduped tool_calls so the assistant message and tool
-                # result messages stay in sync (matching tool_call_ids).
-                assistant_content = result.content or ""
-                messages.append({
-                    "role": "assistant",
-                    "content": assistant_content,
-                    "tool_calls": tool_calls,
-                })
-                # E-full PR-E (#383): persist this assistant tool-call turn
-                # into chat history so the next ``_build_history_for_router``
-                # rebuild emits the same message sequence — without this,
-                # follow-up user turns lose visibility into what tools were
-                # invoked + with what args.
-                #
-                # ``getattr`` guard: test fakes that pre-date PR-E may not
-                # implement ``append_history_entry``. Production hosts
-                # (= RouterHostAdapter) always implement it.
-                _append_entry = getattr(host, "append_history_entry", None)
-                if _append_entry is not None:
-                    _append_entry(
-                        role="assistant",
-                        content=assistant_content,
-                        meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
+                # #1608: the active scheme builds the appendable message sequence
+                # (assistant tool-call turn + per-result {role:tool, tool_call_id}
+                # messages + media follow-ups) AND persists each to history; the OS
+                # only *appends*. universal / enumerate-all / retrieval delegate to
+                # ops.feedback (the relocated construction) → the OS loop no longer
+                # inlines the JSON tool_call/result zip (P7). tool_calls[i] aligns
+                # with tool_results[i] (the #1406/#187 excluded-in-place row keeps its
+                # index). CodeBlock/RePresent never reach here (separate arms).
+                for _fb_msg in self._scheme.format_feedback(
+                    ExecutionResult(
+                        tool_results=tool_results,
                         tool_calls=tool_calls,
-                    )
-                for tc, r in zip(tool_calls, tool_results):
-                    # B41-NF-W7-1: tool handlers may attach `_post_text` to
-                    # the result dict to surface a textual directive after
-                    # the JSON-serialised content (= a place the LLM reads
-                    # as instruction, not as part of the structured data).
-                    # The field is stripped before JSON serialisation and
-                    # appended outside the JSON body. P3-clean: OS handles
-                    # the serialisation contract, tool handler declares
-                    # intent via an optional field.
-                    post_text: str | None = None
-                    if isinstance(r, dict) and isinstance(r.get("_post_text"), str):
-                        post_text = r["_post_text"]
-                        r = {k: v for k, v in r.items() if k != "_post_text"}
-
-                    # Issue #362: extract MCP media blocks (= image, etc.)
-                    # BEFORE JSON-serialising the tool result. The blocks
-                    # would JSON-stringify into the tool message as opaque
-                    # base64 (= wasted tokens) — instead, surface them as a
-                    # multimodal follow-up user message so vision-capable
-                    # models actually see the image. Strip from `r` so the
-                    # tool result text stays compact.
-                    media_blocks: list[dict] = []
-                    if isinstance(r, dict) and isinstance(r.get("media_blocks"), list):
-                        media_blocks = list(r["media_blocks"])
-                        r = {k: v for k, v in r.items() if k != "media_blocks"}
-
-                    content_str = json.dumps(r, default=str)
-                    if post_text:
-                        content_str = f"{content_str}\n\n---\n{post_text}"
-                    # #1128 size axis (dead-end #1): cap an oversized tool result
-                    # ONCE at this chokepoint — the full body is offloaded to the
-                    # #385 store (lossless) and content_str becomes a bounded
-                    # preview, so BOTH consumers below (the live prompt append +
-                    # the persisted-history _append_entry) get the capped form.
-                    # This makes every tool turn individually compactable, so the
-                    # chat retry_loop's shrink can always fold it. getattr keeps
-                    # partial/test hosts a no-op.
-                    _cap = getattr(self.host, "cap_tool_result", None)
-                    if _cap is not None:
-                        content_str = _cap(content_str)
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc["id"],
-                        "content": content_str,
-                    })
-                    # E-full PR-E (#383): persist this tool response so the
-                    # next router turn sees what the tool returned (= image
-                    # follow-up / grep result follow-up / multi-step plan
-                    # use cases listed in #383). The path-ref shape from
-                    # PR-C keeps storage light when results contain media.
-                    if _append_entry is not None:
-                        _append_entry(
-                            role="tool",
-                            content=content_str,
-                            meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
-                            tool_call_id=tc["id"],
-                            name=tc.get("function", {}).get("name"),
-                        )
-                    if media_blocks:
-                        # Issue #383 PR-C: pass the host's media_store so
-                        # path-ref blocks are materialised to data URLs at
-                        # the LLM wire boundary. ``getattr`` keeps tests
-                        # that mock the host with bare attributes happy.
-                        # #272: bound the media follow-up to the budget left
-                        # after the (already-capped) tool text, so the whole
-                        # result turn stays ≤ the per-turn cap. Overflow media
-                        # stays a small lossless ref. getattr keeps partial/test
-                        # hosts unbounded (pre-#272 behaviour).
-                        _media_budget = getattr(host, "media_followup_budget", None)
-                        _budget_tokens = (
-                            _media_budget(content_str) if _media_budget is not None else None
-                        )
-                        followup = _build_media_followup_message(
-                            tool_name=tc.get("function", {}).get("name", "tool"),
-                            media_blocks=media_blocks,
-                            media_store=getattr(host, "media_store", None),
-                            budget_tokens=_budget_tokens,
-                        )
-                        if followup is not None:
-                            messages.append(followup)
+                        assistant_content=result.content or "",
+                    ),
+                    ops=self,
+                ):
+                    messages.append(_fb_msg)
 
                 # B51 NF-W6-3: plan_invalid self-correction loop. When the
                 # plan tool returned ``{status:error, error:{kind:plan_invalid}}``
@@ -3293,11 +3205,80 @@ class RouterLoop:
             self._dispatch_resolved(a["name"], a["args"]) for a in actions
         ])
 
-    def feedback(self, tool_results: list[dict]) -> list[dict]:
-        """SchemeOps.feedback: PR-1 identity — the OS loop's existing feedback
-        assembly (op-specific plan/invoke_skill + media + message building) consumes
-        ``tool_results`` unchanged. A non-universal scheme (PR-2/3) transforms here."""
-        return tool_results
+    def feedback(self, result: "ExecutionResult") -> list[dict]:
+        """SchemeOps.feedback (#1608): build the **appendable message sequence** for
+        an Execute round — the assistant tool-call turn + the per-result
+        ``{role:tool, tool_call_id, content}`` messages (+ media follow-ups) — and
+        persist each to chat history. This is the OS loop's former inline zip,
+        relocated **byte-identically**: the delegating schemes (universal /
+        enumerate-all / retrieval) return this, and the OS loop only *appends*, so it
+        no longer knows the JSON tool_call/result correlation shape (P7). Relies on
+        ``result.tool_calls[i]`` aligning with ``result.tool_results[i]`` (un-reordered
+        — the #1406/#187 excluded-in-place result keeps its index)."""
+        host = self.host
+        _append_entry = getattr(host, "append_history_entry", None)
+        out: list[dict] = []
+        assistant_content = result.assistant_content
+        out.append({
+            "role": "assistant",
+            "content": assistant_content,
+            "tool_calls": result.tool_calls,
+        })
+        if _append_entry is not None:
+            _append_entry(
+                role="assistant",
+                content=assistant_content,
+                meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
+                tool_calls=result.tool_calls,
+            )
+        for tc, r in zip(result.tool_calls, result.tool_results):
+            # B41-NF-W7-1: _post_text → appended outside the JSON body.
+            post_text: str | None = None
+            if isinstance(r, dict) and isinstance(r.get("_post_text"), str):
+                post_text = r["_post_text"]
+                r = {k: v for k, v in r.items() if k != "_post_text"}
+            # Issue #362: extract media blocks BEFORE serialising (surfaced as a
+            # multimodal follow-up user message, not base64 in the tool text).
+            media_blocks: list[dict] = []
+            if isinstance(r, dict) and isinstance(r.get("media_blocks"), list):
+                media_blocks = list(r["media_blocks"])
+                r = {k: v for k, v in r.items() if k != "media_blocks"}
+            content_str = json.dumps(r, default=str)
+            if post_text:
+                content_str = f"{content_str}\n\n---\n{post_text}"
+            # #1128: cap oversized tool results once at this chokepoint.
+            _cap = getattr(host, "cap_tool_result", None)
+            if _cap is not None:
+                content_str = _cap(content_str)
+            out.append({
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": content_str,
+            })
+            # E-full PR-E (#383): persist the tool response (capped form).
+            if _append_entry is not None:
+                _append_entry(
+                    role="tool",
+                    content=content_str,
+                    meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
+                    tool_call_id=tc["id"],
+                    name=tc.get("function", {}).get("name"),
+                )
+            if media_blocks:
+                # Issue #383 PR-C / #272: bounded media follow-up message.
+                _media_budget = getattr(host, "media_followup_budget", None)
+                _budget_tokens = (
+                    _media_budget(content_str) if _media_budget is not None else None
+                )
+                followup = _build_media_followup_message(
+                    tool_name=tc.get("function", {}).get("name", "tool"),
+                    media_blocks=media_blocks,
+                    media_store=getattr(host, "media_store", None),
+                    budget_tokens=_budget_tokens,
+                )
+                if followup is not None:
+                    out.append(followup)
+        return out
 
     async def _run_execute_round(self, interp) -> "tuple[list[dict], list[dict]]":
         """The ``Execute`` arm — **byte-identical** to the former
@@ -3323,10 +3304,11 @@ class RouterLoop:
         )
         for (i, _), r in zip(to_dispatch, exec_res.tool_results):
             results[i] = r
-        tool_results = self._scheme.format_feedback(
-            ExecutionResult(tool_results=results), ops=self,
-        )
-        return tool_calls, tool_results
+        # #1608: return the RAW (tool_calls, results) — the 8 lifecycle/audit sites
+        # (async / spawn-ack / plan / error / routing) consume the pair, and the OS
+        # Execute branch hands it to ``format_feedback`` for the message build. (The
+        # former format_feedback call here was a no-op passthrough.)
+        return tool_calls, results
 
     async def _run_codeblock_round(self, interp) -> "list[dict]":
         """The ``CodeBlock`` arm body — run the CodeAct snippet via the scheme's

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -119,9 +119,18 @@ Interpretation = Execute | RePresent | CodeBlock | PlainText
 class ExecutionResult:
     """The outcome of executing an ``Interpretation`` — per-action tool results
     (JSON-serialisable dicts), consumed by ``format_feedback`` and by the OS loop's
-    scheme-agnostic op-specific handling (plan / invoke_skill)."""
+    scheme-agnostic op-specific handling (plan / invoke_skill).
+
+    ``tool_calls`` + ``assistant_content`` (#1608) enrich the result so a scheme's
+    ``format_feedback`` can build the **full** appendable message sequence (the
+    assistant tool-call turn + the per-result ``{role:tool, tool_call_id}`` messages)
+    — moving the OS loop's former inline zip into the scheme (P7). Both default empty
+    so non-Execute schemes (CodeAct reads only ``tool_results``) are unaffected;
+    ``tool_calls[i]`` aligns with ``tool_results[i]`` (un-reordered — #1406/#187)."""
 
     tool_results: list[dict]
+    tool_calls: list[dict] = field(default_factory=list)
+    assistant_content: str = ""
 
 
 @dataclass
@@ -160,7 +169,7 @@ class SchemeOps(Protocol):
     def present(self, available: Any, layer_ctx: Any) -> Presentation: ...
     def resolve(self, llm_response: Any, tool_catalog: dict) -> list[dict]: ...
     async def dispatch(self, actions: list[dict]) -> list[dict]: ...
-    def feedback(self, tool_results: list[dict]) -> list[dict]: ...
+    def feedback(self, result: "ExecutionResult") -> list[dict]: ...
 
     # Building blocks for SELF-CONTAINED schemes (#1593 PR-2) — a non-delegating
     # scheme composes its own presentation from these instead of calling the

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -73,7 +73,9 @@ class EnumerateAllScheme:
         return ExecutionResult(tool_results=results)
 
     def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
-        return ops.feedback(result.tool_results)
+        # #1608: delegate to the OS substrate (now returns appendable messages);
+        # enumerate-all's Execute feedback is identical to universal's.
+        return ops.feedback(result)
 
 
 __all__ = ["EnumerateAllScheme"]

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -162,7 +162,9 @@ class RetrievalScheme:
         return ExecutionResult(tool_results=results)
 
     def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
-        return ops.feedback(result.tool_results)
+        # #1608: delegate to the OS substrate (now returns appendable messages);
+        # retrieval's Execute feedback is identical to universal's.
+        return ops.feedback(result)
 
 
 __all__ = ["RetrievalScheme"]

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -67,7 +67,11 @@ class UniversalCategoryScheme:
         return ExecutionResult(tool_results=results)
 
     def format_feedback(self, result: ExecutionResult, ops: SchemeOps) -> list[dict]:
-        return ops.feedback(result.tool_results)
+        # #1608: delegate the full appendable-message build to the OS substrate
+        # (ops.feedback now owns the relocated assistant+tool-message construction);
+        # the OS loop appends what this returns. Byte-identical to the former inline
+        # zip — the enriched ``result`` carries tool_calls + assistant_content.
+        return ops.feedback(result)
 
 
 __all__ = ["UniversalCategoryScheme"]

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -54,8 +54,10 @@ class _FakeOps:
         self.dispatched = actions
         return [{"name": a["name"], "ok": True} for a in actions]
 
-    def feedback(self, tool_results: list[dict]) -> list[dict]:
-        return [{"role": "tool", "content": tr["name"]} for tr in tool_results]
+    def feedback(self, result) -> list[dict]:
+        # #1608: ops.feedback now receives the enriched ExecutionResult; build the
+        # representative messages from its tool_results (delegation unchanged).
+        return [{"role": "tool", "content": tr["name"]} for tr in result.tool_results]
 
 
 def test_enumerate_all_conforms_to_protocol() -> None:

--- a/tests/test_format_feedback_golden_1608.py
+++ b/tests/test_format_feedback_golden_1608.py
@@ -1,0 +1,98 @@
+"""Tier 2: #1608 format_feedback unification — the byte-identical GOLDEN gate.
+
+The Stage-1 unify relocates the Execute message-construction zip (the
+``{role:assistant, tool_calls}`` + per-result ``{role:tool, tool_call_id,
+content}`` build) out of the OS loop and into ``universal.format_feedback``. This
+test pins the **exact message sequence** the LLM sees for an Execute round, so the
+relocation is provably byte-identical — it is the #1406/#187 merge gate
+(sandbox_2 co-vets): every tool_call answered, in order, with its own
+``tool_call_id``, and the **excluded-in-place** call's error result at its own
+index (not dropped).
+
+No mocks: real universal scheme + the real ``_ScriptedLLM`` Fake + ``FakeRouterHost``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import FakeRouterHost, text_result, tool_result
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+class _CapturingLLM:
+    """Scripted LLM that records the ``messages`` it saw each call — so the test can
+    assert the exact sequence the OS built after the Execute round."""
+
+    def __init__(self, script: list[LLMToolCallResult]) -> None:
+        self._script = list(script)
+        self.call_count = 0
+        self.messages_per_call: list[list[dict]] = []
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.messages_per_call.append([dict(m) for m in (kwargs.get("messages") or [])])
+        r = self._script[self.call_count]
+        self.call_count += 1
+        return r
+
+
+@pytest.mark.asyncio
+async def test_execute_round_message_sequence_golden(monkeypatch):
+    """Tier 2: #1608/#1406/#187 — an Execute round with a dispatched call + an
+    EXCLUDED-in-place call produces the exact assistant + per-call tool-message
+    sequence, ids aligned, the excluded call's error at its own index."""
+    host = FakeRouterHost()
+    host._files["a.txt"] = "hello"
+    # file__write is excluded → the pre-dispatch gate must emit a tool_excluded
+    # error result IN PLACE at its index (not drop the call).
+    loop = RouterLoop(
+        host=host, chain_id="chain-golden", max_iterations=5,
+        exclude_tools={"file__write"},
+    )
+
+    round1 = tool_result([
+        {"name": "file__read", "args": {"path": "a.txt"}, "id": "call_read"},
+        {"name": "file__write", "args": {"path": "b.txt", "content": "x"}, "id": "call_write"},
+    ])
+    scripted = _CapturingLLM([round1, text_result("done")])
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", scripted)
+
+    await loop.run("read a then write b", [])
+
+    # The 2nd LLM call saw the post-Execute-round message history.
+    seq = scripted.messages_per_call[1]
+    # Drop the leading system/user turns — focus on the assistant tool-call turn
+    # onward (the Execute round's contribution).
+    asst_idx = next(i for i, m in enumerate(seq) if m.get("role") == "assistant")
+    asst = seq[asst_idx]
+    tool_msgs = [m for m in seq[asst_idx:] if m.get("role") == "tool"]
+
+    # (1) assistant turn carries BOTH tool_calls, in order.
+    assert [tc["id"] for tc in asst["tool_calls"]] == ["call_read", "call_write"]
+
+    # (2) exactly one tool message per tool_call, ids aligned in order (#1406/#187).
+    assert [m["tool_call_id"] for m in tool_msgs] == ["call_read", "call_write"]
+
+    # (3) sandbox_2's excluded-row assert: the EXCLUDED call's tool message is at its
+    # own index with its own id, carrying the tool_excluded error (not dropped, not
+    # reordered).
+    write_msg = tool_msgs[1]
+    assert write_msg["tool_call_id"] == "call_write"
+    write_body = json.loads(write_msg["content"])
+    assert write_body.get("status") == "error"
+    assert write_body.get("error", {}).get("kind") == "tool_excluded"
+
+    # (4) the dispatched call's result is its own message at index 0, with its result
+    # JSON-serialised into the content (the per-result serialization the relocation
+    # must preserve — the exact dispatch outcome is harness-dependent, but it must
+    # round-trip as a structured tool result at its own id).
+    read_msg = tool_msgs[0]
+    assert read_msg["tool_call_id"] == "call_read"
+    read_body = json.loads(read_msg["content"])
+    assert "status" in read_body

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -51,8 +51,10 @@ class _FakeOps:
     async def dispatch(self, actions):
         return [{"status": "ok", "for": a["name"]} for a in actions]
 
-    def feedback(self, tool_results):
-        return tool_results
+    def feedback(self, result):
+        # #1608: ops.feedback now receives the enriched ExecutionResult; the Fake
+        # echoes its tool_results so the delegation assertion stays meaningful.
+        return result.tool_results
 
 
 def _tool(name):

--- a/tests/test_tool_use_scheme_1593.py
+++ b/tests/test_tool_use_scheme_1593.py
@@ -50,9 +50,20 @@ class _RecordingOps:
         self.calls.append("dispatch")
         return [{"status": "ok", "for": a["name"]} for a in actions]
 
-    def feedback(self, tool_results: list[dict]) -> list[dict]:
+    def feedback(self, result) -> list[dict]:
+        # #1608: ops.feedback now receives the enriched ExecutionResult and returns
+        # appendable MESSAGES (the relocated assistant+tool-message build). The Fake
+        # records the delegated result + returns a representative message sequence.
         self.calls.append("feedback")
-        return tool_results
+        self.last_feedback_result = result
+        return [
+            {"role": "assistant", "content": result.assistant_content,
+             "tool_calls": result.tool_calls},
+            *(
+                {"role": "tool", "tool_call_id": tc.get("id"), "content": str(r)}
+                for tc, r in zip(result.tool_calls, result.tool_results)
+            ),
+        ]
 
 
 # ── registry ────────────────────────────────────────────────────────────────
@@ -101,13 +112,22 @@ def test_universal_interpret_execute_with_tool_calls() -> None:
 
 @pytest.mark.asyncio
 async def test_universal_execute_and_feedback_round_trip() -> None:
-    """Tier 2: execute delegates dispatch, format_feedback delegates feedback."""
+    """Tier 2: execute delegates dispatch; format_feedback delegates to ops.feedback
+    with the ENRICHED result and returns appendable MESSAGES (#1608 unified contract,
+    not the former tool_results passthrough)."""
     ops = _RecordingOps()
     scheme = UniversalCategoryScheme()
     res = await scheme.execute(Execute(actions=[{"name": "a"}]), ExecContext(), ops)
     assert res.tool_results == [{"status": "ok", "for": "a"}]
-    fb = scheme.format_feedback(ExecutionResult(tool_results=res.tool_results), ops)
-    assert fb == res.tool_results
+    enriched = ExecutionResult(
+        tool_results=res.tool_results, tool_calls=[{"id": "c1"}], assistant_content="hi",
+    )
+    fb = scheme.format_feedback(enriched, ops)
+    # the full enriched result is delegated (not just tool_results) ...
+    assert ops.last_feedback_result is enriched
+    # ... and the return is appendable messages: assistant turn + one tool message.
+    assert fb[0]["role"] == "assistant" and fb[0]["tool_calls"] == [{"id": "c1"}]
+    assert fb[1]["role"] == "tool" and fb[1]["tool_call_id"] == "c1"
     assert ops.calls.count("dispatch") == 1 and ops.calls.count("feedback") == 1
 
 


### PR DESCRIPTION
**[e2e-coder]** — #1608 Stage-1: unify `format_feedback` to a single "return appendable messages" contract (closes the wave's documented divergence). Lead-approved staging design (#1608 issuecomment-4701263580/4701269134).

## What
The OS loop's inline Execute message-construction zip relocates into the scheme's `format_feedback`, so the **OS loop only appends** — it no longer knows the JSON tool_call/result correlation shape (**P7**). All schemes now return appendable messages (CodeBlock + RePresent already did; Execute now does too — the two-path divergence is resolved).

## Boundary (flow-trace, primary-source — refined lead's rough "~7 sites")
**8 lifecycle/audit `tc⊗r` sites STAY** in the OS (async / spawn-ack / plan / error-fallback / routing-audit — they correlate for *dispatch lifecycle* + early-exit, a P3 concern, not feedback-shape). **1 feedback-shape zip MOVES** (the 2528-2633 message-construction block).

## Changes
- `ExecutionResult` enriched `{tool_calls, assistant_content}` — additive (CodeAct reads only `tool_results`, untouched — sandbox_2 axis-3); `tool_calls[i]↔tool_results[i]` un-reordered.
- `ops.feedback` builds the full message sequence (assistant turn + per-result tool messages + `_post_text`/media/cap + media follow-ups) **and persists** (it has `tool_calls`→the `name` for history); universal/enumerate-all/retrieval delegate (PR-1 pattern); `SchemeOps.feedback`: `tool_results → ExecutionResult`.
- `_run_execute_round` drops its no-op passthrough → raw `(tool_calls, results)` (lifecycle sites unchanged).
- OS Execute branch: ~105-line inline zip → `for m in format_feedback(...): messages.append(m)`.

## Test plan
- [x] **#1406/#187 golden gate** (`test_format_feedback_golden_1608`): the exact Execute message sequence — both tool_calls in order, one `{role:tool}` per call id-aligned, the **excluded-in-place** call's `tool_excluded` error **at its own index with its own tc id** (sandbox_2's assert). Passes on **both** pre- and post-relocation → byte-identical.
- [x] Full suite `pytest -q` rootdir → **7306 passed** (the 2 fails — `test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref` — are pre-existing local-env, fail on clean origin/main too; CI's clean env passes them).
- [x] 656 scheme/router/feedback regression green; the 2 contract-reversal delegation tests rewritten to pin the new messages-return contract.
- [x] `ruff check` + `test_tier_audit.py --strict` on changed files → clean.

## Scope
**Stage-1 only** (byte-identical core unify). Stage-2 (generalize cap/persist to CodeBlock — a behavior change, no byte-identical baseline) deferred per design-review.

lead: architecture/byte-identical review. sandbox_2: #1406/#187 golden + Execute-alignment + CodeBlock-half co-vet (axes pre-agreed on #1608).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
