### PR TITLE
fix(1621): pin fastapi<0.137 + starlette<1.3 — unblock main CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,15 @@ docs = [
     "mkdocs-static-i18n>=1.2",
 ]
 web = [
-    "fastapi>=0.110",
+    # #1621: upper-bounds pin (owner steer) — CI's unpinned resolve pulled
+    # fastapi 0.137 + starlette 1.3.1, whose ``_IncludedRouter`` in ``app.routes``
+    # breaks the flat route-introspection the web tests assert on. Pin below 1.3
+    # (the introducing release; local 1.0.0 + the highest <1.3 are working) and
+    # cap fastapi <0.137 (the release that floors starlette to 1.3) so CI is
+    # reproducible. starlette pinned directly (it is a transitive of fastapi).
+    # forward-migration to the new route model is a separate optional follow-up.
+    "fastapi>=0.110,<0.137",
+    "starlette>=1.0,<1.3",
     "uvicorn[standard]>=0.27",
     "websockets>=12",
 ]


### PR DESCRIPTION
**[tui-coder]** — P0 CI-red unblock (critical-path, blocks all merges). Owner-steered minimal pin.

## Problem
Unpinned `fastapi>=0.110` let CI resolve **fastapi 0.137.0 + starlette 1.3.1**, whose new `_IncludedRouter` object in `app.routes` breaks the flat route-introspection (`{getattr(r, "path", ...) for r in app.routes}`) that the 6 web tests assert on. Local (starlette 1.0.0) passed — version drift.

## Fix (owner steer: pin, no migration)
```toml
"fastapi>=0.110,<0.137",   # 0.137 floors starlette to 1.3
"starlette>=1.0,<1.3",     # _IncludedRouter introduced in 1.3; pinned directly (transitive of fastapi)
```
Upper bounds added so CI is reproducible. Forward-migration to starlette's included-router model (recurse for `.path`) is a separate optional follow-up — out of scope here (owner chose the pin for immediate green).

## Verification (primary evidence)
- Pin resolves to the **highest in-range**: starlette **1.2.1** / fastapi **0.136.3** (verified via isolated venv).
- `_IncludedRouter` is **absent** in starlette 1.2.1 (`hasattr(starlette.routing, "_IncludedRouter") == False`).
- All 6 previously-failing web tests **PASS on 1.2.1**: `test_smoke::test_routers_mounted`, `test_a2a::test_a2a_routes_mounted`, `test_mcp_sse::test_mcp_routes_mounted`, `test_resources_router::test_resources_route_is_mounted_on_app`, `test_plugin_loader::test_loader_disambiguates_via_package_field`, `test_fp0001_a2a_endpoints::test_fp0001_routes_mounted`.
- No lockfile in repo → CI resolves from pyproject, so the pin governs CI resolution.

## Test plan
- [x] 6 failing web tests pass on the pinned upper-boundary (starlette 1.2.1) locally
- [x] `_IncludedRouter` absent in resolved version (primary-verified, isolated venv)
- [x] pyproject.toml parses (tomllib)
- [ ] CI green on this branch (the actual gate — confirming before merge)

Fixes #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
