### PR TITLE
fix(tui): cell-aware truncation for events_tab chain/budget hints + agents snippet

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/agents_tab.py
@@ -22,6 +22,7 @@ from .base import (
     _TEXT_DIM,
     _TEXT_MUTED,
     logger,
+    truncate_to_cells,
 )
 
 
@@ -555,10 +556,10 @@ def render_agents(
                     # the "↳" node.
                     flattened = " ".join(snippet.split())
                     _max = 60
-                    short = (
-                        flattened if len(flattened) <= _max
-                        else flattened[:_max - 1] + "…"
-                    )
+                    # cell-aware: recent_user_message is user content (CJK /
+                    # emoji capable), so a len()/codepoint slice overshoots the
+                    # cell budget (wide chars = 2 cells) and wraps the row.
+                    short = truncate_to_cells(flattened, _max)
                     line2 = RichText()
                     line2.append("↳ ", style=_TEXT_DIM)
                     line2.append(short, style=_TEXT_DIMMEST)

--- a/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
@@ -380,13 +380,16 @@ def _event_hint(ev: dict) -> str:
     if t == "loop_limit_exceeded":
         return f"{d.get('phase', '')}: {d.get('visit_count', '?')}/{d.get('max', '?')}"
     if t == "phase_budget_exceeded":
-        return f"{d.get('phase', '')}: {str(d.get('reason', ''))[:30]}"
+        reason, was_trunc = _truncate_to_cells(str(d.get("reason", "")), 30)
+        return f"{d.get('phase', '')}: {reason}" + ("…" if was_trunc else "")
     if t == "chain_timeout":
-        wait = str(d.get("waiting_on", ""))[:25]
-        return f"{wait} ({d.get('timeout_seconds', '?')}s)"
+        wait, was_trunc = _truncate_to_cells(str(d.get("waiting_on", "")), 25)
+        ell = "…" if was_trunc else ""
+        return f"{wait}{ell} ({d.get('timeout_seconds', '?')}s)"
     if t == "chain_timeout_extended":
-        wait = str(d.get("waiting_on", ""))[:25]
-        return f"{wait} +{d.get('extension_seconds', '?')}s"
+        wait, was_trunc = _truncate_to_cells(str(d.get("waiting_on", "")), 25)
+        ell = "…" if was_trunc else ""
+        return f"{wait}{ell} +{d.get('extension_seconds', '?')}s"
     if t in ("budget_warn", "budget_exceeded"):
         dim = d.get("dimension", "")
         skill = d.get("skill", "")

--- a/tests/cli/test_events_tab_cjk_hint.py
+++ b/tests/cli/test_events_tab_cjk_hint.py
@@ -105,6 +105,42 @@ def test_web_search_started_cjk_fits_cell_budget() -> None:
     )
 
 
+def test_phase_budget_exceeded_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK phase_budget_exceeded reason hint stays cell-bounded — one of
+    the 3 chain/budget branches MISSED by the Wave-13 cell-aware sweep (it fixed
+    6 branches but left phase_budget_exceeded / chain_timeout[_extended] on raw
+    ``[:N]``)."""
+    ev = {
+        "type": "phase_budget_exceeded",
+        "data": {"phase": "p", "reason": "予算を超過しました" * 5},  # 45 CJK = 90 cells raw
+    }
+    hint = _event_hint(ev)
+    width = cell_len(hint)
+    assert width <= _MAX_HINT_CELLS, f"cell_width={width}: {hint!r}"
+
+
+def test_chain_timeout_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK chain_timeout waiting_on hint stays cell-bounded (Wave-13 miss)."""
+    ev = {
+        "type": "chain_timeout",
+        "data": {"waiting_on": "応答を待っています" * 5, "timeout_seconds": 30},
+    }
+    hint = _event_hint(ev)
+    width = cell_len(hint)
+    assert width <= _MAX_HINT_CELLS, f"cell_width={width}: {hint!r}"
+
+
+def test_chain_timeout_extended_cjk_fits_cell_budget() -> None:
+    """Tier 2b: CJK chain_timeout_extended waiting_on hint stays cell-bounded (Wave-13 miss)."""
+    ev = {
+        "type": "chain_timeout_extended",
+        "data": {"waiting_on": "応答を待っています" * 5, "extension_seconds": 10},
+    }
+    hint = _event_hint(ev)
+    width = cell_len(hint)
+    assert width <= _MAX_HINT_CELLS, f"cell_width={width}: {hint!r}"
+
+
 def test_tool_failed_cjk_does_not_overflow_message() -> None:
     """Tier 2b: CJK tool_failed hint truncates the message portion with ellipsis."""
     # tool_failed uses a 25-cell cap for the message portion.


### PR DESCRIPTION
**[tui-coder]** — 2nd fix from the TUI rendering-robustness mining sweep (cell-width class; the markup-injection class shipped in #2041). Careful per-site triage — only the real defects, no churn.

## Fixes
### events_tab `_event_hint` — COMPLETENESS (the high-value find)
The Wave-13 cell-aware sweep (per `test_events_tab_cjk_hint.py`) converted **6** branches to `_truncate_to_cells` but **missed 3**: `phase_budget_exceeded` (`[:30]` on `reason`), `chain_timeout` / `chain_timeout_extended` (`[:25]` on `waiting_on`). CJK content overshoots the cell budget ~2× → row wrap + cursor-map misalignment. Converted to the same `_truncate_to_cells(...) + ("…" if was_trunc else "")` idiom as the siblings.

### agents_tab — `↳` recent-user-message snippet
User content (CJK-capable) truncated by `len()`/slice → routed through the cell-aware `truncate_to_cells` helper.

## NOT fixed (verified NON-issue — careful triage avoided churn)
`skill_activity:622/662` `" " * len(self._label_prefix)` — `label_prefix` is `"  └─ "` (box-drawing + spaces, **all narrow / 1-cell**), so `len()` == cell width. The sweep flagged it but verification shows it's a false positive.

## Test plan
- [x] **+3 Tier-2b tests** in `test_events_tab_cjk_hint.py` for the 3 missed branches, **falsify-confirmed** (unfixed CJK hint ≈ 63 cells > the 41-cell bound → fails without the fix)
- [x] 49 tests pass (events_tab_cjk 15 + agents 34 no-regression); `ruff check src tests` clean; `tier_audit --strict` 0
- [x] agents_tab fix: proven-helper swap (`truncate_to_cells` is unit-proven via the events_tab CJK tests + its own behavior); 34 agents tests confirm no regression. A dedicated render test was **disproportionate** — `render_agents` returns a Rich `Group` (not markup), so snippet extraction needs Group/Tree traversal + width-padding handling for a 1-line swap to an already-proven helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
