### PR TITLE
feat(1820 Part1): reference-only preamble on compaction summaries

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -31,6 +31,22 @@ from reyn.services.compaction.engine import (
     trim_tail,
 )
 
+# #1820 Part1: static reference-only preamble prepended to every rendered
+# compaction summary (Hermes SUMMARY_PREFIX analog). Frames the summary as
+# history — not a fresh instruction — so the model (a) treats the latest user
+# message as the single source of truth and (b) does NOT re-execute `pending` /
+# in-progress work after a reverse-signal (stop / undo / change of direction).
+_SUMMARY_PREAMBLE = (
+    "[CONTEXT SUMMARY — REFERENCE ONLY, NOT A NEW INSTRUCTION]\n"
+    "The text below is a compacted summary of EARLIER conversation, kept for "
+    "reference. It is history, not the current task. The most recent user message "
+    "is the single source of truth: when it conflicts with anything here, follow "
+    "the latest user message. If the recent conversation shows a reverse signal — a "
+    "stop, an undo, or a change of direction — treat any 'pending' or in-progress "
+    "work described below as CANCELLED and do not resume it unless re-requested.\n"
+    "--- summary follows ---\n"
+)
+
 if TYPE_CHECKING:
     from reyn.runtime.chat_message import ChatMessage
 
@@ -304,7 +320,13 @@ class CompactionController:
         chat_summary = await self._engine.compact(input_chunk)
         structured = chat_summary.to_dict()
         covers = chat_summary.covers_through_seq or candidates[-1].seq
-        rendered = self._render_summary(structured)
+        # #1820 Part1: frame the rendered summary with a static reference-only
+        # preamble (Hermes SUMMARY_PREFIX analog) so the model treats the summary as
+        # history — NOT a fresh instruction — and does not re-execute `pending` work
+        # after a reverse-signal (stop / undo / change of direction). Prepended here
+        # (controller-owned, render-fn-independent) so every rendered summary carries
+        # it. Static string → no LLM dependency.
+        rendered = _SUMMARY_PREAMBLE + self._render_summary(structured)
 
         summary_msg = self._make_summary_message(rendered, structured, covers)
         self._append_history(summary_msg)

--- a/tests/test_compaction_summary_preamble_1820.py
+++ b/tests/test_compaction_summary_preamble_1820.py
@@ -1,0 +1,96 @@
+"""Tier 2: compaction summary carries the reference-only preamble (#1820 Part1).
+
+#1820 Part1 prepends a STATIC reference-only preamble (Hermes SUMMARY_PREFIX analog)
+to every rendered compaction summary so the model treats the summary as history —
+not a fresh instruction — and does not re-execute `pending` work after a reverse
+signal. This drives the real CompactionController with stub engine/render callables
+(mirroring test_compaction_controller_invariants) and asserts the rendered summary
+leads with the preamble while still carrying the original summary content.
+
+Policy: real CompactionController + real EventLog/CompactionConfig; only the engine
+and the render/append callables are stubs (the existing harness pattern). No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.services.compaction.engine import (
+    ChatSummary,
+    CompactionEngine,
+    ComputedBudgets,
+    HistoryChunkToCompact,
+)
+
+_STUB_BUDGETS = ComputedBudgets(
+    main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
+    new_msg_budget=10_000, B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
+)
+
+
+@dataclass
+class _FakeMessage:
+    role: str
+    text: str
+    ts: str = "2026-01-01T00:00:00+00:00"
+    seq: int = 0
+    meta: dict = field(default_factory=dict)
+
+
+class _SucceedingEngine(CompactionEngine):
+    def __init__(self) -> None:
+        self._model = ""
+        self._events = EventLog()
+        self._budgets = _STUB_BUDGETS
+
+    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+        return ChatSummary(topic_arc="STUB_ARC", covers_through_seq=0)
+
+
+def _make_controller(history: list[_FakeMessage]) -> tuple[CompactionController, list]:
+    ctrl = CompactionController(
+        event_log=EventLog(),
+        config=CompactionConfig(use_chars4_estimate=True),
+        history_access=lambda: list(history),
+        latest_summary=lambda: None,
+        compaction_engine=_SucceedingEngine(),
+        history_appender=history.append,
+        make_summary_message=lambda rendered, structured, covers: _FakeMessage(
+            role="summary", text=rendered, seq=0,
+        ),
+        render_summary=lambda s: str(s),
+    )
+    return ctrl, history
+
+
+def _history(n: int) -> list[_FakeMessage]:
+    return [
+        _FakeMessage(role="user" if i % 2 == 1 else "assistant", text="x" * 200, seq=i)
+        for i in range(1, n + 1)
+    ]
+
+
+def test_summary_leads_with_reference_only_preamble():
+    """Tier 2: the rendered summary leads with the reference-only preamble carrying
+    the source-of-truth + discard-pending-on-reverse-signal directives."""
+    ctrl, hist = _make_controller(_history(7))
+    asyncio.run(ctrl.force_compact_now())
+    summaries = [m for m in hist if m.role == "summary"]
+    assert summaries, "force_compact_now must append a summary"
+    text = summaries[-1].text
+    assert text.startswith("[CONTEXT SUMMARY"), "summary must lead with the reference-only preamble"
+    assert "single source of truth" in text, "must name the latest user message as source of truth"
+    assert "CANCELLED" in text, "must direct discarding pending work on a reverse signal"
+
+
+def test_preamble_is_prepended_not_replacing_summary():
+    """Tier 2: (non-regression) the preamble is PREPENDED — the original rendered
+    summary content still follows it (the summary is not replaced)."""
+    ctrl, hist = _make_controller(_history(7))
+    asyncio.run(ctrl.force_compact_now())
+    text = [m for m in hist if m.role == "summary"][-1].text
+    assert "--- summary follows ---" in text, "delimiter between preamble and summary"
+    assert "STUB_ARC" in text, "the original rendered summary content must survive the prepend"


### PR DESCRIPTION
**[dogfood-coder]** — #1820 Part1 (Part2 tool-output strip = #1849 done). triage: issuecomment-4756903192. The pending-re-execution-prevention preamble was unimplemented.

## What
Prepends a STATIC reference-only preamble (Hermes `SUMMARY_PREFIX` analog) to every rendered compaction summary, at the controller-owned render site (`CompactionController`, between `_render_summary` and `_make_summary_message` — render-fn-independent, primary-verified at `compaction_controller.py:307`). The preamble frames the summary so the model:
- treats it as **history, not a fresh instruction**;
- takes the **latest user message as the single source of truth**;
- **discards `pending`/in-progress work on a reverse signal** (stop / undo / change of direction) instead of re-executing it.

Static string → low-risk, no LLM dependency, no config.

## Test plan
- [x] #1820 Tier-2 **2/2**: summary leads with the preamble + carries the source-of-truth & discard-pending directives; **non-regression** — the preamble is prepended (delimiter present) and the original rendered summary content survives
- [x] compaction sweep: **156 passed**
- [x] `ruff` + tier-audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)