### PR TITLE
fix(1593): CodeAct live-verify cascade — catalog/dispatch/fence/terminal correctness

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -3010,15 +3010,26 @@ class RouterLoop:
                 }
         return None
 
-    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+    async def _dispatch_resolved(
+        self, name: str, args: dict, *, dispatch_catalog: dict | None = None,
+    ) -> dict:
         """#1593: dispatch a resolved, exclude-cleared tool call via the OS substrate
         (DispatchContext / phase-memo / ``dispatch_tool`` — P5). The pure-OS dispatch
         half of the former ``_execute_tool``; the scheme's ``execute`` orchestrates
-        calls to it (it never sees the DispatchContext / phase-memo)."""
+        calls to it (it never sees the DispatchContext / phase-memo).
+
+        ``dispatch_catalog`` overrides the ``tool_catalog`` the ``dispatch_tool``
+        membership gate checks against (default = ``self._catalog``, the advertised
+        ``tools=`` mirror — the Execute path is byte-identical). CodeAct passes the
+        FULL flat catalog here: its advertised payload is empty (the model writes
+        code, not JSON tool calls), so a gate keyed on ``self._catalog`` would reject
+        every in-code ``tool('<name>')`` call as "not in catalog" — #1593 live-verify
+        (the model's correct ``tool('file__read', ...)`` was rejected)."""
         # #1092 PR-C-2.5: phase-mode op-dispatch WAL memoization. A phase host
         # returns the per-phase resume wiring; chat hosts don't implement the hook
         # (getattr → None), so the chat dispatch path below is byte-identical
         # (``caller_kind="router"``, no state_log/skill_run_id → no WAL step).
+        catalog = dispatch_catalog if dispatch_catalog is not None else self._catalog
         memo = getattr(self.host, "op_dispatch_memo", lambda: None)()
         if memo is not None:
             # Phase op: thread state_log + skill_run_id + resume_plan + a
@@ -3032,7 +3043,7 @@ class RouterLoop:
                 caller_kind="skill_phase",
                 caller_id=self.host.agent_name,
                 chain_id=self.chain_id,
-                tool_catalog=self._catalog,
+                tool_catalog=catalog,
                 events=self.host.events,
                 state_log=memo["state_log"],
                 skill_run_id=memo["skill_run_id"],
@@ -3051,7 +3062,7 @@ class RouterLoop:
             caller_kind="router",
             caller_id=self.host.agent_name,
             chain_id=self.chain_id,
-            tool_catalog=self._catalog,
+            tool_catalog=catalog,
             events=self.host.events,
         )
 
@@ -3313,18 +3324,29 @@ class RouterLoop:
         from reyn.sandbox import get_default_backend  # noqa: PLC0415
         from reyn.tools.scheme import ExecContext  # noqa: PLC0415
 
+        # CodeAct's in-code ``tool('<name>')`` can call ANY catalog action, but the
+        # advertised JSON payload is empty (``self._catalog`` is the wrapper/hot-list
+        # mirror, not the flat catalog). Resolve the per-call gate against the FULL
+        # flat catalog — the same projection enumerate-all advertises — so a correct
+        # ``tool('file__read', ...)`` is not rejected as "not in catalog" (#1593
+        # live-verify). Built once per code round (the catalog is stable mid-round).
+        _full_entries = await self.catalog_entries()
+        _codeact_catalog = {e["function"]["name"]: e for e in _full_entries}
+
         async def _os_gate(name: str, args: dict) -> dict:
             excluded = self._excluded_result(name, args)
             if excluded is not None:
                 return excluded
-            return await self._dispatch_resolved(name, args)
+            return await self._dispatch_resolved(
+                name, args, dispatch_catalog=_codeact_catalog,
+            )
 
         # CodeAct-safe default policy (operator-overridable in S4 via the host's
         # configured sandbox policy); the backend auto-selects per platform and the
         # runner is fail-closed when no real sandbox is available.
         sandbox = get_default_backend(getattr(self.host, "sandbox_config", None))
         exec_ctx = ExecContext(
-            tool_catalog=self._catalog,
+            tool_catalog=_codeact_catalog,
             sandbox=sandbox,
             extra={
                 "dispatch": _os_gate,

--- a/src/reyn/kernel/_codeact_harness.py
+++ b/src/reyn/kernel/_codeact_harness.py
@@ -33,6 +33,8 @@ re-gates. Direct FS-write / network / subprocess remain blocked by the sandbox.
 from __future__ import annotations
 
 import ast
+import contextlib
+import io
 import json
 import socket
 import sys
@@ -115,10 +117,14 @@ class ToolError(RuntimeError):
 
 def _exec_codeact(
     code: str, channel: _ControlChannel, allowed_modules: frozenset[str],
-) -> Any:
+) -> tuple[Any, str]:
     """Validate + exec the snippet with the restricted builtins + the tool shim.
 
-    Returns the snippet's ``result`` binding if it defines one, else None. The
+    Returns ``(result, captured_stdout)`` — the snippet's ``result`` binding (or
+    None) and anything it wrote to stdout. The snippet's stdout is captured into a
+    buffer, NOT left on the process stdout: the harness uses stdout for its own JSON
+    result envelope, so an un-captured ``print(...)`` corrupts that envelope (the
+    parent's ``json.loads`` then fails = MalformedResponse, #1593 live-verify). The
     snippet affects the world ONLY through ``tool(...)`` (the parent-gated proxy);
     the restricted builtins block ``open`` / ``eval`` / ``__import__`` of
     non-allowlisted modules (defense-in-depth on top of the sandbox)."""
@@ -132,8 +138,10 @@ def _exec_codeact(
         "tool": _make_tool_shim(channel),
     }
     compiled = compile(tree, filename="<codeact>", mode="exec")
-    exec(compiled, namespace)  # noqa: S102 — sandboxed subprocess + restricted ns
-    return namespace.get("result")
+    stdout_buf = io.StringIO()
+    with contextlib.redirect_stdout(stdout_buf):
+        exec(compiled, namespace)  # noqa: S102 — sandboxed subprocess + restricted ns
+    return namespace.get("result"), stdout_buf.getvalue()
 
 
 def _read_request() -> dict[str, Any]:
@@ -159,7 +167,12 @@ def main() -> int:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=control_fd)
         channel = _ControlChannel(sock)
 
-        result = _exec_codeact(code, channel, allowed_modules)
+        result, captured_stdout = _exec_codeact(code, channel, allowed_modules)
+        # When the snippet printed instead of assigning ``result`` (a common weak
+        # -model idiom — ``print(tool(...))``), surface the captured stdout as the
+        # result so the turn still yields a usable observation (#1593 live-verify).
+        if result is None and captured_stdout.strip():
+            result = captured_stdout.strip()
         _write_response({"ok": True, "result": result})
         return 0
     except Exception as exc:  # noqa: BLE001 — surface every failure as a response

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -31,13 +31,21 @@ from reyn.tools.scheme import (
     CodeBlock,
     ExecContext,
     ExecutionResult,
+    PlainText,
     Presentation,
     register_scheme,
 )
 
-# A fenced ```python ... ``` (or bare ``` ... ```) block — how the CodeAct LLM
-# emits its snippet in the message content.
-_FENCE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
+# A fenced code block — how the CodeAct LLM emits its snippet in the message content.
+# Accept the real code labels (``python`` / ``py`` / Gemini's native ``tool_code``) or
+# a bare fence — but NOT a data label like ``json``: #1593 live-verify showed flash
+# -lite both (a) fences with ```tool_code (a python-only pattern silently dropped it →
+# misclassified as a terminal PlainText turn) and (b) sometimes wraps a JSON tool-call
+# envelope in ```json (matching that exec'd ``{"tool_code": "..."}`` as a no-op dict →
+# ``result`` unset → a misleading "null" observation). A ```json block is the model
+# mis-formatting (an SP-channel pull, #1608②), not a CodeAct snippet — leave it to the
+# no-fence PlainText path rather than exec a data literal.
+_FENCE_RE = re.compile(r"```(?:python|py|tool_code)?[ \t]*\n(.*?)```", re.DOTALL)
 
 
 def _render_code_api(entries: list[dict]) -> str:
@@ -49,36 +57,49 @@ def _render_code_api(entries: list[dict]) -> str:
     lines = [
         "## CodeAct — write a Python script (not JSON tool calls)",
         "",
-        "Write a Python snippet. Call any available action with "
-        "``tool('<name>', <arg>=<value>, ...)`` — it returns the action's result, or "
-        "raises if the action is denied / excluded / unknown. Assign your final answer "
-        "to a variable named ``result``. The standard library is available; "
-        "filesystem / network / subprocess are sandboxed.",
+        "To act, respond with a SINGLE fenced ```python code block and nothing "
+        "else — no prose before or after it, no \"I am a Reyn agent\" preamble. Call "
+        "any available action with ``tool('<name>', <arg>=<value>, ...)`` — it returns "
+        "the action's result, or raises if the action is denied / excluded / unknown. "
+        "Assign your final answer to a variable named ``result``. The standard library "
+        "is available; filesystem / network / subprocess are sandboxed. When you are "
+        "done — you have the answer and need no more actions — reply in plain prose "
+        "with NO code block (that ends the turn).",
         "",
         "Available actions:",
     ]
     for entry in entries:
-        name = entry.get("name", "")
-        params = entry.get("parameters") or {}
+        # The live ``SchemeOps.catalog_entries`` adapter returns the OpenAI
+        # tool-schema shape (``{type, function: {name, description, parameters}}``,
+        # uniform with ``base_tools`` so enumerate-all / retrieval concat into one
+        # ``tools=`` payload). CodeAct is the lone consumer that renders names into a
+        # code-API, so it unwraps the ``function`` envelope here (tolerating a flat
+        # ``{name, ...}`` entry too). #1593 live-verify caught this: reading the
+        # top-level ``name`` yielded ``tool('')`` for every action (empty catalog →
+        # the model's correct ``tool('file__read', ...)`` hit "not in catalog").
+        fn = entry.get("function", entry)
+        name = fn.get("name", "")
+        params = fn.get("parameters") or {}
         arg_names = list((params.get("properties") or {}).keys())
         sig = ", ".join(arg_names)
-        desc_raw = (entry.get("description") or "").strip()
+        desc_raw = (fn.get("description") or "").strip()
         desc = desc_raw.splitlines()[0] if desc_raw else ""
         lines.append(f"- tool('{name}'{', ' + sig if sig else ''}) — {desc}".rstrip(" —"))
     return "\n".join(lines)
 
 
-def _extract_code(llm_response: Any) -> str:
-    """Pull the snippet from the LLM response: the first fenced code block in the
-    content, else the whole content (the model may emit bare code). Empty when
-    there is nothing to run (``execute`` then no-ops)."""
+def _extract_fenced_code(llm_response: Any) -> str | None:
+    """The first fenced ```python block in the response content, or ``None`` when
+    there is no fenced block. A response with no fence is a terminal natural-language
+    reply (→ ``PlainText``), NOT bare code to execute: the SP instructs the model to
+    fence its snippet, and treating un-fenced prose as code made the model's final
+    answer turn raise a spurious ``SyntaxError`` and loop without terminating
+    (#1593 live-verify)."""
     content = getattr(llm_response, "content", None) or ""
     if not isinstance(content, str):
-        return ""
+        return None
     match = _FENCE_RE.search(content)
-    if match:
-        return match.group(1)
-    return content.strip()
+    return match.group(1) if match else None
 
 
 def _format_codeact_observation(out: dict) -> str:
@@ -126,7 +147,14 @@ class CodeActScheme:
         # The OS supplies the session exclude-set via ``available``.
         exclude = (available or {}).get("exclude_tools") or frozenset()
         if exclude:
-            entries = [e for e in entries if e.get("name") not in exclude]
+            # Name lives under the OpenAI ``function`` envelope (live adapter shape);
+            # unwrap it here too — reading the top-level ``name`` made the filter a
+            # silent no-op (excluded actions still rendered = parity/permission leak),
+            # the same nested-shape trap as ``_render_code_api`` (#1593 live-verify).
+            entries = [
+                e for e in entries
+                if (e.get("function", e)).get("name") not in exclude
+            ]
         return Presentation(
             llm_tools_payload=[],
             sp_params={
@@ -136,11 +164,19 @@ class CodeActScheme:
             sp_fragment=_render_code_api(entries),
         )
 
-    def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: Any) -> CodeBlock:
-        """Extract the snippet as a ``CodeBlock`` (the OS-loop's CodeBlock arm runs
-        ``execute``). No resolution/dedup here — CodeAct tool calls are resolved +
-        gated per call inside ``execute`` (via the OS gate), not up front."""
-        return CodeBlock(code=_extract_code(llm_response))
+    def interpret(
+        self, llm_response: Any, *, tool_catalog: dict, ops: Any,
+    ) -> CodeBlock | PlainText:
+        """Classify the response: a fenced ```python block → ``CodeBlock`` (the
+        OS-loop's CodeBlock arm runs ``execute``); no fenced block → ``PlainText``
+        (the terminal text-reply path emits the final answer — the model's natural
+        -language answer turn is NOT code to execute). No resolution/dedup here —
+        CodeAct tool calls are resolved + gated per call inside ``execute`` (via the
+        OS gate), not up front."""
+        code = _extract_fenced_code(llm_response)
+        if code is None:
+            return PlainText()
+        return CodeBlock(code=code)
 
     async def execute(
         self, interp: CodeBlock, exec_ctx: ExecContext, ops: Any,

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -1,7 +1,8 @@
 """Tier 2: #1593 PR-3 S3a — CodeActScheme (interpret + execute glue + feedback).
 
 CodeAct is own-logic (not delegating). This pins:
-  - interpret extracts the snippet (fenced or bare) as a CodeBlock.
+  - interpret returns a CodeBlock for a fenced ```python block, else PlainText (a
+    response with no fence is a terminal natural-language reply, not code to exec).
   - execute threads the OS per-call gate (exec_ctx.extra['dispatch']) + sandbox into
     the CodeActRunner and wraps the result — and REQUIRES the gate (no silent
     ungated run).
@@ -21,7 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult
+from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, PlainText
 from reyn.tools.schemes.codeact import CodeActScheme
 
 
@@ -45,11 +46,26 @@ def test_interpret_extracts_fenced_code() -> None:
     assert interp.code.strip() == "result = tool('m')"
 
 
-def test_interpret_bare_content_when_no_fence() -> None:
-    """Tier 2: interpret falls back to the whole content when there is no fence."""
-    resp = SimpleNamespace(content="result = 1 + 1")
+def test_interpret_extracts_tool_code_fence() -> None:
+    """Tier 2: interpret accepts ANY fence language label — flash-lite fences with
+    Gemini's native ```tool_code (not ```python); a python-only pattern dropped it
+    and the snippet never ran (#1593 live-verify)."""
+    resp = SimpleNamespace(
+        content="I will read it.\n```tool_code\nresult = tool('file__read', path='x')\n```",
+    )
     interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
-    assert interp.code == "result = 1 + 1"
+    assert isinstance(interp, CodeBlock)
+    assert interp.code.strip() == "result = tool('file__read', path='x')"
+
+
+def test_interpret_plaintext_when_no_fence() -> None:
+    """Tier 2: a response with no fenced block is a terminal natural-language reply
+    → PlainText (NOT bare code to execute). The SP instructs the model to fence its
+    snippet; treating un-fenced prose as code made the final answer turn raise a
+    spurious SyntaxError and loop without terminating (#1593 live-verify)."""
+    resp = SimpleNamespace(content="The file contains PURPLE-OTTER-42.")
+    interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
+    assert isinstance(interp, PlainText)
 
 
 @pytest.mark.asyncio
@@ -111,14 +127,29 @@ def test_format_feedback_shapes_observation_message() -> None:
 
 
 class _CatalogOps:
-    """A real Fake SchemeOps exposing the async ``catalog_entries`` adapter (#1599)."""
+    """A real Fake SchemeOps exposing the async ``catalog_entries`` adapter (#1599).
+
+    Returns the **OpenAI tool-schema shape** (``{type, function: {name, description,
+    parameters}}``) the LIVE adapter emits (router_loop ``catalog_entries``, uniform
+    with ``base_tools`` / enumerate-all / retrieval). #1593 live-verify: an earlier
+    flat-shape Fake here false-passed while the nested live shape rendered ``tool('')``
+    for every action ([[feedback_fake_backend_unit_misses_real_integration]])."""
+
+    @staticmethod
+    def _fn(name: str, description: str, properties: dict) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {"type": "object", "properties": properties},
+            },
+        }
 
     async def catalog_entries(self) -> list[dict]:
         return [
-            {"name": "file__read", "description": "Read a file.",
-             "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}},
-            {"name": "web__fetch", "description": "Fetch a URL.\nSecond line ignored.",
-             "parameters": {"type": "object", "properties": {}}},
+            self._fn("file__read", "Read a file.", {"path": {"type": "string"}}),
+            self._fn("web__fetch", "Fetch a URL.\nSecond line ignored.", {}),
         ]
 
 


### PR DESCRIPTION
**[dogfood-coder]** — CodeAct correctness restoration. Foundational live-verify of the #1593 CodeAct scheme on flash-lite (the WHY-validation effort's pre-measurement smoke) caught an **8-defect structural cascade that every Fake-LLM unit passed** — the test Fake used a flat catalog shape while the live `SchemeOps.catalog_entries` adapter returns the OpenAI-nested shape (the fake-backend-misses-integration trap). CodeAct was **fully non-functional live** (the in-code `tool()` could call nothing) before this.

## Fixes (each with primary evidence from `REYN_LLM_TRACE_DUMP`)
| # | Defect | Fix |
|---|--------|-----|
| 1 | `_render_code_api` read top-level `name` on nested entries → code-API rendered `tool('')` ×50 (empty names) | unwrap the `function` envelope (now 50 named) |
| 3 | exclude filter same top-level read → silent no-op (parity/permission leak) | unwrap there too |
| 5 | `_FENCE_RE` python-only; flash-lite fences ` ```tool_code ` → snippet dropped | accept `python\|py\|tool_code`; exclude ` ```json ` (a JSON envelope that exec'd as a no-op dict → null) |
| 2 | `interpret` always `CodeBlock` → final prose answer exec'd → SyntaxError loop | no-fence → `PlainText` terminal (the coexistence test's documented design) |
| 4 | fragment didn't demand fencing | now demands a single fenced block + teaches prose=terminal |
| 7 | in-code `tool()` gate checked `name in self._catalog` (built from the **empty** `llm_tools_payload`) → every call "not in catalog" | additive `dispatch_catalog` override on `_dispatch_resolved` (Execute path byte-identical); CodeAct gate resolves against the full flat catalog, as enumerate-all does |
| 8 | harness wrote its result envelope to stdout; user `print()` put a Python repr there → `json.loads` → MalformedResponse | capture user stdout into a buffer; fall back `result`→captured-stdout when the snippet printed instead of assigning `result` |

## Verification (end-to-end, flash-lite, fresh-agent)
- In-code `tool('file__read')` dispatches → returns the file content **cleanly** (observation = valid JSON, `MalformedResponse=0`) → model terminates via prose in 2 turns.
- `22` codeact tests + strict tier-audit green; `73` pass across codeact/catalog_entries/enumerate/represent/**dispatcher** (incl. resume-memoization + WAL + ARS-fallback — confirms the `_dispatch_resolved` change is byte-identical for the Execute path).

## Reviewer focus (lead)
- **#7** `_dispatch_resolved` additive `dispatch_catalog` override — confirm Execute path byte-identical (default `None` → `self._catalog`).
- **#3** exclude filter — confirm it restores presentation/permission parity.
- e2e: CodeBlock-arm / dispatch seam co-vet.

## Residual (NOT in this PR — owner-gated)
The weak model inconsistently emits CodeAct's code contract because the universal-category routing guide **dominates** the CodeAct SP (CodeAct can only append, not replace it). This is the deferred **#1608②** SP-channel — the primary evidence here overturns its "marginal" defer; lead is surfacing the re-open with the owner. The efficacy measurement stays HELD until CodeAct runs clean end-to-end (these fixes + #1608②).

## Test plan
- [x] `pytest tests/test_codeact_scheme_1593.py tests/test_codeact_coexistence_1593.py tests/test_codeact_runner_1593.py -W error::RuntimeWarning` (22 pass)
- [x] `pytest` across catalog_entries/enumerate/represent/dispatcher suites (73 pass total)
- [x] strict tier-audit on the modified test file (0 errors/warnings)
- [x] live end-to-end on flash-lite — in-code `tool('file__read')` returns content cleanly, `MalformedResponse=0`, terminates in 2 turns
- [x] (skipped — needs Linux) Landlock-backend sandbox e2e (#1527; macOS Seatbelt path exercised here)

---
PR self-check: docstrings declare Tier; no Tier-4 violations; no invariant weakened; tests updated in lockstep (the `_CatalogOps` Fake now uses the live nested shape so it can't false-pass again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)