### PR TITLE
docs(builtin-models): document litellm Responses-API reasoning-parse limitation

### DIFF
--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -131,6 +131,43 @@ hard output cap が必要なときは常に `max_completion_tokens` を優先す
 実際の使用は少ないこともある。 複雑な task で `budget_tokens` を低く設定すると
 answer 品質が落ちる可能性あり。
 
+### ツールを伴う turn での reasoning（Responses-API bridge）
+
+**tools** を伴い、かつ reasoning-capable model に `reasoning_effort` が設定された
+turn は、litellm の Responses-API bridge（`responses/<model>`）を通ります。litellm
+の bridge は現状、model が返す `reasoning` output item を map できないため、call が
+次の error を raise します:
+
+```
+litellm.APIConnectionError: OpenAIException -
+Unknown items in responses API response: [GenericResponseOutputItem(type='reasoning', ...)]
+```
+
+reasoning テキストは response に含まれています — bridge parser がその `reasoning`
+item を chat-completions の形に map しないだけです。これは current と latest 両方の
+litellm release に存在し、released fix はありません。Reyn は provider 固有の回避を
+作りません。
+
+**発火する条件 — 狭い opt-in の組み合わせ。** 両方が成立する必要があります:
+
+1. **tool を伴う** purpose（例: router。その turn は常に tools を持つ）が
+   **reasoning-capable** model を指す — `model_class_by_purpose: router: strong`、
+   またはデフォルトの `model` class を capable model に設定。**かつ**
+2. その model に `reasoning_effort` が設定されている。
+
+**影響を受けないパス:**
+
+- **デフォルト構成。** `standard` class（Gemini Flash Lite）は `reasoning_effort`
+  なしで tool turn を捌くので、bridge でなく `/v1/chat/completions` を通り error
+  なし。（Flash Lite は tool turn で reasoning-dormant でもある。）
+- **tool なしの chat + reasoning。** reasoning-capable model を tools *なし* で使うと
+  `/v1/chat/completions` を通り、reasoning は survive して正常に round-trip します
+  （`reasoning_content` / `thinking_blocks` として現れる）。
+
+**回避するには**、tool を伴う turn を担う reasoning-capable model に
+`reasoning_effort` を設定しない — または tool を伴う purpose を non-reasoning model
+に置く。tool なしの chat パスの reasoning は影響を受けません。
+
 ## Namespace + override semantics
 
 built-in catalog は user entry の **前に** model namespace に merge されるので、

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -155,6 +155,44 @@ Anthropic API via LiteLLM.  The `budget_tokens` value is the upper bound of reas
 tokens; actual usage may be less.  Setting `budget_tokens` too low can degrade answer
 quality on complex tasks.
 
+### Reasoning on tool-bearing turns (Responses-API bridge)
+
+A turn that carries **tools** *and* has `reasoning_effort` set on a
+reasoning-capable model is routed through litellm's Responses-API bridge
+(`responses/<model>`). litellm's bridge currently cannot map the `reasoning`
+output item the model returns, so the call raises:
+
+```
+litellm.APIConnectionError: OpenAIException -
+Unknown items in responses API response: [GenericResponseOutputItem(type='reasoning', ...)]
+```
+
+The reasoning text is present in the response — the bridge parser simply doesn't
+map the `reasoning` item onto the chat-completions shape. This is present in both
+the current and the latest litellm release, with no released fix; Reyn does not
+ship a provider-specific workaround for it.
+
+**When it bites — a narrow, opt-in combination.** Both must hold:
+
+1. a **tool-bearing** purpose (e.g. the router, whose turns always carry tools)
+   is pointed at a **reasoning-capable** model — `model_class_by_purpose: router:
+   strong`, or the default `model` class set to a capable model; **and**
+2. `reasoning_effort` is set on that model.
+
+**Unaffected paths:**
+
+- **The default setup.** The `standard` class (Gemini Flash Lite) handles
+  tool-bearing turns with no `reasoning_effort`, so they go through
+  `/v1/chat/completions`, not the bridge — no error. (Flash Lite is also
+  reasoning-dormant on tool turns.)
+- **Non-tool chat with reasoning.** A reasoning-capable model *without* tools goes
+  through `/v1/chat/completions`; reasoning survives and round-trips normally
+  (surfaced as `reasoning_content` / `thinking_blocks`).
+
+**To avoid it**, keep `reasoning_effort` off any reasoning-capable model that
+serves tool-bearing turns — or keep tool-bearing purposes on a non-reasoning
+model. Reasoning on the non-tool chat path is unaffected.
+
 ## Namespace and override semantics
 
 The built-in catalog is merged into the model namespace **before** user entries, so


### PR DESCRIPTION
**[docs-maintainer]** — owner-requested: record the litellm Responses-API reasoning-parse limitation in Reyn docs (not a code comment). Placement lead-approved: `builtin-models.md` "Vendor-specific quirks". Written from sandbox_2's (dogfood-coder) **primary-evidence repro** (`/tmp/litellm_responses_reasoning_parse_repro.md`), not inference.

## What it documents
A tool-bearing turn with `reasoning_effort` set on a reasoning-capable model is routed through litellm's Responses-API bridge (`responses/<model>`), whose parser can't map the model's `reasoning` output item → `OpenAIException - Unknown items in responses API response: [...type='reasoning'...]`. Present in current **and** latest litellm, no released fix; Reyn ships no provider-specific workaround.

## Honest scoping (primary-verified)
- **Fires** only on the narrow opt-in: tool-bearing purpose (e.g. router) → reasoning-capable model **and** `reasoning_effort` set.
- **Unaffected**: default setup (`standard`=Flash Lite + tools, no `reasoning_effort`) → `/v1/chat/completions`; non-tool chat with reasoning round-trips fine (`reasoning_content` / `thinking_blocks`).
- **Avoidance**: keep `reasoning_effort` off reasoning-capable models serving tool-bearing turns, or keep those purposes on a non-reasoning model.

## Constraints honored (owner brief)
- Provider-neutral, fact-only.
- **No history refs** (no #PR/#issue inline) — grep-verified 0.
- **No issue-filing mention** — grep-verified 0.
- Status = upstream-pending, no Reyn workaround.
- en + ja synced.

Aligns with the #2 reasoning-native-history work (currently `prototype/reasoning-native-history-ab`); if that lands a dedicated reasoning concept doc, this note can cross-link/move.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0
- [x] 0 history refs, 0 issue-filing mentions
- [x] written from primary repro (error string verbatim, firing/non-firing paths, both litellm versions)
- [x] en/ja synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)