### PR TITLE
feat(1805): gateway outbound — self-contained inbound+outbound plugins

### DIFF
--- a/docs/deep-dives/proposals/0048-gateway-outbound-self-contained-plugin.md
+++ b/docs/deep-dives/proposals/0048-gateway-outbound-self-contained-plugin.md
@@ -28,9 +28,27 @@ self-contained unit — the way Hermes' single-file `telegram.py` does inbound
 
 ## Recommended design (案B + 案C, lead-endorsed)
 
+> **Implementation update (flow-trace before the cut, #1805 — lead-endorsed):
+> 案C is DROPPED, 案B is the whole feature.** Tracing the outbound path during
+> implementation showed the **agent's outbound is already complete**:
+> `deps.py` wires `make_outbox_interceptor(routing, mcp_dispatcher=
+> make_session_mcp_dispatcher(session))` → `route_to_mcp` → `mcp_handle`. The
+> 案B in-process tool **reuses that existing path** to close crash-vanish — the
+> agent reply → outbox → interceptor → `route_to_mcp` → in-process tool flows
+> with no new code. So `send_to_transport` (案C) would only **duplicate** the
+> existing outbound, its issue-signature `send_to_transport(transport,
+> destination, text)` can't be built cleanly (it needs `session` for
+> routing+dispatcher), and its caller is ambiguous (the agent uses the
+> interceptor; the plugin's tool handler does the Bot-API call). 案C = YAGNI,
+> **deferred**. This doc's remaining 案C subsections (the `gateway.api`
+> helper, open question 2) are superseded by this note — same "shrink the
+> design correctly via pre-impl flow-trace" discipline as the C6 9→6 and C7
+> dead-vs-live cuts.
+
 **案B (spine): the plugin's outbound tool is hosted in-process by `reyn web`,
-not a separate process.** **案C (authoring surface): a `gateway.api` outbound
-helper** so plugin authors never touch MCP directly.
+not a separate process.** ~~案C (authoring surface): a `gateway.api` outbound
+helper~~ — **dropped (see the update note above); the existing
+`route_to_mcp` path already serves it.**
 
 ### Why B over A / C-alone
 

--- a/src/reyn/gateway/sample_slack/__init__.py
+++ b/src/reyn/gateway/sample_slack/__init__.py
@@ -20,8 +20,12 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
+
+if TYPE_CHECKING:
+    from reyn.mcp.extra_tool import ExtraTool
 
 logger = logging.getLogger(__name__)
 
@@ -57,3 +61,18 @@ def register_router(config: dict) -> APIRouter | None:
         )
         return None
     return build_router(target_agent=target_agent)
+
+
+def register_tools(config: dict) -> "list[ExtraTool]":
+    """Plugin entry point — return the plugin's outbound MCP tools (#1805).
+
+    Sibling of ``register_router``: ``register_router`` provides the inbound
+    webhook; ``register_tools`` provides the outbound ``slack_send`` tool,
+    hosted in-process by reyn web's MCP server so a complete plugin needs no
+    separate Slack MCP server. The tool's handler defers the ``slack_sdk``
+    import and checks ``SLACK_BOT_TOKEN`` at call time, so registration itself
+    is dependency-free.
+    """
+    from .webhook import build_send_tool
+
+    return [build_send_tool()]

--- a/src/reyn/gateway/sample_slack/webhook.py
+++ b/src/reyn/gateway/sample_slack/webhook.py
@@ -45,10 +45,75 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Request
 
+if TYPE_CHECKING:
+    from reyn.mcp.extra_tool import ExtraTool
+
 logger = logging.getLogger(__name__)
+
+
+def build_send_tool() -> "ExtraTool":
+    """Build the Slack outbound MCP tool (in-process send, #1805).
+
+    The tool the agent invokes — via ``external_transports`` → ``route_to_mcp``
+    → reyn-web's in-process MCP server — to deliver a reply to Slack. It calls
+    ``chat.postMessage`` through ``slack_sdk``'s async client **in this reyn-web
+    process**, so a complete plugin needs no separate Slack MCP server. A failed
+    send returns a surfaced ``{"ok": false, "error": ...}`` result rather than a
+    silent drop — the crash-vanish fix #1805 is about.
+    """
+    from reyn.mcp.extra_tool import ExtraTool
+
+    async def _handler(args: dict) -> str:
+        import json
+
+        channel = (args or {}).get("channel")
+        text = (args or {}).get("text", "")
+        thread_ts = (args or {}).get("thread_ts")
+        if not channel:
+            return json.dumps({"ok": False, "error": "channel is required"})
+        token = os.environ.get("SLACK_BOT_TOKEN", "")
+        if not token:
+            return json.dumps({"ok": False, "error": "SLACK_BOT_TOKEN not set"})
+        try:
+            from slack_sdk.web.async_client import AsyncWebClient
+        except ImportError as exc:
+            return json.dumps(
+                {"ok": False, "error": f"slack_sdk not installed: {exc}"},
+            )
+        client = AsyncWebClient(token=token)
+        try:
+            resp = await client.chat_postMessage(
+                channel=channel, text=text, thread_ts=thread_ts,
+            )
+            return json.dumps({"ok": True, "ts": resp.get("ts")})
+        except Exception as exc:  # noqa: BLE001 — surface the send failure
+            return json.dumps({"ok": False, "error": str(exc)})
+
+    return ExtraTool(
+        name="slack_send",
+        description=(
+            "Send a message to a Slack channel or thread (outbound reply "
+            "delivery for the sample_slack gateway plugin)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "channel": {"type": "string", "description": "Slack channel ID."},
+                "text": {"type": "string", "description": "Message text to post."},
+                "thread_ts": {
+                    "type": "string",
+                    "description": "Optional thread ts to reply in-thread.",
+                },
+            },
+            "required": ["channel", "text"],
+            "additionalProperties": False,
+        },
+        handler=_handler,
+    )
 
 
 def build_router(*, target_agent: str) -> APIRouter:

--- a/src/reyn/interfaces/web/plugin_loader.py
+++ b/src/reyn/interfaces/web/plugin_loader.py
@@ -54,9 +54,12 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, FastAPI
+
+if TYPE_CHECKING:
+    from reyn.mcp.extra_tool import ExtraTool
 
 logger = logging.getLogger(__name__)
 
@@ -225,3 +228,72 @@ def load_webhook_plugins(*, app: FastAPI, webhooks_config: dict) -> int:
         )
 
     return mounted
+
+
+def load_webhook_tools(*, webhooks_config: dict) -> "list[ExtraTool]":
+    """Collect each activated webhook plugin's outbound MCP tools (#1805).
+
+    Sibling of ``load_webhook_plugins``: for every enabled plugin whose module
+    defines ``register_tools(config) -> list[ExtraTool]`` (alongside its
+    ``register_router`` entry point), call it and gather the returned tools.
+    These merge into reyn-web's in-process MCP server (``build_server``'s
+    ``extra_tools``) so a complete gateway plugin hosts inbound webhook +
+    outbound tool in one process. Plugins with no ``register_tools`` are
+    inbound-only (skipped, not an error).
+    """
+    tools: list[ExtraTool] = []
+    if not isinstance(webhooks_config, dict) or not webhooks_config:
+        return tools
+
+    for plugin_name, ref in webhooks_config.items():
+        if not isinstance(plugin_name, str) or not plugin_name:
+            continue
+        if ref is None:
+            ref_dict: dict = {}
+        elif isinstance(ref, dict):
+            ref_dict = ref
+        else:
+            continue
+        if not ref_dict.get("enabled", True):
+            continue
+
+        package = ref_dict.get("package")
+        if package is not None and not isinstance(package, str):
+            package = None
+
+        ep = _find_entry_point(plugin_name, package=package)
+        if ep is None:
+            continue
+        try:
+            module = importlib.import_module(ep.module)
+        except Exception as exc:  # noqa: BLE001 — defensive, like router load
+            logger.warning(
+                "webhook plugin %r: module import failed for tools: %s",
+                plugin_name, exc,
+            )
+            continue
+
+        register_tools_fn = getattr(module, "register_tools", None)
+        if register_tools_fn is None:
+            continue  # inbound-only plugin
+
+        plugin_options = {
+            k: v for k, v in ref_dict.items() if k not in _REYN_RESERVED_KEYS
+        }
+        try:
+            plugin_tools = register_tools_fn(plugin_options)
+        except Exception as exc:  # noqa: BLE001 — one plugin must not break boot
+            logger.exception(
+                "webhook plugin %r register_tools raised: %s", plugin_name, exc,
+            )
+            continue
+
+        plugin_tools = list(plugin_tools or [])
+        tools.extend(plugin_tools)
+        if plugin_tools:
+            logger.info(
+                "webhook plugin %r registered %d outbound tool(s)",
+                plugin_name, len(plugin_tools),
+            )
+
+    return tools

--- a/src/reyn/interfaces/web/routers/mcp.py
+++ b/src/reyn/interfaces/web/routers/mcp.py
@@ -83,7 +83,14 @@ async def handle_sse(request: Request, registry=Depends(get_registry)) -> Respon
     expectation of a return value; it is not transmitted.
     """
     transport = _get_sse_transport()
-    server = build_server(registry, timeout=DEFAULT_SEND_TIMEOUT_SECONDS)
+    # #1805: include gateway plugins' outbound tools collected at app startup
+    # so a complete plugin's send tool (e.g. slack_send) is served in-process.
+    gateway_tools = getattr(request.app.state, "gateway_tools", None)
+    server = build_server(
+        registry,
+        timeout=DEFAULT_SEND_TIMEOUT_SECONDS,
+        extra_tools=gateway_tools,
+    )
     init_options = server.create_initialization_options()
 
     # Note: request._send is private but is the canonical way to

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -267,12 +267,21 @@ app.include_router(_web_data_router.router, prefix="/api")
 # project root, separate from reyn.yaml to keep core config lean) and
 # mounted by the plugin loader at app startup. Reyn core stays SDK-free;
 # per-transport protocol code lives in plugins.
+app.state.gateway_tools = []
 try:
     from reyn.config import _find_project_root as _find_root_for_plugins
-    from reyn.interfaces.web.plugin_loader import load_webhook_plugins, load_webhooks_yaml
+    from reyn.interfaces.web.plugin_loader import (
+        load_webhook_plugins,
+        load_webhook_tools,
+        load_webhooks_yaml,
+    )
     _project_root_for_plugins = _find_root_for_plugins(Path.cwd()) or Path.cwd()
     _webhooks_cfg = load_webhooks_yaml(_project_root_for_plugins)
     load_webhook_plugins(app=app, webhooks_config=_webhooks_cfg)
+    # #1805: collect each plugin's outbound MCP tools (register_tools) so the
+    # in-process MCP server (handle_sse → build_server) hosts them — a complete
+    # gateway plugin = inbound webhook + outbound tool in one process.
+    app.state.gateway_tools = load_webhook_tools(webhooks_config=_webhooks_cfg)
 except Exception as _exc:  # noqa: BLE001 — defensive boot
     logger.warning("webhook plugin loading failed: %s", _exc)
 

--- a/src/reyn/mcp/extra_tool.py
+++ b/src/reyn/mcp/extra_tool.py
@@ -1,0 +1,27 @@
+"""ExtraTool — a plugin-supplied MCP tool spec merged into build_server.
+
+A gateway plugin's ``register_tools()`` returns a list of these; ``build_server``
+merges them into the MCP server's catalog (``list_tools``) and dispatch
+(``call_tool``). Kept free of the ``mcp`` SDK so plugins and the web loader can
+import it without the SDK installed — ``build_server`` converts each to an SDK
+``Tool`` internally.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+
+@dataclass(frozen=True)
+class ExtraTool:
+    """One plugin-provided MCP tool.
+
+    ``handler`` is ``async (arguments: dict) -> str`` — it receives the parsed
+    tool arguments and returns the tool's text result (build_server wraps it as
+    an MCP ``TextContent``).
+    """
+
+    name: str
+    description: str
+    input_schema: dict
+    handler: Callable[[dict], Awaitable[str]]

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -41,6 +41,7 @@ from reyn.runtime.agent_locks import get_agent_lock as _get_agent_lock
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from reyn.mcp.extra_tool import ExtraTool
     from reyn.runtime.registry import AgentRegistry
     from reyn.user_intervention import RequestBus
 
@@ -338,6 +339,7 @@ def build_server(
     registry: "AgentRegistry",
     *,
     timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
+    extra_tools: "list[ExtraTool] | None" = None,
 ):
     """Construct an ``mcp.server.Server`` wired to the given registry.
 
@@ -345,9 +347,16 @@ def build_server(
     imported in test environments where ``mcp`` is not installed (the
     tests of this module install it via the ``mcp`` extra; the rest of
     the suite doesn't touch this surface).
+
+    ``extra_tools`` are plugin-supplied tools (e.g. a gateway plugin's outbound
+    send tool, #1805): each is exposed in ``list_tools`` and dispatched in
+    ``call_tool`` after the built-in tools (built-ins take precedence on a name
+    clash).
     """
     from mcp.server import Server
     from mcp.types import TextContent, Tool
+
+    _extra_tools = list(extra_tools or [])
 
     server = Server("reyn")
 
@@ -451,6 +460,14 @@ def build_server(
                     "additionalProperties": False,
                 },
             ),
+            *[
+                Tool(
+                    name=et.name,
+                    description=et.description,
+                    inputSchema=et.input_schema,
+                )
+                for et in _extra_tools
+            ],
         ]
 
     @server.call_tool()
@@ -576,6 +593,13 @@ def build_server(
                     ),
                 }),
             )]
+
+        # Plugin-supplied tools (#1805) — dispatched after the built-ins, so a
+        # built-in name always wins on a clash.
+        for et in _extra_tools:
+            if name == et.name:
+                result = await et.handler(arguments or {})
+                return [TextContent(type="text", text=result)]
 
         return [TextContent(type="text", text=f"error: unknown tool {name!r}")]
 
@@ -967,6 +991,11 @@ async def serve_stdio(
     """
     from mcp.server.stdio import stdio_server
 
+    # No extra_tools here: the stdio MCP server hosts no gateway outbound tools
+    # (#1805) — those are reyn-web-scoped (webhook plugins mount in the FastAPI
+    # app + register_tools is collected onto app.state). A stdio CLI has no app,
+    # so there is nothing to host. The SSE path (web/routers/mcp.py) passes
+    # extra_tools; this asymmetry is by design, not an oversight.
     server = build_server(registry, timeout=timeout)
     # issue #271 M3: capability advertising. Declare what this server
     # actually emits + handles so MCP clients can negotiate features

--- a/tests/gateway/sample_slack/test_outbound.py
+++ b/tests/gateway/sample_slack/test_outbound.py
@@ -1,0 +1,183 @@
+"""Tier 2: sample_slack outbound tool — the in-process send tool (#1805).
+
+A complete gateway plugin provides outbound (not just inbound). These pin the
+``slack_send`` tool handler (incl. the crash-surface behaviour the feature
+fixes: a failed send returns a surfaced error, not a silent drop), the
+``register_tools`` contract, the ``load_webhook_tools`` collection through the
+plugin entry point, and the ``build_server`` extra_tools dispatch.
+
+A fake ``slack_sdk`` is injected so the success / crash-surface tests run in CI
+(which installs ``[dev,mcp,web]`` but not the Slack SDK).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+
+import pytest
+
+from reyn.gateway.sample_slack import register_tools
+from reyn.gateway.sample_slack.webhook import build_send_tool
+
+
+def _install_fake_slack(monkeypatch, *, raise_exc=None, captured=None):
+    """Inject a fake ``slack_sdk.web.async_client.AsyncWebClient`` recording
+    client so the handler runs without the real SDK."""
+    class _FakeClient:
+        def __init__(self, *, token):
+            self.token = token
+
+        async def chat_postMessage(self, **kwargs):
+            if captured is not None:
+                captured.update(kwargs)
+            if raise_exc is not None:
+                raise raise_exc
+            return {"ts": "1700000000.000100"}
+
+    pkg = types.ModuleType("slack_sdk")
+    web = types.ModuleType("slack_sdk.web")
+    ac = types.ModuleType("slack_sdk.web.async_client")
+    ac.AsyncWebClient = _FakeClient
+    monkeypatch.setitem(sys.modules, "slack_sdk", pkg)
+    monkeypatch.setitem(sys.modules, "slack_sdk.web", web)
+    monkeypatch.setitem(sys.modules, "slack_sdk.web.async_client", ac)
+
+
+# ── handler: validation (no SDK needed) ─────────────────────────────────────
+
+def test_slack_send_requires_channel(monkeypatch):
+    """Tier 2: missing channel → surfaced error (no send attempted)."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    tool = build_send_tool()
+    out = json.loads(asyncio.run(tool.handler({"text": "hi"})))
+    assert out["ok"] is False
+    assert "channel" in out["error"]
+
+
+def test_slack_send_requires_token(monkeypatch):
+    """Tier 2: missing SLACK_BOT_TOKEN → surfaced error."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    tool = build_send_tool()
+    out = json.loads(asyncio.run(tool.handler({"channel": "C1", "text": "hi"})))
+    assert out["ok"] is False
+    assert "SLACK_BOT_TOKEN" in out["error"]
+
+
+# ── handler: send + crash-surface (faked SDK) ───────────────────────────────
+
+def test_slack_send_success(monkeypatch):
+    """Tier 2: a configured send posts to Slack and returns ok + ts."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    captured: dict = {}
+    _install_fake_slack(monkeypatch, captured=captured)
+    tool = build_send_tool()
+    out = json.loads(asyncio.run(tool.handler(
+        {"channel": "C1", "text": "hello", "thread_ts": "111.222"},
+    )))
+    assert out == {"ok": True, "ts": "1700000000.000100"}
+    assert captured == {"channel": "C1", "text": "hello", "thread_ts": "111.222"}
+
+
+def test_slack_send_surfaces_failure(monkeypatch):
+    """Tier 2: CRASH-SURFACE — a failed Slack send returns a surfaced error,
+    NOT a silent drop. This is the regression #1805 fixes (outbound failure was
+    previously invisible because the separate MCP server failed in another
+    process)."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    _install_fake_slack(monkeypatch, raise_exc=RuntimeError("slack 503"))
+    tool = build_send_tool()
+    out = json.loads(asyncio.run(tool.handler({"channel": "C1", "text": "hi"})))
+    assert out["ok"] is False
+    assert "slack 503" in out["error"]
+
+
+# ── register_tools + load_webhook_tools collection ──────────────────────────
+
+def test_register_tools_returns_slack_send():
+    """Tier 2: register_tools (the outbound sibling of register_router) returns
+    the slack_send tool."""
+    tools = register_tools({"target_agent": "demo"})
+    assert [t.name for t in tools] == ["slack_send"]
+
+
+def test_load_webhook_tools_collects_via_entry_point():
+    """Tier 2: load_webhook_tools resolves the plugin entry point and gathers
+    its outbound tools (full discovery path: entry point → module →
+    register_tools → tool)."""
+    from reyn.interfaces.web.plugin_loader import load_webhook_tools
+
+    tools = load_webhook_tools(
+        webhooks_config={"sample_slack": {"target_agent": "demo"}},
+    )
+    assert "slack_send" in {t.name for t in tools}
+
+
+def test_load_webhook_tools_skips_disabled():
+    """Tier 2: a disabled plugin contributes no tools."""
+    from reyn.interfaces.web.plugin_loader import load_webhook_tools
+
+    tools = load_webhook_tools(
+        webhooks_config={"sample_slack": {"target_agent": "d", "enabled": False}},
+    )
+    assert tools == []
+
+
+# ── build_server extra_tools dispatch (in-process MCP server) ────────────────
+
+def test_build_server_lists_and_dispatches_extra_tool(tmp_path):
+    """Tier 2: build_server exposes an extra_tool in list_tools AND dispatches
+    call_tool to its handler (the in-process MCP-server half of the e2e)."""
+    pytest.importorskip("mcp")
+    from mcp.types import (
+        CallToolRequest,
+        CallToolRequestParams,
+        ListToolsRequest,
+    )
+
+    from reyn.core.events.state_log import StateLog
+    from reyn.mcp.extra_tool import ExtraTool
+    from reyn.mcp.server import build_server
+    from reyn.runtime.registry import AgentRegistry
+
+    async def _echo(args: dict) -> str:
+        return json.dumps({"echo": args.get("msg", "")})
+
+    tool = ExtraTool(
+        name="echo_tool",
+        description="echo",
+        input_schema={
+            "type": "object",
+            "properties": {"msg": {"type": "string"}},
+            "required": ["msg"],
+            "additionalProperties": False,
+        },
+        handler=_echo,
+    )
+    # The extra_tool dispatch never touches the registry, so a no-op
+    # session_factory is enough to construct one.
+    state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    registry = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda profile: None,
+        state_log=state_log,
+    )
+    server = build_server(registry, extra_tools=[tool])
+
+    list_handler = server.request_handlers[ListToolsRequest]
+    names = {
+        t.name
+        for t in asyncio.run(
+            list_handler(ListToolsRequest(method="tools/list", params=None)),
+        ).root.tools
+    }
+    assert "echo_tool" in names
+    assert {"list_agents", "send_to_agent", "answer_intervention"} <= names
+
+    call_handler = server.request_handlers[CallToolRequest]
+    result = asyncio.run(call_handler(CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name="echo_tool", arguments={"msg": "hi"}),
+    )))
+    assert json.loads(result.root.content[0].text) == {"echo": "hi"}


### PR DESCRIPTION
**[e2e-coder]** — gateway outbound: a complete plugin provides **both** inbound (webhook) and outbound (MCP tool) in one self-contained unit, hosted **in-process** by `reyn web`. Closes the crash-vanish gap (outbound previously needed a separately-run MCP server that, if it died, silently dropped agent replies). Rebased onto the #1824 entry-point hotfix.

## Design = 案B (lead-endorsed; 案C dropped after flow-trace)
The agent's outbound is **already complete** (`make_outbox_interceptor → route_to_mcp → mcp_handle`, wired in deps.py). 案B reuses that path with the tool now **in-process**; 案C `send_to_transport` would only duplicate it → dropped (FP-0048 updated with the scope refinement — same "shrink via pre-impl flow-trace" discipline as C6 9→6 / C7 dead-vs-live).

## What
- **`build_server` `extra_tools` hook** (`reyn.mcp.extra_tool.ExtraTool`, SDK-free): plugin tools listed in `list_tools` + dispatched in `call_tool` **after** the built-ins (built-ins win on a clash).
- **`sample_slack.slack_send`** outbound MCP tool (`register_tools`, sibling of `register_router`): handler calls `chat.postMessage` in-process; a failed send returns a **surfaced `{"ok": false, "error": ...}`** result, not a silent drop — the crash-vanish fix.
- **`plugin_loader.load_webhook_tools`**: collects each plugin's `register_tools` at web startup → `app.state.gateway_tools` → `handle_sse` passes to `build_server`.
- Self-loop: `external_transports.slack` → local reyn-web MCP tool; one process hosts inbound webhook + outbound tool. `route_to_mcp` unchanged; backward-compatible (external MCP server still works, in-process is opt-in).
- The stdio MCP server intentionally hosts **no** gateway tools (reyn-web-scoped; documented inline at the stdio `build_server` call).

## Test plan (gate — strict, feature)
- [x] **Outbound unit + crash-surface** (`test_outbound.py`): validation / success / **failed-send → surfaced error** (the #1805 regression) / `register_tools` / `load_webhook_tools` entry-point collection / `build_server` extra_tools list+dispatch
- [x] **Inbound unchanged** — existing `tests/gateway/` webhook suites + the #1824 entry-point backstop green
- [x] Replay-neutral (no agent SP/tools change — web/MCP-server/gateway tooling); ruff clean; 82 pass across gateway/web/mcp/plugin_loader
- [x] (skipped — full-HTTP self-loop e2e: webhook POST → agent turn → outbound over the MCP-SSE self-loop → faked Slack is harness-heavy + needs no live Slack. The **in-process MCP-server-dispatches-`slack_send`** half is unit-covered by `test_build_server_lists_and_dispatches_extra_tool`; the **inbound** half by the existing webhook suites; the production wiring chain `startup → app.state.gateway_tools → handle_sse → build_server` attr-contract was grep-verified in review.)
- [x] Full CI green (pytest 3.11/3.12 ✓ ruff ✓ test-tier+docstring-gate ✓, re-run after the stdio-comment minor)

Closes #1805.

