### PR TITLE
docs(cli/chat): document the /model slash command (per-session model override)

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -80,6 +80,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/image <path>` | Attach an image to the next user message (multimodal input) |
 | `/list` | List running skills and pending interventions |
 | `/memory [list\|view <name>]` | Inspect project memory entries (see [concepts/memory](../../concepts/data-retrieval/memory.md)) |
+| `/model [<class>]` | Show the session's model class and any override, or set a per-session model-class override with `/model <class>` (validated against known classes; clears on restart) |
 | `/pending [list\|discard <id>\|claim <id>]` | List / discard / claim stalled cross-channel ops |
 | `/plan list` | Show active plan runs (combined view: in-flight tasks + pending-resume) |
 | `/plan discard <plan_id>` | Abort a specific plan run + cleanup; notifies waiting peer agents via R-D14 |


### PR DESCRIPTION
**[docs-maintainer]** — #300 drift cleanup. `/model` landed as a slash command (per-session model-class override) but was missing from the slash-command reference. Found via a landed-feature-vs-docs sweep.

## Change
Added `/model` to the `reference/cli/chat.md` slash-command table (alphabetical, between `/memory` and `/pending`):
- `/model` — show the session's model class, any per-session override, the agent default, and the available classes.
- `/model <class>` — set a per-session model-class override (validated against known classes; clears on restart).

Verified against `src/reyn/interfaces/slash/model.py` (`@slash("model", …)`, `model_cmd`).

## en-only — and why (not a missed ja mirror)
The **ja** `chat.md` slash table is a deliberate **curated subset** — only the crash-recovery / multi-agent core (`/list`, `/cancel`, `/answer`, `/agents`, `/attach`, `/skill`, `/plan`, `/tasks`). It already omits the en utility commands (`/memory`, `/budget`, `/copy`, `/concept`, …). `/model` is in that same utility tier, so adding it en-only keeps both docs internally consistent; adding it to ja while `/memory` etc. stay absent would be arbitrary. If you'd prefer a full ja slash-table sync, that's a separate (larger) pass — flagging rather than half-syncing.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0
- [x] semantics verified against `slash/model.py`
- [x] alphabetical placement consistent with the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)