### PR TITLE
docs(cli/chat): add /session to the ja slash table (orchestration-tier parity)

### DIFF
--- a/docs/reference/cli/chat.ja.md
+++ b/docs/reference/cli/chat.ja.md
@@ -63,6 +63,7 @@ reyn chat researcher
 | `/answer <id> <text>` | 保留中の `ask_user` / Permission プロンプトに回答 |
 | `/agents` | 読み込まれた agent と現在アタッチされているものを一覧表示 |
 | `/attach <name>` | REPL ポインターを別の agent に切り替える（前の agent はバックグラウンドで実行し続ける） |
+| `/session new \| switch <sid> \| list` | アタッチ中 agent の会話セッションを開く / 切り替える / 一覧表示（[Sessions](../../concepts/multi-agent/sessions.md) 参照） |
 | `/skill list` | 実行中の Skill 実行を表示（id / 名前 / current_phase + 親子関係） |
 | `/skill discard <run_id>` | 特定の Skill 実行を中止して cleanup を実行 |
 | `/plan list` | 実行中の Plan を表示（動作中 task と resume 待ちを組み合わせて表示） |


### PR DESCRIPTION
**[docs-maintainer]** — acting on the review steer from #1779: give `/session` **ja parity**.

The ja `chat.ja.md` slash table is a curated subset of the **orchestration-tier** commands (`/agents`, `/attach`, `/skill`, `/plan`, `/tasks`). `/session` (per-agent conversation-session management — the FP-0043 multi-session operator command: `new` / `switch <sid>` / `list`) belongs in that tier alongside `/agents` and `/attach`, so it's added to ja. `/rewind` (time-travel, different domain) and `/compact` (utility) stay en-only, consistent with the subset's curation.

Links to the Sessions concept doc.

## Dependency
The en `/session` row lands in #1779 (content-approved, merging on green). This ja row is in the independent `chat.ja.md` file; once both land, en+ja are in parity for the orchestration tier.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0 (Sessions cross-link resolves)
- [x] placement consistent with the ja orchestration-tier grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)