### PR TITLE
fix(security): bound HTTP response-body reads — unbounded-memory DoS (#1913 class) [DoS-A]

### DIFF
--- a/src/reyn/_http_limits.py
+++ b/src/reyn/_http_limits.py
@@ -1,0 +1,45 @@
+"""Shared HTTP response-body byte ceiling (unbounded-body DoS guard, #1913 class).
+
+Single source of truth for the download-byte cap used by the urllib-based HTTP
+helpers (``reyn.api.safe.http`` / ``reyn.api.unsafe.http`` / ``reyn.mcp.registry``)
+and the ``web.fetch.max_download_bytes`` config default. Stdlib-only (no reyn
+imports) so any layer — config, api, mcp — can import it without a cycle.
+
+A bare ``response.read()`` materialises the ENTIRE body into memory, so a
+hostile / compromised / redirecting endpoint can exhaust memory. ``read_capped``
+reads at most ``max_bytes + 1`` and rejects an over-limit body before more than
+the ceiling is ever materialised. (web_fetch uses an equivalent streaming
+ceiling — #1925; this is the urllib-adapted sibling.)
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# 10 MiB — THE single source for the HTTP response-body ceiling. Referenced by
+# the urllib HTTP helpers and the web.fetch.max_download_bytes config default so
+# the value is defined exactly once.
+MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
+
+
+class ResponseTooLargeError(ValueError):
+    """Raised when a response body exceeds the download-byte ceiling.
+
+    Subclasses :class:`ValueError` so existing ``except ValueError`` paths still
+    treat it as a malformed/oversized response.
+    """
+
+
+def read_capped(resp: Any, max_bytes: int = MAX_DOWNLOAD_BYTES) -> bytes:
+    """Read a urllib/file-like response body, bounded to ``max_bytes``.
+
+    Reads at most ``max_bytes + 1`` bytes (so an over-limit body is detected
+    without ever materialising more than the ceiling) and raises
+    :class:`ResponseTooLargeError` if the body exceeds ``max_bytes``.
+    """
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ResponseTooLargeError(
+            f"response body exceeds the {max_bytes}-byte ceiling "
+            "(unbounded-memory guard)"
+        )
+    return raw

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -45,6 +45,8 @@ from urllib.parse import urlparse as _urlparse
 from urllib.request import Request as _Request
 from urllib.request import urlopen as _urlopen
 
+from reyn._http_limits import read_capped
+
 # ── Internal state ─────────────────────────────────────────────────────────
 #
 # Set once at python harness start-up via :func:`_set_permission_context`.
@@ -100,7 +102,7 @@ def _check_host(url: str) -> None:
 
 def _response_dict(resp: Any) -> dict:
     headers = dict(resp.headers.items()) if hasattr(resp, "headers") else {}
-    raw = resp.read()
+    raw = read_capped(resp)  # bounded read — unbounded-body DoS guard (#1913 class)
     try:
         body = raw.decode("utf-8")
     except UnicodeDecodeError:

--- a/src/reyn/api/unsafe/http.py
+++ b/src/reyn/api/unsafe/http.py
@@ -20,10 +20,12 @@ from urllib.error import HTTPError as _HTTPError
 from urllib.request import Request as _Request
 from urllib.request import urlopen as _urlopen
 
+from reyn._http_limits import read_capped
+
 
 def _response_dict(resp: Any) -> dict:
     headers = dict(resp.headers.items()) if hasattr(resp, "headers") else {}
-    raw = resp.read()
+    raw = read_capped(resp)  # bounded read — unbounded-body DoS guard (#1913 class)
     try:
         body = raw.decode("utf-8")
     except UnicodeDecodeError:

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from reyn._http_limits import MAX_DOWNLOAD_BYTES
 from reyn.runtime.budget.budget import CostConfig, CostLimitConfig
 
 
@@ -72,7 +73,7 @@ class WebFetchConfig:
     """
     verify_ssl: bool | None = None
     ca_bundle: str | None = None
-    max_download_bytes: int = 10 * 1024 * 1024
+    max_download_bytes: int = MAX_DOWNLOAD_BYTES  # single-source (#1913 class)
 
 
 @dataclass

--- a/src/reyn/mcp/registry.py
+++ b/src/reyn/mcp/registry.py
@@ -84,6 +84,7 @@ from typing import Any
 # (= dedup is a list transform; server_info_from_raw is a dict reshape)
 # or scoped to reyn-internal disk cache. None of them are reachable from
 # user code through this safe namespace surface.
+from reyn._http_limits import read_capped
 from reyn.core.registry import cache as _cache
 from reyn.core.registry.client import _dedup_by_latest
 from reyn.core.registry.models import server_info_from_raw
@@ -140,7 +141,7 @@ def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     try:
         with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
-            raw = resp.read()
+            raw = read_capped(resp)  # bounded read — DoS guard (#1913 class)
             status = getattr(resp, "status", None) or resp.getcode()
     except urllib.error.HTTPError as exc:
         raise RegistryError(

--- a/tests/test_http_download_ceiling_dos.py
+++ b/tests/test_http_download_ceiling_dos.py
@@ -1,0 +1,89 @@
+"""Tier 2: HTTP response-body download ceiling (unbounded-body DoS, #1913 class).
+
+The urllib HTTP helpers (`reyn.api.safe.http` / `reyn.api.unsafe.http` /
+`reyn.mcp.registry`) read response bodies with a single shared `read_capped`
+seam (`reyn._http_limits`) so a hostile / oversized response is rejected before
+more than `MAX_DOWNLOAD_BYTES` is materialised — the urllib-adapted sibling of
+the web_fetch ceiling (#1925). One mechanism, single-sourced constant.
+
+Policy: real `read_capped` + real `reyn.api.safe.http` (its `_urlopen` is the
+network boundary, patched with a Fake response — no MagicMock of reyn code).
+Tier line first.
+"""
+from __future__ import annotations
+
+import pytest
+
+import reyn.api.safe.http as safe_http
+from reyn._http_limits import (
+    MAX_DOWNLOAD_BYTES,
+    ResponseTooLargeError,
+    read_capped,
+)
+
+
+class _FakeResp:
+    """Minimal urllib-response stand-in: ``read(amt)`` returns up to ``amt``
+    bytes of a fixed body; supports the ``with`` protocol + ``headers``/``status``."""
+
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.headers = {}
+        self.status = status
+
+    def read(self, amt: int | None = None) -> bytes:
+        return self._body[:amt] if amt is not None else self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+# ── read_capped (the single seam) ────────────────────────────────────────────
+
+def test_read_capped_under_limit_returns_body():
+    """Tier 2: a body within the cap is returned in full."""
+    assert read_capped(_FakeResp(b"x" * 50), max_bytes=100) == b"x" * 50
+
+
+def test_read_capped_at_limit_returns_body():
+    """Tier 2: a body exactly at the cap is allowed (boundary)."""
+    assert read_capped(_FakeResp(b"x" * 100), max_bytes=100) == b"x" * 100
+
+
+def test_read_capped_over_limit_rejects():
+    """Tier 2: a body over the cap raises ResponseTooLargeError without
+    materialising more than the ceiling+1."""
+    with pytest.raises(ResponseTooLargeError):
+        read_capped(_FakeResp(b"x" * 1000), max_bytes=100)
+
+
+def test_default_max_is_single_sourced_with_web_fetch():
+    """Tier 2: the helper default and the web.fetch config default are the SAME
+    constant (single-source, no magic-number duplication)."""
+    from reyn.config.media import WebFetchConfig
+    assert WebFetchConfig().max_download_bytes == MAX_DOWNLOAD_BYTES
+
+
+# ── integration: safe.http rejects an oversized body (falsifiable) ───────────
+
+def test_safe_http_rejects_oversized_body(monkeypatch):
+    """Tier 2: reyn.api.safe.http rejects a response body over the ceiling — the
+    bounded read prevents unbounded materialisation. (Pre-fix this returned the
+    whole body with no cap.)"""
+    safe_http._set_permission_context(http_hosts=["example.com"])
+    huge = b"A" * (MAX_DOWNLOAD_BYTES + 1024)
+    monkeypatch.setattr(safe_http, "_urlopen", lambda *a, **k: _FakeResp(huge))
+    with pytest.raises(ResponseTooLargeError):
+        safe_http.get("https://example.com/huge")
+
+
+def test_safe_http_allows_normal_body(monkeypatch):
+    """Tier 2: (regression) a normal-sized body still returns the full envelope."""
+    safe_http._set_permission_context(http_hosts=["example.com"])
+    monkeypatch.setattr(safe_http, "_urlopen", lambda *a, **k: _FakeResp(b"hello"))
+    out = safe_http.get("https://example.com/ok")
+    assert out["status"] == 200
+    assert out["body"] == "hello"


### PR DESCRIPTION
**[dogfood-coder]** — DoS-resilience sweep (issue #1934, part A of A/B/C). #1925 capped web_fetch's unbounded body, but the **same vulnerability class** remained in the urllib HTTP helpers — a point-fix that left the class half-closed.

## Sites fixed (3 urllib `resp.read()` with no size cap)
- `api/safe/http.py` — the **safe** skill HTTP API (host-allowlisted #571, but body-UNBOUNDED; an attacker-influenceable URL or compromised allowlisted host → unbounded memory). Highest severity.
- `api/unsafe/http.py` — unsafe-mode HTTP.
- `mcp/registry.py` — MCP registry response (hostile/compromised registry).

## Fix (lead's design constraints: single-source + one seam)
- New `reyn/_http_limits.py` (stdlib leaf): single-sourced `MAX_DOWNLOAD_BYTES` (10 MiB = the #1925 default) + ONE `read_capped(resp)` helper — reads at most `MAX+1` and rejects an over-limit body before materialising more than the ceiling (urllib-adapted mirror of #1925's streaming cap).
- All 3 sites call `read_capped` — uniform mechanism, completeness-by-construction. Reject expression per caller context: safe/unsafe `raise ResponseTooLargeError`, registry wraps it as `RegistryError`.
- `config/media.py` `WebFetchConfig.max_download_bytes` default now references `MAX_DOWNLOAD_BYTES`, so the 10 MiB ceiling is defined **exactly once** across web_fetch + the urllib helpers (no magic-number duplication).

## Verification
- 6 Tier-2 tests: `read_capped` (under / at / over limit) + single-source assert + safe.http integration (oversized → reject, normal → ok).
- **Falsification**: revert `read_capped`→`resp.read()` → the integration test goes RED (oversized body no longer rejected); restore → green.
- 53 relevant existing tests pass (web_fetch ceiling #1913, mcp registry, http_get, safe-stdlib, registry-client) — no regression. `ruff` + `test_tier_audit --strict` clean.

## Test plan
- [x] 6 new Tier-2 tests pass
- [x] Falsification: integration RED on pre-fix code, GREEN after
- [x] 53 relevant existing tests green (no regression)
- [x] ruff + test-tier audit clean

## Cluster (#1934) — next, sequential (mine)
B) WS inbound frame (`ws/chat.py:190` `receive_text`, no size cap) and C) subprocess stdout (`SandboxResult.truncated` designed-but-unwired) per lead's routing.

Addresses #1934 (part A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)