### PR TITLE
refactor(1726): FP-0043 Stage 6 — ChatSession → Session holistic rename

### DIFF
--- a/src/reyn/chat/__init__.py
+++ b/src/reyn/chat/__init__.py
@@ -1,9 +1,9 @@
 """Chat agent layer.
 
-ChatSession runs a long-lived asyncio loop that turns user utterances into
+Session runs a long-lived asyncio loop that turns user utterances into
 implicit skill invocations via the stdlib `skill_router` skill. Skills run
 concurrently; the user can keep chatting while they execute.
 """
-from .session import ChatMessage, ChatSession
+from .session import ChatMessage, Session
 
-__all__ = ["ChatSession", "ChatMessage"]
+__all__ = ["Session", "ChatMessage"]

--- a/src/reyn/chat/agent.py
+++ b/src/reyn/chat/agent.py
@@ -1,13 +1,13 @@
 """Agent — the per-agent IDENTITY value object (FP-0043 Stage 2).
 
-Extracted from ``ChatSession``, which historically fused two concerns: the
+Extracted from ``Session``, which historically fused two concerns: the
 **identity** (who the agent is — name, profile role, permissions, workspace
 root, exec/FS backends) and the **conversation** (history, inbox, the running
 ``session.run()`` task). This object owns the identity cluster so that — in a
 later stage — N conversation Sessions can SHARE one ``Agent`` (identity is
 agent-scoped; conversation is session-scoped). Stage 2 is a pure, byte-identical
-extraction: one ``ChatSession`` still holds exactly one ``Agent``, and every
-former ``ChatSession`` identity field reads through it via a delegating property
+extraction: one ``Session`` still holds exactly one ``Agent``, and every
+former ``Session`` identity field reads through it via a delegating property
 — no observable behaviour changes.
 
 Assembled at the construction chokepoint (``build_scoped_chat_session``), which
@@ -17,7 +17,7 @@ profile. ``AgentRegistry`` / ``AgentProfile`` / ``AgentSnapshot`` are unchanged
 extraction stays orthogonal to it).
 
 Scope note (Stage 2, byte-identical): the agent holds ``name`` + ``role`` (the
-two identity fields that flow into a ChatSession today), NOT the full
+two identity fields that flow into a Session today), NOT the full
 ``AgentProfile`` object — threading the profile's allowlists into the session is
 NEW wiring deferred to a later stage (when permissions become explicitly
 agent-scoped). Conceptually the agent owns the profile; the wiring waits.
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class Agent:
     """The agent's identity cluster (FP-0043 Stage 2). Frozen — identity is
-    immutable for a session's lifetime (no ChatSession identity field is
+    immutable for a session's lifetime (no Session identity field is
     reassigned post-construction; verified)."""
 
     # Identity proper.
@@ -64,6 +64,6 @@ class Agent:
     @property
     def workspace_dir(self) -> Path:
         """The agent's home directory (``.reyn/agents/<name>``) — derived from
-        the name, byte-identical to ChatSession's former
+        the name, byte-identical to Session's former
         ``Path(".reyn") / "agents" / self.agent_name``."""
         return Path(".reyn") / "agents" / self.agent_name

--- a/src/reyn/chat/agent_locks.py
+++ b/src/reyn/chat/agent_locks.py
@@ -1,7 +1,7 @@
 """Per-agent serialization lock registry — shared by ALL transport layers.
 
 MCP (``reyn.mcp.server``) and A2A (``reyn.interfaces.web.routers.a2a``) both drive
-``ChatSession.run_one_iteration`` for the same shared session instance. Without
+``Session.run_one_iteration`` for the same shared session instance. Without
 cross-transport coordination a concurrent MCP request and an A2A drain loop on
 the same agent race at every ``await`` inside ``run_one_iteration``, corrupting
 ``session.history`` (both callers mutate it concurrently).

--- a/src/reyn/chat/channel_state.py
+++ b/src/reyn/chat/channel_state.py
@@ -19,7 +19,7 @@ This module defines the **data model** + **inference helpers**:
     explicit register flag)
 
 Concrete senders live in ``reyn.interfaces.web.notifications`` (= HTTP webhook)
-and channel-specific surfaces (= ``ChatSession`` listener for TUI,
+and channel-specific surfaces (= ``Session`` listener for TUI,
 ``A2AInterventionBus.deliver`` for A2A peer). This module is the
 shared vocabulary.
 
@@ -140,7 +140,7 @@ class ChannelState:
     """Per-channel running state for liveness inference (issue #269).
 
     Mutable; the owner (= ``RunRegistry`` per RunEntry for A2A peers,
-    or ``ChatSession`` per attached listener for TUI / future
+    or ``Session`` per attached listener for TUI / future
     channels) updates it on each delivery attempt.
 
     ``is_alive`` reads three signals together:

--- a/src/reyn/chat/external_routing.py
+++ b/src/reyn/chat/external_routing.py
@@ -288,7 +288,7 @@ def make_outbox_interceptor(
     """Build an outbox interceptor for FP-0041 PR-D2 wiring.
 
     Returns an async ``(OutboxMessage) -> bool`` callable to register
-    on ``ChatSession._outbox_interceptor``. When invoked:
+    on ``Session._outbox_interceptor``. When invoked:
 
       1. If ``msg.reply_to`` is not an ``ExternalRef`` → return False
          (= caller falls through to normal outbox queue).

--- a/src/reyn/chat/lifecycle_forwarder.py
+++ b/src/reyn/chat/lifecycle_forwarder.py
@@ -15,7 +15,7 @@ Designed for growth — additional lifecycle handlers (attach / detach
 notifications, budget warnings, session-level errors) can land here
 without expanding the skill forwarder's per-skill contract.
 
-Wired up in :class:`reyn.chat.session.ChatSession` via
+Wired up in :class:`reyn.chat.session.Session` via
 ``self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))``.
 """
 from __future__ import annotations

--- a/src/reyn/chat/message_bus.py
+++ b/src/reyn/chat/message_bus.py
@@ -2,7 +2,7 @@
 
 FP-0013 Component D.
 
-``MessageBus.request`` drives ``ChatSession.run_one_iteration()`` from the
+``MessageBus.request`` drives ``Session.run_one_iteration()`` from the
 same task that handles the MCP / A2A request, sidestepping the anyio
 stdio-starvation problem documented in FP-0013 §ADR-A.
 
@@ -32,7 +32,7 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.chat.transport import TransportRef
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class MessageBus:
 
     async def request(
         self,
-        agent: "ChatSession",
+        agent: "Session",
         kind: str,
         payload: dict,
         reply_to: TransportRef,
@@ -92,7 +92,7 @@ class MessageBus:
         Parameters
         ----------
         agent:
-            The ChatSession to drive.
+            The Session to drive.
         kind:
             Inbox message kind (e.g. ``"user"``).
         payload:
@@ -154,7 +154,7 @@ class MessageBus:
         return collected
 
     @staticmethod
-    def _drain_outbox(agent: "ChatSession", collected: list[OutboxMessage]) -> None:
+    def _drain_outbox(agent: "Session", collected: list[OutboxMessage]) -> None:
         """Non-blocking drain of all currently queued outbox messages."""
         while True:
             try:
@@ -168,7 +168,7 @@ class MessageBus:
             collected.append(msg)
 
     @staticmethod
-    def _is_quiescent(agent: "ChatSession") -> bool:
+    def _is_quiescent(agent: "Session") -> bool:
         """Return True when the agent has no pending work for the current call.
 
         Quiescent ≡ inbox empty AND no running skills AND no running plans.

--- a/src/reyn/chat/outbox.py
+++ b/src/reyn/chat/outbox.py
@@ -1,4 +1,4 @@
-"""OutboxMessage — structured payload for ChatSession's display stream.
+"""OutboxMessage — structured payload for Session's display stream.
 
 Replaces the previous (kind, text) tuple. Provenance fields (run_id,
 skill_name, intervention_id, …) live in `meta: dict` rather than as fixed
@@ -7,7 +7,7 @@ don't require dataclass schema changes. This mirrors the `ChatMessage.meta`
 convention already used for history entries.
 
 Outbox is the **presentation stream**, distinct from history (durable log).
-- agent / skill_done → also persisted to history.jsonl by ChatSession
+- agent / skill_done → also persisted to history.jsonl by Session
 - status / error / trace / intervention → display-only, never in history
 - __end__ → control signal for _output_loop shutdown
 """
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class OutboxMessage:
-    """One item published by ChatSession to its outbox queue.
+    """One item published by Session to its outbox queue.
 
     `kind` selects the renderer's formatting branch. `meta` carries
     optional provenance:

--- a/src/reyn/chat/planner.py
+++ b/src/reyn/chat/planner.py
@@ -915,7 +915,7 @@ async def execute_plan(
     # PR-N4: lazy engine construction (path b).
     #
     # Design choice: path (b) rather than path (a) from the spec.
-    # Threading the ChatSession's engine through dispatcher → RouterLoop →
+    # Threading the Session's engine through dispatcher → RouterLoop →
     # RouterCallerState → PlanRuntime → execute_plan would require touching
     # router_loop.py and session.py (outside the ALLOWED file list for this
     # PR). Path (b) constructs a minimal engine per-plan-run from router_model.
@@ -1500,7 +1500,7 @@ async def dispatch_plan_tool(
          cross-agent notify works for ``/plan discard``).
       3. Write decomposition artifact (= P5 SSoT for resume).
       4. Construct ``PlanRuntime(plan_id=…, chain_id=plan_chain_id)``.
-      5. Hand off to ``host.spawn_plan_task`` — ChatSession owns the
+      5. Hand off to ``host.spawn_plan_task`` — Session owns the
          task lifecycle, terminal-text outbox emit, and decomposition
          cleanup on clean exit.
       6. Return ``{"status": "spawned", "plan_id": ..., ...}``.
@@ -1540,7 +1540,7 @@ async def dispatch_plan_tool(
     except Exception as exc:  # noqa: BLE001
         logger.warning("write_plan_decomposition failed: %r", exc)
 
-    # Construct the runtime; ChatSession spawns it as a task and owns
+    # Construct the runtime; Session spawns it as a task and owns
     # the lifecycle (= terminal outbox emit + artifact cleanup).
     from reyn.core.plan import PlanRuntime
     runtime = PlanRuntime(

--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -1,6 +1,6 @@
-"""AgentRegistry — owner of all ChatSession instances in a `reyn chat` process.
+"""AgentRegistry — owner of all Session instances in a `reyn chat` process.
 
-PR10 introduces multiple agents (= multiple ChatSession instances) sharing
+PR10 introduces multiple agents (= multiple Session instances) sharing
 one process. The registry handles persistence (`.reyn/agents/<name>/`),
 lifecycle (lazy load, background `session.run()` task, attach/detach), and
 attached-agent routing for the REPL.
@@ -16,7 +16,7 @@ Lifecycle invariants (PR10):
 The registry deliberately knows nothing about prompt_toolkit, renderers,
 or the inbox/outbox queue mechanics — those live in `repl.py`. Registry's
 contract is:
-- `attached` returns the currently-attached ChatSession (or None)
+- `attached` returns the currently-attached Session (or None)
 - `attach(name)` makes that session the attached one and returns it
 - `running_tasks_for_agents()` lets the REPL `await` shutdown drain
 """
@@ -101,7 +101,7 @@ def _validate_agent_name(name: str) -> None:
 
 
 class AgentRegistry:
-    """In-process map of agent_name -> ChatSession with persistence wired in.
+    """In-process map of agent_name -> Session with persistence wired in.
 
     Owns the **REPL-facing outbox**: a single queue that consumers (e.g.
     `repl._output_loop`) read regardless of which agent is attached. A
@@ -109,7 +109,7 @@ class AgentRegistry:
     only while that agent is the attached one — detached agents drop
     transient outbox items, durable kinds (agent / skill_done) still
     persist to history via the agent's `_append_history` (handled at the
-    ChatSession layer, not here).
+    Session layer, not here).
     """
 
     def __init__(
@@ -125,7 +125,7 @@ class AgentRegistry:
         act_turn_capture: bool = False,
     ) -> None:
         """
-        session_factory: returns a configured ChatSession given an AgentProfile.
+        session_factory: returns a configured Session given an AgentProfile.
             The factory captures CLI-derived defaults (model, resolver, permissions,
             limits, mcp config, …) — registry doesn't need to know them.
         state_log: PR21 WAL for crash recovery. When None, persistence is
@@ -144,7 +144,7 @@ class AgentRegistry:
         self._project_root = project_root
         # FP-0043 Stage 3: the Registry holds N conversation Sessions per Agent.
         # Identity (the Agent value object, S2) is shared per name; the
-        # conversation instances (= today's ChatSession, inbox+run-loop+history)
+        # conversation instances (= today's Session, inbox+run-loop+history)
         # are keyed by an opaque session-id, default ``_DEFAULT_SID`` ("main") so
         # single-session behaviour is byte-identical. Inbound routing to non-main
         # sessions is Stage 4 — S3 just lets the structure hold N.
@@ -1197,7 +1197,7 @@ class AgentRegistry:
     # would force the WAL to know about agent / skill layout.
 
     _TRUNCATION_THROTTLE_SECS: float = 5.0
-    # R-D4: size safety net default. ChatSession's chat-turn-boundary
+    # R-D4: size safety net default. Session's chat-turn-boundary
     # call uses this threshold. Long-idle skills with no semantic
     # boundary events (= no phase_advanced / skill_completed) would
     # otherwise let the WAL grow unboundedly between turns.
@@ -1298,7 +1298,7 @@ class AgentRegistry:
 
         Called from places that don't naturally fire phase-completion
         events but still want to bound WAL growth — primarily the
-        ChatSession chat-turn boundary (each user message handled).
+        Session chat-turn boundary (each user message handled).
 
         Behavior:
           - If WAL file size <= threshold (default 1 MB): no-op, no
@@ -1458,13 +1458,13 @@ class AgentRegistry:
         choice (event loop friendly, event-sourced state from WAL apply,
         no thread offload).
 
-        Dormant agents (no live ChatSession registered in
+        Dormant agents (no live Session registered in
         ``self._agents``) are excluded from the floor calculation — the
         same skip the pre-N7 disk-read path applied for
         ``applied_seq == 0`` snapshots. The invariant that justifies
         this:
 
-          A dormant agent has no live ``ChatSession``. WAL events are
+          A dormant agent has no live ``Session``. WAL events are
           only appended through a session's ``SnapshotJournal``, which
           targets the session's own agent. Therefore no WAL event can
           target an agent whose session has never been instantiated
@@ -1509,7 +1509,7 @@ class AgentRegistry:
     # ── lifecycle ────────────────────────────────────────────────────────────
 
     def get_or_load(self, name: str) -> "object":
-        """Return the ChatSession for `name`, instantiating from profile if new."""
+        """Return the Session for `name`, instantiating from profile if new."""
         existing = self._peek_session(name)
         if existing is not None:
             return existing
@@ -1626,7 +1626,7 @@ class AgentRegistry:
             if old_session is not None:
                 # Mark detached BEFORE switching so transient outbox emissions
                 # from the old session start dropping at the source
-                # (`ChatSession._put_outbox` filters status/trace).
+                # (`Session._put_outbox` filters status/trace).
                 old_session.is_attached = False
 
         new_session.is_attached = True
@@ -1784,7 +1784,7 @@ class AgentRegistry:
     def iter_other_agents(self, self_name: str) -> list[dict]:
         """List `{name, role}` for every agent except `self_name`.
 
-        Used by RouterLoop (via ChatSession.list_available_agents) to populate
+        Used by RouterLoop (via Session.list_available_agents) to populate
         the reachable agent list. `role` is the first non-empty line of
         each agent's profile.role; empty when the agent has no role.
         """

--- a/src/reyn/chat/router_loop.py
+++ b/src/reyn/chat/router_loop.py
@@ -656,7 +656,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     def get_action_embedding_index(self) -> Any:
         """Return the session-scoped ActionEmbeddingIndex, or None.
 
-        FP-0034 Phase 2 step 1.  Bound by ChatSession when the operator
+        FP-0034 Phase 2 step 1.  Bound by Session when the operator
         has configured ``action_retrieval.embedding_class``.
         """
         ...
@@ -819,7 +819,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     ) -> None: ...
 
     # Plan-mode per-step WAL persistence (ADR-0023 Phase 2 step 6).
-    # Optional — test stubs may omit. ChatSession routes these through
+    # Optional — test stubs may omit. Session routes these through
     # SnapshotJournal.record_plan_step_*.
     async def record_plan_step_started(
         self, *, plan_id: str, step_id: str, depends_on: list[str],
@@ -837,7 +837,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     # Decomposition artifact persistence (ADR-0023 §3.5).
     # The artifact is the canonical SSoT for the plan shape on resume.
-    # ChatSession threads this through reyn.core.plan.decomposition with the
+    # Session threads this through reyn.core.plan.decomposition with the
     # agent-specific state directory; test stubs may no-op.
     async def write_plan_decomposition(
         self, *, plan_id: str, plan: "Any",
@@ -854,7 +854,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     ) -> None:
         """Register a PlanRuntime as a background task (ADR-0023 Phase 2.1).
 
-        ChatSession owns the task lifecycle (= ``running_plans`` dict)
+        Session owns the task lifecycle (= ``running_plans`` dict)
         and the wrap-around finally that emits the terminal aggregator
         text via ``put_outbox(kind="agent")`` and cleans up the
         decomposition artifact on clean exit. dispatch_plan_tool hands
@@ -1386,7 +1386,7 @@ class RouterLoop:
         router_model: "str | None" = None,  # #1672: None → config (model_class_for("router")); was hardcoded "light"
         budget: Any = None,  # BudgetTracker | None — process-shared cost tracker
         system_prompt_override: str | None = None,
-        non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from ChatSession.
+        non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from Session.
         exclude_tools: set[str] | None = None,
         excluded_categories: set[str] | None = None,  # #1667 catalog categories skipped at source
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
@@ -1431,7 +1431,7 @@ class RouterLoop:
         # clarifying question" directive. The original #1440 wired only the
         # session-side _build_router_system_prompt (override/budget path), missing
         # this live path → run-once still dead-stopped (13398). Threaded from
-        # ChatSession._non_interactive via the constructor.
+        # Session._non_interactive via the constructor.
         self._non_interactive = bool(non_interactive)
         # Tool names to drop from the catalog (= post-build filter). Used by
         # plan executor to pass ``{"plan"}`` so plan steps cannot recursively
@@ -1844,7 +1844,7 @@ class RouterLoop:
                     host, "reasoning_continuity_section", lambda: ""
                 )(),
             )
-        # ChatSession._handle_user_message appends the user turn to history
+        # Session._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the
         # caller's `history` argument already ends with this turn's user
         # message. Appending it again as a trailing user message creates a
@@ -1859,7 +1859,7 @@ class RouterLoop:
         # When history's last entry is a user message, trust it — it is
         # either:
         #   - text identical to ``user_text`` (= the normal chat path,
-        #     ChatSession already appended it via _append_history); or
+        #     Session already appended it via _append_history); or
         #   - a content-list shape (= issue #366 multimodal turn where
         #     the user attached images via /image; comparing string
         #     ``user_text`` against the list would always fail and

--- a/src/reyn/chat/router_op_context.py
+++ b/src/reyn/chat/router_op_context.py
@@ -1,7 +1,7 @@
 """#1412: single-source the chat-router OpContext construction.
 
 Two hosts built the ``skill_name="chat_router"`` OpContext with ~95% identical
-code: ``ChatSession._make_router_op_context`` (session.py) and
+code: ``Session._make_router_op_context`` (session.py) and
 ``RouterHostAdapter.make_router_op_context`` (services/router_host_adapter.py).
 They drifted — #1410/#1411 threaded ``base_dir`` to one and lagged the other
 (the #187 wrong-FS class). This factory is the single source for the common
@@ -16,7 +16,7 @@ The divergence the single-sourcing makes explicit (e.g. RouterHostAdapter never
 wires ``agent_id``) is surfaced for a follow-up classification, NOT folded here
 (same "root-fix surfaces a latent gap" pattern as #1402 -> #1431).
 
-Which-ops trace (#1412): ChatSession's impl serves file ops (``_file_op``) +
+Which-ops trace (#1412): Session's impl serves file ops (``_file_op``) +
 MCP ops (which wire ``intervention_bus`` POST-HOC on the returned ctx), so its
 ``intervention_bus=None`` at construction is a wiring-style difference, not a
 missing capability; media/multimodal/compact ops go via the registry /
@@ -53,7 +53,7 @@ def build_router_op_context(
     sandbox_policy: Any,  # raw policy → resolve_sandbox_policy here (#1339)
     # ── per-host fields (caller-supplied; behavior-preserving) ─────────────
     agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
-    intervention_bus: Any = None,  # ChatSession wires post-hoc; RouterHostAdapter inline
+    intervention_bus: Any = None,  # Session wires post-hoc; RouterHostAdapter inline
     multimodal_config: Any = None,  # #364
     media_store: Any = None,  # #383
     compact_now: Any = None,  # #272/#1128

--- a/src/reyn/chat/scoped_session_factory.py
+++ b/src/reyn/chat/scoped_session_factory.py
@@ -1,6 +1,6 @@
-"""#1402: single-source scoped ChatSession construction.
+"""#1402: single-source scoped Session construction.
 
-Three frontends build a ``ChatSession`` with overlapping-but-divergent scoped
+Three frontends build a ``Session`` with overlapping-but-divergent scoped
 wiring:
 
 - ``cli/commands/chat.py`` (chat-CLI / ``run-once``) — the full scoped set;
@@ -15,7 +15,7 @@ exec-seam #1419, empty-stop #1424). This factory is the single chokepoint:
   so every frontend MUST pass them explicitly — ``None`` / off means "not used
   here" *documented*, never silently omitted. Adding a new scoped capability
   here forces all three factories to decide (completeness-by-construction);
-- the common base params flow through ``**base`` so a non-scoped ``ChatSession``
+- the common base params flow through ``**base`` so a non-scoped ``Session``
   param can never drift between factories.
 
 This is a **behavior-preserving** refactor (#1402 lead decision): each factory
@@ -25,7 +25,7 @@ container-rooting) are an explicit-default-documented follow-up — a consumer
 that needs one (e.g. an A2A SWE runner) flips that factory's default to a real
 value in one line.
 
-The multi-callsite invariant (no factory constructs ``ChatSession`` directly —
+The multi-callsite invariant (no factory constructs ``Session`` directly —
 all route through here) is pinned by
 ``tests/test_scoped_session_factory_invariant_1402.py``.
 """
@@ -34,7 +34,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from reyn.chat.agent import Agent
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,17 +69,17 @@ def build_scoped_chat_session(
     chat_tool_use_scheme: str,  # #1593 PR-2 config.tool_use.chat — chat-layer ToolUseScheme name (UNIFORM: every frontend resolves the same reyn.yaml value)
     # ── common base (pass-through; session identity/infra, not a drift surface) ──
     **base: Any,
-) -> ChatSession:
-    """Construct a ``ChatSession`` with the scoped capability + per-session
+) -> Session:
+    """Construct a ``Session`` with the scoped capability + per-session
     config surface passed explicitly. See module docstring for the drift-class
     rationale."""
     # FP-0043 Stage 2: assemble the Agent identity value object at this single
     # construction chokepoint (it gathers every identity input — the explicit
     # scoped env/sandbox/workspace params + the name/model/resolver/role that flow
-    # via ``**base``). ChatSession reads all identity fields through this object
+    # via ``**base``). Session reads all identity fields through this object
     # (delegating properties). This is the prerequisite seam for N Sessions sharing
     # one Agent (a later stage); behaviour here is byte-identical. The identity
-    # params still flow through (for ChatSession's direct/test fallback) — pruning
+    # params still flow through (for Session's direct/test fallback) — pruning
     # them is a later-stage cleanup once sharing is wired.
     agent = Agent(
         agent_name=base["agent_name"],
@@ -92,7 +92,7 @@ def build_scoped_chat_session(
         sandbox_backend=sandbox_backend,
         environment_backend=environment_backend,
     )
-    return ChatSession(
+    return Session(
         agent=agent,
         environment_backend=environment_backend,
         sandbox_backend=sandbox_backend,

--- a/src/reyn/chat/services/__init__.py
+++ b/src/reyn/chat/services/__init__.py
@@ -1,4 +1,4 @@
-"""Service classes extracted from ChatSession (waves 1, 2, and 3)."""
+"""Service classes extracted from Session (waves 1, 2, and 3)."""
 from reyn.chat.services.a2a_handler import A2AHandler
 from reyn.chat.services.auto_resume_handler import AutoResumeHandler
 from reyn.chat.services.budget_gateway import BudgetGateway

--- a/src/reyn/chat/services/a2a_handler.py
+++ b/src/reyn/chat/services/a2a_handler.py
@@ -1,6 +1,6 @@
 """A2AHandler — agent-to-agent messaging logic.
 
-Extracted from ChatSession (FP-0019 Wave 2 part 2, final).  Owns the
+Extracted from Session (FP-0019 Wave 2 part 2, final).  Owns the
 agent-side of the A2A protocol: inbox handling for ``agent_request`` /
 ``agent_response``, pending-chain lifecycle, and multi-hop relay
 coordination.
@@ -14,7 +14,7 @@ and the FP-0013 RoutingLayer's ``AgentRef`` handler.
 
 Design constraints (same pattern as Wave 1/1b/2 services):
 - Injected deps at construction (typed + Callable callbacks).
-- No direct reference to ChatSession.
+- No direct reference to Session.
 - All state mutations go through injected event_log (P6).
 - No skill-specific strings (P7).
 """
@@ -94,7 +94,7 @@ _PEER_REPLY_FAILED_MSG: dict[str, str] = {
 class A2AHandler:
     """Agent-to-agent messaging service.
 
-    Extracted from ChatSession (FP-0019 Wave 2 part 2).
+    Extracted from Session (FP-0019 Wave 2 part 2).
 
     Owns:
     - ``_send_to_agent`` — depth-guarded delegation request dispatch
@@ -116,7 +116,7 @@ class A2AHandler:
     max_hop_depth:
         Maximum delegation hop depth (LangGraph-style guard).
     safety_extensions:
-        Mutable ``dict[str, float]`` from ChatSession — shared by reference so
+        Mutable ``dict[str, float]`` from Session — shared by reference so
         extensions granted by ``handle_chat_limit_checkpoint`` are visible here.
     output_language:
         BCP-47 language code for localised user-facing error messages.  Falls
@@ -145,7 +145,7 @@ class A2AHandler:
         call.  A2AHandler calls this after the depth-drop guard passes.
     on_chain_timeout_fire:
         Async callable ``(chain_id) -> None`` — invoked by ChainManager when a
-        chain's watchdog fires.  Stays in ChatSession; A2AHandler only passes
+        chain's watchdog fires.  Stays in Session; A2AHandler only passes
         it as ``on_fire`` to ``chain_manager.arm_timeout``.
     """
 
@@ -168,7 +168,7 @@ class A2AHandler:
         send_response_callback: "Callable[[str, str, str, int, str], Awaitable[None]]",
         on_chain_timeout_fire: "Callable[[str], Awaitable[None]]",
         emit_router_cap_exhausted_fn: "Callable",  # async (exc, *, chain_id) → None
-        # Delegation tracking (mutable list refs owned by ChatSession)
+        # Delegation tracking (mutable list refs owned by Session)
         get_router_loop_delegations: "Callable[[], list[dict] | None]",
         set_router_loop_delegations: "Callable[[list[dict] | None], None]",
         get_router_loop_agent_replies: "Callable[[], list[str] | None]",
@@ -658,7 +658,7 @@ class A2AHandler:
     ) -> None:
         """User-facing wrap-up when the per-turn router cap is reached.
 
-        Delegates to ChatSession._emit_router_cap_exhausted_user (injected at
+        Delegates to Session._emit_router_cap_exhausted_user (injected at
         construction) so both the SkillPlanGlue and A2AHandler paths call a
         single implementation — zero drift by construction (#1538).
         """

--- a/src/reyn/chat/services/auto_resume_handler.py
+++ b/src/reyn/chat/services/auto_resume_handler.py
@@ -1,6 +1,6 @@
 """AutoResumeHandler — crash recovery for in-flight skill_runs.
 
-Extracted from ChatSession (FP-0019 Wave 3). Reads WAL on session start,
+Extracted from Session (FP-0019 Wave 3). Reads WAL on session start,
 identifies skill_runs that were in-flight at the last shutdown / crash,
 and re-spawns them via the injected launcher callback.
 
@@ -9,7 +9,7 @@ narrator path that previously co-existed with the resume logic.
 Depends on FP-0019 Wave 1b SkillRunner (landed ``9ae66fa``).
 
 All event emissions go through the injected ``event_log``; no silent
-state changes (P6).  Business logic lives entirely here; ChatSession
+state changes (P6).  Business logic lives entirely here; Session
 delegates via :meth:`resume_active` (P3).
 """
 from __future__ import annotations
@@ -49,7 +49,7 @@ class AutoResumeHandler:
         stale pending interventions are pruned from the session.
     launcher:
         Async callable ``(ResumeDecision) -> None``.  In production this is
-        ``ChatSession._spawn_resumed_skill``; in tests it is a stub that records
+        ``Session._spawn_resumed_skill``; in tests it is a stub that records
         dispatched decisions without launching a real SkillRuntime.
     """
 
@@ -107,7 +107,7 @@ class AutoResumeHandler:
           3. ``discard`` decisions: call SkillRegistry.complete +
              drop pending interventions (no task launched)
           4. All other decisions: invoke ``launcher(decision)`` so
-             the caller (production = ``ChatSession._spawn_resumed_skill``)
+             the caller (production = ``Session._spawn_resumed_skill``)
              can wire the actual asyncio task
 
         ``launcher`` kwarg overrides the instance-level launcher injected at

--- a/src/reyn/chat/services/budget_gateway.py
+++ b/src/reyn/chat/services/budget_gateway.py
@@ -1,11 +1,11 @@
 """BudgetGateway — per-session adapter on top of process-shared BudgetTracker
-(extracted from ChatSession wave 3 PR1).
+(extracted from Session wave 3 PR1).
 
 BudgetTracker is a process-shared, ledger-backed object owned by the
 AgentRegistry / startup config; it is NOT owned by this gateway. The gateway
 holds a reference to it (or None for unlimited mode) and absorbs the
 per-session bookkeeping that previously lived as scattered attributes on
-ChatSession: total_usage, total_cost_usd, router cap counter, last reason.
+Session: total_usage, total_cost_usd, router cap counter, last reason.
 """
 from __future__ import annotations
 
@@ -70,7 +70,7 @@ class BudgetGateway:
 
     def accumulate(self, result) -> None:
         """Accumulate a single LLM call result's tokens + cost into per-session
-        totals. Mirrors ChatSession._accumulate."""
+        totals. Mirrors Session._accumulate."""
         if result.token_usage is not None:
             self._total_usage += result.token_usage
         if result.cost_usd is not None:

--- a/src/reyn/chat/services/chain_manager.py
+++ b/src/reyn/chat/services/chain_manager.py
@@ -1,4 +1,4 @@
-"""ChainManager — owns pending_chains lifecycle (extracted from ChatSession wave 1B).
+"""ChainManager — owns pending_chains lifecycle (extracted from Session wave 1B).
 
 Manages: register / update / resolve / timeout + asyncio timer arm/cancel.
 Persistent fields go through SnapshotJournal (via _JournalLike protocol).

--- a/src/reyn/chat/services/compaction_controller.py
+++ b/src/reyn/chat/services/compaction_controller.py
@@ -1,20 +1,20 @@
 """CompactionController — synchronous head/body/tail compaction.
 
-Extracted from ChatSession (FP-0019 Wave 1).  Drives OS-internal compaction
+Extracted from Session (FP-0019 Wave 1).  Drives OS-internal compaction
 (PR-N3: direct Python helper, no skill/phase overhead) via
 :meth:`force_compact_now`, the synchronous pre-frame guard path.
 
 #1128 PR-a: the background fire-and-forget path (``spawn_maybe`` →
 ``_maybe_compact``, the 30K-absolute ``trigger_total_tokens`` trigger) was
 removed. Auto-compaction is now driven solely by the synchronous pre-frame
-guard (``ChatSession._maybe_force_compact_for_router`` → :meth:`force_compact_now`,
+guard (``Session._maybe_force_compact_for_router`` → :meth:`force_compact_now`,
 window-relative ``effective_trigger``, token-budget candidate selection per
 step 3), plus on-demand (the ``compact`` op / ``/compact``) and the
 ``retry_loop`` overflow backstop. With no background task, compaction always
 runs synchronously inside the serial router handler.
 
 All event emissions go through the injected ``event_log``; no silent
-state changes (P6).  Business logic lives entirely here; ChatSession
+state changes (P6).  Business logic lives entirely here; Session
 delegates via :meth:`force_compact_now` (P3).
 """
 from __future__ import annotations
@@ -101,7 +101,7 @@ class CompactionController:
         that owns the single LLM call (PR-N3: OS-internal, no skill/phase).
     history_appender:
         Callable ``(ChatMessage) -> None`` that appends a message to the
-        persisted history.  Wraps ``ChatSession._append_history``.
+        persisted history.  Wraps ``Session._append_history``.
     make_summary_message:
         Callable ``(rendered_text, structured, covers_through_seq) ->
         ChatMessage`` that constructs the summary ``ChatMessage`` to be

--- a/src/reyn/chat/services/context_budget_advisor.py
+++ b/src/reyn/chat/services/context_budget_advisor.py
@@ -1,7 +1,7 @@
-"""ContextBudgetAdvisor — per-turn token budget computation for ChatSession.
+"""ContextBudgetAdvisor — per-turn token budget computation for Session.
 
-Extracted from ChatSession (session.py refactor PR-1).  Owns the five
-budget-arithmetic methods that were inline on ChatSession:
+Extracted from Session (session.py refactor PR-1).  Owns the five
+budget-arithmetic methods that were inline on Session:
 
   - cap_tool_result       — truncate oversized tool-result text (#1128 size axis)
   - per_turn_cap_tokens   — derive B_M-relative per-turn token ceiling
@@ -14,7 +14,7 @@ Plus the shared helper:
   - _free_window_now      — (effective_trigger, estimated_history_tokens)
 
 All public methods are pure or only cause contained async side effects on
-the compaction controller.  ChatSession holds an instance and forwards
+the compaction controller.  Session holds an instance and forwards
 each method as a callback to RouterHostAdapter, keeping the external API
 byte-identical (no caller changes outside session.py).
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 class ContextBudgetAdvisor:
     """Per-turn token budget advisor for the chat router loop.
 
-    Constructed once per ChatSession; passed as callbacks to RouterHostAdapter.
+    Constructed once per Session; passed as callbacks to RouterHostAdapter.
     """
 
     def __init__(

--- a/src/reyn/chat/services/intervention_handler.py
+++ b/src/reyn/chat/services/intervention_handler.py
@@ -1,6 +1,6 @@
 """InterventionHandler — user-facing ask_user flow routing.
 
-Extracted from ChatSession (FP-0019 Wave 2 part 1).  Owns the
+Extracted from Session (FP-0019 Wave 2 part 1).  Owns the
 ask_user dispatch path, intervention announcement to outbox, and
 answer delivery coordination.
 
@@ -10,7 +10,7 @@ extraction, snapshot_journal).
 
 Design constraints (same pattern as other Wave 1/1b services):
 - Injected deps at construction (typed + Callable callbacks).
-- No direct reference to ChatSession.
+- No direct reference to Session.
 - All state mutations go through injected event_log (P6).
 - No skill-specific strings (P7).
 """
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 # Issue #261 / #254 Phase 4 follow-up — source-agent threading.
 #
-# When ``ChatSession.handle_intervention`` takes the ``parent_delegate``
+# When ``Session.handle_intervention`` takes the ``parent_delegate``
 # branch, it sets this var to the name of the agent that decided to
 # delegate (= the *upstream* / source agent, i.e. the recipient who
 # couldn't answer locally and forwarded to its parent). The downstream
@@ -110,7 +110,7 @@ def _iv_meta(iv: UserIntervention) -> dict:
 class InterventionHandler:
     """Routes user-input answers to pending ask_user interventions.
 
-    Extracted from ChatSession (FP-0019 Wave 2 part 1).
+    Extracted from Session (FP-0019 Wave 2 part 1).
 
     Parameters
     ----------
@@ -130,7 +130,7 @@ class InterventionHandler:
     append_history:
         Sync callable ``(role, text, ts, meta) -> None`` — appends a
         conversational history entry for answered interventions.  The
-        callable receives the same positional kwargs as ChatSession's
+        callable receives the same positional kwargs as Session's
         internal ``_append_history`` helper, except it is simplified to
         only the fields InterventionHandler needs.
     """

--- a/src/reyn/chat/services/intervention_registry.py
+++ b/src/reyn/chat/services/intervention_registry.py
@@ -1,4 +1,4 @@
-"""InterventionRegistry — owns active-intervention queue (extracted from ChatSession wave 1C).
+"""InterventionRegistry — owns active-intervention queue (extracted from Session wave 1C).
 
 Crash-recovery persistence (PR-intervention-link L2/L5/L6 + R-D12):
 in-flight interventions ARE durably tracked. ``SnapshotJournal`` records
@@ -6,14 +6,14 @@ in-flight interventions ARE durably tracked. ``SnapshotJournal`` records
 ``intervention_answer_buffered`` / ``intervention_answer_consumed`` events
 to the WAL and maintains ``outstanding_interventions`` +
 ``buffered_intervention_answers`` in the per-agent snapshot. After a
-restart, ``ChatSession.restore_state`` calls :meth:`restore` to re-enqueue
+restart, ``Session.restore_state`` calls :meth:`restore` to re-enqueue
 the saved interventions with a watcher coroutine that fires
 ``intervention_resolved`` once the user answers — see
 ``test_intervention_restore`` + ``test_session_intervention_persistence``
 for the e2e pins.
 
 Announce callback is injected at construction so the registry has no direct
-dependency on ChatSession.
+dependency on Session.
 """
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ class InterventionRegistry:
 
     Crash-recovery persistence is handled outside this class — the
     ``SnapshotJournal`` records dispatch/resolve/buffer events to the WAL
-    and ``ChatSession.restore_state`` calls :meth:`restore` to re-enqueue
+    and ``Session.restore_state`` calls :meth:`restore` to re-enqueue
     saved interventions after a restart. See module docstring for the full
     flow.
 
@@ -70,7 +70,7 @@ class InterventionRegistry:
             registry without a real listener and feed answers manually via
             ``deliver_answer``).
 
-            ChatSession (and any future top-level entry that owns its own
+            Session (and any future top-level entry that owns its own
             listener wiring) opts in via this flag so a missing listener
             (= headless deploy, test without TUI mount, A2A peer offline)
             fails closed instead of waiting on an unresolvable future.
@@ -85,7 +85,7 @@ class InterventionRegistry:
         self._listeners: set[str] = set()
         # issue #268 Phase 1: stalled queue — iv whose origin channel
         # closed while the iv was unresolved. Other channels can
-        # observe / discard / claim entries here via the ChatSession
+        # observe / discard / claim entries here via the Session
         # API; the iv's future stays unresolved until a claim moves it
         # back to ``_active`` for a new origin channel or a discard
         # cancels it. ``_active`` and ``_stalled`` are mutually
@@ -165,7 +165,7 @@ class InterventionRegistry:
     def mark_stalled(self, iv_id: str) -> bool:
         """Move *iv_id* from ``_active`` to ``_stalled``.
 
-        Called by ``ChatSession.handle_intervention`` when the iv's
+        Called by ``Session.handle_intervention`` when the iv's
         ``origin_channel_id`` no longer maps to a registered listener
         (= origin channel closed). Returns True iff the iv was in
         ``_active`` and is now in ``_stalled``.
@@ -189,7 +189,7 @@ class InterventionRegistry:
 
         Read-only snapshot — caller iterates without holding the
         registry's internal collection. Used by
-        ``ChatSession.list_stalled_interventions`` for the cross-channel
+        ``Session.list_stalled_interventions`` for the cross-channel
         observe surface.
         """
         return list(self._stalled.values())
@@ -449,7 +449,7 @@ class InterventionRegistry:
         alive and avoid task GC warnings). FIFO order matches the input list.
 
         Synchronous (not async) so callers from sync context — like
-        ``ChatSession.restore_state`` — don't have to wrap in
+        ``Session.restore_state`` — don't have to wrap in
         ``asyncio.ensure_future`` (which would add a task layer that delays
         when the children become visible in the queue).
         """

--- a/src/reyn/chat/services/memory_service.py
+++ b/src/reyn/chat/services/memory_service.py
@@ -1,9 +1,9 @@
 """MemoryService — per-session memory persistence helpers
-(extracted from ChatSession wave 3 PR2).
+(extracted from Session wave 3 PR2).
 
 Stateless service that centralises the path-resolution + file-op orchestration
 for the remember / forget / read_body operations that previously lived on
-ChatSession.  All file I/O goes through injected async callbacks so the
+Session.  All file I/O goes through injected async callbacks so the
 permission boundary (OpContext) is never bypassed — MemoryService intentionally
 knows nothing about op_runtime, OpContext, Workspace, or PermissionResolver.
 """

--- a/src/reyn/chat/services/plan_runner.py
+++ b/src/reyn/chat/services/plan_runner.py
@@ -1,11 +1,11 @@
 """PlanRunner — plan task lifecycle (launch / track / resume).
 
-Extracted from ChatSession (FP-0019 follow-up, RunSpawner wave). Owns the
+Extracted from Session (FP-0019 follow-up, RunSpawner wave). Owns the
 ``running_plans`` dict and the spawn paths for both fresh plan runs
 (:meth:`spawn_plan_task`) and resumed plans (:meth:`spawn_resumed_plan`).
 Mirrors the SkillRunner contract: the session wires callbacks
 (:func:`put_outbox`, :func:`enqueue_plan_completed`, …) so this service
-never holds a direct ChatSession reference.
+never holds a direct Session reference.
 
 The router-facing entry point for spawning a plan is
 ``RouterHostAdapter.spawn_plan_task`` which is bound to

--- a/src/reyn/chat/services/router_history_buffer.py
+++ b/src/reyn/chat/services/router_history_buffer.py
@@ -1,6 +1,6 @@
-"""RouterHistoryBuffer — history slicing and SP assembly for ChatSession.
+"""RouterHistoryBuffer — history slicing and SP assembly for Session.
 
-Extracted from ChatSession (session.py refactor PR-2).  Owns:
+Extracted from Session (session.py refactor PR-2).  Owns:
 
   - build_history              — slice history into OpenAI-style messages
   - decompose_history_for_retry — head/raw_middle/tail/summary for retry_loop
@@ -133,9 +133,9 @@ def _materialise_path_ref_content(
 
 
 class RouterHistoryBuffer:
-    """Router-view history slicer and system-prompt assembler for ChatSession.
+    """Router-view history slicer and system-prompt assembler for Session.
 
-    Constructed once per ChatSession; owns the three methods that build the
+    Constructed once per Session; owns the three methods that build the
     context presented to the router LLM each turn.
     """
 

--- a/src/reyn/chat/services/router_host_adapter.py
+++ b/src/reyn/chat/services/router_host_adapter.py
@@ -1,9 +1,9 @@
 """RouterHostAdapter — concrete RouterLoopHost implementation.
 
-Extracted from ChatSession wave 3 PR3. Composes ChatSession's collaborators
+Extracted from Session wave 3 PR3. Composes Session's collaborators
 (MemoryService, SnapshotJournal, op-runtime callbacks) so RouterLoop has no
-direct dependency on ChatSession internals. The adapter satisfies the
-RouterLoopHost Protocol structurally; ChatSession constructs one and exposes
+direct dependency on Session internals. The adapter satisfies the
+RouterLoopHost Protocol structurally; Session constructs one and exposes
 it via `self._router_host`.
 """
 from __future__ import annotations
@@ -21,11 +21,11 @@ _DEFAULT_STATE_DIR = Path(".reyn") / "state"
 
 
 class RouterHostAdapter:
-    """Concrete RouterLoopHost implementation extracted from ChatSession.
+    """Concrete RouterLoopHost implementation extracted from Session.
 
     Holds injected identity attrs, catalogue deps, and async callbacks so
     RouterLoop can call host methods without importing or referencing
-    ChatSession directly.
+    Session directly.
 
     Parameters
     ----------
@@ -143,7 +143,7 @@ class RouterHostAdapter:
         agent_replies_tracker: Callable[[], "list[str] | None"],
         # FP-0034 PR-3b-iii/iv: universal catalog wrapper visibility
         # (= reyn.yaml action_retrieval.universal_wrappers_enabled).
-        # ChatSession passes True by default since PR-3b-iv flipped the
+        # Session passes True by default since PR-3b-iv flipped the
         # ActionRetrievalConfig default; this constructor parameter
         # still defaults to False so direct callers (= tests that build
         # adapters by hand) preserve the prior tools= shape and don't
@@ -151,7 +151,7 @@ class RouterHostAdapter:
         universal_wrappers_enabled: bool = False,
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator configured
-        # ``action_retrieval.embedding_class`` AND ChatSession built a
+        # ``action_retrieval.embedding_class`` AND Session built a
         # provider AND the index has been initialized), search_actions
         # appears in tools= and routes to the index.  When any is None
         # the wrapper stays out of tools= (= D14 visibility gate).
@@ -182,11 +182,11 @@ class RouterHostAdapter:
         # router's exec ran on the host (``No such file or directory:
         # '/testbed'``), so the agent's verify loop always failed. Parallel to
         # ``environment_backend`` for FS (#1411) — the legacy
-        # ``ChatSession._make_router_op_context`` already passes it; the live
+        # ``Session._make_router_op_context`` already passes it; the live
         # adapter omitted it (the same live-vs-legacy seam gap as #1410/#1411).
         sandbox_backend_instance: Any = None,
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
-        # ChatSession passes the session-scoped tracker; None when wrappers are
+        # Session passes the session-scoped tracker; None when wrappers are
         # off or hot_list_n == 0.
         action_usage_tracker: Any = None,
         # FP-0034 refactor: zero-arg callable returning the live (=
@@ -199,7 +199,7 @@ class RouterHostAdapter:
             Callable[[], list[tuple[str, float]]] | None
         ) = None,
         # FP-0034 Phase 2 step 5: ActionRetrievalConfig for hot_list_n /
-        # hot_list_seed.  ChatSession passes its config; None → default.
+        # hot_list_seed.  Session passes its config; None → default.
         action_retrieval_config: Any = None,
         # B25-S5-1: when True, RouterLoop awaits the action embedding index
         # build synchronously on the first turn before computing the D14
@@ -208,7 +208,7 @@ class RouterHostAdapter:
         # FP-0022 fix (#53): callable that yields an InterventionBus for
         # router-initiated tools that need the 4-layer approval flow
         # (web_fetch interactive prompt, mcp install / drop ask gates).
-        # ChatSession passes a factory that wraps ``ChatInterventionBus(
+        # Session passes a factory that wraps ``ChatInterventionBus(
         # session, run_id=None, skill_name="chat_router")``; tests can
         # pass None and the OpContext gets ``intervention_bus=None`` (=
         # config-deny path still raises, interactive prompt path raises
@@ -236,7 +236,7 @@ class RouterHostAdapter:
         # router_loop bounds media materialisation. ``None`` = unbounded (pre-#272).
         media_followup_budget: Any = None,
         # #272/#1128 compact op: awaitable () -> {freed_tokens, free_window_after}
-        # wired by ChatSession to its force_compact_now wrapper, so the LLM-
+        # wired by Session to its force_compact_now wrapper, so the LLM-
         # emittable `compact` control_ir op can voluntarily compact history.
         # ``None`` = no compaction context (compact op returns a clear error).
         compact_now: Any = None,
@@ -251,10 +251,10 @@ class RouterHostAdapter:
         state_dir: Path | None = None,
         # FP-0037 S2: project root for yaml mtime watch (3-scope cascade).
         # When None, only the user-global ~/.reyn/config.yaml is watched.
-        # ChatSession passes the project root so all 3 tiers are covered.
+        # Session passes the project root so all 3 tiers are covered.
         project_root: Path | None = None,
         # #1092 PR-F1 (chat activation): the shared turn_budget engine the chat
-        # axis budgets against. Built by ChatSession via
+        # axis budgets against. Built by Session via
         # build_default_turn_budget_engine off the CompactionEngine's RESOLVED
         # model (#1172-safe). Sole consumer (for now) is wrap_up_output_reserve —
         # which hard-caps the force-close wrap-up call's output. None = no engine
@@ -262,7 +262,7 @@ class RouterHostAdapter:
         # never calls _force_close_call until the F2 handoff lands, so wiring the
         # reserve here is inert until then.
         turn_budget_engine: Any = None,
-        # #1468: cooperative turn-cancel signal. ChatSession passes
+        # #1468: cooperative turn-cancel signal. Session passes
         # self._is_turn_cancel_requested; test hosts pass None (= never cancel).
         # run_loop polls via getattr(host, "_is_turn_cancel_requested", None).
         turn_cancel_fn: "Callable[[], bool] | None" = None,
@@ -623,7 +623,7 @@ class RouterHostAdapter:
     def get_action_embedding_index(self) -> Any:
         """Return the ActionEmbeddingIndex instance, or None.
 
-        FP-0034 Phase 2 step 1.  Bound by ChatSession when the operator
+        FP-0034 Phase 2 step 1.  Bound by Session when the operator
         has configured ``action_retrieval.embedding_class``.  RouterLoop
         forwards into ``RouterCallerState.action_embedding_index`` so
         the ``search_actions`` handler can call ``query()``.
@@ -808,7 +808,7 @@ class RouterHostAdapter:
         """FP-0012 non-blocking spawn — returns immediately with the
         ``{status: "spawned", run_id, chain_id, note}`` ack. The skill
         runs in the background; completion arrives via the
-        ``skill_completed`` inbox kind. See ``ChatSession.spawn_skill``
+        ``skill_completed`` inbox kind. See ``Session.spawn_skill``
         for the underlying implementation.
         """
         return await self._spawn_skill_cb(
@@ -1166,7 +1166,7 @@ class RouterHostAdapter:
     ) -> None:
         """Delegate to the session-owned spawn_plan_task callback.
 
-        Task lifecycle (running_plans dict) stays with ChatSession.
+        Task lifecycle (running_plans dict) stays with Session.
         """
         await self._spawn_plan_task_cb(
             plan_id=plan_id,
@@ -1256,7 +1256,7 @@ class RouterHostAdapter:
         """Probe every configured MCP server's tool list and cache the
         results for the session lifetime.
 
-        Called by `ChatSession._handle_user_message` at the start of each
+        Called by `Session._handle_user_message` at the start of each
         user turn. The first call populates the cache (= lazy, post-startup,
         per FP-0037 issue #160). Subsequent calls are no-ops.
 
@@ -1351,7 +1351,7 @@ class RouterHostAdapter:
     def maybe_reload_mcp_tools_cache_from_disk(self) -> None:
         """Reload the in-memory MCP tools cache if the on-disk file is newer.
 
-        FP-0037 S1: called at each turn boundary (in ChatSession before
+        FP-0037 S1: called at each turn boundary (in Session before
         `ensure_mcp_tools_cached`). When the operator runs ``reyn mcp refresh``
         while a session is active, the cache file's mtime advances. This
         method detects that and hot-swaps the in-memory cache so the very next
@@ -1578,7 +1578,7 @@ class RouterHostAdapter:
         from reyn.chat.router_op_context import build_router_op_context
 
         # #1412: single-sourced via build_router_op_context (shared with
-        # ChatSession). RouterHostAdapter wires intervention_bus inline (via the
+        # Session). RouterHostAdapter wires intervention_bus inline (via the
         # factory) + media/multimodal/compact (the registry-dispatch path serves
         # web/media ops). agent_id is unset here (registry-dispatch lacks one) —
         # a #1412 follow-up gap candidate, preserved behaviorally.

--- a/src/reyn/chat/services/router_loop_driver.py
+++ b/src/reyn/chat/services/router_loop_driver.py
@@ -1,6 +1,6 @@
-"""RouterLoopDriver — per-turn router loop orchestration for ChatSession.
+"""RouterLoopDriver — per-turn router loop orchestration for Session.
 
-Extracted from ChatSession (session.py refactor PR-3).  Owns:
+Extracted from Session (session.py refactor PR-3).  Owns:
 
   - run_turn(user_text, chain_id)  — was _run_router_loop
   - _run_with_shrink(loop, text)   — was _router_run_with_shrink
@@ -11,9 +11,9 @@ Extracted from ChatSession (session.py refactor PR-3).  Owns:
   - request_cancel()               — turn-cancel seam (called by cancel_inflight)
 
 Cancel lifecycle (#1468): the cooperative-cancel flag lives here.
-``request_cancel()`` is called by ChatSession.cancel_inflight() for the turn
+``request_cancel()`` is called by Session.cancel_inflight() for the turn
 piece; ``is_cancel_requested()`` is polled at each run_loop iteration via the
-RouterHostAdapter.turn_cancel_fn callback wired in ChatSession.__init__.
+RouterHostAdapter.turn_cancel_fn callback wired in Session.__init__.
 """
 from __future__ import annotations
 
@@ -28,10 +28,10 @@ _MAX_FORCE_CLOSE_HANDOFFS = 1
 
 
 class RouterLoopDriver:
-    """Orchestrates the per-turn router loop for one ChatSession.
+    """Orchestrates the per-turn router loop for one Session.
 
-    Constructed once per ChatSession; all stateful orchestration that previously
-    lived inline in ChatSession._run_router_loop is concentrated here.
+    Constructed once per Session; all stateful orchestration that previously
+    lived inline in Session._run_router_loop is concentrated here.
     """
 
     def __init__(
@@ -53,9 +53,9 @@ class RouterLoopDriver:
         model: str,
         history_buffer: Any,          # RouterHistoryBuffer — history + SP
         budget_advisor: Any,          # ContextBudgetAdvisor — maybe_force_compact
-        limit_checkpoint_fn: Callable,  # async; ChatSession._handle_chat_limit_checkpoint
-        next_seq_fn: Callable[[], int], # ChatSession._next_seq reader
-        append_history_fn: Callable,    # ChatSession._append_history
+        limit_checkpoint_fn: Callable,  # async; Session._handle_chat_limit_checkpoint
+        next_seq_fn: Callable[[], int], # Session._next_seq reader
+        append_history_fn: Callable,    # Session._append_history
         chat_scheme_name: "str | None" = None,  # #1593 PR-2: chat-layer ToolUseScheme name → RouterLoop(scheme_name=); None → universal default
     ) -> None:
         self._router_host = router_host

--- a/src/reyn/chat/services/skill_plan_glue.py
+++ b/src/reyn/chat/services/skill_plan_glue.py
@@ -1,6 +1,6 @@
-"""SkillPlanGlue — skill/plan completion routing and chain timeout for ChatSession.
+"""SkillPlanGlue — skill/plan completion routing and chain timeout for Session.
 
-Extracted from ChatSession (session.py refactor PR-4 — FP-0019 series final).
+Extracted from Session (session.py refactor PR-4 — FP-0019 series final).
 Owns the cluster that routes completed skill/plan work back into the router
 loop and handles chain timeout lifecycle:
 
@@ -12,7 +12,7 @@ loop and handles chain timeout lifecycle:
   - enqueue_plan_completed(**kw)           — was _enqueue_plan_completed
 
 Public-surface note: ``drain_skill_completed_inbox`` is called from
-``mcp_server.py`` (R-A2A-COMPLETION-DRAIN); ChatSession keeps a forwarding
+``mcp_server.py`` (R-A2A-COMPLETION-DRAIN); Session keeps a forwarding
 wrapper so the external call site is unaffected.
 """
 from __future__ import annotations
@@ -31,20 +31,20 @@ class SkillPlanGlue:
     """Routes skill/plan completions into router narration turns; handles chain
     timeout lifecycle.
 
-    Constructed once per ChatSession.  All state (inbox, chains, journal) is
+    Constructed once per Session.  All state (inbox, chains, journal) is
     provided at construction time; this class owns no durable state of its own.
     """
 
     def __init__(
         self,
         *,
-        append_history_fn: Callable,           # ChatSession._append_history
+        append_history_fn: Callable,           # Session._append_history
         events: Any,                           # EventLog — emit events
-        reset_turn_counter_fn: Callable,       # ChatSession._reset_router_turn_counter
+        reset_turn_counter_fn: Callable,       # Session._reset_router_turn_counter
         run_router_loop_fn: Callable,          # async (text, chain_id) → None
         emit_cap_exhausted_fn: Callable,       # async (exc, *, chain_id) → None
         put_outbox_fn: Callable,               # async OutboxMessage → None
-        inbox: asyncio.Queue,                  # ChatSession.inbox
+        inbox: asyncio.Queue,                  # Session.inbox
         journal: Any,                          # SnapshotJournal
         on_limit: Any,                         # SafetyOnLimitConfig
         chains: Any,                           # ChainManager

--- a/src/reyn/chat/services/skill_runner.py
+++ b/src/reyn/chat/services/skill_runner.py
@@ -1,13 +1,13 @@
 """SkillRunner — skill task lifecycle (launch / track / cancel).
 
-Extracted from ChatSession (FP-0019 Wave 1b). Owns the running_skills
+Extracted from Session (FP-0019 Wave 1b). Owns the running_skills
 dict and stdlib skill invocation path. Required as foundation for
 InterventionHandler (Wave 2) and AutoResumeHandler (Wave 3).
 
 Intervention coupling audit (FP-0019 Wave 1b):
     _run_stdlib_skill and _spawn_skill/_run_one_skill both pass a
     ChatInterventionBus to _build_agent. The bus holds a reference to
-    ChatSession (for _dispatch_intervention and
+    Session (for _dispatch_intervention and
     consume_buffered_intervention_answer). SkillRunner does NOT call
     intervention methods directly; it receives a ``build_agent_fn``
     callback from the session that encapsulates the bus construction.
@@ -16,7 +16,7 @@ Intervention coupling audit (FP-0019 Wave 1b):
     reference to ChatInterventionBus or InterventionRegistry here.
 
 All event emissions go through the injected ``event_log``; no silent
-state changes (P6).  Business logic lives entirely here; ChatSession
+state changes (P6).  Business logic lives entirely here; Session
 delegates via :meth:`spawn`, :meth:`spawn_for_router`,
 :meth:`run_stdlib`, :meth:`cancel`, :meth:`cancel_all`, and
 :meth:`running_names` (P3).
@@ -209,7 +209,7 @@ class SkillRunner:
     async def spawn(self, spec: dict, *, chain_id: str | None = None) -> "dict | None":
         """Launch a skill task and register it in the running dicts.
 
-        Extracted from ``ChatSession._spawn_skill``.  Enforces the
+        Extracted from ``Session._spawn_skill``.  Enforces the
         allowlist, budget cap, FP-0003 budget extension, and pre-spawn
         input_schema validation before creating the asyncio Task.
 
@@ -453,7 +453,7 @@ class SkillRunner:
     async def spawn_for_router(self, spec: dict, *, chain_id: str) -> dict:
         """Non-blocking router-side spawn entry point.
 
-        Extracted from ``ChatSession._spawn_skill_for_router``.  Wraps
+        Extracted from ``Session._spawn_skill_for_router``.  Wraps
         :meth:`spawn` and returns the spawn-ack dict the router LLM
         consumes via ``invoke_skill``'s tool_result.
 
@@ -508,7 +508,7 @@ class SkillRunner:
     ):
         """Load a stdlib skill, build an Agent, run it, accumulate cost.
 
-        Extracted from ``ChatSession._run_stdlib_skill``.  Inline stdlib
+        Extracted from ``Session._run_stdlib_skill``.  Inline stdlib
         runs (router / compactor) are NOT tracked in running_skills, so
         run_id is None — intervention cleanup won't fire on them.
 
@@ -776,7 +776,7 @@ class SkillRunner:
     ) -> None:
         """Core skill execution coroutine.
 
-        Extracted from ``ChatSession._run_one_skill``.  Loads the skill,
+        Extracted from ``Session._run_one_skill``.  Loads the skill,
         builds the agent with a ChatEventForwarder subscriber, runs it,
         and emits lifecycle events (P6).
 

--- a/src/reyn/chat/services/snapshot_journal.py
+++ b/src/reyn/chat/services/snapshot_journal.py
@@ -1,4 +1,4 @@
-"""SnapshotJournal — owns AgentSnapshot + StateLog WAL (extracted from ChatSession wave 1).
+"""SnapshotJournal — owns AgentSnapshot + StateLog WAL (extracted from Session wave 1).
 
 All WAL-recorded mutations go through here; in-memory readers go via the
 `.snapshot` property.
@@ -157,7 +157,7 @@ class SnapshotJournal:
     async def append_inbox(self, *, kind: str, payload: dict) -> str:
         """Append ``inbox_put`` to WAL, update snapshot, return assigned msg_id.
 
-        Mirrors ``ChatSession._put_inbox``.  Note: this method does NOT
+        Mirrors ``Session._put_inbox``.  Note: this method does NOT
         queue the message onto the asyncio inbox — the caller (session) is
         responsible for ``inbox.put`` so that the queue ownership stays in
         the session layer.
@@ -179,7 +179,7 @@ class SnapshotJournal:
     async def consume_inbox(self, *, msg_id: str) -> None:
         """Append ``inbox_consume`` to WAL and prune the snapshot entry.
 
-        Mirrors the WAL/snapshot portion of ``ChatSession._consume_inbox``.
+        Mirrors the WAL/snapshot portion of ``Session._consume_inbox``.
         No-op when ``state_log is None`` or ``msg_id`` is ``None``.
         """
         if self._state_log is None or msg_id is None:
@@ -196,7 +196,7 @@ class SnapshotJournal:
     async def record_chain_register(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_register`` to WAL and create the pending_chains entry.
 
-        Mirrors ``ChatSession._record_chain_register``.  ``fields`` must
+        Mirrors ``Session._record_chain_register``.  ``fields`` must
         contain the chain metadata keys produced by the caller (origin_agent,
         origin_depth, original_request, waiting_on).
         """
@@ -216,7 +216,7 @@ class SnapshotJournal:
     async def record_chain_update(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_update`` to WAL and update waiting_on in snapshot.
 
-        Mirrors ``ChatSession._record_chain_update``.  ``fields`` must
+        Mirrors ``Session._record_chain_update``.  ``fields`` must
         contain at least ``waiting_on: list[str]``.
         """
         if self._state_log is None:
@@ -235,7 +235,7 @@ class SnapshotJournal:
     async def record_chain_resolve(self, *, chain_id: str) -> None:
         """Append ``chain_resolve`` to WAL and remove the pending_chains entry.
 
-        Mirrors ``ChatSession._record_chain_resolve``.
+        Mirrors ``Session._record_chain_resolve``.
         """
         if self._state_log is None:
             return
@@ -249,7 +249,7 @@ class SnapshotJournal:
     async def record_chain_timeout_fired(self, *, chain_id: str) -> None:
         """Append ``chain_timeout_fired`` to WAL and remove the pending_chains entry.
 
-        Mirrors ``ChatSession._record_chain_timeout_fired``.
+        Mirrors ``Session._record_chain_timeout_fired``.
         """
         if self._state_log is None:
             return
@@ -315,7 +315,7 @@ class SnapshotJournal:
         but before the resuming skill consumes the answer. Persisting
         this to the WAL+snapshot lets the answer survive a second crash
         (the buffer would otherwise be lost since it lives in
-        ChatSession's in-memory dict).
+        Session's in-memory dict).
         """
         if self._state_log is None:
             return
@@ -490,7 +490,7 @@ class SnapshotJournal:
         """Adopt a recovered snapshot and immediately persist it.
 
         Mirrors the WAL/snapshot install portion of
-        ``ChatSession.restore_state`` (the asyncio queue repopulation and
+        ``Session.restore_state`` (the asyncio queue repopulation and
         chain timeout re-arming remain the session's responsibility).
         """
         self._snapshot = snapshot
@@ -499,7 +499,7 @@ class SnapshotJournal:
     def save(self) -> None:
         """Persist the current snapshot to disk (atomic write via AgentSnapshot.save).
 
-        Mirrors ``ChatSession._save_snapshot``.  Follows the existing
+        Mirrors ``Session._save_snapshot``.  Follows the existing
         convention: no try/except — let I/O errors propagate (there is no
         error-suppression in the original implementation).
         """

--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1,4 +1,4 @@
-"""ChatSession — long-lived chat loop driving the skill_router stdlib skill."""
+"""Session — long-lived chat loop driving the skill_router stdlib skill."""
 from __future__ import annotations
 
 import asyncio
@@ -324,7 +324,7 @@ class PendingOpView:
 
 
 class AgentRequestBus:
-    """``RequestBus`` adapter that subscribes to a ChatSession (= Agent).
+    """``RequestBus`` adapter that subscribes to a Session (= Agent).
 
     issue #254 Phase 3: OS-layer callers (= ``handle_limit_exceeded``,
     permission gates, ``ask_user`` op) hold a ``RequestBus``-typed
@@ -341,12 +341,12 @@ class AgentRequestBus:
     ``InterventionBus`` alias) accepts it without further wiring.
     """
 
-    def __init__(self, session: "ChatSession") -> None:
+    def __init__(self, session: "Session") -> None:
         self._session = session
 
     @property
-    def session(self) -> "ChatSession":
-        """Read-only accessor for the backing ChatSession. Tests verify
+    def session(self) -> "Session":
+        """Read-only accessor for the backing Session. Tests verify
         that adapters from the same session share identity through this
         surface."""
         return self._session
@@ -357,7 +357,7 @@ class AgentRequestBus:
 
 
 class ChatInterventionBus:
-    """``UserChannel`` implementation that routes through ChatSession's
+    """``UserChannel`` implementation that routes through Session's
     outbox/inbox to the attached TUI listener.
 
     One instance per skill spawn — captures `run_id` and a default `skill_name`
@@ -377,7 +377,7 @@ class ChatInterventionBus:
 
     def __init__(
         self,
-        session: "ChatSession",
+        session: "Session",
         run_id: str | None,
         skill_name: str | None,
         *,
@@ -387,7 +387,7 @@ class ChatInterventionBus:
         self._run_id = run_id
         self._skill_name = skill_name
         # issue #268 Phase 2 continuation: optional channel_id stamping.
-        # Production wiring (= ChatSession._build_intervention_bus_for_skill)
+        # Production wiring (= Session._build_intervention_bus_for_skill)
         # passes the session's canonical channel_id (e.g. "tui") so
         # skill-emitted ivs carry provenance for cross-channel routing.
         # Test fixtures that construct ChatInterventionBus directly
@@ -404,7 +404,7 @@ class ChatInterventionBus:
         return self._channel_id
 
     async def deliver(self, iv: "UserIntervention") -> "InterventionAnswer":
-        """``UserChannel.deliver`` — route the prompt to ChatSession's
+        """``UserChannel.deliver`` — route the prompt to Session's
         outbox/inbox so the attached TUI surfaces it to the user.
 
         issue #268 Phase 2 continuation: when this bus was constructed
@@ -791,7 +791,7 @@ def _format_sender_label(sender: str | None) -> str:
 # #398 v4 emitter family — events-log subscriber dispatch table.
 #
 # Maps known emitter event types to (source, template) tuples used by
-# ``ChatSession._on_chat_event_for_state_change`` to convert events
+# ``Session._on_chat_event_for_state_change`` to convert events
 # into ``notify_state_change`` calls. Adding a new emitter is one
 # entry here + the emitter emitting its event on the session's
 # events log (= OpContext.events, bound to ``_chat_events`` for
@@ -878,7 +878,7 @@ def _merge_memory_indexes(
     The router phase used to read `.reyn/memory/MEMORY.md` via a preprocessor
     `file/read` step; that step is removed because the agent-scoped path
     `.reyn/agents/<name>/memory/MEMORY.md` is dynamic and a static phase
-    YAML cannot interpolate it. ChatSession synthesizes the merged view
+    YAML cannot interpolate it. Session synthesizes the merged view
     here and stuffs it directly into the artifact.
 
     The two layers are kept separate in the output markdown — `(shared)` and
@@ -1136,7 +1136,7 @@ def enumerate_available_skills(exclude: set[str]) -> list[dict]:
     return results
 
 
-class ChatSession:
+class Session:
     def __init__(
         self,
         agent_name: str,
@@ -1193,7 +1193,7 @@ class ChatSession:
         # router resolves the selected ToolUseScheme. Default "universal-category"
         # #1657: default enumerate-all (owner H1 fix) — matches ToolUseConfig.chat.
         # The 5 entry callers pass the resolved config.tool_use.chat; this fallback
-        # only applies to direct ChatSession construction without that kwarg.
+        # only applies to direct Session construction without that kwarg.
         chat_tool_use_scheme: str = "enumerate-all",
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
@@ -1203,7 +1203,7 @@ class ChatSession:
         excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_source for external-repo eval)
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
-        # FP-0043 Stage 5: the conversation session id this ChatSession records WAL
+        # FP-0043 Stage 5: the conversation session id this Session records WAL
         # entries under. Default "main" = the implicit single session (byte-identical
         # pre-S5). The registry sets a spawned session's real sid post-construction
         # (spawn_session → set_session_id) before its run-loop goes live, so every
@@ -1296,7 +1296,7 @@ class ChatSession:
         self._multimodal_config = multimodal_config
         # #1212: op-loop gate, threaded to Agents spawned for chat-run skills.
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
-        # Issue #383 PR-C — single MediaStore instance per ChatSession,
+        # Issue #383 PR-C — single MediaStore instance per Session,
         # constructed from the multimodal config's storage dirs.
         # Subsequently threaded into spawned Agents (= for control-IR
         # ops invoked from skills) AND into the router host adapter
@@ -1409,7 +1409,7 @@ class ChatSession:
                 # construction time — the EventLog is built later in
                 # __init__ (= line ~1482). The previous C.3 wiring
                 # captured ``self.events`` (= attribute that does NOT
-                # exist on ChatSession), which silently raised
+                # exist on Session), which silently raised
                 # AttributeError at this point and the outer ``except``
                 # swallowed it, disabling search_actions for every
                 # operator who had ``embedding_class`` set. Mirrors the
@@ -1651,7 +1651,7 @@ class ChatSession:
 
         # PR-refactor-session-1 wave 3 PR1: per-session budget adapter.
         # Absorbs total_usage / total_cost_usd / router-cap state that
-        # previously lived as scattered attributes on ChatSession.
+        # previously lived as scattered attributes on Session.
         self._budget = BudgetGateway(
             budget_tracker=budget_tracker,
             events=self._chat_events,
@@ -1703,7 +1703,7 @@ class ChatSession:
         )
 
         # FP-0019 Wave 2 part 1: InterventionHandler — ask_user dispatch service.
-        # Extracted from ChatSession.  Session keeps thin wrappers on
+        # Extracted from Session.  Session keeps thin wrappers on
         # _dispatch_intervention / _maybe_answer_oldest_intervention /
         # _announce_intervention / _deliver_answer_to so the existing test
         # surface (and ChatInterventionBus) remain stable.
@@ -1782,7 +1782,7 @@ class ChatSession:
         )
 
         # PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
-        # RouterLoopHost implementation extracted from ChatSession. Constructed
+        # RouterLoopHost implementation extracted from Session. Constructed
         # last in __init__ because it receives callbacks that reference self
         # (all of which are bound methods, resolved at call time not here).
         self._router_host = RouterHostAdapter(
@@ -2003,7 +2003,7 @@ class ChatSession:
 
         # FP-0019 Wave 2 part 2: A2AHandler — agent-to-agent messaging service.
         # Extracts _send_to_agent / _send_agent_response / _handle_agent_request /
-        # _handle_agent_response / _resolve_pending_chain from ChatSession.
+        # _handle_agent_response / _resolve_pending_chain from Session.
         # Hybrid design (案 C): A2AHandler owns agent-side logic; transport-side
         # routing handled by FP-0013 RoutingLayer via send_request_callback /
         # send_response_callback injection.
@@ -2246,7 +2246,7 @@ class ChatSession:
         ``queued_count`` / ``list_active`` / ``has_active_listener`` /
         ``is_listener_enforcement_enabled``), so exposing it directly
         keeps callers off the underscore field without forcing a
-        delegate-method explosion on ChatSession. The registry
+        delegate-method explosion on Session. The registry
         instance is set once in ``__init__`` and never re-bound.
         """
         return self._interventions
@@ -2863,7 +2863,7 @@ class ChatSession:
 
         InterventionHandler needs to append a user history entry when an
         intervention is answered.  This adapter bridges the handler's
-        ``(role, text, ts, meta)`` signature to ChatSession._append_history
+        ``(role, text, ts, meta)`` signature to Session._append_history
         (which takes a ChatMessage).
         """
         self._append_history(ChatMessage(
@@ -2877,7 +2877,7 @@ class ChatSession:
         """Adapter callback injected into A2AHandler.
 
         A2AHandler uses the same ``(role, text, ts, meta)`` signature as
-        InterventionHandler.  This adapter bridges to ChatSession._append_history
+        InterventionHandler.  This adapter bridges to Session._append_history
         (which takes a ChatMessage).
         """
         self._append_history(ChatMessage(
@@ -3778,7 +3778,7 @@ class ChatSession:
         """FP-0005: chat-side wrapper for ``handle_limit_exceeded``.
 
         Mirrors ``OSRuntime._handle_limit_checkpoint`` but uses the
-        ChatSession's intervention dispatcher (= ``_dispatch_intervention``,
+        Session's intervention dispatcher (= ``_dispatch_intervention``,
         which records the WAL ``intervention_dispatched`` event before
         delivering the prompt) + on_limit + a session-stable run_id
         (= the agent name when no narrower scope applies, or the
@@ -3787,7 +3787,7 @@ class ChatSession:
         visible alongside the existing chat events.
         """
         # Adapter that conforms to the InterventionBus Protocol by
-        # delegating to ChatSession's existing intervention dispatcher.
+        # delegating to Session's existing intervention dispatcher.
         # _dispatch_intervention records the intervention_dispatched /
         # intervention_resolved WAL events automatically, so per-site
         # callers don't need to.
@@ -4092,7 +4092,7 @@ class ChatSession:
         so it lands in ``_interventions._active`` + WAL +
         ``outstanding_interventions`` + becomes eligible for R-D12's
         persistent answer buffer. Pre-#292, the override replaced
-        dispatch and A2A ivs were invisible to ChatSession's iv
+        dispatch and A2A ivs were invisible to Session's iv
         machinery — fixed structurally here, not patched.
         """
         # FP-0001 / issue #292: chain_id-scoped override notification
@@ -4179,7 +4179,7 @@ class ChatSession:
         instrumenting the hook implementations themselves.
 
         Callers that obtain a ``RequestBus``-typed view of an Agent use
-        ``ChatSession.as_request_bus()`` (which returns an
+        ``Session.as_request_bus()`` (which returns an
         ``AgentRequestBus`` adapter forwarding ``request(iv)`` here).
         """
         # Branch 1: self_answer policy.
@@ -4258,10 +4258,10 @@ class ChatSession:
 
     def resolve_parent_agent(
         self, iv: UserIntervention,
-    ) -> "ChatSession | None":
+    ) -> "Session | None":
         """Hook for parent-agent delegation routing (issue #254 Phase 4).
 
-        Return a ChatSession to forward the request to a chain-upstream
+        Return a Session to forward the request to a chain-upstream
         agent; return ``None`` to fall through to user_channel delivery.
 
         Default implementation returns ``None`` (= no parent resolution).
@@ -4272,17 +4272,17 @@ class ChatSession:
         return None
 
     def as_request_bus(self) -> "AgentRequestBus":
-        """Return a ``RequestBus``-typed adapter for this ChatSession.
+        """Return a ``RequestBus``-typed adapter for this Session.
 
         OS-layer callers (= ``handle_limit_exceeded``, permission gates,
         ``ask_user`` op) can hold an ``AgentRequestBus`` without
-        importing ChatSession or knowing about the Agent's downstream
+        importing Session or knowing about the Agent's downstream
         routing choices. The adapter forwards ``request(iv)`` to
         ``handle_intervention(iv)``.
 
         issue #254 Phase 3 — the type-level realisation of the [A]
         contract from Phase 2: OS owns a ``RequestBus``, the bus is
-        backed by an Agent (= ChatSession), the Agent owns the routing
+        backed by an Agent (= Session), the Agent owns the routing
         decision and the downstream ``UserChannel`` selection.
         """
         return AgentRequestBus(self)
@@ -4777,7 +4777,7 @@ class ChatSession:
             return
 
     # ── RouterLoop helper methods (Wave 3 F1, kept for session callbacks) ──────────
-    # _make_router_op_context + 3 helpers remain on ChatSession because the
+    # _make_router_op_context + 3 helpers remain on Session because the
     # session's internal MCP/file callbacks (_mcp_list_tools, _mcp_call_tool,
     # _file_op) use them. The adapter has its own private copies.
 
@@ -4824,7 +4824,7 @@ class ChatSession:
     def _mcp_servers_flat(self) -> dict:
         """Unwrap config.mcp's `{servers: {...}}` shape to flat `{name: cfg}`.
 
-        ChatSession receives the wrapped form from CLI bootstrap (config.mcp).
+        Session receives the wrapped form from CLI bootstrap (config.mcp).
         The Agent / control_ir_executor unwraps via `.get("servers", {})`;
         chat-router-side helpers historically did not (PR35 oversight) and
         treated "servers" as if it were a server name. Centralized unwrap.
@@ -4867,7 +4867,7 @@ class ChatSession:
         from reyn.chat.router_op_context import build_router_op_context
 
         # #1412: single-sourced via build_router_op_context (shared with
-        # RouterHostAdapter). ChatSession wires intervention_bus POST-HOC on the
+        # RouterHostAdapter). Session wires intervention_bus POST-HOC on the
         # returned ctx (the MCP-op caller), so it is None at construction here;
         # media/multimodal/compact ops go via the registry / RouterHostAdapter
         # path (None here) — behavior-preserving.

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -322,7 +322,7 @@ class ActionRetrievalConfig:
             **Default since FP-0043 Phase 4**: ``"local-mini"`` (=
             ``sentence-transformers/all-MiniLM-L6-v2``). When the
             ``local-embed`` extras are not installed (= ``import
-            sentence_transformers`` fails), ChatSession silently
+            sentence_transformers`` fails), Session silently
             degrades to None — ``search_actions`` stays hidden and
             ``list_actions`` injects a hidden-state hint pointing
             operators at ``pip install 'reyn[local-embed]'``. So the

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -189,7 +189,7 @@ class ReynConfig:
     python: PythonConfig = field(default_factory=PythonConfig)
     # FP-0016 Component E — agent identity for audit trail + HTTP header
     # propagation. Default `reyn/<hostname>` when reyn.yaml has no
-    # `agent:` block. Read by ChatSession to construct its EventLog and
+    # `agent:` block. Read by Session to construct its EventLog and
     # by mcp_client.MCPClient for the X-Reyn-Agent-Id header.
     agent: AgentConfig = field(default_factory=AgentConfig)
     # FP-0016 Component C — OAuth provider configurations for

--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -61,7 +61,7 @@ class AgentSnapshot:
     # Populated when the user answers an intervention post-restart but
     # before the resuming skill consumes it. Survives a *second* crash
     # so the answer is replayed when the skill finally resumes (the
-    # in-memory ``_buffered_intervention_answers`` dict in ChatSession
+    # in-memory ``_buffered_intervention_answers`` dict in Session
     # is the runtime cache; this field is its on-disk durable form).
     # Each value is ``{"text": str, "choice_id": str | None}``.
     buffered_intervention_answers: dict[str, dict] = field(default_factory=dict)

--- a/src/reyn/core/op_runtime/compact.py
+++ b/src/reyn/core/op_runtime/compact.py
@@ -3,7 +3,7 @@
 When the OS-injected context-size signal shows the window is filling, the model
 may emit a ``compact`` control_ir op instead of waiting for the mandatory
 ``retry_loop`` backstop. The op routes through ``ctx.compact_now`` — an
-awaitable the caller (ChatSession / phase runtime) wires to its existing
+awaitable the caller (Session / phase runtime) wires to its existing
 synchronous compaction (``force_compact_now``). The result reports freed tokens
 and the free window afterwards in EXACT tokens, unit-aligned with the
 context-size signal + the media load-contract error, so the model reasons

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -61,7 +61,7 @@ class OpContext:
     # Mutable cache for MCP HTTP clients keyed by server name
     mcp_clients: dict = field(default_factory=dict)
     # FP-0016 Component E: agent identity for X-Reyn-Agent-Id header on
-    # outgoing MCP / external HTTP calls. Plumbed from ChatSession's
+    # outgoing MCP / external HTTP calls. Plumbed from Session's
     # ReynConfig.agent.id (= `reyn/<hostname>` by default). None
     # preserves prior behaviour for direct OpContext construction (e.g.
     # tests that don't simulate a multi-agent identity).
@@ -72,7 +72,7 @@ class OpContext:
     current_phase: str = ""
 
     # #272/#1128: voluntary-compaction capability for the `compact` op.
-    # An awaitable zero-arg callable the caller (ChatSession / phase runtime)
+    # An awaitable zero-arg callable the caller (Session / phase runtime)
     # wires to its synchronous compaction (force_compact_now), returning
     # {"freed_tokens", "free_window_after", ...} in exact tokens. None when no
     # compaction context is available (e.g. preprocessor / direct construction)

--- a/src/reyn/core/plan/decomposition.py
+++ b/src/reyn/core/plan/decomposition.py
@@ -27,7 +27,7 @@ Schema (``DECOMPOSITION_SCHEMA_VERSION = 1``):
       ]
     }
 
-This module is **standalone** — no ChatSession / RouterLoopHost coupling.
+This module is **standalone** — no Session / RouterLoopHost coupling.
 Callers (= ``dispatch_plan_tool`` write path, ``PlanRuntime`` read path,
 ``AgentRegistry.restore_all`` cleanup) thread the agent-state directory
 explicitly. P7-clean: no skill-specific strings.

--- a/src/reyn/core/plan/plan_resume_coordinator.py
+++ b/src/reyn/core/plan/plan_resume_coordinator.py
@@ -24,7 +24,7 @@ Per-purity child actions (= when a step spawned a child skill):
   - ``cancel`` — discard via SkillRegistry.complete(status="discarded")
 
 P7-clean: coordinator takes registries via dependency injection, no
-direct imports of ChatSession internals.
+direct imports of Session internals.
 """
 from __future__ import annotations
 
@@ -283,7 +283,7 @@ class PlanResumeCoordinator:
             adopted children stay live for skill auto-resume.
 
         Returns the subset where ``action ∈ {"resume", "retry_pending"}``
-        — the caller (ChatSession) launches a ``PlanRuntime`` for each.
+        — the caller (Session) launches a ``PlanRuntime`` for each.
         """
         launchable: list[PlanResumeDecision] = []
         for decision in decisions:

--- a/src/reyn/data/embedding/sentence_transformers_provider.py
+++ b/src/reyn/data/embedding/sentence_transformers_provider.py
@@ -98,7 +98,7 @@ def is_available() -> bool:
     heavy module, just checks whether the import would succeed. Used by
     callers that need to decide between an ST-backed path and a graceful
     fallback before any actual embed() call (= FP-0043 Phase 4 default-
-    switch graceful-degrade in :class:`ChatSession`).
+    switch graceful-degrade in :class:`Session`).
     """
     import importlib.util
     return importlib.util.find_spec("sentence_transformers") is not None

--- a/src/reyn/interfaces/chainlit_app/__init__.py
+++ b/src/reyn/interfaces/chainlit_app/__init__.py
@@ -3,7 +3,7 @@
 Surface: ``reyn chainlit`` launches Chainlit's dev server which loads
 ``app.py`` in this package. Coexists with ``reyn chat`` (TUI) and
 ``reyn web`` (FastAPI + openui) — all three share the same
-``ChatSession`` / `OutboxMessage` model defined in ``reyn.chat``.
+``Session`` / `OutboxMessage` model defined in ``reyn.chat``.
 
 Module layout:
 - ``adapter``: pure function mapping ``OutboxMessage`` → Chainlit payload.

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -169,7 +169,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
 
         registry_ref: list = []
 
-        def _session_factory(profile: AgentProfile) -> ChatSession:
+        def _session_factory(profile: AgentProfile) -> Session:
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -398,7 +398,7 @@ async def _handle_intervention(registry: "AgentRegistry", msg) -> None:
 
     # Empty-answer fallback used on every "no response" path below.
     # Without this, the agent stays awaiting ``iv.future`` forever and
-    # ChatSession.run_one_iteration never picks up the next inbox
+    # Session.run_one_iteration never picks up the next inbox
     # message — the entire chat appears frozen.
     async def _resolve_empty() -> None:
         try:
@@ -594,7 +594,7 @@ async def _on_chat_start() -> None:
         # Stripped / mocked session in tests — degrade gracefully.
         pass
 
-    # Replay prior chat turns from ``ChatSession.history`` (= what
+    # Replay prior chat turns from ``Session.history`` (= what
     # ``load_history`` read from ``history.jsonl``) so the operator
     # sees the conversation they had previously with this agent
     # instead of an empty thread on every re-attach / browser open.
@@ -790,7 +790,7 @@ async def _on_message(message: cl.Message) -> None:
     # Multimodal upload bridge: any image element dropped via the
     # chainlit attachment button rides the same ``_pending_user_images``
     # queue that ``/image PATH`` uses. The queue is drained on the
-    # next user turn by ``ChatSession._handle_user_message``.
+    # next user turn by ``Session._handle_user_message``.
     elements = getattr(message, "elements", None) or []
     if elements:
         blocks = collect_image_blocks(elements)

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -121,7 +121,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
         from reyn.chat.scoped_session_factory import build_scoped_chat_session
         from reyn.config import _find_project_root, load_project_context
         from reyn.core.events.state_log import StateLog
-        from reyn.interfaces.cli.session import Session
+        from reyn.interfaces.cli.invocation_context import InvocationContext
         from reyn.runtime.budget.budget import BudgetTracker
         from reyn.security.permissions.permissions import PermissionResolver
 
@@ -130,7 +130,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
         # helpers do ``getattr(args, "...", None)`` everywhere, so an
         # empty Namespace gives us config defaults across the board.
         empty_args = argparse.Namespace()
-        session_cfg = Session.from_args(empty_args)
+        session_cfg = InvocationContext.from_args(empty_args)
         model, _resolved = session_cfg.model_for(empty_args)
         output_language = session_cfg.output_language_for(empty_args)
         safety = session_cfg.safety_for(empty_args)

--- a/src/reyn/interfaces/chainlit_app/history.py
+++ b/src/reyn/interfaces/chainlit_app/history.py
@@ -3,7 +3,7 @@
 When the operator switches to a different agent via the chat-profile
 picker (or just opens a new browser tab on the same agent), chainlit
 spins up a fresh per-session UI thread — but the reyn-side
-``ChatSession.history`` already holds every prior turn from disk
+``Session.history`` already holds every prior turn from disk
 (``load_history`` reads ``history.jsonl``). Without replay, the
 operator sees an empty conversation while the agent still
 "remembers" everything from the LLM side, which is confusing.
@@ -34,7 +34,7 @@ class _MessageLike(Protocol):
 
     Defined as a Protocol so tests can pass a tiny fake without
     instantiating the real ``ChatMessage`` (= avoids dragging in
-    ChatSession's full import graph).
+    Session's full import graph).
     """
     role: str
     content: "str | list[dict]"
@@ -117,7 +117,7 @@ def _truncation_marker(omitted: int) -> HistoryEntry:
 def history_to_chainlit(
     history: Iterable[_MessageLike], *, cap: int | None = None,
 ) -> list[HistoryEntry]:
-    """Convert ``ChatSession.history`` into a list of replay-ready entries.
+    """Convert ``Session.history`` into a list of replay-ready entries.
 
     Order preserved (= chronological), drops applied per
     ``_DROPPED_ROLES``. Empty-text turns (= ``content`` flattens to ``""``)

--- a/src/reyn/interfaces/chainlit_app/settings.py
+++ b/src/reyn/interfaces/chainlit_app/settings.py
@@ -32,7 +32,7 @@ LANGUAGE_ITEMS: dict[str, str] = {
 
 
 def language_to_value(lang: str | None) -> str:
-    """Map ``ChatSession.output_language`` → widget select value.
+    """Map ``Session.output_language`` → widget select value.
 
     None / empty → ``"auto"`` (= the widget always renders a concrete
     selection, never blank). Known codes pass through; unknown codes
@@ -46,7 +46,7 @@ def language_to_value(lang: str | None) -> str:
 
 
 def value_to_language(value: str | None) -> str | None:
-    """Map widget select value → ``ChatSession.output_language``.
+    """Map widget select value → ``Session.output_language``.
 
     ``"auto"`` / None / empty → ``None`` (= let the LLM pick). Any
     other value passes through verbatim so a future widget item
@@ -121,7 +121,7 @@ def list_model_names(resolver: object) -> list[str]:
 
 
 def value_to_model(value: str | None, *, default: str) -> str:
-    """Map widget select value → ``ChatSession.model`` tier name.
+    """Map widget select value → ``Session.model`` tier name.
 
     Empty / None → ``default`` (= preserves current model rather than
     silently flipping to an arbitrary fallback). Any other value

--- a/src/reyn/interfaces/chainlit_app/slash_route.py
+++ b/src/reyn/interfaces/chainlit_app/slash_route.py
@@ -1,6 +1,6 @@
 """Pure helpers for routing slash commands from the chainlit surface.
 
-``ChatSession.submit_user_text`` bypasses slash dispatch (= slash
+``Session.submit_user_text`` bypasses slash dispatch (= slash
 handling lives on the TUI / CUI wrappers via
 ``session._maybe_handle_slash``). The chainlit ``@cl.on_message`` glue
 mirrors the same pattern: if the typed content starts with ``/``,

--- a/src/reyn/interfaces/chainlit_app/uploads.py
+++ b/src/reyn/interfaces/chainlit_app/uploads.py
@@ -1,6 +1,6 @@
 """Convert chainlit ``Element`` uploads into reyn's image-attach queue.
 
-Reyn's ``/image`` slash and ``ChatSession._handle_user_message`` already
+Reyn's ``/image`` slash and ``Session._handle_user_message`` already
 share a per-session queue (``session._pending_user_images: list[dict]``)
 drained on the next user turn. This module mirrors that queue's
 contract from the chainlit side so a file dropped via chainlit's
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Mirror reyn.interfaces.slash.image._IMAGE_EXTENSIONS. Duplicated rather
-# than imported because the slash module pulls in ChatSession
+# than imported because the slash module pulls in Session
 # internals; the chainlit adapter intentionally stays decoupled from
 # that import graph so unit tests run fast.
 _IMAGE_EXTENSIONS: dict[str, str] = {

--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -1,6 +1,6 @@
 """`reyn agent {list,new,rm,show}` — manage persistent agents.
 
-PR10 introduces multi-agent: each agent is a long-lived ChatSession with its
+PR10 introduces multi-agent: each agent is a long-lived Session with its
 own history under `.reyn/agents/<name>/`. The `default` agent is auto-created
 on first use; users can spin up additional named agents with their own role
 prompts via `reyn agent new`.

--- a/src/reyn/interfaces/cli/commands/chainlit.py
+++ b/src/reyn/interfaces/cli/commands/chainlit.py
@@ -2,11 +2,11 @@
 
 Chainlit (https://chainlit.io) を `python -m chainlit run` 経由で起動し、
 ``src/reyn/chainlit_app/app.py`` に定義した @cl.on_chat_start /
-@cl.on_message ハンドラ越しに `ChatSession` と接続する。
+@cl.on_message ハンドラ越しに `Session` と接続する。
 
 TUI (`reyn chat`) / FastAPI Web UI (`reyn web`) と共存する第三の surface:
 - 既存 `reyn web` (FP-0013 MessageBus + openui) と同じ "サーバ起動" 体験
-- 各 Chainlit ブラウザセッション = 独立の `ChatSession`
+- 各 Chainlit ブラウザセッション = 独立の `Session`
 - multi-user は Chainlit 側 WebSocket セッション分離に乗る
 
 このコマンドは reyn の `[chainlit]` オプション依存を必要とする:

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -18,7 +18,7 @@ from reyn.interfaces.cli.env_backend import (
 from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
-from ..session import Session
+from ..invocation_context import InvocationContext
 
 # #187: send_to_agent_impl timeout for the one-shot (`reyn run-once`) drive. The
 # autonomous SWE agent may iterate for many minutes; the external bound is the
@@ -315,7 +315,7 @@ def run(args: argparse.Namespace) -> None:
     from reyn.runtime.budget.budget import BudgetTracker
     from reyn.security.permissions.permissions import PermissionResolver
 
-    session_cfg = Session.from_args(args)
+    session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
     verify_credentials_or_exit(session_cfg, args)
     # ``model`` (= tier key like "standard" / "strong") drives ChatSession's

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -1,7 +1,7 @@
 """`reyn chat [name]` — interactive chat, optionally attaching to a named agent.
 
 PR10: launches the AgentRegistry, attaches to the named agent (or `default`),
-then hands off to `run_repl`. The registry holds all loaded ChatSession
+then hands off to `run_repl`. The registry holds all loaded Session
 instances; switching agents mid-REPL via `/attach <name>` happens through it.
 """
 from __future__ import annotations
@@ -173,7 +173,7 @@ def register(sub) -> None:
         ),
     )
     # Issue #276 Phase A — TUI thin client mode connecting to a remote
-    # `reyn web` server. When set, the local ChatSession / AgentRegistry
+    # `reyn web` server. When set, the local Session / AgentRegistry
     # / state restore are skipped; the TUI streams from
     # ``ws://<host>[:port]/ws/chat/<agent>``. Right panel features that
     # depend on local files (events / memory / pending) render
@@ -249,7 +249,7 @@ def _reset_project_state(project_root: Path, *, confirm: bool = True) -> bool:
 def _run_connect_mode(args: argparse.Namespace, base_url: str) -> None:
     """Issue #276 Phase A — connect to a remote `reyn web` server.
 
-    Skips local ChatSession / AgentRegistry / state restore. The TUI
+    Skips local Session / AgentRegistry / state restore. The TUI
     streams frames from ``ws://<host>[:port]/ws/chat/<agent_name>``;
     user input is forwarded to the server as ``user_message`` frames.
 
@@ -318,7 +318,7 @@ def run(args: argparse.Namespace) -> None:
     session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
     verify_credentials_or_exit(session_cfg, args)
-    # ``model`` (= tier key like "standard" / "strong") drives ChatSession's
+    # ``model`` (= tier key like "standard" / "strong") drives Session's
     # ModelResolver. ``resolved_model`` (= the litellm string like
     # "openai/gemini-2.5-flash-lite") is what the header should surface so
     # the user can see which model their requests actually go to.
@@ -338,7 +338,7 @@ def run(args: argparse.Namespace) -> None:
         print("State reset. Starting with empty session.", file=sys.stderr)
 
     # PR21: process-shared WAL for crash recovery. Owned by AgentRegistry,
-    # injected into each ChatSession at construction.
+    # injected into each Session at construction.
     state_log = StateLog(project_root / ".reyn" / "state" / "wal.jsonl")
     # PR22: process-shared budget tracker. Defaults to all unlimited unless
     # `cost:` is configured.
@@ -362,12 +362,12 @@ def run(args: argparse.Namespace) -> None:
         perm_config.setdefault("file.write", "allow")
     unsafe_python = bool(getattr(args, "allow_unsafe_python", False))
     # #187: parse --exclude-tools (comma-separated tool names) → frozenset, threaded
-    # to ChatSession → the MAIN RouterLoop's exclude_tools (LLM-visible catalog filter).
+    # to Session → the MAIN RouterLoop's exclude_tools (LLM-visible catalog filter).
     _exclude_tools = frozenset(
         t.strip() for t in (getattr(args, "exclude_tools", None) or "").split(",") if t.strip()
     )
     # #1667: parse --exclude-categories (comma-separated category names) → frozenset,
-    # threaded to ChatSession → RouterCallerState.excluded_categories → the universal
+    # threaded to Session → RouterCallerState.excluded_categories → the universal
     # catalog skips them at the source. Empty (interactive default) keeps every category.
     _excluded_categories = frozenset(
         c.strip() for c in (getattr(args, "exclude_categories", None) or "").split(",") if c.strip()
@@ -379,7 +379,7 @@ def run(args: argparse.Namespace) -> None:
     project_context = load_project_context(session_cfg.config, project_root)
 
     # #1289: build the agent-level EnvironmentBackend (host / docker attach|launch)
-    # and pass the SAME instance to BOTH ChatSession seams (FS environment_backend
+    # and pass the SAME instance to BOTH Session seams (FS environment_backend
     # + exec sandbox_backend) — the #1200 single-shared-sandbox invariant. A
     # launched container is torn down at process exit.
     env_backend, ws_base_dir, ws_state_dir, env_cleanup = build_environment_backend(args)

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -303,7 +303,7 @@ def run_run(args: argparse.Namespace) -> None:
 
     # Build the live-LLM runner_fn (injected seam for the real agent path)
     # #1289: build the agent-level EnvironmentBackend and pass the SAME instance
-    # to both ChatSession seams (FS + exec) via _build_live_runner (single-shared
+    # to both Session seams (FS + exec) via _build_live_runner (single-shared
     # sandbox, #1200). A launched container is torn down at process exit.
     _env_backend, _wb, _ws, _env_cleanup = build_environment_backend(args)
     if _env_cleanup is not None:
@@ -371,13 +371,13 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
       frequency counters don't bleed across scenarios.
     - Wipes agents/<name>/history.jsonl before each scenario so chat
       history from prior scenarios is not injected into the LLM's
-      messages. Without this, ChatSession.load_history() (called by the
+      messages. Without this, Session.load_history() (called by the
       session factory) loads the accumulated history-jsonl from disk,
       and scenario N sees scenario 1..N-1's user/assistant turns in its
       context — defeating the "fresh per scenario" guarantee. The
       dogfood_fresh_reset.sh script explicitly defers per-agent history
       wipe to callers (= the runner is the caller); this is that wipe.
-    - Drops the cached ChatSession from the registry between scenarios so
+    - Drops the cached Session from the registry between scenarios so
       the session's in-memory EventLog starts empty each time.
 
     Artifact collection:
@@ -445,7 +445,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         # cell so the factory can reference it before assignment completes.
         _reg_cell: list = []
 
-        def _session_factory(profile: AgentProfile) -> ChatSession:
+        def _session_factory(profile: AgentProfile) -> Session:
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -517,7 +517,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         action_usage_path.unlink(missing_ok=True)
         # Wipe per-agent chat history so prior scenarios' user/assistant
         # turns are NOT injected into the LLM context for this scenario.
-        # ChatSession.load_history() (called by the session factory) reads
+        # Session.load_history() (called by the session factory) reads
         # this file unconditionally; without the wipe, scenario N sees
         # scenarios 1..N-1's messages. dogfood_fresh_reset.sh intentionally
         # defers this wipe to callers because it requires knowing the

--- a/src/reyn/interfaces/cli/commands/embeddings.py
+++ b/src/reyn/interfaces/cli/commands/embeddings.py
@@ -407,7 +407,7 @@ def register(sub: Any) -> None:
         description=(
             "Remove the cached action index SQLite and build-lock "
             "marker. Does NOT itself trigger embedding; the next "
-            "ChatSession that uses search_actions will re-embed."
+            "Session that uses search_actions will re-embed."
         ),
     )
     rebuild.add_argument(

--- a/src/reyn/interfaces/cli/commands/eval.py
+++ b/src/reyn/interfaces/cli/commands/eval.py
@@ -124,10 +124,10 @@ def _register_run(eval_sub) -> None:
 
 def _run_golden(args: argparse.Namespace) -> None:
     """Execute `reyn eval run`."""
-    from reyn.interfaces.cli.session import Session
+    from reyn.interfaces.cli.invocation_context import InvocationContext
     from reyn.interfaces.cli.skill_loader import resolve_skill_path
 
-    session = Session.from_args(args)
+    session = InvocationContext.from_args(args)
     model = getattr(args, "model", None) or session.config.model
 
     # Load dataset
@@ -720,12 +720,12 @@ def _run_spec(args: argparse.Namespace) -> None:
     from reyn.core.compiler import load_dsl_skill
     from reyn.core.compiler.eval_loader import load_eval_spec
     from reyn.interfaces.cli.eval_report import EvalReport
-    from reyn.interfaces.cli.session import Session
+    from reyn.interfaces.cli.invocation_context import InvocationContext
     from reyn.interfaces.cli.skill_loader import resolve_skill_path, stdlib_root
     from reyn.llm.llm import run_async
     from reyn.llm.pricing import TokenUsage
 
-    session = Session.from_args(args)
+    session = InvocationContext.from_args(args)
 
     try:
         spec = load_eval_spec(args.spec)

--- a/src/reyn/interfaces/cli/commands/eval_benchmark.py
+++ b/src/reyn/interfaces/cli/commands/eval_benchmark.py
@@ -911,10 +911,10 @@ def _write_instance_log(log_path: Path, run_result) -> None:
 async def _run_benchmark_async(args: argparse.Namespace) -> None:
     """Core async implementation of `reyn eval benchmark`."""
     from reyn.core.compiler import load_dsl_skill
-    from reyn.interfaces.cli import session as session_mod
+    from reyn.interfaces.cli import invocation_context as invocation_mod
     from reyn.interfaces.cli.skill_loader import resolve_skill_path
 
-    session = session_mod.Session.from_args(args)
+    session = invocation_mod.InvocationContext.from_args(args)
     model = getattr(args, "model", None) or session.config.model
 
     # Derive unsafe_python once at batch start and thread it

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
-from ..session import Session
+from ..invocation_context import InvocationContext
 
 # ---------------------------------------------------------------------------
 # Scope tier helpers
@@ -330,7 +330,7 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.runtime.budget.budget import BudgetTracker
     from reyn.security.permissions.permissions import PermissionResolver
 
-    session_cfg = Session.from_args(args)
+    session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
     verify_credentials_or_exit(session_cfg, args)
     model, _ = session_cfg.model_for(args)

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -369,7 +369,7 @@ def run_serve(args: argparse.Namespace) -> None:
     # which causes any code that uses relative `.reyn/...` paths to try to
     # write under the filesystem root and crash with a read-only-fs error.
     # `--project` only fixes the explicit StateLog/budget paths in this
-    # function; deeper code paths (ChatSession, Workspace, AgentRegistry)
+    # function; deeper code paths (Session, Workspace, AgentRegistry)
     # also use relative paths internally. Anchor the whole process at the
     # project root so the same code that works under `reyn chat` works
     # here unchanged.
@@ -414,7 +414,7 @@ def run_serve(args: argparse.Namespace) -> None:
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,
-            # Same fix as web/deps.py: A2A / MCP-serve ChatSession factory
+            # Same fix as web/deps.py: A2A / MCP-serve Session factory
             # was missing ``sandbox_config`` propagation. Without it, the
             # operator's reyn.yaml ``sandbox.backend`` selection (e.g.
             # ``noop``) never reaches the sandboxed_exec handler.

--- a/src/reyn/interfaces/cli/commands/run.py
+++ b/src/reyn/interfaces/cli/commands/run.py
@@ -13,8 +13,8 @@ from reyn.interfaces.cli.env_backend import (
 from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
+from ..invocation_context import InvocationContext
 from ..logger_factory import make_logger
-from ..session import Session
 from ..skill_loader import load_skill_from_args
 from ..summary import print_run_result
 
@@ -96,7 +96,7 @@ def register(sub) -> None:
 
 
 def run(args: argparse.Namespace) -> None:
-    session = Session.from_args(args)
+    session = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
     verify_credentials_or_exit(session, args)
     loaded = load_skill_from_args(args)

--- a/src/reyn/interfaces/cli/credentials_check.py
+++ b/src/reyn/interfaces/cli/credentials_check.py
@@ -15,7 +15,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from reyn.interfaces.cli.session import Session
+    from reyn.interfaces.cli.invocation_context import InvocationContext
 
 
 # Mapping from litellm provider prefix → required env var (litellm convention).
@@ -32,7 +32,7 @@ _PROVIDER_ENV_VARS: dict[str, str] = {
 
 
 def verify_credentials_or_exit(
-    session: "Session", args: argparse.Namespace,
+    session: "InvocationContext", args: argparse.Namespace,
 ) -> None:
     """Exit 1 with an actionable message if the model the command will use
     has no credentials configured (no env var AND no api_base proxy).

--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -1,8 +1,8 @@
 """
-Session: per-invocation bootstrap.
+InvocationContext: per-invocation bootstrap.
 
 Loads config, applies environment, builds the model resolver. Each command
-receives a Session so it can read effective values without re-running the
+receives an InvocationContext so it can read effective values without re-running the
 load/merge logic.
 """
 from __future__ import annotations
@@ -16,12 +16,12 @@ from reyn.llm.model_resolver import ModelResolver
 
 
 @dataclass
-class Session:
+class InvocationContext:
     config: ReynConfig
     resolver: ModelResolver
 
     @classmethod
-    def from_args(cls, args: argparse.Namespace) -> "Session":
+    def from_args(cls, args: argparse.Namespace) -> "InvocationContext":
         config = load_config()
         if config.api_base:
             os.environ.setdefault("LITELLM_API_BASE", config.api_base)

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -116,7 +116,7 @@ REGISTRY: SlashRegistry = SlashRegistry()
 def suggest_for_unknown(cmd: str, *, names: list[str] | None = None) -> list[str]:
     """Return up to ~3 closest-match suggestions for a typo'd slash command.
 
-    Used by :meth:`ChatSession._dispatch_slash` to build the inline error
+    Used by :meth:`Session._dispatch_slash` to build the inline error
     body when ``/<cmd>`` doesn't resolve. The suggestion list is
     intentionally tight: prefix-matches (= commands whose name starts with
     the typed token) come first, then fuzzy similarity matches

--- a/src/reyn/interfaces/slash/agent.py
+++ b/src/reyn/interfaces/slash/agent.py
@@ -21,7 +21,7 @@ from reyn.chat.profile import AgentProfile
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -44,7 +44,7 @@ _NO_REGISTRY = (
     ),
     usage="/agent new <name> | /agent edit role <text>",
 )
-async def agent_cmd(session: "ChatSession", args: str) -> None:
+async def agent_cmd(session: "Session", args: str) -> None:
     """Dispatch ``/agent <sub>`` subcommands."""
     parts = args.strip().split(maxsplit=1)
     if not parts:
@@ -60,7 +60,7 @@ async def agent_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _USAGE)
 
 
-async def _create_agent(session: "ChatSession", name: str) -> None:
+async def _create_agent(session: "Session", name: str) -> None:
     """Create a new agent profile and attach to it.
 
     Uses the same ``__attach_request__`` sentinel as ``/attach`` so the
@@ -93,7 +93,7 @@ async def _create_agent(session: "ChatSession", name: str) -> None:
     ))
 
 
-async def _edit_agent(session: "ChatSession", args: str) -> None:
+async def _edit_agent(session: "Session", args: str) -> None:
     """Dispatch ``/agent edit <field> <value>`` — currently ``role`` only.
 
     Edits operate on the **attached agent** (= ``session.agent_name``).
@@ -115,7 +115,7 @@ async def _edit_agent(session: "ChatSession", args: str) -> None:
         )
 
 
-async def _edit_role(session: "ChatSession", new_role: str) -> None:
+async def _edit_role(session: "Session", new_role: str) -> None:
     """Replace the attached agent's role text on disk + in-memory.
 
     Two-side update:

--- a/src/reyn/interfaces/slash/agents.py
+++ b/src/reyn/interfaces/slash/agents.py
@@ -14,7 +14,7 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _NO_REGISTRY_AGENTS = (
@@ -38,7 +38,7 @@ def _attach_completer(session: "object", arg_partial: str = "") -> list[str]:
 
 
 @slash("agents", summary="List all agents (* = attached, · = loaded)")
-async def agents_cmd(session: "ChatSession", args: str) -> None:
+async def agents_cmd(session: "Session", args: str) -> None:
     """``/agents`` — list known agents with attach / loaded markers."""
     if session._registry is None:
         await reply_error(session, _NO_REGISTRY_AGENTS)
@@ -90,7 +90,7 @@ async def agents_cmd(session: "ChatSession", args: str) -> None:
     completer=_attach_completer,
     see_also=("docs/concepts/multi-agent/multi-agent.md",),
 )
-async def attach_cmd(session: "ChatSession", args: str) -> None:
+async def attach_cmd(session: "Session", args: str) -> None:
     """``/attach <name>`` — request the REPL switch to a different agent.
 
     The actual switch happens in ``repl._input_loop`` (which owns the

--- a/src/reyn/interfaces/slash/budget.py
+++ b/src/reyn/interfaces/slash/budget.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _TRACKER_DISABLED = (
@@ -20,7 +20,7 @@ _TRACKER_DISABLED = (
 
 
 @slash("cost", summary="Quick token + USD cost summary for this agent")
-async def cost_cmd(session: "ChatSession", args: str) -> None:
+async def cost_cmd(session: "Session", args: str) -> None:
     """``/cost`` — one-line token + USD spend for the attached agent."""
     line = session._budget.cost_line()
     if line is None:
@@ -35,7 +35,7 @@ async def cost_cmd(session: "ChatSession", args: str) -> None:
     usage="/budget [reset]",
     see_also=("docs/reference/config/budget.md",),
 )
-async def budget_cmd(session: "ChatSession", args: str) -> None:
+async def budget_cmd(session: "Session", args: str) -> None:
     """``/budget`` (full breakdown) or ``/budget reset`` (clear counters).
 
     ``reset`` clears per-process counters (agent tokens / cost, chain skill

--- a/src/reyn/interfaces/slash/chat.py
+++ b/src/reyn/interfaces/slash/chat.py
@@ -15,11 +15,11 @@ from reyn.chat.session import _run_meta, _run_short
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 @slash("list", summary="List running skills and pending interventions")
-async def list_cmd(session: "ChatSession", args: str) -> None:
+async def list_cmd(session: "Session", args: str) -> None:
     """``/list`` — show running skill tasks + pending interventions."""
     now = time.monotonic()
     lines: list[str] = []
@@ -79,7 +79,7 @@ def _running_run_id_completer(
     usage="/cancel <id-prefix> [confirm]",
     completer=_running_run_id_completer,
 )
-async def cancel_cmd(session: "ChatSession", args: str) -> None:
+async def cancel_cmd(session: "Session", args: str) -> None:
     """``/cancel <id-prefix>`` — cancel a running skill task (2-step confirm).
 
     First invocation prints a warning and asks the user to re-type with
@@ -178,7 +178,7 @@ def _intervention_id_completer(
     usage="/answer <id-prefix> <text>",
     completer=_intervention_id_completer,
 )
-async def answer_cmd(session: "ChatSession", args: str) -> None:
+async def answer_cmd(session: "Session", args: str) -> None:
     """``/answer <id-prefix> <text>`` — deliver answer to a non-head
     intervention.
 

--- a/src/reyn/interfaces/slash/clear_history.py
+++ b/src/reyn/interfaces/slash/clear_history.py
@@ -1,7 +1,7 @@
 """``/clear-history`` — wipe chat history + action-usage table.
 
 Sibling to ``/reset`` (skill state) at a different scope: this command
-clears the conversation thread (``ChatSession.history`` + per-agent
+clears the conversation thread (``Session.history`` + per-agent
 ``history.jsonl``) and the action-usage tracker (= the ranking that
 backs the Memory tab's hot-list augmentation, persisted at
 ``.reyn/state/action_usage.jsonl``). Everything else stays intact:

--- a/src/reyn/interfaces/slash/compact.py
+++ b/src/reyn/interfaces/slash/compact.py
@@ -9,7 +9,7 @@ imposing it.
 
 Unlike the `compact` op (LLM-emitted, routed through the op runtime), this is
 user input → it calls the session-level compaction directly. It reuses
-``ChatSession._compact_now_for_op`` (the same `force_compact_now` wrapper the
+``Session._compact_now_for_op`` (the same `force_compact_now` wrapper the
 compact op uses), so the freed-token report is the **same contract** as the op:
 ``{freed_tokens, free_window_after}``.
 """
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 @slash(
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     usage="/compact",
     see_also=("docs/reference/runtime/control-ir.md",),
 )
-async def compact_cmd(session: "ChatSession", args: str) -> None:
+async def compact_cmd(session: "Session", args: str) -> None:
     """``/compact`` — fire on-demand history compaction and report what it freed.
 
     Routes through the session's compaction wrapper (force_compact_now); reports

--- a/src/reyn/interfaces/slash/image.py
+++ b/src/reyn/interfaces/slash/image.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 # Mirror op_runtime/file._IMAGE_EXTENSIONS so the slash command accepts
 # the same set #365 accepts via `file__read`.
@@ -59,7 +59,7 @@ _COMPLETER_MAX = 20
 
 
 def _image_path_completer(
-    session: "ChatSession", arg_partial: str = "",
+    session: "Session", arg_partial: str = "",
 ) -> list[str]:
     """Filesystem path completer for ``/image <path>``.
 
@@ -144,7 +144,7 @@ async def image_cmd(session: object, args: str) -> None:
         )
         return
 
-    # Resolve relative to CWD (= the same scope ChatSession uses for
+    # Resolve relative to CWD (= the same scope Session uses for
     # file reads). Absolute paths are honoured as-is.
     path = Path(path_str).expanduser()
     if not path.is_absolute():
@@ -210,11 +210,11 @@ async def image_cmd(session: object, args: str) -> None:
         "mime_type": mime,
         "content_hash": content_hash,
     }
-    # Queue is drained by ChatSession._handle_user_message on the next
+    # Queue is drained by Session._handle_user_message on the next
     # user turn (= attached to that ChatMessage.media).
     queue: list[dict] = getattr(session, "_pending_user_images", None)
     if queue is None:
-        # ChatSession variants without #366 wiring shouldn't accept the
+        # Session variants without #366 wiring shouldn't accept the
         # command — surface a clear error rather than silently no-op.
         await reply_error(
             session,

--- a/src/reyn/interfaces/slash/memory.py
+++ b/src/reyn/interfaces/slash/memory.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -29,7 +29,7 @@ _USAGE = (
 
 
 def _memory_completer(
-    session: "ChatSession", arg_partial: str = "",
+    session: "Session", arg_partial: str = "",
 ) -> list[str]:
     """Surface memory entry names after ``/memory view ``.
 
@@ -55,7 +55,7 @@ def _memory_completer(
     completer=_memory_completer,
     see_also=("docs/concepts/data-retrieval/memory.md",),
 )
-async def memory_cmd(session: "ChatSession", args: str) -> None:
+async def memory_cmd(session: "Session", args: str) -> None:
     """Dispatch ``list`` / ``view <name>`` subcommands."""
     parts = args.strip().split(maxsplit=1)
     if not parts:
@@ -71,7 +71,7 @@ async def memory_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _USAGE)
 
 
-async def _list_memory(session: "ChatSession") -> None:
+async def _list_memory(session: "Session") -> None:
     """Render every memory entry as one line per row.
 
     Sorted by name (the same order ``list_entries`` returns). Type +
@@ -103,7 +103,7 @@ async def _list_memory(session: "ChatSession") -> None:
     await reply(session, "\n".join(lines))
 
 
-async def _view_memory(session: "ChatSession", name: str) -> None:
+async def _view_memory(session: "Session", name: str) -> None:
     """Print the full body of the named entry."""
     name = name.strip()
     if not name:

--- a/src/reyn/interfaces/slash/pending.py
+++ b/src/reyn/interfaces/slash/pending.py
@@ -9,7 +9,7 @@ Sub-commands:
   /pending claim <id>   — rebind origin to this TUI channel + re-dispatch
 
 The 3 operations match the #270 framework vocabulary (= observe / discard /
-claim). All routed through ``ChatSession.{list_stalled_interventions,
+claim). All routed through ``Session.{list_stalled_interventions,
 discard_pending_intervention, claim_pending_intervention}`` introduced in
 PR #275.
 """
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -70,7 +70,7 @@ def _render_list(pending_ops: list) -> str:
 
 
 def _resolve_iv_id(
-    session: "ChatSession", supplied: str,
+    session: "Session", supplied: str,
 ) -> tuple[str | None, str | None]:
     """Resolve a possibly-short iv id to the full one in the stalled list.
 
@@ -105,7 +105,7 @@ def _resolve_iv_id(
     ),
     usage="/pending [list|discard <id>|claim <id>]",
 )
-async def pending_cmd(session: "ChatSession", args: str) -> None:
+async def pending_cmd(session: "Session", args: str) -> None:
     """Dispatch ``/pending [list|discard|claim]`` subcommands."""
     parts = args.strip().split(maxsplit=1)
     if not parts or parts[0] == "list":
@@ -149,7 +149,7 @@ def _render_needs_attention(summary: dict) -> str:
     return "needs attention:\n" + "\n".join(lines)
 
 
-async def _list(session: "ChatSession") -> None:
+async def _list(session: "Session") -> None:
     if not hasattr(session, "list_stalled_interventions"):
         await reply_error(session, _NO_SESSION)
         return
@@ -175,7 +175,7 @@ async def _list(session: "ChatSession") -> None:
     await reply(session, output)
 
 
-async def _discard(session: "ChatSession", supplied_id: str) -> None:
+async def _discard(session: "Session", supplied_id: str) -> None:
     """Two-step confirm: first invocation shows a warning; second executes.
 
     Mirrors ``/reset``'s pattern (Wave-13 B#2).  The user must re-type
@@ -243,7 +243,7 @@ async def _discard(session: "ChatSession", supplied_id: str) -> None:
         await reply_error(session, f"discard {iv_id[:8]}: not in stalled queue")
 
 
-async def _claim(session: "ChatSession", supplied_id: str) -> None:
+async def _claim(session: "Session", supplied_id: str) -> None:
     if not hasattr(session, "claim_pending_intervention"):
         await reply_error(session, _NO_SESSION)
         return

--- a/src/reyn/interfaces/slash/plan.py
+++ b/src/reyn/interfaces/slash/plan.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -28,7 +28,7 @@ _USAGE = (
 )
 
 
-def _plan_completer(session: "ChatSession", arg_partial: str = "") -> list[str]:
+def _plan_completer(session: "Session", arg_partial: str = "") -> list[str]:
     """Surface plan IDs or step IDs for the ``/plan`` arg the user is typing.
 
     Two contexts handled:
@@ -65,7 +65,7 @@ def _plan_completer(session: "ChatSession", arg_partial: str = "") -> list[str]:
 
 
 def _step_ids_for_plan(
-    session: "ChatSession", plan_id: str,
+    session: "Session", plan_id: str,
 ) -> list[str]:
     """Load the decomposition artifact for ``plan_id`` and return step IDs.
 
@@ -94,7 +94,7 @@ def _step_ids_for_plan(
     completer=_plan_completer,
     see_also=("docs/concepts/multi-agent/plan-mode.md",),
 )
-async def plan_cmd(session: "ChatSession", args: str) -> None:
+async def plan_cmd(session: "Session", args: str) -> None:
     """Dispatch to sub-command based on the first argument."""
     parts = args.strip().split(maxsplit=1)
     if not parts:
@@ -112,7 +112,7 @@ async def plan_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _USAGE)
 
 
-async def _list_plan_runs(session: "ChatSession") -> None:
+async def _list_plan_runs(session: "Session") -> None:
     """Emit a status message listing active plan runs.
 
     Reads from session.running_plans (= the asyncio.Task tracking dict
@@ -148,7 +148,7 @@ async def _list_plan_runs(session: "ChatSession") -> None:
     await reply(session, "\n".join(lines))
 
 
-async def _discard_plan_run(session: "ChatSession", args: str) -> None:
+async def _discard_plan_run(session: "Session", args: str) -> None:
     """Abort a plan: cancel task, surface outbox notice, clean up state.
 
     Two-step confirm pattern (mirrors ``/reset``): first invocation prints
@@ -321,7 +321,7 @@ def _parse_resume_args(args: str) -> tuple[str, str] | None:
     return (plan_id, step_id)
 
 
-async def _resume_from_step(session: "ChatSession", args: str) -> None:
+async def _resume_from_step(session: "Session", args: str) -> None:
     """Reset step results from <step_id> onward and re-launch the plan.
 
     ADR-0023 §3.7 surgical operator escape hatch. Use cases:
@@ -335,7 +335,7 @@ async def _resume_from_step(session: "ChatSession", args: str) -> None:
       2. Cancel any currently-running task for this plan.
       3. Load the decomposition artifact (= for topological step order).
       4. Call PlanRegistry.reset_from_step (mutates + persists snapshot).
-      5. Re-launch via ChatSession._spawn_resumed_plan with a fresh
+      5. Re-launch via Session._spawn_resumed_plan with a fresh
          resume_plan derived from the post-reset snapshot.
 
     On any failure surface a /plan list-style hint so the operator

--- a/src/reyn/interfaces/slash/reset.py
+++ b/src/reyn/interfaces/slash/reset.py
@@ -27,7 +27,7 @@ def _format_currently_line(session: "object") -> str:
     """Build the 'Currently: N skills, M plans' context line.
 
     Reads from ``session.current_state_summary()`` when available.
-    Returns an empty string when the session is not a full ChatSession
+    Returns an empty string when the session is not a full Session
     (e.g. test stubs that don't expose the method).
     """
     summary_fn = getattr(session, "current_state_summary", None)

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -25,7 +25,7 @@ from reyn.chat.outbox import OutboxMessage
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 _USAGE = "usage: /session new | /session switch <sid> | /session list"
 
@@ -36,7 +36,7 @@ _USAGE = "usage: /session new | /session switch <sid> | /session list"
     usage="/session new | /session switch <sid> | /session list",
     see_also=("docs/concepts/multi-agent/multi-agent.md",),
 )
-async def session_cmd(session: "ChatSession", args: str) -> None:
+async def session_cmd(session: "Session", args: str) -> None:
     """``/session <new|switch <sid>|list>`` — per-agent multi-session control."""
     reg = session._registry
     if reg is None:

--- a/src/reyn/interfaces/slash/skill.py
+++ b/src/reyn/interfaces/slash/skill.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -38,7 +38,7 @@ _USAGE = (
     summary="Manage active skill runs",
     usage="/skill [list|discard <id>]",
 )
-async def skill_cmd(session: "ChatSession", args: str) -> None:
+async def skill_cmd(session: "Session", args: str) -> None:
     """Dispatch to sub-command based on the first argument."""
     parts = args.strip().split(maxsplit=1)
     if not parts:
@@ -54,7 +54,7 @@ async def skill_cmd(session: "ChatSession", args: str) -> None:
         await reply_error(session, _USAGE)
 
 
-async def _list_skill_runs(session: "ChatSession") -> None:
+async def _list_skill_runs(session: "Session") -> None:
     """Emit a status message listing active skill runs.
 
     R-D13: when a child run was spawned via ``run_skill`` and the parent
@@ -153,7 +153,7 @@ def _format_elapsed(started_monotonic: float | None) -> str:
     return f"{hrs}h{mins:02d}m"
 
 
-async def _discard_skill_run(session: "ChatSession", args: str) -> None:
+async def _discard_skill_run(session: "Session", args: str) -> None:
     """Abort the run: cancel task, drop interventions, mark discarded.
 
     Two-step flow:

--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 _USAGE = (
@@ -44,7 +44,7 @@ _USAGE = (
     summary="Unified view of running async tasks (skills + plans)",
     usage="/tasks [list|status <run_id>|kill <run_id>]",
 )
-async def tasks_cmd(session: "ChatSession", args: str) -> None:
+async def tasks_cmd(session: "Session", args: str) -> None:
     parts = args.strip().split(maxsplit=1)
     if not parts or parts[0] == "list":
         await _list_tasks(session)
@@ -74,7 +74,7 @@ def _format_elapsed(seconds: float) -> str:
 
 
 def _resolve_task(
-    session: "ChatSession", prefix: str,
+    session: "Session", prefix: str,
 ) -> tuple[str | None, str, list[str]]:
     """Resolve a run_id / plan_id from a prefix.
 
@@ -107,7 +107,7 @@ def _resolve_task(
 # ── /tasks list ──────────────────────────────────────────────────────────────
 
 
-async def _list_tasks(session: "ChatSession") -> None:
+async def _list_tasks(session: "Session") -> None:
     skill_lines = _list_skill_lines(session)
     plan_lines = _list_plan_lines(session)
     if not skill_lines and not plan_lines:
@@ -126,7 +126,7 @@ async def _list_tasks(session: "ChatSession") -> None:
     await reply(session, "\n".join(out))
 
 
-def _list_skill_lines(session: "ChatSession") -> list[str]:
+def _list_skill_lines(session: "Session") -> list[str]:
     running = getattr(session, "running_skills", {}) or {}
     if not running:
         return []
@@ -150,7 +150,7 @@ def _list_skill_lines(session: "ChatSession") -> list[str]:
     return lines
 
 
-def _list_plan_lines(session: "ChatSession") -> list[str]:
+def _list_plan_lines(session: "Session") -> list[str]:
     running = getattr(session, "running_plans", None)
     if not running:
         return []
@@ -167,7 +167,7 @@ def _list_plan_lines(session: "ChatSession") -> list[str]:
 # ── /tasks status ────────────────────────────────────────────────────────────
 
 
-async def _task_status(session: "ChatSession", args: str) -> None:
+async def _task_status(session: "Session", args: str) -> None:
     prefix = args.strip()
     if not prefix:
         await reply_error(session, "Usage: /tasks status <run_id_prefix>")
@@ -191,7 +191,7 @@ async def _task_status(session: "ChatSession", args: str) -> None:
         await reply_error(session, f"unknown task kind for {resolved}")
 
 
-async def _skill_status(session: "ChatSession", run_id: str) -> None:
+async def _skill_status(session: "Session", run_id: str) -> None:
     started_at = getattr(session, "running_skills_started_at", {}) or {}
     elapsed = time.monotonic() - started_at.get(run_id, time.monotonic())
     reg = session.get_skill_registry()
@@ -213,7 +213,7 @@ async def _skill_status(session: "ChatSession", run_id: str) -> None:
     await reply(session, "\n".join(out))
 
 
-async def _plan_status(session: "ChatSession", plan_id: str) -> None:
+async def _plan_status(session: "Session", plan_id: str) -> None:
     out = [f"plan {plan_id}", "  (use `/plan list` for the running plan view)"]
     await reply(session, "\n".join(out))
 
@@ -221,7 +221,7 @@ async def _plan_status(session: "ChatSession", plan_id: str) -> None:
 # ── /tasks kill ──────────────────────────────────────────────────────────────
 
 
-async def _kill_task(session: "ChatSession", args: str) -> None:
+async def _kill_task(session: "Session", args: str) -> None:
     prefix = args.strip()
     if not prefix:
         await reply_error(session, "Usage: /tasks kill <run_id_prefix>")

--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -12,7 +12,7 @@ Layout:
 RightPanel (ctrl+b to toggle, ctrl+o to focus, ctrl+w to cycle tabs):
   keys · events · agents · memory · docs
 
-ChatSession integration (phase 3+):
+Session integration (phase 3+):
   - subscribe_outbox():    coroutine draining registry.repl_outbox → render
   - on input submit:       call session.submit_user_text(text)
   - slash dispatch:        REGISTRY.get(cmd).handler(session, args)
@@ -51,7 +51,7 @@ from .widgets import ConversationView, InputBar, InterventionWidget, ReynHeader,
 
 if TYPE_CHECKING:
     from reyn.chat.registry import AgentRegistry
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 # Debounce window for the "nothing-in-flight cancel" line — repeat
@@ -440,7 +440,7 @@ class ReynTUIApp(App):
         self._cost_inline_enabled = bool(prefs.get("cost_inline", False))
 
         # issue #254 Phase 1: declare ourselves as the intervention listener
-        # for the attached session. Without this, ``ChatSession`` constructed
+        # for the attached session. Without this, ``Session`` constructed
         # with ``enforce_listener_presence=True`` would short-circuit
         # ``_dispatch_intervention`` and prompts would never reach the TUI.
         # ``_get_session()`` may return None during early lifecycle (no
@@ -2898,7 +2898,7 @@ class ReynTUIApp(App):
 
     # ── helpers ───────────────────────────────────────────────────────────────
 
-    def _get_session(self) -> "ChatSession | None":
+    def _get_session(self) -> "Session | None":
         if self._agent_registry is None:
             return None
         return self._agent_registry.attached_session()

--- a/src/reyn/interfaces/tui/app_outbox.py
+++ b/src/reyn/interfaces/tui/app_outbox.py
@@ -1180,7 +1180,7 @@ class OutboxRouter:
         # compat for the CLI Panel path and any legacy producers.
         question_text = str(msg.meta.get("prompt") or msg.text)
         detail_text = msg.meta.get("detail")
-        # Issue #261 — opt-in source_agent stamped by ChatSession's
+        # Issue #261 — opt-in source_agent stamped by Session's
         # parent_delegate branch (see services/intervention_handler.py
         # ``source_agent_var``). Absent on the default user_channel
         # path, so the existing non-delegated flow is unaffected.

--- a/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
@@ -1360,7 +1360,7 @@ class RightPanel(Widget):
     def _pending_action_discard(self) -> None:
         """Discard the iv at the current cursor.
 
-        Calls ``ChatSession.discard_pending_intervention``. Flashes
+        Calls ``Session.discard_pending_intervention``. Flashes
         a short status confirmation in the conv pane on success;
         silently no-ops when the cursor isn't on a valid row.
         """

--- a/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
@@ -3,7 +3,7 @@
 Issue #277 (= Phase A TUI surface split from #268 / #270 umbrella).
 
 Consumes ``list[PendingOpView]`` returned by
-``ChatSession.list_stalled_interventions()``. Each row carries the
+``Session.list_stalled_interventions()``. Each row carries the
 ``kind`` discriminator (currently ``"intervention"`` only; future
 ``"mcp_call"`` / ``"peer_delegate"`` per #270 Phase B lift up).
 

--- a/src/reyn/interfaces/tui/ws_client.py
+++ b/src/reyn/interfaces/tui/ws_client.py
@@ -8,7 +8,7 @@ exposes:
   attributes for ``ReynTUIApp._outbox_loop`` and ``_get_session`` to
   function). Drains the WS connection in a background task and pushes
   reconstructed ``OutboxMessage`` items onto its ``repl_outbox`` queue.
-- :class:`_WSSessionProxy` — a minimal ChatSession shape exposing the
+- :class:`_WSSessionProxy` — a minimal Session shape exposing the
   TUI's submit / session-attribute paths the foreground code touches
   on user input. Phase B will expand this with intervention answer /
   cancel / list-agents support.
@@ -55,7 +55,7 @@ _KNOWN_KINDS = frozenset({
 
 
 class _WSSessionProxy:
-    """Minimal ChatSession-shaped object backing the TUI in ``--connect`` mode.
+    """Minimal Session-shaped object backing the TUI in ``--connect`` mode.
 
     The TUI reads ``agent_name`` (for header / Pending tab claim
     channel id construction) and calls ``submit_user_text(text)`` on
@@ -88,7 +88,7 @@ class _WSSessionProxy:
     def interventions(self):
         """Intervention registry — ``None`` in Phase A proxy (no local state).
 
-        Local ``ChatSession`` stores intervention data in ``_interventions``.
+        Local ``Session`` stores intervention data in ``_interventions``.
         The Phase A proxy has no round-trip to the server for this, so
         ``None`` is the correct placeholder: TUI paths that read it already
         use ``getattr(session, "_interventions", None)`` / ``getattr(session,
@@ -104,7 +104,7 @@ class _WSSessionProxy:
     async def submit_user_text(self, text: str) -> None:
         """Send a ``user_message`` WS frame.
 
-        Mirrors :py:meth:`ChatSession.submit_user_text` from the TUI's
+        Mirrors :py:meth:`Session.submit_user_text` from the TUI's
         point of view — kicks off a turn on the remote agent.
         """
         await self._send_fn({"type": "user_message", "text": text})
@@ -112,7 +112,7 @@ class _WSSessionProxy:
     def register_intervention_listener(self, listener_id: str) -> None:
         """No-op stub for the TUI's ``on_mount`` listener registration.
 
-        The local ``ChatSession`` uses this to declare which UI surface
+        The local ``Session`` uses this to declare which UI surface
         consumes intervention prompts (= local TUI vs MCP vs A2A). In
         remote (``--connect``) mode the server-side session handles its
         own listener registration; the thin client doesn't need to
@@ -131,7 +131,7 @@ class _WSSessionProxy:
     async def _maybe_handle_slash(self, text: str) -> bool:
         """Issue #276 Phase B (4/5): forward all slash commands to the server.
 
-        The local ``ChatSession._maybe_handle_slash`` dispatches to a
+        The local ``Session._maybe_handle_slash`` dispatches to a
         registered handler (e.g. ``agents_cmd``, ``attach_cmd``) that
         reads ``session._registry`` — server-side state the proxy
         cannot reach locally. Forward the raw command text instead;
@@ -155,7 +155,7 @@ class _WSSessionProxy:
     async def _maybe_answer_oldest_intervention(self, text: str) -> None:
         """Issue #276 Phase B (2/5): send an ``answer_intervention`` WS frame.
 
-        Mirrors :py:meth:`ChatSession._maybe_answer_oldest_intervention`
+        Mirrors :py:meth:`Session._maybe_answer_oldest_intervention`
         from the TUI's intervention-widget callback path: when the
         user clicks a chip or types a free-text answer, the widget's
         ``answer_callback`` calls this with the chosen string.

--- a/src/reyn/interfaces/web/__init__.py
+++ b/src/reyn/interfaces/web/__init__.py
@@ -1,6 +1,6 @@
 """reyn.interfaces.web — thin FastAPI + WebSocket gateway for the Reyn engine.
 
-Wraps AgentRegistry, ChatSession, EventStore, and friends without modifying
+Wraps AgentRegistry, Session, EventStore, and friends without modifying
 the engine. The gateway is OS-adjacent infrastructure and must satisfy P7:
 no skill-specific strings (phase names, artifact types, decision values)
 may appear in this package. All engine data passes through as opaque JSON.

--- a/src/reyn/interfaces/web/a2a_intervention.py
+++ b/src/reyn/interfaces/web/a2a_intervention.py
@@ -6,14 +6,14 @@ when registered as a chain override — ``_dispatch_intervention``
 replaced its normal handler-dispatch path with ``override.request(iv)``
 and the bus awaited ``iv.future`` directly. The iv lived in this bus +
 ``RunRegistry.pending_intervention`` only; it never entered
-``ChatSession._interventions._active`` or the WAL / snapshot persistence
+``Session._interventions._active`` or the WAL / snapshot persistence
 channels. On restart, the bus coroutine died and the restored iv was
 orphaned — no in-process awaiter, no R-D12 buffer eligibility, no
 ``SkillResumeCoordinator`` integration. See issue #292 body for the
 full analysis.
 
 Post-α this class is a **side-effect observer**: ``on_dispatch(iv)``
-is invoked by ``ChatSession._dispatch_intervention`` BEFORE
+is invoked by ``Session._dispatch_intervention`` BEFORE
 ``InterventionHandler.dispatch`` runs. The bus:
 
   - Mirrors ``status="input-required"`` on the RunEntry so polling
@@ -26,19 +26,19 @@ is invoked by ``ChatSession._dispatch_intervention`` BEFORE
     the skill; the bus has no in-process answer-resolution role.
 
 Peer answers arrive via the A2A router's ``POST /a2a/agents/<name>
-{task_id, answer}`` → ``ChatSession.answer_pending_intervention`` →
+{task_id, answer}`` → ``Session.answer_pending_intervention`` →
 ``handler.deliver_answer_to`` (= same path the TUI uses). The iv future
 is resolved by the handler; the bus is unaware. R-D12's persistent
 answer buffer captures the answer if a crash intervenes before the
 skill consumes it, so restart-resume picks up cleanly.
 
 Wired by ``mcp_server.send_to_agent_impl`` through
-``ChatSession.register_intervention_override(chain_id, bus)``.
+``Session.register_intervention_override(chain_id, bus)``.
 
 Scope guard:
   - ⭕ in-scope: notify A2A peer of input-required state via webhook +
     SSE buffer + RunEntry status mirror.
-  - ❌ out-of-scope: iv ownership (= ChatSession owns it post-α),
+  - ❌ out-of-scope: iv ownership (= Session owns it post-α),
     iv.future resolution (= handler does it), skill completion
     narration (= flows through ``_handle_skill_completed``).
 """
@@ -80,7 +80,7 @@ class A2AInterventionBus:
         """Fire A2A peer-facing side effects when ``iv`` is about to be
         dispatched by the agent.
 
-        Called by ``ChatSession._dispatch_intervention`` for each iv
+        Called by ``Session._dispatch_intervention`` for each iv
         whose chain has this bus registered as an override. Runs
         BEFORE ``InterventionHandler.dispatch`` so the peer learns
         input-required before the awaiter blocks.
@@ -108,7 +108,7 @@ class A2AInterventionBus:
             )
             return
 
-        # Mirror status. Post-α the iv itself lives in ChatSession's
+        # Mirror status. Post-α the iv itself lives in Session's
         # outstanding_interventions; we only reflect the high-level
         # state on the RunEntry for peer polling visibility.
         self._registry.update(self._run_id, status="input-required")

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -300,7 +300,7 @@ def _get_registry():
         registry_ref: list = []
 
         # `reyn web --eager-embedding-build` flag (parity with `reyn chat`).
-        # When set, ChatSession waits for the action_embedding_index build
+        # When set, Session waits for the action_embedding_index build
         # synchronously on the first router turn so ``search_actions`` is
         # visible in tools[] from Turn 1 instead of only after the
         # background build completes. Default False keeps existing
@@ -310,7 +310,7 @@ def _get_registry():
             os.environ.get("REYN_WEB_EAGER_EMBEDDING_BUILD", "").strip() == "1"
         )
 
-        def _session_factory(profile: AgentProfile) -> ChatSession:
+        def _session_factory(profile: AgentProfile) -> Session:
             registry = registry_ref[0]
             _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
             s = build_scoped_chat_session(
@@ -331,7 +331,7 @@ def _get_registry():
                 events_config=config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,
-                # B52 retro fix: A2A-side ChatSession was missing
+                # B52 retro fix: A2A-side Session was missing
                 # ``sandbox_config`` propagation — ``reyn.yaml`` ``sandbox.backend``
                 # set in reyn.local.yaml never reached the sandboxed_exec
                 # handler via the chat-router path. Cron-side

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -536,7 +536,7 @@ async def _escalate_to_task(
 
 
 async def _get_session_for_monitor(registry, agent_name: str):
-    """Resolve the ChatSession instance for the monitor task.
+    """Resolve the Session instance for the monitor task.
 
     Mirrors ``mcp_server._get_session`` but kept local so the import
     surface of this router stays small.
@@ -584,7 +584,7 @@ async def _await_skill_completion(
     # narration turn lands in history.
     # Each iteration is wrapped in the per-agent lock so A2A drain turns
     # serialize with concurrent MCP (or registry.run()) turns on the same
-    # shared ChatSession.
+    # shared Session.
     for _ in range(20):  # bounded; each iteration consumes one inbox msg
         if session.inbox.empty():
             break
@@ -636,7 +636,7 @@ async def _handle_answer_injection(
     """Deliver an answer to a pending ask_user intervention on an async task.
 
     Extracts text from ``params.message.parts`` (same as normal send),
-    then routes to ``ChatSession.answer_pending_intervention`` (= issue
+    then routes to ``Session.answer_pending_intervention`` (= issue
     #292 α path).
 
     issue #267 Gap 4: also extracts ``choice_id`` for closed-set prompts
@@ -650,7 +650,7 @@ async def _handle_answer_injection(
 
     issue #292 (α): pre-#292 this called
     ``run_registry.answer_intervention`` which resolved a separate iv
-    future owned by RunRegistry. Post-α, the iv lives in ChatSession's
+    future owned by RunRegistry. Post-α, the iv lives in Session's
     ``_interventions._active`` and the agent's
     ``answer_pending_intervention`` is the single authoritative entry
     point — R-D12's persistent answer buffer applies automatically so
@@ -679,7 +679,7 @@ async def _handle_answer_injection(
     if isinstance(top_choice, str) and top_choice:
         choice_id = top_choice
 
-    # Look up the owning agent via RunEntry → load ChatSession →
+    # Look up the owning agent via RunEntry → load Session →
     # authoritative answer delivery.
     entry = run_registry.get(task_id)
     if entry is None:
@@ -705,7 +705,7 @@ async def _handle_answer_injection(
     if delivered:
         # Mirror status back to "running" on the RunEntry for peer
         # polling. The actual iv resolution already happened in
-        # ChatSession; this is just the public-status mirror.
+        # Session; this is just the public-status mirror.
         run_registry.update(task_id, status="running")
         result = {"task_id": task_id, "answered": True}
     else:

--- a/src/reyn/interfaces/web/run_registry.py
+++ b/src/reyn/interfaces/web/run_registry.py
@@ -16,7 +16,7 @@ Persistence boundary (= issue #292 α refactor):
 
 Pre-#292, ``RunEntry`` also persisted ``pending_intervention`` (= the
 full ``UserIntervention`` object). That field has been **removed**:
-the iv is owned by ``ChatSession._interventions`` (= same machinery
+the iv is owned by ``Session._interventions`` (= same machinery
 TUI ivs use, including R-D12's persistent answer buffer). What
 ``RunRegistry`` persists is only the A2A-task-wrapper state.
 
@@ -26,7 +26,7 @@ What persists:
 
 What does NOT persist (= volatile, restored as ``None`` / dropped):
   - asyncio.Task reference (= bound to the process that died)
-  - pending iv state (= owned by ChatSession; queried at request time
+  - pending iv state (= owned by Session; queried at request time
     rather than mirrored here)
 """
 from __future__ import annotations
@@ -51,7 +51,7 @@ class RunEntry:
     """One A2A async task. Mutable; ``RunRegistry`` owns lifecycle.
 
     issue #292 (α): ``pending_intervention`` and ``question`` fields
-    removed — iv state lives in ``ChatSession._interventions``. This
+    removed — iv state lives in ``Session._interventions``. This
     entry only carries A2A-task-wrapper state.
 
     issue #269 Phase 2: ``_webhook_channel_state`` (private, lazy-init)
@@ -95,7 +95,7 @@ class RunEntry:
 
         Includes webhook_url + history_events for post-restart peer
         notification + SSE replay continuity. iv state (formerly
-        ``pending_intervention``) is owned by ChatSession and persisted
+        ``pending_intervention``) is owned by Session and persisted
         via AgentSnapshot — see issue #292 body for the layering.
 
         Excludes volatile fields:
@@ -121,7 +121,7 @@ class RunEntry:
         Rebuilds a ``RunEntry`` from the persistence snapshot. Tolerant
         of pre-#292 snapshots that included ``pending_intervention`` /
         ``question`` keys (= silently ignored, the iv is restored via
-        ChatSession's AgentSnapshot instead).
+        Session's AgentSnapshot instead).
         """
 
         def _parse_ts(value: object) -> datetime:
@@ -272,7 +272,7 @@ class RunRegistry:
     ) -> RunEntry | None:
         """Update task-wrapper state. issue #292 (α): ``question`` and
         ``pending_intervention`` params removed — iv lifecycle is owned
-        by ChatSession.
+        by Session.
         """
         entry = self._runs.get(run_id)
         if entry is None:

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -105,10 +105,10 @@ async def _lifespan(app: FastAPI):
     # FP-0001 + issue #267 Gap 5: RunRegistry singleton — process-wide
     # task lifecycle tracking with snapshot persistence so a process
     # restart preserves A2A async-task state (= the structural gap that
-    # left A2A peer routing half-restored against the ChatSession-side
+    # left A2A peer routing half-restored against the Session-side
     # outstanding_interventions persistence wired by PR-intervention-link
     # L2-L6). Snapshot path follows the convention established by
-    # ChatSession's per-agent snapshot.json: server-level state lives at
+    # Session's per-agent snapshot.json: server-level state lives at
     # ``.reyn/state/run_registry.json``.
     from pathlib import Path  # noqa: PLC0415
 

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -10,9 +10,9 @@ as a stdio subprocess and converse with a Reyn agent through two tools:
     message to a named agent and block (with timeout) for the final
     reply text.
 
-Multi-turn continuity falls out for free: ``ChatSession.history`` is
+Multi-turn continuity falls out for free: ``Session.history`` is
 persistent across calls because the registry caches each session
-in-process and ``ChatSession.load_history`` rehydrates from
+in-process and ``Session.load_history`` rehydrates from
 ``history.jsonl`` on construction.
 
 FP-0013: ``send_to_agent_impl`` now drives ``session.run_one_iteration()``
@@ -72,7 +72,7 @@ _IDLE_GRACE_SECONDS: float = 0.05
 
 
 async def _get_session(registry: "AgentRegistry", name: str) -> "object":
-    """Return a loaded ChatSession for `name`.
+    """Return a loaded Session for `name`.
 
     Note: unlike `reyn chat`, the MCP path does NOT spawn a long-lived
     ``session.run()`` task. The MCP SDK's stdio transport (under
@@ -215,7 +215,7 @@ async def send_to_agent_impl(
         # issue #268 Phase 2: when the override exposes a stable
         # ``channel_id`` (= A2AInterventionBus does), register it as
         # an intervention listener so the agent layer's origin-pin
-        # check (= ``ChatSession.handle_intervention`` Branch 3)
+        # check (= ``Session.handle_intervention`` Branch 3)
         # treats the A2A channel as alive while the bus is active.
         # ``getattr`` lets future buses without channel_id participate
         # via the override path without forcing them to expose one.
@@ -385,7 +385,7 @@ def build_server(
                     "Deliver an answer to a pending ask_user / "
                     "permission / safety intervention on a running "
                     "send_to_agent call (issue #270 Phase B). "
-                    "Routes via ChatSession.answer_pending_intervention. "
+                    "Routes via Session.answer_pending_intervention. "
                     "Identify the iv by ``run_id`` (= surfaced in the "
                     "progress notification that the server pushed when "
                     "the iv was dispatched, see experimental capability "
@@ -636,7 +636,7 @@ async def _make_mcp_intervention_bus(
 
     issue #292 α extended to MCP: when a skill spawned via
     ``send_to_agent_impl`` emits a ``UserIntervention``, that iv lands
-    in ``ChatSession._interventions._active`` and ``handler.dispatch``
+    in ``Session._interventions._active`` and ``handler.dispatch``
     awaits its future. Pre-#270 Phase B the MCP transport had no
     observer registered as chain override → no peer-facing surface to
     push the iv question to → the iv would hang if no TUI was
@@ -647,7 +647,7 @@ async def _make_mcp_intervention_bus(
     pushes an MCP notification carrying the iv payload; does NOT await
     ``iv.future``). The peer answers via a separate
     ``answer_intervention`` MCP tool call that lands at
-    ``ChatSession.answer_pending_intervention``.
+    ``Session.answer_pending_intervention``.
 
     Returns ``None`` when the request context is unavailable (= e.g.
     direct test calls bypassing the MCP server). The caller (= send-
@@ -673,7 +673,7 @@ class _MCPInterventionBus:
     Mirrors ``A2AInterventionBus``'s post-α observer shape:
 
       - ``on_dispatch(iv)`` runs as a side effect inside
-        ``ChatSession._dispatch_intervention``, BEFORE the regular
+        ``Session._dispatch_intervention``, BEFORE the regular
         handler dispatch awaits ``iv.future``.
       - Stamps ``iv.origin_channel_id`` so the agent layer can attribute
         this iv to the MCP channel.
@@ -683,7 +683,7 @@ class _MCPInterventionBus:
       - Does NOT await ``iv.future``. The handler awaits on the
         skill's behalf; the peer answers via the
         ``answer_intervention`` MCP tool which routes to
-        ``ChatSession.answer_pending_intervention``.
+        ``Session.answer_pending_intervention``.
 
     Notification transport: uses ``Session.send_progress_notification``
     with the iv payload encoded as JSON in the ``message`` field +

--- a/src/reyn/plugins/api.py
+++ b/src/reyn/plugins/api.py
@@ -3,7 +3,7 @@
 Plugins (= webhook handlers under ``reyn.plugins.*`` or external pip
 packages registered via the ``reyn.webhooks`` entry-point group)
 SHOULD use the helpers in this module to interact with Reyn agents,
-NOT call internal ``ChatSession`` methods (= ``_put_inbox``,
+NOT call internal ``Session`` methods (= ``_put_inbox``,
 ``_handle_user_message``) directly.
 
 The contract here is intended to stay stable across Reyn minor
@@ -49,7 +49,7 @@ async def push_to_agent(
     """Deliver a message to a Reyn agent's inbox.
 
     This is the **stable public API** for webhook / chat-transport
-    plugins. Use it instead of touching ``ChatSession._put_inbox``
+    plugins. Use it instead of touching ``Session._put_inbox``
     directly. Internal session APIs may change between Reyn versions;
     this function won't.
 

--- a/src/reyn/runtime/limits/limit_handler.py
+++ b/src/reyn/runtime/limits/limit_handler.py
@@ -6,12 +6,12 @@ Six sites in the codebase raise on a safety limit hit:
   - F (phase_seconds)         — ``OSRuntime._check_phase_budget``
   - A (max_act_turns)         — ``skill_node_runner`` act-loop
   - C (router_cap)            — ``BudgetGateway.check_and_increment_router_cap``
-  - E (max_hop_depth)         — ``ChatSession._send_to_agent``
+  - E (max_hop_depth)         — ``Session._send_to_agent``
   - G (chain_seconds)         — ``ChainManager`` watchdog fire path
 
 Plus FP-0003 already covers:
 
-  - D (per_chain_skill_calls) — ``ChatSession._ask_budget_extension``
+  - D (per_chain_skill_calls) — ``Session._ask_budget_extension``
 
 This module replaces the bespoke ``_ask_budget_extension`` with a
 generic ``handle_limit_exceeded`` callable that all seven sites share.
@@ -79,7 +79,7 @@ def reset_run_extensions(run_id: str) -> None:
     """Reset auto_extend bookkeeping for ``run_id``.
 
     Call at the start of a run (= ``OSRuntime.run`` entry,
-    ``ChatSession`` turn boundary). After this, ``auto_extend_times``
+    ``Session`` turn boundary). After this, ``auto_extend_times``
     grants are fresh.
     """
     keys_to_drop = [k for k in _auto_extend_used if k[0] == run_id]

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -401,11 +401,11 @@ class PermissionResolver:
         self._unsafe_python_allowed = unsafe_python_allowed
         # #398 v4 emitter wiring: subscribers fired when ``_persist`` lands
         # an approval (= "always allow") or revoke decision to approvals.yaml.
-        # ChatSession registers a callback that mints a ``state_change``
+        # Session registers a callback that mints a ``state_change``
         # history entry so the LLM sees "permission for X was
         # granted/revoked" in its next turn — directly mitigates the
         # #352 in-context-learning refusal trap. PermissionResolver is
-        # shared across sessions; each ChatSession registers its own
+        # shared across sessions; each Session registers its own
         # callback so a project-wide grant notifies every active session.
         self._on_persist_callbacks: list[Callable[[str, bool], None]] = []
 
@@ -454,7 +454,7 @@ class PermissionResolver:
             )
         except Exception:
             pass
-        # #398 v4 emitter wiring: notify subscribers (= ChatSession
+        # #398 v4 emitter wiring: notify subscribers (= Session
         # instances that registered themselves) so the LLM sees the
         # permission change as a ``state_change`` history entry next
         # turn. Iterate a snapshot so a callback that unregisters
@@ -477,13 +477,13 @@ class PermissionResolver:
         """Subscribe to ``_persist`` events for emitter wiring (= #398 v4).
 
         ``callback(key, approved)`` is invoked after the approval is
-        written to ``approvals.yaml``. Used by ChatSession to mint
+        written to ``approvals.yaml``. Used by Session to mint
         a ``state_change`` history entry per ``notify_state_change``
         so the LLM sees the permission update in its next turn
         (= directly mitigates the #352 in-context-learning refusal
         trap pattern).
 
-        Multiple ChatSessions can register the same shared resolver
+        Multiple Sessions can register the same shared resolver
         so a project-wide grant notifies every active session
         independently.
         """
@@ -495,10 +495,10 @@ class PermissionResolver:
         """Detach a previously registered callback.
 
         Returns True iff the callback was found and removed. Use this
-        on ChatSession shutdown to prevent dead-session callbacks from
+        on Session shutdown to prevent dead-session callbacks from
         accumulating in long-running PermissionResolver instances
         (= the shared singleton model in ``reyn web`` / ``reyn run``
-        sessions outlive individual ChatSessions).
+        sessions outlive individual Sessions).
         """
         try:
             self._on_persist_callbacks.remove(callback)

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -524,7 +524,7 @@ def compute_covers_through_seq(new_turn_seqs: list) -> int:
 
     Deterministic; the LLM is not trusted to compute this correctly on
     weak models (a wrong value causes turn duplication or loss in
-    ChatSession.history).
+    Session.history).
     """
     if not new_turn_seqs:
         return 0

--- a/src/reyn/skill_runtime.py
+++ b/src/reyn/skill_runtime.py
@@ -119,7 +119,7 @@ class SkillRuntime:
         self._runtime: OSRuntime | None = None
         # FP-0008 PR-R (= tui-coder finding #1 propagation): run_id from
         # construction site preserves the canonical run_id set by the
-        # caller (e.g. ChatSession._build_agent_for_skill_runner passes
+        # caller (e.g. Session._build_agent_for_skill_runner passes
         # the skill_runner-generated canonical here so the Agent instance
         # carries the same id from birth, before agent.run() is invoked).
         # When None, agent.run() will generate a fresh canonical at
@@ -254,9 +254,9 @@ class SkillRuntime:
     ) -> RunResult:
         # Run-id resolution priority (FP-0008 PR-R wiring contract):
         #   1. ``run_id`` kwarg to this call    (= caller overrides per-call)
-        #   2. ``self.run_id`` set at __init__  (= ChatSession spawn path)
+        #   2. ``self.run_id`` set at __init__  (= Session spawn path)
         #   3. fresh ``_make_run_id(skill.name)`` (= direct callers, resume)
-        # The (2) layer is what PR-R adds: ChatSession's
+        # The (2) layer is what PR-R adds: Session's
         # ``_build_agent_for_skill_runner`` passes the skill_runner-
         # generated canonical to SkillRuntime.__init__, so by the time
         # agent.run() runs, the instance already owns the canonical id.

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -219,7 +219,7 @@ class ActionEmbeddingIndex:
     cosine similarity, returning the top-K items.
 
     Production wiring (= Phase 2 step 2):
-      - One instance per ChatSession (= router-scoped).
+      - One instance per Session (= router-scoped).
       - RouterLoop bootstraps an async ``build()`` task on first turn
         when ``action_retrieval.embedding_class`` is configured.
       - ``search_actions`` handler delegates to ``query()`` when

--- a/src/reyn/tools/action_usage_tracker.py
+++ b/src/reyn/tools/action_usage_tracker.py
@@ -253,7 +253,7 @@ class ActionUsageTracker:
         Intended for the ``/clear-history`` slash command and similar
         explicit "start fresh" affordances. Preserves the tracker's
         identity (= caller's reference stays valid) so the active
-        ChatSession's wiring keeps working immediately after the
+        Session's wiring keeps working immediately after the
         reset — only the *data* is wiped.
 
         Persist-file removal is best-effort (= matches the

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -117,7 +117,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     sub-skill task spawns.
 
     FP-0012 chat-mode preference: when ``rs.spawn_skill_fn`` is
-    populated (= chat-mode RouterLoop, ChatSession host), prefer the
+    populated (= chat-mode RouterLoop, Session host), prefer the
     non-blocking spawn path. The handler returns the spawn-ack
     ``{status: "spawned", run_id, chain_id, note}`` immediately and the
     background task delivers completion via the ``skill_completed``

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -27,7 +27,7 @@ defensive guards, not as live phase-dispatch paths.
 MemoryService access path — design-revisit finding:
   ToolContext.workspace is a reyn.data.workspace.Workspace instance which
   does NOT carry a MemoryService attribute. MemoryService lives on the
-  ChatSession / RouterHostAdapter layer (constructed per-session with
+  Session / RouterHostAdapter layer (constructed per-session with
   injected file-op callbacks). The handlers below duplicate the
   router_loop.py logic directly against workspace file primitives —
   they use ctx.workspace.read_file / write_file / delete_file — rather

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -857,7 +857,7 @@ def _should_inject_hidden_state_hint(rs: Any) -> bool:
     """Return True iff the hint should be added to a list_actions response.
 
     Fires when (a) a production-context router_state is present (=
-    ChatSession-mediated; rules out pure unit-test contexts that
+    Session-mediated; rules out pure unit-test contexts that
     don't construct an rs at all) AND (b) search_actions is not
     currently usable. Pure-test contexts (``rs is None``) are
     explicitly excluded so test fixtures + LLMReplay don't drift.

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -83,7 +83,7 @@ class UserIntervention:
     # (= "tui:<session>" / "a2a:<run_id>" / etc.). When the origin channel
     # closes while the iv is unresolved, the iv becomes **stalled** in
     # the agent layer — other channels can observe / discard / claim it
-    # via ``ChatSession.list_stalled_interventions`` /
+    # via ``Session.list_stalled_interventions`` /
     # ``discard_pending_intervention`` / ``claim_pending_intervention``.
     # ``None`` (= legacy default) skips the origin-pin routing entirely
     # so existing in-tree callers + tests see no change in behaviour.

--- a/tests/cli/test_chainlit_settings.py
+++ b/tests/cli/test_chainlit_settings.py
@@ -3,10 +3,10 @@
 The chat-settings panel surfaces ``output_language`` as a Select
 widget. Two round-trips need to stay consistent:
 
-1. ``ChatSession.output_language`` (str | None) → widget select value
+1. ``Session.output_language`` (str | None) → widget select value
    (always non-empty string, ``"auto"`` for None) so the dropdown is
    never blank.
-2. widget select value → ``ChatSession.output_language`` (str | None)
+2. widget select value → ``Session.output_language`` (str | None)
    so ``"auto"`` round-trips back to ``None`` and reaches reyn's
    "let the LLM decide" branch.
 

--- a/tests/cli/test_intervention_routed_render.py
+++ b/tests/cli/test_intervention_routed_render.py
@@ -1,7 +1,7 @@
 """Tier 2: events tab renders ``intervention_routed`` events with route + kind + iv_id.
 
 Issue #261 — Phase 4 emits ``intervention_routed`` from
-``ChatSession.handle_intervention``'s three branches (self_answer /
+``Session.handle_intervention``'s three branches (self_answer /
 parent_delegate / user_channel). The events tab surfaces those as
 one-line entries so the user can audit routing decisions.
 

--- a/tests/cli/test_slash_error_recall_hint.py
+++ b/tests/cli/test_slash_error_recall_hint.py
@@ -43,18 +43,18 @@ if str(_SRC) not in sys.path:
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "t") -> "ChatSession":
-    from reyn.chat.session import ChatSession
+def _make_session(tmp_path: Path, *, agent_name: str = "t") -> "Session":
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
 
-    return ChatSession(
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: "ChatSession") -> list:
+def _drain_outbox(session: "Session") -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/cli/test_tui_smoke.py
+++ b/tests/cli/test_tui_smoke.py
@@ -10,7 +10,7 @@ These tests verify that:
   7. StreamingRow accumulates text correctly.
   8. InterventionWidget can be mounted and answered.
 
-No ChatSession or AgentRegistry is wired — tests run fully headless
+No Session or AgentRegistry is wired — tests run fully headless
 against ReynTUIApp(registry=None).
 """
 from __future__ import annotations

--- a/tests/cli/test_ws_client_phase_b_answer.py
+++ b/tests/cli/test_ws_client_phase_b_answer.py
@@ -71,7 +71,7 @@ async def test_session_proxy_answer_intervention_returns_none() -> None:
     """Tier 2: returns ``None`` — actual answer-delivery outcome is
     async server-side.
 
-    Mirrors the local ``ChatSession._maybe_answer_oldest_intervention``
+    Mirrors the local ``Session._maybe_answer_oldest_intervention``
     return shape from the *TUI's* point of view: the local method
     returns bool, but the TUI's ``_mount_intervention`` callback
     doesn't use the return value (just calls + awaits). The remote

--- a/tests/cli/test_ws_client_phase_b_slash.py
+++ b/tests/cli/test_ws_client_phase_b_slash.py
@@ -41,7 +41,7 @@ async def test_session_proxy_slash_sends_wire_frame() -> None:
     result = await proxy._maybe_handle_slash("/attach research")
 
     assert sent == [{"type": "slash_command", "text": "/attach research"}]
-    # Local ChatSession returns True when a slash was handled — match
+    # Local Session returns True when a slash was handled — match
     # the shape so the TUI dispatch doesn't fall through to
     # user_message.
     assert result is True

--- a/tests/plugins/test_api.py
+++ b/tests/plugins/test_api.py
@@ -5,7 +5,7 @@ Pins the stable contract that webhook plugins consume:
   push_to_agent(target_agent, text, sender, reply_to=None,
                 kind="user", extra_meta=None, registry=None)
 
-Internal ``ChatSession._put_inbox`` is deliberately private; the
+Internal ``Session._put_inbox`` is deliberately private; the
 helper is the documented path. Tests cover:
 
   1. Happy path: helper resolves registry, calls ensure_running,

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -16,7 +16,7 @@ Policy compliance:
 - No private-state assertions.
 - Docstrings start with ``Tier 2: ``.
 - Real config loader (not a mock) for the deprecation test.
-- Real ChatSession with monkeypatched ``get_max_input_tokens`` for the
+- Real Session with monkeypatched ``get_max_input_tokens`` for the
   elide test (no mocked collaborators).
 """
 from __future__ import annotations
@@ -106,12 +106,12 @@ def test_clean_config_no_warning() -> None:
 
 
 def _make_session_with_t_max(tmp_path: Path, t_max: int):
-    """Return a ChatSession with a synthetic T_max.
+    """Return a Session with a synthetic T_max.
 
     ``section_caps_spec_tokens=0`` keeps B_M positive for small T_max.
     ``use_chars4_estimate=True`` makes token counting deterministic.
     """
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.config import CompactionConfig
     from reyn.core.events.state_log import StateLog
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -119,7 +119,7 @@ def _make_session_with_t_max(tmp_path: Path, t_max: int):
     original = _mb.get_max_input_tokens
     _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]
     try:
-        session = ChatSession(
+        session = Session(
             agent_name="default",
             agent_role="",
             output_language="en",

--- a/tests/test_1200_3axis_uniformity.py
+++ b/tests/test_1200_3axis_uniformity.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from reyn.chat.planner import Plan, PlanStep, _PlanStepHost
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.environment.host_backend import HostBackend
 
@@ -34,7 +34,7 @@ def test_chat_shares_one_instance_across_fs_and_exec_seams(tmp_path: Path) -> No
     exec seam (OpContext.sandbox_backend) as the SAME object — chat does not
     diverge its two seams (review-gate: differ = reject)."""
     agent_backend = HostBackend()
-    session = ChatSession(
+    session = Session(
         agent_name="u",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_1200_chat_fs_backend.py
+++ b/tests/test_1200_chat_fs_backend.py
@@ -2,25 +2,25 @@
 
 #1200 threads the agent's EnvironmentBackend INSTANCE to the chat axis so chat
 file ops run on the SAME backend as the OSRuntime path (and plan, which delegates
-tool exec to chat via _PlanStepHost). F1 is the FS seam: ChatSession gains an
+tool exec to chat via _PlanStepHost). F1 is the FS seam: Session gains an
 ``environment_backend`` param → its router Workspace runs IO on it. Additive —
 None falls back to the workspace's HostBackend default (unchanged behaviour); the
 exec seam (sandbox_backend string via sandbox_config) already flows agent-level,
 so this is safe-to-land regardless of the (pending) exec instance-vs-string call.
 
-No mocks: real ChatSession + real EnvironmentBackend instances.
+No mocks: real Session + real EnvironmentBackend instances.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.environment.host_backend import HostBackend
 
 
-def _session(tmp_path: Path, *, environment_backend=None, sandbox_backend=None) -> ChatSession:
-    return ChatSession(
+def _session(tmp_path: Path, *, environment_backend=None, sandbox_backend=None) -> Session:
+    return Session(
         agent_name="b",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_1289_frontend_container_chat.py
+++ b/tests/test_1289_frontend_container_chat.py
@@ -1,14 +1,14 @@
 """Tier 2: per-frontend container-chat activation (#1289).
 
-#1200 wired ChatSession's two seams (FS Workspace + exec OpContext) to a single
+#1200 wired Session's two seams (FS Workspace + exec OpContext) to a single
 injected backend (verified in test_1200_*). #1289 ACTIVATES that at the CLI
 frontends: a shared `reyn.interfaces.cli.env_backend` helper registers the `--env-backend`
 args + builds the EnvironmentBackend; `reyn chat` / `reyn dogfood` (like `reyn
-run`) build it and pass the SAME instance to BOTH ChatSession seams.
+run`) build it and pass the SAME instance to BOTH Session seams.
 
 These pin the shared-helper surface + the frontend-activation contract (the same
 instance reaches both seams = the #1200 single-shared-sandbox review-gate that any
-frontend must uphold). No mocks: a real argparse parser + real ChatSession +
+frontend must uphold). No mocks: a real argparse parser + real Session +
 a real backend instance.
 """
 from __future__ import annotations
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.environment.host_backend import HostBackend
 from reyn.interfaces.cli.env_backend import build_environment_backend, register_env_backend_args
@@ -56,7 +56,7 @@ def test_frontend_contract_same_instance_reaches_both_seams(tmp_path: Path) -> N
     object. This is the #1200 single-shared-sandbox invariant the activation must
     uphold (a frontend wiring different instances = reject)."""
     one = HostBackend()  # stands in for a built DockerEnvironmentBackend
-    session = ChatSession(
+    session = Session(
         agent_name="b",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_a2a_bus_stamping_268_phase2.py
+++ b/tests/test_a2a_bus_stamping_268_phase2.py
@@ -38,7 +38,7 @@ import pytest
 
 pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
 
-from reyn.chat.session import ChatSession  # noqa: E402
+from reyn.chat.session import Session  # noqa: E402
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 from reyn.user_intervention import (  # noqa: E402
@@ -136,10 +136,10 @@ def test_send_to_agent_impl_registers_a2a_channel_id_as_listener(
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -232,10 +232,10 @@ def test_send_to_agent_impl_skips_listener_when_override_has_no_channel_id(
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -291,10 +291,10 @@ def test_send_to_agent_impl_without_override_does_not_register_listener(
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",

--- a/tests/test_a2a_iv_kind_choices_267_gap4.py
+++ b/tests/test_a2a_iv_kind_choices_267_gap4.py
@@ -182,7 +182,7 @@ def test_webhook_payload_free_text_ask_user_has_empty_choices(monkeypatch) -> No
 
 class _FakeAgentRegistry:
     """Minimal stub — ``_handle_answer_injection`` only calls
-    ``get_or_load(name)``. Returns a captured ChatSession-shape stub.
+    ``get_or_load(name)``. Returns a captured Session-shape stub.
     """
 
     def __init__(self, session) -> None:
@@ -192,9 +192,9 @@ class _FakeAgentRegistry:
         return self._session
 
 
-class _FakeChatSession:
+class _FakeSession:
     """Captures ``answer_pending_intervention`` calls. issue #292 (α):
-    the iv future is owned by ChatSession; the router calls this method
+    the iv future is owned by Session; the router calls this method
     instead of ``RunRegistry.answer_intervention`` (= removed).
     """
 
@@ -210,9 +210,9 @@ class _FakeChatSession:
         return self.return_value
 
 
-def _run_answer_injection(*, params: dict, run_id: str) -> _FakeChatSession:
+def _run_answer_injection(*, params: dict, run_id: str) -> _FakeSession:
     """Drive ``_handle_answer_injection`` with a real RunRegistry and
-    fake agent registry, return the captured FakeChatSession.
+    fake agent registry, return the captured FakeSession.
     """
     from reyn.interfaces.web.routers.a2a import _handle_answer_injection
 
@@ -223,7 +223,7 @@ def _run_answer_injection(*, params: dict, run_id: str) -> _FakeChatSession:
     list(run_registry._runs.values())[0].run_id = run_id  # noqa: SLF001
     run_registry._runs = {run_id: list(run_registry._runs.values())[0]}  # noqa: SLF001
 
-    session = _FakeChatSession()
+    session = _FakeSession()
     agent_registry = _FakeAgentRegistry(session)
 
     asyncio.run(
@@ -241,7 +241,7 @@ def _run_answer_injection(*, params: dict, run_id: str) -> _FakeChatSession:
 def test_handle_answer_injection_extracts_top_level_choice_id() -> None:
     """Tier 2: ``params.choice_id`` (= top-level convenience) is extracted
     and passed into ``InterventionAnswer.choice_id`` for the
-    ChatSession-side delivery (issue #292 α).
+    Session-side delivery (issue #292 α).
     """
     session = _run_answer_injection(
         run_id="run-tlc",

--- a/tests/test_a2a_limit_iv_dispatch_1493.py
+++ b/tests/test_a2a_limit_iv_dispatch_1493.py
@@ -27,7 +27,7 @@ import asyncio
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import OnLimitConfig, SafetyConfig
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus
 from reyn.interfaces.web.run_registry import RunRegistry
@@ -84,7 +84,7 @@ async def test_a2a_limit_answer_injection_resolves_future() -> None:
 
     await bus.on_dispatch(iv)
 
-    # Inject answer (simulates ChatSession.answer_pending_intervention path).
+    # Inject answer (simulates Session.answer_pending_intervention path).
     answer = InterventionAnswer(text="yes", choice_id="yes")
     iv.future.set_result(answer)
 
@@ -131,7 +131,7 @@ def test_a2a_session_on_limit_threads_from_safety_config() -> None:
     """Tier 2: #1493 regression gate — the A2A session factory (deps.py) must
     pass config.safety unmodified so on_limit.mode is NOT forced to "unattended".
 
-    ChatSession(safety=SafetyConfig(on_limit=OnLimitConfig(mode="interactive")))
+    Session(safety=SafetyConfig(on_limit=OnLimitConfig(mode="interactive")))
     must expose session.on_limit.mode == "interactive". If deps.py re-introduces
     a `_dc.replace(config.safety, on_limit=OnLimitConfig(mode="unattended"))` force,
     A2A sessions would silently abort at every limit instead of dispatching iv to
@@ -140,10 +140,10 @@ def test_a2a_session_on_limit_threads_from_safety_config() -> None:
 
     Scope note: the full web-layer _session_factory closure (deps._get_registry)
     is too heavy for isolation testing (requires AgentRegistry + ModelResolver +
-    config-from-disk). This test covers the closest feasible seam: ChatSession
+    config-from-disk). This test covers the closest feasible seam: Session
     constructor threads the provided SafetyConfig.on_limit without override.
     The deps.py seam is inspection-trivial (one `safety=config.safety` kwarg).
     """
     safety = SafetyConfig(on_limit=OnLimitConfig(mode="interactive"))
-    session = ChatSession(agent_name="a2a-regression-test", safety=safety)
+    session = Session(agent_name="a2a-regression-test", safety=safety)
     assert session.on_limit.mode == "interactive"

--- a/tests/test_a2a_restart_resume_292.py
+++ b/tests/test_a2a_restart_resume_292.py
@@ -1,6 +1,6 @@
 """Tier 2: A2A iv restart-resume end-to-end (= structural pin for #292 α deliverable).
 
-Pre-#292 (= pre-PR #300): A2A async-mode ivs bypassed ChatSession's
+Pre-#292 (= pre-PR #300): A2A async-mode ivs bypassed Session's
 iv machinery (= ``InterventionHandler.dispatch`` was replaced, not
 decorated, by the chain override). The iv lived only in the A2A bus
 + ``RunEntry.pending_intervention``. On process restart the bus
@@ -17,17 +17,17 @@ answers:
 
   Phase 1 (pre-crash):
     - Skill emits iv via the chain-override decorated path
-    - Iv lands in ChatSession's outstanding_interventions
+    - Iv lands in Session's outstanding_interventions
     - AgentSnapshot persists the iv
     - "Crash" = drop the session reference
 
   Phase 2 (restart):
-    - Fresh ChatSession loads from the same snapshot path
+    - Fresh Session loads from the same snapshot path
     - ``restore_state`` re-enqueues the iv with a fresh future
 
   Phase 3 (peer answer):
     - Simulate the A2A POST answer path via
-      ``ChatSession.answer_pending_intervention(run_id, answer)``
+      ``Session.answer_pending_intervention(run_id, answer)``
     - Restore watcher fires → R-D12 persists answer to
       ``buffered_intervention_answers`` (= survives second crash)
 
@@ -53,7 +53,7 @@ import pytest
 from reyn.chat.session import (
     DEFAULT_CHAT_CHANNEL_ID,
     ChatInterventionBus,
-    ChatSession,
+    Session,
 )
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
@@ -67,9 +67,9 @@ from reyn.user_intervention import (
 # ── helpers ────────────────────────────────────────────────────────────
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "demo") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path``."""
-    session = ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "demo") -> Session:
+    """Build a Session redirected to ``tmp_path``."""
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -128,7 +128,7 @@ def test_a2a_restart_resume_round_trip_ask_user(tmp_path: Path) -> None:
     )
 
     async def _drive() -> None:
-        # ── Phase 2: restart — fresh ChatSession + restore_state ────
+        # ── Phase 2: restart — fresh Session + restore_state ────
         session = _make_session(tmp_path, agent_name=agent_name)
         session.restore_state(snap)
         # Let the restored intervention task settle.
@@ -333,7 +333,7 @@ def test_handle_answer_injection_routes_through_chat_session(
 ) -> None:
     """Tier 2: the A2A router's ``_handle_answer_injection`` looks up
     the agent via RunEntry.agent_name and calls
-    ``ChatSession.answer_pending_intervention``. Pin that the wiring
+    ``Session.answer_pending_intervention``. Pin that the wiring
     survives — a refactor that drops the registry lookup or reverts
     to ``run_registry.answer_intervention`` (removed in #292) fails
     this test.
@@ -348,7 +348,7 @@ def test_handle_answer_injection_routes_through_chat_session(
     src = inspect.getsource(a2a_router._handle_answer_injection)
     assert "answer_pending_intervention" in src, (
         "_handle_answer_injection must call "
-        "ChatSession.answer_pending_intervention (issue #292 α path)"
+        "Session.answer_pending_intervention (issue #292 α path)"
     )
     assert "get_or_load" in src, (
         "_handle_answer_injection must look up the owning agent via "

--- a/tests/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/test_a2a_router_cap_wrapup_1538.py
@@ -2,20 +2,20 @@
 
 Before #1538, A2AHandler._emit_router_cap_exhausted_user was a standalone
 canned-only implementation: it emitted a static _ROUTER_RETRY_EXHAUSTED_MSG
-without attempting the LLM force-close wrap-up that ChatSession site C (#1496)
+without attempting the LLM force-close wrap-up that Session site C (#1496)
 produces. The tui-coder trace confirmed that router_cap fires exclusively on
 the a2a path (no-reset accumulation) — site C was dead code.
 
 After #1538, A2AHandler receives `emit_router_cap_exhausted_fn` injected from
-ChatSession at construction. Both SkillPlanGlue and A2AHandler paths call the
-single ChatSession._emit_router_cap_exhausted_user — zero drift by construction.
+Session at construction. Both SkillPlanGlue and A2AHandler paths call the
+single Session._emit_router_cap_exhausted_user — zero drift by construction.
 
 Invariants pinned:
 
 1. (wiring gate) A2AHandler._emit_router_cap_exhausted_user delegates to the
    injected callback with (exc, chain_id=...). The old canned path is removed.
 2. (LLM wrap-up reachable) When a scripted LLM returns wrap-up content,
-   ChatSession._emit_router_cap_exhausted_user emits an outbox message with
+   Session._emit_router_cap_exhausted_user emits an outbox message with
    meta["limit_stopped"] is True — proving the dead code is now reachable and
    the user receives a contextual summary instead of a canned string.
 3. (end-to-end a2a path) Driving through handle_agent_response with a
@@ -23,7 +23,7 @@ Invariants pinned:
    live proof that the a2a accumulation path (no-reset) reaches the
    wrap-up, not just compositional reasoning (#1538 definitive closure).
 
-No mocks — real A2AHandler + real ChatSession + real scripted LLM callable.
+No mocks — real A2AHandler + real Session + real scripted LLM callable.
 """
 from __future__ import annotations
 
@@ -34,7 +34,7 @@ import pytest
 
 from reyn.chat.services.a2a_handler import A2AHandler
 from reyn.chat.services.chain_manager import ChainManager
-from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.chat.session import RouterCapExceeded, Session
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -81,7 +81,7 @@ class _ScriptedWrapupLLM:
     """Real scripted LLM callable that returns a fixed wrap-up text on call.
 
     Used to inject a successful LLM wrap-up response via the _llm_caller
-    test seam on ChatSession._emit_router_cap_exhausted_user.
+    test seam on Session._emit_router_cap_exhausted_user.
     """
 
     def __init__(self, wrapup_text: str) -> None:
@@ -169,7 +169,7 @@ async def test_a2a_emit_router_cap_delegates_to_injected_fn() -> None:
 
 @pytest.mark.asyncio
 async def test_a2a_router_cap_wrapup_produces_limit_stopped_meta() -> None:
-    """Tier 2: ChatSession._emit_router_cap_exhausted_user (the fn A2AHandler
+    """Tier 2: Session._emit_router_cap_exhausted_user (the fn A2AHandler
     delegates to) emits an outbox message with meta["limit_stopped"] is True
     when the scripted LLM returns wrap-up content.
 
@@ -180,7 +180,7 @@ async def test_a2a_router_cap_wrapup_produces_limit_stopped_meta() -> None:
     Uses the _llm_caller test seam to inject a scripted LLM without touching
     the real LiteLLM stack.
     """
-    session = ChatSession(agent_name="a2a-wrapup-test")
+    session = Session(agent_name="a2a-wrapup-test")
     scripted = _ScriptedWrapupLLM("Turn ended at limit — here is a summary.")
     exc = RouterCapExceeded(count=3, cap=3, last_reason="a2a chain")
 
@@ -228,7 +228,7 @@ async def test_a2a_handle_agent_response_cap_hit_delivers_wrapup_e2e(
         loop=LoopConfig(max_router_calls_per_turn=1),
         on_limit=OnLimitConfig(mode="unattended"),
     )
-    session = ChatSession(agent_name="a2a-e2e-test", safety=safety)
+    session = Session(agent_name="a2a-e2e-test", safety=safety)
 
     # Scripted LLM: call 0 = router loop text reply; call 1 = wrap-up text.
     class _SequencedLLM:

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -54,7 +54,7 @@ class _Msg:
 
 
 class _Session:
-    """Stand-in ChatSession with the attributes the escalation path reads."""
+    """Stand-in Session with the attributes the escalation path reads."""
 
     def __init__(self, *, running_skills: dict | None = None, history: list | None = None):
         self.running_skills = running_skills or {}

--- a/tests/test_action_retrieval_config.py
+++ b/tests/test_action_retrieval_config.py
@@ -39,7 +39,7 @@ def test_default_action_retrieval_config_is_on() -> None:
     FP-0034 Phase 6 removed hide_legacy_tools (wrapper-only is the sole path).
     FP-0043 Phase 4 flipped embedding_class default from None to "local-mini"
     so semantic action search is on the moment ``reyn[local-embed]`` extras
-    are installed — graceful-degrade kicks in at ChatSession construction
+    are installed — graceful-degrade kicks in at Session construction
     when the extras are absent.
     """
     cfg = ActionRetrievalConfig()

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -1,7 +1,7 @@
 """Tier 2: FP-0034 PR-3b-iii config-to-router_loop wiring.
 
 Verifies that ``ActionRetrievalConfig.universal_wrappers_enabled``
-flows from reyn.yaml → ChatSession → RouterHostAdapter →
+flows from reyn.yaml → Session → RouterHostAdapter →
 RouterLoopHost.get_universal_wrappers_enabled() and reaches
 build_tools() with the correct value.
 
@@ -121,11 +121,11 @@ def test_build_tools_on_when_flag_on() -> None:
     assert names[-3:] == ["list_actions", "describe_action", "invoke_action"]
 
 
-# ── 3. ChatSession constructor accepts action_retrieval_config ───────────
+# ── 3. Session constructor accepts action_retrieval_config ───────────
 
 
 def test_chat_session_accepts_action_retrieval_config() -> None:
-    """Tier 2: ChatSession constructor signature includes
+    """Tier 2: Session constructor signature includes
     action_retrieval_config parameter (= PR-3b-iii integration point).
 
     The constructor accepts the config; downstream wiring is verified
@@ -133,9 +133,9 @@ def test_chat_session_accepts_action_retrieval_config() -> None:
     """
     import inspect
 
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
-    sig = inspect.signature(ChatSession.__init__)
+    sig = inspect.signature(Session.__init__)
     assert "action_retrieval_config" in sig.parameters
     # Default must be None so existing callers don't break
     default = sig.parameters["action_retrieval_config"].default

--- a/tests/test_agent_construction_via_factory_997.py
+++ b/tests/test_agent_construction_via_factory_997.py
@@ -17,7 +17,7 @@ already-wired parent context (NOT a fresh ReynConfig), so ``from_config`` does
 not apply — they forward the bundle they were given:
   - ``skill/sub_skill_runner.py``: a sub-skill inherits the parent OSRuntime's
     resolver + permission_resolver.
-  - ``chat/session.py``: ChatSession's agent-spawn forwards the session's own
+  - ``chat/session.py``: Session's agent-spawn forwards the session's own
     ``self._perm`` / ``self._resolver`` / ``self._mcp_servers``, all wired at
     session construction.
 """

--- a/tests/test_attach_request_forwarded.py
+++ b/tests/test_attach_request_forwarded.py
@@ -34,7 +34,7 @@ class _FakeInterventions:
 
 
 class _FakeSession:
-    """Minimal stand-in for ChatSession that AgentRegistry can attach.
+    """Minimal stand-in for Session that AgentRegistry can attach.
 
     Only exposes the attributes the registry's attach() + _forwarder()
     paths read (= .outbox, .is_attached, .run, ._interventions). The

--- a/tests/test_auto_resume_handler_invariants.py
+++ b/tests/test_auto_resume_handler_invariants.py
@@ -6,7 +6,7 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
 - WAL observation via ``StateLog.iter_from(0)`` (public read accessor).
 - Each test docstring's first line starts with ``Tier 2: ...``.
 
-Reference: FP-0019 Wave 3 (extracted from ChatSession._auto_resume_active_skills).
+Reference: FP-0019 Wave 3 (extracted from Session._auto_resume_active_skills).
 """
 from __future__ import annotations
 

--- a/tests/test_await_quiescent.py
+++ b/tests/test_await_quiescent.py
@@ -1,6 +1,6 @@
-"""Tier 2: ChatSession.await_quiescent — the global-rewind quiescence primitive.
+"""Tier 2: Session.await_quiescent — the global-rewind quiescence primitive.
 
-ADR-0038 Stage 1c part-1. Real `ChatSession` + `StateLog` + real asyncio tasks
+ADR-0038 Stage 1c part-1. Real `Session` + `StateLog` + real asyncio tasks
 (no mocks). `await_quiescent()` must return only once no turn / skill / plan is
 in flight, and — the correctness-critical invariant — **no WAL append lands after
 it returns** (a straggler past the future rewind reset-record would contaminate
@@ -13,13 +13,13 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 
-def _session(tmp_path: Path, log: StateLog, *, agent: str = "alpha") -> ChatSession:
-    session = ChatSession(
+def _session(tmp_path: Path, log: StateLog, *, agent: str = "alpha") -> Session:
+    session = Session(
         agent_name=agent, state_log=log, snapshot_path=tmp_path / "snap.json",
     )
     session.register_intervention_listener("test")

--- a/tests/test_chain_peer_discarded_notify.py
+++ b/tests/test_chain_peer_discarded_notify.py
@@ -7,7 +7,7 @@ skill_run is discarded by the user mid-flight. R-D14 plumbs an
 immediate notification so the waiter resolves within milliseconds.
 
 Layers exercised here:
-  - ``ChatSession._on_chain_peer_discarded`` handler: pops the chain,
+  - ``Session._on_chain_peer_discarded`` handler: pops the chain,
     emits ``chain_peer_discarded`` audit event, sends synthesised
     upstream agent_response (Tier 2)
   - ``AgentRegistry.notify_chain_discarded``: scans every other
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 # ---------------------------------------------------------------------------
@@ -35,8 +35,8 @@ from reyn.core.events.state_log import StateLog
 
 def _make_registry_with_two_agents(
     tmp_path: Path,
-) -> tuple[AgentRegistry, ChatSession, ChatSession, StateLog]:
-    """Build a registry holding two real ChatSessions named A and B.
+) -> tuple[AgentRegistry, Session, Session, StateLog]:
+    """Build a registry holding two real Sessions named A and B.
 
     Both sessions share the same StateLog (single-process invariant).
     The registry's ``_agents`` dict is populated by calling
@@ -45,12 +45,12 @@ def _make_registry_with_two_agents(
     """
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         # Each session gets its own snapshot path under the agent's
         # state dir so they don't collide.
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             state_log=state_log,
             snapshot_path=agent_dir / "state" / "snapshot.json",
@@ -69,13 +69,13 @@ def _make_registry_with_two_agents(
 
     sess_a = registry.get_or_load("A")
     sess_b = registry.get_or_load("B")
-    # Wire the back-reference so ChatSession can call into registry.
+    # Wire the back-reference so Session can call into registry.
     sess_a._registry = registry
     sess_b._registry = registry
     return registry, sess_a, sess_b, state_log
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_chat_bus_stamping_268_continued.py
+++ b/tests/test_chat_bus_stamping_268_continued.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from reyn.chat.session import (
     DEFAULT_CHAT_CHANNEL_ID,
     ChatInterventionBus,
-    ChatSession,
+    Session,
 )
 from reyn.user_intervention import (
     InterventionAnswer,
@@ -58,7 +58,7 @@ def test_chat_bus_without_channel_id_does_not_stamp(tmp_path: Path) -> None:
     construct without channel_id; they need iv to dispatch normally
     against their "test" listener registration).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("test")
     bus = ChatInterventionBus(session, run_id="r1", skill_name="demo")
 
@@ -86,7 +86,7 @@ def test_chat_bus_with_channel_id_stamps_when_iv_origin_is_none(tmp_path: Path) 
     stamps ``iv.origin_channel_id`` to the configured value when the
     iv came in without one (= the common case for skill-emitted ivs).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("tui")
     bus = ChatInterventionBus(
         session, run_id="r1", skill_name="demo", channel_id="tui",
@@ -110,7 +110,7 @@ def test_chat_bus_with_channel_id_respects_preexisting_origin(tmp_path: Path) ->
     set (= e.g. upstream delegation), the bus does NOT overwrite.
     Symmetric with the A2AInterventionBus rule (PR #281).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("upstream:hop")
     bus = ChatInterventionBus(
         session, run_id="r1", skill_name="demo", channel_id="tui",
@@ -140,7 +140,7 @@ def test_chat_bus_channel_id_property_returns_configured_value() -> None:
     """Tier 2: ``ChatInterventionBus.channel_id`` returns the value
     passed at construction, or None when unset.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus_with = ChatInterventionBus(
         session, run_id=None, skill_name=None, channel_id="tui",
     )
@@ -246,7 +246,7 @@ def test_end_to_end_stamped_iv_with_matching_listener_dispatches(tmp_path: Path)
     DEFAULT_CHAT_CHANNEL_ID + ChatTUIApp.on_mount + handle_intervention
     Branch 3 all agree).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     bus = ChatInterventionBus(
         session, run_id="r1", skill_name="demo",
@@ -285,7 +285,7 @@ def test_end_to_end_stamped_iv_without_listener_stalls(tmp_path: Path) -> None:
     moved there from handle_intervention so bus.deliver also benefits
     — issue #268 Phase 2 continuation).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     # Register a NON-tui listener — passes Phase 1 guard but doesn't
     # match the bus's channel_id stamp.
     session.register_intervention_listener("other")
@@ -331,7 +331,7 @@ def test_chat_bus_skips_stamping_when_chain_override_active(tmp_path: Path) -> N
     override is registered for the chain and skips its stamp if so,
     leaving the slot clean for the observer.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("test")
 
     # Simulate A2A-style override observer for chain "chain-A2A".
@@ -381,7 +381,7 @@ def test_chat_bus_stamps_when_no_chain_override_active(tmp_path: Path) -> None:
     TUI-only path), stamping engages normally. Differentiates against
     the override-active branch.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("tui")
     bus = ChatInterventionBus(
         session, run_id="run-TUI", skill_name="demo",
@@ -413,7 +413,7 @@ def test_dispatch_intervention_stall_check_fires_from_bus_path(tmp_path: Path) -
     with a stamped iv whose listener is absent puts the iv in the
     stalled queue + emits a ``user_channel_stalled`` route event.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("other")
 
     routed_events: list[dict] = []

--- a/tests/test_chat_compactor_postprocessor.py
+++ b/tests/test_chat_compactor_postprocessor.py
@@ -6,13 +6,13 @@ PR-N3: `compute_covers_through_seq` moved from the retired
 changed: it now takes ``new_turn_seqs: list`` directly instead of
 an ``artifact`` dict wrapper.
 
-Getting this value wrong corrupts ChatSession.history — a too-low
+Getting this value wrong corrupts Session.history — a too-low
 value re-includes already-summarized turns (duplication); a too-high value
 skips turns that have not been folded into a summary (loss).
 
 Contract:
   - max from a normal list → returns the largest seq
-  - empty / missing list → returns 0 (ChatSession falls back gracefully)
+  - empty / missing list → returns 0 (Session falls back gracefully)
   - single-entry list → returns that entry's seq
   - non-monotonic order → still returns the maximum
 """

--- a/tests/test_chat_exclude_tools_187.py
+++ b/tests/test_chat_exclude_tools_187.py
@@ -8,7 +8,7 @@ agent solves from the issue + repo only.
 Mechanism: RouterLoop already filters its LLM-visible catalog by `exclude_tools`
 (router_loop.py:1791-1796); the sub-loops use `exclude_tools={"plan"}`
 (planner.py:1136). #187 exposes this via `reyn chat --exclude-tools <names>`,
-threaded ChatSession → the MAIN agent loop (session.py).
+threaded Session → the MAIN agent loop (session.py).
 
 The load-bearing constraint (lead-coder): the web-exclusion must be the real
 catalog-filter behavior, not a source-string check. This file pins:

--- a/tests/test_chat_message_e_full_schema.py
+++ b/tests/test_chat_message_e_full_schema.py
@@ -218,15 +218,15 @@ def test_chat_message_round_trips_via_asdict_and_constructor() -> None:
 
 
 def test_load_history_migrates_legacy_lines(tmp_path: Path) -> None:
-    """Tier 2: ChatSession.load_history rewrites pre-#383 entries on read
+    """Tier 2: Session.load_history rewrites pre-#383 entries on read
     (= the on-disk file stays in the old shape until the next append, but
     the in-memory ``self.history`` carries the migrated shape).
     """
     # Build a minimal Session-like object that exercises load_history's
-    # file-reading code path without booting the full ChatSession.
-    from reyn.chat.session import ChatSession
+    # file-reading code path without booting the full Session.
+    from reyn.chat.session import Session
 
-    session = ChatSession.__new__(ChatSession)  # bypass __init__
+    session = Session.__new__(Session)  # bypass __init__
     session.history_path = tmp_path / "history.jsonl"
     session.history = []
     session._next_seq = 1  # touched by post-load init; safe default

--- a/tests/test_chat_router_empty_stop_directive_wired.py
+++ b/tests/test_chat_router_empty_stop_directive_wired.py
@@ -1,9 +1,9 @@
-"""Tier 2: ChatSession wires the empty-stop retry into the chat router's
+"""Tier 2: Session wires the empty-stop retry into the chat router's
 RouterLoop — now the SHARED uniform ``"resume"`` directive, always-on (#187).
 
 Pinned invariants:
 
-- ``ChatSession._handle_user_message`` constructs ``RouterLoop`` with
+- ``Session._handle_user_message`` constructs ``RouterLoop`` with
   ``empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE`` (the single shared
   "resume" directive — NOT a chat-specific string) AND
   ``empty_stop_retry_auto=True`` (always-on; the ``REYN_EMPTY_STOP_RETRY`` env
@@ -19,7 +19,7 @@ tool-call. All sites (chat / plan-step / agent op-loop) now use the single
 content-neutral ``EMPTY_STOP_RETRY_DIRECTIVE`` = "resume". The cross-site
 uniform-wiring invariant is pinned in
 ``test_empty_stop_retry_uniform_187``; this file pins the chat site's wiring
-behaviourally (driving the real ChatSession construction).
+behaviourally (driving the real Session construction).
 """
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ import pytest
 
 from reyn.chat import router_loop as rl
 from reyn.chat.router_loop import EMPTY_STOP_RETRY_DIRECTIVE
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 
@@ -59,19 +59,19 @@ class _ScriptedLLM:
         return result
 
 
-def _make_session(tmp_path: Path) -> ChatSession:
-    return ChatSession(agent_name="test_agent_b44")
+def _make_session(tmp_path: Path) -> Session:
+    return Session(agent_name="test_agent_b44")
 
 
 # ---------------------------------------------------------------------------
-# Wiring pin — ChatSession constructs RouterLoop with the shared directive
+# Wiring pin — Session constructs RouterLoop with the shared directive
 # ---------------------------------------------------------------------------
 
 
 class _CapturingRouterLoop(rl.RouterLoop):
     """Real subclass that records the kwargs every RouterLoop construction
     receives. Used in place of the production RouterLoop via
-    ``monkeypatch.setattr`` so the test observes ChatSession's construction
+    ``monkeypatch.setattr`` so the test observes Session's construction
     call without mocking the type contract."""
 
     last_kwargs: dict[str, Any] = {}
@@ -83,7 +83,7 @@ class _CapturingRouterLoop(rl.RouterLoop):
 
 @pytest.mark.asyncio
 async def test_chat_session_passes_shared_resume_directive_always_on(monkeypatch, tmp_path):
-    """Tier 2c: ``ChatSession._handle_user_message`` wires the SHARED
+    """Tier 2c: ``Session._handle_user_message`` wires the SHARED
     ``EMPTY_STOP_RETRY_DIRECTIVE`` ("resume") + ``empty_stop_retry_auto=True``
     to ``RouterLoop`` (#187 uniform always-on).
 
@@ -105,12 +105,12 @@ async def test_chat_session_passes_shared_resume_directive_always_on(monkeypatch
 
     captured = _CapturingRouterLoop.last_kwargs
     assert captured.get("empty_stop_retry_directive") == EMPTY_STOP_RETRY_DIRECTIVE, (
-        "ChatSession must pass the shared EMPTY_STOP_RETRY_DIRECTIVE, not an "
+        "Session must pass the shared EMPTY_STOP_RETRY_DIRECTIVE, not an "
         "inlined or chat-specific string. Got: "
         + repr(captured.get("empty_stop_retry_directive"))
     )
     assert captured.get("empty_stop_retry_auto") is True, (
-        "ChatSession must pass empty_stop_retry_auto=True (#187 always-on; the "
+        "Session must pass empty_stop_retry_auto=True (#187 always-on; the "
         "REYN_EMPTY_STOP_RETRY env opt-in is retired). Got kwargs: "
         + str(sorted(captured))
     )

--- a/tests/test_chat_router_i18n.py
+++ b/tests/test_chat_router_i18n.py
@@ -11,7 +11,7 @@ G10: when an invoke_skill tool call fails (tool_failed event), the router must
     emit a deterministic i18n message in output_language instead of letting the
     LLM generate an English fallback reply (B2-M2 fix).
 
-Policy: no MagicMock / AsyncMock on collaborators. Real ChatSession and
+Policy: no MagicMock / AsyncMock on collaborators. Real Session and
 build_system_prompt instances. RouterLoop.run() is patched only where strictly
 necessary to avoid network calls (Tier 3 LLM-replay tests are separate).
 """
@@ -24,7 +24,7 @@ from pathlib import Path
 from reyn.chat.router_system_prompt import build_system_prompt
 from reyn.chat.session import (
     _ROUTER_RETRY_EXHAUSTED_MSG,
-    ChatSession,
+    Session,
 )
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -39,15 +39,15 @@ def _make_session(
     *,
     cap: int = 3,
     output_language: str | None = "ja",
-) -> ChatSession:
-    """Minimal ChatSession with a real BudgetTracker and configurable language.
+) -> Session:
+    """Minimal Session with a real BudgetTracker and configurable language.
 
     output_language=None tests the unset-user behavior (= no language
     directive in router prompt; fallback messages use English).
     """
     from reyn.config import LoopConfig, SafetyConfig
     safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=cap))
-    return ChatSession(
+    return Session(
         agent_name="test_agent",
         output_language=output_language,
         budget_tracker=BudgetTracker(CostConfig()),
@@ -55,7 +55,7 @@ def _make_session(
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     msgs = []
     while not session.outbox.empty():
         msgs.append(session.outbox.get_nowait())
@@ -96,7 +96,7 @@ def test_retry_exhausted_fallback_is_japanese_when_output_language_ja(
 
     # Pre-spend the budget and suppress the reset so the very first
     # _run_router_loop attempt inside _handle_user_message is rejected.
-    monkeypatch.setattr(ChatSession, "_reset_router_turn_counter", lambda self: None)
+    monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
     session.router_invocations_this_turn = 3
     session._router_last_reason = "out_of_scope"
 
@@ -125,7 +125,7 @@ def test_retry_exhausted_fallback_is_english_when_output_language_en(
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language="en")
 
-    monkeypatch.setattr(ChatSession, "_reset_router_turn_counter", lambda self: None)
+    monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
     session.router_invocations_this_turn = 3
     session._router_last_reason = "test_reason"
 
@@ -150,7 +150,7 @@ def test_retry_exhausted_fallback_defaults_to_english_for_unsupported_language(
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language="fr")
 
-    monkeypatch.setattr(ChatSession, "_reset_router_turn_counter", lambda self: None)
+    monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
     session.router_invocations_this_turn = 3
     session._router_last_reason = ""
 
@@ -257,7 +257,7 @@ def test_system_prompt_default_output_language_is_none():
 def test_router_loop_passes_output_language_to_system_prompt(tmp_path, monkeypatch):
     """Tier 2: RouterLoop.run() passes the host's output_language to
     build_system_prompt so the LLM receives the correct language instruction
-    (F11 — integration path: ChatSession → RouterLoop → build_system_prompt).
+    (F11 — integration path: Session → RouterLoop → build_system_prompt).
 
     We stub call_llm_tools to avoid network I/O and capture the system prompt
     that RouterLoop would send.

--- a/tests/test_concurrent_multiagent_rewind_1580.py
+++ b/tests/test_concurrent_multiagent_rewind_1580.py
@@ -12,7 +12,7 @@ global-seq state — i.e. the cut is global, not per-agent. A per-agent (non-glo
 rewind would leave the other agent's post-cut turns live and the workspace
 inconsistent → this test would fail.
 
-Real AgentRegistry + 2 real ChatSessions (shared state_log + workspace) + git; a
+Real AgentRegistry + 2 real Sessions (shared state_log + workspace) + git; a
 no-LLM ``_FakeTurnDriver`` drives the real ``_run_router_loop`` so genuine
 ``cut_generation`` fires (only the file write is simulated). No mocks.
 """
@@ -26,7 +26,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 
@@ -42,7 +42,7 @@ class _FakeTurnDriver:
     runtime inbox marker, so the real ``_run_router_loop`` runs and its genuine
     ``cut_generation`` fires. Only the write is simulated."""
 
-    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+    def __init__(self, session: Session, ws_root: Path, content: dict[str, str]) -> None:
         self._session = session
         self._ws = ws_root
         self._content = content
@@ -67,9 +67,9 @@ def _markers(snap: AgentSnapshot) -> list[str]:
 def _two_agent_registry(tmp_path: Path):
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile: AgentProfile) -> ChatSession:
+    def _factory(profile: AgentProfile) -> Session:
         snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
-        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+        return Session(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     for name in ("alpha", "beta"):

--- a/tests/test_durable_answer_buffer.py
+++ b/tests/test_durable_answer_buffer.py
@@ -2,7 +2,7 @@
 
 Background: when an intervention is answered post-restart but before
 the resuming skill consumes the answer, the answer is held in
-ChatSession's in-memory ``_buffered_intervention_answers`` dict. If a
+Session's in-memory ``_buffered_intervention_answers`` dict. If a
 SECOND crash happens in this narrow window, the in-memory buffer is
 lost — the user's answer evaporates and they have to answer again.
 
@@ -15,7 +15,7 @@ Invariants pinned:
   - WAL events ``intervention_answer_buffered`` / ``..._consumed``
     apply correctly to the snapshot.
   - SnapshotJournal records both events with the right shape.
-  - ChatSession.restore_state rehydrates the in-memory buffer from
+  - Session.restore_state rehydrates the in-memory buffer from
     the snapshot field.
 
 Reference: PR-durable-answer-buffer (R-D12) in the active plan.
@@ -27,7 +27,7 @@ import json
 from pathlib import Path
 
 from reyn.chat.services.snapshot_journal import SnapshotJournal
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 from reyn.user_intervention import InterventionAnswer
@@ -184,15 +184,15 @@ def test_journal_consume_is_idempotent(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# ChatSession.restore_state rehydrates the buffer
+# Session.restore_state rehydrates the buffer
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, agent_name: str = "alpha") -> ChatSession:
+def _make_session(tmp_path: Path, agent_name: str = "alpha") -> Session:
     """issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire.
     """
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",

--- a/tests/test_embedding_bench_manifest.py
+++ b/tests/test_embedding_bench_manifest.py
@@ -106,7 +106,7 @@ def test_precision_axis_fixtures_resolve_in_static_catalog() -> None:
     fresh-context (= router_state=None) catalog enumeration.
 
     This pins the "fresh-user precision" framing: bench measurement is over
-    the catalog a brand-new ChatSession sees before any dynamic skill /
+    the catalog a brand-new Session sees before any dynamic skill /
     sandbox-backed exec is wired. Fixtures that would require dynamic
     enumeration go into a future section with explicit router-state setup.
     """

--- a/tests/test_embedding_dl_progress_events.py
+++ b/tests/test_embedding_dl_progress_events.py
@@ -321,7 +321,7 @@ def test_get_provider_threads_event_sink_through_routing_wrapper(
     """Tier 2: ``get_provider("litellm", config, event_sink=…)`` plumbs the sink.
 
     The factory must hand the sink to the routing wrapper so production
-    callers (= ChatSession) only need to call ``get_provider`` once.
+    callers (= Session) only need to call ``get_provider`` once.
     """
     monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
     _FakeST.instances.clear()

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -162,7 +162,7 @@ def test_default_chat_layer_resolves_to_enumerate_all() -> None:
     dataclass (``ToolUseConfig``), the scheme resolver (``_resolve_tool_use_scheme``),
     and the scheme's public ``.name`` — NOT a running router or private state. The
     config value is what each frontend threads (chat_tool_use_scheme) through the
-    factory → ChatSession → RouterLoopDriver → RouterLoop(scheme_name=)."""
+    factory → Session → RouterLoopDriver → RouterLoop(scheme_name=)."""
     from reyn.chat.router_loop import _resolve_tool_use_scheme
     from reyn.config import _build_tool_use_config
 

--- a/tests/test_eval_benchmark_cli.py
+++ b/tests/test_eval_benchmark_cli.py
@@ -66,14 +66,14 @@ def _make_tasks_jsonl(tasks: list[dict]) -> str:
 def benchmark_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Set up a temporary benchmark workspace.
 
-    Returns a namespace with helpers; monkeypatches Session, load_dsl_skill,
+    Returns a namespace with helpers; monkeypatches InvocationContext, load_dsl_skill,
     resolve_skill_path so tests run without a live reyn.yaml or skill on disk.
     """
     monkeypatch.chdir(tmp_path)
 
-    # Stub Session
+    # Stub InvocationContext
     from reyn.config import ReynConfig, SafetyConfig
-    from reyn.interfaces.cli import session as session_mod
+    from reyn.interfaces.cli import invocation_context as invocation_mod
     from reyn.llm.model_resolver import ModelResolver
 
     class _StubSession:
@@ -93,7 +93,7 @@ def benchmark_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         def safety_for(self, args):
             return SafetyConfig()
 
-    monkeypatch.setattr(session_mod, "Session", _StubSession)
+    monkeypatch.setattr(invocation_mod, "InvocationContext", _StubSession)
 
     # Stub load_dsl_skill
     import reyn.core.compiler as compiler_mod

--- a/tests/test_eval_command_invariants.py
+++ b/tests/test_eval_command_invariants.py
@@ -105,7 +105,7 @@ def eval_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     Monkeypatches:
       - CWD → tmp_path   (so .reyn/ resolves under tmp_path)
-      - Session.from_args → minimal stub that avoids reading real reyn.yaml
+      - InvocationContext.from_args → minimal stub that avoids reading real reyn.yaml
       - load_dsl_skill    → returns a sentinel object (skill execution is
                             replaced via _run_case monkeypatch in each test)
     """
@@ -113,9 +113,9 @@ def eval_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.chdir(tmp_path)
 
-    # Stub Session so we don't need a live reyn.yaml.
+    # Stub InvocationContext so we don't need a live reyn.yaml.
     from reyn.config import ReynConfig, SafetyConfig
-    from reyn.interfaces.cli import session as session_mod
+    from reyn.interfaces.cli import invocation_context as invocation_mod
     from reyn.llm.model_resolver import ModelResolver
 
     class _StubSession:
@@ -138,7 +138,7 @@ def eval_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         def shell_allowed_for(self, args):
             return False
 
-    monkeypatch.setattr(session_mod, "Session", _StubSession)
+    monkeypatch.setattr(invocation_mod, "InvocationContext", _StubSession)
 
     # Stub load_dsl_skill so tests don't need a real skill on disk.
     import reyn.core.compiler as compiler_mod

--- a/tests/test_force_close_chat_activation_1092.py
+++ b/tests/test_force_close_chat_activation_1092.py
@@ -1,7 +1,7 @@
 """Tier 2: chat-axis turn_budget activation (#1092 PR-F1, ADDITIVE).
 
 F1 wires the chat axis to the SHARED turn_budget service (the C2 payoff): the
-ChatSession builds a TurnBudgetEngine off the RESOLVED model (#1172-safe) and
+Session builds a TurnBudgetEngine off the RESOLVED model (#1172-safe) and
 hands it to RouterHostAdapter, which exposes ``wrap_up_output_reserve`` — the
 ``output_reserve`` that RouterLoop._force_close_call will pass as ``max_tokens``
 to hard-cap the chat handoff's consolidation (the F2 by-construction floor).
@@ -13,13 +13,13 @@ proactive mid-turn force-close would truncate a live conversation; a phase, bein
 task execution, proactively wraps up — a deliberate per-axis architectural
 choice, not a missing trigger).
 
-No mocks: real engines, a real ModelResolver, a real ChatSession.
+No mocks: real engines, a real ModelResolver, a real Session.
 """
 from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.services.turn_budget import (
     DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS,
@@ -62,12 +62,12 @@ def test_adapter_does_not_expose_proactive_trigger() -> None:
 
 
 def test_chat_session_activates_turn_budget_via_resolved_model(tmp_path: Path) -> None:
-    """Tier 2: a real ChatSession builds the chat turn_budget engine off the
+    """Tier 2: a real Session builds the chat turn_budget engine off the
     RESOLVED model (#1172-safe — never the cosmetic class) and its router host
     exposes a non-None, asserted reserve. Exercises the session wiring (resolve
     self.model + build_default_turn_budget_engine + pass to the adapter), via the
     public ``session.router_host`` surface."""
-    session = ChatSession(
+    session = Session(
         agent_name="f1",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
@@ -100,7 +100,7 @@ def test_try_build_returns_engine_for_large_context_model() -> None:
 def test_chat_session_on_small_model_constructs_without_force_close(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """Tier 2: a ChatSession on a too-small-context model STILL CONSTRUCTS (no
+    """Tier 2: a Session on a too-small-context model STILL CONSTRUCTS (no
     __init__ raise) and exposes reserve=None — force-close is simply unavailable,
     chat falls back to the pre-force-close path. Regression guard: building the
     engine unconditionally would assert-fail here and break every small-model
@@ -108,7 +108,7 @@ def test_chat_session_on_small_model_constructs_without_force_close(
     monkeypatch.setattr(
         "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
     )
-    session = ChatSession(
+    session = Session(
         agent_name="f1-small",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_force_close_covers_slice_1092.py
+++ b/tests/test_force_close_covers_slice_1092.py
@@ -13,7 +13,7 @@ summaries (no ``consolidation`` field) fall through to the unchanged
 head/tail+bridge path → normal chat stays byte-identical (pinned below + by the
 unchanged test_session_router_history_slicing suite).
 
-No mocks: a real ChatSession with a synthetic T_max.
+No mocks: a real Session with a synthetic T_max.
 """
 from __future__ import annotations
 

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -221,7 +221,7 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
 
     from reyn.chat.profile import AgentProfile
     from reyn.chat.registry import AgentRegistry
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
     from reyn.interfaces.web.deps import get_registry
     from reyn.interfaces.web.server import app
@@ -229,11 +229,11 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -282,17 +282,17 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
     an InterventionAnswer to the agent's pending intervention and
     returns ``{"answered": True}``.
 
-    issue #292 (α): iv lives in ``ChatSession._interventions._active``,
+    issue #292 (α): iv lives in ``Session._interventions._active``,
     NOT in ``RunEntry.pending_intervention`` (removed). We seed the iv
     directly into the agent's intervention registry; the router looks
     up the agent via the RunEntry's ``agent_name`` and calls
-    ``ChatSession.answer_pending_intervention``.
+    ``Session.answer_pending_intervention``.
     """
     from fastapi.testclient import TestClient
 
     from reyn.chat.profile import AgentProfile
     from reyn.chat.registry import AgentRegistry
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
     from reyn.interfaces.web.deps import get_registry, get_run_registry
     from reyn.interfaces.web.server import app
@@ -301,11 +301,11 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -325,7 +325,7 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
     entry = run_registry.create(agent_name="demo", chain_id="chain-iv")
 
     # Seed the iv directly into the agent's outstanding intervention
-    # queue (= post-α: ChatSession owns iv state). Use the same loop
+    # queue (= post-α: Session owns iv state). Use the same loop
     # the TestClient will drive so the future is on the right loop.
     loop = asyncio.new_event_loop()
     try:
@@ -388,7 +388,7 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
 
     from reyn.chat.profile import AgentProfile
     from reyn.chat.registry import AgentRegistry
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
     from reyn.interfaces.web.deps import get_registry, get_run_registry
     from reyn.interfaces.web.server import app
@@ -396,11 +396,11 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -450,7 +450,7 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
 # ---------------------------------------------------------------------------
 
 # Test 8 (async_mode=true with real agent spawning a background task) requires
-# F1 (ChatSession.register_intervention_override), F2 (RunRegistry fully wired),
+# F1 (Session.register_intervention_override), F2 (RunRegistry fully wired),
 # and F3 (A2AInterventionBus) to be integrated so the background task can
 # complete without a real LLM. Deferred to F5 e2e integration test.
 

--- a/tests/test_fp0001_a2a_intervention_bus.py
+++ b/tests/test_fp0001_a2a_intervention_bus.py
@@ -3,15 +3,15 @@
 Pre-#292 this file pinned the bus as an iv owner: ``request(iv)``
 awaited ``iv.future`` and returned the answer; the iv was stored in
 ``RunEntry.pending_intervention``. The pre-α architecture is described
-in issue #292 body (= "A2A override completely bypasses ChatSession's
+in issue #292 body (= "A2A override completely bypasses Session's
 iv machinery"); see history of this file in git for the old test
 shape.
 
 Post-α the bus is a **side-effect observer**: ``on_dispatch(iv)`` is
-invoked by ``ChatSession._dispatch_intervention`` for chain-registered
+invoked by ``Session._dispatch_intervention`` for chain-registered
 overrides and runs A2A peer-facing notifications (RunRegistry status
 mirror, SSE history append, webhook POST) without taking iv
-ownership. The iv lives in ``ChatSession._interventions._active`` and
+ownership. The iv lives in ``Session._interventions._active`` and
 the future is awaited by ``InterventionHandler.dispatch`` like any
 other (= TUI) iv.
 
@@ -19,7 +19,7 @@ Pins (= α contract):
 
   1. ``A2AInterventionBus.on_dispatch(iv)`` exists; ``request`` /
      ``deliver`` are removed (= peer answers no longer flow through
-     the bus; they flow through ``ChatSession.answer_pending_intervention``).
+     the bus; they flow through ``Session.answer_pending_intervention``).
   2. ``on_dispatch`` mirrors ``status="input-required"`` on the RunEntry.
   3. ``on_dispatch`` does NOT write ``pending_intervention`` to
      RunEntry (= the field is dropped from RunEntry entirely).
@@ -89,7 +89,7 @@ def test_bus_channel_id_format_unchanged() -> None:
 def test_on_dispatch_mirrors_input_required_status() -> None:
     """Tier 2: ``on_dispatch`` flips RunEntry.status to ``"input-required"``
     so polling peers see the pending state. The iv itself stays in
-    ChatSession; this is a public-status mirror only.
+    Session; this is a public-status mirror only.
     """
     registry, run_id = _make_registry_with_run()
     bus = A2AInterventionBus(run_id=run_id, registry=registry)
@@ -105,7 +105,7 @@ def test_on_dispatch_mirrors_input_required_status() -> None:
 
 def test_on_dispatch_does_not_write_pending_intervention_to_run_entry() -> None:
     """Tier 2: α contract — the RunEntry has NO ``pending_intervention``
-    field. The iv lives in ChatSession's outstanding_interventions.
+    field. The iv lives in Session's outstanding_interventions.
     Verifies the dataclass shape change ships cleanly.
     """
     registry, run_id = _make_registry_with_run()

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -7,7 +7,7 @@ Pins the FP-0001 task lifecycle contracts:
   2. ``A2AInterventionBus.request`` publishes to the registry and awaits
      the Future that ``answer_intervention`` resolves — verifying the
      intervention routing contract without a live HTTP server.
-  3. ``ChatSession.register_intervention_override`` / ``unregister_intervention_override``
+  3. ``Session.register_intervention_override`` / ``unregister_intervention_override``
      — the chain-id-scoped override hook that wires an external bus into
      a skill's ask_user path.
 
@@ -19,15 +19,15 @@ yet present in the router — indicated by the absence of
 flags this for the F4 implementing agent to remove once the endpoints land.
 
 Approach: we exercise the JSON envelopes by driving RunRegistry and
-A2AInterventionBus directly, plus the ChatSession override hook with a
-scripted fake LLM callable (= real ChatSession, no MagicMock).  This
+A2AInterventionBus directly, plus the Session override hook with a
+scripted fake LLM callable (= real Session, no MagicMock).  This
 validates the component-level contracts that the router will rely on without
 requiring the async-mode router extensions to be present.
 
 Policy compliance (docs/deep-dives/contributing/testing.ja.md):
 - Tier 2c (multi-component integration, OS invariant).
 - No MagicMock / AsyncMock / patch of real collaborators.
-- Real RunRegistry, real A2AInterventionBus, real ChatSession instances.
+- Real RunRegistry, real A2AInterventionBus, real Session instances.
 - Observed via public API: RunEntry.status, RunEntry.question,
   RunEntry.result, RunEntry.to_public_dict(), answer_intervention return value.
 """
@@ -118,7 +118,7 @@ def test_run_registry_to_public_dict_excludes_internals():
     """Tier 2c: RunEntry.to_public_dict excludes asyncio.Task. issue
     #292 (α): ``pending_intervention`` / ``question`` were also
     excluded pre-α; α removes them entirely from RunEntry's data
-    shape (= they live in ChatSession).
+    shape (= they live in Session).
     """
     registry = _new_run_registry()
     entry = registry.create(agent_name="b", chain_id="c2")
@@ -135,7 +135,7 @@ def test_run_registry_to_public_dict_excludes_internals():
 
 # Tests for ``RunRegistry.answer_intervention`` removed: post-issue-#292,
 # the method is gone and peer-answer flows go through
-# ``ChatSession.answer_pending_intervention``. See
+# ``Session.answer_pending_intervention``. See
 # tests/test_fp0001_a2a_intervention_bus.py for the post-α coverage.
 
 
@@ -169,12 +169,12 @@ def test_run_registry_cancel_marks_cancelled():
 
 
 # ---------------------------------------------------------------------------
-# Part 3: ChatSession.register_intervention_override
+# Part 3: Session.register_intervention_override
 # ---------------------------------------------------------------------------
 
 
 def test_chat_session_intervention_override_is_used():
-    """Tier 2c: ChatSession.register_intervention_override / unregister pins
+    """Tier 2c: Session.register_intervention_override / unregister pins
     the chain-id-scoped override hook introduced by FP-0001.
 
     Verifies that when an override bus is registered for a chain_id,
@@ -184,7 +184,7 @@ def test_chat_session_intervention_override_is_used():
     """
     import tempfile
 
-    from reyn.chat.session import ChatSession, _new_chain_id
+    from reyn.chat.session import Session, _new_chain_id
     from reyn.core.events.state_log import StateLog
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
     from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
@@ -193,7 +193,7 @@ def test_chat_session_intervention_override_is_used():
         state_log = StateLog(tmp / "wal.jsonl")
         snapshot_path = tmp / "snap.json"
         bt = BudgetTracker(CostConfig())
-        session = ChatSession(
+        session = Session(
             agent_name="test-agent",
             agent_role="tester",
             output_language="en",
@@ -271,16 +271,16 @@ def _build_registry_for_test(tmp_path: Path):
     """
     from reyn.chat.profile import AgentProfile
     from reyn.chat.registry import AgentRegistry
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",

--- a/tests/test_fp0001_run_registry.py
+++ b/tests/test_fp0001_run_registry.py
@@ -158,7 +158,7 @@ async def test_attach_task_stores_task_reference() -> None:
 
 # ---------------------------------------------------------------------------
 # Tests 6-8: removed in issue #292 (α). RunRegistry.answer_intervention is
-# gone; iv resolution lives in ChatSession.answer_pending_intervention,
+# gone; iv resolution lives in Session.answer_pending_intervention,
 # tested in tests/test_fp0001_a2a_intervention_bus.py + the new
 # tests/test_a2a_iv_kind_choices_267_gap4.py answer-injection block.
 # ---------------------------------------------------------------------------
@@ -266,7 +266,7 @@ async def test_to_public_dict_returns_json_safe_fields() -> None:
     """Tier 1: to_public_dict() exposes run_id / agent_name / chain_id
     / status / result / error / timestamps. issue #292 (α):
     ``question`` and ``pending_intervention`` no longer exist on
-    RunEntry (= iv lives in ChatSession).
+    RunEntry (= iv lives in Session).
     """
     registry = _make_registry()
     entry = registry.create(agent_name="myagent", chain_id="chain-99", webhook_url="http://example.com")

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -16,7 +16,7 @@ Covers:
 
 Policy compliance (docs/deep-dives/contributing/testing.ja.md):
   - No unittest.mock / AsyncMock / patch usage for collaborators.
-  - Real ChatSession instances and a concrete _CaptureBus fake.
+  - Real Session instances and a concrete _CaptureBus fake.
   - Tier 2 OS invariant tests only.
 """
 from __future__ import annotations
@@ -28,7 +28,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.mcp.server import send_to_agent_impl
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -84,15 +84,15 @@ class _RecordingHandler:
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> ChatSession:
-    """Build a ChatSession with I/O redirected to tmp_path.
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    """Build a Session with I/O redirected to tmp_path.
 
     issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire — these
     tests exercise the chain-scoped override path and may dispatch to the
     fallback registry path when no override is set.
     """
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}_state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -111,11 +111,11 @@ def _build_registry(tmp_path: Path, agent_specs: list[tuple[str, str]]) -> Agent
     """Construct an AgentRegistry on tmp_path (mirrors test_mcp_server.py pattern)."""
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        session = ChatSession(
+        session = Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -413,7 +413,7 @@ def test_send_to_agent_impl_override_registered_and_cleaned_up(tmp_path, monkeyp
             meta={"chain_id": chain_id},
         ))
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle)
 
     async def go():
         return await send_to_agent_impl(
@@ -529,7 +529,7 @@ def test_concurrent_send_to_agent_impl_no_override_leak(tmp_path, monkeypatch):
             meta={"chain_id": chain_id},
         ))
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle)
 
     async def go():
         r1, r2 = await asyncio.gather(

--- a/tests/test_fp0036_live_runner.py
+++ b/tests/test_fp0036_live_runner.py
@@ -13,13 +13,13 @@ Covers:
   5. History isolation: chat history written by a prior scenario does not
      leak into the next scenario's LLM context. The runner wipes
      .reyn/agents/<name>/history.jsonl before each scenario so that
-     ChatSession.load_history() returns empty for scenario N.
+     Session.load_history() returns empty for scenario N.
 
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock.MagicMock / AsyncMock.  `patch` used only to replace
   `call_llm_tools` with a real async callable — same pattern as
   test_mcp_server.py.
-- Real AgentRegistry + ChatSession instances under tmp_path.
+- Real AgentRegistry + Session instances under tmp_path.
 - Each test docstring's first line declares its Tier.
 """
 from __future__ import annotations
@@ -32,7 +32,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.dev.dogfood.scenarios import Scenario
 from reyn.llm.llm import LLMToolCallResult
@@ -58,7 +58,7 @@ def _text_result(text: str) -> LLMToolCallResult:
 def _make_registry(tmp_path: Path, *, agent_name: str = "default") -> AgentRegistry:
     """Build a real AgentRegistry on tmp_path with a minimal session factory.
 
-    Session factory produces real ChatSession instances with I/O redirected
+    Session factory produces real Session instances with I/O redirected
     to tmp_path so global .reyn state is never touched.  No StateLog is
     wired (= no WAL) which matches the live_runner's own factory.
     """
@@ -67,11 +67,11 @@ def _make_registry(tmp_path: Path, *, agent_name: str = "default") -> AgentRegis
 
     _reg_cell: list = []
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        session = ChatSession(
+        session = Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -319,7 +319,7 @@ async def test_history_jsonl_wiped_before_scenario(tmp_path, monkeypatch):
 
     Regression guard for the 2026-05-17 dogfood runner gap: before this
     fix, `_wipe_scenario_state` cleaned events and action_usage but left
-    `.reyn/agents/<name>/history.jsonl` on disk. `ChatSession.load_history()`
+    `.reyn/agents/<name>/history.jsonl` on disk. `Session.load_history()`
     (called by the session factory) reads that file unconditionally, so
     scenario N inside a single `reyn dogfood run` saw scenarios 1..N-1's
     user/assistant turns in its `messages[]` — defeating "fresh per

--- a/tests/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/test_fp0041_prd2_outbox_interceptor.py
@@ -4,7 +4,7 @@ End-to-end reply path completion for the Slack chat-transport. PR-D
 landed inbound (= Slack → Reyn inbox). PR-D2 completes outbound:
 
   inbox payload reply_to (= ExternalRef from PR-D handler)
-    → ChatSession captures into self._last_reply_to
+    → Session captures into self._last_reply_to
     → agent reply via _put_outbox
     → reply_to defaults from _last_reply_to (when not explicit)
     → _outbox_interceptor invoked (= PR-D2 wiring)
@@ -41,13 +41,13 @@ from reyn.chat.external_routing import (
     make_outbox_interceptor,
 )
 from reyn.chat.outbox import OutboxMessage
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.chat.transport import ExternalRef, TuiRef
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",

--- a/tests/test_fp0043_phase4_default_switch.py
+++ b/tests/test_fp0043_phase4_default_switch.py
@@ -1,5 +1,5 @@
 """Tier 2: FP-0043 Phase 4 — default ``embedding_class`` flip to ``local-mini``
-+ ChatSession graceful-degrade probe when the ``local-embed`` extras
++ Session graceful-degrade probe when the ``local-embed`` extras
 aren't installed.
 
 What lands here:
@@ -96,7 +96,7 @@ def test_probe_st_class_when_extras_missing_returns_true(
     Simulates a fresh user who set ``embedding_class: local-mini`` (or
     inherited the Phase 4 default) but never ran
     ``pip install 'reyn[local-embed]'``. The probe must return True so
-    ChatSession skips embedding wiring entirely; the hidden-state hint
+    Session skips embedding wiring entirely; the hidden-state hint
     path on ``list_actions`` takes over the user-discovery surface.
     """
     monkeypatch.setattr(
@@ -204,9 +204,9 @@ def test_probe_st_prefix_substring_doesnt_trigger() -> None:
 
 
 def test_probe_is_referenced_in_session_init_source() -> None:
-    """Tier 2: the probe call appears in ChatSession.__init__'s gate.
+    """Tier 2: the probe call appears in Session.__init__'s gate.
 
-    We don't construct a full ChatSession here (= heavy deps). Instead
+    We don't construct a full Session here (= heavy deps). Instead
     we sanity-check that ``_embedding_class_needs_missing_extras`` is
     actually invoked from the gate by inspecting the module source.
     Catches a future accidental removal that would silently disable
@@ -217,5 +217,5 @@ def test_probe_is_referenced_in_session_init_source() -> None:
     import inspect
 
     import reyn.chat.session as session_mod
-    src = inspect.getsource(session_mod.ChatSession.__init__)
+    src = inspect.getsource(session_mod.Session.__init__)
     assert "_embedding_class_needs_missing_extras" in src

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -1,11 +1,11 @@
 """Tier 2: Agent routing logic for intervention requests (issue #254 Phase 4).
 
 Pins the 3-way routing decision the Agent makes in
-``ChatSession.handle_intervention(iv)``:
+``Session.handle_intervention(iv)``:
 
   1. ``self_answer`` (= ``try_self_answer`` hook returns non-None)
   2. ``parent_agent.delegate`` (= ``resolve_parent_agent`` hook returns
-     a ChatSession)
+     a Session)
   3. ``user_channel.deliver`` (= default, falls through to
      ``_dispatch_intervention``)
 
@@ -18,7 +18,7 @@ Each branch emits an ``intervention_routed`` event for observability;
 the Phase 4 sub-issue (= dispatched by tui-coder) will surface the
 event in the TUI events tab.
 
-No mocks. Real ChatSession + subclass overrides for the hook tests.
+No mocks. Real Session + subclass overrides for the hook tests.
 """
 from __future__ import annotations
 
@@ -28,31 +28,31 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import AgentRequestBus, ChatSession
+from reyn.chat.session import AgentRequestBus, Session
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 # ── 1. Hook methods exist with the canonical signatures ────────────────
 
 
 def test_try_self_answer_hook_exists() -> None:
-    """Tier 2: ChatSession exposes ``try_self_answer(iv) -> Answer|None``
+    """Tier 2: Session exposes ``try_self_answer(iv) -> Answer|None``
     as the self-answer routing hook.
     """
-    assert hasattr(ChatSession, "try_self_answer")
-    assert inspect.iscoroutinefunction(ChatSession.try_self_answer)
-    sig = inspect.signature(ChatSession.try_self_answer)
+    assert hasattr(Session, "try_self_answer")
+    assert inspect.iscoroutinefunction(Session.try_self_answer)
+    sig = inspect.signature(Session.try_self_answer)
     assert list(sig.parameters.keys()) == ["self", "iv"]
 
 
 def test_resolve_parent_agent_hook_exists() -> None:
-    """Tier 2: ChatSession exposes ``resolve_parent_agent(iv) -> ChatSession|None``
+    """Tier 2: Session exposes ``resolve_parent_agent(iv) -> Session|None``
     as the parent-delegate routing hook.
 
     Synchronous (not async) — chain-walk lookups don't need to await.
     """
-    assert hasattr(ChatSession, "resolve_parent_agent")
-    assert not inspect.iscoroutinefunction(ChatSession.resolve_parent_agent)
-    sig = inspect.signature(ChatSession.resolve_parent_agent)
+    assert hasattr(Session, "resolve_parent_agent")
+    assert not inspect.iscoroutinefunction(Session.resolve_parent_agent)
+    sig = inspect.signature(Session.resolve_parent_agent)
     assert list(sig.parameters.keys()) == ["self", "iv"]
 
 
@@ -60,7 +60,7 @@ def test_default_hooks_return_none() -> None:
     """Tier 2: default implementations return None — Phase 4 ships pure
     scaffold, no kind-specific policies enabled out-of-the-box.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
     async def _check_self_answer() -> InterventionAnswer | None:
@@ -82,7 +82,7 @@ def test_default_routing_fires_user_channel_branch(tmp_path: Path) -> None:
     to verify the branch was actually taken (= the answer's emptiness
     is observable only if dispatch was reached).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
     answer = asyncio.run(session.handle_intervention(iv))
@@ -96,7 +96,7 @@ def test_default_routing_emits_user_channel_event(tmp_path: Path) -> None:
     ``route="user_channel"`` so observers (= TUI events tab, debug
     traces, future routing-policy analysis) can see the decision.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
     asyncio.run(session.handle_intervention(iv))
@@ -116,7 +116,7 @@ def test_default_routing_emits_user_channel_event(tmp_path: Path) -> None:
 # ── 3. self_answer branch — fires when _try_self_answer returns answer ──
 
 
-class _SelfAnsweringSession(ChatSession):
+class _SelfAnsweringSession(Session):
     """Subclass that always self-answers with a fixed answer."""
 
     async def try_self_answer(self, iv: UserIntervention) -> InterventionAnswer | None:
@@ -162,15 +162,15 @@ def test_self_answer_branch_emits_self_answer_event() -> None:
 #      returns a session ─────────────────────────────────────────────────
 
 
-class _DelegatingSession(ChatSession):
+class _DelegatingSession(Session):
     """Subclass that delegates all interventions to a designated parent
     session. Used to verify the parent_delegate routing branch.
     """
 
-    def set_parent(self, parent: ChatSession) -> None:
+    def set_parent(self, parent: Session) -> None:
         self._parent_session = parent
 
-    def resolve_parent_agent(self, iv: UserIntervention) -> ChatSession | None:
+    def resolve_parent_agent(self, iv: UserIntervention) -> Session | None:
         return getattr(self, "_parent_session", None)
 
 
@@ -274,7 +274,7 @@ def test_chain_override_is_notified_through_user_channel_branch(tmp_path: Path) 
     override REPLACED the dispatch; α changed it to DECORATE — the
     iv still flows to the default handler.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     # The default handler awaits iv.future; register a listener so
     # dispatch doesn't short-circuit on no-listener.
     session.register_intervention_listener("test")

--- a/tests/test_intervention_agent_subscriber.py
+++ b/tests/test_intervention_agent_subscriber.py
@@ -1,19 +1,19 @@
-"""Tier 2: Agent (ChatSession) as RequestBus subscriber (issue #254 Phase 3).
+"""Tier 2: Agent (Session) as RequestBus subscriber (issue #254 Phase 3).
 
 Pins Phase 3's behaviour-parity introduction of the Agent-layer
 intervention handler:
 
-  - ``ChatSession.handle_intervention(iv)`` is the Agent's entry point
+  - ``Session.handle_intervention(iv)`` is the Agent's entry point
     for incoming intervention requests. Phase 3 ships pure forward-only
     behaviour (= delegates to ``_dispatch_intervention``); Phase 4 will
     add ``self_answer`` / ``parent_delegate`` branches without changing
     this surface.
-  - ``ChatSession.as_request_bus()`` returns an ``AgentRequestBus``
+  - ``Session.as_request_bus()`` returns an ``AgentRequestBus``
     adapter that satisfies the ``RequestBus`` Protocol from Phase 2.
     OS-layer callers (= ``handle_limit_exceeded``, permission gates,
-    ``ask_user`` op) hold this adapter without importing ChatSession.
+    ``ask_user`` op) hold this adapter without importing Session.
   - ``AgentRequestBus.request(iv)`` forwards to
-    ``ChatSession.handle_intervention(iv)`` — pinning the wire from
+    ``Session.handle_intervention(iv)`` — pinning the wire from
     OS [A] contract → Agent layer → downstream channel selection.
 
 End-to-end behaviour parity is verified via the existing dispatch path
@@ -22,7 +22,7 @@ Phase 3 only adds the Agent-layer NAME for the same code path, so
 existing subscriber-guard / outbox / chain-override semantics are
 re-verified through the new entry-point.
 
-No mocks. Real ChatSession, real adapter.
+No mocks. Real Session, real adapter.
 """
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import AgentRequestBus, ChatSession
+from reyn.chat.session import AgentRequestBus, Session
 from reyn.user_intervention import (
     InterventionAnswer,
     InterventionBus,
@@ -40,16 +40,16 @@ from reyn.user_intervention import (
     UserIntervention,
 )
 
-# ── 1. ChatSession.handle_intervention exists and is the canonical
+# ── 1. Session.handle_intervention exists and is the canonical
 #      Agent-layer entry point ────────────────────────────────────────────
 
 
 def test_chat_session_has_handle_intervention_method() -> None:
-    """Tier 2: ChatSession exposes ``handle_intervention(iv)`` as the
+    """Tier 2: Session exposes ``handle_intervention(iv)`` as the
     Agent's intervention entry point.
     """
-    assert hasattr(ChatSession, "handle_intervention")
-    method = ChatSession.handle_intervention
+    assert hasattr(Session, "handle_intervention")
+    method = Session.handle_intervention
     assert inspect.iscoroutinefunction(method)
 
 
@@ -59,7 +59,7 @@ def test_handle_intervention_signature_is_iv_to_answer() -> None:
     Pinning the shape so a future refactor cannot quietly change the
     contract from underneath OS callers.
     """
-    sig = inspect.signature(ChatSession.handle_intervention)
+    sig = inspect.signature(Session.handle_intervention)
     params = list(sig.parameters.keys())
     assert params == ["self", "iv"]
 
@@ -75,7 +75,7 @@ def test_handle_intervention_forwards_to_dispatch_intervention() -> None:
     is updated to assert the forward-path remains as one of multiple
     branches.
     """
-    src = inspect.getsource(ChatSession.handle_intervention)
+    src = inspect.getsource(Session.handle_intervention)
     assert "self._dispatch_intervention(iv)" in src, (
         "Phase 3 handle_intervention must delegate to "
         "_dispatch_intervention for behaviour parity"
@@ -90,7 +90,7 @@ def test_agent_request_bus_satisfies_request_bus_protocol() -> None:
     RequestBus Protocol — OS callers typed against ``bus: RequestBus``
     accept it directly.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus = AgentRequestBus(session)
     assert isinstance(bus, RequestBus)
 
@@ -100,7 +100,7 @@ def test_agent_request_bus_also_satisfies_legacy_intervention_bus_alias() -> Non
     ``InterventionBus`` name still accept an AgentRequestBus because
     ``InterventionBus`` is an alias of ``RequestBus`` (Phase 2 invariant).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus = AgentRequestBus(session)
     assert isinstance(bus, InterventionBus)
 
@@ -116,11 +116,11 @@ def test_agent_request_bus_request_signature_is_iv_to_answer() -> None:
 
 
 def test_as_request_bus_returns_agent_request_bus() -> None:
-    """Tier 2: ChatSession.as_request_bus() returns an AgentRequestBus
+    """Tier 2: Session.as_request_bus() returns an AgentRequestBus
     bound to this session (= the canonical way for OS callers to get a
     RequestBus-typed reference without importing AgentRequestBus directly).
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus = session.as_request_bus()
     assert isinstance(bus, AgentRequestBus)
     assert isinstance(bus, RequestBus)
@@ -133,7 +133,7 @@ def test_as_request_bus_returns_fresh_adapter_each_call() -> None:
     The adapters are equivalent (all forward to the same session.handle_intervention)
     but distinct objects so OS callers can safely hold their own.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus1 = session.as_request_bus()
     bus2 = session.as_request_bus()
     assert bus1 is not bus2
@@ -157,7 +157,7 @@ def test_agent_request_bus_request_reaches_session_handle_intervention(
     The test asserts the short-circuit IS observed via the new entry
     point — proving the wiring is complete.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     # Deliberately no register_intervention_listener — Phase 1 guard
     # short-circuits the dispatch, returning empty answer.
     bus = session.as_request_bus()
@@ -181,7 +181,7 @@ def test_agent_request_bus_request_with_registered_listener_round_trip(
     the same dispatch path used pre-Phase-3 keeps working when invoked
     through the new RequestBus surface.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("test")
 
     bus = session.as_request_bus()
@@ -209,7 +209,7 @@ def test_agent_request_bus_request_with_registered_listener_round_trip(
 
 
 def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
-    """Tier 2: ChatSession._interventions remains the canonical reference
+    """Tier 2: Session._interventions remains the canonical reference
     to the InterventionRegistry — tui-coder Q2 commitment from issue
     #254 alignment.
 
@@ -221,7 +221,7 @@ def test_session_interventions_attribute_path_is_stable_in_phase3() -> None:
     """
     from reyn.chat.services.intervention_registry import InterventionRegistry
 
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     assert hasattr(session, "_interventions")
     assert isinstance(session.interventions, InterventionRegistry)
     # The registry is still enforcing the Phase 1 subscriber guard.
@@ -238,7 +238,7 @@ def test_handle_intervention_notifies_chain_override_observer(tmp_path: Path) ->
     iv future is owned by the handler post-α; the override is a
     pure observer.
     """
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     session.register_intervention_listener("test")
 
     captured: list[UserIntervention] = []

--- a/tests/test_intervention_bus_protocols.py
+++ b/tests/test_intervention_bus_protocols.py
@@ -35,7 +35,7 @@ import asyncio
 import inspect
 from pathlib import Path
 
-from reyn.chat.session import ChatInterventionBus, ChatSession
+from reyn.chat.session import ChatInterventionBus, Session
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus
 from reyn.user_intervention import (
     InterventionAnswer,
@@ -98,7 +98,7 @@ def test_stdin_intervention_bus_satisfies_both_protocols() -> None:
 
 def test_chat_intervention_bus_satisfies_both_protocols(tmp_path: Path) -> None:
     """Tier 2: ``ChatInterventionBus`` satisfies both Protocols."""
-    session = ChatSession(agent_name="t")
+    session = Session(agent_name="t")
     bus = ChatInterventionBus(session, run_id="r1", skill_name="demo")
     assert isinstance(bus, RequestBus)
     assert isinstance(bus, UserChannel)
@@ -169,7 +169,7 @@ def test_a2a_bus_only_exposes_on_dispatch_post_alpha() -> None:
     """Tier 2: ``A2AInterventionBus.request`` /
     ``deliver`` were removed (issue #292 α) when the bus became a side-effect
     observer. Pin the absence so a future refactor that re-adds them
-    fails first (= the iv ownership question is settled: ChatSession
+    fails first (= the iv ownership question is settled: Session
     owns it, the bus only emits side effects).
     """
     assert not hasattr(A2AInterventionBus, "request")

--- a/tests/test_intervention_restore.py
+++ b/tests/test_intervention_restore.py
@@ -1,8 +1,8 @@
-"""Tier 2: AgentRegistry + ChatSession invariants for intervention restore.
+"""Tier 2: AgentRegistry + Session invariants for intervention restore.
 
 PR-intervention-link L4+L5. After a process crash, the WAL replay
 populates ``AgentSnapshot.outstanding_interventions``. AgentRegistry must
-include this in the "non-empty restore" decision and ChatSession must
+include this in the "non-empty restore" decision and Session must
 re-enqueue the restored interventions into the InterventionRegistry so
 that:
 
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 
@@ -31,14 +31,14 @@ from reyn.core.events.state_log import StateLog
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a Session redirected to ``tmp_path`` via public kwargs.
 
     issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire — these
     tests exercise restore + answer paths, acting as their own listener.
     """
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -99,10 +99,10 @@ async def test_registry_restore_all_includes_outstanding_interventions(tmp_path,
     snap.save(state_dir / "snapshot.json")
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
-    # session_factory: minimal ChatSession with WAL persistence enabled,
+    # session_factory: minimal Session with WAL persistence enabled,
     # consistent with how the chat REPL builds them in production.
     def _factory(profile: AgentProfile):
-        s = ChatSession(agent_name=profile.name, state_log=state_log)
+        s = Session(agent_name=profile.name, state_log=state_log)
         s.register_intervention_listener("test")
         return s
     registry = AgentRegistry(
@@ -128,7 +128,7 @@ async def test_registry_restore_all_includes_outstanding_interventions(tmp_path,
 
 
 # ---------------------------------------------------------------------------
-# L5: ChatSession.restore_state intervention re-enqueue
+# L5: Session.restore_state intervention re-enqueue
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_intervention_resume_e2e.py
+++ b/tests/test_intervention_resume_e2e.py
@@ -11,7 +11,7 @@ Scenario:
     - Process crash mid-await (skill task dies, future never delivered)
 
   Run 2 (restart):
-    - ChatSession.restore_state re-enqueues the intervention from snapshot
+    - Session.restore_state re-enqueues the intervention from snapshot
     - User answers via _maybe_answer_oldest_intervention
     - Watcher buffers the answer keyed by run_id
     - intervention_resolved emitted to WAL (snapshot pruned)
@@ -21,7 +21,7 @@ Scenario:
       and returns it WITHOUT dispatching a new intervention
     - Skill continues with the recovered answer
 
-Persistence note: the buffered answer lives in ChatSession in-memory
+Persistence note: the buffered answer lives in Session in-memory
 state. If the process crashes between the user's answer and the skill's
 resume, the buffer is lost — that's R-D12 (durable answer buffering).
 For most practical scenarios, restart → answer → skill resume happens
@@ -34,7 +34,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatInterventionBus, ChatSession
+from reyn.chat.session import ChatInterventionBus, Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 from reyn.user_intervention import (
@@ -47,15 +47,15 @@ from reyn.user_intervention import (
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a Session redirected to ``tmp_path`` via public kwargs.
 
     issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire — these
     tests drive ``_maybe_answer_oldest_intervention`` manually and are
     effectively their own listener.
     """
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",

--- a/tests/test_intervention_source_agent.py
+++ b/tests/test_intervention_source_agent.py
@@ -1,6 +1,6 @@
 """Tier 2: ``OutboxMessage(kind="intervention").meta["source_agent"]`` opt-in.
 
-Phase 4 follow-up (issue #261) — when ``ChatSession.handle_intervention``
+Phase 4 follow-up (issue #261) — when ``Session.handle_intervention``
 takes the ``parent_delegate`` branch, the downstream ``user_channel``
 emit must stamp ``meta["source_agent"]`` with the delegating agent's
 name so the TUI can render a ``[parent: <name>]`` badge.

--- a/tests/test_intervention_subscriber_guard.py
+++ b/tests/test_intervention_subscriber_guard.py
@@ -15,15 +15,15 @@ Pins:
   2. Enforced mode with zero listeners short-circuits to empty answer.
   3. Enforced mode with one+ listeners awaits as normal.
   4. Register / unregister round-trip restores short-circuit behaviour.
-  5. ChatSession constructs the registry in enforced mode and exposes
+  5. Session constructs the registry in enforced mode and exposes
      ``register_intervention_listener`` / ``unregister_intervention_listener``
      wrappers.
-  6. End-to-end: a ChatSession that hits a safety limit under
+  6. End-to-end: a Session that hits a safety limit under
      ``interactive`` + ``ask_timeout_seconds=0`` with no listener returns
      immediately (no hang) and lets the caller fall through to its
      legacy abort path.
 
-No mocks. Real registry, real ChatSession.
+No mocks. Real registry, real Session.
 """
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ from pathlib import Path
 import pytest
 
 from reyn.chat.services.intervention_registry import InterventionRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.user_intervention import InterventionAnswer, UserIntervention
@@ -212,15 +212,15 @@ def test_unregistering_after_register_re_enables_short_circuit() -> None:
     assert answer.text == ""
 
 
-# ── 5. ChatSession exposes the wrappers and opts into enforcement ──────
+# ── 5. Session exposes the wrappers and opts into enforcement ──────
 
 
 def test_chat_session_constructs_registry_in_enforced_mode(tmp_path: Path) -> None:
-    """Tier 2: a fresh ChatSession has the registry in enforcement mode
+    """Tier 2: a fresh Session has the registry in enforcement mode
     AND starts with zero listeners (= test / headless contexts get the
     short-circuit by default).
     """
-    session = ChatSession(agent_name="test_agent")
+    session = Session(agent_name="test_agent")
     # Internal attribute access is acceptable here because we are pinning
     # the wiring invariant the entry-point relies on. The public surface
     # ``register_intervention_listener`` is what callers use.
@@ -229,10 +229,10 @@ def test_chat_session_constructs_registry_in_enforced_mode(tmp_path: Path) -> No
 
 
 def test_chat_session_register_intervention_listener_round_trip() -> None:
-    """Tier 2: ChatSession's public register / unregister thin wrappers
+    """Tier 2: Session's public register / unregister thin wrappers
     update the registry's listener set.
     """
-    session = ChatSession(agent_name="test_agent")
+    session = Session(agent_name="test_agent")
 
     session.register_intervention_listener("tui")
     assert session.interventions.has_active_listener() is True
@@ -263,7 +263,7 @@ def test_safety_limit_under_interactive_no_timeout_no_listener_no_hang(
         loop=LoopConfig(max_router_calls_per_turn=3),
         on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
     )
-    session = ChatSession(
+    session = Session(
         agent_name="test_agent",
         output_language="ja",
         budget_tracker=BudgetTracker(CostConfig()),

--- a/tests/test_limit_deny_force_close_router_cap_1496.py
+++ b/tests/test_limit_deny_force_close_router_cap_1496.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pytest
 
 from reyn.chat.outbox import OutboxMessage
-from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.chat.session import RouterCapExceeded, Session
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -34,9 +34,9 @@ from tests.test_router_loop import _ScriptedLLM, text_result
 _USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
 
 
-def _make_session(tmp_path: Path, cap: int = 3) -> ChatSession:
+def _make_session(tmp_path: Path, cap: int = 3) -> Session:
     safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=cap))
-    return ChatSession(
+    return Session(
         agent_name="test_cap_agent",
         budget_tracker=BudgetTracker(CostConfig()),
         safety=safety,
@@ -51,7 +51,7 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _drain(session: ChatSession) -> list[OutboxMessage]:
+def _drain(session: Session) -> list[OutboxMessage]:
     msgs = []
     while not session.outbox.empty():
         msgs.append(session.outbox.get_nowait())

--- a/tests/test_live_fork_gate.py
+++ b/tests/test_live_fork_gate.py
@@ -1,7 +1,7 @@
 """Tier 2: OS invariant — Phase-2 end-to-end live-fork gate (ADR-0038 D8, #1533).
 
 The Phase-2 (A)-equivalent of `test_live_rewind_gate.py`. Real `AgentRegistry` +
-`ChatSession` + `StateLog` + real git (no mocks). 2a-2's two-substrate test proves
+`Session` + `StateLog` + real git (no mocks). 2a-2's two-substrate test proves
 checkout *correctness* with manually-built captures; THIS gate proves the
 **production-wiring composition**: a genuine `_run_router_loop` turn's
 `cut_generation` auto-capture × Phase-2 `checkout` (branch-switch to an abandoned
@@ -28,7 +28,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 
@@ -46,7 +46,7 @@ class _FakeTurnDriver:
     without an LLM. The only simulated effect is the file write (the op effect).
     """
 
-    def __init__(self, session: ChatSession, workspace_root: Path, content_by_turn: dict[str, str]):
+    def __init__(self, session: Session, workspace_root: Path, content_by_turn: dict[str, str]):
         self._session = session
         self._ws = workspace_root
         self._content = content_by_turn
@@ -87,7 +87,7 @@ async def test_live_fork_checkout_back_follows_lineage_both_substrates(tmp_path)
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
     snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
 
-    session = ChatSession(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
+    session = Session(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
     session.register_intervention_listener("test")
     session.attach_workspace_store(reg.workspace_store)
     session.attach_anchor_store(reg.anchor_store)

--- a/tests/test_live_rewind_gate.py
+++ b/tests/test_live_rewind_gate.py
@@ -1,6 +1,6 @@
 """Tier 2: OS invariant — Phase-1 end-to-end live-rewind gate (ADR-0038, #1533).
 
-Real `AgentRegistry` + `ChatSession` + `StateLog` + real git (no mocks). The unit
+Real `AgentRegistry` + `Session` + `StateLog` + real git (no mocks). The unit
 tests cover each piece (await_quiescent, rewind_to, WorkspaceVersionStore, the
 cut_generation capture wiring); THIS gate proves the **composition** end-to-end —
 that a live session's turn-boundary auto-capture and a subsequent global rewind
@@ -21,7 +21,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 
@@ -39,7 +39,7 @@ class _FakeTurnDriver:
     without an LLM. The only simulated effect is the file write (the op effect).
     """
 
-    def __init__(self, session: ChatSession, workspace_root: Path, content_by_turn: dict[str, str]):
+    def __init__(self, session: Session, workspace_root: Path, content_by_turn: dict[str, str]):
         self._session = session
         self._ws = workspace_root
         self._content = content_by_turn
@@ -87,7 +87,7 @@ async def test_live_rewind_reverts_both_substrates_to_as_of_n(tmp_path):
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
     snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
 
-    session = ChatSession(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
+    session = Session(agent_name="alpha", state_log=state_log, snapshot_path=snap_path)
     session.register_intervention_listener("test")
     # production wiring: the registry injects its single shared stores.
     session.attach_workspace_store(reg.workspace_store)

--- a/tests/test_mcp_install_state_change_emitter.py
+++ b/tests/test_mcp_install_state_change_emitter.py
@@ -36,20 +36,20 @@ import pytest
 from reyn.chat.session import (
     _STATE_CHANGE_EVENT_MAPPINGS,
     ChatMessage,
-    ChatSession,
+    Session,
 )
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _state_changes(session: ChatSession) -> list[ChatMessage]:
+def _state_changes(session: Session) -> list[ChatMessage]:
     return [
         m for m in session.history
         if m.role == "system" and (m.meta or {}).get("kind") == "state_change"

--- a/tests/test_mcp_iv_support_270_phase_b.py
+++ b/tests/test_mcp_iv_support_270_phase_b.py
@@ -2,7 +2,7 @@
 
 Pre-#270 Phase B: Reyn-as-MCP-server's ``send_to_agent`` ran skills
 that could emit ``UserIntervention`` ivs, but the MCP transport had
-no chain-override observer registered → iv landed in ChatSession's
+no chain-override observer registered → iv landed in Session's
 ``_active`` queue and would hang if no TUI was simultaneously attached
 (= the typical MCP-only deployment). The peer also had no way to
 answer.
@@ -23,7 +23,7 @@ PR #300 established):
      shape PR #285 Gap 4 standardised).
   5. New MCP tool ``answer_intervention`` accepts
      ``{agent_name, run_id, text, choice_id?}`` and routes to
-     ``ChatSession.answer_pending_intervention``.
+     ``Session.answer_pending_intervention``.
   6. Experimental capability ``reyn.iv.input_required`` declared in
      the ``initialize`` response (= mirrors PR #284's calibration
      pattern: declared capability ↔ in-source wire AST pin).
@@ -295,7 +295,7 @@ def test_answer_intervention_tool_is_declared() -> None:
     src = inspect.getsource(mcp_server.build_server)
     # The tool definition must appear in build_server's source.
     assert 'name="answer_intervention"' in src
-    assert "ChatSession.answer_pending_intervention" in src
+    assert "Session.answer_pending_intervention" in src
     # Schema sanity: required fields are listed.
     assert '"required": ["agent_name", "run_id", "text"]' in src
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,7 +21,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -51,11 +51,11 @@ def _build_registry(
     """
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -342,9 +342,9 @@ def test_send_to_agent_waits_for_plan_terminal_text(tmp_path, monkeypatch):
         # Track in running_plans so send_to_agent_impl awaits it.
         self.running_plans["fake_plan_id"] = task
 
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     monkeypatch.setattr(
-        ChatSession, "_handle_user_message", _fake_handle_user_message,
+        Session, "_handle_user_message", _fake_handle_user_message,
     )
 
     async def go():
@@ -374,7 +374,7 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
 
     Fix: ``send_to_agent_impl`` awaits ``running_skills`` after
     ``_handle_user_message`` returns, then calls
-    ``ChatSession.drain_skill_completed_inbox`` to dispatch any queued
+    ``Session.drain_skill_completed_inbox`` to dispatch any queued
     ``skill_completed`` items inline. This test pins the contract by:
 
     1. Faking ``_handle_user_message`` to spawn a background "skill"
@@ -422,10 +422,10 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
         ))
 
     monkeypatch.setattr(
-        ChatSession, "_handle_user_message", _fake_handle_user_message,
+        Session, "_handle_user_message", _fake_handle_user_message,
     )
     monkeypatch.setattr(
-        ChatSession, "_handle_skill_completed", _fake_handle_skill_completed,
+        Session, "_handle_skill_completed", _fake_handle_skill_completed,
     )
 
     async def go():

--- a/tests/test_mcp_server_progress_271.py
+++ b/tests/test_mcp_server_progress_271.py
@@ -50,7 +50,7 @@ from reyn.schemas.models import Event  # noqa: E402
 
 
 class _FakeSession:
-    """Minimal stand-in for ChatSession exposing `_chat_events`."""
+    """Minimal stand-in for Session exposing `_chat_events`."""
 
     def __init__(self, event_log: EventLog) -> None:
         self._chat_events = event_log

--- a/tests/test_mcp_server_resources_adapter.py
+++ b/tests/test_mcp_server_resources_adapter.py
@@ -30,7 +30,7 @@ pytest.importorskip("mcp", reason="MCP SDK not installed")
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
 from reyn.mcp.server import build_server
@@ -40,10 +40,10 @@ def _build_registry_with_agent(tmp_path: Path, agent_name: str) -> AgentRegistry
     """Minimal AgentRegistry with one agent under tmp_path."""
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",

--- a/tests/test_memory_service_invariants.py
+++ b/tests/test_memory_service_invariants.py
@@ -5,7 +5,7 @@ Policy compliance (`docs/deep-dives/contributing/testing.md`):
 - NO private-state assertions.
 - File callbacks are thin closures over tmp_path (plain open/os.unlink/os.listdir).
   These facsimiles stand in for the real _file_write / _file_read / _file_delete /
-  _file_regenerate_index methods on ChatSession; the real ones gate on OpContext +
+  _file_regenerate_index methods on Session; the real ones gate on OpContext +
   Workspace + PermissionResolver, which would pull the entire OS stack into what
   should be a unit-level Tier 2 test. The closures do identical filesystem work
   without the permission layer — permissible because this test verifies
@@ -33,7 +33,7 @@ def _make_callbacks(base: Path):
     """Return (file_write, file_read, file_delete, file_regenerate_index)
     as plain async closures over *base*.
 
-    These exercise the same filesystem surface as ChatSession's real callbacks
+    These exercise the same filesystem surface as Session's real callbacks
     without pulling in OpContext or PermissionResolver.
     """
 

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -38,7 +38,7 @@ import pytest
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
 from reyn.chat.services.chain_manager import ChainManager
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.chat.topology import Topology
 from reyn.core.events.state_log import StateLog
 
@@ -50,18 +50,18 @@ from reyn.core.events.state_log import StateLog
 def _make_registry_with_agents(
     tmp_path: Path,
     names: list[str],
-) -> tuple[AgentRegistry, dict[str, ChatSession], StateLog]:
-    """Build a registry that holds real ChatSessions for each name.
+) -> tuple[AgentRegistry, dict[str, Session], StateLog]:
+    """Build a registry that holds real Sessions for each name.
 
     No background tasks are started — test logic drives inboxes
     synchronously.  Returns (registry, {name: session}, state_log).
     """
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             state_log=state_log,
             snapshot_path=agent_dir / "state" / "snapshot.json",
@@ -72,7 +72,7 @@ def _make_registry_with_agents(
         session_factory=factory,
         state_log=state_log,
     )
-    sessions: dict[str, ChatSession] = {}
+    sessions: dict[str, Session] = {}
     for name in names:
         agent_dir = tmp_path / ".reyn" / "agents" / name
         agent_dir.mkdir(parents=True, exist_ok=True)
@@ -123,7 +123,7 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
     snapshot after both replies arrive.
 
     No LLM required — this exercises pure chain register/resolve mechanics
-    at the ChatSession public surface.
+    at the Session public surface.
     """
     registry, sessions, state_log = _make_registry_with_agents(
         tmp_path, ["A", "B", "C"]

--- a/tests/test_multi_session_restore.py
+++ b/tests/test_multi_session_restore.py
@@ -26,7 +26,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 
@@ -38,8 +38,8 @@ def _make_registry(tmp_path: Path, wal: Path) -> AgentRegistry:
     """
     state_log = StateLog(wal)
 
-    def _factory(profile: AgentProfile) -> ChatSession:
-        s = ChatSession(agent_name=profile.name, state_log=state_log)
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
         s.register_intervention_listener("test")  # satisfy listener-presence guard
         return s
 
@@ -63,7 +63,7 @@ def _iv_dict(iv_id: str, run_id: str) -> dict:
     }
 
 
-def _active_iv_ids(session: "ChatSession") -> list[str]:
+def _active_iv_ids(session: "Session") -> list[str]:
     """Public read of a session's restored, re-enqueued interventions."""
     return [iv.id for iv in session.interventions.list_active()]
 
@@ -77,7 +77,7 @@ async def test_multi_session_restore_is_per_session_independent(tmp_path, monkey
     fell to "main" (the cond-4 forwarding gap) — or where the two sessions shared
     one snapshot.json — would surface as cross-contamination or a missing iv.
     """
-    # chdir so a factory-built ChatSession's default snapshot path
+    # chdir so a factory-built Session's default snapshot path
     # (.reyn/agents/<name>/state/snapshot.json) resolves under tmp_path, aligning
     # the session's base with registry._dir (the base-alignment invariant S5 relies on).
     monkeypatch.chdir(tmp_path)

--- a/tests/test_nested_skill_path.py
+++ b/tests/test_nested_skill_path.py
@@ -21,7 +21,7 @@ import asyncio
 import json
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.skill.skill_registry import SkillRegistry
 from reyn.skill.skill_snapshot import SkillSnapshot
@@ -136,15 +136,15 @@ def test_registry_skill_started_wal_includes_parent_run_id(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path) -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / "wal.wal"),
         snapshot_path=tmp_path / "alpha_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_pending_intervention_268.py
+++ b/tests/test_pending_intervention_268.py
@@ -4,7 +4,7 @@
 Pins the cross-channel intervention routing introduced by #268:
 
   - iv carries ``origin_channel_id`` (= "tui:..." / "a2a:..." / etc.).
-  - ``ChatSession.handle_intervention`` checks if the origin channel
+  - ``Session.handle_intervention`` checks if the origin channel
     is still registered as a listener; if not, the iv is parked in
     the stalled queue instead of being delivered to a different
     channel.
@@ -25,14 +25,14 @@ Pins:
      registered (or ``origin_channel_id=None``).
   3. Stalled queue API: list_stalled / get_stalled / stalled_count /
      discard_stalled / claim_stalled all behave as documented.
-  4. ChatSession session-level operations dispatch to registry
+  4. Session session-level operations dispatch to registry
      correctly + emit audit events.
   5. PendingOpView field shape is the documented set; from_intervention
      populates from iv correctly.
   6. Backwards-compat: iv with ``origin_channel_id=None`` follows the
      pre-#268 dispatch path unchanged.
 
-No mocks. Real ChatSession + real InterventionRegistry.
+No mocks. Real Session + real InterventionRegistry.
 """
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ from datetime import datetime
 import pytest
 
 from reyn.chat.services.intervention_registry import InterventionRegistry
-from reyn.chat.session import ChatSession, PendingOpView
+from reyn.chat.session import PendingOpView, Session
 from reyn.user_intervention import (
     InterventionAnswer,
     UserIntervention,
@@ -199,7 +199,7 @@ def test_registry_claim_stalled_returns_none_when_not_stalled() -> None:
     assert reg.claim_stalled("nonexistent", "tui:session") is None
 
 
-# ── 3. ChatSession handle_intervention origin-pin routing ─────────────
+# ── 3. Session handle_intervention origin-pin routing ─────────────
 
 
 def test_handle_intervention_with_no_origin_uses_existing_path() -> None:
@@ -210,7 +210,7 @@ def test_handle_intervention_with_no_origin_uses_existing_path() -> None:
     dispatch short-circuits to empty answer; we verify the path
     reached the short-circuit rather than the stall queue.
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     iv = UserIntervention(kind="ask_user", prompt="Q?")
     # No origin_channel_id, no listener.
 
@@ -225,7 +225,7 @@ def test_handle_intervention_with_registered_origin_uses_dispatch_path() -> None
     """Tier 2: when origin_channel_id is registered as a listener,
     the dispatch path runs (= origin alive → not stalled).
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     session.register_intervention_listener("tui:session-a")
 
     async def _drive() -> tuple[InterventionAnswer, str]:
@@ -260,7 +260,7 @@ def test_handle_intervention_with_closed_origin_parks_in_stalled_queue() -> None
       - handle_intervention is awaiting (= doesn't return until
         future resolves via discard / claim)
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     # Register a different listener — origin won't match.
     session.register_intervention_listener("tui:current-session")
 
@@ -291,7 +291,7 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
     ``intervention_routed{route="user_channel_stalled"}`` is emitted,
     distinct from the regular ``"user_channel"`` route event.
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -318,14 +318,14 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
     assert last["origin_channel_id"] == "tui:closed"
 
 
-# ── 4. ChatSession cross-channel operations ───────────────────────────
+# ── 4. Session cross-channel operations ───────────────────────────
 
 
 def test_list_stalled_interventions_returns_pending_op_views() -> None:
     """Tier 2: list_stalled_interventions returns a list of
     PendingOpView with the documented field shape.
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> list[PendingOpView]:
@@ -359,7 +359,7 @@ def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
     ``pending_intervention_discarded`` audit event for the P6 audit
     trail when the iv was actually discarded.
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -391,7 +391,7 @@ def test_discard_pending_intervention_returns_false_for_unknown_id() -> None:
     """Tier 2: discard on unknown id is safe + returns False without
     raising or emitting an event.
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
 
     async def _drive() -> bool:
         return await session.discard_pending_intervention("nonexistent")
@@ -411,7 +411,7 @@ def test_claim_pending_intervention_rebinds_origin_and_returns_view() -> None:
         rebound iv; we deliver an answer via the new channel to
         complete the lifecycle cleanly
     """
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
     session.register_intervention_listener("tui:current")
     session.register_intervention_listener("tui:claimer")
 
@@ -445,7 +445,7 @@ def test_claim_pending_intervention_rebinds_origin_and_returns_view() -> None:
 
 def test_claim_pending_intervention_returns_none_for_unknown_id() -> None:
     """Tier 2: claim on unknown id returns None, no exception."""
-    session = ChatSession(agent_name="test")
+    session = Session(agent_name="test")
 
     async def _drive() -> "PendingOpView | None":
         return await session.claim_pending_intervention(

--- a/tests/test_permission_state_change_emitter.py
+++ b/tests/test_permission_state_change_emitter.py
@@ -3,7 +3,7 @@
 The first concrete emitter for the ``notify_state_change`` API
 landed in PR #455. When a permission decision is persisted to
 ``approvals.yaml`` (= user said "yes always" / "no never" on an
-intervention), ChatSession mints a ``state_change`` history entry so
+intervention), Session mints a ``state_change`` history entry so
 the LLM sees the world-state change in its next turn. Directly
 mitigates the #352 in-context-learning refusal trap pattern (= the
 LLM was continuing to refuse a capability after the user had granted
@@ -15,14 +15,14 @@ Pins:
      subscriber API exists and stores callbacks in a list.
   2. ``_persist(key, approved)`` fires all registered callbacks with the
      same ``(key, approved)`` args.
-  3. ChatSession subscribes itself on construction; the callback fires
+  3. Session subscribes itself on construction; the callback fires
      a ``notify_state_change`` with summary derived from ``key`` and
      ``approved``.
-  4. Multiple ChatSessions on the same PermissionResolver all receive
+  4. Multiple Sessions on the same PermissionResolver all receive
      notifications independently (= shared-resolver model).
   5. A bad callback doesn't crash ``_persist`` (= other subscribers
      and the core persistence path are unaffected).
-  6. ChatSession.shutdown unregisters the callback so dead-session
+  6. Session.shutdown unregisters the callback so dead-session
      references don't accumulate.
 
 Tier 2 because the contract is load-bearing for #352 closure —
@@ -34,18 +34,18 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.session import ChatMessage, Session
 from reyn.core.events.state_log import StateLog
 from reyn.security.permissions.permissions import PermissionResolver
 
 
 def _make_session(
     tmp_path: Path, *, agent_name: str, perm_resolver: PermissionResolver,
-) -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` with a shared
+) -> Session:
+    """Build a Session redirected to ``tmp_path`` with a shared
     PermissionResolver injected.
     """
-    return ChatSession(
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -59,7 +59,7 @@ def _make_resolver(tmp_path: Path) -> PermissionResolver:
     )
 
 
-def _state_changes(session: ChatSession) -> list[ChatMessage]:
+def _state_changes(session: Session) -> list[ChatMessage]:
     return [
         m for m in session.history
         if m.role == "system" and (m.meta or {}).get("kind") == "state_change"
@@ -149,7 +149,7 @@ def test_persist_callback_exception_does_not_crash_persist(tmp_path):
     assert resolver.saved_get("safe.key") is True
 
 
-# ── ChatSession wiring ────────────────────────────────────────────────
+# ── Session wiring ────────────────────────────────────────────────
 
 
 def test_session_mints_state_change_on_permission_grant(tmp_path):
@@ -189,7 +189,7 @@ def test_session_mints_state_change_on_permission_revoke(tmp_path):
 
 
 def test_multiple_sessions_all_notified_on_shared_resolver(tmp_path):
-    """Tier 2: when N ChatSessions share the same PermissionResolver
+    """Tier 2: when N Sessions share the same PermissionResolver
     (= the typical reyn web / reyn run model), a single permission
     grant notifies all N sessions independently. Each gets its own
     state_change history entry — the grant is project-wide, all
@@ -206,11 +206,11 @@ def test_multiple_sessions_all_notified_on_shared_resolver(tmp_path):
 
 
 def test_session_with_no_resolver_works_unchanged(tmp_path):
-    """Tier 2: ChatSession can be constructed without a
+    """Tier 2: Session can be constructed without a
     PermissionResolver (= CLI / test stubs). No callback registered,
     no crash on shutdown. Backward compat path.
     """
-    session = ChatSession(
+    session = Session(
         agent_name="loner",
         state_log=StateLog(tmp_path / "loner.wal"),
         snapshot_path=tmp_path / "loner_snapshot.json",
@@ -222,7 +222,7 @@ def test_session_with_no_resolver_works_unchanged(tmp_path):
 
 @pytest.mark.asyncio
 async def test_session_shutdown_unregisters_callback(tmp_path):
-    """Tier 2: ``ChatSession.shutdown`` unregisters its callback from
+    """Tier 2: ``Session.shutdown`` unregisters its callback from
     the shared PermissionResolver — prevents dead-session references
     from accumulating across long-running ``reyn web`` sessions.
     """

--- a/tests/test_phase_no_progress_completion_inject.py
+++ b/tests/test_phase_no_progress_completion_inject.py
@@ -38,7 +38,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import SafetyConfig, TimeoutConfig
 from reyn.core.events.state_log import StateLog
 from reyn.core.kernel.runtime_types import WorkflowAbortedError
@@ -48,9 +48,9 @@ from reyn.core.kernel.runtime_types import WorkflowAbortedError
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> ChatSession:
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
     safety = SafetyConfig(timeout=TimeoutConfig(chain_seconds=60.0))
-    return ChatSession(
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         safety=safety,

--- a/tests/test_plan_async_dispatch.py
+++ b/tests/test_plan_async_dispatch.py
@@ -45,7 +45,7 @@ class _RecordingEvents:
 
 
 class _AsyncCapableHost:
-    """Host that exposes spawn_plan_task; mimics ChatSession's task
+    """Host that exposes spawn_plan_task; mimics Session's task
     handoff. Runs the runtime synchronously inside spawn_plan_task so
     test assertions are deterministic without create_task scheduling."""
 
@@ -74,7 +74,7 @@ class _AsyncCapableHost:
     async def spawn_plan_task(self, *, plan_id, runtime, chain_id):
         # Record handoff metadata; defer runtime.run() until the test
         # explicitly drives it via host.run_spawned() (= mirrors
-        # ChatSession's create_task semantics without scheduling).
+        # Session's create_task semantics without scheduling).
         self.spawn_calls.append(
             {"plan_id": plan_id, "chain_id": chain_id}
         )
@@ -210,7 +210,7 @@ async def test_async_dispatch_decomposition_written_before_spawn() -> None:
 @pytest.mark.asyncio
 async def test_async_runtime_runs_to_completion_via_host() -> None:
     """Tier 2: when the host eventually drives spawned runtimes (= the
-    ChatSession analog calls runtime.run()), plan_started + completed
+    Session analog calls runtime.run()), plan_started + completed
     fire, terminal text reaches outbox."""
     host = _AsyncCapableHost()
     await dispatch_plan_tool(
@@ -218,7 +218,7 @@ async def test_async_runtime_runs_to_completion_via_host() -> None:
         parent_host=host, chain_id="c0",
         available_tool_names=set(),
     )
-    # Drive the runtime now (= mirror ChatSession.spawn_plan_task wrapper).
+    # Drive the runtime now (= mirror Session.spawn_plan_task wrapper).
     await host.run_spawned()
     (only_started,) = host.plan_started_calls
     assert "plan_id" in only_started

--- a/tests/test_plan_chatsession_wiring.py
+++ b/tests/test_plan_chatsession_wiring.py
@@ -1,12 +1,12 @@
 """Tier 2: Phase 2 fresh-run wiring (= ADR-0023 Phase 2 v1 gap fix).
 
-Pins the contract that ChatSession's record_plan_* methods populate
+Pins the contract that Session's record_plan_* methods populate
 the per-agent PlanRegistry alongside SnapshotJournal's WAL-side
 bookkeeping. Without this, ADR-0023 forward replay was dormant
 (PlanRegistry.load_active() returns empty for every fresh-run plan)
 and ADR-0024/ADR-0025 features had nothing to record into.
 
-Tests target the public surface (ChatSession.record_plan_* methods)
+Tests target the public surface (Session.record_plan_* methods)
 and observe via PlanRegistry's on-disk snapshots — no private state
 assertions, no mocks.
 """
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.core.plan import (
     PlanRegistry,
@@ -24,8 +24,8 @@ from reyn.core.plan import (
 )
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -183,7 +183,7 @@ def test_get_plan_registry_returns_singleton(tmp_path, monkeypatch):
 
 def test_get_plan_registry_returns_none_without_state_log(tmp_path):
     """Tier 2: no state_log → no plan registry (= test/standalone mode)."""
-    session = ChatSession(
+    session = Session(
         agent_name="alpha", state_log=None,
         snapshot_path=tmp_path / "snap.json",
     )

--- a/tests/test_plan_decomposition_artifact.py
+++ b/tests/test_plan_decomposition_artifact.py
@@ -5,7 +5,7 @@ SSoT for the plan shape on resume; LLM re-decomposition is non-
 deterministic and would break step-result memoization.
 
 These tests pin the round-trip + corruption-fallback behavior. No
-ChatSession / RouterLoop coupling — the helpers are standalone.
+Session / RouterLoop coupling — the helpers are standalone.
 """
 from __future__ import annotations
 

--- a/tests/test_plan_multi_plan_resume_race.py
+++ b/tests/test_plan_multi_plan_resume_race.py
@@ -18,7 +18,7 @@ Scope:
     can disambiguate by plan_id)
   - Crash mid-flight (kill tasks + drop session) leaves both
     snapshots durable
-  - New ChatSession against same disk state spawns both resume tasks
+  - New Session against same disk state spawns both resume tasks
     (= AgentRegistry._recover_plans_for_agent path)
   - No cross-plan contamination (= each resume reads its own
     decomposition + step results)
@@ -31,7 +31,7 @@ from typing import Any
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.core.plan import (
     PlanRegistry,
@@ -80,8 +80,8 @@ def _stub_router_loop(monkeypatch):
 # ── helpers ──────────────────────────────────────────────────────────────
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "wal.jsonl"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -99,7 +99,7 @@ def _plan_args(goal: str, n_steps: int = 2) -> dict:
     }
 
 
-async def _drain(session: ChatSession) -> None:
+async def _drain(session: Session) -> None:
     """Run pending tasks (= let spawn_plan_task workers complete)."""
     if session.running_plans:
         await asyncio.gather(
@@ -212,7 +212,7 @@ async def test_concurrent_plans_record_distinct_step_results(
 @pytest.mark.asyncio
 async def test_crash_mid_flight_two_plans_resume_both(tmp_path, monkeypatch):
     """Tier 2: two plans in flight, simulate process crash
-    (= kill tasks before completion + new ChatSession against same
+    (= kill tasks before completion + new Session against same
     disk), restart triggers _recover_plans_for_agent which spawns
     both resume tasks. Each picks up its own decomposition and
     completes.
@@ -277,7 +277,7 @@ async def test_crash_mid_flight_two_plans_resume_both(tmp_path, monkeypatch):
         await asyncio.sleep(0.05)
 
     # Simulate crash: cancel all running plan tasks. This drops the
-    # in-memory ChatSession but leaves disk state intact.
+    # in-memory Session but leaves disk state intact.
     for task in list(session1.running_plans.values()):
         if not task.done():
             task.cancel()

--- a/tests/test_plan_resume_coordinator.py
+++ b/tests/test_plan_resume_coordinator.py
@@ -238,7 +238,7 @@ class _MockSkillRegistry:
 
 @pytest.mark.asyncio
 async def test_apply_returns_launchable_subset(tmp_path: Path) -> None:
-    """Tier 2: apply_decisions returns plans for ChatSession to spawn
+    """Tier 2: apply_decisions returns plans for Session to spawn
     (= action ∈ {resume, retry_pending}); discard plans are excluded."""
     reg = PlanRegistry(agent_name="default", agent_state_dir=tmp_path)
     reg.start(plan_id="p001", chain_id="c0", goal="g", applied_seq=10)

--- a/tests/test_plan_router_narration_invariants.py
+++ b/tests/test_plan_router_narration_invariants.py
@@ -10,7 +10,7 @@ Pins the contract that plan completion drives router synthesis via the
 3. ``_handle_plan_completed`` calls ``_run_router_loop`` exactly once (=
    the synthesis turn).
 
-No mocks of collaborators — real ChatSession + real PlanExecutionResult.
+No mocks of collaborators — real Session + real PlanExecutionResult.
 ``_run_router_loop`` is stubbed via monkeypatch.setattr (not MagicMock/patch)
 so the LLM is not invoked in the invariant tests (Tier 2 scope: inbox
 enqueue / history inject / turn invocation; not LLM response content).
@@ -23,13 +23,13 @@ from pathlib import Path
 import pytest
 
 from reyn.chat.planner import PlanExecutionResult
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.core.plan import PlanRegistry
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "wal.jsonl"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
@@ -61,7 +61,7 @@ async def test_plan_completion_emits_plan_completed_inbox(
     async def _stub_run_router_loop(self, user_text: str, chain_id: str) -> None:
         router_calls.append((user_text, chain_id))
 
-    monkeypatch.setattr(ChatSession, "_run_router_loop", _stub_run_router_loop)
+    monkeypatch.setattr(Session, "_run_router_loop", _stub_run_router_loop)
 
     # Build a minimal fake runtime that returns a clean PlanExecutionResult.
     fake_result = PlanExecutionResult(
@@ -137,7 +137,7 @@ async def test_handle_plan_completed_injects_user_message(
     async def _noop_router_loop(self, user_text: str, chain_id: str) -> None:
         pass
 
-    monkeypatch.setattr(ChatSession, "_run_router_loop", _noop_router_loop)
+    monkeypatch.setattr(Session, "_run_router_loop", _noop_router_loop)
 
     payload = {
         "plan_id": "p_narrate_001",
@@ -194,7 +194,7 @@ async def test_handle_plan_completed_runs_router_turn(
         nonlocal router_call_count
         router_call_count += 1
 
-    monkeypatch.setattr(ChatSession, "_run_router_loop", _counting_router_loop)
+    monkeypatch.setattr(Session, "_run_router_loop", _counting_router_loop)
 
     payload = {
         "plan_id": "p_synth_002",
@@ -235,7 +235,7 @@ async def test_handle_plan_completed_injects_step_failures_when_present(
     async def _noop_router_loop(self, user_text: str, chain_id: str) -> None:
         pass
 
-    monkeypatch.setattr(ChatSession, "_run_router_loop", _noop_router_loop)
+    monkeypatch.setattr(Session, "_run_router_loop", _noop_router_loop)
 
     # ── Case A: plan with a failed step ─────────────────────────────────
     payload_with_failures = {

--- a/tests/test_plan_slash_command.py
+++ b/tests/test_plan_slash_command.py
@@ -4,7 +4,7 @@ Two sub-commands:
   /plan list                 — show active plan runs
   /plan discard <plan_id>    — abort a specific plan run + cleanup
 
-Mirrors test_skill_slash_command.py shape; uses real ChatSession +
+Mirrors test_skill_slash_command.py shape; uses real Session +
 SnapshotJournal so the WAL/snapshot paths exercise the production
 wiring.
 """
@@ -16,19 +16,19 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -19,7 +19,7 @@ import asyncio
 from pathlib import Path
 
 from reyn.chat.services import MemoryService, RouterHostAdapter
-from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.session import ChatMessage, Session
 from reyn.config import ReasoningConfig
 from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
@@ -149,7 +149,7 @@ def test_continuity_section_surfaces_via_host():
 
 
 def _session(reasoning_config, tmp_path):
-    return ChatSession(
+    return Session(
         agent_name="t",
         state_log=StateLog(tmp_path / "wal.jsonl"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_registry_multi_session_1726.py
+++ b/tests/test_registry_multi_session_1726.py
@@ -6,7 +6,7 @@ byte-identical). spawn_session opens an additional Session under the SAME Agent
 object. Inbound routing to non-default sessions is Stage 4 — S3 just makes the
 structure hold N.
 
-Real AgentRegistry + real ChatSession (no mocks).
+Real AgentRegistry + real Session (no mocks).
 """
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import _DEFAULT_SID, AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 
 
@@ -22,7 +22,7 @@ def _registry(tmp_path):
     def factory(profile: AgentProfile):
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -16,7 +16,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.snapshot_generations import RewindIntoAbandonedError, rewind
 from reyn.core.events.state_log import StateLog
@@ -161,7 +161,7 @@ async def test_rewind_to_gates_compaction_during_window(tmp_path):
 async def test_rewind_to_drives_loaded_session_to_as_of_n_zero_residue(tmp_path):
     """Tier 2: rewind_to drives a REAL loaded session through the full path.
 
-    A real ChatSession (aligned to the registry's on-disk paths) is injected; the
+    A real Session (aligned to the registry's on-disk paths) is injected; the
     user-facing rewind cancels + quiesces it, reconstructs as-of-N, clears live
     in-memory residue (reset_for_rewind), and re-adopts the as-of-N snapshot
     (restore_state). Post-rewind the session reflects as-of-N with zero pre-rewind
@@ -170,7 +170,7 @@ async def test_rewind_to_drives_loaded_session_to_as_of_n_zero_residue(tmp_path)
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     log = reg.state_log
-    session = ChatSession(
+    session = Session(
         agent_name="alpha", state_log=log,
         snapshot_path=_snap_path(tmp_path, "alpha"),
     )

--- a/tests/test_registry_wal_size_safety_net.py
+++ b/tests/test_registry_wal_size_safety_net.py
@@ -47,7 +47,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 
 
 class _ShimSession:
-    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+    """Minimal duck-typed Session exposing only ``iter_applied_seqs``.
 
     PR-N7 (FP-0008): the WAL truncation floor reads exclusively from
     in-memory session state. Tests register a shim into ``_agents`` and

--- a/tests/test_registry_wal_truncate.py
+++ b/tests/test_registry_wal_truncate.py
@@ -7,7 +7,7 @@ on top of ``StateLog.truncate_below`` (the rewrite primitive, tested
 separately).
 
 PR-N7 (FP-0008): the floor calculation reads exclusively from in-memory
-state (= ``ChatSession.iter_applied_seqs`` via the session's journal +
+state (= ``Session.iter_applied_seqs`` via the session's journal +
 skill / plan registries), not from disk. Tests therefore register a
 duck-typed shim session into ``registry._agents`` and accumulate
 watermarks (= the seqs the shim yields) in the shim's seq list. On-disk
@@ -55,7 +55,7 @@ def _make_registry(tmp_path: Path, *, with_state_log: bool = True) -> AgentRegis
 
 
 class _ShimSession:
-    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+    """Minimal duck-typed Session exposing only ``iter_applied_seqs``.
 
     Tests accumulate watermarks via the seed helpers below; the shim
     surfaces them through the same public-surface contract that

--- a/tests/test_registry_wal_truncate_floor_nonblocking.py
+++ b/tests/test_registry_wal_truncate_floor_nonblocking.py
@@ -1,7 +1,7 @@
 """Tier 2: OS invariant — compute_truncate_floor reads in-memory state only.
 
 PR-N7 (FP-0008): the floor calculation was rewritten to read exclusively
-from in-memory session state (= ``ChatSession.iter_applied_seqs`` via the
+from in-memory session state (= ``Session.iter_applied_seqs`` via the
 session's journal snapshot + skill_registry + plan_registry public
 methods). The pre-N7 implementation walked snapshot files on disk inside
 the async ``truncate_wal_if_eligible`` caller — sync I/O in an async
@@ -68,11 +68,11 @@ def _make_registry(tmp_path: Path, *, with_state_log: bool = True) -> AgentRegis
 
 
 class _ShimSession:
-    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+    """Minimal duck-typed Session exposing only ``iter_applied_seqs``.
 
     The public-surface contract that compute_truncate_floor depends on
     is exactly one method. Tests construct shims with the desired
-    watermarks; no ChatSession boot path needed.
+    watermarks; no Session boot path needed.
     """
 
     def __init__(self, seqs: list[int]) -> None:

--- a/tests/test_replay_skill_router.py
+++ b/tests/test_replay_skill_router.py
@@ -160,7 +160,7 @@ class FakeRouterHost:
     # --- Memory paths ---
 
     def memory_path(self, layer: str, slug: str) -> str:
-        # Match production ChatSession._memory_path: appends .md.
+        # Match production Session._memory_path: appends .md.
         return f"/memory/{layer}/{slug}.md"
 
     def memory_dir(self, layer: str) -> str:
@@ -734,7 +734,7 @@ async def test_named_skill_direct_invoke_without_list_skills():
 # ---------------------------------------------------------------------------
 #
 # These tests exercise the full chain with `universal_wrappers_enabled=True`:
-#   ChatSession (here: FakeRouterHost) → RouterHostAdapter-equivalent
+#   Session (here: FakeRouterHost) → RouterHostAdapter-equivalent
 #   → RouterLoop reads get_universal_wrappers_enabled() → build_tools
 #   appends list_actions / describe_action / invoke_action → LLM may call
 #   either legacy OR wrapper paths → dispatch routes to host callbacks.

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -1,6 +1,6 @@
-"""Tier 2: ChatSession.reset_for_rewind — pre-rewind in-memory residue clearing.
+"""Tier 2: Session.reset_for_rewind — pre-rewind in-memory residue clearing.
 
-ADR-0038 Stage 1c-2. Real `ChatSession` + `StateLog` (no mocks). The global
+ADR-0038 Stage 1c-2. Real `Session` + `StateLog` (no mocks). The global
 rewind path calls ``reset_for_rewind()`` after ``await_quiescent`` and before
 ``restore_state(reconstructed)``; its clear-scope must EXACTLY mirror
 ``restore_state``'s set-scope so re-adopting the reconstructed snapshot leaves
@@ -14,14 +14,14 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 
 
-def _session(tmp_path: Path, log: StateLog, *, agent: str = "alpha") -> ChatSession:
-    session = ChatSession(
+def _session(tmp_path: Path, log: StateLog, *, agent: str = "alpha") -> Session:
+    session = Session(
         agent_name=agent, state_log=log, snapshot_path=tmp_path / "snap.json",
     )
     session.register_intervention_listener("test")

--- a/tests/test_resume_auto_e2e.py
+++ b/tests/test_resume_auto_e2e.py
@@ -3,7 +3,7 @@
 Headline scenario:
   1. Run 1 of a 2-phase skill draft → review crashes mid-review (per
      ``test_resume_e2e._CrashAfterFirstPhase``).
-  2. ChatSession is restored from disk (snapshot survives because the
+  2. Session is restored from disk (snapshot survives because the
      simulated crash bypassed the ``finally`` cleanup).
   3. ``_auto_resume_active_skills`` is called → discovers the in-flight
      run, applies default policy (retry), and invokes the launcher with
@@ -24,7 +24,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.core.kernel.normalizer import NormalizationResult
 from reyn.core.kernel.runtime import OSRuntime, RunResult
@@ -125,7 +125,7 @@ class _StubResumeRuntime(OSRuntime):
 
 
 def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, monkeypatch):
-    """Tier 3: crashed skill on disk → ChatSession.auto_resume → completes via launcher.
+    """Tier 3: crashed skill on disk → Session.auto_resume → completes via launcher.
 
     The injected launcher mimics what production does (build OSRuntime,
     call run with resume_plan) but with a deterministic stub instead
@@ -156,9 +156,9 @@ def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, mon
     snap_path = skills_dir / f"{_RUN_ID}.snapshot.json"
     snap.save(snap_path)
 
-    # ChatSession with WAL configured (the SkillRegistry derives its
+    # Session with WAL configured (the SkillRegistry derives its
     # state_dir from agent_name, which matches our seed above).
-    session = ChatSession(
+    session = Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
         snapshot_path=tmp_path / "alpha_snapshot.json",

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -6,7 +6,7 @@ hard-failed if the first compaction itself overflowed. axis-1's eager 30K
 trigger masked the gap by keeping the middle small. This wires the real
 mechanism in:
 
-- ``ChatSession._decompose_history_for_retry`` exposes the
+- ``Session._decompose_history_for_retry`` exposes the
   head / raw_middle / tail / summary decomposition retry_loop consumes (the
   structural refactor the prior degraded path's comment punted as "follow-up").
 - The router overflow handler hands that decomposition to ``retry_loop`` so it
@@ -18,7 +18,7 @@ and the session's real engine/learner feed it). retry_loop's shrink mechanics
 are covered by test_pr_n6_compaction_overflow_retry.py (Fake engine); the literal
 except-block → retry_loop invocation is verified live via dogfood (the real
 RouterLoop LLM overflow is not reconstructable in a unit test without the full
-router stack). No mocks — real ChatSession + real CompactionEngine + real
+router stack). No mocks — real Session + real CompactionEngine + real
 retry_loop; ``main_call`` is a retry_loop parameter (a test async fn, as the
 PR-N6 tests use), not a mocked collaborator.
 """
@@ -28,7 +28,7 @@ import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
-from reyn.chat.session import ChatMessage, ChatSession, _RouterUsageShim
+from reyn.chat.session import ChatMessage, Session, _RouterUsageShim
 from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.llm.pricing import TokenUsage
@@ -40,8 +40,8 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
-    """Create a ChatSession with a synthetic T_max controlling effective_trigger.
+def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
+    """Create a Session with a synthetic T_max controlling effective_trigger.
 
     #1128 step 3: slicing is token-budget based (not turn-count).
     ``use_chars4_estimate=True`` makes counting deterministic (chars // 4).
@@ -68,7 +68,7 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
     original = _mb.get_max_input_tokens
     _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]  # noqa: E501
     try:
-        session = ChatSession(
+        session = Session(
             agent_name="default",
             agent_role="",
             output_language="en",
@@ -87,7 +87,7 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
 _TURN_80TOK = "X" * 320
 
 
-def _push(session: ChatSession, role: str, text: str) -> None:
+def _push(session: Session, role: str, text: str) -> None:
     if role == "agent":
         role = "assistant"
     session.history.append(ChatMessage(role=role, content=text, ts=_now()))

--- a/tests/test_router_cap.py
+++ b/tests/test_router_cap.py
@@ -2,7 +2,7 @@
 
 Background: Pre-OSS dogfood S4 Run 3 logged 16 router invocations / 245k
 prompt tokens for a single user paste — runaway loop with no upper bound.
-ChatSession now enforces a configurable cap (default 3) on consecutive
+Session now enforces a configurable cap (default 3) on consecutive
 `skill_router` invocations within one user turn (or one fresh
 agent_request).
 
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.chat.session import RouterCapExceeded, Session
 from reyn.config import LoopConfig, SafetyConfig
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 
@@ -39,20 +39,20 @@ def _make_session(
     tmp_path: Path,
     *,
     cap: int = 3,
-) -> ChatSession:
-    """Construct a minimal ChatSession rooted at `tmp_path`. Workspace and
+) -> Session:
+    """Construct a minimal Session rooted at `tmp_path`. Workspace and
     events dirs are created under `.reyn/` relative to the chdir caller.
     The caller is responsible for chdir-ing into `tmp_path`.
     """
     safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=cap))
-    return ChatSession(
+    return Session(
         agent_name="test_agent",
         budget_tracker=BudgetTracker(CostConfig()),
         safety=safety,
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     msgs = []
     while not session.outbox.empty():
         msgs.append(session.outbox.get_nowait())
@@ -105,7 +105,7 @@ def test_handle_user_message_emits_fallback_when_cap_exhausted(
     # calls _run_router_loop — so to simulate exhaustion we monkeypatch
     # the reset to no-op AND pre-set the counter.
     monkeypatch.setattr(
-        ChatSession, "_reset_router_turn_counter", lambda self: None,
+        Session, "_reset_router_turn_counter", lambda self: None,
     )
     session.router_invocations_this_turn = 3
     session._router_last_reason = "out_of_scope"

--- a/tests/test_router_error_classify.py
+++ b/tests/test_router_error_classify.py
@@ -1,6 +1,6 @@
 """Tier 1: contract test for classify_router_error.
 
-The router-loop catch in ``ChatSession`` previously surfaced raw
+The router-loop catch in ``Session`` previously surfaced raw
 exceptions as ``router failed: <repr>`` — typically a litellm class
 name followed by a multi-line JSON blob, truncated mid-sentence by the
 ErrorBox renderer. This module classifies the common buckets so the

--- a/tests/test_router_loop.py
+++ b/tests/test_router_loop.py
@@ -114,7 +114,7 @@ class FakeRouterHost:
     # --- Memory paths ---
 
     def memory_path(self, layer: str, slug: str) -> str:
-        # Match production ChatSession._memory_path contract: appends .md.
+        # Match production Session._memory_path contract: appends .md.
         return f"/memory/{layer}/{slug}.md"
 
     def memory_dir(self, layer: str) -> str:

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -1,6 +1,6 @@
-"""End-to-end tests: ChatSession + RouterLoop integration (PR35 wave F2).
+"""End-to-end tests: Session + RouterLoop integration (PR35 wave F2).
 
-These tests exercise the full ChatSession → RouterLoopHost → RouterLoop
+These tests exercise the full Session → RouterLoopHost → RouterLoop
 path. call_llm_tools is patched to return scripted results without hitting
 the network.
 """
@@ -10,7 +10,7 @@ import asyncio
 import json
 from pathlib import Path
 
-from reyn.chat.session import ChatSession, _PendingChain
+from reyn.chat.session import Session, _PendingChain
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 
@@ -50,14 +50,14 @@ def _tool_result(calls: list[dict]) -> LLMToolCallResult:
     )
 
 
-def _make_session(tmp_path: Path) -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
         agent_name="test_agent",
         chat_tool_use_scheme="universal-category",  # #1657: suite uses universal-category stub shape
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     msgs = []
     while not session.outbox.empty():
         msgs.append(session.outbox.get_nowait())
@@ -68,11 +68,11 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-class _StubChatSession:
-    """Minimal peer ChatSession stub for delegate_to_agent tests.
+class _StubSession:
+    """Minimal peer Session stub for delegate_to_agent tests.
 
     Records submit_agent_request calls without invoking real session lifecycle.
-    Real ChatSession instantiation pulls in the full agent/event/loop stack;
+    Real Session instantiation pulls in the full agent/event/loop stack;
     a stub is sufficient because the test only verifies the chain registration.
     """
 
@@ -92,7 +92,7 @@ class _StubAgentRegistry:
     test only verifies the chain registration side-effect.
     """
 
-    def __init__(self, target_session: _StubChatSession) -> None:
+    def __init__(self, target_session: _StubSession) -> None:
         self._target = target_session
 
     def iter_reachable_agents(self, self_name: str) -> list[dict]:
@@ -104,7 +104,7 @@ class _StubAgentRegistry:
     def permit(self, from_agent: str, to_agent: str) -> bool:
         return True
 
-    def get_or_load(self, name: str) -> _StubChatSession:
+    def get_or_load(self, name: str) -> _StubSession:
         return self._target
 
     async def ensure_running(self, name: str) -> None:
@@ -116,7 +116,7 @@ class _StubAgentRegistry:
 # ---------------------------------------------------------------------------
 
 def test_user_message_chitchat_e2e(tmp_path, monkeypatch):
-    """Tier 1: ChatSession→RouterLoop integration — user message produces kind=agent outbox entry. AsyncMock isolates from network for e2e path verification.
+    """Tier 1: Session→RouterLoop integration — user message produces kind=agent outbox entry. AsyncMock isolates from network for e2e path verification.
 
     Minimal session: mock call_llm_tools to return text 'hi'.
     User message → router → assert outbox has kind='agent', text='hi'.
@@ -168,7 +168,7 @@ def test_user_message_chitchat_appended_to_history(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
-    """Tier 1: ChatSession→RouterLoop invoke_skill — round 1 spawns skill (FP-0012 non-blocking) and the router exits on spawn-ack. AsyncMock required for the e2e path.
+    """Tier 1: Session→RouterLoop invoke_skill — round 1 spawns skill (FP-0012 non-blocking) and the router exits on spawn-ack. AsyncMock required for the e2e path.
 
     Post-H3-ablation contract (= dogfood B32 §4.2 + H3 ablation diagnosis):
     invoke_skill / invoke_action returning the spawn-ack
@@ -287,10 +287,10 @@ def test_delegate_registers_pending_chain(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     # Stub a registry with a single reachable peer.
-    target_session = _StubChatSession()
+    target_session = _StubSession()
     registry = _StubAgentRegistry(target_session)
 
-    session = ChatSession(
+    session = Session(
         agent_name="test_agent",
         registry=registry,
         chat_tool_use_scheme="universal-category",  # #1657
@@ -336,7 +336,7 @@ def test_delegate_registers_pending_chain(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: RouterLoopHost protocol satisfied by ChatSession
+# Test 4: RouterLoopHost protocol satisfied by Session
 # ---------------------------------------------------------------------------
 
 def test_chatsession_satisfies_host_protocol(tmp_path, monkeypatch):
@@ -375,7 +375,7 @@ def test_resolve_model_uses_resolver(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from reyn.llm.model_resolver import ModelResolver
     resolver = ModelResolver({"router": "openai/gpt-4o-mini"})
-    session = ChatSession(agent_name="test_agent", resolver=resolver)
+    session = Session(agent_name="test_agent", resolver=resolver)
 
     assert session.router_host.resolve_model("router") == "openai/gpt-4o-mini"
     assert session.router_host.resolve_model("unknown") == "unknown"  # pass-through

--- a/tests/test_router_loop_spawn_ack_message.py
+++ b/tests/test_router_loop_spawn_ack_message.py
@@ -7,7 +7,7 @@ user-visible acknowledgment via ``put_outbox(kind="agent")`` to close
 the silence window without re-introducing the LLM-composition race
 that H3 fixed.
 
-The full ``ChatSession→RouterLoop`` spawn-ack contract is covered in
+The full ``Session→RouterLoop`` spawn-ack contract is covered in
 ``test_router_loop_chatsession.test_user_message_invoke_skill_e2e``.
 These tests focus on the OS-message invariants:
 

--- a/tests/test_router_loop_swallow_instrument_187.py
+++ b/tests/test_router_loop_swallow_instrument_187.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 
 
 @pytest.mark.asyncio
@@ -31,7 +31,7 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
     event with the error type + repr so the root error is recoverable from the
     event log even when the outbox only carries a classified summary.
     """
-    s = ChatSession(agent_name="t")
+    s = Session(agent_name="t")
 
     async def _raise_mid_work(text: str, chain_id: str) -> None:
         # Stand-in for the real mid-work crash (final call_llm raising after

--- a/tests/test_router_op_context_single_source_1412.py
+++ b/tests/test_router_op_context_single_source_1412.py
@@ -1,6 +1,6 @@
 """Tier 2: #1412 — the chat-router OpContext is built from a single source.
 
-``ChatSession._make_router_op_context`` and
+``Session._make_router_op_context`` and
 ``RouterHostAdapter.make_router_op_context`` built the
 ``skill_name="chat_router"`` OpContext with ~95% identical code and drifted
 (#1410/#1411 threaded base_dir to one, lagged the other — the #187 wrong-FS
@@ -76,7 +76,7 @@ def test_chat_router_opcontext_built_only_in_factory() -> None:
 
 
 def test_both_hosts_delegate_to_build_router_op_context() -> None:
-    """Tier 2: #1412 — ChatSession and RouterHostAdapter both call
+    """Tier 2: #1412 — Session and RouterHostAdapter both call
     build_router_op_context (positive guard: the chokepoint is used)."""
     for rel in ("chat/session.py", "chat/services/router_host_adapter.py"):
         assert _calls_named(rel, "build_router_op_context") >= 1, (

--- a/tests/test_router_opcontext_basedir_live_187.py
+++ b/tests/test_router_opcontext_basedir_live_187.py
@@ -4,7 +4,7 @@ Follow-up to #1410, which patched the WRONG method. The registry file-op dispatc
 uses ``op_context_factory = getattr(host, "make_router_op_context")``
 (router_loop.py), and the chat host is ``RouterHostAdapter`` — so the LIVE factory
 is ``RouterHostAdapter.make_router_op_context``. #1410 instead patched the parallel
-``ChatSession._make_router_op_context`` (used only by the legacy ``_file_op`` /
+``Session._make_router_op_context`` (used only by the legacy ``_file_op`` /
 ``_mcp_call_tool`` callbacks); the two impls had drifted, and #1410's test was green
 on the legacy seam while live file ops still ran on the host cwd (astropy 0/6).
 
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.environment.container_backend import DockerEnvironmentBackend
 
 
@@ -26,7 +26,7 @@ def test_live_op_context_roots_on_container_repo(tmp_path) -> None:
     the container repo (/testbed) over the docker backend — so file__read/grep/glob/
     edit resolve in-container, not on the host reyn cwd."""
     backend = DockerEnvironmentBackend(container="c1", repo_dir="/testbed")
-    s = ChatSession(
+    s = Session(
         agent_name="t", environment_backend=backend,
         workspace_base_dir=Path("/testbed"), workspace_state_dir=tmp_path,
     )
@@ -45,7 +45,7 @@ def test_live_op_context_host_default_unchanged() -> None:
     """Tier 2: no env-backend / base_dir (host backend / interactive chat) → the live
     factory keeps the host cwd default (the fix only takes effect under a container
     base_dir)."""
-    s = ChatSession(agent_name="t")
+    s = Session(agent_name="t")
     ctx = s._router_host.make_router_op_context()
     assert ctx.workspace.base_dir == Path.cwd()
 
@@ -58,11 +58,11 @@ def test_live_op_context_threads_exec_sandbox_backend(tmp_path) -> None:
     Root: ``sandboxed_exec`` reads ``ctx.sandbox_backend or get_default_backend(...)``;
     the live ``RouterHostAdapter.make_router_op_context`` omitted ``sandbox_backend=``
     on its OpContext → None → host seatbelt → exec hit ``/testbed not found`` → the
-    agent's verify loop always failed. The legacy ``ChatSession._make_router_op_context``
+    agent's verify loop always failed. The legacy ``Session._make_router_op_context``
     passed it; this is the same live-vs-legacy seam gap as #1410/#1411 (3rd instance).
     """
     backend = DockerEnvironmentBackend(container="c1", repo_dir="/testbed")
-    s = ChatSession(
+    s = Session(
         agent_name="t", environment_backend=backend, sandbox_backend=backend,
         workspace_base_dir=Path("/testbed"), workspace_state_dir=tmp_path,
     )
@@ -76,6 +76,6 @@ def test_live_op_context_threads_exec_sandbox_backend(tmp_path) -> None:
 def test_live_op_context_no_sandbox_backend_default_unchanged() -> None:
     """Tier 2: no sandbox_backend → ctx.sandbox_backend is None → ``sandboxed_exec``
     falls back to the host default backend (host / interactive behavior unchanged)."""
-    s = ChatSession(agent_name="t")
+    s = Session(agent_name="t")
     ctx = s._router_host.make_router_op_context()
     assert ctx.sandbox_backend is None

--- a/tests/test_run_id_propagation_chat_to_agent.py
+++ b/tests/test_run_id_propagation_chat_to_agent.py
@@ -2,7 +2,7 @@
 
 FP-0008 PR-R (= tui-coder finding #1 propagation layer; PR-N
 canonical-form follow-up). PR-N landed the canonical run_id form in
-`skill_runner.spawn`, but ChatSession's `_build_agent_for_skill_runner`
+`skill_runner.spawn`, but Session's `_build_agent_for_skill_runner`
 received the run_id only for `ChatInterventionBus` and did NOT forward
 it to `_build_agent`. The Agent instance therefore had `self.run_id =
 None` at construction; `agent.run()` then generated a fresh canonical
@@ -13,8 +13,8 @@ via `_make_run_id`, producing a 2-form mismatch:
   skill events.jsonl:     20260528T122441357899Z_word_stats_demo_a197  (different microsec)
 
 The fix threads run_id through:
-  ChatSession._build_agent_for_skill_runner(run_id, ...)
-    → ChatSession._build_agent(run_id=..., ...)
+  Session._build_agent_for_skill_runner(run_id, ...)
+    → Session._build_agent(run_id=..., ...)
       → SkillRuntime(run_id=..., ...) ctor (= sets self.run_id)
         → agent.run() honors self.run_id (= no fresh _make_run_id)
 
@@ -210,7 +210,7 @@ async def test_agent_run_falls_back_to_make_run_id_when_none() -> None:
 
 
 def test_build_agent_for_skill_runner_threads_run_id_to_build_agent() -> None:
-    """Tier 2: source-level audit — ChatSession._build_agent_for_skill_runner passes run_id.
+    """Tier 2: source-level audit — Session._build_agent_for_skill_runner passes run_id.
 
     Catches future regression where _build_agent_for_skill_runner stops
     forwarding run_id to _build_agent (= the exact PR-R defect).

--- a/tests/test_run_once_187.py
+++ b/tests/test_run_once_187.py
@@ -220,10 +220,10 @@ def test_fresh_one_shot_does_not_load_persisted_history(tmp_path, monkeypatch) -
     `load_history()` call below demonstrates (empty → 2)."""
     import json
 
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
     monkeypatch.chdir(tmp_path)  # workspace_dir (.reyn/agents/<name>) is cwd-relative
-    s = ChatSession(agent_name="default")
+    s = Session(agent_name="default")
     # a contaminated persisted history (unrelated prior conversation)
     s.history_path.parent.mkdir(parents=True, exist_ok=True)
     with s.history_path.open("w", encoding="utf-8") as f:

--- a/tests/test_run_registry_persist.py
+++ b/tests/test_run_registry_persist.py
@@ -96,7 +96,7 @@ def test_restore_from_existing_snapshot_repopulates_runs(tmp_path: Path) -> None
     registry_a = RunRegistry(persist_path=persist_path)
     entry = registry_a.create(agent_name="demo", chain_id="chain-A")
     # issue #292 (α): ``question`` field removed — iv state owned by
-    # ChatSession. We only mirror the public ``status`` on RunEntry.
+    # Session. We only mirror the public ``status`` on RunEntry.
     registry_a.update(entry.run_id, status="input-required")
     registry_a.append_event(entry.run_id, {"type": "phase", "name": "greet"})
 
@@ -152,19 +152,19 @@ def test_restored_pending_intervention_has_fresh_future(tmp_path: Path) -> None:
     registry_a = RunRegistry(persist_path=persist_path)
     entry = registry_a.create(agent_name="demo", chain_id="chain-A")
 
-    # issue #292 (α): iv state lives in ChatSession, not RunRegistry.
+    # issue #292 (α): iv state lives in Session, not RunRegistry.
     # Restart simulation just mirrors the public status; iv restore is
     # tested in tests/test_intervention_restore.py via AgentSnapshot.
     registry_a.update(entry.run_id, status="input-required")
 
     # Restart: restored RunEntry has the status mirror; iv state is
-    # restored separately by ChatSession's snapshot path.
+    # restored separately by Session's snapshot path.
     registry_b = RunRegistry(persist_path=persist_path)
     restored = registry_b.get(entry.run_id)
     assert restored is not None
     assert restored.status == "input-required"
     # α: RunEntry no longer carries pending_intervention. iv lives in
-    # ChatSession's AgentSnapshot.outstanding_interventions.
+    # Session's AgentSnapshot.outstanding_interventions.
     assert not hasattr(restored, "pending_intervention")
 
 
@@ -226,7 +226,7 @@ def test_remove_drops_entry_from_snapshot(tmp_path: Path) -> None:
 def test_answer_status_mirror_persists(tmp_path: Path) -> None:
     """Tier 2: post-α, ``answer_intervention`` is removed from
     RunRegistry. The peer-answer flow lives in
-    ``_handle_answer_injection`` → ``ChatSession.answer_pending_intervention``.
+    ``_handle_answer_injection`` → ``Session.answer_pending_intervention``.
     The RunRegistry only mirrors the public ``status`` back to
     ``"running"`` after the answer is delivered. Pin the status
     transition persists correctly.

--- a/tests/test_safety_phase2_wiring.py
+++ b/tests/test_safety_phase2_wiring.py
@@ -8,7 +8,7 @@ LLM, no real workspace) and verify both the legacy abort path
 
 Sites covered here:
   - B (max_phase_visits) — ``OSRuntime._enter_phase``
-  - C (router_cap)        — ``ChatSession._check_and_increment_router_cap``
+  - C (router_cap)        — ``Session._check_and_increment_router_cap``
 
 The remaining sites (F phase_seconds, A max_act_turns, E max_hop_depth,
 G chain_seconds) share the same helper and are exercised indirectly
@@ -22,7 +22,7 @@ import asyncio
 
 import pytest
 
-from reyn.chat.session import ChatSession, RouterCapExceeded
+from reyn.chat.session import RouterCapExceeded, Session
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.core.kernel.runtime import LoopLimitExceededError, OSRuntime
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -98,15 +98,15 @@ async def test_os_max_phase_visits_auto_extend_grants_then_aborts() -> None:
         await rt._enter_phase("greet", {"type": "greet_in", "data": {}})
 
 
-# ─── C (router_cap) — ChatSession._check_and_increment_router_cap ──────
+# ─── C (router_cap) — Session._check_and_increment_router_cap ──────
 
 
-def _make_session(*, cap: int, on_limit: OnLimitConfig) -> ChatSession:
+def _make_session(*, cap: int, on_limit: OnLimitConfig) -> Session:
     safety = SafetyConfig(
         loop=LoopConfig(max_router_calls_per_turn=cap),
         on_limit=on_limit,
     )
-    return ChatSession(
+    return Session(
         agent_name="test_agent",
         budget_tracker=BudgetTracker(CostConfig()),
         safety=safety,
@@ -159,16 +159,16 @@ def test_router_cap_auto_extend_grants_then_aborts(
         asyncio.run(session._check_and_increment_router_cap("d"))
 
 
-# ─── ChatSession threads on_limit through the constructor ─────────────
+# ─── Session threads on_limit through the constructor ─────────────
 
 
 def test_chatsession_default_on_limit_is_interactive() -> None:
-    """Tier 2: a ChatSession without an explicit ``safety`` argument
+    """Tier 2: a Session without an explicit ``safety`` argument
     defaults to ``interactive`` on_limit so a TUI / a2a run holds open
     for a user reply rather than silently discarding mid-run state.
     See ``OnLimitConfig`` docstring for the headless safety story.
     """
-    s = ChatSession(agent_name="t")
+    s = Session(agent_name="t")
     assert s.on_limit.mode == "interactive"
 
 
@@ -179,7 +179,7 @@ def test_chatsession_threads_on_limit_through_constructor() -> None:
     which passes ``config.safety`` from the loaded ReynConfig.
     """
     on_limit = OnLimitConfig(mode="interactive", auto_extend_times=5)
-    s = ChatSession(agent_name="t", safety=SafetyConfig(on_limit=on_limit))
+    s = Session(agent_name="t", safety=SafetyConfig(on_limit=on_limit))
     assert s.on_limit is on_limit
     assert s.on_limit.mode == "interactive"
     assert s.on_limit.auto_extend_times == 5

--- a/tests/test_sandbox_model_completion_1339.py
+++ b/tests/test_sandbox_model_completion_1339.py
@@ -5,7 +5,7 @@ TOOL exposes only argv(+timeout) so the LLM cannot set sandbox axes; (C') the
 handler's started event shows the ENFORCED policy network (not the op's request);
 (B) both chat OpContext factories resolve a concrete default_sandbox_policy (was
 None → the op-fields fallback = the sandbox-escape gap). permission layer
-unchanged. No mocks — real ChatSession / adapter / op_runtime handler.
+unchanged. No mocks — real Session / adapter / op_runtime handler.
 """
 from __future__ import annotations
 
@@ -97,12 +97,12 @@ async def test_handler_event_shows_enforced_policy_network(tmp_path):
 
 
 def test_chat_session_factory_resolves_concrete_policy(tmp_path):
-    """Tier 2: #1339 reproduce-first —the ChatSession router OpContext carries a
+    """Tier 2: #1339 reproduce-first —the Session router OpContext carries a
     concrete default_sandbox_policy (was None → op-fields fallback = the gap)."""
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
 
-    session = ChatSession(
+    session = Session(
         agent_name="b",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -1,7 +1,7 @@
-"""Tier 2: #1402 — scoped ChatSession construction is single-sourced (src-wide).
+"""Tier 2: #1402 — scoped Session construction is single-sourced (src-wide).
 
 Multiple frontends (chat-CLI / web-deps A2A / mcp-serve / dogfood / chainlit)
-built a ChatSession with overlapping-but-divergent scoped wiring. A scoped
+built a Session with overlapping-but-divergent scoped wiring. A scoped
 capability hand-added to one factory silently leaked from the others — the
 forwarding-gap class (sibling to base_dir #1410 / permission-zone #1415 /
 exec-seam #1419 / empty-stop #1424). (The issue named "3 factories"; a flow-trace
@@ -12,11 +12,11 @@ whose scoped params are required (completeness-by-construction).
 This is a PERMANENT drift guard (not scaffold), and it is **src-WIDE**: it
 subsumes (strictly stronger) the former per-config uniformity point-tests
 (test_session_factory_{sandbox,multimodal}_config_uniform), which checked
-"every known ChatSession() call site passes config X / no unknown call sites".
+"every known Session() call site passes config X / no unknown call sites".
 
 Pinned invariants:
 
-- ``ChatSession(...)`` is constructed ONLY in ``chat/scoped_session_factory.py``
+- ``Session(...)`` is constructed ONLY in ``chat/scoped_session_factory.py``
   anywhere in ``src/reyn`` — every other module routes through
   ``build_scoped_chat_session`` (falsifiable: a new/unmigrated/HIDDEN
   construction site anywhere in src/ fails this, naming file:line; this is what
@@ -39,7 +39,7 @@ from reyn.chat.scoped_session_factory import build_scoped_chat_session
 
 _SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
 
-# The ONE module allowed to construct ChatSession directly.
+# The ONE module allowed to construct Session directly.
 _FACTORY_REL = "chat/scoped_session_factory.py"
 
 # The drift surface: scoped capability + per-session config params that MUST stay
@@ -76,14 +76,14 @@ def _chatsession_call_sites() -> list[str]:
             if (
                 isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Name)
-                and node.func.id == "ChatSession"
+                and node.func.id == "Session"
             ):
                 sites.append(f"{rel}:{node.lineno}")
     return sites
 
 
 def test_chatsession_constructed_only_in_scoped_factory() -> None:
-    """Tier 2: #1402 — within src/reyn, ``ChatSession(...)`` is constructed ONLY
+    """Tier 2: #1402 — within src/reyn, ``Session(...)`` is constructed ONLY
     in scoped_session_factory.py; every frontend routes through
     build_scoped_chat_session so a new scoped capability reaches every path by
     construction. Strictly stronger than the former per-config uniformity
@@ -91,7 +91,7 @@ def test_chatsession_constructed_only_in_scoped_factory() -> None:
     src/ fails this, naming file:line."""
     offenders = [s for s in _chatsession_call_sites() if not s.startswith(_FACTORY_REL + ":")]
     assert not offenders, (
-        "ChatSession(...) constructed outside chat/scoped_session_factory.py — "
+        "Session(...) constructed outside chat/scoped_session_factory.py — "
         "re-opens the #1402 drift class; route through build_scoped_chat_session: "
         f"{offenders}"
     )
@@ -99,10 +99,10 @@ def test_chatsession_constructed_only_in_scoped_factory() -> None:
 
 def test_scoped_factory_is_the_sole_constructor() -> None:
     """Tier 2: #1402 — positive guard: scoped_session_factory.py DOES construct
-    ChatSession (the chokepoint exists and is used, not merely imported)."""
+    Session (the chokepoint exists and is used, not merely imported)."""
     factory_sites = [s for s in _chatsession_call_sites() if s.startswith(_FACTORY_REL + ":")]
     assert factory_sites, (
-        "scoped_session_factory.py must construct ChatSession (the single "
+        "scoped_session_factory.py must construct Session (the single "
         "chokepoint) — none found"
     )
 

--- a/tests/test_session_auto_resume.py
+++ b/tests/test_session_auto_resume.py
@@ -1,4 +1,4 @@
-"""Tier 2: OS invariant — ChatSession startup auto-resume hook.
+"""Tier 2: OS invariant — Session startup auto-resume hook.
 
 After ``restore_state`` rehydrates the agent's snapshot + WAL, the
 session must auto-launch resume tasks for every active skill run.
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.skill.skill_resume_coordinator import (
     ResumeDecision,
@@ -33,8 +33,8 @@ from reyn.skill.skill_resume_coordinator import (
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",

--- a/tests/test_session_cost_accumulation.py
+++ b/tests/test_session_cost_accumulation.py
@@ -5,7 +5,7 @@ Two fixes tested here:
          (e.g. "openai/gemini-2.5-flash-lite") which litellm.model_cost
          does not recognise, so cost stayed 0.0 forever.
   Bug 2: RouterLoop.run() returned None, so the router's LLM call usage
-         never reached ChatSession._total_usage / _total_cost_usd.
+         never reached Session._total_usage / _total_cost_usd.
 
 Policy: no MagicMock on collaborators — use real RouterLoop + fake host,
 and real estimate_cost with a fake model_cost entry.
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 
 from reyn.chat.router_loop import RouterLoop
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage, estimate_cost
 
@@ -147,10 +147,10 @@ def test_router_loop_total_usage_propagates_to_session(tmp_path, monkeypatch):
     """Tier 2: after a chat turn hitting RouterLoop, session.total_usage.prompt_tokens > 0.
 
     Verifies Bug 2 fix: RouterLoop.run() now returns the accumulated
-    TokenUsage and _run_router_loop credits it to ChatSession._total_usage.
+    TokenUsage and _run_router_loop credits it to Session._total_usage.
     """
     monkeypatch.chdir(tmp_path)
-    session = ChatSession(agent_name="test_agent")
+    session = Session(agent_name="test_agent")
 
     async def _stub_call_llm_tools(**kwargs):
         return _text_result("こんにちは")

--- a/tests/test_session_dispatch_attribution.py
+++ b/tests/test_session_dispatch_attribution.py
@@ -1,4 +1,4 @@
-"""Tier 2: ChatSession dispatch attribution — FP-0041 (#489) PR-A.
+"""Tier 2: Session dispatch attribution — FP-0041 (#489) PR-A.
 
 Humanic multi-consumer model foundation: when a different consumer
 addresses the agent on the same session inbox (= sender transition),
@@ -36,28 +36,28 @@ import pytest
 
 from reyn.chat.session import (
     ChatMessage,
-    ChatSession,
+    Session,
     _format_sender_label,
 )
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / f"{agent_name}.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _state_changes(session: ChatSession) -> list[ChatMessage]:
+def _state_changes(session: Session) -> list[ChatMessage]:
     return [
         m for m in session.history
         if m.role == "system" and (m.meta or {}).get("kind") == "state_change"
     ]
 
 
-def _attribution_entries(session: ChatSession) -> list[ChatMessage]:
+def _attribution_entries(session: Session) -> list[ChatMessage]:
     """state_change entries minted specifically by dispatch attribution."""
     return [
         m for m in _state_changes(session)

--- a/tests/test_session_intervention_persistence.py
+++ b/tests/test_session_intervention_persistence.py
@@ -1,4 +1,4 @@
-"""Tier 2: ChatSession invariant — intervention dispatch/resolve hits the WAL.
+"""Tier 2: Session invariant — intervention dispatch/resolve hits the WAL.
 
 PR-intervention-link L3. The session-level wrappers
 ``_dispatch_intervention`` / ``_deliver_answer_to`` /
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.user_intervention import (
     InterventionChoice,
@@ -34,15 +34,15 @@ from reyn.user_intervention import (
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via public kwargs.
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a Session redirected to ``tmp_path`` via public kwargs.
 
     issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire — these
     tests dispatch interventions and verify WAL persistence, treating the
     test itself as the listener that will resolve via ``deliver_answer``.
     """
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -1,8 +1,8 @@
-"""Tier 2: OS invariant tests for ChatSession (chain mgmt + intervention + WAL/snapshot).
+"""Tier 2: OS invariant tests for Session (chain mgmt + intervention + WAL/snapshot).
 
 Re-encodes the invariants formerly pinned by `tests/scaffold/test_chain_manager.py`
 and `tests/scaffold/test_intervention_registry.py` (Tier 4 — Mock + private
-state) at the ChatSession public surface (Tier 2). The scaffold files are
+state) at the Session public surface (Tier 2). The scaffold files are
 removed in the same PR that lands these tests.
 
 Policy compliance (`docs/deep-dives/contributing/testing.ja.md`):
@@ -31,7 +31,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import OnLimitConfig, SafetyConfig, TimeoutConfig
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
@@ -100,7 +100,7 @@ class _FakeRegistry:
         self.sent_requests: list[dict] = []
         self.sent_responses: list[dict] = []
 
-    def register(self, name: str, session: "ChatSession") -> None:
+    def register(self, name: str, session: "Session") -> None:
         self._targets[name] = session
 
     def exists(self, name: str) -> bool:
@@ -116,7 +116,7 @@ class _FakeRegistry:
             if n != self_name
         ]
 
-    def get_or_load(self, name: str) -> "ChatSession":
+    def get_or_load(self, name: str) -> "Session":
         return self._targets[name]
 
     async def ensure_running(self, name: str) -> None:
@@ -130,8 +130,8 @@ def _make_session(
     chain_timeout_seconds: float = 60.0,
     registry: _FakeRegistry | None = None,
     on_limit: OnLimitConfig | None = None,
-) -> ChatSession:
-    """Build a ChatSession with WAL + per-test snapshot path via public kwargs.
+) -> Session:
+    """Build a Session with WAL + per-test snapshot path via public kwargs.
 
     issue #254 Phase 1: register a placeholder listener so the registry's
     ``enforce_listener_presence=True`` short-circuit does not fire — these
@@ -148,7 +148,7 @@ def _make_session(
     if on_limit is not None:
         safety_kwargs["on_limit"] = on_limit
     safety = SafetyConfig(**safety_kwargs)
-    session = ChatSession(
+    session = Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         safety=safety,
@@ -173,7 +173,7 @@ def _wal_events(tmp_path: Path) -> list[dict]:
     return list(log.iter_from(0))
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     msgs = []
     while not session.outbox.empty():
         msgs.append(session.outbox.get_nowait())
@@ -224,7 +224,7 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     registry = _FakeRegistry()
-    peer_session = ChatSession(agent_name="peer_agent")
+    peer_session = Session(agent_name="peer_agent")
     registry.register("peer_agent", peer_session)
 
     session = _make_session(tmp_path, registry=registry,
@@ -283,7 +283,7 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     monkeypatch.chdir(tmp_path)
 
     # Peer session: receives agent_request from us, we feed agent_response back.
-    peer_session = ChatSession(agent_name="peer_agent")
+    peer_session = Session(agent_name="peer_agent")
     registry = _FakeRegistry()
     registry.register("peer_agent", peer_session)
 
@@ -350,7 +350,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     monkeypatch.chdir(tmp_path)
 
     # upstream_session receives the error agent_response.
-    upstream_session = ChatSession(agent_name="upstream_agent")
+    upstream_session = Session(agent_name="upstream_agent")
     upstream_received: list[dict] = []
 
     async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
@@ -365,7 +365,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     registry = _FakeRegistry()
     registry.register("upstream_agent", upstream_session)
     # Also add a peer so delegation succeeds.
-    peer_session = ChatSession(agent_name="slow_peer")
+    peer_session = Session(agent_name="slow_peer")
     registry.register("slow_peer", peer_session)
 
     # Short timeout so it fires fast. Use unattended mode so the chain
@@ -429,7 +429,7 @@ async def test_restore_reconstructs_chains_and_inbox_from_snapshot(tmp_path, mon
     """Tier 2: restore_state() re-populates inbox queue and re-arms chain from snapshot.
 
     Scenario: build a pre-populated AgentSnapshot with one pending chain and
-    one inbox message → construct a fresh ChatSession → call restore_state().
+    one inbox message → construct a fresh Session → call restore_state().
 
     P5 invariant: workspace is the single source of truth; restoration must
     reconstruct in-memory state faithfully from the persisted snapshot.
@@ -870,7 +870,7 @@ async def test_agent_request_empty_router_reply_sends_marker_upstream(
     """
     monkeypatch.chdir(tmp_path)
 
-    upstream_session = ChatSession(agent_name="origin_agent")
+    upstream_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
     async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
@@ -893,7 +893,7 @@ async def test_agent_request_empty_router_reply_sends_marker_upstream(
     # LLM returns empty content (finish_reason="stop", content="").
     # With ADR-0021 Option F, RouterLoop detects this as empty-stop and
     # emits a failure message to the outbox (kind="agent", non-empty text).
-    # ChatSession's capture filter picks it up → agent_replies non-empty
+    # Session's capture filter picks it up → agent_replies non-empty
     # → failure message forwarded upstream (not the no-reply marker).
     stub = _make_llm_stub(_text_result(""))
     monkeypatch.setattr("reyn.chat.router_loop.call_llm_tools", stub)
@@ -936,7 +936,7 @@ async def test_agent_request_router_cap_exhausted_sends_marker_upstream(
     """
     monkeypatch.chdir(tmp_path)
 
-    upstream_session = ChatSession(agent_name="origin_agent")
+    upstream_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
     async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
@@ -1071,7 +1071,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     from reyn.chat.session import _no_reply_marker
 
     # Set up upstream origin agent to capture the forwarded response.
-    origin_session = ChatSession(agent_name="origin_agent")
+    origin_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
     async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):

--- a/tests/test_session_notify_state_change.py
+++ b/tests/test_session_notify_state_change.py
@@ -1,4 +1,4 @@
-"""Tier 2: ``ChatSession.notify_state_change`` — first-class state-change
+"""Tier 2: ``Session.notify_state_change`` — first-class state-change
 history entries (#398 v4 frozen contract, 2026-05-22).
 
 Pins the API + storage shape that #398 lands. The contract:
@@ -27,20 +27,20 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.session import ChatMessage, Session
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a minimal ChatSession redirected to ``tmp_path``."""
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a minimal Session redirected to ``tmp_path``."""
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _state_change_entries(session: ChatSession) -> list[ChatMessage]:
+def _state_change_entries(session: Session) -> list[ChatMessage]:
     """Return all history entries that look like state-change events."""
     return [
         m for m in session.history

--- a/tests/test_session_refresh_mcp_servers.py
+++ b/tests/test_session_refresh_mcp_servers.py
@@ -1,6 +1,6 @@
-"""Tier 2: ChatSession.refresh_mcp_servers() — FP-0037 S3 programmatic API.
+"""Tier 2: Session.refresh_mcp_servers() — FP-0037 S3 programmatic API.
 
-Pins the contract for the new public coroutine on ChatSession:
+Pins the contract for the new public coroutine on Session:
   - Calls the 3-step turn-boundary chain (yaml-watch → disk-reload → ensure-cached).
     Ordering is verified via observable effects on the disk-reload path:
     a disk cache written between calls is visible on the next refresh.
@@ -14,7 +14,7 @@ Pins the contract for the new public coroutine on ChatSession:
 No unittest.mock / AsyncMock / MagicMock / patch.
 Private-state access: NONE.  Observable surfaces used:
   - refresh_mcp_servers() return dict (primary observable)
-  - router_host (public ChatSession property)
+  - router_host (public Session property)
   - mcp_tools_cache_snapshot (public RouterHostAdapter property, S1)
 
 All tests chdir to tmp_path so the adapter's default state_dir
@@ -29,11 +29,11 @@ from pathlib import Path
 import pytest
 
 from reyn.chat.services.mcp_cache_file import cache_file_path, write_cache
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 # ---------------------------------------------------------------------------
-# Minimal ChatSession factory
+# Minimal Session factory
 # ---------------------------------------------------------------------------
 
 
@@ -42,15 +42,15 @@ def _make_session(
     *,
     agent_name: str = "s3-test-agent",
     mcp_servers: dict | None = None,
-) -> ChatSession:
-    """Build a minimal ChatSession suitable for refresh_mcp_servers tests.
+) -> Session:
+    """Build a minimal Session suitable for refresh_mcp_servers tests.
 
     WAL + snapshot redirect to tmp_path so tests do not write to the
     real .reyn/ directory.  All tests chdir to tmp_path before calling
     this so the session's default state_dir (``cwd / .reyn / state``)
     resolves inside tmp_path.
     """
-    return ChatSession(
+    return Session(
         agent_name=agent_name,
         mcp_servers=mcp_servers,
         state_log=StateLog(tmp_path / "state.wal"),

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -1,4 +1,4 @@
-"""Tier 2: ChatSession._build_history_for_router token-budget slicing correctness.
+"""Tier 2: Session._build_history_for_router token-budget slicing correctness.
 
 #1128 step 3 (Fork B): elide threshold now coincides with effective_trigger
 (the existing pre-frame compaction trigger) instead of the old turn-count
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import reyn.llm.model_budget as _mb
-from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.session import ChatMessage, Session
 from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -46,8 +46,8 @@ def _synthetic_t_max(t_max: int):
         _mb.get_max_input_tokens = original
 
 
-def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
-    """Create a ChatSession whose compaction engine uses a synthetic T_max.
+def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
+    """Create a Session whose compaction engine uses a synthetic T_max.
 
     ``use_chars4_estimate=True`` makes token estimation deterministic:
     each character counts as 1/4 token.
@@ -64,9 +64,9 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
         use_chars4_estimate=True,  # deterministic: chars // 4
         section_caps_spec_tokens=0,  # keeps B_M positive for small T_max values
     )
-    # Monkeypatch covers the engine's compute_budgets() call at ChatSession init.
+    # Monkeypatch covers the engine's compute_budgets() call at Session init.
     with _synthetic_t_max(t_max):
-        return ChatSession(
+        return Session(
             agent_name="default",
             agent_role="",
             output_language="en",
@@ -77,7 +77,7 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> ChatSession:
         )
 
 
-def _push(session: ChatSession, role: str, text: str) -> None:
+def _push(session: Session, role: str, text: str) -> None:
     if role == "agent":
         role = "assistant"
     session.history.append(ChatMessage(role=role, content=text, ts=_now()))

--- a/tests/test_session_shutdown_acompletion_warning.py
+++ b/tests/test_session_shutdown_acompletion_warning.py
@@ -17,7 +17,7 @@ acompletion``::
 The thread-pool ``completion()`` builds and returns an
 ``OpenAIChatCompletion.acompletion(...)`` coroutine when ``acompletion=True``
 (see ``openai.py:706``); the outer ``await init_response`` is the only point
-that consumes it. When ``ChatSession._drain_on_shutdown`` forces
+that consumes it. When ``Session._drain_on_shutdown`` forces
 ``SkillRunner.cancel_all()`` while a skill's LLM call is at that checkpoint,
 ``CancelledError`` lands BEFORE ``await init_response`` is entered, the inner
 coroutine is GC'd unawaited, and Python emits ::
@@ -62,7 +62,7 @@ def _make_unawaited_coro() -> None:
 
 
 def _shutdown_warning_filter():
-    """Mirror the filter installed by ``ChatSession._drain_on_shutdown``.
+    """Mirror the filter installed by ``Session._drain_on_shutdown``.
 
     Kept in lockstep with ``src/reyn/chat/session.py`` so a future tweak to
     the production filter is forced to update this test (= the assertion
@@ -172,20 +172,20 @@ def test_shutdown_filter_does_not_swallow_unrelated_warnings():
 
 
 def test_drain_on_shutdown_does_not_leak_warning(tmp_path, monkeypatch):
-    """Tier 2: end-to-end — ChatSession._drain_on_shutdown swallows the warning.
+    """Tier 2: end-to-end — Session._drain_on_shutdown swallows the warning.
 
     Integrates the filter into the actual production code path: builds a
-    real ChatSession, monkeypatches ``SkillRunner.cancel_all`` to provoke
+    real Session, monkeypatches ``SkillRunner.cancel_all`` to provoke
     the unawaited-coroutine pattern WHILE the filter window is active
     (mirrors what the litellm executor race does inside cancel_all's await
     chain), and asserts no warning leaks out.
     """
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
 
     monkeypatch.chdir(tmp_path)
 
-    session = ChatSession(
+    session = Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "alpha_snapshot.json",

--- a/tests/test_session_skill_registry_integration.py
+++ b/tests/test_session_skill_registry_integration.py
@@ -1,4 +1,4 @@
-"""Tier 2: OS invariant — ChatSession lazily constructs and configures a per-agent SkillRegistry.
+"""Tier 2: OS invariant — Session lazily constructs and configures a per-agent SkillRegistry.
 
 The session is the layer that owns the production wiring:
   - state_log → SkillRegistry (so step events land in the right WAL)
@@ -12,10 +12,10 @@ them a correctly-wired SkillRegistry. A wiring regression would silently
 disable resume.
 
 Observation flows through:
-  - ChatSession.get_skill_registry() return value type
+  - Session.get_skill_registry() return value type
   - The returned registry's behavior when its lifecycle methods are called
     (does start() append to the WAL? does the hook fire?)
-No mocks — real ChatSession with no LLM (we never call _run_skill_awaitable),
+No mocks — real Session with no LLM (we never call _run_skill_awaitable),
 real StateLog.
 """
 from __future__ import annotations
@@ -23,13 +23,13 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 from reyn.skill.skill_registry import SkillRegistry
 
 
 def _make_session(tmp_path: Path, *, with_state_log: bool, with_registry: bool):
-    """Construct a ChatSession with optional state_log + registry back-ref."""
+    """Construct a Session with optional state_log + registry back-ref."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl") if with_state_log else None
     registry = None
     if with_registry:
@@ -44,7 +44,7 @@ def _make_session(tmp_path: Path, *, with_state_log: bool, with_registry: bool):
             session_factory=_no_factory,
             state_log=state_log,
         )
-    return ChatSession(
+    return Session(
         agent_name="alpha",
         state_log=state_log,
         registry=registry,
@@ -116,7 +116,7 @@ def test_truncate_hook_unwired_without_registry(tmp_path, monkeypatch):
     """Tier 2: with registry=None (test fixtures), the SkillRegistry's truncate hook is None — no truncation triggered.
 
     Production tests that need truncation triggered must instantiate an
-    AgentRegistry; bare ChatSession unit tests get a no-trigger registry.
+    AgentRegistry; bare Session unit tests get a no-trigger registry.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, with_state_log=True, with_registry=False)
@@ -128,7 +128,7 @@ def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
     """Tier 2: with registry set, the hook bridges to AgentRegistry.truncate_wal_if_eligible.
 
     PR-N7 (FP-0008): the floor calc reads in-memory session state via
-    ``ChatSession.iter_applied_seqs``. The session must be registered
+    ``Session.iter_applied_seqs``. The session must be registered
     in ``AgentRegistry._agents`` so the floor walk picks it up; the
     on-disk profile is created so ``list_names`` reflects the agent
     (some unrelated paths rely on that).
@@ -136,7 +136,7 @@ def test_truncate_hook_wired_with_registry(tmp_path, monkeypatch):
     Verified end-to-end: register the live session into AgentRegistry,
     call ``advance_phase`` → SkillRegistry's in-memory snapshot bumps
     ``last_phase_applied_seq`` → hook fires →
-    ``ChatSession.iter_applied_seqs`` yields a non-zero watermark via
+    ``Session.iter_applied_seqs`` yields a non-zero watermark via
     the skill_registry pass-through → AgentRegistry executes a real
     truncation pass. Observable signal is the throttle stamp, which is
     set only when truncation actually attempts a rewrite (floor > 0).

--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -38,7 +38,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import SafetyConfig, TimeoutConfig
 from reyn.core.events.state_log import StateLog
 from reyn.core.kernel.normalizer import NormalizationResult
@@ -205,18 +205,18 @@ class _FinishRuntime(OSRuntime):
 
 def _make_registry_with_two_agents(
     tmp_path: Path,
-) -> tuple[AgentRegistry, ChatSession, ChatSession, StateLog]:
-    """Build a registry holding two real ChatSessions named 'a' and 'b'.
+) -> tuple[AgentRegistry, Session, Session, StateLog]:
+    """Build a registry holding two real Sessions named 'a' and 'b'.
 
     Both sessions share the same StateLog. The registry's _agents dict is
     populated by calling get_or_load for each name.
     """
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             state_log=state_log,
             snapshot_path=agent_dir / "state" / "snapshot.json",
@@ -368,10 +368,10 @@ def test_postprocessor_mid_run_chain_timeout_fires(
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             state_log=state_log,
             snapshot_path=agent_dir / "state" / "snapshot.json",

--- a/tests/test_skill_resume_applier.py
+++ b/tests/test_skill_resume_applier.py
@@ -1,7 +1,7 @@
 """Tier 2: OS invariant — SkillResumeCoordinator.apply_decisions.
 
 Background: ``decide_for_plan`` returns ``ResumeDecision`` per active
-skill run. The runtime layer (ChatSession startup) needs to consume
+skill run. The runtime layer (Session startup) needs to consume
 these decisions:
   - ``discard`` → call ``SkillRegistry.complete(status='discarded')``
     + drop pending interventions for the run_id

--- a/tests/test_skill_slash_command.py
+++ b/tests/test_skill_slash_command.py
@@ -21,22 +21,22 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path`` via the public
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a Session redirected to ``tmp_path`` via the public
     ``snapshot_path`` constructor kwarg.
     """
-    return ChatSession(
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_skills_slash_command.py
+++ b/tests/test_skills_slash_command.py
@@ -16,20 +16,20 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    """Build a ChatSession redirected to ``tmp_path``."""
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    """Build a Session redirected to ``tmp_path``."""
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -33,12 +33,12 @@ class _FakeSession:
     def __init__(self, registry, *, agent_name: str = "default", agent_role: str = "") -> None:
         self._registry = registry
         self.agent_name = agent_name
-        # Mirror the real ChatSession's surface: ``_agent_role`` is the
+        # Mirror the real Session's surface: ``_agent_role`` is the
         # mutable backing field (production code writes here), and
         # ``agent_role`` is the public read-only accessor (tests assert
         # through this). Keep the two-attribute shape so the slash
         # handler's ``session._agent_role = ...`` works against the fake
-        # exactly as it does against ChatSession.
+        # exactly as it does against Session.
         self._agent_role = agent_role
         self.outbox_calls: list[OutboxMessage] = []
 

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -6,7 +6,7 @@ dead-end (the LLM `compact` op + the retry_loop backstop being the other routes)
 via the same `force_compact_now` wrapper the compact op uses (`_compact_now_for_op`),
 and reports freed tokens + the free window afterwards.
 
-Real instances, no mocks: a real ChatSession with a real CompactionController/
+Real instances, no mocks: a real Session with a real CompactionController/
 engine; only `litellm.acompletion` (the compaction LLM call) is monkeypatched to a
 plain async callable returning a scripted summary. Verifies the slash actually
 fires compaction and reports the freed tokens — not LLM behavior.
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 
 import litellm
 
-from reyn.chat.session import ChatMessage, ChatSession
+from reyn.chat.session import ChatMessage, Session
 from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.slash import REGISTRY
@@ -40,8 +40,8 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(tmp_path) -> ChatSession:
-    """Create a ChatSession with a small synthetic T_max to force non-empty candidates.
+def _make_session(tmp_path) -> Session:
+    """Create a Session with a small synthetic T_max to force non-empty candidates.
 
     #1128 step 3: _select_candidates uses token-budget boundaries from the engine.
     With ``t_max=2000`` and ``section_caps_spec_tokens=0`` (T_SP≈1125, T_comp_SP≈481):
@@ -55,7 +55,7 @@ def _make_session(tmp_path) -> ChatSession:
     original = _mb.get_max_input_tokens
     _mb.get_max_input_tokens = lambda model, **kw: 2000  # type: ignore[assignment]
     try:
-        session = ChatSession(
+        session = Session(
             agent_name="default",
             budget_tracker=BudgetTracker(CostConfig()),
             state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),

--- a/tests/test_slash_destructive_confirm_parity.py
+++ b/tests/test_slash_destructive_confirm_parity.py
@@ -133,10 +133,10 @@ async def test_cancel_with_confirm_cancels_task() -> None:
 async def test_plan_discard_no_confirm_shows_warning(tmp_path, monkeypatch):
     """Tier 2: /plan discard <id> (no confirm) → warning msg; plan not discarded."""
     monkeypatch.chdir(tmp_path)
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
 
-    session = ChatSession(
+    session = Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "alpha_snapshot.json",
@@ -167,10 +167,10 @@ async def test_plan_discard_no_confirm_shows_warning(tmp_path, monkeypatch):
 async def test_plan_discard_with_confirm_discards_plan(tmp_path, monkeypatch):
     """Tier 2: /plan discard <id> confirm discards the plan (clears active_plan_ids)."""
     monkeypatch.chdir(tmp_path)
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.core.events.state_log import StateLog
 
-    session = ChatSession(
+    session = Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "alpha_snapshot.json",

--- a/tests/test_slash_multi_line_dispatch.py
+++ b/tests/test_slash_multi_line_dispatch.py
@@ -17,19 +17,19 @@ from pathlib import Path
 
 import pytest
 
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list:
+def _drain_outbox(session: Session) -> list:
     out = []
     while not session.outbox.empty():
         out.append(session.outbox.get_nowait())

--- a/tests/test_transport_ref.py
+++ b/tests/test_transport_ref.py
@@ -18,7 +18,7 @@ import pytest
 from reyn.chat.message_bus import MessageBus
 from reyn.chat.outbox import OutboxMessage
 from reyn.chat.routing import RoutingLayer
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.chat.transport import (
     A2aRef,
     AgentRef,
@@ -34,16 +34,16 @@ from reyn.core.events.state_log import StateLog
 # ---------------------------------------------------------------------------
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> ChatSession:
-    """Build a minimal ChatSession wired to tmp_path."""
-    return ChatSession(
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    """Build a minimal Session wired to tmp_path."""
+    return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
     )
 
 
-def _drain_outbox(session: ChatSession) -> list[OutboxMessage]:
+def _drain_outbox(session: Session) -> list[OutboxMessage]:
     """Non-blocking drain of all outbox messages."""
     msgs = []
     while not session.outbox.empty():
@@ -150,7 +150,7 @@ async def test_run_one_iteration_processes_single_kind(tmp_path, monkeypatch):
     async def _fake_handle_user_message(self, text, *, chain_id):
         processed.append(text)
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     # Enqueue two "user" messages.
     await session._put_inbox("user", {"text": "first"})
@@ -208,11 +208,11 @@ async def test_run_one_iteration_dispatches_all_known_kinds(tmp_path, monkeypatc
     async def _record_agent_response(self, payload):
         dispatched.append("agent_response")
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _record_user)
-    monkeypatch.setattr(ChatSession, "_handle_skill_completed", _record_skill_completed)
-    monkeypatch.setattr(ChatSession, "_handle_plan_completed", _record_plan_completed)
-    monkeypatch.setattr(ChatSession, "_handle_agent_request", _record_agent_request)
-    monkeypatch.setattr(ChatSession, "_handle_agent_response", _record_agent_response)
+    monkeypatch.setattr(Session, "_handle_user_message", _record_user)
+    monkeypatch.setattr(Session, "_handle_skill_completed", _record_skill_completed)
+    monkeypatch.setattr(Session, "_handle_plan_completed", _record_plan_completed)
+    monkeypatch.setattr(Session, "_handle_agent_request", _record_agent_request)
+    monkeypatch.setattr(Session, "_handle_agent_response", _record_agent_response)
 
     for kind in ("user", "skill_completed", "plan_completed", "agent_request", "agent_response"):
         await session._put_inbox(kind, {"text": "x"})
@@ -241,7 +241,7 @@ async def test_run_wraps_run_one_iteration(tmp_path, monkeypatch):
         processed.append(text)
         await self._put_outbox(OutboxMessage(kind="agent", text=f"echo:{text}"))
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     await session._put_inbox("user", {"text": "ping"})
     await session.inbox.put(("shutdown", {}))  # out-of-band, no WAL entry
@@ -366,7 +366,7 @@ async def test_message_bus_request_pumps_until_quiescent(tmp_path, monkeypatch):
     async def _fake_handle_user_message(self, text, *, chain_id):
         await self._put_outbox(OutboxMessage(kind="agent", text=f"echo:{text}"))
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     bus = MessageBus()
     replies = await bus.request(
@@ -397,7 +397,7 @@ async def test_message_bus_collects_multiple_outbox_messages(tmp_path, monkeypat
         await self._put_outbox(OutboxMessage(kind="agent", text="first_fragment"))
         await self._put_outbox(OutboxMessage(kind="agent", text="done"))
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     bus = MessageBus()
     replies = await bus.request(
@@ -434,7 +434,7 @@ async def test_message_bus_waits_for_running_tasks(tmp_path, monkeypatch):
         task = asyncio.create_task(_bg())
         self.running_skills["fake_skill"] = task
 
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     bus = MessageBus()
     replies = await bus.request(
@@ -473,11 +473,11 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
@@ -493,10 +493,10 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
     )
     monkeypatch.chdir(tmp_path)
 
-    # Use a real ChatSession (via factory) and track how inbox was consumed.
+    # Use a real Session (via factory) and track how inbox was consumed.
     inbox_consumed: list[str] = []
 
-    original_put_inbox = ChatSession._put_inbox
+    original_put_inbox = Session._put_inbox
 
     async def _tracking_put_inbox(self, kind, payload):
         inbox_consumed.append(kind)
@@ -514,8 +514,8 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
             meta={"chain_id": chain_id},
         ))
 
-    monkeypatch.setattr(ChatSession, "_put_inbox", _tracking_put_inbox)
-    monkeypatch.setattr(ChatSession, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_put_inbox", _tracking_put_inbox)
+    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
 
     result = await send_to_agent_impl(
         registry,

--- a/tests/test_turn_cancel_1468.py
+++ b/tests/test_turn_cancel_1468.py
@@ -227,9 +227,9 @@ class _SessionWithCancelSeam:
         return self._loop_driver.is_cancel_requested()
 
     async def cancel_inflight(self) -> str:
-        from reyn.chat.session import ChatSession
+        from reyn.chat.session import Session
         # Call the real method (unbound, passing self)
-        return await ChatSession.cancel_inflight(self)  # type: ignore[arg-type]
+        return await Session.cancel_inflight(self)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -46,7 +46,7 @@ class _OutboxRecord:
 
 @dataclass
 class _FakeSession:
-    """Minimal ChatSession-shaped stand-in for /image testing.
+    """Minimal Session-shaped stand-in for /image testing.
 
     Holds only the attributes ``image_cmd`` touches: the pending-images
     queue, the multimodal config, the permission resolver, the
@@ -60,7 +60,7 @@ class _FakeSession:
 
     @property
     def pending_user_images(self) -> list[dict]:
-        """Mirror of ChatSession.pending_user_images for the fake stub."""
+        """Mirror of Session.pending_user_images for the fake stub."""
         return self._pending_user_images
 
     async def _put_outbox(self, msg: object) -> None:
@@ -285,10 +285,10 @@ def _make_history_builder():
     all turns are returned raw — no elide, no duplication.
     """
     from reyn.chat.services.router_history_buffer import RouterHistoryBuffer
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
     from reyn.config import CompactionConfig
 
-    cs = ChatSession.__new__(ChatSession)  # bypass __init__
+    cs = Session.__new__(Session)  # bypass __init__
     cs.history = []  # set by tests
     cs._compaction = CompactionConfig(use_chars4_estimate=True)
     cs._latest_summary = lambda: None  # type: ignore[method-assign]

--- a/tests/test_wal_long_await_floor.py
+++ b/tests/test_wal_long_await_floor.py
@@ -49,7 +49,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 
 
 class _LongAwaitShim:
-    """Minimal duck-typed ChatSession exposing only ``iter_applied_seqs``.
+    """Minimal duck-typed Session exposing only ``iter_applied_seqs``.
 
     PR-N7 (FP-0008): the floor calc reads in-memory state via the
     session's ``iter_applied_seqs`` public method. This shim mirrors
@@ -60,7 +60,7 @@ class _LongAwaitShim:
     """
 
     def __init__(self) -> None:
-        self.agent_seq: int = 0  # ChatSession.journal.snapshot.applied_seq
+        self.agent_seq: int = 0  # Session.journal.snapshot.applied_seq
         # (last_phase_applied_seq, awaiting_since)
         self.skills: list[tuple[int, "float | None"]] = []
 

--- a/tests/test_web_edit_fork_gate_2d.py
+++ b/tests/test_web_edit_fork_gate_2d.py
@@ -13,7 +13,7 @@ must be proven is that the chainlit-free ``resolve_edit_target`` +
   fork target to the PARENT's fork-point turn (not None, not a same-branch miss).
 
 Plus the genesis guard (first turn → reject, decision B). Real AgentRegistry +
-ChatSession + StateLog + git; a no-LLM ``_FakeTurnDriver`` drives the real
+Session + StateLog + git; a no-LLM ``_FakeTurnDriver`` drives the real
 ``_run_router_loop`` so genuine ``cut_generation`` / fork records fire. No mocks.
 """
 from __future__ import annotations
@@ -25,7 +25,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.snapshot_generations import is_active_seq
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.chainlit_app.rewind_actions import (
@@ -45,7 +45,7 @@ class _FakeTurnDriver:
     appends a runtime inbox marker, so the real ``_run_router_loop`` runs and its
     genuine ``cut_generation`` / fork records fire. Only the write is simulated."""
 
-    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+    def __init__(self, session: Session, ws_root: Path, content: dict[str, str]) -> None:
         self._session = session
         self._ws = ws_root
         self._content = content
@@ -66,9 +66,9 @@ class _FakeTurnDriver:
 def _make_registry(tmp_path: Path) -> AgentRegistry:
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile: AgentProfile) -> ChatSession:
+    def _factory(profile: AgentProfile) -> Session:
         snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
-        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+        return Session(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")

--- a/tests/test_web_fetch_unified.py
+++ b/tests/test_web_fetch_unified.py
@@ -289,7 +289,7 @@ def _make_router_op_ctx_factory(resolver, bus, events):
     Builds an OpContext whose ``permission_resolver`` / ``intervention_bus`` /
     ``permission_decl`` mirror what the production factory wires. Used to
     exercise the router-invoked path of WEB_FETCH._handle without spinning
-    up a full ChatSession.
+    up a full Session.
     """
     from reyn.core.op_runtime.context import OpContext
     from reyn.data.workspace.workspace import Workspace

--- a/tests/test_web_rewind_attach_seam_2d.py
+++ b/tests/test_web_rewind_attach_seam_2d.py
@@ -7,11 +7,11 @@ shared workspace shadow-git + anchor stores. This gate proves that auto-attach
 makes a web-path-acquired session's ``checkout`` restore the **workspace**
 (not just runtime) — i.e. the web session is NOT runtime-only.
 
-Distinct from ``test_live_fork_gate`` (which builds ``ChatSession`` directly and
+Distinct from ``test_live_fork_gate`` (which builds ``Session`` directly and
 attaches the stores MANUALLY): here NO manual ``attach_*`` call is made — the
 ``get_or_load`` seam does it. If the seam didn't auto-attach (the #1556-class
 web-construction bug), the workspace would NOT revert on checkout and this test
-would fail. Real AgentRegistry + ChatSession + StateLog + git, no mocks; a
+would fail. Real AgentRegistry + Session + StateLog + git, no mocks; a
 no-LLM ``_FakeTurnDriver`` drives the real ``_run_router_loop`` so genuine
 ``cut_generation`` fires (only the file write is simulated).
 """
@@ -24,7 +24,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.core.events.state_log import StateLog
 
 pytestmark = pytest.mark.skipif(
@@ -39,7 +39,7 @@ class _FakeTurnDriver:
     marker, so the real ``_run_router_loop`` runs and its genuine
     ``cut_generation`` fires. Only the file write is simulated."""
 
-    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+    def __init__(self, session: Session, ws_root: Path, content: dict[str, str]) -> None:
         self._session = session
         self._ws = ws_root
         self._content = content
@@ -64,9 +64,9 @@ async def test_web_path_session_checkout_restores_workspace(tmp_path) -> None:
     store (no manual attach). The #1556-class runtime-only bug fails this."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile: AgentProfile) -> ChatSession:
+    def _factory(profile: AgentProfile) -> Session:
         snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
-        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+        return Session(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
@@ -97,9 +97,9 @@ async def test_web_path_session_records_anchor_for_picker(tmp_path) -> None:
     preview + the edit pre-fill source). Empty anchor store = #1556-class bug."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile: AgentProfile) -> ChatSession:
+    def _factory(profile: AgentProfile) -> Session:
         snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
-        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+        return Session(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")

--- a/tests/test_workspace_capture_optout_1582.py
+++ b/tests/test_workspace_capture_optout_1582.py
@@ -10,7 +10,7 @@ these tests pin that the gate flips the behavior and runtime rewind still works.
 Non-default round-trip (feedback_roundtrip_test_nondefault_value): the opt-out
 (`False`, the NON-default) is exercised end-to-end — gate off → no workspace gen
 + rewind reverts runtime but NOT the workspace; default (`True`) → workspace gen
-present. Real AgentRegistry + ChatSession + StateLog; a no-LLM `_FakeTurnDriver`
+present. Real AgentRegistry + Session + StateLog; a no-LLM `_FakeTurnDriver`
 drives the real `_run_router_loop` so genuine `cut_generation` fires. No mocks.
 """
 from __future__ import annotations
@@ -22,7 +22,7 @@ import pytest
 
 from reyn.chat.profile import AgentProfile
 from reyn.chat.registry import AgentRegistry
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.config import TimeTravelConfig, _build_time_travel_config
 from reyn.core.events.snapshot_generations import is_active_seq
 from reyn.core.events.state_log import StateLog
@@ -35,7 +35,7 @@ class _FakeTurnDriver:
     marker so the real `_run_router_loop` runs and its genuine `cut_generation`
     fires. Only the file write is simulated."""
 
-    def __init__(self, session: ChatSession, ws_root: Path, content: dict[str, str]) -> None:
+    def __init__(self, session: Session, ws_root: Path, content: dict[str, str]) -> None:
         self._session = session
         self._ws = ws_root
         self._content = content
@@ -56,9 +56,9 @@ class _FakeTurnDriver:
 def _make_registry(tmp_path: Path, *, workspace_capture: bool) -> AgentRegistry:
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile: AgentProfile) -> ChatSession:
+    def _factory(profile: AgentProfile) -> Session:
         snap = tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
-        return ChatSession(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
+        return Session(agent_name=profile.name, state_log=state_log, snapshot_path=snap)
 
     reg = AgentRegistry(
         project_root=tmp_path, session_factory=_factory, state_log=state_log,

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -34,7 +34,7 @@ pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)"
 
 from reyn.chat.profile import AgentProfile  # noqa: E402
 from reyn.chat.registry import AgentRegistry  # noqa: E402
-from reyn.chat.session import ChatSession  # noqa: E402
+from reyn.chat.session import Session  # noqa: E402
 from reyn.core.events.state_log import StateLog  # noqa: E402
 from reyn.llm.llm import LLMToolCallResult  # noqa: E402
 from reyn.llm.pricing import TokenUsage  # noqa: E402
@@ -56,11 +56,11 @@ def _build_registry(tmp_path: Path, agents: list[tuple[str, str]]) -> AgentRegis
     """Construct an AgentRegistry on tmp_path with the given (name, role) agents."""
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
-    def factory(profile: AgentProfile) -> ChatSession:
+    def factory(profile: AgentProfile) -> Session:
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
         bt = BudgetTracker(CostConfig())
-        return ChatSession(
+        return Session(
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",

--- a/tests/web/test_external_outbox_interceptor_wiring.py
+++ b/tests/web/test_external_outbox_interceptor_wiring.py
@@ -55,14 +55,14 @@ from reyn.chat.external_routing import (
     ExternalTransportRouting,
 )
 from reyn.chat.outbox import OutboxMessage
-from reyn.chat.session import ChatSession
+from reyn.chat.session import Session
 from reyn.chat.transport import ExternalRef
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.web.deps import _wire_external_outbox_interceptor
 
 
-def _make_session(tmp_path: Path) -> ChatSession:
-    return ChatSession(
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
         agent_name="alpha",
         state_log=StateLog(tmp_path / "alpha.wal"),
         snapshot_path=tmp_path / "alpha_snapshot.json",


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 Stage 6: `ChatSession` → `Session` holistic rename (the cosmetic final stage of #1726). Owner GO'd the literal name "Session"; lead chose option B (rename the mis-named CLI bootstrap class first to free the name). 2 bisectable commits, logic untouched = orthogonal to the time-travel/crash-recovery machinery.

## Commits

- **`d6170dc7` (1/2)** — CLI `Session` → `InvocationContext` (+ module `cli/session.py` → `cli/invocation_context.py`). The CLI class is a per-invocation config+ModelResolver bootstrap — mis-named; `InvocationContext` is accurate and was 0-collision pre-checked. Frees the bare name `Session`.
- **`d02e0369` (2/2)** — `ChatSession` → `Session` across src/ + tests/.

## Lead's 4 review points

1. **Identity-preservation count (surgical proof)** — sibling counts UNCHANGED pre→post: `Agent` 146 / `AgentRegistry` 124 / `AgentProfile` 46 / `AgentSnapshot` 65 / `SkillRuntime` 56. The rename touched only the target class.
2. **Named-gate green & untouched** — 709 time-travel/crash-recovery/session tests pass; rename is logic-orthogonal.
3. **code-vs-prose** — the token `ChatSession` (CamelCase) is unambiguously the class, so the 21 two-word "chat session" concept-prose items (lowercase, space) are NOT matched and stay preserved (verified: still 21). Compound identifiers correctly follow: `ChatSessions`→Sessions, test stubs `_StubChatSession`/`_FakeChatSession`/`FakeChatSession`→`_StubSession` etc., forward-ref annotations + `__all__` export.
4. **commit-2 code-string scan** — no `setattr/getattr/subprocess/eval/import_module` uses "ChatSession" as a STRING. The `monkeypatch.setattr(ChatSession, "_handle_user_message", ...)` cases pass the CLASS OBJECT (renamed via token) with method-name strings (untouched). In commit 1, the test `monkeypatch.setattr(session_mod, "Session", ...)` string-refs WERE caught and renamed to `"InvocationContext"`.

## Scope boundary

`.md` files left as-is: CHANGELOG.md is a historical record (rewriting past entries would be wrong) and the one design doc is prose (docs-maintainer's domain). Flagged for separate docs handling, not part of this code rename.

## Test plan

- [x] Full suite (rootdir, user tree): **7459 passed**, 14 failed = the SAME pre-existing not-my-diff local-env failures as the S5 baseline (copy_to_work×4, swebench×2, eval_judge, python_harness×4, python_step_sandbox, skill_postprocessor, web_fetch — all unrelated subsystems). Zero new failures; pass count identical to S5 baseline = behavior-equivalent.
- [x] `ruff check src tests` clean (I001 import-sort churn auto-fixed, 6 total across the 2 commits).
- [x] Named-gate (time-travel/crash-recovery/session) 709 passed.
- [x] Identity-preservation counts verified unchanged (above).
- [x] Collision pre-checks: `InvocationContext` 0 hits before commit 1; single `class Session` after commit 2 (no double-definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
