### PR TITLE
fix(1695): reword lint.py skill_path param desc scheme-agnostic (#1625 followup)

### DIFF
--- a/src/reyn/tools/lint.py
+++ b/src/reyn/tools/lint.py
@@ -30,9 +30,9 @@ _LINT_PARAMETERS: dict[str, Any] = {
         "skill_path": {
             "type": "string",
             "description": (
-                'qualified action name like "skill__<name>" '
-                "(returned by list_actions), the bare skill name, "
-                "or a workspace-relative directory path. NOT a "
+                'the skill to lint — a qualified action name like '
+                '"skill__<name>", the bare skill name, or a '
+                "workspace-relative directory path. NOT a "
                 "slash-style path under \"skill/\""
             ),
         },


### PR DESCRIPTION
**[tui-coder]** — #1695 (#1625 followup). The `skill_path` **param** description in `tools/lint.py` leaked a scheme-specific HOW: `"(returned by list_actions)"` (list_actions = a universal-category scheme op). #1625 fixed the 4 *rendered* descriptions; this is the param-level leak it left.

## Fix
Reworded to describe what the param **is** (the skill to lint, 3 accepted forms: qualified action name `"skill__<name>"` / bare skill name / workspace-relative dir path), dropping the scheme-op reference. WHAT-not-HOW, consistent with `_LINT_DESCRIPTION` (already scheme-agnostic).

## Replay-fixture risk (deferred by e2e) — did NOT materialize
- grep: **no replay fixture embeds the old param-desc text**, and **no router-catalog fixture references the lint tool at all** → no captured request contains this param desc → **no fixture re-key needed** (the Option-A surgical re-key was the fallback; unnecessary here).

## Test plan
- [x] router replay suite green (52 passed, 1 xfailed) — the caveat's risk
- [x] universal-dispatch + lint tests pass (119)
- [x] `ruff` clean; zero `list_actions`/HOW leak remaining in lint.py
- [ ] CI full-suite green (gate)

Refs #1695 (#1625 followup). Light/parallel to e2e's #1667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
