### PR TITLE
fix(1654): chat router honors per-model kwargs (reasoning_effort) + reasoning ON by default

### DIFF
--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -80,25 +80,42 @@ OpenAI GPT-4o.  Strong general-purpose model.
 
 ```yaml
 model: gemini/gemini-2.5-flash-lite
+reasoning_effort: low      # #1654: reasoning ON by default
 ```
 
-Google Gemini 2.5 Flash Lite.  Very low cost.
+Google Gemini 2.5 Flash Lite.  Very low cost. Ships with `reasoning_effort: low`
+so reasoning/thinking is **on out of the box** (see the reasoning note below).
 
 ### `gemini-pro`
 
 ```yaml
 model: gemini/gemini-2.5-pro
+reasoning_effort: medium   # #1654: reasoning ON by default
 ```
 
-Google Gemini 2.5 Pro.  High capability, suitable for strong-tier tasks.
+Google Gemini 2.5 Pro.  High capability, suitable for strong-tier tasks. Ships
+with `reasoning_effort: medium`.
 
 ### `gemini-3.1-flash-preview`
 
 ```yaml
 model: gemini/gemini-3.1-flash-preview
+reasoning_effort: low      # #1654: reasoning ON by default
 ```
 
-Google Gemini 3.1 Flash Preview.
+Google Gemini 3.1 Flash Preview. Ships with `reasoning_effort: low`.
+
+> **Reasoning on by default (#1654)** — the Gemini reasoning models above ship
+> with a default `reasoning_effort`, and `chat.reasoning.{capture,display,
+> continuity}` default on, so the model's reasoning text is produced, shown
+> (collapsible), and carried across turns out of the box. **Cost note**: thinking
+> tokens add to spend (low ≈ 1024, medium ≈ 2048 thinking-budget tokens/turn). To
+> turn it off, set `reasoning_effort: none` on the model (or `disable`), or keep
+> the budget but hide the text with `chat.reasoning.display: false`. **OpenAI-family
+> caveat**: OpenAI reasoning models (o-series / GPT-5) often do NOT expose raw
+> reasoning text (it is summarized/encrypted) — there `reasoning_effort` still
+> controls the budget but the text display may be empty; prefer a Gemini model
+> for visible reasoning text.
 
 ### `gemini-2.0-flash`
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -153,12 +153,30 @@ models:
 - **Mutually exclusive with an `extra_body` thinking config**: `reasoning_effort` *is* the
   thinking-budget control, so declaring both `reasoning_effort` and an `extra_body`
   thinking config on the same model is **rejected at load** (pick one).
+- **OpenAI summary opt-in (dict form)**: OpenAI reasoning models (o-series / GPT-5)
+  do **not** return raw reasoning text — they encrypt the chain and expose only an
+  optional *summary*, which is **opt-in**. For those models pass the dict form to
+  request the summary text:
+  ```yaml
+  models:
+    strong:
+      model: openai/gpt-5
+      reasoning_effort:
+        effort: medium      # the budget level (validated, same set as above)
+        summary: detailed   # opt into summary text → rides into reasoning_content
+  ```
+  litellm's GPT-5 transformation reads `{effort, summary}`. **Provider difference**:
+  Gemini exposes raw reasoning text natively from the string form; OpenAI needs the
+  dict + `summary` for any text (and even then it is a summary, not the raw chain).
+  Without `summary`, an OpenAI model's `reasoning_effort` still controls the budget
+  but no reasoning text is displayed.
 
-> **Known behavior — reasoning text is not surfaced.** A non-zero `reasoning_effort`
-> sets the provider's `includeThoughts=true`, so the response carries reasoning/thought
-> text. Reyn currently records only the reasoning-vs-output **token-count** split — it
-> does **not** capture or display the reasoning text itself. Enabling `reasoning_effort`
-> therefore costs reasoning tokens without surfacing the thoughts.
+> **Reasoning text IS captured, displayed, and replayed (#1652).** A non-zero
+> `reasoning_effort` sets the provider's `includeThoughts=true`; reyn captures the
+> reasoning text, displays it (TUI + chainlit, collapsible — `chat.reasoning.display`),
+> and replays recent turns' reasoning into the next prompt (`chat.reasoning.continuity`).
+> See the [`chat` block](#chat-block) for the toggles. (For OpenAI models the displayed
+> text is the *summary* and only when the dict `summary` opt-in is set — see above.)
 
 > **Known behavior — re-enables thinking on the tool-use path.** Reyn does not force
 > thinking off; it relies on the provider default (off for Gemini 2.5). Setting

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1872,6 +1872,20 @@ class RouterLoop:
                 _loop_cancelled = True
                 break
             resolved_model = host.resolve_model(self.router_model)
+            # #1654: the FULL ModelSpec (model + operator kwargs) for the LLM
+            # call below, so per-model kwargs (reasoning_effort #1650/#1652,
+            # temperature, extra_body, …) reach litellm. resolve_model returns
+            # the bare string (kwargs dropped) — fine for the model-NAME params
+            # (compaction / force-close / memo-key / events) which keep
+            # resolved_model, but the actual call_llm_tools must get the spec.
+            # Host-polymorphic: phase/test hosts without resolve_model_spec fall
+            # back to a kwargs-less spec = byte-identical to the prior behaviour.
+            _spec_fn = getattr(host, "resolve_model_spec", None)
+            if _spec_fn is not None:
+                resolved_spec = _spec_fn(self.router_model)
+            else:
+                from reyn.llm.model_resolver import ModelSpec
+                resolved_spec = ModelSpec(model=resolved_model, kwargs={})
             # #1092 PR-C-5 (2): per-turn phase wall-clock budget enforcement. A phase
             # host implements ``check_phase_budget`` (RAISES PhaseBudgetExceededError
             # when over budget, unless on_limit grants an extension) — the same
@@ -1977,7 +1991,10 @@ class RouterLoop:
                     # production callers don't have to know about the seam.
                     _llm = self._llm_caller or call_llm_tools
                     result = await _llm(
-                        model=resolved_model,
+                        # #1654: pass the FULL ModelSpec (not the bare string) so
+                        # per-model kwargs (reasoning_effort/temperature/…) reach
+                        # litellm; call_llm_tools accepts Union[str, ModelSpec].
+                        model=resolved_spec,
                         messages=messages,
                         tools=tools,
                         tool_choice="auto",

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -999,6 +999,15 @@ class RouterHostAdapter:
         """Resolve config model name (e.g. 'router') to actual model id."""
         return self._resolver.resolve(name).model
 
+    def resolve_model_spec(self, name: str) -> "Any":
+        """#1654: resolve a config model name to the FULL ModelSpec (model +
+        operator kwargs). The chat router must pass this to call_llm_tools so
+        per-model kwargs (reasoning_effort, temperature, extra_body, …) reach
+        litellm. ``resolve_model`` returns the bare ``.model`` string, DROPPING
+        those kwargs — which left reasoning_effort (#1650/#1652) and every model
+        kwarg inert on the chat-router path."""
+        return self._resolver.resolve(name)
+
     def context_window_status(self) -> "dict | None":
         """#272/#1128: live exact-token context budget for the SP context-size
         signal, or None when no provider is wired (= signal omitted)."""

--- a/src/reyn/llm/builtin_models.py
+++ b/src/reyn/llm/builtin_models.py
@@ -49,9 +49,19 @@ BUILTIN_MODELS: dict[str, dict] = {
     # -------------------------------------------------------------------------
     # Gemini  (gemini/ prefix = correct litellm catalog lookup → 1M context)
     # -------------------------------------------------------------------------
-    "gemini-flash-lite": {"model": "gemini/gemini-2.5-flash-lite"},
-    "gemini-pro": {"model": "gemini/gemini-2.5-pro"},
-    "gemini-3.1-flash-preview": {"model": "gemini/gemini-3.1-flash-preview"},
+    # #1654: reasoning ON by default (out-of-box) — reasoning_effort maps to the
+    # provider's native thinking budget (low→1024, medium→2048; verified live via
+    # the litellm proxy: reasoning_content text exposed). Capture + display +
+    # cross-turn continuity are config-default-ON (chat.reasoning); this default
+    # makes the model actually produce reasoning so the feature works without
+    # operator config. Cost note: thinking tokens add to spend — operators who
+    # want it off set `reasoning_effort: none` (or `disable`) on the model, or
+    # `chat.reasoning.display: false` to keep the budget but hide the text.
+    # Only the gemini reasoning models get a default; gpt-4o* (non-reasoning) +
+    # gemini-2.0-flash (thinking_budget=0, mutually exclusive) are left alone.
+    "gemini-flash-lite": {"model": "gemini/gemini-2.5-flash-lite", "reasoning_effort": "low"},
+    "gemini-pro": {"model": "gemini/gemini-2.5-pro", "reasoning_effort": "medium"},
+    "gemini-3.1-flash-preview": {"model": "gemini/gemini-3.1-flash-preview", "reasoning_effort": "low"},
     "gemini-2.0-flash": {
         "model": "gemini/gemini-2.0-flash",
         "extra_body": {

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -65,10 +65,25 @@ class ModelSpec:
         effort = self.kwargs.get("reasoning_effort")
         if effort is None:
             return
-        if not isinstance(effort, str) or effort not in VALID_REASONING_EFFORTS:
+        # #1654: two accepted forms —
+        #   - str (gemini native): the effort level directly, e.g. "low".
+        #   - dict (OpenAI/GPT-5 summary opt-in): {"effort": <level>, "summary":
+        #     "detailed"}. OpenAI reasoning models don't return reasoning TEXT
+        #     unless a summary is requested; litellm's GPT-5 transformation reads
+        #     {effort, summary} (gpt_5_transformation.py). The level is validated
+        #     either way; the optional "summary" rides through to litellm.
+        if isinstance(effort, dict):
+            level = effort.get("effort")
+        elif isinstance(effort, str):
+            level = effort
+        else:
+            level = None
+        if level not in VALID_REASONING_EFFORTS:
             raise ValueError(
                 f"models reasoning_effort must be one of "
-                f"{sorted(VALID_REASONING_EFFORTS)}, got {effort!r} "
+                f"{sorted(VALID_REASONING_EFFORTS)} (a string), or a dict with "
+                f"'effort' one of them (e.g. {{'effort': 'low', 'summary': "
+                f"'detailed'}} for OpenAI summary text); got {effort!r} "
                 f"(model={self.model!r})"
             )
         # Both-set reject: reasoning_effort already maps to a native thinking

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -1,0 +1,123 @@
+"""Tier 2: #1654 — the chat router resolves to the FULL ModelSpec so per-model
+kwargs (reasoning_effort, temperature, …) reach litellm.
+
+The gap this guards: the chat router used host.resolve_model(name) → the bare
+``.model`` STRING, dropping ModelSpec.kwargs → reasoning_effort (#1650/#1652) and
+every model kwarg were inert on the chat-router path. The #1650/#1652 headless
+tests missed it by passing a ModelSpec DIRECTLY to call_llm_tools / stubbing
+litellm; this test goes through the host's RESOLVE path (resolve_model_spec)
+so the drop can't silently regress. Non-default values (#1646 lesson).
+
+Real RouterHostAdapter + a resolver carrying kwargs + a real async litellm stub
+(no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from reyn.chat.services import MemoryService, RouterHostAdapter
+from reyn.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver, ModelSpec
+
+_EFFORT = "high"     # non-default reasoning_effort
+_TEMP = 0.37         # non-default temperature
+
+
+async def _noop(*a, **k):
+    return {}
+
+
+def _mk_host_with_kwargs():
+    events = EventLog(subscribers=[])
+    workspace = Path(".reyn") / "agents" / "t"
+    resolver = ModelResolver({
+        # the chat router's tier carries per-model kwargs in reyn.yaml dict form
+        "light": {"model": "gemini/gemini-2.5-flash-lite",
+                  "reasoning_effort": _EFFORT, "temperature": _TEMP},
+    })
+    return RouterHostAdapter(
+        agent_name="t", agent_role="r", output_language="en",
+        allowed_skills=None, allowed_mcp=None, permission_resolver=None,
+        mcp_servers=None, project_context="", events=events, resolver=resolver,
+        memory=MemoryService(agent_workspace_dir=workspace, events=events,
+            file_write=_noop, file_read=_noop, file_delete=_noop, file_regenerate_index=_noop),
+        journal=None, agent_registry=None, skill_enumerate_fn=lambda exclude: [],
+        agent_workspace_dir=workspace, plan_registry_getter=lambda: None,
+        file_read=_noop, file_write=_noop, file_delete=_noop, file_list_directory=_noop,
+        file_regenerate_index=_noop, mcp_list_servers=_noop, mcp_list_tools=_noop,
+        mcp_call_tool=_noop, run_skill_awaitable=_noop, spawn_skill=_noop, send_to_agent=_noop,
+        put_outbox=_noop, append_history=lambda m: None, spawn_plan_task=_noop,
+        delegation_tracker=lambda: [], agent_replies_tracker=lambda: [],
+        turn_budget_engine=None, environment_backend=None,
+    )
+
+
+def test_resolve_model_spec_preserves_kwargs_resolve_model_drops_them():
+    """Tier 2: #1654 — resolve_model_spec returns the FULL spec (kwargs intact);
+    resolve_model returns the bare string (the drop that caused the bug). This is
+    the distinction the chat router relies on."""
+    host = _mk_host_with_kwargs()
+    spec = host.resolve_model_spec("light")
+    assert isinstance(spec, ModelSpec)
+    assert spec.kwargs.get("reasoning_effort") == _EFFORT
+    assert spec.kwargs.get("temperature") == _TEMP
+    # resolve_model (the old path) drops kwargs — bare string only:
+    assert host.resolve_model("light") == "gemini/gemini-2.5-flash-lite"
+
+
+def test_dict_form_reasoning_effort_accepted_for_openai_summary():
+    """Tier 2: #1654 — the OpenAI summary opt-in dict form
+    {"effort": <level>, "summary": "detailed"} is accepted (the level is
+    validated; the summary rides through to litellm's GPT-5 transformation)."""
+    spec = ModelSpec(
+        model="openai/gpt-5",
+        kwargs={"reasoning_effort": {"effort": "low", "summary": "detailed"}},
+    )
+    assert spec.kwargs["reasoning_effort"] == {"effort": "low", "summary": "detailed"}
+
+
+def test_dict_form_invalid_effort_level_rejected():
+    """Tier 2: #1654 — an invalid effort level inside the dict is rejected at
+    load (same fail-fast as the string form)."""
+    import pytest
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        ModelSpec(model="openai/gpt-5", kwargs={"reasoning_effort": {"effort": "bogus", "summary": "detailed"}})
+
+
+def _fake_resp():
+    msg = type("_M", (), {"content": "ok", "tool_calls": None, "reasoning_content": None})()
+    ch = type("_C", (), {"message": msg, "finish_reason": "stop"})()
+    us = type("_U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+    return type("_R", (), {"choices": [ch], "usage": us})()
+
+
+class _Capture:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        return _fake_resp()
+
+
+def test_resolved_spec_kwargs_reach_litellm_via_call_llm_tools(monkeypatch):
+    """Tier 2: #1654 — a spec from host.resolve_model_spec, passed to
+    call_llm_tools (the chat-router path), delivers its kwargs to the litellm
+    call — NOT dropped. Goes through the resolve path (the regression guard)."""
+    import litellm
+
+    from reyn.llm.llm import call_llm_tools
+
+    host = _mk_host_with_kwargs()
+    spec = host.resolve_model_spec("light")  # the FIXED resolve path
+    stub = _Capture()
+    monkeypatch.setattr(litellm, "acompletion", stub)
+    asyncio.run(call_llm_tools(
+        model=spec, messages=[{"role": "user", "content": "hi"}], tools=[], max_retries=0,
+    ))
+    assert stub.calls, "litellm.acompletion never reached"
+    kw = stub.calls[0]
+    assert kw.get("reasoning_effort") == _EFFORT, f"reasoning_effort dropped: {sorted(kw)}"
+    assert kw.get("temperature") == _TEMP, f"temperature dropped: {sorted(kw)}"


### PR DESCRIPTION
**[e2e-coder]** — Phase-1 live-verify of the reasoning feature (#1650/#1652) surfaced a blocker: **the feature was inert on the chat-router path** (the owner's primary use case). This PR fixes it + makes reasoning **on by default** (owner: "use reasoning by default"), bundled per lead (the default-on is meaningless without the fix).

## Part 1 — kwargs-drop fix (the blocker)
The chat router called `host.resolve_model(name)` → the bare `.model` **string**, dropping `ModelSpec.kwargs`. So `reasoning_effort` (#1650/#1652) **and every model kwarg** (temperature/extra_body) never reached litellm on the chat path. The #1650/#1652 headless tests missed it (they passed a `ModelSpec` directly / stubbed litellm); the **live run caught it** (`reasoning_effort=None` in every router `acompletion` call → reasoning_content empty).

- New `host.resolve_model_spec(name) -> ModelSpec` (full spec incl kwargs).
- `router_loop` threads the **spec** to the `call_llm_tools` site (1980), host-polymorphic `getattr` (phase/test hosts → kwargs-less spec = byte-identical). Model-NAME params (compaction / force-close / memo-key / events / shrink) keep the string — classified every `resolve_model`/`resolved_model` site.
- **Regression test through the host resolve path** (the gap that hid it): non-default `reasoning_effort` + `temperature` survive to the litellm `call_kwargs`.

**Live 7/7 on real gemini-flash-lite via proxy** (flipped from BLOCKED):
| item | result |
|---|---|
| capture | reasoning_content **3949c** ✓ |
| display | outbox `[reasoning, agent]` (before reply) ✓ |
| persist | history meta carries reasoning ✓ |
| replay | turn-2 SP has prior_reasoning + turn-1 text present ✓ |
| bounding | recent_turns=1→[2], unbounded→[0,1,2] ✓ |
| opt-out | display-off→no signal+still persist; continuity-off→signal+no persist ✓ |
| no-double-inject | wire carries no reasoning_content ✓ |

## Part 2 — reasoning ON by default
Gemini reasoning builtins ship a default `reasoning_effort` (gemini-flash-lite=`low`, gemini-pro=`medium`, gemini-3.1-flash-preview=`low`); `chat.reasoning.{display,continuity}` already default ON → reasoning works out of the box. `gpt-4o*` (non-reasoning) + `gemini-2.0-flash` (`thinking_budget=0`, mutually exclusive) left alone. **Cost note** in docs (thinking tokens add spend; opt out via `reasoning_effort: none` or `chat.reasoning.display: false`).

## Part 2b — OpenAI summary opt-in
OpenAI reasoning models (o-series / GPT-5) don't return raw reasoning text (encrypted); the *summary* is opt-in via litellm's dict form `reasoning_effort={effort, summary:"detailed"}` (`gpt_5_transformation.py`). `ModelSpec` validation now accepts the dict form (level validated, summary rides through); documented as the provider difference. **Not live-verifiable here** — the only OpenAI-family proxy model (`gpt-oss-120b` via openrouter) rejects reasoning params; GPT-5.4 is the owner's company env. Mechanism source-confirmed; owner verifies GPT-5.4 directly.

Refs #1654 #1650 #1652

## Test plan
- [x] regression: chat-router `resolve_model_spec → call_llm_tools` threads non-default kwargs (reasoning_effort + temperature) — guards the drop
- [x] dict-form validation accepted (OpenAI summary) + invalid-level rejected
- [x] **live 7/7** real gemini-flash-lite proxy (table above)
- [x] builtin reasoning_effort defaults load (no #1650 both-set trip); 696 reasoning/router/builtin/config tests pass; ruff + tier-audit clean
- [ ] **(owner, deferred)** GPT-5.4 summary text live-verify in the company env (not reachable here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
