### PR TITLE
fix(tui): events-tab CJK error/url hints overflow column (cell-aware truncation)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
@@ -296,9 +296,14 @@ def _event_hint(ev: dict) -> str:
         at = d.get("artifact_type", "")
         return f"{at} ✗ {len(errors)} err" if errors else f"{at} ✓"
     if t == "validation_error":
-        return f"{d.get('phase', '')}: {str(d.get('error', ''))[:35]}"
+        err, was_trunc = _truncate_to_cells(str(d.get("error", "")), 35)
+        return f"{d.get('phase', '')}: {err}" + ("…" if was_trunc else "")
     if t == "phase_retry":
-        return f"attempt {d.get('attempt', '?')}/{d.get('max_retries', '?')}: {str(d.get('error', ''))[:25]}"
+        err, was_trunc = _truncate_to_cells(str(d.get("error", "")), 25)
+        return (
+            f"attempt {d.get('attempt', '?')}/{d.get('max_retries', '?')}: {err}"
+            + ("…" if was_trunc else "")
+        )
     if t == "permission_denied":
         return f"{d.get('kind', '')} {d.get('path', '')}"
     if t in ("tool_called", "tool_returned"):
@@ -310,8 +315,8 @@ def _event_hint(ev: dict) -> str:
         suffix = " ✗" if d.get("is_error") else ""
         return f"{d.get('server', '')}.{d.get('tool', '')}{suffix}"
     if t == "mcp_failed":
-        err = str(d.get("error", ""))[:25]
-        return f"{d.get('server', '')}.{d.get('tool', '')}: {err}"
+        err, was_trunc = _truncate_to_cells(str(d.get("error", "")), 25)
+        return f"{d.get('server', '')}.{d.get('tool', '')}: {err}" + ("…" if was_trunc else "")
     if t == "mcp_server_installed":
         scope = d.get("scope", "")
         scope_part = f" ({scope})" if scope else ""
@@ -365,7 +370,8 @@ def _event_hint(ev: dict) -> str:
         rc_part = f" rc={rc}" if rc is not None else ""
         return f"[{backend}] {cmd}{suffix}{rc_part}"
     if t == "web_fetch_started":
-        return str(d.get("url", ""))[:45]
+        url, was_trunc = _truncate_to_cells(str(d.get("url", "")), 45)
+        return url + ("…" if was_trunc else "")
     if t == "web_fetch_completed":
         return f"HTTP {d.get('status_code', '')} {d.get('content_length', '')}b"
     if t == "web_search_started":

--- a/tests/cli/test_events_tab_cjk_hint.py
+++ b/tests/cli/test_events_tab_cjk_hint.py
@@ -123,6 +123,58 @@ def test_tool_failed_cjk_does_not_overflow_message() -> None:
     )
 
 
+def test_validation_error_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK validation_error error (35-cell cap) truncates cell-awarely.
+
+    Sibling-completeness for the Wave-13 fix: this branch was missed and still
+    used codepoint slicing (`error[:35]`), so 35 CJK codepoints = 70 cells.
+    """
+    ev = {"type": "validation_error",
+          "data": {"phase": "review", "error": "検証エラー" * 10}}
+    hint = _event_hint(ev)
+    # "review: " (8) + error ≤35 cells + "…" (1) = ≤44; codepoint slice ≈78.
+    assert cell_len(hint) <= 44, (
+        f"validation_error CJK hint cell_width={cell_len(hint)} > 44: {hint!r}"
+    )
+    assert "…" in hint
+
+
+def test_phase_retry_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK phase_retry error (25-cell cap) truncates cell-awarely."""
+    ev = {"type": "phase_retry",
+          "data": {"attempt": 1, "max_retries": 3, "error": "失敗理由" * 10}}
+    hint = _event_hint(ev)
+    # "attempt 1/3: " (13) + error ≤25 + "…" = ≤39; codepoint slice ≈63.
+    assert cell_len(hint) <= 40, (
+        f"phase_retry CJK hint cell_width={cell_len(hint)} > 40: {hint!r}"
+    )
+    assert "…" in hint
+
+
+def test_mcp_failed_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK mcp_failed error (25-cell cap) truncates cell-awarely."""
+    ev = {"type": "mcp_failed",
+          "data": {"server": "fs", "tool": "read", "error": "エラー内容" * 10}}
+    hint = _event_hint(ev)
+    # "fs.read: " (9) + error ≤25 + "…" = ≤35; codepoint slice ≈59.
+    assert cell_len(hint) <= 36, (
+        f"mcp_failed CJK hint cell_width={cell_len(hint)} > 36: {hint!r}"
+    )
+    assert "…" in hint
+
+
+def test_web_fetch_started_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK web_fetch_started url (45-cell cap) truncates cell-awarely."""
+    ev = {"type": "web_fetch_started",
+          "data": {"url": "https://例え.テスト/" + "あ" * 40}}
+    hint = _event_hint(ev)
+    # url ≤45 cells + "…" = ≤46; codepoint slice [:45] of CJK ≈80.
+    assert cell_len(hint) <= 46, (
+        f"web_fetch_started CJK hint cell_width={cell_len(hint)} > 46: {hint!r}"
+    )
+    assert "…" in hint
+
+
 def test_event_hint_ellipsis_present_on_cjk_truncation() -> None:
     """Tier 2b: truncated CJK hints end with the ellipsis character '…'."""
     ev = {"type": "user_message_received", "data": {"text": "今日はどうですか？" * 5}}


### PR DESCRIPTION
**[tui-coder]** — fix(tui): events-tab CJK error/url hints overflow column (cell-aware truncation)

Found via the TUI UX-exploration pass; objective render defect → fixed directly (bug-workflow). **Sibling-completeness** for the Wave-13 narrow-terminal fix.

## Bug
The Wave-13 fix converted 6 `_event_hint` branches from codepoint slicing (`text[:N]`) to the cell-aware `_truncate_to_cells` — CJK chars are 2 cells each, so `text[:N]` overshoots the column budget by ~2× (row wrapping + `event_ys` cursor misalignment). **Four branches were missed** and still slice by codepoint:
- `validation_error` (`error[:35]`), `phase_retry` (`error[:25]`), `mcp_failed` (`error[:25]`), `web_fetch_started` (`url[:45]`)

These render user/external content (exception messages, fetched URLs) that **can be CJK** — directly relevant for Japanese usage, where a CJK error message renders up to 2× its budget and wraps the events-tab row (e.g. `validation_error` with a CJK error → 78 cells vs the 44-cell target).

## Fix
Route all four through `_truncate_to_cells` + the `…` ellipsis, matching the established idiom (`tool_failed`, `web_search_started`, …). Completes the Wave-13 cell-aware-truncation class.

## Test plan
- [x] `tests/cli/test_events_tab_cjk_hint.py` — 4 new Tier-2b: CJK content for each fixed event type stays within (cap + prefix + 1) cells + ends with `…`. **Confirmed RED before the fix** (`validation_error` → 78 cells vs ≤44). Exercises the public `_event_hint` directly — no mocks, no private state.
- [x] events_tab suites — **35 passed**
- [x] `python scripts/test_tier_audit.py` — 0 violations
- [x] ruff clean

## Tier self-check
4 new tests, Tier 2b (public `_event_hint` function, cell-width contract via `rich.cells.cell_len` — no private-state asserts, no len()-pinning of layout, no mocks, no golden files). Docstrings declare `Tier 2b:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
