### PR TITLE
fix(#1972): connect-time IP-pinning for full DNS-rebind resistance (both clients)

### DIFF
--- a/src/reyn/_ssrf_guard.py
+++ b/src/reyn/_ssrf_guard.py
@@ -26,9 +26,14 @@ Policy (lead-approved, #1956):
 Resolution is DNS-aware: the host is resolved and EVERY returned IP is checked
 (deny if ANY is denied), so an allowlisted hostname that resolves to an internal
 IP is caught. IPv4-mapped IPv6 (``::ffff:a.b.c.d``) is normalised so a mapped
-metadata/internal address cannot bypass. Residual: the client re-resolves at
-connect (a small TOCTOU window vs full IP-pinning) — tracked separately as
-future hardening.
+metadata/internal address cannot bypass.
+
+#1972 (full DNS-rebind resistance): :func:`resolve_and_validate` returns the
+validated IPs so each redirect-following client connects to a **pinned** IP
+(preserving the original ``Host`` header + TLS SNI) instead of re-resolving the
+host at connect time — closing the check-time-vs-connect-time TOCTOU window an
+attacker-controlled fast-rebind DNS could exploit. ``assert_fetch_host_allowed``
+remains the check-only Layer-2 gate (it delegates to ``resolve_and_validate``).
 """
 from __future__ import annotations
 
@@ -87,13 +92,27 @@ def _deny_reason(ip: _IPAddr, *, allow_private: bool) -> str | None:
     return None
 
 
-def assert_fetch_host_allowed(host: str, *, allow_private: bool) -> None:
-    """Raise :class:`SSRFBlocked` if ``host`` resolves to any denied IP.
+def resolve_and_validate(host: str, *, allow_private: bool) -> list[str]:
+    """Resolve + validate ``host`` and RETURN its allowed IPs, for connect-time
+    IP-pinning (#1972 — full DNS-rebind resistance).
 
-    A bare IP literal is checked directly (the common redirect-to-IP attack).
-    A hostname is resolved and EVERY returned address is checked (deny if ANY is
-    denied). An unresolvable host is left to the client's own connection error
-    (nothing to gate — no reachable IP). Empty host is denied.
+    Same policy as :func:`assert_fetch_host_allowed` (raise :class:`SSRFBlocked`
+    if ANY resolved IP is denied), but it RETURNS the validated IP strings so the
+    caller can connect to a **pinned** IP instead of letting the HTTP client
+    re-resolve at connect time — closing the DNS-rebind TOCTOU window (an
+    attacker-controlled DNS returning a public IP to our check and an internal IP
+    to the client's connect).
+
+    - A bare IP literal → validated and returned as ``[host]`` (it IS the
+      connect target; no DNS involved).
+    - A hostname → resolved; EVERY returned IP validated (deny if ANY is denied);
+      ALL validated IPs returned, de-duplicated in resolution order (the caller
+      pins to one — typically the first — and preserves the original host for the
+      ``Host`` header + TLS SNI).
+    - Unresolvable → ``[]`` (no IP to pin; the caller falls back to its normal
+      connect, which surfaces the real DNS/connection error — same non-gating
+      behaviour as ``assert_fetch_host_allowed``).
+    - Empty host → denied.
     """
     if not host:
         raise SSRFBlocked("blocked fetch: empty host")
@@ -105,18 +124,37 @@ def assert_fetch_host_allowed(host: str, *, allow_private: bool) -> None:
         reason = _deny_reason(literal, allow_private=allow_private)
         if reason is not None:
             raise SSRFBlocked(f"blocked fetch to {host} ({reason})")
-        return
+        return [host]
     try:
         infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
-        # Unresolvable here → no IP to gate; let the client surface its own
-        # DNS/connection failure rather than mislabelling it as an SSRF block.
-        return
+        # Unresolvable here → no IP to gate or pin; let the client surface its
+        # own DNS/connection failure rather than mislabelling it as an SSRF block.
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
     for info in infos:
-        ip = ipaddress.ip_address(info[4][0])
+        ip_str = info[4][0]
+        ip = ipaddress.ip_address(ip_str)
         reason = _deny_reason(ip, allow_private=allow_private)
         if reason is not None:
             raise SSRFBlocked(f"blocked fetch to {host} → {ip} ({reason})")
+        if ip_str not in seen:  # getaddrinfo repeats per socktype/proto
+            seen.add(ip_str)
+            out.append(ip_str)
+    return out
+
+
+def assert_fetch_host_allowed(host: str, *, allow_private: bool) -> None:
+    """Raise :class:`SSRFBlocked` if ``host`` resolves to any denied IP.
+
+    The check-only entry point (Layer 2 gate at each host boundary). Delegates to
+    :func:`resolve_and_validate` and discards the returned IPs — same resolution,
+    same deny policy, same non-gating behaviour for an unresolvable / empty host.
+    Callers that need the validated IP for connect-time pinning (#1972) call
+    ``resolve_and_validate`` directly.
+    """
+    resolve_and_validate(host, allow_private=allow_private)
 
 
 def resolve_allow_private() -> bool:

--- a/src/reyn/_ssrf_pin.py
+++ b/src/reyn/_ssrf_pin.py
@@ -1,0 +1,285 @@
+"""Connect-time IP-pinning for redirect-following HTTP clients (#1972 DNS-rebind).
+
+Closes the check-time-vs-connect-time TOCTOU window: even if a fast-rebind
+attacker changes the DNS answer between our validation call and the HTTP
+client's connect() syscall, the client connects to the **pre-validated IP**
+returned by ``resolve_and_validate`` at check time — not whatever the resolver
+returns at connect time.
+
+Two adapters are provided:
+
+* **urllib** (stdlib ``http.client``): ``_PinnedHTTPConnection`` /
+  ``_PinnedHTTPSConnection`` + their ``urllib.request`` handler wrappers
+  ``_PinnedHTTPHandler`` / ``_PinnedHTTPSHandler``.  Add both handlers to a
+  ``build_opener(...)`` call to get pinned urllib fetches.
+
+* **httpx** (async): ``PinnedAsyncHTTPTransport`` — an
+  ``httpx.AsyncHTTPTransport`` subclass that resolves + validates the host,
+  rewrites ``request.url.host`` to the pinned IP, preserves the original
+  ``Host`` header, and sets ``request.extensions["sni_hostname"]`` so httpcore
+  validates the TLS cert against the HOSTNAME (not the raw IP).  Wire it with
+  ``httpx.AsyncClient(transport=PinnedAsyncHTTPTransport(...))``.
+
+Stdlib-only imports at module level (stdlib + ``reyn._ssrf_guard``) so this
+module is importable from both ``reyn.api.*`` and ``reyn.core.*`` without
+introducing a dependency cycle.  ``httpx`` is imported lazily inside
+``PinnedAsyncHTTPTransport`` to keep the urllib path dependency-free.
+"""
+from __future__ import annotations
+
+import asyncio
+import http.client
+import ipaddress
+import socket
+import urllib.request
+
+from reyn import _ssrf_guard
+
+
+def _resolve_allow_private() -> bool:
+    """Operator opt-in for private-IP fetches (env-exported by config loader)."""
+    return _ssrf_guard.resolve_allow_private()
+
+
+# ── urllib (stdlib http.client) ───────────────────────────────────────────────
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """``http.client.HTTPConnection`` that connects to a pre-validated IP.
+
+    ``self.host`` is PRESERVED (it carries the ``Host`` header); only the
+    actual socket target is changed to the pinned IP returned by
+    ``resolve_and_validate``.
+
+    If ``resolve_and_validate`` returns ``[]`` (host unresolvable), we fall
+    back to the normal ``super().connect()`` so the real DNS/connection error
+    surfaces instead of a confusing SSRF error.
+    """
+
+    def connect(self) -> None:
+        """Connect to the pinned IP while keeping ``self.host`` for the Host header."""
+        import sys
+
+        sys.audit("http.client.connect", self, self.host, self.port)
+        ips = _ssrf_guard.resolve_and_validate(
+            self.host, allow_private=_resolve_allow_private()
+        )
+        if not ips:
+            # Unresolvable — fall back to the normal path; the OS will surface
+            # the DNS error rather than us mislabelling it as SSRF-blocked.
+            super().connect()
+            return
+        # Connect the socket to the pinned IP, preserving timeout / source_address
+        # exactly as http.client.HTTPConnection.connect does — only the connect
+        # target changes from (self.host, self.port) to (ips[0], self.port).
+        self.sock = self._create_connection(
+            (ips[0], self.port), self.timeout, self.source_address
+        )
+        # Mirror the TCP_NODELAY opt from the base class (ignore ENOPROTOOPT).
+        import errno
+        try:
+            self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as e:
+            if e.errno != errno.ENOPROTOOPT:
+                raise
+        if self._tunnel_host:
+            self._tunnel()
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """``http.client.HTTPSConnection`` that connects to a pre-validated IP.
+
+    The socket connects to the pinned IP, but TLS wrapping uses
+    ``server_hostname=self.host`` (the ORIGINAL hostname) for SNI negotiation
+    and certificate validation — so the server's certificate is validated
+    against the hostname, not the numeric IP.
+
+    Falls back to ``super().connect()`` when the host is unresolvable.
+    """
+
+    def connect(self) -> None:
+        """Connect to pinned IP; TLS SNI + cert validation against original host."""
+        import sys
+
+        sys.audit("http.client.connect", self, self.host, self.port)
+        ips = _ssrf_guard.resolve_and_validate(
+            self.host, allow_private=_resolve_allow_private()
+        )
+        if not ips:
+            super().connect()
+            return
+
+        import errno
+
+        # Step 1 — TCP connect to the pinned IP (same timeout/source_address as base).
+        sock = self._create_connection(
+            (ips[0], self.port), self.timeout, self.source_address
+        )
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as e:
+            if e.errno != errno.ENOPROTOOPT:
+                raise
+
+        # Step 2 — TLS wrap: use the connection's SSL context but override
+        # server_hostname to the ORIGINAL hostname (SNI + cert validation).
+        # Mirrors http.client.HTTPSConnection.connect — _tunnel_host takes
+        # priority for CONNECT-tunnelled requests (proxy), just like the base.
+        if self._tunnel_host:
+            self.sock = sock
+            self._tunnel()
+            server_hostname: str = self._tunnel_host
+        else:
+            server_hostname = self.host
+
+        self.sock = self._context.wrap_socket(sock, server_hostname=server_hostname)
+
+
+class _PinnedHTTPHandler(urllib.request.HTTPHandler):
+    """``urllib.request.HTTPHandler`` that uses ``_PinnedHTTPConnection``."""
+
+    def http_open(self, req):
+        return self.do_open(_PinnedHTTPConnection, req)
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    """``urllib.request.HTTPSHandler`` that uses ``_PinnedHTTPSConnection``.
+
+    Preserves the parent's SSL context (``self._context``) so any custom CA
+    bundle / check_hostname / verify_mode from the existing opener is honoured.
+    """
+
+    def https_open(self, req):
+        return self.do_open(_PinnedHTTPSConnection, req, context=self._context)
+
+
+# ── httpx (async) ─────────────────────────────────────────────────────────────
+
+
+class PinnedAsyncHTTPTransport:
+    """Async HTTP transport that pins each request to a pre-validated IP
+    (#1972 full DNS-rebind resistance).
+
+    Wraps an ``httpx.AsyncHTTPTransport`` and implements the
+    ``httpx.AsyncBaseTransport`` protocol (``__aenter__`` / ``__aexit__`` /
+    ``aclose`` / ``handle_async_request``) so it can be passed directly as
+    ``httpx.AsyncClient(transport=...)``.
+
+    For each request:
+
+    1. If ``request.url.host`` is already a bare IP literal — validate it via
+       ``assert_fetch_host_allowed`` (no DNS involved) and pass through to the
+       underlying transport unchanged.
+
+    2. Otherwise — resolve + validate via ``resolve_and_validate`` (thread-
+       pool, to keep the event loop unblocked).  If the result is empty
+       (unresolvable host) — pass through to the underlying transport, which
+       will surface the real DNS / connection error.
+
+    3. On a valid pin: rewrite ``request.url.host`` to ``ips[0]`` so the
+       socket connects to the pinned IP; inject the original authority into
+       ``request.headers["Host"]`` (so the server sees the right hostname);
+       and set ``request.extensions["sni_hostname"]`` to the original hostname
+       (httpcore reads this extension and passes it to ``start_tls`` as
+       ``server_hostname``, enabling cert validation + SNI against the hostname
+       not the IP).
+
+    Because httpx calls the transport per-hop in a manual redirect loop,
+    every redirect hop is independently validated and pinned.
+
+    Constructor mirrors ``httpx.AsyncHTTPTransport(verify=...)`` — pass the
+    same ``verify`` value you'd give ``httpx.AsyncClient``.
+    """
+
+    def __init__(self, verify: bool | str = True) -> None:
+        import httpx
+
+        self._transport = httpx.AsyncHTTPTransport(verify=verify)
+
+    # ── async context manager protocol (required by httpx.AsyncClient) ────────
+
+    async def __aenter__(self) -> "PinnedAsyncHTTPTransport":
+        await self._transport.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self._transport.__aexit__(*args)
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+    # ── core transport method ─────────────────────────────────────────────────
+
+    async def handle_async_request(self, request) -> object:
+        """Validate + pin the request's host, then delegate to the transport."""
+        import httpx
+
+        host: str = request.url.host
+
+        # ── bare IP literal path ──────────────────────────────────────────────
+        try:
+            ipaddress.ip_address(host)
+            is_literal = True
+        except ValueError:
+            is_literal = False
+
+        if is_literal:
+            # Validate but no re-resolution needed — it IS the connect target.
+            _ssrf_guard.assert_fetch_host_allowed(
+                host, allow_private=_resolve_allow_private()
+            )
+            return await self._transport.handle_async_request(request)
+
+        # ── hostname path ─────────────────────────────────────────────────────
+        ips = await asyncio.to_thread(
+            _ssrf_guard.resolve_and_validate,
+            host,
+            allow_private=_resolve_allow_private(),
+        )
+        if not ips:
+            # Unresolvable — pass through; transport will surface DNS error.
+            return await self._transport.handle_async_request(request)
+
+        pin = ips[0]
+
+        # Build the original Host authority string (host + non-default port).
+        # For standard ports (80/443) httpx returns port=None; in that case
+        # we omit the port from the Host header (RFC 7230 §5.4).
+        port = request.url.port
+        scheme = request.url.scheme
+        standard_port = (scheme == "https" and port == 443) or (
+            scheme == "http" and port == 80
+        )
+        if port is None or standard_port:
+            original_authority = host
+        else:
+            original_authority = f"{host}:{port}"
+
+        # Rewrite the URL host to the pinned IP (socket connect target).
+        new_url = request.url.copy_with(host=pin)
+
+        # sni_hostname must be bytes for httpcore (it decodes the extension in
+        # _connect).  str is also accepted in practice, but bytes is the
+        # canonical form used throughout httpcore's own test fixtures.
+        sni_bytes = host.encode("ascii")
+
+        # Build a new request with the pinned URL, overridden Host header,
+        # and the sni_hostname extension.  httpx.Request is constructed from
+        # scratch (immutable-ish) — we copy all fields and replace what's needed.
+        headers = list(request.headers.raw)
+        # Replace or insert the Host header (case-insensitive search).
+        host_key = b"host"
+        new_headers = [
+            (k, v) for k, v in headers if k.lower() != host_key
+        ]
+        new_headers.insert(0, (b"host", original_authority.encode("ascii")))
+
+        pinned_request = httpx.Request(
+            method=request.method,
+            url=new_url,
+            headers=new_headers,
+            content=request.content,
+            extensions={**request.extensions, "sni_hostname": sni_bytes},
+        )
+
+        return await self._transport.handle_async_request(pinned_request)

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -48,6 +48,7 @@ from urllib.request import build_opener as _build_opener
 
 from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
+from reyn._ssrf_pin import _PinnedHTTPHandler, _PinnedHTTPSHandler
 
 # ── Internal state ─────────────────────────────────────────────────────────
 #
@@ -131,7 +132,13 @@ class _SSRFSafeRedirectHandler(_HTTPRedirectHandler):
 # kept under the ``_urlopen`` name as the stable seam ``_request`` calls (and
 # that tests patch to inject fake responses) — a drop-in for the old
 # ``urllib.request.urlopen`` but redirect-safe.
-_urlopen = _build_opener(_SSRFSafeRedirectHandler()).open
+# #1972: _PinnedHTTP(S)Handler ensure each connection goes to the pre-validated
+# IP (pinned at check time), closing the DNS-rebind TOCTOU window.
+_urlopen = _build_opener(
+    _SSRFSafeRedirectHandler(),
+    _PinnedHTTPHandler(),
+    _PinnedHTTPSHandler(),
+).open
 
 
 def _response_dict(resp: Any) -> dict:

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -5,6 +5,7 @@ import asyncio
 import html.parser
 from typing import Literal
 
+from reyn._ssrf_pin import PinnedAsyncHTTPTransport
 from reyn.schemas.models import WebFetchIROp, WebSearchIROp
 
 from . import register
@@ -280,11 +281,16 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
     try:
         # SSL verification — priority: reyn.yaml web.fetch config → env-var chain.
         # #1956: follow_redirects=False — we follow manually so each hop is gated.
+        # #1972: PinnedAsyncHTTPTransport pins each hop's connect to the pre-
+        # validated IP (resolve_and_validate at gate time) so the client never
+        # re-resolves the host at connect time — closing the DNS-rebind TOCTOU.
+        # The manual redirect loop's _gate_hop L1+L2 logic is preserved; the
+        # transport adds connect-time pinning on top of the check-time gate.
         async with httpx.AsyncClient(
             timeout=op.timeout,
             follow_redirects=False,
             headers={"User-Agent": "reyn/1.0"},
-            verify=_resolve_ssl_verify(ctx),
+            transport=PinnedAsyncHTTPTransport(verify=_resolve_ssl_verify(ctx)),
         ) as client:
             _url = op.url
             for _hop in range(_ssrf_guard.MAX_REDIRECTS + 1):

--- a/src/reyn/core/registry/client.py
+++ b/src/reyn/core/registry/client.py
@@ -21,27 +21,15 @@ by the search response (e.g. ``"io.github.foo/bar-mcp"``).
 """
 from __future__ import annotations
 
-import asyncio
 import os
 import urllib.parse
 from typing import TYPE_CHECKING
 
 from reyn import _ssrf_guard
+from reyn._ssrf_pin import PinnedAsyncHTTPTransport
 
 if TYPE_CHECKING:
     pass
-
-
-async def _ssrf_request_hook(request) -> None:
-    """#1956 SSRF: gate EVERY httpx request — the initial AND each redirect hop
-    (httpx request event-hooks fire per-hop, verified) — against the IP-deny
-    guard, so a malicious / compromised registry that redirects to an internal
-    IP is blocked. ``allow_private`` is the operator opt-in (env-exported)."""
-    await asyncio.to_thread(
-        _ssrf_guard.assert_fetch_host_allowed,
-        request.url.host or "",
-        allow_private=_ssrf_guard.resolve_allow_private(),
-    )
 
 
 class RegistryError(Exception):
@@ -174,13 +162,14 @@ class RegistryClient:
         # through to the litellm env-var chain (same as web_fetch handler).
         verify = self._verify if self._verify is not None else get_ssl_verify()
         # SSL verification — priority: constructor arg → litellm env-var chain.
+        # #1972: PinnedAsyncHTTPTransport replaces the old event_hooks approach —
+        # it both validates (L2 SSRF IP-deny, #1956) AND pins the connect-time
+        # socket to the pre-validated IP, closing the DNS-rebind TOCTOU window.
         self._client = httpx.AsyncClient(
             timeout=15.0,
             follow_redirects=True,
             headers={"User-Agent": "reyn/1.0"},
-            verify=verify,
-            # #1956 SSRF: re-gate every hop (incl. redirects) via the IP-deny guard.
-            event_hooks={"request": [_ssrf_request_hook]},
+            transport=PinnedAsyncHTTPTransport(verify=verify),
         )
         return self
 

--- a/src/reyn/mcp/registry.py
+++ b/src/reyn/mcp/registry.py
@@ -86,6 +86,7 @@ from typing import Any
 # user code through this safe namespace surface.
 from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
+from reyn._ssrf_pin import _PinnedHTTPHandler, _PinnedHTTPSHandler
 from reyn.core.registry import cache as _cache
 from reyn.core.registry.client import _dedup_by_latest
 from reyn.core.registry.models import server_info_from_raw
@@ -156,7 +157,12 @@ def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     # #1956 SSRF: gate the initial host + (via the opener's redirect handler)
     # each redirect hop against the IP-deny guard. Both surface as RegistryError.
-    opener = urllib.request.build_opener(_SSRFRedirectHandler())
+    # #1972: _PinnedHTTP(S)Handler pin the socket connect to the pre-validated IP.
+    opener = urllib.request.build_opener(
+        _SSRFRedirectHandler(),
+        _PinnedHTTPHandler(),
+        _PinnedHTTPSHandler(),
+    )
     try:
         _ssrf_guard.assert_fetch_host_allowed(
             urllib.parse.urlparse(url).hostname or "",

--- a/tests/test_ssrf_guard_1956.py
+++ b/tests/test_ssrf_guard_1956.py
@@ -12,7 +12,19 @@ from reyn._ssrf_guard import (
     SSRFBlocked,
     assert_fetch_host_allowed,
     resolve_allow_private,
+    resolve_and_validate,
 )
+
+
+def _fake_getaddrinfo(*ips: str):
+    """A real getaddrinfo stand-in (NOT a mock) returning fixed IPs — the seam
+    for resolution + DNS-rebind tests."""
+    import socket as _s
+
+    def _f(host, port, **kw):
+        return [(_s.AF_INET, _s.SOCK_STREAM, _s.IPPROTO_TCP, "", (ip, 0)) for ip in ips]
+
+    return _f
 
 
 def test_metadata_hard_deny_even_with_opt_in():
@@ -78,3 +90,65 @@ def test_resolve_allow_private_reads_env_fail_secure(monkeypatch):
     assert resolve_allow_private() is True
     monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "false")
     assert resolve_allow_private() is False
+
+
+# ── resolve_and_validate (#1972 — the pinned-IP source) ──────────────────────
+
+
+def test_resolve_and_validate_literal_returns_self():
+    """Tier 2: a public IP literal is returned as the pinned connect target
+    (no DNS — it IS the target)."""
+    assert resolve_and_validate("93.184.216.34", allow_private=False) == ["93.184.216.34"]
+
+
+def test_resolve_and_validate_literal_denied_raises():
+    """Tier 2: a denied literal (metadata) raises rather than returning a pin."""
+    with pytest.raises(SSRFBlocked):
+        resolve_and_validate("169.254.169.254", allow_private=False)
+
+
+def test_resolve_and_validate_hostname_returns_validated_ips(monkeypatch):
+    """Tier 2: a hostname resolves to its validated public IPs (the pin set),
+    de-duplicated in resolution order — real getaddrinfo seam, no mock."""
+    monkeypatch.setattr(
+        "reyn._ssrf_guard.socket.getaddrinfo",
+        _fake_getaddrinfo("93.184.216.34", "93.184.216.34", "8.8.8.8"),
+    )
+    assert resolve_and_validate("example.com", allow_private=False) == [
+        "93.184.216.34", "8.8.8.8",
+    ]
+
+
+def test_resolve_and_validate_denies_if_any_ip_internal(monkeypatch):
+    """Tier 2: a hostname resolving to ANY denied IP raises (deny-if-any) — the
+    rebind-relevant answer with a public AND an internal IP is rejected, so the
+    caller never pins to (or falls back past) a poisoned record."""
+    monkeypatch.setattr(
+        "reyn._ssrf_guard.socket.getaddrinfo",
+        _fake_getaddrinfo("93.184.216.34", "169.254.169.254"),
+    )
+    with pytest.raises(SSRFBlocked):
+        resolve_and_validate("rebind.example", allow_private=False)
+
+
+def test_resolve_and_validate_unresolvable_returns_empty(monkeypatch):
+    """Tier 2: an unresolvable host returns [] (no IP to pin; the caller falls
+    back to its normal connect, which surfaces the real DNS error) — non-gating,
+    matching assert_fetch_host_allowed."""
+    import socket as _s
+
+    def _raise(*a, **k):
+        raise _s.gaierror("no such host")
+
+    monkeypatch.setattr("reyn._ssrf_guard.socket.getaddrinfo", _raise)
+    assert resolve_and_validate("nx.invalid", allow_private=False) == []
+
+
+def test_assert_delegates_to_resolve_and_validate(monkeypatch):
+    """Tier 2: assert_fetch_host_allowed delegates to resolve_and_validate — a
+    hostname resolving to an internal IP raises via the shared resolve path."""
+    monkeypatch.setattr(
+        "reyn._ssrf_guard.socket.getaddrinfo", _fake_getaddrinfo("10.0.0.5"),
+    )
+    with pytest.raises(SSRFBlocked):
+        assert_fetch_host_allowed("internal.example", allow_private=False)

--- a/tests/test_ssrf_ip_pin_1972.py
+++ b/tests/test_ssrf_ip_pin_1972.py
@@ -1,0 +1,410 @@
+"""Tier 2: connect-time IP-pinning closes the DNS-rebind TOCTOU (#1972).
+
+Each test uses a real recording seam (function or subclass, NOT MagicMock) to
+capture the connect target / request seen by the network layer, then asserts on
+the *public behavior under test*: the socket connects to the pre-validated IP,
+not to whatever the OS resolver would return at connect time.
+
+Testing policy compliance:
+  - Tier 2 (OS invariant) — the pinned-IP guarantee is a security invariant of
+    the OS's outbound-fetch path.
+  - No MagicMock / AsyncMock / patch used anywhere; real recording stand-ins only.
+  - No private-state assertions; we assert on the recorded connect target (= the
+    externally observable behavior of the socket layer).
+"""
+from __future__ import annotations
+
+import asyncio
+import http.client
+import socket
+from typing import Any
+
+import pytest
+
+from reyn._ssrf_guard import SSRFBlocked
+from reyn._ssrf_pin import (
+    PinnedAsyncHTTPTransport,
+    _PinnedHTTPConnection,
+    _PinnedHTTPSConnection,
+)
+
+# ── Shared helper ──────────────────────────────────────────────────────────────
+
+PUBLIC_IP_A = "93.184.216.34"   # example.com — a real, publicly routable IP
+PUBLIC_IP_B = "8.8.8.8"         # alternate public IP
+
+
+def _fake_resolve_and_validate(*ips: str):
+    """Real function (NOT a mock) that records calls and returns fixed IPs.
+
+    Returns a callable matching the ``resolve_and_validate(host, *, allow_private)``
+    signature.  The returned call log (a plain list) lets tests assert that
+    the exact IP used for the connect target came from the resolve-at-check-time
+    call, not from a separate OS resolution.
+    """
+    calls: list[tuple[str, bool]] = []
+
+    def _fn(host: str, *, allow_private: bool) -> list[str]:
+        calls.append((host, allow_private))
+        if not ips:
+            return []
+        return list(ips)
+
+    _fn.calls = calls  # type: ignore[attr-defined]
+    return _fn
+
+
+# ── urllib: _PinnedHTTPConnection ─────────────────────────────────────────────
+
+
+class _RecordingHTTPConnection(_PinnedHTTPConnection):
+    """_PinnedHTTPConnection subclass that records the (ip, port) passed to
+    ``_create_connection`` and raises ConnectionRefusedError to avoid a real
+    network call.  This is a real class (no mocks); the recorded target is
+    the single assertion point.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.recorded_target: tuple[str, int] | None = None
+        # Replace the instance-level _create_connection with a real recording fn.
+        _outer = self
+
+        def _recorder(address: tuple[str, int], timeout: Any, source_address: Any):
+            _outer.recorded_target = address
+            raise ConnectionRefusedError("recording stand-in — no real network")
+
+        self._create_connection = _recorder
+
+
+def test_pinned_http_connection_uses_validated_ip(monkeypatch):
+    """Tier 2: _PinnedHTTPConnection.connect() passes the pre-validated IP (not
+    the hostname) to _create_connection — proving no connect-time re-resolve."""
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    conn = _RecordingHTTPConnection("example.com", 80)
+    with pytest.raises(ConnectionRefusedError):
+        conn.connect()
+
+    # The socket was asked to connect to the pinned IP, not "example.com".
+    assert conn.recorded_target == (PUBLIC_IP_A, 80)
+    # The Host header target (self.host) is UNCHANGED — preserves Host header.
+    assert conn.host == "example.com"
+
+
+def test_pinned_http_connection_fallback_when_unresolvable(monkeypatch):
+    """Tier 2: when resolve_and_validate returns [] (unresolvable), fall back to
+    super().connect() — the OS will surface the DNS error, not an SSRF block."""
+    fake_rv = _fake_resolve_and_validate()  # empty → unresolvable
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    conn = http.client.HTTPConnection("nx-does-not-exist.invalid", 80)
+    # We can't easily intercept super().connect() without a mock, but we can
+    # confirm that _PinnedHTTPConnection does NOT raise SSRFBlocked — it
+    # raises the expected connection/DNS error from the OS path instead.
+    conn2 = _RecordingHTTPConnection("nx-does-not-exist.invalid", 80)
+    # Override resolve to return [] — fallback fires super().connect(), which
+    # hits the real OS and raises socket.gaierror (or similar), NOT SSRFBlocked.
+    with pytest.raises((OSError, ConnectionRefusedError)):
+        conn2.connect()  # recorded_target stays None (super path was taken)
+
+
+def test_pinned_http_connection_blocked_host_raises(monkeypatch):
+    """Tier 2: resolve_and_validate raising SSRFBlocked propagates out of
+    _PinnedHTTPConnection.connect() — the blocked target is never connected."""
+    def _deny(host: str, *, allow_private: bool) -> list[str]:
+        raise SSRFBlocked(f"blocked: {host}")
+
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", _deny)
+
+    conn = _RecordingHTTPConnection("metadata.internal", 80)
+    with pytest.raises(SSRFBlocked):
+        conn.connect()
+    # No connect call was recorded — the block happened before the socket layer.
+    assert conn.recorded_target is None
+
+
+# ── urllib: _PinnedHTTPSConnection ────────────────────────────────────────────
+
+
+class _RecordingHTTPSConnection(_PinnedHTTPSConnection):
+    """_PinnedHTTPSConnection subclass that records (ip, port) + the SNI hostname
+    passed to wrap_socket, then raises to avoid a real TLS handshake.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.recorded_target: tuple[str, int] | None = None
+        self.recorded_server_hostname: str | None = None
+        _outer = self
+
+        def _recorder(address: tuple[str, int], timeout: Any, source_address: Any):
+            _outer.recorded_target = address
+            # Return a real socket object so wrap_socket has something to work
+            # with — except we intercept wrap_socket too (below).
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            return sock
+
+        self._create_connection = _recorder
+
+        # Also intercept wrap_socket on the SSL context to capture server_hostname.
+        original_wrap = self._context.wrap_socket
+
+        def _recording_wrap(s, *, server_hostname=None, **kw):
+            _outer.recorded_server_hostname = server_hostname
+            # Close the real socket — we don't need the TLS layer for this test.
+            try:
+                s.close()
+            except Exception:
+                pass
+            raise ConnectionRefusedError("recording stand-in — no real TLS")
+
+        self._context.wrap_socket = _recording_wrap  # type: ignore[method-assign]
+
+
+def test_pinned_https_connection_pins_ip_keeps_host_for_sni(monkeypatch):
+    """Tier 2: _PinnedHTTPSConnection.connect() connects the socket to the pinned
+    IP and uses the ORIGINAL hostname for TLS SNI / cert validation — not the IP.
+    This is the core DNS-rebind TOCTOU property: connect target ≠ cert target."""
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    conn = _RecordingHTTPSConnection("example.com", 443)
+    with pytest.raises(ConnectionRefusedError):
+        conn.connect()
+
+    # Socket connected to the pinned IP, not "example.com".
+    assert conn.recorded_target == (PUBLIC_IP_A, 443)
+    # TLS SNI / cert validation used the original hostname — not the IP.
+    assert conn.recorded_server_hostname == "example.com"
+    # self.host is unchanged — so the Host header stays the hostname.
+    assert conn.host == "example.com"
+
+
+def test_dns_rebind_proof_https(monkeypatch):
+    """Tier 2: DNS-rebind resistance proof — resolve_and_validate returns IP_A at
+    check time; the socket connects to IP_A regardless of what a subsequent OS
+    DNS call would return.  No second resolution happens because the pinned IP
+    is used directly for the socket.  Verifies: recorded_target == IP_A."""
+    # Simulate attacker rebinding: the fake returns IP_A (public) the first time
+    # (check-time); if there were a second OS call it would return "rebind" IP.
+    # Because _PinnedHTTPSConnection calls resolve_and_validate ONCE and passes
+    # ips[0] directly to _create_connection, there is no second OS call.
+    call_count = 0
+
+    def _rebind_resolver(host: str, *, allow_private: bool) -> list[str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [PUBLIC_IP_A]   # check-time answer: public/valid
+        # If called again (= connect-time re-resolve), attacker's answer.
+        return ["169.254.169.254"]
+
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", _rebind_resolver)
+
+    conn = _RecordingHTTPSConnection("rebind.example", 443)
+    with pytest.raises(ConnectionRefusedError):
+        conn.connect()
+
+    # Exactly ONE resolution call — the check-time call.  No connect-time re-resolve.
+    assert call_count == 1
+    # The socket targeted the check-time IP, not whatever rebind would return.
+    assert conn.recorded_target == (PUBLIC_IP_A, 443)
+
+
+# ── httpx: PinnedAsyncHTTPTransport ───────────────────────────────────────────
+
+
+class _RecordingTransport(PinnedAsyncHTTPTransport):
+    """PinnedAsyncHTTPTransport subclass that records the request handed to the
+    underlying network layer instead of making a real connection.
+
+    This is a real class override (NOT a mock): we override
+    ``_transport.handle_async_request`` with a recording coroutine that captures
+    the request and returns a minimal ``httpx.Response``.
+    """
+
+    def __init__(self) -> None:
+        import httpx
+        super().__init__(verify=False)
+        self.recorded_request: httpx.Request | None = None
+        _outer = self
+
+        async def _recording_handler(request: httpx.Request) -> httpx.Response:
+            _outer.recorded_request = request
+            return httpx.Response(200, content=b"ok")
+
+        # Replace the inner transport's handle_async_request with our recorder.
+        self._transport.handle_async_request = _recording_handler  # type: ignore[method-assign]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_pinned_transport_rewrites_url_host_to_ip(monkeypatch):
+    """Tier 2: PinnedAsyncHTTPTransport rewrites request.url.host → the validated
+    IP before passing to the underlying transport — the socket layer sees the IP,
+    not the hostname (no connect-time re-resolve)."""
+    import httpx
+
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://example.com/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    assert transport.recorded_request is not None
+    # URL host was rewritten to the pinned IP.
+    assert transport.recorded_request.url.host == PUBLIC_IP_A
+
+
+def test_pinned_transport_preserves_host_header(monkeypatch):
+    """Tier 2: PinnedAsyncHTTPTransport sets Host = original hostname (not the
+    pinned IP), so the server receives the correct virtual-host name."""
+    import httpx
+
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://example.com/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    assert transport.recorded_request is not None
+    host_header = transport.recorded_request.headers.get("host")
+    assert host_header == "example.com"
+
+
+def test_pinned_transport_sets_sni_hostname_extension(monkeypatch):
+    """Tier 2: PinnedAsyncHTTPTransport sets extensions['sni_hostname'] to the
+    original hostname bytes so httpcore uses it for TLS SNI + cert validation
+    (not the numeric IP that the socket connects to)."""
+    import httpx
+
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://example.com/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    assert transport.recorded_request is not None
+    sni = transport.recorded_request.extensions.get("sni_hostname")
+    assert sni == b"example.com"
+
+
+def test_pinned_transport_non_standard_port_host_header(monkeypatch):
+    """Tier 2: non-standard port included in Host header (e.g. example.com:8443)."""
+    import httpx
+
+    fake_rv = _fake_resolve_and_validate(PUBLIC_IP_A)
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://example.com:8443/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    assert transport.recorded_request is not None
+    host_header = transport.recorded_request.headers.get("host")
+    assert host_header == "example.com:8443"
+
+
+def test_pinned_transport_bare_ip_literal_passes_through(monkeypatch):
+    """Tier 2: a bare-IP-literal URL (already the connect target) passes through
+    unchanged after assert_fetch_host_allowed — no URL rewrite, no sni_hostname."""
+    import httpx
+
+    # assert_fetch_host_allowed must be called (L2 check), not resolve_and_validate
+    checked: list[str] = []
+
+    def _assert(host: str, *, allow_private: bool) -> None:
+        checked.append(host)
+
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.assert_fetch_host_allowed", _assert)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", f"https://{PUBLIC_IP_A}/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    # The IP was validated.
+    assert PUBLIC_IP_A in checked
+    # URL host is unchanged (still the IP).
+    assert transport.recorded_request is not None
+    assert transport.recorded_request.url.host == PUBLIC_IP_A
+    # No sni_hostname injected for bare-IP requests.
+    assert "sni_hostname" not in transport.recorded_request.extensions
+
+
+def test_pinned_transport_unresolvable_falls_through(monkeypatch):
+    """Tier 2: when resolve_and_validate returns [] the transport passes the
+    original request to the underlying layer (which surfaces the DNS error)."""
+    import httpx
+
+    fake_rv = _fake_resolve_and_validate()  # empty → unresolvable
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", fake_rv)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://nx.invalid/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    assert transport.recorded_request is not None
+    # URL host is NOT rewritten — the original request passes through.
+    assert transport.recorded_request.url.host == "nx.invalid"
+
+
+def test_pinned_transport_blocked_host_raises(monkeypatch):
+    """Tier 2: resolve_and_validate raising SSRFBlocked propagates out of
+    PinnedAsyncHTTPTransport — the request never reaches the transport."""
+    import httpx
+
+    def _deny(host: str, *, allow_private: bool) -> list[str]:
+        raise SSRFBlocked(f"blocked: {host}")
+
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", _deny)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://internal.example/path")
+
+    with pytest.raises(SSRFBlocked):
+        _run(transport.handle_async_request(original_req))
+
+    # No request reached the recording layer.
+    assert transport.recorded_request is None
+
+
+def test_dns_rebind_proof_httpx(monkeypatch):
+    """Tier 2: DNS-rebind resistance proof for httpx — resolve_and_validate is
+    called exactly ONCE (check time); the URL host is rewritten to the check-time
+    IP so no connect-time re-resolve can deliver a different (attacker) IP."""
+    import httpx
+
+    call_count = 0
+
+    def _rebind_resolver(host: str, *, allow_private: bool) -> list[str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [PUBLIC_IP_A]   # check-time answer
+        return ["169.254.169.254"]  # attacker's rebind answer
+
+    monkeypatch.setattr("reyn._ssrf_pin._ssrf_guard.resolve_and_validate", _rebind_resolver)
+
+    transport = _RecordingTransport()
+    original_req = httpx.Request("GET", "https://rebind.example/path")
+
+    _run(transport.handle_async_request(original_req))
+
+    # Exactly one resolve call — no connect-time re-resolve.
+    assert call_count == 1
+    assert transport.recorded_request is not None
+    # The socket target is the check-time IP (not what a second call would return).
+    assert transport.recorded_request.url.host == PUBLIC_IP_A

--- a/tests/test_web_fetch_ssl_config.py
+++ b/tests/test_web_fetch_ssl_config.py
@@ -1,15 +1,22 @@
 """Tier 2: web_fetch SSL config — declarative SSL via reyn.yaml (FP-0022 follow-up).
 
-Verifies that handle_web_fetch and RegistryClient pass the correct ``verify``
-value to httpx.AsyncClient, based on the priority order:
+Verifies that handle_web_fetch and RegistryClient route the correct ``verify``
+value to httpx's TLS layer, based on the priority order:
   1. web.fetch.ca_bundle (str path) → verify=<path>
   2. web.fetch.verify_ssl: false    → verify=False
   3. web.fetch.verify_ssl: true     → verify=True
   4. neither set (None)             → litellm.get_ssl_verify() env-var fallback
 
-No unittest.mock. All helpers use real instances or httpx.MockTransport.
-httpx.AsyncClient is monkeypatched at the class level to capture constructor
-kwargs — this is a structural invariant (the right layer is called), not a
+#1972: SSL now flows through ``httpx.AsyncClient(transport=PinnedAsyncHTTPTransport
+(verify=...))`` (the connect-time IP-pinning transport owns TLS), not
+``AsyncClient(verify=...)``. So the invariant is captured at the transport: the
+``PinnedAsyncHTTPTransport`` is monkeypatched to a real recorder
+(``_RecordVerifyTransport``) that captures ``verify`` without eagerly building the
+real httpx transport (which would load a fake CA path). ``httpx.AsyncClient`` is
+still monkeypatched to capture constructor kwargs (now ``transport=``).
+
+No unittest.mock. All helpers are real instances / recording stand-ins — a
+structural invariant (the right layer receives the verify value), not a
 behavioral assertion on httpx internals.
 """
 from __future__ import annotations
@@ -109,6 +116,32 @@ class _ResponseStreamCtx:
         return None
 
 
+class _RecordVerifyTransport:
+    """#1972: a real recording stand-in for ``PinnedAsyncHTTPTransport`` that
+    captures the ``verify`` value WITHOUT constructing the real httpx transport
+    (so a fake CA-bundle path isn't eagerly loaded → no FileNotFoundError).
+
+    Since #1972 routes SSL through ``httpx.AsyncClient(transport=Pinned(verify=...))``
+    instead of ``AsyncClient(verify=...)``, the SSL-config invariant is now ‘the
+    verify value reaches the transport’ — captured here per-instance via
+    ``captured_kwargs['transport'].verify``."""
+
+    def __init__(self, verify: Any = True) -> None:
+        self.verify = verify
+
+    async def __aenter__(self) -> "_RecordVerifyTransport":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+    async def handle_async_request(self, request: Any) -> Any:  # pragma: no cover
+        raise AssertionError("recorder transport must not handle a real request")
+
+
 # ---------------------------------------------------------------------------
 # 1. ca_bundle config → verify=<path>
 # ---------------------------------------------------------------------------
@@ -128,9 +161,12 @@ def test_verify_ssl_ca_bundle_in_config_passes_to_httpx(monkeypatch: pytest.Monk
     op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
 
-    assert _CaptureAsyncClient.captured_kwargs.get("verify") == "/etc/ssl/certs/corp-ca.pem"
+    assert _CaptureAsyncClient.captured_kwargs["transport"].verify == "/etc/ssl/certs/corp-ca.pem"
 
 
 # ---------------------------------------------------------------------------
@@ -152,9 +188,12 @@ def test_verify_ssl_false_in_config_passes_to_httpx(monkeypatch: pytest.MonkeyPa
     op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
 
-    assert _CaptureAsyncClient.captured_kwargs.get("verify") is False
+    assert _CaptureAsyncClient.captured_kwargs["transport"].verify is False
 
 
 # ---------------------------------------------------------------------------
@@ -174,9 +213,12 @@ def test_verify_ssl_true_in_config_passes_to_httpx(monkeypatch: pytest.MonkeyPat
     op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
 
-    assert _CaptureAsyncClient.captured_kwargs.get("verify") is True
+    assert _CaptureAsyncClient.captured_kwargs["transport"].verify is True
 
 
 # ---------------------------------------------------------------------------
@@ -200,9 +242,12 @@ def test_ca_bundle_takes_priority_over_verify_ssl(monkeypatch: pytest.MonkeyPatc
     op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
 
-    assert _CaptureAsyncClient.captured_kwargs.get("verify") == "/corp/ca.pem"
+    assert _CaptureAsyncClient.captured_kwargs["transport"].verify == "/corp/ca.pem"
 
 
 # ---------------------------------------------------------------------------
@@ -234,13 +279,16 @@ def test_env_var_fallback_when_config_unset(
     op = WebFetchIROp(kind="web_fetch", url="https://example.com", max_length=50_000)
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx, caller="control_ir"))
 
     # The verify value forwarded to httpx must match what litellm.get_ssl_verify()
     # returns in the same env. We do not pin the exact type/value here because
     # litellm's return type (bool vs str) is an internal litellm detail.
     expected = get_ssl_verify()
-    assert _CaptureAsyncClient.captured_kwargs.get("verify") == expected
+    assert _CaptureAsyncClient.captured_kwargs["transport"].verify == expected
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +355,9 @@ def test_registry_client_verify_false_passed_to_httpx(monkeypatch: pytest.Monkey
             pass
 
     monkeypatch.setattr(httpx, "AsyncClient", _CapturingClient)
+    monkeypatch.setattr(
+        "reyn.core.registry.client.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
 
     async def _run() -> None:
         client = RegistryClient(verify=False)
@@ -314,7 +365,7 @@ def test_registry_client_verify_false_passed_to_httpx(monkeypatch: pytest.Monkey
             pass
 
     asyncio.run(_run())
-    assert captured.get("verify") is False
+    assert captured["transport"].verify is False
 
 
 def test_registry_client_ca_bundle_passed_to_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -341,6 +392,9 @@ def test_registry_client_ca_bundle_passed_to_httpx(monkeypatch: pytest.MonkeyPat
             pass
 
     monkeypatch.setattr(httpx, "AsyncClient", _CapturingClient)
+    monkeypatch.setattr(
+        "reyn.core.registry.client.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+    )
 
     async def _run() -> None:
         client = RegistryClient(verify="/corp/ca.pem")
@@ -348,4 +402,4 @@ def test_registry_client_ca_bundle_passed_to_httpx(monkeypatch: pytest.MonkeyPat
             pass
 
     asyncio.run(_run())
-    assert captured.get("verify") == "/corp/ca.pem"
+    assert captured["transport"].verify == "/corp/ca.pem"


### PR DESCRIPTION
**[dogfood-coder]** — `Fixes #1972`. Closes the #1956 D1 residual (connect-time DNS-rebind TOCTOU): the HTTP clients re-resolved the host at connect, separately from the check-time validation, so a fast-rebind DNS could return a public IP to our check and an internal IP to the client's connect. Now every redirect-following client connects to the **pre-validated, pinned IP**.

2 commits: `585a1515` (single-source validated-IP), `20fe9981` (the 4-client pinning).

## Mechanism (single-source, uniform)
- **`_ssrf_guard.resolve_and_validate(host, *, allow_private) -> list[str]`** — same resolve + deny policy as `assert_fetch_host_allowed` but **returns** the validated IPs to pin (literal → `[host]`; hostname → all validated IPs deny-if-any, deduped; unresolvable → `[]`; denied → raises). `assert_fetch_host_allowed` now delegates to it (DRY, check-only).
- **`_ssrf_pin.py`** consumes that single source per client, preserving the original hostname for the `Host` header AND TLS SNI / cert validation (the cert is validated against the **hostname**, never the raw IP):
  - **urllib** (`safe/http.py`, `mcp/registry.py`): `_PinnedHTTP(S)Connection.connect()` — TCP-connects to `ips[0]`, TLS-wraps with `server_hostname=self.host`. Faithfully mirrors `http.client.HTTP(S)Connection.connect` (timeout / source_address / TCP_NODELAY / `_tunnel`). Added to each opener via `_PinnedHTTP(S)Handler`.
  - **httpx** (`web.py`, `core/registry/client.py`): `PinnedAsyncHTTPTransport` — per-hop, rewrites `url.host → pin`, sets `Host` = original authority, sets `extensions["sni_hostname"]` = hostname (httpcore uses it for TLS SNI + cert). Replaces the prior `event_hooks` validate (it now validates **and** pins per hop).

The existing L1 allowlist + L2 per-hop redirect re-validation are **preserved** — pinning is purely additive.

## Notable: `verify` → transport
`registry/client.py` + `web.py` swap `AsyncClient(verify=...)` for `AsyncClient(transport=PinnedAsyncHTTPTransport(verify=...))` (the transport now owns TLS). `test_web_fetch_ssl_config.py` is updated to assert `verify` reaches the **transport** (the SSL-config invariant is preserved — it just flows one layer down).

## Verification
- **DNS-rebind proof** (both clients): a resolver returning a public IP at check-time → the connection uses that pinned IP; `resolve_and_validate` is called **exactly once** (no connect-time re-resolve). Real recording seams, no MagicMock.
- ruff + tier-audit --strict clean (new + changed tests).
- 109 SSRF / web_fetch / registry / safe-http / ssl-config tests pass; 922 in a broad `-k` sweep (4 pre-existing env failures — gateway entry-points + swebench — **proven not-my-diff via stash A/B**, modules my diff doesn't touch).

## ⚠ Net-isolation gap (for review)
sandbox_2 has no live network, so the seam tests verify the **request/connection is constructed to pin the IP + carry `sni_hostname`/`server_hostname`=hostname** — the strongest assertion possible without a live server. The remaining step — httpcore actually honoring `sni_hostname` in a real TLS handshake — is **design-verified against the httpcore source** (`request.extensions["sni_hostname"]` → `start_tls(server_hostname=...)`), not live-smoked. A one-off live-HTTPS smoke (fetch a real host, confirm the pinned connect + cert-against-hostname) would close it; given this is a Low-severity defense-in-depth fix, design + seam-tests + review is proportionate. Flagging per the net-isolation discipline.

## Test plan
- [x] resolve_and_validate: literal/return, deny-if-any (rebind answer), unresolvable→[], assert-delegation
- [x] urllib: connect pins IP, server_hostname=hostname, Host preserved, blocked-raises, DNS-rebind-proof
- [x] httpx: url→pin, Host=hostname, sni_hostname=hostname, bare-IP passthrough, unresolvable fallthrough, blocked-raises, DNS-rebind-proof
- [x] ssl-config invariant preserved (verify→transport) — 7 tests updated
- [x] ruff + tier-audit clean; 109 + 922-test regression; not-my-diff stash A/B
- [ ] (reviewer/optional) a live-HTTPS smoke to close the net-isolation gap

CI-green ping to follow. sandbox_2 does not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
