### PR TITLE
fix(#2003): make toolrow flush-window test deterministic (xdist-load flake)

### DIFF
--- a/tests/cli/test_toolrow_flush_survives_clear.py
+++ b/tests/cli/test_toolrow_flush_survives_clear.py
@@ -2,16 +2,26 @@
 
 Stale-deferred-removal class (feedback_tui_deferred_timer_stale_removal_class).
 ``complete_tool_call_row`` POPS the row from ``_tool_call_rows`` and, if the row
-hasn't met its 0.3s minimum display time, schedules a deferred flush
-(``set_timer``) that later writes the row's lines + removes it.
+hasn't met its minimum display time, schedules a deferred flush (``set_timer``)
+that later writes the row's lines + removes it.
 
 Bug: during that flush window the row is popped-from-dict but still mounted, so
 ``clear()`` (which sweeps the dict + query-sweeps InterventionWidget, but NOT
-tool-call rows) misses it. A Ctrl+L within ~0.3s of a tool completing left a
-ghost tool row mounted AND let the pending timer write stale lines into the
-freshly-cleared log.
+tool-call rows) misses it. A Ctrl+L within the min-display window of a tool
+completing left a ghost tool row mounted AND let the pending timer write stale
+lines into the freshly-cleared log.
 
 Public surface only: the mounted ``ToolCallRow`` widgets in the DOM.
+
+#2003 determinism: the flush window is driven by ``_TOOL_CALL_MIN_DISPLAY_S``
+(default 0.3s) compared against the row's WALL-CLOCK mounted age. With the real
+0.3s window the "row still mounted during the flush window" precondition was a
+wall-clock race — under xdist parallel load a slowed worker let the window close
+(timer fired / elapsed already exceeded 0.3s) before the assertion, intermittently
+failing the precondition. We inject a large min-display window so the flush window
+is OPEN for the whole (ms-scale) test regardless of worker speed: the precondition
+holds deterministically and the clear()-removes-pending-row assertion (the #1980
+contract) is unchanged.
 """
 from __future__ import annotations
 
@@ -24,18 +34,34 @@ _SRC = Path(__file__).parent.parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+# Large enough that the deferred-flush timer cannot fire during a ms-scale test
+# even on a heavily-slowed xdist worker (and that mount→complete elapsed stays
+# well under it → a deferred flush is always scheduled, never an immediate one).
+_DETERMINISTIC_FLUSH_WINDOW_S = 3600.0
+
 
 @pytest.mark.asyncio
-async def test_clear_removes_tool_row_in_flush_window() -> None:
+async def test_clear_removes_tool_row_in_flush_window(monkeypatch) -> None:
     """Tier 2: clear() removes a tool-call row still pending its min-display flush.
 
-    Completes a just-mounted tool row (elapsed << 0.3s → a deferred flush is
-    scheduled and the row stays mounted), then clears immediately. No tool-call
-    row may survive the clear.
+    Completes a just-mounted tool row with the min-display window injected large
+    (elapsed << window → a deferred flush is scheduled and the row stays mounted
+    for the whole test), then clears immediately. No tool-call row may survive
+    the clear. The injected window makes the flush-window precondition
+    deterministic (no wall-clock vs worker-speed race); the assertion is the
+    #1980 contract, unchanged.
     """
     from reyn.interfaces.tui.app import ReynTUIApp
-    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.interfaces.tui.widgets import ConversationView, _inline_row_manager
     from reyn.interfaces.tui.widgets.tool_call_row import ToolCallRow
+
+    # Inject the flush window BEFORE any row completes. _flush_tool_call_row reads
+    # this module global at call-time, so the deferred-flush path is taken with a
+    # window that stays open for the whole test.
+    monkeypatch.setattr(
+        _inline_row_manager, "_TOOL_CALL_MIN_DISPLAY_S",
+        _DETERMINISTIC_FLUSH_WINDOW_S,
+    )
 
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
@@ -44,12 +70,12 @@ async def test_clear_removes_tool_row_in_flush_window() -> None:
 
         conv.start_tool_call_row("op-flush-1", "file__read")
         await pilot.pause()
-        # Complete immediately → elapsed << 0.3s → deferred flush scheduled,
-        # row popped from the dict but still mounted.
+        # Complete → elapsed << injected window → deferred flush scheduled, row
+        # popped from the dict but still mounted (the flush window is open).
         conv.complete_tool_call_row("op-flush-1", result_snippet="done")
         await pilot.pause()
-        # Sanity: the row is still mounted (pending flush), i.e. the race
-        # window is open.
+        # Precondition (now deterministic): the row is still mounted, pending its
+        # deferred flush — i.e. the race window #1980 closed is open here.
         assert list(conv.query(ToolCallRow)), (
             "precondition: row should still be mounted during the flush window"
         )


### PR DESCRIPTION
**[tui-coder]** — Fixes #2003. Root-fix the flush-window determinism (not a serial marker), #1980 assertion preserved.

## Root cause

`test_clear_removes_tool_row_in_flush_window` (from #1980) passes in isolation but its **precondition** — "row should still be mounted during the flush window" — depends on the **wall-clock** min-display window (`_TOOL_CALL_MIN_DISPLAY_S = 0.3s`, in `_inline_row_manager._flush_tool_call_row`) staying open between `complete_tool_call_row` and the assertion. Under CI's `-n auto` (pytest-xdist) a slowed worker lets the window close first (the deferred-flush timer fires, or `mounted_for_seconds()` already exceeds 0.3s → an *immediate* flush, no window at all) → precondition fails, intermittently gating unrelated PRs' pytest-3.12 jobs.

## Fix (root, not workaround)

Inject a large min-display window (`monkeypatch` the module constant to 3600s) so the flush window is **open for the whole ms-scale test regardless of worker speed**:
- `mount→complete` elapsed stays well under it → a *deferred* flush is always scheduled (never an immediate one);
- the 3600s timer cannot fire during the test → the row stays mounted at the precondition.

The flush-window precondition is now deterministic; the **clear()-removes-the-pending-row assertion (the #1980 contract) is unchanged** — `clear()` must still cancel the pending timer + remove the still-mounted row. A `serial`/`xdist_group` marker (mitigation, not root) is not used.

`monkeypatch` here targets a **config constant**, not a collaborator (no `unittest.mock`), so it stays within the testing policy.

## Verification (primary evidence)

| scenario | precondition (row mounted) |
|---|---|
| window=0.3 + simulated 0.5s slow-worker stall | **False** — the flake reproduced |
| window=3600 + same 0.5s stall | **True** — fix robust |

Directly simulating the slowed worker reproduces the exact failure and proves the fix handles it. pytest-xdist isn't installed locally (the flake is CI-only), so robustness is shown this way rather than via `-n auto`.

## Tier self-check

- **Tier 2**; no mocks (monkeypatch on a config constant); public-surface assert (`query(ToolCallRow)`); no format-pins.

## Test plan

- [x] `pytest tests/cli/test_toolrow_flush_survives_clear.py` — passed, 5x stable in isolation
- [x] Slow-worker robustness proof (table above) — flake reproduced at 0.3s, holds at 3600s
- [x] `ruff` clean · `tier_audit --strict` 0 violations · verified against fresh `origin/main` (563a1bba)
- [ ] (skipped — pytest-xdist not installed locally) `-n auto` repro; the slow-worker simulation covers the same mechanism deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
