### PR TITLE
fix(tui): cost-tab name columns collide with token count for long names

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/cost_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/cost_tab.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from rich.cells import cell_len
+
 from reyn.interfaces.tui._palette import _TEXT_DIMMEST
 
 from .base import (
@@ -44,6 +46,32 @@ _BAR_WIDTH = 24
 _WIDE_THRESHOLD   = 54  # full layout: name :<24 / :<22 / :<28
 _MEDIUM_THRESHOLD = 42  # narrow name: :<18 / :<16 / :<22; still show cost
 _BAR_THRESHOLD    = 44  # bar suppressed below this; pct label kept
+
+
+def _fit(s: str, w: int) -> str:
+    """Truncate ``s`` to at most ``w`` display cells, appending '…' when cut.
+
+    Guards the BY-AGENT/SKILL/MODEL/PLAN name columns: these are rendered as
+    ``{name:<{width}}{tokens:>7,} tok``, where the left-justify pads SHORT
+    names so the padding separates the two columns. A name AT-OR-OVER the
+    column width gets no padding and collides with the token count (observed
+    "word_stats_demo107,166 tok" at narrow panel widths). Callers pass
+    ``width - 1`` so the subsequent ``:<{width}}`` always leaves ≥1 trailing
+    space. Cell-aware so wide-char names truncate by display width, not len.
+    """
+    if w <= 0:
+        return ""
+    if cell_len(s) <= w:
+        return s
+    out: list[str] = []
+    used = 0
+    for ch in s:
+        cw = cell_len(ch)
+        if used + cw > w - 1:  # reserve 1 cell for the ellipsis
+            break
+        out.append(ch)
+        used += cw
+    return "".join(out) + "…"
 
 
 def _col_widths(content_width: int) -> tuple[int, int, int, int]:
@@ -418,7 +446,7 @@ def render_cost(
             )
             # name col width adapts to content_width (see _col_widths)
             lines.append(
-                f"[bold {_TEXT_BRIGHT}]  {_esc(agent):<{agent_name_w}}[/]"
+                f"[bold {_TEXT_BRIGHT}]  {_esc(_fit(agent, agent_name_w - 1)):<{agent_name_w}}[/]"
                 f"[{_TEXT_BODY}]{ag_tok:>7,} tok[/]"
                 f"{ag_cost}"
                 f"{ag_calls}"
@@ -437,7 +465,7 @@ def render_cost(
                     if show_extra else ""
                 )
                 lines.append(
-                    f"[{_TEXT_DIM}]    {_esc(skill):<{skill_name_w}}[/]"
+                    f"[{_TEXT_DIM}]    {_esc(_fit(skill, skill_name_w - 1)):<{skill_name_w}}[/]"
                     f"[{_TEXT_DIM}]{tok_total:>7,} tok[/]"
                     f"{cost_part}"
                     f"{calls_part}"
@@ -492,7 +520,7 @@ def render_cost(
                     if show_extra else ""
                 )
                 lines.append(
-                    f"[{_TEXT_DIM}]    {_esc(step_id):<{skill_name_w}}[/]"
+                    f"[{_TEXT_DIM}]    {_esc(_fit(step_id, skill_name_w - 1)):<{skill_name_w}}[/]"
                     f"[{_TEXT_DIM}]{step_tok:>7,} tok[/]"
                     f"{step_cost_part}"
                     f"{step_calls_part}"
@@ -517,7 +545,7 @@ def render_cost(
                 f"  [{_TEXT_MID}]{mb['calls']}c[/]"                if show_extra else ""
             )
             lines.append(
-                f"[{_TEXT_BODY}]  {_esc(model_name):<{model_name_w}}[/]"
+                f"[{_TEXT_BODY}]  {_esc(_fit(model_name, model_name_w - 1)):<{model_name_w}}[/]"
                 f"[{_TEXT_DIM}]{tok_total:>7,} tok[/]"
                 f"{cost_part}"
                 f"{calls_part}"

--- a/tests/cli/test_cost_tab_narrow_columns.py
+++ b/tests/cli/test_cost_tab_narrow_columns.py
@@ -190,6 +190,46 @@ def test_narrow_width_suppresses_cost_calls(tmp_path: Path) -> None:
     )
 
 
+def test_long_name_does_not_collide_with_token_count(tmp_path: Path) -> None:
+    """Tier 2: a name longer than its adaptive column must not collide with
+    the token-count column (#cost-tab name overflow).
+
+    The rows are ``{name:<{width}}{tokens:>7,} tok``; a name at-or-over the
+    column width gets no left-justify padding and glues to the token count
+    (observed "word_stats_demo107,166 tok"). The collision only shows when the
+    token count is ≥7 chars (≥100,000), since ``:>7,`` accidentally pads
+    shorter counts. The fix truncates the name (cell-aware, ellipsis) so the
+    ``:<{width}}`` always leaves ≥1 separating space.
+    """
+    long_agent = "word-stats-demonstration-agent"  # 30 cells, >> narrow width 14
+    # 107,166 total → 7-char token count → no :>7 leading pad → exposes collision.
+    _make_events(tmp_path, agent=long_agent,
+                 prompt_tokens=107000, completion_tokens=166)
+    narrow_width = _MEDIUM_THRESHOLD - 4  # = 38 → narrow agent_name_w = 14
+
+    plain = _render_plain(tmp_path, narrow_width)
+
+    # Locate the BY-AGENT row carrying the token total.
+    token_str = "107,166"
+    rows = [ln for ln in plain.split("\n") if token_str in ln]
+    # The agent row is the one that also carries (a prefix of) the name.
+    agent_row = next(
+        (ln for ln in rows if "word-stats" in ln or "…" in ln), None
+    )
+    assert agent_row is not None, (
+        f"agent row with token total not found. Rendered:\n{plain}"
+    )
+    idx = agent_row.index(token_str)
+    assert agent_row[idx - 1] == " ", (
+        "token count is glued to the agent name (column collision) — expected a "
+        f"separating space. Row: {agent_row!r}"
+    )
+    # The over-long name must have been truncated (ellipsis present).
+    assert "…" in agent_row, (
+        f"long name should be truncated with an ellipsis. Row: {agent_row!r}"
+    )
+
+
 def test_zero_width_does_not_crash(tmp_path: Path) -> None:
     """Tier 2: content_width=0 (unknown / pre-layout) falls back to wide layout.
 


### PR DESCRIPTION
**[tui-coder]** — fix(tui): cost-tab name columns collide with token count for long names

Found during the (b) TUI UX-exploration pass (lead-approved pivot), via real-terminal tmux e2e.

## Bug
The Cost tab's **BY AGENT / SKILL / MODEL / PLAN** rows render as `{name:<{width}}{tokens:>7,} tok` — they rely on the left-justify **padding** to separate the name from the token count. A name **at-or-over** the adaptive column width gets no padding and **glues** to the count.

Observed at a narrow panel (real terminal): `word_stats_demo107,166 tok` — the 15-char skill name fills the 12-col narrow column and touches `107,166` with no separating space. (The collision only surfaces when the count is ≥7 chars / ≥100,000, since `:>7,` accidentally pads shorter counts with a leading space — which is why short-token rows looked fine.)

## Fix
A cell-aware `_fit(name, width-1)` truncation (ellipsis when cut) applied to **all four** name-column sites (agent / skill / plan-step / model), so the subsequent `:<{width}}` always leaves ≥1 separating space and the name never overflows into the count column. Cell-aware (`rich.cells.cell_len`) so wide-char names truncate by display width.

## Test plan
- [x] `tests/cli/test_cost_tab_narrow_columns.py::test_long_name_does_not_collide_with_token_count` — Tier 2: long agent name + 107,166-token total at narrow width → asserts a **separating space before the count** + **ellipsis** truncation. **Confirmed RED before the fix** (`word-stats-demonstration-agent107,166 tok`, char-before-count = `t`). Reuses the existing events-seeding harness; asserts on plain (markup-stripped) text.
- [x] cost_tab / cost_suffix / right_panel / events_tab suites — **55 passed**
- [x] `python scripts/test_tier_audit.py` — 0 violations
- [x] ruff clean

## Tier self-check
1 new test, Tier 2 (real `render_cost` over a synthetic events tree, asserts on the public plain-text surface — no private state, no len()-pinning of layout, no mocks, no golden files). Docstring declares `Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
