### PR TITLE
fix(security/sandbox): enforce allow_subprocess on macOS Seatbelt (#1914)

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -337,7 +337,7 @@ The `sandboxed_exec` policy (`SandboxPolicy`) is scoped **per axis**. The axes a
 |---|---|---|
 | write | tight workspace-allowlist (`write_paths`) | The hard guard — bounds what a process can persist. |
 | network | tight (off by default / allowlist) | The exfiltration gate — a process may read widely but cannot send anything out. |
-| exec | controlled (`allow_subprocess`) | Bounds child-process spawning (advisory under Seatbelt). |
+| exec | controlled (`allow_subprocess`) | Bounds child-process spawning (enforced on Linux via seccomp, macOS via Seatbelt). |
 | read | **broad-allow by default** + optional sensitive deny-list | The strict read-allowlist was abolished (#1199 realignment). |
 
 **Why broad read is safe.** The network gate, not the read surface, is the exfiltration control. With network off by default a process may read widely but cannot send data out. A broad read surface also removes the system-path enumeration (`/usr`, `/lib`, dyld cache, …) that every binary needs just to load — enumeration that, when missing, broke the Landlock backend on Linux. This matches industry practice: Codex defaults to broad read + network-off on Linux; Claude Code treats read-restriction as secondary ("affects functionality") behind its write / network guards.

--- a/docs/concepts/runtime/sandbox.ja.md
+++ b/docs/concepts/runtime/sandbox.ja.md
@@ -19,7 +19,7 @@ Reyn のサンドボックスレイヤーは、スキルが宣言したポリシ
 | `network` | `bool` | `false` | アウトバウンドネットワーク接続を許可 |
 | `read_paths` | `list[str]` | `[]` | サブプロセスが読み取り可能なファイルシステムパス（glob パターンおよび `{{workspace}}` テンプレート可） |
 | `write_paths` | `list[str]` | `[]` | サブプロセスが書き込み可能なファイルシステムパス |
-| `allow_subprocess` | `bool` | `false` | サブプロセスが子プロセスを生成することを許可 |
+| `allow_subprocess` | `bool` | `false` | サンドボックス対象プロセスが子プロセスを生成することを許可。Linux (seccomp) / macOS (Seatbelt) で適用（off の時 `process-fork` を deny、対象自身の exec は `process-exec*` で動作）。 |
 | `env_passthrough` | `list[str]` | `[]` | サブプロセスに引き渡す環境変数名（それ以外はすべて除去） |
 | `timeout_seconds` | `int` | `60` | ウォールクロック上限（超過時にプロセスを強制終了） |
 

--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -20,7 +20,7 @@ Defined in `src/reyn/security/sandbox/policy.py`. Passed as fields on a `sandbox
 | `write_paths` | `list[str]` | `[]` | Filesystem paths the subprocess may write (tight guard). |
 | `read_deny_paths` | `list[str]` | [OS credential paths] | Sensitive paths denied from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt). Default: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker/config.json`, `~/.netrc`. |
 | `read_paths` | `list[str]` | `[]` | **Legacy** — formerly the read allowlist. Under the current broad-read model reads are not restricted to this list; retained for backward compatibility and as documentation of intended read targets. |
-| `allow_subprocess` | `bool` | `false` | Allow the subprocess to spawn child processes. Advisory under Seatbelt (process-fork always permitted for binary bootstrap). |
+| `allow_subprocess` | `bool` | `false` | Allow the sandboxed process to spawn child processes. Enforced on Linux (seccomp) and macOS (Seatbelt: `process-fork` denied when off; the target's own exec still works via `process-exec*`). |
 | `env_passthrough` | `list[str]` | `[]` | Environment variable names passed through to the subprocess (all others are stripped). `PATH` is always passed. |
 | `timeout_seconds` | `int` | `60` | Wall-clock limit; process is killed on expiry. |
 

--- a/docs/guide/for-users/configure-sandbox.ja.md
+++ b/docs/guide/for-users/configure-sandbox.ja.md
@@ -86,7 +86,7 @@ SBPL deny-default プロファイルを使った `sandbox-exec` を使用。macO
 | `write_paths` | 適用 |
 | `network` | 適用 |
 | `read_deny_paths` | **適用** — SBPL deny-after-allow |
-| `allow_subprocess` | **適用** — off の時 `process-fork` を deny（対象自身の exec は `process-exec*` で動作、#1914） |
+| `allow_subprocess` | **適用** — off の時 `process-fork` を deny（対象自身の exec は `process-exec*` で動作） |
 | `timeout_seconds` | 適用 |
 
 ### Landlock（Linux）

--- a/docs/guide/for-users/configure-sandbox.ja.md
+++ b/docs/guide/for-users/configure-sandbox.ja.md
@@ -62,7 +62,7 @@ sandbox:
 | `write_paths` | パスのリスト | `[]` | プロセスが書き込めるパス（厳密なガード）。書き込みは読み取りを含む。 |
 | `read_deny_paths` | パスのリスト | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。Landlock では非対応。 |
 | `read_paths` | パスのリスト | `[]` | レガシー — かつての厳密な読み込み許可リスト。現在、読み込みはデフォルトで広許可のためこのフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
-| `allow_subprocess` | bool | `false` | 子プロセスの生成を許可。Seatbelt では advisory 扱い。 |
+| `allow_subprocess` | bool | `false` | 子プロセスの生成を許可。Linux (seccomp) / macOS (Seatbelt) ともに適用。 |
 | `env_passthrough` | 文字列のリスト | `[]` | プロセスに引き渡す環境変数名。`PATH` は常に引き渡されます。 |
 | `timeout_seconds` | int | `60` | ウォールクロック制限。期限超過でプロセスを終了。 |
 
@@ -86,7 +86,7 @@ SBPL deny-default プロファイルを使った `sandbox-exec` を使用。macO
 | `write_paths` | 適用 |
 | `network` | 適用 |
 | `read_deny_paths` | **適用** — SBPL deny-after-allow |
-| `allow_subprocess` | Advisory — バイナリブートストラップには process-fork が常時許可 |
+| `allow_subprocess` | **適用** — off の時 `process-fork` を deny（対象自身の exec は `process-exec*` で動作、#1914） |
 | `timeout_seconds` | 適用 |
 
 ### Landlock（Linux）

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -68,7 +68,7 @@ restriction: op-level fields govern, and the SandboxLayer is unrestricted.
 | `write_paths` | list of paths | `[]` | Paths the process may write (tight guard). Write implies read. |
 | `read_deny_paths` | list of paths | `[]` | Sensitive paths to deny from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. |
 | `read_paths` | list of paths | `[]` | Legacy — formerly the strict read allowlist. Reads are broad by default; this field now documents intended read targets only. |
-| `allow_subprocess` | bool | `false` | Allow child-process spawning. Advisory under Seatbelt. |
+| `allow_subprocess` | bool | `false` | Allow child-process spawning. Enforced on Linux (seccomp) and macOS (Seatbelt). |
 | `env_passthrough` | list of strings | `[]` | Env vars passed through to the process. `PATH` is always passed. |
 | `timeout_seconds` | int | `60` | Wall-clock limit; process is killed on expiry. |
 
@@ -96,7 +96,7 @@ on macOS.
 | `write_paths` | Enforced |
 | `network` | Enforced |
 | `read_deny_paths` | **Enforced** — SBPL deny-after-allow |
-| `allow_subprocess` | Advisory — process-fork always permitted for binary bootstrap |
+| `allow_subprocess` | **Enforced** — denies `process-fork` when off; the target's own exec still works via `process-exec*` (#1914) |
 | `timeout_seconds` | Enforced |
 
 ### Landlock (Linux)

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -96,7 +96,7 @@ on macOS.
 | `write_paths` | Enforced |
 | `network` | Enforced |
 | `read_deny_paths` | **Enforced** — SBPL deny-after-allow |
-| `allow_subprocess` | **Enforced** — denies `process-fork` when off; the target's own exec still works via `process-exec*` (#1914) |
+| `allow_subprocess` | **Enforced** — denies `process-fork` when off; the target's own exec still works via `process-exec*` |
 | `timeout_seconds` | Enforced |
 
 ### Landlock (Linux)

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -70,13 +70,26 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
         '(import "bsd.sb")',
     ]
 
-    # Always-allowed process-exec: without this, sandbox-exec cannot even
+    # process-exec* is always allowed: without it sandbox-exec cannot even
     # execvp() the target binary under (deny default) (macOS 26+ is strict).
-    # process-fork is similarly needed by virtually every interpreter / runtime
-    # bootstrap (e.g. CRT init); policy.allow_subprocess remains advisory.
+    # This permits only the INITIAL exec of the target, NOT child spawning —
+    # spawning a child additionally needs process-fork, gated below.
     lines.append("")
     lines.append("(allow process-exec*)")
-    lines.append("(allow process-fork)")
+    # process-fork gates child spawning (#1914). IMPORTANT: the (import "bsd.sb")
+    # base above GRANTS process-fork, so merely omitting our own (allow ...) is
+    # NOT sufficient — emit an explicit (deny process-fork) (SBPL is
+    # last-match-wins) to override the base grant when subprocess is disallowed.
+    # A child spawn (subprocess / os.posix_spawn / os.system / multiprocessing /
+    # shell pipeline) needs fork() and is then denied, while the interpreter
+    # itself, threading, and a single exec-replacement still run (those need only
+    # process-exec*). Linux-parity with the seccomp gate; verified via sandbox-exec
+    # (py3.9/3.12 + sh pipeline). The prior "fork needed for runtime bootstrap"
+    # rationale was incorrect.
+    if policy.allow_subprocess:
+        lines.append("(allow process-fork)")
+    else:
+        lines.append("(deny process-fork)")
 
     # #1199 realignment — broad read surface. The strict read-allowlist was
     # abolished: reads are broad by default (this subsumes the old system-path
@@ -114,11 +127,10 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
         lines.append("; — network —")
         lines.append("(allow network*)")
 
-    # Note: process-fork is allowed unconditionally above. policy.allow_subprocess
-    # is currently advisory under Seatbelt — distinguishing "the invoked binary
-    # may fork (interpreter bootstrap)" from "and may spawn arbitrary children"
-    # requires per-pid rules SBPL doesn't cleanly express. Recorded in P6
-    # events for audit.
+    # process-fork is gated on policy.allow_subprocess above (#1914), so
+    # allow_subprocess=False is ENFORCED, not advisory: spawning a child needs
+    # fork(); the interpreter is exec'd by sandbox-exec via process-exec* and
+    # does not itself need fork to run. Matches the Linux seccomp enforcement.
 
     return "\n".join(lines) + "\n"
 

--- a/tests/test_seatbelt_subprocess_enforcement_1914.py
+++ b/tests/test_seatbelt_subprocess_enforcement_1914.py
@@ -1,0 +1,78 @@
+"""Tier 2: Seatbelt enforces allow_subprocess (was advisory-only) — #1914.
+
+Before #1914 the SBPL profile emitted ``(allow process-fork)`` unconditionally, so
+``allow_subprocess=False`` was advisory on macOS (subprocess spawn still worked).
+The fix gates ``(allow process-fork)`` on ``policy.allow_subprocess``; ``process-exec*``
+stays always-allowed (sandbox-exec needs it to execvp the target). Empirically
+(sandbox-exec probe, py3.9/3.12 + sh/bash/node) the interpreter + threading run
+fine without process-fork — only child spawning (which needs fork) is denied.
+Linux-parity with the seccomp gate.
+
+Two tiers of coverage:
+- structural (CI-safe everywhere): the profile string gates process-fork.
+- behavioral (darwin-only): sandbox-exec actually blocks a child spawn.
+
+Policy: real _build_sbpl_profile + real SeatbeltBackend.run (no mocks). Tier first.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from reyn.security.sandbox.backends.seatbelt import (
+    SeatbeltBackend,
+    _build_sbpl_profile,
+)
+from reyn.security.sandbox.policy import SandboxPolicy
+
+# ── structural (CI-safe) ─────────────────────────────────────────────────────
+
+def test_profile_denies_process_fork_when_subprocess_disallowed():
+    """Tier 2: allow_subprocess=False → explicit (deny process-fork). The bsd.sb
+    base GRANTS fork, so a last-match-wins deny is required to override it (mere
+    omission is insufficient); (allow process-exec*) stays for the initial exec."""
+    profile = _build_sbpl_profile(SandboxPolicy(allow_subprocess=False))
+    assert "(deny process-fork)" in profile
+    assert "(allow process-fork)" not in profile
+    assert "(allow process-exec*)" in profile
+
+
+def test_profile_allows_process_fork_when_subprocess_allowed():
+    """Tier 2: allow_subprocess=True → (allow process-fork) emitted (spawning
+    permitted), no (deny process-fork), process-exec* present."""
+    profile = _build_sbpl_profile(SandboxPolicy(allow_subprocess=True))
+    assert "(allow process-fork)" in profile
+    assert "(deny process-fork)" not in profile
+    assert "(allow process-exec*)" in profile
+
+
+# ── behavioral (darwin-only: sandbox-exec is macOS-only) ─────────────────────
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS-only")
+@pytest.mark.asyncio
+async def test_seatbelt_blocks_child_spawn_when_subprocess_disallowed():
+    """Tier 2: with allow_subprocess=False the sandboxed process cannot spawn a
+    child (fork denied); with allow_subprocess=True it can. The target shell runs
+    either way (its own exec is governed by process-exec*, not fork)."""
+    backend = SeatbeltBackend()
+    if not backend.available():
+        pytest.skip("sandbox-exec not available on this machine")
+
+    # A pipeline forces a real fork; a single command would be exec-optimized by
+    # the shell (self-replacement, not a child spawn) and wouldn't exercise fork.
+    spawn_cmd = ["/bin/sh", "-c", "/bin/echo SPAWNED_CHILD | /bin/cat"]
+
+    denied = await backend.run(
+        spawn_cmd, SandboxPolicy(allow_subprocess=False, timeout_seconds=10)
+    )
+    assert b"SPAWNED_CHILD" not in denied.stdout, (
+        f"child spawn must be blocked when allow_subprocess=False (stdout={denied.stdout!r})"
+    )
+
+    allowed = await backend.run(
+        spawn_cmd, SandboxPolicy(allow_subprocess=True, timeout_seconds=10)
+    )
+    assert b"SPAWNED_CHILD" in allowed.stdout, (
+        f"child spawn must work when allow_subprocess=True (stdout={allowed.stdout!r})"
+    )


### PR DESCRIPTION
**[dogfood-coder]** — Fixes #1914. macOS Seatbelt treated `allow_subprocess=False` as advisory (a sandboxed process could still spawn children); this enforces it. Lead-dispatched, investigate-then-fix-or-document → **verdict: FIXABLE** (primary evidence below; not a known-limitation).

## Root cause
The SBPL profile emitted `(allow process-fork)` unconditionally. The non-obvious part: `(import "bsd.sb")` (Apple's base profile) **itself grants `process-fork`**, so merely *omitting* our own allow is insufficient — an explicit `(deny process-fork)` (SBPL last-match-wins) is required to override the base grant. `(allow process-exec*)` must stay always-allowed (sandbox-exec needs it to `execvp` the target; denying it stops the target running at all — confirmed).

## Fix
`_build_sbpl_profile`: gate process-fork on `policy.allow_subprocess` — `(allow process-fork)` when True, **`(deny process-fork)` when False**. A child spawn (subprocess / posix_spawn / os.system / multiprocessing / shell fork) needs `fork()` and is denied; the interpreter itself + threading + a single exec-replacement still run.

## Primary evidence (sandbox-exec probe, proxy-free)
With `allow_subprocess=False` (deny process-fork):
- **BLOCKED**: `subprocess.run` / `os.posix_spawn` / `os.fork` (PermissionError); `os.system` / `sh -c 'a | b'` pipeline / `sh -c 'a; b'` (`fork: Operation not permitted`, rc=127/128).
- **Runs fine**: interpreter start for python3.9, python3.12, /bin/sh, /bin/bash, node; `threading`; a single exec-replacement.
- `(deny process-exec*)` instead → sandbox-exec can't even exec the target (unusable), so process-fork is the correct lever.
- `allow_subprocess=True` → subprocess + pipeline still work (unchanged).

Linux-parity: Landlock/seccomp already gate `allow_subprocess`.

## Tests (`tests/test_seatbelt_subprocess_enforcement_1914.py`)
- 2 structural (CI-safe everywhere): profile gates process-fork (deny when False / allow when True; exec* always present).
- 1 darwin-only behavioral (`skipif sys.platform != "darwin"`): runs real `sandbox-exec`, asserts a fork-forcing child spawn is blocked when disallowed, works when allowed.
- **Falsification**: stashing the fix → structural + behavioral go RED (the `allow=True` guard correctly stays green).

## Docs
Corrected the now-stale "advisory under Seatbelt" claims (en + ja) across `configure-sandbox`, `sandbox`, `permission-model` to state enforcement.

## Out-of-scope note (cataloged per lead, from the resource-cleanup recon)
`src/reyn/interfaces/tui/voice.py:113` stores `self._devnull = open(os.devnull, "w")` — a single low-impact stored handle (devnull, for stdout-swap during voice). Not a leak cluster; noted, not fixed.

## Test plan
- [x] 3 new tests pass (2 structural + 1 darwin behavioral)
- [x] Falsification: tests RED on pre-fix code, GREEN after
- [x] 82 existing sandbox tests green (no regression)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` rc=0; ruff + tier-audit clean
- [x] Primary-evidence verification across spawn vectors + 4 runtimes (sandbox-exec probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)