### PR TITLE
feat(1627 Stage 3): retrieval owns its tool-use SP — sp_fragment folded into a 5th slot (char-identical)

### DIFF
--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -40,6 +40,9 @@ def build_universal_tool_use_slots(
                                     (inside ``## Behaviour``, after the errors line).
       - ``slot_in_environment``   — the cwd-idiom file-discovery HOW clause injected
                                     inside ``## Environment``.
+      - ``slot_post_catalog``     — scheme-owned SP appended at the post-catalog
+                                    position (e.g. retrieval's search guidance),
+                                    before the context-size signal (#1627 Stage 3).
 
     Each slot value equals ``"\\n".join(<elements>)`` where ``<elements>`` is the
     exact list that the corresponding inline region would have appended to ``parts``
@@ -552,7 +555,7 @@ def build_system_prompt(
             "  Do NOT switch language even for error messages or clarifying questions."
         )
 
-    # ── 13b. Scheme-owned SP fragment (#1593) ────────────────────────────────
+    # ── 13b. Scheme-owned SP fragment (#1593) / slot_post_catalog (#1627 Stage 3) ─
     # A tool-use scheme whose tool-use instructions are genuinely new content
     # (e.g. CodeAct's rendered fn-signature code-API, retrieval's search-tool SP)
     # supplies them here as free-form text. The OS appends it verbatim and does
@@ -560,9 +563,14 @@ def build_system_prompt(
     # Empty default ⇒ universal-category / enumerate-all (named-gate schemes) are
     # byte-identical. Placed before the volatile context-size signal so the
     # scheme's tool-use SP sits with the rest of the cached prefix.
-    if scheme_sp_fragment:
+    # #1627 Stage 3: slot_post_catalog — scheme-owned SP appended at the
+    # post-catalog position (e.g. retrieval's search guidance). Sourced from the
+    # slot-map FIRST (when a scheme owns its SP via tool_use_sp dict), else falls
+    # back to the legacy scheme_sp_fragment channel (CodeAct str-shim path).
+    _frag = (_slots.get("slot_post_catalog") if _slots else None) or scheme_sp_fragment
+    if _frag:
         parts.append("")
-        parts.append(scheme_sp_fragment)
+        parts.append(_frag)
 
     # ── 14. Context-size signal (#272/#1128) ─────────────────────────────────
     # OS-injected, pre-rendered by the caller (router_loop / phase runtime) from

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -20,8 +20,10 @@ present that drops the search tool → guaranteed ``Execute`` exit). ``execute``
 """
 from __future__ import annotations
 
+import dataclasses
 import json
 
+from reyn.chat.router_system_prompt import build_universal_tool_use_slots
 from reyn.tools.scheme import (
     ExecContext,
     Execute,
@@ -33,6 +35,7 @@ from reyn.tools.scheme import (
     SchemeOps,
     register_scheme,
 )
+from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 _SEARCH_TOOL_NAME = "search_actions"
 
@@ -94,6 +97,25 @@ class RetrievalScheme:
 
     name = "retrieval"
 
+    def _slots_for(self, available, layer_ctx, terminal: bool) -> "dict[str, str]":
+        """Build the tool-use SP slot-map for a retrieval presentation.
+
+        Mirrors the enumerate-all pattern (#1627 Stage 3): base slots via
+        ``build_universal_tool_use_slots`` (retrieval is always
+        ``universal_wrappers_enabled=False``; ``search_actions_enabled`` derived
+        from ``search_visible``) plus ``slot_post_catalog`` = ``_search_sp(terminal)``
+        — the retrieval search-guidance block injected at the post-catalog position.
+        """
+        slots = build_universal_tool_use_slots(
+            universal_wrappers_enabled=False,
+            search_actions_enabled=bool(layer_ctx.get("search_visible", False)),
+            discovery_mandate=tier_wants_discovery_mandate(layer_ctx.get("router_model")),
+            has_hot_list_aliases=bool((available or {}).get("hot_list_aliases")),
+            non_interactive=bool(layer_ctx.get("non_interactive", False)),
+        )
+        slots["slot_post_catalog"] = _search_sp(terminal=terminal)
+        return slots
+
     async def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
         base = list(ops.base_tools(available, layer_ctx))
         sp_params = {
@@ -103,10 +125,11 @@ class RetrievalScheme:
         refinement = layer_ctx.get("refinement")
         if not refinement:
             # Initial presentation: the base + the search tool (no catalog flood).
-            return Presentation(
+            # #1627 Stage 3: own the tool-use SP via the slot-map (sp_fragment dropped).
+            pres = Presentation(
                 llm_tools_payload=base + [_search_tool_schema()], sp_params=sp_params,
-                sp_fragment=_search_sp(terminal=False),
             )
+            return dataclasses.replace(pres, tool_use_sp=self._slots_for(available, layer_ctx, False))
         # Refined presentation: run the search (the async, dynamic-query I/O) and
         # present the matched catalog subset (∪ everything already presented).
         query = refinement.get("query", "")
@@ -133,10 +156,11 @@ class RetrievalScheme:
         terminal = not new
         if not terminal:
             tools = tools + [_search_tool_schema()]
-        return Presentation(
+        # #1627 Stage 3: own the tool-use SP via the slot-map (sp_fragment dropped).
+        pres = Presentation(
             llm_tools_payload=tools, sp_params=sp_params, candidates=tuple(matched),
-            sp_fragment=_search_sp(terminal=terminal),
         )
+        return dataclasses.replace(pres, tool_use_sp=self._slots_for(available, layer_ctx, terminal))
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
         # Pure classifier (no I/O): NO tool calls → PlainText (the model answered

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -118,28 +118,37 @@ async def test_new_matches_keep_search_tool(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_initial_presentation_supplies_search_sp_fragment(tmp_path) -> None:
-    """Tier 2: #1601 channel — retrieval runs with universal_wrappers_enabled=False
-    (named-gate SP off), so it MUST supply its own search-tool instructions through
-    Presentation.sp_fragment, else the LLM sees search_actions with no guidance."""
+    """Tier 2: #1627 Stage 3 slot-map channel — retrieval runs with
+    universal_wrappers_enabled=False (named-gate SP off), so it MUST supply its own
+    search-tool instructions through Presentation.tool_use_sp["slot_post_catalog"]
+    (formerly sp_fragment; folded into the slot-map in Stage 3). The LLM must see
+    search_actions guidance even when the OS's named-gate block is off."""
     ops = _FakeOps()
     pres = await RetrievalScheme().build_presentation({}, {}, ops)
     assert pres.sp_params["universal_wrappers_enabled"] is False   # named-gate SP off
-    assert pres.sp_fragment                                        # scheme supplies its own
-    assert _SEARCH_TOOL_NAME in pres.sp_fragment                   # tells the LLM to search first
+    assert isinstance(pres.tool_use_sp, dict)                      # scheme owns SP via slot-map
+    slot = pres.tool_use_sp.get("slot_post_catalog", "")
+    assert slot                                                     # scheme supplies its own
+    assert _SEARCH_TOOL_NAME in slot                                # tells the LLM to search first
+    assert pres.sp_fragment == ""                                   # old channel vacated
 
 
 @pytest.mark.asyncio
 async def test_terminal_presentation_sp_fragment_reflects_dropped_search(tmp_path) -> None:
     """Tier 2: when the presentation converges to terminal (search tool dropped), the
-    sp_fragment flips from "search first" to "call one of the presented matches"
-    — the SP and the tools= stay consistent (no dangling search instruction)."""
+    slot_post_catalog guidance flips from "search first" to "call one of the presented
+    matches" — the SP and the tools= stay consistent (no dangling search instruction).
+    #1627 Stage 3: guidance lives in tool_use_sp["slot_post_catalog"] (not sp_fragment)."""
     ops = _FakeOps(matches=["file__write"], catalog=[_tool("file__write")])
     pres = await RetrievalScheme().build_presentation(
         {}, {"refinement": {"query": "edit"}, "presented": ("file__write",)}, ops,
     )
-    assert pres.sp_fragment                                        # still guided
-    assert _SEARCH_TOOL_NAME not in pres.sp_fragment               # no "call search_actions" — it's gone
-    assert "available" in pres.sp_fragment.lower()                 # "matching tools are now available"
+    assert isinstance(pres.tool_use_sp, dict)
+    slot = pres.tool_use_sp.get("slot_post_catalog", "")
+    assert slot                                                     # still guided
+    assert _SEARCH_TOOL_NAME not in slot                            # no "call search_actions" — it's gone
+    assert "available" in slot.lower()                              # "matching tools are now available"
+    assert pres.sp_fragment == ""                                   # old channel vacated
 
 
 def test_interpret_search_call_is_represent_pure() -> None:


### PR DESCRIPTION
**[e2e-coder]** — #1627 Stage 3 of 5, the **last scheme**. Retrieval now owns its tool-use SP via the slot-map, folding its `sp_fragment` (`_search_sp`) APPEND into a new 5th positional slot. **Char-identical.** After this, all 4 schemes own their tool-use SP.

## What
- **5th positional slot `slot_post_catalog`** at the `scheme_sp_fragment` position (post-catalog, after `## About this project`). build_system_prompt sources the post-catalog fragment from `_slots.get("slot_post_catalog")` first, else the legacy `scheme_sp_fragment` — unified injection, char-identical (the legacy param retires in Stage 4). This is the analogue of the cwd-idiom 4th-slot: the `_search_sp` is a genuine 5th tool-use site, at the SP's end, so folding it into R3 would move it (not char-identical) — it needs its own positional slot.
- **retrieval.build_presentation** (both initial + refined modes): enumerate-style base slots (universal_wrappers=False, `bool(search_visible)`) + `slot_post_catalog = _search_sp(terminal=...)`; `tool_use_sp` set via `replace`; **`sp_fragment` kwarg dropped entirely**.
- `_represent_layer_ctx` already spreads `_scheme_layer_ctx` (router_model + non_interactive present) → retrieval's refined-mode derivation works unchanged.

## Char-identical evidence
- **RETRIEVAL 64/64** — `_search_sp` terminal/non-terminal × search_visible × router_model{light/pro} × hot_list × non_interactive × cwd.
- **Full regression clean**: enumerate 32/32, universal 64/64, Stage-0 34/34 (the build_system_prompt fragment-block change doesn't affect non-fragment paths). All independently re-verified.

## Test plan
- [x] RETRIEVAL CHAR-IDENTICAL 64/64 + full regression (enumerate/universal/Stage-0)
- [x] retrieval/represent/scheme/system_prompt/router_loop suites green (220 passed)
- [x] ruff clean; test-tier audit --strict clean (test contract-reversal sp_fragment→slot_post_catalog)
- [ ] lead: char-identical review
- [ ] sandbox_2: authoritative char-diff gate (retrieval path, both modes)

Stacks on #1633 (Stage 2, merged). **Stage 4** (final) = OS cleanup: delete `sp_params`/`scheme_sp_fragment`/the None-path `build_universal_tool_use_slots` call + the router_loop `tier_wants_discovery_mandate` residual, then the **full P7 grep across ALL OS** (tier/mandate/_WEAK_TIERS/wrapper/list_actions/search/discovery/catalog/capabilit/action_categor/routing = 0) = the abstraction-completion proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)