### PR TITLE
feat(1627 Stage 1): universal scheme owns its tool-use SP + tier-policy relocation (char-identical)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from reyn.chat.router_system_prompt import (
     build_system_prompt,
-    tier_wants_discovery_mandate,
 )
 from reyn.chat.router_tools import (
     _DESCRIBE_SKILL_STRIP_FIELDS,
@@ -31,6 +30,7 @@ from reyn.llm.llm import call_llm_tools
 from reyn.llm.pricing import TokenUsage
 from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
 from reyn.services.turn_budget import wrap_up_system_prompt
+from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 if TYPE_CHECKING:
     from reyn.config import SkillSearchConfig
@@ -1697,6 +1697,11 @@ class RouterLoop:
             "univ_enabled": _univ_enabled,
             "search_visible": _search_visible,
             "ctx_signal_present": _ctx_signal is not None,
+            # #1627 Stage 1: raw FACTS the scheme turns into policy. The scheme
+            # (not the OS) derives discovery_mandate + non_interactive idiom from
+            # these. OS does NOT pre-compute discovery_mandate here (P7-clean).
+            "router_model": self.router_model,
+            "non_interactive": self._non_interactive,
         }
         self._scheme_available = _scheme_available
         self._scheme_layer_ctx = _scheme_layer_ctx

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -12,47 +12,6 @@ from collections import defaultdict
 from reyn.chat.router_tools import MAX_DESC_LEN_FOR_LISTING
 
 # ---------------------------------------------------------------------------
-# #187 Stage C: mechanical discovery mandate (weak-tier list_actions-first)
-# ---------------------------------------------------------------------------
-# Weak models under-explore the catalog: they satisfice (refuse / give up /
-# act on the visible hot-list) instead of calling list_actions to discover the
-# action they need. The fix composes INTO the existing V18 intent taxonomy
-# rather than bolting on a standalone unconditional mandate: branch-3 (task →
-# single-target) already routes "obvious/named action → invoke directly;
-# OTHERWISE <discovery chain>", but that OTHERWISE is a SOFT routing hint —
-# the ~33% under-fire root. Stage C strengthens ONLY that OTHERWISE branch into
-# a mechanical MUST, reinforced 3x (branch-3 / §D9 hot-list / Behaviour), each
-# carrying a "NON-obvious / unknown / not-named action" scope qualifier.
-#
-# Why scoped, not unconditional (owner decision + B11-R3 evidence): a bare
-# "list_actions FIRST always" reverses B11-R3 (named-skill → invoke directly,
-# skip the list-hop) whose mandatory hop made weak models fall through to
-# clarification = the exact non-invoke attractor #187 fights. The obvious/named
-# clause (branch-3) and the Conversation (branch-1) / Question (branch-2)
-# branches are UNTOUCHED, so chitchat / named-skill / direct routing are
-# preserved by construction. The mechanical lever (MUST) + 3x reinforcement
-# lifts list_actions-first ~25-55% → ~75-85% for genuine unnamed-discovery.
-#
-# VERBATIM wording — do NOT paraphrase (fire-rate is wording-sensitive). The
-# explicit-action-enumeration "before reading, writing, or editing" is the
-# verified lever (25-55%); the generic "before acting / any other tool" detunes
-# to 0-10%. Gated to weak tiers; lives in the static cacheable prefix.
-
-# Tier-gate: only tiers empirically shown to under-explore receive the mandate.
-# ``light`` is the default intent tier (flash-lite-backed). Unknown/future and
-# strong tiers stay OFF — strong-flexibility-preserving default (owner knob:
-# don't weak-specialise away strong models' latitude).
-_WEAK_TIERS = frozenset({"light"})
-
-
-def tier_wants_discovery_mandate(router_model: str | None) -> bool:
-    """True if the router tier should receive the mechanical list_actions
-    discovery mandate (#187 Stage C). Only verified weak tier(s) opt in;
-    unknown / strong tiers stay OFF (strong-flexibility-preserving default)."""
-    return router_model in _WEAK_TIERS
-
-
-# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -65,7 +24,7 @@ def build_universal_tool_use_slots(
     has_hot_list_aliases: bool,
     non_interactive: bool = False,
 ) -> "dict[str, str]":
-    """Build the three positional tool-use SP slots for the universal-category path.
+    """Build the four positional tool-use SP slots for the universal-category path.
 
     Called only when ``tool_use_sp`` is None — i.e. the OS owns the full tool-use
     SP construction (universal / enumerate / retrieval today).  Returns a dict with
@@ -79,6 +38,8 @@ def build_universal_tool_use_slots(
                                     and ``## Behaviour``).
       - ``slot_in_behaviour``     — R3: never-invent / search guidance + ROUTING RULE
                                     (inside ``## Behaviour``, after the errors line).
+      - ``slot_in_environment``   — the cwd-idiom file-discovery HOW clause injected
+                                    inside ``## Environment``.
 
     Each slot value equals ``"\\n".join(<elements>)`` where ``<elements>`` is the
     exact list that the corresponding inline region would have appended to ``parts``
@@ -264,6 +225,16 @@ def build_universal_tool_use_slots(
         "",
     ])
     slots["slot_in_behaviour"] = "\n".join(_r3)
+
+    # ── R4: cwd-idiom file-discovery HOW clause (slot_in_environment) ────────
+    # Scheme-owned HOW tail for the ## Environment cwd block.  The OS keeps only
+    # the generic neutral default; universal schemes deliver the list_actions
+    # idiom here so the OS stays P7-clean (no scheme-specific strings).
+    slots["slot_in_environment"] = (
+        "discover the contents with `list_actions(category=['file'])` →"
+        " `invoke_action(file__list, ...)` → `invoke_action(file__read, ...)`"
+        " within the cwd's read scope."
+    )
 
     return slots
 
@@ -458,30 +429,23 @@ def build_system_prompt(
                 parts.append(f"git repo: {'yes' if environment_info['is_git_repo'] else 'no'}")
         parts.append("")
         if cwd:
-            # #1618 root-3: the cwd semantic mapping ("this repo" → the project at cwd)
-            # is OS-level (kept for every scheme), but its HOW clause ("discover with
-            # list_actions → invoke_action") is universal-wrapper idiom — the same
-            # tool-use-specific content the discovery-mandate (L453) gates. A
-            # replace-capable scheme owns its own file-discovery idiom (CodeAct's
-            # tool() proxy), so render the universal HOW only when ``tool_use_sp`` is
-            # None (byte-identical), and a scheme-neutral variant otherwise.
-            if tool_use_sp is None:
-                parts.append(
-                    "When the user refers to \"this repo\", \"this code\", \"the codebase\","
-                    " \"this project\", \"ここ\", or any other unqualified reference to"
-                    " surrounding source, interpret it as the project at the cwd above."
-                    " Do NOT ask for a repository URL or path — discover the contents"
-                    " with `list_actions(category=['file'])` → `invoke_action(file__list, ...)`"
-                    " → `invoke_action(file__read, ...)` within the cwd's read scope."
-                )
-            else:
-                parts.append(
-                    "When the user refers to \"this repo\", \"this code\", \"the codebase\","
-                    " \"this project\", \"ここ\", or any other unqualified reference to"
-                    " surrounding source, interpret it as the project at the cwd above."
-                    " Do NOT ask for a repository URL or path — read the contents using"
-                    " your available actions within the cwd's read scope."
-                )
+            # #1627 Stage 1: the cwd semantic mapping ("this repo" → the project at
+            # cwd) is OS-level and kept for every scheme.  The HOW clause (how to
+            # discover file contents) is scheme-owned — delivered via
+            # ``slot_in_environment`` (set unconditionally by
+            # build_universal_tool_use_slots, absent from the CodeAct str-shim).
+            # OS keeps only the generic neutral default; the slot overrides it for
+            # universal schemes (P7-clean: no isinstance / shape-check on slot-map).
+            _cwd_how = _slots.get(
+                "slot_in_environment",
+                "read the contents using your available actions within the cwd's read scope.",
+            )
+            parts.append(
+                "When the user refers to \"this repo\", \"this code\", \"the codebase\","
+                " \"this project\", \"ここ\", or any other unqualified reference to"
+                " surrounding source, interpret it as the project at the cwd above."
+                " Do NOT ask for a repository URL or path — " + _cwd_how
+            )
             parts.append("")
 
     # ── 3.5. Universal catalog + discovery mandate (R2) ─────────────────────

--- a/src/reyn/tools/schemes/_discovery.py
+++ b/src/reyn/tools/schemes/_discovery.py
@@ -1,0 +1,55 @@
+"""Discovery-mandate tier policy for the universal-category tool-use scheme.
+
+Relocated from ``reyn.chat.router_system_prompt`` (Stage 1, #1627) so the
+tier→discovery-mandate POLICY lives in the scheme layer, not the OS.  The OS
+(``router_loop``) still calls ``tier_wants_discovery_mandate`` for the
+enumerate / retrieval None-path ``build_system_prompt`` call until their own
+stages land; ``universal_category`` calls it to compute its own slot-map.
+
+See the full rationale in ``router_system_prompt`` (search for
+``#187 Stage C``).  Verbatim move — no logic change.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# #187 Stage C: mechanical discovery mandate (weak-tier list_actions-first)
+# ---------------------------------------------------------------------------
+# Weak models under-explore the catalog: they satisfice (refuse / give up /
+# act on the visible hot-list) instead of calling list_actions to discover the
+# action they need. The fix composes INTO the existing V18 intent taxonomy
+# rather than bolting on a standalone unconditional mandate: branch-3 (task →
+# single-target) already routes "obvious/named action → invoke directly;
+# OTHERWISE <discovery chain>", but that OTHERWISE is a SOFT routing hint —
+# the ~33% under-fire root. Stage C strengthens ONLY that OTHERWISE branch into
+# a mechanical MUST, reinforced 3x (branch-3 / §D9 hot-list / Behaviour), each
+# carrying a "NON-obvious / unknown / not-named action" scope qualifier.
+#
+# Why scoped, not unconditional (owner decision + B11-R3 evidence): a bare
+# "list_actions FIRST always" reverses B11-R3 (named-skill → invoke directly,
+# skip the list-hop) whose mandatory hop made weak models fall through to
+# clarification = the exact non-invoke attractor #187 fights. The obvious/named
+# clause (branch-3) and the Conversation (branch-1) / Question (branch-2)
+# branches are UNTOUCHED, so chitchat / named-skill / direct routing are
+# preserved by construction. The mechanical lever (MUST) + 3x reinforcement
+# lifts list_actions-first ~25-55% → ~75-85% for genuine unnamed-discovery.
+#
+# VERBATIM wording — do NOT paraphrase (fire-rate is wording-sensitive). The
+# explicit-action-enumeration "before reading, writing, or editing" is the
+# verified lever (25-55%); the generic "before acting / any other tool" detunes
+# to 0-10%. Gated to weak tiers; lives in the static cacheable prefix.
+
+# Tier-gate: only tiers empirically shown to under-explore receive the mandate.
+# ``light`` is the default intent tier (flash-lite-backed). Unknown/future and
+# strong tiers stay OFF — strong-flexibility-preserving default (owner knob:
+# don't weak-specialise away strong models' latitude).
+_WEAK_TIERS = frozenset({"light"})
+
+
+def tier_wants_discovery_mandate(router_model: "str | None") -> bool:
+    """True if the router tier should receive the mechanical list_actions
+    discovery mandate (#187 Stage C). Only verified weak tier(s) opt in;
+    unknown / strong tiers stay OFF (strong-flexibility-preserving default)."""
+    return router_model in _WEAK_TIERS
+
+
+__all__ = ["_WEAK_TIERS", "tier_wants_discovery_mandate"]

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -16,9 +16,19 @@ so the OS can exclude-gate **pre-dispatch** (preserving the #1406/#187 order);
 basic tool_result messages (the op-specific plan / invoke_skill handling stays in
 the OS loop, around it). Universal emits only ``Execute`` — never ``RePresent`` /
 ``CodeBlock`` — so the loop's other tag paths are unreached in PR-1.
+
+#1627 Stage 1: ``build_presentation`` now owns its tool-use SP via the slot-map.
+It calls ``build_universal_tool_use_slots`` with the 5 inputs derived from
+``layer_ctx`` (the OS-supplied raw FACTS), and attaches the resulting slot-map to
+the returned ``Presentation`` as ``tool_use_sp``. This relocates the tier→discovery-
+mandate POLICY out of the OS and into the scheme layer (CHAR-IDENTICAL: Stage 0
+proved the two paths produce the same SP bytes).
 """
 from __future__ import annotations
 
+import dataclasses
+
+from reyn.chat.router_system_prompt import build_universal_tool_use_slots
 from reyn.tools.scheme import (
     ExecContext,
     Execute,
@@ -29,6 +39,7 @@ from reyn.tools.scheme import (
     SchemeOps,
     register_scheme,
 )
+from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 
 class UniversalCategoryScheme:
@@ -46,7 +57,34 @@ class UniversalCategoryScheme:
         # #1593 PR-2 seam: build_presentation is async (enumerate-all/PR-4 do I/O),
         # but universal's body is unchanged — ops.present stays sync and is NOT
         # awaited, so the tools=/sp_params bytes are byte-identical to PR-1.
-        return ops.present(available, layer_ctx)
+        pres = ops.present(available, layer_ctx)
+
+        # #1627 Stage 1: own the tool-use SP via the slot-map.
+        # Derive the 5 builder inputs from the raw FACTS in layer_ctx (the OS
+        # supplies facts; the scheme computes policy). The EXACT formulas below
+        # must match what the OS computed for the None-path (router_loop.py):
+        #
+        #   universal_wrappers_enabled = layer_ctx["univ_enabled"]
+        #   search_actions_enabled     = sv if univ else True   ← CRITICAL subtlety
+        #   discovery_mandate          = tier_wants_discovery_mandate(router_model)
+        #   has_hot_list_aliases       = bool(available["hot_list_aliases"])
+        #   non_interactive            = layer_ctx["non_interactive"]
+        univ: bool = bool(layer_ctx.get("univ_enabled", False))
+        sv: bool = bool(layer_ctx.get("search_visible", True))
+        sa: bool = sv if univ else True  # mirrors ops.present's sp_params formula
+        dm: bool = tier_wants_discovery_mandate(layer_ctx.get("router_model"))
+        hl: bool = bool((available or {}).get("hot_list_aliases"))
+        ni: bool = bool(layer_ctx.get("non_interactive", False))
+
+        slots = build_universal_tool_use_slots(
+            universal_wrappers_enabled=univ,
+            search_actions_enabled=sa,
+            discovery_mandate=dm,
+            has_hot_list_aliases=hl,
+            non_interactive=ni,
+        )
+        # Keep sp_params AS-IS (Stage 4 removes it; harmless now).
+        return dataclasses.replace(pres, tool_use_sp=slots)
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
         # ops.resolve = dedupe + salvage/unwrap → actions with effective names; the

--- a/tests/test_discovery_mandate_stage_c_187.py
+++ b/tests/test_discovery_mandate_stage_c_187.py
@@ -39,8 +39,8 @@ from pathlib import Path
 import reyn.chat.router_loop as rl_mod
 from reyn.chat.router_system_prompt import (
     build_system_prompt,
-    tier_wants_discovery_mandate,
 )
+from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 _BASE = dict(
     agent_name="chat",


### PR DESCRIPTION
**[e2e-coder]** — #1627 Stage 1 of 5. The universal-category scheme now BUILDS its own tool-use SP via the slot-map, and the tier→discovery-mandate POLICY moves OS→scheme layer. **Char-identical.**

## What
- **Tier-policy relocation** (lead's "OS=facts/scheme=policy"): new `reyn/tools/schemes/_discovery.py` holds `_WEAK_TIERS` + `tier_wants_discovery_mandate` (moved verbatim). **The OS SP file no longer contains the tier/mandate concept** (grep: 0). `layer_ctx` carries raw facts `router_model` + `non_interactive`.
- **universal scheme**: `build_presentation` derives the 5 builder inputs (incl. the critical `search_actions_enabled = search_visible if univ else True`, mirroring `ops.present`), calls `build_universal_tool_use_slots`, returns `replace(pres, tool_use_sp=slots)`.

## ⚠️ Design refinement for your review: the cwd-idiom is a **4th slot**, not the 3 I scoped
The `## Environment` file-discovery HOW clause ("discover with `list_actions`→`invoke_action`") is OS-side universal-wrapper vocab. When universal started providing a dict slot-map, the root-3 `tool_use_sp is None` gate broke. The **wrong** fix (which I caught + replaced) was `isinstance(tool_use_sp, dict)` — a P7 smell (OS inspecting slot-map shape to pick a tool-use idiom). The **clean** fix: a 4th positional slot **`slot_in_environment`** — the `list_actions` HOW is built by `build_universal_tool_use_slots` (scheme-owned, travels to the scheme layer in Stage 4); the OS `## Environment` keeps only the generic neutral default + the OS-level cwd semantic mapping. CodeAct's str-shim falls through to the neutral default unchanged (no CodeAct touch).

So the slot-frame is **4 positional slots** (`slot_pre_environment` / `slot_post_environment` / `slot_in_environment` / `slot_in_behaviour`). This strengthens P7 (removes a list_actions-vocab site from the OS). Flagging since it revises the §3 "3 regions".

## Char-identical evidence
- **Stage-1 universal: 64/64** — the scheme-built slot-map path (univ × search_visible × router_model{light/pro} × hot_list × non_interactive × cwd), vs the captured None-path universal baseline.
- **Stage-0 regression: 34/34** — None-path + CodeAct str-shim (ensures CodeAct's cwd-idiom stays neutral).
Both re-verified independently post-rebase.

## Test plan
- [x] CHAR-IDENTICAL 64/64 (universal) + 34/34 (Stage-0 regression incl. CodeAct)
- [x] scheme/universal/system_prompt/router_loop suites green (434 passed)
- [x] ruff clean; tier vocab grep = 0 in OS SP file
- [ ] lead: char-identical review + ruling on the 4th-slot refinement
- [ ] sandbox_2: authoritative char-diff gate (reusable harness, universal path)

Stacks on #1629 (Stage 0, merged). enumerate/retrieval unchanged (Stages 2-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)