### PR TITLE
fix(tui/#1944): emit skill-done trace on skill success/budget — async-strip ghost

### DIFF
--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -936,11 +936,40 @@ class SkillRunner:
                     ))
                 except Exception:  # noqa: BLE001
                     pass
+                # #1944: like the abort branch (#106) and the success branch,
+                # enqueue a "skill done:" trace so the background skill's
+                # AsyncStackPanel row is removed (terminal="aborted" path:
+                # the strip flashes the ✗ shape before unmounting). Without
+                # this the budget-exceeded background skill ghosts too — the
+                # sibling gap to the success-path ghost.
+                try:
+                    await self._put_outbox(SkillOutboundMessage(
+                        kind="trace", text="skill done: aborted: budget exceeded",
+                        meta=meta,
+                    ))
+                except Exception:  # noqa: BLE001
+                    pass
             else:
                 self._accumulate(result)
                 self._events.emit(
                     "skill_run_completed", run_id=run_id, skill=skill_name, status=result.status,
                 )
+                # #1944: a spawned (background) skill's bottom-strip
+                # AsyncStackPanel row is removed by the TUI on the
+                # "skill done:" trace. The abort branch above already
+                # enqueues one directly (#106); the success branch must do
+                # the same — otherwise a successfully-completing background
+                # skill leaves a ghost row with its elapsed counter ticking
+                # forever. Explicit enqueue = completeness-by-construction
+                # (every terminal branch emits "skill done:"); the TUI's
+                # remove is idempotent, so this is safe even if any forwarder
+                # path also delivers one.
+                try:
+                    await self._put_outbox(SkillOutboundMessage(
+                        kind="trace", text="skill done: finished", meta=meta,
+                    ))
+                except Exception:  # noqa: BLE001 — same defense as the abort path
+                    pass
                 _terminal_status = result.status or "finished"
                 _terminal_data = result.data or {}
         finally:

--- a/tests/test_skill_runner_success_done_trace_1944.py
+++ b/tests/test_skill_runner_success_done_trace_1944.py
@@ -1,0 +1,153 @@
+"""Tier 2: SkillRunner emits ``skill done: finished`` trace on success (#1944).
+
+A spawned (background) skill's bottom-strip AsyncStackPanel row is removed by
+the TUI's ``_handle_trace_for_skill_row`` when it sees a ``"skill done:"``
+trace. The abort/exception branch already enqueues one directly (#106,
+``test_skill_runner_aborted_trace``). The **success** branch did NOT — so a
+successfully-completing background skill left a ghost row whose elapsed counter
+ticked forever (observed in real-terminal e2e: ~2.5 s skill still shown
+"running · 1m24s" 90 s later).
+
+This pins the symmetric contract: every non-cancelled terminal branch of
+``_run_one_skill`` enqueues a ``"skill done:"`` trace (completeness-by-
+construction). The TUI's remove is idempotent, so this is safe even if a
+forwarder path also delivers one.
+
+Policy: real EventLog, real asyncio.Queue, real SkillRunner. No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.core.events.events import EventLog
+from reyn.runtime.forwarder import ChatEventForwarder
+from reyn.skill.skill_runner import SkillRunner
+
+
+class _BudgetCheck:
+    allowed: bool = True
+    hard_dimension = None
+    detail = None
+
+    def __init__(self) -> None:
+        self.context: dict = {}
+        self.warn_dimensions: list = []
+
+
+class _Budget:
+    def check_pre_spawn(self, *, chain_id: str, skill: str) -> _BudgetCheck:
+        return _BudgetCheck()
+
+    def record_spawn(self, *, chain_id: str, skill: str) -> None:
+        pass
+
+    def extend_chain_calls(self, *, chain_id: str, skill: str, additional: int) -> int:
+        return additional
+
+
+class _Result:
+    """Minimal duck-typed successful skill result."""
+
+    def __init__(self) -> None:
+        self.status = "completed"
+        self.data: dict = {"answer": "ok"}
+        self.error = None
+
+
+class _SucceedingAgent:
+    """Agent whose ``run`` returns a normal successful result."""
+
+    async def run(self, skill: Any, input_artifact: dict, **kwargs) -> Any:
+        return _Result()
+
+
+def _make_runner_with_succeeding_agent():
+    events = EventLog()
+    outbox: asyncio.Queue = asyncio.Queue()
+    completed_payloads: list[dict] = []
+
+    def _build_agent(run_id, skill_name, *, subscribers=None) -> _SucceedingAgent:
+        return _SucceedingAgent()
+
+    async def _put_outbox(msg) -> None:
+        await outbox.put(msg)
+
+    async def _enqueue_completed(*, run_id, skill, chain_id, status, data) -> None:
+        completed_payloads.append({
+            "run_id": run_id, "skill": skill, "chain_id": chain_id,
+            "status": status, "data": data,
+        })
+
+    def _accumulate(_result) -> None:
+        pass
+
+    def _drop_interventions(_run_id) -> None:
+        pass
+
+    def _get_skill_registry():
+        return None
+
+    async def _ask_budget_extension(**kwargs) -> bool:
+        return False
+
+    runner = SkillRunner(
+        event_log=events,
+        agent_name="test_agent",
+        output_language=None,
+        mcp_servers=None,
+        allowed_skills=None,
+        budget=_Budget(),
+        state_log=None,
+        build_agent_fn=_build_agent,
+        put_outbox=_put_outbox,
+        enqueue_skill_completed=_enqueue_completed,
+        accumulate=_accumulate,
+        drop_interventions_for_run=_drop_interventions,
+        get_skill_registry=_get_skill_registry,
+        ask_budget_extension=_ask_budget_extension,
+        make_subscribers=lambda skill_name, run_id=None: [
+            ChatEventForwarder(skill_name, outbox, run_id=run_id),
+        ],
+        format_refusal=lambda check: "refused",
+        format_warn=lambda dim, ctx: "warn",
+    )
+    return runner, outbox, completed_payloads
+
+
+def test_successful_skill_emits_skill_done_finished_trace(tmp_path, monkeypatch):
+    """Tier 2: a successfully-completing spawned skill enqueues a
+    ``skill done: finished`` trace so the TUI removes its async-strip row."""
+    import reyn.skill.skill_runner as sr_mod
+
+    dummy_dir = tmp_path / "fake_skill"
+    dummy_dir.mkdir()
+    monkeypatch.setattr(sr_mod, "resolve_skill_path", lambda name: (dummy_dir, tmp_path))
+    monkeypatch.setattr(sr_mod, "load_dsl_skill", lambda path, *, skill_root: object())
+
+    runner, outbox, completed = _make_runner_with_succeeding_agent()
+
+    async def _run() -> None:
+        await runner.spawn({"skill": "fake", "input": {}})
+        for _ in range(20):
+            if runner.running_names() == []:
+                break
+            await asyncio.sleep(0)
+        assert runner.running_names() == [], "task did not finish"
+
+    asyncio.run(_run())
+
+    msgs = []
+    while not outbox.empty():
+        msgs.append(outbox.get_nowait())
+
+    trace_msgs = [m for m in msgs if m.kind == "trace"]
+    finished_traces = [m for m in trace_msgs if m.text == "skill done: finished"]
+    assert finished_traces, (
+        "expected a 'skill done: finished' trace on successful completion so the "
+        f"TUI removes the async-strip row; got traces={[m.text for m in trace_msgs]}"
+    )
+
+    # The trace must carry the run_id so the TUI addresses the right strip row.
+    (only_completed,) = completed
+    assert finished_traces[0].meta.get("run_id") == only_completed["run_id"]


### PR DESCRIPTION
**[tui-coder]** — fix(tui/#1944): emit "skill done:" trace on skill success/budget — async-strip ghost task

Closes the ghost-task bug discovered via **real-terminal (tmux) e2e** and root-caused under lead's design-review-first protocol.

## Bug
A spawned (background) skill's bottom-strip `AsyncStackPanel` row is removed by the TUI's `_handle_trace_for_skill_row` when it sees a `"skill done:"` trace. `_run_one_skill`'s **abort/exception** branch already enqueues one directly (#106), but the **success** (L939) and **budget_exceeded** (L923) branches did not — so a successfully-completing background skill left a **ghost row** with its elapsed counter ticking forever.

### Primary evidence (real-terminal e2e)
- skill-run trace: `workflow_finished` @ 21:22:54.76 (ran ~2.5s)
- tmux capture @ 21:24:21: strip still `⟳ direct_llm · 1m24s async: …` (~90s after completion)
- Ctrl+C → `✗ nothing in-flight to cancel` (corroborates the skill had ended)

## Root cause (code-pinned, design-reviewed)
Asymmetric terminal-branch wiring in `_run_one_skill` (the spawn/background-only path; sole caller `spawn` via `create_task`): abort explicitly enqueues `"skill done: aborted"` (the #106 fix), but success/budget rely on the OS `workflow_finished`→forwarder path, which doesn't deliver the remove for spawned skills.

## Fix
Success and budget branches now enqueue a `"skill done:"` trace via `_put_outbox`, mirroring the abort branch — **completeness-by-construction** (every non-cancelled terminal branch emits `"skill done:"`). The remove is then guaranteed whether or not a forwarder path also delivers one; the TUI's remove is **idempotent**, so a double is contained. Spawned-only path → no foreground double-fire. Including the **budget** sibling avoids leaving a budget-exceeded ghost.

## Test plan
- [x] `tests/test_skill_runner_success_done_trace_1944.py` — Tier 2: a successful spawned skill enqueues a `"skill done: finished"` trace carrying the `run_id`. **Confirmed RED before the fix** (`traces=[]`). Real `EventLog` + `asyncio.Queue` + `SkillRunner`, no mocks (mirrors `test_skill_runner_aborted_trace`).
- [x] `tests/test_skill_runner_aborted_trace.py` — abort sibling still green
- [x] skill_runner / forwarder / async_stack suites — **88 passed**, no regression
- [x] `python scripts/test_tier_audit.py` — 0 violations
- [x] ruff clean

## Tier self-check
1 new test, Tier 2 (real collaborators, public outbox-queue + completed-payloads observation — no private-state asserts, no len()-pinning, no mocks, no golden files). Docstring declares `Tier 2:`.

Refs #1944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
