### PR TITLE
fix(#1984): _PlanStepHost family-gates recognize qualified tool names

### DIFF
--- a/src/reyn/runtime/planner.py
+++ b/src/reyn/runtime/planner.py
@@ -552,37 +552,56 @@ class _PlanStepHost:
 
     # ── Catalog narrowing — what tools / skills / agents are visible ──────
 
+    def _uses_family(self, legacy: frozenset[str], qualified_prefix: str) -> bool:
+        """True when this step's tools name a member of a tool family — by its
+        LEGACY name OR its qualified ``<category>__*`` name (#1984).
+
+        Default plans use the **qualified** names (#1657 enumerate-all flat-lists
+        ``skill__x`` / ``file__read`` / …), while pre-#1657 / self-contained plans
+        use the **legacy** names (``invoke_skill`` / ``read_file`` / …). The narrow
+        host's per-family plumbing must recognize BOTH, else a default-mode step
+        that names ``skill__x`` is silently starved of the skill catalog (its
+        ``available_skills`` resolves to ``[]`` → the universal catalog drops the
+        skill category). Purely additive: a legacy-name step is byte-identical."""
+        return bool(self._tool_set & legacy) or any(
+            t.startswith(qualified_prefix) for t in self._tool_set
+        )
+
     def list_available_skills(self) -> list[dict]:
-        # Skills only visible if the step asked for invoke_skill / describe_skill.
-        if _INVOKE_SKILL_TOOL_NAME in self._tool_set or "describe_skill" in self._tool_set:
+        # Skills only visible if the step asked for them (invoke_skill / describe_skill
+        # legacy, or any qualified skill__* — #1984: the latter was the live break).
+        if self._uses_family(frozenset({_INVOKE_SKILL_TOOL_NAME, "describe_skill"}), "skill__"):
             return self._parent.list_available_skills()
         return []
 
     def list_available_agents(self) -> list[dict]:
-        if _DELEGATE_TOOL_NAME in self._tool_set or "describe_agent" in self._tool_set:
+        if self._uses_family(frozenset({_DELEGATE_TOOL_NAME, "describe_agent"}), "multi_agent__"):
             return self._parent.list_available_agents()
         return []
 
     def get_memory_index(self) -> dict:
-        if "list_memory" in self._tool_set or "read_memory_body" in self._tool_set:
+        if self._uses_family(frozenset({"list_memory", "read_memory_body"}), "memory_operation__"):
             return self._parent.get_memory_index()
         return {"status": "not_found", "content": ""}
 
     def get_file_permissions(self) -> dict | None:
-        if self._tool_set & _FILE_TOOL_NAMES:
+        # Consumed by the ``universal`` scheme's build_tools (the enumerate-all
+        # default catalogs file as a static category, so this is masked there —
+        # but the universal scheme is config-selectable, so keep it correct, #1984).
+        if self._uses_family(_FILE_TOOL_NAMES, "file__"):
             return self._parent.get_file_permissions()
         return None
 
     def get_mcp_servers(self) -> list[dict]:
-        if self._tool_set & _MCP_TOOL_NAMES:
+        if self._uses_family(_MCP_TOOL_NAMES, "mcp__"):
             return self._parent.get_mcp_servers()
         return []
 
     def get_web_fetch_allowed(self) -> bool:
         # FP-0022: web_fetch is always allowed at the catalog level; authorization
         # is enforced at the handler level. Return True when the step's tool_set
-        # includes web_fetch, matching the parent's always-True behavior.
-        return _WEB_FETCH_TOOL_NAME in self._tool_set
+        # includes web_fetch (legacy or qualified web__*, #1984).
+        return self._uses_family(frozenset({_WEB_FETCH_TOOL_NAME}), "web__")
 
     def get_project_context(self) -> str:
         # Project context narrowed out by default — plan steps work from

--- a/tests/test_planner_qualified_name_predicates_1984.py
+++ b/tests/test_planner_qualified_name_predicates_1984.py
@@ -1,0 +1,123 @@
+"""Tier 2: #1984 — _PlanStepHost family-gates recognize qualified tool names.
+
+Post-#1657 the default (enumerate-all) scheme flat-lists actions by their
+QUALIFIED ``<category>__<entry>`` names, so a plan step's ``tools`` carry e.g.
+``skill__code_review`` / ``file__read``. The `_PlanStepHost` per-family plumbing
+keyed only on the LEGACY names (``invoke_skill`` / ``read_file`` / …), so a
+default-mode step was silenced of its family data — most importantly its
+``available_skills`` resolved to ``[]``, which makes the universal catalog drop
+the **skill** resource category → ``skill__*`` uncallable from the step.
+
+Falsification:
+- a qualified-name step now plumbs each of the 6 families (RED pre-fix);
+- a legacy-name step still plumbs (byte-identical — purely additive);
+- an unrelated step still silences (the narrowing is preserved);
+- the catalog-level proof: a ``skill__x`` step's host feeds ``rs.available_skills``
+  so the universal-catalog skill category enumerates ``skill__x`` (RED pre-fix —
+  the skill was absent = uncallable).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.runtime.planner import _PlanStepHost
+from reyn.tools import universal_catalog
+from reyn.tools.types import ToolContext
+
+
+class _FakeParent:
+    """A real (non-mock) parent host exposing the family data the narrow host
+    plumbs through when the step asks for that family."""
+
+    def list_available_skills(self):
+        return [{"name": "code_review", "description": "review code"}]
+
+    def list_available_agents(self):
+        return [{"name": "helper", "description": "a helper agent"}]
+
+    def get_memory_index(self):
+        return {"status": "ok", "content": "index"}
+
+    def get_mcp_servers(self):
+        return [{"name": "srv", "description": "a server"}]
+
+    def get_file_permissions(self):
+        return {"read": ["/repo"]}
+
+    def get_web_fetch_allowed(self):
+        return True
+
+
+def _host(tools):
+    return _PlanStepHost(
+        plan=None, step=SimpleNamespace(tools=tools), prior_results={},
+        parent=_FakeParent(),
+    )
+
+
+# (family, qualified tool, legacy tool, probe → truthy-when-plumbed)
+_FAMILIES = [
+    ("skill",  "skill__code_review",            "invoke_skill",      lambda h: h.list_available_skills()),
+    ("agent",  "multi_agent__delegate",         "delegate_to_agent", lambda h: h.list_available_agents()),
+    ("memory", "memory_operation__list_memory", "list_memory",       lambda h: h.get_memory_index().get("status") == "ok"),
+    ("file",   "file__read",                    "read_file",         lambda h: h.get_file_permissions()),
+    ("mcp",    "mcp__call_tool",                "call_mcp_tool",      lambda h: h.get_mcp_servers()),
+    ("web",    "web__fetch",                    "web_fetch",          lambda h: h.get_web_fetch_allowed()),
+]
+
+
+@pytest.mark.parametrize("family,qualified,legacy,probe", _FAMILIES, ids=[f[0] for f in _FAMILIES])
+def test_qualified_name_step_plumbs_family(family, qualified, legacy, probe):
+    """Tier 2: a default-mode step naming the QUALIFIED tool plumbs its family
+    (RED pre-#1984 — qualified names didn't match the legacy gate)."""
+    assert probe(_host([qualified])), f"qualified {qualified!r} did not plumb {family}"
+
+
+@pytest.mark.parametrize("family,qualified,legacy,probe", _FAMILIES, ids=[f[0] for f in _FAMILIES])
+def test_legacy_name_step_still_plumbs(family, qualified, legacy, probe):
+    """Tier 2: a legacy-name step still plumbs — the fix is purely additive
+    (legacy plans byte-identical)."""
+    assert probe(_host([legacy])), f"legacy {legacy!r} stopped plumbing {family}"
+
+
+@pytest.mark.parametrize("family,qualified,legacy,probe", _FAMILIES, ids=[f[0] for f in _FAMILIES])
+def test_unrelated_step_silences_family(family, qualified, legacy, probe):
+    """Tier 2: an unrelated step (no member of the family) still silences it — the
+    per-step narrowing (small LLM calls) is preserved."""
+    assert not probe(_host(["compact_context"])), f"{family} leaked into an unrelated step"
+
+
+def test_skill_step_makes_skill_callable_in_universal_catalog():
+    """Tier 2: #1984 catalog-level proof — a ``skill__x`` step's host feeds
+    ``rs.available_skills``, so the universal-catalog skill category enumerates
+    ``skill__code_review`` (i.e. it is CALLABLE from the step). RED pre-fix: the
+    host returned ``[]`` → the skill category enumerated empty → uncallable."""
+    host = _host(["skill__code_review"])
+    # The chain under test: the (fixed) host predicate feeds rs.available_skills
+    # exactly as RouterLoop._build_router_caller_state does (router_loop.py:3930).
+    rs = SimpleNamespace(
+        available_skills=host.list_available_skills(),
+        excluded_categories=frozenset(),
+    )
+    ctx = ToolContext(events=None, permission_resolver=None, workspace=None,
+                      caller_kind="router", router_state=rs)
+
+    entries = universal_catalog._enumerate_category("skill", ctx)
+    qualified = [e["qualified_name"] for e in entries]
+    assert "skill__code_review" in qualified, (
+        "the skill is absent from the step catalog (uncallable) — the host "
+        "plumbing did not feed rs.available_skills"
+    )
+
+
+def test_skill_absent_when_host_silences_is_the_pre_fix_state():
+    """Tier 2: the same chain with an empty ``available_skills`` (the pre-#1984
+    starved state) enumerates no skill — pinning that the catalog faithfully
+    reflects the host plumbing (so the proof above is meaningful, not vacuous)."""
+    rs = SimpleNamespace(available_skills=[], excluded_categories=frozenset())
+    ctx = ToolContext(events=None, permission_resolver=None, workspace=None,
+                      caller_kind="router", router_state=rs)
+    entries = universal_catalog._enumerate_category("skill", ctx)
+    assert "skill__code_review" not in [e["qualified_name"] for e in entries]


### PR DESCRIPTION
**[e2e-coder]** — #1984 (planner skill-gap). Fix-plan design-check-first reviewed + GO'd by lead-coder ((a) all-6-gates, (b) keep+qualified-aware, purely-additive, catalog-level-proof). Off-lane pickup; the "needs-verify" was resolved with a live probe + catalog code-trace before any code change.

## The break (verified)
Post-#1657 the default **enumerate-all** scheme flat-lists actions by their **qualified** `<category>__<entry>` names, so a plan step's `tools` carry e.g. `skill__code_review`. But `_PlanStepHost`'s per-family plumbing keyed only on **legacy** names (`invoke_skill` / `read_file` / …).

- **Live probe**: a qualified-name step silenced every predicate (`list_available_skills() == []`, `get_file_permissions() is None`, …); a legacy-name step returned the real data.
- **Catalog code-trace**: `skill` is a **resource category** gated by `rs.available_skills` (= `host.list_available_skills()`, `router_loop.py:3930`) → `[]` → the universal catalog drops the skill category (`universal_catalog.py:642`) → **`skill__*` UNCALLABLE from the step** = the real default-mode break. `file`/`web` are **static categories** (masked in enumerate-all, but still gate the config-selectable `universal` scheme's `build_tools` → the predicates are kept-because-used, not dead). `mcp` management verbs are static (fine); only per-tool actions gated (minor).

## Fix (fix-class complete, purely additive)
All **6** family-gates (skill / agent / memory / file / mcp / web) made qualified-name-aware via one `_uses_family(legacy, qualified_prefix)` helper — a step "uses" a family if it names a legacy tool **or** any `<category>__*` tool. Verified the category prefixes against `universal_catalog` (agents = `multi_agent__`, memory = `memory_operation__`, not guessed). A legacy-name step is **byte-identical**; an unrelated step still **silences** (the per-step narrowing that keeps step LLM calls small is preserved).

## Tests (`tests/test_planner_qualified_name_predicates_1984.py`)
- Predicate unit per family × {qualified plumbs, legacy plumbs, unrelated silences}.
- **Catalog-level proof**: a `skill__x` step's host feeds `rs.available_skills` so the universal-catalog skill category enumerates `skill__x` (= callable) — the "skill uncallable" repro the issue asked for, at unit cost; plus a non-vacuousness guard (empty host → skill absent).
- Qualified-awareness **CLEAN-RED falsified**: reverting `_uses_family` to legacy-only fails 7 (all qualified-plumb tests + the catalog proof); legacy/unrelated unaffected.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8180 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path`) which pass in CI.
- [x] Planner / router / universal_catalog sweep (344 tests) green.
- [x] 3 CI gates local: **ruff** clean + **test-tier audit** `--strict` exit 0 + pytest.
- [x] Qualified-awareness CLEAN-RED falsified then restored to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)