### PR TITLE
docs(guide): add "Cap your spending" user how-to (EN+JA)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
               - guide/for-users/manage-permissions.md
               - guide/for-users/configure-sandbox.md
               - guide/for-users/ask-user-mid-phase.md
+              - guide/for-users/cap-spending.md
           - Files & integrations:
               - guide/for-users/work-with-files.md
               - guide/for-users/enable-semantic-search.md

--- a/docs/guide/for-users/cap-spending.ja.md
+++ b/docs/guide/for-users/cap-spending.ja.md
@@ -1,0 +1,75 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# 支出に上限をかける
+
+デフォルトでは Reyn は支出制限なしで動作します — タスクが終わるまで LLM を
+呼び続けます。トークン数や金額にハードな上限を設けたい場合は、`reyn.yaml` に
+`cost:` ブロックを追加します。上限は各 LLM 呼び出しの**前**にチェックされるため、
+拒否された呼び出しには費用がかかりません。
+
+## 1日あたりのドル上限を設定する
+
+最もよくある目的 ——「1日に数ドル以上は使わない」:
+
+```yaml
+# reyn.yaml
+cost:
+  daily_cost_usd:
+    hard_limit: 5.00     # 当日の支出が $5 に達したら次の呼び出しを拒否
+    warn_ratio: 0.8      # 80%（$4.00）で一度だけ警告
+```
+
+日次・月次の上限は**永続的**です — 再起動しても保持され、ローカル時刻の
+深夜0時（日次）または月初1日（月次）に自動リセットされます。
+`.reyn/state/budget_ledger.jsonl` に保存されます。
+
+## 単一エージェント/セッションに上限をかける
+
+エージェント単位の上限は**メモリ内**です — `reyn chat` の再起動や
+`/budget reset` でリセットされます。1日全体ではなく、1つの会話を
+バウンドしたいときに使います:
+
+```yaml
+cost:
+  per_agent_tokens:
+    hard_limit: 50000
+  per_agent_cost_usd:
+    hard_limit: 2.00
+```
+
+## 現在の状況を確認する
+
+`reyn chat` 実行中:
+
+| コマンド | 表示内容 |
+|---------|---------|
+| `/cost` | アタッチ中エージェントの当セッション支出（1行） |
+| `/budget` | 全体内訳 — 当日・当月・エージェント別・レート制限 |
+| `/budget reset` | メモリ内のエージェント別カウンタをクリア（日次/月次は不変） |
+
+## 上限に達したときの挙動
+
+- **警告しきい値**（`hard_limit × warn_ratio`）: 一度だけ `[budget warn]`
+  メッセージが出て、呼び出しは続行されます。
+- **ハード上限**: 次の呼び出しは実行前に拒否されます。`[budget exceeded]` と
+  発火した dimension、対処法（`reyn.yaml` で上限引き上げ / `/budget reset` /
+  再起動）が表示されます。
+
+## 補足
+
+- `cost:` ブロックが無ければ実行は無制限 — フレームワーク全体が opt-in です。
+- ドル金額は [LiteLLM の価格データ](https://github.com/BerriAI/litellm) から
+  推定されます。価格エントリの無いモデルではドルカウンタは `$0.00` のままですが、
+  トークン数は常に正確なので、価格不明でもトークン上限は機能します。
+- レート制限（`rate_limit_per_minute`）は60秒ウィンドウが空くまで呼び出しを
+  拒否します。Reyn は自動スリープしないため、呼び出し側がリトライします。
+
+## 関連
+
+- [リファレンス: Budget and cost tracking](../../reference/config/budget.md) — 全スキーマ・全フィールド・ledger 形式・`/cost` / `/budget` の出力
+- [リファレンス: `reyn.yaml`](../../reference/config/reyn-yaml.md) — 設定ファイル全体
+- [Reyn が停止する理由を理解する](../for-skill-authors/operations/understand-why-reyn-stops.md) — limit と budget は1つの停止フレームワークを共有

--- a/docs/guide/for-users/cap-spending.md
+++ b/docs/guide/for-users/cap-spending.md
@@ -1,0 +1,75 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# Cap your spending
+
+By default Reyn runs without any spending limit — it keeps calling the LLM
+until your task is done. If you want a hard ceiling on tokens or dollars,
+add a `cost:` block to `reyn.yaml`. Caps are checked *before* each LLM call,
+so a refused call costs you nothing.
+
+## Set a daily dollar cap
+
+The most common goal — "never spend more than a few dollars a day":
+
+```yaml
+# reyn.yaml
+cost:
+  daily_cost_usd:
+    hard_limit: 5.00     # refuse the next call once today's spend hits $5
+    warn_ratio: 0.8      # warn once at 80% ($4.00)
+```
+
+Daily and monthly caps are **persistent** — they survive restarts and reset
+automatically at local midnight (daily) or the 1st of the month (monthly).
+They are stored in `.reyn/state/budget_ledger.jsonl`.
+
+## Cap a single agent or session
+
+Per-agent caps are **in-memory** — they reset when you restart `reyn chat` or
+run `/budget reset`. Use them to bound one conversation rather than your whole
+day:
+
+```yaml
+cost:
+  per_agent_tokens:
+    hard_limit: 50000
+  per_agent_cost_usd:
+    hard_limit: 2.00
+```
+
+## Check where you stand
+
+While `reyn chat` is running:
+
+| Command | Shows |
+|---------|-------|
+| `/cost` | One-line spend for the attached agent this session |
+| `/budget` | Full breakdown — today, this month, per-agent, rate limits |
+| `/budget reset` | Clear the in-memory per-agent counters (daily/monthly are untouched) |
+
+## What happens when you hit a cap
+
+- **At the warn threshold** (`hard_limit × warn_ratio`): you get a one-time
+  `[budget warn]` message and the call proceeds.
+- **At the hard limit**: the next call is refused before it runs. You'll see
+  `[budget exceeded]` with the triggered dimension and your options — raise the
+  limit in `reyn.yaml`, run `/budget reset`, or restart.
+
+## Notes
+
+- Without a `cost:` block, runs are unlimited — the whole framework is opt-in.
+- USD figures are estimated from [LiteLLM's pricing data](https://github.com/BerriAI/litellm).
+  If a model has no price entry the dollar counter stays at `$0.00` but token
+  counts are always accurate — so token caps work even when pricing is unknown.
+- A rate limit (`rate_limit_per_minute`) refuses calls until the 60-second
+  window clears; Reyn does not auto-sleep, so the caller retries.
+
+## See also
+
+- [Reference: Budget and cost tracking](../../reference/config/budget.md) — full schema, every field, the ledger format, and the `/cost` / `/budget` command output
+- [Reference: `reyn.yaml`](../../reference/config/reyn-yaml.md) — the complete config file
+- [Understand why Reyn stops](../for-skill-authors/operations/understand-why-reyn-stops.md) — limits and budgets share one stop framework

--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -54,6 +54,7 @@ No configuration required for any of these. Reyn has the skills for them out of 
 - **[Manage permissions](manage-permissions.md)** — approve or deny what Reyn is allowed to do.
 - **[Respond mid-task](ask-user-mid-phase.md)** — answer questions Reyn asks while a skill is running.
 - **[Rewind a session](time-travel.md)** — jump back to an earlier point with `/rewind` and branch from there.
+- **[Cap your spending](cap-spending.md)** — set token / dollar limits so a run can't overspend.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — owner-directed docs mining 軸① how-to #1/4 (budget/cost). 1 topic = 1 PR (lead coordination).

## Gap

Budget/cost was documented only as a **config-schema reference** (`reference/config/budget.md`, audience: reference). No task-oriented **user** how-to for "how do I stop Reyn overspending."

## New doc

`guide/for-users/cap-spending.md` (+`.ja.md`): scenario-driven —
- Set a daily dollar cap (persistent, auto-reset)
- Cap a single agent/session (in-memory)
- Check spend: `/cost` / `/budget` / `/budget reset`
- Warn vs hard-limit behaviour
- Notes: opt-in, LiteLLM pricing, rate-limit no-auto-sleep

Defers full schema to the reference (no duplication). Wired into `for-users/index.md` (Control and safety) + nav.

## impl-verify (against source, not just the reference doc)

| Claim | Source | ✓ |
|-------|--------|---|
| `/cost`, `/budget [reset]` slash commands | `src/reyn/interfaces/slash/budget.py:1,35` | ✅ |
| cost config fields `warn_ratio` / `rate_limit_per_minute` | `src/reyn/config/chat.py:773,806` | ✅ |
| ledger `.reyn/state/budget_ledger.jsonl` | `src/reyn/interfaces/cli/commands/chat.py:372` | ✅ |
| opt-in (no `cost:` = unlimited) | reference + config default (null hard_limit) | ✅ |

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → EXIT=0, zero WARNING
- [x] EN + JA both added (owner JA-parity directive)
- [x] no history-refs; nav + index wired (no orphan page)

## Stacking

Stacked on #1915 (for-users hub discoverability) to compose the shared `index.md` edits. After #1915 merges I'll rebase onto main (drops that commit). Subsequent how-tos (cron/auth/memory) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)