### PR TITLE
feat(1829): S4 — credential rotation (llm.router.credentials) — closes #1829 scope

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -317,6 +317,10 @@ llm:
         - openai/gpt-3.5-turbo
     cooldown_time: 60      # seconds a deployment is cooled down after failures
     allowed_fails: 2       # failures before a deployment is cooled down
+    credentials:           # credential rotation — multiple keys per model
+      openai/gpt-4o-mini:  # ENV-VAR NAMES only; NEVER inline a key value
+        - api_key_env: OPENAI_API_KEY_1
+        - api_key_env: OPENAI_API_KEY_2
 ```
 
 ### `llm.router` fields
@@ -328,6 +332,7 @@ llm:
 | `fallbacks` | map | `{}` | `primary_model → [fallback_model, …]`. Empty → single-deployment Router (no chain). |
 | `cooldown_time` | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
 | `allowed_fails` | int\|null | `null` | Failures before a deployment is cooled down. |
+| `credentials` | map | `{}` | Credential rotation: `model → [{api_key_env: ENV_VAR_NAME}]`. Each usable key → one Router deployment (same model) → the Router rotates / fails over across keys. **Reference env-var NAMES only — never inline a key value**; values are read from `os.environ` at build time and are never logged or cache-fingerprinted. A declared model whose env vars all resolve to nothing is a load error (no silent keyless deployment). |
 
 On the Router path, retry count is **config-only**: `num_retries` is taken from
 `llm.router.num_retries` (a per-call `max_retries` is not applied), so the retry

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -89,6 +89,10 @@
 #         - openai/gpt-3.5-turbo
 #     cooldown_time: 60      # seconds a deployment is cooled down after failures
 #     allowed_fails: 2       # failures before a deployment is cooled down
+#     credentials:           # credential rotation — multiple keys per model.
+#       openai/gpt-4o-mini:  # Reference ENV-VAR NAMES only; NEVER inline a key.
+#         - api_key_env: OPENAI_API_KEY_1   # each usable key → one deployment;
+#         - api_key_env: OPENAI_API_KEY_2   # the Router rotates / fails over.
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -84,6 +84,13 @@ class RouterConfig:
     cooldown_time: float | None = None
     # failures before a deployment is cooled down (None → litellm default).
     allowed_fails: int | None = None
+    # #1829 S4: credential rotation. model_name → list of credential refs, each
+    # ``{"api_key_env": "<ENV_VAR_NAME>"}``. Each usable ref becomes a Router
+    # deployment with the SAME model_name + that key, so the Router rotates / fails
+    # over across keys. Keys are referenced by ENV-VAR NAME only — NEVER inline a
+    # key value here (the value is read from os.environ at build time and is never
+    # logged / fingerprinted; only the NAME is).
+    credentials: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -106,6 +113,12 @@ def _build_router_config(raw: object) -> RouterConfig:
             "llm.router.fallbacks must be a mapping (model → [fallbacks]), "
             f"got {type(fb).__name__}"
         )
+    cred = raw.get("credentials", d.credentials)
+    if cred and not isinstance(cred, dict):
+        raise ValueError(
+            "llm.router.credentials must be a mapping (model → [{api_key_env: NAME}]), "
+            f"got {type(cred).__name__}"
+        )
     return RouterConfig(
         use=bool(raw.get("use", d.use)),
         num_retries=int(raw.get("num_retries", d.num_retries)),
@@ -118,6 +131,16 @@ def _build_router_config(raw: object) -> RouterConfig:
         allowed_fails=(
             int(raw["allowed_fails"]) if raw.get("allowed_fails") is not None else None
         ),
+        # ENV-VAR NAMES only (never key values). A non-dict entry / missing
+        # api_key_env is dropped here; an all-unusable model is caught at build.
+        credentials={
+            str(m): [
+                {"api_key_env": str(c["api_key_env"])}
+                for c in (lst or [])
+                if isinstance(c, dict) and c.get("api_key_env")
+            ]
+            for m, lst in (cred or {}).items()
+        },
     )
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1014,21 +1014,66 @@ def _router_cache_fingerprint(rcfg) -> tuple:
     instead of silently reusing a stale one — the cache is correct WITHOUT relying
     on a "config is loop-uniform" assumption (today config is process-global, so
     this is constant; the key just makes that robust against a future per-session
-    override). ``use`` is excluded — it gates entry to this path, not the build."""
+    override). ``use`` is excluded — it gates entry to this path, not the build.
+
+    #1829 S4: includes the credential ENV-VAR NAMES — **never the key VALUES** (the
+    value is read from os.environ at build, never stored/fingerprinted; secret-safe
+    by construction)."""
     return (
         rcfg.num_retries,
         rcfg.cooldown_time,
         rcfg.allowed_fails,
         tuple(sorted((k, tuple(v)) for k, v in rcfg.fallbacks.items())),
+        tuple(sorted(
+            (m, tuple(c.get("api_key_env") for c in (creds or [])))
+            for m, creds in getattr(rcfg, "credentials", {}).items()
+        )),
     )
 
 
+def _deployments_for_model(model: str, rcfg) -> list:
+    """#1829 S4: the litellm deployment(s) for *model*. With ``llm.router.credentials``
+    configured, one deployment per USABLE key (same ``model_name``, ``api_key``
+    resolved from ``os.environ[api_key_env]``) so the Router rotates / fails over
+    across keys; a missing env var is skipped with a warning. A DECLARED
+    ``credentials[model]`` that resolves to ZERO usable keys raises (fail-loud —
+    never a silent keyless deployment, lead decision 2). No credentials → a single
+    plain deployment (S3b behavior). The key VALUE lives only inside the Router
+    deployment — never in per-call kwargs / events / the cache fingerprint."""
+    creds = getattr(rcfg, "credentials", {}).get(model) or []
+    if not creds:
+        return [{"model_name": model, "litellm_params": {"model": model}}]
+    deployments: list = []
+    for c in creds:
+        env_name = c.get("api_key_env")
+        key = os.environ.get(env_name) if env_name else None
+        if not key:
+            logging.getLogger(__name__).warning(
+                "llm.router.credentials[%s]: env var %r is unset — skipping that key",
+                model, env_name,
+            )
+            continue
+        deployments.append(
+            {"model_name": model, "litellm_params": {"model": model, "api_key": key}}
+        )
+    if not deployments:
+        raise RuntimeError(
+            f"llm.router.credentials[{model!r}] is declared but none of its "
+            f"api_key_env vars resolved to a value "
+            f"({[c.get('api_key_env') for c in creds]}) — set one or remove the block"
+        )
+    return deployments
+
+
 def _single_deployment_router(model: str):
-    """#1829 S1→S3b: return a per-running-loop-cached ``litellm.Router`` for
+    """#1829 S1→S4: return a per-running-loop-cached ``litellm.Router`` for
     *model*. Single deployment by default; when reyn.yaml ``llm.router.fallbacks``
     declares a chain for *model*, a **multi-deployment** Router (primary + each
     fallback target as its own deployment) wired with ``fallbacks`` +
-    ``cooldown_time`` + ``allowed_fails`` — the #1835 fold (Router owns
+    ``cooldown_time`` + ``allowed_fails``; and when ``llm.router.credentials``
+    declares keys for a model, that model expands to one deployment per usable key
+    (same model_name) so the Router rotates / fails over across keys (S4) — the
+    #1835 fold (Router owns
     infra-exception retry w/ native Retry-After + cooldown + cross-model fallback;
     replay-compat probe-verified: a realized fallback still routes through the
     monkeypatched ``litellm.acompletion``). ``num_retries`` comes from the
@@ -1055,14 +1100,16 @@ def _single_deployment_router(model: str):
     cache_key = (model, _router_cache_fingerprint(rcfg))
     router = per_loop.get(cache_key)
     if router is None:
-        fb_targets = [t for t in (rcfg.fallbacks.get(model) or []) if t and t != model]
-        # model_list: primary + each DISTINCT fallback target as its own deployment.
-        seen = {model}
-        model_list = [{"model_name": model, "litellm_params": {"model": model}}]
-        for t in fb_targets:
-            if t not in seen:
-                seen.add(t)
-                model_list.append({"model_name": t, "litellm_params": {"model": t}})
+        fb_targets = list(dict.fromkeys(
+            t for t in (rcfg.fallbacks.get(model) or []) if t and t != model
+        ))
+        # model_list: the primary + each DISTINCT fallback target, each EXPANDED to
+        # one deployment per usable credential (S4 rotation) or a single plain
+        # deployment (S3b). Same model_name across a model's credential deployments
+        # → the Router rotates / fails over across keys.
+        model_list: list = []
+        for m in [model, *fb_targets]:
+            model_list.extend(_deployments_for_model(m, rcfg))
         kwargs: dict = {"model_list": model_list, "num_retries": rcfg.num_retries}
         if fb_targets:
             kwargs["fallbacks"] = [{model: fb_targets}]

--- a/tests/test_llm_router_s4_1829.py
+++ b/tests/test_llm_router_s4_1829.py
@@ -1,0 +1,140 @@
+"""Tier 2: OS-invariant tests for #1829 S4 — credential rotation.
+
+S4 adds ``llm.router.credentials`` (model → [{api_key_env: NAME}]): each USABLE key
+becomes a Router deployment with the same model_name (the Router rotates / fails
+over across keys). Decisions (lead-confirmed): keys are referenced by ENV-VAR NAME
+only (read from os.environ at build); a missing env is skipped with a warning; a
+DECLARED model whose keys ALL resolve to nothing raises (fail-loud, no silent
+keyless deployment).
+
+SECURITY (the impl gate): the key VALUE must never appear in the cache fingerprint
+(env-var NAME only) — pinned here WITH falsification (a sentinel value that would
+show up if the impl ever fingerprinted the resolved key). The #1669 redaction
+backstop (api_key stripped from the llm_request event) is also pinned.
+
+Policy: no mocks of Reyn collaborators — real RouterConfig + real builder +
+real litellm.Router. litellm.acompletion is patched only because it IS the replay
+boundary (used to observe which key each rotated call threads). Tier line first.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import litellm
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.infra import RouterConfig
+from reyn.llm.llm import (
+    _deployments_for_model,
+    _redact_llm_request_params,
+    _router_cache_fingerprint,
+    _single_deployment_router,
+    set_router_config,
+)
+
+_M = "openai/gpt-4o-mini"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
+    llm_mod._router_config_var.set(None)
+    before = dict(litellm.model_cost)
+    yield
+    llm_mod._router_config_var.set(None)
+    litellm.model_cost.clear()
+    litellm.model_cost.update(before)
+
+
+def _cfg(**kw) -> RouterConfig:
+    return RouterConfig(use=True, **kw)
+
+
+# ── deployment expansion ─────────────────────────────────────────────────────
+
+def test_credentials_expand_to_one_deployment_per_usable_key(monkeypatch) -> None:
+    """Tier 2: each usable key → one deployment (same model_name) for rotation."""
+    monkeypatch.setenv("K1", "val-1")
+    monkeypatch.setenv("K2", "val-2")
+    cfg = _cfg(credentials={_M: [{"api_key_env": "K1"}, {"api_key_env": "K2"}]})
+    deps = _deployments_for_model(_M, cfg)
+    assert all(d["model_name"] == _M for d in deps), "same model_name → Router rotates"
+    # both keys present as distinct deployments (set equality ⇒ two distinct keys).
+    assert {d["litellm_params"]["api_key"] for d in deps} == {"val-1", "val-2"}
+
+
+def test_missing_env_key_skipped_remaining_used(monkeypatch) -> None:
+    """Tier 2: a missing env var is skipped (degrade); the remaining key still builds."""
+    monkeypatch.setenv("K1", "val-1")
+    monkeypatch.delenv("K2", raising=False)
+    cfg = _cfg(credentials={_M: [{"api_key_env": "K1"}, {"api_key_env": "K2"}]})
+    deps = _deployments_for_model(_M, cfg)
+    # exactly the one usable key survives (K2 skipped) — list equality pins it.
+    assert [d["litellm_params"]["api_key"] for d in deps] == ["val-1"]
+
+
+def test_all_credentials_unusable_raises(monkeypatch) -> None:
+    """Tier 2: a DECLARED credentials[model] resolving to ZERO usable keys raises
+    (fail-loud — never a silent keyless deployment, lead decision 2)."""
+    monkeypatch.delenv("K1", raising=False)
+    monkeypatch.delenv("K2", raising=False)
+    cfg = _cfg(credentials={_M: [{"api_key_env": "K1"}, {"api_key_env": "K2"}]})
+    with pytest.raises(RuntimeError):
+        _deployments_for_model(_M, cfg)
+
+
+def test_no_credentials_single_plain_deployment() -> None:
+    """Tier 2: no credentials → one plain deployment with no api_key (S3b behavior)."""
+    deps = _deployments_for_model(_M, _cfg())
+    assert deps == [{"model_name": _M, "litellm_params": {"model": _M}}]
+
+
+# ── SECURITY: key VALUE never fingerprinted (falsification) ───────────────────
+
+def test_fingerprint_excludes_secret_value_includes_name(monkeypatch) -> None:
+    """Tier 2: (security) the cache fingerprint contains the env-var NAME but NEVER
+    the resolved key VALUE. Falsification: ``_SECRET_SENTINEL`` is the live value of
+    the env var — if the impl ever fingerprinted the resolved key (instead of the
+    name), this assertion goes red."""
+    monkeypatch.setenv("KSEC", "_SECRET_SENTINEL_VALUE_")
+    cfg = _cfg(credentials={_M: [{"api_key_env": "KSEC"}]})
+    fp_repr = repr(_router_cache_fingerprint(cfg))
+    assert "_SECRET_SENTINEL_VALUE_" not in fp_repr, "secret VALUE must NEVER be fingerprinted"
+    assert "KSEC" in fp_repr, "the env-var NAME identifies the credential in the key"
+
+
+def test_redact_strips_api_key_value() -> None:
+    """Tier 2: (security backstop) the #1669 llm_request-event redaction masks an
+    api_key value (double defense; the proxy path injects api_key)."""
+    redacted = _redact_llm_request_params({"api_key": "_SECRET_KEY_VALUE_", "model": _M}, None)
+    assert "_SECRET_KEY_VALUE_" not in repr(redacted), "api_key value must be redacted"
+
+
+# ── rotation through the (real) Router → litellm.acompletion ──────────────────
+
+@pytest.mark.asyncio
+async def test_rotation_routes_each_key_through_litellm_acompletion(monkeypatch) -> None:
+    """Tier 2: a 2-key credentials chain builds a Router that threads BOTH keys to
+    litellm.acompletion across calls (rotation, replay-compatible boundary)."""
+    monkeypatch.setenv("K1", "val-1")
+    monkeypatch.setenv("K2", "val-2")
+    set_router_config(_cfg(credentials={_M: [{"api_key_env": "K1"}, {"api_key_env": "K2"}]}))
+    seen: list = []
+
+    async def _fake(*a, **k):
+        seen.append(k.get("api_key"))
+
+        class _R:
+            choices = [object()]
+            model = _M
+            usage = None
+        return _R()
+
+    with mock.patch.object(litellm, "acompletion", side_effect=_fake):
+        router = _single_deployment_router(_M)
+        for _ in range(6):
+            await router.acompletion(model=_M, messages=[{"role": "user", "content": "x"}])
+    assert {"val-1", "val-2"} <= set(seen), (
+        f"both rotated keys must reach litellm.acompletion (got {set(seen)!r})"
+    )


### PR DESCRIPTION
**[dogfood-coder]** — #1829 **S4 (final stage)**. Credential rotation behind `llm.router.credentials`, greenlit at #1829#issuecomment-4756205184. Probe-grounded; **default-OFF**.

## What this adds
Multiple API keys per model via the litellm.Router: each usable key → a deployment with the **same `model_name`** → the Router rotates / fails over across keys (probe: 2 keys → both threaded to `litellm.acompletion`). **No new plumbing** — `credentials` is a `RouterConfig` field that flows through S3b's existing ContextVar/factory/frontend wiring.

```yaml
llm:
  router:
    use: true
    credentials:
      openai/gpt-4o-mini:
        - api_key_env: OPENAI_API_KEY_1   # ENV-VAR NAME only — never a key value
        - api_key_env: OPENAI_API_KEY_2
```

## Lead decisions (confirmed)
1. **env-ref only** — keys read from `os.environ[api_key_env]` at build (the existing LLM-key convention); `ScopedSecretStore` is per-skill scoping = wrong layer for an infra key pool.
2. **skip+warn per missing env; ALL-unusable → raise** (fail-loud, no silent keyless deployment).
3. **S4 closes #1829** (close-record below).

## Security gate (addressed + tested)
- Cache fingerprint includes the env-var **NAME only — never the key VALUE**; the value lives only inside the Router deployment (absent from per-call kwargs/events by construction). Pinned **with falsification** (`test_fingerprint_excludes_secret_value_includes_name` — a sentinel value that would surface if the impl fingerprinted the resolved key).
- #1669 `_redact_llm_request_params` backstop (api_key stripped) pinned.

## Test plan
- [x] S4 Tier-2 **7/7** (rotation expansion / skip-missing / all-missing→raise / no-creds plain / **fingerprint excludes secret value** / redact backstop / rotation through litellm.acompletion) + tier-audit clean
- [x] S1/S2/S3a/S3b + mirror #1056 + #1402 invariant + cost: **33 passed**
- [x] replay **OFF (byte-identical)** + **ON green** (17p+1xf each)
- [x] config loader/schema sweep **65 passed**; `ruff` clean

## #1829 close-record (condition verification — for lead's close)
The 3 title items (litellm Router を自前実装なしで獲得):
- **fallback chain** ✅ — S3b, merged #1869 (`15d72c5e`)
- **cooldown** ✅ — S3b `cooldown_time`/`allowed_fails`, merged #1869 (`15d72c5e`)
- **credential rotation** ✅ — S4 (this PR)

Out-of-title tracked follow-up: **#1870** (`retry_policy` typed-RetryPolicy passthrough) — not a close blocker.
→ on this PR's merge, all 3 title conditions are satisfied; #1829 is closeable with this record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)