### PR TITLE
feat(tui/1154): concrete email + diff viewers (owner-approved slice)

### DIFF
--- a/docs/reference/tui/tool-result-viewers.md
+++ b/docs/reference/tui/tool-result-viewers.md
@@ -1,0 +1,265 @@
+---
+type: reference
+topic: tui
+audience: [human, agent]
+---
+
+# Tool-result viewers
+
+The Right Panel events-tab preview renders a tool result (`tool_returned` /
+`tool_executed`) richer than the generic YAML fallback — the Jupyter-style
+"content-type → viewer" idea from #1154. A pluggable **viewer registry** maps a
+result dict to a [Rich](https://rich.readthedocs.io/) renderable; when no
+registered viewer matches, an **LLM-generated template** produces an adaptive
+card for the unknown shape.
+
+This page is the authoring/usage reference. The design rationale lives in the
+proposal `docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md`.
+
+Module: `src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py`.
+It is intentionally pure (dict in → renderable or `None`), so viewers are
+unit-testable without the Textual app.
+
+## How rendering is dispatched
+
+There are two entry points:
+
+| Function | Path |
+|---|---|
+| `render_tool_result(result)` | Sync. Walks the registry; returns the first match. |
+| `render_tool_result_async(result, llm_client)` | Sync registry first, then LLM-template fallback. `llm_client=None` disables the LLM path. |
+
+`render_tool_result` walks the ordered registry and **returns the output of the
+first viewer whose predicate matches** — even if that output is `None`:
+
+```python
+for entry in _VIEWERS:
+    if entry.predicate(result):
+        return entry.viewer(result)   # first predicate match wins
+return None
+```
+
+**Gotcha — make predicates precise.** Because the first matching predicate
+"claims" the result, a predicate that matches but whose viewer returns `None`
+does *not* fall through to the next registered viewer; the sync result is
+`None` (the caller then shows YAML, or — on the async path — tries the LLM
+template). So a predicate should only return `True` when its viewer can
+actually render that result. Fold the "do I have the fields I need?" check into
+the predicate, or accept that a matched-but-`None` viewer degrades to the
+fallback.
+
+## Authoring a concrete viewer
+
+A viewer is two functions plus a registration call.
+
+```python
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    register_viewer, _content_type_of, _result_text,
+)
+
+def _looks_like_thing(result: dict) -> bool:        # predicate: dict -> bool
+    return _content_type_of(result) == "application/x-thing"
+
+def _viewer_thing(result: dict):                     # viewer: dict -> RenderableType | None
+    text = _result_text(result)
+    if not text:
+        return None                                  # nothing to show -> fall back
+    from rich.panel import Panel
+    return Panel(text)
+
+register_viewer(_looks_like_thing, _viewer_thing, name="thing", position=0)
+```
+
+### `register_viewer(predicate, viewer, *, name="", position=-1)`
+
+| Param | Type | Meaning |
+|---|---|---|
+| `predicate` | `Callable[[dict], bool]` | Return `True` if this viewer should render `result`. |
+| `viewer` | `Callable[[dict], RenderableType \| None]` | Build the Rich renderable, or `None` to decline. |
+| `name` | `str` | Label (used for de-registration in tests, and ordering inserts). |
+| `position` | `int` | `-1` appends (lowest priority); `0` inserts at the front (highest). Any index inserts there. |
+
+First match wins, so **order = priority**. The default population follows the
+module convention: *explicit content-type viewers first, shape-sniff viewers
+last.*
+
+### The predicate: detecting content type
+
+Use `_content_type_of(result)` to read an explicit type. It checks, in order,
+`content_type` / `mimeType` / `mime_type` / `media_type`, then the first
+`media_blocks[0].mimeType`, and returns a lowercased string (or `""`).
+
+```python
+def _pred_json(r: dict) -> bool:
+    ct = _content_type_of(r)
+    return bool(ct) and "json" in ct
+```
+
+When a result carries no declared type, **shape-sniff** the dict instead — test
+for a distinctive set of keys or a recognizable text payload:
+
+```python
+_WEB_SUMMARY_KEYS = ("title", "outline", "first_paragraph", "link_count")
+def _looks_like_web_summary(r: dict) -> bool:
+    return all(k in r for k in _WEB_SUMMARY_KEYS)
+```
+
+Prefer explicit-content-type predicates at a higher priority (lower index) than
+shape-sniff predicates, so a declared type always wins over a heuristic guess.
+
+### The viewer: building the renderable
+
+The viewer returns any Rich `RenderableType` (`Table`, `Panel`, `Syntax`,
+`Group`, `Markdown`, …) or `None`. Keep it pure — no Textual widgets, no app
+state — so it stays unit-testable.
+
+**Safety: result values are untrusted external content (#1822).** A tool result
+can come from an MCP server, a fetched web page, or a file. If you place a value
+into a Rich `Table`/`Text.from_markup`/any markup-parsing surface, escape it
+first, or Rich will interpret embedded `[red]…[/red]` console markup:
+
+```python
+from rich.markup import escape
+table.add_row("Subject", escape(str(value)[:500]))
+```
+
+Two markup-safe shortcuts that need **no** explicit escape:
+
+- `rich.text.Text(value)` — constructs literal text (does not parse markup).
+  (Note: `Text.from_markup(value)` *does* parse — don't use it on untrusted input.)
+- `rich.syntax.Syntax(value, "lexer")` — renders through a pygments lexer; does
+  not interpret console markup.
+
+## Worked examples — email and diff
+
+These two concrete viewers ship in the module and are the canonical examples.
+
+### Email (header card)
+
+```python
+def _looks_like_email(result: dict) -> bool:
+    # explicit RFC 822 type, OR a from+subject+(to|body) shape
+    if _content_type_of(result) in ("message/rfc822",):
+        return True
+    return ("from" in result and "subject" in result
+            and ("to" in result or "body" in result))
+
+def _viewer_email(result: dict):
+    from rich.console import Group
+    from rich.markup import escape
+    from rich.text import Text
+    table = Table(show_header=False, box=None, expand=False)
+    table.add_column("field", style="bold"); table.add_column("value")
+    for label, key in (("From","from"),("To","to"),("Subject","subject")):
+        val = result.get(key)
+        if isinstance(val, str) and val.strip():
+            table.add_row(label, escape(val[:500]))      # header: escape()
+    body = result.get("body") or ""
+    if body:
+        return Group(table, Text(""), Text(body[:2000]))  # body: Text() (literal)
+    return table
+```
+
+Header values are `escape()`-d; the body is wrapped in `Text` (literal). Both
+are markup-injection-safe.
+
+### Diff (syntax-highlighted)
+
+```python
+def _looks_like_diff(result: dict) -> bool:
+    if _content_type_of(result) in ("text/x-diff", "text/x-patch"):
+        return True
+    text = _result_text(result)
+    if not text:
+        return False
+    if text.lstrip().startswith("diff --git"):
+        return True
+    if "--- " in text and "+++ " in text:
+        return True
+    return "\n@@ " in text or text.startswith("@@ ")
+
+def _viewer_diff(result: dict):
+    text = _result_text(result)
+    if not text.strip():
+        return None
+    from rich.syntax import Syntax
+    return Syntax(text, "diff", theme="ansi_dark", word_wrap=False,
+                  background_color="default")
+```
+
+`Syntax` is markup-injection-safe by construction (lexer, no markup parse).
+
+Both are registered **before the generic JSON viewer** so an email/diff
+delivered with `content_type: application/json` renders as a card, not a raw
+JSON dump — while still sitting after the explicit markdown/csv content-type
+viewers:
+
+```
+markdown, csv, [email, diff], json, image, web_summary
+```
+
+## The LLM-generated template (fallback for unknown shapes)
+
+When no registered viewer matches, `render_tool_result_async` asks an LLM to
+produce a display **schema** for the result's shape, then renders it through a
+fixed, safe applier. This gives adaptive per-shape rendering without a
+hand-built viewer — at a per-shape LLM cost + latency (so it complements, not
+replaces, concrete viewers).
+
+Pipeline:
+
+1. **`_generate_template(result, llm_client)`** — sends only the result's
+   **top-level key names** (never the values) to a cheap/fast model, asking for
+   JSON: `{"rows": [{"label": "...", "field": "key"}], "caption": "..."}`.
+   Returns `None` on any failure.
+2. **`_parse_template_response(raw, valid_keys)`** — the safety fence:
+   - JSON-only (`json.loads`); no `eval`/`exec`.
+   - each `label` is `escape()`-d at construction.
+   - each `field` must be a member of `valid_keys` (strict allowlist) — keys
+     not present in the result dict are dropped.
+   - rows capped at 8; caption capped at 40 chars.
+   - any parse/type error → `None`.
+3. **`TemplateSchema(rows, caption)`** — the parsed, escaped schema:
+   `rows` is a list of `(escaped_label, field_key)` pairs.
+4. **`_apply_template(result, schema)`** — renders the schema as a `Table`,
+   `escape()`-ing each **value** at display time and skipping missing fields.
+
+Caching: `_SHAPE_TEMPLATE_CACHE` maps a shape fingerprint (the frozenset of
+top-level keys) to its `TemplateSchema` — or to `None`, which means "generation
+failed for this shape; do not retry." So each distinct shape costs at most one
+LLM call per session.
+
+### Why two escape layers
+
+The template is, by definition, an LLM-authored description that becomes Rich
+markup. Both the **label** (LLM output, escaped at parse time) and the **value**
+(untrusted result content, escaped at apply time) are escaped, and `field` is
+constrained to an allowlist of real keys. The LLM never sees the values and
+cannot emit `eval`/`exec` — it only picks labels and key names. This is the
+defense-in-depth that lets an untrusted-shape result be rendered by
+LLM-authored layout without a markup-injection or data-exfiltration path.
+
+## Testing viewers
+
+Viewers are pure, so render to a string and assert on content (no Textual app,
+no golden files):
+
+```python
+from io import StringIO
+from rich.console import Console
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import render_tool_result
+
+def _plain(renderable) -> str:
+    buf = StringIO()
+    Console(file=buf, highlight=False, markup=True, width=120).print(renderable)
+    return buf.getvalue()
+
+def test_email_card():
+    out = _plain(render_tool_result({"from": "a@x", "subject": "Hi", "to": "b@y"}))
+    assert "From" in out and "a@x" in out
+```
+
+For escape coverage, assert the literal bracket survives (markup *not*
+interpreted): `assert "[bold]" in _plain(...)`. Register a custom viewer in a
+test with `register_viewer(..., name="_test_x")` and remove it in a `finally`
+via `_VIEWERS[:] = [e for e in _VIEWERS if e.name != "_test_x"]`.

--- a/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
@@ -26,8 +26,13 @@ Design (lead-ratified #1154 Phase 1–3):
     call, cheap/fast model, 256-token cap, None on any failure) +
     ``render_tool_result_async`` (sync registry first, then LLM fallback with
     cache). Not yet wired at the call site (S4).
-  - Phase 3 (S4, deferred): wire ``render_tool_result_async`` at
+  - Phase 3 (S4): wire ``render_tool_result_async`` at
     ``right_panel/__init__.py:_show_event_in_preview``.
+  - Concrete email + diff viewers (owner-approved slice, 2026-06-20): two
+    hand-built viewers for the stable, high-frequency ``email`` (from/subject
+    card) and ``diff`` (syntax-highlighted patch) shapes — deterministic, no
+    LLM cost/latency. Registered before the generic JSON viewer. table/CSV,
+    image, markdown stay on the LLM-template fallback.
 
 This module is intentionally pure (dict in → Rich renderable | None) so it
 is testable in isolation without the Textual app.
@@ -197,6 +202,115 @@ def _viewer_image(result: dict) -> RenderableType | None:
     return table
 
 
+# ---------------------------------------------------------------------------
+# Concrete email + diff viewers (#1154 owner-approved slice, 2026-06-20)
+#
+# These are the two "stable, high-frequency structured types" the owner GO'd
+# for deterministic hand-built rendering (zero LLM cost/latency) on top of the
+# Phase 3 registry seam. Detection is explicit-content-type-first then a
+# shape-sniff pass (mirrors the module's overall design). They are registered
+# *before* the generic JSON viewer so an email/diff result delivered with a
+# ``application/json`` content-type still renders as an email/diff card rather
+# than a raw JSON dump. table/CSV, image, markdown stay on the existing
+# LLM-template fallback — not concrete-ised.
+# ---------------------------------------------------------------------------
+
+# Standard MIME type for an RFC 822 message.
+_EMAIL_CONTENT_TYPES = ("message/rfc822",)
+# Ordered (label, dict-key) header rows for the email card.
+_EMAIL_HEADER_FIELDS = (
+    ("From", "from"),
+    ("To", "to"),
+    ("Cc", "cc"),
+    ("Date", "date"),
+    ("Subject", "subject"),
+)
+_EMAIL_BODY_KEYS = ("body", "text")
+_MAX_EMAIL_FIELD_CHARS = 500
+_MAX_EMAIL_BODY_CHARS = 2000
+
+
+def _looks_like_email(result: dict) -> bool:
+    """True for an explicit message/rfc822 type or a from+subject+(to|body) shape."""
+    if _content_type_of(result) in _EMAIL_CONTENT_TYPES:
+        return True
+    has_envelope = "from" in result and "subject" in result
+    has_recipient_or_body = "to" in result or "body" in result
+    return has_envelope and has_recipient_or_body
+
+
+def _viewer_email(result: dict) -> RenderableType | None:
+    """From/To/Cc/Date/Subject header card + body (Phase-3 concrete viewer).
+
+    All header values are ``escape()``-d (untrusted external content, #1822);
+    the body is wrapped in ``rich.text.Text`` which treats its input as literal
+    (no console-markup parsing), so it is markup-injection-safe by construction.
+    Returns ``None`` when neither a header field nor a body is present, so an
+    empty/ambiguous match falls through to the YAML / LLM-template fallback.
+    """
+    from rich.console import Group
+    from rich.markup import escape
+    from rich.text import Text
+
+    table = Table(show_header=False, box=None, expand=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    rendered_header = False
+    for label, key in _EMAIL_HEADER_FIELDS:
+        val = result.get(key)
+        if isinstance(val, str) and val.strip():
+            table.add_row(label, escape(val[:_MAX_EMAIL_FIELD_CHARS]))
+            rendered_header = True
+
+    body = ""
+    for key in _EMAIL_BODY_KEYS:
+        v = result.get(key)
+        if isinstance(v, str) and v.strip():
+            body = v
+            break
+
+    if not rendered_header and not body:
+        return None
+
+    table.caption = "✉  email"
+    if body:
+        return Group(table, Text(""), Text(body[:_MAX_EMAIL_BODY_CHARS]))
+    return table
+
+
+# Standard MIME types for a unified diff / patch.
+_DIFF_CONTENT_TYPES = ("text/x-diff", "text/x-patch")
+
+
+def _looks_like_diff(result: dict) -> bool:
+    """True for an explicit diff/patch type or unified-diff shape markers."""
+    if _content_type_of(result) in _DIFF_CONTENT_TYPES:
+        return True
+    text = _result_text(result)
+    if not text:
+        return False
+    if text.lstrip().startswith("diff --git"):
+        return True
+    if "--- " in text and "+++ " in text:
+        return True
+    return "\n@@ " in text or text.startswith("@@ ")
+
+
+def _viewer_diff(result: dict) -> RenderableType | None:
+    """Syntax-highlighted unified diff (Phase-3 concrete viewer).
+
+    ``rich.syntax.Syntax`` renders the raw text through a pygments lexer and
+    does NOT interpret console markup, so the (untrusted, #1822) diff text is
+    markup-injection-safe without an explicit escape pass.
+    """
+    text = _result_text(result)
+    if not text.strip():
+        return None
+    from rich.syntax import Syntax
+
+    return Syntax(text, "diff", theme="ansi_dark", word_wrap=False, background_color="default")
+
+
 _WEB_SUMMARY_KEYS = ("title", "outline", "first_paragraph", "link_count")
 _MAX_OUTLINE_ROWS = 12
 
@@ -264,6 +378,16 @@ register_viewer(_pred_csv, _viewer_csv, name="csv")
 register_viewer(_pred_json, _viewer_json, name="json")
 register_viewer(_pred_image, _viewer_image, name="image")
 register_viewer(_looks_like_web_summary, _viewer_web_summary, name="web_summary")
+
+# Concrete email + diff viewers fire AFTER explicit markdown/csv content-types
+# but BEFORE the generic JSON viewer (owner-approved slice). Insert at the json
+# entry's current index rather than a hardcoded position so this stays correct
+# if the default population order changes.
+def _index_of(name: str) -> int:
+    return next((i for i, e in enumerate(_VIEWERS) if e.name == name), len(_VIEWERS))
+
+register_viewer(_looks_like_email, _viewer_email, name="email", position=_index_of("json"))
+register_viewer(_looks_like_diff, _viewer_diff, name="diff", position=_index_of("json"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_tool_result_viewer_email_diff.py
+++ b/tests/cli/test_tool_result_viewer_email_diff.py
@@ -1,0 +1,237 @@
+"""Tier 2: concrete email + diff viewers (#1154 owner-approved slice).
+
+Two hand-built viewers added on the Phase 3 registry seam (#1853) for the
+stable, high-frequency ``email`` and ``diff`` shapes — deterministic, zero
+LLM cost. Registered BEFORE the generic JSON viewer so an email/diff result
+delivered with an ``application/json`` content-type still renders as a card,
+not a raw JSON dump.
+
+Covered contracts:
+A. email — content-type detection, shape-sniff detection, value escaping,
+   priority over generic JSON.
+B. diff — content-type detection, shape-sniff detection, markup-injection
+   safety, priority over generic JSON.
+C. non-overreach — explicit markdown/csv content-types still win; unrelated
+   dicts fall through.
+
+Falsification anchors:
+- email value escaping: a subject containing "[bold]x[/bold]" renders literal.
+- email-over-json: a from+subject+body dict with content_type json renders
+  the email card (not JSON) — proves registration position.
+- diff shape-sniff: a "diff --git" payload with no content_type is detected.
+- non-overreach: a plain {"k": "v"} dict matches neither and returns None.
+"""
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    render_tool_result,
+)
+
+
+def _plain(renderable) -> str:
+    """Render a Rich renderable to plain text (markup interpreted)."""
+    buf = StringIO()
+    Console(file=buf, highlight=False, markup=True, width=120).print(renderable)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# A. email viewer
+# ---------------------------------------------------------------------------
+
+def test_email_content_type_renders_card() -> None:
+    """Tier 2: a message/rfc822 result renders a header card with From/Subject."""
+    result = {
+        "content_type": "message/rfc822",
+        "from": "alice@example.com",
+        "to": "bob@example.com",
+        "subject": "Lunch?",
+        "body": "Are you free at noon?",
+    }
+    rendered = render_tool_result(result)
+    assert rendered is not None, "expected an email card renderable"
+    plain = _plain(rendered)
+    assert "From" in plain and "alice@example.com" in plain
+    assert "Subject" in plain and "Lunch?" in plain
+    assert "Are you free at noon?" in plain, "expected the body to render"
+
+
+def test_email_shape_sniff_without_content_type() -> None:
+    """Tier 2: from+subject+to shape is detected even with no content_type.
+
+    Falsification: without the shape-sniff branch, a content_type-less email
+    dict would fall through to None.
+    """
+    result = {
+        "from": "carol@example.com",
+        "to": "dave@example.com",
+        "subject": "Status",
+    }
+    rendered = render_tool_result(result)
+    assert rendered is not None, "expected shape-sniff to detect the email"
+    assert "carol@example.com" in _plain(rendered)
+
+
+def test_email_escapes_header_markup() -> None:
+    """Tier 2: header values containing Rich markup render as literal text (#1822).
+
+    Falsification: without escape() on header values, "[bold]x[/bold]" in the
+    subject would be interpreted as markup and the literal brackets would be
+    absent from the output.
+    """
+    result = {
+        "from": "eve@example.com",
+        "subject": "[bold]urgent[/bold]",
+        "body": "see attached",
+    }
+    plain = _plain(render_tool_result(result))
+    assert "[bold]" in plain, f"expected literal '[bold]' (escaped), got: {plain!r}"
+    assert "urgent" in plain
+
+
+def test_email_escapes_body_markup() -> None:
+    """Tier 2: body content containing Rich markup renders as literal text (#1822).
+
+    The body is wrapped in rich.text.Text which does not parse console markup.
+    Falsification: if the body were added via a markup-parsing path, the
+    bracketed tag would be consumed and not appear literally.
+    """
+    result = {
+        "from": "mallory@example.com",
+        "subject": "hi",
+        "body": "[red]injected[/red] payload",
+    }
+    plain = _plain(render_tool_result(result))
+    assert "[red]" in plain, f"expected literal '[red]' in body, got: {plain!r}"
+    assert "injected" in plain
+
+
+def test_email_wins_over_generic_json() -> None:
+    """Tier 2: an email-shaped result with content_type json renders as email.
+
+    This proves the email viewer is registered BEFORE the generic JSON viewer.
+    Falsification: if email were appended after json, the json viewer would
+    match content_type 'application/json' first and dump raw JSON — the
+    distinctive 'From' label / human body line would be absent.
+    """
+    result = {
+        "content_type": "application/json",
+        "from": "frank@example.com",
+        "to": "grace@example.com",
+        "subject": "Report",
+        "body": "Numbers attached.",
+    }
+    plain = _plain(render_tool_result(result))
+    assert "From" in plain, "expected the email card (From label), not a JSON dump"
+    assert "Numbers attached." in plain
+
+
+def test_email_empty_falls_through() -> None:
+    """Tier 2: an rfc822 result with no header/body fields returns None.
+
+    Ambiguous/empty match must fall through to the YAML / LLM fallback rather
+    than render an empty card.
+    """
+    result = {"content_type": "message/rfc822"}
+    assert render_tool_result(result) is None
+
+
+# ---------------------------------------------------------------------------
+# B. diff viewer
+# ---------------------------------------------------------------------------
+
+_GIT_DIFF = (
+    "diff --git a/foo.py b/foo.py\n"
+    "index e69de29..4b825dc 100644\n"
+    "--- a/foo.py\n"
+    "+++ b/foo.py\n"
+    "@@ -0,0 +1 @@\n"
+    "+print('hello')\n"
+)
+
+
+def test_diff_content_type_renders() -> None:
+    """Tier 2: a text/x-diff result renders (non-None)."""
+    result = {"content_type": "text/x-diff", "content": _GIT_DIFF}
+    rendered = render_tool_result(result)
+    assert rendered is not None, "expected a diff renderable"
+    assert "foo.py" in _plain(rendered)
+
+
+def test_diff_shape_sniff_git_header() -> None:
+    """Tier 2: a 'diff --git' payload is detected with no content_type.
+
+    Falsification: without the shape-sniff branch, a content_type-less diff
+    would fall through to None (or be mis-rendered by another viewer).
+    """
+    result = {"content": _GIT_DIFF}
+    rendered = render_tool_result(result)
+    assert rendered is not None, "expected shape-sniff to detect the git diff"
+    assert "hello" in _plain(rendered)
+
+
+def test_diff_shape_sniff_unified_markers() -> None:
+    """Tier 2: a unified diff with --- / +++ markers (no git header) is detected."""
+    text = "--- a/x.txt\n+++ b/x.txt\n@@ -1 +1 @@\n-old\n+new\n"
+    result = {"content": text}
+    rendered = render_tool_result(result)
+    assert rendered is not None, "expected unified-diff markers to be detected"
+
+
+def test_diff_markup_injection_safe() -> None:
+    """Tier 2: diff text containing Rich markup is not interpreted (#1822).
+
+    rich.syntax.Syntax renders raw text through a lexer and does not parse
+    console markup. Falsification: if the diff were routed through a
+    markup-parsing renderer, the bracketed tag would be consumed.
+    """
+    text = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-[bold]x[/bold]\n+y\n"
+    plain = _plain(render_tool_result({"content": text}))
+    assert "[bold]" in plain, f"expected literal '[bold]' in diff, got: {plain!r}"
+
+
+def test_diff_wins_over_generic_json() -> None:
+    """Tier 2: a diff delivered with content_type json renders as a diff.
+
+    Proves the diff viewer is registered BEFORE the generic JSON viewer.
+    """
+    result = {"content_type": "application/json", "content": _GIT_DIFF}
+    plain = _plain(render_tool_result(result))
+    assert "foo.py" in plain and "hello" in plain
+
+
+# ---------------------------------------------------------------------------
+# C. non-overreach — explicit content-types still win, unrelated dicts fall through
+# ---------------------------------------------------------------------------
+
+def test_markdown_content_type_still_wins() -> None:
+    """Tier 2: an explicit text/markdown result is NOT hijacked by email/diff.
+
+    email/diff are registered after markdown/csv, so an explicit markdown
+    content-type still routes to the markdown viewer. Falsification: if email/
+    diff were at position 0, a markdown doc embedding diff-like lines could be
+    mis-detected as a diff.
+    """
+    result = {
+        "content_type": "text/markdown",
+        "content": "# Title\n\n--- a/x\n+++ b/x\nsome prose",
+    }
+    rendered = render_tool_result(result)
+    assert rendered is not None
+    # Markdown renders the heading text; a diff Syntax view would not show
+    # the '#'-stripped heading the same way. Presence of the prose is enough
+    # to confirm a renderable was produced via the markdown path.
+    assert "Title" in _plain(rendered)
+
+
+def test_plain_dict_matches_neither() -> None:
+    """Tier 2: a dict with no email/diff signal returns None (no overreach).
+
+    Falsification: if either predicate were too permissive, this unrelated
+    dict would wrongly render as an email or diff.
+    """
+    assert render_tool_result({"some_key": "some_value", "n": 3}) is None


### PR DESCRIPTION
**[tui-coder]** — #1154 owner-approved narrow concrete-viewer slice. Contract: https://github.com/tya5/reyn/issues/1154 (owner GO 2026-06-20).

## Scope (this slice only)

Two hand-built viewers on the merged Phase 3 registry seam (#1853 `_VIEWERS`/`position`): concrete **`email`** + **`diff`**. table/CSV, image, markdown **stay on the existing LLM-template fallback** (not concrete-ised) — they don't justify hand-built viewers yet.

**Rationale**: registry + LLM-template already gives adaptive per-shape rendering; concrete viewers are the high-ROI optimization for the *stable, high-frequency* email/diff types where deterministic + zero-LLM-cost + zero-latency rendering pays off, without the full-populate maintenance cost.

## Open design Qs (lead asked to resolve at impl)

| Q | Resolution |
|---|---|
| content-type detection (MCP metadata vs shape heuristic) | **explicit MIME wins, then shape-sniff** — mirrors module's existing design. email: `message/rfc822` \| from+subject+(to\|body); diff: `text/x-diff`/`text/x-patch` \| `diff --git`/`--- `+`+++ `/`@@ ` |
| per-type escaping (reuse S2) | email header values `escape()`-d (S2 approach); email body via `rich.text.Text` (no markup parse); diff via `rich.syntax.Syntax` (lexer, no markup parse) — all markup-injection-safe (#1822) |
| ambiguous/empty detection | viewer returns `None` → falls through to YAML / LLM-template fallback (e.g. empty `message/rfc822` with no fields) |

## Registration order

`markdown, csv, [email, diff], json, image, web_summary`

email/diff fire **after** explicit markdown/csv content-types (explicit-type-wins preserved) but **before** the generic JSON viewer — so an email/diff delivered with `content_type: application/json` renders as a card, not a raw JSON dump. Inserted at the json entry's **live index** (not hardcoded) so it survives default-order changes.

## Tests

13 Tier-2 (`tests/cli/test_tool_result_viewer_email_diff.py`):
- email: content-type / shape-sniff / header-escape / body-escape / wins-over-json / empty-fallthrough
- diff: content-type / git-header-sniff / unified-marker-sniff / markup-injection-safe / wins-over-json
- non-overreach: markdown content-type still wins / plain dict → None

## Test plan

- [x] `pytest tests/cli/test_tool_result_viewer_email_diff.py` — 13/13 green
- [x] `pytest` existing viewer suite (registry/1154/template/llm_gen/wire) — 60/60 green (registry reorder non-regressive)
- [x] `ruff check` — clean
- [ ] (skipped — needs live MCP email/diff tool + TUI session) Manual: trigger an email-shaped + diff-shaped tool result in `reyn chat`, confirm the right-panel preview shows the card / syntax-highlighted diff. Covered by unit `_plain`-render assertions on `render_tool_result`.

## Tier self-check

- All Tier 2: assert on public `render_tool_result` surface + `_plain` console-render output.
- No Tier 4: no `len()`-pinning, no private-state asserts, no golden/snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
