### PR TITLE
docs(guide): add "Run a skill on a schedule" user how-to (EN+JA)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
               - guide/for-users/configure-sandbox.md
               - guide/for-users/ask-user-mid-phase.md
               - guide/for-users/cap-spending.md
+              - guide/for-users/schedule-skills.md
           - Files & integrations:
               - guide/for-users/work-with-files.md
               - guide/for-users/enable-semantic-search.md

--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -55,6 +55,7 @@ No configuration required for any of these. Reyn has the skills for them out of 
 - **[Respond mid-task](ask-user-mid-phase.md)** — answer questions Reyn asks while a skill is running.
 - **[Rewind a session](time-travel.md)** — jump back to an earlier point with `/rewind` and branch from there.
 - **[Cap your spending](cap-spending.md)** — set token / dollar limits so a run can't overspend.
+- **[Run a skill on a schedule](schedule-skills.md)** — fire a skill on a cron schedule with `reyn cron`.
 
 ---
 

--- a/docs/guide/for-users/schedule-skills.ja.md
+++ b/docs/guide/for-users/schedule-skills.ja.md
@@ -1,0 +1,81 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# skill を定期実行する
+
+Reyn は cron スケジュールで skill を自動実行できます — 例えば毎時のイベント
+インデックス更新や週次サマリーレポートなど。`reyn.yaml` の `cron.jobs` に
+ジョブを宣言し、スケジューラを起動します。
+
+## ジョブを宣言する
+
+各ジョブには skill 名・5 フィールドの cron 式・任意の入力を指定します:
+
+```yaml
+# reyn.yaml
+cron:
+  jobs:
+    - name: weekly_ops_report
+      skill: ops_report
+      schedule: "0 9 * * MON"   # 毎週月曜 09:00
+      input:
+        since_days: 7
+      enabled: true
+```
+
+| フィールド | 必須 | 意味 |
+|-----------|------|------|
+| `name` | はい | 一意なジョブ識別子 |
+| `skill` | はい | 実行する stdlib またはプロジェクト skill |
+| `schedule` | はい | 5 フィールド cron 式（分 / 時 / 日 / 月 / 曜日） |
+| `input` | いいえ（既定 `{}`） | skill に渡す入力アーティファクト |
+| `enabled` | いいえ（既定 `true`） | `false` でエントリは残しつつスケジュール対象外に |
+
+## スケジューラを起動する
+
+```bash
+reyn cron run
+```
+
+これは**フォアグラウンド**で動作し、Ctrl-C を押すまでブロックします。起動時に
+各有効ジョブの次回発火時刻バナーを表示し、`reyn run` と同じヘッドレス経路で
+各ジョブをスケジュール時刻に dispatch します。
+
+```
+$ reyn cron run
+Started cron scheduler with 1 enabled job(s):
+  • weekly_ops_report  (0 9 * * MON)  next: 2026-05-19T09:00:00+00:00
+^C
+Cron scheduler stopped.
+```
+
+スケジューラは `reyn web` 内（FastAPI lifespan）でも自動起動するため、web
+サーバーを動かしていれば別途 `reyn cron run` プロセスなしでジョブが発火し続けます。
+
+## 起動せずにジョブを確認する
+
+```bash
+reyn cron list      # 全ジョブ + 次回発火時刻
+reyn cron status    # 最終実行状態
+```
+
+`reyn cron list` は `cron.jobs` を読み、スケジューラを起動せずにテーブルを表示します。
+
+## 補足
+
+- **`reyn cron status` は稼働中スケジューラのみ反映**します。v1 では最終実行状態が
+  メモリ内のため、`reyn cron run` セッション外では表示できる実行履歴がありません。
+- ジョブは**ヘッドレス**で実行され、対話プロンプトはありません。skill が必要とする
+  権限は `reyn.yaml` で事前承認しておいてください（スケジュール実行は確認のために
+  停止できません）。
+- 実行時登録ジョブは `<project>/.reyn/cron.yaml` に保存され、名前衝突時は
+  `reyn.yaml` の `cron.jobs` を上書きします。
+
+## 関連
+
+- [リファレンス: `reyn cron`](../../reference/cli/cron.md) — `run` / `list` / `status`、出力形式、終了コード
+- [リファレンス: `reyn.yaml` — `cron:` ブロック](../../reference/config/reyn-yaml.md#cron-block) — 全フィールドスキーマ
+- [支出に上限をかける](cap-spending.md) — スケジュールジョブも日次/月次予算にカウントされます

--- a/docs/guide/for-users/schedule-skills.md
+++ b/docs/guide/for-users/schedule-skills.md
@@ -1,0 +1,84 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# Run a skill on a schedule
+
+Reyn can run a skill automatically on a cron schedule — for example, an
+hourly event index or a weekly summary report. You declare jobs in
+`reyn.yaml` under `cron.jobs`, then start the scheduler.
+
+## Declare a job
+
+Each job names a skill, a 5-field cron expression, and an optional input:
+
+```yaml
+# reyn.yaml
+cron:
+  jobs:
+    - name: weekly_ops_report
+      skill: ops_report
+      schedule: "0 9 * * MON"   # every Monday at 09:00
+      input:
+        since_days: 7
+      enabled: true
+```
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `name` | yes | Unique job identifier |
+| `skill` | yes | A stdlib or project skill to run |
+| `schedule` | yes | 5-field cron expression (minute / hour / day-of-month / month / day-of-week) |
+| `input` | no (default `{}`) | Input artifact passed to the skill |
+| `enabled` | no (default `true`) | Set `false` to keep the entry but skip scheduling |
+
+## Start the scheduler
+
+```bash
+reyn cron run
+```
+
+This runs in the **foreground** and blocks until you press Ctrl-C. It prints
+a startup banner with each enabled job's next fire time, then dispatches each
+job at its scheduled time using the same headless path as `reyn run`.
+
+```
+$ reyn cron run
+Started cron scheduler with 1 enabled job(s):
+  • weekly_ops_report  (0 9 * * MON)  next: 2026-05-19T09:00:00+00:00
+^C
+Cron scheduler stopped.
+```
+
+The scheduler also starts automatically inside `reyn web` (in the FastAPI
+lifespan), so a running web server keeps your jobs firing without a separate
+`reyn cron run` process.
+
+## Inspect jobs without running
+
+```bash
+reyn cron list      # all jobs + next computed fire time
+reyn cron status    # last-run state
+```
+
+`reyn cron list` reads `cron.jobs` and prints the table without starting a
+scheduler.
+
+## Notes
+
+- **`reyn cron status` only reflects a live scheduler.** Last-run state is
+  in-memory in v1, so outside an active `reyn cron run` session there is no
+  persisted run history to show.
+- Jobs run **headless** — there is no interactive prompt. Make sure any
+  permissions the skill needs are pre-approved in `reyn.yaml` (a scheduled run
+  cannot stop to ask you).
+- Runtime-registered jobs live in `<project>/.reyn/cron.yaml` and override
+  `reyn.yaml` `cron.jobs` on a name collision.
+
+## See also
+
+- [Reference: `reyn cron`](../../reference/cli/cron.md) — `run` / `list` / `status`, output formats, exit codes
+- [Reference: `reyn.yaml` — `cron:` block](../../reference/config/reyn-yaml.md#cron-block) — full field schema
+- [Cap your spending](cap-spending.md) — a scheduled job still counts against your daily / monthly budget


### PR DESCRIPTION
**[docs-maintainer]** — owner-directed docs mining 軸① how-to #2/4 (cron). 1 topic = 1 PR.

## Gap

Cron scheduling existed as a CLI reference (`reference/cli/cron.md`) + a config schema block, but no task-oriented **user** how-to for "run a skill on a schedule."

## New doc

`guide/for-users/schedule-skills.md` (+`.ja.md`):
- Declare a job in `cron.jobs` (field table)
- Start the scheduler (`reyn cron run` foreground; also `reyn web` lifespan)
- Inspect with `reyn cron list` / `status`
- Caveats: status is live-only (v1 in-memory), jobs run headless so permissions must be pre-approved, `.reyn/cron.yaml` runtime override

Wired into `for-users/index.md` + nav.

## impl-verify (against source)

| Claim | Source | ✓ |
|-------|--------|---|
| `reyn cron run/list/status` | `src/reyn/interfaces/cli/commands/cron.py` | ✅ |
| `cron.jobs` fields name/skill/schedule/input/enabled | `src/reyn/config/infra.py` `CronJobConfig`/`CronConfig` | ✅ |
| status last-run in-memory (v1) | `cron.py` module docstring | ✅ |
| `.reyn/cron.yaml` runtime override | reyn-yaml.md cron precedence | ✅ |
| scheduler in `reyn web` lifespan | reyn-yaml.md cron block | ✅ |

## Test plan

- [x] `mkdocs build --strict` → EXIT=0, zero WARNING (incl. `#cron-block` anchor resolves)
- [x] EN + JA both added
- [x] no history-refs; nav + index wired

## Stacking

Stacked on #1916 (budget how-to). After #1916 merges I'll rebase onto main. Order: budget(#1916) → cron(this) → auth → memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)