### PR TITLE
feat(1726): FP-0043 S4b-6 — MCP-server shared-session routing (last transport)

### DIFF
--- a/src/reyn/chat/mcp_routing.py
+++ b/src/reyn/chat/mcp_routing.py
@@ -1,0 +1,40 @@
+"""FP-0043 Stage 4b-6: MCP-server-transport session routing (registry-only, unit-testable).
+
+When an external MCP client invokes a Reyn agent (Reyn-as-MCP-server: `reyn mcp
+serve`), the invocation runs on a SHARED "mcp" session per agent — isolated from
+the user's "main" conversation, while preserving the continuity the request-response
+model relies on (a partial send_to_agent leaves running_skills that the NEXT call
+pumps via MessageBus.request — a single stable session per connection).
+
+MCP is stdio: one external client per `reyn mcp serve` process, and the call-tool
+handler carries no connection id (McpRef is per-REQUEST, not per-connection), so
+"per-connection" collapses to one shared mcp session per process. A future SSE
+multi-connection transport could refine to per-connection if a conn-id surfaces.
+
+Unlike the unattended transports (cron/webhook), the MCP path drives the turn INLINE
+(MessageBus.request; the MCP stdio SDK starves a background task) and returns the
+reply in the tool response — so NO ``ensure_session_running`` and no new output
+mechanism. Mirrors the a2a shared-session helper, minus the escalation machinery
+(MCP send_to_agent is pure request-response — no Task escalation).
+"""
+from __future__ import annotations
+
+MCP_TRANSPORT = "mcp"
+# Constant native-id → one shared mcp session per agent (stdio = single connection
+# per process). Per-connection is moot until a multi-connection transport surfaces.
+MCP_NATIVE_ID = "mcp"
+
+
+def mcp_session_id() -> str:
+    """The logical session-id (routing-key) of the shared mcp session: ``mcp:mcp``."""
+    return f"{MCP_TRANSPORT}:{MCP_NATIVE_ID}"
+
+
+def resolve_mcp_session(registry, agent_name: str):
+    """Resolve (get-or-spawn) the agent's shared mcp session.
+
+    Idempotent — both MCP tools that touch a session (send_to_agent /
+    answer_intervention) route through here so they act on the SAME mcp session
+    (not "main"), keeping the request-response continuity intact. No
+    ``ensure_session_running`` — the MCP handler drives the turn inline."""
+    return registry.resolve_session(agent_name, MCP_TRANSPORT, MCP_NATIVE_ID)

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -495,14 +495,22 @@ def build_server(
                 registry, agent_name, server,
             )
             try:
+                # FP-0043 S4b-6: run the invocation on the agent's SHARED mcp
+                # session (isolated from "main"); resolve-or-spawn it (no run-loop
+                # — driven inline by MessageBus.request). The single shared session
+                # preserves the request-response continuity (running_skills pumped
+                # on the next call).
+                from reyn.chat.mcp_routing import mcp_session_id, resolve_mcp_session
+                resolve_mcp_session(registry, agent_name)
                 result = await send_to_agent_impl(
                     registry,
                     agent_name=agent_name,
                     message=message,
                     timeout=timeout,
                     intervention_override=iv_bus,
+                    sid=mcp_session_id(),
                 )
-            except ValueError as e:
+            except (ValueError, FileNotFoundError) as e:
                 return [TextContent(type="text", text=f"error: {e}")]
             except asyncio.CancelledError:
                 # issue #271 M2: client sent CancelledNotification; the
@@ -544,7 +552,10 @@ def build_server(
                     }),
                 )]
             try:
-                session = await _get_session(registry, agent_name)
+                # FP-0043 S4b-6: the run lives on the shared mcp session — resolve
+                # it (not "main") so the pending iv is answered on the right session.
+                from reyn.chat.mcp_routing import resolve_mcp_session
+                session = resolve_mcp_session(registry, agent_name)
             except Exception as exc:  # noqa: BLE001 — defensive
                 return [TextContent(
                     type="text",

--- a/tests/test_mcp_routing.py
+++ b/tests/test_mcp_routing.py
@@ -1,0 +1,79 @@
+"""Tier 2: FP-0043 S4b-6 (last transport) — MCP-server shared-session routing.
+
+An external MCP client's invocation (Reyn-as-MCP-server) routes to the agent's
+SHARED "mcp" session (one per agent, stdio = one connection per process), isolated
+from the user's "main" conversation but shared across calls so the request-response
+continuity (running_skills pumped on the next call) is preserved. Real
+AgentRegistry + StateLog (no mocks).
+
+Falsification (feedback_falsify_acceptance_test_before_proof): the not-main test
+reds if routing falls back to "main"; the shared test reds if it becomes per-call.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.chat.mcp_routing import mcp_session_id, resolve_mcp_session
+from reyn.chat.profile import AgentProfile
+from reyn.chat.registry import AgentRegistry
+from reyn.chat.session import Session
+from reyn.core.events.state_log import StateLog
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def test_mcp_session_id():
+    """Tier 2: the routing-key for the shared mcp session is the constant mcp:mcp."""
+    assert mcp_session_id() == "mcp:mcp"
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_routes_to_mcp_session_not_main(tmp_path):
+    """Tier 2: an MCP-server invocation runs on the mcp session, NOT the user's main."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+
+    s = resolve_mcp_session(reg, "alice")
+    assert s is reg.get_session("alice", "mcp:mcp")     # the shared mcp session
+    assert reg.get_session("alice", "main") is not s     # isolated from main
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_is_shared_across_calls(tmp_path):
+    """Tier 2: every MCP call resumes the SAME mcp session (continuity: a partial
+    send_to_agent's running_skills are pumped by the next call)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+
+    first = resolve_mcp_session(reg, "alice")
+    second = resolve_mcp_session(reg, "alice")           # next MCP call
+    assert second is first                               # shared, not per-call
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_is_per_agent(tmp_path):
+    """Tier 2: each agent has its OWN mcp session (cross-agent isolation)."""
+    reg = _make_registry(tmp_path)
+    _seed(tmp_path, "alice")
+    _seed(tmp_path, "bob")
+
+    a = resolve_mcp_session(reg, "alice")
+    b = resolve_mcp_session(reg, "bob")
+    assert a is not b


### PR DESCRIPTION
**[e2e-coder]** — FP-0043 S4b-6: MCP-server shared-session routing. #1726. **The last transport — completes the S4b arc.** Routes external MCP-client invocations (Reyn-as-MCP-server) onto the agent's shared `mcp` session, isolated from `main`.

## Escalation-fork check (a2a lesson, done up front) = CLEAR

The escalation/`_escalate_to_task`/`_monitor` machinery is a2a.py-only; the MCP `send_to_agent` tool is pure request-response (returns the result; `running_skill_run_ids` computed but never escalated to a Task). No a2a-style HOLD — this path is simpler.

## Design (lead-confirmed)

MCP is stdio = one external client per process; the call-tool handler has no connection id (`McpRef` is per-REQUEST), so per-connection collapses to **one shared mcp session per process**. Shared is also required for continuity (a partial `send_to_agent` leaves `running_skills` the next call pumps — a stable session). Future SSE could refine to per-connection.

- `chat/mcp_routing.py` (new helper, mirrors a2a): `mcp_session_id()` (`mcp:mcp`) + `resolve_mcp_session` (get-or-spawn; **no** `ensure_session_running` — the MCP handler drives the turn inline).
- `mcp/server.py`: the 2 session-touching tools route through the mcp session — `send_to_agent` (`sid=mcp_session_id()`; the MCP-tool routing deferred from S4b-4) + `answer_intervention` (so the iv is answered where the run lives).

reply-to-source = the existing MCP tool RESPONSE (request-response via the `McpRef(request_id)` future) — no new mechanism. byte-identical: the 2 MCP tools' session (main→mcp) only.

## Test plan

- [x] `tests/test_mcp_routing.py` (4): mcp_session_id / MCP→mcp session (NOT main) / shared across calls / per-agent isolation. Falsification-verified (route-to-main → red).
- [x] 1132 mcp/a2a/registry/webhook/cron regression green (zero failures). ruff + tier-audit clean.

## S4b transport arc — COMPLETE

S4b-1 routing primitive (#1742) · S4b-2 web (#1743) · S4b-3a/b cron (#1744/#1745) · S4b-4 a2a (#1748) · S4b-5 webhook (#1749) · **S4b-6 MCP-server (this)**. Five clean re-key patterns + the routing-key primitive, each flow-traced confirm-first + falsification-verified, reusing existing mechanisms (interceptor / sync-return) where they fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
