### PR TITLE
feat(1912a): single shared contextual gate + thread to phase RouterLoop

### DIFF
--- a/src/reyn/core/kernel/phase_executor.py
+++ b/src/reyn/core/kernel/phase_executor.py
@@ -193,8 +193,14 @@ class PhaseExecutor:
         phase_compaction_cfg: "PhaseActResultsCompactionConfig | None" = None,
         op_loop_enabled: bool = False,
         agent_sandbox_policy: dict | None = None,
+        contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase RouterLoop live gate
     ) -> None:
         self._llm_caller = llm_caller
+        # #1912: per-session contextual narrowing (inherited from the spawning
+        # session via SkillRuntime→OSRuntime). Threaded to the phase RouterLoop so
+        # the phase act-turn tool gate (``_excluded_result``) enforces it — closing
+        # the phase-path bypass. None = no narrowing (byte-identical).
+        self._contextual_permission = contextual_permission
         # #1267: WAL-memo seam for the phase compaction summary call (shared by all
         # compact_control_ir_results sites — json-mode / converged / on-demand). Built
         # from the recorder's WAL primitives; getattr-guarded for non-recorder fakes.
@@ -619,6 +625,10 @@ class PhaseExecutor:
         routerloop = RouterLoop(
             host=host,
             chain_id=self._run_id or phase,
+            # #1912: thread the per-session contextual narrowing so the phase
+            # act-turn tool gate (RouterLoop._excluded_result) enforces it —
+            # the same shared gate as the chat path (no phase bypass).
+            contextual_permission=self._contextual_permission,
             # #1092 PR-C-5 (4): use the EFFECTIVE act-turn cap (resume-adjusted), not
             # the raw max_act_turns, so the converged op-loop force-closes
             # json-mode-equally (mirrors _run_act_loop's state.effective_act_turn_cap).

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -78,6 +78,7 @@ class OSRuntime:
         parent_run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
         threat_scan: "object | None" = None,  # FP-0050/#1822 S5 (EP4)
+        contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase RouterLoop + control-IR gates
         router_config: "object | None" = None,  # #1829 S3b: reyn.yaml llm.router.*
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
@@ -332,6 +333,7 @@ class OSRuntime:
             # (#1092) iff its name is listed. Default empty = json-mode (zero change).
             op_loop_enabled=skill.name in (tool_calls_op_loop_skills or ()),
             agent_sandbox_policy=self._agent_sandbox_policy,  # #1326
+            contextual_permission=contextual_permission,  # #1912 → phase RouterLoop live gate
         )
         # FP-0020 Component D: phase sequence + transitions + rollback + skill-node
         # dispatch + resume + SkillRegistry lifecycle extracted to RunOrchestrator.

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3189,14 +3189,11 @@ class RouterLoop:
         have not yet migrated (byte-identical), and S2+ feed a real contextual
         from topology / delegate / ephemeral narrowing."""
         if self._contextual_permission is not None:
-            from reyn.security.permissions.effective import (
-                CapabilityAxis,
-                ContextualLayer,
-            )
+            # #1912: the single shared contextual gate — identical check across
+            # chat / phase RouterLoop + control-IR op dispatch (no path bypass).
+            from reyn.security.permissions.effective import tool_contextually_denied
             effective = args.get("action_name") if name == "invoke_action" else name
-            if not ContextualLayer(self._contextual_permission).allows(
-                CapabilityAxis.TOOL, effective
-            ):
+            if tool_contextually_denied(self._contextual_permission, effective):
                 return {
                     "status": "error",
                     "error": {

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3248,6 +3248,7 @@ class Session:
             resolver=self._resolver,
             permission_resolver=self._perm,
             safety=self._safety,
+            contextual_permission=self._contextual_permission,  # #1912: narrow skill execution too
             mcp_servers=mcp_servers,
             intervention_bus=intervention_bus,
             subscribers=subscribers,

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -267,6 +267,27 @@ class ContextualLayer:
         return True
 
 
+def tool_contextually_denied(
+    contextual: "ContextualPermission | None", effective_name: str
+) -> bool:
+    """The single contextual TOOL-axis gate check (#1912).
+
+    True iff a per-session contextual narrowing is present AND denies
+    ``effective_name``. **Every** tool-dispatch path calls this one function —
+    chat ``RouterLoop._excluded_result``, the phase ``RouterLoop`` (same code),
+    and control-IR op dispatch — so contextual enforcement is a single seam,
+    bypass-impossible by construction. ``contextual is None`` → not denied (⊤),
+    so an un-narrowed path is byte-identical to pre-#1827.
+
+    Callers pass the **effective resolved name** (``invoke_action`` already
+    unwrapped to ``action_name``; a control-IR op mapped to its tool-name) so the
+    same name vocabulary reaches the deny-set on every path.
+    """
+    if contextual is None:
+        return False
+    return not ContextualLayer(contextual).allows(CapabilityAxis.TOOL, effective_name)
+
+
 def _path_under(path_str: str, root: str) -> bool:
     """True if ``path_str`` is ``root`` or a descendant (resolved). Used for the
     sandbox path caps (mirrors the recursive-scope match shape)."""

--- a/src/reyn/skill/skill_runtime.py
+++ b/src/reyn/skill/skill_runtime.py
@@ -53,6 +53,7 @@ class SkillRuntime:
         resolver: ModelResolver | None = None,
         permission_resolver: PermissionResolver | None = None,
         safety: "SafetyConfig | None" = None,
+        contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase/control-IR gates (None = byte-identical)
         mcp_servers: dict | None = None,
         python_allowed_modules: list[str] | None = None,
         prompt_cache_enabled: bool = True,
@@ -89,6 +90,10 @@ class SkillRuntime:
         # #1092 PR-B: skills opted into the converged op-loop (config-driven gate,
         # threaded to OSRuntime so the converged path is reachable on the real run).
         self._safety = safety or SafetyConfig()
+        # #1912: per-session contextual narrowing inherited from the spawning
+        # session — threaded to the phase RouterLoop + control-IR OpContext so a
+        # narrowed agent's skill execution is enforced on every tool path.
+        self._contextual_permission = contextual_permission
         self._resolver = resolver or ModelResolver({})
         self._permission_resolver = permission_resolver
         self._mcp_servers = mcp_servers
@@ -312,6 +317,8 @@ class SkillRuntime:
             parent_run_id=parent_run_id,
             sandbox_config=self._sandbox_config,
             threat_scan=self._safety.threat_scan,  # FP-0050/#1822 S5 (EP4)
+            contextual_permission=self._contextual_permission,  # #1912
+
             environment_backend=self._environment_backend,
             sandbox_backend=self._sandbox_backend,
             multimodal_config=self._multimodal_config,

--- a/tests/test_phase_contextual_gate_1912.py
+++ b/tests/test_phase_contextual_gate_1912.py
@@ -1,0 +1,71 @@
+"""Tier 2: the single shared contextual gate + the phase RouterLoop path (#1912a).
+
+#1827 contextual narrowing was enforced only on the CHAT path. #1912 extracts the
+check into one shared function (`tool_contextually_denied`) that every tool path
+calls, and threads the per-session contextual to the **phase** RouterLoop
+(Session→SkillRuntime→OSRuntime→PhaseExecutor→RouterLoop) so a narrowed agent's
+skill act-turns are enforced too — closing the phase-path bypass.
+
+These pin: (a) the shared gate; (b) a RouterLoop constructed the way the phase
+path constructs it (with `contextual_permission`) blocks the denied tool at the
+live gate, and an un-narrowed one does not (CLEAN RED contrast). The full
+skill→phase→block integration + the control-IR op dispatch are #1912b.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.effective import (
+    ContextualPermission,
+    tool_contextually_denied,
+)
+
+
+def test_shared_gate_denies_and_allows():
+    """Tier 2: tool_contextually_denied — the single seam every path calls."""
+    ctx = ContextualPermission(tool_deny=frozenset({"exec__sandboxed_exec"}))
+    assert tool_contextually_denied(ctx, "exec__sandboxed_exec") is True
+    assert tool_contextually_denied(ctx, "recall") is False
+    # None contextual is inert (⊤) → byte-identical to pre-#1827.
+    assert tool_contextually_denied(None, "exec__sandboxed_exec") is False
+
+
+class _Host:
+    agent_name = "t"
+
+    def __init__(self):
+        class _E:
+            def emit(self, *a, **k): ...
+        self.events = _E()
+        self.calls: list = []
+
+    async def sandboxed_exec(self, **kw):  # runs IFF executed
+        self.calls.append(kw)
+        return {"ok": True}
+
+
+def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
+    return asyncio.run(
+        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+    )
+
+
+def test_phase_style_routerloop_blocks_denied_tool():
+    """Tier 2: a RouterLoop built as the phase path builds it (with contextual)
+    blocks the denied tool; an un-narrowed one does not (CLEAN RED contrast).
+
+    The phase RouterLoop is the SAME class + gate as chat; #1912a's change is that
+    PhaseExecutor now passes ``contextual_permission`` to it. Here we pin that such
+    a RouterLoop blocks via the shared gate (native + invoke_action shapes).
+    """
+    ctx = ContextualPermission(tool_deny=frozenset({"exec__sandboxed_exec"}))
+    narrowed = RouterLoop(host=_Host(), chain_id="p", max_iterations=5,
+                          contextual_permission=ctx)
+    assert _exec(narrowed, "exec__sandboxed_exec", {}).get("error", {}).get("kind") == "tool_excluded"
+    assert _exec(narrowed, "invoke_action", {"action_name": "exec__sandboxed_exec"}).get("error", {}).get("kind") == "tool_excluded"
+
+    # falsify: with no contextual (the pre-#1912 phase RouterLoop) it is NOT blocked
+    open_loop = RouterLoop(host=_Host(), chain_id="p", max_iterations=5)
+    assert _exec(open_loop, "exec__sandboxed_exec", {}).get("error", {}).get("kind") != "tool_excluded"


### PR DESCRIPTION
**[e2e-coder]** — #1912 **a** (single shared gate + phase RouterLoop). The phase-path contextual bypass fix; #1912 design greenlit (single shared gate = completeness-by-construction). Owning the over-claim: S1.5/S3 "single live gate" was **chat-only** (the S3 e2e tested only chat).

## What
- **`effective.py: tool_contextually_denied(contextual, name)`** — the ONE check **every** tool path calls (chat + phase RouterLoop + control-IR), so contextual enforcement is a single seam, **bypass-impossible by construction**. `None` → ⊤.
- **`router_loop._excluded_result`** refactored to call the shared check — **byte-identical** (#1406/#187 + contextual tests unchanged).
- **Threading chain** (mirrors the #1822 `threat_scan` path): `Session._contextual_permission` → `_build_agent_for_skill_runner` → `SkillRuntime` → `OSRuntime` → `PhaseExecutor` → **phase RouterLoop**. A narrowed agent's phase act-turns (op-loop path) now enforce via the same shared gate.

## Test plan
- [x] Shared gate: deny / allow / `None`-inert.
- [x] A **phase-style RouterLoop** (built with `contextual_permission` as the phase path does) blocks the denied tool via native + invoke_action; an un-narrowed loop does **not** (CLEAN RED contrast).
- [x] **Byte-identical**: chat path (#1406/#187) + skill/phase/kernel suites unchanged — **579 passed**. tier-audit + ruff clean.

## Scope split (honest)
The **DEFAULT (json-mode) phase** dispatches ops via `control_ir_executor`, **not** the phase RouterLoop — so the **control-IR op gate** (the bigger half) + the **end-to-end skill→phase→block CLEAN RED** (proving the threading flows through a real skill run) land in **#1912b**, which also adds the op-kind↔tool-name mapping for **every** deny-set entry (per your steer 1). #1912a delivers the shared gate, the chat byte-identical refactor, the full threading chain, and the phase-RouterLoop gate proof.

Refs #1912. Next: #1912b (control-IR gate + mapping completeness + dual-path CLEAN RED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
