### PR TITLE
docs(tool-use-schemes): add H1 root-cause + quantified enumerate-all trade-off

### DIFF
--- a/docs/concepts/tools-integrations/tool-use-schemes.md
+++ b/docs/concepts/tools-integrations/tool-use-schemes.md
@@ -20,6 +20,14 @@ what is allowed, only how the LLM is asked to express a call. See
 
 ## The four schemes
 
+A cross-scheme finding (H1): **tool-name visibility predicts invocation
+success**. Schemes that place the callable name directly in the LLM-facing
+surface (`enumerate-all`, `CodeAct`) let the model invoke without guessing;
+schemes that put the name behind an indirection it must first traverse
+(`universal-category`'s discover→invoke, `retrieval`'s search-first) invite
+name-hallucination on non-hot-list tools. This is why the chat default moved to
+`enumerate-all` (#1657).
+
 ### `enumerate-all` (chat default, #1657)
 
 Presents *every* usable tool flatly in the LLM's tool list and dispatches by
@@ -30,8 +38,11 @@ discover-then-call indirection induced (measured ~30%→100% non-hot-list tool-u
 on the chat path). Leaving `tool_use.chat` unset keeps it.
 
 **Use when:** the default for chat — direct, deterministic name→dispatch. The
-trade-off is request size: the flat list grows with the tool set (see
-`universal-category` for very large catalogs).
+trade-off is a **visibility cost, not a weak-model penalty**: request size grows
+linearly with the catalogue (H1 measured ~67 tools ≈ ~50KB of tool surface,
+~3.2× the `universal-category` request) because every name is shown up front.
+That visibility is precisely what fixes weak-model tool-use; the cost is tokens,
+which only bites at very large catalogues (see `universal-category`).
 
 ### `universal-category`
 


### PR DESCRIPTION
**[docs-maintainer]** — Follow-up to #1657 on `docs/concepts/tools-integrations/tool-use-schemes.md`, per lead-coder dispatch (correct the deep trade-off claim with H1 findings).

## Finding first: #1657 already fixed the main worry
The dispatch was premised on the doc still saying "enumerate-all = small-set-only / NOT a weak-model aid". **On current `main` that text is already gone** — #1657 made `enumerate-all` the chat default, dropped the "hardest surface for weak models" claim, and added the ~30%→100% framing. So no contradiction remains to remove.

## What #1657 did NOT capture (this PR adds)
1. **Cross-scheme root cause (H1):** tool-name *visibility* predicts invocation success — `enumerate-all` / `CodeAct` expose the callable name directly → invoke without guessing; `universal-category` (discover→invoke) / `retrieval` (search-first) hide it behind an indirection → name-hallucination on non-hot-list tools. Added as a one-paragraph lead-in under "The four schemes".
2. **Quantified enumerate-all trade-off:** reframed from a vague "request size grows" to a **visibility cost, not a weak-model penalty** — linear in catalogue size (H1 measured ~67 tools ≈ ~50KB, ~3.2× the `universal-category` request), biting only at very large catalogues.

Quantified figures are attributed to the H1 measurement (not asserted as universal law). No `.ja` mirror exists for this doc, so scope is the single `.md`.

## Test plan
- [x] `mkdocs build --strict` → exit 0 (verified)
- [x] (skipped — nav unchanged) no nav entry added/removed; edits are in-section prose only

🤖 Generated with [Claude Code](https://claude.com/claude-code)