### PR TITLE
feat(tui): async-strip shows live skill phase (design-check #2, Option A)

### DIFF
--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -759,6 +759,26 @@ class ReynTUIApp(App):
         """Called every 1s by set_interval to keep status line current."""
         self._maybe_refresh_status()
 
+    def _async_strip_summary(self, exec_state: dict) -> str:
+        """Build the bottom async-strip row summary from skill exec state.
+
+        ② design-check (Option A): surface WHICH phase a background skill is
+        currently in — ``skill · <phase>`` (+ ``(N/M)`` when a plan-step count
+        is known) — rather than a static skill name with only ticking elapsed,
+        which left a long-running task looking potentially stuck. The
+        AsyncStackPanel truncates this cell-aware, so a long / CJK phase name
+        stays width-safe.
+        """
+        label = (exec_state or {}).get("skill_name") or "skill"
+        phase = (exec_state or {}).get("phase") or ""
+        if phase:
+            label = f"{label} · {phase}"
+        n_done = (exec_state or {}).get("plan_n_done")
+        n_total = (exec_state or {}).get("plan_n_total")
+        if n_done is not None and n_total:
+            label = f"{label} ({n_done}/{n_total})"
+        return label
+
     def _update_skill_exec(self, msg) -> None:
         """Parse a trace OutboxMessage with skill_name in meta and update _skill_exec."""
         import time as _time
@@ -808,7 +828,7 @@ class ReynTUIApp(App):
             # ``[task_completed]`` boundary).
             try:
                 conv = self.query_one("#conversation", ConversationView)
-                conv.add_async_task(run_id, skill_name or "skill")
+                conv.add_async_task(run_id, self._async_strip_summary(existing))
             except Exception:
                 pass
         # Text pattern: "phase started: <phase_name>"
@@ -816,6 +836,15 @@ class ReynTUIApp(App):
             phase = text[len("phase started: "):].strip()
             existing["phase"] = phase
             existing["phase_visits"] = existing.get("phase_visits", 0) + 1
+            # ② design-check: refresh the bottom async-strip row so a
+            # background skill shows its CURRENT phase, not just ticking
+            # elapsed. add() updates an existing row's summary in place
+            # (no flash; started_at/elapsed preserved).
+            try:
+                conv = self.query_one("#conversation", ConversationView)
+                conv.add_async_task(run_id, self._async_strip_summary(existing))
+            except Exception:
+                pass
         # Text pattern: "detail: plan N/M" (= ChatEventForwarder one-shot
         # plan-step badge emit, see forwarder.on_phase_started). Capture
         # the N/M values into _skill_exec so the right-panel agents tab

--- a/tests/cli/test_async_strip_live_phase.py
+++ b/tests/cli/test_async_strip_live_phase.py
@@ -1,0 +1,134 @@
+"""Tier 2: async-strip rows show the running skill's live phase (design-check #2).
+
+Before: ``add_async_task(run_id, skill_name)`` set the bottom-strip row summary
+once at spawn, so a long-running BACKGROUND skill showed only a ticking elapsed
+clock with no signal of WHICH phase it was in (it looked potentially stuck).
+Now each ``phase started`` trace refreshes the row summary to ``skill · <phase>``
+(+ a plan ``(N/M)`` count when known), updating the existing row in place.
+
+Public surface only: ``_async_strip_summary`` output and
+``AsyncStackPanel.snapshot()`` — no private entry dicts asserted.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+def _row(snap: "list[dict]", agent_id: str) -> "dict | None":
+    for s in snap:
+        if s.get("agent_id") == agent_id and not s.get("is_overflow"):
+            return s
+    return None
+
+
+@pytest.mark.asyncio
+async def test_plan_step_count_appears_in_strip() -> None:
+    """Tier 2: a known plan step count surfaces as ``(N/M)`` in the strip summary.
+
+    Drives the real trace stream (``detail: plan N/M`` then a ``phase started``
+    that refreshes the row) and asserts the public ``snapshot()`` summary —
+    pins the plan-count wiring without touching the private summary builder.
+    """
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    def _msg(text: str) -> OutboxMessage:
+        return OutboxMessage(
+            kind="trace", text=text,
+            meta={"run_id": "r1", "skill_name": "my_skill"},
+        )
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+
+        app._update_skill_exec(_msg("phase started: plan"))
+        app._update_skill_exec(_msg("detail: plan 2/5"))
+        app._update_skill_exec(_msg("phase started: execute"))
+        await pilot.pause()
+
+        row = _row(panel.snapshot(), "r1")
+        assert row is not None, "strip row for r1 should be mounted"
+        assert "(2/5)" in row["summary"], (
+            f"strip summary should surface the plan step count; got {row['summary']!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_phase_started_shows_phase_in_strip() -> None:
+    """Tier 2: a ``phase started`` trace surfaces the phase in the strip summary."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+        assert panel is not None
+
+        app._update_skill_exec(OutboxMessage(
+            kind="trace",
+            text="phase started: analyze",
+            meta={"run_id": "r1", "skill_name": "my_skill"},
+        ))
+        await pilot.pause()
+
+        row = _row(panel.snapshot(), "r1")
+        assert row is not None, "strip row for r1 should be mounted"
+        assert "analyze" in row["summary"], (
+            f"strip summary should surface the live phase; got {row['summary']!r}"
+        )
+        assert "my_skill" in row["summary"], (
+            f"strip summary should keep the skill name; got {row['summary']!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_phase_progression_replaces_phase_in_place() -> None:
+    """Tier 2: a later phase replaces the earlier one in the row (live progress).
+
+    The entry is keyed by run_id, so the update is in place; the visible
+    invariant is that the summary tracks the CURRENT phase and drops the prior
+    one — a long-running task no longer looks frozen on its first phase.
+    """
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    def _trace(phase: str) -> OutboxMessage:
+        return OutboxMessage(
+            kind="trace", text=f"phase started: {phase}",
+            meta={"run_id": "r1", "skill_name": "my_skill"},
+        )
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        panel = conv._async_stack()
+
+        app._update_skill_exec(_trace("plan"))
+        await pilot.pause()
+        app._update_skill_exec(_trace("execute"))
+        await pilot.pause()
+
+        row = _row(panel.snapshot(), "r1")
+        assert row is not None, "strip row for r1 should still be present"
+        assert "execute" in row["summary"], (
+            f"strip should show the current phase; got {row['summary']!r}"
+        )
+        assert "plan" not in row["summary"], (
+            f"stale earlier phase leaked into the summary; got {row['summary']!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — design-check ② (async-strip live-phase), **Option A** per lead-coder GO.

## What

The bottom async-strip (running background tasks) set each row's summary **once at spawn** with just the skill name. A long-running BACKGROUND skill then showed only a ticking elapsed clock — no signal of **which phase** it was in, so it could look frozen.

Now each `phase started` trace refreshes the row summary to **`skill · <phase>`** (+ **`(N/M)`** when a plan step count is known). The refresh goes through `add_async_task` → `AsyncStackPanel.add`, which updates the existing entry **in place** — no flash, `started_at`/elapsed preserved (verified `add()` only flashes on interrupt/abort, not summary update).

Example (deterministic render): `research · synthesize (2/5)`.

## Option A (vs B/C)

Lead GO'd Option A (live phase in the summary). Plan `(N/M)` (the Option-C idea) is folded in opportunistically when the count is already known — it's additive, not a separate mode. The "no-progress staleness cue" (Option B fallback) wasn't needed: `phase started` traces are reliably available, so the real phase is shown rather than a proxy.

## Width / CJK safety

The summary flows through the AsyncStackPanel's existing **cell-aware** truncation (`_truncate_to_cells` / `cell_len`), so a long or CJK phase name stays width-safe — no regression to the strip layout.

## Test plan

- [x] Unit — `tests/cli/test_async_strip_live_phase.py` **3/3**: phase surfaces in the strip summary; a later phase **replaces** the earlier one in place (live progression); plan `(N/M)` count appears. All assert via the public `AsyncStackPanel.snapshot()`.
- [x] Regression — `test_tui_smoke` + `test_async_stack_interrupted_flash` + `test_async_stack_panel_wired` = **52/52**.
- [x] Lint / Tier — `ruff` clean; `test_tier_audit.py` **0 errors**.
- [x] Render (deterministic) — pilot `save_screenshot` of the strip after phase traces: `research · synthesize (2/5)`, `·` separator + count render cleanly, no width break.
- [x] (skipped — env) tmux **live** freeze-frame: same constraint as #1969 — the weak demo model's phase timing is erratic to capture mid-flight. Verified via the deterministic pilot render (same Textual pipeline); the live background-skill strip was observed updating during the #1969 verify.

## Tier self-check

3 new tests, all **Tier 2**. Public surface only — `AsyncStackPanel.snapshot()` summaries; no private `_entries` / `_async_strip_summary` assertions (an earlier private-method test was replaced with a public-path one per `feedback_test_public_surface_not_private_state` / `feedback_tier4_delete_preferred`). No format/whitespace pinning beyond the intended summary substring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
