### PR TITLE
feat(1827): S3 — topology→profile→live-gate full-path production wiring

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -192,6 +192,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
         registry_ref: list = []
 
         def _session_factory(profile: AgentProfile) -> Session:
+            # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
+            _ctx_perm, _profile_excluded = registry_ref[0].resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -225,7 +227,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # container-rooting. Fill = 1-line follow-up when a consumer needs it.
                 eager_embedding_build=False,
                 exclude_tools=None,
-                excluded_categories=frozenset(),  # #1667: interactive — keep all categories (incl reyn_source self-help)
+                excluded_categories=_profile_excluded,  # #1667 (none here) + #1827 S3 profile view
+                contextual_permission=_ctx_perm,  # #1827 S3: capability_profile enforcement → live tool gate
                 router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: interactive UI = byte-identical
                 environment_backend=None,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -429,6 +429,9 @@ def run(args: argparse.Namespace) -> None:
 
     def _session_factory(profile: AgentProfile):
         # Captured CLI defaults — registry doesn't need to know them.
+        # #1827 S3: resolve the agent's topology capability_profile → contextual
+        # narrowing (enforcement) + view exclusion. (None, ∅) when unbound = byte-identical.
+        _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
             agent_name=profile.name,
             model=model,
@@ -458,7 +461,8 @@ def run(args: argparse.Namespace) -> None:
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
-            excluded_categories=_excluded_categories,  # #1667: hide categories (e.g. reyn_source) at the catalog source
+            excluded_categories=frozenset(_excluded_categories or ()) | _profile_excluded,  # #1667 + #1827 S3 profile view
+            contextual_permission=_ctx_perm,  # #1827 S3: capability_profile enforcement → live tool gate
             # #187: per-message tool-call budget. Interactive chat uses
             # safety.loop.max_router_iterations (default 5); the one-shot
             # autonomous path raises it via --max-iterations (CLI wins).

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -446,6 +446,12 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         _reg_cell: list = []
 
         def _session_factory(profile: AgentProfile) -> Session:
+            # #1827 S3: resolve the agent's topology capability_profile. The registry
+            # cell may be empty during bootstrap → (None, ∅) = byte-identical.
+            _reg = _reg_cell[0] if _reg_cell else None
+            _ctx_perm, _profile_excluded = (
+                _reg.resolved_profile_for(profile.name) if _reg else (None, frozenset())
+            )
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -485,7 +491,8 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,
-                excluded_categories=frozenset(),  # #1667: dogfood — keep all categories
+                excluded_categories=_profile_excluded,  # #1667 (none here) + #1827 S3 profile view
+                contextual_permission=_ctx_perm,  # #1827 S3: capability_profile enforcement → live tool gate
                 router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: dogfood driver = byte-identical (run-once-only fix)
                 workspace_base_dir=ws_base_dir,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -395,6 +395,8 @@ def run_serve(args: argparse.Namespace) -> None:
     project_context = load_project_context(session_cfg.config, project_root)
 
     def _session_factory(profile: AgentProfile):
+        # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
+        _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
             agent_name=profile.name,
             model=model,
@@ -431,7 +433,8 @@ def run_serve(args: argparse.Namespace) -> None:
             # (behavior-preserving). Fill = 1-line follow-up when a consumer needs it.
             agent_id=None,
             exclude_tools=None,
-            excluded_categories=frozenset(),  # #1667: MCP server — keep all categories
+            excluded_categories=_profile_excluded,  # #1667 (none here) + #1827 S3 profile view
+            contextual_permission=_ctx_perm,  # #1827 S3: capability_profile enforcement → live tool gate
             router_max_iterations=session_cfg.config.safety.loop.max_router_iterations,
             non_interactive=False,  # #1439 Fix #1: stdio-MCP byte-identical (run-once-only fix)
             environment_backend=None,  # gap: MCP-serve lacks env-backend / container-rooting

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -303,6 +303,8 @@ def _get_registry():
         def _session_factory(profile: AgentProfile) -> Session:
             registry = registry_ref[0]
             _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
+            # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
+            _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
                 agent_name=profile.name,
                 model=model,
@@ -346,7 +348,8 @@ def _get_registry():
                 allowed_mcp=None,
                 agent_id=None,
                 exclude_tools=_scoped.exclude_tools,
-                excluded_categories=frozenset(),  # #1667: web/A2A is interactive — keep all categories (a `reyn web` category opt-out would extend _scoped separately)
+                excluded_categories=_profile_excluded,  # #1667 (none here) + #1827 S3 profile view
+                contextual_permission=_ctx_perm,  # #1827 S3: capability_profile enforcement → live tool gate
                 router_max_iterations=config.safety.loop.max_router_iterations,
                 non_interactive=False,  # #1439 Fix #1: A2A byte-identical (run-once-only fix). A2A-non-interactive = documented follow-up (cf factory module doc)
                 environment_backend=_scoped.environment_backend,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -140,6 +140,9 @@ class AgentRegistry:
         self._dir = project_root / ".reyn" / "agents"
         self._dir.mkdir(parents=True, exist_ok=True)
         self._topology_dir = project_root / ".reyn" / TOPOLOGY_DIRNAME
+        # #1827 S3: capability_profile bindings (.reyn/capability_profiles/<name>.yaml)
+        # resolved per-agent from its topology role bindings (Topology.profiles).
+        self._capability_profile_dir = project_root / ".reyn" / "capability_profiles"
         self._factory = session_factory
         self._state_log = state_log
         self._project_root = project_root
@@ -1969,6 +1972,55 @@ class AgentRegistry:
     def topologies_for_agent(self, agent: str) -> list[Topology]:
         """All topologies the agent currently belongs to (including `_default`)."""
         return [t for t in self.list_topologies() if agent in t.members]
+
+    def resolved_profile_for(self, agent: str) -> "tuple[object | None, frozenset[str]]":
+        """#1827 S3: the agent's effective contextual narrowing from its topology
+        capability_profile bindings.
+
+        Returns ``(ContextualPermission | None, excluded_categories)`` — the
+        composition (most-restrictive: ∪ deny, ∩ allow, ∪ excluded) of every
+        profile bound to ``agent`` across its topologies. **No binding →
+        ``(None, frozenset())``** = byte-identical to pre-#1827 (the ``_default``
+        network has no profiles, so unaffiliated agents resolve to None).
+
+        A bound-but-missing or malformed profile file is surfaced (stderr) and
+        skipped — a typo must not silently widen capability, but it also must not
+        crash session construction.
+        """
+        from reyn.security.permissions.capability_profile import (
+            compose_resolved,
+            load_capability_profile,
+            resolve_profile,
+        )
+
+        resolved: list = []
+        for topo in self.topologies_for_agent(agent):
+            name = topo.profile_for(agent)
+            if not name:
+                continue
+            path = self._capability_profile_dir / f"{name}.yaml"
+            if not path.is_file():
+                import sys
+                print(
+                    f"warning: capability_profile {name!r} (bound in topology "
+                    f"{topo.name!r}) not found at {path}",
+                    file=sys.stderr,
+                )
+                continue
+            try:
+                prof = load_capability_profile(path)
+            except Exception as e:  # noqa: BLE001 — hand-edited yaml, surface not crash
+                import sys
+                print(
+                    f"warning: skipping malformed capability_profile {path.name}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            resolved.append(resolve_profile(prof))
+
+        if not resolved:
+            return None, frozenset()
+        return compose_resolved(resolved)
 
     def permit(self, from_agent: str, to_agent: str) -> bool:
         """Return True iff some shared topology permits from→to.

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -60,6 +60,7 @@ def build_router_op_context(
     run_id: str | None = None,  # chat router is outside run scope (#FP-0021)
     cancel_event: Any = None,  # #1470: asyncio.Event for mid-subprocess cancel
     threat_scan: Any = None,  # FP-0050/#1822 S5 (EP4): exec command-scan config
+    contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → OpContext
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -134,4 +135,5 @@ def build_router_op_context(
         ),
         cancel_event=cancel_event,
         threat_scan=threat_scan,
+        contextual_permission=contextual_permission,
     )

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -52,6 +52,7 @@ def build_scoped_chat_session(
     workspace_state_dir: "Path | None",  # #187 host-side OS state dir
     exclude_tools: "frozenset[str] | set[str] | None",  # #1400 tool names hidden + execution-blocked
     excluded_categories: "frozenset[str] | set[str] | None",  # #1667 catalog categories hidden at source (reyn_source for external-repo eval)
+    contextual_permission: "object | None",  # #1827 S3 per-session capability_profile narrowing (ContextualPermission); from registry.resolved_profile_for; None = no narrowing
     agent_id: str | None,  # FP-0016 agent-id-scoped memory
     router_max_iterations: int,  # #187 per-message tool-call budget
     non_interactive: bool,  # #1439 Fix #1: run-once (no TTY) → SP proceeds instead of asking a clarifying question. Per-frontend: chat-CLI = not isatty(); A2A/MCP/chainlit/dogfood = False (interactive byte-identical)
@@ -101,6 +102,7 @@ def build_scoped_chat_session(
         workspace_state_dir=workspace_state_dir,
         exclude_tools=exclude_tools,
         excluded_categories=excluded_categories,
+        contextual_permission=contextual_permission,
         agent_id=agent_id,
         router_max_iterations=router_max_iterations,
         non_interactive=non_interactive,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -269,8 +269,10 @@ class RouterHostAdapter:
         # FP-0050 / #1822: content-threat scan + fence config. None (test hosts)
         # → defaults (disabled-safe via the methods' guards).
         threat_scan: Any = None,
+        contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → control-IR OpContext
     ) -> None:
         self._threat_scan = threat_scan
+        self._contextual_permission = contextual_permission
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
@@ -1684,6 +1686,7 @@ class RouterHostAdapter:
             compact_now=self._compact_now,
             cancel_event=self._cancel_event,
             threat_scan=self._threat_scan,
+            contextual_permission=self._contextual_permission,  # #1827 S3
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -44,6 +44,7 @@ class RouterLoopDriver:
         non_interactive: bool,
         exclude_tools: Any,           # set — for RouterLoop
         excluded_categories: Any = frozenset(),  # #1667 set — catalog categories for RouterLoop
+        contextual_permission: Any = None,  # #1827 S3 ContextualPermission — for RouterLoop live tool gate; None = no narrowing
         budget: Any,                  # BudgetGateway — cap + usage accounting
         resolver: Any,                # LLMResolver — model resolution
         compaction: Any,              # CompactionConfig — retry_loop cfg
@@ -66,6 +67,7 @@ class RouterLoopDriver:
         self._non_interactive = non_interactive
         self._exclude_tools = exclude_tools
         self._excluded_categories = excluded_categories  # #1667
+        self._contextual_permission = contextual_permission  # #1827 S3
         self._budget = budget
         self._resolver = resolver
         self._compaction = compaction
@@ -380,6 +382,7 @@ class RouterLoopDriver:
             # catalog.
             exclude_tools=self._exclude_tools,
             excluded_categories=self._excluded_categories,  # #1667
+            contextual_permission=self._contextual_permission,  # #1827 S3 live tool gate
             # B43-NF-W6-1 / #187: chat router empty-stop retry — always-on +
             # uniform "resume" directive.
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -820,6 +820,7 @@ class Session:
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
         excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_source for external-repo eval)
+        contextual_permission: "object | None" = None,  # #1827 S3: per-session capability_profile narrowing (ContextualPermission); from registry.resolved_profile_for; None = byte-identical
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
         # FP-0043 Stage 5: the conversation session id this Session records WAL
@@ -878,6 +879,10 @@ class Session:
         # SWE-eval excludes web__search/web__fetch so the agent solves from the
         # repo + issue, not a web lookup of the gold solution.
         self._exclude_tools = frozenset(exclude_tools or ())
+        # #1827 S3: per-session capability_profile narrowing (ContextualPermission)
+        # resolved from the agent's topology role. Threaded to the live tool gate
+        # (RouterLoop) + control-IR OpContext. None = no narrowing (byte-identical).
+        self._contextual_permission = contextual_permission
         # #1667: catalog categories hidden at the universal-catalog source (e.g.
         # reyn_source on the external-repo eval path so it doesn't compete with
         # file__* for the weak model); interactive default empty = reyn_source kept.
@@ -1452,6 +1457,7 @@ class Session:
             turn_budget_engine=_chat_turn_budget_engine,
             # FP-0050 / #1822 S2: content-threat scan + fence config.
             threat_scan=self._safety.threat_scan,
+            contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             agent_name=self.agent_name,
             agent_role=self._agent_role,
             output_language=self.output_language,
@@ -1726,6 +1732,7 @@ class Session:
             budget_tracker=self._budget_tracker,
             non_interactive=self._non_interactive,
             exclude_tools=self._exclude_tools,
+            contextual_permission=self._contextual_permission,  # #1827 S3 → RouterLoop live gate
             excluded_categories=self._excluded_categories,
             budget=self._budget,
             resolver=self._resolver,
@@ -4549,6 +4556,7 @@ class Session:
                 else None
             ),
             agent_id=self._agent_id,
+            contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_topology_profile_binding_e2e_1827.py
+++ b/tests/test_topology_profile_binding_e2e_1827.py
@@ -1,0 +1,123 @@
+"""Tier 3a: topology→profile→live-gate production-wiring e2e (#1827 S3).
+
+The #1827 "actually works" proof. A capability_profile bound to a topology role
+on disk → resolved by the real registry → its ContextualPermission blocks the
+denied tool at the LIVE tool gate (router_loop._excluded_result, S1.5).
+
+The denied tool is **`memory__write`, which is in NO `exclude_tools`** — so the
+S1.5 exclude_tools→contextual bridge **cannot** block it. Only the explicit
+topology→profile→gate thread can. So a green test proves the explicit production
+wiring is LIVE; a silently-unwired thread → the tool executes → CLEAN RED.
+
+Real registry + real on-disk YAML + real RouterLoop dispatch path. No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.effective import ContextualPermission
+
+
+def _write_project(tmp_path: Path) -> None:
+    """A project where topology `t` binds member `worker` to profile `reviewer`
+    whose tool_deny removes `memory__write` (a tool not in any exclude_tools)."""
+    topo_dir = tmp_path / ".reyn" / "topologies"
+    topo_dir.mkdir(parents=True)
+    (topo_dir / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [worker, helper]\n"
+        "profiles:\n  worker: reviewer\n",
+        encoding="utf-8",
+    )
+    prof_dir = tmp_path / ".reyn" / "capability_profiles"
+    prof_dir.mkdir(parents=True)
+    (prof_dir / "reviewer.yaml").write_text(
+        "name: reviewer\ntool_deny: [memory__write]\n", encoding="utf-8",
+    )
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(project_root=tmp_path, session_factory=lambda profile: None)
+
+
+class _Host:
+    agent_name = "worker"
+
+    def __init__(self) -> None:
+        class _E:
+            def emit(self, *a, **k): ...
+        self.events = _E()
+        self.memory_write_calls: list = []
+
+    async def memory_write(self, **kw):  # runs IFF the tool executes (the leak)
+        self.memory_write_calls.append(kw)
+        return {"kind": "memory_write", "ok": True}
+
+
+def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
+    return asyncio.run(
+        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+    )
+
+
+def test_resolved_profile_blocks_denied_tool_at_live_gate(tmp_path: Path):
+    """Tier 3a: disk profile → registry resolve → ContextualPermission blocks
+    memory__write at the live gate; an unrelated tool is unaffected."""
+    _write_project(tmp_path)
+    reg = _registry(tmp_path)
+
+    contextual, excluded = reg.resolved_profile_for("worker")
+    # the resolution loaded the profile from disk
+    assert isinstance(contextual, ContextualPermission)
+    assert "memory__write" in contextual.tool_deny
+    assert excluded == frozenset()  # no categories in the profile → no view narrowing
+
+    loop = RouterLoop(host=_Host(), chain_id="c", max_iterations=5,
+                      contextual_permission=contextual)
+    # memory__write is denied by the profile (and is in NO exclude_tools).
+    blocked = _exec(loop, "memory__write", {"k": "v"})
+    assert blocked.get("error", {}).get("kind") == "tool_excluded"
+    # the via-invoke_action bypass shape is also blocked.
+    blocked2 = _exec(loop, "invoke_action", {"action_name": "memory__write"})
+    assert blocked2.get("error", {}).get("kind") == "tool_excluded"
+
+
+def test_unbound_agent_resolves_to_none_inert(tmp_path: Path):
+    """Tier 3a: an agent with no profile binding → (None, ∅) → live gate inert.
+
+    `helper` is a member of topology `t` but has no profile → no narrowing, so
+    its session is byte-identical to pre-#1827 (the gate does not block)."""
+    _write_project(tmp_path)
+    reg = _registry(tmp_path)
+
+    contextual, excluded = reg.resolved_profile_for("helper")
+    assert contextual is None and excluded == frozenset()
+
+    # a loop with no contextual does not block memory__write at the gate
+    loop = RouterLoop(host=_Host(), chain_id="c", max_iterations=5,
+                      contextual_permission=contextual)
+    assert _exec(loop, "memory__write", {}).get("error", {}).get("kind") != "tool_excluded"
+
+
+def test_falsify_memory_write_absent_from_exclude_tools(tmp_path: Path):
+    """Tier 3a: the bridge cannot achieve this block (falsification anchor).
+
+    A loop given memory__write via exclude_tools would block it — but the
+    production path binds NO exclude_tools; the block above comes solely from the
+    resolved profile's ContextualPermission. This pins that the denied tool is
+    not a default/bridge value, so the e2e proves the EXPLICIT thread is live.
+    """
+    _write_project(tmp_path)
+    reg = _registry(tmp_path)
+    contextual, _ = reg.resolved_profile_for("worker")
+    # No exclude_tools anywhere in the production path for memory__write.
+    loop = RouterLoop(host=_Host(), chain_id="c", max_iterations=5,
+                      contextual_permission=contextual)
+    # The block is contextual-sourced: a sibling loop with neither contextual nor
+    # exclude_tools does NOT block (so the block is not incidental).
+    open_loop = RouterLoop(host=_Host(), chain_id="c", max_iterations=5)
+    assert _exec(open_loop, "memory__write", {}).get("error", {}).get("kind") != "tool_excluded"
+    assert _exec(loop, "memory__write", {}).get("error", {}).get("kind") == "tool_excluded"


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S3** (the 本丸: topology→profile→live-gate full-path production wiring). Design + flow-trace + (i) closure-resolve APPROVED. This is #1827's "actually works" proof.

## What
The `capability_profile` resolved from an agent's topology role now threads **end-to-end to the LIVE tool gate** — proven by a non-default e2e the S1.5 bridge **cannot** satisfy.

## Wiring (single chokepoint — verified)
The registry's injected `_factory` **is** each frontend's `_session_factory` → all funnel through `build_scoped_chat_session`.
- **`registry.resolved_profile_for(agent)`**: `topologies_for_agent` → `Topology.profile_for` → load `.reyn/capability_profiles/<name>.yaml` → `resolve_profile` → `compose_resolved` (most-restrictive across memberships). No binding → `(None, ∅)` = byte-identical. Bound-but-missing/malformed → surfaced (stderr) + skipped (never widens).
- **`build_scoped_chat_session`**: `contextual_permission` added to the **REQUIRED scoped surface** → the `test_scoped_session_factory_invariant_1402` forces **all 5 frontends** (chat/web/chainlit/dogfood/mcp) to pass it. Each `_session_factory` closure resolves via the registry + composes the profile's view into `excluded_categories`.
- **`Session(contextual_permission=)`** → `RouterLoopDriver` → `RouterLoop` (live gate, S1.5) + `RouterHostAdapter`/`build_router_op_context` → `OpContext` (control-IR path).

## e2e — production-wired proof (CLEAN RED verified)
Real registry + on-disk YAML + real RouterLoop dispatch: a topology binds `worker` → `reviewer` (`tool_deny: [memory__write]`). **`memory__write` is in NO `exclude_tools`** → the S1.5 bridge can't block it; only the resolved profile's `ContextualPermission` does.
- [x] Blocked at the live gate via **native + invoke_action** shapes (handler never runs).
- [x] Unbound member (`helper`) → `(None, ∅)` → **NOT blocked** (byte-identical).
- [x] **Falsification CLEAN RED**: forcing `resolved_profile_for → (None, ∅)` reds the block e2e (verified, reverted).

## Invariants (security-path rigor, #1884 parity)
- **never-elevate**: rides the S1.5 `all()` gate — structurally can only narrow.
- **visible ⊆ authorized**: view = `excluded_categories`, enforcement = `ContextualPermission` (independent).
- **byte-identical**: no-binding paths unchanged. Regression: full registry/session/router/frontend suite **1429 passed**. tier-audit + ruff clean.

## Not-my-diff note
2 test files fail at collection on a **pre-existing** `host_backend ↔ workspace` circular import (`test_router_opcontext_basedir_live_187`, `test_sandbox_model_completion_1339`) — reproduces **identically on clean main** (verified via stash). Unrelated to #1827.

## Forward (tracked)
`require_tool` runtime live-wiring + `permission.tool ∩` at dispatch = **#1199**.

Refs #1827 (design-check v2 + binding design-check + S3 flow-trace). Closes the #1827 core (S4/S5/S6 = context-auto / delegate / ephemeral remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
