### PR TITLE
refactor(#1682): harden repo-root __file__-walks to reyn.__file__ package-anchor

### DIFF
--- a/src/reyn/dev/dogfood/publish.py
+++ b/src/reyn/dev/dogfood/publish.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import reyn
+
 logger = logging.getLogger(__name__)
 
 _GRAPHQL_URL = "https://api.github.com/graphql"
@@ -31,11 +33,12 @@ _DEFAULT_CATEGORY_ID = "DIC_kwDOSWAku84C9M8T"
 _DEFAULT_REPO_NODE_ID = "R_kgDOSWAkuw"
 
 _DEFAULT_TEMPLATE_PATH = (
-    # src/reyn/dev/dogfood/publish.py → repo root is 5 parents up
-    # (dogfood → dev → reyn → src → root). #1682 broad-#5 B1 moved this
-    # module one level deeper (reyn/dogfood → reyn/dev/dogfood), so the
-    # parent-walk gained one hop.
-    Path(__file__).parent.parent.parent.parent.parent
+    # Anchored on the reyn PACKAGE root (reyn.__file__ = src/reyn/__init__.py
+    # → src/reyn → src → repo root, 3 parents), NOT this module's own
+    # __file__. A parent-count off this module re-breaks on every regroup
+    # (it did in #1682 B1: reyn/dogfood → reyn/dev/dogfood); the package
+    # anchor is move-robust by construction.
+    Path(reyn.__file__).resolve().parent.parent.parent
     / "docs"
     / "deep-dives"
     / "contributing"

--- a/src/reyn/interfaces/slash/concept.py
+++ b/src/reyn/interfaces/slash/concept.py
@@ -21,6 +21,7 @@ import difflib
 import re
 from pathlib import Path
 
+import reyn
 from reyn.interfaces.slash import reply, reply_error, slash
 
 # Canonical path relative to the project root.  Resolved at call time so
@@ -32,13 +33,17 @@ _GLOSSARY_REL = Path(
 
 
 def _project_root() -> Path:
-    """Return the project root (= ancestor of ``src/reyn``)."""
-    # src/reyn/interfaces/slash/concept.py → root is 5 parents up
-    # (slash → interfaces → reyn → src → root). #1682 broad-#5 A1 moved
-    # this module one level deeper (reyn/slash → reyn/interfaces/slash);
-    # the default-glossary parent-walk needs the extra hop (tests inject
-    # _glossary_path, so the default path was not exercised by CI).
-    return Path(__file__).parent.parent.parent.parent.parent
+    """Return the project root (= ancestor of ``src/reyn``).
+
+    Anchored on the ``reyn`` PACKAGE root (``reyn.__file__`` =
+    ``src/reyn/__init__.py``), not this module's own ``__file__`` — so the
+    walk is stable regardless of where this module lives. A parent-count
+    off this module's path re-breaks every time the module is regrouped
+    (it did in #1682 A1: reyn/slash → reyn/interfaces/slash). The package
+    anchor is move-robust by construction.
+    """
+    # src/reyn/__init__.py → src/reyn → src → repo root  (3 parents)
+    return Path(reyn.__file__).resolve().parent.parent.parent
 
 
 def _default_glossary_path() -> Path:


### PR DESCRIPTION
**[tui-coder]** — broad-#5 follow-up: harden the 2 repo-root `__file__`-parent-walks to the move-robust `reyn.__file__` package-anchor idiom (issue #1682). Closes the depth-sensitive class that surfaced twice this wave.

## Why
`concept.py` (`_project_root`) and `dev/dogfood/publish.py` (`_DEFAULT_TEMPLATE_PATH`) computed repo-root by counting parents off their OWN `__file__`. That re-breaks on every regroup: A1 (`reyn/slash` → `reyn/interfaces/slash`) and B1 (`reyn/dogfood` → `reyn/dev/dogfood`) each needed a +1 hop fix (the latter caught pre-push; the former was a latent ship fixed in #1714). A parent-count off a mobile module is fragile by construction.

## Fix
Both now anchor on the `reyn` PACKAGE root:
```python
Path(reyn.__file__).resolve().parent.parent.parent
# src/reyn/__init__.py → src/reyn → src → repo root
```
`reyn.__file__` is stable regardless of where the consuming module lives, so neither re-breaks on a future move. This is the existing `core/kernel/codeact_runner.py` precedent (which anchors on `reyn.__file__` for the same reason). Added `import reyn` to both modules.

## Non-functional
Computes the identical repo-root (verified: both `_default_glossary_path()` and `_DEFAULT_TEMPLATE_PATH` resolve to the same real files as before). Guarded by the existing #1714 concept default-path regression tests + the fp0036_publish tests.

## Verification
- both resolve: concept glossary.md ✓ (39 terms), publish template ✓
- targeted: `tests/test_slash_concept.py` + `tests/test_fp0036_publish.py` + `tests/test_fp0036_interpretation_transcripts.py` → 48 passed
- `ruff check` (both files) → clean
- **full-suite-local: 7316 passed, 0 failed**, 26 = pre-existing artifact

## Test plan
- [x] both paths resolve to the real files (manual)
- [x] targeted concept + publish tests — 48 passed
- [x] full-suite-local — 7316 / 0 failed
- [x] ruff — clean
- [x] (skipped — visual N/A) non-functional path-computation idiom swap

Tier note: no tests added (refactor; existing regression tests already guard). Completes my mechanical structure queue for broad-#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
