### PR TITLE
chore(1792): module docstrings → current-state (mechanize cleanup)

### DIFF
--- a/src/reyn/core/kernel/rollback_state.py
+++ b/src/reyn/core/kernel/rollback_state.py
@@ -1,9 +1,7 @@
 """RollbackState — rollback-specific bookkeeping for one OSRuntime run.
 
-Extracted from runtime.py (FP-0020 Component A prerequisite).  All
-rollback machinery that previously lived as a nested dataclass inside
-runtime.py is now a standalone module so it can be imported by RunState
-without creating a circular dependency.
+A standalone module (rather than a nested dataclass) so it can be imported by
+RunState without creating a circular dependency.
 """
 
 from __future__ import annotations

--- a/src/reyn/interfaces/repl/__init__.py
+++ b/src/reyn/interfaces/repl/__init__.py
@@ -1,5 +1,1 @@
-"""Reyn REPL / console UI (the interactive chat front-end).
-
-#312 PR-A: relocated from ``reyn.runtime`` (the agent runtime) — these are the UI
-modules #1700 left behind. ``reyn.runtime`` itself becomes ``reyn.runtime`` in PR-B.
-"""
+"""Reyn REPL / console UI (the interactive chat front-end)."""

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -1,27 +1,23 @@
 """ContextBudgetAdvisor — per-turn token budget computation for Session.
 
-Extracted from Session (session.py refactor PR-1).  Owns the five
-budget-arithmetic methods that were inline on Session:
+Owns the five budget-arithmetic methods:
 
   - cap_tool_result       — truncate oversized tool-result text (#1128 size axis)
   - per_turn_cap_tokens   — derive B_M-relative per-turn token ceiling
   - media_followup_budget — tokens left for media after capped text (#272)
   - context_window_status — {free_window, effective_trigger} for SP header
-  - maybe_force_compact   — pre-frame overflow guard (#1128 PR-N3)
+  - maybe_force_compact   — pre-frame overflow guard (#1128)
 
 Plus the shared helper:
 
   - _free_window_now      — (effective_trigger, estimated_history_tokens)
 
 All public methods are pure or only cause contained async side effects on
-the compaction controller.  Session holds an instance and forwards
-each method as a callback to RouterHostAdapter, keeping the external API
-byte-identical (no caller changes outside session.py).
+the compaction controller.  Session holds an instance and forwards each
+method as a callback to RouterHostAdapter.
 
 history_fn dependency: a zero-arg callable that returns the current
-router-view history (list of dicts).  Passed as ``self._build_history_for_router``
-during PR-1; when PR-2 relocates that method, session silently re-wires
-the dep without touching this class.
+router-view history (list of dicts).
 """
 from __future__ import annotations
 

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -1,21 +1,20 @@
 """RouterHistoryBuffer — history slicing and SP assembly for Session.
 
-Extracted from Session (session.py refactor PR-2).  Owns:
+Owns:
 
   - build_history              — slice history into OpenAI-style messages
   - decompose_history_for_retry — head/raw_middle/tail/summary for retry_loop
   - build_system_prompt        — assemble the router system prompt string
   - _serialise_turn            — materialise one ChatMessage to a wire dict
 
-Also owns the module-level helpers moved out of session.py:
+Also owns the module-level helpers:
 
   - _is_force_close_consolidation
   - _materialise_path_ref_content
   - _read_pathref_image
 
 history_fn dependency: a zero-arg callable that returns the raw history list
-(all ChatMessages including summaries).  Passed as ``lambda: self.history``
-during PR-2; future refactors can re-wire without touching this class.
+(all ChatMessages including summaries), passed as ``lambda: self.history``.
 """
 from __future__ import annotations
 

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -1,13 +1,13 @@
 """RouterLoopDriver — per-turn router loop orchestration for Session.
 
-Extracted from Session (session.py refactor PR-3).  Owns:
+Owns:
 
-  - run_turn(user_text, chain_id)  — was _run_router_loop
-  - _run_with_shrink(loop, text)   — was _router_run_with_shrink
-  - _check_cap(user_text)          — was _check_and_increment_router_cap
-  - _force_close_handoff(loop, text) — was _force_close_handoff
-  - _force_close_wrap_up(loop, model) — was _force_close_wrap_up
-  - is_cancel_requested()          — was _is_turn_cancel_requested
+  - run_turn(user_text, chain_id)
+  - _run_with_shrink(loop, text)
+  - _check_cap(user_text)
+  - _force_close_handoff(loop, text)
+  - _force_close_wrap_up(loop, model)
+  - is_cancel_requested()
   - request_cancel()               — turn-cancel seam (called by cancel_inflight)
 
 Cancel lifecycle (#1468): the cooperative-cancel flag lives here.

--- a/src/reyn/runtime/services/skill_plan_glue.py
+++ b/src/reyn/runtime/services/skill_plan_glue.py
@@ -1,15 +1,14 @@
 """SkillPlanGlue — skill/plan completion routing and chain timeout for Session.
 
-Extracted from Session (session.py refactor PR-4 — FP-0019 series final).
 Owns the cluster that routes completed skill/plan work back into the router
 loop and handles chain timeout lifecycle:
 
-  - handle_skill_completed(payload)        — was _handle_skill_completed
-  - drain_skill_completed_inbox(deadline)  — was drain_skill_completed_inbox
-  - on_chain_timeout_fire(chain_id)        — was _on_chain_timeout_fire
-  - spawn_skill_for_router(spec, chain_id) — was _spawn_skill_for_router
-  - spawn_skill(spec, chain_id)            — was _spawn_skill
-  - enqueue_plan_completed(**kw)           — was _enqueue_plan_completed
+  - handle_skill_completed(payload)
+  - drain_skill_completed_inbox(deadline)
+  - on_chain_timeout_fire(chain_id)
+  - spawn_skill_for_router(spec, chain_id)
+  - spawn_skill(spec, chain_id)
+  - enqueue_plan_completed(**kw)
 
 Public-surface note: ``drain_skill_completed_inbox`` is called from
 ``mcp_server.py`` (R-A2A-COMPLETION-DRAIN); Session keeps a forwarding

--- a/src/reyn/stdlib/skills/ops_report/aggregate_pure.py
+++ b/src/reyn/stdlib/skills/ops_report/aggregate_pure.py
@@ -1,14 +1,14 @@
 """Pure (mode: safe) aggregation helpers for ops_report.
 
-Split out of ``aggregate.py`` so that ``aggregate_from_recall_chunks`` can be
-declared ``mode: safe`` — the AST validator rejects the whole-module load of
-``aggregate.py`` because of its ``import glob`` / ``import os`` at module top.
+A separate module from ``aggregate.py`` so that ``aggregate_from_recall_chunks``
+can be declared ``mode: safe`` — the AST validator rejects the whole-module load
+of ``aggregate.py`` because of its ``import glob`` / ``import os`` at module top.
 This sibling module imports only PURE_STDLIB_ALLOWLIST entries, so
 ``mode: safe`` (= "ambient sources only" contract) holds at parse time.
 
-The split is purely about syntactic reachability of unsafe modules:
-``aggregate_from_recall_chunks`` itself was already pure; the only blocker
-was that it lived alongside I/O-using siblings.
+The separation is purely about syntactic reachability of unsafe modules:
+``aggregate_from_recall_chunks`` itself is pure; the only blocker is that it
+would otherwise live alongside I/O-using siblings.
 
 Private helpers ``_ERROR_SAMPLE_MAX``, ``_ERROR_EXCERPT_MAX``, and
 ``_top_failing_skills`` are duplicated here (not imported from ``aggregate.py``)

--- a/src/reyn/tools/schemes/_discovery.py
+++ b/src/reyn/tools/schemes/_discovery.py
@@ -1,13 +1,12 @@
 """Discovery-mandate tier policy for the universal-category tool-use scheme.
 
-Relocated from ``reyn.runtime.router_system_prompt`` (Stage 1, #1627) so the
-tier→discovery-mandate POLICY lives in the scheme layer, not the OS.  The OS
-(``router_loop``) still calls ``tier_wants_discovery_mandate`` for the
-enumerate / retrieval None-path ``build_system_prompt`` call until their own
-stages land; ``universal_category`` calls it to compute its own slot-map.
+The tier→discovery-mandate POLICY lives in the scheme layer, not the OS.  The OS
+(``router_loop``) calls ``tier_wants_discovery_mandate`` for the
+enumerate / retrieval None-path ``build_system_prompt`` call;
+``universal_category`` calls it to compute its own slot-map.
 
 See the full rationale in ``router_system_prompt`` (search for
-``#187 Stage C``).  Verbatim move — no logic change.
+``#187 Stage C``).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — the (A) cleanup PR: rewrites the **8 pre-existing module docstrings** flagged by `scripts/verify_module_docstrings.py` (#1801) to current-state only. Sequenced after #1801 (now merged); precedes the whole-tree gate upgrade.

## What
Removes the refactor narrative (extracted-from / relocated-from / split-out-of / PR-N staging / `was _oldname` provenance) from each module docstring; **preserves the current API + design notes**. Docstring-only, **behavior-invariant** (module docstrings never enter LLM requests → no replay impact).

| File | Narrative removed |
|---|---|
| `runtime/services/skill_plan_glue.py` | "Extracted from Session (PR-4 — FP-0019…)" + `was _x` |
| `runtime/services/router_history_buffer.py` | "Extracted from Session (PR-2)" + "moved out of session.py" |
| `runtime/services/context_budget_advisor.py` | "Extracted from Session (PR-1)" + PR-wiring history |
| `runtime/services/router_loop_driver.py` | "Extracted from Session (PR-3)" + `was _x` |
| `core/kernel/rollback_state.py` | "Extracted from runtime.py (FP-0020…)" |
| `tools/schemes/_discovery.py` | "Relocated from … (Stage 1, #1627)" + "Verbatim move" |
| `stdlib/skills/ops_report/aggregate_pure.py` | "Split out of aggregate.py" → "A separate module from" |
| `interfaces/repl/__init__.py` | "#312 PR-A: relocated from reyn.runtime…" |

## Test plan
- [x] `verify_module_docstrings.py src/reyn` → **whole-tree clean** (0 violations — the 8 were the complete set)
- [x] `uvx ruff@latest check` on all 8 → All checks passed
- [x] Full CI green — ✓ (incl the now-active docstring check on the 8 changed files)

## Follow-up
With the tree clean, the next PR upgrades the gate to **whole-tree** (full run on main) so it can't regress; on its land, memory-curator retires the `moved_module_docstring` pin (mechanized).

Refs #1792.
