### PR TITLE
fix(tui): AsyncStackPanel re-add during interrupt flash window

### DIFF
--- a/src/reyn/interfaces/tui/widgets/async_stack_panel.py
+++ b/src/reyn/interfaces/tui/widgets/async_stack_panel.py
@@ -291,10 +291,18 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         """Mount or update a running entry for ``agent_id``."""
         if not agent_id:
             return
+        # An ``agent_id`` re-added during its interrupt/abort flash window
+        # (= the async restarts, or a plan resumes under the same id) must
+        # return to a clean running state. Cancel the pending flash timer —
+        # otherwise it fires ~1.5 s later and yanks this LIVE row — and reset
+        # the flashing state so the row renders as ⟳ running, not ✗ interrupted.
+        self._cancel_flash_timer(agent_id)
         existing = self._entries.get(agent_id)
         if existing is not None:
             existing.summary = summary
             existing.pending_count = 0  # back to running on summary update
+            existing.flashing = False
+            existing.frozen_elapsed_s = None
         else:
             self._entries[agent_id] = _Entry(
                 summary=summary,

--- a/tests/cli/test_async_stack_readd_during_flash.py
+++ b/tests/cli/test_async_stack_readd_during_flash.py
@@ -1,0 +1,95 @@
+"""Tier 2: AsyncStackPanel re-add during the interrupt flash window.
+
+Bug: ``remove(agent_id, terminal="interrupted")`` arms a ~1.5 s flash timer
+that, on fire, deletes ``agent_id``'s entry. If the SAME ``agent_id`` is
+re-added via ``add()`` during that window (= the async/agent restarts, or a
+plan is resumed under the same id), the stale flash timer was neither
+cancelled nor the entry's ``flashing`` state reset. Consequences:
+
+  1. The freshly re-added (running) row renders as ``✗ ... (interrupted)``
+     because ``add()`` left ``flashing=True`` / ``frozen_elapsed_s`` set.
+  2. ~1.5 s later the stale timer fires and yanks the LIVE re-added row out
+     of the panel — a ghost removal of a running entry.
+
+These tests pin the correct behaviour: a re-add returns the entry to the
+running (non-flashing) state AND survives past the old flash deadline.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _panel_has_id(snap: list[dict], agent_id: str) -> bool:
+    return any(s["agent_id"] == agent_id for s in snap if not s["is_overflow"])
+
+
+def _panel_row(snap: list[dict], agent_id: str) -> dict | None:
+    for s in snap:
+        if s["agent_id"] == agent_id and not s["is_overflow"]:
+            return s
+    return None
+
+
+@pytest.mark.asyncio
+async def test_readd_during_flash_returns_to_running_state() -> None:
+    """Tier 2: re-adding an id mid-flash clears the interrupted flash state."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#conversation", ConversationView)._async_stack()
+        assert panel is not None
+
+        panel.add("a1", "running task")
+        await pilot.pause()
+        panel.remove("a1", terminal="interrupted")
+        await pilot.pause(0.1)  # inside the flash window
+
+        # Same agent restarts → re-add under the same id.
+        panel.add("a1", "restarted task")
+        await pilot.pause()
+
+        row = _panel_row(panel.snapshot(), "a1")
+        assert row is not None, "re-added row must be present"
+        assert row["flashing"] is False, (
+            "a re-added (running) row must NOT still be in the interrupted flash "
+            "state — add() must reset flashing"
+        )
+
+
+@pytest.mark.asyncio
+async def test_readd_during_flash_survives_old_timer() -> None:
+    """Tier 2: the stale flash timer must not yank a re-added live row."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#conversation", ConversationView)._async_stack()
+        assert panel is not None
+
+        panel.add("a2", "running task")
+        await pilot.pause()
+        panel.remove("a2", terminal="interrupted")
+        await pilot.pause(0.1)  # inside the flash window
+
+        panel.add("a2", "restarted task")
+        await pilot.pause()
+
+        # Past the ORIGINAL ~1.5 s flash deadline.
+        await pilot.pause(1.6)
+
+        assert _panel_has_id(panel.snapshot(), "a2"), (
+            "the re-added live row must survive past the old flash deadline — "
+            "add() must cancel the stale flash timer"
+        )


### PR DESCRIPTION
**[tui-coder]** — fix(tui): AsyncStackPanel re-add during interrupt flash window (concurrency/race lane)

## Bug (race, reachable)
`AsyncStackPanel.remove(agent_id, terminal="interrupted"|"aborted")` arms a ~1.5s flash timer that deletes `agent_id`'s entry when it fires. If the **same** `agent_id` is re-added via `add()` during that 1.5s window — e.g. an async/agent restarts, or a plan resumes under the same id — the stale flash timer was neither cancelled nor the entry's flash state reset. Two consequences:

1. **Visual**: the freshly re-added (running) row renders as `✗ ... (interrupted)` because `add()` left `flashing=True` / `frozen_elapsed_s` set.
2. **Ghost removal**: ~1.5s later the stale timer fires and yanks the **live** re-added row out of the panel — a running entry silently disappears.

`remove()`, `clear()`, and `_flush_now()` all already cancel flash timers; `add()` was the one mutator that didn't, so re-add was the gap.

## Fix
`add()` now, before mounting/updating, cancels any pending flash timer for the id and resets `flashing=False` / `frozen_elapsed_s=None` on the re-used entry — returning it to a clean running (⟳) state. One-line timer-cancel + two field resets; mirrors the existing discipline in the sibling mutators.

## Test plan
- [x] `tests/cli/test_async_stack_readd_during_flash.py` — 2 Tier-2, both confirmed **RED before the fix** (primary evidence: re-added row `a2` → `[]` snapshot after 1.6s):
  - re-add mid-flash clears the interrupted flash state (`flashing is False`)
  - re-added live row survives past the old flash deadline (timer cancelled)
- [x] `tests/cli/test_async_stack_interrupted_flash.py` — 7 existing flash tests still green (no regression to the interrupt-flash contract)
- [x] full async_stack suite — **39 passed**
- [x] `python scripts/test_tier_audit.py tests/cli/test_async_stack_readd_during_flash.py` — 0 violations
- [x] `ruff check` clean

## Tier self-check
2 new tests are Tier 2 (TUI-widget public-surface via `snapshot()` / `_panel_has_id` on a real `ReynTUIApp` Pilot harness — no private-state asserts, no mocks, no len()-pinning, no golden files). Docstrings declare `Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
