### PR TITLE
test(1827): S4b hardening — producer↔consumer e2e + public project_root accessor

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2338,7 +2338,7 @@ class Session:
             resolve_profile,
         )
         if self._untrusted_contextual_cache is None:
-            root = getattr(self._perm, "_project_root", None) or Path.cwd()
+            root = self._perm.project_root if self._perm is not None else Path.cwd()
             self._untrusted_contextual_cache = resolve_profile(
                 load_untrusted_profile(root)
             )[0]

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -419,6 +419,14 @@ class PermissionResolver:
 
     # ── Public read helpers (= Tier-C1 cleanup wave 27) ───────────────────
 
+    @property
+    def project_root(self) -> Path:
+        """The host-side approvals/config base (where ``.reyn`` lives). Public
+        read accessor — callers (e.g. #1827 S4b's ``_untrusted`` profile load)
+        resolve project paths from here instead of reaching into the private
+        ``_project_root``."""
+        return self._project_root
+
     def saved_get(self, key: str) -> bool | None:
         """Read accessor for the persisted approvals map. Returns the
         stored boolean (or None when not yet recorded)."""

--- a/tests/test_context_auto_producer_consumer_1827.py
+++ b/tests/test_context_auto_producer_consumer_1827.py
@@ -1,0 +1,84 @@
+"""Tier 2: context-auto producer↔consumer link (#1827 S4b follow-up).
+
+Closes the grep-only coverage gap (lead review note): the PRODUCER
+(``InterventionHandler.deliver_answer_to(external_source=True)`` stamping the
+``external_source`` marker on the session history) and the CONSUMER
+(``Session._effective_contextual_for_turn`` reading that marker → narrowing) are
+linked in ONE test, so a future rename of the marker key on either side breaks
+this test (they can't drift apart).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import tool_contextually_denied
+from reyn.user_intervention import UserIntervention
+
+
+def _session(tmp_path: Path) -> Session:
+    s = Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    s.register_intervention_listener("test")
+    return s
+
+
+@pytest.mark.asyncio
+async def test_external_answer_narrows_next_turn_end_to_end(tmp_path):
+    """Tier 2: an external peer answer delivered through the real intervention
+    path narrows the next turn's contextual — producer stamp → consumer compose.
+
+    Before the answer the agent is un-narrowed (no static profile); after the
+    EXTERNAL answer lands in history, ``_effective_contextual_for_turn`` denies the
+    dangerous surfaces (context-auto), proving the marker producer and consumer
+    agree end-to-end.
+    """
+    s = _session(tmp_path)
+
+    # pre-condition: un-narrowed (byte-identical) — the consumer sees no taint.
+    pre = s._effective_contextual_for_turn()
+    assert pre is None
+
+    # PRODUCER: deliver an external peer answer through the real handler path.
+    iv = UserIntervention(kind="ask_user", prompt="name?", run_id="r1")
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(s._dispatch_intervention(iv))
+    await wait_until(lambda: bool(s._interventions.list_active()))
+    delivered = await s._deliver_answer_to(iv, "Mallory", external_source=True)
+    await asyncio.gather(task, return_exceptions=True)
+    assert delivered is True
+
+    # the marker landed on the session history (producer)
+    assert any((m.meta or {}).get("external_source") for m in s.history)
+
+    # CONSUMER: the next turn's contextual now narrows (context-auto).
+    eff = s._effective_contextual_for_turn()
+    assert eff is not None
+    assert tool_contextually_denied(eff, "exec__sandboxed_exec")
+    assert tool_contextually_denied(eff, "memory_operation__remember_shared")
+    assert not tool_contextually_denied(eff, "recall")  # read stays allowed
+
+
+@pytest.mark.asyncio
+async def test_local_answer_does_not_narrow(tmp_path):
+    """Tier 2: a LOCAL answer (non-external) leaves the next turn un-narrowed
+    (falsify gate — only the external-source marker triggers context-auto)."""
+    s = _session(tmp_path)
+    iv = UserIntervention(kind="ask_user", prompt="?", run_id="r1")
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(s._dispatch_intervention(iv))
+    await wait_until(lambda: bool(s._interventions.list_active()))
+    await s._deliver_answer_to(iv, "local user input", external_source=False)
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert not any((m.meta or {}).get("external_source") for m in s.history)
+    eff = s._effective_contextual_for_turn()
+    assert eff is None


### PR DESCRIPTION
**[e2e-coder]** — #1827 S4b hardening (lead's non-blocking follow-ups, post-merge). Addresses 2 of 3:

- **(1) producer↔consumer e2e** — closes the grep-only coverage gap lead noted: a real external peer answer (via the intervention path) stamps the `external_source` marker on session history, and `Session._effective_contextual_for_turn` then narrows the next turn. The PRODUCER (`intervention_handler`) ↔ CONSUMER (`session`) are linked in one test, so the marker key can't drift apart. Local answer → un-narrowed (falsify gate).
- **(3) cleanliness** — public `PermissionResolver.project_root` property; Session's `_untrusted` load uses it instead of the private `_project_root`.
- **(2) deferred** — per-turn `metas_have_untrusted` scan caching is premature until profiled hot; not in this PR.

Permission/session regression **213 passed**; tier-audit + ruff clean. Refs #1827. #1909 (tool-result vector) still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)