### PR TITLE
ci: add strict docs-build gate to PR CI (close Pages-only-red hole)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,30 @@ jobs:
       - name: Run ruff
         run: ruff check .
 
+  docs:
+    name: docs build (strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: pip install -e ".[docs]"
+
+      # Mirrors the "Build documentation" step in pages.yml so broken links
+      # and missing nav targets fail at PR time, not post-merge on the Pages
+      # deploy — which was previously the only place --strict ran (a broken
+      # link could pass PR review and then turn the main Pages job red).
+      - name: Build docs (strict)
+        run: mkdocs build --strict -f .mkdocs/mkdocs.yml
+
   audit:
     name: test-tier audit
     runs-on: ubuntu-latest


### PR DESCRIPTION
**[docs-maintainer]** — structural fix for the main-CI-red root cause (lead-coder endorsed). Resolves the recurring [`project_mkdocs_strict_ci_gate_candidate`] gap.

## Problem

`mkdocs build --strict` only ran in the **Pages deploy workflow** (`pages.yml`, post-merge on push to main). The CI workflow (`test.yml`, PR gate) ran pytest / ruff / audit but **not** the docs build. So a broken link or missing nav target:
1. passed PR review (CI green),
2. merged to main,
3. then turned the **post-merge Pages "Build LP + docs" job red**.

This is exactly what just happened with the `cost-management.md` broken link (fixed in #1902). Manual local `--strict` checks are not a reliable gate — they depend on the author running and correctly reading the build (the failure I just hit).

## Fix

Add a `docs` job to `test.yml` that runs on every PR (and main push), mirroring the Pages "Build documentation" step exactly:

```yaml
  docs:
    name: docs build (strict)
    steps:
      - Set up Python 3.11
      - pip install -e ".[docs]"
      - mkdocs build --strict -f .mkdocs/mkdocs.yml
```

Now broken links / nav drops fail at **PR time**, not post-merge.

## Sequencing

This branch is stacked on #1902 (the `cost-management.md` fix) so the new `docs` job sees the corrected link and goes **green** — demonstrating the gate works. After #1902 merges, I'll rebase onto main (the fix commit drops out, leaving only the workflow change).

## Test plan

- [x] `test.yml` YAML valid; jobs = `[test, lint, docs, audit]`
- [x] `docs` job replicates the verified-working Pages strict-build setup (Python 3.11 / `[docs]` extra / same command)
- [ ] CI `docs` job green on this PR (self-validating — the gate runs on its own PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)