### PR TITLE
feat(#1953): slice 5a-1 — A2A read/cancel surface re-pointed to the Task backend

### DIFF
--- a/src/reyn/interfaces/web/a2a_task_view.py
+++ b/src/reyn/interfaces/web/a2a_task_view.py
@@ -1,0 +1,69 @@
+"""A2A view of a reyn Task (#1953 slice 5a).
+
+The boundary mapper from a reyn ``Task`` (term-neutral core, #1953) to an A2A
+Task envelope. Lives in the A2A layer (P7): the Task core stays term-neutral; the
+A2A vocabulary (``TaskState``, ``contextId``) is constructed only here. ``contextId``
+is recovered from the assignee's core session_id via the A2A reverse map (#1814).
+
+This replaces the closed #1948 RunEntry-based mapping with the settled Task
+lifecycle vocabulary (H3).
+"""
+from __future__ import annotations
+
+from reyn.runtime.a2a_routing import a2a_context_id
+from reyn.task.model import TaskState
+
+# reyn Task state → A2A TaskState (JSON-RPC short-form binding, consistent with
+# the slash-form ``message/send`` Reyn ships).
+#
+# ⚠ ``blocked → input-required`` is an **interim placeholder** (slice 5 surfaces
+# no blocked tasks yet). The **precise split lands in slice 7** with the
+# block-reason discriminator: a **DAG-dependency** block maps to ``working`` (it
+# resolves automatically — telling an A2A client ``input-required`` would be a
+# lie), while only **external-input / auth** blocks map to
+# ``input-required`` / ``auth-required`` (H3).
+_TASK_STATE_TO_A2A: dict[str, str] = {
+    "pending": "submitted",
+    "ready": "submitted",
+    "in_progress": "working",
+    "blocked": "input-required",   # interim — see note above (slice 7)
+    "completed": "completed",
+    "failed": "failed",
+    "aborted": "canceled",
+    "archived": "canceled",        # abort = delete → archived → A2A canceled
+}
+
+# The legal A2A TaskState values this mapper may emit (drift guard for the
+# completeness test — every map target must be one of these).
+_A2A_TASK_STATES: frozenset[str] = frozenset({
+    "submitted", "working", "input-required", "auth-required",
+    "completed", "failed", "canceled",
+})
+
+
+def task_state_to_a2a(state: str) -> str:
+    """Map a reyn Task state to an A2A TaskState. Unknown → ``working`` (a safe,
+    non-terminal default — never silently report a non-spec state)."""
+    return _TASK_STATE_TO_A2A.get(state, "working")
+
+
+def to_a2a_task(task) -> dict:
+    """Build a spec-shaped A2A Task envelope from a reyn ``Task``.
+
+    ``id`` = task_id; ``status.state`` = the mapped A2A TaskState; ``contextId``
+    is the A2A view of the assignee's core session_id (reverse map, #1814 — the
+    contextId term stays in the A2A layer). ``kind: "task"`` is the JSON-RPC
+    discriminator.
+    """
+    status_obj: dict = {
+        "state": task_state_to_a2a(task.status.value),
+        "timestamp": task.updated_at,
+    }
+    out: dict = {
+        "kind": "task",
+        "id": task.task_id,
+        "status": status_obj,
+    }
+    if task.assignee:
+        out["contextId"] = a2a_context_id(task.assignee)
+    return out

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -408,6 +408,13 @@ def get_run_registry(request: Request) -> "RunRegistry":
     return request.app.state.run_registry
 
 
+def get_task_backend(request: Request):
+    """FastAPI dependency: return the process-singleton Task backend (#1953 slice
+    5a). Attached to ``app.state.task_backend`` by ``reyn.interfaces.web.server``;
+    the A2A read/cancel surface reads it."""
+    return request.app.state.task_backend
+
+
 __all__ = [
     "get_project_root",
     "get_reyn_config",

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -45,7 +45,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from reyn.interfaces.web.deps import get_registry, get_run_registry
+from reyn.interfaces.web.a2a_task_view import to_a2a_task
+from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
 from reyn.mcp.server import DEFAULT_SEND_TIMEOUT_SECONDS, send_to_agent_impl
 from reyn.runtime.a2a_routing import (
     a2a_context_id,
@@ -287,6 +288,7 @@ async def a2a_jsonrpc(
     request: Request,
     registry=Depends(get_registry),
     run_registry=Depends(get_run_registry),
+    task_backend=Depends(get_task_backend),
 ) -> dict:
     """JSON-RPC 2.0 endpoint for one Reyn agent.
 
@@ -333,7 +335,7 @@ async def a2a_jsonrpc(
         )
     if method == "tasks/list":
         return await _handle_tasks_list(
-            req_id, body.get("params") or {}, agent_name, run_registry,
+            req_id, body.get("params") or {}, agent_name, task_backend,
         )
 
     return _jsonrpc_error(
@@ -349,17 +351,17 @@ _LIST_TASKS_DEFAULT_PAGE_SIZE = 50
 _LIST_TASKS_MAX_PAGE_SIZE = 100  # A2A spec cap
 
 
-def _task_sort_key(entry) -> tuple[str, str]:
-    """Stable keyset order: (created_at, run_id). ISO-8601 timestamps sort
-    lexicographically = chronologically (all entries are UTC), and run_id
-    breaks ties — so the order is total and insertion-stable, which is what
-    makes the opaque page token a correct keyset cursor."""
-    return (entry.created_at.isoformat(), entry.run_id)
+def _task_sort_key(task) -> tuple[str, str]:
+    """Stable keyset order: (created_at, task_id). ISO-8601 ``Task.created_at``
+    (a string) sorts lexicographically = chronologically (UTC), and task_id
+    breaks ties — a total, insertion-stable order, which makes the opaque page
+    token a correct keyset cursor (#1953 slice 5a: Task-backed)."""
+    return (str(task.created_at), task.task_id)
 
 
-def _encode_page_token(entry) -> str:
+def _encode_page_token(task) -> str:
     raw = json.dumps(
-        {"created_at": entry.created_at.isoformat(), "run_id": entry.run_id},
+        {"created_at": str(task.created_at), "id": task.task_id},
         separators=(",", ":"),
     )
     return base64.urlsafe_b64encode(raw.encode()).decode()
@@ -371,7 +373,7 @@ def _decode_page_token(token: str) -> tuple[str, str] | None:
     try:
         raw = base64.urlsafe_b64decode(token.encode()).decode()
         data = json.loads(raw)
-        return (str(data["created_at"]), str(data["run_id"]))
+        return (str(data["created_at"]), str(data["id"]))
     except Exception:
         return None
 
@@ -380,28 +382,24 @@ async def _handle_tasks_list(
     req_id: Any,
     params: dict,
     agent_name: str,
-    run_registry,
+    task_backend,
 ) -> dict:
-    """A2A ``tasks/list`` — this agent's tasks, optionally filtered by
-    ``contextId`` (→ core session_id) and ``status``, keyset-paginated.
-
-    The A2A spec names this ``ListTasks`` (PascalCase); it is bound here as
-    slash-form ``tasks/list`` to stay consistent with the existing
-    ``message/send`` JSON-RPC binding Reyn ships (#1811). ``status`` is matched
-    against Reyn's own status names (the spec→Reyn STATUS_MAP normalization is a
-    separate cross-cutting #1811 slice that will normalize both ``tasks/list``
-    output and ``GetTask`` together — deferred here to avoid coupling).
+    """A2A ``tasks/list`` — Tasks for a ``contextId``, optionally filtered by
+    ``status``, keyset-paginated, as spec A2A Task envelopes (#1953 slice 5a:
+    Task-backed). Slash-form ``tasks/list`` (consistent with ``message/send``).
+    ``status`` is matched against the Reyn Task-state vocabulary.
     """
     # contextId (A2A term) → core-neutral session_id at the layer boundary; the
-    # A2A layer owns this map so core (RunRegistry) stays term-neutral (#1814).
+    # A2A layer owns this map so core (the Task backend) stays term-neutral
+    # (#1814). The contextId's session is the Task assignee.
     context_id = params.get("contextId")
     session_id = a2a_session_id(context_id) if context_id else None
 
-    entries = run_registry.list(agent_name, session_id=session_id)
+    entries = await task_backend.list(assignee=session_id)
 
     status_filter = params.get("status")
     if status_filter is not None:
-        entries = [e for e in entries if e.status == status_filter]
+        entries = [e for e in entries if e.status.value == status_filter]
 
     entries.sort(key=_task_sort_key)
     total_size = len(entries)  # full filtered set, before pagination
@@ -434,7 +432,7 @@ async def _handle_tasks_list(
     return _jsonrpc_result(
         req_id,
         {
-            "tasks": [e.to_public_dict() for e in page],
+            "tasks": [to_a2a_task(t) for t in page],
             "nextPageToken": next_token,
             "pageSize": page_size,
             "totalSize": total_size,
@@ -1150,13 +1148,16 @@ async def _handle_async_mode(
 @router.get("/a2a/tasks/{run_id}")
 async def get_task(
     run_id: str,
-    run_registry=Depends(get_run_registry),
+    task_backend=Depends(get_task_backend),
 ) -> dict:
-    """Poll a task's status. Returns RunEntry.to_public_dict()."""
-    entry = run_registry.get(run_id)
-    if entry is None:
+    """A2A GetTask — poll a Task's status from the Task backend (#1953 slice 5a).
+    Returns the spec A2A Task envelope (Task-vocab state). The path param is the
+    ``task_id``. A terminal/archived task returns its envelope (status=canceled),
+    a tombstone rather than 404; a genuinely-unknown id is 404."""
+    task = await task_backend.get(run_id)
+    if task is None:
         raise HTTPException(404, f"Task {run_id!r} not found")
-    return entry.to_public_dict()
+    return to_a2a_task(task)
 
 
 # ── POST /a2a/tasks/{run_id}/cancel — cancel a running task ─────────────────
@@ -1165,13 +1166,18 @@ async def get_task(
 @router.post("/a2a/tasks/{run_id}/cancel")
 async def cancel_task(
     run_id: str,
-    run_registry=Depends(get_run_registry),
+    task_backend=Depends(get_task_backend),
 ) -> dict:
-    """Cancel a running task. Idempotent for already-terminal tasks."""
-    if not run_registry.cancel(run_id):
+    """A2A CancelTask — the external requester's remove-op (#1953 slice 5a).
+    Maps to ``task.abort`` (cooperative-terminal: archive the Task + sub-tree;
+    the assignee's in-flight work is rejected by the terminal guard). The A2A
+    client owns the contextId/task as its external requester. Returns the
+    archived Task's A2A envelope (status=canceled). The path param is the
+    ``task_id``; an unknown id is 404."""
+    aborted = await task_backend.abort(run_id)
+    if not aborted:
         raise HTTPException(404, f"Task {run_id!r} not found")
-    entry = run_registry.get(run_id)
-    return entry.to_public_dict() if entry else {"run_id": run_id, "status": "cancelled"}
+    return to_a2a_task(aborted[0])
 
 
 # ── GET /a2a/tasks/{run_id}/events — SSE stream ──────────────────────────────

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -155,6 +155,14 @@ async def _lifespan(app: FastAPI):
     persist_path = Path(".reyn") / "state" / "run_registry.json"
     app.state.run_registry = RunRegistry(persist_path=persist_path)
 
+    # #1953 slice 5a: the process-singleton Task backend the A2A surface reads
+    # (GetTask / ListTasks / Cancel). Single store keyed by session_id columns
+    # (the §24/R1 per-session store for rewind is revisited at slice 9). Durable
+    # sqlite under the server state dir.
+    from reyn.task import create_task_backend  # noqa: PLC0415
+    task_db_path = Path(".reyn") / "state" / "tasks.db"
+    app.state.task_backend = create_task_backend("sqlite", path=str(task_db_path))
+
     # FP-0009 B: cron scheduler — start only if reyn.yaml has any enabled
     # cron jobs.  Failures are caught so a misconfigured cron block does
     # not prevent the web gateway from booting.

--- a/tests/test_a2a_list_tasks_1811.py
+++ b/tests/test_a2a_list_tasks_1811.py
@@ -1,11 +1,11 @@
 """Tier 2: #1811 — A2A ``tasks/list`` (ListTasks) listing + filter + pagination.
 
-``tasks/list`` returns one agent's tasks, narrowable by ``contextId`` (→ the
-core-neutral ``session_id`` routing-key, #1814) and ``status``, with a stable
-keyset cursor (sort key ``(created_at, run_id)``; opaque base64 ``pageToken``;
-``nextPageToken`` MUST always be present, ``''`` at end). Per-task shape reuses
-``RunEntry.to_public_dict()`` (consistent with GetTask; STATUS_MAP normalization
-is a separate #1811 slice). Real RunRegistry, no mocks.
+``tasks/list`` returns a contextId's Tasks (the context's assignee session),
+narrowable by ``status``, with a stable keyset cursor (sort key
+``(created_at, task_id)``; opaque base64 ``pageToken``; ``nextPageToken`` MUST
+always be present, ``''`` at end). Per-task shape is the spec A2A Task envelope
+(``to_a2a_task``, #1953 slice 5a — Task-backed; replaces the #1947 RunRegistry
+version). Real Task backend, no mocks.
 
 Falsification:
 - contextId filter test reds if the session_id filter is dropped (returns both
@@ -16,29 +16,35 @@ Falsification:
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import pytest
 
 from reyn.interfaces.web.routers.a2a import _handle_tasks_list
-from reyn.interfaces.web.run_registry import RunRegistry
 from reyn.runtime.a2a_routing import a2a_session_id
+from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+_SEED_COUNTER = [0]
 
 
-def _seed(reg: RunRegistry, agent: str, session_id: str, n: int, *, status: str = "running"):
-    """Create ``n`` runs with deterministic, strictly-increasing created_at so
-    the keyset order is fully known."""
+async def _seed(backend: InMemoryTaskBackend, session_id: str, n: int, *,
+                status: TaskState = TaskState.IN_PROGRESS):
+    """Create ``n`` Tasks assigned to ``session_id`` (the contextId's session),
+    with globally-unique task_ids + deterministic strictly-increasing created_at
+    so the keyset order is fully known across multiple seed calls."""
     created = []
-    for i in range(n):
-        e = reg.create(agent_name=agent, chain_id=f"c{i}", session_id=session_id)
-        e.status = status
-        e.created_at = datetime(2026, 1, 1, 0, 0, i, tzinfo=timezone.utc)
-        created.append(e)
+    for _ in range(n):
+        k = _SEED_COUNTER[0]
+        _SEED_COUNTER[0] += 1
+        t = Task(task_id=f"task-{k}", name=f"n{k}", assignee=session_id,
+                 requester="req", status=status,
+                 created_at=f"2026-01-01T00:{k // 60:02d}:{k % 60:02d}+00:00")
+        await backend.create(t)
+        created.append(t)
     return created
 
 
-async def _list(reg: RunRegistry, agent: str, **params) -> dict:
-    resp = await _handle_tasks_list(req_id="r1", params=params, agent_name=agent, run_registry=reg)
+async def _list(backend: InMemoryTaskBackend, agent: str, **params) -> dict:
+    resp = await _handle_tasks_list(req_id="r1", params=params, agent_name=agent,
+                                    task_backend=backend)
     assert resp["jsonrpc"] == "2.0"
     assert "result" in resp, resp
     return resp["result"]
@@ -46,14 +52,14 @@ async def _list(reg: RunRegistry, agent: str, **params) -> dict:
 
 @pytest.mark.asyncio
 async def test_tasks_list_filters_by_contextid():
-    """Tier 2: contextId scopes results to that context's session_id only."""
-    reg = RunRegistry()
+    """Tier 2: contextId scopes results to that context's session (assignee) only."""
+    backend = InMemoryTaskBackend()
     ctx_a, ctx_b = "ctx-a", "ctx-b"
-    a_ids = {e.run_id for e in _seed(reg, "alice", a2a_session_id(ctx_a), 3)}
-    _seed(reg, "alice", a2a_session_id(ctx_b), 2)  # other context — must be excluded
+    a_ids = {t.task_id for t in await _seed(backend, a2a_session_id(ctx_a), 3)}
+    await _seed(backend, a2a_session_id(ctx_b), 2)  # other context — must be excluded
 
-    result = await _list(reg, "alice", contextId=ctx_a)
-    returned = {t["run_id"] for t in result["tasks"]}
+    result = await _list(backend, "alice", contextId=ctx_a)
+    returned = {t["id"] for t in result["tasks"]}
 
     # RED if the session_id filter is dropped: returned would also contain ctx_b.
     assert returned == a_ids
@@ -64,9 +70,9 @@ async def test_tasks_list_filters_by_contextid():
 async def test_tasks_list_pagination_keyset_covers_all_once():
     """Tier 2: keyset pages partition the full set — no overlap, no skips, and
     nextPageToken is non-empty until the final page then ''."""
-    reg = RunRegistry()
+    backend = InMemoryTaskBackend()
     ctx = "ctx-pg"
-    all_ids = {e.run_id for e in _seed(reg, "alice", a2a_session_id(ctx), 5)}
+    all_ids = {t.task_id for t in await _seed(backend, a2a_session_id(ctx), 5)}
 
     seen: list[str] = []
     token = ""
@@ -76,9 +82,9 @@ async def test_tasks_list_pagination_keyset_covers_all_once():
         params = {"contextId": ctx, "pageSize": 2}
         if token:
             params["pageToken"] = token
-        result = await _list(reg, "alice", **params)
+        result = await _list(backend, "alice", **params)
         page_lens.append(len(result["tasks"]))
-        seen.extend(t["run_id"] for t in result["tasks"])
+        seen.extend(t["id"] for t in result["tasks"])
         token = result["nextPageToken"]
         pages += 1
         assert pages <= 10, "pagination did not terminate"
@@ -95,14 +101,14 @@ async def test_tasks_list_pagination_keyset_covers_all_once():
 
 @pytest.mark.asyncio
 async def test_tasks_list_filters_by_status():
-    """Tier 2: status narrows the set (matched against Reyn status names)."""
-    reg = RunRegistry()
+    """Tier 2: status narrows the set (matched against the Task-state vocab)."""
+    backend = InMemoryTaskBackend()
     sid = a2a_session_id("ctx-st")
-    done = {e.run_id for e in _seed(reg, "alice", sid, 2, status="completed")}
-    _seed(reg, "alice", sid, 3, status="running")
+    done = {t.task_id for t in await _seed(backend, sid, 2, status=TaskState.COMPLETED)}
+    await _seed(backend, sid, 3, status=TaskState.IN_PROGRESS)
 
-    result = await _list(reg, "alice", contextId="ctx-st", status="completed")
-    returned = {t["run_id"] for t in result["tasks"]}
+    result = await _list(backend, "alice", contextId="ctx-st", status="completed")
+    returned = {t["id"] for t in result["tasks"]}
 
     assert returned == done
     assert result["totalSize"] == 2
@@ -111,30 +117,30 @@ async def test_tasks_list_filters_by_status():
 @pytest.mark.asyncio
 async def test_tasks_list_next_page_token_always_present_on_short_page():
     """Tier 2: nextPageToken MUST be present and '' when results fit one page."""
-    reg = RunRegistry()
-    seeded = _seed(reg, "alice", a2a_session_id("ctx-1"), 1)
+    backend = InMemoryTaskBackend()
+    seeded = await _seed(backend, a2a_session_id("ctx-1"), 1)
 
-    result = await _list(reg, "alice", contextId="ctx-1")
+    result = await _list(backend, "alice", contextId="ctx-1")
 
     # RED if the key is omitted on a single short page.
     assert "nextPageToken" in result
     assert result["nextPageToken"] == ""
     # the single seeded task is the only one returned (no extra page expected).
-    returned = {t["run_id"] for t in result["tasks"]}
-    assert returned == {seeded[0].run_id}
+    returned = {t["id"] for t in result["tasks"]}
+    assert returned == {seeded[0].task_id}
 
 
 @pytest.mark.asyncio
 async def test_tasks_list_rejects_malformed_page_token():
     """Tier 2: a malformed pageToken is an invalid-params error, not a crash."""
-    reg = RunRegistry()
-    _seed(reg, "alice", a2a_session_id("ctx-1"), 1)
+    backend = InMemoryTaskBackend()
+    await _seed(backend, a2a_session_id("ctx-1"), 1)
 
     resp = await _handle_tasks_list(
         req_id="r1",
         params={"contextId": "ctx-1", "pageToken": "!!!not-base64!!!"},
         agent_name="alice",
-        run_registry=reg,
+        task_backend=backend,
     )
 
     assert "error" in resp

--- a/tests/test_a2a_task_view_1953.py
+++ b/tests/test_a2a_task_view_1953.py
@@ -1,0 +1,63 @@
+"""Tier 2: #1953 slice 5a — A2A view of a reyn Task (status-map + envelope).
+
+The term-neutral Task → A2A Task envelope boundary mapper. Completeness: every
+reyn Task state maps to a legal A2A TaskState (drift guard). Envelope shape +
+contextId reverse-map (#1814).
+
+Falsification:
+- the completeness test reds if any Task state maps to a non-spec A2A state.
+- the every-state test reds if a Task state is dropped from the map.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.web.a2a_task_view import (
+    _A2A_TASK_STATES,
+    _TASK_STATE_TO_A2A,
+    task_state_to_a2a,
+    to_a2a_task,
+)
+from reyn.task.model import Task, TaskOrigin, TaskState
+
+
+def test_every_task_state_is_mapped():
+    """Tier 2: the map covers every reyn TaskState (no state silently unmapped)."""
+    mapped = set(_TASK_STATE_TO_A2A)
+    all_states = {s.value for s in TaskState}
+    # RED if a TaskState is added without a map entry.
+    assert mapped == all_states, all_states ^ mapped
+
+
+def test_map_targets_are_legal_a2a_states():
+    """Tier 2: every map target is a legal A2A TaskState (drift guard, #1912b form)."""
+    bad = set(_TASK_STATE_TO_A2A.values()) - _A2A_TASK_STATES
+    assert bad == set()
+
+
+def test_key_state_mappings():
+    """Tier 2: the load-bearing mappings (Task vocab → A2A), incl. the interim
+    blocked→input-required (slice 7 splits it) and abort=delete archived→canceled."""
+    assert task_state_to_a2a("in_progress") == "working"
+    assert task_state_to_a2a("completed") == "completed"
+    assert task_state_to_a2a("failed") == "failed"
+    assert task_state_to_a2a("aborted") == "canceled"
+    assert task_state_to_a2a("archived") == "canceled"
+    assert task_state_to_a2a("blocked") == "input-required"  # interim (slice 7)
+    # unknown → safe non-terminal default.
+    assert task_state_to_a2a("some-future-state") == "working"
+
+
+def test_to_a2a_task_envelope_shape():
+    """Tier 2: the envelope = {kind:task, id, status:{state,timestamp}, contextId}
+    with contextId recovered from the assignee's session_id (A2A reverse map)."""
+    task = Task(task_id="t-1", name="n", assignee="a2a:ctx-7", requester="r",
+                origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS)
+    env = to_a2a_task(task)
+    assert env["kind"] == "task"
+    assert env["id"] == "t-1"
+    assert env["status"]["state"] == "working"
+    assert "timestamp" in env["status"]
+    # contextId = the A2A view of the assignee session_id (term-neutral reverse map).
+    assert env["contextId"] == "ctx-7"
+    # flat reyn shape does not leak.
+    assert "run_id" not in env
+    assert not isinstance(env["status"], str)

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -70,7 +70,7 @@ def _restore_overrides() -> None:
 
 
 def test_get_task_returns_a2a_envelope_from_task_backend() -> None:
-    """Tier 2 (#1953 slice 5a): GET /a2a/tasks/{task_id} returns 200 with the spec
+    """Tier 2: (#1953 slice 5a) GET /a2a/tasks/{task_id} returns 200 with the spec
     A2A Task envelope read from the Task backend (Task-vocab state)."""
     import asyncio
 
@@ -117,7 +117,7 @@ def test_get_task_returns_404_for_unknown_run() -> None:
 
 
 def test_cancel_task_aborts_task_in_backend() -> None:
-    """Tier 2 (#1953 slice 5a): POST /a2a/tasks/{task_id}/cancel = the external
+    """Tier 2: (#1953 slice 5a) POST /a2a/tasks/{task_id}/cancel = the external
     requester's remove-op → task.abort (cooperative-terminal → archived). The
     response is the archived Task's A2A envelope (status=canceled)."""
     import asyncio

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -77,7 +77,7 @@ def test_get_task_returns_a2a_envelope_from_task_backend() -> None:
     from reyn.task import InMemoryTaskBackend, Task, TaskState
 
     backend = InMemoryTaskBackend()
-    asyncio.get_event_loop().run_until_complete(
+    asyncio.new_event_loop().run_until_complete(
         backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-7",
                             requester="r", status=TaskState.IN_PROGRESS)))
     client = _make_client_with_registry(RunRegistry(), task_backend=backend)
@@ -125,7 +125,7 @@ def test_cancel_task_aborts_task_in_backend() -> None:
     from reyn.task import InMemoryTaskBackend, Task, TaskState
 
     backend = InMemoryTaskBackend()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(
         backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-1",
                             requester="r", status=TaskState.IN_PROGRESS)))

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -41,14 +41,20 @@ from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-def _make_client_with_registry(registry: RunRegistry):
-    """Build a TestClient that uses the supplied RunRegistry via DI override."""
+def _make_client_with_registry(registry: RunRegistry, task_backend=None):
+    """Build a TestClient that uses the supplied RunRegistry (and an optional
+    Task backend — #1953 slice 5a — for the Task-backed A2A surface) via DI
+    override. A default in-memory Task backend satisfies a2a_jsonrpc's
+    get_task_backend dependency for tests that don't exercise it."""
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_run_registry
+    from reyn.interfaces.web.deps import get_run_registry, get_task_backend
     from reyn.interfaces.web.server import app
+    from reyn.task import InMemoryTaskBackend
 
+    backend = task_backend if task_backend is not None else InMemoryTaskBackend()
     app.dependency_overrides[get_run_registry] = lambda: registry
+    app.dependency_overrides[get_task_backend] = lambda: backend
     client = TestClient(app, raise_server_exceptions=False)
     return client
 
@@ -63,23 +69,27 @@ def _restore_overrides() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_get_task_returns_public_dict_for_existing_run() -> None:
-    """Tier 2: GET /a2a/tasks/{run_id} returns 200 with RunEntry.to_public_dict()
-    shape when the run exists in the registry."""
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-abc")
-    client = _make_client_with_registry(registry)
+def test_get_task_returns_a2a_envelope_from_task_backend() -> None:
+    """Tier 2 (#1953 slice 5a): GET /a2a/tasks/{task_id} returns 200 with the spec
+    A2A Task envelope read from the Task backend (Task-vocab state)."""
+    import asyncio
+
+    from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+    backend = InMemoryTaskBackend()
+    asyncio.get_event_loop().run_until_complete(
+        backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-7",
+                            requester="r", status=TaskState.IN_PROGRESS)))
+    client = _make_client_with_registry(RunRegistry(), task_backend=backend)
     try:
-        r = client.get(f"/a2a/tasks/{entry.run_id}")
+        r = client.get("/a2a/tasks/t-1")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["run_id"] == entry.run_id
-        assert body["agent_name"] == "demo"
-        assert body["chain_id"] == "chain-abc"
-        assert body["status"] == "running"
-        # to_public_dict must not leak internal-only fields.
-        assert "task" not in body
-        assert "pending_intervention" not in body
+        assert body["kind"] == "task"
+        assert body["id"] == "t-1"
+        assert body["status"]["state"] == "working"  # in_progress → working
+        assert body["contextId"] == "ctx-7"
+        assert "run_id" not in body
     finally:
         _restore_overrides()
 
@@ -106,29 +116,31 @@ def test_get_task_returns_404_for_unknown_run() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cancel_task_marks_entry_as_cancelled() -> None:
-    """Tier 2: POST /a2a/tasks/{run_id}/cancel cancels a running task.
+def test_cancel_task_aborts_task_in_backend() -> None:
+    """Tier 2 (#1953 slice 5a): POST /a2a/tasks/{task_id}/cancel = the external
+    requester's remove-op → task.abort (cooperative-terminal → archived). The
+    response is the archived Task's A2A envelope (status=canceled)."""
+    import asyncio
 
-    Verifies that cancel() transitions entry.status to 'cancelled' and
-    the response carries the updated public dict. The entry is created
-    without an asyncio.Task (= no active coroutine needed to test the
-    status-update path; RunRegistry.cancel handles None-task gracefully).
-    """
-    registry = RunRegistry()
-    entry = registry.create(agent_name="demo", chain_id="chain-cancel")
+    from reyn.task import InMemoryTaskBackend, Task, TaskState
 
-    client = _make_client_with_registry(registry)
+    backend = InMemoryTaskBackend()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(
+        backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-1",
+                            requester="r", status=TaskState.IN_PROGRESS)))
+    client = _make_client_with_registry(RunRegistry(), task_backend=backend)
     try:
-        r = client.post(f"/a2a/tasks/{entry.run_id}/cancel")
+        r = client.post("/a2a/tasks/t-1/cancel")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["status"] == "cancelled"
-        assert body["run_id"] == entry.run_id
+        assert body["kind"] == "task"
+        assert body["id"] == "t-1"
+        assert body["status"]["state"] == "canceled"  # archived → canceled
 
-        # Registry entry status also updated.
-        refreshed = registry.get(entry.run_id)
-        assert refreshed is not None
-        assert refreshed.status == "cancelled"
+        # backend task is archived (the abort terminal).
+        refreshed = loop.run_until_complete(backend.get("t-1"))
+        assert refreshed is not None and refreshed.status is TaskState.ARCHIVED
     finally:
         _restore_overrides()
 
@@ -249,11 +261,13 @@ def test_agent_card_shows_streaming_and_push_notifications_true(tmp_path) -> Non
     )
     registry.create("demo", role="demo agent")
 
-    from reyn.interfaces.web.deps import get_run_registry  # noqa: PLC0415
+    from reyn.interfaces.web.deps import get_run_registry, get_task_backend  # noqa: PLC0415
+    from reyn.task import InMemoryTaskBackend  # noqa: PLC0415
 
     run_registry = RunRegistry()
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
     client = TestClient(app, raise_server_exceptions=False)
     try:
         r = client.get("/a2a/agents/demo/.well-known/agent-card.json")
@@ -353,8 +367,11 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
         session._interventions._active[iv.id] = iv
         session._interventions._order.append(iv.id)
 
+        from reyn.interfaces.web.deps import get_task_backend  # noqa: PLC0415
+        from reyn.task import InMemoryTaskBackend  # noqa: PLC0415
         app.dependency_overrides[get_registry] = lambda: registry
         app.dependency_overrides[get_run_registry] = lambda: run_registry
+        app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
         client = TestClient(app, raise_server_exceptions=False)
         try:
             r = client.post(
@@ -397,12 +414,13 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
     from fastapi.testclient import TestClient
 
     from reyn.core.events.state_log import StateLog
-    from reyn.interfaces.web.deps import get_registry, get_run_registry
+    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
     from reyn.interfaces.web.server import app
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
+    from reyn.task import InMemoryTaskBackend
 
     state_log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
 
@@ -430,6 +448,7 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
 
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
     client = TestClient(app, raise_server_exceptions=False)
     try:
         r = client.post(

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -310,9 +310,10 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
 
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_registry, get_run_registry
+    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
+    from reyn.task import InMemoryTaskBackend
 
     registry = _build_registry_for_test(tmp_path)
     # FP-0009 B: RunRegistry now lives in the FastAPI lifespan startup.
@@ -321,6 +322,7 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     run_registry = RunRegistry()
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
     client = TestClient(app, raise_server_exceptions=False)
 
     try:
@@ -351,43 +353,40 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
-def test_get_task_returns_run_entry(tmp_path, monkeypatch):
-    """Tier 2c: GET /a2a/tasks/{run_id} returns the RunEntry public dict.
+def test_get_task_returns_a2a_envelope_from_task_backend(tmp_path, monkeypatch):
+    """Tier 2c (#1953 slice 5a): GET /a2a/tasks/{task_id} returns the spec A2A
+    Task envelope read from the Task backend (Task-vocab state). A blocked Task
+    surfaces as input-required (interim — slice 7 splits the block-reason)."""
+    import asyncio
 
-    Pre-populates RunRegistry with a known entry so the test exercises the
-    polling endpoint contract without needing a live async task running.
-    Requires F4 router extensions.  Skipped otherwise.
-    """
     monkeypatch.chdir(tmp_path)
 
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_registry, get_run_registry
+    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
+    from reyn.task import InMemoryTaskBackend, Task, TaskState
 
     registry = _build_registry_for_test(tmp_path)
-
-    # Pre-populate RunRegistry with a known entry so we can exercise
-    # GET /a2a/tasks/{run_id} without needing a live async task.
-    # issue #292 (α): ``question`` is removed from the public dict —
-    # iv prompt text is exposed via the SSE stream / webhook payload
-    # (= history_events buffer), not via the GET-task endpoint.
-    run_registry = RunRegistry()
-    entry = run_registry.create(agent_name="default", chain_id="test-chain")
-    run_registry.update(entry.run_id, status="input-required")
+    backend = InMemoryTaskBackend()
+    asyncio.new_event_loop().run_until_complete(
+        backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-9",
+                            requester="r", status=TaskState.BLOCKED)))
 
     app.dependency_overrides[get_registry] = lambda: registry
-    app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_run_registry] = lambda: RunRegistry()
+    app.dependency_overrides[get_task_backend] = lambda: backend
     client = TestClient(app, raise_server_exceptions=False)
 
     try:
-        r = client.get(f"/a2a/tasks/{entry.run_id}")
+        r = client.get("/a2a/tasks/t-1")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert body["run_id"] == entry.run_id
-        assert body["status"] == "input-required"
-        assert "question" not in body  # α: field removed
-        assert body["agent_name"] == "default"
+        assert body["kind"] == "task"
+        assert body["id"] == "t-1"
+        assert body["status"]["state"] == "input-required"  # blocked (interim)
+        assert body["contextId"] == "ctx-9"
+        assert "question" not in body
     finally:
         app.dependency_overrides.clear()

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -354,7 +354,7 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
 def test_get_task_returns_a2a_envelope_from_task_backend(tmp_path, monkeypatch):
-    """Tier 2c (#1953 slice 5a): GET /a2a/tasks/{task_id} returns the spec A2A
+    """Tier 2c: (#1953 slice 5a) GET /a2a/tasks/{task_id} returns the spec A2A
     Task envelope read from the Task backend (Task-vocab state). A blocked Task
     surfaces as input-required (interim — slice 7 splits the block-reason)."""
     import asyncio

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -95,14 +95,16 @@ def _client_with_registry(tmp_path: Path, agents: list[tuple[str, str]]):
     """
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_registry, get_run_registry
+    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
+    from reyn.task import InMemoryTaskBackend
 
     registry = _build_registry(tmp_path, agents)
     run_registry = RunRegistry()
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
     client = TestClient(app, raise_server_exceptions=False)
     return client, registry
 


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 5 (A2A consume), **part 5a-1: the read/cancel surface + status-map** (proposing a 5a-1/5a-2 split — the disposition-sweep is 5a-2; see below). Design-check-first seam-map was lead-reviewed (4 Qs resolved).

## What
- **Task→A2A view** (`a2a_task_view.py`): the term-neutral status-map + `to_a2a_task` envelope, rebuilt on the settled Task lifecycle vocab (replaces the closed #1948 RunEntry-based mapping). status-map covers every Task state (completeness-tested); `contextId` from the assignee session_id via the #1814 reverse map.
- **Re-point GetTask / ListTasks / Cancel** to read `app.state.task_backend` (single store; `get_task_backend` Depends; server-startup wiring). Cancel = `task.abort` (cooperative-terminal → archived → A2A `canceled`). Pagination adapted for Task (`created_at` + `task_id`).
- The closed #1948's gap (Task-vocab GetTask/ListTasks/Cancel) is now closed; #1947's ListTasks is re-pointed to the Task backend.

## ⚠ status-map note (H3, slice 7)
`blocked → input-required` is an **interim placeholder** (slice 5 surfaces no blocked tasks). The **precise split lands in slice 7** with the block-reason discriminator: DAG-dependency blocks → `working` (telling a client `input-required` would be a lie), only external-input/auth → `input-required` / `auth-required`.

## Proposed split
- **5a-1 (this)**: read/cancel surface + status-map. Complete + green.
- **5a-2 (next)**: the **disposition-sweep** — backend-derived (newly-aborted `origin=external` → `post_webhook` + a `disposition_notified` flag) + the A2A-layer contextId→webhook_url map. It's a separable async feature with its own surface (per your Q1/Q2 decisions), so I split it for reviewability + to land 5a-1 now.

## Test plan
- [x] `test_a2a_task_view_1953.py` (4): status-map completeness + drift guard + envelope.
- [x] All A2A surface tests re-pointed to the Task backend (GetTask/ListTasks/Cancel/answer-injection across `fp0001` / `test_a2a_list_tasks` / `tests/web/test_a2a` / `fp0001_e2e`); every a2a_jsonrpc TestClient now sets `app.state.task_backend`.
- [x] Broad a2a/web/server sweep: 575 passed (only the 2 known not-my-diff env-quirks remain). ruff + `scripts/test_tier_audit.py --strict` clean. Full rootdir suite verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)