### PR TITLE
docs: consolidated source-path sweep for broad-#5 + #7 package moves

### DIFF
--- a/docs/concepts/observability/dogfood-scenarios.ja.md
+++ b/docs/concepts/observability/dogfood-scenarios.ja.md
@@ -191,7 +191,7 @@ reyn dogfood run dogfood/scenarios/chat_router_smoke.yaml --replay dogfood/fixtu
 リプレイモードの実行は `run_id` にタグが付くため、レポートでライブ実行と区別できる。
 フィクスチャはリリースタグごとに再記録される。スキーマ不一致は自動的に再記録を強制する。
 
-リプレイは `src/reyn/testing/replay.py`（`LLMReplay`）上に構築されている。
+リプレイは `src/reyn/dev/testing/replay.py`（`LLMReplay`）上に構築されている。
 フィクスチャ記録の詳細は
 [リプレイテストガイド](../../guide/for-reyn-developers/write-replay-tests.md) を参照。
 

--- a/docs/concepts/observability/dogfood-scenarios.md
+++ b/docs/concepts/observability/dogfood-scenarios.md
@@ -204,7 +204,7 @@ Replay-mode runs are tagged in `run_id` so reports distinguish them from live
 runs. Fixtures are re-recorded on every release tag; a schema mismatch forces
 re-recording automatically.
 
-Replay is built on `src/reyn/testing/replay.py` (`LLMReplay`); see
+Replay is built on `src/reyn/dev/testing/replay.py` (`LLMReplay`); see
 [Replay tests guide](../../guide/for-reyn-developers/write-replay-tests.md) for
 fixture recording mechanics.
 

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -56,10 +56,10 @@ The OS (`kernel/runtime.py`) is the only thing that calls the LLM, executes Cont
 | `src/reyn/core/kernel/runtime.py` | Main OS loop — LLM call, validation, op execution, events |
 | `src/reyn/core/kernel/control_ir_executor.py` | Dispatches Control IR ops from the OS to op handlers |
 | `src/reyn/core/op_runtime/registry.py` | Single source of truth for op kinds, Pydantic models, purity classification |
-| `src/reyn/context_builder.py` | Builds the ContextFrame injected into every LLM call (P4 candidates here) |
+| `src/reyn/core/context_builder.py` | Builds the ContextFrame injected into every LLM call (P4 candidates here) |
 | `src/reyn/schemas/models.py` | All Pydantic models — Phase, Skill, SkillGraph, ControlIROp, CandidateOutput |
 | `src/reyn/core/events/events.py` | Append-only EventLog (P6) |
-| `src/reyn/workspace/workspace.py` | Workspace read/write with permission gating (P5) |
+| `src/reyn/data/workspace/workspace.py` | Workspace read/write with permission gating (P5) |
 | `src/reyn/core/compiler/linter.py` | Static validation — graph cycles, allowed_ops spelling, P7 checks |
 | `src/reyn/core/compiler/expander.py` | Loads and expands Skill + Phase from `.md` + `.yaml` files |
 


### PR DESCRIPTION
**[docs-maintainer]** — the single consolidated docs-drift sweep for the landed broad-#5 + #7 mechanical moves (per lead-coder's post-A3 batch ping). Audited `origin/main` (e7096714); ls-tree-enumerated every new package.

## Finding: small living-doc footprint
The full move set (data/ #1706, slash→interfaces #1711, dispatch→core #1712, dev/ #1716, runtime/ #1717, search_backends→tools #1718, mcp-shim-deletion #1720, #7 #1721) had only **3 living-doc source-path refs** left — most were already swept (core/security/interfaces in #1701/#1708; for-* guides + CLAUDE.md + control-ir inline in #1707) or are historical.

## Fixes (3 files, 4 lines)
| File | old → new |
|---|---|
| `for-reyn-developers/index.md` | `context_builder.py` → `core/context_builder.py` |
| `for-reyn-developers/index.md` | `workspace/workspace.py` → `data/workspace/workspace.py` |
| `dogfood-scenarios.md` + `.ja` | `testing/replay.py` → `dev/testing/replay.py` |

## Discipline applied
- **ls-tree-before-grep** per new package (data/dev/runtime/tools/config/core enumerated — the #1708 sub-move lesson)
- **explicit per-term greps** (not combined-alternation — the registry-miss lesson), all 19 moved modules, dotted + file-path forms → 0 remaining in living docs
- **explicit-path staging** (no `git add -A` — the #1708 BOOTSTRAP lesson)

## Preserved (NOT repointed — verified)
- Runtime data paths: `.reyn/memory`, `.reyn/index`, `.reyn/cron.yaml`, `.reyn/events`, `workspace_dir` (≠ the moved packages)
- Stayed-flat: `agent.py`, `schemas/`, `_cli.py`, `user_intervention.py`, `intervention_choices.py`
- `mcp_client`/`mcp_server` living refs already fixed in #1688; remaining are historical (ADR 0030 + journals)

## Left historical (no-touch)
journal/, ADRs/decisions, proposals/, research/, audits/, spec/design

## Test plan
- [x] `mkdocs build --strict` → exit 0
- [x] exhaustive living-doc grep (19 modules, both forms) → 0 remaining
- [x] runtime `.reyn/*` paths confirmed preserved; new `core/`,`data/`,`dev/` paths confirmed present in origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)