### PR TITLE
feat(1726): FP-0043 S4b-3b — cron notify output layer

### DIFF
--- a/src/reyn/chat/external_routing.py
+++ b/src/reyn/chat/external_routing.py
@@ -352,12 +352,37 @@ def make_outbox_interceptor(
     return _interceptor
 
 
+def make_session_mcp_dispatcher(session: Any) -> Callable[[str, dict], Awaitable[Any]]:
+    """Build an MCP dispatcher bound to ``session``'s router OpContext.
+
+    ``async (mcp_tool, args) -> result`` where ``mcp_tool`` is ``<server>__<tool>``.
+    Invokes the tool through the session's own OpContext so the permission gate,
+    workspace, and events log all come from the right session. Shared by the
+    external-transport outbox interceptor (FP-0041 PR-D2) and the cron failure
+    notifier (FP-0043 S4b-3b) so both relay through one consistent path."""
+    async def _mcp_dispatcher(mcp_tool: str, args: dict) -> Any:
+        if "__" not in mcp_tool:
+            raise ValueError(
+                f"external_transports mcp_tool must be '<server>__<tool>', "
+                f"got {mcp_tool!r}",
+            )
+        server, tool = mcp_tool.split("__", 1)
+        from reyn.core.op_runtime.mcp import handle as mcp_handle
+        from reyn.schemas.models import MCPIROp
+        op = MCPIROp(kind="mcp", server=server, tool=tool, args=dict(args))
+        ctx = session._make_router_op_context()
+        return await mcp_handle(op=op, ctx=ctx, caller="external_routing")
+
+    return _mcp_dispatcher
+
+
 __all__ = [
     "ExternalTransportEntry",
     "ExternalTransportRouting",
     "RouteResult",
     "build_mcp_args",
     "make_outbox_interceptor",
+    "make_session_mcp_dispatcher",
     "parse_external_transports",
     "route_to_mcp",
 ]

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -365,6 +365,7 @@ class CronJobConfig:
     schedule: str   # 5-field cron expression
     to: str | None = None        # message-based: target agent name
     message: str | None = None   # message-based: free-form text
+    notify: str | None = None    # FP-0043 S4b-3b: opt-in notify channel (e.g. "telegram"); None = event-log only
     skill: str | None = None     # skill-based legacy: skill name
     input: dict = field(default_factory=dict)
     enabled: bool = True
@@ -458,11 +459,16 @@ def _build_cron_config(raw: object) -> CronConfig:
         if not isinstance(raw_input, dict):
             raw_input = {}
         enabled = bool(entry.get("enabled", True))
+        # FP-0043 S4b-3b: opt-in notify channel (message-based only; a skill-based
+        # job is headless with no conversational reply to relay).
+        notify = entry.get("notify")
+        notify = notify if (has_message_shape and isinstance(notify, str) and notify) else None
         jobs.append(CronJobConfig(
             name=name,
             schedule=schedule,
             to=to if has_message_shape else None,
             message=message if has_message_shape else None,
+            notify=notify,
             skill=skill if has_skill else None,
             input=dict(raw_input),
             enabled=enabled,

--- a/src/reyn/interfaces/cli/commands/cron.py
+++ b/src/reyn/interfaces/cli/commands/cron.py
@@ -102,6 +102,7 @@ def _jobs_to_cron_jobs(job_configs) -> list:
             schedule=jc.schedule,
             to=jc.to,
             message=jc.message,
+            notify=jc.notify,
             skill=jc.skill,
             input=dict(jc.input),
             enabled=jc.enabled,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -182,24 +182,14 @@ def _wire_external_outbox_interceptor(session, routing) -> None:
     allow); failures propagate as exceptions and are surfaced through
     ``RouteResult(status="error", ...)`` by the routing primitive.
     """
-    from reyn.chat.external_routing import make_outbox_interceptor
-
-    async def _mcp_dispatcher(mcp_tool: str, args: dict):
-        if "__" not in mcp_tool:
-            raise ValueError(
-                f"external_transports mcp_tool must be '<server>__<tool>', "
-                f"got {mcp_tool!r}",
-            )
-        server, tool = mcp_tool.split("__", 1)
-        from reyn.core.op_runtime.mcp import handle as mcp_handle
-        from reyn.schemas.models import MCPIROp
-        op = MCPIROp(kind="mcp", server=server, tool=tool, args=dict(args))
-        ctx = session._make_router_op_context()
-        return await mcp_handle(op=op, ctx=ctx, caller="external_routing")
+    from reyn.chat.external_routing import (
+        make_outbox_interceptor,
+        make_session_mcp_dispatcher,
+    )
 
     interceptor = make_outbox_interceptor(
         routing=routing,
-        mcp_dispatcher=_mcp_dispatcher,
+        mcp_dispatcher=make_session_mcp_dispatcher(session),
     )
     session._outbox_interceptor = interceptor
 

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -94,12 +94,46 @@ def _make_cron_runner():
             session = resolve_cron_session(registry, to, native_id)
         except (FileNotFoundError, KeyError):
             return "error"
-        await session._put_inbox("user", dict(envelope))
+        payload = dict(envelope)
+        # FP-0043 S4b-3b: opt-in notify → tag the inbox with reply_to=ExternalRef so
+        # the agent's final reply is relayed to the channel by the (already
+        # factory-wired) external-transport outbox interceptor. No notify → no
+        # reply_to → interceptor falls through → event-log only (current behaviour).
+        notify = payload.pop("notify", None)
+        if notify:
+            from reyn.chat.transport import ExternalRef
+            payload["reply_to"] = ExternalRef(transport=notify, destination={})
+        await session._put_inbox("user", payload)
         return "ok"
+
+    async def _failure_notifier(job, reason: str) -> None:
+        """FP-0043 S4b-3b errors=(b): relay a job-execution FAILURE (a job that
+        never produced a reply) to its notify channel, via the SAME MCP route the
+        outbox interceptor uses (telegram→broker__post_message). Best-effort —
+        unconfigured channel / unresolvable session degrades to event-log."""
+        from reyn.chat.external_routing import make_session_mcp_dispatcher, route_to_mcp
+        from reyn.config import load_config
+        from reyn.interfaces.web.deps import _get_registry
+        from reyn.runtime.cron.routing import resolve_cron_session
+        routing = load_config().external_transports
+        if not routing.transports:
+            return
+        registry = _get_registry()
+        try:
+            session = resolve_cron_session(registry, job.to, job.name)
+        except (FileNotFoundError, KeyError):
+            return
+        await route_to_mcp(
+            job.notify, {},
+            f"⚠ cron job {job.name!r} failed: {reason}",
+            routing=routing,
+            mcp_dispatcher=make_session_mcp_dispatcher(session),
+        )
 
     return build_default_runner(
         legacy_skill_runner=_legacy_skill_runner,
         inbox_pusher=_inbox_pusher,
+        failure_notifier=_failure_notifier,
     )
 
 

--- a/src/reyn/runtime/cron/runners.py
+++ b/src/reyn/runtime/cron/runners.py
@@ -38,6 +38,7 @@ def build_default_runner(
     *,
     legacy_skill_runner: Callable[["CronJob"], Awaitable[str]] | None = None,
     inbox_pusher: Callable[[str, dict, str], Awaitable[str]] | None = None,
+    failure_notifier: Callable[["CronJob", str], Awaitable[None]] | None = None,
 ) -> Callable[["CronJob"], Awaitable[str]]:
     """Construct a CronScheduler-compatible runner.
 
@@ -53,12 +54,30 @@ def build_default_runner(
         the job's own ``cron:<job_name>`` Session. When None, message-based jobs
         return "error" with a warning (= e.g. CLI standalone mode with no
         AgentRegistry context).
+    failure_notifier:
+        ``async (job: CronJob, reason: str) -> None`` invoked when a job with an
+        opt-in ``notify`` channel FAILS to dispatch (FP-0043 S4b-3b, errors = (b)
+        runner-level). The successful turn's final reply is relayed via the outbox
+        interceptor (not here); this covers execution failures that never produce a
+        reply. None / no ``job.notify`` → no failure notification. Best-effort: the
+        notifier's own exceptions are swallowed so notify never fails the job.
 
     Returns
     -------
     Callable returning "ok" / "error" per fire. Exceptions propagate
     to the scheduler which records ``last_run_error``.
     """
+    async def _notify_failure(job: "CronJob", reason: str) -> None:
+        if not job.notify or failure_notifier is None:
+            return
+        try:
+            await failure_notifier(job, reason)
+        except Exception:  # noqa: BLE001 — notify is best-effort, never fail the job
+            logger.warning(
+                "cron failure-notify raised for job %r (channel=%r)",
+                job.name, job.notify,
+            )
+
     async def _runner(job: "CronJob") -> str:
         if job.is_message_based():
             if inbox_pusher is None:
@@ -75,9 +94,21 @@ def build_default_runner(
                 "text": job.message,
                 "sender": f"cron:{job.name}",
             }
+            # FP-0043 S4b-3b: carry the opt-in notify channel so the pusher sets
+            # reply_to=ExternalRef → the final reply routes to the channel via the
+            # outbox interceptor. Skill-based jobs have no conversational reply.
+            if job.notify:
+                envelope["notify"] = job.notify
             # FP-0043 S4b-3a: pass job.name as the routing-key native-id so the
             # pusher delivers to the job's own cron:<job_name> Session.
-            return await inbox_pusher(job.to, envelope, job.name)
+            try:
+                result = await inbox_pusher(job.to, envelope, job.name)
+            except Exception as exc:
+                await _notify_failure(job, f"{type(exc).__name__}: {exc}")
+                raise
+            if result == "error":
+                await _notify_failure(job, "dispatch failed (could not deliver to cron session)")
+            return result
         # Skill-based legacy path.
         if legacy_skill_runner is None:
             logger.warning(

--- a/src/reyn/runtime/cron/scheduler.py
+++ b/src/reyn/runtime/cron/scheduler.py
@@ -43,6 +43,13 @@ class CronJob:
     # ── message-based (FP-0041 PR-B, recommended) ─────────────────
     to: str | None = None       # target agent name
     message: str | None = None  # free-form text dispatched to agent.inbox
+    # FP-0043 S4b-3b: opt-in unattended notification channel (e.g. "telegram").
+    # None = off (event-log only = current behaviour). When set, the fired cron
+    # turn's final reply is routed to the channel via the external-transport outbox
+    # interceptor (reply_to=ExternalRef), and a job-execution FAILURE is notified at
+    # the runner level. The channel name maps to an MCP tool via reyn.yaml
+    # external_transports (e.g. telegram→broker__post_message).
+    notify: str | None = None
     # ── skill-based (FP-0009 legacy, backward compat) ──────────────
     skill: str | None = None    # skill name to run via SkillRuntime.run
     input: dict = field(default_factory=dict)
@@ -64,6 +71,7 @@ class CronJob:
             "name": self.name,
             "to": self.to,
             "message": self.message,
+            "notify": self.notify,
             "skill": self.skill,
             "schedule": self.schedule,
             "input": self.input,

--- a/tests/test_cron_notify.py
+++ b/tests/test_cron_notify.py
@@ -1,0 +1,131 @@
+"""Tier 2: FP-0043 S4b-3b — cron notify output layer (runner hook + config).
+
+The notify layer stands on the existing FP-0041 external-transport outbox
+interceptor: a notify-configured cron job tags its inbox with the channel (→
+``reply_to=ExternalRef`` → the interceptor relays the agent's final reply), and a
+job-execution FAILURE (errors = (b), runner-level) calls an injected failure
+notifier. opt-in default off — no ``notify`` reproduces today's event-log-only
+behaviour. These pin the runner hook + config parse chainlit/web-free (the
+mcp_dispatcher is injected, so no real broker/telegram is needed).
+
+Falsification (feedback_falsify_acceptance_test_before_proof): the opt-in tests red
+if notify stops gating; the failure tests red if the hook stops firing (companion
+comments).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.cron import CronJob
+from reyn.runtime.cron.runners import build_default_runner
+
+
+def _msg_job(*, notify=None) -> CronJob:
+    return CronJob(
+        name="news", schedule="0 9 * * *", to="agent_x", message="hi", notify=notify,
+    )
+
+
+@pytest.mark.asyncio
+async def test_notify_channel_flows_to_the_pusher_envelope():
+    """Tier 2: a notify-configured job carries the channel to the pusher (→ reply_to)."""
+    seen: list = []
+
+    async def _pusher(to, envelope, native_id):
+        seen.append(envelope)
+        return "ok"
+
+    runner = build_default_runner(inbox_pusher=_pusher)
+    await runner(_msg_job(notify="telegram"))
+    assert seen[0].get("notify") == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_no_notify_means_no_channel_tag():
+    """Tier 2: opt-in OFF — no notify → no channel tag (event-log only = today)."""
+    seen: list = []
+
+    async def _pusher(to, envelope, native_id):
+        seen.append(envelope)
+        return "ok"
+
+    runner = build_default_runner(inbox_pusher=_pusher)
+    await runner(_msg_job(notify=None))
+    assert "notify" not in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_failure_notifier_fires_on_dispatch_error():
+    """Tier 2: errors=(b) — a notify job that fails to dispatch calls the notifier."""
+    notified: list = []
+
+    async def _pusher(to, envelope, native_id):
+        return "error"          # delivery failed
+
+    async def _notifier(job, reason):
+        notified.append((job.name, reason))
+
+    runner = build_default_runner(inbox_pusher=_pusher, failure_notifier=_notifier)
+    result = await runner(_msg_job(notify="telegram"))
+    assert result == "error"
+    assert notified and notified[0][0] == "news"
+
+
+@pytest.mark.asyncio
+async def test_failure_notifier_silent_without_notify():
+    """Tier 2: a failing job WITHOUT notify does NOT call the notifier (opt-in)."""
+    notified: list = []
+
+    async def _pusher(to, envelope, native_id):
+        return "error"
+
+    async def _notifier(job, reason):
+        notified.append(job.name)
+
+    runner = build_default_runner(inbox_pusher=_pusher, failure_notifier=_notifier)
+    await runner(_msg_job(notify=None))
+    assert notified == []        # opt-in off → no failure notification
+
+
+@pytest.mark.asyncio
+async def test_failure_notifier_fires_on_exception_then_reraises():
+    """Tier 2: an exception during dispatch notifies, then re-raises for the scheduler."""
+    notified: list = []
+
+    async def _pusher(to, envelope, native_id):
+        raise RuntimeError("boom")
+
+    async def _notifier(job, reason):
+        notified.append(reason)
+
+    runner = build_default_runner(inbox_pusher=_pusher, failure_notifier=_notifier)
+    with pytest.raises(RuntimeError):       # propagates so the scheduler records it
+        await runner(_msg_job(notify="telegram"))
+    assert notified and "boom" in notified[0]
+
+
+def test_notify_field_parses_from_config_message_shape():
+    """Tier 2: cron.jobs[].notify parses onto CronJobConfig (message-based)."""
+    from reyn.config.infra import _build_cron_config
+
+    cfg = _build_cron_config({
+        "jobs": [{
+            "name": "morning_news", "to": "news_agent",
+            "message": "今日のニュース", "schedule": "0 9 * * *",
+            "notify": "telegram",
+        }],
+    })
+    assert cfg.jobs[0].notify == "telegram"
+
+
+def test_notify_ignored_for_skill_shape():
+    """Tier 2: a skill-based job has no conversational reply → notify is dropped."""
+    from reyn.config.infra import _build_cron_config
+
+    cfg = _build_cron_config({
+        "jobs": [{
+            "name": "index", "skill": "index_events",
+            "schedule": "0 9 * * *", "notify": "telegram",
+        }],
+    })
+    assert cfg.jobs[0].notify is None


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-3b: cron notify output layer (**stage 2 of 2 — completes cron**). #1726. Establishes the unattended notification layer by **reusing** the existing FP-0041 external-transport outbox interceptor (lead-confirmed existing-mechanism-first) — **zero fresh channel abstraction**.

## Why reuse works (no new infra)

- The outbox interceptor is wired in the session factory → cron sessions already have it.
- `dispatchable_kinds=("agent",)` is already the "final-result-only" verbosity default.
- telegram→broker routes via the existing `route_to_mcp` (the broker is an MCP server: `broker__post_message`) — the same path I use for reporting (consistency).

## What

- `CronJob`/`CronJobConfig` gain a per-job **`notify:`** field (opt-in, default off; message-based only). Parsed from reyn.yaml/.reyn/cron.yaml.
- **final-result relay (reuse)**: runner tags the envelope with `notify`; web `_inbox_pusher` converts it to `reply_to=ExternalRef(transport=<notify>)` on the cron inbox → the agent reply inherits reply_to → the factory-wired interceptor relays it. No notify → event-log only.
- **errors = (b) runner-level**: `build_default_runner` gains an injected `failure_notifier(job, reason)`; a notify job whose dispatch errors/raises calls it (then re-raises so the scheduler records `last_run_error`). Web wiring routes the failure via the same `route_to_mcp`. Best-effort → degrades to event-log.
- extracted `make_session_mcp_dispatcher` into `external_routing.py` (shared by the interceptor wiring + the cron failure notifier).

`event-log + attach = free` (cron sessions are real registry sessions). backward-compat: existing cron.jobs (no notify) unchanged; byte-identical for non-notify.

## Test plan

- [x] `tests/test_cron_notify.py` (7): notify→envelope tag / opt-in-off no tag / failure-notifier fires on error + on exception(+reraise) / silent without notify / config parse (+ skill shape drops notify). Falsification-verified (notify-gating off / failure-hook off → red). Fake notifier injected (no real broker/telegram).
- [x] 813 cron/config/external-routing/web/registry regression green; 2 failures are pre-existing not-my-diff (swebench, web_fetch_preview — unrelated subsystems).
- [x] ruff + tier-audit clean. CI-testable (headless cron + web extra in CI).

**This completes cron (3a inbound re-key + 3b notify).** Remaining S4b transports: a2a / webhook / MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
