### PR TITLE
refactor(C2): extract RouterCapExceeded → runtime/errors.py (#1792)

### DIFF
--- a/src/reyn/runtime/errors.py
+++ b/src/reyn/runtime/errors.py
@@ -1,0 +1,29 @@
+"""reyn.runtime.errors — exception types raised by the agent runtime.
+
+Runtime-level exceptions that the turn loop raises and its handlers catch to
+surface a structured fallback to the user / requester. Pure exception types —
+no dependency on ``Session`` (the runtime raises and catches these).
+"""
+from __future__ import annotations
+
+
+class RouterCapExceeded(Exception):
+    """Raised when a user turn (or top-level agent_request) drives more
+    skill_router invocations than the configured cap. Caught by handlers,
+    which surface a structured fallback reply to the user / requester.
+
+    FP-0004: ``hint_config_key`` is the user-facing config knob to raise
+    when an operator decides the cap is too tight for their workload.
+    """
+
+    hint_config_key: str = "safety.loop.max_router_calls_per_turn"
+
+    def __init__(self, count: int, cap: int, last_reason: str = "") -> None:
+        super().__init__(
+            f"Router exhausted retry budget ({count}/{cap}) for this turn. "
+            f"→ Raise {RouterCapExceeded.hint_config_key} to allow more "
+            f"router invocations per turn (0 = unlimited)."
+        )
+        self.count = count
+        self.cap = cap
+        self.last_reason = last_reason

--- a/src/reyn/runtime/services/a2a_handler.py
+++ b/src/reyn/runtime/services/a2a_handler.py
@@ -315,7 +315,7 @@ class A2AHandler:
         If no delegations are emitted, behavior matches PR11: send the
         router's reply_text (or empty) right back to the requester.
         """
-        from reyn.runtime.session import RouterCapExceeded
+        from reyn.runtime.errors import RouterCapExceeded
 
         from_agent = payload.get("from_agent", "")
         request = payload.get("request", "")
@@ -442,7 +442,7 @@ class A2AHandler:
           user-facing message (outbox + history); further delegations
           continue with depth+1 on the same chain_id.
         """
-        from reyn.runtime.session import RouterCapExceeded
+        from reyn.runtime.errors import RouterCapExceeded
 
         from_agent = payload.get("from_agent", "")
         response = payload.get("response", "")
@@ -541,7 +541,7 @@ class A2AHandler:
         to compose a synthesized answer (or decide on more delegations,
         which keeps the chain pending).
         """
-        from reyn.runtime.session import RouterCapExceeded
+        from reyn.runtime.errors import RouterCapExceeded
 
         chain_id = pending.chain_id
         pending.waiting_on.discard(from_agent)

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -127,7 +127,7 @@ class BudgetGateway:
         disables the check.
         """
         # Import here to avoid circular import at module load time.
-        from reyn.runtime.session import RouterCapExceeded
+        from reyn.runtime.errors import RouterCapExceeded
 
         if self._router_cap <= 0:
             return

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -141,7 +141,7 @@ class RouterLoopDriver:
         before re-raising. On approval the cap is extended by the configured
         amount and the run continues.
         """
-        from reyn.runtime.session import RouterCapExceeded
+        from reyn.runtime.errors import RouterCapExceeded
         try:
             self._budget.check_and_increment_router_cap(user_text)
         except RouterCapExceeded as exc:

--- a/src/reyn/runtime/services/skill_plan_glue.py
+++ b/src/reyn/runtime/services/skill_plan_glue.py
@@ -83,7 +83,8 @@ class SkillPlanGlue:
         import json as _json
 
         from reyn.runtime.chat_message import ChatMessage, _now_iso
-        from reyn.runtime.session import RouterCapExceeded, _new_chain_id
+        from reyn.runtime.errors import RouterCapExceeded
+        from reyn.runtime.session import _new_chain_id
 
         run_id = payload.get("run_id", "")
         skill_name = payload.get("skill", "")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -46,6 +46,7 @@ from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
     _now_iso,
 )
 from reyn.runtime.error_format import classify_router_error
+from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.limits.limit_handler import (
     LimitDecision,
     handle_limit_exceeded,
@@ -238,28 +239,6 @@ def _exec_gate_backend_name(sandbox_backend: Any, sandbox_config: Any) -> str | 
     if sandbox_config is not None:
         return sandbox_config.backend
     return None
-
-
-class RouterCapExceeded(Exception):
-    """Raised when a user turn (or top-level agent_request) drives more
-    skill_router invocations than the configured cap. Caught by handlers,
-    which surface a structured fallback reply to the user / requester.
-
-    FP-0004: ``hint_config_key`` is the user-facing config knob to raise
-    when an operator decides the cap is too tight for their workload.
-    """
-
-    hint_config_key: str = "safety.loop.max_router_calls_per_turn"
-
-    def __init__(self, count: int, cap: int, last_reason: str = "") -> None:
-        super().__init__(
-            f"Router exhausted retry budget ({count}/{cap}) for this turn. "
-            f"→ Raise {RouterCapExceeded.hint_config_key} to allow more "
-            f"router invocations per turn (0 = unlimited)."
-        )
-        self.count = count
-        self.cap = cap
-        self.last_reason = last_reason
 
 
 # issue #268 Phase 2 continuation: canonical channel identifier for

--- a/tests/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/test_a2a_router_cap_wrapup_1538.py
@@ -35,9 +35,10 @@ import pytest
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
+from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.services.a2a_handler import A2AHandler
 from reyn.runtime.services.chain_manager import ChainManager
-from reyn.runtime.session import RouterCapExceeded, Session
+from reyn.runtime.session import Session
 from tests.test_router_loop import FakeEventLog
 
 _EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)

--- a/tests/test_budget_gateway_invariants.py
+++ b/tests/test_budget_gateway_invariants.py
@@ -17,8 +17,8 @@ from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.services.budget_gateway import BudgetGateway
-from reyn.runtime.session import RouterCapExceeded
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_chat_router_i18n.py
+++ b/tests/test_chat_router_i18n.py
@@ -368,7 +368,7 @@ def test_retry_exhausted_fallback_is_english_when_output_language_is_none(
 
     session._put_outbox = fake_put_outbox  # type: ignore[assignment]
 
-    from reyn.runtime.session import RouterCapExceeded
+    from reyn.runtime.errors import RouterCapExceeded
 
     async def run():
         await session._emit_router_cap_exhausted_user(

--- a/tests/test_limit_deny_force_close_router_cap_1496.py
+++ b/tests/test_limit_deny_force_close_router_cap_1496.py
@@ -27,8 +27,9 @@ from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.outbox import OutboxMessage
-from reyn.runtime.session import RouterCapExceeded, Session
+from reyn.runtime.session import Session
 from tests.test_router_loop import _ScriptedLLM, text_result
 
 _USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)

--- a/tests/test_router_cap.py
+++ b/tests/test_router_cap.py
@@ -28,7 +28,8 @@ import pytest
 
 from reyn.config import LoopConfig, SafetyConfig
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.session import RouterCapExceeded, Session
+from reyn.runtime.errors import RouterCapExceeded
+from reyn.runtime.session import Session
 
 
 def _run(coro):

--- a/tests/test_safety_config.py
+++ b/tests/test_safety_config.py
@@ -188,7 +188,7 @@ def test_router_cap_exception_carries_hint_key() -> None:
     """Tier 2: ``RouterCapExceeded.hint_config_key`` names the loop knob
     and is embedded in the message.
     """
-    from reyn.runtime.session import RouterCapExceeded
+    from reyn.runtime.errors import RouterCapExceeded
 
     assert RouterCapExceeded.hint_config_key == "safety.loop.max_router_calls_per_turn"
     exc = RouterCapExceeded(count=4, cap=3, last_reason="")

--- a/tests/test_safety_phase2_wiring.py
+++ b/tests/test_safety_phase2_wiring.py
@@ -25,8 +25,9 @@ import pytest
 from reyn.config import LoopConfig, OnLimitConfig, SafetyConfig
 from reyn.core.kernel.runtime import LoopLimitExceededError, OSRuntime
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.limits.limit_handler import reset_run_extensions
-from reyn.runtime.session import RouterCapExceeded, Session
+from reyn.runtime.session import Session
 from reyn.schemas.models import Phase, Skill, SkillGraph
 
 

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -964,7 +964,7 @@ async def test_agent_request_router_cap_exhausted_sends_marker_upstream(
     session.is_attached = True
 
     # Force RouterCapExceeded from the handler.
-    from reyn.runtime.session import RouterCapExceeded
+    from reyn.runtime.errors import RouterCapExceeded
 
     async def _raise_cap(*args, **kwargs):
         raise RouterCapExceeded(count=3, cap=3, last_reason="loop")


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **stage 2** (after C1 #1790, merged). Pure move of the `RouterCapExceeded` exception out of the `session.py` god-file.

## What
`RouterCapExceeded` (pure `Exception`, 14 ref-sites / 12 consumer files) → new `reyn.runtime.errors` module.

## Gate (same as C1)
- ✅ **Byte-identical move** — class body verbatim (verified removed==added via diff); no behavior change, no class rename.
- ✅ **No cycle** — `errors.py` imports nothing from `reyn` (only `from __future__`); one-directional `session → errors`.
- ✅ **Clean break, no re-export shim** — all 12 consumers repointed `session import RouterCapExceeded` → `errors import RouterCapExceeded`; mixed-import lines split so `Session` / `_new_chain_id` stay sourced from session.
- ✅ **Repo-wide 4-ref-class straggler 0** — dotted-import / dotted-literal / segment-path / **docstring+comment** grep of old location = 0 (the C1 R2 learning applied up-front).
- ✅ **R1 docstring discipline from the start** — `errors.py` docstring is current-state only (what the module IS); refactor story (#312 / extracted-from-session / FP-0044) is in the **commit message**, not the docstring.

## Test plan
- [x] `uvx ruff@latest check src tests` — All checks passed (4 import-sort autofixes applied)
- [x] Focused suites green: `test_router_cap`, `test_budget_gateway_invariants`, `test_safety_config`, `test_safety_phase2_wiring`, `test_a2a_router_cap_wrapup_1538`, `test_limit_deny_force_close_router_cap_1496` → 31 passed
- [x] Full CI green (pytest 3.11/3.12 + ruff + test-tier) ✓

Refs #1792.

