### PR TITLE
feat(1726): FP-0043 Stage 5 — per-session snapshot re-key (time-travel + crash-recovery)

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -392,6 +392,17 @@ class AgentRegistry:
 
     # ── PR21: crash recovery ─────────────────────────────────────────────────
 
+    def _session_snapshot_path(self, name: str, sid: str) -> Path:
+        """FP-0043 Stage 5: on-disk snapshot path for ``(name, sid)``.
+
+        The "main" session keeps the legacy agent-level path (byte-identical
+        pre-S5); spawned sessions nest under ``state/sessions/<sid>/`` — the same
+        layout spawn_session's fixup writes to (base-aligned via self._dir)."""
+        state_dir = self._dir / name / "state"
+        if sid == _DEFAULT_SID:
+            return state_dir / "snapshot.json"
+        return state_dir / "sessions" / sid / "snapshot.json"
+
     async def restore_all(self) -> dict[str, AgentSnapshot]:
         """Reconstruct each known agent's runtime state from snapshot + WAL.
 
@@ -419,28 +430,47 @@ class AgentRegistry:
         # 0. crash-mid-rewind recovery (no-op without an active reset-record).
         await self.recover_rewind_if_needed()
 
-        # 1. Load snapshots
+        # 1. Load snapshots — main (legacy path) + per-session (spawned).
+        # FP-0043 Stage 5: ``snapshots`` (name → MAIN AgentSnapshot) is the
+        # returned back-compat view; ``all_snaps`` ((name, sid) → AgentSnapshot)
+        # drives per-session replay-routing + restore. A legacy install has only
+        # the main path → loads as session_id "main" (the migration fallback).
         snapshots: dict[str, AgentSnapshot] = {}
+        all_snaps: dict[tuple[str, str], AgentSnapshot] = {}
         for name in self.list_names():
-            snap_path = self._dir / name / "state" / "snapshot.json"
-            if snap_path.is_file():
-                snapshots[name] = AgentSnapshot.load(name, snap_path)
+            state_dir = self._dir / name / "state"
+            main_path = state_dir / "snapshot.json"
+            if main_path.is_file():
+                main_snap = AgentSnapshot.load(name, main_path)
             else:
-                snapshots[name] = AgentSnapshot.empty(name)
+                main_snap = AgentSnapshot.empty(name)
+            snapshots[name] = main_snap
+            all_snaps[(name, main_snap.session_id)] = main_snap
+            # Spawned sessions persist under <state>/sessions/<sid>/snapshot.json.
+            sessions_root = state_dir / "sessions"
+            if sessions_root.is_dir():
+                for sid_dir in sorted(sessions_root.iterdir()):
+                    sp = sid_dir / "snapshot.json"
+                    if sp.is_file():
+                        sid = sid_dir.name
+                        all_snaps[(name, sid)] = AgentSnapshot.load(
+                            name, sp, session_id=sid,
+                        )
 
-        if not snapshots:
+        if not all_snaps:
             return {}
 
-        # 2-3. WAL replay from min(applied_seq) + 1
-        min_seq = min(s.applied_seq for s in snapshots.values())
+        # 2-3. WAL replay from min(applied_seq) + 1. Each snapshot's
+        # _matches_agent now filters by (agent, session_id), so a shared WAL tail
+        # routes every entry to exactly its (name, sid) snapshot.
+        min_seq = min(s.applied_seq for s in all_snaps.values())
         wal_entries = list(self._state_log.iter_from(min_seq + 1))
-        for snap in snapshots.values():
+        for snap in all_snaps.values():
             snap.apply_events(wal_entries)
 
-        # 4. Save the post-replay snapshots
-        for name, snap in snapshots.items():
-            snap_path = self._dir / name / "state" / "snapshot.json"
-            snap.save(snap_path)
+        # 4. Save the post-replay snapshots back to their per-session paths.
+        for (name, sid), snap in all_snaps.items():
+            snap.save(self._session_snapshot_path(name, sid))
 
         # 5. Hand each non-empty snapshot to its session.
         # PR-intervention-link L4: outstanding_interventions also triggers
@@ -450,15 +480,26 @@ class AgentRegistry:
         # ADR-0022: active_plan_ids also triggers restore — needed so the
         # cleanup hook can fire and notify the user that their plan was
         # interrupted.
-        for name, snap in snapshots.items():
+        # FP-0043 S5: the main session is get_or_load'd + ensure_running (live,
+        # unchanged); a spawned session is recreated via spawn_session(name, sid)
+        # — which re-applies the S5 path fixup — then re-adopts its state. Its
+        # run-loop starts lazily on attach_session (S4a), so no auto-run here.
+        for (name, sid), snap in all_snaps.items():
             if (not snap.inbox
                     and not snap.pending_chains
                     and not snap.outstanding_interventions
                     and not snap.active_plan_ids):
                 continue
-            session = self.get_or_load(name)
-            session.restore_state(snap)
-            await self.ensure_running(name)
+            if sid == _DEFAULT_SID:
+                session = self.get_or_load(name)
+                session.restore_state(snap)
+                await self.ensure_running(name)
+            else:
+                if not self._has_session(name, sid):
+                    self.spawn_session(name, sid=sid)
+                session = self._peek_session(name, sid)
+                if session is not None:
+                    session.restore_state(snap)
 
         # 6. ADR-0023 Phase 2: orphan plan recovery via PlanResumeCoordinator.
         # Plans whose decomposition artifact survived (= post-Step-6 plans)
@@ -466,6 +507,12 @@ class AgentRegistry:
         # artifact get the same Phase 1 outcome (= forced discard +
         # outbox notice + plan_aborted) via the coordinator's missing-
         # artifact fallback.
+        # FP-0043 S5 boundary: this iterates the MAIN session only. The recovery
+        # coordinator drives an agent-level PlanRegistry (a separate consumer from
+        # AgentSnapshot), so per-session plan recovery belongs with the deferred
+        # plan/step consumer-scoping line (#1737), not S5's AgentSnapshot re-key. A
+        # spawned session's active_plan_ids is still restored into its snapshot
+        # above; only the orphan-cleanup coordinator stays main-scoped here.
         for name, snap in snapshots.items():
             if not snap.active_plan_ids:
                 continue
@@ -1490,6 +1537,23 @@ class AgentRegistry:
         existing_skill_registry = getattr(session, "_skill_registry", None)
         if existing_skill_registry is not None:
             existing_skill_registry.set_session_id(new_sid)
+        # FP-0043 Stage 5: re-key the spawned session's persistence to its OWN
+        # per-session location so it does NOT collide with the agent's "main"
+        # snapshot.json / generations. Derived from the session's own base (the
+        # parent of its current main snapshot path) so a test tmp-base is respected
+        # — the same base-alignment invariant restore_all's discovery relies on:
+        #   <state>/snapshot.json          (main, byte-identical legacy path)
+        #   <state>/sessions/<sid>/snapshot.json + .../generations  (spawned)
+        state_dir = Path(session._snapshot_path).parent
+        session_dir = state_dir / "sessions" / new_sid
+        per_session_snapshot = session_dir / "snapshot.json"
+        per_session_generations = SnapshotGenerationStore(
+            name, session_dir / "generations",
+        )
+        session._snapshot_path = per_session_snapshot  # diagnostic mirror
+        session._generation_store = per_session_generations  # rewind path reads this
+        session._journal.set_snapshot_path(per_session_snapshot)
+        session._journal.set_generation_store(per_session_generations)
         self._sessions.setdefault(name, {})[new_sid] = session
         return new_sid
 

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -392,16 +392,40 @@ class AgentRegistry:
 
     # ── PR21: crash recovery ─────────────────────────────────────────────────
 
-    def _session_snapshot_path(self, name: str, sid: str) -> Path:
-        """FP-0043 Stage 5: on-disk snapshot path for ``(name, sid)``.
+    def _session_state_dir(self, name: str, sid: str) -> Path:
+        """FP-0043 Stage 5: on-disk state dir for ``(name, sid)``.
 
-        The "main" session keeps the legacy agent-level path (byte-identical
+        The "main" session keeps the legacy agent-level dir (byte-identical
         pre-S5); spawned sessions nest under ``state/sessions/<sid>/`` — the same
         layout spawn_session's fixup writes to (base-aligned via self._dir)."""
         state_dir = self._dir / name / "state"
         if sid == _DEFAULT_SID:
-            return state_dir / "snapshot.json"
-        return state_dir / "sessions" / sid / "snapshot.json"
+            return state_dir
+        return state_dir / "sessions" / sid
+
+    def _session_snapshot_path(self, name: str, sid: str) -> Path:
+        """FP-0043 Stage 5: snapshot.json path for ``(name, sid)``."""
+        return self._session_state_dir(name, sid) / "snapshot.json"
+
+    def _session_generations_dir(self, name: str, sid: str) -> Path:
+        """FP-0043 Stage 5: PITR generations dir for ``(name, sid)``."""
+        return self._session_state_dir(name, sid) / "generations"
+
+    def _discover_session_ids(self, name: str) -> list[str]:
+        """FP-0043 Stage 5: every session id for ``name`` — "main" + loaded +
+        on-disk spawned (``state/sessions/<sid>/``).
+
+        Used by the rewind materialiser, which is shared with crash-recovery
+        (sessions not yet loaded), so disk discovery — not just the loaded map —
+        is required to bring EVERY session's substrate to the target cut."""
+        sids = {_DEFAULT_SID}
+        sids.update(self._sessions.get(name, {}).keys())
+        sessions_root = self._dir / name / "state" / "sessions"
+        if sessions_root.is_dir():
+            for child in sessions_root.iterdir():
+                if child.is_dir():
+                    sids.add(child.name)
+        return sorted(sids)
 
     async def restore_all(self) -> dict[str, AgentSnapshot]:
         """Reconstruct each known agent's runtime state from snapshot + WAL.
@@ -530,19 +554,19 @@ class AgentRegistry:
 
     # ── Global rewind (ADR-0038 Stage 1c-2, D2 consistent-cut) ──────────────
 
-    def _store_for(self, name: str) -> SnapshotGenerationStore:
-        """Return the snapshot-generation store for ``name``.
+    def _store_for(self, name: str, sid: str = _DEFAULT_SID) -> SnapshotGenerationStore:
+        """Return the snapshot-generation store for session ``(name, sid)``.
 
-        Reuses the live session's store when the agent is loaded (so an
-        in-flight session and the rewind path share one view of the
-        generations dir); otherwise constructs one over the on-disk path.
-        """
-        session = self._peek_session(name)
+        Reuses the live session's store when that session is loaded (so an
+        in-flight session and the rewind path share one view of the generations
+        dir); otherwise constructs one over the per-session on-disk path. Default
+        sid "main" = the legacy agent-level generations dir (byte-identical)."""
+        session = self._peek_session(name, sid)
         store = getattr(session, "_generation_store", None)
         if isinstance(store, SnapshotGenerationStore):
             return store
         return SnapshotGenerationStore(
-            name, self._dir / name / "state" / "generations",
+            name, self._session_generations_dir(name, sid),
         )
 
     async def checkout(self, seq: int) -> dict:
@@ -927,22 +951,32 @@ class AgentRegistry:
         rewind_to (= gen-N) or head in recovery (= latest active gen, keeping
         post-rewind workspace work). Returns the agents materialised.
         """
+        # FP-0043 Stage 5: the runtime snapshot is reconstructed PER SESSION (each
+        # (name, sid) from its own generations + session_id-routed WAL delta), so a
+        # global cut moves every session of every agent to the target — consistent
+        # with the D2 whole-world invariant. The workspace substrate stays global
+        # (one SSoT per agent) and is restored once below. Session discovery is from
+        # disk (this is shared with crash-recovery, where sessions are not loaded).
         agents: list[str] = []
         for name in self.list_names():
-            store = self._store_for(name)
-            snap = reconstruct(
-                name, store, self._state_log, target_seq=reconstruct_seq,
-            )
-            # Self-contained: the reset-record carries no agent target, so
-            # reconstruct leaves applied_seq at the last active entry. Pin it to
-            # the head so restore_all's replay floor skips the abandoned segment.
-            snap.applied_seq = reconstruct_seq
-            snap.save(self._dir / name / "state" / "snapshot.json")
-            session = self._peek_session(name)
-            if session is not None:
-                await session.reset_for_rewind()
-                session.restore_state(snap)
-            agents.append(name)
+            for sid in self._discover_session_ids(name):
+                store = self._store_for(name, sid)
+                snap = reconstruct(
+                    name, store, self._state_log,
+                    target_seq=reconstruct_seq, session_id=sid,
+                )
+                # Self-contained: the reset-record carries no agent target, so
+                # reconstruct leaves applied_seq at the last active entry. Pin it to
+                # the head so restore_all's replay floor skips the abandoned segment.
+                snap.applied_seq = reconstruct_seq
+                snap.save(self._session_snapshot_path(name, sid))
+                session = self._peek_session(name, sid)
+                if session is not None:
+                    await session.reset_for_rewind()
+                    session.restore_state(snap)
+                # main → bare name (back-compat with single-session callers);
+                # spawned → "name/sid".
+                agents.append(name if sid == _DEFAULT_SID else f"{name}/{sid}")
         await self._restore_workspace_active(at_or_below=workspace_at_or_below)
         return agents
 
@@ -1235,7 +1269,10 @@ class AgentRegistry:
         """
         try:
             for name in self.list_names():
-                self._store_for(name).prune_below(floor)   # SnapshotGenerationStore (sync)
+                # FP-0043 S5: prune EVERY session's generations (main + spawned),
+                # not just main — per-session generation dirs now exist.
+                for sid in self._discover_session_ids(name):
+                    self._store_for(name, sid).prune_below(floor)  # SnapshotGenerationStore (sync)
             ws = self.workspace_store
             if ws is not None:
                 await ws.prune_below(floor)

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -1477,6 +1477,19 @@ class AgentRegistry:
             # Share the SAME identity object (not the fresh one the factory built),
             # so a future identity change propagates to all of the agent's sessions.
             session._agent = shared
+        # FP-0043 Stage 5: stamp the new session's id so EVERY WAL append it makes
+        # carries new_sid (per-session snapshot routing). Done here — before the
+        # session's run-loop / forwarder go live (that is attach_session, S4a,
+        # strictly later) — so there is NO "main"-tagged append window for the
+        # spawned session. The journal is built eagerly in __init__ (set_session_id
+        # propagates to the in-memory snapshot too); the skill_registry is lazy and
+        # reads _session_id at construction, so setting the attribute covers a later
+        # build, and we also fix up an already-built one defensively.
+        session._session_id = new_sid
+        session._journal.set_session_id(new_sid)
+        existing_skill_registry = getattr(session, "_skill_registry", None)
+        if existing_skill_registry is not None:
+            existing_skill_registry.set_session_id(new_sid)
         self._sessions.setdefault(name, {})[new_sid] = session
         return new_sid
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -84,6 +84,23 @@ class SnapshotJournal:
         self._session_id = session_id
         self._snapshot.session_id = session_id
 
+    def set_snapshot_path(self, snapshot_path: Path) -> None:
+        """FP-0043 Stage 5: re-point the on-disk snapshot path post-construction.
+
+        spawn_session uses this so a spawned session persists to its OWN per-session
+        location (``<state>/sessions/<sid>/snapshot.json``) instead of colliding with
+        the agent's "main" snapshot. Pre-live (before any append/save), so no entry
+        is ever written to the wrong path."""
+        self._snapshot_path = Path(snapshot_path)
+
+    def set_generation_store(self, generation_store) -> None:
+        """FP-0043 Stage 5: re-point the PITR generation store post-construction.
+
+        spawn_session uses this so a spawned session's generations land in its own
+        per-session ``generations`` dir (paired with set_snapshot_path). None →
+        generation cuts become no-ops (unchanged from the no-store default)."""
+        self._generation_store = generation_store
+
     def set_workspace_store(self, workspace_store) -> None:
         """Attach the shared workspace shadow-git store (ADR-0038 Stage 1d).
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -39,8 +39,15 @@ class SnapshotJournal:
         snapshot_path: Path,
         state_log: StateLog | None,
         generation_store: SnapshotGenerationStore | None = None,
+        session_id: str = "main",
     ) -> None:
         self._agent_name = agent_name
+        # FP-0043 Stage 5: the conversation session this journal records for. Tagged
+        # onto every WAL append (session_id=) so replay routes entries to the right
+        # per-session AgentSnapshot; default "main" = byte-identical single session.
+        # Set post-construction by spawn_session for spawned sessions (set_session_id)
+        # — mirroring the _workspace_store/_anchor_store post-construction pattern.
+        self._session_id = session_id
         self._snapshot_path = Path(snapshot_path)
         self._state_log = state_log
         # ADR-0038 Stage 1a: PITR generation store. When None (tests /
@@ -55,7 +62,27 @@ class SnapshotJournal:
         # #1547: per-checkpoint anchor text (truncated last user message). Set
         # post-construction by the registry. None → no anchor capture.
         self._anchor_store = None
-        self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name)
+        self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name, session_id)
+
+    async def _wal_append(self, kind: str, **fields):
+        """FP-0043 Stage 5: the single WAL-append chokepoint for this journal.
+
+        Injects ``session_id=self._session_id`` into EVERY entry so replay routes
+        it to this session's snapshot (the funnel-completeness guarantee — a future
+        journal append inherits session-tagging by construction). Preserves the
+        prior no-state_log behaviour (returns None when the journal has no WAL)."""
+        if self._state_log is None:
+            return None
+        log = self._state_log  # local so the funnel replace doesn't recurse into this call
+        return await log.append(kind, session_id=self._session_id, **fields)
+
+    def set_session_id(self, session_id: str) -> None:
+        """FP-0043 Stage 5: set the conversation session id post-construction
+        (spawn_session uses this for a spawned session, before its run-loop goes
+        live — mirroring set_workspace_store). The in-memory snapshot's session_id
+        is updated too so its save() + apply routing stay consistent."""
+        self._session_id = session_id
+        self._snapshot.session_id = session_id
 
     def set_workspace_store(self, workspace_store) -> None:
         """Attach the shared workspace shadow-git store (ADR-0038 Stage 1d).
@@ -121,7 +148,7 @@ class SnapshotJournal:
         msg_id = uuid.uuid4().hex[:8]
         full_payload = {**payload, "_msg_id": msg_id}
         if self._state_log is not None:
-            seq = await self._state_log.append(
+            seq = await self._wal_append(
                 "inbox_put", target=self._agent_name,
                 msg_id=msg_id, msg_kind=kind, payload=full_payload,
             )
@@ -140,7 +167,7 @@ class SnapshotJournal:
         """
         if self._state_log is None or msg_id is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "inbox_consume", agent=self._agent_name, msg_id=msg_id,
         )
         self._snapshot.applied_seq = seq
@@ -158,7 +185,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "chain_register", agent=self._agent_name, chain_id=chain_id,
             **fields,
         )
@@ -177,7 +204,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "chain_update", agent=self._agent_name, chain_id=chain_id,
             **fields,
         )
@@ -195,7 +222,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "chain_resolve", agent=self._agent_name, chain_id=chain_id,
         )
         self._snapshot.applied_seq = seq
@@ -209,7 +236,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "chain_timeout_fired", agent=self._agent_name, chain_id=chain_id,
         )
         self._snapshot.applied_seq = seq
@@ -233,7 +260,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "intervention_dispatched",
             target=self._agent_name,
             intervention_id=intervention_id,
@@ -253,7 +280,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "intervention_resolved",
             target=self._agent_name,
             intervention_id=intervention_id,
@@ -275,7 +302,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "intervention_answer_buffered",
             target=self._agent_name,
             run_id=run_id,
@@ -302,7 +329,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "intervention_answer_consumed",
             target=self._agent_name,
             run_id=run_id,
@@ -325,7 +352,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_started",
             target=self._agent_name,
             plan_id=plan_id,
@@ -345,7 +372,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_completed",
             target=self._agent_name,
             plan_id=plan_id,
@@ -366,7 +393,7 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_aborted",
             target=self._agent_name,
             plan_id=plan_id,
@@ -392,7 +419,7 @@ class SnapshotJournal:
         """Append ``plan_step_started`` to WAL. Returns the assigned seq."""
         if self._state_log is None:
             return None
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_step_started",
             target=self._agent_name,
             plan_id=plan_id,
@@ -410,7 +437,7 @@ class SnapshotJournal:
         """Append ``plan_step_completed`` to WAL. Returns the assigned seq."""
         if self._state_log is None:
             return None
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_step_completed",
             target=self._agent_name,
             plan_id=plan_id,
@@ -429,7 +456,7 @@ class SnapshotJournal:
         """Append ``plan_step_failed`` to WAL. Returns the assigned seq."""
         if self._state_log is None:
             return None
-        seq = await self._state_log.append(
+        seq = await self._wal_append(
             "plan_step_failed",
             target=self._agent_name,
             plan_id=plan_id,

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1203,6 +1203,12 @@ class ChatSession:
         excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_source for external-repo eval)
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
+        # FP-0043 Stage 5: the conversation session id this ChatSession records WAL
+        # entries under. Default "main" = the implicit single session (byte-identical
+        # pre-S5). The registry sets a spawned session's real sid post-construction
+        # (spawn_session → set_session_id) before its run-loop goes live, so every
+        # WAL append carries the right session_id for per-session snapshot routing.
+        session_id: str = "main",
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -1520,6 +1526,10 @@ class ChatSession:
         # SnapshotJournal (extracted service). The session keeps the
         # snapshot_path here only because other init code references it
         # for diagnostic logging — the journal owns the actual I/O.
+        # FP-0043 Stage 5: the conversation session id (default "main"); threaded to
+        # the journal + skill_registry so every WAL append carries it. A spawned
+        # session's real sid is set post-construction (set_session_id) by the registry.
+        self._session_id = session_id
         self._snapshot_path = snapshot_path or (
             Path(".reyn") / "agents" / self.agent_name / "state" / "snapshot.json"
         )
@@ -1532,6 +1542,7 @@ class ChatSession:
             snapshot_path=self._snapshot_path,
             state_log=state_log,
             generation_store=self._generation_store,
+            session_id=session_id,  # FP-0043 S5: per-session WAL routing
         )
         # ADR-0038 Stage 1c: turn-idle event for quiescence. Set = no turn in
         # flight; cleared while run_one_iteration processes a turn. Lets a global
@@ -3476,6 +3487,7 @@ class ChatSession:
                 agent_state_dir=agent_state_dir,
                 state_log=self._state_log,
                 truncate_eligible_hook=hook,
+                session_id=self._session_id,  # FP-0043 S5: per-session WAL routing
             )
         return self._skill_registry
 

--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -40,6 +40,11 @@ class AgentSnapshot:
     """
 
     agent_name: str
+    # FP-0043 Stage 5: the conversation session this snapshot belongs to. Default
+    # "main" = the implicit single session (byte-identical pre-S5); spawned
+    # sessions get their sid. WAL replay routes each entry by (agent_name,
+    # session_id) so per-session snapshots stay isolated.
+    session_id: str = "main"
     applied_seq: int = 0
     # inbox messages: each is {"id": str, "kind": str, "payload": dict}
     inbox: list[dict] = field(default_factory=list)
@@ -73,19 +78,22 @@ class AgentSnapshot:
     # ── persistence ─────────────────────────────────────────────────────
 
     @classmethod
-    def empty(cls, agent_name: str) -> "AgentSnapshot":
-        return cls(agent_name=agent_name)
+    def empty(cls, agent_name: str, session_id: str = "main") -> "AgentSnapshot":
+        return cls(agent_name=agent_name, session_id=session_id)
 
     @classmethod
-    def load(cls, agent_name: str, path: Path) -> "AgentSnapshot":
+    def load(cls, agent_name: str, path: Path, session_id: str = "main") -> "AgentSnapshot":
+        # FP-0043 Stage 5: session_id defaults to "main" so a legacy caller (and a
+        # legacy agent_name-keyed snapshot at the pre-S5 path) loads as the agent's
+        # "main" session — the migration fallback, no recovery-state loss.
         try:
             data = json.loads(Path(path).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             # Corrupt / missing file → defensive empty (existing behavior;
             # there is no version info to compare anyway).
-            return cls.empty(agent_name)
+            return cls.empty(agent_name, session_id)
         if not isinstance(data, dict):
-            return cls.empty(agent_name)
+            return cls.empty(agent_name, session_id)
         # PR-resume-ux β U4: schema_version refuse. A missing version field
         # or a mismatch is treated as incompatible — operator must
         # explicitly --reset to wipe.
@@ -99,6 +107,9 @@ class AgentSnapshot:
             )
         return cls(
             agent_name=agent_name,
+            # FP-0043 S5: prefer the saved session_id; fall back to the caller's
+            # (which defaults "main") for legacy snapshots written pre-S5.
+            session_id=str(data.get("session_id", session_id)),
             applied_seq=int(data.get("applied_seq", 0)),
             inbox=list(data.get("inbox", []) or []),
             pending_chains=dict(data.get("pending_chains", {}) or {}),
@@ -122,6 +133,7 @@ class AgentSnapshot:
         tmp = path.with_suffix(path.suffix + ".tmp")
         payload = {
             "version": SNAPSHOT_VERSION,
+            "session_id": self.session_id,  # FP-0043 S5 (additive; legacy load → "main")
             "applied_seq": self.applied_seq,
             "inbox": self.inbox,
             "pending_chains": self.pending_chains,
@@ -155,11 +167,18 @@ class AgentSnapshot:
             self.applied_seq = seq
 
     def _matches_agent(self, event: dict) -> bool:
-        """Return True if `event` affects this agent."""
-        return (
+        """Return True if `event` affects THIS (agent, session).
+
+        FP-0043 Stage 5: routes by agent (target/agent) AND session. A WAL entry's
+        ``session_id`` defaults to "main" when absent (legacy entries written
+        pre-S5, and the default single session) — so legacy entries deterministically
+        replay into the agent's "main" session, and a spawned session only absorbs
+        its own entries. This is the per-session replay-determinism guarantee."""
+        agent_matches = (
             event.get("target") == self.agent_name
             or event.get("agent") == self.agent_name
         )
+        return agent_matches and event.get("session_id", "main") == self.session_id
 
     def _apply_one(self, event: dict) -> None:
         kind = event.get("kind")

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -71,9 +71,15 @@ class SnapshotGenerationStore:
         candidates = [s for s in self.seqs() if s <= n]
         return candidates[-1] if candidates else None
 
-    def load(self, seq: int) -> AgentSnapshot:
-        """Load the generation at ``seq`` (raises if absent / schema-mismatch)."""
-        return AgentSnapshot.load(self._agent_name, self._path_for(seq))
+    def load(self, seq: int, session_id: str = "main") -> AgentSnapshot:
+        """Load the generation at ``seq`` (raises if absent / schema-mismatch).
+
+        FP-0043 Stage 5: ``session_id`` is the fallback when the on-disk generation
+        predates the field; a generation written post-S5 carries its own session_id
+        (AgentSnapshot.save) which takes precedence."""
+        return AgentSnapshot.load(
+            self._agent_name, self._path_for(seq), session_id=session_id,
+        )
 
     def prune_below(self, min_keep_seq: int) -> int:
         """Drop generations with seq < ``min_keep_seq``. Returns count dropped.
@@ -345,6 +351,7 @@ def reconstruct(
     store: SnapshotGenerationStore,
     state_log: StateLog,
     target_seq: int,
+    session_id: str = "main",
 ) -> AgentSnapshot:
     """Reconstruct ``agent_name``'s state as-of WAL ``target_seq`` (PITR), on the
     **active branch**.
@@ -369,7 +376,15 @@ def reconstruct(
         (s for s in reversed(store.seqs()) if s <= target_seq and is_active(s)),
         None,
     )
-    base = store.load(base_seq) if base_seq is not None else AgentSnapshot.empty(agent_name)
+    # FP-0043 Stage 5: the reconstructed base is tagged with session_id so the
+    # WAL-delta apply_events below routes ONLY this session's entries into it
+    # (the empty fallback for a session with no generation yet; an on-disk
+    # generation carries its own session_id which store.load prefers).
+    base = (
+        store.load(base_seq, session_id=session_id)
+        if base_seq is not None
+        else AgentSnapshot.empty(agent_name, session_id)
+    )
 
     # Replay the ACTIVE WAL delta, bounded above by target_seq. apply_events skips
     # seq <= base.applied_seq; we additionally cap at target_seq (point-in-time)

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -59,6 +59,7 @@ class SkillRegistry:
         agent_state_dir: Path,
         state_log: "StateLog | None" = None,
         truncate_eligible_hook: Callable[[], Awaitable[None]] | None = None,
+        session_id: str = "main",
     ) -> None:
         """
         truncate_eligible_hook: optional async callback fired *after* each
@@ -72,6 +73,12 @@ class SkillRegistry:
             WAL wiring.
         """
         self._agent_name = agent_name
+        # FP-0043 Stage 5: the conversation session these skill runs belong to.
+        # Tagged onto every WAL append (session_id=) so replay routes the
+        # agent-consumed skill_* kinds (skill_started/completed/discarded) to the
+        # right per-session AgentSnapshot. Default "main" = byte-identical single
+        # session; set post-construction by spawn_session (set_session_id).
+        self._session_id = session_id
         self._state_dir = Path(agent_state_dir)
         self._skills_dir = self._state_dir / "skills"
         self._state_log = state_log
@@ -79,6 +86,22 @@ class SkillRegistry:
         # In-memory cache: run_id → SkillSnapshot. Populated on start() /
         # load_active(); cleared on complete().
         self._snapshots: dict[str, SkillSnapshot] = {}
+
+    async def _wal_append(self, kind: str, **fields):
+        """FP-0043 Stage 5: the single WAL-append chokepoint for this registry.
+
+        Injects ``session_id=self._session_id`` into every entry so replay routes
+        the agent-consumed skill_* kinds to this session's snapshot (mirrors
+        SnapshotJournal._wal_append). No-op (returns None) when no WAL configured."""
+        if self._state_log is None:
+            return None
+        log = self._state_log  # local so the funnel replace doesn't recurse here
+        return await log.append(kind, session_id=self._session_id, **fields)
+
+    def set_session_id(self, session_id: str) -> None:
+        """FP-0043 Stage 5: set the conversation session id post-construction
+        (spawn_session, before the spawned session's run-loop goes live)."""
+        self._session_id = session_id
 
     @property
     def truncate_hook(self):
@@ -142,7 +165,7 @@ class SkillRegistry:
         snap = SkillSnapshot.empty(run_id, skill_name, skill_input)
         snap.parent_run_id = parent_run_id
         if self._state_log is not None:
-            seq = await self._state_log.append(
+            seq = await self._wal_append(
                 "skill_started",
                 target=self._agent_name,
                 agent=self._agent_name,
@@ -185,7 +208,7 @@ class SkillRegistry:
             )
             return
         if self._state_log is not None:
-            seq = await self._state_log.append(
+            seq = await self._wal_append(
                 "skill_phase_advanced",
                 target=self._agent_name,
                 agent=self._agent_name,
@@ -232,7 +255,7 @@ class SkillRegistry:
                 f"expected 'completed' or 'discarded'",
             )
         if self._state_log is not None:
-            await self._state_log.append(
+            await self._wal_append(
                 kind,
                 target=self._agent_name,
                 agent=self._agent_name,

--- a/tests/test_multi_session_restore.py
+++ b/tests/test_multi_session_restore.py
@@ -1,0 +1,134 @@
+"""Tier 2: FP-0043 Stage 5 goal-proof — per-session crash-recovery isolation.
+
+The S5 promise: a spawned conversation session's state survives a restart
+INDEPENDENTLY of the agent's "main" session. This is the persistence analogue
+of S4a's in-memory isolation test — it proves the on-disk substrate (per-session
+snapshot path + session_id-routed WAL replay) keeps each session's recovery
+state separate.
+
+Mechanism under test (all via the public surface):
+  - spawn_session re-keys a spawned session's snapshot to its own per-session
+    path (no collision with main's snapshot.json);
+  - every WAL append carries the session's session_id (the _wal_append funnel);
+  - restore_all discovers main + per-session snapshots, replays the SHARED WAL
+    routing each entry by (agent, session_id), and re-adopts each session's state.
+
+State is carried as an outstanding intervention (rather than an inbox message)
+so restore re-enqueues it WITHOUT starting a live LLM turn — the same hermetic
+pattern as test_intervention_restore — keeping this test deterministic.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import ChatSession
+from reyn.core.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path, wal: Path) -> AgentRegistry:
+    """Build a registry whose sessions share one WAL (= the production wiring).
+
+    A fresh registry over the SAME project_root + wal file simulates a process
+    restart: it re-discovers on-disk snapshots and replays the WAL tail.
+    """
+    state_log = StateLog(wal)
+
+    def _factory(profile: AgentProfile) -> ChatSession:
+        s = ChatSession(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")  # satisfy listener-presence guard
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_factory,
+        state_log=state_log,
+    )
+
+
+def _iv_dict(iv_id: str, run_id: str) -> dict:
+    return {
+        "kind": "ask_user",
+        "prompt": f"Q-{iv_id}?",
+        "detail": "",
+        "choices": [],
+        "suggestions": [],
+        "run_id": run_id,
+        "skill_name": "demo",
+        "id": iv_id,
+    }
+
+
+def _active_iv_ids(session: "ChatSession") -> list[str]:
+    """Public read of a session's restored, re-enqueued interventions."""
+    return [iv.id for iv in session.interventions.list_active()]
+
+
+@pytest.mark.asyncio
+async def test_multi_session_restore_is_per_session_independent(tmp_path, monkeypatch):
+    """Tier 2: spawn → state → drop + restore_all → main & spawned each restore alone.
+
+    Asserts BOTH directions of isolation: each restored session has exactly its
+    own intervention and NOT the other's. A regression where spawned WAL entries
+    fell to "main" (the cond-4 forwarding gap) — or where the two sessions shared
+    one snapshot.json — would surface as cross-contamination or a missing iv.
+    """
+    # chdir so a factory-built ChatSession's default snapshot path
+    # (.reyn/agents/<name>/state/snapshot.json) resolves under tmp_path, aligning
+    # the session's base with registry._dir (the base-alignment invariant S5 relies on).
+    monkeypatch.chdir(tmp_path)
+
+    agent_dir = tmp_path / ".reyn" / "agents" / "alpha"
+    agent_dir.mkdir(parents=True)
+    AgentProfile.new("alpha", role="").save(agent_dir)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    # ── pre-crash: open main + a spawned session, assign distinct state ──
+    reg1 = _make_registry(tmp_path, wal)
+    main1 = reg1.get_or_load("alpha")                 # the implicit "main" session
+    sid = reg1.spawn_session("alpha")                 # a second session under the same agent
+    spawned1 = reg1.get_session("alpha", sid)
+    assert spawned1 is not None
+
+    await main1.journal.record_intervention_dispatched(
+        intervention_id="iv_main", iv_dict=_iv_dict("iv_main", "rM"),
+    )
+    await spawned1.journal.record_intervention_dispatched(
+        intervention_id="iv_spawn", iv_dict=_iv_dict("iv_spawn", "rS"),
+    )
+
+    # per-session snapshots persist to DISTINCT paths (no collision).
+    main_path = agent_dir / "state" / "snapshot.json"
+    spawn_path = agent_dir / "state" / "sessions" / sid / "snapshot.json"
+    assert main_path.is_file(), "main session snapshot must persist at the legacy path"
+    assert spawn_path.is_file(), "spawned session snapshot must persist at its per-session path"
+
+    # ── restart: a fresh registry over the same project_root + WAL ──
+    reg2 = _make_registry(tmp_path, wal)
+    snapshots = await reg2.restore_all()
+
+    # back-compat return: keyed by agent name = the main session's snapshot.
+    assert "alpha" in snapshots
+    assert list(snapshots["alpha"].outstanding_interventions) == ["iv_main"]
+
+    # let restore_state's re-enqueue tasks register the interventions.
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    # main restored ONLY its own intervention.
+    main2 = reg2.get_session("alpha")
+    assert main2 is not None
+    assert _active_iv_ids(main2) == ["iv_main"]
+
+    # spawned was recreated by restore_all and restored ONLY its own intervention.
+    spawned2 = reg2.get_session("alpha", sid)
+    assert spawned2 is not None, "restore_all must recreate the spawned session"
+    assert _active_iv_ids(spawned2) == ["iv_spawn"]
+
+    # explicit cross-contamination guard (both directions).
+    assert "iv_spawn" not in _active_iv_ids(main2)
+    assert "iv_main" not in _active_iv_ids(spawned2)

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -384,3 +384,51 @@ async def test_rewind_to_rejects_target_truncated_out_of_wal(tmp_path):
 
     with pytest.raises(RewindBeyondRetentionError):
         await reg.rewind_to(2)             # seq 2 truncated → outside retention window
+
+
+async def _put_sid(log: StateLog, agent: str, sid: str, text: str) -> int:
+    """Append a session-tagged inbox_put (mirrors the journal's _wal_append)."""
+    return await log.append(
+        "inbox_put", target=agent, session_id=sid,
+        msg_id=text, msg_kind="user", payload={"text": text},
+    )
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_is_per_session_consistent_cut(tmp_path):
+    """Tier 2: FP-0043 S5 — a global rewind reconstructs EACH session at the cut.
+
+    A whole-world rewind (D2) must bring every (agent, session) to the target,
+    each reconstructed from ONLY its own session_id-routed WAL entries. Pre-S5
+    this loop was main-only, so a spawned session's snapshot would be left at HEAD
+    — an inconsistent world. Asserts both per-session correctness (each keeps its
+    pre-cut entry, drops its post-cut entry) AND cross-session isolation.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    # The spawned session's on-disk dir must exist for disk-discovery (the rewind
+    # materialiser is shared with crash-recovery, where sessions are not loaded).
+    spawn_snap_path = (
+        tmp_path / ".reyn" / "agents" / "alpha" / "state" / "sessions" / "s1"
+        / "snapshot.json"
+    )
+    AgentSnapshot.empty("alpha", session_id="s1").save(spawn_snap_path)
+
+    await _put_sid(log, "alpha", "main", "m1")   # seq 1 — main, pre-cut
+    await _put_sid(log, "alpha", "s1", "x1")     # seq 2 — spawned, pre-cut (the cut)
+    await _put_sid(log, "alpha", "main", "m2")   # seq 3 — main, post-cut (undone)
+    await _put_sid(log, "alpha", "s1", "x2")     # seq 4 — spawned, post-cut (undone)
+
+    await reg.rewind_to(2)                        # global cut at seq 2
+
+    main_snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    spawn_snap = AgentSnapshot.load("alpha", spawn_snap_path, session_id="s1")
+
+    # each session reconstructed to ONLY its own pre-cut entry; post-cut undone.
+    assert _inbox_ids(main_snap) == ["m1"]
+    assert _inbox_ids(spawn_snap) == ["x1"]
+    # cross-session isolation (both directions).
+    assert "x1" not in _inbox_ids(main_snap)
+    assert "m1" not in _inbox_ids(spawn_snap)

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -84,6 +84,10 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
     """
     disposition = {
         "agent_name": "identity — unchanged by rewind (same agent)",
+        # FP-0043 Stage 5: a rewind operates within ONE session's timeline, so the
+        # session id is identity-like — unchanged by rewind (same session), exactly
+        # like agent_name. reset_for_rewind must NOT clear it.
+        "session_id": "identity — unchanged by rewind (same session)",
         "applied_seq": "replaced wholesale by journal.install (no separate holder)",
         "inbox": "session.inbox drained",
         "pending_chains": "session._chains.reset()",


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 Stage 5: per-session snapshot re-key (per-session time-travel + crash-recovery). Closes the heaviest, durability-critical stage of #1726. Built in 3 incremental WIP-pushed chunks, each line-by-line reviewed by lead-coder on the branch.

## What & why

S5 restructures crash-recovery + time-travel from **agent-keyed** to **(agent, session)-keyed**, so each conversation Session under a shared Agent (S2/S3/S4a) survives a restart — and rewinds — **independently**. The crux (lead-endorsed): an explicit `session_id` on each WAL entry is a **pure field-addition** — the fsync/flush/replay durability path is *unchanged by construction*; replay routing becomes deterministic via `(agent, session_id)` matching.

## Commits (chunks)

- **`68b2ed7f` (i)+(ii)** — `session_id` WAL thread + `AgentSnapshot` field. A single `_wal_append` chokepoint in `SnapshotJournal` + `SkillRegistry` injects `session_id` into every entry (funnel-complete by construction); `AgentSnapshot._matches_agent` routes by `(agent, session_id)` with absent→"main"; `ChatSession.__init__` threads it; `spawn_session` stamps a spawned sid pre-live (before the run-loop, gate-2).
- **`2ecdf9be` (iii)+(vi)** — per-session snapshot save/restore + the crash-recovery goal-proof. `spawn_session` re-keys a spawned session's persistence to `<state>/sessions/<sid>/` (no collision with main); `restore_all` discovers main + per-session snapshots, replays the shared WAL routing per-session, re-adopts each. Legacy→"main" migration automatic.
- **`c2eb9711` (iv)+(v)** — per-session rewind/generations + full named-gate sweep. `reconstruct`/`store.load` gain `session_id`; `_materialize_rewind` reconstructs the runtime snapshot per-session (workspace stays global SSoT); disk-discovery shared with crash-recovery.

## Scope boundary (lead-accepted, tracked in #1737)

Separate consumers from AgentSnapshot stay main-scoped in S5: `step_*`/truncation-floor and **orphan-plan recovery** (agent-level PlanRegistry). A spawned session's `active_plan_ids` IS restored into its snapshot; only the coordinator re-adoption defers. #1737 is the single home for that deferred consumer-scoping.

## Gates (all met)

- **byte-identical single-session** — full suite 7459 passed; `session_id` defaults to "main" everywhere at N=1.
- **named-gate adapt-not-weaken** — exactly ONE existing test changed (`test_reset_for_rewind` exhaustive-field gate: `session_id` declared as an identity-like, unchanged-by-rewind field; gate stays exhaustive). Reviewed line-by-line.
- **WAL fsync unchanged** — pure WAL-entry field-addition; durability machinery untouched.
- **migration legacy→main** — a pre-S5 install loads as "main" + absorbs session_id-absent WAL via the default.

## Test plan

- [x] `pytest -q` (rootdir) — **7459 passed**, 14 failed = pre-existing not-my-diff local-env quirks (copy_to_work×4, swebench×2, eval_judge, python_harness×4, python_step_sandbox, skill_postprocessor, web_fetch — all unrelated subsystems), **confirmed via `git stash` re-run** (fail identically without this diff). Zero new failures.
- [x] `ruff check` clean on all changed files.
- [x] `scripts/test_tier_audit.py --strict` OK on the 3 changed/added test files.
- [x] Crash-recovery isolation acceptance test (`test_multi_session_restore`, Tier-2, hermetic, public surface) — **falsification-verified**: removing the `_matches_agent` session_id filter fails it cleanly (main absorbs both interventions).
- [x] Per-session rewind isolation acceptance test (`test_rewind_to_is_per_session_consistent_cut`, Tier-2, WAL-direct = disk-discovery path) — **falsification-verified**: main-only discovery leaves the spawned snapshot empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
