### PR TITLE
docs(positioning): add competitive-gaps.md (internal findings record)

### DIFF
--- a/docs/deep-dives/research/positioning/competitive-gaps.md
+++ b/docs/deep-dives/research/positioning/competitive-gaps.md
@@ -1,0 +1,86 @@
+---
+title: Reyn の競合劣位領域（将来強化候補）
+last_updated: 2026-06-15
+status: findings
+audience: [maintainer]
+---
+
+# Reyn の競合劣位領域（将来強化候補）
+
+2026-06 時点の競合調査（ClaudeCode / Codex / Cursor / Windsurf、Hermes /
+OpenClaw、CrewAI / AutoGen / LangGraph）に基づく、Reyn が現状負けている領域の
+findings 記録。owner 方針: 将来これらの強化を検討する。本ドキュメントは
+findings の記録であり提案ではない — 断定で記すが、出典・段階は注記する。
+
+> **出典・確度**: thenewstack / turingpost / Anthropic agent-autonomy / 各社
+> 公式 docs（2026-06 時点、二次情報を含む）+ owner の実観測。競合側の数値・
+> 主張は二次情報ベースで、時点依存。Reyn 側の記述はコードベース（feature-map /
+> concepts）に照合済み。
+
+## 1. コーディング / SWE 卓越性
+
+ClaudeCode（Opus 4.7、最も深い harness）/ Codex（GPT-5.5）/ Cursor / Windsurf が
+専用コーディング agent として圧倒。Reyn は SWE skill 最小化方針 + 汎用 agent 志向
+ゆえ、専用 coding agent には劣位。Hermes ですら「SWE は Cursor / ClaudeCode に
+劣る」と明言している。Reyn の SWE skill は OS 安定性の dogfood シグナル用途で
+あって公表 SWE スコアの追求ではない（設計上の選択）。
+
+## 2. 自己改善 / 学習ループ / 永続スキル自動生成
+
+Hermes / OpenClaw は経験から self-generated skills を作り完了率を上げる（Nous の
+internal 主張: 40% faster）。Reyn には `skill_improver`（eval-plan-apply の反復
+改善）はあるが、**自律 trajectory 学習 → skill 自動生成ループ**は無い。改善は
+明示的・人間ドリブンで、emergent な経験蓄積ループではない。
+
+## 3. 基礎 tool-use 信頼性
+
+owner 実観測（2026-06）: strong モデル（GPT-5.4）でも default の
+`universal-category` scheme の tool 使用が下手で「使い物にならない」場面がある。
+基礎的な tool-use の信頼性で現状負けている。**対応中** — tool-use scheme の
+default 見直し + 代替 scheme（enumerate-all / retrieval / CodeAct）の整備が進行中
+（[tool-use-schemes](../../../concepts/tools-integrations/tool-use-schemes.md) /
+[codeact](../../../concepts/tools-integrations/codeact.md) 参照）。
+
+## 4. Permission / sandbox の成熟度
+
+ClaudeCode は OS レベル sandbox（macOS Seatbelt / Linux seccomp で FS・network
+境界を agentic loop 全体に強制）、Codex は reviewer-agent による自動承認 + 全
+action の audit attribution を持つ。
+
+**Reyn の現状（正確な差分）**: Reyn は OS レベル実行隔離を**持っている** —
+`SeatbeltBackend`（macOS SBPL deny-default）/ `LandlockBackend`（Linux 5.13+
+Landlock LSM + seccomp-BPF stacking）で、subprocess 実行中に syscall レベルで
+境界を強制し、宣言的 permission gating と独立・additive に重なる（stdio MCP
+server も Seatbelt 下で subprocess-sandboxed）。劣位なのは「持っていない」ことでは
+なく**スコープと成熟度**:
+
+- Reyn の OS-sandbox は `sandboxed_exec` op + stdio MCP subprocess に scope され、
+  ClaudeCode のように**エージェントループ全体を丸ごと sandbox する blanket 境界**
+  ではない。
+- Codex 型の **reviewer-agent 自動承認 + per-action audit attribution** フローは
+  無い（Reyn は `chain_id` / `agent_id` の P6 audit 伝播は持つが、reviewer-agent
+  パターンではない）。
+- 成熟度の caveat: `sandbox-exec` は upstream で deprecated（macOS 26.3 では機能
+  するが）、Landlock は kernel 5.13+ 依存。
+
+## 5. Computer use（browser / GUI 操作）
+
+ClaudeCode は単一の agentic loop で computer use（browser / GUI 操作）が成熟。
+Reyn は `web_search` / `web_fetch` のみで、GUI / browser 操作能力は無い。
+
+## 6. 長時間自律の実績
+
+ClaudeCode は 45 分超ターンの運用実績を持つ。Reyn の長時間自律の成熟度は未実証
+（公表できる実績データが無い）。
+
+## 7. multi-agent orchestration の成熟度
+
+CrewAI / AutoGen / LangGraph は production の multi-agent orchestration で成熟。
+Reyn は delegation レベル（topology-gated な `delegate_to_agent` + hop-depth cap +
+`chain_id` 伝播）に留まり、organizational orchestration は未成熟。owner の
+agent-cluster 構想は将来の差別化候補だが現状は未着手。
+
+---
+
+対になる Reyn の潜在優位（宣言的・可搬な OS / Skill 分離、制約付き valid 実行、
+将来の共有 agent 組織）は [reyn-differentiators.md](reyn-differentiators.md) 参照。

--- a/docs/deep-dives/research/positioning/competitive-gaps.md
+++ b/docs/deep-dives/research/positioning/competitive-gaps.md
@@ -11,6 +11,8 @@ audience: [maintainer]
 OpenClaw、CrewAI / AutoGen / LangGraph）に基づく、Reyn が現状負けている領域の
 findings 記録。owner 方針: 将来これらの強化を検討する。本ドキュメントは
 findings の記録であり提案ではない — 断定で記すが、出典・段階は注記する。
+なお §4（sandbox）は当初 gap と疑ったが調査の結果 core 技術は競争力ありと
+判明した項目で、周辺機能の差分のみを gap として残す（経緯も記録として残す）。
 
 > **出典・確度**: thenewstack / turingpost / Anthropic agent-autonomy / 各社
 > 公式 docs（2026-06 時点、二次情報を含む）+ owner の実観測。競合側の数値・
@@ -41,27 +43,33 @@ default 見直し + 代替 scheme（enumerate-all / retrieval / CodeAct）の整
 （[tool-use-schemes](../../../concepts/tools-integrations/tool-use-schemes.md) /
 [codeact](../../../concepts/tools-integrations/codeact.md) 参照）。
 
-## 4. Permission / sandbox の成熟度
+## 4. Sandbox: core tech は競争力あり、周辺機能で差
 
-ClaudeCode は OS レベル sandbox（macOS Seatbelt / Linux seccomp で FS・network
-境界を agentic loop 全体に強制）、Codex は reviewer-agent による自動承認 + 全
-action の audit attribution を持つ。
+**ここは Reyn の劣位ではない。** core sandbox 技術は競合と同等以上:
 
-**Reyn の現状（正確な差分）**: Reyn は OS レベル実行隔離を**持っている** —
-`SeatbeltBackend`（macOS SBPL deny-default）/ `LandlockBackend`（Linux 5.13+
-Landlock LSM + seccomp-BPF stacking）で、subprocess 実行中に syscall レベルで
-境界を強制し、宣言的 permission gating と独立・additive に重なる（stdio MCP
-server も Seatbelt 下で subprocess-sandboxed）。劣位なのは「持っていない」ことでは
-なく**スコープと成熟度**:
+- ClaudeCode = Seatbelt（macOS）+ bubblewrap（Linux）+ network-proxy（opt-in）。
+- Codex = Landlock + seccomp（default-on）。
+- **Reyn = `SeatbeltBackend`（macOS SBPL deny-default）+ `LandlockBackend`
+  （Linux 5.13+ Landlock LSM + seccomp-BPF stacking）** — macOS は ClaudeCode と
+  同等、**Linux は ClaudeCode の bubblewrap より granular（syscall レベル）**。
+  subprocess 実行中に syscall レベルで境界を強制し、宣言的 permission gating と
+  独立・additive に重なる（stdio MCP server も Seatbelt 下で subprocess-sandboxed）。
 
-- Reyn の OS-sandbox は `sandboxed_exec` op + stdio MCP subprocess に scope され、
-  ClaudeCode のように**エージェントループ全体を丸ごと sandbox する blanket 境界**
-  ではない。
-- Codex 型の **reviewer-agent 自動承認 + per-action audit attribution** フローは
-  無い（Reyn は `chain_id` / `agent_id` の P6 audit 伝播は持つが、reviewer-agent
-  パターンではない）。
-- 成熟度の caveat: `sandbox-exec` は upstream で deprecated（macOS 26.3 では機能
-  するが）、Landlock は kernel 5.13+ 依存。
+つまり **core sandbox tech は gap ではない**。残る本当の差分は周辺機能のみ:
+
+- **(a) network 隔離**: ClaudeCode の network-proxy 相当のネットワーク境界制御は
+  未整備（`SandboxPolicy.network` の on/off はあるが proxy ベースの制御ではない）。
+- **(b) cloud microVM 実行**: Claude Code for web 相当の cloud microVM サンドボックス
+  実行環境は無い。
+- **(c) default-on enforcement**: Codex は sandbox が default-on。Reyn の OS-sandbox
+  は op/config 依存で、Codex のような全実行 default-on enforcement ではない。
+- **(d) scope**: Reyn の OS-sandbox は `sandboxed_exec` op + stdio MCP subprocess に
+  scope され、より広い surface（エージェントループ全体）への blanket 適用ではない。
+- **(e) エコシステム成熟度**: backend caveat（`sandbox-exec` は upstream deprecated /
+  macOS 26.3 で機能、Landlock は kernel 5.13+ 依存）。
+
+reviewer-agent 自動承認 + per-action audit attribution（Codex）も無い（Reyn は
+`chain_id` / `agent_id` の P6 audit 伝播は持つが reviewer-agent パターンではない）。
 
 ## 5. Computer use（browser / GUI 操作）
 


### PR DESCRIPTION
**[docs-maintainer]** — New internal positioning-research doc at `docs/deep-dives/research/positioning/competitive-gaps.md` (same dir as #1594, maintainer-audience). Findings record of areas where Reyn currently trails competitors, for owner's future-strengthening roadmap. Synthesized from lead-coder's 2026-06 competitive survey (ClaudeCode / Codex / Cursor / Windsurf, Hermes / OpenClaw, CrewAI / AutoGen / LangGraph).

## 7 areas
1. Coding / SWE excellence — dedicated coding agents dominate; Reyn's minimal-SWE-skill stance is by design.
2. Self-improvement / skill auto-generation loop — `skill_improver` exists but no autonomous trajectory-learning → skill-gen loop.
3. Basic tool-use reliability — owner-observed; **対応中** (scheme default revisit + alt schemes).
4. **Sandbox — NOT a gap.** Core tech (SeatbeltBackend + LandlockBackend Linux 5.13+ Landlock LSM + seccomp-BPF) is competitive: macOS on par with ClaudeCode, Linux more granular (syscall-level) than ClaudeCode's bubblewrap. Only peripheral differences remain as gaps: (a) network-proxy isolation, (b) cloud microVM execution, (c) Codex default-on enforcement, (d) scope (sandboxed_exec op + stdio MCP subprocess), (e) ecosystem maturity.
5. Computer use (browser / GUI) — Reyn has web_search/fetch only.
6. Long-autonomy track record — unproven for Reyn.
7. Multi-agent orchestration maturity — Reyn at delegation level only.

Closes with a pointer to the paired `reyn-differentiators.md` (potential advantages).

## §4 correction history
lead-coder's original brief framed §4 as "OS-isolation 手薄" (a gap). On primary-source / web verification this was found inaccurate twice; lead-coder approved the reframe (msg sequence in broker). Final state: sandbox core tech is competitive, only peripheral network/cloud/default-on/scope/ecosystem differences are gaps. Intro carries a one-line note that §4 was investigated-and-cleared. Other 6 claims as lead-coder gave them.

## Test plan
- [x] `mkdocs build --strict` → exit 0 (verified; remaining output is INFO-level JA-mirror anchor lag, does not fail --strict)
- [x] (skipped — nav unchanged) positioning research docs are not in nav, matching #1594 pattern; no page-drop risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)