### PR TITLE
feat(#1953): slice 5a-2 — A2A disposition sweep (backend-derived webhook notify)

### DIFF
--- a/src/reyn/interfaces/web/a2a_webhook_registry.py
+++ b/src/reyn/interfaces/web/a2a_webhook_registry.py
@@ -1,0 +1,128 @@
+"""A2A-owned webhook registry for Task disposition notify (#1953 slice 5a-2).
+
+P7: ``webhook_url`` is A2A vocabulary, so it is kept here in the A2A layer — NOT
+on the core Task model (which stays term-neutral). Holds two things, both
+persisted (so a server restart neither loses a pending disposition webhook nor
+re-fires a delivered one), mirroring ``RunRegistry``'s persist-path pattern:
+
+  - ``contextId → webhook_url`` — the external requester's push channel, populated
+    when an A2A client creates a task with a ``webhook_url`` (the production
+    populator lands in slice 5b; until then this is seeded directly in tests).
+  - the **notified** ``task_id`` set — which dispositions have already been
+    pushed, so the periodic sweep does not re-fire (idempotence across restarts).
+
+The notified set is kept **bounded by construction**: every sweep calls
+:meth:`reconcile_notified` to intersect it with the still-present (archived) task
+ids, self-pruning any that have been hard-deleted (no slice-9 coupling).
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+class A2AWebhookRegistry:
+    """Persistent A2A-owned map (contextId → webhook_url) + notified task-id set."""
+
+    def __init__(self, *, persist_path: "Path | None" = None) -> None:
+        self._webhooks: dict[str, str] = {}
+        self._notified: set[str] = set()
+        self._persist_path = persist_path
+        if persist_path is not None and persist_path.exists():
+            self._restore_from(persist_path)
+
+    # ── webhook channel map ─────────────────────────────────────────────────
+
+    def register_webhook(self, context_id: str, webhook_url: str) -> None:
+        """Record the external requester's webhook channel for a contextId."""
+        self._webhooks[context_id] = webhook_url
+        self._persist()
+
+    def webhook_for(self, context_id: str) -> "str | None":
+        return self._webhooks.get(context_id)
+
+    # ── notified set (idempotence) ──────────────────────────────────────────
+
+    def is_notified(self, task_id: str) -> bool:
+        return task_id in self._notified
+
+    def mark_notified(self, task_id: str) -> None:
+        self._notified.add(task_id)
+        self._persist()
+
+    def reconcile_notified(self, present_task_ids: "set[str]") -> None:
+        """Prune the notified set to ids still present (archived) in the backend —
+        self-pruning hard-deleted tasks so the set is bounded by construction."""
+        pruned = self._notified & present_task_ids
+        if pruned != self._notified:
+            self._notified = pruned
+            self._persist()
+
+    # ── persistence (RunRegistry pattern: atomic JSON rewrite per mutation) ──
+
+    def _persist(self) -> None:
+        if self._persist_path is None:
+            return
+        self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"webhooks": self._webhooks, "notified": sorted(self._notified)}
+        fd, tmp = tempfile.mkstemp(dir=str(self._persist_path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp, str(self._persist_path))
+        except Exception:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+
+    def _restore_from(self, path: "Path") -> None:
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            return
+        self._webhooks = dict(data.get("webhooks") or {})
+        self._notified = set(data.get("notified") or [])
+
+
+async def sweep_dispositions(task_backend, registry: A2AWebhookRegistry, *, post_fn=None) -> int:
+    """One disposition-sweep pass (#1953 slice 5a-2). Notify the external requester
+    of every archived ``origin=external`` Task not yet notified, via its webhook;
+    returns the count of webhooks fired.
+
+    Backend-derived: the ``archived`` state is the single **cross-process** source
+    of truth that *every* abort path reifies (the agent op-handler, the A2A
+    ``cancel_task`` web endpoint, and the DOWN-cascade) — so this catches them all,
+    fires regardless of inbound A2A traffic (§24 forward-progress), and self-heals
+    across restarts (a missed webhook is caught on the next sweep; a failed POST
+    leaves the task un-notified → retried next sweep, bounded by §24 hard-delete).
+    """
+    from reyn.interfaces.web.notifications import post_webhook
+    from reyn.runtime.a2a_routing import a2a_context_id
+    from reyn.task.model import TaskOrigin
+
+    # ``post_fn`` is the (injectable) webhook poster — the real ``post_webhook`` in
+    # production; tests inject a real recording callable (no mocks).
+    post = post_fn if post_fn is not None else post_webhook
+
+    archived = await task_backend.list(status="archived")
+    external = [t for t in archived if t.origin == TaskOrigin.EXTERNAL]
+    registry.reconcile_notified({t.task_id for t in external})
+
+    fired = 0
+    for t in external:
+        if registry.is_notified(t.task_id):
+            continue
+        context_id = a2a_context_id(t.assignee)
+        url = registry.webhook_for(context_id)
+        if url is None:
+            continue  # no webhook channel registered for this context (e.g. pre-5b)
+        result = await post(
+            url,
+            {"task_id": t.task_id, "contextId": context_id, "disposition": "aborted"},
+        )
+        if getattr(result, "ok", False):
+            registry.mark_notified(t.task_id)
+            fired += 1
+    return fired

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -137,6 +137,11 @@ def _make_cron_runner():
     )
 
 
+# #1953 slice 5a-2: how often the disposition sweep runs (wall-clock interval;
+# decoupled from inbound A2A traffic for §24 forward-progress).
+_DISPOSITION_SWEEP_INTERVAL_SECONDS = 30.0
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
     # ── Startup ──
@@ -162,6 +167,34 @@ async def _lifespan(app: FastAPI):
     from reyn.task import create_task_backend  # noqa: PLC0415
     task_db_path = Path(".reyn") / "state" / "tasks.db"
     app.state.task_backend = create_task_backend("sqlite", path=str(task_db_path))
+
+    # #1953 slice 5a-2: A2A-owned webhook registry (P7 — webhook_url stays out of
+    # the core Task model) + a periodic disposition sweep. The sweep is
+    # backend-derived + decoupled from inbound traffic (§24 forward-progress) and
+    # runs as a lifespan-owned asyncio task (mirrors the cron_scheduler lifecycle).
+    import asyncio  # noqa: PLC0415
+
+    from reyn.interfaces.web.a2a_webhook_registry import (  # noqa: PLC0415
+        A2AWebhookRegistry,
+        sweep_dispositions,
+    )
+    app.state.a2a_webhook_registry = A2AWebhookRegistry(
+        persist_path=Path(".reyn") / "state" / "a2a_webhooks.json"
+    )
+
+    async def _disposition_sweep_loop() -> None:
+        while True:
+            try:
+                await sweep_dispositions(
+                    app.state.task_backend, app.state.a2a_webhook_registry
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — a sweep error must not kill the loop
+                logger.warning("disposition sweep pass failed: %s", exc)
+            await asyncio.sleep(_DISPOSITION_SWEEP_INTERVAL_SECONDS)
+
+    app.state.disposition_sweep_task = asyncio.create_task(_disposition_sweep_loop())
 
     # FP-0009 B: cron scheduler — start only if reyn.yaml has any enabled
     # cron jobs.  Failures are caught so a misconfigured cron block does
@@ -205,6 +238,16 @@ async def _lifespan(app: FastAPI):
     yield  # ── App runs ──
 
     # ── Shutdown ──
+    # #1953 slice 5a-2: cancel the disposition sweep loop (no leak — await it so
+    # the cancellation propagates before the process exits).
+    sweep_task = getattr(app.state, "disposition_sweep_task", None)
+    if sweep_task is not None:
+        sweep_task.cancel()
+        try:
+            await sweep_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — defensive shutdown
+            pass
+
     sched = getattr(app.state, "cron_scheduler", None)
     if sched is not None:
         try:

--- a/tests/test_a2a_disposition_sweep_1953.py
+++ b/tests/test_a2a_disposition_sweep_1953.py
@@ -1,0 +1,146 @@
+"""Tier 2: #1953 slice 5a-2 — A2A disposition sweep (backend-derived webhook).
+
+The periodic sweep notifies the external requester of every archived
+``origin=external`` Task via its registered webhook, exactly once, retrying
+failures, bounded by construction. Real Task backend + a real recording poster
+(no mocks). The webhook channel map is A2A-owned (P7 — never on the Task).
+
+Falsification:
+- (a) an archived external task with a registered webhook → fires once;
+- (b) an archived self-origin task → never fires;
+- (c) a second sweep pass → no re-fire (notified-set);
+- (d) a failed POST → not notified → retried next sweep;
+- (e) the notified-set self-prunes hard-deleted task_ids (bounded);
+- (f) the registry persists the map + notified-set across a reload.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.interfaces.web.a2a_webhook_registry import (
+    A2AWebhookRegistry,
+    sweep_dispositions,
+)
+from reyn.runtime.a2a_routing import a2a_session_id
+from reyn.task import InMemoryTaskBackend, Task, TaskOrigin, TaskState
+
+
+class _RecordingPoster:
+    """A real injectable webhook poster (not a mock) that records calls."""
+
+    def __init__(self, ok: bool = True) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._ok = ok
+
+    async def __call__(self, url: str, payload: dict):
+        self.calls.append((url, payload))
+        return SimpleNamespace(ok=self._ok)
+
+
+async def _archived(backend, task_id, ctx, origin):
+    """Seed an archived task assigned to the context's session."""
+    await backend.create(Task(task_id=task_id, name="n", assignee=a2a_session_id(ctx),
+                              requester="ext", origin=origin, status=TaskState.ARCHIVED))
+
+
+@pytest.mark.asyncio
+async def test_sweep_fires_for_external_and_not_for_self():
+    """Tier 2: an archived external task with a registered webhook fires (a);
+    an archived self-origin task never fires (b)."""
+    backend = InMemoryTaskBackend()
+    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _archived(backend, "self-1", "ctx-b", TaskOrigin.SELF)
+    reg = A2AWebhookRegistry()
+    reg.register_webhook("ctx-a", "https://client.example/hook")
+    reg.register_webhook("ctx-b", "https://client.example/hook")  # self still excluded
+    poster = _RecordingPoster()
+
+    fired = await sweep_dispositions(backend, reg, post_fn=poster)
+
+    # RED if origin filter drops (self would fire) or the external one is missed.
+    assert fired == 1
+    assert [c[1]["task_id"] for c in poster.calls] == ["ext-1"]
+    assert poster.calls[0][0] == "https://client.example/hook"
+    assert poster.calls[0][1]["contextId"] == "ctx-a"
+    assert reg.is_notified("ext-1") and not reg.is_notified("self-1")
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_refire_on_second_pass():
+    """Tier 2: (c): a notified task is not re-fired on the next sweep."""
+    backend = InMemoryTaskBackend()
+    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    reg = A2AWebhookRegistry()
+    reg.register_webhook("ctx-a", "https://client.example/hook")
+    poster = _RecordingPoster()
+
+    await sweep_dispositions(backend, reg, post_fn=poster)
+    await sweep_dispositions(backend, reg, post_fn=poster)
+
+    # RED if the notified-set is dropped: the task would re-fire (the list would
+    # carry "ext-1" twice).
+    assert [c[1]["task_id"] for c in poster.calls] == ["ext-1"]
+
+
+@pytest.mark.asyncio
+async def test_sweep_retries_failed_post():
+    """Tier 2: (d): a failed POST leaves the task un-notified → retried next sweep
+    (§24 forward-progress with retry)."""
+    backend = InMemoryTaskBackend()
+    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    reg = A2AWebhookRegistry()
+    reg.register_webhook("ctx-a", "https://client.example/hook")
+
+    failing = _RecordingPoster(ok=False)
+    await sweep_dispositions(backend, reg, post_fn=failing)
+    assert not reg.is_notified("ext-1")  # not marked on failure
+
+    ok_poster = _RecordingPoster(ok=True)
+    await sweep_dispositions(backend, reg, post_fn=ok_poster)
+    assert ok_poster.calls and reg.is_notified("ext-1")  # retried + succeeded
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_context_without_registered_webhook():
+    """Tier 2: an external task whose context has no webhook (e.g. pre-5b) is
+    skipped (no channel) — no crash, no notify."""
+    backend = InMemoryTaskBackend()
+    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    reg = A2AWebhookRegistry()  # no webhook registered
+    poster = _RecordingPoster()
+
+    fired = await sweep_dispositions(backend, reg, post_fn=poster)
+    assert fired == 0 and poster.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_prunes_hard_deleted_notified():
+    """Tier 2: (e): the notified-set self-prunes a task_id no longer present
+    (hard-deleted) — bounded by construction."""
+    backend = InMemoryTaskBackend()
+    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    reg = A2AWebhookRegistry()
+    reg.register_webhook("ctx-a", "https://client.example/hook")
+    reg.mark_notified("gone-task")  # a task no longer in the backend
+    reg.mark_notified("ext-1")
+
+    await sweep_dispositions(backend, reg, post_fn=_RecordingPoster())
+
+    # RED if reconcile is dropped: the notified-set grows unbounded with stale ids.
+    assert not reg.is_notified("gone-task")
+    assert reg.is_notified("ext-1")  # still present → kept
+
+
+def test_registry_persists_map_and_notified_across_reload(tmp_path):
+    """Tier 2: (f): the contextId→webhook map + notified-set survive a reload (so
+    a server restart neither loses a pending webhook nor re-fires a delivered one)."""
+    path = tmp_path / "state" / "a2a_webhooks.json"
+    reg = A2AWebhookRegistry(persist_path=path)
+    reg.register_webhook("ctx-a", "https://client.example/hook")
+    reg.mark_notified("ext-1")
+
+    reloaded = A2AWebhookRegistry(persist_path=path)
+    assert reloaded.webhook_for("ctx-a") == "https://client.example/hook"
+    assert reloaded.is_notified("ext-1")


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 5 (A2A consume), **part 5a-2: the disposition-sweep** — the final piece (external-requester UP-notify). Seam-map v2 was lead-reviewed (the event-driven candidate was rejected after the trigger comparison).

## What
- **`A2AWebhookRegistry`** (P7-clean): an A2A-owned **persistent** store — `contextId → webhook_url` map + the **notified** task-id set — mirroring RunRegistry's persist-path pattern. `webhook_url` is A2A vocabulary, so it stays here, **never on the core Task model**.
- **`sweep_dispositions`**: one **backend-derived** pass — `list(status=archived)` ∩ `origin=external`, reconcile the notified-set to present ids (self-pruning hard-deleted → **bounded by construction**), `post_webhook` to the context's channel for un-notified tasks, mark notified on success. A failed POST stays un-notified → **retried next sweep** (§24 forward-progress with retry; bounded by §24 hard-delete — no magic retry-cap).
- **`_lifespan`**: a periodic asyncio sweep loop (30s), started on startup + **cancelled-and-awaited on shutdown (no leak)**, mirroring the cron_scheduler lifecycle.

## Why backend-derived (the trigger comparison)
Disposition is **cross-process** — a task is aborted by the requester session OR by the A2A `cancel_task` web endpoint (a separate process). The only reliable cross-session/cross-process source of truth is the **sqlite Task backend's `archived` state**, which *every* abort path reifies (op-handler / A2A-cancel / DOWN-cascade / H4 external sub-tasks). The event-driven alternative was rejected: events.py has **no global bus** (per-session EventLogs), and the A2A `cancel_task` endpoint calls `backend.abort()` directly → emits **no** `task_disposition` P6 event → would silently miss every A2A-cancelled task. Periodic backend-poll is complete + decoupled from inbound traffic (§24) + restart-self-healing.

## ⚠ Integration boundary (no production populator until 5b)
The `contextId → webhook_url` map has **no production populator yet** — it is populated at A2A create-with-webhook (`message/send → task.create`), which is **slice 5b**. (message/send carries both today, but it creates a RunEntry, not a Task — so a 5a-2 populate would be inert.) So 5a-2 is **test-seeded only**: the sweep + store + post_webhook are proven here; the real `create → populate → sweep → webhook-fired` e2e lands in 5b (next, immediately).

## Test plan
- [x] `tests/test_a2a_disposition_sweep_1953.py` (6, Tier 2, real backend + real recording poster, **no mocks**): external archived fires once; **self-origin never fires** (falsification CLEAN RED — defeating the origin filter reds it); **no re-fire** on a second pass; **failed POST retried**; **notified-set self-prunes** hard-deleted ids; map + notified-set **persist across reload**.
- [x] web/server/a2a sweep green (548 passed; only the 2 known not-my-diff quirks). ruff + `scripts/test_tier_audit.py --strict` clean. Full rootdir suite verifying.

This completes the **slice-5 A2A consume** surface (read/cancel in 5a-1 + this disposition-notify); **5b** (message/send → task.create create-side, with the populate wire + real e2e) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)