### PR TITLE
docs(readme): breadth diagram v2 — human-direct lane, FastAPI substrate, in-turn hooks (proposed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ flowchart LR
     end
     HUMAN -- submit_user_text --> Ax
     INBOX --> FLEET
-    HOOK["In-turn hooks<br/>(proposed)"] -. intercept running turn .-> Ax
+    HOOK["In-turn intervention hooks<br/>(proposed)"] -. block / rewrite running turn .-> Ax
     Ax <-. "delegate · topology-gated<br/>network / team / pipeline · chain_id" .-> Ay
     classDef pr stroke-dasharray:5 4;
     class HOOK pr;

--- a/README.md
+++ b/README.md
@@ -125,33 +125,35 @@ The diagram above is the **depth** view — one agent's execution. The **breadth
 
 ```mermaid
 flowchart LR
-    subgraph L1["External connection — outside calls in"]
+    HUMAN["Human (direct)<br/>TUI · Web UI"]
+    subgraph EXT["External connection — outside calls in"]
       direction TB
       MCP["MCP server<br/>AI clients"]
       A2A["A2A server<br/>peer agents"]
       GW["Gateway<br/>Slack / LINE webhooks"]
     end
-    subgraph L2["Internal trigger — Reyn raises a turn"]
-      direction TB
-      CRON["cron<br/>scheduled jobs"]
-    end
+    INT["Internal trigger<br/>cron"]
     INBOX(["agent inbox<br/>send_to_agent"])
-    L1 --> INBOX
-    L2 --> INBOX
+    EXT --> INBOX
+    INT --> INBOX
     subgraph FLEET["Agent fleet"]
       direction TB
       REG[("AgentRegistry<br/>multi-agent")]
-      Ax["Agent A<br/>identity · agent_id"]
+      Ax["Agent A · agent_id"]
       Ay["Agent B"]
       Ax --- SAx["Sessions<br/>multi-session"]
       REG --> Ax
       REG --> Ay
     end
+    HUMAN -- submit_user_text --> Ax
     INBOX --> FLEET
-    Ax <-. "delegate_to_agent · topology-gated<br/>network / team / pipeline · chain_id" .-> Ay
+    HOOK["In-turn hooks<br/>(proposed)"] -. intercept running turn .-> Ax
+    Ax <-. "delegate · topology-gated<br/>network / team / pipeline · chain_id" .-> Ay
+    classDef pr stroke-dasharray:5 4;
+    class HOOK pr;
 ```
 
-- **Reached** — three trigger layers converge on the agent inbox: *external connection* (MCP server · A2A server · gateway webhooks like Slack / LINE), *internal trigger* (`cron`), and *in-turn intervention* (lifecycle hooks — proposed). See [interaction layers](docs/concepts/architecture/interaction-layers.md).
+- **Reached two ways** — *humans drive a session directly* (TUI / browser Web UI → `submit_user_text`), while *systems and schedules inject into an agent's inbox*: external connection (MCP server · A2A server · gateway webhooks like Slack / LINE) and internal trigger (`cron`). An *in-turn hook* layer can intercept a running turn (proposed). The HTTP surfaces — A2A, MCP-over-SSE, gateway webhooks, and the browser Web UI — are all served by the one `reyn web` (FastAPI) gateway. See [interaction layers](docs/concepts/architecture/interaction-layers.md).
 - **Related** — an `AgentRegistry` holds many *Agents* (each an identity), each with many parallel *Sessions*; agents delegate to peers under a *topology* (network / team / pipeline), hop-capped and `chain_id`-traced. See [multi-agent](docs/concepts/multi-agent/multi-agent.md) · [sessions](docs/concepts/multi-agent/sessions.md).
 
 Details: [architecture](docs/concepts/architecture/architecture.md) · [principles](docs/concepts/architecture/principles.md).

--- a/docs/concepts/architecture/interaction-layers.md
+++ b/docs/concepts/architecture/interaction-layers.md
@@ -19,6 +19,12 @@ All three layers ultimately converge on the same primitive — a message placed 
 an **agent's inbox** (the `send_to_agent_impl` path). They differ only in *who
 initiates* and *when*.
 
+> **Distinct from these: the direct operator surface.** The interactive TUI
+> (`reyn chat`) and the browser Web UI drive a session **directly** via
+> `Session.submit_user_text`, not through the inbox. They are the human operator's
+> own surface — the baseline these three trigger layers complement — so they are
+> not counted among the inbox-converging layers below.
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  1. External connection  (outside → Reyn; Reyn is a server)  │


### PR DESCRIPTION
**[docs-maintainer]** — owner-requested enrichment of the README breadth (actor) diagram added in #1970.

## What

- **Human-direct lane** added: the interactive TUI and browser Web UI drive a session **directly** via `Session.submit_user_text` — *not* the inbox. The diagram now shows two paths: direct session drive (humans) vs inbox injection (systems + schedules: MCP / A2A / gateway webhooks / cron).
- **FastAPI = substrate, not a connection**: a bullet notes the HTTP surfaces (A2A, MCP-over-SSE, gateway webhooks, browser Web UI) all share the one `reyn web` (FastAPI) gateway.
- **In-turn hooks** added as a dashed, **(proposed)** node intercepting a running turn.
- `interaction-layers.md`: one-sentence note so the concept doc agrees — TUI / Web UI are the direct operator surface, distinct from the three inbox-converging trigger layers.

## Primary-source verification (owner asked me to confirm)

- **TUI uses `submit_user_text`, not the inbox** — `interfaces/tui/app.py:1172` (+ `ws_client.py` mirrors it for Web UI). `send_to_agent_impl` (inbox) is used by MCP / A2A / gateway webhooks / cron / run-once.
- **Hooks are genuinely proposed (not implemented)** — grepped the whole `src/reyn/`: no `pre_tool_call` / `post_tool_call` / `transform_tool_result` / `pre_llm_call` / `transform_llm_output` dispatch anywhere; `dispatcher.py` has no hook/lifecycle dispatch. The only "hook" hits are unrelated (WAL-truncate callback, SSRF httpx hook, test hooks). So the `(proposed)` marking is accurate.

## Test plan

- [x] breadth mermaid render verified locally via `mmdc` (two paths + hooks dashed node render cleanly; no special-char breakage)
- [x] `mkdocs build --strict` green (interaction-layers.md is in the build)
- [x] No history refs (the earlier grep hit was a `#888` CSS colour in mermaid styling — removed; now clean)
- [x] All links resolve
- [ ] (reviewer) glance at the GitHub-rendered breadth diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)