### PR TITLE
feat(1827): S4b — context-auto per-turn compose (untrusted → minimal profile)

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -45,6 +45,7 @@ class RouterLoopDriver:
         exclude_tools: Any,           # set — for RouterLoop
         excluded_categories: Any = frozenset(),  # #1667 set — catalog categories for RouterLoop
         contextual_permission: Any = None,  # #1827 S3 ContextualPermission — for RouterLoop live tool gate; None = no narrowing
+        contextual_for_turn_fn: Any = None,  # #1827 S4b: () -> ContextualPermission|None — per-turn effective contextual (context-auto); None → static contextual_permission (byte-identical)
         budget: Any,                  # BudgetGateway — cap + usage accounting
         resolver: Any,                # LLMResolver — model resolution
         compaction: Any,              # CompactionConfig — retry_loop cfg
@@ -68,6 +69,7 @@ class RouterLoopDriver:
         self._exclude_tools = exclude_tools
         self._excluded_categories = excluded_categories  # #1667
         self._contextual_permission = contextual_permission  # #1827 S3
+        self._contextual_for_turn_fn = contextual_for_turn_fn  # #1827 S4b
         self._budget = budget
         self._resolver = resolver
         self._compaction = compaction
@@ -382,7 +384,15 @@ class RouterLoopDriver:
             # catalog.
             exclude_tools=self._exclude_tools,
             excluded_categories=self._excluded_categories,  # #1667
-            contextual_permission=self._contextual_permission,  # #1827 S3 live tool gate
+            # #1827 S4b: per-turn effective contextual — when untrusted external
+            # content is live in context (context-auto), the static narrowing is
+            # composed with the minimal _untrusted profile; otherwise the static
+            # S3 contextual (byte-identical). The fn is provided by Session.
+            contextual_permission=(
+                self._contextual_for_turn_fn()
+                if self._contextual_for_turn_fn is not None
+                else self._contextual_permission
+            ),
             # B43-NF-W6-1 / #187: chat router empty-stop retry — always-on +
             # uniform "resume" directive.
             empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -883,6 +883,10 @@ class Session:
         # resolved from the agent's topology role. Threaded to the live tool gate
         # (RouterLoop) + control-IR OpContext. None = no narrowing (byte-identical).
         self._contextual_permission = contextual_permission
+        # #1827 S4b (context-auto): lazily-resolved minimal _untrusted profile
+        # ContextualPermission, composed into the per-turn narrowing while
+        # untrusted external content is live in context. None until first needed.
+        self._untrusted_contextual_cache = None
         # #1667: catalog categories hidden at the universal-catalog source (e.g.
         # reyn_source on the external-repo eval path so it doesn't compete with
         # file__* for the weak model); interactive default empty = reyn_source kept.
@@ -1733,6 +1737,7 @@ class Session:
             non_interactive=self._non_interactive,
             exclude_tools=self._exclude_tools,
             contextual_permission=self._contextual_permission,  # #1827 S3 → RouterLoop live gate
+            contextual_for_turn_fn=self._effective_contextual_for_turn,  # #1827 S4b context-auto
             excluded_categories=self._excluded_categories,
             budget=self._budget,
             resolver=self._resolver,
@@ -2309,6 +2314,38 @@ class Session:
             "interrupted_plans": interrupted_plans,
             "stuck_skills": stuck_skills,
         }
+
+    def _effective_contextual_for_turn(self) -> "object | None":
+        """#1827 S4b (context-auto): the per-session contextual narrowing for THIS
+        turn.
+
+        When untrusted external content is live in the active context (a history
+        entry carrying the #1862 ``external_source`` marker), compose the minimal
+        ``_untrusted`` profile with the static (topology) narrowing —
+        most-restrictive (union-of-excludes) — so a partial prompt-injection has
+        no dangerous tools to reach. The taint is derived from the active history,
+        so it **self-clears** once the untrusted entry compacts out
+        (until-compaction scope). Untrusted absent → the static contextual
+        (byte-identical to pre-S4b).
+        """
+        from reyn.security.permissions.capability_profile import metas_have_untrusted
+
+        if not metas_have_untrusted(m.meta for m in self.history):
+            return self._contextual_permission
+        from reyn.security.permissions.capability_profile import (
+            compose_resolved,
+            load_untrusted_profile,
+            resolve_profile,
+        )
+        if self._untrusted_contextual_cache is None:
+            root = getattr(self._perm, "_project_root", None) or Path.cwd()
+            self._untrusted_contextual_cache = resolve_profile(
+                load_untrusted_profile(root)
+            )[0]
+        resolved = [(self._untrusted_contextual_cache, frozenset())]
+        if self._contextual_permission is not None:
+            resolved.insert(0, (self._contextual_permission, frozenset()))
+        return compose_resolved(resolved)[0]
 
     def _build_agent_for_skill_runner(
         self,

--- a/tests/test_context_auto_1827_s4b.py
+++ b/tests/test_context_auto_1827_s4b.py
@@ -1,0 +1,92 @@
+"""Tier 2: context-auto per-turn compose (#1827 S4b).
+
+When untrusted external content is live in the active context (a history entry
+carrying the #1862 ``external_source`` marker), the agent's per-turn contextual
+narrowing composes the minimal ``_untrusted`` profile with the static topology
+narrowing (most-restrictive). The taint is derived from the active history, so it
+**self-clears** once the marked entry compacts out (until-compaction scope).
+Untrusted absent → the static contextual (byte-identical).
+
+These pin ``Session._effective_contextual_for_turn`` (the per-turn callback the
+RouterLoopDriver consults) — and that the composed contextual actually DENIES the
+dangerous tools at the shared gate (the same ``tool_contextually_denied`` the live
+RouterLoop / control-IR gates call), so the narrowing is enforced, not cosmetic.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import (
+    ContextualPermission,
+    tool_contextually_denied,
+)
+
+
+def _session(tmp_path: Path, *, contextual=None) -> Session:
+    s = Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        contextual_permission=contextual,
+    )
+    return s
+
+
+def _mark_untrusted(s: Session) -> None:
+    s.history.append(ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True}))
+
+
+def test_untainted_returns_static(tmp_path):
+    """Tier 2: with no untrusted entry the per-turn contextual is the static one."""
+    s = _session(tmp_path)  # no static narrowing
+    eff = s._effective_contextual_for_turn()
+    assert eff is None  # byte-identical
+    s.history.append(ChatMessage(role="user", content="normal", meta={}))
+    eff = s._effective_contextual_for_turn()
+    assert eff is None
+
+
+def test_tainted_composes_untrusted_and_denies(tmp_path):
+    """Tier 2: an untrusted entry → the per-turn contextual denies the dangerous
+    tools (the built-in _untrusted deny-set) at the shared gate."""
+    s = _session(tmp_path)
+    _mark_untrusted(s)
+    eff = s._effective_contextual_for_turn()
+    assert eff is not None
+    # the dangerous side-effecting surfaces are now denied (context-auto)
+    for denied in ("memory_operation__remember_shared", "delegate_to_agent",
+                   "exec__sandboxed_exec", "sandboxed_exec"):
+        assert tool_contextually_denied(eff, denied), denied
+    # a read tool stays allowed
+    assert not tool_contextually_denied(eff, "recall")
+
+
+def test_self_clears_when_taint_removed(tmp_path):
+    """Tier 2: once the untrusted entry is gone (compaction), the narrowing clears."""
+    s = _session(tmp_path)
+    _mark_untrusted(s)
+    eff = s._effective_contextual_for_turn()
+    assert tool_contextually_denied(eff, "exec__sandboxed_exec")
+    # simulate the untrusted entry compacting out of the active context
+    s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+    eff = s._effective_contextual_for_turn()
+    assert eff is None  # back to static (none)
+
+
+def test_composes_with_static_union(tmp_path):
+    """Tier 2: a static topology narrowing AND the untrusted profile both apply
+    while tainted (union-of-excludes / most-restrictive)."""
+    static = ContextualPermission(tool_deny=frozenset({"web__search"}))
+    s = _session(tmp_path, contextual=static)
+    # untainted: only the static deny applies
+    eff = s._effective_contextual_for_turn()
+    assert tool_contextually_denied(eff, "web__search")
+    assert not tool_contextually_denied(eff, "exec__sandboxed_exec")
+    # tainted: BOTH the static deny AND the untrusted deny-set apply
+    _mark_untrusted(s)
+    eff = s._effective_contextual_for_turn()
+    assert tool_contextually_denied(eff, "web__search")          # static
+    assert tool_contextually_denied(eff, "exec__sandboxed_exec")  # untrusted


### PR DESCRIPTION
**[e2e-coder]** — #1827 **S4b** (context-auto per-turn compose). S4a foundation merged; this lands the dynamic narrowing. Resumes after #1912 closed the gate-completeness gap.

## What
Defense-in-depth with the #1862 fence: while untrusted external content is live in the active context, the agent is **also capability-narrowed** — a partial injection has no dangerous tools to reach.

- **`Session._effective_contextual_for_turn()`**: when the active history carries an `external_source`-marked entry (`metas_have_untrusted`), compose the minimal `_untrusted` profile with the static topology narrowing (`compose_resolved` — union-of-excludes). The taint is **derived from the active history**, so it **self-clears** once the marked entry compacts out (until-compaction scope, lead-approved). Untrusted absent → static (byte-identical). `_untrusted` is lazy-cached, overridable via `.reyn/capability_profiles/_untrusted.yaml`.
- **`RouterLoopDriver.run_turn`**: the per-turn RouterLoop is built with the effective contextual via a new `contextual_for_turn_fn` callback (mirrors `model_override_fn`); Session injects the taint-compose. Fn absent → static (byte-identical). The composed narrowing rides the **#1912 single gate** (chat + phase + control-IR + preprocessor) → enforced on every path.

## Test plan
- [x] Untainted → static (byte-identical, `None` when no topology).
- [x] Tainted → the dangerous surfaces (`memory_operation__remember_shared` / `delegate_to_agent` / `exec__sandboxed_exec`) are **denied at the shared gate**; a read tool stays allowed.
- [x] **Self-clears** when the marked entry is removed (compaction sim).
- [x] **Composes with a static topology deny** (union — both apply while tainted).
- [x] **Falsification CLEAN RED**: no-taint-detection reds the tainted-denies test (verified, reverted).
- [x] Byte-identical: session / driver / contextual suites **306 passed**; tier-audit + ruff clean.

## Scope
v1 narrows the **chat turn** processing the untrusted answer (the primary target). Skill-spawn-while-tainted propagation is a refinement (forward). The tool-result mid-turn vector is tracked at **#1909**.

Refs #1827. Next (after merge): the #1827 forward sequence continues (S5 delegate / S6 ephemeral) per owner sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
