### PR TITLE
feat(1867): high-cost model BLOCK gate (S4) — unified-framework consumer

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -974,12 +974,14 @@ High-cost model pre-selection awareness. Surfaces a `[⚠ high-cost model: …]`
 cost_warn:
   enabled: true
   model_threshold_per_1m_input_usd: 5.0  # warn above $5/1M input tokens
+  block_on_high_cost: false              # optional confirm gate (see below)
 ```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | bool | `true` | Master switch. Set to `false` to silence all model-cost warnings. |
 | `model_threshold_per_1m_input_usd` | float | `5.0` | Warn when the selected model's input rate exceeds this value (USD per 1M tokens). Default catches Opus-class (~$15/1M) without triggering on Sonnet-class (~$3/1M). |
+| `block_on_high_cost` | bool | `false` | When `true`, a `/model <class>` switch to a high-cost model is held for an interactive confirmation and applies **only on approval** (routed through the shared safety-limit framework, the same one budget-exceed continuation uses). A decline leaves the current model unchanged. A non-interactive session (no TTY) **fail-closes** — it cannot show the confirm, so the high-cost switch is denied; keep this `false` to use high-cost models head-less. Session startup stays warn-only regardless of this flag. |
 
 **Pricing source:** reyn looks up model costs from the [LiteLLM pricing database](https://github.com/BerriAI/litellm) (`litellm.model_cost`). Models not in the database are treated as below-threshold (no warning). Custom or proxy models that resolve to a key in the database will be matched.
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -380,6 +380,11 @@
 # cost_warn:
 #   enabled: true
 #   model_threshold_per_1m_input_usd: 5.0  # warn above $5/1M input tokens
+#   block_on_high_cost: false  # #1867: when true, a /model switch to a high-cost
+#                              # model is held for an interactive confirm (unified
+#                              # safety framework) and applies only on approval; a
+#                              # non-interactive session fail-closes (switch denied).
+#                              # Session startup stays warn-only regardless.
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -207,9 +207,16 @@ class CostWarnConfig:
     - ``model_threshold_per_1m_input_usd`` — warn if input rate exceeds this
       value in USD per 1M tokens. Default 5.0: catches Opus-class (~$15/1M)
       without triggering on Sonnet-class (~$3/1M). User-overridable in reyn.yaml.
+    - ``block_on_high_cost`` — #1867 (S4) opt-in: when True, a ``/model`` switch
+      to a high-cost model is held for an interactive confirm via the unified
+      safety framework (``handle_limit_exceeded``); the switch applies only on
+      approval. Default False (warn-only — S1–S3 behaviour). A non-interactive
+      session (no TTY) fail-closes (the switch is denied) since it cannot
+      confirm. Session-startup stays warn-only regardless of this flag.
     """
     enabled: bool = True
     model_threshold_per_1m_input_usd: float = 5.0
+    block_on_high_cost: bool = False
 
 
 @dataclass
@@ -745,9 +752,11 @@ def _build_cost_warn_config(raw: object) -> "CostWarnConfig":
         threshold = float(threshold)
     except (TypeError, ValueError):
         threshold = defaults.model_threshold_per_1m_input_usd
+    block_on_high_cost = raw.get("block_on_high_cost", defaults.block_on_high_cost)
     return CostWarnConfig(
         enabled=bool(enabled),
         model_threshold_per_1m_input_usd=threshold,
+        block_on_high_cost=bool(block_on_high_cost),
     )
 
 

--- a/src/reyn/interfaces/slash/model.py
+++ b/src/reyn/interfaces/slash/model.py
@@ -56,6 +56,22 @@ async def model_cmd(session: "Session", args: str) -> None:
         )
         return
 
+    # #1867 / FP-0052 S4: optional blocking confirm BEFORE the switch is applied.
+    # When ``cost_warn.block_on_high_cost`` is on and the target is high-cost, the
+    # switch is held for an interactive confirm via the unified safety framework;
+    # a decline (or a non-interactive session — fail-closed) leaves the current
+    # model unchanged. No-op (returns True) under the default warn-only config.
+    from reyn.runtime.model_cost_warn import (
+        maybe_block_high_cost_model,
+        maybe_emit_model_cost_warn,
+    )
+    if not await maybe_block_high_cost_model(session, requested, action="model_override"):
+        await reply(
+            session,
+            f"model switch to {requested} cancelled (high-cost model not confirmed).",
+        )
+        return
+
     session._model_override = requested
     # #1752: the per-turn budget consumers (history buffer / context budget
     # advisor) read the live resolved model via their model_fn, but the
@@ -66,7 +82,6 @@ async def model_cmd(session: "Session", args: str) -> None:
     # #1830 / FP-0052: emit model_cost_warn event if the chosen model exceeds
     # the configured cost threshold (pre-selection awareness). De-duped per
     # session: same model warned at most once.
-    from reyn.runtime.model_cost_warn import maybe_emit_model_cost_warn
     maybe_emit_model_cost_warn(session, requested, action="model_override")
 
     await reply(session, f"model → {requested} (this session — clears on restart)")

--- a/src/reyn/runtime/model_cost_warn.py
+++ b/src/reyn/runtime/model_cost_warn.py
@@ -66,3 +66,82 @@ def maybe_emit_model_cost_warn(
         )
     except Exception:
         pass
+
+
+async def maybe_block_high_cost_model(
+    session: "Session",
+    model_class: str,
+    *,
+    action: str,
+) -> bool:
+    """Return whether a high-cost model switch may proceed (#1867 / FP-0052 S4).
+
+    Returns ``True`` when the switch should be applied:
+      - ``cost_warn`` disabled, or ``block_on_high_cost`` off (warn-only,
+        S1–S3 behaviour), or
+      - the resolved model is not high-cost, or
+      - the user approved the interactive confirm.
+
+    Returns ``False`` to BLOCK the switch (the caller must NOT apply it):
+      - block enabled + high-cost + the user declined the confirm, or
+      - block enabled + high-cost + non-interactive session — fail-closed: a
+        confirm cannot be shown, so a costly switch is denied rather than
+        applied silently (#1867 Q2). Operators who run high-cost models
+        head-less keep ``block_on_high_cost=False`` (warn-only).
+
+    The confirm routes through the unified safety framework via
+    ``session._handle_chat_limit_checkpoint`` (= the ``handle_limit_exceeded``
+    wrapper) — no bespoke block path.
+
+    Unexpected errors fail OPEN (return ``True``): the model-cost confirm is an
+    advisory cost-UX convenience, not a security boundary (the budget caps
+    remain the real spend backstop), so a gate bug must never wedge ``/model``.
+    The *explicit* non-interactive case above is the one place this fails closed.
+    """
+    try:
+        cost_warn_cfg = session._config.cost_warn
+        if not cost_warn_cfg.enabled or not cost_warn_cfg.block_on_high_cost:
+            return True
+
+        from reyn.llm.model_cost_rate import (
+            get_input_cost_per_1m_usd,
+            is_high_cost_model,
+        )
+
+        resolved_model = session._resolver.resolve(model_class).model
+        threshold = cost_warn_cfg.model_threshold_per_1m_input_usd
+        if not is_high_cost_model(resolved_model, threshold):
+            return True
+
+        cost = get_input_cost_per_1m_usd(resolved_model)
+        cost_str = f"${cost:.2f}/1M input tokens" if cost is not None else "high-cost"
+
+        if getattr(session, "_non_interactive", False):
+            session._chat_events.emit(
+                "model_cost_block",
+                model=resolved_model,
+                model_class=model_class,
+                cost_per_1m_input_usd=cost,
+                action=action,
+                reason="non_interactive_fail_closed",
+            )
+            return False
+
+        decision = await session._handle_chat_limit_checkpoint(
+            kind="cost.high_cost_model",
+            prompt=f"Switch to high-cost model {resolved_model} ({cost_str})?",
+            detail=f"model_class={model_class}",
+            extension_amount=1.0,
+        )
+        allow = bool(getattr(decision, "allow_continue", False))
+        session._chat_events.emit(
+            "model_cost_block",
+            model=resolved_model,
+            model_class=model_class,
+            cost_per_1m_input_usd=cost,
+            action=action,
+            reason="approved" if allow else "declined",
+        )
+        return allow
+    except Exception:
+        return True

--- a/tests/cli/test_model_cost_block_1867.py
+++ b/tests/cli/test_model_cost_block_1867.py
@@ -1,0 +1,168 @@
+"""Tier 2: high-cost model BLOCK gate (#1867 / FP-0052 S4).
+
+`maybe_block_high_cost_model` is the optional blocking confirm layered on top
+of the #1830/#1861 warn-only feature. When `cost_warn.block_on_high_cost` is
+on and the target is high-cost, a `/model` switch is held for an interactive
+confirm routed through the unified safety framework
+(`session._handle_chat_limit_checkpoint` → `handle_limit_exceeded`). The switch
+applies only on approval; a decline — or a non-interactive session
+(fail-closed) — blocks it.
+
+Falsification anchors:
+- not-bespoke: the confirm is dispatched with kind="cost.high_cost_model"
+  through the session's limit-checkpoint wrapper (a custom block path would
+  never call it).
+- fail-closed: a non-interactive session returns False WITHOUT dispatching a
+  confirm (a prompt would hang) — proving the pre-checkpoint guard.
+- opt-in: block_on_high_cost=False never calls the checkpoint (warn-only).
+- no-gate for cheap: a below-threshold model is never gated.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.config.chat import CostWarnConfig
+from reyn.llm.model_cost_rate import get_input_cost_per_1m_usd
+from reyn.runtime.model_cost_warn import maybe_block_high_cost_model
+
+
+class _FakeEventLog:
+    def __init__(self) -> None:
+        self._emitted: list[tuple[str, dict]] = []
+
+    def emit(self, event_type: str, **data: object) -> None:
+        self._emitted.append((event_type, dict(data)))
+
+    def snapshot(self) -> list[tuple[str, dict]]:
+        return list(self._emitted)
+
+
+class _FakeResolver:
+    def resolve(self, name: str) -> object:
+        class _Spec:
+            model = name
+        return _Spec()
+
+
+class _RecordingCheckpoint:
+    """Records the kind/prompt of each limit-checkpoint call and returns a
+    fixed decision — the unified-framework seam the block must route through."""
+
+    def __init__(self, allow_continue: bool) -> None:
+        self._allow = allow_continue
+        self.calls: list[dict] = []
+
+    async def __call__(self, *, kind: str, prompt: str, detail: str,
+                       extension_amount: float, run_id: str | None = None) -> object:
+        self.calls.append({"kind": kind, "prompt": prompt, "detail": detail})
+        return type("Decision", (), {"allow_continue": self._allow})()
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        *,
+        block: bool,
+        threshold: float,
+        non_interactive: bool = False,
+        checkpoint_allows: bool = True,
+    ) -> None:
+        self._config = type("Cfg", (), {
+            "cost_warn": CostWarnConfig(
+                enabled=True,
+                model_threshold_per_1m_input_usd=threshold,
+                block_on_high_cost=block,
+            ),
+        })()
+        self._resolver = _FakeResolver()
+        self._chat_events = _FakeEventLog()
+        self._non_interactive = non_interactive
+        self._handle_chat_limit_checkpoint = _RecordingCheckpoint(checkpoint_allows)
+
+    @property
+    def checkpoint_calls(self) -> list[dict]:
+        return self._handle_chat_limit_checkpoint.calls
+
+    def event_snapshot(self) -> list[tuple[str, dict]]:
+        return self._chat_events.snapshot()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _skip_if_no_pricing() -> None:
+    if get_input_cost_per_1m_usd("gpt-4o") is None:
+        pytest.skip("gpt-4o not in litellm pricing DB")
+
+
+# ---------------------------------------------------------------------------
+
+def test_approve_allows_switch_via_unified_framework() -> None:
+    """Tier 2: block on + high-cost + approved → True, routed through the
+    kind='cost.high_cost_model' checkpoint (not a bespoke path)."""
+    _skip_if_no_pricing()
+    s = _FakeSession(block=True, threshold=0.0, checkpoint_allows=True)
+    allowed = _run(maybe_block_high_cost_model(s, "gpt-4o", action="model_override"))
+    assert allowed is True
+    assert s.checkpoint_calls, "expected the unified limit-checkpoint to be called"
+    assert s.checkpoint_calls[0]["kind"] == "cost.high_cost_model"
+
+
+def test_decline_blocks_switch() -> None:
+    """Tier 2: block on + high-cost + declined → False (switch must not apply)."""
+    _skip_if_no_pricing()
+    s = _FakeSession(block=True, threshold=0.0, checkpoint_allows=False)
+    allowed = _run(maybe_block_high_cost_model(s, "gpt-4o", action="model_override"))
+    assert allowed is False
+
+
+def test_block_disabled_is_warn_only_no_checkpoint() -> None:
+    """Tier 2: block_on_high_cost=False → True and the checkpoint is NOT called.
+
+    Falsification: if the gate ignored the opt-in flag, the warn-only default
+    (S1–S3) would suddenly start prompting for every high-cost switch.
+    """
+    _skip_if_no_pricing()
+    s = _FakeSession(block=False, threshold=0.0)
+    allowed = _run(maybe_block_high_cost_model(s, "gpt-4o", action="model_override"))
+    assert allowed is True
+    assert s.checkpoint_calls == [], "warn-only must not dispatch a confirm"
+
+
+def test_non_interactive_fail_closed_no_checkpoint() -> None:
+    """Tier 2: non-interactive + block + high-cost → False WITHOUT a confirm.
+
+    Falsification: dispatching a confirm on a non-TTY session would hang; the
+    pre-checkpoint guard must deny first. Asserts no checkpoint call + a
+    fail-closed block event.
+    """
+    _skip_if_no_pricing()
+    s = _FakeSession(block=True, threshold=0.0, non_interactive=True)
+    allowed = _run(maybe_block_high_cost_model(s, "gpt-4o", action="model_override"))
+    assert allowed is False
+    assert s.checkpoint_calls == [], "non-interactive must not dispatch a confirm"
+    reasons = [d.get("reason") for _, d in s.event_snapshot()]
+    assert "non_interactive_fail_closed" in reasons
+
+
+def test_low_cost_model_is_not_gated() -> None:
+    """Tier 2: a below-threshold model is never gated (True, no checkpoint)."""
+    _skip_if_no_pricing()
+    # threshold absurdly high → gpt-4o counts as below-threshold.
+    s = _FakeSession(block=True, threshold=10_000.0)
+    allowed = _run(maybe_block_high_cost_model(s, "gpt-4o", action="model_override"))
+    assert allowed is True
+    assert s.checkpoint_calls == [], "a cheap model must not be gated"
+
+
+def test_unknown_model_is_not_gated() -> None:
+    """Tier 2: an unknown model (no pricing) is treated as not-high-cost → True."""
+    s = _FakeSession(block=True, threshold=0.0)
+    allowed = _run(
+        maybe_block_high_cost_model(s, "__no_such_model__", action="model_override")
+    )
+    assert allowed is True
+    assert s.checkpoint_calls == []


### PR DESCRIPTION
**[tui-coder]** — #1867 (#1830 follow-up S4). Design-checked + lead greenlit (Q1/Q2 confirmed).

## Scope

S1–S3 (#1861) shipped **warn-only** high-cost awareness. S4 adds an **opt-in blocking confirm** before a high-cost `/model` switch takes effect — held until the user approves.

## Consumer-reuse (no bespoke path)

Routes the confirm through the **existing** `session._handle_chat_limit_checkpoint` — the `handle_limit_exceeded` wrapper that budget-exceed continuation (#1868) also uses. The returned `LimitDecision.allow_continue` gates the switch; dispatched with `kind="cost.high_cost_model"`. ✅ AC "reuses the shared framework".

## Design (Q1/Q2 owner-confirmed)

| Q | Resolution |
|---|---|
| Q1 — session-start block semantics | startup stays **warn-only** (a startup model has no switch to withhold); the block applies to explicit `/model` switches only |
| Q2 — non-interactive (no TTY) | **fail-closed at the helper BEFORE dispatching** a confirm (a prompt would hang): the high-cost switch is denied + a `model_cost_block` event. Head-less high-cost use keeps `block_on_high_cost=False` |
| gate error | fails **open** (cost confirm is advisory UX; budget caps are the real spend backstop — a gate bug must not wedge `/model`). The explicit non-interactive case is the one place this fails closed |

## Surface

- `CostWarnConfig.block_on_high_cost: bool = False` (opt-in; warn-only stays default)
- `maybe_block_high_cost_model(session, model_class, *, action) -> bool` (True = apply / False = block)
- `/model <class>`: gate runs **before** `session._model_override = requested`; on block the model is unchanged + a cancel message shown

## Config mirror (#1056 gate)

`block_on_high_cost` documented in both `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md`.

## Tests

6 Tier-2 (`tests/cli/test_model_cost_block_1867.py`):
- approve → apply (routed via `kind="cost.high_cost_model"` — **not-bespoke proof**)
- decline → block / block-disabled → warn-only (no checkpoint) / **non-interactive → fail-closed (no checkpoint)** / low-cost → no-gate / unknown-model → no-gate

## Test plan

- [x] `pytest tests/cli/test_model_cost_block_1867.py` — 6/6 green
- [x] `pytest tests/cli/test_model_cost_warn.py tests/test_slash_model.py` — 25/25 (no regression)
- [x] `pytest tests/test_config_mirror_coverage_1056.py tests/test_config_schema_introspection.py` — 24/24 green
- [x] `ruff check` — clean
- [ ] (skipped — needs live TUI + high-cost model + TTY) Manual: `block_on_high_cost: true`, `/model <high-cost class>` → interactive confirm; approve applies, decline keeps current model. Covered by helper-level Tier-2 (interactive approve/decline via recording checkpoint).

## Tier self-check

- All Tier 2: public `maybe_block_high_cost_model` + event `snapshot()` surface, real `CostWarnConfig` + recording checkpoint (no mocks).
- No Tier 4: no `len()`-pinning, no private-state asserts, no golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
