### PR TITLE
fix(tui): cell-aware truncation for CJK plan goals + intervention text (agents/pending)

### DIFF
--- a/src/reyn/interfaces/tui/_text_util.py
+++ b/src/reyn/interfaces/tui/_text_util.py
@@ -1,6 +1,8 @@
 """Shared text helpers for the TUI."""
 from __future__ import annotations
 
+from rich.cells import cell_len
+
 
 def _esc(s: str) -> str:
     """Escape Rich markup brackets in plain strings.
@@ -12,4 +14,26 @@ def _esc(s: str) -> str:
     return s.replace("[", "\\[").replace("]", "\\]")
 
 
-__all__ = ["_esc"]
+def truncate_to_cells(s: str, max_cells: int) -> str:
+    """Truncate ``s`` to at most ``max_cells`` display columns, '…' if cut.
+
+    CJK / full-width characters consume 2 cells each, so a naive ``s[:N]``
+    codepoint slice overshoots a column budget by up to 2× and wraps narrow
+    panel rows (mis-aligning cursor/row maps). ``rich.cells.cell_len`` is
+    East-Asian-Width aware and matches what Textual renders. Returns the
+    original string unchanged when it already fits.
+    """
+    if cell_len(s) <= max_cells:
+        return s
+    out: list[str] = []
+    used = 0
+    for ch in s:
+        w = cell_len(ch)
+        if used + w > max_cells:
+            break
+        out.append(ch)
+        used += w
+    return "".join(out) + "…"
+
+
+__all__ = ["_esc", "truncate_to_cells"]

--- a/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
@@ -23,6 +23,7 @@ from .base import (
     _TEXT_DIM,
     _TEXT_MUTED,
     logger,
+    truncate_to_cells,
 )
 
 
@@ -715,7 +716,7 @@ def render_agents(
                 item_ys.append(y_counter)
                 y_counter += 1
                 if p["goal"]:
-                    goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
+                    goal = truncate_to_cells(p["goal"], 60)
                     plan_node.add(RichText(goal, style=_TEXT_DIM))
                     y_counter += 1
                 flat_items.append({
@@ -829,7 +830,7 @@ def render_agents(
                 item_ys.append(y_counter)
                 y_counter += 1
                 if p["goal"]:
-                    goal = p["goal"][:60] + ("…" if len(p["goal"]) > 60 else "")
+                    goal = truncate_to_cells(p["goal"], 60)
                     node.add(RichText(goal, style=_TEXT_DIM))
                     y_counter += 1
                 flat_items.append({

--- a/src/reyn/interfaces/tui/widgets/right_panel/base.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/base.py
@@ -36,7 +36,7 @@ from reyn.interfaces.tui._palette import (
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
 )
-from reyn.interfaces.tui._text_util import _esc
+from reyn.interfaces.tui._text_util import _esc, truncate_to_cells
 
 logger = logging.getLogger(__name__)
 
@@ -68,4 +68,5 @@ __all__ = [
     "_TEXT_NEUTRAL",
     "_esc",
     "logger",
+    "truncate_to_cells",
 ]

--- a/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
@@ -28,6 +28,7 @@ from .base import (
     _TEXT_DIM,
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
+    truncate_to_cells,
 )
 
 # ── kind-specific row renderers ──────────────────────────────────────────────
@@ -70,9 +71,9 @@ def _render_kind_intervention(
     )
     lines = [head]
     if summary:
-        lines.append(f"    [{_TEXT_NEUTRAL}]↳[/] [{_TEXT_BODY}]{summary[:60]}[/]")
+        lines.append(f"    [{_TEXT_NEUTRAL}]↳[/] [{_TEXT_BODY}]{truncate_to_cells(summary, 60)}[/]")
     if detail:
-        lines.append(f"      [{_TEXT_DIM}]{detail[:60]}[/]")
+        lines.append(f"      [{_TEXT_DIM}]{truncate_to_cells(detail, 60)}[/]")
     return lines
 
 
@@ -95,7 +96,7 @@ def _render_kind_unknown(
     summary = str(view.get("summary", ""))
     return [
         f"{pfx}[{name_style}]{kind}[/]  [{_TEXT_MUTED}]{iv_id_short}[/]  "
-        f"[{_TEXT_BODY}]{summary[:60]}[/]",
+        f"[{_TEXT_BODY}]{truncate_to_cells(summary, 60)}[/]",
     ]
 
 

--- a/tests/cli/test_panel_tab_cjk_truncation.py
+++ b/tests/cli/test_panel_tab_cjk_truncation.py
@@ -1,0 +1,79 @@
+"""Tier 2b: cell-aware truncation of CJK user content in agents/pending tabs.
+
+Sibling-completeness for the events-tab cell-aware-truncation class: the
+agents-tab plan `goal` and the pending-tab intervention `summary`/`detail`
+still used codepoint slicing (`text[:60]`). CJK characters are 2 cells each, so
+`text[:60]` overshoots the column budget by up to 2× and wraps the narrow
+panel rows (relevant for Japanese plan goals / intervention prompts).
+
+Fix: a shared `truncate_to_cells` helper (in `_text_util`) applied to all
+sites. These tests pin the helper contract + the pending-tab integration.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from rich.cells import cell_len
+from rich.text import Text
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.tui._text_util import truncate_to_cells
+from reyn.interfaces.tui.widgets.right_panel.pending_tab import render_pending
+
+
+@dataclass(frozen=True)
+class _View:
+    id: str
+    kind: str
+    origin_channel_id: str
+    created_at: str
+    summary: str
+    detail: str = ""
+
+
+def _plain(markup: str) -> str:
+    return "\n".join(Text.from_markup(line).plain for line in markup.split("\n"))
+
+
+def test_truncate_to_cells_cjk_bounded() -> None:
+    """Tier 2b: a wide CJK string truncates to ≤ budget cells + ellipsis."""
+    s = "あ" * 50  # 100 cells
+    out = truncate_to_cells(s, 60)
+    assert cell_len(out) <= 61, f"cell_width={cell_len(out)} > 61: {out!r}"
+    assert out.endswith("…")
+
+
+def test_truncate_to_cells_ascii_passthrough() -> None:
+    """Tier 2b: a string already within budget is returned unchanged."""
+    assert truncate_to_cells("hello world", 60) == "hello world"
+    assert truncate_to_cells("", 60) == ""
+
+
+def test_pending_cjk_summary_does_not_overflow() -> None:
+    """Tier 2b: a CJK intervention summary is cell-truncated, not codepoint-sliced.
+
+    Before the fix `summary[:60]` of CJK = up to 120 cells, overflowing the
+    panel row. The summary line must stay within (60 + ellipsis + chrome).
+    """
+    view = _View(
+        id="iv12345678", kind="intervention", origin_channel_id="user",
+        created_at="2026-06-20T10:00:00",
+        summary="検証してください" * 12,  # ~96 cells uncut
+    )
+    rendered, _flat, _ys = render_pending([view])
+    plain = _plain(rendered)
+    sum_lines = [ln for ln in plain.split("\n") if "検証してください" in ln]
+    assert sum_lines, f"summary line not found. Rendered:\n{plain}"
+    width = cell_len(sum_lines[0])
+    assert width <= 70, (
+        f"pending summary line overflows ({width} cells, codepoint-slice ≈126): "
+        f"{sum_lines[0]!r}"
+    )
+    assert "…" in sum_lines[0], (
+        f"long CJK summary should be truncated with an ellipsis: {sum_lines[0]!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — fix(tui): cell-aware truncation for CJK plan goals + intervention text (agents/pending tabs)

Found via the TUI UX-exploration narrow-width/CJK sweep; objective render defect → fixed directly. **Sibling-completeness** for the events-tab CJK fix (#1960).

## Bug
The agents-tab plan `goal` and the pending-tab intervention `summary`/`detail` still used codepoint slicing (`text[:60]`). CJK chars are 2 cells each, so `text[:60]` overshoots the column budget by up to 2× and **wraps the narrow panel rows** — directly relevant for **Japanese** plan goals / intervention prompts (a CJK summary rendered **126 cells** vs the ~60-cell target).

## Fix
Promote a shared `truncate_to_cells` helper to `_text_util` (re-exported via `.base`, next to `_esc`) and apply it to all 5 sites: agents_tab plan `goal` (×2), pending_tab `summary` (×2) + `detail` (×1).

## Test plan
- [x] `tests/cli/test_panel_tab_cjk_truncation.py` — 3 Tier-2b: `truncate_to_cells` helper (CJK bounded + ellipsis; ASCII/empty passthrough) + `render_pending` CJK summary stays within budget. **Confirmed RED before the fix** (summary line 126 cells vs ≤70). Real render fns, no mocks, no private state.
- [x] agents_tab / pending_tab / panel suites — **102 passed**
- [x] `python scripts/test_tier_audit.py` — 0 violations
- [x] ruff clean

## Note
`events_tab` keeps its local `_truncate_to_cells` (same logic) for now; consolidating it + `cost_tab._fit` onto the shared helper is a follow-up cleanup, deferred to avoid stacking on the unmerged #1960.

## Tier self-check
3 new tests, Tier 2b (shared helper + real `render_pending`; cell-width contract via `rich.cells.cell_len`, plain-text assertion — no private state, no len()-pinning, no mocks, no golden files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
