### PR TITLE
docs: file-path drift sweep for structural package-move refactors (#3/#1/#1699/#1700)

### DIFF
--- a/docs/concepts/runtime/sandbox.ja.md
+++ b/docs/concepts/runtime/sandbox.ja.md
@@ -12,7 +12,7 @@ Reyn のサンドボックスレイヤーは、スキルが宣言したポリシ
 
 ## `SandboxPolicy` フィールドリファレンス
 
-`src/reyn/sandbox/policy.py` で定義。`sandboxed_exec` Control IR op のフィールドとして渡されます。
+`src/reyn/security/sandbox/policy.py` で定義。`sandboxed_exec` Control IR op のフィールドとして渡されます。
 
 | フィールド | 型 | デフォルト | 意味 |
 |---|---|---|---|

--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -12,7 +12,7 @@ The sandbox complements the [permission model](../runtime/permission-model.md): 
 
 ## `SandboxPolicy` field reference
 
-Defined in `src/reyn/sandbox/policy.py`. Passed as fields on a `sandboxed_exec` Control IR op.
+Defined in `src/reyn/security/sandbox/policy.py`. Passed as fields on a `sandboxed_exec` Control IR op.
 
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|

--- a/docs/concepts/skills/skill-self-improvement.ja.md
+++ b/docs/concepts/skills/skill-self-improvement.ja.md
@@ -41,8 +41,8 @@ skill_improver (stdlib スキル)
 | A | すべての `run_skill_started` イベントに `skill_version_hash` フィールドを付与 | `src/reyn/op_runtime/run_skill.py` |
 | B | `.reyn/skill-versions/<name>/v<N>.md` スナップショット + `current` ポインタ | `skill_improver/version_snapshot.py` + `phases/finalize.md` |
 | C | `collect_traces` フェーズ（recall パス + raw-events フォールバック） | `skill_improver/trace_collector.py` + `phases/collect_traces.md` |
-| D | `on_propose: ask_user\|auto\|disabled` 設定 + finalize ゲート | `src/reyn/config.py` `SelfImprovementConfig` + `phases/finalize.md` |
-| E | `reyn skill versions / rollback` CLI | `src/reyn/cli/commands/skill.py` |
+| D | `on_propose: ask_user\|auto\|disabled` 設定 + finalize ゲート | `src/reyn/config/execution.py` `SelfImprovementConfig` + `phases/finalize.md` |
+| E | `reyn skill versions / rollback` CLI | `src/reyn/interfaces/cli/commands/skill.py` |
 
 ## ワークフロー詳細
 

--- a/docs/concepts/skills/skill-self-improvement.md
+++ b/docs/concepts/skills/skill-self-improvement.md
@@ -41,8 +41,8 @@ The `collect_traces` phase is optional — it depends on [Operational Intelligen
 | A | `skill_version_hash` field on every `run_skill_started` event | `src/reyn/op_runtime/run_skill.py` |
 | B | `.reyn/skill-versions/<name>/v<N>.md` snapshot + `current` pointer | `skill_improver/version_snapshot.py` + `phases/finalize.md` |
 | C | `collect_traces` phase (recall path + raw-events fallback) | `skill_improver/trace_collector.py` + `phases/collect_traces.md` |
-| D | `on_propose: ask_user\|auto\|disabled` config + finalize gate | `src/reyn/config.py` `SelfImprovementConfig` + `phases/finalize.md` |
-| E | `reyn skill versions / rollback` CLI | `src/reyn/cli/commands/skill.py` |
+| D | `on_propose: ask_user\|auto\|disabled` config + finalize gate | `src/reyn/config/execution.py` `SelfImprovementConfig` + `phases/finalize.md` |
+| E | `reyn skill versions / rollback` CLI | `src/reyn/interfaces/cli/commands/skill.py` |
 
 ## Workflow walk-through
 

--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -405,5 +405,5 @@ action_retrieval:
 - [`src/reyn/tools/universal_dispatch.py`](https://github.com/anthropics/reyn) — routing table、 `ResolvedAction`、 `UnknownActionError`、 `suggest_similar_names`
 - [`src/reyn/chat/router_tools.py`](https://github.com/anthropics/reyn) — `build_tools` integration (flag-gate された wrapper)
 - [`src/reyn/chat/router_system_prompt.py`](https://github.com/anthropics/reyn) — `## Action categories` section
-- [`src/reyn/config.py`](https://github.com/anthropics/reyn) — `ActionRetrievalConfig`
+- [`src/reyn/config/embedding.py`](https://github.com/anthropics/reyn) — `ActionRetrievalConfig`
 - [`docs/reference/config/reyn-yaml.ja.md`](../../reference/config/reyn-yaml.ja.md#action_retrieval) — config reference

--- a/docs/concepts/tools-integrations/universal-catalog.md
+++ b/docs/concepts/tools-integrations/universal-catalog.md
@@ -476,5 +476,5 @@ in a single retry. See `_LEGACY_CATEGORY_REDIRECTS` in
 - [`src/reyn/tools/universal_dispatch.py`](https://github.com/anthropics/reyn) — routing tables, `ResolvedAction`, `UnknownActionError`, `suggest_similar_names`
 - [`src/reyn/chat/router_tools.py`](https://github.com/anthropics/reyn) — `build_tools` integration (flag-gated wrappers)
 - [`src/reyn/chat/router_system_prompt.py`](https://github.com/anthropics/reyn) — `## Action categories` section
-- [`src/reyn/config.py`](https://github.com/anthropics/reyn) — `ActionRetrievalConfig`
+- [`src/reyn/config/embedding.py`](https://github.com/anthropics/reyn) — `ActionRetrievalConfig`
 - [`docs/reference/config/reyn-yaml.md`](../../reference/config/reyn-yaml.md#action_retrieval-block) — config reference

--- a/docs/concepts/tools-integrations/voice.md
+++ b/docs/concepts/tools-integrations/voice.md
@@ -68,5 +68,5 @@ Set `language: ""` or `language: null` to opt back into Whisper auto-detection.
 
 ## See also
 
-- `src/reyn/chat/tui/voice.py`
-- `src/reyn/config.py` — `VoiceConfig`
+- `src/reyn/interfaces/tui/voice.py`
+- `src/reyn/config/media.py` — `VoiceConfig`

--- a/docs/deep-dives/research/positioning/reyn-mcp-cli-shape.md
+++ b/docs/deep-dives/research/positioning/reyn-mcp-cli-shape.md
@@ -225,4 +225,4 @@ Reyn config 階層 (ADR-0031 3-layer: `~/.reyn/config.yaml` / `<project>/reyn.ya
 - `docs/deep-dives/research/competitive/{openclaw,hermes-agent,pi}.md` — enterprise differentiation の競合 baseline
 - 既存 `mcp_search` skill: `src/reyn/stdlib/skills/mcp_search/`
 - `MCPClient` + `expand_env()`: `src/reyn/mcp/client.py`
-- `PermissionDecl` / `require_mcp()`: `src/reyn/permissions/permissions.py`
+- `PermissionDecl` / `require_mcp()`: `src/reyn/security/permissions/permissions.py`

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -573,7 +573,7 @@ Bounded-operation checkpoints that stop the agent gracefully rather than hard-fa
 
 ### TUI
 
-The Textual terminal interface for `reyn chat` (`src/reyn/chat/tui/`).
+The Textual terminal interface for `reyn chat` (`src/reyn/interfaces/tui/`).
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|

--- a/docs/guide/for-skill-authors/ux-polish/enable-voice-input.ja.md
+++ b/docs/guide/for-skill-authors/ux-polish/enable-voice-input.ja.md
@@ -127,4 +127,4 @@ opt-in のみでデフォルトにはしない。
 ## 関連
 
 - [`reyn chat` リファレンス](../../../reference/cli/chat.md)
-- TUI キーバインドのカスタマイズ *(doc 予定、 当面は `src/reyn/chat/tui/app.py` の `Ctrl+R` を直接編集)*
+- TUI キーバインドのカスタマイズ *(doc 予定、 当面は `src/reyn/interfaces/tui/app.py` の `Ctrl+R` を直接編集)*

--- a/docs/guide/for-skill-authors/ux-polish/enable-voice-input.md
+++ b/docs/guide/for-skill-authors/ux-polish/enable-voice-input.md
@@ -130,5 +130,5 @@ to OpenAI — opt-in only, never the default.
 - [`reyn chat` reference](../../../reference/cli/chat.md)
 - **Customizing key bindings**: `Ctrl+R` and its `Enter`-while-recording
   companion are declared in `BINDINGS` at the top of
-  `src/reyn/chat/tui/app.py`. To remap them, edit that file directly —
+  `src/reyn/interfaces/tui/app.py`. To remap them, edit that file directly —
   there is no config-file key-binding layer at this time.


### PR DESCRIPTION
**[docs-maintainer]** — comprehensive docs-drift sweep for the landed structural package moves (lead-coder dispatch + cascade; revised after review caught a missed move-class). Audited `origin/main`; all new canonical paths verified to exist via ls-tree.

## Finding: drift is file-path-only, in two move-classes
Dotted module refs are all re-exported → **0 dotted-path drift**. The drift is in docs naming modules by **file path**, in two classes:

**Class 1 — direct moves**
| ref | old → new |
|---|---|
| SelfImprovementConfig | `config.py` → `config/execution.py` |
| ActionRetrievalConfig | `config.py` → `config/embedding.py` |
| VoiceConfig | `config.py` → `config/media.py` |
| sandbox policy | `sandbox/policy.py` → `security/sandbox/policy.py` |
| skill CLI cmd | `cli/commands/skill.py` → `interfaces/cli/commands/skill.py` |
| permissions impl | `permissions/permissions.py` → `security/permissions/permissions.py` |

**Class 2 — #2→#1700 chain (`chat/tui` → `interfaces/tui`)** *(added after review)*
- `voice.md`: `chat/tui/voice.py` → `interfaces/tui/voice.py`
- `feature-map.md`: `chat/tui/` → `interfaces/tui/`
- `enable-voice-input.md` + `.ja`: `chat/tui/app.py` → `interfaces/tui/app.py`

## Verified-and-LEFT (not moved)
`chat/` package stays — `chat/router_tools.py`, `router_system_prompt.py`, `session.py`, `router_loop.py`, `external_routing.py`, `transport.py`, `services/` + dotted `reyn.chat.transport`/`reyn.chat.external_routing` all confirmed present at `chat/` (only `chat/tui` & `chat/slash` moved). Left unchanged.

## NOT touched (historical / out of scope)
- journal/, ADRs, proposals, FP-analyses, design specs (handoff, cli-redesign)
- `reyn._cli` entry shim (unchanged); `safety:` yaml key (≠ `safety/`→`limits/`)
- **borderline, flagged to lead-coder**: `research/landscape/reyn-strategic-priorities.md` + `research/tui-light-terminal-audit.md` (`chat/tui/` refs in research-analysis docs, outside the concept/reference scope)

## Test plan
- [x] `mkdocs build --strict` → exit 0
- [x] exhaustive canonical-doc grep (concepts/reference/guide/feature-map) for all moved-old-path forms → 0 remaining
- [x] all new canonical paths confirmed present in origin/main; non-moved `chat/` refs confirmed still valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)