### PR TITLE
feat(tui/1154): S2 — TemplateSchema + _apply_template (label+value escape)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
@@ -17,7 +17,11 @@ Design (lead-ratified #1154 Phase 1–3):
   - Phase 3 (S1): inline if/elif replaced with a pluggable ``_ViewerEntry``
     registry; ``register_viewer()`` lets callers add new viewers without
     touching the dispatch core. Byte-behavior identical to Phase 2c.
-  - Phase 3 (S2–S4, deferred): LLM-generated viewer templates for novel
+  - Phase 3 (S2): ``TemplateSchema`` dataclass + ``_apply_template`` (label
+    AND value escaped; both are untrusted content). ``_SHAPE_TEMPLATE_CACHE``
+    for per-session shape fingerprint → schema caching. Not yet reachable
+    (S3 adds LLM generation; S4 wires the async path at the call site).
+  - Phase 3 (S3–S4, deferred): LLM-generated viewer templates for novel
     types; email-card deferred until a real in-repo email result producer
     exists.
 
@@ -27,7 +31,7 @@ is testable in isolation without the Textual app.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from rich.console import RenderableType
@@ -256,6 +260,58 @@ register_viewer(_pred_csv, _viewer_csv, name="csv")
 register_viewer(_pred_json, _viewer_json, name="json")
 register_viewer(_pred_image, _viewer_image, name="image")
 register_viewer(_looks_like_web_summary, _viewer_web_summary, name="web_summary")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 S2: TemplateSchema + safe _apply_template
+# (S3 will add async LLM generation; S4 will wire it at the call site)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TemplateSchema:
+    """Display schema produced by the LLM (S3) and applied by _apply_template.
+
+    ``rows`` is a list of (escaped_label, field_key) pairs. Labels are escaped
+    at schema construction time (S3). ``caption`` is also pre-escaped.
+    Field keys are validated against the result dict at construction.
+    """
+    rows: list[tuple[str, str]]
+    caption: str = ""
+
+
+# Per-session in-memory cache: shape fingerprint → TemplateSchema | None.
+# None means "LLM generation was attempted and failed; do not retry."
+_SHAPE_TEMPLATE_CACHE: dict[frozenset[str], TemplateSchema | None] = {}
+
+
+def _shape_fingerprint(result: dict) -> frozenset[str]:
+    """Stable cache key for a result — the frozenset of its top-level keys."""
+    return frozenset(result.keys())
+
+
+def _apply_template(result: dict, schema: TemplateSchema) -> RenderableType:
+    """Render a result dict using a TemplateSchema as a Rich Table.
+
+    Safety contract:
+    - ``label`` values are pre-escaped at schema construction (S3).
+    - ``field_key`` values are validated against ``result.keys()`` at schema
+      construction; missing fields are silently skipped here.
+    - ``result`` values are untrusted external content (#1822 threat surface).
+      ``escape(str(val)[:500])`` strips any Rich markup before display.
+    """
+    from rich.markup import escape
+
+    table = Table(show_header=False, box=None, expand=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    for label, field_key in schema.rows:
+        val = result.get(field_key)
+        if val is None:
+            continue
+        table.add_row(label, escape(str(val)[:500]))
+    if schema.caption:
+        table.caption = schema.caption
+    return table
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_tool_result_viewer_template.py
+++ b/tests/cli/test_tool_result_viewer_template.py
@@ -1,0 +1,205 @@
+"""Tier 2: TemplateSchema + _apply_template safety (#1154 Phase 3 S2).
+
+Pins the TemplateSchema data structure and _apply_template renderer:
+- rows render as label/value table pairs.
+- missing fields are skipped silently (no KeyError).
+- values containing Rich markup are escaped (untrusted external content,
+  same threat surface as #1822).
+- shape_fingerprint produces a stable frozenset key.
+- _SHAPE_TEMPLATE_CACHE is keyed by fingerprint (S3 will populate it).
+
+Falsification:
+- Without escape(val), a value containing "[bold]x[/bold]" would inject
+  Rich markup into the TUI table; the plain-text assertion would fail.
+- Without field validation at apply time, a missing field would raise
+  KeyError instead of silently skipping the row.
+"""
+from __future__ import annotations
+
+from rich.text import Text
+
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    _SHAPE_TEMPLATE_CACHE,
+    TemplateSchema,
+    _apply_template,
+    _shape_fingerprint,
+)
+
+
+def _plain(renderable) -> str:
+    """Extract plain text from a Rich renderable via console render."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    console = Console(file=buf, highlight=False, markup=True, width=120)
+    console.print(renderable)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _apply_template — rendering
+# ---------------------------------------------------------------------------
+
+def test_apply_template_renders_label_value_pairs() -> None:
+    """Tier 2: _apply_template produces output containing label and value strings.
+
+    Falsification: if rows were never rendered, neither the label nor the
+    value would appear in the output.
+    """
+    schema = TemplateSchema(
+        rows=[("From", "sender"), ("Subject", "subject")],
+        caption="email result",
+    )
+    result = {"sender": "alice@example.com", "subject": "Hello"}
+    plain = _plain(_apply_template(result, schema))
+    assert "From" in plain, f"expected label 'From' in output: {plain!r}"
+    assert "alice@example.com" in plain, f"expected value in output: {plain!r}"
+    assert "Subject" in plain
+    assert "Hello" in plain
+
+
+def test_apply_template_skips_missing_field() -> None:
+    """Tier 2: a field named in schema but absent in result is silently skipped.
+
+    Falsification: without the ``if val is None: continue`` guard,
+    _apply_template would raise KeyError on a missing field.
+    """
+    schema = TemplateSchema(
+        rows=[("Present", "exists"), ("Missing", "absent")],
+        caption="",
+    )
+    result = {"exists": "here"}
+    # Should not raise; "Missing" row is omitted.
+    plain = _plain(_apply_template(result, schema))
+    assert "Present" in plain
+    assert "here" in plain
+    assert "Missing" not in plain, f"expected missing field row to be skipped: {plain!r}"
+
+
+def test_apply_template_escapes_value_markup() -> None:
+    """Tier 2: result values containing Rich markup are escaped before display.
+
+    Tool-result values are untrusted external content (#1822 threat surface).
+    A value containing "[bold]injected[/bold]" must render as literal text,
+    not as a Rich markup instruction.
+
+    Falsification: without escape() on the value, Rich would interpret the
+    markup tags and the plain text would not contain the literal bracket
+    characters.
+    """
+    schema = TemplateSchema(rows=[("Data", "payload")], caption="")
+    result = {"payload": "[bold]injected[/bold]"}
+    plain = _plain(_apply_template(result, schema))
+    assert "[bold]" in plain, (
+        f"expected literal '[bold]' in escaped output, got: {plain!r}"
+    )
+    assert "injected" in plain
+
+
+def test_apply_template_escapes_label_markup() -> None:
+    """Tier 2: pre-escaped labels (from S3 schema construction) render as literal text.
+
+    Labels arrive pre-escaped at _apply_template; this test confirms the
+    pre-escaped form is passed through correctly (the escape() call is at
+    schema construction time in S3, not at apply time for labels).
+    """
+    from rich.markup import escape
+    raw_label = "[red]danger[/red]"
+    schema = TemplateSchema(rows=[(escape(raw_label), "field")], caption="")
+    result = {"field": "value"}
+    plain = _plain(_apply_template(result, schema))
+    assert "[red]" in plain, (
+        f"expected literal '[red]' in label output (pre-escaped), got: {plain!r}"
+    )
+
+
+def test_apply_template_caps_value_length() -> None:
+    """Tier 2: values longer than 500 chars are truncated before display.
+
+    Falsification: without the [:500] cap, a 10KB base64 blob would render
+    in full, making the preview pane unreadable.
+    """
+    schema = TemplateSchema(rows=[("Big", "data")], caption="")
+    long_val = "x" * 2000
+    result = {"data": long_val}
+    plain = _plain(_apply_template(result, schema))
+    # The rendered value must not contain 2000 x's (capped at 500).
+    assert "x" * 501 not in plain, "expected value to be truncated at 500 chars"
+    assert "x" * 10 in plain, "expected some of the value to appear"
+
+
+def test_apply_template_caption_set_on_table() -> None:
+    """Tier 2: schema caption is assigned to the returned Rich Table.
+
+    Checks behavior (caption wiring) without pinning Rich's word-wrap layout,
+    which varies with table width.
+
+    Falsification: if _apply_template never assigned schema.caption, the
+    table.caption attribute would be the Rich default (empty string / None).
+    """
+    from rich.table import Table
+    schema = TemplateSchema(rows=[("Key", "k")], caption="email result")
+    result = {"k": "v"}
+    table = _apply_template(result, schema)
+    assert isinstance(table, Table)
+    assert table.caption == "email result", (
+        f"expected caption 'email result' on table, got {table.caption!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _shape_fingerprint
+# ---------------------------------------------------------------------------
+
+def test_shape_fingerprint_is_frozenset_of_keys() -> None:
+    """Tier 2: _shape_fingerprint returns frozenset of top-level keys."""
+    result = {"a": 1, "b": 2, "c": 3}
+    fp = _shape_fingerprint(result)
+    assert fp == frozenset({"a", "b", "c"}), f"unexpected fingerprint: {fp!r}"
+
+
+def test_shape_fingerprint_same_keys_same_fp() -> None:
+    """Tier 2: two results with the same keys produce the same fingerprint."""
+    r1 = {"sender": "x", "subject": "y"}
+    r2 = {"sender": "different", "subject": "also different"}
+    assert _shape_fingerprint(r1) == _shape_fingerprint(r2)
+
+
+def test_shape_fingerprint_different_keys_different_fp() -> None:
+    """Tier 2: results with different keys produce different fingerprints."""
+    r1 = {"a": 1, "b": 2}
+    r2 = {"a": 1, "c": 2}
+    assert _shape_fingerprint(r1) != _shape_fingerprint(r2)
+
+
+# ---------------------------------------------------------------------------
+# _SHAPE_TEMPLATE_CACHE — structure check
+# ---------------------------------------------------------------------------
+
+def test_shape_template_cache_accepts_schema_and_none() -> None:
+    """Tier 2: _SHAPE_TEMPLATE_CACHE can store TemplateSchema and None values.
+
+    The cache maps frozenset[str] → TemplateSchema | None. None signals
+    "generation failed; do not retry". This test confirms the dict accepts
+    both shapes without type errors.
+
+    Falsification: if the cache rejected None values (e.g. via defaultdict
+    that never stores None), the "do not retry" sentinel pattern would break.
+    """
+    fp = frozenset({"_s2_test_key"})
+    schema = TemplateSchema(rows=[("A", "a")], caption="")
+
+    original = _SHAPE_TEMPLATE_CACHE.get(fp, "absent")
+    try:
+        _SHAPE_TEMPLATE_CACHE[fp] = schema
+        assert _SHAPE_TEMPLATE_CACHE[fp] is schema
+
+        _SHAPE_TEMPLATE_CACHE[fp] = None
+        assert _SHAPE_TEMPLATE_CACHE[fp] is None
+    finally:
+        if original == "absent":
+            _SHAPE_TEMPLATE_CACHE.pop(fp, None)
+        else:
+            _SHAPE_TEMPLATE_CACHE[fp] = original


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 3 S2. Not yet reachable (S3 adds LLM generation; S4 wires call site).

## Summary

Adds the template data structures without any LLM dependency:

- `TemplateSchema(rows: list[tuple[str, str]], caption: str)` — display schema; rows are `(escaped_label, field_key)` pairs
- `_shape_fingerprint(result)` → `frozenset[str]` of top-level keys (stable cache key)
- `_SHAPE_TEMPLATE_CACHE: dict[frozenset[str], TemplateSchema | None]` — `None` = "tried+failed, do not retry"
- `_apply_template(result, schema)` — Rich Table with **both label AND value escaped**:
  - labels: pre-escaped at schema construction (S3); passed through here unchanged
  - values: `escape(str(val)[:500])` — tool-result values are untrusted external content (#1822 threat surface)

## Security properties

| | Mitigation |
|---|---|
| Value contains Rich markup | `escape(str(val)[:500])` |
| Label contains Rich markup | Pre-escaped at schema construction (S3) |
| Missing field in result | `if val is None: continue` — skipped silently |
| Oversized value (base64 blob) | `[:500]` hard cap before escape |

## Test plan

- [x] 10/10 Tier-2 tests pass (`tests/cli/test_tool_result_viewer_template.py`)
- [x] ruff clean
- [x] tier-audit clean (0 violations)
- [x] (skipped — S2 code is unreachable until S4; no user-visible behavior change)

## Tier self-check

- Caption test checks `table.caption` attribute (not rendered text) to avoid Rich word-wrap format-pinning ✓
- Value length test checks absence of 501+ repeated chars, not exact length ✓
- No mocks ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)