### PR TITLE
refactor(#1953): final plan-residue sweep — dead PlanConfig + stale plan-mode comments

### DIFF
--- a/src/reyn/config/execution.py
+++ b/src/reyn/config/execution.py
@@ -73,23 +73,6 @@ def _build_self_improvement_config(raw: object) -> "SelfImprovementConfig":
 
 
 @dataclass
-class PlanConfig:
-    """`plan:` — plan-mode execution tuning.
-
-    ``step_max_iterations``: maximum RouterLoop iterations per plan step
-    before the OS records a step failure.  Default 5 (FP-0029).  Raise
-    when steps regularly run long tool chains; lower for tighter budgets.
-
-    ``retry_limit``: maximum automatic retries per step on transient errors
-    (FP-0031-C).  Default 3.  Set 0 to disable auto-retry.  Exceptions
-    that have their own ask/abort path (PermissionError, BudgetExceeded,
-    etc.) are always excluded from retry regardless of this setting.
-    """
-    step_max_iterations: int = 5
-    retry_limit: int = 3
-
-
-@dataclass
 class SkillResumeConfig:
     """`skill_resume:` — policy for handling ambiguous steps on resume.
 
@@ -280,26 +263,3 @@ def _build_skill_resume_config(raw: object) -> SkillResumeConfig:
     return SkillResumeConfig(default=default, per_skill=per_skill)
 
 
-def _build_plan_config(raw: object) -> PlanConfig:
-    """Parse ``plan:`` block; unknown keys are ignored (forward-compat)."""
-    defaults = PlanConfig()
-    if not isinstance(raw, dict):
-        return defaults
-    step_max_raw = raw.get("step_max_iterations")
-    try:
-        step_max = int(step_max_raw) if step_max_raw is not None else defaults.step_max_iterations
-    except (TypeError, ValueError):
-        step_max = defaults.step_max_iterations
-    if step_max < 1:
-        step_max = defaults.step_max_iterations
-    retry_limit_raw = raw.get("retry_limit")
-    try:
-        retry_limit = int(retry_limit_raw) if retry_limit_raw is not None else defaults.retry_limit
-    except (TypeError, ValueError):
-        retry_limit = defaults.retry_limit
-    if retry_limit < 0:
-        retry_limit = defaults.retry_limit
-    return PlanConfig(
-        step_max_iterations=step_max,
-        retry_limit=retry_limit,
-    )

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -19,7 +19,6 @@ from reyn.config.embedding import (  # #1682 #3 cross-section
     _build_skill_search_config,
 )
 from reyn.config.execution import (  # #1682 #3 cross-section
-    _build_plan_config,
     _build_self_improvement_config,
     _build_skill_resume_config,
     _build_time_travel_config,
@@ -480,7 +479,6 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         web=_build_web_config(merged.get("web")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),
         skill_search=_build_skill_search_config(merged.get("skill_search")),
-        plan=_build_plan_config(merged.get("plan")),
         eval=_build_eval_config(merged.get("eval")),
         sandbox=_build_sandbox_config(merged.get("sandbox")),
         self_improvement=_build_self_improvement_config(merged.get("self_improvement")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -42,7 +42,6 @@ from reyn.config.embedding import (
     SkillSearchConfig,
 )
 from reyn.config.execution import (
-    PlanConfig,
     SelfImprovementConfig,
     SkillResumeConfig,
     TimeTravelConfig,
@@ -261,8 +260,6 @@ class ReynConfig:
     # Issue #364 — multi-modal cluster: cap binary media size (= images from
     # web__fetch / file__read / MCP) + iv-gated user permission when exceeded.
     multimodal: MultimodalConfig = field(default_factory=MultimodalConfig)
-    # FP-0029: plan-mode execution tuning (step iteration budget, etc.)
-    plan: PlanConfig = field(default_factory=PlanConfig)
     # FP-0007 Component A: trace export adapter config.
     # Empty exporters list (default) = no export; full backward compat.
     eval: EvalConfig = field(default_factory=EvalConfig)

--- a/src/reyn/runtime/limits/limit_handler.py
+++ b/src/reyn/runtime/limits/limit_handler.py
@@ -159,7 +159,7 @@ async def handle_limit_exceeded(
               for event audit + as part of the ``UserIntervention.kind``
               namespace (``safety.limit.<kind>``).
         run_id: Stable run identifier used for the auto_extend counter.
-                Pass the OSRuntime run_id, plan_id, or chain_id —
+                Pass the OSRuntime run_id or chain_id —
                 whichever scopes the extension correctly for this site.
         prompt: User-facing question text.
         detail: Optional second line of context (= specifics like

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -710,7 +710,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     # FP-0012: non-blocking skill dispatch. Chat-mode hosts return
     # ``{status: "spawned", run_id, chain_id, note}`` immediately and
     # deliver completion via the ``skill_completed`` inbox kind. Hosts
-    # that don't support spawn semantics (e.g. plan-mode steps) leave
+    # that don't support spawn semantics (e.g. blocking phase sub-loops) leave
     # this method un-bound (= duck-typing / hasattr check) so the
     # invoke_skill handler falls back to ``run_skill_awaitable``.
     async def spawn_skill(self, *, skill: str, input: dict,
@@ -1387,7 +1387,7 @@ class RouterLoop:
         # ADR-0025: optional sub-loop LLM call memoization. When set,
         # ``call_llm_tools`` invocations consult the provider before
         # invoking — args_hash hit returns the recorded LLMToolCallResult
-        # without paying LLM cost. Used by plan-mode resume so a crashed
+        # without paying LLM cost. Used by phase-step resume so a crashed
         # mid-step sub-loop replays its earlier LLM turns from snapshot
         # rather than re-paying. ``None`` = normal execution (no memo).
         self._memo_provider = memo_provider
@@ -1470,9 +1470,9 @@ class RouterLoop:
         _tracker_getter = getattr(host, "get_action_usage_tracker", None)
         _tracker = _tracker_getter() if _tracker_getter else None
         # FP-0034 PR-3b-iii: read universal wrapper visibility from host.
-        # getattr fallback so narrow hosts (= plan-mode sub-host) that
+        # getattr fallback so narrow hosts (= phase sub-host) that
         # don't implement the method default to off (= preserve prior
-        # plan-step tools= shape).
+        # phase-step tools= shape).
         _univ_enabled_getter = getattr(
             host, "get_universal_wrappers_enabled", None,
         )
@@ -1624,7 +1624,7 @@ class RouterLoop:
                 # FP-0034 refactor: live (= uncompacted) tool-call records
                 # are scanned on demand so the hot-list reflects in-session
                 # invocations without needing per-call disk writes. Hosts
-                # without the accessor (= older mocks, plan-mode sub-host)
+                # without the accessor (= older mocks, phase sub-host)
                 # degrade to compacted-table-only ranking.
                 _live_records: list = []
                 _live_getter = getattr(
@@ -1925,7 +1925,7 @@ class RouterLoop:
             )
             # ADR-0025: memo lookup — a recorded LLMToolCallResult for
             # this exact (model, messages, tools, tool_choice) tuple
-            # short-circuits the call. Used by plan-mode resume so a
+            # short-circuits the call. Used by phase-step resume so a
             # crashed mid-step sub-loop replays earlier LLM turns
             # without re-paying. memo_provider is None for non-resume
             # paths (= chat router main loop, fresh plan runs).
@@ -3691,11 +3691,11 @@ class RouterLoop:
             send_to_agent=_send_to_agent_bound,
             # Skill invocation bridge (= for invoke_skill handler;
             # Phase 3.5-B-light) — chain_id pre-bound to preserve PR14
-            # multi-hop chain semantics. Plan-mode keeps using this for
+            # multi-hop chain semantics. Phase sub-loops keep using this for
             # blocking step execution; chat-mode prefers spawn_skill_fn.
             run_skill_fn=_run_skill_bound,
             # FP-0012: non-blocking spawn binding for chat-mode invoke_skill.
-            # None for plan-mode hosts (= no spawn_skill method on host).
+            # None for blocking phase sub-loop hosts (= no spawn_skill method on host).
             spawn_skill_fn=_spawn_skill_bound,
             # Memory tool bridges (= for memory cluster handlers;
             # Phase 3.5-B-heavy) — bound to RouterLoop's private helpers

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1928,7 +1928,7 @@ class RouterLoop:
             # short-circuits the call. Used by phase-step resume so a
             # crashed mid-step sub-loop replays earlier LLM turns
             # without re-paying. memo_provider is None for non-resume
-            # paths (= chat router main loop, fresh plan runs).
+            # paths (= chat router main loop, fresh phase-step runs).
             result = None
             args_hash: str | None = None
             if self._memo_provider is not None:

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -121,8 +121,8 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     non-blocking spawn path. The handler returns the spawn-ack
     ``{status: "spawned", run_id, chain_id, note}`` immediately and the
     background task delivers completion via the ``skill_completed``
-    inbox kind. Plan-mode RouterLoops leave ``spawn_skill_fn=None`` so
-    plan steps keep blocking semantics (= step's LLM sees the actual
+    inbox kind. Blocking phase sub-loop RouterLoops leave ``spawn_skill_fn=None``
+    so their steps keep blocking semantics (= step's LLM sees the actual
     skill result and can synthesize the next step's input).
 
     Fallback (= phase-side dispatch / test sites): build a transient
@@ -148,7 +148,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
                     f"available: {sorted(available)}"
                 )
         # FP-0012: prefer non-blocking spawn when chat-mode binding is
-        # active. Plan-mode falls through to run_skill_fn (blocking).
+        # active. Blocking sub-loops fall through to run_skill_fn (blocking).
         if rs.spawn_skill_fn is not None:
             return await rs.spawn_skill_fn(
                 skill=skill_name,

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -111,7 +111,7 @@ class RouterCallerState:
     # op_runtime caller="control_ir" would not carry chain_id and PR14
     # pending_chain semantics would break for sub-skill delegations.
     #
-    # FP-0012: blocking call — used by plan-mode steps that need the
+    # FP-0012: blocking call — used by blocking phase sub-loop steps that need the
     # nested skill's result inline to feed the next step. Chat-mode now
     # prefers ``spawn_skill_fn`` (below) for non-blocking dispatch.
     run_skill_fn: Callable[..., Awaitable[Any]] | None = None
@@ -123,8 +123,8 @@ class RouterCallerState:
     # the background; completion is delivered to the chat router via
     # the ``"skill_completed"`` inbox kind which injects a user-role
     # message into the existing conversation thread for narration.
-    # Plan-mode RouterLoops bind this to None so plan steps keep
-    # their blocking semantics via ``run_skill_fn``.
+    # Blocking phase sub-loop RouterLoops bind this to None so their
+    # steps keep blocking semantics via ``run_skill_fn``.
     spawn_skill_fn: Callable[..., Awaitable[Any]] | None = None
 
     # RouterLoopHost reference for handlers that need duck-typed access


### PR DESCRIPTION
**[e2e-coder]** — #1953 the **final, exhaustive plan-residue sweep** (lead-directed: "a miss suggests a class" — the 5-PR delete-completion sweep missed config + comment residue; this is the clean-break's true completion). Plain `grep -rn` for ALL plan identifiers, each classified dead / verified-live / false-match / other-owner.

## Removed (dead)
- **`PlanConfig`** (`config/execution.py` class + `_build_plan_config`; `config/root.py` `plan: PlanConfig` field + import; `config/loader.py` build-call + import). The planner's per-step tuning (`step_max_iterations`/`retry_limit`) — the planner is deleted (#2018) so it has **no live reader** (built + stored on `config.plan`, never read; the `.plan` refs are `ResumePlan`/`decision.plan` crash-recovery — a false match).

## Reworded (stale "plan-mode" comments on LIVE code → "phase sub-loop"/"phase-step")
The blocking `run_skill_fn`, the phase `memo_provider`, and narrow phase sub-hosts are used by the **live phase sub-loop path**, not the dead planner — the comments mis-framed them as "plan-mode". Comment-only, count-asserted, zero behavior change: `router_loop.py` (7), `tools/types.py`, `tools/invoke_skill.py`, `limits/limit_handler.py`.

## Verified-LIVE — kept (plan-NAMED but NOT planner-residue)
`lint_plan` (skill_builder DSL lint for a skill's *design* plan), `plan_step_llm_memoized` (phase memo, ADR-0025), `resume_plan` (crash recovery), `plan_completed` SystemRef (skill_plan_glue), `_REWIND_PLAN_STEP_KINDS` (the skill-step-fed rewind boundary).

## Other owners (flagged, not in this PR)
- **TUI residue** (`/plan` slash refs in input_bar/slash_picker, plan_step rendering) → tui (lead-assigned, post-Stage-2).
- **Doc residue** (plan-mode.md, reyn-yaml.md#plan-block, safety.md `plan.step_max_iterations`, feature-map plan block) → docs-maintainer (the plan-mode-doc staleness sweep; the PlanConfig removal adds to that set).

## Test plan
- [x] Config suites: 133 passed; root config has no `plan` field; PlanConfig gone from execution
- [x] router_loop/invoke_skill/limit slice: 173 passed; parse+import OK; ruff clean
- [x] No dangling `PlanConfig`/`_build_plan_config`/`config.plan` refs; no orphaned `plan:` yaml key
- [x] Full-suite `pytest -q` from rootdir → **7990 passed**, 2 failed (both pre-existing env-blocked: swebench-dataset / media-store, CI-green, unrelated) — zero new failures

Refs #1953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
