### PR TITLE
fix(1679): wire model_class_by_purpose.compaction (was a dead key)

### DIFF
--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -947,8 +947,17 @@ async def execute_plan(
             # T_SP=0: step-results context is not the main session SP;
             # main_pool = T_max - 0 = T_max, so threshold =
             # step_results_ratio * T_max (conservative large-window default).
+            # #1679: honor a documented model_class_by_purpose.compaction override
+            # when set; otherwise keep router_model (byte-identical). Guarded for a
+            # host without a resolver (= router_model passes through unchanged).
+            _compaction_resolver = getattr(parent_host, "resolver", None)
+            _compaction_model = (
+                _compaction_resolver.purpose_class_or("compaction", router_model)
+                if _compaction_resolver is not None
+                else router_model
+            )
             _effective_engine = CompactionEngine(
-                model=router_model,
+                model=_compaction_model,
                 events=parent_host.events,
                 T_SP=0,
                 cfg=None,  # use default CompactionConfig for budget derivation

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1922,12 +1922,15 @@ class ChatSession:
             history_access=lambda: self.history,
             latest_summary=self._latest_summary,
             compaction_engine=CompactionEngine(
-                # #1172: pass self.model (a model CLASS like "standard") plus
-                # the resolver — CompactionEngine resolves to a litellm string
-                # by construction. Without resolution the engine would hand
-                # "standard" straight to litellm (BadRequestError) and every
-                # compaction trigger would fail (dead-end-critical).
-                model=self.model,
+                # #1172: pass a model CLASS (like "standard") plus the resolver —
+                # CompactionEngine resolves to a litellm string by construction.
+                # Without resolution the engine would hand "standard" straight to
+                # litellm (BadRequestError) and every compaction trigger would
+                # fail (dead-end-critical).
+                # #1679: honor a documented model_class_by_purpose.compaction
+                # override when set; otherwise keep self.model (byte-identical to
+                # the former hardcode, incl. an Agent(model=…) override).
+                model=self._resolver.purpose_class_or("compaction", self.model),
                 events=self._chat_events,
                 system_prompt_provider=self._build_router_system_prompt,
                 resolver=self._resolver,

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -263,7 +263,25 @@ class ModelResolver:
         BEFORE this fallback and still win. Returns a CLASS name — feed it through
         ``resolve()`` to get the ModelSpec / litellm string.
         """
-        return self._purpose_classes.get(purpose, self._default_class)
+        return self.purpose_class_or(purpose, self._default_class)
+
+    def purpose_class_or(self, purpose: str, default: str) -> str:
+        """#1679: the per-purpose class override if one is configured, else
+        *default* — a caller-supplied fallback.
+
+        Unlike ``class_for_purpose`` (whose fallback is the resolver's configured
+        ``default_class`` = ``ReynConfig.model``), this lets a caller keep its OWN
+        existing model source when no override is set. The CompactionEngine sites
+        need exactly this: their model source today is the chat session's model
+        (``self.model``) / the plan router model, which can diverge from
+        ``default_class`` under an ``Agent(model=…)`` override — so feeding
+        ``default_class`` would silently move compaction OFF the agent's chosen
+        model. With ``default`` = the site's existing source, wiring is
+        byte-identical until ``model_class_by_purpose.compaction`` is set, at which
+        point the documented key takes effect (was a dead key — #1679). Returns a
+        CLASS name — feed it through ``resolve()`` to get the litellm string.
+        """
+        return self._purpose_classes.get(purpose, default)
 
     def is_known_class(self, name: str) -> bool:
         """Return True if name is a configured model class (i.e. present in the namespace).

--- a/tests/test_compaction_purpose_class_1679.py
+++ b/tests/test_compaction_purpose_class_1679.py
@@ -1,0 +1,76 @@
+"""Tier 2: #1679 — model_class_by_purpose.compaction is a REAL key (was a dead key).
+
+`compaction` was a documented `model_class_by_purpose` purpose, but no call site
+read it: both CompactionEngine sites resolved their model from a config-following
+source (chat session = `self.model`, planner = the router-purpose model), so
+setting `model_class_by_purpose.compaction` silently no-opped.
+
+The fix wires both sites through `ModelResolver.purpose_class_or(purpose, default)`
+— the per-purpose override if configured, else the *caller-supplied* fallback
+(NOT the resolver's `default_class`). Keeping each site's existing fallback is what
+makes the wiring byte-identical for every current config: it preserves
+`self.model` / `router_model` even when those diverge from `default_class`, which
+they do under `Agent.from_config(config, model=X)` (the model-override path). The
+naive `resolve_purpose_class(None, …, "compaction")` would fall back to
+`default_class` and silently move compaction OFF the agent's explicit model — a
+behavior change masked as a wiring. `purpose_class_or` avoids that by construction.
+
+Production call sites (grep-verified, non-test): `chat/session.py` and
+`chat/planner.py` both call `purpose_class_or("compaction", <site fallback>)`.
+
+No mocks: real `ModelResolver` instances.
+"""
+from __future__ import annotations
+
+from reyn.llm.model_resolver import ModelResolver
+
+# A resolver whose default_class deliberately differs from the per-site fallback,
+# modelling `Agent.from_config(config, model="agent_model")`: the session/planner
+# fallback is the agent's model ("agent_model"), while the resolver's default_class
+# is the config default ("config_default"). This is the divergence the fix must
+# preserve.
+_DEFAULT_CLASS = "config_default"
+_SITE_FALLBACK = "agent_model"  # = self.model / router_model under a model override
+
+
+def test_purpose_class_or_unset_uses_supplied_fallback_not_default_class() -> None:
+    """Tier 2: #1679 (a) — compaction UNSET → the caller-supplied fallback, NOT the
+    resolver's default_class. This is the no-regression proof for the model-override
+    (Agent.from_config(model=X)) case: compaction must stay on the agent's model
+    even though it differs from default_class. (Naive resolve_purpose_class would
+    return default_class here = the divergence avoided.)"""
+    r = ModelResolver({}, default_class=_DEFAULT_CLASS, purpose_classes={})
+    assert r.purpose_class_or("compaction", _SITE_FALLBACK) == _SITE_FALLBACK
+    # and it is NOT silently the default_class (= the bug we avoided)
+    assert r.purpose_class_or("compaction", _SITE_FALLBACK) != _DEFAULT_CLASS
+
+
+def test_purpose_class_or_set_resolves_to_configured_class() -> None:
+    """Tier 2: #1679 (b) — compaction SET → the configured class wins over the
+    site fallback. This is the dead-key-now-real proof: setting
+    model_class_by_purpose.compaction now takes effect."""
+    r = ModelResolver(
+        {}, default_class=_DEFAULT_CLASS, purpose_classes={"compaction": "heavy"},
+    )
+    assert r.purpose_class_or("compaction", _SITE_FALLBACK) == "heavy"
+
+
+def test_purpose_class_or_other_purpose_unaffected() -> None:
+    """Tier 2: #1679 — a compaction override does not leak into other purposes;
+    each purpose with no override still falls back to the supplied default."""
+    r = ModelResolver(
+        {}, default_class=_DEFAULT_CLASS, purpose_classes={"compaction": "heavy"},
+    )
+    assert r.purpose_class_or("router", _SITE_FALLBACK) == _SITE_FALLBACK
+
+
+def test_class_for_purpose_still_uses_default_class() -> None:
+    """Tier 2: #1679 — the class_for_purpose refactor (delegating to
+    purpose_class_or with default_class) is behavior-preserving: an unset purpose
+    still resolves to default_class, an override still wins (mirrors the #1672
+    contract, which is unchanged)."""
+    r = ModelResolver(
+        {}, default_class=_DEFAULT_CLASS, purpose_classes={"router": "light"},
+    )
+    assert r.class_for_purpose("control_ir") == _DEFAULT_CLASS  # unset → default_class
+    assert r.class_for_purpose("router") == "light"  # override wins


### PR DESCRIPTION
**[e2e-coder]** — #1682 cleanup umbrella, item #1679. Design approved by lead (broker, `purpose_class_or` shape).

## Problem

`compaction` is listed in the documented `model_class_by_purpose` purpose vocabulary
(#1672 presents `model_class_by_purpose: {compaction: …}` as settable), **but no call
site read `class_for_purpose("compaction")`** — both `CompactionEngine` sites resolved
their model from a config-following source:

- `chat/session.py` → `self.model`
- `chat/planner.py` → the router-purpose model (`router_model`)

So setting `model_class_by_purpose.compaction` **silently no-opped** — the misleading
"I set it and nothing happened" class of dead config key (`[[feedback_no_uncustomizable_hardcoded_choices]]`).

## Fix

New `ModelResolver.purpose_class_or(purpose, default)` — the per-purpose override if
configured, else the **caller-supplied** fallback. Wire both sites through it:

| Site | Before | After |
|------|--------|-------|
| `session.py` | `model=self.model` | `model=self._resolver.purpose_class_or("compaction", self.model)` |
| `planner.py` | `model=router_model` | `model=<resolver>.purpose_class_or("compaction", router_model)` (None-guarded) |

`class_for_purpose` refactored to delegate: `purpose_class_or(purpose, self._default_class)`
— behavior-preserving (the #1672 contract is unchanged).

### Why `purpose_class_or`, not `resolve_purpose_class(None, …, "compaction")`

The naive helper falls back to `default_class` (= `ReynConfig.model`), which **diverges
from `self.model` / `router_model` under `Agent.from_config(config, model=X)`** (the
model-override path, exercised in the replay tests). It would silently move compaction
*off* the agent's explicit model — a behavior change masked as a wiring. `purpose_class_or`
keeps **each site's existing fallback**, so the wiring is **byte-identical for every
current config**; only setting `model_class_by_purpose.compaction` changes anything =
the documented dead key becomes real, with zero collateral. (Lead confirmed this is the
correct byte-identical discipline.)

## Test (Tier 2) — pins both legs lead required

- **(a) no-regression / model-override**: compaction UNSET → the site fallback even
  when it differs from `default_class` (= the `Agent.from_config(model=X)` divergence
  avoided; asserts it is *not* silently `default_class`).
- **(b) dead-key-now-real**: compaction SET → the configured class wins over the site
  fallback.
- Plus: other-purpose isolation + `class_for_purpose` behavior-preservation.

Production call sites grep-verified (non-test): `chat/session.py`, `chat/planner.py`.

## Test plan

- [x] `tests/test_compaction_purpose_class_1679.py` + `tests/test_model_class_by_purpose_1672.py` — 13 passed
- [x] targeted regression (`-k "compaction or planner or model_resolver or model_class or resolver or purpose"`) — 288 passed
- [x] `ruff check` (changed files) — clean
- [x] `scripts/test_tier_audit.py --strict` (new test) — 0 violations
- [x] full `pytest -q` from rootdir — (result in final comment; the only fails are the known pre-existing local machine-quirk pair, CI-green on main)

Closes #1679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
