### PR TITLE
docs: LLM router resilience + safety parallel gate + TUI viewer registry

### DIFF
--- a/docs/concepts/agent-engineering/reliability-engineering.md
+++ b/docs/concepts/agent-engineering/reliability-engineering.md
@@ -43,6 +43,20 @@ This protects against:
 
 Each LLM HTTP call carries a per-call timeout (`limits.llm.timeout`, default `60`s) passed through to LiteLLM, plus LiteLLM's built-in exponential-backoff retry (`limits.llm.max_retries`, default `3`) for transient failures (`429`, `5xx`, network resets). Application-level rejection (validation, normalization) is handled separately by the re-prompt loop above — these are different failure modes and don't share a budget.
 
+### LLM router resilience (`llm.router.*`)
+
+An opt-in `litellm.Router` slot-in for provider-level resilience. Default OFF (`llm.router.use: false`) — with the switch off the call path is the direct `litellm.acompletion`, byte-identical to behaviour before this feature existed. When `use: true`, the Router owns infra-exception retry, `Retry-After` header handling, per-deployment cooldown, and a cross-model fallback chain; Reyn does not re-implement any of these.
+
+**Retry-After aware retry.** `llm.router.num_retries` (default `3`) caps infra retries (`429`, `5xx`, network resets). Unlike a plain exponential backoff, the Router natively honours provider `Retry-After` response headers, so retry timing respects rate-limit windows rather than a fixed backoff schedule.
+
+**Cross-model fallback chain.** `llm.router.fallbacks` maps each primary deployment to an ordered list of fallback models. On primary failure (after retries exhaust) the Router tries each fallback in order. `llm.router.cooldown_time` + `allowed_fails` cools a deployment after repeated failures so it is bypassed for subsequent calls until recovery.
+
+**Cost accuracy on fallback.** The actual responding model is recorded from `response.model` so cost attribution reflects which deployment served the call, not the originally requested model.
+
+**Replay compatibility.** The Router routes through the same `litellm.acompletion` chokepoint that LLMReplay monkeypatches — a realized fallback still exercises the replay machinery unchanged. The Router is cached per event loop with a `(model, config-fingerprint)` key so a changed `llm.router.*` rebuilds the instance rather than silently reusing a stale one.
+
+See [Config: llm block](../../reference/config/reyn-yaml.md#llm-block) for the full field reference.
+
 ### Python preprocessor timeout
 
 Per `python` preprocessor step, a wall-clock `timeout` (default `30`s) is enforced via subprocess. On timeout the parent SIGKILLs the child and the step fails — the failure surfaces to the LLM as a step result it can react to. The timeout protects against accidentally compute-heavy preprocessor functions (regex catastrophic backtracking, infinite loops in user code).
@@ -67,7 +81,7 @@ Every reliability event lands in the JSONL log:
 
 A few reliability primitives are intentionally simple today and on the roadmap to deepen:
 
-**Retry policy splits cleanly but isn't deep.** Application-level rejections re-prompt up to `max_phase_retries` (default `2`) with the validation error injected as feedback — no jitter, no per-failure-kind strategy. Transient HTTP errors get LiteLLM's built-in exponential backoff via `limits.llm.max_retries`. The two paths don't share state, which is the right shape, but neither path lets the user customize backoff or per-error policy yet.
+**Retry policy splits cleanly but isn't deep.** Application-level rejections re-prompt up to `max_phase_retries` (default `2`) with the validation error injected as feedback — no jitter, no per-failure-kind strategy. Transient HTTP errors are handled by two separate mechanisms that don't share state (which is the right shape): the built-in `litellm.acompletion` retry on the direct path, and the `litellm.Router` on the router-enabled path (see [LLM router resilience](#llm-router-resilience-llmrouter)). The Router path adds Retry-After awareness and per-deployment cooldown, closing the jitter/Retry-After gap for operators who opt in.
 
 **Phase budget is soft, not a hard cancel.** `limits.phase.max_wall_seconds` checks at retry/turn boundaries — a single very long LLM call or preprocessor step can overshoot the budget by one operation. This trades "hard guarantees" for "consistent workspace state," and is the right default for most workflows; mid-call cancellation is on the roadmap as an opt-in mode.
 
@@ -80,7 +94,7 @@ A few reliability primitives are intentionally simple today and on the roadmap t
 - [Reference: events](../../reference/runtime/events.md) — full event taxonomy
 - [Reference: llm-output-contract](../../reference/runtime/llm-output-contract.md)
 - [Reference: common-flags](../../reference/cli/common-flags.md) — `--max-phase-visits`, `--phase-budget`, `--llm-timeout`, `--llm-max-retries`
-- [Reference: reyn.yaml](../../reference/config/reyn-yaml.md) — `limits` block
+- [Reference: reyn.yaml](../../reference/config/reyn-yaml.md) — `limits` block · [llm.router.*](../../reference/config/reyn-yaml.md#llm-block)
 - [How-to: debug with events](../../guide/for-skill-authors/operations/debug-with-events.md)
 - [evaluation-and-observability.md](evaluation-and-observability.md) — measuring failure rates
 - [tool-contract-design.md](tool-contract-design.md) — what gets validated

--- a/docs/concepts/runtime/safety.md
+++ b/docs/concepts/runtime/safety.md
@@ -10,6 +10,8 @@ or a clean partial/degrade** — every checkpoint either asks the operator for
 permission to continue, auto-extends within a configured budget, or stops
 with a decision-enabling message that explains what to change.
 
+**Parallel gate design.** The [permission system](permission-model.md) (JIT operator ask for tier-2/3 ops) and this limit framework are intentionally parallel: both share the `RequestBus` interface for their interactive paths, both offer the same three-state gate (`allow` / `deny` / ask), and both degrade to deny when no bus is wired. An operator who understands one gate understands the other.
+
 ---
 
 ## Modes (`safety.on_limit.mode`)

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -162,6 +162,12 @@ mindmap
       Force-close wrap-up
       limit_denied event
       On-limit modes
+    🔄 LLM Provider Resilience
+      litellm.Router delegation
+      Cross-model fallback chain
+      Retry-After aware retry
+      Per-deployment cooldown
+      Default OFF byte-identical
     🧪 Content-layer defense
       Threat-pattern scan
       Content fence
@@ -208,6 +214,9 @@ mindmap
       Conversation view
       Right Panel tabs
       tool-result viewers
+        Viewer registry seam
+        LLM template fallback
+        Email-diff viewer
       Input + command palette
     🐳 Environment
       EnvironmentBackend
@@ -347,6 +356,22 @@ User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2
 | Operator slash commands | `/plan list` / `/plan discard` / `/plan resume --from <step>` for plan lifecycle management | [Plan Mode](concepts/multi-agent/plan-mode.md) |
 
 > **Differentiation vs general agents:** plan decomposition is OS-governed — persisted, resumable per-step (completed steps replay without LLM cost), with per-step compaction and multi-plan concurrency — not an ad-hoc in-prompt task loop.
+
+#### LLM router resilience
+
+Config-gated `litellm.Router` slot-in for provider-resilience. Default OFF (`llm.router.use: false`) — the direct `litellm.acompletion` path is byte-identical. When enabled the Router owns infra retry, Retry-After handling, cooldown, and cross-model fallback; Reyn does not re-implement any of these.
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| litellm.Router delegation | When `llm.router.use: true`, LLM calls route through a `litellm.Router`; Reyn delegates infra-exception retry / Retry-After / cooldown / fallback entirely to the Router | [Config: llm block](reference/config/reyn-yaml.md#llm-block) · [Reliability](concepts/agent-engineering/reliability-engineering.md) |
+| Default OFF — byte-identical | `use: false` (default) keeps the direct `litellm.acompletion` path with no routing overhead; the on/off switch is the only code-path change | [Config: llm block](reference/config/reyn-yaml.md#llm-block) |
+| Cross-model fallback chain | `llm.router.fallbacks` maps primary deployments to an ordered fallback list; on primary failure the Router tries each fallback model in order | [Config: llm block](reference/config/reyn-yaml.md#llm-block) |
+| Retry-After aware retry | `llm.router.num_retries` caps infra retries; the Router natively honours provider `Retry-After` headers (fold of retry-engineering gap) | [Reliability](concepts/agent-engineering/reliability-engineering.md) |
+| Per-deployment cooldown | `llm.router.cooldown_time` + `allowed_fails` cools a deployment after repeated failures; subsequent calls route to the fallback chain until recovery | [Config: llm block](reference/config/reyn-yaml.md#llm-block) |
+| Accurate cost on fallback | On fallback the actual responding model is recorded from `response.model` so cost attribution reflects which deployment served the call | [Budget & Cost](concepts/agent-engineering/cost-management.md) |
+| Config-fingerprint Router cache | Router is cached per event-loop with a `(model, config-fingerprint)` key; a changed `llm.router.*` rebuilds the Router rather than silently reusing a stale instance | [Config: llm block](reference/config/reyn-yaml.md#llm-block) |
+
+> **Differentiation vs general agents:** provider-resilience is delegated entirely to litellm.Router (Retry-After, jitter, cooldown, cross-model fallback chain) rather than re-implemented — the on/off gate keeps the direct path byte-identical, so replay and cost-recording work unchanged whether or not the Router is active.
 
 ---
 
@@ -620,7 +645,9 @@ The Textual terminal interface for `reyn chat` (`src/reyn/interfaces/tui/`).
 |---------|-------------|---------------|
 | Conversation view | Streaming conversation with inline thinking rows and tool-call rendering | — |
 | Right Panel tabs | Live side panels: Agents / Cost / Docs / Events / Keys / Memory / Pending | — |
-| Tool-result viewers | Content-type-aware result cards — text / image / web-page summary (#1154) | — |
+| Tool-result viewer registry ✅ | `register_viewer` seam replaces inline content-type dispatch; viewers registered as `_ViewerEntry` list with content-type + sync renderer | — |
+| LLM-generated template fallback ✅ | On registry miss, `_generate_template` async-generates a `TemplateSchema` (label/value rows + caption) via LLM call; `_apply_template` renders it with label escape and row/caption caps | [FP-0051 proposal](deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md) |
+| Email-diff viewer ⚗ | In-progress specialized viewer for email / diff result types; authoring doc to follow in `docs/reference/` once landed | — |
 | Input + command palette | Input bar with slash commands (`/plan`, `/compact`, `/find`, `/help`, `/clear`) via a command palette | — |
 | Intervention widget | In-TUI `ask_user` prompt rendering | — |
 | Chainlit web chat (⚗ PoC) | Alternative browser chat UI sharing the same agent — `reyn chainlit` + `chainlit_app/` (agent picker, settings, uploads, slash routing); coexists with the TUI | — |

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -216,7 +216,8 @@ mindmap
       tool-result viewers
         Viewer registry seam
         LLM template fallback
-        Email-diff viewer
+        Email viewer
+        Diff viewer
       Input + command palette
     🐳 Environment
       EnvironmentBackend
@@ -645,9 +646,9 @@ The Textual terminal interface for `reyn chat` (`src/reyn/interfaces/tui/`).
 |---------|-------------|---------------|
 | Conversation view | Streaming conversation with inline thinking rows and tool-call rendering | — |
 | Right Panel tabs | Live side panels: Agents / Cost / Docs / Events / Keys / Memory / Pending | — |
-| Tool-result viewer registry ✅ | `register_viewer` seam replaces inline content-type dispatch; viewers registered as `_ViewerEntry` list with content-type + sync renderer | — |
-| LLM-generated template fallback ✅ | On registry miss, `_generate_template` async-generates a `TemplateSchema` (label/value rows + caption) via LLM call; `_apply_template` renders it with label escape and row/caption caps | [FP-0051 proposal](deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md) |
-| Email-diff viewer ⚗ | In-progress specialized viewer for email / diff result types; authoring doc to follow in `docs/reference/` once landed | — |
+| Tool-result viewer registry ✅ | `register_viewer` seam replaces inline content-type dispatch; viewers registered as `_ViewerEntry` list with content-type + sync renderer | [Tool-result viewers reference](reference/tui/tool-result-viewers.md) |
+| LLM-generated template fallback ✅ | On registry miss, `_generate_template` async-generates a `TemplateSchema` (label/value rows + caption) via LLM call; `_apply_template` renders it with label escape and row/caption caps (`_MAX_TEMPLATE_ROWS=8`, `_MAX_CAPTION_CHARS=40`) | [Tool-result viewers reference](reference/tui/tool-result-viewers.md) · [FP-0051 proposal](deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md) |
+| Email-diff viewer ✅ | Concrete viewers for `message/rfc822` (email from/subject card) and `text/x-diff` / `text/x-patch` (syntax-highlighted patch); registered before the generic JSON viewer so declared content-type takes priority | [Tool-result viewers reference](reference/tui/tool-result-viewers.md) |
 | Input + command palette | Input bar with slash commands (`/plan`, `/compact`, `/find`, `/help`, `/clear`) via a command palette | — |
 | Intervention widget | In-TUI `ask_user` prompt rendering | — |
 | Chainlit web chat (⚗ PoC) | Alternative browser chat UI sharing the same agent — `reyn chainlit` + `chainlit_app/` (agent picker, settings, uploads, slash routing); coexists with the TUI | — |


### PR DESCRIPTION
**[docs-maintainer]** — owner 指示 (2026-06-20) による concept doc coverage + feature-map 更新。lead-coder dispatch に基づく。

## Changes

### `docs/concepts/agent-engineering/reliability-engineering.md`
- 新§ **"LLM router resilience (`llm.router.*`)"** — litellm.Router 委譲、Retry-After aware retry、cross-model fallback chain、cooldown、fallback 時の cost accuracy、replay 互換性、config-fingerprint cache を記述
- "Where it's still thin" retry 段落更新: Router path が jitter/Retry-After gap を解消(opt-in) と明記、新§へ cross-ref 追加
- See Also: `llm.router.*` anchor link 追加

### `docs/concepts/runtime/safety.md`
- **"Parallel gate design"** note 追加: limit framework と permission system が `RequestBus` を共有し 3-state gate (allow/deny/ask) が平行設計であることを 1 段落明示

### `docs/feature-map.md`
- 新 mindmap node: 🔄 LLM Provider Resilience (5 children)
- Chat Engine 下に新§ **"LLM router resilience"** (7-row table: delegation / default-OFF / fallback chain / retry / cooldown / cost / cache fingerprint)
- TUI § tool-result viewers: 1行を3行に展開 (registry seam ✅ / LLM template fallback ✅ / email-diff ⚗)、history ref 削除、mindmap node に3 children 追加

## Accuracy verification (origin/main)

| claim | file:line | result |
|---|---|---|
| `register_viewer(position=-1)` default | `tool_result_viewers.py:70` | ✓ |
| `_MAX_TEMPLATE_ROWS = 8` | `tool_result_viewers.py:339` | ✓ |
| `_MAX_CAPTION_CHARS = 40` | `tool_result_viewers.py:340` | ✓ |
| Router `_router_cache_fingerprint` + `(model, fingerprint)` key | `llm.py:1010,1055` | ✓ |
| `RequestBus` shared by limit handler + permission gate | `user_intervention.py:7-8,165-169` | ✓ |
| litellm.Router replay-compat (monkeypatch path) | `llm.py:1033` comment | ✓ |

## Test plan

- [ ] `mkdocs build` — no broken links (特に `reliability-engineering.md#llm-router-resilience-llmrouter` anchor + `reyn-yaml.md#llm-block` anchor)
- [ ] feature-map mindmap: mermaid render — 括弧なし node のみ使用確認 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)