### PR TITLE
feat(#2035): /tasks shows dynamic task-ops (restore unified view)

### DIFF
--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -111,8 +111,11 @@ async def _list_tasks(session: "Session") -> None:
         await reply(session, "(no running tasks)")
         return
 
+    # "task(s)" not "running task(s)": the Tasks section now shows the full plan
+    # incl completed (#2036), so the count spans running skill runs + persistent
+    # tasks of any non-archived status.
     total = len(skill_lines) + len(task_lines)
-    out: list[str] = [f"{total} running task(s):"]
+    out: list[str] = [f"{total} task(s):"]
     if skill_lines:
         out.append("  Skills:")
         out.extend(f"    {ln}" for ln in skill_lines)
@@ -146,21 +149,24 @@ def _list_skill_lines(session: "Session") -> list[str]:
     return lines
 
 
-# Terminal Task states never transition further; a "running view" of /tasks
-# hides them so the list stays focused on the live work-units (mirrors the
-# skill-runs section, which only ever holds in-flight runs).
-_TERMINAL_TASK_STATUSES = frozenset(
-    {"completed", "failed", "aborted", "archived"}
-)
+# Dynamic Tasks are PERSISTENT trackable work-units (the point of the
+# dynamic-task model), so the Tasks section shows the FULL plan WITH status —
+# active + completed + failed + aborted — so the user sees progress ("3/6 done")
+# and deps referencing completed tasks stay intact. Only ``archived`` (the
+# user-dismissed state) is hidden. NB the skill-runs section keeps its own
+# running-only filter (ephemeral runs, not trackable plans = different
+# semantics); the split is intentional (#2036 review).
+_HIDDEN_TASK_STATUSES = frozenset({"archived"})
 
 
 async def _list_dynamic_task_lines(session: "Session") -> list[str]:
     """Render the dynamic Tasks (``task__create`` work-units) for /tasks.
 
     Reads ``session.task_backend`` (#1953 slice R). Returns ``[]`` when the
-    session carries no backend. Terminal tasks are filtered out so the view
-    mirrors the skill-runs section (in-flight only); each surviving task is
-    formatted in the same idiom as ``_list_skill_lines``.
+    session carries no backend. Shows the full plan WITH status (active +
+    completed + failed + aborted) so the user sees progress + intact deps; only
+    ``archived`` tasks are hidden. Each task is formatted in the same idiom as
+    ``_list_skill_lines``.
     """
     backend = getattr(session, "task_backend", None)
     if backend is None:
@@ -169,7 +175,7 @@ async def _list_dynamic_task_lines(session: "Session") -> list[str]:
     lines: list[str] = []
     for task in tasks:
         status = getattr(task.status, "value", task.status)
-        if status in _TERMINAL_TASK_STATUSES:
+        if status in _HIDDEN_TASK_STATUSES:
             continue
         deps = list(getattr(task, "deps", []) or [])
         if deps:

--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -1,7 +1,13 @@
 """/tasks slash command — unified async-task view (FP-0012 Component D).
 
+Spans both async-task families in one view (#2035, restoring the FP-0012
+"unified" intent after the planner deletion #2018):
+  - **skill runs** — long-running ``@sub_skill`` / ``run_skill`` executions
+  - **dynamic tasks** — the Tasks the chat LLM creates via ``task__create``
+    (#2026/#2028/#2034), tracked in the session-scoped Task backend.
+
 Sub-commands:
-  /tasks                          — list all running tasks (skill runs)
+  /tasks                          — list running skill runs + dynamic tasks
   /tasks list                     — same as `/tasks`
   /tasks status <run_id_prefix>   — show current phase + elapsed time + last event
   /tasks kill   <run_id_prefix>   — cancel a specific task
@@ -10,6 +16,8 @@ Reads from existing infrastructure (= no new state required):
   - ``session.running_skills`` / ``running_skills_started_at`` /
     ``running_skills_chain`` for skill runs (PR22)
   - SkillRegistry per-skill snapshot for current_phase
+  - ``session.task_backend`` for dynamic tasks (#1953 slice R); ``None`` when
+    the session carries no backend, in which case the dynamic section is empty.
   - The P6 events log via ``self._chat_events`` is NOT consulted here (= keeping
     the slash cheap and synchronous; users wanting raw events run ``reyn events``).
 
@@ -31,7 +39,7 @@ if TYPE_CHECKING:
 
 _USAGE = (
     "Usage: /tasks [list|status <run_id>|kill <run_id>]\n"
-    "  list              — show all running tasks (skill runs). Default.\n"
+    "  list              — show running skill runs + dynamic tasks. Default.\n"
     "  status <prefix>   — show current phase + elapsed for a specific task\n"
     "  kill   <prefix>   — cancel a specific task"
 )
@@ -39,7 +47,7 @@ _USAGE = (
 
 @slash(
     "tasks",
-    summary="Unified view of running async tasks (skill runs)",
+    summary="Unified view of running async tasks (skill runs + dynamic tasks)",
     usage="/tasks [list|status <run_id>|kill <run_id>]",
 )
 async def tasks_cmd(session: "Session", args: str) -> None:
@@ -98,14 +106,19 @@ def _resolve_task(
 
 async def _list_tasks(session: "Session") -> None:
     skill_lines = _list_skill_lines(session)
-    if not skill_lines:
+    task_lines = await _list_dynamic_task_lines(session)
+    if not skill_lines and not task_lines:
         await reply(session, "(no running tasks)")
         return
 
-    out: list[str] = []
-    out.append(f"{len(skill_lines)} running task(s):")
-    out.append("  Skills:")
-    out.extend(f"    {ln}" for ln in skill_lines)
+    total = len(skill_lines) + len(task_lines)
+    out: list[str] = [f"{total} running task(s):"]
+    if skill_lines:
+        out.append("  Skills:")
+        out.extend(f"    {ln}" for ln in skill_lines)
+    if task_lines:
+        out.append("  Tasks:")
+        out.extend(f"    {ln}" for ln in task_lines)
     await reply(session, "\n".join(out))
 
 
@@ -129,6 +142,43 @@ def _list_skill_lines(session: "Session") -> list[str]:
         lines.append(
             f"{skill_label}  [{run_id}]  {_format_elapsed(elapsed)}  "
             f"phase: {phase}"
+        )
+    return lines
+
+
+# Terminal Task states never transition further; a "running view" of /tasks
+# hides them so the list stays focused on the live work-units (mirrors the
+# skill-runs section, which only ever holds in-flight runs).
+_TERMINAL_TASK_STATUSES = frozenset(
+    {"completed", "failed", "aborted", "archived"}
+)
+
+
+async def _list_dynamic_task_lines(session: "Session") -> list[str]:
+    """Render the dynamic Tasks (``task__create`` work-units) for /tasks.
+
+    Reads ``session.task_backend`` (#1953 slice R). Returns ``[]`` when the
+    session carries no backend. Terminal tasks are filtered out so the view
+    mirrors the skill-runs section (in-flight only); each surviving task is
+    formatted in the same idiom as ``_list_skill_lines``.
+    """
+    backend = getattr(session, "task_backend", None)
+    if backend is None:
+        return []
+    tasks = await backend.list()
+    lines: list[str] = []
+    for task in tasks:
+        status = getattr(task.status, "value", task.status)
+        if status in _TERMINAL_TASK_STATUSES:
+            continue
+        deps = list(getattr(task, "deps", []) or [])
+        if deps:
+            deps_summary = ", ".join(d[:8] for d in deps)
+        else:
+            deps_summary = "(none)"
+        lines.append(
+            f"{task.name}  [{task.task_id[:8]}]  status: {status}  "
+            f"deps: {deps_summary}"
         )
     return lines
 

--- a/tests/cli/test_tasks_slash_dynamic_view.py
+++ b/tests/cli/test_tasks_slash_dynamic_view.py
@@ -1,0 +1,146 @@
+"""Tier 2: /tasks list spans skill runs + dynamic tasks (#2035).
+
+Pins the unified-view contract for the ``/tasks`` slash command: its list
+path renders BOTH the existing skill-run lines AND the dynamic Tasks the
+chat LLM creates via ``task__create`` (read from ``session.task_backend``).
+
+No mocks — a real :class:`InMemoryTaskBackend` is seeded with Tasks (with a
+real dependency edge), and a minimal Session-shaped capture object exposes
+the same public surface ``/tasks`` reads (``running_skills`` /
+``get_skill_registry`` / ``task_backend``) plus the ``_put_outbox`` reply
+seam. Per testing.md: real backend instance, public surface only, no
+private-state assertions.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.slash.tasks import _list_tasks
+from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+
+class _CaptureSession:
+    """Session-shaped stand-in capturing the reply text /tasks emits.
+
+    Exposes only the public attributes ``/tasks`` reads. ``_put_outbox`` is
+    the documented reply seam (``reply()`` -> ``session._put_outbox``); we
+    record the emitted ``OutboxMessage.text`` so the test asserts on the
+    rendered output the user sees.
+    """
+
+    def __init__(self, *, running_skills=None, task_backend=None):
+        self.running_skills = running_skills or {}
+        self._task_backend = task_backend
+        self.replies: list[str] = []
+
+    @property
+    def task_backend(self):
+        return self._task_backend
+
+    def get_skill_registry(self):
+        return None
+
+    async def _put_outbox(self, message) -> None:
+        self.replies.append(message.text)
+
+
+async def _seed_tasks(backend: InMemoryTaskBackend) -> None:
+    """Two dynamic tasks with a real dependency: ``build`` -> depends on ``plan``.
+
+    ``plan`` is IN_PROGRESS; ``build`` is born with a dep on the not-yet-completed
+    ``plan`` so the backend derives it as BLOCKED (both non-terminal → both shown).
+    """
+    plan = Task(
+        task_id="plan-aaaaaaaa-0001",
+        name="plan",
+        assignee="sess-1",
+        requester="req",
+        status=TaskState.IN_PROGRESS,
+    )
+    await backend.create(plan)
+    build = Task(
+        task_id="build-bbbbbbbb-0002",
+        name="build",
+        assignee="sess-1",
+        requester="req",
+        status=TaskState.READY,
+        deps=["plan-aaaaaaaa-0001"],
+    )
+    await backend.create(build)
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_includes_dynamic_tasks():
+    """Tier 2: ``/tasks`` renders dynamic-task lines (name + short id + status)."""
+    backend = InMemoryTaskBackend()
+    await _seed_tasks(backend)
+    session = _CaptureSession(task_backend=backend)
+
+    await _list_tasks(session)
+
+    assert session.replies, "expected /tasks to emit a reply"
+    out = session.replies[-1]
+    # Section header distinguishing dynamic tasks from skill runs.
+    assert "Tasks:" in out
+    # Each dynamic task surfaces name + short (8-char) id + status.
+    assert "plan" in out
+    assert "plan-aaa" in out  # task_id[:8]
+    assert "status: in_progress" in out
+    assert "build" in out
+    assert "build-bb" in out  # task_id[:8]
+    # The dependency edge is summarised by the depended-on short id.
+    assert "deps: plan-aaa" in out
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_shows_both_skill_runs_and_dynamic_tasks():
+    """Tier 2: both sections render when skill runs AND dynamic tasks exist."""
+    backend = InMemoryTaskBackend()
+    await _seed_tasks(backend)
+    session = _CaptureSession(
+        running_skills={"run-skill-xyz": object()},
+        task_backend=backend,
+    )
+
+    await _list_tasks(session)
+
+    out = session.replies[-1]
+    # Skill-run section still present (existing behavior preserved).
+    assert "Skills:" in out
+    assert "run-skill-xyz" in out
+    # Dynamic-task section added alongside it.
+    assert "Tasks:" in out
+    assert "build" in out
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_no_backend_falls_back_to_skill_only():
+    """Tier 2: ``task_backend`` is None → no dynamic section, skill runs only."""
+    session = _CaptureSession(
+        running_skills={"run-skill-xyz": object()},
+        task_backend=None,
+    )
+
+    await _list_tasks(session)
+
+    out = session.replies[-1]
+    assert "Skills:" in out
+    assert "run-skill-xyz" in out
+    assert "Tasks:" not in out
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_empty_when_nothing_running():
+    """Tier 2: no skill runs and no dynamic tasks → existing empty message."""
+    session = _CaptureSession(task_backend=InMemoryTaskBackend())
+
+    await _list_tasks(session)
+
+    assert session.replies[-1] == "(no running tasks)"

--- a/tests/cli/test_tasks_slash_dynamic_view.py
+++ b/tests/cli/test_tasks_slash_dynamic_view.py
@@ -137,6 +137,35 @@ async def test_tasks_list_no_backend_falls_back_to_skill_only():
 
 
 @pytest.mark.asyncio
+async def test_tasks_list_shows_completed_hides_only_archived():
+    """Tier 2: the Tasks section shows the full plan WITH status (#2036) — a
+    COMPLETED task is SHOWN (so the user sees "done" progress + deps to it stay
+    intact); only an ARCHIVED (user-dismissed) task is hidden. The split is
+    intentional vs the skill-runs section's running-only filter."""
+    backend = InMemoryTaskBackend()
+    # deps-less tasks → the backend honors the given status (no readiness derive).
+    await backend.create(Task(
+        task_id="done-cccccccc-0003", name="done-step", assignee="sess-1",
+        requester="req", status=TaskState.COMPLETED,
+    ))
+    await backend.create(Task(
+        task_id="arch-dddddddd-0004", name="archived-step", assignee="sess-1",
+        requester="req", status=TaskState.ARCHIVED,
+    ))
+    session = _CaptureSession(task_backend=backend)
+
+    await _list_tasks(session)
+
+    out = session.replies[-1]
+    # COMPLETED task surfaces WITH its status (progress visibility).
+    assert "done-step" in out
+    assert "status: completed" in out
+    # ARCHIVED task is hidden.
+    assert "archived-step" not in out
+    assert "arch-ddd" not in out
+
+
+@pytest.mark.asyncio
 async def test_tasks_list_empty_when_nothing_running():
     """Tier 2: no skill runs and no dynamic tasks → existing empty message."""
     session = _CaptureSession(task_backend=InMemoryTaskBackend())


### PR DESCRIPTION
**[tui-coder]** — closes #2035, the UX-completeness follow-up to the #1953 epic terminus.

## Why
Stage-2/2.5 verified the chat LLM creates Tasks via `task__create` (adoption + reachability, 3/3 in default-chat). But `/tasks` listed only skill runs — **the user creates Tasks they can't *see***. This restores `/tasks`' FP-0012 "unified" intent (after the #2018 planner deletion): it now spans **skill runs + dynamic tasks**.

## What
- New `async _list_dynamic_task_lines(session)` — reads `session.task_backend`, `await backend.list()`, formats each task mirroring `_list_skill_lines`: `{name}  [{task_id[:8]}]  status: {status}  deps: {short-ids}`. `None` backend → empty section.
- `_list_tasks` renders a `Skills:` and/or `Tasks:` section (each gated on non-empty); total count spans both; `(no running tasks)` preserved when both empty. Skill-runs handling unchanged.
- Docstring/`_USAGE`/summary → accurate unified scope.

## Wiring (code-confirmed)
`/tasks` reads **the same backend** `task__create` writes to: `self._task_backend` is threaded to the op-runtime task ops (`session.py:1463/3228`) **and** returned by the `task_backend` property (`session.py:2198`) — same instance. So no separate plumbing.

## Test plan
- [x] 4 new Tier-2 tests (`test_tasks_slash_dynamic_view.py`) — real `InMemoryTaskBackend` seeded with a dep'd task pair + a Session-shaped capture (no MagicMock/AsyncMock/patch): dynamic lines present (name/short-id/status/deps), both sections render together, `task_backend=None` → skill-only, empty → `(no running tasks)`
- [x] 5 tasks tests pass (4 new + parity); `ruff check src tests` clean; `tier_audit --strict` 0 violations
- [x] `/tasks` is a **deterministic** slash command (not LLM-triggered/variance-dependent) → unit tests with a real backend are the appropriate verification; wiring code-confirmed (same instance)
- [ ] (manual, optional) real-terminal e2e: create tasks via a decompose prompt → `/tasks` lists them. Deterministic + wiring-confirmed, so noted not blocking.

## UX call for your review (flagged, easily adjustable)
**Terminal-status filtering**: I kept the running-view default — `/tasks` hides terminal tasks (`completed/failed/aborted/archived`), mirroring the skill-runs section (in-flight only). At creation all tasks are non-terminal so the gap is closed; the filter only hides tasks once done.
- **Trade-off**: hide-terminal keeps the view focused + avoids accumulation over many sessions, BUT for a *persistent dep-linked plan* (the 6-task migration), hiding completed tasks loses the "3/6 done" progress picture, and a `deps: [done-id]` then references a hidden task.
- **My lean**: for a task-*tracking* view, showing all-with-status (or active + a "+N done" count) is arguably better than the skill-runs-style hide. But it's a genuine 50/50 you own (you decided the unified-view question) — one-line to drop the `_TERMINAL_TASK_STATUSES` filter if you prefer show-all. Happy to adjust pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
