### PR TITLE
docs: fix broken permission-model link breaking mkdocs --strict (unblock main)

### DIFF
--- a/docs/concepts/architecture/sandbox-vs-permission.md
+++ b/docs/concepts/architecture/sandbox-vs-permission.md
@@ -21,7 +21,7 @@ policy** for a specific skill:
 
 Permissions are **skill-level**: each skill declares its own, and the operator
 or user approves them. The runtime enforces them through the AgentLayer of the
-[conjunctive permission model](permission-model.md#effective-permission-conjunctive-restrict-model).
+[conjunctive permission model](../runtime/permission-model.md#effective-permission-conjunctive-restrict-model).
 
 ```yaml
 # skill.md


### PR DESCRIPTION
**[docs-maintainer]** — unblocks the **main docs-build red** ("Build LP + docs" workflow failing `mkdocs build --strict`).

## Root cause

`concepts/architecture/sandbox-vs-permission.md:24` linked `permission-model.md#effective-permission-conjunctive-restrict-model`, which MkDocs resolves relative to the source dir → `concepts/architecture/permission-model.md` (does not exist). The actual file is in `concepts/runtime/`. This is a **WARNING-level** event, which `--strict` promotes to an error → workflow red. Pre-existing drift, unrelated to #1622 / CodeAct work.

## Fix

`../runtime/permission-model.md#effective-permission-conjunctive-restrict-model` — matches the already-correct path on line 90 of the same file. Verified the target heading + explicit anchor exist (`permission-model.md:495 ## Effective permission: conjunctive restrict model {#effective-permission-conjunctive-restrict-model}`).

## Verification

- `mkdocs build --strict` → **exit 0** (was non-zero). Confirmed the only WARNING-level event is gone.
- Remaining build output is all **INFO-level** JA-mirror anchor misses, which do **not** fail `--strict` (tracked separately in #1615 — see note below).

## Correction to the record

My earlier #1615 / #1614 framing said `--strict` "aborts on the JA-mirror anchor lag." That was an inference error: I conflated INFO-level anchor-misses (non-failing) with this WARNING-level broken link (the actual `--strict` failure). The JA-anchor lag (#1615) is real but does **not** block `--strict`. I'll correct #1615 + the backlog pin accordingly. This means the standing "--strict CI gate" is *not* blocked by JA mirroring once WARNING-level links are clean (now true).

## Test plan

- [x] `mkdocs build --strict` exits 0
- [x] Target file + heading + anchor verified to exist
- [x] No other WARNING-level events in the build (grep `^WARNING` empty)
- [x] Single-line fix, matches sibling link on line 90
- [ ] lead-coder review/merge to green main

🤖 Generated with [Claude Code](https://claude.com/claude-code)