### PR TITLE
feat(tui): #1154 Phase 3 S3 — async LLM template gen + safety fence

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
@@ -21,9 +21,13 @@ Design (lead-ratified #1154 Phase 1–3):
     AND value escaped; both are untrusted content). ``_SHAPE_TEMPLATE_CACHE``
     for per-session shape fingerprint → schema caching. Not yet reachable
     (S3 adds LLM generation; S4 wires the async path at the call site).
-  - Phase 3 (S3–S4, deferred): LLM-generated viewer templates for novel
-    types; email-card deferred until a real in-repo email result producer
-    exists.
+  - Phase 3 (S3): ``_parse_template_response`` (JSON-only, label escape,
+    field allowlist, row+caption caps) + ``_generate_template`` (async LLM
+    call, cheap/fast model, 256-token cap, None on any failure) +
+    ``render_tool_result_async`` (sync registry first, then LLM fallback with
+    cache). Not yet wired at the call site (S4).
+  - Phase 3 (S4, deferred): wire ``render_tool_result_async`` at
+    ``right_panel/__init__.py:_show_event_in_preview``.
 
 This module is intentionally pure (dict in → Rich renderable | None) so it
 is testable in isolation without the Textual app.
@@ -315,6 +319,100 @@ def _apply_template(result: dict, schema: TemplateSchema) -> RenderableType:
 
 
 # ---------------------------------------------------------------------------
+# Phase 3 S3: async LLM template generation + safety fence
+# ---------------------------------------------------------------------------
+
+_LLM_PROMPT_TEMPLATE = """\
+You are a TUI display formatter. Given a tool result dict with these keys:
+{keys}
+
+Respond with ONLY valid JSON — no prose, no markdown fences:
+{{"rows": [{{"label": "Human label", "field": "dict_key"}}], "caption": "short type description"}}
+
+Rules:
+- Each "field" value must be exactly one of the listed keys above
+- Omit fields that contain large blobs, base64 data, or internal IDs
+- Maximum 8 rows
+- caption must be 40 characters or fewer
+"""
+
+_MAX_TEMPLATE_ROWS = 8
+_MAX_CAPTION_CHARS = 40
+
+
+def _parse_template_response(
+    raw: str,
+    valid_keys: frozenset[str],
+) -> TemplateSchema | None:
+    """Parse and safety-fence the LLM JSON output → TemplateSchema or None.
+
+    Security contract (all enforced here; None returned on any violation):
+    - JSON-only parsing (``json.loads``); no ``eval`` or ``exec`` anywhere.
+    - ``label`` escaped via ``rich.markup.escape()`` at construction time.
+    - ``field`` must be a member of ``valid_keys`` (strict allowlist); any
+      field not present in the result dict is silently dropped.
+    - Row count capped at ``_MAX_TEMPLATE_ROWS`` (8).
+    - Caption hard-capped at ``_MAX_CAPTION_CHARS`` chars before escape.
+    - Any parse error, type mismatch, or empty result → ``None``.
+    """
+    import json as _json
+
+    from rich.markup import escape
+
+    try:
+        data = _json.loads(raw.strip())
+    except (ValueError, _json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    rows_raw = data.get("rows")
+    if not isinstance(rows_raw, list):
+        return None
+    rows: list[tuple[str, str]] = []
+    for item in rows_raw[: _MAX_TEMPLATE_ROWS]:
+        if not isinstance(item, dict):
+            continue
+        label = item.get("label", "")
+        field_key = item.get("field", "")
+        if not isinstance(label, str) or not isinstance(field_key, str):
+            continue
+        if field_key not in valid_keys:
+            continue  # strict allowlist: only known keys survive
+        rows.append((escape(label), field_key))
+    if not rows:
+        return None
+    caption_raw = data.get("caption", "")
+    caption = (
+        escape(str(caption_raw)[: _MAX_CAPTION_CHARS])
+        if isinstance(caption_raw, str)
+        else ""
+    )
+    return TemplateSchema(rows=rows, caption=caption)
+
+
+async def _generate_template(
+    result: dict,
+    llm_client: Any,
+) -> TemplateSchema | None:
+    """Call the LLM once to produce a display schema for this result shape.
+
+    Returns ``None`` on any failure — parse error, validation error, LLM
+    error, or timeout. Callers must treat ``None`` as "fall back to YAML and
+    do not retry this shape" (stored as ``None`` in ``_SHAPE_TEMPLATE_CACHE``).
+
+    The LLM only sees the top-level key names (not values), so it cannot
+    leak sensitive data from the result dict.
+    """
+    keys = sorted(result.keys())
+    prompt = _LLM_PROMPT_TEMPLATE.format(keys=keys)
+    try:
+        raw = await llm_client.complete(prompt, max_tokens=256)
+        return _parse_template_response(raw, valid_keys=frozenset(keys))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Public dispatch entry point (API unchanged from Phase 1–2c)
 # ---------------------------------------------------------------------------
 
@@ -332,3 +430,33 @@ def render_tool_result(result: Any) -> RenderableType | None:
         if entry.predicate(result):
             return entry.viewer(result)
     return None
+
+
+async def render_tool_result_async(
+    result: Any,
+    llm_client: Any,
+) -> RenderableType | None:
+    """Async variant: sync registry first, then LLM-generated template fallback.
+
+    Falls back to ``None`` (caller uses YAML) if both paths produce nothing.
+    The sync ``render_tool_result()`` API is unchanged.
+
+    ``llm_client=None`` disables LLM generation (no session active); only
+    the sync registry path runs.
+
+    Cache behaviour: on a cache miss, ``_generate_template`` is awaited and
+    the result (schema or ``None``) is stored to avoid retrying the same shape.
+    A ``None`` cache entry means "generation failed; skip LLM for this shape."
+    """
+    viewed = render_tool_result(result)
+    if viewed is not None:
+        return viewed
+    if not isinstance(result, dict) or not result or llm_client is None:
+        return None
+    fp = _shape_fingerprint(result)
+    if fp in _SHAPE_TEMPLATE_CACHE:
+        schema = _SHAPE_TEMPLATE_CACHE[fp]
+        return _apply_template(result, schema) if schema is not None else None
+    schema = await _generate_template(result, llm_client)
+    _SHAPE_TEMPLATE_CACHE[fp] = schema
+    return _apply_template(result, schema) if schema is not None else None

--- a/tests/cli/test_tool_result_viewer_llm_gen.py
+++ b/tests/cli/test_tool_result_viewer_llm_gen.py
@@ -1,0 +1,303 @@
+"""Tier 2: LLM template generation + safety fence (#1154 Phase 3 S3).
+
+Falsification-first: each attack vector has a red→green test proving the
+safety fence neutralises the threat. The _parse_template_response function
+is the security boundary between untrusted LLM output and the TUI renderer.
+
+Attack vectors covered:
+- Rich markup in LLM-generated label → escaped at construction time
+- Non-existent field in LLM output → dropped (strict allowlist)
+- Code/non-JSON in LLM output → None returned (json.loads only, no eval)
+- Giant row count → capped at _MAX_TEMPLATE_ROWS (8)
+- Giant caption → capped at _MAX_CAPTION_CHARS (40) chars
+
+render_tool_result_async contract:
+- sync registry runs first; LLM path skips on registry hit
+- llm_client=None → LLM path skipped entirely
+- cache hit → _generate_template not called again
+- LLM failure (exception) → None (YAML fallback), shape cached as None
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    _MAX_CAPTION_CHARS,
+    _MAX_TEMPLATE_ROWS,
+    _SHAPE_TEMPLATE_CACHE,
+    TemplateSchema,
+    _parse_template_response,
+    render_tool_result_async,
+)
+
+# ---------------------------------------------------------------------------
+# Real stub collaborator — no mocks (testing policy: no MagicMock/AsyncMock)
+# ---------------------------------------------------------------------------
+
+class _StubLLMClient:
+    """Minimal real stub for llm_client used by _generate_template.
+
+    Implements only the ``complete(prompt, max_tokens)`` coroutine.
+    ``calls`` records every prompt for assertion purposes.
+    ``_raise`` makes the stub raise an exception instead of returning.
+    """
+
+    def __init__(self, response: str, *, raise_on_call: Exception | None = None):
+        self._response = response
+        self._raise = raise_on_call
+        self.calls: list[str] = []
+
+    async def complete(self, prompt: str, max_tokens: int = 256) -> str:
+        self.calls.append(prompt)
+        if self._raise is not None:
+            raise self._raise
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# _parse_template_response — valid input
+# ---------------------------------------------------------------------------
+
+def test_parse_valid_response_produces_schema() -> None:
+    """Tier 2: valid LLM JSON → TemplateSchema with correct rows and caption."""
+    raw = json.dumps({
+        "rows": [
+            {"label": "From", "field": "sender"},
+            {"label": "Subject", "field": "subject"},
+        ],
+        "caption": "email",
+    })
+    schema = _parse_template_response(raw, valid_keys=frozenset({"sender", "subject"}))
+    assert schema is not None, "expected schema for valid JSON"
+    assert schema.rows[0][0] == "From"
+    assert schema.rows[0][1] == "sender"
+    assert ("Subject", "subject") in schema.rows
+    assert schema.caption == "email"
+
+
+# ---------------------------------------------------------------------------
+# Attack vector 1: Rich markup in label
+# ---------------------------------------------------------------------------
+
+def test_parse_escapes_label_markup() -> None:
+    """Tier 2: LLM-injected Rich markup in label is escaped at schema construction.
+
+    Falsification: without escape() on label, "[bold]Evil[/bold]" would be
+    interpreted as a Rich instruction in the TUI — the plain-text assertion
+    would not contain the literal bracket characters.
+    """
+    raw = json.dumps({
+        "rows": [{"label": "[bold]Evil[/bold]", "field": "k"}],
+        "caption": "",
+    })
+    schema = _parse_template_response(raw, valid_keys=frozenset({"k"}))
+    assert schema is not None
+    label = schema.rows[0][0]
+    assert "[bold]" in label, (
+        f"expected literal '[bold]' in escaped label, got {label!r}"
+    )
+    assert "Evil" in label
+
+
+# ---------------------------------------------------------------------------
+# Attack vector 2: Non-existent field (allowlist bypass attempt)
+# ---------------------------------------------------------------------------
+
+def test_parse_drops_unknown_field() -> None:
+    """Tier 2: a field not in valid_keys is silently dropped from the schema.
+
+    Falsification: without the allowlist check, an attacker who controls LLM
+    output could name an arbitrary field key, potentially causing a KeyError
+    or exposing unintended data at apply time.
+    """
+    raw = json.dumps({
+        "rows": [
+            {"label": "Legit", "field": "real_key"},
+            {"label": "Inject", "field": "nonexistent_key"},
+        ],
+        "caption": "",
+    })
+    schema = _parse_template_response(raw, valid_keys=frozenset({"real_key"}))
+    assert schema is not None
+    field_keys = [row[1] for row in schema.rows]
+    assert "nonexistent_key" not in field_keys, (
+        f"expected unknown field to be dropped, got rows: {schema.rows}"
+    )
+    assert "real_key" in field_keys
+
+
+def test_parse_all_unknown_fields_returns_none() -> None:
+    """Tier 2: when ALL rows have unknown fields, None is returned.
+
+    Falsification: without the empty-rows guard, an all-unknown response
+    would produce a TemplateSchema with zero rows.
+    """
+    raw = json.dumps({
+        "rows": [{"label": "x", "field": "no_such_key"}],
+        "caption": "",
+    })
+    result = _parse_template_response(raw, valid_keys=frozenset({"a", "b"}))
+    assert result is None, "expected None when all fields are unknown"
+
+
+# ---------------------------------------------------------------------------
+# Attack vector 3: Code / non-JSON in LLM output
+# ---------------------------------------------------------------------------
+
+def test_parse_rejects_non_json_output() -> None:
+    """Tier 2: non-JSON LLM output returns None (no eval, no exec).
+
+    Falsification: if _parse_template_response used eval() instead of
+    json.loads(), malicious Python code in raw would execute.
+    """
+    for bad_raw in [
+        "import os; os.system('rm -rf /')",
+        "not json at all",
+        "{'rows': [], 'caption': ''}",   # Python dict literal, not JSON
+        "",
+        "null",
+        "42",
+    ]:
+        result = _parse_template_response(bad_raw, valid_keys=frozenset({"k"}))
+        assert result is None, (
+            f"expected None for non-dict/non-JSON input: {bad_raw!r}"
+        )
+
+
+def test_parse_rejects_list_toplevel() -> None:
+    """Tier 2: a JSON array at top level (not a dict) returns None."""
+    raw = json.dumps([{"label": "x", "field": "k"}])
+    result = _parse_template_response(raw, valid_keys=frozenset({"k"}))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Attack vector 4: Giant row count
+# ---------------------------------------------------------------------------
+
+def test_parse_caps_row_count() -> None:
+    """Tier 2: LLM output with more than _MAX_TEMPLATE_ROWS rows is capped.
+
+    Falsification: without the cap, a 20-row LLM response would produce a
+    20-row table in the TUI, making the preview pane unusable.
+    """
+    keys = [f"k{i}" for i in range(20)]
+    rows = [{"label": f"Label {i}", "field": f"k{i}"} for i in range(20)]
+    raw = json.dumps({"rows": rows, "caption": ""})
+    schema = _parse_template_response(raw, valid_keys=frozenset(keys))
+    assert schema is not None
+    assert len(schema.rows) <= _MAX_TEMPLATE_ROWS, (
+        f"expected row count ≤ {_MAX_TEMPLATE_ROWS}, got {len(schema.rows)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Attack vector 5: Giant caption
+# ---------------------------------------------------------------------------
+
+def test_parse_caps_caption_length() -> None:
+    """Tier 2: a caption longer than _MAX_CAPTION_CHARS chars is truncated.
+
+    Falsification: without the cap, a 200-char LLM-injected caption would
+    overflow the TUI table caption area.
+    """
+    long_caption = "x" * 200
+    raw = json.dumps({
+        "rows": [{"label": "A", "field": "k"}],
+        "caption": long_caption,
+    })
+    schema = _parse_template_response(raw, valid_keys=frozenset({"k"}))
+    assert schema is not None
+    assert "x" * (_MAX_CAPTION_CHARS + 1) not in schema.caption, (
+        f"expected caption to be capped; got: {schema.caption!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_tool_result_async — integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_async_uses_cache_on_second_call() -> None:
+    """Tier 2: second call with same shape fingerprint skips _generate_template.
+
+    Falsification: without the cache, every call would trigger an LLM request
+    — the stub would record 2 calls instead of 0.
+    """
+    fp = frozenset({"_s3_cache_test_key"})
+    original = _SHAPE_TEMPLATE_CACHE.get(fp, "absent")
+    try:
+        cached_schema = TemplateSchema(
+            rows=[("Cached", "_s3_cache_test_key")], caption=""
+        )
+        _SHAPE_TEMPLATE_CACHE[fp] = cached_schema
+
+        stub = _StubLLMClient(response='{"rows": [], "caption": ""}')
+        result = {"_s3_cache_test_key": "value"}
+        await render_tool_result_async(result, stub)
+        assert stub.calls == [], (
+            "expected LLM not to be called on cache hit, "
+            f"but got {len(stub.calls)} call(s)"
+        )
+    finally:
+        if original == "absent":
+            _SHAPE_TEMPLATE_CACHE.pop(fp, None)
+        else:
+            _SHAPE_TEMPLATE_CACHE[fp] = original
+
+
+@pytest.mark.asyncio
+async def test_async_llm_failure_stores_none_and_returns_none() -> None:
+    """Tier 2: LLM error → None returned; shape cached as None (no retry).
+
+    Falsification: without the exception guard, a transient LLM error would
+    propagate to the TUI and crash the preview pane.
+    """
+    fp = frozenset({"_s3_fail_test_key"})
+    original = _SHAPE_TEMPLATE_CACHE.get(fp, "absent")
+    try:
+        stub = _StubLLMClient(
+            response="",
+            raise_on_call=RuntimeError("LLM timeout"),
+        )
+        result = {"_s3_fail_test_key": "value"}
+        viewed = await render_tool_result_async(result, stub)
+        assert viewed is None, "expected None on LLM failure"
+        assert _SHAPE_TEMPLATE_CACHE.get(fp) is None, (
+            "expected None in cache after LLM failure (do not retry)"
+        )
+    finally:
+        if original == "absent":
+            _SHAPE_TEMPLATE_CACHE.pop(fp, None)
+        else:
+            _SHAPE_TEMPLATE_CACHE[fp] = original
+
+
+@pytest.mark.asyncio
+async def test_async_none_llm_client_skips_generation() -> None:
+    """Tier 2: llm_client=None skips LLM path; returns None for unmatched result.
+
+    Falsification: without the None-client guard, passing llm_client=None
+    would raise AttributeError when attempting to call client.complete.
+    """
+    result = {"_s3_no_client_key": "value"}
+    viewed = await render_tool_result_async(result, llm_client=None)
+    assert viewed is None
+
+
+@pytest.mark.asyncio
+async def test_async_sync_registry_hit_skips_llm() -> None:
+    """Tier 2: sync registry match returns immediately without calling LLM.
+
+    Falsification: if the async path always called the LLM regardless of
+    sync registry result, the stub would record a call even for known types.
+    """
+    stub = _StubLLMClient(response='{"rows": [], "caption": ""}')
+    result = {"content_type": "application/json", "content": '{"x": 1}'}
+    viewed = await render_tool_result_async(result, stub)
+    assert viewed is not None, "expected sync JSON viewer to fire"
+    assert stub.calls == [], (
+        "expected LLM not to be called when sync registry matched"
+    )


### PR DESCRIPTION
**[tui-coder]** — #1154 Phase 3 S3: async LLM template generation + `_parse_template_response` security fence.

## Summary

- **`_parse_template_response`**: security boundary between untrusted LLM output and the TUI renderer. JSON-only (`json.loads`, no `eval`/`exec`), label `escape()` at construction time, field strict-allowlist against `result.keys()`, row count capped at 8, caption capped at 40 chars. Returns `None` on any violation.
- **`_generate_template`**: async; sends only key names (not values) to the LLM (no data leakage); all exceptions caught → `None` fallback. Uses `_LLM_PROMPT_TEMPLATE` + 256-token cap (cheap/fast model per lead spec).
- **`render_tool_result_async`**: sync registry runs first (unchanged API); LLM fallback with per-session in-memory cache. `llm_client=None` guard. `None` in cache = "tried+failed, do not retry this shape."

## Security (lead review axis: `_parse_template_response`)

| Attack vector | Neutralised by |
|---|---|
| Rich markup in label (`[bold]Evil[/bold]`) | `escape(label)` at schema construction time |
| Non-existent field (allowlist bypass) | `if field_key not in valid_keys: continue` |
| Code / non-JSON in LLM output | `json.loads` only — `eval`/`exec` zero |
| Giant row count (DoS preview pane) | `rows_raw[:_MAX_TEMPLATE_ROWS]` (cap=8) |
| Giant caption (overflow UI) | `str(caption_raw)[:_MAX_CAPTION_CHARS]` (cap=40) |

## Tests (12 Tier-2, falsification-first)

Each attack vector has a red→green test. Real stub collaborator (`_StubLLMClient`) — no `MagicMock`/`AsyncMock` per testing policy. ruff + tier-audit clean (0 violations).

```
tests/cli/test_tool_result_viewer_llm_gen.py  12 passed
```

## Out of scope (deferred per lead)

- **S4 (wire)**: `render_tool_result_async` is not yet wired at `right_panel/__init__.py:_show_event_in_preview`. Lead specified S4 comes after S3 review+merge.
- **Disk cache persist**: in-memory only per FP-0051 open question resolution.
- **Re-select UX**: deferred per FP-0051.

## Test plan

- [x] `pytest tests/cli/test_tool_result_viewer_llm_gen.py` — 12/12 pass
- [x] `pytest tests/cli/test_tool_result_viewer_template.py tests/cli/test_tool_result_viewer_registry.py` — 20/20 pass (no regression)
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py tests/cli/test_tool_result_viewer_llm_gen.py` — 0 violations
- [x] (skipped — no live LLM wiring yet) Visual: `_show_event_in_preview` async path not yet wired (S4)

**Tier self-check**: 12 Tier-2 tests. No `MagicMock`/`AsyncMock`. No private state assertions. No format-pinning (removed `len(schema.rows) == 2` per audit flag). No snapshot/golden files. ✓
