### PR TITLE
feat(#1892): reyn audit — deep skill-ops gateway analysis (control_ir/phase ops)

### DIFF
--- a/src/reyn/interfaces/cli/commands/audit.py
+++ b/src/reyn/interfaces/cli/commands/audit.py
@@ -179,11 +179,133 @@ def _gateway_mcp() -> list[Finding]:
     return findings
 
 
+# ── #1892: control_ir / phase-ops gateway analysis ──────────────────────────
+# Deep static analysis of a skill's PHASE OPS (vs the .py scan in _gateway_skill):
+# ``allowed_ops`` is the phase's op-KIND capability GRANT (statically declared);
+# a preprocessor step carries a LITERAL op with literal args. Runtime LLM-emitted
+# op args are out of static scope — the GRANT is the auditable gateway-exposure
+# (the OpenClaw audit-* analog flags capability, not runtime values).
+#
+# Op-kind → gateway category (single-source). Severities lead-decided (#1892):
+#   sandboxed_exec GRANT → MED (common + legit build/test grants → visibility,
+#     no CI-block); a LITERAL preprocessor sandboxed_exec → HIGH (hard-coded exec
+#     is materially riskier); network GRANT → egress INFO, + secret access →
+#     egress+secrets HIGH; out-of-zone LITERAL preprocessor file path → broad-FS
+#     MED. (Severity policy is config-tightenable in a later pass.)
+# The map's completeness vs OP_PURITY world/side_effect is guarded by a test
+# (test_audit_skill_ops_1892), not a runtime finding — avoids per-skill noise.
+_EXEC_OPS = frozenset({"sandboxed_exec"})
+_EGRESS_OPS = frozenset({"web_fetch", "web_search", "mcp", "call_mcp_tool"})
+_SECRET_OPS = frozenset({"recall"})  # memory/secret retrieval (#1892 Q2)
+_FS_PATH_OPS = frozenset({
+    "read_file", "write_file", "edit_file", "delete_file", "glob_files",
+    "grep_files", "file",
+})
+
+
+def _resolve_coarse(grants: set[str]) -> set[str]:
+    """Expand coarse op families (``allowed_ops:[mcp]`` → its fine kinds) so the
+    category match sees the real granted capability."""
+    from reyn.core.op_runtime.registry import COARSE_TO_FINE
+    out = set(grants)
+    for g in grants:
+        out |= set(COARSE_TO_FINE.get(g, frozenset()))
+    return out
+
+
+def _skill_reads_secrets(skill_dir: Path, grants: set[str]) -> bool:
+    """#1892 Q2: a skill can read secrets if it GRANTS a memory/secret-retrieval
+    op (``recall``) OR declares a secret-looking permission in skill.md."""
+    if grants & _SECRET_OPS:
+        return True
+    from reyn.core.compiler.parser import parse_skill
+    try:
+        perms = parse_skill(skill_dir / "skill.md").permissions or {}
+    except Exception:
+        return False
+    return any("secret" in str(k).lower() for k in perms)
+
+
+def _is_out_of_zone(path: object) -> bool:
+    """#1892 Q3: a literal preprocessor file-op path is out-of-zone if it is
+    absolute or escapes upward (``..``). The runtime sandbox read/write allowlist
+    is the dynamic guard; statically we flag a hard-coded path that leaves the
+    skill/workspace-relative zone."""
+    if not isinstance(path, str) or not path:
+        return False
+    from pathlib import PurePosixPath
+    return os.path.isabs(path) or ".." in PurePosixPath(path).parts
+
+
+def _gateway_skill_ops(skill_dir: Path) -> list[Finding]:
+    """Rule 3 (#1892): static gateway analysis of a skill's phase ops — the
+    op-KIND capability grants (``allowed_ops``) + literal preprocessor ops.
+    Never executes (reads the parsed IR only)."""
+    from reyn.core.compiler.parser import parse_phase
+
+    parsed: list[tuple[Path, object]] = []
+    for pf in sorted(skill_dir.glob("phases/*.md")):
+        try:
+            parsed.append((pf, parse_phase(pf)))
+        except Exception:
+            continue
+    if not parsed:
+        return []
+
+    # #1892 Q2: secret access is a skill-wide signal (union of all phases' grants).
+    union = _resolve_coarse({op for _, pd in parsed for op in (pd.allowed_ops or [])})
+    reads_secrets = _skill_reads_secrets(skill_dir, union)
+
+    findings: list[Finding] = []
+    for pf, pd in parsed:
+        loc = f"{skill_dir.name}/{pf.relative_to(skill_dir).as_posix()}"
+        grants = _resolve_coarse(set(pd.allowed_ops or []))
+        # (a) sandboxed_exec GRANT → MED capability (HIGH only for a literal exec, (c)).
+        if grants & _EXEC_OPS:
+            findings.append(Finding(
+                loc, "gateway:exec-capability", _MED,
+                "phase grants sandboxed_exec (op-layer subprocess capability)",
+            ))
+        # (b) network GRANT → egress INFO; + secret access → egress+secrets HIGH.
+        net = sorted(grants & _EGRESS_OPS)
+        if net:
+            if reads_secrets:
+                findings.append(Finding(
+                    loc, "gateway:egress+secrets", _HIGH,
+                    f"network grant {net} co-occurs with secret access "
+                    f"(recall / secret-permission) — exfiltration risk",
+                ))
+            else:
+                findings.append(Finding(
+                    loc, "gateway:egress", _INFO, f"phase grants network op(s): {net}",
+                ))
+        # (c) preprocessor LITERAL ops (literal args ARE statically knowable).
+        for step in (pd.preprocessor or []):
+            op = step.get("op") if isinstance(step, dict) else None
+            if not isinstance(op, dict):
+                continue
+            kind = op.get("kind")
+            if kind in _EXEC_OPS:
+                findings.append(Finding(
+                    loc, "gateway:sandboxed-exec", _HIGH,
+                    f"preprocessor ships a literal sandboxed_exec (argv={op.get('argv')!r})",
+                ))
+            elif kind in _FS_PATH_OPS:
+                for path in (op.get("path"), op.get("dest_path")):
+                    if _is_out_of_zone(path):
+                        findings.append(Finding(
+                            loc, "gateway:broad-fs", _MED,
+                            f"preprocessor {kind} uses an out-of-zone literal path: {path!r}",
+                        ))
+    return findings
+
+
 def _collect(only: str | None) -> list[Finding]:
     findings: list[Finding] = []
     for d in _skill_dirs(only):
         findings.extend(_scan_text_files(d))
         findings.extend(_gateway_skill(d))
+        findings.extend(_gateway_skill_ops(d))  # #1892: deep phase-ops gateway
     findings.extend(_secrets_perm())
     if only is None:
         findings.extend(_gateway_mcp())

--- a/tests/test_audit_skill_ops_1892.py
+++ b/tests/test_audit_skill_ops_1892.py
@@ -1,0 +1,158 @@
+"""Tier 2: reyn audit — deep skill-ops gateway analysis (#1892).
+
+Static analysis of a skill's phase ops: ``allowed_ops`` (the op-KIND capability
+GRANT) + literal preprocessor ops. Real tmp skill fixtures parsed by the real
+compiler parser; the analyzer never executes skill code. No mocks.
+
+Severities (lead-decided #1892): sandboxed_exec grant → MED, literal preprocessor
+exec → HIGH, network grant → egress INFO (+ secret access → HIGH), out-of-zone
+literal preprocessor file path → broad-FS MED. Plus a completeness guard: every
+world/side_effect op is in the category map or the acknowledged-benign set, so a
+new gateway-relevant op fails here until triaged.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.cli.commands.audit import (
+    _EGRESS_OPS,
+    _EXEC_OPS,
+    _FS_PATH_OPS,
+    _SECRET_OPS,
+    _gateway_skill_ops,
+)
+
+
+def _phase_md(name: str, allowed_ops=None, preprocessor: str = "") -> str:
+    """Build a real phase.md as clean top-level lines (no dedent — the
+    preprocessor block is appended at column 0 so YAML indentation is valid)."""
+    lines = [
+        "---", "type: phase", f"name: {name}",
+        "input: {type: object, properties: {}}",
+    ]
+    if allowed_ops:
+        lines.append("allowed_ops: [%s]" % ", ".join(allowed_ops))
+    if preprocessor:
+        lines.append(preprocessor)
+    lines += ["---", "do work", ""]
+    return "\n".join(lines)
+
+
+def _skill(tmp_path, name: str, phases: dict[str, str]):
+    """Build a real skill dir (skill.md + phases/<n>.md) parsed by the real parser."""
+    d = tmp_path / name
+    (d / "phases").mkdir(parents=True)
+    (d / "skill.md").write_text(f"---\ntype: skill\nname: {name}\n---\nx\n", encoding="utf-8")
+    for pname, fm in phases.items():
+        (d / "phases" / f"{pname}.md").write_text(fm, encoding="utf-8")
+    return d
+
+
+def _rules(findings) -> set[tuple[str, str]]:
+    return {(f.rule, f.severity) for f in findings}
+
+
+def _runop(op_inline: str) -> str:
+    return f"preprocessor:\n  - type: run_op\n    op: {{{op_inline}}}\n    into: data._x"
+
+
+# ── grant signals (allowed_ops) ──────────────────────────────────────────────
+
+
+def test_sandboxed_exec_grant_is_med(tmp_path):
+    """Tier 2: a phase GRANTING sandboxed_exec → MED exec-capability (NOT HIGH —
+    legit build/test skills; security-UX balance keeps CI-block off the grant)."""
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["sandboxed_exec"])})
+    assert ("gateway:exec-capability", "MED") in _rules(_gateway_skill_ops(d))
+
+
+def test_network_grant_is_egress_info(tmp_path):
+    """Tier 2: a network grant with no secret access → egress INFO."""
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["web_fetch"])})
+    assert ("gateway:egress", "INFO") in _rules(_gateway_skill_ops(d))
+
+
+def test_network_plus_recall_is_egress_secrets_high(tmp_path):
+    """Tier 2: a network grant co-occurring (skill-wide) with recall (secret
+    access) → HIGH egress+secrets, NOT a plain egress INFO (upgraded)."""
+    d = _skill(tmp_path, "s", {
+        "fetch": _phase_md("fetch", allowed_ops=["web_fetch"]),
+        "remember": _phase_md("remember", allowed_ops=["recall"]),
+    })
+    rules = _rules(_gateway_skill_ops(d))
+    assert ("gateway:egress+secrets", "HIGH") in rules
+    assert ("gateway:egress", "INFO") not in rules
+
+
+def test_coarse_mcp_grant_is_egress(tmp_path):
+    """Tier 2: a coarse ``mcp`` grant resolves (COARSE_TO_FINE) to call_mcp_tool →
+    egress (the capability is seen through the coarse family)."""
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["mcp"])})
+    assert any(r == "gateway:egress" for r, _ in _rules(_gateway_skill_ops(d)))
+
+
+# ── literal preprocessor signals ─────────────────────────────────────────────
+
+
+def test_literal_preprocessor_exec_is_high(tmp_path):
+    """Tier 2: a LITERAL sandboxed_exec in a preprocessor → HIGH (a hard-coded
+    exec is materially riskier than a mere grant)."""
+    pre = _runop("kind: sandboxed_exec, argv: [echo, hi]")
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["sandboxed_exec"], preprocessor=pre)})
+    assert ("gateway:sandboxed-exec", "HIGH") in _rules(_gateway_skill_ops(d))
+
+
+def test_out_of_zone_absolute_path_is_broad_fs_med(tmp_path):
+    """Tier 2: a literal preprocessor file op with an ABSOLUTE path → broad-FS MED."""
+    pre = _runop("kind: write_file, path: /etc/evil")
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["write_file"], preprocessor=pre)})
+    assert ("gateway:broad-fs", "MED") in _rules(_gateway_skill_ops(d))
+
+
+def test_out_of_zone_traversal_path_is_broad_fs_med(tmp_path):
+    """Tier 2: a literal preprocessor file op with a ``..`` traversal path → MED."""
+    pre = _runop("kind: edit_file, path: ../../etc/passwd")
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["edit_file"], preprocessor=pre)})
+    assert ("gateway:broad-fs", "MED") in _rules(_gateway_skill_ops(d))
+
+
+def test_in_zone_relative_path_not_flagged(tmp_path):
+    """Tier 2: a relative in-zone preprocessor path is NOT flagged (no false pos)."""
+    pre = _runop("kind: write_file, path: out/result.txt")
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["write_file"], preprocessor=pre)})
+    assert not any(f.rule == "gateway:broad-fs" for f in _gateway_skill_ops(d))
+
+
+def test_benign_skill_has_no_gateway_ops_findings(tmp_path):
+    """Tier 2: a skill with only read/grep ops + no exec/network/out-of-zone →
+    no gateway-ops findings (no over-flagging the common case)."""
+    d = _skill(tmp_path, "s", {"act": _phase_md("act", allowed_ops=["read_file", "grep_files"])})
+    assert _gateway_skill_ops(d) == []
+
+
+# ── completeness guard (vs OP_PURITY) ────────────────────────────────────────
+
+
+def test_category_map_complete_vs_op_purity():
+    """Tier 2: every world/side_effect op kind is classified in the gateway
+    category map OR the acknowledged-benign set — a new gateway-relevant op added
+    to OP_PURITY fails here until triaged (completeness-by-construction, the
+    dev-time hint; no per-skill runtime noise)."""
+    from reyn.core.op_runtime.registry import OP_PURITY, OpPurity
+
+    gateway_relevant = {k for k, v in OP_PURITY.items()
+                        if v in (OpPurity.world, OpPurity.side_effect)}
+    classified = _EXEC_OPS | _EGRESS_OPS | _SECRET_OPS | _FS_PATH_OPS
+    # Acknowledged: world/side_effect ops that are NOT a phase-ops gateway concern
+    # (internal RAG/read, name resolve, task mgmt, UI, plugin lifecycle — the last
+    # covered by _gateway_mcp). A new op in neither set → triage.
+    acknowledged = {
+        "index_query", "index_drop", "skill_resolve", "ask_user",
+        "mcp_install", "mcp_drop_server",
+        "task.get", "task.list", "task.create", "task.update_status",
+        "task.add_dependency", "task.remove_dependency", "task.repoint_dependency",
+        "task.abort", "task.heartbeat", "task.register_unblock_predicate", "task.comment",
+    }
+    uncovered = gateway_relevant - classified - acknowledged
+    assert not uncovered, (
+        f"world/side_effect op(s) unclassified for the gateway audit: {sorted(uncovered)} "
+        f"— add to the category map (_EXEC/_EGRESS/_SECRET/_FS_PATH_OPS) or the acknowledged set"
+    )


### PR DESCRIPTION
**[dogfood-coder]** — `Fixes #1892` (follow-up to #1864 `reyn audit`). Implements the lead-approved design note (#1892 issuecomment-4762240051) with **Q1–Q3 decided**. Extends `reyn audit` rule 3 with `_gateway_skill_ops`: deep **static** analysis of a skill's **control_ir / phase ops** (vs the `.py`-text scan in `_gateway_skill`). Static-only — reuses `compiler.parser.parse_phase` + `OP_PURITY` + the existing `Finding` model; **never executes** skill code (reads the parsed IR).

## Signals + severities (Q1–Q3, lead-decided)
| signal | source | rule | severity |
|---|---|---|---|
| `sandboxed_exec` GRANT (`allowed_ops`) | grant | `gateway:exec-capability` | **MED** (Q1) |
| LITERAL `sandboxed_exec` in a `preprocessor` | literal arg | `gateway:sandboxed-exec` | **HIGH** |
| network GRANT (`web_fetch`/`web_search`/`mcp`/`call_mcp_tool`, coarse-resolved) | grant | `gateway:egress` | **INFO** |
| network grant + secret access (`recall` grant or secret-permission decl, skill-wide) | grant | `gateway:egress+secrets` | **HIGH** (Q2) |
| out-of-zone LITERAL preprocessor file path (absolute / `..`-traversal) | literal arg | `gateway:broad-fs` | **MED** (Q3) |

**Q1 (the security-UX-balance call)**: the `sandboxed_exec` *grant* is MED, not HIGH — many legit build/test/git skills are granted it, so a blanket HIGH would be false-positive CI-block friction; a *literal hard-coded* exec in a preprocessor is materially riskier → HIGH. (Severity policy is config-tightenable in a later pass, per your note.)

## Static-knowability scope (the proportionate design)
The audit flags (a) the op-KIND capability **GRANT** (`allowed_ops`, statically declared) and (b) **literal** preprocessor op args. Runtime LLM-emitted op args are out of static scope — **the grant *is* the auditable gateway-exposure** (the OpenClaw `audit-*` analog flags capability, not runtime values).

## Completeness guard (dev-time, no runtime noise)
The op-kind→category map is single-sourced; `test_category_map_complete_vs_op_purity` asserts every `world`/`side_effect` op in `OP_PURITY` is in the category map **or** an acknowledged-benign set — so a new gateway-relevant op fails the test until classified. (A runtime `unclassified-op` finding would be per-skill noise; the test is the right layer.)

## Verification
- 10 new tests (real tmp skill fixtures, no mock): each severity pattern + coarse-`mcp` resolution + in-zone-not-flagged + benign-skill-no-findings + the completeness guard.
- ruff + tier-audit --strict clean; **42 tests incl. the #1864 `test_reyn_audit_1864.py` (no regression)**; `reyn audit --json` runs clean end-to-end.
- Static-only (net-isolation OK); CLI audit — no LLM payload, **no replay re-key**.

## Test plan
- [x] grant signals: sandboxed_exec→MED, network→egress INFO, network+recall→egress+secrets HIGH, coarse-mcp→egress
- [x] literal preprocessor: sandboxed_exec→HIGH, out-of-zone path (absolute + `..`)→broad-FS MED
- [x] no false-positives: in-zone path + benign read/grep skill → no findings
- [x] completeness guard vs OP_PURITY (new gateway-op fails until classified)
- [x] ruff + tier-audit clean; 42-test incl #1864 no-regression; end-to-end command smoke
- [ ] (lead) careful security review (severity policy + the grant-vs-literal split + Q2/Q3 signals)

CI-green ping to follow → your careful review (security feature). sandbox_2 does not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
