### PR TITLE
feat(1827): S1+S1.5 — contextual ∩-layer + LIVE tool gate (retire exclude_tools enforcement)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -123,6 +123,14 @@ class OpContext:
     # block-severity hit denies; warn emits + proceeds. None = no scan.
     threat_scan: "object | None" = None
 
+    # #1827 S1: per-session contextual capability narrowing (a
+    # ``ContextualPermission``). When set, permission gates add it as one more
+    # restrict-only ∩ layer (ContextualLayer) on top of the static authority —
+    # never-elevate is the structural ``all()`` in EffectivePermission. None =
+    # no contextual narrowing (byte-identical to the pre-#1827 gate). Sourced
+    # per-session from delegation / topology / ephemeral context (later slices).
+    contextual_permission: "object | None" = None
+
     # FP-0008 C7 #2: runtime backend-instance override for sandboxed_exec.
     # When set, the sandboxed_exec handler uses this backend INSTANCE verbatim
     # instead of resolving one by name from sandbox_config. This is the seam for

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1389,6 +1389,7 @@ class RouterLoop:
         non_interactive: bool = False,  # #1440 followup: run-once (no TTY) → live router SP proceeds instead of asking a clarifying question (13398). Threaded from Session.
         exclude_tools: set[str] | None = None,
         excluded_categories: set[str] | None = None,  # #1667 catalog categories skipped at source
+        contextual_permission: "object | None" = None,  # #1827 S1: per-session ContextualPermission (TOOL-axis enforcement); None → bridged from exclude_tools
         memo_provider: Any = None,  # SubLoopMemoProvider | None (ADR-0025)
         skill_search_config: "SkillSearchConfig | None" = None,  # FP-0024-A BM25 pre-filter
         empty_stop_retry_directive: str | None = None,  # B42-NF-W6-1 opt-in retry
@@ -1443,6 +1444,23 @@ class RouterLoop:
         # #1667: catalog categories skipped at the source (_enumerate_category),
         # threaded onto RouterCallerState so the universal catalog drops them.
         self._excluded_categories: frozenset[str] = frozenset(excluded_categories or set())
+        # #1827 S1 (live-gate): the TOOL-axis ENFORCEMENT now flows through the
+        # unified ∩-model (effective.py ContextualLayer) at the single live gate
+        # ``_excluded_result`` — NOT a standalone ``exclude_tools`` membership.
+        # ``_exclude_tools`` is retained as the axis-B VISIBILITY input only
+        # (``_apply_tool_exclusions``). Bridge: when no explicit contextual is
+        # given, derive one from ``exclude_tools`` so existing callers keep their
+        # execution-block byte-identically; topology / delegate / ephemeral
+        # sources (S2+) pass a ``ContextualPermission`` directly.
+        from reyn.security.permissions.effective import ContextualPermission
+        if contextual_permission is not None:
+            self._contextual_permission: "object | None" = contextual_permission
+        elif self._exclude_tools:
+            self._contextual_permission = ContextualPermission(
+                tool_deny=self._exclude_tools
+            )
+        else:
+            self._contextual_permission = None
         # FP-0034 Phase 2 step 1: action embedding index background
         # build task handle.  None until the first turn that finds the
         # index configured + not ready, then asyncio.Task while
@@ -3160,10 +3178,25 @@ class RouterLoop:
         effective resolved action — unwrap ``invoke_action`` — and reject if excluded.
         Covers all three bypass paths (native direct / salvaged / direct
         invoke_action). The ``tool_excluded`` kind + decision-enabling message lets
-        the model adjust ([[deny-message-decision-enabling]])."""
-        if self._exclude_tools:
+        the model adjust ([[deny-message-decision-enabling]]).
+
+        #1827 S1 (live-gate): the decision now flows through the unified ∩-model
+        (effective.py ``ContextualLayer``) — the single live TOOL-axis enforcement
+        gate. ``never-elevate`` is the structural ``all()`` in
+        ``EffectivePermission`` (a contextual deny can't be re-granted). The
+        standalone ``exclude_tools`` *enforcement* membership is retired; the
+        per-session contextual is bridged from ``exclude_tools`` for callers that
+        have not yet migrated (byte-identical), and S2+ feed a real contextual
+        from topology / delegate / ephemeral narrowing."""
+        if self._contextual_permission is not None:
+            from reyn.security.permissions.effective import (
+                CapabilityAxis,
+                ContextualLayer,
+            )
             effective = args.get("action_name") if name == "invoke_action" else name
-            if effective in self._exclude_tools:
+            if not ContextualLayer(self._contextual_permission).allows(
+                CapabilityAxis.TOOL, effective
+            ):
                 return {
                     "status": "error",
                     "error": {

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -28,6 +28,7 @@ context, not in any resolver `__init__`.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -221,6 +222,49 @@ class ProfileLayer:
         if axis is CapabilityAxis.MCP:
             return pr.allowed_mcp is None or value in pr.allowed_mcp
         return True  # profile constrains only skill / mcp
+
+
+@dataclass(frozen=True)
+class ContextualPermission:
+    """Per-session contextual narrowing (#1827) — a restrict-only ∩ term layered
+    on top of the static authority (``permission.tool`` etc.). Sourced per-session
+    from a delegation / topology role / ephemeral profile (later slices wire those
+    sources) and carried on ``OpContext.contextual_permission``.
+
+    S1 covers the TOOL axis: ``tool_allow`` (None = unconstrained) ∩ ``¬tool_deny``.
+    Further axes are added as later slices wire them — until then this term is ⊤
+    on those axes (never narrows).
+    """
+
+    tool_allow: "frozenset[str] | None" = None
+    tool_deny: "frozenset[str]" = field(default_factory=frozenset)
+
+
+class ContextualLayer:
+    """The CONTEXTUAL ∩ layer (#1827): per-session narrowing from a delegation /
+    topology / ephemeral context.
+
+    never-elevate is **structural**, not a runtime check: a ``ContextualLayer`` is
+    just one more conjunct in :meth:`EffectivePermission.allows` (``all(...)``), so
+    it can only contribute ``False`` (narrow) and **no other layer's ``True`` can
+    re-grant what it denies, nor can it re-grant a lower layer's ``False``**. A
+    ``None`` context is ⊤ (the layer is inert → byte-identical to the pre-#1827
+    stack)."""
+
+    def __init__(self, contextual: "ContextualPermission | None") -> None:
+        self._ctx = contextual
+
+    def allows(self, axis: CapabilityAxis, value: Any) -> bool:
+        c = self._ctx
+        if c is None:
+            return True
+        if axis is CapabilityAxis.TOOL:
+            in_allow = c.tool_allow is None or value in c.tool_allow
+            not_denied = value not in c.tool_deny
+            return in_allow and not_denied
+        # S1: only TOOL is constrained; other axes are ⊤ until later slices wire
+        # them (so the ∩ never narrows an axis the context does not yet cover).
+        return True
 
 
 def _path_under(path_str: str, root: str) -> bool:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1523,18 +1523,41 @@ class PermissionResolver:
 
     async def require_tool(
         self, decl: PermissionDecl, tool: str, bus: RequestBus,
+        *, contextual: "object | None" = None,
     ) -> None:
         # #1199 S3.1b-2c: the static tool authority (decl.tool) flows through the
         # unified model (TOOL axis). Byte-identical; the _approve prompt remains.
+        #
+        # #1827 S1: an optional per-session ``contextual`` (a ``ContextualPermission``)
+        # is added as one more restrict-only ∩ layer (``ContextualLayer``). The
+        # decision is the structural ``all()`` over the layer stack — a contextual
+        # deny cannot be re-granted, and the contextual layer cannot re-grant the
+        # static authority's deny (never-elevate). ``contextual=None`` → the stack
+        # is exactly ``[AgentLayer(decl)]`` = byte-identical to the pre-#1827 gate.
         from reyn.security.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
+            ContextualLayer,
             EffectivePermission,
         )
 
-        if not EffectivePermission([AgentLayer(decl)]).allows(
-            CapabilityAxis.TOOL, tool
-        ):
+        layers: list = [AgentLayer(decl)]
+        if contextual is not None:
+            layers.append(ContextualLayer(contextual))
+        if not EffectivePermission(layers).allows(CapabilityAxis.TOOL, tool):
+            # Decision-enabling deny: distinguish "static authority never granted
+            # it" (declare it) from "the active capability context narrowed it
+            # away" (the tool IS declared, but delegation/topology/ephemeral
+            # narrowing blocks it) — without ever re-granting either.
+            static_ok = EffectivePermission([AgentLayer(decl)]).allows(
+                CapabilityAxis.TOOL, tool
+            )
+            if static_ok:
+                raise PermissionError(
+                    f"tool {tool!r} is blocked by the active capability context "
+                    f"(delegation / topology / ephemeral narrowing). It is declared "
+                    f"in skill permissions but removed by the current context."
+                )
             raise PermissionError(
                 f"tool {tool!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  tool: [{tool}]` to the skill.md frontmatter."

--- a/tests/test_contextual_permission_1827.py
+++ b/tests/test_contextual_permission_1827.py
@@ -166,3 +166,89 @@ def test_none_context_layer_is_top():
     layer = ContextualLayer(None)
     assert layer.allows(CapabilityAxis.TOOL, "anything") is True
     assert layer.allows(CapabilityAxis.MCP, "anything") is True
+
+
+# ── live gate: _excluded_result is now effective.py-backed (#1827 S1.5) ──────
+#
+# The LIVE tool-enforcement gate (router_loop._excluded_result, the #1406/#187
+# pre-dispatch block) now consults the ∩-model (ContextualLayer) — the single
+# enforcement gate. These pin that an explicit ContextualPermission blocks via
+# every bypass shape (native / salvaged / direct invoke_action), and that the
+# gate is load-bearing (no narrowing → the tool executes).
+import asyncio
+import json
+
+from reyn.runtime.router_loop import RouterLoop
+
+
+class _Events:
+    def emit(self, *a, **k) -> None:
+        pass
+
+
+class _MiniHost:
+    agent_name = "t"
+
+    def __init__(self) -> None:
+        self.events = _Events()
+        self.web_search_calls: list[dict] = []
+
+    async def web_search(self, **kw) -> dict:  # runs IFF the tool executes
+        self.web_search_calls.append(kw)
+        return {"kind": "web_search", "results": ["LEAKED GOLD"]}
+
+
+def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
+    return asyncio.run(
+        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+    )
+
+
+def test_live_gate_blocks_via_explicit_contextual_all_paths():
+    """Tier 2: an explicit ContextualPermission.tool_deny blocks the live gate via
+    every bypass shape, and the excluded tool's handler never runs (#187)."""
+    host = _MiniHost()
+    loop = RouterLoop(
+        host=host, chain_id="t", max_iterations=5,
+        contextual_permission=ContextualPermission(tool_deny=frozenset({"web__search"})),
+    )
+    # (a) native, (b) salvaged (= native by name), (c) direct invoke_action.
+    r_native = _exec(loop, "web__search", {"query": "gold?"})
+    r_invoke = _exec(loop, "invoke_action", {"action_name": "web__search", "query": "gold?"})
+    assert r_native.get("error", {}).get("kind") == "tool_excluded"
+    assert r_invoke.get("error", {}).get("kind") == "tool_excluded"
+    assert host.web_search_calls == [], "excluded handler must never run (no leak)"
+
+
+def test_live_gate_is_load_bearing_gated_not_unconditional():
+    """Tier 2: the live gate blocks ONLY when narrowing is present (falsify gate).
+
+    With a tool_deny the dispatch returns the tool_excluded block; with no
+    narrowing the same call is NOT blocked (it proceeds past the gate). Proves
+    the block is gated, not unconditional. (Breaking the gate makes the all-paths
+    block test above go CLEAN RED.)
+    """
+    deny_loop = RouterLoop(
+        host=_MiniHost(), chain_id="t", max_iterations=5,
+        contextual_permission=ContextualPermission(tool_deny=frozenset({"web__search"})),
+    )
+    assert _exec(deny_loop, "web__search", {}).get("error", {}).get("kind") == "tool_excluded"
+
+    open_loop = RouterLoop(host=_MiniHost(), chain_id="t", max_iterations=5)
+    assert _exec(open_loop, "web__search", {}).get("error", {}).get("kind") != "tool_excluded"
+
+
+def test_live_gate_exclude_tools_bridge_preserves_block():
+    """Tier 2: the legacy exclude_tools input bridges to the contextual gate.
+
+    An existing caller passing exclude_tools (no explicit contextual) gets the
+    SAME execution block through the new effective.py path — an unchanged result,
+    so the #1406 / #187 callers keep their behaviour.
+    """
+    loop = RouterLoop(
+        host=_MiniHost(), chain_id="t", max_iterations=5,
+        exclude_tools={"web__search"},
+    )
+    blocked = _exec(loop, "invoke_action", {"action_name": "web__search"})
+    assert blocked.get("error", {}).get("kind") == "tool_excluded"
+    assert _exec(loop, "file__read", {}).get("error", {}).get("kind") != "tool_excluded"

--- a/tests/test_contextual_permission_1827.py
+++ b/tests/test_contextual_permission_1827.py
@@ -1,0 +1,168 @@
+"""Tier 2: contextual capability narrowing via the conjunctive-∩ model (#1827 S1).
+
+#1827 folds per-session contextual narrowing (delegation / topology / ephemeral)
+into the existing `EffectivePermission` ∩-stack as one more restrict-only layer
+(`ContextualLayer`) — NOT a new enforcement path. The `require_tool` gate gains an
+optional `contextual` arg; `contextual=None` is byte-identical to the pre-#1827
+gate.
+
+never-elevate is the STRUCTURAL `all()` in `EffectivePermission.allows`: a
+`ContextualLayer` is just another conjunct, so it can only narrow — it can neither
+re-grant what it denies nor re-grant the static authority's deny.
+
+Falsification gates (lead-required):
+  - byte-identical: with `contextual=None` the gate decision (allow / the exact
+    "not declared" deny message) is unchanged → breaking inertness goes CLEAN RED.
+  - never-elevate: a `ContextualLayer` that "allows" a tool the static authority
+    never granted must STILL be denied (no grant-back) → asserting the raise is
+    the proof.
+
+Policy: real `PermissionResolver` + real `EffectivePermission` + real gate; the
+intervention bus (the only ask boundary) is a recording fake. No mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.security.permissions.effective import (
+    AgentLayer,
+    CapabilityAxis,
+    ContextualLayer,
+    ContextualPermission,
+    EffectivePermission,
+)
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _RecordingBus:
+    """Real ask-boundary fake (mirrors test_permission_prompt_phrasing)."""
+
+    def __init__(self, answer_id: str = "no") -> None:
+        self.captured: list[UserIntervention] = []
+        self._answer_id = answer_id
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.captured.append(iv)
+        return InterventionAnswer(text=self._answer_id, choice_id=self._answer_id)
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=True,
+    )
+
+
+# ── byte-identical: contextual=None is inert ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_none_contextual_allows_declared_tool(tmp_path):
+    """Tier 2: contextual=None on a declared tool passes the layer (byte-identical).
+
+    Falsify: if the contextual plumbing wrongly narrowed when None, a declared
+    tool would be denied → CLEAN RED. 'yes' on the bus clears the _approve prompt.
+    """
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="yes")
+    decl = PermissionDecl(tool=["web_search"])
+    # No raise = the layer admitted it (and the user approved).
+    await r.require_tool(decl, "web_search", bus, contextual=None)
+
+
+@pytest.mark.asyncio
+async def test_none_contextual_preserves_undeclared_message(tmp_path):
+    """Tier 2: contextual=None keeps the exact pre-#1827 'not declared' deny."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="yes")
+    decl = PermissionDecl(tool=[])  # web_search NOT declared
+    with pytest.raises(PermissionError, match="not declared in skill permissions"):
+        await r.require_tool(decl, "web_search", bus, contextual=None)
+
+
+# ── contextual narrowing (the new capability) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contextual_deny_blocks_declared_tool(tmp_path):
+    """Tier 2: a declared tool denied by contextual tool_deny is blocked.
+
+    The deny is decision-enabling (distinct message: blocked by context, not
+    undeclared) and fires at the layer — before the _approve prompt.
+    """
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="yes")
+    decl = PermissionDecl(tool=["web_search"])
+    ctx = ContextualPermission(tool_deny=frozenset({"web_search"}))
+    with pytest.raises(PermissionError, match="blocked by the active capability context"):
+        await r.require_tool(decl, "web_search", bus, contextual=ctx)
+    assert bus.captured == [], "contextual deny must fire before the approve prompt"
+
+
+@pytest.mark.asyncio
+async def test_contextual_allowlist_narrows_to_subset(tmp_path):
+    """Tier 2: a contextual tool_allow narrows a multi-tool decl to the subset."""
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="yes")
+    decl = PermissionDecl(tool=["web_search", "file_read"])
+    ctx = ContextualPermission(tool_allow=frozenset({"web_search"}))
+    # web_search: declared ∩ contextual-allowed → passes.
+    await r.require_tool(decl, "web_search", bus, contextual=ctx)
+    # file_read: declared but NOT in the contextual allow-list → narrowed away.
+    with pytest.raises(PermissionError, match="blocked by the active capability context"):
+        await r.require_tool(decl, "file_read", bus, contextual=ctx)
+
+
+# ── never-elevate (the structural invariant) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contextual_cannot_grant_back_static_deny(tmp_path):
+    """Tier 2: a ContextualLayer that 'allows' an UNDECLARED tool cannot grant it.
+
+    never-elevate falsification: the static authority never granted web_search
+    (decl.tool empty); the context 'allows' it — but the gate must STILL deny
+    (the static 'not declared' path wins). If grant-back were possible this would
+    pass → asserting the raise is the proof.
+    """
+    r = _resolver(tmp_path)
+    bus = _RecordingBus(answer_id="yes")
+    decl = PermissionDecl(tool=[])  # NOT declared
+    ctx = ContextualPermission(tool_allow=frozenset({"web_search"}))  # context "allows"
+    with pytest.raises(PermissionError, match="not declared in skill permissions"):
+        await r.require_tool(decl, "web_search", bus, contextual=ctx)
+
+
+def test_effective_all_seam_is_never_elevate():
+    """Tier 2: EffectivePermission.allows = all(layers) — the structural seam.
+
+    Directly pins both never-elevate directions on the ∩ model itself:
+      (a) static-grant ∩ contextual-deny → denied (contextual narrows);
+      (b) static-deny ∩ contextual-allow → denied (no grant-back).
+    """
+    granted = PermissionDecl(tool=["web_search"])
+    denied = PermissionDecl(tool=[])
+    deny_ctx = ContextualLayer(ContextualPermission(tool_deny=frozenset({"web_search"})))
+    allow_ctx = ContextualLayer(ContextualPermission(tool_allow=frozenset({"web_search"})))
+
+    # (a) granted by AgentLayer, denied by ContextualLayer → all() = False.
+    assert EffectivePermission([AgentLayer(granted), deny_ctx]).allows(
+        CapabilityAxis.TOOL, "web_search"
+    ) is False
+    # (b) denied by AgentLayer, "allowed" by ContextualLayer → all() = False (no grant-back).
+    assert EffectivePermission([AgentLayer(denied), allow_ctx]).allows(
+        CapabilityAxis.TOOL, "web_search"
+    ) is False
+    # control: granted by both → True (the layer is genuinely inert when it permits).
+    assert EffectivePermission([AgentLayer(granted), allow_ctx]).allows(
+        CapabilityAxis.TOOL, "web_search"
+    ) is True
+
+
+def test_none_context_layer_is_top():
+    """Tier 2: ContextualLayer(None) is ⊤ on every axis (inert)."""
+    layer = ContextualLayer(None)
+    assert layer.allows(CapabilityAxis.TOOL, "anything") is True
+    assert layer.allows(CapabilityAxis.MCP, "anything") is True


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S1 + S1.5** (folded per lead: land as a LIVE debt-killing slice, not an inert layer). Design v2 APPROVED; decision (b) APPROVED.

## What this kills
The discovered **2-path tech-debt**: `exclude_tools` did double duty — execution-block (`_excluded_result`) **and** advertisement-hide (`_apply_tool_exclusions`). This unifies the **enforcement** onto the ∩-model (`effective.py`) at a single live gate, retiring the standalone `exclude_tools` enforcement membership; the **visibility** axis is left untouched (= the 2-axis separation owner wants).

## S1 — the contextual layer (axis A model)
- `effective.py`: `ContextualPermission` (TOOL axis: `tool_allow` None=⊤ ∩ `¬tool_deny`) + `ContextualLayer` — one more restrict-only conjunct in `EffectivePermission.allows` (`all()`).
- `OpContext.contextual_permission`: per-session carrier (threat_scan #1822 pattern).
- `require_tool(contextual=)`: byte-identical when None; decision-enabling deny distinguishes static-undeclared vs contextual-blocked.
- **never-elevate = the `all()` seam** (effective.py): a ContextualLayer `False` can't be re-granted, nor can it re-grant a lower layer's `False`.

## S1.5 — the LIVE gate (kills the debt)
- The live TOOL-axis gate **`_excluded_result`** (router_loop.py, the #1406/#187 pre-dispatch block) now consults `ContextualLayer(self._contextual_permission).allows(TOOL, effective)` — **not** the standalone `effective in self._exclude_tools`. Preserves the 3-bypass-path effective-name resolution + the `tool_excluded` decision-enabling message.
- `RouterLoop.contextual_permission` (per-session, same seam as `_exclude_tools`). **Bridge**: when not given, derived `ContextualPermission(tool_deny=exclude_tools)` so existing callers (eval #187 `web` hide, planner `{"plan"}` guard) keep the execution-block **byte-identically**. S2+ (topology/delegate/ephemeral) feed a real contextual directly.
- `exclude_tools` **enforcement** membership retired; **visibility** (`_apply_tool_exclusions` / `excluded_categories`) untouched.

## Why decision (b), not (a)
(a) wires the **dead** `require_tool` (a strict `decl.tool` allow-list + a per-call `_approve` prompt) into dispatch → would impose "every dispatched tool must be declared" + a prompt on the whole router = a **semantics change** (today tools are default-allow-unless-excluded). Making the static authority (`permission.tool ∩`) live at dispatch is the separate **#1199 dead-gate wiring** (needs every skill to declare every tool) — **forward item, tracked**.

## Test plan (real `RouterLoop` + real dispatch + real `EffectivePermission`, no mocks)
- [x] S1: byte-identical (`contextual=None`), contextual deny/allow narrowing, never-elevate (contextual can't grant-back an undeclared tool), the `all()` seam directly. **passed.**
- [x] S1.5: explicit `tool_deny` blocks the live gate via **all 3 bypass shapes** (handler never runs); the gate is **gated not unconditional**; the `exclude_tools`→contextual **bridge preserves the block**. **passed.**
- [x] **Falsification (CLEAN RED verified)**: `all()`→`any()` reds the never-elevate test; breaking `_excluded_result` reds the block tests. Reverted.
- [x] Backward-compat: `test_exclude_execution_block_1406` (the #187 e2e) + `test_permission_prompt_phrasing` pass unchanged.
- [x] Regression: exclude/router_loop/permission/effective **313 passed**; planner plan-guard **58 passed**; tier-audit + ruff clean.

## Forward (tracked)
- (a) `require_tool` runtime live-wiring + full `permission.tool ∩` at dispatch = **#1199**.
- Visibility → `capability_profile` view, topology/delegate/ephemeral contextual sources = S2+.

Refs #1827 (design-check v2 + live-seam trace). Ready for security-path review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
