### PR TITLE
fix(1752): per-turn budget consumers track the live /model override

### DIFF
--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -57,4 +57,9 @@ async def model_cmd(session: "Session", args: str) -> None:
         return
 
     session._model_override = requested
+    # #1752: the per-turn budget consumers (history buffer / context budget
+    # advisor) read the live resolved model via their model_fn, but the
+    # turn_budget engine bakes derived headroom at construction, so rebuild it
+    # for the new model's context window.
+    session._rebuild_turn_budget_engine_for_model()
     await reply(session, f"model → {requested} (this session — clears on restart)")

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -39,16 +39,24 @@ class ContextBudgetAdvisor:
         compaction: Any,             # CompactionConfig — use_chars4_estimate
         compaction_controller: Any,  # for engine.budgets + force_compact_now
         media_store: Any,            # MediaStore | None — for cap_tool_result
-        model: str,
+        model_fn: Callable[[], str],  # zero-arg → CURRENT resolved model (#1752)
         events: Any,                 # EventLog — for fallback budget + emit
         history_fn: Callable[[], list],  # zero-arg → current router-view history
     ) -> None:
         self._compaction = compaction
         self._compaction_controller = compaction_controller
         self._media_store = media_store
-        self._model = model
+        self._model_fn = model_fn
         self._events = events
         self._history_fn = history_fn
+
+    @property
+    def _model(self) -> str:
+        # #1752: resolve the model live each call so a /model override (which can
+        # change the context window) is reflected in budgeting. The session-side
+        # fn resolves the class → litellm string; without this the advisor would
+        # budget against the construction-time model after a /model switch.
+        return self._model_fn()
 
     # ── Internal helpers ─────────────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -144,7 +144,7 @@ class RouterHistoryBuffer:
         history_fn: Callable[[], list],   # zero-arg → raw history (all roles)
         compaction: Any,                  # CompactionConfig — use_chars4_estimate
         compaction_controller: Any,       # for engine.budgets
-        model: str,
+        model_fn: Callable[[], str],      # zero-arg → CURRENT resolved model (#1752)
         events: Any,                      # EventLog — for fallback tokens
         media_store: Any,                 # MediaStore | None — for _serialise_turn
         router_host: Any,                 # RouterHostAdapter — for build_system_prompt
@@ -155,7 +155,7 @@ class RouterHistoryBuffer:
         self._history_fn = history_fn
         self._compaction = compaction
         self._compaction_controller = compaction_controller
-        self._model = model
+        self._model_fn = model_fn
         self._events = events
         self._media_store = media_store
         self._router_host = router_host
@@ -165,6 +165,14 @@ class RouterHistoryBuffer:
         # (native re-attach) instead of a router-SP text section. ReasoningConfig
         # gates it (.continuity) and bounds it (.recent_turns). None → off.
         self._reasoning = reasoning
+
+    @property
+    def _model(self) -> str:
+        # #1752: resolve the model live each call so a /model override (which can
+        # change the context window) is reflected in token counting / trimming.
+        # The session-side fn resolves the class → litellm string; without this
+        # the buffer would count against the construction-time model.
+        return self._model_fn()
 
     # ── Internal helpers ─────────────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -394,6 +394,18 @@ class RouterHostAdapter:
         engine = self._turn_budget_engine
         return engine.budget.output_reserve if engine is not None else None
 
+    def set_turn_budget_engine(self, engine: Any) -> None:
+        """#1752: swap the chat turn_budget engine (rebuild-on-/model-switch).
+
+        The engine bakes derived headroom (max_input + wrap-up-SP cost) for one
+        (model, config) at construction. A /model override changes the context
+        window, so the session rebuilds the engine for the new resolved model
+        and rewires it here; ``wrap_up_output_reserve`` reads it fresh each turn,
+        so the swap takes effect on the next turn. ``None`` (small-context model
+        that cannot satisfy the force-close floor) keeps force-close inert.
+        """
+        self._turn_budget_engine = engine
+
     def _is_turn_cancel_requested(self) -> bool:
         """#1468: True when the session has requested a cooperative turn cancel.
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1573,7 +1573,10 @@ class Session:
             history_fn=lambda: self.history,
             compaction=self._compaction,
             compaction_controller=None,  # patched after CompactionController below
-            model=self.model,
+            # #1752: live resolved model — a /model override changes the context
+            # window, so resolve the active class → litellm string each call
+            # instead of caching the construction-time model.
+            model_fn=lambda: self._resolver.resolve(self.model).model,
             events=self._chat_events,
             media_store=self._media_store,
             router_host=self._router_host,
@@ -1669,7 +1672,8 @@ class Session:
             compaction=self._compaction,
             compaction_controller=self._compaction_controller,
             media_store=self._media_store,
-            model=self.model,
+            # #1752: live resolved model (see RouterHistoryBuffer above).
+            model_fn=lambda: self._resolver.resolve(self.model).model,
             events=self._chat_events,
             history_fn=self._history_buffer.build_history,
         )
@@ -1748,6 +1752,25 @@ class Session:
     @property
     def model(self) -> str:
         return self._model_override if self._model_override is not None else self._agent.model
+
+    def _rebuild_turn_budget_engine_for_model(self) -> None:
+        """#1752: rebuild the chat turn_budget engine for the active model.
+
+        The engine bakes derived headroom (max_input + wrap-up-SP token cost)
+        for one resolved (model, config) at construction (a deliberate
+        compute-once invariant, mirroring CompactionEngine). A ``/model``
+        override changes the context window, so on switch we rebuild the engine
+        for the new resolved model and rewire it into the RouterHostAdapter —
+        rather than recomputing per turn for a rare event. ``try_build_*``
+        returns ``None`` for a small-context model (force-close stays inert),
+        matching the original construction at ``__init__``.
+        """
+        from reyn.services.turn_budget import try_build_default_turn_budget_engine
+        engine = try_build_default_turn_budget_engine(
+            self._resolver.resolve(self.model).model,
+            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
+        )
+        self._router_host.set_turn_budget_engine(engine)
 
     @property
     def workspace_dir(self) -> "Path":

--- a/tests/test_live_model_budget_consumers_1752.py
+++ b/tests/test_live_model_budget_consumers_1752.py
@@ -1,0 +1,91 @@
+"""Tier 2: per-turn budget consumers read the model live via ``model_fn`` (#1752).
+
+ContextBudgetAdvisor + RouterHistoryBuffer used to cache ``model=self.model`` at
+construction, so a ``/model`` override (which can change the context window) left
+them budgeting against the construction-time model. #1752 threads a live
+``model_fn`` (the session resolves the active class → litellm string); the
+consumers read it on every budget/count instead of caching.
+
+These are consumer-contract unit tests: a mutable ``model_fn`` is flipped and the
+change is observed through each consumer's PUBLIC budget surface
+(``compaction_controller=None`` so the window comes straight from the model, with
+no compaction-engine confound). Real instances, no mocks.
+
+Falsification (per the file's convention): each test documents the assertion that
+would fail under the pre-#1752 construction-cache.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.llm.model_budget import get_max_input_tokens
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+
+def test_context_budget_advisor_reads_model_fn_live():
+    """Tier 2: ContextBudgetAdvisor.context_window_status() reflects model_fn live.
+
+    Falsification: pre-#1752 the advisor cached the model at __init__, so after
+    flipping model_fn the effective_trigger would stay the gpt-4o window and the
+    ``after != base`` assertion would fail.
+    """
+    current = {"m": "openai/gpt-4o"}  # 128K window
+    advisor = ContextBudgetAdvisor(
+        compaction=CompactionConfig(),
+        compaction_controller=None,  # → effective_trigger straight from the model window
+        media_store=None,
+        model_fn=lambda: current["m"],
+        events=None,
+        history_fn=lambda: [],
+    )
+
+    base = advisor.context_window_status()["effective_trigger"]
+    assert base == get_max_input_tokens("openai/gpt-4o")
+
+    current["m"] = "openai/gpt-4"  # 8K window — live switch
+    after = advisor.context_window_status()["effective_trigger"]
+    assert after == get_max_input_tokens("openai/gpt-4")
+    assert after != base  # budgeting tracks the active model, not the cached one
+
+
+def test_router_history_buffer_reads_model_fn_live():
+    """Tier 2: RouterHistoryBuffer.build_history() trims against the live model.
+
+    An oversized history fits a 128K window (no elide) but exceeds an 8K window
+    (elide to head+tail). Flipping model_fn from gpt-4o → gpt-4 must change the
+    sliced output.
+
+    Falsification: pre-#1752 the buffer cached the model at __init__, so both
+    build_history() calls would use the gpt-4o window and produce identical
+    (un-elided) output — the ``len(trimmed) < len(full)`` assertion would fail.
+    """
+    big = "word " * 5000  # ~25k chars ≈ ~6k tokens per turn
+    history = [
+        ChatMessage(
+            role=("user" if i % 2 == 0 else "assistant"),
+            content=big,
+            ts="t",
+        )
+        for i in range(8)
+    ]
+    current = {"m": "openai/gpt-4o"}  # 128K window — all 8 turns fit
+    buf = RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(),
+        compaction_controller=None,  # → window straight from the model
+        model_fn=lambda: current["m"],
+        events=None,
+        media_store=None,
+        router_host=None,
+        action_retrieval=None,
+        non_interactive=False,
+    )
+
+    full = buf.build_history()  # 128K: full raw conversation, no elide
+
+    current["m"] = "openai/gpt-4"  # 8K window — live switch → elide
+    trimmed = buf.build_history()
+    # Fewer messages survive the smaller live window → the buffer tracks the
+    # active model, not the construction-time one.
+    assert len(trimmed) < len(full)

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -94,6 +94,11 @@ class _FakeSession:
     async def _put_outbox(self, msg: OutboxMessage) -> None:
         self.outbox.append(msg)
 
+    def _rebuild_turn_budget_engine_for_model(self) -> None:
+        # #1752: no-op on the stub — it has no turn_budget engine / router host.
+        # The real rebuild is exercised in Group D against a real Session.
+        pass
+
     def error_text(self) -> str:
         return "\n".join(m.text for m in self.outbox if m.kind == "error" and m.text)
 
@@ -250,3 +255,28 @@ def test_known_classes_includes_user_configured():
     assert "strong" in classes
     assert "fast" in classes
     assert classes == sorted(classes)
+
+
+# ===========================================================================
+# Group D: #1752 — per-turn budget consumers track the live /model override
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_turn_budget_engine_rebuilt_on_model_switch(tmp_path):
+    """Tier 2: /model switch rebuilds the chat turn_budget engine for the new
+    model (rebuild-on-switch; the engine bakes derived headroom at construction).
+
+    Falsification: if model_cmd did not call
+    ``session._rebuild_turn_budget_engine_for_model()``, the RouterHostAdapter
+    would keep the construction-time engine object and the identity assertion
+    below would fail (after is before).
+    """
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver()
+    before = session._router_host._turn_budget_engine
+    assert before is not None  # baseline engine built (gpt-4o has a usable window)
+
+    await model_cmd(session, "strong")
+
+    after = session._router_host._turn_budget_engine
+    assert after is not before  # engine rebuilt for the new model

--- a/tests/test_user_image_input.py
+++ b/tests/test_user_image_input.py
@@ -296,7 +296,7 @@ def _make_history_builder():
         history_fn=lambda: cs.history,
         compaction=cs._compaction,
         compaction_controller=None,
-        model="",
+        model_fn=lambda: "",
         events=None,
         media_store=None,
         router_host=None,


### PR DESCRIPTION
**[e2e-coder]** — follow-on closing #1752. The `/model` override already routes the response/router model live (RouterLoopDriver via `model_override_fn`), but three per-turn consumers captured `model=self.model` at session `__init__` and budgeted against the construction-time model after a switch. Threads the live model to all three (both lead-endorsed shapes), flow-trace-first ([seam map](https://github.com/tya5/reyn/issues/1752#issuecomment-4748618136)).

## Changes
**Advisors** (model is a per-call input — ~7 read sites each):
- `ContextBudgetAdvisor` / `RouterHistoryBuffer`: take `model_fn` instead of `model`; `self._model` becomes a property returning `model_fn()` → 0 usage-site churn.
- Session wires `model_fn=lambda: self._resolver.resolve(self.model).model`. **Resolving in the session-side lambda is required**: `_model_override` is a model *class* (`"standard"`), but `get_max_input_tokens` needs a resolved litellm string — an unresolved class would 128K-fallback to the wrong window. Advisors stay resolver-free.

**turn_budget engine** (bakes derived headroom for one `(model, config)` at init — a deliberate compute-once invariant, mirrors CompactionEngine):
- **rebuild-on-switch**: `Session._rebuild_turn_budget_engine_for_model()` rebuilds the engine for the new resolved model; `RouterHostAdapter.set_turn_budget_engine` swaps it (`wrap_up_output_reserve` reads it fresh each turn). The `/model` handler calls the rebuild after setting the override. Preserves the once-resolved invariant + small blast radius vs per-turn recompute for a rare event.

## Scope (verified — completeness, no silent exclusion)
- **Plan-axis turn_budget engine** (`planner.py:988`): sources `router_model` from the config `"router"` class, **never** `session._model_override` (the only override-sourced `router_model` in `src` is `router_loop_driver.py:371`). `/model` is a per-session *chat* override (`model.py:6` "sticky for [chat]"); plans are a separate model context → **correctly out-of-scope**.
- **CompactionEngine** excluded per the issue (`purpose_class.compaction`, separate concern).

## Test plan
- [x] Consumer-contract units (`test_live_model_budget_consumers_1752.py`) — flip a mutable `model_fn`, observe each consumer's **public** budget surface (`context_window_status` / `build_history` trim) with `compaction_controller=None` (no compaction-engine confound)
- [x] Real-Session integration (`test_slash_model.py` Group D) — `/model` switch rebuilds the turn_budget engine
- [x] **Non-default** model round-trip (gpt-4o 128K → gpt-4 8K) per #302's lesson (default round-trip passes trivially)
- [x] **Falsify-verified** — the advisor test goes red under a simulated construction-cache (`after` stayed at the gpt-4o window vs gpt-4's 8192)
- [x] Broad regression set (session/budget/router/turn_budget/compaction/slash) — 490 passed
- [x] Full rootdir suite — 7592 passed (2 failures both pre-existing not-my-diff local-env: swebench eval-extra + web_fetch HTML-to-text; reproduce identically on clean main)
- [x] `ruff check src tests` clean + `test_tier_audit --strict` clean

Closes #1752