### PR TITLE
fix(word_stats_demo): budget the python-step timeout for harness cold-start (5s→15s)

### DIFF
--- a/src/reyn/stdlib/skills/word_stats_demo/skill.md
+++ b/src/reyn/stdlib/skills/word_stats_demo/skill.md
@@ -20,7 +20,13 @@ permissions:
     - module: ./stats.py
       function: compute_text_stats
       mode: safe
-      timeout: 5
+      # 15s budgets the sandboxed python HARNESS subprocess (interpreter spawn +
+      # reyn import cold-start), not just compute_text_stats (which runs in
+      # microseconds — see Overview). 5s was under-budgeted: on a cold/loaded
+      # machine the harness cold-start alone can exceed it, causing intermittent
+      # spurious `kind=Timeout` PreprocessorErrors (the run retries via
+      # will_resume but surfaces a confusing "stuck" — word_stats hang triage).
+      timeout: 15
 # FP-0016 D: this skill needs no static secrets / OAuth tokens.
 required_credentials: []
 ---


### PR DESCRIPTION
**[dogfood-coder]** — low-pri quick-win from the word_stats hang triage (closed non-bug). In-lane static fix (no live-LLM).

## Root cause (primary-evidence)
word_stats_demo's `review` python step set `timeout: 5`, but the timeout wraps the **sandboxed python harness subprocess** (`python -m reyn.core.kernel._python_harness` spawn + reyn import cold-start), not just `compute_text_stats` (which runs in microseconds — the skill's own Overview says so). On a cold/loaded machine the harness cold-start alone can exceed 5s → intermittent spurious `kind=Timeout` `PreprocessorError` → `skill_run_interrupted{will_resume:true}` (the run retries + eventually completes, but surfaces a confusing "stuck @ skill_run_interrupted").

Evidence (tui-coder's `reyn support-bundle` events): **4/4** failing 2026-05-28 runs = `python_step_failed{kind:Timeout, "compute_text_stats timed out after 5s"}`; a 2026-06-20 run **completed** → intermittent, not deterministic; not a hang/livelock (graph `review:[]` is terminal).

## Fix + intent check (lead's gate)
Verified the skill's intent: it demos the python step's **speed** ("microseconds"), **not** the timeout feature → `timeout:5` was **under-budgeted**, not an intentional timeout demo. So per lead's branch: **relax** to `15s` (budgets the harness cold-start) + a comment explaining why. Harness cold-start itself (intentional isolation cost; affects all python steps) is a separate latent perf item — **untouched**.

## Test plan
- [x] skill.md parses with `timeout:15` + comment
- [x] word_stats_demo-referencing tests (version-hash / input-hint-stdlib / multi-agent-p7 / hot-list): 23 passed
- [x] stdlib / compiler / parser sweep: 113 passed
- [x] no hash/version pin broken; no config-value test added (would be a brittle pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)