### PR TITLE
feat(1827): S2b — Topology.profiles per-member capability_profile binding

### DIFF
--- a/src/reyn/runtime/topology.py
+++ b/src/reyn/runtime/topology.py
@@ -54,6 +54,11 @@ class Topology:
     members: tuple[str, ...] = field(default_factory=tuple)
     leader: str | None = None
     created_at: str = ""
+    # #1827 S2b: per-member capability_profile binding (member name → profile
+    # name). A bound member's session is narrowed by the resolved profile (S3
+    # wires registry → resolver → the #1402 factory → the live gate). Excluded
+    # from __hash__ (dict is unhashable; Topology is keyed by other fields).
+    profiles: dict[str, str] = field(default_factory=dict, hash=False)
 
     def __post_init__(self) -> None:
         if self.kind not in KINDS:
@@ -62,6 +67,12 @@ class Topology:
             )
         if len(set(self.members)) != len(self.members):
             raise ValueError(f"topology {self.name!r}: duplicate members in {self.members}")
+        # #1827 S2b: a profile may only bind a member of this topology.
+        unknown = set(self.profiles) - set(self.members)
+        if unknown:
+            raise ValueError(
+                f"topology {self.name!r}: profiles bind non-members {sorted(unknown)}"
+            )
         if self.kind == "team":
             if self.leader is None:
                 raise ValueError(f"topology {self.name!r}: kind=team requires a leader")
@@ -96,6 +107,13 @@ class Topology:
             return j == i + 1
         return False
 
+    def profile_for(self, member: str) -> "str | None":
+        """Return the capability_profile name bound to ``member``, or None.
+
+        #1827 S2b. S3 resolves the name → a ``CapabilityProfile`` → the
+        ``(ContextualPermission, excluded_categories)`` threaded at session build."""
+        return self.profiles.get(member)
+
     def edges(self) -> list[tuple[str, str]]:
         """All directed edges this topology permits — used by `topology show`."""
         out: list[tuple[str, str]] = []
@@ -115,6 +133,7 @@ class Topology:
         kind: str,
         members: list[str],
         leader: str | None = None,
+        profiles: "dict[str, str] | None" = None,
     ) -> "Topology":
         _validate_topology_name(name)
         return cls(
@@ -123,18 +142,26 @@ class Topology:
             members=tuple(members),
             leader=leader,
             created_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            profiles=dict(profiles or {}),
         )
 
     @classmethod
     def load(cls, path: Path) -> "Topology":
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         members = data.get("members", []) or []
+        profiles_raw = data.get("profiles") or {}
+        profiles = (
+            {str(k): str(v) for k, v in profiles_raw.items()}
+            if isinstance(profiles_raw, dict)
+            else {}
+        )
         return cls(
             name=str(data.get("name", path.stem)),
             kind=str(data.get("kind", "network")),
             members=tuple(str(m) for m in members),
             leader=(str(data["leader"]) if data.get("leader") else None),
             created_at=str(data.get("created_at", "") or ""),
+            profiles=profiles,
         )
 
     def save(self, path: Path) -> None:
@@ -148,6 +175,8 @@ class Topology:
             payload["leader"] = self.leader
         if self.created_at:
             payload["created_at"] = self.created_at
+        if self.profiles:
+            payload["profiles"] = dict(self.profiles)
         path.write_text(
             yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
             encoding="utf-8",
@@ -164,6 +193,7 @@ class Topology:
             members=self.members + (agent,),
             leader=self.leader,
             created_at=self.created_at,
+            profiles=dict(self.profiles),
         )
 
     def with_member_removed(self, agent: str) -> "Topology":
@@ -179,6 +209,8 @@ class Topology:
             members=tuple(m for m in self.members if m != agent),
             leader=self.leader,
             created_at=self.created_at,
+            # #1827 S2b: drop the removed member's profile binding (no orphan).
+            profiles={m: p for m, p in self.profiles.items() if m != agent},
         )
 
 

--- a/tests/test_topology_profiles_1827.py
+++ b/tests/test_topology_profiles_1827.py
@@ -1,0 +1,77 @@
+"""Tier 2: Topology.profiles — per-member capability_profile binding (#1827 S2b).
+
+A topology may bind members to capability_profiles (member → profile name).
+S3 resolves the name → a CapabilityProfile → the (ContextualPermission,
+excluded_categories) threaded at session build. This pins the schema field:
+YAML round-trip, the member-validity invariant, the accessor, and builder
+propagation. Existing topologies (no profiles) are byte-identical.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.topology import Topology
+
+
+def test_profiles_round_trip_non_default(tmp_path: Path):
+    """Tier 2: a topology with profile bindings save→load round-trips."""
+    t = Topology.new(
+        "ci", kind="pipeline", members=["builder", "tester", "deployer"],
+        profiles={"tester": "reviewer", "deployer": "deploy_only"},
+    )
+    path = tmp_path / "ci.yaml"
+    t.save(path)
+    # the profiles block is persisted...
+    assert "profiles:" in path.read_text(encoding="utf-8")
+    loaded = Topology.load(path)
+    assert loaded.profiles == {"tester": "reviewer", "deployer": "deploy_only"}
+    assert loaded.members == ("builder", "tester", "deployer")
+
+
+def test_load_without_profiles_is_empty(tmp_path: Path):
+    """Tier 2: a topology YAML with no profiles → empty dict (byte-identical)."""
+    path = tmp_path / "n.yaml"
+    path.write_text("name: n\nkind: network\nmembers: [a, b]\n", encoding="utf-8")
+    loaded = Topology.load(path)
+    assert loaded.profiles == {}
+    # and save omits an empty profiles block
+    out = tmp_path / "n2.yaml"
+    loaded.save(out)
+    assert "profiles:" not in out.read_text(encoding="utf-8")
+
+
+def test_profile_for_accessor():
+    """Tier 2: profile_for returns the bound name or None."""
+    t = Topology.new(
+        "team", kind="team", members=["lead", "a"], leader="lead",
+        profiles={"a": "reviewer"},
+    )
+    assert t.profile_for("a") == "reviewer"
+    assert t.profile_for("lead") is None
+
+
+def test_profile_binding_non_member_rejected():
+    """Tier 2: a profile bound to a non-member is a construction error."""
+    with pytest.raises(ValueError, match="non-members"):
+        Topology(name="x", kind="network", members=("a",), profiles={"ghost": "p"})
+
+
+def test_with_member_added_preserves_profiles():
+    """Tier 2: adding a member keeps existing bindings."""
+    t = Topology.new("n", kind="network", members=["a"], profiles={"a": "reviewer"})
+    t2 = t.with_member_added("b")
+    assert t2.profiles == {"a": "reviewer"}
+    assert t2.members == ("a", "b")
+
+
+def test_with_member_removed_drops_binding():
+    """Tier 2: removing a bound member drops its binding (no orphan)."""
+    t = Topology.new(
+        "n", kind="network", members=["a", "b"],
+        profiles={"a": "reviewer", "b": "deploy_only"},
+    )
+    t2 = t.with_member_removed("a")
+    assert t2.profiles == {"b": "deploy_only"}
+    assert "a" not in t2.members


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S2b** (topology→profile binding field). S2a (#1890) merged; this adds the topology side.

## What
A topology may bind members to capability_profiles (member name → profile name). S3 resolves the name → `CapabilityProfile` → `(ContextualPermission, excluded_categories)` threaded at session build.

- **`Topology.profiles: dict[str,str]`** (frozen dataclass, `hash=False` — Topology is keyed by its other fields, never hashed on the dict). `__post_init__` rejects a profile bound to a **non-member**.
- **`load()`** parses the `profiles:` block; **`save()`** writes it only when non-empty → an existing profile-less topology round-trips **byte-identically** (no `profiles:` key emitted).
- **`new()`** gains a `profiles` kwarg; **`with_member_added`** propagates bindings; **`with_member_removed`** drops the removed member's binding (no orphan).
- **`profile_for(member)`** accessor for S3.

```yaml
# .reyn/topologies/ci.yaml
kind: pipeline
members: [builder, tester, deployer]
profiles:
  tester: reviewer
  deployer: deploy_only
```

## Test plan
- [x] **Non-default round-trip** (lead steer): `profiles: {tester: reviewer, deployer: deploy_only}` → save → load → assert (the `profiles:` block persisted).
- [x] No-profiles → empty dict + `save()` omits the block (existing topologies byte-identical).
- [x] `profile_for` accessor; the **non-member binding invariant** (ValueError); builder propagation + removed-member drop.
- [x] Existing topology suite unchanged (**8 passed**); tier-audit + ruff clean.

Refs #1827. Next: **S3** — `registry.resolved_profile_for(agent)` → `scoped_session_factory` #1402 → live gate full-path thread, proven by a `memory__write` non-default e2e (a `tool_deny` tool absent from `exclude_tools`, so only the explicit thread can block it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
