### PR TITLE
docs(cli): add reyn run-once reference page

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
       - CLI:
           - Running Reyn:
               - reference/cli/run.md
+              - reference/cli/run-once.md
               - reference/cli/chat.md
               - reference/cli/skill.md
               - reference/cli/skills.md

--- a/docs/reference/cli/run-once.ja.md
+++ b/docs/reference/cli/run-once.ja.md
@@ -1,0 +1,74 @@
+---
+type: reference
+topic: cli
+audience: [human, agent]
+applies_to: [reyn run-once]
+---
+
+# `reyn run-once`
+
+ワンショットの非対話エージェント呼び出し。stdin の**全体**を 1 つの user message
+として読み、general agent を完了まで駆動し（任意回数の tool-call → 1 回の停止）、
+最終返信を出力して終了します。対話的な [`reyn chat`](chat.md) のバッチ / プログラム
+版です — SWE-bench runner などの自動化が task 全体を 1 メッセージとして渡します。
+
+## 書式
+
+```
+reyn run-once [agent_name] [OPTIONS] < prompt
+```
+
+prompt は stdin から全体を（行単位でなく）読みます。
+
+## 位置引数
+
+| 名前 | 説明 |
+|------|------|
+| `agent_name` | 駆動する agent。デフォルト: `default`。 |
+
+## オプション
+
+| フラグ | 説明 |
+|------|------|
+| `--max-iterations N` | 自律ループの 1 メッセージあたり tool-call 予算。デフォルト `80` — 対話 chat より高く、agent が explore → edit → verify を完了まで反復できる。 |
+| `--grant-file-write` | resolver 層で `file.read` + `file.write` を付与し、非対話 agent が prompt なしで working tree を編集できる（sandbox の write-paths で bound）。`reyn chat --grant-file-write` と同じ。 |
+| `--exclude-tools NAMES` | agent の LLM-visible カタログから隠すツール名（カンマ区切り、例 `web__search,web__fetch`）。`reyn chat --exclude-tools` と同じ。 |
+| `--exclude-categories NAMES` | カタログソースで隠すカテゴリ名（カンマ区切り、例: task に Reyn 自身のソースが無関係なら `reyn_source`）。`reyn chat --exclude-categories` と同じ。 |
+
+environment-backend フラグと [共通フラグ](common-flags.md) は `reyn chat` /
+`reyn run` と共有です。
+
+## 挙動メモ
+
+- **ステートレス。** ワンショット実行は agent の永続化された会話履歴を **読み込み
+  ません** — 継続すべき先行会話がないためです。スコープ付きセッション（permission
+  grant・除外ツール・environment backend）は `reyn chat` と同一に構築され、最終的な
+  駆動だけが異なります（行単位 REPL でなくワンショット完了）。
+- **stdin 全体読み。** stdin ストリーム全体を 1 メッセージとして取るので、複数行の
+  task もそのまま届きます。
+
+## 例
+
+デフォルト agent をパイプした prompt で実行:
+
+```bash
+echo "README を要約して open TODO を列挙して" | reyn run-once
+```
+
+working tree を編集しうる named agent を駆動:
+
+```bash
+cat task.md | reyn run-once coder --grant-file-write
+```
+
+外部リポジトリ task で web ツールと Reyn-source カテゴリを隠す:
+
+```bash
+cat task.md | reyn run-once --exclude-tools web__search,web__fetch --exclude-categories reyn_source
+```
+
+## 関連
+
+- [`reyn chat`](chat.md) — 対話版（スコープ付きセッション構築を共有）
+- [`reyn run`](run.md) — 特定の skill を端から端まで実行
+- [共通フラグ](common-flags.md)

--- a/docs/reference/cli/run-once.md
+++ b/docs/reference/cli/run-once.md
@@ -1,0 +1,76 @@
+---
+type: reference
+topic: cli
+audience: [human, agent]
+applies_to: [reyn run-once]
+---
+
+# `reyn run-once`
+
+One-shot, non-interactive agent invocation. Reads the **whole** of stdin as a
+single user message, drives the general agent to completion (any number of
+tool-call iterations → one final stop), prints the final reply, and exits. It is
+the batch / programmatic counterpart to interactive [`reyn chat`](chat.md) — the
+SWE-bench runner and other automation pipe a whole task in as one message.
+
+## Synopsis
+
+```
+reyn run-once [agent_name] [OPTIONS] < prompt
+```
+
+The prompt is read from stdin in full (not line by line).
+
+## Positional arguments
+
+| Name | Description |
+|------|-------------|
+| `agent_name` | Agent to drive. Default: `default`. |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--max-iterations N` | Per-message tool-call budget for the autonomous loop. Default `80` — higher than interactive chat so the agent can iterate explore → edit → verify to completion. |
+| `--grant-file-write` | Grant `file.read` + `file.write` at the resolver layer so the non-interactive agent edits its working tree without a prompt (bounded by the sandbox write-paths). Same as `reyn chat --grant-file-write`. |
+| `--exclude-tools NAMES` | Comma-separated tool names to hide from the agent's LLM-visible catalog (e.g. `web__search,web__fetch`). Same as `reyn chat --exclude-tools`. |
+| `--exclude-categories NAMES` | Comma-separated catalog category names to hide at the catalog source (e.g. `reyn_source` when the agent's own source is irrelevant to the task). Same as `reyn chat --exclude-categories`. |
+
+Environment-backend flags and the [common flags](common-flags.md) are shared with
+`reyn chat` / `reyn run`.
+
+## Behavior notes
+
+- **Stateless.** A one-shot run does **not** load the agent's persisted
+  conversation history — there is no prior conversation to continue. The scoped
+  session (permission grants, excluded tools, environment backend) is constructed
+  exactly as for `reyn chat`; only the final drive differs (one-shot completion
+  instead of the line-by-line REPL).
+- **Whole-stdin read.** The entire stdin stream is taken as one message, so a
+  multi-line task is delivered intact.
+
+## Examples
+
+Run the default agent on a piped prompt:
+
+```bash
+echo "Summarize the README and list open TODOs" | reyn run-once
+```
+
+Drive a named agent that may edit its working tree:
+
+```bash
+cat task.md | reyn run-once coder --grant-file-write
+```
+
+Hide web tools and the Reyn-source category for an external-repo task:
+
+```bash
+cat task.md | reyn run-once --exclude-tools web__search,web__fetch --exclude-categories reyn_source
+```
+
+## See also
+
+- [`reyn chat`](chat.md) — the interactive counterpart (shares the scoped-session construction)
+- [`reyn run`](run.md) — run a specific skill end-to-end
+- [Common flags](common-flags.md)


### PR DESCRIPTION
**[docs-maintainer]** — #300 CLI-completeness sweep (sub-area 1, lead-GO'd). Enumerated top-level `reyn` subcommands vs `reference/cli/` pages.

## Drift found → fixed
`reyn run-once` — a stable, load-bearing one-shot command (reads the whole of stdin as one message, drives the general agent to completion, prints the reply, exits; the batch counterpart to `reyn chat`, used by the SWE-bench runner and other automation) — had **no reference page**, only a passing mention in a reyn-yaml config note. Every other top-level command has its own `reference/cli/` page.

Added `reference/cli/run-once.md` (+ `.ja`), mirroring `run.md` structure. Verified against `src/reyn/interfaces/cli/commands/run_once.py`:
- positional `agent_name` (default `default`)
- `--max-iterations` (default 80), `--grant-file-write`, `--exclude-tools`, `--exclude-categories`
- shared env-backend + common flags; **stateless** (no persisted history loaded); whole-stdin read
- cross-links to `chat.md`, `run.md`, `common-flags.md`. Added to Reference → CLI nav.

## Sweep result + scope note
Of 23 top-level commands, only `run-once` and `chainlit` were undocumented. **`chainlit`** is a **PoC optional-dep** (`help="...PoC"`, `pip install -e ".[chainlit]"`) — deliberately left undocumented until it stabilizes; flagging rather than writing a reference page for a PoC. If you'd rather document it now (or mark it experimental), say the word.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0 (nav + cross-links resolve)
- [x] all flags/behavior verified against `run_once.py`
- [x] 0 history refs, en/ja synced
- [x] every documented cli page maps to a real command; only run-once/chainlit were impl-not-doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)