### PR TITLE
feat(1608 ④): scheme self-registration on import (P7 — OS resolver names no class)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -37,30 +37,20 @@ if TYPE_CHECKING:
 
 
 def _resolve_tool_use_scheme(name: "str | None" = None):
-    """Return the active ``ToolUseScheme`` (#1593). Registers the built-in
-    universal-category scheme on first use (idempotent) and resolves by name,
-    defaulting to universal-category — PR-1 byte-identical. Per-layer config
-    (``tool_use:{chat,step,phase}``) passes the selected name here."""
-    from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme, register_scheme
-    from reyn.tools.schemes.codeact import CodeActScheme
-    from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
-    from reyn.tools.schemes.retrieval import RetrievalScheme
-    from reyn.tools.schemes.universal_category import UniversalCategoryScheme
+    """Return the active ``ToolUseScheme`` (#1593), resolving by name and defaulting
+    to universal-category. Per-layer config (``tool_use:{chat,step,phase}``) passes
+    the selected name here.
 
-    # Register each built-in independently + idempotently (keyed on the scheme's
-    # OWN .name → P7-clean, no scheme-literal in OS code). A single guard on the
-    # default's absence would couple enumerate-all's registration to universal
-    # NOT being registered yet — so anything that registers universal first (a
-    # direct register_scheme caller, a test) would leave enumerate-all absent and
-    # silently fall back to default. Per-scheme guard avoids that sibling gap.
-    for _builtin in (
-        UniversalCategoryScheme(),
-        EnumerateAllScheme(),  # #1593 PR-2
-        RetrievalScheme(),  # #1593 PR-4
-        CodeActScheme(),  # #1593 PR-3 — selectable via tool_use=codeact (not default)
-    ):
-        if get_scheme(_builtin.name) is None:
-            register_scheme(_builtin)
+    #1608 ④: the built-ins **self-register at import time** — this function names NO
+    scheme class (P7 cleanliness). Importing the ``schemes`` package runs every
+    built-in module's import-time ``register_scheme`` (the package ``__init__``
+    imports them all), so the full set is present without the OS resolve knowing any
+    concrete scheme."""
+    # Importing the package self-registers all built-in schemes (the bundle
+    # self-describes; no scheme-literal in OS code). Idempotent — modules import once.
+    import reyn.tools.schemes  # noqa: F401  (register_scheme import-time side effect)
+    from reyn.tools.scheme import DEFAULT_SCHEME_NAME, get_scheme
+
     # Unknown / unconfigured name → default (universal-category) — byte-identical.
     return get_scheme(name or DEFAULT_SCHEME_NAME) or get_scheme(DEFAULT_SCHEME_NAME)
 

--- a/src/reyn/tools/schemes/__init__.py
+++ b/src/reyn/tools/schemes/__init__.py
@@ -1,0 +1,19 @@
+"""Built-in tool-use schemes (#1593).
+
+Each scheme module calls ``register_scheme`` at import time (self-registration),
+and this package ``__init__`` imports every built-in module — so importing the
+package (or *any* submodule, since a submodule import runs the package ``__init__``
+first) registers the full built-in set. The OS scheme resolver
+(``_resolve_tool_use_scheme``) therefore no longer needs to name any scheme class:
+it imports this package and resolves by name (P7 cleanliness, #1608 ④).
+
+Completeness invariant: all built-in scheme names resolve after importing this
+package, with NO prior explicit scheme import by the caller (pinned by a
+fresh-interpreter registry self-test).
+"""
+from . import (  # noqa: F401 — imported for the register_scheme import-time side effect
+    codeact,
+    enumerate_all,
+    retrieval,
+    universal_category,
+)

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -27,7 +27,13 @@ import re
 from typing import Any
 
 from reyn.kernel.codeact_runner import CodeActRunner
-from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, Presentation
+from reyn.tools.scheme import (
+    CodeBlock,
+    ExecContext,
+    ExecutionResult,
+    Presentation,
+    register_scheme,
+)
 
 # A fenced ```python ... ``` (or bare ``` ... ```) block — how the CodeAct LLM
 # emits its snippet in the message content.
@@ -175,3 +181,7 @@ class CodeActScheme:
             {"role": "user", "content": _format_codeact_observation(out)}
             for out in exec_result.tool_results
         ]
+
+
+# #1608: self-register on import (P7 — the OS resolve no longer names this class).
+register_scheme(CodeActScheme())

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -36,6 +36,7 @@ from reyn.tools.scheme import (
     Interpretation,
     Presentation,
     SchemeOps,
+    register_scheme,
 )
 
 
@@ -79,3 +80,6 @@ class EnumerateAllScheme:
 
 
 __all__ = ["EnumerateAllScheme"]
+
+# #1608: self-register on import (P7 — the OS resolve no longer names this class).
+register_scheme(EnumerateAllScheme())

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -31,6 +31,7 @@ from reyn.tools.scheme import (
     Presentation,
     RePresent,
     SchemeOps,
+    register_scheme,
 )
 
 _SEARCH_TOOL_NAME = "search_actions"
@@ -168,3 +169,6 @@ class RetrievalScheme:
 
 
 __all__ = ["RetrievalScheme"]
+
+# #1608: self-register on import (P7 — the OS resolve no longer names this class).
+register_scheme(RetrievalScheme())

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -27,6 +27,7 @@ from reyn.tools.scheme import (
     PlainText,
     Presentation,
     SchemeOps,
+    register_scheme,
 )
 
 
@@ -75,3 +76,8 @@ class UniversalCategoryScheme:
 
 
 __all__ = ["UniversalCategoryScheme"]
+
+# #1608: self-register on import (the scheme bundle self-describes; the OS resolve
+# no longer names built-in classes — P7). ``schemes/__init__`` imports all built-in
+# modules so importing the package (or any submodule) registers the full set.
+register_scheme(UniversalCategoryScheme())

--- a/tests/test_scheme_self_register_1608.py
+++ b/tests/test_scheme_self_register_1608.py
@@ -1,0 +1,77 @@
+"""Tier 2: #1608 ④ — built-in tool-use schemes self-register on import.
+
+The OS scheme resolver no longer names any scheme class; each scheme module calls
+``register_scheme`` at import time and the ``schemes`` package ``__init__`` imports
+them all. The load-bearing invariant (sandbox_2's completeness axis): **all built-in
+names resolve after importing only the package, with NO prior explicit scheme import
+by the caller.** This MUST be checked in a FRESH interpreter — an in-process test
+would false-pass because sibling tests already populate the global registry.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import reyn
+
+# This test tree's src root — propagated to the subprocess so it imports the SAME
+# reyn (the #1609 worktree-drift lesson: sys.executable's default reyn may resolve
+# to a different worktree's venv).
+_SRC = str(Path(reyn.__file__).resolve().parent.parent)
+
+
+def _fresh_interpreter(code: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": _SRC + os.pathsep + os.environ.get("PYTHONPATH", "")}
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_all_builtins_resolve_in_fresh_interpreter() -> None:
+    """Tier 2: #1608 ④ — a fresh interpreter that imports ONLY the schemes package
+    (no explicit scheme-class import) finds all 4 built-ins registered + resolvable,
+    and the default is unchanged. This is the completeness gate."""
+    result = _fresh_interpreter(
+        """
+        # The ONLY scheme-related import — must self-register the full built-in set.
+        import reyn.tools.schemes  # noqa: F401
+        from reyn.tools.scheme import (
+            DEFAULT_SCHEME_NAME, get_scheme, registered_scheme_names,
+        )
+        expected = {"universal-category", "enumerate-all", "retrieval", "codeact"}
+        names = set(registered_scheme_names())
+        assert expected <= names, f"missing built-ins: {expected - names}"
+        for n in expected:
+            s = get_scheme(n)
+            assert s is not None and s.name == n, n
+        assert DEFAULT_SCHEME_NAME == "universal-category"
+        assert get_scheme(DEFAULT_SCHEME_NAME) is not None
+        print("RESOLVE_OK")
+        """
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "RESOLVE_OK" in result.stdout
+
+
+def test_resolver_finds_all_builtins_without_naming_them() -> None:
+    """Tier 2: #1608 ④ — _resolve_tool_use_scheme (the OS resolver, which names NO
+    scheme class) resolves each built-in name from a fresh interpreter, and an
+    unknown name falls back to the default. Behaviour-invariant vs the old lazy loop."""
+    result = _fresh_interpreter(
+        """
+        from reyn.chat.router_loop import _resolve_tool_use_scheme
+        for n in ("universal-category", "enumerate-all", "retrieval", "codeact"):
+            s = _resolve_tool_use_scheme(n)
+            assert s is not None and s.name == n, n
+        # Unknown / None → default.
+        assert _resolve_tool_use_scheme("no-such").name == "universal-category"
+        assert _resolve_tool_use_scheme(None).name == "universal-category"
+        print("RESOLVE_OK")
+        """
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "RESOLVE_OK" in result.stdout


### PR DESCRIPTION
**[e2e-coder]** — refactor ④: built-in scheme **self-registration on import** so the OS resolver names no scheme class (P7 cleanliness). lead-dispatched; behaviour-invariant.

## What
`_resolve_tool_use_scheme` (OS code) used to import all 4 built-in scheme CLASSES and register them in a lazy loop — scheme-literals in OS code. Now each scheme module self-registers at import time, the `schemes` package `__init__` imports them all, and the resolver just imports the package + resolves by name. The OS names **no** concrete scheme.

## Changes
- Each scheme module (`universal_category` / `enumerate_all` / `retrieval` / `codeact`) → `register_scheme(TheScheme())` at module bottom. All 4 are parameterless + stateless (safe to instantiate at import); codeact was already eager-imported by the old resolver, so the import graph is unchanged; no circular (`scheme.py` protocol imports no concrete scheme).
- `schemes/__init__.py` (was empty) imports all built-in modules → importing the package, or **any** submodule (a submodule import runs the package `__init__` first), registers the full set. This closes the completeness trap (sandbox_2): import-time self-registration only fires for modules that get imported.
- `_resolve_tool_use_scheme` → drops the 4 class imports + the register loop → `import reyn.tools.schemes` (self-register side effect) + `get_scheme(name or DEFAULT)`.

## Test plan
- [x] **Completeness gate** (`tests/test_scheme_self_register_1608.py`) — a **fresh-interpreter** subprocess test (the only valid proof; an in-process test false-passes from sibling-test imports) asserts (a) importing ONLY the package self-registers all 4 names + the default; (b) `_resolve_tool_use_scheme` resolves each built-in + falls back to default for unknown — without the caller naming any class. The subprocess propagates this tree's reyn via `PYTHONPATH` (the #1609 worktree-drift lesson). 2 passed.
- [x] Full suite `pytest -q` rootdir → **7308 passed** (the 2 fails — `test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref` — are pre-existing local-env, fail on clean origin/main too).
- [x] 646 scheme/router regression green; `ruff check` + `test_tier_audit.py --strict` clean.

Small, behaviour-invariant cleanliness PR (refactor ④). sandbox_2 co-vets the completeness axis (it's their S4 resolver being replaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
