### PR TITLE
tooling(1792): module-docstring refactor-narrative CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,3 +102,23 @@ jobs:
             # entire test suite — invariant safety net, unchanged.
             python scripts/test_tier_audit.py --strict tests/
           fi
+
+      # scripts/verify_module_docstrings.py is stdlib-only. Scoped to the
+      # src/ files changed in a PR: blocks NEW moved-module refactor-narrative
+      # docstrings (the C-series discipline) without requiring a one-shot
+      # cleanup of pre-existing instances. main push: no-op (a full-tree gate
+      # awaits that cleanup — see PR introducing this step).
+      - name: Run module-docstring narrative check
+        if: github.event_name == 'pull_request'
+        run: |
+          CHANGED=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}"...HEAD \
+            -- 'src/**.py')
+          if [ -z "$CHANGED" ]; then
+            echo "No src files changed — docstring check skipped."
+            exit 0
+          fi
+          echo "Checking changed src files:"
+          echo "$CHANGED"
+          # shellcheck disable=SC2086
+          python scripts/verify_module_docstrings.py $CHANGED

--- a/scripts/verify_module_docstrings.py
+++ b/scripts/verify_module_docstrings.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fail if a MODULE docstring carries moved-module refactor narrative.
+
+The C-series discipline (and #311 / #1787 / #1790 before it): a module's
+docstring describes the **current state** — what the module IS — and the
+**refactor story** (extracted-from / proposal id / staging) lives in the commit
+message, not the docstring. This catches the most common violation shape
+mechanically so it isn't re-flagged by hand each extraction.
+
+Scope is deliberately narrow to keep **zero false positives**: only MODULE
+docstrings (extracted via ``ast`` — class/func docstrings are never inspected,
+so a class's legitimate ``#383`` contract ref is out of scope), and only the
+precise anti-pattern shape — an **extract/move/split verb** pointing at a
+**source module** (a ``reyn.`` dotted path, a ``*.py`` filename, or the words
+"god-file" / "decomposition"). Bare ``#NNNN`` / ``FP-NNNN`` refs are NOT
+flagged: they pervade legitimate current-state design-context docstrings (a
+calibration scan found 94 / 121 such module docstrings on main), so flagging
+them would make the gate cry wolf. The trade-off is accepted false negatives
+on creative phrasings — those stay covered by review.
+
+stdlib-only (ast / re / argparse / pathlib), mirroring
+scripts/test_tier_audit.py, so CI runs it dep-free.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+SKIP_DIRS = {".git", "__pycache__", ".venv", "node_modules"}
+
+# An extract/move verb whose object is a *source module* (not a concept).
+# Kept tight so legitimate prose ("extract the token count", "moved the cursor")
+# doesn't trip — the object must look like a module/file or the decomposition
+# vocabulary.
+_VERB = r"(?:extract(?:ed|s|ing)?|moved|split(?:\s+out)?|relocat(?:ed|es|ing)?|pulled)"
+_SOURCE = (
+    r"(?:"
+    r"reyn\.\w[\w.]*"          # a reyn dotted module path
+    r"|\b\w+\.py\b"            # a *.py filename
+    r"|god-file"              # the decomposition vocabulary
+    r"|decompos\w*"
+    r")"
+)
+NARRATIVE = re.compile(
+    rf"(?is)\b{_VERB}\b[^.\n]{{0,60}}?\b(?:from|out of)\b[^.\n]{{0,60}}?{_SOURCE}"
+)
+
+
+def _py_files(paths: list[str]) -> list[Path]:
+    out: list[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file() and p.suffix == ".py":
+            out.append(p)
+        elif p.is_dir():
+            for f in p.rglob("*.py"):
+                if any(part in SKIP_DIRS or part.endswith(".egg-info") for part in f.parts):
+                    continue
+                out.append(f)
+    return out
+
+
+def violations(paths: list[str]) -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    for p in _py_files(paths):
+        try:
+            doc = ast.get_docstring(ast.parse(p.read_text(encoding="utf-8")), clean=False)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        if not doc:
+            continue
+        m = NARRATIVE.search(doc)
+        if m:
+            found.append((str(p), " ".join(m.group(0).split())[:90]))
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "paths",
+        nargs="*",
+        default=["src/reyn"],
+        help="files or dirs to scan (default: src/reyn)",
+    )
+    args = ap.parse_args(argv)
+    paths = args.paths or ["src/reyn"]
+
+    found = violations(paths)
+    if not found:
+        print(f"OK: no module-docstring refactor narrative in {' '.join(paths)}.")
+        return 0
+
+    print(f"FAIL: {len(found)} module docstring(s) carry refactor narrative.")
+    print("Move the refactor story (extracted-from / proposal id / staging) to "
+          "the commit message; keep the module docstring current-state only.\n")
+    for fp, snippet in found:
+        print(f"  {fp}\n      :: {snippet!r}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**[e2e-coder]** — mechanizes the **moved-module-docstring discipline** (C1 R1, 3× recurrence #311/#1787/#1790; owner policy: mechanical rules → CI, not memory; lead GO). Second of two mechanize PRs (other = #1799 verify_package_move).

## What
`scripts/verify_module_docstrings.py` — AST-extracts **MODULE docstrings only** (a class's legit `#issue` contract ref is out of scope **by construction** — node-type separation) and flags the precise anti-pattern: an **extract/move/split verb → source module** (`reyn.<dotted>` / `*.py` / god-file / decomposition).

**Deliberately narrow for ZERO false positives.** Calibration scan of all 456 `src/reyn` module docstrings: bare `#NNNN` trips 94, `FP-NNNN` trips 121 — these pervade *legitimate* current-state docstrings (e.g. `#254` contract refs), so they are **not** flagged. Trade-off: accepted false negatives on creative phrasings (covered by review). A gate that cries wolf gets disabled; this one won't.

## CI wiring
Added to the `audit` job, scoped to **PR-changed src files** (mirrors the test-tier audit's changed-files scope) — blocks NEW violations without a one-shot cleanup. main push: no-op for this step.

## Test plan
- [x] Calibration: `src/reyn` negative control (legit `#254` docstring) → PASS
- [x] Positive: synthetic C1-shape ("Extracted verbatim from reyn.runtime.session") → FAIL, rc 1
- [x] `uvx ruff@latest check scripts/verify_module_docstrings.py` — All checks passed
- [x] `test.yml` valid YAML
- [ ] Full CI green — pending

## ⚠️ Discovered debt — 8 pre-existing violations (NOT fixed here)
The check surfaced 8 existing module docstrings with the anti-pattern. Left for a deliberate decision (whole-tree gate + fix vs fix-when-touched) rather than a unilateral cross-workstream mass-edit:
- `runtime/services/skill_plan_glue.py`, `router_history_buffer.py`, `context_budget_advisor.py`, `router_loop_driver.py` — "Extracted from Session (session.py…)" (FP-0043 collaborators)
- `core/kernel/rollback_state.py` — "Extracted from runtime.py"
- `tools/schemes/_discovery.py` — "Relocated from reyn.runtime.router_system_prompt"
- `stdlib/skills/ops_report/aggregate_pure.py` — "Split out of aggregate.py"
- `interfaces/repl/__init__.py` — "relocated from reyn.runtime"

**Recommendation**: fast-follow cleanup PR fixes the 8 (docstring-only, current-state rewrite), then upgrade the gate to whole-tree (full run on main) so it can't regress. Lead/owner call.

## Follow-up
Once this + #1799 land, memory-curator retires the `moved_module_docstring` + `package_move_completeness` pins (mechanized).

Refs #1792.