### PR TITLE
fix(1673): thread resolver to tool-spawned OpContexts (latent literal-model bug + #1672 CAT-3)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -3290,6 +3290,10 @@ class RouterLoop:
             workspace=getattr(self.host, "workspace", None),
             caller_kind="router",
             router_state=rs,
+            # #1673: thread the config-aware resolver so a tool handler that spawns
+            # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
+            # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
+            resolver=getattr(self.host, "resolver", None),
         )
         return [
             {
@@ -3703,6 +3707,8 @@ class RouterLoop:
                 workspace=getattr(self.host, "workspace", None),
                 caller_kind="router",
                 router_state=rs,
+                # #1673: thread the config-aware resolver (see the sibling sites).
+                resolver=getattr(self.host, "resolver", None),
             )
             list_actions_def = get_default_registry().lookup("list_actions")
             if list_actions_def is None:
@@ -3928,6 +3934,10 @@ class RouterLoop:
             workspace=getattr(self.host, "workspace", None),
             caller_kind="router",
             router_state=rs,
+            # #1673: thread the config-aware resolver so a tool handler that spawns
+            # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
+            # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
+            resolver=getattr(self.host, "resolver", None),
         )
         result = await invoke_tool(get_default_registry(), name, args, tool_ctx)
         return self._normalise_router_tool_result(name, result)

--- a/src/reyn/kernel/control_ir_executor.py
+++ b/src/reyn/kernel/control_ir_executor.py
@@ -525,6 +525,10 @@ class ControlIRExecutor:
                         workspace=self.workspace,
                         caller_kind="phase",
                         phase_state=phase_state,
+                        # #1673: thread the config-aware resolver so a tool handler
+                        # that spawns a sub-run hands it a real resolver (not None →
+                        # literal "standard" → litellm BadRequestError).
+                        resolver=self._resolver,
                     )
                     result = await invoke_tool(_registry, _name, args, tool_ctx)
                 else:

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -74,6 +74,10 @@ async def _handle_compact(args: Mapping[str, Any], ctx: ToolContext) -> ToolResu
             permission_resolver=ctx.permission_resolver,
             skill_name="",
             subscribers=getattr(ctx.events, "subscribers", []),
+            # #1673: never resolver=None (the bug-class invariant). This minimal
+            # path returns compaction_unavailable (no LLM call), but the uniform
+            # threading keeps the invariant provable.
+            resolver=ctx.resolver,
         )
 
     return await execute_op(op, legacy_ctx, caller="control_ir")

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Mapping
 
+from reyn.llm.model_resolver import resolve_purpose_class  # #1673
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 if TYPE_CHECKING:
@@ -193,8 +194,12 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         permission_resolver=ctx.permission_resolver,
         skill_name="",
         skill=None,
-        model="standard",
-        resolver=None,
+        # #1673: the spawned skill run follows the configured "tool" purpose class
+        # (was the literal "standard"), and gets the REAL config-aware resolver
+        # (was None → run_skill's resolver-None branch yielded the literal
+        # "standard" → litellm BadRequestError on the spawned run's first LLM call).
+        model=resolve_purpose_class(None, ctx.resolver, "tool"),
+        resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
         max_phase_visits=25,

--- a/src/reyn/tools/lint.py
+++ b/src/reyn/tools/lint.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.llm.model_resolver import resolve_purpose_class  # #1673
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 _LINT_DESCRIPTION = (
@@ -81,8 +82,11 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         permission_resolver=ctx.permission_resolver,
         skill_name="",
         skill=None,
-        model="standard",
-        resolver=None,
+        # #1673: real resolver + "tool" purpose class (was None + literal
+        # "standard") — eliminates the resolver=None → litellm-BadRequestError class
+        # by construction (uniform with invoke_skill; this handler makes no LLM call).
+        model=resolve_purpose_class(None, ctx.resolver, "tool"),
+        resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
         max_phase_visits=25,

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Final, Mapping
 
+from reyn.llm.model_resolver import resolve_purpose_class  # #1673
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 if TYPE_CHECKING:
@@ -303,8 +304,11 @@ async def _handle_call_mcp_tool(
             permission_resolver=ctx.permission_resolver,
             skill_name="",
             skill=None,
-            model="standard",
-            resolver=None,
+            # #1673: real resolver + "tool" purpose class (was None + literal
+            # "standard") — eliminates the resolver=None → litellm-BadRequestError
+            # class by construction (uniform; this handler makes no LLM call).
+            model=resolve_purpose_class(None, ctx.resolver, "tool"),
+            resolver=ctx.resolver,
             subscribers=getattr(ctx.events, "subscribers", []),
             output_language=None,
             max_phase_visits=25,

--- a/src/reyn/tools/op_context_bridge.py
+++ b/src/reyn/tools/op_context_bridge.py
@@ -51,6 +51,8 @@ def build_legacy_op_context(ctx: "ToolContext") -> Any:
     phase_op_ctx = (
         ctx.phase_state.op_context if ctx.phase_state is not None else None
     )
+    from reyn.llm.model_resolver import resolve_purpose_class  # #1673
+
     return OpContext(
         workspace=ctx.workspace,
         events=ctx.events,
@@ -61,4 +63,11 @@ def build_legacy_op_context(ctx: "ToolContext") -> Any:
         ),
         permission_resolver=ctx.permission_resolver,
         skill_name="",
+        # #1673: thread the config-aware resolver + "tool" purpose class so this
+        # ONE shared bridge gives every delegating tool a real resolver instead of
+        # the OpContext default resolver=None (+ literal "standard"). Eliminates the
+        # resolver=None → litellm-BadRequestError class by construction for all
+        # bridge-using tools (recall / web_fetch / compact / file / …).
+        model=resolve_purpose_class(None, ctx.resolver, "tool"),
+        resolver=ctx.resolver,
     )

--- a/src/reyn/tools/recall.py
+++ b/src/reyn/tools/recall.py
@@ -180,6 +180,11 @@ async def _handle_recall(args: Mapping[str, Any], ctx: ToolContext) -> ToolResul
             permission_resolver=ctx.permission_resolver,
             skill_name="",
             subscribers=getattr(ctx.events, "subscribers", []),
+            # #1673: thread the config-aware resolver so this OpContext is never
+            # resolver=None (the bug-class invariant). recall uses op.embedding_model
+            # for its embedding call — no chat-LLM sink here — but the uniform
+            # threading keeps the "no tool OpContext is resolver=None" invariant.
+            resolver=ctx.resolver,
         )
 
     return await execute_op(op, legacy_ctx, caller="control_ir")

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.llm.model_resolver import resolve_purpose_class  # #1673
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 _SANDBOXED_EXEC_DESCRIPTION = (
@@ -111,8 +112,12 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         permission_resolver=ctx.permission_resolver,
         skill_name="",
         skill=None,
-        model="standard",
-        resolver=None,
+        # #1673: real config-aware resolver + "tool" purpose class (was None +
+        # literal "standard"). This handler makes no LLM call, but threading the
+        # resolver eliminates the resolver=None → litellm-BadRequestError class by
+        # construction (uniform with invoke_skill, the LLM-bearing sibling).
+        model=resolve_purpose_class(None, ctx.resolver, "tool"),
+        resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
         max_phase_visits=25,

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -259,6 +259,12 @@ class ToolContext:
     # Typed sub-objects carry caller-kind-specific state.
     router_state: RouterCallerState | None = None    # populated for caller_kind="router"
     phase_state: PhaseCallerState | None = None      # populated for caller_kind="phase"
+    # #1673: the config-aware ModelResolver, threaded so tool handlers that spawn a
+    # sub-run (invoke_skill → run_skill) hand the spawned OpContext a REAL resolver
+    # + a config-following model class instead of resolver=None + the literal
+    # "standard" (which litellm rejects with BadRequestError — the latent bug).
+    # Also completes #1672 CAT-3 (tool sub-runs follow model_class_by_purpose).
+    resolver: Any | None = None                      # ModelResolver | None
 
 
 # ToolHandler: async callable signature.

--- a/src/reyn/tools/web_fetch.py
+++ b/src/reyn/tools/web_fetch.py
@@ -101,6 +101,9 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             permission_resolver=ctx.permission_resolver,
             skill_name="",
             subscribers=getattr(ctx.events, "subscribers", []),
+            # #1673: never resolver=None (the bug-class invariant). web_fetch makes
+            # no LLM call, but the uniform threading keeps the invariant provable.
+            resolver=ctx.resolver,
         )
 
     return await handle_web_fetch(op=op, ctx=legacy_ctx, caller="control_ir")

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.llm.model_resolver import resolve_purpose_class  # #1673
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # Description must be byte-identical to the current router_tools.py
@@ -87,8 +88,11 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         permission_resolver=ctx.permission_resolver,
         skill_name="",
         skill=None,
-        model="standard",
-        resolver=None,
+        # #1673: real resolver + "tool" purpose class (was None + literal
+        # "standard") — eliminates the resolver=None → litellm-BadRequestError class
+        # by construction (uniform with invoke_skill; this handler makes no LLM call).
+        model=resolve_purpose_class(None, ctx.resolver, "tool"),
+        resolver=ctx.resolver,
         subscribers=getattr(ctx.events, "subscribers", []),
         output_language=None,
         max_phase_visits=25,

--- a/tests/test_tool_spawn_resolver_1673.py
+++ b/tests/test_tool_spawn_resolver_1673.py
@@ -1,0 +1,123 @@
+"""Tier 2: #1673 — tool-spawned skill runs get a real resolver + config-following
+model class (latent literal-model-to-litellm bug + #1672 CAT-3 completion).
+
+The 5 hand-building tool handlers built their OpContext with `resolver=None` +
+the literal `model="standard"`, and `ToolContext` carried no resolver. With
+`resolver=None` the spawned run degrades to `ModelResolver({})`, where
+`resolve("standard").model == "standard"` — a LITERAL model name that litellm
+rejects with `BadRequestError` on the spawned run's first LLM call (the same
+"standard"-literal class #1172 fixed for compaction but missed for tool-spawns).
+
+The fix threads the config-aware resolver through `ToolContext` to the spawned
+OpContext, and resolves the model via `class_for_purpose("tool")` (follows
+`model_class_by_purpose` / config.model). This pins:
+  - the bug shape (resolver-None → literal "standard"), and
+  - the fix (real resolver → a real provider/model string, NOT the literal).
+
+No mocks: a real `ModelResolver`, a real `ToolContext`, and a real async capture
+function (a counting/inspecting wrapper monkeypatched onto the run_skill handler —
+the permitted pattern, not unittest.mock).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.llm.model_resolver import ModelResolver, resolve_purpose_class
+from reyn.tools.invoke_skill import _handle as invoke_skill_handle
+from reyn.tools.types import ToolContext
+
+
+class _MinimalEvents:
+    subscribers: list = []
+
+
+def _ctx_with_resolver(resolver) -> ToolContext:
+    """A ToolContext on the FALLBACK path (router_state=None → invoke_skill builds
+    the minimal OpContext) carrying a real config-aware resolver."""
+    return ToolContext(
+        events=_MinimalEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=None,
+        resolver=resolver,
+    )
+
+
+# ── the bug shape (what the fix prevents) ───────────────────────────────────────
+
+
+def test_bug_shape_resolver_none_yields_literal_standard() -> None:
+    """Tier 2: #1673 — the pre-fix degradation: a resolver=None OpContext resolves
+    the "standard" class to the LITERAL "standard" (which litellm rejects with
+    BadRequestError). Documents the bug the threading prevents."""
+    degraded = ModelResolver({})  # what resolver=None becomes in the spawned runtime
+    assert degraded.resolve("standard").model == "standard", (
+        "the literal 'standard' is what reached litellm pre-fix"
+    )
+
+
+# ── the fix: invoke_skill threads the real resolver + a resolvable model ─────────
+
+
+def test_invoke_skill_threads_real_resolver_and_resolvable_model(monkeypatch) -> None:
+    """Tier 2: #1673 — invoke_skill's fallback builds the spawned OpContext with the
+    THREADED config-aware resolver and a model that resolves to a real provider/model
+    string (NOT the literal "standard" → no BadRequestError)."""
+    captured: dict = {}
+
+    async def _capture_handle(*, op, ctx, caller):  # real async fn, not a Mock
+        captured["model"] = ctx.model
+        captured["resolver"] = ctx.resolver
+        return {"status": "ok"}
+
+    # Replace the run_skill handler invoke_skill delegates to (lazy import target).
+    monkeypatch.setattr("reyn.op_runtime.run_skill.handle", _capture_handle)
+
+    resolver = ModelResolver(
+        {"standard": "openai/gpt-4o"}, default_class="standard",
+    )
+    ctx = _ctx_with_resolver(resolver)
+    asyncio.run(invoke_skill_handle({"name": "demo", "input": {"text": "hi"}}, ctx))
+
+    # The spawned OpContext carries the REAL resolver (not None).
+    assert captured["resolver"] is resolver
+    # And its model resolves to a real provider/model string — NOT the literal.
+    resolved = resolver.resolve(captured["model"]).model
+    assert resolved == "openai/gpt-4o", f"expected a real model, got {resolved!r}"
+    assert captured["model"] != "standard" or resolved != "standard"
+
+
+def test_invoke_skill_follows_tool_purpose_class(monkeypatch) -> None:
+    """Tier 2: #1673 / #1672 CAT-3 — a `model_class_by_purpose: {tool: ...}` override
+    is honoured for the spawned run (it follows the "tool" purpose class, not a
+    hardcoded tier)."""
+    captured: dict = {}
+
+    async def _capture_handle(*, op, ctx, caller):
+        captured["model"] = ctx.model
+        return {"status": "ok"}
+
+    monkeypatch.setattr("reyn.op_runtime.run_skill.handle", _capture_handle)
+
+    resolver = ModelResolver(
+        {"standard": "openai/gpt-4o", "strong": "anthropic/claude-3-7-sonnet"},
+        default_class="standard",
+        purpose_classes={"tool": "strong"},
+    )
+    ctx = _ctx_with_resolver(resolver)
+    asyncio.run(invoke_skill_handle({"name": "demo", "input": {"text": "hi"}}, ctx))
+
+    # tool purpose → "strong" class → the strong model.
+    assert resolver.resolve(captured["model"]).model == "anthropic/claude-3-7-sonnet"
+
+
+def test_tool_purpose_class_helper_resolvable_not_literal() -> None:
+    """Tier 2: #1673 — resolve_purpose_class(None, <real resolver>, "tool") yields a
+    class the resolver maps to a real provider/model (the boundary the tool sites
+    now use), vs the no-resolver path which can only fall back to "standard"."""
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"}, default_class="standard")
+    cls = resolve_purpose_class(None, resolver, "tool")
+    assert resolver.resolve(cls).model == "gemini/gemini-2.5-flash-lite"
+    # No resolver → "standard" (the literal that would need a resolver to be safe).
+    assert resolve_purpose_class(None, None, "tool") == "standard"


### PR DESCRIPTION
**[e2e-coder]** — fast-follow from #1672 (CAT-3). Closes #1673. Confirm-first repro + completeness enumeration ACKed by lead.

## The latent bug (hard crash — confirmed repro)

Tool handlers that build an `OpContext` for `op_runtime` delegation passed `resolver=None` + the literal `model="standard"` (and `ToolContext` carried no resolver). With `resolver=None` the spawned run degrades to `ModelResolver({})`, where:

```
ModelResolver({}).resolve("standard").model == "standard"   # a LITERAL model name
litellm.completion(model="standard", ...) →
  litellm.exceptions.BadRequestError: LLM Provider NOT provided ... You passed model=standard
```

`invoke_skill`'s phase-side fallback **always** builds this minimal OpContext (no `op_context_factory` branch), so a tool-invoked skill with no explicit `op.model` **hard-crashes** on the spawned run's first LLM call. This is the same `"standard"`-literal class #1172 fixed for compaction but **missed for the tool-spawn path**.

## Fix

Add a `resolver` field to `ToolContext`, populate it at all **4 build sites** (`router_loop` ×3 via `host.resolver`, `control_ir_executor` via `self._resolver`), and thread it (+ the `"tool"` purpose class via `resolve_purpose_class`) into every tool-built OpContext. This also **completes #1672 CAT-3** — tool sub-runs follow `model_class_by_purpose["tool"]` / `config.model`.

## Completeness — exhaustive (anti-#1172-miss)

Every tool-built OpContext is now threaded → **ZERO `resolver=None`** → the bug class is impossible by construction:

| OpContext site | reaches chat-LLM? | fix |
|---|---|---|
| `invoke_skill` (hand-built) | **YES** → `run_skill` spawn (the bug) | `resolver=ctx.resolver` + `class_for_purpose("tool")` |
| `sandboxed_exec` / `web_search` / `lint` / `mcp` (hand-built, were explicit `resolver=None`) | no | uniform resolver + tool class |
| `op_context_bridge` (shared #1442 bridge → file ops etc.) | no | fixed once, covers all bridge-users |
| `recall` / `web_fetch` / `compact` (hand-built) | no (embedding / fetch / marker) | `resolver=ctx.resolver` |

Threading **uniformly** (even non-LLM sites) makes the "reaches chat-LLM?" classification non-load-bearing — a future mis-classification can't reintroduce the bug. The CAT-4 resolver-None else-branches (`run_skill:165`, `judge_output:124`) are now **unreachable** from every fixed path; kept as a defensive last-resort.

## Test plan

- [x] `pytest -q` from rootdir → **7425 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** (worktree-verified earlier this session; orthogonal modules).
- [x] New `test_tool_spawn_resolver_1673.py` (4 Tier-2, no Mock — real `ModelResolver` + a real async capture wrapper monkeypatched onto the run_skill handler, not `unittest.mock`): pins the **bug shape** (resolver-None → literal `"standard"`) and the **fix** (invoke_skill threads the real resolver → the spawned model resolves to a REAL provider string `openai/gpt-4o`, not the literal) + follows `model_class_by_purpose["tool"]`.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] 480 tool/control_ir/router tests pass — no new regressions (the ToolContext schema change is additive: `resolver` defaults to `None`).
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓

## Context
- Parent: #1672 (resolver-present sites). This PR closes the resolver-None remainder + the latent crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
