### PR TITLE
feat(1726): FP-0043 S4b-5 — webhook per-sender session routing

### DIFF
--- a/src/reyn/chat/webhook_routing.py
+++ b/src/reyn/chat/webhook_routing.py
@@ -1,0 +1,52 @@
+"""FP-0043 Stage 4b-5: webhook-transport session routing (registry-only, unit-testable).
+
+An inbound webhook (slack / line / generic plugin) maps to its OWN conversation
+Session of the target agent, keyed by the message sender. The webhook ``sender``
+already carries ``"<transport>:<external_id>"`` (e.g. ``"slack:U456"`` /
+``"line:user:U999"`` / ``"webhook:github:42"``), so it is parsed straight into the
+routing-key: slack/line get their own logical-transport namespace (matching the
+0043 §Routing-key doc — namespaced by the LOGICAL transport, not the delivery
+surface), generic webhooks get ``webhook:``. Per-external-user continuity (a slack
+user's conversation persists + is isolated), consistent with web per-thread.
+
+Behaviour change note (FP-0043 S4b-5, owner-approved): webhook delivery moves from
+the agent's shared "main" session to a per-sender mapping — peer/external traffic
+no longer pollutes the user's REPL/web conversation. Output is UNCHANGED: the plugin
+sets ``reply_to=ExternalRef`` and the factory-wired outbox interceptor routes the
+agent's reply back to the source (fire-and-forget; reuse, no new output code).
+"""
+from __future__ import annotations
+
+_GENERIC_WEBHOOK_TRANSPORT = "webhook"
+
+
+def parse_webhook_sender(sender: str) -> tuple[str, str]:
+    """Split a webhook ``sender`` into ``(transport, external_id)``.
+
+    ``"slack:U456"`` → ``("slack", "U456")``; ``"webhook:github:42"`` →
+    ``("webhook", "github:42")`` (only the FIRST ``:`` splits, so an external_id
+    that itself contains ``:`` is preserved). A sender with no transport prefix
+    falls back to the generic ``webhook`` namespace with the whole sender as the
+    external_id."""
+    transport, sep, external_id = sender.partition(":")
+    if not sep or not transport.strip():
+        return _GENERIC_WEBHOOK_TRANSPORT, sender
+    return transport, external_id
+
+
+def resolve_webhook_session(registry, agent_name: str, sender: str):
+    """Resolve (get-or-spawn) the per-sender webhook Session and boot its run-loop.
+
+    Steps (pure registry + session ops):
+      1. parse the sender → ``(transport, external_id)`` routing-key.
+      2. ``resolve_session`` get-or-spawn (persistent per sender; the same external
+         user resumes the same Session).
+      3. ``ensure_session_running`` — run-loop WITHOUT a forwarder (webhook is
+         fire-and-forget; the reply routes via the factory-wired outbox interceptor
+         from the plugin's ``reply_to=ExternalRef``, not the REPL sink).
+
+    Idempotent. Returns the resolved Session."""
+    transport, native_id = parse_webhook_sender(sender)
+    session = registry.resolve_session(agent_name, transport, native_id)
+    registry.ensure_session_running(agent_name, f"{transport}:{native_id}")
+    return session

--- a/src/reyn/plugins/api.py
+++ b/src/reyn/plugins/api.py
@@ -96,7 +96,14 @@ async def push_to_agent(
     if registry is None:
         from reyn.interfaces.web.deps import _get_registry
         registry = _get_registry()
-    session = await registry.ensure_running(target_agent)
+    # FP-0043 S4b-5: route to the sender's OWN webhook session (parsed from the
+    # "<transport>:<external_id>" sender), not the agent's shared "main" — so an
+    # external user's conversation is stateful + isolated, and peer traffic doesn't
+    # pollute the user's REPL/web conversation. Fire-and-forget: ensure_session_running
+    # boots the run-loop (no forwarder); the reply routes via the factory-wired outbox
+    # interceptor from reply_to=ExternalRef below (output unchanged, reuse).
+    from reyn.chat.webhook_routing import resolve_webhook_session
+    session = resolve_webhook_session(registry, target_agent, sender)
     envelope: dict[str, Any] = {
         "text": text,
         "sender": sender,

--- a/tests/plugins/sample_line/test_webhook.py
+++ b/tests/plugins/sample_line/test_webhook.py
@@ -98,6 +98,15 @@ def _line_client(monkeypatch):
         async def ensure_running(self, name):
             return _StubSession()
 
+        # FP-0043 S4b-5: deliver_to_agent routes to a per-sender webhook session via
+        # resolve_session + ensure_session_running (every _StubSession shares the
+        # capture list, so the routing detail is transparent here).
+        def resolve_session(self, name, transport, native_id):
+            return _StubSession()
+
+        def ensure_session_running(self, name, sid):
+            return None
+
         def list_names(self):
             return ["line_agent"]
 

--- a/tests/plugins/sample_slack/test_webhook.py
+++ b/tests/plugins/sample_slack/test_webhook.py
@@ -123,6 +123,15 @@ def _slack_client(monkeypatch):
         async def ensure_running(self, name):
             return _StubSession()
 
+        # FP-0043 S4b-5: deliver_to_agent routes to a per-sender webhook session via
+        # resolve_session + ensure_session_running (every _StubSession shares the
+        # ``pushed`` capture list, so the routing detail is transparent here).
+        def resolve_session(self, name, transport, native_id):
+            return _StubSession()
+
+        def ensure_session_running(self, name, sid):
+            return None
+
         def list_names(self):
             return ["news_agent"]
 

--- a/tests/plugins/test_api.py
+++ b/tests/plugins/test_api.py
@@ -54,6 +54,20 @@ class _StubRegistry:
             self._sessions[name] = _StubSession()
         return self._sessions[name]
 
+    # FP-0043 S4b-5: deliver_to_agent now routes to a per-sender webhook session via
+    # resolve_session + ensure_session_running. This single-agent stub collapses them
+    # onto the one per-agent session (the per-sender routing itself is pinned by
+    # test_webhook_routing); both return the SAME session the tests assert on.
+    def resolve_session(self, name, transport, native_id):
+        if name in self._missing:
+            raise FileNotFoundError(name)
+        if name not in self._sessions:
+            self._sessions[name] = _StubSession()
+        return self._sessions[name]
+
+    def ensure_session_running(self, name, sid):
+        return self._sessions.get(name)
+
 
 # ── tests ─────────────────────────────────────────────────────────────
 

--- a/tests/test_webhook_routing.py
+++ b/tests/test_webhook_routing.py
@@ -1,0 +1,84 @@
+"""Tier 2: FP-0043 S4b-5 — webhook-transport session routing (registry-only helper).
+
+An inbound webhook delivery (deliver_to_agent) routes to a PER-SENDER session keyed
+by parsing the ``"<transport>:<external_id>"`` sender — slack/line get their own
+logical-transport namespace, generic webhooks get ``webhook:`` — isolated from the
+agent's "main" conversation and from other senders. Output (reply-to-source) is the
+EXISTING FP-0041 interceptor (plugin sets reply_to=ExternalRef) and is unchanged.
+Real AgentRegistry + StateLog (no mocks).
+
+Falsification (feedback_falsify_acceptance_test_before_proof): the not-main test
+reds if routing falls back to "main"; the parse tests red if the sender stops
+splitting on the first ':'.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import Session
+from reyn.chat.webhook_routing import parse_webhook_sender, resolve_webhook_session
+from reyn.core.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def test_parse_webhook_sender():
+    """Tier 2: sender → (transport, external_id); only the FIRST ':' splits."""
+    assert parse_webhook_sender("slack:U456") == ("slack", "U456")
+    assert parse_webhook_sender("line:user:U999") == ("line", "user:U999")
+    assert parse_webhook_sender("webhook:github:42") == ("webhook", "github:42")
+    # no transport prefix → generic webhook namespace, whole sender as external_id.
+    assert parse_webhook_sender("bare") == ("webhook", "bare")
+
+
+@pytest.mark.asyncio
+async def test_resolve_webhook_routes_per_sender_not_main(tmp_path):
+    """Tier 2: a webhook sender resolves to its own logical-transport session, NOT main."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "agent")
+
+    s = resolve_webhook_session(reg, "agent", "slack:U456")
+    assert s is reg.get_session("agent", "slack:U456")   # logical-transport namespace
+    assert reg.get_session("agent", "main") is not s       # isolated from main
+
+
+@pytest.mark.asyncio
+async def test_resolve_webhook_senders_are_isolated_and_persistent(tmp_path):
+    """Tier 2: distinct senders → distinct sessions; the same sender resumes its own."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "agent")
+
+    u1 = resolve_webhook_session(reg, "agent", "slack:U456")
+    u2 = resolve_webhook_session(reg, "agent", "slack:U999")
+    assert u1 is not u2                                   # per-external-user isolation
+    assert resolve_webhook_session(reg, "agent", "slack:U456") is u1  # persistent
+
+
+@pytest.mark.asyncio
+async def test_resolve_webhook_generic_namespace(tmp_path):
+    """Tier 2: a generic (non slack/line) webhook gets the webhook: namespace."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "agent")
+
+    g = resolve_webhook_session(reg, "agent", "webhook:github:42")
+    assert g is reg.get_session("agent", "webhook:github:42")
+    assert reg.get_session("agent", "main") is not g


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-5: webhook per-sender session routing. #1726. Routes inbound webhook deliveries (slack/line/generic plugins) onto a per-sender session, isolated from the user's `main` conversation.

## What

- `chat/webhook_routing.py` (new helper): `parse_webhook_sender` (splits the `<transport>:<external_id>` sender on the FIRST `:`, so an external_id with `:` is preserved; no prefix → `webhook:`) + `resolve_webhook_session` (resolve_session get-or-spawn + ensure_session_running).
- `plugins/api.py`: `deliver_to_agent` (the **stable public plugin API**) re-keyed from `ensure_running(main)` → `resolve_webhook_session` — **one point covers every webhook plugin** (completeness-by-construction).

slack/line get their own logical-transport namespace (`slack:U456` / `line:user:U999`, matching the 0043 §Routing-key doc); generic webhooks get `webhook:`. Per-external-user continuity + isolation, like web per-thread.

## Output unchanged (existing-mechanism-first, no new code)

webhook is fire-and-forget; the plugin already sets `reply_to=ExternalRef`, and the factory-wired outbox interceptor routes the reply back to the source via `route_to_mcp`. The webhook session inherits the interceptor (same factory) + run-loop (`ensure_session_running`, no forwarder — like cron).

byte-identical: webhook session (main→per-sender) only. Plugin API / reply-to-source / MCP / a2a / cron / everything else unchanged.

## Test plan

- [x] `tests/test_webhook_routing.py` (4): parse-sender / webhook→mapped session (NOT main) / per-sender isolation + persistence / generic namespace. Falsification-verified (route-to-main → red).
- [x] Named-gate adapt-not-weaken: deliver_to_agent + slack/line webhook stub registries gain `resolve_session` + `ensure_session_running` (per-sender routing pinned by test_webhook_routing; stubs collapse onto their shared capture session). All plugin tests pass.
- [x] 940 webhook/plugin/registry/a2a/cron regression green (1 pre-existing not-my-diff: web_fetch). ruff + tier-audit clean.

**This completes webhook.** Remaining S4b transport: **MCP-server (S4b-6, last)** — builds on the `send_to_agent_impl` `sid` param from S4b-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
