### PR TITLE
refactor(C3): extract PendingOpView → runtime/pending_op_view.py (#1792)

### DIFF
--- a/src/reyn/runtime/pending_op_view.py
+++ b/src/reyn/runtime/pending_op_view.py
@@ -1,0 +1,64 @@
+"""reyn.runtime.pending_op_view — the cross-channel pending-operation view.
+
+``PendingOpView`` is the read-only, frozen value object describing one pending /
+stalled operation in a channel-agnostic shape, so the TUI Pending tab and the
+``/pending`` slash command can render it without depending on the originating
+op type. Built from a ``UserIntervention`` today; the ``kind`` discriminator
+admits other pending-op sources. Pure value object — no dependency on
+``Session``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.user_intervention import UserIntervention
+
+
+@dataclass(frozen=True)
+class PendingOpView:
+    """Read-only view of a pending / stalled operation surfaced across channels
+    (= issue #268 Phase 1, #270 umbrella vocabulary).
+
+    First instance carries ``UserIntervention`` data; Phase B refactor
+    (= #270) generalises this dataclass to also describe MCP pending
+    calls / peer-delegation pending operations. The ``kind`` field is
+    the discriminator. Field shape is **pinned at Phase A landing**
+    per tui-coder commitment so the TUI Pending tab + ``/pending``
+    slash command code path doesn't churn as new kinds land.
+
+    Pinned fields (= TUI consume contract):
+      - ``id``: stable identifier (= iv.id for interventions)
+      - ``kind``: discriminator (= "intervention" for now, future
+        "mcp_call" / "peer_delegate")
+      - ``origin_channel_id``: where the op originated (= "tui:..." /
+        "a2a:..." etc.)
+      - ``created_at``: ISO timestamp string for age-rendering
+      - ``summary``: short human-readable description (= iv.prompt
+        first line for interventions)
+      - ``detail``: optional second line (= iv.detail for interventions)
+    """
+    id: str
+    kind: str
+    origin_channel_id: str
+    created_at: str
+    summary: str
+    detail: str = ""
+
+    @classmethod
+    def from_intervention(cls, iv: "UserIntervention") -> "PendingOpView":
+        """Build a view from a ``UserIntervention``. ``created_at`` is
+        the current time at view construction since iv doesn't carry
+        its own timestamp; the TUI uses this for relative age display
+        even though it's a view-time stamp.
+        """
+        from datetime import datetime, timezone  # noqa: PLC0415
+        return cls(
+            id=iv.id,
+            kind="intervention",
+            origin_channel_id=iv.origin_channel_id or "",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            summary=iv.prompt,
+            detail=iv.detail or "",
+        )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -53,6 +53,7 @@ from reyn.runtime.limits.limit_handler import (
     reset_run_extensions,
 )
 from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.pending_op_view import PendingOpView
 from reyn.runtime.services import (
     AutoResumeHandler,
     BudgetGateway,
@@ -257,54 +258,6 @@ DEFAULT_CHAT_CHANNEL_ID = "tui"
 # differentiation). Imported function-locally at the construction site below
 # (session→router_loop is a function-local import to avoid the module-level
 # cycle: router_loop imports from session).
-
-
-@dataclass(frozen=True)
-class PendingOpView:
-    """Read-only view of a pending / stalled operation surfaced across channels
-    (= issue #268 Phase 1, #270 umbrella vocabulary).
-
-    First instance carries ``UserIntervention`` data; Phase B refactor
-    (= #270) generalises this dataclass to also describe MCP pending
-    calls / peer-delegation pending operations. The ``kind`` field is
-    the discriminator. Field shape is **pinned at Phase A landing**
-    per tui-coder commitment so the TUI Pending tab + ``/pending``
-    slash command code path doesn't churn as new kinds land.
-
-    Pinned fields (= TUI consume contract):
-      - ``id``: stable identifier (= iv.id for interventions)
-      - ``kind``: discriminator (= "intervention" for now, future
-        "mcp_call" / "peer_delegate")
-      - ``origin_channel_id``: where the op originated (= "tui:..." /
-        "a2a:..." etc.)
-      - ``created_at``: ISO timestamp string for age-rendering
-      - ``summary``: short human-readable description (= iv.prompt
-        first line for interventions)
-      - ``detail``: optional second line (= iv.detail for interventions)
-    """
-    id: str
-    kind: str
-    origin_channel_id: str
-    created_at: str
-    summary: str
-    detail: str = ""
-
-    @classmethod
-    def from_intervention(cls, iv: "UserIntervention") -> "PendingOpView":
-        """Build a view from a ``UserIntervention``. ``created_at`` is
-        the current time at view construction since iv doesn't carry
-        its own timestamp; the TUI uses this for relative age display
-        even though it's a view-time stamp.
-        """
-        from datetime import datetime, timezone  # noqa: PLC0415
-        return cls(
-            id=iv.id,
-            kind="intervention",
-            origin_channel_id=iv.origin_channel_id or "",
-            created_at=datetime.now(timezone.utc).isoformat(),
-            summary=iv.prompt,
-            detail=iv.detail or "",
-        )
 
 
 class AgentRequestBus:

--- a/tests/test_pending_intervention_268.py
+++ b/tests/test_pending_intervention_268.py
@@ -42,8 +42,9 @@ from datetime import datetime
 
 import pytest
 
+from reyn.runtime.pending_op_view import PendingOpView
 from reyn.runtime.services.intervention_registry import InterventionRegistry
-from reyn.runtime.session import PendingOpView, Session
+from reyn.runtime.session import Session
 from reyn.user_intervention import (
     InterventionAnswer,
     UserIntervention,


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **stage 3** (after C1 #1790, C2 #1793, both merged). Pure move of the `PendingOpView` frozen dataclass out of the `session.py` god-file.

## What
`PendingOpView` (frozen dataclass, cross-channel pending-op view) → new `reyn.runtime.pending_op_view` module.

## Gate
- ✅ **Byte-identical move** — class body verbatim (verified removed==added via diff); no behavior change, no rename.
- ✅ **No cycle** — `UserIntervention` imported under `TYPE_CHECKING` only (never at runtime); the `from_intervention` body is duck-typed. `pending_op_view.py` has no runtime `reyn` dependency on Session.
- ✅ **Clean break, no re-export shim** — the one real consumer (`tests/test_pending_intervention_268.py`) repointed to `pending_op_view`; mixed line split so `Session` stays from session. All TUI/slash references are duck-typed **comments**, not imports — untouched.
- ✅ **Repo-wide 4-ref-class straggler 0** — dotted-import / dotted-literal / segment-path / **docstring+comment** grep of old location = 0.
- ✅ **R1 docstring discipline** — `pending_op_view.py` module docstring is current-state only; refactor story in the **commit message**. (The class docstring's #268/#270 refs describe the class's own field-shape contract and are part of the byte-identical move — kept verbatim.)

## Test plan
- [x] `uvx ruff@latest check src tests` — All checks passed (1 import-sort autofix)
- [x] `test_pending_intervention_268` + `cli/test_pending_tab_render` → 29 passed
- [x] Full CI green (pytest 3.11/3.12 + ruff + test-tier) ✓

Refs #1792.
