### PR TITLE
refactor(C8): extract InterventionCoordinator from Session (#1792)

### DIFF
--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -5,6 +5,7 @@ from reyn.runtime.services.budget_gateway import BudgetGateway
 from reyn.runtime.services.chain_manager import ChainManager, _PendingChain
 from reyn.runtime.services.compaction_controller import CompactionController
 from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.runtime.services.intervention_coordinator import InterventionCoordinator
 from reyn.runtime.services.intervention_handler import InterventionHandler
 from reyn.runtime.services.intervention_registry import InterventionRegistry
 from reyn.runtime.services.memory_service import MemoryService
@@ -31,6 +32,7 @@ __all__ = [
     "CompactionController",
     "CompactionEngine",
     "HistoryChunkToCompact",
+    "InterventionCoordinator",
     "InterventionHandler",
     "InterventionRegistry",
     "MemoryService",

--- a/src/reyn/runtime/services/intervention_coordinator.py
+++ b/src/reyn/runtime/services/intervention_coordinator.py
@@ -1,0 +1,142 @@
+"""InterventionCoordinator — chain-override ownership + intervention dispatch.
+
+Owns the per-chain intervention overrides (the ``RequestBus`` registered for
+ask_user prompts emitted by skills spawned under a chain_id) and orchestrates
+one intervention's dispatch: notify any registered chain-override observer
+(side-effects only), park the iv as stalled when its origin channel has no live
+listener, else route through ``InterventionHandler``. Holds the
+``InterventionRegistry`` + ``InterventionHandler`` it delegates to; reads the
+session's run→chain map through an injected accessor. The override state lives
+here (not on Session), and ``is_override_active`` is the single predicate the
+dispatch path and ``ChatInterventionBus`` both consult.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Callable
+
+from reyn.user_intervention import InterventionAnswer
+
+if TYPE_CHECKING:
+    from reyn.core.events.events import EventLog
+    from reyn.user_intervention import RequestBus, UserIntervention
+
+    from .intervention_handler import InterventionHandler
+    from .intervention_registry import InterventionRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class InterventionCoordinator:
+    """Owns chain-override state and the per-intervention dispatch orchestration."""
+
+    def __init__(
+        self,
+        *,
+        registry: "InterventionRegistry",
+        handler: "InterventionHandler",
+        events: "EventLog",
+        running_skills_chain_fn: "Callable[[], dict]",
+    ) -> None:
+        self._registry = registry
+        self._handler = handler
+        self._events = events
+        # run_id → chain_id map lives on Session; read it live each call.
+        self._running_skills_chain_fn = running_skills_chain_fn
+        # chain_id → RequestBus. The one piece of intervention state that does
+        # not live in the registry/handler.
+        self._overrides: dict[str, "RequestBus"] = {}
+
+    # ── Override registration (chain_id → RequestBus) ───────────────────────
+
+    def register_override(self, chain_id: str, bus: "RequestBus") -> None:
+        """Register a ``RequestBus`` for ask_user prompts emitted by skills
+        spawned under *chain_id*. Caller must pair with ``unregister_override``
+        in a try/finally."""
+        self._overrides[chain_id] = bus
+
+    def unregister_override(self, chain_id: str) -> None:
+        """Remove an override. Idempotent."""
+        self._overrides.pop(chain_id, None)
+
+    def has_override(self, chain_id: str) -> bool:
+        """Return True iff *chain_id* currently has a registered override."""
+        return chain_id in self._overrides
+
+    def get_override(self, chain_id: str) -> "RequestBus | None":
+        """Return the override bus for *chain_id* or None if absent."""
+        return self._overrides.get(chain_id)
+
+    def override_count(self) -> int:
+        """Return the number of currently-registered overrides."""
+        return len(self._overrides)
+
+    # ── Override resolution ─────────────────────────────────────────────────
+
+    def _override_for_run(self, run_id: "str | None") -> "RequestBus | None":
+        """Resolve the override bus active for *run_id* (run → chain → bus)."""
+        if run_id is None or not self._overrides:
+            return None
+        chain_id = self._running_skills_chain_fn().get(run_id)
+        if chain_id is None:
+            return None
+        return self._overrides.get(chain_id)
+
+    def is_override_active(self, run_id: "str | None") -> bool:
+        """True iff a chain-override is registered for *run_id*'s chain.
+
+        The single predicate consulted by both the dispatch path and
+        ``ChatInterventionBus.deliver`` (origin-channel stamping skip).
+        """
+        return self._override_for_run(run_id) is not None
+
+    # ── Dispatch orchestration ──────────────────────────────────────────────
+
+    async def dispatch(self, iv: "UserIntervention") -> InterventionAnswer:
+        """Dispatch one intervention.
+
+        issue #292 (α): a registered chain override runs as a **side-effect
+        observer** (notify A2A peer surfaces / write history / post webhook)
+        BEFORE the regular dispatch path, instead of replacing it — the iv
+        always flows through ``InterventionHandler.dispatch`` so it lands in
+        the registry's active set + WAL + persistent answer buffer.
+
+        issue #268 Phase 2: when the iv carries an ``origin_channel_id`` whose
+        listener is gone (origin channel closed mid-call), park it stalled
+        instead of delivering to a fall-through listener; other channels
+        observe / claim / discard it.
+        """
+        # Override observer: notify before dispatch so the peer learns
+        # input-required before the awaiter (handler.dispatch) blocks the iv
+        # future. Notification must NOT block dispatch — a failed webhook /
+        # SSE append / status mirror is best-effort.
+        override = self._override_for_run(iv.run_id)
+        if override is not None:
+            try:
+                await override.on_dispatch(iv)
+            except Exception:  # noqa: BLE001 — side effects are best-effort
+                logger.exception(
+                    "intervention override on_dispatch raised "
+                    "(iv_id=%s)", iv.id,
+                )
+        # Origin-pin stall check: an iv pinned to an absent listener is parked
+        # in the stalled queue rather than delivered to a fall-through listener.
+        if (
+            iv.origin_channel_id is not None
+            and not self._registry.has_listener(iv.origin_channel_id)
+        ):
+            self._events.emit(
+                "intervention_routed",
+                route="user_channel_stalled",
+                iv_kind=iv.kind,
+                iv_id=iv.id,
+                origin_channel_id=iv.origin_channel_id,
+            )
+            self._registry.park_stalled(iv)
+            try:
+                return await iv.future
+            except asyncio.CancelledError:
+                return InterventionAnswer(text="")
+        # Default: route through the regular InterventionHandler.
+        return await self._handler.dispatch(iv)

--- a/src/reyn/runtime/services/intervention_registry.py
+++ b/src/reyn/runtime/services/intervention_registry.py
@@ -135,6 +135,10 @@ class InterventionRegistry:
         """Return True iff at least one listener is currently registered."""
         return bool(self._listeners)
 
+    def has_listener(self, listener_id: str) -> bool:
+        """Return True iff *listener_id* is a currently-registered listener."""
+        return listener_id in self._listeners
+
     def listener_count(self) -> int:
         """Return the number of currently-registered listeners."""
         return len(self._listeners)
@@ -183,6 +187,17 @@ class InterventionRegistry:
             pass
         self._stalled[iv_id] = iv
         return True
+
+    def park_stalled(self, iv: UserIntervention) -> None:
+        """Park a never-active iv directly into the stalled queue.
+
+        Unlike ``mark_stalled`` (which transitions an *active* iv out of
+        ``_active``), this records an iv that arrived already pinned to an
+        absent origin channel — it never entered ``_active`` / ``_order``, so
+        it goes straight into ``_stalled`` for cross-channel observe / discard
+        / claim. The iv's future stays unresolved.
+        """
+        self._stalled[iv.id] = iv
 
     def list_stalled(self) -> list[UserIntervention]:
         """Return all stalled interventions (= origin channel closed).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -59,6 +59,7 @@ from reyn.runtime.services import (
     BudgetGateway,
     ChainManager,
     CompactionController,
+    InterventionCoordinator,
     InterventionHandler,
     InterventionRegistry,
     MemoryService,
@@ -1329,6 +1330,15 @@ class Session:
             put_outbox=self._put_outbox,
             append_history=self._append_history_for_handler,
         )
+        # Owns the chain-override state + the per-intervention dispatch
+        # orchestration. running_skills_chain (run→chain map) lives on the
+        # SkillRunner built below; read it live via the lambda.
+        self._intervention_coordinator = InterventionCoordinator(
+            registry=self._interventions,
+            handler=self._intervention_handler,
+            events=self._chat_events,
+            running_skills_chain_fn=lambda: self.running_skills_chain,
+        )
 
         # FP-0019 Wave 1b: SkillRunner — skill task lifecycle service.
         # Owns running_skills / running_skills_started_at / running_skills_chain.
@@ -1623,11 +1633,6 @@ class Session:
         # Hybrid design (案 C): A2AHandler owns agent-side logic; transport-side
         # routing handled by FP-0013 RoutingLayer via send_request_callback /
         # send_response_callback injection.
-        # FP-0001: chain_id-scoped intervention bus overrides.
-        # Allows A2A async-mode tasks to redirect ask_user prompts to
-        # their RunRegistry-backed A2AInterventionBus while the agent's
-        # default ChatInterventionBus continues to serve chat-mode interactions.
-        self._intervention_overrides: dict[str, "RequestBus"] = {}
 
         self._a2a_handler = A2AHandler(
             event_log=self._chat_events,
@@ -3542,30 +3547,30 @@ class Session:
         Protocol, but the type hint now reflects the OS↔Agent contract
         layer the override participates in.
         """
-        self._intervention_overrides[chain_id] = bus
+        self._intervention_coordinator.register_override(chain_id, bus)
 
     def unregister_intervention_override(self, chain_id: str) -> None:
         """Remove an override. Idempotent."""
-        self._intervention_overrides.pop(chain_id, None)
+        self._intervention_coordinator.unregister_override(chain_id)
 
     def has_intervention_override(self, chain_id: str) -> bool:
         """Return True iff *chain_id* currently has a registered override
         ``RequestBus``. Public read-side counterpart to
         ``register_intervention_override`` / ``unregister_intervention_override``.
         """
-        return chain_id in self._intervention_overrides
+        return self._intervention_coordinator.has_override(chain_id)
 
     def get_intervention_override(self, chain_id: str) -> "RequestBus | None":
         """Return the override bus for *chain_id* or None if absent. Read-only
         accessor for callers (= primarily tests) that need to confirm the
         registered bus identity without consuming the override."""
-        return self._intervention_overrides.get(chain_id)
+        return self._intervention_coordinator.get_override(chain_id)
 
     def intervention_override_count(self) -> int:
         """Return the number of currently-registered overrides. Public
         emptiness probe for cleanup-leak tests (= prefer over reading the
         private mapping directly)."""
-        return len(self._intervention_overrides)
+        return self._intervention_coordinator.override_count()
 
     # ── Listener registration (issue #254 Phase 1) ──────────────────────────
 
@@ -3688,76 +3693,15 @@ class Session:
         return PendingOpView.from_intervention(iv)
 
     async def _dispatch_intervention(self, iv: UserIntervention) -> InterventionAnswer:
-        """Thin wrapper → InterventionHandler.dispatch.
+        """Dispatch one intervention via the InterventionCoordinator.
 
-        ChatInterventionBus, _handle_chat_limit_checkpoint, and
-        _ask_budget_extension all call this method directly; keeping it
-        as a session-level entry keeps those call sites stable.
-
-        issue #268 Phase 2 continuation: the origin-pin check (= stall
-        when iv.origin_channel_id is set but the listener has gone)
-        lives here so it fires for ALL iv flows, not just the
-        handle_intervention path. The check sits AFTER the chain-override
-        notification so A2A peers still see the iv's input-required
-        signal even if the local TUI listener is absent.
-
-        issue #292 (α): chain overrides now run as **side-effect
-        observers** (= notify A2A peer surfaces, write history, post
-        webhook) BEFORE the regular dispatch path, instead of replacing
-        it. The iv always flows through ``InterventionHandler.dispatch``
-        so it lands in ``_interventions._active`` + WAL +
-        ``outstanding_interventions`` + becomes eligible for R-D12's
-        persistent answer buffer. Pre-#292, the override replaced
-        dispatch and A2A ivs were invisible to Session's iv
-        machinery — fixed structurally here, not patched.
+        Kept as a Session-level entry so existing call sites
+        (ChatInterventionBus, _handle_chat_limit_checkpoint,
+        _ask_budget_extension, tests) stay stable; the override-observe /
+        origin-pin-stall / handler-dispatch orchestration lives in
+        ``InterventionCoordinator.dispatch``.
         """
-        # FP-0001 / issue #292: chain_id-scoped override notification
-        # (A2A async tasks). The override is now an OBSERVER that runs
-        # side effects (= webhook / SSE / RunRegistry status mirror)
-        # alongside the normal dispatch — NOT a bypass replacement.
-        # Notify before dispatch so the peer learns input-required
-        # before the awaiter (= handler.dispatch) blocks the iv future.
-        if iv.run_id is not None and self._intervention_overrides:
-            chain_id = self.running_skills_chain.get(iv.run_id)
-            if chain_id is not None:
-                override = self._intervention_overrides.get(chain_id)
-                if override is not None:
-                    try:
-                        await override.on_dispatch(iv)
-                    except Exception:  # noqa: BLE001 — side effects are best-effort
-                        # Override notification must NOT block dispatch.
-                        # A failed webhook / SSE append / status mirror
-                        # is logged elsewhere; dispatch proceeds.
-                        logger.exception(
-                            "intervention override on_dispatch raised "
-                            "(chain_id=%s iv_id=%s)", chain_id, iv.id,
-                        )
-        # issue #268 Phase 2 continuation: origin-pin stall check.
-        # When the iv carries an explicit ``origin_channel_id`` whose
-        # listener is no longer present (= the origin channel closed
-        # mid-call), park the iv in the stalled queue instead of
-        # delivering to a fall-through listener. Other channels
-        # observe / claim / discard via the cross-channel API. ivs
-        # without ``origin_channel_id`` (= legacy default or
-        # override-active spawn) skip this check.
-        if (
-            iv.origin_channel_id is not None
-            and iv.origin_channel_id not in self._interventions._listeners
-        ):
-            self._chat_events.emit(
-                "intervention_routed",
-                route="user_channel_stalled",
-                iv_kind=iv.kind,
-                iv_id=iv.id,
-                origin_channel_id=iv.origin_channel_id,
-            )
-            self._interventions._stalled[iv.id] = iv
-            try:
-                return await iv.future
-            except asyncio.CancelledError:
-                return InterventionAnswer(text="")
-        # Default: route through the regular InterventionHandler.
-        return await self._intervention_handler.dispatch(iv)
+        return await self._intervention_coordinator.dispatch(iv)
 
     # ── Agent-layer intervention entry point (issue #254 Phase 3) ───────────
 

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -124,19 +124,10 @@ class ChatInterventionBus:
         # captured ``_run_id`` for the override lookup since
         # ``iv.run_id`` isn't filled in until below.
         if self._channel_id is not None and iv.origin_channel_id is None:
-            override_active = False
             run_id_for_lookup = iv.run_id or self._run_id
-            if (
-                run_id_for_lookup is not None
-                and self._session._intervention_overrides
-            ):
-                chain_id = self._session.running_skills_chain.get(
-                    run_id_for_lookup,
-                )
-                if chain_id is not None:
-                    override_active = (
-                        chain_id in self._session._intervention_overrides
-                    )
+            override_active = self._session._intervention_coordinator.is_override_active(
+                run_id_for_lookup,
+            )
             if not override_active:
                 iv.origin_channel_id = self._channel_id
         if iv.run_id is None:

--- a/tests/test_intervention_coordinator.py
+++ b/tests/test_intervention_coordinator.py
@@ -1,0 +1,173 @@
+"""Tier 2: InterventionCoordinator owns override state + dispatch orchestration.
+
+Pins the three behaviours that relocated from Session into the coordinator
+(#1792 intervention seam): override-observer side-effect (best-effort, fires
+before dispatch), origin-pin stall (absent listener → parked), and the
+``is_override_active`` predicate the bus consults. Uses a real
+InterventionRegistry + small fakes (no mocks).
+"""
+import asyncio
+
+import pytest
+
+from reyn.runtime.services.intervention_coordinator import InterventionCoordinator
+from reyn.runtime.services.intervention_registry import InterventionRegistry
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _Events:
+    """Records emit() calls."""
+
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, name: str, **kw) -> None:
+        self.emitted.append((name, kw))
+
+
+class _Override:
+    """Override observer fake — records on_dispatch, optionally raises."""
+
+    def __init__(self, *, raise_exc: Exception | None = None) -> None:
+        self.calls: list[UserIntervention] = []
+        self._raise = raise_exc
+
+    async def on_dispatch(self, iv: UserIntervention) -> None:
+        self.calls.append(iv)
+        if self._raise is not None:
+            raise self._raise
+
+
+class _Handler:
+    """Records dispatch() calls; returns a sentinel answer."""
+
+    def __init__(self) -> None:
+        self.calls: list[UserIntervention] = []
+
+    async def dispatch(self, iv: UserIntervention) -> InterventionAnswer:
+        self.calls.append(iv)
+        return InterventionAnswer(text="handled")
+
+
+async def _noop_announce(iv: UserIntervention) -> None:
+    return None
+
+
+def _make_iv(*, run_id=None, origin_channel_id=None) -> UserIntervention:
+    iv = UserIntervention(kind="ask_user", prompt="Q?", run_id=run_id)
+    iv.origin_channel_id = origin_channel_id
+    iv.future = asyncio.get_running_loop().create_future()
+    return iv
+
+
+def _coord(*, chain_map=None):
+    registry = InterventionRegistry(on_announce=_noop_announce)
+    handler = _Handler()
+    events = _Events()
+    coord = InterventionCoordinator(
+        registry=registry,
+        handler=handler,
+        events=events,
+        running_skills_chain_fn=lambda: (chain_map or {}),
+    )
+    return coord, registry, handler, events
+
+
+# ── override accessors + is_override_active ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_override_accessors_and_is_active() -> None:
+    """Tier 2: register/unregister/has/get/count + is_override_active(run_id)."""
+    coord, _registry, _handler, _events = _coord(chain_map={"r1": "c1"})
+    bus = _Override()
+    assert coord.override_count() == 0
+    assert not coord.has_override("c1")
+    assert not coord.is_override_active("r1")
+
+    coord.register_override("c1", bus)
+    assert coord.has_override("c1")
+    assert coord.get_override("c1") is bus
+    assert coord.override_count() == 1
+    # run → chain → override
+    assert coord.is_override_active("r1") is True
+    assert coord.is_override_active("r2") is False  # r2 has no chain
+    assert coord.is_override_active(None) is False
+
+    coord.unregister_override("c1")
+    assert not coord.has_override("c1")
+    assert coord.override_count() == 0
+    coord.unregister_override("c1")  # idempotent
+
+
+# ── dispatch: override-observer side-effect (best-effort, before handler) ────
+
+@pytest.mark.asyncio
+async def test_dispatch_notifies_override_observer_then_handler() -> None:
+    """Tier 2: a registered override's on_dispatch fires (side-effect) AND the
+    iv still flows through the handler (override observes, does not replace)."""
+    coord, registry, handler, _events = _coord(chain_map={"r1": "c1"})
+    registry.register_listener("ch")  # present listener → no stall
+    bus = _Override()
+    coord.register_override("c1", bus)
+
+    iv = _make_iv(run_id="r1", origin_channel_id="ch")
+    answer = await coord.dispatch(iv)
+
+    assert bus.calls == [iv]               # observer notified
+    assert handler.calls == [iv]           # AND handler still reached
+    assert answer.text == "handled"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_override_observer_is_best_effort() -> None:
+    """Tier 2: a raising on_dispatch must NOT block dispatch — the iv still
+    reaches the handler."""
+    coord, registry, handler, _events = _coord(chain_map={"r1": "c1"})
+    registry.register_listener("ch")
+    bus = _Override(raise_exc=RuntimeError("webhook down"))
+    coord.register_override("c1", bus)
+
+    iv = _make_iv(run_id="r1", origin_channel_id="ch")
+    answer = await coord.dispatch(iv)
+
+    assert bus.calls == [iv]
+    assert handler.calls == [iv]           # reached despite the raise
+    assert answer.text == "handled"
+
+
+# ── dispatch: origin-pin stall (absent listener → parked) ───────────────────
+
+@pytest.mark.asyncio
+async def test_dispatch_parks_iv_when_origin_listener_absent() -> None:
+    """Tier 2: an iv pinned to an origin_channel_id with no live listener is
+    parked stalled (not delivered to the handler) and awaits its future."""
+    coord, registry, handler, events = _coord()
+    iv = _make_iv(origin_channel_id="gone")  # no listener "gone" registered
+
+    task = asyncio.ensure_future(coord.dispatch(iv))
+    await asyncio.sleep(0)  # let dispatch reach the park + await
+
+    assert [iv2.id for iv2 in registry.list_stalled()] == [iv.id]  # parked
+    assert handler.calls == []                                     # NOT handled
+    assert events.emitted and events.emitted[0][0] == "intervention_routed"
+    assert events.emitted[0][1]["route"] == "user_channel_stalled"
+
+    # Resolve the parked future to clean up the awaiting task.
+    iv.future.set_result(InterventionAnswer(text="claimed"))
+    answer = await task
+    assert answer.text == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_handler_when_listener_present() -> None:
+    """Tier 2: an iv whose origin listener IS present routes to the handler
+    (no stall)."""
+    coord, registry, handler, _events = _coord()
+    registry.register_listener("ch")
+    iv = _make_iv(origin_channel_id="ch")
+
+    answer = await coord.dispatch(iv)
+
+    assert handler.calls == [iv]
+    assert registry.list_stalled() == []
+    assert answer.text == "handled"


### PR DESCRIPTION
**[e2e-coder]** — FP-0044 C-series **Stage-2, final hard cut** (owner-approved via FP-0047 #1813) — the **first cut that moves STATE off Session**, not just methods. Behavior-preserving (replay-green); real-logic + state extraction, not a pure move. Owner picked **single PR** (#1/#2/#3 per lead's rec).

## What
1. **2 clean `InterventionRegistry` APIs** replace Session's reach into the registry's **private** state: `has_listener(listener_id)` + `park_stalled(iv)`. The `._listeners` read + `._stalled` write in `_dispatch_intervention` are gone — registry is again the **sole owner of its queues** (private access eliminated).
2. **New `InterventionCoordinator`** owns `_intervention_overrides` (dict moves off Session) + the 5 override accessors + the dispatch orchestration + **`is_override_active(run_id)`** — which **de-dups** the override-active check that was duplicated in `_dispatch_intervention` AND `ChatInterventionBus.deliver` (the bus read `_session._intervention_overrides` directly; now calls the coordinator predicate).
3. **`handle_intervention` / `_dispatch_intervention` / the 5 accessors stay as thin Session delegates** — the external call surface (mcp/server, web, ~25 test sites) is unchanged.

## Gate (state-move → stronger than residue cuts)
- ✅ **Replay green, no re-record** — no MissingFixture → SP/tools unchanged → behavior-preserving.
- ✅ **1054 pass** across replay/intervention/bus/a2a/session/force_close.
- ✅ **New `test_intervention_coordinator.py`** pins the 3 relocated behaviours **directly** at the collaborator: override-observer best-effort (raising `on_dispatch` doesn't block), origin-pin stall (absent listener → `park_stalled`), `is_override_active` predicate.
- ✅ **No construction cycle** — registry/handler built early, coordinator right after (reads `running_skills_chain` via lambda), buses call at runtime.
- ✅ **Straggler 0** — `_intervention_overrides` residue gone + registry-private access (`._listeners`/`._stalled`) eliminated.
- ✅ ruff clean. Session 4781 → 4725 LOC.

## Stage-2 goal reached
With this, **Session is substantively a lifecycle coordinator holding collaborators** — the FP-0043/0044 goal. Remaining: only the small persistence/journal accessors.

## Test plan
- [x] Replay green (no re-record)
- [x] 1054 pass (intervention/bus/a2a/session/replay/force_close)
- [x] Coordinator-direct unit pins (3 behaviours) + test-tier audit pass
- [x] Straggler 0 (override residue + registry-private access); ruff clean
- [x] Full CI green — ✓ (pytest 3.11/3.12, ruff, test-tier+docstring-gate)

Refs #1792.

