### PR TITLE
feat(llm): env-override for LLM retry attempts + backoff base (flaky-provider lever)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -513,8 +513,25 @@ class LLMToolCallResult:
 # Resolved lazily so importing this module does not trigger `import litellm`.
 _RETRYABLE_LITELLM_EXCEPTIONS: tuple | None = None
 
-_LLM_RETRY_MAX_ATTEMPTS: int = 3   # total attempts = 1 initial + 2 retries
-_LLM_RETRY_BASE_S: float = 2.0     # first backoff: 2s → 4s → 8s (capped at 16s)
+def _env_num(name: str, default: "int | float", lo: "int | float", hi: "int | float",
+             cast):
+    """Operator tuning knob from the environment, clamped to ``[lo, hi]``; falls back
+    to ``default`` on unset/invalid. A flaky-provider robustness lever: bump retries /
+    backoff without a code change (parallels REYN_LLM_TRACE_DUMP + the #1626
+    empty-choices observability). Read once at import — set it in the subprocess env."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(lo, min(hi, cast(raw)))
+    except (TypeError, ValueError):
+        return default
+
+
+# Defaults preserve today's behaviour (3 attempts / 2s base); the env overrides let an
+# operator absorb a transient empty-generation / 5xx storm without editing code.
+_LLM_RETRY_MAX_ATTEMPTS: int = _env_num("REYN_LLM_RETRY_MAX_ATTEMPTS", 3, 1, 10, int)
+_LLM_RETRY_BASE_S: float = _env_num("REYN_LLM_RETRY_BASE_S", 2.0, 0.1, 30.0, float)
 _LLM_RETRY_MAX_BACKOFF_S: float = 16.0
 
 

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -52,6 +52,7 @@ from reyn.llm.llm import (
     EmptyLLMResponseError,
     _backoff_s,
     _empty_response_diag,
+    _env_num,
     _is_retryable_exc,
     _llm_call_with_retry,
 )
@@ -568,3 +569,37 @@ async def test_empty_choices_error_message_carries_provider_diag(monkeypatch):
 
     with pytest.raises(EmptyLLMResponseError, match="RECITATION"):
         await _llm_call_with_retry(_RichEmptyCallable(), "model-x", _make_event_log())
+
+
+# ---------------------------------------------------------------------------
+# Test 14: retry tuning-knob env-override (REYN_LLM_RETRY_MAX_ATTEMPTS / _BASE_S)
+# ---------------------------------------------------------------------------
+
+
+def test_env_num_retry_knob(monkeypatch):
+    """Tier 2: OS invariant — _env_num reads an operator retry tuning knob from the
+    environment (clamped, safe fallback), the flaky-provider robustness lever that
+    lets a measurement/operator bump retries+backoff without a code change. Default
+    preserves today's behaviour. Real env (monkeypatch), no mock."""
+    monkeypatch.delenv("REYN_TEST_KNOB", raising=False)
+    assert _env_num("REYN_TEST_KNOB", 3, 1, 10, int) == 3          # unset → default
+    monkeypatch.setenv("REYN_TEST_KNOB", "5")
+    assert _env_num("REYN_TEST_KNOB", 3, 1, 10, int) == 5          # valid override
+    monkeypatch.setenv("REYN_TEST_KNOB", "99")
+    assert _env_num("REYN_TEST_KNOB", 3, 1, 10, int) == 10         # clamp to hi
+    monkeypatch.setenv("REYN_TEST_KNOB", "0")
+    assert _env_num("REYN_TEST_KNOB", 3, 1, 10, int) == 1          # clamp to lo
+    monkeypatch.setenv("REYN_TEST_KNOB", "not-a-number")
+    assert _env_num("REYN_TEST_KNOB", 3, 1, 10, int) == 3          # invalid → default
+    monkeypatch.setenv("REYN_TEST_KNOB", "4.5")
+    assert _env_num("REYN_TEST_KNOB", 2.0, 0.1, 30.0, float) == 4.5  # float knob (base backoff)
+
+
+def test_retry_constants_default_preserved():
+    """Tier 2: the retry constants keep their historical defaults when no env override
+    is set (1 initial + 2 retries; 2s base) — the env-override is opt-in, byte-compat."""
+    import os
+    if "REYN_LLM_RETRY_MAX_ATTEMPTS" not in os.environ:
+        assert _LLM_RETRY_MAX_ATTEMPTS == 3
+    if "REYN_LLM_RETRY_BASE_S" not in os.environ:
+        assert _LLM_RETRY_BASE_S == 2.0


### PR DESCRIPTION
**[dogfood-coder]** — pre-approved by lead. Makes the LLM-call retry tunable via env so a dogfood measurement (or operator) can absorb a provider empty-generation storm without editing code.

## Why
The empty-choices flake (#187/#1626: gemini-2.5-flash-lite intermittently returns 200 + `choices:[]` / 0 completion tokens / `vertex_ai_safety_results:[]` — a **provider-side genuine-empty-generation transient**, root-caused via #1626's observability, NOT safety/payload/reyn) spikes during provider-load windows. During the #1631 efficacy-measurement ROI-smoke a storm flaked a whole cell to **0-scored**. The retry count was a hardcoded `3`, so riding out a storm meant a code edit.

## Change (default-preserving, opt-in)
- `REYN_LLM_RETRY_MAX_ATTEMPTS` (clamp 1–10, default **3**)
- `REYN_LLM_RETRY_BASE_S` (clamp 0.1–30s, default **2.0**)
- via a small `_env_num(name, default, lo, hi, cast)` clamp+fallback helper.

Bumping `3→5` makes a call flake only on **5-consecutive-empties** (much rarer than 3) → the run-flake rate drops → a measurement rides out residual flake without waiting for full calm. A flaky-provider robustness lever parallel to `REYN_LLM_TRACE_DUMP` + the #1626 empty-choices diag (same mining-infra). Read once at import (set in the subprocess env). **Defaults unchanged → byte-compat for all existing runs.**

## Verification
- end-to-end: `REYN_LLM_RETRY_MAX_ATTEMPTS=5 REYN_LLM_RETRY_BASE_S=4.0` → fresh import reads 5 / 4.0; no env → 3 / 2.0.
- Tests (Tier 2, real env via monkeypatch, no mock): `_env_num` default/parse/clamp-hi/clamp-lo/invalid-fallback/float-knob; constants keep historical defaults when unset. 15/15 in test_llm_call_retry.py pass; strict tier-audit 0-errors.

## Test plan
- [x] `pytest tests/test_llm_call_retry.py -W error::RuntimeWarning` (15 pass, incl. existing #187/#1626 retry+empty-choices tests unaffected)
- [x] strict tier-audit on the test file (0 errors)
- [x] env-override end-to-end (5/4.0 with env, 3/2.0 default)
- [ ] (reviewer) confirm the clamp bounds (1–10 attempts / 0.1–30s) are sane operator limits

---
PR self-check: docstrings declare Tier; no Tier-4 violations; no invariant weakened (retry/backoff logic unchanged — only the constants' source); real-env tests, no mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)