### PR TITLE
fix(cli): support-bundle --since huge relative value crashed with OverflowError

### DIFF
--- a/src/reyn/interfaces/cli/commands/support_bundle.py
+++ b/src/reyn/interfaces/cli/commands/support_bundle.py
@@ -55,7 +55,15 @@ def _parse_since(raw: str | None) -> datetime | None:
     if raw and raw[-1] in ("d", "h", "m") and raw[:-1].isdigit():
         n = int(raw[:-1])
         unit = {"d": "days", "h": "hours", "m": "minutes"}[raw[-1]]
-        return datetime.now(UTC) - timedelta(**{unit: n})
+        try:
+            return datetime.now(UTC) - timedelta(**{unit: n})
+        except (OverflowError, ValueError) as exc:
+            # A huge relative window (e.g. ``99999999999999999999d``) overflows
+            # timedelta's C-int range — surface the same graceful SystemExit the
+            # ISO path gives, not an uncaught traceback.
+            raise SystemExit(
+                f"support-bundle: invalid --since {raw!r}: {exc}"
+            ) from exc
     try:
         dt = datetime.fromisoformat(raw)
         return dt if dt.tzinfo else dt.replace(tzinfo=UTC)

--- a/tests/test_support_bundle_1833.py
+++ b/tests/test_support_bundle_1833.py
@@ -112,3 +112,45 @@ def test_bundle_has_meta_with_version(tmp_path, monkeypatch):
         assert "meta.json" in zf.namelist()
         meta = json.loads(zf.read("meta.json"))
     assert "reyn_version" in meta and "redaction" in meta
+
+
+# ── _parse_since edge handling ──────────────────────────────────────────────
+
+
+def test_parse_since_relative_window_parses() -> None:
+    """Tier 2: a normal relative window (Nd/Nh/Nm) returns a past datetime."""
+    now = datetime.now(UTC)
+    result = support_bundle._parse_since("3h")
+    assert result is not None
+    delta = now - result
+    # ~3 hours ago (allow a wide margin for execution time)
+    assert timedelta(hours=2, minutes=59) <= delta <= timedelta(hours=3, minutes=1)
+
+
+def test_parse_since_huge_relative_window_is_graceful() -> None:
+    """Tier 2: an over-large relative window exits gracefully, not with a traceback.
+
+    ``timedelta(days=N)`` raises OverflowError for N beyond its C-int range. The
+    relative path used to leave that uncaught (the try/except wrapped only the
+    ISO path) — a typo'd giant ``--since`` crashed the CLI with a traceback
+    instead of the clean ``SystemExit`` every other invalid value gets.
+
+    Falsification: without the guard around ``timedelta``, this raises
+    OverflowError (not SystemExit) and the assertion below fails.
+    """
+    with pytest.raises(SystemExit) as exc:
+        support_bundle._parse_since("99999999999999999999d")
+    assert "invalid --since" in str(exc.value)
+
+
+def test_parse_since_invalid_iso_is_graceful() -> None:
+    """Tier 2: a non-relative, non-ISO value exits gracefully (regression guard)."""
+    with pytest.raises(SystemExit) as exc:
+        support_bundle._parse_since("not-a-time")
+    assert "invalid --since" in str(exc.value)
+
+
+def test_parse_since_none_returns_none() -> None:
+    """Tier 2: no --since (None / empty) returns None (no filter)."""
+    assert support_bundle._parse_since(None) is None
+    assert support_bundle._parse_since("") is None

--- a/tests/test_support_bundle_1833.py
+++ b/tests/test_support_bundle_1833.py
@@ -152,5 +152,7 @@ def test_parse_since_invalid_iso_is_graceful() -> None:
 
 def test_parse_since_none_returns_none() -> None:
     """Tier 2: no --since (None / empty) returns None (no filter)."""
-    assert support_bundle._parse_since(None) is None
-    assert support_bundle._parse_since("") is None
+    none_result = support_bundle._parse_since(None)
+    empty_result = support_bundle._parse_since("")
+    assert none_result is None
+    assert empty_result is None


### PR DESCRIPTION
**[tui-coder]** — feature-map bug-mining finding (2026-06-20). Low-severity CLI crash.

## Bug

`reyn support-bundle --since 99999999999999999999d` crashes with an **uncaught**:

```
OverflowError: Python int too large to convert to C int
```

instead of the graceful `SystemExit` error that every other invalid `--since` value gets (e.g. `--since -5d`, `--since 1.5h`, `--since not-a-time` all exit cleanly with `support-bundle: invalid --since ...`).

## Root cause

`_parse_since` wrapped **only the ISO-8601 path** in try/except. The relative-window path's `timedelta(**{unit: n})` — which raises `OverflowError` for `N` beyond timedelta's C-int range — was unguarded.

## Fix

Wrap the relative-path `timedelta` in the same try/except → `SystemExit` with the consistent `"invalid --since"` message. Normal relative windows (`Nd`/`Nh`/`Nm`) and ISO values unchanged.

## Tests

4 Tier-2 (`tests/test_support_bundle_1833.py`): normal relative window parses / **huge value → graceful SystemExit** (falsifying: unguarded → OverflowError) / invalid ISO → graceful (regression guard) / None/empty → None.

## Test plan

- [x] `pytest tests/test_support_bundle_1833.py` — 9/9 green (4 new + 5 existing)
- [x] `ruff check` — clean
- [x] Manual: `python -c "_parse_since('99999999999999999999d')"` → graceful SystemExit (was OverflowError traceback)

## Tier self-check

- Tier 2: public `_parse_since` surface, real datetime (no mocks).
- No Tier 4: no `len()`-pinning, no private-state asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
