### PR TITLE
refactor(C7): collapse 3 Session forwarders to RouterLoopDriver (#1792)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4779,15 +4779,3 @@ class Session:
         await self._journal.cut_generation(
             anchor=_truncate_anchor(user_text), full_message=user_text,
         )
-
-    async def _router_run_with_shrink(self, loop, user_text: str) -> "Any":
-        """Forwarding → RouterLoopDriver._run_with_shrink (PR-3)."""
-        return await self._loop_driver._run_with_shrink(loop, user_text)
-
-    async def _force_close_handoff(self, loop, user_text: str) -> None:
-        """Forwarding → RouterLoopDriver._force_close_handoff (PR-3)."""
-        await self._loop_driver._force_close_handoff(loop, user_text)
-
-    async def _force_close_wrap_up(self, loop, resolved_model: str) -> str:
-        """Forwarding → RouterLoopDriver._force_close_wrap_up (PR-3)."""
-        return await self._loop_driver._force_close_wrap_up(loop, resolved_model)

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -154,7 +154,7 @@ async def test_wrap_up_bounded_fallback_fits(tmp_path) -> None:
     for t in ("U1", "A1", "U2", "A2"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     loop = _FailFirstLoop(fail_first=2)
-    out = await session._force_close_wrap_up(loop, resolved_model="m")
+    out = await session._loop_driver._force_close_wrap_up(loop, resolved_model="m")
     assert out == _CONSOL
     assert loop.attempts == 3  # 2 over-large candidates fell back, 3rd fit
 
@@ -171,7 +171,7 @@ async def test_wrap_up_sub_viable_raises(tmp_path) -> None:
     session = _make_session(tmp_path, t_max=2000)
     _push(session, "user", "U1")
     with pytest.raises(ContextOverflowError):
-        await session._force_close_wrap_up(_AlwaysOverflowWrapUp(), resolved_model="m")
+        await session._loop_driver._force_close_wrap_up(_AlwaysOverflowWrapUp(), resolved_model="m")
 
 
 # ── install: covering consolidation + covered turns dropped (reaches-LLM) ─────
@@ -188,7 +188,7 @@ async def test_force_close_handoff_installs_covering_consolidation(tmp_path) -> 
     session._append_history(_msg("assistant", "A1-covered"))
     events = _capture_events(session)
 
-    await session._force_close_handoff(loop=_FakeRouterLoop(), user_text="x")
+    await session._loop_driver._force_close_handoff(loop=_FakeRouterLoop(), user_text="x")
 
     slice_blob = "\n".join(
         str(m.get("content", "")) for m in session._history_buffer.build_history()


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **Stage-2, second cut** (owner-approved C7-first via FP-0046 #1806). Collapses the remaining turn-dispatch forwarding residue to `RouterLoopDriver` — the **third** FP-0043 collaborator — **completing** the residue collapse Session→{advisor, buffer, loop_driver} (C6 did the first two). Behavior-preserving rewire, replay-green.

## What
- `_router_run_with_shrink` → **deleted** (dead; zero callers, verified full grep).
- `_force_close_handoff` → **deleted**; its one Session-external caller (`test_force_close_chat_handoff_1092:191`) rewired to `session._loop_driver._force_close_handoff` (driver calls its own). *(corrected from FP-0046's initial "dead" claim per docs-maintainer audit.)*
- `_force_close_wrap_up` → **deleted**; 2 test call-sites rewired to `session._loop_driver._force_close_wrap_up`.
- `_run_router_loop` → **retained** — forwards to `run_turn` AND does `self._journal.cut_generation(...)` (turn-boundary side-effect); coordinator glue, not a pure forward (same exclusion as C6).

## Gate
- ✅ **Replay green, no re-record** — 166 replay pass, **no MissingFixture** → SP/tools unchanged → behavior-preserving.
- ✅ **872 pass** across touched areas (force_close/router/retry/safety/session).
- ✅ **No construction cycle** — these are not pre-construction callback injections (unlike C6's host_adapter).
- ✅ **Call-residue = 0** (deleted Session forwarders) + dead-method (`_router_run_with_shrink`) zero-caller re-confirmed (full grep, no truncation).
- ✅ ruff clean. Session 4793 → 4781 LOC, −3 methods.

## Closes the FP-0043 forwarding-residue story
C6 (advisor+buffer) + C7 (loop_driver) = all Session→FP-0043-collaborator forwarding residue collapsed. The 3 cycle-bound late-binding shims (C6) and `_run_router_loop`'s journal glue remain as legitimate wiring.

## Test plan
- [x] Replay suites green (no re-record)
- [x] Touched-area sweep → 872 passed
- [x] Call-residue grep = 0; dead-method re-confirmed; ruff clean
- [x] Full CI green — ✓ (pytest 3.11/3.12, ruff, test-tier+docstring-gate)

Refs #1792.

