### PR TITLE
docs(contributing): document the three pre-push CI gates (ruff / tier-audit / pytest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,17 @@ Key constraints (full rationale in the doc):
 ## PR workflow (READ BEFORE OPENING / REVIEWING A PR)
 
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
-per-PR coders) authenticating as the same `gh` user. Three rules keep that
-coherent:
+per-PR coders) authenticating as the same `gh` user.
+
+**Before you open a PR, run all three CI gates locally** — `ruff check src
+tests`, `python scripts/test_tier_audit.py --strict <changed test files>`, and
+`pytest` (from the repo root) are *separate* CI jobs. A green `pytest` alone is
+**not** a green CI run (`pytest-green ≠ CI-green`): ruff `I001` import-sort and a
+Tier-4 format pin (`len(...) == N`) both fail CI while `pytest` passes. Details
++ the Tier-4 → behavioral-assertion fix idioms:
+`docs/deep-dives/contributing/testing.md` § "Before you push".
+
+Three rules then keep multi-session work coherent:
 
 1. **Finish your own Test plan before merge.** PR authors run every
    Manual / Visual item in the Test plan and tick the box, or replace

--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -406,6 +406,36 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 
 ---
 
+## プッシュ前 — 3 つの CI ゲート
+
+`pytest` が green でも CI が green とは限りません。`.github/workflows/test.yml`
+は **3 つの独立したゲート**を回します。PR を ready とする前に、diff に対して 3 つ
+ともローカルで実行してください:
+
+1. **pytest** — リポジトリルートから（サブセットパスでなく）。collection が CI と一致します:
+   ```bash
+   python -m pytest tests/ -q
+   ```
+2. **ruff** — lint + import-sort（`I001`）:
+   ```bash
+   ruff check src tests        # autofix 可能な I001 / format は --fix
+   ```
+3. **test-tier audit** — 新規・変更したテストファイルごとに
+   `scripts/test_tier_audit.py --strict`（後述の Tier コンプライアンス監査ツールと
+   同じ linter）。Tier-4 の format-pin（`len(...) == N`、exact whitespace、行数）は
+   pytest が green でもここで fail します — behavioral assertion に置き換えてください
+   （長さでなく抽出した値そのものを assert）:
+   ```bash
+   python scripts/test_tier_audit.py --strict <変更したテストファイル>
+   ```
+
+`pytest` だけが green の PR が、CI で ruff（`I001`）や tier audit（`len(...) == 1`
+の format-pin）で bounce した実例があります。report scope は正直に: 走らせたのが
+pytest だけなら「pytest passed」と言い、「suite passed」（lint・audit ゲートも含意する）
+とは言わないこと。
+
+---
+
 ## 新しい OS 機能のカバレッジチェックリスト
 
 LLM 依存の OS パスを新たに追加する場合:

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -487,6 +487,37 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 
 ---
 
+## Before you push — the three CI gates
+
+A green `pytest` run is **not** a green CI run. `.github/workflows/test.yml` runs
+three *separate* gates; run all three locally on your diff before calling a PR
+ready:
+
+1. **pytest** — from the repo root (not a subset path) so collection matches CI:
+   ```bash
+   python -m pytest tests/ -q
+   ```
+2. **ruff** — lint + import-sort (`I001`):
+   ```bash
+   ruff check src tests        # add --fix for autofixable I001 / formatting
+   ```
+3. **test-tier audit** — `scripts/test_tier_audit.py --strict` on each new or
+   modified test file (the linter described under
+   [Tier compliance auditor](#tier-compliance-auditor)). A Tier-4 format pin
+   (`len(...) == N`, exact whitespace, line count) fails here even when pytest is
+   green — replace it with a behavioural assertion (assert on the extracted value,
+   not its length):
+   ```bash
+   python scripts/test_tier_audit.py --strict <changed_test_files>
+   ```
+
+A green `pytest` alone has shipped PRs that CI then bounced on ruff (`I001`) or
+the tier audit (a `len(...) == 1` format pin). Report scope honestly: say
+"pytest passed" if that is all you ran — "suite passed" implies the lint and
+audit gates too.
+
+---
+
 ## Coverage checklist for a new OS feature
 
 When adding a new LLM-dependent OS path:


### PR DESCRIPTION
**[docs-maintainer]** — actively-resolve of a doc gap surfaced during an e2e cross-ref audit (a pytest-only "suite passed" report bounced at merge on ruff + tier-audit). The pre-push CI-gate checklist was nowhere in the contributing docs.

## What

Split by altitude (lead steer):
- **`CLAUDE.md` PR-workflow section** — a short, always-loaded rule: before opening a PR, run all three CI gates locally; `pytest-green ≠ CI-green`. Discoverability-optimised (the miss happened because the coder didn't know the three gates exist).
- **`testing.md` (+ `.ja`)** — the detailed *"Before you push — the three CI gates"* section: exact commands (`ruff check src tests`, `python scripts/test_tier_audit.py --strict <changed>`, `pytest` from rootdir) + the Tier-4 format-pin → behavioural-assertion fix idiom.

## Notes

- **History-ref-free** per operator-doc policy (lead-confirmed): the originating slice is rationale, not inlined.
- The three gates match `.github/workflows/test.yml` job names (`ruff`, `test-tier audit`, `pytest`) — verified.
- These files are not in the mkdocs build (deep-dives / repo-root), so no strict-build impact; no mermaid.

## Test plan

- [x] Three gate commands match the actual `test.yml` jobs
- [x] EN (`testing.md`) ↔ JA (`testing.ja.md`) parity for the new section
- [x] No history refs in the added content (grep clean)
- [x] CLAUDE.md rule cross-links to the testing.md detail section
- [ ] (reviewer) confirm placement / wording of the CLAUDE.md rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)