### PR TITLE
feat(1868): unify budget-exceed onto the 3-mode limit framework (deny/auto-allow/ask)

### DIFF
--- a/src/reyn/core/kernel/llm_call_recorder.py
+++ b/src/reyn/core/kernel/llm_call_recorder.py
@@ -170,7 +170,7 @@ class LLMCallRecorder:
                 # else: corrupt memo result → fall through to fresh call
 
         # Normal call path
-        self._check_budget_pre_llm(resolved_model)
+        await self._check_budget_pre_llm(resolved_model)
         self._events.emit(
             "llm_called",
             run_id=self._run_id,
@@ -369,7 +369,7 @@ class LLMCallRecorder:
         the memo-MISS path ONLY — resume-HIT skips the LLM call and replays
         events from the log (ADR-0002), so no double cost/emit.
         """
-        self._check_budget_pre_llm(resolved_model)
+        await self._check_budget_pre_llm(resolved_model)
         self._events.emit(
             "llm_called",
             run_id=self._run_id,
@@ -669,7 +669,7 @@ class LLMCallRecorder:
             return self._caller.split("/", 1)[1]
         return None
 
-    def _check_budget_pre_llm(self, model: str) -> None:
+    async def _check_budget_pre_llm(self, model: str) -> None:
         if self._budget_tracker is None:
             return
         agent = self._budget_agent_name()
@@ -682,10 +682,16 @@ class LLMCallRecorder:
                 agent=agent,
                 chain_id=self._chain_id,
             )
-            raise BudgetExceeded(
-                check.hard_dimension or "budget",
-                format_refusal_message(check, agent=agent),
-            )
+            # #1868: route the exceed through the 3-mode limit policy (deny /
+            # auto-allow / ask-user). Denied — or no policy context (fail-closed)
+            # — raises (today's behavior); approved / auto-extended → proceed past
+            # the cap (the call is still recorded; accounting unchanged).
+            from reyn.llm.llm import _budget_exceed_allows_continue
+            if not await _budget_exceed_allows_continue(check, agent):
+                raise BudgetExceeded(
+                    check.hard_dimension or "budget",
+                    format_refusal_message(check, agent=agent),
+                )
         for dim in check.warn_dimensions:
             self._events.emit(
                 "budget_warn",

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -159,6 +159,12 @@ class OSRuntime:
         self._intervention_bus = intervention_bus
         # FP-0005: per-run safety-limit checkpoint policy.
         self._on_limit = _safety.on_limit
+        # #1868: publish the budget-exceed policy context (reuses safety.on_limit —
+        # one unified limit policy covers budget too) so the per-LLM-call cost gate
+        # (LLMCallRecorder) routes through the 3-mode framework. NOT guarded: bus /
+        # run_id are per-run, so a child runtime correctly re-binds its own context.
+        from reyn.llm.llm import set_budget_limit_context
+        set_budget_limit_context(self._intervention_bus, self._on_limit, run_id, False)
         self._state_log = state_log
         self._skill_registry = skill_registry
         # PR-skill-resume D3b-3: optional ResumePlan for forward-replay

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -595,6 +595,54 @@ def _use_llm_router() -> bool:
     return bool(_resolved_router_config().use)
 
 
+# #1868: ambient budget-limit policy context for the per-LLM-call cost gate. The
+# runtime/session sets (bus, on_limit, run_id, non_interactive) here at the same
+# place it binds the limit framework (mirrors set_llm_request_event_log /
+# set_router_config). UNSET → the budget gate FAILS CLOSED (deny / unattended) — no
+# policy context means no silent allow (owner + safety-critical requirement).
+_budget_limit_context_var: "contextvars.ContextVar[tuple | None]" = contextvars.ContextVar(
+    "reyn_budget_limit_context", default=None,
+)
+
+
+def set_budget_limit_context(
+    bus: object, on_limit: object, run_id: object, non_interactive: bool = False,
+) -> "contextvars.Token":
+    """#1868: publish the budget-exceed policy context (bus / on_limit / run_id /
+    non_interactive) the per-LLM-call cost gate routes through. Set by the runtime
+    at construction; propagates into the run's tasks. Returns the token so a caller
+    MAY reset for a nested scope."""
+    return _budget_limit_context_var.set((bus, on_limit, run_id, non_interactive))
+
+
+async def _budget_exceed_allows_continue(check: object, budget_agent: object) -> bool:
+    """#1868: route a ``check_pre_llm`` refusal through the limit framework's 3-mode
+    policy (``handle_limit_exceeded``). Returns True if the over-budget call may
+    proceed (interactive-approved or bounded auto-extend), False to deny (the caller
+    then raises ``BudgetExceeded`` — today's behavior). The ambient policy context
+    is set by ``set_budget_limit_context``; **UNSET → fail-closed deny** (no policy
+    = no silent allow). BudgetLedger accounting is unchanged — only the exceed→
+    response path is unified; an allowed call is still recorded by construction."""
+    ctx = _budget_limit_context_var.get()
+    if ctx is None:
+        return False  # fail-closed: no policy context → deny (= unattended)
+    bus, on_limit, run_id, non_interactive = ctx
+    from reyn.runtime.budget.budget import format_refusal_message
+    from reyn.runtime.limits.limit_handler import handle_limit_exceeded
+    dimension = getattr(check, "hard_dimension", None) or "budget"
+    decision = await handle_limit_exceeded(
+        bus=bus,
+        on_limit=on_limit,
+        kind=f"cost.{dimension}",  # dimension-in-kind (#1868 Q4): own auto_extend counter + audit
+        run_id=str(run_id or ""),
+        prompt=format_refusal_message(check, agent=budget_agent),
+        detail=(f"agent={budget_agent}" if budget_agent else ""),
+        extension_amount=1.0,  # allow ONE over-cap call past the gate (bounded by auto_extend_times)
+        non_interactive=bool(non_interactive),
+    )
+    return bool(decision.allow_continue)
+
+
 class EmptyLLMResponseError(Exception):
     """The LLM returned a 200 response with an empty ``choices`` list.
 
@@ -1653,10 +1701,15 @@ async def call_llm(
         from reyn.runtime.budget.budget import BudgetExceeded, format_refusal_message
         check = budget.check_pre_llm(model=spec.model, agent=budget_agent)
         if not check.allowed:
-            raise BudgetExceeded(
-                check.hard_dimension or "budget",
-                format_refusal_message(check, agent=budget_agent),
-            )
+            # #1868: route the exceed through the 3-mode limit policy (deny /
+            # auto-allow / ask-user). Denied — or NO policy context (fail-closed)
+            # — raises (today's behavior); approved / auto-extended → proceed past
+            # the cap (the call is still recorded; BudgetLedger accounting unchanged).
+            if not await _budget_exceed_allows_continue(check, budget_agent):
+                raise BudgetExceeded(
+                    check.hard_dimension or "budget",
+                    format_refusal_message(check, agent=budget_agent),
+                )
 
     messages: list[dict] = build_phase_messages(
         frame,
@@ -1881,10 +1934,15 @@ async def call_llm_tools(
         from reyn.runtime.budget.budget import BudgetExceeded, format_refusal_message
         check = budget.check_pre_llm(model=spec.model, agent=budget_agent)
         if not check.allowed:
-            raise BudgetExceeded(
-                check.hard_dimension or "budget",
-                format_refusal_message(check, agent=budget_agent),
-            )
+            # #1868: route the exceed through the 3-mode limit policy (deny /
+            # auto-allow / ask-user). Denied — or NO policy context (fail-closed)
+            # — raises (today's behavior); approved / auto-extended → proceed past
+            # the cap (the call is still recorded; BudgetLedger accounting unchanged).
+            if not await _budget_exceed_allows_continue(check, budget_agent):
+                raise BudgetExceeded(
+                    check.hard_dimension or "budget",
+                    format_refusal_message(check, agent=budget_agent),
+                )
 
     # #309: per-class routing (api_base/provider) wins; None → global proxy.
     _routing = routing_for_spec(spec)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1261,6 +1261,23 @@ class Session:
         if router_config is not None:
             from reyn.llm.llm import set_router_config
             set_router_config(router_config)
+        # #1868: publish the budget-exceed policy context for the chat path's
+        # per-LLM-call cost gate (call_llm / call_llm_tools). Reuses safety.on_limit
+        # (one unified limit policy) + the SAME intervention path the chat-side
+        # limit checkpoint uses (a bus wrapping _dispatch_intervention, which records
+        # the WAL intervention events). run_id falls back to agent_name (session
+        # scope, mirroring _handle_limit_checkpoint); non_interactive flows so a
+        # non-tty run fails closed (bounded). UNSET → fail-closed deny.
+        _session_dispatch = self._dispatch_intervention
+
+        class _ChatBudgetBus:
+            async def request(self, iv):  # type: ignore[no-untyped-def]
+                return await _session_dispatch(iv)
+
+        from reyn.llm.llm import set_budget_limit_context
+        set_budget_limit_context(
+            _ChatBudgetBus(), self._on_limit, self.agent_name, self._non_interactive,
+        )
         # Issue #162: surface session-level lifecycle events (compaction
         # today; attach/detach + budget warnings as growth) into the
         # conv pane via OutboxMessage(kind="system"). Sibling of the

--- a/tests/test_budget_limit_unify_1868.py
+++ b/tests/test_budget_limit_unify_1868.py
@@ -1,0 +1,122 @@
+"""Tier 2: OS-invariant tests for #1868 — budget-exceed → 3-mode limit framework.
+
+The per-LLM-call cost gate no longer hard-denies unconditionally: a
+``check_pre_llm`` refusal routes through ``handle_limit_exceeded``
+(deny / auto-allow / ask-user), reusing ``safety.on_limit`` (lead decision A). The
+policy context (bus / on_limit / run_id / non_interactive) is published by the
+runtime via ``set_budget_limit_context``; **UNSET → fail-closed deny** (safety-
+critical: no policy = no silent allow).
+
+Mandatory gates (lead): (a) fail-closed non-tty, (b) budget-iv falsification
+(exceed→ask→yes=allow / no=deny), (c) unset-context fail-closed. (d) replay OFF
+byte-identical + budget=None inert is covered by the replay suite + the unchanged
+``if budget is not None`` guard (structural).
+
+Policy: real ``BudgetCheck`` + real ``handle_limit_exceeded`` + real
+``OnLimitConfig`` + real ``set_budget_limit_context``; the bus is a minimal fake
+(it IS the user-ask boundary, mirroring test_safety_limit_handler). Tier line first.
+"""
+from __future__ import annotations
+
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.chat import OnLimitConfig
+from reyn.llm.llm import _budget_exceed_allows_continue, set_budget_limit_context
+from reyn.runtime.budget.budget import BudgetCheck
+from reyn.user_intervention import InterventionAnswer
+
+
+@pytest.fixture(autouse=True)
+def _reset_budget_ctx():
+    llm_mod._budget_limit_context_var.set(None)
+    yield
+    llm_mod._budget_limit_context_var.set(None)
+
+
+class _Bus:
+    """Minimal RequestBus fake (mirrors test_safety_limit_handler._FakeBus)."""
+
+    def __init__(self, choice: str | None) -> None:
+        self._choice = choice
+        self.asked = False
+        self.last_kind: str | None = None
+
+    async def request(self, iv) -> InterventionAnswer:  # type: ignore[no-untyped-def]
+        self.asked = True
+        self.last_kind = getattr(iv, "kind", None)
+        return InterventionAnswer(text="", choice_id=self._choice)
+
+
+def _refusal() -> BudgetCheck:
+    return BudgetCheck(allowed=False, hard_dimension="daily_cost_usd", detail="cap reached")
+
+
+# (c) unset-context fail-closed ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unset_context_fails_closed() -> None:
+    """Tier 2: no policy context published → the gate fails CLOSED (deny). A budget
+    exceed with no runtime context must never silently allow."""
+    allowed = await _budget_exceed_allows_continue(_refusal(), "agent-a")
+    assert allowed is False
+
+
+# (b) budget-iv falsification -----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_interactive_yes_allows() -> None:
+    """Tier 2: interactive + user says YES → the over-budget call is allowed
+    (owner intent: 予算到達時も iv による継続判断)."""
+    bus = _Bus("yes")
+    set_budget_limit_context(bus, OnLimitConfig(mode="interactive"), "run-yes", False)
+    assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is True
+    assert bus.asked and bus.last_kind == "safety.limit.cost.daily_cost_usd", (
+        "the budget exceed must reach the user as a cost-kind intervention"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_no_denies() -> None:
+    """Tier 2: (falsification) interactive + user says NO → denied. If the gate
+    ignored the answer this would wrongly allow."""
+    bus = _Bus("no")
+    set_budget_limit_context(bus, OnLimitConfig(mode="interactive"), "run-no", False)
+    assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is False
+
+
+@pytest.mark.asyncio
+async def test_unattended_denies() -> None:
+    """Tier 2: unattended mode → immediate deny (today's default preserved)."""
+    bus = _Bus("yes")  # would say yes, but unattended never asks
+    set_budget_limit_context(bus, OnLimitConfig(mode="unattended"), "run-un", False)
+    assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is False
+    assert bus.asked is False
+
+
+# (a) fail-closed non-tty ---------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_non_interactive_bounded_no_bus_call() -> None:
+    """Tier 2: interactive mode but non-tty (non_interactive=True) → it must NOT
+    hang on the bus and must be BOUNDED. With auto_extend_times=0 it denies
+    immediately; the bus is never asked (no TTY to ask)."""
+    bus = _Bus("yes")
+    set_budget_limit_context(
+        bus, OnLimitConfig(mode="interactive", auto_extend_times=0), "run-nitty", True,
+    )
+    allowed = await _budget_exceed_allows_continue(_refusal(), "agent-a")
+    assert allowed is False, "non-tty interactive with 0 extensions must deny (bounded)"
+    assert bus.asked is False, "non-tty must never dispatch to the bus (no hang)"
+
+
+@pytest.mark.asyncio
+async def test_auto_extend_bounded() -> None:
+    """Tier 2: auto_extend allows up to auto_extend_times then denies (bounded
+    auto-allow), per-(run_id, kind)."""
+    set_budget_limit_context(
+        _Bus(None), OnLimitConfig(mode="auto_extend", auto_extend_times=1), "run-ax", False,
+    )
+    first = await _budget_exceed_allows_continue(_refusal(), "agent-a")
+    second = await _budget_exceed_allows_continue(_refusal(), "agent-a")
+    assert first is True and second is False, "auto_extend is bounded (1 allow, then deny)"


### PR DESCRIPTION
**[dogfood-coder]** — #1868, greenlit at #1868#issuecomment-4756322754 (owner: default interactive). **SAFETY-CRITICAL (budget enforcement)** → please security/safety-review. The per-LLM-call cost gate stops hard-denying unconditionally; a `check_pre_llm` refusal now routes through the FP-0005 3-mode policy, consistent with limit + permission.

## Design (lead-confirmed)
- **Decision A — reuse `safety.on_limit`** (one unified limit policy covers budget too). `BudgetTracker` already receives `safety`; a dedicated `cost.on_limit` would fight the budget↔config import cycle (flagged at budget.py:307) for no UX gain. **No new config field, no mirror change.** owner FYI: budget-mode = safety-limit-mode shared (a dedicated budget policy = a later (B) switch if ever needed).
- **Ambient policy context** `set_budget_limit_context(bus, on_limit, run_id, non_interactive)` (mirrors `set_router_config`/`set_llm_request_event_log`), set by OSRuntime (kernel) + Session (chat, via a bus wrapping `_dispatch_intervention`). **UNSET → fail-closed deny** (no policy = no silent allow).
- **All THREE raise sites** route through `_budget_exceed_allows_continue`: `llm.py:call_llm` + `call_llm_tools`; `llm_call_recorder._check_budget_pre_llm` (now `async`, both callers awaited). Denied / fail-closed → `raise BudgetExceeded` (today's behavior); approved / auto-extended → proceed past the cap.
- `kind=cost.<dimension>` (dimension-in-kind) → per-`(run_id, kind)` auto_extend counter + audit.
- **Preserve** BudgetLedger fsync-per-call accounting — only the exceed→response path is unified; an allowed call is still recorded.

## ⚠️ Scope flag — `ask_on_exceed` deferred (for your call)
The greenlight listed "ask_on_exceed clean-break subsume," but `ask_on_exceed` gates a **DIFFERENT seam** — `per_chain_skill_calls` (FP-0003), which is **already ask-capable** via `_ask_budget_extension` (NOT the unconditional-deny outlier #1868 targets). Subsuming it touches skill_runner + session + budget_gateway = a sizable coupled change. For a safety-critical PR, smaller units are safer, so I **deferred it to a focused follow-up** (it stays functional — non-breaking). → confirm the split, or say if you want it folded in here.

## Test plan
- [x] #1868 Tier-2 **6/6**: (a) fail-closed non-tty (no bus-hang, bounded) · (b) budget-iv falsification (interactive yes=allow / no=deny) · (c) unset-context fail-closed · unattended=deny · auto_extend bounded · kind-carries-dimension (`safety.limit.cost.<dim>`)
- [x] budget + cost + recorder + safety-limit regression: **230 passed**
- [x] kernel / phase / run_orchestrator / router_loop: **97 passed**
- [x] replay **OFF byte-identical** (budget=None inert by the unchanged `if budget is not None` guard)
- [x] `ruff` + tier-audit clean

Companion **#1867** (high-cost-model S4) consumes this once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)