### PR TITLE
fix(1640): enumerate interpret — add no-tool_calls→PlainText guard (weak-model ∞-loop)

### DIFF
--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -38,6 +38,7 @@ from reyn.tools.scheme import (
     Execute,
     ExecutionResult,
     Interpretation,
+    PlainText,
     Presentation,
     SchemeOps,
     register_scheme,
@@ -77,6 +78,13 @@ class EnumerateAllScheme:
         return Presentation(llm_tools_payload=flat_tools, tool_use_sp=slots)
 
     def interpret(self, llm_response, *, tool_catalog: dict, ops: SchemeOps) -> Interpretation:
+        # #1640: no tool_calls = a plain-text answer (the model's normal terminal) →
+        # PlainText so the OS loop exits to the text-reply path. Without this guard,
+        # resolve→[] → Execute([]) → the loop runs nothing → re-prompt → empty-content
+        # turn → never terminates → 120s timeout (weak-model robustness bug). Mirrors
+        # universal_category + retrieval (and root-3 #2's codeact no-fence→PlainText).
+        if not getattr(llm_response, "tool_calls", None):
+            return PlainText()
         # Flat (qualified) names resolve through the shared resolution (dedupe +
         # salvage/unwrap → effective names) so the OS exclude-gates pre-dispatch.
         actions = ops.resolve(llm_response, tool_catalog)

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -25,6 +26,7 @@ if str(_SRC) not in sys.path:
 from reyn.tools.scheme import (
     Execute,
     ExecutionResult,
+    PlainText,
     Presentation,
     SchemeOps,
     ToolUseScheme,
@@ -106,12 +108,27 @@ async def test_build_presentation_tool_use_sp_disable_wrappers() -> None:
 
 
 def test_interpret_resolves_to_execute() -> None:
-    """Tier 2: interpret delegates to ops.resolve → Execute carrying resolved
-    effective-name actions (qualified names route through the shared resolution)."""
+    """Tier 2: with tool_calls present, interpret delegates to ops.resolve → Execute
+    carrying resolved effective-name actions (qualified names route through the shared
+    resolution)."""
     s = EnumerateAllScheme()
-    interp = s.interpret("llm-resp", tool_catalog={}, ops=_FakeOps())
+    resp = SimpleNamespace(tool_calls=[{"id": "1"}])
+    interp = s.interpret(resp, tool_catalog={}, ops=_FakeOps())
     assert isinstance(interp, Execute)
     assert interp.actions[0]["name"] == "git__commit"
+
+
+def test_interpret_no_tool_calls_returns_plaintext_terminal() -> None:
+    """Tier 2: #1640 — a response with NO tool_calls is a plain-text answer (the model's
+    normal terminal) ⇒ PlainText, so the OS loop exits to the text-reply path. Without
+    this guard, resolve→[] → Execute([]) → the loop runs nothing → re-prompt →
+    empty-content turn → never terminates → 120s timeout (weak-model robustness bug).
+    Mirrors universal_category + retrieval (real instance, no mocks)."""
+    s = EnumerateAllScheme()
+    resp = SimpleNamespace(tool_calls=None, content="The answer is 42.")
+    interp = s.interpret(resp, tool_catalog={}, ops=_FakeOps())
+    assert isinstance(interp, PlainText)
+    assert not isinstance(interp, Execute)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — Closes #1640. Second weak-model robustness fix from dogfood mining (after #1638 bare-tool()).

## Root cause (dogfood-coder enumtrace-history mining, primary evidence)
`enumerate_all.py::interpret` lacked the `no-tool_calls → PlainText` guard — it unconditionally `return Execute(ops.resolve(...))`. On a weak model's plain-text answer (its **normal terminal** — no tool calls), `resolve→[]` → `Execute([])` → the OS loop runs nothing → re-prompts → empty-content turn → **never terminates → 120s timeout.**

**enumerate-specific**: `universal_category.py` + `retrieval.py` both already have `if not getattr(llm_response, "tool_calls", None): return PlainText()`; only enumerate was missing it. Same defect class as #1618 root-3 #2 (codeact no-fence→PlainText).

## Fix
Mirror the existing pattern (~3 lines):
```python
if not getattr(llm_response, "tool_calls", None):
    return PlainText()
```
A plain-text answer routes to the OS text-reply terminal path instead of an empty Execute. Low risk (existing-pattern mirror; 3 of 4 schemes already do exactly this).

## Test plan
- [x] regression test `test_interpret_no_tool_calls_returns_plaintext_terminal` (real instance, no mocks) + updated `test_interpret_resolves_to_execute` (now passes a response WITH tool_calls)
- [x] enumerate suite green (8 passed); test-tier audit --strict clean; ruff clean
- [ ] lead: review (existing-pattern mirror)
- [ ] dogfood-coder: enumerate 15-run on flash-lite — plain-text answers terminate cleanly (no timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)