### PR TITLE
feat(#1811): A2A tasks/list (ListTasks) — contextId filter + keyset pagination

### DIFF
--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -37,6 +37,8 @@ Spec reference: https://google.github.io/A2A/
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import logging
 import uuid
 from typing import Any
@@ -288,7 +290,9 @@ async def a2a_jsonrpc(
 ) -> dict:
     """JSON-RPC 2.0 endpoint for one Reyn agent.
 
-    Supported method: ``message/send``. Three modes:
+    Supported methods: ``message/send`` and ``tasks/list``.
+
+    ``message/send`` has three modes:
 
     1. **Answer injection** (``params.task_id`` present): deliver an
        answer to a pending ask_user intervention on a running async task.
@@ -327,11 +331,114 @@ async def a2a_jsonrpc(
         return await _handle_message_send(
             req_id, body.get("params") or {}, agent_name, registry, run_registry,
         )
+    if method == "tasks/list":
+        return await _handle_tasks_list(
+            req_id, body.get("params") or {}, agent_name, run_registry,
+        )
 
     return _jsonrpc_error(
         req_id,
         _METHOD_NOT_FOUND,
-        f"Method not found: {method!r}. Supported: message/send.",
+        f"Method not found: {method!r}. Supported: message/send, tasks/list.",
+    )
+
+
+# ── tasks/list — A2A ListTasks (#1811) ──────────────────────────────────────
+
+_LIST_TASKS_DEFAULT_PAGE_SIZE = 50
+_LIST_TASKS_MAX_PAGE_SIZE = 100  # A2A spec cap
+
+
+def _task_sort_key(entry) -> tuple[str, str]:
+    """Stable keyset order: (created_at, run_id). ISO-8601 timestamps sort
+    lexicographically = chronologically (all entries are UTC), and run_id
+    breaks ties — so the order is total and insertion-stable, which is what
+    makes the opaque page token a correct keyset cursor."""
+    return (entry.created_at.isoformat(), entry.run_id)
+
+
+def _encode_page_token(entry) -> str:
+    raw = json.dumps(
+        {"created_at": entry.created_at.isoformat(), "run_id": entry.run_id},
+        separators=(",", ":"),
+    )
+    return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+def _decode_page_token(token: str) -> tuple[str, str] | None:
+    """Inverse of :func:`_encode_page_token`. Returns None for any malformed
+    token (→ caller responds -32602 invalid params)."""
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+        data = json.loads(raw)
+        return (str(data["created_at"]), str(data["run_id"]))
+    except Exception:
+        return None
+
+
+async def _handle_tasks_list(
+    req_id: Any,
+    params: dict,
+    agent_name: str,
+    run_registry,
+) -> dict:
+    """A2A ``tasks/list`` — this agent's tasks, optionally filtered by
+    ``contextId`` (→ core session_id) and ``status``, keyset-paginated.
+
+    The A2A spec names this ``ListTasks`` (PascalCase); it is bound here as
+    slash-form ``tasks/list`` to stay consistent with the existing
+    ``message/send`` JSON-RPC binding Reyn ships (#1811). ``status`` is matched
+    against Reyn's own status names (the spec→Reyn STATUS_MAP normalization is a
+    separate cross-cutting #1811 slice that will normalize both ``tasks/list``
+    output and ``GetTask`` together — deferred here to avoid coupling).
+    """
+    # contextId (A2A term) → core-neutral session_id at the layer boundary; the
+    # A2A layer owns this map so core (RunRegistry) stays term-neutral (#1814).
+    context_id = params.get("contextId")
+    session_id = a2a_session_id(context_id) if context_id else None
+
+    entries = run_registry.list(agent_name, session_id=session_id)
+
+    status_filter = params.get("status")
+    if status_filter is not None:
+        entries = [e for e in entries if e.status == status_filter]
+
+    entries.sort(key=_task_sort_key)
+    total_size = len(entries)  # full filtered set, before pagination
+
+    raw_page_size = params.get("pageSize")
+    if raw_page_size is None:
+        page_size = _LIST_TASKS_DEFAULT_PAGE_SIZE
+    else:
+        try:
+            page_size = int(raw_page_size)
+        except (TypeError, ValueError):
+            return _jsonrpc_error(req_id, _INVALID_PARAMS, "pageSize must be an integer")
+        if page_size < 1:
+            return _jsonrpc_error(req_id, _INVALID_PARAMS, "pageSize must be >= 1")
+        page_size = min(page_size, _LIST_TASKS_MAX_PAGE_SIZE)
+
+    page_token = params.get("pageToken")
+    if page_token:
+        cursor = _decode_page_token(page_token)
+        if cursor is None:
+            return _jsonrpc_error(req_id, _INVALID_PARAMS, "invalid pageToken")
+        # Keyset: keep only entries strictly after the cursor's sort key.
+        entries = [e for e in entries if _task_sort_key(e) > cursor]
+
+    page = entries[:page_size]
+    # nextPageToken MUST always be present; '' when there are no more results.
+    has_more = len(entries) > page_size
+    next_token = _encode_page_token(page[-1]) if (has_more and page) else ""
+
+    return _jsonrpc_result(
+        req_id,
+        {
+            "tasks": [e.to_public_dict() for e in page],
+            "nextPageToken": next_token,
+            "pageSize": page_size,
+            "totalSize": total_size,
+        },
     )
 
 

--- a/src/reyn/interfaces/web/run_registry.py
+++ b/src/reyn/interfaces/web/run_registry.py
@@ -268,10 +268,26 @@ class RunRegistry:
     def get(self, run_id: str) -> RunEntry | None:
         return self._runs.get(run_id)
 
-    def list(self, agent_name: str | None = None) -> list[RunEntry]:
-        if agent_name is None:
-            return list(self._runs.values())
-        return [e for e in self._runs.values() if e.agent_name == agent_name]
+    def list(
+        self,
+        agent_name: str | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> list[RunEntry]:
+        """Return runs, optionally narrowed by ``agent_name`` and/or
+        ``session_id``.
+
+        ``session_id`` is the core-neutral routing-key (#1814,
+        ``<transport>:<native_id>``) — filtering by it is how the A2A
+        layer scopes ListTasks to one ``contextId`` (the A2A layer owns
+        the ``contextId ↔ session_id`` map; core stays term-neutral).
+        """
+        entries = self._runs.values()
+        if agent_name is not None:
+            entries = [e for e in entries if e.agent_name == agent_name]
+        if session_id is not None:
+            entries = [e for e in entries if e.session_id == session_id]
+        return list(entries)
 
     def update(
         self,

--- a/tests/test_a2a_list_tasks_1811.py
+++ b/tests/test_a2a_list_tasks_1811.py
@@ -1,0 +1,141 @@
+"""Tier 2: #1811 — A2A ``tasks/list`` (ListTasks) listing + filter + pagination.
+
+``tasks/list`` returns one agent's tasks, narrowable by ``contextId`` (→ the
+core-neutral ``session_id`` routing-key, #1814) and ``status``, with a stable
+keyset cursor (sort key ``(created_at, run_id)``; opaque base64 ``pageToken``;
+``nextPageToken`` MUST always be present, ``''`` at end). Per-task shape reuses
+``RunEntry.to_public_dict()`` (consistent with GetTask; STATUS_MAP normalization
+is a separate #1811 slice). Real RunRegistry, no mocks.
+
+Falsification:
+- contextId filter test reds if the session_id filter is dropped (returns both
+  contexts' tasks).
+- pagination test reds if ``nextPageToken`` is never emitted (single page) or if
+  pages overlap / skip entries.
+- always-present test reds if the key is omitted on the final (short) page.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from reyn.interfaces.web.routers.a2a import _handle_tasks_list
+from reyn.interfaces.web.run_registry import RunRegistry
+from reyn.runtime.a2a_routing import a2a_session_id
+
+
+def _seed(reg: RunRegistry, agent: str, session_id: str, n: int, *, status: str = "running"):
+    """Create ``n`` runs with deterministic, strictly-increasing created_at so
+    the keyset order is fully known."""
+    created = []
+    for i in range(n):
+        e = reg.create(agent_name=agent, chain_id=f"c{i}", session_id=session_id)
+        e.status = status
+        e.created_at = datetime(2026, 1, 1, 0, 0, i, tzinfo=timezone.utc)
+        created.append(e)
+    return created
+
+
+async def _list(reg: RunRegistry, agent: str, **params) -> dict:
+    resp = await _handle_tasks_list(req_id="r1", params=params, agent_name=agent, run_registry=reg)
+    assert resp["jsonrpc"] == "2.0"
+    assert "result" in resp, resp
+    return resp["result"]
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_filters_by_contextid():
+    """Tier 2: contextId scopes results to that context's session_id only."""
+    reg = RunRegistry()
+    ctx_a, ctx_b = "ctx-a", "ctx-b"
+    a_ids = {e.run_id for e in _seed(reg, "alice", a2a_session_id(ctx_a), 3)}
+    _seed(reg, "alice", a2a_session_id(ctx_b), 2)  # other context — must be excluded
+
+    result = await _list(reg, "alice", contextId=ctx_a)
+    returned = {t["run_id"] for t in result["tasks"]}
+
+    # RED if the session_id filter is dropped: returned would also contain ctx_b.
+    assert returned == a_ids
+    assert result["totalSize"] == 3
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_pagination_keyset_covers_all_once():
+    """Tier 2: keyset pages partition the full set — no overlap, no skips, and
+    nextPageToken is non-empty until the final page then ''."""
+    reg = RunRegistry()
+    ctx = "ctx-pg"
+    all_ids = {e.run_id for e in _seed(reg, "alice", a2a_session_id(ctx), 5)}
+
+    seen: list[str] = []
+    token = ""
+    pages = 0
+    page_lens: list[int] = []
+    while True:
+        params = {"contextId": ctx, "pageSize": 2}
+        if token:
+            params["pageToken"] = token
+        result = await _list(reg, "alice", **params)
+        page_lens.append(len(result["tasks"]))
+        seen.extend(t["run_id"] for t in result["tasks"])
+        token = result["nextPageToken"]
+        pages += 1
+        assert pages <= 10, "pagination did not terminate"
+        if token == "":
+            break
+
+    # RED if nextPageToken never emitted (would be one page of 2, missing 3) or
+    # if pages overlapped/skipped (seen != all_ids or duplicates).
+    assert page_lens == [2, 2, 1]
+    assert len(seen) == len(set(seen)) == 5
+    assert set(seen) == all_ids
+    assert result["totalSize"] == 5
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_filters_by_status():
+    """Tier 2: status narrows the set (matched against Reyn status names)."""
+    reg = RunRegistry()
+    sid = a2a_session_id("ctx-st")
+    done = {e.run_id for e in _seed(reg, "alice", sid, 2, status="completed")}
+    _seed(reg, "alice", sid, 3, status="running")
+
+    result = await _list(reg, "alice", contextId="ctx-st", status="completed")
+    returned = {t["run_id"] for t in result["tasks"]}
+
+    assert returned == done
+    assert result["totalSize"] == 2
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_next_page_token_always_present_on_short_page():
+    """Tier 2: nextPageToken MUST be present and '' when results fit one page."""
+    reg = RunRegistry()
+    seeded = _seed(reg, "alice", a2a_session_id("ctx-1"), 1)
+
+    result = await _list(reg, "alice", contextId="ctx-1")
+
+    # RED if the key is omitted on a single short page.
+    assert "nextPageToken" in result
+    assert result["nextPageToken"] == ""
+    # the single seeded task is the only one returned (no extra page expected).
+    returned = {t["run_id"] for t in result["tasks"]}
+    assert returned == {seeded[0].run_id}
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_rejects_malformed_page_token():
+    """Tier 2: a malformed pageToken is an invalid-params error, not a crash."""
+    reg = RunRegistry()
+    _seed(reg, "alice", a2a_session_id("ctx-1"), 1)
+
+    resp = await _handle_tasks_list(
+        req_id="r1",
+        params={"contextId": "ctx-1", "pageToken": "!!!not-base64!!!"},
+        agent_name="alice",
+        run_registry=reg,
+    )
+
+    assert "error" in resp
+    assert resp["error"]["code"] == -32602


### PR DESCRIPTION
**[e2e-coder]** — #1811 A2A protocol gap-list, **slice-2: ListTasks** (slice-1 = #1814 per-contextId session separation, merged). Lead design flow-trace **APPROVED → GO** (audit trail below).

## What
Adds the A2A `ListTasks` method as JSON-RPC **`tasks/list`** on `POST /a2a/agents/{name}`, alongside the existing `message/send`. Lists one agent's tasks, filterable by `contextId` (→ core `session_id`) and `status`, with stable keyset pagination.

## Premise verify (current main, post-#1814 — corrected 3 stale points in the issue body)
- `RunRegistry.list(agent_name)` **already existed** (#1811's "add `all()`" was partly done) — extended in place.
- **No** ListTasks endpoint; `a2a_jsonrpc` routed only `message/send`.
- GetTask returns **raw `to_public_dict()`** — STATUS_MAP / A2A Task envelope is **not** landed (the issue body attributed it to #1814, but the first slice didn't include it).
- `RunEntry` carries `session_id` (#1814, core-neutral) + `created_at` → filter + stable-sort keys ready.

## Design (lead-reviewed)
- **Transport** — JSON-RPC `tasks/list` (slash-form). Spec §9.4.4 names it PascalCase `ListTasks`, but Reyn ships slash-form `message/send`; `tasks/list` keeps the binding consistent. slash→PascalCase migration = separate forward item (tracked, OUT of scope here).
- **Core** — `RunRegistry.list(agent_name=None, *, session_id=None)`. `session_id` is the core-neutral routing-key (#1814); filtering by it is legitimate core (NOT a domain-term leak — the A2A layer keeps the `contextId↔session_id` map). Additive keyword-only → backward-compatible.
- **A2A layer** (`_handle_tasks_list`) — `contextId → a2a_session_id → registry.list(session_id=)`; `status` filter (A2A-domain param, matched against Reyn status names); **keyset cursor** (sort `(created_at, run_id)`; opaque base64 `pageToken`; `nextPageToken` MUST always be present, `''` at end; `pageSize` clamp ≤100, default 50; keyset not offset → concurrent-insert stable); per-task shape reuses `to_public_dict()` (consistent with GetTask).
- **Scope split** (lead-confirmed) — **STATUS_MAP state-name normalization deferred**: it's cross-cutting (touches GetTask + ListTasks), so a separate slice normalizes both together; normalizing only ListTasks output would be inconsistent. Also deferred: `statusTimestampAfter` / `historyLength` / `includeArtifacts`, A2A Task-envelope normalization, PascalCase migration.

## Lead GO (audit trail)
> #1811 ListTasks design flow-trace reviewed → APPROVE → GO impl. (a) `tasks/list` (slash) confirm — consistent with `message/send`, slash→PascalCase tracked as forward item. (b) keyset cursor GO — sort (created_at,run_id) + opaque base64 + nextPageToken=''@end (MUST-present invariant) + pageSize clamp≤100 default 50 = correct (keyset not offset = concurrent-insert stable). (c) scope split GO — to_public_dict() reuse + STATUS_MAP defer correct (cross-cutting normalization, separate slice fixes both). + core RunRegistry.list(session_id=) filter core-neutral, valid (#1814 term-leak correction honored).

## Test plan
- [x] `tests/test_a2a_list_tasks_1811.py` — 5 tests pass (Tier 2, real RunRegistry, no mocks).
- [x] **Falsification CLEAN RED** verified: (1) drop the `contextId→session_id` filter → `test_tasks_list_filters_by_contextid` reds (returns both contexts); (2) force `nextPageToken=''` always → `test_tasks_list_pagination_keyset_covers_all_once` reds (single page, missing entries). Both reverted.
- [x] a2a suite green (`test_a2a_routing` / `test_a2a_sync_async_escalation` / `test_fp0001_a2a_endpoints` + new): 35 passed, 1 skipped.
- [x] ruff clean; `scripts/test_tier_audit.py --strict` clean (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)