### PR TITLE
docs(getting-started): introduce the AGENTS.md project-context file

### DIFF
--- a/docs/guide/getting-started/01-installation.ja.md
+++ b/docs/guide/getting-started/01-installation.ja.md
@@ -65,6 +65,16 @@ reyn init
 
 これで `reyn.yaml` と `reyn.local.yaml.example` が存在しない場合に作成されます。
 
+## プロジェクトコンテキスト（任意）
+
+プロジェクトルートに `AGENTS.md` を置くと、Reyn がそれを毎セッションに
+プロジェクト固有のコンテキスト（規約、アーキテクチャのメモ、やること / 避けること）
+として注入します。`AGENTS.md` は Claude Code・Codex・opencode 等も読む cross-tool
+標準なので、それらツールと既に共有しているプロジェクトが Reyn 専用ファイルなしで
+そのまま動きます（legacy の `REYN.md` も fallback として有効）。別ファイルに固定
+したり無効化するには [`project_context_path`](../../reference/config/reyn-yaml.md) を
+参照してください。
+
 ## 確認する
 
 ```bash

--- a/docs/guide/getting-started/01-installation.md
+++ b/docs/guide/getting-started/01-installation.md
@@ -64,6 +64,15 @@ reyn init
 
 This creates `reyn.yaml` and `reyn.local.yaml.example` if they don't exist.
 
+## Project context (optional)
+
+Drop an `AGENTS.md` in your project root and Reyn injects it into every session as
+project-specific context (conventions, architecture notes, do's and don'ts).
+`AGENTS.md` is the cross-tool standard that Claude Code, Codex, and opencode also
+read, so a project you already share with those tools works as-is — no
+Reyn-specific file needed (a legacy `REYN.md` is still honored as a fallback). To
+pin a different file or turn it off, see [`project_context_path`](../../reference/config/reyn-yaml.md).
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
**[docs-maintainer]** — the discoverability follow-up lead GO'd after #1772. Project context was documented only in the `reyn-yaml` config reference; new users had no way to discover that Reyn reads `AGENTS.md`.

## Change (en + ja)
Added a short **"Project context (optional)"** step to `guide/getting-started/01-installation.md`, right after `reyn init`:
- `AGENTS.md` in the project root is injected into every session (conventions, architecture notes, do's/don'ts).
- **Positioning**: `AGENTS.md` is the cross-tool standard that Claude Code / Codex / opencode also read → a project already shared with those tools works as-is, no Reyn-specific file. Legacy `REYN.md` still works as a fallback.
- Pointer to [`project_context_path`](../../reference/config/reyn-yaml.md) to pin a file or disable.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0 (cross-link to reyn-yaml resolves)
- [x] 0 history refs
- [x] en/ja synced

Completes the AGENTS.md docs (config reference #1772 + this discoverability step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)