### PR TITLE
test(#2003-class): harden async-stack flash-window tests against xdist flake

### DIFF
--- a/tests/cli/test_async_stack_interrupted_flash.py
+++ b/tests/cli/test_async_stack_interrupted_flash.py
@@ -47,6 +47,36 @@ def _panel_row(snap: list[dict], agent_id: str) -> dict | None:
     return None
 
 
+# #2003-class flake-harden: the flash window is wall-clock-driven
+# (``_FLASH_DURATION_S``), so a "row still in the flash window" precondition was a
+# timing race under xdist parallel load — a slowed worker let the window close
+# before the assertion. Drive the window deterministically (same shape as #2003,
+# tests/cli/test_toolrow_flush_survives_clear.py); flash-contract assertions are
+# unchanged. Inject a LARGE window for "still-present" tests (stays open the whole
+# ms-scale test) and a FAST window + a poll for "gone-after" tests (closes
+# promptly, then wait for the removal to land rather than a fixed pause-past).
+_FLASH_OPEN_S = 3600.0
+_FLASH_FAST_S = 0.05
+
+
+def _patch_flash(monkeypatch, seconds: float) -> None:
+    import reyn.interfaces.tui.widgets.async_stack_panel as _asp
+    monkeypatch.setattr(_asp, "_FLASH_DURATION_S", seconds)
+
+
+async def _wait_until(pilot, predicate, *, cap: float = 2.0, step: float = 0.02) -> bool:
+    """Poll ``predicate`` (yielding the loop) until true or ``cap`` — a
+    deterministic wait for a timer-driven transition (vs a fixed pause that races
+    the removal task under load). Returns the final predicate value."""
+    waited = 0.0
+    while waited < cap:
+        if predicate():
+            return True
+        await pilot.pause(step)
+        waited += step
+    return predicate()
+
+
 # ── test 1: terminal="ok" → immediate unmount ────────────────────────────────
 
 @pytest.mark.asyncio
@@ -76,11 +106,12 @@ async def test_remove_ok_unmounts_immediately() -> None:
 # ── test 2: terminal="interrupted" → row stays (flashing) for 0.1 s ─────────
 
 @pytest.mark.asyncio
-async def test_remove_interrupted_row_still_present_before_flush() -> None:
-    """Tier 2: remove(terminal="interrupted") → row present and flashing after 0.1 s."""
+async def test_remove_interrupted_row_still_present_before_flush(monkeypatch) -> None:
+    """Tier 2: remove(terminal="interrupted") → row present and flashing in window."""
     from reyn.interfaces.tui.app import ReynTUIApp
     from reyn.interfaces.tui.widgets import ConversationView
 
+    _patch_flash(monkeypatch, _FLASH_OPEN_S)  # window stays open for the whole test
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
@@ -93,7 +124,7 @@ async def test_remove_interrupted_row_still_present_before_flush() -> None:
         assert _panel_has_id(panel.snapshot(), "p2"), "row must appear after add"
 
         panel.remove("p2", terminal="interrupted")
-        await pilot.pause(0.1)  # 0.1 s — well before the 1.5 s flush
+        await pilot.pause()  # the injected window cannot close during the test
 
         snap = panel.snapshot()
         row = _panel_row(snap, "p2")
@@ -113,11 +144,12 @@ async def test_remove_interrupted_row_still_present_before_flush() -> None:
 # ── test 3: terminal="interrupted" → row gone after 1.6 s ───────────────────
 
 @pytest.mark.asyncio
-async def test_remove_interrupted_row_gone_after_flush_delay() -> None:
-    """Tier 2: remove(terminal="interrupted") → row gone after ~1.6 s (post-flush)."""
+async def test_remove_interrupted_row_gone_after_flush_delay(monkeypatch) -> None:
+    """Tier 2: remove(terminal="interrupted") → row gone after the flash window."""
     from reyn.interfaces.tui.app import ReynTUIApp
     from reyn.interfaces.tui.widgets import ConversationView
 
+    _patch_flash(monkeypatch, _FLASH_FAST_S)  # window closes promptly; poll for the removal
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
@@ -129,11 +161,11 @@ async def test_remove_interrupted_row_gone_after_flush_delay() -> None:
         await pilot.pause()
 
         panel.remove("p2b", terminal="interrupted")
-        await pilot.pause(1.6)  # past the 1.5 s flash window
+        # Poll past the (fast) window for the flush to land — deterministic vs a
+        # fixed pause that races the removal task under load.
+        gone = await _wait_until(pilot, lambda: not _panel_has_id(panel.snapshot(), "p2b"))
 
-        assert not _panel_has_id(panel.snapshot(), "p2b"), (
-            "row must be gone from DOM after the 1.5 s flash window expires"
-        )
+        assert gone, "row must be gone from DOM after the flash window expires"
 
 
 # ── test 4: second remove() cancels pending timer + unmounts immediately ─────
@@ -199,7 +231,7 @@ async def test_remove_no_kwarg_still_works() -> None:
 # ── test 6: elapsed freezes at flash start (not live) ────────────────────────
 
 @pytest.mark.asyncio
-async def test_elapsed_frozen_at_flash_start() -> None:
+async def test_elapsed_frozen_at_flash_start(monkeypatch) -> None:
     """Tier 2: elapsed_s in snapshot is frozen the moment remove(terminal!='ok') fires.
 
     After calling remove(terminal='aborted'), the snapshot's elapsed_s for
@@ -209,6 +241,7 @@ async def test_elapsed_frozen_at_flash_start() -> None:
     from reyn.interfaces.tui.app import ReynTUIApp
     from reyn.interfaces.tui.widgets import ConversationView
 
+    _patch_flash(monkeypatch, _FLASH_OPEN_S)  # window stays open across the freeze check
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
@@ -232,8 +265,9 @@ async def test_elapsed_frozen_at_flash_start() -> None:
         assert row1["flashing"] is True
         elapsed_at_flash = row1["elapsed_s"]
 
-        # Wait ~1 s — well inside the 1.5 s flash window.
-        await pilot.pause(1.0)
+        # Let time pass — the window stays open (injected), so the row is still
+        # flashing and elapsed_s must NOT have advanced (it is frozen).
+        await pilot.pause(0.3)
 
         snap2 = panel.snapshot()
         row2 = _panel_row(snap2, "p5")

--- a/tests/cli/test_async_stack_readd_during_flash.py
+++ b/tests/cli/test_async_stack_readd_during_flash.py
@@ -37,12 +37,39 @@ def _panel_row(snap: list[dict], agent_id: str) -> dict | None:
     return None
 
 
+# #2003-class flake-harden: the flash window is wall-clock-driven, so "re-add
+# inside the flash window" was a timing race under xdist load (a slowed worker
+# let the window close before the re-add, silently degrading the test to a fresh
+# add). Drive the window deterministically — a LARGE window keeps it open across
+# the re-add; for the "survives the stale timer" test the re-add is SYNCHRONOUS
+# (cancels the timer before it can fire) and we poll past a FAST window for a
+# (buggy) stale removal. Same shape as #2003; behaviour assertions unchanged.
+_FLASH_OPEN_S = 3600.0
+_FLASH_FAST_S = 0.05
+
+
+def _patch_flash(monkeypatch, seconds: float) -> None:
+    import reyn.interfaces.tui.widgets.async_stack_panel as _asp
+    monkeypatch.setattr(_asp, "_FLASH_DURATION_S", seconds)
+
+
+async def _wait_until(pilot, predicate, *, cap: float = 2.0, step: float = 0.02) -> bool:
+    waited = 0.0
+    while waited < cap:
+        if predicate():
+            return True
+        await pilot.pause(step)
+        waited += step
+    return predicate()
+
+
 @pytest.mark.asyncio
-async def test_readd_during_flash_returns_to_running_state() -> None:
+async def test_readd_during_flash_returns_to_running_state(monkeypatch) -> None:
     """Tier 2: re-adding an id mid-flash clears the interrupted flash state."""
     from reyn.interfaces.tui.app import ReynTUIApp
     from reyn.interfaces.tui.widgets import ConversationView
 
+    _patch_flash(monkeypatch, _FLASH_OPEN_S)  # window stays open across the re-add
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
@@ -52,9 +79,9 @@ async def test_readd_during_flash_returns_to_running_state() -> None:
         panel.add("a1", "running task")
         await pilot.pause()
         panel.remove("a1", terminal="interrupted")
-        await pilot.pause(0.1)  # inside the flash window
+        await pilot.pause()  # the injected window cannot close during the test
 
-        # Same agent restarts → re-add under the same id.
+        # Same agent restarts → re-add under the same id, still inside the window.
         panel.add("a1", "restarted task")
         await pilot.pause()
 
@@ -67,11 +94,12 @@ async def test_readd_during_flash_returns_to_running_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_readd_during_flash_survives_old_timer() -> None:
+async def test_readd_during_flash_survives_old_timer(monkeypatch) -> None:
     """Tier 2: the stale flash timer must not yank a re-added live row."""
     from reyn.interfaces.tui.app import ReynTUIApp
     from reyn.interfaces.tui.widgets import ConversationView
 
+    _patch_flash(monkeypatch, _FLASH_FAST_S)  # original timer would fire promptly
     app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
     async with app.run_test(headless=True) as pilot:
         await pilot.pause()
@@ -81,15 +109,19 @@ async def test_readd_during_flash_survives_old_timer() -> None:
         panel.add("a2", "running task")
         await pilot.pause()
         panel.remove("a2", terminal="interrupted")
-        await pilot.pause(0.1)  # inside the flash window
-
+        # Re-add WHILE the flash timer is still pending — synchronously, before any
+        # await lets the timer fire, so the re-add deterministically lands inside
+        # the window and must cancel the stale timer (no wall-clock race).
         panel.add("a2", "restarted task")
         await pilot.pause()
 
-        # Past the ORIGINAL ~1.5 s flash deadline.
-        await pilot.pause(1.6)
-
-        assert _panel_has_id(panel.snapshot(), "a2"), (
+        # Poll PAST the original (fast) flash deadline for a (buggy) stale removal:
+        # a non-cancelled timer would yank the live row; it must never happen.
+        yanked = await _wait_until(
+            pilot, lambda: not _panel_has_id(panel.snapshot(), "a2"),
+            cap=_FLASH_FAST_S * 6,
+        )
+        assert not yanked, (
             "the re-added live row must survive past the old flash deadline — "
             "add() must cancel the stale flash timer"
         )


### PR DESCRIPTION
**[tui-coder]** — Sibling-harden of the #2003 wall-clock-window flake class (lead-directed follow-up to the toolrow fix).

## Why

The AsyncStackPanel interrupt-flash tests assert "row still in the flash window" after a fixed `pilot.pause`, relying on the wall-clock `_FLASH_DURATION_S` (1.5s) staying open. Under CI's `-n auto` (pytest-xdist) a slowed worker can let the window close before the assertion — the **same timing race as #2003**. The 1.5s window is a larger margin than #2003's 0.3s (lower probability), but the root is identical wall-clock dependence; this makes it **class-complete deterministic** rather than margin-reliant (per lead: "margin 頼みにしない").

## Fix (same shape as #2003, per assertion direction)

Monkeypatch the module constant `_FLASH_DURATION_S` (read dynamically at `remove()` time); behaviour assertions unchanged:

| assertion | harden |
|---|---|
| "still-present **in** window" (interrupted: present-before-flush, elapsed-frozen; readd: returns-to-running) | inject a **LARGE** window (3600s) → can't close during the ms-scale test |
| "gone **after** window" (interrupted: gone-after-flush) | inject a **FAST** window + **poll** for the removal (deterministic vs a fixed pause-past that races the removal task — the #927 lesson) |
| "survives the stale timer" (readd: survives-old-timer) | **synchronous re-add** (cancels the timer before any await lets it fire) + a FAST window + poll for a buggy stale removal |

## Proof the injection fixes the flake (mirrors #2003)

```
window=1.5  + 1.7s simulated slow-worker stall → row present=False  (flake reproduced)
window=3600 + 1.7s stall                       → row present=True   (harden robust)
```

So the large-window injection demonstrably keeps the row present past the old deadline (and the monkeypatch reaches the panel's `set_timer`).

## Tier self-check

- **Tier 2**; no mocks (monkeypatch a config constant + a poll helper, not a collaborator fake); behavioural asserts; no format-pins.

## Test plan

- [x] `pytest tests/cli/test_async_stack_interrupted_flash.py tests/cli/test_async_stack_readd_during_flash.py` — 9 passed, **3x stable**
- [x] Robustness proof (table above) — flake reproduced at 1.5s, robust at 3600s
- [x] `ruff` clean · `tier_audit --strict` 0 violations
- [ ] (skipped — pytest-xdist not installed locally) `-n auto` repro; the slow-worker simulation covers the same mechanism deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
