### PR TITLE
fix(tui): skill-row widget id collision on same-day skills (DuplicateIds)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
+++ b/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
@@ -12,6 +12,7 @@ Dependencies injected via parent reference:
 """
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from .skill_activity import SkillActivityRow
@@ -51,7 +52,13 @@ class _InlineRowManager:
         row = SkillActivityRow(
             run_id=run_id,
             skill_name=skill_name,
-            id=f"skillrow_{run_id[:8]}",
+            # Key the widget id on the FULL run_id (the same value used as the
+            # dedup dict key above), not ``run_id[:8]`` — that prefix is the
+            # YYYYMMDD date, so two skills spawned the same day collided on one
+            # widget id and the second mount raised DuplicateIds (the row was
+            # then lost). Sanitise to the Textual id charset; the ``skillrow_``
+            # prefix already satisfies the leading-character rule.
+            id=f"skillrow_{re.sub(r'[^A-Za-z0-9_-]', '_', run_id)}",
             label_prefix=label_prefix,
         )
         self._skill_rows[run_id] = row

--- a/tests/cli/test_skill_row_id_uniqueness.py
+++ b/tests/cli/test_skill_row_id_uniqueness.py
@@ -1,0 +1,63 @@
+"""Tier 2: inline SkillActivityRow widget IDs are unique per run_id, not per date.
+
+Regression: the inline row id was ``skillrow_{run_id[:8]}`` — but a run_id like
+``20260621T003150717803Z_direct_llm_056f`` has ``[:8] == "20260621"`` (the
+YYYYMMDD date). So two skills spawned the SAME day collapsed to the same widget
+id; the second mount raised Textual ``DuplicateIds`` (swallowed by the outbox
+trace handler → the second skill's inline row silently vanished + an error was
+logged). The widget id must track the full run_id (= the dict key already used
+for dedup in ``start_skill_row``).
+
+Public surface only: the rendered ``SkillActivityRow`` widgets in the DOM and
+their ``id`` attributes — no private dicts asserted.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_two_skills_same_day_distinct_run_ids_both_mount() -> None:
+    """Tier 2: two distinct same-day run_ids mount two rows with distinct ids.
+
+    Falsifies the date-truncation collision: ``run_id[:8]`` is identical for
+    both run_ids below, so the buggy id scheme mounts the second row with a
+    duplicate widget id (DuplicateIds). The fix keys the id on the full run_id.
+    """
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.interfaces.tui.widgets.skill_activity import SkillActivityRow
+
+    # Same YYYYMMDD prefix, different time + hash → run_id[:8] collides.
+    rid1 = "20260621T003150717803Z_direct_llm_056f"
+    rid2 = "20260621T003153486860Z_direct_llm_de29"
+    assert rid1[:8] == rid2[:8] and rid1 != rid2, "collision precondition broken"
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv.start_skill_row(rid1, "direct_llm")
+        conv.start_skill_row(rid2, "direct_llm")
+        await pilot.pause()
+
+        rows = list(conv.query(SkillActivityRow))
+        row_count = len(rows)
+        assert row_count == 2, (
+            f"both same-day skills should mount a row; got {row_count}"
+        )
+        # The fix: distinct widget ids per run_id (buggy code reused
+        # skillrow_<date> for both). Assert distinctness directly, not a
+        # set-size, so this pins behaviour rather than a count.
+        ids = [r.id for r in rows]
+        assert ids[0] != ids[1], (
+            f"skill-row widget ids must be distinct per run_id; got {ids!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — objective crash-class bug found during the ① tmux verify (separate branch, bug-workflow).

## Bug

`_InlineRowManager.start_skill_row` dedups skill rows by the **full `run_id`** (the dict key), but built the Textual widget `id` from **`run_id[:8]`** — which is the `YYYYMMDD` **date**:

```
run_id  = 20260621T003150717803Z_direct_llm_056f
run_id[:8] = "20260621"   # the date, not unique
```

So two skills spawned the **same day** both got widget id `skillrow_20260621`. The second mount raised Textual `DuplicateIds`; the outbox trace handler swallowed it, so the **second skill's inline row silently vanished** (+ an error logged). Observed live:

```
outbox handler [trace] raised: textual._node_list.DuplicateIds:
Tried to insert a widget with ID 'skillrow_20260621', but a widget already exists ...
```

## Fix

Key the widget id on the **full `run_id`** (matching the dedup dict key), sanitized to the Textual id charset. One line in `_inline_row_manager.py`.

## Test plan

- [x] Falsifying Tier-2 — `tests/cli/test_skill_row_id_uniqueness.py`: two distinct **same-day** run_ids must both mount with **distinct** widget ids. **Reproduced** `DuplicateIds` on pre-fix code (`skillrow_20260621`); **passes** after the fix.
- [x] Regression — `test_skill_in_phase_detail` + `test_skill_activity_narrow_truncation` + `test_tui_smoke` = **62/62**.
- [x] Lint / Tier — `ruff` clean; `test_tier_audit.py` **0 errors**.

## Tier self-check

1 new test, **Tier 2** (widget invariant). Public surface only — the mounted `SkillActivityRow` widgets in the DOM and their `id` attributes; distinctness asserted via `ids[0] != ids[1]` (not a set-size), no private dicts, no format pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
