### PR TITLE
fix(tui): tool-call + stream row id collision (#1971 class completeness)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
+++ b/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
@@ -129,7 +129,11 @@ class _InlineRowManager:
             tool_name=tool_name,
             args_repr=args_repr,
             label_prefix=label_prefix,
-            id=f"toolcall_{op_id[:8]}",
+            # Same id-collision class as the skillrow fix (#1971): the row is
+            # deduped by the FULL op_id above, but ``op_id[:8]`` truncated the
+            # widget id, so two distinct op_ids sharing an 8-char prefix
+            # collided → DuplicateIds. Key on the full sanitized op_id.
+            id=f"toolcall_{re.sub(r'[^A-Za-z0-9_-]', '_', op_id)}",
         )
         self._tool_call_rows[op_id] = row
         self._parent.mount(row)

--- a/src/reyn/interfaces/tui/widgets/conversation.py
+++ b/src/reyn/interfaces/tui/widgets/conversation.py
@@ -1537,7 +1537,11 @@ class _StreamController:
         self._parent._renderer.set_speaker("reyn", time.time())
         row = StreamingRow(
             prefix="",
-            id=f"stream_{msg_id[:8]}",
+            # Same id-collision class as the skillrow fix (#1971): deduped by
+            # the FULL msg_id below, but ``msg_id[:8]`` truncated the widget id
+            # so two msg_ids sharing an 8-char prefix would collide →
+            # DuplicateIds. Key on the full sanitized msg_id.
+            id=f"stream_{re.sub(r'[^A-Za-z0-9_-]', '_', msg_id)}",
             indent=self._parent._current_body_indent(),
         )
         self._stream_rows[msg_id] = row

--- a/tests/cli/test_tui_inline_row_id_collision.py
+++ b/tests/cli/test_tui_inline_row_id_collision.py
@@ -1,0 +1,85 @@
+"""Tier 2: tool-call + streaming row widget IDs survive an 8-char-prefix clash.
+
+Sibling class of the skillrow DuplicateIds fix (#1971). Both rows are deduped by
+their FULL correlation id (op_id = args_hash for tool calls; msg_id for streams),
+but the widget id was built from ``id[:8]`` — so two distinct ids sharing an
+8-char prefix collapsed to one widget id and the second mount raised Textual
+``DuplicateIds`` (swallowed → the row vanished). The widget id must track the
+full (sanitized) correlation id.
+
+Unlike the skillrow case (run_id[:8] = the date = a DETERMINISTIC clash), these
+prefixes are hashes/ids so a real-world clash is birthday-rare — but it is the
+same latent class and the full-id fix makes it collision-proof. The tests force
+the clash to pin the invariant.
+
+Public surface only: the mounted row widgets in the DOM and their ``id``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_tool_call_rows_prefix_clash_both_mount() -> None:
+    """Tier 2: two op_ids sharing an 8-char prefix mount two distinct tool rows."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.interfaces.tui.widgets.tool_call_row import ToolCallRow
+
+    # Share the first 8 chars, differ after → id[:8] collides pre-fix.
+    op1 = "aabbccdd0001"
+    op2 = "aabbccdd0002"
+    assert op1[:8] == op2[:8] and op1 != op2, "clash precondition broken"
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv.start_tool_call_row(op1, "file__read")
+        conv.start_tool_call_row(op2, "file__write")
+        await pilot.pause()
+
+        rows = list(conv.query(ToolCallRow))
+        row_count = len(rows)
+        assert row_count == 2, f"both tool calls should mount a row; got {row_count}"
+        ids = [r.id for r in rows]
+        assert ids[0] != ids[1], (
+            f"tool-call widget ids must be distinct per op_id; got {ids!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_rows_prefix_clash_both_mount() -> None:
+    """Tier 2: two msg_ids sharing an 8-char prefix mount two distinct stream rows."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.interfaces.tui.widgets.streaming_row import StreamingRow
+
+    msg1 = "streamid0001"
+    msg2 = "streamid0002"
+    assert msg1[:8] == msg2[:8] and msg1 != msg2, "clash precondition broken"
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv.begin_stream(msg1)
+        conv.begin_stream(msg2)
+        await pilot.pause()
+
+        rows = list(conv.query(StreamingRow))
+        row_count = len(rows)
+        assert row_count == 2, f"both streams should mount a row; got {row_count}"
+        ids = [r.id for r in rows]
+        assert ids[0] != ids[1], (
+            f"stream widget ids must be distinct per msg_id; got {ids!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — completeness fix for the DuplicateIds class (#1971 siblings), found by deterministic concurrent-race mining (lead-directed in-lane infra task).

## What

#1971 fixed the **skillrow** widget-id collision (`run_id[:8]` = the date). Systematically reading the inline-row lifecycle handlers (the mining approach) surfaced **two remaining siblings of the same class**:

| site | id scheme | dedup key |
|------|-----------|-----------|
| `start_tool_call_row` (`_inline_row_manager.py`) | `toolcall_{op_id[:8]}` | full `op_id` |
| `begin_stream` (`conversation.py`) | `stream_{msg_id[:8]}` | full `msg_id` |

Both dedup by the **full** correlation id but truncated the **widget id** to 8 chars. Two distinct ids sharing an 8-char prefix → one widget id → second mount raises `DuplicateIds` (swallowed by the trace handler → the row silently vanishes).

## Severity (honest)

Unlike skillrow — where `run_id[:8]` is the **date**, a *deterministic* clash every same day (the bug I hit live) — `op_id` (= `args_hash`) and `msg_id` are hashes/ids, so a real-world 8-char-prefix clash is **birthday-rare**. But it's the same latent class, trivially fixed, and the full-id fix makes both **collision-proof**. Filing for class completeness ([[feedback_completeness_for_gate_routing_fixes]]) — don't leave latent siblings of a fixed crash class.

## Fix

Key the widget id on the full **sanitized** id (same shape as the #1971 skillrow fix) — also handles any non-id chars defensively.

## Test plan

- [x] Falsifying Tier-2 — `tests/cli/test_tui_inline_row_id_collision.py`: two op_ids / two msg_ids sharing an 8-char prefix must each mount a **distinct** row. Verified via `git stash` that **both reproduce `DuplicateIds` on pre-fix code** (`toolcall_aabbccdd`) and pass after.
- [x] Regression — `test_tui_smoke` + `test_skill_row_id_uniqueness` + `test_skill_in_phase_detail` + `test_tool_call_row_flush_indent` = **56/56**.
- [x] Lint / Tier — `ruff` clean; `test_tier_audit.py` **0 errors**.

## Tier self-check

2 new tests, **Tier 2** (widget invariant). Public surface only — mounted row widgets + their `id`; distinctness via `ids[0] != ids[1]` (not a set-size); no private dicts, no format pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
