### PR TITLE
refactor(#1953): OS-plan-residue — plan_step badge + plan lifecycle + step_compaction config

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -334,43 +334,9 @@ class ChatConfig:
 
 
 @dataclass
-class PlannerStepCompactionConfig:
-    """`plan.step_compaction:` — Plan step_results compaction policy (PR-N4).
-
-    Mirrors CompactionConfig's ratio-based approach but scoped to the
-    prior-step output accumulation that feeds each plan step's sub-loop
-    system prompt.  When accumulated step_results would balloon the next
-    step's sys_prompt, older entries are summarised using
-    CompactionEngine and replaced with a single
-    ``__compacted_step_summary__`` entry.
-
-    Fields
-    ------
-    recent_step_results_raw:
-        Keep the last N step_results verbatim; compact older ones.
-    summarize_older_threshold_tokens:
-        Total token threshold above which older step_results are compacted.
-        ``None`` uses the CompactionEngine's ``effective_trigger`` from
-        ``ComputedBudgets`` (= derived from the router model context window).
-    step_results_ratio:
-        Fraction of ``main_pool`` (= T_max - T_SP) allocated for the
-        step_results portion of the next step's sys_prompt.  Sibling to
-        CompactionConfig.component_weights["body"].
-    use_chars4_estimate:
-        When True, use len(text)//4 for token estimation instead of
-        litellm.token_counter (latency opt-out, mirrors CompactionConfig).
-    """
-    recent_step_results_raw: int = 3
-    summarize_older_threshold_tokens: int | None = None
-    step_results_ratio: float = 0.50
-    use_chars4_estimate: bool = False
-
-
-@dataclass
 class PhaseActResultsCompactionConfig:
     """`phase.act_results_compaction:` — phase act-loop control_ir_results
-    compaction policy. Sibling to CompactionConfig (chat) and
-    PlannerStepCompactionConfig (planner step).
+    compaction policy. Sibling to CompactionConfig (chat).
 
     When accumulated ``control_ir_results`` in a phase's act loop would push
     the next prompt over the model's effective context budget, older results
@@ -382,9 +348,8 @@ class PhaseActResultsCompactionConfig:
     ------
     recent_act_turns_raw:
         Keep the last N act-turn results verbatim; compact older ones.
-        Higher than PlannerStepCompactionConfig.recent_step_results_raw (= 3)
-        because phase ops carry specific data the LLM needs to plan next ops.
-        Default 5.
+        Default 5 (a wider raw window than chat compaction because phase ops
+        carry specific data the LLM needs to plan next ops).
     control_ir_results_ratio:
         Fraction of ``main_pool`` (= T_max - T_SP) allocated for the
         control_ir_results portion of the act-loop context. Sibling to
@@ -553,51 +518,6 @@ def _build_phase_act_results_compaction_config(
     )
 
 
-def _build_plan_step_compaction_config(raw: object) -> "PlannerStepCompactionConfig":
-    """Parse ``plan.step_compaction:`` sub-block.
-
-    Missing / non-dict block returns defaults.  Unknown keys are ignored
-    (forward-compat).
-    """
-    defaults = PlannerStepCompactionConfig()
-    if not isinstance(raw, dict):
-        return defaults
-
-    recent_raw = raw.get("recent_step_results_raw")
-    try:
-        recent = int(recent_raw) if recent_raw is not None else defaults.recent_step_results_raw
-    except (TypeError, ValueError):
-        recent = defaults.recent_step_results_raw
-    if recent < 0:
-        recent = defaults.recent_step_results_raw
-
-    threshold_raw = raw.get("summarize_older_threshold_tokens")
-    if threshold_raw is None:
-        threshold: int | None = None
-    else:
-        try:
-            threshold = int(threshold_raw)
-            if threshold <= 0:
-                threshold = None
-        except (TypeError, ValueError):
-            threshold = None
-
-    ratio_raw = raw.get("step_results_ratio")
-    try:
-        ratio = float(ratio_raw) if ratio_raw is not None else defaults.step_results_ratio
-    except (TypeError, ValueError):
-        ratio = defaults.step_results_ratio
-    if not (0.0 < ratio <= 1.0):
-        ratio = defaults.step_results_ratio
-
-    use_chars4 = bool(raw.get("use_chars4_estimate", defaults.use_chars4_estimate))
-
-    return PlannerStepCompactionConfig(
-        recent_step_results_raw=recent,
-        summarize_older_threshold_tokens=threshold,
-        step_results_ratio=ratio,
-        use_chars4_estimate=use_chars4,
-    )
 
 
 # ── FP-0004: safety: section parsers ───────────────────────────────────────

--- a/src/reyn/config/execution.py
+++ b/src/reyn/config/execution.py
@@ -6,10 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from reyn.config.chat import (  # #1682 #3: plan-step compaction configs live in chat
+from reyn.config.chat import (  # #1682 #3: phase compaction config lives in chat
     PhaseActResultsCompactionConfig,
-    PlannerStepCompactionConfig,
-    _build_plan_step_compaction_config,  # #1682 #3 cross-section
 )
 from reyn.runtime.budget.budget import CostConfig, CostLimitConfig
 
@@ -86,17 +84,9 @@ class PlanConfig:
     (FP-0031-C).  Default 3.  Set 0 to disable auto-retry.  Exceptions
     that have their own ask/abort path (PermissionError, BudgetExceeded,
     etc.) are always excluded from retry regardless of this setting.
-
-    ``step_compaction``: prior step_results compaction policy (PR-N4).
-    When accumulated step outputs would exceed the threshold, older entries
-    are summarised by CompactionEngine before the next step's sys_prompt
-    is built.  Default-enabled with conservative thresholds.
     """
     step_max_iterations: int = 5
     retry_limit: int = 3
-    step_compaction: PlannerStepCompactionConfig = field(
-        default_factory=PlannerStepCompactionConfig
-    )
 
 
 @dataclass
@@ -309,9 +299,7 @@ def _build_plan_config(raw: object) -> PlanConfig:
         retry_limit = defaults.retry_limit
     if retry_limit < 0:
         retry_limit = defaults.retry_limit
-    step_compaction = _build_plan_step_compaction_config(raw.get("step_compaction"))
     return PlanConfig(
         step_max_iterations=step_max,
         retry_limit=retry_limit,
-        step_compaction=step_compaction,
     )

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -473,10 +473,6 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         skill_resume=_build_skill_resume_config(merged.get("skill_resume")),
         time_travel=_build_time_travel_config(merged.get("time_travel")),
         tool_use=_build_tool_use_config(merged.get("tool_use")),
-        plan_resume_raw=(
-            merged.get("plan_resume")
-            if isinstance(merged.get("plan_resume"), dict) else None
-        ),
         voice=_build_voice_config(merged.get("voice")),
         embedding=_build_embedding_config(merged.get("embedding")),
         safety=safety,

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -221,11 +221,6 @@ class ReynConfig:
     # #1593 — per-layer tool-use scheme selector (chat/step/phase). Default all
     # universal-category (today's behaviour); generalizes universal_wrappers_enabled.
     tool_use: ToolUseConfig = field(default_factory=ToolUseConfig)
-    # Plan resume policy (ADR-0023 Phase 2) — how the resume coordinator
-    # treats interrupted plan-mode runs on restart. Loaded as a raw dict
-    # and parsed lazily by the coordinator (= keeps PlanResumeConfig in
-    # the plan/ module rather than coupling config.py to it).
-    plan_resume_raw: dict | None = None
     # Voice input (Whisper) settings for the chat TUI. Optional feature gated
     # by the `reyn[voice]` extras; the OS itself never depends on this block.
     voice: VoiceConfig = field(default_factory=VoiceConfig)

--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -65,15 +65,6 @@ class AgentSnapshot:
     # is the runtime cache; this field is its on-disk durable form).
     # Each value is ``{"text": str, "choice_id": str | None}``.
     buffered_intervention_answers: dict[str, dict] = field(default_factory=dict)
-    # ADR-0022 — plan-mode crash resilience Phase 1.
-    # plan_ids of in-flight plan-mode executions for this agent. Populated
-    # by `plan_started` WAL events; pruned by `plan_completed` /
-    # `plan_aborted`. AgentRegistry.restore_all uses non-empty
-    # active_plan_ids post-replay as the "interrupted plan" signal and
-    # discards orphan child skills + emits a user-facing outbox message.
-    # Additive field (no SNAPSHOT_VERSION bump) — follows the R-D13
-    # `parent_run_id` precedent on `load`: defaults to [] when absent.
-    active_plan_ids: list[str] = field(default_factory=list)
 
     # ── persistence ─────────────────────────────────────────────────────
 
@@ -131,9 +122,6 @@ class AgentSnapshot:
             buffered_intervention_answers=dict(
                 data.get("buffered_intervention_answers", {}) or {}
             ),
-            # ADR-0022: additive — defaults to [] when reading older snapshots
-            # written before the field existed. No SNAPSHOT_VERSION bump.
-            active_plan_ids=list(data.get("active_plan_ids", []) or []),
         )
 
     def save(self, path: Path) -> None:
@@ -149,7 +137,6 @@ class AgentSnapshot:
             "active_skill_run_ids": self.active_skill_run_ids,
             "outstanding_interventions": self.outstanding_interventions,
             "buffered_intervention_answers": self.buffered_intervention_answers,
-            "active_plan_ids": self.active_plan_ids,
         }
         with tmp.open("w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
@@ -246,15 +233,6 @@ class AgentSnapshot:
             run_id = event.get("run_id")
             if run_id:
                 self.buffered_intervention_answers.pop(run_id, None)
-        # ── ADR-0022: plan-mode lifecycle (Phase 1) ─────────────────────
-        elif kind == "plan_started":
-            plan_id = event.get("plan_id")
-            if plan_id and plan_id not in self.active_plan_ids:
-                self.active_plan_ids.append(plan_id)
-        elif kind in ("plan_completed", "plan_aborted"):
-            plan_id = event.get("plan_id")
-            if plan_id and plan_id in self.active_plan_ids:
-                self.active_plan_ids.remove(plan_id)
         # skill_phase_advanced, step_started/completed/failed, skill_resumed
         # mutate per-skill snapshot only — no agent-level state change here.
         # Unknown kinds: no-op (forward compatibility for future kinds)

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -47,7 +47,6 @@ class EventLog:
         *,
         agent_id: str | None = None,
         run_id: str | None = None,
-        plan_step: dict | None = None,
     ) -> None:
         self._events: list[Event] = []
         self._subscribers: list[Callable[[Event], None]] = list(subscribers or [])
@@ -62,15 +61,6 @@ class EventLog:
         # sub-skill spawned via the ``run_skill`` op (which currently
         # inherits the parent's subscriber list).
         self._run_id = run_id
-        # Issue #214 (= #180 #2 split): plan_step is auto-injected when
-        # a skill OSRuntime is constructed within the scope of a plan
-        # step. Subscribers (= ChatEventForwarder) read ``plan_step`` on
-        # the first ``phase_started`` to render "plan N/M" detail on the
-        # SkillActivityRow, so the user can correlate a spawned skill
-        # row with the originating step. Same caller-wins convention as
-        # agent_id / run_id. Shape: {"n_done": int, "n_total": int,
-        # "step_id": str}. None = top-level (not inside a plan step).
-        self._plan_step = plan_step
 
     @property
     def subscribers(self) -> list[Callable[[Event], None]]:
@@ -90,11 +80,6 @@ class EventLog:
     def run_id(self) -> str | None:
         """The run_id this EventLog stamps onto emitted events (issue #134)."""
         return self._run_id
-
-    @property
-    def plan_step(self) -> dict | None:
-        """The plan_step this EventLog stamps onto emitted events (issue #214)."""
-        return self._plan_step
 
     def add_subscriber(self, fn: Callable[[Event], None]) -> None:
         self._subscribers.append(fn)
@@ -128,13 +113,6 @@ class EventLog:
         # the parent's subscriber list.
         if self._run_id and "run_id" not in data:
             data = {**data, "run_id": self._run_id}
-        # Issue #214: stamp plan_step (= {n_done, n_total, step_id}) so
-        # ChatEventForwarder can render "plan N/M" detail on the
-        # SkillActivityRow of any skill spawned inside a plan step.
-        # Caller-wins matches the run_id / agent_id pattern — a skill
-        # explicitly emitting plan_step in data is preserved.
-        if self._plan_step and "plan_step" not in data:
-            data = {**data, "plan_step": self._plan_step}
         event = Event(type=type, data=data)
         self._events.append(event)
         for sub in self._subscribers:

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -60,10 +60,6 @@ WAL_EVENT_KINDS = (
     # second crash before the resuming skill consumes it
     "intervention_answer_buffered",
     "intervention_answer_consumed",
-    # NEW (ADR-0022) — plan-mode lifecycle (Phase 1: fail-safe + observability)
-    "plan_started",
-    "plan_completed",
-    "plan_aborted",
     # NEW (ADR-0023 Phase 2 step 4) — per-step events promoted from
     # events-log into WAL for resume determinism. The analyzer pairs
     # (plan_step_started, plan_step_completed | plan_step_failed) by

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -89,7 +89,6 @@ class OSRuntime:
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
         secret_store: "ScopedSecretStore | None" = None,
-        plan_step: dict | None = None,
         workspace_base_dir: "Path | None" = None,
         workspace_state_dir: "Path | None" = None,
         phase_compaction_engine: "CompactionEngine | None" = None,
@@ -111,7 +110,7 @@ class OSRuntime:
         # #1092); un-listed skills run json-mode unchanged.
         self._tool_calls_op_loop_skills = list(tool_calls_op_loop_skills or [])
         self.events = EventLog(
-            subscribers=subscribers, run_id=run_id, plan_step=plan_step,
+            subscribers=subscribers, run_id=run_id,
         )
         # #1669: publish this runtime's EventLog as the ambient sink for the LLM
         # acompletion chokepoint, so every LLM call in this run emits an observable

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -169,15 +169,6 @@ class OpContext:
     # passes it down through Agent → OSRuntime → executors → OpContext.
     secret_store: "ScopedSecretStore | None" = None
 
-    # Issue #214 (= #180 #2 split): plan_step context for any skill spawned
-    # within a plan step's RouterLoop. ``run_skill`` op propagates this
-    # forward to the sub-skill's OSRuntime so the child EventLog stamps
-    # ``plan_step`` into every emit, letting ChatEventForwarder render
-    # "plan N/M" detail on the child's SkillActivityRow. None = top-level
-    # (= not inside a plan step). Shape: ``{"n_done": int, "n_total": int,
-    # "step_id": str}``.
-    plan_step: dict | None = None
-
     # #1470: per-turn asyncio.Event fired by cancel_inflight(). When set,
     # sandboxed_exec backends kill the running subprocess instead of waiting
     # for it to complete. None = no cancel-awareness (OS-internal ops,

--- a/src/reyn/runtime/forwarder.py
+++ b/src/reyn/runtime/forwarder.py
@@ -28,10 +28,6 @@ class ChatEventForwarder:
         self.skill_name = skill_name
         self.outbox = outbox
         self.run_id = run_id
-        # Issue #214: track which run_ids have already received their
-        # "plan N/M" one-shot detail so we don't spam the row on every
-        # phase advance (= once per child skill at first phase_started).
-        self._plan_step_announced: set[str] = set()
 
     def __call__(self, event: Event) -> None:
         handler = getattr(self, f"on_{event.type}", None)
@@ -42,28 +38,6 @@ class ChatEventForwarder:
         phase = data.get("phase", "?")
         # No [skill_name] prefix — renderer prepends it from meta provenance.
         source_run_id = data.get("run_id")
-        # Issue #214: when the event carries plan_step, emit a one-shot
-        # "plan N/M" detail line for this run_id BEFORE the phase trace.
-        # The SkillActivityRow detail is replaced on the NEXT in-phase
-        # signal (on_llm_called / on_act_executed) — so the user sees
-        # "plan N/M" briefly on row mount, then it gets overwritten by
-        # real-time signals. That's the right tradeoff: plan context is
-        # most useful at row mount; once the skill is grinding, the
-        # in-phase signal carries more information.
-        plan_step = data.get("plan_step")
-        if (
-            plan_step
-            and source_run_id
-            and source_run_id not in self._plan_step_announced
-        ):
-            n_done = plan_step.get("n_done")
-            n_total = plan_step.get("n_total")
-            if n_done and n_total:
-                self._enqueue(
-                    f"detail: plan {n_done}/{n_total}",
-                    source_run_id=source_run_id,
-                )
-                self._plan_step_announced.add(source_run_id)
         self._enqueue(f"phase started: {phase}", source_run_id=source_run_id)
 
     def on_phase_completed(self, data: dict) -> None:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -579,9 +579,6 @@ class AgentRegistry:
         # restore — without it, an agent whose only stranded state is an
         # in-flight ask_user would be skipped here and the user could not
         # clear the queued intervention after restart.
-        # ADR-0022: active_plan_ids also triggers restore — needed so the
-        # cleanup hook can fire and notify the user that their plan was
-        # interrupted.
         # FP-0043 S5: the main session is get_or_load'd + ensure_running (live,
         # unchanged); a spawned session is recreated via spawn_session(name, sid)
         # — which re-applies the S5 path fixup — then re-adopts its state. Its
@@ -589,8 +586,7 @@ class AgentRegistry:
         for (name, sid), snap in all_snaps.items():
             if (not snap.inbox
                     and not snap.pending_chains
-                    and not snap.outstanding_interventions
-                    and not snap.active_plan_ids):
+                    and not snap.outstanding_interventions):
                 continue
             if sid == _DEFAULT_SID:
                 session = self.get_or_load(name)

--- a/src/reyn/services/compaction/__init__.py
+++ b/src/reyn/services/compaction/__init__.py
@@ -1,6 +1,5 @@
 """Compaction engine — multi-axis OS-internal compaction (chat / planner step / phase)."""
 from reyn.services.compaction.engine import (
-    STEP_RESULTS_COMPACTED_KEY,
     ChatSummary,
     ChatSummaryRaw,
     CompactionEngine,
@@ -13,7 +12,6 @@ from reyn.services.compaction.engine import (
     UnrecoveredError,
     assert_static_bounds,
     compact_control_ir_results,
-    compact_step_results,
     compute_budgets,
     compute_covers_through_seq,
     estimate_tokens,
@@ -35,10 +33,8 @@ __all__ = [
     "ForceCompactRaceUnrecoveredError",
     "NewMsgExceedsBudgetError",
     "UnrecoveredError",
-    "STEP_RESULTS_COMPACTED_KEY",
     "assert_static_bounds",
     "compact_control_ir_results",
-    "compact_step_results",
     "compute_budgets",
     "compute_covers_through_seq",
     "estimate_tokens",

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -57,7 +57,6 @@ if TYPE_CHECKING:
     from reyn.config import (
         CompactionConfig,
         PhaseActResultsCompactionConfig,
-        PlannerStepCompactionConfig,
     )
     from reyn.core.events.events import EventLog
     from reyn.llm.model_resolver import ModelResolver
@@ -1127,193 +1126,9 @@ def _get_learner_class() -> type:
 
 
 # ---------------------------------------------------------------------------
-# Step-results compaction (PR-N4)
+# Phase act-results compaction (control_ir_results)
 # ---------------------------------------------------------------------------
 
-# Stable key used to store the compacted summary in the step_results dict.
-# Chosen to be visually distinct from step IDs (which are short hex-like
-# strings) and to signal "this is a synthetic OS-inserted entry".
-STEP_RESULTS_COMPACTED_KEY = "__compacted_step_summary__"
-
-# System prompt for the step-results summariser.  Distinct from
-# _COMPACTION_SYSTEM_PROMPT (chat axis) to avoid coupling the step-results
-# concept to chat-history structure fields (topic_arc, decisions, etc.).
-_STEP_RESULTS_SUMMARY_PROMPT = """\
-You are summarising several prior plan-step outputs into a single concise summary.
-
-Each input entry is a key-value pair where the key is the step ID and the value
-is the step's output text.
-
-Your task:
-- Produce a single paragraph (or two at most) that preserves ALL actionable
-  findings from the inputs: relevant code paths, function names, file paths,
-  line numbers, key values, decisions made.
-- Prioritise information that a later synthesis step would need to produce a
-  correct final reply.
-- Do NOT add commentary about what was summarised — output the summary text only.
-Output ONLY the summary text. No headers, no bullet points, no JSON.
-"""
-
-
-async def compact_step_results(
-    step_results: dict[str, str],
-    *,
-    engine: "CompactionEngine",
-    cfg: "PlannerStepCompactionConfig",
-    events: "EventLog",
-) -> dict[str, str]:
-    """Return a new step_results dict where older entries are summarised.
-
-    PR-N4 (FP-0008): step_results compaction.
-
-    Algorithm
-    ---------
-    1. Estimate total token cost of all step_results values as plain text.
-    2. Compute the effective threshold: ``cfg.summarize_older_threshold_tokens``
-       when set, else ``step_results_ratio * engine.budgets.main_pool``.
-    3. If total tokens ≤ threshold → return the input unchanged (identity).
-    4. Split into *recent* (last ``cfg.recent_step_results_raw`` keys) and
-       *older* (all keys before the recent window).
-    5. Run one LLM summarisation call on the older values via the engine's
-       model and proxy configuration.
-    6. Apply ``hard_truncate_summary`` to bound the summary to ``body_budget``.
-    7. Return ``{STEP_RESULTS_COMPACTED_KEY: summary, **recent_dict}``.
-    8. Emit ``planner_step_results_compacted`` event.
-
-    Bounded
-    -------
-    After compaction, token count of the returned dict's values is bounded by
-    ``body_budget + sum(recent step tokens)`` where ``body_budget`` comes from
-    the engine's ComputedBudgets (= same cap used for chat summary truncation,
-    Axis 9).
-
-    Failure modes
-    -------------
-    - If fewer than 2 step_results exist, or all entries fit in recent window,
-      returns unchanged (= no-op).
-    - If the summarisation LLM call fails, emits
-      ``planner_step_results_compaction_failed`` and returns the input unchanged
-      (= best-effort; does NOT raise — the step proceeds with the un-compacted
-      prompt rather than crashing the plan run).
-
-    Multimodal note: step_results values are plain strings (``dict[str, str]``),
-    so no image-aware token counting is required.
-    """
-    if not step_results:
-        return step_results
-
-    keys = list(step_results.keys())
-    use_chars4 = cfg.use_chars4_estimate
-    model = engine._model  # noqa: SLF001 — internal use; CompactionEngine owns this
-
-    # Step 1: estimate total tokens of all step_results values.
-    total_tokens = sum(
-        estimate_tokens(v, model, use_chars4=use_chars4)
-        for v in step_results.values()
-    )
-
-    # Step 2: effective threshold.
-    if cfg.summarize_older_threshold_tokens is not None:
-        threshold = cfg.summarize_older_threshold_tokens
-    else:
-        threshold = int(cfg.step_results_ratio * engine.budgets.main_pool)
-        if threshold <= 0:
-            # Model context info unavailable — skip compaction.
-            return step_results
-
-    # Step 3: identity check.
-    if total_tokens <= threshold:
-        return step_results
-
-    # Step 4: split into older + recent.
-    n_recent = max(0, cfg.recent_step_results_raw)
-    recent_keys = keys[-n_recent:] if n_recent > 0 else []
-    older_keys = keys[: len(keys) - n_recent] if n_recent > 0 else keys
-
-    if not older_keys:
-        # Nothing to compact (all entries are within the recent window).
-        return step_results
-
-    older_text = "\n\n".join(
-        f"[Step {k}]\n{step_results[k]}" for k in older_keys
-    )
-
-    # Step 5 + 6: call LLM summariser, then hard-truncate.
-    summary_text: str
-    try:
-        from reyn.llm.llm import recorded_acompletion
-        response = await recorded_acompletion(
-            model=model,
-            messages=[
-                {"role": "system", "content": _STEP_RESULTS_SUMMARY_PROMPT},
-                {"role": "user", "content": older_text},
-            ],
-            purpose="compaction",
-            recorder=getattr(engine, "_recorder", None),
-            agent=getattr(engine, "_recorder_agent", None),
-        )
-        raw_summary = (response.choices[0].message.content or "").strip()
-        if not raw_summary:
-            raise ValueError("step_results compaction LLM returned empty response")
-        # Bound the summary to the engine's body_budget (Axis 9 pattern).
-        summary_text = hard_truncate_summary(
-            raw_summary,
-            engine.budgets.body_budget,
-            model,
-            events,
-            use_chars4=use_chars4,
-        )
-    except Exception as exc:  # noqa: BLE001 — best-effort; never raise
-        logger.warning(
-            "compact_step_results: LLM summarisation failed (%r); "
-            "proceeding with un-compacted step_results",
-            exc,
-        )
-        try:
-            events.emit(
-                "planner_step_results_compaction_failed",
-                n_older=len(older_keys),
-                error=repr(exc),
-            )
-        except Exception:  # noqa: BLE001
-            pass
-        return step_results
-
-    # Step 7: build result dict.
-    recent_dict = {k: step_results[k] for k in recent_keys}
-    result: dict[str, str] = {STEP_RESULTS_COMPACTED_KEY: summary_text, **recent_dict}
-
-    # Step 8: emit event.
-    original_tokens = total_tokens
-    summary_tokens = estimate_tokens(summary_text, model, use_chars4=use_chars4)
-    recent_tokens = sum(
-        estimate_tokens(step_results[k], model, use_chars4=use_chars4)
-        for k in recent_keys
-    )
-    try:
-        events.emit(
-            "planner_step_results_compacted",
-            n_older_compacted=len(older_keys),
-            n_recent_kept=len(recent_keys),
-            original_tokens=original_tokens,
-            summary_tokens=summary_tokens,
-            recent_tokens=recent_tokens,
-        )
-    except Exception:  # noqa: BLE001
-        pass
-
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Phase act-loop control_ir_results compaction (PR-N5)
-# ---------------------------------------------------------------------------
-
-# Phase axis comp_SP — op-kind-aware structured preservation.
-# Distinct from the chat axis comp_SP (_COMPACTION_SYSTEM_PROMPT) because
-# phase op results carry specific data (paths, line numbers, exit codes) that
-# the LLM must retain to continue acting on them; pure abstraction loses
-# utility.
 _PHASE_COMPACTION_SYSTEM_PROMPT = """\
 You are summarising older `control_ir_results` from a phase's act loop
 to keep the next prompt within the model's context budget.
@@ -1503,10 +1318,8 @@ __all__ = [
     "ForceCompactRaceUnrecoveredError",
     "NewMsgExceedsBudgetError",
     "UnrecoveredError",
-    "STEP_RESULTS_COMPACTED_KEY",
     "assert_static_bounds",
     "compact_control_ir_results",
-    "compact_step_results",
     "compute_budgets",
     "compute_covers_through_seq",
     "estimate_tokens",

--- a/src/reyn/skill/run_skill.py
+++ b/src/reyn/skill/run_skill.py
@@ -234,9 +234,6 @@ async def run(op: RunSkillIROp, ctx: OpContext, caller: Literal["preprocessor", 
         # /skill list and future cascade-discard can walk the tree.
         parent_run_id=ctx.parent_skill_run_id,
         secret_store=scoped_store,
-        # Issue #214: forward plan_step so the sub-skill's EventLog
-        # stamps "plan N/M" context into every emit. None = not in a plan.
-        plan_step=ctx.plan_step,
     )
 
     # PR20: per-run events live at

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -680,10 +680,6 @@ class SkillRunner:
             subscribers=self._make_subscribers(skill_name, run_id),
         )
 
-        # Issue #214: forward the plan_step ContextVar so a blocking
-        # router invoke_skill inside a plan step's sub-loop stamps the
-        # spawned skill's events with the originating step.
-        _plan_step = None  # plan-step context removed with plan (#1953)
         try:
             result = await agent.run(
                 skill, input_artifact,
@@ -691,7 +687,6 @@ class SkillRunner:
                 chain_id=chain_id,
                 skill_registry=self._get_skill_registry(),
                 state_log=self._state_log,
-                plan_step=_plan_step,
             )
         except asyncio.CancelledError:
             return {"status": "error", "data": {"error": "cancelled"}}
@@ -874,12 +869,6 @@ class SkillRunner:
         # success) produced the terminal status.
         _terminal_status: str | None = None
         _terminal_data: dict = {}
-        # Issue #214: read the plan_step ContextVar set by planner.py
-        # around the step's sub-RouterLoop. ContextVar propagates through
-        # any asyncio.Task created within the scope, so this spawn site
-        # sees the planner-set value when the skill was invoked inside a
-        # plan step. None = top-level invocation (not in a plan).
-        _plan_step = None  # plan-step context removed with plan (#1953)
         try:
             result = await agent.run(
                 skill, input_artifact,
@@ -887,7 +876,6 @@ class SkillRunner:
                 chain_id=chain_id,
                 skill_registry=self._get_skill_registry(),
                 state_log=self._state_log,
-                plan_step=_plan_step,
             )
         except asyncio.CancelledError:
             await self._put_outbox(SkillOutboundMessage(

--- a/src/reyn/skill/skill_runtime.py
+++ b/src/reyn/skill/skill_runtime.py
@@ -265,7 +265,6 @@ class SkillRuntime:
         resume_plan: "Any | None" = None,
         run_id: str | None = None,
         parent_run_id: str | None = None,
-        plan_step: dict | None = None,
     ) -> RunResult:
         # Run-id resolution priority (FP-0008 PR-R wiring contract):
         #   1. ``run_id`` kwarg to this call    (= caller overrides per-call)
@@ -333,7 +332,6 @@ class SkillRuntime:
             multimodal_config=self._multimodal_config,
             media_store=self._media_store,
             secret_store=self._secret_store,
-            plan_step=plan_step,
             workspace_base_dir=self._workspace_base_dir,
             workspace_state_dir=self._workspace_state_dir,
             tool_calls_op_loop_skills=self._tool_calls_op_loop_skills,

--- a/src/reyn/skill/sub_skill_runner.py
+++ b/src/reyn/skill/sub_skill_runner.py
@@ -46,7 +46,6 @@ async def invoke_sub_skill(
     caller: str = "direct",
     parent_run_id: str | None = None,
     secret_store: "ScopedSecretStore | None" = None,  # NEW (FP-0016 D)
-    plan_step: dict | None = None,
 ) -> SubSkillResult:
     """Run a sub-app and return a SubSkillResult.
 
@@ -87,7 +86,6 @@ async def invoke_sub_skill(
         sub_skill, input_artifact,
         output_language=output_language,
         parent_run_id=parent_run_id,
-        plan_step=plan_step,
     )
     return SubSkillResult(
         data=run_result.data,

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -92,7 +92,6 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
         "inbox": "session.inbox drained",
         "pending_chains": "session._chains.reset()",
         "active_skill_run_ids": "session.running_skills (+ started_at / chain) cleared",
-        "active_plan_ids": "session.running_plans cleared",
         "outstanding_interventions": "session._interventions.clear() + restore tasks",
         "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
     }


### PR DESCRIPTION
**[e2e-coder]** — Delete-completion sweep **PR 2 of 3** (split confirmed by lead-coder: cost #2020 / **OS-plan-residue (this)** / TUI-plan-residue #2021 / PITR-cleanup later).

## What

Removes three dead planner-residue families left after the planner clean-break (#2018). Each is verified-dead (no emitter / no setter / no consumer), audited with **plain `grep -rn`** (authoritative — `git grep` under-reports on `tests/`).

### (A) `plan_step` progress badge (#214)
The `{n_done,n_total,step_id}` progress-badge ContextVar. Its setter (planner.py) is gone, so the carrier threaded an always-`None` value end to end. Removed the full carrier:
- `EventLog`: `plan_step` ctor param + `_plan_step` attr + property + the emit-time stamp block (the always-False branch)
- `OpContext.plan_step` field
- `OSRuntime` param + EventLog pass; `skill_runtime.run` / `sub_skill_runner` / `run_skill` / `skill_runner` (×2 spawn sites) param + every forward-pass (all `= None` defaults → signature-safe, param paired with its pass per call-hop)
- `ChatEventForwarder`: the `on_phase_started` `plan_step`→"plan N/M" producer + `_plan_step_announced` set (the OS-layer producer; lead-scoped)

### (B) plan lifecycle (ADR-0022)
`plan_started/completed/aborted` have 0 emitters → `active_plan_ids` always empty. Removed the WAL kinds, `AgentSnapshot.active_plan_ids` (field + to/from_dict + apply_events handlers), and the `and not snap.active_plan_ids` restore-trigger OR-term (the other three triggers remain; the always-empty term never changed the outcome).

### config / engine
The planner step-results compaction subsystem (`compact_step_results` had 0 callers; `execution_config.step_compaction` never read). Removed `PlannerStepCompactionConfig` + builder, `PlanConfig.step_compaction`, `plan_resume_raw` (0 readers), `compact_step_results` + `STEP_RESULTS_COMPACTED_KEY` + `_STEP_RESULTS_SUMMARY_PROMPT`.

## Boundary discipline (what was KEPT — the differentiator)
- **`resume_plan`** (kernel crash-recovery forward-replay, `ResumePlan.committed_steps`, PR21) — naming collides with the deleted planner; **untouched**.
- **C-family PITR machinery** (`plan_step_started/completed/failed` WAL kinds, `record_plan_step_completed` generation-cut, `_rewind_point_kind`, `plan_step_llm_memoized`) — verified-dead but PITR-adjacent (ADR-0038); **deferred to a separate focused PITR-cleanup PR** per lead.
- **TUI badge readers** (cost_tab/events_tab/skill_activity/agents_tab) + their widget-level tests — **tui's #2021** (they inject `plan_n_done`/"plan N/M" directly, independent of this OS carrier).
- The **`else` over-removal**: a boundary-anchored deletion initially swept `_PHASE_COMPACTION_SYSTEM_PROMPT` (belongs to the KEPT phase fn) — caught by *running* the suite (a runtime NameError compile misses), restored verbatim.

## Discovered, NOT in this PR
(D) The LLM-facing **"plan" tool is still advertised** (router_tools.py fallback mirror) + dispatched in router_loop despite the deleted executor — a load-bearing 4th family flagged to lead for a separate scoping decision.

## Test plan
- [x] Targeted suites green: config/compaction **411**, snapshot/registry/rewind **35**, events/forwarder/skill_runner/runtime/sub_skill + TUI plan_step tests **205**
- [x] Full-suite `pytest -q` from rootdir → **7992 passed**, 2 failed (both pre-existing env-blocked: swebench-dataset / media-store missing locally, CI-green, unrelated to this diff) — zero new failures
- [x] `ruff check` on all touched files → clean
- [x] Plain `grep -rn` post-removal: 0 residual non-C `plan_step` / `active_plan_ids` / config symbols in `src`; 0 test callers passing the removed params
- [x] WAL-replay tolerance: old WALs with plan lifecycle kinds replay via the unknown-kind no-op (forward-compat) — clean removal

Refs #1953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)