### PR TITLE
feat(1772): capture prompt-cache tokens in usage + cost events

### DIFF
--- a/src/reyn/core/kernel/llm_call_recorder.py
+++ b/src/reyn/core/kernel/llm_call_recorder.py
@@ -214,6 +214,10 @@ class LLMCallRecorder:
             raw=raw,
             prompt_tokens=llm_result.usage.prompt_tokens if llm_result.usage else None,
             completion_tokens=llm_result.usage.completion_tokens if llm_result.usage else None,
+            cached_tokens=llm_result.usage.cached_tokens if llm_result.usage else None,
+            cache_creation_tokens=(
+                llm_result.usage.cache_creation_tokens if llm_result.usage else None
+            ),
             cost_usd=cost_usd,
             pricing_snapshot=pricing_snapshot,
         )
@@ -410,6 +414,10 @@ class LLMCallRecorder:
             },
             prompt_tokens=result.usage.prompt_tokens if result.usage else None,
             completion_tokens=result.usage.completion_tokens if result.usage else None,
+            cached_tokens=result.usage.cached_tokens if result.usage else None,
+            cache_creation_tokens=(
+                result.usage.cache_creation_tokens if result.usage else None
+            ),
             cost_usd=cost_usd,
             pricing_snapshot=pricing_snapshot,
         )

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -830,15 +830,47 @@ def _extract_json(text: str) -> str:
     return stripped
 
 
+def _extract_cache_tokens(u) -> tuple[int, int]:
+    """Extract (cached_tokens, cache_creation_tokens) from a litellm usage obj.
+
+    cached_tokens (cache READ / hit) is cross-provider normalized: litellm
+    surfaces it as both ``usage.cache_read_input_tokens`` (top-level, Anthropic
+    style) and ``usage.prompt_tokens_details.cached_tokens`` (OpenAI style) —
+    equal when both present. Prefer the top-level field, fall back to the
+    nested one. cache_creation (``cache_creation_input_tokens``, Anthropic
+    cache-write) has no OpenAI / Gemini equivalent → 0 there.
+    Best-effort: any missing / non-numeric field reads as 0.
+    """
+    def _as_int(v) -> int:
+        try:
+            return int(v or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    cached = _as_int(getattr(u, "cache_read_input_tokens", None))
+    if cached == 0:
+        details = getattr(u, "prompt_tokens_details", None)
+        if details is not None:
+            getter = details.get if isinstance(details, dict) else (
+                lambda k, _d=details: getattr(_d, k, None)
+            )
+            cached = _as_int(getter("cached_tokens"))
+    creation = _as_int(getattr(u, "cache_creation_input_tokens", None))
+    return cached, creation
+
+
 def _extract_usage(response) -> TokenUsage | None:
     """Extract token usage from a litellm response object."""
     try:
         u = response.usage
         if u is None:
             return None
+        cached, creation = _extract_cache_tokens(u)
         return TokenUsage(
             prompt_tokens=int(u.prompt_tokens or 0),
             completion_tokens=int(u.completion_tokens or 0),
+            cached_tokens=cached,
+            cache_creation_tokens=creation,
         )
     except Exception:
         return None
@@ -1030,6 +1062,8 @@ def _emit_chat_cost_events(model: str, usage: "TokenUsage | None") -> None:
             "llm_response_received",
             prompt_tokens=usage.prompt_tokens,
             completion_tokens=usage.completion_tokens,
+            cached_tokens=usage.cached_tokens,
+            cache_creation_tokens=usage.cache_creation_tokens,
             cost_usd=cost_usd,
         )
     except Exception:  # noqa: BLE001 — observability emit must never break the call

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -17,6 +17,18 @@ from dataclasses import dataclass
 class TokenUsage:
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Prompt-cache metrics (#1772). Both are SUBSETS / side-metrics of the
+    # billed tokens, NOT additive to total_tokens:
+    #   cached_tokens          — prompt tokens served from cache (cache READ /
+    #                            hit). A subset of prompt_tokens; cross-provider
+    #                            normalized (litellm surfaces this as both
+    #                            usage.cache_read_input_tokens and
+    #                            usage.prompt_tokens_details.cached_tokens).
+    #   cache_creation_tokens  — tokens written to the cache (Anthropic
+    #                            cache-write); 0 for providers without an
+    #                            explicit write metric (OpenAI / Gemini).
+    cached_tokens: int = 0
+    cache_creation_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:
@@ -26,11 +38,15 @@ class TokenUsage:
         return TokenUsage(
             prompt_tokens=self.prompt_tokens + other.prompt_tokens,
             completion_tokens=self.completion_tokens + other.completion_tokens,
+            cached_tokens=self.cached_tokens + other.cached_tokens,
+            cache_creation_tokens=self.cache_creation_tokens + other.cache_creation_tokens,
         )
 
     def __iadd__(self, other: "TokenUsage") -> "TokenUsage":
         self.prompt_tokens += other.prompt_tokens
         self.completion_tokens += other.completion_tokens
+        self.cached_tokens += other.cached_tokens
+        self.cache_creation_tokens += other.cache_creation_tokens
         return self
 
     def to_dict(self) -> dict:
@@ -38,6 +54,8 @@ class TokenUsage:
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.total_tokens,
+            "cached_tokens": self.cached_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
         }
 
     @classmethod
@@ -50,6 +68,8 @@ class TokenUsage:
         return cls(
             prompt_tokens=int(data.get("prompt_tokens", 0)),
             completion_tokens=int(data.get("completion_tokens", 0)),
+            cached_tokens=int(data.get("cached_tokens", 0)),
+            cache_creation_tokens=int(data.get("cache_creation_tokens", 0)),
         )
 
 

--- a/tests/test_cache_token_capture_1772.py
+++ b/tests/test_cache_token_capture_1772.py
@@ -1,0 +1,142 @@
+"""Tier 2: #1772 — prompt-cache token capture in usage + cost events.
+
+`_extract_usage` must pull the prompt-cache metrics litellm surfaces so the
+cost tab can show cache hits. Cross-provider field placement (verified
+ref-exact against real router fixtures):
+
+  - Anthropic: ``usage.cache_read_input_tokens`` (+ ``cache_creation_input_tokens``)
+  - OpenAI:    ``usage.prompt_tokens_details.cached_tokens``
+  - litellm normalizes Anthropic's read to BOTH the top-level field and the
+    nested OpenAI-style field; Gemini exposes no cache-creation metric.
+
+Tests use real ``litellm.types.utils.Usage`` objects (not mocks) so they pin
+the actual provider contract, plus the ``TokenUsage`` public surface.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import litellm
+import pytest
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+from reyn.core.events.events import EventLog, set_llm_request_event_log
+from reyn.llm.llm import _extract_cache_tokens, _extract_usage, recorded_acompletion
+from reyn.llm.pricing import TokenUsage
+
+
+def test_extract_anthropic_style_read_and_creation() -> None:
+    """Tier 2: Anthropic top-level cache_read + cache_creation are captured."""
+    u = Usage(
+        prompt_tokens=2885,
+        completion_tokens=17,
+        cache_read_input_tokens=2719,
+        cache_creation_input_tokens=500,
+    )
+    assert _extract_cache_tokens(u) == (2719, 500)
+
+
+def test_extract_openai_style_nested_cached_only() -> None:
+    """Tier 2: OpenAI nested cached_tokens is captured when no top-level field."""
+    u = Usage(
+        prompt_tokens=900,
+        completion_tokens=10,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=800),
+    )
+    assert _extract_cache_tokens(u) == (800, 0)
+
+
+def test_extract_no_cache_is_zero() -> None:
+    """Tier 2: a response with no cache metrics yields (0, 0)."""
+    u = Usage(prompt_tokens=100, completion_tokens=5)
+    assert _extract_cache_tokens(u) == (0, 0)
+
+
+def test_extract_usage_carries_cache_fields() -> None:
+    """Tier 2: _extract_usage threads the cache metrics onto TokenUsage."""
+    u = Usage(prompt_tokens=2885, completion_tokens=17, cache_read_input_tokens=2719)
+    tu = _extract_usage(SimpleNamespace(usage=u))
+    assert tu is not None
+    assert tu.prompt_tokens == 2885
+    assert tu.completion_tokens == 17
+    assert tu.cached_tokens == 2719
+    assert tu.cache_creation_tokens == 0
+
+
+def test_token_usage_roundtrip_and_total_excludes_cached() -> None:
+    """Tier 2: cached is a SUBSET of prompt (not in total) + survives round-trip."""
+    tu = TokenUsage(
+        prompt_tokens=2885,
+        completion_tokens=17,
+        cached_tokens=2719,
+        cache_creation_tokens=500,
+    )
+    # cached_tokens are part of prompt_tokens, not additive to the total.
+    assert tu.total_tokens == 2885 + 17
+    d = tu.to_dict()
+    assert d["cached_tokens"] == 2719
+    assert d["cache_creation_tokens"] == 500
+    rt = TokenUsage.from_dict(d)
+    assert rt == tu
+
+
+def test_token_usage_add_accumulates_cache() -> None:
+    """Tier 2: __add__ / __iadd__ accumulate the cache metrics."""
+    a = TokenUsage(prompt_tokens=10, completion_tokens=1, cached_tokens=8, cache_creation_tokens=2)
+    b = TokenUsage(prompt_tokens=20, completion_tokens=2, cached_tokens=15, cache_creation_tokens=0)
+    assert (a + b).cached_tokens == 23
+    assert (a + b).cache_creation_tokens == 2
+    a += b
+    assert a.cached_tokens == 23
+    assert a.cache_creation_tokens == 2
+
+
+def test_from_dict_backward_compat_missing_cache_fields() -> None:
+    """Tier 2: older usage dicts (no cache fields) read as 0 (no crash)."""
+    rt = TokenUsage.from_dict({"prompt_tokens": 50, "completion_tokens": 5})
+    assert rt.cached_tokens == 0
+    assert rt.cache_creation_tokens == 0
+
+
+@pytest.fixture
+def _reset_event_log():
+    yield
+    set_llm_request_event_log(None)
+
+
+def test_cost_event_carries_flat_cache_tokens(monkeypatch, _reset_event_log) -> None:
+    """Tier 2: the emitted llm_response_received carries FLAT cached_tokens.
+
+    cost_tab reads flat fields off llm_response_received (not the nested usage
+    dict), so the cache metric must ride the event as a flat field. No mocks:
+    real recorded_acompletion + a real async fake for litellm.acompletion
+    returning a cache-bearing litellm Usage + a real EventLog.
+    """
+    async def _resp(**_kwargs):
+        return SimpleNamespace(
+            usage=Usage(
+                prompt_tokens=3000,
+                completion_tokens=20,
+                cache_read_input_tokens=2719,
+            ),
+            choices=[],
+        )
+
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setattr(litellm, "acompletion", _resp)
+    log = EventLog()
+    set_llm_request_event_log(log)
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        purpose="main",
+        recorder=None,
+        emit_cost_events=True,
+    ))
+
+    resp = next(e for e in log.all() if e.type == "llm_response_received")
+    assert resp.data["prompt_tokens"] == 3000
+    assert resp.data["cached_tokens"] == 2719
+    assert resp.data["cache_creation_tokens"] == 0


### PR DESCRIPTION
**[e2e-coder]** — Refs #1772 (prompt-cache improvement ① — capture + record; TUI display = tui-coder, separate PR)

## Problem
Prompt-cache hit/write tokens were dropped — `_extract_usage` captured only prompt/completion, so the cost tab couldn't surface cache savings.

## Flow-trace (ref-exact)
- Extraction: `_extract_usage` (llm.py) → `TokenUsage` (prompt/completion only).
- Two emit paths feeding the cost tab (`llm_called` + `llm_response_received`): chat (`_emit_chat_cost_events`) and kernel (`LLMCallRecorder` ×2). cost_tab reads **flat** fields off the event (not the nested usage dict).
- litellm cache fields (verified on real router fixtures, not guessed): `usage.cache_read_input_tokens` (top-level) **and** `usage.prompt_tokens_details.cached_tokens` (nested) — equal when both present; Gemini has no `cache_creation`.

## Changes
- **`TokenUsage`**: `cached_tokens` (cache READ/hit) + `cache_creation_tokens` (Anthropic cache-write). Both are **subsets** of billed tokens → **not** added to `total_tokens`. Threaded through `__add__`/`__iadd__`/`to_dict`/`from_dict` (back-compat: missing → 0).
- **`_extract_usage`**: new `_extract_cache_tokens` normalizes cross-provider — prefer top-level `cache_read_input_tokens`, fall back to nested `cached_tokens`; `cache_creation_input_tokens` → 0 for OpenAI/Gemini.
- **Emit** flat `cached_tokens` / `cache_creation_tokens` on `llm_response_received` in **both** paths. Same events-store JSONL persistence as cost (satisfies owner's "persist like cost").

## tui-coder contract (agreed)
`cached_tokens` / `cache_creation_tokens` flat on `llm_response_received`; cost-tab bucket gains `"cached"`. `cached` is a subset of `p` (display as "of which X cached", don't sum).

## Tests (`tests/test_cache_token_capture_1772.py`, 8 — no mocks, real litellm `Usage`)
extraction Anthropic / OpenAI-nested / no-cache · `TokenUsage` round-trip + `total` excludes cached · `__add__` accumulates · `from_dict` back-compat · **flat `cached_tokens` rides the emitted `llm_response_received`** (real `EventLog` + `recorded_acompletion`).

## Verification
- New + chat-cost regression: 12 passed. Broad sweep (`-k "usage or pricing or cost or token or memoization or llm_request"`): **222 passed, 1 skipped**. ruff clean.

## Test plan
- [x] Cross-provider extraction (Anthropic/OpenAI/none) on real litellm Usage
- [x] TokenUsage round-trip + total excludes cached + accumulation + back-compat
- [x] Flat cached_tokens rides llm_response_received (chat path, real EventLog)
- [x] No regression (222 passed) + ruff clean

> Same-land with tui-coder's display PR recommended (cached must ride the event before display works). docs n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
