### PR TITLE
docs(ia): #1733 unify site at root (landing + docs one site, regen toolchain preserved)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,11 @@
 # Build the landing page + mkdocs site and deploy them to GitHub Pages.
 #
-# Layout produced under the deploy artifact:
-#   /                     → website/dist/index.html (the LP)
-#   /assets/              → LP assets
-#   /docs/                → mkdocs site (built from docs/ via mkdocs.yml)
+# Unified-root layout (#1733) produced under the deploy artifact:
+#   /                     → website/dist/index.html (the landing page)
+#   /architecture.html    → website/dist/architecture.html (landing arch page)
+#   /assets/              → landing assets
+#   /<path>/              → mkdocs site, served root-relative (e.g. /start/, /guide/…)
+#   /docs/<path>/         → legacy meta-refresh redirect stubs → /<path>/ (old URLs)
 #
 # Trigger: every push to main, plus manual dispatch from the Actions tab.
 # Settings → Pages → Source must be set to "GitHub Actions" (one-time click
@@ -55,13 +57,19 @@ jobs:
         run: mkdocs build --strict -f .mkdocs/mkdocs.yml
 
       - name: Assemble deploy directory
-        # The Pages artifact wants a single directory whose root contains
-        # the site to serve. Combine LP at the root + mkdocs under /docs/.
+        # Unified-root (#1733): mkdocs docs serve at the root (/start/, /guide/…),
+        # the landing (build.py output) takes the root home (/) + /architecture.html.
         run: |
-          mkdir -p _deploy/docs
+          mkdir -p _deploy
+          # 1) mkdocs docs at the root (root-relative URLs)
+          cp -r site/. _deploy/
+          # 2) legacy /docs/* meta-refresh redirect stubs (Pages has no server
+          #    redirects) — one per built page, old docs home → /start/
+          python scripts/gen_docs_redirects.py site _deploy/docs /reyn/
+          # 3) landing overwrites the root home (its index.html beats mkdocs's
+          #    shadowed i18n home) + adds /architecture.html
           cp -r website/dist/. _deploy/
           cp -r website/assets _deploy/assets
-          cp -r site/. _deploy/docs/
           # Disable Jekyll: GitHub Pages would otherwise apply Jekyll
           # filtering, which strips files starting with `_` (mkdocs uses
           # them under search/) and reformats some HTML.

--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Reyn
 site_description: LLM workflow OS — phase transitions as a constrained decision graph
-site_url: https://tya5.github.io/reyn/docs/
+site_url: https://tya5.github.io/reyn/
 docs_dir: ../docs
 # Build output to repo-root site/ (config now lives in .mkdocs/, so make the
 # output dir explicit rather than relying on the default .mkdocs/site/).
@@ -73,6 +73,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Start here: start.md
   - Feature Map: feature-map.md
   - Guide:
       - Getting started:

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,30 +1,17 @@
 ---
 type: landing
-audience: [human]
+audience: [human, agent]
 ---
+
+<!--
+  i18n homepage stub（locale 'ja'）。公開サイトの root (/) はプロジェクトの
+  ランディングページ（website/ を website/build.py で生成）で、この mkdocs home は
+  deploy 時にそれで上書きされる。mkdocs-static-i18n が locale ごとに index.md を
+  要求するため存在する。実際のドキュメント入口は start.ja.md（/start/ で配信）。
+-->
 
 # reyn
 
-**LLM ワークフロー OS — Phase の状態遷移として実行する。**
+**LLM ワークフロー OS — フェーズ遷移を制約付き決定グラフとして扱う。**
 
-reyn は LLM ワークフローを「状態機械」として実行します。Phase は状態を持たず再利用可能、Skill が graph と最終出力スキーマを所有し、OS が実行を制御します。LLM の役割は **OS が提示した遷移候補から選ぶこと**、そして構造化されたアーティファクトを返すことに限定され、制御フローを発明することはありません。
-
-## どこから読む？
-
-| 目的 | 行き先 |
-|---|---|
-| インストールして最初の skill を動かす | [Getting started](guide/getting-started/01-installation.md) |
-| 仕様を正確に知りたい | [Reference](reference/cli/run.md) |
-| 設計思想を理解したい | [コンセプト](concepts/architecture/principles.md) |
-
-!!! note "翻訳状況"
-    日本語版は主要ドキュメントから順次翻訳中です。未訳のページは英語版にフォールバックします。
-
-## Powered by AI
-
-reyn は 2 つの意味で「 AI 駆動」 です:
-
-- **ランタイム**: すべての Skill 実行は LiteLLM 経由で LLM プロバイダに判断を委譲します。 reyn は設計上 LLM ワークフロー OS です。
-- **開発**: コードベース、 stdlib スキル、 本ドキュメント、 ランディングページの相当部分は AI ツール (= 主に Claude Code (Anthropic) による実装、 Claude Design による Web サイト) で起草されました。 人間によるレビュー / 統合 / 最終的なアーキテクチャ判断はメンテナが担い、 AI の寄与は git 履歴の `Co-Authored-By: Claude ...` trailer として記録されています。
-
-これはマーケティングコピーではなく透明性のための開示です。 来歴を監査する場合は `git log --grep="Co-Authored-By: Claude"` および `website/_design/` 配下のデザインプロンプトを参照してください。
+**→ [ここから始める](start.ja.md)** — 全体像と次に読むべき場所。

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,42 +3,15 @@ type: landing
 audience: [human, agent]
 ---
 
+<!--
+  i18n homepage stub. The published site root (/) is the project landing page
+  (built from website/ via website/build.py); this mkdocs home is shadowed by it
+  at deploy time. It exists because mkdocs-static-i18n requires an index.md per
+  locale. The real documentation entry point is start.md (served at /start/).
+-->
+
 # reyn
 
 **LLM workflow OS — phase transitions as a constrained decision graph.**
 
-reyn runs LLM workflows as a state machine. Phases are stateless and reusable; a Skill defines the graph and the final output schema; the OS controls execution. The LLM's role is reduced to choosing among OS-provided transitions and producing structured artifacts — never to inventing control flow.
-
-## Where to start
-
-| If you want to... | Go to |
-|---|---|
-| Install and run your first skill | [Getting started](guide/getting-started/01-installation.md) |
-| Solve a specific problem (chat user) | [Guide / for users](guide/for-users/manage-permissions.md) |
-| Solve a specific problem (skill author) | [Guide / for skill authors](guide/for-skill-authors/phase-mechanics/validate-artifacts.md) |
-| Look up exact behavior | [Reference](reference/cli/run.md) |
-| Understand the design | [Concepts](concepts/architecture/principles.md) |
-| Read reyn through agent-engineering lenses | [Seven lenses](concepts/agent-engineering/index.md) |
-| Read LLM-targeted rubrics | [Skill-builder checklist](guide/for-skill-authors/stdlib-authoring-tools/skill-builder-checklist.md) |
-| Contribute | See `docs/deep-dives/contributing/` in the repository |
-
-## The four reading modes (Diátaxis)
-
-- **Guide** — task-oriented. *Getting started* for onboarding, *for users* for chat-mode usage, *for skill authors* for building skills.
-- **Reference** — information-oriented. Look up and leave.
-- **Concepts** — understanding-oriented. The "why" of reyn.
-
-LLM-targeted rubrics (skill-builder checklist, eval-builder rubric, etc.) live under `guide/for-skill-authors/` — their primary reader is a reyn skill (e.g. `skill_builder`), but humans read them too.
-
-## Project status
-
-reyn is in alpha (0.1.x). The DSL, CLI, and event log are stable enough to build skills against, but APIs may still shift. Changelog and roadmap pages are coming in a later docs phase (`changelog.md`, `architecture/roadmap.md`).
-
-## Powered by AI
-
-Reyn is powered by AI in two senses:
-
-- **At runtime.** Every Skill execution delegates decisions to an LLM provider via LiteLLM. Reyn is an LLM workflow OS by design.
-- **In its development.** Substantial portions of the codebase, the stdlib skills, this documentation, and the landing page were drafted with AI tooling — primarily Claude Code (Anthropic) for implementation and Claude Design for the website. Human review, integration, and final architectural calls live with the maintainer; AI contributions are recorded as `Co-Authored-By: Claude ...` trailers in the git history.
-
-This is a transparency note, not a marketing line. For provenance auditing, see `git log --grep="Co-Authored-By: Claude"` and the design prompts under `website/_design/`.
+**→ [Start here](start.md)** — orientation and where to go next.

--- a/docs/start.ja.md
+++ b/docs/start.ja.md
@@ -1,0 +1,30 @@
+---
+type: landing
+audience: [human]
+---
+
+# reyn
+
+**LLM ワークフロー OS — Phase の状態遷移として実行する。**
+
+reyn は LLM ワークフローを「状態機械」として実行します。Phase は状態を持たず再利用可能、Skill が graph と最終出力スキーマを所有し、OS が実行を制御します。LLM の役割は **OS が提示した遷移候補から選ぶこと**、そして構造化されたアーティファクトを返すことに限定され、制御フローを発明することはありません。
+
+## どこから読む？
+
+| 目的 | 行き先 |
+|---|---|
+| インストールして最初の skill を動かす | [Getting started](guide/getting-started/01-installation.md) |
+| 仕様を正確に知りたい | [Reference](reference/cli/run.md) |
+| 設計思想を理解したい | [コンセプト](concepts/architecture/principles.md) |
+
+!!! note "翻訳状況"
+    日本語版は主要ドキュメントから順次翻訳中です。未訳のページは英語版にフォールバックします。
+
+## Powered by AI
+
+reyn は 2 つの意味で「 AI 駆動」 です:
+
+- **ランタイム**: すべての Skill 実行は LiteLLM 経由で LLM プロバイダに判断を委譲します。 reyn は設計上 LLM ワークフロー OS です。
+- **開発**: コードベース、 stdlib スキル、 本ドキュメント、 ランディングページの相当部分は AI ツール (= 主に Claude Code (Anthropic) による実装、 Claude Design による Web サイト) で起草されました。 人間によるレビュー / 統合 / 最終的なアーキテクチャ判断はメンテナが担い、 AI の寄与は git 履歴の `Co-Authored-By: Claude ...` trailer として記録されています。
+
+これはマーケティングコピーではなく透明性のための開示です。 来歴を監査する場合は `git log --grep="Co-Authored-By: Claude"` および `website/_design/` 配下のデザインプロンプトを参照してください。

--- a/docs/start.md
+++ b/docs/start.md
@@ -1,0 +1,44 @@
+---
+type: landing
+audience: [human, agent]
+---
+
+# reyn
+
+**LLM workflow OS — phase transitions as a constrained decision graph.**
+
+reyn runs LLM workflows as a state machine. Phases are stateless and reusable; a Skill defines the graph and the final output schema; the OS controls execution. The LLM's role is reduced to choosing among OS-provided transitions and producing structured artifacts — never to inventing control flow.
+
+## Where to start
+
+| If you want to... | Go to |
+|---|---|
+| Install and run your first skill | [Getting started](guide/getting-started/01-installation.md) |
+| Solve a specific problem (chat user) | [Guide / for users](guide/for-users/manage-permissions.md) |
+| Solve a specific problem (skill author) | [Guide / for skill authors](guide/for-skill-authors/phase-mechanics/validate-artifacts.md) |
+| Look up exact behavior | [Reference](reference/cli/run.md) |
+| Understand the design | [Concepts](concepts/architecture/principles.md) |
+| Read reyn through agent-engineering lenses | [Seven lenses](concepts/agent-engineering/index.md) |
+| Read LLM-targeted rubrics | [Skill-builder checklist](guide/for-skill-authors/stdlib-authoring-tools/skill-builder-checklist.md) |
+| Contribute | See `docs/deep-dives/contributing/` in the repository |
+
+## The four reading modes (Diátaxis)
+
+- **Guide** — task-oriented. *Getting started* for onboarding, *for users* for chat-mode usage, *for skill authors* for building skills.
+- **Reference** — information-oriented. Look up and leave.
+- **Concepts** — understanding-oriented. The "why" of reyn.
+
+LLM-targeted rubrics (skill-builder checklist, eval-builder rubric, etc.) live under `guide/for-skill-authors/` — their primary reader is a reyn skill (e.g. `skill_builder`), but humans read them too.
+
+## Project status
+
+reyn is in alpha (0.1.x). The DSL, CLI, and event log are stable enough to build skills against, but APIs may still shift. Changelog and roadmap pages are coming in a later docs phase (`changelog.md`, `architecture/roadmap.md`).
+
+## Powered by AI
+
+Reyn is powered by AI in two senses:
+
+- **At runtime.** Every Skill execution delegates decisions to an LLM provider via LiteLLM. Reyn is an LLM workflow OS by design.
+- **In its development.** Substantial portions of the codebase, the stdlib skills, this documentation, and the landing page were drafted with AI tooling — primarily Claude Code (Anthropic) for implementation and Claude Design for the website. Human review, integration, and final architectural calls live with the maintainer; AI contributions are recorded as `Co-Authored-By: Claude ...` trailers in the git history.
+
+This is a transparency note, not a marketing line. For provenance auditing, see `git log --grep="Co-Authored-By: Claude"` and the design prompts under `website/_design/`.

--- a/scripts/gen_docs_redirects.py
+++ b/scripts/gen_docs_redirects.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Generate redirect stubs for the legacy ``/docs/*`` URL prefix.
+
+#1733 unified the site at the Pages root: docs moved from ``/<base>/docs/<path>``
+to ``/<base>/<path>``. GitHub Pages has no server-side redirects, so for every
+built page we emit a meta-refresh stub at the OLD ``docs/<path>`` location
+pointing at the new URL. The old docs home (``/docs/``) maps to ``/start/`` —
+the orientation page that ``docs/index.md`` content moved to (the new root is
+the project landing page).
+
+Usage:
+    gen_docs_redirects.py <mkdocs_site_dir> <out_docs_dir> [<url_base>]
+
+  <mkdocs_site_dir>  the mkdocs build output (e.g. ``site``)
+  <out_docs_dir>     where to write stubs (e.g. ``_deploy/docs``)
+  <url_base>         absolute URL base, default ``/reyn/`` (the Pages project path)
+
+Covers EVERY ``*.html`` under the site (completeness — no page left without a
+legacy redirect).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def served_url(relpath: str, base: str) -> str:
+    """Map a built file's relpath to the URL it is served at (new location)."""
+    p = Path(relpath)
+    if p.name == "index.html":
+        d = p.parent.as_posix()
+        if d == ".":
+            # old /docs/ (docs home) → /start/ (where index.md content moved)
+            return base + "start/"
+        return f"{base}{d}/"
+    return base + relpath
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    site = Path(argv[1])
+    out = Path(argv[2])
+    base = argv[3] if len(argv) > 3 else "/reyn/"
+    if not base.endswith("/"):
+        base += "/"
+
+    count = 0
+    for html in sorted(site.rglob("*.html")):
+        rel = html.relative_to(site).as_posix()
+        target = served_url(rel, base)
+        dest = out / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(
+            '<!doctype html><html><head><meta charset="utf-8">'
+            f'<meta http-equiv="refresh" content="0; url={target}">'
+            f'<link rel="canonical" href="{target}">'
+            "<title>Redirecting…</title></head>"
+            f'<body>This page has moved to <a href="{target}">{target}</a>.</body>'
+            "</html>\n",
+            encoding="utf-8",
+        )
+        count += 1
+    print(f"gen_docs_redirects: wrote {count} legacy /docs/* stubs → {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -336,7 +336,7 @@
     </a>
     <nav class="nav-links" aria-label="Primary">
       <a href="{{NAV_ARCH_HREF}}" class="is-current">{{NAV_ARCH}}</a>
-      <a href="docs/">{{NAV_DOCS}}</a>
+      <a href="start/">{{NAV_DOCS}}</a>
       <a href="{{NAV_GITHUB_HREF}}">{{NAV_GITHUB}}</a>
     </nav>
   </div>

--- a/website/copy.yaml
+++ b/website/copy.yaml
@@ -205,7 +205,7 @@ ARCH_CTA_HEADING_HTML: "Go deeper in the <em>docs.</em>"
 ARCH_CTA_BODY: >-
   The concepts section covers each component in detail — with design
   rationale, edge cases, and links to the implementation.
-ARCH_CTA_DOCS_HREF: "docs/concepts/architecture/"
+ARCH_CTA_DOCS_HREF: "concepts/architecture/"
 
 # ── footer ───────────────────────────────────────────────────────────────────
 # Powered by AI is intentional double-meaning: Reyn (a) runs on LLMs at

--- a/website/index.html
+++ b/website/index.html
@@ -536,7 +536,7 @@
       </a>
       <nav class="nav-links" aria-label="Primary">
         <a href="{{NAV_ARCH_HREF}}">{{NAV_ARCH}}</a>
-        <a href="docs/">{{NAV_DOCS}}</a>
+        <a href="start/">{{NAV_DOCS}}</a>
         <a href="{{NAV_GITHUB_HREF}}">{{NAV_GITHUB}}</a>
       </nav>
     </div>
@@ -557,7 +557,7 @@
             {{HERO_CTA_PRIMARY}}
             <svg class="ic arrow" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M2 8h12M9 3l5 5-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </a>
-          <a href="docs/" class="btn btn-secondary">{{HERO_CTA_SECONDARY}}</a>
+          <a href="start/" class="btn btn-secondary">{{HERO_CTA_SECONDARY}}</a>
         </div>
       </div>
     </div>
@@ -636,7 +636,7 @@
       <h2 class="section-heading">{{S04_HEADING_HTML}}</h2>
       <div class="install">
         <div>
-          <a href="docs/" class="docs-link">
+          <a href="start/" class="docs-link">
             {{S04_DOCS_LINK}}
             <svg class="ic arrow" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </a>


### PR DESCRIPTION
**[docs-maintainer]** — #1733, revised per owner co-design: **flag#1 = unified-root**, **flag#4 = keep build.py/regen**. The original "fold into mkdocs + retire build.py" plan was void; this is **deploy/URL unification only** (website/ toolchain fully preserved). lead-decisions #2/#3/#5 are moot (regen kept).

## Changes
- **mkdocs `site_url` → root** (was `…/reyn/docs/`). Docs now serve root-relative: `/start/`, `/guide/…`, `/concepts/…`.
- **docs-home (sub-1a):** `docs/index.md` content (the "where to start" page) → **`docs/start.md`** (+ `.ja`), served at `/start/`. A **minimal `docs/index.md`** (+ `.ja`) remains as the mkdocs-static-i18n homepage (**required per locale** — removing it warns/fails strict); it's shadowed by the landing at deploy. nav: `Home` (index.md) + `Start here` (start.md).
- **landing docs-links → root-relative:** `index.html`/`architecture.html` `href="docs/"` → `start/` (all 4 occurrences); `copy.yaml ARCH_CTA_DOCS_HREF` → `concepts/architecture/`.
- **Deploy (pages.yml):** mkdocs docs at root → landing overwrites root home (+ `/architecture.html`) → assets → **legacy `/docs/*` meta-refresh redirect stubs**.

## Redirect mechanism (sub-2, corrected)
mkdocs-redirects handles intra-docs *page moves*, **not** the `/docs/`→`/` URL-*prefix* shift (lead agreed). So `scripts/gen_docs_redirects.py` emits a meta-refresh stub at every old `/docs/<path>` → new `/<path>` (old docs home `/docs/` → `/start/`). One stub per built page.

## Verification (local deploy simulation)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, zero warnings (i18n homepage satisfied)
- [x] **completeness: 327 mkdocs pages → 327 `/docs/*` stubs (1:1, no page un-redirected)**
- [x] root `/index.html` = landing (hero marker present, not mkdocs home)
- [x] docs root-relative: `/start/`, `/guide/getting-started/01-installation/`, `/architecture.html` all present
- [x] stub targets: `/docs/` → `/reyn/start/`; `/docs/guide/X` → `/reyn/guide/X/`
- [x] `.ja` consistent (`/start/` via start.ja.md); explicit-path staging (no stray)

## Preserved (flag#4)
`website/` toolchain unchanged: `build.py`, `copy.yaml`, templates, `assets/`, `_design/` (provenance — README/docs refs still valid). Claude-Design regeneration workflow intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)