### PR TITLE
docs(guide): update stale agent.py ref → skill_runtime.py (#1724 rename)

### DIFF
--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -29,7 +29,7 @@ Reyn routes your request to the right built-in skill automatically — you don't
 |---|---|
 | Ask questions | `"What's the capital of France?"` |
 | Summarize files | `"Summarize README.md"` |
-| Work on local files | `"What functions are in src/reyn/agent.py?"` |
+| Work on local files | `"What functions are in src/reyn/skill_runtime.py?"` |
 | Search the web | `"What's the latest release of Python?"` |
 | Run multi-step tasks | `"Research X and write a report"` |
 


### PR DESCRIPTION
**[docs-maintainer]** — #1724 public-API docs-drift sweep (lead-coder GO, independent of the #1725 proposal audit). #1724 renamed `src/reyn/agent.py` → `src/reyn/skill_runtime.py` (class `Agent` → `SkillRuntime`, `reyn.Agent` removed).

## Finding: 1-line living-doc footprint
Explicit grep of living docs for all CODE/public-API Agent forms (`reyn.Agent`, `from reyn import Agent`, `reyn.agent`, `src/reyn/agent.py`, `Agent(` constructor/usage) found **exactly one** stale ref:
- `guide/for-users/index.md:32` — example query `"What functions are in src/reyn/agent.py?"` → `skill_runtime.py`

(The `Agent` class wasn't doc-referenced as public API; docs use conceptual "Agent" prose, which is correctly left untouched.)

## Scope discrimination (per lead-coder)
- **Updated:** the CODE/file-path reference only.
- **LEFT (intentional):** conceptual "Agent" architecture prose (`User→Agent→Skill→OS`) — FP-0043 reintroduces an Agent-identity concept; the holistic conceptual pass lands with that restructure.
- Historical (journal/ADR/proposal/research/audits) — no-touch.

## Test plan
- [x] `mkdocs build --strict` → exit 0
- [x] explicit grep of all CODE/public-API Agent forms in living docs → 0 remaining
- [x] new public form confirmed: `reyn.SkillRuntime` (re-exported) / `reyn.skill_runtime.SkillRuntime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)