### PR TITLE
feat(tui/1154): S1 — viewer registry seam (inline dispatch → _ViewerEntry list)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
@@ -1,23 +1,25 @@
-"""Content-type-aware viewers for tool results (#1154 Phase 1).
+"""Content-type-aware viewers for tool results (#1154 Phase 1–3).
 
-A small registry mapping a tool result's content-type / MIME to a Rich
+A pluggable registry mapping a tool result's content-type / MIME to a Rich
 renderable. The Right Panel events-tab preview (``_show_event_in_preview``)
 consults this to render ``tool_returned`` / ``tool_executed`` results richer
-than the generic YAML fallback — the first slice of the Jupyter-style
-content-type → viewer vision in #1154.
+than the generic YAML fallback — the Jupyter-style content-type → viewer
+vision from #1154.
 
-Design (lead-ratified #1154 Phase 1–2):
+Design (lead-ratified #1154 Phase 1–3):
   - keyed by ``content_type`` / ``mimeType`` (the fields file/web/mcp op
     results already carry); explicit type wins, then a shape-sniff pass.
   - Phase 1 viewers: markdown (rendered) + CSV/table. Phase 2a adds a JSON
     viewer (formatted + syntax-highlighted); Phase 2b adds an image metadata
     card (mime / size / source — avoids dumping the base64 blob); Phase 2c
     adds a shape-sniffed web-page-summary card (web-fetch HTML preview, which
-    carries no content_type but a distinctive field set). Unknown / unmatched
-    → ``render_tool_result`` returns ``None`` so the caller falls back to the
-    existing YAML preview (degrade, never hide content).
-  - Phase 3 (deferred): LLM-generated viewer templates for novel types;
-    email-card deferred until a real in-repo email result producer exists.
+    carries no content_type but a distinctive field set).
+  - Phase 3 (S1): inline if/elif replaced with a pluggable ``_ViewerEntry``
+    registry; ``register_viewer()`` lets callers add new viewers without
+    touching the dispatch core. Byte-behavior identical to Phase 2c.
+  - Phase 3 (S2–S4, deferred): LLM-generated viewer templates for novel
+    types; email-card deferred until a real in-repo email result producer
+    exists.
 
 This module is intentionally pure (dict in → Rich renderable | None) so it
 is testable in isolation without the Textual app.
@@ -25,7 +27,8 @@ is testable in isolation without the Textual app.
 from __future__ import annotations
 
 import json
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Callable
 
 from rich.console import RenderableType
 from rich.json import JSON as RichJSON
@@ -37,13 +40,45 @@ from rich.table import Table
 _MAX_TABLE_ROWS = 50
 
 
-def _content_type_of(result: dict) -> str:
-    """Best-effort lowercase content-type / MIME string from a result dict.
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
 
-    Checks the explicit fields op results carry (``content_type`` on
-    file/web, ``mimeType`` on mcp/media blocks). Returns ``""`` when no
-    type is discoverable — the caller then falls back to YAML.
+@dataclass
+class _ViewerEntry:
+    predicate: Callable[[dict], bool]
+    viewer: Callable[[dict], RenderableType | None]
+    name: str = ""
+
+
+_VIEWERS: list[_ViewerEntry] = []
+
+
+def register_viewer(
+    predicate: Callable[[dict], bool],
+    viewer: Callable[[dict], RenderableType | None],
+    *,
+    name: str = "",
+    position: int = -1,
+) -> None:
+    """Register a viewer in the ordered dispatch list.
+
+    First matching entry wins. ``position=-1`` appends (lowest priority);
+    ``position=0`` inserts at the front (highest priority).
     """
+    entry = _ViewerEntry(predicate=predicate, viewer=viewer, name=name)
+    if position < 0:
+        _VIEWERS.append(entry)
+    else:
+        _VIEWERS.insert(position, entry)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by viewers
+# ---------------------------------------------------------------------------
+
+def _content_type_of(result: dict) -> str:
+    """Best-effort lowercase content-type / MIME string from a result dict."""
     for key in ("content_type", "mimeType", "mime_type", "media_type"):
         v = result.get(key)
         if isinstance(v, str) and v:
@@ -75,6 +110,10 @@ def _human_bytes(n: int) -> str:
     return f"{n} B"
 
 
+# ---------------------------------------------------------------------------
+# Built-in viewers (Phase 1–2c)
+# ---------------------------------------------------------------------------
+
 def _viewer_markdown(result: dict) -> RenderableType | None:
     text = _result_text(result)
     if not text:
@@ -98,7 +137,7 @@ def _viewer_csv(result: dict) -> RenderableType | None:
     body = rows[1:]
     for r in body[:_MAX_TABLE_ROWS]:
         cells = [c.strip() for c in r][: len(header)]
-        cells += [""] * (len(header) - len(cells))  # pad ragged rows
+        cells += [""] * (len(header) - len(cells))
         table.add_row(*cells)
     if len(body) > _MAX_TABLE_ROWS:
         table.caption = f"… {len(body) - _MAX_TABLE_ROWS} more rows"
@@ -106,13 +145,7 @@ def _viewer_csv(result: dict) -> RenderableType | None:
 
 
 def _viewer_json(result: dict) -> RenderableType | None:
-    """Syntax-highlighted, indented JSON (Phase 2a).
-
-    Parses the text payload and renders via ``rich.json.JSON`` (formats +
-    highlights). Returns ``None`` when there's nothing to render or the
-    payload isn't valid JSON — the caller then falls back to YAML, which
-    still shows the raw event (degrade, never hide content).
-    """
+    """Syntax-highlighted, indented JSON (Phase 2a)."""
     text = _result_text(result)
     if not text:
         return None
@@ -123,14 +156,7 @@ def _viewer_json(result: dict) -> RenderableType | None:
 
 
 def _viewer_image(result: dict) -> RenderableType | None:
-    """Metadata card for an image result (Phase 2b).
-
-    A terminal preview can't raster the image, and the raw result carries a
-    large base64 ``data`` blob — so YAML fallback would spew that blob. This
-    card summarizes the useful metadata (mime / size / source) instead, which
-    is strictly more readable than the raw dump. Always returns a renderable
-    (never None) when dispatched, since the content-type alone is informative.
-    """
+    """Metadata card for an image result (Phase 2b)."""
     blocks = result.get("media_blocks")
     block = (
         blocks[0]
@@ -147,7 +173,7 @@ def _viewer_image(result: dict) -> RenderableType | None:
     if not isinstance(size, int):
         data = block.get("data")
         if isinstance(data, str) and data:
-            size = (len(data) * 3) // 4  # approx decoded bytes from base64 len
+            size = (len(data) * 3) // 4
     if isinstance(size, int):
         table.add_row("size", _human_bytes(size))
 
@@ -163,28 +189,16 @@ def _viewer_image(result: dict) -> RenderableType | None:
     return table
 
 
-# Shape-sniff (Phase 2c): some results carry no ``content_type`` but have a
-# distinctive field set. The web-fetch HTML preview (web.py ``_generate_web_
-# fetch_preview``) returns ``{title, outline, first_paragraph, link_count,
-# content_chars}``. We require ALL of these distinctive keys to match — a
-# single-field sniff (e.g. just ``title``) would false-positive on unrelated
-# results, so precision comes from the combination.
 _WEB_SUMMARY_KEYS = ("title", "outline", "first_paragraph", "link_count")
 _MAX_OUTLINE_ROWS = 12
 
 
 def _looks_like_web_summary(result: dict) -> bool:
-    """True when *result* carries the full web-page-summary field set."""
     return all(k in result for k in _WEB_SUMMARY_KEYS)
 
 
 def _viewer_web_summary(result: dict) -> RenderableType | None:
-    """Card for a web-fetch HTML page summary (Phase 2c, shape-sniffed).
-
-    Renders the distilled page (title / first paragraph / heading outline /
-    link count) — far more readable than the raw nested dict. Returns the
-    card; the dispatcher only calls this once the shape has matched.
-    """
+    """Card for a web-fetch HTML page summary (Phase 2c, shape-sniffed)."""
     table = Table(show_header=False, box=None, expand=False)
     table.add_column("field", style="bold")
     table.add_column("value")
@@ -215,28 +229,50 @@ def _viewer_web_summary(result: dict) -> RenderableType | None:
     return table
 
 
+# ---------------------------------------------------------------------------
+# Default registry population (Phase 1–2c, same priority as the former
+# inline chain: explicit content-type first, shape-sniff last)
+# ---------------------------------------------------------------------------
+
+def _pred_markdown(r: dict) -> bool:
+    ct = _content_type_of(r)
+    return bool(ct) and ("markdown" in ct or ct.endswith("/md"))
+
+def _pred_csv(r: dict) -> bool:
+    ct = _content_type_of(r)
+    return bool(ct) and ("csv" in ct or "tab-separated" in ct)
+
+def _pred_json(r: dict) -> bool:
+    ct = _content_type_of(r)
+    return bool(ct) and "json" in ct
+
+def _pred_image(r: dict) -> bool:
+    ct = _content_type_of(r)
+    return bool(ct) and ct.startswith("image/")
+
+
+register_viewer(_pred_markdown, _viewer_markdown, name="markdown")
+register_viewer(_pred_csv, _viewer_csv, name="csv")
+register_viewer(_pred_json, _viewer_json, name="json")
+register_viewer(_pred_image, _viewer_image, name="image")
+register_viewer(_looks_like_web_summary, _viewer_web_summary, name="web_summary")
+
+
+# ---------------------------------------------------------------------------
+# Public dispatch entry point (API unchanged from Phase 1–2c)
+# ---------------------------------------------------------------------------
+
 def render_tool_result(result: Any) -> RenderableType | None:
     """Pick a viewer for ``result`` (or ``None`` for the YAML fallback).
 
-    Explicit ``content_type`` / MIME wins; when none matches, a shape-sniff
-    pass handles results that carry a distinctive field set but no content
-    type (web-page summary). ``None`` when ``result`` is not a dict, nothing
+    Walks the registered viewer list in order; returns the first non-None
+    renderable. Returns ``None`` when ``result`` is not a dict, nothing
     matches, or the matched viewer has nothing to render — the caller then
     falls back to the generic YAML preview.
     """
     if not isinstance(result, dict):
         return None
-    ct = _content_type_of(result)
-    if ct:
-        if "markdown" in ct or ct.endswith("/md"):
-            return _viewer_markdown(result)
-        if "csv" in ct or "tab-separated" in ct:
-            return _viewer_csv(result)
-        if "json" in ct:
-            return _viewer_json(result)
-        if ct.startswith("image/"):
-            return _viewer_image(result)
-    # No explicit content-type match → shape-sniff distinctive field sets.
-    if _looks_like_web_summary(result):
-        return _viewer_web_summary(result)
+    for entry in _VIEWERS:
+        if entry.predicate(result):
+            return entry.viewer(result)
     return None

--- a/tests/cli/test_tool_result_viewer_registry.py
+++ b/tests/cli/test_tool_result_viewer_registry.py
@@ -1,0 +1,156 @@
+"""Tier 2: tool-result viewer registry seam (#1154 Phase 3 S1).
+
+Pins the registry seam introduced in S1:
+- existing Phase 1–2c viewers are preserved with byte-identical behavior.
+- ``register_viewer`` fires before the fallback for matching results.
+- ``position`` parameter controls priority.
+
+Falsification:
+- Without the registry, a custom viewer could not fire without editing
+  the dispatch core — the register_viewer test would fail.
+- Without position control, a high-priority viewer could not override a
+  default viewer for the same content-type.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    _VIEWERS,
+    register_viewer,
+    render_tool_result,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — result dicts for each Phase 1–2c viewer
+# ---------------------------------------------------------------------------
+
+_MARKDOWN_RESULT = {"content_type": "text/markdown", "content": "# Hello\n\nworld"}
+_CSV_RESULT = {"content_type": "text/csv", "content": "a,b\n1,2\n3,4"}
+_JSON_RESULT = {"content_type": "application/json", "content": '{"x": 1}'}
+_IMAGE_RESULT = {
+    "mimeType": "image/png",
+    "media_blocks": [{"mimeType": "image/png", "data": "abc123"}],
+}
+_WEB_RESULT = {
+    "title": "Example",
+    "outline": ["H1", "H2"],
+    "first_paragraph": "Some text",
+    "link_count": 5,
+}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1–2c behavior preservation
+# ---------------------------------------------------------------------------
+
+def test_markdown_viewer_preserved() -> None:
+    """Tier 2: markdown result still dispatches to _viewer_markdown via registry."""
+    result = render_tool_result(_MARKDOWN_RESULT)
+    assert result is not None, "expected a renderable for markdown result"
+
+
+def test_csv_viewer_preserved() -> None:
+    """Tier 2: CSV result still dispatches to _viewer_csv via registry."""
+    result = render_tool_result(_CSV_RESULT)
+    assert result is not None, "expected a renderable for CSV result"
+
+
+def test_json_viewer_preserved() -> None:
+    """Tier 2: JSON result still dispatches to _viewer_json via registry."""
+    result = render_tool_result(_JSON_RESULT)
+    assert result is not None, "expected a renderable for JSON result"
+
+
+def test_image_viewer_preserved() -> None:
+    """Tier 2: image result still dispatches to _viewer_image via registry."""
+    result = render_tool_result(_IMAGE_RESULT)
+    assert result is not None, "expected a renderable for image result"
+
+
+def test_web_summary_viewer_preserved() -> None:
+    """Tier 2: web-summary result still dispatches to _viewer_web_summary via registry."""
+    result = render_tool_result(_WEB_RESULT)
+    assert result is not None, "expected a renderable for web-summary result"
+
+
+def test_unmatched_result_returns_none() -> None:
+    """Tier 2: a result that matches no registered viewer returns None.
+
+    Falsification: if any default viewer were too permissive (e.g. always
+    returning non-None), this would fail — indicating a viewer overreach bug.
+    """
+    result = render_tool_result({"some_unknown_key": "value"})
+    assert result is None, "expected None for unrecognised result shape"
+
+
+def test_non_dict_returns_none() -> None:
+    """Tier 2: render_tool_result returns None for non-dict inputs."""
+    assert render_tool_result(None) is None
+    assert render_tool_result("plain string") is None
+    assert render_tool_result(42) is None
+
+
+# ---------------------------------------------------------------------------
+# register_viewer — custom viewer fires
+# ---------------------------------------------------------------------------
+
+def test_register_viewer_fires_for_matching_result() -> None:
+    """Tier 2: a viewer registered via register_viewer fires for matching results.
+
+    Falsification: without register_viewer wiring the custom sentinel would
+    never be returned — render_tool_result would return None for this result.
+    """
+    sentinel = object()
+    original_len = len(_VIEWERS)
+
+    register_viewer(
+        predicate=lambda r: r.get("_test_custom") == "S1",
+        viewer=lambda r: sentinel,
+        name="_test_s1_custom",
+    )
+    try:
+        result = render_tool_result({"_test_custom": "S1", "other": "data"})
+        assert result is sentinel, f"expected sentinel from custom viewer, got {result!r}"
+    finally:
+        _VIEWERS[:] = [e for e in _VIEWERS if e.name != "_test_s1_custom"]
+
+
+def test_register_viewer_does_not_fire_for_non_matching_result() -> None:
+    """Tier 2: custom viewer predicate is respected; non-matching results fall through."""
+    register_viewer(
+        predicate=lambda r: r.get("_test_custom") == "S1_NOMATCH",
+        viewer=lambda r: (_ for _ in ()).throw(AssertionError("should not be called")),
+        name="_test_s1_nomatch",
+    )
+    try:
+        result = render_tool_result({"_test_custom": "DIFFERENT"})
+        assert result is None
+    finally:
+        _VIEWERS[:] = [e for e in _VIEWERS if e.name != "_test_s1_nomatch"]
+
+
+# ---------------------------------------------------------------------------
+# register_viewer — position controls priority
+# ---------------------------------------------------------------------------
+
+def test_register_viewer_position_zero_overrides_defaults() -> None:
+    """Tier 2: a viewer at position=0 fires before the default viewers.
+
+    Falsification: if position were ignored (always append), the default
+    markdown viewer would fire first for a markdown result, returning a
+    RichMarkdown — not the sentinel.
+    """
+    sentinel = object()
+
+    register_viewer(
+        predicate=lambda r: "content_type" in r,
+        viewer=lambda r: sentinel,
+        name="_test_priority_first",
+        position=0,
+    )
+    try:
+        result = render_tool_result(_MARKDOWN_RESULT)
+        assert result is sentinel, (
+            "expected high-priority viewer at position=0 to win over markdown default"
+        )
+    finally:
+        _VIEWERS[:] = [e for e in _VIEWERS if e.name != "_test_priority_first"]


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 3 S1: pure refactor, zero behavior change.

## Summary

Replaces the inline `if/elif` content-type dispatch in `render_tool_result` with a pluggable ordered `_VIEWERS` registry:

- `_ViewerEntry(predicate, viewer, name)` dataclass
- `register_viewer(predicate, viewer, *, name, position=-1)` public seam
- `render_tool_result` walks `_VIEWERS`; first match wins; **public API unchanged**

All Phase 1–2c viewers migrated to registry entries in the same priority order — byte-behavior identical. New viewers can be registered without touching the dispatch core (P7 spirit).

## Files

- `src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py` — registry seam + viewer migration
- `tests/cli/test_tool_result_viewer_registry.py` (NEW) — 10 Tier-2 tests

## Test plan

- [x] 10/10 Tier-2 tests pass
- [x] ruff clean
- [x] tier-audit clean (0 violations)
- [x] (skipped — no user-visible behavior change; TUI preview output identical to Phase 2c)

## Tier self-check

- No format pinning ✓
- No private state assertions ✓
- No mocks (real module imports, module-level `_VIEWERS` list) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)