### PR TITLE
refactor(C5): extract _RouterUsageShim → runtime/usage_shim.py (#1792)

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -257,7 +257,8 @@ class RouterLoopDriver:
         it ONLY when it actually gives up (cap reached / sub-viable model), so a
         recoverable handoff is not mislogged as a dead-end.
         """
-        from reyn.runtime.session import _render_summary_for_storage, _RouterUsageShim
+        from reyn.runtime.session import _render_summary_for_storage
+        from reyn.runtime.usage_shim import _RouterUsageShim
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
         )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -261,22 +261,6 @@ DEFAULT_CHAT_CHANNEL_ID = "tui"
 # cycle: router_loop imports from session).
 
 
-class _RouterUsageShim:
-    """Wrap a RouterLoop ``TokenUsage`` as ``.usage`` for ``retry_loop`` (#1125).
-
-    ``retry_loop``'s learner-feedback path reads ``response.usage.prompt_tokens``
-    (the litellm response convention). RouterLoop.run returns the bare
-    ``TokenUsage`` instead, so this shim exposes it under ``.usage`` — letting
-    the adaptive estimator observe the chat axis's actual prompt size. The
-    overflow-recovery caller reads ``.usage`` back out to credit session usage.
-    """
-
-    __slots__ = ("usage",)
-
-    def __init__(self, usage: object) -> None:
-        self.usage = usage
-
-
 def _ts_iso_to_epoch(ts: str | None) -> float | None:
     """Best-effort ISO-8601 → epoch-seconds conversion.
 

--- a/src/reyn/runtime/usage_shim.py
+++ b/src/reyn/runtime/usage_shim.py
@@ -1,0 +1,24 @@
+"""reyn.runtime.usage_shim — token-usage adapter for the retry loop.
+
+``_RouterUsageShim`` wraps a bare ``TokenUsage`` so it is readable as
+``response.usage`` (the litellm response convention) by ``retry_loop``'s
+learner-feedback path, which observes ``response.usage.prompt_tokens``.
+Dependency-free value wrapper.
+"""
+from __future__ import annotations
+
+
+class _RouterUsageShim:
+    """Wrap a RouterLoop ``TokenUsage`` as ``.usage`` for ``retry_loop`` (#1125).
+
+    ``retry_loop``'s learner-feedback path reads ``response.usage.prompt_tokens``
+    (the litellm response convention). RouterLoop.run returns the bare
+    ``TokenUsage`` instead, so this shim exposes it under ``.usage`` — letting
+    the adaptive estimator observe the chat axis's actual prompt size. The
+    overflow-recovery caller reads ``.usage`` back out to credit session usage.
+    """
+
+    __slots__ = ("usage",)
+
+    def __init__(self, usage: object) -> None:
+        self.usage = usage

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -33,7 +33,8 @@ from reyn.core.events.state_log import StateLog
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage
-from reyn.runtime.session import Session, _RouterUsageShim
+from reyn.runtime.session import Session
+from reyn.runtime.usage_shim import _RouterUsageShim
 from reyn.services.compaction.engine import retry_loop
 
 


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **stage 5 — the final non-Session class extraction, completing Stage-1** (session.py god-file class decomposition). After C1–C4, all merged.

## What
`_RouterUsageShim` (dependency-free token-usage adapter for retry_loop) → new `reyn.runtime.usage_shim` module.

## Gate
- ✅ **Byte-identical move** — class body verified removed==added via diff.
- ✅ **No cycle** — dependency-free wrapper (`usage: object`); zero imports.
- ✅ **No back-import** — session.py doesn't reference the shim internally (only `router_loop_driver` does, function-locally), so session.py simply drops the class.
- ✅ **Clean break, no shim** — both consumers repointed to `usage_shim`; mixed lines split so `Session` / `_render_summary_for_storage` stay from session.
- ✅ **Repo-wide straggler 0** — all ref classes incl multi-line parenthesised import blocks (C4 learning applied up-front).
- ✅ **R1 docstring discipline** — `usage_shim.py` current-state only; story in commit.

## Test plan
- [x] `uvx ruff@latest check src tests` — All checks passed (2 import-sort autofixes)
- [x] `test_retry_loop_chat_wiring_1125` → 7 passed
- [x] Full CI green (pytest 3.11/3.12 + ruff + test-tier) ✓

## Stage-1 complete
With C5, all 6 non-Session classes are extracted from session.py (ChatMessage, RouterCapExceeded, PendingOpView, AgentRequestBus, ChatInterventionBus, _RouterUsageShim). Remaining C6+ (Session method-cluster extraction) is **owner-gated** — a seam design doc will go to lead + owner for review before any cut.

Refs #1792.
