### PR TITLE
docs(dogfood): 4-way weak-model scheme comparison refresh (2026-06-17, incl retrieval)

### DIFF
--- a/docs/deep-dives/journal/dogfood/2026-06-17-4way-retrieval-refresh/README.md
+++ b/docs/deep-dives/journal/dogfood/2026-06-17-4way-retrieval-refresh/README.md
@@ -1,0 +1,30 @@
+# 4-way weak-model tool-use-scheme comparison — refresh (2026-06-17)
+
+**Point-in-time dogfood results** (owner request: refresh the comparison, now including
+`retrieval`, mechanism-verified by #1604 part-1). Internal-signal only — **pass-rate is
+NOT a published leaderboard** (owner standing constraint). Primary value =
+structural-defect mining + cross-scheme behavior/efficiency.
+
+## Setup
+- HEAD: `b4158974` (post #1616/#1657/#1659/#1693/#1697/#1698; current main at run time).
+- Model: weak `gemini-2.5-flash-lite` (+ `text-embedding-3-small`, `embedding_class: standard` for retrieval).
+- Schemes: `retrieval` / `enumerate-all` (chat default) / `universal-category` / `codeact` (post-#1659 direct-fn).
+- Scenarios (reuse #1631 set, HOST-REPO → no #1667 /testbed foot-gun confound):
+  S1 single-read · S2 multi-file-explore · S3 conditional · M1 read-aggregate · M2 read→transform→write chain.
+- N=5 per scheme×scenario (100 runs). Per-run 200s cap (timeout = efficiency signal per lead, option-a).
+- Harness: `/tmp/refresh_4way.py`; raw results: `/tmp/refresh_4way_results.jsonl`.
+
+## Metrics
+- Task-completion (internal-signal), efficiency (round-trips / tool-calls to converge),
+  structural-defect markers (reyn_source/run_code misselection [#1667], tool_call-runaway
+  degeneracy, malformed act-JSON, codeact-crash, provider-empties, timeouts).
+
+## Results
+_(numbers + matrices filled on run completion — see `results.md`)_
+
+## Key findings (filled on completion)
+- Fairness control (lead): does the S2/M multi-file SEQUENTIAL-READ round-trip cost appear
+  ACROSS all schemes (= weak-model ceiling, don't penalize retrieval) vs retrieval-specific?
+- Retrieval multi-step = slow-but-PROGRESSING (sequential reads, 0 search_actions on multi-file)
+  = tuning/inefficiency, NOT a structural degeneracy defect (S2 standalone diag: rc=0, 16 round-trips).
+- #1667 foot-gun cross-scheme rate on host-repo (expect ~0 → confirms context-specificity).

--- a/docs/deep-dives/journal/dogfood/2026-06-17-4way-retrieval-refresh/results.md
+++ b/docs/deep-dives/journal/dogfood/2026-06-17-4way-retrieval-refresh/results.md
@@ -1,0 +1,36 @@
+# 4-way refresh — results (2026-06-17, point-in-time)
+
+weak `gemini-2.5-flash-lite`, N=5/scenario, HEAD `b4158974`. **Internal-signal only** (not a published leaderboard).
+
+## Completion (success/N)
+| scheme | S1 | S2 | S3 | M1 | M2 | total |
+|---|---|---|---|---|---|---|
+| enumerate-all | 5/5 | 3/5 | 5/5 | 4/5 | 5/5 | **22/25** |
+| codeact | 5/5 | 4/5 | 4/5 | 2/5 | 5/5 | 20/25 |
+| retrieval | 5/5 | 0/5* | 5/5 | 0/5* | 5/5 | 15/25 |
+| universal-category | 5/5 | 1/5 | 3/5 | 0/5 | 5/5 | 14/25 |
+
+\*retrieval S2/M1 = timeout-censored (see below), NOT cognition fail.
+
+## Efficiency (mean round-trips, lower=better)
+| scheme | S1 | S2 | S3 | M1 | M2 |
+|---|---|---|---|---|---|
+| enumerate-all | 2.0 | 2.2 | 2.2 | 3.6 | 4.0 |
+| universal-category | 2.0 | 2.0 | 2.4 | 4.0 | 4.0 |
+| codeact | 2.0 | 2.0 | 3.4 | 4.2 | 3.4 |
+| retrieval | 2.0 | 4.8 | 2.0 | 4.4 | 4.0 |
+
+## Structural-defect markers (primary value)
+- **#1667 foot-gun (reyn_source/run_code misselection): ZERO / 100 runs** — host-repo → independently confirms #1667 is /testbed-(external-repo)-context-specific.
+- codeact: empty-runs 10/25 (provider-intermittent-empty exposure — codeact's larger payloads; known fragility).
+- enumerate: 0 timeouts, 0 empties, 0 defects (fastest-terminating).
+- retrieval: 9 timeouts (S2/M1 read-heavy — the search→embed-query→represent per-round cost ≈40s × multi-round sequential reads → 200s cap; standalone w/o cap COMPLETES = correct-but-slow, tuning not defect).
+
+## Verdict
+- **enumerate-all = weak default, confirmed** (best completion + cleanest/fastest). Owner default-switch holds.
+- **retrieval = catalog-scaling opt-in** (clean single-step/chain; slow on read-heavy multi-file). NOT a weak-default replacement.
+- **codeact = capable-but-fragile** (provider-empty exposure; composition edge needs a capable model).
+- **universal = worst** (invoke_action indirection).
+
+## Method note (measurement-infra)
+Driver invocation MUST drain stdout/stderr safely (file-redirect OR Popen+communicate, NOT `subprocess.run(capture_output=True)`): the enumerate arm initially showed all-200s-timeout + rounds=5 — a CAPTURE-PIPE DEADLOCK on enumerate's larger stdout, NOT an enumerate defect (manual run = 9s clean). Re-ran enumerate with the drain-safe method → valid (0 timeouts). The "all-timeout AND mostly-success" internal inconsistency is the tell.


### PR DESCRIPTION
**[dogfood-coder]** — point-in-time dogfood results for the owner-requested #1604-followup 4-way refresh (now including `retrieval`, mechanism-verified by #1604 Part-1). **Internal-signal only — not a published leaderboard** (owner standing constraint).

## Completion (success/N, weak flash-lite, N=5, HEAD b4158974)
| scheme | total | note |
|---|---|---|
| enumerate-all | **22/25** | best weak default — CONFIRMED (#1657 switch holds) |
| codeact | 20/25 | provider-empty exposure (10/25 empty-runs) = known flash-lite fragility |
| retrieval | 15/25 | catalog-scaling opt-in; S2/M1 = timeout-censored slowness (tuning), not cognition |
| universal-category | 14/25 | worst (invoke_action indirection) |

## Key findings (the value)
- **#1667 foot-gun: ZERO / 100 runs** on host-repo → independently confirms #1667 is /testbed-(external-repo)-context-specific.
- **Fairness**: retrieval's read-heavy 0/5 = the search-machinery per-round overhead (~40s) × multi-round sequential reads → 200s cap; standalone (no cap) completes the same task. Correct-but-slow, NOT cognitively worse.
- enumerate = fastest-terminating (0 timeouts); retrieval = catalog-scaling opt-in (does NOT displace enumerate as the weak default).

## Measurement-infra note
Includes a method note: dogfood subprocess harnesses MUST drain stdout safely (file-redirect / Popen.communicate, not `subprocess.run(capture_output=True)`) — a capture-pipe deadlock corrupted the enumerate arm (all-timeout) until caught + re-run. (Pinned to memory.)

**Approval chain**: owner GO'd #1604; lead accepted the verdict + greenlit this PR (lead reviews). Verdict broker-reported; this is the durable numbers record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)