### PR TITLE
feat(config): adopt AGENTS.md as the cross-tool project-context default

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -54,24 +54,47 @@ def _load_yaml(path: Path) -> dict:
         return {}
 
 
-def load_project_context(config: ReynConfig, project_root: Path) -> str:
-    """Read the project context markdown file referenced by config.project_context_path.
+# Cross-tool default resolution order when project_context_path is unset
+# (None): AGENTS.md is the convention Claude Code / Codex / opencode / etc.
+# all read; REYN.md is the legacy fallback. First existing file wins (mirrors
+# opencode's "AGENTS.md beats CLAUDE.md when both exist").
+DEFAULT_PROJECT_CONTEXT_FILES: tuple[str, ...] = ("AGENTS.md", "REYN.md")
 
-    Returns the file content stripped, or "" when the path is unset, missing,
-    or unreadable. Empty / whitespace-only content also yields "" so callers
-    can short-circuit the system-prompt section.
+
+def load_project_context(config: ReynConfig, project_root: Path) -> str:
+    """Read the project context markdown file for the system prompt.
+
+    Resolution:
+      - ``project_context_path = None`` (default, unset): auto-resolve the
+        cross-tool standard — ``AGENTS.md`` if present, else ``REYN.md``
+        (``DEFAULT_PROJECT_CONTEXT_FILES``). First existing file wins.
+      - explicit non-empty path: pin exactly that file.
+      - explicit ``""``: disabled.
+
+    Returns the chosen file's content stripped, or "" when disabled, none of
+    the candidates exist, or the chosen file is unreadable. Empty /
+    whitespace-only content also yields "" so callers can short-circuit the
+    system-prompt section. The first EXISTING candidate is authoritative even
+    if empty (AGENTS.md present-but-empty does not fall through to REYN.md).
     """
-    rel = (config.project_context_path or "").strip()
-    if not rel or project_root is None:
+    if project_root is None:
         return ""
-    target = project_root / rel
-    if not target.is_file():
-        return ""
-    try:
-        content = target.read_text(encoding="utf-8").strip()
-    except OSError:
-        return ""
-    return content
+    rel = config.project_context_path
+    if rel is None:
+        candidates: tuple[str, ...] = DEFAULT_PROJECT_CONTEXT_FILES
+    else:
+        rel = rel.strip()
+        if not rel:
+            return ""
+        candidates = (rel,)
+    for name in candidates:
+        target = project_root / name
+        if target.is_file():
+            try:
+                return target.read_text(encoding="utf-8").strip()
+            except OSError:
+                return ""
+    return ""
 
 
 def _merge(base: dict, override: dict) -> dict:
@@ -357,7 +380,13 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # silently ignored (always the dataclass default = a no-op set). Wire
         # them through merged so the operator-set value actually takes effect.
         prompt_cache_enabled=bool(merged.get("prompt_cache_enabled", True)),
-        project_context_path=str(merged.get("project_context_path", "REYN.md")),
+        # Absent → None (auto-resolve AGENTS.md → REYN.md in
+        # load_project_context). Present → pin that path ("" disables).
+        project_context_path=(
+            str(merged["project_context_path"])
+            if "project_context_path" in merged
+            else None
+        ),
         permissions=dict(merged.get("permissions") or {}),
         mcp=dict(merged.get("mcp") or {}),
         mcp_search_threshold=_parse_mcp_search_threshold(merged.get("mcp")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -228,10 +228,18 @@ class ReynConfig:
     # Path (relative to project root) of a markdown file whose content is
     # injected into the system prompt for every phase. Use this to put
     # project-wide background, conventions, or references somewhere all
-    # skills implicitly inherit. Set "" or point to a non-existent file to
-    # disable. Default "REYN.md"; users sharing the project with Claude Code
-    # may set this to "CLAUDE.md" to reuse the same source.
-    project_context_path: str = "REYN.md"
+    # skills implicitly inherit.
+    #
+    # Default (``None``) auto-resolves the cross-tool standard:
+    # ``AGENTS.md`` (the convention Claude Code / Codex / opencode / etc.
+    # all read) if present, else ``REYN.md`` (legacy fallback) — so a new
+    # project works with AGENTS.md out of the box, an existing REYN.md
+    # project keeps working, and a project shared with another tool shares
+    # the same AGENTS.md source.
+    #
+    # An explicit value pins one path (e.g. ``"CLAUDE.md"`` to reuse that
+    # source); ``""`` disables injection entirely.
+    project_context_path: str | None = None
     # RAG embedding settings (ADR-0033 Phase 1). Default-completed: usable
     # without any reyn.yaml edits after `pip install reyn` + OPENAI_API_KEY.
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)

--- a/tests/test_project_context_agents_md.py
+++ b/tests/test_project_context_agents_md.py
@@ -1,0 +1,97 @@
+"""Tier 2: project-context resolution adopts AGENTS.md (cross-tool standard).
+
+`load_project_context` resolves the markdown injected into the router system
+prompt. The default (project_context_path=None) auto-resolves the cross-tool
+standard AGENTS.md (read by Claude Code / Codex / opencode / etc.) and falls
+back to the legacy REYN.md — migration-safe. An explicit path pins one file;
+"" disables.
+
+Each fixture writes DISTINCT content per file so the assertion pins WHICH file
+was read, not merely that some content came back (round-trip on a non-default
+value).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.config import ReynConfig, load_project_context
+
+_AGENTS = "AGENTS content — cross-tool standard"
+_REYN = "REYN content — legacy fallback"
+_CLAUDE = "CLAUDE content — explicit pin"
+
+
+def _write(root: Path, name: str, body: str) -> None:
+    (root / name).write_text(body, encoding="utf-8")
+
+
+def test_default_reads_agents_md_when_only_agents(tmp_path: Path) -> None:
+    """Tier 2: default (None) reads AGENTS.md when it is the only file."""
+    _write(tmp_path, "AGENTS.md", _AGENTS)
+    cfg = ReynConfig()  # project_context_path defaults to None (auto)
+    assert cfg.project_context_path is None
+    assert load_project_context(cfg, tmp_path) == _AGENTS
+
+
+def test_default_falls_back_to_reyn_md_when_only_reyn(tmp_path: Path) -> None:
+    """Tier 2: default (None) falls back to REYN.md (migration-safe)."""
+    _write(tmp_path, "REYN.md", _REYN)
+    cfg = ReynConfig()
+    assert load_project_context(cfg, tmp_path) == _REYN
+
+
+def test_default_prefers_agents_md_when_both_exist(tmp_path: Path) -> None:
+    """Tier 2: default (None) prefers AGENTS.md over REYN.md when both exist."""
+    _write(tmp_path, "AGENTS.md", _AGENTS)
+    _write(tmp_path, "REYN.md", _REYN)
+    cfg = ReynConfig()
+    assert load_project_context(cfg, tmp_path) == _AGENTS
+
+
+def test_explicit_path_pins_that_file_over_defaults(tmp_path: Path) -> None:
+    """Tier 2: an explicit path wins over the auto-resolved defaults."""
+    _write(tmp_path, "AGENTS.md", _AGENTS)
+    _write(tmp_path, "REYN.md", _REYN)
+    _write(tmp_path, "CLAUDE.md", _CLAUDE)
+    cfg = ReynConfig(project_context_path="CLAUDE.md")
+    assert load_project_context(cfg, tmp_path) == _CLAUDE
+
+
+def test_explicit_empty_disables_injection(tmp_path: Path) -> None:
+    """Tier 2: explicit "" disables, even when default files exist."""
+    _write(tmp_path, "AGENTS.md", _AGENTS)
+    cfg = ReynConfig(project_context_path="")
+    assert load_project_context(cfg, tmp_path) == ""
+
+
+def test_default_returns_empty_when_no_file(tmp_path: Path) -> None:
+    """Tier 2: default (None) with neither file present yields ""."""
+    cfg = ReynConfig()
+    assert load_project_context(cfg, tmp_path) == ""
+
+
+def test_present_but_empty_agents_md_does_not_fall_through(tmp_path: Path) -> None:
+    """Tier 2: an existing-but-empty AGENTS.md is authoritative (no REYN.md fallthrough).
+
+    Mirrors opencode's "AGENTS.md beats CLAUDE.md when both exist" — presence,
+    not content, decides which file is read.
+    """
+    _write(tmp_path, "AGENTS.md", "   \n")
+    _write(tmp_path, "REYN.md", _REYN)
+    cfg = ReynConfig()
+    assert load_project_context(cfg, tmp_path) == ""
+
+
+def test_yaml_omitted_resolves_to_none_default(tmp_path: Path) -> None:
+    """Tier 2: a reyn.yaml without project_context_path → None → AGENTS.md read.
+
+    Pins the loader wiring (absent key → None, not the literal "REYN.md") so the
+    auto-resolution actually triggers for real configs.
+    """
+    from reyn.config import load_config
+
+    (tmp_path / "reyn.yaml").write_text("prompt_cache_enabled: true\n", encoding="utf-8")
+    _write(tmp_path, "AGENTS.md", _AGENTS)
+    cfg = load_config(tmp_path)
+    assert cfg.project_context_path is None
+    assert load_project_context(cfg, tmp_path) == _AGENTS


### PR DESCRIPTION
**[e2e-coder]** — owner-GO: adopt AGENTS.md (cross-tool standard) as the project-context default.

## What
AGENTS.md is the project-context convention read by Claude Code / Codex / opencode / etc. Make Reyn read it too, **migration-safe** (config stays in root; reyn.yaml unchanged).

## Behaviour (read-both with precedence)
`load_project_context` resolution:
1. **explicit `project_context_path`** → pins exactly that file (existing behaviour preserved; `""` disables).
2. **unset (default `None`)** → auto-resolve `AGENTS.md` (if present) → `REYN.md` (legacy fallback). **First existing file wins** (mirrors opencode's "AGENTS.md beats CLAUDE.md when both exist") — presence, not content, decides (an empty AGENTS.md does not fall through to REYN.md).

Result: new project works with AGENTS.md out of the box · existing REYN.md project keeps working · project shared with another tool shares one AGENTS.md.

## Changes
- `config/root.py`: `project_context_path: str = "REYN.md"` → `str | None = None` + AGENTS.md-centric doc (REYN.md = legacy fallback).
- `config/loader.py`: omitted reyn.yaml key → `None` (auto), not literal `"REYN.md"`, so auto-resolution actually triggers; `load_project_context` rewritten with the `DEFAULT_PROJECT_CONTEXT_FILES = ("AGENTS.md", "REYN.md")` order.

## Owner's per-agent/session question (verified, ref-exact)
`project_context_path` is **project-level only** — every caller passes `(config, project_root)` and loads one file relative to `project_root`; there is **no per-agent/per-session project-context layer**. The per-agent context surface that exists is the separate **memory system** (`tools/memory.py`), not project context. (Corrects the "per-agent/session REYN.md" notion — nothing to align there.)

## Tests (`tests/test_project_context_agents_md.py`, 8 cases)
AGENTS-only · REYN-only fallback · both→AGENTS · explicit-pin-wins · `""`→disabled · none→`""` · empty-AGENTS-no-fallthrough · yaml-omitted→None round-trip. Distinct content per file so each pins **which** file was read (non-default values).

## Verification
- New tests + `test_config_schema_enforcement_1056`: 13 passed.
- Broad sweep (`-k "config or loader or project_context or load_config"`): **445 passed, 1 skipped**. ruff clean.

## Test plan
- [x] AGENTS.md default resolution + REYN.md fallback (round-trip, non-default content)
- [x] explicit path + `""`-disable preserved
- [x] yaml-omitted → None auto (loader wiring pinned)
- [x] per-agent/session layer verified absent (project-level only)
- [x] ruff clean + config sweep green

> Docs (AGENTS.md references) to be handled by docs-maintainer after land, per dispatch. No issue number was assigned; link as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
