### PR TITLE
fix(#1989): strip provider function-calling namespace prefix from tool names

### DIFF
--- a/src/reyn/runtime/planner.py
+++ b/src/reyn/runtime/planner.py
@@ -55,6 +55,7 @@ from reyn.runtime.router_loop import (
     RouterLoop,
     RouterLoopHost,
 )
+from reyn.tools.universal_catalog import strip_provider_tool_namespace
 
 if TYPE_CHECKING:
     from reyn.config import PlannerStepCompactionConfig
@@ -332,18 +333,27 @@ def parse_and_validate_plan(args: dict, *, allowed_tool_names: set[str]) -> Plan
             raise PlanValidationError(
                 f"plan.steps[{i}] (id={sid!r}).tools must be a list (use [] for narration-only steps)"
             )
-        tools_tuple: tuple[str, ...] = tuple(raw_tools)
-        for t in tools_tuple:
+        # #1989: a weak model (Gemini) sometimes writes a tool name with its
+        # function-calling namespace prefix (``default_api.invoke_action``) as a
+        # step-tools VALUE. Normalize it away BEFORE the membership check AND
+        # before storing, so the step carries the bare name downstream (the
+        # narrow host / dispatch see the catalog name). Safe: reyn names are
+        # dot-free (see strip_provider_tool_namespace).
+        normalized: list[str] = []
+        for t in raw_tools:
             if not isinstance(t, str):
                 raise PlanValidationError(
                     f"plan.steps[{i}] (id={sid!r}).tools[*] must be strings"
                 )
-            if t not in allowed_tool_names:
+            nt = strip_provider_tool_namespace(t)
+            if nt not in allowed_tool_names:
                 raise PlanValidationError(
                     f"plan.steps[{i}] (id={sid!r}).tools references {t!r} "
                     f"which is not in the available tool catalog. "
                     f"Allowed: {sorted(allowed_tool_names)}"
                 )
+            normalized.append(nt)
+        tools_tuple: tuple[str, ...] = tuple(normalized)
         raw_deps = raw.get("depends_on", [])
         if not isinstance(raw_deps, list):
             raise PlanValidationError(

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3155,7 +3155,13 @@ class RouterLoop:
         **Resolution only** (no dispatch), so the scheme's ``interpret`` runs it and
         the OS exclude-gates the result BEFORE ``execute`` — preserving the #1406/#187
         pre-dispatch order across the scheme split (byte-identical)."""
-        name = tc["function"]["name"]
+        from reyn.tools.universal_catalog import strip_provider_tool_namespace  # noqa: PLC0415
+
+        # #1989: a weak model (Gemini) may echo its function-calling namespace
+        # onto the call name (``default_api.invoke_action`` /
+        # ``default_api.web__search``). Strip it FIRST so the catalog membership +
+        # the ``__`` salvage below see the bare name. Safe: reyn names are dot-free.
+        name = strip_provider_tool_namespace(tc["function"]["name"])
         try:
             args = json.loads(tc["function"]["arguments"])
         except (json.JSONDecodeError, KeyError):

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -165,6 +165,31 @@ def is_valid_qualified_name(qualified_name: str) -> bool:
     return True
 
 
+# ── provider tool-name normalization (#1989) ───────────────────────────────
+
+# Known LLM function-calling namespace prefixes a model may echo onto a tool
+# name. Gemini wraps tools in a ``default_api`` namespace and a weak model
+# sometimes emits ``default_api.<tool>`` (e.g. ``default_api.invoke_action`` /
+# ``default_api.web__search``) — both as a function-call name and, observed in
+# #1989, as a string value inside a ``plan``'s step ``tools``. Stripping a
+# leading one is SAFE for EVERY provider: reyn tool names never contain a ``.``
+# — qualified names use ``__`` (``_NAME_SEPARATOR``) and bare verbs use single
+# underscores — so a dot-delimited ``<namespace>.`` prefix can never be part of a
+# legit reyn name. Extending the set (e.g. OpenAI ``functions.``) is a one-line add.
+_PROVIDER_TOOL_NAMESPACES: tuple[str, ...] = ("default_api.",)
+
+
+def strip_provider_tool_namespace(name: str) -> str:
+    """Strip a leading provider function-calling namespace prefix from a tool
+    name (#1989). A no-op for a name without a known prefix (so it is safe to
+    apply unconditionally). Safe across providers because reyn names are
+    dot-free, so a ``<namespace>.`` prefix is never part of a legit name."""
+    for ns in _PROVIDER_TOOL_NAMESPACES:
+        if name.startswith(ns):
+            return name[len(ns):]
+    return name
+
+
 # ── D14 visibility gating helpers ──────────────────────────────────────────
 
 

--- a/tests/test_provider_tool_namespace_strip_1989.py
+++ b/tests/test_provider_tool_namespace_strip_1989.py
@@ -1,0 +1,151 @@
+"""Tier 2: #1989 — strip a provider function-calling namespace prefix from tool names.
+
+A weak model (Gemini) sometimes echoes its ``default_api`` function-calling
+namespace onto a tool name — both as a ``plan`` step-tools VALUE
+(``default_api.invoke_action`` / ``default_api.web__search``, the reported
+``plan_invalid``) and, latently, as an actual function-call NAME. ``reyn`` tool
+names are dot-free (qualified use ``__``, bare verbs single underscores), so
+stripping a leading ``<namespace>.`` is safe for every provider (a no-op when
+absent). The shared helper is applied at BOTH surfaces (validator + dispatch).
+
+Falsification:
+- the helper strips a known prefix and is a no-op for a dot-free / bare name;
+- the plan validator accepts a ``default_api.``-prefixed step tool + stores the
+  bare name (RED pre-#1989 = ``plan_invalid``); a genuinely-unknown tool still
+  rejects (no over-acceptance);
+- the dispatch resolver strips the prefix so the call hits the catalog / salvage.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.runtime.planner import PlanValidationError, parse_and_validate_plan
+from reyn.runtime.router_loop import RouterLoop
+from reyn.tools.universal_catalog import strip_provider_tool_namespace
+
+# ── 1. the helper ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("default_api.invoke_action", "invoke_action"),      # bare verb under namespace
+    ("default_api.web__search", "web__search"),          # qualified under namespace
+    ("invoke_action", "invoke_action"),                  # bare, no prefix → no-op
+    ("web__search", "web__search"),                      # qualified, no prefix → no-op
+    ("file__read", "file__read"),                        # dot-free legit name → untouched
+    ("", ""),                                            # empty → no-op
+])
+def test_strip_provider_tool_namespace(raw, expected):
+    """Tier 2: strips a known provider namespace prefix; a no-op otherwise (so it
+    is safe to apply unconditionally — reyn names are dot-free)."""
+    assert strip_provider_tool_namespace(raw) == expected
+
+
+def test_strip_does_not_touch_a_non_leading_or_unknown_namespace():
+    """Tier 2: only a LEADING known prefix is stripped — a name that merely
+    contains the token, or an unknown provider namespace, is left intact (no
+    over-strip)."""
+    assert strip_provider_tool_namespace("skill__default_api.thing") == "skill__default_api.thing"
+    assert strip_provider_tool_namespace("functions.invoke_action") == "functions.invoke_action"
+
+
+# ── 2. the plan validator (the reported surface) ────────────────────────────
+
+
+def _plan_args(tools_step1, tools_step2):
+    return {
+        "goal": "do the thing",
+        "steps": [
+            {"id": "s1", "description": "first", "tools": tools_step1, "depends_on": []},
+            {"id": "s2", "description": "second", "tools": tools_step2, "depends_on": ["s1"]},
+        ],
+    }
+
+
+def test_validator_accepts_namespaced_tool_and_stores_bare_name():
+    """Tier 2: a ``default_api.``-prefixed step tool validates (RED pre-#1989 =
+    plan_invalid) AND the stored step carries the BARE name downstream."""
+    plan = parse_and_validate_plan(
+        _plan_args(["default_api.invoke_action"], ["default_api.web__search"]),
+        allowed_tool_names={"invoke_action", "web__search"},
+    )
+    assert plan.steps[0].tools == ("invoke_action",)
+    assert plan.steps[1].tools == ("web__search",)
+
+
+def test_validator_still_accepts_bare_names_unaffected():
+    """Tier 2: a bare-name plan is unaffected — the strip is purely additive (a
+    no-op for names without a provider prefix)."""
+    plan = parse_and_validate_plan(
+        _plan_args(["invoke_action"], ["web__search"]),
+        allowed_tool_names={"invoke_action", "web__search"},
+    )
+    assert plan.steps[0].tools == ("invoke_action",)
+    assert plan.steps[1].tools == ("web__search",)
+
+
+def test_validator_still_rejects_genuinely_unknown_tool():
+    """Tier 2: a real unknown tool (not a namespace artifact) still rejects — the
+    strip does not over-accept."""
+    with pytest.raises(PlanValidationError):
+        parse_and_validate_plan(
+            _plan_args(["invoke_action"], ["totally_made_up_tool"]),
+            allowed_tool_names={"invoke_action", "web__search"},
+        )
+
+
+# ── 3. the dispatch resolver (the fix-class extension) ──────────────────────
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, type: str, **data: Any) -> None:
+        self.events.append((type, dict(data)))
+
+
+class _ResolveShim:
+    """Minimal RouterLoop surface to exercise the real ``_resolve_tool_call`` +
+    ``_maybe_salvage_qualified_direct_call`` (bound from RouterLoop — no dup)."""
+
+    chain_id = "test-chain"
+    _resolve_tool_call = RouterLoop._resolve_tool_call
+    _maybe_salvage_qualified_direct_call = RouterLoop._maybe_salvage_qualified_direct_call
+
+    def __init__(self, catalog) -> None:
+        self._catalog = catalog
+
+        class _Host:
+            events = _RecordingEvents()
+        self.host = _Host()
+
+
+def _tc(name, arguments="{}"):
+    return {"function": {"name": name, "arguments": arguments}}
+
+
+def test_resolve_strips_namespace_so_bare_name_hits_catalog():
+    """Tier 2: ``default_api.invoke_action`` as a call NAME → stripped → hits the
+    catalog directly (RED pre-#1989 = unknown_tool)."""
+    shim = _ResolveShim(catalog={"invoke_action": object()})
+    name, args = shim._resolve_tool_call(_tc("default_api.invoke_action", '{"x": 1}'))
+    assert name == "invoke_action"
+    assert args == {"x": 1}
+
+
+def test_resolve_strips_namespace_then_salvages_qualified_call_name():
+    """Tier 2: ``default_api.web__search`` as a call NAME → stripped → ``web__search``
+    (not in catalog, has ``__``) → salvaged to invoke_action(action_name=...)."""
+    shim = _ResolveShim(catalog={"invoke_action": object()})
+    name, args = shim._resolve_tool_call(_tc("default_api.web__search", '{"query": "q"}'))
+    assert name == "invoke_action"
+    assert args == {"action_name": "web__search", "args": {"query": "q"}}
+
+
+def test_resolve_bare_name_is_unchanged():
+    """Tier 2: a normal bare call name is unaffected (no-op strip)."""
+    shim = _ResolveShim(catalog={"invoke_action": object()})
+    name, _ = shim._resolve_tool_call(_tc("invoke_action"))
+    assert name == "invoke_action"


### PR DESCRIPTION
**[e2e-coder]** — #1989 (Gemini `default_api.` namespace-prefix → intermittent `plan_invalid`). Triage verdict + fix-path design-check reviewed + GO'd by lead-coder (helper reused at validator + dispatch salvage, scope (i) targeted via a known-namespace set).

## Triage verdict (design-investigation)
**Legit provider-normalization, not gemini-overfit.** A weak model (Gemini) echoes its `default_api` function-calling namespace onto a tool name — observed (tui-coder live tmux trace) as a `plan` step-tools VALUE (`default_api.invoke_action` / `default_api.web__search`), which the validator's strict membership check rejected.

**Safety (the load-bearing fact, primary-sourced)**: reyn tool names **never contain a `.`** — qualified names use `__` (`_NAME_SEPARATOR`), bare verbs use single underscores; categories are `skill / multi_agent / mcp / file / web / …` (no `default_api`). Gemini's `default_api.` is dot-delimited, so a leading strip **cannot collide** with any legit name → safe for every provider (a no-op when absent).

## Fix (fix-class complete)
- New `strip_provider_tool_namespace(name)` helper (`universal_catalog`, beside `build_qualified_name`) backed by a `_PROVIDER_TOOL_NAMESPACES` set (`{"default_api."}`; extending to e.g. OpenAI `functions.` is a one-line add).
- Applied at **both** surfaces:
  - **plan validator** (`planner.parse_and_validate_plan`) — normalize each step tool before the membership check AND **store the bare name** so the step carries the catalog name downstream.
  - **dispatch resolver** (`router_loop._resolve_tool_call`) — normalize the call name before the catalog check, closing the latent gap where the existing `__`-only salvage wouldn't handle a `default_api.`-prefixed **call name**.

## Tests (`tests/test_provider_tool_namespace_strip_1989.py`)
- Helper: strips a known prefix; no-op for bare / dot-free-legit / non-leading / unknown-namespace names (**no over-strip**).
- Validator: accepts a `default_api.`-prefixed step tool + stores the bare name (RED pre-fix = `plan_invalid`); still **rejects** a genuinely-unknown tool.
- Dispatch resolver: strips → hits the catalog directly, and strips → salvages a qualified call name (`default_api.web__search` → `invoke_action(action_name=web__search)`).
- Strip **CLEAN-RED falsified**: as a no-op, 5 fail (helper + validator-accept + both resolve-strips); the bare/no-op/reject cases stay green.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8204 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path`) which pass in CI.
- [x] planner / router_loop / dispatch / universal_catalog sweep (603 tests) green.
- [x] 3 CI gates local: **ruff** clean + **test-tier audit** `--strict` exit 0 + pytest.
- [x] Strip CLEAN-RED falsified then restored to green.

Note on verification posture: the Gemini emission is tui-coder's primary live evidence (relayed) — I'm net-isolated + strong-gemini is cost-gated, so I verified the strip **safety** + **locus** (primary-source) rather than re-reproducing the emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)