### PR TITLE
fix(tui): screenshot saves to .reyn/ artifact dir, not the cwd

### DIFF
--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -72,6 +72,25 @@ _COST_SUFFIX_DEFER_MAX_ATTEMPTS = 30
 _ESC_ESC_WINDOW_S = 0.6
 
 
+def _resolve_screenshot_dir(project_root: "Path | None") -> "Path":
+    """Directory for ``Ctrl+\\`` screenshots — the gitignored ``.reyn/`` artifact
+    dir, NEVER the cwd.
+
+    A screenshot saved into the current working directory drops an untracked
+    ``reyn_*.svg`` into whatever repo the operator launched ``reyn chat`` from
+    (git-status clutter / accidental ``git add .``). Route it into
+    ``<project_root>/.reyn/screenshots/`` when the project root is known (``.reyn/``
+    is already gitignored), else ``~/.reyn/screenshots/`` — both keep the user's
+    working tree clean.
+    """
+    reyn_dir = (
+        Path(project_root) / ".reyn"
+        if project_root is not None
+        else Path.home() / ".reyn"
+    )
+    return reyn_dir / "screenshots"
+
+
 class ReynTUIApp(App):
     """Main Textual application for `reyn chat`."""
 
@@ -1194,12 +1213,24 @@ class ReynTUIApp(App):
         conv.clear()
 
     def action_screenshot(self) -> None:
-        """Ctrl+\\ — save an SVG screenshot, open it, and log the path."""
-        filename = self.save_screenshot()
+        """Ctrl+\\ — save an SVG screenshot, open it, and log the path.
+
+        Saved into the gitignored ``.reyn/screenshots/`` artifact dir (never the
+        cwd) so the screenshot can't pollute the operator's working tree — see
+        ``_resolve_screenshot_dir``.
+        """
+        screenshots_dir = _resolve_screenshot_dir(self._project_root_path())
+        try:
+            screenshots_dir.mkdir(parents=True, exist_ok=True)
+            filename = self.save_screenshot(path=str(screenshots_dir))
+        except Exception:
+            # Last-resort fallback that still avoids the cwd: ~/.reyn/screenshots.
+            home_dir = Path.home() / ".reyn" / "screenshots"
+            home_dir.mkdir(parents=True, exist_ok=True)
+            filename = self.save_screenshot(path=str(home_dir))
         try:
             import subprocess
             import sys
-            from pathlib import Path
 
             from rich.text import Text
             abs_path = Path(filename).resolve()

--- a/tests/cli/test_screenshot_artifact_dir.py
+++ b/tests/cli/test_screenshot_artifact_dir.py
@@ -1,0 +1,92 @@
+"""Tier 2: Ctrl+\\ screenshots land in .reyn/, never the cwd.
+
+Real-terminal dogfood finding (2026-06-20): the screenshot action saved
+``reyn_<ts>.svg`` into the current working directory — i.e. into whatever repo
+the operator launched ``reyn chat`` from — and it was not gitignored, so it
+showed as an untracked file (git-status clutter / accidental ``git add .``). A
+tool must not pollute the user's working tree.
+
+The screenshot now routes into the gitignored ``.reyn/screenshots/`` artifact
+dir (project root when known, else ``~/.reyn/screenshots/``).
+
+Falsification: if the action reverts to ``save_screenshot()`` with no path, a
+new ``.svg`` appears in the cwd and ``test_action_screenshot_does_not_touch_cwd``
+fails.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+# ── pure helper: the directory contract ─────────────────────────────────────
+
+def test_resolve_screenshot_dir_under_project_reyn() -> None:
+    """Tier 2: a known project root → <root>/.reyn/screenshots."""
+    from reyn.interfaces.tui.app import _resolve_screenshot_dir
+
+    d = _resolve_screenshot_dir(Path("/tmp/some-project"))
+    assert d == Path("/tmp/some-project/.reyn/screenshots")
+    assert ".reyn" in d.parts and "screenshots" in d.parts
+
+
+def test_resolve_screenshot_dir_falls_back_to_home_reyn() -> None:
+    """Tier 2: no project root → ~/.reyn/screenshots (never the cwd)."""
+    from reyn.interfaces.tui.app import _resolve_screenshot_dir
+
+    d = _resolve_screenshot_dir(None)
+    assert d == Path.home() / ".reyn" / "screenshots"
+    assert ".reyn" in d.parts
+
+
+def test_resolve_screenshot_dir_is_never_bare_cwd() -> None:
+    """Tier 2: the resolved dir is always under a ``.reyn`` segment.
+
+    Falsification: a cwd-relative save (the bug) would have no ``.reyn`` segment.
+    """
+    from reyn.interfaces.tui.app import _resolve_screenshot_dir
+
+    for root in (Path("/tmp/p"), None):
+        d = _resolve_screenshot_dir(root)
+        assert ".reyn" in d.parts, f"screenshot dir must be under .reyn, got {d}"
+
+
+# ── e2e: the action does not pollute the cwd ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_action_screenshot_does_not_touch_cwd(tmp_path, monkeypatch) -> None:
+    """Tier 2: action_screenshot writes into <project>/.reyn/screenshots, not cwd.
+
+    Falsification: pre-fix this dropped a ``reyn_*.svg`` into the cwd — the
+    cwd-svg snapshot below would grow.
+    """
+    # The open() subprocess is an OS side-effect (Preview / xdg-open); stub it so
+    # the test doesn't spawn a viewer. Not a collaborator — just an OS effect.
+    import subprocess
+
+    from reyn.interfaces.tui.app import ReynTUIApp
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
+
+    cwd_svgs_before = set(Path.cwd().glob("*.svg"))
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        # Pin the project root to tmp so the screenshot lands under tmp/.reyn.
+        monkeypatch.setattr(app, "_project_root_path", lambda: tmp_path)
+        app.action_screenshot()
+        await pilot.pause()
+
+    shots = list((tmp_path / ".reyn" / "screenshots").glob("*.svg"))
+    assert shots, "expected an SVG under <project>/.reyn/screenshots"
+
+    cwd_svgs_after = set(Path.cwd().glob("*.svg"))
+    assert cwd_svgs_after == cwd_svgs_before, (
+        f"screenshot polluted the cwd: {cwd_svgs_after - cwd_svgs_before}"
+    )


### PR DESCRIPTION
**[tui-coder]** — real-terminal dogfood finding (2026-06-20), lead-confirmed as a real bug.

## Bug

`Ctrl+\` saved `reyn_<ts>.svg` into the **current working directory** — i.e. into whatever repo the operator launched `reyn chat` from — and `reyn_*.svg` is **not gitignored**, so it appeared as an untracked file (`?? reyn_*.svg` in `git status`): working-tree clutter + accidental `git add .` risk. A tool must not pollute the user's working tree.

## Fix

Route the screenshot into the gitignored `.reyn/screenshots/` artifact dir via a new pure helper `_resolve_screenshot_dir(project_root)`:
- project root known → `<project_root>/.reyn/screenshots/`
- else → `~/.reyn/screenshots/`
- **never the cwd**

`action_screenshot` mkdir's the dir and passes `path=` to Textual's `save_screenshot`; a last-resort fallback uses `~/.reyn/screenshots/` (still not the cwd). The user's `.gitignore` is **not** modified (invasive) — `.reyn/` is already gitignored.

## Tests

4 Tier-2 (`tests/cli/test_screenshot_artifact_dir.py`): helper resolves under `.reyn` for project-root / home / never-bare-cwd, plus a Pilot e2e that `action_screenshot` writes under `<project>/.reyn/screenshots` and **leaves the cwd's `.svg` set unchanged** (falsifying: pre-fix the cwd set grew).

## Test plan

- [x] `pytest tests/cli/test_screenshot_artifact_dir.py tests/cli/test_tui_smoke.py` — 44/44 green
- [x] `python scripts/test_tier_audit.py tests/cli/test_screenshot_artifact_dir.py` — 4 OK / 0 violations
- [x] `ruff check` — clean
- [x] Manual e2e (dogfood): pre-fix Ctrl+\ → `?? reyn_*.svg` in cwd; post-fix → saved under `.reyn/screenshots/`, cwd clean

## Tier self-check

- Tier 2: public `_resolve_screenshot_dir` + Pilot harness; `subprocess.Popen` (OS `open`) stubbed as an OS side-effect, no collaborator mocks.
- No Tier 4: no `len()`-pinning, no private-state asserts (audit: 4 OK / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
