### PR TITLE
fix(security): PermissionDecl.from_dict fail-secure on malformed permissions

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -320,7 +320,15 @@ class PermissionDecl:
 
     @classmethod
     def from_dict(cls, d: dict | None) -> "PermissionDecl":
-        if not d:
+        # Fail-secure on a missing OR malformed (non-dict) permissions block. A
+        # skill.md with ``permissions: <string|list>`` (an authoring typo) is not
+        # coerced by the parser (parser.py ``or {}`` keeps a truthy non-dict) and
+        # reaches the compiler via ``expander.py`` unguarded — ``d.get(...)`` on a
+        # str/list would then crash with an unclear AttributeError. Default to an
+        # EMPTY decl (no grants): crash-safe AND the secure default for a
+        # permissions primitive. (The skill validator surfaces the malformed
+        # block separately with a clear message.)
+        if not isinstance(d, dict):
             return cls()
         # #571 collapse arc Phase 5: warn on legacy bool-axis keys so
         # user-side skills get a visible migration prompt. The values

--- a/tests/test_permission_decl_from_dict_malformed.py
+++ b/tests/test_permission_decl_from_dict_malformed.py
@@ -1,0 +1,48 @@
+"""Tier 2: PermissionDecl.from_dict fails secure on a malformed permissions block.
+
+Found via bug-mining (2026-06-20). A skill.md with `permissions: <string|list>`
+(an authoring typo) is not coerced by the parser (`parser.py` uses `or {}`,
+which keeps a truthy non-dict) and reaches the compiler via `expander.py:210`
+unguarded — `d.get(...)` on a str/list then crashed with an unclear
+AttributeError on skill expansion. The skill *validator* guards its own path,
+but the *expander* did not.
+
+Fix: `from_dict` defaults a non-dict to an EMPTY decl (no grants) — crash-safe
+AND the secure default for a permissions primitive (a malformed block must not
+silently grant anything).
+
+Falsification: pre-fix a non-dict raised AttributeError; the valid-decl test
+proves the guard doesn't swallow real grants.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+@pytest.mark.parametrize("bad", ["allow", ["file.write"], 42, ("x",)])
+def test_malformed_permissions_yield_empty_decl(bad) -> None:
+    """Tier 2: a non-dict permissions value → empty decl (no crash, no grants)."""
+    decl = PermissionDecl.from_dict(bad)
+    # fail-secure: nothing is granted from a malformed block
+    assert not decl.file_write
+    assert not decl.mcp
+    assert not decl.tool
+
+
+def test_none_still_yields_empty_decl() -> None:
+    """Tier 2: the pre-existing None/falsy resilience is preserved."""
+    assert PermissionDecl.from_dict(None) is not None
+    assert PermissionDecl.from_dict({}) is not None
+
+
+def test_valid_permissions_still_parse() -> None:
+    """Tier 2: a well-formed permissions block is unaffected (regression guard).
+
+    Falsification: if the guard were too broad, real grants would be dropped.
+    """
+    decl = PermissionDecl.from_dict(
+        {"file.write": [{"path": "out.txt", "scope": "just_path"}]}
+    )
+    assert decl.file_write, "a valid file.write grant must survive"


### PR DESCRIPTION
**[tui-coder]** — bug-mining finding (2026-06-20). Security-primitive deserializer crash, fixed fail-secure.

## Bug

A skill.md with `permissions: <string|list>` (an authoring typo) crashed the compiler with an **unclear AttributeError** on skill expansion:

```
PermissionDecl.from_dict("shell")  → AttributeError: 'str' object has no attribute 'get'
```

Trace:
- `parser.py:132` — `fm.get("permissions") or {}` keeps a *truthy* non-dict (only None/falsy is coerced).
- `ir.py:52` — types the field `dict` but doesn't enforce it.
- `expander.py:210` — `PermissionDecl.from_dict(skill_def.permissions)` **unguarded** → `d.get(...)` on a str/list crashes.

The skill **validator** guards its own path (`validator.py:257` `if not isinstance(raw_perm, dict): raw_perm = {}`) — proving non-dict permissions reach this deserializer in practice — but the **expander** path did not.

## Fix

`from_dict` defaults a non-dict to an **EMPTY decl (no grants)**. Crash-safe **and** the secure default for a permissions primitive — a malformed block must never silently grant anything. (`if not d` → `if not isinstance(d, dict)`, also covering the existing None/falsy case.)

## Tests

6 Tier-2 (`tests/test_permission_decl_from_dict_malformed.py`): 4 malformed types (string/list/int/tuple) → empty decl / None+{} resilience preserved / valid grant still parses (regression).

## Test plan

- [x] `pytest tests/test_permission_decl_from_dict_malformed.py tests/test_permission_collapse_phase2.py` — 20/20 green
- [x] `python scripts/test_tier_audit.py …` — 3 OK / 0
- [x] `ruff check` — clean
- [x] Manual: `from_dict("shell")` → empty decl (was AttributeError)

## Tier self-check

- Tier 2: public `PermissionDecl.from_dict` surface, real grant round-trip (no mocks).
- No Tier 4: no `len()`-pinning, no private-state asserts; audit 3 OK / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
