### PR TITLE
feat(#1953 P3): TUI-surface parity — decompose drives AsyncStackPanel like plan

### DIFF
--- a/src/reyn/interfaces/tui/app_outbox.py
+++ b/src/reyn/interfaces/tui/app_outbox.py
@@ -1360,19 +1360,30 @@ class OutboxRouter:
         """
         source = (msg.meta or {}).get("source", "")
         plan_id = (msg.meta or {}).get("plan_id", "")
-        if plan_id:
-            if source == "plan_summary":
-                # Compact summary for the bottom strip — the full
-                # multi-line ``Executing plan: …`` text already lands
-                # in the conv pane via the default render below.
-                summary = f"plan #{str(plan_id)[:8]}"
+        # #1953 P3 (b) TUI-surface parity: the task-driven ``decompose`` mirrors
+        # plan's lifecycle surface — ``task_summary`` / ``task_complete`` (keyed on
+        # ``parent_task_id``) drive the SAME bottom-strip AsyncStackPanel row as
+        # ``plan_summary`` / ``plan_complete`` (keyed on ``plan_id``), so the two
+        # decomposition paths render an equivalent "running" progress UX. The
+        # synthesized reply stays a ``kind="agent"`` message (the user-facing
+        # answer), exactly like plan's aggregator reply. (Emit side = decompose's
+        # dispatcher; #1953 slice P3.)
+        task_id = (msg.meta or {}).get("parent_task_id", "")
+        row_key = plan_id or task_id
+        if row_key:
+            if source in ("plan_summary", "task_summary"):
+                # Compact summary for the bottom strip — the full multi-line
+                # start text already lands in the conv pane via the default
+                # render below.
+                label = "task" if source == "task_summary" else "plan"
+                summary = f"{label} #{str(row_key)[:8]}"
                 try:
-                    conv.add_async_task(str(plan_id), summary)
+                    conv.add_async_task(str(row_key), summary)
                 except Exception:
                     pass
-            elif source == "plan_complete":
+            elif source in ("plan_complete", "task_complete"):
                 try:
-                    conv.remove_async_task(str(plan_id))
+                    conv.remove_async_task(str(row_key))
                 except Exception:
                     pass
             elif source == "plan_aborted":
@@ -1380,7 +1391,7 @@ class OutboxRouter:
                 # so the user sees the row terminated abnormally rather
                 # than silently disappearing (= audit finding A#6).
                 try:
-                    conv.remove_async_task(str(plan_id), terminal="aborted")
+                    conv.remove_async_task(str(row_key), terminal="aborted")
                 except Exception:
                     pass
         # Default render path — preserves the dim marker line / slash

--- a/tests/cli/test_async_stack_panel_task_parity_1953.py
+++ b/tests/cli/test_async_stack_panel_task_parity_1953.py
@@ -1,0 +1,118 @@
+"""Tier 2: #1953 P3 (b) — task-driven decompose drives AsyncStackPanel at parity with plan.
+
+The task-driven ``decompose`` tool is the analog of ``plan``. For TUI-surface
+parity (the P4 delete-gate's TUI half), its lifecycle must render the SAME
+bottom-strip AsyncStackPanel "running" row as plan. The agreed owner-split:
+
+  - EMIT (decompose dispatcher): ``OutboxMessage(kind="system",
+    meta={"source": "task_summary"|"task_complete", "parent_task_id": ...})`` —
+    mirrors plan_runner's ``plan_summary``/``plan_complete`` (keyed on plan_id).
+  - RENDER (here): ``OutboxRouter._on_system`` routes ``task_summary`` →
+    ``conv.add_async_task`` and ``task_complete`` → ``conv.remove_async_task``,
+    keyed on ``parent_task_id`` — reusing the exact plan render path.
+
+These pin the RENDER half against the agreed message shape (the EMIT half lands
+in decompose's dispatcher; end-to-end is validated by a real-terminal post-wire
+capture). Same no-mock pattern as test_async_stack_panel_plan_lifecycle.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_task_summary_adds_async_stack_row() -> None:
+    """Tier 2: task_summary system msg → AsyncStackPanel row mounted (keyed on parent_task_id)."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.app_outbox import OutboxRouter
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        msg = OutboxMessage(
+            kind="system",
+            text="Decomposing:\n1. gather X\n2. gather Y",
+            meta={"parent_task_id": "task-abc12345-def6", "source": "task_summary"},
+        )
+        router._on_system(msg, conv, header)
+        await pilot.pause()
+
+        rows = [s for s in conv.async_stack_snapshot() if not s["is_overflow"]]
+        assert any(s["agent_id"] == "task-abc12345-def6" for s in rows), (
+            f"task row should appear in panel snapshot (parity with plan); got {rows!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_task_complete_removes_async_stack_row() -> None:
+    """Tier 2: task_complete system msg → AsyncStackPanel row dropped (parity with plan_complete)."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.app_outbox import OutboxRouter
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        spawn = OutboxMessage(
+            kind="system", text="Decomposing:\n1. step",
+            meta={"parent_task_id": "task-zzz999", "source": "task_summary"},
+        )
+        router._on_system(spawn, conv, header)
+        await pilot.pause()
+        assert any(
+            s["agent_id"] == "task-zzz999"
+            for s in conv.async_stack_snapshot() if not s["is_overflow"]
+        )
+
+        complete = OutboxMessage(
+            kind="system", text="done · task-zzz999",
+            meta={"parent_task_id": "task-zzz999", "source": "task_complete"},
+        )
+        router._on_system(complete, conv, header)
+        await pilot.pause()
+        assert all(s["agent_id"] != "task-zzz999" for s in conv.async_stack_snapshot())
+
+
+@pytest.mark.asyncio
+async def test_task_summary_missing_parent_task_id_is_silent_noop() -> None:
+    """Tier 2b: task_summary without parent_task_id (and no plan_id) → silent no-op.
+
+    Guard against emit-side shape drift — no row keyed on empty string.
+    """
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.app_outbox import OutboxRouter
+    from reyn.interfaces.tui.widgets import ConversationView
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        router = OutboxRouter(app)
+        header = app.query_one("#header")
+
+        msg = OutboxMessage(
+            kind="system", text="Decomposing:\n…",
+            meta={"source": "task_summary"},  # no parent_task_id, no plan_id
+        )
+        router._on_system(msg, conv, header)
+        await pilot.pause()
+        assert conv.async_stack_snapshot() == []


### PR DESCRIPTION
**[tui-coder]** — P3 (b) TUI-surface parity, the **RENDER half** of the lead/e2e-agreed owner-split. The P4 delete-gate's TUI parity.

## The gap (pre-characterized, verified-in-main, agreed)

`decompose` is the task-driven analog of `plan`. For TUI parity its lifecycle must render the SAME bottom-strip **AsyncStackPanel "running" row**. But decompose posted only `kind="agent"` messages, so `app_outbox._on_system`'s plan-specific handling (`source==plan_summary/plan_complete` + `plan_id`) never fired → **no progress row** (plan: `⟳ plan #… · running`; decompose: just two agent messages).

## Owner-split (this PR = RENDER)

| half | owner | change |
|---|---|---|
| EMIT | e2e (decompose dispatcher, follow-up) | mirror plan: `kind="system"` `source="task_summary"`(start)/`"task_complete"`(end) + `meta.parent_task_id`; synthesized answer stays `kind="agent"` (= plan's aggregator reply) |
| **RENDER (here)** | tui-coder | `_on_system` routes `source ∈ {plan_summary, task_summary}`→`add_async_task`, `{plan_complete, task_complete}`→`remove`, keyed on `plan_id`-or-`parent_task_id` — **reuses the exact plan render path**, no new widget |

## Validation status (honest)

- **Render logic — unit-tested** (3 tests, synthesized `task_*` `OutboxMessage`s → row mount/remove + missing-id no-op), mirroring `test_async_stack_panel_plan_lifecycle.py`. Plan path unchanged (4 lifecycle tests pass).
- **End-to-end production-wiring — PENDING e2e's emit**: the real proof (real `decompose` run → e2e's `task_summary` emit → this render → AsyncStackPanel row, plan-vs-decompose match) is a real-terminal **post-wire tmux capture** I'll add once e2e's emit (#2012-followup) is pushed. This PR is **inert until then** (the `task_*` branches don't fire without the markers — safe to land ahead).
- **Item 2** (per-sub-task SkillActivityRow via a `set_task_step` contextvar) = **joint-assess**, not in this PR.

## Merge sequencing

Composes with e2e's emit PR. Safe to land inert (no behavior until the markers exist), or sequence after e2e's emit + my post-wire capture — reviewer's call.

## Tier self-check

- **Tier 2**; no mocks (real `OutboxMessage` drives the real `_on_system`; public `async_stack_snapshot` surface); behavioral asserts; no format-pins.

## Test plan

- [x] `pytest tests/cli/test_async_stack_panel_task_parity_1953.py` — 3 passed (render half)
- [x] `pytest -k "async_stack or outbox or tui_smoke or plan_lifecycle"` — 100 passed (no regression)
- [x] `ruff` clean · `tier_audit --strict` 0 violations
- [ ] (pending e2e's emit) post-wire real-terminal tmux capture: plan-vs-decompose AsyncStackPanel render match

🤖 Generated with [Claude Code](https://claude.com/claude-code)
