### PR TITLE
feat(slash): /model — per-session runtime model-class override

### DIFF
--- a/src/reyn/chat/session.py
+++ b/src/reyn/chat/session.py
@@ -1235,6 +1235,10 @@ class Session:
             environment_backend=environment_backend,
         )
         self._resolver = resolver or ModelResolver({})
+        # Per-session runtime model override — set by ``/model <class>``.
+        # None = use Agent identity default (byte-identical to pre-override).
+        # In-memory only: cleared on session restart (not persisted to journal).
+        self._model_override: str | None = None
         # #398 v4 emitter wiring (= permission_manager → state_change).
         # Subscribe to ``_persist`` events on the shared PermissionResolver
         # so a permission grant / revoke mints a state_change history
@@ -2121,7 +2125,7 @@ class Session:
 
     @property
     def model(self) -> str:
-        return self._agent.model
+        return self._model_override if self._model_override is not None else self._agent.model
 
     @property
     def workspace_dir(self) -> "Path":

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -247,6 +247,7 @@ from reyn.interfaces.slash import help as _help_mod  # noqa: E402, F401
 from reyn.interfaces.slash import image as _image_mod  # noqa: E402, F401
 from reyn.interfaces.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401
+from reyn.interfaces.slash import model as _model_mod  # noqa: E402, F401
 from reyn.interfaces.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.interfaces.slash import plan as _plan_mod  # noqa: E402, F401
 from reyn.interfaces.slash import quit as _quit_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -1,0 +1,60 @@
+"""``/model`` — runtime model-class override for the current session.
+
+Switch the model class used by this session without restarting:
+
+  /model              → show current model + agent default + available classes
+  /model <class>      → override this session's model to <class> (sticky for
+                        the session lifetime; cleared on restart)
+
+Valid ``<class>`` values are the operator-configured model classes from
+``reyn.yaml`` (e.g. ``light``, ``standard``, ``strong``, plus any user-defined
+entries). Unknown class names are rejected with the full list — the resolver's
+class gate ensures proxy config stays the single source of truth.
+
+Byte-identical when unused: a session that never runs ``/model`` uses the
+agent-identity default (``Agent.model``) unchanged.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.interfaces.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.chat.session import ChatSession
+
+
+@slash(
+    "model",
+    summary="Show or override the model class for this session",
+    usage="/model [<class>]",
+)
+async def model_cmd(session: "ChatSession", args: str) -> None:
+    """/model [<class>] — show current model or set a per-session override."""
+    resolver = session._resolver
+    requested = args.strip()
+
+    if not requested:
+        agent_default = session._agent.model
+        current = session.model
+        override = session._model_override
+        lines = [f"model: {current}"]
+        if override is not None:
+            lines.append(f"  override: {override} (this session — clears on restart)")
+            lines.append(f"  agent default: {agent_default}")
+        else:
+            lines.append("  (agent default, no override set)")
+        lines.append(f"available: {', '.join(resolver.known_classes())}")
+        await reply(session, "\n".join(lines))
+        return
+
+    if not resolver.is_known_class(requested):
+        await reply_error(
+            session,
+            f"unknown model class {requested!r}; "
+            f"available: {', '.join(resolver.known_classes())}",
+        )
+        return
+
+    session._model_override = requested
+    await reply(session, f"model → {requested} (this session — clears on restart)")

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -293,6 +293,13 @@ class ModelResolver:
         """
         return name in self._resolved
 
+    def known_classes(self) -> list[str]:
+        """Return a sorted list of all known model class names (user-configured +
+        built-ins). Use for user-facing display (e.g. ``/model`` no-arg) and for
+        validation error messages — single public surface, avoids callers reaching
+        into ``_resolved`` directly."""
+        return sorted(self._resolved)
+
     def resolve_class_or_fallback(
         self, requested: str | None, fallback: str | None, *, where: str = "",
     ) -> str:

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -1,204 +1,252 @@
 """Tier 2: ``/model`` slash command — per-session model-class override.
 
-Tests:
-  1. override wins over Agent default (session.model returns override)
-  2. invalid class rejected with known_classes() list in error
-  3. unset → Agent default returned (byte-identical baseline)
-  4. sticky within session lifetime (override survives multiple calls)
-  5. known_classes() includes user-configured classes
+Three test groups:
 
-Each test is falsification-verified per [[feedback_falsify_acceptance_test_before_proof]]:
-the acceptance assertion is paired with a direct check that the mechanism
-under test WOULD fail without it (documented inline).
+A. ``Session.model`` property (real Session, public-surface assert):
+   Exercises the actual production property — no stub copy. The FP-0043
+   coherence the lead wanted to verify lives here.
+
+B. ``model_cmd`` handler (mixed):
+   - B1: Real Session with captured ``_put_outbox`` for paths that read
+     ``session.model`` (no-arg display).
+   - B2: Stub session for paths that don't read ``session.model`` (valid/
+     invalid class dispatch) — stub has no ``model`` property so any
+     accidental read would raise AttributeError, making the boundary explicit.
+
+C. ``ModelResolver.known_classes()`` — no session needed.
+
+Falsification notes (per [[feedback_falsify_acceptance_test_before_proof]]):
+  Every test documents which assertion would fail if the mechanism were absent.
 """
 from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 
 from reyn.chat.outbox import OutboxMessage
+from reyn.chat.session import Session
+from reyn.config import SafetyConfig, TimeoutConfig
+from reyn.core.events.state_log import StateLog
 from reyn.interfaces.slash.model import model_cmd
 from reyn.llm.model_resolver import ModelResolver
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(tmp_path: Path, *, model: str = "standard") -> Session:
+    """Minimal real Session with WAL."""
+    return Session(
+        agent_name="test_agent",
+        model=model,
+        state_log=StateLog(tmp_path / "state.wal"),
+        safety=SafetyConfig(timeout=TimeoutConfig(chain_seconds=60.0)),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
 
 def _make_resolver(extra: dict | None = None) -> ModelResolver:
-    """Resolver with light/standard/strong plus any extra user classes."""
-    mapping = {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o", "strong": "openai/gpt-4"}
+    mapping = {
+        "light": "openai/gpt-4o-mini",
+        "standard": "openai/gpt-4o",
+        "strong": "openai/gpt-4",
+    }
     if extra:
         mapping.update(extra)
     return ModelResolver(mapping, builtin={})
 
 
-class _FakeAgent:
-    model: str = "standard"
-    agent_name: str = "test-agent"
+def _capture_outbox(session: Session) -> list[OutboxMessage]:
+    """Replace session._put_outbox with a simple collector; return the list."""
+    captured: list[OutboxMessage] = []
+
+    async def _collect(msg: OutboxMessage) -> None:
+        captured.append(msg)
+
+    session._put_outbox = _collect  # type: ignore[method-assign]
+    return captured
+
+
+def _reply_text(msgs: list[OutboxMessage]) -> str:
+    return "\n".join(m.text for m in msgs if m.text)
+
+
+def _error_text(msgs: list[OutboxMessage]) -> str:
+    return "\n".join(m.text for m in msgs if m.kind == "error" and m.text)
 
 
 class _FakeSession:
+    """Stub for handler tests that do NOT read session.model.
+
+    Deliberately has NO ``model`` property — any accidental read raises
+    AttributeError, making the test boundary explicit.  Model-state assertions
+    belong in Group A (real Session).
+    """
+
     def __init__(self, resolver: ModelResolver, *, agent_model: str = "standard"):
-        _agent = _FakeAgent()
-        _agent.model = agent_model
-        self._agent = _agent
+        from reyn.chat.agent import Agent as _Agent
+        self._agent = _Agent(agent_name="test", model=agent_model)
         self._resolver = resolver
         self._model_override: str | None = None
         self.outbox: list[OutboxMessage] = []
 
-    @property
-    def model(self) -> str:
-        return self._model_override if self._model_override is not None else self._agent.model
-
     async def _put_outbox(self, msg: OutboxMessage) -> None:
         self.outbox.append(msg)
 
-    def reply_text(self) -> str:
-        return "\n".join(m.text for m in self.outbox if m.text)
+    def error_text(self) -> str:
+        return "\n".join(m.text for m in self.outbox if m.kind == "error" and m.text)
 
 
-# ---------------------------------------------------------------------------
-# Test 1: override wins over Agent default
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Group A: Session.model property — real Session, public-surface assert
+# ===========================================================================
+
+def test_session_model_returns_override_when_set(tmp_path):
+    """Tier 2 (Group A): session.model returns override class when _model_override set.
+
+    Falsification: if the property still returned self._agent.model, then after
+    setting _model_override = "light", session.model would remain "standard"
+    and the assertion below would fail.
+    """
+    session = _make_session(tmp_path, model="standard")
+    assert session.model == "standard"  # baseline: no override
+
+    session._model_override = "light"
+    assert session.model == "light"  # override wins
+
+
+def test_session_model_returns_agent_default_when_no_override(tmp_path):
+    """Tier 2 (Group A): session.model == agent default when _model_override is None.
+
+    Falsification: if _model_override were not initialised to None (e.g. defaulted
+    to some class), session.model would not equal the construction-time model and
+    this assertion would fail.
+    """
+    session = _make_session(tmp_path, model="strong")
+    assert session.model == "strong"  # agent default, no override applied
+
+
+def test_session_model_override_cleared_returns_agent_default(tmp_path):
+    """Tier 2 (Group A): clearing _model_override restores agent default.
+
+    Falsification: if clearing the override did not affect the property, the
+    final assertion would still return "light" instead of "standard".
+    """
+    session = _make_session(tmp_path, model="standard")
+    session._model_override = "light"
+    assert session.model == "light"
+
+    session._model_override = None
+    assert session.model == "standard"  # agent default restored
+
+
+# ===========================================================================
+# Group B1: no-arg display — real Session (reads session.model)
+# ===========================================================================
 
 @pytest.mark.asyncio
-async def test_model_override_wins_over_agent_default():
-    """Tier 2: session.model returns override when /model <class> is set.
+async def test_model_cmd_no_arg_display_with_active_override(tmp_path):
+    """Tier 2 (Group B1): /model (no-arg) with active override shows transient note.
 
-    Falsification: if the property still returned self._agent.model, then
-    session.model == "standard" even after override — the assertion below
-    would fail. Verified by asserting session.model BEFORE override == "standard".
+    Uses real Session so session.model reads through the production property.
+    Falsification: if the no-arg branch exited without posting, captured msgs
+    would be empty and all assertions would fail.
+    """
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver()
+    msgs = _capture_outbox(session)
+    session._model_override = "light"
+
+    await model_cmd(session, "")
+
+    text = _reply_text(msgs)
+    assert "light" in text
+    assert "this session" in text  # transient-override UX note
+    assert "available:" in text
+
+
+@pytest.mark.asyncio
+async def test_model_cmd_no_arg_display_no_override(tmp_path):
+    """Tier 2 (Group B1): /model (no-arg) without override shows no transient note.
+
+    Falsification: if the no-arg branch exited early, msgs would be empty.
+    """
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver()
+    msgs = _capture_outbox(session)
+
+    await model_cmd(session, "")
+
+    text = _reply_text(msgs)
+    assert "standard" in text
+    assert "no override" in text
+    assert "available:" in text
+    assert "this session" not in text  # no transient note when not overridden
+
+
+# ===========================================================================
+# Group B2: valid/invalid dispatch — stub (does NOT read session.model)
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_model_cmd_valid_class_replies_confirmation():
+    """Tier 2 (Group B2): /model <valid-class> posts confirmation reply.
+
+    Stub session has no model property; if the handler accidentally read
+    session.model it would raise AttributeError.
+    Falsification: if model_cmd exited without calling _put_outbox, outbox
+    would be empty and the assertion would fail.
     """
     resolver = _make_resolver()
     session = _FakeSession(resolver, agent_model="standard")
-    assert session.model == "standard"  # baseline: no override
 
     await model_cmd(session, "light")
 
-    assert session._model_override == "light"
-    assert session.model == "light"  # override wins
-    assert "model → light" in session.reply_text()
+    texts = [m.text for m in session.outbox if m.text]
+    assert texts, "expected a confirmation reply"
+    combined = "\n".join(texts)
+    assert "light" in combined
+    assert "this session" in combined  # transient-override UX note
 
-
-# ---------------------------------------------------------------------------
-# Test 2: invalid class rejected with known_classes() list
-# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_model_invalid_class_rejected():
-    """Tier 2: /model <unknown> posts an error with available classes listed.
+async def test_model_cmd_invalid_class_posts_error_with_class_list():
+    """Tier 2 (Group B2): /model <unknown> posts error listing available classes.
 
     Falsification: if is_known_class() always returned True, no error would be
-    posted and _model_override would be set to the unknown value — the
-    assertion `session._model_override is None` would fail.
+    posted and error_text() would be empty — assertion would fail.
     """
     resolver = _make_resolver()
     session = _FakeSession(resolver)
 
     await model_cmd(session, "does_not_exist")
 
-    assert session._model_override is None  # not set on invalid class
-    error_msgs = [m for m in session.outbox if m.kind == "error"]
-    assert error_msgs, "expected an error outbox message"
-    error_text = error_msgs[0].text
-    assert "does_not_exist" in error_text
-    assert "light" in error_text  # available classes listed
-    assert "standard" in error_text
-    assert "strong" in error_text
+    error = session.error_text()
+    assert error, "expected an error message"
+    assert "does_not_exist" in error
+    assert "light" in error
+    assert "standard" in error
+    assert "strong" in error
+    # no success (non-error) messages
+    success = [m for m in session.outbox if m.kind != "error"]
+    assert not success, f"expected no success reply, got {success}"
 
 
-# ---------------------------------------------------------------------------
-# Test 3: unset → Agent default (byte-identical baseline)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_model_unset_returns_agent_default():
-    """Tier 2: session.model == Agent.model when no override is set.
-
-    Falsification: if _model_override defaulted to something non-None, this
-    assertion would fail. The test directly checks the before-any-override
-    state == Agent identity value, proving byte-identical behaviour.
-    """
-    resolver = _make_resolver()
-    session = _FakeSession(resolver, agent_model="strong")
-
-    assert session._model_override is None
-    assert session.model == "strong"  # Agent default, no override
-
-
-# ---------------------------------------------------------------------------
-# Test 4: sticky — override persists within session lifetime
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_model_override_sticky():
-    """Tier 2: once set, override persists across subsequent calls to session.model.
-
-    Falsification: if _model_override were reset on each property read,
-    session.model would return the Agent default on the second check.
-    """
-    resolver = _make_resolver()
-    session = _FakeSession(resolver, agent_model="standard")
-
-    await model_cmd(session, "light")
-    assert session.model == "light"
-
-    # second read — must still return override, not agent default
-    assert session.model == "light"
-    assert session._agent.model == "standard"  # agent default unchanged
-
-
-# ---------------------------------------------------------------------------
-# Test 5: no-arg display shows current + override note + available classes
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_model_no_arg_display_with_override():
-    """Tier 2: /model (no-arg) shows current model, override note, available classes.
-
-    Falsification: if the handler exited early without building the display
-    string, session.outbox would be empty — the assertion would fail.
-    Also verifies the transient-override UX note is present.
-    """
-    resolver = _make_resolver()
-    session = _FakeSession(resolver, agent_model="standard")
-    # Set an override first so the display branch fires
-    session._model_override = "light"
-
-    await model_cmd(session, "")
-
-    text = session.reply_text()
-    assert "light" in text            # current model shown
-    assert "this session" in text     # transient note shown
-    assert "standard" in text         # agent default shown
-    assert "available:" in text       # class list present
-
-
-@pytest.mark.asyncio
-async def test_model_no_arg_display_no_override():
-    """Tier 2: /model (no-arg) without an override shows agent default + no override note."""
-    resolver = _make_resolver()
-    session = _FakeSession(resolver, agent_model="standard")
-
-    await model_cmd(session, "")
-
-    text = session.reply_text()
-    assert "standard" in text
-    assert "no override" in text
-    assert "available:" in text
-    assert "this session" not in text  # no override note when not set
-
-
-# ---------------------------------------------------------------------------
-# Test 6: known_classes() includes user-configured classes
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Group C: ModelResolver.known_classes() — no session needed
+# ===========================================================================
 
 def test_known_classes_includes_user_configured():
-    """Tier 2: ModelResolver.known_classes() returns user-defined classes.
+    """Tier 2 (Group C): known_classes() returns sorted list including user-defined.
 
     Falsification: if known_classes() only returned STANDARD_CLASSES and ignored
-    user mapping, "fast" would not appear in the result.
+    user mapping, "fast" would not appear — assertion would fail.
     """
     resolver = _make_resolver(extra={"fast": "openai/gpt-3.5-turbo"})
     classes = resolver.known_classes()
     assert "light" in classes
     assert "standard" in classes
     assert "strong" in classes
-    assert "fast" in classes  # user-configured class present
-    assert classes == sorted(classes)  # sorted guarantee
+    assert "fast" in classes
+    assert classes == sorted(classes)

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -1,0 +1,204 @@
+"""Tier 2: ``/model`` slash command — per-session model-class override.
+
+Tests:
+  1. override wins over Agent default (session.model returns override)
+  2. invalid class rejected with known_classes() list in error
+  3. unset → Agent default returned (byte-identical baseline)
+  4. sticky within session lifetime (override survives multiple calls)
+  5. known_classes() includes user-configured classes
+
+Each test is falsification-verified per [[feedback_falsify_acceptance_test_before_proof]]:
+the acceptance assertion is paired with a direct check that the mechanism
+under test WOULD fail without it (documented inline).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.chat.outbox import OutboxMessage
+from reyn.interfaces.slash.model import model_cmd
+from reyn.llm.model_resolver import ModelResolver
+
+
+def _make_resolver(extra: dict | None = None) -> ModelResolver:
+    """Resolver with light/standard/strong plus any extra user classes."""
+    mapping = {"light": "openai/gpt-4o-mini", "standard": "openai/gpt-4o", "strong": "openai/gpt-4"}
+    if extra:
+        mapping.update(extra)
+    return ModelResolver(mapping, builtin={})
+
+
+class _FakeAgent:
+    model: str = "standard"
+    agent_name: str = "test-agent"
+
+
+class _FakeSession:
+    def __init__(self, resolver: ModelResolver, *, agent_model: str = "standard"):
+        _agent = _FakeAgent()
+        _agent.model = agent_model
+        self._agent = _agent
+        self._resolver = resolver
+        self._model_override: str | None = None
+        self.outbox: list[OutboxMessage] = []
+
+    @property
+    def model(self) -> str:
+        return self._model_override if self._model_override is not None else self._agent.model
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox.append(msg)
+
+    def reply_text(self) -> str:
+        return "\n".join(m.text for m in self.outbox if m.text)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: override wins over Agent default
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_override_wins_over_agent_default():
+    """Tier 2: session.model returns override when /model <class> is set.
+
+    Falsification: if the property still returned self._agent.model, then
+    session.model == "standard" even after override — the assertion below
+    would fail. Verified by asserting session.model BEFORE override == "standard".
+    """
+    resolver = _make_resolver()
+    session = _FakeSession(resolver, agent_model="standard")
+    assert session.model == "standard"  # baseline: no override
+
+    await model_cmd(session, "light")
+
+    assert session._model_override == "light"
+    assert session.model == "light"  # override wins
+    assert "model → light" in session.reply_text()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: invalid class rejected with known_classes() list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_invalid_class_rejected():
+    """Tier 2: /model <unknown> posts an error with available classes listed.
+
+    Falsification: if is_known_class() always returned True, no error would be
+    posted and _model_override would be set to the unknown value — the
+    assertion `session._model_override is None` would fail.
+    """
+    resolver = _make_resolver()
+    session = _FakeSession(resolver)
+
+    await model_cmd(session, "does_not_exist")
+
+    assert session._model_override is None  # not set on invalid class
+    error_msgs = [m for m in session.outbox if m.kind == "error"]
+    assert error_msgs, "expected an error outbox message"
+    error_text = error_msgs[0].text
+    assert "does_not_exist" in error_text
+    assert "light" in error_text  # available classes listed
+    assert "standard" in error_text
+    assert "strong" in error_text
+
+
+# ---------------------------------------------------------------------------
+# Test 3: unset → Agent default (byte-identical baseline)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_unset_returns_agent_default():
+    """Tier 2: session.model == Agent.model when no override is set.
+
+    Falsification: if _model_override defaulted to something non-None, this
+    assertion would fail. The test directly checks the before-any-override
+    state == Agent identity value, proving byte-identical behaviour.
+    """
+    resolver = _make_resolver()
+    session = _FakeSession(resolver, agent_model="strong")
+
+    assert session._model_override is None
+    assert session.model == "strong"  # Agent default, no override
+
+
+# ---------------------------------------------------------------------------
+# Test 4: sticky — override persists within session lifetime
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_override_sticky():
+    """Tier 2: once set, override persists across subsequent calls to session.model.
+
+    Falsification: if _model_override were reset on each property read,
+    session.model would return the Agent default on the second check.
+    """
+    resolver = _make_resolver()
+    session = _FakeSession(resolver, agent_model="standard")
+
+    await model_cmd(session, "light")
+    assert session.model == "light"
+
+    # second read — must still return override, not agent default
+    assert session.model == "light"
+    assert session._agent.model == "standard"  # agent default unchanged
+
+
+# ---------------------------------------------------------------------------
+# Test 5: no-arg display shows current + override note + available classes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_no_arg_display_with_override():
+    """Tier 2: /model (no-arg) shows current model, override note, available classes.
+
+    Falsification: if the handler exited early without building the display
+    string, session.outbox would be empty — the assertion would fail.
+    Also verifies the transient-override UX note is present.
+    """
+    resolver = _make_resolver()
+    session = _FakeSession(resolver, agent_model="standard")
+    # Set an override first so the display branch fires
+    session._model_override = "light"
+
+    await model_cmd(session, "")
+
+    text = session.reply_text()
+    assert "light" in text            # current model shown
+    assert "this session" in text     # transient note shown
+    assert "standard" in text         # agent default shown
+    assert "available:" in text       # class list present
+
+
+@pytest.mark.asyncio
+async def test_model_no_arg_display_no_override():
+    """Tier 2: /model (no-arg) without an override shows agent default + no override note."""
+    resolver = _make_resolver()
+    session = _FakeSession(resolver, agent_model="standard")
+
+    await model_cmd(session, "")
+
+    text = session.reply_text()
+    assert "standard" in text
+    assert "no override" in text
+    assert "available:" in text
+    assert "this session" not in text  # no override note when not set
+
+
+# ---------------------------------------------------------------------------
+# Test 6: known_classes() includes user-configured classes
+# ---------------------------------------------------------------------------
+
+def test_known_classes_includes_user_configured():
+    """Tier 2: ModelResolver.known_classes() returns user-defined classes.
+
+    Falsification: if known_classes() only returned STANDARD_CLASSES and ignored
+    user mapping, "fast" would not appear in the result.
+    """
+    resolver = _make_resolver(extra={"fast": "openai/gpt-3.5-turbo"})
+    classes = resolver.known_classes()
+    assert "light" in classes
+    assert "standard" in classes
+    assert "strong" in classes
+    assert "fast" in classes  # user-configured class present
+    assert classes == sorted(classes)  # sorted guarantee

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -103,7 +103,7 @@ class _FakeSession:
 # ===========================================================================
 
 def test_session_model_returns_override_when_set(tmp_path):
-    """Tier 2 (Group A): session.model returns override class when _model_override set.
+    """Tier 2: session.model returns override class when _model_override set.
 
     Falsification: if the property still returned self._agent.model, then after
     setting _model_override = "light", session.model would remain "standard"
@@ -117,7 +117,7 @@ def test_session_model_returns_override_when_set(tmp_path):
 
 
 def test_session_model_returns_agent_default_when_no_override(tmp_path):
-    """Tier 2 (Group A): session.model == agent default when _model_override is None.
+    """Tier 2: session.model == agent default when _model_override is None.
 
     Falsification: if _model_override were not initialised to None (e.g. defaulted
     to some class), session.model would not equal the construction-time model and
@@ -128,7 +128,7 @@ def test_session_model_returns_agent_default_when_no_override(tmp_path):
 
 
 def test_session_model_override_cleared_returns_agent_default(tmp_path):
-    """Tier 2 (Group A): clearing _model_override restores agent default.
+    """Tier 2: clearing _model_override restores agent default.
 
     Falsification: if clearing the override did not affect the property, the
     final assertion would still return "light" instead of "standard".
@@ -147,7 +147,7 @@ def test_session_model_override_cleared_returns_agent_default(tmp_path):
 
 @pytest.mark.asyncio
 async def test_model_cmd_no_arg_display_with_active_override(tmp_path):
-    """Tier 2 (Group B1): /model (no-arg) with active override shows transient note.
+    """Tier 2: /model (no-arg) with active override shows transient note.
 
     Uses real Session so session.model reads through the production property.
     Falsification: if the no-arg branch exited without posting, captured msgs
@@ -168,7 +168,7 @@ async def test_model_cmd_no_arg_display_with_active_override(tmp_path):
 
 @pytest.mark.asyncio
 async def test_model_cmd_no_arg_display_no_override(tmp_path):
-    """Tier 2 (Group B1): /model (no-arg) without override shows no transient note.
+    """Tier 2: /model (no-arg) without override shows no transient note.
 
     Falsification: if the no-arg branch exited early, msgs would be empty.
     """
@@ -191,7 +191,7 @@ async def test_model_cmd_no_arg_display_no_override(tmp_path):
 
 @pytest.mark.asyncio
 async def test_model_cmd_valid_class_replies_confirmation():
-    """Tier 2 (Group B2): /model <valid-class> posts confirmation reply.
+    """Tier 2: /model <valid-class> posts confirmation reply.
 
     Stub session has no model property; if the handler accidentally read
     session.model it would raise AttributeError.
@@ -212,7 +212,7 @@ async def test_model_cmd_valid_class_replies_confirmation():
 
 @pytest.mark.asyncio
 async def test_model_cmd_invalid_class_posts_error_with_class_list():
-    """Tier 2 (Group B2): /model <unknown> posts error listing available classes.
+    """Tier 2: /model <unknown> posts error listing available classes.
 
     Falsification: if is_known_class() always returned True, no error would be
     posted and error_text() would be empty — assertion would fail.
@@ -238,7 +238,7 @@ async def test_model_cmd_invalid_class_posts_error_with_class_list():
 # ===========================================================================
 
 def test_known_classes_includes_user_configured():
-    """Tier 2 (Group C): known_classes() returns sorted list including user-defined.
+    """Tier 2: known_classes() returns sorted list including user-defined.
 
     Falsification: if known_classes() only returned STANDARD_CLASSES and ignored
     user mapping, "fast" would not appear — assertion would fail.


### PR DESCRIPTION
**[tui-coder]** — owner-requested feature, dispatched by lead-coder. Seam confirm-first flow followed.

## Summary

- **`/model [<class>]`** slash command: show or override the model class for the current session
- **`/model`** (no-arg): shows `model: <current>`, override note with `(this session — clears on restart)` if active, agent default, and `available: <list>`
- **`/model <class>`**: sets `session._model_override`; validated via `ModelResolver.is_known_class()`; invalid class gives decision-enabling error with full list
- **Byte-identical when unused**: `_model_override = None` → `session.model` returns `self._agent.model` unchanged
- **Sticky in-memory only** (per lead decision): cleared on session restart; durability via snapshot is a future follow-up for e2e (FP-0043 sensitive)

## Files changed

| File | Change |
|------|--------|
| `src/reyn/llm/model_resolver.py` | Add `known_classes() -> list[str]` public accessor (sorted; avoids `_resolved` private access at call sites) |
| `src/reyn/chat/session.py` | Add `_model_override: str \| None = None` in `__init__`; update `model` @property to return override if set |
| `src/reyn/interfaces/slash/model.py` | New `/model` handler |
| `src/reyn/interfaces/slash/__init__.py` | Register `model` module |
| `tests/test_slash_model.py` | 7 Tier-2 tests, falsification-verified |

## Tier-2 test coverage (falsification-verified)

Each test documents how it would fail if the mechanism were absent:
1. Override wins over Agent default (would fail if property still returned `_agent.model`)
2. Invalid class rejected (would fail if `is_known_class()` always True)
3. Unset → Agent default (would fail if `_model_override` defaulted non-None)
4. Sticky within session (would fail if property reset on each read)
5. No-arg display with override (transient note visible)
6. No-arg display without override (no transient note)
7. `known_classes()` includes user-configured (would fail if only returned STANDARD_CLASSES)

## Verification gates

- `pytest tests/test_slash_model.py` — 7/7 ✓
- `pytest tests/test_session_invariants.py tests/test_python_harness_no_litellm_import.py` — 29/29 ✓
- `ruff check src tests` — clean ✓
- S4b conflict check: `transport.py` has zero model references; `_model_override` only affects `session.model` reads ✓

## Tier self-check

All 7 tests are Tier 2 (OS invariant / public surface contracts). No Tier 4. Falsification verified per [[feedback_falsify_acceptance_test_before_proof]].