### PR TITLE
feat(1829): S3b — llm.router.* config + multi-deployment fallback chain (folds #1835)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -329,6 +329,11 @@ llm:
 | `cooldown_time` | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
 | `allowed_fails` | int\|null | `null` | Failures before a deployment is cooled down. |
 
+On the Router path, retry count is **config-only**: `num_retries` is taken from
+`llm.router.num_retries` (a per-call `max_retries` is not applied), so the retry
+budget has a single source. (On the direct, non-Router path the per-call
+`max_retries` is unchanged.)
+
 ## `chat` block
 
 Chat-session runtime knobs. `chat.compaction` controls chat-history compaction

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -295,6 +295,40 @@ than a hidden default. Explicit per-call selections (a skill's `op.model`, a
 phase's frontmatter `model_class`) still win over this fallback. Unknown purpose
 keys are warned (not fatal) at load time.
 
+## `llm` block
+
+LLM-layer config. Currently the **`llm.router`** surface — opt-in
+[litellm.Router](https://docs.litellm.ai/docs/routing) provider-resilience
+(#1829). **Default OFF**: with `use: false` the LLM call path is the direct
+`litellm.acompletion` (byte-identical to no-Router). When enabled, the Router owns
+infra-exception retry (with native `Retry-After` respect), per-deployment
+cooldown, and a cross-model fallback chain — Reyn does not re-implement any of
+these. The single config surface supersedes the legacy `REYN_LLM_USE_ROUTER` /
+`REYN_LLM_ROUTER_NUM_RETRIES` env vars, which remain a back-compat fallback when
+this block is absent (the `ssl_verify` → env → default idiom).
+
+```yaml
+llm:
+  router:
+    use: false             # master switch (env REYN_LLM_USE_ROUTER is the fallback)
+    num_retries: 3         # infra-exception retries (litellm Retry-After aware)
+    fallbacks:             # primary model → ordered list of fallback models
+      openai/gpt-4o-mini:
+        - openai/gpt-3.5-turbo
+    cooldown_time: 60      # seconds a deployment is cooled down after failures
+    allowed_fails: 2       # failures before a deployment is cooled down
+```
+
+### `llm.router` fields
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `use` | bool | `false` | Master switch. `false` → direct `litellm.acompletion`. Supersedes `REYN_LLM_USE_ROUTER`. |
+| `num_retries` | int | `3` | Infra-exception retry count (Retry-After aware). Supersedes `REYN_LLM_ROUTER_NUM_RETRIES`. |
+| `fallbacks` | map | `{}` | `primary_model → [fallback_model, …]`. Empty → single-deployment Router (no chain). |
+| `cooldown_time` | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
+| `allowed_fails` | int\|null | `null` | Failures before a deployment is cooled down. |
+
 ## `chat` block
 
 Chat-session runtime knobs. `chat.compaction` controls chat-history compaction

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -72,6 +72,26 @@
 
 
 # -----------------------------------------------------------------------------
+# llm.router: litellm.Router provider-resilience (#1829). DEFAULT OFF
+# (use=false → direct litellm.acompletion, byte-identical to no-Router).
+# When on, the Router owns infra-exception retry (with native Retry-After
+# respect), per-deployment cooldown, and a cross-model fallback chain — no
+# self-implemented retry/cooldown/fallback. `use` / `num_retries` supersede the
+# legacy REYN_LLM_USE_ROUTER / REYN_LLM_ROUTER_NUM_RETRIES env vars (which remain
+# a back-compat fallback when this block is absent).
+# -----------------------------------------------------------------------------
+# llm:
+#   router:
+#     use: false             # master switch (REYN_LLM_USE_ROUTER fallback)
+#     num_retries: 3         # infra-exception retries (Retry-After aware)
+#     fallbacks:             # primary model → ordered fallback model list
+#       openai/gpt-4o-mini:
+#         - openai/gpt-3.5-turbo
+#     cooldown_time: 60      # seconds a deployment is cooled down after failures
+#     allowed_fails: 2       # failures before a deployment is cooled down
+
+
+# -----------------------------------------------------------------------------
 # api_base: LiteLLM proxy / direct provider base URL.
 # Empty (default) → providers' own endpoints. A local proxy is the most
 # common override:

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -59,6 +59,78 @@ def _build_agent_config(raw: object) -> AgentConfig:
 
 
 @dataclass
+class RouterConfig:
+    """``llm.router:`` — litellm.Router resilience config (#1829).
+
+    The Router gives provider-resilience (infra-exception retry with native
+    Retry-After respect, per-deployment cooldown, cross-model fallback chain)
+    without Reyn re-implementing it. **Default OFF** — ``use=False`` keeps the
+    direct ``litellm.acompletion`` path (byte-identical to pre-#1829).
+
+    Single config surface: ``use`` / ``num_retries`` supersede the legacy
+    ``REYN_LLM_USE_ROUTER`` / ``REYN_LLM_ROUTER_NUM_RETRIES`` env vars, which
+    remain a back-compat fallback when no reyn.yaml router config is loaded
+    (the ``ssl_verify`` → env → default idiom).
+    """
+
+    use: bool = False
+    num_retries: int = 3
+    # model_name → [fallback model_names]. Converted to litellm's
+    # ``[{primary: [fallbacks]}]`` form when the Router is built. Empty → no
+    # chain (single-deployment Router).
+    fallbacks: dict = field(default_factory=dict)
+    # seconds a deployment is cooled down after ``allowed_fails`` failures
+    # (None → litellm default). Only meaningful with a fallback chain.
+    cooldown_time: float | None = None
+    # failures before a deployment is cooled down (None → litellm default).
+    allowed_fails: int | None = None
+
+
+@dataclass
+class LLMConfig:
+    """``llm:`` — LLM-layer config. Currently the litellm.Router surface (#1829)."""
+
+    router: RouterConfig = field(default_factory=RouterConfig)
+
+
+def _build_router_config(raw: object) -> RouterConfig:
+    """Parse ``llm.router:`` from reyn.yaml. None/missing → defaults (router OFF)."""
+    if raw is None:
+        return RouterConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(f"llm.router must be a mapping, got {type(raw).__name__}")
+    d = RouterConfig()
+    fb = raw.get("fallbacks", d.fallbacks)
+    if fb and not isinstance(fb, dict):
+        raise ValueError(
+            "llm.router.fallbacks must be a mapping (model → [fallbacks]), "
+            f"got {type(fb).__name__}"
+        )
+    return RouterConfig(
+        use=bool(raw.get("use", d.use)),
+        num_retries=int(raw.get("num_retries", d.num_retries)),
+        fallbacks={
+            str(k): [str(x) for x in (v or [])] for k, v in (fb or {}).items()
+        },
+        cooldown_time=(
+            float(raw["cooldown_time"]) if raw.get("cooldown_time") is not None else None
+        ),
+        allowed_fails=(
+            int(raw["allowed_fails"]) if raw.get("allowed_fails") is not None else None
+        ),
+    )
+
+
+def _build_llm_config(raw: object) -> LLMConfig:
+    """Parse ``llm:`` from reyn.yaml. None/missing → defaults."""
+    if raw is None:
+        return LLMConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(f"llm must be a mapping, got {type(raw).__name__}")
+    return LLMConfig(router=_build_router_config(raw.get("router")))
+
+
+@dataclass
 class AuthConfig:
     """``auth:`` — OAuth provider configurations for `reyn auth login`.
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -31,6 +31,7 @@ from reyn.config.infra import (  # #1682 #3 cross-section
     _build_cron_config,
     _build_eval_config,
     _build_events_config,
+    _build_llm_config,
     _build_python_config,
     _build_sandbox_config,
 )
@@ -174,6 +175,17 @@ def _merge(base: dict, override: dict) -> dict:
                 else:
                     merged_safety[sub_key] = sub_val
             result["safety"] = merged_safety
+        elif key == "llm" and isinstance(val, dict):
+            existing = result.get("llm", {})
+            if not isinstance(existing, dict):
+                existing = {}
+            merged_llm = dict(existing)
+            for sub_key, sub_val in val.items():
+                if sub_key == "router" and isinstance(sub_val, dict):
+                    merged_llm["router"] = {**existing.get("router", {}), **sub_val}
+                else:
+                    merged_llm[sub_key] = sub_val
+            result["llm"] = merged_llm
         else:
             result[key] = val
     return result
@@ -372,6 +384,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         model_class_by_purpose=_build_model_class_by_purpose(
             merged.get("model_class_by_purpose"),
         ),
+        llm=_build_llm_config(merged.get("llm")),
         tool_calls_op_loop_skills=[
             str(s) for s in (merged.get("tool_calls_op_loop_skills") or [])
         ],

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -54,6 +54,7 @@ from reyn.config.infra import (
     CronConfig,
     EvalConfig,
     EventsConfig,
+    LLMConfig,
     PythonConfig,
     SandboxConfig,
 )
@@ -96,6 +97,13 @@ class ReynConfig:
     models: dict[str, str | dict] = field(
         default_factory=dict,
         metadata={"desc": "Map of model class names to LiteLLM model strings."},
+    )
+    # #1829: LLM-layer config — the litellm.Router resilience surface
+    # (llm.router.*: use / num_retries / fallbacks / cooldown_time /
+    # allowed_fails). Default OFF (router.use=False → direct litellm.acompletion).
+    llm: LLMConfig = field(
+        default_factory=LLMConfig,
+        metadata={"desc": "LLM-layer config (litellm.Router resilience: llm.router.*)."},
     )
     # #1672: per-purpose model-class override. The mapping from a logical call
     # purpose (router / control_ir / tool / compaction / judge) to a model CLASS

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -78,6 +78,7 @@ class OSRuntime:
         parent_run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
         threat_scan: "object | None" = None,  # FP-0050/#1822 S5 (EP4)
+        router_config: "object | None" = None,  # #1829 S3b: reyn.yaml llm.router.*
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
@@ -113,6 +114,12 @@ class OSRuntime:
         # the call stack. Set at creation → propagates into the op-loop's tasks.
         from reyn.core.events.events import set_llm_request_event_log
         set_llm_request_event_log(self.events)
+        # #1829 S3b: publish reyn.yaml llm.router.* for the LLM chokepoint. Guarded
+        # — only set when provided, so a sub-runtime spawned within a session does
+        # not clobber the session's inherited ContextVar with None.
+        if router_config is not None:
+            from reyn.llm.llm import set_router_config
+            set_router_config(router_config)
         self.workspace = Workspace(
             self.events,
             permission_resolver=permission_resolver,

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -217,6 +217,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 action_retrieval_config=session_cfg.config.action_retrieval,
                 chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
                 embedding_config=session_cfg.config.embedding,
+                router_config=session_cfg.config.llm.router,  # #1829 S3b
                 agent_id=session_cfg.config.agent.id,
                 # #1402: scoped surface passed EXPLICITLY (required by
                 # build_scoped_chat_session). chainlit's current behaviour

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -454,6 +454,7 @@ def run(args: argparse.Namespace) -> None:
             action_retrieval_config=session_cfg.config.action_retrieval,
             chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
+            router_config=session_cfg.config.llm.router,  # #1829 S3b
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -481,6 +481,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # cwd while env_backend pointed at the container). chat.py uses
                 # the same ws_base_dir/ws_state_dir pattern.
                 embedding_config=None,  # gap: dogfood omitted embedding_config (had action_retrieval but not its sibling) → preserved as None
+                router_config=config.llm.router,  # #1829 S3b
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -424,6 +424,7 @@ def run_serve(args: argparse.Namespace) -> None:
             action_retrieval_config=session_cfg.config.action_retrieval,
             chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
+            router_config=session_cfg.config.llm.router,  # #1829 S3b
             # #1402: scoped capability surface, passed EXPLICITLY (required by
             # build_scoped_chat_session). The stdio-MCP factory's current
             # behaviour — defaults that document the gaps, NOT new capabilities

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -335,6 +335,7 @@ def _get_registry():
                 action_retrieval_config=config.action_retrieval,
                 chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
                 embedding_config=config.embedding,
+                router_config=config.llm.router,  # #1829 S3b
                 eager_embedding_build=_eager_embedding_build,
                 # #1401: the 3 scoped capabilities, filled from the CLI override
                 # holder (env-backend INSTANCE → both FS+exec seams = single-shared

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1002,9 +1002,25 @@ def proxy_kwargs() -> dict:
 # reason S1 built per-call). Keying by the RUNNING loop gives each loop its own
 # Router — the same loop-aware-registry pattern as the #1762 agent-lock fix.
 # WeakKeyDictionary → a finished loop's Routers are GC'd with the loop.
-_ROUTERS_BY_LOOP: "weakref.WeakKeyDictionary[object, dict[str, object]]" = (
+_ROUTERS_BY_LOOP: "weakref.WeakKeyDictionary[object, dict[object, object]]" = (
     weakref.WeakKeyDictionary()
 )
+
+
+def _router_cache_fingerprint(rcfg) -> tuple:
+    """#1829 S3b (F1): a hashable signature of the Router-build-affecting config
+    (``num_retries`` / ``cooldown_time`` / ``allowed_fails`` / ``fallbacks``). Part
+    of the per-loop cache key so a changed ``llm.router.*`` rebuilds the Router
+    instead of silently reusing a stale one — the cache is correct WITHOUT relying
+    on a "config is loop-uniform" assumption (today config is process-global, so
+    this is constant; the key just makes that robust against a future per-session
+    override). ``use`` is excluded — it gates entry to this path, not the build."""
+    return (
+        rcfg.num_retries,
+        rcfg.cooldown_time,
+        rcfg.allowed_fails,
+        tuple(sorted((k, tuple(v)) for k, v in rcfg.fallbacks.items())),
+    )
 
 
 def _single_deployment_router(model: str):
@@ -1025,8 +1041,9 @@ def _single_deployment_router(model: str):
     internally — receives the SAME (model, messages, kwargs) as a direct call →
     LLMReplay/cost-recording-compatible. Cached per running loop so the cached
     Router is never reused across event loops (the #1762 binding class). The cache
-    key is the loop+model; the resolved config is session-stable (set once at
-    construction) so a cached Router does not go stale within a loop.
+    key is ``(model, config-fingerprint)`` (#1829 S3b F1) — a changed
+    ``llm.router.*`` rebuilds rather than silently reusing a stale Router, so the
+    cache is correct without assuming config is loop-uniform.
     """
     import litellm as _ll
     rcfg = _resolved_router_config()
@@ -1035,7 +1052,8 @@ def _single_deployment_router(model: str):
     if per_loop is None:
         per_loop = {}
         _ROUTERS_BY_LOOP[loop] = per_loop
-    router = per_loop.get(model)
+    cache_key = (model, _router_cache_fingerprint(rcfg))
+    router = per_loop.get(cache_key)
     if router is None:
         fb_targets = [t for t in (rcfg.fallbacks.get(model) or []) if t and t != model]
         # model_list: primary + each DISTINCT fallback target as its own deployment.
@@ -1053,7 +1071,7 @@ def _single_deployment_router(model: str):
         if rcfg.allowed_fails is not None:
             kwargs["allowed_fails"] = rcfg.allowed_fails
         router = _ll.Router(**kwargs)
-        per_loop[model] = router
+        per_loop[cache_key] = router
     return router
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import json
 import logging
 import os
@@ -545,23 +546,53 @@ _LLM_RETRY_MAX_ATTEMPTS: int = _env_num("REYN_LLM_RETRY_MAX_ATTEMPTS", 3, 1, 10,
 _LLM_RETRY_BASE_S: float = _env_num("REYN_LLM_RETRY_BASE_S", 2.0, 0.1, 30.0, float)
 _LLM_RETRY_MAX_BACKOFF_S: float = 16.0
 
-# #1829 S3a (#1835 fold): per-Router baseline exception-retry count when routing
-# through a litellm.Router. The Router does infra-exception retry WITH native
-# Retry-After respect (and cooldown/fallbacks once S3b adds a multi-deployment
-# model_list), so on the router path Reyn's _llm_call_with_retry drops to
-# empty-choices-only (Router never retries a non-exception 200 → #187 B1 stays
-# Reyn-owned). A per-call num_retries (the callsite's max_retries) still overrides
-# this baseline (probe-verified: per-call wins). Default 3 = today's attempt count.
-_LLM_ROUTER_NUM_RETRIES: int = _env_num("REYN_LLM_ROUTER_NUM_RETRIES", 3, 0, 10, int)
+# #1829 S3b: SINGLE-SOURCE router config resolution. The chokepoint funcs
+# (_use_llm_router / the Router builder) must NOT each read env independently
+# (double-source). They all resolve through ``_resolved_router_config()``:
+# reyn.yaml ``llm.router.*`` (set on this ContextVar by the runtime/session at
+# construction — same pattern as ``set_llm_request_event_log``) is authoritative;
+# when absent (tests / CLI / pre-#1829 configs) it falls back to the legacy env
+# vars + defaults (the ``ssl_verify`` → env → default idiom). One resolution site.
+_router_config_var: "contextvars.ContextVar[object | None]" = contextvars.ContextVar(
+    "reyn_llm_router_config", default=None,
+)
+
+
+def set_router_config(cfg: object) -> "contextvars.Token":
+    """#1829 S3b: set the ambient ``RouterConfig`` (reyn.yaml ``llm.router.*``)
+    the LLM chokepoint resolves against. The runtime/session sets this at
+    construction (mirrors ``set_llm_request_event_log``). Returns the token so a
+    caller MAY reset for a nested scope. ``None`` → env+default fallback."""
+    return _router_config_var.set(cfg)
+
+
+def _env_router_config():
+    """Back-compat ``RouterConfig`` from the legacy env vars + defaults, used when
+    no reyn.yaml router config is in context (tests / CLI / pre-#1829). This is the
+    ``env → default`` tail of the single-source idiom."""
+    from reyn.config.infra import RouterConfig
+    return RouterConfig(
+        use=os.environ.get("REYN_LLM_USE_ROUTER", "").strip().lower()
+        in ("1", "true", "yes"),
+        num_retries=_env_num("REYN_LLM_ROUTER_NUM_RETRIES", 3, 0, 10, int),
+    )
+
+
+def _resolved_router_config():
+    """#1829 S3b single-source: the effective ``RouterConfig``. reyn.yaml (via the
+    ContextVar) is authoritative; absent → env+default. The ONLY place router
+    config is resolved — ``_use_llm_router`` and the Router builder both read this,
+    so there is never a double source (PR-review axis #3)."""
+    cfg = _router_config_var.get()
+    return cfg if cfg is not None else _env_router_config()
 
 
 def _use_llm_router() -> bool:
-    """#1829 S1: gate for routing acompletion through a litellm.Router (default OFF
-    → byte-equivalent to the current direct litellm.acompletion call). S1 is a
-    single-deployment, no-fallback/no-extra-retry equivalence step; fallbacks /
-    cooldown / retry_policy (folding #1835) land in later stages. Env-gated for now
-    (REYN_LLM_USE_ROUTER); a reyn.yaml config field can supersede this in S2."""
-    return os.environ.get("REYN_LLM_USE_ROUTER", "").strip().lower() in ("1", "true", "yes")
+    """#1829: True when the LLM call routes through a litellm.Router. Default OFF
+    → byte-equivalent to the direct ``litellm.acompletion`` call. Resolved
+    single-source from reyn.yaml ``llm.router.use`` (authoritative) or the legacy
+    ``REYN_LLM_USE_ROUTER`` env var (fallback)."""
+    return bool(_resolved_router_config().use)
 
 
 class EmptyLLMResponseError(Exception):
@@ -977,24 +1008,28 @@ _ROUTERS_BY_LOOP: "weakref.WeakKeyDictionary[object, dict[str, object]]" = (
 
 
 def _single_deployment_router(model: str):
-    """#1829 S1→S3a: return a single-deployment ``litellm.Router`` for *model*,
-    cached per running event loop (#1829 S2). The Router owns exception-retry with
-    native Retry-After respect (``num_retries=_LLM_ROUTER_NUM_RETRIES`` baseline; a
-    per-call ``num_retries`` from the callsite's ``max_retries`` overrides it —
-    probe-verified). On this router path Reyn's ``_llm_call_with_retry`` is
-    empty-choices-only (#1835 fold, S3a). A multi-deployment ``model_list`` +
-    ``fallbacks``/``cooldown_time`` (cross-model chain — where multiple deployments
-    are needed) land in S3b.
+    """#1829 S1→S3b: return a per-running-loop-cached ``litellm.Router`` for
+    *model*. Single deployment by default; when reyn.yaml ``llm.router.fallbacks``
+    declares a chain for *model*, a **multi-deployment** Router (primary + each
+    fallback target as its own deployment) wired with ``fallbacks`` +
+    ``cooldown_time`` + ``allowed_fails`` — the #1835 fold (Router owns
+    infra-exception retry w/ native Retry-After + cooldown + cross-model fallback;
+    replay-compat probe-verified: a realized fallback still routes through the
+    monkeypatched ``litellm.acompletion``). ``num_retries`` comes from the
+    single-source resolved config (``_resolved_router_config`` — reyn.yaml
+    authoritative, env fallback), NOT a module constant (no double source).
 
     Per-call routing params (api_base / provider / api_key / response_format / …)
     are passed through on the ``router.acompletion`` call (not baked into the
     deployment), so the underlying ``litellm.acompletion`` — which Router invokes
-    internally (replay-compat verified, #1829 probe) — receives the SAME
-    (model, messages, kwargs) as a direct call → byte-equivalent +
-    LLMReplay/cost-recording-compatible. The cache is keyed per running loop so
-    the cached Router is never reused across event loops (the #1762 binding class).
+    internally — receives the SAME (model, messages, kwargs) as a direct call →
+    LLMReplay/cost-recording-compatible. Cached per running loop so the cached
+    Router is never reused across event loops (the #1762 binding class). The cache
+    key is the loop+model; the resolved config is session-stable (set once at
+    construction) so a cached Router does not go stale within a loop.
     """
     import litellm as _ll
+    rcfg = _resolved_router_config()
     loop = asyncio.get_running_loop()
     per_loop = _ROUTERS_BY_LOOP.get(loop)
     if per_loop is None:
@@ -1002,10 +1037,22 @@ def _single_deployment_router(model: str):
         _ROUTERS_BY_LOOP[loop] = per_loop
     router = per_loop.get(model)
     if router is None:
-        router = _ll.Router(
-            model_list=[{"model_name": model, "litellm_params": {"model": model}}],
-            num_retries=_LLM_ROUTER_NUM_RETRIES,
-        )
+        fb_targets = [t for t in (rcfg.fallbacks.get(model) or []) if t and t != model]
+        # model_list: primary + each DISTINCT fallback target as its own deployment.
+        seen = {model}
+        model_list = [{"model_name": model, "litellm_params": {"model": model}}]
+        for t in fb_targets:
+            if t not in seen:
+                seen.add(t)
+                model_list.append({"model_name": t, "litellm_params": {"model": t}})
+        kwargs: dict = {"model_list": model_list, "num_retries": rcfg.num_retries}
+        if fb_targets:
+            kwargs["fallbacks"] = [{model: fb_targets}]
+        if rcfg.cooldown_time is not None:
+            kwargs["cooldown_time"] = rcfg.cooldown_time
+        if rcfg.allowed_fails is not None:
+            kwargs["allowed_fails"] = rcfg.allowed_fails
+        router = _ll.Router(**kwargs)
         per_loop[model] = router
     return router
 
@@ -1340,13 +1387,18 @@ async def recorded_acompletion(
         if rf is not None:
             call_kwargs["response_format"] = rf
         if _use_llm_router():
-            # #1829 S1: route through a single-deployment litellm.Router (gated OFF
-            # by default → this branch is inert in production). Router.acompletion
-            # invokes litellm.acompletion internally (replay-compat verified), so the
-            # LLMReplay monkeypatch + this cost-recording chokepoint both still apply
-            # and the call is byte-equivalent to the direct path.
+            # #1829: route through a litellm.Router (gated OFF by default → this
+            # branch is inert in production). Router.acompletion invokes
+            # litellm.acompletion internally (replay-compat verified, incl. a
+            # realized fallback), so the LLMReplay monkeypatch + this
+            # cost-recording chokepoint both still apply.
+            # S3b single-source num_retries: the Router's retry count comes from
+            # the resolved config (baked at construction), so STRIP the per-call
+            # num_retries (the callsite's max_retries) — else it would override the
+            # config-set value (probe: per-call wins). Config is the one source.
+            router_kwargs = {k: v for k, v in call_kwargs.items() if k != "num_retries"}
             return await _single_deployment_router(effective_model).acompletion(
-                model=effective_model, messages=messages, **call_kwargs
+                model=effective_model, messages=messages, **router_kwargs
             )
         return await litellm.acompletion(model=effective_model, messages=messages, **call_kwargs)
 
@@ -1388,9 +1440,20 @@ async def recorded_acompletion(
         raise
 
     usage = _extract_usage(response)
+    # #1829 S3b (cost-records-actual-model): when routing through the Router, a
+    # FALLBACK may have served the call with a different model than requested —
+    # attribute cost to the model that ACTUALLY ran (``response.model``), not the
+    # requested one. Gated on router-ON + a genuine difference, so the OFF path
+    # (and router-ON without a realized fallback) records ``effective_model``
+    # exactly as before (byte-identical).
+    _cost_model = effective_model
+    if _use_llm_router():
+        _actual = getattr(response, "model", None)
+        if isinstance(_actual, str) and _actual and _actual != effective_model:
+            _cost_model = _actual
     if recorder is not None and usage is not None:
         recorder.record_llm(
-            model=effective_model, agent=agent, usage=usage, purpose=purpose,
+            model=_cost_model, agent=agent, usage=usage, purpose=purpose,
         )
     # #1683: the interactive chat path records cost to the in-memory recorder
     # (→ header) but emits NO usage event, so the TUI cost tab (which reads
@@ -1401,7 +1464,7 @@ async def recorded_acompletion(
     # (Interim: a future cleanup could centralize the kernel's emission into this
     # chokepoint and drop the flag — out of scope here.)
     if emit_cost_events:
-        _emit_chat_cost_events(effective_model, usage)
+        _emit_chat_cost_events(_cost_model, usage)
     return response
 
 

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -65,6 +65,7 @@ def build_scoped_chat_session(
     multimodal_config: Any,  # MultimodalConfig | None
     action_retrieval_config: Any,  # ActionRetrievalConfig | None
     embedding_config: Any,  # EmbeddingConfig | None
+    router_config: Any,  # #1829 S3b RouterConfig | None — reyn.yaml llm.router.*
     tool_calls_op_loop_skills: list[str] | None,  # #1212 op-loop gate
     chat_tool_use_scheme: str,  # #1593 PR-2 config.tool_use.chat — chat-layer ToolUseScheme name (UNIFORM: every frontend resolves the same reyn.yaml value)
     # ── common base (pass-through; session identity/infra, not a drift surface) ──
@@ -109,6 +110,7 @@ def build_scoped_chat_session(
         multimodal_config=multimodal_config,
         action_retrieval_config=action_retrieval_config,
         embedding_config=embedding_config,
+        router_config=router_config,
         tool_calls_op_loop_skills=tool_calls_op_loop_skills,
         chat_tool_use_scheme=chat_tool_use_scheme,
         **base,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -20,6 +20,7 @@ from reyn.config import (  # noqa: F401
     EventsConfig,
     MultimodalConfig,
     OnLimitConfig,
+    RouterConfig,
     SafetyConfig,
     SandboxConfig,
 )
@@ -810,6 +811,11 @@ class Session:
         chat_tool_use_scheme: str = "enumerate-all",
         embedding_config: "EmbeddingConfig | None" = None,
         eager_embedding_build: bool = False,
+        # #1829 S3b: reyn.yaml llm.router.* — set on the LLM chokepoint's
+        # ContextVar at construction (mirrors set_llm_request_event_log). None →
+        # the chokepoint's env+default fallback (back-compat). Skill OSRuntimes
+        # spawned within this session inherit the ContextVar (propagation).
+        router_config: "RouterConfig | None" = None,
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
@@ -1249,6 +1255,12 @@ class Session:
         # the call stack. Set at creation → propagates into the run loop's tasks.
         from reyn.core.events.events import set_llm_request_event_log
         set_llm_request_event_log(self._chat_events)
+        # #1829 S3b: publish reyn.yaml llm.router.* as the ambient router config
+        # for the LLM chokepoint. Guarded — only set when provided, so a nested
+        # construction never clobbers an inherited ContextVar with None.
+        if router_config is not None:
+            from reyn.llm.llm import set_router_config
+            set_router_config(router_config)
         # Issue #162: surface session-level lifecycle events (compaction
         # today; attach/detach + budget warnings as growth) into the
         # conv pane via OutboxMessage(kind="system"). Sibling of the

--- a/tests/test_llm_router_s3b_1829.py
+++ b/tests/test_llm_router_s3b_1829.py
@@ -1,0 +1,169 @@
+"""Tier 2: OS-invariant tests for #1829 S3b — llm.router.* single-source config,
+multi-deployment fallback chain, and cost-records-actual-model.
+
+S3b adds (a) a single-source resolver (``_resolved_router_config`` — reyn.yaml via
+the ContextVar is authoritative, the legacy env vars are the fallback; ONE
+resolution site so ``_use_llm_router`` and the Router builder never double-source),
+(b) a multi-deployment ``litellm.Router`` builder that wires a cross-model
+``fallbacks`` chain from ``llm.router.fallbacks``, and (c) cost-records-actual-model
+(on a router fallback, attribute cost to ``response.model``, gated so the OFF path
+stays byte-identical).
+
+Policy: no mocks of Reyn collaborators — real ``RouterConfig`` + real resolver +
+real ``recorded_acompletion`` + a real ``litellm.Router``. ``litellm.acompletion``
+is patched only because it IS the replay boundary (the same seam ``LLMReplay``
+monkeypatches) — used here to script a deterministic primary-fail → fallback path.
+Tier line first; no private-state / count pins beyond the public contract.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import litellm
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.infra import RouterConfig
+from reyn.llm.llm import (
+    _resolved_router_config,
+    _single_deployment_router,
+    _use_llm_router,
+    recorded_acompletion,
+    set_router_config,
+)
+
+_PRIMARY = "openai/gpt-4o-mini"
+_FALLBACK = "openai/gpt-3.5-turbo"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_router_ctx_and_model_cost(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with NO ambient router config (→ env/default fallback) and
+    no router env vars; litellm.model_cost is snapshot/restored (Router build
+    registers price-less placeholders — the #1762 global-state class)."""
+    monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
+    monkeypatch.delenv("REYN_LLM_ROUTER_NUM_RETRIES", raising=False)
+    llm_mod._router_config_var.set(None)
+    before = dict(litellm.model_cost)
+    yield
+    llm_mod._router_config_var.set(None)
+    litellm.model_cost.clear()
+    litellm.model_cost.update(before)
+
+
+class _Usage:
+    def __init__(self, p: int, c: int) -> None:
+        self.prompt_tokens = p
+        self.completion_tokens = c
+
+
+class _Resp:
+    def __init__(self, model: str) -> None:
+        self.choices = [object()]
+        self.model = model
+        self.usage = _Usage(10, 5)
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.models: list[str] = []
+
+    def record_llm(self, *, model, agent, usage, purpose) -> None:
+        self.models.append(model)
+
+
+# ── (a) single-source config resolution ──────────────────────────────────────
+
+def test_contextvar_config_is_authoritative() -> None:
+    """Tier 2: reyn.yaml (the ContextVar RouterConfig) is the authoritative source;
+    _use_llm_router + num_retries both read it (single source, no env)."""
+    set_router_config(RouterConfig(use=True, num_retries=7))
+    assert _use_llm_router() is True
+    assert _resolved_router_config().num_retries == 7
+
+
+def test_env_fallback_when_no_contextvar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: with NO reyn.yaml config in context, the legacy env vars are the
+    fallback tail of the single-source idiom (back-compat)."""
+    monkeypatch.setenv("REYN_LLM_USE_ROUTER", "1")
+    monkeypatch.setenv("REYN_LLM_ROUTER_NUM_RETRIES", "4")
+    assert _use_llm_router() is True
+    assert _resolved_router_config().num_retries == 4
+
+
+def test_router_off_by_default() -> None:
+    """Tier 2: no config + no env → router OFF (the direct litellm.acompletion path)."""
+    assert _use_llm_router() is False
+
+
+# ── (b) multi-deployment fallback chain builder ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fallback_chain_built_and_fires() -> None:
+    """Tier 2: a configured llm.router.fallbacks chain builds a multi-deployment
+    Router that actually falls back to the next model when the primary fails."""
+    set_router_config(RouterConfig(use=True, num_retries=0, fallbacks={_PRIMARY: [_FALLBACK]}))
+    calls: list[str] = []
+
+    async def _fake(*a, **k):
+        m = k.get("model")
+        calls.append(m)
+        if m == _PRIMARY:
+            raise litellm.InternalServerError("primary down", model=_PRIMARY, llm_provider="openai")
+        return _Resp(m)
+
+    with mock.patch.object(litellm, "acompletion", side_effect=_fake):
+        resp = await _single_deployment_router(_PRIMARY).acompletion(
+            model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
+        )
+    assert resp.model == _FALLBACK, "the chain must fall back to the configured model"
+    assert _PRIMARY in calls and _FALLBACK in calls, (
+        "both the primary attempt and the fallback must route through "
+        "litellm.acompletion (replay-compat)"
+    )
+
+
+# ── (c) cost-records-actual-model (+ OFF byte-identical) ──────────────────────
+
+@pytest.mark.asyncio
+async def test_cost_records_actual_model_on_fallback() -> None:
+    """Tier 2: when a router fallback serves the call, cost is attributed to the
+    ACTUAL deployment (response.model), not the requested model."""
+    set_router_config(RouterConfig(use=True, num_retries=0, fallbacks={_PRIMARY: [_FALLBACK]}))
+    rec = _Recorder()
+
+    async def _fake(*a, **k):
+        if k.get("model") == _PRIMARY:
+            raise litellm.InternalServerError("down", model=_PRIMARY, llm_provider="openai")
+        return _Resp(k.get("model"))
+
+    with mock.patch.object(litellm, "acompletion", side_effect=_fake):
+        await recorded_acompletion(
+            model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
+            purpose="dogfood", recorder=rec,
+        )
+    assert rec.models == [_FALLBACK], (
+        "a fallback must record cost against the model that actually ran, not the "
+        f"requested one (got {rec.models!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cost_records_requested_model_when_router_off() -> None:
+    """Tier 2: OFF path is byte-identical — cost records the REQUESTED model even
+    if the (direct) response.model string differs (no actual-model switch)."""
+    # router OFF (default). The direct litellm.acompletion path.
+    rec = _Recorder()
+
+    async def _fake(*a, **k):
+        return _Resp("some/normalized-name")  # response.model != requested
+
+    with mock.patch.object(litellm, "acompletion", side_effect=_fake):
+        await recorded_acompletion(
+            model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
+            purpose="dogfood", recorder=rec,
+        )
+    assert rec.models == [_PRIMARY], (
+        "OFF path must record the requested model (byte-identical), not switch to "
+        f"response.model (got {rec.models!r})"
+    )

--- a/tests/test_llm_router_s3b_1829.py
+++ b/tests/test_llm_router_s3b_1829.py
@@ -126,6 +126,20 @@ async def test_fallback_chain_built_and_fires() -> None:
 # ── (c) cost-records-actual-model (+ OFF byte-identical) ──────────────────────
 
 @pytest.mark.asyncio
+async def test_router_cache_rebuilds_on_config_change() -> None:
+    """Tier 2: (F1) the per-loop Router cache key includes a config fingerprint —
+    a changed llm.router.* rebuilds the Router (no silent stale reuse), while the
+    same config still hits the cache (the #1762 loop-cache efficiency is kept)."""
+    set_router_config(RouterConfig(use=True, num_retries=2))
+    r1 = _single_deployment_router(_PRIMARY)
+    assert _single_deployment_router(_PRIMARY) is r1, "same config must hit the cache"
+    set_router_config(RouterConfig(use=True, num_retries=5))  # config changed
+    assert _single_deployment_router(_PRIMARY) is not r1, (
+        "a changed config must rebuild the Router, not reuse a stale-config one"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cost_records_actual_model_on_fallback() -> None:
     """Tier 2: when a router fallback serves the call, cost is attributed to the
     ACTUAL deployment (response.model), not the requested model."""

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -62,6 +62,7 @@ _REQUIRED_SCOPED = frozenset({
     "multimodal_config",
     "action_retrieval_config",
     "embedding_config",
+    "router_config",  # #1829 S3b reyn.yaml llm.router.* (per-session, UNIFORM)
     "tool_calls_op_loop_skills",
     "chat_tool_use_scheme",  # #1593 PR-2 per-layer chat scheme selector
 })


### PR DESCRIPTION
**[dogfood-coder]** — #1829 S3b. The cross-model fallback-chain slice behind a single **reyn.yaml `llm.router.*`** config surface. Greenlit (steer locked at #1829#issuecomment-4756094981); probe-verified replay-compat before impl. **Default OFF** (`llm.router.use=false` → direct `litellm.acompletion`, byte-identical).

## What this adds
- **Config surface** `llm.router.*` — `use` / `num_retries` / `fallbacks` (map: primary → [fallbacks]) / `cooldown_time` / `allowed_fails`. `RouterConfig`+`LLMConfig` in `config/infra.py`, `ReynConfig.llm`, loader build + deep-merge. Mirrored in `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md` (**config-mirror gate #1056 green**).
- **Multi-deployment Router builder** — when `fallbacks[model]` is set, build primary + fallback-target deployments wired with `fallbacks`/`cooldown_time`/`allowed_fails`; else single-deployment (S3a). Folds the multi-deployment part of #1835.
- **Single-source resolution** — `_resolved_router_config()` (ContextVar set by Session/OSRuntime via `set_router_config`; reyn.yaml authoritative, ENV fallback). Removes the S3a `_LLM_ROUTER_NUM_RETRIES` module constant; `_use_llm_router` + the builder both read this one resolver.
- **Plumbing** — Session/OSRuntime set the ContextVar at construction (guarded, so skill sub-runtimes inherit); `build_scoped_chat_session` required `router_config` param (#1402 completeness-by-construction, invariant extended); 5 frontends pass `cfg.llm.router`.

## Lead's 4 review axes (addressed)
1. **cost-records-actual-model** — on a fallback, `recorded_acompletion` records `response.model` (actual deployment), gated on router-ON + a genuine diff. Test: `test_cost_records_actual_model_on_fallback` (real fallback path, asserts `[fallback]`).
2. **OFF byte-identical** — the actual-model switch + the router branch are both behind `_use_llm_router()`. Tests: `test_cost_records_requested_model_when_router_off` + replay OFF byte-identical.
3. **single-source** — one resolver (`_resolved_router_config`); no double source (module env-constant removed). Tests: `test_contextvar_config_is_authoritative` + `test_env_fallback_when_no_contextvar`.
4. **AST-guard #1190** — `litellm.acompletion` stays inside `recorded_acompletion` / the Router library; no new reyn-code call site.

## Scope note
`retry_policy` **deferred** — it needs a typed litellm `RetryPolicy` object (marginal over `num_retries` + `cooldown_time`); the 5 delivered knobs cover the fallback-chain robustness. Credential rotation stays S4 (per steer).

## Test plan
- [x] S3b Tier-2 **6/6** (single-source ×3, fallback-chain fires, cost-actual-model, OFF byte-identical) + tier-audit clean
- [x] router S1/S2/S3a/S3b + cost-accumulation + config-mirror #1056 + #1402 invariant: **25 passed**
- [x] replay **OFF (17p+1xf, byte-identical)** + **ON (17p+1xf, green)**
- [x] config loader/schema sweep **68 passed**; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)