### PR TITLE
docs(cli/chat): document /rewind, /compact, /session slash commands

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -69,6 +69,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/budget [reset]` | Full budget breakdown; `/budget reset` clears per-process counters (see [config/budget](../config/budget.md)) |
 | `/cancel <id-prefix>` | Cancel a running skill (accepts any unique prefix of the run_id) |
 | `/clear-history` | Wipe chat history (**destructive**; clears in-memory + persistent history) |
+| `/compact` | Compact the conversation history now to free up the context window (see [chat-compaction](../../concepts/data-retrieval/chat-compaction.md)) |
 | `/concept <term>` | Inline glossary lookup (T1-3) |
 | `/copy [N\|list]` | Copy an agent reply to the clipboard (1 = newest, 2 = one turn back, …) |
 | `/cost` | Quick token + USD cost summary for this agent |
@@ -87,7 +88,9 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/plan resume <plan_id> --from <step_id>` | Surgical operator escape hatch; clears step results from the target step onward and re-launches with a fresh resume_plan ; see [concepts/plan-mode](../../concepts/multi-agent/plan-mode.md) |
 | `/quit` | Exit the chat (alias: `/exit`, Ctrl+D) |
 | `/reset confirm` | Reset in-flight skill state (snapshots + WAL; audit logs preserved) |
+| `/rewind [seq]` | Time-travel to an earlier checkpoint — no arg opens the picker menu; `seq` jumps directly (see [Time-travel](../../concepts/runtime/time-travel.md) · [How-to](../../guide/for-users/time-travel.md)) |
 | `/save [path]` | Save the conv pane to a file (auto-names if path omitted) |
+| `/session new \| switch <sid> \| list` | Open / switch / list conversation sessions for the attached agent (see [Sessions](../../concepts/multi-agent/sessions.md)) |
 | `/skill list` | Show active skill runs (id, name, current phase + parent lineage) |
 | `/skill discard <run_id>` | Abort a specific skill run + cleanup |
 | `/skills` | List available skills (stdlib, project, local) |


### PR DESCRIPTION
**[docs-maintainer]** — #300 self-driven slash-command completeness sweep (bounded, lead-sanctioned). Enumerated every `@slash` registration on origin/main and diffed against the `chat.md` reference table.

## Drift found → fixed
Three **visible** (non-hidden) commands were missing from the table:
- `/rewind [seq]` — time-travel to an earlier checkpoint (no arg = picker menu). A headline feature, documented in concepts/how-to but absent from the slash reference.
- `/compact` — compact conversation history now to free the context window.
- `/session new \| switch <sid> \| list` — open / switch / list conversation sessions for the attached agent (the **FP-0043 multi-session** operator command; ties to the Sessions concept doc).

All verified against `src/reyn/interfaces/slash/{rewind,compact,session}.py`; cross-linked to time-travel / chat-compaction / Sessions.

## Sweep completeness (audit trail)
- 34 raw `@slash` tokens → triaged: `donut`/`matrix`/`zen` are `hidden=True` easter eggs (correctly undocumented); `ping`/`pong` were a docstring example; `object` was a `"object"` type-hint false positive; `/model` was added in #1778. Net real gap = these 3.

## en-only — and why
The ja `chat.md` slash table is a curated subset (crash-recovery / multi-agent core only). `/rewind` and `/compact` are utility-tier (ja already omits `/memory`, `/budget`, etc.); `/session` is arguably core but I'm not partial-syncing one row — a fuller ja slash-table sync is a separate pass (flagged on #1778 too).

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0 (3 new cross-links resolve)
- [x] semantics verified against each `slash/*.py`
- [x] hidden/easter-egg commands correctly excluded
- [x] alphabetical placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)