### PR TITLE
feat(#1953): Task slice 3 PR-2b-2 — abort UP-notify via task_disposition event

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -514,13 +514,17 @@ whole sub-tree** (DOWN-cascade, §18). There is **no forced cancel** — the
 assignee's in-flight work is rejected by the **terminal-state guard** on
 `update_status` at its next write (so no straggler lands, and a sibling task's
 work is untouched). This is correct under 1:N (a session owns many tasks) and
-needs no cross-session machinery.
+needs no cross-session machinery. **UP-notify** (§16): abort emits a generic P6
+`task_disposition` event per aborted task (carrying `task_id` / `requester` /
+`origin` / `disposition`); the A2A layer routes `origin=external` tasks to their
+external (webhook) channel — internal requesters need no notify (they own the
+tree, and the assignee discovers the abort via the terminal guard).
 
 **States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
 `failed` / `aborted` / `archived`.
 
-Still landing in later slices: `abort` UP-notify to the persistent requester
-(§16), dependency cycle-check + readiness, unblock-predicate evaluation.
+Still landing in later slices: dependency cycle-check + readiness,
+unblock-predicate evaluation.
 
 ---
 

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -181,9 +181,23 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
     _task, denied = await _authorize("task.abort", ctx, _backend(ctx), op.task_id, "requester")
     if denied is not None:
         return denied
-    task = await _backend(ctx).abort(op.task_id, reason=op.reason)
-    _audit(ctx, "task.abort", op.task_id, status=task.status.value)
-    return _ok("task.abort", task=task.to_dict())
+    aborted = await _backend(ctx).abort(op.task_id, reason=op.reason)
+    if not aborted:
+        return _not_found("task.abort", op.task_id)
+    # UP-notify (2b-2): emit a generic, term-neutral P6 disposition event per
+    # aborted task carrying requester + origin. The A2A layer (slice 5) consumes
+    # these and fires the external (webhook) channel for origin=external tasks
+    # (the persistent stakeholders); internal requesters need no notify (they own
+    # the tree + the assignee discovers the abort via the terminal-guard).
+    events = getattr(ctx, "events", None)
+    if events is not None:
+        for t in aborted:
+            events.emit(
+                "task_disposition", task_id=t.task_id, disposition="aborted",
+                requester=t.requester, origin=t.origin.value, root=op.task_id,
+            )
+    root = aborted[0]
+    return _ok("task.abort", task=root.to_dict())
 
 
 async def _heartbeat(op, ctx: OpContext, caller) -> dict:

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -55,7 +55,7 @@ class TaskBackend(Protocol):
 
     async def add_dependency(self, task_id: str, depends_on: str) -> Task | None: ...
 
-    async def abort(self, task_id: str, reason: str | None = None) -> Task | None: ...
+    async def abort(self, task_id: str, reason: str | None = None) -> list[Task]: ...
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None: ...
 
@@ -138,12 +138,14 @@ class InMemoryTaskBackend:
         task.updated_at = _now_iso()
         return task
 
-    async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
+    async def abort(self, task_id: str, reason: str | None = None) -> list[Task]:
         # abort = delete (cooperative-terminal, Option B): archive this task + its
         # whole sub-tree (DOWN-cascade, §18). No forced cancel — the assignee's
         # in-flight work is rejected by the terminal state at its next status-write.
+        # Returns the aborted tasks (root first) so the caller can emit a
+        # disposition event per task (UP-notify, 2b-2); [] if no such task.
         if task_id not in self._tasks:
-            return None
+            return []
         subtree: list[str] = [task_id]
         frontier = [task_id]
         while frontier:
@@ -152,10 +154,12 @@ class InMemoryTaskBackend:
                 if t.parent_id == pid and tid not in subtree:
                     subtree.append(tid)
                     frontier.append(tid)
+        aborted: list[Task] = []
         for tid in subtree:
             self._tasks[tid].status = TaskState.ARCHIVED
             self._tasks[tid].updated_at = _now_iso()
-        return self._tasks[task_id]
+            aborted.append(self._tasks[tid])
+        return aborted
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         task = self._tasks.get(task_id)

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -261,18 +261,19 @@ class SqliteTaskBackend:
             self._conn.commit()
             return self._fetch(task_id)
 
-    async def abort(self, task_id: str, reason: str | None = None) -> Task | None:
+    async def abort(self, task_id: str, reason: str | None = None) -> list[Task]:
         """abort = delete (cooperative-terminal, #1953 Option B): set this task +
         its whole sub-tree to ``archived`` (DOWN-cascade, §18). There is no forced
         cancel — the assignee's in-flight work discovers the abort at its next
-        status-write, which the terminal state rejects (so no straggler lands;
-        and a sibling task's work is untouched). Returns the now-archived task, or
-        None if it doesn't exist."""
+        status-write, which the terminal state rejects (so no straggler lands; and
+        a sibling task's work is untouched). Returns the aborted tasks (root
+        first) so the caller can emit a disposition event per task (UP-notify,
+        2b-2); ``[]`` if no such task."""
         async with self._lock:
             if self._conn.execute(
                 "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
             ).fetchone() is None:
-                return None
+                return []
             # BFS the sub-tree (this task + all descendants via parent_id;
             # acyclic by construction, with a guard).
             subtree: list[str] = [task_id]
@@ -294,7 +295,7 @@ class SqliteTaskBackend:
                 )
                 self._emit(tid, "aborted", root=task_id)
             self._conn.commit()
-            return self._fetch(task_id)
+            return [t for t in (self._fetch(tid) for tid in subtree) if t is not None]
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         async with self._lock:

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -156,6 +156,36 @@ async def test_update_status_single_writer_is_assignee_session():
 
 
 @pytest.mark.asyncio
+async def test_abort_emits_disposition_event_per_aborted_task():
+    """Tier 2: abort (UP-notify, 2b-2) emits a term-neutral `task_disposition`
+    P6 event per aborted task carrying requester + origin — the A2A layer (slice
+    5) routes origin=external to the external (webhook) channel. Falsification (d):
+    each aborted task's event carries the correct requester + origin."""
+    from reyn.core.events.events import EventLog
+    from reyn.task import InMemoryTaskBackend, Task, TaskOrigin
+
+    backend = InMemoryTaskBackend()
+    # external root P (origin=external, persistent external requester X) with an
+    # internal child C — abort P cascades to C; both get a disposition event.
+    await backend.create(Task(task_id="p", name="p", assignee="A", requester="X",
+                              origin=TaskOrigin.EXTERNAL))
+    await backend.create(Task(task_id="c", name="c", assignee="A", requester="Y",
+                              origin=TaskOrigin.SELF, parent_id="p"))
+    events = EventLog()
+    ctx = SimpleNamespace(task_backend=backend, session_id="X", agent_id="x", events=events)
+
+    res = await taskmod._abort(SimpleNamespace(task_id="p", reason=None), ctx, "control_ir")
+    assert res["status"] == "ok"
+
+    disp = {e.data["task_id"]: e.data for e in events.all() if e.type == "task_disposition"}
+    # RED if a cascade-aborted task is missing an event, or origin/requester wrong.
+    assert set(disp) == {"p", "c"}
+    assert disp["p"]["origin"] == "external" and disp["p"]["requester"] == "X"
+    assert disp["c"]["origin"] == "self" and disp["c"]["requester"] == "Y"
+    assert all(d["disposition"] == "aborted" for d in disp.values())
+
+
+@pytest.mark.asyncio
 async def test_abort_archives_and_rejects_assignee_straggler():
     """Tier 2: abort = delete → archived (Option B); a post-abort straggler
     update_status by the assignee is rejected by the terminal state, so nothing


### PR DESCRIPTION
**[e2e-coder]** — #1953 Task-system, **slice 3 PR-2b-2** — the final abort-infra piece (Option B), dramatically lightened by the flow-trace-first seam-map review.

## What
- abort emits a generic, **term-neutral P6 `task_disposition` event** per aborted task in the cascade, carrying `task_id` / `requester` / `origin` / `disposition`. `backend.abort` now returns the aborted sub-tree (`list[Task]`) so the handler emits one event per task.
- The **A2A layer (slice 5) consumes** these and routes `origin=external` tasks to their external (webhook) channel — the **H4 transitive-ancestor walk collapses to a per-task `origin` check** (origin already marks persistence, set by the entry point). Internal requesters need no notify (they own the tree; the assignee discovers the abort via the terminal guard, PR-2b-1).

## Why so light (the flow-trace-first payoff)
The seam-map surfaced that direct UP-notify would need cross-session reach (`registry.get_session` → `_put_inbox`) + an external channel the Task doesn't carry. Lead's review collapsed it: emit a P6 disposition event only; **external→webhook is slice-5's job** (A2A owns external channels, P7-clean), so **no cross-session reach, no inbox push, no Task webhook field**.

## Test plan
- [x] **Falsification (d) CLEAN RED**: each cascade-aborted task's disposition event carries the correct `requester` + `origin` (external root + internal child); breaking the per-task `origin` reds the test (verified, reverted).
- [x] task suite (24), broad op/coverage/dispatch sweep: 1506 passed. ruff + `scripts/test_tier_audit.py --strict` clean. Full rootdir suite verifying.

This **completes the #1953 abort-infra (Option B)** and the corrected-model foundation rework: Task↔session single-writer (PR-1) → role authority + create-unify (PR-2a) → abort=delete cooperative-terminal + cascade (PR-2b-1) → UP-notify (this). Remaining #1953 work (slices 5-9: A2A re-point/`task_disposition` consume, DAG/scheduling, completion-assist, budget, retention) is owner-sequenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)