### PR TITLE
fix(tui): suppressed transient must not arm a hide timer

### DIFF
--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -1726,8 +1726,11 @@ class ReynTUIApp(App):
                 pass
             self._action_hint_timer = None
         try:
-            conv.show_status(text, kind=kind)
-            self._action_hint_timer = self.set_timer(duration, conv.hide_status)
+            # Only arm the auto-hide when the hint actually displayed — a
+            # priority-suppressed hint must not arm a timer that would later
+            # dismiss the higher-priority incumbent.
+            if conv.show_status(text, kind=kind):
+                self._action_hint_timer = self.set_timer(duration, conv.hide_status)
         except Exception:
             pass
 

--- a/src/reyn/interfaces/tui/app_outbox.py
+++ b/src/reyn/interfaces/tui/app_outbox.py
@@ -353,8 +353,14 @@ class OutboxRouter:
         into the agent's run.
         """
         self._cancel_transient_timer()
-        conv.show_status(text, kind=kind)
-        self._transient_status_timer = self._app.set_timer(duration, conv.hide_status)
+        # Only arm the auto-hide timer when the status actually displayed.
+        # A priority-suppressed transient (= a higher-priority error / mode
+        # sticky is active) must NOT arm a hide — it would later dismiss the
+        # incumbent the suppression just protected.
+        if conv.show_status(text, kind=kind):
+            self._transient_status_timer = self._app.set_timer(
+                duration, conv.hide_status,
+            )
 
     # ── main loop ─────────────────────────────────────────────────────────────
 

--- a/src/reyn/interfaces/tui/widgets/conversation.py
+++ b/src/reyn/interfaces/tui/widgets/conversation.py
@@ -361,10 +361,12 @@ class _StatusSpinnerController:
     def __init__(self, parent: "ConversationView") -> None:
         self._parent = parent
 
-    def show_status(self, text: str, kind: str = "general", *, terminal: bool = False) -> None:
+    def show_status(self, text: str, kind: str = "general", *, terminal: bool = False) -> bool:
+        """Return True when the sticky displayed, False when priority-suppressed."""
         s = self._parent._sticky()
-        if s is not None:
-            s.show(text, kind=kind, terminal=terminal)
+        if s is None:
+            return False
+        return s.show(text, kind=kind, terminal=terminal)
 
     def update_status(self, text: str) -> None:
         s = self._parent._sticky()
@@ -2225,8 +2227,9 @@ class ConversationView(Widget):
 
     # ── sticky status (A3) ────────────────────────────────────────────────────
 
-    def show_status(self, text: str, kind: str = "general", *, terminal: bool = False) -> None:
-        self._status_ctrl.show_status(text, kind=kind, terminal=terminal)
+    def show_status(self, text: str, kind: str = "general", *, terminal: bool = False) -> bool:
+        """Return True when the sticky displayed, False when priority-suppressed."""
+        return self._status_ctrl.show_status(text, kind=kind, terminal=terminal)
 
     def update_status(self, text: str) -> None:
         self._status_ctrl.update_status(text)

--- a/src/reyn/interfaces/tui/widgets/sticky_status.py
+++ b/src/reyn/interfaces/tui/widgets/sticky_status.py
@@ -140,8 +140,14 @@ class StickyStatus(Static):
 
     # ── public API ────────────────────────────────────────────────────────────
 
-    def show(self, text: str, kind: str = "general", *, terminal: bool = False) -> None:
+    def show(self, text: str, kind: str = "general", *, terminal: bool = False) -> bool:
         """Activate the status bar with the given body text and glyph kind.
+
+        Returns True when the status was displayed, False when the call was
+        suppressed by the priority hierarchy (= a higher-priority sticky is
+        active). Callers that arm an auto-hide timer MUST check this — arming
+        a hide on a suppressed show would later dismiss the higher-priority
+        incumbent the suppression just protected.
 
         Wave-10 G-F8 + I-F8: when the sticky is already active with a
         higher-priority ``kind``, a lower-priority ``show()`` is
@@ -169,13 +175,14 @@ class StickyStatus(Static):
             new_priority = _KIND_PRIORITY.get(new_kind, 0)
         if self._active:
             if new_priority < self._current_priority:
-                return
+                return False
         self._kind = new_kind
         self._glyph = _GLYPHS[self._kind]
         self._active = True
         self._current_priority = new_priority
         self.add_class("active")
         self.update_text(text)
+        return True
 
     def update_text(self, text: str) -> None:
         """Update the body text without resetting the elapsed timer."""

--- a/tests/cli/test_transient_suppressed_show_no_timer.py
+++ b/tests/cli/test_transient_suppressed_show_no_timer.py
@@ -1,0 +1,93 @@
+"""Tier 2: a priority-suppressed transient must not arm a hide timer.
+
+`StickyStatus.show()` suppresses a lower-priority transient when a
+higher-priority sticky (error / mode / terminal-error) is active — so a routine
+`/copy` "copied" toast can't overwrite a "CRITICAL: auth failed" error. But
+`OutboxRouter._show_transient_status` armed its auto-hide timer
+UNCONDITIONALLY, even when the show was suppressed. The timer then fired and
+hid the higher-priority incumbent the suppression had just protected — the
+exact Wave-10 G-F8/I-F8 failure, reintroduced via the hide path.
+
+Fix: `show()` reports whether it displayed; `_show_transient_status` arms the
+hide timer only when the transient actually took over the sticky.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.tui.app import ReynTUIApp
+from reyn.interfaces.tui.app_outbox import OutboxRouter
+from reyn.interfaces.tui.widgets import ConversationView
+from reyn.interfaces.tui.widgets.sticky_status import StickyStatus
+
+
+def _make_app() -> ReynTUIApp:
+    return ReynTUIApp(
+        registry=None, agent_name="t", model="m", budget_tracker=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_suppressed_transient_does_not_hide_active_error() -> None:
+    """Tier 2: a suppressed general transient must not arm a hide timer that
+    later dismisses the higher-priority error it could not overwrite."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        router = OutboxRouter(app)
+
+        # An error is showing (priority 80).
+        conv.show_status("CRITICAL: auth failed", kind="error")
+        assert sticky.snapshot()["active"] is True
+
+        # A routine transient (priority 50) — suppressed by the error, but
+        # must NOT arm a hide timer.
+        router._show_transient_status(conv, "copied reply", duration=0.2)
+        snap_after = sticky.snapshot()
+        assert snap_after["body"] == "CRITICAL: auth failed", (
+            "the error must still be the displayed body (transient suppressed)"
+        )
+        assert router.has_transient_status_timer() is False, (
+            "a suppressed transient must not arm a hide timer"
+        )
+
+        # Past the transient's would-be hide deadline — the error must survive.
+        await pilot.pause(0.3)
+        survived = sticky.snapshot()
+        assert survived["active"] is True, (
+            "the higher-priority error must survive a suppressed transient's "
+            "(non-)timer"
+        )
+        assert survived["body"] == "CRITICAL: auth failed"
+
+
+@pytest.mark.asyncio
+async def test_unsuppressed_transient_still_arms_and_hides() -> None:
+    """Tier 2: a transient that DOES display still auto-hides (no regression)."""
+    app = _make_app()
+    async with app.run_test(headless=True, size=(120, 30)) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        sticky = conv.query_one("#sticky-status", StickyStatus)
+        router = OutboxRouter(app)
+
+        # No incumbent → the transient displays and arms its hide timer.
+        router._show_transient_status(conv, "copied reply", duration=0.2)
+        shown = sticky.snapshot()
+        assert shown["active"] is True
+        assert shown["body"] == "copied reply"
+        assert router.has_transient_status_timer() is True
+
+        await pilot.pause(0.3)
+        assert sticky.snapshot()["active"] is False, (
+            "an un-suppressed transient must still auto-hide after its duration"
+        )


### PR DESCRIPTION
**[tui-coder]** — fix(tui): suppressed transient must not arm a hide timer (concurrency/race lane, 5th — in the shared seam itself)

## Bug (confirmed via repro)
`StickyStatus.show()` has a priority hierarchy (Wave-10 G-F8/I-F8): a lower-priority transient is **suppressed** when a higher-priority sticky (error=80 / mode=85 / terminal-error=110) is active — so a routine `/copy` "copied" toast or an F-key hint (general=50) can't overwrite a `CRITICAL: auth failed` error.

But `OutboxRouter._show_transient_status` (and the `_show_action_hint` pre-drain fallback) armed the auto-hide timer **unconditionally**, regardless of whether the `show()` was suppressed. So:

```
error shown (prio 80)  →  transient "copied" (prio 50, SUPPRESSED — error stays)  →  ...but timer armed
→ duration later: timer fires hide() → the error is dismissed
```

The transient's own timer hides the higher-priority incumbent the suppression had just protected — the exact failure Wave-10 fixed, reintroduced through the hide path. **Confirmed with a repro** (error → suppressed transient → after the transient's deadline the error is gone).

## Fix
`StickyStatus.show()` now returns whether it displayed (`False` when priority-suppressed); the `_StatusController` and `ConversationView` delegates propagate the bool; `_show_transient_status` and the `_show_action_hint` fallback arm the hide timer **only when the status actually took over the sticky**.

## Test plan
- [x] `tests/cli/test_transient_suppressed_show_no_timer.py` — 2 Tier-2:
  - a suppressed transient under an active error arms **no** timer, and the error **survives** past the would-be deadline (**RED before fix**: timer armed → `assert True is False` → error dismissed)
  - an un-suppressed transient still arms + auto-hides (no regression)
- [x] sticky / transient / hint / smoke / boundary / ws_disconnect regression — **185 passed** (`show()` None→bool is additive; existing callers that ignore the return are unaffected)
- [x] `python scripts/test_tier_audit.py tests/cli/test_transient_suppressed_show_no_timer.py` — 0 violations
- [x] `ruff check` clean

## Tier self-check
2 new tests are Tier 2 (public surface: `StickyStatus.snapshot()` + `OutboxRouter.has_transient_status_timer()` on a real Pilot harness; assertions are `is True/False` bools + `snapshot()["body"]` equality — no private-state asserts, no len()-pinning, no mocks, no golden files). Docstrings declare `Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
