### PR TITLE
tooling(1792): upgrade module-docstring gate to whole-tree on main push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,22 +103,25 @@ jobs:
             python scripts/test_tier_audit.py --strict tests/
           fi
 
-      # scripts/verify_module_docstrings.py is stdlib-only. Scoped to the
-      # src/ files changed in a PR: blocks NEW moved-module refactor-narrative
-      # docstrings (the C-series discipline) without requiring a one-shot
-      # cleanup of pre-existing instances. main push: no-op (a full-tree gate
-      # awaits that cleanup — see PR introducing this step).
+      # scripts/verify_module_docstrings.py is stdlib-only. PR events: scoped
+      # to changed src files (fast). main push: full-tree run — the
+      # regress-proof invariant net, now that the tree is clean (#1802). Blocks
+      # moved-module refactor-narrative docstrings (the C-series discipline).
       - name: Run module-docstring narrative check
-        if: github.event_name == 'pull_request'
         run: |
-          CHANGED=$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}"...HEAD \
-            -- 'src/**.py')
-          if [ -z "$CHANGED" ]; then
-            echo "No src files changed — docstring check skipped."
-            exit 0
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}"...HEAD \
+              -- 'src/**.py')
+            if [ -z "$CHANGED" ]; then
+              echo "No src files changed — docstring check skipped."
+              exit 0
+            fi
+            echo "Checking changed src files:"
+            echo "$CHANGED"
+            # shellcheck disable=SC2086
+            python scripts/verify_module_docstrings.py $CHANGED
+          else
+            # push to main (or any non-PR trigger): full-tree gate.
+            python scripts/verify_module_docstrings.py src/reyn
           fi
-          echo "Checking changed src files:"
-          echo "$CHANGED"
-          # shellcheck disable=SC2086
-          python scripts/verify_module_docstrings.py $CHANGED


### PR DESCRIPTION
**[e2e-coder]** — final step of the mechanize arc. Now the tree is clean (#1802), the docstring-narrative check runs **full-tree on main push** (regress-proof invariant net) in addition to the fast changed-files scope on PRs — mirroring the test-tier audit's PR-vs-main structure.

## What
`test.yml` docstring step: drop the `if: pull_request` guard; PR events run changed-src scope, non-PR (main push) runs `verify_module_docstrings.py src/reyn`. A reintroduced moved-module refactor-narrative docstring now fails CI regardless of which file carries it.

## Test plan
- [x] `test.yml` valid YAML
- [x] Simulated main-push full-tree run (`verify_module_docstrings.py src/reyn`) → `OK: no module-docstring refactor narrative` (clean post-#1802)
- [x] Full CI green — ✓ (pytest 3.11/3.12, ruff, test-tier-audit incl docstring step)

## Completes the mechanize arc
With this + `verify_package_move.py` (#1799) active, the two C-series disciplines are memory→mechanism. On land, memory-curator retires the `moved_module_docstring` pin (lead signals); the `package_move_completeness` pin's mechanization (#1799) similarly clears it for retirement.

Refs #1792.
