### PR TITLE
feat(1676): capture LLM call exceptions as a P6 llm_request_error event

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -897,6 +897,88 @@ def _redact_llm_request_params(base_kwargs: dict, response_format: dict | None) 
     return out
 
 
+# #1676: env vars whose values are API secrets — scrubbed from the (freeform)
+# provider error text so a captured 405/4xx body never leaks a key.
+_LLM_SECRET_ENV_VARS: tuple[str, ...] = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "LITELLM_API_KEY", "AZURE_API_KEY",
+)
+
+
+def _collect_secret_values(base_kwargs: dict) -> list[str]:
+    """#1676: the concrete secret VALUES to scrub from freeform provider error
+    text — the secret-keyed kwargs (e.g. the proxy-injected ``api_key``) + known
+    API-key env vars. Scrubbing the actual value is precise (vs guessing patterns
+    in arbitrary provider output)."""
+    vals: list[str] = []
+    for k, v in base_kwargs.items():
+        if isinstance(v, str) and v and any(h in k.lower() for h in _LLM_REQUEST_SECRET_HINTS):
+            vals.append(v)
+    for env in _LLM_SECRET_ENV_VARS:
+        val = os.environ.get(env)
+        if val:
+            vals.append(val)
+    return vals
+
+
+def _scrub_secrets(value: object, secrets: list[str]) -> object:
+    """#1676: replace any known secret value occurring in a string with a marker.
+    Non-strings pass through unchanged (dict/list provider bodies are kept whole —
+    providers do not echo your API key in the error body, and the full body is the
+    root-cause signal we must NOT truncate)."""
+    if not isinstance(value, str) or not secrets:
+        return value
+    for s in secrets:
+        if s:
+            value = value.replace(s, "***REDACTED***")
+    return value
+
+
+def _emit_llm_request_error(
+    model: str, purpose: str, exc: BaseException, base_kwargs: dict,
+) -> None:
+    """#1676: emit a P6 ``llm_request_error`` with the FULL provider error detail
+    (status_code + whole message/body, NOT truncated — the owner's 405 root-cause
+    signal) so an LLM-call failure is visible in the event tab. Same ambient
+    EventLog (ContextVar) + ``model``/``purpose`` context as ``llm_request``
+    (#1669). Secret values are scrubbed from the freeform text. Wrapped so the
+    audit emit can never mask the real exception (the caller re-raises regardless)."""
+    try:
+        from reyn.events.events import get_llm_request_event_log
+        log = get_llm_request_event_log()
+        if log is None:
+            return
+        secrets = _collect_secret_values(base_kwargs)
+        detail: dict = {
+            "error_type": type(exc).__name__,
+            "error_message": _scrub_secrets(str(exc), secrets),
+            "status_code": getattr(exc, "status_code", None),
+        }
+        # litellm exceptions carry the provider body on ``.body`` (often the parsed
+        # error dict) and/or ``.response`` (an httpx.Response). Capture BOTH, whole.
+        body = getattr(exc, "body", None)
+        if body is not None:
+            detail["provider_body"] = (
+                body if isinstance(body, (dict, list))
+                else _scrub_secrets(str(body), secrets)
+            )
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            text = getattr(resp, "text", None)
+            detail["provider_response"] = _scrub_secrets(
+                text if isinstance(text, str) else str(resp), secrets,
+            )
+        log.emit(
+            "llm_request_error",
+            model=model,
+            purpose=purpose,
+            params=_redact_llm_request_params(base_kwargs, None),
+            **detail,
+        )
+    except Exception:  # noqa: BLE001 — audit emit must never mask the real error
+        pass
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -987,13 +1069,21 @@ async def recorded_acompletion(
     # separate-decide) and never combines tools+response_format, so the
     # per-(model, call-shape) combine-degrade cache (D5) was superseded and
     # pruned (#1226, user GO).
+    # #1676: capture an LLM-call failure as a P6 ``llm_request_error`` (full
+    # provider detail incl status_code + whole body) at this single chokepoint,
+    # then RE-RAISE (never swallow). Wraps the response_format-fallback retry so a
+    # final failure (no fallback, or the fallback also failed) emits exactly once.
     try:
-        response = await _once(response_format)
-    except Exception:
-        if response_format is not None and fallback_without_response_format:
-            response = await _once(None)
-        else:
-            raise
+        try:
+            response = await _once(response_format)
+        except Exception:
+            if response_format is not None and fallback_without_response_format:
+                response = await _once(None)
+            else:
+                raise
+    except Exception as exc:
+        _emit_llm_request_error(effective_model, purpose, exc, base_kwargs)
+        raise
 
     if recorder is not None:
         usage = _extract_usage(response)

--- a/tests/test_llm_request_error_1676.py
+++ b/tests/test_llm_request_error_1676.py
@@ -1,0 +1,146 @@
+"""Tier 2: #1676 — capture LLM-call exceptions as a P6 `llm_request_error` event.
+
+When an LLM call fails (e.g. the owner's persistent 405) the exception detail was
+recorded nowhere, so it couldn't be root-caused. `recorded_acompletion` (the single
+acompletion chokepoint) now emits a P6 `llm_request_error` carrying the FULL
+provider detail (status_code + whole message/body, NOT truncated) — same ambient
+EventLog (ContextVar) + model/purpose context as `llm_request` (#1669) — and then
+RE-RAISES (never swallows). Secret values are scrubbed from the freeform text.
+
+No mocks: a real `EventLog`, a real async fake for `litellm.acompletion` that
+raises a litellm-shaped exception (.status_code / .body / .response), monkeypatched
+on the module (the documented replay seam).
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import litellm
+import pytest
+
+from reyn.events.events import EventLog, set_llm_request_event_log
+from reyn.llm.llm import recorded_acompletion
+
+
+class _FakeProviderError(Exception):
+    """Real fake mirroring a litellm provider exception (no Mock)."""
+
+    def __init__(self, message: str, status_code: int, body, response_text: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+        self.response = SimpleNamespace(text=response_text)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ambient_event_log():
+    yield
+    set_llm_request_event_log(None)
+
+
+def _raising_acompletion(message="Boom", status_code=405, body=None, response_text=""):
+    async def _fn(**_kwargs):
+        raise _FakeProviderError(message, status_code, body, response_text)
+    return _fn
+
+
+def _call(monkeypatch, **extra_kwargs):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    return asyncio.run(
+        recorded_acompletion(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            purpose="main",
+            recorder=None,
+            extra_kwargs=extra_kwargs,
+        )
+    )
+
+
+# ── the event fires with full detail + the exception still propagates ───────────
+
+
+def test_error_event_emitted_and_reraised(monkeypatch) -> None:
+    """Tier 2: #1676 — a failing call emits one llm_request_error with the full
+    provider detail (status_code + message) AND the exception propagates (the call
+    is never silently swallowed)."""
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(message="Method Not Allowed", status_code=405,
+                             body={"error": "method not allowed on /v1/chat"},
+                             response_text="405 page"),
+    )
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, temperature=0.5)
+
+    # Exactly one llm_request_error (unpack-enforcement).
+    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    data = err.data
+    assert data["model"] == "gpt-5.4"
+    assert data["purpose"] == "main"
+    assert data["error_type"] == "_FakeProviderError"
+    assert "Method Not Allowed" in data["error_message"]
+    assert data["status_code"] == 405
+    # The whole provider body survives (root-cause signal — not truncated).
+    assert data["provider_body"] == {"error": "method not allowed on /v1/chat"}
+
+
+def test_error_body_not_truncated(monkeypatch) -> None:
+    """Tier 2: #1676 — a long provider body is captured WHOLE (the 405's body is
+    the root-cause signal; truncating it would lose the detail)."""
+    long_body = "X" * 5000 + "ROOT_CAUSE_MARKER"
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(message="err", status_code=400, body=long_body,
+                             response_text=""),
+    )
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch)
+
+    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    # Exact equality proves the whole body survived (no truncation).
+    assert err.data["provider_body"] == long_body
+
+
+def test_error_event_redacts_secret_value(monkeypatch) -> None:
+    """Tier 2: #1676 — a secret value (api_key) echoed in the provider error text is
+    scrubbed from the captured event (no key leak in the audit log)."""
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(
+            message="Auth failed for key sk-supersecret-123",
+            status_code=401,
+            body="rejected token sk-supersecret-123",
+            response_text="sk-supersecret-123",
+        ),
+    )
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, api_key="sk-supersecret-123")
+
+    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    data = err.data
+    # The secret must not leak anywhere in the captured error event.
+    assert "sk-supersecret-123" not in repr(data), "secret value must be scrubbed"
+    assert "***REDACTED***" in data["error_message"]
+    # The params dict redacts the api_key by key, too.
+    assert data["params"]["api_key"] == "***REDACTED***"
+
+
+def test_no_event_when_ambient_log_unset_but_still_raises(monkeypatch) -> None:
+    """Tier 2: #1676 — with no ambient EventLog (tests / CLI), no event is emitted
+    but the exception STILL propagates (capture is best-effort; re-raise is not)."""
+    set_llm_request_event_log(None)
+    monkeypatch.setattr(litellm, "acompletion", _raising_acompletion())
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch)


### PR DESCRIPTION
**[e2e-coder]** — high-priority, owner-blocking (the owner can't root-cause his persistent 405 because the exception detail is recorded nowhere). Closes #1676. The exception-path counterpart to #1669 (same chokepoint + ambient EventLog).

## Fix

At `recorded_acompletion` (the single `litellm.acompletion` chokepoint, #1190 AST-guarded), wrap the call (incl the `response_format`-fallback retry) in try/except; on a **final** failure emit a P6 `llm_request_error` and then **re-raise** (never swallow):

- `model` + `purpose` (same context as `llm_request`)
- `error_type` + `error_message` + `status_code`
- the **FULL** provider body + response text — **NOT truncated** (the 405's body is the root-cause signal). litellm exceptions carry `.status_code` / `.body` / `.response`.
- `params` (redacted, reusing the #1669 redactor)

Secret **values** (the proxy-injected `api_key` + known API-key env vars) are scrubbed from the freeform provider text; the audit emit is wrapped so it can never mask the real exception. Emitted **once** (the wrap covers the fallback retry → a final failure doesn't double-emit).

## Coverage / the "which path" flag (lead's ask)

`recorded_acompletion` is the single AST-guarded **completion** chokepoint → this covers **every completion call**. So if the owner's 405 is a completion call, it will now appear in the event tab with the full detail (which call / status / body). **If it does NOT appear, the 405 is on a different chokepoint** — most likely the **embedding** path (`litellm.aembedding` in `embedding/litellm_provider.py`, a separate uninstrumented chokepoint; MCP calls don't go through litellm). That cleanly narrows the root cause; a sibling `aembedding` instrumentation is a fast follow-up if needed.

## Test plan

- [x] `pytest -q` from rootdir → **7425 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** (worktree-verified earlier this session; orthogonal modules). Rebased onto current main (post-#1673).
- [x] New `test_llm_request_error_1676.py` (4 Tier-2, no Mock — real `EventLog` + a real async fake for `litellm.acompletion` raising a litellm-shaped exception with `.status_code`/`.body`/`.response`): event emitted with full detail + **exception still propagates**; long provider body captured **whole** (exact-equality, not truncated); secret value echoed in the error text **scrubbed**; unset-ambient-log path still re-raises.
- [x] Regression: `test_llm_request_event_1669` (the #1669 happy path) + `test_cost_chokepoint_1190` + AST-guard + `test_llm_call_recorder_invariants` + `test_llm_call_retry` + `test_event_audit_invariants` all green.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓

## Coordination
- tui-coder rendering = fast-follow (the event tab's generic fallback surfaces the new `llm_request_error` kind raw immediately; a per-kind formatter/filter can follow, mirroring #1670).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
