### PR TITLE
docs(tool-use-schemes): retrieval = catalogue-scaling opt-in, not weak-default (4-way verdict)

### DIFF
--- a/docs/concepts/tools-integrations/tool-use-schemes.md
+++ b/docs/concepts/tools-integrations/tool-use-schemes.md
@@ -70,6 +70,16 @@ catalogues.
 **Use when:** the tool set is **very large** and presenting it in full would cost
 too many tokens — the search narrows the candidates before the call.
 
+**Measured (weak-model 4-way refresh, #1604-followup — internal signal):** retrieval
+is clean on single-step reads and read→transform→write chains, but on **read-heavy
+multi-file** tasks the weak model reads files sequentially and the search→re-present
+per-round overhead makes it slow (timeout-prone) — *correct-but-slow*, a tuning cost,
+not a cognition gap (uncapped, it completes the same task). So retrieval is a
+**catalogue-scaling opt-in, not a weak-default replacement**: `enumerate-all` remains
+the weak-model chat default (highest task-completion and fastest-terminating in the
+comparison; #1657). See the 4-way refresh journal under
+`docs/deep-dives/journal/dogfood/2026-06-17-4way-retrieval-refresh/`.
+
 ### `CodeAct`
 
 Code-as-tools. The LLM writes a short Python snippet, and tool calls happen as


### PR DESCRIPTION
**[dogfood-coder]** — #1604-followup qualitative verdict update to the tool-use-schemes concept doc, from the weak-model 4-way refresh (PR #1709 has the numbers). **Internal-signal verdict; the doc states no pass-rate** (owner constraint).

Adds a "Measured (4-way refresh)" note to the `retrieval` section:
- retrieval is **clean on single-step + read→transform→write chains**, but **slow (timeout-prone) on read-heavy multi-file** — the search→re-present per-round overhead × the weak model's sequential reads → 200s cap. **Correct-but-slow** (uncapped it completes), a tuning cost, NOT a cognition gap.
- → retrieval = **catalogue-scaling opt-in, not a weak-default replacement**; `enumerate-all` stays the weak chat default (#1657: highest completion + fastest-terminating).

This **reinforces** the #1703 retrieval opt-in blessing (does not conflict — both frame retrieval as a large-catalogue opt-in, enumerate as the default).

**Approval chain**: owner GO'd #1604 (Part-2 = the docs-bless); lead accepted the verdict + approved this exact framing. Companion numbers PR: #1709. Sequenced after #1703 (rebased on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)