### PR TITLE
fix(1683): emit cost events from the chat path so the TUI cost tab updates

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2069,6 +2069,9 @@ class RouterLoop:
                         budget=self.budget,
                         budget_agent=host.agent_name,
                         trace_caller="router",
+                        # #1683: chat path emits llm_called + llm_response_received
+                        # so the TUI cost tab updates (kernel emits via LLMCallRecorder).
+                        emit_cost_events=True,
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a
@@ -3023,6 +3026,8 @@ class RouterLoop:
             budget=self.budget,
             budget_agent=self.host.agent_name,
             trace_caller="router_force_close",
+            # #1683: chat path emits cost events for the TUI cost tab.
+            emit_cost_events=True,
         )
 
     async def _force_close_call_with_retry(

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -39,7 +39,7 @@ def _truncate_json_for_event(raw: str, pos: "int | None", cap: int = _JSON_DECOD
     head = f"…[{start} bytes before]\n" if start > 0 else ""
     tail = f"\n…[{len(raw) - end} bytes after]" if end < len(raw) else ""
     return head + raw[start:end] + tail
-from reyn.llm.pricing import TokenUsage
+from reyn.llm.pricing import TokenUsage, estimate_cost
 from reyn.schemas.models import ContextFrame
 
 if TYPE_CHECKING:
@@ -1005,6 +1005,37 @@ def _to_responses_model(model: str) -> str:
     return f"responses/{model}"
 
 
+def _emit_chat_cost_events(model: str, usage: "TokenUsage | None") -> None:
+    """#1683: emit the cost-tab's usage events for the chat path via the #1669
+    ambient EventLog. The TUI cost tab reads ``llm_called`` (model) then accumulates
+    tokens/cost on ``llm_response_received``, so emit BOTH (in that order). Minimal
+    fields — the cost tab derives skill="(chat)" from the events file path, so no
+    run_id/skill is needed. None EventLog (no active session) → skip. Wrapped so an
+    observability emit never breaks the LLM call."""
+    if usage is None:
+        return
+    try:
+        from reyn.events.events import get_llm_request_event_log
+        log = get_llm_request_event_log()
+        if log is None:
+            return
+        # Strip the proxy provider-prefix for the pricing lookup (mirrors the
+        # kernel's LLMCallRecorder), then emit model + tokens + cost_usd.
+        _pricing_model = (
+            model.split("/", 1)[1] if "/" in model and proxy_kwargs() else model
+        )
+        cost_usd, _snapshot = estimate_cost(_pricing_model, usage)
+        log.emit("llm_called", model=model)
+        log.emit(
+            "llm_response_received",
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            cost_usd=cost_usd,
+        )
+    except Exception:  # noqa: BLE001 — observability emit must never break the call
+        pass
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -1015,6 +1046,7 @@ async def recorded_acompletion(
     response_format: dict | None = None,
     fallback_without_response_format: bool = False,
     extra_kwargs: dict | None = None,
+    emit_cost_events: bool = False,  # #1683: chat path opts in (kernel emits via LLMCallRecorder)
 ) -> object:
     """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
 
@@ -1141,12 +1173,21 @@ async def recorded_acompletion(
             ) from exc
         raise
 
-    if recorder is not None:
-        usage = _extract_usage(response)
-        if usage is not None:
-            recorder.record_llm(
-                model=effective_model, agent=agent, usage=usage, purpose=purpose,
-            )
+    usage = _extract_usage(response)
+    if recorder is not None and usage is not None:
+        recorder.record_llm(
+            model=effective_model, agent=agent, usage=usage, purpose=purpose,
+        )
+    # #1683: the interactive chat path records cost to the in-memory recorder
+    # (→ header) but emits NO usage event, so the TUI cost tab (which reads
+    # `llm_called` + accumulates on `llm_response_received` from the events log)
+    # stays empty. Opt-in callers (the chat router) emit BOTH events here via the
+    # #1669 ambient EventLog. The kernel/phase path leaves this False — it emits
+    # these events via LLMCallRecorder, so emitting here too would double-count.
+    # (Interim: a future cleanup could centralize the kernel's emission into this
+    # chokepoint and drop the flag — out of scope here.)
+    if emit_cost_events:
+        _emit_chat_cost_events(effective_model, usage)
     return response
 
 
@@ -1470,6 +1511,7 @@ async def call_llm_tools(
     purpose: str = "main",  # #1190 cost-attribution bucket (chat router = main)
     trace_caller: str | None = None,
     event_log: "EventLog | None" = None,
+    emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -1611,6 +1653,7 @@ async def call_llm_tools(
         return await recorded_acompletion(
             model=_model, messages=_messages, purpose=purpose,
             recorder=None, extra_kwargs=_kw,
+            emit_cost_events=emit_cost_events,  # #1683: chat opts in
         )
 
     response = await _llm_call_with_retry(_tools_call, effective_model, event_log)

--- a/tests/test_chat_cost_events_1683.py
+++ b/tests/test_chat_cost_events_1683.py
@@ -1,0 +1,123 @@
+"""Tier 2: #1683 — the interactive chat path emits cost events so the TUI cost tab updates.
+
+The chat path recorded cost to the in-memory recorder (→ header) but emitted NO
+usage event, so the TUI cost tab (which reads `llm_called` then accumulates
+tokens/cost on `llm_response_received` from the events log) stayed empty. The fix:
+chat callers pass `emit_cost_events=True` to `recorded_acompletion`, which then
+emits BOTH events via the #1669 ambient EventLog. The kernel/phase path leaves the
+flag False (it emits these via LLMCallRecorder — emitting here too would
+double-count).
+
+No mocks: real `recorded_acompletion`, a real async fake for `litellm.acompletion`
+(returning a usage-bearing response), a real `EventLog`, and the real `render_cost`
+over a synthetic events tree.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import litellm
+import pytest
+
+from reyn.events.events import EventLog, set_llm_request_event_log
+from reyn.llm.llm import recorded_acompletion
+from reyn.tui.widgets.right_panel.cost_tab import render_cost  # #2 moved chat/tui → reyn/tui
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    yield
+    set_llm_request_event_log(None)
+
+
+def _usage_response(prompt=100, completion=50):
+    async def _fn(**_kwargs):
+        return SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion),
+            choices=[],
+        )
+    return _fn
+
+
+def _call(monkeypatch, *, emit_cost_events):
+    return asyncio.run(recorded_acompletion(
+        model="openai/gpt-4o", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None, emit_cost_events=emit_cost_events,
+    ))
+
+
+# ── flag=True (chat) emits both events; flag=False (kernel) does not ─────────────
+
+
+def test_chat_flag_emits_both_cost_events(monkeypatch) -> None:
+    """Tier 2: #1683 — emit_cost_events=True emits llm_called (model) THEN
+    llm_response_received (prompt/completion tokens + cost_usd) — the pair the cost
+    tab needs."""
+    monkeypatch.setattr(litellm, "acompletion", _usage_response(100, 50))
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    _call(monkeypatch, emit_cost_events=True)
+
+    kinds = [e.type for e in log.all()]
+    # order matters: llm_called before llm_response_received (pending_model).
+    assert kinds.index("llm_called") < kinds.index("llm_response_received")
+    called = next(e for e in log.all() if e.type == "llm_called")
+    assert called.data["model"] == "openai/gpt-4o"
+    resp = next(e for e in log.all() if e.type == "llm_response_received")
+    assert resp.data["prompt_tokens"] == 100
+    assert resp.data["completion_tokens"] == 50
+    assert "cost_usd" in resp.data  # present (value may be None for an unknown model)
+
+
+def test_no_flag_does_not_emit_cost_events(monkeypatch) -> None:
+    """Tier 2: #1683 — the default (emit_cost_events=False, the kernel/phase path)
+    emits NEITHER cost event here, so the kernel's LLMCallRecorder emission is not
+    double-counted."""
+    monkeypatch.setattr(litellm, "acompletion", _usage_response())
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    _call(monkeypatch, emit_cost_events=False)
+
+    kinds = [e.type for e in log.all()]
+    assert "llm_called" not in kinds
+    assert "llm_response_received" not in kinds
+
+
+# ── the emitted events accumulate in the cost tab ───────────────────────────────
+
+
+def test_cost_tab_accumulates_chat_events(tmp_path) -> None:
+    """Tier 2: #1683 — events of the shape this fix emits accumulate in render_cost.
+    The BY-MODEL bucket populates ONLY when llm_response_received accumulates after
+    a llm_called, so the model appearing in the render proves accumulation (vs the
+    pre-fix empty bucket)."""
+    events_dir = tmp_path / ".reyn" / "events" / "direct"
+    events_dir.mkdir(parents=True)
+    lines = [
+        {"type": "llm_called", "data": {"model": "openai/uniqmodel-xyz"}},
+        {"type": "llm_response_received",
+         "data": {"prompt_tokens": 100, "completion_tokens": 50, "cost_usd": 0.0012}},
+    ]
+    (events_dir / "2026-06-16.jsonl").write_text(
+        "\n".join(json.dumps(x) for x in lines) + "\n", encoding="utf-8",
+    )
+
+    out = render_cost(tmp_path, content_width=120)
+
+    # The model appears only if llm_response_received accumulated for it (the
+    # per-model bucket keys on the preceding llm_called's model).
+    assert "uniqmodel-xyz" in out
+    assert "(no events yet)" not in out
+
+
+def test_cost_tab_empty_without_events(tmp_path) -> None:
+    """Tier 2: #1683 — regression baseline: no events → the cost tab is empty
+    (the pre-fix chat state). Pairs with the accumulation test above."""
+    (tmp_path / ".reyn" / "events").mkdir(parents=True)
+    out = render_cost(tmp_path, content_width=120)
+    assert "uniqmodel-xyz" not in out


### PR DESCRIPTION
**[e2e-coder]** — owner-reported bug. Closes #1683. Confirm-first ACKed by lead (Option A — chokepoint flag).

## Bug

The interactive chat path recorded LLM cost to the in-memory recorder (→ header, which updates) but emitted **no usage event** — so the TUI cost tab (which reads `llm_called` then accumulates tokens/cost on `llm_response_received` from `.reyn/events/*.jsonl`) stayed **empty**. (The kernel/phase path emits both events via `LLMCallRecorder`, so its cost tab works.)

## Confirm-first corrected two premises in the original "emit llm_called" plan
1. The cost tab accumulates on **`llm_response_received`**, NOT `llm_called` (which only sets `pending_model`) → must emit **both**.
2. Both chat AND kernel funnel through `recorded_acompletion`, and the kernel already emits these via `LLMCallRecorder` → emitting unconditionally from the shared chokepoint would **double-count the kernel** (the "don't break kernel-path semantics" risk).

## Fix (Option A — chokepoint flag)
- `recorded_acompletion` gains `emit_cost_events=False`. On success it emits BOTH `llm_called` (model) + `llm_response_received` (prompt_tokens / completion_tokens / cost_usd via `estimate_cost`) through the #1669 ambient EventLog. **Minimal fields** — the cost tab derives `skill="(chat)"` from the events file path, so no run_id/skill needed.
- `call_llm_tools` forwards the flag; the chat router's 2 call sites pass `True`.
- The kernel/phase path leaves the flag `False` (it emits via `LLMCallRecorder`) → **no double-count**. Explicit caller flag (not `purpose`-based) so a future kernel main-purpose call cannot accidentally double-count.
- **Interim**: a future cleanup could centralize the kernel's emission into the chokepoint and drop the flag — out of scope here.

## Test plan
- [x] `pytest -q` from rootdir → **7440 passed**, 14 skipped, 3 xfailed. Only the 2 pre-existing failures (`test_eval_benchmark_tier1_swebench`, `test_web_fetch_preview_path_ref`) — worktree-verified pre-existing this session.
- [x] New `test_chat_cost_events_1683.py` (4 Tier-2, no Mock — real `recorded_acompletion` + usage-bearing async fake for `litellm.acompletion` + real `EventLog` + real `render_cost`): flag=True emits both events ordered with cost fields; flag=False (kernel) emits neither (no double-count); the emitted shape **accumulates** in `render_cost` (BY-MODEL bucket populates → model appears); empty baseline stays empty.
- [x] Regression: `test_replay_skill_router`, `test_cost_chokepoint_1190` + AST-guard, `test_llm_call_recorder_invariants`, `test_llm_request_event_1669`/`_error_1676`/`responses_api_1678`, `test_router_loop` — all green.
- [x] `ruff check` clean; `scripts/test_tier_audit.py --strict` → 0 violations.
- [x] Tier rule self-check: docstring ✓ / Tier 4 0 ✓ / invariant 弱化なし ✓ / audit 0 ✓

## Coordination
- Rebased onto main **after tui-coder's #2 merged** (chat/tui → reyn/tui); updated the test's `render_cost` import to `reyn.tui.widgets.right_panel.cost_tab`. Prod changes (llm.py + router_loop.py) are unaffected by #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
