### PR TITLE
fix(security/web): pin WebSocket frame ceiling explicitly + operator-tunable (web.ws_max_size) [DoS-B]

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -327,6 +327,7 @@ web:
   fetch:
     verify_ssl: true     # true | false | 省略（デフォルト: 環境変数チェーン）
     ca_bundle: /path/to/ca-bundle.pem   # 省略可; カスタム CA バンドル
+  ws_max_size: 16777216  # WebSocket インバウンドフレーム上限（デフォルト 16MB）
 ```
 
 優先度チェーン（高い順）:
@@ -339,6 +340,8 @@ web:
 | 4 | 両方省略 | フォールスルー: `SSL_VERIFY` 環境変数 → `litellm.ssl_verify` → `SSL_CERT_FILE` → `True` |
 
 `verify_ssl` と `ca_bundle` は MCP レジストリの HTTP 呼び出し（パッケージインストール）にも適用されます。
+
+`web.ws_max_size`（int, デフォルト `16777216` = 16MB）は `reyn web` ゲートウェイが受け付ける単一 WebSocket インバウンドフレームの最大バイト数。サーバーライブラリの暗黙デフォルトに依存せず上限を明示的に固定するため、ライブラリアップグレード後も bound が維持されます。operator は tighten / loosen 可能。`<= 0` / 非整数はデフォルトにフォールバック。
 
 ## `eval` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -545,6 +545,7 @@ web:
     verify_ssl: true     # true | false | omit (default: env-var chain)
     ca_bundle: /path/to/ca-bundle.pem   # optional custom CA bundle
     max_download_bytes: 10485760        # wire-byte ceiling (default 10MB)
+  ws_max_size: 16777216                 # WS inbound-frame ceiling (default 16MB)
 ```
 
 Priority chain (highest first):
@@ -561,6 +562,7 @@ Priority chain (highest first):
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `web.fetch.max_download_bytes` | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
+| `web.ws_max_size` | int | `16777216` (16MB) | Maximum size (bytes) of a single inbound WebSocket frame the `reyn web` gateway accepts; a larger frame is rejected by the server before delivery. Pins the WebSocket frame ceiling explicitly instead of relying on the server library's implicit default, so the bound stays in place across server-library upgrades. Operators may tighten or loosen it. `<= 0` or non-integer falls back to the default. |
 
 ## `eval` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -590,6 +590,7 @@
 #     verify_ssl: null              # null = delegate to env / litellm fallback
 #     ca_bundle: null               # absolute / cwd-relative PEM path
 #     max_download_bytes: 10485760  # 10MB wire-byte ceiling (DoS guard)
+#   ws_max_size: 16777216           # 16MB WebSocket inbound-frame ceiling (reyn web gateway)
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -76,14 +76,23 @@ class WebFetchConfig:
     max_download_bytes: int = MAX_DOWNLOAD_BYTES  # single-source (#1913 class)
 
 
+# Default WebSocket max frame size (bytes) for the `reyn web` gateway. Pins
+# uvicorn/websockets' implicit 16 MiB default EXPLICITLY so a uvicorn version
+# bump or an operator server override can't silently drop the bound. Operator-
+# tunable via ``web.ws_max_size``.
+DEFAULT_WS_MAX_SIZE = 16 * 1024 * 1024
+
+
 @dataclass
 class WebConfig:
-    """`web:` — web operation settings.
+    """`web:` — web settings.
 
-    Aggregates ``web.fetch`` sub-section. Extend here when ``web.search``
-    gets its own knobs.
+    Aggregates the ``web.fetch`` sub-section (web_fetch operation knobs) and
+    ``ws_max_size`` (the gateway WebSocket inbound-frame ceiling). Extend here
+    when ``web.search`` gets its own knobs.
     """
     fetch: WebFetchConfig = field(default_factory=WebFetchConfig)
+    ws_max_size: int = DEFAULT_WS_MAX_SIZE
 
 
 def _build_web_fetch_config(raw: object) -> WebFetchConfig:
@@ -116,7 +125,13 @@ def _build_web_config(raw: object) -> WebConfig:
     if not isinstance(raw, dict):
         return WebConfig()
     fetch_raw = raw.get("fetch")
-    return WebConfig(fetch=_build_web_fetch_config(fetch_raw))
+    try:
+        ws_max_size = int(raw.get("ws_max_size", DEFAULT_WS_MAX_SIZE))
+        if ws_max_size <= 0:
+            ws_max_size = DEFAULT_WS_MAX_SIZE
+    except (TypeError, ValueError):
+        ws_max_size = DEFAULT_WS_MAX_SIZE
+    return WebConfig(fetch=_build_web_fetch_config(fetch_raw), ws_max_size=ws_max_size)
 
 
 # ── multimodal: media-size gate for image/audio/etc. (#364 cluster) ─────────

--- a/src/reyn/interfaces/cli/commands/web.py
+++ b/src/reyn/interfaces/cli/commands/web.py
@@ -192,10 +192,18 @@ def run(args: argparse.Namespace) -> None:
     # uvicorn.run so the lazy session factory / perm resolver read them).
     _apply_cli_scoped_overrides(args)
 
+    # Explicit WebSocket frame ceiling: previously this relied on uvicorn's
+    # implicit ~16 MiB default, which a uvicorn version bump or operator server
+    # override could silently drop. Pin it from config (operator-tunable via
+    # web.ws_max_size) so the inbound-frame bound is explicit + version-independent.
+    from reyn.config import load_config
+    _ws_max_size = load_config().web.ws_max_size
+
     uvicorn.run(
         "reyn.interfaces.web.server:app",
         host=args.host,
         port=args.port,
         reload=args.reload,
         log_level=args.log_level,
+        ws_max_size=_ws_max_size,
     )

--- a/tests/test_web_ws_max_size_config_1934.py
+++ b/tests/test_web_ws_max_size_config_1934.py
@@ -1,0 +1,66 @@
+"""Tier 2: web.ws_max_size explicit WebSocket frame ceiling (#1934 part B).
+
+The `reyn web` gateway previously relied on uvicorn's IMPLICIT ~16 MiB ws_max_size
+default to bound inbound WebSocket frames. This pins it EXPLICITLY + makes it
+operator-tunable via `web.ws_max_size`, so a uvicorn version bump or an operator
+server override cannot silently drop the bound. Hardening (fragility removal),
+not an unbounded-vuln fix — frames were already server-bounded at 16 MiB.
+
+Policy: real `_build_web_config` + real `web.run` (uvicorn.run / load_config are
+the external/boundary seams, patched). Tier line first.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+
+import pytest
+
+from reyn.config.media import (
+    DEFAULT_WS_MAX_SIZE,
+    WebConfig,
+    _build_web_config,
+)
+
+# ── config round-trip ────────────────────────────────────────────────────────
+
+def test_ws_max_size_round_trip_non_default():
+    """Tier 2: a NON-DEFAULT ws_max_size round-trips — a non-default value proves
+    real parsing (a default value would pass even if the field were unwired)."""
+    cfg = _build_web_config({"ws_max_size": 5_000_000})
+    assert cfg.ws_max_size == 5_000_000
+    assert cfg.ws_max_size != DEFAULT_WS_MAX_SIZE
+
+
+def test_ws_max_size_default_when_absent():
+    """Tier 2: a missing ws_max_size → the named default constant."""
+    assert _build_web_config({}).ws_max_size == DEFAULT_WS_MAX_SIZE
+    assert WebConfig().ws_max_size == DEFAULT_WS_MAX_SIZE
+
+
+@pytest.mark.parametrize("bad", [0, -5, "x", None])
+def test_ws_max_size_invalid_falls_back_to_default(bad):
+    """Tier 2: <=0 / non-integer falls back to the default (no crash, no zero cap)."""
+    assert _build_web_config({"ws_max_size": bad}).ws_max_size == DEFAULT_WS_MAX_SIZE
+
+
+# ── wiring: the value reaches uvicorn.run ─────────────────────────────────────
+
+def test_web_run_passes_ws_max_size_to_uvicorn(monkeypatch):
+    """Tier 2: `reyn web` threads the configured ws_max_size through to uvicorn.run
+    (the bound is actually applied at the server, not merely stored in config)."""
+    import uvicorn
+
+    import reyn.config as config_mod
+    import reyn.interfaces.cli.commands.web as web_cmd
+    from reyn.config.root import ReynConfig
+
+    cfg = dataclasses.replace(ReynConfig(), web=WebConfig(ws_max_size=7_000_000))
+    monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: cfg)
+    captured: dict = {}
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **k: captured.update(k))
+
+    web_cmd.run(
+        argparse.Namespace(host="127.0.0.1", port=8080, reload=False, log_level="info")
+    )
+    assert captured.get("ws_max_size") == 7_000_000


### PR DESCRIPTION
**[dogfood-coder]** — DoS sweep (issue #1934, part B). Per lead's decision: **primary layer only** (explicit + configurable `ws_max_size`), app-side check skipped.

## What
The `reyn web` gateway relied on uvicorn's **implicit ~16 MiB `ws_max_size` default** to bound inbound WebSocket frames. A uvicorn version bump or an operator server override could silently drop that bound. This pins it **explicitly** and makes it **operator-tunable**: `WebConfig.ws_max_size` (named `DEFAULT_WS_MAX_SIZE` = 16 MiB, single-source) parsed from `web.ws_max_size` (`<=0`/non-int → default), threaded into `uvicorn.run(ws_max_size=...)`.

## Why this is hardening, not a vuln fix
Frames were already server-bounded at 16 MiB (co-vet-confirmed: `uvicorn.run` had no `ws_max_size` → uvicorn/websockets default rejects a >16 MiB frame before `receive_text()` returns; the receive loop processes frames independently, no accumulation). This removes the **implicit-default fragility** — pins the bound explicit + version-independent + operator-tunable. The app-side tighter check was intentionally **skipped** (redundant with the transport bound + a hardcoded tighter cap would reject legit large pastes = UX cost; operators tighten via config).

## Verification
- 7 Tier-2 tests: non-default round-trip (proves real parsing) + clamp (`<=0`/non-int → default) + **wiring** (`reyn web` threads `ws_max_size` into `uvicorn.run`).
- **Falsification**: drop the `ws_max_size=` kwarg → the wiring test goes RED.
- Regression: 35 config/web tests pass (web-fetch cap, SSL config, config cascade/malformed). `ruff` + `test_tier_audit --strict` clean. `mkdocs build --strict` rc=0.
- config-mirror (#1056): `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md`; en + ja reference updated.

## Test plan
- [x] 7 new Tier-2 tests pass
- [x] Falsification: wiring test RED without the kwarg
- [x] 35 config/web regression tests green
- [x] ruff + test-tier audit + mkdocs --strict clean
- [x] config-mirror (example + reference, en/ja)

## Note
The ja `web` reference block was already missing `web.fetch.max_download_bytes` (a pre-existing en-only gap from #1925/#1936) — flagged to docs-maintainer separately; not backfilled here to keep this PR scoped.

Addresses #1934 (part B). C (subprocess stdout, C2 bounded-read) is next — design-review-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)