### PR TITLE
fix(security): safe/file resists symlink-traversal escape (realpath gate + O_NOFOLLOW)

### DIFF
--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -128,21 +128,23 @@ def _set_permission_context(
 def _is_under(path: str, allowed: tuple[str, ...]) -> bool:
     """Return True if ``path`` resolves under any of ``allowed`` paths.
 
-    Each ``allowed`` entry is normalised via ``os.path.abspath`` and
-    treated as a directory-or-file prefix. ``path`` is normalised the
-    same way, so ``../foo`` style escapes are caught by abspath
-    expansion.
+    Each ``allowed`` entry and ``path`` are normalised via
+    ``os.path.realpath`` (resolves symlinks AND ``..``), so BOTH a
+    symlink-traversal escape (a symlink inside an allowed dir pointing
+    outside, incl. via a parent-dir symlink) and a ``../foo`` escape are
+    caught before the prefix check. (``abspath`` resolved ``..`` only and
+    let symlinks through — the safe-file sandbox escape this guards.)
 
     Behaviour notes:
       - ``""`` (= empty string) in ``allowed`` matches nothing.
       - An exact-match prefix at a directory boundary counts (= the
         ``+ os.sep`` guard prevents ``/foo/bar`` matching ``/foo/barbaz``).
     """
-    abs_path = _os.path.abspath(path)
+    abs_path = _os.path.realpath(path)
     for entry in allowed:
         if not entry:
             continue
-        abs_entry = _os.path.abspath(entry)
+        abs_entry = _os.path.realpath(entry)
         if abs_path == abs_entry:
             return True
         # Treat allowed entries as prefixes only at directory boundaries.
@@ -179,10 +181,10 @@ def _is_canonical_protected_write(path: str) -> bool:
     zone, but the collapse-arc Phase 2 carve-out requires they be listed
     explicitly in ``_write_paths`` (not via a parent-directory prefix).
     """
-    abs_path = _os.path.abspath(path)
+    abs_path = _os.path.realpath(path)
     cwd = _os.getcwd()
     for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
-        if abs_path == _os.path.abspath(_os.path.join(cwd, rel)):
+        if abs_path == _os.path.realpath(_os.path.join(cwd, rel)):
             return True
     return False
 
@@ -193,9 +195,9 @@ def _is_explicitly_listed(path: str, allowed: tuple[str, ...]) -> bool:
     Stricter than :func:`_is_under` — does not accept parent-directory
     prefix matches. Used to enforce the #571 protected-paths exception.
     """
-    abs_path = _os.path.abspath(path)
+    abs_path = _os.path.realpath(path)
     for entry in allowed:
-        if entry and abs_path == _os.path.abspath(entry):
+        if entry and abs_path == _os.path.realpath(entry):
             return True
     return False
 
@@ -239,6 +241,15 @@ def _check_write(path: str) -> None:
 # ── High-level API (drop-in for reyn.api.unsafe.file) ───────────────────────
 
 
+def _nofollow_opener(path: str, flags: int) -> int:
+    """``opener`` for ``builtins.open`` that adds ``O_NOFOLLOW`` — the open
+    refuses to follow a symlink in the FINAL path component (an atomic TOCTOU
+    guard complementing the realpath gate, which covers parent-dir symlinks +
+    the full-path escape at check time). Degrades to a plain open on a platform
+    without ``O_NOFOLLOW`` (the realpath gate still applies)."""
+    return _os.open(path, flags | getattr(_os, "O_NOFOLLOW", 0))
+
+
 def read(path: str, *, encoding: str = "utf-8") -> str:
     """Read and return the text contents of ``path``.
 
@@ -246,7 +257,7 @@ def read(path: str, *, encoding: str = "utf-8") -> str:
     declared ``read_paths``. Raises :class:`PermissionError` otherwise.
     """
     _check_read(path)
-    with _builtins.open(path, encoding=encoding) as f:
+    with _builtins.open(path, encoding=encoding, opener=_nofollow_opener) as f:
         return f.read()
 
 
@@ -257,7 +268,7 @@ def write(path: str, content: str, *, encoding: str = "utf-8") -> None:
     declared ``write_paths``. Raises :class:`PermissionError` otherwise.
     """
     _check_write(path)
-    with _builtins.open(path, "w", encoding=encoding) as f:
+    with _builtins.open(path, "w", encoding=encoding, opener=_nofollow_opener) as f:
         f.write(content)
 
 
@@ -274,7 +285,7 @@ def write_atomic(path: str, content: str, *, encoding: str = "utf-8") -> None:
     files, and other small-file writes where crash-safety matters.
     """
     _check_write(path)
-    dir_path = _os.path.dirname(_os.path.abspath(path)) or "."
+    dir_path = _os.path.dirname(_os.path.realpath(path)) or "."
     fd, tmp = _tempfile.mkstemp(prefix=".reyn_safe_atomic_", dir=dir_path)
     try:
         with _os.fdopen(fd, "w", encoding=encoding) as f:
@@ -401,4 +412,4 @@ def open(  # noqa: A001 — intentional shadowing of builtin in this module's su
     else:
         # Default to read for empty / read-only modes ("r", "rb", "rt", ...).
         _check_read(path)
-    return _builtins.open(path, mode, encoding=encoding, **kwargs)
+    return _builtins.open(path, mode, encoding=encoding, opener=_nofollow_opener, **kwargs)

--- a/tests/test_safe_file_symlink_traversal.py
+++ b/tests/test_safe_file_symlink_traversal.py
@@ -1,0 +1,89 @@
+"""Tier 2: safe/file resists symlink-traversal escape (path-safety hardening).
+
+`api/safe/file._is_under` gated with `os.path.abspath` (resolves `..` but NOT
+symlinks), so a symlink inside an allowed dir pointing outside escaped the gate —
+read/write OUTSIDE the declared root (reproduced: read a secret + overwrite an
+arbitrary outside file). Fixed with a realpath gate (resolves symlinks at check
+time, incl. parent-dir symlinks) + `O_NOFOLLOW` on the opens (final-component
+TOCTOU guard).
+
+Policy: real filesystem + real symlinks + real `safe.file` (its permission
+context is the seam, set directly) — no mocks. Tier line first.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import reyn.api.safe.file as sf
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sf._set_permission_context(read_paths=[str(allowed)], write_paths=[str(allowed)])
+    return allowed, outside
+
+
+def test_read_via_symlink_to_outside_blocked(ctx):
+    """Tier 2: a symlink inside an allowed dir → outside is BLOCKED on read (the
+    realpath gate resolves the symlink to its outside target → denied)."""
+    allowed, outside = ctx
+    secret = outside / "secret.txt"
+    secret.write_text("OUTSIDE-SECRET")
+    link = allowed / "link"
+    os.symlink(secret, link)
+    with pytest.raises(PermissionError):
+        sf.read(str(link))
+
+
+def test_write_via_symlink_to_outside_blocked(ctx):
+    """Tier 2: writing through an allowed-dir symlink → outside is BLOCKED (the
+    reproduced arbitrary-outside-file overwrite); the target stays unchanged."""
+    allowed, outside = ctx
+    victim = outside / "victim.txt"
+    victim.write_text("ORIGINAL")
+    link = allowed / "wlink"
+    os.symlink(victim, link)
+    with pytest.raises(PermissionError):
+        sf.write(str(link), "PWNED-VIA-SYMLINK")
+    assert victim.read_text() == "ORIGINAL"
+
+
+def test_read_via_parent_dir_symlink_blocked(ctx):
+    """Tier 2: a symlink in a PARENT component → outside is BLOCKED — realpath
+    resolves the whole path (O_NOFOLLOW alone guards only the final component)."""
+    allowed, outside = ctx
+    sub = outside / "sub"
+    sub.mkdir()
+    (sub / "f.txt").write_text("PARENT-ESCAPE")
+    dlink = allowed / "dlink"
+    os.symlink(sub, dlink)
+    with pytest.raises(PermissionError):
+        sf.read(str(dlink / "f.txt"))
+
+
+def test_within_allowed_final_symlink_refused_by_nofollow(ctx):
+    """Tier 2: the O_NOFOLLOW layer refuses a final-component symlink even when its
+    target is WITHIN the allowed root (no symlink-following at all — the atomic
+    TOCTOU-safe behavior; intended post-fix stricture)."""
+    allowed, _outside = ctx
+    real = allowed / "real.txt"
+    real.write_text("INNER")
+    link = allowed / "innerlink"
+    os.symlink(real, link)
+    with pytest.raises(OSError):  # ELOOP from O_NOFOLLOW (not a PermissionError)
+        sf.read(str(link))
+
+
+def test_legit_non_symlink_paths_still_work(ctx):
+    """Tier 2: (regression) legit non-symlink reads/writes under the allowed root
+    are unaffected by the hardening."""
+    allowed, _outside = ctx
+    p = allowed / "ok.txt"
+    sf.write(str(p), "hello")
+    assert sf.read(str(p)) == "hello"


### PR DESCRIPTION
**[dogfood-coder]** — Path-safety hardening (self-driven static-security recon after the #1934 DoS cluster; lead-approved design = BOTH).

## Finding (reproduced — primary evidence)
`api/safe/file._is_under` (the read+write path gate) normalized via `os.path.abspath` — resolves `..` but **NOT symlinks**. A symlink inside an allowed dir pointing outside passed the gate (abspath stays under-allowed), but the real op followed the symlink → **read/write OUTSIDE the declared root** = escape of the safe-file sandbox. Reproduced on real FS: read an outside secret + **overwrite an arbitrary outside file**.

## Exploitability = MEDIUM (defense-in-depth)
A default safe-mode step can't self-plant a symlink (`write()` writes content; `os`/`os.symlink` not in the safe-mode AST allowlist). Real via a **pre-planted symlink** in an allowed dir (another process / other agent / attacker-influenced read_path — e.g. the workspace) or an operator `os`-whitelist. Not an emergency; fix justified (esp. the write-escape).

## Fix (BOTH, per design-review)
- **realpath gate** (core): `_is_under` / `_is_canonical_protected_write` / `_is_explicitly_listed` normalize via `os.path.realpath` → resolves symlinks (incl. **parent-dir** symlinks) + `..` at check time; an escape resolves outside allowed → denied. One change, all safe/file ops.
- **O_NOFOLLOW** (TOCTOU layer): `read`/`write`/`open` use an `opener` adding `O_NOFOLLOW` → the open refuses a final-component symlink (atomic; closes the check→open TOCTOU window realpath alone can't). Degrades gracefully where `O_NOFOLLOW` is absent.

## Scope
safe/file's single gate + ops (read/write/write_atomic/exists/stat/mkdir/delete/open). unsafe/file = intentionally ungated (out). workspace/snapshot/WAL = reyn-internal fixed paths (out; a `.reyn/`-tampered symlink is broader env-trust).

## Verification
- **Reproduced**: pre-fix read+write escape on real FS.
- **Falsification**: revert to the pre-fix gate → the 4 escape/hardening tests go RED (escapes succeed); legit regression stays green; restore → 5 green.
- 5 Tier-2 tests (read/write/parent-dir escape blocked + O_NOFOLLOW final-component + legit regression).
- 121 regression pass (safe/file API + #571 collapse-phase2 + chunkers + unsafe) — realpath doesn't break #571; macOS /tmp→/private/tmp handled (both sides resolved). ruff + `test_tier_audit --strict` clean.

## Test plan
- [x] 5 new Tier-2 tests pass
- [x] Falsification: 4 escape/hardening tests RED on pre-fix, GREEN after
- [x] 121 safe/file + #571 + chunkers + unsafe regression green
- [x] ruff + test-tier audit clean
- [x] escape reproduced pre-fix (read + write), blocked post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)