### PR TITLE
feat(1726): FP-0043 S4b-3a — message-based cron → per-job cron Session

### DIFF
--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -73,21 +73,26 @@ def _make_cron_runner():
         result = await agent.run(skill, dict(job.input))
         return "ok" if result.ok else "error"
 
-    async def _inbox_pusher(to: str, envelope: dict) -> str:
-        """Deliver ``envelope`` to agent ``to`` via the registry.
+    async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        """Deliver ``envelope`` to the job's own ``cron:<job_name>`` Session of
+        agent ``to`` via the registry.
 
-        Uses ``ensure_running`` so the agent's router loop is live to
-        consume the inbox put — same pattern A2A uses. The envelope
-        is dispatched as ``kind="user"`` so the LLM processes the
-        text as a turn; PR-A sender attribution emits the
-        ``[context shift]`` state_change entry from the
-        ``sender="cron:<name>"`` field.
+        FP-0043 S4b-3a: a message-based cron job is re-keyed from the agent's
+        "main" session to a per-job ``cron:<native_id>`` Session (resolve_session
+        get-or-spawn). Persistent per job — the stable ``native_id`` (= job name)
+        resumes the SAME session across fires, so the conversation accumulates a
+        history of prior runs ("what changed since last run"). The run-loop is
+        booted WITHOUT a forwarder (``ensure_session_running``) since cron is
+        unattended (output handling = S4b-3b notify layer); the envelope is
+        dispatched as ``kind="user"`` so the LLM processes the text as a turn, with
+        ``sender="cron:<name>"`` driving the PR-A attribution state_change.
         """
         from reyn.interfaces.web.deps import _get_registry
+        from reyn.runtime.cron.routing import resolve_cron_session
         registry = _get_registry()
         try:
-            session = await registry.ensure_running(to)
-        except FileNotFoundError:
+            session = resolve_cron_session(registry, to, native_id)
+        except (FileNotFoundError, KeyError):
             return "error"
         await session._put_inbox("user", dict(envelope))
         return "ok"

--- a/src/reyn/runtime/cron/routing.py
+++ b/src/reyn/runtime/cron/routing.py
@@ -1,0 +1,39 @@
+"""FP-0043 Stage 4b-3a: cron-transport session routing (registry-only, unit-testable).
+
+Maps a fired cron job to its OWN conversation Session of the target agent via the
+routing-key primitive (registry.resolve_session). Kept free of any web / chainlit
+import so the mapping + run-binding is unit-tested directly with a registry; the
+web-server cron runner (``_inbox_pusher``) is the thin glue that supplies the
+registry + delivers the envelope.
+
+Behaviour change note (FP-0043 S4b-3a, owner-approved): a message-based cron job's
+delivery moves from the agent's shared "main" session to a ``cron:<job_name>``
+mapping — each job is its own conversation, PERSISTENT per job (the stable job name
+resumes the same Session across fires, so the conversation accumulates a history of
+prior runs = "what changed since last run"). Skill-based cron jobs stay headless
+(``SkillRuntime.run``); standalone ``reyn cron run`` (no registry) is unchanged.
+"""
+from __future__ import annotations
+
+CRON_TRANSPORT = "cron"
+
+
+def cron_session_id(job_name: str) -> str:
+    """The logical session-id (routing-key) for a cron job: ``cron:<job_name>``."""
+    return f"{CRON_TRANSPORT}:{job_name}"
+
+
+def resolve_cron_session(registry, agent_name: str, job_name: str):
+    """Resolve (get-or-spawn) the persistent ``cron:<job_name>`` Session of
+    ``agent_name`` and boot its run-loop so the scheduled turn is processed.
+
+    Steps (pure registry + session ops):
+      1. ``resolve_session(agent, "cron", job_name)`` — get-or-spawn by routing-key
+         (persistent: the same job resumes the same Session across fires).
+      2. ``ensure_session_running`` — boot the run-loop WITHOUT a forwarder (cron is
+         unattended; output handling is the S4b-3b notify layer, not the REPL sink).
+
+    Idempotent. Returns the resolved Session."""
+    session = registry.resolve_session(agent_name, CRON_TRANSPORT, job_name)
+    registry.ensure_session_running(agent_name, cron_session_id(job_name))
+    return session

--- a/src/reyn/runtime/cron/runners.py
+++ b/src/reyn/runtime/cron/runners.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 def build_default_runner(
     *,
     legacy_skill_runner: Callable[["CronJob"], Awaitable[str]] | None = None,
-    inbox_pusher: Callable[[str, dict], Awaitable[str]] | None = None,
+    inbox_pusher: Callable[[str, dict, str], Awaitable[str]] | None = None,
 ) -> Callable[["CronJob"], Awaitable[str]]:
     """Construct a CronScheduler-compatible runner.
 
@@ -47,10 +47,12 @@ def build_default_runner(
         ``async (job: CronJob) -> str`` that executes a skill-based job.
         When None, skill-based jobs return "error" with a warning.
     inbox_pusher:
-        ``async (to: str, envelope: dict) -> str`` that delivers an
-        envelope to the target agent's inbox. When None, message-based
-        jobs return "error" with a warning (= e.g. CLI standalone mode
-        with no AgentRegistry context).
+        ``async (to: str, envelope: dict, native_id: str) -> str`` that
+        delivers an envelope to the target agent's inbox. ``native_id`` is the
+        job name (FP-0043 S4b-3a routing-key native-id) so the pusher routes to
+        the job's own ``cron:<job_name>`` Session. When None, message-based jobs
+        return "error" with a warning (= e.g. CLI standalone mode with no
+        AgentRegistry context).
 
     Returns
     -------
@@ -73,7 +75,9 @@ def build_default_runner(
                 "text": job.message,
                 "sender": f"cron:{job.name}",
             }
-            return await inbox_pusher(job.to, envelope)
+            # FP-0043 S4b-3a: pass job.name as the routing-key native-id so the
+            # pusher delivers to the job's own cron:<job_name> Session.
+            return await inbox_pusher(job.to, envelope, job.name)
         # Skill-based legacy path.
         if legacy_skill_runner is None:
             logger.warning(

--- a/tests/test_cron_routing.py
+++ b/tests/test_cron_routing.py
@@ -1,0 +1,80 @@
+"""Tier 2: FP-0043 S4b-3a — cron-transport session routing (registry-only helper).
+
+A fired message-based cron job re-keys from the agent's shared "main" session to a
+``cron:<job_name>`` Session — persistent per job (the stable job name resumes the
+same Session across fires) and isolated from both "main" and other jobs. Real
+AgentRegistry + StateLog (no mocks).
+
+Falsification (feedback_falsify_acceptance_test_before_proof): the not-main /
+persistence assertions red if resolve_cron_session stops namespacing by job (both
+checked in the companion comments).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import Session
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.cron.routing import cron_session_id, resolve_cron_session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def test_cron_session_id():
+    """Tier 2: the routing-key for a cron job is cron:<job_name>."""
+    assert cron_session_id("morning_news") == "cron:morning_news"
+
+
+@pytest.mark.asyncio
+async def test_resolve_cron_session_maps_job_to_its_own_session(tmp_path):
+    """Tier 2: a job resolves to its own cron:<job> session, NOT the agent's main."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "news_agent")
+
+    s = resolve_cron_session(reg, "news_agent", "morning_news")
+    assert s is reg.get_session("news_agent", "cron:morning_news")
+    # the re-key: cron delivery is NOT the agent's shared "main" session.
+    assert reg.get_session("news_agent", "main") is not s
+
+
+@pytest.mark.asyncio
+async def test_resolve_cron_session_is_persistent_per_job(tmp_path):
+    """Tier 2: the same job resumes the SAME session across fires (history accrues)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "news_agent")
+
+    first = resolve_cron_session(reg, "news_agent", "morning_news")
+    second = resolve_cron_session(reg, "news_agent", "morning_news")  # next fire
+    assert second is first                            # persistent, not fresh-per-fire
+
+
+@pytest.mark.asyncio
+async def test_resolve_cron_session_jobs_are_isolated(tmp_path):
+    """Tier 2: distinct jobs get distinct sessions (no cross-job bleed)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "news_agent")
+
+    a = resolve_cron_session(reg, "news_agent", "morning_news")
+    b = resolve_cron_session(reg, "news_agent", "nightly_digest")
+    assert a is not b
+    assert reg.get_session("news_agent", "cron:morning_news") is a
+    assert reg.get_session("news_agent", "cron:nightly_digest") is b

--- a/tests/test_fp0041_prb_cron_message_shape.py
+++ b/tests/test_fp0041_prb_cron_message_shape.py
@@ -327,8 +327,10 @@ async def test_runner_dispatches_message_based_to_inbox_pusher():
 
     pushed: list = []
 
-    async def _pusher(to, envelope):
-        pushed.append((to, envelope))
+    # FP-0043 S4b-3a: the pusher now also receives ``native_id`` (= job.name) so
+    # it can route to the job's own cron:<job_name> Session.
+    async def _pusher(to, envelope, native_id):
+        pushed.append((to, envelope, native_id))
         return "ok"
 
     async def _legacy(job):
@@ -347,10 +349,12 @@ async def test_runner_dispatches_message_based_to_inbox_pusher():
 
     assert result == "ok"
     assert pushed, "inbox_pusher must be called at least once for message-based job"
-    target, envelope = pushed[0]
+    target, envelope, native_id = pushed[0]
     assert target == "news_agent"
     assert envelope["text"] == "今日のニュース"
     assert envelope["sender"] == "cron:morning_news"
+    # S4b-3a: the routing-key native-id is the job name (→ cron:morning_news session).
+    assert native_id == "morning_news"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-3a: message-based cron → per-job `cron:<job_name>` Session (the inbound re-key; **stage 1 of 2** — S4b-3b adds the notify output layer). #1726.

## What

Re-keys a message-based cron job's delivery from the agent's shared "main" session to a per-job `cron:<job_name>` Session via the routing-key primitive — **persistent per job** (stable job name resumes the same Session across fires → the conversation accumulates a history of prior runs, "what changed since last run"). Reuses the S4b-2 no-forwarder run primitive (`ensure_session_running`).

- `runners.py`: `build_default_runner` threads `job.name` as the routing-key native-id to the pusher (signature `(to, envelope, native_id)`).
- `runtime/cron/routing.py` (new, registry-only helper, unit-testable): `cron_session_id` + `resolve_cron_session` (resolve_session get-or-spawn + ensure_session_running). Mirrors the S4b-2 `resolve_web_session` split lead praised.
- `web/server.py` `_inbox_pusher`: routes via `resolve_cron_session` instead of `ensure_running(to)` (= main).

## Scope (lead-decided)

- **message-based only** — skill-based cron stays headless (`SkillRuntime.run`; one-shot scheduled skill-run needs no conversation).
- **registry-having path only** — only `reyn web` cron changes; standalone `reyn cron run` (`inbox_pusher=None`) unchanged.
- **byte-identical** otherwise: skill-based / standalone / everything else unchanged; existing cron.jobs configs keep working. Output handling unchanged here (cron outbox holds only bounded durable kinds until S4b-3b's notify drain).

## Test plan

- [x] `tests/test_cron_routing.py` (4): job→`cron:<job>` session (NOT main) / persistent-per-job / job isolation. Falsification-verified (route-to-main → mapping + isolation red).
- [x] Adapted `test_fp0041_prb_cron_message_shape.py` dispatch test → 3-arg pusher + `native_id=job.name` contract.
- [x] 645 cron/web/registry/a2a regression green; ruff + tier-audit clean.
- [x] CI-testable (headless cron — no chainlit-skip problem; the web extra is in CI).

Next: **S4b-3b** — the net-new notify output layer (cron session outbox → notify drain → broker post→telegram + event-log + attach), separate PR for careful review of the novel channel abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
