### PR TITLE
docs(swe-bench): de-stale proposal 0008 + add current operator run how-to

### DIFF
--- a/docs/deep-dives/proposals/0008-swe-bench-integration.ja.md
+++ b/docs/deep-dives/proposals/0008-swe-bench-integration.ja.md
@@ -1,10 +1,20 @@
 # FP-0008: SWE-bench 参加インフラ — stdlib スキル + バッチ実行
 
-**Status**: proposed
+**Status**: partially superseded — Component A（`swe_bench` スキル）は #187 で退役 / Component B（`reyn eval benchmark`）は実装済
 **Proposed**: 2026-05-10
 **Author**: Research session (eager-shaw-389d9d)
 
 ---
+
+> **Status update（#187 以降）。** Component B — `reyn eval benchmark` バッチランナー
+> — は実装され現行。Component A — `swe_bench` stdlib スキル — は実装後 **#187 で退役**:
+> 現在の SWE-bench 実行方式は各 instance を **general agent 経由 `reyn run-once`**（スキル
+> なし、prompt に held-out `test_patch` なし）でルートし、per-instance に
+> `scripts/swe_bench_runner.py` がラップする。authoritative スコアリングは外部
+> `swebench` harness（`eval_benchmark.run_tier1_swebench_eval`）へ委譲。以下のスキル
+> ベース設計（Component A）は当初提案の記録として保持する。
+> **今 SWE-bench を実際に回す手順は operator how-to を参照:
+> [Run SWE-bench](../../guide/for-reyn-developers/run-swe-bench.md)。**
 
 ## Summary
 
@@ -53,6 +63,11 @@ SWE-bench harness
   → pass / fail を判定
 ```
 
+> ⚠️ **Superseded（歴史的記録）。** 上記の「Reyn が swe_bench スキルを実行」ステップは
+> #187 で退役。現在のフローは per-instance コンテナ内で **general agent 経由 `reyn run-once`**
+> を実行（スキルなし）し、harness が patch を apply して外部スコアリングする。
+> [operator how-to](../../guide/for-reyn-developers/run-swe-bench.md) を参照。
+
 Reyn の呼び出し口:
 
 ```
@@ -67,7 +82,11 @@ reyn eval benchmark swe_bench --tasks swe_bench_verified.jsonl --output results/
 
 ## Proposed implementation
 
-### Component A — `swe_bench` stdlib スキル（MEDIUM）
+### Component A — `swe_bench` stdlib スキル（MEDIUM） — #187 で退役
+
+> **退役済。** このスキルは実装後 #187 で退役し、agent-routed runner（general agent
+> 経由 `reyn run-once`、スキルなし）へ置換された。以下の phase/スキル設計は当初提案の
+> 記録としてのみ保持する。
 
 ```
 src/reyn/stdlib/skills/swe_bench/
@@ -142,9 +161,15 @@ class SweBenchResult(BaseModel):
     attempts: int       # verify ループの回数
 ```
 
-### Component B — `reyn eval benchmark` バッチ実行コマンド（MEDIUM）
+### Component B — `reyn eval benchmark` バッチ実行コマンド（MEDIUM） — 実装済
 
 SWE-bench Verified の 500 問を効率的に実行するバッチランナー。
+
+> **実装済（現行）。** `reyn eval benchmark <SKILL> --tasks … --output …` は実在し、
+> バッチドライバとして稼働。スキルを JSONL タスクファイルに対し並行ディスパッチで実行し、
+> Tier-1 faithful スコアリングを内蔵する（SWE-bench タスクは `--clone-task-repo`）。
+> [`reyn eval` reference](../../reference/cli/eval.md#subcommand-benchmark) と
+> [operator how-to](../../guide/for-reyn-developers/run-swe-bench.md) を参照。
 
 ```
 reyn eval benchmark <skill_name> \

--- a/docs/deep-dives/proposals/0008-swe-bench-integration.md
+++ b/docs/deep-dives/proposals/0008-swe-bench-integration.md
@@ -1,10 +1,21 @@
 # FP-0008: SWE-bench Participation Infrastructure — stdlib Skill + Batch Execution
 
-**Status**: proposed
+**Status**: partially superseded — Component A (`swe_bench` skill) retired in #187; Component B (`reyn eval benchmark`) shipped
 **Proposed**: 2026-05-10
 **Author**: Research session (eager-shaw-389d9d)
 
 ---
+
+> **Status update (post-#187).** Component B — the `reyn eval benchmark` batch
+> runner — was implemented and is current. Component A — the `swe_bench` stdlib
+> skill — was implemented and then **retired in #187**: the current SWE-bench run
+> method routes each instance through the **general agent via `reyn run-once`** (no
+> skill, no held-out `test_patch` in the prompt), wrapped per-instance by
+> `scripts/swe_bench_runner.py`. Authoritative scoring delegates to the external
+> `swebench` harness (`eval_benchmark.run_tier1_swebench_eval`). The skill-based
+> design below (Component A) is preserved as the original proposal record.
+> **To actually run SWE-bench today, see the operator how-to:
+> [Run SWE-bench](../../guide/for-reyn-developers/run-swe-bench.md).**
 
 ## Summary
 
@@ -53,6 +64,12 @@ SWE-bench harness
   → judges pass / fail
 ```
 
+> ⚠️ **Superseded (historical).** The "Reyn runs the swe_bench skill" step above was
+> retired in #187. The current flow runs the **general agent via `reyn run-once`** in a
+> per-instance container (no skill); the harness still applies the patch and scores
+> externally. See the
+> [operator how-to](../../guide/for-reyn-developers/run-swe-bench.md).
+
 Reyn's entry point:
 
 ```
@@ -67,7 +84,11 @@ reyn eval benchmark swe_bench --tasks swe_bench_verified.jsonl --output results/
 
 ## Proposed implementation
 
-### Component A — `swe_bench` stdlib Skill (MEDIUM)
+### Component A — `swe_bench` stdlib Skill (MEDIUM) — RETIRED in #187
+
+> **Retired.** This skill was implemented and later retired in #187 in favour of the
+> agent-routed runner (general agent via `reyn run-once`, no skill). The phase/skill
+> design below is preserved as the original proposal record only.
 
 ```
 src/reyn/stdlib/skills/swe_bench/
@@ -142,9 +163,15 @@ class SweBenchResult(BaseModel):
     attempts: int       # Number of verify loop iterations
 ```
 
-### Component B — `reyn eval benchmark` Batch Execution Command (MEDIUM)
+### Component B — `reyn eval benchmark` Batch Execution Command (MEDIUM) — SHIPPED
 
 A batch runner for efficiently executing all 500 problems in SWE-bench Verified.
+
+> **Shipped (current).** `reyn eval benchmark <SKILL> --tasks … --output …` exists and
+> is the batch driver. It runs a skill across a JSONL task file with concurrent dispatch
+> and built-in Tier-1 faithful scoring (`--clone-task-repo` for SWE-bench tasks). See the
+> [`reyn eval` reference](../../reference/cli/eval.md#subcommand-benchmark) and the
+> [operator how-to](../../guide/for-reyn-developers/run-swe-bench.md).
 
 ```
 reyn eval benchmark <skill_name> \

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -39,6 +39,10 @@ The OS (`kernel/runtime.py`) is the only thing that calls the LLM, executes Cont
 - **[Add a new op kind](add-an-op-kind.md)** — register a new Control IR operation. Three touch points: model, registry, handler.
 - **[Write LLMReplay tests](write-replay-tests.md)** — test LLM-dependent behaviour deterministically without live API calls.
 
+### Benchmarking
+
+- **[Run SWE-bench](run-swe-bench.md)** — run Reyn against SWE-bench: solve a single instance, run a batch, and the optional-dep / honest-skip scoring gotcha.
+
 ### Understanding the system
 
 - **[P1–P8 and the code that enforces them](principles-and-code.md)** — file-by-file map of how each principle is mechanically upheld.

--- a/docs/guide/for-reyn-developers/run-swe-bench.md
+++ b/docs/guide/for-reyn-developers/run-swe-bench.md
@@ -1,0 +1,181 @@
+---
+type: tutorial
+topic: os-development
+audience: [human]
+---
+
+# Run SWE-bench
+
+This how-to covers running Reyn against [SWE-bench](https://www.swebench.com/)
+(the standard coding-agent benchmark) to measure how the general agent solves
+real GitHub issues. There are two surfaces, and they are independent:
+
+- **Solve a single instance** — `scripts/swe_bench_runner.py` runs the general
+  agent on one SWE-bench instance and emits a prediction (a git patch). It does
+  **not** score.
+- **Run a batch** — `reyn eval benchmark` runs a skill across a JSONL task file
+  with concurrent dispatch and **built-in faithful scoring**.
+
+Scoring in both cases is delegated to the official `swebench` harness, which is
+an **optional dependency** — see [Faithful scoring](#faithful-scoring-and-the-honest-skip).
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| Reyn installed (`reyn --version`) | the solver |
+| Docker running | faithful runs use the official pre-built SWE-bench instance images |
+| `pip install swebench` | **optional** — required only for authoritative Tier-1 scoring; see below |
+
+A SWE-bench instance is a JSON object in the standard dataset format:
+
+```json
+{
+  "instance_id": "django__django-1234",
+  "repo": "django/django",
+  "base_commit": "abc123...",
+  "problem_statement": "...",
+  "hints_text": "...",
+  "test_patch": "..."
+}
+```
+
+`hints_text` and `test_patch` are optional. The agent solves from the issue and
+the repository only — the held-out `test_patch` is **not** put in the prompt;
+the harness applies it at scoring time.
+
+## Solve a single instance
+
+`scripts/swe_bench_runner.py` solves one instance with the general agent and
+prints one prediction JSON object on stdout:
+
+```bash
+# Faithful run: solve inside the official pre-built instance image
+python scripts/swe_bench_runner.py \
+  --input instance.json \
+  --env-backend docker \
+  --image swebench/sweb.eval.x86_64.django__django-1234:latest \
+  --repo-dir /testbed
+
+# Or read the instance JSON from stdin
+cat instance.json | python scripts/swe_bench_runner.py --stdin --env-backend docker --image <IMAGE>
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--input PATH` / `--stdin` | — | **one is required** — the instance JSON source |
+| `--env-backend host\|docker` | `host` | `docker` = faithful per-instance container run (recommended) |
+| `--image IMAGE` | — | **required with `--env-backend docker`** — the pre-built SWE-bench instance image |
+| `--repo-dir PATH` | `/testbed` | in-container repo working tree |
+| `--model-name NAME` | `reyn` | value for the harness `model_name_or_path` field |
+| `--timeout SECONDS` | `600` | max wall-clock for the solve |
+
+Under `--env-backend docker` the runner owns the container lifecycle: it starts
+the instance image, provisions a Python 3.11 venv with Reyn inside the
+container, then drives the general agent (via `reyn run-once`) to explore →
+edit → verify against the repo. Web tools are disabled so the agent cannot look
+up the upstream fix. The repo's `git diff HEAD` becomes the prediction.
+
+Output is a single JSON object on stdout:
+
+```json
+{"instance_id": "django__django-1234", "model_name_or_path": "reyn", "model_patch": "<git diff>"}
+```
+
+On failure (non-zero solve, timeout, or unparseable output) it emits
+`{"instance_id": ..., "model_name_or_path": ..., "error": "..."}` and **still
+exits 0**, so a batch loop over many instances is never aborted by one bad
+instance. All progress and diagnostics go to stderr.
+
+To score the prediction, feed it to the official `swebench` harness
+(`python -m swebench.harness.run_evaluation`), or use the batch driver below,
+which scores inline.
+
+## Run a batch
+
+`reyn eval benchmark` runs a skill across a JSONL task file (one task per line)
+with concurrent dispatch, and scores each result inline:
+
+```bash
+reyn eval benchmark <SKILL> \
+  --tasks swe_bench_verified.jsonl \
+  --output results/ \
+  --clone-task-repo \
+  --concurrency 4 \
+  [--limit 50] \
+  [--resume]
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `<SKILL>` | — | the skill to run on each task (resolved via reyn/project → local → stdlib) |
+| `--tasks PATH` | — | **required** — JSONL; each line is one task input |
+| `--output DIR` | — | **required** — results land under `<DIR>/run_<timestamp>/` |
+| `--clone-task-repo` | off | **needed for SWE-bench** — clones `<repo>` and checks out `<base_commit>` into each task's workspace |
+| `--concurrency N` | `4` | max concurrent runs |
+| `--limit N` | all | stop after the first N tasks (after `--resume` filtering) |
+| `--resume` | off | skip instances already completed in the latest prior run under `--output` |
+| `--model MODEL` | from `reyn.yaml` | model override |
+
+The batch auto-detects the verification environment once at start: with Docker
+available it runs **Tier-1 faithful scoring** (the official SWE-bench image
+applies your patch + the held-out test patch and reports the authoritative
+verdict); otherwise every result is honest-skipped (see below).
+
+Results land under `results/run_<timestamp>/`:
+
+```
+results/run_<timestamp>/
+  summary.json          # faithful accounting + per-instance verdicts
+  patches/<id>.diff     # extracted model patch (when the output carries one)
+  logs/<id>.jsonl       # per-instance event log
+```
+
+The final stdout line and `summary.json` always show the **faithful
+accounting**: how many results were faithfully verified, how many passed, and
+how many were skipped. The authoritative harness verdict — not the agent's own
+self-check — drives the pass count; a result is never counted as pass or fail
+unless it was faithfully verified.
+
+### Non-interactive permissions
+
+`reyn eval benchmark` never prompts. Every permission the skill needs must be
+pre-approved before the run, either by running the skill once interactively and
+accepting the prompts, or by granting in `reyn.yaml`:
+
+```yaml
+permissions:
+  python.safe: allow
+  python.unsafe: allow   # also requires --allow-unsafe-python at runtime
+```
+
+Without prior approval a task fails and is reported as not-finished. See the
+[`reyn eval` reference](../../reference/cli/eval.md#non-interactive-constraint)
+and [Manage permissions](../for-users/manage-permissions.md).
+
+## Faithful scoring and the honest-skip
+
+Authoritative scoring is delegated to the official `swebench` harness, which is
+an **optional dependency** Reyn does not install by default. The behaviour when
+it is absent is the key gotcha to understand:
+
+- **With `pip install swebench` + Docker**: each patch is scored by the official
+  harness (applies the model patch + the held-out test patch in the pre-built
+  image, runs the tests, reports `resolved`).
+- **Without `swebench` installed**: scoring **honest-skips**. The result is
+  marked `verify_skipped` with a clear reason — Reyn **never emits a fake
+  PASS/FAIL**. In the batch, skipped results are excluded from the pass rate
+  (which becomes `null` if nothing was faithfully verified), and the prominent
+  accounting line reports the skip count.
+
+So a batch can complete "successfully" with a `null` pass rate purely because
+`swebench` was not installed — the patches were produced, but nothing was
+authoritatively scored. Always check the faithful-verified / skipped counts in
+the summary, not just that the run finished.
+
+## See also
+
+- [`reyn eval` reference](../../reference/cli/eval.md) — full `benchmark` flag reference
+- [Configure the sandbox](../for-users/configure-sandbox.md) — how container/host execution is bounded
+- [Manage permissions](../for-users/manage-permissions.md) — pre-approval mechanics
+- [SWE-bench integration proposal](../../deep-dives/proposals/0008-swe-bench-integration.md) — the original design record

--- a/docs/guide/for-reyn-developers/run-swe-bench.md
+++ b/docs/guide/for-reyn-developers/run-swe-bench.md
@@ -96,6 +96,16 @@ which scores inline.
 `reyn eval benchmark` runs a skill across a JSONL task file (one task per line)
 with concurrent dispatch, and scores each result inline:
 
+> **There is no bundled `swe_bench` skill.** The batch driver runs whatever
+> skill you name, and the previously bundled `swe_bench` skill was retired — so
+> `reyn eval benchmark swe_bench …` will dead-end with "skill not found". The
+> batch path requires a **caller-supplied** skill. The agent-routed (no-skill)
+> SWE-bench solve is the [single-instance runner](#solve-a-single-instance)
+> above; to cover a full dataset that way, loop the runner over instances and
+> score the predictions with the `swebench` harness yourself. There is no single
+> bundled command that runs the agent-routed solve over all of SWE-bench
+> Verified **and** scores it.
+
 ```bash
 reyn eval benchmark <SKILL> \
   --tasks swe_bench_verified.jsonl \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,8 @@ nav:
           - Extending Reyn:
               - guide/for-reyn-developers/add-an-op-kind.md
               - guide/for-reyn-developers/write-replay-tests.md
+          - Benchmarking:
+              - guide/for-reyn-developers/run-swe-bench.md
   - Reference:
       - CLI:
           - Running Reyn:


### PR DESCRIPTION
**[docs-maintainer]** — owner-flagged SWE-bench doc gap (via lead-coder dispatch, GO confirmed). Primary source: `scripts/swe_bench_runner.py` docstring + `src/reyn/cli/commands/eval_benchmark.py`.

## What changed
1. **De-stale `docs/deep-dives/proposals/0008-swe-bench-integration.md` (+ `.ja`)** — the proposal described the retired `swe_bench` skill path as current. Added a status banner + marked Component A (`swe_bench` skill) **retired in #187** and Component B (`reyn eval benchmark`) **shipped**; historical design narrative preserved (proposal = mutable, not an ADR).
2. **New operator how-to `docs/guide/for-reyn-developers/run-swe-bench.md`** (+ index entry + nav) — operator-facing, no inline history/#issue refs. Covers: single-instance runner (`swe_bench_runner.py`, general agent via `reyn run-once` in a per-instance container), batch driver (`reyn eval benchmark`), non-interactive permission pre-approval, and the **`swebench` optional-dep / honest-skip** gotcha (no `pip install swebench` ⇒ patches still produced but Tier-1 scoring honest-skips — never a fake PASS/FAIL).

## ⚠️ Findings surfaced during primary-source read (please confirm)
These came up while reading the code; I documented the **actual** behaviour, but flag them since they differ from a "runner + batch driver chain" mental model:

1. **The two surfaces are independent, not chained.** `scripts/swe_bench_runner.py` solves **one instance** via `reyn run-once` (general agent, **no skill**). `reyn eval benchmark` is a **skill-based** batch driver (`agent.run(skill, …)`) with its **own inline** Tier-1 scoring. `swe_bench_runner.py` is **not referenced anywhere in `src/`** — `reyn eval benchmark` does not invoke it. The how-to documents them as two distinct surfaces accordingly.
2. **`reyn eval benchmark` requires a `<SKILL>` arg, but the `swe_bench` skill is retired.** So the batch path needs a caller-supplied skill today; there is no single wired command that runs the agent-routed runner across all of SWE-bench Verified + scores it. I described the surfaces honestly rather than implying a one-command end-to-end batch.
3. **`swe_bench_runner.py`'s own argparse help is internally stale** (code, not docs): help strings still say "Wrap `reyn run swe_bench`" / "the swe_bench skill's repo FS" (lines ~378, 411, 416, 423), contradicting its own updated module docstring (agent-routed, skill retired). Out of scope for this docs PR — flagging for a code follow-up.

## Test plan
- [x] `mkdocs build --strict` → exit 0 (remaining output is INFO-level: proposals excluded-from-site + JA-mirror anchor lag on `eval.ja.md`; neither fails --strict; precedent: `rag.md`→0008)
- [x] EN anchors verified present (`eval.md#subcommand-benchmark`, `#non-interactive-constraint`)
- [x] nav page-drop check: net +1 page (`run-swe-bench.md`), 0 dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)