### PR TITLE
feat(1642): show tool-call args/result inline in the chainlit conversation

### DIFF
--- a/src/reyn/chainlit_app/adapter.py
+++ b/src/reyn/chainlit_app/adapter.py
@@ -94,27 +94,61 @@ _AUTHOR_TOOL = "🔧 tool"
 _AUTHOR_FALLBACK = "ℹ system"
 
 
+# #1642: char caps (NOT byte — multibyte/JA-safe; Python str slicing is char-based)
+# so a large arg/result doesn't fill the conversation (full content out of scope for
+# this inline row). args ~120 / result ~200 per lead; cross-surface-aligned with the
+# TUI renderer (skill_activity.py). _TOOL_VALUE_LIMIT caps one arg value so a single
+# big arg can't dominate the whole-args preview.
+_TOOL_ARGS_LIMIT = 120
+_TOOL_RESULT_LIMIT = 200
+_TOOL_VALUE_LIMIT = 80
+
+
+def _truncate_one_line(s: str, limit: int) -> str:
+    """Collapse to one line + cap CHAR length with an ellipsis (multibyte-safe)."""
+    s = " ".join(s.split())  # collapse whitespace/newlines to a single line
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def _preview_tool_content(value: object, limit: int) -> str:
+    """#1642: a one-line, length-bounded preview of a tool call's args dict or
+    result, for inline display in the conversation row. Args render as a compact
+    ``key=value, …``; a scalar/other result renders via str/repr. Empty/None ⇒ ``""``
+    (caller falls back to the bare name — no noisy ``name()``)."""
+    if value is None or value == {} or value == "":
+        return ""
+    if isinstance(value, dict):
+        body = ", ".join(
+            f"{k}={_truncate_one_line(v if isinstance(v, str) else repr(v), _TOOL_VALUE_LIMIT)}"
+            for k, v in value.items()
+        )
+    else:
+        body = value if isinstance(value, str) else repr(value)
+    return _truncate_one_line(body, limit)
+
+
 def _format_tool_call(msg: OutboxMessage) -> str:
     """Build the tool-call body text with a status-prefix marker.
 
     The lifecycle forwarder packs the tool name into both ``text`` and
     ``meta["tool"]`` so either works; we prefer meta when present so a
-    future emitter that uses a richer text field (e.g. with args
-    inline) won't collide with the prefix.
+    future emitter that uses a richer text field won't collide with the prefix.
+    #1642: args (``meta["args"]``) render inline on start and result
+    (``meta["result"]``) as a preview on completion — both truncated.
     """
-    name = msg.meta.get("tool") if isinstance(msg.meta, dict) else None
+    meta = msg.meta if isinstance(msg.meta, dict) else {}
+    name = meta.get("tool")
     if not isinstance(name, str) or not name:
         name = msg.text or "(unnamed)"
     if msg.kind == "tool_call_started":
-        return f"→ {name}"
+        args = _preview_tool_content(meta.get("args"), _TOOL_ARGS_LIMIT)
+        return f"→ {name}({args})" if args else f"→ {name}"
     if msg.kind == "tool_call_completed":
-        return f"✓ {name}"
+        result = _preview_tool_content(meta.get("result"), _TOOL_RESULT_LIMIT)
+        return f"✓ {name} → {result}" if result else f"✓ {name}"
     # tool_call_failed
-    err = ""
-    if isinstance(msg.meta, dict):
-        em = msg.meta.get("error_message")
-        if isinstance(em, str) and em:
-            err = f": {em}"
+    em = meta.get("error_message")
+    err = f": {em}" if isinstance(em, str) and em else ""
     return f"✗ {name}{err}"
 
 

--- a/tests/cli/test_chainlit_adapter.py
+++ b/tests/cli/test_chainlit_adapter.py
@@ -118,18 +118,52 @@ def test_tool_call_started_renders_arrow_prefix():
     assert payload.message_type == MSG_TYPE_SYSTEM
 
 
-def test_tool_call_completed_renders_check_prefix():
-    """Tier 1: ``tool_call_completed`` → ``✓ <name>``."""
+def test_tool_call_completed_renders_result_preview():
+    """Tier 1: #1642 — ``tool_call_completed`` renders the result preview inline:
+    ``✓ <name> → <result>`` (from meta["result"]); bare ``✓ <name>`` when absent."""
     msg = OutboxMessage(
         kind="tool_call_completed",
         text="shell__run",
-        meta={"tool": "shell__run", "op_id": "h2", "result": "..."},
+        meta={"tool": "shell__run", "op_id": "h2", "result": "exit 0"},
     )
     payload = outbox_to_chainlit(msg)
     assert payload is not None
     assert payload.author == "🔧 tool"
-    assert payload.content == "✓ shell__run"
+    assert payload.content == "✓ shell__run → exit 0"
     assert payload.message_type == MSG_TYPE_SYSTEM
+
+    # No result in meta → bare name (fallback).
+    bare = OutboxMessage(kind="tool_call_completed", text="t", meta={"tool": "t"})
+    assert outbox_to_chainlit(bare).content == "✓ t"
+
+
+def test_tool_call_started_renders_args_inline():
+    """Tier 1: #1642 — ``tool_call_started`` renders args inline: ``→ <name>(k=v, …)``
+    (from meta["args"]); bare ``→ <name>`` when args absent/empty."""
+    with_args = OutboxMessage(
+        kind="tool_call_started",
+        text="file__read",
+        meta={"tool": "file__read", "args": {"path": "notes.txt"}},
+    )
+    assert outbox_to_chainlit(with_args).content == "→ file__read(path=notes.txt)"
+
+    empty_args = OutboxMessage(
+        kind="tool_call_started", text="x", meta={"tool": "x", "args": {}},
+    )
+    assert outbox_to_chainlit(empty_args).content == "→ x"
+
+
+def test_tool_call_content_is_truncated():
+    """Tier 1: #1642 — a large arg/result preview is truncated (the inline row is
+    length-bounded; full content is out of scope). Behavior-pinned: truncation marker
+    present + the full result is NOT inlined — no exact-length assertion."""
+    full = "A" * 1000
+    big = OutboxMessage(
+        kind="tool_call_completed", text="x", meta={"tool": "x", "result": full},
+    )
+    content = outbox_to_chainlit(big).content
+    assert content.endswith("…")   # truncation marker (the documented behavior)
+    assert full not in content     # the full result is NOT inlined (bounded)
 
 
 def test_tool_call_failed_renders_x_with_error_message():


### PR DESCRIPTION
**[e2e-coder]** — Refs #1642 (owner-directed). Chainlit half (TUI half = tui-coder, skill_activity.py).

## What
Display tool-call **content** in the conversation, not just the name:
- started: `→ {name}({args_preview})`
- completed: `✓ {name} → {result_preview}`
- failed: unchanged

## Renderer-only (flow-trace finding)
The emitter already enriches `OutboxMessage.meta` with `args` (tool_call_started) + `result` (tool_call_completed) via `_enqueue_tool_call`'s `meta.update(extra_meta)`. Only `_format_tool_call` (adapter.py) ignored them (NAME-only). So this is a pure renderer change — no emitter/event-schema change (lead's scope #1 was already done).

## Truncation (load-bearing design, lead-approved)
- **CHAR caps (multibyte/JA-safe** — Python str slicing is char-based, not byte): args ~120 / result ~200, per-arg-value ~80 (one big arg can't dominate).
- whitespace/newlines collapsed to one line; full content out of scope for the inline row.
- empty/None args → bare `→ name` (no noisy `name()`).
- **No content redaction** (owner's own UI, display is the goal; truncation bounds size) — lead flagging conversation export/share secret-exposure to owner separately.
- Caps **cross-surface-aligned** with the TUI renderer (args 120 / result 200 / value 80) per tui-coder coordination.

## Test plan
- [x] started-with-args / completed-with-result / empty-fallback / truncation (behavior-pinned: marker + full result not inlined, NO exact-length assert) + existing name-fallback/prefers-meta
- [x] adapter suite 22 passed; test-tier audit --strict clean (14 OK); ruff clean
- [ ] lead: review (render/truncation)
- [ ] owner: visual confirm in conversation UI
- [ ] tui-coder: TUI half (skill_activity.py) — aligned caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)