### PR TITLE
feat(1877): subsume ask_on_exceed into the safety.on_limit 3-mode policy

### DIFF
--- a/docs/deep-dives/proposals/0003-budget-exceed-user-approval.ja.md
+++ b/docs/deep-dives/proposals/0003-budget-exceed-user-approval.ja.md
@@ -1,6 +1,13 @@
 # FP-0003: budget 超過時のユーザー許諾・再開フロー
 
-**Status**: done (landed 2026-05-10、 commit `2ec46c0`)
+> **一部 superseded (#1877, 2026-06-20):** 以下で説明する per-dimension の
+> `CostLimitConfig.ask_on_exceed` bool は撤去され、 unified な `safety.on_limit`
+> 3-mode policy (FP-0005) に subsume された。 `per_chain_skill_calls` の超過フローは
+> `safety.on_limit.mode` (interactive / auto_extend / unattended) で駆動され、
+> `extension_calls > 0` が per-dimension の opt-in シグナル。 `extend_chain_calls`
+> と extension の bookkeeping は不変。 以下の `ask_on_exceed` は歴史的文脈として読むこと。
+
+**Status**: done (landed 2026-05-10、 commit `2ec46c0`); `ask_on_exceed` は `safety.on_limit` に subsume (#1877)
 **Proposed**: 2026-05-10
 **Author**: Research session (eager-shaw-389d9d)
 **Implemented**: 2026-05-10 — `CostLimitConfig.ask_on_exceed` + `extension_calls` フィールド + `BudgetTracker.extend_chain_calls()` + `ChatSession._ask_budget_extension()` ask_user dispatch + 8 Tier 2 invariants (`tests/test_budget_extend_chain.py`)。 後続: FP-0005 Phase 2 で shared `handle_limit_exceeded` helper に統合 (`dad53f4`)、 `cost.per_chain_skill_calls` キー自体は legacy 撤去 (`0b464ab`) で `safety.loop.skill_calls_per_chain` に移動。

--- a/docs/deep-dives/proposals/0003-budget-exceed-user-approval.md
+++ b/docs/deep-dives/proposals/0003-budget-exceed-user-approval.md
@@ -1,6 +1,14 @@
 # FP-0003: User approval and resume flow on budget exceed
 
-**Status**: done (landed 2026-05-10, commit pending)
+> **Superseded in part (#1877, 2026-06-20):** the per-dimension
+> `CostLimitConfig.ask_on_exceed` bool described below was removed and subsumed
+> into the unified `safety.on_limit` 3-mode policy (FP-0005). The exceed flow
+> for `per_chain_skill_calls` is now driven by `safety.on_limit.mode`
+> (interactive / auto_extend / unattended); `extension_calls > 0` is the
+> per-dimension opt-in signal. `extend_chain_calls` + the extension bookkeeping
+> are unchanged. Read `ask_on_exceed` below as historical context.
+
+**Status**: done (landed 2026-05-10); `ask_on_exceed` subsumed into `safety.on_limit` (#1877)
 **Proposed**: 2026-05-10
 **Author**: Research session (eager-shaw-389d9d)
 **Implemented**: 2026-05-10 — `CostLimitConfig.ask_on_exceed` + `extension_calls` fields + `BudgetTracker.extend_chain_calls()` + `ChatSession._ask_budget_extension()` ask_user dispatch + 8 Tier 2 invariants (`tests/test_budget_extend_chain.py`). Backward-compatible: `ask_on_exceed: false` (default) preserves prior hard-refuse behaviour.

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -579,9 +579,9 @@ and the dogfood done-gate remain. Canonical design: [content-threat scan proposa
 | Rate limits | Per-model calls-per-minute sliding window | [Budget config](reference/config/budget.md) |
 | Daily quotas | Persistent JSONL ledger, resets at local midnight | [Budget config](reference/config/budget.md) |
 | Monthly quotas | Persistent JSONL ledger, resets at month boundary | [Budget config](reference/config/budget.md) |
-| `ask_on_exceed` | User-approval extension flow on hard cap hit | [Budget config](reference/config/budget.md) |
+| `extension_calls` (+ `safety.on_limit.mode`) | Budget-extension flow on hard cap hit; `extension_calls > 0` opts the dimension into the unified `safety.on_limit` policy (ask / auto-extend / deny). The per-dimension `ask_on_exceed` bool was removed in #1877. | [Budget config](reference/config/budget.md) |
 
-> **Differentiation vs general agents:** token + USD caps per agent / chain / model with refuse-on-exceed and an `ask_on_exceed` extension flow — runaway spend is structurally bounded, not merely observed after the fact.
+> **Differentiation vs general agents:** token + USD caps per agent / chain / model with refuse-on-exceed and a `safety.on_limit`-driven extension flow — runaway spend is structurally bounded, not merely observed after the fact.
 
 ---
 

--- a/docs/guide/for-skill-authors/operations/understand-why-reyn-stops.ja.md
+++ b/docs/guide/for-skill-authors/operations/understand-why-reyn-stops.ja.md
@@ -118,13 +118,18 @@ safety:
   loop:
     skill_calls_per_chain:
       hard_limit: 5
-      ask_on_exceed: true       # ask_user 経由で問い合わせる
-      extension_calls: 3        # 承認時に +3 回付与
+      extension_calls: 3        # 拡張 1 回あたり +3 回。 > 0 で
+                                # この dimension が safety.on_limit フローに参加
+  on_limit:
+    mode: interactive           # 到達時に問い合わせ(default)。 他に
+                                # auto_extend(bounded) / unattended(deny)
 ```
 
-上限到達時に Reyn が *「Skill `X` が上限 5 回に達しました。+3 回追加で
-継続しますか?」* と問います。承認は何度でも可能で、毎回 `extension_calls`
-分だけキャップが拡張されます。
+`on_limit.mode: interactive` で上限到達時に Reyn が *「Skill `X` が上限 5 回に
+達しました。+3 回追加で継続しますか?」* と問います。承認は何度でも可能で、
+毎回 `extension_calls` 分だけキャップが拡張されます。 (per-dimension の
+`ask_on_exceed` bool は #1877 で撤去 — 超過時の挙動は unified な
+`safety.on_limit.mode` に従います。)
 
 ---
 
@@ -169,7 +174,7 @@ safety:
 | `safety.loop.max_router_calls_per_turn` | `Session._check_and_increment_router_cap` | interactive / auto_extend |
 | `safety.loop.max_agent_hops` | `Session._send_to_agent` | interactive / auto_extend |
 | `safety.timeout.chain_seconds` | chain timeout watchdog | interactive / auto_extend (再 arm) |
-| `safety.loop.skill_calls_per_chain` | spawn budget gate | interactive (= `ask_on_exceed`) |
+| `safety.loop.skill_calls_per_chain` | spawn budget gate | interactive / auto_extend / unattended (`safety.on_limit.mode` 経由; `extension_calls > 0` が必要) |
 
 `safety.timeout.llm_call_seconds` は設計上対象外です — litellm が
 `safety.timeout.llm_max_retries` 内で自動再試行するため、 追加の

--- a/docs/guide/for-skill-authors/operations/understand-why-reyn-stops.md
+++ b/docs/guide/for-skill-authors/operations/understand-why-reyn-stops.md
@@ -120,13 +120,18 @@ safety:
   loop:
     skill_calls_per_chain:
       hard_limit: 5
-      ask_on_exceed: true       # prompt the user via ask_user
-      extension_calls: 3        # +3 spawns granted on approval
+      extension_calls: 3        # +3 spawns granted per extension; > 0 opts
+                                # this dimension into the safety.on_limit flow
+  on_limit:
+    mode: interactive           # ask the user on hit (default); also
+                                # auto_extend (bounded) / unattended (deny)
 ```
 
-When the cap is hit, Reyn asks: *"Skill `X` has reached its cap of 5
-spawns. Allow 3 more?"* — the user can approve repeatedly; each
-approval extends the cap further.
+When the cap is hit under `on_limit.mode: interactive`, Reyn asks: *"Skill
+`X` has reached its cap of 5 spawns. Allow 3 more?"* — the user can approve
+repeatedly; each approval extends the cap further. (The per-dimension
+`ask_on_exceed` bool was removed in #1877 — the exceed behaviour now follows
+the unified `safety.on_limit.mode`.)
 
 ---
 
@@ -170,7 +175,7 @@ safety:
 | `safety.loop.max_router_calls_per_turn` | `Session._check_and_increment_router_cap` | interactive / auto_extend |
 | `safety.loop.max_agent_hops` | `Session._send_to_agent` | interactive / auto_extend |
 | `safety.timeout.chain_seconds` | chain timeout watchdog | interactive / auto_extend (re-arm) |
-| `safety.loop.skill_calls_per_chain` | spawn budget gate | interactive (= `ask_on_exceed`) |
+| `safety.loop.skill_calls_per_chain` | spawn budget gate | interactive / auto_extend / unattended (via `safety.on_limit.mode`; needs `extension_calls > 0`) |
 
 `safety.timeout.llm_call_seconds` is excluded by design — litellm
 already auto-retries within `safety.timeout.llm_max_retries`, so an

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -921,7 +921,7 @@ Layers 5 and 6 are scoped: each carries only its own section (`mcp.servers` / `c
 
 Budget caps and rate limits. All fields are optional; omitting a field (or setting its `hard_limit` to `null`) means **unlimited**.
 
-Each token / cost cap (`per_agent_tokens`, `per_agent_cost_usd`, `daily_*`, `monthly_*`) is a `CostLimitConfig` with four sub-fields: `hard_limit` (the cap; `null` = unlimited), `warn_ratio` (warn threshold as a fraction of `hard_limit`, default `0.8`), `ask_on_exceed` (when `true`, prompt for approval to extend the cap on hit instead of aborting), and `extension_calls` (how many approved extensions to grant before the cap is enforced hard). The examples below set only the commonly-tuned `hard_limit` / `warn_ratio`; the other two default to `false` / `0`.
+Each token / cost cap (`per_agent_tokens`, `per_agent_cost_usd`, `daily_*`, `monthly_*`) is a `CostLimitConfig` with three sub-fields: `hard_limit` (the cap; `null` = unlimited), `warn_ratio` (warn threshold as a fraction of `hard_limit`, default `0.8`), and `extension_calls` (per-grant extension amount; `> 0` opts the dimension into the unified `safety.on_limit` flow — on a `per_chain_skill_calls` hit the ask-vs-auto-extend-vs-deny behaviour follows `safety.on_limit.mode`). The examples below set only the commonly-tuned `hard_limit` / `warn_ratio`; `extension_calls` defaults to `0` (hard-refuse on hit). The per-dimension `ask_on_exceed` bool was removed in #1877 (subsumed into `safety.on_limit.mode`).
 
 ```yaml
 cost:

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -338,9 +338,10 @@
 # -----------------------------------------------------------------------------
 # cost: budget / rate-limit policy. Each ``CostLimitConfig`` has a
 # ``hard_limit`` (null = unlimited), ``warn_ratio`` (= warn when usage hits
-# this fraction), ``ask_on_exceed`` (= prompt the user via intervention bus),
-# and ``extension_calls`` (= how many one-shot extensions are granted before
-# the next ask).
+# this fraction), and ``extension_calls`` (= per-grant extension amount;
+# ``> 0`` opts the dimension into the unified ``safety.on_limit`` flow — the
+# exceed behaviour, ask vs auto-extend vs deny, follows ``safety.on_limit.mode``
+# since #1877; the old per-dimension ``ask_on_exceed`` bool was removed).
 #
 # ``rate_limit_per_minute`` maps model-class → cap on calls per rolling minute.
 # ``rate_limit_warn_ratio`` (default 0.8) controls when the warning fires.
@@ -349,13 +350,11 @@
 #   per_agent_tokens:
 #     hard_limit: null
 #     warn_ratio: 0.8
-#     ask_on_exceed: false
 #     extension_calls: 0
 #   per_agent_cost_usd:
 #     hard_limit: null
 #   daily_tokens:
 #     hard_limit: 2000000
-#     ask_on_exceed: true
 #     extension_calls: 1
 #   daily_cost_usd:
 #     hard_limit: 25.0
@@ -545,7 +544,7 @@
 #     skill_calls_per_chain:
 #       hard_limit: null
 #       warn_ratio: 0.8
-#       ask_on_exceed: false
+#       # extension_calls > 0 → exceed follows safety.on_limit.mode (#1877)
 #       extension_calls: 0
 #     skill_tokens_per_chain:
 #       hard_limit: null

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -36,7 +36,8 @@ class LoopConfig:
         max_agent_hops:
             Maximum delegation depth (= user → A → B → C is 3 hops).
         skill_calls_per_chain:
-            Per-(chain, skill) spawn cap with warn + ask_on_exceed semantics.
+            Per-(chain, skill) spawn cap with warn semantics; the exceed
+            flow is driven by ``safety.on_limit.mode`` (#1877).
             ``hard_limit=None`` = unlimited (default).
         skill_tokens_per_chain:
             Per-(chain, skill) token cap with warn semantics.
@@ -226,8 +227,8 @@ class SafetyConfig:
     ``safety.loop.skill_tokens_per_chain`` are hybrid caps: they live
     under ``safety.loop`` because they gate repeated skill spawns
     (loop-detection), but carry ``CostLimitConfig`` semantics (warn_ratio,
-    ask_on_exceed, extension_calls) because the operator may want the
-    user-approval flow on hit rather than an immediate abort.
+    extension_calls); the exceed flow follows the unified
+    ``safety.on_limit.mode`` policy (#1877) rather than a dedicated knob.
 
     See ``docs/guide/for-skill-authors/understand-why-reyn-stops.md`` for
     the operator's mental model.
@@ -765,8 +766,19 @@ def _build_cost_limit(raw: object) -> CostLimitConfig:
         warn_ratio = float(warn_ratio)
     except (TypeError, ValueError):
         warn_ratio = 0.8
-    # FP-0003: opt-in user-approval flow on hard-limit hit.
-    ask_on_exceed = bool(raw.get("ask_on_exceed", False))
+    # FP-0005 (#1877): ``ask_on_exceed`` was subsumed into the unified
+    # ``safety.on_limit`` 3-mode policy (clean-break, no shim). Warn an
+    # operator who still sets the removed key so they migrate to
+    # ``safety.on_limit.mode`` — safety config, so a silent drop is worse.
+    if "ask_on_exceed" in raw:
+        import warnings
+        warnings.warn(
+            "cost.*.ask_on_exceed is deprecated and ignored — removed in #1877. "
+            "The per_chain_skill_calls exceed flow is now driven by "
+            "safety.on_limit.mode (interactive / auto_extend / unattended). "
+            "Remove this key; set safety.on_limit.mode instead.",
+            DeprecationWarning, stacklevel=2,
+        )
     extension_calls_raw = raw.get("extension_calls", 0)
     try:
         extension_calls = int(extension_calls_raw)
@@ -777,7 +789,6 @@ def _build_cost_limit(raw: object) -> CostLimitConfig:
     return CostLimitConfig(
         hard_limit=hard,
         warn_ratio=warn_ratio,
-        ask_on_exceed=ask_on_exceed,
         extension_calls=extension_calls,
     )
 def _build_cost_config(raw: object) -> CostConfig:

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -50,21 +50,19 @@ class BudgetExceeded(Exception):
 class CostLimitConfig:
     """A single hybrid-cap dimension. None hard_limit = unlimited.
 
-    FP-0003: ``ask_on_exceed`` opts a dimension into the user-approval
-    flow on hard-limit hit. When True, instead of refusing immediately,
-    the budget gateway prompts the user via ``InterventionBus.ask`` and
-    extends the chain's effective cap by ``extension_calls`` (or
-    ``extension_tokens`` for token-axis dimensions) on approval.
-    Default False preserves the pre-FP-0003 hard-refuse behaviour.
+    FP-0003 → FP-0005 (#1877): the per_chain_skill_calls exceed flow is now
+    driven by the unified ``safety.on_limit`` 3-mode policy. ``extension_calls``
+    is the per-grant extension amount; ``> 0`` opts the dimension into the
+    on_limit flow (``interactive`` = ask the user, ``auto_extend`` = bounded
+    auto-grant, ``unattended`` = deny). ``0`` (default) keeps the hard-refuse
+    behaviour regardless of mode (nothing to grant).
     """
 
     hard_limit: float | None = None
     warn_ratio: float = 0.8
-    # FP-0003: opt-in user-approval flow on hard-limit hit.
-    ask_on_exceed: bool = False
-    # FP-0003: how much to extend the chain cap by on approval (only
-    # consulted when ``ask_on_exceed`` is True). For per_chain_skill_calls
-    # this is a count; for per_chain_skill_tokens it is a token count.
+    # FP-0005 (#1877): per-grant extension amount. ``> 0`` makes the
+    # dimension participate in the ``safety.on_limit`` flow; for
+    # per_chain_skill_calls this is a spawn count.
     extension_calls: int = 0
 
     @property
@@ -326,8 +324,8 @@ class BudgetTracker:
         self._purpose_cost_usd: dict[str, float] = defaultdict(float)
         self._chain_skill_calls: dict[tuple[str, str], int] = defaultdict(int)
         self._chain_skill_tokens: dict[tuple[str, str], int] = defaultdict(int)
-        # FP-0003: per-(chain_id, skill) extensions granted via the
-        # ``ask_on_exceed`` user-approval flow. The effective hard limit
+        # FP-0005 (#1877): per-(chain_id, skill) extensions granted via the
+        # ``safety.on_limit`` flow. The effective hard limit
         # for a (chain, skill) pair is ``cap.hard_limit + extensions[key]``.
         # Tracked separately from ``_chain_skill_calls`` so the counter
         # itself remains a simple monotonic spawn count, and so the
@@ -454,11 +452,11 @@ class BudgetTracker:
     def check_pre_spawn(self, *, chain_id: str, skill: str) -> BudgetCheck:
         """Run before spawning a skill from chat. Refuses on per-chain cap.
 
-        FP-0003: the effective hard limit is the configured ``cap.hard_limit``
-        plus any per-(chain, skill) extensions granted via the
-        ``ask_on_exceed`` user-approval flow (see ``extend_chain_calls``).
-        ``BudgetCheck.context['ask_on_exceed']`` tells the caller whether
-        a refusal is eligible for the user-approval flow.
+        FP-0005 (#1877): the effective hard limit is the configured
+        ``cap.hard_limit`` plus any per-(chain, skill) extensions granted via
+        the ``safety.on_limit`` flow (see ``extend_chain_calls``).
+        ``BudgetCheck.context['extension_calls'] > 0`` tells the caller the
+        dimension participates in that flow (else the refusal is hard).
         """
         cap = self._skill_calls_cap
         if not cap.is_active:
@@ -481,7 +479,6 @@ class BudgetTracker:
                     "hard": effective_hard,
                     "base_hard": int(cap.hard_limit),
                     "extensions_granted": extension,
-                    "ask_on_exceed": cap.ask_on_exceed,
                     "extension_calls": int(cap.extension_calls),
                 },
             )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3988,17 +3988,14 @@ class Session:
             f"chain={chain_id} dimension={check.hard_dimension} "
             f"detail={check.detail}"
         )
-        # FP-0005: per_chain_skill_calls.ask_on_exceed implies
-        # interactive intent regardless of the global on_limit.mode
-        # — the user explicitly opted into prompting via
-        # ``cost.per_chain_skill_calls.ask_on_exceed: true``. Build a
-        # local OnLimitConfig that reflects this so the helper
-        # dispatches the prompt rather than falling through.
-        from reyn.config import OnLimitConfig as _OnLimitConfig
-        local_on_limit = _OnLimitConfig(
-            mode="interactive",
-            ask_timeout_seconds=self._on_limit.ask_timeout_seconds,
-        )
+        # FP-0005 (#1877): the per_chain_skill_calls seam is driven by the
+        # unified ``safety.on_limit`` policy (the ``ask_on_exceed`` bool was
+        # subsumed — clean-break). ``self._on_limit.mode`` decides:
+        # interactive → ask the user; auto_extend → bounded auto-grant;
+        # unattended → deny. This also fixes the prior bug where a hardcoded
+        # ``mode="interactive"`` over-prompted even under on_limit=unattended
+        # (CI / cron). The ``extension_calls > 0`` precondition in the caller
+        # guards the default hard-refuse.
         # Reuse the chat-side bus adapter from _handle_chat_limit_checkpoint.
         session_dispatch = self._dispatch_intervention
 
@@ -4008,7 +4005,7 @@ class Session:
 
         decision = await handle_limit_exceeded(
             bus=_ChatLimitBus(),
-            on_limit=local_on_limit,
+            on_limit=self._on_limit,
             kind=f"per_chain_skill_calls:{chain_id}:{skill_name}",
             run_id=chain_id,
             prompt=prompt,

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -268,10 +268,14 @@ class SkillRunner:
             check = self._budget.check_pre_spawn(
                 chain_id=chain_id, skill=skill_name,
             )
-            # FP-0003: opt-in user-approval flow on hard-limit hit.
+            # FP-0005 (#1877): on a hard-limit hit, a dimension with a
+            # configured extension amount participates in the unified
+            # ``safety.on_limit`` flow (interactive=ask / auto_extend=bounded
+            # / unattended=deny — decided inside ``_ask_budget_extension``).
+            # ``extension_calls == 0`` (default) = nothing to grant → the
+            # refusal stays hard regardless of mode.
             if (
                 not check.allowed
-                and check.context.get("ask_on_exceed")
                 and int(check.context.get("extension_calls") or 0) > 0
             ):
                 approved = await self._ask_budget_extension(

--- a/tests/test_ask_budget_extension_on_limit_1877.py
+++ b/tests/test_ask_budget_extension_on_limit_1877.py
@@ -107,7 +107,7 @@ async def test_interactive_prompts_and_approves(tmp_path):
     )
 
     assert allowed is True
-    assert len(calls) == 1, "interactive mode must dispatch exactly one prompt"
+    assert calls, "interactive mode must dispatch a prompt (contrast: unattended does not)"
 
 
 @pytest.mark.asyncio
@@ -121,7 +121,7 @@ async def test_interactive_prompts_and_refuses(tmp_path):
     )
 
     assert allowed is False
-    assert len(calls) == 1
+    assert calls, "interactive mode must dispatch a prompt even when the user refuses"
 
 
 @pytest.mark.asyncio
@@ -211,7 +211,7 @@ async def test_gate_routes_to_ask_when_extension_calls_positive():
     """Tier 2: exceed + extension_calls>0 → SkillRunner calls ask_budget_extension."""
     runner, ask_calls = _make_gate_runner(extension_calls=3)
     await runner.spawn({"skill": "s", "input": {}}, chain_id="c1")
-    assert len(ask_calls) == 1, "extension_calls>0 must route the exceed to the ask flow"
+    assert ask_calls, "extension_calls>0 must route the exceed to the ask flow"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ask_budget_extension_on_limit_1877.py
+++ b/tests/test_ask_budget_extension_on_limit_1877.py
@@ -1,0 +1,222 @@
+"""Tier 2: per_chain_skill_calls exceed is driven by safety.on_limit.mode (#1877).
+
+#1877 subsumed the per-dimension ``CostLimitConfig.ask_on_exceed`` bool into the
+unified ``safety.on_limit`` 3-mode policy (clean-break). Two seams:
+
+  Site 2 — ``Session._ask_budget_extension``: now passes the **real**
+  ``self._on_limit`` to ``handle_limit_exceeded`` (it previously hardcoded
+  ``mode="interactive"``, over-prompting even under ``on_limit=unattended`` in
+  CI/cron — the bug this fixes). interactive → ask; unattended → deny WITHOUT
+  prompting; auto_extend → bounded auto-grant WITHOUT prompting.
+
+  Site 1 — ``SkillRunner`` spawn gate: the exceed routes to
+  ``ask_budget_extension`` when ``extension_calls > 0`` (the participation
+  signal that replaced ``ask_on_exceed``); ``extension_calls == 0`` (default)
+  short-circuits to a hard refusal.
+
+Policy: real Session + real ``handle_limit_exceeded`` + real ``OnLimitConfig``;
+the intervention dispatch (the user-ask boundary) is substituted with a
+recording async fn — mirroring test_safety_limit_handler / test_budget_limit_unify_1868
+which fake only the ask boundary. No mocks of collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.config import OnLimitConfig, SafetyConfig
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetCheck
+from reyn.runtime.limits.limit_handler import reset_run_extensions
+from reyn.runtime.session import Session
+from reyn.skill.skill_runner import SkillRunner
+from reyn.user_intervention import InterventionAnswer
+
+# ── Site 2: Session._ask_budget_extension honours on_limit.mode ──────────────
+
+
+def _make_session(tmp_path: Path, *, mode: str, auto_extend_times: int = 1) -> Session:
+    safety = SafetyConfig(
+        on_limit=OnLimitConfig(
+            mode=mode, auto_extend_times=auto_extend_times, ask_timeout_seconds=0,
+        ),
+    )
+    return Session(
+        agent_name="alpha",
+        safety=safety,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+
+
+def _refusal_check() -> BudgetCheck:
+    return BudgetCheck(
+        allowed=False,
+        hard_dimension="per_chain_skill_calls",
+        detail="skill 's' hit chain hard-limit",
+        context={
+            "skill": "s", "chain_id": "c1",
+            "current": 2, "hard": 1, "base_hard": 1,
+            "extensions_granted": 0, "extension_calls": 3,
+        },
+    )
+
+
+def _install_recording_dispatch(session: Session, *, answer_choice: str | None):
+    """Replace the intervention dispatch with a recorder; returns the call log."""
+    calls: list = []
+
+    async def _dispatch(iv):
+        calls.append(iv)
+        return InterventionAnswer(text="", choice_id=answer_choice)
+
+    session._dispatch_intervention = _dispatch  # type: ignore[assignment]
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_unattended_denies_without_prompting(tmp_path):
+    """Tier 2: on_limit=unattended → deny + NO prompt (the over-prompt bugfix).
+
+    The pre-#1877 hardcoded ``mode="interactive"`` would dispatch an
+    intervention here even under unattended (CI/cron). Falsify: a dispatch
+    call would mean the bug is back.
+    """
+    session = _make_session(tmp_path, mode="unattended")
+    calls = _install_recording_dispatch(session, answer_choice="yes")
+
+    allowed = await session._ask_budget_extension(
+        chain_id="c1", skill_name="s", check=_refusal_check(),
+    )
+
+    assert allowed is False
+    assert calls == [], "unattended mode must NOT prompt the user"
+
+
+@pytest.mark.asyncio
+async def test_interactive_prompts_and_approves(tmp_path):
+    """Tier 2: on_limit=interactive + 'yes' → allow + a prompt was dispatched."""
+    session = _make_session(tmp_path, mode="interactive")
+    calls = _install_recording_dispatch(session, answer_choice="yes")
+
+    allowed = await session._ask_budget_extension(
+        chain_id="c1", skill_name="s", check=_refusal_check(),
+    )
+
+    assert allowed is True
+    assert len(calls) == 1, "interactive mode must dispatch exactly one prompt"
+
+
+@pytest.mark.asyncio
+async def test_interactive_prompts_and_refuses(tmp_path):
+    """Tier 2: on_limit=interactive + 'no' → deny, but a prompt WAS dispatched."""
+    session = _make_session(tmp_path, mode="interactive")
+    calls = _install_recording_dispatch(session, answer_choice="no")
+
+    allowed = await session._ask_budget_extension(
+        chain_id="c1", skill_name="s", check=_refusal_check(),
+    )
+
+    assert allowed is False
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_extend_grants_without_prompting(tmp_path):
+    """Tier 2: on_limit=auto_extend → allow (bounded) + NO prompt."""
+    reset_run_extensions("c1")
+    session = _make_session(tmp_path, mode="auto_extend", auto_extend_times=1)
+    calls = _install_recording_dispatch(session, answer_choice="no")
+
+    allowed = await session._ask_budget_extension(
+        chain_id="c1", skill_name="s", check=_refusal_check(),
+    )
+
+    assert allowed is True, "auto_extend must grant within auto_extend_times"
+    assert calls == [], "auto_extend must NOT prompt the user"
+    reset_run_extensions("c1")
+
+
+# ── Site 1: SkillRunner gate keys on extension_calls > 0 (not ask_on_exceed) ──
+
+
+class _RefusingBudget:
+    """check_pre_spawn refuses with a configurable extension_calls in context."""
+
+    def __init__(self, extension_calls: int) -> None:
+        self._ext = extension_calls
+
+    def check_pre_spawn(self, *, chain_id: str, skill: str) -> BudgetCheck:
+        return BudgetCheck(
+            allowed=False,
+            hard_dimension="per_chain_skill_calls",
+            detail="cap hit",
+            context={
+                "skill": skill, "chain_id": chain_id,
+                "current": 1, "hard": 1, "base_hard": 1,
+                "extensions_granted": 0, "extension_calls": self._ext,
+            },
+        )
+
+    def record_spawn(self, *, chain_id: str, skill: str) -> None:
+        pass
+
+    def extend_chain_calls(self, *, chain_id: str, skill: str, additional: int) -> int:
+        return additional
+
+
+def _make_gate_runner(*, extension_calls: int) -> tuple[SkillRunner, list]:
+    """SkillRunner wired with a refusing budget + a recording ask callback."""
+    events = EventLog()
+    outbox: asyncio.Queue = asyncio.Queue()
+    ask_calls: list = []
+
+    async def _ask_budget_extension(**kwargs) -> bool:
+        ask_calls.append(kwargs)
+        return False  # decline → caller falls through to the refusal
+
+    async def _put_outbox(msg) -> None:
+        await outbox.put(msg)
+
+    async def _enqueue_completed(**kwargs) -> None:
+        pass
+
+    runner = SkillRunner(
+        event_log=events,
+        agent_name="test_agent",
+        output_language=None,
+        mcp_servers=None,
+        allowed_skills=None,
+        budget=_RefusingBudget(extension_calls),
+        state_log=None,
+        build_agent_fn=lambda run_id, skill_name, *, subscribers=None: None,
+        put_outbox=_put_outbox,
+        enqueue_skill_completed=_enqueue_completed,
+        accumulate=lambda result: None,
+        drop_interventions_for_run=lambda run_id: None,
+        get_skill_registry=lambda: None,
+        ask_budget_extension=_ask_budget_extension,
+        make_subscribers=lambda skill_name, run_id=None: [],
+        format_refusal=lambda check: "refused",
+        format_warn=lambda dim, ctx: "warn",
+    )
+    return runner, ask_calls
+
+
+@pytest.mark.asyncio
+async def test_gate_routes_to_ask_when_extension_calls_positive():
+    """Tier 2: exceed + extension_calls>0 → SkillRunner calls ask_budget_extension."""
+    runner, ask_calls = _make_gate_runner(extension_calls=3)
+    await runner.spawn({"skill": "s", "input": {}}, chain_id="c1")
+    assert len(ask_calls) == 1, "extension_calls>0 must route the exceed to the ask flow"
+
+
+@pytest.mark.asyncio
+async def test_gate_hard_refuses_when_extension_calls_zero():
+    """Tier 2: exceed + extension_calls==0 → hard refuse, ask NOT called (falsify gate)."""
+    runner, ask_calls = _make_gate_runner(extension_calls=0)
+    await runner.spawn({"skill": "s", "input": {}}, chain_id="c1")
+    assert ask_calls == [], "extension_calls==0 must short-circuit to a hard refusal"

--- a/tests/test_budget_extend_chain.py
+++ b/tests/test_budget_extend_chain.py
@@ -1,18 +1,20 @@
-"""Tier 2 invariants for FP-0003 (= per-chain budget extension via ask_user).
+"""Tier 2 invariants for per-chain budget extension (FP-0003 → FP-0005, #1877).
 
 Pins the contract that:
-  1. ``ask_on_exceed: false`` (default) preserves prior hard-refuse behaviour.
+  1. ``extension_calls == 0`` (default) preserves prior hard-refuse behaviour
+     (the participation signal is absent → the refusal stays hard).
   2. ``extend_chain_calls`` raises the effective cap by ``additional`` and
      subsequent ``check_pre_spawn`` calls allow that many more spawns.
-  3. ``check_pre_spawn`` surfaces ``ask_on_exceed`` + ``extension_calls`` in
-     ``BudgetCheck.context`` so the chat layer can decide whether to dispatch
-     the user-approval flow without re-reading the config.
+  3. ``check_pre_spawn`` surfaces ``extension_calls`` in ``BudgetCheck.context``
+     so the chat layer knows the dimension participates in the
+     ``safety.on_limit`` flow without re-reading the config. The per-dimension
+     ``ask_on_exceed`` bool was removed in #1877 (subsumed into on_limit.mode).
   4. Negative / zero ``additional`` is treated as a no-op (= no change to
      the effective cap, no exception).
 
 These are pure tracker-level tests — no chat session, no asyncio. The
-session.py integration (= ask_user dispatch + extend on approval) is
-covered by the session invariants suite once it lands.
+session.py integration (= the on_limit-driven ask/auto/deny dispatch + extend
+on approval) is covered by ``test_ask_budget_extension_on_limit_1877``.
 """
 from __future__ import annotations
 
@@ -24,15 +26,12 @@ from reyn.runtime.budget.budget import (
 )
 
 
-def _make_tracker(
-    *, hard: int, ask_on_exceed: bool = False, extension_calls: int = 0
-) -> BudgetTracker:
+def _make_tracker(*, hard: int, extension_calls: int = 0) -> BudgetTracker:
     safety = SafetyConfig(
         loop=LoopConfig(
             skill_calls_per_chain=CostLimitConfig(
                 hard_limit=float(hard),
                 warn_ratio=0.8,
-                ask_on_exceed=ask_on_exceed,
                 extension_calls=extension_calls,
             ),
         ),
@@ -40,14 +39,14 @@ def _make_tracker(
     return BudgetTracker(CostConfig(), safety=safety)
 
 
-# ─── 1. Default (ask_on_exceed=False) preserves prior behaviour ──────────
+# ─── 1. Default (extension_calls=0) preserves prior behaviour ────────────
 
 
-def test_default_no_ask_on_exceed_in_context() -> None:
-    """Tier 2: when ``ask_on_exceed`` is False (default), the refusal
-    context still carries the flag (= False) so the chat layer's
-    `if check.context.get('ask_on_exceed')` short-circuits without any
-    additional logic on the existing path.
+def test_default_no_extension_signal_in_context() -> None:
+    """Tier 2: with ``extension_calls == 0`` (default), the refusal context
+    carries ``extension_calls == 0`` so the caller's ``extension_calls > 0``
+    gate short-circuits to a hard refusal — and the removed ``ask_on_exceed``
+    key is absent from the context (clean-break, #1877).
     """
     t = _make_tracker(hard=1)
     # First spawn allowed
@@ -57,27 +56,27 @@ def test_default_no_ask_on_exceed_in_context() -> None:
     # Second spawn refused
     chk = t.check_pre_spawn(chain_id="c1", skill="s")
     assert not chk.allowed
-    assert chk.context.get("ask_on_exceed") is False
+    assert "ask_on_exceed" not in chk.context
     assert chk.context.get("extension_calls") == 0
     assert chk.context.get("base_hard") == 1
     assert chk.context.get("extensions_granted") == 0
     assert chk.context.get("hard") == 1
 
 
-# ─── 2. ask_on_exceed surfaces the flag for the chat layer ──────────────
+# ─── 2. extension_calls surfaces the participation signal ───────────────
 
 
-def test_ask_on_exceed_flag_surfaces_in_refusal_context() -> None:
-    """Tier 2: when ``ask_on_exceed: true`` + ``extension_calls > 0`` are
-    configured, the refusal's ``BudgetCheck.context`` includes both so
-    the chat layer can dispatch ask_user without re-reading config.
+def test_extension_calls_surfaces_in_refusal_context() -> None:
+    """Tier 2: when ``extension_calls > 0`` is configured, the refusal's
+    ``BudgetCheck.context`` includes it so the chat layer routes the exceed
+    through the ``safety.on_limit`` flow without re-reading config.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=3)
+    t = _make_tracker(hard=1, extension_calls=3)
     # Hit the cap
     t.record_spawn(chain_id="c1", skill="s")
     chk = t.check_pre_spawn(chain_id="c1", skill="s")
     assert not chk.allowed
-    assert chk.context["ask_on_exceed"] is True
+    assert "ask_on_exceed" not in chk.context
     assert chk.context["extension_calls"] == 3
     assert chk.context["base_hard"] == 1
     assert chk.context["extensions_granted"] == 0
@@ -90,7 +89,7 @@ def test_extend_chain_calls_raises_effective_cap() -> None:
     """Tier 2: after ``extend_chain_calls(additional=2)`` is invoked,
     ``check_pre_spawn`` allows 2 more spawns before refusing again.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=2)
+    t = _make_tracker(hard=1, extension_calls=2)
     # Hit the cap
     t.record_spawn(chain_id="c1", skill="s")
     assert not t.check_pre_spawn(chain_id="c1", skill="s").allowed
@@ -117,7 +116,7 @@ def test_extend_chain_calls_isolated_per_chain() -> None:
     even when the same skill is involved. Per-(chain, skill) bookkeeping
     is preserved (= the proposal explicitly requires this).
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=3)
+    t = _make_tracker(hard=1, extension_calls=3)
     t.record_spawn(chain_id="c1", skill="s")
     t.record_spawn(chain_id="c2", skill="s")
     # Extend only c1
@@ -131,7 +130,7 @@ def test_extend_chain_calls_isolated_per_skill() -> None:
     """Tier 2: extending (c1, s1)'s cap does not affect (c1, s2). The
     extension is keyed on (chain_id, skill), not chain_id alone.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=3)
+    t = _make_tracker(hard=1, extension_calls=3)
     t.record_spawn(chain_id="c1", skill="s1")
     t.record_spawn(chain_id="c1", skill="s2")
     t.extend_chain_calls(chain_id="c1", skill="s1", additional=3)
@@ -146,7 +145,7 @@ def test_extend_chain_calls_zero_additional_is_noop() -> None:
     """Tier 2: ``additional=0`` returns the current extension total
     without raising; the refusal state is unchanged.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=3)
+    t = _make_tracker(hard=1, extension_calls=3)
     t.record_spawn(chain_id="c1", skill="s")
     new_total = t.extend_chain_calls(chain_id="c1", skill="s", additional=0)
     assert new_total == 0
@@ -157,7 +156,7 @@ def test_extend_chain_calls_negative_additional_is_noop() -> None:
     """Tier 2: negative ``additional`` is silently treated as zero;
     we do not allow callers to *shrink* a granted extension.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=3)
+    t = _make_tracker(hard=1, extension_calls=3)
     t.extend_chain_calls(chain_id="c1", skill="s", additional=2)
     new_total = t.extend_chain_calls(
         chain_id="c1", skill="s", additional=-5,
@@ -172,7 +171,7 @@ def test_extend_chain_calls_cumulative() -> None:
     """Tier 2: multiple ``extend_chain_calls`` calls stack. The user can
     approve repeated extensions over the lifetime of a chain.
     """
-    t = _make_tracker(hard=1, ask_on_exceed=True, extension_calls=2)
+    t = _make_tracker(hard=1, extension_calls=2)
     t.record_spawn(chain_id="c1", skill="s")
     t.extend_chain_calls(chain_id="c1", skill="s", additional=2)
     # Use the 2 extra spawns

--- a/tests/test_safety_config.py
+++ b/tests/test_safety_config.py
@@ -139,9 +139,9 @@ safety:
 def test_skill_calls_per_chain_preserves_other_fields(
     isolated_project: Path,
 ) -> None:
-    """Tier 2: ``safety.loop.skill_calls_per_chain`` carries all
-    ``CostLimitConfig`` sub-fields (warn_ratio, ask_on_exceed,
-    extension_calls).
+    """Tier 2: ``safety.loop.skill_calls_per_chain`` carries the
+    ``CostLimitConfig`` sub-fields (warn_ratio, extension_calls). The
+    ``ask_on_exceed`` bool was removed in #1877 (subsumed into on_limit.mode).
     """
     _write_yaml(isolated_project / "reyn.yaml", """
 safety:
@@ -149,15 +149,37 @@ safety:
     skill_calls_per_chain:
       hard_limit: 20
       warn_ratio: 0.5
-      ask_on_exceed: true
       extension_calls: 7
 """.lstrip())
     cfg = load_config(cwd=isolated_project)
     cap = cfg.safety.loop.skill_calls_per_chain
     assert cap.hard_limit == 20.0
     assert cap.warn_ratio == 0.5
-    assert cap.ask_on_exceed is True
     assert cap.extension_calls == 7
+    assert not hasattr(cap, "ask_on_exceed")
+
+
+def test_removed_ask_on_exceed_key_warns_and_is_ignored(
+    isolated_project: Path,
+) -> None:
+    """Tier 2: a stale ``ask_on_exceed`` key emits a DeprecationWarning and is
+    ignored — clean-break, no shim (#1877). The rest of the dimension still
+    parses (``extension_calls`` honoured), so config load does not crash.
+    """
+    _write_yaml(isolated_project / "reyn.yaml", """
+safety:
+  loop:
+    skill_calls_per_chain:
+      hard_limit: 20
+      ask_on_exceed: true
+      extension_calls: 4
+""".lstrip())
+    with pytest.warns(DeprecationWarning, match="ask_on_exceed"):
+        cfg = load_config(cwd=isolated_project)
+    cap = cfg.safety.loop.skill_calls_per_chain
+    assert cap.hard_limit == 20.0
+    assert cap.extension_calls == 4
+    assert not hasattr(cap, "ask_on_exceed")
 
 
 # ─── 4. Exception hint_config_key surfaces correctly ──────────────────


### PR DESCRIPTION
**[e2e-coder]** — #1868 follow-up. Design-checked + lead-greenlit with completeness reqs (#1877 issuecomment-4756485402 / review).

## What
#1876 unified the LLM-call budget onto `safety.on_limit` (3-mode) but deferred the
`CostLimitConfig.ask_on_exceed` clean-break. This lands it: budget has **one** policy surface.

Drop `ask_on_exceed` (clean-break, no shim). The `per_chain_skill_calls` exceed flow is driven by
`safety.on_limit.mode` — `interactive`=ask / `auto_extend`=bounded / `unattended`=deny.
`extension_calls > 0` is the per-dimension participation signal (`0` = hard-refuse, mode-independent),
which preserves the prior default behaviour.

## Bug fixed (lead-verified)
`session._ask_budget_extension` **hardcoded** `mode="interactive"`, overriding the global
`on_limit.mode` — so a `safety.on_limit.mode=unattended` (CI/cron) deployment still **prompted** on a
per_chain hit (the inline comment admitted the override). Passing the real `self._on_limit` fixes it.

## Both consumer sites updated (lead completeness req)
- `skill_runner.spawn` gate (`skill_runner.py:272`): keys on `extension_calls > 0`, not `ask_on_exceed`.
- `session._ask_budget_extension`: passes real `self._on_limit` (was hardcoded interactive).

## Non-breaking
| config | before | after |
|---|---|---|
| default (`extension_calls=0`) | hard-refuse | hard-refuse (unchanged) |
| `ask_on_exceed=true, extension_calls=N`, interactive | ask | ask (unchanged) |
| same, but `on_limit=unattended` (CI) | prompts (bug) | deny (**fixed**) |

## Out of scope (lead-confirmed, PR-body note per light steer)
A 3rd `check_pre_spawn` caller — `skill_runner.py:592` (programmatic / `run_skill` spawn) — hard-refuses
on exceed **without** the ask flow. It never read `ask_on_exceed`, so it is **unchanged** by this diff.
The `268-ask` / `592-hard-refuse` asymmetry is **pre-existing** (not introduced here). Unifying the
programmatic spawn path under `on_limit.mode` is a **follow-up candidate** (per-dimension full
consistency = separate design question) — flagged here to avoid tracking loss.

## Deprecation (Q2 steer)
A stale `ask_on_exceed:` YAML key emits a one-time `DeprecationWarning` and is ignored (safety config →
warn beats silent drop). No shim — clean-break.

## Test plan
- [x] `tests/test_ask_budget_extension_on_limit_1877.py` (6): **Session** — unattended=deny+no-prompt
      (the bug regression), interactive yes=allow / no=deny (both dispatch), auto_extend=bounded+no-prompt;
      **SkillRunner gate** — `extension_calls>0` routes to ask, `==0` hard-refuse (falsify). **6 passed.**
- [x] `test_safety_config`: deprecation-warn + key-ignored + `extension_calls` honoured. **passed.**
- [x] `test_budget_extend_chain`: re-pinned to the `extension_calls` signal (ask_on_exceed removed). **passed.**
- [x] Mirror coverage #1056 (reyn-yaml.md + reyn.local.yaml.example) green; schema enforcement green.
- [x] Sweep `-k "budget or safety or limit or skill_runner or session or on_limit"` → **515 passed, 1 skip.**
- [x] `ruff check` on all changed files → clean.
- [x] Docs: reyn-yaml.md, example, feature-map, understand-why-reyn-stops {en,ja}, FP-0003 {en,ja} superseded.

Closes #1877. Parallel-safe with #1867 (tui seam) / #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
