### PR TITLE
fix(#1711): /concept default glossary path — depth +1 + relocated glossary

### DIFF
--- a/src/reyn/interfaces/slash/concept.py
+++ b/src/reyn/interfaces/slash/concept.py
@@ -1,6 +1,7 @@
 """/concept [<term>] — inline glossary lookup for TUI vocabulary.
 
-Surfaces definitions from ``docs/guide/for-skill-authors/glossary.md``
+Surfaces definitions from
+``docs/guide/for-skill-authors/stdlib-authoring-tools/glossary.md``
 without leaving the chat pane.  The glossary uses Markdown tables with
 ``| English | 日本語 | Definition |`` rows (and some two-column variant
 tables); the parser walks all tables and captures every term → definition
@@ -25,12 +26,19 @@ from reyn.interfaces.slash import reply, reply_error, slash
 # Canonical path relative to the project root.  Resolved at call time so
 # tests can inject a custom path via the ``_glossary_path`` kwarg on the
 # internal helpers.
-_GLOSSARY_REL = Path("docs/guide/for-skill-authors/glossary.md")
+_GLOSSARY_REL = Path(
+    "docs/guide/for-skill-authors/stdlib-authoring-tools/glossary.md"
+)
 
 
 def _project_root() -> Path:
     """Return the project root (= ancestor of ``src/reyn``)."""
-    return Path(__file__).parent.parent.parent.parent
+    # src/reyn/interfaces/slash/concept.py → root is 5 parents up
+    # (slash → interfaces → reyn → src → root). #1682 broad-#5 A1 moved
+    # this module one level deeper (reyn/slash → reyn/interfaces/slash);
+    # the default-glossary parent-walk needs the extra hop (tests inject
+    # _glossary_path, so the default path was not exercised by CI).
+    return Path(__file__).parent.parent.parent.parent.parent
 
 
 def _default_glossary_path() -> Path:
@@ -135,7 +143,8 @@ def _lookup(
 # ── slash command ──────────────────────────────────────────────────────────
 
 _GLOSSARY_PATH_HINT = (
-    "Full glossary: Ctrl+B → Docs → guide/for-skill-authors/glossary"
+    "Full glossary: Ctrl+B → Docs → "
+    "guide/for-skill-authors/stdlib-authoring-tools/glossary"
 )
 
 

--- a/tests/test_slash_concept.py
+++ b/tests/test_slash_concept.py
@@ -264,3 +264,35 @@ def test_concept_in_registry() -> None:
     cmd = REGISTRY.get("concept")
     assert cmd is not None
     assert cmd.name == "concept"
+
+
+# ── regression: the REAL default glossary path (no injection) ──────────────
+#
+# Every test above injects glossary_path, so a broken DEFAULT path was
+# invisible to CI. Two defects hid here at once: the #1682 A1 package move
+# (reyn/slash → reyn/interfaces/slash) added a directory level that the
+# _project_root() parent-walk did not account for, AND the glossary file had
+# been relocated under stdlib-authoring-tools/ (#1091) without _GLOSSARY_REL
+# being updated. These exercise the real, non-injected path end-to-end.
+
+
+def test_default_glossary_path_resolves_to_real_file() -> None:
+    """Tier 2: the shipped default glossary path resolves to an existing file."""
+    from reyn.interfaces.slash.concept import _default_glossary_path
+
+    path = _default_glossary_path()
+    assert path.exists(), f"default glossary path does not resolve: {path}"
+
+
+def test_default_glossary_loads_canonical_terms() -> None:
+    """Tier 2: the real shipped glossary parses to a non-empty map with a stable core term."""
+    from reyn.interfaces.slash.concept import (
+        _default_glossary_path,
+        _parse_glossary,
+    )
+
+    glossary = _parse_glossary(
+        _default_glossary_path().read_text(encoding="utf-8")
+    )
+    assert len(glossary) > 0
+    assert "skill" in glossary  # foundational reyn concept, stable across edits


### PR DESCRIPTION
**[tui-coder]** — bug fix surfaced during broad-#5 B1. The `/concept` slash command's DEFAULT glossary lookup resolves to a non-existent file on `main` right now — two compounding defects, invisible to CI because **every** test in `test_slash_concept.py` injects `glossary_path` and never exercises the real default.

## Defects
1. **Depth-sensitive parent-walk (my #1711 regression).** #1682 A1 moved this module `reyn/slash` → `reyn/interfaces/slash` (one level deeper). `_project_root()` did `Path(__file__).parent.parent.parent.parent` → after the move that returns `src/`, not repo-root. So `_default_glossary_path()` → `src/docs/.../glossary.md` (missing). **+1 parent.**
2. **Relocated glossary (pre-existing, since #1091).** The docs-nav restructure moved `glossary.md` under `stdlib-authoring-tools/`, but `_GLOSSARY_REL`, the user-facing `_GLOSSARY_PATH_HINT`, and the module docstring still pointed at the old `docs/guide/for-skill-authors/glossary.md`. **Repointed all three.**

Before: `_project_root()` → `…/src`; `_default_glossary_path().exists()` → False.
After: `_project_root()` → repo root; default glossary resolves + parses **39 terms** end-to-end.

## Why CI didn't catch it
The depth-sensitive `__file__`-parent-walk class breaks when a module moves but its target (repo-root `docs/`) does not move with it. The same class hit `dev/dogfood/publish.py` in B1 — there the pre-push full-suite caught it (4 tests). Here the only test path injected the glossary, so the default was never exercised.

## Fix + guard
- `_project_root()` parent-walk +1 (with comment).
- `_GLOSSARY_REL` + path hint + docstring → `stdlib-authoring-tools/glossary.md`.
- **2 new Tier-2 regression tests** exercising the real non-injected default path (resolves + parses a stable core term "skill").

## Test plan
- [x] `pytest tests/test_slash_concept.py` — 16 passed (14 existing + 2 new)
- [x] ruff check (concept.py + test) — clean
- [x] manual: `_default_glossary_path().exists()` → True, parses 39 terms
- [x] (skipped — TUI-run visual) covered by the end-to-end parse assertion

Tier note: 2 tests added, both Tier 2 (real shipped behavior via public helpers, non-brittle — "skill" is a foundational term). Per testing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
