### PR TITLE
feat(1870): llm.router.retry_policy — typed litellm RetryPolicy passthrough

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -321,6 +321,9 @@ llm:
       openai/gpt-4o-mini:  # ENV-VAR NAMES only; NEVER inline a key value
         - api_key_env: OPENAI_API_KEY_1
         - api_key_env: OPENAI_API_KEY_2
+    retry_policy:          # per-exception-type retry counts (litellm.RetryPolicy)
+      RateLimitErrorRetries: 5
+      TimeoutErrorRetries: 3
 ```
 
 ### `llm.router` fields
@@ -333,6 +336,7 @@ llm:
 | `cooldown_time` | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
 | `allowed_fails` | int\|null | `null` | Failures before a deployment is cooled down. |
 | `credentials` | map | `{}` | Credential rotation: `model → [{api_key_env: ENV_VAR_NAME}]`. Each usable key → one Router deployment (same model) → the Router rotates / fails over across keys. **Reference env-var NAMES only — never inline a key value**; values are read from `os.environ` at build time and are never logged or cache-fingerprinted. A declared model whose env vars all resolve to nothing is a load error (no silent keyless deployment). |
+| `retry_policy` | map\|null | `null` | Per-exception-type retry counts. Absent (null) → litellm defaults (`num_retries` applies uniformly). When set, constructs a `litellm.RetryPolicy` and passes it to the Router. Supported keys: `RateLimitErrorRetries`, `TimeoutErrorRetries`, `BadRequestErrorRetries`, `AuthenticationErrorRetries`, `ContentPolicyViolationErrorRetries`, `InternalServerErrorRetries`. |
 
 On the Router path, retry count is **config-only**: `num_retries` is taken from
 `llm.router.num_retries` (a per-call `max_retries` is not applied), so the retry

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -93,6 +93,13 @@
 #       openai/gpt-4o-mini:  # Reference ENV-VAR NAMES only; NEVER inline a key.
 #         - api_key_env: OPENAI_API_KEY_1   # each usable key → one deployment;
 #         - api_key_env: OPENAI_API_KEY_2   # the Router rotates / fails over.
+#     retry_policy:          # per-exception-type retry counts (overrides num_retries
+#                            # for the matched exception class). Absent → litellm
+#                            # defaults (num_retries applies uniformly).
+#       RateLimitErrorRetries: 5
+#       TimeoutErrorRetries: 3
+#       # Supported: BadRequestErrorRetries, AuthenticationErrorRetries,
+#       #   ContentPolicyViolationErrorRetries, InternalServerErrorRetries
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -91,6 +91,13 @@ class RouterConfig:
     # key value here (the value is read from os.environ at build time and is never
     # logged / fingerprinted; only the NAME is).
     credentials: dict = field(default_factory=dict)
+    # per-exception-type retry counts (None → litellm defaults, i.e. no typed
+    # policy). A mapping of RetryPolicy field names → counts; constructed into a
+    # ``litellm.RetryPolicy`` at Router build time. Supported keys:
+    #   RateLimitErrorRetries, TimeoutErrorRetries, BadRequestErrorRetries,
+    #   AuthenticationErrorRetries, ContentPolicyViolationErrorRetries,
+    #   InternalServerErrorRetries.
+    retry_policy: dict | None = None
 
 
 @dataclass
@@ -119,6 +126,11 @@ def _build_router_config(raw: object) -> RouterConfig:
             "llm.router.credentials must be a mapping (model → [{api_key_env: NAME}]), "
             f"got {type(cred).__name__}"
         )
+    rp_raw = raw.get("retry_policy")
+    if rp_raw is not None and not isinstance(rp_raw, dict):
+        raise ValueError(
+            f"llm.router.retry_policy must be a mapping, got {type(rp_raw).__name__}"
+        )
     return RouterConfig(
         use=bool(raw.get("use", d.use)),
         num_retries=int(raw.get("num_retries", d.num_retries)),
@@ -141,6 +153,9 @@ def _build_router_config(raw: object) -> RouterConfig:
             ]
             for m, lst in (cred or {}).items()
         },
+        # None → absent (default litellm behavior); mapping → constructed at Router
+        # build time into a litellm.RetryPolicy object.
+        retry_policy={str(k): int(v) for k, v in rp_raw.items()} if rp_raw else None,
     )
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1077,7 +1077,11 @@ def _router_cache_fingerprint(rcfg) -> tuple:
 
     #1829 S4: includes the credential ENV-VAR NAMES — **never the key VALUES** (the
     value is read from os.environ at build, never stored/fingerprinted; secret-safe
-    by construction)."""
+    by construction).
+
+    #1870: includes ``retry_policy`` mapping (None → empty) so a changed
+    retry_policy invalidates the cached Router."""
+    rp = rcfg.retry_policy or {}
     return (
         rcfg.num_retries,
         rcfg.cooldown_time,
@@ -1087,6 +1091,7 @@ def _router_cache_fingerprint(rcfg) -> tuple:
             (m, tuple(c.get("api_key_env") for c in (creds or [])))
             for m, creds in getattr(rcfg, "credentials", {}).items()
         )),
+        tuple(sorted(rp.items())),
     )
 
 
@@ -1176,6 +1181,8 @@ def _single_deployment_router(model: str):
             kwargs["cooldown_time"] = rcfg.cooldown_time
         if rcfg.allowed_fails is not None:
             kwargs["allowed_fails"] = rcfg.allowed_fails
+        if rcfg.retry_policy:
+            kwargs["retry_policy"] = _ll.RetryPolicy(**rcfg.retry_policy)
         router = _ll.Router(**kwargs)
         per_loop[cache_key] = router
     return router

--- a/tests/test_llm_router_retry_policy_1870.py
+++ b/tests/test_llm_router_retry_policy_1870.py
@@ -1,0 +1,122 @@
+"""Tier 2: OS-invariant tests for #1870 — llm.router.retry_policy typed
+litellm.RetryPolicy passthrough.
+
+#1870 adds ``llm.router.retry_policy``: a mapping of per-exception-type retry
+counts that is constructed into a ``litellm.RetryPolicy`` and threaded into the
+Router builder. Three invariants are pinned:
+
+1. A configured retry_policy reaches the built Router's ``retry_policy``
+   attribute with a NON-DEFAULT value so an unwired path cannot silently pass.
+2. Absent config → no retry_policy on the Router (default-OFF, no behavior
+   change).
+3. A retry_policy change invalidates the per-loop Router cache (same invariant
+   as num_retries config change, now extended to retry_policy).
+
+Policy: no mocks of Reyn collaborators — real RouterConfig + real resolver +
+real litellm.Router. litellm.acompletion is not called here; we only inspect
+the Router's public ``retry_policy`` attribute. Tier line first.
+"""
+from __future__ import annotations
+
+import litellm
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.infra import RouterConfig, _build_router_config
+from reyn.llm.llm import (
+    _single_deployment_router,
+    set_router_config,
+)
+
+_M = "openai/gpt-4o-mini"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with NO ambient router config; litellm.model_cost is
+    snapshot/restored (Router build registers price-less placeholders)."""
+    monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
+    llm_mod._router_config_var.set(None)
+    before = dict(litellm.model_cost)
+    yield
+    llm_mod._router_config_var.set(None)
+    litellm.model_cost.clear()
+    litellm.model_cost.update(before)
+
+
+# ── (1) configured retry_policy reaches the Router ───────────────────────────
+
+@pytest.mark.asyncio
+async def test_retry_policy_reaches_router() -> None:
+    """Tier 2: a configured llm.router.retry_policy constructs a litellm.RetryPolicy
+    and threads it to the Router — the Router's retry_policy attribute reflects the
+    NON-DEFAULT value (RateLimitErrorRetries=5) so an unwired path cannot pass."""
+    set_router_config(RouterConfig(
+        use=True,
+        retry_policy={"RateLimitErrorRetries": 5},
+    ))
+    router = _single_deployment_router(_M)
+    rp = router.retry_policy
+    assert rp is not None, "retry_policy must be set on the Router when configured"
+    assert isinstance(rp, litellm.RetryPolicy), (
+        f"retry_policy must be a litellm.RetryPolicy, got {type(rp)}"
+    )
+    assert rp.RateLimitErrorRetries == 5, (
+        f"RateLimitErrorRetries must be 5 (non-default), got {rp.RateLimitErrorRetries}"
+    )
+
+
+# ── (2) absent config → no retry_policy on the Router (default-OFF) ──────────
+
+@pytest.mark.asyncio
+async def test_absent_retry_policy_not_set_on_router() -> None:
+    """Tier 2: when llm.router.retry_policy is absent the Router is built without a
+    retry_policy — default-OFF, current behavior is unchanged."""
+    set_router_config(RouterConfig(use=True))  # no retry_policy
+    router = _single_deployment_router(_M)
+    # litellm.Router sets retry_policy=None when not provided
+    assert router.retry_policy is None, (
+        "retry_policy must not be set when absent from config (default-OFF)"
+    )
+
+
+# ── (3) retry_policy change invalidates the cache ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cache_invalidated_on_retry_policy_change() -> None:
+    """Tier 2: a changed retry_policy invalidates the per-loop Router cache so a
+    stale Router (with the old policy) is never silently reused."""
+    set_router_config(RouterConfig(use=True, retry_policy={"RateLimitErrorRetries": 3}))
+    r1 = _single_deployment_router(_M)
+    assert _single_deployment_router(_M) is r1, "same config must hit the cache"
+
+    set_router_config(RouterConfig(use=True, retry_policy={"RateLimitErrorRetries": 7}))
+    r2 = _single_deployment_router(_M)
+    assert r2 is not r1, (
+        "a changed retry_policy must rebuild the Router, not reuse the stale one"
+    )
+    assert r2.retry_policy is not None
+    assert r2.retry_policy.RateLimitErrorRetries == 7
+
+
+# ── (4) _build_router_config parses retry_policy from raw yaml dict ──────────
+
+def test_build_router_config_parses_retry_policy() -> None:
+    """Tier 2: _build_router_config correctly parses the retry_policy mapping from
+    a raw reyn.yaml dict into the RouterConfig field."""
+    cfg = _build_router_config({
+        "use": True,
+        "retry_policy": {
+            "RateLimitErrorRetries": 5,
+            "TimeoutErrorRetries": 2,
+        },
+    })
+    assert cfg.retry_policy == {"RateLimitErrorRetries": 5, "TimeoutErrorRetries": 2}
+
+
+def test_build_router_config_absent_retry_policy_is_none() -> None:
+    """Tier 2: absent retry_policy in raw yaml → RouterConfig.retry_policy is None
+    (not an empty dict) — so the Router builder's 'if rcfg.retry_policy' gate is
+    falsy and no RetryPolicy is constructed."""
+    cfg = _build_router_config({"use": True})
+    assert cfg.retry_policy is None


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #1870

## Summary

- Add `llm.router.retry_policy` config field to `RouterConfig`: a mapping of per-exception-type retry counts (e.g. `RateLimitErrorRetries: 5`) stored as `dict | None` (None = absent = default-OFF).
- `_build_router_config` parses the raw yaml mapping into the `RouterConfig` field (validates it is a dict; normalises keys to str, values to int).
- `_router_cache_fingerprint` includes the retry_policy mapping (as a sorted tuple of pairs) so a policy change invalidates the cached Router.
- `_single_deployment_router` constructs `litellm.RetryPolicy(**rcfg.retry_policy)` and passes it as `retry_policy=` to `litellm.Router` only when configured; absent → no kwarg (default-OFF, byte-identical to pre-#1870).
- Docs mirrored in `reyn.local.yaml.example` (commented example) and `docs/reference/config/reyn-yaml.md` (table row + yaml snippet) per config-mirror gate #1056.

## Test plan

Tier-2 test file `tests/test_llm_router_retry_policy_1870.py` (5 tests, all green, ruff-clean, tier-audit-clean):

- [x] `test_retry_policy_reaches_router` — configured `RateLimitErrorRetries=5` reaches `router.retry_policy.RateLimitErrorRetries` (non-default value, unwired path cannot silently pass)
- [x] `test_absent_retry_policy_not_set_on_router` — absent config → `router.retry_policy is None` (default-OFF)
- [x] `test_cache_invalidated_on_retry_policy_change` — changing retry_policy rebuilds the Router (cache fingerprint gate)
- [x] `test_build_router_config_parses_retry_policy` — raw yaml dict with two keys parses correctly into `RouterConfig.retry_policy`
- [x] `test_build_router_config_absent_retry_policy_is_none` — absent key in raw yaml → `RouterConfig.retry_policy is None` (falsy gate in builder)
- [x] `ruff check src tests --fix` — clean (All checks passed!)
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_router_retry_policy_1870.py` — 5/5 OK
- [x] Sibling router tests (`test_llm_router_s{1,2,3b,4}_1829.py`, 21 tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)