### PR TITLE
docs(guide): add "Log in to an OAuth provider" user how-to (EN+JA)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
               - guide/for-users/work-with-files.md
               - guide/for-users/enable-semantic-search.md
               - guide/for-users/popular-mcp-servers.md
+              - guide/for-users/oauth-login.md
       - For skill authors:
           - guide/for-skill-authors/index.md
           - Foundation:

--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -48,6 +48,7 @@ No configuration required for any of these. Reyn has the skills for them out of 
 - **[Work with local files](work-with-files.md)** — reference files and directories in your requests.
 - **[Use an MCP server](../for-skill-authors/operations/use-an-mcp-server.md)** — add GitHub, Slack, a database, or any MCP-compatible tool.
 - **[Enable semantic search](enable-semantic-search.md)** — index your own docs so Reyn can search them by meaning.
+- **[Log in to an OAuth provider](oauth-login.md)** — authorize GitHub / Google / etc. via the browser device flow.
 
 ### Control and safety
 

--- a/docs/guide/for-users/oauth-login.ja.md
+++ b/docs/guide/for-users/oauth-login.ja.md
@@ -1,0 +1,94 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# OAuth プロバイダにログインする
+
+ツールによっては静的 API キーではなく OAuth ログインが必要です — 例えば
+ブラウザでアクセス承認が要る GitHub や Google 連携など。`reyn auth` は
+[RFC 8628 デバイスグラントフロー](https://datatracker.ietf.org/doc/html/rfc8628)
+を実行します: ブラウザで一度承認すれば、Reyn がトークンを保存（かつ自動更新）します。
+
+> 静的 API キーは代わりに `reyn secret` を使います。`reyn auth` は対話的な
+> OAuth 承認が必要なプロバイダにのみ使用してください。
+
+## 1. プロバイダを宣言する
+
+`reyn.yaml` の `auth.providers` にプロバイダを追加:
+
+```yaml
+# reyn.yaml
+auth:
+  providers:
+    github:
+      client_id: "${secret:github_oauth_client_id}"
+      device_authorization_url: "https://github.com/login/device/code"
+      token_url: "https://github.com/login/oauth/access_token"
+      scopes: [repo, user]
+      client_secret: "${secret:github_oauth_client_secret}"   # PKCE-only クライアントでは省略
+```
+
+| フィールド | 必須 | |
+|-----------|------|---|
+| `client_id` | はい | プロバイダ発行の OAuth クライアント id |
+| `device_authorization_url` | はい | device + user コードを返す |
+| `token_url` | はい | アクセス/リフレッシュトークンを発行 |
+| `scopes` | はい | スコープのリスト（無ければ `[]`） |
+| `client_secret` | いいえ | 機密クライアントのみ |
+| `audience` | いいえ | 一部プロバイダ（例: Auth0）で必須 |
+
+## 2. シークレットを保存する
+
+`${secret:...}` の値は `~/.reyn/secrets.env` から解決されます:
+
+```bash
+reyn secret set github_oauth_client_id
+reyn secret set github_oauth_client_secret
+```
+
+## 3. ログインする
+
+```bash
+reyn auth login github
+```
+
+Reyn が URL と user コードを表示します。任意のブラウザで URL を開き、コードを
+入力して承認すると、Reyn は完了までポーリングしトークンを保存します:
+
+```
+$ reyn auth login github
+
+To authenticate, open this URL in your browser:
+  https://github.com/login/device
+  and enter code: WDJB-MJHT
+
+Waiting for approval...
+Saved OAuth token under key 'github'. Expires at 2026-05-17T11:00:00+00:00.
+```
+
+トークンは `~/.reyn/oauth_tokens.json`（`chmod 600`）に書き込まれ、skill が
+使用する際に自動更新されます — リフレッシュトークン自体が失効するまで
+再ログインは不要です。
+
+### 1 プロバイダで複数アカウント
+
+`--save-as` で別キーにトークンを分けて保存:
+
+```bash
+reyn auth login github --save-as github-work
+```
+
+## 保存済みトークンを管理する
+
+```bash
+reyn auth list           # 保存済みトークンキー + 有効期限を一覧
+reyn auth revoke github  # ストアからトークンを削除
+```
+
+## 関連
+
+- [リファレンス: `reyn auth`](../../reference/cli/auth.md) — `login` / `list` / `revoke`、オプション、監査イベント
+- [リファレンス: `reyn.yaml` — `auth` ブロック](../../reference/config/reyn-yaml.md#auth-block) — 全プロバイダフィールドスキーマ
+- [コンセプト: secret handling](../../concepts/runtime/secret-handling.md) — OAuth ライフサイクルと認証情報スコープ

--- a/docs/guide/for-users/oauth-login.md
+++ b/docs/guide/for-users/oauth-login.md
@@ -1,0 +1,94 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# Log in to an OAuth provider
+
+Some tools need an OAuth login rather than a static API key — for example a
+GitHub or Google integration that requires you to approve access in a browser.
+`reyn auth` runs the [RFC 8628 device-grant flow](https://datatracker.ietf.org/doc/html/rfc8628):
+you approve once in a browser and Reyn stores (and auto-refreshes) the token.
+
+> Static API keys go through `reyn secret` instead — use `reyn auth` only for
+> providers that require an interactive OAuth approval.
+
+## 1. Declare the provider
+
+Add the provider under `auth.providers` in `reyn.yaml`:
+
+```yaml
+# reyn.yaml
+auth:
+  providers:
+    github:
+      client_id: "${secret:github_oauth_client_id}"
+      device_authorization_url: "https://github.com/login/device/code"
+      token_url: "https://github.com/login/oauth/access_token"
+      scopes: [repo, user]
+      client_secret: "${secret:github_oauth_client_secret}"   # omit for PKCE-only clients
+```
+
+| Field | Required | |
+|-------|----------|---|
+| `client_id` | yes | OAuth client id from the provider |
+| `device_authorization_url` | yes | Returns the device + user codes |
+| `token_url` | yes | Issues the access / refresh tokens |
+| `scopes` | yes | List of scopes (`[]` if none) |
+| `client_secret` | no | Confidential clients only |
+| `audience` | no | Required by some providers (e.g. Auth0) |
+
+## 2. Store the secrets
+
+`${secret:...}` values resolve from `~/.reyn/secrets.env`:
+
+```bash
+reyn secret set github_oauth_client_id
+reyn secret set github_oauth_client_secret
+```
+
+## 3. Log in
+
+```bash
+reyn auth login github
+```
+
+Reyn prints a URL and a user code. Open the URL in any browser, enter the
+code, approve — Reyn polls until you finish and then saves the token:
+
+```
+$ reyn auth login github
+
+To authenticate, open this URL in your browser:
+  https://github.com/login/device
+  and enter code: WDJB-MJHT
+
+Waiting for approval...
+Saved OAuth token under key 'github'. Expires at 2026-05-17T11:00:00+00:00.
+```
+
+The token is written to `~/.reyn/oauth_tokens.json` (`chmod 600`) and refreshed
+automatically when a skill uses it — you don't log in again until the refresh
+token itself expires.
+
+### Multiple accounts for one provider
+
+Use `--save-as` to keep separate tokens under distinct keys:
+
+```bash
+reyn auth login github --save-as github-work
+```
+
+## Manage stored tokens
+
+```bash
+reyn auth list           # list saved token keys + expiry
+reyn auth revoke github  # remove a token from the store
+```
+
+## See also
+
+- [Reference: `reyn auth`](../../reference/cli/auth.md) — `login` / `list` / `revoke`, options, audit events
+- [Reference: `reyn.yaml` — `auth` block](../../reference/config/reyn-yaml.md#auth-block) — full provider-field schema
+- [Concepts: secret handling](../../concepts/runtime/secret-handling.md) — OAuth lifecycle and credential scoping


### PR DESCRIPTION
**[docs-maintainer]** — owner-directed docs mining 軸① how-to #3/4 (auth/oauth). 1 topic = 1 PR.

## Gap

OAuth login (`reyn auth`) existed as a CLI reference + an `auth` config-block schema, but no task-oriented **user** how-to for "log in to GitHub/Google."

## New doc

`guide/for-users/oauth-login.md` (+`.ja.md`):
- Declare a provider under `auth.providers` (field table)
- Store secrets with `reyn secret set`
- Run `reyn auth login <provider>` (device-grant flow walkthrough)
- Multi-account `--save-as`
- Manage tokens: `reyn auth list` / `revoke`
- Distinguishes `reyn auth` (OAuth) from `reyn secret` (static keys)

Wired into `for-users/index.md` (Files and tools) + nav.

## impl-verify (against source)

| Claim | Source | ✓ |
|-------|--------|---|
| `reyn auth login/list/revoke` + `--save-as` | `src/reyn/interfaces/cli/commands/auth.py:7,52,58,261` | ✅ |
| token store `~/.reyn/oauth_tokens.json` chmod 600 + auto-refresh | `src/reyn/security/secrets/oauth.py:5,137` | ✅ |
| `auth.providers` required fields client_id/device_authorization_url/token_url/scopes | `src/reyn/config/infra.py:217` | ✅ |
| `${secret:}` resolves from `~/.reyn/secrets.env` | reyn-yaml.md auth block | ✅ |

## Test plan

- [x] `mkdocs build --strict` → EXIT=0, zero WARNING (`#auth-block` + `secret-handling.md` cross-refs resolve)
- [x] EN + JA both added
- [x] no history-refs; nav + index wired

## Stacking

Stacked on #1917 (cron how-to). Order: budget(#1916) → cron(#1917) → auth(this) → memory. Rebase onto main as the chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)