### PR TITLE
fix(1638): backtick-wrap CodeAct code-API tool() calls — gemini-flash-lite empty-response bug

### DIFF
--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -65,7 +65,7 @@ def _render_code_api(entries: list[dict]) -> str:
         "no \"I am a Reyn agent\" preamble on an action turn. Inside the block, call any "
         "available action:",
         "",
-        "    result = tool('<name>', <arg>=<value>, ...)",
+        "    result = `tool('<name>', <arg>=<value>, ...)`",
         "",
         "`tool(...)` returns the action's result, or raises if the action is denied / "
         "excluded / unknown. Assign your final answer to `result`. The Python standard "
@@ -85,7 +85,12 @@ def _render_code_api(entries: list[dict]) -> str:
         sig = ", ".join(arg_names)
         desc_raw = (entry.get("description") or "").strip()
         desc = desc_raw.splitlines()[0] if desc_raw else ""
-        lines.append(f"- tool('{name}'{', ' + sig if sig else ''}) — {desc}".rstrip(" —"))
+        # #1638: backtick-wrap the rendered call so the SP carries NO bare quoted
+        # `tool('<x>')` token — gemini-2.5-flash-lite returns ~100% empty-choices on a
+        # bare `tool('<quoted>')` token (content-trigger; lead+sandbox_2 proxy-probe:
+        # bare 6/6 empty → backtick 0/6). Presentation-only: the catalog is a reference
+        # list the model READS; it still writes bare `tool(...)` inside its python block.
+        lines.append(f"- `tool('{name}'{', ' + sig if sig else ''})` — {desc}".rstrip(" —"))
     return "\n".join(lines)
 
 

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -170,6 +170,22 @@ async def test_build_presentation_includes_arg_names() -> None:
 
 
 @pytest.mark.asyncio
+async def test_code_api_has_no_bare_tool_call_for_flashlite() -> None:
+    """Tier 2: #1638 — the rendered code-API carries NO bare quoted ``tool('<x>')``
+    token. gemini-2.5-flash-lite returns ~100% empty-choices on a bare ``tool('<quoted>')``
+    token (content-trigger, lead+sandbox_2 proxy-probe: bare 6/6 empty → backtick 0/6);
+    the CodeAct code-API rendered ~50 such bare lines. Presentation-only — every rendered
+    call is backtick-wrapped; the model still writes bare ``tool(...)`` in its python block."""
+    import re
+
+    pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
+    # No bare `tool('` (one not immediately preceded by a backtick) anywhere in the render.
+    assert not re.search(r"(?<!`)tool\('", pres.tool_use_sp)
+    # The call IS present, backtick-wrapped (the action is still discoverable/usable).
+    assert "`tool('file__read'" in pres.tool_use_sp
+
+
+@pytest.mark.asyncio
 async def test_build_presentation_omits_excluded_actions() -> None:
     """Tier 2: presentation parity (#1400) — an excluded action is omitted from the
     code-API (CodeAct presentation not looser than JSON tools=). The OS supplies the


### PR DESCRIPTION
**[e2e-coder]** — Closes #1638. Fix for the gemini-2.5-flash-lite ~100%-empty CodeAct bug (root-cause: lead + dogfood-coder; fix: e2e, owner of `_render_code_api`).

## Root cause
gemini-2.5-flash-lite returns ~100% empty-choices on any prompt containing a bare (non-backtick) quoted `tool('<x>')` token — a content-trigger (HTTP 200 / `choices:[]` / 0 completion tokens / no safety block). `_render_code_api` rendered ~50 bare `- tool('name', args) — desc` catalog lines + a bare `result = tool('<name>', ...)` example, so CodeAct dogfood on flash-lite was ~100% empty. universal/enumerate/retrieval (invoke_action/list_actions idioms) are unaffected.

## Fix
Backtick-wrap **both** rendered call sites in `_render_code_api`: the catalog entries (`` - `tool('name', args)` — desc ``) and the example line. No bare quoted `tool('<x>')` token remains in the rendered code-API.

**Presentation-only invariant (lead review focus #1)**: the code-API is a reference the model READS; the backtick is SP markdown only. The model still writes bare `tool(...)` inside its python block — confirmed by dogfood-coder's live-verify (3/4 dispatched correctly after backtick → code-generation + interpret intact).

## Evidence (lead + dogfood-coder proxy-probe, content-isolated, Reyn-not-in-loop)
- bare quoted `tool('file__read', path='x')` → **6/6 EMPTY**; backtick `` `tool('...')` `` → **6/6 OK**; no-quotes `tool(...)` → 5/6 OK; `invoke_action()`/`list_actions()` → clean; word "tool" → clean. **Trigger = the bare quoted token specifically.**
- CodeAct-style SP 5/5 empty vs universal-style 0/5.
- **Catalog-only backtick (example left bare) → 1/4 residual** → confirmed BOTH sites must be wrapped (this PR wraps both).

## Test plan
- [x] regression test: rendered code-API carries zero bare `tool('` (only backtick-wrapped) — `test_code_api_has_no_bare_tool_call_for_flashlite`
- [x] codeact suite green; test-tier audit --strict clean; ruff clean
- [x] NOT char-identical (deliberate SP-content fix) — so the gate is **behavioral**, not char-diff
- [ ] lead: review (focus #1 presentation-only invariant, #2 regression test, #4 lives in slot_pre_environment / universal-enum-retrieval unaffected)
- [ ] dogfood-coder: flash-lite codeact re-run — empties vanish AND model writes correct `tool()` + dispatch intact → codeact 15-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)