### PR TITLE
fix(tui): right-panel tab header clips first char when a non-first tab is active

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/__init__.py
@@ -184,6 +184,17 @@ class RightPanel(Widget):
         margin: 0 1 0 0;
     }}
 
+    /* The 7 tab labels (37 cells) + 7 right-margins = 44 cells, but the
+       panel's min-width 44 minus the Tabs border-left (1) leaves only 43 —
+       so Textual's Tabs scrolls-to-active and clips the leftmost label's
+       first char ("Keys" → "eys") whenever a non-first tab is active. The
+       last tab's right-margin is pure waste (nothing sits to its right), so
+       dropping it brings the row to 43 cells = an exact fit, no scroll, no
+       clip. No panel-width change → conv pane unaffected. */
+    RightPanel Tab#pending {{
+        margin: 0 0 0 0;
+    }}
+
     RightPanel Tab.-active {{
         color: $primary;
         text-style: bold;


### PR DESCRIPTION
**[tui-coder]** — fix(tui): right-panel tab header clips first char when a non-first tab is active

Found via the TUI UX-exploration pass; lead-triaged as an objective render defect → fixed directly (bug-workflow), no design-check needed.

## Bug
The 7 panel tab labels (`Keys Events Agents Memory Cost Docs Pending` = 37 cells) + 7 inter-tab right-margins (`RightPanel Tab { margin: 0 1 0 0 }`) total **44 cells**, but the panel's `min-width: 44` minus the Tabs `border-left` (1 col) leaves only **43** cells of content. Textual's `Tabs` then scrolls to keep the active tab visible, **clipping the leftmost label's first char** — `Keys` renders as `eys` whenever a non-first tab is active.

Confirmed **active-tab-dependent** (Keys-active = intact; Cost/Memory/Pending-active = "eys") and **width-independent** at the min-width floor — which most terminals hit (33% < 44 below ~133 cols).

## Fix
The **last** tab's right-margin is pure waste (nothing sits to its right). Dropping it (`RightPanel Tab#pending { margin: 0 0 0 0 }`) brings the row to **43 cells = an exact fit** → no scroll → no clip. **No panel-width change** → the conv pane is unaffected (the deliberate `min-width: 44` stays). CSS-only, one rule.

## Test plan (visual — Textual layout has no deterministic non-visual assertion)
- [x] tmux real-terminal (110×36, panel open):
  - **BEFORE**: non-first tab active → `│eys Events…` (K clipped)
  - **AFTER**: non-first tab active → `│Keys Events…` (K intact). Verified with **Cost**, **Pending** (the modified tab), and **Keys** active — all intact, no regression; Pending's active-underline still renders correctly at the row end.
  - **Bonus**: confirmed #1957 live in the same session — `word_stats… 107,166 tok` (was `word_stats_demo107,166`).
- [x] 251 panel / tab / right_panel tests pass (no regression)
- [x] ruff clean
- [x] (skipped — no unit test: Textual Tabs scroll/clip is layout-engine behavior; verified visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
