### PR TITLE
feat(309): per-model-class api_base / provider routing (multi-provider)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -890,6 +890,37 @@ def proxy_kwargs() -> dict:
     return {"api_base": api_base, "custom_llm_provider": "openai", "api_key": api_key}
 
 
+def routing_for_spec(spec: "ModelSpec | None") -> dict | None:
+    """#309: per-class litellm routing (api_base / custom_llm_provider) for a
+    model class, or ``None`` to inherit the global ``proxy_kwargs()`` endpoint
+    (backward-compat — existing single-endpoint configs are byte-identical).
+
+    Enables simultaneous multi-provider use (e.g. router=light on a Gemini proxy
+    + skill=capable on Anthropic-direct):
+      - ``api_base`` set → route to that endpoint; ``custom_llm_provider`` =
+        ``spec.provider`` or ``"openai"`` (OpenAI-compatible proxy). api_key from
+        OPENAI_API_KEY (litellm standard — never a literal secret in config).
+      - ``provider`` set, no ``api_base`` → DIRECT to that provider (no api_base
+        override); litellm resolves the key from its standard env var
+        (ANTHROPIC_API_KEY / GEMINI_API_KEY / …). This opts the class OUT of the
+        global proxy.
+      - neither → ``None`` → caller falls back to ``proxy_kwargs()``.
+    """
+    if spec is None:
+        return None
+    api_base = getattr(spec, "api_base", None)
+    provider = getattr(spec, "provider", None)
+    if api_base:
+        return {
+            "api_base": api_base,
+            "custom_llm_provider": provider or "openai",
+            "api_key": os.environ.get("OPENAI_API_KEY", "dummy"),
+        }
+    if provider:
+        return {"custom_llm_provider": provider}
+    return None
+
+
 # #1190 cost-observability: the valid purpose (cost-attribution) buckets. Every
 # recorded_acompletion call must tag one so /cost can break spend down by where
 # the LLM call originated. ``dogfood`` covers test/trace sites (recorder=None).
@@ -1081,6 +1112,7 @@ async def recorded_acompletion(
     fallback_without_response_format: bool = False,
     extra_kwargs: dict | None = None,
     emit_cost_events: bool = False,  # #1683: chat path opts in (kernel emits via LLMCallRecorder)
+    routing: dict | None = None,  # #309: per-class api_base/provider; None → global proxy_kwargs()
 ) -> object:
     """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
 
@@ -1107,10 +1139,17 @@ async def recorded_acompletion(
             f"must be one of {LLM_PURPOSES}"
         )
 
-    extra = proxy_kwargs()
-    effective_model = model.split("/", 1)[1] if extra and "/" in model else model
+    # #309: per-class routing (api_base/provider) wins; None → global proxy_kwargs().
+    extra = routing if routing is not None else proxy_kwargs()
+    # Strip the provider prefix ONLY when routing to an api_base endpoint
+    # (OpenAI-compatible proxy expects a bare model + custom_llm_provider). A
+    # direct-provider route (provider set, no api_base) keeps the prefix so
+    # litellm resolves the provider from it.
+    effective_model = (
+        model.split("/", 1)[1] if extra.get("api_base") and "/" in model else model
+    )
     base_kwargs = dict(extra_kwargs or {})
-    base_kwargs.update(extra)  # Reyn proxy kwargs win over caller-supplied ones
+    base_kwargs.update(extra)  # Reyn routing/proxy kwargs win over caller-supplied ones
 
     # #1650: when an operator sets ``reasoning_effort`` on a model, the proxy
     # path forces ``custom_llm_provider=openai`` (proxy_kwargs), under which
@@ -1408,11 +1447,17 @@ async def call_llm(
             ]
 
         # response_format may not be supported by all models; pass it only when available
-        extra = proxy_kwargs()
-        # When routing via a local proxy, strip the provider prefix from the model
-        # name (e.g. "openai/gemini-2.5-flash-lite" → "gemini-2.5-flash-lite") so
-        # the proxy receives the bare model name it registered under.
-        effective_model = spec.model.split("/", 1)[1] if extra and "/" in spec.model else spec.model
+        # #309: per-class routing (api_base/provider) wins; None → global proxy.
+        _routing = routing_for_spec(spec)
+        extra = _routing if _routing is not None else proxy_kwargs()
+        # When routing via a proxy (api_base set), strip the provider prefix from
+        # the model name (e.g. "openai/gemini-2.5-flash-lite" → "gemini-2.5-flash-
+        # lite") so the proxy receives the bare model it registered under. A
+        # direct-provider route keeps the prefix (litellm resolves from it).
+        effective_model = (
+            spec.model.split("/", 1)[1]
+            if extra.get("api_base") and "/" in spec.model else spec.model
+        )
         common_kwargs = {"timeout": timeout, "num_retries": max_retries}
         # Merge operator-declared kwargs (spec.kwargs) with Reyn defaults.
         # Reyn-set options (common_kwargs, extra) take precedence over spec.kwargs
@@ -1447,6 +1492,7 @@ async def call_llm(
                 response_format={"type": "json_object"},
                 fallback_without_response_format=True,
                 extra_kwargs={**spec_kwargs, **common_kwargs},
+                routing=_routing,  # #309 per-class api_base/provider
             )
 
         response = await _llm_call_with_retry(_do_call, effective_model, event_log)
@@ -1571,9 +1617,15 @@ async def call_llm_tools(
                 format_refusal_message(check, agent=budget_agent),
             )
 
-    extra = proxy_kwargs()
-    # Strip provider prefix when routing via local proxy (same logic as call_llm)
-    effective_model = spec.model.split("/", 1)[1] if extra and "/" in spec.model else spec.model
+    # #309: per-class routing (api_base/provider) wins; None → global proxy.
+    _routing = routing_for_spec(spec)
+    extra = _routing if _routing is not None else proxy_kwargs()
+    # Strip provider prefix only when routing to an api_base proxy (same logic as
+    # call_llm); a direct-provider route keeps the prefix.
+    effective_model = (
+        spec.model.split("/", 1)[1]
+        if extra.get("api_base") and "/" in spec.model else spec.model
+    )
     # Operator-declared kwargs from ModelSpec; Gemini-safe forced settings override these.
     spec_kwargs = dict(spec.kwargs)
 
@@ -1688,6 +1740,7 @@ async def call_llm_tools(
             model=_model, messages=_messages, purpose=purpose,
             recorder=None, extra_kwargs=_kw,
             emit_cost_events=emit_cost_events,  # #1683: chat opts in
+            routing=_routing,  # #309 per-class api_base/provider (else global wins)
         )
 
     response = await _llm_call_with_retry(_tools_call, effective_model, event_log)

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -51,6 +51,17 @@ class ModelSpec:
 
     model: str
     kwargs: dict[str, Any] = field(default_factory=dict)
+    # #309 per-class routing (multi-provider). Explicit routing fields (NOT in
+    # ``kwargs``) so a class can target its own endpoint/provider while others
+    # use the global default — e.g. router=light on a Gemini proxy + skill=
+    # capable on Anthropic-direct, simultaneously. Mirrors EmbeddingClassSpec
+    # (which carries ``api_base``); ``provider`` is added for the direct-vs-proxy
+    # opt-out. NO per-class api_key field by design: a literal secret must never
+    # live in checked-in config — litellm resolves the key from the standard
+    # provider env (OPENAI_API_KEY for a proxy, ANTHROPIC_API_KEY/GEMINI_API_KEY
+    # for a direct provider). Both default None → inherit the global api_base.
+    api_base: str | None = None
+    provider: str | None = None  # litellm custom_llm_provider
 
     def __post_init__(self) -> None:
         # #1650: validate the operator-declared ``reasoning_effort`` at
@@ -127,8 +138,24 @@ class ModelSpec:
                 raise ValueError(
                     f"ModelSpec 'model' must be a string, got {type(model).__name__}"
                 )
-            kwargs = {k: v for k, v in value.items() if k not in ("model", "extends")}
-            return cls(model=model, kwargs=kwargs)
+            # #309: api_base / provider are explicit routing fields, not litellm
+            # passthrough kwargs. (No api_key: literal secrets never in config —
+            # litellm reads the key from the standard provider env.)
+            api_base = value.get("api_base")
+            provider = value.get("provider")
+            if api_base is not None and not isinstance(api_base, str):
+                raise ValueError(
+                    f"ModelSpec 'api_base' must be a string, got {type(api_base).__name__}"
+                )
+            if provider is not None and not isinstance(provider, str):
+                raise ValueError(
+                    f"ModelSpec 'provider' must be a string, got {type(provider).__name__}"
+                )
+            kwargs = {
+                k: v for k, v in value.items()
+                if k not in ("model", "extends", "api_base", "provider")
+            }
+            return cls(model=model, kwargs=kwargs, api_base=api_base, provider=provider)
         raise ValueError(
             f"ModelSpec.from_config expects str or dict, got {type(value).__name__}"
         )

--- a/tests/test_per_class_api_base_309.py
+++ b/tests/test_per_class_api_base_309.py
@@ -1,0 +1,121 @@
+"""Tier 2: #309 — per-model-class api_base / provider routing (multi-provider).
+
+A model class can target its own endpoint/provider while other classes use the
+global default — e.g. router=light on a Gemini proxy + skill=capable on
+Anthropic-direct, simultaneously. Mirrors EmbeddingClassSpec.api_base; provider
+is added for the direct-vs-proxy opt-out. NO per-class api_key (no literal
+secret in config — litellm resolves the key from the standard provider env).
+
+No mocks: real ModelSpec / routing_for_spec, and a real async fake for
+litellm.acompletion that captures the kwargs it received.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import litellm
+import pytest
+
+from reyn.llm.llm import recorded_acompletion, routing_for_spec
+from reyn.llm.model_resolver import ModelSpec
+
+# ── routing_for_spec resolution ──────────────────────────────────────────────
+
+
+def test_routing_api_base_is_proxy_route(monkeypatch) -> None:
+    """Tier 2: api_base set → proxy route (custom_llm_provider openai default)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "k-proxy")
+    r = routing_for_spec(ModelSpec(model="openai/x", api_base="https://proxy.local"))
+    assert r == {
+        "api_base": "https://proxy.local",
+        "custom_llm_provider": "openai",
+        "api_key": "k-proxy",
+    }
+
+
+def test_routing_api_base_with_explicit_provider() -> None:
+    """Tier 2: provider overrides the default custom_llm_provider on a proxy."""
+    r = routing_for_spec(ModelSpec(model="x", api_base="https://h", provider="vertex_ai"))
+    assert r["api_base"] == "https://h"
+    assert r["custom_llm_provider"] == "vertex_ai"
+
+
+def test_routing_provider_only_is_direct() -> None:
+    """Tier 2: provider w/o api_base → DIRECT (no api_base; litellm env key)."""
+    r = routing_for_spec(ModelSpec(model="anthropic/claude", provider="anthropic"))
+    assert r == {"custom_llm_provider": "anthropic"}
+    assert "api_base" not in r  # direct → no endpoint override
+
+
+def test_routing_none_inherits_global() -> None:
+    """Tier 2: no per-class routing → None → caller falls back to proxy_kwargs."""
+    assert routing_for_spec(ModelSpec(model="openai/x")) is None
+    assert routing_for_spec(None) is None
+
+
+# ── ModelSpec.from_config: routing fields are explicit, not kwargs ───────────
+
+
+def test_from_config_extracts_routing_fields() -> None:
+    """Tier 2: api_base/provider become explicit fields, NOT litellm kwargs."""
+    spec = ModelSpec.from_config({
+        "model": "anthropic/claude",
+        "provider": "anthropic",
+        "api_base": "https://h",
+        "temperature": 0.5,
+    })
+    assert spec.api_base == "https://h"
+    assert spec.provider == "anthropic"
+    assert spec.kwargs == {"temperature": 0.5}  # routing fields not leaked to kwargs
+
+
+def test_from_config_backward_compat_no_routing() -> None:
+    """Tier 2: configs without routing → fields None, kwargs unchanged."""
+    s_str = ModelSpec.from_config("openai/gpt-4o")
+    assert s_str.api_base is None and s_str.provider is None
+    s_dict = ModelSpec.from_config({"model": "openai/gpt-4o", "max_tokens": 100})
+    assert s_dict.api_base is None and s_dict.provider is None
+    assert s_dict.kwargs == {"max_tokens": 100}
+
+
+# ── integration: per-class routing wins over the global proxy ────────────────
+
+
+def _capture_acompletion(box: dict):
+    async def _fn(**kwargs):
+        box.update(kwargs)
+        return SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1), choices=[],
+        )
+    return _fn
+
+
+def test_per_class_routing_overrides_global_proxy(monkeypatch) -> None:
+    """Tier 2: with a GLOBAL proxy set, a per-class routing still wins — the call
+    hits the per-class api_base, not the global one."""
+    monkeypatch.setenv("LITELLM_API_BASE", "https://GLOBAL.proxy")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    box: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capture_acompletion(box))
+
+    asyncio.run(recorded_acompletion(
+        model="gemini/x", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        routing={"api_base": "https://PERCLASS.endpoint", "custom_llm_provider": "openai", "api_key": "k"},
+    ))
+    assert box["api_base"] == "https://PERCLASS.endpoint"  # per-class, not GLOBAL
+
+
+def test_global_proxy_used_when_no_per_class_routing(monkeypatch) -> None:
+    """Tier 2: backward-compat — no routing → the global proxy_kwargs applies."""
+    monkeypatch.setenv("LITELLM_API_BASE", "https://GLOBAL.proxy")
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    box: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capture_acompletion(box))
+
+    asyncio.run(recorded_acompletion(
+        model="gemini/x", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,  # routing defaults None → global
+    ))
+    assert box["api_base"] == "https://GLOBAL.proxy"


### PR DESCRIPTION
**[e2e-coder]** — Refs #309. owner-GO, design GO'd (flow-trace shared earlier).

## What
A single global `api_base` forces every model class through one endpoint. This adds **per-class routing** so classes can target different providers simultaneously — e.g. **router=light on a Gemini proxy + skill=capable on Anthropic-direct**. Mirrors `EmbeddingClassSpec.api_base`.

## Design (provider-agnostic, no Reyn hacks)
- **`ModelSpec`**: explicit routing fields `api_base` + `provider` (NOT litellm passthrough kwargs). `from_config` extracts them; other keys still → `kwargs`.
- **No per-class `api_key`** (security): a literal secret must never live in checked-in config. litellm resolves the key from the standard provider env (`OPENAI_API_KEY` for a proxy; `ANTHROPIC_API_KEY`/`GEMINI_API_KEY` for direct). Confirmed against the embedding precedent — `EmbeddingClassSpec` carries **only `api_base`**, no api_key (lead's refinement: that signals direct = litellm-env-resolution suffices).
- **`routing_for_spec(spec)`**: `api_base` set → proxy route (`custom_llm_provider` = `provider` or `"openai"`); `provider`-only → **direct** (no api_base override → opts the class out of the global proxy); neither → `None` → `proxy_kwargs()` global fallback.
- **`recorded_acompletion`** gains a `routing` param (per-class wins; else `proxy_kwargs`). The model-prefix strip now fires **only for an api_base proxy route**, so a direct route keeps its prefix for litellm. `call_llm`/`call_llm_tools` thread `routing` through — else the chokepoint's `proxy_kwargs` re-derivation would overwrite per-class with global.

## Backward-compat
`api_base`/`provider` default `None` → `routing_for_spec` `None` → `proxy_kwargs()` → **byte-identical** for existing single-endpoint configs. Verified: model_resolver/proxy/replay sweep **167 passed**.

## Tests (`tests/test_per_class_api_base_309.py`, 8 — no mocks)
routing resolution (proxy / explicit-provider / direct / none→global) · `from_config` extracts routing fields not kwargs + backward-compat · **integration: per-class routing overrides a set global proxy** (and global used when none) via a capturing async fake for `litellm.acompletion`.

## Test plan
- [x] routing_for_spec: api_base proxy / direct provider / none→global fallback
- [x] from_config: explicit routing fields, not leaked to kwargs; str + no-routing backward-compat
- [x] Integration: per-class api_base wins over a set global proxy; global used when no per-class
- [x] No regression (167 passed model_resolver/proxy/replay); ruff clean

> Sequenced after #1776 (②) — branched from current origin/main (post-#1776 merge), no llm.py conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
