### PR TITLE
feat(#1953): slice 6 — Task dependency-DAG (cycle-check + completion-driven readiness)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -523,8 +523,27 @@ tree, and the assignee discovers the abort via the terminal guard).
 **States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
 `failed` / `aborted` / `archived`.
 
-Still landing in later slices: dependency cycle-check + readiness,
-unblock-predicate evaluation.
+**Dependency DAG (§13).** `task.add_dependency` and `task.create(deps=[...])` add
+depends-on edges through a **shared edge-guard** (completeness): the `depends_on`
+task must exist and the edge must not create a cycle. A rejected edge returns a
+decision-enabling **error result** (`status="error"`, `error.kind="cycle"` /
+`"dep_not_found"`, the offending `edge`, and — for a cycle — the `path`), never a
+raised exception. Edge-add is a **pure topology write** — it never flips a task's
+status (the requester does not write the assignee's status). A task born with
+not-all-completed deps is **OS-derived `blocked`** at create (deps-less tasks keep
+their requested status).
+
+**Completion-driven readiness (OS-authority).** When a predecessor reaches
+`completed`, `task.update_status` drives an OS readiness recompute: each dependent
+whose deps are **all** `completed` transitions `blocked → ready`, emitting a
+generic P6 `task_readiness` event. This `blocked → ready` write is an **OS
+scheduling transition** (P3) — like `abort`, it is a dedicated backend method that
+**bypasses the assignee CAS** (it is not an assignee progress write). A
+non-`completed` terminal dep (`failed` / `aborted`) does not satisfy an edge
+(liveness backstop lands in a later slice).
+
+Still landing in later slices: unblock-predicate evaluation; terminal-non-completed
+dependency handling (liveness backstop).
 
 ---
 

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -20,7 +20,14 @@ from __future__ import annotations
 
 import uuid
 
-from reyn.task import InMemoryTaskBackend, Task, TaskOrigin
+from reyn.task import (
+    InMemoryTaskBackend,
+    Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
+    TaskOrigin,
+    TaskState,
+)
 
 from . import register
 from .context import OpContext
@@ -58,6 +65,31 @@ def _ok(kind: str, **data) -> dict:
 
 def _not_found(kind: str, task_id: str) -> dict:
     return {"kind": kind, "status": "error", "error": f"task {task_id!r} not found"}
+
+
+def _edge_error(op_kind: str, err: Exception) -> dict:
+    """Decision-enabling error result for a rejected dependency edge (#1953 slice
+    6, OQ-5): a structured ``status="error"`` dict (the edge + cycle path), NOT a
+    raised exception through the op dispatcher."""
+    if isinstance(err, TaskCycleError):
+        return {
+            "kind": op_kind,
+            "status": "error",
+            "error": {
+                "kind": "cycle",
+                "edge": [err.task_id, err.depends_on],
+                "path": err.path,
+            },
+        }
+    assert isinstance(err, TaskDepNotFoundError)
+    return {
+        "kind": op_kind,
+        "status": "error",
+        "error": {
+            "kind": "dep_not_found",
+            "edge": [err.task_id, err.depends_on],
+        },
+    }
 
 
 def _actor(ctx: OpContext) -> str | None:
@@ -127,7 +159,11 @@ async def _create(op, ctx: OpContext, caller) -> dict:
         created_by=_actor(ctx),
         deps=list(op.deps),
     )
-    created = await _backend(ctx).create(task)
+    try:
+        created = await _backend(ctx).create(task)
+    except (TaskCycleError, TaskDepNotFoundError) as err:
+        # A born-with dependency is dangling or cycle-forming (OQ-1/OQ-4/OQ-5).
+        return _edge_error("task.create", err)
     _audit(ctx, "task.create", created.task_id, status=created.status.value,
            assignee=created.assignee, parent_id=parent_id)
     return _ok("task.create", task=created.to_dict())
@@ -142,6 +178,19 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
     if task is None:
         return _not_found("task.update_status", op.task_id)
     _audit(ctx, "task.update_status", op.task_id, status=op.status)
+    # OQ-3: a predecessor reaching `completed` drives DAG readiness (OS scheduling,
+    # P3) — recompute its dependents and flip any fully-satisfied one blocked→ready
+    # via the OS-authority backend method (no assignee CAS). `completed` only;
+    # failed/aborted/archived deps don't satisfy an edge (H5/OQ-7 → slice 7).
+    if task.status is TaskState.COMPLETED:
+        promoted = await _backend(ctx).recompute_readiness(op.task_id)
+        events = getattr(ctx, "events", None)
+        if events is not None:
+            for p in promoted:
+                # Generic P6 audit (like task_op/task_disposition); NOT a WAL
+                # closed-vocab kind (WAL-vs-P6 separation, P7).
+                events.emit("task_readiness", task_id=p.task_id, to="ready",
+                            trigger=op.task_id)
     return _ok("task.update_status", task=task.to_dict())
 
 
@@ -169,7 +218,14 @@ async def _add_dependency(op, ctx: OpContext, caller) -> dict:
         "task.add_dependency", ctx, _backend(ctx), op.task_id, "requester")
     if denied is not None:
         return denied
-    task = await _backend(ctx).add_dependency(op.task_id, op.depends_on)
+    try:
+        task = await _backend(ctx).add_dependency(op.task_id, op.depends_on)
+    except (TaskCycleError, TaskDepNotFoundError) as err:
+        # OQ-1/OQ-4/OQ-5: dangling or cycle-forming edge → decision-enabling dict.
+        return _edge_error("task.add_dependency", err)
+    if task is None:
+        return _not_found("task.add_dependency", op.task_id)
+    _audit(ctx, "task.add_dependency", op.task_id, depends_on=op.depends_on)
     return _ok("task.add_dependency", task=task.to_dict())
 
 

--- a/src/reyn/task/__init__.py
+++ b/src/reyn/task/__init__.py
@@ -18,6 +18,8 @@ from reyn.task.factory import create_task_backend
 from reyn.task.model import (
     TERMINAL_STATES,
     Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
     TaskOrigin,
     TaskState,
 )
@@ -28,6 +30,8 @@ __all__ = [
     "TaskState",
     "TaskOrigin",
     "TERMINAL_STATES",
+    "TaskCycleError",
+    "TaskDepNotFoundError",
     "TaskBackend",
     "InMemoryTaskBackend",
     "SqliteTaskBackend",

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -23,9 +23,49 @@ Enforcement deferred to later slices:
 """
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Callable, Protocol
 
-from reyn.task.model import TERMINAL_STATES, Task, TaskState, _now_iso
+from reyn.task.model import (
+    TERMINAL_STATES,
+    Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
+    TaskState,
+    _now_iso,
+)
+
+
+def find_cycle_path(
+    deps_of: Callable[[str], list[str]], task_id: str, depends_on: str
+) -> list[str] | None:
+    """Return the cycle node-path if adding the edge ``task_id depends-on
+    depends_on`` would create a cycle in the dependency DAG, else ``None``
+    (#1953 slice 6, OQ-4). A cycle forms iff ``task_id`` is already reachable
+    from ``depends_on`` by following depends-on edges (then ``task_id ->
+    depends_on -> ... -> task_id``), or the edge is a self-loop.
+
+    Pure + backend-agnostic: ``deps_of(node)`` returns ``node``'s depends-on
+    ids, so the in-memory and sqlite backends share one cycle check (the
+    shared-helper completeness OQ-4 calls for). Returns the offending cycle as a
+    node sequence for a decision-enabling error (OQ-5)."""
+    if task_id == depends_on:
+        return [task_id, depends_on]
+    parent: dict[str, str | None] = {depends_on: None}
+    stack: list[str] = [depends_on]
+    while stack:
+        node = stack.pop()
+        for d in deps_of(node):
+            if d == task_id:
+                # Reconstruct depends_on .. node, then close the cycle T -> .. -> T.
+                chain = [node]
+                while parent[chain[-1]] is not None:
+                    chain.append(parent[chain[-1]])  # type: ignore[arg-type]
+                chain.reverse()
+                return [task_id, *chain, task_id]
+            if d not in parent:
+                parent[d] = node
+                stack.append(d)
+    return None
 
 
 class TaskBackend(Protocol):
@@ -53,7 +93,22 @@ class TaskBackend(Protocol):
         caller raises ``PermissionError``. Returns None for an unknown task."""
         ...
 
-    async def add_dependency(self, task_id: str, depends_on: str) -> Task | None: ...
+    async def add_dependency(self, task_id: str, depends_on: str) -> Task | None:
+        """Add a depends-on edge (pure topology write, OQ-2 — never flips the
+        task's status). Validates ``depends_on`` exists (raises
+        ``TaskDepNotFoundError``) and that the edge does not create a cycle
+        (raises ``TaskCycleError``); the op layer maps both to error results.
+        Returns None for an unknown ``task_id``."""
+        ...
+
+    async def recompute_readiness(self, completed_task_id: str) -> list[Task]:
+        """OS-authority readiness recompute (#1953 slice 6, OQ-3): a predecessor
+        reaching ``completed`` → re-evaluate its dependents → any whose deps are
+        ALL ``completed`` transitions ``blocked → ready``. This is an OS
+        scheduling write (P3), **not** an assignee progress write — it takes no
+        ``caller_session_id`` and bypasses the single-writer CAS (like ``abort``).
+        Returns the newly-readied tasks (so the caller emits P6 + later nudges)."""
+        ...
 
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]: ...
 
@@ -77,7 +132,33 @@ class InMemoryTaskBackend:
         self._comments: dict[str, list[dict]] = {}
         self._comment_seq = 0
 
+    def _deps_of(self, node: str) -> list[str]:
+        t = self._tasks.get(node)
+        return list(t.deps) if t is not None else []
+
+    def _validate_edge(self, task_id: str, depends_on: str) -> None:
+        """Shared edge guard (#1953 slice 6, OQ-1/OQ-4): the ``depends_on`` task
+        must exist, and the edge must not create a cycle. Called by both
+        ``create(deps)`` and ``add_dependency`` (completeness-by-construction)."""
+        if depends_on not in self._tasks:
+            raise TaskDepNotFoundError(task_id, depends_on)
+        path = find_cycle_path(self._deps_of, task_id, depends_on)
+        if path is not None:
+            raise TaskCycleError(task_id, depends_on, path)
+
     async def create(self, task: Task) -> Task:
+        # Validate every born-with dep (existence + cycle) before storing (OQ-4
+        # shared helper on the create path too).
+        for dep in task.deps:
+            self._validate_edge(task.task_id, dep)
+        # Born-blocked (OQ-3 origin of `blocked`): a task born with deps that are
+        # not ALL already completed is OS-derived `blocked` at birth (§13). This is
+        # an initial-status derivation, not a post-hoc status flip (OQ-2) — deps-less
+        # tasks (e.g. the A2A create path) keep their requested status.
+        if task.deps and not all(
+            self._tasks[d].status == TaskState.COMPLETED for d in task.deps
+        ):
+            task.status = TaskState.BLOCKED
         self._tasks[task.task_id] = task
         return task
 
@@ -132,11 +213,31 @@ class InMemoryTaskBackend:
         task = self._tasks.get(task_id)
         if task is None:
             return None
-        # slice 6 adds cycle-check + readiness propagation; slice 1 records the edge.
+        # Pure topology write (OQ-2): validate (existence + cycle) then record the
+        # edge — never flips this task's status (the requester must not write the
+        # assignee's status; readiness is OS-derived on completion).
+        self._validate_edge(task_id, depends_on)
         if depends_on not in task.deps:
             task.deps.append(depends_on)
         task.updated_at = _now_iso()
         return task
+
+    async def recompute_readiness(self, completed_task_id: str) -> list[Task]:
+        # OS-authority (OQ-3): no caller_session_id, no CAS — readiness is OS
+        # scheduling (P3). Re-evaluate the just-completed task's dependents; flip
+        # blocked → ready only when ALL of a dependent's deps are completed.
+        promoted: list[Task] = []
+        for t in self._tasks.values():
+            if t.status is not TaskState.BLOCKED or completed_task_id not in t.deps:
+                continue
+            if all(
+                d in self._tasks and self._tasks[d].status == TaskState.COMPLETED
+                for d in t.deps
+            ):
+                t.status = TaskState.READY
+                t.updated_at = _now_iso()
+                promoted.append(t)
+        return promoted
 
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]:
         # abort = delete (cooperative-terminal, Option B): archive this task + its

--- a/src/reyn/task/model.py
+++ b/src/reyn/task/model.py
@@ -40,6 +40,35 @@ TERMINAL_STATES: frozenset[TaskState] = frozenset(
 )
 
 
+class TaskDepNotFoundError(Exception):
+    """A dependency edge references a ``depends_on`` task that does not exist
+    (#1953 slice 6, OQ-1). A dangling dep is an instant latent deadlock, so the
+    edge is rejected at add-time. The op layer maps this to a decision-enabling
+    ``status="error"`` result (never propagated through the op dispatcher)."""
+
+    def __init__(self, task_id: str, depends_on: str) -> None:
+        self.task_id = task_id
+        self.depends_on = depends_on
+        super().__init__(
+            f"dependency {depends_on!r} of task {task_id!r} does not exist"
+        )
+
+
+class TaskCycleError(Exception):
+    """Adding a dependency edge would create a cycle in the dependency DAG
+    (#1953 slice 6, OQ-4/5) — rejected so the graph stays acyclic-by-construction
+    (deadlock-impossible, §13). Carries the offending edge + the cycle node-path
+    for a decision-enabling op result (never propagated through the dispatcher)."""
+
+    def __init__(self, task_id: str, depends_on: str, path: list[str]) -> None:
+        self.task_id = task_id
+        self.depends_on = depends_on
+        self.path = path
+        super().__init__(
+            f"edge {task_id!r}->{depends_on!r} would create a cycle: {' -> '.join(path)}"
+        )
+
+
 class TaskOrigin(str, Enum):
     """Origin decides deletion coupling (#1953 §17).
 

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -35,7 +35,16 @@ import json
 import sqlite3
 from pathlib import Path
 
-from reyn.task.model import TERMINAL_STATES, Task, TaskOrigin, TaskState, _now_iso
+from reyn.task.backend import find_cycle_path
+from reyn.task.model import (
+    TERMINAL_STATES,
+    Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
+    TaskOrigin,
+    TaskState,
+    _now_iso,
+)
 
 # Terminal status values (no further transitions) — used by the update_status
 # terminal-guard (the abort straggler-reject, #1953 Option B).
@@ -65,6 +74,8 @@ CREATE TABLE IF NOT EXISTS task_links(
   depends_on TEXT NOT NULL,
   PRIMARY KEY(task_id, depends_on)
 );
+-- #1953 slice 6 (OQ-8): reverse (dependents) lookup for readiness recompute.
+CREATE INDEX IF NOT EXISTS idx_task_links_depends_on ON task_links(depends_on);
 CREATE TABLE IF NOT EXISTS task_runs(
   run_id TEXT PRIMARY KEY,
   task_id TEXT NOT NULL,
@@ -130,6 +141,22 @@ class SqliteTaskBackend:
         ).fetchall()
         return [r["depends_on"] for r in rows]
 
+    def _exists(self, task_id: str) -> bool:
+        return self._conn.execute(
+            "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
+        ).fetchone() is not None
+
+    def _validate_edge(self, task_id: str, depends_on: str) -> None:
+        """Shared edge guard (#1953 slice 6, OQ-1/OQ-4): ``depends_on`` must exist
+        and the edge must not create a cycle. Called by both ``create(deps)`` and
+        ``add_dependency`` (completeness-by-construction). Read-only — call inside
+        the lock, before opening the write transaction."""
+        if not self._exists(depends_on):
+            raise TaskDepNotFoundError(task_id, depends_on)
+        path = find_cycle_path(self._deps, task_id, depends_on)
+        if path is not None:
+            raise TaskCycleError(task_id, depends_on, path)
+
     def _row_to_task(self, row: sqlite3.Row) -> Task:
         return Task(
             task_id=row["task_id"],
@@ -159,6 +186,25 @@ class SqliteTaskBackend:
 
     async def create(self, task: Task) -> Task:
         async with self._lock:
+            # Validate every born-with dep (existence + cycle) before writing
+            # (OQ-4 shared helper on the create path); read-only, pre-transaction.
+            for dep in task.deps:
+                self._validate_edge(task.task_id, dep)
+            # Born-blocked (OQ-3 origin of `blocked`): a task born with deps not ALL
+            # completed is OS-derived `blocked` at birth (§13) — initial-status
+            # derivation, not a post-hoc flip (OQ-2). Deps-less tasks (the A2A create
+            # path) keep their requested status.
+            status = task.status
+            if task.deps:
+                dep_statuses = [
+                    (self._conn.execute(
+                        "SELECT status FROM tasks WHERE task_id=?", (dep,)
+                    ).fetchone() or {"status": None})["status"]
+                    for dep in task.deps
+                ]
+                if not all(s == TaskState.COMPLETED.value for s in dep_statuses):
+                    status = TaskState.BLOCKED
+            task.status = status
             self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 f"INSERT INTO tasks({_TASK_COLUMNS}) "
@@ -245,10 +291,11 @@ class SqliteTaskBackend:
 
     async def add_dependency(self, task_id: str, depends_on: str) -> Task | None:
         async with self._lock:
-            if self._conn.execute(
-                "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
-            ).fetchone() is None:
+            if not self._exists(task_id):
                 return None
+            # Pure topology write (OQ-2): validate (existence + cycle) then record
+            # the edge — never flips this task's status (readiness is OS-derived).
+            self._validate_edge(task_id, depends_on)
             self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 "INSERT OR IGNORE INTO task_links(task_id, depends_on) VALUES (?,?)",
@@ -260,6 +307,51 @@ class SqliteTaskBackend:
             self._emit(task_id, "dependency_added", depends_on=depends_on)
             self._conn.commit()
             return self._fetch(task_id)
+
+    async def recompute_readiness(self, completed_task_id: str) -> list[Task]:
+        """OS-authority readiness recompute (#1953 slice 6, OQ-3): no
+        ``caller_session_id`` / no CAS (P3 scheduling, like ``abort``). Flip each
+        dependent of ``completed_task_id`` from ``blocked`` → ``ready`` when ALL of
+        its deps are ``completed``. The ``WHERE status='blocked'`` guard IS the
+        OS-authority write (no assignee equality), distinct from ``update_status``."""
+        async with self._lock:
+            dependents = [
+                r["task_id"] for r in self._conn.execute(
+                    "SELECT task_id FROM task_links WHERE depends_on=?", (completed_task_id,)
+                ).fetchall()
+            ]
+            promoted_ids: list[str] = []
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                for dep_task in dependents:
+                    row = self._conn.execute(
+                        "SELECT status FROM tasks WHERE task_id=?", (dep_task,)
+                    ).fetchone()
+                    if row is None or row["status"] != TaskState.BLOCKED.value:
+                        continue
+                    deps = self._deps(dep_task)
+                    statuses = [
+                        (self._conn.execute(
+                            "SELECT status FROM tasks WHERE task_id=?", (d,)
+                        ).fetchone() or {"status": None})["status"]
+                        for d in deps
+                    ]
+                    if deps and all(s == TaskState.COMPLETED.value for s in statuses):
+                        cur = self._conn.execute(
+                            "UPDATE tasks SET status=?, updated_at=? "
+                            "WHERE task_id=? AND status=?",
+                            (TaskState.READY.value, _now_iso(), dep_task,
+                             TaskState.BLOCKED.value),
+                        )
+                        if cur.rowcount:
+                            self._emit(dep_task, "readiness_changed", to="ready",
+                                       trigger=completed_task_id)
+                            promoted_ids.append(dep_task)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            return [t for t in (self._fetch(tid) for tid in promoted_ids) if t is not None]
 
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]:
         """abort = delete (cooperative-terminal, #1953 Option B): set this task +

--- a/tests/test_task_dag_slice6_1953.py
+++ b/tests/test_task_dag_slice6_1953.py
@@ -1,0 +1,307 @@
+"""Tier 2b: #1953 slice 6 — Task dependency-DAG (cycle-check + completion-driven readiness).
+
+The dependency DAG (§13) stays acyclic-by-construction (cycle-forming edges
+rejected at add-time via a shared helper on BOTH create(deps) and add_dependency)
+and a predecessor reaching ``completed`` drives OS-authority readiness recompute
+(a fully-satisfied dependent flips ``blocked → ready`` without the assignee CAS).
+Real sqlite backend + in-memory backend (parametrized); no mocks.
+
+Falsification (per axis, CLEAN-RED):
+- cycle rejected (self / 2- / N-cycle) with the offending path; non-cycle DAG accepted;
+- a dangling dep (OQ-1) rejected on both create and add_dependency;
+- create with incomplete deps is born-blocked; deps-less create keeps its status;
+- a completed predecessor promotes a fully-satisfied dependent + emits P6; a
+  partially-satisfied dependent stays blocked;
+- the readiness write is OS-authority (no assignee session); it persists across a
+  sqlite reload;
+- the op layer maps a rejected edge to a decision-enabling error dict (OQ-5), and
+  completion through ``task.update_status`` drives the recompute + the P6 event.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.task import (
+    InMemoryTaskBackend,
+    SqliteTaskBackend,
+    Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
+    TaskState,
+)
+from reyn.task.backend import find_cycle_path
+
+
+def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess", requester="req"):
+    return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
+                status=status, deps=list(deps or []))
+
+
+@pytest.fixture(params=["inmem", "sqlite"])
+def backend(request, tmp_path):
+    if request.param == "inmem":
+        yield InMemoryTaskBackend()
+    else:
+        b = SqliteTaskBackend(tmp_path / "dag.db")
+        yield b
+        b.close()
+
+
+# ── cycle-check (OQ-4/OQ-5) ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_cycle_rejected(backend):
+    """Tier 2b: a self-loop edge (a→a) is a cycle."""
+    await backend.create(_task("a"))
+    with pytest.raises(TaskCycleError):
+        await backend.add_dependency("a", "a")
+
+
+@pytest.mark.asyncio
+async def test_two_cycle_rejected(backend):
+    """Tier 2b: a 2-cycle (a→b then b→a) is rejected at the closing edge."""
+    await backend.create(_task("a"))
+    await backend.create(_task("b"))
+    await backend.add_dependency("a", "b")
+    with pytest.raises(TaskCycleError):
+        await backend.add_dependency("b", "a")
+
+
+@pytest.mark.asyncio
+async def test_n_cycle_rejected_with_path(backend):
+    """Tier 2b: an N-cycle (a→b→c then c→a) is rejected; the error carries the
+    offending cycle path (decision-enabling, OQ-5)."""
+    for t in ("a", "b", "c"):
+        await backend.create(_task(t))
+    await backend.add_dependency("a", "b")
+    await backend.add_dependency("b", "c")
+    with pytest.raises(TaskCycleError) as ei:
+        await backend.add_dependency("c", "a")
+    # path closes the cycle: c -> ... -> c.
+    assert ei.value.path[0] == "c" and ei.value.path[-1] == "c"
+
+
+@pytest.mark.asyncio
+async def test_non_cycle_dag_accepted(backend):
+    """Tier 2b: a diamond DAG (no cycle) is accepted on every edge."""
+    for t in ("a", "b", "c"):
+        await backend.create(_task(t))
+    await backend.add_dependency("a", "b")
+    await backend.add_dependency("a", "c")
+    await backend.add_dependency("b", "c")
+    got = await backend.get("a")
+    assert set(got.deps) == {"b", "c"}
+
+
+# ── existence (OQ-1) ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dangling_dep_rejected_on_add(backend):
+    """Tier 2b: add_dependency to a non-existent task is rejected (OQ-1)."""
+    await backend.create(_task("a"))
+    with pytest.raises(TaskDepNotFoundError):
+        await backend.add_dependency("a", "ghost")
+
+
+@pytest.mark.asyncio
+async def test_dangling_dep_rejected_on_create(backend):
+    """Tier 2b: create(deps=[non-existent]) is rejected — the shared helper guards
+    the create path too (OQ-4 completeness)."""
+    with pytest.raises(TaskDepNotFoundError):
+        await backend.create(_task("a", deps=["ghost"]))
+
+
+# ── born-blocked (OQ-3 origin of `blocked`) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_with_incomplete_deps_is_born_blocked(backend):
+    """Tier 2b: a task born with not-all-completed deps is OS-derived blocked."""
+    await backend.create(_task("d"))  # pending, not completed
+    await backend.create(_task("a", deps=["d"], status=TaskState.PENDING))
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_create_without_deps_keeps_requested_status(backend):
+    """Tier 2b: a deps-less create keeps its requested status (the A2A path is
+    unaffected — OQ-2: birth-derivation only fires when deps are present)."""
+    await backend.create(_task("a", status=TaskState.IN_PROGRESS))
+    assert (await backend.get("a")).status is TaskState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_create_with_already_completed_deps_not_blocked(backend):
+    """Tier 2b: if every born-with dep is already completed, the task is not
+    born-blocked (nothing to wait for)."""
+    await backend.create(_task("d", assignee="sd"))
+    await backend.update_status("d", "completed", caller_session_id="sd")
+    await backend.create(_task("a", deps=["d"], status=TaskState.PENDING))
+    assert (await backend.get("a")).status is TaskState.PENDING
+
+
+# ── completion-driven readiness (OQ-3) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_completed_predecessor_promotes_satisfied_dependent(backend):
+    """Tier 2b: a predecessor reaching completed → a fully-satisfied dependent
+    flips blocked → ready."""
+    await backend.create(_task("d", assignee="sd"))
+    await backend.create(_task("a", deps=["d"]))
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+    await backend.update_status("d", "completed", caller_session_id="sd")
+    promoted = await backend.recompute_readiness("d")
+    assert [t.task_id for t in promoted] == ["a"]
+    assert (await backend.get("a")).status is TaskState.READY
+
+
+@pytest.mark.asyncio
+async def test_partially_satisfied_dependent_stays_blocked(backend):
+    """Tier 2b: a dependent with one of two deps completed stays blocked."""
+    await backend.create(_task("d1", assignee="s1"))
+    await backend.create(_task("d2", assignee="s2"))
+    await backend.create(_task("a", deps=["d1", "d2"]))
+    await backend.update_status("d1", "completed", caller_session_id="s1")
+    promoted = await backend.recompute_readiness("d1")
+    assert promoted == []
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_recompute_is_os_authority_no_assignee_session(backend):
+    """Tier 2b: the blocked→ready write takes NO caller_session_id and bypasses
+    the assignee CAS (OS scheduling, P3) — the dependent's assignee is a different
+    session, yet the OS promotes it with no session context."""
+    await backend.create(_task("d", assignee="sd"))
+    await backend.create(_task("a", deps=["d"], assignee="sa"))
+    await backend.update_status("d", "completed", caller_session_id="sd")
+    promoted = await backend.recompute_readiness("d")  # no caller identity at all
+    assert [t.task_id for t in promoted] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_readiness_and_edges_persist_across_sqlite_reload(tmp_path):
+    """Tier 2b: the promoted readiness + the dependency edge survive a sqlite
+    close + reopen from disk (durable, not in-memory cache)."""
+    path = tmp_path / "persist.db"
+    b = SqliteTaskBackend(path)
+    await b.create(_task("d", assignee="sd"))
+    await b.create(_task("a", deps=["d"]))
+    await b.update_status("d", "completed", caller_session_id="sd")
+    await b.recompute_readiness("d")
+    b.close()
+
+    reopened = SqliteTaskBackend(path)
+    a = await reopened.get("a")
+    assert a is not None and a.status is TaskState.READY and a.deps == ["d"]
+    reopened.close()
+
+
+# ── pure cycle helper ───────────────────────────────────────────────────────
+
+
+def test_find_cycle_path_detects_and_clears():
+    """Tier 2b: the shared pure cycle helper returns the closing path for a
+    cycle-forming edge and None for a non-cycle (diamond) edge."""
+    graph = {"a": ["b"], "b": ["c"], "c": []}
+    deps_of = lambda n: graph.get(n, [])  # noqa: E731
+    # c→a closes a→b→c→a.
+    assert find_cycle_path(deps_of, "c", "a") == ["c", "a", "b", "c"]
+    # a→c is a diamond shortcut, no cycle (c has no path back to a).
+    assert find_cycle_path(deps_of, "a", "c") is None
+
+
+# ── op layer: OQ-5 error dict + completion-driven recompute + P6 ────────────
+
+
+class _Recorder:
+    """A real recording event log (not a mock) capturing emit() calls."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **fields) -> None:
+        self.events.append((kind, fields))
+
+
+def _opctx(backend, *, events=None, session_id="req"):
+    return SimpleNamespace(session_id=session_id, agent_id="a",
+                           events=events, task_backend=backend)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_op_add_dependency_cycle_returns_error_dict():
+    """Tier 2b: a cycle-forming edge through the op layer returns a structured
+    error dict (OQ-5) — not a raised exception through the dispatcher."""
+    b = InMemoryTaskBackend()
+    await b.create(_task("a", requester="req"))
+    await b.create(_task("b", requester="req"))
+    await taskmod._add_dependency(SimpleNamespace(task_id="a", depends_on="b"),
+                                  _opctx(b), "control_ir")
+    res = await taskmod._add_dependency(SimpleNamespace(task_id="b", depends_on="a"),
+                                        _opctx(b), "control_ir")
+    assert res["status"] == "error"
+    assert res["error"]["kind"] == "cycle"
+    assert res["error"]["edge"] == ["b", "a"]
+    assert res["error"]["path"][0] == "b" and res["error"]["path"][-1] == "b"
+
+
+@pytest.mark.asyncio
+async def test_op_create_dangling_dep_returns_error_dict():
+    """Tier 2b: create(deps=[non-existent]) through the op layer returns the
+    dep_not_found error dict (OQ-1/OQ-5)."""
+    b = InMemoryTaskBackend()
+    op = SimpleNamespace(name="x", assignee=None, origin="self", description=None,
+                         budget_cap=None, deps=["ghost"], parent_id=None)
+    res = await taskmod._create(op, _opctx(b), "control_ir")
+    assert res["status"] == "error"
+    assert res["error"]["kind"] == "dep_not_found"
+    assert res["error"]["edge"][1] == "ghost"
+
+
+@pytest.mark.asyncio
+async def test_op_update_status_completion_drives_readiness_and_emits_p6():
+    """Tier 2b: completing a predecessor through task.update_status drives the
+    OS readiness recompute and emits a generic P6 task_readiness event."""
+    b = InMemoryTaskBackend()
+    rec = _Recorder()
+    await b.create(_task("d", assignee="sd"))
+    await b.create(_task("a", deps=["d"], assignee="sa"))
+    # Complete d (ctx.session_id must equal d's assignee for the CAS).
+    res = await taskmod._update_status(
+        SimpleNamespace(task_id="d", status="completed"),
+        _opctx(b, events=rec, session_id="sd"), "control_ir")
+    assert res["status"] == "ok"
+    # a was promoted → exactly one task_readiness event for a (behavioral, not a
+    # size pin): which task readied, triggered by which predecessor.
+    readied = [(f["task_id"], f["trigger"]) for k, f in rec.events if k == "task_readiness"]
+    assert readied == [("a", "d")]
+    assert (await b.get("a")).status is TaskState.READY
+
+
+@pytest.mark.asyncio
+async def test_op_update_status_non_completion_does_not_recompute():
+    """Tier 2b: a non-completed transition (e.g. in_progress) does NOT drive
+    readiness — only `completed` satisfies a dependency edge."""
+    b = InMemoryTaskBackend()
+    rec = _Recorder()
+    await b.create(_task("d", assignee="sd"))
+    await b.create(_task("a", deps=["d"], assignee="sa"))
+    await taskmod._update_status(
+        SimpleNamespace(task_id="d", status="in_progress"),
+        _opctx(b, events=rec, session_id="sd"), "control_ir")
+    assert [k for k, _ in rec.events if k == "task_readiness"] == []
+    assert (await b.get("a")).status is TaskState.BLOCKED

--- a/tests/test_task_sqlite_backend_1953.py
+++ b/tests/test_task_sqlite_backend_1953.py
@@ -28,6 +28,9 @@ async def test_nondefault_task_round_trips_across_reload_from_disk(tmp_path):
     """Tier 2: a fully non-default task survives a close + reopen from disk."""
     path = _db(tmp_path)
     backend = SqliteTaskBackend(path)
+    # #1953 slice 6 (OQ-1): deps must reference existing tasks — create them first.
+    await backend.create(Task(task_id="d-1", name="d1", assignee="bob", requester="alice"))
+    await backend.create(Task(task_id="d-2", name="d2", assignee="bob", requester="alice"))
     task = Task(
         task_id="t-1", name="ship", assignee="bob", requester="alice",
         origin=TaskOrigin.EXTERNAL, status=TaskState.BLOCKED,
@@ -155,6 +158,9 @@ async def test_add_dependency_and_comment(tmp_path):
     """Tier 2: dependency edges + comments persist."""
     backend = SqliteTaskBackend(_db(tmp_path))
     await backend.create(Task(task_id="t", name="n", assignee="b", requester="r"))
+    # #1953 slice 6 (OQ-1): the depends_on task must exist (a dangling dep is
+    # rejected as an instant deadlock), so create it first.
+    await backend.create(Task(task_id="u", name="u", assignee="b", requester="r"))
     updated = await backend.add_dependency("t", "u")
     assert updated is not None and updated.deps == ["u"]
 


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 6 (Task dependency-DAG, §13). Seam-map design-check-first reviewed + GO'd by lead-coder (all OQ rulings + the born-blocked surface confirmed). The DAG stays acyclic-by-construction and a predecessor reaching `completed` drives OS-authority readiness scheduling.

## What (per OQ ruling)
- **Cycle-check (OQ-4/OQ-5)** — a shared pure `find_cycle_path` helper + a backend `_validate_edge` guard called by **both** `add_dependency` AND `create(deps)` (completeness-by-construction; both insert `task_links`). A cycle-forming edge raises a domain exception that the op layer maps to a **decision-enabling error dict** (`status="error"`, `error.kind="cycle"`, the offending `edge` + cycle `path`) — **never a raised exception through the dispatcher**.
- **Existence (OQ-1)** — a dangling `depends_on` is rejected (instant latent deadlock), on both edge paths.
- **Born-blocked (OQ-3 origin of `blocked`)** — `create` OS-derives `blocked` when a task is born with not-all-completed deps (§13); a **deps-less create keeps its requested status** (the A2A 5b create path is unaffected). `add_dependency` is **pure-topology** (OQ-2 — never flips the assignee's status).
- **Completion-driven readiness (OQ-3, LOAD-BEARING)** — `recompute_readiness(completed_task_id)` is a **new backend method** (InMemory + sqlite + Protocol) that flips a fully-satisfied dependent `blocked → ready`. It is an **OS scheduling write (P3) that BYPASSES the assignee CAS** (no `caller_session_id`, like `abort`), triggered from the `task.update_status` handler on a `completed` transition, emitting a generic P6 `task_readiness` event (**not** a WAL closed-vocab kind — WAL-vs-P6 separation, P7).
- **OQ-8** — `idx_task_links_depends_on` index for the reverse (dependents) lookup.

## Excluded → slice 7 (documented gap)
`OQ-7`/`H5` (terminal-non-completed dep → dependent's fate) + `§16`/`H4` deletion-mediation. Slice 6 is **happy-path only**: a `dep-aborted → dependent-stuck` task is the known, documented slice-7 gap (liveness backstop / eager-fail is the owner-decision lead surfaced).

## Tests (real sqlite + in-memory, parametrized — no mocks)
`tests/test_task_dag_slice6_1953.py`, every axis CLEAN-RED falsified:
- cycle reject (self / 2- / N-cycle, with the offending path) + non-cycle DAG accept;
- dangling dep reject on **both** create and add_dependency;
- born-blocked (incomplete deps) / deps-less keeps status / all-completed-deps not blocked;
- completed-predecessor promotes a satisfied dependent + emits P6 / partially-satisfied stays blocked;
- **OS-authority** recompute promotes with **no assignee session**;
- sqlite reload-from-disk persists readiness + edges;
- op-layer OQ-5 error dict (cycle + dep_not_found) + `task.update_status`-driven recompute + P6 emit; non-completion does NOT recompute.

Updated 2 pre-slice-6 sqlite tests that seeded dummy (non-existent) dep ids — now correctly rejected by OQ-1, so they create the dep task first.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8160 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip` missing dataset, `test_legacy_no_media_store_path` missing media-store) which pass in CI.
- [x] Targeted task + op + registry suite (86 tests) green.
- [x] **ruff** clean + **test-tier audit** `--strict` exit 0 on the new/changed test files (the 3 CI gates, run locally per the pre-PR lesson).
- [x] Each DAG mechanism (cycle-check, born-blocked, completion-recompute, OS-authority) CLEAN-RED falsified then restored to green.
- [x] `control-ir.md` synced (DAG edge-guard + completion-driven readiness sections; removed the "still landing" note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)