### PR TITLE
feat(1829): S2 — loop-aware Router cache + cost-mutation fix

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import uuid
+import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Coroutine, TypeVar, Union
@@ -946,26 +947,45 @@ def proxy_kwargs() -> dict:
     return {"api_base": api_base, "custom_llm_provider": "openai", "api_key": api_key}
 
 
-def _single_deployment_router(model: str):
-    """#1829 S1: build a minimal single-deployment ``litellm.Router`` for *model*
-    with NO extra retry/fallback/cooldown (``num_retries=0``). The per-call
-    routing params (api_base / provider / api_key / response_format / …) are passed
-    through on the ``router.acompletion`` call (not baked into the deployment), so
-    the underlying ``litellm.acompletion`` — which Router invokes internally
-    (replay-compat verified, #1829 probe) — receives the SAME (model, messages,
-    kwargs) as a direct call → byte-equivalent + LLMReplay/cost-recording-compatible.
+# #1829 S2: loop-aware single-deployment Router cache. A ``litellm.Router`` binds
+# to the event loop it first awaits on, so a process-global cache would trip
+# "bound to a different event loop" under pytest-asyncio's per-test loops (the
+# reason S1 built per-call). Keying by the RUNNING loop gives each loop its own
+# Router — the same loop-aware-registry pattern as the #1762 agent-lock fix.
+# WeakKeyDictionary → a finished loop's Routers are GC'd with the loop.
+_ROUTERS_BY_LOOP: "weakref.WeakKeyDictionary[object, dict[str, object]]" = (
+    weakref.WeakKeyDictionary()
+)
 
-    Built per-call (no cache) for S1: a cached Router would bind to the event loop
-    of its first await (the #1762 asyncio-loop-binding class), unsafe under
-    pytest-asyncio's per-test loops. Loop-aware caching + a multi-deployment
-    model_list (from ModelResolver) land in S2; fallbacks/cooldown/retry_policy
-    (folding #1835) in S3.
+
+def _single_deployment_router(model: str):
+    """#1829 S1→S2: return a single-deployment ``litellm.Router`` for *model*, now
+    cached per running event loop (#1829 S2). NO extra retry/fallback/cooldown
+    (``num_retries=0``) — fallbacks/cooldown/retry_policy (folding #1835) and a
+    multi-deployment model_list (where fallbacks need it) land in S3.
+
+    Per-call routing params (api_base / provider / api_key / response_format / …)
+    are passed through on the ``router.acompletion`` call (not baked into the
+    deployment), so the underlying ``litellm.acompletion`` — which Router invokes
+    internally (replay-compat verified, #1829 probe) — receives the SAME
+    (model, messages, kwargs) as a direct call → byte-equivalent +
+    LLMReplay/cost-recording-compatible. The cache is keyed per running loop so
+    the cached Router is never reused across event loops (the #1762 binding class).
     """
     import litellm as _ll
-    return _ll.Router(
-        model_list=[{"model_name": model, "litellm_params": {"model": model}}],
-        num_retries=0,
-    )
+    loop = asyncio.get_running_loop()
+    per_loop = _ROUTERS_BY_LOOP.get(loop)
+    if per_loop is None:
+        per_loop = {}
+        _ROUTERS_BY_LOOP[loop] = per_loop
+    router = per_loop.get(model)
+    if router is None:
+        router = _ll.Router(
+            model_list=[{"model_name": model, "litellm_params": {"model": model}}],
+            num_retries=0,
+        )
+        per_loop[model] = router
+    return router
 
 
 def routing_for_spec(spec: "ModelSpec | None") -> dict | None:

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -91,6 +91,18 @@ def estimate_cost(
     try:
         import litellm
 
+        # #1829 S2 (option 3): a ``litellm.model_cost`` entry can EXIST with None
+        # prices — a price-less PLACEHOLDER (e.g. a ``litellm.Router`` deployment
+        # registration adds one). ``cost_per_token`` then returns 0.0 for it,
+        # conflating "cost unknown" with "free". An unpriced model means cost
+        # UNKNOWN → return (None, None), not 0.0. (unknown ≠ free — None is the
+        # explicit unknown sentinel; 0.0 would wrongly read as a real free call.)
+        _entry = litellm.model_cost.get(model)
+        if (not _entry
+                or _entry.get("input_cost_per_token") is None
+                or _entry.get("output_cost_per_token") is None):
+            return None, None
+
         prompt_cost, completion_cost = litellm.cost_per_token(
             model=model,
             prompt_tokens=usage.prompt_tokens,

--- a/tests/test_llm_router_s2_1829.py
+++ b/tests/test_llm_router_s2_1829.py
@@ -1,0 +1,92 @@
+"""Tier 2: OS-invariant tests for #1829 S2 — loop-aware Router cache + cost-fix.
+
+S2 adds (a) a per-running-loop cache for the single-deployment Router (reusing the
+#1762 loop-aware-registry pattern — a litellm.Router binds to the loop it first
+awaits on, so a process-global cache would trip "bound to a different event loop"
+under pytest-asyncio per-test loops), and (b) the cost-mutation fix in
+``estimate_cost``: a litellm.model_cost entry with None prices (a price-less
+placeholder, e.g. a Router deployment registration) means cost UNKNOWN → (None,
+None), not 0.0 (unknown != free).
+
+Policy: no mocks; real Router + real estimate_cost; no private-state/count-pins;
+Tier line.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from reyn.llm.llm import TokenUsage, _single_deployment_router
+from reyn.llm.pricing import estimate_cost
+
+
+@pytest.fixture(autouse=True)
+def _isolate_litellm_model_cost():
+    """Restore litellm.model_cost in place (Router build registers placeholders;
+    same #1762 global-state-isolation discipline as the S1 test)."""
+    before = dict(litellm.model_cost)
+    yield
+    litellm.model_cost.clear()
+    litellm.model_cost.update(before)
+
+
+# (a) loop-aware Router cache ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_cached_within_a_loop() -> None:
+    """Tier 2: repeated calls within one running loop return the SAME cached Router."""
+    a = _single_deployment_router("openai/gemini-2.5-flash-lite")
+    b = _single_deployment_router("openai/gemini-2.5-flash-lite")
+    assert a is b, "the single-deployment Router must be cached per running loop"
+
+
+def test_router_distinct_across_event_loops() -> None:
+    """Tier 2: distinct event loops get DISTINCT Routers (no cross-loop binding).
+
+    A cached Router reused across loops would raise "bound to a different event
+    loop" (the #1762 class). Two separate asyncio.run() loops must each get their
+    own Router without error — the loop-aware cache key guarantees this.
+    """
+    async def _get() -> int:
+        return id(_single_deployment_router("openai/gemini-2.5-flash-lite"))
+
+    id1 = asyncio.run(_get())   # loop 1
+    id2 = asyncio.run(_get())   # loop 2 — must not raise, must be a fresh Router
+    assert id1 != id2, "each event loop must get its own Router (loop-aware cache)"
+
+
+# (b) cost-mutation fix (estimate_cost) -------------------------------------------
+
+def test_estimate_cost_none_price_placeholder_returns_none() -> None:
+    """Tier 2: a None-price model_cost placeholder → (None, None), not 0.0.
+
+    A litellm.Router deployment registration adds a price-less placeholder entry to
+    the global litellm.model_cost; estimate_cost must treat that as cost UNKNOWN
+    (None), not free (0.0). This keeps cost-recording correct when the Router goes
+    live (#1829 S2 cost-mutation gate).
+    """
+    litellm.model_cost["openai/gemini-2.5-flash-lite"] = {
+        "input_cost_per_token": None, "output_cost_per_token": None,
+        "litellm_provider": None,
+    }
+    cost, snapshot = estimate_cost(
+        "openai/gemini-2.5-flash-lite",
+        TokenUsage(prompt_tokens=1000, completion_tokens=500),
+    )
+    assert cost is None and snapshot is None, (
+        "an unpriced (None-price) model entry means cost UNKNOWN → (None, None), "
+        "not 0.0 — unknown != free"
+    )
+
+
+def test_estimate_cost_real_priced_model_unchanged() -> None:
+    """Tier 2: a real-priced model still computes a positive cost (fix non-regression)."""
+    cost, snapshot = estimate_cost(
+        "gpt-4o-mini",
+        TokenUsage(prompt_tokens=1000, completion_tokens=500),
+    )
+    assert cost is not None and cost > 0, (
+        "the None-price guard must NOT affect real-priced models — they still cost"
+    )


### PR DESCRIPTION
**[dogfood-coder]** — Refs #1829. **Stage 2 of 4** (S1 #1854 merged). Builds on the config-gated single-deployment Router.

## What
- **Loop-aware Router cache** (`WeakKeyDictionary[running-loop → {model: Router}]`), replacing S1's per-call build. A litellm.Router binds to the event loop it first awaits on → a process-global cache trips "bound to a different event loop" under pytest-asyncio per-test loops; keyed by the running loop, each loop gets its own Router — the **same loop-aware-registry pattern as the #1762 agent-lock fix**. Routing flows via per-call kwargs (deployment stays bare; S1 byte-equivalence preserved).
- **Cost-mutation fix (lead-approved option 3)**: `estimate_cost` → (None, None) when a `litellm.model_cost` entry exists with None prices (a price-less placeholder, e.g. a Router deployment registration). `cost_per_token` returns 0.0 for such an entry, conflating *unknown* with *free*; unpriced = cost UNKNOWN → None, not 0. Correct independent of the Router; keeps cost-recording correct when the Router goes live.

Per the approved S2/S3 split: full multi-deployment model_list + fallbacks/cooldown/retry_policy (folds #1835) land in S3 (build-where-needed — a multi-deployment list is inert without fallbacks).

## Verification (per-stage gates)
- **loop-aware-cache**: cached within a loop; distinct across loops (no bind error). Tier-2 tests.
- **cost-mutation gate**: None-price→None; real-priced unchanged; existing cost tests 3/3 unchanged.
- **single-deployment equivalence + replay-compat**: replay-green gate-ON (13p+1xf) and gate-OFF.
- **config default-off**; ruff clean.
- Full regression (S1+S2 router + cost + replay, default-off): 23 passed + 1 xfailed.

## Test plan
- [x] loop-aware-cache tests (per-loop / cross-loop)
- [x] cost-fix tests (None-price→None / real-priced unchanged)
- [x] replay-green gate-ON (equivalence) + gate-OFF
- [x] existing cost tests unchanged; ruff clean
- [ ] full CI green

## Stages ahead
S3 = full model_list + fallbacks/cooldown/retry_policy (folds #1835) · S4 = credential rotation. #1829 close gated against the original full scope (fallback chain + cooldown + cred rotation).

---
PR self-check: Tier-2 tests declare Tier; no mocks (real Router + real estimate_cost); model_cost isolation fixture (no global-state leak); config default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)