### PR TITLE
chore: untrack + gitignore .mcp.json (dev-team broker MCP config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ spike_results/
 
 # Local dogfood/MCP sandbox scratch (traces, replay fixtures, test.db) — never commit
 .mcp-sandbox/
+
+# Dev-team broker MCP config — per-developer, not reyn source
+/.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "broker": {
-      "type": "http",
-      "url": "http://127.0.0.1:8765/mcp"
-    }
-  }
-}


### PR DESCRIPTION
**[e2e-coder]** — owner-directed repo hygiene (top-level cleanup audit).

## What

`.mcp.json` is the **dev-team broker MCP config** (a per-developer `http://127.0.0.1:8765/mcp` endpoint), not part of reyn's source. It was tracked, so it clutters external clones of this LICENSE/CONTRIBUTING-bearing repo with dev-team-specific config. The owner confirmed it should be gitignored.

## Change

- `git rm --cached .mcp.json` — **untrack, keep the local file** (per-developer working trees keep their own config; the file is not deleted).
- Add a **root-anchored** `/.mcp.json` to `.gitignore`, grouped with the other root-anchored dev-tooling ignores (`/chainlit.md`, `.mcp-sandbox/`), with a one-line comment.

## Verified
- `git ls-files .mcp.json` → empty (no longer tracked).
- local `.mcp.json` still present (untrack kept the working-tree file).
- `git check-ignore .mcp.json` → matches `/.mcp.json` (now ignored).

## Test plan
- [x] N/A — gitignore/untrack only, no code change (no test surface).
- [x] Verified untrack + keep-local + ignore (above).

## Note (non-blocking)
Considered a `.mcp.json.example` for onboarding (so a fresh clone knows to create one for the broker), but the owner's direction was "ignore it" → defaulting to the minimal untrack+gitignore. Flagging in case the team later wants the onboarding example; not adding it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
