### PR TITLE
feat(1618 root-3): replace-capable scheme-owned tool-use SP + interpret-robustness (#2/#5)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1773,6 +1773,12 @@ class RouterLoop:
                 # retrieval search-SP) supplies its own tool-use text here and
                 # the OS appends it verbatim (P7 — no scheme concepts in the OS).
                 scheme_sp_fragment=_pres.sp_fragment,
+                # #1618 root-3: scheme REPLACEMENT for the tool-use SP region. None
+                # (named-gate schemes) ⇒ OS builds today's tool-use SP byte-identical;
+                # non-None (CodeAct code-API) ⇒ OS injects it at the ## Capabilities
+                # position + skips the universal tool-use construction (P7 — OS owns
+                # the region/position, the scheme owns the content).
+                tool_use_sp=_pres.tool_use_sp,
                 # #272/#1128: OS-injected context-size signal (header), computed
                 # once above. Rendered LAST in the SP (most volatile section →
                 # preserves the cached prefix above it); None when ample.

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -73,6 +73,7 @@ def build_system_prompt(
     cwd: str | None = None,
     search_actions_enabled: bool = True,  # FP-0034 §D14 — default True preserves byte-compat
     scheme_sp_fragment: str = "",  # #1593 — free-form scheme-owned tool-use SP; OS appends verbatim (P7), default "" = byte-identical named-gate path
+    tool_use_sp: "str | None" = None,  # #1618 root-3 — scheme REPLACEMENT for the tool-use SP region; None = OS builds today's (byte-identical), non-None = inject + skip the universal tool-use construction
     context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
     discovery_mandate: bool = False,  # #187 Stage C — weak-tier list_actions-first mandate (3x)
     non_interactive: bool = False,  # #1439 Fix #1 — run-once (no TTY): no user to ask, proceed instead of clarifying
@@ -191,6 +192,11 @@ def build_system_prompt(
     )
     parts.append("")
 
+    # #1618 root-3: capture the index before the tool-use ## Capabilities region so a
+    # replace-capable scheme (``tool_use_sp``) can slice-replace the whole built region
+    # with its own tool-use SP — no re-indent; byte-identical when ``tool_use_sp`` is
+    # None (no replacement happens).
+    _cap_start = len(parts)
     # ── 3. Capabilities (routing guide) — FP-0023 Change 2 ─────────────────
     # Merges the old "## What you can do (intent axis)" (internal routing
     # labels) and "## When asked what you can do" (user-facing) into one
@@ -304,6 +310,14 @@ def build_system_prompt(
         ),
         "",
     ])
+
+    # #1618 root-3: a replace-capable scheme injects its tool-use SP HERE, replacing
+    # the whole built ## Capabilities region (CodeAct's code-API — so the universal
+    # routing guide can't dominate it). discovery / search / ROUTING-RULE below are
+    # separately gated off; the OS-level sections (environment / behaviour-errors /
+    # project / …) remain. Byte-identical when ``tool_use_sp`` is None (no replacement).
+    if tool_use_sp is not None:
+        parts[_cap_start:] = [tool_use_sp]
 
     # ── 3.4. Environment (CWD context, P7-clean) ─────────────────────────────
     # Tells the LLM where it is running so unqualified references like
@@ -436,7 +450,10 @@ def build_system_prompt(
     # obviously matches") so it reinforces the SAME non-obvious scope as
     # branch-3, never a blanket rule (bleed guard). Renders whenever the tier
     # opts in; list_actions is always available.
-    if discovery_mandate:
+    # #1618 root-3: the list_actions-first MANDATE is tool-use-specific (universal
+    # discovery vocab) — a replace-capable scheme owns its own discovery story inside
+    # ``tool_use_sp``, so skip the universal mandate when a scheme replaced the region.
+    if discovery_mandate and tool_use_sp is None:
         parts.append(
             "When no visible tool obviously matches the action you need, "
             "calling list_actions is MANDATORY and comes FIRST — before any "
@@ -474,7 +491,13 @@ def build_system_prompt(
     # when it is actually in tools= (= search_actions_enabled=True).
     # When not available, omit the search_actions signal entirely so the
     # LLM does not attempt to call a tool that does not exist.
-    if search_actions_enabled:
+    # #1618 root-3: the "never invent action names; use list_actions/search_actions"
+    # guidance is universal-vocab tool-use SP — a replace-capable scheme states its
+    # own action-naming contract inside ``tool_use_sp`` (e.g. CodeAct's "Available
+    # actions:" list), so skip the universal guidance when the region was replaced.
+    if tool_use_sp is not None:
+        pass
+    elif search_actions_enabled:
         parts.extend([
             "  - Never invent action names; only use those returned by",
             "    `list_actions` or `search_actions`.",
@@ -493,13 +516,17 @@ def build_system_prompt(
     # B12-R2/B13-R3 V3 ABSOLUTE rule preserved in wrapper vocab (1-line,
     # JA examples dropped — per B23-PRE-1 SP simplification policy).
     # P7-compliant placeholder: `<action_name>` (= qualified name format).
-    parts.append("")
-    parts.extend([
-        "  ROUTING RULE (ABSOLUTE): When the user message contains an action"
-        " name (= valid `invoke_action` action_name, e.g. `skill__code_review`),"
-        " call `invoke_action` immediately. NO clarifying questions. NO text replies.",
-        "",
-    ])
+    # #1618 root-3: the invoke_action ROUTING-RULE is universal-wrapper vocab — a
+    # replace-capable scheme encodes its own act-on-named-action rule inside
+    # ``tool_use_sp``, so skip the universal rule when the region was replaced.
+    if tool_use_sp is None:
+        parts.append("")
+        parts.extend([
+            "  ROUTING RULE (ABSOLUTE): When the user message contains an action"
+            " name (= valid `invoke_action` action_name, e.g. `skill__code_review`),"
+            " call `invoke_action` immediately. NO clarifying questions. NO text replies.",
+            "",
+        ])
 
     # ==========================================================================
     # DYNAMIC — varies per session / configuration

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -348,14 +348,30 @@ def build_system_prompt(
                 parts.append(f"git repo: {'yes' if environment_info['is_git_repo'] else 'no'}")
         parts.append("")
         if cwd:
-            parts.append(
-                "When the user refers to \"this repo\", \"this code\", \"the codebase\","
-                " \"this project\", \"ここ\", or any other unqualified reference to"
-                " surrounding source, interpret it as the project at the cwd above."
-                " Do NOT ask for a repository URL or path — discover the contents"
-                " with `list_actions(category=['file'])` → `invoke_action(file__list, ...)`"
-                " → `invoke_action(file__read, ...)` within the cwd's read scope."
-            )
+            # #1618 root-3: the cwd semantic mapping ("this repo" → the project at cwd)
+            # is OS-level (kept for every scheme), but its HOW clause ("discover with
+            # list_actions → invoke_action") is universal-wrapper idiom — the same
+            # tool-use-specific content the discovery-mandate (L453) gates. A
+            # replace-capable scheme owns its own file-discovery idiom (CodeAct's
+            # tool() proxy), so render the universal HOW only when ``tool_use_sp`` is
+            # None (byte-identical), and a scheme-neutral variant otherwise.
+            if tool_use_sp is None:
+                parts.append(
+                    "When the user refers to \"this repo\", \"this code\", \"the codebase\","
+                    " \"this project\", \"ここ\", or any other unqualified reference to"
+                    " surrounding source, interpret it as the project at the cwd above."
+                    " Do NOT ask for a repository URL or path — discover the contents"
+                    " with `list_actions(category=['file'])` → `invoke_action(file__list, ...)`"
+                    " → `invoke_action(file__read, ...)` within the cwd's read scope."
+                )
+            else:
+                parts.append(
+                    "When the user refers to \"this repo\", \"this code\", \"the codebase\","
+                    " \"this project\", \"ここ\", or any other unqualified reference to"
+                    " surrounding source, interpret it as the project at the cwd above."
+                    " Do NOT ask for a repository URL or path — read the contents using"
+                    " your available actions within the cwd's read scope."
+                )
             parts.append("")
 
     # ── 3.5. Universal catalog (FP-0034 §D9, opt-in via action_retrieval) ────

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -71,6 +71,16 @@ class Presentation:
     # dispatchable = advertised (``llm_tools_payload``) — byte-identical for
     # universal / enumerate-all / retrieval, whose three catalog notions coincide.
     dispatchable_catalog: "list[dict] | None" = None
+    # #1618 root-2 (②, replace-capable SP): the scheme's REPLACEMENT for the OS-owned
+    # tool-use SP region. ``None`` ⇒ the OS builds today's tool-use SP from sp_params
+    # (universal / enumerate-all — BYTE-IDENTICAL). Non-None ⇒ the OS injects this
+    # verbatim AT the tool-use region position and SKIPS the universal tool-use
+    # construction (wrapper / V18-routing / categories / hot-list / discovery-mandate /
+    # search / ROUTING-RULE) entirely. This is the REPLACE channel (vs the #1601
+    # ``sp_fragment`` APPEND): CodeAct's code-API must not sit beneath a dominant
+    # universal guide that contradicts it. P7: the OS owns the region/position; the
+    # content is scheme-owned. OS retains identity + errors-verbatim + non-tool routing.
+    tool_use_sp: "str | None" = None
 
 
 # ── Canonical catalog-shape projections (#1618 root-1) ──────────────────────

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -31,14 +31,17 @@ from reyn.tools.scheme import (
     CodeBlock,
     ExecContext,
     ExecutionResult,
+    PlainText,
     Presentation,
     flat_catalog_entries,
     register_scheme,
 )
 
-# A fenced ```python ... ``` (or bare ``` ... ```) block — how the CodeAct LLM
-# emits its snippet in the message content.
-_FENCE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
+# A fenced code block — how the CodeAct LLM emits its snippet in the message
+# content. #1618 root-3 (#5): accept the Gemini-native ``tool_code`` fence label
+# alongside ``python`` / ``py`` / bare ``` (fence-label variation — weak models
+# vary the label; the snippet body is the same Python the runner executes).
+_FENCE_RE = re.compile(r"```(?:python|py|tool_code)?\s*\n(.*?)```", re.DOTALL)
 
 
 def _render_code_api(entries: list[dict]) -> str:
@@ -47,14 +50,31 @@ def _render_code_api(entries: list[dict]) -> str:
     ``tool(...)`` proxy. Pure presentation — the model reads it; it is NOT executed
     Python. The arg names come from each entry's JSON-schema ``parameters.properties``
     (CodeAct's strictest-consumer schema-completeness floor guarantees a dict)."""
+    # #1618 root-3 (②): this is the REPLACEMENT tool-use SP (Presentation.tool_use_sp)
+    # — it is the SOLE tool-use instruction the model sees (the OS drops the universal
+    # invoke_action / list_actions / ROUTING-RULE vocab for this region). So it must
+    # carry the whole CodeAct contract: act = a single fenced python block; prose = the
+    # terminal final answer (the #2 loop-unify contract — the model must KNOW prose ends
+    # the turn, or it never cleanly finishes). Wording is the measured variable for the
+    # fence-compliance oracle (dogfood-coder owns content finalization).
     lines = [
-        "## CodeAct — write a Python script (not JSON tool calls)",
+        "## Tool use — this agent acts by running Python, not JSON tool calls",
         "",
-        "Write a Python snippet. Call any available action with "
-        "``tool('<name>', <arg>=<value>, ...)`` — it returns the action's result, or "
-        "raises if the action is denied / excluded / unknown. Assign your final answer "
-        "to a variable named ``result``. The standard library is available; "
-        "filesystem / network / subprocess are sandboxed.",
+        "To DO anything (read a file, call an action, compute), respond with a "
+        "SINGLE fenced ```python block and NOTHING else — no prose before or after it, "
+        "no \"I am a Reyn agent\" preamble on an action turn. Inside the block, call any "
+        "available action:",
+        "",
+        "    result = tool('<name>', <arg>=<value>, ...)",
+        "",
+        "`tool(...)` returns the action's result, or raises if the action is denied / "
+        "excluded / unknown. Assign your final answer to `result`. The Python standard "
+        "library is available; filesystem / network / subprocess are sandboxed — reach "
+        "the outside world ONLY via `tool()`.",
+        "",
+        "When you are DONE (answer in hand, no more actions to run): reply in plain "
+        "prose with NO code block — that ends the turn. A turn is EITHER one fenced "
+        "```python block OR a plain-prose final answer, never both.",
         "",
         "Available actions:",
     ]
@@ -69,17 +89,24 @@ def _render_code_api(entries: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _extract_code(llm_response: Any) -> str:
+def _extract_fenced_code(llm_response: Any) -> "str | None":
     """Pull the snippet from the LLM response: the first fenced code block in the
-    content, else the whole content (the model may emit bare code). Empty when
-    there is nothing to run (``execute`` then no-ops)."""
+    content, or ``None`` when there is NO recognized fence.
+
+    #1618 root-3 (#2): returning ``None`` (instead of the old "else the whole
+    content" bare-code fallback) is the loop-unify "prose = terminal" contract. The
+    SP demands a fenced block for any action turn, so a no-fence response is the
+    model's plain-prose final answer — NOT bare code to run. The old fallback ran
+    prose as code (no-op → empty observation → the model retries forever → timeout,
+    the oracle-baseline finding); ``interpret`` now maps ``None`` → ``PlainText``
+    (terminal) so the loop cleanly exits."""
     content = getattr(llm_response, "content", None) or ""
     if not isinstance(content, str):
-        return ""
+        return None
     match = _FENCE_RE.search(content)
     if match:
         return match.group(1)
-    return content.strip()
+    return None
 
 
 def _format_codeact_observation(out: dict) -> str:
@@ -119,9 +146,11 @@ class CodeActScheme:
         self, available: Any, layer_ctx: Any, ops: Any,
     ) -> Presentation:
         """Render the permission-eligible actions as a CodeAct *code-API* in the
-        ``sp_fragment`` (#1601 channel) — each action a callable the model invokes via
-        the ``tool(name, **args)`` proxy. No JSON ``tools=`` (``llm_tools_payload``
-        empty): the model writes a Python snippet in its content, not tool calls.
+        ``tool_use_sp`` (#1618 root-3 REPLACE channel — the code-API replaces the
+        universal tool-use SP region, vs the #1601 ``sp_fragment`` APPEND that left the
+        universal vocab in place) — each action a callable the model invokes via the
+        ``tool(name, **args)`` proxy. No JSON ``tools=`` (``llm_tools_payload`` empty):
+        the model writes a Python snippet in its content, not tool calls.
 
         ``ops.catalog_entries()`` is async (the SchemeOps adapter ensures the
         rag/source-populated context — e2e Option A: adapter owns the rs-ensure
@@ -156,14 +185,33 @@ class CodeActScheme:
                 "universal_wrappers_enabled": False,
                 "search_actions_enabled": False,
             },
-            sp_fragment=_render_code_api(rendered),
+            # #1618 root-3 (②): REPLACE the universal tool-use SP region with the
+            # code-API (not the old sp_fragment APPEND, which left the universal
+            # invoke_action / list_actions / ROUTING-RULE vocab in place → leaks
+            # 1/2/5/6). tool_use_sp ⇒ the OS injects this at the ## Capabilities
+            # position + drops the universal tool-use construction, so the code-API is
+            # the SOLE tool-use instruction the model sees.
+            tool_use_sp=_render_code_api(rendered),
         )
 
-    def interpret(self, llm_response: Any, *, tool_catalog: dict, ops: Any) -> CodeBlock:
-        """Extract the snippet as a ``CodeBlock`` (the OS-loop's CodeBlock arm runs
-        ``execute``). No resolution/dedup here — CodeAct tool calls are resolved +
-        gated per call inside ``execute`` (via the OS gate), not up front."""
-        return CodeBlock(code=_extract_code(llm_response))
+    def interpret(
+        self, llm_response: Any, *, tool_catalog: dict, ops: Any,
+    ) -> "CodeBlock | PlainText":
+        """Classify the LLM output: a fenced code snippet ⇒ ``CodeBlock`` (the OS-loop's
+        CodeBlock arm runs ``execute``); no fence ⇒ ``PlainText`` (terminal — the model
+        replied in prose = done, the loop exits to the text-reply path). No
+        resolution/dedup here — CodeAct tool calls are resolved + gated per call inside
+        ``execute`` (via the OS gate), not up front.
+
+        #1618 root-3 (#2): the no-fence ⇒ PlainText branch is what lets a CodeAct turn
+        cleanly TERMINATE. Without it (old: always CodeBlock), a prose final answer ran
+        as bare code → no-op → the model never finishes → loop/timeout (oracle-baseline
+        finding). ``interpret`` is a pure classifier (P-aligned): PlainText is dataless;
+        the OS already holds ``llm_response.content`` for the reply."""
+        code = _extract_fenced_code(llm_response)
+        if code is None:
+            return PlainText()
+        return CodeBlock(code=code)
 
     async def execute(
         self, interp: CodeBlock, exec_ctx: ExecContext, ops: Any,

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -1,14 +1,17 @@
 """Tier 2: #1593 PR-3 S3a — CodeActScheme (interpret + execute glue + feedback).
 
 CodeAct is own-logic (not delegating). This pins:
-  - interpret extracts the snippet (fenced or bare) as a CodeBlock.
+  - interpret classifies the LLM output: a fenced code block ⇒ CodeBlock; no fence ⇒
+    PlainText (terminal — #1618 root-3 #2 loop-unify "prose = done" contract). The
+    fence label may be python / py / tool_code (#1618 root-3 #5 fence-label variation).
   - execute threads the OS per-call gate (exec_ctx.extra['dispatch']) + sandbox into
     the CodeActRunner and wraps the result — and REQUIRES the gate (no silent
     ungated run).
   - format_feedback shapes each runner envelope into a user-role observation message
     (the CodeBlock arm's append shape; the documented Execute/CodeBlock divergence).
-  - build_presentation renders the actions as a code-API in sp_fragment (no JSON
-    tools=), with excluded actions omitted (presentation parity with JSON).
+  - build_presentation renders the actions as a code-API in tool_use_sp (#1618 root-3
+    REPLACE channel, not the sp_fragment APPEND), no JSON tools=, with excluded
+    actions omitted (presentation parity with JSON).
 
 The per-call gate RE-ENTRY invariant (N calls → N gate invocations, exclude
 per-call) is pinned at the runner level in test_codeact_runner_1593.py (the gate is
@@ -21,7 +24,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult
+from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, PlainText
 from reyn.tools.schemes.codeact import CodeActScheme
 
 
@@ -45,11 +48,26 @@ def test_interpret_extracts_fenced_code() -> None:
     assert interp.code.strip() == "result = tool('m')"
 
 
-def test_interpret_bare_content_when_no_fence() -> None:
-    """Tier 2: interpret falls back to the whole content when there is no fence."""
-    resp = SimpleNamespace(content="result = 1 + 1")
+def test_interpret_no_fence_returns_plaintext_terminal() -> None:
+    """Tier 2: #1618 root-3 (#2) — no recognized fence ⇒ PlainText (terminal), NOT a
+    CodeBlock. A prose-only response is the model's final answer (loop-unify "prose =
+    done" contract); the old "run the whole content as bare code" behavior no-op'd →
+    the model never cleanly finished → loop/timeout. PlainText is dataless (the OS
+    holds the content for the reply)."""
+    resp = SimpleNamespace(content="The file contains a config for the build.")
     interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
-    assert interp.code == "result = 1 + 1"
+    assert isinstance(interp, PlainText)
+    # Not misclassified as code (would run prose → no-op → loop).
+    assert not isinstance(interp, CodeBlock)
+
+
+def test_interpret_extracts_tool_code_fence() -> None:
+    """Tier 2: #1618 root-3 (#5) — the Gemini-native ```tool_code fence label is
+    recognized as a code block (fence-label variation), same as ```python."""
+    resp = SimpleNamespace(content="```tool_code\nresult = tool('m')\n```")
+    interp = CodeActScheme().interpret(resp, tool_catalog={}, ops=None)
+    assert isinstance(interp, CodeBlock)
+    assert interp.code.strip() == "result = tool('m')"
 
 
 @pytest.mark.asyncio
@@ -107,7 +125,7 @@ def test_format_feedback_shapes_observation_message() -> None:
     assert "denied" in err[0]["content"]
 
 
-# ── S3b: build_presentation (code-API render into sp_fragment) ────────────────
+# ── S3b: build_presentation (code-API render into tool_use_sp) ────────────────
 
 
 class _CatalogOps:
@@ -123,18 +141,23 @@ class _CatalogOps:
 
 
 @pytest.mark.asyncio
-async def test_build_presentation_renders_code_api_into_sp_fragment() -> None:
-    """Tier 2: build_presentation renders the actions as a code-API in sp_fragment
-    (no JSON tools=); behavior-pinned (action names + tool() proxy instruction
-    present), not format-pinned."""
+async def test_build_presentation_renders_code_api_into_tool_use_sp() -> None:
+    """Tier 2: #1618 root-3 — build_presentation renders the actions as a code-API in
+    tool_use_sp (the REPLACE channel, not sp_fragment APPEND); no JSON tools=.
+    Behavior-pinned (action names + tool() proxy + prose=terminal contract present),
+    not format-pinned."""
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
-    # No JSON tools= — CodeAct presents via the SP fragment, model writes a snippet.
+    # No JSON tools= — CodeAct presents via the SP, model writes a snippet.
     assert pres.llm_tools_payload == []
-    # The actions surface in the code-API + the tool() proxy is instructed.
-    assert "file__read" in pres.sp_fragment
-    assert "web__fetch" in pres.sp_fragment
-    assert "tool(" in pres.sp_fragment
-    # The named SP gates are off (CodeAct expresses tool-use via the fragment).
+    # The actions surface in the code-API + the tool() proxy is instructed, via the
+    # REPLACE channel (tool_use_sp), and the old APPEND channel is unused.
+    assert "file__read" in pres.tool_use_sp
+    assert "web__fetch" in pres.tool_use_sp
+    assert "tool(" in pres.tool_use_sp
+    assert not pres.sp_fragment  # root-3: replace channel, not append
+    # The prose=terminal contract (#2) must be stated so the model knows how to finish.
+    assert "plain prose" in pres.tool_use_sp
+    # The named SP gates are off (CodeAct expresses tool-use via tool_use_sp).
     assert pres.sp_params.get("universal_wrappers_enabled") is False
     assert pres.sp_params.get("search_actions_enabled") is False
 
@@ -143,7 +166,7 @@ async def test_build_presentation_renders_code_api_into_sp_fragment() -> None:
 async def test_build_presentation_includes_arg_names() -> None:
     """Tier 2: an action's schema arg names appear in its code-API signature."""
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
-    assert "path" in pres.sp_fragment  # file__read's parameters.properties key
+    assert "path" in pres.tool_use_sp  # file__read's parameters.properties key
 
 
 @pytest.mark.asyncio
@@ -154,8 +177,8 @@ async def test_build_presentation_omits_excluded_actions() -> None:
     pres = await CodeActScheme().build_presentation(
         {"exclude_tools": frozenset({"web__fetch"})}, {}, _CatalogOps(),
     )
-    assert "file__read" in pres.sp_fragment   # kept
-    assert "web__fetch" not in pres.sp_fragment  # excluded → omitted
+    assert "file__read" in pres.tool_use_sp   # kept
+    assert "web__fetch" not in pres.tool_use_sp  # excluded → omitted
 
 
 # ── S4: registration + selectability ─────────────────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — root-3 of the holistic 4-root #1618 design (coherently fixes the CodeAct 8-defect cascade; #1617 HELD as the behavioral oracle). root-1+4 (#1619) and root-2 (#1620) are merged; this is root-3.

## What

**The efficacy-driven ② redesign: append → replace.** CodeAct used the `sp_fragment` APPEND channel (#1601), which left the universal `invoke_action` / `list_actions` / ROUTING-RULE vocab in the SP *alongside* the code-API → the model mixed the two (leaks 1/2/5/6). root-3 makes the tool-use SP region **scheme-replaceable** so the code-API is the SOLE tool-use instruction.

### Seam (OS-generic, P7-clean)
- `Presentation.tool_use_sp: str | None` (`None` ⇒ OS builds today's tool-use SP byte-identical; non-`None` ⇒ OS injects it at the `## Capabilities` position + skips the universal tool-use construction).
- `build_system_prompt(tool_use_sp=...)`: the `## Capabilities` (V18 routing) region is **slice-replaced** (`_cap_start` index capture + `parts[_cap_start:] = [tool_use_sp]`, no re-indent of the 110-line block); the 3 post-Environment tool-use-specific blocks (discovery-mandate / search-guidance / ROUTING-RULE-ABSOLUTE) gate on `tool_use_sp is None`.
- **Content-domain boundary** (lead + dogfood-coder ratified): replaceable region = ALL tool-use-specific universal vocab; OS retains identity + role + environment + `## Behaviour`-errors-verbatim + project/skills/memory.

### codeact side
- `build_presentation` sets `tool_use_sp = <code-API>` (drops `sp_fragment`); the render header now carries the full contract (act = a single fenced python block; **prose = the terminal final answer**).
- **#2 (no-fence → PlainText terminal)**: `interpret` classifies — fenced block ⇒ `CodeBlock`; no fence ⇒ `PlainText` (terminal). The old "run the whole content as bare code" fallback no-op'd a prose final answer → the model never cleanly finished → loop/timeout (dogfood oracle-baseline finding). **This is the minimum requirement to measure ②'s effect at full-success, not just first-act-turn.**
- **#5 (fence-label)**: recognize the Gemini-native ` ```tool_code ` label alongside ` ```python ` / ` ```py ` / bare ` ``` `.

root-3b (deferred, measure-then-handle): the Gemini-native ` ```json ` / `print` residual leaks 3/4.

## Byte-identical proof
The `None` path (every non-replace scheme) is **byte-identical across all 16 `sp_param` combos** (universal_wrappers × search × discovery × hot_list) vs the captured pre-change baseline — verified at each gate. The replace path drops `## Capabilities` + list_actions-MANDATORY + ROUTING-RULE + invent-action-names; retains identity + errors-verbatim + `## Behaviour`.

## Behavioral oracle (gate)
dogfood-coder runs the **first-act-turn fence-compliance A/B oracle** (append-SP vs replace-SP; loop-independent primary metric) + co-vets. The holistic correctness criterion: symptoms vanish *by construction* without #1617's point-patches.

## Test plan
- [x] codeact suite — 24 passed, 1 skipped (`pytest -k codeact`)
- [x] SP None-path byte-identical — 16/16 combos vs baseline
- [x] router_loop + system_prompt — 137 passed
- [x] ruff clean (changed files)
- [x] test-tier audit `--strict` — 10 OK, 0 warnings, 0 errors
- [ ] dogfood-coder: first-act-turn fence-compliance A/B oracle (append vs replace) — behavioral lift confirmation
- [ ] lead: byte-identical review of the slice-replace + gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)