### PR TITLE
docs(guide): surface time-travel + semantic-search in for-users hub

### DIFF
--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -47,11 +47,13 @@ No configuration required for any of these. Reyn has the skills for them out of 
 
 - **[Work with local files](work-with-files.md)** — reference files and directories in your requests.
 - **[Use an MCP server](../for-skill-authors/operations/use-an-mcp-server.md)** — add GitHub, Slack, a database, or any MCP-compatible tool.
+- **[Enable semantic search](enable-semantic-search.md)** — index your own docs so Reyn can search them by meaning.
 
 ### Control and safety
 
 - **[Manage permissions](manage-permissions.md)** — approve or deny what Reyn is allowed to do.
 - **[Respond mid-task](ask-user-mid-phase.md)** — answer questions Reyn asks while a skill is running.
+- **[Rewind a session](time-travel.md)** — jump back to an earlier point with `/rewind` and branch from there.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — owner-directed docs mining 軸② (discoverability) の即修正。

## Problem

`guide/for-users/index.md`(ユーザ how-to の入口)の "How-tos" リストに、実在する 2 つの user-facing how-to が**未リンク** = hub からユーザが発見できない:
- `time-travel.md`(/rewind)— feature-map から 7 箇所リンクされるのに user hub から辿れない
- `enable-semantic-search.md`

## Fix

index の How-tos に 2 リンク追加:
- "Files and tools" → Enable semantic search
- "Control and safety" → Rewind a session

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → EXIT=0, zero WARNING(新 docs-strict gate 基準で verify)
- [x] リンク先 2ファイルの実在確認(既存 doc)
- [x] no history-refs

## Context

Owner directive のdocs 使い方 mining で発見した 3 軸 gap の軸②。軸①(budget/cron/auth/memory の how-to 新規 4本)は別 PR で続けます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)