### PR TITLE
feat(1618) root-2: harness IPC channel separation — result on the control socket (byte-identical)

### DIFF
--- a/src/reyn/kernel/_codeact_harness.py
+++ b/src/reyn/kernel/_codeact_harness.py
@@ -60,6 +60,12 @@ class _ControlChannel:
         self._sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
         return self._recv_line()
 
+    def send(self, payload: dict[str, Any]) -> None:
+        """Send one frame with NO reply (#1618 root-2: the snippet's final result
+        envelope travels on this control channel, NOT stdout — so user-code
+        ``print()`` to stdout can never corrupt the protocol)."""
+        self._sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+
     def _recv_line(self) -> dict[str, Any]:
         while b"\n" not in self._buf:
             chunk = self._sock.recv(65536)
@@ -150,6 +156,7 @@ def _write_response(payload: dict[str, Any]) -> None:
 
 def main() -> int:
     sock: socket.socket | None = None
+    channel: "_ControlChannel | None" = None
     try:
         req = _read_request()
         code = str(req["code"])
@@ -160,15 +167,27 @@ def main() -> int:
         channel = _ControlChannel(sock)
 
         result = _exec_codeact(code, channel, allowed_modules)
-        _write_response({"ok": True, "result": result})
+        # #1618 root-2: final result on the CONTROL CHANNEL (op="final"), not stdout
+        # — user code's stdout/stderr stay clean for the parent to capture as data.
+        channel.send({"op": "final", "ok": True, "result": result})
         return 0
     except Exception as exc:  # noqa: BLE001 — surface every failure as a response
-        _write_response({
+        _final = {
+            "op": "final",
             "ok": False,
             "kind": type(exc).__name__,
             "error": str(exc),
             "traceback": traceback.format_exc(limit=20),
-        })
+        }
+        # Prefer the control channel; if it never opened (early error) or is dead,
+        # fall back to stdout so the parent's no-final crash-path still surfaces it.
+        if channel is not None:
+            try:
+                channel.send(_final)
+            except OSError:
+                _write_response(_final)
+        else:
+            _write_response(_final)
         return 1
     finally:
         if sock is not None:

--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -141,7 +141,12 @@ class CodeActRunner:
 
         loop = asyncio.get_running_loop()
         parent_sock.setblocking(False)
-        service_task = asyncio.create_task(self._service(parent_sock, dispatch, loop))
+        # #1618 root-2: the snippet's result arrives as an op="final" frame on the
+        # control channel (not stdout); _service captures it here.
+        final_box: list[dict] = []
+        service_task = asyncio.create_task(
+            self._service(parent_sock, dispatch, loop, final_box)
+        )
 
         # ``communicate(input=...)`` writes the request to stdin (the child reads it
         # fully before touching the control channel), then reads stdout/stderr +
@@ -152,16 +157,23 @@ class CodeActRunner:
         comm_future = loop.run_in_executor(
             None, lambda: proc.communicate(input=request_bytes),
         )
+        timed_out = False
         try:
             stdout_b, stderr_b = await asyncio.wait_for(comm_future, timeout=timeout)
         except asyncio.TimeoutError:
-            await _kill_proc_group(proc, loop)
-            return {
-                "ok": False, "status": "timeout",
-                "kind": "Timeout", "error": f"codeact timed out after {timeout}s",
-            }
-        finally:
+            timed_out = True
             service_task.cancel()
+            await _kill_proc_group(proc, loop)
+            stdout_b, stderr_b = b"", b""
+        else:
+            # Normal exit: the child sent op="final" then closed the channel (EOF), so
+            # DRAIN the service task (bounded) to populate final_box, rather than
+            # cancelling it mid-frame.
+            try:
+                await asyncio.wait_for(service_task, timeout=2.0)
+            except Exception:  # noqa: BLE001 — drain best-effort; cancel if it hangs
+                service_task.cancel()
+        finally:
             try:
                 parent_sock.close()
             except OSError:
@@ -169,6 +181,21 @@ class CodeActRunner:
             if cleanup is not None:
                 cleanup()
 
+        if timed_out:
+            return {
+                "ok": False, "status": "timeout",
+                "kind": "Timeout", "error": f"codeact timed out after {timeout}s",
+            }
+        # #1618 root-2: the result is the op="final" frame; stdout/stderr are now PURE
+        # user-program output, captured as data (the format_feedback fallback when the
+        # snippet print()s instead of binding ``result``). No final frame = an early
+        # crash before the channel opened → the stdout crash-path fallback.
+        if final_box:
+            final = dict(final_box[0])
+            final.pop("op", None)
+            final["stdout"] = (stdout_b or b"").decode("utf-8", errors="replace")
+            final["stderr"] = (stderr_b or b"").decode("utf-8", errors="replace")
+            return final
         return self._parse_response(stdout_b, stderr_b, proc.returncode)
 
     def _resolve_sandbox_spawn(
@@ -244,10 +271,13 @@ class CodeActRunner:
 
     async def _service(
         self, sock: socket.socket, dispatch: DispatchFn, loop: asyncio.AbstractEventLoop,
+        final_box: list[dict],
     ) -> None:
         """Service the control channel until the child closes it (EOF). Each
         ``tool_call`` is gated by ``dispatch`` (the parent's exclude + dispatch_tool
-        + permission pipeline) and the result envelope is sent back."""
+        + permission pipeline) and the result envelope is sent back. The terminal
+        ``op="final"`` frame (#1618 root-2: the snippet's result, now on this channel
+        instead of stdout) is captured into ``final_box`` — no reply, the child exits."""
         buf = b""
         while True:
             try:
@@ -262,7 +292,11 @@ class CodeActRunner:
                 if not line:
                     continue
                 req = json.loads(line.decode("utf-8"))
-                if req.get("op") != "tool_call":
+                op = req.get("op")
+                if op == "final":
+                    final_box.append(req)  # the snippet's result envelope
+                    continue
+                if op != "tool_call":
                     continue
                 result = await dispatch(req.get("name", ""), req.get("args", {}) or {})
                 reply = json.dumps({"op": "result", "result": result}).encode("utf-8")

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -87,8 +87,22 @@ def _format_codeact_observation(out: dict) -> str:
     the model reads after its code turn (success result, or the error/kind on
     failure / timeout / sandbox-unavailable)."""
     if out.get("ok"):
-        body = json.dumps(out.get("result"), default=str, ensure_ascii=False)
-        return f"[codeact result]\n{body}"
+        result = out.get("result")
+        stdout = (out.get("stdout") or "").strip()
+        if result is not None:
+            body = json.dumps(result, default=str, ensure_ascii=False)
+            obs = f"[codeact result]\n{body}"
+        elif stdout:
+            # #1618 root-2 (#6): the snippet print()d instead of binding ``result`` —
+            # surface the captured stdout so the observation is not empty (the model
+            # otherwise sees nothing and retries / gives up).
+            obs = f"[codeact stdout]\n{stdout}"
+        else:
+            obs = f"[codeact result]\n{json.dumps(result, default=str)}"
+        stderr = (out.get("stderr") or "").strip()
+        if stderr:
+            obs = f"{obs}\n[codeact stderr]\n{stderr}"
+        return obs
     kind = out.get("kind", "Error")
     return f"[codeact {kind}]\n{out.get('error', '')}"
 

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -225,3 +225,37 @@ def test_harness_subprocess_env_preserves_existing_pythonpath(monkeypatch) -> No
     parts = _harness_subprocess_env()["PYTHONPATH"].split(os.pathsep)
     assert "/some/existing/path" in parts
     assert parts[-1] == "/some/existing/path"  # appended after the prepended tree
+
+
+@pytest.mark.asyncio
+async def test_user_print_does_not_corrupt_result() -> None:
+    """Tier 2: #1618 root-2 (#8) — user-code ``print()`` to stdout no longer corrupts
+    the result. The result envelope now travels on the control channel (op="final"),
+    so a snippet that prints AND binds ``result`` returns the correct result (was
+    MalformedResponse when the print's repr landed on stdout ahead of the envelope)."""
+    async def dispatch(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": "PURPLE-OTTER-42"}
+
+    runner = CodeActRunner()
+    code = "print('noisy debug line'); print({'a': 1})\nresult = tool('file__read', path='x')"
+    out = await runner.run(code=code, dispatch=dispatch, allow_unsandboxed=True)
+    assert out["ok"] is True, out
+    assert out["result"] == "PURPLE-OTTER-42"          # result intact, not corrupted
+    assert "noisy debug line" in (out.get("stdout") or "")  # user stdout captured as data
+
+
+@pytest.mark.asyncio
+async def test_print_only_snippet_surfaces_via_stdout() -> None:
+    """Tier 2: #1618 root-2 (#6) — a snippet that print()s WITHOUT binding ``result``
+    yields result=None but the captured stdout is returned as data, so the observation
+    is not empty (the model otherwise sees nothing and retries / gives up)."""
+    async def dispatch(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": None}
+
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="print('the answer is 42')", dispatch=dispatch, allow_unsandboxed=True,
+    )
+    assert out["ok"] is True, out
+    assert out.get("result") is None
+    assert "the answer is 42" in (out.get("stdout") or "")


### PR DESCRIPTION
**[e2e-coder]** — #1618 holistic design, **staging increment 2: root-2 (harness IPC channel separation)**. Collapses CodeAct #8/#6 by construction; byte-identical for non-CodeAct.

## What
The harness multiplexed **protocol output** (the result envelope) and **user-program output** (`print()` → stdout) onto the same byte stream → any snippet that printed corrupted the parent's `json.loads(stdout)` (#8 MalformedResponse); and a snippet that `print()`d instead of binding `result` yielded an empty observation (#6). Fix = separate the channels (sandbox_2's design + lead's notes: reuse the control socket, capture stderr too, format_feedback precedence).

- **Harness**: the result envelope travels on the existing **control socket** (`op="final"`), NOT stdout. Stdout retained only as the early-crash fallback (channel never opened).
- **Runner**: `_service` captures the `final` frame; `run()` **drains** the service task on normal exit (child sent final → EOF) rather than cancelling mid-frame; returns the envelope with `stdout`/`stderr` attached as **pure user-output data**.
- **format_feedback**: result-primary / captured-stdout-fallback (#6) / stderr-when-present. OS stays P7-agnostic (generic channel + precedence; observation text is CodeAct's).

## Test plan
- [x] `test_codeact_runner_1593.py` +2 Tier-2: print-doesn't-corrupt-result (#8 — result intact + stdout captured) + print-only-surfaces-via-stdout (#6).
- [x] 11 existing runner round-trips green under the result-on-socket change.
- [x] 429 codeact/represent/dispatch/scheme regression green (byte-identical for non-CodeAct).
- [x] ruff + tier-audit clean.
- [ ] (sandbox_2) **oracle #8 MalformedResponse-vanish signature check** — does a print()-ing snippet's MalformedResponse vanish WITHOUT #1617's patches?

Staging: root-1+4 merged (#1619); root-2 here; **root-3 (replace-capable SP, the ② re-design)** + result-shape hardening follow. #1617 stays the behavioral oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
