### PR TITLE
fix(tui): route F-key action hints through the shared transient timer

### DIFF
--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -269,6 +269,12 @@ class ReynTUIApp(App):
         # outbox loop (= Ctrl+G / Ctrl+Shift+G ``/find`` cycle navigation)
         # can reach the find-cycle state living on the router.
         self._outbox_router = None  # type: ignore[assignment]
+        # Pre-drain fallback handle for action-hint auto-hide. Once the
+        # OutboxRouter exists, action hints share ITS single transient handle
+        # (so a live-status / stream-start takeover cancels them too); this
+        # app-local handle only carries the no-registry / pre-drain case where
+        # no router (hence no cross-source transient) exists yet.
+        self._action_hint_timer = None  # type: ignore[assignment]
         self._panel_visible = False
         # ADR-0038 1f: the mounted RewindMenuWidget while the /rewind picker is
         # open, else None. Navigation (↑/↓/Enter) + Esc dismiss are gated on
@@ -1685,6 +1691,46 @@ class ReynTUIApp(App):
             return
         router.cycle_find(-1)
 
+    def _show_action_hint(
+        self,
+        conv: "ConversationView",
+        text: str,
+        *,
+        kind: str = "general",
+        duration: float = 2.0,
+    ) -> None:
+        """Show a transient F-key status hint that auto-hides after ``duration`` s.
+
+        Routes through the OutboxRouter's single transient handle
+        (``_show_transient_status``) so the hint shares ONE auto-hide timer
+        with the outbox transients (``/copy``, ``/cost-inline``, …). That is
+        what lets a load-bearing takeover — a live ``thinking…`` status
+        (``_on_status``), a stream start, or an ``/attach`` — cancel a pending
+        hint timer before it can fire and hide the live indicator. Using a
+        private ``set_timer(hide_status)`` per keypress (the prior behaviour)
+        left those hints invisible to that cancellation, so a stale hint
+        auto-hide could kill the ``⟳ thinking…`` spinner or a newer error.
+
+        When the router does not exist yet (no registry / pre-drain), fall
+        back to an app-owned single cancellable handle — there are no outbox
+        transients in that state, so a single app-local handle is sufficient.
+        """
+        router = self._outbox_router
+        if router is not None:
+            router._show_transient_status(conv, text, kind=kind, duration=duration)
+            return
+        if self._action_hint_timer is not None:
+            try:
+                self._action_hint_timer.stop()
+            except Exception:
+                pass
+            self._action_hint_timer = None
+        try:
+            conv.show_status(text, kind=kind)
+            self._action_hint_timer = self.set_timer(duration, conv.hide_status)
+        except Exception:
+            pass
+
     def _maybe_emit_f3_tip(
         self,
         show_status_fn: "Callable[[str], None]",
@@ -1751,26 +1797,25 @@ class ReynTUIApp(App):
         except Exception:
             return
         # First-use tip fires regardless of whether any rows are
-        # in flight — teaching what F3 does is useful either way.
+        # in flight — teaching what F3 does is useful either way. The tip is
+        # shown (and auto-hidden after ~4 s) through the shared transient
+        # handle so a turn starting mid-tip cancels it instead of killing the
+        # live indicator.
         tip_shown = self._maybe_emit_f3_tip(
-            lambda msg: conv.show_status(msg, kind="general"),
+            lambda msg: self._show_action_hint(
+                conv, msg, kind="general", duration=4.0,
+            ),
         )
         skill_rows = conv.in_flight_skill_rows()
         tool_rows = conv.in_flight_tool_call_rows()
         rows: list = list(skill_rows) + list(tool_rows)
         if not rows:
-            if tip_shown:
-                # Tip replaces the "no rows" hint for this first press only;
-                # auto-hide after ~4 s.
-                self.set_timer(4.0, conv.hide_status)
-            else:
-                try:
-                    conv.show_status(
-                        "no active rows to expand", kind="general",
-                    )
-                    self.set_timer(2.0, conv.hide_status)
-                except Exception:
-                    pass
+            # Tip (already shown + auto-hiding) replaces the "no rows" hint for
+            # the first press only; otherwise show the transient "no rows" hint.
+            if not tip_shown:
+                self._show_action_hint(
+                    conv, "no active rows to expand", duration=2.0,
+                )
             return
         # Pick a single target state for THIS keypress so the set
         # converges. Without this, F3 on a mixed set (one expanded,
@@ -1780,9 +1825,8 @@ class ReynTUIApp(App):
         for row in rows:
             if row.is_expanded != target_expand:
                 row.toggle_expand()
-        if tip_shown:
-            # Auto-hide the tip after ~4 s once expand has been applied.
-            self.set_timer(4.0, conv.hide_status)
+        # The tip (if shown) was already armed to auto-hide via the shared
+        # transient handle by the callback above — no separate timer needed.
 
     def action_focus_async_stack(self) -> None:
         """F4 — focus the bottom AsyncStackPanel for keyboard navigation.
@@ -1801,10 +1845,9 @@ class ReynTUIApp(App):
         if not panel.snapshot():
             try:
                 conv = self.query_one("#conversation", ConversationView)
-                conv.show_status(
-                    "no active tasks in async strip", kind="general",
+                self._show_action_hint(
+                    conv, "no active tasks in async strip", duration=2.0,
                 )
-                self.set_timer(2.0, conv.hide_status)
             except Exception:
                 pass
             return
@@ -1837,8 +1880,9 @@ class ReynTUIApp(App):
         row = conv.latest_failed_tool_row()
         if row is None:
             try:
-                conv.show_status("no recent tool failure", kind="general")
-                self.set_timer(2.0, conv.hide_status)
+                self._show_action_hint(
+                    conv, "no recent tool failure", duration=2.0,
+                )
             except Exception:
                 pass
             return
@@ -1854,11 +1898,11 @@ class ReynTUIApp(App):
         if not still_mounted:
             # Row already in scroll history -- point at events for full trace.
             try:
-                conv.show_status(
+                self._show_action_hint(
+                    conv,
                     "tool row flushed — Ctrl+B → Events tab for full trace",
-                    kind="general",
+                    duration=3.0,
                 )
-                self.set_timer(3.0, conv.hide_status)
             except Exception:
                 pass
             return
@@ -1882,8 +1926,7 @@ class ReynTUIApp(App):
         new_state = conv.toggle_timestamps()
         label = "on" if new_state else "off"
         try:
-            conv.show_status(f"timestamps: {label}", kind="general")
-            self.set_timer(2.0, conv.hide_status)
+            self._show_action_hint(conv, f"timestamps: {label}", duration=2.0)
         except Exception:
             pass
 

--- a/tests/cli/test_action_hint_shared_transient_timer.py
+++ b/tests/cli/test_action_hint_shared_transient_timer.py
@@ -1,0 +1,97 @@
+"""Tier 2: F-key action status hints share the single transient auto-hide handle.
+
+The F-key hints (F3 expand tip / "no active rows", F4 "no active tasks",
+F7 "no recent tool failure" / "row flushed", F9 "timestamps: …") armed a RAW
+``self.set_timer(N, conv.hide_status)`` instead of going through the
+``OutboxRouter`` single-handle seam (``_show_transient_status`` /
+``_cancel_transient_timer``) that the outbox transients (``/copy``,
+``/cost-inline``, …) use.
+
+Consequences of the separate, untracked timer:
+  • A live status / agent reply taking over the sticky (``_on_status`` /
+    ``_on_stream_start``) cancels the ROUTER's handle — but NOT a stale
+    action-hint timer. So a hint armed just before a turn started would fire
+    ~N s in and hide the live ``⟳ thinking…`` indicator (= the exact Async-F4
+    race the router seam fixed, left open on the keypress path).
+  • Two transients from different sources (an outbox ``/copy`` + an F-key hint)
+    each kept their own timer; the older one hid the newer sticky.
+
+Fix: action hints route through the same single transient handle, so any
+load-bearing takeover (live status, stream start, attach) or a newer transient
+cancels them too.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.tui.app import ReynTUIApp
+from reyn.interfaces.tui.app_outbox import OutboxRouter
+from reyn.interfaces.tui.widgets import ConversationView, ReynHeader
+from reyn.interfaces.tui.widgets.sticky_status import StickyStatus
+from reyn.runtime.outbox import OutboxMessage
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None, agent_name="aria", model="test-model", budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_action_hint_arms_shared_transient_handle() -> None:
+    """Tier 2: an F-key hint arms the router's single transient timer handle."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        # Simulate the drain being active so the shared router seam exists.
+        router = OutboxRouter(app)
+        app._outbox_router = router
+
+        # F4 with an empty async strip → "no active tasks in async strip" hint.
+        app.action_focus_async_stack()
+        await pilot.pause()
+
+        assert router.has_transient_status_timer(), (
+            "an F-key action hint must arm the SHARED transient handle "
+            "(not a private untracked set_timer)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_live_status_cancels_stale_action_hint_timer() -> None:
+    """Tier 2: a live status takeover cancels a pending action-hint timer.
+
+    Otherwise the stale hint timer fires mid-turn and hides the live
+    ``thinking…`` indicator (Async-F4 race on the keypress path).
+    """
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        header = app.query_one("#header", ReynHeader)
+        router = OutboxRouter(app)
+        app._outbox_router = router
+
+        # Arm an action hint (F4, empty strip).
+        app.action_focus_async_stack()
+        await pilot.pause()
+        assert router.has_transient_status_timer()
+
+        # A live status arrives — the takeover must cancel the hint's timer.
+        router._on_status(
+            OutboxMessage(kind="status", text="thinking…"), conv, header,
+        )
+        assert not router.has_transient_status_timer(), (
+            "a live-status takeover must cancel the pending action-hint timer "
+            "so it cannot later hide the live indicator"
+        )
+        assert conv.query_one("#sticky-status", StickyStatus).has_class("active"), (
+            "the live status must be showing after the takeover"
+        )


### PR DESCRIPTION
**[tui-coder]** — fix(tui): route F-key action hints through the shared transient timer (concurrency/race lane, completeness gap)

## Bug (stale-deferred-timer race, completeness gap)
The OutboxRouter already has a single-handle transient seam — `_show_transient_status` arms ONE tracked auto-hide timer and `_cancel_transient_timer` cancels it; the load-bearing takeover flows (`_on_status` live `thinking…`, `_on_stream_start`, `_on_attach_request`) all cancel that handle so a stale transient can't hide a live indicator. This fixed the Async-F1/F4 / Multi-F1 races for **outbox** transients (`/copy`, `/cost-inline`, …).

But the **F-key action hints** (F3 expand tip / "no active rows", F4 "no active tasks", F7 "no recent tool failure" / "row flushed", F9 "timestamps: …") armed a **raw** `self.set_timer(N, conv.hide_status)`, bypassing that seam. Since the hint timer was untracked:
- A turn starting (live `_on_status`) cancels the router handle but **not** a stale hint timer → a hint armed just before the turn fires ~N s in and **hides the live `⟳ thinking…` indicator** (Async-F4 race, left open on the keypress path).
- A hint + an outbox transient each keep their own timer; the older one hides the newer sticky.

Classic completeness gap — same decision (auto-hide a transient sticky) wired safely on one path, raw on the sibling path.

## Fix
New `_show_action_hint(conv, text, *, kind, duration)` routes hints through the router's **shared** transient handle when the drain is active (so any takeover / newer transient cancels them too), with an app-owned single cancellable fallback handle for the no-registry / pre-drain case (where no outbox transient — hence no cross-source collision — can exist). All 7 raw hint sites now go through it; the F3 tip's show + auto-hide both flow through the shared handle via its callback (removing two redundant `set_timer`s).

## Test plan
- [x] `tests/cli/test_action_hint_shared_transient_timer.py` — 2 Tier-2, both confirmed **RED before the fix**:
  - an F-key hint arms the SHARED transient handle (`has_transient_status_timer()`)
  - a live-status takeover (`_on_status`) cancels the pending hint timer so it can't later hide the live indicator
- [x] `tests/cli/test_sticky_timer_cancellation.py` + sticky / async_stack / smoke regression — **229 passed**
- [x] `python scripts/test_tier_audit.py tests/cli/test_action_hint_shared_transient_timer.py` — 0 violations
- [x] `ruff check` clean

## Tier self-check
2 new tests are Tier 2 (public surface: `has_transient_status_timer()` + `StickyStatus.has_class("active")` on a real `ReynTUIApp` Pilot harness; the `_outbox_router` assignment is test setup, not an assertion — asserts use the public `transient_status_timer` accessor). No private-state asserts, no mocks, no golden files. Docstrings declare `Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
