### PR TITLE
fix(tui): tool-call row in min-display flush window survives clear() (stale-removal race)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
+++ b/src/reyn/interfaces/tui/widgets/_inline_row_manager.py
@@ -32,6 +32,13 @@ class _InlineRowManager:
         self._skill_rows: dict[str, SkillActivityRow] = {}
         self._tool_call_rows: dict[str, ToolCallRow] = {}
         self._last_failed_tool_row: ToolCallRow | None = None
+        # Rows in their min-display flush window: popped from
+        # ``_tool_call_rows`` but still mounted with a pending deferred-flush
+        # timer. Tracked so ``clear()`` can cancel the timer + remove the row
+        # (the dict sweep can't see them — stale-removal hazard, see
+        # feedback_tui_deferred_timer_stale_removal_class). Each entry is
+        # ``(row, timer)``; ``timer`` has a ``stop()`` method.
+        self._pending_flush: list[tuple[ToolCallRow, object]] = []
 
     # ── skill rows ────────────────────────────────────────────────────────────
 
@@ -174,15 +181,23 @@ class _InlineRowManager:
         if elapsed < _TOOL_CALL_MIN_DISPLAY_S:
             delay = _TOOL_CALL_MIN_DISPLAY_S - elapsed
             try:
-                self._parent.app.set_timer(
+                timer = self._parent.app.set_timer(
                     delay, lambda: self._do_flush_tool_call_row(row),
                 )
+                # Track so clear() can cancel + remove this still-mounted row.
+                self._pending_flush.append((row, timer))
                 return
             except Exception:
                 pass
         self._do_flush_tool_call_row(row)
 
     def _do_flush_tool_call_row(self, row: ToolCallRow) -> None:
+        # The deferred flush fired (or we flushed immediately) — drop any
+        # pending-flush tracking for this row so clear() doesn't double-handle.
+        if self._pending_flush:
+            self._pending_flush = [
+                (r, t) for (r, t) in self._pending_flush if r is not row
+            ]
         try:
             line1 = row._build_line1()
             line2 = row._build_line2()
@@ -207,4 +222,19 @@ class _InlineRowManager:
             except Exception:
                 pass
         self._tool_call_rows.clear()
+        # Rows mid-flush are popped from the dict above but still mounted with a
+        # pending timer — invisible to the sweep, the same untracked hazard the
+        # InterventionWidget query-sweep in ConversationView.clear() handles.
+        # Cancel the timer (so it can't write stale lines into the cleared log)
+        # and remove the ghost row.
+        for row, timer in self._pending_flush:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+            try:
+                row.remove()
+            except Exception:
+                pass
+        self._pending_flush.clear()
         self._last_failed_tool_row = None

--- a/tests/cli/test_toolrow_flush_survives_clear.py
+++ b/tests/cli/test_toolrow_flush_survives_clear.py
@@ -1,0 +1,64 @@
+"""Tier 2: a tool-call row in its min-display flush window is removed by clear().
+
+Stale-deferred-removal class (feedback_tui_deferred_timer_stale_removal_class).
+``complete_tool_call_row`` POPS the row from ``_tool_call_rows`` and, if the row
+hasn't met its 0.3s minimum display time, schedules a deferred flush
+(``set_timer``) that later writes the row's lines + removes it.
+
+Bug: during that flush window the row is popped-from-dict but still mounted, so
+``clear()`` (which sweeps the dict + query-sweeps InterventionWidget, but NOT
+tool-call rows) misses it. A Ctrl+L within ~0.3s of a tool completing left a
+ghost tool row mounted AND let the pending timer write stale lines into the
+freshly-cleared log.
+
+Public surface only: the mounted ``ToolCallRow`` widgets in the DOM.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_tool_row_in_flush_window() -> None:
+    """Tier 2: clear() removes a tool-call row still pending its min-display flush.
+
+    Completes a just-mounted tool row (elapsed << 0.3s → a deferred flush is
+    scheduled and the row stays mounted), then clears immediately. No tool-call
+    row may survive the clear.
+    """
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.interfaces.tui.widgets.tool_call_row import ToolCallRow
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        conv.start_tool_call_row("op-flush-1", "file__read")
+        await pilot.pause()
+        # Complete immediately → elapsed << 0.3s → deferred flush scheduled,
+        # row popped from the dict but still mounted.
+        conv.complete_tool_call_row("op-flush-1", result_snippet="done")
+        await pilot.pause()
+        # Sanity: the row is still mounted (pending flush), i.e. the race
+        # window is open.
+        assert list(conv.query(ToolCallRow)), (
+            "precondition: row should still be mounted during the flush window"
+        )
+
+        conv.clear()
+        await pilot.pause()
+
+        survivors = list(conv.query(ToolCallRow))
+        assert not survivors, (
+            "a tool-call row in its min-display flush window survived clear() "
+            f"(ghost row / stale-write race); still mounted: {survivors!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — stale-deferred-removal race found by harness mining (lead-directed in-lane task; the "deferred-timer race" seam).

## Bug

`complete_tool_call_row` / `fail_tool_call_row` / `abort_tool_call_rows` **pop** the row from `_tool_call_rows`, then `_flush_tool_call_row` — if the row hasn't met its 0.3s minimum display time — schedules a deferred flush (`set_timer`) that later writes the row's lines + removes it.

During that flush window the row is **popped-from-dict but still mounted**. `ConversationView.clear()` sweeps the dict (`_row_mgr.clear()`) and query-sweeps `InterventionWidget`, but **not** tool-call rows. So a **Ctrl+L within ~0.3s of a tool completing**:
1. leaves a **ghost tool row** mounted on the otherwise-cleared pane, and
2. lets the pending timer **write stale tool lines into the freshly-cleared log**.

This is the stale-deferred-removal class ([[feedback_tui_deferred_timer_stale_removal_class]]) — the same untracked-after-pop hazard the existing `InterventionWidget` query-sweep in `clear()` was added to handle, just never extended to the mid-flush tool rows.

## Fix

Track `(row, timer)` for rows in their flush window; `clear()` **cancels the timers** (so they can't write stale lines) and **removes the ghost rows**. `_do_flush_tool_call_row` untracks on normal completion. No behavior change to the happy path.

## Test plan

- [x] Falsifying Tier-2 — `tests/cli/test_toolrow_flush_survives_clear.py`: complete a just-mounted tool row (elapsed << 0.3s → flush scheduled, row stays mounted), then `clear()` — no `ToolCallRow` may survive. **Reproduced the ghost row on pre-fix code** (`ToolCallRow(id='toolcall_op-flush')`); passes after.
- [x] Regression — `test_tui_smoke` + `test_tool_call_row_flush_indent` = **45/45**.
- [x] Lint / Tier — `ruff` clean; `test_tier_audit.py` **0 errors**.

## Tier self-check

1 new test, **Tier 2** (widget lifecycle invariant). Public surface only — `conv.query(ToolCallRow)` (mounted DOM widgets); a precondition assert documents the open race window; no private dicts asserted, no format pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
