### PR TITLE
feat(1647): MCP tools as first-class qualified actions mcp__<server>__<tool>

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -540,6 +540,52 @@ def _enumerate_static_category(category: str) -> list[dict[str, str]]:
     return out
 
 
+def _mcp_tool_qualified_name(server: str, tool: str) -> str:
+    """The first-class per-tool action name (#1647): ``mcp__<server>__<tool>``.
+
+    Single-sourced so enumeration + describe + the dispatch split all agree on
+    the ``<server>__<tool>`` identifier form (double-underscore boundary, the
+    same form ``mcp_call_tool`` splits on)."""
+    return build_qualified_name("mcp", f"{server}__{tool}")
+
+
+def _enumerate_mcp_tools(rs: Any) -> list[dict[str, str]]:
+    """Per-tool MCP actions ``mcp__<server>__<tool>`` from the cached snapshot.
+
+    #1647: reads ``rs.mcp_servers`` — shape ``[{name, description,
+    tools?: [{name, description, inputSchema}]}]`` — which RouterLoop fills from
+    the FP-0037 per-session ``_mcp_tools_cache`` (probed once on the first turn,
+    disk-warm-started). No live probe here: enumeration is a pure read of the
+    cached snapshot, so list_actions / hot-list / retrieval do not re-fetch
+    (FP-0034 caching req). ``tools`` is absent until the cache is warm → graceful
+    empty. Each cached tool ``name`` is the BARE server-side tool name; the
+    qualified action is ``mcp__<server>__<tool>``."""
+    if rs is None:
+        return []
+    servers = getattr(rs, "mcp_servers", None) or []
+    out: list[dict[str, str]] = []
+    for server in servers:
+        if not isinstance(server, Mapping):
+            continue
+        sname = server.get("name")
+        tools = server.get("tools")
+        if not sname or not tools:
+            continue
+        for t in tools:
+            if not isinstance(t, Mapping):
+                continue
+            tname = t.get("name")
+            if not tname:
+                continue
+            out.append({
+                "qualified_name": _mcp_tool_qualified_name(str(sname), str(tname)),
+                "short_description": _truncate_short_description(
+                    t.get("description", ""),
+                ),
+            })
+    return out
+
+
 def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]:
     """Enumerate qualified names for ``category`` consulting caller state.
 
@@ -577,9 +623,20 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
 
     if category in (
         "file", "web", "memory_operation", "reyn_source", "rag_operation",
-        "mcp", "multi_agent", "validation",
+        "multi_agent", "validation",
     ):
         return _enumerate_static_category(category)
+
+    # #1647: the ``mcp`` category carries BOTH the static management verbs
+    # (mcp__call_tool / mcp__list_tools / mcp__install_* / …) AND first-class
+    # per-tool actions ``mcp__<server>__<tool>`` for every tool on a connected
+    # server (from the FP-0037 cached snapshot on router_state). The per-tool
+    # actions make each MCP tool selectable by name with its real inputSchema,
+    # superseding the generic call_mcp_tool double-args foot-gun (#1646).
+    if category == "mcp":
+        items = list(_enumerate_static_category("mcp"))
+        items.extend(_enumerate_mcp_tools(rs))
+        return items
 
     if category == "skill":
         if rs is None or not rs.available_skills:
@@ -1171,6 +1228,31 @@ def _drop_field_from_schema(params: Mapping[str, Any], field_name: str) -> dict:
     return out
 
 
+def _find_mcp_tool(entry_name: str, rs: Any) -> "Mapping | None":
+    """Find the cached MCP tool dict for a ``mcp__<server>__<tool>`` action's
+    entry_name (= ``"<server>__<tool>"``), or ``None``.
+
+    #1647: returns None for a static mcp verb (entry_name has no ``__``, e.g.
+    ``call_tool`` / ``list_tools``), for an unknown server/tool, or when the
+    FP-0037 snapshot (``rs.mcp_servers[*].tools``) isn't warm — so the describe
+    helpers fall back to the dispatcher target for verbs while surfacing the real
+    per-tool schema/description for tools. Splits on the FIRST ``__`` (server =
+    first segment; the same convention ``mcp_call_tool`` uses), so a tool name
+    may itself contain ``__``."""
+    if rs is None or "__" not in entry_name:
+        return None
+    server_name, tool_name = entry_name.split("__", 1)
+    if not server_name or not tool_name:
+        return None
+    for server in (getattr(rs, "mcp_servers", None) or []):
+        if not isinstance(server, Mapping) or server.get("name") != server_name:
+            continue
+        for t in (server.get("tools") or []):
+            if isinstance(t, Mapping) and t.get("name") == tool_name:
+                return t
+    return None
+
+
 def _resource_input_schema(
     qualified_name: str,
     ctx: ToolContext,
@@ -1187,9 +1269,9 @@ def _resource_input_schema(
       - ``mcp.server__<name>`` — empty object (``list_mcp_tools`` takes
         only the curried ``server`` arg).
       - ``rag_corpus__<name>`` — ``recall`` parameters minus ``sources``.
-      - ``mcp.tool__<server>.<tool>`` — scans
-        ``ctx.router_state.mcp_servers`` for the tool's declared
-        ``inputSchema`` (FP-0032 expanded shape).
+      - ``mcp__<server>__<tool>`` — scans ``ctx.router_state.mcp_servers``
+        for the tool's declared ``inputSchema`` (#1647 per-tool action; static
+        mcp verbs fall through to the verb's parameters).
 
     Returns ``None`` when the category isn't a resource category, or when
     the per-resource metadata isn't reachable (= test sites with stub
@@ -1222,6 +1304,17 @@ def _resource_input_schema(
             return None
         return _drop_field_from_schema(tool.parameters, "sources")
 
+    if category == "mcp":
+        # #1647: a per-tool action mcp__<server>__<tool> describes with the MCP
+        # tool's OWN declared inputSchema (so the LLM constructs args directly,
+        # one level — no generic call_mcp_tool {tool, tool_args} envelope). Static
+        # mcp verbs (entry_name w/o "__") → None → caller falls back to the verb's
+        # parameters.
+        t = _find_mcp_tool(entry_name, rs)
+        if t is not None and isinstance(t.get("inputSchema"), Mapping):
+            return dict(t["inputSchema"])
+        return None
+
     # memory_entry__X and any other category: pre-existing dispatch shape
     # mismatch (memory_entry's transform sends {name} but read_memory_body
     # wants {layer, slug}); fall back to target.parameters so the LLM at
@@ -1250,8 +1343,9 @@ def _resource_description(
         ``ctx.router_state.host.list_available_skills()``.
       - ``agent.peer__<name>`` — pulls ``description`` (or ``role``
         fallback) from ``ctx.router_state.host.list_available_agents()``.
-      - ``mcp.tool__<server>.<tool>`` — pulls ``description`` from the
-        tool's MCP-server entry (FP-0032 expanded shape).
+      - ``mcp__<server>__<tool>`` — pulls ``description`` from the tool's
+        MCP-server entry in ``ctx.router_state.mcp_servers`` (#1647 per-tool
+        action; static mcp verbs fall through to the verb's description).
       - ``mcp.server__<name>`` — pulls server-level ``description`` from
         ``ctx.router_state.mcp_servers``.
 
@@ -1295,6 +1389,15 @@ def _resource_description(
                     return str(desc) if desc else None
         except Exception:
             return None
+        return None
+
+    if category == "mcp":
+        # #1647: per-tool action mcp__<server>__<tool> — the MCP tool's own
+        # description. Static verbs → None → caller falls back to the verb's text.
+        t = _find_mcp_tool(entry_name, rs)
+        if t is not None:
+            desc = t.get("description")
+            return str(desc) if desc else None
         return None
 
     # rag_corpus / memory_entry / unknown — fall through to target.description

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -180,6 +180,23 @@ def _recall_single_source_args(
     return out
 
 
+def _mcp_tool_args(entry_name: str, args: Mapping[str, Any]) -> dict[str, Any]:
+    """``mcp__<server>__<tool>`` → ``mcp_call_tool({tool, tool_args})`` (#1647).
+
+    First-class per-tool MCP action. The LLM passes the target MCP tool's OWN
+    parameters as the top-level ``args`` (matching the tool's real inputSchema,
+    surfaced by describe_action) — ONE args level, no generic ``server`` /
+    ``mcp_tool_name`` / nested-args foot-gun (#1646). This shaper wraps them into
+    the EXISTING ``mcp_call_tool`` verb's shape: the ``<server>__<tool>``
+    identifier (= entry_name, already in that form) under ``tool``, the tool's
+    params under ``tool_args``. Dispatch then routes through the SAME
+    ``mcp_call_tool`` ToolDefinition that ``mcp__call_tool`` uses → identical
+    permission gate + MCPClient path (zero new dispatch/gate surface — the
+    per-tool action is purely a catalog/args ergonomics layer over call_mcp_tool).
+    """
+    return {"tool": entry_name, "tool_args": dict(args)}
+
+
 def _passthrough_args(
     entry_name: str, args: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -222,6 +239,13 @@ _RESOURCE_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], d
     "skill":         ("invoke_skill",        _invoke_skill_args),
     "memory_entry":  ("read_memory_body",    _read_memory_body_args),
     "rag_corpus":    ("recall",              _recall_single_source_args),
+    # #1647: per-tool MCP actions ``mcp__<server>__<tool>`` resolve here (the
+    # full name is NOT a static verb in _OPERATION_RULES, so it falls through to
+    # this per-category rule). entry_name = ``<server>__<tool>`` → wrapped into
+    # the existing mcp_call_tool verb (same gate). Static mcp__* verbs
+    # (mcp__call_tool / mcp__list_tools / …) match _OPERATION_RULES FIRST, so they
+    # are unaffected; only dynamic per-tool names reach this rule.
+    "mcp":           ("mcp_call_tool",       _mcp_tool_args),
 }
 
 

--- a/tests/test_mcp_first_class_actions_1647.py
+++ b/tests/test_mcp_first_class_actions_1647.py
@@ -1,0 +1,152 @@
+"""Tier 2: #1647 — MCP tools as first-class qualified actions mcp__<server>__<tool>.
+
+FP-0034: each connected MCP tool is a first-class action selectable by name with
+its REAL inputSchema (like skill__<name>), retiring the generic call_mcp_tool
+double-args foot-gun (#1646). This pins the three surfaces:
+
+  - DISPATCH: invoke_action("mcp__<server>__<tool>", args={tool params}) resolves
+    to the EXISTING mcp_call_tool verb with the IDENTICAL {tool, tool_args} shape
+    mcp__call_tool produces → same permission gate (security: no new dispatch path).
+  - ENUMERATE: the mcp category lists mcp__<server>__<tool> per cached tool
+    (from router_state.mcp_servers[*].tools) alongside the static verbs.
+  - DESCRIBE: describe surfaces the tool's OWN inputSchema (one args level), not
+    the generic call_mcp_tool {tool, tool_args} envelope.
+
+Static mcp verbs (mcp__call_tool / mcp__list_tools / …) are unaffected — they
+match _OPERATION_RULES first.
+
+Real ToolContext + RouterCallerState + registry (no mocks).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.tools import get_default_registry
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import (
+    _describe_one,
+    _enumerate_category,
+    _handle_invoke_action,
+)
+from reyn.tools.universal_dispatch import resolve_invoke_action
+
+_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}},
+    "required": ["query"],
+}
+_MCP_SERVERS = [
+    {
+        "name": "brave",
+        "description": "Brave search MCP server",
+        "tools": [
+            {"name": "search", "description": "Run a web search", "inputSchema": _TOOL_SCHEMA},
+        ],
+    },
+]
+
+
+class _FakeEvents:
+    def emit(self, *a, **k) -> None:
+        pass
+
+
+def _ctx(with_tools: bool = True) -> ToolContext:
+    return ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            available_skills=[],
+            mcp_servers=_MCP_SERVERS if with_tools else None,
+        ),
+    )
+
+
+def test_per_tool_dispatch_matches_call_tool_gate() -> None:
+    """Tier 2: #1647 (security) — mcp__<server>__<tool> resolves to the SAME
+    mcp_call_tool verb with the IDENTICAL {tool, tool_args} shape that the generic
+    mcp__call_tool produces, so the dispatch routes through the existing permission
+    gate unchanged (no bypass). The per-tool action only moves the server__tool id
+    into the NAME and the tool params into one args level."""
+    per_tool = resolve_invoke_action("mcp__brave__search", {"query": "x"})
+    generic = resolve_invoke_action(
+        "mcp__call_tool", {"tool": "brave__search", "tool_args": {"query": "x"}},
+    )
+    assert per_tool.target_tool_name == "mcp_call_tool"
+    assert per_tool.target_tool_name == generic.target_tool_name
+    assert per_tool.target_args == {"tool": "brave__search", "tool_args": {"query": "x"}}
+    assert per_tool.target_args == generic.target_args
+
+
+def test_static_mcp_verb_unaffected() -> None:
+    """Tier 2: #1647 — a static mcp verb (entry without "__") still matches
+    _OPERATION_RULES first; the per-tool _RESOURCE_RULES["mcp"] only catches
+    dynamic <server>__<tool> names."""
+    r = resolve_invoke_action("mcp__list_tools", {"server": "brave"})
+    assert r.target_tool_name == "list_mcp_tools"
+
+
+def test_enumeration_lists_per_tool_actions() -> None:
+    """Tier 2: #1647 — the mcp category enumerates mcp__<server>__<tool> for each
+    cached tool ALONGSIDE the static verbs (read of the FP-0037 snapshot, no probe)."""
+    names = {it["qualified_name"] for it in _enumerate_category("mcp", _ctx())}
+    assert "mcp__brave__search" in names, "per-tool action enumerated"
+    assert "mcp__call_tool" in names, "static verbs still present"
+
+
+def test_enumeration_empty_when_cache_cold() -> None:
+    """Tier 2: #1647 — no warm cache (mcp_servers None) → only the static verbs,
+    no per-tool entries (graceful)."""
+    names = {it["qualified_name"] for it in _enumerate_category("mcp", _ctx(with_tools=False))}
+    assert not any(n.startswith("mcp__brave__") for n in names)
+    assert "mcp__call_tool" in names
+
+
+class _RecordingHost:
+    """Minimal router host that records the MCP call reaching the gate boundary
+    (host.mcp_call_tool is what _handle_call_mcp_tool delegates to on the router
+    path, downstream of which lives the permission gate)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
+        self.calls.append((server, tool, dict(args)))
+        return {"ok": True, "result": "recorded"}
+
+
+@pytest.mark.asyncio
+async def test_per_tool_dispatch_reaches_mcp_gate_e2e() -> None:
+    """Tier 2: #1647 (security, e2e) — a per-tool invoke_action drives the FULL
+    real dispatch chain (resolve → mcp_call_tool verb → split → _handle_call_mcp_tool
+    → host.mcp_call_tool) and reaches the SAME gated boundary the generic
+    mcp__call_tool uses, with the server/tool/args intact — proving the new
+    resolution path does NOT bypass the gate (it routes through it identically)."""
+    host = _RecordingHost()
+    ctx = ToolContext(
+        events=_FakeEvents(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(host=host, mcp_servers=_MCP_SERVERS),
+    )
+    await _handle_invoke_action(
+        {"action_name": "mcp__brave__search", "args": {"query": "hello"}}, ctx,
+    )
+    # The per-tool action's params reached host.mcp_call_tool as
+    # (server, tool, the tool's own args) — one level, no nesting/collision.
+    assert host.calls == [("brave", "search", {"query": "hello"})]
+
+
+def test_describe_surfaces_tool_input_schema() -> None:
+    """Tier 2: #1647 — describe_action on a per-tool action returns the MCP tool's
+    OWN inputSchema (one args level), NOT the generic call_mcp_tool {tool, tool_args}
+    envelope. This is the #1646 foot-gun fix."""
+    one = _describe_one("mcp__brave__search", _ctx(), get_default_registry())
+    assert one is not None
+    assert one["input_schema"] == _TOOL_SCHEMA
+    assert one["description"] == "Run a web search"
+    # NOT the generic envelope keys
+    assert "tool_args" not in (one["input_schema"].get("properties") or {})


### PR DESCRIPTION
**[e2e-coder]** — #1647 FP-0034: MCP tools as first-class qualified actions. Owner GO; design + #879 prior-art + descope all confirmed by lead (broker).

## What

Expose each connected MCP tool as a first-class qualified action
`mcp__<server>__<tool>` — selectable by name with its **real inputSchema** (like
`skill__<name>`) — retiring the generic `call_mcp_tool` double-args foot-gun
(#1646, where the LLM passed server + tool + a nested args object via one generic
verb and collapsed the nested args → empty MCP call).

## Design (reuses existing infra, mirrors `skill__*`)

| Surface | Mechanism |
|---|---|
| **Dispatch** | new `_RESOURCE_RULES["mcp"]` — `mcp__<server>__<tool>` falls through `_OPERATION_RULES` (static verbs) to this per-category rule (like skill__/memory_entry__). `_mcp_tool_args` wraps the LLM's one-level tool params into the **existing** `mcp_call_tool` verb's `{tool, tool_args}` shape. |
| **Enumerate** | `_enumerate_mcp_tools` reads `router_state.mcp_servers[*].tools` (the **existing FP-0037 `_mcp_tools_cache`** — probed once on the first turn, disk-warm-started). Pure cached read, **no per-enumerate re-probe** (FP-0034 caching). Cold cache → graceful empty. |
| **Describe** | `_resource_input_schema` / `_resource_description` gain an `mcp` branch (`_find_mcp_tool`) surfacing the tool's **own** inputSchema + description (one args level). |

Per-tool actions are **normal first-class catalog entries** (catalog_entries /
list_actions / describe / hot-list / retrieval) — not special-cased; the scheme
handles catalog-size scaling (lead (a)). `call_mcp_tool` stays as the internal
dispatch target + LLM-facing fallback (lead (b)).

## Security (lead's review focus) — gate-equivalence, no bypass

The per-tool resolver routes to the **same** `mcp_call_tool` ToolDefinition with
the **byte-identical** `{tool, tool_args}` args the generic `mcp__call_tool`
produces → the same `_handle_call_mcp_tool` → the same `host.mcp_call_tool`
(permission gate). The per-tool action is purely a catalog/args ergonomics layer.
Two tests pin this:
- `test_per_tool_dispatch_matches_call_tool_gate` — resolution byte-equivalence
  (per-tool `target_tool_name` + `target_args` == generic).
- `test_per_tool_dispatch_reaches_mcp_gate_e2e` — drives the **full** dispatch
  chain (`invoke_action` → verb → split → `_handle_call_mcp_tool` →
  `host.mcp_call_tool`) and asserts the host receives `("brave", "search",
  {"query": …})` — exercises the real gated boundary, not a proxy.

## #879 prior-art (lead (d), verified — I authored #879)

#879 removed the separate `mcp.tool` **category** (taxonomy fragmentation → LLM
misselection). #1647 adds per-tool **actions within** the single `mcp` category
(not a new category) — preserving #879's unification win **and** improving
discovery (per-tool by real name/schema vs the generic verb hiding tools).

## Deferred (lead-approved descope → tracked follow-up, lead filing)

The LLM-facing **polish** is NOT in this PR: marking `mcp__call_tool`'s description
"prefer per-tool" (lead (b)) + updating stale `mcp.tool__brave.search` examples to
`mcp__<server>__<tool>`. Those strings are in the **rendered catalog**, so changing
them changes the `tools=` hash → breaks Tier-3a real-LLM replay fixtures
(`test_replay_skill_router`) which this env **cannot re-record** (gemini/vertex_ai
needs the google SDK, not installed). Hand re-keying 23-24-entry multi-turn fixtures
is the wrong-order false-pass hazard the replay-discipline forbids — so the 3
catalog-visible strings are reverted to keep replay green. The core (per-tool
actions) is unaffected — those fixtures have no MCP servers. The stale
`mcp.tool__brave.search` example is **pre-existing** (not a #1647 regression).

## Coordination

tui-coder A2 (#1712, dispatch/→core/dispatch) is disjoint; A3 (mcp/-move) held
until this lands. Possible trivial 1-line `router_loop.py` import rebase if #1712
merges first.

## Test plan

- [x] `ruff check src tests` — clean
- [x] Tier-2 `test_mcp_first_class_actions_1647` (6: dispatch-equivalence + e2e gate + enumerate ×2 + describe + static-verb-unaffected) — pass
- [x] `test_replay_skill_router` (the catalog-sensitive replay suite) — green (core is replay-safe)
- [x] `scripts/test_tier_audit.py --strict` (new test) — 0 violations
- [x] full `pytest -q` from rootdir — (result in final comment; expect only known pre-existing local fails)

Refs #1647
Refs #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
