### PR TITLE
refactor(C6): collapse 6 Session forwarders to advisor/history-buffer (#1792)

### DIFF
--- a/docs/deep-dives/proposals/0045-session-c6-first-method-cluster-seam.md
+++ b/docs/deep-dives/proposals/0045-session-c6-first-method-cluster-seam.md
@@ -83,12 +83,49 @@ forwards and are **out of scope** for the first cut:
 - `reasoning_continuity_section` (L4788) — a **retired stub** (always `""`,
   #1652/②); a separate trivial cleanup, not part of this seam.
 
+## Implementation finding (flow-trace before the cut): 9 → 6
+
+A pre-implementation flow-trace refined the count. Of the candidate forwarders,
+**6 are genuine residue and collapse cleanly; 3 are not residue and are
+retained** (see the construction-cycle note below). The first cut is **6**:
+
+- **4 pure-residue forwarders → rewire callers to the collaborator directly,
+  delete the `Session` method**: `_build_history_for_router`,
+  `_decompose_history_for_retry`, `_build_router_system_prompt`
+  (→ `RouterHistoryBuffer`), `_free_window_now` (→ `ContextBudgetAdvisor`; its
+  only caller is the retained `_compact_now_for_op`, rewired to
+  `self._budget_advisor._free_window_now()`).
+- **2 dead forwarders → delete** (zero live callers, verified):
+  `_per_turn_cap_tokens`, `_maybe_force_compact_for_router`.
+
+### Retained: 3 cycle-bound late-binding shims (NOT residue)
+
+`_cap_tool_result`, `_media_followup_budget`, `_context_window_status` are
+injected as **callbacks into `RouterHostAdapter` at its construction**
+(`session.py:1403`), which runs **before** `ContextBudgetAdvisor` is built
+(`:1658`). And `RouterHistoryBuffer` (`:1557`, which the advisor's `history_fn`
+depends on) takes `router_host=self._router_host` — so there is a real
+construction cycle: `host_adapter → (callback) budget_advisor →
+history_buffer → host_adapter`. Injecting `self._budget_advisor.<m>` at
+`:1498/1501/1507` would `AttributeError` (advisor not built yet). These three
+are therefore **legitimate late-binding wiring, not forwarding residue** — they
+exist precisely to bridge the construction-order gap, and are kept.
+
+- A lambda-wrap at the injection site was **rejected**: it removes the named
+  method but keeps the same runtime hop (cosmetic surface change, worse
+  readability).
+- Truly collapsing these three requires **breaking the construction cycle**
+  (e.g. two-phase init: build `host_adapter` with placeholder callbacks, build
+  the collaborators, then set the callbacks). That is a construction-order
+  refactor — a *different, higher-care* change than residue-collapse, and is
+  **owner-gated**; deferred to a possible follow-up cut, not done here.
+
 ## Recommended first cut
 
-**Collapse the ContextBudgetAdvisor + RouterHistoryBuffer forwarding residue
-(the 9 pure forwarders to those two collaborators) by rewiring their callers —
-internal calls and callback injections — to the collaborator directly, then
-deleting the `Session` forwarders.**
+**Collapse the 6 ContextBudgetAdvisor + RouterHistoryBuffer forwarders that are
+genuine residue/dead by rewiring their callers — internal calls and the
+`system_prompt_provider` injection — to the collaborator directly, then
+deleting the `Session` forwarders. The 3 cycle-bound shims are retained.**
 
 Rationale (why this is the cleanest possible *first* cut):
 
@@ -100,11 +137,12 @@ Rationale (why this is the cleanest possible *first* cut):
 2. **Dependency direction is already correct** — `Session → advisor/buffer`;
    collapsing only *removes* an indirection hop, it cannot introduce a cycle.
 3. **It directly advances the FP-0043/0044 goal** — every removed forwarder
-   makes `Session` measurably thinner (≈ -60 LOC + 9 methods off the public
-   surface) and removes `Session` from a call path it has no reason to be on.
-4. **Smallest blast radius** — the callers are `router_host_adapter`
-   (callback kwargs) + `context_budget_advisor` (one callback) + a handful of
-   internal `self._...` calls. No cross-process / wire-format surface.
+   makes `Session` measurably thinner (≈ -45 LOC + 6 methods off the surface)
+   and removes `Session` from a call path it has no reason to be on.
+4. **Smallest blast radius** — the callers are the `system_prompt_provider`
+   injection into `CompactionEngine`, the retained `_compact_now_for_op`'s
+   internal `_free_window_now` call, and test call-sites. No cross-process /
+   wire-format surface.
 
 `Session` ends this cut still holding the collaborators (it constructs them),
 but no longer *forwarding* to them — it wires `host_adapter` to them directly.

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -7,7 +7,7 @@ Extracted from Session (FP-0019 Wave 1).  Drives OS-internal compaction
 #1128 PR-a: the background fire-and-forget path (``spawn_maybe`` →
 ``_maybe_compact``, the 30K-absolute ``trigger_total_tokens`` trigger) was
 removed. Auto-compaction is now driven solely by the synchronous pre-frame
-guard (``Session._maybe_force_compact_for_router`` → :meth:`force_compact_now`,
+guard (``ContextBudgetAdvisor.maybe_force_compact`` → :meth:`force_compact_now`,
 window-relative ``effective_trigger``, token-budget candidate selection per
 step 3), plus on-demand (the ``compact`` op / ``/compact``) and the
 ``retry_loop`` overflow backstop. With no background task, compaction always
@@ -188,7 +188,7 @@ class CompactionController:
     async def force_compact_now(self) -> None:
         """Synchronous force-trigger — single pass (#1128 PR-c).
 
-        Used by the pre-frame guard in ``_maybe_force_compact_for_router`` when
+        Used by the pre-frame guard in ``ContextBudgetAdvisor.maybe_force_compact`` when
         the projected prompt would exceed the model's max_input_tokens.  Emits
         ``compaction_check`` with ``outcome="forced_sync"``.
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1583,7 +1583,7 @@ class Session:
                 # the former hardcode, incl. an SkillRuntime(model=…) override).
                 model=self._resolver.purpose_class_or("compaction", self.model),
                 events=self._chat_events,
-                system_prompt_provider=self._build_router_system_prompt,
+                system_prompt_provider=self._history_buffer.build_system_prompt,
                 resolver=self._resolver,
                 # #1190 stage (ii): record chat compaction LLM spend (purpose=compaction).
                 recorder=self._budget_tracker,
@@ -3034,7 +3034,7 @@ class Session:
         # #1128 PR-a: the post-reply fire-and-forget compaction check
         # (spawn_maybe → _maybe_compact, 30K-absolute trigger) was removed.
         # Auto-compaction is driven synchronously by the pre-frame guard
-        # (_maybe_force_compact_for_router → force_compact_now, window-relative
+        # (ContextBudgetAdvisor.maybe_force_compact → force_compact_now, window-relative
         # effective_trigger) before each router call, plus on-demand (/compact,
         # compact op) and the retry_loop overflow backstop.
 
@@ -4685,38 +4685,13 @@ class Session:
 
     # --- RouterLoop orchestration ---
 
-    def _build_history_for_router(self) -> list[dict]:
-        """Forwarding → RouterHistoryBuffer.build_history (PR-2)."""
-        return self._history_buffer.build_history()
-
-    def _decompose_history_for_retry(
-        self,
-    ) -> "tuple[list[dict], list[dict], list[dict], dict | None]":
-        """Forwarding → RouterHistoryBuffer.decompose_history_for_retry (PR-2)."""
-        return self._history_buffer.decompose_history_for_retry()
-
-    def _build_router_system_prompt(self) -> str:
-        """Forwarding → RouterHistoryBuffer.build_system_prompt (PR-2)."""
-        return self._history_buffer.build_system_prompt()
-
     def _cap_tool_result(self, content_str: str) -> str:
         """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1)."""
         return self._budget_advisor.cap_tool_result(content_str)
 
-    def _per_turn_cap_tokens(self) -> int:
-        """Forwarding → ContextBudgetAdvisor.per_turn_cap_tokens (PR-1)."""
-        return self._budget_advisor.per_turn_cap_tokens()
-
     def _media_followup_budget(self, tool_content: str) -> int:
         """Forwarding → ContextBudgetAdvisor.media_followup_budget (PR-1)."""
         return self._budget_advisor.media_followup_budget(tool_content)
-
-    def _free_window_now(self) -> "tuple[int, int]":
-        """Forwarding → ContextBudgetAdvisor._free_window_now (PR-1).
-
-        Kept for _compact_now_for_op which calls self._free_window_now().
-        """
-        return self._budget_advisor._free_window_now()
 
     def _context_window_status(self) -> dict:
         """Forwarding → ContextBudgetAdvisor.context_window_status (PR-1)."""
@@ -4753,10 +4728,10 @@ class Session:
             except Exception:  # noqa: BLE001 — estimation best-effort
                 return 0
 
-        effective_trigger, before = self._free_window_now()
+        effective_trigger, before = self._budget_advisor._free_window_now()
         prev_cover = _cover()
         await self._compaction_controller.force_compact_now()
-        _, after = self._free_window_now()
+        _, after = self._budget_advisor._free_window_now()
         new_cover = _cover()
 
         # Chat middle-compression: the conversational turns newly covered by the
@@ -4777,13 +4752,6 @@ class Session:
             "compressed_tokens": sum(_est(m.text) for m in middle),
             "bridge_tokens": _est(bridge_text) if summary is not None else 0,
         }
-
-    async def _maybe_force_compact_for_router(
-        self,
-        new_msg_text: "str | None" = None,
-    ) -> None:
-        """Forwarding → ContextBudgetAdvisor.maybe_force_compact (PR-1)."""
-        await self._budget_advisor.maybe_force_compact(new_msg_text=new_msg_text)
 
     def reasoning_continuity_section(self) -> str:
         """#1652/②: RETIRED — always ``""``.

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -164,7 +164,7 @@ def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
     for text in ["alpha", "beta", "gamma"]:
         _push(session, "user", text)
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     contents = [m["content"] for m in msgs]
 
     assert contents == ["alpha", "beta", "gamma"], (
@@ -190,7 +190,7 @@ def test_build_history_large_chat_elides_middle(tmp_path) -> None:
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     contents = [m["content"] for m in msgs]
     present = set(contents)
 

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -702,7 +702,7 @@ def test_new_msg_exceeds_budget_error_fields_and_raises() -> None:
     """Tier 2: NewMsgExceedsBudgetError has correct new_msg_tokens and new_msg_budget
     fields, and its token count exceeds its budget.
 
-    Exercises the public contract for the error that _maybe_force_compact_for_router
+    Exercises the public contract for the error that ContextBudgetAdvisor.maybe_force_compact
     raises (ISSUE #5) when new_msg_text exceeds new_msg_budget.  Uses a deliberately
     huge text (10 million chars = 2.5M tokens via chars//4) against a small budget.
     """

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -97,7 +97,7 @@ async def test_handoff_fires_installs_consolidation_and_converges(
     # The P6 event log (audit truth) shows EXACTLY ONE handoff → converged
     # in one (the by-construction backstop (a)); the run returned (no raise).
     assert events.count("router_force_close_handoff") == 1
-    slice_msgs = session._build_history_for_router()
+    slice_msgs = session._history_buffer.build_history()
     assert _has_consolidation(slice_msgs)              # reaches-LLM
 
 
@@ -191,7 +191,7 @@ async def test_force_close_handoff_installs_covering_consolidation(tmp_path) -> 
     await session._force_close_handoff(loop=_FakeRouterLoop(), user_text="x")
 
     slice_blob = "\n".join(
-        str(m.get("content", "")) for m in session._build_history_for_router()
+        str(m.get("content", "")) for m in session._history_buffer.build_history()
     )
     assert _CONSOL in slice_blob                # consolidation reaches the slice
     assert "U1-covered" not in slice_blob        # covered raw turns dropped

--- a/tests/test_force_close_covers_slice_1092.py
+++ b/tests/test_force_close_covers_slice_1092.py
@@ -49,7 +49,7 @@ def test_force_close_consolidation_drops_covered_head_tail(tmp_path) -> None:
         _push(session, "user" if t.startswith("U") else "assistant", t)
     _append_force_close_summary(session, "CONSOLIDATED-ESSENCE")
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
     assert "CONSOLIDATED-ESSENCE" in blob          # consolidation reaches the slice
     for covered in ("U1-covered", "A1-covered", "U2-covered", "A2-covered"):
@@ -67,7 +67,7 @@ def test_post_consolidation_turns_retained_including_assistant(tmp_path) -> None
     _push(session, "user", "U2-after")
     _push(session, "assistant", "A2-after-assistant")  # seq=0
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
     assert "CONSOL" in blob
     assert "U2-after" in blob
@@ -92,7 +92,7 @@ def test_normal_compaction_summary_does_not_trigger_reset(tmp_path) -> None:
         meta={"structured": {"topic_arc": "x"}, "covers_through_seq": 0},
     ))
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     blob = "\n".join(m["content"] for m in msgs if isinstance(m.get("content"), str))
     assert "U1-raw" in blob and "A1-raw" in blob    # raw turns NOT dropped
 

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -113,7 +113,7 @@ def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
     for i in range(msgs_pushed):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
-    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
 
     assert head, "head must be non-empty after elide"
     assert tail, "tail must be non-empty after elide"
@@ -142,7 +142,7 @@ def test_decompose_no_elide_when_history_fits_window(tmp_path) -> None:
     for i in range(3):
         _push(session, "user", f"q-{i}")
 
-    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
 
     assert [m["content"] for m in head] == ["q-0", "q-1", "q-2"]
     assert raw_middle == []
@@ -163,7 +163,7 @@ def test_decompose_extracts_structured_summary(tmp_path) -> None:
     for i in range(6):
         _push(session, "user", f"m-{i}")
 
-    _head, _raw_middle, _tail, summary = session._decompose_history_for_retry()
+    _head, _raw_middle, _tail, summary = session._history_buffer.decompose_history_for_retry()
     assert summary == structured
 
 
@@ -182,8 +182,8 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     for i in range(8):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
-    head, raw_middle, tail, _summary = session._decompose_history_for_retry()
-    via_build = session._build_history_for_router()
+    head, raw_middle, tail, _summary = session._history_buffer.decompose_history_for_retry()
+    via_build = session._history_buffer.build_history()
 
     # Both paths must return the same non-bridge turns in the same order.
     # _build_history_for_router: head + [bridge?] + tail (no summary → no bridge).
@@ -229,13 +229,13 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
     # Normal path bridge content.
-    normal = session._build_history_for_router()
+    normal = session._history_buffer.build_history()
     normal_bridge = next(
         m["content"] for m in normal
         if isinstance(m["content"], str) and m["content"].startswith("[summary")
     )
     # Recovery path renders the structured dict the same way.
-    _h, _rm, _t, summary_dict = session._decompose_history_for_retry()
+    _h, _rm, _t, summary_dict = session._history_buffer.decompose_history_for_retry()
     recovery_bridge = (
         "[summary of earlier conversation]\n" + _render_summary_for_storage(summary_dict)
     )
@@ -259,7 +259,7 @@ def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
     for i in range(3):
         _push(session, "user", f"hi-{i}")
 
-    head, raw_middle, tail, summary = session._decompose_history_for_retry()
+    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
     engine = session._compaction_controller._engine
     new_msg = {"role": "user", "content": "latest"}
 
@@ -270,7 +270,7 @@ def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
         return _RouterUsageShim(TokenUsage(prompt_tokens=123))
 
     shim = asyncio.run(retry_loop(
-        SP=session._build_router_system_prompt(),
+        SP=session._history_buffer.build_system_prompt(),
         head=head,
         summary=summary,
         raw_middle=raw_middle,

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -417,7 +417,7 @@ def test_build_history_for_router_shape(tmp_path, monkeypatch):
         ChatMessage(role="assistant", content="sure!", ts="t4"),
     ]
 
-    history = session._build_history_for_router()
+    history = session._history_buffer.build_history()
 
     assert isinstance(history, list)
     for msg in history:

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -103,7 +103,7 @@ def test_history_fits_in_window_returns_all_turns(tmp_path):
     for text in pushed:
         _push(session, "user", text)
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     contents = [m["content"] for m in msgs]
     # All pushed turns returned — no drops, no duplicates.
     assert set(contents) == set(pushed), (
@@ -117,7 +117,7 @@ def test_history_fits_in_window_returns_all_turns(tmp_path):
 def test_empty_history_returns_empty_messages(tmp_path):
     """Tier 2: empty history → empty result."""
     session = _make_session(tmp_path)
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     assert msgs == [], f"expected empty result for empty history, got {msgs!r}"
 
 
@@ -125,7 +125,7 @@ def test_single_turn_returns_single_message(tmp_path):
     """Tier 2: single turn → exactly one message, no duplication."""
     session = _make_session(tmp_path)
     _push(session, "user", "hello")
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     assert msgs == [{"role": "user", "content": "hello"}]
 
 
@@ -153,7 +153,7 @@ def test_history_exceeds_trigger_elides_middle(tmp_path):
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     contents = [m["content"] for m in msgs]
 
     # The middle turn(s) must be absent.
@@ -192,7 +192,7 @@ def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)
 
-    msgs = session._build_history_for_router()
+    msgs = session._history_buffer.build_history()
     bridge_msgs = [m for m in msgs if isinstance(m.get("content"), str)
                    and m["content"].startswith("[summary")]
     assert bridge_msgs, (

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -315,7 +315,7 @@ def test_history_text_only_emits_string_content():
         ChatMessage(role="user", content="hi", ts="t1"),
         ChatMessage(role="assistant", content="hello", ts="t2"),
     ]
-    msgs = cs._build_history_for_router()
+    msgs = cs._history_buffer.build_history()
 
     assert msgs[0] == {"role": "user", "content": "hi"}
     assert msgs[1] == {"role": "assistant", "content": "hello"}
@@ -334,7 +334,7 @@ def test_history_message_with_media_emits_content_list():
             ts="t1",
         ),
     ]
-    msgs = cs._build_history_for_router()
+    msgs = cs._history_buffer.build_history()
 
     assert msgs[0]["role"] == "user"
     content = msgs[0]["content"]
@@ -350,6 +350,6 @@ def test_history_message_with_media_and_no_text_emits_only_image() -> None:
     cs = _make_history_builder()
     block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
     cs.history = [ChatMessage(role="user", content=[block], ts="t1")]
-    msgs = cs._build_history_for_router()
+    msgs = cs._history_buffer.build_history()
 
     assert msgs[0]["content"] == [block]


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **Stage-2, first cut** (owner-approved via FP-0045 #1798). Removes Session's residual forwarding layer to the FP-0043 collaborators. **Behavior-preserving rewire** (not byte-identical) — LLM-facing SP/tools unchanged, internal call path shortened one hop.

## Flow-trace refined 9 → 6 (finding in FP-0045, updated here)
**6 collapsed:**
- **4 pure-residue → deleted, callers rewired direct**: `_build_history_for_router`, `_decompose_history_for_retry`, `_build_router_system_prompt` → `RouterHistoryBuffer` (test call-sites + the `CompactionEngine` `system_prompt_provider` injection); `_free_window_now` → `ContextBudgetAdvisor` (its only caller, the retained `_compact_now_for_op`, rewired).
- **2 dead → deleted** (verified 0 live callers): `_per_turn_cap_tokens`, `_maybe_force_compact_for_router`.

**3 retained — NOT residue:** `_cap_tool_result` / `_media_followup_budget` / `_context_window_status` are legitimate **late-binding shims** bridging a real construction cycle — `RouterHostAdapter` (built :1403, receives them as callbacks) ⇄ `ContextBudgetAdvisor` (built :1658, via `RouterHistoryBuffer` which takes `router_host`). Direct injection → `AttributeError`. Collapsing them needs a construction-order refactor (two-phase init) = a **separate owner-gated cut**, documented as a follow-up in FP-0045.

## Gate
- ✅ **Replay green, no re-record** — 166 replay pass, **no MissingFixture** → SP/tools unchanged → behavior-preserving (the cut only shortens an internal call path).
- ✅ **1399 pass** across touched areas (session/router/history/budget/compaction/force_close/retry/intervention/context_window).
- ✅ **Old-forwarder call-residue = 0** (grep of `._<method>()` for all 6).
- ✅ **Dead-method safety** — `_per_turn_cap_tokens`/`_maybe_force_compact_for_router` have zero references (remaining mentions were stale comments, updated).
- ✅ ruff clean. Session 4825 → 4793 LOC, −6 methods.

> Note: conceptual comment mentions of the relocated wire-build step names (e.g. `_build_history_for_router` in router_loop/host_adapter/media_store) are left — they name the step/concept, and the **code call-residue is 0**.

## Test plan
- [x] Replay suites green (no re-record)
- [x] Touched-area sweep → 1399 passed
- [x] Call-residue grep = 0; ruff clean
- [x] Full CI green — ✓ (pytest 3.11/3.12, ruff, test-tier+docstring gate)

Refs #1792.
