### PR TITLE
fix(1667): explicit excluded_categories — reyn_source catalog opt-out for external-repo tasks

### DIFF
--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -308,6 +308,13 @@ def run_reyn_once_in_container(
             # benchmark answer) — matching SWE-agent/OpenHands (no web in-bench). The
             # exec network path is already sandbox-gated off; web is the only leak.
             "--exclude-tools", "web__search,web__fetch",
+            # #1667 explicit opt-out: this is an external-repo task on /testbed, so
+            # Reyn's own source (reyn_source__read/list/glob/grep self-help surface)
+            # is irrelevant — hide the whole category at the catalog source so the
+            # weak model doesn't misselect reyn_source__grep over file__* (it would
+            # search Reyn's source, never the repo → empty patch). The interactive
+            # agent keeps reyn_source (this is per-invocation explicit, owner 明示).
+            "--exclude-categories", "reyn_source",
             # autonomous SWE needs many tool rounds (explore→edit→verify) > chat's 5.
             "--max-iterations", str(max_iterations),
         ]

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -1388,6 +1388,7 @@ class RouterLoop:
         system_prompt_override: str | None = None,
         non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from ChatSession.
         exclude_tools: set[str] | None = None,
+        excluded_categories: set[str] | None = None,  # #1667 catalog categories skipped at source
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
@@ -1439,6 +1440,9 @@ class RouterLoop:
         # compare" produced 3 plan invocations because step LLMs saw plan
         # in their tool catalog and self-decomposed.
         self._exclude_tools: frozenset[str] = frozenset(exclude_tools or set())
+        # #1667: catalog categories skipped at the source (_enumerate_category),
+        # threaded onto RouterCallerState so the universal catalog drops them.
+        self._excluded_categories: frozenset[str] = frozenset(excluded_categories or set())
         # FP-0034 Phase 2 step 1: action embedding index background
         # build task handle.  None until the first turn that finds the
         # index configured + not ready, then asyncio.Task while
@@ -3869,6 +3873,8 @@ class RouterLoop:
             budget=self.budget,
             router_model=self.router_model,
             available_tool_names=list(self._tool_names),
+            # #1667: catalog categories the universal catalog skips at source.
+            excluded_categories=self._excluded_categories,
             # OpContext factory (= for file / mcp / web handlers; Phase 3.5-A+C).
             # ``getattr`` fallback keeps test stubs (= FakeRouterHost without
             # the method) compatible — the handler then uses its minimal

--- a/src/reyn/chat/scoped_session_factory.py
+++ b/src/reyn/chat/scoped_session_factory.py
@@ -50,6 +50,7 @@ def build_scoped_chat_session(
     workspace_base_dir: "Path | None",  # #187 chat OpContext FS root (container repo) / None=host cwd
     workspace_state_dir: "Path | None",  # #187 host-side OS state dir
     exclude_tools: "frozenset[str] | set[str] | None",  # #1400 tool names hidden + execution-blocked
+    excluded_categories: "frozenset[str] | set[str] | None",  # #1667 catalog categories hidden at source (reyn_source for external-repo eval)
     agent_id: str | None,  # FP-0016 agent-id-scoped memory
     router_max_iterations: int,  # #187 per-message tool-call budget
     non_interactive: bool,  # #1439 Fix #1: run-once (no TTY) → SP proceeds instead of asking a clarifying question. Per-frontend: chat-CLI = not isatty(); A2A/MCP/chainlit/dogfood = False (interactive byte-identical)
@@ -77,6 +78,7 @@ def build_scoped_chat_session(
         workspace_base_dir=workspace_base_dir,
         workspace_state_dir=workspace_state_dir,
         exclude_tools=exclude_tools,
+        excluded_categories=excluded_categories,
         agent_id=agent_id,
         router_max_iterations=router_max_iterations,
         non_interactive=non_interactive,

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -43,6 +43,7 @@ class RouterLoopDriver:
         budget_tracker: Any,          # BudgetTracker — for RouterLoop
         non_interactive: bool,
         exclude_tools: Any,           # set — for RouterLoop
+        excluded_categories: Any = frozenset(),  # #1667 set — catalog categories for RouterLoop
         budget: Any,                  # BudgetGateway — cap + usage accounting
         resolver: Any,                # LLMResolver — model resolution
         compaction: Any,              # CompactionConfig — retry_loop cfg
@@ -63,6 +64,7 @@ class RouterLoopDriver:
         self._budget_tracker = budget_tracker
         self._non_interactive = non_interactive
         self._exclude_tools = exclude_tools
+        self._excluded_categories = excluded_categories  # #1667
         self._budget = budget
         self._resolver = resolver
         self._compaction = compaction
@@ -355,6 +357,7 @@ class RouterLoopDriver:
             # #187: hide excluded tools from the MAIN agent loop's LLM-visible
             # catalog.
             exclude_tools=self._exclude_tools,
+            excluded_categories=self._excluded_categories,  # #1667
             # B43-NF-W6-1 / #187: chat router empty-stop retry — always-on +
             # uniform "resume" directive.
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1192,6 +1192,7 @@ class ChatSession:
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
+        excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_source for external-repo eval)
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
     ) -> None:
@@ -1226,6 +1227,10 @@ class ChatSession:
         # SWE-eval excludes web__search/web__fetch so the agent solves from the
         # repo + issue, not a web lookup of the gold solution.
         self._exclude_tools = frozenset(exclude_tools or ())
+        # #1667: catalog categories hidden at the universal-catalog source (e.g.
+        # reyn_source on the external-repo eval path so it doesn't compete with
+        # file__* for the weak model); interactive default empty = reyn_source kept.
+        self._excluded_categories = frozenset(excluded_categories or ())
         # #187: per-message tool-call budget for the MAIN chat RouterLoop. The
         # interactive default (5) suits a human turn; an autonomous one-shot run
         # (`reyn chat --once` for SWE) needs far more (explore→edit→verify rounds),
@@ -2023,6 +2028,7 @@ class ChatSession:
             budget_tracker=self._budget_tracker,
             non_interactive=self._non_interactive,
             exclude_tools=self._exclude_tools,
+            excluded_categories=self._excluded_categories,
             budget=self._budget,
             resolver=self._resolver,
             compaction=self._compaction,

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -202,6 +202,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # container-rooting. Fill = 1-line follow-up when a consumer needs it.
                 eager_embedding_build=False,
                 exclude_tools=None,
+                excluded_categories=frozenset(),  # #1667: interactive — keep all categories (incl reyn_source self-help)
                 router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: interactive UI = byte-identical
                 environment_backend=None,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -133,6 +133,22 @@ def register(sub) -> None:
             "are just not offered to the model this session."
         ),
     )
+    # #1667: hide whole catalog CATEGORIES at the universal-catalog source
+    # (orthogonal to --exclude-tools, which is top-level tool names). The
+    # external-repo eval path (SWE-bench on /testbed) passes 'reyn_source' so
+    # Reyn's own self-help surface doesn't compete with file__* for the weak
+    # model. Empty (the interactive default) keeps every category.
+    p.add_argument(
+        "--exclude-categories", dest="exclude_categories", default=None,
+        metavar="NAMES",
+        help=(
+            "Comma-separated catalog category names to hide from the agent's "
+            "catalog at the source (e.g. 'reyn_source' for an external-repo task "
+            "where Reyn's own source is irrelevant). Distinct from --exclude-tools "
+            "(top-level tool names); this drops the whole category from "
+            "list_actions + every scheme's action list + dispatch."
+        ),
+    )
     p.add_argument(
         "--banner",
         action="store_true",
@@ -350,6 +366,12 @@ def run(args: argparse.Namespace) -> None:
     _exclude_tools = frozenset(
         t.strip() for t in (getattr(args, "exclude_tools", None) or "").split(",") if t.strip()
     )
+    # #1667: parse --exclude-categories (comma-separated category names) → frozenset,
+    # threaded to ChatSession → RouterCallerState.excluded_categories → the universal
+    # catalog skips them at the source. Empty (interactive default) keeps every category.
+    _excluded_categories = frozenset(
+        c.strip() for c in (getattr(args, "exclude_categories", None) or "").split(",") if c.strip()
+    )
     # #1414: the single PermissionResolver is constructed BELOW, after
     # build_environment_backend, because it needs ``ws_base_dir`` for the
     # container file-zone anchor (file_zone_root). It isn't used before then.
@@ -410,6 +432,7 @@ def run(args: argparse.Namespace) -> None:
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
+            excluded_categories=_excluded_categories,  # #1667: hide categories (e.g. reyn_source) at the catalog source
             # #187: per-message tool-call budget. Interactive chat uses
             # safety.loop.max_router_iterations (default 5); the one-shot
             # autonomous path raises it via --max-iterations (CLI wins).

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -484,6 +484,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,
+                excluded_categories=frozenset(),  # #1667: dogfood — keep all categories
                 router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: dogfood driver = byte-identical (run-once-only fix)
                 workspace_base_dir=ws_base_dir,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -430,6 +430,7 @@ def run_serve(args: argparse.Namespace) -> None:
             # (behavior-preserving). Fill = 1-line follow-up when a consumer needs it.
             agent_id=None,
             exclude_tools=None,
+            excluded_categories=frozenset(),  # #1667: MCP server — keep all categories
             router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
             non_interactive=False,  # #1439 Fix #1: stdio-MCP byte-identical (run-once-only fix)
             environment_backend=None,  # gap: MCP-serve lacks env-backend / container-rooting

--- a/src/reyn/interfaces/cli/commands/run_once.py
+++ b/src/reyn/interfaces/cli/commands/run_once.py
@@ -58,6 +58,15 @@ def register(sub) -> None:
         ),
     )
     p.add_argument(
+        "--exclude-categories", dest="exclude_categories", default=None,
+        metavar="NAMES",
+        help=(
+            "Comma-separated catalog category names to hide at the catalog source "
+            "(e.g. 'reyn_source' for an external-repo task where Reyn's own source "
+            "is irrelevant). Same as `reyn chat --exclude-categories`. #1667."
+        ),
+    )
+    p.add_argument(
         "--max-iterations", dest="max_iterations", type=int, default=80, metavar="N",
         help=(
             "Per-message tool-call budget for the autonomous loop (default 80). "

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -355,6 +355,7 @@ def _get_registry():
                 allowed_mcp=None,
                 agent_id=None,
                 exclude_tools=_scoped.exclude_tools,
+                excluded_categories=frozenset(),  # #1667: web/A2A is interactive — keep all categories (a `reyn web` category opt-out would extend _scoped separately)
                 router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: A2A byte-identical (run-once-only fix). A2A-non-interactive = documented follow-up (cf factory module doc)
                 environment_backend=_scoped.environment_backend,

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -75,6 +75,14 @@ class RouterCallerState:
     router_model: str | None = None
     available_tool_names: list[str] | None = None
 
+    # #1667: catalog categories to skip at the SOURCE (``_enumerate_category``),
+    # so an excluded category vanishes UNIFORMLY from ``catalog_entries`` (every
+    # scheme's flat list) + ``list_actions`` + dispatch — orthogonal to
+    # ``exclude_tools`` (which filters top-level ``tools=`` by name and cannot
+    # reach the universal catalog source). The task-agent / external-repo eval path
+    # sets e.g. ``{"reyn_source"}``; the general/interactive agent leaves it empty.
+    excluded_categories: frozenset[str] = frozenset()
+
     # Memory access (= for memory tools when invoked router-side;
     # router uses MemoryService directly, phase wraps via
     # ctx.workspace callbacks)

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -561,6 +561,20 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
     """
     rs = ctx.router_state
 
+    # #1667: explicit per-session category exclusion. The task-agent / external-repo
+    # eval path (e.g. SWE-bench on /testbed) sets ``excluded_categories`` so a
+    # category irrelevant to the task — Reyn's own ``reyn_source`` self-help surface
+    # — does not compete with ``file__*`` for the weak model's selection. Applied at
+    # the catalog SOURCE so the category vanishes UNIFORMLY from ``catalog_entries``
+    # (every scheme's flat list: codeact code-API / enumerate-all / retrieval) +
+    # ``list_actions`` + dispatch — a top-level ``exclude_tools`` name filter cannot
+    # reach this. The general/interactive agent leaves it empty and keeps the
+    # category (self-help preserved). P7-clean: the excluded set is caller data, no
+    # hardcoded category name here.
+    excluded = getattr(rs, "excluded_categories", None) or frozenset()
+    if category in excluded:
+        return []
+
     if category in (
         "file", "web", "memory_operation", "reyn_source", "rag_operation",
         "mcp", "multi_agent", "validation",

--- a/tests/test_excluded_categories_1667.py
+++ b/tests/test_excluded_categories_1667.py
@@ -1,0 +1,81 @@
+"""Tier 2: #1667 — explicit per-session category exclusion at the catalog SOURCE.
+
+``reyn_source`` (Reyn's own self-help read/list/glob/grep surface) is default-IN
+for the general/interactive agent, but a foot-gun in external-repo task contexts
+(SWE-bench/eval on /testbed): the weak model misselects ``reyn_source__grep`` over
+``file__*`` and searches Reyn's source instead of the repo. The fix is an EXPLICIT
+opt-out: the task-agent path sets ``excluded_categories={"reyn_source"}``, threaded
+to ``RouterCallerState`` and applied at ``_enumerate_category`` — the single
+catalog source. Because ``catalog_entries`` / ``list_actions`` / ``describe`` /
+dispatch all derive from ``_enumerate_category``, the category vanishes UNIFORMLY
+from every scheme (codeact / enumerate / retrieval) — which a top-level
+``exclude_tools`` name filter cannot reach (reyn_source ops are never top-level
+tools). The interactive agent leaves it empty and keeps reyn_source (self-help
+preserved). Orthogonal to ``exclude_tools`` (a separate param, by design).
+
+Real ToolContext + RouterCallerState (no mocks of collaborators).
+"""
+from __future__ import annotations
+
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import _enumerate_category, catalog_entries
+
+
+class _FakeEvents:
+    def emit(self, *args, **kwargs) -> None:
+        pass
+
+
+def _ctx(excluded: "frozenset[str] | set[str]" = frozenset()) -> ToolContext:
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            available_skills=[],
+            mcp_servers=None,
+            excluded_categories=frozenset(excluded),
+        ),
+    )
+
+
+def test_excluded_category_dropped_from_catalog_entries() -> None:
+    """Tier 2: #1667 — with excluded_categories={"reyn_source"}, NO reyn_source__*
+    action appears in catalog_entries (every scheme's flat list), while file__*
+    survives. This is the misselection-disappears proof."""
+    names = {e["name"] for e in catalog_entries(_ctx(excluded={"reyn_source"}))}
+    assert not any(n.startswith("reyn_source__") for n in names), (
+        "excluded reyn_source category must vanish from catalog_entries"
+    )
+    assert any(n.startswith("file__") for n in names), (
+        "non-excluded categories (file) must remain"
+    )
+
+
+def test_unset_keeps_reyn_source() -> None:
+    """Tier 2: #1667 — the interactive default (empty excluded_categories) KEEPS
+    reyn_source (self-help capability preserved — the owner's default-IN). This is
+    the don't-kill-the-feature proof."""
+    names = {e["name"] for e in catalog_entries(_ctx())}
+    assert any(n.startswith("reyn_source__") for n in names), (
+        "with no exclusion, reyn_source must remain (interactive self-help)"
+    )
+
+
+def test_enumerate_category_skip_is_at_the_source() -> None:
+    """Tier 2: #1667 — the skip is at _enumerate_category (the single source feeding
+    catalog_entries + list_actions + describe + dispatch), so an excluded category
+    enumerates empty while a sibling static category does not."""
+    ctx = _ctx(excluded={"reyn_source"})
+    assert _enumerate_category("reyn_source", ctx) == []
+    assert _enumerate_category("file", ctx), "a non-excluded static category still enumerates"
+
+
+def test_other_category_exclusion_is_generic() -> None:
+    """Tier 2: #1667 — the mechanism is generic (P7: the excluded set is caller
+    data, not a hardcoded reyn_source). Excluding "web" drops web__* and leaves
+    reyn_source__*."""
+    names = {e["name"] for e in catalog_entries(_ctx(excluded={"web"}))}
+    assert not any(n.startswith("web__") for n in names)
+    assert any(n.startswith("reyn_source__") for n in names)

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -51,6 +51,7 @@ _REQUIRED_SCOPED = frozenset({
     "workspace_base_dir",
     "workspace_state_dir",
     "exclude_tools",
+    "excluded_categories",  # #1667 catalog category opt-out (per-frontend scoped)
     "agent_id",
     "router_max_iterations",
     "non_interactive",  # #1439 Fix #1: run-once SP autonomy flag (per-frontend scoped)


### PR DESCRIPTION
**[e2e-coder]** — #1667 reyn_source catalog foot-gun. Owner design settled (explicit opt-out); locus + mechanism confirmed by lead (broker) after a flow-trace corrected the dispatched `category_filter` locus.

## Problem

`reyn_source` (Reyn's own read/list/glob/grep self-help surface) is **default-IN**
for the general/interactive agent — its purpose is self-help (a user *using* Reyn who
doesn't understand an operation → the agent reads Reyn's own source/docs). But it's a
foot-gun in **external-repo task contexts** (SWE-bench/eval on `/testbed`): the weak
model misselects `reyn_source__grep` over `file__*` → searches Reyn's source instead
of the repo → empty `model_patch`. Cross-scheme (codeact-docker + enumerate + retrieval).

## Locus (corrected by flow-trace)

The dispatched `_validate_category_filter` is the `list_actions` browse-**arg** validator
(call-time include), not a construction-time exclusion. And `exclude_tools` only filters
**top-level `tools=`** by name — `reyn_source__*` are never top-level (reachable via the
universal wrapper). The misselection lives in **`catalog_entries` / `_enumerate_category`**,
which enumerate every category **unconditionally** for every scheme's flat action list.

## Fix — explicit `excluded_categories` at the catalog SOURCE

Lead-confirmed: a **separate, orthogonal** param (do NOT overload `exclude_tools`),
threaded as a drift-surface capability exactly like `exclude_tools`:

```
run_once/chat --exclude-categories
  → scoped_session_factory (new REQUIRED drift-surface param)
    → all 5 frontends (chainlit/web/mcp/dogfood pass frozenset(); chat/run_once pass the flag)
      → ChatSession → RouterLoopDriver → RouterLoop → RouterCallerState.excluded_categories
        → _enumerate_category skips the category at the SOURCE
```

Because `catalog_entries` + `list_actions` + `describe` + dispatch all derive from
`_enumerate_category`, an excluded category vanishes **uniformly** from every scheme.
Interactive leaves it empty → **keeps reyn_source** (self-help preserved). P7-clean
(the excluded set is caller data). `swe_bench_runner` passes `--exclude-categories
reyn_source` (the explicit eval opt-out, alongside the existing web `--exclude-tools`).

The `scoped_session_factory` drift-guard (`test_scoped_session_factory_invariant_1402`)
gains `excluded_categories` in its REQUIRED set → no frontend can silently omit it
(completeness-by-construction, mirrors `exclude_tools`).

## Notes

- **#1700 interfaces/ move**: the frontends had relocated to `interfaces/` (`cli/` →
  `interfaces/cli/`, etc.) — re-discovered the call sites under the new layout rather
  than editing stale paths (`[[feedback_package_move_completeness_three_ref_classes]]`).
- **Thread-2**: `file__read` (catalog name) and `read_file` (op-runtime target) are the
  same op at two layers, never siblings in one catalog → no dup to collapse.
- **Scope**: plan-mode sub-loops default to no exclusion — the reported misselection +
  the gate are the main-loop schemes (codeact/enumerate/retrieval), covered by the
  RouterLoopDriver path; plan-mode-on-eval propagation is a noted follow-up (the opt-out
  is explicit-per-invocation, no silent gap).
- Likely also helps **#1604** (retrieval discovery-skip — same foot-gun class), hence
  `Refs #1604`.

## Gate

The misselection only manifests under the docker SWE-eval. **@sandbox_2's dogfood is the
gate**: (a) `reyn_source`-over-`file__` misselection DISAPPEARS uniformly
(codeact/enumerate/retrieval), AND (b) the interactive agent STILL has `reyn_source`
(self-help not killed). Filed `Refs` (not `Closes`) so it stays open until that lands.

## Test plan

- [x] `ruff check src tests scripts` — clean
- [x] Tier-2 behavior test (excluded → reyn_source gone, file kept; empty → reyn_source kept; generic) — passes
- [x] drift-guard invariant + catalog + frontend/session/driver wiring — 769 passed (no missed required-param site)
- [x] `test_tier_audit --strict` (new + changed tests) — 0 violations
- [x] full `pytest -q` from rootdir — 7451 passed; 3 local fails, all NOT this diff: the 2 known machine-quirk pair (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path_returns_inline_content`) + `test_lazy_import_not_at_module_top` (a fresh-subprocess test that **passes isolated on both this branch AND origin/main** — a pre-existing full-suite-only env/ordering pollution; my diff touches neither the swebench/eval_benchmark import path nor any env var). CI (no swebench installed) is green on all three. (evidence in final comment)
- [x] **(sandbox_2, docker gate)** SWE-eval (astropy-13236, real Linux/docker, #1704 HEAD) = **PASS, all 4 checks**: (1) main-loop misselection GONE — codeact used `file__*` ×N, **zero `reyn_source__`** (empty patch = weak-model ceiling, not #1704); (2) interactive `reyn chat` keeps reyn_source; (3) #1604 retrieval — reyn_source gone there too; (4) **sub-loop boundary CLEAN** — forced a `run_skill` sub-loop → no reyn_source (narrowed catalog; the documented boundary does not leak). Dispatchable exclusion complete everywhere (0 reyn_source in tools across main + sub-loop). **Minor non-functional residual** (NOT a blocker): the universal/enumerate/retrieval SP *template* hardcodes reyn_source usage *examples* (not catalog-gated) — fail-closed (dispatch rejects a copied example), cosmetic; optional SP-scrub follow-up.

Refs #1667
Refs #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
