### PR TITLE
feat(#1953): slice 6-ext — mutable dependency ops + abort/failed→parent routing

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -38,6 +38,8 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `task.get` | Read one Task record | requester-gated |
 | `task.list` | List Tasks (filter by assignee / requester / status / parent) | none (filtered read) |
 | `task.add_dependency` | Add a depends-on edge (dependency DAG) | requester-gated |
+| `task.remove_dependency` | Drop a depends-on edge (idempotent); may promote a now-satisfied dependent | requester-gated |
+| `task.repoint_dependency` | Atomically repoint an edge `from_depends_on`→`to_depends_on` (cycle-checked first); re-evals readiness | requester-gated |
 | `task.abort` | Remove-op (= delete): archive the task + sub-tree (cooperative-terminal) | requester-gated |
 | `task.heartbeat` | Liveness / unblock-predicate trigger for a blocked Task | assignee-gated |
 | `task.register_unblock_predicate` | Register a deterministic unblock predicate | assignee-gated |
@@ -533,17 +535,36 @@ status (the requester does not write the assignee's status). A task born with
 not-all-completed deps is **OS-derived `blocked`** at create (deps-less tasks keep
 their requested status).
 
-**Completion-driven readiness (OS-authority).** When a predecessor reaches
-`completed`, `task.update_status` drives an OS readiness recompute: each dependent
-whose deps are **all** `completed` transitions `blocked → ready`, emitting a
-generic P6 `task_readiness` event. This `blocked → ready` write is an **OS
-scheduling transition** (P3) — like `abort`, it is a dedicated backend method that
-**bypasses the assignee CAS** (it is not an assignee progress write). A
-non-`completed` terminal dep (`failed` / `aborted`) does not satisfy an edge
-(liveness backstop lands in a later slice).
+**Mutable edges (slice 6-ext).** `task.remove_dependency` drops an edge
+(idempotent — a no-op on a missing edge); `task.repoint_dependency` atomically
+repoints `from_depends_on` → `to_depends_on`, **cycle-checking the NEW edge BEFORE
+any mutation** (a cycle/dangling repoint changes nothing and returns the same
+structured error). Both are requester topology writes that go through the same
+shared edge-guard, then run the **OS-authority readiness re-derive**.
 
-Still landing in later slices: unblock-predicate evaluation; terminal-non-completed
-dependency handling (liveness backstop).
+**Readiness re-derive (OS-authority, P3).** A single primitive derives a task's
+readiness over the **pre-run** scheduling states `{pending, ready, blocked}`:
+promote `blocked → ready` when all deps are satisfied (incl. a deps-less task —
+removing the last dep readies it), re-block `{pending, ready} → blocked` when they
+are not. An `in_progress` (the assignee owns the run) or terminal task is left
+untouched — this is the single-writer split (the OS schedules pre-run, the
+assignee owns the run), and the write **bypasses the assignee CAS** like `abort`.
+Completion-recompute (relax → only promotes), `remove` (relax), and `repoint`
+(may demote or promote) all share it. A readiness change emits a generic P6
+`task_readiness` event.
+
+**Disposition → parent routing (slice 6-ext).** When a task reaches a
+non-`completed` terminal (`aborted` via `task.abort`, or `failed` via
+`task.update_status`) and has **still-alive dependents**, the OS routes the
+disposition to the task's **parent session** (`parent_id`'s assignee) to decide
+recovery — the parent re-wires via ordinary ops (`repoint` / `remove` / fail /
+support-self), **not** a `decision=` vocabulary (P7). Emits a generic P6
+`task_dependency_aborted`. A root task (no parent) or an already-terminal parent
+routes nothing (the parent's own cascade subsumes it). The session **wake** is the
+slice-7 `TaskWaker` (stubbed here via `OpContext.task_waker`).
+
+Still landing in later slices: the `TaskWaker` driver (turns the events into a
+session wake) + unblock-predicate evaluation.
 
 ---
 

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -193,6 +193,13 @@ class OpContext:
     # across BOTH the control-IR and preprocessor ctx-build seams.
     task_backend: "object | None" = None
 
+    # #1953 slice 6-ext: the OS TaskWaker driver (parallel to task_backend). The
+    # abort/failed → parent-routing hub calls it to wake the parent's session to
+    # decide recovery. None = no-op stub here (slice 7 wires the real TaskWaker +
+    # threads it through the same Session → SkillRuntime → OSRuntime chain). Tests
+    # inject a recording waker to verify the call-site fires.
+    task_waker: "object | None" = None
+
     # #1953 slice 3 (rework): the caller's session identity (#1814 per-contextId
     # routing-key ``Session._session_id``), threaded down the same chain. This is
     # the single-writer key for Task ``update_status`` — the backend CAS-rejects

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -61,6 +61,8 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "task.get": frozenset(),
     "task.list": frozenset(),
     "task.add_dependency": frozenset(),
+    "task.remove_dependency": frozenset(),
+    "task.repoint_dependency": frozenset(),
     "task.abort": frozenset(),
     "task.heartbeat": frozenset(),
     "task.register_unblock_predicate": frozenset(),

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -153,6 +153,8 @@ OP_PURITY: dict[str, OpPurity] = {
     "task.create": OpPurity.side_effect,
     "task.update_status": OpPurity.side_effect,
     "task.add_dependency": OpPurity.side_effect,
+    "task.remove_dependency": OpPurity.side_effect,
+    "task.repoint_dependency": OpPurity.side_effect,
     "task.abort": OpPurity.side_effect,
     "task.heartbeat": OpPurity.side_effect,
     "task.register_unblock_predicate": OpPurity.side_effect,
@@ -196,7 +198,8 @@ COARSE_TO_FINE: dict[str, frozenset[str]] = {
     # declare allowed_ops: [task] to permit the whole Task op family.
     "task": frozenset({
         "task.create", "task.update_status", "task.get", "task.list",
-        "task.add_dependency", "task.abort", "task.heartbeat",
+        "task.add_dependency", "task.remove_dependency", "task.repoint_dependency",
+        "task.abort", "task.heartbeat",
         "task.register_unblock_predicate", "task.comment",
     }),
 }

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -28,6 +28,7 @@ from reyn.task import (
     TaskOrigin,
     TaskState,
 )
+from reyn.task.model import TERMINAL_STATES
 
 from . import register
 from .context import OpContext
@@ -191,6 +192,11 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
                 # closed-vocab kind (WAL-vs-P6 separation, P7).
                 events.emit("task_readiness", task_id=p.task_id, to="ready",
                             trigger=op.task_id)
+    elif task.status is TaskState.FAILED:
+        # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
+        # doesn't satisfy a dependency edge → route the disposition to the parent's
+        # session to decide recovery (the OQ-7/H5 gap-close; wake stubbed → slice 7).
+        await _route_terminal_to_parent(ctx, _backend(ctx), task)
     return _ok("task.update_status", task=task.to_dict())
 
 
@@ -229,6 +235,89 @@ async def _add_dependency(op, ctx: OpContext, caller) -> dict:
     return _ok("task.add_dependency", task=task.to_dict())
 
 
+def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigger: str) -> None:
+    """Emit the generic P6 ``task_readiness`` event when an OS re-derive changed a
+    task's readiness (#1953 slice 6-ext). ``before_status`` is captured from the
+    role-gate fetch (pre-mutation), so this fires only on an actual transition and
+    only for the pre-run readiness states (ready / blocked)."""
+    if task.status is before_status:
+        return
+    if task.status not in (TaskState.READY, TaskState.BLOCKED):
+        return
+    events = getattr(ctx, "events", None)
+    if events is not None:
+        events.emit("task_readiness", task_id=task.task_id,
+                    to=task.status.value, trigger=trigger)
+
+
+async def _route_terminal_to_parent(ctx: OpContext, backend, terminal_task) -> None:
+    """slice 6-ext §C: when a task reaches a non-completed terminal (aborted /
+    failed) and has STILL-ALIVE dependents, notify its parent's session to decide
+    recovery (the parent re-wires via ordinary ops — NOT a `decision=` vocabulary,
+    P7). The wake is via ``OpContext.task_waker`` (slice 7 real driver; None here =
+    no-op stub — only the P6 audit fires). Guards: a root task (no parent) and a
+    parent that is itself terminal (its own cascade handles it) route nothing."""
+    parent_id = getattr(terminal_task, "parent_id", None)
+    if not parent_id:
+        return
+    deps_on_it = await backend.dependents(terminal_task.task_id)
+    stuck = [d for d in deps_on_it if d.status not in TERMINAL_STATES]
+    if not stuck:
+        return
+    parent = await backend.get(parent_id)
+    if parent is None or parent.status in TERMINAL_STATES:
+        return  # parent-gone guard (the parent's own cascade subsumes this)
+    events = getattr(ctx, "events", None)
+    if events is not None:
+        # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation).
+        events.emit(
+            "task_dependency_aborted", task_id=terminal_task.task_id,
+            disposition=terminal_task.status.value, parent_id=parent_id,
+            parent_session=parent.assignee, dependents=[d.task_id for d in stuck],
+        )
+    waker = getattr(ctx, "task_waker", None)
+    if waker is not None:
+        await waker.notify_parent_decide(
+            parent_session=parent.assignee, terminal_task=terminal_task, dependents=stuck,
+        )
+
+
+async def _remove_dependency(op, ctx: OpContext, caller) -> dict:
+    # requester-gated: the decomposing requester owns the dependency topology (§13).
+    _task, denied = await _authorize(
+        "task.remove_dependency", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
+    before = _task.status  # captured pre-mutation (InMemory mutates in place)
+    task = await _backend(ctx).remove_dependency(op.task_id, op.depends_on)
+    if task is None:
+        return _not_found("task.remove_dependency", op.task_id)
+    _audit(ctx, "task.remove_dependency", op.task_id, depends_on=op.depends_on)
+    _emit_readiness_if_changed(ctx, task, before, op.task_id)
+    return _ok("task.remove_dependency", task=task.to_dict())
+
+
+async def _repoint_dependency(op, ctx: OpContext, caller) -> dict:
+    # requester-gated: the parent re-wires the topology (its recovery move, §C).
+    _task, denied = await _authorize(
+        "task.repoint_dependency", ctx, _backend(ctx), op.task_id, "requester")
+    if denied is not None:
+        return denied
+    before = _task.status
+    try:
+        task = await _backend(ctx).repoint_dependency(
+            op.task_id, op.from_depends_on, op.to_depends_on)
+    except (TaskCycleError, TaskDepNotFoundError) as err:
+        # The NEW edge is dangling or cycle-forming → nothing changed (atomic).
+        return _edge_error("task.repoint_dependency", err)
+    if task is None:
+        return _not_found("task.repoint_dependency", op.task_id)
+    _audit(ctx, "task.repoint_dependency", op.task_id,
+           from_depends_on=op.from_depends_on, to_depends_on=op.to_depends_on)
+    _emit_readiness_if_changed(ctx, task, before, op.task_id)
+    return _ok("task.repoint_dependency", task=task.to_dict())
+
+
 async def _abort(op, ctx: OpContext, caller) -> dict:
     # requester-gated remove-op (§model abort=delete). Cooperative-terminal
     # (Option B): the backend archives the task + its sub-tree (DOWN-cascade);
@@ -253,6 +342,10 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
                 requester=t.requester, origin=t.origin.value, root=op.task_id,
             )
     root = aborted[0]
+    # slice 6-ext §C: route the aborted root to its parent so a stuck sibling
+    # dependent gets a recovery decision (the OQ-7/H5 gap-close). The cascade's
+    # descendants have an in-subtree (now terminal) parent → the guard skips them.
+    await _route_terminal_to_parent(ctx, _backend(ctx), root)
     return _ok("task.abort", task=root.to_dict())
 
 
@@ -287,6 +380,8 @@ register("task.update_status", _update_status)
 register("task.get", _get)
 register("task.list", _list)
 register("task.add_dependency", _add_dependency)
+register("task.remove_dependency", _remove_dependency)
+register("task.repoint_dependency", _repoint_dependency)
 register("task.abort", _abort)
 register("task.heartbeat", _heartbeat)
 register("task.register_unblock_predicate", _register_unblock_predicate)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -588,9 +588,11 @@ class TaskCreateIROp(BaseModel):
 
 
 class TaskUpdateStatusIROp(BaseModel):
-    """Declare a status transition. Writer = the task's assignee; the gate is a
-    backend-CAS on the caller's skill-run run_id (threaded from OpContext, not a
-    field here — audit C2), enforced in slice 3."""
+    """Declare a status transition. Writer = the task's **assignee session**; the
+    gate is a fixed-equality backend CAS ``assignee == caller_session_id``
+    (``OpContext.session_id``, the #1814 routing-key — threaded, not a field here).
+    The assignee is immutable, so no claim token / run_id / version is needed; a
+    terminal task rejects all writes (the cooperative-terminal guard)."""
 
     kind: Literal["task.update_status"]
     task_id: str
@@ -617,18 +619,43 @@ class TaskListIROp(BaseModel):
 
 class TaskAddDependencyIROp(BaseModel):
     """Add a depends-on edge (dependency DAG, §13). Topology owned by the
-    decomposing parent; readiness is derived read-only (no write to the dep).
-    Cycle-check lands in slice 6."""
+    decomposing requester; readiness is derived read-only (no write to the dep).
+    Existence + cycle-checked via the shared edge-guard (slice 6)."""
 
     kind: Literal["task.add_dependency"]
     task_id: str
     depends_on: str
 
 
+class TaskRemoveDependencyIROp(BaseModel):
+    """Drop a depends-on edge (#1953 slice 6-ext). Requester topology write,
+    idempotent (no-op on a missing edge). Dropping an edge only relaxes the graph,
+    so the OS re-derive may promote a now-satisfied blocked dependent (incl. the
+    last-dep-removed → ready case); it never demotes."""
+
+    kind: Literal["task.remove_dependency"]
+    task_id: str
+    depends_on: str
+
+
+class TaskRepointDependencyIROp(BaseModel):
+    """Atomically repoint an edge ``from_depends_on`` → ``to_depends_on`` (#1953
+    slice 6-ext) — the parent's primary recovery move (point a dependent at a
+    substitute). The NEW edge is cycle-checked BEFORE any mutation (a cycle/dangling
+    repoint changes nothing, returning the structured error); then the dependent's
+    readiness is re-blocked + re-evaluated against the new graph."""
+
+    kind: Literal["task.repoint_dependency"]
+    task_id: str
+    from_depends_on: str
+    to_depends_on: str
+
+
 class TaskAbortIROp(BaseModel):
-    """OS-authority terminal cancel (→ aborted; A2A canceled). The enforced
-    contract is cooperative: ``cancel_inflight → await_quiescent → terminal``
-    (+ seq-fence) so no write lands after terminal (audit C1, slice 3)."""
+    """Requester remove-op (= delete) → ``aborted``/``archived`` (A2A canceled).
+    Cooperative-terminal: it archives the task + its sub-tree (DOWN-cascade); there
+    is no forced cancel — the assignee's in-flight work is rejected by the terminal
+    guard at its next status-write (no straggler, no sibling-kill)."""
 
     kind: Literal["task.abort"]
     task_id: str
@@ -707,6 +734,8 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "task.get": TaskGetIROp,
     "task.list": TaskListIROp,
     "task.add_dependency": TaskAddDependencyIROp,
+    "task.remove_dependency": TaskRemoveDependencyIROp,
+    "task.repoint_dependency": TaskRepointDependencyIROp,
     "task.abort": TaskAbortIROp,
     "task.heartbeat": TaskHeartbeatIROp,
     "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
@@ -736,7 +765,8 @@ if TYPE_CHECKING:
             IndexQueryIROp, RecallIROp, IndexDropIROp,
             SandboxedExecIROp, JudgeOutputIROp, SkillResolveIROp, CompactIROp,
             TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
-            TaskAddDependencyIROp, TaskAbortIROp,
+            TaskAddDependencyIROp, TaskRemoveDependencyIROp, TaskRepointDependencyIROp,
+            TaskAbortIROp,
             TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
             TaskCommentIROp,
         ],

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -110,6 +110,29 @@ class TaskBackend(Protocol):
         Returns the newly-readied tasks (so the caller emits P6 + later nudges)."""
         ...
 
+    async def dependents(self, task_id: str) -> list[Task]:
+        """Tasks that depend ON ``task_id`` (reverse edge lookup, §13) — the
+        abort/failed → parent-routing hub reads it to find stuck dependents."""
+        ...
+
+    async def remove_dependency(self, task_id: str, depends_on: str) -> Task | None:
+        """Drop a depends-on edge (#1953 slice 6-ext) — requester topology write,
+        idempotent (no-op on a missing edge). Dropping an edge only RELAXES, so the
+        OS-authority re-derive may promote a now-satisfied ``blocked`` task (incl.
+        the I-1 last-dep-removed → ready case), never demote. None for unknown task."""
+        ...
+
+    async def repoint_dependency(
+        self, task_id: str, from_depends_on: str, to_depends_on: str
+    ) -> Task | None:
+        """Atomically repoint an edge ``from_depends_on`` → ``to_depends_on``
+        (#1953 slice 6-ext) — the parent's primary recovery move. Cycle-checks the
+        NEW edge BEFORE any mutation (raises ``TaskCycleError`` / ``TaskDepNotFoundError``
+        → the op layer returns the structured error, nothing changed). Re-blocks
+        then re-evaluates readiness (the new edge may demote or the graph may now be
+        satisfied). None for unknown task."""
+        ...
+
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]: ...
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None: ...
@@ -222,22 +245,89 @@ class InMemoryTaskBackend:
         task.updated_at = _now_iso()
         return task
 
+    def _all_deps_satisfied(self, task: Task) -> bool:
+        # A dep is satisfied when it exists + is completed. No deps → vacuously
+        # satisfied (the #1953 slice 6-ext I-1 case: an ordering-free task is ready).
+        return all(
+            d in self._tasks and self._tasks[d].status == TaskState.COMPLETED
+            for d in task.deps
+        )
+
+    def _derive_readiness(self, task: Task, *, allow_demote: bool = False) -> str | None:
+        """OS-authority readiness derivation (#1953 slice 6-ext, P3 — no CAS).
+        Operates ONLY on the pre-run scheduling states {PENDING, READY, BLOCKED};
+        an IN_PROGRESS task (the assignee owns the run) or a terminal task is left
+        untouched (the single-writer split). Always promotes BLOCKED → READY when
+        all deps are satisfied; **only when ``allow_demote``** re-blocks
+        {PENDING, READY} → BLOCKED when they are not. Returns the transition
+        (``"ready"`` / ``"blocked"``) when the status changed, else None.
+
+        The shared primitive: completion-recompute + ``remove`` only RELAX the
+        graph → promote-only (``allow_demote=False``, consistent with the OQ-2
+        pure-topology rule that a mere edge change does not re-block a non-blocked
+        task); ``repoint`` is a material re-wire → full re-derive (``allow_demote=True``)."""
+        if task.status not in (TaskState.PENDING, TaskState.READY, TaskState.BLOCKED):
+            return None
+        satisfied = self._all_deps_satisfied(task)
+        if satisfied and task.status is TaskState.BLOCKED:
+            task.status = TaskState.READY
+            task.updated_at = _now_iso()
+            return "ready"
+        if allow_demote and not satisfied and task.status in (TaskState.PENDING, TaskState.READY):
+            task.status = TaskState.BLOCKED
+            task.updated_at = _now_iso()
+            return "blocked"
+        return None
+
+    async def dependents(self, task_id: str) -> list[Task]:
+        """Tasks that depend ON ``task_id`` (reverse edge lookup, §13)."""
+        return [t for t in self._tasks.values() if task_id in t.deps]
+
     async def recompute_readiness(self, completed_task_id: str) -> list[Task]:
-        # OS-authority (OQ-3): no caller_session_id, no CAS — readiness is OS
-        # scheduling (P3). Re-evaluate the just-completed task's dependents; flip
-        # blocked → ready only when ALL of a dependent's deps are completed.
+        # OS-authority (OQ-3): re-derive readiness for each dependent of the just-
+        # completed task via the shared primitive. A completion only RELAXES, so
+        # the only transition that can fire here is a promote (blocked → ready).
         promoted: list[Task] = []
         for t in self._tasks.values():
-            if t.status is not TaskState.BLOCKED or completed_task_id not in t.deps:
+            if completed_task_id not in t.deps:
                 continue
-            if all(
-                d in self._tasks and self._tasks[d].status == TaskState.COMPLETED
-                for d in t.deps
-            ):
-                t.status = TaskState.READY
-                t.updated_at = _now_iso()
+            if self._derive_readiness(t) == "ready":
                 promoted.append(t)
         return promoted
+
+    async def remove_dependency(self, task_id: str, depends_on: str) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        # Requester topology write; idempotent (no-op if the edge is absent).
+        # Dropping an edge only RELAXES → the re-derive can only promote (incl. the
+        # I-1 last-dep-removed → ready case), never demote.
+        if depends_on in task.deps:
+            task.deps.remove(depends_on)
+            task.updated_at = _now_iso()
+        self._derive_readiness(task)
+        return task
+
+    async def repoint_dependency(
+        self, task_id: str, from_depends_on: str, to_depends_on: str
+    ) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        # Cycle-check the NEW edge BEFORE any mutation (atomic): a cycle/dangling
+        # repoint raises → nothing changes. Safe with the from-edge still present
+        # (``task → from`` is task's OUTGOING edge, never on a ``to → … → task``
+        # cycle path, so no false reject).
+        self._validate_edge(task_id, to_depends_on)
+        if from_depends_on in task.deps:
+            task.deps.remove(from_depends_on)
+        if to_depends_on not in task.deps:
+            task.deps.append(to_depends_on)
+        task.updated_at = _now_iso()
+        # Re-block then re-evaluate (the new edge may TIGHTEN → demote, or the
+        # graph may now be satisfied → promote).
+        self._derive_readiness(task, allow_demote=True)
+        return task
 
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]:
         # abort = delete (cooperative-terminal, Option B): archive this task + its

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -157,6 +157,53 @@ class SqliteTaskBackend:
         if path is not None:
             raise TaskCycleError(task_id, depends_on, path)
 
+    def _all_deps_completed(self, task_id: str) -> bool:
+        # No deps → vacuously satisfied (the slice 6-ext I-1 case). Else every dep
+        # must exist + be completed.
+        deps = self._deps(task_id)
+        for d in deps:
+            row = self._conn.execute(
+                "SELECT status FROM tasks WHERE task_id=?", (d,)
+            ).fetchone()
+            if row is None or row["status"] != TaskState.COMPLETED.value:
+                return False
+        return True
+
+    def _derive_readiness(self, task_id: str, *, allow_demote: bool = False) -> str | None:
+        """OS-authority readiness derivation (#1953 slice 6-ext, P3 — no CAS) — the
+        shared primitive for recompute / remove / repoint. Sync; call INSIDE the
+        caller's ``BEGIN IMMEDIATE`` transaction. Pre-run states only
+        {pending, ready, blocked}: always promote ``blocked → ready`` when all deps
+        are satisfied; only when ``allow_demote`` re-block {pending, ready} →
+        ``blocked`` when not (recompute / remove relax → promote-only; repoint
+        re-wires → full). IN_PROGRESS / terminal left untouched (assignee owns the
+        run). Returns the transition (``"ready"`` / ``"blocked"``) or None."""
+        row = self._conn.execute(
+            "SELECT status FROM tasks WHERE task_id=?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        status = row["status"]
+        if status not in (
+            TaskState.PENDING.value, TaskState.READY.value, TaskState.BLOCKED.value
+        ):
+            return None
+        satisfied = self._all_deps_completed(task_id)
+        if satisfied and status == TaskState.BLOCKED.value:
+            new = TaskState.READY.value
+        elif allow_demote and not satisfied and status in (
+            TaskState.PENDING.value, TaskState.READY.value
+        ):
+            new = TaskState.BLOCKED.value
+        else:
+            return None
+        self._conn.execute(
+            "UPDATE tasks SET status=?, updated_at=? WHERE task_id=?",
+            (new, _now_iso(), task_id),
+        )
+        self._emit(task_id, "readiness_changed", to=new)
+        return new
+
     def _row_to_task(self, row: sqlite3.Row) -> Task:
         return Task(
             task_id=row["task_id"],
@@ -308,12 +355,75 @@ class SqliteTaskBackend:
             self._conn.commit()
             return self._fetch(task_id)
 
+    async def dependents(self, task_id: str) -> list[Task]:
+        async with self._lock:
+            rows = self._conn.execute(
+                "SELECT task_id FROM task_links WHERE depends_on=?", (task_id,)
+            ).fetchall()
+            return [t for t in (self._fetch(r["task_id"]) for r in rows) if t is not None]
+
+    async def remove_dependency(self, task_id: str, depends_on: str) -> Task | None:
+        async with self._lock:
+            if not self._exists(task_id):
+                return None
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Idempotent: DELETE is a no-op on a missing edge. Dropping an edge
+                # only RELAXES → the re-derive can only promote (incl. I-1).
+                self._conn.execute(
+                    "DELETE FROM task_links WHERE task_id=? AND depends_on=?",
+                    (task_id, depends_on),
+                )
+                self._conn.execute(
+                    "UPDATE tasks SET updated_at=? WHERE task_id=?", (_now_iso(), task_id)
+                )
+                self._emit(task_id, "dependency_removed", depends_on=depends_on)
+                self._derive_readiness(task_id)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            return self._fetch(task_id)
+
+    async def repoint_dependency(
+        self, task_id: str, from_depends_on: str, to_depends_on: str
+    ) -> Task | None:
+        async with self._lock:
+            if not self._exists(task_id):
+                return None
+            # Cycle-check the NEW edge BEFORE any mutation (read-only, pre-tx): a
+            # cycle/dangling repoint raises → nothing changes (atomic). Safe with the
+            # from-edge present (task→from is task's outgoing, never on a to→…→task path).
+            self._validate_edge(task_id, to_depends_on)
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "DELETE FROM task_links WHERE task_id=? AND depends_on=?",
+                    (task_id, from_depends_on),
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO task_links(task_id, depends_on) VALUES (?,?)",
+                    (task_id, to_depends_on),
+                )
+                self._conn.execute(
+                    "UPDATE tasks SET updated_at=? WHERE task_id=?", (_now_iso(), task_id)
+                )
+                self._emit(task_id, "dependency_repointed",
+                           from_depends_on=from_depends_on, to_depends_on=to_depends_on)
+                # Re-block then re-evaluate (may demote on the new edge or promote).
+                self._derive_readiness(task_id, allow_demote=True)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            return self._fetch(task_id)
+
     async def recompute_readiness(self, completed_task_id: str) -> list[Task]:
         """OS-authority readiness recompute (#1953 slice 6, OQ-3): no
-        ``caller_session_id`` / no CAS (P3 scheduling, like ``abort``). Flip each
-        dependent of ``completed_task_id`` from ``blocked`` → ``ready`` when ALL of
-        its deps are ``completed``. The ``WHERE status='blocked'`` guard IS the
-        OS-authority write (no assignee equality), distinct from ``update_status``."""
+        ``caller_session_id`` / no CAS (P3 scheduling, like ``abort``). Re-derive
+        readiness for each dependent of the just-completed task via the shared
+        ``_derive_readiness`` primitive — a completion only RELAXES, so only a
+        promote (``blocked → ready``) can fire here."""
         async with self._lock:
             dependents = [
                 r["task_id"] for r in self._conn.execute(
@@ -324,29 +434,8 @@ class SqliteTaskBackend:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 for dep_task in dependents:
-                    row = self._conn.execute(
-                        "SELECT status FROM tasks WHERE task_id=?", (dep_task,)
-                    ).fetchone()
-                    if row is None or row["status"] != TaskState.BLOCKED.value:
-                        continue
-                    deps = self._deps(dep_task)
-                    statuses = [
-                        (self._conn.execute(
-                            "SELECT status FROM tasks WHERE task_id=?", (d,)
-                        ).fetchone() or {"status": None})["status"]
-                        for d in deps
-                    ]
-                    if deps and all(s == TaskState.COMPLETED.value for s in statuses):
-                        cur = self._conn.execute(
-                            "UPDATE tasks SET status=?, updated_at=? "
-                            "WHERE task_id=? AND status=?",
-                            (TaskState.READY.value, _now_iso(), dep_task,
-                             TaskState.BLOCKED.value),
-                        )
-                        if cur.rowcount:
-                            self._emit(dep_task, "readiness_changed", to="ready",
-                                       trigger=completed_task_id)
-                            promoted_ids.append(dep_task)
+                    if self._derive_readiness(dep_task) == "ready":
+                        promoted_ids.append(dep_task)
                 self._conn.commit()
             except Exception:
                 self._conn.rollback()

--- a/tests/test_phase_dispatch_registry_coverage.py
+++ b/tests/test_phase_dispatch_registry_coverage.py
@@ -94,6 +94,8 @@ _LEGACY_ONLY_KINDS: frozenset[str] = frozenset({
     "task.get",
     "task.list",
     "task.add_dependency",
+    "task.remove_dependency",
+    "task.repoint_dependency",
     "task.abort",
     "task.heartbeat",
     "task.register_unblock_predicate",

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -71,6 +71,8 @@ def test_union_validates_every_task_kind():
         "task.get": {"kind": "task.get", "task_id": "t"},
         "task.list": {"kind": "task.list"},
         "task.add_dependency": {"kind": "task.add_dependency", "task_id": "t", "depends_on": "u"},
+        "task.remove_dependency": {"kind": "task.remove_dependency", "task_id": "t", "depends_on": "u"},
+        "task.repoint_dependency": {"kind": "task.repoint_dependency", "task_id": "t", "from_depends_on": "u", "to_depends_on": "v"},
         "task.abort": {"kind": "task.abort", "task_id": "t"},
         "task.heartbeat": {"kind": "task.heartbeat", "task_id": "t"},
         "task.register_unblock_predicate": {"kind": "task.register_unblock_predicate", "task_id": "t", "predicate": "x"},

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -1,0 +1,330 @@
+"""Tier 1/2: #1953 slice 6-ext — mutable dependency ops + abort/failed→parent routing.
+
+Extends slice 6 with `task.remove_dependency` / `task.repoint_dependency` (the
+parent's recovery moves) over the shared OS-authority readiness primitive
+(`_derive_readiness`: promote/demote across the pre-run states only), and routes a
+non-completed terminal (aborted/failed) with still-alive dependents to the parent's
+session (the OQ-7/H5 gap-close; the wake is the slice-7 TaskWaker, stubbed here via
+a recording waker). Real sqlite + in-memory backends; no mocks.
+
+Falsification per axis (CLEAN-RED): remove promotes a now-satisfied dependent +
+the I-1 last-dep case + idempotent + never-demotes; repoint cycle/dangling rejected
+ATOMICALLY (graph unchanged) + demote + promote + in_progress-untouched; the
+abort/failed routing fires the waker + P6 with the right parent/dependents, and the
+no-parent / parent-terminal guards route nothing.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.task import (
+    InMemoryTaskBackend,
+    SqliteTaskBackend,
+    Task,
+    TaskCycleError,
+    TaskDepNotFoundError,
+    TaskState,
+)
+
+
+def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
+          requester="req", parent_id=None):
+    return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
+                status=status, deps=list(deps or []), parent_id=parent_id)
+
+
+@pytest.fixture(params=["inmem", "sqlite"])
+def backend(request, tmp_path):
+    if request.param == "inmem":
+        yield InMemoryTaskBackend()
+    else:
+        b = SqliteTaskBackend(tmp_path / "ext.db")
+        yield b
+        b.close()
+
+
+async def _complete(backend, task_id, assignee):
+    await backend.update_status(task_id, "completed", caller_session_id=assignee)
+
+
+# ── remove_dependency ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remove_promotes_now_satisfied_dependent(backend):
+    """Tier 2: dropping the last unsatisfied edge promotes a blocked dependent."""
+    await backend.create(_task("d1", assignee="s1"))
+    await backend.create(_task("d2", assignee="s2"))
+    await backend.create(_task("a", deps=["d1", "d2"]))     # born-blocked
+    await _complete(backend, "d1", "s1")
+    await backend.recompute_readiness("d1")                 # still blocked (d2 pending)
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+    await backend.remove_dependency("a", "d2")              # only d1 (completed) left
+    assert (await backend.get("a")).status is TaskState.READY
+
+
+@pytest.mark.asyncio
+async def test_remove_last_dep_readies_i1(backend):
+    """Tier 2: I-1 — removing the LAST dep readies an ordering-free task."""
+    await backend.create(_task("d1", assignee="s1"))
+    await backend.create(_task("a", deps=["d1"]))           # born-blocked
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+    await backend.remove_dependency("a", "d1")
+    a = await backend.get("a")
+    assert a.status is TaskState.READY and a.deps == []
+
+
+@pytest.mark.asyncio
+async def test_remove_is_idempotent_on_missing_edge(backend):
+    """Tier 2: removing an absent edge is a no-op (no raise, no status flip)."""
+    await backend.create(_task("a", status=TaskState.IN_PROGRESS))
+    task = await backend.remove_dependency("a", "never-there")
+    assert task is not None and task.status is TaskState.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_remove_never_demotes(backend):
+    """Tier 2: dropping an edge only relaxes — a ready task stays ready."""
+    await backend.create(_task("d1", assignee="s1"))
+    await _complete(backend, "d1", "s1")
+    await backend.create(_task("a", deps=["d1"]))           # deps all completed → not born-blocked
+    await backend.create(_task("d2", assignee="s2"))
+    await backend.add_dependency("a", "d2")                 # a now has d2 (incomplete) — pure topology
+    # a is PENDING (add_dependency doesn't re-block, OQ-2). Removing d2 keeps it PENDING.
+    before = (await backend.get("a")).status
+    task = await backend.remove_dependency("a", "d1")
+    assert task.status is before  # relax-only never demotes a non-blocked task
+
+
+# ── repoint_dependency ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_repoint_cycle_rejected_atomically(backend):
+    """Tier 2: a cycle-forming repoint raises AND leaves the graph unchanged."""
+    await backend.create(_task("x", assignee="sx"))
+    await backend.create(_task("a", deps=["x"]))
+    await backend.create(_task("b", deps=["a"]))            # b → a
+    with pytest.raises(TaskCycleError):
+        await backend.repoint_dependency("a", "x", "b")     # a → b would close a→b→a
+    # ATOMIC: a still depends on x only (nothing changed).
+    assert (await backend.get("a")).deps == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_repoint_dangling_rejected_atomically(backend):
+    """Tier 2: a repoint to a non-existent task raises + changes nothing."""
+    await backend.create(_task("x", assignee="sx"))
+    await backend.create(_task("a", deps=["x"]))
+    with pytest.raises(TaskDepNotFoundError):
+        await backend.repoint_dependency("a", "x", "ghost")
+    assert (await backend.get("a")).deps == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_repoint_promotes_when_new_edge_satisfied(backend):
+    """Tier 2: repointing a blocked task onto a completed substitute readies it."""
+    await backend.create(_task("x", assignee="sx"))         # incomplete
+    await backend.create(_task("y", assignee="sy"))
+    await _complete(backend, "y", "sy")                     # completed substitute
+    await backend.create(_task("a", deps=["x"]))            # born-blocked on x
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+    await backend.repoint_dependency("a", "x", "y")
+    a = await backend.get("a")
+    assert a.status is TaskState.READY and a.deps == ["y"]
+
+
+@pytest.mark.asyncio
+async def test_repoint_demotes_when_new_edge_unsatisfied(backend):
+    """Tier 2: repointing a pre-run task onto an incomplete substitute re-blocks it
+    (repoint is the full re-derive — allow_demote)."""
+    await backend.create(_task("x", assignee="sx"))
+    await _complete(backend, "x", "sx")
+    await backend.create(_task("y", assignee="sy"))         # incomplete
+    await backend.create(_task("a", deps=["x"]))            # x completed → PENDING (pre-run, demotable)
+    assert (await backend.get("a")).status is TaskState.PENDING
+
+    await backend.repoint_dependency("a", "x", "y")         # now depends on incomplete y
+    assert (await backend.get("a")).status is TaskState.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_derive_readiness_leaves_in_progress_untouched(backend):
+    """Tier 2: load-bearing single-writer — repointing a dep of an IN_PROGRESS task
+    does NOT re-block it (the OS schedules pre-run states; the assignee owns the run)."""
+    await backend.create(_task("x", assignee="sx"))
+    await _complete(backend, "x", "sx")
+    await backend.create(_task("y", assignee="sy"))         # incomplete
+    await backend.create(_task("a", deps=["x"], assignee="sa"))
+    await backend.update_status("a", "in_progress", caller_session_id="sa")
+    assert (await backend.get("a")).status is TaskState.IN_PROGRESS
+
+    await backend.repoint_dependency("a", "x", "y")         # new incomplete dep
+    # untouched: the assignee owns the run, OS does not yank it back to blocked.
+    a = await backend.get("a")
+    assert a.status is TaskState.IN_PROGRESS and a.deps == ["y"]
+
+
+@pytest.mark.asyncio
+async def test_dependents_reverse_lookup(backend):
+    """Tier 2: dependents(x) returns every task that depends ON x."""
+    await backend.create(_task("x", assignee="sx"))
+    await backend.create(_task("a", deps=["x"]))
+    await backend.create(_task("b", deps=["x"]))
+    await backend.create(_task("c", assignee="sc"))         # unrelated
+    deps = await backend.dependents("x")
+    assert sorted(d.task_id for d in deps) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_repoint_persists_across_sqlite_reload(tmp_path):
+    """Tier 2: the repointed edge + the re-derived readiness survive a reload."""
+    path = tmp_path / "persist.db"
+    b = SqliteTaskBackend(path)
+    await b.create(_task("x", assignee="sx"))
+    await b.create(Task(task_id="y", name="y", assignee="sy", requester="r",
+                        status=TaskState.COMPLETED))
+    await b.create(_task("a", deps=["x"]))                  # born-blocked
+    await b.repoint_dependency("a", "x", "y")               # → ready (y completed)
+    b.close()
+    reopened = SqliteTaskBackend(path)
+    a = await reopened.get("a")
+    assert a is not None and a.status is TaskState.READY and a.deps == ["y"]
+    reopened.close()
+
+
+# ── op-layer: edge-error dict + P6 readiness + abort/failed→parent routing ──
+
+
+class _Rec:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **f) -> None:
+        self.events.append((kind, f))
+
+
+class _RecordingWaker:
+    """A real (non-mock) injectable TaskWaker recording its parent-notify calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def notify_parent_decide(self, *, parent_session, terminal_task, dependents):
+        self.calls.append({
+            "parent_session": parent_session,
+            "terminal_task": terminal_task.task_id,
+            "dependents": [d.task_id for d in dependents],
+        })
+
+
+def _opctx(backend, *, events=None, waker=None, session_id="req"):
+    return SimpleNamespace(session_id=session_id, agent_id="a",
+                           events=events, task_backend=backend, task_waker=waker)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_op_repoint_cycle_returns_edge_error_dict():
+    """Tier 2: a cycle-forming repoint through the op layer returns the structured
+    error dict (OQ-5 shape) — not a raised exception."""
+    b = InMemoryTaskBackend()
+    await b.create(_task("x", assignee="sx", requester="req"))
+    await b.create(_task("a", deps=["x"], requester="req"))
+    await b.create(_task("bb", deps=["a"], requester="req"))
+    res = await taskmod._repoint_dependency(
+        SimpleNamespace(task_id="a", from_depends_on="x", to_depends_on="bb"),
+        _opctx(b), "control_ir")
+    assert res["status"] == "error"
+    assert res["error"]["kind"] == "cycle"
+    assert (await b.get("a")).deps == ["x"]  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_op_remove_emits_readiness_on_promote():
+    """Tier 2: a remove that promotes a dependent emits the generic P6
+    task_readiness (to=ready)."""
+    b = InMemoryTaskBackend()
+    rec = _Rec()
+    await b.create(_task("d1", assignee="s1", requester="req"))
+    await b.create(_task("a", deps=["d1"], requester="req"))  # born-blocked
+    res = await taskmod._remove_dependency(
+        SimpleNamespace(task_id="a", depends_on="d1"),
+        _opctx(b, events=rec, session_id="req"), "control_ir")
+    assert res["status"] == "ok"
+    readied = [(f["task_id"], f["to"]) for k, f in rec.events if k == "task_readiness"]
+    assert readied == [("a", "ready")]
+
+
+@pytest.mark.asyncio
+async def test_op_abort_routes_disposition_to_parent():
+    """Tier 2: aborting a task with a still-alive sibling dependent routes the
+    disposition to the parent's session (recording waker fired + P6)."""
+    b = InMemoryTaskBackend()
+    rec = _Rec()
+    waker = _RecordingWaker()
+    await b.create(_task("P", assignee="sP", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="sB", requester="req", parent_id="P",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
+
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
+                         _opctx(b, events=rec, waker=waker, session_id="req"), "control_ir")
+
+    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B", "dependents": ["A"]}]
+    routed = [f for k, f in rec.events if k == "task_dependency_aborted"]
+    assert routed and routed[0]["parent_session"] == "sP" and routed[0]["dependents"] == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_op_failed_routes_disposition_to_parent():
+    """Tier 2: a `failed` declaration (assignee) with dependents routes to parent."""
+    b = InMemoryTaskBackend()
+    waker = _RecordingWaker()
+    await b.create(_task("P", assignee="sP", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="sB", requester="req", parent_id="P",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
+
+    # failed is assignee-gated → caller must be B's assignee.
+    await taskmod._update_status(SimpleNamespace(task_id="B", status="failed"),
+                                 _opctx(b, waker=waker, session_id="sB"), "control_ir")
+    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B", "dependents": ["A"]}]
+
+
+@pytest.mark.asyncio
+async def test_op_abort_root_without_parent_routes_nothing():
+    """Tier 2: a root task (no parent) routes nothing on abort."""
+    b = InMemoryTaskBackend()
+    waker = _RecordingWaker()
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))  # dependent, no common parent
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
+                         _opctx(b, waker=waker, session_id="req"), "control_ir")
+    assert waker.calls == []  # B.parent_id is None → no parent to mediate
+
+
+@pytest.mark.asyncio
+async def test_op_abort_terminal_parent_routes_nothing():
+    """Tier 2: an already-terminal parent routes nothing (its own cascade subsumes)."""
+    b = InMemoryTaskBackend()
+    waker = _RecordingWaker()
+    await b.create(_task("P", assignee="sP", requester="req", status=TaskState.ARCHIVED))
+    await b.create(_task("B", assignee="sB", requester="req", parent_id="P",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
+                         _opctx(b, waker=waker, session_id="req"), "control_ir")
+    assert waker.calls == []  # parent-gone guard


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 6-ext (dispatch-ready spec Section B/C/I). Seam-map design-check-first reviewed + GO'd by lead-coder (3 confirms YES + 2 notes folded: generic-emit for the routing event, shared `_derive_readiness` primitive). Owner-confirmed op names (I-4), I-1 ruled YES. Extends the landed slice 6.

## What
- **`task.remove_dependency`** — requester topology write, idempotent (no-op on a missing edge). Dropping an edge only RELAXES → the OS re-derive promotes a now-satisfied blocked dependent (incl. **I-1**: removing the last dep → ready); never demotes (consistent with OQ-2 pure-topology).
- **`task.repoint_dependency`** — atomic remove+add; **cycle-checks the NEW edge BEFORE any mutation** (a cycle/dangling repoint changes nothing + returns the structured `_edge_error` dict — safe with the from-edge present, since `task→from` is never on a `to→…→task` cycle path); then re-blocks + re-evaluates (the full re-derive). The parent's primary recovery move.
- **OS-authority `_derive_readiness(allow_demote=)`** — one shared primitive over the pre-run states `{pending, ready, blocked}`: always promote `blocked→ready` when satisfied; re-block `{pending, ready}→blocked` only when `allow_demote` (repoint). **IN_PROGRESS / terminal untouched** — the single-writer split (OS schedules pre-run, the assignee owns the run). `recompute_readiness` refactored onto it (promote-only, per note 2 DRY).
- **abort/failed → parent routing** — `_route_terminal_to_parent` (from `_abort` on the aborted root + a new `failed`-branch in `_update_status`) routes a non-completed terminal **with still-alive dependents** to the task's **parent session** (`parent_id`'s assignee) to decide recovery via ordinary ops (P7 — no `decision=` vocab). Emits a generic P6 `task_dependency_aborted` (note 1: generic `EventLog.emit`, not a WAL kind). The wake is the slice-7 `TaskWaker`, **stubbed** via a new `OpContext.task_waker` (None = no-op). New `backend.dependents()` reverse lookup. Guards: root (no parent) + already-terminal parent route nothing.
- **doc-drift fix** — `TaskUpdateStatusIROp` / `TaskAbortIROp` docstrings updated from the stale slice-3 claim-token/run_id wording to the settled model (assignee CAS + cooperative-terminal).

Wiring: 2 IROps → `OP_KIND_MODEL_MAP` (union auto-derives, #1994) + `OP_PURITY` + `COARSE_TO_FINE["task"]` + contextual-gate aliases + `control-ir.md` section + requester-gated handlers + the partition/union completeness tests.

## Excluded → slice 7
The real `TaskWaker` driver (turns the routed events into a session wake; `OpContext.task_waker` is None/no-op here). The abort→parent routing's call-site + P6 are live and tested via a recording waker.

## Tests (`tests/test_task_slice6ext_1953.py` — real sqlite + in-memory, no mocks)
remove promote / I-1 / idempotent / never-demote; repoint cycle + dangling rejected **atomically** (graph unchanged) / demote / promote / **in_progress-untouched** (the single-writer test) / sqlite reload-persist; dependents; op-layer edge-error dict + P6 readiness + abort/failed→parent routing fires the recording waker + P6 with the right parent/dependents + the no-parent / parent-terminal guards. Each mechanism CLEAN-RED falsified.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8239 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path`) which pass in CI.
- [x] task / op / registry / contextual-gate / control-ir sweep (1050 tests) green.
- [x] 3 CI gates local: **ruff** clean + **test-tier audit** `--strict` exit 0 + pytest.
- [x] abort→parent routing + repoint cycle-atomicity CLEAN-RED falsified then restored to green.
- [x] `control-ir.md` synced (rows + mutable-edge / readiness-re-derive / disposition-routing sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)