### PR TITLE
docs(guide): add "Inspect and manage memory" user how-to (EN+JA)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
               - guide/for-users/enable-semantic-search.md
               - guide/for-users/popular-mcp-servers.md
               - guide/for-users/oauth-login.md
+              - guide/for-users/manage-memory.md
       - For skill authors:
           - guide/for-skill-authors/index.md
           - Foundation:

--- a/docs/guide/for-users/index.md
+++ b/docs/guide/for-users/index.md
@@ -49,6 +49,7 @@ No configuration required for any of these. Reyn has the skills for them out of 
 - **[Use an MCP server](../for-skill-authors/operations/use-an-mcp-server.md)** — add GitHub, Slack, a database, or any MCP-compatible tool.
 - **[Enable semantic search](enable-semantic-search.md)** — index your own docs so Reyn can search them by meaning.
 - **[Log in to an OAuth provider](oauth-login.md)** — authorize GitHub / Google / etc. via the browser device flow.
+- **[Inspect and manage memory](manage-memory.md)** — review, edit, back up, or restore what Reyn remembers.
 
 ### Control and safety
 
@@ -62,7 +63,7 @@ No configuration required for any of these. Reyn has the skills for them out of 
 
 ## Things Reyn handles for you
 
-**Memory** — Reyn remembers facts across sessions automatically. No setup needed.
+**Memory** — Reyn remembers facts across sessions automatically. No setup needed. To review or curate what it has stored, see [Inspect and manage memory](manage-memory.md).
 
 **Crash recovery** — if a long task is interrupted, re-run `reyn chat` and it resumes from where it left off.
 

--- a/docs/guide/for-users/manage-memory.ja.md
+++ b/docs/guide/for-users/manage-memory.ja.md
@@ -1,0 +1,59 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# メモリを確認・管理する
+
+Reyn はセッションをまたいで事実を自動的に記憶します — 設定は不要です。
+このページは、記憶された内容を*見たい*・*整理したい*ときのためのものです:
+事実の確認、古い記憶の修正、バックアップ、別マシンへの移行など。これらはすべて
+chat セッションが動いていない状態で `reyn memory` を使って行います。
+
+## メモリの保存場所
+
+| レイヤ | パス | `--agent` フラグ |
+|-------|------|-----------------|
+| 共有（既定） | `.reyn/memory/` | 省略 |
+| エージェント別 | `.reyn/agents/<name>/memory/` | `--agent <name>` |
+
+以下のコマンドはすべて既定で共有レイヤを対象とします。特定エージェントの
+メモリを対象にするには `--agent <name>` を追加します。
+
+## 保存内容を見る
+
+```bash
+reyn memory list                    # 全メモリファイル（共有レイヤ）
+reyn memory list --agent my_agent   # 特定エージェントのメモリ
+reyn memory show preferences        # 1 つのメモリ内容を表示
+reyn memory search "API key" -i     # 正規表現検索（-i = 大文字小文字無視）
+```
+
+## メモリを修正・削除する
+
+```bash
+reyn memory edit preferences        # $EDITOR で開く
+reyn memory delete preferences      # 削除（確認プロンプトあり）
+reyn memory delete preferences -y   # プロンプトなしで削除
+```
+
+`delete` はそのレイヤの `MEMORY.md` インデックスからもエントリを除去するため、
+インデックスが存在しないファイルを指し続けることはありません。
+
+## バックアップと復元
+
+```bash
+reyn memory export --out backup.json      # 全メモリをファイルに dump
+reyn memory export                        # または stdout へ（既定）
+reyn memory import backup.json            # 復元（既存ファイルはスキップ）
+reyn memory import backup.json --overwrite # 復元（既存を上書き）
+```
+
+`import` は `--overwrite` を付けない限り既存のメモリをスキップするため、
+通常の import は再実行しても安全です。
+
+## 関連
+
+- [リファレンス: `reyn memory`](../../reference/cli/memory.md) — 全サブコマンド・フラグ・終了コード
+- [コンセプト: memory](../../concepts/data-retrieval/memory.md) — Reyn が何を記憶するか、recall の仕組み

--- a/docs/guide/for-users/manage-memory.md
+++ b/docs/guide/for-users/manage-memory.md
@@ -1,0 +1,60 @@
+---
+type: how-to
+topic: using-reyn
+audience: [human]
+---
+
+# Inspect and manage memory
+
+Reyn remembers facts across sessions automatically — you don't have to set
+anything up. This page is for when you want to *look at* or *curate* what it
+has stored: review a fact, fix a stale one, back memories up, or move them to
+another machine. All of this is done with `reyn memory` while no chat session
+is running.
+
+## Where memories live
+
+| Layer | Path | `--agent` flag |
+|-------|------|----------------|
+| Shared (default) | `.reyn/memory/` | omit |
+| Per-agent | `.reyn/agents/<name>/memory/` | `--agent <name>` |
+
+Every command below defaults to the shared layer; add `--agent <name>` to
+target one agent's memories instead.
+
+## Look at what's stored
+
+```bash
+reyn memory list                    # all memory files (shared layer)
+reyn memory list --agent my_agent   # one agent's memories
+reyn memory show preferences        # print one memory's contents
+reyn memory search "API key" -i     # regex search (-i = case-insensitive)
+```
+
+## Fix or remove a memory
+
+```bash
+reyn memory edit preferences        # open in $EDITOR
+reyn memory delete preferences      # delete (prompts to confirm)
+reyn memory delete preferences -y   # delete without the prompt
+```
+
+`delete` also removes the entry from the layer's `MEMORY.md` index, so the
+index never points at a file that no longer exists.
+
+## Back up and restore
+
+```bash
+reyn memory export --out backup.json      # dump all memories to a file
+reyn memory export                        # or to stdout (default)
+reyn memory import backup.json            # restore (skips existing files)
+reyn memory import backup.json --overwrite # restore, replacing existing
+```
+
+`import` skips any memory that already exists unless you pass `--overwrite` —
+so a plain import is safe to re-run.
+
+## See also
+
+- [Reference: `reyn memory`](../../reference/cli/memory.md) — every subcommand, flag, and exit code
+- [Concepts: memory](../../concepts/data-retrieval/memory.md) — how Reyn decides what to remember and how recall works


### PR DESCRIPTION
**[docs-maintainer]** — owner-directed docs mining 軸① how-to #4/4 (memory). 1 topic = 1 PR. Completes the 軸① set.

## Gap

`reyn memory` (CRUD/search/export/import) existed only as a CLI reference, and `for-users/index.md` framed memory as "automatic, no setup needed" — so the power-user management CLI was effectively invisible to users.

## New doc

`guide/for-users/manage-memory.md` (+`.ja.md`):
- Framed as *curation of the automatic memory* (consistent with "no setup")
- Where memories live (shared `.reyn/memory/` vs `--agent`)
- Look: `list` / `show` / `search`
- Fix/remove: `edit` / `delete` (+ MEMORY.md index strip)
- Back up/restore: `export` / `import` (+ `--overwrite` safety)

Wired into `for-users/index.md` (Files and tools list + a pointer from the Memory paragraph) + nav.

## impl-verify (against source)

| Claim | Source | ✓ |
|-------|--------|---|
| subcommands list/show/edit/delete/search/export/import | `src/reyn/interfaces/cli/commands/memory.py:42-77` | ✅ |
| shared `.reyn/memory/` vs `--agent .reyn/agents/<name>/memory/` | `memory.py:91` | ✅ |
| `delete` strips MEMORY.md entry | `memory.py:56` | ✅ |
| flags `--ignore-case/-i`, `--yes/-y`, `--out`, `--overwrite` | `memory.py:58,65,70,77` | ✅ |
| `import` skips existing unless `--overwrite` | `memory.py:77` | ✅ |

## Test plan

- [x] `mkdocs build --strict` → EXIT=0, zero WARNING
- [x] EN + JA both added
- [x] no history-refs; nav + index wired

## Stacking

Top of the stack: budget(#1916) → cron(#1917) → auth(#1921) → memory(this). Rebase onto main as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)