### PR TITLE
refactor(312 C1): extract ChatMessage VO → runtime/chat_message.py

### DIFF
--- a/src/reyn/runtime/__init__.py
+++ b/src/reyn/runtime/__init__.py
@@ -28,9 +28,10 @@ load ``session`` — that pulls in ``reyn.config`` and closes a
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .session import ChatMessage, Session
+    from .chat_message import ChatMessage
+    from .session import Session
 
-_LAZY_ATTRS = {"Session": ".session", "ChatMessage": ".session"}
+_LAZY_ATTRS = {"Session": ".session", "ChatMessage": ".chat_message"}
 
 __all__ = ["ChatMessage", "Session"]
 

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -1,0 +1,181 @@
+"""ChatMessage — the chat-history entry value object.
+
+One ``ChatMessage`` is a single entry in the LLM-facing conversation history,
+shaped to mirror the OpenAI/Anthropic message-list wire format so the history
+serialises straight to the LLM (``user`` / ``assistant`` / ``tool`` / ``system``
+/ ``summary`` / ``skill_event`` roles; ``str`` or list-of-parts ``content``;
+OpenAI tool-turn fields). Also provides the read-time migration that rewrites
+pre-#383 on-disk history entries into this shape (``_migrate_legacy_chat_message``)
+and the ``_now_iso`` timestamp helper. Pure value object — no dependency on
+``Session``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+
+@dataclass(init=False)
+class ChatMessage:
+    """Chat-history entry, shaped to mirror the OpenAI/Anthropic message
+    list wire format (issue #383 E-full).
+
+    Each ``ChatMessage`` is one entry in the LLM-facing conversation, so
+    ``self.history`` can be serialised straight to the LLM without
+    synthesis. Tool turns are represented as their own ``role="tool"``
+    entries; assistant turns that emitted tool calls carry the
+    ``tool_calls`` field; multi-modal user / tool turns use the
+    list-of-parts ``content`` shape.
+
+    Role vocabulary:
+      - ``user`` — user input
+      - ``assistant`` — LLM reply (= previously ``agent``)
+      - ``tool`` — tool response (= new)
+      - ``system`` — system prompt (rare; usually built at wire time)
+      - ``summary`` — chat-compactor output (Reyn-internal, filtered at wire boundary)
+      - ``skill_event`` — TUI display marker (Reyn-internal, filtered at wire boundary)
+    """
+    role: Literal[
+        "user", "assistant", "tool", "system", "summary", "skill_event",
+    ]
+    # ``content`` is either:
+    #   - a ``str`` (= text-only turn), or
+    #   - a ``list[dict]`` of litellm-style content parts (= multimodal user
+    #     turn / tool response with an image / etc.). Each part is e.g.
+    #       {"type": "text", "text": "..."}
+    #       {"type": "image_url", "image_url": {"url": "<data url OR file ref>"}}
+    #       {"type": "image",     "path": "<abs or cwd-rel>",
+    #                             "mime_type": "...", "content_hash": "sha256:..."}
+    # The last shape (= ``"image"`` with ``path``) is the **path-ref**
+    # introduced by #383: storage points at a file on disk, the
+    # wire-shape builder reads and embeds the binary at LLM-call time.
+    content: str | list[dict] = ""
+    ts: str = ""
+    seq: int = 0  # monotonic per-session sequence id; 0 for non-conversational entries
+    meta: dict = field(default_factory=dict)
+    # OpenAI/Anthropic tool-turn fields ─────────────────────────────────
+    # ``tool_calls`` is set ONLY on ``role="assistant"`` entries where the
+    # LLM emitted one or more tool calls. Each block follows the OpenAI
+    # function-tool shape:
+    #   {"id": "<tool_call_id>", "type": "function",
+    #    "function": {"name": "<tool>", "arguments": "<json str>"}}
+    tool_calls: list[dict] | None = None
+    # ``tool_call_id`` is set ONLY on ``role="tool"`` entries. Links the
+    # response back to the originating ``tool_call`` block on the
+    # preceding assistant message.
+    tool_call_id: str | None = None
+    # ``name`` is set ONLY on ``role="tool"`` entries (= function name).
+    # Mirrors the OpenAI tool-message ``name`` field; some providers
+    # require it for tool-result attribution.
+    name: str | None = None
+
+    def __init__(
+        self,
+        role: str,
+        content: "str | list[dict]" = "",
+        ts: str = "",
+        seq: int = 0,
+        meta: "dict | None" = None,
+        tool_calls: "list[dict] | None" = None,
+        tool_call_id: "str | None" = None,
+        name: "str | None" = None,
+    ) -> None:
+        # Reject the pre-#383 ``"agent"`` spelling. Migration of on-disk
+        # ``history.jsonl`` entries happens at load time via
+        # ``_migrate_legacy_chat_message``; nothing else should be
+        # constructing with ``role="agent"`` anymore.
+        if role == "agent":
+            raise ValueError(
+                "ChatMessage role='agent' was renamed to 'assistant' in "
+                "issue #383. Pass role='assistant' instead. "
+                "(Legacy on-disk entries are migrated read-time by "
+                "_migrate_legacy_chat_message.)"
+            )
+        self.role = role
+        self.content = content
+        self.ts = ts
+        self.seq = seq
+        self.meta = meta if meta is not None else {}
+        self.tool_calls = tool_calls
+        self.tool_call_id = tool_call_id
+        self.name = name
+
+    @property
+    def text(self) -> str:
+        """Derived view returning a str representation of ``content``.
+
+        - str content → returned as-is.
+        - list-of-parts content → the first ``{"type":"text"}`` part's text.
+        - neither → empty string.
+
+        This is a convenience accessor, NOT a legacy compatibility shim:
+        readers that want a textual rendering of any ChatMessage (text or
+        multimodal) call ``m.text`` instead of branching on isinstance.
+        Writers update ``content`` directly.
+        """
+        if isinstance(self.content, str):
+            return self.content
+        if isinstance(self.content, list):
+            for part in self.content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    return part.get("text", "")
+        return ""
+
+
+# ── Legacy ChatMessage migration ───────────────────────────────────────
+#
+# history.jsonl files written before issue #383 used the pre-Design-B
+# shape: ``role`` ∈ {"user","agent","skill_event","summary"}; ``text:
+# str``; ``media: list[dict]`` (= inline base64 image_url parts from
+# #366). On load, ``_migrate_legacy_chat_message`` rewrites such
+# entries into the new wire shape so the runtime only ever sees
+# Design-B ChatMessage instances.
+
+
+def _migrate_legacy_chat_message(raw: dict) -> dict:
+    """Read-time migration for pre-#383 history.jsonl entries.
+
+    Detects the legacy shape (= ``text`` key + optional ``media`` list,
+    ``role="agent"`` for assistant replies) and emits the Design-B
+    shape (= ``content`` field, ``role="assistant"``). Mutates a copy;
+    the caller hands the result to ``ChatMessage(**kwargs)``.
+
+    Legacy → new:
+      role: "agent"            → "assistant"
+      text: "hi"               → content: "hi"
+      text + media: [...]      → content: [{"type": "text", "text": "hi"}, ...media]
+      (no text, media: [...])  → content: [...media]
+
+    Inline base64 in media blocks is left alone — those entries
+    pre-date the path-ref design and rewriting them to files would
+    be a one-shot tool, out of scope for read-time migration.
+    """
+    raw = dict(raw)  # don't mutate the caller's dict
+    if "content" in raw:
+        # Already new shape (= written post-#383 or already migrated).
+        # Still normalise role just in case "agent" snuck in.
+        if raw.get("role") == "agent":
+            raw["role"] = "assistant"
+        return raw
+
+    # Legacy shape: text + optional media.
+    text_val = raw.pop("text", "")
+    media_val = raw.pop("media", None) or []
+
+    if media_val:
+        parts: list[dict] = []
+        if text_val:
+            parts.append({"type": "text", "text": text_val})
+        parts.extend(media_val)
+        raw["content"] = parts
+    else:
+        raw["content"] = text_val
+
+    if raw.get("role") == "agent":
+        raw["role"] = "assistant"
+    return raw
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -32,7 +32,7 @@ from reyn.services.compaction.engine import (
 )
 
 if TYPE_CHECKING:
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class CompactionController:
         current chat history (``list[ChatMessage]``).
     latest_summary:
         Zero-argument callable that returns the most recent ``"summary"``
-        :class:`~reyn.runtime.session.ChatMessage`, or ``None``.
+        :class:`~reyn.runtime.chat_message.ChatMessage`, or ``None``.
     compaction_engine:
         :class:`~reyn.services.compaction.engine.CompactionEngine`
         that owns the single LLM call (PR-N3: OS-internal, no skill/phase).

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -304,7 +304,7 @@ class RouterHistoryBuffer:
         # path below, so normal chat stays byte-identical.
         _fc_summary = self._latest_summary()
         if _fc_summary is not None and _is_force_close_consolidation(_fc_summary):
-            from reyn.runtime.session import ChatMessage  # noqa: PLC0415
+            from reyn.runtime.chat_message import ChatMessage
             _idx = next(
                 (i for i, m in enumerate(history) if m is _fc_summary), -1
             )
@@ -349,7 +349,7 @@ class RouterHistoryBuffer:
                     summary.content if isinstance(summary.content, str)
                     else json.dumps(summary.content, ensure_ascii=False)
                 )
-                from reyn.runtime.session import ChatMessage  # noqa: PLC0415
+                from reyn.runtime.chat_message import ChatMessage
                 bridge = [ChatMessage(
                     role="assistant",
                     content=f"[summary of earlier conversation]\n{summary_text}",

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -847,7 +847,7 @@ class RouterHostAdapter:
         the gap so the next ``_build_history_for_router`` rebuild
         replays the full LLM message sequence.
         """
-        from reyn.runtime.session import ChatMessage, _now_iso
+        from reyn.runtime.chat_message import ChatMessage, _now_iso
         self._append_history_cb(ChatMessage(
             role=role,
             content=content,
@@ -859,8 +859,8 @@ class RouterHostAdapter:
         ))
 
     async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+        from reyn.runtime.chat_message import ChatMessage, _now_iso
         from reyn.runtime.outbox import OutboxMessage
-        from reyn.runtime.session import ChatMessage, _now_iso
         # #1652: centralised reasoning handling for agent replies. The router
         # passes the turn's reasoning as meta["reasoning"]; this single chokepoint
         # applies the two independent gates so every agent-reply site is covered

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -173,7 +173,8 @@ class RouterLoopDriver:
         overflowed.  ``user_text`` is unused here (the new message is re-applied
         by the loop's next ``_run_with_shrink``); kept for symmetry / future audit.
         """
-        from reyn.runtime.session import ChatMessage, _now_iso, _render_summary_for_storage
+        from reyn.runtime.chat_message import ChatMessage, _now_iso
+        from reyn.runtime.session import _render_summary_for_storage
 
         resolved_model = self._resolver.resolve(self._effective_router_model_class()).model
         consolidation = await self._force_close_wrap_up(loop, resolved_model)

--- a/src/reyn/runtime/services/skill_plan_glue.py
+++ b/src/reyn/runtime/services/skill_plan_glue.py
@@ -82,7 +82,8 @@ class SkillPlanGlue:
         """
         import json as _json
 
-        from reyn.runtime.session import ChatMessage, RouterCapExceeded, _new_chain_id, _now_iso
+        from reyn.runtime.chat_message import ChatMessage, _now_iso
+        from reyn.runtime.session import RouterCapExceeded, _new_chain_id
 
         run_id = payload.get("run_id", "")
         skill_name = payload.get("skill", "")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -40,6 +40,11 @@ from reyn.runtime.budget.budget import (
     format_refusal_message,
     format_warn_message,
 )
+from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
+    ChatMessage,
+    _migrate_legacy_chat_message,
+    _now_iso,
+)
 from reyn.runtime.error_format import classify_router_error
 from reyn.runtime.limits.limit_handler import (
     LimitDecision,
@@ -467,171 +472,6 @@ class ChatInterventionBus:
     # Note: _dispatch_intervention on session.py is now a thin wrapper around
     # InterventionRegistry.dispatch (wave 2 of PR-refactor-session-1). Kept
     # method-level call so the bus signature stays stable.
-
-
-@dataclass(init=False)
-class ChatMessage:
-    """Chat-history entry, shaped to mirror the OpenAI/Anthropic message
-    list wire format (issue #383 E-full).
-
-    Each ``ChatMessage`` is one entry in the LLM-facing conversation, so
-    ``self.history`` can be serialised straight to the LLM without
-    synthesis. Tool turns are represented as their own ``role="tool"``
-    entries; assistant turns that emitted tool calls carry the
-    ``tool_calls`` field; multi-modal user / tool turns use the
-    list-of-parts ``content`` shape.
-
-    Role vocabulary:
-      - ``user`` — user input
-      - ``assistant`` — LLM reply (= previously ``agent``)
-      - ``tool`` — tool response (= new)
-      - ``system`` — system prompt (rare; usually built at wire time)
-      - ``summary`` — chat-compactor output (Reyn-internal, filtered at wire boundary)
-      - ``skill_event`` — TUI display marker (Reyn-internal, filtered at wire boundary)
-    """
-    role: Literal[
-        "user", "assistant", "tool", "system", "summary", "skill_event",
-    ]
-    # ``content`` is either:
-    #   - a ``str`` (= text-only turn), or
-    #   - a ``list[dict]`` of litellm-style content parts (= multimodal user
-    #     turn / tool response with an image / etc.). Each part is e.g.
-    #       {"type": "text", "text": "..."}
-    #       {"type": "image_url", "image_url": {"url": "<data url OR file ref>"}}
-    #       {"type": "image",     "path": "<abs or cwd-rel>",
-    #                             "mime_type": "...", "content_hash": "sha256:..."}
-    # The last shape (= ``"image"`` with ``path``) is the **path-ref**
-    # introduced by #383: storage points at a file on disk, the
-    # wire-shape builder reads and embeds the binary at LLM-call time.
-    content: str | list[dict] = ""
-    ts: str = ""
-    seq: int = 0  # monotonic per-session sequence id; 0 for non-conversational entries
-    meta: dict = field(default_factory=dict)
-    # OpenAI/Anthropic tool-turn fields ─────────────────────────────────
-    # ``tool_calls`` is set ONLY on ``role="assistant"`` entries where the
-    # LLM emitted one or more tool calls. Each block follows the OpenAI
-    # function-tool shape:
-    #   {"id": "<tool_call_id>", "type": "function",
-    #    "function": {"name": "<tool>", "arguments": "<json str>"}}
-    tool_calls: list[dict] | None = None
-    # ``tool_call_id`` is set ONLY on ``role="tool"`` entries. Links the
-    # response back to the originating ``tool_call`` block on the
-    # preceding assistant message.
-    tool_call_id: str | None = None
-    # ``name`` is set ONLY on ``role="tool"`` entries (= function name).
-    # Mirrors the OpenAI tool-message ``name`` field; some providers
-    # require it for tool-result attribution.
-    name: str | None = None
-
-    def __init__(
-        self,
-        role: str,
-        content: "str | list[dict]" = "",
-        ts: str = "",
-        seq: int = 0,
-        meta: "dict | None" = None,
-        tool_calls: "list[dict] | None" = None,
-        tool_call_id: "str | None" = None,
-        name: "str | None" = None,
-    ) -> None:
-        # Reject the pre-#383 ``"agent"`` spelling. Migration of on-disk
-        # ``history.jsonl`` entries happens at load time via
-        # ``_migrate_legacy_chat_message``; nothing else should be
-        # constructing with ``role="agent"`` anymore.
-        if role == "agent":
-            raise ValueError(
-                "ChatMessage role='agent' was renamed to 'assistant' in "
-                "issue #383. Pass role='assistant' instead. "
-                "(Legacy on-disk entries are migrated read-time by "
-                "_migrate_legacy_chat_message.)"
-            )
-        self.role = role
-        self.content = content
-        self.ts = ts
-        self.seq = seq
-        self.meta = meta if meta is not None else {}
-        self.tool_calls = tool_calls
-        self.tool_call_id = tool_call_id
-        self.name = name
-
-    @property
-    def text(self) -> str:
-        """Derived view returning a str representation of ``content``.
-
-        - str content → returned as-is.
-        - list-of-parts content → the first ``{"type":"text"}`` part's text.
-        - neither → empty string.
-
-        This is a convenience accessor, NOT a legacy compatibility shim:
-        readers that want a textual rendering of any ChatMessage (text or
-        multimodal) call ``m.text`` instead of branching on isinstance.
-        Writers update ``content`` directly.
-        """
-        if isinstance(self.content, str):
-            return self.content
-        if isinstance(self.content, list):
-            for part in self.content:
-                if isinstance(part, dict) and part.get("type") == "text":
-                    return part.get("text", "")
-        return ""
-
-
-# ── Legacy ChatMessage migration ───────────────────────────────────────
-#
-# history.jsonl files written before issue #383 used the pre-Design-B
-# shape: ``role`` ∈ {"user","agent","skill_event","summary"}; ``text:
-# str``; ``media: list[dict]`` (= inline base64 image_url parts from
-# #366). On load, ``_migrate_legacy_chat_message`` rewrites such
-# entries into the new wire shape so the runtime only ever sees
-# Design-B ChatMessage instances.
-
-
-def _migrate_legacy_chat_message(raw: dict) -> dict:
-    """Read-time migration for pre-#383 history.jsonl entries.
-
-    Detects the legacy shape (= ``text`` key + optional ``media`` list,
-    ``role="agent"`` for assistant replies) and emits the Design-B
-    shape (= ``content`` field, ``role="assistant"``). Mutates a copy;
-    the caller hands the result to ``ChatMessage(**kwargs)``.
-
-    Legacy → new:
-      role: "agent"            → "assistant"
-      text: "hi"               → content: "hi"
-      text + media: [...]      → content: [{"type": "text", "text": "hi"}, ...media]
-      (no text, media: [...])  → content: [...media]
-
-    Inline base64 in media blocks is left alone — those entries
-    pre-date the path-ref design and rewriting them to files would
-    be a one-shot tool, out of scope for read-time migration.
-    """
-    raw = dict(raw)  # don't mutate the caller's dict
-    if "content" in raw:
-        # Already new shape (= written post-#383 or already migrated).
-        # Still normalise role just in case "agent" snuck in.
-        if raw.get("role") == "agent":
-            raw["role"] = "assistant"
-        return raw
-
-    # Legacy shape: text + optional media.
-    text_val = raw.pop("text", "")
-    media_val = raw.pop("media", None) or []
-
-    if media_val:
-        parts: list[dict] = []
-        if text_val:
-            parts.append({"type": "text", "text": text_val})
-        parts.extend(media_val)
-        raw["content"] = parts
-    else:
-        raw["content"] = text_val
-
-    if raw.get("role") == "agent":
-        raw["role"] = "assistant"
-    return raw
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
 
 
 class _RouterUsageShim:

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -137,7 +137,7 @@ def _make_session_with_t_max(tmp_path: Path, t_max: int):
 
 
 def _push(session, role: str, content: str) -> None:
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
     if role == "agent":
         role = "assistant"
     session.history.append(ChatMessage(role=role, content=content, ts=_now()))

--- a/tests/test_a2a_sync_async_escalation.py
+++ b/tests/test_a2a_sync_async_escalation.py
@@ -43,7 +43,7 @@ from reyn.interfaces.web.run_registry import RunRegistry
 
 
 class _Msg:
-    """Minimal stand-in for ``reyn.runtime.session.ChatMessage`` used in
+    """Minimal stand-in for ``reyn.runtime.chat_message.ChatMessage`` used in
     history-harvesting tests. The real ChatMessage has many fields the
     harvester doesn't read; this isolates the contract: role + text + meta."""
 

--- a/tests/test_chat_message_e_full_schema.py
+++ b/tests/test_chat_message_e_full_schema.py
@@ -19,7 +19,7 @@ import json
 from dataclasses import asdict
 from pathlib import Path
 
-from reyn.runtime.session import ChatMessage, _migrate_legacy_chat_message
+from reyn.runtime.chat_message import ChatMessage, _migrate_legacy_chat_message
 
 # ── Constructor: new shape ─────────────────────────────────────────────
 

--- a/tests/test_compaction_controller_tool_aware.py
+++ b/tests/test_compaction_controller_tool_aware.py
@@ -15,10 +15,10 @@ PR-N3: the phase prompt is now a string constant in
 """
 from __future__ import annotations
 
+from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.services.compaction_controller import (
     _turn_to_compactor_input,
 )
-from reyn.runtime.session import ChatMessage
 
 # ── _turn_to_compactor_input ──────────────────────────────────────────
 

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -22,7 +22,8 @@ import pytest
 
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
-from reyn.runtime.session import _MAX_FORCE_CLOSE_HANDOFFS, ChatMessage
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import _MAX_FORCE_CLOSE_HANDOFFS
 from reyn.services.compaction.engine import ContextOverflowError
 from tests.test_session_router_history_slicing import _make_session, _push
 

--- a/tests/test_fp0001_session_override.py
+++ b/tests/test_fp0001_session_override.py
@@ -400,7 +400,7 @@ def test_send_to_agent_impl_override_registered_and_cleaned_up(tmp_path, monkeyp
 
     # Stub _handle_user_message so the session produces a synthetic reply
     # without invoking a real LLM.
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
 
     async def _fake_handle(self_inner, message, *, chain_id):
         self_inner._append_history(ChatMessage(
@@ -511,7 +511,7 @@ def test_concurrent_send_to_agent_impl_no_override_leak(tmp_path, monkeypatch):
     session.register_intervention_override = _spy_register  # type: ignore[method-assign]
     session.unregister_intervention_override = _spy_unregister  # type: ignore[method-assign]
 
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
 
     call_count = 0
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -323,7 +323,7 @@ def test_send_to_agent_waits_for_plan_terminal_text(tmp_path, monkeypatch):
     # Stub LLM: not invoked because we directly simulate plan dispatch
     # via a fake _handle_user_message that schedules a background task.
     async def _fake_handle_user_message(self, message, *, chain_id):
-        from reyn.runtime.session import ChatMessage
+        from reyn.runtime.chat_message import ChatMessage
         # Append the user message (= mirror real path)
         self._append_history(ChatMessage(
             role="user", content=message, ts="2026-05-08T00:00:00",
@@ -390,7 +390,7 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
     sentinel = "SKILL_COMPLETION_NARRATION_MARKER"
 
     async def _fake_handle_user_message(self, message, *, chain_id):
-        from reyn.runtime.session import ChatMessage
+        from reyn.runtime.chat_message import ChatMessage
         self._append_history(ChatMessage(
             role="user", content=message, ts="2026-05-11T00:00:00",
             meta={"chain_id": chain_id},
@@ -410,7 +410,7 @@ def test_send_to_agent_drains_skill_completed_inbox(tmp_path, monkeypatch):
         self.running_skills["fake_run_0001"] = task
 
     async def _fake_handle_skill_completed(self, payload):
-        from reyn.runtime.session import ChatMessage
+        from reyn.runtime.chat_message import ChatMessage
         self._append_history(ChatMessage(
             role="assistant",
             content=f"{sentinel}: {payload.get('skill')} {payload.get('status')}",

--- a/tests/test_path_ref_materialisation.py
+++ b/tests/test_path_ref_materialisation.py
@@ -17,12 +17,12 @@ import base64
 from pathlib import Path
 
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.router_loop import _build_media_followup_message
 from reyn.runtime.services.router_history_buffer import (
     _materialise_path_ref_content,
     _read_pathref_image,
 )
-from reyn.runtime.session import ChatMessage
 
 # ── helpers ────────────────────────────────────────────────────────────
 

--- a/tests/test_permission_state_change_emitter.py
+++ b/tests/test_permission_state_change_emitter.py
@@ -35,7 +35,8 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.runtime.session import ChatMessage, Session
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
 from reyn.security.permissions.permissions import PermissionResolver
 
 

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -22,8 +22,9 @@ from reyn.config import ReasoningConfig
 from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
 from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.services import MemoryService, RouterHostAdapter
-from reyn.runtime.session import ChatMessage, Session
+from reyn.runtime.session import Session
 
 _REASONING = "REYN_1652_THOUGHTS: 17*23 = 391."
 

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -32,7 +32,8 @@ from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.session import ChatMessage, Session, _RouterUsageShim
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session, _RouterUsageShim
 from reyn.services.compaction.engine import retry_loop
 
 

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -406,7 +406,7 @@ def test_list_available_skills_excludes_stdlib_router(tmp_path, monkeypatch):
 def test_build_history_for_router_shape(tmp_path, monkeypatch):
     """Tier 1: _build_history_for_router returns OpenAI-style dicts with correct role mapping and ordering from session history."""
     monkeypatch.chdir(tmp_path)
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
     session = _make_session(tmp_path)
 
     # Inject some history (Issue #383: new content kwarg + assistant role)

--- a/tests/test_router_loop_tool_turn_persistence.py
+++ b/tests/test_router_loop_tool_turn_persistence.py
@@ -85,7 +85,7 @@ def test_adapter_append_history_entry_creates_chatmessage():
     ``_append_history`` callback (= integration with the runtime
     persistence path).
     """
-    from reyn.runtime.session import ChatMessage
+    from reyn.runtime.chat_message import ChatMessage
 
     captured: list[ChatMessage] = []
 
@@ -99,7 +99,7 @@ def test_adapter_append_history_entry_creates_chatmessage():
             self, *, role, content, meta=None, tool_calls=None,
             tool_call_id=None, name=None,
         ) -> None:
-            from reyn.runtime.session import ChatMessage, _now_iso
+            from reyn.runtime.chat_message import ChatMessage, _now_iso
             self._append_history_cb(ChatMessage(
                 role=role, content=content, ts=_now_iso(),
                 meta=meta if meta is not None else {},

--- a/tests/test_session_notify_state_change.py
+++ b/tests/test_session_notify_state_change.py
@@ -28,7 +28,8 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.runtime.session import ChatMessage, Session
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -24,7 +24,8 @@ import reyn.llm.model_budget as _mb
 from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.session import ChatMessage, Session
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
 
 
 def _now() -> str:

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -24,7 +24,8 @@ from reyn.config import CompactionConfig
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.slash import REGISTRY
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.session import ChatMessage, Session
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
 
 # Compaction summary the engine's litellm call returns; new_turn_seqs lists the
 # candidate turn seqs (head=2/tail=2 over 8 turns → candidates 3..6).

--- a/tests/test_transport_ref.py
+++ b/tests/test_transport_ref.py
@@ -503,7 +503,7 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
         return await original_put_inbox(self, kind, payload)
 
     async def _fake_handle_user_message(self, text, *, chain_id):
-        from reyn.runtime.session import ChatMessage
+        from reyn.runtime.chat_message import ChatMessage
         self._append_history(ChatMessage(
             role="user", content=text, ts="2026-05-14T00:00:00",
             meta={"chain_id": chain_id},

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -25,7 +25,7 @@ import pytest
 
 from reyn.config import MultimodalConfig
 from reyn.interfaces.slash import REGISTRY
-from reyn.runtime.session import ChatMessage
+from reyn.runtime.chat_message import ChatMessage
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 


### PR DESCRIPTION
**[e2e-coder]** — Refs #312, **C-series C1** (FP-0044 god-file decomposition, stage 1). lead-approved seam-design.

## What
Extract the `ChatMessage` value object + `_migrate_legacy_chat_message` + `_now_iso` out of the `session.py` god-file → new `runtime/chat_message.py`. **Pure move (byte-identical), no class rename** (the "chat" legacy naming is a separate optional cleanup, per lead).

- **New `runtime/chat_message.py`**: `ChatMessage` (`@dataclass(init=False)`) + the legacy-migration helper + `_now_iso`, with their `dataclasses`/`datetime`/`typing` imports. **No Session dependency** → Session imports chat_message (one-directional, no cycle).
- **`session.py`**: removed the 165-line region; imports the 3 symbols from chat_message for its own use. God-file **5214 → 5049 LOC**.
- **`runtime/__init__`**: lazy `ChatMessage` re-export → `.chat_message` (+ TYPE_CHECKING).
- **Repointed 22 consumers**: the 3 moved symbols import from chat_message; `Session`/`RouterCapExceeded`/etc. stay on session (mixed imports split).

## Verification (per-PR gates)
- **byte-gate**: class + helper bodies verbatim (confirmed the `@dataclass`/`__init__`/agent-reject/`_now_iso` blocks are character-identical in the new module).
- **no cycle**: `import reyn.runtime.session` + `from reyn.runtime.chat_message import …` + `from reyn.runtime import ChatMessage` (lazy) all resolve clean.
- **collect-only**: 7581 tests collect (all imports resolve).
- **4-ref-class straggler 0** (repo-wide: the 3 moved symbols no longer imported from session anywhere except session.py's own internal import).
- ChatMessage behavior smoke (text accessor + agent-reject) intact.
- Consumer sweep **1249 passed**; the 1 fail (`test_web_fetch_preview_path_ref` legacy-no-media-store, HTML extraction) is **pre-existing local-env** (reproduces on clean main with this stashed — falsified). ruff clean.

## Test plan
- [x] ChatMessage + helpers byte-identical move to runtime/chat_message.py; no Session dep (no cycle)
- [x] session.py imports the 3 symbols; god-file shrinks 165 LOC; lazy re-export repointed
- [x] 22 consumers repointed (mixed imports split); straggler 0 repo-wide
- [x] collect-only 7581 + consumer sweep 1249 passed (1 pre-existing-env fail falsified); ruff clean

> C-series next: C2 (RouterCapExceeded), C3 (PendingOpView), C4 (session_buses), C5 (_RouterUsageShim) — 1 PR each, after this lands. method-cluster extraction (C6+) = owner-level seam (will escalate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
