### PR TITLE
docs(config): AGENTS.md is the default project-context file (REYN.md legacy fallback)

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -50,8 +50,19 @@ models:
 | `permissions` | マップ | デフォルトの Permission ポリシー。以下参照。 |
 | `plan_resume_raw` | マップ | プランモードのレジューム ポリシーの raw dict。プランコーディネーターが遅延パース。 |
 | `prompt_cache_enabled` | bool | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
-| `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。デフォルト `REYN.md`。 |
+| `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。下記の注記参照。 |
 | `api_base` | 文字列 | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
+
+> **プロジェクトコンテキストファイル（`project_context_path`）。** 未設定のとき
+> Reyn は `AGENTS.md` を読みます — Claude Code・Codex・opencode 等も読む cross-tool
+> 標準です — ので、それらツールと共有するプロジェクトが Reyn 専用ファイルなしでその
+> まま動きます。`AGENTS.md` が無ければ `REYN.md`（legacy）に fallback。最初に存在する
+> ファイルが優先され、present-but-empty な `AGENTS.md` は authoritative（`REYN.md` へは
+> fall through しません）。
+>
+> **移行。** 既存の `REYN.md` プロジェクトは無変更で動作し続けます。新規は `AGENTS.md`
+> を推奨。標準に依らず特定ファイルに固定するには `project_context_path` にそのパスを
+> 設定、`""` でプロジェクトコンテキストを一切注入しない。
 
 ## `models` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -53,9 +53,21 @@ models:
 | `permissions` | map | Default permission policy. See below. |
 | `plan_resume_raw` | map | Raw resume-policy dict for plan-mode runs. Parsed lazily by the plan coordinator. |
 | `prompt_cache_enabled` | bool | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
-| `project_context_path` | string | Markdown file injected into every phase system prompt. Default `REYN.md`. |
+| `project_context_path` | string | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. See note below. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
 | `tool_calls_op_loop_skills` | list | **Transitional.** Skill names opted into the native-tools op-loop — the phase act-loop drives the shared `RouterLoop.run_loop` (the converged op-loop, #1092): ops are emitted as native `tool_calls`, run through the shared executor, and threaded as native tool-role message-history. Default empty = all skills use json-mode (unchanged). Removed once the op-loop becomes the default. (#1092 PR-C-3 merged the former separate `routerloop_convergence_skills` gate into this one — the converged path is now the op-loop's implementation.) |
+
+> **Project context file (`project_context_path`).** Left unset, Reyn reads
+> `AGENTS.md` — the cross-tool convention that Claude Code, Codex, opencode and
+> others also read — so a project shared with those tools works as-is, with no
+> Reyn-specific file. If `AGENTS.md` is absent, Reyn falls back to `REYN.md`
+> (legacy). The first existing file wins, and a present-but-empty `AGENTS.md` is
+> authoritative (it does not fall through to `REYN.md`).
+>
+> **Migration.** Existing `REYN.md` projects keep working unchanged; new projects
+> should prefer `AGENTS.md`. To pin a specific file regardless of the standard,
+> set `project_context_path` to that path; set it to `""` to inject no project
+> context at all.
 
 ## `models` block
 


### PR DESCRIPTION
**[docs-maintainer]** — docs update for the AGENTS.md adoption (project-context file resolution). Lead-dispatched after that merged.

## Change documented
`project_context_path` resolution is now **AGENTS.md-first**: unset (default) auto-resolves `AGENTS.md` if present, else `REYN.md` (legacy fallback); first existing file wins; a **present-but-empty `AGENTS.md` is authoritative** (does not fall through). Explicit path pins one file; `""` disables. Verified against `config/loader.py` (`DEFAULT_PROJECT_CONTEXT_FILES = ("AGENTS.md", "REYN.md")`, `load_project_context`).

## Edits (en + ja)
- `reyn-yaml.{md,ja.md}` — `project_context_path` row updated off the stale "Default `REYN.md`".
- Added a callout after the table: **positioning** (Reyn reads `AGENTS.md`, the cross-tool standard Claude Code / Codex / opencode also read → a project shared with those tools works as-is, no Reyn-specific file) + **resolution order** + **migration** (existing `REYN.md` unchanged / new → `AGENTS.md` / explicit path / `""` disables).

## Scope note (discoverability gap, FYI — not expanded here)
In **live docs**, `REYN.md` / project-context is referenced **only** in this one `reyn-yaml` field (exhaustive grep, deep-dives excluded). There's no getting-started / concept page that introduces a project-context file, so the AGENTS.md positioning currently lives only in the config reference. If you want it more discoverable (e.g. a one-liner in a getting-started), that'd be a separate small doc — flagging rather than expanding scope.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0
- [x] 0 history refs in additions (file has a pre-existing #1092 in an unrelated row — untouched)
- [x] resolution semantics verified against `config/loader.py`
- [x] en/ja synced; config placement (root) intentionally not touched (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)