### PR TITLE
fix(#1740): complete ChatSession→Session rename straggler in slash/model.py

### DIFF
--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 
 if TYPE_CHECKING:
-    from reyn.chat.session import ChatSession
+    from reyn.chat.session import Session
 
 
 @slash(
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     summary="Show or override the model class for this session",
     usage="/model [<class>]",
 )
-async def model_cmd(session: "ChatSession", args: str) -> None:
+async def model_cmd(session: "Session", args: str) -> None:
     """/model [<class>] — show current model or set a per-session override."""
     resolver = session._resolver
     requested = args.strip()


### PR DESCRIPTION
**[tui-coder]**

## Summary

- `src/reyn/interfaces/slash/model.py` was the only remaining file using the old `ChatSession` name after the #1740 holistic rename
- Two lines under `TYPE_CHECKING`: import and `model_cmd` signature
- `git grep "ChatSession" origin/main -- src/` → 0 after this fix

## Test plan

- [x] `git grep "ChatSession" -- src/` → exit 1 (0 matches)
- [x] `ruff check src/reyn/interfaces/slash/model.py` → clean
- [x] `pytest tests/test_slash_model.py` → 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)