### PR TITLE
fix(tui): escape untrusted intervention fields in pending_tab (markup injection)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/pending_tab.py
@@ -28,6 +28,7 @@ from .base import (
     _TEXT_DIM,
     _TEXT_MUTED,
     _TEXT_NEUTRAL,
+    _esc,
     truncate_to_cells,
 )
 
@@ -63,17 +64,22 @@ def _render_kind_intervention(
     summary = str(view.get("summary", ""))
     detail = str(view.get("detail", ""))
 
+    # _esc untrusted intervention fields (id / origin / summary / detail —
+    # permission-request + A2A-inbound content) before markup interpolation: the
+    # row is rendered via ``Text.from_markup`` (shells.py), so unescaped ``[..]``
+    # in the content would inject Rich markup / corrupt the parse. (age is the
+    # internal ``_format_age`` output, safe.) Matches the sibling tabs' pattern.
     head = (
         f"{pfx}[{name_style}]intervention[/]  "
-        f"[{_TEXT_MUTED}]{iv_id_short}[/]  "
-        f"[{_EVENT_SKILL}]{origin}[/]  "
+        f"[{_TEXT_MUTED}]{_esc(iv_id_short)}[/]  "
+        f"[{_EVENT_SKILL}]{_esc(origin)}[/]  "
         f"[{_TEXT_NEUTRAL}]{age}[/]"
     )
     lines = [head]
     if summary:
-        lines.append(f"    [{_TEXT_NEUTRAL}]↳[/] [{_TEXT_BODY}]{truncate_to_cells(summary, 60)}[/]")
+        lines.append(f"    [{_TEXT_NEUTRAL}]↳[/] [{_TEXT_BODY}]{_esc(truncate_to_cells(summary, 60))}[/]")
     if detail:
-        lines.append(f"      [{_TEXT_DIM}]{truncate_to_cells(detail, 60)}[/]")
+        lines.append(f"      [{_TEXT_DIM}]{_esc(truncate_to_cells(detail, 60))}[/]")
     return lines
 
 
@@ -95,8 +101,8 @@ def _render_kind_unknown(
     iv_id_short = str(view.get("id", ""))[:8]
     summary = str(view.get("summary", ""))
     return [
-        f"{pfx}[{name_style}]{kind}[/]  [{_TEXT_MUTED}]{iv_id_short}[/]  "
-        f"[{_TEXT_BODY}]{truncate_to_cells(summary, 60)}[/]",
+        f"{pfx}[{name_style}]{_esc(kind)}[/]  [{_TEXT_MUTED}]{_esc(iv_id_short)}[/]  "
+        f"[{_TEXT_BODY}]{_esc(truncate_to_cells(summary, 60))}[/]",
     ]
 
 

--- a/tests/cli/test_pending_tab_render.py
+++ b/tests/cli/test_pending_tab_render.py
@@ -154,6 +154,50 @@ def test_dict_shaped_input_flows_through() -> None:
     assert flat_items[0]["id"] == "iv-xyz12345"
 
 
+def test_intervention_fields_with_markup_are_escaped_not_injected() -> None:
+    """Tier 2b: untrusted intervention fields containing Rich markup are ESCAPED,
+    not interpreted — so an origin / summary / detail carrying ``[..]`` (e.g.
+    A2A-inbound or permission-request content) can't inject styling or corrupt
+    the Pending tab (each row is rendered downstream via ``Text.from_markup``)."""
+    from rich.text import Text
+
+    op = _PendingOpViewLike(
+        id="iv-1",
+        kind="intervention",
+        origin_channel_id="a2a:[bold]evil[/]",
+        created_at="",
+        summary="please [red]ALERT[/red] approve",
+        detail="[link=http://x]click[/link]",
+    )
+    rendered, _flat, _ys = render_pending([op])
+    # The renderer output feeds Text.from_markup downstream. With the content
+    # escaped, the opening ``[..`` tags survive as LITERAL plain text; WITHOUT
+    # escaping they'd be consumed as style tags and absent from the plain text
+    # (the ALERT text styled instead of shown with its brackets).
+    plain = Text.from_markup(rendered).plain
+    assert "ALERT" in plain
+    assert "[red" in plain               # summary's tag kept literal (escaped)
+    assert "[bold" in plain              # origin's tag kept literal
+    assert "[link=http://x" in plain     # detail's link tag kept literal
+
+
+def test_unknown_kind_fields_with_markup_are_escaped() -> None:
+    """Tier 2b: the fallback (unknown-kind) renderer escapes its untrusted
+    ``kind`` / ``summary`` too — a future kind name or summary with ``[..]``
+    stays literal."""
+    from rich.text import Text
+
+    op = _PendingOpViewLike(
+        id="op-1", kind="weird[red]kind[/]", origin_channel_id="x",
+        created_at="", summary="do [bold]X[/bold]",
+    )
+    rendered, _flat, _ys = render_pending([op])
+    plain = Text.from_markup(rendered).plain
+    assert "weird[red" in plain   # kind's tag kept literal (escaped)
+    assert "do [bold" in plain    # summary's tag kept literal
+    assert "X" in plain
+
+
 def test_cursor_index_marks_row_distinctly() -> None:
     """Tier 2b: ``cursor=N`` marks the Nth row with the coral ``▶`` prefix.
 


### PR DESCRIPTION
**[tui-coder]** — first fix from a fresh-area TUI rendering-robustness mining sweep (post-#1953-epic, lead-directed mine-when-idle).

## The defect (CRITICAL — markup injection)
`pending_tab` interpolates intervention fields — `id` / `origin_channel_id` / `summary` / `detail` / `kind` — into Rich-markup f-strings rendered downstream via `Text.from_markup` (shells.py:55). Those fields carry **untrusted content** (permission-request prompts, A2A-inbound message text), so content with Rich markup injects styling or corrupts the Pending tab:
- `summary="[/]"` → breaks the markup parse
- `summary="[red]ALERT[/red]"` → styling injected; the brackets vanish from the display

`pending_tab` was the **outlier**: sibling tabs (cost/keys/memory/docs) already `_esc()` their untrusted fields — `pending_tab` didn't even import `_esc`. (The sweep first claimed "imports `_esc` but unused"; verifying showed it's simply **not imported** — corrected.)

## Fix
Import `_esc` + wrap the untrusted fields in both the intervention renderer and the unknown-kind fallback. `age` (internal `_format_age` output) left as-is.

## Test plan
- [x] +2 Tier-2b tests: intervention/unknown-kind fields carrying markup render **literal (escaped)**, not interpreted
- [x] **Falsify-confirmed**: without the fix, `[red]` is consumed as a style → absent from the plain text → the test fails (non-tautological; verified directly)
- [x] 9 pending_tab tests pass; `ruff check src tests` clean; `tier_audit --strict` 0

## Notes (separate concerns, flagged)
- **`_esc` cosmetic quirk**: `_esc` escapes `]` as well as `[` (Rich only needs `[` escaped), leaving a `\]` backslash artifact on content containing `]`. Pre-existing, affects **all** `_esc` callers — not introduced here, worth a separate cosmetic look.
- **Other sweep candidates** (separate cell-width PR): raw `len()`/slice truncation on wide chars in `skill_activity.py:622/662`, `agents_tab.py:559`, `events_tab.py:383-388`. (`async_stack_panel` f-strings are plain-text-append mode = safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
