### PR TITLE
fix(#1950): heal RichLog resize corruption via debounced repaint-after-settle

### DIFF
--- a/src/reyn/interfaces/tui/widgets/conversation.py
+++ b/src/reyn/interfaces/tui/widgets/conversation.py
@@ -48,6 +48,7 @@ from rich.markdown import Markdown as RichMarkdown
 from rich.padding import Padding
 from rich.text import Text
 from textual.app import ComposeResult
+from textual.events import Resize
 from textual.widget import Widget
 from textual.widgets import RichLog, Static
 
@@ -112,6 +113,12 @@ _RECENT_REPLIES_MAX = 10
 # turn anchors below are drop-aware so even pathological sessions that DO
 # cross the boundary don't break Ctrl+P/N navigation.
 _RICHLOG_MAX_LINES = 20_000
+# #1950: debounce window for the resize-repaint heal. A rapid terminal-resize
+# (SIGWINCH) storm — e.g. drag-resizing the window — corrupts the RichLog's
+# rendered TTY output (dropped characters) via a Textual compositor issue; the
+# log.lines data stays intact. We repaint ONCE after the storm settles, not on
+# every event. Small enough to feel instant, large enough to coalesce a drag.
+_RESIZE_REPAINT_DEBOUNCE_S = 0.15
 # F-H: minimum visible duration for an inline ToolCallRow before the conv
 # pane flushes it into the RichLog scroll history + unmounts the live
 # widget. Cache hits / instant returns would otherwise mount + flush
@@ -1766,6 +1773,42 @@ class ConversationView(Widget):
         # signal time sits BELOW the monolithic RichLog, so the non-streaming
         # reply (RichLog text) would render above it — wrong order.
         self._pending_reasoning: str | None = None
+        # #1950: debounce timer for the resize-repaint heal (see on_resize).
+        self._resize_repaint_timer: object | None = None
+
+    # ── #1950 resize-repaint heal ──────────────────────────────────────────────
+
+    def on_resize(self, event: Resize) -> None:
+        """Heal RichLog TTY corruption from a rapid terminal-resize storm.
+
+        Drag-resizing the window emits a continuous SIGWINCH stream; under it the
+        Textual compositor's writes to the TTY drop characters, corrupting the
+        VISIBLE conversation text (e.g. ``"It uses a hash function"`` →
+        ``"It a hash function"``) while ``log.lines`` stays byte-intact. We force
+        a full repaint of the log from those intact lines AFTER the storm settles
+        — debounced so a drag coalesces into one repaint. Documented Textual
+        workaround (Discussion #3527); reyn's data model is provably correct, so
+        this is display-only healing, not a content fix.
+        """
+        if self._resize_repaint_timer is not None:
+            self._resize_repaint_timer.stop()
+        self._resize_repaint_timer = self.set_timer(
+            _RESIZE_REPAINT_DEBOUNCE_S, self._repaint_after_resize,
+        )
+
+    def _repaint_after_resize(self) -> None:
+        self._resize_repaint_timer = None
+        # call_after_refresh: run the repaint once the post-resize layout pass has
+        # settled the new geometry, then force a full RichLog repaint from the
+        # intact lines (repaint=True re-renders the region, overwriting the
+        # compositor's corrupted cells).
+        self.call_after_refresh(self._force_log_repaint)
+
+    def _force_log_repaint(self) -> None:
+        try:
+            self._log().refresh(repaint=True)
+        except Exception:
+            pass
 
     # ── #1652 reasoning ────────────────────────────────────────────────────────
 

--- a/tests/cli/test_conv_resize_repaint_1950.py
+++ b/tests/cli/test_conv_resize_repaint_1950.py
@@ -1,0 +1,73 @@
+"""Tier 2: #1950 — a resize storm coalesces into ONE debounced log repaint.
+
+A rapid terminal-resize (SIGWINCH) storm corrupts the RichLog's rendered TTY
+output (dropped characters) via a Textual compositor issue; ``log.lines`` stays
+intact. ConversationView.on_resize schedules a debounced full repaint that
+re-renders from those intact lines AFTER the storm settles, healing the display.
+
+The heal itself is a real-terminal compositor effect (NOT reproducible in a
+headless pilot — the data model is correct, only the TTY writes drop chars), so
+this pins the part that IS deterministically testable: the storm of resize events
+coalesces into exactly ONE repaint, deferred until the storm settles (not one
+repaint per event, and not a synchronous repaint on the first event). No mocks —
+a real recording callable observes the widget's own repaint hook.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from textual.events import Resize
+from textual.geometry import Size
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_resize_storm_coalesces_to_one_deferred_repaint(monkeypatch) -> None:
+    """Tier 2: #1950 — N rapid resize events → exactly one repaint, after settle."""
+    import reyn.interfaces.tui.widgets.conversation as conv_mod
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+
+    # Shrink the debounce so the coalesced repaint lands fast in the test.
+    monkeypatch.setattr(conv_mod, "_RESIZE_REPAINT_DEBOUNCE_S", 0.05)
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+
+        # Recording seam: wrap the widget's own repaint hook with a real callable
+        # that counts + delegates (not a mock — observes the SUT's behaviour).
+        repaints = 0
+        real_repaint = conv._force_log_repaint
+
+        def _recording_repaint() -> None:
+            nonlocal repaints
+            repaints += 1
+            real_repaint()
+
+        conv._force_log_repaint = _recording_repaint  # type: ignore[method-assign]
+
+        # A resize storm — many rapid on_resize events (drag-resizing the window).
+        sz = Size(80, 24)
+        for _ in range(8):
+            conv.on_resize(Resize(sz, sz))
+
+        # Deferred: the first event does NOT repaint synchronously.
+        assert repaints == 0, "repaint must be debounced, not fired on the first event"
+
+        # After the storm settles (past the shrunk debounce), exactly ONE repaint —
+        # the storm coalesced (not one repaint per event). The delegated real hook
+        # also exercises refresh(repaint=True) against the live RichLog (no error).
+        for _ in range(30):
+            await pilot.pause(0.02)
+            if repaints:
+                break
+        assert repaints == 1, (
+            f"a resize storm must coalesce into one repaint, got {repaints}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Fixes #1950 (owner-GO'd: no upstream report → documented Textual workaround = fix).

## Problem

Drag-resizing the terminal during/after an agent reply emits a SIGWINCH storm; under it the Textual compositor's TTY writes drop characters, corrupting the **visible** RichLog text (e.g. `"It uses a hash function"` → `"It a hash function"`). Root-caused earlier: the render path is width-sweep-clean and `log.lines` stay byte-intact — the loss is in the compositor's TTY writes (a Textual issue, not reyn). The corruption persists because nothing re-marks the log dirty after the storm.

## Fix (canonical documented Textual workaround)

`ConversationView.on_resize` schedules a **debounced full repaint** (`refresh(repaint=True)`) of the log, fired **once after the storm settles** (when the TTY is calm), re-rendering from the intact `log.lines` — which overwrites the corrupted cells. Textual Discussion #3527's pattern (full repaint after resize); debounced via the established `set_timer`+`.stop()` idiom so a drag coalesces into one repaint. Display-only healing — reyn's data model is provably correct.

**Heal mechanism (compositor analysis, `_compositor.py`):** `refresh(repaint=True)` marks the RichLog region dirty → `render_partial_update` re-renders + writes those lines (there is no TTY-diff layer that would skip an "unchanged" region — a dirty region is always re-written) → corrupted cells overwritten. The earlier-verified intact `log.lines` guarantee the re-render is correct.

## Verification

- **Unit (Tier 2)**: a resize storm coalesces into exactly **one deferred repaint** (not per-event, not synchronous); the delegated real hook exercises the live `refresh(repaint=True)` without error.
- **Real-terminal tmux**: no-regression across **12+ resize storms** (content stays intact; the heal path doesn't disturb rendering).
- **Honest caveat**: the rare display glitch **did not reproduce on-demand this session** (timing/load-dependent, drag-only — the same rarity that made it a "rare display glitch"), so I could not capture a live corrupted→healed A/B. The heal is established by the **compositor analysis** + the **intact data model**, not a live before/after. (Earlier root-cause did reproduce it ~1/2; conditions differ.)

## Tier self-check

- **Tier 2**; no mocks (a real recording callable observes the SUT's own repaint hook — not a collaborator fake); behavioral asserts (a counter, not `len()==N`); no format-pins.

## Test plan

- [x] `pytest tests/cli/test_conv_resize_repaint_1950.py` — passed (coalescing + real-repaint exercised)
- [x] `pytest tests/cli/test_conv_pane_tool_call_lifecycle.py test_toolrow_flush_survives_clear.py test_tui_smoke.py` — 62 passed (no regression)
- [x] `ruff` clean · `tier_audit --strict` 0 violations
- [x] Real-terminal tmux: no-regression across 12+ storms; reply content intact after storm + debounce repaint
- [ ] (not obtained — rare glitch didn't reproduce on-demand) live corrupted→healed capture; heal established by compositor analysis + intact data model instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
