### PR TITLE
fix(#1983): single-source the ControlIROp union from OP_KIND_MODEL_MAP + enforce mcp_drop_server (Finding 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Single format for all phases:
 - NEVER describe Control IR format in Phase instructions (P8)
 - ALWAYS validate LLM output (Transition + Finish above)
 - ALWAYS emit events for state changes (P6)
-- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/core/op_runtime/registry.py`. New op kinds get a section in the reference in the same PR.
+- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `ControlIROp` union derives from the same map). New op kinds get a section in the reference in the same PR.
 
 ## Testing policy (READ BEFORE WRITING TESTS)
 

--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -471,7 +471,7 @@ class ControlIRExecutor:
         if allowed_ops is not None:
             catalog_ops = allowed_ops
         else:
-            from reyn.core.op_runtime.registry import OP_KIND_MODEL_MAP
+            from reyn.schemas.models import OP_KIND_MODEL_MAP
             catalog_ops = set(OP_KIND_MODEL_MAP.keys())
         tool_catalog = _build_phase_tool_catalog(catalog_ops)
 

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -46,6 +46,7 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "mcp_install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
     }),
+    "mcp_drop_server": frozenset({"mcp__drop_server"}),
     "mcp": frozenset(),
     # control-IR-only ops with no distinct chat-tool qualified name → kind only.
     "run_skill": frozenset(),

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -12,9 +12,11 @@ execution backend (``op_runtime/file.py`` ``register("file", handle)``)
 is KEPT — fine handlers still build ``FileIROp(kind="file")`` internally.
 
   1. ``OP_KIND_MODEL_MAP`` — op kind → IROp Pydantic model.
+     **Relocated to ``reyn.schemas.models`` (#1983)** (co-located with IROp
+     classes; registry re-imports ``ALL_OP_KINDS`` from there).
      Schema derivation is done by ``reyn.tools.ToolRegistry``
-     entries (= ADR-0026 Phase 4-3); this map is retained as a
-     stable target for ``ALL_OP_KINDS`` and purity classification.
+     entries (= ADR-0026 Phase 4-3); the map remains the stable target
+     for ``ALL_OP_KINDS`` and purity classification.
 
   2. ``ALL_OP_KINDS`` — frozenset of op kinds.  Used by the DSL
      linter to flag misspelled ``allowed_ops`` entries; also drives
@@ -43,39 +45,14 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel
-
-from reyn.schemas.models import (
-    AskUserIROp,
-    CompactIROp,
-    DeleteFileIROp,
-    EditFileIROp,
-    GlobFilesIROp,
-    GrepFilesIROp,
-    IndexDropIROp,
-    IndexQueryIROp,
-    JudgeOutputIROp,
-    LintIROp,
-    MCPInstallIROp,
-    MCPIROp,
-    ReadFileIROp,
-    RecallIROp,
-    RunSkillIROp,
-    SandboxedExecIROp,
-    SkillResolveIROp,
-    TaskAbortIROp,
-    TaskAddDependencyIROp,
-    TaskCommentIROp,
-    TaskCreateIROp,
-    TaskGetIROp,
-    TaskHeartbeatIROp,
-    TaskListIROp,
-    TaskRegisterUnblockPredicateIROp,
-    TaskUpdateStatusIROp,
-    WebFetchIROp,
-    WebSearchIROp,
-    WriteFileIROp,
-)
+# #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS relocated to schemas/models.py
+# (co-located with the IROp model classes + the now-derived ControlIROp union =
+# single source; the map lived here before, but registry imports those model
+# classes, so models.py could not derive the union from the map without a cycle).
+# registry keeps the *purity* classification (OP_PURITY) and re-imports
+# ALL_OP_KINDS from models for ALL_TOOL_NAMES — an intentional op-runtime-view
+# convenience, NOT a migration shim.
+from reyn.schemas.models import ALL_OP_KINDS
 
 
 class OpPurity(str, Enum):
@@ -105,63 +82,10 @@ class OpPurity(str, Enum):
     llm = "llm"
 
 
-# ---------------------------------------------------------------------------
-# OP_KIND_MODEL_MAP
-# ---------------------------------------------------------------------------
-# Maps op kind → IROp Pydantic model used for JSON schema derivation.
-# Add a new entry here whenever a new op kind is introduced — the kernel
-# executor and DSL linter both derive from this single source.
-# ---------------------------------------------------------------------------
-
-OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
-    # #1240 Wave 2b: coarse "file" kind dropped from OP_KIND_MODEL_MAP.
-    # The execution backend (op_runtime/file.py register("file") + handle())
-    # is KEPT — fine handlers still build FileIROp(kind="file") internally.
-    # #1240 Wave 1: fine-grained file kinds (phase = chat-tools subset).
-    # control_ir_executor routes each via the registry (READ_FILE/WRITE_FILE/...
-    # ToolDefinitions, gates.phase=allow) — no separate op_runtime handler.
-    "read_file":   ReadFileIROp,
-    "write_file":  WriteFileIROp,
-    "edit_file":   EditFileIROp,
-    "delete_file": DeleteFileIROp,
-    # #1240 Wave 1.5: glob_files / grep_files fine kinds (same pattern).
-    # GLOB_FILES/GREP_FILES ToolDefinitions (tools/file.py, gates.phase=allow)
-    # route via the unified registry — same handler path chat uses.
-    "glob_files":  GlobFilesIROp,
-    "grep_files":  GrepFilesIROp,
-    "mcp":         MCPIROp,
-    "run_skill":   RunSkillIROp,
-    "lint":        LintIROp,
-    "ask_user":    AskUserIROp,
-    "web_fetch":   WebFetchIROp,
-    "web_search":  WebSearchIROp,
-    "mcp_install": MCPInstallIROp,
-    # ADR-0033: RAG-extensible OS — index_* / recall ops.
-    # #1303 Stage I: embed + index_write deleted (chunkers stream into
-    # reyn.api.safe.embed_index; recall embeds provider-direct).
-    "index_query": IndexQueryIROp,
-    "recall":      RecallIROp,
-    "index_drop":  IndexDropIROp,
-    # FP-0017: sandboxed_exec — argv under SandboxPolicy via SandboxBackend.
-    "sandboxed_exec": SandboxedExecIROp,
-    # FP-0007 Component D: LLM-based output scorer for in-phase eval loops.
-    "judge_output": JudgeOutputIROp,
-    # R-PURE-MODE Wave 5a: resolve a skill name to its on-disk path.
-    "skill_resolve": SkillResolveIROp,
-    # #272/#1128: LLM-emittable voluntary compaction (advisory; the mandatory
-    # retry_loop backstop is independent).
-    "compact": CompactIROp,
-    # #1953 slice 1: Task ops (first-class trackable work-units).
-    "task.create": TaskCreateIROp,
-    "task.update_status": TaskUpdateStatusIROp,
-    "task.get": TaskGetIROp,
-    "task.list": TaskListIROp,
-    "task.add_dependency": TaskAddDependencyIROp,
-    "task.abort": TaskAbortIROp,
-    "task.heartbeat": TaskHeartbeatIROp,
-    "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
-    "task.comment": TaskCommentIROp,
-}
+# #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS now live in schemas/models.py — the
+# single source (the ControlIROp discriminated union derives from the map there,
+# completeness-by-construction). Add a new op kind in models.py; ALL_OP_KINDS is
+# imported above (used by ALL_TOOL_NAMES below). registry owns only OP_PURITY.
 
 # ---------------------------------------------------------------------------
 # OP_PURITY
@@ -200,6 +124,8 @@ OP_PURITY: dict[str, OpPurity] = {
     "ask_user":    OpPurity.side_effect,
     # MCP server install: writes config + secrets, runs registry fetch.
     "mcp_install": OpPurity.side_effect,
+    # #1983: MCP server drop — mutates config (removes a server entry).
+    "mcp_drop_server": OpPurity.side_effect,
     # ADR-0033 RAG ops (#1303 Stage I: embed + index_write deleted):
     # - index_query: read-only, depends on backend state (= world).
     "index_query": OpPurity.world,
@@ -245,21 +171,8 @@ def get_op_purity(op_kind: str) -> OpPurity:
     return OP_PURITY.get(op_kind, OpPurity.side_effect)
 
 
-# ---------------------------------------------------------------------------
-# ALL_OP_KINDS
-# ---------------------------------------------------------------------------
-# Coarse-name set (= OP_KIND_MODEL_MAP.keys()).  These are the kinds phase
-# Control IR emits in ``op.kind`` today, the names ``allowed_ops``
-# frontmatter targets, and the rows OP_PURITY classifies.  Fine-grained
-# router-side names (= read_file / write_file / call_mcp_tool / etc.) are
-# NOT in this set; they live in the unified ToolRegistry (reyn.tools).
-# When phase Control IR migrates to fine-grained kinds in a future phase,
-# this set will expand to a union of coarse + fine.  Until then, the
-# ``is_op_allowed`` helper below covers the prefix-wildcard semantics for
-# any fine-grained kinds the future phase emits.
-# ---------------------------------------------------------------------------
-
-ALL_OP_KINDS: frozenset[str] = frozenset(OP_KIND_MODEL_MAP.keys())
+# ALL_OP_KINDS is imported from schemas/models.py above (single source, #1983);
+# it remains importable from this module for back-compat (intentional convenience).
 
 
 # ---------------------------------------------------------------------------

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Any, Literal, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, Field, model_serializer, model_validator
 
@@ -663,32 +663,90 @@ class TaskCommentIROp(BaseModel):
     body: str
 
 
-# Discriminated union — Pydantic selects the variant via the "kind" field.
-# All variants below are implemented in `op_runtime/`:
-#   file, mcp, ask_user, shell, lint, run_skill, web_fetch, web_search,
-#   mcp_install, embed, index_write, index_query, recall, index_drop,
-#   sandboxed_exec, judge_output, skill_resolve, compact, task.* (#1953).
-# Fine-grained file ops (#1240 Wave 1+1.5): read_file, write_file, edit_file,
-#   delete_file, glob_files, grep_files (phase=allow registry entries).
-ControlIROp = Annotated[
-    Union[
-        FileIROp,
-        # #1240 Wave 1: fine-grained file ops (coarse FileIROp retained for compat).
-        ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
-        # #1240 Wave 1.5: glob_files / grep_files fine ops.
-        GlobFilesIROp, GrepFilesIROp,
-        MCPIROp, AskUserIROp, LintIROp,
-        RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
-        IndexQueryIROp, RecallIROp, IndexDropIROp,
-        SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
-        # #1953: Task ops.
-        TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
-        TaskAddDependencyIROp, TaskAbortIROp,
-        TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
-        TaskCommentIROp,
-    ],
-    Field(discriminator="kind"),
-]
+# ── Op-kind registry — the single source for the Control IR op surface ───────
+# #1983: OP_KIND_MODEL_MAP is co-located HERE (relocated from
+# op_runtime/registry.py) so the ControlIROp union, ALL_OP_KINDS, and
+# op_runtime's purity / op_catalog all derive from ONE map. Previously the map
+# lived in registry.py — which imports these model classes — so models.py could
+# not derive the union from it without a cycle; that dual-source (hand-listed
+# union vs the map) was #1983's root cause. Add a new op kind HERE (kind → IROp
+# model); the union + ALL_OP_KINDS follow by construction. op_runtime/registry.py
+# keeps the *purity* classification (OP_PURITY) and re-imports ALL_OP_KINDS from
+# here (intentional convenience, not a migration shim).
+#
+# NOTE: the coarse "file" kind is intentionally NOT in the map (#1240 Wave 2b
+# dropped it; fine handlers still build FileIROp(kind="file") internally). It is
+# the one explicit non-map member of the union below.
+OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
+    "read_file":   ReadFileIROp,
+    "write_file":  WriteFileIROp,
+    "edit_file":   EditFileIROp,
+    "delete_file": DeleteFileIROp,
+    "glob_files":  GlobFilesIROp,
+    "grep_files":  GrepFilesIROp,
+    "mcp":         MCPIROp,
+    "run_skill":   RunSkillIROp,
+    "lint":        LintIROp,
+    "ask_user":    AskUserIROp,
+    "web_fetch":   WebFetchIROp,
+    "web_search":  WebSearchIROp,
+    "mcp_install": MCPInstallIROp,
+    # #1983: was registered + documented (control-ir.md) + handled but ABSENT
+    # here → a phase emitting it failed ActOutput validation. Added to restore
+    # the control-ir.md ↔ map sync invariant.
+    "mcp_drop_server": MCPDropServerIROp,
+    "index_query": IndexQueryIROp,
+    "recall":      RecallIROp,
+    "index_drop":  IndexDropIROp,
+    "sandboxed_exec": SandboxedExecIROp,
+    "judge_output": JudgeOutputIROp,
+    "skill_resolve": SkillResolveIROp,
+    "compact": CompactIROp,
+    "task.create": TaskCreateIROp,
+    "task.update_status": TaskUpdateStatusIROp,
+    "task.get": TaskGetIROp,
+    "task.list": TaskListIROp,
+    "task.add_dependency": TaskAddDependencyIROp,
+    "task.abort": TaskAbortIROp,
+    "task.heartbeat": TaskHeartbeatIROp,
+    "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
+    "task.comment": TaskCommentIROp,
+}
+
+# Frozenset of op kinds — DSL linter, OP_PURITY coverage, contextual gate.
+ALL_OP_KINDS: frozenset[str] = frozenset(OP_KIND_MODEL_MAP.keys())
+
+# Discriminated union — DERIVED from OP_KIND_MODEL_MAP (#1983, completeness-by-
+# construction: any kind in the map is in the union → no dual-source). FileIROp
+# (coarse "file") is the only explicit non-map member (internal-use, see note
+# above). Pydantic accepts the dynamically-built discriminated Union (verified).
+if TYPE_CHECKING:
+    # Static mirror for type-checkers only — mypy can't evaluate the runtime-built
+    # Union. The RUNTIME value derives from the map (below); this list is NOT the
+    # source of truth and is pinned in sync by the completeness-invariant test
+    # ({union kinds} == ALL_OP_KINDS ∪ {"file"}).
+    ControlIROp = Annotated[
+        Union[
+            FileIROp,
+            ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
+            GlobFilesIROp, GrepFilesIROp,
+            MCPIROp, AskUserIROp, LintIROp,
+            RunSkillIROp, WebFetchIROp, WebSearchIROp, MCPInstallIROp,
+            MCPDropServerIROp,
+            IndexQueryIROp, RecallIROp, IndexDropIROp,
+            SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
+            TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
+            TaskAddDependencyIROp, TaskAbortIROp,
+            TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
+            TaskCommentIROp,
+        ],
+        Field(discriminator="kind"),
+    ]
+else:
+    ControlIROp = Annotated[
+        Union[tuple([FileIROp, *OP_KIND_MODEL_MAP.values()])],
+        Field(discriminator="kind"),
+    ]
 
 # Resolve forward references now that ControlIROp is in scope.
 RunOpStep.model_rebuild()

--- a/tests/test_control_ir_contextual_gate_1912.py
+++ b/tests/test_control_ir_contextual_gate_1912.py
@@ -23,9 +23,8 @@ from reyn.core.op_runtime.contextual_gate import (
     op_contextually_denied,
     op_kind_tool_names,
 )
-from reyn.core.op_runtime.registry import ALL_OP_KINDS
 from reyn.data.workspace.workspace import Workspace
-from reyn.schemas.models import SandboxedExecIROp
+from reyn.schemas.models import ALL_OP_KINDS, SandboxedExecIROp
 from reyn.security.permissions.effective import ContextualPermission
 from reyn.security.permissions.permissions import PermissionResolver
 

--- a/tests/test_control_ir_union_single_source_1983.py
+++ b/tests/test_control_ir_union_single_source_1983.py
@@ -1,0 +1,98 @@
+"""Tier 2: #1983 — the ControlIROp union is single-sourced from OP_KIND_MODEL_MAP.
+
+Finding 3: ``mcp_drop_server`` was registered (universal_dispatch), documented
+(``control-ir.md``), modeled (``MCPDropServerIROp``) and handled by the executor,
+but ABSENT from the hand-listed ``ControlIROp`` discriminated union and from
+``OP_KIND_MODEL_MAP`` — so a phase emitting it failed ``ActOutput`` validation
+(advertise-but-don't-enforce; the worst direction of the control-ir.md ↔ map
+sync invariant).
+
+The fix relocates the map to ``schemas/models.py`` and DERIVES the union from it
+(``Union[(FileIROp, *OP_KIND_MODEL_MAP.values())]``) so completeness is by
+construction. These are the regression guards on that construction: a map kind
+that fails to surface in the union — or a hand-added union member outside the
+map — breaks here. Real models + the real linter; no mocks.
+
+``OP_KIND_MODEL_MAP`` / ``ALL_OP_KINDS`` are imported LOCALLY (inside the
+construction tests) so this module collects against the PRE-fix tree too,
+letting the falsifying tests give a clean RED when the fix is reverted.
+"""
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from reyn.schemas.models import ActOutput, ControlIROp
+
+
+def _union_member_kinds() -> set[str]:
+    """The literal ``kind`` of every member of the ControlIROp discriminated union.
+
+    ``ControlIROp == Annotated[Union[...], Field(discriminator="kind")]`` →
+    ``get_args(...)[0]`` is the ``Union``; its args are the member models; each
+    member's ``kind`` field is a ``Literal["<kind>"]``.
+    """
+    union = get_args(ControlIROp)[0]
+    kinds: set[str] = set()
+    for member in get_args(union):
+        kind_ann = member.model_fields["kind"].annotation
+        kinds.add(get_args(kind_ann)[0])
+    return kinds
+
+
+def test_union_members_complete_vs_map():
+    """Tier 2: union member kinds == OP_KIND_MODEL_MAP keys ∪ {"file"}.
+
+    Falsify: a kind in the map but missing from the union (the Finding-3 bug) —
+    or a hand-added union member outside the map — breaks this. The coarse
+    ``file`` op (``FileIROp``) is the only deliberate non-map member."""
+    from reyn.schemas.models import OP_KIND_MODEL_MAP
+
+    expected = set(OP_KIND_MODEL_MAP) | {"file"}
+    actual = _union_member_kinds()
+    missing_from_union = expected - actual
+    extra_in_union = actual - expected
+    assert not missing_from_union, f"map kinds missing from union: {sorted(missing_from_union)}"
+    assert not extra_in_union, f"union members outside map (+file): {sorted(extra_in_union)}"
+
+
+def test_all_op_kinds_is_exactly_map_keys():
+    """Tier 2: ALL_OP_KINDS is exactly the map keys (single-source frozenset —
+    no separately-maintained kind list can drift from the map)."""
+    from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP
+
+    assert set(ALL_OP_KINDS) == set(OP_KIND_MODEL_MAP)
+
+
+def test_mcp_drop_server_validates_through_act_output():
+    """Tier 2: Finding-3 falsifying — an act turn carrying an ``mcp_drop_server``
+    op validates. PRE-fix (kind absent from the union) this raised
+    ValidationError — the exact bug: registered + documented + handled but not
+    enforceable. Revert the fix and this goes RED."""
+    out = ActOutput.model_validate(
+        {"type": "act", "ops": [{"kind": "mcp_drop_server", "server": "stale_srv"}]}
+    )
+    assert out.ops[0].kind == "mcp_drop_server"
+    assert out.ops[0].server == "stale_srv"
+
+
+def test_mcp_drop_server_is_a_known_allowed_op():
+    """Tier 2: Finding-3 falsifying — ``mcp_drop_server`` is in ``ALL_TOOL_NAMES``,
+    the complete op-kind set the DSL linter validates ``allowed_ops`` against
+    (``linter.py`` imports it as ``_KNOWN_ALLOWED_OPS_NAMES``). PRE-fix the kind
+    was absent from the set, so a phase declaring it in ``allowed_ops`` was
+    flagged 'not a known Control IR op kind' and silently filtered at runtime —
+    advertised + handled but not declarable."""
+    from reyn.core.op_runtime.registry import ALL_TOOL_NAMES
+
+    assert "mcp_drop_server" in ALL_TOOL_NAMES
+
+
+def test_derived_union_still_rejects_unknown_kind():
+    """Tier 2: deriving the union from the map did NOT open the discriminator to
+    arbitrary kinds — an unknown kind is still rejected (closed-set invariant)."""
+    adapter = TypeAdapter(ControlIROp)
+    with pytest.raises(ValidationError):
+        adapter.validate_python({"kind": "no_such_op_kind_xyz", "server": "x"})

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -537,8 +537,7 @@ def test_mcp_install_irop_model_defaults():
 
 def test_mcp_install_irop_in_op_kind_model_map():
     """Tier 2: mcp_install is registered in OP_KIND_MODEL_MAP."""
-    from reyn.core.op_runtime.registry import OP_KIND_MODEL_MAP
-    from reyn.schemas.models import MCPInstallIROp
+    from reyn.schemas.models import OP_KIND_MODEL_MAP, MCPInstallIROp
 
     assert "mcp_install" in OP_KIND_MODEL_MAP
     assert OP_KIND_MODEL_MAP["mcp_install"] is MCPInstallIROp
@@ -546,7 +545,7 @@ def test_mcp_install_irop_in_op_kind_model_map():
 
 def test_mcp_install_in_all_op_kinds():
     """Tier 2: mcp_install is in ALL_OP_KINDS (used by DSL linter)."""
-    from reyn.core.op_runtime.registry import ALL_OP_KINDS
+    from reyn.schemas.models import ALL_OP_KINDS
 
     assert "mcp_install" in ALL_OP_KINDS
 

--- a/tests/test_op_purity_classification.py
+++ b/tests/test_op_purity_classification.py
@@ -15,12 +15,8 @@ Reference: PR-memo-purity-fix M1 in the active plan.
 """
 from __future__ import annotations
 
-from reyn.core.op_runtime.registry import (
-    ALL_OP_KINDS,
-    OP_PURITY,
-    OpPurity,
-    get_op_purity,
-)
+from reyn.core.op_runtime.registry import OP_PURITY, OpPurity, get_op_purity
+from reyn.schemas.models import ALL_OP_KINDS
 
 # ---------------------------------------------------------------------------
 # Per-op-kind classification

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -19,14 +19,9 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime import execute_op
 from reyn.core.op_runtime.context import OpContext
-from reyn.core.op_runtime.registry import (
-    ALL_OP_KINDS,
-    OP_KIND_MODEL_MAP,
-    OP_PURITY,
-    OpPurity,
-)
+from reyn.core.op_runtime.registry import OP_PURITY, OpPurity
 from reyn.data.workspace.workspace import Workspace
-from reyn.schemas.models import SandboxedExecIROp
+from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, SandboxedExecIROp
 from reyn.security.permissions.permissions import PermissionDecl
 from reyn.security.sandbox import (
     NoopBackend,

--- a/tests/test_op_skill_resolve.py
+++ b/tests/test_op_skill_resolve.py
@@ -15,9 +15,9 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime import execute_op
 from reyn.core.op_runtime.context import OpContext
-from reyn.core.op_runtime.registry import OP_KIND_MODEL_MAP, OP_PURITY, OpPurity
+from reyn.core.op_runtime.registry import OP_PURITY, OpPurity
 from reyn.data.workspace.workspace import Workspace
-from reyn.schemas.models import SkillResolveIROp
+from reyn.schemas.models import OP_KIND_MODEL_MAP, SkillResolveIROp
 from reyn.security.permissions.permissions import PermissionDecl
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import pytest
 
-from reyn.core.op_runtime.registry import OP_KIND_MODEL_MAP
+from reyn.schemas.models import OP_KIND_MODEL_MAP
 from reyn.tools import get_default_registry
 
 # Coarse op kinds that dispatch through the unified registry.
@@ -53,6 +53,9 @@ _REGISTRY_WIRED_KINDS: frozenset[str] = frozenset({
     "lint",
     # #1240 Wave 2b: "mcp" and "run_skill" moved to _LEGACY_ONLY_KINDS (see below).
     "mcp_install",
+    # #1983: mcp_drop_server has a phase=allow ToolDefinition (tools/mcp_drop.py
+    # MCP_DROP_SERVER_OP) — registry-wired, same pattern as mcp_install.
+    "mcp_drop_server",
     "recall",
     "sandboxed_exec",
     "web_fetch",

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -21,8 +21,8 @@ from pydantic import TypeAdapter
 from reyn.core.op_runtime import available_kinds
 from reyn.core.op_runtime import task as taskmod
 from reyn.core.op_runtime.contextual_gate import _OP_KIND_ALIASES
-from reyn.core.op_runtime.registry import ALL_OP_KINDS, OP_KIND_MODEL_MAP, OP_PURITY
-from reyn.schemas.models import ControlIROp
+from reyn.core.op_runtime.registry import OP_PURITY
+from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, ControlIROp
 from reyn.task import InMemoryTaskBackend, Task, TaskState
 
 _TASK_KINDS = frozenset(k for k in ALL_OP_KINDS if k.startswith("task."))

--- a/tests/test_universal_dispatch_skill_op_coverage_1212.py
+++ b/tests/test_universal_dispatch_skill_op_coverage_1212.py
@@ -164,7 +164,7 @@ def _skill_real_op_kinds(skill_dir: Path) -> dict[str, set[str]]:
     """
     # Import here so the test can be collected without a full reyn install; the
     # import is deferred to function body so collection errors surface as test errors.
-    from reyn.core.op_runtime.registry import ALL_OP_KINDS  # noqa: PLC0415
+    from reyn.schemas.models import ALL_OP_KINDS  # noqa: PLC0415
 
     op_to_sources: dict[str, set[str]] = {}
 
@@ -334,7 +334,7 @@ def test_op_kind_category_map_references_known_skills_only() -> None:
     for an op kind that doesn't exist in the OS registry — that would be
     a stale entry silently hiding a missing op kind.
     """
-    from reyn.core.op_runtime.registry import ALL_OP_KINDS  # noqa: PLC0415
+    from reyn.schemas.models import ALL_OP_KINDS  # noqa: PLC0415
 
     stale = {k for k in _OP_KIND_CATEGORY if k not in ALL_OP_KINDS}
     assert stale == set(), (


### PR DESCRIPTION
**[dogfood-coder]** — Addresses **Finding 3 of #1983** (the HIGH one). Finding 4 (`op_catalog` truncation) is split to **#1993** — see "Scope" below.

## The bug (Finding 3)

The `ControlIROp` discriminated union (`schemas/models.py`) was **hand-listed separately** from the authoritative `OP_KIND_MODEL_MAP` (`op_runtime/registry.py`) — a dual-source. `mcp_drop_server` was registered (`universal_dispatch`), documented (`control-ir.md`), modeled (`MCPDropServerIROp`) and handled by the executor, but **absent from both the union and the map** → a phase emitting it failed `ActOutput` validation (`union_tag_invalid`). Advertise-but-don't-enforce — the worst direction of the `control-ir.md` ↔ map sync invariant.

## The fix (lead-approved D1 = relocate, clean-break)

The map's **location** was why the union couldn't derive from it: `registry.py` imports the IROp model classes, so `models.py` importing registry's map would cycle. So:

- **Relocate** `OP_KIND_MODEL_MAP` + `ALL_OP_KINDS` into `schemas/models.py` (co-located with the IROp classes + the union). `registry.py` keeps `OP_PURITY` and re-imports `ALL_OP_KINDS` from models for `ALL_TOOL_NAMES` — an intentional op-runtime-view convenience, documented (not a migration shim).
- **Derive** the union from the map: `Union[(FileIROp, *OP_KIND_MODEL_MAP.values())]` — completeness **by construction**. `FileIROp` (coarse `file`) is the only deliberate non-map member. A `TYPE_CHECKING` static mirror keeps mypy precise.
- **Add** `mcp_drop_server`: map + `OP_PURITY` (side_effect) + `_OP_KIND_ALIASES` + the phase-dispatch wired set. The union + `ALL_OP_KINDS` follow by construction.
- **Repoint** all importers (`control_ir_executor` + 8 tests) registry → models (clean-break, no shim). `CLAUDE.md` sync-rule ref updated (`registry.py` → `schemas/models.py`).

Commits: `26e8f839` (relocation + cascade), `68615eda` (tests).

## Scope: Finding 4 deferred → #1993 (please confirm)

Reading the code showed Finding 4 (`op_catalog` truncated) is a **different, more entangled change** than the original #1983 plan assumed, so I split it out rather than rush it at the tail of this change:

- `op_catalog = available_ops()`, and `available_ops()` uses **chat-name aliases** (`call_mcp_tool`→`mcp`) + **per-config filtering** (`call_mcp_tool` only with `_mcp_servers`) — not a clean slice of `ALL_OP_KINDS`.
- The `phase_op_catalog_gap` warning keys off `available_ops`, **not** `op_catalog` — so the plan's **D3 ("remove the now-inert gap-warning") rests on a false premise** and is NOT done here.
- There may be a broader `available_ops()` advertisement gap (are task ops reachable in a phase today?) that needs verification first.

Full analysis + proposed direction in #1993. **If you'd rather Finding 4 land in this PR, say so and I'll fold it in.**

## Verification (primary evidence)

- **RED→GREEN**: reverted the fix files to `origin/main` → the falsifying test fails with `union_tag_invalid` (pre-fix union lacks `mcp_drop_server`); restored → validates. Captured live.
- **Completeness by construction + test**: union member kinds == `OP_KIND_MODEL_MAP` keys ∪ `{"file"}`; `ALL_OP_KINDS` == map keys; unknown kind still rejected (closed-set).
- **No cycle**: `import reyn.schemas.models, …registry, …control_ir_executor, …runtime, …linter` → OK.
- **Regression**: 109 passed across the relocation importers + op/control-ir/runtime/contextual-gate consumers.
- **ruff** clean (changed src + test); **tier-audit --strict** clean on the new test (5 OK, 0 violations).

## Test plan

- [x] new Tier-2 guards pass (`tests/test_control_ir_union_single_source_1983.py`, 5 passed)
- [x] RED→GREEN of the falsifying test verified by reverting the fix
- [x] no circular import (5-module import smoke)
- [x] 109-test regression across changed-module importers
- [x] ruff + tier-audit --strict clean
- [ ] (lead) flow-trace review of the relocation cascade — core-refactor + `CLAUDE.md` touch, per your #1983 note

Requesting **flow-trace review** (you flagged core-refactor + CLAUDE.md as careful-review). sandbox_2 does not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
