### PR TITLE
feat(#1953): Task slice 3 PR-2a — role-based op authority + create-unify

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -33,16 +33,15 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `judge_output` | LLM scorer: rubric + threshold + `on_fail` policy | none (LLM cost) |
 | `skill_resolve` | Resolve a skill name to its on-disk path (read-only) | none |
 | `compact` | Voluntarily compact the conversation/phase history (advisory) | none (LLM cost; the mandatory `retry_loop` backstop is independent) |
-| `task.create` | Create a trackable Task (born with its assignee) | none (gated by `allowed_ops`) |
-| `task.update_status` | Declare a status transition (assignee only) | none (single-writer = backend-CAS on caller run_id, not P5) |
-| `task.get` | Read one Task record | none |
-| `task.list` | List Tasks (filter by assignee / requester / status / parent) | none |
-| `task.create_subtask` | Decompose into a child Task assigned to another worker | none |
-| `task.add_dependency` | Add a depends-on edge (dependency DAG) | none |
-| `task.abort` | OS-authority terminal cancel (→ aborted) | none |
-| `task.archive` | Soft-delete a Task (→ archived) | none |
-| `task.heartbeat` | Liveness / unblock-predicate trigger for a blocked Task | none |
-| `task.register_unblock_predicate` | Register a deterministic unblock predicate | none |
+| `task.create` | Create a Task (optional `parent_id` sub-task / `deps`) | requester-gated (caller becomes requester) |
+| `task.update_status` | Declare a status transition | assignee-gated (single-writer CAS on `assignee == caller session_id`) |
+| `task.get` | Read one Task record | requester-gated |
+| `task.list` | List Tasks (filter by assignee / requester / status / parent) | none (filtered read) |
+| `task.add_dependency` | Add a depends-on edge (dependency DAG) | requester-gated |
+| `task.abort` | Remove-op: cancel → terminal (→ delete, full cascade in 2b) | requester-gated |
+| `task.archive` | Soft-delete a Task (→ archived; folds into abort in 2b) | requester-gated |
+| `task.heartbeat` | Liveness / unblock-predicate trigger for a blocked Task | assignee-gated |
+| `task.register_unblock_predicate` | Register a deterministic unblock predicate | assignee-gated |
 | `task.comment` | Append a comment to a Task's thread | none |
 
 ## Common envelope
@@ -483,30 +482,39 @@ These ops are **term-neutral (P7)**: names + fields are generic; A2A vocabulary
 kinds); like any op, each is also subject to the per-session contextual gate.
 
 ```json
-{ "kind": "task.create", "name": "ship-feature", "assignee": "bob",
-  "requester": "alice", "origin": "self" }
+{ "kind": "task.create", "name": "ship-feature" }
+{ "kind": "task.create", "name": "sub", "parent_id": "<id>", "deps": ["<other-id>"] }
 { "kind": "task.update_status", "task_id": "<id>", "status": "in_progress" }
-{ "kind": "task.create_subtask", "parent_id": "<id>", "name": "sub", "assignee": "carol" }
 { "kind": "task.add_dependency", "task_id": "<id>", "depends_on": "<other-id>" }
-{ "kind": "task.archive", "task_id": "<id>" }
+{ "kind": "task.abort", "task_id": "<id>" }
 ```
 
-**Roles & invariants.** `assignee` is the **single-writer** of `status` and is
-**immutable** for the Task's life — there is no handoff; delegation is
-`task.create_subtask` (decomposition). `requester` is the disposition
-notify-target. `origin` (`self` | `external`) decides delete-coupling.
+**Roles.** A Task is owned by two session identities (the #1814 per-contextId
+routing-key): the **requester** (origin / assigner / disposition notify-target —
+the caller of `task.create`, set by the OS, not an op field) and the **assignee**
+(the worker session, the single-writer of `status`, **immutable** — no handoff;
+delegation is sub-task decomposition via `task.create` with `parent_id`).
+`assignee` defaults to the caller (a self-task); a different value delegates
+cross-session (requester=A → assignee=B). One session can be the assignee of many
+Tasks (1 : N).
 
-**Single-writer enforcement** is a **backend compare-and-swap on the caller's
-skill-run `run_id`** (threaded by the OS from the op context — *not* an op
-field, so it cannot be forged), **not** a permission gate: the permission system
-is resource-scoped and carries no caller identity at op-exec time. The CAS
-reject, the cooperative `abort` contract (`cancel_inflight → await_quiescent →
-terminal` + seq-fence), the deletion cascade (DOWN-abort children / UP-notify
-requester), dependency cycle-checking, and unblock-predicate evaluation land in
-later slices; slice 1 ships the op shapes + an in-memory backend.
+**Single-writer** is a backend **fixed-equality CAS** `assignee == caller
+session_id` (`OpContext.session_id`, threaded by the OS — not an op field, so it
+cannot be forged). The assignee is immutable, so no claim token / version is
+needed; a non-assignee write is rejected. This is **not** a permission gate (the
+permission system is resource-scoped, no caller identity at op-exec).
+
+**Role-based op authority (P5).** Each op is gated on the caller's `session_id`:
+*assignee-gated* — `update_status` / `heartbeat` / `register_unblock_predicate`;
+*requester-gated* — `create` / `add_dependency` / `get` / `abort`. A violation
+returns a `role_denied` result.
 
 **States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
 `failed` / `aborted` / `archived`.
+
+Still landing in later slices: `abort = delete` unification (cancel 3-step →
+archive → DOWN-cascade + UP-notify, folding `task.archive` into `task.abort`),
+dependency cycle-check + readiness, unblock-predicate evaluation.
 
 ---
 

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -59,7 +59,6 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "task.update_status": frozenset(),
     "task.get": frozenset(),
     "task.list": frozenset(),
-    "task.create_subtask": frozenset(),
     "task.add_dependency": frozenset(),
     "task.abort": frozenset(),
     "task.archive": frozenset(),

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -68,7 +68,6 @@ from reyn.schemas.models import (
     TaskArchiveIROp,
     TaskCommentIROp,
     TaskCreateIROp,
-    TaskCreateSubtaskIROp,
     TaskGetIROp,
     TaskHeartbeatIROp,
     TaskListIROp,
@@ -158,7 +157,6 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "task.update_status": TaskUpdateStatusIROp,
     "task.get": TaskGetIROp,
     "task.list": TaskListIROp,
-    "task.create_subtask": TaskCreateSubtaskIROp,
     "task.add_dependency": TaskAddDependencyIROp,
     "task.abort": TaskAbortIROp,
     "task.archive": TaskArchiveIROp,
@@ -230,7 +228,6 @@ OP_PURITY: dict[str, OpPurity] = {
     "task.list": OpPurity.world,
     "task.create": OpPurity.side_effect,
     "task.update_status": OpPurity.side_effect,
-    "task.create_subtask": OpPurity.side_effect,
     "task.add_dependency": OpPurity.side_effect,
     "task.abort": OpPurity.side_effect,
     "task.archive": OpPurity.side_effect,
@@ -289,7 +286,6 @@ COARSE_TO_FINE: dict[str, frozenset[str]] = {
     # declare allowed_ops: [task] to permit the whole Task op family.
     "task": frozenset({
         "task.create", "task.update_status", "task.get", "task.list",
-        "task.create_subtask", "task.add_dependency", "task.abort",
         "task.archive", "task.heartbeat", "task.register_unblock_predicate",
         "task.comment",
     }),

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -56,33 +56,83 @@ def _not_found(kind: str, task_id: str) -> dict:
 
 
 def _actor(ctx: OpContext) -> str | None:
-    """The acting agent identity (audit provenance — created_by / comment author).
-    NOT the single-writer token (that is the run_id, threaded separately)."""
+    """The acting agent identity (audit provenance — created_by / comment author)."""
     return getattr(ctx, "agent_id", None)
 
 
+def _caller_session(ctx: OpContext) -> str | None:
+    """The caller's session identity (OpContext.session_id, the #1814 routing-key)
+    — the key for role-based op authority (assignee / requester gating)."""
+    return getattr(ctx, "session_id", None)
+
+
+def _role_denied(op_kind: str, task_id: str, role: str, caller: str | None) -> dict:
+    """Decision-enabling denied result for a role-gated op (P5)."""
+    return {
+        "kind": op_kind,
+        "status": "denied",
+        "error": {
+            "kind": "role_denied",
+            "message": (
+                f"op {op_kind!r} on task {task_id!r} requires the task's {role} "
+                f"session; caller {caller!r} is not the {role}."
+            ),
+        },
+    }
+
+
+async def _authorize(op_kind: str, ctx: OpContext, backend, task_id: str, role: str):
+    """Fetch the task + enforce role-based authority (P5): the caller's session_id
+    must equal the task's ``role`` (``assignee`` or ``requester``). Both roles are
+    immutable (set at create), so the read-then-check is race-free.
+
+    Returns ``(task, None)`` when authorized, else ``(None, <result-dict>)`` (a
+    not-found or a role-denied result for the handler to return verbatim)."""
+    task = await backend.get(task_id)
+    if task is None:
+        return None, _not_found(op_kind, task_id)
+    caller = _caller_session(ctx)
+    if caller != getattr(task, role):
+        return None, _role_denied(op_kind, task_id, role, caller)
+    return task, None
+
+
 async def _create(op, ctx: OpContext, caller) -> dict:
+    # requester = the caller's session (the origin / assigner, §model "requester=self").
+    # cross-session delegation supplies a different ``assignee``; a self-task defaults
+    # the assignee to the caller. parent_id (optional, absorbs the old create_subtask)
+    # must reference a task the CALLER owns as requester (tree decomposition, §12).
+    requester = _caller_session(ctx)
+    parent_id = getattr(op, "parent_id", None)
+    if parent_id:
+        parent = await _backend(ctx).get(parent_id)
+        if parent is None:
+            return _not_found("task.create", parent_id)
+        if parent.requester != requester:
+            return _role_denied("task.create", parent_id, "requester", requester)
     task = Task(
         task_id=uuid.uuid4().hex,
         name=op.name,
-        assignee=op.assignee,
-        requester=op.requester,
-        origin=TaskOrigin(op.origin),
+        assignee=(getattr(op, "assignee", None) or requester),
+        requester=requester,
+        origin=TaskOrigin(getattr(op, "origin", "self") or "self"),
         description=op.description,
-        budget_cap=op.budget_cap,
+        budget_cap=getattr(op, "budget_cap", None),
+        parent_id=parent_id,
         created_by=_actor(ctx),
         deps=list(op.deps),
     )
     created = await _backend(ctx).create(task)
-    _audit(ctx, "task.create", created.task_id, status=created.status.value)
+    _audit(ctx, "task.create", created.task_id, status=created.status.value,
+           assignee=created.assignee, parent_id=parent_id)
     return _ok("task.create", task=created.to_dict())
 
 
 async def _update_status(op, ctx: OpContext, caller) -> dict:
-    # Single-writer key = the caller's session identity (OpContext.session_id, the
-    # #1814 routing-key). The backend CAS-rejects when it != the immutable assignee.
+    # assignee-gated single-writer: the backend CAS-rejects when ctx.session_id
+    # != the immutable assignee (#1814 routing-key). Atomic, so no separate check.
     task = await _backend(ctx).update_status(
-        op.task_id, op.status, caller_session_id=getattr(ctx, "session_id", None)
+        op.task_id, op.status, caller_session_id=_caller_session(ctx)
     )
     if task is None:
         return _not_found("task.update_status", op.task_id)
@@ -91,9 +141,10 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
 
 
 async def _get(op, ctx: OpContext, caller) -> dict:
-    task = await _backend(ctx).get(op.task_id)
-    if task is None:
-        return _not_found("task.get", op.task_id)
+    # requester-gated: the requester polls its task's status (§model requester-IF).
+    task, denied = await _authorize("task.get", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
     return _ok("task.get", task=task.to_dict())
 
 
@@ -107,61 +158,52 @@ async def _list(op, ctx: OpContext, caller) -> dict:
     return _ok("task.list", tasks=[t.to_dict() for t in tasks])
 
 
-async def _create_subtask(op, ctx: OpContext, caller) -> dict:
-    parent = await _backend(ctx).get(op.parent_id)
-    if parent is None:
-        return _not_found("task.create_subtask", op.parent_id)
-    child = Task(
-        task_id=uuid.uuid4().hex,
-        name=op.name,
-        assignee=op.assignee,
-        requester=op.parent_id,  # parent is the child's requester (§16)
-        origin=parent.origin,    # lineage inherits origin
-        description=op.description,
-        parent_id=op.parent_id,
-        created_by=_actor(ctx),
-        deps=list(op.deps),
-    )
-    created = await _backend(ctx).create(child)
-    _audit(ctx, "task.create_subtask", created.task_id, parent_id=op.parent_id)
-    return _ok("task.create_subtask", task=created.to_dict())
-
-
 async def _add_dependency(op, ctx: OpContext, caller) -> dict:
+    # requester-gated: the decomposing requester owns the dependency topology (§13).
+    _task, denied = await _authorize(
+        "task.add_dependency", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
     task = await _backend(ctx).add_dependency(op.task_id, op.depends_on)
-    if task is None:
-        return _not_found("task.add_dependency", op.task_id)
     return _ok("task.add_dependency", task=task.to_dict())
 
 
 async def _abort(op, ctx: OpContext, caller) -> dict:
+    # requester-gated remove-op (§model abort=delete; full cancel/cascade in 2b).
+    _task, denied = await _authorize("task.abort", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
     task = await _backend(ctx).abort(op.task_id, reason=op.reason)
-    if task is None:
-        return _not_found("task.abort", op.task_id)
     _audit(ctx, "task.abort", op.task_id, status=task.status.value)
     return _ok("task.abort", task=task.to_dict())
 
 
 async def _archive(op, ctx: OpContext, caller) -> dict:
+    # requester-gated (transient — folded into abort in 2b).
+    _task, denied = await _authorize("task.archive", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
     task = await _backend(ctx).archive(op.task_id)
-    if task is None:
-        return _not_found("task.archive", op.task_id)
     _audit(ctx, "task.archive", op.task_id, status=task.status.value)
     return _ok("task.archive", task=task.to_dict())
 
 
 async def _heartbeat(op, ctx: OpContext, caller) -> dict:
-    task = await _backend(ctx).get(op.task_id)
-    if task is None:
-        return _not_found("task.heartbeat", op.task_id)
-    # slice 7 adds predicate-eval + liveness-timeout; slice 1 reports state.
+    # assignee-gated: only the worker session heartbeats its own task.
+    task, denied = await _authorize("task.heartbeat", ctx, _backend(ctx), op.task_id, "assignee")
+    if denied is not None:
+        return denied
+    # slice 7 adds predicate-eval + liveness-timeout; here it reports state.
     return _ok("task.heartbeat", task_id=op.task_id, state=task.status.value, unblocked=False)
 
 
 async def _register_unblock_predicate(op, ctx: OpContext, caller) -> dict:
-    task = await _backend(ctx).set_unblock_predicate(op.task_id, op.predicate)
-    if task is None:
-        return _not_found("task.register_unblock_predicate", op.task_id)
+    # assignee-gated: the worker registers its own unblock predicate.
+    _task, denied = await _authorize(
+        "task.register_unblock_predicate", ctx, _backend(ctx), op.task_id, "assignee")
+    if denied is not None:
+        return denied
+    await _backend(ctx).set_unblock_predicate(op.task_id, op.predicate)
     return _ok("task.register_unblock_predicate", task_id=op.task_id)
 
 
@@ -176,7 +218,6 @@ register("task.create", _create)
 register("task.update_status", _update_status)
 register("task.get", _get)
 register("task.list", _list)
-register("task.create_subtask", _create_subtask)
 register("task.add_dependency", _add_dependency)
 register("task.abort", _abort)
 register("task.archive", _archive)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -569,20 +569,22 @@ class CompactIROp(BaseModel):
 
 
 class TaskCreateIROp(BaseModel):
-    """Create a Task born with its assignee (immutable; no handoff — §12).
+    """Create a Task. The **requester** is the caller's session (set by the OS,
+    not an op field — §model "requester=self"); the **assignee** is the worker
+    session, immutable for the Task's life (no handoff — §12). ``assignee``
+    defaults to the caller (a self-task); a different value delegates cross-session.
 
-    ``origin`` decides delete-coupling (§17): ``self`` couples to the agent,
-    ``external`` persists with an external requester. ``requester`` is the
-    disposition notify-target (§16)."""
+    Optional ``parent_id`` makes this a sub-task of a task the caller owns as
+    requester (tree decomposition, §12 — absorbs the former ``create_subtask``);
+    ``deps`` are depends-on edges (dependency DAG, §13)."""
 
     kind: Literal["task.create"]
     name: str
-    assignee: str
-    requester: str
-    origin: Literal["self", "external"] = "self"
+    assignee: str | None = None  # default: the caller's own session (self-task)
     description: str | None = None
     budget_cap: float | None = None
     deps: list[str] = Field(default_factory=list)  # depends-on task_ids (DAG, §13)
+    parent_id: str | None = None  # optional tree parent (must be requester-owned)
 
 
 class TaskUpdateStatusIROp(BaseModel):
@@ -611,18 +613,6 @@ class TaskListIROp(BaseModel):
     requester: str | None = None
     status: str | None = None
     parent_id: str | None = None
-
-
-class TaskCreateSubtaskIROp(BaseModel):
-    """Decompose work into a child Task assigned to another worker (§12). The
-    parent is the child's requester; lineage = ``parent_id`` (no handoff-log)."""
-
-    kind: Literal["task.create_subtask"]
-    parent_id: str
-    name: str
-    assignee: str
-    description: str | None = None
-    deps: list[str] = Field(default_factory=list)
 
 
 class TaskAddDependencyIROp(BaseModel):
@@ -701,9 +691,9 @@ ControlIROp = Annotated[
         RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
         IndexQueryIROp, RecallIROp, IndexDropIROp,
         SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
-        # #1953 slice 1: Task ops.
+        # #1953: Task ops.
         TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
-        TaskCreateSubtaskIROp, TaskAddDependencyIROp, TaskAbortIROp,
+        TaskAddDependencyIROp, TaskAbortIROp,
         TaskArchiveIROp, TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
         TaskCommentIROp,
     ],

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -90,7 +90,6 @@ _LEGACY_ONLY_KINDS: frozenset[str] = frozenset({
     "task.update_status",
     "task.get",
     "task.list",
-    "task.create_subtask",
     "task.add_dependency",
     "task.abort",
     "task.archive",

--- a/tests/test_task_backend_threading_1953.py
+++ b/tests/test_task_backend_threading_1953.py
@@ -76,7 +76,7 @@ async def test_handler_uses_threaded_sqlite_backend(tmp_path: Path):
     in-memory fallback."""
     taskmod.reset_backend_for_test()  # ensure the fallback is empty
     backend = SqliteTaskBackend(str(tmp_path / "tasks.db"))
-    ctx = SimpleNamespace(task_backend=backend, run_id="run-1", agent_id="alice", events=None)
+    ctx = SimpleNamespace(task_backend=backend, session_id="sess-1", agent_id="alice", events=None)
 
     created = await taskmod._create(
         SimpleNamespace(name="n", assignee="bob", requester="alice",

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -28,9 +28,10 @@ from reyn.task import InMemoryTaskBackend, Task, TaskState
 _TASK_KINDS = frozenset(k for k in ALL_OP_KINDS if k.startswith("task."))
 
 
-def _ctx(run_id: str = "run-1", agent_id: str = "alice"):
-    """Minimal OpContext stand-in — the task handlers read only run_id + agent_id."""
-    return SimpleNamespace(run_id=run_id, agent_id=agent_id)
+def _ctx(session_id: str = "sess-1", agent_id: str = "alice"):
+    """Minimal OpContext stand-in. session_id is the caller identity (requester on
+    create + the role-gate key); the handlers also read agent_id (audit) + events."""
+    return SimpleNamespace(session_id=session_id, agent_id=agent_id, events=None)
 
 
 @pytest.fixture(autouse=True)
@@ -65,11 +66,10 @@ def test_union_validates_every_task_kind():
     """Tier 1: each task op kind round-trips through the ControlIROp union."""
     adapter = TypeAdapter(ControlIROp)
     samples = {
-        "task.create": {"kind": "task.create", "name": "n", "assignee": "a", "requester": "r"},
+        "task.create": {"kind": "task.create", "name": "n"},
         "task.update_status": {"kind": "task.update_status", "task_id": "t", "status": "in_progress"},
         "task.get": {"kind": "task.get", "task_id": "t"},
         "task.list": {"kind": "task.list"},
-        "task.create_subtask": {"kind": "task.create_subtask", "parent_id": "p", "name": "n", "assignee": "b"},
         "task.add_dependency": {"kind": "task.add_dependency", "task_id": "t", "depends_on": "u"},
         "task.abort": {"kind": "task.abort", "task_id": "t"},
         "task.archive": {"kind": "task.archive", "task_id": "t"},
@@ -181,3 +181,88 @@ async def test_handlers_return_error_for_unknown_task():
     got = await taskmod._get(SimpleNamespace(task_id="nope"), _ctx(), "control_ir")
     assert got["status"] == "error"
     assert "not found" in got["error"]
+
+
+# ── role-based op authority (P5) ────────────────────────────────────────────
+
+
+async def _make_cross_session_task(requester="R", assignee="A"):
+    """Create a task with requester=R (the caller) and assignee=A (cross-session)."""
+    created = await taskmod._create(
+        SimpleNamespace(name="n", assignee=assignee, description=None,
+                        budget_cap=None, deps=[], parent_id=None),
+        SimpleNamespace(session_id=requester, agent_id="x", events=None), "control_ir",
+    )
+    assert created["task"]["requester"] == requester
+    assert created["task"]["assignee"] == assignee
+    return created["task"]["task_id"]
+
+
+@pytest.mark.asyncio
+async def test_requester_gated_ops_reject_non_requester():
+    """Tier 2: get / add_dependency / abort are requester-gated — the assignee
+    (non-requester) is denied (role_denied). RED if the gate is dropped."""
+    task_id = await _make_cross_session_task(requester="R", assignee="A")
+    assignee_ctx = SimpleNamespace(session_id="A", agent_id="a", events=None)
+
+    for handler, op in (
+        (taskmod._get, SimpleNamespace(task_id=task_id)),
+        (taskmod._add_dependency, SimpleNamespace(task_id=task_id, depends_on="u")),
+        (taskmod._abort, SimpleNamespace(task_id=task_id, reason=None)),
+    ):
+        res = await handler(op, assignee_ctx, "control_ir")
+        assert res["status"] == "denied", (handler.__name__, res)
+        assert res["error"]["kind"] == "role_denied"
+
+    # the requester itself is allowed.
+    req_ctx = SimpleNamespace(session_id="R", agent_id="r", events=None)
+    allowed = await taskmod._get(SimpleNamespace(task_id=task_id), req_ctx, "control_ir")
+    assert allowed["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_assignee_gated_ops_reject_non_assignee():
+    """Tier 2: update_status / heartbeat / register_unblock_predicate are
+    assignee-gated — the requester (non-assignee) is denied. RED if the gate drops."""
+    task_id = await _make_cross_session_task(requester="R", assignee="A")
+    req_ctx = SimpleNamespace(session_id="R", agent_id="r", events=None)
+    assignee_ctx = SimpleNamespace(session_id="A", agent_id="a", events=None)
+
+    # update_status: backend CAS raises PermissionError for the non-assignee.
+    with pytest.raises(PermissionError):
+        await taskmod._update_status(
+            SimpleNamespace(task_id=task_id, status="failed", reason=None), req_ctx, "control_ir")
+    # heartbeat / register: handler role-gate → denied for the non-assignee.
+    for handler, op in (
+        (taskmod._heartbeat, SimpleNamespace(task_id=task_id)),
+        (taskmod._register_unblock_predicate, SimpleNamespace(task_id=task_id, predicate="x")),
+    ):
+        res = await handler(op, req_ctx, "control_ir")
+        assert res["status"] == "denied", (handler.__name__, res)
+
+    # the assignee itself is allowed.
+    allowed = await taskmod._heartbeat(SimpleNamespace(task_id=task_id), assignee_ctx, "control_ir")
+    assert allowed["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_create_parent_id_must_be_requester_owned():
+    """Tier 2: create with parent_id validates the parent is owned by the caller
+    as requester (tree decomposition §12) — another session's parent is denied."""
+    parent_id = await _make_cross_session_task(requester="R", assignee="A")
+
+    # a different session cannot make a sub-task under R's parent.
+    other_ctx = SimpleNamespace(session_id="OTHER", agent_id="o", events=None)
+    res = await taskmod._create(
+        SimpleNamespace(name="sub", assignee=None, description=None, budget_cap=None,
+                        deps=[], parent_id=parent_id), other_ctx, "control_ir")
+    assert res["status"] == "denied"
+    assert res["error"]["kind"] == "role_denied"
+
+    # R (the parent's requester) can.
+    req_ctx = SimpleNamespace(session_id="R", agent_id="r", events=None)
+    ok = await taskmod._create(
+        SimpleNamespace(name="sub", assignee=None, description=None, budget_cap=None,
+                        deps=[], parent_id=parent_id), req_ctx, "control_ir")
+    assert ok["status"] == "ok"
+    assert ok["task"]["parent_id"] == parent_id


### PR DESCRIPTION
**[e2e-coder]** — #1953 Task-system, **slice 3 PR-2a (op-model + authority)**. Lead-approved 2a/2b split (abort=delete infra is PR-2b). Per the consolidated #1953 canonical spec.

## What
- **Role-based op authority (P5)** — each op gated on the caller's `session_id` (the #1814 routing-key, threaded in PR-1):
  - *assignee-gated*: `update_status` (the backend single-writer CAS), `heartbeat`, `register_unblock_predicate`.
  - *requester-gated*: `create`, `add_dependency`, `get`, `abort`.
  - A handler-level `_authorize()` helper fetches the task + checks `ctx.session_id == task.<role>`; roles are **immutable** (set at create) so the read-then-check is race-free. A violation returns a `role_denied` result.
- **create-unify** — `requester` = the caller's session (set by the OS, not an op field — "requester=self"); `assignee` defaults to the caller (self-task) or delegates cross-session. Optional `parent_id` makes a sub-task of a **requester-owned** task (validated), **absorbing `task.create_subtask`** (op removed). Optional `deps[]` retained.
- **1:N + cross-session** — a session is the assignee of many tasks; requester=A can delegate to assignee=B.

`control-ir.md` synced (gating column + section rewrite; `create_subtask` row removed; the stale run_id/current_run_id text from slice 1 corrected to the session-key model).

## Test plan
- [x] `tests/test_task_ops_interface_1953.py` (11 tests): **requester-gated ops reject the assignee**, **assignee-gated ops reject the requester**, **create `parent_id` requester-owned validation** — each a role-gate falsification (violation → RED by construction); create-unify (`parent_id`/`deps`); union validates the 10 task kinds (create_subtask gone).
- [x] sqlite + threading task tests still green (19); coverage/gate/purity sweep green (71); broad op/schema/dispatch sweep: 1728 passed.
- [x] ruff + `scripts/test_tier_audit.py --strict` clean. Full rootdir suite verifying.

**PR-2b** (after this merges): `task.abort`+`task.archive` fold + the C1 3-step (`cancel_inflight → await_quiescent → terminal` + seq-fence, Session-access threaded like PR-1's task_backend) + DOWN-cascade (§18) + UP-notify (§16, H4 transitive walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)