### PR TITLE
fix(security): _redact_secrets leaked secrets in tuples/sets/dict-keys

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -170,8 +170,19 @@ def _redact_secrets(payload: dict) -> dict:
         if isinstance(obj, str):
             return _mask(obj)
         if isinstance(obj, dict):
-            return {k: _walk(v) for k, v in obj.items()}
-        if isinstance(obj, list):
+            # Mask string KEYS too — a secret used as a dict key leaks just as
+            # much as one in a value. The result is a redacted copy destined for
+            # json.dumps, so changing keys is safe (no caller re-reads it by key).
+            return {
+                (_mask(k) if isinstance(k, str) else k): _walk(v)
+                for k, v in obj.items()
+            }
+        # tuple / set are walked too (not just list) — a secret inside one would
+        # otherwise pass through untouched. The redacted copy is json-serialized
+        # by every caller, where tuples/sets already become arrays, so emitting a
+        # list here changes nothing downstream (and a set, which json can't even
+        # serialize, now survives as a redacted list).
+        if isinstance(obj, (list, tuple, set)):
             return [_walk(v) for v in obj]
         return obj
 

--- a/tests/test_redact_secrets_containers.py
+++ b/tests/test_redact_secrets_containers.py
@@ -1,0 +1,73 @@
+"""Tier 2: llm._redact_secrets walks ALL containers, not just dict/list.
+
+Found via bug-mining (2026-06-20). The trace/bundle redaction walker
+(`reyn.llm.llm._redact_secrets`) recursed into ``dict`` values and ``list``
+items, but a secret inside a ``tuple`` or ``set``, or used as a ``dict`` KEY,
+passed through untouched — a redaction MISS in a security primitive. Because the
+redacted copy is ``json.dumps``-ed by every caller (where a tuple already
+becomes an array), a secret hidden in a tuple would be written to the trace /
+support-bundle in the clear.
+
+Falsification: pre-fix each of the container cases below leaked ``_SECRET``
+(verified). The fix recurses into tuple/set and masks string dict keys.
+
+No mocks — the real `_redact_secrets` with the real default patterns.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.llm.llm import _redact_secrets
+
+# openai-key-shaped token (matches the sk-[A-Za-z0-9_-]{20,} default pattern)
+_SECRET = "sk-" + "A1b2C3d4E5f6G7h8I9j0KLMNOP"
+
+
+@pytest.fixture(autouse=True)
+def _redaction_on(monkeypatch):
+    # The walker is a no-op when REYN_LLM_TRACE_REDACT=off — ensure it's ON.
+    monkeypatch.delenv("REYN_LLM_TRACE_REDACT", raising=False)
+
+
+def _leaks(payload: object) -> bool:
+    return _SECRET in repr(_redact_secrets(payload))
+
+
+def test_secret_in_dict_value_redacted_baseline() -> None:
+    """Tier 2: the already-supported dict/list path still redacts (baseline)."""
+    assert not _leaks({"k": _SECRET})
+    assert not _leaks({"k": [_SECRET]})
+
+
+def test_secret_in_tuple_is_redacted() -> None:
+    """Tier 2: a secret inside a tuple is redacted (was leaked pre-fix).
+
+    Falsification: the unfixed walker returned the tuple untouched, so the
+    secret survived into the json-serialized trace.
+    """
+    assert not _leaks({"k": (_SECRET,)})
+    assert not _leaks({"k": [(_SECRET,)]})  # nested tuple-in-list
+
+
+def test_secret_in_set_is_redacted_and_serializable() -> None:
+    """Tier 2: a secret inside a set is redacted AND the result json-serializes.
+
+    A set isn't json-serializable at all; the fix emits a redacted list so the
+    trace both succeeds and carries no secret.
+    """
+    redacted = _redact_secrets({"k": {_SECRET}})
+    assert _SECRET not in repr(redacted)
+    json.dumps(redacted)  # must not raise (set → list)
+
+
+def test_secret_as_dict_key_is_redacted() -> None:
+    """Tier 2: a secret used as a dict KEY is redacted (was leaked pre-fix)."""
+    assert not _leaks({_SECRET: "value"})
+
+
+def test_legit_content_not_over_redacted() -> None:
+    """Tier 2: ordinary container content is untouched (no false-positive)."""
+    out = _redact_secrets({"msg": "hello", "items": ("a", "b"), "n": 3})
+    assert out == {"msg": "hello", "items": ["a", "b"], "n": 3}


### PR DESCRIPTION
**[tui-coder]** — bug-mining finding (2026-06-20). Redaction completeness gap in a security primitive.

## Bug

`reyn.llm.llm._redact_secrets` (the trace / support-bundle redaction walker) recursed into dict **values** and list items only. A secret inside a **`tuple`** or **`set`**, or used as a **`dict` KEY**, passed through **untouched**.

Because the redacted copy is `json.dumps`-ed by every caller (LLM trace dump at `llm.py:202/303`, support-bundle), where a tuple already serializes to an array, a secret hidden in a tuple would be written to the trace / bundle **in the clear**.

Verified leak (pre-fix) — each survived `_redact_secrets`:

```
str-in-TUPLE         -> *** LEAKED ***
str-in-SET           -> *** LEAKED ***
secret-as-dict-KEY   -> *** LEAKED ***
nested-tuple-in-list -> *** LEAKED ***
```

**Severity**: current exploitability is low (LLM trace payloads are mostly JSON-shaped dicts/lists), but it's a completeness hole in a primitive whose whole contract is *"mask secrets in a payload"* — defense-in-depth.

## Fix

`_walk` now recurses into **tuple/set** (emitting a redacted list — callers json-serialize the result, where tuples/sets already become arrays; a set, otherwise unserializable, now survives as a redacted list) and masks **string dict KEYS**. The redacted copy is display/storage-only, so changing keys and tuple/set→list is safe (no caller re-reads it by key or type).

## Tests

5 Tier-2 (`tests/test_redact_secrets_containers.py`): dict/list baseline / tuple / set (+ json-serializable) / dict-key / no-over-redaction. **Falsifying** — each container case leaked pre-fix.

## Test plan

- [x] `pytest tests/test_redact_secrets_containers.py tests/test_llm_trace_dump_hardening.py tests/test_support_bundle_1833.py` — 25/25 green
- [x] `python scripts/test_tier_audit.py tests/test_redact_secrets_containers.py` — 0 errors
- [x] `ruff check` — clean
- [x] Manual: `_redact_secrets({"k": ("sk-...",)})` → redacted (was leaked)

## Tier self-check

- Tier 2: public `_redact_secrets`, real default patterns (no mocks).
- No Tier 4: no `len()`-pinning, no private-state asserts; test_tier_audit 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
