### PR TITLE
feat(1912b): control-IR op contextual gate — close the common-path bypass

### DIFF
--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -488,7 +488,10 @@ class ControlIRExecutor:
         _registry = get_default_registry()
 
         # Lazy import to avoid module-init cycles.
-        from reyn.core.op_runtime.contextual_gate import op_contextually_denied
+        from reyn.core.op_runtime.contextual_gate import (
+            contextual_denied_result,
+            op_contextually_denied,
+        )
         from reyn.core.op_runtime.registry import is_op_instance_allowed
 
         for op_idx, op in enumerate(ops):
@@ -509,17 +512,7 @@ class ControlIRExecutor:
             # ``contextual_permission is None`` → no narrowing (byte-identical).
             if op_contextually_denied(ctx.contextual_permission, op.kind):
                 self.events.emit("control_ir_contextually_denied", kind=op.kind)
-                results.append({
-                    "kind": op.kind,
-                    "status": "denied",
-                    "error": {
-                        "kind": "tool_excluded",
-                        "message": (
-                            f"op {op.kind!r} is excluded this session by the active "
-                            "capability profile; it is not available."
-                        ),
-                    },
-                })
+                results.append(contextual_denied_result(op.kind))
                 continue
 
             # Exclude None so unset optional fields are OMITTED rather than sent

--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -96,6 +96,7 @@ class ControlIRExecutor:
         run_id: str | None = None,
         sandbox_config: "SandboxConfig | None" = None,
         threat_scan: Any = None,  # FP-0050/#1822 S5 (EP4): exec command-scan config
+        contextual_permission: Any = None,  # #1912b: per-session capability narrowing → control-IR op gate
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
@@ -139,6 +140,7 @@ class ControlIRExecutor:
         # auto-detection (= unchanged behavior pre-wiring).
         self._sandbox_config = sandbox_config
         self._threat_scan = threat_scan
+        self._contextual_permission = contextual_permission  # #1912b
         # FP-0008 #1115 Stage 2: per-run injected exec backend instance. When
         # set (a dual-Protocol container backend), it takes precedence over
         # name-based platform selection in the sandboxed_exec handler
@@ -397,6 +399,7 @@ class ControlIRExecutor:
             sandbox_config=self._sandbox_config,
             # FP-0050/#1822 S5 (EP4): exec command-scan config.
             threat_scan=self._threat_scan,
+            contextual_permission=self._contextual_permission,  # #1912b
             # FP-0008 #1115 Stage 2: per-run injected exec backend instance
             # (dual-Protocol container backend); None → platform auto-detect.
             sandbox_backend=self._sandbox_backend,
@@ -485,6 +488,7 @@ class ControlIRExecutor:
         _registry = get_default_registry()
 
         # Lazy import to avoid module-init cycles.
+        from reyn.core.op_runtime.contextual_gate import op_contextually_denied
         from reyn.core.op_runtime.registry import is_op_instance_allowed
 
         for op_idx, op in enumerate(ops):
@@ -497,6 +501,24 @@ class ControlIRExecutor:
                     "kind": op.kind,
                     "status": "skipped",
                     "reason": "not_allowed_in_phase",
+                })
+                continue
+
+            # #1912b: the control-IR contextual gate — the SAME check as the chat /
+            # phase RouterLoop path (a narrowed agent's skill ops are enforced too).
+            # ``contextual_permission is None`` → no narrowing (byte-identical).
+            if op_contextually_denied(ctx.contextual_permission, op.kind):
+                self.events.emit("control_ir_contextually_denied", kind=op.kind)
+                results.append({
+                    "kind": op.kind,
+                    "status": "denied",
+                    "error": {
+                        "kind": "tool_excluded",
+                        "message": (
+                            f"op {op.kind!r} is excluded this session by the active "
+                            "capability profile; it is not available."
+                        ),
+                    },
                 })
                 continue
 

--- a/src/reyn/core/kernel/preprocessor_executor.py
+++ b/src/reyn/core/kernel/preprocessor_executor.py
@@ -113,6 +113,7 @@ class PreprocessorExecutor:
         sandbox_backend: "SandboxBackend | None" = None,
         agent_sandbox_policy: dict | None = None,
         threat_scan: "object | None" = None,  # FP-0050/#1822 S5 (EP4)
+        contextual_permission: "object | None" = None,  # #1912b: per-session capability narrowing → run_op/iterate gate
     ) -> None:
         self._skill = skill
         self._workspace = workspace
@@ -143,6 +144,7 @@ class PreprocessorExecutor:
         # makes the index write-gate fire there (#1321). None → no agent policy.
         self._agent_sandbox_policy = agent_sandbox_policy
         self._threat_scan = threat_scan
+        self._contextual_permission = contextual_permission  # #1912b
 
     @property
     def secret_store(self):
@@ -188,6 +190,7 @@ class PreprocessorExecutor:
             # preprocessor sandboxed_exec (deterministic; WINS over op fields).
             default_sandbox_policy=self._agent_sandbox_policy,
             threat_scan=self._threat_scan,  # FP-0050/#1822 S5 (EP4)
+            contextual_permission=self._contextual_permission,  # #1912b
         )
 
     async def run(
@@ -319,7 +322,18 @@ class PreprocessorExecutor:
                 _set_at_path(enriched, step.into, None)
                 return enriched, TokenUsage()
             return artifact, TokenUsage()
-        result = await execute_op(op, ctx, caller="preprocessor")
+        # #1912b: the same contextual gate as control-IR / RouterLoop — a narrowed
+        # agent's run_op preprocessor step cannot dispatch a denied op (the denied
+        # result flows through the on_error handling below). None → byte-identical.
+        from reyn.core.op_runtime.contextual_gate import (
+            contextual_denied_result,
+            op_contextually_denied,
+        )
+        if op_contextually_denied(ctx.contextual_permission, op.kind):
+            self._events.emit("preprocessor_contextually_denied", kind=op.kind)
+            result = contextual_denied_result(op.kind)
+        else:
+            result = await execute_op(op, ctx, caller="preprocessor")
 
         status = result.get("status")
         if status in ("error", "denied"):
@@ -408,7 +422,16 @@ class PreprocessorExecutor:
                 "preprocessor_iterate_item_started",
                 phase=phase_name, step_index=index, item_index=j,
             )
-            result = await execute_op(op_inst, ctx, caller="preprocessor")
+            # #1912b: contextual gate on each iterated op (same shared check).
+            from reyn.core.op_runtime.contextual_gate import (
+                contextual_denied_result,
+                op_contextually_denied,
+            )
+            if op_contextually_denied(ctx.contextual_permission, op_inst.kind):
+                self._events.emit("preprocessor_contextually_denied", kind=op_inst.kind)
+                result = contextual_denied_result(op_inst.kind)
+            else:
+                result = await execute_op(op_inst, ctx, caller="preprocessor")
             ctx.sub_state_dir_override = None
 
             status = result.get("status")

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -248,6 +248,7 @@ class OSRuntime:
             sandbox_backend=sandbox_backend,
             agent_sandbox_policy=self._agent_sandbox_policy,
             threat_scan=threat_scan,  # FP-0050/#1822 S5 (EP4)
+            contextual_permission=contextual_permission,  # #1912b: preprocessor run_op/iterate gate
         )
         # FP-0020 Component A: all mutable run-scope state encapsulated in RunState.
         self._state = RunState()

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -224,6 +224,7 @@ class OSRuntime:
             run_id=run_id,
             sandbox_config=sandbox_config,
             threat_scan=threat_scan,
+            contextual_permission=contextual_permission,  # #1912b: control-IR op gate
             sandbox_backend=sandbox_backend,
             multimodal_config=multimodal_config,
             media_store=media_store,

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -70,3 +70,20 @@ def op_contextually_denied(contextual: "object | None", op_kind: str) -> bool:
         tool_contextually_denied(contextual, name)
         for name in op_kind_tool_names(op_kind)
     )
+
+
+def contextual_denied_result(op_kind: str) -> dict:
+    """The decision-enabling denied result for an op blocked by the contextual
+    gate — one shared shape across every op-dispatch site (control-IR execute +
+    preprocessor run_op / iterate), so a narrowed agent sees the same signal."""
+    return {
+        "kind": op_kind,
+        "status": "denied",
+        "error": {
+            "kind": "tool_excluded",
+            "message": (
+                f"op {op_kind!r} is excluded this session by the active "
+                "capability profile; it is not available."
+            ),
+        },
+    }

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -1,0 +1,72 @@
+"""Contextual capability gate for control-IR ops (#1912b).
+
+The chat / phase RouterLoop tool gate (``router_loop._excluded_result``) and this
+control-IR op gate both call the SAME shared check
+(``effective.tool_contextually_denied``) — so a per-session contextual narrowing
+is enforced on every tool path, bypass-impossible by construction (#1912).
+
+A contextual ``tool_deny`` is expressed in *tool* names (the chat vocabulary,
+e.g. ``exec__sandboxed_exec``). A control-IR op has an *op kind* (e.g.
+``sandboxed_exec``). This module bridges the two: for an op kind it returns the
+contextual name-candidates = ``{kind}`` ∪ the chat-tool qualified aliases. The op
+kind itself is ALWAYS a candidate, so an un-aliased kind still gates on its own
+name — no op kind can silently bypass. ``_OP_KIND_ALIASES`` is exhaustive over
+``ALL_OP_KINDS`` (pinned by ``test_contextual_op_gate_completeness_1912``).
+"""
+from __future__ import annotations
+
+from reyn.security.permissions.effective import tool_contextually_denied
+
+# op kind → the chat-tool qualified aliases a contextual deny-set may use for it
+# (from the universal_dispatch _DISPATCH map). Empty when the op has no distinct
+# chat-tool qualified name (it is gated on its own kind name). Must cover every
+# entry of ``ALL_OP_KINDS`` — a missing entry would be a silent bypass.
+_OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
+    # file ops (file__* → fine-grained op kinds)
+    "read_file": frozenset({"file__read"}),
+    "write_file": frozenset({"file__write"}),
+    "delete_file": frozenset({"file__delete"}),
+    "edit_file": frozenset({"file__edit"}),
+    "glob_files": frozenset({"file__glob"}),
+    "grep_files": frozenset({"file__grep"}),
+    # web
+    "web_search": frozenset({"web__search"}),
+    "web_fetch": frozenset({"web__fetch"}),
+    # rag / memory-read
+    "recall": frozenset({"rag_operation__recall"}),
+    "index_query": frozenset(),
+    "index_drop": frozenset({"rag_operation__drop_source"}),
+    # exec (the dangerous one — both forms)
+    "sandboxed_exec": frozenset({"exec__sandboxed_exec"}),
+    # validation
+    "lint": frozenset({"validation__lint"}),
+    # mcp: the install surface is its OWN op kind (precisely gated); the generic
+    # ``mcp`` op (call_tool / list / …) is gated on its kind name (per-verb deny
+    # is a follow-up — the built-in untrusted profile denies install, not call).
+    "mcp_install": frozenset({
+        "mcp__install_registry", "mcp__install_package", "mcp__install_local",
+    }),
+    "mcp": frozenset(),
+    # control-IR-only ops with no distinct chat-tool qualified name → kind only.
+    "run_skill": frozenset(),
+    "skill_resolve": frozenset(),
+    "judge_output": frozenset(),
+    "compact": frozenset(),
+    "ask_user": frozenset(),
+}
+
+
+def op_kind_tool_names(op_kind: str) -> "frozenset[str]":
+    """The contextual name-candidates for a control-IR op kind: the kind itself
+    plus its chat-tool qualified aliases."""
+    return frozenset({op_kind}) | _OP_KIND_ALIASES.get(op_kind, frozenset())
+
+
+def op_contextually_denied(contextual: "object | None", op_kind: str) -> bool:
+    """True iff the per-session contextual narrowing denies this control-IR op
+    (by any of its name candidates). Shares the RouterLoop path's check
+    (``tool_contextually_denied``) so enforcement is a single seam."""
+    return any(
+        tool_contextually_denied(contextual, name)
+        for name in op_kind_tool_names(op_kind)
+    )

--- a/tests/test_control_ir_contextual_gate_1912.py
+++ b/tests/test_control_ir_contextual_gate_1912.py
@@ -44,6 +44,19 @@ def test_op_kind_always_self_named():
         assert kind in op_kind_tool_names(kind)
 
 
+def test_alias_values_are_valid_qualified_names():
+    """Tier 2: every alias VALUE is a real qualified name (a key in the dispatch
+    map) — so a future rename of a qualified name breaks THIS test, keeping the
+    alias map drift-proof. Without this, a stale alias would silently let a
+    qualified-named deny leak past the control-IR gate (the keys-only completeness
+    test cannot catch a value drift)."""
+    from reyn.tools.universal_dispatch import _OPERATION_RULES, _RESOURCE_RULES
+    valid = set(_OPERATION_RULES) | set(_RESOURCE_RULES)
+    for kind, aliases in _OP_KIND_ALIASES.items():
+        for alias in aliases:
+            assert alias in valid, f"{kind}: alias {alias!r} is not a current qualified name"
+
+
 def test_dangerous_deny_entries_reach_their_ops():
     """Tier 2: the built-in untrusted deny-set entries that map to ops do block
     them — via BOTH the qualified and the unwrapped form."""

--- a/tests/test_control_ir_contextual_gate_1912.py
+++ b/tests/test_control_ir_contextual_gate_1912.py
@@ -153,3 +153,44 @@ def test_osruntime_threads_contextual_to_control_ir(tmp_path, monkeypatch):
     )
     assert results[0]["status"] == "denied"
     assert results[0]["error"]["kind"] == "tool_excluded"
+
+
+# ── completeness: the 4th dispatch site — preprocessor run_op (#1912b) ───────
+
+
+class _NeverRunBackend:
+    """Sandbox backend that fails if reached — a denied op must never get here."""
+
+    async def run(self, *a, **k):
+        raise AssertionError("a contextually-denied op must NOT reach the sandbox backend")
+
+
+def test_preprocessor_run_op_is_gated(tmp_path):
+    """Tier 2: a narrowed agent's run_op preprocessor step cannot dispatch a
+    denied op — the gate fires before execute_op, so the sandbox backend is never
+    reached (built-in CLEAN RED: an un-gated path would raise AssertionError)."""
+    from reyn.core.kernel.preprocessor_executor import PreprocessorExecutor
+    from reyn.schemas.models import Phase, RunOpStep
+
+    events = EventLog()
+    phase = Phase(
+        name="pp", instructions="d", input_schema={"type": "object", "properties": {}},
+        allowed_ops=["sandboxed_exec"],
+        preprocessor=[RunOpStep(
+            type="run_op",
+            op=SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "x"]),
+            into="data._exec", on_error="skip",
+        )],
+    )
+    pe = PreprocessorExecutor(
+        skill=_one_phase_skill(),
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        model="standard", events=events, subscribers=[], resolver=None,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=tmp_path, interactive=False),
+        sandbox_backend=_NeverRunBackend(),
+        contextual_permission=ContextualPermission(tool_deny=frozenset({"sandboxed_exec"})),
+    )
+    # No AssertionError = the denied op never reached the backend (gated).
+    asyncio.run(pe.run(phase, {"type": "x", "data": {}}, None))
+    assert any(e.type == "preprocessor_contextually_denied" for e in events.all())

--- a/tests/test_control_ir_contextual_gate_1912.py
+++ b/tests/test_control_ir_contextual_gate_1912.py
@@ -1,0 +1,155 @@
+"""Tier 2: control-IR op contextual gate (#1912b).
+
+The default (json-mode) skill phase dispatches ops via
+``ControlIRExecutor.execute`` — the common path a narrowed agent's skill takes.
+#1912b gates that path through the SAME shared check as the chat / phase
+RouterLoop (``tool_contextually_denied``), so contextual narrowing is enforced on
+every tool path (bypass-impossible by construction).
+
+Pins: (a) the op-kind↔tool-name mapping is EXHAUSTIVE over ALL_OP_KINDS (a gap =
+silent bypass); (b) the dangerous deny-set entries reach their ops; (c) the REAL
+``execute`` denies a contextually-denied op and an un-narrowed executor does not
+(CLEAN RED). No mocks — real ControlIRExecutor + real execute().
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.core.kernel.control_ir_executor import ControlIRExecutor
+from reyn.core.op_runtime.contextual_gate import (
+    _OP_KIND_ALIASES,
+    op_contextually_denied,
+    op_kind_tool_names,
+)
+from reyn.core.op_runtime.registry import ALL_OP_KINDS
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import SandboxedExecIROp
+from reyn.security.permissions.effective import ContextualPermission
+from reyn.security.permissions.permissions import PermissionResolver
+
+# ── steer 1: mapping completeness (no silent bypass) ────────────────────────
+
+
+def test_mapping_covers_all_op_kinds():
+    """Tier 2: every op kind is mapped — a missing entry would silently bypass."""
+    assert set(_OP_KIND_ALIASES) == set(ALL_OP_KINDS)
+
+
+def test_op_kind_always_self_named():
+    """Tier 2: an op's candidates always include its own kind (un-aliased kinds
+    still gate on their name)."""
+    for kind in ALL_OP_KINDS:
+        assert kind in op_kind_tool_names(kind)
+
+
+def test_dangerous_deny_entries_reach_their_ops():
+    """Tier 2: the built-in untrusted deny-set entries that map to ops do block
+    them — via BOTH the qualified and the unwrapped form."""
+    # exec: qualified form blocks the sandboxed_exec op
+    assert op_contextually_denied(
+        ContextualPermission(tool_deny=frozenset({"exec__sandboxed_exec"})), "sandboxed_exec",
+    )
+    # exec: unwrapped form also blocks it
+    assert op_contextually_denied(
+        ContextualPermission(tool_deny=frozenset({"sandboxed_exec"})), "sandboxed_exec",
+    )
+    # mcp install: qualified form blocks the mcp_install op
+    assert op_contextually_denied(
+        ContextualPermission(tool_deny=frozenset({"mcp__install_registry"})), "mcp_install",
+    )
+    # router-only deny targets have NO op kind (chat gate covers them)
+    assert "delegate_to_agent" not in ALL_OP_KINDS
+    assert "remember_shared" not in ALL_OP_KINDS
+
+
+def test_op_gate_inert_when_no_narrowing():
+    """Tier 2: None contextual → never denied (byte-identical)."""
+    assert op_contextually_denied(None, "sandboxed_exec") is False
+    assert op_contextually_denied(
+        ContextualPermission(tool_deny=frozenset({"recall"})), "sandboxed_exec",
+    ) is False
+
+
+# ── steer 3: the REAL execute() gate (CLEAN RED) ────────────────────────────
+
+
+def _executor(tmp_path: Path, *, contextual=None) -> ControlIRExecutor:
+    events = EventLog()
+    return ControlIRExecutor(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={}, project_root=tmp_path, interactive=False,
+        ),
+        skill_name="s",
+        chain_id="c",
+        contextual_permission=contextual,
+    )
+
+
+def test_execute_denies_contextually_denied_op(tmp_path, monkeypatch):
+    """Tier 2: a narrowed ControlIRExecutor denies a denied op at execute() —
+    the same path the default json-mode phase uses. The denied op never reaches
+    its handler (the gate returns status='denied' first)."""
+    monkeypatch.chdir(tmp_path)
+    ex = _executor(
+        tmp_path,
+        contextual=ContextualPermission(tool_deny=frozenset({"sandboxed_exec"})),
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["echo", "hi"])
+    results = asyncio.run(ex.execute([op], phase="p", allowed_ops={"sandboxed_exec"}))
+    assert results[0]["status"] == "denied"
+    assert results[0]["error"]["kind"] == "tool_excluded"
+
+
+def test_execute_un_narrowed_does_not_deny(tmp_path, monkeypatch):
+    """Tier 2: with no contextual the same op is NOT denied at the gate (CLEAN RED
+    contrast — it proceeds past the gate to dispatch). Falsify: if the gate fired
+    unconditionally this would be 'denied'."""
+    monkeypatch.chdir(tmp_path)
+    ex = _executor(tmp_path)  # no contextual
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["echo", "hi"])
+    results = asyncio.run(ex.execute([op], phase="p", allowed_ops={"sandboxed_exec"}))
+    # not gated as tool_excluded (it may still error later for other reasons,
+    # but NOT the contextual denial).
+    assert not (
+        results[0].get("status") == "denied"
+        and results[0].get("error", {}).get("kind") == "tool_excluded"
+    )
+
+
+# ── steer 3: threading flows (OSRuntime → ControlIRExecutor) ─────────────────
+
+
+def _one_phase_skill():
+    from reyn.schemas.models import Phase, Skill, SkillGraph
+    p = Phase(name="draft", instructions="d",
+              input_schema={"type": "object", "properties": {}}, allowed_ops=["sandboxed_exec"])
+    return Skill(
+        name="ctx_test", entry_phase="draft", phases={"draft": p},
+        graph=SkillGraph(transitions={}, can_finish_phases=["draft"]),
+        final_output_schema={"type": "object", "properties": {}}, final_output_name="result",
+    )
+
+
+def test_osruntime_threads_contextual_to_control_ir(tmp_path, monkeypatch):
+    """Tier 3a: a narrowed OSRuntime threads contextual to its ControlIRExecutor
+    so a denied op is blocked — proving the per-session contextual FLOWS through
+    skill execution (Session→SkillRuntime→OSRuntime→ControlIRExecutor), not just
+    that the executor gate works in isolation. Falsify: without the OSRuntime→CIE
+    thread the op would not be denied (it would dispatch)."""
+    from reyn.core.kernel.runtime import OSRuntime
+    monkeypatch.chdir(tmp_path)
+    rt = OSRuntime(
+        _one_phase_skill(), model="stub/model", run_id="r",
+        workspace_base_dir=tmp_path,
+        contextual_permission=ContextualPermission(tool_deny=frozenset({"sandboxed_exec"})),
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["echo", "hi"])
+    results = asyncio.run(
+        rt.control_ir_executor.execute([op], phase="draft", allowed_ops={"sandboxed_exec"})
+    )
+    assert results[0]["status"] == "denied"
+    assert results[0]["error"]["kind"] == "tool_excluded"


### PR DESCRIPTION
**[e2e-coder]** — #1912 **b** (control-IR op gate — the common-path half). #1912a (#1920) merged. This closes the **larger** half: the DEFAULT (json-mode) skill phase dispatches ops via `ControlIRExecutor.execute` — the common path a narrowed agent's skill takes.

## What
Gates the control-IR op dispatch through the **SAME shared check** as the chat / phase RouterLoop (`effective.tool_contextually_denied`) → contextual narrowing is enforced on **every** tool path, bypass-impossible by construction.

- **`contextual_gate.py`**: `op_kind_tool_names` (op kind ∪ chat-tool qualified aliases) + `op_contextually_denied`. The op kind is **always** a name candidate → an un-aliased kind still gates on its own name (no silent bypass). `_OP_KIND_ALIASES` is **exhaustive over `ALL_OP_KINDS`** (pinned — steer 1).
- **`control_ir_executor.execute`**: a pre-handler gate denies a contextually-denied op (`status="denied"` / `tool_excluded`, decision-enabling) before the handler runs.
- **Threading**: `OSRuntime → ControlIRExecutor → OpContext`, completing the `Session→SkillRuntime→OSRuntime` chain from #1912a.

## Mapping (steer 1 — every deny-set entry accounted for)
`sandboxed_exec` / `mcp_install` (dangerous, **have** op kinds) → gated via **both** qualified (`exec__sandboxed_exec`, `mcp__install_*`) + unwrapped forms. `delegate` / memory-writes have **no** op kind → router-only (the chat gate covers them).

## Test plan (real ControlIRExecutor + real execute(), no mocks)
- [x] **Mapping completeness** over `ALL_OP_KINDS` (steer 1) + op-kind self-named.
- [x] Dangerous deny entries reach their ops (qualified + unwrapped).
- [x] The **REAL `execute()`** denies a denied op; un-narrowed does **not** (CLEAN RED contrast). **Falsification-verified**: removing the gate reds the deny test (reverted).
- [x] **Threading-flows** (steer 3): a narrowed **OSRuntime** threads contextual to its `ControlIRExecutor` so the op is blocked — proving the contextual **flows through skill execution**, not just the gate in isolation.
- [x] Byte-identical: control-IR/kernel/skill suites **245 passed**; tier-audit + ruff clean.

## Result
With #1912a + #1912b, `effective.py` is the **truly single tool gate** across chat + phase + control-IR — the phase-path bypass is closed (the over-claim corrected).

Forward: per-MCP-verb deny for the generic `mcp` op; #1199 `require_tool` static-authority live-wiring. Refs #1912. **Closes #1912.** S4b (#1827 context-auto) resumes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
