### PR TITLE
docs(coverage-matrix): mark for-users how-to JA parity complete

### DIFF
--- a/docs/deep-dives/contributing/user-doc-coverage-matrix.md
+++ b/docs/deep-dives/contributing/user-doc-coverage-matrix.md
@@ -175,11 +175,18 @@ the for-users hub's *Things Reyn handles for you* section, cross-linking
 ### JA parity
 
 A ✅ in this matrix means an **EN** how-to exists. Japanese parity is a separate
-axis tracked outside this matrix. As of the last full sweep, several
-`for-users/` pages still lacked `.ja.md` (e.g. chat-and-web-ui,
-enable-semantic-search, time-travel, work-with-files, popular-mcp-servers). New
-how-tos in the 2026-06-20 wave shipped EN+JA together; the backlog of
-pre-existing EN-only user pages is the remaining JA gap.
+axis tracked outside this matrix. The 2026-06-20 docs wave shipped its new
+how-tos EN+JA together, and the **five pre-existing EN-only `for-users` how-tos
+were backfilled with `.ja.md` in the same wave** (chat-and-web-ui,
+enable-semantic-search, time-travel, work-with-files, popular-mcp-servers).
+
+Remaining JA gap on `for-users/`:
+
+- `for-users/index.md` (the landing page) is still EN-only — deferred pending a
+  decision on whether the landing hub needs a JA version.
+
+All `for-users` **how-to** pages now have JA; only the landing page is
+outstanding.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — merge follow-up to #1949. Updates the coverage matrix's JA-parity note now that the 5 EN-only for-users how-tos have `.ja.md`.

## What

#1949 backfilled JA for chat-and-web-ui / enable-semantic-search / time-travel / work-with-files / popular-mcp-servers. This updates the matrix's `### JA parity` note to reflect that **all for-users how-to pages now have JA**; only `for-users/index.md` (the landing page) remains EN-only, deferred pending a JA-need decision.

Internal doc only (`deep-dives/`, excluded from the published site).

## Test plan

- [x] `mkdocs build --strict` → EXIT=0, 0 WARNING (note: deep-dives is build-excluded, so this only confirms nothing else broke)
- [x] Note now matches merged reality (#1949 landed the 5 JA pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)