### PR TITLE
feat(1678): route reasoning_effort+tools to the OpenAI Responses API + decision-enabling 405 error

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -979,6 +979,32 @@ def _emit_llm_request_error(
         pass
 
 
+class ResponsesEndpointRequiredError(Exception):
+    """#1678: raised when a ``reasoning_effort + tools`` call was routed to the
+    OpenAI ``/v1/responses`` endpoint but the configured endpoint/proxy does not
+    serve it (HTTP 405). Carries a decision-enabling message naming BOTH remedies
+    so the operator isn't left with a raw 405."""
+
+
+def _to_responses_model(model: str) -> str:
+    """#1678: rewrite a resolved litellm model string to route through the OpenAI
+    Responses API (``/v1/responses``) via the ``responses/`` bridge marker, which
+    litellm.acompletion honours and returns a chat-completions-shaped response for
+    (so reyn's response parsing is unchanged). Idempotent — an already-routed model
+    (explicit ``openai/responses/...`` prefix) is returned unchanged.
+
+    - ``openai/gpt-5.4``    → ``openai/responses/gpt-5.4`` (direct path)
+    - ``gpt-5.4``           → ``responses/gpt-5.4``        (proxy path, post-strip;
+      reyn's ``custom_llm_provider="openai"`` carries the provider)
+    """
+    if "/responses/" in model or model.startswith("responses/"):
+        return model
+    if "/" in model:
+        provider, rest = model.split("/", 1)
+        return f"{provider}/responses/{rest}"
+    return f"responses/{model}"
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -1035,6 +1061,22 @@ async def recorded_acompletion(
             _allowed.append("reasoning_effort")
         base_kwargs["allowed_openai_params"] = _allowed
 
+    # #1678: route reasoning-model + tools calls to the OpenAI Responses API.
+    # ``reasoning_effort`` + ``tools`` together are only valid on /v1/responses
+    # (owner-confirmed: removing reasoning_effort cleared the 405) — but reyn
+    # sends everything via acompletion (/chat/completions) → 405. litellm's
+    # auto-route is unreliable (litellm#23156), so apply the ``responses/`` bridge
+    # prefix EXPLICITLY: it routes to /v1/responses yet returns a chat-completions
+    # shape, so the existing chokepoint + response parsing are unchanged (no
+    # parallel recorded_aresponses). An explicit operator prefix is preserved
+    # (idempotent). ``_routed_to_responses`` gates the decision-enabling error
+    # below so a normal 405 is unaffected.
+    _routed_to_responses = bool(
+        base_kwargs.get("tools") and base_kwargs.get("reasoning_effort")
+    )
+    if _routed_to_responses:
+        effective_model = _to_responses_model(effective_model)
+
     # #1669: emit a P6 ``llm_request`` event (TUI-observable) carrying the
     # non-message call params, ONCE here — before the ``_once`` response_format
     # retry loop, so a fallback retry does not double-emit. Ambient EventLog via
@@ -1083,6 +1125,20 @@ async def recorded_acompletion(
                 raise
     except Exception as exc:
         _emit_llm_request_error(effective_model, purpose, exc, base_kwargs)
+        # #1678: when WE routed this call to /v1/responses (reasoning_effort +
+        # tools) and it still 405s, the endpoint/proxy does not serve /v1/responses.
+        # Turn that raw dead-end into a decision-enabling error naming BOTH remedies
+        # (the raw 405 detail is already captured in the #1676 llm_request_error
+        # event above). Only fires when reyn applied the responses route, so a
+        # normal/unrelated 405 is unaffected.
+        if _routed_to_responses and getattr(exc, "status_code", None) == 405:
+            raise ResponsesEndpointRequiredError(
+                f"This call combines reasoning_effort + tools on model {model!r}, "
+                "which requires the OpenAI /v1/responses endpoint — but the "
+                "configured endpoint/proxy does not serve /v1/responses (HTTP 405). "
+                "Options: (1) set reasoning_effort to none / unset it for this "
+                "agent, OR (2) enable the /v1/responses endpoint on your proxy."
+            ) from exc
         raise
 
     if recorder is not None:

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -1,0 +1,164 @@
+"""Tier 2: #1678 — route reasoning_effort + tools to the OpenAI Responses API.
+
+`reasoning_effort` + `tools` together are only valid on `/v1/responses`, but reyn
+sent everything via `acompletion` (`/chat/completions`) → 405 (owner-confirmed:
+removing reasoning_effort cleared it). The fix routes that combo through the
+`openai/responses/<model>` bridge prefix (returns a chat-completions shape →
+parsing unchanged, no parallel chokepoint). When the proxy/endpoint does not serve
+`/v1/responses`, the routed call 405s → reyn raises a decision-enabling error
+(naming BOTH remedies) instead of a raw dead-end; #1676 still captures the raw 405.
+
+No mocks: real `recorded_acompletion`, a real async fake for `litellm.acompletion`
+(capturing the model / raising a litellm-shaped 405), monkeypatched.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import litellm
+import pytest
+
+from reyn.events.events import EventLog, set_llm_request_event_log
+from reyn.llm.llm import (
+    ResponsesEndpointRequiredError,
+    _to_responses_model,
+    recorded_acompletion,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)  # no proxy → model unstripped
+    yield
+    set_llm_request_event_log(None)
+
+
+# ── the model-string transform ──────────────────────────────────────────────────
+
+
+def test_to_responses_model_inserts_after_provider() -> None:
+    """Tier 2: #1678 — insert the `responses/` bridge marker after the provider
+    (direct path) or prepend it (proxy post-strip), idempotent for an already-routed
+    model."""
+    assert _to_responses_model("openai/gpt-5.4") == "openai/responses/gpt-5.4"
+    assert _to_responses_model("gpt-5.4") == "responses/gpt-5.4"
+    # idempotent — an explicit operator prefix is preserved (no double-prefix).
+    assert _to_responses_model("openai/responses/gpt-5.4") == "openai/responses/gpt-5.4"
+    assert _to_responses_model("responses/gpt-5.4") == "responses/gpt-5.4"
+
+
+# ── routing applied only on (tools + reasoning_effort) ──────────────────────────
+
+
+def _capturing_acompletion(captured: dict):
+    async def _fn(**kwargs):
+        captured["model"] = kwargs.get("model")
+        return SimpleNamespace(choices=[], usage=None)
+    return _fn
+
+
+def test_combo_routes_to_responses(monkeypatch) -> None:
+    """Tier 2: #1678 — a tools + reasoning_effort call is routed: litellm.acompletion
+    receives the `responses/`-bridged model (→ /v1/responses)."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "openai/responses/gpt-5.4"
+
+
+def test_no_tools_not_routed(monkeypatch) -> None:
+    """Tier 2: #1678 — reasoning_effort WITHOUT tools is NOT routed (normal path
+    unaffected — the 405 only occurs for the combo)."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"reasoning_effort": "low"},  # no tools
+    ))
+    assert captured["model"] == "openai/gpt-5.4", "must NOT be routed without tools"
+
+
+def test_no_reasoning_not_routed(monkeypatch) -> None:
+    """Tier 2: #1678 — tools WITHOUT reasoning_effort is NOT routed."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}]},  # no reasoning_effort
+    ))
+    assert captured["model"] == "openai/gpt-5.4", "must NOT be routed without reasoning_effort"
+
+
+# ── decision-enabling error on a /responses 405 ─────────────────────────────────
+
+
+class _FakeProviderError(Exception):
+    def __init__(self, message, status_code):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = None
+        self.response = SimpleNamespace(text=message)
+
+
+def test_responses_405_raises_decision_enabling_error(monkeypatch) -> None:
+    """Tier 2: #1678 — when reyn routed the combo to /responses and it 405s (proxy
+    doesn't serve it), a decision-enabling error is raised naming BOTH remedies."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(ResponsesEndpointRequiredError) as ei:
+        asyncio.run(recorded_acompletion(
+            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+        ))
+    msg = str(ei.value).lower()
+    assert "/v1/responses" in str(ei.value)
+    assert "reasoning_effort" in msg and ("none" in msg or "unset" in msg)  # remedy 1
+    assert "proxy" in msg  # remedy 2
+    assert "gpt-5.4" in str(ei.value)  # names the model
+
+
+def test_responses_405_still_captures_raw_via_1676(monkeypatch) -> None:
+    """Tier 2: #1678 — the #1676 llm_request_error event still captures the raw 405
+    detail before the decision-enabling error is raised (complementary)."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    with pytest.raises(ResponsesEndpointRequiredError):
+        asyncio.run(recorded_acompletion(
+            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+        ))
+    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    assert err.data["status_code"] == 405
+
+
+def test_non_routed_405_is_not_wrapped(monkeypatch) -> None:
+    """Tier 2: #1678 — a 405 on a call reyn did NOT route (no combo) is NOT wrapped
+    in the responses-error (the wrap only fires when reyn applied the route)."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(_FakeProviderError):  # raw error propagates, NOT wrapped
+        asyncio.run(recorded_acompletion(
+            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"reasoning_effort": "low"},  # no tools → not routed
+        ))


### PR DESCRIPTION
**[e2e-coder]** — owner 405 root-cause fix. Closes #1678. Confirm-first design approved by lead (mechanism + proxy-feasibility + the no-/responses decision-enabling addition); the design analysis is durable on the issue.

## Root cause (owner-live-confirmed)

`reasoning_effort` + `tools` together are only valid on the OpenAI **`/v1/responses`** endpoint, but reyn sent everything via `acompletion` (`/chat/completions`) → **405**. The owner confirmed it live: removing `reasoning_effort` cleared the 405.

## Fix (single `recorded_acompletion` chokepoint)

1. **Route** — when `tools` AND `reasoning_effort` are both present, rewrite the resolved model with the `responses/` bridge marker (`openai/gpt-5.4` → `openai/responses/gpt-5.4`; proxy post-strip `gpt-5.4` → `responses/gpt-5.4`, carried by reyn's `custom_llm_provider="openai"`). The litellm `openai/responses/` bridge routes to `/v1/responses` **but returns a chat-completions shape** → the existing chokepoint + response parsing are unchanged (**no parallel `recorded_aresponses`** — the load-bearing simplicity finding). litellm auto-route is unreliable (litellm#23156) → the prefix is applied **explicitly**. Idempotent (an explicit operator prefix is preserved).
2. **Decision-enabling error** — when reyn routed the combo to `/responses` and it still **405s** (the endpoint/proxy doesn't serve `/v1/responses` — **the owner's company-proxy case**), raise `ResponsesEndpointRequiredError` naming **both** remedies (set `reasoning_effort: none`, OR enable `/v1/responses` on the proxy) + the model, instead of a raw dead-end. The **#1676 `llm_request_error` event still captures the raw 405 detail first** (complementary: raw in audit, guided in the raised error). Only fires when reyn itself applied the route → a normal/unrelated 405 is unaffected.

Detection (`tools + reasoning_effort`) is exactly litellm's own auto-route trigger and the owner's live-confirmed condition. **All non-combo paths are byte-identical.**

## Proxy feasibility (from the confirm-first)
- reyn's proxy strip + `custom_llm_provider="openai"` preserves the `responses/` bridge marker (verified, litellm 1.84.0).
- A litellm proxy serves `/v1/responses` (local probe: POST → 400 = exists, vs 405 = absent).
- **The owner's company proxy does NOT serve `/v1/responses`** (lead-confirmed) → for him the **decision-enabling error is the load-bearing benefit**; the routing transform is correct for any `/responses`-serving env (direct OpenAI / proxies with it enabled).

## Test plan

- [x] `pytest -q` from rootdir → **7436 passed**, 14 skipped, 3 xfailed. The only 2 failures (`test_eval_benchmark_tier1_swebench::test_swebench_missing_honest_skip`, `test_web_fetch_preview_path_ref::test_legacy_no_media_store_path_returns_inline_content`) are **pre-existing on clean `origin/main`** (worktree-verified this session; orthogonal modules).
- [x] New `test_responses_api_routing_1678.py` (7 Tier-2, no Mock — real `recorded_acompletion` + a real async fake for `litellm.acompletion` capturing the model / raising a 405): the transform (insert-after-provider / prepend / idempotent); routed **only** on the combo (NOT tools-only or reasoning-only); the decision-enabling error on a `/responses` 405 naming **both** remedies + the model; #1676 still captures the raw 405; a non-routed 405 is NOT wrapped.
- [x] Regression: `test_llm_request_error_1676`, `test_llm_request_event_1669`, `test_cost_chokepoint_1190` + AST-guard, `test_llm_call_recorder_invariants`, `test_llm_call_retry` — all green.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] Tier rule self-check: docstring ✓ / Tier 4 violations 0 ✓ / invariant 弱化なし ✓ / audit 0 errors ✓
- [x] (Live-final-verification = the owner's env) — his no-`/responses` company proxy can't be fully reproduced here; the transform is verified to construct the `responses/`-bridged model + the decision-enabling error is unit-pinned. The owner exercises the real proxy 405 → decision-enabling-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
