### PR TITLE
fix(#1913): web_fetch download-byte ceiling — unbounded-body memory DoS

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -544,6 +544,7 @@ web:
   fetch:
     verify_ssl: true     # true | false | omit (default: env-var chain)
     ca_bundle: /path/to/ca-bundle.pem   # optional custom CA bundle
+    max_download_bytes: 10485760        # wire-byte ceiling (default 10MB)
 ```
 
 Priority chain (highest first):
@@ -556,6 +557,10 @@ Priority chain (highest first):
 | 4 | Both unset | Fall through: `SSL_VERIFY` env var → `litellm.ssl_verify` → `SSL_CERT_FILE` → `True` |
 
 `verify_ssl` and `ca_bundle` also apply to MCP registry HTTP calls (package install).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `web.fetch.max_download_bytes` | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
 
 ## `eval` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -577,11 +577,19 @@
 #
 # Set ``ca_bundle`` for corporate MITM / custom PKI; set
 # ``verify_ssl: false`` only in controlled test environments.
+#
+# ``max_download_bytes`` caps how many response bytes ``web_fetch`` will
+# pull off the wire (default 10MB). A response whose ``Content-Length``
+# exceeds it is rejected before download; a chunked / unknown-length body
+# is aborted once the stream passes the ceiling. Guards against an
+# unbounded-body memory blow-up from a hostile / runaway URL. ``<= 0`` or a
+# non-integer falls back to the 10MB default.
 # -----------------------------------------------------------------------------
 # web:
 #   fetch:
 #     verify_ssl: null              # null = delegate to env / litellm fallback
 #     ca_bundle: null               # absolute / cwd-relative PEM path
+#     max_download_bytes: 10485760  # 10MB wire-byte ceiling (DoS guard)
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -60,9 +60,19 @@ class WebFetchConfig:
         ca_bundle:
             Absolute path (or path relative to cwd) of a CA bundle PEM file.
             When set, takes priority over ``verify_ssl`` and env vars.
+        max_download_bytes:
+            #1913: hard ceiling on the HTTP response body downloaded by
+            ``web_fetch``, BEFORE the body is materialized into memory. A
+            response whose ``Content-Length`` exceeds this — or that streams past
+            it without one — is rejected (``status="too_large"``), preventing an
+            unbounded-memory DoS from a hostile URL (including a benign URL that
+            redirects to a huge payload). Distinct from ``WebFetchIROp.max_length``
+            (which caps the *extracted text* only AFTER the full body is loaded).
+            Default 10 MiB.
     """
     verify_ssl: bool | None = None
     ca_bundle: str | None = None
+    max_download_bytes: int = 10 * 1024 * 1024
 
 
 @dataclass
@@ -86,7 +96,18 @@ def _build_web_fetch_config(raw: object) -> WebFetchConfig:
         verify_ssl: bool | None = None
     else:
         verify_ssl = bool(verify_ssl_raw)
-    return WebFetchConfig(verify_ssl=verify_ssl, ca_bundle=ca_bundle)
+    defaults = WebFetchConfig()
+    try:
+        max_download_bytes = int(raw.get("max_download_bytes", defaults.max_download_bytes))
+        if max_download_bytes <= 0:
+            max_download_bytes = defaults.max_download_bytes
+    except (TypeError, ValueError):
+        max_download_bytes = defaults.max_download_bytes
+    return WebFetchConfig(
+        verify_ssl=verify_ssl,
+        ca_bundle=ca_bundle,
+        max_download_bytes=max_download_bytes,
+    )
 
 
 def _build_web_config(raw: object) -> WebConfig:

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -236,6 +236,28 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         )
 
     ctx.events.emit("web_fetch_started", url=op.url)
+    # #1913: hard ceiling on the downloaded body to prevent an unbounded-memory
+    # DoS. ``client.get`` materializes the ENTIRE response into memory before
+    # ``max_length`` (an extracted-TEXT cap) ever applies, so a hostile URL —
+    # including a benign one that redirects to a huge payload — could exhaust
+    # memory. Stream instead, rejecting on a declared Content-Length over the
+    # cap and on the running byte total exceeding it (covers chunked / no-CL).
+    _max_dl = (
+        ctx.web_config.fetch.max_download_bytes
+        if ctx.web_config is not None
+        else 10 * 1024 * 1024
+    )
+
+    def _too_large(n: int) -> dict:
+        ctx.events.emit("web_fetch_too_large", url=op.url, downloaded=n, limit=_max_dl)
+        return {
+            "kind": "web_fetch", "url": op.url, "status": "too_large",
+            "error": (
+                f"response body ({n} bytes) exceeds the {_max_dl}-byte download "
+                f"cap (web.fetch.max_download_bytes)"
+            ),
+        }
+
     try:
         # SSL verification — priority: reyn.yaml web.fetch config → env-var chain.
         # See _resolve_ssl_verify() docstring for the full priority order.
@@ -245,7 +267,18 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
             headers={"User-Agent": "reyn/1.0"},
             verify=_resolve_ssl_verify(ctx),
         ) as client:
-            response = await client.get(op.url)
+            async with client.stream("GET", op.url) as response:
+                _cl = response.headers.get("content-length")
+                if _cl is not None and _cl.isdigit() and int(_cl) > _max_dl:
+                    return _too_large(int(_cl))
+                _chunks: list[bytes] = []
+                _total = 0
+                async for _chunk in response.aiter_bytes():
+                    _total += len(_chunk)
+                    if _total > _max_dl:
+                        return _too_large(_total)
+                    _chunks.append(_chunk)
+                body = b"".join(_chunks)
     except httpx.TimeoutException:
         return {"kind": "web_fetch", "url": op.url, "status": "timeout",
                 "error": f"request timed out after {op.timeout}s"}
@@ -262,7 +295,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
     # path's errors="replace" behaviour, which preserves the pre-#364
     # output for non-image binary.
     if content_type.startswith("image/"):
-        image_bytes = response.content
+        image_bytes = body  # #1913: the streamed, size-capped bytes
         if ctx.permission_resolver is not None and ctx.multimodal_config is not None:
             if ctx.intervention_bus is None:
                 raise RuntimeError(
@@ -322,7 +355,11 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
             "media_blocks": [media_block],
         }
 
-    raw = response.text
+    # #1913: decode the streamed bytes ourselves (the stream is consumed, so
+    # ``response.text`` is unavailable). Use the header-declared charset
+    # (``charset_encoding`` needs no body) with the same errors="replace"
+    # tolerance the old ``.text`` path relied on for malformed bytes.
+    raw = body.decode(response.charset_encoding or "utf-8", errors="replace")
 
     if "text/html" in content_type:
         content, extractor_name = _extract_html_text(raw)

--- a/tests/test_web_fetch_binary_media_gate.py
+++ b/tests/test_web_fetch_binary_media_gate.py
@@ -212,6 +212,10 @@ class _CapturingImageClient:
     async def get(self, url: str) -> httpx.Response:
         return self._response
 
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
+
 
 def _make_ctx(tmp_path: Path, *, multimodal: MultimodalConfig, bus_answer: str = "yes") -> Any:
     from reyn.core.events.events import EventLog
@@ -354,6 +358,8 @@ def test_html_response_unchanged_when_image_gate_present(tmp_path, monkeypatch) 
             return self
         async def __aexit__(self, *args: object) -> None: pass
         async def get(self, url: str) -> httpx.Response: return self._response
+        def stream(self, method: str, url: str) -> "_ResponseStreamCtx":  # #1913
+            return _ResponseStreamCtx(self._response)
 
     monkeypatch.setattr(httpx, "AsyncClient", _HTMLClient)
 
@@ -369,3 +375,18 @@ def test_html_response_unchanged_when_image_gate_present(tmp_path, monkeypatch) 
     assert result["media_blocks"] == []
     assert "hello world" in result["content"]
     assert result["extractor"] in {"trafilatura", "stdlib"}
+
+
+class _ResponseStreamCtx:
+    """Async-CM mirroring ``client.stream(...)``. A canned ``httpx.Response``
+    built with ``content=`` already supports ``aiter_bytes`` / ``headers`` /
+    ``charset_encoding`` / ``status_code``, so it is yielded as-is (#1913)."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    async def __aenter__(self) -> "httpx.Response":
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None

--- a/tests/test_web_fetch_download_cap_1913.py
+++ b/tests/test_web_fetch_download_cap_1913.py
@@ -1,0 +1,135 @@
+"""Tier 2: web_fetch download-size cap prevents unbounded-memory DoS (#1913).
+
+`client.get` materialized the ENTIRE response body into memory before
+`max_length` (an extracted-TEXT cap) ever applied — so a hostile URL (or a
+benign one that redirects to a huge payload) could exhaust memory. web_fetch now
+streams with a byte ceiling (`web.fetch.max_download_bytes`), rejecting a
+response whose `Content-Length` exceeds the cap (early, before download) or
+whose streamed body runs past it (chunked / no Content-Length).
+
+Falsification:
+- body-over-cap: a body past the cap → status="too_large" (the cap is the gate —
+  a larger cap lets the SAME body through → ok).
+- content-length precheck: a declared CL over the cap is rejected WITHOUT
+  consuming the body (the byte stream raises if touched, and we still get
+  too_large — proving the early reject).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from reyn.config.media import WebConfig, WebFetchConfig
+from reyn.core.op_runtime.web import handle_web_fetch
+from reyn.schemas.models import WebFetchIROp
+
+
+def _make_ctx(max_download_bytes: int) -> Any:
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    class _FakeEventLog:
+        def emit(self, *a: object, **k: object) -> None:
+            pass
+
+    return OpContext(
+        workspace=type("W", (), {})(),  # type: ignore[arg-type]
+        events=_FakeEventLog(),          # type: ignore[arg-type]
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        web_config=WebConfig(fetch=WebFetchConfig(max_download_bytes=max_download_bytes)),
+    )
+
+
+class _StreamResp:
+    def __init__(self, *, body: bytes, content_length: str | None,
+                 raise_on_iter: bool = False) -> None:
+        hdrs = {"content-type": "text/plain"}
+        if content_length is not None:
+            hdrs["content-length"] = content_length
+        self.headers = httpx.Headers(hdrs)
+        self.status_code = 200
+        self.charset_encoding = None
+        self._body = body
+        self._raise = raise_on_iter
+
+    async def aiter_bytes(self):  # noqa: ANN201
+        if self._raise:
+            raise AssertionError("body must not be downloaded when CL exceeds cap")
+        # deliver in small chunks so the byte-ceiling is exercised mid-stream
+        for i in range(0, len(self._body), 16):
+            yield self._body[i : i + 16]
+
+
+class _StreamCtx:
+    def __init__(self, resp: _StreamResp) -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> _StreamResp:
+        return self._resp
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+def _client_factory(resp: _StreamResp):
+    class _Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *a: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamCtx:
+            return _StreamCtx(resp)
+
+    return _Client
+
+
+def _run(monkeypatch, resp: _StreamResp, cap: int) -> dict:
+    monkeypatch.setattr(httpx, "AsyncClient", _client_factory(resp))
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    return asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(cap), caller="control_ir"))
+
+
+def test_body_over_cap_rejected(monkeypatch) -> None:
+    """Tier 2: a streamed body past the cap → status='too_large'."""
+    resp = _StreamResp(body=b"A" * 500, content_length=None)
+    result = _run(monkeypatch, resp, cap=100)
+    assert result["status"] == "too_large", result
+
+
+def test_larger_cap_allows_same_body(monkeypatch) -> None:
+    """Tier 2: the SAME body passes under a larger cap → ok (falsification).
+
+    Proves the cap is the gate, not some unrelated rejection.
+    """
+    resp = _StreamResp(body=b"A" * 500, content_length=None)
+    result = _run(monkeypatch, resp, cap=10_000)
+    assert result["status"] == "ok", result
+    assert result["content"] == "A" * 500
+
+
+def test_content_length_over_cap_rejected_without_download(monkeypatch) -> None:
+    """Tier 2: a declared Content-Length over the cap is rejected early.
+
+    ``aiter_bytes`` raises if touched — getting ``too_large`` without that
+    AssertionError proves the body was never downloaded (the precheck fired).
+    """
+    resp = _StreamResp(body=b"A" * 500, content_length="500", raise_on_iter=True)
+    result = _run(monkeypatch, resp, cap=100)
+    assert result["status"] == "too_large", result
+
+
+def test_normal_body_ok(monkeypatch) -> None:
+    """Tier 2: a body under the cap fetches normally (no regression)."""
+    resp = _StreamResp(body=b"hello world", content_length="11")
+    result = _run(monkeypatch, resp, cap=10 * 1024 * 1024)
+    assert result["status"] == "ok", result
+    assert result["content"] == "hello world"

--- a/tests/test_web_fetch_extractor_selection.py
+++ b/tests/test_web_fetch_extractor_selection.py
@@ -69,6 +69,10 @@ class _CapturingHTMLClient:
     async def get(self, url: str) -> httpx.Response:
         return self._response
 
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
+
 
 class _CapturingTextClient:
     """httpx.AsyncClient drop-in that returns text/plain (= no extractor)."""
@@ -89,6 +93,10 @@ class _CapturingTextClient:
 
     async def get(self, url: str) -> httpx.Response:
         return self._response
+
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
 
 
 # ── _extract_html_text unit tests ──────────────────────────────────────
@@ -217,3 +225,18 @@ def test_result_envelope_uses_stdlib_when_trafilatura_unavailable(
     assert result["status"] == "ok"
     assert result["extractor"] == "stdlib"
     assert "hello world" in result["content"]
+
+
+class _ResponseStreamCtx:
+    """Async-CM mirroring ``client.stream(...)``. A canned ``httpx.Response``
+    built with ``content=`` already supports ``aiter_bytes`` / ``headers`` /
+    ``charset_encoding`` / ``status_code``, so it is yielded as-is (#1913)."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    async def __aenter__(self) -> "httpx.Response":
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None

--- a/tests/test_web_fetch_pagination.py
+++ b/tests/test_web_fetch_pagination.py
@@ -68,6 +68,10 @@ class _CapturingTextClient:
     async def get(self, url: str) -> httpx.Response:
         return self._response
 
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
+
 
 # ── default behaviour preserved (no start_index supplied) ──────────────
 
@@ -200,3 +204,18 @@ def test_two_call_pagination_covers_whole_document(monkeypatch: pytest.MonkeyPat
     assert r2["next_start"] is None
 
     assert r1["content"] + r2["content"] == _CapturingTextClient.body
+
+
+class _ResponseStreamCtx:
+    """Async-CM mirroring ``client.stream(...)``. A canned ``httpx.Response``
+    built with ``content=`` already supports ``aiter_bytes`` / ``headers`` /
+    ``charset_encoding`` / ``status_code``, so it is yielded as-is (#1913)."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    async def __aenter__(self) -> "httpx.Response":
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None

--- a/tests/test_web_fetch_preview_path_ref.py
+++ b/tests/test_web_fetch_preview_path_ref.py
@@ -111,6 +111,10 @@ class _CapturingHtmlClient:
     async def get(self, url: str) -> httpx.Response:
         return self._response
 
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
+
 
 _SAMPLE_HTML = """<!DOCTYPE html>
 <html><head><title>Sample Article Title</title></head>
@@ -265,3 +269,18 @@ def test_legacy_no_media_store_path_returns_inline_content(
     assert "preview" not in result
     assert "path_ref" not in result
     assert "stored_as" not in result
+
+
+class _ResponseStreamCtx:
+    """Async-CM mirroring ``client.stream(...)``. A canned ``httpx.Response``
+    built with ``content=`` already supports ``aiter_bytes`` / ``headers`` /
+    ``charset_encoding`` / ``status_code``, so it is yielded as-is (#1913)."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    async def __aenter__(self) -> "httpx.Response":
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None

--- a/tests/test_web_fetch_ssl_config.py
+++ b/tests/test_web_fetch_ssl_config.py
@@ -89,6 +89,25 @@ class _CaptureAsyncClient:
     async def get(self, url: str) -> httpx.Response:
         return self._response
 
+    def stream(self, method: str, url: str) -> "_ResponseStreamCtx":
+        # #1913: production now streams (client.stream) instead of client.get.
+        return _ResponseStreamCtx(self._response)
+
+
+class _ResponseStreamCtx:
+    """Async-CM mirroring ``client.stream(...)``. A canned ``httpx.Response``
+    built with ``content=`` already supports ``aiter_bytes()`` / ``headers`` /
+    ``charset_encoding`` / ``status_code``, so it is yielded as-is."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> httpx.Response:
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
 
 # ---------------------------------------------------------------------------
 # 1. ca_bundle config → verify=<path>


### PR DESCRIPTION
**[tui-coder]** — fix(#1913): web_fetch download-byte ceiling (unbounded-body memory DoS)

## Problem
`handle_web_fetch` called `client.get(op.url)`, which materializes the **entire** HTTP response body into memory before any cap applies. `WebFetchIROp.max_length` only caps **extracted text**, and only *after* the full body is loaded. A hostile URL — or a benign one that 302-redirects to a multi-GB payload — could therefore exhaust process memory (unbounded-body DoS).

## Fix
Stream the response with a hard wire-byte ceiling `web.fetch.max_download_bytes` (default 10MB):
- Declared `Content-Length` over the cap → rejected **before** any body is downloaded.
- Chunked / unknown-length body → aborted once the running byte total passes the ceiling.
- Either path returns `status="too_large"` + emits a `web_fetch_too_large` event (no crash, fail-secure).

`response.text` is unavailable once a stream is consumed, so the text path now decodes the accumulated bytes via the header-declared charset (`charset_encoding`, header-only) with the same `errors="replace"` tolerance the old `.text` relied on.

## Consumer audit
Production no longer calls `client.get`, so 5 existing web_fetch test fakes (`.get`-only) gained a `stream` async-CM. All re-verified green — no behavioral regression.

## Config mirror (#1056)
`max_download_bytes` documented in **both** `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md`. Bad value / `<= 0` → 10MB default fallback.

## Test plan
- [x] `tests/test_web_fetch_download_cap_1913.py` — 4 Tier-2:
  - body-over-cap → `too_large` (streaming ceiling)
  - **falsification**: same body under a larger cap → `ok` (proves the cap is the gate)
  - CL precheck rejects WITHOUT downloading (`aiter_bytes` raises if touched → still `too_large`)
  - normal body → `ok` (no regression)
- [x] all web_fetch suites green — 64 passed, 1 skipped
- [x] config-mirror gate #1056 green (18 passed)
- [x] `python scripts/test_tier_audit.py tests/test_web_fetch_download_cap_1913.py` — 0 violations
- [x] `ruff check` clean

## Tier self-check
4 new tests are Tier 2 (OS-invariant: byte-ceiling enforcement on real `handle_web_fetch` + real `OpContext`/`WebConfig`, no collaborator mocks). Docstrings declare `Tier 2:`. No private-state asserts, no len()-pinning, no golden files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
