### PR TITLE
docs(tool-use): Tool-Use Schemes feature-map group + concept doc

### DIFF
--- a/docs/concepts/tools-integrations/tool-use-schemes.md
+++ b/docs/concepts/tools-integrations/tool-use-schemes.md
@@ -1,0 +1,95 @@
+---
+type: concept
+topic: tool-use-schemes
+audience: [human, agent]
+---
+
+# Tool-Use Schemes
+
+How an agent's tools are shown to the LLM — and how the LLM's calls are turned
+back into dispatched actions — is a **pluggable scheme**. Reyn ships four, and
+you select one per layer in `reyn.yaml`. The default reproduces the standard
+behaviour, so schemes are entirely opt-in.
+
+The key invariant: **the scheme only changes the LLM-facing surface**. Every
+tool call, whichever scheme produced it, is routed through the same OS gate —
+exclusion check → permission check → dispatch. Swapping schemes never changes
+what is allowed, only how the LLM is asked to express a call. See
+[Permission model](../runtime/permission-model.md).
+
+## The four schemes
+
+### `universal-category` (default)
+
+The [universal action catalog](universal-catalog.md): every action — a skill, an
+MCP tool, a memory entry, a file op, an indexed corpus — is addressed by a single
+qualified name and reached through a small fixed set of wrappers (discover →
+describe → invoke). The LLM-facing tool list stays constant as the catalogue
+grows. This is Reyn's shipped behaviour; leaving `tool_use` unset keeps it.
+
+**Use when:** the default — a broad, growing tool set where you don't want the
+tool list to scale with the number of resources.
+
+### `enumerate-all`
+
+Presents *every* usable tool flatly in the LLM's tool list and dispatches by
+name — the plain, native-JSON baseline with no discovery indirection.
+
+**Use when:** the tool set is **small** and you want maximum determinism and the
+simplest possible mapping from the LLM's call to a dispatch. Note this is *not* a
+weak-model aid — a flat JSON tool list is the hardest surface for weak models.
+
+### `retrieval`
+
+RAG-over-tools. Instead of presenting the whole catalogue, it presents a **search
+tool**; the LLM searches, the OS re-presents only the matched actions as callable
+tools, and the LLM calls one.
+
+**Use when:** the tool set is **very large** and presenting it in full would cost
+too many tokens — the search narrows the candidates before the call.
+
+### `CodeAct`
+
+Code-as-tools. The LLM writes a short Python snippet, and tool calls happen as
+in-code `tool(...)` calls. The snippet runs in a **sandboxed subprocess**, and
+each in-code call round-trips through the **same permission gate as a JSON tool
+call** — a CodeAct call is gated at least as strictly as the equivalent JSON
+call, plus sandbox containment.
+
+**Use when:** running **weak / low-cost models**, where expressing tool use as
+code measurably outperforms JSON tool-calling.
+
+## Per-layer selection
+
+The scheme is chosen independently for each of the three layers an agent runs:
+
+```yaml
+# reyn.yaml
+tool_use:
+  chat: universal-category    # top-level chat router
+  step: universal-category    # plan / skill steps
+  phase: universal-category   # OS phases
+```
+
+Any layer can use any registered scheme; the others are unaffected. Full per-key
+reference: [`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block).
+
+## Why this is safe to swap
+
+The scheme is *presentation and parsing* — pluggable data the OS reads. The
+load-bearing parts are not part of the scheme:
+
+- The LLM still may only call tools the OS has made eligible (the candidate set);
+  a scheme cannot widen that.
+- Every call still passes the exclusion + permission gate before dispatch.
+- Validation of the call and its result is unchanged.
+
+So choosing `enumerate-all`, `retrieval`, or `CodeAct` changes how the model is
+asked to use tools, not what it is permitted to do. The presentation varies; the
+gate is constant.
+
+## See also
+
+- [Universal Action Catalog](universal-catalog.md) — the internals of the default `universal-category` scheme
+- [`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block) — config reference
+- [Permission model](../runtime/permission-model.md) — the gate every scheme dispatches through

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -86,6 +86,13 @@ mindmap
       compact
       skill_resolve
       judge_output
+    🔧 Tool-Use Schemes
+      Pluggable per-layer
+      universal-category default
+      enumerate-all
+      retrieval
+      CodeAct
+      Per-call gate unchanged
     📝 DSL
       skill.md
       phase.md
@@ -347,6 +354,23 @@ The op kinds below mirror `OP_KIND_MODEL_MAP` in `op_runtime/registry.py` (20 ki
 | `judge_output` | LLM scorer with rubric + threshold + `on_fail` policy |
 
 > The `embed` and `index_write` ops were removed in #1303 Stage I — embedding and index-writing now run provider-direct inside `reyn.safe.embed_index` and the `recall` op, not as standalone ops. See [Control IR](reference/runtime/control-ir.md).
+
+---
+
+### Tool-Use Schemes
+
+How tools are presented to the LLM and how its calls are dispatched is a **pluggable scheme**, selectable per layer (`tool_use: {chat, step, phase}` in `reyn.yaml`). The default is `universal-category` — identical to the shipped behaviour — so this is opt-in. All schemes route every tool call through the same OS gate (exclude → permission → dispatch), so the security and validation pipeline is unchanged whichever scheme is active.
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| Pluggable scheme protocol | `ToolUseScheme` seam — tool presentation + interpretation + dispatch + feedback behind one interface; schemes are swapped by config, no OS change | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) |
+| Per-layer selection | Independent scheme per layer — chat / plan-step / OS-phase — via `tool_use` config | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) · [`reyn.yaml` § tool_use](reference/config/reyn-yaml.md#tool_use-block) |
+| `universal-category` (default) | The universal action catalog — 4 wrappers over every category, qualified-name discover + dispatch | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) · [Universal catalog](concepts/tools-integrations/universal-catalog.md) |
+| `enumerate-all` | Flat-native-JSON baseline — every usable tool presented flatly, dispatched by name. Best for small tool sets where determinism matters | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) |
+| `retrieval` | RAG-over-tools — present a search tool, the LLM searches, the OS re-presents matched tools as callable. Best for very large tool sets where full-catalog token cost is prohibitive | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) |
+| `CodeAct` | Code-as-tools — the LLM writes a Python snippet whose in-code `tool()` calls run in a sandboxed subprocess under the same permission gate as a JSON call. Strongest for weak models | [Tool-Use Schemes](concepts/tools-integrations/tool-use-schemes.md) |
+
+> **Differentiation vs general agents:** the tool-use strategy is a swappable scheme — `enumerate-all` / `retrieval` / `CodeAct` / the default catalog — chosen per layer by config, *without* changing the OS. Because every scheme dispatches through the same exclude → permission → `dispatch_tool` gate (P4/P5), swapping the LLM-facing tool surface never weakens the security or validation pipeline. The presentation is data; the gate is constant.
 
 ---
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -290,7 +290,7 @@ time_travel:
 
 ## `tool_use` block
 
-Per-layer tool-use scheme selector (#1593). Each layer picks a registered `ToolUseScheme` by name — generalizing the binary `universal_wrappers_enabled` toggle into a pluggable, per-layer mechanism.
+Per-layer tool-use scheme selector. Each layer picks a registered `ToolUseScheme` by name — a pluggable, per-layer mechanism for how tools are presented to and dispatched from the LLM.
 
 ```yaml
 tool_use:
@@ -306,6 +306,8 @@ tool_use:
 | `phase` | string | `universal-category` | Tool-use scheme for the OS phase layer. |
 
 Defaults preserve today's behaviour (all `universal-category`). A scheme owns how the `tools=` payload is built, the SP tool-use instructions, how an LLM response is interpreted, and how it is dispatched — so swapping a layer's scheme changes the whole tool-use loop for that layer without OS changes.
+
+For what each scheme does and **when to choose which** (`enumerate-all` / `retrieval` / `CodeAct` vs the default), see [Tool-Use Schemes](../../concepts/tools-integrations/tool-use-schemes.md).
 
 ## `phase` block
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
       - Tools & integrations:
           - concepts/tools-integrations/mcp.md
           - concepts/tools-integrations/universal-catalog.md
+          - concepts/tools-integrations/tool-use-schemes.md
           - concepts/tools-integrations/voice.md
       - Observability:
           - concepts/observability/dogfood-scenarios.md


### PR DESCRIPTION
**[docs-maintainer]** — tool-use scheme abstraction docs per owner directive (via lead-coder dispatch). Structure pre-approved by lead-coder.

## Summary

Reflects the landed pluggable tool-use scheme abstraction. Verified against origin/main 552f8a5e (tool_use config + all 4 scheme impls + docstrings) before writing.

1. **feature-map.md** — new `🔧 Tool-Use Schemes` group (mindmap node + feature-index section): the `ToolUseScheme` protocol, per-layer selection (`tool_use: {chat,step,phase}`), and 4 schemes with use-cases:
   - `universal-category` (default, byte-identical) · `enumerate-all` (small toolset/determinism) · `retrieval` (huge toolset/token-cost) · `CodeAct` (weak models)
   - Differentiation callout: schemes are pluggable data; the exclude→permission→`dispatch_tool` gate (P4/P5) is unchanged across all schemes.
2. **concepts/tools-integrations/tool-use-schemes.md** (new) — abstraction + when-to-use each + per-layer config + the OS-gate-unchanged invariant. Cross-links universal-catalog (the internals of the default scheme).
3. **reyn.yaml § tool_use** — light pointer to the concept doc; dropped the inline `(#1593)` history ref.
4. **mkdocs.yml** — nav entry under Tools & integrations.

## Test plan

- [x] Primary-source verified: 4 scheme impls + tool_use config + docstrings (origin/main 552f8a5e)
- [x] No history refs in user-facing text (#1593/FP/PR dropped)
- [x] Current-landed only (all 4 schemes shipped + tested)
- [x] Mindmap render-safe: `🔧 Tool-Use Schemes` node + children plain text, no bracket/paren nodes (grep-verified; only `root((...))` has brackets)
- [x] EN cross-links resolve (`#tool_use-block`, universal-catalog, permission-model)
- [x] Page drop: zero (additions only)
- [ ] **`mkdocs build --strict` note**: aborts on **pre-existing JA-mirror anchor lag** — `reyn-yaml.ja.md` lacks `#tool_use-block` (and `#plan-block`/`#safety-block`/etc., the same lag on *every* existing block link). My EN links are correct; the JA translation mirroring is a separate systemic backlog, not introduced here. No new defect class. (The `0038` excluded-link warning is from the already-merged time-travel row, not this PR.)
- [ ] lead-coder review (accuracy + render + no-history + group-integrity + use-case correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)