### PR TITLE
docs(reference/config): backfill web.fetch.max_download_bytes in reyn-yaml.ja

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -327,6 +327,7 @@ web:
   fetch:
     verify_ssl: true     # true | false | 省略（デフォルト: 環境変数チェーン）
     ca_bundle: /path/to/ca-bundle.pem   # 省略可; カスタム CA バンドル
+    max_download_bytes: 10485760        # ワイヤバイト上限（デフォルト 10MB）
   ws_max_size: 16777216  # WebSocket インバウンドフレーム上限（デフォルト 16MB）
 ```
 
@@ -340,6 +341,8 @@ web:
 | 4 | 両方省略 | フォールスルー: `SSL_VERIFY` 環境変数 → `litellm.ssl_verify` → `SSL_CERT_FILE` → `True` |
 
 `verify_ssl` と `ca_bundle` は MCP レジストリの HTTP 呼び出し（パッケージインストール）にも適用されます。
+
+`web.fetch.max_download_bytes`（int, デフォルト `10485760` = 10MB）は `web_fetch` がワイヤから読み取るレスポンスの最大バイト数。`Content-Length` がこの値を超えるレスポンスは本文ダウンロード前に拒否され、chunked / 長さ不明の本文はストリームが上限を超えた時点で中断されます（ステータス `too_large`）。悪意ある / 暴走 URL による無制限な本文のメモリ枯渇を防ぎます。`<= 0` / 非整数はデフォルトにフォールバック。
 
 `web.ws_max_size`（int, デフォルト `16777216` = 16MB）は `reyn web` ゲートウェイが受け付ける単一 WebSocket インバウンドフレームの最大バイト数。サーバーライブラリの暗黙デフォルトに依存せず上限を明示的に固定するため、ライブラリアップグレード後も bound が維持されます。operator は tighten / loosen 可能。`<= 0` / 非整数はデフォルトにフォールバック。
 


### PR DESCRIPTION
**[docs-maintainer]** — JA-parity backfill flagged by dogfood-coder (sandbox_2) during the DoS-fix wave.

## What

`docs/reference/config/reyn-yaml.md` (EN) documents `web.fetch.max_download_bytes` — the wire-byte download ceiling (default 10MB), added with the unbounded-body DoS fix. The JA mirror's `web` block was updated EN-only and lacked this field (it carried only `verify_ssl` / `ca_bundle` / `ws_max_size`).

This PR adds to `reyn-yaml.ja.md`:
- the `max_download_bytes: 10485760` line in the `web.fetch:` YAML example
- a JA description paragraph mirroring the EN field-table entry (Content-Length pre-check, chunked-stream abort → `too_large`, `<= 0`/non-int fallback)

Pure JA-parity sync; no EN or behaviour change. `ws_max_size` (added separately) already had both EN+JA.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → EXIT=0, 0 WARNING, no Aborted (direct log read)
- [x] EN/JA `web.fetch` blocks now at field parity (`verify_ssl` / `ca_bundle` / `max_download_bytes` + `ws_max_size`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)