### PR TITLE
fix(1642): surface assistant tool-turn text content in the conversation

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2107,6 +2107,21 @@ class RouterLoop:
             if isinstance(interp, Execute):
                 # B28-Q2: count non-empty tool_call rounds for chat_turn_completed_inline.
                 _tool_calls_attempted += 1
+                # #1642: surface the assistant's TEXT content that accompanies tool_calls.
+                # The terminal text-reply path (below, ~line 2638) only fires for a
+                # no-tool_calls turn, so on a tool-turn the explanatory text was dropped
+                # from the conversation (it is still persisted to history). Emit it as an
+                # ``agent`` bubble BEFORE _run_execute_round so the text renders ahead of
+                # the tool rows (lifecycle_forwarder queues tool_call_started during the
+                # round). Skip empty (no empty bubble); no double-emit — the terminal path
+                # is no-tool_calls-only, and history persistence is unchanged.
+                _tool_turn_text = result.content or ""
+                if _tool_turn_text.strip():
+                    await self.host.put_outbox(
+                        kind="agent",
+                        text=_tool_turn_text,
+                        meta={"chain_id": self.chain_id, "source": "router_tool_turn_text"},
+                    )
                 # F5 fix (dogfood batch 1): dedupe duplicate async
                 # tool_calls within the same round. Weak models
                 # occasionally emit `delegate_to_agent` twice in one

--- a/tests/test_router_loop_tool_turn_text_1642.py
+++ b/tests/test_router_loop_tool_turn_text_1642.py
@@ -1,0 +1,111 @@
+"""Tier 3a: #1642 — assistant TEXT content that accompanies tool_calls is surfaced
+to the conversation, not dropped.
+
+When an LLM response carries BOTH ``tool_calls`` and ``content`` (e.g. "Let me read
+that file first." + a file__read call), the explanatory text must appear in the
+conversation. Pre-#1642 the only site that emitted ``result.content`` to the outbox was
+the no-tool_calls terminal text-reply path, so on a tool-turn the text was persisted to
+history but never displayed. The fix emits an ``agent`` outbox bubble at the start of the
+Execute arm (before tool execution), with meta ``source="router_tool_turn_text"``.
+
+Driven via the ``call_llm_tools`` scripted-injection seam + ``FakeRouterHost`` (real Fake
+that records ``put_outbox`` on its public ``.outbox`` list) — no mocks; asserts on the
+public outbox surface (testing.ja.md).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests.test_router_loop import (
+    FakeRouterHost,
+    _ScriptedLLM,
+    make_loop,
+    text_result,
+)
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _text_and_tool(content: str, *, skill: str) -> LLMToolCallResult:
+    """An LLM response carrying BOTH text content AND a tool_call (the #1642 case)."""
+    return LLMToolCallResult(
+        content=content,
+        tool_calls=[
+            {
+                "id": "t1",
+                "type": "function",
+                "function": {
+                    "name": "invoke_skill",
+                    "arguments": json.dumps(
+                        {"name": skill, "input": {"type": "Foo", "data": {}}}
+                    ),
+                },
+            }
+        ],
+        finish_reason="tool_calls",
+        usage=_USAGE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_turn_text_content_surfaced_to_conversation(monkeypatch):
+    """Tier 3a: a turn with content + tool_calls emits the content as an ``agent``
+    bubble (the fix), in addition to the terminal text on the final no-tool turn."""
+    host = FakeRouterHost(skills=[{"name": "my_skill", "category": "general"}])
+    loop = make_loop(host)
+    script = [
+        _text_and_tool("Let me run your skill first.", skill="my_skill"),  # Execute turn
+        text_result("All done."),                                          # terminal turn
+    ]
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _ScriptedLLM(script))
+    await loop.run("run my skill", [])
+
+    agent = [m for m in host.outbox if m["kind"] == "agent"]
+    texts = [m["text"] for m in agent]
+    # The tool-turn's accompanying text is surfaced (pre-#1642 it was dropped) ...
+    assert "Let me run your skill first." in texts
+    # ... and the terminal text-reply still emits (existing behavior, no regression).
+    assert "All done." in texts
+    # The tool-turn text is emitted exactly once (no double-emit), via the fix's marker.
+    fix_texts = [
+        m["text"] for m in agent if m["meta"].get("source") == "router_tool_turn_text"
+    ]
+    assert fix_texts == ["Let me run your skill first."]
+
+
+@pytest.mark.asyncio
+async def test_no_tool_calls_turn_emits_content_once(monkeypatch):
+    """Tier 3a: a no-tool_calls turn emits its content once via the terminal path only —
+    NOT also via the tool-turn fix (which is Execute-arm-only). Guards against double-emit."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    monkeypatch.setattr(
+        "reyn.chat.router_loop.call_llm_tools", _ScriptedLLM([text_result("just text")])
+    )
+    await loop.run("hi", [])
+
+    agent = [m for m in host.outbox if m["kind"] == "agent"]
+    assert [m["text"] for m in agent] == ["just text"]  # exactly one, no duplicate
+    assert not any(m["meta"].get("source") == "router_tool_turn_text" for m in agent)
+
+
+@pytest.mark.asyncio
+async def test_tool_turn_empty_content_skipped(monkeypatch):
+    """Tier 3a: a tool-turn with empty/whitespace content emits NO agent bubble on the
+    tool-turn (no empty-bubble noise) — only the terminal text appears."""
+    host = FakeRouterHost(skills=[{"name": "my_skill", "category": "general"}])
+    loop = make_loop(host)
+    script = [
+        _text_and_tool("   ", skill="my_skill"),  # whitespace-only content + tool_call
+        text_result("done"),
+    ]
+    monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _ScriptedLLM(script))
+    await loop.run("go", [])
+
+    agent = [m for m in host.outbox if m["kind"] == "agent"]
+    assert not any(m["meta"].get("source") == "router_tool_turn_text" for m in agent)
+    assert [m["text"] for m in agent] == ["done"]  # only the terminal text


### PR DESCRIPTION
**[e2e-coder]** — Closes #1642 (the owner-corrected target). NOTE: #1643 (args/result preview, merged) was a different read of the original ask; **this PR is the owner's actual #1642** — the assistant's text content accompanying tool_calls was dropped from the conversation.

## Root cause (flow-trace verified)
The Execute arm (`isinstance(interp, Execute)`) handles tool-turns and `continue`s; the only site emitting `result.content` to the outbox is the **no-tool_calls terminal** text-reply path (router_loop.py ~2638). So when an LLM response carries both tool_calls AND text content, the text is persisted to history but never displayed. (lead's root-cause line refs were pre-#1593 — the current dispatch is on `interp`, so the fix lands in the Execute arm, not a raw `if result.tool_calls:`.)

## Fix (producer, 1 site)
At the start of the Execute arm, BEFORE `_run_execute_round`, emit `put_outbox(kind="agent", text=result.content, meta={chain_id, source:"router_tool_turn_text"})` when content is non-empty:
- **before tool execution** → the text renders ahead of the tool rows (lifecycle_forwarder queues tool_call_started during the round)
- **empty/whitespace skipped** (no empty bubble)
- **no double-emit** (terminal path is no-tool_calls-only)
- **history persistence unchanged** (display-only addition)
- **consumer-side unchanged** — chainlit/TUI already render kind="agent"

## Test plan (Tier 3a, LLMReplay-driven, public outbox surface, no mocks)
- [x] content+tool_calls turn → agent bubble surfaced (+ terminal text, no regression)
- [x] no-tool_calls turn → content emitted once (no double-emit)
- [x] empty tool-turn content → skipped (no empty bubble)
- [x] existing router_loop suite green (83 passed); tier-audit --strict + ruff clean
- [ ] lead: review
- [ ] owner: visual confirm (the actual request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)