### PR TITLE
fix(1649): non-TTY interactive limit no longer silently auto-denies (bounded auto-extend + loud non-zero abort)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2781,7 +2781,15 @@ class RouterLoop:
                 f"Configure safety.on_limit.mode=interactive or auto_extend to "
                 f"extend, or increase safety.loop.max_router_iterations."
             ),
-            meta={"chain_id": self.chain_id},
+            # #1649 PART B: the limit_stopped marker lets the run-once / A2A
+            # caller detect a limit-abort (vs a normal reply) → surface the
+            # message + exit non-zero, so a non-TTY wrapper never sees a silent
+            # exit-0 stop. Mirrors the wrap-up agent message's marker above.
+            meta={
+                "chain_id": self.chain_id,
+                "limit_stopped": True,
+                "limit_kind": "max_iterations",
+            },
         )
         return self._total_usage
 

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2709,6 +2709,10 @@ class RouterLoop:
                 ),
                 detail=f"chain_id={self.chain_id}",
                 extension_amount=float(self.max_iterations),
+                # #1649: non-TTY/run-once → handle_limit_exceeded falls back to
+                # bounded auto-extend instead of a silent refuse (the agent
+                # completes instead of an empty exit-0 stop).
+                non_interactive=self._non_interactive,
             )
             if _dec.allow_continue:
                 self.max_iterations += int(_dec.extension)

--- a/src/reyn/cli/commands/chat.py
+++ b/src/reyn/cli/commands/chat.py
@@ -28,16 +28,20 @@ from ..session import Session
 _ONCE_SEND_TIMEOUT = 3600.0
 
 
-async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> str:
+async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> dict:
     """#187 one-shot drive: read the WHOLE *instream* (default stdin) as a SINGLE
     user message and drive the agent to completion via ``send_to_agent_impl``,
-    returning the final reply.
+    returning the result dict (``reply`` + ``limit_stopped`` + …).
 
     This is the structural fix for the #1401 line-fragmentation bug: the WHOLE
     stdin becomes ONE message (one ``send`` call), NOT one message per line (the
     REPL's line-by-line ``readline``). ``instream`` / ``send`` are injectable so
     the whole-message-not-fragmented behavior is testable with a recording double
     (no mock); production uses ``sys.stdin`` + the real ``send_to_agent_impl``.
+
+    #1649: returns the full result dict (not just the reply str) so the caller
+    can detect ``limit_stopped`` and exit non-zero — a limit hit must never be a
+    silent exit-0 stop for a non-TTY wrapper.
     """
     if instream is None:
         instream = sys.stdin
@@ -48,7 +52,7 @@ async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> 
         agent_registry, agent_name=agent_name, message=message,
         timeout=_ONCE_SEND_TIMEOUT,
     )
-    return result.get("reply", "") or ""
+    return result if isinstance(result, dict) else {"reply": result or ""}
 
 
 def register(sub) -> None:
@@ -525,8 +529,14 @@ def run(args: argparse.Namespace) -> None:
             # A2A use (registry.get_or_load returns this attached scoped session, no
             # fresh unscoped build), then print the final reply and exit.
             if getattr(args, "once", False):
-                reply = await _run_once(registry, name)
-                sys.stdout.write(reply + "\n")
+                _once_result = await _run_once(registry, name)
+                sys.stdout.write((_once_result.get("reply", "") or "") + "\n")
+                # #1649: a limit-abort must propagate a non-zero exit so a
+                # non-TTY wrapper/CI detects the runaway-stop (vs a clean reply).
+                # The decision-enabling message is already in the reply above
+                # (never silent). exit(2) distinguishes it from arg/usage errors.
+                if _once_result.get("limit_stopped"):
+                    sys.exit(2)
                 return
             await run_repl(registry, renderer=renderer)
 

--- a/src/reyn/mcp_server.py
+++ b/src/reyn/mcp_server.py
@@ -274,11 +274,29 @@ async def send_to_agent_impl(
             if not task.done():
                 running_skill_run_ids.append(rid)
 
+    # #1649 PART B: detect a limit-abort. The router stamps ``limit_stopped`` on
+    # the limit wrap-up / degrade outbox message. A non-TTY run-once / wrapper
+    # caller uses this to (a) surface the decision-enabling message even when the
+    # history harvest is empty (kind="error" isn't persisted to history) and
+    # (b) exit NON-ZERO — so a limit hit is never a silent exit-0 stop.
+    limit_stopped = any(
+        isinstance(getattr(r, "meta", None), dict) and r.meta.get("limit_stopped")
+        for r in replies
+    )
+    if limit_stopped and not reply_text:
+        _limit_texts = [
+            r.text for r in replies
+            if isinstance(getattr(r, "meta", None), dict)
+            and r.meta.get("limit_stopped") and r.text
+        ]
+        reply_text = "\n\n".join(_limit_texts).strip() or reply_text
+
     return {
         "reply": reply_text,
         "partial": (not idle),
         "agent": agent_name,
         "running_skill_run_ids": running_skill_run_ids,
+        "limit_stopped": limit_stopped,
     }
 
 

--- a/src/reyn/safety/limit_handler.py
+++ b/src/reyn/safety/limit_handler.py
@@ -99,6 +99,32 @@ def _yes_no_choices() -> list[InterventionChoice]:
     ]
 
 
+def _bounded_auto_extend(
+    *,
+    on_limit: OnLimitConfig,
+    run_id: str,
+    kind: str,
+    extension_amount: float,
+    exhausted_reason: str,
+) -> LimitDecision:
+    """Per-(run_id, kind) bounded auto-extend: grant up to
+    ``on_limit.auto_extend_times`` extensions, then refuse with
+    ``exhausted_reason``. Shared by ``auto_extend`` mode and the
+    interactive-but-no-TTY fallback (#1649)."""
+    key = (run_id, kind)
+    used = _auto_extend_used.get(key, 0)
+    if used < on_limit.auto_extend_times:
+        _auto_extend_used[key] = used + 1
+        _logger.info(
+            "safety.limit auto-extended (kind=%s run=%s used=%d/%d via=%s)",
+            kind, run_id, used + 1, on_limit.auto_extend_times, exhausted_reason,
+        )
+        return LimitDecision(
+            allow_continue=True, extension=extension_amount, reason="auto_extended",
+        )
+    return LimitDecision(allow_continue=False, extension=0.0, reason=exhausted_reason)
+
+
 async def handle_limit_exceeded(
     *,
     bus: Optional[RequestBus],
@@ -109,6 +135,7 @@ async def handle_limit_exceeded(
     detail: str = "",
     extension_amount: float = 1.0,
     skill_name: str | None = None,
+    non_interactive: bool = False,
 ) -> LimitDecision:
     """Generic safety-limit checkpoint dispatcher (FP-0005).
 
@@ -151,25 +178,27 @@ async def handle_limit_exceeded(
         )
 
     if on_limit.mode == "auto_extend":
-        key = (run_id, kind)
-        used = _auto_extend_used.get(key, 0)
-        if used < on_limit.auto_extend_times:
-            _auto_extend_used[key] = used + 1
-            _logger.info(
-                "safety.limit auto-extended (kind=%s run=%s used=%d/%d)",
-                kind, run_id, used + 1, on_limit.auto_extend_times,
-            )
-            return LimitDecision(
-                allow_continue=True,
-                extension=extension_amount,
-                reason="auto_extended",
-            )
-        # Auto-extend budget exhausted — fall through to abort.
-        return LimitDecision(
-            allow_continue=False, extension=0.0, reason="unattended",
+        return _bounded_auto_extend(
+            on_limit=on_limit, run_id=run_id, kind=kind,
+            extension_amount=extension_amount, exhausted_reason="unattended",
         )
 
     # interactive
+    if non_interactive:
+        # #1649: mode=interactive but this run CANNOT ask the user (non-TTY /
+        # run-once / piped — isatty()=False, threaded from the session's
+        # non_interactive flag). The operator chose interactive = "continue
+        # when asked"; with no way to ask, the intent-preserving behaviour is a
+        # BOUNDED auto-extend (the agent makes progress + completes) rather than
+        # a SILENT refuse that a wrapper sees as an empty exit-0 stop (the
+        # owner's "auto-deny"). When the bounded extensions are exhausted the
+        # caller emits a loud decision-enabling abort + non-zero exit — never
+        # silent. The interactive TTY path (non_interactive=False) is untouched.
+        return _bounded_auto_extend(
+            on_limit=on_limit, run_id=run_id, kind=kind,
+            extension_amount=extension_amount,
+            exhausted_reason="interactive_no_tty_exhausted",
+        )
     if bus is None:
         # No bus → no way to ask. Behave as unattended so headless
         # callers (= dispatch_tool / scripted runs) abort silently

--- a/tests/test_run_once_187.py
+++ b/tests/test_run_once_187.py
@@ -99,7 +99,7 @@ def test_one_shot_delivers_whole_stdin_as_one_message() -> None:
         captured["agent"] = agent_name
         return {"reply": "done", "partial": False, "agent": agent_name}
 
-    reply = asyncio.run(
+    result = asyncio.run(
         chat._run_once(
             object(), "default",
             instream=io.StringIO(multi_line),
@@ -111,7 +111,36 @@ def test_one_shot_delivers_whole_stdin_as_one_message() -> None:
     assert captured["message"] == multi_line, "the multi-line task must arrive unsplit"
     assert "\n" in captured["message"]  # newlines preserved (not fragmented)
     assert captured["agent"] == "default"
-    assert reply == "done"
+    # #1649: _run_once now returns the full result dict (so the caller can detect
+    # limit_stopped + exit non-zero); the reply is under the "reply" key.
+    assert result["reply"] == "done"
+
+
+def test_run_once_propagates_limit_stopped_for_nonzero_exit() -> None:
+    """Tier 2: #1649 PART B — _run_once returns the full result incl
+    limit_stopped, so the run-once caller surfaces the decision-enabling message
+    AND exits non-zero (a limit hit is never a silent exit-0 stop for a non-TTY
+    wrapper). Pairs with send_to_agent_impl, which sets limit_stopped + surfaces
+    the message from the router's limit-abort outbox marker."""
+    import asyncio
+    import io
+
+    from reyn.cli.commands import chat
+
+    async def _send_limit(registry, *, agent_name, message, timeout):
+        return {
+            "reply": "Router loop exceeded max iterations (5). Configure "
+                     "safety.on_limit.mode or increase max_router_iterations.",
+            "limit_stopped": True,
+            "partial": False,
+            "agent": agent_name,
+        }
+
+    result = asyncio.run(
+        chat._run_once(object(), "default", instream=io.StringIO("go"), send=_send_limit)
+    )
+    assert result["limit_stopped"] is True  # caller exits non-zero on this
+    assert "exceeded max iterations" in result["reply"]  # message surfaced, not silent
 
 
 # ── R1: in-container execution ────────────────────────────────────────────────

--- a/tests/test_safety_limit_handler.py
+++ b/tests/test_safety_limit_handler.py
@@ -164,6 +164,47 @@ async def test_interactive_no_bus_returns_no_bus_reason() -> None:
 
 
 @pytest.mark.asyncio
+async def test_interactive_non_tty_falls_back_to_bounded_auto_extend() -> None:
+    """Tier 2: #1649 — mode=interactive but ``non_interactive=True`` (non-TTY /
+    run-once, can't ask) → BOUNDED auto-extend instead of a SILENT refuse. The
+    operator chose interactive ("continue when asked"); with no TTY the
+    intent-preserving behaviour is to extend (make progress + complete), then
+    abort LOUDLY (a distinct reason) when the bounded budget is exhausted —
+    never a silent exit-0 stop (the owner's "auto-deny")."""
+    reset_run_extensions("run-NTTY")
+    cfg = OnLimitConfig(mode="interactive", auto_extend_times=1)
+    # bus is irrelevant (never asked) — pass None to prove we don't try to ask.
+    d1 = await handle_limit_exceeded(
+        bus=None, on_limit=cfg, kind="max_iterations", run_id="run-NTTY",
+        prompt="?", extension_amount=5.0, non_interactive=True,
+    )
+    assert d1.allow_continue is True
+    assert d1.extension == 5.0
+    assert d1.reason == "auto_extended"
+    # exhausted → loud, distinct reason (NOT silent "no_bus"/"unattended")
+    d2 = await handle_limit_exceeded(
+        bus=None, on_limit=cfg, kind="max_iterations", run_id="run-NTTY",
+        prompt="?", extension_amount=5.0, non_interactive=True,
+    )
+    assert d2.allow_continue is False
+    assert d2.reason == "interactive_no_tty_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_interactive_tty_path_unchanged_by_non_interactive_default() -> None:
+    """Tier 2: #1649 regression guard — the interactive TTY path
+    (non_interactive defaults False) is UNTOUCHED: a real bus is still asked,
+    and bus=None still returns no_bus (not the auto-extend fallback)."""
+    bus = _FakeBus(answer_choice="yes")
+    d = await handle_limit_exceeded(
+        bus=bus, on_limit=OnLimitConfig(mode="interactive"),
+        kind="max_iterations", run_id="run-TTY", prompt="?", extension_amount=3.0,
+    )
+    assert d.allow_continue is True and d.reason == "user_approved"
+    assert bus.dispatched, "TTY path must still ASK the user (no auto-extend shortcut)"
+
+
+@pytest.mark.asyncio
 async def test_interactive_ask_timeout_returns_refusal() -> None:
     """Tier 2: when ``ask_timeout_seconds`` elapses without a reply
     the helper returns ``ask_timeout``. The hung bus is cancelled by


### PR DESCRIPTION
**[e2e-coder]** — Fixes the owner's "single agent silently auto-denies / stops" frustration. tui-coder's controlled 3-way primary evidence: a **non-TTY / run-once / piped** run at the router iteration limit **silently refused + exited 0** (empty stdout+stderr — undetectable). The interactive TTY path is healthy (don't regress).

## Root cause
`handle_limit_exceeded` (`limit_handler.py`), in `mode=interactive` (the default), couldn't ask the user in a non-TTY context → refused (`no_bus` / EOFError→`user_refused`) → the limit-deny path's `kind="error"` message was **dropped** by `_run_once` (which returned only the `kind="agent"` reply) and exited 0 → silent.

## Fix (intent-preserving + always detectable)

**PART A — non-TTY interactive → bounded auto_extend (not silent refuse).**
`handle_limit_exceeded` gains `non_interactive` (threaded from the session's `isatty()`-derived flag via `router_loop`). When `mode=interactive` AND `non_interactive` (can't ask): fall back to a **bounded** auto_extend (shared `_bounded_auto_extend`, capped by `auto_extend_times`) instead of a silent refuse. Rationale: the operator chose interactive = "continue when asked"; with no TTY the intent-preserving behavior is to **extend → make progress → complete**, not stop. The interactive TTY path (`non_interactive=False`) is **untouched** (regression-guarded test).

**PART B — exhausted abort: surface a decision-enabling message + non-zero exit.**
When the bounded extensions ARE exhausted (genuine runaway): the limit-deny outbox carries a `limit_stopped` marker; `send_to_agent_impl` detects it → **surfaces** the decision-enabling message (even when the history harvest is empty — `kind="error"` isn't persisted) + returns `limit_stopped`; `_run_once` returns the full result dict; the run-once CLI writes the reply (**never silent**) then **exits non-zero (2)** so wrappers/CI detect the runaway-stop.

Net: non-TTY interactive now **extends + completes** (common case) or **aborts loudly + non-zero** (exhausted) — never a silent exit-0 stop.

## Owner-morning note (flag, not decided)
The default `safety.loop.max_router_iterations=5` may be **too low** for real agentic tasks — the owner hit it. Separate from this fix (which makes hitting the limit graceful, not silent), but worth raising for an owner decision.

Refs #1649

## Test plan
- [x] non-TTY interactive → bounded auto_extend (continuation), then loud distinct `interactive_no_tty_exhausted` on exhaustion (not silent)
- [x] interactive TTY path unchanged (still asks; bus=None still `no_bus`) — regression guard
- [x] `_run_once` returns the result dict incl `limit_stopped` → caller exits non-zero; message surfaced
- [x] 1445 limit/router/chat/mcp/session regression pass; ruff + tier-audit clean
- [ ] **(tui-coder, post-fix)** tmux 3-way live re-verify (interactive prompts / non-TTY extends-or-loud-aborts / no silent exit-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
