### PR TITLE
docs(readme): add breadth (actor) architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ flowchart TB
 - **Governance** — *Permission* gates every action; cost caps and the sandbox bound it.
 - **State of record** — the *Workspace* holds data, the *WAL* drives crash recovery, the *AuditEvent log* drives replay and audit. These are separate logs on purpose.
 
+The diagram above is the **depth** view — one agent's execution. The **breadth** view shows how agents are *reached* and how they *relate*: every trigger converges on an agent's inbox, and the fleet delegates under a topology.
+
+```mermaid
+flowchart LR
+    subgraph L1["External connection — outside calls in"]
+      direction TB
+      MCP["MCP server<br/>AI clients"]
+      A2A["A2A server<br/>peer agents"]
+      GW["Gateway<br/>Slack / LINE webhooks"]
+    end
+    subgraph L2["Internal trigger — Reyn raises a turn"]
+      direction TB
+      CRON["cron<br/>scheduled jobs"]
+    end
+    INBOX(["agent inbox<br/>send_to_agent"])
+    L1 --> INBOX
+    L2 --> INBOX
+    subgraph FLEET["Agent fleet"]
+      direction TB
+      REG[("AgentRegistry<br/>multi-agent")]
+      Ax["Agent A<br/>identity · agent_id"]
+      Ay["Agent B"]
+      Ax --- SAx["Sessions<br/>multi-session"]
+      REG --> Ax
+      REG --> Ay
+    end
+    INBOX --> FLEET
+    Ax <-. "delegate_to_agent · topology-gated<br/>network / team / pipeline · chain_id" .-> Ay
+```
+
+- **Reached** — three trigger layers converge on the agent inbox: *external connection* (MCP server · A2A server · gateway webhooks like Slack / LINE), *internal trigger* (`cron`), and *in-turn intervention* (lifecycle hooks — proposed). See [interaction layers](docs/concepts/architecture/interaction-layers.md).
+- **Related** — an `AgentRegistry` holds many *Agents* (each an identity), each with many parallel *Sessions*; agents delegate to peers under a *topology* (network / team / pipeline), hop-capped and `chain_id`-traced. See [multi-agent](docs/concepts/multi-agent/multi-agent.md) · [sessions](docs/concepts/multi-agent/sessions.md).
+
 Details: [architecture](docs/concepts/architecture/architecture.md) · [principles](docs/concepts/architecture/principles.md).
 
 ---


### PR DESCRIPTION
**[docs-maintainer]** — follow-up to #1968 (owner-requested). Adds a second architecture diagram to the README: the **breadth / actor** view, complementing the existing **depth** (one-agent execution) diagram.

## What

The Architecture section now shows both axes:
- **Depth** (existing) — one agent's execution: User → Agent → Session → OS → Workspace/WAL/AuditEvent.
- **Breadth** (new) — how agents are *reached* and how they *relate*, grounded in [`concepts/architecture/interaction-layers.md`](docs/concepts/architecture/interaction-layers.md):
  - **Reached**: three trigger layers converge on the agent inbox — *external connection* (MCP server · A2A server · **gateway webhooks**, e.g. Slack/LINE), *internal trigger* (`cron`), and *in-turn lifecycle hooks* (marked **proposed**, not overstated).
  - **Related**: `AgentRegistry` → many *Agents* (multi-agent) → many *Sessions* (multi-session); peers delegate under a *topology* (network / team / pipeline), hop-capped + `chain_id`-traced.

## Accuracy note

Corrects an earlier mischaracterization (caught by owner): **gateway webhooks (Slack/LINE) are an INBOUND trigger** (layer 1), distinct from the *outbound* A2A async-task webhook push (`params.webhook_url`). Verified against `src/reyn/gateway/sample_{slack,line}/webhook.py` + `runtime/webhook_routing.py` + the interaction-layers concept doc. The diagram mirrors that doc, so it stays drift-free.

## Test plan

- [x] mermaid render verified locally via `mmdc` (the breadth block renders cleanly — layers → inbox → fleet → topology delegation; no special-char breakage)
- [x] All new relative links resolve (interaction-layers / multi-agent / sessions)
- [x] No inline history refs; proposed-vs-implemented marked honestly
- [x] README is repo-root (GitHub-rendered), not in the mkdocs build — mermaid renders natively, strict-docs gate N/A
- [ ] (reviewer) glance at the GitHub-rendered branch to confirm the breadth mermaid renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)