### PR TITLE
docs(testing): observer-not-factory test-seam discipline (concrete example)

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -173,6 +173,29 @@ with patch("litellm.acompletion", return_value=hand_built_dict):
 
 Fake は実際の API サーフェスを通じてルーティングします。`LLMReplay` は `litellm.acompletion` をパッチしますが、記録済みデータから本物の `litellm.ModelResponse` を再構築します。シグネチャのドリフトは呼び出しサイト（TypeError、AttributeError）またはルックアップ時（`MissingFixture`）で検出されます。
 
+#### test seam は construction-wiring gate を弱めてはならない
+
+構造的 / AST 不変条件 gate で守られた class — たとえば `node.func.id == "RouterLoop"`
+を AST 走査して全 construction site が必須 keyword を wire していることを証明する
+gate — に Tier-2 test seam を足す時、その construction を**置換してはいけません**。
+*factory* seam（`RouterLoop(...)` を注入された `_loop_factory(...)` へ迂回させる）は
+避けてください: literal な constructor 呼び出しが AST から消え、gate が 0 site を見て
+fail し、さらに gate が守っている穴そのものを開けます（注入された callable が guarded
+kwargs を省略できてしまう）。代わりに **post-construction observer** — 構築済み
+instance を渡される spy callback — を使います:
+
+```python
+# class は実際の方法で自身を構築する; observer は inspect するだけ
+loop = RouterLoop(..., resume_always_on=...)   # literal call は AST に残る
+if self._loop_observer is not None:
+    self._loop_observer(loop)                  # 解決済み instance を spy
+```
+
+observer は literal な construction を AST に残し（gate は引き続き検出できる）、実際の
+constructor が guarded kwargs を無条件に wire させます; テストは生の constructor kwargs
+でなく解決済み instance（`loop.router_model` 等）を assert します。これは上のルールの
+seam 版です: コントラクトを bypass せず adapt する。
+
 ### 使い方
 
 ```python

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -217,6 +217,31 @@ For LLM-dependent paths, prefer `LLMReplay` (Tier 3) — it preserves the
 full litellm boundary. Stub callables are appropriate for Tier 2c
 integration tests where the LLM is incidental rather than under test.
 
+#### A test seam must not weaken a construction-wiring gate
+
+When a class is guarded by a structural / AST invariant gate — say a gate that
+walks the AST for `node.func.id == "RouterLoop"` to prove every construction site
+wires a required keyword — a Tier-2 test seam for that class must **not** replace
+the construction. Avoid a *factory* seam (`RouterLoop(...)` redirected through an
+injected `_loop_factory(...)`): it deletes the literal constructor call from the
+AST, so the gate finds zero sites and fails, and it reopens the very hole the gate
+protects — the injected callable can omit the guarded kwargs. Use a
+**post-construction observer** instead — a spy callback handed the already-built
+instance:
+
+```python
+# the class still constructs itself the real way; the observer only inspects it
+loop = RouterLoop(..., resume_always_on=...)   # literal call stays in the AST
+if self._loop_observer is not None:
+    self._loop_observer(loop)                  # spy on the resolved instance
+```
+
+The observer keeps the literal construction in the AST (the gate still sees it)
+and lets the real constructor wire the guarded kwargs unconditionally; the test
+asserts on the resolved instance (`loop.router_model`, …) rather than raw
+constructor kwargs. It is the seam analogue of the rule above: adapt to the
+contract, don't bypass it.
+
 ### How
 
 ```python


### PR DESCRIPTION
**[docs-maintainer]** — promote the observer-vs-factory test-seam lesson into the normative testing policy (lead-approved). Scope per the dispatch:

## Placement
A **concrete example under Mock vs Fake** (not a new section) — the "adapt to the contract, don't bypass it" discipline. New subsection `#### A test seam must not weaken a construction-wiring gate`.

## Content (general principle + mechanism)
A Tier-2 seam for a class guarded by a structural/AST invariant gate must **not** replace the construction:
- a *factory* seam (`RouterLoop(...)` → injected `_loop_factory(...)`) deletes the literal constructor call from the AST → the gate's `node.func.id == "ClassName"` walk finds 0 sites → fails; and it reopens the invariant hole the gate protects (injected callable can omit guarded kwargs).
- a **post-construction observer** (spy on the already-built instance) keeps the literal construction in the AST and lets the real constructor wire the guarded kwargs unconditionally; tests assert on the resolved instance, not raw kwargs.

## Discipline
- **No history refs** — no #issue/PR/FP/stage numbers; abstract example (`RouterLoop`-like class + AST construction-wiring gate). Verified: 0 history refs in the additions.
- **en + ja synced** same PR, equivalent content.
- testing.md/.ja are under `deep-dives/` (excluded from the built site); `mkdocs build --strict` → exit 0.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0
- [x] no-history-refs grep on the diff → 0
- [x] en/ja equivalence (same subsection, same example/mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)