### PR TITLE
feat(#1953): slice 7 — TaskWaker C3 re-invoke driver (dep-recovery wake)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -560,11 +560,21 @@ disposition to the task's **parent session** (`parent_id`'s assignee) to decide
 recovery — the parent re-wires via ordinary ops (`repoint` / `remove` / fail /
 support-self), **not** a `decision=` vocabulary (P7). Emits a generic P6
 `task_dependency_aborted`. A root task (no parent) or an already-terminal parent
-routes nothing (the parent's own cascade subsumes it). The session **wake** is the
-slice-7 `TaskWaker` (stubbed here via `OpContext.task_waker`).
+routes nothing (the parent's own cascade subsumes it).
 
-Still landing in later slices: the `TaskWaker` driver (turns the events into a
-session wake) + unblock-predicate evaluation.
+**The TaskWaker (slice 7).** The `OpContext.task_waker` (the OS `TaskWaker`
+driver) turns these dispositions into actual session **wakes** via the canonical
+`resolve_session → _put_inbox → ensure_session_running` triple: a promoted
+dependent (on a predecessor `completed` OR a recovery `repoint`/`remove`) is woken
+with a `task_ready` inbox message; a parent is woken with `task_dependency_aborted`.
+Both surface to the woken session's LLM as one router turn (OS-generic inbox kinds,
+P7) so it resumes / recovers via ordinary task ops. A **loopless** session (A2A /
+MCP, no run-loop) is booted by `ensure_session_running`; a looped one is an
+idempotent no-op. This in-process driver is complementary to the cross-process A2A
+webhook disposition sweep.
+
+Still landing in later slices: per-task liveness (unblock-predicate / heartbeat
+evaluation) — the residual non-terminal-stuck backstop.
 
 ---
 

--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -99,6 +99,7 @@ class ControlIRExecutor:
         contextual_permission: Any = None,  # #1912b: per-session capability narrowing → control-IR op gate
         sandbox_backend: "SandboxBackend | None" = None,
         task_backend: Any = None,  # #1953 slice 3a: session-scoped Task backend instance
+        task_waker: Any = None,  # #1953 slice 7: the OS TaskWaker driver
         session_id: Any = None,  # #1953 slice 3: caller session identity (single-writer key)
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
@@ -144,6 +145,7 @@ class ControlIRExecutor:
         self._threat_scan = threat_scan
         self._contextual_permission = contextual_permission  # #1912b
         self._task_backend = task_backend  # #1953 slice 3a
+        self._task_waker = task_waker  # #1953 slice 7
         self._task_session_id = session_id  # #1953 slice 3
         # FP-0008 #1115 Stage 2: per-run injected exec backend instance. When
         # set (a dual-Protocol container backend), it takes precedence over
@@ -409,6 +411,8 @@ class ControlIRExecutor:
             sandbox_backend=self._sandbox_backend,
             # #1953 slice 3a: session-scoped Task backend (task.* op handlers).
             task_backend=self._task_backend,
+            # #1953 slice 7: the OS TaskWaker (abort/failed/ready → session wake).
+            task_waker=self._task_waker,
             # #1953 slice 3: caller session identity (Task single-writer key).
             session_id=self._task_session_id,
             # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy

--- a/src/reyn/core/kernel/preprocessor_executor.py
+++ b/src/reyn/core/kernel/preprocessor_executor.py
@@ -115,6 +115,7 @@ class PreprocessorExecutor:
         threat_scan: "object | None" = None,  # FP-0050/#1822 S5 (EP4)
         contextual_permission: "object | None" = None,  # #1912b: per-session capability narrowing → run_op/iterate gate
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend
+        task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver
         session_id: "str | None" = None,  # #1953 slice 3: caller session identity (single-writer key)
     ) -> None:
         self._skill = skill
@@ -148,6 +149,7 @@ class PreprocessorExecutor:
         self._threat_scan = threat_scan
         self._contextual_permission = contextual_permission  # #1912b
         self._task_backend = task_backend  # #1953 slice 3a
+        self._task_waker = task_waker  # #1953 slice 7
         self._task_session_id = session_id  # #1953 slice 3
 
     @property
@@ -196,6 +198,7 @@ class PreprocessorExecutor:
             threat_scan=self._threat_scan,  # FP-0050/#1822 S5 (EP4)
             contextual_permission=self._contextual_permission,  # #1912b
             task_backend=self._task_backend,  # #1953 slice 3a
+            task_waker=self._task_waker,  # #1953 slice 7
             session_id=self._task_session_id,  # #1953 slice 3
         )
 

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -80,6 +80,7 @@ class OSRuntime:
         threat_scan: "object | None" = None,  # FP-0050/#1822 S5 (EP4)
         contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase RouterLoop + control-IR gates
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend → control-IR + preprocessor op gates
+        task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker → control-IR + preprocessor op ctx
         task_session_id: "str | None" = None,  # #1953 slice 3: caller session identity (Task single-writer key)
         router_config: "object | None" = None,  # #1829 S3b: reyn.yaml llm.router.*
         environment_backend: "EnvironmentBackend | None" = None,
@@ -228,6 +229,7 @@ class OSRuntime:
             threat_scan=threat_scan,
             contextual_permission=contextual_permission,  # #1912b: control-IR op gate
             task_backend=task_backend,  # #1953 slice 3a
+            task_waker=task_waker,  # #1953 slice 7
             session_id=task_session_id,  # #1953 slice 3
             sandbox_backend=sandbox_backend,
             multimodal_config=multimodal_config,
@@ -254,6 +256,7 @@ class OSRuntime:
             threat_scan=threat_scan,  # FP-0050/#1822 S5 (EP4)
             contextual_permission=contextual_permission,  # #1912b: preprocessor run_op/iterate gate
             task_backend=task_backend,  # #1953 slice 3a
+            task_waker=task_waker,  # #1953 slice 7
             session_id=task_session_id,  # #1953 slice 3
         )
         # FP-0020 Component A: all mutable run-scope state encapsulated in RunState.

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -186,12 +186,17 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
     if task.status is TaskState.COMPLETED:
         promoted = await _backend(ctx).recompute_readiness(op.task_id)
         events = getattr(ctx, "events", None)
-        if events is not None:
-            for p in promoted:
+        waker = getattr(ctx, "task_waker", None)
+        for p in promoted:
+            if events is not None:
                 # Generic P6 audit (like task_op/task_disposition); NOT a WAL
                 # closed-vocab kind (WAL-vs-P6 separation, P7).
                 events.emit("task_readiness", task_id=p.task_id, to="ready",
                             trigger=op.task_id)
+            # slice 7: wake the now-ready dependent's session to continue its work
+            # (the C3 re-invoke driver; None waker = no-op stub, slice 6-ext).
+            if waker is not None:
+                await waker.wake_ready_dependent(p)
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
         # doesn't satisfy a dependency edge → route the disposition to the parent's
@@ -235,11 +240,13 @@ async def _add_dependency(op, ctx: OpContext, caller) -> dict:
     return _ok("task.add_dependency", task=task.to_dict())
 
 
-def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigger: str) -> None:
+async def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigger: str) -> None:
     """Emit the generic P6 ``task_readiness`` event when an OS re-derive changed a
     task's readiness (#1953 slice 6-ext). ``before_status`` is captured from the
     role-gate fetch (pre-mutation), so this fires only on an actual transition and
-    only for the pre-run readiness states (ready / blocked)."""
+    only for the pre-run readiness states (ready / blocked). On a promote to
+    ``ready`` (e.g. the parent repoints a dependent onto a completed substitute —
+    the recovery loop), the task's session is also woken (slice 7)."""
     if task.status is before_status:
         return
     if task.status not in (TaskState.READY, TaskState.BLOCKED):
@@ -248,6 +255,10 @@ def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigger: str
     if events is not None:
         events.emit("task_readiness", task_id=task.task_id,
                     to=task.status.value, trigger=trigger)
+    if task.status is TaskState.READY:
+        waker = getattr(ctx, "task_waker", None)
+        if waker is not None:
+            await waker.wake_ready_dependent(task)
 
 
 async def _route_terminal_to_parent(ctx: OpContext, backend, terminal_task) -> None:
@@ -293,7 +304,7 @@ async def _remove_dependency(op, ctx: OpContext, caller) -> dict:
     if task is None:
         return _not_found("task.remove_dependency", op.task_id)
     _audit(ctx, "task.remove_dependency", op.task_id, depends_on=op.depends_on)
-    _emit_readiness_if_changed(ctx, task, before, op.task_id)
+    await _emit_readiness_if_changed(ctx, task, before, op.task_id)
     return _ok("task.remove_dependency", task=task.to_dict())
 
 
@@ -314,7 +325,7 @@ async def _repoint_dependency(op, ctx: OpContext, caller) -> dict:
         return _not_found("task.repoint_dependency", op.task_id)
     _audit(ctx, "task.repoint_dependency", op.task_id,
            from_depends_on=op.from_depends_on, to_depends_on=op.to_depends_on)
-    _emit_readiness_if_changed(ctx, task, before, op.task_id)
+    await _emit_readiness_if_changed(ctx, task, before, op.task_id)
     return _ok("task.repoint_dependency", task=task.to_dict())
 
 

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -94,8 +94,19 @@ def build_scoped_chat_session(
         sandbox_backend=sandbox_backend,
         environment_backend=environment_backend,
     )
+    # #1953 slice 7: construct the OS TaskWaker for this session at the single
+    # factory chokepoint (every frontend builds sessions here). It closes over the
+    # AgentRegistry + this agent's name to resolve + wake sibling sessions on a
+    # dep-graph disposition. None when no registry is available (direct/test
+    # construction) → the op-runtime no-op stub.
+    _registry = base.get("registry")
+    task_waker = None
+    if _registry is not None:
+        from reyn.runtime.services.task_wake import TaskWaker  # noqa: PLC0415
+        task_waker = TaskWaker(_registry, base["agent_name"])
     return Session(
         agent=agent,
+        task_waker=task_waker,
         environment_backend=environment_backend,
         sandbox_backend=sandbox_backend,
         workspace_base_dir=workspace_base_dir,

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -1,0 +1,83 @@
+"""TaskWaker — the OS C3 re-invoke driver for the Task dep-graph (#1953 slice 7).
+
+Turns the dep-graph dispositions that slice 6-ext emits into actual **session
+wakes**, via the canonical wake-triple ``resolve_session → _put_inbox →
+ensure_session_running`` (the same pattern ``webhook_routing`` /
+``gateway.api.push_to_agent`` use). Threaded onto ``OpContext.task_waker`` (the
+slice 6-ext stub) like ``task_backend``.
+
+Two drivers:
+  - ``wake_ready_dependent(task)`` — complete-side: a dependent the OS promoted to
+    ``ready`` is woken to continue its work.
+  - ``notify_parent_decide(...)`` — abort/failed-side: the parent of a terminal
+    task with stuck dependents is woken to decide recovery (it re-wires via
+    ordinary task ops — NOT a ``decision=`` vocabulary, P7).
+
+Single-agent scope: a dependency lives WITHIN one decomposition = within one
+agent (the owner model: a cross-agent hand-off is a *request*, not a dep-edge), so
+the target session is a sibling session of THIS agent — the waker closes over its
+own ``agent_name`` and resolves the assignee/parent session-id (the #1814
+``<transport>:<native_id>`` routing-key) within it.
+
+Loopless wake: an A2A (``a2a:<contextId>``) / MCP (``mcp:mcp``) session has no
+run-loop (its turns are driven inline by ``MessageBus.request``), so
+``ensure_session_running`` is **mandatory** to boot ``session.run()`` and drain
+the wake message. Idempotent for an already-looping session (the ``.done()``
+guard). This in-process driver is distinct from the external A2A webhook *sweep*
+(cross-process, backend-list-derived) — complementary layers.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# The OS-generic inbox kinds (P7 — no skill/A2A vocabulary; the run-loop routes
+# them to a router turn). NOT added to the WAL closed vocab (WAL-vs-P6 separation).
+WAKE_READY_KIND = "task_ready"
+WAKE_PARENT_KIND = "task_dependency_aborted"
+
+
+class TaskWaker:
+    """Wakes a sibling session (same agent) on a dep-graph disposition (#1953 sl.7)."""
+
+    def __init__(self, registry: Any, agent_name: str) -> None:
+        self._registry = registry
+        self._agent_name = agent_name
+
+    async def _wake(self, session_id: str, kind: str, text: str, **meta: Any) -> None:
+        """The canonical wake-triple. ``session_id`` is the assignee/parent
+        routing-key ``<transport>:<native_id>``; resolve the sibling session of
+        THIS agent, deliver the OS message, and ensure its run-loop runs (booting
+        a loopless A2A/MCP session; idempotent for a looped one)."""
+        transport, _, native_id = session_id.partition(":")
+        session = self._registry.resolve_session(self._agent_name, transport, native_id)
+        await session._put_inbox(kind, {"text": text, "sender": "task:os", "meta": dict(meta)})
+        self._registry.ensure_session_running(self._agent_name, session_id)
+
+    async def wake_ready_dependent(self, task: Any) -> None:
+        """Complete-side: a dependent the OS promoted to ``ready`` → wake it to
+        continue. The session resumes the task's work via ordinary ops."""
+        await self._wake(
+            task.assignee, WAKE_READY_KIND,
+            f"[task] Task {task.task_id!r} ('{task.name}') is now READY — its "
+            f"dependencies are all satisfied. Continue its work.",
+            task_id=task.task_id,
+        )
+
+    async def notify_parent_decide(self, *, parent_session: str, terminal_task: Any,
+                                   dependents: "list[Any]") -> None:
+        """Abort/failed-side: wake the parent to decide recovery for its stuck
+        dependents (it re-wires via ordinary task ops — repoint to a substitute /
+        remove the edge / fail / handle itself; P7 — no decision vocabulary)."""
+        dep_ids = [d.task_id for d in dependents]
+        await self._wake(
+            parent_session, WAKE_PARENT_KIND,
+            f"[task] A dependency of your sub-tasks reached "
+            f"{terminal_task.status.value!r}: task {terminal_task.task_id!r} "
+            f"('{terminal_task.name}'). These dependents are now stuck: {dep_ids}. "
+            f"Decide recovery using the task ops (repoint to a substitute, remove "
+            f"the dependency, fail them, or handle the work yourself).",
+            task_id=terminal_task.task_id, dependents=dep_ids,
+        )
+
+
+__all__ = ["TaskWaker", "WAKE_READY_KIND", "WAKE_PARENT_KIND"]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -822,6 +822,7 @@ class Session:
         excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_source for external-repo eval)
         contextual_permission: "object | None" = None,  # #1827 S3: per-session capability_profile narrowing (ContextualPermission); from registry.resolved_profile_for; None = byte-identical
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend instance (injected by the session factory); None → op-runtime in-memory fallback
+        task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver (injected by the session factory); None → op-runtime no-op stub
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
         # FP-0043 Stage 5: the conversation session id this Session records WAL
@@ -890,6 +891,7 @@ class Session:
         # session-scoped sqlite db path is finalized with §24); None → the op-runtime
         # falls back to its in-memory backend (tests / direct construction).
         self._task_backend = task_backend
+        self._task_waker = task_waker  # #1953 slice 7
         # #1827 S4b (context-auto): lazily-resolved minimal _untrusted profile
         # ContextualPermission, composed into the per-turn narrowing while
         # untrusted external content is live in context. None until first needed.
@@ -2971,9 +2973,24 @@ class Session:
                 # user-role message with step_results and run one
                 # router LLM turn for synthesis narration.
                 await self._handle_plan_completed(payload)
+            elif kind in ("task_ready", "task_dependency_aborted"):
+                # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
+                # (a dependent became ready, or a parent must decide recovery). Both
+                # surface as an OS-originated message + one router turn so the LLM
+                # acts via ordinary task ops (P7 — no decision vocabulary).
+                await self._handle_task_wake(payload)
         finally:
             self._turn_idle.set()
         return True
+
+    async def _handle_task_wake(self, payload: dict) -> None:
+        """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /
+        ``task_dependency_aborted``) to the LLM as one router turn, so it resumes /
+        recovers the work via ordinary task ops."""
+        await self._handle_user_message(
+            payload.get("text", ""),
+            chain_id=payload.get("chain_id") or _new_chain_id(),
+        )
 
     async def run(self) -> None:
         self._chat_events.emit("chat_started", agent_name=self.agent_name, model=self.model)
@@ -3294,6 +3311,7 @@ class Session:
             safety=self._safety,
             contextual_permission=self._contextual_permission,  # #1912: narrow skill execution too
             task_backend=self._task_backend,  # #1953 slice 3a: session-scoped Task backend
+            task_waker=self._task_waker,  # #1953 slice 7: the OS TaskWaker driver
             task_session_id=self._session_id,  # #1953 slice 3: caller session identity (single-writer key)
             mcp_servers=mcp_servers,
             intervention_bus=intervention_bus,

--- a/src/reyn/skill/skill_runtime.py
+++ b/src/reyn/skill/skill_runtime.py
@@ -55,6 +55,7 @@ class SkillRuntime:
         safety: "SafetyConfig | None" = None,
         contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase/control-IR gates (None = byte-identical)
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend
+        task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver
         task_session_id: "str | None" = None,  # #1953 slice 3: caller session identity (Task single-writer key)
         mcp_servers: dict | None = None,
         python_allowed_modules: list[str] | None = None,
@@ -97,6 +98,7 @@ class SkillRuntime:
         # narrowed agent's skill execution is enforced on every tool path.
         self._contextual_permission = contextual_permission
         self._task_backend = task_backend  # #1953 slice 3a
+        self._task_waker = task_waker  # #1953 slice 7
         self._task_session_id = task_session_id  # #1953 slice 3
         self._resolver = resolver or ModelResolver({})
         self._permission_resolver = permission_resolver
@@ -323,6 +325,7 @@ class SkillRuntime:
             threat_scan=self._safety.threat_scan,  # FP-0050/#1822 S5 (EP4)
             contextual_permission=self._contextual_permission,  # #1912
             task_backend=self._task_backend,  # #1953 slice 3a
+            task_waker=self._task_waker,  # #1953 slice 7
             task_session_id=self._task_session_id,  # #1953 slice 3
 
             environment_backend=self._environment_backend,

--- a/tests/test_task_waker_slice7_1953.py
+++ b/tests/test_task_waker_slice7_1953.py
@@ -1,0 +1,174 @@
+"""Tier 2: #1953 slice 7 — the TaskWaker C3 re-invoke driver + the recovery loop.
+
+Turns the dep-graph dispositions slice 6-ext emits into session wakes via the
+canonical wake-triple ``resolve_session → _put_inbox → ensure_session_running``.
+Verified with a real recording registry + recording session (no mocks):
+
+- ``wake_ready_dependent`` / ``notify_parent_decide`` each fire the 3-step triple
+  with the right OS-generic inbox kind + message;
+- the op layer wakes through it: a `completed` predecessor wakes its promoted
+  dependents; an `abort` / `failed` wakes the parent; a `repoint` that promotes a
+  dependent (the parent's recovery move) wakes it;
+- the **recovery loop** end-to-end: abort a dep → the parent is woken with
+  ``task_dependency_aborted`` → it repoints the stuck dependent onto a completed
+  substitute → the dependent becomes `ready` AND is woken with ``task_ready``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.services.task_wake import TaskWaker
+from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+
+def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
+          requester="req", parent_id=None):
+    return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
+                status=status, deps=list(deps or []), parent_id=parent_id)
+
+
+class _RecSession:
+    def __init__(self) -> None:
+        self.inbox: list[tuple[str, dict]] = []
+
+    async def _put_inbox(self, kind: str, payload: dict) -> str:
+        self.inbox.append((kind, payload))
+        return "msg-1"
+
+
+class _RecRegistry:
+    """A real (non-mock) registry recording the wake-triple calls."""
+
+    def __init__(self) -> None:
+        self.resolved: list[tuple[str, str, str]] = []
+        self.ensured: list[tuple[str, str]] = []
+        self._sessions: dict[tuple[str, str, str], _RecSession] = {}
+
+    def resolve_session(self, agent_name: str, transport: str, native_id: str):
+        key = (agent_name, transport, native_id)
+        self.resolved.append(key)
+        return self._sessions.setdefault(key, _RecSession())
+
+    def ensure_session_running(self, name: str, sid: str):
+        self.ensured.append((name, sid))
+        return None
+
+    def inbox_of(self, agent, transport, native_id):
+        return self._sessions[(agent, transport, native_id)].inbox
+
+
+# ── 1. the wake-triple ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wake_ready_dependent_fires_the_triple():
+    """Tier 2: wake_ready_dependent resolves the dependent's sibling session,
+    delivers a `task_ready` message, and ensures the run-loop runs."""
+    reg = _RecRegistry()
+    waker = TaskWaker(reg, "alice")
+    task = SimpleNamespace(task_id="A", name="do-A", assignee="a2a:ctx-1",
+                           status=TaskState.READY)
+
+    await waker.wake_ready_dependent(task)
+
+    assert reg.resolved == [("alice", "a2a", "ctx-1")]      # same-agent resolve
+    kind, payload = reg.inbox_of("alice", "a2a", "ctx-1")[0]
+    assert kind == "task_ready" and "A" in payload["text"]
+    assert reg.ensured == [("alice", "a2a:ctx-1")]          # loopless wake
+
+
+@pytest.mark.asyncio
+async def test_notify_parent_decide_fires_the_triple():
+    """Tier 2: notify_parent_decide wakes the parent session with the disposition
+    + the stuck dependents."""
+    reg = _RecRegistry()
+    waker = TaskWaker(reg, "alice")
+    terminal = SimpleNamespace(task_id="B", name="do-B", status=TaskState.ABORTED)
+    deps = [SimpleNamespace(task_id="A")]
+
+    await waker.notify_parent_decide(parent_session="mcp:mcp", terminal_task=terminal,
+                                     dependents=deps)
+
+    assert reg.resolved == [("alice", "mcp", "mcp")]
+    kind, payload = reg.inbox_of("alice", "mcp", "mcp")[0]
+    assert kind == "task_dependency_aborted"
+    assert "B" in payload["text"] and payload["meta"]["dependents"] == ["A"]
+    assert reg.ensured == [("alice", "mcp:mcp")]
+
+
+# ── 2. op-layer wakes through the waker ─────────────────────────────────────
+
+
+def _ctx(backend, waker, session_id="req"):
+    return SimpleNamespace(session_id=session_id, agent_id="alice", events=None,
+                           task_backend=backend, task_waker=waker)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_completed_wakes_promoted_dependent():
+    """Tier 2: completing a predecessor wakes the dependent the OS promoted."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    await b.create(_task("d", assignee="a2a:sd"))
+    await b.create(_task("a", deps=["d"], assignee="a2a:sa"))  # born-blocked
+    await taskmod._update_status(SimpleNamespace(task_id="d", status="completed"),
+                                 _ctx(b, TaskWaker(reg, "alice"), session_id="a2a:sd"),
+                                 "control_ir")
+    assert ("alice", "a2a", "sa") in reg.resolved
+    assert reg.ensured == [("alice", "a2a:sa")]
+
+
+@pytest.mark.asyncio
+async def test_abort_wakes_parent():
+    """Tier 2: aborting a task with a stuck dependent wakes the parent."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="a2a:sB", parent_id="P", status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
+                         _ctx(b, TaskWaker(reg, "alice")), "control_ir")
+    assert ("alice", "a2a", "sP") in reg.resolved
+    assert reg.inbox_of("alice", "a2a", "sP")[0][0] == "task_dependency_aborted"
+
+
+# ── 3. the recovery loop (end-to-end mechanism) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recovery_loop_abort_then_parent_repoint_wakes_both():
+    """Tier 2: the full dep-recovery loop — abort a dep → the parent is woken →
+    it repoints the stuck dependent onto a completed substitute → the dependent
+    becomes ready AND is woken (the close-gate at the op-mechanism level)."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    waker = TaskWaker(reg, "alice")
+    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="a2a:sB", parent_id="P", status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))  # blocked on B
+    await b.create(_task("Bsub", assignee="a2a:sBsub", parent_id="P", status=TaskState.COMPLETED))
+    ctx = _ctx(b, waker)  # requester "req" owns P/B/A/Bsub
+
+    # 1. abort B → the parent P is woken to decide.
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None), ctx, "control_ir")
+    assert ("alice", "a2a", "sP") in reg.resolved
+    assert reg.inbox_of("alice", "a2a", "sP")[0][0] == "task_dependency_aborted"
+
+    # 2. the parent's recovery move: repoint A from the aborted B onto the
+    #    completed substitute Bsub → A becomes ready and is woken.
+    await taskmod._repoint_dependency(
+        SimpleNamespace(task_id="A", from_depends_on="B", to_depends_on="Bsub"),
+        ctx, "control_ir")
+    assert (await b.get("A")).status is TaskState.READY
+    assert ("alice", "a2a", "sA") in reg.resolved
+    assert reg.inbox_of("alice", "a2a", "sA")[0][0] == "task_ready"


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 7 (spec Section D). Seam-map design-check-first reviewed + GO'd by lead-coder (4 confirms resolved, heartbeat-eval **deferred**). The heart of dep-recovery: turns the slice 6-ext dispositions into actual session wakes.

## What
- **`TaskWaker`** (`runtime/services/task_wake.py`) — `wake_ready_dependent(task)` (complete / recovery-side) + `notify_parent_decide(...)` (abort / failed-side), both via the canonical wake-triple **`resolve_session → _put_inbox → ensure_session_running`** (the pattern `webhook_routing` / `gateway.api.push_to_agent` use).
  - **Single-agent scope** (lead-confirmed): a dependency is intra-decomposition = intra-agent (owner model: a cross-agent hand-off is a *request*, not a dep-edge), so the waker closes over its own `agent_name` and resolves the assignee/parent **SID** (the #1814 `<transport>:<native_id>` routing-key) within it. No `agent` field on the Task.
  - **Loopless wake**: an A2A (`a2a:<contextId>`) / MCP (`mcp:mcp`) session has no run-loop → `ensure_session_running` boots `session.run()` to drain the wake; a looped session is an idempotent no-op (`.done()` guard).
- **OS-generic inbox kinds** `task_ready` / `task_dependency_aborted` (P7, not WAL vocab) — `run_one_iteration` routes both to `_handle_task_wake` → one router turn, so the woken LLM resumes / recovers via ordinary task ops.
- **Threading rail** — `task_waker` mirrors `task_backend`: Session → SkillRuntime → OSRuntime → ControlIRExecutor **+ PreprocessorExecutor** (both ctx-build seams) → `OpContext`. Constructed at the single `build_scoped_chat_session` chokepoint (closes over the registry + `agent_name`; None when no registry → the op no-op stub).
- **Wake wiring** — `_update_status` (`completed`) wakes each promoted dependent; `_abort` / `_update_status` (`failed`) wakes the parent (the slice 6-ext call-site, now real); a `repoint` / `remove` that **promotes** a dependent (the parent's recovery move) wakes it too — this closes the recovery loop.

## Deferred (lead) + boundary notes
- **heartbeat-eval (per-task liveness)** is deferred: the revised model resolves H5 via abort→parent-LLM + cap-hit→parent-LLM (slice 8), leaving only the true non-terminal-stuck residual → re-scoped later. **Slice 7 = TaskWaker only.**
- **Loop-lifecycle (lead's check)**: `run()` blocks on `inbox.get()` (no busy-spin = **no busy-leak**); a loopless wake boots a persistent *parked* run-loop — the standard session lifecycle (webhook/cron sessions live the same way), ended on shutdown. The real-LLM wake behavior + this lifecycle get the **tui live-verify at land** (per lead).
- Production session-injection of the **backend** itself remains the spec-E prerequisite (the chat factory doesn't pass `task_backend=` yet); the waker wires independently at the factory chokepoint.

## Tests (`tests/test_task_waker_slice7_1953.py` — real recording registry + session, no mocks)
- The wake-triple 3-step (resolve + put_inbox + ensure) for both methods + the right OS-generic kind/message;
- op-layer wakes (completed → dependent, abort → parent);
- the **recovery loop e2e**: abort a dep → the parent is woken with `task_dependency_aborted` → it repoints the stuck dependent onto a completed substitute → the dependent becomes `ready` **and** is woken with `task_ready` (the close-gate at the op-mechanism level; the real-LLM variant is the tui live-verify).
- Each mechanism CLEAN-RED falsified.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8244 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path`) which pass in CI.
- [x] task / session / runtime / executor / scheme sweep (609 tests) green — the broad threading rail.
- [x] 3 CI gates local: **ruff** clean + **test-tier audit** `--strict` exit 0 + pytest.
- [x] wake-triple + recovery-loop wake CLEAN-RED falsified then restored to green.
- [x] `control-ir.md` synced (the TaskWaker section).
- [ ] (deferred to land) tui live-verify of the real-LLM recovery loop + the loopless-wake lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)