### PR TITLE
fix(tui): drop stale async events-preview write after navigation

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
@@ -236,6 +236,12 @@ class RightPanel(Widget):
         self._events_filelist_cache: list = []
         self._events_cursor: int = 0
         self._events_visible: list[dict] = []
+        # Monotonic token bumped on every ``_update_preview`` (= any tab
+        # switch / cursor move / refresh that replaces the preview content).
+        # The events-tab async LLM viewer fallback captures this at spawn and
+        # re-checks it before writing, so a result that arrives after the user
+        # has navigated away cannot clobber the now-current preview.
+        self._preview_token: int = 0
         # y-coord (0-indexed line) of each event's headline row in the
         # rendered output. Populated by `render_events`; used by
         # `_scroll_events_into_view` so chain-switch blank lines + the
@@ -1083,6 +1089,10 @@ class RightPanel(Widget):
         return False
 
     def _update_preview(self) -> None:
+        # Advance the preview token: any in-flight async events-tab LLM
+        # fallback (spawned by a PRIOR preview) is now stale and must not
+        # write over the content we are about to render.
+        self._preview_token += 1
         try:
             pane = self.query_one("#preview-pane", _PreviewPane)
             if self._panel_type == "docs" and self._docs_files:
@@ -1226,17 +1236,39 @@ class RightPanel(Widget):
             # Sync registry miss: show YAML now, try LLM template async.
             pane.show_text(title, self._render_as_yaml(ev))
             import asyncio
+            # Capture the current preview token so the async result is dropped
+            # if the user navigates away (= a newer _update_preview bumps it)
+            # before the LLM call returns. Otherwise A's late result would
+            # clobber B's preview.
             asyncio.create_task(
-                self._show_event_llm_fallback(pane, result, title)
+                self._show_event_llm_fallback(
+                    pane, result, title, token=self._preview_token,
+                )
             )
             return
         pane.show_text(title, self._render_as_yaml(ev))
+
+    def _write_preview_if_current(
+        self, pane: "_PreviewPane", title: str, renderable: object, token: int,
+    ) -> bool:
+        """Write ``renderable`` to ``pane`` only if ``token`` is still current.
+
+        Returns True when the write happened, False when it was suppressed as
+        stale (= a newer ``_update_preview`` advanced ``_preview_token`` while
+        an async preview producer was awaiting). The single guarded-write seam
+        for deferred preview producers.
+        """
+        if token != self._preview_token:
+            return False
+        pane.show_text(title, renderable)
+        return True
 
     async def _show_event_llm_fallback(
         self,
         pane: _PreviewPane,
         result: object,
         title: str,
+        token: int,
     ) -> None:
         """Async LLM viewer-template fallback for tool-result preview (#1154 S4).
 
@@ -1244,11 +1276,16 @@ class RightPanel(Widget):
         with a cheap LLM client; if a template is generated it replaces the YAML
         that _show_event_in_preview showed. Uses the per-session in-memory cache,
         so repeated navigation to the same result shape incurs no LLM call.
+
+        ``token`` is the preview token captured at spawn: if the user navigated
+        to a different event (or tab) during the LLM call, ``_update_preview``
+        has bumped the token and this stale result is dropped rather than
+        overwriting the now-current preview.
         """
         from .tool_result_viewers import render_tool_result_async
         viewed = await render_tool_result_async(result, _ViewerTemplateLLMClient())
         if viewed is not None:
-            pane.show_text(title, viewed)
+            self._write_preview_if_current(pane, title, viewed, token)
 
     def _memory_move(self, delta: int) -> None:
         """Move the memory tab cursor; sync preview if open.

--- a/tests/cli/test_events_preview_stale_async_guard.py
+++ b/tests/cli/test_events_preview_stale_async_guard.py
@@ -1,0 +1,110 @@
+"""Tier 2: events-tab async LLM preview fallback is dropped after navigation.
+
+`_show_event_in_preview` shows YAML immediately on a sync-registry miss, then
+spawns `_show_event_llm_fallback`, which `await`s an LLM viewer-template call
+(seconds) and then writes the result into the shared preview pane. Before the
+fix that write was UNCONDITIONAL — so if the user pressed j/k to move the
+events cursor (or switched tabs) during the LLM call, event A's late result
+clobbered event B's preview (showing "event #0 …" content while the cursor sat
+on #3).
+
+The fix threads a monotonic ``_preview_token`` (bumped by every
+``_update_preview`` = any tab switch / cursor move / refresh) through the async
+fallback; the result is written only via ``_write_preview_if_current``, which
+drops it when the token has advanced. These tests pin that guarded-write
+contract and the navigation → token-bump → stale-drop path.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _CapturePane:
+    """Minimal preview-pane stub recording show_text/clear calls (UI surface,
+    not a collaborator with an API contract — no mock needed)."""
+
+    def __init__(self) -> None:
+        self.writes: list = []
+
+    def show_text(self, title: str, renderable: object) -> None:
+        self.writes.append((title, renderable))
+
+    def clear(self) -> None:
+        self.writes.append(("__clear__", None))
+
+
+@pytest.mark.asyncio
+async def test_write_preview_if_current_drops_stale_token() -> None:
+    """Tier 2: a guarded write lands at the current token, is dropped otherwise."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+        cur = panel._preview_token
+
+        # Current token → the write lands.
+        pane_ok = _CapturePane()
+        wrote_current = panel._write_preview_if_current(
+            pane_ok, "event #0", "body", cur,
+        )
+        assert wrote_current is True
+        assert ("event #0", "body") in pane_ok.writes
+
+        # An older (stale) token → suppressed, pane untouched.
+        pane_stale = _CapturePane()
+        wrote_stale = panel._write_preview_if_current(
+            pane_stale, "event #0", "body", cur - 1,
+        )
+        assert wrote_stale is False
+        assert pane_stale.writes == []
+
+
+@pytest.mark.asyncio
+async def test_navigation_bumps_token_so_inflight_result_is_dropped() -> None:
+    """Tier 2: moving the events cursor bumps the token, stranding an in-flight
+    async fallback that captured the pre-navigation token."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import RightPanel
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        panel = app.query_one("#right_panel", RightPanel)
+
+        # Two non-tool-result events so _update_preview takes the plain-YAML
+        # path (no real LLM task spawned during this test).
+        panel._panel_type = "events"
+        panel._preview_visible = True
+        panel._events_visible = [
+            {"type": "phase_started", "data": {"chain_id": "c"}},
+            {"type": "phase_completed", "data": {"chain_id": "c"}},
+        ]
+        panel._events_cursor = 0
+
+        # An async LLM fallback launched for event #0 would have captured this.
+        token_for_event0 = panel._preview_token
+
+        # User navigates to event #1 → _events_move → _update_preview bumps token.
+        panel._events_move(1)
+        await pilot.pause()
+
+        # The late result for event #0 must now be dropped, not clobber #1.
+        pane = _CapturePane()
+        wrote = panel._write_preview_if_current(
+            pane, "event #0", "stale-A-content", token_for_event0,
+        )
+        assert wrote is False, (
+            "an async fallback that captured the pre-navigation token must be "
+            "dropped after the cursor moved"
+        )
+        assert pane.writes == []


### PR DESCRIPTION
**[tui-coder]** — fix(tui): drop stale async events-preview write after navigation (concurrency/race lane, 4th race)

## Bug (stale-deferred-write race, via create_task this time)
RightPanel events-tab `_show_event_in_preview` shows YAML immediately on a sync-registry miss, then spawns `_show_event_llm_fallback`, which `await`s an LLM viewer-template call (#1154 S4) — potentially seconds — and then wrote the result into the **shared** preview pane **unconditionally**:

```python
viewed = await render_tool_result_async(result, _ViewerTemplateLLMClient())
if viewed is not None:
    pane.show_text(title, viewed)   # no check the cursor is still on this event
```

If the user pressed j/k to move the events cursor (or switched tabs) during the LLM call, `_events_move` → `_update_preview` re-rendered the pane for event B — then event A's late result landed via `pane.show_text(title_A, viewed_A)`, **clobbering B's preview** (showing "event #0 …" content while the cursor sat on #3). Same stale-deferred-action class as the just-merged AsyncStackPanel flash (#1926) and F-key hint (#1929) races, here through `asyncio.create_task` + await rather than `set_timer`.

## Fix
A monotonic `_preview_token`, bumped at the top of `_update_preview` (the single choke point for every tab switch / cursor move / refresh), is captured when the async fallback is spawned and threaded through it. The result is written only via the new `_write_preview_if_current`, which drops it when the token has advanced. The snapshot path (`_capture_preview_as_text`) writes to a fake stub pane and cannot reach the real pane, so it's unaffected.

## Test plan
- [x] `tests/cli/test_events_preview_stale_async_guard.py` — 2 Tier-2:
  - a guarded write lands at the current token, is dropped at a stale token
  - navigation (`_events_move`) bumps the token so an in-flight result that captured the pre-navigation token is dropped
  - **RED confirmed**: neutralizing the guard (pre-fix unconditional write) → both fail `assert True is False` (the stale write lands)
- [x] right_panel / events_tab / preview / #1154 regression — **103 passed**
- [x] `tests/cli/test_tool_result_viewer_wire.py` — 6 passed (the `_show_event_llm_fallback` signature change is compatible)
- [x] `python scripts/test_tier_audit.py tests/cli/test_events_preview_stale_async_guard.py` — 0 violations
- [x] `ruff check` clean

## Tier self-check
2 new tests are Tier 2 (public method `_write_preview_if_current` driven on a real `ReynTUIApp` Pilot harness; assertions are variable-bound bools + write-content membership on a capture stub — no private-state asserts, no len()-pinning, no mocks/patch, no golden files). Docstrings declare `Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
