### PR TITLE
docs(1664): fix stale swe_bench_runner argparse help text

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -375,9 +375,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="swe_bench_runner.py",
         description=(
-            "Wrap `reyn run swe_bench` for the SWE-bench evaluation harness. "
-            "Reads a single SWE-bench instance, runs the Reyn solver, and emits "
-            "the harness-expected JSON on stdout."
+            "Solve a SWE-bench instance with the general agent via `reyn run-once` "
+            "for the SWE-bench evaluation harness (the swe_bench skill was retired "
+            "in #187 — the agent iterates with its own tools, no test_patch). Reads "
+            "a single SWE-bench instance and emits the harness-expected JSON on stdout."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
@@ -407,13 +408,13 @@ def build_parser() -> argparse.ArgumentParser:
     # FP-0008 #1115 Stage 2 (β2b): faithful in-container run. When
     # --env-backend=docker, the runner owns the per-instance container lifecycle
     # (docker run the official SWE-bench image → reyn run inside it via the
-    # generic --env-backend flags → teardown), so the swe_bench skill's
+    # generic --env-backend flags → teardown), so the general agent's
     # repo FS + commands execute against the pre-built /testbed, not the host.
     p.add_argument(
         "--env-backend", dest="env_backend", choices=["host", "docker"],
         default="host",
         help=(
-            "Where the swe_bench skill's repo FS + commands run: 'host' (default) "
+            "Where the general agent's repo FS + commands run: 'host' (default) "
             "or 'docker' (per-instance container from --image; faithful in-container run)."
         ),
     )


### PR DESCRIPTION
**[e2e-coder]** — low-priority cleanup. Refs #1664. Trivial follow-up to the SWE doc work (#1662).

## Problem

`scripts/swe_bench_runner.py`'s argparse help strings were stale — they contradicted the file's own (already-updated) module docstring:
- description: `"Wrap \`reyn run swe_bench\`"` 
- `--env-backend` help + comment: `"the swe_bench skill's repo FS + commands"`

The `swe_bench` **skill** was retired in #187 — the solver is the general agent via `reyn run-once` (no skill, no `test_patch`). The docstring and `--agent-mode` help already say this; the description + `--env-backend` strings lagged.

## Change (help-text only, no behaviour change)

- description → "Solve a SWE-bench instance with the general agent via `reyn run-once` … (the swe_bench skill was retired in #187 …)", mirroring the docstring.
- `--env-backend` help + its lead comment → "the general agent's repo FS + commands" (was "the swe_bench skill's …").

The remaining `swe_bench skill` mentions in the file are all correct past-tense "was retired" context (lines 4, 229, 379, 454, 489), not stale claims.

## Test plan

- [x] `python -m py_compile scripts/swe_bench_runner.py` → clean
- [x] `python scripts/swe_bench_runner.py --help` renders the corrected description + flag help (verified output)
- [x] `ruff check scripts/swe_bench_runner.py` → clean
- [x] No behaviour change → no test changes (argparse `dest`/`choices`/`default` all untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
