### PR TITLE
feat(tui): in-flight Enter held-feedback (design-check #1, Option A)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/input_bar.py
+++ b/src/reyn/interfaces/tui/widgets/input_bar.py
@@ -25,6 +25,7 @@ Keybindings (handled here):
 from __future__ import annotations
 
 from collections import deque
+from typing import TYPE_CHECKING
 
 from rich.cells import cell_len
 from textual import events, on
@@ -37,6 +38,9 @@ from textual.widgets import Label, TextArea
 from reyn.interfaces.slash import SlashCommand
 
 from .slash_picker import SlashPicker
+
+if TYPE_CHECKING:
+    from textual.timer import Timer
 
 # Wave-11 C#1 — bounded + persisted input history.
 #
@@ -114,6 +118,9 @@ class InputBar(Widget):
     InputBar.disconnected #hints {
         color: #553333;
     }
+    InputBar.held-flash {
+        border-top: solid #d4a017;  /* advisory amber — momentary held-Enter flash */
+    }
     """
 
     # ── messages ──────────────────────────────────────────────────────────────
@@ -168,6 +175,12 @@ class InputBar(Widget):
         # callers toggle it via ``set_in_flight``: True at submit
         # time, False at stream_end / cancel / slash-return.
         self._in_flight: bool = False
+        # Option A held-Enter feedback: pending restore timer for the
+        # momentary ``.held-flash`` border + ``_HINT_HELD`` footer swap.
+        # Race-safe per feedback_tui_deferred_timer_stale_removal_class —
+        # cancelled before re-arm and on any in-flight transition so a
+        # turn-end mid-flash never restores a stale hint.
+        self._held_timer: "Timer | None" = None
         # Wave-13 T1-3: disconnected state for ``--connect`` WS mode.
         # When the WS connection drops, the session is unrecoverable
         # without a TUI restart. InputBar is locked permanently (= no
@@ -299,6 +312,11 @@ class InputBar(Widget):
         if self._in_flight == in_flight:
             return
         self._in_flight = in_flight
+        # Any held-flash in progress is now stale: the turn boundary changed,
+        # and the #hints rebuild below restores the correct footer. Cancel the
+        # pending restore + drop the flash class so a late timer can't repaint
+        # a stale hint (feedback_tui_deferred_timer_stale_removal_class).
+        self._cancel_held_flash()
         if in_flight:
             self.add_class("in-flight")
         else:
@@ -346,6 +364,65 @@ class InputBar(Widget):
         per the project testing policy: feedback_test_public_surface_not_private_state).
         """
         return self._in_flight
+
+    # ── Option A: held-Enter feedback ─────────────────────────────────────────
+
+    def _flash_held(self) -> None:
+        """Acknowledge an Enter pressed during an in-flight turn (Option A).
+
+        Adds a momentary amber border (``.held-flash``) and swaps the footer
+        to ``_HINT_HELD`` so the keypress is visibly *received* instead of
+        silently swallowed. The typed text is left untouched for manual
+        resubmit once the turn ends — pure feedback, NOT a queue/auto-send.
+
+        Re-arm semantics: a rapid second Enter cancels the pending restore
+        and restarts, so back-to-back presses extend the flash rather than
+        letting an earlier timer clear it mid-press
+        (feedback_tui_deferred_timer_stale_removal_class).
+        """
+        if self._held_timer is not None:
+            self._held_timer.stop()
+            self._held_timer = None
+        self.add_class("held-flash")
+        try:
+            self.query_one("#hints", Label).update(self._HINT_HELD)
+        except Exception:
+            pass
+        self._held_timer = self.set_timer(
+            self._HELD_FLASH_S, self._restore_after_held
+        )
+
+    def _restore_after_held(self) -> None:
+        """Timer callback: drop the flash + repaint the footer for the CURRENT
+        state.
+
+        Reads ``_in_flight`` live via ``_build_hint`` (not a value captured at
+        flash time) so a turn that ended during the flash restores the normal
+        hint, while a still-running turn restores the in-flight hint — the
+        stale-restore guard from
+        feedback_tui_deferred_timer_stale_removal_class.
+        """
+        self._held_timer = None
+        self.remove_class("held-flash")
+        try:
+            w = self.size.width
+        except Exception:
+            w = 0
+        try:
+            self.query_one("#hints", Label).update(self._build_hint(w))
+        except Exception:
+            pass
+
+    def _cancel_held_flash(self) -> None:
+        """Cancel a pending held-flash + drop the class without repainting.
+
+        For callers that rebuild ``#hints`` themselves (``set_in_flight``).
+        Idempotent — safe when no flash is in progress.
+        """
+        if self._held_timer is not None:
+            self._held_timer.stop()
+            self._held_timer = None
+        self.remove_class("held-flash")
 
     @property
     def disconnected(self) -> bool:
@@ -842,7 +919,13 @@ class InputBar(Widget):
         # quickly while an LLM call is in progress dispatches the same
         # prompt twice → doubled spend + duplicated reply in the conv
         # pane.
+        #
+        # Option A active feedback: rather than swallow silently, flash the
+        # border + momentarily swap the footer to _HINT_HELD so the user sees
+        # the Enter was received but held (text retained for manual resubmit;
+        # NOT queued — that is Option B).
         if self._in_flight:
+            self._flash_held()
             return
         if not self._history or self._history[-1] != text:
             self._history.append(text)
@@ -931,6 +1014,19 @@ class InputBar(Widget):
     # explicit blocked-state message so the user understands why pressing
     # Enter does nothing.
     _HINT_IN_FLIGHT = "  ⟳ responding — Ctrl+C to cancel"
+    # Option A active feedback: momentarily swapped in (with a border flash)
+    # when Enter is pressed during an in-flight turn, so the keypress is
+    # acknowledged instead of silently swallowed. "held" = received-but-not-
+    # sent; the typed text stays for MANUAL resubmit — it is NOT queued /
+    # auto-sent (that is Option B, deferred per owner product judgment), so
+    # the wording deliberately avoids promising a later send. No emoji /
+    # 23Fx glyph (e.g. ⏳) — those fall outside the TUI's monospace symbol
+    # set (│ ⟳ · —) and risk double-width / fallback boxes; the amber border
+    # flash is the visual punch, the text the explanation.
+    _HINT_HELD = "  Enter held — Ctrl+C to cancel"
+    # How long the held-flash border + hint swap stays before restoring the
+    # current footer (re-armed on each rapid Enter; see _flash_held).
+    _HELD_FLASH_S = 1.0
 
     # Cell width below which _HINT_MID is used instead of _HINT_FULL.
     _HINT_FULL_MIN_WIDTH = 55

--- a/tests/cli/test_input_bar_inflight_hint.py
+++ b/tests/cli/test_input_bar_inflight_hint.py
@@ -144,3 +144,147 @@ async def test_set_in_flight_idempotent_does_not_corrupt_hint() -> None:
         assert "responding" in text, (
             f"redundant set_in_flight(True) corrupted hint; got: {text!r}"
         )
+
+
+# ── Option A: held-Enter feedback (border flash + transient hint) ─────────────
+
+
+async def _wait_until(pilot, predicate, *, timeout: float = 2.0) -> bool:
+    """Poll the event loop until ``predicate()`` is true or timeout elapses.
+
+    Held-flash clears via a real Textual ``set_timer`` (wall-clock), so a
+    fixed ``pilot.pause(N)`` would be flaky. Poll instead
+    (feedback_event_loop_dependent_test_polling).
+    """
+    import asyncio
+    waited = 0.0
+    step = 0.05
+    while waited < timeout:
+        if predicate():
+            return True
+        await pilot.pause(step)
+        await asyncio.sleep(0)
+        waited += step
+    return predicate()
+
+
+def _load_and_submit_while_inflight(app):
+    """Type text, lock in-flight, then drive the real Enter→_submit path.
+
+    Returns (bar, ta) for assertions. ``_submit`` is the handler the Enter
+    keypress routes through; calling it directly keeps the test deterministic
+    while still exercising the production code path.
+    """
+    from textual.widgets import TextArea
+
+    from reyn.interfaces.tui.widgets import InputBar
+
+    bar = app.query_one("#inputbar", InputBar)
+    ta = app.query_one("#input", TextArea)
+    ta.load_text("draft kept while busy")
+    bar.set_in_flight(True)
+    bar._submit(ta)
+    return bar, ta
+
+
+@pytest.mark.asyncio
+async def test_held_enter_flashes_and_keeps_text() -> None:
+    """Tier 2: Enter while in-flight flashes the border + swaps hint to held — and
+    does NOT submit (text retained).
+
+    Option A = pure feedback: the keypress is acknowledged (``.held-flash``
+    class + ``_HINT_HELD`` footer) but the typed text stays in the TextArea
+    for manual resubmit (= NOT cleared, NOT posted). Regression-guards the
+    Wave-9 D-F11 double-submit protection at the same time.
+    """
+    from textual.widgets import Label
+
+    from reyn.interfaces.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar, ta = _load_and_submit_while_inflight(app)
+        await pilot.pause()
+        label = app.query_one("#hints", Label)
+
+        # Active feedback present.
+        assert bar.has_class("held-flash"), "held-flash border class not applied"
+        held_text = _label_text(label)
+        assert "held" in held_text.lower(), (
+            f"footer should acknowledge the held Enter; got: {held_text!r}"
+        )
+        # Pure feedback: text retained (not submitted/cleared).
+        assert ta.text == "draft kept while busy", (
+            f"typed text must survive an in-flight Enter; got: {ta.text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_held_flash_clears_to_inflight_hint_when_still_busy() -> None:
+    """Tier 2: after the flash timer the border clears and the footer restores
+    to the in-flight hint (turn still running).
+    """
+    from textual.widgets import Label
+
+    from reyn.interfaces.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar, _ta = _load_and_submit_while_inflight(app)
+        await pilot.pause()
+        assert bar.has_class("held-flash")
+
+        cleared = await _wait_until(pilot, lambda: not bar.has_class("held-flash"))
+        assert cleared, "held-flash never cleared after the flash timer"
+
+        # Still in-flight → footer restores to the in-flight hint, not held.
+        label = app.query_one("#hints", Label)
+        restored = _label_text(label)
+        assert "responding" in restored, (
+            f"after flash, in-flight footer should return; got: {restored!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_held_flash_turn_end_midflash_restores_normal_no_stale() -> None:
+    """Tier 2: a turn that ENDS during the held-flash restores the NORMAL hint
+    (falsification — no stale held/in-flight text repainted).
+
+    This is the stale-deferred-write guard
+    (feedback_tui_deferred_timer_stale_removal_class): the restore must read
+    the live in-flight state, and the in-flight transition must cancel the
+    pending flash so a late timer can't repaint a stale footer.
+    """
+    from textual.widgets import Label
+
+    from reyn.interfaces.tui.app import ReynTUIApp
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        bar, _ta = _load_and_submit_while_inflight(app)
+        await pilot.pause()
+        assert bar.has_class("held-flash")
+
+        # Turn ends BEFORE the flash timer would fire.
+        bar.set_in_flight(False)
+        await pilot.pause()
+
+        # Flash class dropped immediately; footer is the normal hint.
+        assert not bar.has_class("held-flash"), (
+            "in-flight transition must drop the held-flash class"
+        )
+        label = app.query_one("#hints", Label)
+        text = _label_text(label)
+        assert "Enter send" in text, f"normal hint should be restored; got: {text!r}"
+        assert "held" not in text.lower(), f"stale held text leaked; got: {text!r}"
+        assert "responding" not in text, f"stale in-flight text leaked; got: {text!r}"
+
+        # And a late timer fire (if any) must not repaint stale text.
+        await _wait_until(pilot, lambda: False, timeout=1.2)
+        late = _label_text(label)
+        assert "Enter send" in late and "held" not in late.lower(), (
+            f"late flash timer repainted a stale footer; got: {late!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — design-check ① (in-flight Enter), **Option A** per lead-coder GO.

## What

When Enter is pressed during an in-flight turn, `_submit` returned early **silently**. The typed text stayed in the box (good — the Wave-9 D-F11 double-submit guard), but there was no *active* acknowledgment at the moment of the keypress — only the passive, persistent in-flight footer hint (`⟳ responding — Ctrl+C to cancel`). A user pressing Enter couldn't tell if it registered or the UI was stuck.

This adds active feedback at the keypress:
- a momentary **amber border flash** (`.held-flash`, `#d4a017`), and
- a footer swap to `_HINT_HELD` = **`Enter held — Ctrl+C to cancel`**.

The flash auto-restores after `_HELD_FLASH_S` (1.0s) to whatever the footer should currently show.

## Scope (Option A = pure feedback)

The typed text is **retained for manual resubmit** — it is **NOT queued / auto-sent**. That (type-ahead / message queue) is **Option B**, deferred per owner product judgment. Nothing about message ordering changes; this is purely additive feedback.

## Hint-text note for reviewer

The GO suggested the hint text 「⏳ held — ターン終了後送信」. I deliberately did **not** use "send after turn" wording: that promises auto-send (= Option B behavior), which would mislead under Option A (the message is *not* sent automatically). The accurate text is `Enter held — Ctrl+C to cancel`. I also dropped the leading emoji `⏳` (U+23F3): it's outside the TUI's monospace symbol set (`│ ⟳ · —`) and risks double-width / fallback boxes (same class as the `⏺`/`⏪` glyph issues from the README screenshots) — the amber border flash is the visual punch instead.

## Race-safety

The restore timer is the [stale-deferred-write class](feedback_tui_deferred_timer_stale_removal_class):
- **cancel-before-rearm** — a rapid second Enter extends the flash rather than letting an earlier timer clear it mid-press;
- **cancelled on any in-flight transition** — a turn that ends mid-flash drops the class immediately, and `set_in_flight`'s own `#hints` rebuild restores the correct footer;
- the restore reads **live** `_in_flight` via `_build_hint` (not a value captured at flash time), so it never repaints a stale held/in-flight hint.

## Test plan

- [x] Unit — `tests/cli/test_input_bar_inflight_hint.py` **6/6** (3 existing + 3 new held tests: flash+text-retention, timer-clear-to-inflight, **turn-end-midflash stale-guard** = falsification).
- [x] Regression — `test_tui_smoke.py` **40/40**; full `input_bar` suite **31/31**.
- [x] Lint / Tier — `ruff` clean; `test_tier_audit.py` **0 errors** (all 6 Tier-2, public-surface only).
- [x] Render (deterministic) — pilot `save_screenshot` of the held state: amber border flash + `Enter held — Ctrl+C to cancel`, input text retained, no box/overflow.
- [x] (skipped — env) tmux **live** freeze-frame of the flash: the foreground in-flight window with the weak demo model is too brief to capture (it dispatches to background async). Verified instead via the deterministic pilot screenshot (same Textual render pipeline) + a tmux run confirming normal operation (boots, processes turns, no layout break).

## Tier self-check

3 new tests, all **Tier 2** (OS/widget invariant). Assert only on public surface — `has_class("held-flash")`, the live `#hints` Label text, and `TextArea.text` — no private-state asserts, no format/whitespace pinning. The stale-guard test is a falsification of the deferred-write race. Event-loop-dependent waits use a polling helper, not a fixed `pause` (per `feedback_event_loop_dependent_test_polling`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
