### PR TITLE
feat(tui/1154): content-type-keyed viewer registration helper

### DIFF
--- a/docs/reference/tui/tool-result-viewers.md
+++ b/docs/reference/tui/tool-result-viewers.md
@@ -83,6 +83,34 @@ First match wins, so **order = priority**. The default population follows the
 module convention: *explicit content-type viewers first, shape-sniff viewers
 last.*
 
+### `register_content_type_viewer(content_types, viewer, *, name, position=-1, match="exact")`
+
+The ergonomic shortcut for the common case — *"this MIME maps to this viewer."*
+It builds the `_content_type_of` predicate for you and delegates to
+`register_viewer`, so `name` / `position` / first-match semantics are identical.
+
+```python
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    register_content_type_viewer,
+)
+
+register_content_type_viewer("application/pdf", _viewer_pdf, name="pdf")            # exact
+register_content_type_viewer("image/", _viewer_image, name="image", match="prefix")  # any image/*
+register_content_type_viewer(("csv", "tab-separated"), _viewer_csv, name="csv",
+                             match="substring")                                       # either, anywhere
+```
+
+| Param | Type | Meaning |
+|---|---|---|
+| `content_types` | `str \| Sequence[str]` | One MIME value, or several — a result matches if **any** matches. Case-insensitive. |
+| `match` | `"exact" \| "prefix" \| "substring"` | How each value is tested against `_content_type_of(result)`. Default `"exact"`. |
+| `name` / `position` | — | Same as `register_viewer`. |
+
+Use this for a pure content-type check. Reach for `register_viewer` with a
+hand-written predicate when you need more — a **suffix** test (the built-in
+`markdown` viewer matches a `/md` suffix), a **shape-sniff** over dict keys
+(`email` / `diff` / `web_summary`), or any multi-field heuristic.
+
 ### The predicate: detecting content type
 
 Use `_content_type_of(result)` to read an explicit type. It checks, in order,

--- a/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/tool_result_viewers.py
@@ -40,6 +40,7 @@ is testable in isolation without the Textual app.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -84,6 +85,49 @@ def register_viewer(
         _VIEWERS.append(entry)
     else:
         _VIEWERS.insert(position, entry)
+
+
+def register_content_type_viewer(
+    content_types: "str | Sequence[str]",
+    viewer: Callable[[dict], RenderableType | None],
+    *,
+    name: str = "",
+    position: int = -1,
+    match: str = "exact",
+) -> None:
+    """Register a viewer keyed by content-type / MIME — the ergonomic path for
+    the common "this MIME maps to this viewer" case.
+
+    Builds a ``_content_type_of``-based predicate so callers don't hand-write
+    one. ``content_types`` is a single string or a sequence; a result matches
+    when ``_content_type_of(result)`` matches ANY listed value under ``match``:
+
+    - ``"exact"`` (default) — equal to a listed type (e.g. ``"message/rfc822"``).
+    - ``"prefix"``          — starts with a listed value (e.g. ``"image/"``).
+    - ``"substring"``       — contains a listed value (e.g. ``"json"``).
+
+    Delegates to :func:`register_viewer`, so ``name`` / ``position`` behave
+    identically (first match wins; ``position`` orders priority). For anything
+    beyond a content-type check — shape-sniff, multi-field heuristics, a suffix
+    test — use :func:`register_viewer` with a custom predicate instead.
+    """
+    patterns = (
+        (content_types.lower(),)
+        if isinstance(content_types, str)
+        else tuple(c.lower() for c in content_types)
+    )
+
+    def _predicate(result: dict) -> bool:
+        ct = _content_type_of(result)
+        if not ct:
+            return False
+        if match == "prefix":
+            return any(ct.startswith(p) for p in patterns)
+        if match == "substring":
+            return any(p in ct for p in patterns)
+        return ct in patterns  # exact (default)
+
+    register_viewer(_predicate, viewer, name=name, position=position)
 
 
 # ---------------------------------------------------------------------------
@@ -356,27 +400,21 @@ def _viewer_web_summary(result: dict) -> RenderableType | None:
 # inline chain: explicit content-type first, shape-sniff last)
 # ---------------------------------------------------------------------------
 
+# ``markdown`` keeps a hand-written predicate: it matches a "/md" SUFFIX in
+# addition to the "markdown" substring, which is more than a content-type
+# membership test. The pure content-type viewers (csv / json / image) use the
+# content-type-keyed helper.
 def _pred_markdown(r: dict) -> bool:
     ct = _content_type_of(r)
     return bool(ct) and ("markdown" in ct or ct.endswith("/md"))
 
-def _pred_csv(r: dict) -> bool:
-    ct = _content_type_of(r)
-    return bool(ct) and ("csv" in ct or "tab-separated" in ct)
-
-def _pred_json(r: dict) -> bool:
-    ct = _content_type_of(r)
-    return bool(ct) and "json" in ct
-
-def _pred_image(r: dict) -> bool:
-    ct = _content_type_of(r)
-    return bool(ct) and ct.startswith("image/")
-
 
 register_viewer(_pred_markdown, _viewer_markdown, name="markdown")
-register_viewer(_pred_csv, _viewer_csv, name="csv")
-register_viewer(_pred_json, _viewer_json, name="json")
-register_viewer(_pred_image, _viewer_image, name="image")
+register_content_type_viewer(
+    ("csv", "tab-separated"), _viewer_csv, name="csv", match="substring",
+)
+register_content_type_viewer("json", _viewer_json, name="json", match="substring")
+register_content_type_viewer("image/", _viewer_image, name="image", match="prefix")
 register_viewer(_looks_like_web_summary, _viewer_web_summary, name="web_summary")
 
 # Concrete email + diff viewers fire AFTER explicit markdown/csv content-types

--- a/tests/cli/test_tool_result_viewer_content_type_register.py
+++ b/tests/cli/test_tool_result_viewer_content_type_register.py
@@ -1,0 +1,129 @@
+"""Tier 2: content-type-keyed viewer registration (#1154 registry generalization).
+
+`register_content_type_viewer` is the ergonomic extension point for mapping a
+content-type / MIME to a viewer without hand-writing a `_content_type_of`
+predicate. It delegates to `register_viewer`, so name / position / first-match
+semantics are unchanged; it just builds the predicate under one of three match
+modes (exact / prefix / substring), single value or sequence, case-insensitive.
+
+Falsification anchors:
+- exact does NOT match a superstring ("application/x-foo" ≠ "application/x-foobar").
+- prefix matches only at the start ("audio/" matches "audio/mpeg", not "x-audio/").
+- substring matches anywhere; a sequence matches ANY listed value.
+- a result with no content-type never matches (falls through).
+- position is honoured (a position=0 content-type viewer wins over defaults).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.tui.widgets.right_panel.tool_result_viewers import (
+    _VIEWERS,
+    register_content_type_viewer,
+    render_tool_result,
+)
+
+
+def _cleanup(name: str) -> None:
+    _VIEWERS[:] = [e for e in _VIEWERS if e.name != name]
+
+
+def test_exact_match_dispatches_and_rejects_superstring() -> None:
+    """Tier 2: match='exact' matches the exact MIME only, not a superstring."""
+    sentinel = object()
+    register_content_type_viewer(
+        "application/x-foo", lambda r: sentinel, name="_t_exact", match="exact",
+    )
+    try:
+        assert render_tool_result({"content_type": "application/x-foo"}) is sentinel
+        # a superstring must NOT match under exact
+        assert render_tool_result({"content_type": "application/x-foobar"}) is not sentinel
+    finally:
+        _cleanup("_t_exact")
+
+
+def test_prefix_match() -> None:
+    """Tier 2: match='prefix' matches a leading value, not a non-prefix occurrence."""
+    sentinel = object()
+    register_content_type_viewer(
+        "audio/", lambda r: sentinel, name="_t_prefix", match="prefix", position=0,
+    )
+    try:
+        assert render_tool_result({"content_type": "audio/mpeg"}) is sentinel
+        assert render_tool_result({"content_type": "x-audio/wav"}) is not sentinel
+    finally:
+        _cleanup("_t_prefix")
+
+
+def test_substring_match() -> None:
+    """Tier 2: match='substring' matches the value anywhere in the MIME."""
+    sentinel = object()
+    register_content_type_viewer(
+        "yaml", lambda r: sentinel, name="_t_sub", match="substring", position=0,
+    )
+    try:
+        assert render_tool_result({"content_type": "application/yaml"}) is sentinel
+        assert render_tool_result({"content_type": "text/x-yaml"}) is sentinel
+    finally:
+        _cleanup("_t_sub")
+
+
+def test_sequence_matches_any_listed_value() -> None:
+    """Tier 2: a sequence of content-types matches if ANY entry matches."""
+    sentinel = object()
+    register_content_type_viewer(
+        ("application/toml", "text/x-toml"),
+        lambda r: sentinel,
+        name="_t_seq",
+        match="exact",
+        position=0,
+    )
+    try:
+        assert render_tool_result({"content_type": "application/toml"}) is sentinel
+        assert render_tool_result({"content_type": "text/x-toml"}) is sentinel
+        assert render_tool_result({"content_type": "application/json"}) is not sentinel
+    finally:
+        _cleanup("_t_seq")
+
+
+def test_case_insensitive() -> None:
+    """Tier 2: matching is case-insensitive (registered lower, MIME upper)."""
+    sentinel = object()
+    register_content_type_viewer(
+        "application/x-case", lambda r: sentinel, name="_t_case", match="exact", position=0,
+    )
+    try:
+        assert render_tool_result({"content_type": "APPLICATION/X-CASE"}) is sentinel
+    finally:
+        _cleanup("_t_case")
+
+
+def test_no_content_type_does_not_match() -> None:
+    """Tier 2: a result without any content-type field never matches the helper.
+
+    Falsification: if the predicate did not guard the empty content-type, a
+    typeless dict could wrongly dispatch to a content-type viewer.
+    """
+    sentinel = object()
+    register_content_type_viewer(
+        "text/plain", lambda r: sentinel, name="_t_none", match="exact", position=0,
+    )
+    try:
+        assert render_tool_result({"some_field": "value"}) is not sentinel
+    finally:
+        _cleanup("_t_none")
+
+
+def test_position_zero_overrides_default_viewers() -> None:
+    """Tier 2: a content-type viewer at position=0 wins over the default chain.
+
+    A JSON result normally dispatches to the built-in json viewer; a
+    position=0 registration for the same MIME must win (first match).
+    """
+    sentinel = object()
+    register_content_type_viewer(
+        "json", lambda r: sentinel, name="_t_priority", match="substring", position=0,
+    )
+    try:
+        result = render_tool_result({"content_type": "application/json", "content": "{}"})
+        assert result is sentinel, "expected the position=0 viewer to win over the default json viewer"
+    finally:
+        _cleanup("_t_priority")


### PR DESCRIPTION
**[tui-coder]** — #1154 registry-generalization slice (owner direction 2026-06-20, lead scope-approved).

## What

The viewer registry already dispatches via `register_viewer(predicate, viewer)`, but every pure content-type viewer re-wrote the same `_content_type_of` predicate boilerplate. This adds the ergonomic **content-type → viewer** extension point:

```python
register_content_type_viewer("application/pdf", _viewer_pdf, name="pdf")             # exact
register_content_type_viewer("image/", _viewer_image, name="image", match="prefix")  # any image/*
register_content_type_viewer(("csv", "tab-separated"), _viewer_csv, match="substring")
```

- `register_content_type_viewer(content_types, viewer, *, name, position=-1, match="exact")` — builds the predicate and delegates to `register_viewer` (name / position / first-match unchanged). String **or sequence** (matches any); `match` ∈ exact / prefix / substring; case-insensitive.
- **Migrates the pure content-type defaults to it** — `csv` / `json` / `image` — so the new method is exercised **in production**, not unit-only, and the `_pred_csv/_pred_json/_pred_image` boilerplate is removed. Behaviour-preserving.
- `markdown` keeps its predicate (matches a `/md` **suffix**, more than a content-type membership test); the **shape-sniff** viewers (`email` / `diff` / `web_summary`) keep their predicates.

The speculative **LLM-generated-template path stays deferred / untouched** (out of this slice).

## Tests

7 Tier-2 (`tests/cli/test_tool_result_viewer_content_type_register.py`): exact (rejects superstring) / prefix / substring / sequence-matches-any / case-insensitive / no-content-type-no-match / position=0-overrides-default.

## Test plan

- [x] `pytest tests/cli/test_tool_result_viewer_content_type_register.py` — 7/7 green
- [x] `pytest` full viewer suite (registry / 1154 / email-diff / template / llm_gen / wire) — 73/73 green (csv/json/image migration **non-regressive** — existing tests guard dispatch + order)
- [x] `ruff check` — clean
- [ ] (skipped — needs live MCP tool emitting a new content-type) Manual: register a viewer for a new MIME and confirm the right-panel preview dispatches to it. Covered by the sentinel-viewer unit tests on `render_tool_result`.

## Tier self-check

- All Tier 2: public `register_content_type_viewer` + `render_tool_result` surface via sentinel viewers.
- No Tier 4: no `len()`-pinning, no private-state asserts, no golden.

Doc: `docs/reference/tui/tool-result-viewers.md` gains the helper as the preferred path for simple content-type viewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
