### PR TITLE
fix(1807): repoint webhook entry points reyn.plugins → reyn.gateway

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,8 @@ reyn = "reyn._cli:main"
 # FP-0041 #489 plugin framework: sample webhook plugins bundled with reyn.
 # External plugins register the same way via their own pyproject.toml.
 [project.entry-points."reyn.webhooks"]
-sample_slack = "reyn.plugins.sample_slack:register_router"
-sample_line = "reyn.plugins.sample_line:register_router"
+sample_slack = "reyn.gateway.sample_slack:register_router"
+sample_line = "reyn.gateway.sample_line:register_router"
 
 # FP-0041 #489 plugins-api PR-2: sample plugins now use OSS SDKs for
 # transport-specific protocol (= slack-bolt / line-bot-sdk). Installed

--- a/tests/gateway/test_entry_points.py
+++ b/tests/gateway/test_entry_points.py
@@ -1,0 +1,39 @@
+"""Tier 2: reyn.webhooks entry points resolve to the gateway plugin modules.
+
+Regression backstop for #1807. The plugins→gateway rename (#1807/#1816) moved
+the code (``src/reyn/plugins`` → ``src/reyn/gateway``) but the ``pyproject.toml``
+entry points still pointed at the deleted ``reyn.plugins.*`` — so webhook plugin
+discovery (``load_webhook_plugins`` → ``ep.load()``) silently failed at runtime
+(``ModuleNotFoundError`` caught + skipped). No test exercised entry-point
+resolution, so CI stayed green while inbound webhook plugins were broken.
+
+This pins resolution against the installed entry-point metadata: ``ep.load()``
+raises ``ModuleNotFoundError`` if the target module is wrong, so a future rename
+that forgets the entry points fails here instead of silently in production.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+
+@pytest.mark.parametrize("plugin_name", ["sample_slack", "sample_line"])
+def test_webhook_entry_point_resolves_to_gateway(plugin_name):
+    """Tier 2: the reyn.webhooks entry point for *plugin_name* points at the
+    ``reyn.gateway`` module and loads its ``register_router`` (not the deleted
+    ``reyn.plugins``)."""
+    eps = [
+        ep
+        for ep in importlib.metadata.entry_points(group="reyn.webhooks")
+        if ep.name == plugin_name
+    ]
+    assert eps, f"no reyn.webhooks entry point named {plugin_name!r}"
+    ep = eps[0]
+    assert ep.module.startswith("reyn.gateway."), (
+        f"entry point {plugin_name!r} points at module {ep.module!r}; "
+        f"expected reyn.gateway.* (the #1807 rename target)"
+    )
+    # Would raise ModuleNotFoundError on the #1807 stale-entry-point bug.
+    register_router = ep.load()
+    assert callable(register_router)


### PR DESCRIPTION
**[e2e-coder]** — **production regression hotfix** (fast/isolated, per lead). Surfaced during #1805 implementation.

## Bug
The #1807/#1816 plugins→gateway rename moved the code (`src/reyn/plugins` → `src/reyn/gateway`) but `pyproject.toml`'s `reyn.webhooks` entry points still named the deleted `reyn.plugins.*`. At runtime, `load_webhook_plugins` → `ep.load()` raised `ModuleNotFoundError` (caught + skipped), so **every webhook gateway plugin (sample_slack / sample_line) silently failed to mount since #1807**. No test exercised entry-point resolution → CI stayed green.

## Fix
- Repoint both entry points to `reyn.gateway`.
- Add `tests/gateway/test_entry_points.py` — a **fresh-install backstop**: resolves each `reyn.webhooks` entry point and calls `ep.load()` (raises on a wrong module). A future rename that forgets the entry points now fails CI instead of silently in production.

## Root cause of the miss
`verify_package_move.py` was run with `--roots src tests docs` for #1807, **excluding `pyproject.toml`** at the repo root where entry points live. Tool repo-root-config coverage = a separate follow-up (per lead).

## Test plan
- [x] `tests/gateway/test_entry_points.py` → 2 passed (resolves to reyn.gateway + ep.load())
- [x] ruff clean
- [ ] Full CI green (fresh install validates the entry-point→module linkage) — pending

Refs #1807.