### PR TITLE
feat(1618) root-1+4: canonical catalog-shape contract + dispatchable/advertised decouple (holistic, byte-identical)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1433,7 +1433,11 @@ class RouterLoop:
         # patch``. Production callers leave this as ``None``.
         self._llm_caller = llm_caller
         self._on_limit = on_limit  # FP-0005 max_iterations checkpoint config
-        self._catalog: dict[str, dict] = {}  # populated per run()
+        self._catalog: dict[str, dict] = {}  # populated per run() — the ADVERTISED mirror
+        # #1618 root-1: the DISPATCHABLE membership map (None ⇒ = self._catalog,
+        # byte-identical for schemes whose advertised = dispatchable). Set per run()
+        # from ``Presentation.dispatchable_catalog`` when a scheme decouples them.
+        self._dispatch_catalog: "dict[str, dict] | None" = None
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
         # #1593: the active tool-use scheme. PR-1 = universal-category (the shipped
@@ -1713,6 +1717,15 @@ class RouterLoop:
         tools = _apply_tool_exclusions(tools, self._exclude_tools)
         self._catalog = {t["function"]["name"]: t for t in tools}
         self._tool_names = frozenset(self._catalog.keys())  # backward compat
+        # #1618 root-1: source the dispatch membership map from the scheme's
+        # DISPATCHABLE set when it decouples it from the advertised payload (CodeAct:
+        # advertises ∅, dispatches the full catalog). None ⇒ dispatch gate keys on
+        # self._catalog (byte-identical for universal / enumerate / retrieval).
+        if _pres.dispatchable_catalog is not None:
+            from reyn.tools.scheme import dispatch_catalog_map  # noqa: PLC0415
+            self._dispatch_catalog = dispatch_catalog_map(_pres.dispatchable_catalog)
+        else:
+            self._dispatch_catalog = None
         if self._system_prompt_override is not None:
             system_prompt = self._system_prompt_override
         else:
@@ -3014,7 +3027,20 @@ class RouterLoop:
         """#1593: dispatch a resolved, exclude-cleared tool call via the OS substrate
         (DispatchContext / phase-memo / ``dispatch_tool`` — P5). The pure-OS dispatch
         half of the former ``_execute_tool``; the scheme's ``execute`` orchestrates
-        calls to it (it never sees the DispatchContext / phase-memo)."""
+        calls to it (it never sees the DispatchContext / phase-memo).
+
+        #1618 root-1: the membership/resolution gate (``tool_catalog``) is sourced
+        from the scheme's DISPATCHABLE set (``self._dispatch_catalog``) — decoupled
+        from the ADVERTISED ``tools=`` mirror (``self._catalog``). Default ``None`` ⇒
+        ``self._catalog`` (universal / enumerate / retrieval, where dispatchable =
+        advertised — byte-identical). CodeAct advertises ∅ but dispatches the full
+        catalog, so its gate must key on the dispatchable set, not the empty mirror
+        (the #7 "not in catalog" root)."""
+        catalog = (
+            self._dispatch_catalog
+            if self._dispatch_catalog is not None
+            else self._catalog
+        )
         # #1092 PR-C-2.5: phase-mode op-dispatch WAL memoization. A phase host
         # returns the per-phase resume wiring; chat hosts don't implement the hook
         # (getattr → None), so the chat dispatch path below is byte-identical
@@ -3032,7 +3058,7 @@ class RouterLoop:
                 caller_kind="skill_phase",
                 caller_id=self.host.agent_name,
                 chain_id=self.chain_id,
-                tool_catalog=self._catalog,
+                tool_catalog=catalog,
                 events=self.host.events,
                 state_log=memo["state_log"],
                 skill_run_id=memo["skill_run_id"],
@@ -3051,7 +3077,7 @@ class RouterLoop:
             caller_kind="router",
             caller_id=self.host.agent_name,
             chain_id=self.chain_id,
-            tool_catalog=self._catalog,
+            tool_catalog=catalog,
             events=self.host.events,
         )
 

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -63,6 +63,51 @@ class Presentation:
     # empty ⇒ stop). Default empty: schemes that never RePresent (universal /
     # enumerate-all) leave it untouched, so it is inert for them.
     candidates: tuple = field(default_factory=tuple)
+    # #1618 root-1: the scheme's DISPATCHABLE action set — the membership/resolution
+    # gate for ANY call (JSON tool_call OR in-code ``tool()``), in the canonical
+    # ``catalog_entries`` shape. Decoupled from ``llm_tools_payload`` (what the LLM
+    # is ADVERTISED): a scheme can advertise nothing yet dispatch everything (CodeAct
+    # writes code, advertises ∅, dispatches the full catalog). Default ``None`` ⇒
+    # dispatchable = advertised (``llm_tools_payload``) — byte-identical for
+    # universal / enumerate-all / retrieval, whose three catalog notions coincide.
+    dispatchable_catalog: "list[dict] | None" = None
+
+
+# ── Canonical catalog-shape projections (#1618 root-1) ──────────────────────
+# ``catalog_entries`` (and ``llm_tools_payload``) carry ONE canonical entry shape —
+# the OpenAI-nested ``{"type":"function","function":{"name","description",
+# "parameters"}}``. The OS owns the projections every consumer needs, so no consumer
+# hand-reads a nested dict at a guessed depth (the #1/#3 root: render + the exclude
+# filter read ``entry["name"]`` top-level on a nested entry → empty / silent no-op).
+
+
+def flat_catalog_entries(entries: "list[dict]") -> "list[dict]":
+    """Project canonical (OpenAI-nested) entries → the FLAT ``{name, description,
+    parameters}`` shape that the code-API render + the dispatch membership map read.
+    Tolerates an already-flat entry (defensive). ``parameters`` is always a valid
+    (possibly empty) JSON-schema object."""
+    out: list[dict] = []
+    for e in entries:
+        fn = e.get("function") if isinstance(e.get("function"), dict) else e
+        out.append({
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": fn.get("parameters") or {"type": "object", "properties": {}},
+        })
+    return out
+
+
+def dispatch_catalog_map(entries: "list[dict]") -> "dict[str, dict]":
+    """Project canonical entries → the ``{name → canonical_entry}`` membership map the
+    dispatch gate (``DispatchContext.tool_catalog``) checks. Keyed by the entry's
+    function name."""
+    out: dict[str, dict] = {}
+    for e in entries:
+        fn = e.get("function") if isinstance(e.get("function"), dict) else e
+        name = fn.get("name")
+        if name:
+            out[name] = e
+    return out
 
 
 # ── Interpretation: the tagged union the OS loop dispatches on ──────────────

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -32,6 +32,7 @@ from reyn.tools.scheme import (
     ExecContext,
     ExecutionResult,
     Presentation,
+    flat_catalog_entries,
     register_scheme,
 )
 
@@ -119,21 +120,29 @@ class CodeActScheme:
         in ``execute`` (a code call to an excluded action is rejected at dispatch).
         Presentation-level omission is deferred to a follow-up (it needs the exclude
         set, which the OS applies post-presentation to ``tools=`` today)."""
-        entries = await ops.catalog_entries()
+        entries = await ops.catalog_entries()  # canonical (OpenAI-nested) shape
+        # #1618 root-1: project to the FLAT {name, params} shape the render reads (the
+        # OS-owned projection — no hand-read of a nested dict at a guessed depth, which
+        # was #1: tool('') ×50, and #3: the exclude filter silently never matched).
+        flat = flat_catalog_entries(entries)
         # Presentation parity with the JSON path (#1400): omit excluded actions from
-        # the code-API too, so CodeAct's presentation is not looser than JSON tools=
-        # ("CodeAct >= JSON" on the presentation face, not just the per-call gate).
-        # The OS supplies the session exclude-set via ``available``.
+        # the rendered code-API (defense-in-depth — the real gate is per-call). The OS
+        # supplies the session exclude-set via ``available``.
         exclude = (available or {}).get("exclude_tools") or frozenset()
-        if exclude:
-            entries = [e for e in entries if e.get("name") not in exclude]
+        rendered = [e for e in flat if e["name"] not in exclude] if exclude else flat
         return Presentation(
             llm_tools_payload=[],
+            # #1618 root-1: CodeAct advertises ∅ but dispatches the FULL catalog (the
+            # model writes code). The dispatch gate's membership is sourced from this
+            # (NOT the empty llm_tools_payload → #7 "not in catalog"). Excluded actions
+            # stay IN the dispatchable set so an in-code call to one gets the clear
+            # ``tool_excluded`` message (per-call gate), not ``unknown_tool``.
+            dispatchable_catalog=entries,
             sp_params={
                 "universal_wrappers_enabled": False,
                 "search_actions_enabled": False,
             },
-            sp_fragment=_render_code_api(entries),
+            sp_fragment=_render_code_api(rendered),
         )
 
     def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: Any) -> CodeBlock:

--- a/tests/test_catalog_shape_contract_1618.py
+++ b/tests/test_catalog_shape_contract_1618.py
@@ -1,0 +1,71 @@
+"""Tier 2: #1618 root-1 + root-4 — the canonical catalog-shape contract + projections.
+
+`catalog_entries` (and `llm_tools_payload`) carry ONE canonical entry shape — the
+OpenAI-nested `{type, function:{name, description, parameters}}`. The OS provides the
+projections every consumer reads (`flat_catalog_entries` for render + the dispatch
+membership; `dispatch_catalog_map` for the gate), so **no consumer hand-reads a nested
+dict at a guessed depth** — the #1 root (`_render_code_api` read top-level `name` on a
+nested entry → `tool('')` ×50) and #3 root (the exclude filter never matched).
+
+This is the **test-shape-fidelity gate (root-4)**: the 8-defect cascade slipped past CI
+because the unit Fakes returned a FLAT shape while the live adapter returns NESTED. A
+contract test keyed on the canonical (nested) shape fails the moment a projection or a
+consumer's shape assumption diverges — which is what live-verify had to catch.
+"""
+from __future__ import annotations
+
+from reyn.tools.scheme import dispatch_catalog_map, flat_catalog_entries
+
+# The canonical shape the LIVE `catalog_entries` adapter emits (OpenAI-nested). Tests
+# that exercise a scheme's catalog consumer MUST use this shape, not a hand-flattened
+# Fake (root-4: single shape-truth).
+_CANONICAL: list[dict] = [
+    {"type": "function", "function": {
+        "name": "file__read",
+        "description": "Read a file.\nsecond line dropped by render",
+        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+    }},
+    {"type": "function", "function": {
+        "name": "file__write",
+        "description": "",
+        "parameters": {"type": "object", "properties": {}},
+    }},
+]
+
+
+def test_flat_projection_extracts_name_and_params_from_nested() -> None:
+    """Tier 2: #1618 root-1 — flat_catalog_entries pulls name/description/parameters
+    out of `function.*` (the #1 fix: a consumer that read top-level `name` got '')."""
+    flat = flat_catalog_entries(_CANONICAL)
+    assert [e["name"] for e in flat] == ["file__read", "file__write"]
+    assert flat[0]["parameters"]["properties"] == {"path": {"type": "string"}}
+    # every entry carries a valid (possibly empty) JSON-schema parameters object.
+    assert flat[1]["parameters"] == {"type": "object", "properties": {}}
+    assert flat[0]["description"].startswith("Read a file.")
+
+
+def test_dispatch_map_keys_by_function_name_value_is_canonical_entry() -> None:
+    """Tier 2: #1618 root-1 — dispatch_catalog_map keys the membership gate by
+    `function.name`; the value is the canonical entry (the #7 gate's tool_catalog)."""
+    m = dispatch_catalog_map(_CANONICAL)
+    assert set(m) == {"file__read", "file__write"}
+    assert m["file__read"] is _CANONICAL[0]
+
+
+def test_projections_tolerate_already_flat_entry() -> None:
+    """Tier 2: #1618 root-1 — the projections are defensive: an already-flat entry
+    (no `function` wrapper) passes through unchanged, so a mixed/legacy producer can't
+    silently empty a name."""
+    flat_in = [{"name": "x__y", "description": "d",
+                "parameters": {"type": "object", "properties": {}}}]
+    assert flat_catalog_entries(flat_in)[0]["name"] == "x__y"
+    assert set(dispatch_catalog_map(flat_in)) == {"x__y"}
+
+
+def test_canonical_shape_is_nested_not_flat() -> None:
+    """Tier 2: #1618 root-4 — pin the shape-truth: the canonical entry is NESTED
+    (`function.name`), NOT flat (`name` top-level). A producer that emits flat, or a
+    Fake that diverges to flat, breaks this — the fidelity gap that hid the cascade."""
+    entry = _CANONICAL[0]
+    assert "function" in entry and "name" in entry["function"]
+    assert "name" not in entry  # name is NOT top-level on the canonical shape


### PR DESCRIPTION
**[e2e-coder]** — #1618 holistic design, **staging increment 1: root-1 (catalog-shape contract) + root-4 (test-shape fidelity)**. Lead-approved architecture (#1618); fixes CodeAct defects #1/#3/#7 **by construction** (not point-patches); byte-identical for universal/enumerate-all/retrieval.

## What
The 8-defect CodeAct cascade's roots, not 8 patches. This increment: the catalog-shape contract.
- **`Presentation.dispatchable_catalog`** (seam (a)) — a scheme declares its DISPATCHABLE set independently of its ADVERTISED `llm_tools_payload`. Default `None` ⇒ dispatchable = advertised (univ/enum/retrieval byte-identical; their 3 catalog notions coincide). CodeAct advertises ∅, dispatches the full catalog.
- **Canonical projections** (`flat_catalog_entries` / `dispatch_catalog_map`) — OS-owned shape transforms; the single chokepoint every consumer reads → no consumer hand-reads a nested dict at a guessed depth → #1 (`tool('')` ×50) + #3 (silent exclude no-op) **structurally impossible**.
- **codeact.build_presentation** projects → flat for render + exclude (#1/#3), sets `dispatchable_catalog` = full canonical catalog (#7 source; excluded stay in → `tool_excluded` not `unknown_tool`).
- **OS #7 threading** — `self._dispatch_catalog` (run()-set from `dispatchable_catalog`; `None` ⇒ `self._catalog`); the dispatch gate keys on it. Supersedes #1617's per-call `dispatch_catalog` override with a principled `dispatchable≠advertised` field.
- **root-4** — `test_catalog_shape_contract_1618.py` pins the canonical NESTED shape + projections; closes the fidelity trap (flat Fakes ≠ nested live) at the single-projection-point.

## Reviews (recorded)
- **lead byte-identical review = PASS** (6 points, primary-evidence: gate resolution is identity for the 3 `None` schemes; Execute-path interpret unchanged; projections = single chokepoint; root-4 closes the trap structurally).
- **sandbox_2 dispatch-seam co-vet = PASS** (clean, no note; 67 tests; supersedes #1617 cleanly).
- **sandbox_2 oracle/behavioral proof** (WITHOUT #1617 patches): #1 render empty=0/named=50; #7 ZERO "not in catalog", fresh runs cleanly dispatched `tool('file__read')` → real content. **The symptoms vanish by construction** — proving CodeAct-can't-call-tools was structural, not model cognition.

## Test plan
- [x] 471 codeact/represent/dispatch/scheme/enumerate/retrieval regression green (byte-identical for non-CodeAct) + 13 contract/codeact.
- [x] `ruff check` + `test_tier_audit.py --strict` clean.
- [x] Oracle: #1/#7 vanish without the point-patches (sandbox_2, fresh-agent runs).

Staging: roots 2 (harness IPC) + 3 (replace-capable SP, the ② re-design) + the result-shape hardening follow as increments. #1617 stays the behavioral oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
