### PR TITLE
feat(#1811): A2A Agent Card — add the v0.2.0 `provider` discovery field

### DIFF
--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -81,6 +81,16 @@ _A2A_PROTOCOL_VERSION = "0.2.0"
 # a stale Reyn instance during interop debugging).
 _REYN_A2A_VERSION = "0.1.0"
 
+# A2A AgentProvider (#1811) — the service provider of these agents. The v0.2.0
+# AgentCard's optional `provider` (organization + url, both required when present)
+# was the one discovery-metadata field still missing. Sourced from the project
+# metadata (pyproject [project.urls] Homepage), kept as constants in the same
+# style as the version constants above. (preferredTransport / additionalInterfaces
+# do NOT exist in the v0.2.0 schema reyn declares — they are later-0.2.x additions
+# that would require a protocolVersion bump, so they are intentionally omitted.)
+_PROVIDER_ORGANIZATION = "Reyn"
+_PROVIDER_URL = "https://tya5.github.io/reyn/"
+
 
 # ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -141,6 +151,13 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
         "name": agent_name,
         "description": role or f"Reyn agent {agent_name!r}",
         "url": base_url,
+        # A2A v0.2.0 optional `provider` (#1811) — the service provider metadata
+        # peers read during discovery. organization + url are both required when
+        # `provider` is present.
+        "provider": {
+            "organization": _PROVIDER_ORGANIZATION,
+            "url": _PROVIDER_URL,
+        },
         "version": _REYN_A2A_VERSION,
         "protocolVersion": _A2A_PROTOCOL_VERSION,
         "capabilities": {

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -170,6 +170,13 @@ def test_agent_card_returns_canonical_shape(tmp_path):
         # Endpoint URL points at the JSON-RPC handler for THIS agent.
         assert card["url"].endswith("/a2a/agents/default")
 
+        # Provider: A2A v0.2.0 discovery metadata (#1811). The optional
+        # `provider` requires organization + url when present; reyn now surfaces
+        # both (sourced from the project Homepage).
+        provider = card["provider"]
+        assert provider["organization"] == "Reyn"
+        assert provider["url"].startswith("https://")
+
         # Capabilities advertised: issue #267 Gap 3 Z-c re-elevation
         # — both True after Gap 1 + Gap 2 closed.
         caps = card["capabilities"]


### PR DESCRIPTION
**[e2e-coder]** — the **only autonomous-actionable** part of #1811 (A2A spec gaps), per the spec-verify recon below. Closes the one real, zero-decision discovery-metadata gap; the rest of #1811 reduces to owner-decisions.

## Change
Add the A2A v0.2.0 optional `provider` field to the Agent Card (`organization` + `url`, both required when `provider` is present), sourced from the project `pyproject [project.urls] Homepage`:
```json
"provider": { "organization": "Reyn", "url": "https://tya5.github.io/reyn/" }
```

## Spec-verify (the important part — verified the NORMATIVE source, not the issue)
Fetched the A2A **v0.2.0** `types.ts` (the version reyn declares via `_A2A_PROTOCOL_VERSION = "0.2.0"`):
- **All v0.2.0 REQUIRED fields were already present** — the card IS v0.2.0-compliant. The issue's "required fields missing" framing was **inaccurate for the declared version**.
- **`preferredTransport` / `additionalInterfaces` do NOT exist in v0.2.0** — they are later-0.2.x additions. Adding them would be anachronistic and would require a **protocolVersion bump** (a protocol-version decision → deferred to the owner, not folded in here).
- **`provider` is the sole zero-decision, v0.2.0-valid addition** — optional but a genuine discovery-metadata gap.

## Test plan
- [x] `test_agent_card_returns_canonical_shape` extended to assert `provider` (organization + https url); 25 A2A tests pass (test_a2a.py + fp0001 + capability-claim-interim)
- [x] ruff + `test_tier_audit.py --strict` clean
- [ ] Full-suite `pytest -q` from rootdir → CI-green-ping on completion

Refs #1811 (annotated with the full spec-verify recon — it reduces to an owner-decision tracker: version-bump for preferredTransport/interfaces, auth design for securitySchemes/security/pushNotifications-CRUD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)