### PR TITLE
feat(1669): emit llm_request P6 event with non-message LLM call params (backend half)

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1591,6 +1591,12 @@ class ChatSession:
             subscribers=[self._event_store],
             agent_id=self._agent_id,  # FP-0016 E: auto-inject agent_id into every event
         )
+        # #1669: publish this session's EventLog as the ambient sink for the LLM
+        # acompletion chokepoint, so every in-session LLM call emits an observable
+        # `llm_request` event (non-message params) without threading events through
+        # the call stack. Set at creation → propagates into the run loop's tasks.
+        from reyn.events.events import set_llm_request_event_log
+        set_llm_request_event_log(self._chat_events)
         # Issue #162: surface session-level lifecycle events (compaction
         # today; attach/detach + budget warnings as growth) into the
         # conv pane via OutboxMessage(kind="system"). Sibling of the

--- a/src/reyn/events/events.py
+++ b/src/reyn/events/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import logging
 from datetime import date
 from pathlib import Path
@@ -8,6 +9,35 @@ from typing import Callable
 from reyn.schemas.models import Event
 
 logger = logging.getLogger(__name__)
+
+
+# #1669: session-scoped ambient EventLog for the single LLM acompletion chokepoint.
+# ``recorded_acompletion`` (reyn.llm.llm) is the one place ALL LLM calls funnel
+# through (#1190 AST-guarded), but it receives no events sink (only budget /
+# recorder). Threading one through its 9 call sites would be churn AND incomplete
+# (judge / compaction / dogfood callers lack a sink). Instead the chat session /
+# kernel runtime sets this ContextVar to its EventLog at creation; the chokepoint
+# reads it and emits ``llm_request``. ContextVars copy into child asyncio tasks at
+# spawn, so a set-before-the-run-loop propagates to every in-session LLM call.
+# None (tests / dogfood / CLI, no active session) → the chokepoint skips the emit,
+# mirroring the ``recorder=None`` graceful path.
+_llm_request_event_log: contextvars.ContextVar["EventLog | None"] = contextvars.ContextVar(
+    "reyn_llm_request_event_log", default=None,
+)
+
+
+def set_llm_request_event_log(log: "EventLog | None") -> contextvars.Token:
+    """Set the ambient EventLog the LLM chokepoint emits ``llm_request`` to (#1669).
+
+    Returns the token so a caller MAY reset to the prior value for a nested scope;
+    the session / runtime set-at-creation sites do not reset (last-set-wins is the
+    intended session-scoped lifetime — the active top-level run owns the sink)."""
+    return _llm_request_event_log.set(log)
+
+
+def get_llm_request_event_log() -> "EventLog | None":
+    """Read the ambient EventLog for the LLM chokepoint (#1669); None when unset."""
+    return _llm_request_event_log.get()
 
 
 class EventLog:

--- a/src/reyn/kernel/runtime.py
+++ b/src/reyn/kernel/runtime.py
@@ -106,6 +106,12 @@ class OSRuntime:
         self.events = EventLog(
             subscribers=subscribers, run_id=run_id, plan_step=plan_step,
         )
+        # #1669: publish this runtime's EventLog as the ambient sink for the LLM
+        # acompletion chokepoint, so every LLM call in this run emits an observable
+        # `llm_request` event (non-message params) without threading events through
+        # the call stack. Set at creation → propagates into the op-loop's tasks.
+        from reyn.events.events import set_llm_request_event_log
+        set_llm_request_event_log(self.events)
         self.workspace = Workspace(
             self.events,
             permission_resolver=permission_resolver,

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -866,6 +866,37 @@ LLM_PURPOSES: tuple[str, ...] = (
 )
 
 
+# #1669: top-level kwarg keys whose VALUE is secret-like and must be redacted
+# from the llm_request observability event (the proxy path injects ``api_key``,
+# see ``proxy_kwargs``). Substring match, case-insensitive.
+_LLM_REQUEST_SECRET_HINTS: tuple[str, ...] = (
+    "api_key", "api-key", "authorization", "secret", "token",
+)
+
+
+def _redact_llm_request_params(base_kwargs: dict, response_format: dict | None) -> dict:
+    """#1669: build the non-message, non-tools LLM call params for the
+    ``llm_request`` event, with secret-like values redacted.
+
+    ``messages`` is never present (separate positional arg); ``tools`` is dropped
+    (surfaced as ``tools_count``); ``response_format`` is added explicitly because
+    it is applied inside ``_once`` rather than carried in ``base_kwargs``, so the
+    event still reflects the actual outgoing param.
+    """
+    out: dict = {}
+    for k, v in base_kwargs.items():
+        if k in ("tools", "messages"):  # tools → count; messages never surfaced
+            continue
+        kl = k.lower()
+        if any(hint in kl for hint in _LLM_REQUEST_SECRET_HINTS):
+            out[k] = "***REDACTED***"
+        else:
+            out[k] = v
+    if response_format is not None and "response_format" not in out:
+        out["response_format"] = response_format
+    return out
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -921,6 +952,27 @@ async def recorded_acompletion(
         if "reasoning_effort" not in _allowed:
             _allowed.append("reasoning_effort")
         base_kwargs["allowed_openai_params"] = _allowed
+
+    # #1669: emit a P6 ``llm_request`` event (TUI-observable) carrying the
+    # non-message call params, ONCE here — before the ``_once`` response_format
+    # retry loop, so a fallback retry does not double-emit. Ambient EventLog via
+    # ContextVar (set by the session / kernel runtime); None → skip, mirroring the
+    # ``recorder=None`` graceful path. ``messages`` is excluded by construction
+    # (a separate positional arg, never in base_kwargs); ``tools`` → count;
+    # secret-like fields redacted. Never let an audit emit break the LLM call.
+    try:
+        from reyn.events.events import get_llm_request_event_log
+        _llm_event_log = get_llm_request_event_log()
+        if _llm_event_log is not None:
+            _llm_event_log.emit(
+                "llm_request",
+                model=effective_model,
+                purpose=purpose,
+                tools_count=len(base_kwargs.get("tools") or []),
+                params=_redact_llm_request_params(base_kwargs, response_format),
+            )
+    except Exception:  # noqa: BLE001
+        pass
 
     async def _once(rf: dict | None) -> object:
         call_kwargs = dict(base_kwargs)

--- a/tests/test_llm_request_event_1669.py
+++ b/tests/test_llm_request_event_1669.py
@@ -1,0 +1,175 @@
+"""Tier 2: #1669 — the `llm_request` P6 observability event at the LLM chokepoint.
+
+`recorded_acompletion` (the single `litellm.acompletion` chokepoint, #1190
+AST-guarded) emits a P6 `llm_request` event carrying the NON-message call params
+so they are TUI-verifiable when testing a model (reasoning_effort, temperature,
+extra_body, response_format, …). The event is delivered via a session-scoped
+ambient `EventLog` (ContextVar set by the chat session / kernel runtime); when
+unset (tests / dogfood / CLI) the chokepoint skips the emit, mirroring the
+`recorder=None` graceful path.
+
+Contract pinned here:
+  - the event fires at the chokepoint when the ambient EventLog is set (= the
+    ContextVar read propagates — lead's propagation verify);
+  - `messages` is excluded; `tools` → `tools_count`; secret-like fields redacted;
+  - `response_format` is reflected even though it is applied inside `_once`;
+  - ambient EventLog unset → no event (graceful skip).
+
+No mocks: a real `EventLog`, the real redaction helper, and a real async fake for
+`litellm.acompletion` (monkeypatched — the documented replay seam).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from reyn.events.events import (
+    EventLog,
+    get_llm_request_event_log,
+    set_llm_request_event_log,
+)
+from reyn.llm.llm import _redact_llm_request_params, recorded_acompletion
+
+
+@pytest.fixture(autouse=True)
+def _reset_ambient_event_log():
+    """Clear the ambient LLM-request EventLog after each test so the ContextVar
+    does not leak across tests in the same process."""
+    yield
+    set_llm_request_event_log(None)
+
+
+async def _fake_acompletion(**_kwargs):
+    """Real async fake for litellm.acompletion — returns a minimal object. The
+    chokepoint only parses usage when recorder is given (None here), so the shape
+    is irrelevant to the event-emit path under test."""
+    return object()
+
+
+def _call(monkeypatch, **extra_kwargs):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)  # no proxy → model unstripped
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+    return asyncio.run(
+        recorded_acompletion(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "secret message body"}],
+            purpose="main",
+            recorder=None,
+            response_format={"type": "json_object"},
+            extra_kwargs=extra_kwargs,
+        )
+    )
+
+
+# ── the event fires + carries the non-message params ───────────────────────────
+
+
+def test_event_emitted_with_non_message_params(monkeypatch) -> None:
+    """Tier 2: #1669 — with the ambient EventLog set, a chokepoint call emits one
+    `llm_request` event carrying model / purpose / the non-message params (proves
+    the ContextVar read propagates into the call — lead's propagation verify)."""
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    _call(
+        monkeypatch,
+        reasoning_effort="low",
+        temperature=0.7,
+        extra_body={"thinking": {"budget": 1024}},
+    )
+
+    kinds = [e.type for e in log.all()]
+    assert kinds == ["llm_request"], f"expected exactly one llm_request; got {kinds}"
+    data = log.all()[0].data
+    assert data["model"] == "gpt-5.4"
+    assert data["purpose"] == "main"
+    assert data["params"]["reasoning_effort"] == "low"
+    assert data["params"]["temperature"] == 0.7
+    assert data["params"]["extra_body"] == {"thinking": {"budget": 1024}}
+    # response_format is applied inside _once but still reflected in the event.
+    assert data["params"]["response_format"] == {"type": "json_object"}
+
+
+def test_event_excludes_messages(monkeypatch) -> None:
+    """Tier 2: #1669 — the event NEVER carries `messages` (owner: 'メッセージ以外').
+    The secret message body must not leak anywhere in the event data."""
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    _call(monkeypatch, temperature=0.1)
+
+    data = log.all()[0].data
+    assert "messages" not in data
+    assert "messages" not in data["params"]
+    assert "secret message body" not in repr(data)
+
+
+def test_event_tools_count_not_array(monkeypatch) -> None:
+    """Tier 2: #1669 — `tools` is surfaced as a count, never the (large) array."""
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    tools = [{"type": "function", "function": {"name": f"t{i}"}} for i in range(18)]
+    _call(monkeypatch, tools=tools, temperature=0.0)
+
+    data = log.all()[0].data
+    assert data["tools_count"] == 18
+    assert "tools" not in data["params"], "the tools array must not be in the event"
+
+
+def test_event_redacts_secret_fields(monkeypatch) -> None:
+    """Tier 2: #1669 — secret-like params (api_key / authorization) are redacted."""
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    _call(monkeypatch, api_key="sk-super-secret", authorization="Bearer tok-123")
+
+    params = log.all()[0].data["params"]
+    assert params["api_key"] == "***REDACTED***"
+    assert params["authorization"] == "***REDACTED***"
+    assert "sk-super-secret" not in repr(params)
+    assert "tok-123" not in repr(params)
+
+
+def test_no_event_when_ambient_log_unset(monkeypatch) -> None:
+    """Tier 2: #1669 — with NO ambient EventLog (tests / dogfood / CLI), the
+    chokepoint skips the emit (graceful, mirrors recorder=None). The call still
+    completes normally."""
+    set_llm_request_event_log(None)
+    assert get_llm_request_event_log() is None
+
+    # Should not raise even though there is no sink.
+    result = _call(monkeypatch, temperature=0.5)
+    assert result is not None
+
+
+# ── the redaction helper (pure) ────────────────────────────────────────────────
+
+
+def test_redact_helper_drops_tools_and_messages_keeps_rest() -> None:
+    """Tier 2: #1669 — the pure redaction helper drops tools/messages, redacts
+    secrets, keeps the rest, and folds in response_format."""
+    out = _redact_llm_request_params(
+        {
+            "tools": [1, 2, 3],
+            "messages": ["leak"],
+            "reasoning_effort": "high",
+            "API_KEY": "x",  # case-insensitive
+            "num_retries": 2,
+        },
+        response_format={"type": "json_object"},
+    )
+    assert "tools" not in out and "messages" not in out
+    assert out["reasoning_effort"] == "high"
+    assert out["num_retries"] == 2
+    assert out["API_KEY"] == "***REDACTED***"
+    assert out["response_format"] == {"type": "json_object"}
+
+
+def test_redact_helper_omits_response_format_when_none() -> None:
+    """Tier 2: #1669 — response_format absent when None (not forced into params)."""
+    out = _redact_llm_request_params({"temperature": 0.3}, response_format=None)
+    assert "response_format" not in out
+    assert out["temperature"] == 0.3


### PR DESCRIPTION
**[e2e-coder]** — owner-directed (observability). Refs #1669. **Backend half** of the 2-peer split; TUI half = tui-coder's **#1670** (renders this event). Confirm-first ACKed by lead (ContextVar + schema).

## Problem

When testing a model (e.g. GPT-5.4), there's no way to confirm which **non-message** params actually went out — `reasoning_effort`, `temperature`, `extra_body` (thinking config), `response_format`, etc. The only indirect signal was the 💭 reasoning block (and only if the model returned `reasoning_content`). The owner wants a direct, model-output-independent view.

## Fix — P6 `llm_request` event at the single acompletion chokepoint

**Capture (complete-by-construction):** `recorded_acompletion` is the SINGLE `litellm.acompletion` chokepoint for ALL LLM calls (#1190 AST-guarded — nothing bypasses it). Emit the event there.

**Delivery — ambient ContextVar (confirm-first finding + lead-approved):** the chokepoint receives no events sink (only `budget`/`recorder`); threading `events` through its 9 call sites would be churn **and** incomplete (judge/compaction/dogfood callers lack a sink). Instead a session-scoped `ContextVar[EventLog]` (`events/events.py`) is set by the chat session (`session.py` `_chat_events`) + kernel runtime (`runtime.py` `self.events`) at EventLog creation; the chokepoint reads it and emits. ContextVars copy into child asyncio tasks at spawn, so set-before-the-run-loop propagates to every in-session call. Unset (tests/dogfood/CLI) → skip, mirroring the `recorder=None` graceful path. (Established pattern — 4 existing ContextVar uses in reyn.)

## Event schema (locked with tui-coder — #1670)

`kind=llm_request`, `data`:
- `model`: str (effective_model, post proxy-prefix-strip)
- `purpose`: str (cost bucket: main/phase/compaction/judge/skill_node_adapt/dogfood)
- `tools_count`: int (the array → count only)
- `params`: dict — the non-message call kwargs (reasoning_effort, temperature, extra_body, response_format, timeout, num_retries, …)

`messages` excluded **by construction** (a separate positional arg, never in `base_kwargs`). Secret-like keys (`api_key`/`authorization`/`secret`/`token`, case-insensitive — the proxy path injects `api_key`) → `***REDACTED***`. `response_format` folded in (applied inside `_once`). Emitted **once** before the `_once` response_format-retry loop (no double-emit).

## Test plan

- [x] `pytest -q` from rootdir → **7407 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** (worktree-verified earlier this session; both in swebench-eval / web_fetch modules — orthogonal to this diff's llm/events/session/runtime).
- [x] New `test_llm_request_event_1669.py` (7 Tier-2, no Mock — real `EventLog` + real async fake for `litellm.acompletion`): event fires when the ambient EventLog is set (**= the ContextVar read propagates into the call**, lead's propagation verify), carries the non-message params, excludes `messages` (no leak), `tools`→`tools_count`, secrets redacted; unset → no event; + the pure redaction helper's contract.
- [x] Regression: `test_event_audit_invariants`, `test_cost_chokepoint_1190` + AST-guard, `test_llm_call_recorder_invariants`, session-factory/cost suites all green.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] `llm_request` intentionally **not** added to `EVENT_AUDIT_REQUIREMENTS` (that registry enforces a curated correlation-field subset; most kinds aren't listed).

## Coordination
- Pairs with **#1670** (tui-coder, render+filter). Once this emitter lands, a real session drives the owner's live key-cascade confirm (tui-coder's tmux key-nav item is an explicit skip-with-reason: the tmux MCP can't send the Ctrl-chord; their `render_events()` functional test + units prove render+filter logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
