### PR TITLE
docs(tui): sweep stale /plan slash-command refs (post-#2018)

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -25,8 +25,8 @@ from typing import Awaitable, Callable, Iterable
 HandlerFn = Callable[..., Awaitable[None]]
 # CompleterFn signature: ``(session, arg_partial: str = "") -> list[str]``.
 # ``arg_partial`` is the string typed after the slash command and the
-# trailing space (e.g. for ``/plan discard ab`` the partial is
-# ``"discard ab"``). Completers that don't need it (e.g. ``/attach``
+# trailing space (e.g. for ``/tasks kill ab`` the partial is
+# ``"kill ab"``). Completers that don't need it (e.g. ``/attach``
 # which always lists agent names) can ignore the arg via a default.
 CompleterFn = Callable[..., list[str]]
 # TabFooterFn signature: ``() -> str | None``. Supplies the optional
@@ -62,7 +62,7 @@ class SlashCommand:
     # the focus panel appends a ``  see also: <path1>, <path2>`` footer
     # so the user can navigate from the picker-hint summary to the
     # canonical concept doc. Paths are repo-relative (e.g.
-    # ``"docs/concepts/plan-mode.md"``). Defaults to empty tuple so all
+    # ``"docs/concepts/runtime/events.md"``). Defaults to empty tuple so all
     # existing commands without explicit see_also are unaffected.
     see_also: tuple[str, ...] = ()
     # Optional picker-hint footer supplier. When set, the SlashPicker hint

--- a/src/reyn/interfaces/slash/agents.py
+++ b/src/reyn/interfaces/slash/agents.py
@@ -29,7 +29,7 @@ def _attach_completer(session: "object", arg_partial: str = "") -> list[str]:
     """Return known agent names for tab completion.
 
     Accepts ``arg_partial`` for forward-compat with the CompleterFn
-    signature evolution (multi-arg commands like ``/plan`` need it) —
+    signature evolution (multi-arg commands like ``/tasks`` need it) —
     ``/attach`` itself is single-arg so the partial is unused.
     """
     if getattr(session, "_registry", None) is None:

--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -1,7 +1,7 @@
 """/tasks slash command — unified async-task view (FP-0012 Component D).
 
 Sub-commands:
-  /tasks                          — list all running tasks (skills + plans)
+  /tasks                          — list all running tasks (skill runs)
   /tasks list                     — same as `/tasks`
   /tasks status <run_id_prefix>   — show current phase + elapsed time + last event
   /tasks kill   <run_id_prefix>   — cancel a specific task
@@ -14,8 +14,8 @@ Reads from existing infrastructure (= no new state required):
     the slash cheap and synchronous; users wanting raw events run ``reyn events``).
 
 The legacy ``/skill list`` and ``/skill discard`` commands continue to work as
-before (= unchanged); ``/tasks`` is the unified entry point spanning both
-skill runs and plan tasks. This mirrors the FP-0012 proposal's Component D.
+before (= unchanged); ``/tasks`` is the entry point for running skill runs.
+This mirrors the FP-0012 proposal's Component D.
 """
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 _USAGE = (
     "Usage: /tasks [list|status <run_id>|kill <run_id>]\n"
-    "  list              — show all running tasks (skills + plans). Default.\n"
+    "  list              — show all running tasks (skill runs). Default.\n"
     "  status <prefix>   — show current phase + elapsed for a specific task\n"
     "  kill   <prefix>   — cancel a specific task"
 )
@@ -39,7 +39,7 @@ _USAGE = (
 
 @slash(
     "tasks",
-    summary="Unified view of running async tasks (skills + plans)",
+    summary="Unified view of running async tasks (skill runs)",
     usage="/tasks [list|status <run_id>|kill <run_id>]",
 )
 async def tasks_cmd(session: "Session", args: str) -> None:

--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -1260,7 +1260,7 @@ class ReynTUIApp(App):
             pass
 
     def action_cancel_inflight(self) -> None:
-        """Cancel the in-flight skill/plan/model call on the attached session.
+        """Cancel the in-flight skill/model call on the attached session.
 
         Visibility: unmounts the inline thinking spinner AND clears the
         sticky ``⟳ thinking…`` indicator. Also writes a one-line summary

--- a/src/reyn/interfaces/tui/widgets/async_stack_panel.py
+++ b/src/reyn/interfaces/tui/widgets/async_stack_panel.py
@@ -292,7 +292,7 @@ class AsyncStackPanel(RenderableCacheMixin, Widget):
         if not agent_id:
             return
         # An ``agent_id`` re-added during its interrupt/abort flash window
-        # (= the async restarts, or a plan resumes under the same id) must
+        # (= the async restarts, or a task resumes under the same id) must
         # return to a clean running state. Cancel the pending flash timer —
         # otherwise it fires ~1.5 s later and yanks this LIVE row — and reset
         # the flashing state so the row renders as ⟳ running, not ✗ interrupted.

--- a/src/reyn/interfaces/tui/widgets/input_bar.py
+++ b/src/reyn/interfaces/tui/widgets/input_bar.py
@@ -849,8 +849,8 @@ class InputBar(Widget):
 
         Filtering uses the LAST whitespace-delimited token of
         ``arg_partial`` rather than the whole string, so multi-arg
-        commands like ``/plan discard ab`` filter the completions
-        (= plan_ids) by ``"ab"`` and not by ``"discard ab"`` — the
+        commands like ``/tasks kill ab`` filter the completions
+        (= run_ids) by ``"ab"`` and not by ``"kill ab"`` — the
         subcommand prefix is consumed in choosing the completer's
         context, not in the prefix match.
         """

--- a/src/reyn/interfaces/tui/widgets/slash_picker.py
+++ b/src/reyn/interfaces/tui/widgets/slash_picker.py
@@ -380,7 +380,7 @@ class SlashPicker(RenderableCacheMixin, Static):
         #
         # Wave-11 C#5: previously skipped when ``_completions`` was
         # non-empty — but the commands with both required args AND a
-        # finite arg list (/attach, /memory view, /plan resume) were
+        # finite arg list (/attach, /memory view, /tasks kill) were
         # exactly the ones that benefit most from showing usage.
         # The guard meant usage rarely rendered in practice. Now
         # always renders when ``cmd.usage`` is set; total row count


### PR DESCRIPTION
**[tui-coder]** — the low-pri post-Stage-2 `/plan` slash-ref sweep lead queued (e2e's residue sweep + my broad grep). Pure comment/docstring cleanup, no logic change.

## What
The `/plan` command was deleted in #2018; its examples lingered in comments/docstrings. Lead flagged 2 (`input_bar.py:852`, `slash_picker.py:383`); a broad `grep -rn` across **both** `interfaces/tui` and `interfaces/slash` surfaced the complete set (10 refs across 7 files).

The live successor `/tasks status|kill <run_id_prefix>` has the same subcommand+id-prefix completion shape as the old `/plan discard|resume <id>`, so it replaces the `/plan` examples cleanly.

### interfaces/tui
- `app.py` — Ctrl+C cancel docstring "skill/plan/model call" → "skill/model call" (plan-cancel was removed in #2018)
- `async_stack_panel.py` — "a plan resumes under the same id" → "a task resumes"
- `input_bar.py` — arg-completion example "/plan discard ab" → "/tasks kill ab"
- `slash_picker.py` — usage-example list "/plan resume" → "/tasks kill"

### interfaces/slash
- `tasks.py` — "(skills + plans)" ×3 → "(skill runs)"; "spanning both skill runs and plan tasks" → "for running skill runs"
- `agents.py` — multi-arg example "/plan" → "/tasks"
- `__init__.py` — CompleterFn example "/plan discard ab" → "/tasks kill ab"; see_also example path "docs/concepts/plan-mode.md" → "docs/concepts/runtime/events.md"

## Test plan
- [x] Zero `/plan`-residue grep across `interfaces/tui` + `interfaces/slash`
- [x] `ruff check src tests` — clean
- [x] 40 `tui_smoke` + slash/tasks tests pass (comment-only → no behavior change)
- [x] (skipped — env) broad `pytest -k` collection hits the pre-existing `tests._support` rootdir quirk (reproduces on main, not this diff); `tests/cli` runs clean, CI runs the full suite
- [x] No test files touched → no tier-audit delta

## Flags (separate owners, not this PR)
- **docs-maintainer**: `docs/concepts/multi-agent/plan-mode.md` still exists — a stale doc about the deleted `/plan` feature. Doc cleanup is your domain; flagging for the docs backlog.
- **lead/e2e**: `/tasks` (interfaces/slash/tasks.py) lists only `running_skills` — it does NOT span the new dynamic task-ops (#2026). If `/tasks` should be the unified view of skill runs **+** dynamic tasks, that's a follow-up wiring question (out of scope for this stale-ref sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
