### PR TITLE
docs(config): remove dead plan-mode config refs (post-#2029)

### DIFF
--- a/docs/concepts/runtime/safety.md
+++ b/docs/concepts/runtime/safety.md
@@ -41,7 +41,6 @@ the current configured value, and which config key to change.
 | Phase wall-clock | `safety.timeout.phase_seconds` | 0 (off) | ✅ | yes |
 | Chain wait | `safety.timeout.chain_seconds` | 60 | ✅ | yes |
 | Router iterations | `safety.loop.max_router_iterations` | 5 | ✅ | partial |
-| Plan step iterations | `plan.step_max_iterations` | 5 | ✅ | partial |
 | LLM call timeout | `safety.timeout.llm_call_seconds` | 60 | ❌ auto-retry/abort | — |
 | Media cap | `multimodal.max_bytes` | 5 MB | ❌ auto-degrade | — |
 | Summary body cap | `chat.compaction.body_token_cap` | 1500 | ❌ auto-truncate | — |
@@ -124,12 +123,8 @@ safety:
     max_router_calls_per_turn: 3
     max_agent_hops: 3
     max_router_iterations: 5   # max LLM tool-call iterations per user turn (CLI --max-iterations overrides)
-    plan_invalid_retries: 1
   timeout:
     phase_seconds: 0.0         # 0 = disabled
     chain_seconds: 60.0
     llm_call_seconds: 60.0
-
-plan:
-  step_max_iterations: 5       # max RouterLoop iterations per plan step
 ```

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -479,7 +479,6 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `sandbox` | Backend selection (auto/seatbelt/landlock/noop) + `on_unsupported` | [reyn-yaml § sandbox](reference/config/reyn-yaml.md#sandbox-block) |
 | `web` | `web.fetch` SSL `verify_ssl` and `ca_bundle` override | [reyn-yaml § web](reference/config/reyn-yaml.md#web-block) |
 | `eval` | Trace exporters: file / langfuse / **otlp** (optional dep `opentelemetry-exporter-otlp-proto-http`) / ietf_audit | [reyn-yaml § eval](reference/config/reyn-yaml.md#eval-block) |
-| `plan` | `step_max_iterations` / `retry_limit` per plan step | [reyn-yaml § plan](reference/config/reyn-yaml.md#plan-block) |
 | `chat` | Compaction trigger / head+tail retention / section token caps | [Chat Compaction](concepts/data-retrieval/chat-compaction.md) |
 | `embedding` | Model classes / batch_size / cost_warn_threshold | [RAG concepts](concepts/data-retrieval/rag.md) |
 | `voice` | Whisper model / language / device — optional `reyn[voice]` | [Voice concepts](concepts/tools-integrations/voice.md) |

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -28,7 +28,6 @@ models:
 | `output_language` | 文字列 | デフォルトの出力言語コード（例: `en`、`ja`）。`--output-language` でオーバーライド。 |
 | `safety` | マップ | ランタイムの停止条件: ループ検出上限、タイムアウト、上限超過時ポリシー。以下参照。 |
 | `cost` | マップ | バジェット上限とレート制限（エージェントごと、日次、月次）。以下参照。 |
-| `plan` | マップ | プランモードのステップバジェットとリトライ設定。以下参照。 |
 | `web` | マップ | `web_fetch` と MCP レジストリ呼び出しの SSL 設定。以下参照。 |
 | `eval` | マップ | `reyn eval` のトレース exporter バックエンド。以下参照。 |
 | `sandbox` | マップ | `sandboxed_exec` のバックエンド選択・非対応プラットフォームポリシー・agent-level サンドボックスポリシー。以下参照。 |
@@ -48,7 +47,6 @@ models:
 | `external_transports` | マップ | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
 | `multimodal` | マップ | バイナリメディア（画像・音声）のサイズ上限・超過時の挙動・アーティファクト保存先。以下参照。 |
 | `permissions` | マップ | デフォルトの Permission ポリシー。以下参照。 |
-| `plan_resume_raw` | マップ | プランモードのレジューム ポリシーの raw dict。プランコーディネーターが遅延パース。 |
 | `prompt_cache_enabled` | bool | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
 | `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。下記の注記参照。 |
 | `api_base` | 文字列 | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
@@ -269,7 +267,6 @@ safety:
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | ユーザーターンごとのチャットルーター呼び出し数。`0` = 無制限。 |
 | `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | ユーザーターンごとの LLM ツール呼び出しイテレーション上限。CLI `--max-iterations` が指定された場合はそちらが優先。`reyn run-once` のデフォルトは 80。 |
 | `safety.loop.max_agent_hops` | int | `3` | — | 最大委譲深度（ユーザー → A → B → C = 3 ホップ）。 |
-| `safety.loop.plan_invalid_retries` | int | `1` | — | ルーターが malformed な `plan()` ツール呼び出しを emit した時、エラー + 「内側クォートをエスケープ」 ヒントを user-role directive として追加して LLM に再 emit させる。`0` で無効化。`1`（デフォルト）でチャットターンごとに 1 回の directive 駆動訂正を許可。 |
 
 ### `safety.timeout` フィールド
 
@@ -287,36 +284,6 @@ safety:
 | `safety.on_limit.mode` | 文字列 | `interactive` | ループ/タイムアウト上限発動時の動作。`interactive`（デフォルト） — `ask_user` でユーザーに延長許可を確認。ヘッドレス（bus=None / 非 TTY）は自動的に abort へ短絡。`unattended` — 即時中止（CI / cron / スクリプト実行向けのオプトイン）。`auto_extend` — `auto_extend_times` 回自動延長後に中止。 |
 | `safety.on_limit.auto_extend_times` | int | `1` | abort フォールスルーまでの自動延長回数。`mode: auto_extend` 時のみ使用。 |
 | `safety.on_limit.ask_timeout_seconds` | float（秒） | `0` | `interactive` モードでユーザー返答を待機する時間。`0`（デフォルト） = 無制限待機、正の値 = ウィンドウ経過で partial data として abort。 |
-
-## `plan` ブロック
-
-プランのステップ実行バジェット、リトライ動作、ステップ結果コンパクションを制御します。
-
-```yaml
-plan:
-  step_max_iterations: 5   # ステップあたりの最大 RouterLoop ターン数（デフォルト: 5）
-  retry_limit: 3           # ステップ失敗時の最大自動リトライ数（デフォルト: 3）
-  step_compaction:
-    recent_step_results_raw: 3                # 最新 N 件の step_results はそのまま保持
-    step_results_ratio: 0.50                  # main_pool のうち step_results に割り当てる比率
-    summarize_older_threshold_tokens: null    # null = main_pool から導出（ComputedBudgets）
-    use_chars4_estimate: false                # true = len(text)//4（レイテンシ opt-out）
-```
-
-| キー | 型 | デフォルト | 説明 |
-|-----|------|---------|-------------|
-| `step_max_iterations` | integer | `5` | 1 つのプランステップが失敗として記録される前に消費できる最大 RouterLoop イテレーション数。 |
-| `retry_limit` | integer | `3` | 一時的エラーによるステップあたりの最大自動リトライ数。上限到達後はユーザーにバジェット延長を求めます。トークン制限と同様のコスト保護上限として機能します。 |
-| `step_compaction` | マップ | 下記デフォルト | prior `step_results` コンパクションポリシー。`chat.compaction` の sibling — 蓄積したステップ出力が次ステップのシステムプロンプトを肥大化させそうな時、古いエントリは要約されます。 |
-
-### `plan.step_compaction` フィールド
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `recent_step_results_raw` | int | `3` | 最新 N 件の step_results はそのまま保持し、それより古いものをコンパクション。 |
-| `step_results_ratio` | float | `0.50` | `main_pool`（= `T_max - T_SP`）のうち次ステップの sys_prompt 内 step_results 部分に割り当てる比率。`chat.compaction.component_weights` の body 配分の sibling。 |
-| `summarize_older_threshold_tokens` | int \| null | `null` | 古い step_results をコンパクションする閾値（トークン数）。`null` の場合は `ComputedBudgets`（= `step_results_ratio × main_pool`）から導出。 |
-| `use_chars4_estimate` | bool | `false` | `true` の場合、`litellm.token_counter` の代わりに `len(text)//4` を使用（レイテンシ opt-out、`chat.compaction.use_chars4_estimate` と同じ意味）。 |
 
 ## `web` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -29,7 +29,6 @@ models:
 | `output_language` | string | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
 | `safety` | map | Runtime stop conditions: loop-detection caps, timeouts, on-limit policy. See below. |
 | `cost` | map | Budget caps and rate limits (per-agent, daily, monthly). See below. |
-| `plan` | map | Plan-mode step budget and retry tuning. See below. |
 | `web` | map | SSL settings for `web_fetch` and MCP registry calls. See below. |
 | `eval` | map | Trace exporter backends for `reyn eval`. See below. |
 | `sandbox` | map | Sandboxed-exec backend selection, unsupported-platform policy, and the agent-level sandbox policy. See below. |
@@ -51,7 +50,6 @@ models:
 | `external_transports` | map | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
 | `multimodal` | map | Binary media (image/audio) size cap, on-oversize behaviour, and artefact storage paths. See below. |
 | `permissions` | map | Default permission policy. See below. |
-| `plan_resume_raw` | map | Raw resume-policy dict for plan-mode runs. Parsed lazily by the plan coordinator. |
 | `prompt_cache_enabled` | bool | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
 | `project_context_path` | string | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. See note below. |
 | `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
@@ -273,7 +271,7 @@ specific purpose; an unset purpose falls back to `model`.
 
 | Purpose | What it covers |
 |---|---|
-| `router` | The per-turn chat router / intent classification (and the plan-decomposition router). |
+| `router` | The per-turn chat router / intent classification. |
 | `control_ir` | Control-IR sub-execution model. |
 | `tool` | The default class for tool-spawned skill runs. |
 | `compaction` | Context-compaction summarisation. |
@@ -342,8 +340,8 @@ budget has a single source. (On the direct, non-Router path the per-call
 ### `llm.retry` fields (#1835)
 
 Controls the **timing** of the Reyn self-retry layer only (semantic-retry
-behaviours — EmptyLLMResponseError, empty\_stop\_retry, plan\_invalid\_retry,
-compaction shrink — are unaffected). Both defaults are `true`.
+behaviours — EmptyLLMResponseError, empty\_stop\_retry, compaction shrink — are
+unaffected). Both defaults are `true`.
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
@@ -428,7 +426,6 @@ safety:
 | `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | Maximum LLM tool-call iterations per user turn. CLI `--max-iterations` overrides when provided; `reyn run-once` uses CLI default of 80. |
 | `safety.loop.max_tool_calls_per_turn` | int | `50` | — | Cost-bound: maximum `tool_calls` honoured from a SINGLE LLM completion. A degenerate completion can emit thousands (observed 3451); the OS processes only the first N, drops the overflow, and appends a re-grounding notice. `0` = unlimited. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
-| `safety.loop.plan_invalid_retries` | int | `1` | — | When the router emits a malformed `plan()` tool call, append the error + an "escape inner quotes" hint and let the LLM re-emit. `0` disables; `1` (default) allows one directive-driven correction per chat turn. |
 | `safety.loop.skill_calls_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) spawn cap. `hard_limit` + `warn_ratio` sub-fields. Hybrid: loop-detection semantics, budget-style user approval on hit. |
 | `safety.loop.skill_tokens_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) token cap. `hard_limit` + `warn_ratio` sub-fields. |
 
@@ -461,36 +458,6 @@ Content-layer threat defense (FP-0050 / #1822): inspects untrusted content for p
 | `safety.threat_scan.block_severity` | string | `block` | Minimum severity that BLOCKS at agent-write seams (memory write / skill install). `block` = only `block`-severity patterns; `warn` = warn-severity also blocks (stricter). |
 | `safety.threat_scan.custom_patterns` | list | `[]` | Operator pattern extensions, each `[regex, id, scope, severity]`. Merged into the built-in catalog for scans. |
 
-## `plan` block
-
-Controls plan step execution budget, retry behaviour, and prior-step compaction.
-
-```yaml
-plan:
-  step_max_iterations: 5   # max RouterLoop turns per step (default: 5)
-  retry_limit: 3           # max auto-retries per step on failure (default: 3)
-  step_compaction:
-    recent_step_results_raw: 3                # keep the last N step_results verbatim
-    step_results_ratio: 0.50                  # fraction of main_pool reserved for step_results
-    summarize_older_threshold_tokens: null    # null = derive from main_pool (engine ComputedBudgets)
-    use_chars4_estimate: false                # true = len(text)//4 (latency opt-out)
-```
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `step_max_iterations` | integer | `5` | Maximum RouterLoop iterations one plan step may consume before being recorded as failed. |
-| `retry_limit` | integer | `3` | Maximum automatic retries per step on transient errors. When exhausted, the user is prompted to extend the budget. Acts as a cost protection ceiling analogous to token limits. |
-| `step_compaction` | map | see defaults | Prior `step_results` compaction policy. Sibling to `chat.compaction` — when accumulated step outputs would balloon the next step's system prompt, older entries are summarised. |
-
-### `plan.step_compaction` fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `recent_step_results_raw` | int | `3` | Keep the last N step_results verbatim; compact older ones. |
-| `step_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the step_results portion of the next step's sys_prompt. Sibling to `chat.compaction.component_weights` body allocation. |
-| `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older step_results are compacted. `null` derives the threshold from `ComputedBudgets` (= `step_results_ratio × main_pool`). |
-| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out, mirrors `chat.compaction.use_chars4_estimate`). |
-
 ## `time_travel` block
 
 Cost knobs for the time-travel (rewind/resume) feature (#1582).
@@ -520,7 +487,7 @@ tool_use:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `chat` | string | `enumerate-all` | Tool-use scheme for the top-level chat layer. **Default `enumerate-all` (#1657)** — flat-lists actions so the LLM invokes them directly instead of hallucinating `invoke_action` names (raised non-hot-list tool-use ~30%→100%). Set to `universal-category` for a minimal-surface / many-tool catalog (discover-then-call), or another registered scheme. |
-| `step` | string | `universal-category` | Tool-use scheme for the plan/skill step layer. |
+| `step` | string | `universal-category` | Tool-use scheme for the skill step layer. |
 | `phase` | string | `universal-category` | Tool-use scheme for the OS phase layer. |
 
 The chat layer defaults to `enumerate-all` (#1657); `step` / `phase` keep `universal-category`. A scheme owns how the `tools=` payload is built, the SP tool-use instructions, how an LLM response is interpreted, and how it is dispatched — so swapping a layer's scheme changes the whole tool-use loop for that layer without OS changes. `universal-category` remains available per-layer via this config (e.g. for very large tool catalogs where flat-listing every action would bloat the request). `retrieval` (search-over-tools) and `CodeAct` are likewise supported opt-in schemes per layer; `retrieval` additionally requires `action_retrieval.embedding_class` set to a configured embedding provider.
@@ -542,11 +509,11 @@ phase:
 
 ### `phase.act_results_compaction` fields
 
-Controls how the act-loop's accumulated `control_ir_results` are compacted when they approach the context budget. Sibling to `plan.step_compaction` (planner step) and `chat.compaction` (conversation history).
+Controls how the act-loop's accumulated `control_ir_results` are compacted when they approach the context budget. Sibling to `chat.compaction` (conversation history).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `recent_act_turns_raw` | int | `5` | Keep the last N act-turn results verbatim; compact older ones. Higher than `plan.step_compaction.recent_step_results_raw` (= 3) because phase ops carry specific structured data (paths, line numbers, exit codes) the LLM needs for planning next ops. |
+| `recent_act_turns_raw` | int | `5` | Keep the last N act-turn results verbatim; compact older ones. Set higher than the conversation-history default because phase ops carry specific structured data (paths, line numbers, exit codes) the LLM needs for planning next ops. |
 | `control_ir_results_ratio` | float | `0.50` | Fraction of `main_pool` (= `T_max - T_SP`) allocated for the `control_ir_results` portion of the act-loop context. Sibling to `chat.compaction.component_weights["body"]`. |
 | `summarize_older_threshold_tokens` | int \| null | `null` | Total token threshold above which older results are compacted. `null` derives the threshold from `control_ir_results_ratio × main_pool` (via `ComputedBudgets`). |
 | `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation (latency opt-out). |

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -105,7 +105,7 @@ class RetryConfig:
     """``llm.retry:`` — backoff timing for the Reyn self-retry layer (#1835).
 
     Controls TIMING only; semantic-retry behaviours (EmptyLLMResponseError,
-    empty_stop_retry, plan_invalid_retry, compaction shrink) are unaffected.
+    empty_stop_retry, compaction shrink) are unaffected.
 
     ``jitter=true`` (default): equal jitter (AWS pattern) —
       ``sleep = backoff/2 + uniform(0, backoff/2)``


### PR DESCRIPTION
**[docs-maintainer]** — Config-reference sweep for dead `plan` config, requested by e2e-coder after #2029 merged (PlanConfig class + `_build_plan_config` + `config.plan` field + the `plan()` router tool all removed from origin/main).

## What & why
Every `plan` config key is now dead on origin/main (verified by grep: `step_max_iterations` / `step_compaction` / `plan_resume_raw` / `plan_invalid_retries` / `retry_limit` = **0 src refs**; `plan()` router tool gone → `plan_invalid_retry` semantic-retry no longer fires). The config-reference docs still documented all of it.

This is broader than e2e's two named spots (`reyn-yaml.md#plan-block` + `safety.md:44/134`) — a primary grep surfaced **8** plan refs in `reyn-yaml.md`. Removing only the named two would leave known drift, so this sweeps the full dead-plan-config set (same concern).

## Changes
- **reyn-yaml.md / .ja** — drop `plan` + `plan_resume_raw` top-level rows, the `safety.loop.plan_invalid_retries` row, and the entire `## plan` block (step_max_iterations / retry_limit / step_compaction). (.ja is a partial translation — only those refs exist there.)
- **reyn-yaml.md** — reword (not delete) **live** mechanisms that merely *name* dead plan config: `router` purpose (drop "plan-decomposition router"), `tool_use.step` ("plan/skill step layer" → "skill step layer"), `phase.act_results_compaction` sibling refs, `llm.retry` unaffected-behaviours example list (drop `plan_invalid_retry`).
- **safety.md** — drop the `plan.step_max_iterations` ceiling row + `plan_invalid_retries` / `plan:` block from the yaml example.
- **feature-map.md** — drop the `plan` config-table row (it linked to the now-removed `#plan-block` anchor).
- **infra.py** — drop the stale `plan_invalid_retry` mention from `RetryConfig`'s docstring example list. **Cross-domain note for reviewer:** this is the one src touch — docstring-only (no logic), included to keep code↔doc synced rather than leave the same stale token in the code comment the doc mirrors. Flag if you'd prefer it split out.

## Scope guard
`"plan-step"` checkpoint-boundary vocabulary (time_travel block + execution.py / workspace_op_content_log.py comments) is **left intact** — it's still live in src as a boundary-kind name, so editing it would be doc-ahead-of-code.

## Test plan
- [x] `git grep origin/main` confirms 0 src refs for every removed config key + `plan()` tool gone
- [x] 0 residual dead-plan tokens in the 4 touched docs
- [x] 0 dangling `#plan-block` links repo-wide
- [x] `ruff check src/reyn/config/infra.py` — passed
- [x] `python -c "import reyn.config.infra"` — OK (docstring-only)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — EXIT=0, no WARNING/Aborted

🤖 Generated with [Claude Code](https://claude.com/claude-code)