### PR TITLE
feat(1650): per-model reasoning_effort reyn.yaml field (validated, proxy-safe)

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -117,12 +117,34 @@ models:
 | `max_tokens` | いいえ | レガシーのソフトヒント — 多くのプロバイダーが無視する。`max_completion_tokens` を推奨。 |
 | `top_p` | いいえ | litellm に渡す top-p サンプリング。 |
 | `extra_body` | いいえ | プロバイダー固有のペイロード（例：推論モデルの `thinking`）。 |
+| `reasoning_effort` | いいえ | モデルの推論バジェット: `minimal` / `low` / `medium` / `high` / `disable` / `none`。**ロード時にバリデーション**（下記参照）。 |
 | `extends` | いいえ | 名前付きクラスから継承し、オーバーライドを deep merge（下記参照）。 |
 | *（その他のフィールド）* | いいえ | litellm にそのまま渡されます（パススルーポリシー）。 |
 
 > **コスト制限**: `max_tokens` ではなく `max_completion_tokens` を使用してください。`max_tokens` は多くのプロバイダーが無視するレガシーのソフトヒントです。`max_completion_tokens` は API レベルで強制されます（OpenAI o1+ および Anthropic モデル）。
 
-**フィールドポリシー**: `model` のみ必須です。他のフィールドはすべてバリデーションなしで `litellm.acompletion` に直接渡されます（未知のフィールドも silent に転送されます — future-proof）。タイポは reyn エラーではなく silent な litellm 失敗を引き起こします。
+**フィールドポリシー**: `model` のみ必須です。ほとんどのフィールドはバリデーションなしで `litellm.acompletion` に直接渡されます（未知のフィールドも silent に転送されます — future-proof）。タイポは reyn エラーではなく silent な litellm 失敗を引き起こします。唯一の例外は `reasoning_effort` で、ロード時にバリデーションされます（下記）。
+
+### `reasoning_effort`（モデルごとの推論バジェット）
+
+モデルが回答前にどれだけ「思考」するかを設定します。分かりやすさのためモデル定義ごとに宣言します:
+
+```yaml
+models:
+  light:
+    model: gemini-flash-lite
+    reasoning_effort: low      # minimal | low | medium | high | disable | none
+```
+
+- **有効な値**: `minimal`, `low`, `medium`, `high`, `disable`, `none`。無効な値は litellm の呼び出し中ではなく**コンフィグロード時に fail-fast**（不正値を示す明確な `ValueError`）。
+- **ネイティブマッピング**: 値は litellm にネイティブに渡され、プロバイダー自身の推論バジェットにマッピングされます。Gemini（例: `gemini-2.5-flash-lite`）では: `low` → thinking budget 1024、`medium` → 2048、`high` → 4096、`minimal` → モデル固有（flash-lite は 512）、`disable` / `none` → 0。手書きの `extra_body` は不要です。
+- **`extra_body` の thinking 設定とは排他**: `reasoning_effort` *が* thinking-budget の制御なので、同一モデルに `reasoning_effort` と `extra_body` の thinking 設定の両方を宣言すると**ロード時に reject**されます（どちらか一方を選択）。
+
+> **既知の挙動 — 推論テキストは表示されません。** 非ゼロの `reasoning_effort` はプロバイダーの `includeThoughts=true` を設定するため、レスポンスに推論／思考テキストが含まれます。reyn は現在、推論 vs 出力の**トークン数**の内訳のみを記録し、推論テキスト自体は捕捉・表示しません。したがって `reasoning_effort` を有効にすると、思考を表示せずに推論トークンのコストが発生します。
+
+> **既知の挙動 — tool-use パスで thinking が再有効化されます。** reyn は thinking を強制 off にせず、プロバイダーのデフォルト（Gemini 2.5 は off）に従います。`reasoning_effort` を設定すると thinking が on になり、Gemini で以前 parallel-tools + thinking の相互作用があったマルチターン tool-use パス（Gemini #17949）でも有効になります。tool-heavy なエージェントで有効化する場合はモデルの挙動を検証してください。
+
+> **プロキシ経由（openai 互換）での透過**: litellm プロキシ経由でルーティングする場合、reyn は `reasoning_effort` を `allowed_openai_params` でホワイトリスト化し、プロキシに転送します（プロキシがプロバイダーのネイティブ thinking budget にマッピング）。追加設定は不要です。
 
 **Skill / Phase 側オーバーライド**: サポートしていません。Operator config（`reyn.yaml`）が LLM パラメータの唯一の source of truth です。Skill 作者はクラス名のみを指定します（例：`model_class: strong`）。
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -120,6 +120,7 @@ models:
 | `max_tokens` | no | Legacy soft hint — ignored by many providers. Prefer `max_completion_tokens`. |
 | `top_p` | no | Top-p sampling passed to litellm. |
 | `extra_body` | no | Provider-specific payload (e.g. `thinking` for reasoning models). |
+| `reasoning_effort` | no | Reasoning budget for the model: `minimal` / `low` / `medium` / `high` / `disable` / `none`. **Validated at load** (see below). |
 | `extends` | no | Inherit from a named class and deep-merge overrides (see below). |
 | *(any other field)* | no | Silently passed through to litellm (passthrough policy). |
 
@@ -127,7 +128,48 @@ models:
 > soft hint that many providers ignore; it has no enforcement power on OpenAI o1+ or
 > Anthropic models.  `max_completion_tokens` is enforced at the API level.
 
-**Field policy**: `model` is the only required field. All other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof). Typos cause silent litellm failures, not reyn errors.
+**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. The one exception is `reasoning_effort`, which is validated at load (below).
+
+### `reasoning_effort` (per-model reasoning budget)
+
+Set how much the model is allowed to "think" before answering. Declared per model
+definition so it's explicit and easy to understand:
+
+```yaml
+models:
+  light:
+    model: gemini-flash-lite
+    reasoning_effort: low      # minimal | low | medium | high | disable | none
+```
+
+- **Valid values**: `minimal`, `low`, `medium`, `high`, `disable`, `none`. An invalid
+  value **fails fast at config load** (a clear `ValueError` naming the bad value), not
+  mid-call inside litellm.
+- **Native mapping**: the value is passed through natively to litellm, which maps it to
+  the provider's own reasoning budget. For Gemini (e.g. `gemini-2.5-flash-lite`):
+  `low` → thinking budget 1024, `medium` → 2048, `high` → 4096, `minimal` →
+  model-specific (512 for flash-lite), `disable` / `none` → 0. No hand-rolled
+  `extra_body` needed.
+- **Mutually exclusive with an `extra_body` thinking config**: `reasoning_effort` *is* the
+  thinking-budget control, so declaring both `reasoning_effort` and an `extra_body`
+  thinking config on the same model is **rejected at load** (pick one).
+
+> **Known behavior — reasoning text is not surfaced.** A non-zero `reasoning_effort`
+> sets the provider's `includeThoughts=true`, so the response carries reasoning/thought
+> text. Reyn currently records only the reasoning-vs-output **token-count** split — it
+> does **not** capture or display the reasoning text itself. Enabling `reasoning_effort`
+> therefore costs reasoning tokens without surfacing the thoughts.
+
+> **Known behavior — re-enables thinking on the tool-use path.** Reyn does not force
+> thinking off; it relies on the provider default (off for Gemini 2.5). Setting
+> `reasoning_effort` turns thinking on, including on the multi-turn tool-use path where
+> Gemini previously had a parallel-tools + thinking interaction (Gemini #17949). Verify
+> behavior on your model if you enable it for a tool-heavy agent.
+
+> **Proxy passthrough (openai-compat).** When routing through a litellm proxy, reyn
+> whitelists `reasoning_effort` via `allowed_openai_params` so it is forwarded to the
+> proxy (which maps it to the provider's native thinking budget) instead of being
+> rejected as an unsupported OpenAI param. No extra configuration needed.
 
 **Skill / phase override**: NOT supported. Operator config (`reyn.yaml`) is the single source of truth for LLM parameters. Skill authors specify class names only (e.g. `model_class: strong`).
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -901,6 +901,21 @@ async def recorded_acompletion(
     base_kwargs = dict(extra_kwargs or {})
     base_kwargs.update(extra)  # Reyn proxy kwargs win over caller-supplied ones
 
+    # #1650: when an operator sets ``reasoning_effort`` on a model, the proxy
+    # path forces ``custom_llm_provider=openai`` (proxy_kwargs), under which
+    # litellm validates params against OpenAI and REJECTS ``reasoning_effort``
+    # as unsupported for a gemini model name BEFORE forwarding to the proxy
+    # (UnsupportedParamsError). Whitelisting it via ``allowed_openai_params``
+    # makes litellm forward it to the proxy, which maps it to the provider's
+    # native thinking budget. Verified live (#1650 proxy smoke: reasoning_tokens
+    # 0 → ~420). Harmless on the direct path where reasoning_effort is already
+    # a native gemini param. Single chokepoint = covers call_llm + call_llm_tools.
+    if "reasoning_effort" in base_kwargs:
+        _allowed = list(base_kwargs.get("allowed_openai_params") or [])
+        if "reasoning_effort" not in _allowed:
+            _allowed.append("reasoning_effort")
+        base_kwargs["allowed_openai_params"] = _allowed
+
     async def _once(rf: dict | None) -> object:
         call_kwargs = dict(base_kwargs)
         if rf is not None:

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -27,6 +27,16 @@ from reyn.llm.builtin_models import BUILTIN_MODELS
 #: The three standard model tiers. Users should map these in reyn.yaml.
 STANDARD_CLASSES = ("light", "standard", "strong")
 
+#: #1650: valid values for the per-model ``reasoning_effort`` field. These are
+#: litellm's accepted reasoning-effort levels for the gemini provider, each of
+#: which maps to a native thinking budget (low→1024, medium→2048, high→4096,
+#: minimal→model-specific, disable/none→0; verified live against litellm 1.84.0
+#: gemini/gemini-2.5-flash-lite). Validated at config-load (fail-fast) so a typo
+#: surfaces at startup instead of raising mid-call inside litellm.
+VALID_REASONING_EFFORTS: frozenset = frozenset(
+    {"minimal", "low", "medium", "high", "disable", "none"}
+)
+
 
 @dataclass(frozen=True)
 class ModelSpec:
@@ -41,6 +51,40 @@ class ModelSpec:
 
     model: str
     kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # #1650: validate the operator-declared ``reasoning_effort`` at
+        # config-load (fail-fast) rather than letting an invalid value reach
+        # litellm and raise mid-call. The value itself rides the existing
+        # ``kwargs`` passthrough to litellm.acompletion (call_llm:1155 /
+        # call_llm_tools:1359), which maps it to the provider's native thinking
+        # budget — we only gate the value set + the conflicting-config combo.
+        # Placed here (not in from_config) so BOTH the plain-dict path and the
+        # extends-merge path (which build ModelSpec directly) are covered
+        # by-construction — single validation site, no parallel drift.
+        effort = self.kwargs.get("reasoning_effort")
+        if effort is None:
+            return
+        if not isinstance(effort, str) or effort not in VALID_REASONING_EFFORTS:
+            raise ValueError(
+                f"models reasoning_effort must be one of "
+                f"{sorted(VALID_REASONING_EFFORTS)}, got {effort!r} "
+                f"(model={self.model!r})"
+            )
+        # Both-set reject: reasoning_effort already maps to a native thinking
+        # budget, so a hand-set extra_body thinking config is a contradictory
+        # second control (litellm raises UnsupportedParamsError on a
+        # thinking_level+budget conflict). Reject at load so the operator picks
+        # exactly one.
+        extra_body = self.kwargs.get("extra_body")
+        if isinstance(extra_body, dict) and (
+            "thinking_config" in extra_body or "thinkingConfig" in extra_body
+        ):
+            raise ValueError(
+                f"models cannot set both reasoning_effort and an extra_body "
+                f"thinking config (model={self.model!r}); reasoning_effort "
+                f"already maps to the native thinking budget — set only one."
+            )
 
     @classmethod
     def from_config(cls, value: object) -> "ModelSpec":

--- a/tests/test_reasoning_effort_config_1650.py
+++ b/tests/test_reasoning_effort_config_1650.py
@@ -1,0 +1,186 @@
+"""#1650: per-model ``reasoning_effort`` reyn.yaml field.
+
+The feature is sugar+validation over the existing ModelSpec.kwargs passthrough:
+``reasoning_effort`` declared on a model def lands in ``spec.kwargs`` and rides
+the established passthrough to ``litellm.acompletion`` (which maps it to the
+provider's native thinking budget — verified live against litellm 1.84.0
+gemini). We add load-time validation (fail-fast on a typo) + a both-set reject.
+
+Tiers:
+- config-parse round-trip + validation = Tier 1 (the ModelSpec config contract).
+- "the non-default value ARRIVES at the litellm boundary, not silently dropped"
+  = Tier 2 (the operator-kwargs-reach-the-provider-call invariant; the #1646
+  silently-dropped-key lesson).
+
+No mocks: the litellm boundary is a real async callable stub (testing policy),
+monkeypatched in, that records the kwargs it receives.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.llm.model_resolver import (
+    VALID_REASONING_EFFORTS,
+    ModelResolver,
+    ModelSpec,
+)
+
+_NON_DEFAULT = "medium"  # not the provider default (thinking off); distinctive
+
+
+# ── Tier 1: config-parse round-trip ────────────────────────────────────────
+
+
+def test_reasoning_effort_round_trips_from_config_into_kwargs():
+    """Tier 1: #1650 — a model def's ``reasoning_effort`` lands in spec.kwargs
+    (the existing passthrough vehicle), round-tripping a NON-DEFAULT value."""
+    spec = ModelSpec.from_config(
+        {"model": "gemini/gemini-2.5-flash-lite", "reasoning_effort": _NON_DEFAULT}
+    )
+    assert spec.kwargs.get("reasoning_effort") == _NON_DEFAULT
+    assert spec.model == "gemini/gemini-2.5-flash-lite"
+
+
+def test_reasoning_effort_round_trips_through_resolver_startup():
+    """Tier 1: #1650 — the value survives ModelResolver resolution (startup) for
+    a tier mapping, the path a real reyn.yaml ``models.light`` takes."""
+    r = ModelResolver(
+        {"light": {"model": "gemini/gemini-2.5-flash-lite", "reasoning_effort": "low"}}
+    )
+    assert r.resolve("light").kwargs.get("reasoning_effort") == "low"
+
+
+# ── Tier 1: load-time validation (fail-fast) ────────────────────────────────
+
+
+def test_invalid_reasoning_effort_rejected_at_construction():
+    """Tier 1: #1650 — an invalid value fails fast at ModelSpec construction
+    (config-load), not mid-call inside litellm."""
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        ModelSpec(model="gemini/x", kwargs={"reasoning_effort": "bogus"})
+
+
+def test_invalid_reasoning_effort_rejected_at_resolver_startup():
+    """Tier 1: #1650 — the fail-fast also fires through the resolver startup
+    path (a real reyn.yaml typo surfaces at load, with the offending value)."""
+    with pytest.raises(ValueError, match="bogus"):
+        ModelResolver({"light": {"model": "gemini/x", "reasoning_effort": "bogus"}})
+
+
+@pytest.mark.parametrize("effort", sorted(VALID_REASONING_EFFORTS))
+def test_all_valid_reasoning_efforts_accepted(effort: str):
+    """Tier 1: #1650 — every advertised valid value is accepted (no false
+    reject narrowing the contract below what litellm supports)."""
+    spec = ModelSpec(model="gemini/x", kwargs={"reasoning_effort": effort})
+    assert spec.kwargs["reasoning_effort"] == effort
+
+
+def test_reasoning_effort_and_extra_body_thinking_config_rejected():
+    """Tier 1: #1650 — reasoning_effort already maps to a thinking budget, so a
+    second hand-set extra_body thinking config is a contradictory control and is
+    rejected at load (litellm would otherwise raise on the conflict mid-call)."""
+    with pytest.raises(ValueError, match="cannot set both reasoning_effort"):
+        ModelSpec(
+            model="gemini/x",
+            kwargs={
+                "reasoning_effort": "low",
+                "extra_body": {"thinking_config": {"thinking_budget": 0}},
+            },
+        )
+
+
+def test_no_reasoning_effort_is_unaffected():
+    """Tier 1: #1650 — a model def without reasoning_effort is unchanged (the
+    validation is a no-op; the passthrough policy for other kwargs is intact)."""
+    spec = ModelSpec(model="gemini/x", kwargs={"temperature": 0.2})
+    assert spec.kwargs == {"temperature": 0.2}
+
+
+# ── Tier 2: the value ARRIVES at the litellm boundary (not dropped) ─────────
+
+
+def _fake_litellm_response():
+    msg = type("_Msg", (), {"content": "ok", "tool_calls": None})()
+    choice = type("_Choice", (), {"message": msg, "finish_reason": "stop"})()
+    usage = type("_Usage", (), {"prompt_tokens": 10, "completion_tokens": 5})()
+    return type("_Resp", (), {"choices": [choice], "usage": usage})()
+
+
+class _CapturingLLM:
+    """Real async callable stub (testing policy) recording the kwargs it gets."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        return _fake_litellm_response()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_arrives_at_litellm_call(monkeypatch):
+    """Tier 2: #1650 — a NON-DEFAULT reasoning_effort declared on the model def
+    threads through the REAL call_llm_tools (the chat/router path) and ARRIVES in
+    the kwargs handed to litellm.acompletion — not silently dropped (#1646
+    lesson). The litellm boundary is a real capturing async stub."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    stub = _CapturingLLM()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+
+    spec = ModelSpec(
+        model="gemini/gemini-2.5-flash-lite",
+        kwargs={"reasoning_effort": _NON_DEFAULT},
+    )
+    await call_llm_tools(
+        model=spec,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_retries=0,
+    )
+
+    assert stub.calls, "litellm.acompletion was never reached"
+    assert stub.calls[0].get("reasoning_effort") == _NON_DEFAULT, (
+        f"reasoning_effort was dropped before the litellm call; "
+        f"got kwargs keys: {sorted(stub.calls[0])}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_whitelisted_for_proxy_passthrough(monkeypatch):
+    """Tier 2: #1650 — on the openai-compat PROXY path, reasoning_effort must be
+    whitelisted via allowed_openai_params or litellm rejects it as an unsupported
+    openai param BEFORE forwarding (UnsupportedParamsError; caught by the live
+    proxy smoke, not by the monkeypatch which bypasses litellm validation). This
+    pins that the whitelist is threaded so the proxy receives + maps it."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    monkeypatch.setenv("LITELLM_API_BASE", "http://localhost:4000")  # engage proxy path
+    stub = _CapturingLLM()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+
+    spec = ModelSpec(
+        model="gemini/gemini-2.5-flash-lite",
+        kwargs={"reasoning_effort": _NON_DEFAULT},
+    )
+    await call_llm_tools(
+        model=spec,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_retries=0,
+    )
+
+    assert stub.calls, "litellm.acompletion was never reached"
+    kw = stub.calls[0]
+    assert kw.get("reasoning_effort") == _NON_DEFAULT
+    assert "reasoning_effort" in (kw.get("allowed_openai_params") or []), (
+        f"reasoning_effort not whitelisted for proxy forwarding; the proxy path "
+        f"would raise UnsupportedParamsError. allowed_openai_params="
+        f"{kw.get('allowed_openai_params')!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Owner feature: native, config-settable `reasoning_effort` per model definition. Implements approved **design (B)** — a validated recognized field over the existing `ModelSpec.kwargs` passthrough.

## What it does
```yaml
models:
  light:
    model: gemini-flash-lite
    reasoning_effort: low      # minimal | low | medium | high | disable | none
```
- **Validation (fail-fast)**: `ModelSpec.__post_init__` validates the value at config-load — an invalid value raises a clear `ValueError` at startup, not mid-call inside litellm. Setting both `reasoning_effort` and an `extra_body` thinking config is rejected (contradictory controls). Placed in `__post_init__` so **both** the plain-dict and extends-merge construction paths are covered by-construction (single validation site, no parallel drift).
- **Native passthrough**: the value lands in `spec.kwargs` and rides the established passthrough to `litellm.acompletion`, which maps it to the provider's native thinking budget (verified live, litellm 1.84.0 gemini: `low`→1024, `medium`→2048, `high`→4096, `minimal`→512 flash-lite, `disable`/`none`→0).

## Proxy passthrough — the load-bearing live-smoke caught this
reyn's proxy path forces `custom_llm_provider=openai`, under which litellm **rejects** `reasoning_effort` as an unsupported OpenAI param for a gemini model name *before* forwarding (`UnsupportedParamsError`). The monkeypatched unit test could not catch this (it bypasses litellm validation) — only the live proxy smoke did. Fix: `recorded_acompletion` (the single litellm chokepoint, covering `call_llm` + `call_llm_tools`) now whitelists it via `allowed_openai_params` when set, so litellm forwards it to the proxy, which maps it.

**Live proxy smoke (gate #1):** reasoning_tokens `0` (baseline) → `~420` (effort=low) through the owner's proxy → gemini. ✓

## Corrections to the original design premises (primary-source, confirm-first)
- **No `thinking_budget=0` collision on the light model** — that config is on the untiered `gemini-2.0-flash`, not `gemini-flash-lite`; the call path forces only `stream=False`. Precedence is trivial.
- **Already settable via long-form kwargs** — the real gap was the short-form mapping + no validation + discoverability (+ the proxy block above).

## Known behaviors documented (NOT scope-crept into capture, per lead)
- `includeThoughts=true` → response carries reasoning text; reyn records only the token-count split, does not surface the reasoning text.
- Re-enables thinking on the tool-use path (Gemini #17949 context).

Refs #1650

## Test plan
- [x] config round-trip (non-default value) → spec.kwargs + through resolver startup
- [x] load-validation fail-fast (direct ModelSpec + resolver startup; invalid → ValueError)
- [x] all valid values accepted (no false reject); both-set reject
- [x] arrives at litellm.acompletion (the #1646 dropped-key lesson)
- [x] proxy whitelist (`allowed_openai_params`) threaded on the openai-compat path
- [x] **live proxy smoke**: reasoning_tokens 0→~420 reyn→proxy→gemini (gate #1)
- [x] 1126 LLM/replay/model/router regression pass; tier-audit + ruff clean
- [x] docs: reyn-yaml.md + .ja.md (field + valid values + native mapping + both known behaviors + proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
