### PR TITLE
feat(1827): S2a — capability_profile schema + pure resolver

### DIFF
--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -1,0 +1,137 @@
+"""Capability profile (#1827 S2a) — the named role spec + its pure resolver.
+
+A ``capability_profile`` is a named, declarative narrowing of an agent's
+capabilities, loaded from ``.reyn/capability_profiles/<name>.yaml``. It is the
+single source for BOTH #1827 axes:
+
+- **authority (enforcement, axis A)** → a :class:`ContextualPermission`
+  (``tool_allow`` / ``tool_deny``) that rides the live ∩-gate (S1.5, #1884).
+- **visibility (cognitive, axis B)** → an ``excluded_categories`` set derived
+  from ``categories`` against the canonical 12-entry catalog.
+
+This module is PURE — schema + loader + resolver + compose. It is **unwired**:
+no binding to topology / delegate / ephemeral yet (S2b/S3 wire it through the
+``scoped_session_factory`` #1402 single-source). With no profile applied the
+session is byte-identical to pre-#1827.
+
+The resolver never *grants* — both products are restrict-only:
+``ContextualPermission`` is an ∩ term (never-elevate is the ``all()`` in
+``EffectivePermission``); ``excluded_categories`` only hides. So **visible ⊆
+authorized** holds structurally.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from reyn.security.permissions.effective import ContextualPermission
+from reyn.tools.universal_catalog import CATEGORIES
+
+
+@dataclass(frozen=True)
+class CapabilityProfile:
+    """A named capability narrowing (loaded from YAML).
+
+    - ``categories`` — the catalog categories to KEEP VISIBLE (axis B). ``None``
+      = no visibility narrowing (show everything). An explicit (possibly empty)
+      tuple narrows the view to that set.
+    - ``tool_allow`` — the tools to permit (axis A allow-list). ``None`` =
+      unconstrained (deny-list only).
+    - ``tool_deny`` — the tools to forbid (axis A).
+
+    Tuples (not sets) so the dataclass stays frozen/hashable; the resolver
+    converts to frozensets.
+    """
+
+    name: str
+    description: str = ""
+    categories: "tuple[str, ...] | None" = None
+    tool_allow: "tuple[str, ...] | None" = None
+    tool_deny: "tuple[str, ...]" = ()
+
+
+def _as_tuple(value: "object | None") -> "tuple[str, ...] | None":
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return tuple(str(v) for v in value)
+    return (str(value),)
+
+
+def load_capability_profile(path: "str | Path") -> CapabilityProfile:
+    """Load a ``CapabilityProfile`` from a ``.reyn/capability_profiles/<name>.yaml``.
+
+    Unknown keys are ignored (forward-compat). ``name`` defaults to the file stem.
+    A missing ``categories`` key → ``None`` (no view narrowing); a present-but-empty
+    list → ``()`` (narrow the view to nothing).
+    """
+    import yaml
+
+    p = Path(path)
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        data = {}
+    return CapabilityProfile(
+        name=str(data.get("name", p.stem)),
+        description=str(data.get("description", "") or ""),
+        categories=_as_tuple(data["categories"]) if "categories" in data else None,
+        tool_allow=_as_tuple(data["tool_allow"]) if "tool_allow" in data else None,
+        tool_deny=_as_tuple(data.get("tool_deny")) or (),
+    )
+
+
+def resolve_profile(
+    profile: CapabilityProfile,
+) -> "tuple[ContextualPermission, frozenset[str]]":
+    """Resolve a profile into ``(ContextualPermission, excluded_categories)``.
+
+    - enforcement: ``ContextualPermission(tool_allow, tool_deny)`` — the S1 ∩ term.
+    - view: ``excluded_categories = CATEGORIES − categories`` when ``categories``
+      is set; ``∅`` (no view narrowing) when ``categories is None``.
+
+    Unknown category names in ``categories`` are simply not in ``CATEGORIES`` and
+    so do not reduce the excluded set (they are a no-op, not an error — the loader
+    is forward-compat).
+    """
+    contextual = ContextualPermission(
+        tool_allow=(
+            frozenset(profile.tool_allow) if profile.tool_allow is not None else None
+        ),
+        tool_deny=frozenset(profile.tool_deny),
+    )
+    if profile.categories is None:
+        excluded_categories: "frozenset[str]" = frozenset()
+    else:
+        excluded_categories = frozenset(CATEGORIES) - frozenset(profile.categories)
+    return contextual, excluded_categories
+
+
+def compose_resolved(
+    resolved: "list[tuple[ContextualPermission, frozenset[str]]]",
+) -> "tuple[ContextualPermission, frozenset[str]]":
+    """Compose N resolved profiles, most-restrictive-wins (#1827 multi-membership).
+
+    Monotonic with the S1 ∩ model: **union of denials, intersection of allows**.
+    - ``tool_deny`` → union (any profile's deny wins).
+    - ``tool_allow`` → intersection of the *set* allow-lists (``None`` = ⊤, skipped);
+      a tool stays allowed only if every constraining profile allows it.
+    - ``excluded_categories`` → union (any profile's hide wins).
+
+    Empty input → an inert ``(ContextualPermission(), ∅)``.
+    """
+    deny: "set[str]" = set()
+    excluded: "set[str]" = set()
+    allow_sets: "list[frozenset[str]]" = []
+    for contextual, excl in resolved:
+        deny |= set(contextual.tool_deny)
+        excluded |= set(excl)
+        if contextual.tool_allow is not None:
+            allow_sets.append(contextual.tool_allow)
+    if allow_sets:
+        combined_allow: "frozenset[str] | None" = frozenset.intersection(*allow_sets)
+    else:
+        combined_allow = None
+    return (
+        ContextualPermission(tool_allow=combined_allow, tool_deny=frozenset(deny)),
+        frozenset(excluded),
+    )

--- a/tests/test_capability_profile_1827.py
+++ b/tests/test_capability_profile_1827.py
@@ -1,0 +1,128 @@
+"""Tier 2: capability profile schema + pure resolver (#1827 S2a).
+
+A ``capability_profile`` resolves into BOTH #1827 axes via one pure resolver:
+authority (``ContextualPermission``, rides the S1.5 live ∩-gate) + visibility
+(``excluded_categories`` over the 12-entry catalog). This module is unwired —
+these pin the schema round-trip, the resolution of each axis, and the
+most-restrictive composition.
+
+The round-trip uses a NON-DEFAULT profile (a ``tool_deny`` tool that is not a
+default / bridge value) so a silently-wrong load can't pass trivially.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from reyn.security.permissions.capability_profile import (
+    CapabilityProfile,
+    compose_resolved,
+    load_capability_profile,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    ContextualLayer,
+    ContextualPermission,
+)
+from reyn.tools.universal_catalog import CATEGORIES
+
+
+def test_load_round_trip_non_default(tmp_path: Path):
+    """Tier 2: a non-default profile YAML round-trips into the dataclass."""
+    p = tmp_path / "reviewer.yaml"
+    p.write_text(textwrap.dedent("""
+        name: reviewer
+        description: read + memo only
+        categories: [file, validation]
+        tool_allow: [file__read]
+        tool_deny: [memory__write, delegate_to_agent]
+    """).lstrip(), encoding="utf-8")
+
+    prof = load_capability_profile(p)
+
+    assert prof.name == "reviewer"
+    assert prof.description == "read + memo only"
+    assert prof.categories == ("file", "validation")
+    assert prof.tool_allow == ("file__read",)
+    assert prof.tool_deny == ("memory__write", "delegate_to_agent")
+
+
+def test_load_missing_categories_is_none_vs_empty(tmp_path: Path):
+    """Tier 2: absent ``categories`` → None (no view narrowing); empty list → ()."""
+    p1 = tmp_path / "a.yaml"
+    p1.write_text("name: a\ntool_deny: [x]\n", encoding="utf-8")
+    assert load_capability_profile(p1).categories is None
+
+    p2 = tmp_path / "b.yaml"
+    p2.write_text("name: b\ncategories: []\n", encoding="utf-8")
+    assert load_capability_profile(p2).categories == ()
+
+
+def test_resolve_view_excludes_complement_of_categories():
+    """Tier 2: categories → excluded_categories = CATEGORIES − categories."""
+    prof = CapabilityProfile(name="r", categories=("file", "web"))
+    _contextual, excluded = resolve_profile(prof)
+    assert "file" not in excluded and "web" not in excluded
+    assert excluded == frozenset(CATEGORIES) - {"file", "web"}
+    # every other catalog category is hidden
+    assert "memory_entry" in excluded and "exec" in excluded
+
+
+def test_resolve_no_categories_no_view_narrowing():
+    """Tier 2: categories=None → no view narrowing (empty excluded set)."""
+    prof = CapabilityProfile(name="r", tool_deny=("memory__write",))
+    _contextual, excluded = resolve_profile(prof)
+    assert excluded == frozenset()
+
+
+def test_resolve_enforcement_denies_via_live_gate_type():
+    """Tier 2: tool_deny resolves to a ContextualPermission that blocks at the gate.
+
+    The resolved ContextualPermission is the SAME type the live gate
+    (router_loop._excluded_result, S1.5) consults — so a denied tool is blocked
+    and an allowed one passes (visible ⊆ authorized: the resolver never grants).
+    """
+    prof = CapabilityProfile(
+        name="r", tool_allow=("file__read",), tool_deny=("memory__write",),
+    )
+    contextual, _excluded = resolve_profile(prof)
+    layer = ContextualLayer(contextual)
+    assert layer.allows(CapabilityAxis.TOOL, "memory__write") is False  # denied
+    assert layer.allows(CapabilityAxis.TOOL, "file__read") is True       # allowed
+    # not in the allow-list → narrowed away (allow-list semantics)
+    assert layer.allows(CapabilityAxis.TOOL, "web__search") is False
+
+
+def test_compose_union_deny_intersect_allow_union_excluded():
+    """Tier 2: compose = most-restrictive (∪ deny, ∩ allow, ∪ excluded)."""
+    a = (
+        ContextualPermission(tool_allow=frozenset({"x", "y"}), tool_deny=frozenset({"d1"})),
+        frozenset({"file"}),
+    )
+    b = (
+        ContextualPermission(tool_allow=frozenset({"y", "z"}), tool_deny=frozenset({"d2"})),
+        frozenset({"web"}),
+    )
+    contextual, excluded = compose_resolved([a, b])
+    assert contextual.tool_deny == frozenset({"d1", "d2"})        # union
+    assert contextual.tool_allow == frozenset({"y"})             # intersection
+    assert excluded == frozenset({"file", "web"})               # union
+
+
+def test_compose_none_allow_is_top():
+    """Tier 2: a None (⊤) allow-list does not constrain the composed allow."""
+    a = (ContextualPermission(tool_allow=None, tool_deny=frozenset({"d1"})), frozenset())
+    b = (ContextualPermission(tool_allow=frozenset({"x"}), tool_deny=frozenset()), frozenset())
+    contextual, _ = compose_resolved([a, b])
+    # only b constrains the allow-list → effective allow = {x}
+    assert contextual.tool_allow == frozenset({"x"})
+    assert contextual.tool_deny == frozenset({"d1"})
+
+
+def test_compose_empty_is_inert():
+    """Tier 2: composing nothing yields an inert (⊤ allow, ∅ deny, ∅ excluded)."""
+    contextual, excluded = compose_resolved([])
+    assert contextual.tool_allow is None
+    assert contextual.tool_deny == frozenset()
+    assert excluded == frozenset()


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S2a** (capability_profile foundation). Binding design-check + addendum APPROVED; slice S2a→S2b→S3 greenlit.

## What
A `capability_profile` (`.reyn/capability_profiles/<name>.yaml`) is the single source for **both** #1827 axes. This lands the **schema + a PURE resolver**, **unwired** (no topology/delegate/ephemeral binding yet — S2b/S3) → **byte-identical**.

- **`CapabilityProfile`** (frozen, tuple-backed): `name` / `description` / `categories` / `tool_allow` / `tool_deny`. `load_capability_profile` (YAML, forward-compat unknown keys; absent `categories` → `None` = no view narrowing, `[]` → `()` = narrow to nothing).
- **`resolve_profile` → `(ContextualPermission, excluded_categories)`**: enforcement = the S1 `ContextualPermission` (rides the S1.5 live gate); view = `CATEGORIES − categories` (`∅` when `categories is None`). **One resolver, both axes.**
- **`compose_resolved` → most-restrictive** (`∪` deny, `∩` allow, `∪` excluded) for an agent in N topologies — monotonic with the S1 ∩ model; S3 wires it.

Restrict-only by construction — the resolver never grants (`ContextualPermission` is an ∩ term; `excluded_categories` only hides) → **visible ⊆ authorized**.

## Test plan (pure unit, no mocks)
- [x] **Non-default round-trip** (lead steer 2): a profile with `tool_deny: [memory__write, delegate_to_agent]` — non-bridge values — round-trips load→dataclass. A silently-wrong load can't pass trivially.
- [x] `categories` None-vs-`[]` distinction; view = complement-of-categories over the real 12-entry `CATEGORIES`.
- [x] Enforcement: a resolved `tool_deny` **blocks via the real `ContextualLayer` gate type** (the same type the live `_excluded_result` consults); allow-list narrows.
- [x] Compose: union deny / intersect allow / union excluded; `None` allow is ⊤; empty input inert.
- [x] tier-audit + ruff clean.

## Scope honesty
S2a is **pure + unwired** — nothing imports it yet, so no behavior change (byte-identical). The production wiring (the part that proves "wired to the real callsite") is **S3**, where the resolved profile threads through the `scoped_session_factory` #1402 single-source to the live gate, proven by the **non-default e2e** (a `tool_deny` tool absent from `exclude_tools`, so only the explicit thread — not the S1.5 bridge — can block it).

Refs #1827. Next: S2b (`Topology.profiles` + round-trip) → S3 (full-path thread + non-default e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
