### PR TITLE
feat(#1953): slice P2 — task-driven execution + per-Task cost attribution

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1922,6 +1922,7 @@ async def call_llm_tools(
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
     purpose: str = "main",  # #1190 cost-attribution bucket (chat router = main)
+    task_id: str | None = None,  # #1953 slice P2: per-Task cost attribution (set by a Task exec sub-loop)
     trace_caller: str | None = None,
     event_log: "EventLog | None" = None,
     emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
@@ -2095,6 +2096,7 @@ async def call_llm_tools(
             agent=budget_agent,
             usage=usage,
             purpose=purpose,
+            task_id=task_id,
         )
 
     # Normalize tool_calls to plain dicts so callers don't depend on litellm internals

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -178,12 +178,15 @@ class BudgetLedger:
         tokens: int,
         cost_usd: float,
         purpose: str | None = None,
+        task_id: str | None = None,
     ) -> None:
         """Append one LLM-call record and fsync.
 
         ``purpose`` (#1190) is the cost-attribution bucket
-        (main/phase/compaction/judge/skill_node_adapt/dogfood). Omitted from the
-        record when None so pre-#1190 ledger lines stay byte-identical.
+        (main/phase/compaction/judge/skill_node_adapt/dogfood). ``task_id``
+        (#1953 slice P2) attributes the call to the Task whose exec sub-loop made
+        it. Both are omitted from the record when None so pre-existing ledger
+        lines stay byte-identical.
         """
         record: dict = {
             "ts": self._now_iso(),
@@ -194,6 +197,8 @@ class BudgetLedger:
         }
         if purpose is not None:
             record["purpose"] = purpose
+        if task_id is not None:
+            record["task_id"] = task_id
         self._write_record(record)
 
     def append_spawn(self, *, chain_id: str, skill: str) -> None:
@@ -355,6 +360,12 @@ class BudgetTracker:
         # judge/skill_node_adapt/dogfood) for the /budget breakdown payoff.
         self._purpose_tokens: dict[str, int] = defaultdict(int)
         self._purpose_cost_usd: dict[str, float] = defaultdict(float)
+        # #1953 slice P2: per-task cost attribution (the global-ledger breakdown
+        # complement to the slice-8 per-Task cap counter). task_id is injected at
+        # RouterLoop construction (NOT a global handle) so every LLM call made
+        # inside a Task's exec sub-loop attributes here unforgeably.
+        self._task_tokens: dict[str, int] = defaultdict(int)
+        self._task_cost_usd: dict[str, float] = defaultdict(float)
         self._chain_skill_calls: dict[tuple[str, str], int] = defaultdict(int)
         self._chain_skill_tokens: dict[tuple[str, str], int] = defaultdict(int)
         # FP-0005 (#1877): per-(chain_id, skill) extensions granted via the
@@ -609,6 +620,7 @@ class BudgetTracker:
         chain_id: str | None = None,
         skill: str | None = None,
         purpose: str | None = None,
+        task_id: str | None = None,
     ) -> BudgetCheck:
         """Update counters after a successful LLM call.
 
@@ -628,6 +640,11 @@ class BudgetTracker:
         if purpose is not None:
             self._purpose_tokens[purpose] += usage.total_tokens
             self._purpose_cost_usd[purpose] += cost_usd
+
+        # #1953 slice P2: per-task attribution (mirrors purpose).
+        if task_id is not None:
+            self._task_tokens[task_id] += usage.total_tokens
+            self._task_cost_usd[task_id] += cost_usd
 
         if agent is not None:
             new_tokens = self._agent_tokens[agent] + usage.total_tokens
@@ -663,6 +680,7 @@ class BudgetTracker:
                 tokens=usage.total_tokens,
                 cost_usd=cost_usd,
                 purpose=purpose,
+                task_id=task_id,
             )
 
         # Warn on daily / monthly thresholds
@@ -687,6 +705,13 @@ class BudgetTracker:
         if self._ledger is not None:
             self._ledger.append_spawn(chain_id=chain_id, skill=skill)
         self._maybe_auto_save()
+
+    def task_cost_usd(self, task_id: str) -> float:
+        """#1953 slice P2: the cost attributed so far to ``task_id`` (the sum of
+        every LLM call whose RouterLoop carried this task_id). The exec driver
+        reads the before/after delta to charge the Task's cap counter — so the
+        cap charge is the *actually recorded* cost, never a re-priced estimate."""
+        return self._task_cost_usd.get(task_id, 0.0)
 
     # ── reset / introspect ──────────────────────────────────────────────
 
@@ -888,6 +913,8 @@ class BudgetTracker:
             # #1190 stage (iii): per-purpose cost attribution.
             "purpose_tokens": dict(self._purpose_tokens),
             "purpose_cost_usd": dict(self._purpose_cost_usd),
+            "task_tokens": dict(self._task_tokens),
+            "task_cost_usd": dict(self._task_cost_usd),
             "chain_skill_calls": {
                 f"{cid}/{sk}": v
                 for (cid, sk), v in self._chain_skill_calls.items()

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1399,10 +1399,12 @@ class RouterLoop:
         on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
         scheme_name: "str | None" = None,  # #1593 PR-2: per-layer tool-use scheme (None → universal default; the construction site resolves config.tool_use.<layer>)
+        task_id: "str | None" = None,  # #1953 slice P2: when this loop runs a Task's exec engine, every LLM call is cost-attributed to this Task (injected at construction, never a global handle)
     ):
         self.host = host
         self.chain_id = chain_id
         self.max_iterations = max_iterations
+        self._task_id = task_id
         # #1672: an UNSET router_model follows the configured model (no hidden
         # "light" tier) — resolve the "router" purpose class via the host's
         # config-aware ModelResolver. Explicit router_model still wins. The plan
@@ -2096,6 +2098,10 @@ class RouterLoop:
                     # falls through to the module-level ``call_llm_tools`` so
                     # production callers don't have to know about the seam.
                     _llm = self._llm_caller or call_llm_tools
+                    # #1953 slice P2: attribute this call to the Task only when this
+                    # loop is a Task exec engine; omitted otherwise so the test-fake
+                    # seam (llm_caller) keeps its existing signature.
+                    _task_kw = {"task_id": self._task_id} if self._task_id is not None else {}
                     result = await _llm(
                         # #1654: pass the FULL ModelSpec (not the bare string) so
                         # per-model kwargs (reasoning_effort/temperature/…) reach
@@ -2111,6 +2117,7 @@ class RouterLoop:
                         # #1683: chat path emits llm_called + llm_response_received
                         # so the TUI cost tab updates (kernel emits via LLMCallRecorder).
                         emit_cost_events=True,
+                        **_task_kw,
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a
@@ -3060,6 +3067,7 @@ class RouterLoop:
         if _reserve is not None:
             from reyn.llm.model_resolver import ModelSpec
             _model = ModelSpec(model=resolved_model, kwargs={"max_tokens": int(_reserve)})
+        _task_kw = {"task_id": self._task_id} if self._task_id is not None else {}
         return await _llm(
             model=_model,
             messages=wrap_messages,
@@ -3071,6 +3079,7 @@ class RouterLoop:
             trace_caller="router_force_close",
             # #1683: chat path emits cost events for the TUI cost tab.
             emit_cost_events=True,
+            **_task_kw,
         )
 
     async def _force_close_call_with_retry(

--- a/src/reyn/runtime/task_execution.py
+++ b/src/reyn/runtime/task_execution.py
@@ -36,6 +36,25 @@ class TaskExecutionHost:
     the step's system prompt or tool schema.
     """
 
+    @classmethod
+    def for_task(
+        cls,
+        task: Any,
+        *,
+        parent: RouterLoopHost,
+        prior_results: "dict[str, str] | None" = None,
+        turn_budget_engine: Any = None,
+    ) -> "TaskExecutionHost":
+        """Task-driven construction (#1953 slice P2): narrow to the **Task**'s
+        ``tools``. The engine is unit-agnostic — it reads only ``.tools`` (a Task
+        and a plan-step both carry it) + captures the reply text — so this is an
+        additive entry that leaves the plan-step path byte-identical.
+        ``prior_results`` is the dep-results map the caller assembled from the
+        backend (the result-channel; which dep feeds the unit is the caller's /
+        LLM's concern, not a graph property — I-2)."""
+        return cls(plan=None, step=task, prior_results=prior_results or {},
+                   parent=parent, turn_budget_engine=turn_budget_engine)
+
     def __init__(
         self,
         *,
@@ -49,6 +68,8 @@ class TaskExecutionHost:
         self._step = step
         self._prior_results = prior_results
         self._parent = parent
+        # The narrowed tool set — read off the UNIT (a plan-step or a Task; both
+        # carry ``.tools``). The engine is otherwise unit-agnostic.
         self._tool_set: frozenset[str] = frozenset(step.tools)
         # Captured by put_outbox; the executor reads this after RouterLoop
         # finishes to collect this step's text contribution.

--- a/src/reyn/runtime/task_graph.py
+++ b/src/reyn/runtime/task_graph.py
@@ -1,0 +1,207 @@
+"""Task-driven decomposition + execution (#1953 slice P2).
+
+The internal entry that subsumes ``plan``: decompose a goal into a parent Task +
+a child Task DAG (each child = a unit of work with its own narrowed ``tools`` and
+``depends_on`` edges), then drive the DAG to completion through the
+``TaskExecutionHost`` engine, propagating readiness (slices 6/6-ext) as each unit
+completes and synthesizing the final reply from the children's results.
+
+P2 keeps this **internal** (not an LLM-facing router tool yet — the router-expose
+co-lands with the plan-tool repoint at P3, avoiding a dual LLM-facing entry while
+``plan`` still runs in parallel). The orchestration takes an injectable
+``run_unit`` so it is testable without a live RouterLoop / LLM; the production
+``run_unit`` builds the engine + sub-loop.
+
+Result-channel (I-2): a unit's reply text lands on its Task (``set_result``); a
+dependent reads its deps' results from the backend at run time. The edges are pure
+topology — which dep's result feeds a unit is the unit's (the LLM's) concern, not a
+graph property.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Awaitable, Callable
+
+from reyn.task import Task, TaskState
+from reyn.tools.universal_catalog import (
+    is_valid_qualified_name,
+    strip_provider_tool_namespace,
+)
+
+# run_unit(task, prior_results) -> (result_text, cost_usd). The production impl
+# builds a TaskExecutionHost + sub-loop and runs it; tests inject a stub.
+RunUnit = Callable[[Any, "dict[str, str]"], Awaitable["tuple[str, float]"]]
+
+
+class TaskStepValidationError(ValueError):
+    """A task-step's ``tools`` reference a tool outside the available catalog."""
+
+
+def validate_step_tools(
+    tools: "list[Any]",
+    *,
+    allowed_tool_names: "set[str]",
+    accept_qualified_actions: bool = False,
+) -> "list[str]":
+    """Normalize + validate a task-step's narrowing tool set, returning the
+    normalized names. Carries the plan path's tool-vocabulary correctness onto
+    the Task system (#1953 slice P2):
+
+    - #1989: strip a provider function-calling namespace (``default_api.``) a weak
+      model may echo onto a tool name, so the Task stores the bare catalog name.
+    - #1998 / #2004: under the universal scheme the callable tools are the
+      wrappers (``invoke_action``/…) but a step's narrowing vocabulary is the
+      qualified ``<category>__action`` names (which the exec engine's family-gate
+      keys on, and which ``invoke_action`` can reach). When the caller signals
+      that scheme (``accept_qualified_actions``), accept any *valid* qualified
+      action name in addition to the wrapper allow-set — scoped, not blanket
+      leniency (reachability via ``invoke_action`` is unchanged)."""
+    normalized: list[str] = []
+    for t in tools:
+        if not isinstance(t, str):
+            raise TaskStepValidationError("task step tools[*] must be strings")
+        nt = strip_provider_tool_namespace(t)
+        if nt not in allowed_tool_names and not (
+            accept_qualified_actions and is_valid_qualified_name(nt)
+        ):
+            allowed = sorted(allowed_tool_names)
+            extra = (
+                " (or a qualified <category>__action name)"
+                if accept_qualified_actions else ""
+            )
+            raise TaskStepValidationError(
+                f"task step tool {t!r} is not in the available tool catalog. "
+                f"Allowed: {allowed}{extra}"
+            )
+        normalized.append(nt)
+    return normalized
+
+
+async def build_task_graph(
+    backend: Any,
+    *,
+    goal: str,
+    steps: "list[dict]",
+    assignee: str,
+    requester: str,
+    created_by: "str | None" = None,
+    allowed_tool_names: "set[str] | None" = None,
+    accept_qualified_actions: bool = False,
+) -> str:
+    """Create the parent Task (the goal) + a child Task per step, wiring each
+    child's ``depends_on`` (step ids) into the Task DAG. Returns the parent
+    ``task_id``. The shared edge-guard cycle-checks every dep on create (a cycle
+    raises ``TaskCycleError`` / a dangling dep ``TaskDepNotFoundError``).
+
+    When ``allowed_tool_names`` is given each step's ``tools`` are validated +
+    normalized through :func:`validate_step_tools` (the router entry passes its
+    catalog + ``accept_qualified_actions=True`` under the universal scheme); when
+    None the tools are stored as-is (the internal driver path, P2).
+
+    ``steps`` items: ``{"id", "description", "tools", "depends_on"?}``."""
+    parent = await backend.create(Task(
+        task_id=uuid.uuid4().hex, name=goal, description=goal,
+        assignee=assignee, requester=requester, created_by=created_by,
+    ))
+    # Pre-allocate child ids so a step's depends_on (step ids) maps to task ids.
+    id_map: dict[str, str] = {s["id"]: uuid.uuid4().hex for s in steps}
+    for s in steps:
+        deps = [id_map[d] for d in s.get("depends_on", [])]
+        raw_tools = list(s.get("tools", []))
+        tools = (
+            validate_step_tools(
+                raw_tools, allowed_tool_names=allowed_tool_names,
+                accept_qualified_actions=accept_qualified_actions)
+            if allowed_tool_names is not None else raw_tools
+        )
+        await backend.create(Task(
+            task_id=id_map[s["id"]], name=s["description"][:120],
+            description=s["description"], assignee=assignee, requester=requester,
+            parent_id=parent.task_id, tools=tools, deps=deps,
+            created_by=created_by,
+        ))
+    return parent.task_id
+
+
+async def run_task_graph(
+    backend: Any,
+    parent_id: str,
+    *,
+    run_unit: RunUnit,
+    on_unit_cost: "Callable[[str, float], Awaitable[None]] | None" = None,
+) -> str:
+    """Drive the parent's child DAG to completion: repeatedly run every runnable
+    child (no unsatisfied deps) through ``run_unit``, store its result, charge its
+    cost, mark it completed (which propagates readiness to its dependents), until
+    no child remains runnable. Then synthesize the parent's result (the
+    topologically-last completed child's text, mirroring the plan aggregator) and
+    return it.
+
+    ``run_unit`` is handed each unit + the dep-results map it reads from the
+    backend; ``on_unit_cost`` (the slice-8 ``record_task_cost`` prod-caller) charges
+    the unit's cost onto its Task (cap-enforcement)."""
+    completed_order: list[str] = []
+    while True:
+        children = await backend.list(parent_id=parent_id)
+        runnable = [c for c in children if c.status in (TaskState.PENDING, TaskState.READY)]
+        if not runnable:
+            break
+        for child in runnable:
+            prior_results = {}
+            for dep_id in child.deps:
+                dep = await backend.get(dep_id)
+                prior_results[dep_id] = (dep.result or "") if dep is not None else ""
+            result_text, cost = await run_unit(child, prior_results)
+            await backend.set_result(child.task_id, result_text)
+            if on_unit_cost is not None:
+                await on_unit_cost(child.task_id, cost)
+            await backend.update_status(
+                child.task_id, "completed", caller_session_id=child.assignee)
+            await backend.recompute_readiness(child.task_id)
+            completed_order.append(child.task_id)
+    # Synthesis: the last completed child's result is the aggregate reply (the
+    # plan aggregator's "topologically-last non-empty" rule).
+    final = ""
+    for tid in reversed(completed_order):
+        t = await backend.get(tid)
+        if t is not None and t.result:
+            final = t.result
+            break
+    await backend.set_result(parent_id, final)
+    return final
+
+
+def make_production_run_unit(
+    parent_host: Any,
+    *,
+    chain_id: str,
+    router_model: "str | None",
+    budget: Any,
+    exclude_tools: "frozenset[str]" = frozenset({"plan"}),
+) -> RunUnit:
+    """Build the production ``run_unit``: each unit runs through a
+    ``TaskExecutionHost``-narrowed ``RouterLoop`` that carries the unit's
+    ``task_id``, so every LLM call the unit makes is cost-attributed to its Task
+    (the RouterLoop-construction injection — never a global handle). The charged
+    cost is the budget's *recorded* before/after delta for the Task, so the
+    cap-counter charge is the actually-spent cost, not a re-priced estimate.
+
+    ``exclude_tools`` drops ``plan`` by default so a unit cannot recursively
+    self-decompose (the plan path's long-standing guard)."""
+    from reyn.runtime.router_loop import RouterLoop
+    from reyn.runtime.task_execution import TaskExecutionHost
+
+    async def run_unit(task: Any, prior_results: "dict[str, str]") -> "tuple[str, float]":
+        before = budget.task_cost_usd(task.task_id) if budget is not None else 0.0
+        host = TaskExecutionHost.for_task(
+            task, parent=parent_host, prior_results=prior_results)
+        loop = RouterLoop(
+            host=host, chain_id=chain_id, router_model=router_model,
+            budget=budget, exclude_tools=set(exclude_tools),
+            task_id=task.task_id,
+        )
+        await loop.run(user_text=task.description or task.name, history=[])
+        after = budget.task_cost_usd(task.task_id) if budget is not None else 0.0
+        return host.captured_text, (after - before)
+
+    return run_unit

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -140,6 +140,12 @@ class TaskBackend(Protocol):
         None for an unknown task."""
         ...
 
+    async def set_result(self, task_id: str, result: str) -> Task | None:
+        """Record the exec-layer output text on the task (#1953 slice P2). The
+        exec-engine writes it on a unit's completion; a dependent reads its deps'
+        results from here. None for an unknown task."""
+        ...
+
     async def abort(self, task_id: str, reason: str | None = None) -> list[Task]: ...
 
     async def set_awaiting(self, task_id: str, awaiting_since: float | None) -> Task | None: ...
@@ -400,6 +406,14 @@ class InMemoryTaskBackend:
         if task is None:
             return None
         task.cost_accum += delta
+        task.updated_at = _now_iso()
+        return task
+
+    async def set_result(self, task_id: str, result: str) -> Task | None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        task.result = result
         task.updated_at = _now_iso()
         return task
 

--- a/src/reyn/task/model.py
+++ b/src/reyn/task/model.py
@@ -109,6 +109,8 @@ class Task:
     cost_accum: float = 0.0
     awaiting_since: float | None = None  # R-D16 WAL-floor exclusion (set while blocked)
     deps: list[str] = field(default_factory=list)  # depends-on task_ids (DAG, §13)
+    tools: list[str] = field(default_factory=list)  # narrowed tool set for the exec engine (#1953 slice P2)
+    result: str | None = None  # exec-layer output captured on completion (#1953 slice P2)
     created_at: str = field(default_factory=_now_iso)
     updated_at: str = field(default_factory=_now_iso)
 
@@ -128,6 +130,8 @@ class Task:
             "cost_accum": self.cost_accum,
             "awaiting_since": self.awaiting_since,
             "deps": list(self.deps),
+            "tools": list(self.tools),
+            "result": self.result,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -69,6 +69,8 @@ CREATE TABLE IF NOT EXISTS tasks(
   cost_accum REAL NOT NULL DEFAULT 0,
   awaiting_since REAL,
   unblock_predicate TEXT,
+  tools TEXT,
+  result TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -107,7 +109,7 @@ CREATE TABLE IF NOT EXISTS task_comments(
 
 _TASK_COLUMNS = (
     "task_id, name, assignee, requester, origin, status, description, created_by, "
-    "parent_id, budget_cap, cost_accum, awaiting_since, created_at, updated_at"
+    "parent_id, budget_cap, cost_accum, awaiting_since, tools, result, created_at, updated_at"
 )
 
 
@@ -144,6 +146,12 @@ class SqliteTaskBackend:
         conn.execute("PRAGMA busy_timeout=0")
         if init_schema:
             conn.executescript(_SCHEMA)
+            # #1953 slice P2: additive migration for DBs created before the
+            # tools / result columns (CREATE TABLE IF NOT EXISTS won't add them).
+            existing = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+            for col in ("tools", "result"):
+                if col not in existing:
+                    conn.execute(f"ALTER TABLE tasks ADD COLUMN {col} TEXT")
             conn.commit()
         return conn
 
@@ -291,6 +299,8 @@ class SqliteTaskBackend:
             cost_accum=row["cost_accum"],
             awaiting_since=row["awaiting_since"],
             deps=self._deps(row["task_id"]),
+            tools=json.loads(row["tools"]) if row["tools"] else [],
+            result=row["result"],
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )
@@ -327,12 +337,13 @@ class SqliteTaskBackend:
             self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 f"INSERT INTO tasks({_TASK_COLUMNS}) "
-                f"VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                f"VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     task.task_id, task.name, task.assignee, task.requester,
                     task.origin.value, task.status.value, task.description,
                     task.created_by, task.parent_id, task.budget_cap,
                     task.cost_accum, task.awaiting_since,
+                    json.dumps(task.tools) if task.tools else None, task.result,
                     task.created_at, task.updated_at,
                 ),
             )
@@ -561,6 +572,20 @@ class SqliteTaskBackend:
                 self._conn.rollback()
                 return None
             self._emit(task_id, "cost_recorded", delta=delta)
+            self._conn.commit()
+            return self._fetch(task_id)
+
+    async def set_result(self, task_id: str, result: str) -> Task | None:
+        async with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            cur = self._conn.execute(
+                "UPDATE tasks SET result=?, updated_at=? WHERE task_id=?",
+                (result, _now_iso(), task_id),
+            )
+            if cur.rowcount == 0:
+                self._conn.rollback()
+                return None
+            self._emit(task_id, "result_set")
             self._conn.commit()
             return self._fetch(task_id)
 

--- a/tests/test_task_cost_attribution_sliceP2_1953.py
+++ b/tests/test_task_cost_attribution_sliceP2_1953.py
@@ -1,0 +1,114 @@
+"""Tier 2: #1953 slice P2 — per-Task cost attribution (slice-8 (B) completed).
+
+The cost co-land: a Task's exec sub-loop carries its ``task_id``, injected at
+RouterLoop construction (never a global handle), so every LLM call it makes is
+attributed to that Task in the budget ledger; the exec driver then charges the
+*recorded* cost delta onto the Task's cap counter through the slice-8
+``record_task_cost`` prod-caller. These tests cover the three links of that chain.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from reyn.config import CostConfig
+from reyn.core.op_runtime import task as taskmod
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import BudgetTracker
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.task_graph import (
+    build_task_graph,
+    make_production_run_unit,
+    run_task_graph,
+)
+from reyn.task import InMemoryTaskBackend
+from tests._support.router_loop import FakeRouterHost, text_result
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+def test_record_llm_attributes_tokens_and_cost_to_task():
+    """Tier 2: record_llm(task_id=...) attributes the call's tokens + cost to the
+    Task (mirroring the per-purpose bucket); task_cost_usd() reads it back."""
+    budget = BudgetTracker(CostConfig())
+    budget.record_llm(model="gpt-4o-mini", agent="a",
+                      usage=TokenUsage(prompt_tokens=1000, completion_tokens=500),
+                      task_id="task-1")
+    snap = budget.snapshot()
+    assert snap["task_tokens"]["task-1"] == 1500
+    assert snap["task_cost_usd"]["task-1"] == budget.task_cost_usd("task-1")
+    # an unrelated call (no task_id) does not leak into the per-task bucket.
+    budget.record_llm(model="gpt-4o-mini", agent="a",
+                      usage=TokenUsage(prompt_tokens=10, completion_tokens=10))
+    assert budget.snapshot()["task_tokens"]["task-1"] == 1500
+
+
+@pytest.mark.asyncio
+async def test_routerloop_injects_task_id_into_llm_call():
+    """Tier 2: a RouterLoop constructed with task_id forwards it to the LLM call
+    (the construction-injection); a loop without one omits the kwarg, so the
+    existing test-fake / production signatures stay intact."""
+    captured: list[Any] = []
+
+    async def fake_llm(**kwargs):
+        captured.append(kwargs.get("task_id", "__absent__"))
+        return text_result("ok")
+
+    host = FakeRouterHost()
+    await RouterLoop(host=host, chain_id="c", task_id="task-9",
+                    llm_caller=fake_llm).run(user_text="go", history=[])
+    await RouterLoop(host=host, chain_id="c",
+                    llm_caller=fake_llm).run(user_text="go", history=[])
+    assert captured == ["task-9", "__absent__"]
+
+
+@pytest.mark.asyncio
+async def test_production_run_unit_charges_recorded_cost_onto_task(monkeypatch):
+    """Tier 2: the full chain minus litellm — make_production_run_unit builds a
+    task_id-carrying RouterLoop; the (faked) call_llm_tools records cost under that
+    task_id; run_task_graph charges the recorded delta onto the Task via
+    record_task_cost. cost_accum == the budget's recorded task cost (slice-8 (B))."""
+    budget = BudgetTracker(CostConfig())
+
+    async def fake_call_llm_tools(**kwargs):
+        # Stand in for the real call_llm_tools' post-record (which now forwards
+        # task_id). The RouterLoop interprets the returned text reply + captures it.
+        budget.record_llm(model="gpt-4o-mini", agent=kwargs.get("budget_agent"),
+                          usage=TokenUsage(prompt_tokens=2000, completion_tokens=1000),
+                          task_id=kwargs.get("task_id"))
+        return text_result("unit reply")
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_call_llm_tools)
+
+    b = InMemoryTaskBackend()
+    parent_host = FakeRouterHost()
+    parent_id = await build_task_graph(
+        b, goal="g", assignee="a2a:s", requester="req",
+        steps=[{"id": "s1", "description": "only", "tools": []}])
+    child = (await b.list(parent_id=parent_id))[0]
+
+    ctx = SimpleNamespace(session_id="req", agent_id="a", events=None,
+                          task_backend=b, task_waker=None)
+
+    async def on_unit_cost(task_id, cost):
+        await taskmod.record_task_cost(ctx, task_id, cost)
+
+    run_unit = make_production_run_unit(
+        parent_host, chain_id="c", router_model=None, budget=budget)
+    final = await run_task_graph(b, parent_id, run_unit=run_unit,
+                                 on_unit_cost=on_unit_cost)
+
+    # the unit's reply was captured + synthesized; its cost was attributed to the
+    # Task in the ledger AND charged onto the Task's cap counter (the same number).
+    assert final == "unit reply"
+    assert budget.snapshot()["task_tokens"][child.task_id] == 3000
+    charged = (await b.get(child.task_id)).cost_accum
+    assert charged == budget.task_cost_usd(child.task_id)
+    assert charged > 0.0

--- a/tests/test_task_graph_sliceP2_1953.py
+++ b/tests/test_task_graph_sliceP2_1953.py
@@ -1,0 +1,156 @@
+"""Tier 2: #1953 slice P2 — task-driven decomposition + execution driver.
+
+`build_task_graph` decomposes a goal into a parent + child Task DAG; `run_task_graph`
+drives it to completion through an (injected) per-unit runner, passing each unit
+its deps' results (the result-channel), charging each unit's cost (the slice-8
+`record_task_cost` prod-caller — the cost-attribution co-land), and synthesizing
+the final reply. Real backend; the per-unit LLM run is the injection seam.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.task_graph import (
+    TaskStepValidationError,
+    build_task_graph,
+    run_task_graph,
+    validate_step_tools,
+)
+from reyn.task import InMemoryTaskBackend, TaskState
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_build_task_graph_creates_parent_and_child_dag():
+    """Tier 2: a goal + steps → a parent Task + child Tasks carrying tools + the
+    dependency DAG (born-blocked when they have unsatisfied deps)."""
+    b = InMemoryTaskBackend()
+    parent_id = await build_task_graph(
+        b, goal="ship it", assignee="a2a:s", requester="req",
+        steps=[
+            {"id": "s1", "description": "read the code", "tools": ["file__read"]},
+            {"id": "s2", "description": "review it", "tools": ["skill__review"],
+             "depends_on": ["s1"]},
+        ])
+    parent = await b.get(parent_id)
+    assert parent.name == "ship it"
+    children = await b.list(parent_id=parent_id)
+    assert {c.name for c in children} == {"read the code", "review it"}
+    s1 = next(c for c in children if c.name == "read the code")
+    s2 = next(c for c in children if c.name == "review it")
+    assert s1.tools == ["file__read"] and s1.status is TaskState.PENDING   # no deps
+    assert s2.tools == ["skill__review"] and s2.status is TaskState.BLOCKED  # born-blocked on s1
+    assert s2.deps == [s1.task_id]
+
+
+@pytest.mark.asyncio
+async def test_build_task_graph_carries_1998_qualified_tool_vocabulary():
+    """Tier 2: #1998 vocabulary carried onto the Task path — under the universal
+    scheme a task-step naming a qualified action (web__search) validates + narrows,
+    while a bogus qualified name is rejected (scoped guard, not blanket leniency).
+    A provider namespace prefix (default_api.) is stripped (#1989)."""
+    b = InMemoryTaskBackend()
+    catalog = {"invoke_action", "list_actions"}  # universal wrappers
+    parent_id = await build_task_graph(
+        b, goal="g", assignee="a2a:s", requester="req",
+        allowed_tool_names=catalog, accept_qualified_actions=True,
+        steps=[{"id": "s1", "description": "search",
+                "tools": ["web__search", "default_api.invoke_action"]}])
+    child = (await b.list(parent_id=parent_id))[0]
+    # web__search accepted (qualified) + namespace stripped to the bare wrapper.
+    assert child.tools == ["web__search", "invoke_action"]
+    # the scoped guard still rejects a non-parseable / bogus name.
+    with pytest.raises(TaskStepValidationError):
+        await build_task_graph(
+            b, goal="g2", assignee="a2a:s", requester="req",
+            allowed_tool_names=catalog, accept_qualified_actions=True,
+            steps=[{"id": "s1", "description": "x", "tools": ["bogus action!"]}])
+    # without the universal-scheme signal, a qualified action is NOT auto-accepted.
+    assert validate_step_tools(["invoke_action"], allowed_tool_names=catalog) == \
+        ["invoke_action"]
+    with pytest.raises(TaskStepValidationError):
+        validate_step_tools(["web__search"], allowed_tool_names=catalog)
+
+
+@pytest.mark.asyncio
+async def test_run_task_graph_orders_passes_results_and_synthesizes():
+    """Tier 2: the driver runs s1 before its dependent s2, passes s1's result into
+    s2 (the result-channel), and the parent synthesizes the last unit's result."""
+    b = InMemoryTaskBackend()
+    parent_id = await build_task_graph(
+        b, goal="g", assignee="a2a:s", requester="req",
+        steps=[
+            {"id": "s1", "description": "first", "tools": []},
+            {"id": "s2", "description": "second", "tools": [], "depends_on": ["s1"]},
+        ])
+    seen_prior: dict[str, dict] = {}
+
+    async def run_unit(task, prior_results):
+        seen_prior[task.name] = dict(prior_results)
+        return f"result-of-{task.name}", 1.0
+
+    final = await run_task_graph(b, parent_id, run_unit=run_unit)
+
+    # s1 ran with no prior; s2 ran AFTER s1 with s1's result in its prior_results.
+    s1 = next(c for c in await b.list(parent_id=parent_id) if c.name == "first")
+    assert seen_prior["first"] == {}
+    assert seen_prior["second"] == {s1.task_id: "result-of-first"}
+    # both completed + carry their result; parent synthesizes the last unit's text.
+    assert (await b.get(s1.task_id)).status is TaskState.COMPLETED
+    assert final == "result-of-second"
+    assert (await b.get(parent_id)).result == "result-of-second"
+
+
+@pytest.mark.asyncio
+async def test_run_task_graph_charges_cost_via_record_task_cost():
+    """Tier 2: the cost-attribution co-land — each unit's cost is charged onto its
+    Task through the slice-8 `record_task_cost` prod-caller (this is where slice 8's
+    deferred (B) is completed: the exec-engine's exactly-one-task scope makes the
+    cost unambiguous)."""
+    b = InMemoryTaskBackend()
+    parent_id = await build_task_graph(
+        b, goal="g", assignee="a2a:s", requester="req",
+        steps=[{"id": "s1", "description": "only", "tools": []}])
+    ctx = SimpleNamespace(session_id="req", agent_id="a", events=None,
+                          task_backend=b, task_waker=None)
+
+    async def run_unit(task, prior_results):
+        return "done", 3.5
+
+    async def on_unit_cost(task_id, cost):
+        await taskmod.record_task_cost(ctx, task_id, cost)
+
+    await run_task_graph(b, parent_id, run_unit=run_unit, on_unit_cost=on_unit_cost)
+
+    s1 = next(c for c in await b.list(parent_id=parent_id) if c.name == "only")
+    assert (await b.get(s1.task_id)).cost_accum == 3.5
+
+
+@pytest.mark.asyncio
+async def test_run_unit_narrows_via_engine_for_task():
+    """Tier 2: the per-unit engine narrows to the unit's tools (the TaskExecutionHost
+    Task-driven mode) — a `skill__*` unit plumbs skills, an unrelated one silences."""
+    from reyn.runtime.task_execution import TaskExecutionHost
+
+    class _FakeParent:
+        def list_available_skills(self):
+            return [{"name": "review", "description": "x"}]
+        def list_available_agents(self):
+            return []
+
+    b = InMemoryTaskBackend()
+    parent_id = await build_task_graph(
+        b, goal="g", assignee="a2a:s", requester="req",
+        steps=[{"id": "s1", "description": "review", "tools": ["skill__review"]}])
+    child = (await b.list(parent_id=parent_id))[0]
+    host = TaskExecutionHost.for_task(child, parent=_FakeParent())
+    assert host.list_available_skills()  # narrowed to the unit's skill tool


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice P2: task-driven execution (subsumes the planner's exec engine)

## What
P1 relocated the narrowed-LLM execution engine into `TaskExecutionHost` (byte-identical move). P2 generalizes it to a **Task-driven** entry: a goal decomposes into a parent + child Task DAG, and the DAG is driven to completion through that engine — the orchestration that `plan` used to own now runs on the Task subsystem (readiness, deps, result-passing, cost).

This is the **internal** entry only (per the design: internal-entry P2 / router-expose P3 — no dual LLM-facing entry while `plan` still runs in parallel).

## Changes
- **`runtime/task_graph.py`** (new):
  - `build_task_graph(goal, steps)` → parent Task + child Task per step, wiring `depends_on` into the Task DAG (deps cycle-checked by the shared edge-guard from slice 6).
  - `run_task_graph(parent_id, run_unit, on_unit_cost)` → readiness-driven loop: run each runnable unit via `run_unit`, pass its deps' results through the **result-channel** (each unit reads deps' `Task.result`), `set_result`, charge cost, mark completed (propagating readiness), then **synthesize** the parent reply. `run_unit` is injectable so the orchestration is testable without a live LLM.
  - `make_production_run_unit(...)` → the real `run_unit`: a `TaskExecutionHost.for_task`-narrowed `RouterLoop` carrying the unit's `task_id`.
- **Cost co-land — completes slice 8 deferred (B)** (`PR must明示`): a Task's exec sub-loop carries its `task_id`, **injected at RouterLoop construction (NOT a global handle)** → `call_llm_tools` → `record_llm` attributes per-Task tokens/cost in the budget ledger (mirrors the per-purpose bucket). The driver then charges the budget's **recorded** cost delta onto the Task via the slice-8 `record_task_cost` prod-caller — so the cap charge is *actual recorded spend*, never a re-priced estimate. Adds `BudgetTracker.task_cost_usd()` + snapshot keys + ledger `task_id` field.
- **#1998 vocabulary carried onto the Task path** (lead heads-up): `validate_step_tools` ports the #1989 provider-namespace strip + the #2004 A-minimal qualified-action logic (universal scheme accepts a valid `<category>__action` via `is_valid_qualified_name`, **scoped — not blanket leniency**). `build_task_graph` validates when a catalog is passed (the router entry, P3).

## Scope boundaries
- Router-expose (the LLM-facing `task`-style tool) = **P3**, co-landing with the `plan`-tool repoint + N≥3 dogfood behavioral parity (the delete gate).
- `plan` path untouched (coexist) — atomic clean-break delete is **P4**.
- The production `run_unit`'s full live-LLM e2e is exercised at P3 dogfood; P2 proves every component (narrowing, task_id injection, recorded-cost delta, driver orchestration) with real backend + the fake-LLM seam.

## Test plan
- [x] `tests/test_task_graph_sliceP2_1953.py` — build DAG (born-blocked deps), run ordering + result-channel + synthesis, record_task_cost fires during exec, engine narrowing, #1998 qualified-tool validate+narrow + scoped reject (8 tests).
- [x] `tests/test_task_cost_attribution_sliceP2_1953.py` — record_llm per-Task attribution, RouterLoop task_id construction-injection, full chain minus litellm (cost_accum == recorded task cost) (3 tests).
- [x] ruff clean; `test_tier_audit.py --strict` 11/11 OK; `verify_module_docstrings.py` clean (task_graph docstring current-state-only).
- [x] Full suite from rootdir: 8280 passed; the only 2 failures are the known not-my-diff env gaps (swebench dataset + media-store missing locally — pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
