### PR TITLE
fix(#1953): wire per-unit step system prompt — result-channel SP-injection (b)-caught

### DIFF
--- a/src/reyn/runtime/task_graph.py
+++ b/src/reyn/runtime/task_graph.py
@@ -206,6 +206,7 @@ def make_production_run_unit(
     chain_id: str,
     router_model: "str | None",
     budget: Any,
+    goal: str = "",
     exclude_tools: "frozenset[str]" = frozenset({"plan"}),
 ) -> RunUnit:
     """Build the production ``run_unit``: each unit runs through a
@@ -215,18 +216,45 @@ def make_production_run_unit(
     cost is the budget's *recorded* before/after delta for the Task, so the
     cap-counter charge is the actually-spent cost, not a re-priced estimate.
 
-    ``exclude_tools`` drops ``plan`` by default so a unit cannot recursively
-    self-decompose (the plan path's long-standing guard)."""
+    Each unit's LLM call gets the **narrow step system prompt** (goal framing +
+    the unit's assignment + its dependencies' results as inputs), built the same
+    way the plan executor builds it and passed as ``system_prompt_override``.
+    Without it the unit would run on the generic router prompt and a dependent
+    unit would not see its deps' results — the result-channel would be silently
+    dropped (#1953: the bug live-parity caught that byte-equal replay could not).
+
+    ``goal`` is the parent decomposition goal (shared by every unit); ``exclude_tools``
+    drops ``plan`` by default so a unit cannot recursively self-decompose (the plan
+    path's long-standing guard)."""
+    from reyn.runtime.planner import (
+        Plan,
+        PlanStep,
+        build_plan_step_system_prompt,
+    )
     from reyn.runtime.router_loop import RouterLoop
     from reyn.runtime.task_execution import TaskExecutionHost
+
+    _output_language = getattr(parent_host, "output_language", None)
 
     async def run_unit(task: Any, prior_results: "dict[str, str]") -> "tuple[str, float]":
         before = budget.task_cost_usd(task.task_id) if budget is not None else 0.0
         host = TaskExecutionHost.for_task(
             task, parent=parent_host, prior_results=prior_results)
+        # Build the per-unit step SP (goal + assignment + dep-results channel),
+        # byte-matching the plan path. A synthetic Plan/PlanStep adapts the Task to
+        # the shared builder; its depends_on = the unit's dep ids, which key
+        # prior_results, so the "## Prior step results" section renders. (P4 repoints
+        # this builder onto the Task system.)
+        _step = PlanStep(
+            id=task.task_id, description=task.description or task.name,
+            tools=tuple(task.tools), depends_on=tuple(task.deps))
+        _sys_prompt = build_plan_step_system_prompt(
+            Plan(goal=goal, steps=(_step,)), _step, prior_results,
+            output_language=_output_language)
         loop = RouterLoop(
             host=host, chain_id=chain_id, router_model=router_model,
             budget=budget, exclude_tools=set(exclude_tools),
+            system_prompt_override=_sys_prompt,
             task_id=task.task_id,
         )
         await loop.run(user_text=task.description or task.name, history=[])
@@ -285,7 +313,8 @@ async def dispatch_task_tool(
         assignee=assignee, requester=requester,
     )
     run_unit = make_production_run_unit(
-        parent_host, chain_id=chain_id, router_model=router_model, budget=budget)
+        parent_host, chain_id=chain_id, router_model=router_model, budget=budget,
+        goal=plan.goal)
 
     # slice-8 (B) cap-charge in the live path: charge each unit's recorded cost
     # onto its Task via the record_task_cost prod-caller. A minimal ctx carries the

--- a/tests/test_sliceP3_plan_task_byte_equal_parity_1953.py
+++ b/tests/test_sliceP3_plan_task_byte_equal_parity_1953.py
@@ -19,6 +19,46 @@ from reyn.runtime.task_graph import build_task_graph, make_production_run_unit, 
 from reyn.task import InMemoryTaskBackend
 from tests._support.router_loop import FakeRouterHost, text_result
 
+
+@pytest.mark.asyncio
+async def test_dependent_unit_sp_carries_goal_and_prior_results(monkeypatch):
+    """Tier 2: regression for the SP-injection gap (b) live-parity caught — a
+    dependent unit's step system prompt must carry the goal framing AND its deps'
+    results (the I-2 result-channel rendered into the LLM context). (a) byte-equal
+    could not catch this: the scripted LLM keyed on the user message and ignored
+    the SP; only a real LLM reads the SP, so the channel was silently dropped."""
+    captured: dict[str, str] = {}
+
+    async def fake(**kwargs):
+        msgs = kwargs.get("messages", [])
+        sys_msg = next((str(m.get("content", "")) for m in msgs
+                        if m.get("role") == "system"), "")
+        users = [m for m in msgs if m.get("role") == "user"]
+        seed = str(users[-1].get("content", "")) if users else ""
+        captured[seed[:10]] = sys_msg
+        return text_result(f"REPLY[{seed[:10]}]")
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake)
+    b = InMemoryTaskBackend()
+    parent_id = await build_task_graph(
+        b, goal="THE-DECOMP-GOAL", assignee="a2a:s", requester="r", steps=[
+            {"id": "s1", "description": "alpha unit", "tools": [], "depends_on": []},
+            {"id": "s2", "description": "beta unit", "tools": [], "depends_on": ["s1"]},
+        ])
+    run_unit = make_production_run_unit(
+        FakeRouterHost(), chain_id="c", router_model=None, budget=None,
+        goal="THE-DECOMP-GOAL")
+    await run_task_graph(b, parent_id, run_unit=run_unit)
+
+    s2_sp = captured["beta unit"[:10]]
+    assert "THE-DECOMP-GOAL" in s2_sp                 # goal framing
+    assert "Prior step results" in s2_sp              # the channel section
+    assert "REPLY[alpha unit]" in s2_sp               # s1's actual result threaded in
+    # s1 (no deps) gets the goal but no prior-results section.
+    s1_sp = captured["alpha unit"[:10]]
+    assert "THE-DECOMP-GOAL" in s1_sp
+    assert "Prior step results" not in s1_sp
+
 # A fixed decomposition with a diamond dependency (s4 depends on two branches) so
 # the topological order + result-channel are exercised, not just a linear chain.
 _GOAL = "summarize the module"
@@ -75,7 +115,7 @@ async def test_plan_and_task_engines_are_byte_equal(monkeypatch):
         b, goal=_GOAL, assignee="a2a:s", requester="req", steps=_STEPS)
     task_host = FakeRouterHost()
     run_unit = make_production_run_unit(
-        task_host, chain_id="c", router_model=None, budget=None)
+        task_host, chain_id="c", router_model=None, budget=None, goal=_GOAL)
     task_final = await run_task_graph(b, parent_id, run_unit=run_unit)
 
     # 1. byte-equal synthesized reply (the user-facing aggregate).


### PR DESCRIPTION
**[e2e-coder]** — #1953: wire the per-unit step system prompt (result-channel SP-injection) — the bug (b) live-parity caught

## The dual-proof in action
This is the gap the **(b) live dogfood** half caught that **(a) byte-equal** structurally could not — the decisive evidence that lead's dual-proof ruling was right.

Running the SAME fixed decomposition through both engines live (gemini), diamond DAG, s3 = "combine the prior two facts":
- **plan** s3 → *"The number 7 is a prime number, and eight is the smallest cube…"* — combined the prior facts ✓
- **task** s3 → *"I need more info. Please tell me what the prior two facts are."* — ran blind to its inputs ✗

(a) could not see this: the scripted LLM keyed on the user message and ignored the system prompt; only a real LLM reads the SP.

## Root cause
`make_production_run_unit` built each unit's `RouterLoop` **without** a `system_prompt_override`, so every unit ran on the generic router prompt — missing the goal framing AND the dependency-results channel. The I-2 result-channel was wired for **storage** (`set_result` + backend read) but the **SP-injection** half (rendering deps' results into the unit's LLM context) was never wired. The plan path builds this SP externally via `build_plan_step_system_prompt(plan, step, prior_results)` and passes it as the override; the task path skipped it.

## Fix
`make_production_run_unit` now builds the per-unit step SP via `build_plan_step_system_prompt` (a synthetic `Plan`/`PlanStep` adapts the Task; its `depends_on` = the unit's dep ids, which key `prior_results`, so the "## Prior step results" section renders) + passes `system_prompt_override` — byte-matching the plan path. `goal` is threaded in (the shared decomposition goal). P4 repoints the builder onto the Task system.

**Live re-run after fix**: both engines combine the prior facts. ✓

## Test plan
- [x] Regression test (deterministic — the gap (a) had): a dependent unit's SP carries the goal + "Prior step results" section + the dep's actual result; a no-dep unit gets the goal but no prior-results section.
- [x] (a) byte-equal updated to thread `goal` (SP fidelity) — still byte-equal.
- [x] P2+P3 suite (14 tests) green; consumer suite 481 passed (goal param is backward-compat default).
- [x] ruff full-tree clean; tier-audit clean; verify_module_docstrings clean.
- [ ] (b) N≥3 live dogfood parity re-run (now that the channel works) — reported next on #1953 / this PR.

## Context
P3 PR #2011 (coexist/additive, plan untouched) merged before this was found, so no regression to existing flows — decompose is a new, not-yet-default tool. This is a P3 correctness fix, not P4 scope. A second parity gap (TUI-surface progress-row, `source=="plan*"`-specific) is owned by tui-coder; both gaps were surfaced to owner via lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
