### PR TITLE
refactor(1794): S2 — SkillRuntime → reyn.skill.skill_runtime (budget TYPE_CHECKING-gate)

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -20,12 +20,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # import-cost-free hints for type checkers / IDEs
     from reyn.core.kernel.runtime import RunResult
     from reyn.schemas.models import Phase, Skill, SkillGraph
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
 __all__ = ["Skill", "Phase", "SkillGraph", "SkillRuntime", "RunResult"]
 
 _LAZY_ATTRS = {
-    "SkillRuntime": "reyn.skill_runtime",
+    "SkillRuntime": "reyn.skill.skill_runtime",
     "RunResult": "reyn.core.kernel.runtime",
     "Phase": "reyn.schemas.models",
     "Skill": "reyn.schemas.models",

--- a/src/reyn/interfaces/cli/commands/cron.py
+++ b/src/reyn/interfaces/cli/commands/cron.py
@@ -279,7 +279,7 @@ def _build_runner():
         from reyn.interfaces.cli.logger_factory import make_logger
         from reyn.interfaces.cli.skill_loader import resolve_skill_path
         from reyn.llm.model_resolver import ModelResolver
-        from reyn.skill_runtime import SkillRuntime
+        from reyn.skill.skill_runtime import SkillRuntime
         from reyn.user_intervention import StdinInterventionBus
 
         config = load_config()

--- a/src/reyn/interfaces/cli/commands/eval.py
+++ b/src/reyn/interfaces/cli/commands/eval.py
@@ -254,7 +254,7 @@ def _run_case(
     """Run a single eval case; return a result record."""
     from reyn.config import _find_project_root, load_project_context
     from reyn.llm.llm import run_async
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
     from reyn.user_intervention import StdinInterventionBus
 
     case_id = _make_case_id(case)
@@ -812,7 +812,7 @@ def _run_spec_case(
 ) -> tuple[dict, object, float | None]:
     from reyn.config import _find_project_root, load_project_context
     from reyn.llm.llm import run_async
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
     from reyn.user_intervention import StdinInterventionBus
 
     print(f"━━━ case: {case.name} ━━━")

--- a/src/reyn/interfaces/cli/commands/eval_benchmark.py
+++ b/src/reyn/interfaces/cli/commands/eval_benchmark.py
@@ -695,7 +695,7 @@ async def _run_single_task(
     instead of emitting a non-faithful PASS/FAIL.
     """
     from reyn.config import _find_project_root, load_project_context
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
     async with semaphore:
         # Build input artifact

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -675,7 +675,7 @@ def run_install(args: argparse.Namespace) -> None:
     from reyn.security.permissions.permissions import PermissionResolver
     from reyn.skill.skill_paths import SkillNotFoundError, is_stdlib_skill
     from reyn.skill.skill_paths import resolve_skill_path as _resolve_skill_path_raw
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
     from reyn.user_intervention import StdinInterventionBus
 
     from ..logger_factory import make_logger

--- a/src/reyn/interfaces/cli/commands/run.py
+++ b/src/reyn/interfaces/cli/commands/run.py
@@ -134,7 +134,7 @@ def run(args: argparse.Namespace) -> None:
         from reyn.skill.skill_paths import is_stdlib_skill
         unsafe_python = is_stdlib_skill(loaded.skill_md.parent)
     from reyn.config import _find_project_root, load_project_context
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
     from reyn.user_intervention import StdinInterventionBus
     project_root = _find_project_root(Path.cwd())
     project_context = load_project_context(session.config, project_root)

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -48,7 +48,7 @@ def _make_cron_runner():
         from reyn.core.compiler import load_dsl_skill
         from reyn.security.permissions.permissions import PermissionResolver
         from reyn.skill.skill_paths import resolve_skill_path
-        from reyn.skill_runtime import SkillRuntime
+        from reyn.skill.skill_runtime import SkillRuntime
 
         cfg = load_config()
         project_root = _find_project_root(_Path.cwd())

--- a/src/reyn/runtime/services/skill_runner.py
+++ b/src/reyn/runtime/services/skill_runner.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from reyn.runtime.budget.budget import BudgetGateway
     from reyn.schemas.models import Skill
     from reyn.skill.skill_registry import SkillRegistry
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
 logger = logging.getLogger(__name__)
 
@@ -423,7 +423,7 @@ class SkillRunner:
         # flight — TUI `remove_async_task(run_id)` then failed to find rows
         # by key. Funneling through the canonical eliminates the
         # cross-layer mismatch class.
-        from reyn.skill_runtime import SkillRuntime as _SkillRuntime
+        from reyn.skill.skill_runtime import SkillRuntime as _SkillRuntime
         run_id = _SkillRuntime._make_run_id(skill_name)
         self._events.emit("skill_run_spawned", run_id=run_id, skill=skill_name)
         self.running_skills_started_at[run_id] = time.monotonic()
@@ -594,7 +594,7 @@ class SkillRunner:
         # tui-coder finding #1 fix (2026-05-28): canonical run_id form via
         # SkillRuntime._make_run_id (see sibling spawn site above for full
         # rationale).
-        from reyn.skill_runtime import SkillRuntime as _SkillRuntime
+        from reyn.skill.skill_runtime import SkillRuntime as _SkillRuntime
         run_id = _SkillRuntime._make_run_id(skill_name)
         self._events.emit(
             "skill_run_spawned", run_id=run_id, skill=skill_name,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -75,7 +75,7 @@ from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
 from reyn.skill.skill_paths import SkillNotFoundError, resolve_skill_path, stdlib_root
 from reyn.skill.skill_registry import SkillRegistry
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 from reyn.user_intervention import (
     InterventionAnswer,
     InterventionChoice,

--- a/src/reyn/skill/skill_runtime.py
+++ b/src/reyn/skill/skill_runtime.py
@@ -7,12 +7,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.config import OnLimitConfig, SafetyConfig
-from reyn.runtime.budget.budget import BudgetTracker
 
 if TYPE_CHECKING:
     from reyn.config import MultimodalConfig, SandboxConfig
     from reyn.data.workspace.media_store import MediaStore
     from reyn.environment.backend import EnvironmentBackend
+
+    # #1794 S2: annotation-only (budget_tracker is held + forwarded, never
+    # called) → TYPE_CHECKING-gated so reyn.skill takes no runtime dependency
+    # on reyn.runtime (the layer-direction invariant).
+    from reyn.runtime.budget.budget import BudgetTracker
     from reyn.security.sandbox.backend import SandboxBackend
     from reyn.security.secrets.store import ScopedSecretStore
 from reyn.core.events.event_store import EventStore

--- a/src/reyn/skill/sub_skill_runner.py
+++ b/src/reyn/skill/sub_skill_runner.py
@@ -71,7 +71,7 @@ async def invoke_sub_skill(
     require approvals to be in place beforehand via reyn.yaml / reyn.local.yaml
     or .reyn/approvals.yaml (per documented permission model).
     """
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
     agent = SkillRuntime(
         model=model,

--- a/tests/test_agent_from_config_wiring_997.py
+++ b/tests/test_agent_from_config_wiring_997.py
@@ -21,7 +21,7 @@ No mocks — real ReynConfig + real SkillRuntime.
 from __future__ import annotations
 
 from reyn.config import ReynConfig
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 
 def test_from_config_model_defaults_to_config() -> None:

--- a/tests/test_events_state_dir_1132.py
+++ b/tests/test_events_state_dir_1132.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 
 def test_state_dir_honors_workspace_state_dir(tmp_path: Path) -> None:

--- a/tests/test_fp0016_d_secret_store_threading.py
+++ b/tests/test_fp0016_d_secret_store_threading.py
@@ -103,7 +103,7 @@ def _make_preprocessor_executor(
 
 def test_agent_default_secret_store_is_none() -> None:
     """Tier 2: SkillRuntime(secret_store=None) is the default; _secret_store is None."""
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
     agent = SkillRuntime(model="standard")
     assert agent.secret_store is None
@@ -111,7 +111,7 @@ def test_agent_default_secret_store_is_none() -> None:
 
 def test_agent_explicit_secret_store_is_stored() -> None:
     """Tier 2: SkillRuntime(secret_store=<store>) stores the reference on _secret_store."""
-    from reyn.skill_runtime import SkillRuntime
+    from reyn.skill.skill_runtime import SkillRuntime
 
     store = _make_store(["API_KEY"])
     agent = SkillRuntime(model="standard", secret_store=store)

--- a/tests/test_python_harness_no_litellm_import.py
+++ b/tests/test_python_harness_no_litellm_import.py
@@ -46,12 +46,12 @@ def test_harness_import_does_not_load_agent_llm_chain():
     ``Agent -> llm -> httpx`` (~0.5s), which under the in-container venv path on
     an emulated host inflated past the ~5s step timeout. The package __init__s
     are now PEP 562-lazy, so importing the harness must NOT transitively load
-    ``reyn.skill_runtime`` / ``reyn.llm`` / ``httpx``. This is the structural invariant
+    ``reyn.skill.skill_runtime`` / ``reyn.llm`` / ``httpx``. This is the structural invariant
     (robust to host speed); the timing guard below is a coarse backstop.
     """
     code = (
         "import reyn.core.kernel._python_harness; import sys; "
-        "leaked = [m for m in ('reyn.skill_runtime', 'reyn.llm', 'reyn.llm.llm', 'httpx') "
+        "leaked = [m for m in ('reyn.skill.skill_runtime', 'reyn.llm', 'reyn.llm.llm', 'httpx') "
         "          if m in sys.modules]; "
         "assert not leaked, 'harness import eagerly loaded heavy chain: ' + str(leaked)"
     )

--- a/tests/test_routerloop_convergence_replay_1092.py
+++ b/tests/test_routerloop_convergence_replay_1092.py
@@ -59,7 +59,7 @@ import reyn.schemas.models as _models
 from reyn.config import ReynConfig
 from reyn.dev.testing.replay import REPLAY_DATETIME
 from reyn.schemas.models import Phase, Skill, SkillGraph
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 _SKILL_NAME = "converge_replay"
 # Direct-to-Google standard model (GOOGLE_API_KEY), the free dogfood workhorse.

--- a/tests/test_routerloop_convergence_threading_1092.py
+++ b/tests/test_routerloop_convergence_threading_1092.py
@@ -24,7 +24,7 @@ from reyn.config import ReynConfig
 from reyn.llm.llm import LLMCallResult, LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.schemas.models import Phase, Skill, SkillGraph
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 _SKILL_NAME = "converge_thread"
 

--- a/tests/test_run_id_propagation_chat_to_agent.py
+++ b/tests/test_run_id_propagation_chat_to_agent.py
@@ -36,7 +36,7 @@ import asyncio
 
 import pytest
 
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 # ── 1. SkillRuntime.__init__ accepts run_id ─────────────────────────────────────
 
@@ -92,7 +92,7 @@ async def test_agent_run_honors_constructor_run_id() -> None:
     # so we capture run_id immediately after the resolution step but
     # before any heavy work. (= no mocks; we're injecting a known-stop
     # callable via the module's import path.)
-    import reyn.skill_runtime as agent_mod
+    import reyn.skill.skill_runtime as agent_mod
     real_event_store = agent_mod.EventStore
     agent_mod.EventStore = _capture_and_stop  # type: ignore[assignment]
 
@@ -138,7 +138,7 @@ async def test_agent_run_kwarg_overrides_constructor_run_id() -> None:
         captured["run_id"] = agent.run_id
         raise _StopSentinel
 
-    import reyn.skill_runtime as agent_mod
+    import reyn.skill.skill_runtime as agent_mod
     real_event_store = agent_mod.EventStore
     agent_mod.EventStore = _capture_and_stop  # type: ignore[assignment]
 
@@ -180,7 +180,7 @@ async def test_agent_run_falls_back_to_make_run_id_when_none() -> None:
         captured["run_id"] = agent.run_id
         raise _StopSentinel
 
-    import reyn.skill_runtime as agent_mod
+    import reyn.skill.skill_runtime as agent_mod
     real_event_store = agent_mod.EventStore
     agent_mod.EventStore = _capture_and_stop  # type: ignore[assignment]
 

--- a/tests/test_skill_runner_canonical_run_id.py
+++ b/tests/test_skill_runner_canonical_run_id.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from reyn.skill_runtime import SkillRuntime
+from reyn.skill.skill_runtime import SkillRuntime
 
 # Canonical run_id form: YYYYMMDDTHHMMSSffffffZ_<skill_name>_<4hex>
 # - timestamp: 14 base digits + 6 microsecond digits + Z = 21 chars


### PR DESCRIPTION
**[e2e-coder]** — #1794 skill-execution consolidation **stage 2** (per FP-0049). Moves the public `SkillRuntime` entry from the loose top-level module into `reyn.skill`, with its one `reyn.runtime` edge resolved by **TYPE_CHECKING-gating** (no inversion — the annotation-only path lead confirmed).

## What
- `git mv src/reyn/skill_runtime.py → src/reyn/skill/skill_runtime.py`.
- The only `reyn.runtime` import — `from reyn.runtime.budget.budget import BudgetTracker` — is **annotation-only** (`budget_tracker` is held + forwarded, never called; used only in two `: BudgetTracker | None` hints; lazy via `from __future__ import annotations`). Moved under `if TYPE_CHECKING:` → `reyn.skill` takes **zero runtime dependency** on `reyn.runtime`.
- Repoint all **18 importers** `reyn.skill_runtime` → `reyn.skill.skill_runtime` (incl. `reyn/__init__`'s lazy `SkillRuntime` re-export + `reyn.skill.sub_skill_runner`, now intra-package).

## Gate
- ✅ **Layer gate PASS** — the S1 `test_skill_layer_independence` confirms `reyn.skill` (incl. the moved skill_runtime) has 0 executed `reyn.runtime` imports (the budget edge stays green as TYPE_CHECKING, as designed).
- ✅ Straggler 0 (`verify_package_move reyn.skill_runtime --new reyn.skill.skill_runtime`)
- ✅ Replay green (behavior-preserving — the gate is annotation-only); 478 pass across importer areas (cli/session/skill_runner/eval/run_id/replay); ruff clean
- [ ] Full CI green — pending

> One local `swebench_missing_honest_skip` failure is **pre-existing env** (swebench installed locally → the missing-skip test takes the real-eval path; verified **identical on clean base** with S2 stashed). CI without the `eval` extra honest-skips → passes.

Builds on S1 (#1836, merged). Next: S3 (skill_runner — outbox a-vs-b'' **design-confirm before starting**). Refs #1794.