### PR TITLE
feat(#1953): Task slice 3 PR-2b-1 — abort=delete (cooperative-terminal) + DOWN-cascade

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -38,8 +38,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `task.get` | Read one Task record | requester-gated |
 | `task.list` | List Tasks (filter by assignee / requester / status / parent) | none (filtered read) |
 | `task.add_dependency` | Add a depends-on edge (dependency DAG) | requester-gated |
-| `task.abort` | Remove-op: cancel → terminal (→ delete, full cascade in 2b) | requester-gated |
-| `task.archive` | Soft-delete a Task (→ archived; folds into abort in 2b) | requester-gated |
+| `task.abort` | Remove-op (= delete): archive the task + sub-tree (cooperative-terminal) | requester-gated |
 | `task.heartbeat` | Liveness / unblock-predicate trigger for a blocked Task | assignee-gated |
 | `task.register_unblock_predicate` | Register a deterministic unblock predicate | assignee-gated |
 | `task.comment` | Append a comment to a Task's thread | none |
@@ -509,12 +508,19 @@ permission system is resource-scoped, no caller identity at op-exec).
 *requester-gated* — `create` / `add_dependency` / `get` / `abort`. A violation
 returns a `role_denied` result.
 
+**`abort` = delete (cooperative-terminal).** `task.abort` is the requester's
+remove-op (it absorbs the former `task.archive`): it archives the task **and its
+whole sub-tree** (DOWN-cascade, §18). There is **no forced cancel** — the
+assignee's in-flight work is rejected by the **terminal-state guard** on
+`update_status` at its next write (so no straggler lands, and a sibling task's
+work is untouched). This is correct under 1:N (a session owns many tasks) and
+needs no cross-session machinery.
+
 **States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
 `failed` / `aborted` / `archived`.
 
-Still landing in later slices: `abort = delete` unification (cancel 3-step →
-archive → DOWN-cascade + UP-notify, folding `task.archive` into `task.abort`),
-dependency cycle-check + readiness, unblock-predicate evaluation.
+Still landing in later slices: `abort` UP-notify to the persistent requester
+(§16), dependency cycle-check + readiness, unblock-predicate evaluation.
 
 ---
 

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -61,7 +61,6 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "task.list": frozenset(),
     "task.add_dependency": frozenset(),
     "task.abort": frozenset(),
-    "task.archive": frozenset(),
     "task.heartbeat": frozenset(),
     "task.register_unblock_predicate": frozenset(),
     "task.comment": frozenset(),

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -65,7 +65,6 @@ from reyn.schemas.models import (
     SkillResolveIROp,
     TaskAbortIROp,
     TaskAddDependencyIROp,
-    TaskArchiveIROp,
     TaskCommentIROp,
     TaskCreateIROp,
     TaskGetIROp,
@@ -159,7 +158,6 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "task.list": TaskListIROp,
     "task.add_dependency": TaskAddDependencyIROp,
     "task.abort": TaskAbortIROp,
-    "task.archive": TaskArchiveIROp,
     "task.heartbeat": TaskHeartbeatIROp,
     "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
     "task.comment": TaskCommentIROp,
@@ -230,7 +228,6 @@ OP_PURITY: dict[str, OpPurity] = {
     "task.update_status": OpPurity.side_effect,
     "task.add_dependency": OpPurity.side_effect,
     "task.abort": OpPurity.side_effect,
-    "task.archive": OpPurity.side_effect,
     "task.heartbeat": OpPurity.side_effect,
     "task.register_unblock_predicate": OpPurity.side_effect,
     "task.comment": OpPurity.side_effect,
@@ -286,8 +283,8 @@ COARSE_TO_FINE: dict[str, frozenset[str]] = {
     # declare allowed_ops: [task] to permit the whole Task op family.
     "task": frozenset({
         "task.create", "task.update_status", "task.get", "task.list",
-        "task.archive", "task.heartbeat", "task.register_unblock_predicate",
-        "task.comment",
+        "task.add_dependency", "task.abort", "task.heartbeat",
+        "task.register_unblock_predicate", "task.comment",
     }),
 }
 

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -1,15 +1,20 @@
 """Task op handlers (#1953) — route ``task.*`` Control IR ops to the Task backend.
 
 The backend is resolved from ``OpContext.task_backend`` (the session-scoped,
-config-selected backend threaded in slice 3a) with an in-memory fallback for
-tests / direct construction. The single-writer claim token is the caller's
-``run_id`` from ``OpContext`` (audit C2) — never an op field, so the LLM cannot
-forge it; the sqlite backend CAS-rejects on a mismatch (slice 2). Each mutating
-handler also emits a generic P6 audit event (``task_op``); the backend's own
-``task_events`` is the source of truth (the WAL closed vocab is not expanded, P7).
+config-selected backend) with an in-memory fallback for tests / direct
+construction. Role-based authority (P5) gates each op on the caller's
+``OpContext.session_id``: *assignee-gated* (``update_status`` / ``heartbeat`` /
+``register_unblock_predicate``) vs *requester-gated* (``create`` /
+``add_dependency`` / ``get`` / ``abort``). The single-writer is a fixed-equality
+CAS ``assignee == caller session_id`` in the backend; ``abort`` is the
+cooperative-terminal remove-op (archives the task + sub-tree; the assignee's
+in-flight work is rejected by the terminal state at its next write — no forced
+cancel). Each mutating handler emits a generic P6 audit event (``task_op``); the
+backend's own ``task_events`` is the source of truth (the WAL closed vocab is not
+expanded, P7).
 
-Still deferred: abort quiescence 3-step (slice 3b), cascade, cycle-check,
-predicate-eval (later slices).
+Still deferred: abort UP-notify (2b-2), cycle-check (slice 6), predicate-eval
+(slice 7).
 """
 from __future__ import annotations
 
@@ -169,23 +174,16 @@ async def _add_dependency(op, ctx: OpContext, caller) -> dict:
 
 
 async def _abort(op, ctx: OpContext, caller) -> dict:
-    # requester-gated remove-op (§model abort=delete; full cancel/cascade in 2b).
+    # requester-gated remove-op (§model abort=delete). Cooperative-terminal
+    # (Option B): the backend archives the task + its sub-tree (DOWN-cascade);
+    # the assignee's in-flight work is rejected by the terminal state at its next
+    # status-write (no forced cancel, no sibling-kill). task.archive is folded in.
     _task, denied = await _authorize("task.abort", ctx, _backend(ctx), op.task_id, "requester")
     if denied is not None:
         return denied
     task = await _backend(ctx).abort(op.task_id, reason=op.reason)
     _audit(ctx, "task.abort", op.task_id, status=task.status.value)
     return _ok("task.abort", task=task.to_dict())
-
-
-async def _archive(op, ctx: OpContext, caller) -> dict:
-    # requester-gated (transient — folded into abort in 2b).
-    _task, denied = await _authorize("task.archive", ctx, _backend(ctx), op.task_id, "requester")
-    if denied is not None:
-        return denied
-    task = await _backend(ctx).archive(op.task_id)
-    _audit(ctx, "task.archive", op.task_id, status=task.status.value)
-    return _ok("task.archive", task=task.to_dict())
 
 
 async def _heartbeat(op, ctx: OpContext, caller) -> dict:
@@ -220,7 +218,6 @@ register("task.get", _get)
 register("task.list", _list)
 register("task.add_dependency", _add_dependency)
 register("task.abort", _abort)
-register("task.archive", _archive)
 register("task.heartbeat", _heartbeat)
 register("task.register_unblock_predicate", _register_unblock_predicate)
 register("task.comment", _comment)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -635,16 +635,6 @@ class TaskAbortIROp(BaseModel):
     reason: str | None = None
 
 
-class TaskArchiveIROp(BaseModel):
-    """Soft-delete (→ archived; the "delete" verb). Triggers the deletion matrix
-    in slice 3: DOWN-abort children + UP-notify persistent requester (§18/19).
-    Archived tasks are time-travel-recoverable within the retention window (§24)."""
-
-    kind: Literal["task.archive"]
-    task_id: str
-    reason: str | None = None
-
-
 class TaskHeartbeatIROp(BaseModel):
     """Liveness + (slice 7) unblock-predicate evaluation trigger for a blocked
     task. Returns the current state; predicate-eval / liveness-timeout land in
@@ -694,7 +684,7 @@ ControlIROp = Annotated[
         # #1953: Task ops.
         TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
         TaskAddDependencyIROp, TaskAbortIROp,
-        TaskArchiveIROp, TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
+        TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
         TaskCommentIROp,
     ],
     Field(discriminator="kind"),

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from reyn.task.model import Task, TaskState, _now_iso
+from reyn.task.model import TERMINAL_STATES, Task, TaskState, _now_iso
 
 
 class TaskBackend(Protocol):
@@ -54,8 +54,6 @@ class TaskBackend(Protocol):
         ...
 
     async def add_dependency(self, task_id: str, depends_on: str) -> Task | None: ...
-
-    async def archive(self, task_id: str) -> Task | None: ...
 
     async def abort(self, task_id: str, reason: str | None = None) -> Task | None: ...
 
@@ -118,6 +116,14 @@ class InMemoryTaskBackend:
                 f"{caller_session_id!r} is not the assignee {task.assignee!r} "
                 f"(single-writer)"
             )
+        # Terminal-guard: a terminal task takes no further transitions — this is
+        # the abort straggler-reject (Option B, #1953): an assignee write after
+        # the requester aborts the task is rejected, so no straggler lands.
+        if task.status in TERMINAL_STATES:
+            raise PermissionError(
+                f"task {task_id!r} status-write rejected: task is terminal "
+                f"({task.status.value}) — no further transitions (e.g. post-abort straggler)"
+            )
         task.status = TaskState(status)
         task.updated_at = _now_iso()
         return task
@@ -132,24 +138,24 @@ class InMemoryTaskBackend:
         task.updated_at = _now_iso()
         return task
 
-    async def archive(self, task_id: str) -> Task | None:
-        task = self._tasks.get(task_id)
-        if task is None:
-            return None
-        task.status = TaskState.ARCHIVED
-        task.updated_at = _now_iso()
-        return task
-
     async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
-        task = self._tasks.get(task_id)
-        if task is None:
+        # abort = delete (cooperative-terminal, Option B): archive this task + its
+        # whole sub-tree (DOWN-cascade, §18). No forced cancel — the assignee's
+        # in-flight work is rejected by the terminal state at its next status-write.
+        if task_id not in self._tasks:
             return None
-        # audit C1: the real abort is cancel_inflight → await_quiescent → terminal
-        # (+ seq-fence), so no in-flight write lands after the terminal transition.
-        # That needs Session access (slice 3); the stub sets the terminal state only.
-        task.status = TaskState.ABORTED
-        task.updated_at = _now_iso()
-        return task
+        subtree: list[str] = [task_id]
+        frontier = [task_id]
+        while frontier:
+            pid = frontier.pop()
+            for tid, t in self._tasks.items():
+                if t.parent_id == pid and tid not in subtree:
+                    subtree.append(tid)
+                    frontier.append(tid)
+        for tid in subtree:
+            self._tasks[tid].status = TaskState.ARCHIVED
+            self._tasks[tid].updated_at = _now_iso()
+        return self._tasks[task_id]
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         task = self._tasks.get(task_id)

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -35,7 +35,12 @@ import json
 import sqlite3
 from pathlib import Path
 
-from reyn.task.model import Task, TaskOrigin, TaskState, _now_iso
+from reyn.task.model import TERMINAL_STATES, Task, TaskOrigin, TaskState, _now_iso
+
+# Terminal status values (no further transitions) — used by the update_status
+# terminal-guard (the abort straggler-reject, #1953 Option B).
+_TERMINAL_VALUES: tuple[str, ...] = tuple(s.value for s in TERMINAL_STATES)
+_TERMINAL_PLACEHOLDERS = ",".join("?" * len(_TERMINAL_VALUES))
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS tasks(
@@ -209,21 +214,27 @@ class SqliteTaskBackend:
     ) -> Task | None:
         async with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
-            # Single-writer CAS: only the assignee session may write (fixed
-            # equality — assignee is immutable). rowcount == 0 → either no such
-            # task or a non-assignee caller; distinguish for the caller.
+            # Single-writer CAS + terminal-guard: only the assignee may write, and
+            # only to a non-terminal task. rowcount == 0 → no such task, a
+            # non-assignee caller, or a terminal task (incl. the abort straggler-
+            # reject — Option B, #1953). Distinguish for a decision-enabling error.
             cur = self._conn.execute(
                 "UPDATE tasks SET status=?, updated_at=? "
-                "WHERE task_id=? AND assignee=?",
-                (status, _now_iso(), task_id, caller_session_id),
+                f"WHERE task_id=? AND assignee=? AND status NOT IN ({_TERMINAL_PLACEHOLDERS})",
+                (status, _now_iso(), task_id, caller_session_id, *_TERMINAL_VALUES),
             )
             if cur.rowcount == 0:
                 self._conn.rollback()
-                exists = self._conn.execute(
-                    "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
+                row = self._conn.execute(
+                    "SELECT assignee, status FROM tasks WHERE task_id=?", (task_id,)
                 ).fetchone()
-                if exists is None:
+                if row is None:
                     return None
+                if row["status"] in _TERMINAL_VALUES:
+                    raise PermissionError(
+                        f"task {task_id!r} status-write rejected: task is terminal "
+                        f"({row['status']}) — no further transitions (e.g. post-abort straggler)"
+                    )
                 raise PermissionError(
                     f"task {task_id!r} status-write rejected: caller "
                     f"{caller_session_id!r} is not the assignee (single-writer)"
@@ -250,25 +261,40 @@ class SqliteTaskBackend:
             self._conn.commit()
             return self._fetch(task_id)
 
-    async def _terminal(self, task_id: str, state: TaskState, kind: str) -> Task | None:
+    async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
+        """abort = delete (cooperative-terminal, #1953 Option B): set this task +
+        its whole sub-tree to ``archived`` (DOWN-cascade, §18). There is no forced
+        cancel — the assignee's in-flight work discovers the abort at its next
+        status-write, which the terminal state rejects (so no straggler lands;
+        and a sibling task's work is untouched). Returns the now-archived task, or
+        None if it doesn't exist."""
         async with self._lock:
-            self._conn.execute("BEGIN IMMEDIATE")
-            cur = self._conn.execute(
-                "UPDATE tasks SET status=?, updated_at=? WHERE task_id=?",
-                (state.value, _now_iso(), task_id),
-            )
-            if cur.rowcount == 0:
-                self._conn.rollback()
+            if self._conn.execute(
+                "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
+            ).fetchone() is None:
                 return None
-            self._emit(task_id, kind, status=state.value)
+            # BFS the sub-tree (this task + all descendants via parent_id;
+            # acyclic by construction, with a guard).
+            subtree: list[str] = [task_id]
+            frontier = [task_id]
+            while frontier:
+                pid = frontier.pop()
+                for row in self._conn.execute(
+                    "SELECT task_id FROM tasks WHERE parent_id=?", (pid,)
+                ).fetchall():
+                    child = row["task_id"]
+                    if child not in subtree:
+                        subtree.append(child)
+                        frontier.append(child)
+            self._conn.execute("BEGIN IMMEDIATE")
+            for tid in subtree:
+                self._conn.execute(
+                    "UPDATE tasks SET status=?, updated_at=? WHERE task_id=?",
+                    (TaskState.ARCHIVED.value, _now_iso(), tid),
+                )
+                self._emit(tid, "aborted", root=task_id)
             self._conn.commit()
             return self._fetch(task_id)
-
-    async def archive(self, task_id: str) -> Task | None:
-        return await self._terminal(task_id, TaskState.ARCHIVED, "archived")
-
-    async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
-        return await self._terminal(task_id, TaskState.ABORTED, "aborted")
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         async with self._lock:

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -92,7 +92,6 @@ _LEGACY_ONLY_KINDS: frozenset[str] = frozenset({
     "task.list",
     "task.add_dependency",
     "task.abort",
-    "task.archive",
     "task.heartbeat",
     "task.register_unblock_predicate",
     "task.comment",

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -72,7 +72,6 @@ def test_union_validates_every_task_kind():
         "task.list": {"kind": "task.list"},
         "task.add_dependency": {"kind": "task.add_dependency", "task_id": "t", "depends_on": "u"},
         "task.abort": {"kind": "task.abort", "task_id": "t"},
-        "task.archive": {"kind": "task.archive", "task_id": "t"},
         "task.heartbeat": {"kind": "task.heartbeat", "task_id": "t"},
         "task.register_unblock_predicate": {"kind": "task.register_unblock_predicate", "task_id": "t", "predicate": "x"},
         "task.comment": {"kind": "task.comment", "task_id": "t", "body": "hi"},
@@ -157,22 +156,27 @@ async def test_update_status_single_writer_is_assignee_session():
 
 
 @pytest.mark.asyncio
-async def test_archive_and_abort_reach_terminal_states():
-    """Tier 2: archive → archived, abort → aborted (terminal contract surface)."""
-    async def _mk(name):
-        c = await taskmod._create(
-            SimpleNamespace(name=name, assignee="b", requester="a",
-                            origin="self", description=None, budget_cap=None, deps=[]),
-            _ctx(), "control_ir",
-        )
-        return c["task"]["task_id"]
+async def test_abort_archives_and_rejects_assignee_straggler():
+    """Tier 2: abort = delete → archived (Option B); a post-abort straggler
+    update_status by the assignee is rejected by the terminal state, so nothing
+    lands (RED if the terminal-guard is dropped)."""
+    created = await taskmod._create(
+        SimpleNamespace(name="t", assignee="A", description=None, budget_cap=None,
+                        deps=[], parent_id=None),
+        SimpleNamespace(session_id="R", agent_id="r", events=None), "control_ir")
+    task_id = created["task"]["task_id"]
 
-    a_id = await _mk("a")
-    b_id = await _mk("b")
-    arch = await taskmod._archive(SimpleNamespace(task_id=a_id, reason=None), _ctx(), "control_ir")
-    abrt = await taskmod._abort(SimpleNamespace(task_id=b_id, reason="cancel"), _ctx(), "control_ir")
-    assert arch["task"]["status"] == "archived"
-    assert abrt["task"]["status"] == "aborted"
+    # requester R aborts (= delete) → archived.
+    aborted = await taskmod._abort(
+        SimpleNamespace(task_id=task_id, reason="don't need it"),
+        SimpleNamespace(session_id="R", agent_id="r", events=None), "control_ir")
+    assert aborted["task"]["status"] == "archived"
+
+    # the assignee's straggler write is rejected by the terminal state.
+    with pytest.raises(PermissionError):
+        await taskmod._update_status(
+            SimpleNamespace(task_id=task_id, status="completed", reason=None),
+            SimpleNamespace(session_id="A", agent_id="a", events=None), "control_ir")
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_sqlite_backend_1953.py
+++ b/tests/test_task_sqlite_backend_1953.py
@@ -104,27 +104,50 @@ async def test_update_status_unknown_task_returns_none(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_awaiting_and_archive_persist_and_emit_events(tmp_path):
-    """Tier 2: set_awaiting + archive persist, and the own task_events projection
-    records each state change (the backend is the source of truth)."""
+async def test_awaiting_and_abort_persist_and_emit_events(tmp_path):
+    """Tier 2: set_awaiting + abort(=archive) persist, and the own task_events
+    projection records each state change (the backend is the source of truth)."""
     path = _db(tmp_path)
     backend = SqliteTaskBackend(path)
     await backend.create(Task(task_id="t", name="n", assignee="b", requester="r",
                               status=TaskState.BLOCKED))
     await backend.set_awaiting("t", 999.0)
-    await backend.archive("t")
+    await backend.abort("t")
     backend.close()
 
     reopened = SqliteTaskBackend(path)
     got = await reopened.get("t")
     assert got is not None
     assert got.awaiting_since == 999.0
-    assert got.status is TaskState.ARCHIVED
+    assert got.status is TaskState.ARCHIVED  # abort = delete → archived
 
     kinds = [e["kind"] for e in await reopened.events("t")]
-    # created + awaiting_set + archived recorded in the backend's own projection.
-    assert kinds == ["created", "awaiting_set", "archived"]
+    assert kinds == ["created", "awaiting_set", "aborted"]
     reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_abort_down_cascade_and_sibling_intact(tmp_path):
+    """Tier 2: aborting a parent archives its whole sub-tree (DOWN-cascade,
+    Option B), while an unrelated sibling task is untouched (proof there is no
+    whole-session cancel)."""
+    backend = SqliteTaskBackend(_db(tmp_path))
+    await backend.create(Task(task_id="p", name="p", assignee="A", requester="R"))
+    await backend.create(Task(task_id="c1", name="c1", assignee="A", requester="R", parent_id="p"))
+    await backend.create(Task(task_id="c2", name="c2", assignee="A", requester="R", parent_id="c1"))
+    # an unrelated task owned by the SAME assignee session A (1:N) — must survive.
+    await backend.create(Task(task_id="sib", name="sib", assignee="A", requester="R"))
+
+    await backend.abort("p")
+
+    # whole sub-tree archived (recursive, leaf-terminal).
+    for tid in ("p", "c1", "c2"):
+        t = await backend.get(tid)
+        assert t is not None and t.status is TaskState.ARCHIVED, tid
+    # RED if abort whole-session-cancelled: the sibling task A also owns is intact.
+    sib = await backend.get("sib")
+    assert sib is not None and sib.status is TaskState.PENDING
+    backend.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #1953 Task-system, **slice 3 PR-2b-1**. `abort` = the requester's remove-op (= delete), folding `task.archive` in. Owner-confirmed **Option B (cooperative-terminal)** — chosen after premise-verify surfaced that Option A (forced per-task cancel) needs a net-new task→async-work linkage and `cancel_inflight` is whole-session (would collateral-kill sibling tasks under 1:N).

## What
- **abort = cooperative-terminal**: archives the task **+ its whole sub-tree** (DOWN-cascade, §18 — BFS over `parent_id`, leaf-terminal). **No forced cancel** — the assignee's in-flight work is rejected by the new **terminal-guard** on `update_status` at its next write, so no straggler lands and a sibling task (1:N — the same assignee owns many tasks) is untouched.
- **terminal-guard**: `update_status` (sqlite `CAS WHERE status NOT IN (terminal)` + in-memory check) rejects a write to a terminal task — the straggler-reject that *is* Option B's "no-straggler-land after abort" guarantee (replaces the cancel→quiescence 3-step; cleaner, no cross-session, no new infra).
- **`task.archive` removed** (op + `backend.archive` + protocol), folded into `task.abort`.

`control-ir.md` synced (archive row removed; abort section rewritten to the cooperative-terminal model).

## Why Option B (premise-verify, in the design thread)
`cancel_inflight()` is whole-session (cancels turn + ALL skills + plans), and there is **no task→spawned-work linkage** (grep=0) — so forced per-task cancel (A) is net-new architectural (owner-audit). B avoids all of it: abort sets terminal; the assignee cooperatively observes it at its next op (rejected by the terminal state), mirroring the completion=declaration model. Its only tradeoff (an already-running tool finishes before the assignee notices) is **identical to `cancel_inflight`'s own documented V1 boundary** — no real loss.

## Test plan
- [x] **Falsification CLEAN RED**: (a) post-abort straggler `update_status` rejected — drop the terminal-guard → straggler lands → RED (verified, reverted); (b) sibling task intact (no whole-session cancel); (c) DOWN-cascade archives the sub-tree.
- [x] task suite (23), broad op/coverage/dispatch sweep: 1533 passed. ruff + `scripts/test_tier_audit.py --strict` clean. Full rootdir suite verifying.

**PR-2b-2** (next): abort **UP-notify** to the persistent requester (§16, H4 transitive walk; webhook external / inbox internal) — the only remaining part, and the only one needing cross-session reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)