### PR TITLE
docs(#1953): reframe async-skill-execution plan-mode prose → phase sub-loops

### DIFF
--- a/docs/concepts/skills/async-skill-execution.ja.md
+++ b/docs/concepts/skills/async-skill-execution.ja.md
@@ -26,9 +26,9 @@ await _handle_user_message()
 User が入力した内容は inbox に黙って溜まるだけで、 ack も progress feedback も
 途中の clarifying question も不可能でした。
 
-Chat-mode の `invoke_skill` は非 blocking 化されました。 Plan-mode は意図的に
-blocking のままです (= 各 step の LLM が次 step の入力に nested skill 結果を
-inline で必要)。
+Chat-mode の `invoke_skill` は非 blocking 化されました。 blocking な phase sub-loop は
+意図的に blocking path を保ちます (= phase op-loop が次 op の入力に nested skill
+結果を inline で必要)。
 
 ## chat-mode invoke_skill の現挙動
 
@@ -136,12 +136,10 @@ agent では完了 narration が fire しません。
 `send_to_agent_impl` は `_handle_user_message` 完了後に残 timeout
 予算内で 3 step でこの gap を埋めます:
 
-1. `await asyncio.gather(*running_plans)` — plan-mode async task
-   (= ADR-0023 §2.1.1) が完了し、 terminal text を history に append。
-2. `await asyncio.gather(*running_skills)` — spawn 済 skill が
+1. `await asyncio.gather(*running_skills)` — spawn 済 skill が
    terminal status に到達し、 `_enqueue_skill_completed` 経由で
    `skill_completed` を enqueue。
-3. `session.drain_skill_completed_inbox(deadline_monotonic=...)` —
+2. `session.drain_skill_completed_inbox(deadline_monotonic=...)` —
    `skill_completed` item を非 blocking で pop、 WAL consume entry
    を記録、 各々を `_handle_skill_completed` (= router LLM を回して
    narration 生成) に dispatch。 `skill_completed` 以外の kind は
@@ -150,13 +148,13 @@ agent では完了 narration が fire しません。
 deadline が drain 中に fire したら `partial=True` で返り、 残 item は
 次 call の pickup を待って inbox に残ります。
 
-## Plan-mode は blocking のまま
+## Phase sub-loop は blocking のまま
 
-Plan-mode RouterLoop は `run_skill_fn` のみ bind し (= 旧 blocking path)、
-`spawn_skill_fn` は None のまま。 そのため plan step の LLM が `invoke_skill`
-を呼んでも完了まで blocking し、 結果が次 step に inline で feed されます。
-これは意図的で — plan step は sequential 実行で、 次 step の prompt は前 step
-の結果を含むことが頻繁にあるため。 spawn-and-return semantics だと planner が
+blocking な phase sub-loop は `run_skill_fn` のみ bind し (= blocking path)、
+`spawn_skill_fn` は None のまま。 そのため phase op-loop の LLM が `invoke_skill`
+を呼んでも完了まで blocking し、 結果が次 op に inline で feed されます。
+これは意図的で — phase op は sequential 実行で、 次 op の prompt は前 op
+の結果を含むことが頻繁にあるため。 spawn-and-return semantics だと sub-loop が
 独自の完了追跡層を構築する必要があり、 複雑性に見合いません。
 
 切り分けは `RouterLoop._build_router_caller_state` で wiring されています:
@@ -173,15 +171,15 @@ return RouterCallerState(
 )
 ```
 
-Plan-mode の `_PlanStepHost` は `spawn_skill` を実装しないので hasattr check が
+`spawn_skill` を実装しない host (= phase sub-host) は hasattr check が
 失敗し、 binding は None のまま維持されます。
 
 ## Slash commands
 
-`/tasks` は Skill 実行と Plan task を横断する統合 entry point:
+`/tasks` は Skill 実行の統合 entry point:
 
 ```
-/tasks                          → 実行中の全 task (skills + plans) を一覧
+/tasks                          → 実行中の全 skill task を一覧
 /tasks list                     → /tasks と同じ
 /tasks status <run_id_prefix>   → current phase + 経過時間 + chain_id
 /tasks kill <run_id_prefix>     → 特定 task を中止
@@ -190,7 +188,6 @@ Plan-mode の `_PlanStepHost` は `spawn_skill` を実装しないので hasattr
 旧 command も alias として継続:
 
 - `/skill list` / `/skill discard <run_id>` — Skill のみ (PR-resume-ux U2)
-- `/plan list` / `/plan discard <plan_id>` — Plan のみ (ADR-0023)
 
 ## Crash 越しに保持されるもの
 

--- a/docs/concepts/skills/async-skill-execution.md
+++ b/docs/concepts/skills/async-skill-execution.md
@@ -28,9 +28,9 @@ Anything the user typed during those minutes silently queued in the
 inbox. No acknowledgment, no progress feedback, no way to ask a quick
 clarifying question while the long task ran.
 
-Chat-mode `invoke_skill` is now non-blocking. Plan-mode keeps blocking
-semantics on purpose (= sequential step execution needs the nested
-skill's result inline to feed the next step's LLM).
+Chat-mode `invoke_skill` is now non-blocking. Blocking phase sub-loops
+keep the blocking path on purpose (= a phase op-loop needs the nested
+skill's result inline to feed the next op).
 
 ## How chat-mode action dispatch works
 
@@ -39,7 +39,8 @@ Since FP-0034 Phase 6, the LLM-visible surface is
 `universal_dispatch.py` routes the wrapper call to the same internal
 `invoke_skill` handler — the spawn-ack mechanism is unchanged.
 The legacy `invoke_skill(name, input)` direct form is no longer
-the production surface (kept internally for plan-mode; see below).
+the production surface (kept internally for blocking phase sub-loops /
+phase-side dispatch; see below).
 
 ```
 User: "skill_builder で string_length を作って"
@@ -144,13 +145,10 @@ agents.
 `_handle_user_message` returns, all within the remaining timeout
 budget:
 
-1. `await asyncio.gather(*running_plans)` — plan-mode async tasks
-   (= ADR-0023 §2.1.1) finish and append their terminal text to
-   history.
-2. `await asyncio.gather(*running_skills)` — spawned skills run to
+1. `await asyncio.gather(*running_skills)` — spawned skills run to
    terminal status and enqueue `skill_completed` via
    `_enqueue_skill_completed`.
-3. `session.drain_skill_completed_inbox(deadline_monotonic=...)` —
+2. `session.drain_skill_completed_inbox(deadline_monotonic=...)` —
    pops `skill_completed` items non-blockingly, records the WAL
    consume entry, and dispatches each one to
    `_handle_skill_completed` (which runs the router LLM for
@@ -160,16 +158,15 @@ budget:
 If the deadline fires mid-drain, `partial=True` is returned and the
 remaining items stay on the inbox for the next call to pick up.
 
-## Plan-mode keeps blocking semantics
+## Phase sub-loops keep blocking semantics
 
-Plan-mode RouterLoops bind only `run_skill_fn` (= the legacy blocking
-path); `spawn_skill_fn` is left None. So when a plan step's LLM calls
-`invoke_skill`, it blocks until completion and the result feeds the
-next step inline. This is intentional — plan steps are sequential and
-the next step's prompt frequently includes the previous step's
-outcome. Spawn-and-return semantics would force the planner to
-build its own completion-tracking layer and is not worth the
-complexity.
+Blocking phase sub-loops bind only `run_skill_fn` (= the blocking
+path); `spawn_skill_fn` is left None. So when a phase op-loop's LLM
+calls `invoke_skill`, it blocks until completion and the result feeds
+the next op inline. This is intentional — phase ops are sequential and
+the next op's prompt frequently includes the previous op's outcome.
+Spawn-and-return semantics would force the sub-loop to build its own
+completion-tracking layer and is not worth the complexity.
 
 The split is wired in `RouterLoop._build_router_caller_state`:
 
@@ -185,16 +182,15 @@ return RouterCallerState(
 )
 ```
 
-Plan-mode's `_PlanStepHost` does not implement `spawn_skill`, so the
-hasattr check fails and the binding stays None.
+A host that does not implement `spawn_skill` (= a phase sub-host) fails
+the hasattr check, so the binding stays None.
 
 ## Slash commands
 
-`/tasks` is the unified entry point spanning skill runs and plan
-tasks:
+`/tasks` is the unified entry point for skill runs:
 
 ```
-/tasks                          → list all running tasks (skills + plans)
+/tasks                          → list all running skill tasks
 /tasks list                     → same as /tasks
 /tasks status <run_id_prefix>   → current phase + elapsed time + chain_id
 /tasks kill <run_id_prefix>     → cancel a specific task
@@ -203,7 +199,6 @@ tasks:
 Legacy commands continue to work as aliases:
 
 - `/skill list` / `/skill discard <run_id>` — skills only (PR-resume-ux U2)
-- `/plan list` / `/plan discard <plan_id>` — plans only (ADR-0023)
 
 ## What's preserved across crashes
 
@@ -227,7 +222,7 @@ a fresh run.
 - [Concepts: skill-resume](../skills/skill-resume.md) — crash recovery for
   in-flight skill state
 - [Reference: chat CLI](../../reference/cli/chat.md) — `/tasks` /
-  `/skill` / `/plan` slash commands
+  `/skill` slash commands
 - FP-0011 (`docs/deep-dives/proposals/0011-remove-narrator.md`) —
   removed the dedicated narrator skill; router LLM narrates inline
 - FP-0012 (`docs/deep-dives/proposals/0012-../skills/async-skill-execution.md`) —


### PR DESCRIPTION
**[e2e-coder]** — #1953 doc residue (docs-maintainer-delegated): the `async-skill-execution.md` plan-mode prose. The "Plan-mode keeps blocking semantics" content was a **live concept mis-framed** — chat `invoke_skill` = non-blocking (`spawn_skill_fn`), phase sub-loops = blocking (`run_skill_fn`). I verified the blocking path is LIVE (phase_executor drives a phase RouterLoop; invoke_skill phase-side dispatch uses the blocking fallback — no `spawn_skill` on phase hosts), **not** planner-residue.

## Changes (doc-only)
- `## Plan-mode keeps blocking semantics` → `## Phase sub-loops keep blocking semantics`; prose reframed (plan step → phase op; `_PlanStepHost` → phase sub-host).
- Removed dead bits: the step-1 `asyncio.gather(*running_plans)` drain (`running_plans` removed #2018), the `/plan list` / `/plan discard` slash line (handler deleted), the plan-mode.md concept link (removed by docs-maintainer #2030).
- `/tasks` wording: "(skills + plans)" → "(skill runs)".

## Coordination
- `async-skill-execution.ja.md` bilingual sync → docs-maintainer (the same reframe in JA).
- `chat.md` `/tasks` "skill runs + plan tasks" wording → docs-maintainer's #2030 (avoid cross-branch conflict on chat.md).

Refs #1953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)