### PR TITLE
feat(1657): default chat tool-use scheme → enumerate-all (owner H1 fix; 30%→100% tool-use)

### DIFF
--- a/docs/concepts/tools-integrations/tool-use-schemes.md
+++ b/docs/concepts/tools-integrations/tool-use-schemes.md
@@ -8,8 +8,9 @@ audience: [human, agent]
 
 How an agent's tools are shown to the LLM — and how the LLM's calls are turned
 back into dispatched actions — is a **pluggable scheme**. Reyn ships four, and
-you select one per layer in `reyn.yaml`. The default reproduces the standard
-behaviour, so schemes are entirely opt-in.
+you select one per layer in `reyn.yaml`. The defaults are `enumerate-all` for the
+`chat` layer (#1657) and `universal-category` for `step` / `phase`; any layer can
+be switched to another scheme via config.
 
 The key invariant: **the scheme only changes the LLM-facing surface**. Every
 tool call, whichever scheme produced it, is routed through the same OS gate —
@@ -19,25 +20,31 @@ what is allowed, only how the LLM is asked to express a call. See
 
 ## The four schemes
 
-### `universal-category` (default)
+### `enumerate-all` (chat default, #1657)
+
+Presents *every* usable tool flatly in the LLM's tool list and dispatches by
+name — the plain, native-JSON baseline with no discovery indirection. **This is
+the default for the `chat` layer** (#1657): flat-listing actions lets the LLM
+invoke them directly, avoiding the `invoke_action` name-hallucination that the
+discover-then-call indirection induced (measured ~30%→100% non-hot-list tool-use
+on the chat path). Leaving `tool_use.chat` unset keeps it.
+
+**Use when:** the default for chat — direct, deterministic name→dispatch. The
+trade-off is request size: the flat list grows with the tool set (see
+`universal-category` for very large catalogs).
+
+### `universal-category`
 
 The [universal action catalog](universal-catalog.md): every action — a skill, an
 MCP tool, a memory entry, a file op, an indexed corpus — is addressed by a single
 qualified name and reached through a small fixed set of wrappers (discover →
 describe → invoke). The LLM-facing tool list stays constant as the catalogue
-grows. This is Reyn's shipped behaviour; leaving `tool_use` unset keeps it.
+grows. The default for the `step` / `phase` layers; set `tool_use.chat:
+universal-category` to use it for chat too.
 
-**Use when:** the default — a broad, growing tool set where you don't want the
-tool list to scale with the number of resources.
-
-### `enumerate-all`
-
-Presents *every* usable tool flatly in the LLM's tool list and dispatches by
-name — the plain, native-JSON baseline with no discovery indirection.
-
-**Use when:** the tool set is **small** and you want maximum determinism and the
-simplest possible mapping from the LLM's call to a dispatch. Note this is *not* a
-weak-model aid — a flat JSON tool list is the hardest surface for weak models.
+**Use when:** a very large / fast-growing tool set where flat-listing every
+action in the request would cost too many tokens — the wrappers keep the
+LLM-facing tool list constant.
 
 ### `retrieval`
 
@@ -66,9 +73,9 @@ The scheme is chosen independently for each of the three layers an agent runs:
 ```yaml
 # reyn.yaml
 tool_use:
-  chat: universal-category    # top-level chat router
-  step: universal-category    # plan / skill steps
-  phase: universal-category   # OS phases
+  chat: enumerate-all         # top-level chat router (default, #1657)
+  step: universal-category    # plan / skill steps (default)
+  phase: universal-category   # OS phases (default)
 ```
 
 Any layer can use any registered scheme; the others are unaffected. Full per-key
@@ -90,6 +97,6 @@ gate is constant.
 
 ## See also
 
-- [Universal Action Catalog](universal-catalog.md) — the internals of the default `universal-category` scheme
+- [Universal Action Catalog](universal-catalog.md) — the internals of the `universal-category` scheme (step/phase default; chat alternative)
 - [`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block) — config reference
 - [Permission model](../runtime/permission-model.md) — the gate every scheme dispatches through

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -387,18 +387,18 @@ Per-layer tool-use scheme selector. Each layer picks a registered `ToolUseScheme
 
 ```yaml
 tool_use:
-  chat: universal-category    # default
+  chat: enumerate-all         # default (#1657)
   step: universal-category    # default
   phase: universal-category   # default
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `chat` | string | `universal-category` | Tool-use scheme for the top-level chat layer. Set to another registered scheme (e.g. `enumerate-all`) to change how tools are presented to / dispatched from the LLM at that layer. |
+| `chat` | string | `enumerate-all` | Tool-use scheme for the top-level chat layer. **Default `enumerate-all` (#1657)** — flat-lists actions so the LLM invokes them directly instead of hallucinating `invoke_action` names (raised non-hot-list tool-use ~30%→100%). Set to `universal-category` for a minimal-surface / many-tool catalog (discover-then-call), or another registered scheme. |
 | `step` | string | `universal-category` | Tool-use scheme for the plan/skill step layer. |
 | `phase` | string | `universal-category` | Tool-use scheme for the OS phase layer. |
 
-Defaults preserve today's behaviour (all `universal-category`). A scheme owns how the `tools=` payload is built, the SP tool-use instructions, how an LLM response is interpreted, and how it is dispatched — so swapping a layer's scheme changes the whole tool-use loop for that layer without OS changes.
+The chat layer defaults to `enumerate-all` (#1657); `step` / `phase` keep `universal-category`. A scheme owns how the `tools=` payload is built, the SP tool-use instructions, how an LLM response is interpreted, and how it is dispatched — so swapping a layer's scheme changes the whole tool-use loop for that layer without OS changes. `universal-category` remains available per-layer via this config (e.g. for very large tool catalogs where flat-listing every action would bloat the request).
 
 For what each scheme does and **when to choose which** (`enumerate-all` / `retrieval` / `CodeAct` vs the default), see [Tool-Use Schemes](../../concepts/tools-integrations/tool-use-schemes.md).
 

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1183,8 +1183,10 @@ class ChatSession:
         # #1593 PR-2: the chat-layer tool-use scheme name (config.tool_use.chat).
         # Threaded → RouterLoopDriver → RouterLoop(scheme_name=) so the chat
         # router resolves the selected ToolUseScheme. Default "universal-category"
-        # keeps today's behaviour (the factory passes the resolved config value).
-        chat_tool_use_scheme: str = "universal-category",
+        # #1657: default enumerate-all (owner H1 fix) — matches ToolUseConfig.chat.
+        # The 5 entry callers pass the resolved config.tool_use.chat; this fallback
+        # only applies to direct ChatSession construction without that kwarg.
+        chat_tool_use_scheme: str = "enumerate-all",
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1670,18 +1670,21 @@ class ToolUseConfig:
 
     Each layer (chat / step / phase) selects a registered ``ToolUseScheme`` by name,
     generalizing the binary ``action_retrieval.universal_wrappers_enabled`` toggle
-    into a pluggable, per-layer scheme selector. Defaults = ``universal-category``
-    for all three (today's behaviour). Future schemes (``enumerate-all``,
-    ``codeact``) are selected by setting a layer to their name.
+    into a pluggable, per-layer scheme selector. #1657: the ``chat`` default is
+    ``enumerate-all`` (the owner H1 fix — flat-listing actions stops
+    invoke_action name-hallucination, 30%→100% non-hot-list tool-use). ``step`` /
+    ``phase`` keep ``universal-category`` (unchanged — the H1 evidence is the chat
+    path). Any layer can be set to another scheme name via reyn.yaml.
     """
 
-    chat: str = "universal-category"
+    chat: str = "enumerate-all"
     step: str = "universal-category"
     phase: str = "universal-category"
 
 
 def _build_tool_use_config(raw: object) -> ToolUseConfig:
-    """Parse ``tool_use:`` from reyn.yaml. None / missing / empty → all-universal.
+    """Parse ``tool_use:`` from reyn.yaml. None / missing / empty → defaults
+    (chat=enumerate-all #1657; step/phase=universal-category).
 
     Each layer key accepts a scheme name (string); a missing key keeps the default.
     A non-mapping block or non-string value is a config error (fail loud)."""
@@ -1701,7 +1704,7 @@ def _build_tool_use_config(raw: object) -> ToolUseConfig:
         return val
 
     return ToolUseConfig(
-        chat=_name("chat", "universal-category"),
+        chat=_name("chat", "enumerate-all"),  # #1657: owner default switch (H1 fix)
         step=_name("step", "universal-category"),
         phase=_name("phase", "universal-category"),
     )

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -311,10 +311,13 @@ def registered_scheme_names() -> list[str]:
     return sorted(_SCHEMES)
 
 
-# The default scheme name — universal-category, preserving today's behaviour when
-# no per-layer config overrides it. The OS holds the *name* string (a config key),
-# not scheme logic, so this stays P7-clean.
-DEFAULT_SCHEME_NAME = "universal-category"
+# The default scheme name — enumerate-all (#1657: owner default switch, the H1
+# fix; enumerate-all flat-lists actions so the LLM invokes them directly instead
+# of hallucinating invoke_action names → 30%→100% non-hot-list tool-use).
+# universal-category remains available via config (tool_use.chat) for many-tool /
+# minimal-surface setups. The OS holds the *name* string (a config key), not
+# scheme logic, so this stays P7-clean.
+DEFAULT_SCHEME_NAME = "enumerate-all"
 
 
 __all__ = [

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -208,5 +208,5 @@ def test_codeact_scheme_registered_and_selectable() -> None:
     selected = _resolve_tool_use_scheme("codeact")
     assert selected.name == "codeact"
     assert isinstance(selected, CodeActScheme)
-    # Default is unchanged (universal-category), not codeact.
-    assert _resolve_tool_use_scheme(None).name == "universal-category"
+    # #1657: default is now enumerate-all (not codeact, not universal).
+    assert _resolve_tool_use_scheme(None).name == "enumerate-all"  # #1657

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -152,10 +152,11 @@ def test_format_feedback_delegates_to_ops() -> None:
     assert msgs == [{"role": "tool", "content": "git__commit"}]
 
 
-def test_per_layer_config_nondefault_selects_enumerate_all() -> None:
-    """Tier 2: a NON-default ``tool_use: {chat: enumerate-all}`` resolves the chat
-    layer to EnumerateAllScheme, while the default stays universal-category
-    (byte-identical) and a chat-only override leaves step/phase untouched.
+def test_default_chat_layer_resolves_to_enumerate_all() -> None:
+    """Tier 2: #1657 — the DEFAULT chat layer (None / missing tool_use:) is
+    ``enumerate-all`` (the owner H1 fix) and resolves to EnumerateAllScheme;
+    step/phase keep ``universal-category``. A config override flips chat back to
+    universal-category per-layer (the knob still works both ways).
 
     Pins the config→selection seam at its public surfaces: the per-layer config
     dataclass (``ToolUseConfig``), the scheme resolver (``_resolve_tool_use_scheme``),
@@ -165,14 +166,18 @@ def test_per_layer_config_nondefault_selects_enumerate_all() -> None:
     from reyn.chat.router_loop import _resolve_tool_use_scheme
     from reyn.config import _build_tool_use_config
 
-    # Default (None / missing tool_use:) → all layers universal-category.
+    # #1657: default chat → enumerate-all (resolves to EnumerateAllScheme);
+    # step/phase remain universal-category (the H1 evidence is the chat path).
     default_cfg = _build_tool_use_config(None)
-    assert default_cfg.chat == "universal-category"
-    assert _resolve_tool_use_scheme(default_cfg.chat).name == "universal-category"
+    assert default_cfg.chat == "enumerate-all"
+    assert default_cfg.step == "universal-category"
+    assert default_cfg.phase == "universal-category"
+    assert _resolve_tool_use_scheme(default_cfg.chat).name == "enumerate-all"
 
-    # NON-default chat layer → enumerate-all; sibling layers keep the default.
-    cfg = _build_tool_use_config({"chat": "enumerate-all"})
-    assert cfg.chat == "enumerate-all"
-    assert cfg.step == "universal-category"    # chat-only override is per-layer
+    # The override knob still works: chat → universal-category (the now-non-default)
+    # resolves back, and is per-layer (step/phase untouched).
+    cfg = _build_tool_use_config({"chat": "universal-category"})
+    assert cfg.chat == "universal-category"
+    assert cfg.step == "universal-category"
     assert cfg.phase == "universal-category"
-    assert _resolve_tool_use_scheme(cfg.chat).name == "enumerate-all"
+    assert _resolve_tool_use_scheme(cfg.chat).name == "universal-category"

--- a/tests/test_replay_skill_router.py
+++ b/tests/test_replay_skill_router.py
@@ -281,7 +281,7 @@ def _tool_result(calls: list[dict]) -> LLMToolCallResult:
 
 
 def _make_loop(host: FakeRouterHost, max_iterations: int = 5) -> RouterLoop:
-    return RouterLoop(host=host, chain_id="chain-test", max_iterations=max_iterations)
+    return RouterLoop(host=host, chain_id="chain-test", max_iterations=max_iterations, scheme_name="universal-category")  # #1657: this suite covers universal-category
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -53,6 +53,7 @@ def _tool_result(calls: list[dict]) -> LLMToolCallResult:
 def _make_session(tmp_path: Path) -> ChatSession:
     return ChatSession(
         agent_name="test_agent",
+        chat_tool_use_scheme="universal-category",  # #1657: suite uses universal-category stub shape
     )
 
 
@@ -292,6 +293,7 @@ def test_delegate_registers_pending_chain(tmp_path, monkeypatch):
     session = ChatSession(
         agent_name="test_agent",
         registry=registry,
+        chat_tool_use_scheme="universal-category",  # #1657
     )
     session.is_attached = True
 

--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -197,7 +197,7 @@ def _run_with_llm_sequence(
     async def _fake_call_llm_tools(**kwargs: object) -> LLMToolCallResult:
         return turns.pop(0)
 
-    loop = RouterLoop(host=host, chain_id="chain-test", max_iterations=5)
+    loop = RouterLoop(host=host, chain_id="chain-test", max_iterations=5, scheme_name="universal-category")  # #1657
     monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _fake_call_llm_tools)
     asyncio.run(loop.run("hello", []))
 
@@ -460,7 +460,7 @@ def test_invoke_action_description_has_no_ars_block(monkeypatch: pytest.MonkeyPa
         captured["tools"] = kwargs.get("tools")
         return _text_result("ok")  # finish immediately
 
-    loop = RouterLoop(host=host, chain_id="chain-test", max_iterations=5)
+    loop = RouterLoop(host=host, chain_id="chain-test", max_iterations=5, scheme_name="universal-category")  # #1657
     monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", _capture_tools)
     asyncio.run(loop.run("hello", []))
 

--- a/tests/test_scheme_self_register_1608.py
+++ b/tests/test_scheme_self_register_1608.py
@@ -48,7 +48,7 @@ def test_all_builtins_resolve_in_fresh_interpreter() -> None:
         for n in expected:
             s = get_scheme(n)
             assert s is not None and s.name == n, n
-        assert DEFAULT_SCHEME_NAME == "universal-category"
+        assert DEFAULT_SCHEME_NAME == "enumerate-all"
         assert get_scheme(DEFAULT_SCHEME_NAME) is not None
         print("RESOLVE_OK")
         """
@@ -68,8 +68,8 @@ def test_resolver_finds_all_builtins_without_naming_them() -> None:
             s = _resolve_tool_use_scheme(n)
             assert s is not None and s.name == n, n
         # Unknown / None → default.
-        assert _resolve_tool_use_scheme("no-such").name == "universal-category"
-        assert _resolve_tool_use_scheme(None).name == "universal-category"
+        assert _resolve_tool_use_scheme("no-such").name == "enumerate-all"
+        assert _resolve_tool_use_scheme(None).name == "enumerate-all"
         print("RESOLVE_OK")
         """
     )

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -154,6 +154,13 @@ def _make_session(
         safety=safety,
         registry=registry,
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+        # #1657: these chain-invariant tests stub the LLM with the universal-
+        # category tool-call shape (_delegate_result = invoke_action wrapper),
+        # so pin the scheme to match the stub. They assert WAL/chain behaviour,
+        # not the tool-use scheme; the default is now enumerate-all (which
+        # interprets FLAT native tool_calls, not the wrapper) so an unpinned
+        # session would not dispatch the stub's delegate → no chain_register.
+        chat_tool_use_scheme="universal-category",
     )
     session.register_intervention_listener("test")
     return session

--- a/tests/test_tool_use_scheme_1593.py
+++ b/tests/test_tool_use_scheme_1593.py
@@ -72,9 +72,9 @@ class _RecordingOps:
 def test_registry_register_get_resolve() -> None:
     """Tier 2: register a scheme by name, look it up, and the default name resolves."""
     register_scheme(UniversalCategoryScheme())
-    assert DEFAULT_SCHEME_NAME == "universal-category"
+    assert DEFAULT_SCHEME_NAME == "enumerate-all"
     s = get_scheme(DEFAULT_SCHEME_NAME)
-    assert s is not None and s.name == "universal-category"
+    assert s is not None and s.name == "enumerate-all"  # #1657
     assert DEFAULT_SCHEME_NAME in registered_scheme_names()
     assert get_scheme("no-such-scheme") is None
 
@@ -138,7 +138,7 @@ def test_tool_use_config_per_layer_and_defaults() -> None:
     """Tier 2: per-layer scheme selection parses (NON-default) + defaults to
     universal-category; a non-string value is a loud error."""
     assert _build_tool_use_config(None) == ToolUseConfig()
-    assert ToolUseConfig().chat == "universal-category"
+    assert ToolUseConfig().chat == "enumerate-all"
     cfg = _build_tool_use_config({"chat": "enumerate-all"})
     assert cfg.chat == "enumerate-all"
     assert cfg.step == "universal-category" and cfg.phase == "universal-category"


### PR DESCRIPTION
**[e2e-coder]** — Owner-decided H1 fix: **default the chat tool-use scheme `universal-category` → `enumerate-all`**. Flat-listing actions lets the LLM invoke them directly instead of hallucinating `invoke_action` names (the discover-then-call indirection) — root-caused as the H1 cause of ~30%→100% non-hot-list tool-use. The owner's #1 "unusable" fix.

## Change
- `DEFAULT_SCHEME_NAME` (scheme.py) → `enumerate-all` (the router fallback when a layer name is unset).
- `ToolUseConfig.chat` default + `_build_tool_use_config` loader → `enumerate-all`. **`step` / `phase` keep `universal-category`** (the H1 evidence is the chat path).
- `session.py` `chat_tool_use_scheme` default → `enumerate-all` (matches the config).
- **Completeness (the #1646 lesson)**: classified every `resolve_model`/scheme call-site. The 5 entry callers (chainlit/chat/dogfood/mcp/web) + scoped_session_factory all thread `config.tool_use.chat` — **none hardcode a literal**, so the switch propagates cleanly; router_loop's fallback is `DEFAULT_SCHEME_NAME`.

`reyn.yaml` override still works (`tool_use.chat: universal-category`); enumerate's no-tool_calls guard is robust (#1641) — no ∞-loop risk.

## Tests
- Flipped the default-assertion tests (DEFAULT_SCHEME_NAME / resolve / `ToolUseConfig.chat`) to `enumerate-all`; rewrote the per-layer test for the **inverted contract** (default=enumerate-all + universal-category override still works) — so the default can't silently regress.
- **Blast-radius fix (14 tests)**: pinned the universal-category-specific tests to `chat_tool_use_scheme`/`scheme_name="universal-category"` (replay_skill_router ×7, routing_decided ×4 [invoke_action/hot-list events], router_loop_chatsession ×2, codeact ×1). They test universal-category behaviour / use universal-category-shaped stubs+fixtures — still a valid config; enumerate-all has its own coverage (`test_enumerate_all_scheme`).
- **Full suite**: the only remaining 2 failures (`swebench_missing_honest_skip`, `web_fetch no_media_store`) are **pre-existing on clean origin/main** (verified via worktree — zero overlap with this diff).

## Docs
`reyn-yaml.md` § tool_use + `tool-use-schemes.md` (enumerate-all = chat default; universal-category = step/phase default + large-catalog alternative).

⚠️ **Flag for owner/lead (not decided here)**: the concept doc previously framed `enumerate-all` as "small-tool-set only / NOT a weak-model aid" — which the H1 finding (enumerate-all-as-default fixed 30%→100%) appears to contradict. I updated the default labels but left a deeper trade-off-analysis review to you, since it's a substantive claim the H1 data may have updated.

Refs #1657

## Test plan
- [x] default resolves to enumerate-all (DEFAULT_SCHEME_NAME / ToolUseConfig.chat / resolver) — new assertion guards the switch
- [x] override `tool_use.chat: universal-category` still resolves back (per-layer)
- [x] 14 universal-category-specific tests pinned + green
- [x] full suite: no new failures (2 remaining proven pre-existing on main); ruff + tier-audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
