### PR TITLE
refactor(1794): S3 — skill_runner → reyn.skill (3 runtime-edge inversions)

### DIFF
--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -14,7 +14,6 @@ from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 from reyn.runtime.services.router_host_adapter import RouterHostAdapter
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 from reyn.runtime.services.skill_plan_glue import SkillPlanGlue
-from reyn.runtime.services.skill_runner import SkillRunner
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
 from reyn.services.compaction.engine import (
     ChatSummary,
@@ -41,7 +40,6 @@ __all__ = [
     "RouterHostAdapter",
     "RouterLoopDriver",
     "SkillPlanGlue",
-    "SkillRunner",
     "SnapshotJournal",
     "_PendingChain",
 ]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -69,12 +69,13 @@ from reyn.runtime.services import (
 )
 from reyn.runtime.services.a2a_handler import A2AHandler
 from reyn.runtime.services.chain_manager import _PendingChain
-from reyn.runtime.services.skill_runner import SkillRunner
 from reyn.runtime.session_buses import AgentRequestBus, ChatInterventionBus
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
+from reyn.skill.skill_outbound import SkillOutboundMessage
 from reyn.skill.skill_paths import SkillNotFoundError, resolve_skill_path, stdlib_root
 from reyn.skill.skill_registry import SkillRegistry
+from reyn.skill.skill_runner import SkillRunner
 from reyn.skill.skill_runtime import SkillRuntime
 from reyn.user_intervention import (
     InterventionAnswer,
@@ -1353,13 +1354,17 @@ class Session:
             budget=self._budget,
             state_log=self._state_log,
             build_agent_fn=self._build_agent_for_skill_runner,
-            put_outbox=self._put_outbox,
             enqueue_skill_completed=self._enqueue_skill_completed,
             accumulate=self._accumulate,
             drop_interventions_for_run=self._drop_interventions_for_run,
             get_skill_registry=self.get_skill_registry,
             ask_budget_extension=self._ask_budget_extension,
-            outbox=self.outbox,
+            # #1794 S3: runtime-boundary seams — SkillRunner (now in reyn.skill)
+            # stays free of reyn.runtime; the session supplies the runtime objects.
+            put_outbox=self._skill_outbox_adapter,
+            make_subscribers=self._make_skill_subscribers,
+            format_refusal=format_refusal_message,
+            format_warn=format_warn_message,
         )
 
         # F2: Delegation tracking for RouterLoop runs. Set to a list before
@@ -3184,6 +3189,25 @@ class Session:
             run_id=run_id,
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,
         )
+
+    async def _skill_outbox_adapter(self, msg: "SkillOutboundMessage") -> None:
+        """#1794 S3: adapt a skill's transport-neutral ``SkillOutboundMessage``
+        to the runtime ``OutboxMessage`` and enqueue. Skills emit kind/text/meta
+        only and never set ``reply_to``, so the adapter passes ``reply_to=None`` —
+        behavior-identical to the prior direct ``OutboxMessage`` constructs that
+        lived inside SkillRunner before it moved to ``reyn.skill``."""
+        await self._put_outbox(
+            OutboxMessage(kind=msg.kind, text=msg.text, meta=msg.meta),
+        )
+
+    def _make_skill_subscribers(
+        self, skill_name: str, run_id: "str | None" = None,
+    ) -> list:
+        """#1794 S3: build the chat-event subscribers for a skill spawn — the
+        ``ChatEventForwarder`` construction that ``SkillRunner`` (now in
+        ``reyn.skill``) DI's so it takes no ``reyn.runtime`` dependency."""
+        from reyn.runtime.forwarder import ChatEventForwarder
+        return [ChatEventForwarder(skill_name, self.outbox, run_id=run_id)]
 
     async def _put_outbox(self, msg: OutboxMessage) -> None:
         """Drop transient kinds while detached; durable kinds are queued.

--- a/src/reyn/skill/skill_outbound.py
+++ b/src/reyn/skill/skill_outbound.py
@@ -1,0 +1,23 @@
+"""SkillOutboundMessage — a skill's outbound message, transport-neutral (#1794).
+
+A skill emits status / progress / result messages during a spawn. This is the
+layer-neutral record it produces: ``kind`` + ``text`` + ``meta`` only, with no
+transport coupling. The runtime boundary (the ``put_outbox`` adapter wired on
+``Session``) converts it to the runtime's ``OutboxMessage`` (which carries the
+transport ``reply_to``) when enqueuing — so ``reyn.skill`` stays free of the
+runtime/transport ``OutboxMessage`` + ``TransportRef`` VOs (the #1794 layer
+direction). A skill never sets ``reply_to``; the adapter supplies ``None``,
+which is behavior-identical to the prior direct ``OutboxMessage`` constructs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class SkillOutboundMessage:
+    """A transport-neutral outbound message produced inside a skill spawn."""
+
+    kind: str
+    text: str
+    meta: dict = field(default_factory=dict)

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -1,10 +1,9 @@
 """SkillRunner — skill task lifecycle (launch / track / cancel).
 
-Extracted from Session (FP-0019 Wave 1b). Owns the running_skills
-dict and stdlib skill invocation path. Required as foundation for
-InterventionHandler (Wave 2) and AutoResumeHandler (Wave 3).
+Owns the running_skills dict and the stdlib skill invocation path; the Session
+delegates skill spawns to it.
 
-Intervention coupling audit (FP-0019 Wave 1b):
+Intervention coupling:
     _run_stdlib_skill and _spawn_skill/_run_one_skill both pass a
     ChatInterventionBus to _build_agent. The bus holds a reference to
     Session (for _dispatch_intervention and
@@ -32,7 +31,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable
 
 from reyn.core.compiler import load_dsl_skill
 from reyn.core.events.events import EventLog
-from reyn.runtime.outbox import OutboxMessage
+from reyn.skill.skill_outbound import SkillOutboundMessage
 from reyn.skill.skill_paths import SkillNotFoundError, resolve_skill_path, stdlib_root
 
 if TYPE_CHECKING:
@@ -46,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 def _run_meta(run_id: str | None, skill_name: str | None) -> dict:
-    """Standard ``meta`` payload for OutboxMessage produced inside a skill spawn."""
+    """Standard ``meta`` payload for SkillOutboundMessage produced inside a skill spawn."""
     if run_id is None:
         return {"skill_name": skill_name} if skill_name else {}
     return {
@@ -85,7 +84,7 @@ class SkillRunner:
         session wrapper). The session supplies this callback so
         SkillRunner never references ``ChatInterventionBus`` directly.
     put_outbox:
-        Async callable ``(OutboxMessage) -> None``.
+        Async callable ``(SkillOutboundMessage) -> None``.
     enqueue_skill_completed:
         Async callable with keyword args ``run_id``, ``skill``,
         ``chain_id``, ``status``, ``data``.
@@ -97,8 +96,15 @@ class SkillRunner:
         Zero-arg callable returning ``SkillRegistry | None``.
     ask_budget_extension:
         Async callable ``(chain_id, skill_name, check) -> bool``.
-    outbox:
-        Raw ``asyncio.Queue`` for :meth:`run_stdlib` subscriber wiring.
+    make_subscribers:
+        ``(skill_name, run_id=None) -> list`` — builds the chat-event
+        subscribers for a spawn (the session supplies a factory that
+        constructs the runtime ``ChatEventForwarder``, so SkillRunner never
+        imports it — #1794 layer direction).
+    format_refusal / format_warn:
+        Budget message formatters (``(check) -> str`` / ``(dim, context) ->
+        str``); the session supplies the runtime ``reyn.runtime.budget``
+        formatters so SkillRunner stays free of that import.
     """
 
     def __init__(
@@ -112,13 +118,15 @@ class SkillRunner:
         budget: BudgetGateway,
         state_log: StateLog | None,
         build_agent_fn: Callable[..., SkillRuntime],
-        put_outbox: Callable[[OutboxMessage], Awaitable[None]],
+        put_outbox: Callable[[SkillOutboundMessage], Awaitable[None]],
         enqueue_skill_completed: Callable[..., Awaitable[None]],
         accumulate: Callable,
         drop_interventions_for_run: Callable[[str | None], None],
         get_skill_registry: Callable[[], SkillRegistry | None],
         ask_budget_extension: Callable[..., Awaitable[bool]],
-        outbox: asyncio.Queue,
+        make_subscribers: Callable[..., list],
+        format_refusal: Callable[..., str],
+        format_warn: Callable[..., str],
     ) -> None:
         self._events = event_log
         self._agent_name = agent_name
@@ -134,7 +142,15 @@ class SkillRunner:
         self._drop_interventions_for_run = drop_interventions_for_run
         self._get_skill_registry = get_skill_registry
         self._ask_budget_extension = ask_budget_extension
-        self._outbox = outbox
+        # #1794 S3: DI'd runtime-boundary seams so reyn.skill.skill_runner takes
+        # no executed reyn.runtime dependency (the layer invariant):
+        #   make_subscribers → ChatEventForwarder construction (forwarder is a
+        #     runtime object; Session supplies the factory).
+        #   format_refusal / format_warn → budget message formatters (take a
+        #     runtime BudgetCheck; kept type-opaque here via the callbacks).
+        self._make_subscribers = make_subscribers
+        self._format_refusal = format_refusal
+        self._format_warn = format_warn
 
         # Public dicts — slash commands (slash/skill.py, slash/tasks.py)
         # access these via ``session._skill_runner.*`` forwarding properties.
@@ -224,7 +240,7 @@ class SkillRunner:
         skill_name = spec.get("skill")
         input_artifact = spec.get("input")
         if not skill_name or not isinstance(input_artifact, dict):
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="error", text=f"invalid skill spec: {spec}",
             ))
             return None
@@ -234,7 +250,7 @@ class SkillRunner:
             self._allowed_skills is not None
             and skill_name not in self._allowed_skills
         ):
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="error",
                 text=(
                     f"skill {skill_name!r} is not in allowed_skills for agent "
@@ -282,7 +298,6 @@ class SkillRunner:
                         chain_id=chain_id, skill=skill_name,
                     )
             if not check.allowed:
-                from reyn.runtime.budget.budget import format_refusal_message
                 self._events.emit(
                     "budget_exceeded",
                     dimension=check.hard_dimension,
@@ -290,22 +305,21 @@ class SkillRunner:
                     skill=skill_name,
                     chain_id=chain_id,
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error",
-                    text=format_refusal_message(check),
+                    text=self._format_refusal(check),
                     meta={"chain_id": chain_id, "skill": skill_name},
                 ))
                 return None
             for dim in check.warn_dimensions:
-                from reyn.runtime.budget.budget import format_warn_message
                 self._events.emit(
                     "budget_warn",
                     dimension=dim, chain_id=chain_id, skill=skill_name,
                     **check.context,
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="status",
-                    text=format_warn_message(dim, check.context),
+                    text=self._format_warn(dim, check.context),
                     meta={"chain_id": chain_id, "skill": skill_name},
                 ))
             self._budget.record_spawn(chain_id=chain_id, skill=skill_name)
@@ -336,7 +350,7 @@ class SkillRunner:
                 skill=skill_name,
                 detail=str(exc),
             )
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="error",
                 text=f"skill not found: {skill_name}",
                 meta={"chain_id": chain_id, "skill": skill_name},
@@ -360,7 +374,7 @@ class SkillRunner:
                 skill=skill_name,
                 detail=str(exc),
             )
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="error",
                 text=f"failed to load {skill_name}: {exc}",
                 meta={"chain_id": chain_id, "skill": skill_name},
@@ -397,7 +411,7 @@ class SkillRunner:
                     skill=skill_name,
                     detail=exc.message,
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error",
                     text=(
                         f"input validation failed for skill "
@@ -428,7 +442,7 @@ class SkillRunner:
         self._events.emit("skill_run_spawned", run_id=run_id, skill=skill_name)
         self.running_skills_started_at[run_id] = time.monotonic()
         self.running_skills_chain[run_id] = chain_id
-        await self._put_outbox(OutboxMessage(
+        await self._put_outbox(SkillOutboundMessage(
             kind="status", text="starting…",
             meta=_run_meta(run_id, skill_name),
         ))
@@ -520,8 +534,7 @@ class SkillRunner:
 
         subscribers = None
         if forward_events:
-            from reyn.runtime.forwarder import ChatEventForwarder
-            subscribers = [ChatEventForwarder(skill_name, self._outbox)]
+            subscribers = self._make_subscribers(skill_name)
 
         agent = self._build_agent_fn(
             run_id=None, skill_name=skill_name, subscribers=subscribers,
@@ -629,12 +642,9 @@ class SkillRunner:
                 "data": {"error": f"failed to load {skill_name}: {exc}"},
             }
 
-        from reyn.runtime.forwarder import ChatEventForwarder
         agent = self._build_agent_fn(
             run_id=run_id, skill_name=skill_name,
-            subscribers=[
-                ChatEventForwarder(skill_name, self._outbox, run_id=run_id),
-            ],
+            subscribers=self._make_subscribers(skill_name, run_id),
         )
 
         # Issue #214: forward the plan_step ContextVar so a blocking
@@ -706,17 +716,14 @@ class SkillRunner:
                 "skill_run_failed", run_id=run_id, skill=skill_name,
                 error=f"resume failed to load: {exc}",
             )
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="error", text=f"resume failed: {exc}", meta=meta,
             ))
             return
 
-        from reyn.runtime.forwarder import ChatEventForwarder
         agent = self._build_agent_fn(
             run_id=run_id, skill_name=skill_name,
-            subscribers=[
-                ChatEventForwarder(skill_name, self._outbox, run_id=run_id),
-            ],
+            subscribers=self._make_subscribers(skill_name, run_id),
         )
 
         async def _runner():
@@ -730,7 +737,7 @@ class SkillRunner:
                     run_id=run_id,
                 )
             except asyncio.CancelledError:
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="status", text="cancelled", meta=meta,
                 ))
                 raise
@@ -739,7 +746,7 @@ class SkillRunner:
                     "skill_run_failed", run_id=run_id, skill=skill_name,
                     error=str(exc),
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error", text=f"resume failed: {exc}", meta=meta,
                 ))
 
@@ -749,7 +756,7 @@ class SkillRunner:
         # by the timeout watchdog). If a future re-issue path needs to
         # carry chain_id across resume, plumb it through ``decision``.
         self.running_skills_chain[run_id] = None
-        await self._put_outbox(OutboxMessage(
+        await self._put_outbox(SkillOutboundMessage(
             kind="status", text="resuming…", meta=meta,
         ))
         task = asyncio.create_task(_runner())
@@ -798,7 +805,7 @@ class SkillRunner:
                     "skill_run_failed", run_id=run_id, skill=skill_name,
                     error=f"skill not found: {skill_name}",
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error", text=f"skill not found: {skill_name}", meta=meta,
                 ))
                 await self._enqueue_skill_completed(
@@ -813,7 +820,7 @@ class SkillRunner:
                     "skill_run_failed", run_id=run_id, skill=skill_name,
                     error=f"failed to load: {exc}",
                 )
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error", text=f"failed to load {skill_name}: {exc}", meta=meta,
                 ))
                 await self._enqueue_skill_completed(
@@ -822,10 +829,9 @@ class SkillRunner:
                 )
                 return
 
-        from reyn.runtime.forwarder import ChatEventForwarder
         agent = self._build_agent_fn(
             run_id=run_id, skill_name=skill_name,
-            subscribers=[ChatEventForwarder(skill_name, self._outbox, run_id=run_id)],
+            subscribers=self._make_subscribers(skill_name, run_id),
         )
         # B33 W6 NEW-1 fix: track the terminal (status, data) pair so
         # _enqueue_skill_completed fires even when an intermediate await
@@ -853,7 +859,7 @@ class SkillRunner:
                 plan_step=_plan_step,
             )
         except asyncio.CancelledError:
-            await self._put_outbox(OutboxMessage(
+            await self._put_outbox(SkillOutboundMessage(
                 kind="status", text="cancelled", meta=meta,
             ))
             raise  # CancelledError: no completion enqueue (task was discarded)
@@ -864,7 +870,7 @@ class SkillRunner:
             _terminal_data = {"error": str(exc)}
             self._events.emit("skill_run_failed", run_id=run_id, skill=skill_name, error=str(exc))
             try:
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="error", text=f"failed: {exc}", meta=meta,
                 ))
             except Exception:  # noqa: BLE001 — outbox failure must not suppress enqueue
@@ -875,7 +881,7 @@ class SkillRunner:
             # SkillActivityRow spinning forever. Enqueue the trace
             # directly so the TUI finishes the row.
             try:
-                await self._put_outbox(OutboxMessage(
+                await self._put_outbox(SkillOutboundMessage(
                     kind="trace", text="skill done: aborted", meta=meta,
                 ))
             except Exception:  # noqa: BLE001 — same defense as above
@@ -890,7 +896,7 @@ class SkillRunner:
                     error="budget_exceeded",
                 )
                 try:
-                    await self._put_outbox(OutboxMessage(
+                    await self._put_outbox(SkillOutboundMessage(
                         kind="error",
                         text=result.error or "budget exceeded",
                         meta=meta,

--- a/tests/test_phase_no_progress_completion_inject.py
+++ b/tests/test_phase_no_progress_completion_inject.py
@@ -6,7 +6,7 @@ phase_no_progress abort path (WorkflowAbortedError) that B33 W6 observed
 skipping ``skill_completion_injected``.
 
 Root cause (B33 W6 analysis):
-    src/reyn/runtime/services/skill_runner.py — the ``except Exception`` block
+    src/reyn/skill/skill_runner.py — the ``except Exception`` block
     for the agent.run() call path placed ``_enqueue_skill_completed`` AFTER
     ``await _put_outbox(...)``. If ``_put_outbox`` raised (e.g. closed session,
     outbox queue issue), the enqueue was silently skipped.
@@ -104,7 +104,7 @@ async def test_skill_completed_enqueued_on_workflow_aborted_phase_no_progress(
     """
     monkeypatch.chdir(tmp_path)
 
-    import reyn.runtime.services.skill_runner as skill_runner_mod
+    import reyn.skill.skill_runner as skill_runner_mod
 
     dummy_skill_dir = tmp_path / "dummy_skill"
     dummy_skill_dir.mkdir()
@@ -178,7 +178,7 @@ async def test_skill_completion_injected_fires_on_workflow_aborted(
     """
     monkeypatch.chdir(tmp_path)
 
-    import reyn.runtime.services.skill_runner as skill_runner_mod
+    import reyn.skill.skill_runner as skill_runner_mod
 
     dummy_skill_dir = tmp_path / "dummy_skill"
     dummy_skill_dir.mkdir()
@@ -264,7 +264,7 @@ async def test_skill_completed_enqueued_even_when_put_outbox_raises(
     """
     monkeypatch.chdir(tmp_path)
 
-    import reyn.runtime.services.skill_runner as skill_runner_mod
+    import reyn.skill.skill_runner as skill_runner_mod
 
     dummy_skill_dir = tmp_path / "dummy_skill"
     dummy_skill_dir.mkdir()

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -1352,7 +1352,7 @@ async def test_skill_completed_inbox_enqueued_on_finish(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
 
-    import reyn.runtime.services.skill_runner as skill_runner_mod
+    import reyn.skill.skill_runner as skill_runner_mod
     from reyn.core.kernel.runtime import RunResult
 
     dummy_skill_dir = tmp_path / "dummy_skill"

--- a/tests/test_skill_outbound_adapter.py
+++ b/tests/test_skill_outbound_adapter.py
@@ -1,0 +1,72 @@
+"""Tier 2: the skill-outbound record + Session adapter (#1794 S3).
+
+Pins the runtime-boundary seam that lets SkillRunner live in reyn.skill without
+a reyn.runtime dependency: a skill emits the transport-neutral
+SkillOutboundMessage, and Session._skill_outbox_adapter converts it to the
+runtime OutboxMessage (reply_to=None) before enqueuing. Includes the falsify —
+bypassing the adapter (enqueuing the neutral record directly) fails, proving the
+adapter is load-bearing, not decorative.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.skill.skill_outbound import SkillOutboundMessage
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="t",
+        state_log=StateLog(tmp_path / "t.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+
+def test_skill_outbound_message_is_neutral():
+    """Tier 2: the record carries kind/text/meta only (no transport reply_to)."""
+    m = SkillOutboundMessage(kind="status", text="hi", meta={"a": 1})
+    assert (m.kind, m.text, m.meta) == ("status", "hi", {"a": 1})
+    assert not hasattr(m, "reply_to")
+
+
+@pytest.mark.asyncio
+async def test_adapter_round_trips_to_outbox_message(tmp_path):
+    """Tier 2: the adapter converts the neutral record → OutboxMessage with
+    kind/text/meta preserved and reply_to=None (behavior-identical to the prior
+    direct OutboxMessage constructs)."""
+    session = _make_session(tmp_path)
+    await session._skill_outbox_adapter(
+        SkillOutboundMessage(kind="error", text="boom", meta={"chain_id": "c1"}),
+    )
+    msg = session.outbox.get_nowait()
+    assert (msg.kind, msg.text, msg.meta) == ("error", "boom", {"chain_id": "c1"})
+    assert msg.reply_to is None
+
+
+@pytest.mark.asyncio
+async def test_adapter_is_load_bearing_falsify(tmp_path):
+    """Tier 2: FALSIFY — bypassing the adapter (enqueuing the neutral record
+    straight through _put_outbox) fails, because the record lacks the transport
+    reply_to the runtime outbox path reads. Proves the adapter is required."""
+    session = _make_session(tmp_path)
+    with pytest.raises(AttributeError):
+        await session._put_outbox(
+            SkillOutboundMessage(kind="status", text="x"),  # type: ignore[arg-type]
+        )
+
+
+def test_make_skill_subscribers_builds_forwarder(tmp_path):
+    """Tier 2: the subscriber factory builds a ChatEventForwarder for the skill
+    (the construction SkillRunner DI's so it stays reyn.runtime-free)."""
+    from reyn.runtime.forwarder import ChatEventForwarder
+
+    session = _make_session(tmp_path)
+    subs = session._make_skill_subscribers("demo_skill", run_id="r1")
+    forwarder = subs[0]
+    assert isinstance(forwarder, ChatEventForwarder)
+    assert forwarder.skill_name == "demo_skill"
+    assert forwarder.run_id == "r1"

--- a/tests/test_skill_runner_aborted_trace.py
+++ b/tests/test_skill_runner_aborted_trace.py
@@ -23,7 +23,8 @@ import asyncio
 from typing import Any
 
 from reyn.core.events.events import EventLog
-from reyn.runtime.services.skill_runner import SkillRunner
+from reyn.runtime.forwarder import ChatEventForwarder
+from reyn.skill.skill_runner import SkillRunner
 
 # ── Fakes (mirrors test_skill_runner_invariants.py style) ────────────────────
 
@@ -103,7 +104,11 @@ def _make_runner_with_raising_agent(exc: Exception):
         drop_interventions_for_run=_drop_interventions,
         get_skill_registry=_get_skill_registry,
         ask_budget_extension=_ask_budget_extension,
-        outbox=outbox,
+        make_subscribers=lambda skill_name, run_id=None: [
+            ChatEventForwarder(skill_name, outbox, run_id=run_id),
+        ],
+        format_refusal=lambda check: "refused",
+        format_warn=lambda dim, ctx: "warn",
     )
     return runner, outbox, completed_payloads
 
@@ -120,7 +125,7 @@ def test_unexpected_exception_emits_skill_done_aborted_trace(tmp_path, monkeypat
     both the error message AND the trace are present, in the same
     ``run_id`` meta.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "fake_skill"
     dummy_dir.mkdir()

--- a/tests/test_skill_runner_canonical_run_id.py
+++ b/tests/test_skill_runner_canonical_run_id.py
@@ -87,8 +87,7 @@ def test_skill_runner_does_not_construct_own_run_id() -> None:
     invariant against accidental reversal.
     """
     source = (
-        Path(__file__).parent.parent / "src" / "reyn" / "runtime" / "services"
-        / "skill_runner.py"
+        Path(__file__).parent.parent / "src" / "reyn" / "skill" / "skill_runner.py"
     ).read_text(encoding="utf-8")
     # The old bespoke construction signature: a strftime call that
     # generates the timestamp portion of a run_id, paired with
@@ -114,8 +113,7 @@ def test_skill_runner_references_canonical_constructor() -> None:
     aliased name like `_SkillRuntime`) appears in the file.
     """
     source = (
-        Path(__file__).parent.parent / "src" / "reyn" / "runtime" / "services"
-        / "skill_runner.py"
+        Path(__file__).parent.parent / "src" / "reyn" / "skill" / "skill_runner.py"
     ).read_text(encoding="utf-8")
     references_canonical = (
         "SkillRuntime._make_run_id" in source or "_SkillRuntime._make_run_id" in source

--- a/tests/test_skill_runner_invariants.py
+++ b/tests/test_skill_runner_invariants.py
@@ -14,7 +14,8 @@ from typing import Any
 import pytest
 
 from reyn.core.events.events import EventLog
-from reyn.runtime.services.skill_runner import SkillRunner
+from reyn.runtime.forwarder import ChatEventForwarder
+from reyn.skill.skill_runner import SkillRunner
 
 # ---------------------------------------------------------------------------
 # Helpers — minimal fakes and SkillRunner factory
@@ -130,7 +131,11 @@ def _make_runner(
         drop_interventions_for_run=_drop_interventions,
         get_skill_registry=_get_skill_registry,
         ask_budget_extension=_ask_budget_extension,
-        outbox=outbox,
+        make_subscribers=lambda skill_name, run_id=None: [
+            ChatEventForwarder(skill_name, outbox, run_id=run_id),
+        ],
+        format_refusal=lambda check: "refused",
+        format_warn=lambda dim, ctx: "warn",
     )
     return runner, events, outbox, completed_payloads
 
@@ -154,7 +159,7 @@ def test_dispatch_spawns_task_in_running_dict(tmp_path, monkeypatch):
     """
     # Patch resolve_skill_path and load_dsl_skill in skill_runner module so
     # the runner doesn't try to load a real skill file.
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "fake_skill"
     dummy_dir.mkdir()
@@ -207,7 +212,7 @@ def test_cancel_all_during_shutdown_graceful(tmp_path, monkeypatch):
     The done-callback (_drop_interventions_for_run) is exercised
     implicitly — if it raised, the gather would surface it.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "fake_skill"
     dummy_dir.mkdir()
@@ -251,7 +256,7 @@ def test_dispatch_emits_skill_run_spawned_event(tmp_path, monkeypatch):
     P6 invariant: every state change must produce an event. The spawn
     is the state change; the event must precede completion.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "fake_skill"
     dummy_dir.mkdir()
@@ -306,7 +311,7 @@ def test_wait_for_completion_emits_skill_run_completed(tmp_path, monkeypatch):
          ``skill_run_interrupted`` is NOT emitted.
       5. Asserting ``running_names()`` is empty after the wait.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "fake_skill"
     dummy_dir.mkdir()

--- a/tests/test_skill_runner_pre_spawn_validation.py
+++ b/tests/test_skill_runner_pre_spawn_validation.py
@@ -44,7 +44,7 @@ def test_spawn_no_schema_proceeds(tmp_path, monkeypatch):
     """Tier 2: when the loaded skill has no entry_input_schema, spawn()
     skips validation and proceeds to create the asyncio task (= legacy
     behavior preserved for skills without declared schemas)."""
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_no_schema"
     dummy_dir.mkdir()
@@ -76,7 +76,7 @@ def test_spawn_no_schema_proceeds(tmp_path, monkeypatch):
 def test_spawn_valid_input_proceeds(tmp_path, monkeypatch):
     """Tier 2: input that matches the entry_input_schema passes through
     pre-spawn validation; the asyncio task is created."""
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_with_schema"
     dummy_dir.mkdir()
@@ -115,7 +115,7 @@ def test_spawn_invalid_input_returns_structured_error(tmp_path, monkeypatch):
     pre-spawn. spawn() returns a structured error dict carrying
     schema_hint, NO asyncio task is created, and the
     skill_spawn_refused event fires with reason=input_schema_violation."""
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_strict"
     dummy_dir.mkdir()
@@ -165,7 +165,7 @@ def test_spawn_skill_not_found_returns_structured_error(tmp_path, monkeypatch):
     """Tier 2: SkillNotFoundError during pre-spawn skill load is
     converted to a structured error dict, NO task is created, and the
     skill_spawn_refused event fires with reason=skill_not_found."""
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     def _raise_not_found(name):
         raise sr_mod.SkillNotFoundError(name, [str(tmp_path)])
@@ -198,7 +198,7 @@ def test_spawn_for_router_propagates_pre_spawn_error(tmp_path, monkeypatch):
     sees the schema_hint in the same tool_result round-trip as its
     originating invoke_action call (= sync error path, no async
     [task_completed] correlation needed)."""
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_strict"
     dummy_dir.mkdir()
@@ -243,7 +243,7 @@ def test_spawn_passes_pre_loaded_skill_no_second_load(tmp_path, monkeypatch):
     ``pre_loaded_skill``, so the async task body skips the duplicate
     resolve_skill_path + load_dsl_skill that happened pre-issue-#644.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_reuse"
     dummy_dir.mkdir()
@@ -290,7 +290,7 @@ def test_run_one_skill_falls_back_to_load_when_pre_loaded_skill_absent(
     it still performs the resolve + load itself. Preserves backward
     compatibility for any non-spawn() entry path.
     """
-    import reyn.runtime.services.skill_runner as sr_mod
+    import reyn.skill.skill_runner as sr_mod
 
     dummy_dir = tmp_path / "skill_fallback"
     dummy_dir.mkdir()


### PR DESCRIPTION
**[e2e-coder]** — #1794 **stage 3** (the largest; per FP-0049 + the lead-endorsed 3-edge design-confirm). Moves the 919-LOC SkillRunner into `reyn.skill`, resolving **all three** of its executed `reyn.runtime` edges → zero runtime dependency (the layer gate is the completeness arbiter).

## The 3 inversions
1. **OutboxMessage (18 constructs) → `reyn.skill.SkillOutboundMessage` record + Session adapter**. `OutboxMessage` carries `reply_to: TransportRef`, so (a)-move-to-schemas would drag transport into the shared layer (186-import blast) — rejected. The 18 constructs are all `kind/text/meta` (no reply_to), so a neutral record is an exact fit; `Session._skill_outbox_adapter` converts → `OutboxMessage(reply_to=None)` at the put_outbox boundary (behavior-identical).
2. **ChatEventForwarder (4 constructs) → `make_subscribers` forwarder-factory callback** (Session supplies it; run_id default None = identical to the no-run_id site, verified).
3. **budget `format_refusal/warn_message` (called) → format callbacks** (Session passes the runtime formatters; agent default None = same).

`build_agent_fn` was already DI; all wiring is contained to the **single** SkillRunner-construct site. skill_runner module docstring rewritten to current-state.

## Gate
- ✅ **Layer gate PASS** — `reyn.skill` (incl skill_runner) executed `reyn.runtime` imports = **0** (the completeness arbiter — a missed 4th edge would go CI-red).
- ✅ Straggler 0 (`verify_package_move reyn.runtime.services.skill_runner --new reyn.skill.skill_runner`)
- ✅ **Replay green** (behavior-preserving — adapter reply_to=None + callback-DI of existing behavior)
- ✅ **`test_skill_outbound_adapter`** pins the record + adapter round-trip + **FALSIFY** (bypassing the adapter → AttributeError, proving it's load-bearing) + the forwarder factory
- ✅ Test fixtures + source-path tests repointed; 1758 pass across replay/skill/session/router; ruff + tier-audit clean
- [ ] Full CI green — pending

Builds on S1+S2 (merged). Next: **S4** (run_skill + skill_resolve op-backend delegation) closes #1794. Refs #1794.