### PR TITLE
fix(1762): loop-aware per-agent lock registry (kill cross-loop test flake)

### DIFF
--- a/src/reyn/runtime/agent_locks.py
+++ b/src/reyn/runtime/agent_locks.py
@@ -10,37 +10,62 @@ The fix: every transport that drives ``run_one_iteration`` acquires the same
 per-agent ``asyncio.Lock`` before entering the critical section.
 
 This module is the single registry for those locks.  Both ``mcp_server`` and
-``a2a`` import ``get_agent_lock`` from here; they therefore share the same
-``_AGENT_LOCKS`` dict and thus the same lock object for any given agent name.
+``a2a`` import ``get_agent_lock`` from here; on a given event loop they therefore
+share the same lock object for any given agent name.
 
 Design constraints:
-- Module-level singleton dict: one process, one event-loop — the module is
-  imported once and the dict is stable for the process lifetime.
-- ``asyncio.Lock`` is not thread-safe, but Reyn runs on a single asyncio
-  event loop, so this is fine.
 - The lock is keyed by the *agent name string* — the same identity used by
   ``AgentRegistry.get_or_load``.  Transport callers must use the canonical
   name (not a URL slug or alias) so the key matches.
+- ``asyncio.Lock`` is not thread-safe, but Reyn runs on a single asyncio
+  event loop, so this is fine.
+- **Loop-aware keying (#1762).** An ``asyncio.Lock`` binds to the event loop it
+  is first awaited on; caching one lock across loops raises ``"... is bound to a
+  different event loop"`` the moment a *second* loop has a waiter on it. In
+  production this never happens (single process-wide loop), but a registry keyed
+  *only* by name leaks that assumption into any multi-loop context — most
+  visibly pytest-asyncio, which gives every test a fresh loop, so a lock created
+  under one test's loop is reused (and trips) under the next. Keying the registry
+  by the *running loop* makes each loop get its own lock object: identity holds
+  WITHIN a loop (all the serialization guarantee needs — production is one loop)
+  while cross-loop reuse can no longer occur. The per-loop maps live in a
+  ``WeakKeyDictionary`` so a finished loop's locks are garbage-collected with it.
 """
 from __future__ import annotations
 
 import asyncio
+import weakref
 
-# Module-level registry — intentionally a plain dict.
-# Callers must NOT mutate this dict directly; use ``get_agent_lock`` only.
-_AGENT_LOCKS: dict[str, asyncio.Lock] = {}
+# Per-running-loop registries of per-agent locks (#1762). Keyed by the event loop
+# so each loop gets distinct lock objects (an asyncio.Lock is bound to the loop it
+# is awaited on). WeakKeyDictionary → a dead loop's locks are GC'd with it.
+# Callers must NOT mutate this directly; use ``get_agent_lock`` only.
+_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]]" = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def get_agent_lock(agent_name: str) -> asyncio.Lock:
-    """Return the per-agent ``asyncio.Lock`` for *agent_name*.
+    """Return the per-agent ``asyncio.Lock`` for *agent_name* on the running loop.
 
-    Creates the lock on first access; subsequent calls with the same name
-    return the **same** ``asyncio.Lock`` object (identity guarantee).  Locks
-    for different names are distinct objects.
+    Must be called from within a running event loop — every transport driver
+    acquires the lock inside its ``async with`` critical section, so a running
+    loop is always present at the call site.
 
-    Thread-safety: this function is NOT thread-safe (dict.setdefault is not
-    atomic across threads), but Reyn is single-threaded asyncio — concurrent
-    coroutines on the same loop are safe here because Python's GIL prevents
-    true parallelism during the ``setdefault`` call.
+    Identity guarantee: repeated calls with the same name **on the same loop**
+    return the **same** ``asyncio.Lock`` object; different names yield distinct
+    objects. Different loops yield distinct objects by design — an
+    ``asyncio.Lock`` is bound to the loop it is awaited on, so cross-loop reuse
+    would raise ``"bound to a different event loop"`` (#1762). Production runs on
+    a single loop, so this is transparent there.
+
+    Thread-safety: NOT thread-safe (``dict.setdefault`` is not atomic across
+    threads), but Reyn is single-threaded asyncio — concurrent coroutines on the
+    same loop are safe because the GIL serializes the ``setdefault`` call.
     """
-    return _AGENT_LOCKS.setdefault(agent_name, asyncio.Lock())
+    loop = asyncio.get_running_loop()
+    per_loop = _LOCKS_BY_LOOP.get(loop)
+    if per_loop is None:
+        per_loop = {}
+        _LOCKS_BY_LOOP[loop] = per_loop
+    return per_loop.setdefault(agent_name, asyncio.Lock())

--- a/tests/test_agent_locks_shared_1128.py
+++ b/tests/test_agent_locks_shared_1128.py
@@ -5,20 +5,24 @@ issue #1128: MCP and A2A must acquire the SAME ``asyncio.Lock`` for a
 given agent name so concurrent MCP+A2A calls to the same session serialize
 rather than racing on ``session.history``.
 
-Invariants exercised:
-  (a) ``get_agent_lock("x")`` is idempotent: repeated calls return the
-      identical lock object (``is`` identity).
+Invariants exercised (identity invariants hold WITHIN a running loop — the
+registry is loop-aware since #1762, see ``agent_locks`` docstring):
+  (a) ``get_agent_lock("x")`` is idempotent: repeated calls on the same loop
+      return the identical lock object (``is`` identity).
   (b) Different agent names yield distinct lock objects.
-  (c) MCP and A2A obtain the SAME lock object for the same agent_name —
-      both import from ``reyn.runtime.agent_locks``; the module-level dict
-      ensures identity.
+  (c) MCP and A2A obtain the SAME lock object for the same agent_name on the
+      same loop — both import from ``reyn.runtime.agent_locks``; the per-loop
+      registry ensures identity.
   (d) Concurrent coroutines acquiring the same lock are serialized:
       critical sections do not overlap (behavioral, not count-pin).
+  (e) #1762 regression: a contended lock used across distinct event loops
+      (= pytest-asyncio's per-test fresh loops) must NOT raise "bound to a
+      different event loop" — loop-aware keying gives each loop its own lock.
 
 Policy compliance (docs/deep-dives/contributing/testing.ja.md):
 - No unittest.mock / MagicMock / AsyncMock / patch.
 - Real ``asyncio.Lock`` instances via the public ``get_agent_lock`` surface.
-- No private-state assertions (``_AGENT_LOCKS`` internals not touched).
+- No private-state assertions (``_LOCKS_BY_LOOP`` internals not touched).
 - No ``len(x) == N`` count pins; behavioral / identity assertions only.
 - Each test docstring first line is exactly ``Tier 2: ...``.
 """
@@ -35,8 +39,9 @@ from reyn.runtime.agent_locks import get_agent_lock
 # ---------------------------------------------------------------------------
 
 
-def test_same_name_returns_same_lock() -> None:
-    """Tier 2: get_agent_lock returns the identical lock object on repeated calls."""
+@pytest.mark.asyncio
+async def test_same_name_returns_same_lock() -> None:
+    """Tier 2: get_agent_lock returns the identical lock object on repeated calls (same loop)."""
     lock_first = get_agent_lock("agent-alpha")
     lock_second = get_agent_lock("agent-alpha")
     assert lock_first is lock_second, (
@@ -50,7 +55,8 @@ def test_same_name_returns_same_lock() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_different_names_return_distinct_locks() -> None:
+@pytest.mark.asyncio
+async def test_different_names_return_distinct_locks() -> None:
     """Tier 2: get_agent_lock returns distinct lock objects for different agent names."""
     lock_a = get_agent_lock("agent-one")
     lock_b = get_agent_lock("agent-two")
@@ -65,8 +71,9 @@ def test_different_names_return_distinct_locks() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_and_a2a_share_same_lock_registry() -> None:
-    """Tier 2: MCP and A2A obtain the same lock object for the same agent_name.
+@pytest.mark.asyncio
+async def test_mcp_and_a2a_share_same_lock_registry() -> None:
+    """Tier 2: MCP and A2A obtain the same lock object for the same agent_name (same loop).
 
     This is the central cross-transport guarantee of #1128 PR-b: both
     mcp_server and a2a import ``get_agent_lock`` (aliased as
@@ -137,3 +144,47 @@ async def test_concurrent_lock_acquirers_are_serialized() -> None:
         "second_waiter entered the critical section before first_holder released "
         "the lock — the per-agent lock is not serializing concurrent coroutines"
     )
+
+
+# ---------------------------------------------------------------------------
+# (e) #1762 regression: a contended lock is reusable across distinct loops
+# ---------------------------------------------------------------------------
+
+
+def test_agent_lock_reusable_across_event_loops() -> None:
+    """Tier 2: a contended agent lock survives distinct event loops (#1762).
+
+    Before #1762 the registry keyed locks by name only, so a lock created under
+    one event loop was cached and reused under the next. An ``asyncio.Lock``
+    binds to the loop a *waiter* registers on, so the second loop's waiter raised
+    ``"... is bound to a different event loop"``. This is exactly pytest-asyncio's
+    pattern (a fresh loop per test) → an order-dependent flake.
+
+    This test drives the SAME agent name through two separate ``asyncio.run``
+    loops, each with a contended acquire (a holder + a waiter, so the lock's
+    loop-binding path is exercised). Loop-aware keying must make both runs pass.
+    Run sync (two real loops via ``asyncio.run``) since the bug is precisely a
+    cross-loop one — a single ``@pytest.mark.asyncio`` loop could not surface it.
+    """
+    agent = "cross-loop-regression-agent-1762"
+
+    async def contended_once() -> None:
+        lock = get_agent_lock(agent)
+        first_in = asyncio.Event()
+
+        async def holder() -> None:
+            async with lock:
+                first_in.set()
+                await asyncio.sleep(0.01)
+
+        async def waiter() -> None:
+            await first_in.wait()  # ensure holder holds → this acquire must WAIT
+            async with lock:       # the waiting path is what binds the lock to the loop
+                pass
+
+        await asyncio.gather(holder(), waiter())
+
+    # Two separate event loops, same agent name. Pre-#1762 the second run raised
+    # RuntimeError("... bound to a different event loop"); loop-aware keying passes.
+    asyncio.run(contended_once())
+    asyncio.run(contended_once())


### PR DESCRIPTION
**[dogfood-coder]** — Closes #1762. (lead-coder root-caused; impl + verification by sandbox_2/dogfood-coder, proxy/test env.)

## Root cause
The shared per-agent lock registry (`reyn.runtime.agent_locks`) keyed `asyncio.Lock` objects by agent name in one module-level dict. An `asyncio.Lock` binds to the event loop a **waiter** registers on; caching one lock across loops raises `"... is bound to a different event loop"` once a second loop has a contended acquire. Production never hits this (single process-wide loop), but pytest-asyncio gives every test a fresh loop → a lock bound under one test's loop trips under the next = an order-dependent flake.

## Fix (structural, not band-aid)
Key the registry by the **running event loop** (`WeakKeyDictionary[loop → {name: lock}]` → dead loops' locks GC'd). Each loop gets its own lock object: identity holds **within** a loop (all the cross-transport serialization guarantee needs — production is one loop); cross-loop reuse can no longer occur. `get_agent_lock` now requires a running loop, which every transport caller already has (both `mcp_server` + `a2a` acquire inside `async with`).

## Tests
- 3 identity tests → async (they exercised an artificial no-loop path; production always calls in-loop).
- New regression test `test_agent_lock_reusable_across_event_loops`: drives the same agent name through two `asyncio.run` loops with a contended acquire.
- Cross-transport identity (MCP↔agent_locks same lock) + serialization invariants preserved.

## Verification (primary evidence)
- **Falsification**: gate test FAILS pre-fix with the exact `RuntimeError: ... is bound to a different event loop`; PASSES post-fix (stash-revert A/B on the production file only).
- 5/5 stable across N-runs (5×) **and** both file orderings.
- Broader lock-driving slice (mcp/router/chat + agent_locks) green, no loop-bind, no regression.
- `ruff check` clean on both files.

## Test plan
- [x] gate test falsified pre-fix → passes post-fix
- [x] N-run (5×) + order-variation stable
- [x] broader lock-driving slice no-regression
- [x] ruff clean
- [ ] full CI green (CI will confirm)

---
PR self-check: docstrings declare Tier (2); no Tier-4/mock/private-state assertions added; identity invariants preserved (not weakened); regression gate is falsified (real, not tautological).

🤖 Generated with [Claude Code](https://claude.com/claude-code)