### PR TITLE
fix(1646): MCP tool args empty at call — kill invoke_action↔mcp_verbs `args` collision

### DIFF
--- a/docs/concepts/tools-integrations/mcp.ja.md
+++ b/docs/concepts/tools-integrations/mcp.ja.md
@@ -66,7 +66,7 @@ reyn mcp install --source https://github.com/modelcontextprotocol/servers/tree/m
 | `mcp__install_local({name, command, args})`                 | local command (LLM 生成 script 等) を直接 MCP server として登録 |
 | `mcp__list_servers()`                                       | `.reyn/mcp.yaml` に設定された全サーバー名を返す |
 | `mcp__list_tools({server})`                                 | 1 サーバーが露出する tool 一覧を `{name: "<server>__<tool>", description, inputSchema}` 形式で返す |
-| `mcp__call_tool({tool, args})`                              | `<server>__<tool>` ID + tool の declared args で tool を call |
+| `mcp__call_tool({tool, tool_args})`                              | `<server>__<tool>` ID + tool の declared tool_args で tool を call |
 | `mcp__drop_server({server})`                                | install 済サーバーを config から削除 |
 
 LLM router がチャット turn 内で直接これらを呼べます。 初回利用の典型 flow:

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -66,7 +66,7 @@ If you prefer to configure a server manually (or are adding a server not in the 
 | `mcp__install_local({name, command, args})`                 | Register a local command (e.g. LLM-authored script) as an MCP server |
 | `mcp__list_servers()`                                       | Returns the names of all servers configured in `.reyn/mcp.yaml` |
 | `mcp__list_tools({server})`                                 | Returns the tools exposed by one server (each entry has `name="<server>__<tool>"`, `description`, `inputSchema`) |
-| `mcp__call_tool({tool, args})`                              | Call a tool by `<server>__<tool>` identifier (from `mcp__list_tools`) with its declared args |
+| `mcp__call_tool({tool, tool_args})`                              | Call a tool by `<server>__<tool>` identifier (from `mcp__list_tools`) with its declared tool_args |
 | `mcp__drop_server({server})`                                | Remove an installed server from the config |
 
 The LLM router can call these directly during a chat turn. Typical first-time flow:

--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -74,7 +74,7 @@ hallucination 0/35)。
 | `mcp__install_local`    | local command (LLM 生成 script 等) を直接登録 |
 | `mcp__list_servers`     | install 済 server を列挙 |
 | `mcp__list_tools`     | 1 server の tool を `<server>__<tool>` ID で列挙 |
-| `mcp__call_tool`      | `<server>__<tool>` ID + `args` で tool を call |
+| `mcp__call_tool`      | `<server>__<tool>` ID + `tool_args` で tool を call |
 | `mcp__drop_server`    | install 済 server を削除 |
 
 ## Qualified-name format
@@ -183,7 +183,7 @@ invoke すると、 その種別の *canonical default operation* が走る:
 旧 `mcp.server` / `mcp.tool` の resource entry は削除。
 per-MCP-server / per-MCP-tool dispatch は `mcp` category 内の verb
 actions 経由 (= `mcp__list_tools` →
-`mcp__call_tool({tool: "<server>__<tool>", args})`) で flow する。
+`mcp__call_tool({tool: "<server>__<tool>", tool_args})`) で flow する。
 
 これにより LLM は `invoke_action("rag_corpus__meetings", {"query": "Q3
 roadmap"})` と書くだけで wrapper が `recall(sources=["meetings"],

--- a/docs/concepts/tools-integrations/universal-catalog.md
+++ b/docs/concepts/tools-integrations/universal-catalog.md
@@ -71,7 +71,7 @@ The `mcp` category provides six verb_object actions that cover the LLM-visible s
 | `mcp__install_local`    | Register a local command (e.g. LLM-authored script) as an MCP server |
 | `mcp__list_servers`     | Enumerate installed servers |
 | `mcp__list_tools`     | Enumerate one server's tools as `<server>__<tool>` ids |
-| `mcp__call_tool`      | Call a tool by `<server>__<tool>` id with `args` |
+| `mcp__call_tool`      | Call a tool by `<server>__<tool>` id with `tool_args` |
 | `mcp__drop_server`    | Remove an installed server |
 
 `exec` is gated by `is_exec_available()` — it only appears when a real
@@ -185,7 +185,7 @@ resource runs the *canonical default operation* for that kind:
 | `rag_corpus` | single-source recall |
 
 The previous `mcp.server` / `mcp.tool` resource entries are removed; per-MCP-server / per-MCP-tool dispatch now flows through the verb actions in the `mcp` category (= `mcp__list_tools` →
-`mcp__call_tool({tool: "<server>__<tool>", args})`).
+`mcp__call_tool({tool: "<server>__<tool>", tool_args})`).
 
 This means an LLM can say `invoke_action("rag_corpus__meetings",
 {"query": "Q3 roadmap"})` and the wrapper expands it to

--- a/docs/guide/for-users/popular-mcp-servers.md
+++ b/docs/guide/for-users/popular-mcp-servers.md
@@ -114,7 +114,7 @@ reyn chat
 > What time is it in Tokyo right now?
 ```
 
-The agent calls `mcp__call_tool({tool: "time__get_current_time", args:
+The agent calls `mcp__call_tool({tool: "time__get_current_time", tool_args:
 {timezone: "Asia/Tokyo"}})` and replies in natural language. For
 multi-timezone queries ("Tokyo, NYC, London"), the agent chains 3
 calls and synthesises one answer.
@@ -153,7 +153,7 @@ reyn chat
 > Summarise the last 3 commits in this repo.
 ```
 
-The agent calls `mcp__call_tool({tool: "git__git_log", args: {repo_path:
+The agent calls `mcp__call_tool({tool: "git__git_log", tool_args: {repo_path:
 "<session cwd>", max_count: 3}})` and produces a short summary.
 
 ### Tools surfaced
@@ -298,7 +298,7 @@ reyn chat
 > Use the everything MCP server to compute 17 plus 25.
 ```
 
-The agent calls `mcp__call_tool({tool: "everything__get-sum", args:
+The agent calls `mcp__call_tool({tool: "everything__get-sum", tool_args:
 {a: 17, b: 25}})` and reports the result. Success rate ≈ 90% on clean history.
 
 > Note: explicitly mentioning "the everything MCP server" in the

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -43,7 +43,7 @@ is handled by the caller per ADR-0026 M3 wave pattern.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Final, Mapping
 
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
@@ -90,6 +90,15 @@ _LIST_MCP_TOOLS_PARAMETERS: dict[str, Any] = {
     "required": ["server"],
 }
 
+# #1646: the target MCP tool's OWN parameters are carried under THIS key —
+# deliberately NOT "args". The universal-scheme live path wraps this verb in
+# invoke_action(action_name="mcp__call_tool", args={...}); a nested "args" here would
+# collide with invoke_action's own "args" (two same-named levels), which the LLM
+# collapsed (params flat beside server/mcp_tool_name, inner level dropped) → empty args
+# at the MCP call (owner-observed). A distinct key kills the collision by construction.
+# Single-sourced so the schema decl + both read sites (router + phase) cannot drift.
+_MCP_TOOL_ARGS_KEY: Final[str] = "tool_args"
+
 _CALL_MCP_TOOL_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -104,9 +113,16 @@ _CALL_MCP_TOOL_PARAMETERS: dict[str, Any] = {
                 "the enum. Use describe_mcp_tool for the full input schema."
             ),
         },
-        "args": {"type": "object"},
+        _MCP_TOOL_ARGS_KEY: {
+            "type": "object",
+            "description": (
+                "The target MCP tool's OWN parameters (the shape from "
+                "describe_mcp_tool), as a nested object here — NOT flat alongside "
+                "server / mcp_tool_name."
+            ),
+        },
     },
-    "required": ["server", "mcp_tool_name", "args"],
+    "required": ["server", "mcp_tool_name", _MCP_TOOL_ARGS_KEY],
 }
 
 _DESCRIBE_MCP_TOOL_PARAMETERS: dict[str, Any] = {
@@ -250,7 +266,7 @@ async def _handle_call_mcp_tool(
         # Dotted form "server.tool_name" → extract the bare tool name for MCPClient.
         # If the caller passed a bare name (no dot), use it as-is for compatibility.
         bare_tool = mcp_tool_name.split(".", 1)[-1] if "." in mcp_tool_name else mcp_tool_name
-        tool_args = dict(args.get("args") or {})
+        tool_args = dict(args.get(_MCP_TOOL_ARGS_KEY) or {})  # #1646: distinct key, no invoke_action collision
         return await host.mcp_call_tool(server, bare_tool, tool_args)
 
     # Phase path: build MCPIROp and dispatch through op_runtime.
@@ -264,7 +280,7 @@ async def _handle_call_mcp_tool(
     mcp_tool_name = str(args["mcp_tool_name"])
     # Dotted form → extract bare tool name for MCPIROp.
     tool = mcp_tool_name.split(".", 1)[-1] if "." in mcp_tool_name else mcp_tool_name
-    tool_args = dict(args.get("args") or {})
+    tool_args = dict(args.get(_MCP_TOOL_ARGS_KEY) or {})  # #1646: distinct key, no invoke_action collision
 
     op = MCPIROp(kind="mcp", server=server, tool=tool, args=tool_args)
 

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any, Mapping
 
+from reyn.tools.mcp import _MCP_TOOL_ARGS_KEY  # #1646: single-source the inner-args key
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # ── mcp__search_registry ──────────────────────────────────────────────────────
@@ -480,7 +481,11 @@ _MCP_CALL_TOOL_PARAMETERS: dict[str, Any] = {
                 "(e.g. 'time__get_current_time')."
             ),
         },
-        "args": {
+        # #1646: the target tool's params nest under "tool_args", NOT "args" — the
+        # universal-scheme live path is invoke_action(action_name="mcp__call_tool",
+        # args={tool, tool_args:{...}}); a nested "args" here collided with
+        # invoke_action's own "args" (the LLM collapsed it → empty at the MCP call).
+        _MCP_TOOL_ARGS_KEY: {
             "type": "object",
             "description": "Per-tool args dict (consult mcp__list_tools).",
         },
@@ -522,7 +527,10 @@ async def _handle_mcp_call_tool(
         {
             "server": server,
             "mcp_tool_name": mcp_tool_name,
-            "args": dict(args.get("args") or {}),
+            # #1646: read the LLM's params from tool_args (K3 collision-kill) AND pass
+            # them to mcp.py under the SAME key it now reads (K4 — pre-fix this passed
+            # "args" while mcp.py read tool_args → delegation dropped to {}).
+            _MCP_TOOL_ARGS_KEY: dict(args.get(_MCP_TOOL_ARGS_KEY) or {}),
         },
         ctx,
     )

--- a/tests/test_mcp_invoke_action_tool_args_1646.py
+++ b/tests/test_mcp_invoke_action_tool_args_1646.py
@@ -1,0 +1,86 @@
+"""Tier 3a: #1646 full-flow threading — MCP tool args reach the boundary non-empty.
+
+The load-bearing gate the isolated schema tests miss: drive the REAL universal-scheme
+wrapped path. The live MCP call is invoke_action(action_name="mcp__call_tool",
+args={tool:"<server>__<tool>", tool_args:{...}}) → resolve_invoke_action → mcp_verbs
+`_handle_mcp_call_tool` (splits the `<server>__<tool>` id, reads the renamed inner
+`tool_args`) → DELEGATES to mcp.py `_handle_call_mcp_tool` (also reads `tool_args`) →
+host.mcp_call_tool(server, tool, <params>). Assert the params arrive there NON-EMPTY with
+a NON-DEFAULT value (so a zeroing/unwired path can't pass silently).
+
+Pre-#1646 the inner key was `args` at BOTH mcp_verbs (LLM-facing) and the delegation,
+colliding with invoke_action's outer `args` → the LLM collapsed it (params flat, inner
+dropped) → empty at the MCP call (owner-observed). The distinct `tool_args` removes the
+collision AND keeps the cross-file (mcp_verbs→mcp.py) delegation key consistent.
+
+Real handlers + real ToolContext + a real Fake host (records the boundary call) — no
+mocks (mirrors test_describe_mcp_tool_handler).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.tools import get_default_registry
+from reyn.tools.types import RouterCallerState, ToolContext
+
+_NON_DEFAULT = "REYN_1646_NONDEFAULT_a7f3"  # distinctive → no silent default-pass
+
+
+class _RecordingMCPHost:
+    """A trivial echo MCP tool at the host.mcp_call_tool boundary — records what it gets."""
+
+    def __init__(self) -> None:
+        self.mcp_calls: list[dict] = []
+
+    async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+        self.mcp_calls.append({"server": server, "tool": tool, "args": dict(args)})
+        return {"status": "ok", "server": server, "tool": tool, "echo": dict(args)}
+
+
+def _ctx(host: _RecordingMCPHost) -> ToolContext:
+    return ToolContext(
+        caller_kind="router",
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        router_state=RouterCallerState(host=host),
+    )
+
+
+def _invoke_action(inner: dict, host: _RecordingMCPHost) -> dict:
+    handler = get_default_registry().lookup("invoke_action").handler
+    return asyncio.run(
+        handler({"action_name": "mcp__call_tool", "args": inner}, _ctx(host))
+    )
+
+
+def test_mcp_tool_args_reach_boundary_via_invoke_action():
+    """Tier 3a: #1646 — correctly-nested tool_args thread invoke_action → mcp_verbs →
+    mcp.py → host.mcp_call_tool with the NON-DEFAULT value intact (the renamed contract
+    + the cross-file delegation work end-to-end on the REAL wrapped path)."""
+    host = _RecordingMCPHost()
+    # The shape the renamed mcp_verbs schema asks for (the invoke_action-wrapped path):
+    # outer invoke_action args = {tool:"<server>__<tool>", tool_args:{<params>}}.
+    inner = {"tool": "web-search__search", "tool_args": {"query": _NON_DEFAULT}}
+    result = _invoke_action(inner, host)
+
+    assert "error" not in result, f"invoke_action returned error: {result}"
+    assert host.mcp_calls, "MCP boundary (host.mcp_call_tool) was never reached"
+    rec = host.mcp_calls[0]
+    # The target tool's params arrived non-empty, with the NON-DEFAULT value intact.
+    assert rec["args"] == {"query": _NON_DEFAULT}
+    assert rec["server"] == "web-search"
+    assert rec["tool"] == "search"
+
+
+def test_mcp_pre_fix_single_nest_would_drop_args():
+    """Tier 3a: #1646 contrast — the PRE-fix collapse (params flat in invoke_action's
+    args, NO inner tool_args level) yields EMPTY args at the MCP boundary = the
+    owner-observed failure. Documents WHY the distinct inner key matters."""
+    host = _RecordingMCPHost()
+    collapsed = {"tool": "web-search__search", "query": _NON_DEFAULT}  # no inner tool_args
+    result = _invoke_action(collapsed, host)
+    assert "error" not in result, f"invoke_action returned error: {result}"
+    assert host.mcp_calls, "MCP boundary was never reached"
+    # No inner tool_args ⇒ the tool runs with EMPTY args (the bug); query did NOT arrive.
+    assert host.mcp_calls[0]["args"] == {}

--- a/tests/test_mcp_unified.py
+++ b/tests/test_mcp_unified.py
@@ -50,11 +50,14 @@ def test_call_mcp_tool_router_render_exact_parameters():
     assert params["type"] == "object"
     assert "server" in params["properties"]
     assert "mcp_tool_name" in params["properties"]
-    assert "args" in params["properties"]
+    # #1646: the target tool's params nest under "tool_args" (NOT "args") to avoid the
+    # invoke_action-wrapper "args" collision; "args" must be gone.
+    assert "tool_args" in params["properties"]
+    assert "args" not in params["properties"]
     assert "tool" not in params["properties"], (
         "Legacy 'tool' param must be removed — FP-0032 renames to 'mcp_tool_name'"
     )
-    assert set(params["required"]) == {"server", "mcp_tool_name", "args"}
+    assert set(params["required"]) == {"server", "mcp_tool_name", "tool_args"}
 
 
 def test_call_mcp_tool_router_render_name():
@@ -207,7 +210,10 @@ def test_call_mcp_tool_render_for_phase_shape():
     assert "tool" not in rendered["args_schema"]["properties"], (
         "Legacy 'tool' key must not appear in render_for_phase — FP-0032 rename"
     )
-    assert rendered["args_schema"]["properties"]["args"] == {"type": "object"}
+    # #1646: tool_args (renamed from args) carries the target tool's params; type
+    # object, now with a guidance description (so check type, not exact equality).
+    assert "args" not in rendered["args_schema"]["properties"]
+    assert rendered["args_schema"]["properties"]["tool_args"]["type"] == "object"
     assert rendered["purity"] == "side_effect"
 
 
@@ -275,23 +281,24 @@ def test_registry_lookup_by_name():
 
 # ── 8. Polymorphic args contract for call_mcp_tool ───────────────────────────
 
-def test_call_mcp_tool_args_schema_accepts_object():
-    """Tier 2: call_mcp_tool args parameter schema is {"type": "object"}, making
-    the dynamic MCP tool space polymorphic — any JSON object can be passed as args.
-    This is the key invariant that allows arbitrary MCP servers/tools without
-    OS-level changes (P7 compliance)."""
+def test_call_mcp_tool_tool_args_schema_accepts_object():
+    """Tier 2: #1646 — call_mcp_tool's target-tool params nest under "tool_args" (renamed
+    from "args" to avoid the invoke_action-wrapper collision), schema type "object" — the
+    dynamic MCP tool space stays polymorphic (any JSON object). P7-compliant (arbitrary
+    MCP servers/tools, no OS-level changes)."""
     params = dict(CALL_MCP_TOOL.parameters)
-    assert params["properties"]["args"] == {"type": "object"}
+    assert "args" not in params["properties"]
+    assert params["properties"]["tool_args"]["type"] == "object"
     # No additionalProperties constraint — fully open to arbitrary MCP tool args
-    assert "additionalProperties" not in params["properties"]["args"]
+    assert "additionalProperties" not in params["properties"]["tool_args"]
 
 
 def test_call_mcp_tool_required_fields():
     """Tier 2: call_mcp_tool requires exactly server + mcp_tool_name + args
     (FP-0032 vocabulary: 'tool' renamed to 'mcp_tool_name')."""
     params = dict(CALL_MCP_TOOL.parameters)
-    assert set(params["required"]) == {"server", "mcp_tool_name", "args"}, (
-        "FP-0032: 'tool' must be replaced by 'mcp_tool_name' in required fields"
+    assert set(params["required"]) == {"server", "mcp_tool_name", "tool_args"}, (
+        "FP-0032: 'tool'→'mcp_tool_name'; #1646: 'args'→'tool_args' (collision-kill)"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** — Fixes the owner-observed bug: **MCP tool args are correct in the `tool_call` but EMPTY at the MCP call.**

## Root cause (confirm-repro-first; full-flow gate, not reading)

The bug lives on the `invoke_action`-wrapped path. `mcp_call_tool` (mcp_verbs) advertised its target-tool params under the inner key **`args`**, which collides with `invoke_action`'s OWN outer **`args`**. The LLM collapses the two levels — the target params land flat alongside `tool`, and the inner object is dropped → **empty params at the MCP boundary**.

Isolated schema probes couldn't reproduce it (the single-nest is context-dependent). A **load-bearing full-flow test** on the real wrapped path is what pins it.

## Fix (rename-only; by-construction)

| | change |
|---|---|
| **K3** (the collision-kill) | mcp_verbs `mcp_call_tool` LLM-facing inner key `args`→`tool_args` (schema + read). Distinct from `invoke_action`'s outer `args`, so the nest can't collapse. |
| **K4** (regression WIP 1/2 introduced) | the mcp_verbs→mcp.py delegation passed `"args"` while mcp.py (post WIP 1/2) reads `tool_args` → delegation dropped to `{}`. Now passes `tool_args`. |
| **single-source** | mcp_verbs imports `_MCP_TOOL_ARGS_KEY` from mcp.py so the four inner-key sites across both files can't drift. |

WIP 1/2 (`922a3d6c`, mcp.py inner rename + const) was right but incomplete — it missed both mcp_verbs sites. This PR completes it.

## Verification — load-bearing full-flow gate

`tests/test_mcp_invoke_action_tool_args_1646.py` drives the REAL path:
`invoke_action(action_name="mcp__call_tool", args={tool:"<server>__<tool>", tool_args:{...}})` → mcp_verbs → mcp.py → `host.mcp_call_tool`, asserting a **NON-DEFAULT value round-trips to the MCP boundary non-empty**. A contrast test pins that the pre-fix collapse (flat params, no inner level) yields empty args = the owner-observed failure.

- `pytest -k mcp`: **489 passed, 1 skipped**
- `test_tier_audit --strict` (new test): **0 errors**
- `ruff check .`: **clean**

## Consumer audit (complete)
- code: `mcp.py` + `mcp_verbs.py` (both inner-key sites + delegation)
- describe: registry renders `tool_args` on the LLM-facing schema
- docs: `popular-mcp-servers`, `mcp[.ja]`, `universal-catalog[.ja]` off the stale `{tool, args}`
- tests: `test_mcp_unified` + the new full-flow gate

The two-handler smell (`call_mcp_tool {server,mcp_tool_name}` mcp.py vs `mcp_call_tool {tool}` mcp_verbs — duplicate surfaces, different shapes) is **deferred to #1647** (not consolidated here; this PR = collision-kill + regression-fix).

Refs #1646

## Test plan
- [x] full-flow gate: non-default tool_args round-trips to MCP boundary (2/2 pass)
- [x] `pytest -k mcp` no regression (489 pass)
- [x] tier-audit --strict + ruff clean
- [x] docs consumers updated off stale `{tool, args}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
