### PR TITLE
docs(a2a): no-history pass — drop FP-0001 refs (en + ja)

### DIFF
--- a/docs/concepts/multi-agent/a2a.ja.md
+++ b/docs/concepts/multi-agent/a2a.ja.md
@@ -44,7 +44,7 @@ Agent Card に含まれる情報：
 | メソッド / 機能 | 状態 | 備考 |
 |---|---|---|
 | `message/send`（同期返信） | ✅ | デフォルトモード。ピアは最終返信テキストまで待機します。 |
-| `message/send`（`async_mode: true` による非同期） | ✅ | A2A `Task` envelope を返し、ピアはポーリングまたは購読します。下記 [タスクライフサイクル](#タスクライフサイクルと非同期実行-fp-0001) 参照。 |
+| `message/send`（`async_mode: true` による非同期） | ✅ | A2A `Task` envelope を返し、ピアはポーリングまたは購読します。下記 [タスクライフサイクル](#タスクライフサイクルと非同期実行) 参照。 |
 | `GET /a2a/tasks/{run_id}`（ステータスポーリング） | ✅ | `running` / `input-required` / `completed` / `failed` / `cancelled` を返します。 |
 | `POST /a2a/tasks/{run_id}/cancel` | ✅ | 内部 `asyncio.Task` をキャンセル（idempotent）。 |
 | `GET /a2a/tasks/{run_id}/events`（SSE ストリーム） | ✅ | Reyn ネイティブのストリーミング窓口。終了状態でクローズ。 |
@@ -56,7 +56,7 @@ Agent Card に含まれる情報：
 | 認証（bearer トークン / OAuth） | ❌ | v1 では対象外。ネットワーク層のアクセス制御に依存。 |
 | テキスト以外のパーツ（`file`、`data`） | ❌ | 現状はファイルを Reyn workspace 経由で交換。 |
 
-`message/send` が MVP の中心機能です。最も一般的な interop パターン（ピア agent が Reyn agent に質問し、最終返信テキストを受け取る）をカバーするためです。マルチターンの履歴は呼び出し間で保持されます。Reyn の `Session.history` は agent ごとに永続化されており — MCP パスと同じ特性です。上に重ねた非同期タスクライフサイクル（FP-0001、下記詳細）により、ピアは長時間実行 skill を駆動し、実行中の `ask_user` に応答し、キャンセルできます。`message/send` のワイヤー形状は変わりません。
+`message/send` が MVP の中心機能です。最も一般的な interop パターン（ピア agent が Reyn agent に質問し、最終返信テキストを受け取る）をカバーするためです。マルチターンの履歴は呼び出し間で保持されます。Reyn の `Session.history` は agent ごとに永続化されており — MCP パスと同じ特性です。上に重ねた非同期タスクライフサイクル（下記詳細）により、ピアは長時間実行 skill を駆動し、実行中の `ask_user` に応答し、キャンセルできます。`message/send` のワイヤー形状は変わりません。
 
 ## MCP と A2A の両方を使う理由
 
@@ -67,7 +67,7 @@ MCP と A2A は、どちらも「外部 LLM が Reyn と通信する」という
 
 Reyn にとってこれは主にワイヤーフォーマットの選択であり、基盤となるエンジンは同じです。外部システムがツール呼び出しを持つ LLM であれば MCP を選択してください。外部システム自体が agent であれば A2A を選択してください。
 
-## タスクライフサイクルと非同期実行 (FP-0001)
+## タスクライフサイクルと非同期実行
 
 A2A ピアは実行中に `ask_user` を発する skill と対話できるようになりました。
 以前のバージョンは同期実行のみをサポートしており、`message/send` は

--- a/docs/concepts/multi-agent/a2a.md
+++ b/docs/concepts/multi-agent/a2a.md
@@ -58,7 +58,7 @@ The Agent Card surfaces:
 | Method / capability | Status | Notes |
 |---|---|---|
 | `message/send` (synchronous reply) | ✅ | Default mode — peer waits for the final reply text. |
-| `message/send` (async via `async_mode: true`) | ✅ | Returns an A2A `Task` envelope; peer polls or subscribes. See [Task lifecycle](#task-lifecycle-and-async-execution-fp-0001). |
+| `message/send` (async via `async_mode: true`) | ✅ | Returns an A2A `Task` envelope; peer polls or subscribes. See [Task lifecycle](#task-lifecycle-and-async-execution). |
 | `GET /a2a/tasks/{run_id}` (status polling) | ✅ | Reports `running` / `input-required` / `completed` / `failed` / `cancelled`. |
 | `POST /a2a/tasks/{run_id}/cancel` | ✅ | Cancels the underlying `asyncio.Task` (idempotent). |
 | `GET /a2a/tasks/{run_id}/events` (SSE stream) | ✅ | Reyn-native streaming surface; closes on terminal status. |
@@ -75,7 +75,7 @@ common interop pattern: peer agent has a question for a Reyn agent,
 gets the final reply text. Multi-turn history is preserved across
 calls because Reyn's `Session.history` is per-agent and
 persistent — exactly the same property the MCP path relies on. The
-async task lifecycle layered on top (FP-0001, detailed below) lets
+async task lifecycle layered on top (detailed below) lets
 peers drive long-running skills, react to mid-run `ask_user`, and
 cancel without changing the wire shape of the `message/send` call.
 
@@ -96,7 +96,7 @@ For Reyn this is mostly a wire-format choice; the underlying engine
 is the same. Pick MCP when the outer system is an LLM with tool
 calling. Pick A2A when the outer system is itself an agent.
 
-## Task lifecycle and async execution (FP-0001)
+## Task lifecycle and async execution
 
 A2A peers can now interact with skills that emit `ask_user` mid-execution.
 Earlier versions could only run synchronously — `message/send` returned


### PR DESCRIPTION
**[docs-maintainer]** — the low-pri a2a no-history follow-up lead flagged during the ChatSession sweep (#1761, now merged). Removes the pre-existing `FP-0001` history-refs from the a2a concept doc ([[feedback_no_history_refs_in_user_docs]]).

## Changes (en + ja)
- Prose: `(FP-0001, detailed below)` → `(detailed below)` (a2a.md:78 / a2a.ja.md:59)
- Heading: `## Task lifecycle and async execution (FP-0001)` → drop `(FP-0001)` (a2a.md:99 / a2a.ja.md:70)
- **Ripple fix** (heading change moves the anchor slug): the intra-doc link `See [Task lifecycle](#...-fp-0001)` → `#task-lifecycle-and-async-execution` (en) / `#タスクライフサイクルと非同期実行` (ja) (a2a.md:61 / a2a.ja.md:47)

## Scope / verification
- Exhaustive history-ref grep (`FP-`/`#NNNN`/`PR`/`ADR-`/`Stage`/`Phase`/`RFC`) → **only FP-0001** present.
- Based on merged #1761 (so the `Session.history` sweep is already in; no overlap/conflict).
- en + ja synced.

## Test plan
- [x] `grep FP-0001 a2a.{md,ja.md}` → 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0 (updated anchors validated, no broken intra-doc link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)