### PR TITLE
feat(#1953): slice 5b — A2A create path creates the canonical Task

### DIFF
--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -415,6 +415,14 @@ def get_task_backend(request: Request):
     return request.app.state.task_backend
 
 
+def get_a2a_webhook_registry(request: Request):
+    """FastAPI dependency: return the process-singleton A2A webhook registry
+    (#1953 slice 5a-2). Attached to ``app.state.a2a_webhook_registry`` by
+    ``reyn.interfaces.web.server``; the A2A create path (slice 5b) populates the
+    contextId→webhook_url channel, and the disposition sweep reads it."""
+    return request.app.state.a2a_webhook_registry
+
+
 __all__ = [
     "get_project_root",
     "get_reyn_config",

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -46,7 +46,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from reyn.interfaces.web.a2a_task_view import to_a2a_task
-from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
+from reyn.interfaces.web.deps import (
+    get_a2a_webhook_registry,
+    get_registry,
+    get_run_registry,
+    get_task_backend,
+)
 from reyn.mcp.server import DEFAULT_SEND_TIMEOUT_SECONDS, send_to_agent_impl
 from reyn.runtime.a2a_routing import (
     a2a_context_id,
@@ -289,6 +294,7 @@ async def a2a_jsonrpc(
     registry=Depends(get_registry),
     run_registry=Depends(get_run_registry),
     task_backend=Depends(get_task_backend),
+    webhook_registry=Depends(get_a2a_webhook_registry),
 ) -> dict:
     """JSON-RPC 2.0 endpoint for one Reyn agent.
 
@@ -332,6 +338,7 @@ async def a2a_jsonrpc(
     if method == "message/send":
         return await _handle_message_send(
             req_id, body.get("params") or {}, agent_name, registry, run_registry,
+            task_backend=task_backend, webhook_registry=webhook_registry,
         )
     if method == "tasks/list":
         return await _handle_tasks_list(
@@ -446,6 +453,9 @@ async def _handle_message_send(
     agent_name: str,
     registry,
     run_registry,
+    *,
+    task_backend=None,
+    webhook_registry=None,
 ) -> dict:
     """Backing for ``message/send``.
 
@@ -503,6 +513,7 @@ async def _handle_message_send(
         return await _handle_async_mode(
             req_id, text, agent_name, registry, run_registry, webhook_url,
             context_id=context_id,
+            task_backend=task_backend, webhook_registry=webhook_registry,
         )
 
     # ── Mode 3: synchronous (default) ────────────────────────────────────
@@ -1040,6 +1051,28 @@ class _A2AProgressBridge:
                 channel_state.record_attempt(result)
 
 
+async def _reflect_task_terminal(task_backend, task_id: str, status: str, assignee_sid: str) -> None:
+    """#1953 slice 5b: reflect the async execution's terminal outcome onto the
+    canonical Task (single-writer = the assignee session, fixed-equality CAS).
+
+    Best-effort and **race-safe**: if an A2A ``Cancel`` already archived the Task,
+    the terminal-guard rejects this write (``PermissionError``) — the abort wins
+    and the disposition sweep, not this reflection, notifies the requester. A
+    missing backend (unit-test sync path) or unknown task is a no-op. Reflection
+    is decoration on top of the RunEntry exec-record; it must never break ``_run``.
+    """
+    if task_backend is None:
+        return
+    try:
+        await task_backend.update_status(task_id, status, caller_session_id=assignee_sid)
+    except PermissionError:
+        # Terminal-guard (post-abort) or — impossibly here — a non-assignee write.
+        # Either way the Task is already in its authoritative terminal; leave it.
+        logger.debug("a2a task %r terminal-reflection skipped (terminal-guard)", task_id)
+    except Exception:  # noqa: BLE001 — reflection is best-effort decoration
+        logger.exception("a2a task %r terminal-reflection failed", task_id)
+
+
 async def _handle_async_mode(
     req_id: Any,
     text: str,
@@ -1049,10 +1082,25 @@ async def _handle_async_mode(
     webhook_url: str | None,
     *,
     context_id: str | None = None,  # #1814: per-contextId session
+    task_backend=None,
+    webhook_registry=None,
 ) -> dict:
-    """Spawn a background asyncio task and return an A2A Task envelope."""
+    """Spawn a background asyncio task and return an A2A Task envelope.
+
+    #1953 slice 5b — the A2A create path also creates a first-class **Task**
+    (the single canonical A2A work-unit authority: GetTask / ListTasks / Cancel /
+    disposition all read the Task backend). The ``RunEntry`` stays as the internal
+    execution detail (SSE progress replay, escalation, answer-injection) and is
+    **linked by a shared id** (``task_id == run_id``) so the execution can reflect
+    its terminal outcome onto the Task. The single-writer of the Task's status is
+    the assignee session (``a2a_session_id(context_id)``), which is exactly the
+    session the background ``_run`` executes on — so the reflection update passes
+    the fixed-equality CAS. An A2A ``Cancel`` that archived the Task first wins:
+    the reflection is then rejected by the terminal-guard (race-safe).
+    """
     from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: PLC0415
     from reyn.runtime.session import _new_chain_id  # noqa: PLC0415
+    from reyn.task.model import Task, TaskOrigin, TaskState  # noqa: PLC0415
 
     chain_id = _new_chain_id()
     entry = run_registry.create(
@@ -1062,6 +1110,29 @@ async def _handle_async_mode(
         session_id=a2a_session_id(context_id),  # #1814 core routing-key
     )
     run_id = entry.run_id
+
+    # #1953 slice 5b: create the canonical Task (linked to the RunEntry by a shared
+    # id). assignee = the per-contextId a2a session_id (#1814 routing-key) = the
+    # session ``_run`` executes on (so the status-reflection CAS passes); origin =
+    # external (an A2A client requested it → disposition sweep notifies it).
+    assignee_sid = a2a_session_id(context_id)
+    a2a_task = None
+    if task_backend is not None:
+        a2a_task = await task_backend.create(
+            Task(
+                task_id=run_id,
+                name=text[:120],
+                assignee=assignee_sid,
+                requester="external",
+                origin=TaskOrigin.EXTERNAL,
+                status=TaskState.IN_PROGRESS,
+            )
+        )
+        # Populate the A2A push channel so the disposition sweep (slice 5a-2) can
+        # reach this external requester on abort. A2A-owned (P7 — webhook_url is
+        # A2A vocabulary, never on the core Task).
+        if webhook_url and webhook_registry is not None:
+            webhook_registry.register_webhook(context_id, webhook_url)
 
     bus = A2AInterventionBus(run_id, run_registry)
 
@@ -1098,12 +1169,21 @@ async def _handle_async_mode(
                 message=text,
                 timeout=DEFAULT_SEND_TIMEOUT_SECONDS,
                 intervention_override=bus,
-                sid=a2a_session_id(),
+                # #1814: the async background run executes on the SAME per-contextId
+                # session as the sync send / escalation / answer-injection (the
+                # a2a_session_id docstring's invariant). The bare ``a2a_session_id()``
+                # here both raised (the arg is required) and — once defaulted — would
+                # mis-route to the native session; the assignee CAS for the 5b
+                # status-reflection relies on this being the contextId session.
+                sid=assignee_sid,
             )
             run_registry.update(
                 run_id,
                 status="completed",
                 result=result.get("reply", ""),
+            )
+            await _reflect_task_terminal(
+                task_backend, run_id, "completed", assignee_sid,
             )
             if webhook_url:
                 from reyn.interfaces.web.notifications import post_webhook  # noqa: PLC0415
@@ -1118,6 +1198,9 @@ async def _handle_async_mode(
         except Exception as exc:  # noqa: BLE001
             logger.exception("a2a async task %r raised", run_id)
             run_registry.update(run_id, status="failed", error=str(exc))
+            await _reflect_task_terminal(
+                task_backend, run_id, "failed", assignee_sid,
+            )
             if webhook_url:
                 from reyn.interfaces.web.notifications import post_webhook  # noqa: PLC0415
                 await post_webhook(
@@ -1131,6 +1214,11 @@ async def _handle_async_mode(
     task = asyncio.create_task(_run())
     run_registry.attach_task(run_id, task)
 
+    # #1953 slice 5b: return the canonical Task envelope (id = task_id = run_id).
+    # When no Task backend is wired (direct-call unit tests of the sync path),
+    # fall back to the pre-5b RunEntry-shaped envelope.
+    if a2a_task is not None:
+        return _jsonrpc_result(req_id, to_a2a_task(a2a_task))
     return _jsonrpc_result(
         req_id,
         {

--- a/tests/test_a2a_task_reflection_1953.py
+++ b/tests/test_a2a_task_reflection_1953.py
@@ -1,0 +1,64 @@
+"""Tier 2: #1953 slice 5b — A2A async-run terminal status-reflection.
+
+The async background run reflects its terminal outcome onto the canonical Task
+via the single-writer assignee CAS (``_reflect_task_terminal``). The reflection
+is **best-effort + race-safe**: if an A2A ``Cancel`` archived the Task first, the
+terminal-guard rejects the late reflection and the abort wins — the helper
+swallows the rejection so the background run never crashes on it.
+
+Real Task backend, no mocks. Observed via the backend's public ``get``.
+
+Falsification:
+- (a) a completed run reflects ``completed`` onto an in_progress Task (RED if the
+  reflection is dropped — the Task would stay in_progress, a stale tombstone);
+- (b) a reflection after the requester aborted is swallowed and the Task stays
+  archived (RED if the terminal-guard rejection re-raises out of the helper, or
+  if the late write clobbers the abort).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.web.routers.a2a import _reflect_task_terminal
+from reyn.runtime.a2a_routing import a2a_session_id
+from reyn.task import InMemoryTaskBackend, Task, TaskOrigin, TaskState
+
+
+def _a2a_task(backend, task_id, sid):
+    return backend.create(
+        Task(task_id=task_id, name="n", assignee=sid, requester="external",
+             origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS)
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_run_reflects_onto_task():
+    """Tier 2: (a) a completed async run reflects ``completed`` onto its Task via
+    the assignee CAS (the run executes on the assignee session)."""
+    backend = InMemoryTaskBackend()
+    sid = a2a_session_id("ctx-r")
+    await _a2a_task(backend, "t-1", sid)
+
+    await _reflect_task_terminal(backend, "t-1", "completed", sid)
+
+    refreshed = await backend.get("t-1")
+    assert refreshed is not None and refreshed.status is TaskState.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_reflection_after_abort_is_swallowed_and_abort_wins():
+    """Tier 2: (b) when an A2A Cancel archived the Task first, the late terminal
+    reflection is rejected by the terminal-guard, swallowed (no raise), and the
+    archived (abort) state stands — the race-safe contract lead affirmed."""
+    backend = InMemoryTaskBackend()
+    sid = a2a_session_id("ctx-r")
+    await _a2a_task(backend, "t-1", sid)
+
+    aborted = await backend.abort("t-1")  # requester cancels first → archived
+    assert aborted and aborted[0].status is TaskState.ARCHIVED
+
+    # Must NOT raise even though the Task is terminal (best-effort reflection).
+    await _reflect_task_terminal(backend, "t-1", "completed", sid)
+
+    refreshed = await backend.get("t-1")
+    assert refreshed is not None and refreshed.status is TaskState.ARCHIVED

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -41,20 +41,28 @@ from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-def _make_client_with_registry(registry: RunRegistry, task_backend=None):
+def _make_client_with_registry(registry: RunRegistry, task_backend=None, webhook_registry=None):
     """Build a TestClient that uses the supplied RunRegistry (and an optional
     Task backend — #1953 slice 5a — for the Task-backed A2A surface) via DI
-    override. A default in-memory Task backend satisfies a2a_jsonrpc's
-    get_task_backend dependency for tests that don't exercise it."""
+    override. A default in-memory Task backend + A2A webhook registry satisfy
+    a2a_jsonrpc's get_task_backend / get_a2a_webhook_registry dependencies for
+    tests that don't exercise them."""
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_run_registry, get_task_backend
+    from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry
+    from reyn.interfaces.web.deps import (
+        get_a2a_webhook_registry,
+        get_run_registry,
+        get_task_backend,
+    )
     from reyn.interfaces.web.server import app
     from reyn.task import InMemoryTaskBackend
 
     backend = task_backend if task_backend is not None else InMemoryTaskBackend()
+    reg = webhook_registry if webhook_registry is not None else A2AWebhookRegistry()
     app.dependency_overrides[get_run_registry] = lambda: registry
     app.dependency_overrides[get_task_backend] = lambda: backend
+    app.dependency_overrides[get_a2a_webhook_registry] = lambda: reg
     client = TestClient(app, raise_server_exceptions=False)
     return client
 
@@ -367,11 +375,16 @@ def test_answer_injection_delivers_to_pending_intervention(tmp_path) -> None:
         session._interventions._active[iv.id] = iv
         session._interventions._order.append(iv.id)
 
-        from reyn.interfaces.web.deps import get_task_backend  # noqa: PLC0415
+        from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry  # noqa: PLC0415
+        from reyn.interfaces.web.deps import (  # noqa: PLC0415
+            get_a2a_webhook_registry,
+            get_task_backend,
+        )
         from reyn.task import InMemoryTaskBackend  # noqa: PLC0415
         app.dependency_overrides[get_registry] = lambda: registry
         app.dependency_overrides[get_run_registry] = lambda: run_registry
         app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
+        app.dependency_overrides[get_a2a_webhook_registry] = lambda: A2AWebhookRegistry()
         client = TestClient(app, raise_server_exceptions=False)
         try:
             r = client.post(
@@ -414,7 +427,13 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
     from fastapi.testclient import TestClient
 
     from reyn.core.events.state_log import StateLog
-    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
+    from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry
+    from reyn.interfaces.web.deps import (
+        get_a2a_webhook_registry,
+        get_registry,
+        get_run_registry,
+        get_task_backend,
+    )
     from reyn.interfaces.web.server import app
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
     from reyn.runtime.profile import AgentProfile
@@ -449,6 +468,7 @@ def test_answer_injection_returns_answered_false_for_unknown_task(tmp_path) -> N
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
     app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
+    app.dependency_overrides[get_a2a_webhook_registry] = lambda: A2AWebhookRegistry()
     client = TestClient(app, raise_server_exceptions=False)
     try:
         r = client.post(

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -310,7 +310,13 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
 
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
+    from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry
+    from reyn.interfaces.web.deps import (
+        get_a2a_webhook_registry,
+        get_registry,
+        get_run_registry,
+        get_task_backend,
+    )
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
     from reyn.task import InMemoryTaskBackend
@@ -320,9 +326,11 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     # TestClient constructed without ``with ...`` doesn't fire the lifespan,
     # so override the dependency with a real instance for this test.
     run_registry = RunRegistry()
+    task_backend = InMemoryTaskBackend()
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
-    app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
+    app.dependency_overrides[get_task_backend] = lambda: task_backend
+    app.dependency_overrides[get_a2a_webhook_registry] = lambda: A2AWebhookRegistry()
     client = TestClient(app, raise_server_exceptions=False)
 
     try:
@@ -345,9 +353,129 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
         body = r.json()
         assert body.get("jsonrpc") == "2.0"
         result = body.get("result", {})
+        # #1953 slice 5b: async-mode returns the canonical Task envelope (the Task
+        # is the single A2A work-unit authority; id = task_id, status is nested).
         assert result.get("kind") == "task", f"Expected kind=task, got: {result}"
-        assert "id" in result, "Task envelope must include a run_id"
-        assert result.get("status") == "running"
+        task_id = result.get("id")
+        assert task_id, "Task envelope must include a task_id"
+        assert result["status"]["state"] == "working"  # in_progress → working
+        # The create path actually created the canonical Task in the backend
+        # (RED if 5b's Task creation is dropped — the async run would be a
+        # RunEntry-only tombstone invisible to GetTask).
+        created = asyncio.new_event_loop().run_until_complete(task_backend.get(task_id))
+        assert created is not None and created.origin.value == "external"
+        assert created.assignee.startswith("a2a:")  # the #1814 per-contextId session_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
+def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeypatch):
+    """Tier 2c: #1953 slice 5b — the full create→cancel→disposition wiring proof.
+
+    Drives the REAL endpoints (no mock collaborators; the agent send is a real
+    injected stub callable, the webhook poster is a real recording callable):
+
+      message/send (async + webhook_url)  → Task created + webhook channel
+                                            registered in the live A2AWebhookRegistry
+      POST /a2a/tasks/{task_id}/cancel    → task.abort → archived (cooperative-terminal)
+      sweep_dispositions(...)             → the registered webhook fires exactly once,
+                                            carrying the right contextId + task_id
+
+    This is the production-wiring proof that slice 5a-2's registry is populated by
+    the live create path (replacing the test-seeded `register_webhook` of the unit
+    test) — RED if 5b drops the `register_webhook` call or the assignee→contextId
+    round-trip breaks (the sweep would find no channel and fire 0).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    import reyn.interfaces.web.routers.a2a as a2a_mod
+    from fastapi.testclient import TestClient
+
+    from reyn.interfaces.web.a2a_webhook_registry import (
+        A2AWebhookRegistry,
+        sweep_dispositions,
+    )
+    from reyn.interfaces.web.deps import (
+        get_a2a_webhook_registry,
+        get_registry,
+        get_run_registry,
+        get_task_backend,
+    )
+    from reyn.interfaces.web.run_registry import RunRegistry
+    from reyn.interfaces.web.server import app
+    from reyn.task import InMemoryTaskBackend
+
+    # Real injected collaborators (no mocks): a fast agent-send stub so the
+    # background run doesn't reach the LLM, and a recording webhook poster.
+    async def _stub_send(*_args, **_kwargs):
+        return {"reply": "ok", "partial": False, "running_skill_run_ids": []}
+
+    monkeypatch.setattr(a2a_mod, "send_to_agent_impl", _stub_send)
+    monkeypatch.setattr(
+        a2a_mod, "resolve_a2a_session",
+        lambda registry, agent_name, context_id=None: None,
+    )
+
+    class _RecordingPoster:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict]] = []
+
+        async def __call__(self, url, payload):
+            self.calls.append((url, payload))
+            from types import SimpleNamespace
+            return SimpleNamespace(ok=True)
+
+    registry = _build_registry_for_test(tmp_path)
+    run_registry = RunRegistry()
+    task_backend = InMemoryTaskBackend()
+    webhook_registry = A2AWebhookRegistry()  # the ONE live instance create + sweep share
+
+    app.dependency_overrides[get_registry] = lambda: registry
+    app.dependency_overrides[get_run_registry] = lambda: run_registry
+    app.dependency_overrides[get_task_backend] = lambda: task_backend
+    app.dependency_overrides[get_a2a_webhook_registry] = lambda: webhook_registry
+    client = TestClient(app, raise_server_exceptions=False)
+
+    hook_url = "https://client.example/disposition-hook"
+    try:
+        # 1. create with a webhook_url → Task created + channel registered.
+        r = client.post(
+            "/a2a/agents/default",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {
+                    "message": {"role": "user", "parts": [{"kind": "text", "text": "go"}]},
+                    "contextId": "ctx-e2e",
+                    "async_mode": True,
+                    "webhook_url": hook_url,
+                },
+            },
+        )
+        assert r.status_code == 200, r.text
+        task_id = r.json()["result"]["id"]
+        # The live create path populated the registry (NOT a test seed).
+        assert webhook_registry.webhook_for("ctx-e2e") == hook_url
+
+        # 2. external requester cancels → task.abort → archived.
+        rc = client.post(f"/a2a/tasks/{task_id}/cancel")
+        assert rc.status_code == 200, rc.text
+        assert rc.json()["status"]["state"] == "canceled"
+
+        # 3. the periodic sweep notifies the external requester exactly once.
+        poster = _RecordingPoster()
+        fired = asyncio.new_event_loop().run_until_complete(
+            sweep_dispositions(task_backend, webhook_registry, post_fn=poster)
+        )
+        assert fired == 1
+        assert len(poster.calls) == 1
+        url, payload = poster.calls[0]
+        assert url == hook_url
+        assert payload["task_id"] == task_id
+        assert payload["contextId"] == "ctx-e2e"
+        assert payload["disposition"] == "aborted"
     finally:
         app.dependency_overrides.clear()
 

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -389,9 +389,9 @@ def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeyp
     """
     monkeypatch.chdir(tmp_path)
 
-    import reyn.interfaces.web.routers.a2a as a2a_mod
     from fastapi.testclient import TestClient
 
+    import reyn.interfaces.web.routers.a2a as a2a_mod
     from reyn.interfaces.web.a2a_webhook_registry import (
         A2AWebhookRegistry,
         sweep_dispositions,
@@ -470,10 +470,11 @@ def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeyp
             sweep_dispositions(task_backend, webhook_registry, post_fn=poster)
         )
         assert fired == 1
-        assert len(poster.calls) == 1
+        # Exactly the one aborted external task was notified, on its channel —
+        # behavioral (which task_ids fired), not a size/shape pin.
+        assert [c[1]["task_id"] for c in poster.calls] == [task_id]
         url, payload = poster.calls[0]
         assert url == hook_url
-        assert payload["task_id"] == task_id
         assert payload["contextId"] == "ctx-e2e"
         assert payload["disposition"] == "aborted"
     finally:

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -95,7 +95,13 @@ def _client_with_registry(tmp_path: Path, agents: list[tuple[str, str]]):
     """
     from fastapi.testclient import TestClient
 
-    from reyn.interfaces.web.deps import get_registry, get_run_registry, get_task_backend
+    from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry
+    from reyn.interfaces.web.deps import (
+        get_a2a_webhook_registry,
+        get_registry,
+        get_run_registry,
+        get_task_backend,
+    )
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
     from reyn.task import InMemoryTaskBackend
@@ -105,6 +111,7 @@ def _client_with_registry(tmp_path: Path, agents: list[tuple[str, str]]):
     app.dependency_overrides[get_registry] = lambda: registry
     app.dependency_overrides[get_run_registry] = lambda: run_registry
     app.dependency_overrides[get_task_backend] = lambda: InMemoryTaskBackend()
+    app.dependency_overrides[get_a2a_webhook_registry] = lambda: A2AWebhookRegistry()
     client = TestClient(app, raise_server_exceptions=False)
     return client, registry
 


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 5b (A2A create-side). Completes slice-5: the A2A surface now has the **Task as its single canonical work-unit authority** end-to-end (create → poll → cancel → disposition), closing the gap left by 5a-1/5a-2 where GetTask/Cancel/sweep read the Task backend but nothing on the create side populated it.

## What
`message/send` (async mode) now creates a first-class **Task** and returns the canonical Task envelope:
- **create** — `Task(origin=external, assignee=a2a_session_id(contextId), status=in_progress, task_id == run_id)`. RunEntry stays as the **internal execution detail** (SSE/escalation/answer-injection), linked by the shared id → no dual A2A authority.
- **populate** — registers the `contextId → webhook_url` channel in the live `A2AWebhookRegistry` so 5a-2's disposition sweep can reach the external requester on abort (replaces the test-seeded `register_webhook`).
- **reflect** — the async run reflects its terminal outcome onto the Task via the single-writer **assignee CAS**; best-effort + **race-safe**: a prior A2A `Cancel` that archived the Task wins (terminal-guard rejects the late reflection, swallowed).

## Ownership boundary (lead-reviewed)
Task = sole A2A status authority (every write assignee-CAS-gated, single-direction). RunEntry = execution detail, not an A2A-facing competitor. `escalation(RunEntry) ↔ abort(Task)` non-conflict is guaranteed by the terminal-guard.

## In-path fix (pre-existing #1814 violation)
The async background run's send used `sid=a2a_session_id()` — the arg is required so it **raised** (caught → run marked failed; async runs never executed the agent), and once defaulted it would mis-route to the native session. Now `sid=a2a_session_id(contextId)`, per the `a2a_session_id` docstring's own invariant ("sync send / escalation / answer-injection / **async** all act on the SAME per-contextId session"). The 5b status-reflection's assignee CAS relies on this.

## Deferred → tracked in #1981
Full RunEntry→Task migration of: SSE `history_events` replay, sync-mode auto-escalation (`_escalate_to_task` still RunEntry-shaped), and answer-injection. Out of 5b scope (heavy SSE/escalation rewrite); surfaced, not dropped.

## Tests (real backends + real recording poster — no mocks)
- **Mandatory e2e** (`test_e2e_create_with_webhook_then_cancel_fires_disposition`): drives the real endpoints — create-with-webhook → Task + channel registered in the live registry → `POST /cancel` → archived → `sweep_dispositions` → webhook fires **once** with the right `contextId` + `task_id`. CLEAN-RED falsified (disable `register_webhook` → fires 0).
- **Status-reflection** (`test_a2a_task_reflection_1953.py`): completed reflects via CAS; post-abort reflection swallowed + abort wins. Both guards CLEAN-RED falsified.
- Updated the async-mode return-shape assertion to the canonical Task envelope; re-pointed every `a2a_jsonrpc` TestClient to override `get_a2a_webhook_registry`.

## Test plan
- [x] `pytest -q` full suite from rootdir — 8127 passed, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip` missing dataset, `test_legacy_no_media_store_path` missing media-store) which pass in CI.
- [x] Targeted a2a suite (8 files) green: 71 passed, 1 skipped.
- [x] Mandatory e2e + both reflection guards CLEAN-RED falsified then restored to green.
- [x] (B) full-migration tracking issue filed (#1981) at land per the deferred-work-ticket rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)