### PR TITLE
fix(1616): cause-aware embedding-index-build error + direct-call drop_params + docs

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -925,6 +925,20 @@ See [Concepts: MCP](../../concepts/tools-integrations/mcp.md) for the protocol o
 
 RAG embedding model classes and batch settings. Built-in defaults cover the OpenAI path — no `reyn.yaml` changes are required for a fresh install with `OPENAI_API_KEY`.
 
+> **Non-OpenAI embeddings behind a LiteLLM proxy (#1616).** If your embedding
+> class routes through a LiteLLM proxy to a non-OpenAI provider (e.g. an
+> OpenAI-named route like `text-embedding-3-small` that the proxy maps to
+> `gemini-embedding-001`), the proxy may add `encoding_format` — which Gemini
+> rejects (`UnsupportedParamsError`), and the **action embedding index build
+> fails → `search_actions` is disabled** (the retrieval scheme goes dead). The
+> fix is **proxy-side**: set `litellm_settings:\n  drop_params: true` on your
+> LiteLLM proxy so it drops provider-unsupported params. (The client-side flag
+> does **not** apply on the proxy route — a known litellm behaviour. For a
+> *direct* non-proxy embedding call, reyn already passes `drop_params=True`.)
+> Alternatively use an OpenAI-compatible embedding class, or set
+> `action_retrieval.embedding_class: null` to opt out. reyn surfaces this exact
+> guidance when the index build fails with an `UnsupportedParamsError`.
+
 ```yaml
 embedding:
   default_class: standard         # class to use when no class is specified

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -498,6 +498,61 @@ def _is_context_overflow_error(exc: BaseException) -> bool:
     return any(kw in msg for kw in _CONTEXT_OVERFLOW_KEYWORDS)
 
 
+def _is_unsupported_param_error(exc: BaseException) -> bool:
+    """#1616: True when *exc* is the embedding provider rejecting a param.
+
+    Detects the gemini-via-LiteLLM-proxy case where the proxy adds
+    ``encoding_format`` and the provider rejects it (``UnsupportedParamsError``),
+    which fails the action embedding index build. Keyword/typename match — the
+    same stringified-exception heuristic family as ``_is_context_overflow_error``.
+    """
+    return (
+        "UnsupportedParams" in type(exc).__name__
+        or "does not support parameter" in str(exc)
+        or "encoding_format" in str(exc)
+    )
+
+
+def _action_index_build_failure_warning(exc: BaseException, model_class: Any) -> str:
+    """#1616: cause-aware operator guidance for a failed action-embedding-index build.
+
+    Two distinct failure modes need two distinct operator actions, so branch on
+    the cause instead of emitting one misleading message (the #1458 warning was
+    HF-download-specific):
+
+    * **Unsupported-param** (``UnsupportedParamsError`` — the embedding provider
+      rejected a param, typically ``encoding_format`` on a gemini-routed embedding
+      behind a LiteLLM proxy): point to the recommended *proxy-side* fix
+      (``litellm_settings: drop_params: true``), since reyn cannot suppress a
+      param the proxy injects.
+    * **Otherwise** (e.g. a Hugging Face model download failed): the pre-existing
+      offline/cache guidance.
+
+    Returned as a fully-formatted string so the cause-selection is unit-testable
+    without driving the whole index build.
+    """
+    if _is_unsupported_param_error(exc):
+        return (
+            "Semantic search_actions disabled for this session: the embedding "
+            f"provider REJECTED a parameter ({type(exc).__name__}: {exc}). This is "
+            "typically `encoding_format` on a gemini-routed embedding behind a "
+            "LiteLLM proxy (the proxy adds it; the provider rejects it). Fix: set "
+            "`litellm_settings:\n  drop_params: true` on your LiteLLM PROXY (the "
+            "client-side flag does NOT apply on the proxy route — known litellm "
+            "behaviour), OR use an OpenAI-compatible embedding class. Options to "
+            "opt out: set `action_retrieval.embedding_class: null`."
+        )
+    return (
+        "Semantic search_actions disabled for this session: action embedding "
+        f"index build failed for model class {model_class!r} "
+        f"({type(exc).__name__}). Possible cause: model download failed — "
+        "Hugging Face unreachable (offline / corporate network?). Options: "
+        "(1) pre-download the model on a connected machine so it is in the HF "
+        "cache, (2) set `action_retrieval.embedding_class: null` to opt out, "
+        "(3) use an API-backed class (e.g. `standard`)."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Host protocol
 # ---------------------------------------------------------------------------
@@ -3580,16 +3635,12 @@ class RouterLoop:
             # consistent.
             import logging
 
+            # #1616: cause-aware guidance (UnsupportedParamsError → proxy-side
+            # drop_params; else the HF-download case). Extracted to a unit-testable
+            # module helper so the cause-selection is pinned without driving the
+            # whole index build.
             logging.getLogger(__name__).warning(
-                "Semantic search_actions disabled for this session: action "
-                "embedding index build failed for model class %r (%s). "
-                "Possible cause: model download failed — Hugging Face "
-                "unreachable (offline / corporate network?). "
-                "Options: (1) pre-download the model on a connected machine "
-                "so it is in the HF cache, (2) set "
-                "`action_retrieval.embedding_class: null` to opt out, "
-                "(3) use an API-backed class (e.g. `standard`).",
-                model_class, type(exc).__name__,
+                "%s", _action_index_build_failure_warning(exc, model_class)
             )
 
     async def _build_router_caller_state(self) -> Any:

--- a/src/reyn/embedding/litellm_provider.py
+++ b/src/reyn/embedding/litellm_provider.py
@@ -298,6 +298,14 @@ class LiteLLMEmbeddingProvider:
                 response = await litellm.aembedding(
                     model=effective_model,
                     input=batch,
+                    # #1616: drop provider-unsupported params (e.g. encoding_format
+                    # on a DIRECT gemini-embedding call) — the litellm-recommended
+                    # client default for embeddings. Fixes the direct / non-proxy
+                    # provider-mismatch; a harmless no-op when routing via a proxy
+                    # (there the param is added/rejected proxy-side, so the proxy
+                    # needs `litellm_settings: drop_params: true` — see the
+                    # action-index-build-failed operator guidance + docs).
+                    drop_params=True,
                     **extra,
                 )
                 return self._parse_response(response, resolved_model)

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -134,3 +134,85 @@ def test_warning_log_emitted_once_with_options(caplog) -> None:
     assert "hugging face" in text or "hf" in text or "download" in text, (
         "cause (HF / download) must be named"
     )
+
+
+# ── #1616: cause-aware guidance — UnsupportedParamsError vs HF-download ──────────
+
+
+class _UnsupportedParamsError(Exception):
+    """Real fake mirroring litellm's UnsupportedParamsError TYPENAME (the helper
+    keys on the type name, not the class identity). No Mock per policy."""
+
+
+class _UnsupportedParamProvider:
+    """Real fake provider whose embed() raises the proxy-rejects-param error —
+    the #1616 gemini-via-LiteLLM-proxy case (encoding_format rejected)."""
+
+    async def embed(self, *_args, **_kwargs):  # type: ignore[override]
+        raise _UnsupportedParamsError(
+            "litellm.UnsupportedParamsError: gemini-embedding-001 does not support "
+            "parameter: encoding_format"
+        )
+
+    def get_dimension(self, *_args, **_kwargs) -> int:
+        raise _UnsupportedParamsError("does not support parameter: encoding_format")
+
+
+class _UnsupportedParamIndex:
+    """Real fake index whose build() surfaces the provider's UnsupportedParamsError
+    (mirrors ActionEmbeddingIndex.build propagating the embed() exception)."""
+
+    def is_ready(self) -> bool:
+        return False
+
+    async def build(self, items, provider, model_class):  # type: ignore[override]
+        # Drive the real embed() so the genuine provider exception propagates,
+        # exactly as the production build path does (idx.build(items, provider, model_class)).
+        await provider.embed(items)
+
+
+def test_helper_unsupported_param_points_to_proxy_drop_params() -> None:
+    """Tier 2: #1616 — the cause-aware helper, given an UnsupportedParamsError,
+    returns the PROXY-side drop_params guidance (not the misleading HF-download
+    message). reyn cannot suppress a param the proxy injects, so the operator is
+    pointed to the recommended `litellm_settings: drop_params: true` on the proxy."""
+    from reyn.chat.router_loop import _action_index_build_failure_warning
+
+    exc = _UnsupportedParamsError(
+        "gemini-embedding-001 does not support parameter: encoding_format"
+    )
+    msg = _action_index_build_failure_warning(exc, "standard").lower()
+    assert "drop_params" in msg, "must name the recommended proxy-side fix"
+    assert "proxy" in msg, "must say the fix is proxy-side"
+    assert "encoding_format" in msg, "must name the rejected param"
+    # Must NOT mislead with the HF-download cause for a param-rejection failure.
+    assert "hugging face" not in msg and "download" not in msg
+
+
+def test_helper_generic_failure_keeps_hf_guidance() -> None:
+    """Tier 2: #1616 — a non-param failure (e.g. HF unreachable) still returns the
+    pre-existing offline/cache guidance (regression pin for the #1458 branch)."""
+    from reyn.chat.router_loop import _action_index_build_failure_warning
+
+    exc = RuntimeError("Name or service not known (HF unreachable)")
+    msg = _action_index_build_failure_warning(exc, "local-mini").lower()
+    assert "hugging face" in msg or "download" in msg
+    assert "drop_params" not in msg
+
+
+def test_build_failure_unsupported_param_warns_proxy_fix(caplog) -> None:
+    """Tier 2: #1616 — driving the real build path with a provider that raises the
+    proxy-rejects-param error logs the proxy drop_params guidance (the operator is
+    NOT left with a silent empty index nor the misleading HF message)."""
+    loop = _LoopWithFailingBuild()
+    idx = _UnsupportedParamIndex()
+    provider = _UnsupportedParamProvider()
+    with caplog.at_level(logging.WARNING, logger="reyn.chat.router_loop"):
+        asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
+
+    text = " ".join(
+        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+    ).lower()
+    assert "drop_params" in text and "proxy" in text, (
+        f"expected proxy drop_params guidance; got: {text!r}"
+    )

--- a/tests/test_embedding_provider.py
+++ b/tests/test_embedding_provider.py
@@ -283,6 +283,38 @@ class TestEmbedEmptyList:
         assert result["vectors"] == []
 
 
+class TestEmbedDropParams:
+    def test_direct_call_passes_drop_params_true(self, monkeypatch):
+        """Tier 2: #1616 — the direct litellm.aembedding call passes drop_params=True
+        so a provider-unsupported param (e.g. encoding_format on a DIRECT gemini-
+        embedding call) is dropped client-side instead of failing the index build.
+        Captures the real kwargs via a monkeypatched aembedding (no Mock)."""
+        from types import SimpleNamespace
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_aembedding(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                data=[{"index": 0, "embedding": [0.1, 0.2, 0.3]}],
+                usage=SimpleNamespace(total_tokens=3),
+                model=kwargs.get("model", ""),
+            )
+
+        import litellm
+
+        monkeypatch.setattr(litellm, "aembedding", _fake_aembedding)
+
+        provider = _make_provider()
+        result = asyncio.run(provider.embed(["hello"], "openai/text-embedding-3-small"))
+
+        assert captured.get("drop_params") is True, (
+            f"expected drop_params=True forwarded to litellm.aembedding; got {captured!r}"
+        )
+        assert captured.get("input") == ["hello"]
+        assert result["vectors"] == [[0.1, 0.2, 0.3]]
+
+
 # ---------------------------------------------------------------------------
 # estimate_indexing_cost
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — owner-priority. Refs #1616.

## Problem

The action-embedding-index build dies on a **gemini-routed embedding behind a LiteLLM proxy**: the proxy maps an OpenAI-named route (`text-embedding-3-small`) to `gemini-embedding-001` and forwards `encoding_format` → Gemini rejects it (`UnsupportedParamsError`) → `ActionEmbeddingIndex.build` fails → `search_actions` empty → **retrieval scheme dead** (blocks #1631's retrieval arm). Today this degrades to a *silent empty index* with a misleading HF-download warning.

## Confirm-first — primary data (curl bisection against the live proxy at :4000)

| Request | Result |
|---|---|
| bare embed (`model`, `input` only) | **SUCCESS — 3072 dims** |
| `+ encoding_format: "float"` | **error (provider rejects param)** |

→ gemini-embedding is fine **without** the param; the **proxy adds/forwards it**, and **reyn-code cannot suppress a param the proxy injects** (litellm also re-injects `encoding_format` downstream at `openai.py:101-107` regardless of client introspection — so the "omit via `get_supported_openai_params`" idea was also discarded with evidence). The recommended fix is therefore **proxy-side**: `litellm_settings: drop_params: true` on the LiteLLM proxy.

Contrast with #1650 (same param-mismatch class, **opposite** direction): there we *whitelisted* a param via `allowed_openai_params` so the proxy receives it; here the provider *rejects* a param we cannot remove proxy-side, so the operator must drop it on the proxy.

## Fix (minimal reyn-side scope, owner-directed "litellm の正しいやり方")

1. **Clear operator error** (replaces the silent-degrade trap). The #1458 build-failure warning now branches on cause via a unit-testable module helper `_action_index_build_failure_warning`:
   - `UnsupportedParamsError` → points to the recommended **proxy-side** `litellm_settings: drop_params: true` (+ OpenAI-compatible class / `embedding_class: null` opt-out).
   - otherwise → the pre-existing HF-download/offline guidance (regression-pinned).
2. **Direct-call defense**: `litellm.aembedding(..., drop_params=True)` — drops the unsupported param **client-side** for a *direct / non-proxy* gemini-embedding call (litellm-recommended embedding default). Harmless no-op on the proxy route (the client flag doesn't apply there — known litellm behaviour; not live-testable without a direct provider key, the proxy case is curl-verified above).
3. **Docs**: `docs/reference/config/reyn-yaml.md` `embedding` block callout for the proxy `drop_params` setting.

## Test plan

- [x] `pytest tests/test_action_embedding_build_failure_1458.py tests/test_embedding_provider.py tests/test_action_embedding_index.py tests/test_router_loop.py -q` → **108 passed**
- [x] New Tier-2 tests: helper cause-selection (param-reject → proxy guidance / no HF mislead; HF → keeps HF guidance), build-path integration logs the proxy fix, direct `aembedding` forwards `drop_params=True` (captured kwargs, no Mock)
- [x] `ruff check` on changed files → clean
- [x] `scripts/test_tier_audit.py --strict` on changed test files → 0 violations
- [x] (skipped — no direct-provider key in this env) live direct-call drop_params verify; the **proxy** rejection path is curl-verified (bisection above), and the proxy-side `drop_params: true` is the recommended setting reyn now surfaces clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
