### PR TITLE
feat(#1953): slice P3 (b) — TUI-parity emit + committed live parity harness

### DIFF
--- a/scripts/dogfood_sliceP3_parity.py
+++ b/scripts/dogfood_sliceP3_parity.py
@@ -1,0 +1,148 @@
+"""Live plan-vs-task behavioral parity harness (#1953 slice P3, the (b) delete gate).
+
+The real-env complement to the deterministic byte-equal proof
+(``tests/test_sliceP3_plan_task_byte_equal_parity_1953.py``). On a set of fixed
+decompositions, run BOTH execution engines — ``execute_plan`` (the path P4 deletes)
+and ``run_task_graph`` (the Task-driven successor) — through the LIVE LLM, N>=3 each,
+and assert structural behavioral-equivalence:
+
+  * every unit produced a non-empty result;
+  * each dependent unit RECEIVED its prior context (a dropped result-channel shows
+    up as a "need more info" failure — the bug live-parity caught at #1953);
+  * the synthesized reply is non-empty.
+
+Variance-robust: each engine runs N>=3 times per goal; parity holds only if both
+engines pass every run. This is the gate that — together with (a) byte-equal + the
+TUI-surface check + the owner carve-out cross-check — clears the P4 plan delete.
+
+Usage::
+
+    python scripts/dogfood_sliceP3_parity.py [--n 3] [--model gemini/gemini-2.5-flash-lite]
+
+Requires a live LLM (GOOGLE_API_KEY). Exit code 0 iff full parity.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# The shared FakeRouterHost lives under tests/_support; reuse it for a lightweight
+# host whose only override is identity model resolution (so the real model string
+# reaches litellm instead of the test stub's "fake-model-" prefix).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
+
+from _support.router_loop import FakeRouterHost  # noqa: E402
+
+from reyn.runtime.planner import Plan, PlanStep, execute_plan  # noqa: E402
+from reyn.runtime.task_graph import (  # noqa: E402
+    build_task_graph,
+    make_production_run_unit,
+    run_task_graph,
+)
+from reyn.task import InMemoryTaskBackend  # noqa: E402
+
+
+class _LiveHost(FakeRouterHost):
+    def resolve_model(self, name: str) -> str:  # identity — reach the real model
+        return name
+
+
+# Each goal's final step DEPENDS on prior steps and REQUIRES their content, so a
+# dropped result-channel surfaces as a "need more info" failure pattern.
+_GOALS: list[tuple[str, str, list[dict]]] = [
+    ("facts-synthesis", "state and combine facts about 7 and 8", [
+        {"id": "s1", "description": "In one sentence, state a fact about the number 7.", "tools": [], "depends_on": []},
+        {"id": "s2", "description": "In one sentence, state a fact about the number 8.", "tools": [], "depends_on": []},
+        {"id": "s3", "description": "Combine the two prior facts into a single sentence.", "tools": [], "depends_on": ["s1", "s2"]},
+    ]),
+    ("linear-chain", "pick a color then describe its mood", [
+        {"id": "s1", "description": "Name one primary color in one word.", "tools": [], "depends_on": []},
+        {"id": "s2", "description": "In one sentence, describe a mood evoked by the color from the prior step.", "tools": [], "depends_on": ["s1"]},
+    ]),
+]
+
+_FAIL_PATTERNS = (
+    "need more info", "tell me what", "what are the prior", "please provide",
+    "please tell me", "i don't have", "no prior", "what were the",
+)
+
+
+def _context_received(text: str) -> bool:
+    t = (text or "").lower()
+    return bool(t.strip()) and not any(p in t for p in _FAIL_PATTERNS)
+
+
+async def _run_plan(goal: str, steps: list[dict], model: str) -> dict:
+    plan = Plan(goal=goal, steps=tuple(
+        PlanStep(id=s["id"], description=s["description"],
+                 tools=tuple(s["tools"]), depends_on=tuple(s["depends_on"]))
+        for s in steps))
+    r = await execute_plan(plan, parent_host=_LiveHost(), chain_id="c",
+                           budget=None, router_model=model)
+    return {
+        "units": {s["id"]: r.step_results.get(s["id"], "") for s in steps},
+        "final": r.text,
+        "dep_ids": [s["id"] for s in steps if s["depends_on"]],
+    }
+
+
+async def _run_task(goal: str, steps: list[dict], model: str) -> dict:
+    b = InMemoryTaskBackend()
+    pid = await build_task_graph(
+        b, goal=goal, assignee="a2a:s", requester="r", steps=steps)
+    run_unit = make_production_run_unit(
+        _LiveHost(), chain_id="c", router_model=model, budget=None, goal=goal)
+    final = await run_task_graph(b, pid, run_unit=run_unit)
+    children = {c.name: c for c in await b.list(parent_id=pid)}
+    return {
+        "units": {s["id"]: (children[s["description"][:120]].result or "") for s in steps},
+        "final": final,
+        "dep_ids": [s["id"] for s in steps if s["depends_on"]],
+    }
+
+
+def _assess(run: dict) -> tuple[bool, dict]:
+    detail = {
+        "all_units_nonempty": all((v or "").strip() for v in run["units"].values()),
+        "deps_received_context": all(_context_received(run["units"][d]) for d in run["dep_ids"]),
+        "final_nonempty": bool((run["final"] or "").strip()),
+    }
+    return all(detail.values()), detail
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=3)
+    ap.add_argument("--model", default="gemini/gemini-2.5-flash-lite")
+    args = ap.parse_args()
+
+    report: dict = {}
+    parity = True
+    for name, goal, steps in _GOALS:
+        report[name] = {"plan": [], "task": []}
+        for i in range(args.n):
+            p_ok, p_d = _assess(await _run_plan(goal, steps, args.model))
+            t_ok, t_d = _assess(await _run_task(goal, steps, args.model))
+            report[name]["plan"].append({"ok": p_ok, **p_d})
+            report[name]["task"].append({"ok": t_ok, **t_d})
+            print(f"[{name} run{i + 1}] plan={'PASS' if p_ok else 'FAIL'} | "
+                  f"task={'PASS' if t_ok else 'FAIL'}")
+    print(f"\n=== PARITY SUMMARY (N={args.n} each) ===")
+    for name in report:
+        p = sum(r["ok"] for r in report[name]["plan"])
+        t = sum(r["ok"] for r in report[name]["task"])
+        ok = (p == t == args.n)
+        parity = parity and ok
+        print(f"  {name}: plan {p}/{args.n}, task {t}/{args.n} -> "
+              f"parity={'YES' if ok else 'NO'}")
+    out = Path("/tmp/sliceP3_parity_report.json")
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nreport: {out}  |  overall parity: {'YES' if parity else 'NO'}")
+    return 0 if parity else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/reyn/runtime/task_graph.py
+++ b/src/reyn/runtime/task_graph.py
@@ -333,14 +333,27 @@ async def dispatch_task_tool(
         await _taskmod.record_task_cost(_cost_ctx, task_id, cost)
 
     async def _run_and_post() -> None:
-        # Mirror execute_plan's start + terminal outbox emits (event/TUI parity).
-        await _safe_outbox(parent_host, kind="agent",
-                           text=f"Decomposed into {len(steps)} sub-tasks; running…",
-                           meta={"source": "decompose", "parent_task_id": parent_id})
+        # Mirror the plan path's outbox surface (TUI parity, agreed with tui-coder):
+        #   start  → kind="system" source="task_summary"  (AsyncStackPanel row add)
+        #   reply  → kind="agent"                          (the user-facing answer)
+        #   end    → kind="system" source="task_complete"  (progress row remove)
+        # The TUI's _on_system treats {plan_summary, task_summary}→add /
+        # {plan_complete, task_complete}→remove, keyed on parent_task_id, reusing the
+        # plan render path. (plan_runner.py:91 emits the analogous plan_summary.)
+        summary = "\n".join(
+            f"{i + 1}. {s['description']}" for i, s in enumerate(steps))
+        await _safe_outbox(
+            parent_host, kind="system",
+            text=f"Decomposing into {len(steps)} sub-tasks:\n{summary}",
+            meta={"parent_task_id": parent_id, "source": "task_summary"})
         final = await run_task_graph(
             task_backend, parent_id, run_unit=run_unit, on_unit_cost=_on_unit_cost)
-        await _safe_outbox(parent_host, kind="agent", text=final,
-                           meta={"source": "decompose", "parent_task_id": parent_id})
+        await _safe_outbox(
+            parent_host, kind="agent", text=final,
+            meta={"parent_task_id": parent_id, "source": "decompose"})
+        await _safe_outbox(
+            parent_host, kind="system", text="Decompose complete",
+            meta={"parent_task_id": parent_id, "source": "task_complete"})
 
     if hasattr(parent_host, "spawn_task_graph"):
         await parent_host.spawn_task_graph(

--- a/tests/test_sliceP3_decompose_tool_1953.py
+++ b/tests/test_sliceP3_decompose_tool_1953.py
@@ -78,6 +78,39 @@ async def test_dispatch_task_tool_builds_runs_and_posts(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_task_tool_emits_tui_parity_surface(monkeypatch):
+    """Tier 2: the dispatch emits the plan-mirroring outbox surface (TUI parity,
+    agreed with tui-coder): a kind="system" source="task_summary" start marker, the
+    synthesized reply as kind="agent", and a kind="system" source="task_complete"
+    end marker — all carrying parent_task_id so the TUI's _on_system reuses the plan
+    progress-row render path."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
+    taskmod.reset_backend_for_test()
+    host = FakeRouterHost()
+    backend = InMemoryTaskBackend()
+    args = {"goal": "summarize", "steps_json": _steps_json([
+        {"id": "s1", "description": "read the file", "tools": [], "depends_on": []},
+        {"id": "s2", "description": "report findings", "tools": [], "depends_on": ["s1"]},
+    ])}
+    result = await dispatch_task_tool(
+        args=args, parent_host=host, chain_id="c", task_backend=backend,
+        assignee="a2a:s", requester="a2a:s", available_tool_names={"file_read"})
+    pid = result["parent_task_id"]
+
+    # every emitted message carries the parent_task_id; the markers are kind=system,
+    # the reply is kind=agent (= plan's aggregator-reply shape).
+    assert all(o["meta"].get("parent_task_id") == pid for o in host.outbox)
+    by_source = {o["meta"].get("source"): o for o in host.outbox}
+    assert by_source["task_summary"]["kind"] == "system"
+    assert by_source["task_complete"]["kind"] == "system"
+    assert by_source["decompose"]["kind"] == "agent"
+    assert by_source["decompose"]["text"] == "REPORT-RESULT"   # the synthesized reply
+    # ordering: summary start → reply → complete end.
+    sources = [o["meta"].get("source") for o in host.outbox]
+    assert sources.index("task_summary") < sources.index("decompose") < sources.index("task_complete")
+
+
+@pytest.mark.asyncio
 async def test_dispatch_task_tool_invalid_returns_error():
     """Tier 2: a structurally-invalid decomposition (1 step < min) returns a
     decompose_invalid error instead of creating any Task."""


### PR DESCRIPTION
**[e2e-coder]** — #1953 slice P3 (b): TUI-parity emit shape + committed live parity harness

Completes the (b) delete-gate half (engine behavioral parity is proven; this lands the durable harness + the TUI-surface emit side). Pairs with tui-coder's render half (#2013).

## (b1) Committed live parity harness
`scripts/dogfood_sliceP3_parity.py` — the durable, reusable real-env complement to the (a) deterministic byte-equal test. Runs BOTH engines (`execute_plan` vs `run_task_graph`) on fixed decompositions through the LIVE LLM, N≥3 each, asserting structural behavioral-equivalence:
- every unit non-empty;
- each **dependent unit received its prior context** (a dropped result-channel surfaces as a "need more info" failure — the bug live-parity caught);
- synthesized reply non-empty.

Exit 0 iff full parity. **Verified: facts-synthesis + linear-chain, plan 3/3 == task 3/3 = parity YES**, variance-robust.

## (b2) TUI-surface emit (owner-split with tui-coder, source names locked)
`dispatch_task_tool` now mirrors the plan path's outbox surface instead of 2 generic agent messages:
- start → `kind="system"` `source="task_summary"` (+parent_task_id) — AsyncStackPanel progress-row add
- reply → `kind="agent"` `source="decompose"` — the user-facing answer (= plan's aggregator reply)
- end → `kind="system"` `source="task_complete"` (+parent_task_id) — progress-row remove

tui-coder's `_on_system` (#2013, inert until this emit) treats `{plan_summary, task_summary}`→add / `{plan_complete, task_complete}`→remove keyed on `plan_id|parent_task_id`, **reusing the plan render path** (no new widget). Verified the real `RouterHostAdapter.put_outbox(*, kind, text, meta)` builds the same `OutboxMessage` shape `plan_runner` emits, so `source`+`parent_task_id` reach `_on_system`.

## Test plan
- [x] Tier-2 emit-shape test: dispatch emits task_summary → reply → task_complete in order, markers `kind=system` + reply `kind=agent`, all carrying `parent_task_id`.
- [x] Harness verified live (N≥3, both goals, parity YES); smoke `--n 1` exit 0.
- [x] Consumer suite 68 passed; ruff full-tree + tier-audit + verify_module_docstrings clean.
- [ ] **End-to-end TUI validation = tui-coder** (tmux real-terminal, plan-vs-decompose AsyncStackPanel row match) once this emit lands — they'll tick #2013's test plan.
- [ ] Item 2 (`set_task_step` contextvar → per-sub-task SkillActivityRow) = joint-assess (only fires when a sub-task invokes a skill).

## Gate status (toward P4 plan-delete)
(a) byte-equal ✅ + (b1) behavioral N≥3 ✅ + (b2 TUI emit) ✅here/render #2013/e2e🔨tui + owner carve-out cross-check 🔨 = P4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
