### PR TITLE
feat(#1953): Task subsystem slice 1 — task.* op interface + in-memory backend

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -33,6 +33,17 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `judge_output` | LLM scorer: rubric + threshold + `on_fail` policy | none (LLM cost) |
 | `skill_resolve` | Resolve a skill name to its on-disk path (read-only) | none |
 | `compact` | Voluntarily compact the conversation/phase history (advisory) | none (LLM cost; the mandatory `retry_loop` backstop is independent) |
+| `task.create` | Create a trackable Task (born with its assignee) | none (gated by `allowed_ops`) |
+| `task.update_status` | Declare a status transition (assignee only) | none (single-writer = backend-CAS on caller run_id, not P5) |
+| `task.get` | Read one Task record | none |
+| `task.list` | List Tasks (filter by assignee / requester / status / parent) | none |
+| `task.create_subtask` | Decompose into a child Task assigned to another worker | none |
+| `task.add_dependency` | Add a depends-on edge (dependency DAG) | none |
+| `task.abort` | OS-authority terminal cancel (→ aborted) | none |
+| `task.archive` | Soft-delete a Task (→ archived) | none |
+| `task.heartbeat` | Liveness / unblock-predicate trigger for a blocked Task | none |
+| `task.register_unblock_predicate` | Register a deterministic unblock predicate | none |
+| `task.comment` | Append a comment to a Task's thread | none |
 
 ## Common envelope
 
@@ -457,6 +468,45 @@ Returns:
 **Visibility**: advertised to the LLM (tool / `available_control_ops`) only when the window is filling — paired with the context-size signal — so it is not offered when there is nothing to compact (mirrors the `search_actions` visibility gate). The permission gate stays "allow"; only *when surfaced* is gated.
 
 **Axis scope (chat vs phase)**: the `compact` op is available on **both** axes. On the **chat** axis, it routes to `force_compact_now`; on the **phase** axis, it routes to the `compact_control_ir_results` on-demand seam wired by the phase runtime (in addition to the automatic per-frame compaction that fires regardless). In both cases the OS wires `ctx.compact_now`; the op handler itself is axis-agnostic. Both axes also inject the paired context-size signal so the model knows when to emit `compact`.
+
+## Task ops (#1953)
+
+First-class trackable work-units. A Task is **opt-in and additive** — the
+session model (concurrent / interleaved) is unchanged; a Task is a discrete
+handle whose lifecycle is tracked independently. **Completion is an explicit
+declaration** (the assignee emits `task.update_status`), never inferred from
+session state.
+
+These ops are **term-neutral (P7)**: names + fields are generic; A2A vocabulary
+(`contextId`, `TaskState`) maps only at the A2A layer. The op family is gated by
+`allowed_ops` (declare `task` for the whole family, or individual `task.*`
+kinds); like any op, each is also subject to the per-session contextual gate.
+
+```json
+{ "kind": "task.create", "name": "ship-feature", "assignee": "bob",
+  "requester": "alice", "origin": "self" }
+{ "kind": "task.update_status", "task_id": "<id>", "status": "in_progress" }
+{ "kind": "task.create_subtask", "parent_id": "<id>", "name": "sub", "assignee": "carol" }
+{ "kind": "task.add_dependency", "task_id": "<id>", "depends_on": "<other-id>" }
+{ "kind": "task.archive", "task_id": "<id>" }
+```
+
+**Roles & invariants.** `assignee` is the **single-writer** of `status` and is
+**immutable** for the Task's life — there is no handoff; delegation is
+`task.create_subtask` (decomposition). `requester` is the disposition
+notify-target. `origin` (`self` | `external`) decides delete-coupling.
+
+**Single-writer enforcement** is a **backend compare-and-swap on the caller's
+skill-run `run_id`** (threaded by the OS from the op context — *not* an op
+field, so it cannot be forged), **not** a permission gate: the permission system
+is resource-scoped and carries no caller identity at op-exec time. The CAS
+reject, the cooperative `abort` contract (`cancel_inflight → await_quiescent →
+terminal` + seq-fence), the deletion cascade (DOWN-abort children / UP-notify
+requester), dependency cycle-checking, and unblock-predicate evaluation land in
+later slices; slice 1 ships the op shapes + an in-memory backend.
+
+**States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
+`failed` / `aborted` / `archived`.
 
 ---
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -133,6 +133,9 @@ from . import recall as _recall  # noqa: F401, E402
 from . import run_skill as _run_skill  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 from . import skill_resolve as _skill_resolve  # noqa: F401, E402
+
+# #1953 slice 1: Task ops (first-class trackable work-units).
+from . import task as _task  # noqa: F401, E402
 from . import web as _web  # noqa: F401, E402
 
 __all__ = [

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -53,6 +53,19 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "judge_output": frozenset(),
     "compact": frozenset(),
     "ask_user": frozenset(),
+    # #1953 slice 1: Task ops have no distinct chat-tool qualified name → each
+    # is gated on its own kind name (no silent bypass).
+    "task.create": frozenset(),
+    "task.update_status": frozenset(),
+    "task.get": frozenset(),
+    "task.list": frozenset(),
+    "task.create_subtask": frozenset(),
+    "task.add_dependency": frozenset(),
+    "task.abort": frozenset(),
+    "task.archive": frozenset(),
+    "task.heartbeat": frozenset(),
+    "task.register_unblock_predicate": frozenset(),
+    "task.comment": frozenset(),
 }
 
 

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -63,6 +63,17 @@ from reyn.schemas.models import (
     RunSkillIROp,
     SandboxedExecIROp,
     SkillResolveIROp,
+    TaskAbortIROp,
+    TaskAddDependencyIROp,
+    TaskArchiveIROp,
+    TaskCommentIROp,
+    TaskCreateIROp,
+    TaskCreateSubtaskIROp,
+    TaskGetIROp,
+    TaskHeartbeatIROp,
+    TaskListIROp,
+    TaskRegisterUnblockPredicateIROp,
+    TaskUpdateStatusIROp,
     WebFetchIROp,
     WebSearchIROp,
     WriteFileIROp,
@@ -142,6 +153,18 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # #272/#1128: LLM-emittable voluntary compaction (advisory; the mandatory
     # retry_loop backstop is independent).
     "compact": CompactIROp,
+    # #1953 slice 1: Task ops (first-class trackable work-units).
+    "task.create": TaskCreateIROp,
+    "task.update_status": TaskUpdateStatusIROp,
+    "task.get": TaskGetIROp,
+    "task.list": TaskListIROp,
+    "task.create_subtask": TaskCreateSubtaskIROp,
+    "task.add_dependency": TaskAddDependencyIROp,
+    "task.abort": TaskAbortIROp,
+    "task.archive": TaskArchiveIROp,
+    "task.heartbeat": TaskHeartbeatIROp,
+    "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
+    "task.comment": TaskCommentIROp,
 }
 
 # ---------------------------------------------------------------------------
@@ -200,6 +223,20 @@ OP_PURITY: dict[str, OpPurity] = {
     # emits its own events. external = emit both started+completed so a crash
     # mid-compaction surfaces as ambiguous on resume.
     "compact": OpPurity.external,
+    # #1953 slice 1: Task ops. Reads = world (backend state); mutations =
+    # side_effect (backend write). Conservative; finer attempt-vs-task purity
+    # is not needed for resume since the Task backend is its own source of truth.
+    "task.get": OpPurity.world,
+    "task.list": OpPurity.world,
+    "task.create": OpPurity.side_effect,
+    "task.update_status": OpPurity.side_effect,
+    "task.create_subtask": OpPurity.side_effect,
+    "task.add_dependency": OpPurity.side_effect,
+    "task.abort": OpPurity.side_effect,
+    "task.archive": OpPurity.side_effect,
+    "task.heartbeat": OpPurity.side_effect,
+    "task.register_unblock_predicate": OpPurity.side_effect,
+    "task.comment": OpPurity.side_effect,
 }
 
 
@@ -248,6 +285,14 @@ COARSE_TO_FINE: dict[str, frozenset[str]] = {
     # longer includes "file") and should migrate to fine kinds.
     "mcp":       frozenset({"call_mcp_tool", "list_mcp_servers", "list_mcp_tools"}),
     "run_skill": frozenset({"invoke_skill"}),
+    # #1953 slice 1: coarse "task" → all task.* fine kinds, so a skill can
+    # declare allowed_ops: [task] to permit the whole Task op family.
+    "task": frozenset({
+        "task.create", "task.update_status", "task.get", "task.list",
+        "task.create_subtask", "task.add_dependency", "task.abort",
+        "task.archive", "task.heartbeat", "task.register_unblock_predicate",
+        "task.comment",
+    }),
 }
 
 

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -1,0 +1,163 @@
+"""Task op handlers (#1953 slice 1) — route ``task.*`` Control IR ops to the
+Task backend.
+
+Slice 1 uses a process-local in-memory backend (the stub the design calls for);
+slice 2 swaps in config-driven sqlite resolution threaded through ``OpContext``.
+The single-writer claim token is the caller's ``run_id`` from ``OpContext``
+(audit C2) — never an op field, so it cannot be forged by the LLM. Enforcement
+(CAS reject, abort quiescence, cascade, cycle-check, predicate-eval) lands in
+later slices; these handlers expose the contract surface.
+"""
+from __future__ import annotations
+
+import uuid
+
+from reyn.task import InMemoryTaskBackend, Task, TaskOrigin
+
+from . import register
+from .context import OpContext
+
+# Slice-1 process-local backend. Replaced in slice 2 by config-driven resolution
+# (sqlite / in-memory / gh-issue) threaded through OpContext.
+_BACKEND: InMemoryTaskBackend = InMemoryTaskBackend()
+
+
+def _backend() -> InMemoryTaskBackend:
+    return _BACKEND
+
+
+def reset_backend_for_test() -> None:
+    """Test hook — reset the slice-1 process-local backend between tests."""
+    global _BACKEND
+    _BACKEND = InMemoryTaskBackend()
+
+
+def _ok(kind: str, **data) -> dict:
+    return {"kind": kind, "status": "ok", **data}
+
+
+def _not_found(kind: str, task_id: str) -> dict:
+    return {"kind": kind, "status": "error", "error": f"task {task_id!r} not found"}
+
+
+def _actor(ctx: OpContext) -> str | None:
+    """The acting agent identity (audit provenance — created_by / comment author).
+    NOT the single-writer token (that is the run_id, threaded separately)."""
+    return getattr(ctx, "agent_id", None)
+
+
+async def _create(op, ctx: OpContext, caller) -> dict:
+    task = Task(
+        task_id=uuid.uuid4().hex,
+        name=op.name,
+        assignee=op.assignee,
+        requester=op.requester,
+        origin=TaskOrigin(op.origin),
+        description=op.description,
+        budget_cap=op.budget_cap,
+        created_by=_actor(ctx),
+        deps=list(op.deps),
+    )
+    created = await _backend().create(task)
+    return _ok("task.create", task=created.to_dict())
+
+
+async def _update_status(op, ctx: OpContext, caller) -> dict:
+    # writer_token = caller's run_id (single-writer claim token, audit C2); slice 3
+    # CAS-rejects on current_run_id mismatch.
+    task = await _backend().update_status(op.task_id, op.status, writer_token=ctx.run_id)
+    if task is None:
+        return _not_found("task.update_status", op.task_id)
+    return _ok("task.update_status", task=task.to_dict())
+
+
+async def _get(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().get(op.task_id)
+    if task is None:
+        return _not_found("task.get", op.task_id)
+    return _ok("task.get", task=task.to_dict())
+
+
+async def _list(op, ctx: OpContext, caller) -> dict:
+    tasks = await _backend().list(
+        assignee=op.assignee,
+        requester=op.requester,
+        status=op.status,
+        parent_id=op.parent_id,
+    )
+    return _ok("task.list", tasks=[t.to_dict() for t in tasks])
+
+
+async def _create_subtask(op, ctx: OpContext, caller) -> dict:
+    parent = await _backend().get(op.parent_id)
+    if parent is None:
+        return _not_found("task.create_subtask", op.parent_id)
+    child = Task(
+        task_id=uuid.uuid4().hex,
+        name=op.name,
+        assignee=op.assignee,
+        requester=op.parent_id,  # parent is the child's requester (§16)
+        origin=parent.origin,    # lineage inherits origin
+        description=op.description,
+        parent_id=op.parent_id,
+        created_by=_actor(ctx),
+        deps=list(op.deps),
+    )
+    created = await _backend().create(child)
+    return _ok("task.create_subtask", task=created.to_dict())
+
+
+async def _add_dependency(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().add_dependency(op.task_id, op.depends_on)
+    if task is None:
+        return _not_found("task.add_dependency", op.task_id)
+    return _ok("task.add_dependency", task=task.to_dict())
+
+
+async def _abort(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().abort(op.task_id, reason=op.reason)
+    if task is None:
+        return _not_found("task.abort", op.task_id)
+    return _ok("task.abort", task=task.to_dict())
+
+
+async def _archive(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().archive(op.task_id)
+    if task is None:
+        return _not_found("task.archive", op.task_id)
+    return _ok("task.archive", task=task.to_dict())
+
+
+async def _heartbeat(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().get(op.task_id)
+    if task is None:
+        return _not_found("task.heartbeat", op.task_id)
+    # slice 7 adds predicate-eval + liveness-timeout; slice 1 reports state.
+    return _ok("task.heartbeat", task_id=op.task_id, state=task.status.value, unblocked=False)
+
+
+async def _register_unblock_predicate(op, ctx: OpContext, caller) -> dict:
+    task = await _backend().set_unblock_predicate(op.task_id, op.predicate)
+    if task is None:
+        return _not_found("task.register_unblock_predicate", op.task_id)
+    return _ok("task.register_unblock_predicate", task_id=op.task_id)
+
+
+async def _comment(op, ctx: OpContext, caller) -> dict:
+    comment_id = await _backend().add_comment(op.task_id, _actor(ctx) or "unknown", op.body)
+    if comment_id is None:
+        return _not_found("task.comment", op.task_id)
+    return _ok("task.comment", task_id=op.task_id, comment_id=comment_id)
+
+
+register("task.create", _create)
+register("task.update_status", _update_status)
+register("task.get", _get)
+register("task.list", _list)
+register("task.create_subtask", _create_subtask)
+register("task.add_dependency", _add_dependency)
+register("task.abort", _abort)
+register("task.archive", _archive)
+register("task.heartbeat", _heartbeat)
+register("task.register_unblock_predicate", _register_unblock_predicate)
+register("task.comment", _comment)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -557,11 +557,137 @@ class CompactIROp(BaseModel):
     reason: str | None = None   # optional model-supplied rationale (audit only)
 
 
+# ---------------------------------------------------------------------------
+# Task ops (#1953 slice 1) — first-class trackable work-units.
+# ---------------------------------------------------------------------------
+# Agent-facing Task operations as Control IR ops (P4). P7 term-neutral: op
+# names + fields are generic; A2A vocabulary (contextId / TaskState) maps only
+# at the A2A layer. Single-writer is a backend-CAS on the caller's skill-run
+# run_id (threaded from OpContext, NOT an op field → unforgeable; audit C2),
+# NOT a permission gate. Enforcement (CAS reject, abort quiescence, cascade,
+# cycle-check, predicate-eval) lands in later slices; these are the shapes.
+
+
+class TaskCreateIROp(BaseModel):
+    """Create a Task born with its assignee (immutable; no handoff — §12).
+
+    ``origin`` decides delete-coupling (§17): ``self`` couples to the agent,
+    ``external`` persists with an external requester. ``requester`` is the
+    disposition notify-target (§16)."""
+
+    kind: Literal["task.create"]
+    name: str
+    assignee: str
+    requester: str
+    origin: Literal["self", "external"] = "self"
+    description: str | None = None
+    budget_cap: float | None = None
+    deps: list[str] = Field(default_factory=list)  # depends-on task_ids (DAG, §13)
+
+
+class TaskUpdateStatusIROp(BaseModel):
+    """Declare a status transition. Writer = the task's assignee; the gate is a
+    backend-CAS on the caller's skill-run run_id (threaded from OpContext, not a
+    field here — audit C2), enforced in slice 3."""
+
+    kind: Literal["task.update_status"]
+    task_id: str
+    status: str
+    reason: str | None = None
+
+
+class TaskGetIROp(BaseModel):
+    """Read one Task record."""
+
+    kind: Literal["task.get"]
+    task_id: str
+
+
+class TaskListIROp(BaseModel):
+    """List Tasks, optionally narrowed by assignee / requester / status / parent."""
+
+    kind: Literal["task.list"]
+    assignee: str | None = None
+    requester: str | None = None
+    status: str | None = None
+    parent_id: str | None = None
+
+
+class TaskCreateSubtaskIROp(BaseModel):
+    """Decompose work into a child Task assigned to another worker (§12). The
+    parent is the child's requester; lineage = ``parent_id`` (no handoff-log)."""
+
+    kind: Literal["task.create_subtask"]
+    parent_id: str
+    name: str
+    assignee: str
+    description: str | None = None
+    deps: list[str] = Field(default_factory=list)
+
+
+class TaskAddDependencyIROp(BaseModel):
+    """Add a depends-on edge (dependency DAG, §13). Topology owned by the
+    decomposing parent; readiness is derived read-only (no write to the dep).
+    Cycle-check lands in slice 6."""
+
+    kind: Literal["task.add_dependency"]
+    task_id: str
+    depends_on: str
+
+
+class TaskAbortIROp(BaseModel):
+    """OS-authority terminal cancel (→ aborted; A2A canceled). The enforced
+    contract is cooperative: ``cancel_inflight → await_quiescent → terminal``
+    (+ seq-fence) so no write lands after terminal (audit C1, slice 3)."""
+
+    kind: Literal["task.abort"]
+    task_id: str
+    reason: str | None = None
+
+
+class TaskArchiveIROp(BaseModel):
+    """Soft-delete (→ archived; the "delete" verb). Triggers the deletion matrix
+    in slice 3: DOWN-abort children + UP-notify persistent requester (§18/19).
+    Archived tasks are time-travel-recoverable within the retention window (§24)."""
+
+    kind: Literal["task.archive"]
+    task_id: str
+    reason: str | None = None
+
+
+class TaskHeartbeatIROp(BaseModel):
+    """Liveness + (slice 7) unblock-predicate evaluation trigger for a blocked
+    task. Returns the current state; predicate-eval / liveness-timeout land in
+    slice 7."""
+
+    kind: Literal["task.heartbeat"]
+    task_id: str
+
+
+class TaskRegisterUnblockPredicateIROp(BaseModel):
+    """Register a deterministic unblock predicate (code, no LLM) evaluated at
+    heartbeat (§22 tier B'); true → unblock → LLM only then. Predicate-eval is
+    slice 7; this records it."""
+
+    kind: Literal["task.register_unblock_predicate"]
+    task_id: str
+    predicate: str
+
+
+class TaskCommentIROp(BaseModel):
+    """Append a comment to a Task's thread (durable inter-agent/HITL protocol —
+    Hermes gap7). Core-contract field; richer thread semantics deferred."""
+
+    kind: Literal["task.comment"]
+    task_id: str
+    body: str
+
+
 # Discriminated union — Pydantic selects the variant via the "kind" field.
 # All variants below are implemented in `op_runtime/`:
 #   file, mcp, ask_user, shell, lint, run_skill, web_fetch, web_search,
 #   mcp_install, embed, index_write, index_query, recall, index_drop,
-#   sandboxed_exec, judge_output, skill_resolve, compact.
+#   sandboxed_exec, judge_output, skill_resolve, compact, task.* (#1953).
 # Fine-grained file ops (#1240 Wave 1+1.5): read_file, write_file, edit_file,
 #   delete_file, glob_files, grep_files (phase=allow registry entries).
 ControlIROp = Annotated[
@@ -575,6 +701,11 @@ ControlIROp = Annotated[
         RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
         IndexQueryIROp, RecallIROp, IndexDropIROp,
         SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
+        # #1953 slice 1: Task ops.
+        TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
+        TaskCreateSubtaskIROp, TaskAddDependencyIROp, TaskAbortIROp,
+        TaskArchiveIROp, TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
+        TaskCommentIROp,
     ],
     Field(discriminator="kind"),
 ]

--- a/src/reyn/task/__init__.py
+++ b/src/reyn/task/__init__.py
@@ -1,0 +1,31 @@
+"""Task subsystem — first-class trackable work-units (#1953).
+
+A Task is an opt-in, additive handle over a unit of work; the session model
+(concurrent / interleaved / cross-chain) is unchanged. Completion is an
+*explicit declaration* (an assignee calls ``task.update_status``), never an
+inference from session state — which is why a Task can be tracked discretely
+while the session keeps interleaving (#1953 §10).
+
+This package holds the **term-neutral** domain model + the swappable backend
+contract (P7: generic vocabulary; A2A terms like ``contextId`` / ``TaskState``
+map only at the A2A layer). Slice 1 ships the contract + an in-memory backend;
+sqlite (slice 2), single-writer CAS + P6 events (slice 3), and the rest follow.
+"""
+from __future__ import annotations
+
+from reyn.task.backend import InMemoryTaskBackend, TaskBackend
+from reyn.task.model import (
+    TERMINAL_STATES,
+    Task,
+    TaskOrigin,
+    TaskState,
+)
+
+__all__ = [
+    "Task",
+    "TaskState",
+    "TaskOrigin",
+    "TERMINAL_STATES",
+    "TaskBackend",
+    "InMemoryTaskBackend",
+]

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -1,0 +1,179 @@
+"""Task backend contract + in-memory implementation (#1953 slice 1).
+
+``TaskBackend`` is the **tracker-agnostic core contract** every backend must
+implement (id / status / assignee / requester / links / fields). Slice 1 ships
+``InMemoryTaskBackend`` (the stub the design calls for); slice 2 adds the sqlite
+backend (single-writer CAS via ``BEGIN IMMEDIATE`` + ``current_run_id``), and
+later slices layer P6 events, cascades, cycle-checks, and budget on top.
+
+Scope note (slice 1): these methods provide the *contract surface* — basic
+persistence + retrieval. Enforcement that the design assigns to later slices is
+intentionally NOT here yet:
+  - **single-writer CAS reject** → slice 3. NOTE (part-3 audit C2): this is a
+    **backend-CAS on ``current_run_id``**, NOT a permission gate — the permission
+    system has no caller/session identity at op-exec time, so "caller≠assignee →
+    reject via P5" is unimplementable. The writer-token is the caller's durable
+    skill-run ``run_id`` (threaded from ``OpContext.run_id``, never an LLM param
+    → unforgeable); ``update_status`` carries it now so slice 3 can CAS on
+    ``current_run_id == writer_token`` (Hermes ``current_run_id`` CAS, same form).
+  - **abort** → slice 3. NOTE (audit C1): abort is *cooperative*, not SIGKILL —
+    ``cancel_inflight()`` only takes effect at the next tool-boundary, so an
+    in-flight write can still land. The contract is the 3-step
+    ``cancel_inflight → await_quiescent → terminal`` (+ seq-fence) so no write
+    lands after the terminal transition. The stub here just sets the terminal
+    state; the quiescence step needs Session access (slice 3).
+  - deletion cascade (DOWN-abort children / UP-notify requester) → slice 3.
+  - dependency cycle-check + readiness propagation → slice 6.
+  - unblock-predicate evaluation → slice 7.
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+from reyn.task.model import Task, TaskState, _now_iso
+
+
+class TaskBackend(Protocol):
+    """The contract a Task backend implements. Async so a remote/db backend
+    (sqlite, gh-issue, jira) can do I/O without changing callers."""
+
+    async def create(self, task: Task) -> Task: ...
+
+    async def get(self, task_id: str) -> Task | None: ...
+
+    async def list(
+        self,
+        *,
+        assignee: str | None = None,
+        requester: str | None = None,
+        status: str | None = None,
+        parent_id: str | None = None,
+    ) -> list[Task]: ...
+
+    async def update_status(
+        self, task_id: str, status: str, *, writer_token: str | None = None
+    ) -> Task | None:
+        """Transition status. ``writer_token`` is the caller's durable skill-run
+        run_id (the single-writer claim token, audit C2). Slice 3 CAS-rejects when
+        ``current_run_id`` is set and ``!= writer_token``; slice 1 accepts it."""
+        ...
+
+    async def add_dependency(self, task_id: str, depends_on: str) -> Task | None: ...
+
+    async def archive(self, task_id: str) -> Task | None: ...
+
+    async def abort(self, task_id: str, reason: str | None = None) -> Task | None: ...
+
+    async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None: ...
+
+    async def set_unblock_predicate(self, task_id: str, predicate: str) -> Task | None: ...
+
+    async def add_comment(self, task_id: str, author: str, body: str) -> str | None: ...
+
+
+class InMemoryTaskBackend:
+    """Process-local dict-backed backend (slice 1 stub + the ``in-memory``
+    config option for tests). Not durable, not crash-safe — sqlite (slice 2)
+    is the first durable backend. Single-threaded async; no locking needed
+    because slice 1 does not yet enforce CAS."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, Task] = {}
+        # slice-1 stub stores for ops whose enforcement lands later.
+        self._predicates: dict[str, str] = {}
+        self._comments: dict[str, list[dict]] = {}
+        self._comment_seq = 0
+
+    async def create(self, task: Task) -> Task:
+        self._tasks[task.task_id] = task
+        return task
+
+    async def get(self, task_id: str) -> Task | None:
+        return self._tasks.get(task_id)
+
+    async def list(
+        self,
+        *,
+        assignee: str | None = None,
+        requester: str | None = None,
+        status: str | None = None,
+        parent_id: str | None = None,
+    ) -> list[Task]:
+        out = list(self._tasks.values())
+        if assignee is not None:
+            out = [t for t in out if t.assignee == assignee]
+        if requester is not None:
+            out = [t for t in out if t.requester == requester]
+        if status is not None:
+            out = [t for t in out if t.status.value == status]
+        if parent_id is not None:
+            out = [t for t in out if t.parent_id == parent_id]
+        return out
+
+    async def update_status(
+        self, task_id: str, status: str, *, writer_token: str | None = None
+    ) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        # slice 3 adds the CAS reject on current_run_id != writer_token (audit C2);
+        # slice 1 records the claim token (first writer claims) without rejecting.
+        if writer_token is not None and task.current_run_id is None:
+            task.current_run_id = writer_token
+        task.status = TaskState(status)
+        task.updated_at = _now_iso()
+        return task
+
+    async def add_dependency(self, task_id: str, depends_on: str) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        # slice 6 adds cycle-check + readiness propagation; slice 1 records the edge.
+        if depends_on not in task.deps:
+            task.deps.append(depends_on)
+        task.updated_at = _now_iso()
+        return task
+
+    async def archive(self, task_id: str) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        task.status = TaskState.ARCHIVED
+        task.updated_at = _now_iso()
+        return task
+
+    async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        # audit C1: the real abort is cancel_inflight → await_quiescent → terminal
+        # (+ seq-fence), so no in-flight write lands after the terminal transition.
+        # That needs Session access (slice 3); the stub sets the terminal state only.
+        task.status = TaskState.ABORTED
+        task.updated_at = _now_iso()
+        return task
+
+    async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        task.awaiting_since = awaiting_since
+        task.updated_at = _now_iso()
+        return task
+
+    async def set_unblock_predicate(self, task_id: str, predicate: str) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        self._predicates[task_id] = predicate
+        return task
+
+    async def add_comment(self, task_id: str, author: str, body: str) -> str | None:
+        if task_id not in self._tasks:
+            return None
+        self._comment_seq += 1
+        comment_id = f"c{self._comment_seq}"
+        self._comments.setdefault(task_id, []).append(
+            {"id": comment_id, "author": author, "body": body, "ts": _now_iso()}
+        )
+        return comment_id

--- a/src/reyn/task/model.py
+++ b/src/reyn/task/model.py
@@ -1,0 +1,106 @@
+"""Task domain model — term-neutral (#1953).
+
+States, origin, and the ``Task`` record. No backend / A2A / sqlite vocabulary
+here — the A2A layer maps ``TaskState`` ↔ A2A states at its boundary (#1948),
+and backends map this record to their own storage (sqlite table, gh issue, …).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TaskState(str, Enum):
+    """Lifecycle states (#1953 §0-Q1).
+
+    ``ready`` = DAG-unblocked but not yet started; ``archived`` = soft-deleted
+    (WAL-window auto-purge eligible, §24). A2A mapping lives in the A2A layer:
+    ready→submitted, in_progress→working, blocked→input-required/auth-required,
+    completed→completed, failed→failed, aborted→canceled, archived→(internal).
+    """
+
+    PENDING = "pending"
+    READY = "ready"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ABORTED = "aborted"
+    ARCHIVED = "archived"
+
+
+# Terminal states never transition further (single-writer is moot once here).
+TERMINAL_STATES: frozenset[TaskState] = frozenset(
+    {TaskState.COMPLETED, TaskState.FAILED, TaskState.ABORTED, TaskState.ARCHIVED}
+)
+
+
+class TaskOrigin(str, Enum):
+    """Origin decides deletion coupling (#1953 §17).
+
+    ``self`` — agent's own working unit; requester == assignee == agent →
+    deleted together with the agent (coupled), no external notify.
+    ``external`` — A2A client / human / other system requested it; requester is
+    external and persists → assignee-delete archives + notifies the requester.
+    """
+
+    SELF = "self"
+    EXTERNAL = "external"
+
+
+@dataclass
+class Task:
+    """One trackable work-unit.
+
+    ``assignee`` is the single-writer of ``status`` and is immutable for the
+    Task's life (no handoff — delegation is sub-task decomposition, §12).
+    ``requester`` is the notify-target on disposition (§16). ``current_run_id``
+    + ``version`` back the single-writer CAS (enforced in slice 3). ``deps`` are
+    depends-on edges (the dependency DAG, §13) — kept here for the in-memory
+    backend; the sqlite backend stores them in a ``task_links`` table.
+    """
+
+    task_id: str
+    name: str
+    assignee: str
+    requester: str
+    origin: TaskOrigin = TaskOrigin.SELF
+    status: TaskState = TaskState.PENDING
+    description: str | None = None
+    created_by: str | None = None  # audit provenance (§0-Q3); operative notify = requester
+    parent_id: str | None = None  # ownership tree (§12), distinct from deps DAG
+    budget_cap: float | None = None  # per-task budget (§8)
+    cost_accum: float = 0.0
+    awaiting_since: float | None = None  # R-D16 WAL-floor exclusion (set while blocked)
+    current_run_id: str | None = None  # CAS token (slice 3)
+    version: int = 0  # CAS generalization (slice 3)
+    deps: list[str] = field(default_factory=list)  # depends-on task_ids (DAG, §13)
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+
+    def to_dict(self) -> dict:
+        """JSON-safe projection (op return shape + backend round-trip)."""
+        return {
+            "task_id": self.task_id,
+            "name": self.name,
+            "assignee": self.assignee,
+            "requester": self.requester,
+            "origin": self.origin.value,
+            "status": self.status.value,
+            "description": self.description,
+            "created_by": self.created_by,
+            "parent_id": self.parent_id,
+            "budget_cap": self.budget_cap,
+            "cost_accum": self.cost_accum,
+            "awaiting_since": self.awaiting_since,
+            "current_run_id": self.current_run_id,
+            "version": self.version,
+            "deps": list(self.deps),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -84,6 +84,19 @@ _LEGACY_ONLY_KINDS: frozenset[str] = frozenset({
     "mcp",
     "run_skill",
     "skill_resolve",
+    # #1953 slice 1: Task ops dispatch via op_runtime handlers (op_runtime/task.py
+    # register()), not phase=allow ToolDefinitions — legacy-only by this taxonomy.
+    "task.create",
+    "task.update_status",
+    "task.get",
+    "task.list",
+    "task.create_subtask",
+    "task.add_dependency",
+    "task.abort",
+    "task.archive",
+    "task.heartbeat",
+    "task.register_unblock_predicate",
+    "task.comment",
 })
 
 

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -1,0 +1,174 @@
+"""Tier 1/2: #1953 slice 1 — Task op interface contract surface.
+
+The ``task.*`` Control IR ops exist, validate through the ControlIROp union, are
+registered + gated (completeness), and round-trip through the in-memory backend.
+Enforcement (single-writer CAS, abort quiescence, cascade, cycle-check,
+predicate-eval) lands in later slices — this slice is the contract surface.
+
+Falsification:
+- completeness test reds if any task op kind is missing from the contextual gate
+  (a silent capability bypass) or from the handler registry.
+- the writer-token test reds if ``update_status`` stops threading the caller's
+  run_id as the single-writer claim token (audit C2).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import TypeAdapter
+
+from reyn.core.op_runtime import available_kinds
+from reyn.core.op_runtime import task as taskmod
+from reyn.core.op_runtime.contextual_gate import _OP_KIND_ALIASES
+from reyn.core.op_runtime.registry import ALL_OP_KINDS, OP_KIND_MODEL_MAP, OP_PURITY
+from reyn.schemas.models import ControlIROp
+from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+_TASK_KINDS = frozenset(k for k in ALL_OP_KINDS if k.startswith("task."))
+
+
+def _ctx(run_id: str = "run-1", agent_id: str = "alice"):
+    """Minimal OpContext stand-in — the task handlers read only run_id + agent_id."""
+    return SimpleNamespace(run_id=run_id, agent_id=agent_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+# ── registry / gate completeness (Tier 1 contract) ──────────────────────────
+
+
+def test_all_task_kinds_present_in_registry_and_purity():
+    """Tier 1: every task op kind has a model + purity + handler (no half-wiring)."""
+    assert _TASK_KINDS  # non-empty; the exact set is pinned in the union test
+    handlers = set(available_kinds())
+    for kind in _TASK_KINDS:
+        assert kind in OP_KIND_MODEL_MAP
+        assert kind in OP_PURITY
+        assert kind in handlers
+
+
+def test_contextual_gate_covers_every_task_kind():
+    """Tier 1: the contextual gate enumerates every task kind — a missing entry
+    would be a silent capability bypass (the #1912b completeness invariant)."""
+    missing = _TASK_KINDS - set(_OP_KIND_ALIASES)
+    # RED if a task op is added without a gate entry.
+    assert missing == set()
+
+
+def test_union_validates_every_task_kind():
+    """Tier 1: each task op kind round-trips through the ControlIROp union."""
+    adapter = TypeAdapter(ControlIROp)
+    samples = {
+        "task.create": {"kind": "task.create", "name": "n", "assignee": "a", "requester": "r"},
+        "task.update_status": {"kind": "task.update_status", "task_id": "t", "status": "in_progress"},
+        "task.get": {"kind": "task.get", "task_id": "t"},
+        "task.list": {"kind": "task.list"},
+        "task.create_subtask": {"kind": "task.create_subtask", "parent_id": "p", "name": "n", "assignee": "b"},
+        "task.add_dependency": {"kind": "task.add_dependency", "task_id": "t", "depends_on": "u"},
+        "task.abort": {"kind": "task.abort", "task_id": "t"},
+        "task.archive": {"kind": "task.archive", "task_id": "t"},
+        "task.heartbeat": {"kind": "task.heartbeat", "task_id": "t"},
+        "task.register_unblock_predicate": {"kind": "task.register_unblock_predicate", "task_id": "t", "predicate": "x"},
+        "task.comment": {"kind": "task.comment", "task_id": "t", "body": "hi"},
+    }
+    # every kind has a sample (forces this test to grow with the op-set)
+    assert set(samples) == _TASK_KINDS
+    for kind, payload in samples.items():
+        op = adapter.validate_python(payload)
+        assert op.kind == kind
+
+
+# ── backend round-trip (Tier 2 — in-memory stub) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inmemory_backend_create_get_list_roundtrip():
+    """Tier 2: a non-default Task round-trips through the in-memory backend."""
+    backend = InMemoryTaskBackend()
+    task = Task(
+        task_id="t1", name="ship", assignee="bob", requester="alice",
+        status=TaskState.BLOCKED, budget_cap=12.5,
+    )
+    await backend.create(task)
+
+    got = await backend.get("t1")
+    assert got is not None
+    assert got.assignee == "bob" and got.budget_cap == 12.5
+    assert got.status is TaskState.BLOCKED
+
+    by_assignee = await backend.list(assignee="bob")
+    assert [t.task_id for t in by_assignee] == ["t1"]
+    assert await backend.list(assignee="nobody") == []
+
+
+# ── handler contract (Tier 2) ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_then_get_via_handlers():
+    """Tier 2: task.create returns a task_id that task.get resolves."""
+    created = await taskmod._create(
+        SimpleNamespace(name="ship", assignee="bob", requester="alice",
+                        origin="self", description=None, budget_cap=None, deps=[]),
+        _ctx(), "control_ir",
+    )
+    assert created["status"] == "ok"
+    task_id = created["task"]["task_id"]
+
+    got = await taskmod._get(SimpleNamespace(task_id=task_id), _ctx(), "control_ir")
+    assert got["status"] == "ok"
+    assert got["task"]["assignee"] == "bob"
+
+
+@pytest.mark.asyncio
+async def test_update_status_threads_run_id_as_writer_token():
+    """Tier 2: update_status threads the caller's run_id as the single-writer
+    claim token (audit C2) — the backend records it on first write."""
+    created = await taskmod._create(
+        SimpleNamespace(name="n", assignee="bob", requester="alice",
+                        origin="self", description=None, budget_cap=None, deps=[]),
+        _ctx(run_id="run-XYZ"), "control_ir",
+    )
+    task_id = created["task"]["task_id"]
+
+    updated = await taskmod._update_status(
+        SimpleNamespace(task_id=task_id, status="in_progress", reason=None),
+        _ctx(run_id="run-XYZ"), "control_ir",
+    )
+    assert updated["status"] == "ok"
+    # RED if update_status stops threading run_id as the claim token (C2 fix gone).
+    assert updated["task"]["current_run_id"] == "run-XYZ"
+    assert updated["task"]["status"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_archive_and_abort_reach_terminal_states():
+    """Tier 2: archive → archived, abort → aborted (terminal contract surface)."""
+    async def _mk(name):
+        c = await taskmod._create(
+            SimpleNamespace(name=name, assignee="b", requester="a",
+                            origin="self", description=None, budget_cap=None, deps=[]),
+            _ctx(), "control_ir",
+        )
+        return c["task"]["task_id"]
+
+    a_id = await _mk("a")
+    b_id = await _mk("b")
+    arch = await taskmod._archive(SimpleNamespace(task_id=a_id, reason=None), _ctx(), "control_ir")
+    abrt = await taskmod._abort(SimpleNamespace(task_id=b_id, reason="cancel"), _ctx(), "control_ir")
+    assert arch["task"]["status"] == "archived"
+    assert abrt["task"]["status"] == "aborted"
+
+
+@pytest.mark.asyncio
+async def test_handlers_return_error_for_unknown_task():
+    """Tier 2: ops on a missing task return a decision-enabling error, not a crash."""
+    got = await taskmod._get(SimpleNamespace(task_id="nope"), _ctx(), "control_ir")
+    assert got["status"] == "error"
+    assert "not found" in got["error"]


### PR DESCRIPTION
**[e2e-coder]** — #1953 Task-system, **slice 1 (interface)**. design-check-first GO from lead ([design-check](https://github.com/tya5/reyn/issues/1953#issuecomment-4758730471) + [integration](https://github.com/tya5/reyn/issues/1953#issuecomment-4758737369) + [C1/C2 fold](https://github.com/tya5/reyn/issues/1953#issuecomment-4758778155)). This slice is the **contract surface**; enforcement lands in later slices per the slice plan.

## What
- **`src/reyn/task/`** — term-neutral domain (`Task`, `TaskState` 8-state set, `TaskOrigin`) + `TaskBackend` contract + `InMemoryTaskBackend` stub. P7: no A2A/sqlite vocabulary — A2A terms map only at the A2A layer.
- **11 `task.*` Control IR ops** — `create / update_status / get / list / create_subtask / add_dependency / abort / archive / heartbeat / register_unblock_predicate / comment`: IROp models (`schemas/models.py`), `OP_KIND_MODEL_MAP` + `OP_PURITY` + `COARSE_TO_FINE["task"]` (`registry.py`), contextual-gate entries (`contextual_gate.py`, completeness-tested), handlers (`op_runtime/task.py`), `control-ir.md` table rows + section.

## Folds the part-3 falsification audit (C1/C2)
- **C2 — single-writer = backend-CAS, not P5.** The permission system is resource-scoped with no caller identity at op-exec time, so "caller≠assignee → reject via P5" is unimplementable. `update_status` threads a **writer-token = the caller's skill-run `run_id`** (from `OpContext.run_id`, **never an op field → unforgeable**). The CAS reject (`current_run_id != writer_token`) is slice 3; this slice records the claim token.
- **C1 — abort is cooperative.** The contract is `cancel_inflight → await_quiescent → terminal` (+ seq-fence) so no write lands after terminal; documented on the op + backend. The stub sets the terminal state only (quiescence needs Session access → slice 3).

## Scope (explicitly deferred per slice plan)
CAS reject + abort quiescence + deletion cascade + P6 events (Task state in the backend's *own* sqlite, NOT WAL `state_log`) → slice 3; dependency cycle-check + readiness → slice 6; completion-assist idle-driver + predicate-eval + per-task liveness → slice 7. `task.archive` is the explicit soft-delete op; `task.abort` is the OS-authority terminal.

## Test plan
- [x] `tests/test_task_ops_interface_1953.py` (8 tests, Tier 1/2) — registry+purity+handler completeness; **contextual-gate completeness** (missing entry = silent bypass); union validates every kind; in-memory backend roundtrip (non-default values); handler contract; **writer-token threading** (audit C2).
- [x] `test_phase_dispatch_registry_coverage.py` updated — task ops classified legacy-only (op_runtime handler dispatch, no phase ToolDefinition); partition test green.
- [x] Broad op/schema/dispatch/contextual-gate sweep: 1466 passed, 1 skipped, 1 xfailed. Full rootdir suite verifying (will confirm before merge-ready).
- [x] ruff clean; `scripts/test_tier_audit.py --strict` clean (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)