### PR TITLE
fix(#2024): rekey_fixtures.py — capture MISSING_KEY (-s) + preview-match per-entry

### DIFF
--- a/scripts/rekey_fixtures.py
+++ b/scripts/rekey_fixtures.py
@@ -39,6 +39,7 @@ def _capture_new_keys(test_pattern: str) -> list[dict]:
     # a small wrapper script that installs the patch before importing pytest.
 
     patcher_code = textwrap.dedent("""\
+        import json
         import sys
         from pathlib import Path
         from reyn.dev.testing.replay import LLMReplay, MissingFixture
@@ -48,9 +49,15 @@ def _capture_new_keys(test_pattern: str) -> list[dict]:
         def _patched_replay(self, key, model, messages):
             if key not in self._records:
                 preview = self._prompt_preview(messages)
-                # Emit machine-readable line BEFORE raising
+                # Emit a machine-readable JSON line BEFORE raising. JSON keeps it
+                # single-line + delimiter-safe: a preview or path may contain
+                # newlines or '|' (the old f-string |-split form truncated those).
                 print(
-                    f"MISSING_KEY={key}|{self.fixture_path}|{preview[:200]}",
+                    "MISSING_KEY=" + json.dumps({
+                        "new_key": key,
+                        "fixture_path": str(self.fixture_path),
+                        "prompt_preview": preview[:200],
+                    }),
                     flush=True,
                 )
             return _orig_replay(self, key, model, messages)
@@ -69,36 +76,53 @@ def _capture_new_keys(test_pattern: str) -> list[dict]:
         cmd = [
             sys.executable, str(patcher_path),
             test_pattern,
-            "-v", "--tb=no", "--no-header", "-q",
+            # `-s` (= --capture=no) is MANDATORY: without it pytest captures the
+            # patcher's MISSING_KEY print per-test and `--tb=no -q` never surfaces
+            # it, so the scan finds nothing and silently no-ops (#2024 bug 1).
+            "-s", "--tb=no", "--no-header", "-q",
         ]
         result = subprocess.run(
             cmd, capture_output=True, text=True, cwd=str(REPO_ROOT)
         )
-        output = result.stdout + result.stderr
-
-        captured: list[dict] = []
-        seen: set[tuple] = set()
-        for line in output.splitlines():
-            if not line.startswith("MISSING_KEY="):
-                continue
-            rest = line[len("MISSING_KEY="):]
-            parts = rest.split("|", 2)
-            if len(parts) < 2:
-                continue
-            new_key = parts[0]
-            fixture_path = Path(parts[1])
-            prompt_preview = parts[2] if len(parts) > 2 else ""
-            dedup = (new_key, str(fixture_path))
-            if dedup not in seen:
-                seen.add(dedup)
-                captured.append({
-                    "new_key": new_key,
-                    "fixture_path": fixture_path,
-                    "prompt_preview": prompt_preview,
-                })
-        return captured
+        return _parse_missing_keys(result.stdout + result.stderr)
     finally:
         patcher_path.unlink(missing_ok=True)
+
+
+def _parse_missing_keys(output: str) -> list[dict]:
+    """Parse ``MISSING_KEY=<json>`` lines from the patcher subprocess output.
+
+    Each line is ``MISSING_KEY=`` followed by a JSON object
+    ``{new_key, fixture_path, prompt_preview}``. JSON-encoding makes the line
+    newline-/delimiter-safe (a preview or path may contain ``|`` or a newline —
+    the old ``|``-split + raw f-string form truncated the preview at the first
+    newline, #2024 bug 1). The marker is matched anywhere in the line (pytest may
+    prefix it), and results are deduped by ``(new_key, fixture_path)``."""
+    marker = "MISSING_KEY="
+    captured: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for line in output.splitlines():
+        idx = line.find(marker)
+        if idx < 0:
+            continue
+        try:
+            rec = json.loads(line[idx + len(marker):])
+        except json.JSONDecodeError:
+            continue
+        new_key = rec.get("new_key")
+        fixture_path = rec.get("fixture_path")
+        if not new_key or not fixture_path:
+            continue
+        dedup = (new_key, fixture_path)
+        if dedup in seen:
+            continue
+        seen.add(dedup)
+        captured.append({
+            "new_key": new_key,
+            "fixture_path": Path(fixture_path),
+            "prompt_preview": rec.get("prompt_preview", ""),
+        })
+    return captured
 
 
 # ── Step 3: load fixture, find latest entry, append under new key ──────────────
@@ -125,7 +149,20 @@ def _rekey_fixture(
     prompt_preview: str,
     dry_run: bool,
 ) -> bool:
-    """Append a new entry for new_key reusing the last entry's response.
+    """Append a new entry for ``new_key`` reusing the response of the EXISTING
+    entry whose ``prompt_preview`` matches.
+
+    A re-key happens when a system-prompt change shifts the SHA key of an
+    otherwise-identical request. The fixture's ``prompt_preview`` is the last
+    message's content, which is stable across SP changes — so the new key's
+    captured preview matches the original entry's preview exactly, and that
+    entry's response is the correct one to reuse.
+
+    Reusing the LAST entry unconditionally (the old behavior) corrupts
+    multi-round fixtures: every re-keyed round would get the final round's
+    response (#2024 bug 2). On an ambiguous match (several entries share a
+    preview) the most-recent match is reused (tie-break); on NO match the rekey
+    is skipped with a warning — never write an unjustified response.
 
     Returns True if a rekey was performed (or would be in dry-run).
     """
@@ -138,27 +175,37 @@ def _rekey_fixture(
         print(f"  [SKIP] key already present: {new_key[:16]}... in {fixture_path.name}")
         return False
 
-    # Use the last entry's response (most recent recorded state)
-    last_entry = entries[-1]
+    # Preview-match: the existing entry(ies) for the same logical request. The
+    # last among matches is the most-recent recording (tie-break for duplicates).
+    matches = [e for e in entries if e.get("prompt_preview", "") == prompt_preview]
+    if not matches:
+        print(
+            f"  [WARN] no prompt_preview match for {new_key[:16]}... in "
+            f"{fixture_path.name} — skip (manual rekey needed; not reusing an "
+            f"unrelated response)",
+            file=sys.stderr,
+        )
+        return False
+    source = matches[-1]
+
     new_entry = {
         "key": new_key,
-        "model": last_entry.get("model", ""),
-        "prompt_preview": prompt_preview or last_entry.get("prompt_preview", ""),
-        "response": last_entry["response"],
+        "model": source.get("model", ""),
+        "prompt_preview": prompt_preview or source.get("prompt_preview", ""),
+        "response": source["response"],
     }
 
     if dry_run:
-        old_key = last_entry["key"]
         print(
             f"  [DRY-RUN] {fixture_path.name}\n"
-            f"    old key: {old_key[:16]}...\n"
+            f"    matched key: {source['key'][:16]}...\n"
             f"    new key: {new_key[:16]}..."
         )
         return True
 
     with fixture_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(new_entry, ensure_ascii=False) + "\n")
-    print(f"  [REKEY] {fixture_path.name}: +{new_key[:16]}...")
+    print(f"  [REKEY] {fixture_path.name}: +{new_key[:16]}... (matched {source['key'][:16]}...)")
     return True
 
 

--- a/tests/test_rekey_fixtures_tool.py
+++ b/tests/test_rekey_fixtures_tool.py
@@ -102,14 +102,15 @@ def test_dry_run_does_not_write(tmp_path):
     assert fixture.read_text() == original_text   # file must not change
 
 
-def test_rekey_uses_last_entry_response_when_multiple(tmp_path):
-    """Tier 2: when a fixture has multiple entries, the newest response is reused."""
+def test_rekey_tiebreak_most_recent_when_previews_identical(tmp_path):
+    """Tier 2: when several entries share the SAME preview (an ambiguous match),
+    the most-recent (last) match is reused — the tie-break (#2024)."""
     fixture = tmp_path / "fixture.jsonl"
     entries = [
         {
             "key": f"key{i}",
             "model": "gemini-2.5-flash-lite",
-            "prompt_preview": "Q",
+            "prompt_preview": "Q",   # all identical → ambiguous match
             "response": {"choices": [{"message": {"content": f"resp{i}"}}]},
         }
         for i in range(3)
@@ -127,5 +128,100 @@ def test_rekey_uses_last_entry_response_when_multiple(tmp_path):
     assert result, "fixture must contain entries after rekey"
     new_entry = result[-1]
     assert new_entry["key"] == "new_key_xyz"
-    # Must reuse last (index 2) entry's response
+    # tie-break: most-recent match (index 2)
     assert new_entry["response"]["choices"][0]["message"]["content"] == "resp2"
+
+
+def test_rekey_multiround_matches_per_entry_not_last(tmp_path):
+    """Tier 2: #2024 bug 2 — a multi-round fixture (DISTINCT previews per round)
+    re-keys each entry to ITS OWN matched response, NOT the last entry's. The old
+    last-entry reuse gave every round the final round's response (corruption)."""
+    fixture = tmp_path / "fixture.jsonl"
+    entries = [
+        {
+            "key": "round1_oldkey",
+            "model": "gemini-2.5-flash-lite",
+            "prompt_preview": "round one: what is X?",
+            "response": {"choices": [{"message": {"content": "X is one"}}]},
+        },
+        {
+            "key": "round2_oldkey",
+            "model": "gemini-2.5-flash-lite",
+            "prompt_preview": "round two: what is Y?",
+            "response": {"choices": [{"message": {"content": "Y is two"}}]},
+        },
+    ]
+    _write_fixture(fixture, entries)
+
+    # re-key round 1 (preview matches the FIRST entry, not the last)
+    rk._rekey_fixture(
+        fixture_path=fixture, new_key="round1_newkey",
+        prompt_preview="round one: what is X?", dry_run=False,
+    )
+    # re-key round 2
+    rk._rekey_fixture(
+        fixture_path=fixture, new_key="round2_newkey",
+        prompt_preview="round two: what is Y?", dry_run=False,
+    )
+
+    by_key = {e["key"]: e for e in _read_fixture(fixture)}
+    # round 1's new key reuses round 1's response (the bug: it would be "Y is two")
+    assert by_key["round1_newkey"]["response"]["choices"][0]["message"]["content"] == "X is one"
+    assert by_key["round2_newkey"]["response"]["choices"][0]["message"]["content"] == "Y is two"
+
+
+def test_rekey_skips_when_no_preview_match(tmp_path):
+    """Tier 2: #2024 — when no existing entry's preview matches, the rekey is
+    skipped (no write) rather than reusing an unrelated response (no silent
+    corruption)."""
+    fixture = tmp_path / "fixture.jsonl"
+    entry = {
+        "key": "only_key",
+        "model": "gemini-2.5-flash-lite",
+        "prompt_preview": "the recorded request",
+        "response": {"choices": [{"message": {"content": "recorded"}}]},
+    }
+    _write_fixture(fixture, [entry])
+    before = fixture.read_text()
+
+    changed = rk._rekey_fixture(
+        fixture_path=fixture, new_key="unmatched_newkey",
+        prompt_preview="a completely different request", dry_run=False,
+    )
+
+    assert changed is False
+    assert fixture.read_text() == before  # nothing written
+
+
+def test_parse_missing_keys_json_newline_safe(tmp_path):
+    """Tier 2: #2024 bug 1 — _parse_missing_keys reads the JSON MISSING_KEY line
+    and preserves a preview containing a newline + a '|' (the old |-split form
+    truncated at the first newline). Interleaved pytest output is ignored."""
+    preview = "line one of the prompt\nline two with a | pipe"
+    line = "MISSING_KEY=" + json.dumps({
+        "new_key": "abc123def456",
+        "fixture_path": "tests/fixtures/replay/foo.jsonl",
+        "prompt_preview": preview,
+    })
+    output = "\n".join([
+        "============ test session starts ============",
+        "tests/test_x.py::test_y FAILED",
+        line,
+        "1 failed in 0.5s",
+    ])
+
+    parsed = rk._parse_missing_keys(output)
+
+    # exactly this key parsed (content, not count) — interleaved pytest lines ignored
+    assert [r["new_key"] for r in parsed] == ["abc123def456"]
+    rec = parsed[0]
+    assert rec["fixture_path"] == Path("tests/fixtures/replay/foo.jsonl")
+    assert rec["prompt_preview"] == preview  # full preview preserved (newline + pipe)
+
+
+def test_parse_missing_keys_dedups(tmp_path):
+    """Tier 2: #2024 — duplicate (new_key, fixture_path) lines collapse to one."""
+    rec = json.dumps({"new_key": "k1", "fixture_path": "f.jsonl", "prompt_preview": "p"})
+    output = f"MISSING_KEY={rec}\nMISSING_KEY={rec}\n"
+    parsed = rk._parse_missing_keys(output)
+    assert [r["new_key"] for r in parsed] == ["k1"]  # deduped to the one request


### PR DESCRIPTION
**[e2e-coder]** — fixes the dev-tool trap I hit during the #1953 (D) replay re-key (filed by lead from my discovery). `scripts/rekey_fixtures.py` silently no-opped AND could corrupt multi-round fixtures — a real hazard for any future catalog-change re-key.

## Bug 1 — silent no-op (the MISSING_KEY capture)
The patcher subprocess ran pytest **without `-s`**, so pytest captured the patcher's `MISSING_KEY=` print per-test and `--tb=no -q` never surfaced it → the scan parsed nothing → **"No missing keys found" even when keys were missing** (the rekey never happened).

**Fix:** add `-s` (`--capture=no`). Verified empirically:
```
WITHOUT -s (old):  MISSING_KEY captured: False   ← swallowed (the silent no-op)
WITH    -s (fix):  MISSING_KEY captured: True
```
Also hardened the line format: `MISSING_KEY=` now carries a **JSON object** (newline-/`|`-safe) instead of a raw `key|path|preview` f-string that truncated previews at the first newline (the preview is the last message's content — it can contain both). The parse is extracted into a pure `_parse_missing_keys(output)` (unit-tested).

## Bug 2 — multi-round corruption (the response reuse)
`_rekey_fixture` reused the **LAST entry's response for every new key**, so a multi-round fixture got the final round's response on every re-keyed round.

**Fix:** **preview-match per entry.** The fixture `prompt_preview` (the last message's content) is stable across SP changes, so the new key's captured preview matches its original entry exactly → reuse **that** entry's response. Ambiguous match (identical previews) → most-recent (tie-break); **no** match → skip with a warning (never write an unjustified response).

## Tests (`tests/test_rekey_fixtures_tool.py`)
- Reframed the old `uses_last_entry_response_when_multiple` → `tiebreak_most_recent_when_previews_identical` (the identical-preview case it actually exercises; the old name implied "last is always reused" = the bug).
- **`multiround_matches_per_entry_not_last`** — the bug-2 regression: distinct previews → each round matched to ITS OWN response (old code gave every round the last response).
- **`skips_when_no_preview_match`** — no silent corruption on no-match.
- **`parse_missing_keys_json_newline_safe`** + `_dedups` — bug-1 parse robustness (newline + `|` preserved; interleaved pytest lines ignored; dedup).

## Test plan
- [x] 8 rekey tests green; ruff + `test_tier_audit.py --strict` clean
- [x] Bug-1 `-s` capture mechanism verified empirically (swallowed → captured)
- [x] Script end-to-end smoke (`--dry-run`, default pattern) runs clean through the real subprocess + parse
- [x] Full-suite `pytest -q` from rootdir: **8011 passed, 2 failed** — the same two pre-existing & unrelated failures (swebench HF_TOKEN; web_fetch HTML-extraction drift). #2024 is scripts-only (no src/), so neither is mine.

Closes #2024. (Scripts-only + its test; no `src/` change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)