### PR TITLE
feat(1835): jitter + Retry-After honouring to LLM self-retry layer

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -297,15 +297,8 @@ keys are warned (not fatal) at load time.
 
 ## `llm` block
 
-LLM-layer config. Currently the **`llm.router`** surface — opt-in
-[litellm.Router](https://docs.litellm.ai/docs/routing) provider-resilience
-(#1829). **Default OFF**: with `use: false` the LLM call path is the direct
-`litellm.acompletion` (byte-identical to no-Router). When enabled, the Router owns
-infra-exception retry (with native `Retry-After` respect), per-deployment
-cooldown, and a cross-model fallback chain — Reyn does not re-implement any of
-these. The single config surface supersedes the legacy `REYN_LLM_USE_ROUTER` /
-`REYN_LLM_ROUTER_NUM_RETRIES` env vars, which remain a back-compat fallback when
-this block is absent (the `ssl_verify` → env → default idiom).
+LLM-layer config: **`llm.router`** (opt-in litellm.Router, #1829) and
+**`llm.retry`** (backoff timing for the Reyn self-retry layer, #1835).
 
 ```yaml
 llm:
@@ -324,6 +317,9 @@ llm:
     retry_policy:          # per-exception-type retry counts (litellm.RetryPolicy)
       RateLimitErrorRetries: 5
       TimeoutErrorRetries: 3
+  retry:
+    jitter: true           # equal jitter (AWS pattern): sleep = base/2 + uniform(0, base/2)
+    respect_retry_after: true  # honour provider Retry-After header (capped at max_backoff)
 ```
 
 ### `llm.router` fields
@@ -342,6 +338,22 @@ On the Router path, retry count is **config-only**: `num_retries` is taken from
 `llm.router.num_retries` (a per-call `max_retries` is not applied), so the retry
 budget has a single source. (On the direct, non-Router path the per-call
 `max_retries` is unchanged.)
+
+### `llm.retry` fields (#1835)
+
+Controls the **timing** of the Reyn self-retry layer only (semantic-retry
+behaviours — EmptyLLMResponseError, empty\_stop\_retry, plan\_invalid\_retry,
+compaction shrink — are unaffected). Both defaults are `true`.
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `jitter` | bool | `true` | Apply equal jitter (AWS pattern): `sleep = base/2 + uniform(0, base/2)` where `base = min(base_s * 2**attempt, max_backoff)`. Range `[base/2, base]`. Prevents thundering herd when parallel chains retry in lockstep. `false` → pure exponential (2 s, 4 s, 8 s, 16 s). |
+| `respect_retry_after` | bool | `true` | When a retryable exception carries a `Retry-After` header (delta-seconds **or** HTTP-date), honour it (capped at `_LLM_RETRY_MAX_BACKOFF_S` = 16 s) **instead of** the jittered backoff. Falls back to jittered backoff when the header is absent or unparseable. `false` → always use jittered backoff. |
+
+> **Router path**: when `llm.router.use: true`, the litellm.Router owns
+> infra-exception retry with its own `Retry-After` respect. The `llm.retry`
+> fields only apply to the Reyn self-retry layer (= the direct, non-Router path,
+> plus `EmptyLLMResponseError` on both paths). See the `llm.router` block above.
 
 ## `chat` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -100,6 +100,12 @@
 #       TimeoutErrorRetries: 3
 #       # Supported: BadRequestErrorRetries, AuthenticationErrorRetries,
 #       #   ContentPolicyViolationErrorRetries, InternalServerErrorRetries
+#   retry:                   # backoff timing for the Reyn self-retry layer (#1835)
+#     jitter: true           # equal jitter (AWS): sleep=base/2+uniform(0,base/2).
+#                            # Prevents thundering herd on parallel-chain retries.
+#     respect_retry_after: true  # honour provider Retry-After header on 429/503.
+#                            # Caps the wait at llm_retry_max_backoff (16 s).
+#                            # Falls back to jittered backoff when header absent.
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -101,10 +101,46 @@ class RouterConfig:
 
 
 @dataclass
+class RetryConfig:
+    """``llm.retry:`` — backoff timing for the Reyn self-retry layer (#1835).
+
+    Controls TIMING only; semantic-retry behaviours (EmptyLLMResponseError,
+    empty_stop_retry, plan_invalid_retry, compaction shrink) are unaffected.
+
+    ``jitter=true`` (default): equal jitter (AWS pattern) —
+      ``sleep = backoff/2 + uniform(0, backoff/2)``
+      where ``backoff = min(base * 2**attempt, max_backoff)``.
+      Prevents thundering herd when parallel chains retry in lockstep.
+
+    ``respect_retry_after=true`` (default): when a retryable exception carries
+      a ``Retry-After`` header (delta-seconds or HTTP-date), honour it (capped
+      at ``_LLM_RETRY_MAX_BACKOFF_S``) instead of the computed jittered backoff.
+      Lets the provider's guidance drive wait time on 429/503 responses.
+    """
+
+    jitter: bool = True
+    respect_retry_after: bool = True
+
+
+@dataclass
 class LLMConfig:
-    """``llm:`` — LLM-layer config. Currently the litellm.Router surface (#1829)."""
+    """``llm:`` — LLM-layer config (#1829 router, #1835 retry)."""
 
     router: RouterConfig = field(default_factory=RouterConfig)
+    retry: RetryConfig = field(default_factory=RetryConfig)
+
+
+def _build_retry_config(raw: object) -> RetryConfig:
+    """Parse ``llm.retry:`` from reyn.yaml. None/missing → defaults (both true)."""
+    if raw is None:
+        return RetryConfig()
+    if not isinstance(raw, dict):
+        raise ValueError(f"llm.retry must be a mapping, got {type(raw).__name__}")
+    d = RetryConfig()
+    return RetryConfig(
+        jitter=bool(raw.get("jitter", d.jitter)),
+        respect_retry_after=bool(raw.get("respect_retry_after", d.respect_retry_after)),
+    )
 
 
 def _build_router_config(raw: object) -> RouterConfig:
@@ -165,7 +201,10 @@ def _build_llm_config(raw: object) -> LLMConfig:
         return LLMConfig()
     if not isinstance(raw, dict):
         raise ValueError(f"llm must be a mapping, got {type(raw).__name__}")
-    return LLMConfig(router=_build_router_config(raw.get("router")))
+    return LLMConfig(
+        router=_build_router_config(raw.get("router")),
+        retry=_build_retry_config(raw.get("retry")),
+    )
 
 
 @dataclass

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -83,6 +83,7 @@ class OSRuntime:
         task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker → control-IR + preprocessor op ctx
         task_session_id: "str | None" = None,  # #1953 slice 3: caller session identity (Task single-writer key)
         router_config: "object | None" = None,  # #1829 S3b: reyn.yaml llm.router.*
+        retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.*
         environment_backend: "EnvironmentBackend | None" = None,
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
@@ -124,6 +125,11 @@ class OSRuntime:
         if router_config is not None:
             from reyn.llm.llm import set_router_config
             set_router_config(router_config)
+        # #1835: publish reyn.yaml llm.retry.* for the LLM retry chokepoint. Same
+        # guard: only set when provided to avoid clobbering the parent's ContextVar.
+        if retry_config is not None:
+            from reyn.llm.llm import set_retry_config
+            set_retry_config(retry_config)
         self.workspace = Workspace(
             self.events,
             permission_resolver=permission_resolver,

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -221,6 +221,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
                 embedding_config=session_cfg.config.embedding,
                 router_config=session_cfg.config.llm.router,  # #1829 S3b
+                retry_config=session_cfg.config.llm.retry,  # #1835
                 agent_id=session_cfg.config.agent.id,
                 # #1402: scoped surface passed EXPLICITLY (required by
                 # build_scoped_chat_session). chainlit's current behaviour

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -462,6 +462,7 @@ def run(args: argparse.Namespace) -> None:
             chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
             router_config=session_cfg.config.llm.router,  # #1829 S3b
+            retry_config=session_cfg.config.llm.retry,  # #1835
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -489,6 +489,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # the same ws_base_dir/ws_state_dir pattern.
                 embedding_config=None,  # gap: dogfood omitted embedding_config (had action_retrieval but not its sibling) → preserved as None
                 router_config=config.llm.router,  # #1829 S3b
+                retry_config=config.llm.retry,  # #1835
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -432,6 +432,7 @@ def run_serve(args: argparse.Namespace) -> None:
             chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
             embedding_config=session_cfg.config.embedding,
             router_config=session_cfg.config.llm.router,  # #1829 S3b
+            retry_config=session_cfg.config.llm.retry,  # #1835
             # #1402: scoped capability surface, passed EXPLICITLY (required by
             # build_scoped_chat_session). The stdio-MCP factory's current
             # behaviour — defaults that document the gaps, NOT new capabilities

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -338,6 +338,7 @@ def _get_registry():
                 chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
                 embedding_config=config.embedding,
                 router_config=config.llm.router,  # #1829 S3b
+                retry_config=config.llm.retry,  # #1835
                 eager_embedding_build=_eager_embedding_build,
                 # #1401: the 3 scoped capabilities, filled from the CLI override
                 # holder (env-backend INSTANCE → both FS+exec seams = single-shared

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -3,12 +3,14 @@ import contextvars
 import json
 import logging
 import os
+import random
 import re
 import sys
 import uuid
 import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Coroutine, TypeVar, Union
 
 import httpx
@@ -606,6 +608,38 @@ def _use_llm_router() -> bool:
     return bool(_resolved_router_config().use)
 
 
+# #1835: ambient retry config (jitter + respect_retry_after). The runtime/session
+# sets this at construction via ``set_retry_config`` (mirrors set_router_config).
+# Default=None → env-fallback defaults (both features ON). The ContextVar scope
+# ensures per-task isolation under pytest-asyncio per-test event loops.
+_retry_config_var: "contextvars.ContextVar[object | None]" = contextvars.ContextVar(
+    "reyn_llm_retry_config", default=None,
+)
+
+
+def set_retry_config(cfg: object) -> "contextvars.Token":
+    """#1835: publish the ambient ``RetryConfig`` (reyn.yaml ``llm.retry.*``).
+
+    The runtime/session sets this at construction; mirrors ``set_router_config``.
+    Returns the token so a caller MAY reset for a nested scope. ``None`` → defaults.
+    """
+    return _retry_config_var.set(cfg)
+
+
+def _resolved_retry_config():
+    """#1835: single-source effective ``RetryConfig``.
+
+    reyn.yaml ``llm.retry.*`` (via the ContextVar) is authoritative; absent →
+    default (both jitter and respect_retry_after ON). The ONLY place retry timing
+    config is resolved — ``_backoff_s`` and ``_llm_call_with_retry`` read this.
+    """
+    cfg = _retry_config_var.get()
+    if cfg is not None:
+        return cfg
+    from reyn.config.infra import RetryConfig
+    return RetryConfig()
+
+
 # #1868: ambient budget-limit policy context for the per-LLM-call cost gate. The
 # runtime/session sets (bus, on_limit, run_id, non_interactive) here at the same
 # place it binds the limit framework (mirrors set_llm_request_event_log /
@@ -717,23 +751,97 @@ def _is_retryable_exc(exc: BaseException) -> bool:
 
 
 def _backoff_s(attempt: int) -> float:
-    """Exponential backoff: 2s, 4s, 8s, … capped at _LLM_RETRY_MAX_BACKOFF_S.
+    """Exponential backoff with optional equal jitter (#1835), capped at max.
 
-    ``attempt`` is 0-indexed (= attempt 0 is the first retry, after the initial
-    call fails).  Min 0.0 — never negative if someone passes a negative index.
+    When ``llm.retry.jitter`` is true (default), applies AWS-style equal jitter:
+      ``sleep = base/2 + uniform(0, base/2)`` (range: [base/2, base]).
+    When false, returns pure exponential (legacy: 2s, 4s, 8s, 16s).
+
+    ``attempt`` is 0-indexed (attempt 0 = first retry, after initial call fails).
+    Min 0.0 — never negative on a negative index.
     """
-    return min(_LLM_RETRY_BASE_S * (2 ** attempt), _LLM_RETRY_MAX_BACKOFF_S)
+    base = min(_LLM_RETRY_BASE_S * (2 ** attempt), _LLM_RETRY_MAX_BACKOFF_S)
+    if _resolved_retry_config().jitter:
+        # Equal jitter: half fixed + half random. Range [base/2, base].
+        return base / 2 + random.uniform(0, base / 2)
+    return base
+
+
+def _extract_retry_after(exc: BaseException) -> float | None:
+    """#1835: extract the ``Retry-After`` wait (seconds) from a retryable exception.
+
+    Checks (in order, defensive at each step — an unparseable value is ignored):
+      1. ``exc.response.headers["retry-after"]`` — the canonical HTTP location.
+         litellm wraps provider responses as ``httpx.Response``; the header is
+         present on 429 / 503 replies that carry it.
+      2. ``exc.headers`` — a secondary attr some litellm exception shapes expose
+         (not present in current litellm, but defensive probe costs nothing).
+
+    ``Retry-After`` value formats (RFC 7231):
+      - Delta-seconds (e.g. ``"30"`` → 30.0 s).
+      - HTTP-date (e.g. ``"Sat, 21 Jun 2026 12:00:00 GMT"`` → computed delta).
+        Negative deltas (date in the past) are clamped to 0.
+
+    Returns the wait in seconds, capped at ``_LLM_RETRY_MAX_BACKOFF_S``, or
+    ``None`` when no parseable ``Retry-After`` is found (caller falls back to
+    jittered backoff).  Never raises — unparseable values are silently ignored.
+    """
+    # Gather candidate header dicts (response.headers takes priority).
+    header_dicts: list = []
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            header_dicts.append(headers)
+    exc_headers = getattr(exc, "headers", None)
+    if exc_headers is not None:
+        header_dicts.append(exc_headers)
+
+    for headers in header_dicts:
+        try:
+            raw = headers.get("retry-after") or headers.get("Retry-After")
+        except Exception:
+            continue
+        if not raw:
+            continue
+        try:
+            # Try delta-seconds first (most common: "30", "120").
+            delta = float(raw)
+            return min(max(0.0, delta), _LLM_RETRY_MAX_BACKOFF_S)
+        except (ValueError, TypeError):
+            pass
+        try:
+            # Try HTTP-date ("Sat, 21 Jun 2026 12:00:00 GMT").
+            dt = parsedate_to_datetime(raw)
+            delta = (dt - datetime.now(UTC)).total_seconds()
+            return min(max(0.0, delta), _LLM_RETRY_MAX_BACKOFF_S)
+        except Exception:
+            pass
+    return None
 
 
 async def _llm_call_with_retry(
     coro_fn,
     model: str,
     event_log: "EventLog | None",
+    *,
+    sleep_fn=None,
 ) -> object:
     """Execute ``coro_fn()`` with infrastructure-error retry + backoff.
 
     ``coro_fn`` must be a zero-arg async callable that returns the litellm
     response object.  It is called once per attempt.
+
+    ``sleep_fn`` is an injectable async sleep callable (default: ``asyncio.sleep``).
+    Tests pass a recording shim here to capture actual sleep durations without
+    mocking — the default is preserved in production so behaviour is unchanged.
+
+    Backoff timing (#1835):
+      - ``llm.retry.jitter=true`` (default): equal jitter (AWS pattern):
+        ``sleep = base/2 + uniform(0, base/2)`` where ``base = min(base_s * 2**attempt, max_s)``.
+      - ``llm.retry.respect_retry_after=true`` (default): when a retryable exception
+        carries a ``Retry-After`` header, honour it (capped at max_backoff) INSTEAD
+        of the jittered backoff.
 
     Emits ``llm_call_retry`` on each retry and ``llm_call_retry_exhausted``
     when all attempts are exhausted.  When ``event_log`` is None, observability
@@ -741,6 +849,8 @@ async def _llm_call_with_retry(
 
     Raises the last exception when all retries are exhausted.
     """
+    if sleep_fn is None:
+        sleep_fn = asyncio.sleep
     last_exc: BaseException | None = None
     for attempt in range(_LLM_RETRY_MAX_ATTEMPTS):
         try:
@@ -794,7 +904,15 @@ async def _llm_call_with_retry(
                     except Exception:
                         pass
                 raise
-            backoff = _backoff_s(attempt)
+            # #1835: Retry-After takes priority over jittered backoff when
+            # respect_retry_after is enabled (default true) and the exception
+            # carries a parseable Retry-After header. Falls back to _backoff_s
+            # (which applies equal jitter when jitter=true, default).
+            retry_cfg = _resolved_retry_config()
+            retry_after = (
+                _extract_retry_after(exc) if retry_cfg.respect_retry_after else None
+            )
+            backoff = retry_after if retry_after is not None else _backoff_s(attempt)
             if event_log is not None:
                 try:
                     event_log.emit(
@@ -806,7 +924,7 @@ async def _llm_call_with_retry(
                     )
                 except Exception:
                     pass
-            await asyncio.sleep(backoff)
+            await sleep_fn(backoff)
     # Should be unreachable — loop always raises or returns.
     assert last_exc is not None
     raise last_exc  # pragma: no cover

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -68,6 +68,7 @@ def build_scoped_chat_session(
     action_retrieval_config: Any,  # ActionRetrievalConfig | None
     embedding_config: Any,  # EmbeddingConfig | None
     router_config: Any,  # #1829 S3b RouterConfig | None — reyn.yaml llm.router.*
+    retry_config: Any,  # #1835 RetryConfig | None — reyn.yaml llm.retry.*
     tool_calls_op_loop_skills: list[str] | None,  # #1212 op-loop gate
     chat_tool_use_scheme: str,  # #1593 PR-2 config.tool_use.chat — chat-layer ToolUseScheme name (UNIFORM: every frontend resolves the same reyn.yaml value)
     # ── common base (pass-through; session identity/infra, not a drift surface) ──
@@ -126,6 +127,7 @@ def build_scoped_chat_session(
         action_retrieval_config=action_retrieval_config,
         embedding_config=embedding_config,
         router_config=router_config,
+        retry_config=retry_config,  # #1835
         tool_calls_op_loop_skills=tool_calls_op_loop_skills,
         chat_tool_use_scheme=chat_tool_use_scheme,
         **base,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -816,6 +816,7 @@ class Session:
         # the chokepoint's env+default fallback (back-compat). Skill OSRuntimes
         # spawned within this session inherit the ContextVar (propagation).
         router_config: "RouterConfig | None" = None,
+        retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.* timing config
         tool_calls_op_loop_skills: list[str] | None = None,  # #1212: op-loop gate for chat-run skills
         agent_id: str | None = None,
         exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
@@ -1285,6 +1286,11 @@ class Session:
         if router_config is not None:
             from reyn.llm.llm import set_router_config
             set_router_config(router_config)
+        # #1835: publish reyn.yaml llm.retry.* as the ambient retry timing config.
+        # Same guard as router_config.
+        if retry_config is not None:
+            from reyn.llm.llm import set_retry_config
+            set_retry_config(retry_config)
         # #1868: publish the budget-exceed policy context for the chat path's
         # per-LLM-call cost gate (call_llm / call_llm_tools). Reuses safety.on_limit
         # (one unified limit policy) + the SAME intervention path the chat-side

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -48,9 +48,7 @@ from reyn.core.events.events import EventLog
 from reyn.llm.llm import (
     _LLM_RETRY_BASE_S,
     _LLM_RETRY_MAX_ATTEMPTS,
-    _LLM_RETRY_MAX_BACKOFF_S,
     EmptyLLMResponseError,
-    _backoff_s,
     _empty_response_diag,
     _env_num,
     _is_retryable_exc,
@@ -235,10 +233,17 @@ async def test_retry_and_succeed(monkeypatch):
     assert ev.data["model"] == "test-model"
     assert ev.data["error_kind"] == "Timeout"
     assert ev.data["attempt_n"] == 1
-    assert ev.data["backoff_s"] == _backoff_s(0)
+    # #1835: jitter is default-ON — the emitted backoff_s and the sleep duration are
+    # independently drawn from [base/2, base] = [1.0, 2.0] for attempt 0 (base=2.0),
+    # so exact-value equality would be non-deterministic. Assert the range instead.
+    assert 1.0 <= ev.data["backoff_s"] <= 2.0, (
+        f"backoff_s for attempt 0 must be in [1.0, 2.0] (jitter range), got {ev.data['backoff_s']}"
+    )
 
-    # Sleep called once with the correct backoff
-    assert slept == [_backoff_s(0)]
+    # Sleep called exactly once (one retry); with jitter the value is in [1.0, 2.0].
+    # Use unpack to assert exactly-one-element rather than len() (pin behavior not size).
+    (sleep_val,) = slept
+    assert 1.0 <= sleep_val <= 2.0, f"sleep duration must be in [1.0, 2.0], got {sleep_val}"
 
 
 # ---------------------------------------------------------------------------
@@ -312,38 +317,11 @@ async def test_4xx_no_retry(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 5: backoff shape
+# Test 5: backoff shape — removed (covered by test_backoff_s_jitter_off_is_pure_exponential
+# in test_llm_retry_jitter_retry_after_1835.py, which tests jitter=off for the pure
+# exponential curve including the cap-at-16 assertion; #1835 made jitter default-ON so
+# exact-value assertions here would be non-deterministic).
 # ---------------------------------------------------------------------------
-
-
-def test_backoff_shape():
-    """Tier 2: _backoff_s — exponential curve capped at max.
-
-    Verifies the mathematical shape without relying on exact constants so a
-    future config change doesn't silently break the invariant.
-    """
-    # Monotonically increasing up to the cap
-    b0 = _backoff_s(0)
-    b1 = _backoff_s(1)
-    b2 = _backoff_s(2)
-    b3 = _backoff_s(3)
-
-    assert b0 > 0, "first backoff must be positive"
-    assert b1 > b0, "second backoff must be larger than first"
-    assert b2 > b1, "third backoff must be larger than second"
-
-    # Each step doubles up to the cap
-    assert b1 == min(b0 * 2, _LLM_RETRY_MAX_BACKOFF_S)
-    assert b2 == min(b0 * 4, _LLM_RETRY_MAX_BACKOFF_S)
-
-    # Cap is respected
-    assert b3 <= _LLM_RETRY_MAX_BACKOFF_S
-
-    # Concrete values (documentation + regression guard against constant changes)
-    assert b0 == _LLM_RETRY_BASE_S
-    assert b1 == _LLM_RETRY_BASE_S * 2
-    assert b2 == _LLM_RETRY_BASE_S * 4
-
 
 # ---------------------------------------------------------------------------
 # Test 6: httpx transport errors retried

--- a/tests/test_llm_retry_jitter_retry_after_1835.py
+++ b/tests/test_llm_retry_jitter_retry_after_1835.py
@@ -1,0 +1,317 @@
+"""Tier 2: OS-invariant tests for #1835 — jitter + Retry-After in the LLM self-retry layer.
+
+Pinned invariants:
+
+- ``_backoff_s`` with jitter=true produces sleep times in ``[base/2, base]``
+  and NOT all equal to the pure-exponential value (= jitter is actually applied,
+  not a no-op). base = min(2.0 * 2**attempt, 16.0).
+- ``_backoff_s`` with jitter=false returns the pure-exponential value (2s, 4s,
+  8s, 16s) — behaviour is preserved as opt-out.
+- ``_extract_retry_after`` parses delta-seconds and HTTP-date forms of the
+  ``Retry-After`` header from a real httpx.Response on a real litellm exception.
+- ``_extract_retry_after`` returns None when no header is present.
+- ``_extract_retry_after`` caps at ``_LLM_RETRY_MAX_BACKOFF_S``.
+- ``_llm_call_with_retry`` with respect_retry_after=true uses the parsed
+  Retry-After value (not jittered backoff) when the exception carries a header.
+- ``_llm_call_with_retry`` with respect_retry_after=false ignores the header
+  and uses jittered backoff instead.
+
+Testing policy compliance (testing.ja.md):
+- sleep_fn is an injectable parameter on ``_llm_call_with_retry`` — a real
+  callable seam (not a mock). The shim records durations; calling convention
+  matches asyncio.sleep exactly.
+- Exceptions are constructed as real litellm / httpx objects (not mocks).
+  A real httpx.Response carries the Retry-After header so _extract_retry_after
+  can access it via exc.response.headers — the real chain.
+- No MagicMock / AsyncMock / patch. The retry_config ContextVar is set /
+  cleared with the real set_retry_config + ContextVar.reset() seam.
+- Private state is NOT asserted. The test observes recorded sleep durations
+  (the public side-effect of the retry) and return values.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+from email.utils import format_datetime
+from typing import Any
+
+import httpx
+import litellm
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.infra import RetryConfig
+from reyn.llm.llm import (
+    _LLM_RETRY_MAX_BACKOFF_S,
+    _backoff_s,
+    _extract_retry_after,
+    _llm_call_with_retry,
+    _retry_config_var,
+    set_retry_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _RecordingSleep:
+    """Callable shim for sleep_fn= injection.
+
+    Records each requested duration so tests can assert on what durations
+    were passed.  Returns immediately so tests don't actually wait.
+    Matches the asyncio.sleep(delay) signature (a single positional arg).
+    """
+
+    def __init__(self) -> None:
+        self.durations: list[float] = []
+
+    async def __call__(self, delay: float) -> None:  # noqa: D105
+        self.durations.append(delay)
+
+
+def _make_exc_with_retry_after(header_value: str, status: int = 503):
+    """Real litellm exception carrying a Retry-After header on a real httpx.Response."""
+    response = httpx.Response(
+        status_code=status,
+        headers={"retry-after": header_value},
+        text="service unavailable",
+    )
+    return litellm.exceptions.ServiceUnavailableError(
+        message="503 test",
+        response=response,
+        llm_provider="openai",
+        model="openai/gpt-4o-mini",
+    )
+
+
+def _make_exc_no_retry_after(status: int = 503):
+    """Real litellm exception with no Retry-After header."""
+    response = httpx.Response(
+        status_code=status,
+        text="service unavailable",
+    )
+    return litellm.exceptions.ServiceUnavailableError(
+        message="503 test",
+        response=response,
+        llm_provider="openai",
+        model="openai/gpt-4o-mini",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_retry_config():
+    """Restore the retry_config ContextVar to None after each test."""
+    token = _retry_config_var.set(None)
+    yield
+    _retry_config_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# _backoff_s — jitter on/off
+# ---------------------------------------------------------------------------
+
+def test_backoff_s_jitter_on_stays_within_bounds():
+    """Tier 2: _backoff_s with jitter=true stays within [base/2, base].
+
+    Verifies the equal-jitter bound holds for all 4 exponential steps.
+    We run 20 samples per step to get statistical confidence that the
+    range constraint is not accidentally met by a single draw.
+    """
+    set_retry_config(RetryConfig(jitter=True, respect_retry_after=False))
+    for attempt in range(4):  # 0→2s, 1→4s, 2→8s, 3→16s
+        base = min(2.0 * (2 ** attempt), 16.0)
+        lo, hi = base / 2, base
+        for _ in range(20):
+            s = _backoff_s(attempt)
+            assert lo <= s <= hi, (
+                f"attempt={attempt}: sleep={s:.4f} outside [{lo:.2f}, {hi:.2f}]"
+            )
+
+
+def test_backoff_s_jitter_on_not_all_identical():
+    """Tier 2: _backoff_s with jitter=true produces non-constant values.
+
+    With 50 samples the probability that all land on the same float by
+    chance is negligible — if jitter were a no-op, all values would be
+    the pure-exponential constant and this assertion would fail.
+    """
+    set_retry_config(RetryConfig(jitter=True, respect_retry_after=False))
+    samples = [_backoff_s(0) for _ in range(50)]
+    assert len(set(samples)) > 1, (
+        "All 50 samples of _backoff_s(0) were identical — jitter is a no-op"
+    )
+
+
+def test_backoff_s_jitter_off_is_pure_exponential():
+    """Tier 2: _backoff_s with jitter=false returns exact exponential values.
+
+    Preserves the pre-#1835 behaviour when the operator opts out of jitter.
+    """
+    set_retry_config(RetryConfig(jitter=False, respect_retry_after=False))
+    assert _backoff_s(0) == 2.0
+    assert _backoff_s(1) == 4.0
+    assert _backoff_s(2) == 8.0
+    assert _backoff_s(3) == 16.0   # capped at max
+
+
+# ---------------------------------------------------------------------------
+# _extract_retry_after — header parsing
+# ---------------------------------------------------------------------------
+
+def test_extract_retry_after_delta_seconds():
+    """Tier 2: _extract_retry_after parses delta-seconds from exc.response.headers.
+
+    Uses 7 seconds — well below the 16 s cap — so the raw parsed value is
+    returned unmodified (cap does not mask the parsing result).
+    """
+    exc = _make_exc_with_retry_after("7")
+    result = _extract_retry_after(exc)
+    assert result == pytest.approx(7.0)
+
+
+def test_extract_retry_after_delta_seconds_capped():
+    """Tier 2: _extract_retry_after caps the value at _LLM_RETRY_MAX_BACKOFF_S."""
+    exc = _make_exc_with_retry_after("999")
+    result = _extract_retry_after(exc)
+    assert result == pytest.approx(_LLM_RETRY_MAX_BACKOFF_S)
+
+
+def test_extract_retry_after_http_date_future():
+    """Tier 2: _extract_retry_after parses HTTP-date and computes positive delta."""
+    # Use a date far in the future (2099) so the delta is always positive.
+    future = datetime.datetime(2099, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    header_val = format_datetime(future, usegmt=True)
+    exc = _make_exc_with_retry_after(header_val)
+    result = _extract_retry_after(exc)
+    # The delta is a large positive number; cap is 16.0.
+    assert result == pytest.approx(_LLM_RETRY_MAX_BACKOFF_S)
+
+
+def test_extract_retry_after_http_date_past_clamps_zero():
+    """Tier 2: _extract_retry_after clamps negative HTTP-date deltas to 0."""
+    past = datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    header_val = format_datetime(past, usegmt=True)
+    exc = _make_exc_with_retry_after(header_val)
+    result = _extract_retry_after(exc)
+    assert result == pytest.approx(0.0)
+
+
+def test_extract_retry_after_no_header_returns_none():
+    """Tier 2: _extract_retry_after returns None when no Retry-After header."""
+    exc = _make_exc_no_retry_after()
+    result = _extract_retry_after(exc)
+    assert result is None
+
+
+def test_extract_retry_after_unparseable_returns_none():
+    """Tier 2: _extract_retry_after ignores unparseable header values."""
+    exc = _make_exc_with_retry_after("not-a-number-or-date")
+    result = _extract_retry_after(exc)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _llm_call_with_retry — integration of jitter + Retry-After via sleep_fn seam
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_retry_uses_retry_after_when_header_present():
+    """Tier 2: retry loop honours Retry-After header when respect_retry_after=true.
+
+    Constructs a real ServiceUnavailableError with Retry-After: 7 on a real
+    httpx.Response. The first call raises it; the second succeeds (simulates a
+    transient 503). The recorded sleep must be ~7 (within float tolerance) and
+    NOT the jittered exponential (which for attempt=0 would be in [1.0, 2.0]).
+    """
+    set_retry_config(RetryConfig(jitter=True, respect_retry_after=True))
+    exc = _make_exc_with_retry_after("7")
+
+    # A real mock-free callable sequence: first call raises, second returns.
+    class _FakeResponse:
+        choices = [object()]  # non-empty → not EmptyLLMResponseError
+
+    calls = [0]
+
+    async def _coro_fn() -> Any:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise exc
+        return _FakeResponse()
+
+    recorder = _RecordingSleep()
+    result = await _llm_call_with_retry(
+        _coro_fn, model="test-model", event_log=None, sleep_fn=recorder
+    )
+    assert result is not None
+    # One retry occurred (first call failed, second succeeded) → one sleep was recorded.
+    assert recorder.durations, "expected at least one sleep from the retry"
+    # The sleep value must come from the Retry-After header (7 s), not jittered backoff.
+    assert recorder.durations[-1] == pytest.approx(7.0, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_retry_uses_jittered_backoff_when_no_header():
+    """Tier 2: retry loop uses jittered backoff when no Retry-After header.
+
+    The first call raises a real ServiceUnavailableError with no header.
+    The recorded sleep must fall in [1.0, 2.0] (= [base/2, base] for attempt=0,
+    base=2.0) — NOT the exact pure-exponential 2.0.
+    """
+    set_retry_config(RetryConfig(jitter=True, respect_retry_after=True))
+    exc = _make_exc_no_retry_after()
+
+    class _FakeResponse:
+        choices = [object()]
+
+    calls = [0]
+
+    async def _coro_fn() -> Any:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise exc
+        return _FakeResponse()
+
+    recorder = _RecordingSleep()
+    await _llm_call_with_retry(
+        _coro_fn, model="test-model", event_log=None, sleep_fn=recorder
+    )
+    assert recorder.durations, "expected at least one sleep from the retry"
+    s = recorder.durations[-1]
+    assert 1.0 <= s <= 2.0, (
+        f"Expected jittered sleep in [1.0, 2.0] for attempt=0, got {s:.4f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_ignores_retry_after_when_disabled():
+    """Tier 2: retry loop ignores Retry-After header when respect_retry_after=false.
+
+    The exception carries Retry-After: 99. With respect_retry_after=false and
+    jitter=false, the sleep must be the pure-exponential 2.0 (attempt=0),
+    NOT 99.
+    """
+    set_retry_config(RetryConfig(jitter=False, respect_retry_after=False))
+    exc = _make_exc_with_retry_after("99")
+
+    class _FakeResponse:
+        choices = [object()]
+
+    calls = [0]
+
+    async def _coro_fn() -> Any:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise exc
+        return _FakeResponse()
+
+    recorder = _RecordingSleep()
+    await _llm_call_with_retry(
+        _coro_fn, model="test-model", event_log=None, sleep_fn=recorder
+    )
+    assert recorder.durations, "expected at least one sleep from the retry"
+    # Must be the pure-exponential 2.0 (attempt=0), NOT the 99 s from the header.
+    assert recorder.durations[-1] == pytest.approx(2.0)  # pure-exponential attempt=0


### PR DESCRIPTION
**[per-PR-coder]** — Implements #1835: adds equal jitter (AWS pattern) and Retry-After header honouring to `_llm_call_with_retry` in `src/reyn/llm/llm.py`.

Fixes #1835

## Summary

- **Jitter** (`llm.retry.jitter`, default `true`): equal jitter — `sleep = base/2 + uniform(0, base/2)` where `base = min(2.0 * 2**attempt, 16.0)`. Prevents thundering herd when parallel chains retry in lockstep.
- **Retry-After** (`llm.retry.respect_retry_after`, default `true`): when a retryable exception carries a `Retry-After` header (delta-seconds or HTTP-date), honours it (capped at 16 s) instead of the jittered backoff. Extracted via `exc.response.headers` (real httpx.Response chain).
- **Config-overridable**: new `RetryConfig` dataclass in `src/reyn/config/infra.py`, parsed as `llm.retry.*` from reyn.yaml. Threaded via a ContextVar (`_retry_config_var` / `set_retry_config`) — same pattern as `_router_config_var` (#1829). Wired in `runtime.py`, `session.py`, `scoped_session_factory.py`, and all 4 frontend call-sites (cli/chat, cli/dogfood, cli/mcp, chainlit, web).
- **`sleep_fn` injectable seam** added to `_llm_call_with_retry` (default `asyncio.sleep`) so tests record sleep durations without any mock.
- **Docs**: `docs/reference/config/reyn-yaml.md` + `reyn.local.yaml.example` updated (config-mirror gate satisfied).
- **Scope preserved**: only backoff TIMING is changed. Semantic-retry behaviours (EmptyLLMResponseError, empty_stop_retry, plan_invalid_retry, compaction shrink) are untouched.

## Files changed

- `src/reyn/llm/llm.py` — `_backoff_s` (jitter), `_extract_retry_after` (new), `_llm_call_with_retry` (sleep_fn seam, Retry-After logic), `_retry_config_var` / `set_retry_config` / `_resolved_retry_config` (new)
- `src/reyn/config/infra.py` — `RetryConfig` + `_build_retry_config` + `LLMConfig` update
- `src/reyn/core/kernel/runtime.py` — `retry_config` param + `set_retry_config` wiring
- `src/reyn/runtime/session.py` — same
- `src/reyn/runtime/scoped_session_factory.py` — same
- `src/reyn/interfaces/cli/commands/chat.py` — pass `llm.retry`
- `src/reyn/interfaces/cli/commands/dogfood.py` — same
- `src/reyn/interfaces/cli/commands/mcp.py` — same
- `src/reyn/interfaces/chainlit_app/app.py` — same
- `src/reyn/interfaces/web/deps.py` — same
- `reyn.local.yaml.example` — `llm.retry` block
- `docs/reference/config/reyn-yaml.md` — `llm.retry` section + fields table
- `tests/test_llm_retry_jitter_retry_after_1835.py` — 12 Tier 2 tests

## Test plan

- [x] `ruff check src tests --fix` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_retry_jitter_retry_after_1835.py` — 12/12 OK, 0 errors
- [x] `pytest tests/test_llm_retry_jitter_retry_after_1835.py -v` — 12 passed
- [x] (skipped — no live LLM in sandbox) dogfood smoke: verify jitter produces non-constant sleeps on a real 503 replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)