### PR TITLE
feat(1672): user-configurable per-purpose model class (model_class_by_purpose)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -25,6 +25,7 @@ models:
 |-----|------|-------------|
 | `model` | string | Default model class. Resolved via `models`. Override with `--model`. |
 | `models` | map | Class name → LiteLLM model string **or** dict (see below). |
+| `model_class_by_purpose` | map | Per-purpose model-class override (`router` / `control_ir` / `tool` / `compaction` / `judge`). Unset purpose → `model`. See below. |
 | `output_language` | string | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
 | `safety` | map | Runtime stop conditions: loop-detection caps, timeouts, on-limit policy. See below. |
 | `cost` | map | Budget caps and rate limits (per-agent, daily, monthly). See below. |
@@ -249,6 +250,38 @@ User-declared entries **override** built-ins with the same name.  The built-in c
 is a convenience starting point; your `reyn.yaml` is always the source of truth.
 
 See [Reference: built-in models](../builtin-models.md) for per-entry details.
+
+### `model_class_by_purpose` — per-purpose model class
+
+Reyn makes several internal LLM calls beyond the main agent reply, each tied to a
+logical **purpose**. By default every purpose uses your configured `model` (the
+default class) — **routing follows the model you configured; there is no hidden
+cheaper tier**. `model_class_by_purpose` lets you override the class for a
+specific purpose; an unset purpose falls back to `model`.
+
+| Purpose | What it covers |
+|---|---|
+| `router` | The per-turn chat router / intent classification (and the plan-decomposition router). |
+| `control_ir` | Control-IR sub-execution model. |
+| `tool` | The default class for tool-spawned skill runs. |
+| `compaction` | Context-compaction summarisation. |
+| `judge` | Output-judging / evaluation calls. |
+
+```yaml
+model: standard                  # the default class for every purpose
+models:
+  standard: openai/gpt-5.4
+  light:    openai/gpt-4o-mini
+model_class_by_purpose:
+  router: light                  # opt INTO a cheaper per-turn router (an explicit choice)
+  # control_ir / tool / compaction / judge unset → follow `model` (gpt-5.4)
+```
+
+**Cost note**: the router runs on every turn, so the cheap-router optimisation is
+still available — it is now an explicit one-line opt-in (`router: light`) rather
+than a hidden default. Explicit per-call selections (a skill's `op.model`, a
+phase's frontmatter `model_class`) still win over this fallback. Unknown purpose
+keys are warned (not fatal) at load time.
 
 ## `chat` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -59,6 +59,19 @@
 
 
 # -----------------------------------------------------------------------------
+# model_class_by_purpose: per-purpose model-class override (#1672).
+# Reyn makes internal LLM calls beyond the main reply, each tied to a purpose
+# (router / control_ir / tool / compaction / judge). By DEFAULT every purpose
+# follows `model` (no hidden cheaper tier). Override a purpose here; an unset
+# purpose falls back to `model`. The per-turn router is a common cost knob —
+# opt into a cheaper class explicitly:
+# -----------------------------------------------------------------------------
+# model_class_by_purpose:
+#   router: light            # cheaper per-turn router (explicit opt-in)
+#   # control_ir / tool / compaction / judge unset → follow `model`
+
+
+# -----------------------------------------------------------------------------
 # api_base: LiteLLM proxy / direct provider base URL.
 # Empty (default) → providers' own endpoints. A local proxy is the most
 # common override:

--- a/src/reyn/agent.py
+++ b/src/reyn/agent.py
@@ -195,7 +195,11 @@ class Agent:
             strict=strict,
             subscribers=subscribers,
             intervention_bus=intervention_bus,
-            resolver=resolver if resolver is not None else ModelResolver(config.models),
+            resolver=resolver if resolver is not None else ModelResolver(
+                config.models,
+                default_class=config.model,
+                purpose_classes=config.model_class_by_purpose,
+            ),
             permission_resolver=permission_resolver,
             safety=safety if safety is not None else config.safety,
             mcp_servers=config.mcp,

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -857,13 +857,23 @@ def _build_sub_loop_memo_provider(
     )
 
 
+def _resolve_router_model(router_model: "str | None", host: Any) -> str:
+    """#1672: resolve an UNSET (None) router_model to the configured "router"
+    purpose class via the host's config-aware ModelResolver — so the plan
+    decomposition router follows the configured model instead of a hidden "light"
+    tier. An explicit value passes through unchanged. Delegates to the shared
+    ``resolve_purpose_class`` so it stays identical to RouterLoop's resolution."""
+    from reyn.llm.model_resolver import resolve_purpose_class
+    return resolve_purpose_class(router_model, getattr(host, "resolver", None), "router")
+
+
 async def execute_plan(
     plan: Plan,
     *,
     parent_host: RouterLoopHost,
     chain_id: str,
     budget: Any = None,
-    router_model: str = "light",
+    router_model: "str | None" = None,  # #1672: None → config "router" purpose class (was "light")
     plan_id: str | None = None,
     resume_plan: Any = None,
     step_max_iterations: int | None = None,
@@ -899,6 +909,9 @@ async def execute_plan(
     sharing). When neither is provided, step-results compaction is skipped
     (= legacy / no-config path, backward-compatible).
     """
+    # #1672: resolve an unset router_model to the configured "router" class so the
+    # plan decomposition router follows config (not the old hidden "light").
+    router_model = _resolve_router_model(router_model, parent_host)
     # PR-N4: lazy engine construction (path b).
     #
     # Design choice: path (b) rather than path (a) from the spec.
@@ -1456,7 +1469,7 @@ async def dispatch_plan_tool(
     parent_host: RouterLoopHost,
     chain_id: str,
     budget: Any = None,
-    router_model: str = "light",
+    router_model: "str | None" = None,  # #1672: None → config "router" purpose class (was "light")
     available_tool_names: set[str],
 ) -> dict:
     """Entry point invoked from the chat router's ``plan`` tool dispatch.
@@ -1491,6 +1504,8 @@ async def dispatch_plan_tool(
     ``plan_<plan_id>`` so R-D14 notifications target the right
     waiter on plan discard.
     """
+    # #1672: an unset router_model follows the configured "router" class (was "light").
+    router_model = _resolve_router_model(router_model, parent_host)
     try:
         plan = parse_and_validate_plan(args, allowed_tool_names=available_tool_names)
     except PlanValidationError as exc:

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1383,7 +1383,7 @@ class RouterLoop:
         host: RouterLoopHost,
         chain_id: str,
         max_iterations: int = 5,
-        router_model: str = "light",  # config tier (light = intent classification)
+        router_model: "str | None" = None,  # #1672: None → config (model_class_for("router")); was hardcoded "light"
         budget: Any = None,  # BudgetTracker | None — process-shared cost tracker
         system_prompt_override: str | None = None,
         non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from ChatSession.
@@ -1401,7 +1401,16 @@ class RouterLoop:
         self.host = host
         self.chain_id = chain_id
         self.max_iterations = max_iterations
-        self.router_model = router_model
+        # #1672: an UNSET router_model follows the configured model (no hidden
+        # "light" tier) — resolve the "router" purpose class via the host's
+        # config-aware ModelResolver. Explicit router_model still wins. The plan
+        # path inherits this resolved value (dispatch_plan_tool passes
+        # self.router_model), so the chat router + plan-decomposition router both
+        # follow config from this single resolution point.
+        from reyn.llm.model_resolver import resolve_purpose_class
+        self.router_model = resolve_purpose_class(
+            router_model, getattr(host, "resolver", None), "router",
+        )
         self.budget = budget
         # #1092 PR-C-2.5: phase-relative op-dispatch counter for crash-resume WAL
         # memoization. Only advanced when the host opts a dispatch into phase-memo

--- a/src/reyn/chat/services/plan_runner.py
+++ b/src/reyn/chat/services/plan_runner.py
@@ -182,7 +182,7 @@ class PlanRunner:
         *,
         decision: Any,
         budget: Any = None,
-        router_model: str = "light",
+        router_model: "str | None" = None,  # #1672: None → config "router" class (resolved downstream by execute_plan)
     ) -> None:
         """Launch a PlanRuntime for a resume decision (ADR-0023 §3.4).
 

--- a/src/reyn/cli/commands/cron.py
+++ b/src/reyn/cli/commands/cron.py
@@ -283,7 +283,11 @@ def _build_runner():
 
         config = load_config()
         model_class = config.model
-        resolver = ModelResolver(config.models)
+        resolver = ModelResolver(
+            config.models,
+            default_class=config.model,
+            purpose_classes=config.model_class_by_purpose,
+        )
         resolved = resolver.resolve(model_class).model
         project_root = _find_project_root(Path.cwd())
         project_context = load_project_context(config, project_root)

--- a/src/reyn/cli/commands/dogfood.py
+++ b/src/reyn/cli/commands/dogfood.py
@@ -415,7 +415,11 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
 
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
     config = load_config()
-    resolver = ModelResolver(config.models)
+    resolver = ModelResolver(
+        config.models,
+        default_class=config.model,
+        purpose_classes=config.model_class_by_purpose,
+    )
     model = config.model
     output_language = config.output_language
     safety = config.safety

--- a/src/reyn/cli/commands/mcp.py
+++ b/src/reyn/cli/commands/mcp.py
@@ -726,7 +726,11 @@ def run_install(args: argparse.Namespace) -> None:
 
     if config.api_base:
         os.environ.setdefault("LITELLM_API_BASE", config.api_base)
-    resolver = ModelResolver(config.models)
+    resolver = ModelResolver(
+        config.models,
+        default_class=config.model,
+        purpose_classes=config.model_class_by_purpose,
+    )
     logger = make_logger()
     # #997 dir2: config-derived permission/runtime bundle wired by from_config.
     agent = Agent.from_config(

--- a/src/reyn/cli/session.py
+++ b/src/reyn/cli/session.py
@@ -25,7 +25,11 @@ class Session:
         config = load_config()
         if config.api_base:
             os.environ.setdefault("LITELLM_API_BASE", config.api_base)
-        return cls(config=config, resolver=ModelResolver(config.models))
+        return cls(config=config, resolver=ModelResolver(
+            config.models,
+            default_class=config.model,
+            purpose_classes=config.model_class_by_purpose,
+        ))
 
     # ── argparse-aware setting resolution (CLI > config) ─────────────────────
 

--- a/src/reyn/config.py
+++ b/src/reyn/config.py
@@ -1742,6 +1742,23 @@ class ReynConfig:
         default_factory=dict,
         metadata={"desc": "Map of model class names to LiteLLM model strings."},
     )
+    # #1672: per-purpose model-class override. The mapping from a logical call
+    # purpose (router / control_ir / tool / compaction / judge) to a model CLASS
+    # was hardcoded in code (router="light", control_ir/tool="standard"), so the
+    # user could set what a class resolves to but NOT which class each purpose
+    # uses — the owner's "don't do things users can't customize" complaint. This
+    # map exposes it: an UNSET purpose falls back to ``model`` (the configured
+    # main), so by default routing follows the configured model — no hidden
+    # cheaper tier. Setting e.g. ``router: light`` is the explicit opt-in to the
+    # cheap per-turn router. Explicit per-call selections (run_skill op.model,
+    # phase frontmatter model_class) still WIN over this fallback.
+    model_class_by_purpose: dict[str, str] = field(
+        default_factory=dict,
+        metadata={"desc": (
+            "Per-purpose model class override (router / control_ir / tool / "
+            "compaction / judge). Unset purpose → the `model` default."
+        )},
+    )
     tool_calls_op_loop_skills: list[str] = field(
         default_factory=list,
         metadata={"desc": (
@@ -1903,6 +1920,46 @@ class ReynConfig:
     external_transports: "ExternalTransportRouting" = field(
         default_factory=lambda: _empty_external_transports(),
     )
+
+    def model_class_for(self, purpose: str) -> str:
+        """#1672: the model CLASS for a logical call *purpose*.
+
+        A per-purpose override in ``model_class_by_purpose`` wins; otherwise the
+        configured default class ``model`` (so unset purposes follow the user's
+        configured model — no hidden cheaper tier). Explicit per-call selections
+        (run_skill ``op.model``, phase frontmatter ``model_class``) are applied by
+        the caller BEFORE this fallback and still win.
+        """
+        return self.model_class_by_purpose.get(purpose, self.model)
+
+
+# #1672: the logical purposes whose model class is configurable via
+# ``model_class_by_purpose``. A typo'd key would silently never apply (the call
+# sites look up fixed keys), so the parser warns on an unknown key rather than
+# hard-failing (forward-compatible — a future purpose key is a warn, not a crash).
+MODEL_CLASS_PURPOSES: frozenset[str] = frozenset({
+    "router", "control_ir", "tool", "compaction", "judge",
+})
+
+
+def _build_model_class_by_purpose(raw: object) -> dict[str, str]:
+    """#1672: parse ``model_class_by_purpose`` (purpose → model class). Unknown
+    purpose keys WARN (not error) — a typo would silently never apply, so flag it
+    decision-enablingly while staying forward-compatible with future purposes."""
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        key = str(k)
+        if key not in MODEL_CLASS_PURPOSES:
+            import logging
+            logging.getLogger(__name__).warning(
+                "model_class_by_purpose.%s is not a known purpose %s — it will "
+                "never be applied; check for a typo.",
+                key, sorted(MODEL_CLASS_PURPOSES),
+            )
+        out[key] = str(v)
+    return out
 
 
 def _empty_external_transports():
@@ -2328,6 +2385,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             str(k): (v if isinstance(v, dict) else str(v))
             for k, v in (merged.get("models") or {}).items()
         },
+        model_class_by_purpose=_build_model_class_by_purpose(
+            merged.get("model_class_by_purpose"),
+        ),
         tool_calls_op_loop_skills=[
             str(s) for s in (merged.get("tool_calls_op_loop_skills") or [])
         ],

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -359,7 +359,10 @@ class ControlIRExecutor:
             permission_resolver=self._perm,
             skill_name=self._skill_name,
             skill=None,  # control IR doesn't lean on preloaded sub-skills
-            model="standard",
+            # #1672: the control_ir purpose class follows config (was hardcoded
+            # "standard"); byte-identical at default (config.model defaults to
+            # "standard"). Resolver is config-aware (class_for_purpose).
+            model=self._resolver.class_for_purpose("control_ir"),
             resolver=self._resolver,
             subscribers=self.events.subscribers,
             output_language=None,

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -164,12 +164,33 @@ def _strip_keys(d: dict, keys: set[str]) -> dict:
     return {k: v for k, v in d.items() if k not in keys}
 
 
+def resolve_purpose_class(
+    explicit: "str | None", resolver: "ModelResolver | None", purpose: str,
+) -> str:
+    """#1672: pick the model CLASS for a *purpose*, with explicit-wins precedence.
+
+    An ``explicit`` (caller-supplied) value wins; otherwise the *resolver*'s
+    per-purpose class (``class_for_purpose``, which falls back to the configured
+    default class); otherwise ``"standard"`` when no config-aware resolver is
+    available (a stub / no-resolver context — byte-identical to the former
+    hardcodes). Shared by ``RouterLoop`` (router) + the planner so the chat router
+    and plan-decomposition router resolve identically from one place.
+    """
+    if explicit is not None:
+        return explicit
+    if resolver is not None and hasattr(resolver, "class_for_purpose"):
+        return resolver.class_for_purpose(purpose)
+    return "standard"
+
+
 class ModelResolver:
     def __init__(
         self,
         mapping: dict[str, Any],
         *,
         builtin: dict[str, dict] | None = None,
+        default_class: str = "standard",
+        purpose_classes: dict[str, str] | None = None,
     ) -> None:
         """Build a ModelResolver.
 
@@ -178,9 +199,19 @@ class ModelResolver:
             builtin:  Built-in catalog.  Defaults to ``BUILTIN_MODELS``.
                       User entries in *mapping* override entries with the same
                       name.  Pass ``{}`` to disable built-ins (useful in tests).
+            default_class: #1672 — the configured default model class
+                      (``ReynConfig.model``) returned by ``class_for_purpose`` for
+                      any unset purpose. Defaults to ``"standard"`` so resolvers
+                      built without it stay byte-identical to the old hardcodes.
+            purpose_classes: #1672 — per-purpose class overrides
+                      (``ReynConfig.model_class_by_purpose``). A purpose present
+                      here wins over ``default_class`` in ``class_for_purpose``.
         """
         if builtin is None:
             builtin = BUILTIN_MODELS
+
+        self._default_class = default_class
+        self._purpose_classes: dict[str, str] = dict(purpose_classes or {})
 
         # Flat namespace: user entries override built-ins.
         self._namespace: dict[str, Any] = {**builtin, **mapping}
@@ -219,6 +250,20 @@ class ModelResolver:
             return self._resolved[name]
         # Unknown name: passthrough — the name IS the LiteLLM model string.
         return ModelSpec(model=name, kwargs={})
+
+    def class_for_purpose(self, purpose: str) -> str:
+        """#1672: the model CLASS for a logical call *purpose* (router / control_ir
+        / tool / compaction / judge).
+
+        A per-purpose override (``model_class_by_purpose``) wins; otherwise the
+        configured default class (``ReynConfig.model``). This is the OS-side mirror
+        of ``ReynConfig.model_class_for`` for the many call sites that hold a
+        threaded ``ModelResolver`` but not the ``ReynConfig`` object. Explicit
+        per-call selections (op.model / frontmatter) are applied by the caller
+        BEFORE this fallback and still win. Returns a CLASS name — feed it through
+        ``resolve()`` to get the ModelSpec / litellm string.
+        """
+        return self._purpose_classes.get(purpose, self._default_class)
 
     def is_known_class(self, name: str) -> bool:
         """Return True if name is a configured model class (i.e. present in the namespace).

--- a/src/reyn/op_runtime/judge_output.py
+++ b/src/reyn/op_runtime/judge_output.py
@@ -106,11 +106,21 @@ async def handle(
     # (#1454 PR-B): a non-class value falls back to the runtime model rather
     # than passing through as a literal LiteLLM string that bypasses the proxy.
     if ctx.resolver is not None:
+        # #1672: op.model (explicit) wins, then the runtime ctx.model, then the
+        # configured "judge" purpose class (was an implicit "standard" tier) — so an
+        # op-less, ctx.model-less judge call follows config instead of a hidden tier.
+        # Byte-identical at default (judge unset → config.model) and when ctx.model
+        # is set (ctx.model still wins).
         model_class = ctx.resolver.resolve_class_or_fallback(
-            op.model, ctx.model, where="judge_output",
+            op.model,
+            ctx.model or ctx.resolver.class_for_purpose("judge"),
+            where="judge_output",
         )
         resolved_model = ctx.resolver.resolve(model_class).model
     else:
+        # No resolver (degenerate / tool-spawned resolver=None path — tracked with
+        # the CAT-3 resolver-threading fast-follow); "standard" is the only safe
+        # fallback without a config-aware resolver here.
         model_class = op.model or ctx.model or "standard"
         resolved_model = model_class
 

--- a/src/reyn/op_runtime/run_skill.py
+++ b/src/reyn/op_runtime/run_skill.py
@@ -149,10 +149,19 @@ async def handle(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor
     # falls back to the runtime model, keeping the proxy config the single
     # source of truth. #1454 PR-B: the guard is the shared resolver gate.
     if ctx.resolver is not None:
+        # #1672: op.model (skill-supplied) wins, then the runtime ctx.model, then
+        # the configured default class (via class_for_purpose — unset "tool"
+        # purpose → config.model) instead of a hidden "standard" tier. Byte-
+        # identical at default and when ctx.model is set (ctx.model still wins).
         model = ctx.resolver.resolve_class_or_fallback(
-            op.model, ctx.model, where="run_skill",
+            op.model,
+            ctx.model or ctx.resolver.class_for_purpose("tool"),
+            where="run_skill",
         )
     else:
+        # No resolver (tool-invoked skill passes resolver=None — the latent bug +
+        # config-ification tracked in the CAT-3 fast-follow); "standard" is the
+        # only safe fallback without a config-aware resolver here.
         model = op.model or ctx.model or "standard"
 
     # Compute sub-state-dir based on caller context.

--- a/src/reyn/plan/plan_runtime.py
+++ b/src/reyn/plan/plan_runtime.py
@@ -56,7 +56,7 @@ class PlanRuntime:
         chain_id: str,
         plan_id: str | None = None,
         budget: Any = None,
-        router_model: str = "light",
+        router_model: "str | None" = None,  # #1672: None → config "router" class (resolved downstream by execute_plan)
         resume_plan: PlanResumePlan | None = None,
         step_max_iterations: int | None = None,
         retry_limit: int | None = None,

--- a/src/reyn/web/deps.py
+++ b/src/reyn/web/deps.py
@@ -288,7 +288,11 @@ def _get_registry():
             os.environ.setdefault("LITELLM_API_BASE", config.api_base)
 
         from reyn.llm.model_resolver import ModelResolver
-        resolver = ModelResolver(config.models)
+        resolver = ModelResolver(
+            config.models,
+            default_class=config.model,
+            purpose_classes=config.model_class_by_purpose,
+        )
         model = config.model
         output_language = config.output_language
 

--- a/tests/test_model_class_by_purpose_1672.py
+++ b/tests/test_model_class_by_purpose_1672.py
@@ -1,0 +1,129 @@
+"""Tier 2: #1672 — per-purpose model class is user-configurable (not hardcoded).
+
+The purpose→tier mapping (router="light", control_ir/tool="standard") was
+hardcoded in code, so the user could set what a class resolves to but NOT which
+class each purpose uses. This adds `model_class_by_purpose` (reyn.yaml) +
+`ReynConfig.model_class_for` / `ModelResolver.class_for_purpose` /
+`resolve_purpose_class`, with the owner-confirmed default: an UNSET purpose
+follows the configured `model` (no hidden cheaper tier); `light` is an explicit
+opt-in. Explicit per-call selections still win.
+
+No mocks: real `ReynConfig` / `ModelResolver` instances + `load_config` round-trip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import ReynConfig, load_config
+from reyn.llm.model_resolver import ModelResolver, resolve_purpose_class
+
+# ── ReynConfig.model_class_for ─────────────────────────────────────────────────
+
+
+def test_config_unset_purpose_follows_model() -> None:
+    """Tier 2: #1672 — an unset purpose falls back to `model` (the configured
+    main) — the owner's default: routing follows the configured model."""
+    cfg = ReynConfig(model="strong", model_class_by_purpose={})
+    assert cfg.model_class_for("router") == "strong"
+    assert cfg.model_class_for("control_ir") == "strong"
+
+
+def test_config_override_wins() -> None:
+    """Tier 2: #1672 — a per-purpose override wins over `model` (the explicit
+    cheap-router opt-in)."""
+    cfg = ReynConfig(model="strong", model_class_by_purpose={"router": "light"})
+    assert cfg.model_class_for("router") == "light"
+    # other purposes still follow `model`
+    assert cfg.model_class_for("judge") == "strong"
+
+
+# ── ModelResolver.class_for_purpose ────────────────────────────────────────────
+
+
+def test_resolver_class_for_purpose_override_and_default() -> None:
+    """Tier 2: #1672 — ModelResolver.class_for_purpose: override wins, unset →
+    the configured default class."""
+    r = ModelResolver({}, default_class="strong", purpose_classes={"router": "light"})
+    assert r.class_for_purpose("router") == "light"
+    assert r.class_for_purpose("control_ir") == "strong"
+
+
+def test_resolver_default_class_is_standard_at_default() -> None:
+    """Tier 2: #1672 — a ModelResolver built WITHOUT config (the test / no-config
+    fallback) defaults to "standard" for every purpose — identical to the former
+    hardcodes (CAT-2/3/4 unchanged at the default config)."""
+    r = ModelResolver({})
+    assert r.class_for_purpose("router") == "standard"
+    assert r.class_for_purpose("control_ir") == "standard"
+    assert r.class_for_purpose("judge") == "standard"
+
+
+# ── resolve_purpose_class (shared by RouterLoop + planner) ──────────────────────
+
+
+def test_resolve_purpose_class_explicit_wins() -> None:
+    """Tier 2: #1672 — an explicit (caller-supplied) value wins over the resolver."""
+    r = ModelResolver({}, default_class="strong")
+    assert resolve_purpose_class("light", r, "router") == "light"
+
+
+def test_resolve_purpose_class_unset_uses_resolver() -> None:
+    """Tier 2: #1672 — None → the resolver's per-purpose class (the router/plan
+    resolution point; this is what flips the chat router from the old hidden
+    "light" to follow-config)."""
+    r = ModelResolver({}, default_class="strong", purpose_classes={"router": "light"})
+    assert resolve_purpose_class(None, r, "router") == "light"
+    assert resolve_purpose_class(None, r, "control_ir") == "strong"
+
+
+def test_resolve_purpose_class_no_resolver_is_standard() -> None:
+    """Tier 2: #1672 — None + no resolver (host stub) → "standard" (safe default,
+    byte-identical to the old fallback)."""
+    assert resolve_purpose_class(None, None, "router") == "standard"
+
+
+# ── yaml → ReynConfig round-trip (non-default value pins the parser) ────────────
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_yaml_round_trip_non_default(tmp_path, monkeypatch) -> None:
+    """Tier 2: #1672 — model_class_by_purpose parses from reyn.yaml (a NON-default
+    value pins the parser wiring, not a trivial empty round-trip)."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "reyn.yaml", """
+model: strong
+models:
+  strong: gemini/gemini-2.5-pro
+  light: openai/gpt-4o-mini
+model_class_by_purpose:
+  router: light
+  control_ir: strong
+""".lstrip())
+    cfg = load_config(cwd=tmp_path)
+    assert cfg.model_class_by_purpose == {"router": "light", "control_ir": "strong"}
+    # And the helper resolves through it.
+    assert cfg.model_class_for("router") == "light"
+    assert cfg.model_class_for("compaction") == "strong"  # unset → model
+
+
+def test_yaml_unknown_purpose_warns_but_loads(tmp_path, monkeypatch, caplog) -> None:
+    """Tier 2: #1672 — an unknown purpose key warns (decision-enabling, catches a
+    typo) but does not crash load_config (forward-compatible)."""
+    import logging
+
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "reyn.yaml", """
+model: standard
+model_class_by_purpose:
+  rooter: light
+""".lstrip())
+    with caplog.at_level(logging.WARNING):
+        cfg = load_config(cwd=tmp_path)
+    assert "rooter" in cfg.model_class_by_purpose  # preserved (not dropped)
+    assert any("rooter" in r.getMessage() and "purpose" in r.getMessage()
+               for r in caplog.records), "expected a typo warning naming the bad key"

--- a/tests/test_replay_skill_router.py
+++ b/tests/test_replay_skill_router.py
@@ -281,7 +281,12 @@ def _tool_result(calls: list[dict]) -> LLMToolCallResult:
 
 
 def _make_loop(host: FakeRouterHost, max_iterations: int = 5) -> RouterLoop:
-    return RouterLoop(host=host, chain_id="chain-test", max_iterations=max_iterations, scheme_name="universal-category")  # #1657: this suite covers universal-category
+    # #1672: pin router_model="light" — these fixtures were recorded with the
+    # former hardcoded "light" default. The suite verifies ROUTING LOGIC, not the
+    # model-class default (which #1672 flips to follow config); pinning the
+    # recorded value keeps the fixtures valid without re-recording. The new
+    # default-follows-config behavior is covered by test_model_class_by_purpose_1672.
+    return RouterLoop(host=host, chain_id="chain-test", max_iterations=max_iterations, router_model="light", scheme_name="universal-category")  # #1657: this suite covers universal-category
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — owner-directed. Closes #1672. Confirm-first audit + config shape + default + scope split all ACKed by lead. Fast-follow: **#1673** (CAT-3 + resolver-None branches).

## Problem

The mapping from a logical call **purpose** to a model **class** was hardcoded in code — `router="light"`, `control_ir`/tool-spawn=`"standard"`. The user could set what a class *resolves to* but **not which class each purpose uses**. The owner saw a **gpt-4o router call while their configured model was GPT-5.4** ("don't do things users can't customize"). Audit confirmed the live chat router uses the hardcoded `"light"` (the driver doesn't override the default).

## Fix — one coherent per-purpose map

`model_class_by_purpose` in reyn.yaml, keyed by purpose (`router` / `control_ir` / `tool` / `compaction` / `judge`):
- `ReynConfig.model_class_for(purpose)` + the OS-side mirror `ModelResolver.class_for_purpose(purpose)` (fed `default_class=config.model` + the map at the **6 config-aware resolver constructions**).
- **An unset purpose → `model` (the configured main): routing follows the configured model, no hidden cheaper tier.** `light` is now an explicit one-line opt-in. Explicit per-call selections (`op.model`, frontmatter `model_class`) still win. Unknown purpose keys warn (not fatal).
- Shared `resolve_purpose_class(explicit, resolver, purpose)` (explicit-wins) used by **both** RouterLoop and the planner — one resolution seam.

### Sites fixed here (resolver-PRESENT)
- **CAT-1 router** (the owner's fix): `RouterLoop.router_model` default `"light"` → `None`, resolved once in `__init__`; the plan path inherits it (`dispatch_plan_tool` passes `self.router_model`) and `execute_plan`/`dispatch_plan_tool` resolve `None` from `parent_host`. All `"light"` defaults across planner/plan_runner/plan_runtime → `None`.
- **CAT-2 control_ir**: `model="standard"` → `class_for_purpose("control_ir")`.
- **CAT-4**: judge + run_skill resolver-PRESENT fallbacks → `class_for_purpose` (op.model > ctx.model still win).

**Default behavioral delta = CAT-1 router only** (`light` → `config.model`). CAT-2/CAT-4 are **byte-identical at the default config** (`config.model` defaults to `"standard"`).

## Residual gap (tracked: #1673)

The resolver-**None** sites are deferred: CAT-3 tool sub-runs (`invoke_skill` etc. pass `resolver=None` + `model="standard"`) and the resolver-None `or "standard"` fallbacks (judge/run_skill). They share the root (no resolver to resolve a class) **plus a latent literal-model-to-litellm bug** (a tool-spawned skill with no `op.model` sends `"standard"` as a literal model name), so they get a focused PR + tests. **At the default config this residual is byte-identical** (`config.model` defaults to `"standard"`); it only diverges on a customized `config.model`. Narrow, tracked, acceptable.

## Test plan

- [x] `pytest -q` from rootdir → **7421 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** (worktree-verified on current HEAD; orthogonal modules).
- [x] New `test_model_class_by_purpose_1672.py` (9 Tier-2, no Mock — real `ReynConfig`/`ModelResolver` + `load_config`): `model_class_for` (override / unset→model), `class_for_purpose` (override / default), `resolve_purpose_class` (explicit/unset/no-resolver), **non-default** yaml round-trip, unknown-key warn.
- [x] `test_replay_skill_router` pins `router_model="light"` — fixtures were recorded with the former default; the suite verifies routing logic, not the model-class default (which this PR flips). Root confirmed: `router_model`'s value flows into the request; pinning preserves fixtures without re-recording (replay-fixture discipline). New default covered by the Tier-2 suite above.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] Doc/example mirror guard (`test_config_mirror_coverage_1056`) satisfied — `model_class_by_purpose` documented in `reyn-yaml.md` (table row + dedicated subsection) and `reyn.local.yaml.example`.
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
