### PR TITLE
feat(#1953): slice 8 — per-Task budget cap-hit as a first-class disposition

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -554,13 +554,24 @@ Completion-recompute (relax → only promotes), `remove` (relax), and `repoint`
 `task_readiness` event.
 
 **Disposition → parent routing (slice 6-ext).** When a task reaches a
-non-`completed` terminal (`aborted` via `task.abort`, or `failed` via
-`task.update_status`) and has **still-alive dependents**, the OS routes the
-disposition to the task's **parent session** (`parent_id`'s assignee) to decide
-recovery — the parent re-wires via ordinary ops (`repoint` / `remove` / fail /
-support-self), **not** a `decision=` vocabulary (P7). Emits a generic P6
-`task_dependency_aborted`. A root task (no parent) or an already-terminal parent
-routes nothing (the parent's own cascade subsumes it).
+non-`completed` terminal (`aborted` via `task.abort`, `failed` via
+`task.update_status`, or `cap_exceeded` on a per-Task budget cap-hit) and has
+**still-alive dependents**, the OS routes the disposition to the task's **parent
+session** (`parent_id`'s assignee) to decide recovery — the parent re-wires via
+ordinary ops (`repoint` / `remove` / fail / support-self), **not** a `decision=`
+vocabulary (P7). The **disposition** is carried first-class (in both the P6
+`task_dependency_aborted` event and the parent payload) so a budget `cap_exceeded`
+is never conflated with a genuine error `failed` (slice 8). A root task (no parent)
+or an already-terminal parent routes nothing (the parent's own cascade subsumes it).
+
+**Per-Task budget cap (slice 8).** `record_cost(task_id, delta)` accumulates an
+LLM call's cost onto the Task's `cost_accum`; when it crosses the Task's
+`budget_cap` (an INDEPENDENT cap dimension, enforced alongside the session / daily
+caps — the tighter hits first), the OS force-terminates the task (abort-like) and
+routes the `cap_exceeded` disposition through the SAME parent-LLM seam — so one
+recovery mechanism resolves both a terminal-dependency and a cap-hit. (The
+production wiring of the LLM cost recorder to `record_cost` co-lands with the
+task-execution engine in a later slice.)
 
 **The TaskWaker (slice 7).** The `OpContext.task_waker` (the OS `TaskWaker`
 driver) turns these dispositions into actual session **wakes** via the canonical

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -200,8 +200,8 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
         # doesn't satisfy a dependency edge → route the disposition to the parent's
-        # session to decide recovery (the OQ-7/H5 gap-close; wake stubbed → slice 7).
-        await _route_terminal_to_parent(ctx, _backend(ctx), task)
+        # session to decide recovery (the OQ-7/H5 gap-close).
+        await _route_terminal_to_parent(ctx, _backend(ctx), task, disposition="failed")
     return _ok("task.update_status", task=task.to_dict())
 
 
@@ -261,13 +261,25 @@ async def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigge
             await waker.wake_ready_dependent(task)
 
 
-async def _route_terminal_to_parent(ctx: OpContext, backend, terminal_task) -> None:
+async def _route_terminal_to_parent(
+    ctx: OpContext, backend, terminal_task, *, disposition: str | None = None,
+) -> None:
     """slice 6-ext §C: when a task reaches a non-completed terminal (aborted /
-    failed) and has STILL-ALIVE dependents, notify its parent's session to decide
-    recovery (the parent re-wires via ordinary ops — NOT a `decision=` vocabulary,
-    P7). The wake is via ``OpContext.task_waker`` (slice 7 real driver; None here =
-    no-op stub — only the P6 audit fires). Guards: a root task (no parent) and a
-    parent that is itself terminal (its own cascade handles it) route nothing."""
+    failed / cap_exceeded) and has STILL-ALIVE dependents, notify its parent's
+    session to decide recovery (the parent re-wires via ordinary ops — NOT a
+    `decision=` vocabulary, P7).
+
+    ``disposition`` is the **first-class** terminal reason carried in BOTH the P6
+    event and the parent payload (#1953 slice 8 no-conflation invariant): a
+    budget ``cap_exceeded`` must be distinguishable from a genuine error
+    ``failed`` — the parent's recovery differs, and a downstream reader must not
+    misread a cap-hit as an error. Defaults to the task's status value (the abort
+    path) when not given explicitly.
+
+    The wake is via ``OpContext.task_waker`` (slice 7 real driver; None = no-op
+    stub — only the P6 audit fires). Guards: a root task (no parent) and a parent
+    that is itself terminal (its own cascade handles it) route nothing."""
+    disp = disposition or terminal_task.status.value
     parent_id = getattr(terminal_task, "parent_id", None)
     if not parent_id:
         return
@@ -283,14 +295,56 @@ async def _route_terminal_to_parent(ctx: OpContext, backend, terminal_task) -> N
         # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation).
         events.emit(
             "task_dependency_aborted", task_id=terminal_task.task_id,
-            disposition=terminal_task.status.value, parent_id=parent_id,
+            disposition=disp, parent_id=parent_id,
             parent_session=parent.assignee, dependents=[d.task_id for d in stuck],
         )
     waker = getattr(ctx, "task_waker", None)
     if waker is not None:
         await waker.notify_parent_decide(
-            parent_session=parent.assignee, terminal_task=terminal_task, dependents=stuck,
+            parent_session=parent.assignee, terminal_task=terminal_task,
+            dependents=stuck, disposition=disp,
         )
+
+
+async def record_task_cost(ctx: OpContext, task_id: str, delta: float):
+    """OS-internal per-Task cost attribution + cap enforcement (#1953 slice 8).
+
+    Accumulates ``delta`` onto the task's ``cost_accum``; on a **cap-hit**
+    (``cost_accum >= budget_cap``, when a per-Task ``budget_cap`` is set) the task
+    is force-terminated (abort-like — the work can't continue out of budget, so the
+    sub-tree is archived) and a first-class ``cap_exceeded`` disposition is routed
+    to the parent via the SAME parent-LLM seam as abort/failed — the "one decision
+    resolves OQ-7 + cap-hit" property. The ``cap_exceeded`` disposition is carried
+    first-class in both the P6 ``task_disposition`` event and the parent payload
+    (the no-conflation invariant: a budget cap-hit is NOT a genuine error
+    ``failed``). Per-Task is an INDEPENDENT cap dimension (§I-3 (A)): the existing
+    session / daily caps stay enforced separately (tighter-hits-first).
+
+    This is the **tested primitive**. The production cost-path attribution — wiring
+    the LLM-call cost recorder to call this with the right ``task_id`` — is a
+    DELIBERATE, TRACKED defer that co-lands with the task-execution engine
+    (slice P); there is no implicit active-task handle to thread it from today
+    (§I-3 (B)). Returns the (possibly terminated) task, or None for an unknown id."""
+    backend = _backend(ctx)
+    task = await backend.record_cost(task_id, delta)
+    if task is None:
+        return None
+    if task.budget_cap is None or task.cost_accum < task.budget_cap:
+        return task  # under cap (or uncapped) — nothing to enforce
+    # Cap-hit: force-terminate (archive the sub-tree, like abort) + route the
+    # cap_exceeded disposition to the parent for a recovery decision.
+    aborted = await backend.abort(task_id, reason="budget cap exceeded")
+    events = getattr(ctx, "events", None)
+    if events is not None:
+        for t in aborted:
+            events.emit(
+                "task_disposition", task_id=t.task_id, disposition="cap_exceeded",
+                requester=t.requester, origin=t.origin.value, root=task_id,
+            )
+    if aborted:
+        await _route_terminal_to_parent(
+            ctx, backend, aborted[0], disposition="cap_exceeded")
+    return await backend.get(task_id)
 
 
 async def _remove_dependency(op, ctx: OpContext, caller) -> dict:
@@ -356,7 +410,7 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
     # slice 6-ext §C: route the aborted root to its parent so a stuck sibling
     # dependent gets a recovery decision (the OQ-7/H5 gap-close). The cascade's
     # descendants have an in-subtree (now terminal) parent → the guard skips them.
-    await _route_terminal_to_parent(ctx, _backend(ctx), root)
+    await _route_terminal_to_parent(ctx, _backend(ctx), root, disposition="aborted")
     return _ok("task.abort", task=root.to_dict())
 
 

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -64,19 +64,22 @@ class TaskWaker:
         )
 
     async def notify_parent_decide(self, *, parent_session: str, terminal_task: Any,
-                                   dependents: "list[Any]") -> None:
-        """Abort/failed-side: wake the parent to decide recovery for its stuck
-        dependents (it re-wires via ordinary task ops — repoint to a substitute /
-        remove the edge / fail / handle itself; P7 — no decision vocabulary)."""
+                                   dependents: "list[Any]", disposition: str | None = None) -> None:
+        """Abort/failed/cap_exceeded-side: wake the parent to decide recovery for
+        its stuck dependents (it re-wires via ordinary task ops — repoint to a
+        substitute / remove the edge / fail / handle itself; P7 — no decision
+        vocabulary). ``disposition`` is the first-class terminal reason (#1953
+        slice 8 no-conflation: a budget ``cap_exceeded`` vs a genuine ``failed``)."""
         dep_ids = [d.task_id for d in dependents]
+        disp = disposition or terminal_task.status.value
         await self._wake(
             parent_session, WAKE_PARENT_KIND,
-            f"[task] A dependency of your sub-tasks reached "
-            f"{terminal_task.status.value!r}: task {terminal_task.task_id!r} "
-            f"('{terminal_task.name}'). These dependents are now stuck: {dep_ids}. "
-            f"Decide recovery using the task ops (repoint to a substitute, remove "
-            f"the dependency, fail them, or handle the work yourself).",
-            task_id=terminal_task.task_id, dependents=dep_ids,
+            f"[task] A dependency of your sub-tasks reached {disp!r}: task "
+            f"{terminal_task.task_id!r} ('{terminal_task.name}'). These dependents "
+            f"are now stuck: {dep_ids}. Decide recovery using the task ops (repoint "
+            f"to a substitute, remove the dependency, fail them, or handle the work "
+            f"yourself).",
+            task_id=terminal_task.task_id, dependents=dep_ids, disposition=disp,
         )
 
 

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -133,6 +133,13 @@ class TaskBackend(Protocol):
         satisfied). None for unknown task."""
         ...
 
+    async def record_cost(self, task_id: str, delta: float) -> Task | None:
+        """Accumulate ``delta`` onto the task's ``cost_accum`` (#1953 slice 8) — the
+        per-Task cost-attribution primitive. Pure write (the cap-hit check + the
+        ``cap_exceeded`` disposition routing is the op layer's, which has the ctx).
+        None for an unknown task."""
+        ...
+
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]: ...
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None: ...
@@ -351,6 +358,14 @@ class InMemoryTaskBackend:
             self._tasks[tid].updated_at = _now_iso()
             aborted.append(self._tasks[tid])
         return aborted
+
+    async def record_cost(self, task_id: str, delta: float) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        task.cost_accum += delta
+        task.updated_at = _now_iso()
+        return task
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         task = self._tasks.get(task_id)

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -478,6 +478,20 @@ class SqliteTaskBackend:
             self._conn.commit()
             return [t for t in (self._fetch(tid) for tid in subtree) if t is not None]
 
+    async def record_cost(self, task_id: str, delta: float) -> Task | None:
+        async with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            cur = self._conn.execute(
+                "UPDATE tasks SET cost_accum=cost_accum+?, updated_at=? WHERE task_id=?",
+                (delta, _now_iso(), task_id),
+            )
+            if cur.rowcount == 0:
+                self._conn.rollback()
+                return None
+            self._emit(task_id, "cost_recorded", delta=delta)
+            self._conn.commit()
+            return self._fetch(task_id)
+
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None:
         async with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")

--- a/tests/test_task_cap_hit_slice8_1953.py
+++ b/tests/test_task_cap_hit_slice8_1953.py
@@ -1,0 +1,210 @@
+"""Tier 2: #1953 slice 8 — per-Task cap-hit as a first-class disposition.
+
+`record_cost(task_id, delta)` is the per-Task cost-attribution primitive; the
+OS-internal `record_task_cost` helper enforces a per-Task `budget_cap`: on a
+cap-hit it force-terminates the task (abort-like — out of budget) and routes a
+**first-class `cap_exceeded`** disposition to the parent via the SAME parent-LLM
+seam as abort/failed (the "one decision resolves OQ-7 + cap-hit" property). The
+no-conflation invariant: a budget cap-hit must be distinguishable from a genuine
+error `failed` — `cap_exceeded` rides BOTH the P6 `task_disposition` event AND the
+parent wake payload. Per-Task is an INDEPENDENT cap dimension (§I-3 (A)).
+
+Real sqlite + in-memory backends + a real recording registry (TaskWaker); no mocks.
+
+Note: `record_task_cost` is the **tested primitive** — the production cost-path
+attribution (wiring the LLM cost recorder to it with a task_id) is a deliberate,
+tracked defer that co-lands with the task-execution engine (slice P).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.services.task_wake import TaskWaker
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
+
+
+def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
+          requester="req", parent_id=None, budget_cap=None):
+    return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
+                status=status, deps=list(deps or []), parent_id=parent_id,
+                budget_cap=budget_cap)
+
+
+@pytest.fixture(params=["inmem", "sqlite"])
+def backend(request, tmp_path):
+    if request.param == "inmem":
+        yield InMemoryTaskBackend()
+    else:
+        b = SqliteTaskBackend(tmp_path / "cost.db")
+        yield b
+        b.close()
+
+
+# ── record_cost primitive ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_cost_accumulates(backend):
+    """Tier 2: record_cost adds onto cost_accum (the per-Task counter)."""
+    await backend.create(_task("t"))
+    await backend.record_cost("t", 1.5)
+    await backend.record_cost("t", 2.0)
+    assert (await backend.get("t")).cost_accum == 3.5
+
+
+@pytest.mark.asyncio
+async def test_record_cost_unknown_task_is_none(backend):
+    """Tier 2: record_cost on an unknown task is a None no-op (no row created)."""
+    assert await backend.record_cost("nope", 1.0) is None
+
+
+@pytest.mark.asyncio
+async def test_record_cost_persists_across_sqlite_reload(tmp_path):
+    """Tier 2: cost_accum survives a sqlite close + reopen (durable counter)."""
+    path = tmp_path / "persist.db"
+    b = SqliteTaskBackend(path)
+    await b.create(_task("t"))
+    await b.record_cost("t", 4.25)
+    b.close()
+    re = SqliteTaskBackend(path)
+    assert (await re.get("t")).cost_accum == 4.25
+    re.close()
+
+
+# ── cap-hit → cap_exceeded disposition → parent routing ─────────────────────
+
+
+class _Rec:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **f) -> None:
+        self.events.append((kind, f))
+
+
+class _RecSession:
+    def __init__(self) -> None:
+        self.inbox: list[tuple[str, dict]] = []
+
+    async def _put_inbox(self, kind: str, payload: dict) -> str:
+        self.inbox.append((kind, payload))
+        return "m"
+
+
+class _RecRegistry:
+    def __init__(self) -> None:
+        self.ensured: list[tuple[str, str]] = []
+        self._sessions: dict[tuple[str, str, str], _RecSession] = {}
+
+    def resolve_session(self, agent, transport, native_id):
+        return self._sessions.setdefault((agent, transport, native_id), _RecSession())
+
+    def ensure_session_running(self, name, sid):
+        self.ensured.append((name, sid))
+
+    def inbox_of(self, agent, transport, native_id):
+        return self._sessions[(agent, transport, native_id)].inbox
+
+
+def _ctx(backend, waker, *, events=None, session_id="req"):
+    return SimpleNamespace(session_id=session_id, agent_id="alice", events=events,
+                           task_backend=backend, task_waker=waker)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_under_cap_does_not_terminate():
+    """Tier 2: cost under the cap leaves the task alive (nothing routed)."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    await b.create(_task("t", budget_cap=10.0, assignee="a2a:st",
+                         status=TaskState.IN_PROGRESS))
+    res = await taskmod.record_task_cost(_ctx(b, TaskWaker(reg, "alice")), "t", 3.0)
+    assert res.status is TaskState.IN_PROGRESS
+    assert reg.ensured == []  # no wake
+
+
+@pytest.mark.asyncio
+async def test_uncapped_task_never_terminates():
+    """Tier 2: a task with no budget_cap accrues cost without termination."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    await b.create(_task("t", assignee="a2a:st", status=TaskState.IN_PROGRESS))
+    res = await taskmod.record_task_cost(_ctx(b, TaskWaker(reg, "alice")), "t", 999.0)
+    assert res.status is TaskState.IN_PROGRESS and res.cost_accum == 999.0
+
+
+@pytest.mark.asyncio
+async def test_cap_hit_terminates_and_routes_cap_exceeded_first_class():
+    """Tier 2: a cap-hit force-terminates the task and routes a FIRST-CLASS
+    `cap_exceeded` disposition to the parent — in BOTH the P6 event and the parent
+    payload (the no-conflation invariant: NOT `failed`, NOT `aborted`)."""
+    b = InMemoryTaskBackend()
+    rec = _Rec()
+    reg = _RecRegistry()
+    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", budget_cap=5.0, assignee="a2a:sB", parent_id="P",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))  # stuck dependent
+
+    await taskmod.record_task_cost(_ctx(b, TaskWaker(reg, "alice"), events=rec), "B", 6.0)
+
+    # B force-terminated (archived).
+    assert (await b.get("B")).status is TaskState.ARCHIVED
+    # P6 task_disposition carries cap_exceeded first-class (not aborted/failed).
+    disp = [f for k, f in rec.events if k == "task_disposition" and f["task_id"] == "B"]
+    assert disp and disp[0]["disposition"] == "cap_exceeded"
+    # parent woken with the cap_exceeded disposition in the payload.
+    kind, payload = reg.inbox_of("alice", "a2a", "sP")[0]
+    assert kind == "task_dependency_aborted"
+    assert payload["meta"]["disposition"] == "cap_exceeded"
+    assert "cap_exceeded" in payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_cap_hit_at_exact_cap_terminates():
+    """Tier 2: hitting the cap exactly (cost_accum == budget_cap) terminates."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    await b.create(_task("t", budget_cap=5.0, assignee="a2a:st", parent_id=None,
+                         status=TaskState.IN_PROGRESS))
+    res = await taskmod.record_task_cost(_ctx(b, TaskWaker(reg, "alice")), "t", 5.0)
+    assert res.status is TaskState.ARCHIVED  # >= cap
+
+
+# ── the cap-hit recovery loop (end-to-end mechanism) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cap_hit_recovery_loop_parent_removes_dep_readies_dependent():
+    """Tier 2: cap-hit → the parent is woken (cap_exceeded) → it removes the dead
+    dependency from the stuck dependent → the dependent (its last dep gone) becomes
+    ready AND is woken (the recovery loop closes through the SAME seam as abort)."""
+    b = InMemoryTaskBackend()
+    reg = _RecRegistry()
+    waker = TaskWaker(reg, "alice")
+    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", budget_cap=5.0, assignee="a2a:sB", parent_id="P",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))  # blocked on B
+    ctx = _ctx(b, waker)
+
+    # 1. B hits its cap → the parent P is woken with cap_exceeded.
+    await taskmod.record_task_cost(ctx, "B", 6.0)
+    assert reg.inbox_of("alice", "a2a", "sP")[0][1]["meta"]["disposition"] == "cap_exceeded"
+
+    # 2. the parent's recovery move: drop A's dead dependency on B → A (last dep
+    #    gone, I-1) becomes ready and is woken.
+    await taskmod._remove_dependency(SimpleNamespace(task_id="A", depends_on="B"),
+                                     ctx, "control_ir")
+    assert (await b.get("A")).status is TaskState.READY
+    assert reg.inbox_of("alice", "a2a", "sA")[0][0] == "task_ready"

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -216,11 +216,13 @@ class _RecordingWaker:
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
-    async def notify_parent_decide(self, *, parent_session, terminal_task, dependents):
+    async def notify_parent_decide(self, *, parent_session, terminal_task, dependents,
+                                   disposition=None):
         self.calls.append({
             "parent_session": parent_session,
             "terminal_task": terminal_task.task_id,
             "dependents": [d.task_id for d in dependents],
+            "disposition": disposition,
         })
 
 
@@ -283,9 +285,11 @@ async def test_op_abort_routes_disposition_to_parent():
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, events=rec, waker=waker, session_id="req"), "control_ir")
 
-    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B", "dependents": ["A"]}]
+    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B",
+                            "dependents": ["A"], "disposition": "aborted"}]
     routed = [f for k, f in rec.events if k == "task_dependency_aborted"]
     assert routed and routed[0]["parent_session"] == "sP" and routed[0]["dependents"] == ["A"]
+    assert routed[0]["disposition"] == "aborted"
 
 
 @pytest.mark.asyncio
@@ -301,7 +305,8 @@ async def test_op_failed_routes_disposition_to_parent():
     # failed is assignee-gated → caller must be B's assignee.
     await taskmod._update_status(SimpleNamespace(task_id="B", status="failed"),
                                  _opctx(b, waker=waker, session_id="sB"), "control_ir")
-    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B", "dependents": ["A"]}]
+    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B",
+                            "dependents": ["A"], "disposition": "failed"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice 8 (spec G-3 / I-3). Seam-map design-check-first reviewed + 3 rulings by lead-coder (durable record in #1953). When a Task hits its budget cap, route it through the SAME slice-7 parent-LLM seam as abort/failed — the "one decision resolves OQ-7 + cap-hit" property.

## What
- **`record_cost(task_id, delta) -> Task`** — backend method (Protocol + InMemory + sqlite, the `set_awaiting` UPDATE pattern). The per-Task cost-attribution primitive (the one real GAP — the `cost_accum` / `budget_cap` columns already existed).
- **`record_task_cost(ctx, task_id, delta)`** — OS-internal helper: accumulates the cost; on a cap-hit (`cost_accum >= budget_cap`) force-terminates the task (abort-like — out of budget → archive the sub-tree) and routes a **first-class `cap_exceeded`** disposition to the parent.

## The 3 rulings
- **① no-conflation invariant** — `cap_exceeded` rides first-class in **BOTH** the P6 `task_disposition` event AND the parent wake payload; never just `status=failed` (the parent's recovery differs for a budget cap-hit vs a genuine error, and a downstream reader must not misread a cap-hit as an error). `_route_terminal_to_parent` + `TaskWaker.notify_parent_decide` gained an explicit `disposition` param; abort/failed now pass theirs explicitly too.
- **②=(B) — deliberate tracked defer**: `record_task_cost` is the **tested primitive**. The production cost-path attribution — wiring the LLM cost recorder (`record_llm` at the 4 M4 call-sites) to call it with the right `task_id` — **co-lands with the task-execution engine (slice P)**: there is no implicit active-task handle to thread it from today (1 session : N tasks interleave), and an `OpContext.current_task_id` setter would be exactly the interleave-fragile handle the model forbids ("no implicit active-task handle"). This is a tracked defer, **not** an accidental no-prod-caller.
- **③=(A) provisional** — the per-Task cap is an **independent** dimension, enforced alongside the existing session / daily caps (tighter hits first); matches the existing `check_pre_llm` multi-dimension structure. (B) sub-allocation partitioning is a future enhancement (owner override possible).

## Tests (`tests/test_task_cap_hit_slice8_1953.py` — real sqlite + in-memory + recording registry/TaskWaker, no mocks)
- `record_cost` accumulate / unknown→None / sqlite reload-persist;
- under-cap + uncapped → no termination;
- cap-hit (over the cap + exactly at it) → force-terminates + routes `cap_exceeded` **first-class** in both the event + payload, distinct from `failed`/`aborted`;
- the **cap-hit recovery loop** (close-gate, op-mechanism level): cap-hit → parent woken with `cap_exceeded` → parent removes the dead dep → the dependent (last dep gone, I-1) becomes ready **and** is woken with `task_ready`.
- cap-hit detection + the `cap_exceeded` no-conflation CLEAN-RED falsified.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8254 passed**, 17 skipped, 3 xfailed; only the 2 known not-my-diff env failures (`test_swebench_missing_honest_skip`, `test_legacy_no_media_store_path`) which pass in CI.
- [x] task / op / gate / waker sweep (201 tests) green.
- [x] 3 CI gates local: **ruff** clean + **test-tier audit** `--strict` exit 0 + pytest.
- [x] cap-hit detection + no-conflation CLEAN-RED falsified then restored to green.
- [x] `control-ir.md` synced (cap-hit disposition + per-Task budget cap sections).
- [ ] (co-lands slice P) production cost-path attribution wiring + its Tier-3 real-LLM recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)