### PR TITLE
feat(#1953 slice R): Task backend as the 3rd rewind substrate (rewind-participation, I-5=A)

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -210,6 +210,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 registry=registry_ref[0],
                 allowed_skills=profile.allowed_skills,
                 allowed_mcp=profile.allowed_mcp,
+                task_backend=None,  # #1953 slice R: behaviour-preserving (op-runtime fallback); per-session rewind opt-in is a follow-up
                 events_config=session_cfg.config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -334,6 +334,7 @@ def run(args: argparse.Namespace) -> None:
     from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
     from reyn.security.permissions.permissions import PermissionResolver
+    from reyn.task import per_session_sqlite_backend  # #1953 slice R
 
     session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
@@ -448,6 +449,9 @@ def run(args: argparse.Namespace) -> None:
             registry=registry,  # back-reference for :agents / :attach + PR11 messaging
             allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
+            # #1953 slice R, I-5=(A): per-session sqlite Task backend → in-session
+            # task.* ops are durable + rewind with the session (local single-tenant).
+            task_backend=per_session_sqlite_backend(profile.name),
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -468,6 +468,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 registry=_reg_cell[0] if _reg_cell else None,
                 allowed_skills=profile.allowed_skills,
                 allowed_mcp=profile.allowed_mcp,
+                task_backend=None,  # #1953 slice R: dogfood eval has no WAL/rewind → op-runtime fallback
                 events_config=config.events,
                 state_log=None,  # no WAL for dogfood dispatch
                 budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -329,6 +329,7 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
     from reyn.security.permissions.permissions import PermissionResolver
+    from reyn.task import per_session_sqlite_backend  # #1953 slice R
 
     session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
@@ -413,6 +414,10 @@ def run_serve(args: argparse.Namespace) -> None:
             registry=registry,
             allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
+            # #1953 slice R, I-5=(A): stdio-MCP is single-tenant per process, so a
+            # per-session sqlite backend (rewind-participating) ≈ the singleton —
+            # durable in-session task state, opt-in rewind (flag #3 confirmed).
+            task_backend=per_session_sqlite_backend(profile.name),
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -346,6 +346,12 @@ def _get_registry():
                 # byte-identical. allowed_mcp / agent_id / router_max_iterations
                 # remain the #1431 item-2 gaps (separate capability decision).
                 allowed_mcp=None,
+                # #1953 slice R, I-5=(A): A2A/web does NOT thread a per-session
+                # backend. The process-singleton A2A Task surface (app.state.
+                # task_backend, GetTask/ListTasks/Cancel + sweep) is read directly
+                # and stays untouched/durable; A2A tasks are not rewound (external
+                # state can't be) — the cross-session fan-out is tracked in #1997.
+                task_backend=None,
                 agent_id=None,
                 exclude_tools=_scoped.exclude_tools,
                 excluded_categories=_profile_excluded,  # #1667 (none here) + #1827 S3 profile view

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -174,6 +174,13 @@ class AgentRegistry:
         # tracked follow-up (#1544). Lazily built so non-chat / no-WAL callers
         # never touch git.
         self._workspace_store: WorkspaceVersionStore | None = None
+        # #1953 slice R: the rewind-participating per-session Task backend, pulled
+        # from the session at construction (the session owns it — threaded via
+        # build_scoped_chat_session). The rewind/recovery restore
+        # (_restore_task_active) reads it. I-5=(A): only a local cli/chat
+        # per-session backend lands here; the A2A/web singleton is never threaded
+        # into a session, so it stays None here and its tasks never rewind.
+        self._task_backend: object | None = None
         # ADR-0038 #1544: FS+exec backend. None / name!="container" → host mode
         # (host subprocess git runner). When container, git runs in-container via
         # backend.run with the container path context (the work-tree is
@@ -1049,6 +1056,7 @@ class AgentRegistry:
                 # spawned → "name/sid".
                 agents.append(name if sid == _DEFAULT_SID else f"{name}/{sid}")
         await self._restore_workspace_active(at_or_below=workspace_at_or_below)
+        await self._restore_task_active(at_or_below=workspace_at_or_below)
         return agents
 
     async def _restore_workspace_active(self, *, at_or_below: int) -> None:
@@ -1069,6 +1077,29 @@ class AgentRegistry:
         ]
         if active:
             await ws.restore_to_seq(max(active))
+
+    async def _restore_task_active(self, *, at_or_below: int) -> None:
+        """Restore the Task substrate to the nearest ACTIVE generation
+        <= ``at_or_below`` — byte-mirror of ``_restore_workspace_active`` (same
+        ``is_active_seq`` honor; the rewind active-interval logic is WAL-derived
+        and substrate-agnostic, so it is shared, not re-implemented).
+
+        #1953 slice R, I-5=(A): only a rewind-participating per-session backend is
+        attached here (local cli/chat); the A2A/web process-singleton is not
+        threaded into this path, so it no-ops there (its tasks stay durable but
+        un-rewound — the cross-session fan-out is tracked in #1997). No-ops when
+        no backend is attached (e.g. crash-recovery before any session loads, so
+        crash-recovery stays untouched) or when the backend opts out of rewind.
+        """
+        tb = self._task_backend
+        if tb is None or not getattr(tb, "supports_rewind", False):
+            return
+        active = [
+            s for s in await tb.generation_seqs()
+            if s <= at_or_below and is_active_seq(self._state_log, s)
+        ]
+        if active:
+            await tb.restore_to_seq(max(active))
 
     async def recover_rewind_if_needed(self) -> dict | None:
         """Re-materialise both substrates as-of-N after a crash mid-rewind (1d).
@@ -1347,6 +1378,11 @@ class AgentRegistry:
             ws = self.workspace_store
             if ws is not None:
                 await ws.prune_below(floor)
+            # #1953 slice R: prune Task-substrate generations on the SAME boundary
+            # (bounds the full-DB-copy storage to the retention window — flag #2).
+            tb = self._task_backend
+            if tb is not None and getattr(tb, "supports_rewind", False):
+                await tb.prune_generations_below(floor)
             # #1560 PR-3: act-turn op-content-log GC on the same boundary — drop
             # entries below the floor + unref the out-window op-trees (so auto-gc
             # reclaims them, the same bounded lifecycle generations get).
@@ -1611,6 +1647,14 @@ class AgentRegistry:
         attach_anchor = getattr(session, "attach_anchor_store", None)
         if anchors is not None and callable(attach_anchor):
             attach_anchor(anchors)
+        # #1953 slice R: pull the session's rewind-participating Task backend so
+        # the rewind/recovery restore (_restore_task_active) has a handle to the
+        # same per-session backend the session's cut_generation captures. Only a
+        # backend that opts into rewind is held (I-5=(A) per-session); a None /
+        # non-rewinding backend leaves the restore path inert.
+        tb = getattr(session, "task_backend", None)
+        if tb is not None and getattr(tb, "supports_rewind", False):
+            self._task_backend = tb
         return session
 
     def spawn_session(self, name: str, sid: "str | None" = None) -> str:

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -58,6 +58,7 @@ def build_scoped_chat_session(
     non_interactive: bool,  # #1439 Fix #1: run-once (no TTY) → SP proceeds instead of asking a clarifying question. Per-frontend: chat-CLI = not isatty(); A2A/MCP/chainlit/dogfood = False (interactive byte-identical)
     eager_embedding_build: bool,  # build the action embedding index up-front
     allowed_mcp: list[str] | None,  # per-profile MCP allow-list
+    task_backend: Any,  # #1953 slice R — session-scoped Task backend instance. I-5=(A): cli/chat + MCP pass a per-session sqlite (rewind-participating); A2A/web passes None (the process-singleton A2A surface is read directly, NOT threaded here, so A2A tasks stay durable but un-rewound). None → op-runtime in-memory fallback (_BACKEND)
     # ── per-session config (required: should be UNIFORM across factories) ──
     # These are reyn.yaml-derived config every factory loads the same way; the
     # sandbox_config + multimodal_config drifts each previously needed a
@@ -108,6 +109,7 @@ def build_scoped_chat_session(
         non_interactive=non_interactive,
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
+        task_backend=task_backend,  # #1953 slice R
         sandbox_config=sandbox_config,
         multimodal_config=multimodal_config,
         action_retrieval_config=action_retrieval_config,

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -62,6 +62,10 @@ class SnapshotJournal:
         # #1547: per-checkpoint anchor text (truncated last user message). Set
         # post-construction by the registry. None → no anchor capture.
         self._anchor_store = None
+        # #1953 slice R: the session-scoped Task backend (set by the owning
+        # Session when it carries a rewind-participating per-session backend).
+        # None / supports_rewind=False → task capture is skipped.
+        self._task_backend = None
         self._snapshot: AgentSnapshot = AgentSnapshot.empty(agent_name, session_id)
 
     async def _wal_append(self, kind: str, **fields):
@@ -117,6 +121,18 @@ class SnapshotJournal:
         """
         self._anchor_store = anchor_store
 
+    def set_task_backend(self, task_backend) -> None:
+        """Attach the session-scoped Task backend (#1953 slice R).
+
+        Set by the owning Session when it carries a rewind-participating
+        per-session backend (I-5=(A): local cli/chat). The capture seam
+        (cut_generation) then snapshots the task db at the SAME boundary seq as
+        the runtime + workspace substrates; the registry's rewind/recovery
+        restores it. A backend with ``supports_rewind=False`` (in-memory /
+        external) is skipped at capture time.
+        """
+        self._task_backend = task_backend
+
     async def cut_generation(self, anchor: str = "", full_message: str = "") -> None:
         """Record the current snapshot as a PITR generation (ADR-0038 Stage 1a/1d).
 
@@ -140,6 +156,12 @@ class SnapshotJournal:
         self._generation_store.record(self._snapshot)
         if self._workspace_store is not None:
             await self._workspace_store.capture(self._snapshot.applied_seq)
+        # #1953 slice R: the 3rd substrate — capture the Task db at the same WAL
+        # boundary seq (opt-in; skipped for a non-rewinding backend).
+        if self._task_backend is not None and getattr(
+            self._task_backend, "supports_rewind", False
+        ):
+            await self._task_backend.snapshot_generation(self._snapshot.applied_seq)
         if self._anchor_store is not None and anchor:
             self._anchor_store.capture(
                 self._snapshot.applied_seq, anchor, full=full_message,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1183,6 +1183,12 @@ class Session:
             generation_store=self._generation_store,
             session_id=session_id,  # FP-0043 S5: per-session WAL routing
         )
+        # #1953 slice R: hand the journal this session's Task backend so
+        # cut_generation captures the task db at each WAL boundary (opt-in — a
+        # non-rewinding backend is skipped there). I-5=(A): only a per-session
+        # backend is threaded here (build_scoped_chat_session); the A2A/web
+        # process-singleton is never given to a session, so it never rewinds.
+        self._journal.set_task_backend(self._task_backend)
         # ADR-0038 Stage 1c: turn-idle event for quiescence. Set = no turn in
         # flight; cleared while run_one_iteration processes a turn. Lets a global
         # rewind await all in-flight WAL appends settling (await_quiescent) before
@@ -2215,6 +2221,17 @@ class Session:
         instance is set once in ``__init__`` and never re-bound.
         """
         return self._journal
+
+    @property
+    def task_backend(self) -> "object | None":
+        """Read-only accessor for this session's Task backend (#1953 slice R).
+
+        The registry pulls it at construction (``_construct_session``) so the
+        rewind/recovery restore (``_restore_task_active``) has a handle to the
+        same per-session backend the capture seam (cut_generation) snapshots.
+        None when the session carries no backend (op-runtime in-memory fallback).
+        """
+        return self._task_backend
 
     def iter_applied_seqs(
         self, *, now_ts: float, long_await_threshold: float,

--- a/src/reyn/task/__init__.py
+++ b/src/reyn/task/__init__.py
@@ -14,7 +14,7 @@ sqlite (slice 2), single-writer CAS + P6 events (slice 3), and the rest follow.
 from __future__ import annotations
 
 from reyn.task.backend import InMemoryTaskBackend, TaskBackend
-from reyn.task.factory import create_task_backend
+from reyn.task.factory import create_task_backend, per_session_sqlite_backend
 from reyn.task.model import (
     TERMINAL_STATES,
     Task,
@@ -36,4 +36,5 @@ __all__ = [
     "InMemoryTaskBackend",
     "SqliteTaskBackend",
     "create_task_backend",
+    "per_session_sqlite_backend",
 ]

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -141,6 +141,42 @@ class TaskBackend(Protocol):
 
     async def add_comment(self, task_id: str, author: str, body: str) -> str | None: ...
 
+    # ── Rewind substrate (#1953 slice R) ─────────────────────────────────────
+    # A backend opts INTO session-rewind participation by setting
+    # ``supports_rewind = True`` and implementing per-generation snapshot/restore.
+    # The OS captures a generation at every WAL boundary seq (``SnapshotJournal.
+    # cut_generation``) and restores the nearest *active* generation <= the rewind
+    # target (``_materialize_rewind``) — symmetric with ``WorkspaceVersionStore``
+    # (the runtime + workspace substrates). A backend whose state cannot be
+    # rewound (in-memory; external trackers like gh-issue/jira) leaves
+    # ``supports_rewind = False`` and the OS skips it (opt-out).
+    supports_rewind: bool
+
+    async def snapshot_generation(self, seq: int) -> None:
+        """Capture a full point-in-time generation keyed by the WAL boundary
+        ``seq``. Idempotent for a given seq. No-op when ``supports_rewind`` is
+        False."""
+        ...
+
+    async def restore_to_seq(self, seq: int) -> None:
+        """Restore backend state to the generation captured at ``seq`` — the OS
+        passes the nearest active seq <= the rewind target. No-op when
+        ``supports_rewind`` is False."""
+        ...
+
+    async def generation_seqs(self) -> list[int]:
+        """Seqs of all captured generations, ascending — the OS resolves the
+        nearest *active* one <= the rewind target (``is_active_seq``, symmetric
+        with ``WorkspaceVersionStore.seqs``). Empty when ``supports_rewind`` is
+        False."""
+        ...
+
+    async def prune_generations_below(self, min_keep_seq: int) -> int:
+        """Drop generations older than ``min_keep_seq`` (WAL-truncation
+        piggyback, bounds storage). Returns the count removed. No-op when
+        ``supports_rewind`` is False."""
+        ...
+
 
 class InMemoryTaskBackend:
     """Process-local dict-backed backend (slice 1 stub + the ``in-memory``
@@ -376,3 +412,20 @@ class InMemoryTaskBackend:
             {"id": comment_id, "author": author, "body": body, "ts": _now_iso()}
         )
         return comment_id
+
+    # ── Rewind substrate (#1953 slice R): opt-out ────────────────────────────
+    # In-memory state is ephemeral and process-local — it cannot be rewound, so
+    # this backend declares supports_rewind=False and no-ops the substrate hooks.
+    supports_rewind: bool = False
+
+    async def snapshot_generation(self, seq: int) -> None:
+        return None
+
+    async def restore_to_seq(self, seq: int) -> None:
+        return None
+
+    async def generation_seqs(self) -> list[int]:
+        return []
+
+    async def prune_generations_below(self, min_keep_seq: int) -> int:
+        return 0

--- a/src/reyn/task/factory.py
+++ b/src/reyn/task/factory.py
@@ -33,3 +33,22 @@ def create_task_backend(kind: str | None = None, *, path: str | None = None):
             raise ValueError("sqlite task backend requires a 'path' (session-scoped db)")
         return SqliteTaskBackend(path)
     raise ValueError(f"unknown task backend kind: {kind!r} (expected 'sqlite' or 'in-memory')")
+
+
+def per_session_sqlite_backend(agent_name: str) -> "SqliteTaskBackend":
+    """#1953 slice R, I-5=(A): a per-session sqlite Task backend at the agent's
+    default state dir — so in-session ``task.*`` ops are durable AND participate
+    in that session's rewind window (alongside runtime-snapshot + workspace).
+
+    The path is the sibling of the Session's default ``_snapshot_path`` /
+    ``generations`` dir (``.reyn/agents/<name>/state/tasks.db``), centralized here
+    so the capture (``cut_generation``) and restore (``_restore_task_active``)
+    operate on the same db. Used by the single-tenant local frontends (cli/chat,
+    stdio-MCP); A2A/web pass ``None`` (the process-singleton A2A surface is read
+    directly, not threaded into a session — its tasks stay durable but un-rewound,
+    the cross-session fan-out tracked in #1997).
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    path = Path(".reyn") / "agents" / agent_name / "state" / "tasks.db"
+    return create_task_backend("sqlite", path=str(path))

--- a/src/reyn/task/generation_store.py
+++ b/src/reyn/task/generation_store.py
@@ -1,0 +1,60 @@
+"""Per-generation sqlite snapshot store (#1953 slice R).
+
+The Task-substrate analog of ``core/events/snapshot_generations.py``'s
+``SnapshotGenerationStore``: a directory of full-DB copies (``task-gen-<seq>.db``),
+each a clean WAL-less sqlite file produced by ``VACUUM INTO`` at a WAL boundary
+seq (the ``applied_seq`` ``SnapshotJournal.cut_generation`` keys runtime +
+workspace on too).
+
+This store holds NO lineage logic. Which generation is "active" at a rewind
+target is resolved by the OS via ``is_active_seq`` (the same WAL-derived
+predicate the runtime + workspace substrates use, ``snapshot_generations.py``),
+so the store only manages files keyed by seq — symmetric with
+``WorkspaceVersionStore`` (git tags) one layer down.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_GEN_RE = re.compile(r"^task-gen-(\d+)\.db$")
+
+
+class SqliteTaskGenerationStore:
+    """Directory of ``task-gen-<seq>.db`` full-DB copies."""
+
+    def __init__(self, gen_dir: str | Path) -> None:
+        self._dir = Path(gen_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def dir(self) -> Path:
+        return self._dir
+
+    def gen_path(self, seq: int) -> Path:
+        return self._dir / f"task-gen-{seq}.db"
+
+    def has(self, seq: int) -> bool:
+        return self.gen_path(seq).exists()
+
+    def seqs(self) -> list[int]:
+        """All captured generation seqs, ascending."""
+        out: list[int] = []
+        for p in self._dir.iterdir():
+            m = _GEN_RE.match(p.name)
+            if m is not None:
+                out.append(int(m.group(1)))
+        return sorted(out)
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Unlink generations with ``seq < min_keep_seq`` (WAL-truncation
+        piggyback) and sweep any stale ``.tmp`` files from interrupted captures.
+        Returns the count of generations removed."""
+        removed = 0
+        for s in self.seqs():
+            if s < min_keep_seq:
+                self.gen_path(s).unlink(missing_ok=True)
+                removed += 1
+        for tmp in self._dir.glob("task-gen-*.db.tmp"):
+            tmp.unlink(missing_ok=True)
+        return removed

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -32,10 +32,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import shutil
 import sqlite3
 from pathlib import Path
 
 from reyn.task.backend import find_cycle_path
+from reyn.task.generation_store import SqliteTaskGenerationStore
 from reyn.task.model import (
     TERMINAL_STATES,
     Task,
@@ -109,21 +112,90 @@ _TASK_COLUMNS = (
 
 
 class SqliteTaskBackend:
-    """Durable Task backend backed by a single sqlite database."""
+    """Durable Task backend backed by a single sqlite database.
+
+    Opts INTO session-rewind participation (#1953 slice R): the durable db file
+    is captured per WAL boundary via ``VACUUM INTO`` and restored by replacing
+    the file — symmetric with ``WorkspaceVersionStore`` (the runtime + workspace
+    substrates). The rewind generations are a separate filesystem mechanism from
+    the WAL ``state_log`` (P7: no new WAL kind) and from crash-recovery (the dep
+    graph + decision-ops stay WAL-durable in the live db independent of them)."""
+
+    #: #1953 slice R — this backend's durable state can be rewound (opt-in).
+    supports_rewind: bool = True
 
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = str(db_path)
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA busy_timeout=0")
-        self._conn.executescript(_SCHEMA)
-        self._conn.commit()
+        self._conn = self._open(init_schema=True)
         self._lock = asyncio.Lock()
+        # Sibling directory holding the per-generation full-DB copies.
+        self._gens = SqliteTaskGenerationStore(
+            Path(self._db_path).parent / "task-generations"
+        )
+
+    def _open(self, *, init_schema: bool = False) -> sqlite3.Connection:
+        """Open (or reopen, after a restore file-swap) the live connection with
+        the backend's fixed pragmas. ``init_schema`` only on first open — a
+        restored generation already carries the schema."""
+        conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=0")
+        if init_schema:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+        return conn
 
     def close(self) -> None:
         self._conn.close()
+
+    # ── Rewind substrate (#1953 slice R) ─────────────────────────────────────
+
+    async def snapshot_generation(self, seq: int) -> None:
+        """Capture a full point-in-time copy of the db keyed by the WAL boundary
+        ``seq``. Idempotent (a boundary already captured is left intact). The
+        ``async with self._lock`` guarantees no ``BEGIN IMMEDIATE`` is open, so
+        ``VACUUM INTO`` (which cannot run inside a transaction) is legal here; it
+        produces a fully-checkpointed, WAL-less single-file copy that includes
+        committed WAL frames. Published via tmp→rename for atomicity (a crash
+        mid-copy leaves only a ``.tmp`` the next prune sweeps)."""
+        dest = self._gens.gen_path(seq)
+        async with self._lock:
+            if dest.exists():
+                return
+            tmp = dest.with_suffix(dest.suffix + ".tmp")
+            if tmp.exists():
+                tmp.unlink()
+            self._conn.execute("VACUUM INTO ?", (str(tmp),))
+            os.replace(tmp, dest)
+
+    async def restore_to_seq(self, seq: int) -> None:
+        """Replace the live db with the generation captured at ``seq`` (the OS
+        passes the nearest active seq <= the rewind target). Closes the live
+        connection, copies the (WAL-less) generation file over the db path, drops
+        any stale ``-wal``/``-shm`` side-files so the old WAL is not replayed over
+        the restored copy, then reopens. Re-runnable (idempotent under the
+        rewind keystone). Defensive no-op if the generation is missing."""
+        src = self._gens.gen_path(seq)
+        async with self._lock:
+            if not src.exists():
+                return
+            self._conn.close()
+            shutil.copy2(src, self._db_path)
+            for side in ("-wal", "-shm"):
+                stale = Path(self._db_path + side)
+                if stale.exists():
+                    stale.unlink()
+            self._conn = self._open()
+
+    async def generation_seqs(self) -> list[int]:
+        async with self._lock:
+            return self._gens.seqs()
+
+    async def prune_generations_below(self, min_keep_seq: int) -> int:
+        async with self._lock:
+            return self._gens.prune_below(min_keep_seq)
 
     # ── helpers ─────────────────────────────────────────────────────────────
 

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -57,6 +57,7 @@ _REQUIRED_SCOPED = frozenset({
     "non_interactive",  # #1439 Fix #1: run-once SP autonomy flag (per-frontend scoped)
     "eager_embedding_build",
     "allowed_mcp",
+    "task_backend",  # #1953 slice R: per-session Task backend (per-frontend scoped — I-5=(A))
     # per-session config (should be UNIFORM across factories)
     "sandbox_config",
     "multimodal_config",

--- a/tests/test_task_rewind_participation_1953_sliceR.py
+++ b/tests/test_task_rewind_participation_1953_sliceR.py
@@ -1,0 +1,236 @@
+"""Tier 1/2: #1953 slice R — the Task backend participates in session rewind.
+
+The sqlite Task backend is the 3rd rewind substrate (beside runtime-snapshot +
+workspace): ``cut_generation`` captures a full-DB copy at each WAL boundary seq
+and ``_materialize_rewind`` restores the nearest *active* generation <= the
+target — symmetric with ``WorkspaceVersionStore``. In-memory / external backends
+opt out (``supports_rewind=False``).
+
+Real AgentRegistry + real Session + real sqlite + real StateLog/WAL; a no-LLM
+``_FakeTurnDriver`` drives the genuine ``_run_router_loop`` so a real
+``cut_generation`` fires (only the task write is simulated). No mocks.
+
+Merge gates (lead): §7c falsifying-rewind (a task created after the rewind target
+is gone after the rewind — RED on current main, which never restores the task
+backend → GREEN) + §7d crash-recovery-untouched (``recover_rewind_if_needed``
+still recovers with a task backend attached, and a non-rewinding backend leaves
+the path inert).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for the workspace substrate",
+)
+
+
+# ── Tier 1: interface contract ───────────────────────────────────────────────
+
+
+def test_sqlite_opts_into_rewind_inmemory_opts_out():
+    """Tier 1: sqlite advertises supports_rewind=True; in-memory (and any
+    non-durable/external backend) advertises False (opt-out — external state
+    cannot be rewound)."""
+    assert SqliteTaskBackend.supports_rewind is True
+    assert InMemoryTaskBackend.supports_rewind is False
+
+
+@pytest.mark.asyncio
+async def test_inmemory_rewind_hooks_are_noops():
+    """Tier 1: the opt-out backend no-ops the substrate hooks (the OS guards on
+    supports_rewind, but the hooks must be safe to call regardless)."""
+    b = InMemoryTaskBackend()
+    await b.snapshot_generation(1)
+    await b.restore_to_seq(1)
+    assert await b.generation_seqs() == []
+    assert await b.prune_generations_below(5) == 0
+
+
+@pytest.mark.asyncio
+async def test_sqlite_snapshot_restore_prune_unit(tmp_path):
+    """Tier 2: the sqlite substrate primitive — capture@1, create-after, capture@2,
+    restore_to_seq(1) drops the post-1 task; prune bounds storage."""
+    b = SqliteTaskBackend(tmp_path / "state" / "tasks.db")
+    await b.create(Task(task_id="t1", name="t1", assignee="s", requester="r",
+                        status=TaskState.PENDING))
+    await b.snapshot_generation(1)
+    await b.create(Task(task_id="t2", name="t2", assignee="s", requester="r",
+                        status=TaskState.PENDING))
+    await b.snapshot_generation(2)
+    assert await b.generation_seqs() == [1, 2]
+    await b.restore_to_seq(1)
+    assert await b.get("t1") is not None
+    assert await b.get("t2") is None          # created after gen-1 → gone
+    # writable after restore (reopened connection)
+    await b.create(Task(task_id="t3", name="t3", assignee="s", requester="r",
+                        status=TaskState.PENDING))
+    assert await b.get("t3") is not None
+    assert await b.prune_generations_below(2) == 1   # gen-1 dropped
+    assert await b.generation_seqs() == [2]
+
+
+# ── shared real-registry harness (mirrors test_concurrent_multiagent_rewind_1580) ─
+
+
+class _TaskTurnDriver:
+    """No-LLM driver: creates a Task (keyed by user_text) in the session's backend
+    + a runtime inbox marker, so the real loop's genuine cut_generation captures
+    BOTH the runtime snapshot AND (slice R) the task-db generation."""
+
+    def __init__(self, session: Session, backend) -> None:
+        self._session = session
+        self._backend = backend
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        if self._backend is not None:
+            await self._backend.create(Task(
+                task_id=user_text, name=user_text, assignee="sess",
+                requester="req", status=TaskState.PENDING,
+            ))
+        await self._session._journal.append_inbox(
+            kind="user_message", payload={"turn": user_text},
+        )
+
+    def request_cancel(self) -> None:
+        return None
+
+    def is_cancel_requested(self) -> bool:
+        return False
+
+
+def _registry(tmp_path: Path, *, backend_kind: str):
+    """One-agent registry whose session carries a task backend of ``backend_kind``
+    ('sqlite' rewinds, 'inmem' opts out, 'none' threads nothing). Returns
+    (registry, session, backend)."""
+    from reyn.core.events.state_log import StateLog
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict[str, object] = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        state = tmp_path / ".reyn" / "agents" / profile.name / "state"
+        snap = state / "snapshot.json"
+        if backend_kind == "sqlite":
+            tb: object | None = SqliteTaskBackend(state / "tasks.db")
+        elif backend_kind == "inmem":
+            tb = InMemoryTaskBackend()
+        else:
+            tb = None
+        holder["backend"] = tb
+        return Session(
+            agent_name=profile.name, state_log=state_log, snapshot_path=snap,
+            task_backend=tb,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    sess = reg.get_or_load("alpha")
+    sess.register_intervention_listener("test")
+    sess._loop_driver = _TaskTurnDriver(sess, holder["backend"])
+    return reg, sess, holder["backend"]
+
+
+# ── §7c: falsifying-rewind (the headline merge gate) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rewind_restores_task_substrate(tmp_path):
+    """Tier 2: §7c falsifying-rewind — rewinding to turn-1's boundary restores the
+    task db to its as-of-seq state — the task created in turn 2 is GONE.
+
+    RED on current main: ``_materialize_rewind`` restores runtime + workspace but
+    NOT the task backend, so t2 survives the rewind. GREEN with slice R. Revert
+    the slice-R src commits and this assertion fails."""
+    reg, sess, tb = _registry(tmp_path, backend_kind="sqlite")
+
+    await sess._run_router_loop("t1", "c1")
+    seq1 = sess.current_snapshot.applied_seq
+    await sess._run_router_loop("t2", "c1")
+
+    assert await tb.get("t1") is not None
+    assert await tb.get("t2") is not None        # pre-rewind: both live
+
+    await reg.rewind_to(seq1)                      # global rewind to turn-1 boundary
+
+    assert await tb.get("t1") is not None         # captured at/below seq1 → kept
+    assert await tb.get("t2") is None             # created after seq1 → restored away
+
+
+@pytest.mark.asyncio
+async def test_rewind_then_new_turn_recaptures_active_branch(tmp_path):
+    """Tier 2: is_active honor — after rewinding past turn 2 and running a NEW turn,
+    a later rewind to that new boundary restores the post-rewind active branch
+    (the abandoned turn-2 generation is never chosen)."""
+    reg, sess, tb = _registry(tmp_path, backend_kind="sqlite")
+
+    await sess._run_router_loop("t1", "c1")
+    seq1 = sess.current_snapshot.applied_seq
+    await sess._run_router_loop("t2", "c1")       # abandoned by the rewind below
+    await reg.rewind_to(seq1)
+    assert await tb.get("t2") is None
+
+    await sess._run_router_loop("t3", "c1")        # new active-branch turn
+    seq3 = sess.current_snapshot.applied_seq
+    assert await tb.get("t3") is not None
+    await reg.rewind_to(seq3)                       # rewind to the new boundary
+    assert await tb.get("t1") is not None
+    assert await tb.get("t3") is not None          # active branch kept
+    assert await tb.get("t2") is None              # abandoned gen never restored
+
+
+# ── §7d: crash-recovery untouched + opt-out inert ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rewind_with_inmemory_backend_is_inert(tmp_path):
+    """Tier 2: opt-out — a non-rewinding (in-memory) task backend leaves the rewind
+    path inert — the rewind still cuts runtime/workspace and does NOT error, and
+    the in-memory task survives (it is not a rewind substrate)."""
+    reg, sess, tb = _registry(tmp_path, backend_kind="inmem")
+    await sess._run_router_loop("t1", "c1")
+    seq1 = sess.current_snapshot.applied_seq
+    await sess._run_router_loop("t2", "c1")
+    await reg.rewind_to(seq1)                       # must not raise on the task path
+    # in-memory opts out → not restored (its state is ephemeral, not a substrate).
+    assert await tb.get("t2") is not None
+
+
+@pytest.mark.asyncio
+async def test_rewind_with_no_backend_is_inert(tmp_path):
+    """Tier 2: §7d crash-recovery-untouched — with NO task backend threaded (the
+    A2A/web + crash-recovery-before-session-load case) the rewind/recovery path is
+    a clean no-op — runtime still cuts, nothing errors."""
+    reg, sess, _tb = _registry(tmp_path, backend_kind="none")
+    await sess._run_router_loop("t1", "c1")
+    seq1 = sess.current_snapshot.applied_seq
+    await sess._run_router_loop("t2", "c1")
+    res = await reg.rewind_to(seq1)                 # no task backend → no-op task path
+    assert res is not None                          # runtime rewind still happened
+
+
+@pytest.mark.asyncio
+async def test_crash_recovery_replays_rewind_with_task_backend(tmp_path):
+    """Tier 2: §7d — recover_rewind_if_needed (the crash-recovery entry that
+    replays a pending rewind at restart) runs cleanly with a task backend attached
+    — the existing runtime recovery is untouched and the task substrate restore
+    rides the SAME idempotent path (re-running it does not error)."""
+    reg, sess, tb = _registry(tmp_path, backend_kind="sqlite")
+    await sess._run_router_loop("t1", "c1")
+    seq1 = sess.current_snapshot.applied_seq
+    await sess._run_router_loop("t2", "c1")
+    await reg.rewind_to(seq1)
+    assert await tb.get("t2") is None
+    # re-run the recovery path (simulates a restart after the rewind record): it is
+    # idempotent and must not error or resurrect t2.
+    await reg.recover_rewind_if_needed()
+    assert await tb.get("t1") is not None
+    assert await tb.get("t2") is None


### PR DESCRIPTION
**[dogfood-coder]** — implements **#1953 slice R** (rewind-participation interface) per the lead-approved seam-map (#1953 issuecomment-4761224479) + **impl GO with I-5=(A)**. Makes the sqlite Task backend the **3rd rewind substrate** beside runtime-snapshot + workspace, so a session rewind also restores task state. Resolves the time-travel × Task skew (#1954-adjacent).

3 commits: `3e19d093` (S1 interface + S2 sqlite mechanism), `c99df0b1` (S3-S5+S7 wiring), `4a24afa5` (merge-gate tests).

## What it does (symmetric with WorkspaceVersionStore)
- **S1 interface** (`task/backend.py`): `TaskBackend` Protocol gains `supports_rewind` + `snapshot_generation(seq)` + `restore_to_seq(seq)` + `generation_seqs()` + `prune_generations_below(min_seq)`. In-memory / external = opt-out (`supports_rewind=False` + no-ops).
- **S2 sqlite** (`task/generation_store.py` + `sqlite_backend.py`): `SqliteTaskGenerationStore` manages `task-gen-<seq>.db` full-DB copies; capture via `VACUUM INTO` (outside a txn under the lock → WAL-less consistent copy) published tmp→rename; restore via close→copy→drop stale `-wal`/`-shm`→reopen; `is_active` resolution stays in the OS (shared `is_active_seq`).
- **S3 threading** (`build_scoped_chat_session` + 5 callers): a **required** scoped `task_backend` kwarg (completeness-by-construction; `_REQUIRED_SCOPED` invariant extended). I-5=(A): cli/chat + stdio-MCP thread a per-session sqlite (`.reyn/agents/<name>/state/tasks.db`, sibling of `generations/`); A2A/web + dogfood + chainlit pass `None`.
- **S4 capture** (`snapshot_journal.py`): `cut_generation` snapshots the task db at the same WAL boundary seq as runtime + workspace (opt-in).
- **S5 restore** (`registry.py`): `_restore_task_active` — a byte-mirror of `_restore_workspace_active` — in `_materialize_rewind`; the registry pulls the per-session backend from the session.
- **S7 prune** (`registry.py`): the task substrate prunes on the same WAL-truncation boundary.

## I-5 → (A) (lead-ruled); A2A fan-out → #1997
Per-session rewind requires per-session db files, so the op-runtime SoT and the A2A query singleton can't be one store once rewind is on. (A): per-session for rewind-participating local sessions; the A2A/web process-singleton stays untouched (durable, un-rewound). Cross-session fan-out tracked in **#1997**.

## Flow-trace flags (lead, documented)
1. **A2A no-regression** — traced: in-session task ops **today** hit the in-memory `_BACKEND` fallback (`op_runtime/task.py:45`), **not** the A2A sqlite singleton (`app.state.task_backend`, `server.py:169`, which only the A2A router + disposition sweep read). So (A) is a **strict upgrade** for local sessions (in-memory → durable per-session sqlite that rewinds); web passes `None`, so `GetTask`/`ListTasks`/`Cancel`/sweep are **wholly untouched**. No A2A regression.
2. **Storage bound** — S7 prunes `task-gen-<seq>.db` on the same retention floor as runtime/workspace generations (`_prune_generations_below`), so a long-running session's full-DB copies are bounded to the retention window (no unbounded growth).
3. **MCP per-session ≈ singleton** — confirmed: stdio-MCP is single-tenant per process, so a per-session backend is effectively the process backend; threading it is a strict durability+rewind upgrade with no multi-tenant concern.

## Merge gates (close-gates)
- **§7c falsifying-rewind** ✅ — `test_rewind_restores_task_substrate`: a real `reg.rewind_to(turn-1 boundary)` makes a task created in turn 2 vanish (t1 kept). **RED→GREEN verified live**: reverting the slice-R src → the test fails (t2 survives, no task-substrate restore); restored → passes.
- **§7d crash-recovery-untouched** ✅ — `recover_rewind_if_needed` re-runs idempotently with a backend attached (no resurrection/error); None + in-memory backends leave the task path inert while runtime/workspace still cut. Independently: `reconstruct`/`restore_all` never touch the task backend; generations are a filesystem mechanism outside `WAL_EVENT_KINDS` (P7 — no new WAL kind; only the existing `"rewind"` kind).

## Verification (primary evidence)
- 8 slice-R tests pass (real registry/session/sqlite/WAL, no mocks); §7c RED→GREEN proven by src-revert.
- Broad regression: 62 across rewind/task/scoped consumers; **167 task tests** pass.
- ruff clean (all changed files); tier-audit --strict clean (11 tests); imports clean (no cycle).

## Test plan
- [x] §7c falsifying-rewind RED→GREEN (live src-revert proof)
- [x] §7d crash-recovery-untouched + opt-out inert
- [x] Tier-1 interface contract (opt-in/opt-out) + sqlite primitive unit + is_active honor
- [x] 167 task tests + 62-test rewind/scoped regression
- [x] ruff + tier-audit --strict + import smoke
- [ ] (lead) flow-trace review of the substrate wiring (capture/restore symmetry + the I-5=(A) threading)

Requesting **flow-trace review**. sandbox_2 does not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
