### PR TITLE
feat(1726): FP-0043 Stage 3 — Registry holds N Sessions per Agent (byte-identical N=1)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -30,6 +30,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -1427,6 +1428,14 @@ class AgentRegistry:
                 f"agent {name!r} not found; run `reyn agent new {name}` to create it"
             )
         profile = self.load_profile(name)
+        session = self._construct_session(profile)
+        self._store_session(name, session)
+        return session
+
+    def _construct_session(self, profile: AgentProfile) -> "object":
+        """Build a configured Session from a profile (factory + shared-store
+        attach), WITHOUT inserting it into the session map. Shared by get_or_load
+        (default session) and spawn_session (additional sessions) — FP-0043 S3."""
         session = self._factory(profile)
         # ADR-0038 Stage 1d: hand the session the single shared workspace
         # shadow-git store so cut_generation captures the workspace at each
@@ -1441,8 +1450,29 @@ class AgentRegistry:
         attach_anchor = getattr(session, "attach_anchor_store", None)
         if anchors is not None and callable(attach_anchor):
             attach_anchor(anchors)
-        self._store_session(name, session)
         return session
+
+    def spawn_session(self, name: str, sid: "str | None" = None) -> str:
+        """FP-0043 Stage 3: open a NEW conversation Session under an existing
+        Agent, SHARING the agent's identity object. Returns the new session-id.
+
+        Structure-only (lead-confirmed): this lets the Registry hold N sessions
+        per agent; INBOUND routing to a non-default session is Stage 4 — until
+        then the default "main" session receives all inbound traffic. The new
+        session shares ``self._identities[name]`` (the same Agent object, S2's
+        ``agent=`` seam) so identity is genuinely shared, not duplicated."""
+        self.get_or_load(name)  # ensure the default session + _identities[name] exist
+        shared = self._identities.get(name)
+        new_sid = sid or uuid4().hex[:8]
+        if self._has_session(name, new_sid):
+            raise ValueError(f"session {new_sid!r} already exists for agent {name!r}")
+        session = self._construct_session(self.load_profile(name))
+        if shared is not None:
+            # Share the SAME identity object (not the fresh one the factory built),
+            # so a future identity change propagates to all of the agent's sessions.
+            session._agent = shared
+        self._sessions.setdefault(name, {})[new_sid] = session
+        return new_sid
 
     async def ensure_running(self, name: str) -> "object":
         """Load + start session.run() + forwarder for `name` without

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -57,6 +57,10 @@ from .profile import PROFILE_FILENAME, AgentProfile
 from .topology import TOPOLOGY_DIRNAME, Topology, _validate_topology_name
 
 DEFAULT_AGENT_NAME = "default"
+# FP-0043 Stage 3: the implicit per-agent session id. Single-session paths
+# resolve to this id, keeping N=1 behaviour byte-identical. Spawned sessions get
+# generated ids (Stage 4 routes inbound messages to non-default sessions).
+_DEFAULT_SID = "main"
 
 # ADR-0038 1f: WAL-entry-kind → rewind-point boundary label. All inputs are
 # OS-level ``WAL_EVENT_KINDS`` (P7-safe — no skill/domain strings). The three
@@ -137,10 +141,19 @@ class AgentRegistry:
         self._factory = session_factory
         self._state_log = state_log
         self._project_root = project_root
-        self._agents: dict[str, "object"] = {}            # name -> ChatSession
-        self._tasks: dict[str, asyncio.Task] = {}         # name -> session.run() task
-        self._forward_tasks: dict[str, asyncio.Task] = {} # name -> outbox forwarder
-        self._attached: str | None = None
+        # FP-0043 Stage 3: the Registry holds N conversation Sessions per Agent.
+        # Identity (the Agent value object, S2) is shared per name; the
+        # conversation instances (= today's ChatSession, inbox+run-loop+history)
+        # are keyed by an opaque session-id, default ``_DEFAULT_SID`` ("main") so
+        # single-session behaviour is byte-identical. Inbound routing to non-main
+        # sessions is Stage 4 — S3 just lets the structure hold N.
+        self._identities: dict[str, "object"] = {}            # name -> Agent (shared identity)
+        self._sessions: dict[str, dict[str, "object"]] = {}   # name -> {sid -> Session}
+        # Run-loop + outbox-forwarder task handles, keyed by (name, sid) — they are
+        # per-conversation, so they scale with sessions, not identities.
+        self._tasks: dict[tuple[str, str], asyncio.Task] = {}         # (name,sid) -> session.run() task
+        self._forward_tasks: dict[tuple[str, str], asyncio.Task] = {} # (name,sid) -> outbox forwarder
+        self._attached: "tuple[str, str] | None" = None              # (name, sid) focus
         # WAL truncation throttle (skill resume design). monotonic ts of last
         # successful truncation attempt; ``None`` means no throttle is active.
         self._last_truncation_ts: float | None = None
@@ -221,6 +234,40 @@ class AgentRegistry:
                 out.append(entry.name)
         return sorted(out)
 
+    # ── FP-0043 Stage 3: session-store accessors (centralize sid-defaulting) ──
+    # Every former ``self._agents[name]`` access routes through these so the
+    # ~25 internal call-sites + the public API stay correct by construction
+    # (default sid = "main" → byte-identical at N=1). The conversation Session
+    # lives in self._sessions[name][sid]; the shared Agent in self._identities.
+    def _peek_session(self, name: str, sid: str = _DEFAULT_SID) -> "object | None":
+        """Non-loading lookup of a Session (= the former ``self._agents.get(name)``)."""
+        return self._sessions.get(name, {}).get(sid)
+
+    def _store_session(self, name: str, session: "object", sid: str = _DEFAULT_SID) -> None:
+        """Insert a Session under (name, sid), capturing its shared Agent identity."""
+        self._sessions.setdefault(name, {})[sid] = session
+        ident = getattr(session, "_agent", None)
+        if ident is not None:
+            self._identities.setdefault(name, ident)
+
+    def _has_session(self, name: str, sid: str = _DEFAULT_SID) -> bool:
+        return sid in self._sessions.get(name, {})
+
+    def _iter_sessions(self) -> "list[object]":
+        """All conversation Sessions across every (name, sid)."""
+        return [s for sd in self._sessions.values() for s in sd.values()]
+
+    def _iter_named_sessions(self) -> "list[tuple[str, object]]":
+        """(name, Session) for every (name, sid) — for per-agent-name fan-out."""
+        return [(name, s) for name, sd in self._sessions.items() for s in sd.values()]
+
+    def get_session(self, name: str, sid: str = _DEFAULT_SID) -> "object | None":
+        """Public non-loading accessor for a Session (FP-0043 Stage 3) — the
+        supported replacement for external ``registry._agents.get(name)`` reach-in.
+        Defaults to the implicit "main" session (byte-identical to the prior
+        single-session lookup)."""
+        return self._peek_session(name, sid)
+
     def load_profile(self, name: str) -> AgentProfile:
         return AgentProfile.load(self._dir / name)
 
@@ -238,17 +285,21 @@ class AgentRegistry:
     def remove(self, name: str) -> None:
         if name == DEFAULT_AGENT_NAME:
             raise ValueError("cannot remove the default agent")
-        if name == self._attached:
+        if self._attached is not None and self._attached[0] == name:
             raise ValueError(f"cannot remove attached agent {name!r}")
         target = self._dir / name
         if not target.is_dir():
             raise FileNotFoundError(target)
-        # Cancel any cached tasks / drop session before deleting on-disk state.
+        # Cancel any cached tasks / drop sessions before deleting on-disk state.
+        # FP-0043 Stage 3: removing an agent drops ALL its sessions (every sid).
+        sids = list(self._sessions.get(name, {}).keys())
         for task_dict in (self._tasks, self._forward_tasks):
-            task = task_dict.pop(name, None)
-            if task and not task.done():
-                task.cancel()
-        self._agents.pop(name, None)
+            for sid in sids:
+                task = task_dict.pop((name, sid), None)
+                if task and not task.done():
+                    task.cancel()
+        self._sessions.pop(name, None)
+        self._identities.pop(name, None)
         # Recursive rm — agents/<name>/ is reyn-managed, no surprises expected.
         import shutil
         shutil.rmtree(target)
@@ -411,7 +462,7 @@ class AgentRegistry:
         for name, snap in snapshots.items():
             if not snap.active_plan_ids:
                 continue
-            session = self._agents.get(name)
+            session = self._peek_session(name)
             if session is None:
                 continue
             try:
@@ -432,7 +483,7 @@ class AgentRegistry:
         in-flight session and the rewind path share one view of the
         generations dir); otherwise constructs one over the on-disk path.
         """
-        session = self._agents.get(name)
+        session = self._peek_session(name)
         store = getattr(session, "_generation_store", None)
         if isinstance(store, SnapshotGenerationStore):
             return store
@@ -492,7 +543,7 @@ class AgentRegistry:
 
         self._rewind_in_progress = True
         try:
-            sessions = list(self._agents.values())
+            sessions = self._iter_sessions()
             # 2. all-cancel (stop-world).
             for session in sessions:
                 await session.cancel_inflight()
@@ -833,7 +884,7 @@ class AgentRegistry:
             # the head so restore_all's replay floor skips the abandoned segment.
             snap.applied_seq = reconstruct_seq
             snap.save(self._dir / name / "state" / "snapshot.json")
-            session = self._agents.get(name)
+            session = self._peek_session(name)
             if session is not None:
                 await session.reset_for_rewind()
                 session.restore_state(snap)
@@ -1228,7 +1279,7 @@ class AgentRegistry:
         discard path.
         """
         notified = False
-        for name, session in self._agents.items():
+        for name, session in self._iter_named_sessions():
             if name == by_agent_name:
                 continue
             chain_mgr = getattr(session, "_chains", None)
@@ -1344,7 +1395,7 @@ class AgentRegistry:
         """
         seqs: list[int] = []
         now = time.monotonic()
-        for session in self._agents.values():
+        for session in self._iter_sessions():
             iter_method = getattr(session, "iter_applied_seqs", None)
             if iter_method is None:
                 # Conservative: a session shim without the method (test
@@ -1368,8 +1419,9 @@ class AgentRegistry:
 
     def get_or_load(self, name: str) -> "object":
         """Return the ChatSession for `name`, instantiating from profile if new."""
-        if name in self._agents:
-            return self._agents[name]
+        existing = self._peek_session(name)
+        if existing is not None:
+            return existing
         if not self.exists(name):
             raise FileNotFoundError(
                 f"agent {name!r} not found; run `reyn agent new {name}` to create it"
@@ -1389,7 +1441,7 @@ class AgentRegistry:
         attach_anchor = getattr(session, "attach_anchor_store", None)
         if anchors is not None and callable(attach_anchor):
             attach_anchor(anchors)
-        self._agents[name] = session
+        self._store_session(name, session)
         return session
 
     async def ensure_running(self, name: str) -> "object":
@@ -1403,10 +1455,12 @@ class AgentRegistry:
         attach to B, B's pre-existing outbox messages route correctly.
         """
         session = self.get_or_load(name)
-        if name not in self._tasks or self._tasks[name].done():
-            self._tasks[name] = asyncio.create_task(session.run())
-        if name not in self._forward_tasks or self._forward_tasks[name].done():
-            self._forward_tasks[name] = asyncio.create_task(self._forwarder(name))
+        sid = _DEFAULT_SID  # FP-0043 S3: name-keyed API drives the default session
+        key = (name, sid)
+        if key not in self._tasks or self._tasks[key].done():
+            self._tasks[key] = asyncio.create_task(session.run())
+        if key not in self._forward_tasks or self._forward_tasks[key].done():
+            self._forward_tasks[key] = asyncio.create_task(self._forwarder(name, sid))
         return session
 
     async def attach(self, name: str) -> "object":
@@ -1414,9 +1468,11 @@ class AgentRegistry:
         and the outbox forwarder for the new agent if not already running.
         Old agent stays in `self._tasks` (background)."""
         new_session = self.get_or_load(name)
-        old_name = self._attached
-        if old_name and old_name != name:
-            old_session = self._agents.get(old_name)
+        sid = _DEFAULT_SID  # FP-0043 S3: attach(name) focuses the default session
+        key = (name, sid)
+        old = self._attached
+        if old is not None and old != key:
+            old_session = self._peek_session(old[0], old[1])
             if old_session is not None:
                 # Mark detached BEFORE switching so transient outbox emissions
                 # from the old session start dropping at the source
@@ -1426,13 +1482,13 @@ class AgentRegistry:
         new_session.is_attached = True
         # Boot session.run() + forwarder on first attach. Keep them alive
         # across detach/re-attach cycles — shutdown drains via `running_tasks()`.
-        if name not in self._tasks or self._tasks[name].done():
-            self._tasks[name] = asyncio.create_task(new_session.run())
-        if name not in self._forward_tasks or self._forward_tasks[name].done():
-            self._forward_tasks[name] = asyncio.create_task(
-                self._forwarder(name)
+        if key not in self._tasks or self._tasks[key].done():
+            self._tasks[key] = asyncio.create_task(new_session.run())
+        if key not in self._forward_tasks or self._forward_tasks[key].done():
+            self._forward_tasks[key] = asyncio.create_task(
+                self._forwarder(name, sid)
             )
-        self._attached = name
+        self._attached = key
 
         # Re-announce any pending interventions for the user. While detached,
         # `_announce_intervention` already put the original message on the
@@ -1445,22 +1501,23 @@ class AgentRegistry:
                 await new_session._announce_intervention(iv)
         return new_session
 
-    async def _forwarder(self, name: str) -> None:
-        """Pump one agent's outbox into the registry-level repl_outbox.
+    async def _forwarder(self, name: str, sid: str = _DEFAULT_SID) -> None:
+        """Pump one session's outbox into the registry-level repl_outbox.
 
-        Runs continuously per agent. Only forwards when this agent is the
-        attached one; otherwise drops the message (transient kinds were
-        already dropped at source, durable narration is in history). Special
-        kind `__attach_request__` is consumed here as a control signal.
+        Runs continuously per (name, sid) session. Only forwards when that
+        session is the attached one; otherwise drops the message (transient
+        kinds were already dropped at source, durable narration is in history).
+        Special kind `__attach_request__` is consumed here as a control signal.
         """
-        agent = self._agents[name]
+        key = (name, sid)
+        agent = self._peek_session(name, sid)
         while True:
             msg = await agent.outbox.get()
             if msg.kind == "__end__":
                 # Session shut down — propagate to REPL only if we're the
                 # attached one (otherwise REPL would terminate spuriously
-                # on a detached agent's shutdown).
-                if name == self._attached:
+                # on a detached session's shutdown).
+                if key == self._attached:
                     await self.repl_outbox.put(msg)
                 return
             if msg.kind == "__attach_request__":
@@ -1474,28 +1531,31 @@ class AgentRegistry:
                     # but TUI needs the same signal for render update.
                     await self.repl_outbox.put(msg)
                 continue
-            if name == self._attached:
+            if key == self._attached:
                 await self.repl_outbox.put(msg)
-            # else: drop — agent is detached, transient kinds were already
+            # else: drop — session is detached, transient kinds were already
             # dropped at source, durable narration is in history.jsonl
 
     def detach(self) -> None:
-        """Mark the attached agent as detached without stopping its task."""
+        """Mark the attached session as detached without stopping its task."""
         if self._attached is None:
             return
-        session = self._agents.get(self._attached)
+        session = self._peek_session(self._attached[0], self._attached[1])
         if session is not None:
             session.is_attached = False
         self._attached = None
 
     @property
     def attached_name(self) -> str | None:
-        return self._attached
+        # FP-0043 S3: _attached is (name, sid); the public accessor exposes the
+        # agent NAME (byte-identical to the prior str|None) — the focused sid is
+        # an internal detail until multi-session UI lands.
+        return self._attached[0] if self._attached is not None else None
 
     def attached_session(self) -> "object | None":
         if self._attached is None:
             return None
-        return self._agents.get(self._attached)
+        return self._peek_session(self._attached[0], self._attached[1])
 
     def running_tasks(self) -> list[asyncio.Task]:
         """All non-completed tasks (session.run + forwarders) for shutdown drain."""
@@ -1506,7 +1566,7 @@ class AgentRegistry:
 
     async def shutdown(self) -> None:
         """Best-effort: stop all loaded sessions, then await tasks."""
-        for name, agent in list(self._agents.items()):
+        for name, agent in self._iter_named_sessions():
             try:
                 await agent.shutdown()
             except Exception as exc:
@@ -1519,7 +1579,7 @@ class AgentRegistry:
             await asyncio.gather(*self.running_tasks(), return_exceptions=True)
 
     def loaded_names(self) -> list[str]:
-        return list(self._agents.keys())
+        return list(self._sessions.keys())
 
     def iter_other_agents(self, self_name: str) -> list[dict]:
         """List `{name, role}` for every agent except `self_name`.

--- a/src/reyn/chat/repl.py
+++ b/src/reyn/chat/repl.py
@@ -159,7 +159,7 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
         total_usage = TokenUsage()
         total_cost = 0.0
         for name in registry.loaded_names():
-            session = registry._agents.get(name)
+            session = registry.get_session(name)
             if session is None:
                 continue
             total_usage += session.total_usage

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -527,7 +527,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
 
     def _collect_events(registry: AgentRegistry) -> list[dict]:
         """Harvest events emitted during the scenario from the EventStore."""
-        session = registry._agents.get(agent_name)
+        session = registry.get_session(agent_name)
         if session is None:
             return []
         try:

--- a/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
@@ -337,7 +337,7 @@ def _plans_for_agent(registry: "AgentRegistry", name: str) -> list[dict]:
     """
     out: list[dict] = []
     try:
-        session = registry._agents.get(name)  # type: ignore[attr-defined]
+        session = registry.get_session(name)  # type: ignore[attr-defined]
     except Exception:
         return out
     if session is None:

--- a/tests/test_live_fork_gate.py
+++ b/tests/test_live_fork_gate.py
@@ -91,7 +91,7 @@ async def test_live_fork_checkout_back_follows_lineage_both_substrates(tmp_path)
     session.register_intervention_listener("test")
     session.attach_workspace_store(reg.workspace_store)
     session.attach_anchor_store(reg.anchor_store)
-    reg._agents["alpha"] = session
+    reg._sessions["alpha"] = {"main": session}
     session._loop_driver = _FakeTurnDriver(
         session, tmp_path, {"turn A": "v1", "turn B": "v2", "turn C": "v3"},
     )

--- a/tests/test_live_rewind_gate.py
+++ b/tests/test_live_rewind_gate.py
@@ -92,7 +92,7 @@ async def test_live_rewind_reverts_both_substrates_to_as_of_n(tmp_path):
     # production wiring: the registry injects its single shared stores.
     session.attach_workspace_store(reg.workspace_store)
     session.attach_anchor_store(reg.anchor_store)
-    reg._agents["alpha"] = session
+    reg._sessions["alpha"] = {"main": session}
     # swap the no-LLM driver in; the rest of _run_router_loop (incl cut_generation) is real.
     session._loop_driver = _FakeTurnDriver(
         session, tmp_path, {"turn A": "v1", "turn B": "v2"},

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -207,7 +207,7 @@ def test_send_to_agent_history_persists_across_calls(tmp_path, monkeypatch):
         )
         # Read history through the registry's cached session — same
         # in-process instance both calls landed on.
-        session = registry._agents["default"]
+        session = registry._sessions["default"]["main"]
         return r1, r2, list(session.history)
 
     r1, r2, history = asyncio.run(go())

--- a/tests/test_registry_multi_session_1726.py
+++ b/tests/test_registry_multi_session_1726.py
@@ -1,0 +1,76 @@
+"""Tier 2: #1726 FP-0043 Stage 3 — Registry holds N Sessions per Agent.
+
+The structural multi-session enabler: identity (Agent, S2) is shared per name;
+conversation Sessions are keyed by an opaque session-id (default "main" → N=1
+byte-identical). spawn_session opens an additional Session under the SAME Agent
+object. Inbound routing to non-default sessions is Stage 4 — S3 just makes the
+structure hold N.
+
+Real AgentRegistry + real ChatSession (no mocks).
+"""
+from __future__ import annotations
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import _DEFAULT_SID, AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+
+def _registry(tmp_path):
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return ChatSession(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    return reg
+
+
+def test_default_session_lookup_unchanged(tmp_path) -> None:
+    """Tier 2: #1726 — get_or_load(name) yields the default "main" session, and
+    get_session(name) / get_session(name, "main") return that SAME instance
+    (the prior single-session lookup, unchanged at N=1)."""
+    reg = _registry(tmp_path)
+    s = reg.get_or_load("default")
+    assert reg.get_session("default") is s
+    assert reg.get_session("default", _DEFAULT_SID) is s
+    assert reg.loaded_names() == ["default"]
+
+
+def test_spawn_session_creates_distinct_session_sharing_agent(tmp_path) -> None:
+    """Tier 2: #1726 — spawn_session opens an ADDITIONAL Session under the agent:
+    a distinct CONVERSATION instance under the SAME identity. Observably: the
+    spawned session is a different object with its own inbox, but reports the
+    identical identity (agent_name/role), and the registry still lists ONE agent.
+    (Impl shares the same Agent object via the S2 ``agent=`` seam — verified by
+    construction in spawn_session; the frozen+private Agent isn't an observable
+    surface, so the test pins the public identity-equivalence contract.)"""
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("default")
+    sid = reg.spawn_session("default")
+    spawned = reg.get_session("default", sid)
+
+    assert sid != _DEFAULT_SID
+    assert spawned is not None and spawned is not main, "a distinct conversation Session"
+    # Same identity (public surface), different conversation.
+    assert spawned.agent_name == main.agent_name == "default"
+    assert spawned.agent_role == main.agent_role, "same identity (role) as the agent"
+    assert spawned.inbox is not main.inbox, "conversation (inbox) is per-session"
+    # Still ONE agent in the registry (N sessions under one identity).
+    assert reg.loaded_names() == ["default"]
+
+
+def test_default_session_unaffected_by_spawn(tmp_path) -> None:
+    """Tier 2: #1726 — spawning a second session does not disturb the default
+    one (get_or_load still returns the original "main" instance)."""
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("default")
+    reg.spawn_session("default")
+    assert reg.get_or_load("default") is main
+    assert reg.get_session("default") is main

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -175,7 +175,7 @@ async def test_rewind_to_drives_loaded_session_to_as_of_n_zero_residue(tmp_path)
         snapshot_path=_snap_path(tmp_path, "alpha"),
     )
     session.register_intervention_listener("test")
-    reg._agents["alpha"] = session
+    reg._sessions["alpha"] = {"main": session}
 
     await _put(log, "alpha", "a1")         # seq 1 (kept by rewind to 1)
     await _put(log, "alpha", "a2")         # seq 2 (abandoned)
@@ -321,7 +321,7 @@ async def test_compute_truncate_floor_clamped_by_retention(tmp_path):
         retention_policy=RetentionPolicy(keep_generations=2),
     )
     _seed_agent(tmp_path, "alpha")
-    reg._agents["alpha"] = _WatermarkShim([10])         # live floor = 11
+    reg._sessions["alpha"] = {"main": _WatermarkShim([10])}  # live floor = 11
 
     store = reg._store_for("alpha")                      # record 3 checkpoints
     for s in (1, 2, 3):
@@ -341,7 +341,7 @@ async def test_live_policy_floor_unchanged(tmp_path):
         project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
     )  # default policy = live
     _seed_agent(tmp_path, "alpha")
-    reg._agents["alpha"] = _WatermarkShim([10])
+    reg._sessions["alpha"] = {"main": _WatermarkShim([10])}
     store = reg._store_for("alpha")
     for s in (1, 2, 3):
         snap = AgentSnapshot.empty("alpha")

--- a/tests/test_registry_wal_size_safety_net.py
+++ b/tests/test_registry_wal_size_safety_net.py
@@ -62,10 +62,10 @@ class _ShimSession:
 
 
 def _get_or_create_shim(registry: AgentRegistry, name: str) -> _ShimSession:
-    if name not in registry._agents:
+    if name not in registry._sessions:
         AgentProfile.new(name, role="").save(registry._dir / name)
-        registry._agents[name] = _ShimSession()
-    shim = registry._agents[name]
+        registry._sessions[name] = {"main": _ShimSession()}
+    shim = registry._sessions[name]["main"]
     assert isinstance(shim, _ShimSession)
     return shim
 

--- a/tests/test_registry_wal_truncate.py
+++ b/tests/test_registry_wal_truncate.py
@@ -76,10 +76,10 @@ def _get_or_create_shim(registry: AgentRegistry, name: str) -> _ShimSession:
     on first use. Mirrors the on-disk-profile creation pattern so
     ``list_names`` still includes the agent.
     """
-    if name not in registry._agents:
+    if name not in registry._sessions:
         AgentProfile.new(name, role="").save(registry._dir / name)
-        registry._agents[name] = _ShimSession()
-    shim = registry._agents[name]
+        registry._sessions[name] = {"main": _ShimSession()}
+    shim = registry._sessions[name]["main"]
     assert isinstance(shim, _ShimSession), (
         f"agent {name!r} is registered with a non-shim object — test fixture bug"
     )
@@ -305,7 +305,7 @@ def test_truncate_advances_seqs_across_active_skill_completion(tmp_path):
     registry = _make_registry(tmp_path)
     _seed_agent(registry, "alpha", applied_seq=10)
     _seed_skill(registry, "alpha", "run_zzz", last_phase_applied_seq=3)
-    shim = registry._agents["alpha"]
+    shim = registry._sessions["alpha"]["main"]
 
     async def go():
         for i in range(1, 21):

--- a/tests/test_registry_wal_truncate_floor_nonblocking.py
+++ b/tests/test_registry_wal_truncate_floor_nonblocking.py
@@ -93,7 +93,7 @@ def _register_shim(registry: AgentRegistry, name: str, seqs: list[int]) -> _Shim
     """
     AgentProfile.new(name, role="").save(registry._dir / name)
     shim = _ShimSession(seqs)
-    registry._agents[name] = shim
+    registry._sessions[name] = {"main": shim}
     return shim
 
 

--- a/tests/test_session_skill_registry_integration.py
+++ b/tests/test_session_skill_registry_integration.py
@@ -152,7 +152,7 @@ def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
     )
     # Register the live session into the registry's in-memory map so the
     # PR-N7 in-memory floor walk picks up its iter_applied_seqs.
-    session.agent_registry._agents["alpha"] = session
+    session.agent_registry._sessions["alpha"] = {"main": session}
 
     reg = session.get_skill_registry()
     assert reg.truncate_hook is not None

--- a/tests/test_wal_long_await_floor.py
+++ b/tests/test_wal_long_await_floor.py
@@ -79,10 +79,10 @@ class _LongAwaitShim:
 
 
 def _get_or_create_shim(registry: AgentRegistry, name: str) -> _LongAwaitShim:
-    if name not in registry._agents:
+    if name not in registry._sessions:
         AgentProfile.new(name, role="").save(registry._dir / name)
-        registry._agents[name] = _LongAwaitShim()
-    shim = registry._agents[name]
+        registry._sessions[name] = {"main": _LongAwaitShim()}
+    shim = registry._sessions[name]["main"]
     assert isinstance(shim, _LongAwaitShim)
     return shim
 
@@ -206,7 +206,7 @@ def test_clearing_awaiting_since_restores_inclusion(tmp_path: Path, monkeypatch)
         registry, "alpha", "run-x",
         last_phase_applied_seq=50, awaiting_since=10.0,
     )
-    shim = registry._agents["alpha"]
+    shim = registry._sessions["alpha"]["main"]
 
     # First: long-await → excluded, floor=1001
     monkeypatch.setattr("reyn.chat.registry.time.monotonic", lambda: 500.0)


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 **Stage 3**: Registry holds N conversation Sessions per Agent (the multi-session structural enabler). Owner-delegated to lead, self-drive; design + seam confirmed by lead (broker, canonical on #1726). **Byte-identical at N=1.**

## What

Identity is extracted (S2: shareable `Agent`); conversation machinery (inbox/run-loop/history/`_router_host`) is already per-instance. The only thing fusing "one conversation per identity" was the Registry keying one slot by `agent_name`. Stage 3 re-keys it:

| Before | After |
|---|---|
| `_agents: {name→ChatSession}` | `_identities: {name→Agent}` (shared identity) + `_sessions: {name→{sid→Session}}` (conversation) |
| `_tasks`/`_forward_tasks: {name→task}` | `{(name, sid)→task}` |
| `_attached: str\|None` | `(name, sid)\|None` |

- **`_DEFAULT_SID = "main"`**: every name-keyed path (`get_or_load`/`ensure_running`/`attach`/`detach`/`attached_*`/`remove`/`restore_all`/`loaded_names`/`shutdown` + the 3 iteration sites: rewind all-cancel / peer-notify / budget-floor) resolves to the default session → **byte-identical at N=1**.
- **Helper methods** (`_peek_session`/`_store_session`/`_has_session`/`_iter_sessions`/`_iter_named_sessions`) centralize sid-defaulting, so the ~25 call-sites stay correct by construction (the `_agent_role`-cascade lesson — convert ALL read-sites).
- **`spawn_session(name) → sid`**: opens an additional Session under the existing Agent, **sharing the same Agent identity object** (the S2 `agent=` seam, set on a session built via the factored `_construct_session`). **Structure-only** (lead-confirmed): inbound routing to non-default sessions is Stage 4 — the `"main"` session keeps receiving all inbound traffic until then.

## External-access completeness (lead point #1)

`registry._agents` was reached into **outside** the registry — public-API signature preservation only protects public callers. New public **`get_session(name, sid="main")`**; the 3 external src sites (`chat/repl.py`, `interfaces/tui/.../agents_tab.py`, `cli/commands/dogfood.py`) + 9 test files (WAL/rewind shim injectors) routed through it / the `_sessions` structure — so the byte-identical guarantee covers external callers too.

## Gates

- **Named gate** (time-travel + crash-recovery: rewind/fork/act_turn/snapshot/restore + session/registry/scoped): **949 passed / 0 failed** (946 prior + 3 new multi-session). **Snapshot UNTOUCHED** — stays `agent_name`-keyed (restore → `"main"`); re-key is S5, so orthogonality holds.
- **Identity-symbol-count proof**: `AgentRegistry`/`AgentProfile`/`AgentSnapshot`/`AgentRef` unchanged (=1 each); `Agent` =1 (from S2). No identity-layer churn.
- ruff clean; tier-audit 0 (the multi-session test pins public identity-equivalence, not private `_agent`); full `pytest -q` — result in final comment.

## Test plan

- [x] `ruff check src tests` — clean
- [x] Named gate + session/registry/scoped/multi_session — 949 passed, 0 failed
- [x] `test_registry_multi_session_1726` (Tier 2): default-lookup unchanged + spawn distinct-session-same-identity + default-unaffected — pass
- [x] `test_scoped_session_factory_invariant_1402` — pass
- [x] tier-audit `--strict` (new test) — 0 violations
- [x] full `pytest -q` from rootdir — (result in final comment; expect only known pre-existing local fails)

Refs #1726
Refs #1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)
