### PR TITLE
fix(1663): codeact harness uses host sys.executable, not REYN_HARNESS_PYTHON

### DIFF
--- a/src/reyn/kernel/codeact_runner.py
+++ b/src/reyn/kernel/codeact_runner.py
@@ -40,8 +40,10 @@ def _harness_subprocess_env() -> dict[str, str]:
     multi-worktree editable-install dev env can point at a DIFFERENT worktree lacking
     this harness module (``No module named reyn.kernel._codeact_harness``). Prepending
     this process's reyn tree makes the subprocess resolve the SAME tree. Production
-    (single reyn install) is unaffected — same path either way. (``REYN_HARNESS_PYTHON``
-    still overrides the *interpreter*; this fixes the *module-resolution* default.)"""
+    (single reyn install) is unaffected — same path either way. (The codeact harness
+    interpreter is always the host ``sys.executable`` — #1663; it does NOT honor
+    ``REYN_HARNESS_PYTHON`` (unlike the preprocessor harness), so this PYTHONPATH
+    propagation pairs with that host interpreter.)"""
     import reyn  # noqa: PLC0415
 
     tree = str(Path(reyn.__file__).resolve().parent.parent)  # dir containing the reyn pkg
@@ -64,11 +66,19 @@ class CodeActRunner:
     """
 
     def __init__(self, python_executable: str | None = None) -> None:
-        self.python_executable = (
-            python_executable
-            or os.environ.get("REYN_HARNESS_PYTHON")
-            or sys.executable
-        )
+        # #1663: the CodeAct harness is a HOST-LOCAL orchestrator — its AF_UNIX
+        # control socket is passed to the child via ``pass_fds`` (an inherited fd
+        # cannot cross a ``docker exec`` boundary), so the harness must run on the
+        # reyn host under the reyn-process interpreter. It deliberately does NOT
+        # honor ``REYN_HARNESS_PYTHON``: that override targets the in-container
+        # #1356 *preprocessor* harness (PythonRunner), which is routed through
+        # ``backend.run`` (= ``docker exec``) and so needs the container's python.
+        # Picking it up here pointed codeact's host Popen at a container-only path
+        # (``/opt/reyn-venv/bin/python``) under ``--env-backend=docker`` → the
+        # seatbelt-wrapped exec failed with execvp rc=71. Tool EFFECTS still reach
+        # the container via the gated dispatch (DockerEnvironmentBackend), so the
+        # host-local harness loses nothing. An explicit arg still wins (tests).
+        self.python_executable = python_executable or sys.executable
 
     async def run(
         self,

--- a/tests/test_codeact_runner_harness_python_1663.py
+++ b/tests/test_codeact_runner_harness_python_1663.py
@@ -1,0 +1,48 @@
+"""Tier 2: #1663 — the CodeAct harness interpreter is the HOST python, NOT
+REYN_HARNESS_PYTHON.
+
+CodeActRunner's harness is a host-local orchestrator: its AF_UNIX control socket
+is handed to the child via ``pass_fds`` (an inherited fd cannot cross a
+``docker exec`` boundary), so the harness must run on the reyn host under the
+reyn-process interpreter. It deliberately does NOT honor ``REYN_HARNESS_PYTHON``
+— that operator override targets the in-container #1356 *preprocessor* harness
+(``PythonRunner``), which is routed through ``backend.run`` (= ``docker exec``)
+and so needs the container's python. Picking it up here pointed codeact's host
+``Popen`` at a container-only path (``/opt/reyn-venv/bin/python``) under
+``--env-backend=docker``, and the seatbelt-wrapped exec failed with execvp rc=71.
+
+This is the inverse of ``test_python_runner_harness_python_env`` (PythonRunner
+MUST honor the env var); the two pin the deliberate divergence.
+
+Real CodeActRunner (no mocks); env controlled via monkeypatch.
+"""
+from __future__ import annotations
+
+import sys
+
+from reyn.kernel.codeact_runner import CodeActRunner
+
+
+def test_codeact_ignores_harness_python_env(monkeypatch) -> None:
+    """Tier 2: #1663 — even with REYN_HARNESS_PYTHON set to a container path,
+    CodeActRunner uses the host sys.executable (the rc=71 regression guard). A
+    non-default sentinel pins it: were the env fallback still present, the runner
+    would pick up the container path and this would fail."""
+    monkeypatch.setenv("REYN_HARNESS_PYTHON", "/opt/reyn-venv/bin/python")
+    runner = CodeActRunner()
+    assert runner.python_executable == sys.executable
+    assert runner.python_executable != "/opt/reyn-venv/bin/python"
+
+
+def test_codeact_unset_env_is_sys_executable(monkeypatch) -> None:
+    """Tier 2: #1663 — with the env var unset, the default is the host
+    sys.executable (unchanged for the normal non-docker path)."""
+    monkeypatch.delenv("REYN_HARNESS_PYTHON", raising=False)
+    assert CodeActRunner().python_executable == sys.executable
+
+
+def test_codeact_explicit_arg_wins(monkeypatch) -> None:
+    """Tier 2: #1663 — an explicit python_executable arg still wins (test/caller
+    override), independent of the env var."""
+    monkeypatch.setenv("REYN_HARNESS_PYTHON", "/opt/reyn-venv/bin/python")
+    assert CodeActRunner("/explicit/python").python_executable == "/explicit/python"


### PR DESCRIPTION
**[e2e-coder]** — #1663 Option A (container-is-the-boundary). Owner-approved; design + corrected mechanism confirmed by lead (broker) after a flow-trace caught the dispatched mechanism was based on the issue's initial (wrong) root-cause framing.

## Symptom

Under `--env-backend=docker`, every codeact turn died with
`sandbox-exec: execvp() ... No such file (rc=71)` → agent executed nothing → empty
`model_patch`. codeact unusable in the docker SWE-eval env.

## Root cause (corrected by flow-trace)

reyn runs on the macOS **host** (`reyn run-once --env-backend=docker --container <c>`,
resolves the seatbelt sandbox). The SWE runner sets
`REYN_HARNESS_PYTHON=/opt/reyn-venv/bin/python` — a **container** path — for the
in-container #1356 *preprocessor* harness, which is correctly routed via
`backend.run` (= `docker exec`). **CodeActRunner also read `REYN_HARNESS_PYTHON`**
and used that container-only path for its **host-local** `Popen`, wrapped by host
seatbelt:

```
[sandbox-exec, -f, <profile>, /opt/reyn-venv/bin/python, -m, reyn.kernel._codeact_harness]
```

On the host, `sandbox-exec` runs but `execvp`s the container python path (absent on
the host) → rc=71. (The issue's "sandbox-exec missing in the container" was the wrong
inference — the `Popen` runs on the host.)

## Why the harness must stay host-local (the gating story)

codeact's permission gate is an **AF_UNIX socketpair handed to the child via
`pass_fds`** — the child marshals every `tool()` call back to the parent `_service`
(the sole chokepoint). **An inherited host fd cannot cross a `docker exec`
boundary**, so routing the harness through the env backend (the originally
dispatched mechanism) would *break the gate it must preserve*. It doesn't need to:
codeact `tool()` calls dispatch through the parent gate to the tool handlers, which
for `--env-backend=docker` execute **in the container** via `DockerEnvironmentBackend`
(the same path `enumerate` uses) — so repo **effects** already reach the container
while the host-local harness keeps **zero authority** beyond the gated channel.

## Fix (minimal — lead-confirmed shape 1)

`CodeActRunner` no longer falls back to `REYN_HARNESS_PYTHON`; it uses
`sys.executable` (the reyn host interpreter) — for both host and docker
env-backend (the harness is always host-local). `REYN_HARNESS_PYTHON` is left for
`PythonRunner` (the preprocessor) where it belongs. The host **seatbelt wrap is
kept** (defense-in-depth on the restricted orchestrator). Explicit
`python_executable` arg still wins.

**Gating preserved**: (a) AF_UNIX socket-dispatch gate untouched, (b) host
orchestrator has zero authority beyond the gated tools, (c) effects route to the
container via tool dispatch.

## Test (Tier 2)

Pins the **inverse** of `test_python_runner_harness_python_env`: `CodeActRunner`
ignores `REYN_HARNESS_PYTHON` (uses `sys.executable`) while `PythonRunner` honors it
— the deliberate divergence + the rc=71 regression guard (non-default container-path
sentinel).

## Gate — real-env verification

The rc=71 only reproduces under the docker SWE-eval harness, which **cannot** run on
the macOS maintainer host. Per `[[feedback_optional_dep_glue_needs_real_env_verify]]`,
**@sandbox_2's docker SWE-eval verify is the gate**: codeact runs without rc=71, the
AF_UNIX gate stays intact, and effects reach the container. Filed `Refs #1663` (not
`Closes`) so it stays open until that live-verify lands.

## Test plan

- [x] `ruff check src tests` — clean
- [x] codeact + python_runner test suites + new test — 34 passed
- [x] `scripts/test_tier_audit.py --strict` (new test) — 0 violations
- [x] full `pytest -q` from rootdir — (result in final comment; expect only the 2 known machine-quirk fails)
- [x] **(sandbox_2, docker gate)** codeact under `--env-backend=docker`: **FULL PASS** on astropy-13236 @ a87a7c3c — (1) no rc=71 (rc=0, zero crashes), (2) AF_UNIX gate intact (gated round-trips throughout), (3) effects reach container — positively verified: gated `file__write("/testbed/verify1698.txt","VERIFY1698OK")` → `file__read` → `"VERIFY1698OK"` landed in-container via DockerEnvironmentBackend (primary data: `/tmp/ca1698_c3_trace.jsonl`). The natural-run empty patch was a separate #1667 `reyn_source__grep` misselection, not a #1663 defect.

Refs #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
