### PR TITLE
feat(1666): per-turn tool_call count cap (OS-level cost-bound)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -294,6 +294,7 @@ safety:
     max_act_turns_per_phase: 10  # LLM ↔ op volleys per phase visit; 0 = unlimited
     max_router_calls_per_turn: 3 # chat-router calls per user turn
     max_router_iterations: 5   # LLM tool-call iterations per user turn (CLI --max-iterations overrides)
+    max_tool_calls_per_turn: 50 # max tool_calls honoured from ONE completion (cost-bound); 0 = unlimited
     max_agent_hops: 3          # maximum delegation depth
   timeout:
     llm_call_seconds: 60       # per-call HTTP timeout (--llm-timeout)
@@ -314,6 +315,7 @@ safety:
 | `safety.loop.max_act_turns_per_phase` | int | `10` | — | LLM ↔ op volleys allowed inside one phase visit. `0` = unlimited. |
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | Chat-router invocations per user turn. `0` = unlimited. |
 | `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | Maximum LLM tool-call iterations per user turn. CLI `--max-iterations` overrides when provided; `reyn run-once` uses CLI default of 80. |
+| `safety.loop.max_tool_calls_per_turn` | int | `50` | — | Cost-bound: maximum `tool_calls` honoured from a SINGLE LLM completion. A degenerate completion can emit thousands (observed 3451); the OS processes only the first N, drops the overflow, and appends a re-grounding notice. `0` = unlimited. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
 | `safety.loop.plan_invalid_retries` | int | `1` | — | When the router emits a malformed `plan()` tool call, append the error + an "escape inner quotes" hint and let the LLM re-emit. `0` disables; `1` (default) allows one directive-driven correction per chat turn. |
 | `safety.loop.skill_calls_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) spawn cap. `hard_limit` + `warn_ratio` sub-fields. Hybrid: loop-detection semantics, budget-style user approval on hit. |

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -487,6 +487,7 @@
 #     max_phase_visits: 25
 #     max_router_calls_per_turn: 3
 #     max_router_iterations: 5  # max LLM tool-call iterations per user turn; CLI --max-iterations overrides
+#     max_tool_calls_per_turn: 50  # cost-bound: max tool_calls honoured from ONE completion; 0 = unlimited
 #     max_agent_hops: 3
 #     # plan() tool call parse-error self-correction (B51 NF-W6-3). 0 = disable.
 #     plan_invalid_retries: 1

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1393,6 +1393,7 @@ class RouterLoop:
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
         empty_stop_retry_auto: bool = False,  # #187: always-on (no env opt-in); all prod sites pass True
         plan_invalid_retries: int = 1,  # B51 NF-W6-3 — safety.loop.plan_invalid_retries
+        max_tool_calls_per_turn: int = 50,  # #1666 — safety.loop.max_tool_calls_per_turn (0 = unlimited)
         on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
         scheme_name: "str | None" = None,  # #1593 PR-2: per-layer tool-use scheme (None → universal default; the construction site resolves config.tool_use.<layer>)
@@ -1480,6 +1481,8 @@ class RouterLoop:
         # (``max_router_calls_per_turn`` + ``max_iterations``) still
         # apply on top. ``0`` disables the retry (= pre-fix behaviour).
         self._plan_invalid_max_retries = max(0, int(plan_invalid_retries))
+        # #1666: per-turn tool_call count cap (cost-bound). 0 = unlimited.
+        self._max_tool_calls_per_turn = max(0, int(max_tool_calls_per_turn))
         # Tier 2 test seam: when set, ``run()`` calls this callable instead of
         # the module-level ``call_llm_tools``. Allows real-fake injection
         # (= scripted async callable) without ``unittest.mock.patch`` — per
@@ -2089,6 +2092,11 @@ class RouterLoop:
                 ExecutionResult,
                 RePresent,
             )
+            # #1666: bound the per-turn tool_call count BEFORE interpret, so all
+            # branches + the assistant↔tool-result alignment inherit the cap from a
+            # single choke point. ``_cap_info`` carries (attempted, kept) when it
+            # fired → the round appends a re-grounding notice after its results.
+            _cap_info = self._enforce_tool_call_cap(result)
             interp = self._scheme.interpret(
                 result, tool_catalog=self._catalog, ops=self,
             )
@@ -2162,6 +2170,11 @@ class RouterLoop:
                         "tool_call_id": _tc["id"],
                         "content": _REPRESENT_ACK,
                     })
+                # #1666: if the cap fired on this re-present turn, append the
+                # re-grounding notice after the synthetic acks (cost-bound applies
+                # to every branch, not only Execute).
+                if _cap_info is not None:
+                    messages.append(self._tool_call_cap_notice(*_cap_info))
                 _represent_layer_ctx = {
                     **(getattr(self, "_scheme_layer_ctx", None) or {}),
                     "refinement": interp.refinement,
@@ -2620,6 +2633,20 @@ class RouterLoop:
                     ops=self,
                 ):
                     messages.append(_fb_msg)
+
+                # #1666: after a capped round's results, append the single
+                # re-grounding notice (placed AFTER all tool results so the
+                # assistant.tool_calls ↔ tool_result pairing stays intact —
+                # same ordering contract as the plan_invalid directive below).
+                if _cap_info is not None:
+                    _cap_msg = self._tool_call_cap_notice(*_cap_info)
+                    messages.append(_cap_msg)
+                    _cap_append = getattr(host, "append_history_entry", None)
+                    if _cap_append is not None:
+                        _cap_append(
+                            role=_cap_msg["role"], content=_cap_msg["content"],
+                            meta={"chain_id": self.chain_id, "source": "tool_call_cap_notice"},
+                        )
 
                 # B51 NF-W6-3: plan_invalid self-correction loop. When the
                 # plan tool returned ``{status:error, error:{kind:plan_invalid}}``
@@ -3379,6 +3406,62 @@ class RouterLoop:
                 if followup is not None:
                     out.append(followup)
         return out
+
+    def _enforce_tool_call_cap(self, result) -> "tuple[int, int] | None":
+        """#1666: bound the per-turn ``tool_calls`` count (cost-bound, OS-level).
+
+        A degenerate (weak-model, long-context) completion can emit thousands of
+        ``tool_calls`` — observed 3451 in one SWE-bench completion — each costing a
+        tool-result message + token inflation. This caps the count at
+        ``self._max_tool_calls_per_turn`` (``0`` = unlimited): the overflow calls are
+        TRUNCATED off ``result.tool_calls`` **in place, before ``interpret``**, so
+        every downstream branch (Execute / RePresent) and the assistant-message ↔
+        tool-result alignment inherit the bound from a single choke point (only the
+        kept calls are interpreted, executed, and appended).
+
+        Scheme-agnostic (operates on the generic ``result.tool_calls`` shape, no
+        skill-specific strings — P7-clean). Emits the P6 ``tool_call_cap_exceeded``
+        event recording the **original attempted count** so history is bounded to
+        ``kept`` while the true magnitude survives in the audit log.
+
+        Returns ``(attempted, kept)`` when the cap fired (so the caller appends the
+        re-grounding notice), else ``None``.
+        """
+        cap = self._max_tool_calls_per_turn
+        if cap <= 0:
+            return None
+        tcs = getattr(result, "tool_calls", None) or []
+        attempted = len(tcs)
+        if attempted <= cap:
+            return None
+        # Truncate in place — the assistant message + interpret + execute all read
+        # this same list, so 50 calls ↔ 50 results stays aligned by construction.
+        result.tool_calls = tcs[:cap]
+        try:
+            self.host.events.emit(
+                "tool_call_cap_exceeded",
+                chain_id=self.chain_id,
+                attempted=attempted,
+                kept=cap,
+            )
+        except Exception:  # noqa: BLE001 — never let an audit emit break the loop
+            pass
+        return attempted, cap
+
+    def _tool_call_cap_notice(self, attempted: int, kept: int) -> dict:
+        """#1666: the single decision-enabling notice appended after a capped
+        round's results so the model re-grounds (deny-message-is-decision-enabling:
+        states what happened + what to do, with the true attempted count)."""
+        return {
+            "role": "user",
+            "content": (
+                f"[system notice] Your last turn emitted {attempted} tool_calls, "
+                f"which exceeds the per-turn cap of {kept}. Only the first {kept} "
+                "were executed; the rest were dropped. This usually means the model "
+                "is looping or over-fanning-out — issue far fewer tool_calls "
+                "(typically one to a few) and proceed step by step."
+            ),
+        }
 
     async def _run_execute_round(self, interp) -> "tuple[list[dict], list[dict]]":
         """The ``Execute`` arm — **byte-identical** to the former

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -336,6 +336,13 @@ class RouterLoopDriver:
             "plan_invalid_retries",
             1,
         )
+        # #1666: per-turn tool_call count cap (cost-bound) sourced from
+        # safety.loop.max_tool_calls_per_turn (default 50). 0 = unlimited.
+        _max_tool_calls_per_turn = getattr(
+            getattr(self._safety, "loop", None),
+            "max_tool_calls_per_turn",
+            50,
+        )
         loop = RouterLoop(
             host=self._router_host, chain_id=chain_id,
             # #1593 PR-2: select the chat-layer tool-use scheme (None → universal).
@@ -353,6 +360,8 @@ class RouterLoopDriver:
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
             empty_stop_retry_auto=True,
             plan_invalid_retries=_plan_invalid_retries_cap,
+            # #1666: per-turn tool_call count cap (cost-bound).
+            max_tool_calls_per_turn=_max_tool_calls_per_turn,
             # FP-0005: wire safety.on_limit so max_iterations exhaustion routes
             # through handle_limit_exceeded instead of flat-aborting.
             on_limit=getattr(self._safety, "on_limit", None),

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -220,6 +220,16 @@ class LoopConfig:
             (= per user turn). ``0`` = unlimited. CLI ``--max-iterations``
             overrides this when provided. Run-once / autonomous contexts
             typically set this higher (e.g. 80) via CLI.
+        max_tool_calls_per_turn:
+            Cost-bound (#1666): the maximum number of ``tool_calls`` honoured
+            from a SINGLE LLM completion. A degenerate (weak-model, long-context)
+            completion can emit thousands of tool_calls — observed 3451 in one
+            SWE-bench completion — each costing a tool-result message + token
+            inflation. When a completion exceeds this cap the OS processes only
+            the first ``max_tool_calls_per_turn`` calls, drops the overflow
+            (un-executed, un-appended), and appends a single re-grounding notice.
+            Default ``50`` is generous headroom over legitimate parallel tool use
+            (observed < 10) yet ~70x below the runaway. ``0`` = unlimited.
     """
 
     max_act_turns_per_phase: int = 10
@@ -227,6 +237,7 @@ class LoopConfig:
     max_router_calls_per_turn: int = 3
     max_agent_hops: int = 3
     max_router_iterations: int = 5
+    max_tool_calls_per_turn: int = 50
     skill_calls_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
     skill_tokens_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
 
@@ -2665,6 +2676,9 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
         max_router_iterations=int(loop_raw.get(
             "max_router_iterations", loop_defaults.max_router_iterations,
+        )),
+        max_tool_calls_per_turn=int(loop_raw.get(
+            "max_tool_calls_per_turn", loop_defaults.max_tool_calls_per_turn,
         )),
         skill_calls_per_chain=_build_cost_limit(
             loop_raw.get("skill_calls_per_chain")

--- a/tests/test_safety_config.py
+++ b/tests/test_safety_config.py
@@ -68,6 +68,7 @@ safety:
     max_phase_visits: 50
     max_router_calls_per_turn: 7
     max_agent_hops: 5
+    max_tool_calls_per_turn: 17
     skill_calls_per_chain:
       hard_limit: 12
     plan_invalid_retries: 2
@@ -76,6 +77,9 @@ safety:
     assert cfg.safety.loop.max_phase_visits == 50
     assert cfg.safety.loop.max_router_calls_per_turn == 7
     assert cfg.safety.loop.max_agent_hops == 5
+    # #1666: non-default value proves the yaml→LoopConfig parser wiring (not the
+    # trivial default round-trip).
+    assert cfg.safety.loop.max_tool_calls_per_turn == 17
     assert cfg.safety.loop.skill_calls_per_chain.hard_limit == 12.0
     assert cfg.safety.loop.plan_invalid_retries == 2
 

--- a/tests/test_tool_call_cap_1666.py
+++ b/tests/test_tool_call_cap_1666.py
@@ -1,0 +1,144 @@
+"""Tier 2: #1666 — per-turn tool_call count cap (cost-bound, OS-level).
+
+A degenerate (weak-model, long-context) completion can emit thousands of
+``tool_calls`` (observed 3451 in one SWE-bench completion) → thousands of
+tool-result messages → context/cost blowup. ``RouterLoop._enforce_tool_call_cap``
+bounds the count at ``safety.loop.max_tool_calls_per_turn`` by TRUNCATING the
+overflow off ``result.tool_calls`` in place **before** interpret, so every
+downstream branch + the assistant↔tool-result alignment inherit the bound from a
+single choke point. The P6 ``tool_call_cap_exceeded`` event records the original
+*attempted* count (history is bounded to ``kept``; the true magnitude survives in
+the audit log), and a single re-grounding notice is appended after the round.
+
+No mocks: a real ``LLMToolCallResult`` completion + a real recording events sink.
+The cap method is exercised directly on a minimally-constructed ``RouterLoop``
+(the loop wiring around it is straightforward message-append, covered by the
+config + driver threading + the notice-content assertions here).
+"""
+from __future__ import annotations
+
+from reyn.chat.router_loop import RouterLoop
+from reyn.llm import TokenUsage
+from reyn.llm.llm import LLMToolCallResult
+
+
+class _RecordingEvents:
+    """Real fake events sink; records emitted events (no Mock)."""
+
+    def __init__(self) -> None:
+        self.emitted: list[dict] = []
+
+    def emit(self, kind: str, **kwargs) -> None:
+        self.emitted.append({"kind": kind, **kwargs})
+
+
+class _MinimalHost:
+    def __init__(self) -> None:
+        self.events = _RecordingEvents()
+
+
+class _CapLoop(RouterLoop):
+    """RouterLoop with just the state ``_enforce_tool_call_cap`` /
+    ``_tool_call_cap_notice`` read — skips the real __init__ (the cap method only
+    needs ``host.events``, ``chain_id``, and ``_max_tool_calls_per_turn``)."""
+
+    def __init__(self, cap: int) -> None:
+        self.host = _MinimalHost()  # type: ignore[assignment]
+        self.chain_id = "test-chain"
+        self._max_tool_calls_per_turn = cap
+
+
+def _make_result(n: int) -> LLMToolCallResult:
+    """A real completion carrying *n* distinct tool_calls (varying args, so dedup
+    would NOT collapse them — mirrors the #1666 repro)."""
+    tcs = [
+        {
+            "id": f"call_{i}",
+            "type": "function",
+            "function": {"name": "list_actions", "arguments": f'{{"q": "{i}"}}'},
+        }
+        for i in range(n)
+    ]
+    return LLMToolCallResult(
+        content="", tool_calls=tcs, finish_reason="tool_calls", usage=TokenUsage(),
+    )
+
+
+def test_cap_truncates_overflow_in_place() -> None:
+    """Tier 2: #1666 — a completion with > cap tool_calls is truncated IN PLACE to
+    the first cap; the overflow is dropped before interpret (so it is never
+    executed nor appended). Returns (attempted, kept)."""
+    loop = _CapLoop(cap=50)
+    result = _make_result(120)
+
+    info = loop._enforce_tool_call_cap(result)
+
+    assert info == (120, 50)
+    # The KEPT calls are exactly the first 50 (index 0..49), order preserved →
+    # alignment intact; the overflow (call_50+) is gone.
+    assert result.tool_calls[0]["id"] == "call_0"
+    assert result.tool_calls[-1]["id"] == "call_49"
+    assert all(tc["id"] != "call_50" for tc in result.tool_calls), "overflow dropped"
+
+
+def test_cap_emits_event_with_original_attempted_count() -> None:
+    """Tier 2: #1666 — the P6 tool_call_cap_exceeded event records the ORIGINAL
+    attempted count (3451-style magnitude survives in the audit log even though
+    history is bounded to kept). Audit-fidelity requirement (lead)."""
+    loop = _CapLoop(cap=50)
+    loop._enforce_tool_call_cap(_make_result(3451))
+
+    # Exactly one cap event recorded (the sink saw nothing else this turn).
+    assert [e["kind"] for e in loop.host.events.emitted] == ["tool_call_cap_exceeded"]
+    event = loop.host.events.emitted[0]
+    assert event["attempted"] == 3451, "true attempted count must survive in audit"
+    assert event["kept"] == 50
+
+
+def test_cap_no_op_at_or_below_limit() -> None:
+    """Tier 2: #1666 — a completion at/below the cap is untouched: no truncation,
+    no event, returns None (the common case must be a pure pass-through)."""
+    loop = _CapLoop(cap=50)
+    result = _make_result(50)
+
+    info = loop._enforce_tool_call_cap(result)
+
+    assert info is None
+    # All 50 retained (index 49 = the 50th) — at-limit is not truncated.
+    assert result.tool_calls[-1]["id"] == "call_49"
+    assert not loop.host.events.emitted, "no event when the cap does not fire"
+
+
+def test_cap_zero_means_unlimited() -> None:
+    """Tier 2: #1666 — cap=0 disables the bound (matches the sibling loop-cap
+    convention): a huge batch passes through untouched, no event."""
+    loop = _CapLoop(cap=0)
+    result = _make_result(5000)
+
+    info = loop._enforce_tool_call_cap(result)
+
+    assert info is None
+    # The full batch passes through untouched (last = index 4999 = the 5000th).
+    assert result.tool_calls[-1]["id"] == "call_4999"
+    assert not loop.host.events.emitted
+
+
+def test_cap_notice_states_attempted_and_kept() -> None:
+    """Tier 2: #1666 — the re-grounding notice is decision-enabling: it states the
+    true attempted count, the cap, and what to do (call fewer)."""
+    loop = _CapLoop(cap=50)
+    msg = loop._tool_call_cap_notice(3451, 50)
+
+    assert msg["role"] == "user"
+    body = msg["content"]
+    assert "3451" in body and "50" in body
+    assert "fewer" in body.lower()
+
+
+def test_cap_default_is_50_in_config() -> None:
+    """Tier 2: #1666 — the default safety.loop.max_tool_calls_per_turn is 50
+    (the confirmed cost-bound default; ~70x below the runaway, headroom over
+    legitimate parallel use)."""
+    from reyn.config import LoopConfig
+
+    assert LoopConfig().max_tool_calls_per_turn == 50


### PR DESCRIPTION
**[e2e-coder]** — owner-directed (cost-bounding). Closes #1666. Confirm-first ACKed by lead (default / placement / truncate-vs-reject all approved + the audit-fidelity addition).

## Problem (primary evidence)

A single LLM completion can emit an unbounded number of `tool_calls`. On a SWE-bench run (astropy-13236, flash-lite, enumerate scheme) **one completion emitted 3451 `tool_calls`** — all hallucinating `list_actions` with varying args (so dedup does NOT collapse them) → 3459 tool-result messages → context/cost blowup. The OS catalog-validation rejected them, but each still cost a result message + token inflation.

## Fix — OS-level, scheme-agnostic count cap

`safety.loop.max_tool_calls_per_turn` (default **50**, `0` = unlimited). Lives under `LoopConfig` next to the sibling `max_router_calls_per_turn` (same "runaway-bound" family — better taxonomy fit than a new top-level `safety.*` key; lead approved this over the issue's original placement).

**Mechanism (single choke point, P7-clean):** `_enforce_tool_call_cap` truncates the overflow off `result.tool_calls` **in place, before `interpret`**, so every downstream branch (Execute / RePresent) **and** the assistant-message ↔ tool-result alignment inherit the bound (only the kept calls are interpreted, executed, appended — 50 calls ↔ 50 results, aligned by construction).

**Truncate-to-MAX (not reject-whole-turn):** the model still gets real feedback for the first MAX + a single re-grounding notice → re-grounds a degenerate model better than a content-free reject (which would likely re-emit the same batch); cost is bounded either way (in the repro the OS already rejected the bad calls cheaply and recovered, so 50 bounded rejections is trivially safe).

**Audit fidelity (lead's addition):** the P6 `tool_call_cap_exceeded` event records the **original attempted count** (`attempted=3451, kept=50`) — history is bounded to `kept`, but the 3451 magnitude survives in the audit log (it's the evidence the cap is working). The synthetic notice states attempted-vs-kept so the model calls fewer.

## Confirm-first survey — default = 50

Grepped src/docs/tests for parallel/batch tool-call patterns + count expectations: **nothing legitimate batches >10**. The only multi-call patterns are the dedup guards (weak model emits `delegate_to_agent`/`invoke_skill` twice = 2); no test pins `len(tool_calls) ≥ 10`; embedding `max_concurrent_batches` (1–10) is unrelated batch-concurrency. → 50 = ~5× headroom over observed legit use, ~70× below the 3451 runaway.

## Test plan

- [x] `pytest -q` from rootdir → **7400 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** — verified identical failures via a throwaway worktree, unrelated to this diff (swebench-eval / web_fetch-media, not router_loop/config).
- [x] New `test_tool_call_cap_1666.py` (6 Tier-2, no Mock — real `LLMToolCallResult` + recording events sink): truncate-in-place (id-boundary asserts), P6 event carries original `attempted=3451`, no-op at/below limit, `0`=unlimited, notice states attempted/kept, config default=50.
- [x] `test_safety_config.py` — yaml→`LoopConfig` parser wiring pinned with a **non-default** value (17) round-trip.
- [x] Config doc/example mirror guard (`test_config_mirror_coverage_1056`) satisfied — field added to `reyn-yaml.md` (inline + table row) and `reyn.local.yaml.example`.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations (rewrote the count asserts as id-boundary/exact-event-list to avoid the `len(...)==N` format-pin rule).

## Notes
- Scheme-incidental degeneracy — **not** framed as an enumerate fix (the cap is OS-level, applies to all schemes via the generic `result.tool_calls`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
