### PR TITLE
fix(tui): degrade malformed intervention choice instead of dropping it

### DIFF
--- a/src/reyn/interfaces/tui/app_outbox.py
+++ b/src/reyn/interfaces/tui/app_outbox.py
@@ -1141,11 +1141,15 @@ class OutboxRouter:
             # Forward the full choice shape (label / id / hotkey / default)
             # so the widget can render `[h] Label` prefixes and highlight a
             # default option. Missing keys fall back to safe blanks — callers
-            # that historically only set label+id keep working.
+            # that historically only set label+id keep working. Interventions
+            # are load-bearing (the user must see + answer them), so a
+            # malformed choice degrades gracefully here rather than raising —
+            # a KeyError would drop the whole intervention (the handler's
+            # try/except swallows it), leaving the user unable to respond.
             choices = [
                 {
-                    "label": c["label"],
-                    "id": c["id"],
+                    "label": c.get("label", "?"),
+                    "id": c.get("id", ""),
                     "hotkey": c.get("hotkey") or "",
                     "default": bool(c.get("default", False)),
                 }

--- a/tests/cli/test_intervention_choice_degrade.py
+++ b/tests/cli/test_intervention_choice_degrade.py
@@ -1,0 +1,57 @@
+"""Tier 2: _on_intervention degrades a malformed choice instead of dropping the
+load-bearing intervention.
+
+The choice-normalization in ``OutboxRouter._on_intervention`` documents (in its
+own comment) that "missing keys fall back to safe blanks", but historically read
+``c["label"]`` / ``c["id"]`` with bracket access — a KeyError on a malformed
+choice. Interventions are load-bearing (the user must see + answer a permission
+request); the outbox consume loop's try/except swallows a handler raise, so a
+KeyError here would silently DROP the intervention, leaving the user unable to
+respond. The fix aligns label/id with the documented intent + the hotkey/default
+fields (all ``.get()``).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+@pytest.mark.asyncio
+async def test_intervention_with_malformed_choice_still_mounts() -> None:
+    """Tier 2: a choice missing label/id degrades (safe blanks) and the
+    intervention still mounts — rather than raising KeyError + being dropped."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.app_outbox import OutboxRouter
+    from reyn.interfaces.tui.widgets.intervention import InterventionWidget
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation")
+        header = app.query_one("#header")
+        router = OutboxRouter(app)
+        msg = OutboxMessage(
+            kind="intervention",
+            text="Approve?",
+            meta={
+                "intervention_id": "iv-degrade-1",
+                "prompt": "Approve the operation?",
+                # First choice is malformed (no label AND no id) — pre-fix the
+                # bracket access raised KeyError here, dropping the whole iv.
+                "choices": [{"hotkey": "y"}, {"label": "No", "id": "n"}],
+            },
+        )
+        # Direct call (no outer try/except): pre-fix this raises KeyError;
+        # post-fix it degrades the malformed choice and mounts the intervention.
+        router._on_intervention(msg, conv, header)
+        await pilot.pause()
+        assert app.query(InterventionWidget), (
+            "intervention must still mount (not be dropped) when a choice is malformed"
+        )


### PR DESCRIPTION
**[tui-coder]** — fix from the 3rd mining sweep (message-routing / handler-completeness class).

## The defect (code↔comment inconsistency in a load-bearing path)
`OutboxRouter._on_intervention` normalizes choice dicts, and its **own comment** says *"Missing keys fall back to safe blanks"* — but it read `c["label"]` / `c["id"]` with **bracket access** (only `hotkey`/`default` used `.get()`). A choice missing `label`/`id` raised `KeyError`, contradicting the documented intent.

**Why it matters**: interventions are **load-bearing** (the user must see + answer a permission request). The outbox consume loop wraps each handler in `try/except`, so a `KeyError` here is *swallowed* → the whole intervention is silently **dropped** → the user can't respond (stuck). Aligning `label`/`id` with `.get()` degrades a malformed choice gracefully and keeps the intervention visible.

## Test plan
- [x] +1 Tier-2 test: an intervention whose first choice has no `label`/`id` still mounts (real `ReynTUIApp` + `OutboxRouter`, no mocks)
- [x] Falsify Python-semantics-certain: pre-fix `{"hotkey":"y"}["label"]` → `KeyError` on the direct call
- [x] 4 intervention tests pass (degrade + resolved-meta no-regression); `ruff check src tests` clean; `tier_audit --strict` 0

## Sweep context
The message-routing layer was otherwise **clean** — producer↔consumer kind-sets match (the dispatch is complete), handlers + the consume loop are guarded. This code↔comment inconsistency was the one actionable find. (Two non-defects correctly left alone: the `__session_switch_request__` kind is registry-owned before the TUI loop; the dead `__stream_*` handlers are an architectural remnant with a documenting comment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
