### PR TITLE
feat(1726): FP-0043 S4b-1 — resolve_session routing-core primitive

### DIFF
--- a/src/reyn/chat/registry.py
+++ b/src/reyn/chat/registry.py
@@ -30,6 +30,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
+from urllib.parse import quote, unquote
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
@@ -275,6 +276,45 @@ class AgentRegistry:
         spawned ids thereafter."""
         return list(self._sessions.get(name, {}).keys())
 
+    def resolve_session(
+        self,
+        agent_name: str,
+        transport: str,
+        native_id: str,
+        explicit_sid: "str | None" = None,
+    ) -> "object":
+        """FP-0043 Stage 4b-1: the routing-core primitive — map an inbound message
+        to the right Session of ``agent_name`` by routing-key (settled design, the
+        0043 §Routing-key). Scope is WITHIN one Agent (shared identity/permissions).
+
+        - **Default — deterministic mapping**: ``session_id = "<transport>:<native_id>"``
+          (namespaced; e.g. ``slack:T123`` / ``cron:morning_news`` / ``web:<tab>``).
+          get-or-spawn: the first message for a key auto-spawns the Session; the
+          same key resumes it (stateful per-conversation + isolation, zero-config).
+        - **Explicit — join an EXISTING Session** (``explicit_sid``; cross-transport
+          bridging): looked up only. A non-existent explicit id is an ERROR — a
+          Session is created via the mapping default or an explicit spawn op, never
+          silently by a typo'd id.
+
+        This is a pure S3 reuse (``_has_session`` / ``spawn_session`` /
+        ``get_session``); transport wiring of the inbound sites is staged separately
+        (S4b-2+). Returns the resolved Session."""
+        if explicit_sid is not None:
+            session = self.get_session(agent_name, explicit_sid)
+            if session is None:
+                raise KeyError(
+                    f"explicit-join target session {explicit_sid!r} does not exist "
+                    f"for agent {agent_name!r}. An explicit session id must already "
+                    f"exist (created via the routing-key mapping default or an "
+                    f"explicit spawn) — it is never auto-created, so a typo'd id is "
+                    f"rejected rather than silently opening a new conversation."
+                )
+            return session
+        sid = f"{transport}:{native_id}"
+        if not self._has_session(agent_name, sid):
+            self.spawn_session(agent_name, sid=sid)
+        return self.get_session(agent_name, sid)
+
     def load_profile(self, name: str) -> AgentProfile:
         return AgentProfile.load(self._dir / name)
 
@@ -392,16 +432,40 @@ class AgentRegistry:
 
     # ── PR21: crash recovery ─────────────────────────────────────────────────
 
+    @staticmethod
+    def _encode_sid_for_dir(sid: str) -> str:
+        """FP-0043 S4b-1: bijective-encode a logical sid into a SAFE single-path-
+        segment directory name.
+
+        A routing-key sid is ``<transport>:<native_id>`` where native_id is
+        arbitrary (webhook source / MCP conn id can carry ``:`` ``/`` whitespace).
+        Used verbatim as a dir name that breaks (``/`` → nested/garbled dirs) or is
+        non-portable. percent-encode with an EMPTY safe set so every reserved /
+        unsafe char (``:`` ``/`` space …) is escaped into one flat segment;
+        alphanumerics + ``_.-~`` pass through unchanged, so an existing safe sid
+        (uuid hex, "main") encodes to ITSELF = byte-identical for pre-S4b sessions.
+        The logical sid is unchanged everywhere else (dict key / WAL session_id /
+        _matches_agent filter) — only the filesystem dir component is encoded."""
+        return quote(sid, safe="")
+
+    @staticmethod
+    def _decode_sid_from_dir(dirname: str) -> str:
+        """FP-0043 S4b-1: inverse of ``_encode_sid_for_dir`` — recover the logical
+        sid from an on-disk session dir name (round-trip for discovery/restore)."""
+        return unquote(dirname)
+
     def _session_state_dir(self, name: str, sid: str) -> Path:
         """FP-0043 Stage 5: on-disk state dir for ``(name, sid)``.
 
         The "main" session keeps the legacy agent-level dir (byte-identical
-        pre-S5); spawned sessions nest under ``state/sessions/<sid>/`` — the same
-        layout spawn_session's fixup writes to (base-aligned via self._dir)."""
+        pre-S5); spawned sessions nest under ``state/sessions/<enc(sid)>/`` — the
+        same layout spawn_session's fixup writes to (base-aligned via self._dir).
+        S4b-1: the dir component is bijective-encoded so an arbitrary routing-key
+        sid (``slack:T123``, ``webhook:a/b``) is a single safe path segment."""
         state_dir = self._dir / name / "state"
         if sid == _DEFAULT_SID:
             return state_dir
-        return state_dir / "sessions" / sid
+        return state_dir / "sessions" / self._encode_sid_for_dir(sid)
 
     def _session_snapshot_path(self, name: str, sid: str) -> Path:
         """FP-0043 Stage 5: snapshot.json path for ``(name, sid)``."""
@@ -424,7 +488,8 @@ class AgentRegistry:
         if sessions_root.is_dir():
             for child in sessions_root.iterdir():
                 if child.is_dir():
-                    sids.add(child.name)
+                    # S4b-1: dir names are encoded → decode back to logical sid.
+                    sids.add(self._decode_sid_from_dir(child.name))
         return sorted(sids)
 
     async def restore_all(self) -> dict[str, AgentSnapshot]:
@@ -476,7 +541,10 @@ class AgentRegistry:
                 for sid_dir in sorted(sessions_root.iterdir()):
                     sp = sid_dir / "snapshot.json"
                     if sp.is_file():
-                        sid = sid_dir.name
+                        # S4b-1: dir name is encoded → decode to the logical sid so
+                        # the session restores under its routing-key, not the escaped
+                        # form (else get_session(logical_sid) misses post-restore).
+                        sid = self._decode_sid_from_dir(sid_dir.name)
                         all_snaps[(name, sid)] = AgentSnapshot.load(
                             name, sp, session_id=sid,
                         )
@@ -1580,9 +1648,11 @@ class AgentRegistry:
         # parent of its current main snapshot path) so a test tmp-base is respected
         # — the same base-alignment invariant restore_all's discovery relies on:
         #   <state>/snapshot.json          (main, byte-identical legacy path)
-        #   <state>/sessions/<sid>/snapshot.json + .../generations  (spawned)
+        #   <state>/sessions/<enc(sid)>/snapshot.json + .../generations  (spawned)
+        # S4b-1: dir component bijective-encoded (same as _session_state_dir) so an
+        # arbitrary routing-key sid is one safe segment; discovery reverse-decodes.
         state_dir = Path(session._snapshot_path).parent
-        session_dir = state_dir / "sessions" / new_sid
+        session_dir = state_dir / "sessions" / self._encode_sid_for_dir(new_sid)
         per_session_snapshot = session_dir / "snapshot.json"
         per_session_generations = SnapshotGenerationStore(
             name, session_dir / "generations",

--- a/tests/test_resolve_session_routing.py
+++ b/tests/test_resolve_session_routing.py
@@ -1,0 +1,144 @@
+"""Tier 2: FP-0043 S4b-1 — resolve_session routing-core primitive.
+
+The routing-key seam (0043 §Routing-key, settled): an inbound transport message
+maps to the right Session of one Agent. Real AgentRegistry + StateLog + on-disk
+agents (no mocks). Covers the four settled rules + the S4b-1 path-safety encoding:
+
+  1. default deterministic mapping  — same <transport>:<native_id> → same Session;
+  2. explicit-join an EXISTING session;
+  3. non-existent explicit id = ERROR (never auto-created);
+  4. scope within one Agent;
+  5. path round-trip — an arbitrary native_id (with ':' and '/') survives
+     spawn → encoded dir → discover → restore as the SAME logical sid + state.
+
+Each assertion is falsification-checked against the production mechanism
+(see the companion comments) per feedback_falsify_acceptance_test_before_proof.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import Session
+from reyn.core.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path, wal: Path) -> AgentRegistry:
+    state_log = StateLog(wal)
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _iv_dict(iv_id: str) -> dict:
+    return {
+        "kind": "ask_user", "prompt": "Q?", "detail": "", "choices": [],
+        "suggestions": [], "run_id": "r", "skill_name": "demo", "id": iv_id,
+    }
+
+
+def test_resolve_session_default_mapping_is_deterministic(tmp_path):
+    """Tier 2: same routing-key → same Session (get-or-spawn); distinct keys isolate."""
+    reg = _make_registry(tmp_path, tmp_path / ".reyn" / "wal.jsonl")
+    _seed(tmp_path, "alpha")
+
+    s1 = reg.resolve_session("alpha", "slack", "T123")
+    s2 = reg.resolve_session("alpha", "slack", "T123")
+    assert s1 is s2                                   # resume, not re-spawn
+    s3 = reg.resolve_session("alpha", "slack", "T999")
+    assert s3 is not s1                               # distinct native_id isolates
+    # the logical sid is the namespaced routing-key.
+    assert "slack:T123" in reg.session_ids("alpha")
+    assert "slack:T999" in reg.session_ids("alpha")
+
+
+def test_resolve_session_explicit_join_existing(tmp_path):
+    """Tier 2: explicit_sid joins an existing Session (cross-transport bridge)."""
+    reg = _make_registry(tmp_path, tmp_path / ".reyn" / "wal.jsonl")
+    _seed(tmp_path, "alpha")
+
+    created = reg.resolve_session("alpha", "web", "tab1")   # sid = "web:tab1"
+    joined = reg.resolve_session("alpha", "cron", "ignored", explicit_sid="web:tab1")
+    assert joined is created                          # same Session, not a new one
+
+
+def test_resolve_session_explicit_nonexistent_is_error(tmp_path):
+    """Tier 2: a non-existent explicit id is rejected (never auto-created)."""
+    reg = _make_registry(tmp_path, tmp_path / ".reyn" / "wal.jsonl")
+    _seed(tmp_path, "alpha")
+    reg.resolve_session("alpha", "slack", "T1")       # some existing session
+
+    with pytest.raises(KeyError):
+        reg.resolve_session("alpha", "x", "y", explicit_sid="typo:nope")
+    # behavioral contract: the typo'd id was NOT auto-created (no silent new session).
+    assert "typo:nope" not in reg.session_ids("alpha")
+
+
+def test_resolve_session_scope_is_within_one_agent(tmp_path):
+    """Tier 2: routing scope is per-Agent — a key on agent B is independent of A."""
+    reg = _make_registry(tmp_path, tmp_path / ".reyn" / "wal.jsonl")
+    _seed(tmp_path, "alpha")
+    _seed(tmp_path, "beta")
+
+    a = reg.resolve_session("alpha", "slack", "T1")
+    # explicit-join of alpha's sid on beta is an error — scope does not cross agents.
+    with pytest.raises(KeyError):
+        reg.resolve_session("beta", "x", "y", explicit_sid="slack:T1")
+    # a mapping resolve on beta creates beta's OWN distinct session under the key.
+    b = reg.resolve_session("beta", "slack", "T1")
+    assert b is not a
+    assert reg.get_session("alpha", "slack:T1") is a
+    assert reg.get_session("beta", "slack:T1") is b
+
+
+@pytest.mark.asyncio
+async def test_resolve_session_path_round_trip_arbitrary_native_id(tmp_path, monkeypatch):
+    """Tier 2: an arbitrary native_id (':' and '/') round-trips spawn→dir→discover→restore.
+
+    The logical sid stays "<transport>:<native_id>"; only the filesystem dir is
+    bijective-encoded. A '/' in native_id would otherwise create a nested/garbled
+    dir that discovery + restore could not recover.
+    """
+    monkeypatch.chdir(tmp_path)                       # base-align the session snapshot path
+    _seed(tmp_path, "alpha")
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+    reg = _make_registry(tmp_path, wal)
+
+    sid = "webhook:a/b:c"                             # native_id "a/b:c" → ':' and '/'
+    s = reg.resolve_session("alpha", "webhook", "a/b:c")
+    assert s is reg.get_session("alpha", sid)
+    await s.journal.record_intervention_dispatched(
+        intervention_id="iv1", iv_dict=_iv_dict("iv1"),
+    )
+
+    # the '/' in native_id must NOT have created a nested dir tree (the failure mode
+    # the encoding prevents) — verbatim it would be sessions/webhook:a/b:c/.
+    sessions_root = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "sessions"
+    assert not (sessions_root / "webhook:a" / "b:c").exists()
+    # the live session is keyed by the LOGICAL sid (public surface), not the encoding.
+    assert sid in reg.session_ids("alpha")
+
+    # restart: a fresh registry must DISCOVER the encoded dir, decode it back to the
+    # logical sid, and restore the session + its state under that sid (the round-trip
+    # that exercises encode→dir→discover→decode→restore via the public surface).
+    reg2 = _make_registry(tmp_path, wal)
+    await reg2.restore_all()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    restored = reg2.get_session("alpha", sid)
+    assert restored is not None, "encoded-dir session must restore under its logical sid"
+    assert [iv.id for iv in restored.interventions.list_active()] == ["iv1"]


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-1: the `resolve_session` routing-core primitive on the merged Session (#1726). Lead-GO'd; pure S3 reuse, transport wiring deferred to S4b-2+ (byte-identical, 0 callers).

## Primitive

`registry.resolve_session(agent_name, transport, native_id, explicit_sid=None) → Session`:
- **default** = deterministic mapping `session_id = "<transport>:<native_id>"` → get-or-spawn (`_has_session`/`spawn_session`/`get_session`). First message auto-spawns; same key resumes.
- **explicit_sid** = join an EXISTING session; non-existent = `KeyError` with a decision-enabling message (never auto-created from a typo'd id).
- **scope** = within one Agent.

## Path-safety (lead's generalized decision iii)

A routing-key sid carries an **arbitrary** native_id (webhook/MCP ids may contain `:` `/` whitespace) — it would break the S5 per-session dir derivation (`/` → nested/garbled dirs). Fix: the logical sid stays `<transport>:<native_id>` everywhere (dict key / WAL session_id / `_matches_agent` filter); only the filesystem **dir component** is bijective-encoded (percent-encode, empty safe set) + reverse-decoded on discovery. alnum/`_.-~` pass through → existing safe sids (uuid hex, "main") encode to themselves = **byte-identical for pre-S4b sessions**.

Applied at all 4 derivation sites: `_session_state_dir`, the `spawn_session` fixup, `_discover_session_ids` (decode), **and `restore_all`'s own discovery loop** — that last one was a real bug the round-trip test caught (it read the encoded dir name as the sid without decoding → the session missed `get_session(logical_sid)` post-restore).

## Tier-2 test (falsification-verified)

`tests/test_resolve_session_routing.py` — 5 assertions: mapping determinism / explicit-join existing / non-existent=error (asserts the behavioral no-auto-create invariant, not message text) / scope-within-agent / **path round-trip** (sid with `:` and `/` survives spawn→encoded-dir→discover→decode→restore + state). Falsified both cores: encoding-off → `/` nests the dir (round-trip reds); get-or-spawn-off → mapping non-deterministic (reds).

## Test plan

- [x] `tests/test_resolve_session_routing.py` 5 passed; both mechanisms falsification-verified (clean reds, restored).
- [x] 782 per-session/restore/rewind/registry regression tests green (encode/decode touches durability-critical discovery/restore).
- [x] `ruff check` clean; `test_tier_audit --strict` clean (no Tier-4).
- [x] byte-identical: 0 callers of resolve_session; safe sids encode to themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
