### PR TITLE
feat(1827): S4a — context-auto untrusted-source abstraction (seam-agnostic)

### DIFF
--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -241,17 +241,20 @@ class InterventionHandler:
         if external_source and self._threat_scan is not None:
             from reyn.security.content_guard import fence_if_enabled
             history_text = fence_if_enabled(text, self._threat_scan)
-        self._append_history(
-            "user",
-            history_text,
-            _now_iso(),
-            {
-                "answered_skill": iv.skill_name or "",
-                "answered_run_id": iv.run_id or "",
-                "intervention_id": iv.id,
-                "intervention_kind": iv.kind,
-            },
-        )
+        meta = {
+            "answered_skill": iv.skill_name or "",
+            "answered_run_id": iv.run_id or "",
+            "intervention_id": iv.id,
+            "intervention_kind": iv.kind,
+        }
+        if external_source:
+            # #1827 S4: seam-agnostic untrusted-source taint marker. While this
+            # external (A2A / webhook peer) answer is live in context, the agent
+            # is capability-narrowed (context-auto) — defense-in-depth with the
+            # fence above. The key is the convention in
+            # reyn.security.permissions.capability_profile.UNTRUSTED_META_KEY.
+            meta["external_source"] = True
+        self._append_history("user", history_text, _now_iso(), meta)
         self._events.emit(
             "user_answered_intervention",
             intervention_id=iv.id,

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -135,3 +135,85 @@ def compose_resolved(
         ContextualPermission(tool_allow=combined_allow, tool_deny=frozenset(deny)),
         frozenset(excluded),
     )
+
+
+# ── #1827 S4: context-auto untrusted-source narrowing ───────────────────────
+#
+# Defense-in-depth with the #1862 content-fence: while untrusted external content
+# is live in the agent's active context, the agent is also CAPABILITY-narrowed —
+# so even a partial prompt-injection has no dangerous tools to reach. This is
+# **seam-agnostic**: any untrusted-content seam stamps ``UNTRUSTED_META_KEY`` on
+# its history/context entry meta (the external peer answer in S4 v1; external
+# tool-results in the #1909 follow-up), and the tainted-derivation is marker-
+# driven, not seam-specific.
+
+# The marker key a seam stamps on a history-entry meta to mark untrusted content.
+UNTRUSTED_META_KEY: "str" = "external_source"
+
+# The well-known auto-applied profile name. An operator
+# ``.reyn/capability_profiles/_untrusted.yaml`` overrides the built-in secure
+# default — an override is a *deliberate loosening*, never a tightening of the
+# floor below what the operator opts into.
+UNTRUSTED_PROFILE_NAME: "str" = "_untrusted"
+
+# The built-in secure default: deny the side-effecting / persistence /
+# re-delegation / execution / install surfaces so untrusted content can be read
+# and reasoned about but cannot drive irreversible actions. Both the qualified
+# catalog names and their unwrapped aliases are denied (the live gate matches the
+# effective resolved name, which differs by scheme / invoke_action unwrap).
+_BUILTIN_UNTRUSTED_DENY: "frozenset[str]" = frozenset({
+    # memory writes / deletes — no persistence from untrusted content
+    "memory_operation__remember_shared",
+    "memory_operation__remember_agent",
+    "memory_operation__forget",
+    # re-delegation — no spawning peers from untrusted content
+    "multi_agent__delegate", "delegate_to_agent",
+    # code execution
+    "exec__sandboxed_exec", "sandboxed_exec",
+    # MCP install — no installing servers from untrusted content
+    "mcp__install_registry", "mcp__install_package", "mcp__install_local",
+})
+
+
+def builtin_untrusted_profile() -> CapabilityProfile:
+    """The built-in secure default auto-applied while untrusted content is live."""
+    return CapabilityProfile(
+        name=UNTRUSTED_PROFILE_NAME,
+        description="auto-applied while untrusted external content is in context (#1827 S4)",
+        tool_deny=tuple(sorted(_BUILTIN_UNTRUSTED_DENY)),
+    )
+
+
+def load_untrusted_profile(project_root: "str | Path") -> CapabilityProfile:
+    """The minimal profile auto-applied while untrusted external content is live.
+
+    An operator ``.reyn/capability_profiles/_untrusted.yaml`` overrides the
+    built-in secure default (a deliberate loosening). A malformed override falls
+    back to the built-in (surfaced on stderr) — a typo must not silently drop the
+    untrusted floor.
+    """
+    path = Path(project_root) / ".reyn" / "capability_profiles" / f"{UNTRUSTED_PROFILE_NAME}.yaml"
+    if path.is_file():
+        try:
+            return load_capability_profile(path)
+        except Exception as e:  # noqa: BLE001 — fall back to the secure default
+            import sys
+            print(
+                f"warning: malformed {path.name}: {e} — using the built-in "
+                "untrusted default",
+                file=sys.stderr,
+            )
+    return builtin_untrusted_profile()
+
+
+def metas_have_untrusted(metas: "object") -> bool:
+    """Seam-agnostic taint check: True iff any entry meta carries the untrusted
+    marker. Derived from the **active** context (the caller passes the live,
+    un-compacted entries), which gives the until-compaction scope for free —
+    a compacted-out untrusted entry is simply not present."""
+    try:
+        return any(
+            isinstance(m, dict) and m.get(UNTRUSTED_META_KEY) for m in metas  # type: ignore[union-attr]
+        )
+    except TypeError:
+        return False

--- a/tests/test_untrusted_profile_1827_s4.py
+++ b/tests/test_untrusted_profile_1827_s4.py
@@ -1,0 +1,155 @@
+"""Tier 2: context-auto untrusted-source abstraction (#1827 S4a).
+
+The seam-agnostic pieces of S4: the untrusted-source taint marker, the built-in
+secure default profile + its `_untrusted.yaml` override, and the marker-driven
+tainted derivation. S4b wires these into the per-turn compose. The external
+peer answer also stamps the marker on its history entry (the v1 seam); the
+#1909 follow-up will stamp the SAME marker on external tool-results.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.security.permissions.capability_profile import (
+    UNTRUSTED_META_KEY,
+    UNTRUSTED_PROFILE_NAME,
+    builtin_untrusted_profile,
+    load_untrusted_profile,
+    metas_have_untrusted,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+# ── the built-in secure default + override ──────────────────────────────────
+
+
+def test_builtin_denies_side_effecting_surfaces():
+    """Tier 2: the built-in untrusted profile denies write/delegate/exec/install."""
+    prof = builtin_untrusted_profile()
+    contextual, _ = resolve_profile(prof)
+    layer = ContextualLayer(contextual)
+    for denied in (
+        "memory_operation__remember_shared", "multi_agent__delegate",
+        "delegate_to_agent", "exec__sandboxed_exec", "mcp__install_registry",
+    ):
+        assert layer.allows(CapabilityAxis.TOOL, denied) is False, denied
+    # a read/query tool is NOT denied by the built-in (read + reason is allowed)
+    assert layer.allows(CapabilityAxis.TOOL, "recall") is True
+
+
+def test_load_untrusted_returns_builtin_when_no_override(tmp_path: Path):
+    """Tier 2: with no _untrusted.yaml the secure built-in default is used."""
+    prof = load_untrusted_profile(tmp_path)
+    assert prof.name == UNTRUSTED_PROFILE_NAME
+    assert "multi_agent__delegate" in prof.tool_deny
+
+
+def test_load_untrusted_honors_override(tmp_path: Path):
+    """Tier 2: an operator _untrusted.yaml overrides the built-in (deliberate loosen)."""
+    d = tmp_path / ".reyn" / "capability_profiles"
+    d.mkdir(parents=True)
+    (d / "_untrusted.yaml").write_text(
+        "name: _untrusted\ntool_deny: [exec__sandboxed_exec]\n", encoding="utf-8",
+    )
+    prof = load_untrusted_profile(tmp_path)
+    assert prof.tool_deny == ("exec__sandboxed_exec",)  # only the operator's choice
+
+
+def test_load_untrusted_malformed_falls_back_to_builtin(tmp_path: Path):
+    """Tier 2: a malformed override falls back to the built-in (floor not dropped)."""
+    d = tmp_path / ".reyn" / "capability_profiles"
+    d.mkdir(parents=True)
+    (d / "_untrusted.yaml").write_text("name: [unclosed\n", encoding="utf-8")
+    prof = load_untrusted_profile(tmp_path)
+    assert "multi_agent__delegate" in prof.tool_deny  # built-in restored
+
+
+# ── the seam-agnostic tainted derivation ────────────────────────────────────
+
+
+def test_metas_have_untrusted_detects_marker():
+    """Tier 2: the marker is detected regardless of which seam stamped it."""
+    assert metas_have_untrusted([{"x": 1}, {UNTRUSTED_META_KEY: True}]) is True
+    assert metas_have_untrusted([{"x": 1}, {"answered_skill": "s"}]) is False
+    assert metas_have_untrusted([]) is False
+    assert metas_have_untrusted(None) is False  # non-iterable is safe
+
+
+# ── the v1 seam stamps the marker (external peer answer) ─────────────────────
+
+
+class _Recorder:
+    def __init__(self):
+        self.history: list[dict] = []
+
+    def append(self, role, text, ts, meta):
+        self.history.append({"role": role, "text": text, "meta": meta})
+
+
+def _build_handler(history):
+    import tempfile
+
+    from reyn.config.chat import ThreatScanConfig
+    from reyn.core.events.event_store import EventStore
+    from reyn.core.events.events import EventLog
+    from reyn.runtime.services.intervention_handler import InterventionHandler
+    from reyn.runtime.services.intervention_registry import InterventionRegistry
+    from reyn.runtime.services.snapshot_journal import SnapshotJournal
+    tmp = Path(tempfile.mkdtemp())
+    events = EventLog(subscribers=[EventStore(tmp / "events")])
+    journal = SnapshotJournal(agent_name="t", snapshot_path=tmp / "s.json", state_log=None)
+
+    ref: list = []
+
+    async def _on_announce(iv):
+        if ref:
+            await ref[0].announce(iv)
+
+    registry = InterventionRegistry(on_announce=_on_announce)
+    h = InterventionHandler(
+        intervention_registry=registry, journal=journal, event_log=events,
+        put_outbox=lambda m: asyncio.sleep(0), append_history=history.append,
+        threat_scan=ThreatScanConfig(),
+    )
+    ref.append(h)
+    return h, registry
+
+
+@pytest.mark.asyncio
+async def test_external_answer_stamps_untrusted_marker():
+    """Tier 2: an external peer answer stamps UNTRUSTED_META_KEY on its history entry."""
+    hist = _Recorder()
+    h, registry = _build_handler(hist)
+    iv = UserIntervention(kind="ask_user", prompt="?", run_id="r")
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(h.dispatch(iv))
+    from _async_wait import wait_until
+    await wait_until(lambda: bool(registry.list_active()))
+
+    await h.deliver_answer_to(iv, "the answer", external_source=True)
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert hist.history, "expected a history entry"
+    assert hist.history[-1]["meta"].get(UNTRUSTED_META_KEY) is True
+
+
+@pytest.mark.asyncio
+async def test_local_answer_does_not_stamp_marker():
+    """Tier 2: a local (non-external) answer does NOT stamp the marker (falsify)."""
+    hist = _Recorder()
+    h, registry = _build_handler(hist)
+    iv = UserIntervention(kind="ask_user", prompt="?", run_id="r")
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(h.dispatch(iv))
+    from _async_wait import wait_until
+    await wait_until(lambda: bool(registry.list_active()))
+
+    await h.deliver_answer_to(iv, "local", external_source=False)
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert hist.history
+    assert UNTRUSTED_META_KEY not in hist.history[-1]["meta"]


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S4a** (context-auto foundation). S4 design-check greenlit (until-compaction scope ✓, minimal + `_untrusted.yaml` override ✓, seam-agnostic abstraction ✓). Tool-result follow-up tracked at **#1909**.

## What
Defense-in-depth with the #1862 fence: while untrusted external content is live in context, the agent is **also capability-narrowed** — a partial injection has no dangerous tools to reach. This lands the **seam-agnostic** pieces, **unwired** (S4b does the per-turn compose) → **byte-identical**.

- **`UNTRUSTED_META_KEY`** — the marker any untrusted-content seam stamps on a history-entry meta. The tainted-derivation is **marker-driven, not seam-specific**, so #1909 (tool-results) extends it by stamping the same marker.
- **`builtin_untrusted_profile()`** — secure default: deny memory-write / `delegate` / `exec` / mcp-install (both qualified catalog names + unwrapped aliases, since the live gate matches the effective resolved name).
- **`load_untrusted_profile(project_root)`** — built-in default, overridable by `.reyn/capability_profiles/_untrusted.yaml` (a **deliberate loosening**); a malformed override falls back to the built-in (floor not silently dropped).
- **`metas_have_untrusted(metas)`** — seam-agnostic taint check over the **active (un-compacted)** context → the **until-compaction** scope falls out for free.
- **intervention_handler**: the external peer answer (#1862 seam) stamps the marker when `external_source` — the v1 seam.

## Test plan (pure + the InterventionHandler seam, no mocks)
- [x] Built-in denies the side-effecting surfaces (via the real `ContextualLayer` gate type) + allows a read tool.
- [x] `_untrusted.yaml` override honored; **malformed → built-in restored** (floor preserved).
- [x] Marker detection (seam-agnostic; empty/non-iterable safe).
- [x] External answer **stamps** the marker; local answer does **not** (falsify).
- [x] #1862 byte-identical (**41 passed**); tier-audit + ruff clean.

## Reuse / no new enforcement
`ContextualPermission` / `resolve_profile` (S2a); enforcement = the S1.5 live gate. S4b composes `[static, _untrusted]` per-turn when tainted (reuses `compose_resolved`).

Refs #1827. Follow-up #1909 (tool-result mid-turn). Next: **S4b** — per-turn compose + thread in `run_turn` + until-compaction e2e (denied tool blocked **while tainted**, un-narrowed after compaction) + CLEAN RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
