### PR TITLE
feat(1726): FP-0043 S4b-4 — a2a per-agent shared-session routing (B)

### DIFF
--- a/src/reyn/chat/a2a_routing.py
+++ b/src/reyn/chat/a2a_routing.py
@@ -1,0 +1,35 @@
+"""FP-0043 Stage 4b-4: a2a-transport session routing (registry-only, unit-testable).
+
+Peer (Agent2Agent) delegations run on a SHARED ``a2a`` Session per agent — option
+(B): one a2a conversation per agent, isolated from the user's own "main" session
+(so peer traffic never pollutes the REPL/web conversation), while preserving the
+existing sync→Task escalation + continuation machinery (which assumes a single
+per-agent session — the monitor pumps it, completion narration lands on the next
+call to the same agent). Per-delegation isolation (option A) is deferred until that
+escalation machinery is made per-session-aware.
+
+The inbound A2A HTTP request carries no caller identity, so per-peer routing is
+infeasible; a constant native-id gives the one shared a2a session. No run-loop —
+the a2a handlers drive turns inline via ``MessageBus.request``.
+"""
+from __future__ import annotations
+
+A2A_TRANSPORT = "a2a"
+# Constant native-id → one shared a2a session per agent (option B). Per-delegation
+# (a fresh id per request) is the future once escalation is per-session-aware.
+A2A_NATIVE_ID = "a2a"
+
+
+def a2a_session_id() -> str:
+    """The logical session-id (routing-key) of the shared a2a session: ``a2a:a2a``."""
+    return f"{A2A_TRANSPORT}:{A2A_NATIVE_ID}"
+
+
+def resolve_a2a_session(registry, agent_name: str):
+    """Resolve (get-or-spawn) the agent's shared a2a Session.
+
+    Idempotent — every a2a inbound mode (sync send / escalation monitor / async /
+    answer-injection) routes through here so they all act on the SAME a2a session
+    (not "main"), keeping the escalation/continuation contract intact. No
+    ``ensure_session_running`` — the a2a handlers drive the turn inline."""
+    return registry.resolve_session(agent_name, A2A_TRANSPORT, A2A_NATIVE_ID)

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -43,6 +43,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from reyn.chat.a2a_routing import a2a_session_id, resolve_a2a_session
 from reyn.chat.agent_locks import get_agent_lock
 from reyn.interfaces.web.deps import get_registry, get_run_registry
 from reyn.mcp.server import DEFAULT_SEND_TIMEOUT_SECONDS, send_to_agent_impl
@@ -377,12 +378,21 @@ async def _handle_message_send(
         )
 
     # ── Mode 3: synchronous (default) ────────────────────────────────────
+    # FP-0043 S4b-4 (B): run the delegation on the agent's SHARED a2a session
+    # (isolated from "main" so peer traffic doesn't pollute the user's conversation)
+    # — resolve-or-spawn it (no run-loop; driven inline by MessageBus.request). The
+    # single shared session keeps the sync→Task escalation / continuation intact.
+    try:
+        resolve_a2a_session(registry, agent_name)
+    except (FileNotFoundError, KeyError):
+        pass  # unknown agent → send_to_agent_impl raises ValueError below
     try:
         result = await send_to_agent_impl(
             registry,
             agent_name=agent_name,
             message=text,
             timeout=DEFAULT_SEND_TIMEOUT_SECONDS,
+            sid=a2a_session_id(),
         )
     except ValueError as e:
         # Unknown agent: surface as JSON-RPC error rather than HTTP 404
@@ -538,10 +548,11 @@ async def _escalate_to_task(
 async def _get_session_for_monitor(registry, agent_name: str):
     """Resolve the Session instance for the monitor task.
 
-    Mirrors ``mcp_server._get_session`` but kept local so the import
-    surface of this router stays small.
-    """
-    return registry.get_or_load(agent_name)
+    FP-0043 S4b-4 (B): the a2a turn ran on the agent's shared a2a session, so the
+    monitor must pump THAT session (not "main") to detect the running skill's
+    completion. resolve_a2a_session is idempotent (returns the already-spawned
+    shared a2a session)."""
+    return resolve_a2a_session(registry, agent_name)
 
 
 async def _await_skill_completion(
@@ -688,7 +699,9 @@ async def _handle_answer_injection(
         })
 
     try:
-        session = registry.get_or_load(entry.agent_name)
+        # FP-0043 S4b-4 (B): the run lives on the shared a2a session — resolve it
+        # (not "main") so the pending ask_user is answered on the right session.
+        session = resolve_a2a_session(registry, entry.agent_name)
     except Exception:  # noqa: BLE001 — defensive (agent missing / load failure)
         logger.exception(
             "answer_injection: failed to load agent %r for task %r",
@@ -925,7 +938,8 @@ async def _handle_async_mode(
         # decoration; the answer is the contract).
         bridge: "_A2AProgressBridge | None" = None
         try:
-            session = registry.get_or_load(agent_name)
+            # FP-0043 S4b-4 (B): the async run also lives on the shared a2a session.
+            session = resolve_a2a_session(registry, agent_name)
             bridge = _A2AProgressBridge(
                 session=session,
                 run_id=run_id,
@@ -943,6 +957,7 @@ async def _handle_async_mode(
                 message=text,
                 timeout=DEFAULT_SEND_TIMEOUT_SECONDS,
                 intervention_override=bus,
+                sid=a2a_session_id(),
             )
             run_registry.update(
                 run_id,

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -71,8 +71,17 @@ _IDLE_GRACE_SECONDS: float = 0.05
 # (baseline → MessageBus.request → history-read must be atomic per agent).
 
 
-async def _get_session(registry: "AgentRegistry", name: str) -> "object":
-    """Return a loaded Session for `name`.
+async def _get_session(
+    registry: "AgentRegistry", name: str, *, sid: "str | None" = None,
+) -> "object":
+    """Return a loaded Session for `name` (the agent's "main" session by default).
+
+    FP-0043 S4b-4: when ``sid`` is given (a per-delegation ``a2a:<id>`` session the
+    a2a router already spawned via resolve_session), return THAT session so the
+    delegation runs isolated from "main". The session needs no run-loop — the
+    caller drives the turn inline via ``MessageBus.request`` — so this is a plain
+    lookup, mirroring the no-background-task note below. Falls back to "main" when
+    the sid is absent or unknown.
 
     Note: unlike `reyn chat`, the MCP path does NOT spawn a long-lived
     ``session.run()`` task. The MCP SDK's stdio transport (under
@@ -84,6 +93,10 @@ async def _get_session(registry: "AgentRegistry", name: str) -> "object":
     event loop / task that the SDK is actively scheduling, and the
     LLM call awaits cleanly through to completion.
     """
+    if sid is not None and sid != "main":
+        existing = registry.get_session(name, sid)
+        if existing is not None:
+            return existing
     return registry.get_or_load(name)
 
 
@@ -173,6 +186,7 @@ async def send_to_agent_impl(
     message: str,
     timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
     intervention_override: "RequestBus | None" = None,
+    sid: "str | None" = None,
 ) -> dict:
     """Backing implementation of the ``send_to_agent`` tool.
 
@@ -198,7 +212,7 @@ async def send_to_agent_impl(
             f"create it with `reyn agent new {agent_name}`"
         )
 
-    session = await _get_session(registry, agent_name)
+    session = await _get_session(registry, agent_name, sid=sid)
 
     from reyn.chat.message_bus import MessageBus  # noqa: PLC0415 — lazy import
     from reyn.chat.session import _new_chain_id  # noqa: PLC0415 — lazy import

--- a/tests/test_a2a_iv_kind_choices_267_gap4.py
+++ b/tests/test_a2a_iv_kind_choices_267_gap4.py
@@ -181,14 +181,18 @@ def test_webhook_payload_free_text_ask_user_has_empty_choices(monkeypatch) -> No
 
 
 class _FakeAgentRegistry:
-    """Minimal stub — ``_handle_answer_injection`` only calls
-    ``get_or_load(name)``. Returns a captured Session-shape stub.
+    """Minimal stub. ``_handle_answer_injection`` resolves the agent's a2a session
+    (FP-0043 S4b-4 (B)) — for a single-agent stub the a2a session IS the captured
+    Session-shape stub, so both ``get_or_load`` and ``resolve_session`` return it.
     """
 
     def __init__(self, session) -> None:
         self._session = session
 
     def get_or_load(self, name: str):  # noqa: ANN202
+        return self._session
+
+    def resolve_session(self, name: str, transport: str, native_id: str):  # noqa: ANN202
         return self._session
 
 

--- a/tests/test_a2a_restart_resume_292.py
+++ b/tests/test_a2a_restart_resume_292.py
@@ -350,9 +350,10 @@ def test_handle_answer_injection_routes_through_chat_session(
         "_handle_answer_injection must call "
         "Session.answer_pending_intervention (issue #292 α path)"
     )
-    assert "get_or_load" in src, (
-        "_handle_answer_injection must look up the owning agent via "
-        "AgentRegistry.get_or_load(entry.agent_name)"
+    assert "resolve_a2a_session" in src, (
+        "_handle_answer_injection must look up the owning agent's SESSION via the "
+        "registry (FP-0043 S4b-4 (B): resolve_a2a_session → the shared a2a session, "
+        "not run_registry.answer_intervention)"
     )
     # The pre-#292 path (= run_registry.answer_intervention call) MUST
     # be gone. Pin its absence so a refactor that re-adds it (=

--- a/tests/test_a2a_routing.py
+++ b/tests/test_a2a_routing.py
@@ -1,0 +1,79 @@
+"""Tier 2: FP-0043 S4b-4 (B) — a2a shared-session routing.
+
+Peer delegations route to the agent's SHARED ``a2a`` session (one per agent),
+isolated from the user's "main" conversation but shared across delegations (so the
+existing sync→Task escalation / continuation, which assumes a single per-agent
+session, keeps working). Real AgentRegistry + StateLog (no mocks).
+
+Falsification (feedback_falsify_acceptance_test_before_proof): the not-main test
+reds if routing falls back to "main"; the shared test reds if it becomes
+per-delegation (a fresh id per call). Per-delegation (option A) is future.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.a2a_routing import a2a_session_id, resolve_a2a_session
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import Session
+from reyn.core.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def test_a2a_session_id():
+    """Tier 2: the routing-key for the shared a2a session is the constant a2a:a2a."""
+    assert a2a_session_id() == "a2a:a2a"
+
+
+@pytest.mark.asyncio
+async def test_resolve_a2a_routes_to_a2a_session_not_main(tmp_path):
+    """Tier 2: peer delegations run on the a2a session, NOT the user's "main"."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+
+    s = resolve_a2a_session(reg, "alice")
+    assert s is reg.get_session("alice", "a2a:a2a")    # the shared a2a session
+    assert reg.get_session("alice", "main") is not s   # isolated from main
+
+
+@pytest.mark.asyncio
+async def test_resolve_a2a_is_shared_across_delegations(tmp_path):
+    """Tier 2: option (B) — every delegation resumes the SAME a2a session (so the
+    escalation/continuation machinery, single-session by design, is preserved)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+
+    first = resolve_a2a_session(reg, "alice")
+    second = resolve_a2a_session(reg, "alice")          # another peer delegation
+    assert second is first                              # shared, not per-delegation
+
+
+@pytest.mark.asyncio
+async def test_resolve_a2a_is_per_agent(tmp_path):
+    """Tier 2: each agent has its OWN a2a session (cross-agent isolation)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+    _seed(tmp_path, "bob")
+
+    a = resolve_a2a_session(reg, "alice")
+    b = resolve_a2a_session(reg, "bob")
+    assert a is not b

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -264,7 +264,9 @@ class _StubSendImpl:
     def __init__(self, result: dict):
         self._result = result
 
-    async def __call__(self, registry, *, agent_name, message, timeout):
+    async def __call__(self, registry, *, agent_name, message, timeout, **kwargs):
+        # **kwargs absorbs FP-0043 S4b-4's ``sid`` (the a2a session id) + any future
+        # keyword the real impl gains — this stub only cares about the result dict.
         return self._result
 
 
@@ -289,6 +291,9 @@ async def test_escalation_skipped_when_reply_text_nonempty(monkeypatch):
         "running_skill_run_ids": ["run-skill-builder-1"],
     })
     monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+    # FP-0043 S4b-4 (B): the handler spawns the agent's shared a2a session before
+    # delegating; stub it (the stubbed send_to_agent_impl ignores the real session).
+    monkeypatch.setattr(a2a_mod, "resolve_a2a_session", lambda registry, agent_name: None)
 
     result = await _handle_message_send(
         req_id=1,
@@ -334,6 +339,9 @@ async def test_escalation_still_fires_when_reply_text_empty(monkeypatch):
         "running_skill_run_ids": ["run-skill-builder-2"],
     })
     monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+    # FP-0043 S4b-4 (B): the handler spawns the agent's shared a2a session before
+    # delegating; stub it (the stubbed send_to_agent_impl ignores the real session).
+    monkeypatch.setattr(a2a_mod, "resolve_a2a_session", lambda registry, agent_name: None)
 
     # _escalate_to_task tries to fetch the session; patch _get_session_for_monitor
     # to return a minimal stand-in so the monitor task can be created.
@@ -378,6 +386,9 @@ async def test_escalation_skipped_when_whitespace_only_reply(monkeypatch):
         "running_skill_run_ids": ["run-1"],
     })
     monkeypatch.setattr(a2a_mod, "send_to_agent_impl", stub)
+    # FP-0043 S4b-4 (B): the handler spawns the agent's shared a2a session before
+    # delegating; stub it (the stubbed send_to_agent_impl ignores the real session).
+    monkeypatch.setattr(a2a_mod, "resolve_a2a_session", lambda registry, agent_name: None)
     monkeypatch.setattr(
         a2a_mod, "_get_session_for_monitor",
         lambda registry, agent_name: _Session(),

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -329,7 +329,11 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
     # the TestClient will drive so the future is on the right loop.
     loop = asyncio.new_event_loop()
     try:
-        session = registry.get_or_load("demo")
+        # FP-0043 S4b-4 (B): a2a delegations + answer-injection run on the agent's
+        # shared a2a session, so seed the iv there (not "main") — the same session
+        # the endpoint resolves.
+        from reyn.chat.a2a_routing import resolve_a2a_session
+        session = resolve_a2a_session(registry, "demo")
         iv_future = loop.create_future()
         iv = UserIntervention(
             kind="ask_user",


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-4: a2a per-agent shared-session routing (**option B**). #1726. Routes peer (A2A) delegations onto the agent's shared `a2a` session — isolated from the user's `main` conversation — while **preserving** the existing sync→Task escalation + continuation machinery.

## Why (B), not the originally-planned (A)

A flow-trace fork during impl showed **(A) per-delegation ephemeral breaks the escalation/continuation contract**: `_escalate_to_task`'s `_monitor` re-acquires the session via `_get_session(agent)` = `main`, but the skill ran in the per-delegation session; and GC would kill the session the monitor pumps; and B48 lands skill completion "on the next message/send to the same agent" (single-session assumption). I HELD, surfaced the fork, and re-decided with lead → **(B) shared a2a session**: achieves the a2a↔main isolation win without touching the tested escalation contract. Per-delegation is future (when escalation is made per-session-aware).

## What

- `chat/a2a_routing.py` (new, registry-only helper): `a2a_session_id()` (`a2a:a2a`) + `resolve_a2a_session` (get-or-spawn; no run-loop — a2a drives inline via `MessageBus.request`).
- `mcp/server.py`: `send_to_agent_impl`/`_get_session` gain optional `sid` — a2a passes the a2a session id; the MCP `send_to_agent` tool leaves it unset = `main` (byte-identical; MCP-tool routing is the later MCP stage).
- `web/routers/a2a.py`: ALL inbound modes route through the a2a session — sync send, escalation monitor, answer-injection, async-mode + bridge.

byte-identical: a2a inbound (main→shared a2a session) + concurrency unchanged (serialized off-main, chain_id-scoped); MCP tool / everything else unchanged.

## Test plan

- [x] `tests/test_a2a_routing.py` (4): a2a→a2a session (NOT main) / shared across delegations / per-agent isolation. Falsification-verified (route-to-main → red).
- [x] Named-gate adapt-not-weaken across 4 a2a test files (fake registry gains `resolve_session`; escalation stubs absorb the `sid` kwarg + stub `resolve_a2a_session`; #292 source-inspection pins `resolve_a2a_session`; fp0001 seeds the iv on the a2a session). All 111 a2a tests pass.
- [x] 1234 a2a/mcp/web/registry regression green (2 pre-existing not-my-diff: swebench, web_fetch). ruff + tier-audit clean.

**This completes a2a.** Remaining S4b transports: webhook / MCP-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
