### PR TITLE
fix(1918): remove dead ChannelState.to_dict/from_dict + false-resilience docstring

### DIFF
--- a/src/reyn/runtime/channel_state.py
+++ b/src/reyn/runtime/channel_state.py
@@ -32,7 +32,6 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -211,50 +210,6 @@ class ChannelState:
             if current - self.last_ack_at > self.stale_after:
                 return False
         return True
-
-    def to_dict(self) -> dict[str, Any]:
-        """JSON-safe serialization for persistence (= RunRegistry Phase 1
-        snapshot integration)."""
-        return {
-            "channel_id": self.channel_id,
-            "is_open": self.is_open,
-            "last_ack_at": (
-                self.last_ack_at.isoformat()
-                if self.last_ack_at is not None
-                else None
-            ),
-            "delivery_failures": self.delivery_failures,
-            "delivery_attempts_total": self.delivery_attempts_total,
-            "failure_threshold": self.failure_threshold,
-            "stale_after_seconds": self.stale_after.total_seconds(),
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ChannelState":
-        """Inverse of ``to_dict``. Resilient to missing optional fields."""
-        last_ack_raw = data.get("last_ack_at")
-        last_ack: datetime | None = None
-        if isinstance(last_ack_raw, str):
-            try:
-                last_ack = datetime.fromisoformat(last_ack_raw)
-            except ValueError:
-                last_ack = None
-        stale_seconds = data.get("stale_after_seconds")
-        try:
-            stale_after = timedelta(seconds=float(stale_seconds))
-        except (TypeError, ValueError):
-            stale_after = timedelta(minutes=5)
-        return cls(
-            channel_id=str(data.get("channel_id", "")),
-            is_open=bool(data.get("is_open", True)),
-            last_ack_at=last_ack,
-            delivery_failures=int(data.get("delivery_failures", 0) or 0),
-            delivery_attempts_total=int(
-                data.get("delivery_attempts_total", 0) or 0,
-            ),
-            failure_threshold=int(data.get("failure_threshold", 3) or 3),
-            stale_after=stale_after,
-        )
 
 
 __all__ = [

--- a/tests/test_channel_state.py
+++ b/tests/test_channel_state.py
@@ -19,9 +19,7 @@ Pins:
   4. ``ChannelState.is_alive`` 3-way inference: explicit ``is_open=False``,
      ``delivery_failures >= failure_threshold``, stale ``last_ack_at``
      all return False; otherwise True.
-  5. JSON round-trip preserves shape (= persistence into RunRegistry
-     snapshot Phase 2 follow-up).
-  6. Default values (= DEFAULT_RETRY_POLICY, NO_RETRY_POLICY) are the
+  5. Default values (= DEFAULT_RETRY_POLICY, NO_RETRY_POLICY) are the
      expected shapes.
 
 No mocks. Pure data-model tests.
@@ -218,53 +216,3 @@ def test_channel_state_is_alive_true_when_last_ack_is_recent() -> None:
     state = ChannelState(channel_id="a2a:test", last_ack_at=ts)
     assert state.is_alive(now=slightly_later) is True
 
-
-# ── 5. JSON round-trip ──────────────────────────────────────────────
-
-
-def test_channel_state_to_dict_from_dict_round_trip() -> None:
-    """Tier 2: ``to_dict`` + ``from_dict`` preserves shape verbatim.
-
-    Used by RunRegistry Phase 2 follow-up to persist channel state
-    alongside RunEntry; this round-trip pin guards the contract.
-    """
-    ts = datetime(2026, 5, 20, 12, 30, 0, tzinfo=timezone.utc)
-    state = ChannelState(
-        channel_id="a2a:run-abc123",
-        is_open=True,
-        last_ack_at=ts,
-        delivery_failures=1,
-        delivery_attempts_total=5,
-        failure_threshold=5,
-        stale_after=timedelta(minutes=10),
-    )
-    restored = ChannelState.from_dict(state.to_dict())
-    assert restored.channel_id == state.channel_id
-    assert restored.is_open == state.is_open
-    assert restored.last_ack_at == state.last_ack_at
-    assert restored.delivery_failures == state.delivery_failures
-    assert restored.delivery_attempts_total == state.delivery_attempts_total
-    assert restored.failure_threshold == state.failure_threshold
-    assert restored.stale_after == state.stale_after
-
-
-def test_channel_state_from_dict_tolerates_missing_fields() -> None:
-    """Tier 2: ``from_dict`` with a minimal payload returns a usable
-    state (= defaults applied for missing optional fields).
-    """
-    state = ChannelState.from_dict({"channel_id": "a2a:test"})
-    assert state.channel_id == "a2a:test"
-    assert state.is_open is True
-    assert state.last_ack_at is None
-    assert state.delivery_failures == 0
-
-
-def test_channel_state_from_dict_tolerates_malformed_timestamp() -> None:
-    """Tier 2: a malformed ``last_ack_at`` ISO string yields ``None``
-    rather than crashing on restore.
-    """
-    state = ChannelState.from_dict({
-        "channel_id": "a2a:test",
-        "last_ack_at": "not a real timestamp",
-    })
-    assert state.last_ack_at is None


### PR DESCRIPTION
**[per-PR-coder]** — Closes #1918.

## Summary

- **Dead code confirmed**: `ChannelState.to_dict` and `ChannelState.from_dict` have zero production callers. Caller grep across all of `src/` and `tests/` found only 3 call sites — all in `tests/test_channel_state.py` (the tests that exercised the dead methods).
- **False-resilience docstring removed**: The `to_dict` docstring claimed "persistence into RunRegistry snapshot Phase 2 follow-up"; the `from_dict` docstring said "Resilient to missing optional fields." Both referenced a persistence path that was never implemented. `run_registry.py` lines 72–74 explicitly document `_webhook_channel_state` as "In-memory only (not persisted) — restart starts fresh", confirming the Phase 2 follow-up never landed.
- **Clean-break per convention**: No deprecation shim added. Two methods + one now-unused `Any` import deleted from `channel_state.py`. Three tests (`test_channel_state_to_dict_from_dict_round_trip`, `test_channel_state_from_dict_tolerates_missing_fields`, `test_channel_state_from_dict_tolerates_malformed_timestamp`) deleted from `test_channel_state.py`.

## Caller-grep evidence

```
grep -rn "ChannelState\.from_dict\|ChannelState\.to_dict\|channel_state\.to_dict\|channel_state\.from_dict" src/ tests/
```

Results — tests only (3 call sites, all in `tests/test_channel_state.py`):
```
tests/test_channel_state.py:241:    restored = ChannelState.from_dict(state.to_dict())
tests/test_channel_state.py:255:    state = ChannelState.from_dict({"channel_id": "a2a:test"})
tests/test_channel_state.py:266:    state = ChannelState.from_dict({
```

Zero hits in `src/`. Verdict: **test-only callers — case (b)** → remove methods + tests.

## Test plan

- [x] `python -m pytest tests/test_channel_state.py tests/test_channel_state_webhook_wire_269.py tests/test_webhook_delivery_ack.py -v` — 26 passed, 1 skipped (pre-existing skip for httpx optional dep)
- [x] `python -m pytest tests/test_os_invariants.py -v` — 9 passed
- [x] `ruff check src tests --fix` — all checks passed
- [x] `python scripts/test_tier_audit.py` — 7571 tests inspected, 0 errors, 0 warnings
- [x] Full test suite (excl. optional-dep fastapi/mcp tests that fail pre-change on this env): 7729 passed, 6 failed (all pre-existing: missing `mcp` module + `reyn.safe` path shim test), 37 skipped

## Files changed

- `src/reyn/runtime/channel_state.py`: deleted `to_dict`, `from_dict`, unused `from typing import Any`
- `tests/test_channel_state.py`: deleted 3 tests that only exercised the dead serialization surface; updated module docstring item list (removed item 5 referencing JSON round-trip)