### PR TITLE
feat(1658): CodeAct direct-function code-API (replace tool('name') string-proxy; kills name-hallucination)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -3383,6 +3383,12 @@ class RouterLoop:
             sandbox=sandbox,
             extra={
                 "dispatch": _os_gate,
+                # #1658: the DISPATCHABLE catalog (the gate's membership map — the same
+                # names `_os_gate` accepts). CodeAct builds the {identifier:
+                # qualified_name} direct-function stub map from this; self._catalog (the
+                # ADVERTISED payload) is empty for CodeAct, so the dispatchable map is
+                # the right source. Generic catalog (action names), not scheme vocab (P7).
+                "dispatchable_catalog": self._dispatch_catalog or self._catalog,
                 "sandbox_policy": getattr(self.host, "default_sandbox_policy", None)
                 or {"network": False, "allow_subprocess": False, "env_passthrough": ["PATH"]},
             },

--- a/src/reyn/kernel/_codeact_harness.py
+++ b/src/reyn/kernel/_codeact_harness.py
@@ -109,6 +109,22 @@ def _make_tool_shim(channel: _ControlChannel):
     return tool
 
 
+def _make_action_stub(qualified_name: str, tool_shim: Any):
+    """#1658: a gated DIRECT-FUNCTION stub for one action — a thin renamed wrapper of
+    the ``tool`` marshalling primitive with the qualified name BAKED IN. Calling
+    ``file__read(path=...)`` marshals ``('file__read', kwargs)`` over the SAME control
+    channel to the SAME parent gate (exclude + dispatch_tool + permission). Gating is
+    identical to the old ``tool('file__read', ...)`` proxy; only the LLM-facing surface
+    changes (a selected identifier, never a produced string). Keyword args only
+    (matches the proxy contract + the SP's keyword example); a positional call raises a
+    clear TypeError the model self-corrects from."""
+
+    def _stub(**kwargs: Any) -> Any:
+        return tool_shim(qualified_name, **kwargs)
+
+    return _stub
+
+
 class ToolError(RuntimeError):
     """Raised inside a CodeAct snippet when a proxied tool call returns an error
     envelope (permission_denied / tool_excluded / unknown_tool / exception)."""
@@ -120,23 +136,38 @@ class ToolError(RuntimeError):
 
 
 def _exec_codeact(
-    code: str, channel: _ControlChannel, allowed_modules: frozenset[str],
+    code: str,
+    channel: _ControlChannel,
+    allowed_modules: frozenset[str],
+    actions: "dict[str, str] | None" = None,
 ) -> Any:
-    """Validate + exec the snippet with the restricted builtins + the tool shim.
+    """Validate + exec the snippet with the restricted builtins + the gated
+    direct-function stubs.
 
     Returns the snippet's ``result`` binding if it defines one, else None. The
-    snippet affects the world ONLY through ``tool(...)`` (the parent-gated proxy);
-    the restricted builtins block ``open`` / ``eval`` / ``__import__`` of
-    non-allowlisted modules (defense-in-depth on top of the sandbox)."""
+    snippet affects the world ONLY through the injected action functions (#1658:
+    ``file__read(...)`` etc., each a parent-gated stub) — or the internal ``tool()``
+    primitive they wrap (kept available but NOT advertised). The restricted builtins
+    block ``open`` / ``eval`` / ``__import__`` of non-allowlisted modules
+    (defense-in-depth on top of the sandbox)."""
     tree = ast.parse(code, filename="<codeact>")
     _validate_safe_ast(tree, allowed_modules)
     builtins_dict = _build_restricted_builtins(allowed_modules)
 
+    tool_shim = _make_tool_shim(channel)
     namespace: dict[str, Any] = {
         "__builtins__": builtins_dict,
         "__name__": "__reyn_codeact__",
-        "tool": _make_tool_shim(channel),
+        # Internal marshalling primitive — the stubs wrap it. Kept callable for
+        # back-compat but NOT advertised in the SP (the code-API lists the direct
+        # functions only; advertising tool('name') would reintroduce the
+        # string-production hallucination path #1658 eliminates).
+        "tool": tool_shim,
     }
+    # #1658: inject one gated direct-function stub per action (identifier →
+    # qualified-name closure over the SAME tool_shim → SAME parent gate).
+    for ident, qualified in (actions or {}).items():
+        namespace[ident] = _make_action_stub(qualified, tool_shim)
     compiled = compile(tree, filename="<codeact>", mode="exec")
     exec(compiled, namespace)  # noqa: S102 — sandboxed subprocess + restricted ns
     return namespace.get("result")
@@ -162,11 +193,12 @@ def main() -> int:
         code = str(req["code"])
         control_fd = int(req["control_fd"])
         allowed_modules = frozenset(req.get("allowed_modules") or [])
+        actions = req.get("actions") or {}  # #1658 {identifier: qualified_name}
 
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=control_fd)
         channel = _ControlChannel(sock)
 
-        result = _exec_codeact(code, channel, allowed_modules)
+        result = _exec_codeact(code, channel, allowed_modules, actions)
         # #1618 root-2: final result on the CONTROL CHANNEL (op="final"), not stdout
         # — user code's stdout/stderr stay clean for the parent to capture as data.
         channel.send({"op": "final", "ok": True, "result": result})

--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -75,6 +75,7 @@ class CodeActRunner:
         *,
         code: str,
         dispatch: DispatchFn,
+        actions: "dict[str, str] | None" = None,  # #1658 {identifier: qualified_name}
         sandbox_backend: Any = None,
         sandbox_policy: dict | None = None,
         allowed_modules: list[str] | None = None,
@@ -115,6 +116,11 @@ class CodeActRunner:
         request = {
             "code": code,
             "control_fd": child_fd,
+            # #1658: {identifier: qualified_name} — the harness injects a gated direct-
+            # function stub per identifier (each marshals the REAL qualified name over
+            # the control channel to the parent gate). Empty → no direct functions
+            # (back-compat: the snippet can still use the internal tool() primitive).
+            "actions": dict(actions or {}),
             "allowed_modules": list(allowed_modules or []),
         }
 

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -23,10 +23,46 @@ permission internals — it orchestrates, the OS gates (P3/P7).
 from __future__ import annotations
 
 import json
+import keyword
 import re
 from typing import Any
 
 from reyn.kernel.codeact_runner import CodeActRunner
+
+
+def _sanitize_identifier(name: str) -> str:
+    """#1658: a qualified action name → a valid Python identifier. Most names
+    (``file__read``, ``exec__sandboxed_exec``) already are; MCP / skill names with
+    hyphens or dots (``web-search__search``) are not — non-identifier chars become
+    ``_``, a leading digit is prefixed, and a Python keyword is suffixed. The REAL
+    qualified name is preserved in the actions map and is what the parent gate
+    receives — the identifier is only the LLM-facing Python name."""
+    s = re.sub(r"\W", "_", name)
+    if not s or s[0].isdigit():
+        s = "_" + s
+    if keyword.iskeyword(s):
+        s = s + "_"
+    return s
+
+
+def _build_actions_map(qualified_names: "list[str]") -> "dict[str, str]":
+    """#1658: ``{python_identifier: qualified_name}`` for the direct-function code-API.
+
+    DETERMINISTIC (sorted) with collision-disambiguation (``_2`` / ``_3`` …) so that
+    ``build_presentation`` (renders the SP signatures) and ``execute`` (builds the
+    harness stubs) compute the **identical** map when both run it over the same full
+    dispatchable name set — the model's identifier call always matches a stub, and
+    the stub marshals the real qualified name to the parent gate."""
+    out: "dict[str, str]" = {}
+    used: set[str] = set()
+    for qn in sorted(qualified_names):
+        base = _sanitize_identifier(qn)
+        ident, n = base, 2
+        while ident in used:
+            ident, n = f"{base}_{n}", n + 1
+        used.add(ident)
+        out[ident] = qn
+    return out
 from reyn.tools.scheme import (
     CodeBlock,
     ExecContext,
@@ -44,53 +80,54 @@ from reyn.tools.scheme import (
 _FENCE_RE = re.compile(r"```(?:python|py|tool_code)?\s*\n(.*?)```", re.DOTALL)
 
 
-def _render_code_api(entries: list[dict]) -> str:
-    """Render flat ``{name, description, parameters}`` action entries as a CodeAct
-    *code-API*: a reference list of the actions the model invokes via the
-    ``tool(...)`` proxy. Pure presentation — the model reads it; it is NOT executed
-    Python. The arg names come from each entry's JSON-schema ``parameters.properties``
-    (CodeAct's strictest-consumer schema-completeness floor guarantees a dict)."""
-    # #1618 root-3 (②): this is the REPLACEMENT tool-use SP (Presentation.tool_use_sp)
-    # — it is the SOLE tool-use instruction the model sees (the OS drops the universal
-    # invoke_action / list_actions / ROUTING-RULE vocab for this region). So it must
-    # carry the whole CodeAct contract: act = a single fenced python block; prose = the
-    # terminal final answer (the #2 loop-unify contract — the model must KNOW prose ends
-    # the turn, or it never cleanly finishes). Wording is the measured variable for the
-    # fence-compliance oracle (dogfood-coder owns content finalization).
+def _render_code_api(entries: list[dict], ident_by_qn: "dict[str, str]") -> str:
+    """#1658: render flat ``{name, description, parameters}`` entries as a CodeAct
+    *code-API* — DIRECT function signatures the model calls by name
+    (``file__read(path=...)``), NOT the old ``tool('name', ...)`` string-proxy. The
+    function name is a selected Python identifier (``ident_by_qn[qualified]``), so the
+    action name can never be a hallucinated produced string. Pure presentation — the
+    model reads these signatures and writes the calls; the OS injects gated stubs of
+    the same names into the sandbox namespace (each marshals to the parent gate).
+
+    This is the SOLE tool-use instruction the model sees (Presentation.tool_use_sp —
+    the OS drops the universal invoke_action / list_actions vocab for this region), so
+    it carries the whole CodeAct contract: act = a single fenced python block; prose =
+    the terminal final answer (the loop-unify contract — prose ends the turn)."""
     lines = [
         "## Tool use — this agent acts by running Python, not JSON tool calls",
         "",
         "To DO anything (read a file, call an action, compute), respond with a "
         "SINGLE fenced ```python block and NOTHING else — no prose before or after it, "
-        "no \"I am a Reyn agent\" preamble on an action turn. Inside the block, call any "
-        "available action:",
+        "no \"I am a Reyn agent\" preamble on an action turn. Inside the block, call the "
+        "available functions DIRECTLY by name and assign your final value to `result`:",
         "",
-        "    result = `tool('<name>', <arg>=<value>, ...)`",
+        "    result = file__read(path=\"README.md\")",
         "",
-        "`tool(...)` returns the action's result, or raises if the action is denied / "
-        "excluded / unknown. Assign your final answer to `result`. The Python standard "
-        "library is available; filesystem / network / subprocess are sandboxed — reach "
-        "the outside world ONLY via `tool()`.",
+        "Each function returns the action's result, or raises if the action is denied / "
+        "excluded / unknown. The Python standard library is available; filesystem / "
+        "network / subprocess are sandboxed — reach the outside world ONLY by calling "
+        "these functions.",
         "",
         "When you are DONE (answer in hand, no more actions to run): reply in plain "
         "prose with NO code block — that ends the turn. A turn is EITHER one fenced "
         "```python block OR a plain-prose final answer, never both.",
         "",
-        "Available actions:",
+        "Available functions:",
     ]
     for entry in entries:
         name = entry.get("name", "")
+        ident = ident_by_qn.get(name, _sanitize_identifier(name))
         params = entry.get("parameters") or {}
         arg_names = list((params.get("properties") or {}).keys())
         sig = ", ".join(arg_names)
         desc_raw = (entry.get("description") or "").strip()
         desc = desc_raw.splitlines()[0] if desc_raw else ""
-        # #1638: backtick-wrap the rendered call so the SP carries NO bare quoted
-        # `tool('<x>')` token — gemini-2.5-flash-lite returns ~100% empty-choices on a
-        # bare `tool('<quoted>')` token (content-trigger; lead+sandbox_2 proxy-probe:
-        # bare 6/6 empty → backtick 0/6). Presentation-only: the catalog is a reference
-        # list the model READS; it still writes bare `tool(...)` inside its python block.
-        lines.append(f"- `tool('{name}'{', ' + sig if sig else ''})` — {desc}".rstrip(" —"))
+        # A direct function signature — the model calls `ident(args)`. No quoted
+        # `tool('<x>')` token anywhere in the SP (#1638: that bare token caused
+        # ~100% empty choices on gemini-2.5-flash-lite; the direct-call form removes
+        # it entirely — the model writes an identifier call, not a quoted string).
+        line = f"- `def {ident}({sig})`"
+        lines.append(f"{line} — {desc}" if desc else line)
     return "\n".join(lines)
 
 
@@ -173,6 +210,12 @@ class CodeActScheme:
         # OS-owned projection — no hand-read of a nested dict at a guessed depth, which
         # was #1: tool('') ×50, and #3: the exclude filter silently never matched).
         flat = flat_catalog_entries(entries)
+        # #1658: the identifier map over the FULL dispatchable name set (deterministic
+        # sort + collision-disambig) so it is IDENTICAL to the map execute builds for
+        # the harness stubs → the model's identifier call always matches a stub.
+        ident_by_qn = {
+            qn: ident for ident, qn in _build_actions_map([e["name"] for e in flat]).items()
+        }
         # Presentation parity with the JSON path (#1400): omit excluded actions from
         # the rendered code-API (defense-in-depth — the real gate is per-call). The OS
         # supplies the session exclude-set via ``available``.
@@ -196,7 +239,7 @@ class CodeActScheme:
             # 1/2/5/6). tool_use_sp ⇒ the OS injects this at the ## Capabilities
             # position + drops the universal tool-use construction, so the code-API is
             # the SOLE tool-use instruction the model sees.
-            tool_use_sp=_render_code_api(rendered),
+            tool_use_sp=_render_code_api(rendered, ident_by_qn),
         )
 
     def interpret(
@@ -233,9 +276,25 @@ class CodeActScheme:
                 "(the OS per-call exclude + dispatch_tool gate)"
             )
         extra = exec_ctx.extra or {}
+        # #1658: build the {identifier: qualified_name} map over the full dispatchable
+        # catalog the OS threads in (the gate's membership) using the SAME deterministic
+        # _build_actions_map as build_presentation → identical identifiers as the SP.
+        # The harness injects a gated stub per identifier that marshals the REAL
+        # qualified name to `dispatch` (the parent gate) — gating identical to the old
+        # tool('name') proxy (denied/excluded/unknown → same raise).
+        _dispatchable = extra.get("dispatchable_catalog") or exec_ctx.tool_catalog or {}
+        if isinstance(_dispatchable, dict):
+            _names = list(_dispatchable.keys())
+        else:
+            _names = [
+                (e.get("function") if isinstance(e.get("function"), dict) else e).get("name", "")
+                for e in _dispatchable
+            ]
+        actions_map = _build_actions_map([n for n in _names if n])
         out = await self._runner.run(
             code=interp.code,
             dispatch=dispatch,
+            actions=actions_map,
             sandbox_backend=exec_ctx.sandbox,
             sandbox_policy=extra.get("sandbox_policy"),
             allowed_modules=extra.get("allowed_modules"),

--- a/tests/test_codeact_direct_functions_1658.py
+++ b/tests/test_codeact_direct_functions_1658.py
@@ -1,0 +1,108 @@
+"""Tier 2: #1658 — CodeAct direct-function stubs gate EXACTLY like the old
+tool('name') proxy, including the hyphenated-alias path.
+
+The redesign replaces the tool('<name>', args) string-proxy with gated direct
+functions (file__read(...)) injected into the sandbox namespace. Each stub is a
+thin renamed wrapper of the same marshalling primitive — it sends the REAL
+qualified name over the SAME control channel to the SAME parent dispatch gate. So:
+(a) the gate runs on the REAL qualified name (not the Python identifier), even
+    when the identifier was sanitized from a hyphenated MCP name; and
+(b) a denied action raises in the snippet, exactly as the proxy did.
+
+Real CodeActRunner + a real async dispatch double (no mocks); allow_unsandboxed
+(the test-only transport escape — the sandbox is orthogonal to the gating proof).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.kernel.codeact_runner import CodeActRunner
+
+
+@pytest.mark.asyncio
+async def test_direct_function_marshals_real_qualified_name_through_gate() -> None:
+    """Tier 2: #1658 — calling the sanitized identifier ``web_search__search(...)``
+    marshals the REAL qualified name ``web-search__search`` to the parent gate (the
+    gate runs on the real name, not the Python identifier). The aliasing-gate path."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": {"hits": 1}}
+
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="result = web_search__search(query='reyn')",
+        dispatch=dispatch,
+        actions={"web_search__search": "web-search__search"},
+        allow_unsandboxed=True,
+    )
+    assert out["ok"] is True, out
+    # The gate received the REAL hyphenated qualified name, not the identifier.
+    assert seen == [("web-search__search", {"query": "reyn"})]
+    assert out["result"] == {"hits": 1}
+
+
+@pytest.mark.asyncio
+async def test_direct_function_denied_raises_in_snippet() -> None:
+    """Tier 2: #1658 — a denied action (gate returns an error envelope) raises inside
+    the snippet exactly as the old tool() proxy did (gating ENFORCED: denied→raise)."""
+    async def dispatch(name: str, args: dict) -> dict:
+        return {
+            "status": "error",
+            "error": {"message": "permission denied", "kind": "permission_denied"},
+        }
+
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="result = exec__sandboxed_exec(cmd='rm -rf /')",
+        dispatch=dispatch,
+        actions={"exec__sandboxed_exec": "exec__sandboxed_exec"},
+        allow_unsandboxed=True,
+    )
+    # The denied stub call raised ToolError → uncaught → snippet failed.
+    assert out["ok"] is False
+    assert "permission denied" in (out.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_simple_identifier_direct_call_gates_same_name() -> None:
+    """Tier 2: #1658 — a plain-identifier action (file__read) gates the same name."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": "CONTENT"}
+
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="result = file__read(path='README.md')",
+        dispatch=dispatch,
+        actions={"file__read": "file__read"},
+        allow_unsandboxed=True,
+    )
+    assert out["ok"] is True and out["result"] == "CONTENT"
+    assert seen == [("file__read", {"path": "README.md"})]
+
+
+@pytest.mark.asyncio
+async def test_internal_tool_primitive_still_callable() -> None:
+    """Tier 2: #1658 — the internal tool() primitive the stubs wrap stays callable
+    (back-compat / dynamic-name escape), even though the SP advertises only the direct
+    functions. Confirms the redesign ADDS the direct surface without removing the
+    underlying gated primitive."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": 42}
+
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="result = tool('file__read', path='x')",
+        dispatch=dispatch,
+        actions={"file__read": "file__read"},
+        allow_unsandboxed=True,
+    )
+    assert out["ok"] is True and out["result"] == 42
+    assert seen == [("file__read", {"path": "x"})]

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -149,11 +149,13 @@ async def test_build_presentation_renders_code_api_into_tool_use_sp() -> None:
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
     # No JSON tools= — CodeAct presents via the SP, model writes a snippet.
     assert pres.llm_tools_payload == []
-    # The actions surface in the code-API + the tool() proxy is instructed, via the
-    # REPLACE channel (tool_use_sp), and the old APPEND channel is unused.
+    # The actions surface in the code-API as DIRECT functions (#1658: def <name>(...),
+    # not the tool('name') string-proxy), via the REPLACE channel (tool_use_sp); the
+    # old APPEND channel is unused.
     assert "file__read" in pres.tool_use_sp
     assert "web__fetch" in pres.tool_use_sp
-    assert "tool(" in pres.tool_use_sp
+    assert "def file__read(" in pres.tool_use_sp  # #1658 direct-function signature
+    assert "tool('" not in pres.tool_use_sp        # #1658: no string-proxy token
     assert not pres.sp_fragment  # root-3: replace channel, not append
     # The prose=terminal contract (#2) must be stated so the model knows how to finish.
     assert "plain prose" in pres.tool_use_sp
@@ -170,19 +172,19 @@ async def test_build_presentation_includes_arg_names() -> None:
 
 
 @pytest.mark.asyncio
-async def test_code_api_has_no_bare_tool_call_for_flashlite() -> None:
-    """Tier 2: #1638 — the rendered code-API carries NO bare quoted ``tool('<x>')``
-    token. gemini-2.5-flash-lite returns ~100% empty-choices on a bare ``tool('<quoted>')``
-    token (content-trigger, lead+sandbox_2 proxy-probe: bare 6/6 empty → backtick 0/6);
-    the CodeAct code-API rendered ~50 such bare lines. Presentation-only — every rendered
-    call is backtick-wrapped; the model still writes bare ``tool(...)`` in its python block."""
-    import re
-
+async def test_code_api_has_no_tool_string_proxy_token() -> None:
+    """Tier 2: #1658 (supersedes #1638) — the rendered code-API carries NO
+    ``tool('<x>')`` string-proxy token at all. The direct-function redesign renders
+    ``def file__read(path)`` signatures the model calls by name, so the quoted
+    ``tool('<quoted>')`` token (which caused ~100% empty-choices on
+    gemini-2.5-flash-lite, #1638) is eliminated entirely — there is no string the
+    model produces for the action name. Strictly stronger than the #1638 backtick-wrap."""
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
-    # No bare `tool('` (one not immediately preceded by a backtick) anywhere in the render.
-    assert not re.search(r"(?<!`)tool\('", pres.tool_use_sp)
-    # The call IS present, backtick-wrapped (the action is still discoverable/usable).
-    assert "`tool('file__read'" in pres.tool_use_sp
+    # NO tool('...') string-proxy token anywhere (direct functions only).
+    assert "tool('" not in pres.tool_use_sp
+    assert 'tool("' not in pres.tool_use_sp
+    # The action IS present as a DIRECT function the model calls by name.
+    assert "def file__read(" in pres.tool_use_sp
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — Owner directive: eliminate CodeAct's indirect-call deviation. Replace the `tool('<name>', args)` **string-proxy** with gated **direct functions** in the exec namespace (industry CodeAct: `file__read(...)` / `exec__sandboxed_exec(...)` called directly). The action name becomes a **selected Python identifier**, never a produced string → kills the name-hallucination AND aligns with the industry.

## Design (lead-approved)
- `_render_code_api` emits `def <identifier>(<params>)` signatures (not `tool('name')`); the model calls them directly.
- `_sanitize_identifier` + `_build_actions_map`: qualified names like `file__read` are already valid identifiers; MCP/skill names with hyphens/dots (`web-search__search`) are sanitized (→ `web_search__search`) with deterministic collision-disambiguation. `build_presentation` (SP render) + `execute` (harness stubs) compute the **identical** map over the full dispatchable set → the SP's identifiers always match the injected stubs.
- The harness (`_codeact_harness`) injects **one gated stub per action** — a thin renamed wrapper of the existing `tool()` marshalling primitive with the qualified name **baked in**.

## Gating preserved EXACTLY (the critical correctness — lead's merge gate)
`file__read(**kw)` ≡ `tool('file__read', **kw)` → **same** control-channel op → **same** parent gate (exclude + dispatch_tool + permission, P5) → same envelope. The child still holds **zero** permission authority, the AF_UNIX socket stays the sole audited hole, the fail-closed sandbox is unchanged, denied/excluded/unknown → same raise. The stubs simply wrap the existing primitive — **no new authority in the child**. P6 audit unchanged (same op). `tool()` stays callable internally (stubs wrap it) but is **not advertised** (advertising `tool('name')` would reintroduce the string-production hallucination this eliminates).

**Verified end-to-end (real runner subprocess)** — `test_codeact_direct_functions_1658`:
- the direct stub marshals the **REAL** qualified name to the gate, incl. the **alias path** (`web_search__search` stub → gate sees `web-search__search`) ✓
- denied action → **raises** in the snippet ✓
- simple identifier gates the same name ✓; internal `tool()` still callable ✓

## #1638 side-benefit (by construction)
The SP carries **NO** `tool('<quoted>')` token (the gemini-flash-lite ~100%-empty-choices trigger) — only `def <name>(...)` signatures. A test asserts it (`test_code_api_has_no_tool_string_proxy_token`), strictly stronger than the old #1638 backtick-wrap.

Refs #1658 #1638

## Test plan
- [x] gating-preservation: real-name marshalled (incl. hyphen-alias path), denied→raises, internal tool() intact
- [x] direct-function rendering (`def file__read(...)`) + no `tool('` token in the SP
- [x] sanitization deterministic + collision-disambiguation (order-independent)
- [x] 164 codeact/scheme/router/harness regression pass; ruff + tier-audit clean
- [ ] **(sandbox_2, dogfood 4-way)** live model-behavior before/after on the H1 exec task: name-hallucination gone (model writes `exec__sandboxed_exec(...)` directly) + #1638 empty-choices resolved on gemini-flash-lite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
