### PR TITLE
docs(1608): correct stale format_feedback-divergence comment (unification landed in #1611)

### DIFF
--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -2121,12 +2121,16 @@ class RouterLoop:
                 # CodeActRunner — each in-code tool() call re-enters the SAME exclude
                 # + dispatch_tool + permission gate per call (so a CodeAct call is
                 # gated >= a JSON call) — then append the [assistant: code] turn + the
-                # scheme's format_feedback message(s) and loop. Separate path from the
-                # Execute zip (a CodeBlock turn has no tool_calls): the scheme OWNS the
-                # feedback message shape, the OS only appends (no synthetic tool_call =
-                # provider-safe). Documented contract divergence (Execute →
-                # tool_results-for-zip / CodeBlock → messages-for-append); unification
-                # is a tracked follow-up, out of PR-3 scope.
+                # scheme's format_feedback message(s) and loop. A CodeBlock turn has
+                # no tool_calls, so the scheme returns observation message(s) and the
+                # OS only appends (no synthetic tool_call = provider-safe). #1608
+                # (#1611) UNIFIED format_feedback to a SINGLE-SHAPE appendable-messages
+                # contract across BOTH paths: the Execute arm delegates to ops.feedback
+                # (the assistant + {role:tool, tool_call_id} zip relocated there, so the
+                # OS no longer knows the JSON correlation shape — P7), this CodeBlock arm
+                # returns observation messages; the OS *appends* in either case. The arms
+                # stay separate because the INTERPRETATION differs (snippet vs tool_calls),
+                # not because the feedback shape differs.
                 cb_feedback = await self._run_codeblock_round(interp)
                 _cb_content = result.content or ""
                 messages.append({"role": "assistant", "content": _cb_content})


### PR DESCRIPTION
**[e2e-coder]** — #1608 follow-up. Owner GO'd #1608 but the substance **already landed** (#1611 Stage-1 unify + #1612 ④ self-register) — lead confirmed no Stage-2; this PR is the only residual.

## What

The CodeBlock-arm comment in `router_loop.py` still claimed:
> Documented contract divergence (Execute → tool_results-for-zip / CodeBlock → messages-for-append); unification is a tracked follow-up, out of PR-3 scope.

That is now **false**. #1608 Stage-1 (#1611) unified `format_feedback` to a
**single-shape appendable-messages** contract (option 1): the Execute arm's
assistant + `{role:tool, tool_call_id}` zip was relocated into `ops.feedback` (so
the OS no longer knows the JSON correlation shape — **P7**), and the OS only
*appends* in both the Execute and CodeBlock arms. The arms stay separate because the
**interpretation** differs (snippet vs tool_calls), not the feedback shape.

Comment-only correction; cites #1611.

## Verify-before-impl note

This started as a re-dispatch of #1608, but `git log --grep 1608` + reading the
current `run_loop` arms showed the unification + its byte-identical golden gate
(`test_format_feedback_golden_1608`) already landed (#1611/#1612) — so no
re-implementation, just the stale-comment fix. The 3 Execute schemes now
`return ops.feedback(result)`; run_loop:2643 appends `format_feedback` messages; the
#1608 suite is green (20 tests).

## Test plan

- [x] `ruff check src/reyn/chat/router_loop.py` — clean
- [x] `test_format_feedback_golden_1608` + `test_codeact_scheme_1593` — 12 passed (comment-only; unchanged behavior)

`Refs #1608` (lead closes the issue on merge with the #1611/#1612-delivered note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)