### PR TITLE
docs(security): update content-layer defense — accurate S1-S5 coverage + honest gaps

### DIFF
--- a/docs/concepts/agent-engineering/security.md
+++ b/docs/concepts/agent-engineering/security.md
@@ -43,9 +43,24 @@ Skill authors are nudged toward `safe`; reaching for `unsafe` is a deliberate ch
 
 `reyn eval` does not prompt. Permissions must be in place before the run — either pre-approved in `reyn.yaml` (`permissions.<key>: allow`) or persisted from a prior interactive run. The trust model doesn't change between modes; eval just inherits the decisions you've already made.
 
+### Content-layer defense
+
+Untrusted content is scanned and fenced at the OS seams where it enters the LLM prompt. Two primitives:
+
+- **Pattern scan** (`security/threat_patterns.py`) — regex-based detection of injection / exfiltration / role-hijack / exec-scope threats. Matches emit threat events; blocked patterns abort the operation.
+- **Structural fence** (`security/content_fence.py`) — explicit delimiters wrap untrusted content so the model sees it as data, not instructions.
+
+Both apply at these seams:
+- **Tool results** — scanned and fenced via `security/content_guard.py` before reaching the prompt
+- **Memory writes** — writes matching threat patterns are blocked at the router level
+- **Context files** (REYN.md/AGENTS.md) — fenced on load
+- **A2A inbound messages** — fenced + scanned on arrival
+- **Pre-exec commands** — `sandboxed_exec` scans the full joined argv for exec-scope threats before the subprocess is launched
+- **Compaction input** — secret-looking content is stripped before summaries persist (`security/secret_redaction.py`)
+
 ## Where it's still thin
 
-**Prompt injection is not specifically defended.** If untrusted text reaches the LLM (a fetched web page, a user-supplied file), the LLM may follow embedded instructions. reyn's permission system bounds the *capabilities* a compromised LLM can reach (it cannot write outside approved paths, cannot run shell without `--allow-shell`, etc.) but does not pre-screen LLM input for injection. Defenses for that layer (input filtering, dual-LLM patterns, output gating) belong in the skill design, not the OS.
+**Content-layer defense is seam-based regex detection, not a prompt-injection guarantee.** Pattern scans catch known attack shapes at OS seams; novel or obfuscated payloads that don't match a regex pass through. Once untrusted content is fenced and in the prompt, the LLM may still follow embedded instructions that read as natural language rather than a recognisable attack pattern. The OS does not gate the LLM's *response* for injection residue — capability damage is bounded by the permission system (no writes outside approved paths, no shell without `--allow-shell`) but response-level interception is not implemented. Direct operator input (`ask_user`, chat messages) is trusted by definition and not scanned. Skill design still matters: keep untrusted content summarised rather than passed verbatim, validate structured outputs, and use `judge_output` to gate critical decisions.
 
 **`mode: unsafe` is OS-level trust, not OS-level sandbox.** An unsafe Python step runs as the same user with the same filesystem access; it is not kernel-sandboxed. The system trusts that the user authorized the specific (module, function) pair. This is the right boundary for a developer tool — but it means unsafe steps deserve code review the way a Makefile target does.
 
@@ -56,3 +71,4 @@ Skill authors are nudged toward `safe`; reaching for `unsafe` is a deliberate ch
 - [Reference: reyn.yaml](../../reference/config/reyn-yaml.md) — `permissions:` key
 - [How-to: manage permissions](../../guide/for-users/manage-permissions.md)
 - [reliability-engineering.md](reliability-engineering.md) — what happens when an op is denied
+- [Feature map — Content-layer defense](../../feature-map.md#content-layer-defense) — full mechanism inventory


### PR DESCRIPTION
**[docs-maintainer]** — security.md stale claim 解消。owner review 必要 (positioning doc)。

## Problem

`docs/concepts/agent-engineering/security.md` の "Where it's still thin" に「Prompt injection is not specifically defended」が残存。content-threat-scan S1-S5 (#1822 wave) landing 後は stale。

## Changes

### New section: `### Content-layer defense` (under "How reyn handles it")

Describes the two primitives (`threat_patterns.py` + `content_fence.py`) and the 6 seams they cover:
- Tool results (`content_guard.py`)
- Memory writes (blocked at router level)
- Context files REYN.md/AGENTS.md (fenced on load)
- A2A inbound messages (fenced + scanned)
- Pre-exec commands (`sandboxed_exec` argv scan)
- Compaction input (`secret_redaction.py`)

### Updated "Where it's still thin"

Replaces stale "not specifically defended" with accurate framing: **seam-based regex detection, not a guarantee**. Honest gaps preserved:
- Regex bypass (novel/obfuscated attacks)
- Semantic natural-language attacks past the fence
- No response-level gating (capability damage bounded by permission system, not response interception)
- Operator input (`ask_user`, chat) not scanned — trusted by definition

Skill-design guidance kept intact (summarise, validate, judge_output).

### See also: feature-map cross-ref added

## Accuracy verification

| Claim | Source | Verified |
|-------|--------|---------|
| `threat_patterns.py` injection/exfilt/role-hijack/exec scopes | `security/threat_patterns.py:20-23` | ✅ |
| `content_fence.py` structural delimiters | `security/content_fence.py:4,17,27` | ✅ |
| Tool-result guard `content_guard.py` | `security/content_guard.py:3,18,19` | ✅ |
| Memory write block | `runtime/router_loop.py:4467` | ✅ |
| Pre-exec command scan | `core/op_runtime/sandboxed_exec.py:26-42` | ✅ |
| A2A inbound fence `a2a_handler.py` | `runtime/services/a2a_handler.py:309-310` | ✅ |
| Context-file fence `router_host_adapter.py` | `:579` FP-0050 S4b EP3 comment | ✅ |
| Compaction `secret_redaction.py` | `security/secret_redaction.py:1` | ✅ |

## Test plan

- [x] No `#issue/PR/FP` history-refs in changed doc
- [x] No mermaid diagrams modified
- [x] `mkdocs build --strict` — pre-existing `.ja.md` anchor warnings only (same as #1885); this file (`security.md`) has no broken links
- [x] Feature-map cross-ref anchor `#content-layer-defense` — exists in feature-map.md (section added in #1885)

🤖 Generated with [Claude Code](https://claude.com/claude-code)