### PR TITLE
docs: update MCP module paths to post-#1684 canonical locations

### DIFF
--- a/docs/deep-dives/research/positioning/reyn-mcp-cli-shape.md
+++ b/docs/deep-dives/research/positioning/reyn-mcp-cli-shape.md
@@ -224,5 +224,5 @@ Reyn config 階層 (ADR-0031 3-layer: `~/.reyn/config.yaml` / `<project>/reyn.ya
 - `docs/deep-dives/research/positioning/web-ui-direction.md` — `reyn serve` での credentials UX (= server-side dotenv) と直結
 - `docs/deep-dives/research/competitive/{openclaw,hermes-agent,pi}.md` — enterprise differentiation の競合 baseline
 - 既存 `mcp_search` skill: `src/reyn/stdlib/skills/mcp_search/`
-- `MCPClient` + `expand_env()`: `src/reyn/mcp_client.py`
+- `MCPClient` + `expand_env()`: `src/reyn/mcp/client.py`
 - `PermissionDecl` / `require_mcp()`: `src/reyn/permissions/permissions.py`

--- a/docs/guide/for-users/popular-mcp-servers.md
+++ b/docs/guide/for-users/popular-mcp-servers.md
@@ -66,7 +66,7 @@ Servers covered:
   server (= one-liner shown in each section).
 
 The smoke runner `scripts/mcp_smoke.py` goes straight to
-`reyn.mcp_client.MCPClient`, bypassing the chat router. Useful for
+`reyn.mcp.client.MCPClient`, bypassing the chat router. Useful for
 connectivity sanity. For agent-driven usage (= the typical end-user
 shape), the chat router calls the server via the universal
 `mcp__call_tool` / `invoke_action` dispatch.


### PR DESCRIPTION
**[docs-maintainer]** — docs drift cleanup from the #1682/#1684 MCP consolidation, flagged by e2e-coder. Revised per lead-coder review (see below).

The #1684 consolidation moved the **impl** client `reyn.mcp_client` → `reyn.mcp.client` (old path kept as a back-compat shim). Two current-canonical docs cited the old impl path.

## Fixes (2, impl-path only)
| File | old → new |
|---|---|
| `guide/for-users/popular-mcp-servers.md` | `reyn.mcp_client.MCPClient` → `reyn.mcp.client.MCPClient` |
| `research/positioning/reyn-mcp-cli-shape.md` | `src/reyn/mcp_client.py` → `src/reyn/mcp/client.py` |

## Deliberately NOT changed (corrected after review)
- **`reyn.safe.mcp.registry`** in `mcp.md`/`.ja` + `reyn-yaml.md` — initially changed to `reyn.mcp.registry`, then **reverted**. Primary source (`src/reyn/safe/mcp/registry.py` shim docstring): *"`reyn.safe.mcp.registry` remains as the public allowlist surface for skills (FP-0042)"*. The raw impl moved to `reyn.mcp.registry`, but the **skill-facing** path stays `reyn.safe.mcp.registry`, and those doc lines describe the "safe-mode skill-internal lookup" (skill-facing) — so they correctly name `reyn.safe.mcp.registry`. Good catch, lead-coder.
- **Historical records**: all `docs/deep-dives/journal/**`, ADR `0030`, proposal `0042` — point-in-time snapshots.
- **`reyn.registry.client`** — not in the #1684 rename set.
- **tui rename** (`reyn.chat.tui`/`reyn.chat.slash`): 0 doc references.

## Test plan
- [x] `mkdocs build --strict` → exit 0
- [x] final diff = 2 files, impl-path only (registry skill-facing refs reverted to `reyn.safe.mcp.registry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)