### PR TITLE
docs(concepts): add agent interaction-layers concept doc (3-layer model)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -240,6 +240,7 @@ nav:
           - concepts/architecture/care-boundary.md
           - concepts/architecture/phase-vs-skill-vs-os.md
           - concepts/architecture/llm-invocation-surfaces.md
+          - concepts/architecture/interaction-layers.md
           - concepts/architecture/llm-as-decision-engine.md
           - concepts/architecture/sandbox-vs-permission.md
       - Runtime:

--- a/docs/concepts/architecture/interaction-layers.ja.md
+++ b/docs/concepts/architecture/interaction-layers.ja.md
@@ -1,0 +1,118 @@
+---
+type: concept
+topic: architecture
+audience: [human, agent]
+---
+
+# Agent インタラクション層
+
+agent を動かすものは構造的に 3 種類あります: **外部システムが呼び込む**、**Reyn
+自身がターンを起こす**、**実行中のターンに割り込む**。これらを 3 層として名付ける
+ことで、agent の制御プレーンを明示的かつ governable に保てます — これが要点です。
+autonomy-first なフレームワーク（OpenClaw / Hermes 系の self-hosted agent）は「世界が
+どう agent に到達するか」を自由な配線と LLM の裁量に大きく委ねますが、Reyn は trigger
+境界を first-class で監査可能なサーフェスにします。predictability-over-autonomy の
+姿勢と一貫しています。
+
+3 層はいずれも最終的に同じ primitive — **agent の inbox** に置かれる message
+（`send_to_agent_impl` パス）— に合流します。違いは *誰が起点で*、*いつ* かだけです。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. 外部接続層   (外 → Reyn; Reyn は server)                 │
+│       MCP server · A2A server · gateway                       │
+├─────────────────────────────────────────────────────────────┤
+│  2. 内部トリガー層 (Reyn → 新しい agent ターン)              │
+│       cron · inject_message (提案)                            │
+├─────────────────────────────────────────────────────────────┤
+│  3. ターン内介入層 (実行中ターンに割り込む)                  │
+│       lifecycle hooks (提案)                                  │
+└─────────────────────────────────────────────────────────────┘
+                          ↓ 全層が合流
+                   agent inbox / send_to_agent_impl
+```
+
+> **ステータス注記。** 層 1 と cron（層 2）は **実装済**。`inject_message`（層 2）と
+> hook 層全体（層 3）は **提案段階** — 設計段階でありコードには未存在。本ページは各々を
+> その旨マークします。提案中の機構を現状の挙動と読み違えないでください。
+
+## 1. 外部接続層（外が Reyn を呼ぶ）
+
+外部 caller が agent session に message を届け、Reyn は passive server として振る舞い
+ます。3 つの接続種別、いずれも **実装済**:
+
+| 接続 | caller | 返答の配送 |
+|---|---|---|
+| **MCP server**（SSE / stdio）— `src/reyn/mcp/server.py` | AI クライアント（Claude Code, Cursor） | 同期 — caller がブロックして待つ |
+| **A2A server**（HTTP JSON-RPC）— `src/reyn/interfaces/web/routers/a2a.py` | peer AI エージェント（LangGraph, CrewAI 等） | 同期、または caller 指定の `webhook_url` へ非同期 |
+| **gateway**（Slack / LINE 等）— `src/reyn/plugins/` | 人間（チャットプラットフォーム経由） | 非同期 — Reyn が platform API を呼んで配送 |
+
+**outbound の非対称性。** MCP と A2A は **outbound 返答を caller に委ねられます**:
+返答は同期で返るか、caller が提供した callback URL へ POST されるため、Reyn 側に
+platform 固有の outbound コードは不要です。**gateway は違い、Reyn が outbound を担い
+ます**: socket で待っている caller がいないため、Reyn が能動的に platform へ返答を
+push する必要があります。
+
+現状のコードでは gateway は **inbound のみ**配送します（`sample_line` /
+`sample_slack` の webhook が `push_to_agent` を呼ぶ）。outbound 返答は gateway 自身で
+なく別の MCP tool（例: Slack MCP server）経由が前提です。gateway が inbound と
+outbound の両方を担う形 — 自前の outbound MCP tool を登録し、self-contained な
+gateway が送受信を完結させる — はこの層の **提案中**の完成形です。（この双方向
+ブリッジの役割を表すため `plugins/` パッケージを `gateway/` に **改名する提案**が
+あります。現状のパッケージは `plugins/` です。）
+
+関連: [A2A](../multi-agent/a2a.md)、[MCP](../tools-integrations/mcp.md)。
+
+## 2. 内部トリガー層（Reyn がターンを起こす）
+
+ここでは外部 caller を介さず、Reyn 自身が新しい agent ターンを開始します。
+
+- **cron** — `src/reyn/runtime/cron/`（**実装済**）。スケジュールされた `CronJob` が
+  対象 agent の inbox に message を dispatch し、スケジュールされた trigger からの
+  attributed な agent ターンを生みます。
+- **`inject_message`**（**提案**）— agent の inbox に message を置いてターンを起こす
+  プログラム的な呼び出し。
+
+両者は **構造的に同じ操作** — *agent の inbox に message を置いてターンを開始する* —
+であり、dispatch の契機（スケジュール か 明示呼び出し か）だけが異なります。この
+等価性こそが両者を 1 層にまとめる理由です。
+
+## 3. ターン内介入層（実行中のターンに割り込む）— 提案
+
+最初の 2 層がターンを *開始する* のに対し、この層は **既に実行中のターンに割り込み・
+拡張** します。これは全体が **提案段階** です — Reyn には現状 hook 機構がありません
+（router loop や session に lifecycle callback 点がない）。
+
+提案されている形は lifecycle **hooks** の集合で、`src/reyn/core/dispatch/dispatcher.py`
+から dispatch されます:
+
+- `pre_tool_call` — tool 実行直前（block / 書き換え可能）。
+- `post_tool_call` / `transform_tool_result` — tool 実行直後。
+- `pre_llm_call` — LLM 呼び出し直前（例: context injection）。
+- `transform_llm_output`、および session-lifecycle events。
+
+これは調査した competitor の hook システムに最も直接対応する層です。Reyn では OS の
+他部分と同じ permission / event 規律の下に置かれることになります。
+
+## 実装済 vs 提案（まとめ）
+
+| 層 | 実装済 | 提案 |
+|---|---|---|
+| 1 — 外部接続 | MCP, A2A, gateway（inbound） | gateway outbound 完成; `plugins/`→`gateway/` 改名 |
+| 2 — 内部トリガー | cron | `inject_message` |
+| 3 — ターン内介入 | — | lifecycle hooks（層全体） |
+
+## なぜ 3 層か
+
+価値は、agent に到達する新しい手段すべてに対する単一かつ網羅的な問い —
+*これは 外→Reyn か、Reyn→新ターン か、ターン内 か?* — にあります。あらゆる
+インタラクションがちょうど 1 つの層に属し、同じ inbox primitive に合流するため、
+制御プレーンは監査可能なまま保たれ、新機構は後付けでなく OS の permission / event
+保証を継承します。これらの経路が場当たり的な autonomy-first フレームワークに対する、
+governance-first 側の対応物です。
+
+## 関連
+
+- [LLM invocation surfaces](llm-invocation-surfaces.md) — router vs phase（別の軸: LLM が *どう呼ばれるか* であって agent に *どう到達するか* ではない）
+- [マルチエージェント](../multi-agent/multi-agent.md) · [A2A](../multi-agent/a2a.md) · [MCP](../tools-integrations/mcp.md)
+- [Principles](principles.md) — P4（制約された decision engine）、本モデルの背後にある governance 姿勢

--- a/docs/concepts/architecture/interaction-layers.md
+++ b/docs/concepts/architecture/interaction-layers.md
@@ -1,0 +1,124 @@
+---
+type: concept
+topic: architecture
+audience: [human, agent]
+---
+
+# Agent interaction layers
+
+Three structurally distinct things can set an agent in motion: an **outside
+system calls in**, **Reyn itself raises a turn**, or **something intervenes
+inside a turn already running**. Naming these as three layers keeps the agent's
+control plane explicit and governable — which is the point: autonomy-first
+frameworks (the OpenClaw / Hermes class of self-hosted agents) leave "how the
+world reaches the agent" largely to free wiring and LLM discretion; Reyn makes
+the trigger boundary a first-class, auditable surface, consistent with its
+predictability-over-autonomy stance.
+
+All three layers ultimately converge on the same primitive — a message placed on
+an **agent's inbox** (the `send_to_agent_impl` path). They differ only in *who
+initiates* and *when*.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. External connection  (outside → Reyn; Reyn is a server)  │
+│       MCP server · A2A server · gateway                       │
+├─────────────────────────────────────────────────────────────┤
+│  2. Internal trigger     (Reyn → a fresh agent turn)         │
+│       cron · inject_message (proposed)                        │
+├─────────────────────────────────────────────────────────────┤
+│  3. In-turn intervention (interrupt a turn in flight)        │
+│       lifecycle hooks (proposed)                              │
+└─────────────────────────────────────────────────────────────┘
+                          ↓ all converge
+                   agent inbox / send_to_agent_impl
+```
+
+> **Status note.** Layer 1 and cron (layer 2) are **implemented**.
+> `inject_message` (layer 2) and the entire hook layer (layer 3) are **proposed**
+> — design-stage, not in the codebase. This page marks each accordingly; do not
+> read a proposed mechanism as current behavior.
+
+## 1. External connection layer (outside calls Reyn)
+
+An external caller delivers a message to an agent session; Reyn acts as a passive
+server. Three connection kinds, all **implemented**:
+
+| Connection | Caller | Reply delivery |
+|---|---|---|
+| **MCP server** (SSE / stdio) — `src/reyn/mcp/server.py` | AI clients (Claude Code, Cursor) | Synchronous — the caller blocks for the reply |
+| **A2A server** (HTTP JSON-RPC) — `src/reyn/interfaces/web/routers/a2a.py` | Peer AI agents (LangGraph, CrewAI, …) | Synchronous, or async to a caller-supplied `webhook_url` |
+| **Gateway** (Slack / LINE / …) — `src/reyn/plugins/` | Humans, via a chat platform | Asynchronous — Reyn must call the platform API to deliver |
+
+**The outbound asymmetry.** MCP and A2A can **delegate the outbound reply to the
+caller**: the response either returns synchronously or is POSTed to a callback URL
+the caller provided, so Reyn needs no platform-specific outbound code. The
+**gateway is different — Reyn owns the outbound path**: there is no caller waiting
+on a socket, so Reyn must actively push the reply back out to the platform.
+
+In the current code the gateway delivers **inbound only** (the `sample_line` /
+`sample_slack` webhooks call `push_to_agent`); outbound replies are expected to go
+through a separate MCP tool (e.g. a Slack MCP server) rather than the gateway
+itself. Making a gateway own both inbound *and* outbound — register its own
+outbound MCP tool so a self-contained gateway handles send and receive — is a
+**proposed** completion of this layer. (A **proposed** rename of the `plugins/`
+package to `gateway/` reflects this bidirectional-bridge role; the package is
+`plugins/` today.)
+
+See also: [A2A](../multi-agent/a2a.md), [MCP](../tools-integrations/mcp.md).
+
+## 2. Internal trigger layer (Reyn raises a turn)
+
+Here Reyn itself starts a fresh agent turn — no external caller involved.
+
+- **cron** — `src/reyn/runtime/cron/` (**implemented**). A scheduled `CronJob`
+  dispatches a message to a target agent's inbox, producing an attributed agent
+  turn from a scheduled trigger.
+- **`inject_message`** (**proposed**) — a programmatic call that places a message
+  on an agent's inbox to raise a turn.
+
+The two are **structurally the same operation** — *put a message on an agent's
+inbox to start a turn* — and differ only in what causes the dispatch (a schedule
+vs. an explicit call). That equivalence is why they belong in one layer.
+
+## 3. In-turn intervention layer (interrupt a turn already running) — proposed
+
+Unlike the first two layers, which *start* a turn, this layer **interrupts or
+augments a turn already in flight**. It is entirely **proposed** — Reyn has no
+hook mechanism today (there are no lifecycle callback points in the router loop
+or session).
+
+The proposed shape is a set of lifecycle **hooks**, dispatched from
+`src/reyn/core/dispatch/dispatcher.py`:
+
+- `pre_tool_call` — before a tool runs (able to block or rewrite).
+- `post_tool_call` / `transform_tool_result` — after a tool runs.
+- `pre_llm_call` — before the LLM call (e.g. context injection).
+- `transform_llm_output`, plus session-lifecycle events.
+
+This is the layer that maps most directly to the hook systems in the surveyed
+competitors; in Reyn it would sit under the same permission and event discipline
+as the rest of the OS.
+
+## Implemented vs. proposed (summary)
+
+| Layer | Implemented | Proposed |
+|---|---|---|
+| 1 — External connection | MCP, A2A, gateway (inbound) | gateway outbound completion; `plugins/`→`gateway/` rename |
+| 2 — Internal trigger | cron | `inject_message` |
+| 3 — In-turn intervention | — | lifecycle hooks (whole layer) |
+
+## Why three layers
+
+The value is a single, exhaustive question for any new way of reaching an agent:
+*is this outside→Reyn, Reyn→new-turn, or within-turn?* Every interaction lands in
+exactly one layer and converges on the same inbox primitive, so the control plane
+stays auditable and each new mechanism inherits the OS's permission and event
+guarantees rather than being bolted on. It is the governance-first counterpart to
+the autonomy-first frameworks where these paths are ad hoc.
+
+## See also
+
+- [LLM invocation surfaces](llm-invocation-surfaces.md) — router vs. phase (a different axis: how the LLM is *called*, not how the agent is *reached*)
+- [Multi-agent](../multi-agent/multi-agent.md) · [A2A](../multi-agent/a2a.md) · [MCP](../tools-integrations/mcp.md)
+- [Principles](principles.md) — P4 (constrained decision engine), the governance stance behind this model


### PR DESCRIPTION
**[docs-maintainer]** — #1808 first step: formalize the three-layer model of how an agent is set in motion (from the OpenClaw/Hermes competitive analysis). New concept doc under `concepts/architecture/`.

## The model
1. **External connection** (outside → Reyn): MCP server, A2A server, gateway — with the **outbound asymmetry** (MCP/A2A delegate outbound to the caller; the gateway owns outbound). **Implemented.**
2. **Internal trigger** (Reyn → a fresh turn): `cron` (implemented) + `inject_message` (proposed) — structurally identical (message → inbox).
3. **In-turn intervention** (interrupt a live turn): lifecycle hooks — **entirely proposed** (no hook mechanism in src).
All three converge on the agent inbox / `send_to_agent_impl`.

## Implemented vs proposed — marked throughout (the core requirement)
Status note + summary table separate **implemented** (MCP/A2A/gateway-inbound, cron) from **proposed** (`inject_message`, hooks/whole layer, gateway-outbound completion, `plugins/`→`gateway/` rename). No proposed mechanism is presented as current behavior.

## Accuracy (verified against current main)
`mcp/server.py` ✓, `runtime/cron/` (CronJob → inbox) ✓, `interfaces/web/routers/a2a.py` ✓, `src/reyn/plugins/` webhooks = **inbound only** (`push_to_agent`; webhook.py itself notes outbound goes via a separate Slack MCP server) ✓, `core/dispatch/dispatcher.py` ✓, hooks/`inject_message` = **0 in src** (proposed) ✓, `send_to_agent_impl` convergence ✓. Grounded in lead's breakdown + issues (#1808/#1800/#1805/#1807, not inlined) + `research/competitive/{openclaw,hermes-agent}.md`.

## Discipline
- **No history refs** (conceptual; issue#s not inlined) — grep-verified 0.
- en + ja synced; cross-links resolve; `mkdocs --strict` exit 0.
- e2e can corroborate the runtime-structure accuracy if desired.

Independent track (between C-series audits, non-urgent). Framing/accuracy review welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)