### PR TITLE
fix(llm): capture provider response shape on empty-choices (flake observability)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -532,6 +532,19 @@ class EmptyLLMResponseError(Exception):
     """
 
 
+def _empty_response_diag(response: object) -> str:
+    """Compact provider-response shape for an empty-choices error (flake
+    observability). The block reason — Gemini ``finish_reason``
+    SAFETY/MAX_TOKENS/RECITATION, ``prompt_feedback``, ``usage`` — lives in
+    vendor-specific fields we can't predict, so dump the whole (truncated) response
+    so a recurrence is diagnosable instead of a bare "empty choices". Best-effort:
+    diagnostics must NEVER mask or replace the empty-choices error itself."""
+    try:
+        return json.dumps(response.model_dump(), default=str)[:500]
+    except Exception:  # noqa: BLE001 — never let a diag failure shadow the real error
+        return repr(response)[:300]
+
+
 def _get_retryable_litellm_exceptions() -> tuple:
     """Return the tuple of retryable litellm exceptions, loading litellm lazily.
 
@@ -604,8 +617,19 @@ async def _llm_call_with_retry(
             # call_llm and call_llm_tools, the two choices[0] callsites), and on
             # exhaustion the caller sees a clear error instead of an IndexError.
             if not getattr(response, "choices", None):
+                # Flake observability: capture the provider response shape (finish_reason
+                # / prompt_feedback / safety-block / usage) so a recurrence is
+                # diagnosable. logging.warning fires per attempt (a flake that self
+                # -recovers on retry still leaves its WHY in the log); the error message
+                # carries it for the exhaustion path.
+                _diag = _empty_response_diag(response)
+                logging.getLogger(__name__).warning(
+                    "LLM returned 200 with empty choices (model=%s) — provider response: %s",
+                    model, _diag,
+                )
                 raise EmptyLLMResponseError(
-                    f"LLM returned a 200 response with empty choices (model={model!r})"
+                    f"LLM returned a 200 response with empty choices (model={model!r}); "
+                    f"provider response: {_diag}"
                 )
             return response
         except BaseException as exc:

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -51,6 +51,7 @@ from reyn.llm.llm import (
     _LLM_RETRY_MAX_BACKOFF_S,
     EmptyLLMResponseError,
     _backoff_s,
+    _empty_response_diag,
     _is_retryable_exc,
     _llm_call_with_retry,
 )
@@ -506,3 +507,64 @@ async def test_empty_choices_exhausted_raises_named_error(monkeypatch):
     exhausted = [e for e in log.all() if e.type == "llm_call_retry_exhausted"]
     assert exhausted, "persistent empty choices must emit llm_call_retry_exhausted"
     assert exhausted[0].data["error_kind"] == "EmptyLLMResponseError"
+
+
+# ---------------------------------------------------------------------------
+# Test 11-13: empty-choices flake OBSERVABILITY — capture the provider response
+# shape (finish_reason / prompt_feedback / usage) so a recurrence is diagnosable
+# ---------------------------------------------------------------------------
+
+
+def test_empty_response_diag_includes_vendor_fields():
+    """Tier 2: flake observability — _empty_response_diag dumps the provider response
+    shape (the block reason / prompt_feedback / usage live in vendor-specific fields),
+    so an empty-choices recurrence is diagnosable, not a bare "empty choices". Real
+    Fake with model_dump(), no mock."""
+    class _RichEmpty:
+        choices: list = []
+
+        def model_dump(self):
+            return {
+                "choices": [],
+                "model": "gemini-2.5-flash-lite",
+                "prompt_feedback": {"block_reason": "SAFETY"},
+                "usage": {"prompt_tokens": 12, "completion_tokens": 0},
+            }
+
+    diag = _empty_response_diag(_RichEmpty())
+    assert "SAFETY" in diag          # the actual block reason surfaces
+    assert "prompt_feedback" in diag
+    assert "usage" in diag
+
+
+def test_empty_response_diag_best_effort_when_no_model_dump():
+    """Tier 2: flake observability — diag is best-effort: a response object without a
+    usable model_dump() degrades to repr (returns a non-empty str, never raises) so a
+    diag failure can NEVER mask the empty-choices error itself."""
+    class _Bare:
+        choices: list = []
+
+    diag = _empty_response_diag(_Bare())
+    assert isinstance(diag, str) and diag  # non-empty, no exception
+
+
+@pytest.mark.asyncio
+async def test_empty_choices_error_message_carries_provider_diag(monkeypatch):
+    """Tier 2: flake observability — the raised EmptyLLMResponseError message carries
+    the provider response shape (the WHY), not just the model name, so the exhaustion
+    path is diagnosable. Real Fake (model_dump), sleep no-op'd for speed."""
+    import reyn.llm.llm as llm_mod
+    monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
+
+    class _RichEmptyCallable:
+        async def __call__(self):
+            class _R:
+                choices: list = []
+
+                def model_dump(self):
+                    return {"choices": [], "prompt_feedback": {"block_reason": "RECITATION"}}
+
+            return _R()
+
+    with pytest.raises(EmptyLLMResponseError, match="RECITATION"):
+        await _llm_call_with_retry(_RichEmptyCallable(), "model-x", _make_event_log())


### PR DESCRIPTION
**[dogfood-coder]** — flake observability (lead-dispatched from my empty-choices flake trace). The ② A/B oracle hit a ~6/9 empty-choices flake window; my repro **ruled out structural causes** (payload-size / concurrency / burst all clean in direct litellm calls → not a reyn code path), leaving a transient provider/proxy condition. But it's **not diagnosable**: `EmptyLLMResponseError` (llm.py) carried only the model name, so the WHY — Gemini `finish_reason` SAFETY/MAX_TOKENS/RECITATION, `prompt_feedback`, `usage` (vendor-specific fields we can't predict) — is lost on every recurrence.

## Change (observability only — no retry/raise contract change)
- `_empty_response_diag(response)`: a truncated (≤500c) `json.dumps(response.model_dump())`, **best-effort** (falls back to `repr`, never raises — a diag failure must never mask the empty-choices error itself).
- At the raise site: `logging.warning` it **per attempt** (a flake that self-recovers on retry still leaves its WHY in the log) + include it in the `EmptyLLMResponseError` message (the exhaustion path).

→ The next empty-choices recurrence is **diagnosable** (finish_reason / prompt_feedback / safety-block surface) → root-cause-able. This is the enabler I couldn't get during the trace (no live empty reproduced; nothing logs the shape).

## Tests (Tier 2, real Fakes, no mock)
- `test_empty_response_diag_includes_vendor_fields` — diag surfaces `prompt_feedback`/block-reason/`usage` from a `model_dump()`-able response.
- `test_empty_response_diag_best_effort_when_no_model_dump` — degrades to a non-empty `repr` str, never raises.
- `test_empty_choices_error_message_carries_provider_diag` — the raised error message carries the diag (`match="RECITATION"`), sleep no-op'd for speed.
- All 13 in `test_llm_call_retry.py` pass; strict tier-audit 0-errors; existing #187 tests 9/10 unaffected (type-only raises).

## Context
Root-cause verdict (reported to lead): the flake is transient shared-proxy/provider load, **not a structural bug** → no behavioral fix to dispatch; this observability add is the only worthwhile change so a future recurrence is diagnosable. Core llm.py path — careful review welcome.

## Test plan
- [x] `pytest tests/test_llm_call_retry.py -W error::RuntimeWarning` (13 pass)
- [x] strict tier-audit on the test file (0 errors)
- [x] `import reyn.llm.llm` clean
- [ ] (reviewer) confirm the per-attempt `logging.warning` volume is acceptable (fires only on empty-choices, which is rare outside a flake window)

---
PR self-check: docstrings declare Tier; no Tier-4 violations; no invariant weakened (retry/raise contract unchanged — only the error message + a log line added); real-instance Fakes, no mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)