### PR TITLE
feat(1669): render llm_request (non-message LLM call params) in events tab — TUI half

### DIFF
--- a/src/reyn/chat/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/chat/tui/widgets/right_panel/events_tab.py
@@ -78,6 +78,7 @@ _EVENT_COLORS: dict[str, str] = {
     "context_built":               _GREEN_DIMMEST,
     "llm_called":                  _EVENT_LLM,
     "llm_response_received":       _EVENT_LLM,
+    "llm_request":                 _EVENT_LLM,  # #1669 — non-message call params
     "artifact_created":            _EVENT_SKILL,
     "artifact_validated":          _EVENT_SKILL,
     "validation_error":            _STATUS_ERROR,
@@ -170,6 +171,11 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "control_ir_failed", "control_ir_skipped",
     })),
     ("llm",   frozenset({"llm_called", "llm_response_received"})),
+    # #1669 — non-message LLM call params (reasoning_effort / temperature /
+    # extra_body / …). A DEDICATED group (not lumped into "llm") so the owner can
+    # ISOLATE just the request-param events while verifying a model's call params
+    # (e.g. GPT-5.4) — one-per-LLM-call, so independent toggle-ability matters.
+    ("request", frozenset({"llm_request"})),
     ("tool",  frozenset({
         "tool_called", "tool_returned", "tool_failed", "tool_executed",
         "mcp_called", "mcp_completed", "mcp_failed",
@@ -266,6 +272,23 @@ def _event_hint(ev: dict) -> str:
         ct = d.get("completion_tokens", 0)
         cost = d.get("cost_usd", 0)
         return f"{pt}+{ct}t ${cost:.4f}"
+    if t == "llm_request":
+        # #1669: model + purpose + the salient non-message params inline; the
+        # FULL param set is in the Space→JSON preview. Params live under the
+        # nested ``params`` key (#1669 schema); absent keys are simply omitted
+        # (no ``=None`` noise). tools_count is top-level.
+        params = d.get("params") or {}
+        bits = [str(d.get("model", "")), str(d.get("purpose", ""))]
+        re_ = params.get("reasoning_effort")
+        if re_ is not None:
+            bits.append(f"reasoning_effort={re_}")
+        temp = params.get("temperature")
+        if temp is not None:
+            bits.append(f"temp={temp}")
+        tc = d.get("tools_count")
+        if tc:
+            bits.append(f"tools={tc}")
+        return " · ".join(b for b in bits if b)
     if t == "artifact_created":
         return f"{d.get('artifact_type', '')} @ {d.get('phase', '')}"
     if t == "artifact_validated":

--- a/tests/cli/test_events_tab_llm_request_1669.py
+++ b/tests/cli/test_events_tab_llm_request_1669.py
@@ -1,0 +1,84 @@
+"""Tier 2: events-tab llm_request rendering (#1669).
+
+#1669 surfaces the non-message LLM call params (reasoning_effort / temperature /
+extra_body / …) in the events tab so the owner can verify what's sent to the
+model. The backend (e2e) emits a P6 ``llm_request`` event; this is the TUI render
+half: a per-kind colour, a DEDICATED filter group (isolatable while model-testing),
+and a one-line hint (model + purpose + salient params; full set via Space-preview).
+
+Pins the deterministic render pieces (the formatter string from a synthesized
+event of the locked schema, the filter-group entry, the colour) — public module
+surface, no running app needed. The live render + filter toggle are tmux-verified
+separately (real-terminal, per the headless boundary).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.chat.tui.widgets.right_panel.events_tab import (  # noqa: E402
+    _EVENT_COLORS,
+    _FILTER_GROUPS,
+    _event_hint,
+)
+
+
+def _llm_request_event(**data) -> dict:
+    base = {"model": "gpt-5.4", "purpose": "main",
+            "params": {"reasoning_effort": "high", "temperature": 0.7},
+            "tools_count": 12}
+    base.update(data)
+    return {"type": "llm_request", "data": base}
+
+
+def test_hint_renders_model_purpose_and_salient_params() -> None:
+    """Tier 2: the one-line hint carries model + purpose + the salient params
+    (reasoning_effort / temperature from the nested ``params``) + tools count."""
+    hint = _event_hint(_llm_request_event())
+    assert "gpt-5.4" in hint
+    assert "main" in hint
+    assert "reasoning_effort=high" in hint
+    assert "temp=0.7" in hint
+    assert "tools=12" in hint
+
+
+def test_hint_omits_absent_params_no_none_noise() -> None:
+    """Tier 2: params absent from the nested dict are omitted (no '=None' noise)
+    — the #1669 schema says absent keys are simply absent."""
+    hint = _event_hint(_llm_request_event(params={}, tools_count=0))
+    assert "reasoning_effort" not in hint     # absent → omitted
+    assert "temp" not in hint
+    assert "tools=" not in hint               # 0 tools → omitted
+    assert "None" not in hint
+    assert "gpt-5.4" in hint                  # model still shown
+
+
+def test_params_read_from_nested_key_not_top_level() -> None:
+    """Tier 2: salient params are read from ``data['params']`` (the #1669 nested
+    shape), NOT top-level — a top-level reasoning_effort must not be picked up."""
+    ev = {"type": "llm_request",
+          "data": {"model": "m", "purpose": "phase",
+                   "reasoning_effort": "TOPLEVEL",   # wrong place — must be ignored
+                   "params": {}}}
+    hint = _event_hint(ev)
+    assert "TOPLEVEL" not in hint
+
+
+def test_llm_request_has_dedicated_filter_group() -> None:
+    """Tier 2: a DEDICATED 'request' filter group isolates llm_request (owner's
+    model-testing use case), separate from the all-LLM 'llm' group."""
+    groups = dict(_FILTER_GROUPS)
+    assert "request" in groups
+    assert groups["request"] == frozenset({"llm_request"})
+    # Not folded into "llm" (that would prevent isolating just request events).
+    assert "llm_request" not in groups["llm"]
+
+
+def test_llm_request_has_event_colour() -> None:
+    """Tier 2: llm_request has a per-kind colour (so it's visually distinct, not
+    the generic default)."""
+    assert "llm_request" in _EVENT_COLORS


### PR DESCRIPTION
**[tui-coder]** — #1669 TUI render half (owner-directed). Pairs with e2e's `llm_request` P6 emitter half (the data side). Lets the owner verify, in the events tab, the params sent to the LLM other than messages (reasoning_effort / temperature / extra_body / …) — driving use case: inspecting a model's call params while testing it (e.g. GPT-5.4).

## What lands (against e2e's locked schema)
Schema: `kind=llm_request`, `data={model, purpose, params:{reasoning_effort, temperature, extra_body, …}, tools_count}`; secrets redacted backend-side; `messages` excluded by construction.

- **`_EVENT_COLORS["llm_request"]` = `_EVENT_LLM`** — groups visually with the other LLM events.
- **Dedicated `"request"` filter group** (NOT lumped into `"llm"`) — the owner's use case is *isolating* just the request-param events while model-testing, so independent toggle-ability matters (e2e-confirmed). `("request", frozenset({"llm_request"}))`.
- **`_event_hint` one-liner**: `model · purpose · reasoning_effort=… · temp=… · tools=N` — salient params read from the **nested** `data["params"]`; absent keys omitted (no `=None` noise); `tools_count` top-level.
- **Full param set**: the existing **Space→JSON preview** auto-renders the event data dict (safe verbatim — e2e redacts secrets pre-emit). No extra work.

## Test plan
- [x] 5 Tier-2 units: formatter (model+purpose+salient params), absent-omit (no `=None`), nested-not-top-level read, dedicated-group isolation, colour present. No Mock (hand-built event dicts).
- [x] **Functional `render_events()`** (the real terminal-output function + real event-loading, with synthesized `llm_request` events): ALL shows the hint, **REQUEST isolates** `llm_request`, **LLM excludes** it — the render/filter behavioral contract proven.
- [x] 53 events_tab tests green (no regression); ruff + tier-audit clean.
- [x] (skipped — tmux MCP can't send Ctrl+B chord; render+filter proven via real render_events(); [f]-cycle is existing infra + new group functionally verified; owner real-keyboard confirms end-to-end once e2e's emitter lands) live tmux key-nav (Ctrl+B panel + [f] filter toggle).

## Notes
- The `[f]` filter-cycle is **existing** key-binding infra; this PR only adds a *data entry* to `_FILTER_GROUPS` + a colour/hint — so "[f] reaches the new group" is low-risk-by-construction.
- Pairs with e2e's `llm_request` emitter PR (lands shortly; once live, a real session emits the event for the owner's live key-cascade confirm).

Refs #1669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
