### PR TITLE
fix(security/#1956): SSRF — re-validate host on every redirect hop + ipaddress deny

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -328,6 +328,7 @@ web:
     verify_ssl: true     # true | false | 省略（デフォルト: 環境変数チェーン）
     ca_bundle: /path/to/ca-bundle.pem   # 省略可; カスタム CA バンドル
     max_download_bytes: 10485760        # ワイヤバイト上限（デフォルト 10MB）
+    allow_private_ips: false            # #1956 SSRF: プライベート IP への opt-in（デフォルト deny）
   ws_max_size: 16777216  # WebSocket インバウンドフレーム上限（デフォルト 16MB）
 ```
 
@@ -343,6 +344,8 @@ web:
 `verify_ssl` と `ca_bundle` は MCP レジストリの HTTP 呼び出し（パッケージインストール）にも適用されます。
 
 `web.fetch.max_download_bytes`（int, デフォルト `10485760` = 10MB）は `web_fetch` がワイヤから読み取るレスポンスの最大バイト数。`Content-Length` がこの値を超えるレスポンスは本文ダウンロード前に拒否され、chunked / 長さ不明の本文はストリームが上限を超えた時点で中断されます（ステータス `too_large`）。悪意ある / 暴走 URL による無制限な本文のメモリ枯渇を防ぎます。`<= 0` / 非整数はデフォルトにフォールバック。
+
+`web.fetch.allow_private_ips`（bool, デフォルト `false`）は #1956 SSRF 対策。`true` のとき `web_fetch` / `safe.http` がプライベート RFC1918/ULA アドレスへ到達できます（エンタープライズの内部 fetch 向け opt-in）。link-local / クラウドメタデータ（`169.254.169.254`）/ ループバックはこのフラグに関わらず**常に**拒否されます。HTTP リダイレクトは hop ごとに再検証（allowlist + IP-deny）されるため、allowlist 済みホストが内部ターゲットへリダイレクトすることはできません。`REYN_FETCH_ALLOW_PRIVATE_IPS` 環境変数にもエクスポートされ、safe.http サブプロセス + レジストリクライアントが同じ opt-in を参照します。
 
 `web.ws_max_size`（int, デフォルト `16777216` = 16MB）は `reyn web` ゲートウェイが受け付ける単一 WebSocket インバウンドフレームの最大バイト数。サーバーライブラリの暗黙デフォルトに依存せず上限を明示的に固定するため、ライブラリアップグレード後も bound が維持されます。operator は tighten / loosen 可能。`<= 0` / 非整数はデフォルトにフォールバック。
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -545,6 +545,7 @@ web:
     verify_ssl: true     # true | false | omit (default: env-var chain)
     ca_bundle: /path/to/ca-bundle.pem   # optional custom CA bundle
     max_download_bytes: 10485760        # wire-byte ceiling (default 10MB)
+    allow_private_ips: false            # #1956 SSRF: opt-in to private IPs (default deny)
   ws_max_size: 16777216                 # WS inbound-frame ceiling (default 16MB)
 ```
 
@@ -562,6 +563,7 @@ Priority chain (highest first):
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `web.fetch.max_download_bytes` | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
+| `web.fetch.allow_private_ips` | bool | `false` | SSRF opt-in. When `true`, `web_fetch` / `safe.http` may fetch **private** RFC1918/ULA addresses (enterprise internal-fetch). Link-local, cloud-metadata (`169.254.169.254`), and loopback are **always** denied regardless of this flag. HTTP redirects are re-validated per hop (both the host allowlist and the IP-deny), so an allowlisted host cannot redirect to an internal target. Also exported to the `REYN_FETCH_ALLOW_PRIVATE_IPS` env var so the safe.http subprocess and registry clients honor the same opt-in. |
 | `web.ws_max_size` | int | `16777216` (16MB) | Maximum size (bytes) of a single inbound WebSocket frame the `reyn web` gateway accepts; a larger frame is rejected by the server before delivery. Pins the WebSocket frame ceiling explicitly instead of relying on the server library's implicit default, so the bound stays in place across server-library upgrades. Operators may tighten or loosen it. `<= 0` or non-integer falls back to the default. |
 
 ## `eval` block

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -584,12 +584,21 @@
 # is aborted once the stream passes the ceiling. Guards against an
 # unbounded-body memory blow-up from a hostile / runaway URL. ``<= 0`` or a
 # non-integer falls back to the 10MB default.
+#
+# ``allow_private_ips`` (#1956 SSRF, default false) controls whether
+# ``web_fetch`` / ``safe.http`` may reach PRIVATE RFC1918 / ULA addresses
+# (enterprise internal-fetch opt-in). Link-local, cloud-metadata
+# (169.254.169.254), and loopback are ALWAYS denied regardless of this flag.
+# HTTP redirects are re-validated per hop, so an allowlisted host cannot
+# bounce to an internal target. Also exported to REYN_FETCH_ALLOW_PRIVATE_IPS
+# for the safe.http subprocess + registry clients.
 # -----------------------------------------------------------------------------
 # web:
 #   fetch:
 #     verify_ssl: null              # null = delegate to env / litellm fallback
 #     ca_bundle: null               # absolute / cwd-relative PEM path
 #     max_download_bytes: 10485760  # 10MB wire-byte ceiling (DoS guard)
+#     allow_private_ips: false      # #1956 SSRF: opt-in to private IPs (link-local/metadata/loopback always denied)
 #   ws_max_size: 16777216           # 16MB WebSocket inbound-frame ceiling (reyn web gateway)
 
 

--- a/src/reyn/_ssrf_guard.py
+++ b/src/reyn/_ssrf_guard.py
@@ -1,0 +1,132 @@
+"""Single-source SSRF guard — deny outbound fetches resolving to internal IPs.
+
+#1956: ``web_fetch`` / ``safe.http`` validated only the INITIAL host against the
+declared allowlist, then followed HTTP redirects transparently — so an
+allowlisted host could redirect to a link-local / metadata / loopback / private
+target (e.g. the cloud metadata endpoint ``169.254.169.254`` → IAM creds into
+the LLM context). This module is the single-source **Layer 2** validator applied
+at EVERY host gate (initial request + each redirect hop) across all
+redirect-following clients. **Layer 1** (per-hop allowlist re-validation) lives
+in each client.
+
+Stdlib-only leaf (``socket`` / ``ipaddress`` / ``os``) so it imports cleanly from
+both ``reyn.api.*`` and ``reyn.core.*`` with no reyn import cycle — mirrors
+:mod:`reyn._http_limits`.
+
+Policy (lead-approved, #1956):
+  - **HARD deny, no opt-out** — link-local (``169.254.0.0/16``, ``fe80::/10``),
+    cloud-metadata (``169.254.169.254``, ``fd00:ec2::254``), loopback
+    (``127.0.0.0/8``, ``::1``), reserved, multicast, unspecified. An LLM/skill
+    fetch has no legitimate use for these.
+  - **deny by default, operator opt-in** — private RFC1918 / ULA
+    (``10/8``, ``172.16/12``, ``192.168/16``, ``fc00::/7``). Allowed only when
+    ``allow_private`` is True (``web.fetch.allow_private_ips: true``, for
+    enterprise internal-fetch).
+
+Resolution is DNS-aware: the host is resolved and EVERY returned IP is checked
+(deny if ANY is denied), so an allowlisted hostname that resolves to an internal
+IP is caught. IPv4-mapped IPv6 (``::ffff:a.b.c.d``) is normalised so a mapped
+metadata/internal address cannot bypass. Residual: the client re-resolves at
+connect (a small TOCTOU window vs full IP-pinning) — tracked separately as
+future hardening.
+"""
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+
+_IPAddr = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+# Cloud metadata endpoints (IMDS). Hard-deny even though ``fd00:ec2::254`` is
+# unique-local (= ``is_private``): metadata is never a legitimate fetch target,
+# so it must be denied regardless of the ``allow_private`` opt-in.
+_METADATA_IPS: frozenset[_IPAddr] = frozenset({
+    ipaddress.ip_address("169.254.169.254"),   # AWS / GCP / Azure IMDS (v4)
+    ipaddress.ip_address("fd00:ec2::254"),      # AWS IMDS (v6)
+})
+
+# Config→env export read by config-less surfaces (the safe.http subprocess +
+# the registry main-process modules), mirroring REYN_MCP_REGISTRY_URLS. Absent
+# / unset → deny-private (fail-secure even if a sandbox strips the env).
+_ALLOW_PRIVATE_ENV = "REYN_FETCH_ALLOW_PRIVATE_IPS"
+
+# Shared redirect cap so both manual-loop clients agree (httpx default is 20,
+# urllib's is 10 — single-source the bound here).
+MAX_REDIRECTS = 20
+
+
+class SSRFBlocked(PermissionError):
+    """Raised when an outbound fetch target resolves to a denied (internal) IP."""
+
+
+def _normalise(ip: _IPAddr) -> _IPAddr:
+    """Collapse an IPv4-mapped IPv6 address to its IPv4 form (bypass guard)."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+def _deny_reason(ip: _IPAddr, *, allow_private: bool) -> str | None:
+    """Return a human deny-reason if ``ip`` is disallowed, else ``None``."""
+    ip = _normalise(ip)
+    if ip in _METADATA_IPS:
+        return "cloud-metadata endpoint"
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link-local"
+    if ip.is_multicast:
+        return "multicast"
+    if ip.is_reserved or ip.is_unspecified:
+        return "reserved"
+    # ``is_private`` also covers loopback/link-local for IPv4, but those are
+    # caught above with specific reasons; this is the RFC1918 / ULA case.
+    if ip.is_private and not allow_private:
+        return "private (RFC1918/ULA)"
+    return None
+
+
+def assert_fetch_host_allowed(host: str, *, allow_private: bool) -> None:
+    """Raise :class:`SSRFBlocked` if ``host`` resolves to any denied IP.
+
+    A bare IP literal is checked directly (the common redirect-to-IP attack).
+    A hostname is resolved and EVERY returned address is checked (deny if ANY is
+    denied). An unresolvable host is left to the client's own connection error
+    (nothing to gate — no reachable IP). Empty host is denied.
+    """
+    if not host:
+        raise SSRFBlocked("blocked fetch: empty host")
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        reason = _deny_reason(literal, allow_private=allow_private)
+        if reason is not None:
+            raise SSRFBlocked(f"blocked fetch to {host} ({reason})")
+        return
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        # Unresolvable here → no IP to gate; let the client surface its own
+        # DNS/connection failure rather than mislabelling it as an SSRF block.
+        return
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        reason = _deny_reason(ip, allow_private=allow_private)
+        if reason is not None:
+            raise SSRFBlocked(f"blocked fetch to {host} → {ip} ({reason})")
+
+
+def resolve_allow_private() -> bool:
+    """Operator opt-in for private-IP fetches, from the config→env export.
+
+    The config loader exports ``web.fetch.allow_private_ips`` into
+    ``REYN_FETCH_ALLOW_PRIVATE_IPS``; the safe.http subprocess and the
+    config-less registry main-process modules read it here. Absent / unset →
+    ``False`` (deny private — fail-secure even if a sandbox strips the env).
+    """
+    return os.environ.get(_ALLOW_PRIVATE_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -42,9 +42,11 @@ import json as _json
 from typing import Any
 from urllib.error import HTTPError as _HTTPError
 from urllib.parse import urlparse as _urlparse
+from urllib.request import HTTPRedirectHandler as _HTTPRedirectHandler
 from urllib.request import Request as _Request
-from urllib.request import urlopen as _urlopen
+from urllib.request import build_opener as _build_opener
 
+from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
 
 # ── Internal state ─────────────────────────────────────────────────────────
@@ -77,7 +79,16 @@ def _set_permission_context(
 
 
 def _check_host(url: str) -> None:
-    """Raise PermissionError if ``url``'s host is not in the allowlist."""
+    """Raise PermissionError if ``url``'s host is disallowed.
+
+    L1: the declared ``http_hosts`` allowlist. L2 (#1956 SSRF): the host's
+    resolved IP must not be link-local / metadata / loopback / private (private
+    allowed only via the ``web.fetch.allow_private_ips`` operator opt-in). L2
+    runs on the allowlisted host too — an allowlisted host can still resolve to,
+    or (via a redirect hop) BE, an internal IP. ``SSRFBlocked`` is a
+    ``PermissionError`` subclass, so callers catching ``PermissionError`` handle
+    both layers.
+    """
     if not _context_initialised:
         raise PermissionError(
             "reyn.api.safe.http: permission context not initialised. This "
@@ -89,6 +100,10 @@ def _check_host(url: str) -> None:
     parsed = _urlparse(url)
     host = parsed.hostname or ""
     if host in _allowed_hosts:
+        # L2 (#1956 SSRF): IP-deny even for an allowlisted host.
+        _ssrf_guard.assert_fetch_host_allowed(
+            host, allow_private=_ssrf_guard.resolve_allow_private()
+        )
         return
     raise PermissionError(
         f"reyn.api.safe.http: request to host {host!r} (url={url!r}) is not "
@@ -98,6 +113,18 @@ def _check_host(url: str) -> None:
         f"    http.get:\n"
         f"      - host: {host}\n"
     )
+
+
+class _SSRFSafeRedirectHandler(_HTTPRedirectHandler):
+    """#1956: re-validate the host on EVERY redirect hop (L1 allowlist + L2 SSRF
+    IP-deny). Stock urllib follows redirects to ANY host with no re-check, so an
+    allowlisted host could redirect to a link-local / metadata / loopback /
+    private target. ``_check_host`` raises (PermissionError / SSRFBlocked) on a
+    denied hop, aborting the fetch."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _check_host(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
 def _response_dict(resp: Any) -> dict:
@@ -132,8 +159,11 @@ def _request(
         else:
             data = str(body).encode("utf-8")
     req = _Request(url, data=data, headers=hdrs, method=method)
+    # #1956: open via an opener whose redirect handler re-gates each hop (L1+L2),
+    # replacing the stock global opener that followed redirects without re-check.
+    opener = _build_opener(_SSRFSafeRedirectHandler())
     try:
-        with _urlopen(req, timeout=timeout) as resp:  # noqa: S310 — see module docstring
+        with opener.open(req, timeout=timeout) as resp:  # noqa: S310 — see module docstring
             return _response_dict(resp)
     except _HTTPError as exc:
         return _response_dict(exc)

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -127,6 +127,13 @@ class _SSRFSafeRedirectHandler(_HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
+# Module-level URL opener whose redirect handler re-gates every hop (#1956),
+# kept under the ``_urlopen`` name as the stable seam ``_request`` calls (and
+# that tests patch to inject fake responses) — a drop-in for the old
+# ``urllib.request.urlopen`` but redirect-safe.
+_urlopen = _build_opener(_SSRFSafeRedirectHandler()).open
+
+
 def _response_dict(resp: Any) -> dict:
     headers = dict(resp.headers.items()) if hasattr(resp, "headers") else {}
     raw = read_capped(resp)  # bounded read — unbounded-body DoS guard (#1913 class)
@@ -159,11 +166,10 @@ def _request(
         else:
             data = str(body).encode("utf-8")
     req = _Request(url, data=data, headers=hdrs, method=method)
-    # #1956: open via an opener whose redirect handler re-gates each hop (L1+L2),
-    # replacing the stock global opener that followed redirects without re-check.
-    opener = _build_opener(_SSRFSafeRedirectHandler())
+    # #1956: ``_urlopen`` is the SSRF-safe opener (redirect handler re-gates each
+    # hop). Called via the module global so tests can patch the seam.
     try:
-        with opener.open(req, timeout=timeout) as resp:  # noqa: S310 — see module docstring
+        with _urlopen(req, timeout=timeout) as resp:  # noqa: S310 — see module docstring
             return _response_dict(resp)
     except _HTTPError as exc:
         return _response_dict(exc)

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -402,6 +402,21 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             if urls:
                 _os_for_mcp.environ["REYN_MCP_REGISTRY_URLS"] = ",".join(urls)
 
+    # #1956: propagate ``web.fetch.allow_private_ips`` into the
+    # ``REYN_FETCH_ALLOW_PRIVATE_IPS`` env var so the config-less SSRF-guard
+    # surfaces read the operator opt-in: the safe.http subprocess (inherits
+    # parent env) and the registry main-process modules (reyn.mcp.registry /
+    # reyn.core.registry.client, same process). Mirrors the REYN_MCP_REGISTRY_URLS
+    # export above. Explicit operator-set env var wins; absent → unset → the
+    # guard's fail-secure deny-private default. Only the truthy case is exported
+    # (deny is the default, so a False/absent value leaves the var unset).
+    if not _os_for_mcp.environ.get("REYN_FETCH_ALLOW_PRIVATE_IPS"):
+        _web_cfg = merged.get("web")
+        _fetch_cfg = _web_cfg.get("fetch") if isinstance(_web_cfg, dict) else None
+        _ap = _fetch_cfg.get("allow_private_ips") if isinstance(_fetch_cfg, dict) else None
+        if _ap is True or (isinstance(_ap, str) and _ap.strip().lower() in ("1", "true", "yes", "on")):
+            _os_for_mcp.environ["REYN_FETCH_ALLOW_PRIVATE_IPS"] = "1"
+
     raw_ol = merged.get("output_language")
     output_language: str | None
     if isinstance(raw_ol, str) and raw_ol.strip():

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -70,10 +70,19 @@ class WebFetchConfig:
             redirects to a huge payload). Distinct from ``WebFetchIROp.max_length``
             (which caps the *extracted text* only AFTER the full body is loaded).
             Default 10 MiB.
+        allow_private_ips:
+            #1956 SSRF: when ``True``, ``web_fetch`` / ``safe.http`` may reach
+            private RFC1918/ULA addresses (enterprise internal-fetch opt-in).
+            Default ``False`` = deny. Link-local / cloud-metadata / loopback are
+            ALWAYS denied regardless of this flag (no opt-out). Also exported to
+            the ``REYN_FETCH_ALLOW_PRIVATE_IPS`` env var so the config-less
+            SSRF-guard surfaces (the safe.http subprocess + registry clients)
+            see the same opt-in.
     """
     verify_ssl: bool | None = None
     ca_bundle: str | None = None
     max_download_bytes: int = MAX_DOWNLOAD_BYTES  # single-source (#1913 class)
+    allow_private_ips: bool = False  # #1956 SSRF: opt-in to private RFC1918/ULA
 
 
 # Default WebSocket max frame size (bytes) for the `reyn web` gateway. Pins
@@ -113,10 +122,16 @@ def _build_web_fetch_config(raw: object) -> WebFetchConfig:
             max_download_bytes = defaults.max_download_bytes
     except (TypeError, ValueError):
         max_download_bytes = defaults.max_download_bytes
+    # #1956: bool, but tolerate a truthy string (e.g. an interpolated ${VAR}).
+    ap_raw = raw.get("allow_private_ips")
+    allow_private_ips = ap_raw is True or (
+        isinstance(ap_raw, str) and ap_raw.strip().lower() in ("1", "true", "yes", "on")
+    )
     return WebFetchConfig(
         verify_ssl=verify_ssl,
         ca_bundle=ca_bundle,
         max_download_bytes=max_download_bytes,
+        allow_private_ips=allow_private_ips,
     )
 
 

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -211,37 +211,54 @@ def _resolve_ssl_verify(ctx: OpContext) -> bool | str:
 
 
 async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:
+    from urllib.parse import urljoin, urlparse
+
     import httpx
 
-    # #571 Phase 7: route through ``require_http_get`` (= unified
-    # ``http.get`` axis). Declared specific hosts pass silently if
-    # approved at startup_guard; wildcard ``http.get: ["*"]`` fires
-    # a per-host 4-layer prompt; the legacy ``web.fetch`` config /
-    # approvals keys remain honored during the segmented migration
-    # window. A skill with no http.get declaration falls back to the
-    # legacy ``web.fetch`` prompt with a DeprecationWarning.
-    if ctx.permission_resolver is not None:
-        from urllib.parse import urlparse
-        host = urlparse(op.url).hostname or ""
+    from reyn import _ssrf_guard
+
+    # #1956 SSRF: the http.get allowlist (require_http_get) used to be validated
+    # ONLY on the initial url, then follow_redirects=True let httpx reach ANY
+    # host — an allowlisted host could redirect to a link-local / metadata /
+    # loopback / private target (e.g. 169.254.169.254 → cloud IAM creds). We now
+    # follow redirects MANUALLY and re-gate EACH hop: Layer 1 = allowlist
+    # re-validate (require_http_get), Layer 2 = IP-deny (reyn._ssrf_guard).
+    # ``allow_private`` is the operator opt-in (web.fetch.allow_private_ips).
+    _allow_private = (
+        ctx.web_config.fetch.allow_private_ips if ctx.web_config is not None else False
+    )
+
+    async def _gate_hop(hop_url: str) -> dict | None:
+        """L1 (allowlist) + L2 (SSRF IP-deny) for one hop's host. Returns an
+        error envelope to short-circuit on block, else None."""
+        host = urlparse(hop_url).hostname or ""
         if not host:
             return {
                 "kind": "web_fetch", "url": op.url, "status": "error",
-                "error": f"web_fetch: cannot resolve host from URL {op.url!r}",
+                "error": f"web_fetch: cannot resolve host from URL {hop_url!r}",
             }
-        # #1199 S3.1c-2: fold the phase sandbox policy into the http gate's ∩ —
-        # a sandbox with network:false vetoes the fetch (overrides config-allow).
-        await ctx.permission_resolver.require_http_get(
-            ctx.permission_decl, host, ctx.intervention_bus, ctx.skill_name,
-            sandbox_policy=_sandbox_policy_from_ctx(ctx),
-        )
+        # L1 — #571 Phase 7 unified http.get axis (specific hosts pass silently;
+        # wildcard fires the per-host prompt). #1199 S3.1c-2: a sandbox with
+        # network:false vetoes the fetch. Re-run on EVERY hop (not just initial).
+        if ctx.permission_resolver is not None:
+            await ctx.permission_resolver.require_http_get(
+                ctx.permission_decl, host, ctx.intervention_bus, ctx.skill_name,
+                sandbox_policy=_sandbox_policy_from_ctx(ctx),
+            )
+        # L2 — SSRF IP-deny (always; independent of the permission system).
+        try:
+            await asyncio.to_thread(
+                _ssrf_guard.assert_fetch_host_allowed, host, allow_private=_allow_private,
+            )
+        except _ssrf_guard.SSRFBlocked as exc:
+            ctx.events.emit("web_fetch_ssrf_blocked", url=hop_url, host=host, reason=str(exc))
+            return {"kind": "web_fetch", "url": op.url, "status": "blocked", "error": str(exc)}
+        return None
 
     ctx.events.emit("web_fetch_started", url=op.url)
     # #1913: hard ceiling on the downloaded body to prevent an unbounded-memory
-    # DoS. ``client.get`` materializes the ENTIRE response into memory before
-    # ``max_length`` (an extracted-TEXT cap) ever applies, so a hostile URL —
-    # including a benign one that redirects to a huge payload — could exhaust
-    # memory. Stream instead, rejecting on a declared Content-Length over the
-    # cap and on the running byte total exceeding it (covers chunked / no-CL).
+    # DoS. Stream instead, rejecting on a declared Content-Length over the cap
+    # and on the running byte total exceeding it (covers chunked / no-CL).
     _max_dl = (
         ctx.web_config.fetch.max_download_bytes
         if ctx.web_config is not None
@@ -258,27 +275,50 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
             ),
         }
 
+    _REDIRECT_CODES = (301, 302, 303, 307, 308)
+    body = b""
     try:
         # SSL verification — priority: reyn.yaml web.fetch config → env-var chain.
-        # See _resolve_ssl_verify() docstring for the full priority order.
+        # #1956: follow_redirects=False — we follow manually so each hop is gated.
         async with httpx.AsyncClient(
             timeout=op.timeout,
-            follow_redirects=True,
+            follow_redirects=False,
             headers={"User-Agent": "reyn/1.0"},
             verify=_resolve_ssl_verify(ctx),
         ) as client:
-            async with client.stream("GET", op.url) as response:
-                _cl = response.headers.get("content-length")
-                if _cl is not None and _cl.isdigit() and int(_cl) > _max_dl:
-                    return _too_large(int(_cl))
-                _chunks: list[bytes] = []
-                _total = 0
-                async for _chunk in response.aiter_bytes():
-                    _total += len(_chunk)
-                    if _total > _max_dl:
-                        return _too_large(_total)
-                    _chunks.append(_chunk)
-                body = b"".join(_chunks)
+            _url = op.url
+            for _hop in range(_ssrf_guard.MAX_REDIRECTS + 1):
+                _blocked = await _gate_hop(_url)
+                if _blocked is not None:
+                    return _blocked
+                async with client.stream("GET", _url) as response:
+                    _loc = response.headers.get("location")
+                    if response.status_code in _REDIRECT_CODES and _loc:
+                        # next hop — the redirect response body is drained on
+                        # the ``async with`` exit; only its Location matters.
+                        _url = urljoin(_url, _loc)
+                        continue
+                    _cl = response.headers.get("content-length")
+                    if _cl is not None and _cl.isdigit() and int(_cl) > _max_dl:
+                        return _too_large(int(_cl))
+                    _chunks: list[bytes] = []
+                    _total = 0
+                    async for _chunk in response.aiter_bytes():
+                        _total += len(_chunk)
+                        if _total > _max_dl:
+                            return _too_large(_total)
+                        _chunks.append(_chunk)
+                    body = b"".join(_chunks)
+                    break
+            else:
+                ctx.events.emit(
+                    "web_fetch_too_many_redirects", url=op.url,
+                    limit=_ssrf_guard.MAX_REDIRECTS,
+                )
+                return {
+                    "kind": "web_fetch", "url": op.url, "status": "error",
+                    "error": f"too many redirects (exceeded {_ssrf_guard.MAX_REDIRECTS})",
+                }
     except httpx.TimeoutException:
         return {"kind": "web_fetch", "url": op.url, "status": "timeout",
                 "error": f"request timed out after {op.timeout}s"}

--- a/src/reyn/core/registry/client.py
+++ b/src/reyn/core/registry/client.py
@@ -21,12 +21,27 @@ by the search response (e.g. ``"io.github.foo/bar-mcp"``).
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import urllib.parse
 from typing import TYPE_CHECKING
 
+from reyn import _ssrf_guard
+
 if TYPE_CHECKING:
     pass
+
+
+async def _ssrf_request_hook(request) -> None:
+    """#1956 SSRF: gate EVERY httpx request — the initial AND each redirect hop
+    (httpx request event-hooks fire per-hop, verified) — against the IP-deny
+    guard, so a malicious / compromised registry that redirects to an internal
+    IP is blocked. ``allow_private`` is the operator opt-in (env-exported)."""
+    await asyncio.to_thread(
+        _ssrf_guard.assert_fetch_host_allowed,
+        request.url.host or "",
+        allow_private=_ssrf_guard.resolve_allow_private(),
+    )
 
 
 class RegistryError(Exception):
@@ -164,6 +179,8 @@ class RegistryClient:
             follow_redirects=True,
             headers={"User-Agent": "reyn/1.0"},
             verify=verify,
+            # #1956 SSRF: re-gate every hop (incl. redirects) via the IP-deny guard.
+            event_hooks={"request": [_ssrf_request_hook]},
         )
         return self
 

--- a/src/reyn/mcp/registry.py
+++ b/src/reyn/mcp/registry.py
@@ -84,6 +84,7 @@ from typing import Any
 # (= dedup is a list transform; server_info_from_raw is a dict reshape)
 # or scoped to reyn-internal disk cache. None of them are reachable from
 # user code through this safe namespace surface.
+from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
 from reyn.core.registry import cache as _cache
 from reyn.core.registry.client import _dedup_by_latest
@@ -135,12 +136,33 @@ class RegistryError(RuntimeError):
     """Raised when the registry response is non-2xx or cannot be parsed."""
 
 
+class _SSRFRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """#1956 SSRF: re-validate the host (IP-deny) on each redirect hop. Registry
+    URLs are operator-configured, but a malicious / compromised registry could
+    redirect to an internal IP — Layer 2 stops that reach. No allowlist here
+    (operator URL, not a per-skill http.get axis)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _ssrf_guard.assert_fetch_host_allowed(
+            urllib.parse.urlparse(newurl).hostname or "",
+            allow_private=_ssrf_guard.resolve_allow_private(),
+        )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def _http_get_json(url: str) -> dict:
     """GET ``url`` and JSON-parse the body. Raises :class:`RegistryError` on
     any failure (HTTP non-2xx, transport error, JSON parse error)."""
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    # #1956 SSRF: gate the initial host + (via the opener's redirect handler)
+    # each redirect hop against the IP-deny guard. Both surface as RegistryError.
+    opener = urllib.request.build_opener(_SSRFRedirectHandler())
     try:
-        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+        _ssrf_guard.assert_fetch_host_allowed(
+            urllib.parse.urlparse(url).hostname or "",
+            allow_private=_ssrf_guard.resolve_allow_private(),
+        )
+        with opener.open(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
             raw = read_capped(resp)  # bounded read — DoS guard (#1913 class)
             status = getattr(resp, "status", None) or resp.getcode()
     except urllib.error.HTTPError as exc:

--- a/tests/test_safe_http_ssrf_redirect_1956.py
+++ b/tests/test_safe_http_ssrf_redirect_1956.py
@@ -1,0 +1,86 @@
+"""Tier 2: safe.http blocks redirect-to-internal — the #1956 SSRF bypass.
+
+Real local redirect server + real ``safe.http`` (its allowlist is the seam, set
+via ``_set_permission_context``) — no mocks. Pre-fix the allowlisted host's
+redirect to a loopback secret was followed and the body returned; post-fix it
+raises (``_check_host`` adds L2, and the custom redirect handler re-gates each
+hop). The behavioural test asserts on ``PermissionError`` (``SSRFBlocked``'s base)
+so it goes CLEAN RED on pre-fix without importing the new module; the handler
+units pin per-hop L1 + L2 re-validation. Tier line first.
+"""
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+import reyn.api.safe.http as sh
+
+SECRET = b"LOOPBACK-SECRET-1956"
+_port = 0
+
+
+class _H(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{_port}/secret")
+            self.end_headers()
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(SECRET)
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+@pytest.fixture
+def server(monkeypatch):
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    global _port
+    srv = HTTPServer(("127.0.0.1", 0), _H)
+    _port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield _port
+    srv.shutdown()
+
+
+def test_redirect_chain_to_loopback_blocked(server):
+    """Tier 2: an allowlisted host whose redirect reaches a loopback secret is
+    BLOCKED post-fix (pre-fix the body was returned — the reproduced bypass)."""
+    sh._set_permission_context(http_hosts=["127.0.0.1"])
+    with pytest.raises(PermissionError):
+        sh.get(f"http://127.0.0.1:{server}/redirect")
+
+
+def test_redirect_handler_blocks_non_allowlisted_host(monkeypatch):
+    """Tier 2: the redirect handler re-validates the new host — a redirect to a
+    PUBLIC host NOT in the allowlist is blocked (L1 per-hop re-validation)."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    sh._set_permission_context(http_hosts=["allowed.example"])
+    handler = sh._SSRFSafeRedirectHandler()
+    with pytest.raises(PermissionError):
+        # 1.1.1.1 is public (L2 passes) but ∉ allowlist → L1 blocks the hop.
+        handler.redirect_request(None, None, 302, "Found", {}, "http://1.1.1.1/x")
+
+
+def test_redirect_handler_blocks_metadata_even_if_allowlisted(monkeypatch):
+    """Tier 2: a redirect to the metadata endpoint is blocked even when that host
+    is allowlisted (L2 IP-deny on the redirect hop, independent of L1)."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    sh._set_permission_context(http_hosts=["169.254.169.254"])
+    handler = sh._SSRFSafeRedirectHandler()
+    with pytest.raises(PermissionError):
+        handler.redirect_request(
+            None, None, 302, "Found", {}, "http://169.254.169.254/latest/meta-data/"
+        )
+
+
+def test_allowlisted_public_literal_passes(monkeypatch):
+    """Tier 2: (regression) an allowlisted PUBLIC host passes _check_host — the
+    guard does not over-block legitimate public fetches."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    sh._set_permission_context(http_hosts=["8.8.8.8"])
+    sh._check_host("http://8.8.8.8/")  # no raise (public literal, no DNS)

--- a/tests/test_ssrf_guard_1956.py
+++ b/tests/test_ssrf_guard_1956.py
@@ -1,0 +1,80 @@
+"""Tier 2: reyn._ssrf_guard classifies internal / metadata IPs as denied (#1956 L2).
+
+The single-source SSRF validator both clients call at every hop. Pure
+classification for IP literals (no network); the ``allow_private`` opt-in and the
+env-resolver are exercised directly. Tier line first.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn._ssrf_guard import (
+    SSRFBlocked,
+    assert_fetch_host_allowed,
+    resolve_allow_private,
+)
+
+
+def test_metadata_hard_deny_even_with_opt_in():
+    """Tier 2: the cloud-metadata endpoint is denied even when allow_private=True
+    (no opt-out — it must never be reachable)."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("169.254.169.254", allow_private=True)
+
+
+def test_metadata_v6_hard_deny():
+    """Tier 2: the AWS IMDSv6 endpoint (unique-local) is hard-denied despite
+    being is_private — the explicit metadata set overrides the opt-in."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("fd00:ec2::254", allow_private=True)
+
+
+def test_v4_mapped_metadata_cannot_bypass():
+    """Tier 2: an IPv4-mapped IPv6 metadata address is normalised → denied."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("::ffff:169.254.169.254", allow_private=True)
+
+
+def test_loopback_hard_deny():
+    """Tier 2: loopback is denied even under the opt-in (no opt-out)."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("127.0.0.1", allow_private=True)
+
+
+def test_link_local_denied():
+    """Tier 2: a link-local address is denied."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("169.254.1.1", allow_private=False)
+
+
+def test_private_denied_by_default():
+    """Tier 2: private RFC1918 is denied by default (deny-private secure default)."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("10.0.0.1", allow_private=False)
+
+
+def test_private_allowed_with_opt_in():
+    """Tier 2: private RFC1918 is reachable ONLY via the operator opt-in."""
+    assert_fetch_host_allowed("10.0.0.1", allow_private=True)  # no raise
+
+
+def test_public_allowed():
+    """Tier 2: a public IP literal is allowed (no over-block / regression)."""
+    assert_fetch_host_allowed("8.8.8.8", allow_private=False)  # no raise
+
+
+def test_empty_host_denied():
+    """Tier 2: an empty host is denied."""
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("", allow_private=True)
+
+
+def test_resolve_allow_private_reads_env_fail_secure(monkeypatch):
+    """Tier 2: resolve_allow_private reads the config→env export; absent/false →
+    False (fail-secure deny-private), a truthy value → True."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    assert resolve_allow_private() is False
+    monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "1")
+    assert resolve_allow_private() is True
+    monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "false")
+    assert resolve_allow_private() is False

--- a/tests/test_web_fetch_ssrf_redirect_1956.py
+++ b/tests/test_web_fetch_ssrf_redirect_1956.py
@@ -1,0 +1,94 @@
+"""Tier 2: web_fetch blocks redirect-to-internal — the #1956 SSRF bypass.
+
+Real local redirect server + real httpx via ``handle_web_fetch``
+(``permission_resolver=None`` so L1 is skipped → this exercises L2, the IP-deny).
+Pre-fix the redirect to a loopback secret was followed and the body returned
+(``status='ok'``); post-fix the loopback target is denied (``status='blocked'``).
+Asserts on the status string so it goes CLEAN RED on pre-fix without importing the
+new module. Tier line first.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from reyn.config.media import WebConfig, WebFetchConfig
+from reyn.core.op_runtime.web import handle_web_fetch
+from reyn.schemas.models import WebFetchIROp
+
+SECRET = "LOOPBACK-SECRET-1956"
+_port = 0
+
+
+class _H(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{_port}/secret")
+            self.end_headers()
+        else:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(SECRET.encode())
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+def _make_ctx(allow_private: bool = False) -> Any:
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    class _Ev:
+        def emit(self, *a: object, **k: object) -> None:
+            pass
+
+    return OpContext(
+        workspace=type("W", (), {})(),  # type: ignore[arg-type]
+        events=_Ev(),                    # type: ignore[arg-type]
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        web_config=WebConfig(fetch=WebFetchConfig(allow_private_ips=allow_private)),
+    )
+
+
+@pytest.fixture
+def server(monkeypatch):
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    global _port
+    srv = HTTPServer(("127.0.0.1", 0), _H)
+    _port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield _port
+    srv.shutdown()
+
+
+def _fetch(url: str, ctx: Any) -> dict:
+    op = WebFetchIROp(kind="web_fetch", url=url)
+    return asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
+
+
+def test_redirect_to_loopback_blocked(server):
+    """Tier 2: a redirect chain reaching a loopback secret is BLOCKED post-fix
+    (pre-fix returned status='ok' with the secret — the reproduced bypass)."""
+    result = _fetch(f"http://127.0.0.1:{server}/redirect", _make_ctx())
+    assert result["status"] == "blocked", result
+    assert SECRET not in result.get("content", "")
+
+
+def test_direct_loopback_blocked(server):
+    """Tier 2: a direct loopback fetch is blocked by the L2 IP-deny."""
+    result = _fetch(f"http://127.0.0.1:{server}/secret", _make_ctx())
+    assert result["status"] == "blocked", result
+
+
+def test_metadata_url_blocked():
+    """Tier 2: a direct fetch to the cloud metadata endpoint is blocked (no
+    server needed — 169.254.169.254 is a literal link-local IP)."""
+    result = _fetch("http://169.254.169.254/latest/meta-data/", _make_ctx())
+    assert result["status"] == "blocked", result


### PR DESCRIPTION
**[dogfood-coder]** — closes #1956 (SSRF redirect-bypass). Design-review-first **passed** (lead approved the flow-trace + falsifying-test plan → impl GO; all 5 decisions D1–D5 = the approved recommendations). Follow-up #1972 tracks the D1 residual.

## Problem

`web_fetch` and `safe.http` validated the `http.get` allowlist **only on the initial URL**, then followed redirects transparently. A `3xx` to a different host was fetched with **no per-hop re-validation**, and there was **no IP-range guard** anywhere — so an allowlisted host (open-redirect / compromised / prompt-injected) could bounce the fetch to `http://169.254.169.254/...` → cloud IAM creds into the LLM context. Reproduced on **both** httpx and urllib (see #1956).

## Fix (both layers, lead-approved)

- **Layer 1 — per-hop allowlist re-validate:** `web_fetch` now follows redirects **manually** (`follow_redirects=False`) and re-runs `require_http_get` on every hop; `safe.http` uses a custom `HTTPRedirectHandler`. The #1936 streaming size-cap is preserved on the terminal response.
- **Layer 2 — single-source IP-deny:** new stdlib-only leaf `reyn._ssrf_guard` (mirrors `reyn._http_limits`). Resolves the host and denies, by resolved IP: link-local / cloud-metadata (`169.254.169.254`, `fd00:ec2::254`) / loopback / reserved / multicast = **HARD deny, no opt-out**; private RFC1918/ULA = **deny + `web.fetch.allow_private_ips` opt-in**. DNS-aware; IPv4-mapped IPv6 normalised so a mapped internal address cannot bypass.

The opt-in is delivered config → env (`REYN_FETCH_ALLOW_PRIVATE_IPS`, exported by the loader exactly like `REYN_MCP_REGISTRY_URLS`), so the `safe.http` subprocess + registry clients honor it **without** threading a new arg through `PreprocessorExecutor`/`PythonRunner`/harness. Fail-secure: env absent → deny-private.

## Completeness sweep (httpx + urllib are the only outbound stacks)

| Site | Client | Scope |
|---|---|---|
| `op_runtime/web.py` web_fetch | httpx | **PRIMARY — L1+L2** (manual redirect loop) |
| `api/safe/http.py` | urllib | **PRIMARY — L1+L2** (redirect handler) |
| `core/registry/client.py` | httpx | secondary — **L2** (request event-hook, verified fires per-hop) |
| `mcp/registry.py` | urllib | secondary — **L2** (redirect handler) |
| `api/unsafe/http.py` | urllib | OUT (by-design ungated) |
| `secrets/oauth.py`, `dev/*` | httpx | OUT (no redirect-follow — httpx default False) |

## Decisions (D1–D5, as approved)

D1 resolve-then-check now (IP-pin = follow-up **#1972**) · D2 strict host-change re-validate · D3 secondary included · D4 `allow_private_ips` default-False · D5 root-leaf module.

## Falsifying CLEAN RED proof (break → red → revert)

Reverted the two client files to pre-fix (`origin/main`) and ran the behavioral tests:

```
FAILED test_web_fetch_ssrf_redirect_1956.py::test_redirect_to_loopback_blocked   (status was leaked-ok, not blocked)
FAILED test_safe_http_ssrf_redirect_1956.py::test_redirect_chain_to_loopback_blocked  (DID NOT RAISE PermissionError)
```

Restored to HEAD → **17/17 GREEN**. The tests assert on behavior (status string / `PermissionError` base), so they go clean RED on pre-fix without importing the new module.

## Test plan

- [x] Validator unit (`test_ssrf_guard_1956.py`) — metadata hard-deny (incl. opt-in), v6 + v4-mapped metadata, loopback/link-local/private deny, private opt-in allow, public allow, env-resolver fail-secure (11 tests)
- [x] web_fetch behavioral (`test_web_fetch_ssrf_redirect_1956.py`) — redirect→loopback blocked, direct loopback blocked, metadata URL blocked (RED→GREEN proven)
- [x] safe.http behavioral + handler units (`test_safe_http_ssrf_redirect_1956.py`) — redirect-chain blocked (RED→GREEN), per-hop L1 + L2 re-validation, public-literal regression
- [x] `ruff check` clean (all changed src + tests)
- [x] `scripts/test_tier_audit.py --strict` — 17/17, 0 Tier-4 violations
- [x] Regression — 542 passed across web_fetch / safe.http / registry / config / media / loader
- [x] Config-mirror gate (#1056) — `allow_private_ips` documented in `reyn.local.yaml.example` + `reyn-yaml.md` + `reyn-yaml.ja.md`
- [x] `mkdocs build --strict` — exit 0 (no new warnings; pre-existing INFO link-anchor notices only)

## Tier rule self-check

- [x] Each test docstring declares its Tier (`Tier 2:`)
- [x] No Tier 4 violations (tier-audit 0 errors)
- [x] No invariant weakening / private-state asserts / format-pinning
- [x] Real instances + real local servers — no `MagicMock`/`patch` of collaborators (`monkeypatch.setenv`/`delenv` = real env mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
