### PR TITLE
feat(#1811): A2A Task envelope + reyn-status→TaskState map (GetTask + ListTasks)

### DIFF
--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -343,6 +343,82 @@ async def a2a_jsonrpc(
     )
 
 
+# ── A2A Task envelope + state mapping (#1811) ───────────────────────────────
+
+# Valid A2A TaskState values (JSON-RPC short-form binding — consistent with the
+# slash-form ``message/send`` Reyn ships; the spec's protobuf ``TASK_STATE_*``
+# enum is the separate gRPC binding). Documents the legal targets so the
+# completeness test can assert every ``_STATUS_MAP`` value lands on a real state.
+_A2A_TASK_STATES = frozenset({
+    "submitted", "working", "completed", "failed",
+    "canceled", "input-required", "rejected", "auth-required",
+})
+
+# Reyn's own free-form run-status vocabulary → A2A TaskState. Reyn statuses are
+# not a closed enum, so ``_a2a_task_state`` passes unmapped values through (+ a
+# debug log) rather than crashing — a never-hit safety net for drift.
+_STATUS_MAP = {
+    "running": "working",
+    "in-progress": "working",
+    "completed": "completed",
+    "failed": "failed",
+    "cancelled": "canceled",       # reyn double-l → spec single-l
+    "input-required": "input-required",
+    "timeout": "failed",           # reyn-specific (spec-external) → nearest terminal-error
+}
+
+
+def _a2a_task_state(reyn_status: str) -> str:
+    """Map a Reyn run status to an A2A TaskState (short-form). Unknown statuses
+    pass through verbatim (+ debug log) — never crash on an unmapped value."""
+    mapped = _STATUS_MAP.get(reyn_status)
+    if mapped is None:
+        logger.debug("a2a: unmapped run status %r — passing through", reyn_status)
+        return reyn_status
+    return mapped
+
+
+def _to_a2a_task(entry) -> dict:
+    """Build a spec-shaped A2A Task object (§4.1.1) from a RunEntry (#1811).
+
+    ``id`` + ``status`` (TaskStatus) are required; ``contextId`` / ``artifacts``
+    optional. RunEntry's flat ``result`` has no home in a spec Task → it becomes
+    an output Artifact; ``error`` becomes the TaskStatus.message note. ``kind``
+    is kept as the JSON-RPC response discriminator (spec §4.1.1 omits it, but the
+    existing ``message/send`` responses + clients rely on it).
+
+    ``contextId`` is recovered from the core-neutral ``session_id`` via the A2A
+    layer's reverse map (``a2a_context_id``) — the contextId term stays in the
+    A2A layer; core (RunEntry) only stores ``session_id`` (#1814).
+    """
+    status_obj: dict = {
+        "state": _a2a_task_state(entry.status),
+        "timestamp": entry.updated_at.isoformat(),
+    }
+    if entry.error:
+        status_obj["message"] = {
+            "kind": "message",
+            "role": "agent",
+            "parts": [{"kind": "text", "text": entry.error}],
+        }
+
+    task: dict = {
+        "kind": "task",
+        "id": entry.run_id,
+        "status": status_obj,
+    }
+    if entry.session_id:
+        task["contextId"] = a2a_context_id(entry.session_id)
+    if entry.result:
+        task["artifacts"] = [
+            {
+                "artifactId": entry.run_id,
+                "parts": [{"kind": "text", "text": entry.result}],
+            }
+        ]
+    return task
+
+
 # ── tasks/list — A2A ListTasks (#1811) ──────────────────────────────────────
 
 _LIST_TASKS_DEFAULT_PAGE_SIZE = 50
@@ -434,7 +510,7 @@ async def _handle_tasks_list(
     return _jsonrpc_result(
         req_id,
         {
-            "tasks": [e.to_public_dict() for e in page],
+            "tasks": [_to_a2a_task(e) for e in page],
             "nextPageToken": next_token,
             "pageSize": page_size,
             "totalSize": total_size,
@@ -1152,11 +1228,11 @@ async def get_task(
     run_id: str,
     run_registry=Depends(get_run_registry),
 ) -> dict:
-    """Poll a task's status. Returns RunEntry.to_public_dict()."""
+    """Poll a task's status. Returns a spec-shaped A2A Task object (#1811)."""
     entry = run_registry.get(run_id)
     if entry is None:
         raise HTTPException(404, f"Task {run_id!r} not found")
-    return entry.to_public_dict()
+    return _to_a2a_task(entry)
 
 
 # ── POST /a2a/tasks/{run_id}/cancel — cancel a running task ─────────────────

--- a/tests/test_a2a_list_tasks_1811.py
+++ b/tests/test_a2a_list_tasks_1811.py
@@ -3,9 +3,9 @@
 ``tasks/list`` returns one agent's tasks, narrowable by ``contextId`` (→ the
 core-neutral ``session_id`` routing-key, #1814) and ``status``, with a stable
 keyset cursor (sort key ``(created_at, run_id)``; opaque base64 ``pageToken``;
-``nextPageToken`` MUST always be present, ``''`` at end). Per-task shape reuses
-``RunEntry.to_public_dict()`` (consistent with GetTask; STATUS_MAP normalization
-is a separate #1811 slice). Real RunRegistry, no mocks.
+``nextPageToken`` MUST always be present, ``''`` at end). Per-task shape is the
+spec A2A Task envelope (``_to_a2a_task`` — ``id`` not ``run_id``), consistent
+with GetTask. Real RunRegistry, no mocks.
 
 Falsification:
 - contextId filter test reds if the session_id filter is dropped (returns both
@@ -53,7 +53,7 @@ async def test_tasks_list_filters_by_contextid():
     _seed(reg, "alice", a2a_session_id(ctx_b), 2)  # other context — must be excluded
 
     result = await _list(reg, "alice", contextId=ctx_a)
-    returned = {t["run_id"] for t in result["tasks"]}
+    returned = {t["id"] for t in result["tasks"]}
 
     # RED if the session_id filter is dropped: returned would also contain ctx_b.
     assert returned == a_ids
@@ -78,7 +78,7 @@ async def test_tasks_list_pagination_keyset_covers_all_once():
             params["pageToken"] = token
         result = await _list(reg, "alice", **params)
         page_lens.append(len(result["tasks"]))
-        seen.extend(t["run_id"] for t in result["tasks"])
+        seen.extend(t["id"] for t in result["tasks"])
         token = result["nextPageToken"]
         pages += 1
         assert pages <= 10, "pagination did not terminate"
@@ -102,7 +102,7 @@ async def test_tasks_list_filters_by_status():
     _seed(reg, "alice", sid, 3, status="running")
 
     result = await _list(reg, "alice", contextId="ctx-st", status="completed")
-    returned = {t["run_id"] for t in result["tasks"]}
+    returned = {t["id"] for t in result["tasks"]}
 
     assert returned == done
     assert result["totalSize"] == 2
@@ -120,7 +120,7 @@ async def test_tasks_list_next_page_token_always_present_on_short_page():
     assert "nextPageToken" in result
     assert result["nextPageToken"] == ""
     # the single seeded task is the only one returned (no extra page expected).
-    returned = {t["run_id"] for t in result["tasks"]}
+    returned = {t["id"] for t in result["tasks"]}
     assert returned == {seeded[0].run_id}
 
 

--- a/tests/test_a2a_status_map_1811.py
+++ b/tests/test_a2a_status_map_1811.py
@@ -1,0 +1,108 @@
+"""Tier 2: #1811 — Reyn run-status → A2A TaskState mapping + A2A Task envelope.
+
+``_to_a2a_task`` renders a RunEntry as a spec-shaped A2A Task (§4.1.1): ``id`` +
+nested ``status.{state,timestamp,message}`` + optional ``contextId`` / ``artifacts``.
+``_a2a_task_state`` maps Reyn's free-form status vocabulary to the JSON-RPC
+short-form TaskState; unknown statuses pass through (never crash). Real RunEntry,
+no mocks.
+
+Falsification:
+- the mapping table test reds if cancelled→canceled (spelling), running→working,
+  or timeout→failed regress.
+- the completeness test reds if any _STATUS_MAP value is not a legal TaskState.
+- the envelope test reds if result is not lifted to artifacts / error not lifted
+  to status.message / the flat reyn shape leaks.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from reyn.interfaces.web.routers.a2a import (
+    _A2A_TASK_STATES,
+    _STATUS_MAP,
+    _a2a_task_state,
+    _to_a2a_task,
+)
+from reyn.interfaces.web.run_registry import RunEntry
+
+
+def _entry(**kw) -> RunEntry:
+    base = dict(run_id="r-1", agent_name="a", chain_id="c")
+    base.update(kw)
+    return RunEntry(**base)
+
+
+def test_status_map_known_reyn_states_map_to_expected_taskstate():
+    """Tier 2: each Reyn run status maps to its A2A TaskState (incl. the
+    cancelled→canceled spelling fix and the spec-external timeout→failed)."""
+    expected = {
+        "running": "working",
+        "in-progress": "working",
+        "completed": "completed",
+        "failed": "failed",
+        "cancelled": "canceled",
+        "input-required": "input-required",
+        "timeout": "failed",
+    }
+    actual = {reyn: _a2a_task_state(reyn) for reyn in expected}
+    # RED if any mapping regresses (e.g. cancelled→"cancelled" or timeout passthrough).
+    assert actual == expected
+
+
+def test_status_map_values_are_all_legal_taskstates():
+    """Tier 2: completeness — every _STATUS_MAP target is a legal A2A TaskState
+    (mirrors the #1912b op-kind-alias value-drift guard)."""
+    unknown_targets = set(_STATUS_MAP.values()) - _A2A_TASK_STATES
+    # RED if a mapping points at a typo'd / non-spec state.
+    assert unknown_targets == set()
+
+
+def test_a2a_task_state_passes_unknown_through():
+    """Tier 2: an unmapped status passes through verbatim (never-hit safety net),
+    not crash or silently mislabel."""
+    assert _a2a_task_state("some-future-state") == "some-future-state"
+
+
+def test_to_a2a_task_envelope_shape():
+    """Tier 2: a RunEntry renders as a spec A2A Task — id, nested status.state,
+    kind=task — and the flat reyn shape does not leak."""
+    e = _entry(status="running")
+    task = _to_a2a_task(e)
+
+    assert task["kind"] == "task"
+    assert task["id"] == "r-1"
+    assert task["status"]["state"] == "working"
+    assert "timestamp" in task["status"]
+    # RED if the flat reyn shape leaks (run_id / flat string status).
+    assert "run_id" not in task
+    assert not isinstance(task["status"], str)
+
+
+def test_to_a2a_task_lifts_result_to_artifacts():
+    """Tier 2: RunEntry.result (no home in a spec Task) becomes an output Artifact."""
+    e = _entry(status="completed", result="the output")
+    task = _to_a2a_task(e)
+
+    assert task["status"]["state"] == "completed"
+    arts = task["artifacts"]
+    assert arts[0]["parts"][0]["text"] == "the output"
+    # RED if result were left as a flat top-level field instead.
+    assert "result" not in task
+
+
+def test_to_a2a_task_lifts_error_to_status_message():
+    """Tier 2: RunEntry.error becomes the TaskStatus.message note."""
+    e = _entry(status="failed", error="boom")
+    task = _to_a2a_task(e)
+
+    assert task["status"]["state"] == "failed"
+    assert task["status"]["message"]["parts"][0]["text"] == "boom"
+
+
+def test_to_a2a_task_recovers_contextid_from_session_id():
+    """Tier 2: contextId is the A2A-layer reverse map of the core session_id
+    (the contextId term never lives in core — #1814)."""
+    e = _entry(status="running", session_id="a2a:ctx-42")
+    task = _to_a2a_task(e)
+
+    assert task["contextId"] == "ctx-42"

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -63,9 +63,10 @@ def _restore_overrides() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_get_task_returns_public_dict_for_existing_run() -> None:
-    """Tier 2: GET /a2a/tasks/{run_id} returns 200 with RunEntry.to_public_dict()
-    shape when the run exists in the registry."""
+def test_get_task_returns_a2a_task_envelope_for_existing_run() -> None:
+    """Tier 2: GET /a2a/tasks/{run_id} returns 200 with a spec-shaped A2A Task
+    envelope (#1811) — kind=task, id=run_id, and a nested TaskStatus whose state
+    is the run status mapped to an A2A TaskState (running→working)."""
     registry = RunRegistry()
     entry = registry.create(agent_name="demo", chain_id="chain-abc")
     client = _make_client_with_registry(registry)
@@ -73,11 +74,14 @@ def test_get_task_returns_public_dict_for_existing_run() -> None:
         r = client.get(f"/a2a/tasks/{entry.run_id}")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["run_id"] == entry.run_id
-        assert body["agent_name"] == "demo"
-        assert body["chain_id"] == "chain-abc"
-        assert body["status"] == "running"
-        # to_public_dict must not leak internal-only fields.
+        assert body["kind"] == "task"
+        assert body["id"] == entry.run_id
+        # nested TaskStatus with the run status mapped to a spec TaskState.
+        assert body["status"]["state"] == "working"
+        # the flat reyn shape is gone: id replaces run_id, status is an object.
+        assert "run_id" not in body
+        assert not isinstance(body["status"], str)
+        # internal-only fields never leak.
         assert "task" not in body
         assert "pending_intervention" not in body
     finally:

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -385,9 +385,9 @@ def test_get_task_returns_run_entry(tmp_path, monkeypatch):
         r = client.get(f"/a2a/tasks/{entry.run_id}")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["run_id"] == entry.run_id
-        assert body["status"] == "input-required"
-        assert "question" not in body  # α: field removed
-        assert body["agent_name"] == "default"
+        # #1811: GetTask returns a spec A2A Task envelope (id + nested status).
+        assert body["id"] == entry.run_id
+        assert body["status"]["state"] == "input-required"
+        assert "question" not in body  # α: field removed (the core contract here)
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
**[e2e-coder]** — #1811 A2A protocol gap-list, **slice-3: STATUS_MAP + A2A Task envelope** (slice-1 #1814 per-contextId, slice-2 #1947 ListTasks — both merged). Lead design flow-trace **APPROVED → GO**; owner-requested granularity web-research separately confirmed run=Task is spec-correct.

## What
GetTask and ListTasks now return **spec-shaped A2A Task objects** (§4.1.1) instead of the flat RunEntry dict, via a single `_to_a2a_task(entry)` mapper.

## Premise verify (current main)
All three task-emitting sites (GetTask, ListTasks, async-escalation) returned non-spec envelopes with raw reyn `status` strings — the gap is the whole envelope, not just state names. Consumer audit: only external A2A clients + reyn tests read the shape (no internal production poller) → migration needs test updates only.

## Design (lead-reviewed)
- **`_to_a2a_task(entry)`** → `{kind:"task", id, status:{state, timestamp, message?}, contextId?, artifacts?}`.
- **`_a2a_task_state`** maps Reyn's free-form run status → A2A TaskState (**JSON-RPC short-form** binding, consistent with the shipped `message/send`; the spec's protobuf `TASK_STATE_*` is the separate gRPC binding):
  `running`/`in-progress`→`working`, `completed`→`completed`, `failed`→`failed`, `cancelled`→`canceled` (spelling fix), `input-required`→`input-required`, `timeout`→`failed` (spec-external → nearest terminal). Unknown → passthrough + debug log (never-hit safety net; reyn status is free-form, not a closed enum).
- **`result` → output Artifact**, **`error` → `status.message`** (a spec Task has no top-level `result`).
- **`contextId`** recovered from core-neutral `session_id` via `a2a_context_id` (reverse map) — contextId term stays in the A2A layer, core term-neutral (#1814).
- **`kind:"task"`** kept as the JSON-RPC response discriminator (spec §4.1.1 omits it, but existing `message/send` responses + clients rely on it).

## Scope
- **B1 (this PR)** — read endpoints GetTask + ListTasks (lead's named pair).
- **B2 (follow-up, soon)** — create-response Task envelopes (`_escalate_to_task` / async-mode / answer-injection) + CancelTask + SSE-end converge on the same mapper (avoids the lingering read-vs-create inconsistency lead flagged).
- **Also tracked** — taskId-continuation of `input-required` Tasks (owner/lead verification item): reyn has `_handle_answer_injection` (taskId → continue existing run); full message/send routing check is a #1811 follow-up post-merge.
- **Scope-out** — `history` / `metadata` / full Artifact-parts fidelity / inbound-only states (SUBMITTED/REJECTED/AUTH_REQUIRED — reyn never emits them).

## Lead GO (audit trail)
> STATUS_MAP design-check flow-trace reviewed → APPROVE → GO. (a) short-form confirm (protobuf enum is the gRPC binding). (b) B1 (GetTask+ListTasks) GO; B2 soon to avoid read-vs-create inconsistency. (c) result→artifacts / error→status.message GO. (d) kind keep GO. + STATUS_MAP completeness test (mirrors #1912b op-kind-alias value guard), unknown→passthrough safety net. term-leak honored (contextId via reverse map).

## Test plan
- [x] `tests/test_a2a_status_map_1811.py` (new, 7 tests) — mapping table, **completeness guard** (every `_STATUS_MAP` value ∈ legal TaskState), unknown-passthrough, envelope shape, result→artifacts, error→status.message, contextId reverse-map.
- [x] **Falsification CLEAN RED**: regress `cancelled→cancelled` → mapping test **and** completeness guard both red (reverted).
- [x] `tests/test_a2a_list_tasks_1811.py` updated (envelope `id` key). `tests/test_fp0001_a2a_endpoints.py` GetTask test updated to envelope shape (cancel test untouched = B2 boundary proof).
- [x] a2a suite green: 42 passed, 1 skipped. ruff clean. `scripts/test_tier_audit.py --strict` clean (23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)