### PR TITLE
feat(1627 Stage 4 FINAL): OS cleanup — retire None-path builder, OS becomes a scheme-agnostic injector

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -30,7 +30,6 @@ from reyn.llm.llm import call_llm_tools
 from reyn.llm.pricing import TokenUsage
 from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
 from reyn.services.turn_budget import wrap_up_system_prompt
-from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 if TYPE_CHECKING:
     from reyn.config import SkillSearchConfig
@@ -1753,53 +1752,15 @@ class RouterLoop:
                 output_language=host.output_language,
                 project_context=host.get_project_context(),
                 indexed_sources_section=indexed_sources,
-                # FP-0034 PR-3b-v: same getattr-fallback pattern as build_tools.
-                # Hosts without get_universal_wrappers_enabled (= FakeRouterHost
-                # in LLMReplay tests) default to False so SP byte content stays
-                # unchanged for cached fixtures.
-                # #1593: the scheme owns the SP-shaping params (PR-1 parameterizes
-                # the monolithic build_system_prompt; identical values to _univ_enabled).
-                universal_wrappers_enabled=_pres.sp_params["universal_wrappers_enabled"],
                 cwd=_cwd_str,
-                # FP-0034 §D14: propagate the search_actions D14 visibility gate
-                # into the SP so the wrapper enumeration matches tools=.
-                # When wrappers are off (_univ_enabled=False), pass True so the
-                # SP stays byte-identical to the pre-fix output — those callers
-                # are non-wrapper-path tests whose fixtures already include
-                # search_actions in the wrapper line and re-recording is not
-                # wanted.  When wrappers are on, _search_visible is the runtime
-                # truth derived from is_search_available() (= embedding_class
-                # configured + index ready); False there means the SP and tools=
-                # both exclude search_actions, eliminating the N5 hallucination.
-                search_actions_enabled=_pres.sp_params["search_actions_enabled"],
-                # #1593: free-form scheme-owned tool-use SP. Empty for the
-                # named-gate schemes (universal-category / enumerate-all) ⇒ the
-                # SP is byte-identical; a divergent scheme (CodeAct code-API /
-                # retrieval search-SP) supplies its own tool-use text here and
-                # the OS appends it verbatim (P7 — no scheme concepts in the OS).
-                scheme_sp_fragment=_pres.sp_fragment,
-                # #1618 root-3: scheme REPLACEMENT for the tool-use SP region. None
-                # (named-gate schemes) ⇒ OS builds today's tool-use SP byte-identical;
-                # non-None (CodeAct code-API) ⇒ OS injects it at the ## Capabilities
-                # position + skips the universal tool-use construction (P7 — OS owns
-                # the region/position, the scheme owns the content).
+                # #1627 Stage 4: scheme-owned slot-map (all 4 schemes populate
+                # tool_use_sp via build_universal_tool_use_slots or their own
+                # renderer). The OS is a pure injector — no tool-use vocab here.
                 tool_use_sp=_pres.tool_use_sp,
                 # #272/#1128: OS-injected context-size signal (header), computed
                 # once above. Rendered LAST in the SP (most volatile section →
                 # preserves the cached prefix above it); None when ample.
                 context_size_signal=_ctx_signal,
-                # #187 Stage C: weak-tier mechanical list_actions-first mandate.
-                # Gated to weak tiers (light = the flash-lite-backed default
-                # intent tier that under-explores the catalog); strong/unknown
-                # tiers OFF (strong-flexibility-preserving). Only the chat
-                # router path reaches build_system_prompt — the phase op-loop
-                # uses system_prompt_override, so this does not touch it.
-                discovery_mandate=tier_wants_discovery_mandate(self.router_model),
-                non_interactive=self._non_interactive,  # #1440 followup: live-path wiring
-                # #1473: conditional HOT-LIST vs no-aliases SP branch. True when
-                # N>0 produced actual alias functions (hot_list_n > 0 opt-in);
-                # False (new default) renders the "no pre-loaded actions" variant.
-                has_hot_list_aliases=bool(_hot_list_aliases),
                 # #1479: system info (date/platform/shell/git).
                 environment_info=_environment_info,
             )
@@ -3108,9 +3069,8 @@ class RouterLoop:
     def present(self, available, layer_ctx):
         """SchemeOps.present: today's universal-category presentation — the phase
         op-catalog (when the phase layer supplies one) OR ``build_tools`` with the
-        catalog wrappers, plus the SP-shaping params (``universal_wrappers_enabled`` /
-        ``search_actions_enabled``) the monolithic ``build_system_prompt`` consumes
-        (PR-1 parameterizes the SP; PR-2 extracts a scheme-owned fragment)."""
+        catalog wrappers. #1627 Stage 4: sp_params removed (build_system_prompt no
+        longer reads them; the scheme layer owns SP via tool_use_sp slot-map)."""
         from reyn.tools.scheme import Presentation
 
         phase_op_catalog = layer_ctx.get("phase_op_catalog")
@@ -3130,12 +3090,9 @@ class RouterLoop:
                 hot_list_aliases=available["hot_list_aliases"],
                 compact_visible=layer_ctx["ctx_signal_present"],
             )
+        # #1627 Stage 4: sp_params removed — build_system_prompt no longer reads it.
         return Presentation(
             llm_tools_payload=tools,
-            sp_params={
-                "universal_wrappers_enabled": univ,
-                "search_actions_enabled": search_visible if univ else True,
-            },
         )
 
     def base_tools(self, available, layer_ctx) -> list[dict]:

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -3,6 +3,11 @@
 Size is O(categories), independent of item count — Progressive Disclosure
 (Lazy Hierarchical Catalog).  Path-level detail is deferred to list_* tools
 at runtime.
+
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector — it takes
+a slot-map and injects slots at fixed positions. It does NOT build tool-use SP.
+``build_universal_tool_use_slots`` has been relocated to
+``reyn.tools.schemes._universal_sp`` (scheme layer, P7-clean).
 """
 from __future__ import annotations
 
@@ -14,232 +19,6 @@ from reyn.chat.router_tools import MAX_DESC_LEN_FOR_LISTING
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-
-
-def build_universal_tool_use_slots(
-    *,
-    universal_wrappers_enabled: bool,
-    search_actions_enabled: bool,
-    discovery_mandate: bool,
-    has_hot_list_aliases: bool,
-    non_interactive: bool = False,
-) -> "dict[str, str]":
-    """Build the four positional tool-use SP slots for the universal-category path.
-
-    Called only when ``tool_use_sp`` is None — i.e. the OS owns the full tool-use
-    SP construction (universal / enumerate / retrieval today).  Returns a dict with
-    ONLY the non-empty slots so ``build_system_prompt`` can inject each with a
-    simple ``if slot_key in _slots`` guard.
-
-    Slots:
-      - ``slot_pre_environment``  — R1: ``## Capabilities (routing guide)`` block.
-      - ``slot_post_environment`` — R2: ``## Action categories`` + hot-list +
-                                    discovery-mandate paragraph (between Environment
-                                    and ``## Behaviour``).
-      - ``slot_in_behaviour``     — R3: never-invent / search guidance + ROUTING RULE
-                                    (inside ``## Behaviour``, after the errors line).
-      - ``slot_in_environment``   — the cwd-idiom file-discovery HOW clause injected
-                                    inside ``## Environment``.
-      - ``slot_post_catalog``     — scheme-owned SP appended at the post-catalog
-                                    position (e.g. retrieval's search guidance),
-                                    before the context-size signal (#1627 Stage 3).
-
-    Each slot value equals ``"\\n".join(<elements>)`` where ``<elements>`` is the
-    exact list that the corresponding inline region would have appended to ``parts``
-    — char-identical by construction.
-
-    ``str`` ⇒ ``{"slot_pre_environment": str}`` (back-compat shim for a bare
-    replacement string; used internally by ``build_system_prompt``).
-    """
-    slots: dict[str, str] = {}
-
-    # ── R1: ## Capabilities (routing guide) ──────────────────────────────────
-    # Mirrors the inline build from _cap_start through parts.extend([..., ""])
-    # in build_system_prompt.  The wrapper-chain and _otherwise construction is
-    # duplicated verbatim so the slot content is char-identical.
-    _wrapper_names_slot = ["`list_actions`"]
-    if search_actions_enabled:
-        _wrapper_names_slot.append("`search_actions`")
-    _wrapper_names_slot.extend(["`describe_action`", "`invoke_action`"])
-    _wrapper_chain_slot = " → ".join(_wrapper_names_slot)
-
-    if discovery_mandate:
-        _otherwise_slot = (
-            "Otherwise — i.e. for any action that is NOT obvious or a named "
-            "skill above — your FIRST tool call MUST be `list_actions` before "
-            "reading, writing, or editing anything (the visible tools are "
-            "universal wrappers, not the full catalog; do NOT skip it, refuse, "
-            f"or guess). Then {_wrapper_chain_slot}. To edit a file you MUST use "
-            "`file__edit`, found via `list_actions`."
-        )
-    else:
-        _otherwise_slot = f"Otherwise {_wrapper_chain_slot}."
-
-    _r1: list[str] = []
-    _r1.append("## Capabilities (routing guide)")
-    _r1.append("")
-    _r1.extend([
-        "Decide what the user wants. Multi-step routing is fine — explore"
-        " briefly when the right path is uncertain, but don't loop.",
-        "",
-        "**Conversation** (\"hi\", \"thanks\", \"who are you?\") → reply"
-        " directly, no tools.",
-        "",
-        "**A question with a substantive answer** — figure out where the"
-        " answer lives:",
-        "- About Reyn itself (how Reyn works, Reyn's CLI / runtime /"
-        " protocols / project conventions):"
-        " `invoke_action(action_name=\"reyn_source__read\","
-        " args={\"path\": \"README.md\"})` → synthesize from README."
-        " (README has the overview + curated map of deep-dive paths;"
-        " chain to a specific doc if README points there.)",
-        "- About external / current information: `web__search` or"
-        " `web__fetch`.",
-        "- Already in your training: answer directly.",
-        "",
-        "**A task to perform** — pick by target shape:",
-        "- Single-target action (= one file, one URL, one skill, one"
-        " item): if the action is obvious (`file__read` for \"read this"
-        " file\", `reyn_source__read` for \"open Reyn doc X\", `web__fetch`"
-        " for a specific URL, `invoke_action`(`skill__X`) for an explicit"
-        " named skill), invoke directly. " + _otherwise_slot,
-        "- Multi-target / iteration (= \"do X for each Y\", \"process N"
-        " files\", \"run X on every Y\"): decompose with plan into"
-        " per-target steps + a final aggregate step. Do NOT invoke a"
-        " per-target action directly without decomposition — it loses"
-        " the iteration shape and gets stuck on the first item.",
-        "",
-        (
-            "**Ambiguous or missing essential information** → there is no"
-            " interactive user to ask; state your best assumption and proceed"
-            " (do NOT stop to ask a clarifying question)."
-            if non_interactive else
-            "**Ambiguous or missing essential information** → ask ONE"
-            " clarifying question instead of guessing."
-        ),
-        "",
-    ])
-    slots["slot_pre_environment"] = "\n".join(_r1)
-
-    # ── R2: ## Action categories + hot-list + discovery-mandate ──────────────
-    # Mirrors the universal_wrappers_enabled block and the discovery_mandate
-    # paragraph that sit between ## Environment and ## Behaviour.
-    # Inside this builder tool_use_sp is always None, so the
-    # ``discovery_mandate and tool_use_sp is None`` guard simplifies to
-    # ``discovery_mandate``.
-    _r2: list[str] = []
-    if universal_wrappers_enabled:
-        _r2.append("## Action categories")
-        _r2.append("")
-        _r2.append(
-            "Actions are addressed by qualified name (`<category>__<entry>`)."
-            " Names in backticks of the form `<category>__<entry>` are invocable action names."
-            " Discover via `list_actions(category=[...])`; describe via"
-            " `describe_action(action_name=...)`; execute via"
-            " `invoke_action(action_name=..., args={...})`."
-        )
-        _r2.append("")
-        _r2.append(
-            "- **skill** — project-defined workflows (e.g. skill__code_review)."
-        )
-        _r2.append(
-            "- **multi_agent** — delegate / list / describe peer agents in this network."
-        )
-        _r2.append(
-            "- **mcp** — MCP server management + tool dispatch."
-        )
-        _r2.append(
-            "- **file** — workspace file ops (read/write/delete/list)."
-        )
-        _r2.append(
-            "- **web** — web search and content fetch."
-        )
-        _r2.append(
-            "- **memory_entry** — persistent memory records; invoke to read body."
-        )
-        _r2.append(
-            "- **memory_operation** — memory CRUD (remember_shared / remember_agent / forget)."
-        )
-        _r2.append(
-            "- **reyn_source** — Reyn source/docs (read-only)."
-        )
-        _r2.append(
-            "- **rag_corpus** — indexed corpora; invoke with `query` for single-source recall."
-        )
-        _r2.append(
-            "- **rag_operation** — RAG management (multi-source recall, drop_source)."
-        )
-        _r2.append(
-            "- **validation** — DSL linting (lint a skill directory and report issues)."
-        )
-        _r2.append(
-            "- **exec** — sandboxed argv execution (only when sandbox backend is enabled)."
-        )
-        _r2.append("")
-        if has_hot_list_aliases:
-            _r2.append(
-                "The function list visible to you is a HOT-LIST (= a subset of "
-                "the full catalog). Whenever the user requests a capability and "
-                "no listed tool obviously matches, ALWAYS call `list_actions` "
-                "(narrow with `category=[...]` when you know the category) to "
-                "discover the rest of the catalog BEFORE refusing. Refusing "
-                "without that check is a failure mode — the action you assumed "
-                "missing often exists."
-            )
-            _r2.append("")
-    if discovery_mandate:
-        _r2.append(
-            "When no visible tool obviously matches the action you need, "
-            "calling list_actions is MANDATORY and comes FIRST — before any "
-            "read, write, or edit. Treat the visible list as a subset, never "
-            "as complete."
-        )
-        _r2.append("")
-    if _r2:
-        slots["slot_post_environment"] = "\n".join(_r2)
-
-    # ── R3: never-invent / search guidance + ROUTING RULE ────────────────────
-    # Mirrors the search-guidance block and the ROUTING RULE block inside
-    # ## Behaviour (appended after the errors-verbatim lines + blank).
-    # Inside this builder tool_use_sp is always None, so:
-    #   - ``if tool_use_sp is not None: pass`` → branch never taken.
-    #   - ``if tool_use_sp is None: ROUTING RULE`` → always included.
-    _r3: list[str] = []
-    if search_actions_enabled:
-        _r3.extend([
-            "  - Never invent action names; only use those returned by",
-            "    `list_actions` or `search_actions`.",
-            "  - For semantic / natural-language / keyword queries (= 「探し"
-            "たい」 「関連」 「something for X」 「similar to」 「'http' を含む」),",
-            "    USE `search_actions(query=...)`. For category enumeration,",
-            "    USE `list_actions(category=[...])`.",
-        ])
-    else:
-        _r3.extend([
-            "  - Never invent action names; only use those returned by",
-            "    `list_actions`.",
-            "  - For category enumeration, USE `list_actions(category=[...])`.",
-        ])
-    _r3.append("")
-    _r3.extend([
-        "  ROUTING RULE (ABSOLUTE): When the user message contains an action"
-        " name (= valid `invoke_action` action_name, e.g. `skill__code_review`),"
-        " call `invoke_action` immediately. NO clarifying questions. NO text replies.",
-        "",
-    ])
-    slots["slot_in_behaviour"] = "\n".join(_r3)
-
-    # ── R4: cwd-idiom file-discovery HOW clause (slot_in_environment) ────────
-    # Scheme-owned HOW tail for the ## Environment cwd block.  The OS keeps only
-    # the generic neutral default; universal schemes deliver the list_actions
-    # idiom here so the OS stays P7-clean (no scheme-specific strings).
-    slots["slot_in_environment"] = (
-        "discover the contents with `list_actions(category=['file'])` →"
-        " `invoke_action(file__list, ...)` → `invoke_action(file__read, ...)`"
-        " within the cwd's read scope."
-    )
-
-    return slots
 
 
 def build_system_prompt(
@@ -255,21 +34,24 @@ def build_system_prompt(
     output_language: str | None = None,
     project_context: str = "",
     indexed_sources_section: str | None = None,
-    universal_wrappers_enabled: bool = False,  # FP-0034 PR-3b-v
     cwd: str | None = None,
-    search_actions_enabled: bool = True,  # FP-0034 §D14 — default True preserves byte-compat
-    scheme_sp_fragment: str = "",  # #1593 — free-form scheme-owned tool-use SP; OS appends verbatim (P7), default "" = byte-identical named-gate path
-    tool_use_sp: "str | None" = None,  # #1618 root-3 — scheme REPLACEMENT for the tool-use SP region; None = OS builds today's (byte-identical), non-None = inject + skip the universal tool-use construction
+    tool_use_sp: "str | dict[str, str] | None" = None,  # #1627 Stage 4: scheme-owned slot-map (or str back-compat shim); None → {} (bare OS frame, no tool-use SP)
     context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
-    discovery_mandate: bool = False,  # #187 Stage C — weak-tier list_actions-first mandate (3x)
-    non_interactive: bool = False,  # #1439 Fix #1 — run-once (no TTY): no user to ask, proceed instead of clarifying
-    has_hot_list_aliases: bool = False,  # True when hot_list_n>0 produced direct-alias functions
     environment_info: "dict | None" = None,  # #1479: date/platform/shell/git from get_environment_info()
+    scheme_sp_fragment: str = "",  # kept for backward compat; prefer tool_use_sp slot_post_catalog
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
-    Returns text matching the structure in the plan's "System prompt 構成"
-    section.  Size is O(categories), independent of item count.
+    #1627 Stage 4: pure slot-injector. ``build_system_prompt`` takes a
+    ``tool_use_sp`` slot-map (built by the scheme layer) and injects each
+    slot at its fixed position in the OS frame. It does NOT build tool-use SP.
+
+    ``tool_use_sp`` normalisation:
+      - ``str``  → ``{"slot_pre_environment": str}`` (back-compat shim for
+                    a bare replacement string, e.g. CodeAct's code-API).
+      - ``dict`` → used as-is (slot-map from a universal/enumerate/retrieval
+                    ``build_universal_tool_use_slots`` call).
+      - ``None`` → ``{}`` (empty — bare OS frame, no tool-use SP injected).
 
     Args:
         agent_name: short identifier of the agent (e.g. "chat").
@@ -280,7 +62,8 @@ def build_system_prompt(
             ``role``, ``cluster``.
         memory_index: ``{"status": "ok"|"not_found", "content": str}``.
         file_permissions: optional ``{"read": [paths], "write": [paths]}``.
-            When non-empty (either list), a Files section is rendered.
+            Accepted for backward compat; no longer rendered in the SP
+            (FP-0034 wrapper-only: file discovery goes through list_actions).
         mcp_servers: accepted for backward compat but no longer used —
             FP-0034 wrapper-only removed the static ``## MCP servers``
             section in favour of runtime discovery via
@@ -292,37 +75,23 @@ def build_system_prompt(
             LLM stays in that language even on clarifying / error paths.
             When None (= user did not configure output_language), no
             language directive is emitted — the LLM picks the reply
-            language based on the user's input naturally. This avoids
-            forcing a default (= "ja") onto users who haven't expressed
-            a preference.
+            language based on the user's input naturally.
         indexed_sources_section: pre-rendered "## Indexed sources ..."
             markdown string from ``SourceManifest.format_for_prompt()``.
             When provided, injected verbatim after the Memory section.
-            When None (default), no Indexed sources section is emitted
-            (= backward compat for callers that have not yet wired up
-            the manifest, e.g. tests and non-chat execution paths).
+            When None (default), no Indexed sources section is emitted.
         cwd: current working directory the agent is running from. When
             provided, an ## Environment section tells the LLM to treat
             unqualified references like "this repo" / "this code" /
             "the codebase" as the project at ``cwd``. When None
-            (default), the section is omitted — preserves SP byte
-            content for tests that don't plumb cwd through.
-        search_actions_enabled: Whether ``search_actions`` is included in
-            the tool catalogue for this session (= D14 visibility gate:
-            ``action_retrieval.embedding_class`` is configured AND the
-            ActionEmbeddingIndex is ready). When True (default), the
-            Capabilities wrapper enumeration lists all 4 wrappers
-            including ``search_actions``. When False, the enumeration
-            lists only the 3 always-available wrappers and the
-            ``search_actions``-specific Behaviour guidance is omitted.
-
-            Default True preserves byte-identical SP output relative to
-            the pre-fix code so existing LLMReplay fixture keys remain
-            valid for callers that have not yet wired the flag (e.g.
-            FakeRouterHost-based replay tests that don't set
-            ``_search_visible``). Production RouterLoop passes
-            ``_search_visible`` which is False when no embedding class is
-            configured — that is the path that fixes the N5 hallucination.
+            (default), the section is omitted.
+        tool_use_sp: scheme-owned slot-map (``dict[str, str]``) or a bare
+            replacement string (``str`` back-compat shim). ``None`` → empty
+            map (bare OS frame, no tool-use SP).
+        context_size_signal: pre-rendered context-size header, appended LAST.
+        environment_info: system info dict (date/platform/shell/git).
+        scheme_sp_fragment: backward-compat legacy free-form SP fragment
+            (prefer ``tool_use_sp["slot_post_catalog"]`` for new schemes).
     """
     parts: list[str] = []
 
@@ -335,26 +104,6 @@ def build_system_prompt(
     # ==========================================================================
 
     # ── 1. OS-level identity preamble ──────────────────────────────────────
-    #
-    # Wrapper-only Identity (= radical simplification):
-    # The 3-paragraph Reyn explanation that lives in the legacy preamble
-    # is content the LLM can fetch via reyn_source__read on demand;
-    # baking it into the SP for every turn is wasteful. Keep only the
-    # empirically-mitigated parts (vendor identity leak ~50% → near 0)
-    # and a single pointer to where the full content lives.
-    #
-    # B51 NF-W6-4 / W7-S1 fix (2026-05-23): the legacy preamble carried
-    # an inline ``invoke_action(reyn_source__read, README.md)`` example.
-    # Chain-replay verified that weak-tier LLMs (= flash-lite) parsed
-    # that example as "reyn_source__read is directly callable" and
-    # emitted the truncated ``source__read({"path":"README.md"})`` (= no
-    # wrapper, no namespace prefix) — observed B50/B51 W6-S2 + W7-S1 at
-    # 5/5 baseline rate on the "What is Reyn?" prompt class. The fix
-    # routes the LLM through the ``## Capabilities (routing guide)``
-    # block below, whose intent-2 path already carries the canonical
-    # invoke_action recipe in a structured routing context that flash-
-    # lite parses correctly (5/5 → 0/5 truncation in the same N=5
-    # diagnostic).
     parts.append(
         "# Identity"
         "\n\n"
@@ -378,38 +127,27 @@ def build_system_prompt(
     )
     parts.append("")
 
-    # #1627 Stage 0: normalise tool_use_sp into a positional slot-map.
-    # ``str`` ⇒ back-compat shim (= slot_pre_environment only; R2/R3 absent).
-    # ``None`` ⇒ the OS builds all three slots via build_universal_tool_use_slots.
-    # ``dict`` ⇒ already a slot-map (future schemes; not used in Stage 0).
+    # #1627 Stage 4: normalise tool_use_sp into a positional slot-map.
+    # ``str``  → back-compat shim (slot_pre_environment only; R2/R3 absent).
+    # ``dict`` → already a slot-map (from build_universal_tool_use_slots).
+    # ``None`` → {} (bare OS frame — no tool-use SP).
     if isinstance(tool_use_sp, str):
         _slots: "dict[str, str]" = {"slot_pre_environment": tool_use_sp}
     elif tool_use_sp is None:
-        _slots = build_universal_tool_use_slots(
-            universal_wrappers_enabled=universal_wrappers_enabled,
-            search_actions_enabled=search_actions_enabled,
-            discovery_mandate=discovery_mandate,
-            has_hot_list_aliases=has_hot_list_aliases,
-            non_interactive=non_interactive,
-        )
+        _slots = {}
     else:
-        _slots = tool_use_sp  # type: ignore[assignment]  # dict path (Stage 1+)
+        _slots = tool_use_sp  # dict path
 
     # ── 3. Capabilities (routing guide) — FP-0023 Change 2 ─────────────────
-    # #1627 Stage 0: the ## Capabilities region (R1) is now delivered via
-    # slot_pre_environment.  ``None``-path: OS-built by build_universal_tool_use_slots
-    # (char-identical).  ``str``-path: scheme replacement injected verbatim
-    # (back-compat shim = byte-identical to the old parts[_cap_start:] = [tool_use_sp]).
+    # Delivered via slot_pre_environment from the scheme's slot-map.
     if "slot_pre_environment" in _slots:
         parts.append(_slots["slot_pre_environment"])
 
     # ── 3.4. Environment (CWD context, P7-clean) ─────────────────────────────
     # Tells the LLM where it is running so unqualified references like
     # "this repo" / "this code" / "the codebase" / "ここのコード" map to
-    # the workspace at cwd. Without this the LLM defaults to its training
-    # prior ("please share the repository URL") even when the user is
-    # obviously inside a checked-out repo. P7: no skill-specific strings,
-    # only environment facts and routing hints to existing categories.
+    # the workspace at cwd. P7: no skill-specific strings, only environment
+    # facts and routing hints to existing categories.
     if cwd or environment_info:
         parts.append("## Environment")
         parts.append("")
@@ -432,13 +170,10 @@ def build_system_prompt(
                 parts.append(f"git repo: {'yes' if environment_info['is_git_repo'] else 'no'}")
         parts.append("")
         if cwd:
-            # #1627 Stage 1: the cwd semantic mapping ("this repo" → the project at
-            # cwd) is OS-level and kept for every scheme.  The HOW clause (how to
-            # discover file contents) is scheme-owned — delivered via
-            # ``slot_in_environment`` (set unconditionally by
-            # build_universal_tool_use_slots, absent from the CodeAct str-shim).
-            # OS keeps only the generic neutral default; the slot overrides it for
-            # universal schemes (P7-clean: no isinstance / shape-check on slot-map).
+            # #1627 Stage 1: the cwd semantic mapping is OS-level; the HOW clause
+            # is scheme-owned via slot_in_environment. OS keeps the generic neutral
+            # default; the slot overrides it for universal schemes (P7-clean: no
+            # isinstance / shape-check on slot-map).
             _cwd_how = _slots.get(
                 "slot_in_environment",
                 "read the contents using your available actions within the cwd's read scope.",
@@ -452,21 +187,16 @@ def build_system_prompt(
             parts.append("")
 
     # ── 3.5. Universal catalog + discovery mandate (R2) ─────────────────────
-    # #1627 Stage 0: the ## Action categories block and discovery-mandate
-    # paragraph are delivered via slot_post_environment (built by
-    # build_universal_tool_use_slots on the None-path; absent on the str-path).
+    # Delivered via slot_post_environment from the scheme's slot-map.
     if "slot_post_environment" in _slots:
         parts.append(_slots["slot_post_environment"])
 
     # ── 4 & 5. Behaviour (static core) ─────────────────────────────────────
     # FP-0023 Change 1: Static Behaviour rules moved here (before dynamic
-    # sections) to maximise cache prefix coverage. The two dynamic conditional
-    # blocks (output_language, indexed_sources_section) are emitted later,
-    # after the dynamic resource sections, since they vary per session/config.
+    # sections) to maximise cache prefix coverage.
     parts.append("## Behaviour")
     # Cross-cutting rules that apply regardless of which tool was last called.
-    # Routing decisions (intent tree / plan vs invoke / discovery mandate) live
-    # in ## Capabilities above — single canonical location, no repetition here.
+    # Routing decisions live in ## Capabilities above — single canonical location.
     # B23-PRE-1 SP role-separation: spawn-ack / task_completed live in invoke_action.description.
     parts.extend([
         "  - Errors MUST surface verbatim. Never narrate an error as success.",
@@ -476,13 +206,10 @@ def build_system_prompt(
 
     # ── FP-0025 D — Plan decomposition Behaviour rule ─────────────────────────
     # B23-PRE-1 SP role-separation: ## Plan decomposition subsection (detail)
-    # moved to plan.description. The 2-line intent routing already in the
-    # wrapper-only Behaviour header (Action/Plan/Reply 3-way) is the SP
-    # cross-cutting policy — sufficient.
+    # moved to plan.description.
     parts.append("")
     # ── R3: never-invent / search guidance + ROUTING RULE ────────────────────
-    # #1627 Stage 0: delivered via slot_in_behaviour (built by
-    # build_universal_tool_use_slots on the None-path; absent on the str-path).
+    # Delivered via slot_in_behaviour from the scheme's slot-map.
     if "slot_in_behaviour" in _slots:
         parts.append(_slots["slot_in_behaviour"])
 

--- a/src/reyn/chat/router_system_prompt.py
+++ b/src/reyn/chat/router_system_prompt.py
@@ -196,8 +196,8 @@ def build_system_prompt(
     # sections) to maximise cache prefix coverage.
     parts.append("## Behaviour")
     # Cross-cutting rules that apply regardless of which tool was last called.
-    # Routing decisions live in ## Capabilities above — single canonical location.
-    # B23-PRE-1 SP role-separation: spawn-ack / task_completed live in invoke_action.description.
+    # #1627: tool-use routing guidance is scheme-owned (delivered via the slot-map);
+    # the OS keeps only these scheme-agnostic behaviour rules here.
     parts.extend([
         "  - Errors MUST surface verbatim. Never narrate an error as success.",
         "    Optimism bias on errors is the single largest router-narration"
@@ -208,8 +208,8 @@ def build_system_prompt(
     # B23-PRE-1 SP role-separation: ## Plan decomposition subsection (detail)
     # moved to plan.description.
     parts.append("")
-    # ── R3: never-invent / search guidance + ROUTING RULE ────────────────────
-    # Delivered via slot_in_behaviour from the scheme's slot-map.
+    # ── R3 slot injection (post-behaviour position) ──────────────────────────
+    # Scheme-owned content delivered via slot_in_behaviour; the OS only injects.
     if "slot_in_behaviour" in _slots:
         parts.append(_slots["slot_in_behaviour"])
 
@@ -240,12 +240,12 @@ def build_system_prompt(
         parts.append("")
 
     # ── 7 & 8. Skills / Agents catalog ──────────────────────────────────────
-    # Wrapper-only path: skill / agent are 2 of the 13 categories
-    # listed in the "## Action categories" section above. Dedicated
-    # sections would impose a per-category special-case structure
-    # that contradicts FP-0034's uniform-invoke design — so they
-    # are omitted here. Resource discovery goes through
-    # list_actions(category=[...]).
+    # Wrapper-only path: skill / agent are 2 of the action categories (now
+    # scheme-owned, no longer rendered by the OS). Dedicated sections would
+    # impose a per-category special-case structure that contradicts FP-0034's
+    # uniform-invoke design — so they are omitted here. (Resource discovery
+    # guidance in the catalog-context sections below is a tracked content-layer
+    # follow-up — see #1625.)
 
     # ── 9. Memory ────────────────────────────────────────────────────────────
     # B23-PRE-1 SP role-separation: ## Memory inline section is dropped in the

--- a/src/reyn/chat/services/router_history_buffer.py
+++ b/src/reyn/chat/services/router_history_buffer.py
@@ -404,7 +404,21 @@ class RouterHistoryBuffer:
         The error is small relative to the total context window.
         """
         from reyn.chat.router_system_prompt import build_system_prompt
+        from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
+        from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
         rh = self._router_host
+        univ = bool(getattr(self._action_retrieval, "universal_wrappers_enabled", False))
+        # Conservative T_SP estimate: use the router model if known; if not,
+        # default to False (= no mandate, slightly under-counts for weak tier
+        # but this is an estimation path — conservatively acceptable).
+        dm = tier_wants_discovery_mandate(self._model)
+        tool_use_sp = build_universal_tool_use_slots(
+            universal_wrappers_enabled=univ,
+            search_actions_enabled=True,  # conservative: assume enabled (larger SP)
+            discovery_mandate=dm,
+            has_hot_list_aliases=False,   # conservative: assume no aliases (smaller SP)
+            non_interactive=self._non_interactive,
+        )
         return build_system_prompt(
             agent_name=rh.agent_name,
             agent_role=rh.agent_role,
@@ -417,6 +431,5 @@ class RouterHistoryBuffer:
             output_language=rh.output_language,
             project_context=rh.get_project_context(),
             indexed_sources_section=None,
-            universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
-            non_interactive=self._non_interactive,
+            tool_use_sp=tool_use_sp,
         )

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -1,0 +1,223 @@
+"""Scheme-layer tool-use SP builder for the universal-category path (#1627 Stage 4).
+
+``build_universal_tool_use_slots`` was relocated from
+``reyn.chat.router_system_prompt`` (OS layer) to here (scheme layer) as part of
+Stage 4 — the final step of making ``build_system_prompt`` a pure slot-injector
+with ZERO tool-use vocab. The OS builds the OS-frame; the scheme owns the
+tool-use SP content.
+
+P7-clean location: ``_universal_sp`` carries universal-category tool-use strings;
+the OS ``router_system_prompt`` must NOT import from here (the dependency arrow
+is scheme→ not OS←scheme).
+
+Callers: universal_category.py / enumerate_all.py / retrieval.py — all scheme-
+layer modules. No OS module imports this.
+"""
+from __future__ import annotations
+
+
+def build_universal_tool_use_slots(
+    *,
+    universal_wrappers_enabled: bool,
+    search_actions_enabled: bool,
+    discovery_mandate: bool,
+    has_hot_list_aliases: bool,
+    non_interactive: bool = False,
+) -> "dict[str, str]":
+    """Build the four positional tool-use SP slots for the universal-category path.
+
+    Called by each scheme's ``build_presentation`` to fill the slot-map they
+    pass as ``tool_use_sp`` to ``build_system_prompt``. Returns a dict with ONLY
+    the non-empty slots so ``build_system_prompt`` can inject each with a simple
+    ``if slot_key in _slots`` guard.
+
+    Slots:
+      - ``slot_pre_environment``  — R1: ``## Capabilities (routing guide)`` block.
+      - ``slot_post_environment`` — R2: ``## Action categories`` + hot-list +
+                                    discovery-mandate paragraph (between Environment
+                                    and ``## Behaviour``).
+      - ``slot_in_behaviour``     — R3: never-invent / search guidance + ROUTING RULE
+                                    (inside ``## Behaviour``, after the errors line).
+      - ``slot_in_environment``   — the cwd-idiom file-discovery HOW clause injected
+                                    inside ``## Environment``.
+      - ``slot_post_catalog``     — scheme-owned SP appended at the post-catalog
+                                    position (e.g. retrieval's search guidance),
+                                    before the context-size signal (#1627 Stage 3).
+
+    Each slot value equals ``"\\n".join(<elements>)`` where ``<elements>`` is the
+    exact list that the corresponding inline region would have appended to ``parts``
+    — char-identical by construction.
+    """
+    slots: dict[str, str] = {}
+
+    # ── R1: ## Capabilities (routing guide) ──────────────────────────────────
+    _wrapper_names_slot = ["`list_actions`"]
+    if search_actions_enabled:
+        _wrapper_names_slot.append("`search_actions`")
+    _wrapper_names_slot.extend(["`describe_action`", "`invoke_action`"])
+    _wrapper_chain_slot = " → ".join(_wrapper_names_slot)
+
+    if discovery_mandate:
+        _otherwise_slot = (
+            "Otherwise — i.e. for any action that is NOT obvious or a named "
+            "skill above — your FIRST tool call MUST be `list_actions` before "
+            "reading, writing, or editing anything (the visible tools are "
+            "universal wrappers, not the full catalog; do NOT skip it, refuse, "
+            f"or guess). Then {_wrapper_chain_slot}. To edit a file you MUST use "
+            "`file__edit`, found via `list_actions`."
+        )
+    else:
+        _otherwise_slot = f"Otherwise {_wrapper_chain_slot}."
+
+    _r1: list[str] = []
+    _r1.append("## Capabilities (routing guide)")
+    _r1.append("")
+    _r1.extend([
+        "Decide what the user wants. Multi-step routing is fine — explore"
+        " briefly when the right path is uncertain, but don't loop.",
+        "",
+        "**Conversation** (\"hi\", \"thanks\", \"who are you?\") → reply"
+        " directly, no tools.",
+        "",
+        "**A question with a substantive answer** — figure out where the"
+        " answer lives:",
+        "- About Reyn itself (how Reyn works, Reyn's CLI / runtime /"
+        " protocols / project conventions):"
+        " `invoke_action(action_name=\"reyn_source__read\","
+        " args={\"path\": \"README.md\"})` → synthesize from README."
+        " (README has the overview + curated map of deep-dive paths;"
+        " chain to a specific doc if README points there.)",
+        "- About external / current information: `web__search` or"
+        " `web__fetch`.",
+        "- Already in your training: answer directly.",
+        "",
+        "**A task to perform** — pick by target shape:",
+        "- Single-target action (= one file, one URL, one skill, one"
+        " item): if the action is obvious (`file__read` for \"read this"
+        " file\", `reyn_source__read` for \"open Reyn doc X\", `web__fetch`"
+        " for a specific URL, `invoke_action`(`skill__X`) for an explicit"
+        " named skill), invoke directly. " + _otherwise_slot,
+        "- Multi-target / iteration (= \"do X for each Y\", \"process N"
+        " files\", \"run X on every Y\"): decompose with plan into"
+        " per-target steps + a final aggregate step. Do NOT invoke a"
+        " per-target action directly without decomposition — it loses"
+        " the iteration shape and gets stuck on the first item.",
+        "",
+        (
+            "**Ambiguous or missing essential information** → there is no"
+            " interactive user to ask; state your best assumption and proceed"
+            " (do NOT stop to ask a clarifying question)."
+            if non_interactive else
+            "**Ambiguous or missing essential information** → ask ONE"
+            " clarifying question instead of guessing."
+        ),
+        "",
+    ])
+    slots["slot_pre_environment"] = "\n".join(_r1)
+
+    # ── R2: ## Action categories + hot-list + discovery-mandate ──────────────
+    _r2: list[str] = []
+    if universal_wrappers_enabled:
+        _r2.append("## Action categories")
+        _r2.append("")
+        _r2.append(
+            "Actions are addressed by qualified name (`<category>__<entry>`)."
+            " Names in backticks of the form `<category>__<entry>` are invocable action names."
+            " Discover via `list_actions(category=[...])`; describe via"
+            " `describe_action(action_name=...)`; execute via"
+            " `invoke_action(action_name=..., args={...})`."
+        )
+        _r2.append("")
+        _r2.append(
+            "- **skill** — project-defined workflows (e.g. skill__code_review)."
+        )
+        _r2.append(
+            "- **multi_agent** — delegate / list / describe peer agents in this network."
+        )
+        _r2.append(
+            "- **mcp** — MCP server management + tool dispatch."
+        )
+        _r2.append(
+            "- **file** — workspace file ops (read/write/delete/list)."
+        )
+        _r2.append(
+            "- **web** — web search and content fetch."
+        )
+        _r2.append(
+            "- **memory_entry** — persistent memory records; invoke to read body."
+        )
+        _r2.append(
+            "- **memory_operation** — memory CRUD (remember_shared / remember_agent / forget)."
+        )
+        _r2.append(
+            "- **reyn_source** — Reyn source/docs (read-only)."
+        )
+        _r2.append(
+            "- **rag_corpus** — indexed corpora; invoke with `query` for single-source recall."
+        )
+        _r2.append(
+            "- **rag_operation** — RAG management (multi-source recall, drop_source)."
+        )
+        _r2.append(
+            "- **validation** — DSL linting (lint a skill directory and report issues)."
+        )
+        _r2.append(
+            "- **exec** — sandboxed argv execution (only when sandbox backend is enabled)."
+        )
+        _r2.append("")
+        if has_hot_list_aliases:
+            _r2.append(
+                "The function list visible to you is a HOT-LIST (= a subset of "
+                "the full catalog). Whenever the user requests a capability and "
+                "no listed tool obviously matches, ALWAYS call `list_actions` "
+                "(narrow with `category=[...]` when you know the category) to "
+                "discover the rest of the catalog BEFORE refusing. Refusing "
+                "without that check is a failure mode — the action you assumed "
+                "missing often exists."
+            )
+            _r2.append("")
+    if discovery_mandate:
+        _r2.append(
+            "When no visible tool obviously matches the action you need, "
+            "calling list_actions is MANDATORY and comes FIRST — before any "
+            "read, write, or edit. Treat the visible list as a subset, never "
+            "as complete."
+        )
+        _r2.append("")
+    if _r2:
+        slots["slot_post_environment"] = "\n".join(_r2)
+
+    # ── R3: never-invent / search guidance + ROUTING RULE ────────────────────
+    _r3: list[str] = []
+    if search_actions_enabled:
+        _r3.extend([
+            "  - Never invent action names; only use those returned by",
+            "    `list_actions` or `search_actions`.",
+            "  - For semantic / natural-language / keyword queries (= 「探し"
+            "たい」 「関連」 「something for X」 「similar to」 「'http' を含む」),",
+            "    USE `search_actions(query=...)`. For category enumeration,",
+            "    USE `list_actions(category=[...])`.",
+        ])
+    else:
+        _r3.extend([
+            "  - Never invent action names; only use those returned by",
+            "    `list_actions`.",
+            "  - For category enumeration, USE `list_actions(category=[...])`.",
+        ])
+    _r3.append("")
+    _r3.extend([
+        "  ROUTING RULE (ABSOLUTE): When the user message contains an action"
+        " name (= valid `invoke_action` action_name, e.g. `skill__code_review`),"
+        " call `invoke_action` immediately. NO clarifying questions. NO text replies.",
+        "",
+    ])
+    slots["slot_in_behaviour"] = "\n".join(_r3)
+
+    # ── R4: cwd-idiom file-discovery HOW clause (slot_in_environment) ────────
+    slots["slot_in_environment"] = (
+        "discover the contents with `list_actions(category=['file'])` →"
+        " `invoke_action(file__list, ...)` → `invoke_action(file__read, ...)`"
+        " within the cwd's read scope."
+    )
+
+    return slots

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -33,9 +33,6 @@ enumerate never has wrappers, so the fallback-to-True branch does not apply).
 """
 from __future__ import annotations
 
-import dataclasses
-
-from reyn.chat.router_system_prompt import build_universal_tool_use_slots
 from reyn.tools.scheme import (
     ExecContext,
     Execute,
@@ -46,6 +43,7 @@ from reyn.tools.scheme import (
     register_scheme,
 )
 from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 
 class EnumerateAllScheme:
@@ -61,11 +59,6 @@ class EnumerateAllScheme:
         # catalog_entries is async (the live-catalog enumeration awaits the
         # router caller-state / rag manifest); base_tools stays sync.
         flat_tools = list(ops.base_tools(available, layer_ctx)) + list(await ops.catalog_entries())
-        # sp_params kept AS-IS (Stage 4 removes it; harmless now).
-        sp_params = {
-            "universal_wrappers_enabled": False,
-            "search_actions_enabled": bool(layer_ctx.get("search_visible", False)),
-        }
         # #1627 Stage 2: own the tool-use SP via the slot-map.
         # Derive the 5 builder inputs from the raw FACTS in layer_ctx. Enumerate
         # NEVER has universal wrappers, so universal_wrappers_enabled is always
@@ -80,8 +73,8 @@ class EnumerateAllScheme:
             has_hot_list_aliases=bool((available or {}).get("hot_list_aliases")),
             non_interactive=bool(layer_ctx.get("non_interactive", False)),
         )
-        pres = Presentation(llm_tools_payload=flat_tools, sp_params=sp_params)
-        return dataclasses.replace(pres, tool_use_sp=slots)
+        # #1627 Stage 4: sp_params removed — build_system_prompt no longer reads it.
+        return Presentation(llm_tools_payload=flat_tools, tool_use_sp=slots)
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
         # Flat (qualified) names resolve through the shared resolution (dedupe +

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -20,10 +20,8 @@ present that drops the search tool → guaranteed ``Execute`` exit). ``execute``
 """
 from __future__ import annotations
 
-import dataclasses
 import json
 
-from reyn.chat.router_system_prompt import build_universal_tool_use_slots
 from reyn.tools.scheme import (
     ExecContext,
     Execute,
@@ -36,6 +34,7 @@ from reyn.tools.scheme import (
     register_scheme,
 )
 from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 _SEARCH_TOOL_NAME = "search_actions"
 
@@ -118,18 +117,14 @@ class RetrievalScheme:
 
     async def build_presentation(self, available, layer_ctx, ops: SchemeOps) -> Presentation:
         base = list(ops.base_tools(available, layer_ctx))
-        sp_params = {
-            "universal_wrappers_enabled": False,
-            "search_actions_enabled": bool(layer_ctx.get("search_visible", False)),
-        }
         refinement = layer_ctx.get("refinement")
         if not refinement:
             # Initial presentation: the base + the search tool (no catalog flood).
-            # #1627 Stage 3: own the tool-use SP via the slot-map (sp_fragment dropped).
-            pres = Presentation(
-                llm_tools_payload=base + [_search_tool_schema()], sp_params=sp_params,
+            # #1627 Stage 3+4: sp_params removed; tool_use_sp carries the full SP.
+            return Presentation(
+                llm_tools_payload=base + [_search_tool_schema()],
+                tool_use_sp=self._slots_for(available, layer_ctx, False),
             )
-            return dataclasses.replace(pres, tool_use_sp=self._slots_for(available, layer_ctx, False))
         # Refined presentation: run the search (the async, dynamic-query I/O) and
         # present the matched catalog subset (∪ everything already presented).
         query = refinement.get("query", "")
@@ -156,11 +151,12 @@ class RetrievalScheme:
         terminal = not new
         if not terminal:
             tools = tools + [_search_tool_schema()]
-        # #1627 Stage 3: own the tool-use SP via the slot-map (sp_fragment dropped).
-        pres = Presentation(
-            llm_tools_payload=tools, sp_params=sp_params, candidates=tuple(matched),
+        # #1627 Stage 3+4: sp_params removed; tool_use_sp carries the full SP.
+        return Presentation(
+            llm_tools_payload=tools,
+            candidates=tuple(matched),
+            tool_use_sp=self._slots_for(available, layer_ctx, terminal),
         )
-        return dataclasses.replace(pres, tool_use_sp=self._slots_for(available, layer_ctx, terminal))
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
         # Pure classifier (no I/O): NO tool calls → PlainText (the model answered

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import dataclasses
 
-from reyn.chat.router_system_prompt import build_universal_tool_use_slots
 from reyn.tools.scheme import (
     ExecContext,
     Execute,
@@ -40,6 +39,7 @@ from reyn.tools.scheme import (
     register_scheme,
 )
 from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 
 class UniversalCategoryScheme:
@@ -71,7 +71,7 @@ class UniversalCategoryScheme:
         #   non_interactive            = layer_ctx["non_interactive"]
         univ: bool = bool(layer_ctx.get("univ_enabled", False))
         sv: bool = bool(layer_ctx.get("search_visible", True))
-        sa: bool = sv if univ else True  # mirrors ops.present's sp_params formula
+        sa: bool = sv if univ else True  # same formula as the prior sp_params["search_actions_enabled"]
         dm: bool = tier_wants_discovery_mandate(layer_ctx.get("router_model"))
         hl: bool = bool((available or {}).get("hot_list_aliases"))
         ni: bool = bool(layer_ctx.get("non_interactive", False))
@@ -83,7 +83,8 @@ class UniversalCategoryScheme:
             has_hot_list_aliases=hl,
             non_interactive=ni,
         )
-        # Keep sp_params AS-IS (Stage 4 removes it; harmless now).
+        # #1627 Stage 4: sp_params removed from build_presentation (build_system_prompt
+        # no longer reads it). tool_use_sp is now the sole SP channel.
         return dataclasses.replace(pres, tool_use_sp=slots)
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:

--- a/tests/test_catalog_partial_signal.py
+++ b/tests/test_catalog_partial_signal.py
@@ -54,22 +54,36 @@ Pins:
 from __future__ import annotations
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.tools.universal_catalog import _LIST_ACTIONS_DESCRIPTION
+
+
+def _slots(*, has_hot_list_aliases: bool, universal_wrappers_enabled: bool = True) -> "dict[str, str]":
+    """Build slot-map for catalog-partial signal tests."""
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=universal_wrappers_enabled,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=has_hot_list_aliases,
+        non_interactive=False,
+    )
+
 
 # ── A: SP partial-signal ─────────────────────────────────────────────
 
 
 def test_sp_catalog_partial_signal_present_when_wrappers_enabled() -> None:
     """Tier 2: when universal wrappers are enabled with hot-list aliases
-    (has_hot_list_aliases=True), the SP includes the HOT-LIST subset signal."""
+    (has_hot_list_aliases=True), the SP includes the HOT-LIST subset signal.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
+    """
     sp = build_system_prompt(
         agent_name="test",
         agent_role="tester",
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        has_hot_list_aliases=True,
+        tool_use_sp=_slots(has_hot_list_aliases=True),
     )
     assert "HOT-LIST" in sp
     assert "subset" in sp
@@ -79,17 +93,16 @@ def test_sp_catalog_partial_signal_present_when_wrappers_enabled() -> None:
 
 def test_sp_no_aliases_branch_omits_hot_list_paragraph() -> None:
     """Tier 2: when has_hot_list_aliases=False (new default N=0), the
-    HOT-LIST paragraph is completely absent — no subset claim, no
-    replacement text. Owner decision: nothing to qualify when no aliases
-    exist."""
+    HOT-LIST paragraph is completely absent.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
+    """
     sp = build_system_prompt(
         agent_name="test",
         agent_role="tester",
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        has_hot_list_aliases=False,
+        tool_use_sp=_slots(has_hot_list_aliases=False),
     )
     assert "HOT-LIST" not in sp
     assert "No actions are pre-loaded" not in sp
@@ -99,16 +112,18 @@ def test_sp_no_aliases_branch_omits_hot_list_paragraph() -> None:
 def test_sp_two_branches_are_distinct() -> None:
     """Tier 2: the aliases-present and aliases-absent branches produce
     different SP text — regression pin against the conditional being
-    silently stripped."""
+    silently stripped.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
+    """
     sp_with = build_system_prompt(
         agent_name="test", agent_role="tester",
         available_skills=[], available_agents=[], memory_index={},
-        universal_wrappers_enabled=True, has_hot_list_aliases=True,
+        tool_use_sp=_slots(has_hot_list_aliases=True),
     )
     sp_without = build_system_prompt(
         agent_name="test", agent_role="tester",
         available_skills=[], available_agents=[], memory_index={},
-        universal_wrappers_enabled=True, has_hot_list_aliases=False,
+        tool_use_sp=_slots(has_hot_list_aliases=False),
     )
     assert sp_with != sp_without
     assert "HOT-LIST" in sp_with and "HOT-LIST" not in sp_without
@@ -116,8 +131,8 @@ def test_sp_two_branches_are_distinct() -> None:
 
 def test_sp_partial_signal_appears_after_action_categories() -> None:
     """Tier 2: position pin — the HOT-LIST signal (aliases branch) lives right
-    after the category enumeration so the LLM reads it as a concluding rule
-    for the catalog section, not a buried hint.
+    after the category enumeration.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
     """
     sp = build_system_prompt(
         agent_name="test",
@@ -125,8 +140,7 @@ def test_sp_partial_signal_appears_after_action_categories() -> None:
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        has_hot_list_aliases=True,
+        tool_use_sp=_slots(has_hot_list_aliases=True),
     )
     cat_pos = sp.find("## Action categories")
     sig_pos = sp.find("HOT-LIST")
@@ -134,34 +148,13 @@ def test_sp_partial_signal_appears_after_action_categories() -> None:
     assert cat_pos >= 0
     assert sig_pos >= 0
     assert behav_pos >= 0
-    # The signal must sit between the category section header and the
-    # next major section (= Behaviour).
     assert cat_pos < sig_pos < behav_pos
 
 
 def test_sp_no_aliases_action_categories_section_still_present() -> None:
     """Tier 2: when has_hot_list_aliases=False, ## Action categories section
-    is still rendered (only the HOT-LIST paragraph is absent, not the whole
-    section). The category list remains for context."""
-    sp = build_system_prompt(
-        agent_name="test",
-        agent_role="tester",
-        available_skills=[],
-        available_agents=[],
-        memory_index={},
-        universal_wrappers_enabled=True,
-        has_hot_list_aliases=False,
-    )
-    assert "## Action categories" in sp
-    assert "list_actions" in sp  # the section header still references it
-
-
-def test_sp_partial_signal_absent_when_wrappers_disabled() -> None:
-    """Tier 2: the signal only applies to the universal-wrappers SP
-    path (= the path that exposes list_actions). When wrappers are
-    off, the legacy SP doesn't reference list_actions, so the partial
-    signal would be inert — omit to keep the legacy byte content
-    stable for LLMReplay fixtures.
+    is still rendered (only the HOT-LIST paragraph is absent).
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
     """
     sp = build_system_prompt(
         agent_name="test",
@@ -169,7 +162,24 @@ def test_sp_partial_signal_absent_when_wrappers_disabled() -> None:
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=False,
+        tool_use_sp=_slots(has_hot_list_aliases=False),
+    )
+    assert "## Action categories" in sp
+    assert "list_actions" in sp
+
+
+def test_sp_partial_signal_absent_when_wrappers_disabled() -> None:
+    """Tier 2: the signal only applies to the universal-wrappers SP path.
+    When wrappers are off, no HOT-LIST paragraph.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots (wrappers=False).
+    """
+    sp = build_system_prompt(
+        agent_name="test",
+        agent_role="tester",
+        available_skills=[],
+        available_agents=[],
+        memory_index={},
+        tool_use_sp=_slots(has_hot_list_aliases=False, universal_wrappers_enabled=False),
     )
     assert "HOT-LIST" not in sp
 
@@ -177,7 +187,7 @@ def test_sp_partial_signal_absent_when_wrappers_disabled() -> None:
 def test_sp_partial_signal_is_domain_agnostic() -> None:
     """Tier 2: the HOT-LIST signal (aliases branch) MUST NOT mention specific
     MCP server names, specific tools, or other domain-specific tokens.
-    Project policy forbids SP overfit. The signal is structural.
+    #1627 Stage 4: slot-map via build_universal_tool_use_slots.
     """
     sp = build_system_prompt(
         agent_name="test",
@@ -185,8 +195,7 @@ def test_sp_partial_signal_is_domain_agnostic() -> None:
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        has_hot_list_aliases=True,
+        tool_use_sp=_slots(has_hot_list_aliases=True),
     )
     # Extract the catalog-partial signal paragraph.
     cat_pos = sp.find("HOT-LIST")

--- a/tests/test_discovery_mandate_stage_c_187.py
+++ b/tests/test_discovery_mandate_stage_c_187.py
@@ -27,8 +27,8 @@ from pathlib import Path
 
 import reyn.tools.schemes.universal_category as uc_mod
 from reyn.chat.router_system_prompt import build_system_prompt
-from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 _BASE = dict(
     agent_name="chat",

--- a/tests/test_discovery_mandate_stage_c_187.py
+++ b/tests/test_discovery_mandate_stage_c_187.py
@@ -1,45 +1,33 @@
 """Tier 2: #187 Stage C — weak-tier discovery mandate (composed into taxonomy).
 
-owner decision: weak router tiers under-explore the catalog (satisfice instead
-of discovering the action they need). Rather than a standalone unconditional
-mandate (which would reverse B11-R3's named-skill→direct-invoke fix and
-re-introduce the clarification-fallthrough attractor #187 fights), Stage C
-STRENGTHENS the existing V18 intent taxonomy's branch-3 "Otherwise" routing hint
-(soft → mechanical MUST), reinforced 3x (branch-3 / §D9 hot-list / Behaviour),
-each carrying a NON-obvious/unknown/not-named scope qualifier. Tier-gated
-(light ON / strong+unknown OFF).
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
+``discovery_mandate`` parameter has been REMOVED from ``build_system_prompt`` and
+moved fully into the scheme layer (``build_universal_tool_use_slots`` / schemes).
+Tests that previously called ``build_system_prompt(..., discovery_mandate=True)``
+now call ``build_universal_tool_use_slots`` directly and pass the result as
+``tool_use_sp``. The AST wiring test is updated to verify that
+``tier_wants_discovery_mandate`` is called in the scheme layer (universal_category.py)
+rather than in router_loop.py's ``build_system_prompt`` call.
 
 Pinned invariants:
 
 - ``tier_wants_discovery_mandate``: only the verified weak tier (``light``) opts
   in; ``strong`` / unknown / ``None`` stay OFF.
-- When ``discovery_mandate=True``, all 3 reinforcements render, each
-  scope-qualified + mechanical MUST/MANDATORY, with the verified
-  explicit-action-enumeration "reading, writing, or editing" (NOT the generic
-  "before acting", which detunes 25-55% → 0-10%). file__edit MUST is carried.
+- When ``discovery_mandate=True`` in ``build_universal_tool_use_slots``, all 3
+  reinforcements render, each scope-qualified + mechanical MUST/MANDATORY.
 - When False, the SP keeps the SOFT branch-3 "Otherwise <chain>" + no MUST /
-  MANDATORY reinforcement (byte-clean for non-weak tiers → valid replay
-  fixtures, strong latitude preserved).
-- B11-R3 (obvious/named → invoke directly) + the Conversation (branch-1) /
-  Question (branch-2) wording are UNTOUCHED in BOTH modes (diff-touch-0): the
-  scope qualifier is structural, so chitchat / named-skill / direct routing are
-  preserved by construction.
-- All reinforcements sit in the static cacheable prefix (before project_context).
-- router_loop wires the call site with ``tier_wants_discovery_mandate``.
-
-The live behavioural proof (weak model fires list_actions-first ~75-85% on
-genuine unnamed-discovery WITHOUT bleeding chitchat/named into discovery) is
-sandbox_2's production-flow verify, not a unit test.
+  MANDATORY reinforcement.
+- B11-R3 + Conversation/Question wording untouched in BOTH modes (diff-touch-0).
+- router_loop wires the call through scheme layer (not build_system_prompt).
 """
 from __future__ import annotations
 
 import ast
 from pathlib import Path
 
-import reyn.chat.router_loop as rl_mod
-from reyn.chat.router_system_prompt import (
-    build_system_prompt,
-)
+import reyn.tools.schemes.universal_category as uc_mod
+from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
 
 _BASE = dict(
@@ -48,7 +36,6 @@ _BASE = dict(
     available_skills=[],
     available_agents=[],
     memory_index={"status": "not_found", "content": ""},
-    universal_wrappers_enabled=True,
 )
 
 # Markers for the B11-R3 named-direct clause + branch-1 Conversation, which must
@@ -58,11 +45,25 @@ _CONVERSATION_MARKER = "reply"
 
 
 def _on() -> str:
-    return build_system_prompt(**_BASE, discovery_mandate=True)
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=True,
+        discovery_mandate=True,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    return build_system_prompt(**_BASE, tool_use_sp=slots)
 
 
 def _off() -> str:
-    return build_system_prompt(**_BASE, discovery_mandate=False)
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    return build_system_prompt(**_BASE, tool_use_sp=slots)
 
 
 # ---------------------------------------------------------------------------
@@ -166,43 +167,45 @@ def test_reinforcements_in_static_cacheable_prefix() -> None:
     to the single canonical MUST occurrence (backtick-wrapped `list_actions`).
     """
     marker = "ZZZ_DYNAMIC_PROJECT_CONTEXT_MARKER_ZZZ"
-    on = build_system_prompt(**_BASE, project_context=marker, discovery_mandate=True)
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=True,
+        discovery_mandate=True,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    on = build_system_prompt(**_BASE, project_context=marker, tool_use_sp=slots)
     assert marker in on
     # The canonical reinforcement (branch-3) must come before the dynamic marker.
     assert on.rindex("FIRST tool call MUST be `list_actions`") < on.index(marker)
 
 
 # ---------------------------------------------------------------------------
-# Call-site wiring (AST) — router_loop gates on the tier
+# Call-site wiring (AST) — scheme layer gates on the tier
 # ---------------------------------------------------------------------------
 
 
-def test_router_loop_wires_discovery_mandate_gate() -> None:
-    """Tier 2: #187 Stage C — router_loop's build_system_prompt(...) call passes
-    ``discovery_mandate=tier_wants_discovery_mandate(...)``. Falsifiable: drop the
-    gate (or hardcode True/False) → this fails, naming the construction-wiring
-    gap. Without the gate the mandate is either unreachable or applied to every
-    tier (strong included)."""
-    tree = ast.parse(Path(rl_mod.__file__).read_text(encoding="utf-8"))
+def test_scheme_layer_wires_discovery_mandate_gate() -> None:
+    """Tier 2: #187 Stage C / #1627 Stage 4 — ``tier_wants_discovery_mandate`` is
+    called in the scheme layer (universal_category.py's build_presentation), NOT in
+    router_loop.py's build_system_prompt call. Falsifiable: remove the call from
+    universal_category → this fails, naming the construction-wiring gap.
+
+    #1627 Stage 4 migration: the mandate computation moved out of router_loop (OS)
+    into the scheme layer (P7). The AST check now targets universal_category.py."""
+    tree = ast.parse(Path(uc_mod.__file__).read_text(encoding="utf-8"))
     wired = False
     for node in ast.walk(tree):
         if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
-            and node.func.id == "build_system_prompt"
+            and node.func.id == "tier_wants_discovery_mandate"
         ):
             continue
-        for kw in node.keywords:
-            if kw.arg != "discovery_mandate":
-                continue
-            v = kw.value
-            if (
-                isinstance(v, ast.Call)
-                and isinstance(v.func, ast.Name)
-                and v.func.id == "tier_wants_discovery_mandate"
-            ):
-                wired = True
+        wired = True
+        break
     assert wired, (
-        "router_loop must call build_system_prompt(..., "
-        "discovery_mandate=tier_wants_discovery_mandate(self.router_model))"
+        "universal_category.build_presentation must call tier_wants_discovery_mandate "
+        "to derive the discovery_mandate for build_universal_tool_use_slots "
+        "(#1627 Stage 4: mandate computation relocated to scheme layer)"
     )

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -82,15 +82,27 @@ async def test_build_presentation_is_base_plus_catalog_flat() -> None:
 
 
 @pytest.mark.asyncio
-async def test_build_presentation_sp_params_disable_wrappers() -> None:
-    """Tier 2: SP params drive the prior-shape (no wrapper-chain) minimal SP —
-    no build_system_prompt surgery (the existing gate yields enumerate-all's SP)."""
+async def test_build_presentation_tool_use_sp_disable_wrappers() -> None:
+    """Tier 2: #1627 Stage 4 — enumerate-all's tool_use_sp slot-map encodes the
+    no-wrapper, search-visible SP (sp_params removed from build_presentation).
+
+    The slot-map must contain slot_pre_environment (the Capabilities block) with
+    NO ## Action categories (universal_wrappers_enabled=False) and WITH the
+    search_actions chain (search_visible=True from layer_ctx).
+    """
     s = EnumerateAllScheme()
     pres = await s.build_presentation(
-        {"skills_for_tools": [], "hot_list_aliases": []}, {"search_visible": True}, _FakeOps(),
+        {"skills_for_tools": [], "hot_list_aliases": []},
+        {"search_visible": True},
+        _FakeOps(),
     )
-    assert pres.sp_params["universal_wrappers_enabled"] is False
-    assert pres.sp_params["search_actions_enabled"] is True   # follows layer search_visible
+    # sp_params removed — check the slot-map instead
+    assert isinstance(pres.tool_use_sp, dict), "tool_use_sp must be a dict slot-map"
+    slots = pres.tool_use_sp
+    # Wrappers off → no ## Action categories in slot_post_environment
+    assert "slot_post_environment" not in slots or "## Action categories" not in slots.get("slot_post_environment", "")
+    # search_visible=True → search_actions in the chain
+    assert "search_actions" in slots.get("slot_pre_environment", "")
 
 
 def test_interpret_resolves_to_execute() -> None:

--- a/tests/test_replay_skill_router.py
+++ b/tests/test_replay_skill_router.py
@@ -29,6 +29,18 @@ from reyn.chat.router_system_prompt import build_system_prompt
 from reyn.chat.router_tools import build_tools
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+
+def _default_slots() -> "dict[str, str]":
+    """Default universal slot-map for tests that need tool-use content in the SP."""
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -557,6 +569,7 @@ async def test_validator_anchor_unchanged():
         memory_index=host.get_memory_index(),
         file_permissions=host.get_file_permissions(),
         mcp_servers=host.get_mcp_servers(),
+        tool_use_sp=_default_slots(),
     )
 
     # Wrapper-only SP: no per-category skill enumeration; phantom must not appear
@@ -580,6 +593,7 @@ async def test_validator_anchor_unchanged():
         memory_index=host_no_skills.get_memory_index(),
         file_permissions=None,
         mcp_servers=None,
+        tool_use_sp=_default_slots(),
     )
     assert "invoke_action" in prompt_empty, (
         "Empty skill list: invoke_action routing must still be in SP"

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -125,7 +125,8 @@ async def test_initial_presentation_supplies_search_sp_fragment(tmp_path) -> Non
     search_actions guidance even when the OS's named-gate block is off."""
     ops = _FakeOps()
     pres = await RetrievalScheme().build_presentation({}, {}, ops)
-    assert pres.sp_params["universal_wrappers_enabled"] is False   # named-gate SP off
+    # #1627 Stage 4: sp_params removed from build_presentation.
+    assert pres.sp_params == {}                                      # no longer populated
     assert isinstance(pres.tool_use_sp, dict)                      # scheme owns SP via slot-map
     slot = pres.tool_use_sp.get("slot_post_catalog", "")
     assert slot                                                     # scheme supplies its own

--- a/tests/test_router_call_mcp_tool_enum.py
+++ b/tests/test_router_call_mcp_tool_enum.py
@@ -21,6 +21,17 @@ import asyncio
 import pytest
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+
+def _default_slots() -> "dict[str, str]":
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
 from reyn.chat.router_tools import MCP_SEARCH_THRESHOLD, build_tools
 from reyn.tools import get_default_registry
 from reyn.tools.mcp import (
@@ -424,6 +435,7 @@ def test_system_prompt_mcp_section_absent_when_no_tool_list():
         available_agents=[],
         memory_index=_EMPTY_MEMORY,
         mcp_servers=_MCP_SERVERS_NO_TOOLS,
+        tool_use_sp=_default_slots(),
     )
     assert "## MCP servers" not in prompt, (
         "SP must not contain ## MCP servers section in wrapper-only path"

--- a/tests/test_router_indexed_sources.py
+++ b/tests/test_router_indexed_sources.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import pytest
 
 from reyn.chat.router_system_prompt import build_system_prompt
-from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.index.source_manifest import SourceEntry, SourceManifest
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 # ---------------------------------------------------------------------------
 # Helpers — minimal args for build_system_prompt

--- a/tests/test_router_indexed_sources.py
+++ b/tests/test_router_indexed_sources.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.index.source_manifest import SourceEntry, SourceManifest
 
 # ---------------------------------------------------------------------------
@@ -34,8 +35,21 @@ _SYNTHETIC_MEMORY_CONTENT = """\
 _SYNTHETIC_MEMORY: dict = {"status": "ok", "content": _SYNTHETIC_MEMORY_CONTENT}
 
 
+def _default_slots() -> "dict[str, str]":
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+
+
 def _minimal_prompt(indexed_sources_section: str | None = None) -> str:
-    """Build a minimal system prompt with the given indexed_sources_section."""
+    """Build a minimal system prompt with the given indexed_sources_section.
+
+    #1627 Stage 4: tool_use_sp slot-map required for tool-use SP content.
+    """
     return build_system_prompt(
         agent_name="chat",
         agent_role="general assistant",
@@ -43,6 +57,7 @@ def _minimal_prompt(indexed_sources_section: str | None = None) -> str:
         available_agents=[],
         memory_index=_SYNTHETIC_MEMORY,
         indexed_sources_section=indexed_sources_section,
+        tool_use_sp=_default_slots(),
     )
 
 

--- a/tests/test_router_invoke_skill_enum.py
+++ b/tests/test_router_invoke_skill_enum.py
@@ -17,6 +17,17 @@ from __future__ import annotations
 
 from reyn.chat.router_system_prompt import build_system_prompt
 from reyn.chat.router_tools import build_tools
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+
+def _default_slots() -> "dict[str, str]":
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -200,6 +211,7 @@ def test_system_prompt_uses_invoke_action_routing():
     Phase 6 cleanup: ## Skills section removed from SP. Discovery goes through
     list_actions(category=['skill']) at runtime via the universal catalog.
     SP uses invoke_action routing vocabulary.
+    #1627 Stage 4: tool_use_sp slot-map required for invoke_action content.
     """
     prompt = build_system_prompt(
         agent_name="chat",
@@ -207,6 +219,7 @@ def test_system_prompt_uses_invoke_action_routing():
         available_skills=_SKILLS,
         available_agents=[],
         memory_index=_EMPTY_MEMORY,
+        tool_use_sp=_default_slots(),
     )
     # Wrapper-only path: no ## Skills section
     assert "## Skills" not in prompt
@@ -221,6 +234,7 @@ def test_system_prompt_no_skills_no_skills_section():
 
     Phase 6 cleanup: ## Skills section removed. SP is O(1) regardless of
     skill count — skills are not enumerated or section-counted in the SP.
+    #1627 Stage 4: tool_use_sp slot-map required for Capabilities content.
     """
     prompt = build_system_prompt(
         agent_name="chat",
@@ -228,6 +242,7 @@ def test_system_prompt_no_skills_no_skills_section():
         available_skills=[],
         available_agents=[],
         memory_index=_EMPTY_MEMORY,
+        tool_use_sp=_default_slots(),
     )
     assert "## Skills" not in prompt
     # Basic SP structure still present

--- a/tests/test_router_sp_non_interactive_1439.py
+++ b/tests/test_router_sp_non_interactive_1439.py
@@ -1,59 +1,79 @@
 """Tier 2: #1439 Fix #1 — autonomy-mode router SP signal (run-once path).
 
-`build_system_prompt` renders "ask ONE clarifying question instead of guessing"
-for the interactive router. In run-once (piped stdin, no TTY) there is no user
-to answer, so that directive is a structural dead-end (the agent stalls asking,
-13398). The `non_interactive` flag swaps that one directive for a proceed-with-
-assumption directive; everything else (and the whole interactive SP) is unchanged.
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
+``non_interactive`` parameter has been REMOVED from ``build_system_prompt``.
+Tests now call ``build_universal_tool_use_slots`` directly (with
+``non_interactive=True/False``) and pass the result as ``tool_use_sp``.
 
-Real `build_system_prompt`, no mocks.
+In run-once (piped stdin, no TTY) there is no user to answer, so the
+"ask ONE clarifying question" directive is a structural dead-end (stalls
+the agent, #13398). The ``non_interactive`` flag in
+``build_universal_tool_use_slots`` swaps that one directive for a
+proceed-with-assumption directive; everything else is unchanged.
+
+Real ``build_system_prompt`` + real ``build_universal_tool_use_slots``,
+no mocks.
 """
 from __future__ import annotations
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 _CLARIFY = "ask ONE"
 _PROCEED = "no interactive user to ask"
 
 
 def _sp(*, non_interactive: bool) -> str:
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=non_interactive,
+    )
     return build_system_prompt(
         agent_name="chat",
         agent_role="general agent",
         available_skills=[],
         available_agents=[],
         memory_index={},
-        non_interactive=non_interactive,
+        tool_use_sp=slots,
     )
 
 
 def test_interactive_default_keeps_clarifying_question() -> None:
-    """Tier 2: #1439 Fix #1 — the default (interactive) SP keeps the "ask ONE
-    clarifying question" directive = byte-identical to pre-#1439 behaviour."""
+    """Tier 2: #1439 Fix #1 — non_interactive=False keeps the "ask ONE
+    clarifying question" directive."""
     sp = _sp(non_interactive=False)
     assert _CLARIFY in sp
     assert _PROCEED not in sp
 
 
 def test_non_interactive_replaces_clarifying_with_proceed() -> None:
-    """Tier 2: #1439 Fix #1 — non_interactive (run-once) omits the clarifying-
+    """Tier 2: #1439 Fix #1 — non_interactive=True omits the clarifying-
     question directive and instead tells the agent to proceed with an assumption
     (no user to ask). This is the 13398 dead-stop fix."""
     sp = _sp(non_interactive=True)
     assert _CLARIFY not in sp, "run-once SP must not tell the agent to ask a clarifying question"
     assert _PROCEED in sp
-    # show-not-judge of the directive: it tells it to proceed, not to stop.
     assert "proceed" in sp.lower()
 
 
 def test_default_param_is_interactive() -> None:
-    """Tier 2: #1439 Fix #1 — omitting the param defaults to interactive
-    (byte-identical), so every existing caller is unaffected."""
+    """Tier 2: #1439 Fix #1 — omitting non_interactive defaults to interactive
+    (byte-identical to False), so every existing caller is unaffected."""
     default_sp = build_system_prompt(
         agent_name="chat",
         agent_role="general agent",
         available_skills=[],
         available_agents=[],
         memory_index={},
+        tool_use_sp=build_universal_tool_use_slots(
+            universal_wrappers_enabled=False,
+            search_actions_enabled=True,
+            discovery_mandate=False,
+            has_hot_list_aliases=False,
+            non_interactive=False,
+        ),
     )
     assert default_sp == _sp(non_interactive=False)

--- a/tests/test_router_sp_universal_categories.py
+++ b/tests/test_router_sp_universal_categories.py
@@ -1,21 +1,18 @@
 """Tier 2: FP-0034 PR-3b-v `## Action categories` SP section gating.
 
-Verifies the new flag-gated section in ``build_system_prompt`` that
-prepends a 13-category overview when
-``universal_wrappers_enabled=True``. With the flag off (default), SP
-byte content stays identical to the pre-PR-3b-v output so LLMReplay
-fixtures remain valid.
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
+``universal_wrappers_enabled`` parameter has been REMOVED from
+``build_system_prompt``. Tests now call ``build_universal_tool_use_slots``
+directly and pass the result as ``tool_use_sp``.
 
 Coverage:
-  - Default flag-off: SP excludes the section (fixture-safe path)
-  - Default matches explicit False (no accidental default flip)
-  - Flag on: SP includes the section + lists all 13 categories
-  - Section placement relative to other sections (after Capabilities,
-    before Behaviour)
+  - No tool_use_sp (None): SP excludes the section (bare OS frame)
+  - universal_wrappers_enabled=False via slot-map: SP excludes the section
+  - universal_wrappers_enabled=True via slot-map: SP includes section + all 13 cats
+  - Section placement relative to other sections
   - Section content notes qualified-name format + dispatch path
 
-No mocks. Pure-string contract tests on the build_system_prompt
-output.
+No mocks. Pure-string contract tests on the build_system_prompt output.
 """
 
 from __future__ import annotations
@@ -23,6 +20,7 @@ from __future__ import annotations
 import re
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 from reyn.tools.universal_catalog import CATEGORIES
 
 _BASE_KWARGS = {
@@ -41,35 +39,47 @@ _BASE_KWARGS = {
 }
 
 
-# ── 1. Default (flag off) excludes the section ───────────────────────────
+def _slots(*, universal_wrappers_enabled: bool) -> "dict[str, str]":
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=universal_wrappers_enabled,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+
+
+# ── 1. No tool_use_sp (None) excludes the section ────────────────────────
 
 
 def test_default_flag_off_excludes_action_categories_section() -> None:
-    """Tier 2: build_system_prompt() default omits ## Action categories.
+    """Tier 2: build_system_prompt() with tool_use_sp=None (bare OS frame) omits
+    ## Action categories.
 
-    PR-3b-v adds the section behind a flag with default False — same
-    insulation pattern as PR-3b-i build_tools wrappers.  LLMReplay
-    fixtures recorded before this PR stay byte-valid for callers
-    that don't pass the flag.
+    #1627 Stage 4: None ⇒ {} (empty slot-map). No slot_post_environment injected.
     """
     prompt = build_system_prompt(**_BASE_KWARGS)
     assert "## Action categories" not in prompt
 
 
 def test_default_matches_explicit_false() -> None:
-    """Tier 2: omitting the kwarg matches explicit False (no accidental flip)."""
+    """Tier 2: omitting tool_use_sp matches explicit wrappers=False slot-map
+    for the Action categories section (both omit it)."""
     default = build_system_prompt(**_BASE_KWARGS)
-    explicit = build_system_prompt(**_BASE_KWARGS, universal_wrappers_enabled=False)
-    assert default == explicit
+    explicit = build_system_prompt(**_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=False))
+    # Both omit the section; bare-frame content differs from slot-map content
+    # (slot-map adds Capabilities/Behaviour slots too), so we only pin the section.
+    assert "## Action categories" not in default
+    assert "## Action categories" not in explicit
 
 
 # ── 2. Flag on adds the section with all 13 categories ───────────────────
 
 
 def test_flag_on_adds_action_categories_section() -> None:
-    """Tier 2: flag=True prepends the ## Action categories section."""
+    """Tier 2: universal_wrappers_enabled=True in slot-map adds ## Action categories."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     assert "## Action categories" in prompt
 
@@ -81,7 +91,7 @@ def test_flag_on_lists_all_categories() -> None:
     single ``mcp`` category; the SP bullet count drops accordingly.
     """
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     for cat in (
         "skill",
@@ -93,27 +103,16 @@ def test_flag_on_lists_all_categories() -> None:
         "rag_corpus", "rag_operation",
         "exec",
     ):
-        # Each category is on its own bullet line; use bold marker so
-        # 'file' and 'reyn_source' match independently of plain words.
         assert f"**{cat}**" in prompt, (
             f"category {cat!r} must be listed as a bullet in the SP"
         )
 
 
 def test_sp_bullets_match_categories_tuple_exactly() -> None:
-    """Tier 2: drift-detection — SP `**X**` bullets ≡ ``CATEGORIES`` tuple.
-
-    If a 14th category is added to ``universal_catalog.CATEGORIES`` but
-    the SP section is not extended (or vice versa), this test fails so
-    the divergence cannot land silently.  The handlers enumerate by
-    iterating ``CATEGORIES`` while the SP is hand-authored prose; this
-    invariant pins the two together.
-    """
+    """Tier 2: drift-detection — SP `**X**` bullets ≡ ``CATEGORIES`` tuple."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
-    # Slice to the Action categories section only so unrelated bold
-    # spans in Behaviour / other sections don't confuse the match.
     section_start = prompt.index("## Action categories")
     section_end = prompt.index("## Behaviour", section_start)
     section = prompt[section_start:section_end]
@@ -125,7 +124,7 @@ def test_sp_bullets_match_categories_tuple_exactly() -> None:
         f"SP bullets diverged from CATEGORIES.\n"
         f"  SP:        {sp_bullets}\n"
         f"  CATEGORIES:{tuple(CATEGORIES)}\n"
-        f"Update both src/reyn/chat/router_system_prompt.py AND "
+        f"Update both src/reyn/tools/schemes/_universal_sp.py AND "
         f"src/reyn/tools/universal_catalog.py together."
     )
 
@@ -133,7 +132,7 @@ def test_sp_bullets_match_categories_tuple_exactly() -> None:
 def test_flag_on_describes_qualified_name_format() -> None:
     """Tier 2: section explains <category>__<entry> qualified-name format."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     assert "<category>__<entry>" in prompt
 
@@ -141,41 +140,27 @@ def test_flag_on_describes_qualified_name_format() -> None:
 def test_flag_on_mentions_three_wrappers() -> None:
     """Tier 2: section names the 3 universal wrappers + hand-off chain."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     for name in ("list_actions", "describe_action", "invoke_action"):
         assert name in prompt
 
 
 def test_flag_on_mentions_similar_name_suggestions() -> None:
-    """Tier 2: section notes §D12 error-with-suggestions recovery path.
-
-    The invoke_action description says "returns an error with similar-name
-    suggestions" on unknown action_name. The SP section notes discovery via
-    list_actions. Both signals together guide the LLM to recover from typos.
-    """
+    """Tier 2: section notes §D12 error-with-suggestions recovery path."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
-    # Discovery path must be mentioned
-    assert "list_actions" in prompt  # the recovery hint references it
-    # The invoke_action description carries the "similar-name suggestions"
-    # phrase (tested in test_tool_description_role_separation.py).
-    # SP section need only confirm list_actions is the recovery tool.
+    assert "list_actions" in prompt
 
 
 # ── 3. Section placement ──────────────────────────────────────────────────
 
 
 def test_section_placed_between_capabilities_and_behaviour() -> None:
-    """Tier 2: ## Action categories sits after Capabilities, before Behaviour.
-
-    The static prefix maximises Anthropic prompt-cache prefix coverage
-    (= the section lives in the always-static part of the prompt, not
-    after dynamic sections that vary per request).
-    """
+    """Tier 2: ## Action categories sits after Capabilities, before Behaviour."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     cap_idx = prompt.index("## Capabilities (routing guide)")
     cats_idx = prompt.index("## Action categories")
@@ -190,18 +175,11 @@ def test_section_placed_between_capabilities_and_behaviour() -> None:
 
 
 def test_flag_on_preserves_behaviour_and_capabilities_sections() -> None:
-    """Tier 2: ## Capabilities and ## Behaviour sections remain when flag on.
-
-    Phase 6 cleanup: ## Skills section removed from SP (wrapper-only path
-    routes skill discovery via list_actions at runtime). ## Capabilities
-    and ## Behaviour remain as the SP routing structure.
-    """
+    """Tier 2: ## Capabilities and ## Behaviour sections remain when flag on."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
-    # ## Skills section is gone in wrapper-only path
     assert "## Skills" not in prompt
-    # Core structure still present
     assert "## Capabilities (routing guide)" in prompt
     assert "## Behaviour" in prompt
 
@@ -209,6 +187,6 @@ def test_flag_on_preserves_behaviour_and_capabilities_sections() -> None:
 def test_flag_on_preserves_behaviour_section() -> None:
     """Tier 2: existing ## Behaviour section still present when flag on."""
     prompt = build_system_prompt(
-        **_BASE_KWARGS, universal_wrappers_enabled=True,
+        **_BASE_KWARGS, tool_use_sp=_slots(universal_wrappers_enabled=True),
     )
     assert "## Behaviour" in prompt

--- a/tests/test_router_system_prompt.py
+++ b/tests/test_router_system_prompt.py
@@ -1,9 +1,29 @@
-"""Tests for the PR35 router system prompt builder."""
+"""Tests for the PR35 router system prompt builder.
+
+#1627 Stage 4: ``build_system_prompt`` is a pure slot-injector. Tests that
+need tool-use SP content (Capabilities routing guide, ROUTING RULE, etc.) must
+pass a ``tool_use_sp`` slot-map explicitly — the default (None) yields a bare
+OS frame with no tool-use SP.
+"""
 from __future__ import annotations
 
 import pytest
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+
+def _default_slots() -> "dict[str, str]":
+    """Default universal slot-map (wrappers off, search on) — mirrors the legacy
+    tool_use_sp=None path that previously called build_universal_tool_use_slots
+    with all defaults."""
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -32,13 +52,17 @@ _EMPTY_MEMORY: dict = {"status": "not_found", "content": ""}
 
 class TestEmptyStateRenders:
     def test_empty_state_renders(self):
-        """Tier 2: build_system_prompt returns a non-empty string with required sections."""
+        """Tier 2: build_system_prompt returns a non-empty string with required sections.
+
+        #1627 Stage 4: tool_use_sp must be supplied for Capabilities content.
+        """
         prompt = build_system_prompt(
             agent_name="chat",
             agent_role="general assistant",
             available_skills=[],
             available_agents=[],
             memory_index=_EMPTY_MEMORY,
+            tool_use_sp=_default_slots(),
         )
         assert isinstance(prompt, str)
         assert len(prompt) > 0
@@ -260,8 +284,9 @@ class TestIntentAxisDynamic:
 
         Phase 6 cleanup: intent-axis row format removed; routing intent
         encoded in Behaviour section via invoke_action vocabulary.
+        #1627 Stage 4: tool_use_sp slot-map required for routing content.
         """
-        prompt = _base_prompt()
+        prompt = _base_prompt(tool_use_sp=_default_slots())
         assert "ROUTING RULE (ABSOLUTE)" in prompt
         assert "invoke_action" in prompt
         assert "NO clarifying questions" in prompt
@@ -283,13 +308,16 @@ class TestBehaviourRulesAfterF3F9Fix:
     def test_reply_directly_restricted_to_chitchat(self):
         """Tier 2: 'Reply directly' rule restricted — only conversation (chitchat).
         Domain tasks must go to invoke_action. Canonical location: Capabilities
-        routing guide (#1475: Policy 1 removed from Behaviour, single canonical)."""
+        routing guide (#1475: Policy 1 removed from Behaviour, single canonical).
+        #1627 Stage 4: tool_use_sp slot-map required for Capabilities content.
+        """
         prompt = build_system_prompt(
             agent_name="chat",
             agent_role="",
             available_skills=[],
             available_agents=[],
             memory_index=_EMPTY_MEMORY,
+            tool_use_sp=_default_slots(),
         )
         # Conversation → reply directly (canonical in Capabilities routing guide)
         assert "Conversation" in prompt
@@ -299,6 +327,7 @@ class TestBehaviourRulesAfterF3F9Fix:
     def test_v3_absolute_routing_rule_present(self):
         """Tier 2: B13-R3 V3 wording — ABSOLUTE routing rule block is present
         in the Behaviour section with the required components.
+        #1627 Stage 4: tool_use_sp slot-map required for ROUTING RULE content.
         """
         prompt = build_system_prompt(
             agent_name="chat",
@@ -306,6 +335,7 @@ class TestBehaviourRulesAfterF3F9Fix:
             available_skills=[_make_skill("skill_improver", "general")],
             available_agents=[],
             memory_index=_EMPTY_MEMORY,
+            tool_use_sp=_default_slots(),
         )
         # ABSOLUTE rule framing must be present
         assert "ROUTING RULE (ABSOLUTE)" in prompt

--- a/tests/test_router_system_prompt_wrapper_visibility.py
+++ b/tests/test_router_system_prompt_wrapper_visibility.py
@@ -1,38 +1,21 @@
 """Tier 2: FP-0034 §D14 — search_actions SP wrapper visibility gate.
 
-Verifies that ``build_system_prompt`` renders the wrapper enumeration line
-and search_actions Behaviour guidance conditionally based on
-``search_actions_enabled``.
-
-Defect context (N5 probe, 2026-05-17):
-  The weak default model ``gemini-2.5-flash-lite`` read the hardcoded SP
-  line "4 universal wrappers: list_actions / search_actions / describe_action
-  / invoke_action" and hallucinated a call to ``search_actions(query="...")``.
-  Since ``embedding_class`` was not configured, ``search_actions`` was
-  excluded from ``tools=`` — the dispatcher returned an ``unknown_tool``
-  error. The model did NOT recover (did not fall back to list_actions or a
-  hot-list alias); it gave up. This PR gates the enumeration on
-  ``_search_visible`` (= D14 embedding-class gate) so the SP and ``tools=``
-  stay in sync.
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
+``search_actions_enabled`` parameter has been REMOVED from ``build_system_prompt``.
+Tests now call ``build_universal_tool_use_slots`` directly and pass the result
+as ``tool_use_sp``.
 
 Coverage:
-  - search_actions_enabled=True (default): SP says "4 universal wrappers"
-    and includes search_actions in both the wrapper line and Behaviour
-    guidance.
-  - search_actions_enabled=False: SP says "3 universal wrappers" and
-    search_actions is absent from the SP entirely.
-  - Default (no kwarg): byte-identical to explicit True (backward compat
-    for existing LLMReplay fixtures).
-  - When universal_wrappers_enabled=False: search_actions_enabled is
-    irrelevant to the wrapper line (the line is always emitted for compat).
-
-No mocks — pure-string contract tests on build_system_prompt output.
+  - search_actions_enabled=True in slot-map: SP names search_actions in wrapper chain
+  - search_actions_enabled=False in slot-map: search_actions absent from SP
+  - Default (tool_use_sp=None): bare OS frame, no wrapper content
 """
 from __future__ import annotations
 
 import pytest
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 _BASE = {
     "agent_name": "chat",
@@ -43,44 +26,40 @@ _BASE = {
 }
 
 
+def _slots(*, search_actions_enabled: bool) -> "dict[str, str]":
+    """Build slot-map with universal wrappers on (needed to show the chain)."""
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=search_actions_enabled,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+
+
 # ---------------------------------------------------------------------------
-# search_actions_enabled=True (default)
+# search_actions_enabled=True
 # ---------------------------------------------------------------------------
 
 
 def test_search_actions_enabled_true_includes_search_actions_in_wrapper_chain() -> None:
-    """Tier 2: search_actions_enabled=True → SP names search_actions in the
-    Capabilities routing chain.
-
-    V18 SP replaced the legacy "N universal wrappers:" introductory line
-    with a 4-intent multi-step routing block; the wrapper chain now
-    appears as "list_actions → search_actions → describe_action → invoke_action"
-    inside intent 3 (task / action) under the "Not obvious" sub-bullet.
-    The contract enforced here: when search_actions is wired in tools=,
-    its name appears in the SP so the LLM has the right vocabulary; when
-    it is not wired, its name MUST be absent (N5 hallucination guard).
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=True)
+    """Tier 2: search_actions_enabled=True in slot-map → SP names search_actions in
+    the Capabilities routing chain."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
     assert "search_actions" in sp
     assert "`list_actions` → `search_actions`" in sp
 
 
 def test_search_actions_enabled_true_includes_four_wrapper_names() -> None:
-    """Tier 2: with search_actions_enabled=True, all four wrapper names appear
-    in the wrapper enumeration line.
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=True)
+    """Tier 2: with search_actions_enabled=True, all four wrapper names appear."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
     for name in ("list_actions", "search_actions", "describe_action", "invoke_action"):
         assert name in sp, f"expected {name!r} in SP with search_actions_enabled=True"
 
 
 def test_search_actions_enabled_true_includes_behaviour_guidance() -> None:
-    """Tier 2: search_actions_enabled=True → Behaviour section references search_actions.
-
-    The routing guidance "USE search_actions(query=...)" for semantic queries
-    must only appear when search_actions is actually in tools=.
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=True)
+    """Tier 2: search_actions_enabled=True → Behaviour section references search_actions."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
     assert "USE `search_actions(query=...)`" in sp
 
 
@@ -90,42 +69,22 @@ def test_search_actions_enabled_true_includes_behaviour_guidance() -> None:
 
 
 def test_search_actions_enabled_false_omits_search_actions_from_sp() -> None:
-    """Tier 2: search_actions_enabled=False → search_actions absent from SP.
-
-    This is the path when embedding_class is unset (= explicit ``null`` /
-    empty in ``reyn.yaml``) OR the graceful-degrade probe fired (= FP-0043
-    Phase 4 default `local-mini` but ``reyn[local-embed]`` extras absent).
-    Both routes set ``search_actions_enabled=False`` upstream. The LLM
-    must not see search_actions in the SP because it is not in tools=,
-    which would invite hallucinated calls (N5 finding).
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=False)
+    """Tier 2: search_actions_enabled=False → search_actions absent from SP."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=False))
     assert "search_actions" not in sp
 
 
 def test_search_actions_enabled_false_omits_search_actions_from_chain() -> None:
-    """Tier 2: search_actions_enabled=False → wrapper chain in SP omits
-    search_actions entirely.
-
-    V18 SP replaced the legacy "N universal wrappers:" introductory line
-    with a 4-intent multi-step routing block. The chain expression
-    (= "list_actions → describe_action → invoke_action" when disabled,
-    "list_actions → search_actions → describe_action → invoke_action"
-    when enabled) is what matches tools= shape now; the count phrasing
-    is gone. Contract: search_actions must not appear in SP when the
-    embedding class isn't configured (N5 hallucination guard).
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=False)
+    """Tier 2: search_actions_enabled=False → wrapper chain omits search_actions."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=False))
     assert "search_actions" not in sp
-    # The disabled chain shape: list_actions chained directly to describe_action
     assert "`list_actions` → `describe_action` → `invoke_action`" in sp
 
 
 def test_search_actions_enabled_false_three_wrapper_names_present() -> None:
     """Tier 2: search_actions_enabled=False → the three always-available wrapper
-    names appear in the SP.
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=False)
+    names appear in the SP."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=False))
     for name in ("list_actions", "describe_action", "invoke_action"):
         assert name in sp, (
             f"expected {name!r} in SP when search_actions_enabled=False"
@@ -133,44 +92,37 @@ def test_search_actions_enabled_false_three_wrapper_names_present() -> None:
 
 
 def test_search_actions_enabled_false_omits_semantic_search_behaviour() -> None:
-    """Tier 2: search_actions_enabled=False → search_actions Behaviour guidance absent.
-
-    The 'USE search_actions(query=...)' routing hint must only appear when
-    the tool is available, otherwise the LLM gets conflicting signals.
-    """
-    sp = build_system_prompt(**_BASE, search_actions_enabled=False)
+    """Tier 2: search_actions_enabled=False → search_actions Behaviour guidance absent."""
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=False))
     assert "USE search_actions" not in sp
     assert "search_actions" not in sp
 
 
 # ---------------------------------------------------------------------------
-# Default kwarg — byte-compat
+# Default kwarg — bare OS frame (no tool-use SP)
 # ---------------------------------------------------------------------------
 
 
 def test_default_kwarg_matches_explicit_true() -> None:
-    """Tier 2: omitting search_actions_enabled is byte-identical to explicit True.
+    """Tier 2: #1627 Stage 4 — the default (tool_use_sp=None) yields a bare OS
+    frame distinct from any slot-map. Two explicit calls with the same slot-map
+    are byte-identical to each other.
 
-    This preserves byte-compat for existing LLMReplay fixtures recorded
-    before the search_actions_enabled flag was introduced. Those fixtures
-    include search_actions in the SP and must continue to match.
+    NOTE: After Stage 4, omitting tool_use_sp is no longer byte-identical to
+    explicit True — None produces the bare frame, not the universal SP.
+    This test pins the new contract: two identical slot-map calls are equal.
     """
-    sp_default = build_system_prompt(**_BASE)
-    sp_explicit_true = build_system_prompt(**_BASE, search_actions_enabled=True)
-    assert sp_default == sp_explicit_true, (
-        "default search_actions_enabled must produce byte-identical SP to "
-        "explicit True — existing fixture keys depend on this"
-    )
+    sp_explicit_true_a = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
+    sp_explicit_true_b = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
+    assert sp_explicit_true_a == sp_explicit_true_b
 
 
 def test_default_includes_search_actions() -> None:
-    """Tier 2: default SP includes search_actions (backward compat).
+    """Tier 2: slot-map with search_actions_enabled=True includes search_actions.
 
-    Existing fixtures were recorded with 'search_actions' in the SP. The
-    default (True) must preserve this so fixture replay keys stay valid.
-    V18 SP carries search_actions inside the Capabilities chain
-    expression rather than the legacy "N universal wrappers:" line.
+    #1627 Stage 4: callers must supply the slot-map explicitly. This test verifies
+    the slot-map path, not the default (None) path.
     """
-    sp = build_system_prompt(**_BASE)
+    sp = build_system_prompt(**_BASE, tool_use_sp=_slots(search_actions_enabled=True))
     assert "search_actions" in sp
     assert "`list_actions` → `search_actions`" in sp

--- a/tests/test_scheme_sp_fragment_1593.py
+++ b/tests/test_scheme_sp_fragment_1593.py
@@ -1,20 +1,12 @@
-"""Tier 2: #1593 — the scheme-owned ``Presentation.sp_fragment`` SP channel.
+"""Tier 2: #1593/#1627 — the scheme-owned ``Presentation.sp_fragment`` / slot-map SP channel.
 
-A tool-use scheme shapes the system prompt through two deliberately separate
-channels (see ``Presentation``):
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The legacy
+``scheme_sp_fragment`` backward-compat param is still accepted and appended
+verbatim. The canonical path is ``tool_use_sp["slot_post_catalog"]`` (used by
+retrieval's ``_search_sp``); ``scheme_sp_fragment`` stays for callers that haven't
+migrated. This file pins the OS-side contract for the fragment channel:
 
-  - ``sp_params`` — named gates ``build_system_prompt`` already understands
-    (``universal_wrappers_enabled`` / ``search_actions_enabled`` …). The
-    named-gate schemes (universal-category, enumerate-all) express their whole
-    SP through these, leaving ``sp_fragment`` empty.
-  - ``sp_fragment`` — free-form, scheme-owned tool-use SP text the OS appends
-    **verbatim** without interpreting it (P7: the OS has no notion of
-    "code-API" / "search-SP"). CodeAct / retrieval are the first consumers.
-
-This file pins the OS-side contract of that second channel:
-
-  1. Empty fragment (the default) ⇒ the SP is byte-identical to the call with
-     no fragment argument at all — the named-gate path is untouched.
+  1. Empty fragment + empty slot-map ⇒ no fragment in the SP.
   2. A non-empty fragment appears verbatim in the rendered SP.
   3. The fragment is appended (OS-agnostic): the OS does not transform, prefix,
      or wrap it — what the scheme wrote is what lands.
@@ -26,6 +18,19 @@ No mocks. Tests call ``build_system_prompt`` with real arguments.
 from __future__ import annotations
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+
+def _base_slots() -> "dict[str, str]":
+    """Minimal universal slot-map (wrappers on, search off) — mirrors the
+    prior universal_wrappers_enabled=True / search_actions_enabled=False call."""
+    return build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
 
 
 def _sp(*, scheme_sp_fragment: str = "", context_size_signal: str | None = None) -> str:
@@ -35,29 +40,25 @@ def _sp(*, scheme_sp_fragment: str = "", context_size_signal: str | None = None)
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        search_actions_enabled=False,
+        tool_use_sp=_base_slots(),
         scheme_sp_fragment=scheme_sp_fragment,
         context_size_signal=context_size_signal,
     )
 
 
-# ── 1. Empty fragment = byte-identical named-gate path ───────────────────────
+# ── 1. Empty fragment = byte-identical to same call with no fragment arg ────────
 
 
 def test_empty_fragment_leaves_named_gate_sp_unchanged() -> None:
-    """Tier 2: #1593 — default ``sp_fragment=""`` renders an SP equal to the call
-    that passes no fragment argument; the named-gate schemes (universal-category
-    / enumerate-all) are therefore unchanged by this seam. This is a permanent
-    contract (the empty channel is invisible), not a refactor-equivalence check."""
+    """Tier 2: #1593/#1627 — ``scheme_sp_fragment=""`` renders an SP equal to the call
+    that passes no fragment argument; the empty channel is invisible, permanent contract."""
     without_arg = build_system_prompt(
         agent_name="test",
         agent_role="tester",
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=True,
-        search_actions_enabled=False,
+        tool_use_sp=_base_slots(),
     )
     with_empty = _sp(scheme_sp_fragment="")
     assert with_empty == without_arg, (

--- a/tests/test_sp_minimization_1475.py
+++ b/tests/test_sp_minimization_1475.py
@@ -1,5 +1,10 @@
 """Tier 2: #1475 — SP minimization: backtick convention + Behaviour dedup.
 
+#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
+``universal_wrappers_enabled``, ``discovery_mandate``, and ``search_actions_enabled``
+parameters have been REMOVED. Tests now call ``build_universal_tool_use_slots``
+and pass the result as ``tool_use_sp``.
+
 Pins:
 
 1. Backtick convention: action qualified names and tool names in the SP
@@ -15,25 +20,32 @@ Pins:
 3. N=0 smoke residual: discovery_mandate `_otherwise` branch no longer says
    "hot-list subset" (false when N=0) — says "universal wrappers" instead.
 
-No mocks. Tests call build_system_prompt with real arguments.
+No mocks. Tests call build_system_prompt + build_universal_tool_use_slots with
+real arguments.
 """
 from __future__ import annotations
 
 from reyn.chat.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
 
 def _sp(*, universal_wrappers_enabled: bool = True,
         discovery_mandate: bool = False,
         search_actions_enabled: bool = False) -> str:
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=universal_wrappers_enabled,
+        search_actions_enabled=search_actions_enabled,
+        discovery_mandate=discovery_mandate,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
     return build_system_prompt(
         agent_name="test",
         agent_role="tester",
         available_skills=[],
         available_agents=[],
         memory_index={},
-        universal_wrappers_enabled=universal_wrappers_enabled,
-        search_actions_enabled=search_actions_enabled,
-        discovery_mandate=discovery_mandate,
+        tool_use_sp=slots,
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — #1627 Stage 5 of 5... **Stage 4 of 5 (FINAL)**. All 4 schemes own their tool-use SP (Stages 1-3 merged); this retires the OS's tool-use SP construction so `build_system_prompt` is a pure scheme-agnostic slot-injector.

## What
- **`build_universal_tool_use_slots` relocated** router_system_prompt.py → `schemes/_universal_sp.py` (the `list_actions`/wrapper vocab leaves the OS SP file).
- **None-path retired**: `tool_use_sp=None` → `{}` (bare OS frame). Removed the dead params (`universal_wrappers_enabled`/`search_actions_enabled`/`discovery_mandate`/`has_hot_list_aliases`/`non_interactive`) from build_system_prompt + ALL callers (router_loop, router_history_buffer, tests).
- **router_loop**: removed the `tier_wants_discovery_mandate` import/call + sp_params plumbing. Schemes: removed the unused sp_params dict.

## Char-identical evidence
**SCHEME-PATH 162/162** — all 4 schemes' SPs via their slot-maps (universal univ×sv×rm×hl×ni, enumerate, retrieval×terminal, codeact) × cwd. Independently re-verified post-rebase. Full suite **7318 passed** (2 pre-existing failures unrelated: swebench + web_fetch_preview, confirmed on stash). ruff clean.

## P7 grep — abstraction-completion proof (⚠️ honest nuance, needs lead's scope ruling)
The **SP-construction path now has ZERO tool-use vocab** — the core goal met. Remaining grep matches, categorized:
1. **Stale comments** referencing the relocated `## Capabilities`/`R3` — I'll clean per your preference (cosmetic).
2. **Legitimate non-SP code**: router_loop's dispatch-path action-name list `["list_actions","search_actions",...]` (real action names the dispatcher routes) + `get_universal_wrappers_enabled` host method (a raw-FACT provider — P7-clean by design).
3. **`list_actions(category=...)` discovery hints in OS-retained catalog-context sections** (`## Memory`/`## Indexed sources`/`## MCP`) — tool-use vocab, but in OS *context* sections, not the tool-use-SP region #1627 targets. **Scope question**: (A) out of #1627's scope → fold into the content-layer P7 follow-up alongside #1625 [my rec]; or (B) a Stage 5 to relocate them.

## Test plan
- [x] SCHEME-PATH CHAR-IDENTICAL 162/162; full suite 7318 passed (2 pre-existing)
- [x] ruff clean; 14 test files updated (param-removal callers → slot-map)
- [ ] lead: review + **ruling on the P7-grep scope** (catalog-context hints A vs B) + stale-comment cleanup preference
- [ ] sandbox_2: authoritative P7 grep + 5-slot regression gate (git worktree)

Stacks on #1636 (Stage 3, merged). This completes the per-scheme externalization; the catalog-context hints + #1625 are the remaining content-layer P7 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)