### PR TITLE
tooling: verify_package_move scans repo-root config (entry points / paths)

### DIFF
--- a/scripts/verify_package_move.py
+++ b/scripts/verify_package_move.py
@@ -44,6 +44,11 @@ from pathlib import Path
 
 DEFAULT_ROOTS = ("src", "tests")
 SKIP_DIRS = {".git", "__pycache__", ".venv", "node_modules"}
+# Repo-root config that carries package references outside src/tests — entry
+# points (dotted literals) + package-data / find paths. A package move that
+# repoints only src/tests/docs misses these (the #1807 webhooks entry-point
+# regression), so they are always scanned for the dotted-literal / path checks.
+ROOT_CONFIG_FILES = ("pyproject.toml", "setup.cfg", "setup.py", "MANIFEST.in")
 
 
 def _py_files(roots: list[str]) -> list[Path]:
@@ -169,6 +174,9 @@ def main(argv: list[str] | None = None) -> int:
 
     py_files = _py_files(args.roots)
     text_files = _all_text_files(args.roots)
+    # Always include repo-root config (entry points / package-data live here,
+    # outside the src/tests roots) for the dotted-literal + path-hit checks.
+    text_files += [Path(f) for f in ROOT_CONFIG_FILES if Path(f).is_file()]
     self_path = "scripts/verify_package_move.py"
 
     sections: list[tuple[str, list[str]]] = []

--- a/tests/test_verify_package_move_root_config.py
+++ b/tests/test_verify_package_move_root_config.py
@@ -1,0 +1,36 @@
+"""Tier 2: verify_package_move scans repo-root config (entry points / paths).
+
+Backstop for the #1807 miss: the tool was run with ``--roots src tests docs``,
+so ``pyproject.toml``'s entry points (still naming the deleted ``reyn.plugins``)
+were never scanned and the broken webhook discovery shipped. ``ROOT_CONFIG_FILES``
+is now always included in the dotted-literal / path checks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scripts.verify_package_move import main
+
+
+def _write_pyproject(tmp_path, dotted: str) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        '[project.entry-points."reyn.webhooks"]\n'
+        f'sample = "{dotted}:register_router"\n'
+    )
+
+
+def test_root_config_pyproject_is_scanned(tmp_path, monkeypatch):
+    """Tier 2: a stale dotted ref in pyproject.toml is caught even when --roots
+    excludes the repo root (the #1807 entry-point regression class)."""
+    _write_pyproject(tmp_path, "old.pkg.sample")
+    monkeypatch.chdir(tmp_path)
+    # package-move mode (no symbol); src is empty, so the ONLY hit is pyproject.
+    assert main(["old.pkg", "--roots", "src"]) == 1
+
+
+def test_clean_root_config_passes(tmp_path, monkeypatch):
+    """Tier 2: no residual reference in root config → clean exit."""
+    _write_pyproject(tmp_path, "new.pkg.sample")
+    monkeypatch.chdir(tmp_path)
+    assert main(["old.pkg", "--roots", "src"]) == 0


### PR DESCRIPTION
**[e2e-coder]** — follow-up mechanizing the root-cause of the #1807 entry-point regression (lead-approved, no new issue per owner's policy).

## Why
The #1807 plugins→gateway rename's stale `pyproject.toml` entry points were missed because `verify_package_move.py` was run with `--roots src tests docs` — `pyproject.toml` lives at the **repo root**, outside those roots. Its entry points (dotted literals) + package-data (paths) were never scanned → broken webhook discovery shipped (fixed in #1824).

## Fix
Always include `ROOT_CONFIG_FILES` (`pyproject.toml` / `setup.cfg` / `setup.py` / `MANIFEST.in`) in the dotted-literal + path-hit checks, regardless of `--roots`. This adds **"repo-root config"** to the package-move ref-classes the tool enforces — so a future rename that forgets entry points / package-data **fails the straggler gate** (no memory pin needed; the tool mechanizes it).

## Test plan
- [x] Backstop test: a stale ref in `pyproject.toml` is caught with `--roots src` → 2 passed
- [x] On main, `verify_package_move.py reyn.gateway --roots src` now surfaces the pyproject entry points (proves root config is scanned)
- [x] ruff + test-tier audit clean
- [ ] Full CI green — pending

Refs #1807.