### PR TITLE
fix(pricing): TokenUsage.from_dict crashed on null/non-numeric WAL value

### DIFF
--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -62,14 +62,24 @@ class TokenUsage:
     def from_dict(cls, data: dict) -> "TokenUsage":
         """Reconstruct from a dict produced by ``to_dict``.
 
-        Resilient to missing fields (defaults to 0) — useful for
-        backward-compat reading of older WAL records.
+        Resilient to missing fields AND to a malformed value (defaults to 0) —
+        useful for backward-compat reading of older / hand-edited / corrupted
+        WAL records. ``.get(key, 0)`` only defaults a *missing* key, so a key
+        present with ``null`` or a non-numeric value would otherwise crash
+        (``int(None)`` → TypeError, ``int("abc")`` → ValueError); ``_coerce_int``
+        closes that gap to honour the stated resilience contract.
         """
+        def _coerce_int(v: object) -> int:
+            try:
+                return int(v)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return 0
+
         return cls(
-            prompt_tokens=int(data.get("prompt_tokens", 0)),
-            completion_tokens=int(data.get("completion_tokens", 0)),
-            cached_tokens=int(data.get("cached_tokens", 0)),
-            cache_creation_tokens=int(data.get("cache_creation_tokens", 0)),
+            prompt_tokens=_coerce_int(data.get("prompt_tokens", 0)),
+            completion_tokens=_coerce_int(data.get("completion_tokens", 0)),
+            cached_tokens=_coerce_int(data.get("cached_tokens", 0)),
+            cache_creation_tokens=_coerce_int(data.get("cache_creation_tokens", 0)),
         )
 
 

--- a/tests/test_token_usage_from_dict.py
+++ b/tests/test_token_usage_from_dict.py
@@ -1,0 +1,58 @@
+"""Tier 2: TokenUsage.from_dict is resilient to malformed WAL values.
+
+Found via bug-mining (2026-06-20). `from_dict`'s docstring promises resilience
+"for backward-compat reading of older WAL records", but `int(data.get(k, 0))`
+only defaults a *missing* key — a key present with `null` or a non-numeric
+string crashed (`int(None)` → TypeError, `int("abc")` → ValueError). A corrupted
+/ hand-edited / older-format WAL record (read at `llm_call_recorder.py:651`)
+would then crash on replay.
+
+Fix: `_coerce_int` defaults a malformed value to 0, honouring the stated
+resilience contract.
+
+Falsification: pre-fix the null / non-numeric cases raised; the round-trip test
+proves good data is unaffected.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import TokenUsage
+
+
+def test_null_value_defaults_to_zero() -> None:
+    """Tier 2: a key present with null defaults to 0 (was TypeError)."""
+    u = TokenUsage.from_dict({"prompt_tokens": None, "completion_tokens": None})
+    assert u.prompt_tokens == 0
+    assert u.completion_tokens == 0
+    assert u.total_tokens == 0
+
+
+def test_non_numeric_value_defaults_to_zero() -> None:
+    """Tier 2: a non-numeric string defaults to 0 (was ValueError)."""
+    u = TokenUsage.from_dict({"prompt_tokens": "abc"})
+    assert u.prompt_tokens == 0
+
+
+def test_missing_keys_still_default_to_zero() -> None:
+    """Tier 2: the pre-existing missing-key resilience is preserved."""
+    u = TokenUsage.from_dict({})
+    assert u.total_tokens == 0
+
+
+def test_valid_record_round_trips() -> None:
+    """Tier 2: a well-formed record reconstructs unchanged (regression guard).
+
+    Falsification: if the coercion were too aggressive (e.g. always 0), this
+    would lose the real counts.
+    """
+    original = TokenUsage(
+        prompt_tokens=120,
+        completion_tokens=34,
+        cached_tokens=80,
+        cache_creation_tokens=12,
+    )
+    restored = TokenUsage.from_dict(original.to_dict())
+    assert restored.prompt_tokens == 120
+    assert restored.completion_tokens == 34
+    assert restored.cached_tokens == 80
+    assert restored.cache_creation_tokens == 12
+    assert restored.total_tokens == 154


### PR DESCRIPTION
**[tui-coder]** — bug-mining finding (2026-06-20). Contract-vs-behaviour gap in a deserializer.

## Bug

`TokenUsage.from_dict`'s docstring promises resilience *"for backward-compat reading of older WAL records"* — but `int(data.get(k, 0))` only defaults a **missing** key. A key present with `null` or a non-numeric value crashes:

```
{"prompt_tokens": None}  → TypeError: int() argument must be a string...
{"prompt_tokens": "abc"} → ValueError: invalid literal for int()
```

Reachable via `llm_call_recorder.py:651` on a corrupted / hand-edited / older-format WAL record → crash on replay. The function claims resilience it doesn't deliver.

## Fix

A `_coerce_int` helper defaults a malformed value to 0, closing the gap to honour the stated contract. Valid records are unchanged.

## Tests

4 Tier-2 (`tests/test_token_usage_from_dict.py`): null → 0 / non-numeric → 0 / missing-key resilience preserved / valid record round-trips (regression guard).

## Test plan

- [x] `pytest tests/test_token_usage_from_dict.py` — 4/4 green
- [x] `python scripts/test_tier_audit.py tests/test_token_usage_from_dict.py` — 4 OK / 0
- [x] `ruff check` — clean

## Tier self-check

- Tier 2: public `TokenUsage.from_dict` / `to_dict` surface, real round-trip (no mocks).
- No Tier 4: no `len()`-pinning, no private-state asserts; audit 4 OK / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
