### PR TITLE
fix(#1998): universal plan step.tools accepts qualified action names

### DIFF
--- a/src/reyn/runtime/planner.py
+++ b/src/reyn/runtime/planner.py
@@ -55,7 +55,10 @@ from reyn.runtime.router_loop import (
     RouterLoop,
     RouterLoopHost,
 )
-from reyn.tools.universal_catalog import strip_provider_tool_namespace
+from reyn.tools.universal_catalog import (
+    is_valid_qualified_name,
+    strip_provider_tool_namespace,
+)
 
 if TYPE_CHECKING:
     from reyn.config import PlannerStepCompactionConfig
@@ -248,7 +251,10 @@ class PlanValidationError(ValueError):
 # ── Parsing + validation ────────────────────────────────────────────────────
 
 
-def parse_and_validate_plan(args: dict, *, allowed_tool_names: set[str]) -> Plan:
+def parse_and_validate_plan(
+    args: dict, *, allowed_tool_names: set[str],
+    accept_qualified_actions: bool = False,
+) -> Plan:
     """Convert raw plan tool-call arguments into a typed ``Plan``.
 
     ``allowed_tool_names`` is the set of router-tool names available in
@@ -346,11 +352,28 @@ def parse_and_validate_plan(args: dict, *, allowed_tool_names: set[str]) -> Plan
                     f"plan.steps[{i}] (id={sid!r}).tools[*] must be strings"
                 )
             nt = strip_provider_tool_namespace(t)
-            if nt not in allowed_tool_names:
+            # #1998: in the universal scheme the callable tools are the wrappers
+            # (invoke_action/…), but step.tools' vocabulary is the per-step
+            # *narrowing* set — qualified ``<category>__action`` names (which
+            # _PlanStepHost._uses_family keys on, and which invoke_action can
+            # reach). The wrapper-only allow-set rejected exactly those qualified
+            # names a weak model correctly emits. When the caller signals the
+            # wrapper scheme (accept_qualified_actions), also accept any valid
+            # qualified action name. NOT leniency: invoke_action reachability is
+            # unchanged — this fixes the validator's vocabulary, scoped to the
+            # universal scheme (enumerate keeps the wrapper/qualified coincidence).
+            if nt not in allowed_tool_names and not (
+                accept_qualified_actions and is_valid_qualified_name(nt)
+            ):
+                allowed = sorted(allowed_tool_names)
+                extra = (
+                    " (or a qualified <category>__action name)"
+                    if accept_qualified_actions else ""
+                )
                 raise PlanValidationError(
                     f"plan.steps[{i}] (id={sid!r}).tools references {t!r} "
                     f"which is not in the available tool catalog. "
-                    f"Allowed: {sorted(allowed_tool_names)}"
+                    f"Allowed: {allowed}{extra}"
                 )
             normalized.append(nt)
         tools_tuple: tuple[str, ...] = tuple(normalized)
@@ -1509,6 +1532,7 @@ async def dispatch_plan_tool(
     budget: Any = None,
     router_model: "str | None" = None,  # #1672: None → config "router" purpose class (was "light")
     available_tool_names: set[str],
+    accept_qualified_actions: bool = False,  # #1998: universal scheme → step.tools may name qualified actions, not just the callable wrappers
 ) -> dict:
     """Entry point invoked from the chat router's ``plan`` tool dispatch.
 
@@ -1545,7 +1569,10 @@ async def dispatch_plan_tool(
     # #1672: an unset router_model follows the configured "router" class (was "light").
     router_model = _resolve_router_model(router_model, parent_host)
     try:
-        plan = parse_and_validate_plan(args, allowed_tool_names=available_tool_names)
+        plan = parse_and_validate_plan(
+            args, allowed_tool_names=available_tool_names,
+            accept_qualified_actions=accept_qualified_actions,
+        )
     except PlanValidationError as exc:
         return {
             "status": "error",

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3894,6 +3894,14 @@ class RouterLoop:
                 budget=self.budget,
                 router_model=self.router_model,
                 available_tool_names=set(self._tool_names) - {"plan"},
+                # #1998: under the universal scheme the callable tools are the
+                # wrappers (univ_enabled gates them into the catalog → _tool_names),
+                # so step.tools must also accept qualified ``<category>__action``
+                # names (the per-step narrowing vocabulary). Enumerate keeps the
+                # strict wrapper/qualified coincidence.
+                accept_qualified_actions=bool(
+                    self._scheme_layer_ctx.get("univ_enabled", False)
+                ),
             )
 
         # FP-0034 Phase 2 prep: snapshot indexed RAG corpora for the

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -144,6 +144,74 @@ def test_parse_rejects_unknown_tool_name():
         parse_and_validate_plan(args, allowed_tool_names=_ALLOWED)
 
 
+# ── #1998: universal scheme — step.tools may name qualified actions ──────────
+# Under the universal scheme the callable tools are the wrappers
+# (invoke_action/…), but step.tools' vocabulary is the per-step *narrowing* set:
+# qualified ``<category>__action`` names. The wrapper-only allow-set used to
+# reject exactly those qualified names a weak model correctly emits.
+
+_WRAPPERS = {"invoke_action", "describe_action", "list_actions"}
+
+
+def test_universal_step_tools_accepts_qualified_action_name():
+    """Tier 2: #1998 — with accept_qualified_actions (the universal scheme), a
+    step.tools entry naming a qualified ``<category>__action`` (e.g. web__search)
+    VALIDATES against the wrapper-only callable set."""
+    args = {
+        "goal": "search the web",
+        "steps_json": json.dumps([
+            {"id": "s1", "description": "search", "tools": ["web__search"]},
+            {"id": "s2", "description": "synthesise", "tools": [], "depends_on": ["s1"]},
+        ]),
+    }
+    plan = parse_and_validate_plan(
+        args, allowed_tool_names=_WRAPPERS, accept_qualified_actions=True)
+    assert plan.steps[0].tools == ("web__search",)
+
+
+def test_universal_qualified_action_rejected_without_the_flag():
+    """Tier 2: #1998 RED-guard — the SAME qualified name is rejected when
+    accept_qualified_actions is off (the pre-fix behaviour, == the enumerate
+    default where a name absent from the callable catalog is a real error)."""
+    args = {
+        "goal": "search the web",
+        "steps_json": json.dumps([
+            {"id": "s1", "description": "search", "tools": ["web__search"]},
+            {"id": "s2", "description": "synthesise", "tools": [], "depends_on": ["s1"]},
+        ]),
+    }
+    with pytest.raises(PlanValidationError, match="web__search"):
+        parse_and_validate_plan(args, allowed_tool_names=_WRAPPERS)
+
+
+def test_accept_qualified_actions_rejects_unknown_category():
+    """Tier 2: #1998 — the relaxation widens only to STRUCTURALLY-valid qualified
+    names with a KNOWN category; an unknown-category ``bogus__action`` (and a bare
+    non-qualified token) are still rejected. Scoped, not blanket-lenient."""
+    for bad in ("bogus__action", "totally_bogus"):
+        args = {"goal": "g", "steps_json": json.dumps([
+            {"id": "s1", "description": "x", "tools": [bad]},
+            {"id": "s2", "description": "y", "tools": []}])}
+        with pytest.raises(PlanValidationError, match=bad):
+            parse_and_validate_plan(
+                args, allowed_tool_names=_WRAPPERS, accept_qualified_actions=True)
+
+
+def test_enumerate_step_tools_validation_unchanged():
+    """Tier 2: #1998 regression-guard — the enumerate path (flag off, the default)
+    is unchanged: a catalog tool validates; a qualified name NOT in the catalog is
+    still rejected (no silent widening when the flag is absent)."""
+    ok = {"goal": "g", "steps_json": json.dumps([
+        {"id": "s1", "description": "read", "tools": ["read_file"]},
+        {"id": "s2", "description": "synth", "tools": []}])}
+    assert parse_and_validate_plan(ok, allowed_tool_names=_ALLOWED).steps[0].tools == ("read_file",)
+    bad = {"goal": "g", "steps_json": json.dumps([
+        {"id": "s1", "description": "x", "tools": ["file__read"]},  # qualified, not in _ALLOWED
+        {"id": "s2", "description": "y", "tools": []}])}
+    with pytest.raises(PlanValidationError, match="file__read"):
+        parse_and_validate_plan(bad, allowed_tool_names=_ALLOWED)
+
+
 def test_parse_rejects_unknown_depends_on_target():
     """Tier 2: depends_on must reference an id that exists in the plan."""
     args = {
@@ -398,6 +466,26 @@ def test_narrow_host_passes_file_perms_when_read_file_in_tools():
     )
     host = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
     assert host.get_file_permissions() == {"read": ["docs"], "write": []}
+
+
+def test_narrow_host_exposes_family_for_qualified_action_name():
+    """Tier 2: #1998 'validate + narrow' pair — a qualified ``web__search`` in
+    step.tools (the universal scheme's narrowing vocabulary, now accepted by the
+    validator) drives the per-step narrowing correctly: _uses_family keys on the
+    ``web__`` prefix, so the web family is exposed for that step and withheld from
+    a step that doesn't name it."""
+    parent = _FakeParentHost()
+    plan = Plan(
+        goal="g",
+        steps=(
+            PlanStep(id="a", description="search", tools=("web__search",)),
+            PlanStep(id="b", description="y", tools=()),
+        ),
+    )
+    needs_web = _PlanStepHost(plan=plan, step=plan.steps[0], prior_results={}, parent=parent)
+    no_web = _PlanStepHost(plan=plan, step=plan.steps[1], prior_results={}, parent=parent)
+    assert needs_web.get_web_fetch_allowed() is True
+    assert no_web.get_web_fetch_allowed() is False
 
 
 def test_narrow_host_silences_project_context():


### PR DESCRIPTION
**[tui-coder]** — Fixes #1998. A-minimal fix (lead-approved, design-check in the issue). Provisional pending the owner-axis call (provisional = owner may override to A-maximal); structural bug worth fixing now.

## Root cause: validator-vocabulary mismatch (not weak-model fumbling)

`step.tools` is consumed by two layers with divergent vocabularies in universal mode:

1. **Validator** (`planner.py`): `step.tools ⊆ available_tool_names`. In universal mode `available_tool_names = set(self._tool_names) - {"plan"}` = the **callable wrappers** `{invoke_action, describe_action, list_actions}` (the catalog the scheme builds when `univ_enabled`).
2. **Per-step narrowing** (`_PlanStepHost._uses_family`): every family is gated on `step.tools` naming a **qualified `<category>__action`** — e.g. `get_web_fetch_allowed()` keys on `startswith("web__")`.

→ A universal-mode step can't satisfy both: a wrapper **starves** every family in discovery; a qualified name (`web__search`, what the model correctly emits) is **rejected** by the validator. The two vocabularies **coincide in enumerate mode** (callable names ARE the qualified names) and **diverge in universal mode** — that divergence is the bug. (Primary evidence + the full design-check, including that `step.tools` is discovery-only/non-load-bearing for invocation in universal mode, are in the #1998 thread.)

## Fix (A-minimal)

When the caller signals the wrapper scheme (`accept_qualified_actions`, sourced from `_scheme_layer_ctx["univ_enabled"]` at the dispatch site), the validator **also** accepts any structurally-valid qualified action name (`is_valid_qualified_name`, an existing pure predicate that validates `<known-category>__<entry>`).

- **Not leniency**: `invoke_action` reachability is unchanged (it already reaches the full catalog via static routing). This fixes the validator's *vocabulary* — distinct from the "resolve bare→invoke_action" lenient option.
- **Scoped to universal**: enumerate keeps the strict wrapper/qualified coincidence (unchanged).
- **Per-step focusing preserved**: A-maximal (remove narrowing) would need evidence the focusing is valueless; none exists. Owner-axis (is per-step discovery focusing valuable in universal mode?) surfaced for the next owner digest — owner may override to A-maximal.

## Tier self-check

- **Tier 2** (OS contract — the plan validator's allow-set semantics).
- **No mocks**; behavioral asserts; no format-pins; docstrings declare `Tier 2:`.

## Test plan

- [x] `pytest tests/test_planner.py` — 51 passed (5 new #1998 + 1 narrowing pair; existing unchanged)
- [x] New tests: universal `web__search` validates **+ narrows** (web family exposed); RED-guard (rejected without the flag); unknown-category `bogus__action` / non-qualified garbage still rejected; enumerate regression-guard (qualified-not-in-catalog still rejected)
- [x] Regression: `test_provider_tool_namespace_strip_1989.py` + `test_plan_runtime.py` + `test_plan_dispatch_artifact.py` — 26 passed
- [x] `ruff check` clean · `tier_audit --strict` 0 violations
- [x] Verified against fresh `origin/main` (160f6536)
- [ ] (skipped — needs real weak-model + universal scheme) live dogfood that a Gemini plan with `web__search` no longer hits `plan_invalid`; the unit RED→GREEN + narrowing pair cover the contract deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
