### PR TITLE
test: make swebench/web_fetch tests robust to optional-dep presence

### DIFF
--- a/tests/test_eval_benchmark_tier1_swebench.py
+++ b/tests/test_eval_benchmark_tier1_swebench.py
@@ -21,6 +21,7 @@ are e2e tests validated separately on a Docker host.
 """
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 
@@ -304,9 +305,13 @@ def test_swebench_missing_honest_skip() -> None:
         run_tier1_swebench_eval,
     )
 
-    # Ensure swebench is not currently installed in THIS venv
-    # (it's a Tier1-only optional dep, not in reyn's core requirements)
-    if "swebench" in sys.modules:
+    # Ensure swebench is not installed in THIS venv (it's a Tier1-only optional
+    # dep, not in reyn's core requirements). Check IMPORTABILITY, not
+    # ``sys.modules``: swebench may be installed but not yet imported, in which
+    # case the lazy import inside run_tier1_swebench_eval would succeed and the
+    # function would proceed past the swebench-missing path (and hit the HF Hub).
+    # The missing path is only exercisable when swebench is genuinely absent.
+    if importlib.util.find_spec("swebench") is not None:
         pytest.skip(
             "swebench is installed in this environment; "
             "the swebench-missing path is only exercisable when it is absent"

--- a/tests/test_web_fetch_preview_path_ref.py
+++ b/tests/test_web_fetch_preview_path_ref.py
@@ -263,9 +263,14 @@ def test_legacy_no_media_store_path_returns_inline_content(
     )
 
     assert result["status"] == "ok"
-    # content is the extracted body (= what every pre-PoC test asserts).
+    # content is the extracted body (= what every pre-PoC test asserts). Assert on
+    # paragraph text, NOT a heading: the content extractor is `trafilatura` when
+    # `reyn[fetch]` is installed, and it legitimately drops a lone <h1> on a
+    # minimal doc (keeps the main paragraph bodies) — so a heading assertion is
+    # extractor-fragile. Paragraph text is preserved by both trafilatura and the
+    # stdlib fallback extractor.
     assert result["content"]  # non-empty
-    assert "Top Heading" in result["content"]
+    assert "opening paragraph introduces the topic" in result["content"]
     assert "preview" not in result
     assert "path_ref" not in result
     assert "stored_as" not in result


### PR DESCRIPTION
**[e2e-coder]** — the 2 "pre-existing failures" I reported across this session's CI-green-pings, triaged to root cause. **Both are test-fragility, not production regressions, and not CI debt** (CI is green because CI lacks these optional deps). They fail only in an env that HAS the optional deps installed (e.g. my local `reyn[fetch]` + swebench) — a supported config, so the suite should be robust to it.

## #1 `test_legacy_no_media_store_path_returns_inline_content`
Asserted the page `<h1>` ("Top Heading") appears in the extracted content. The content extractor is **trafilatura** when `reyn[fetch]` is installed (trafilatura 2.0.0 locally), and it legitimately drops a lone `<h1>` on a minimal doc — keeping only the paragraph bodies (verified by direct `trafilatura.extract()` repro). Only the stdlib fallback extractor keeps the heading. **Fix:** assert on paragraph text both extractors preserve.

## #2 `test_swebench_missing_honest_skip`
The skip guard checked `"swebench" in sys.modules` (already-imported). When swebench is **installed-but-not-yet-imported**, the guard missed → the lazy import inside `run_tier1_swebench_eval` succeeded → the function proceeded past the swebench-missing path and hit the HF Hub (needs `HF_TOKEN`) instead of raising `RuntimeError('swebench_missing')`. **Fix:** check importability (`importlib.util.find_spec`) — the missing path is only exercisable when swebench is genuinely absent.

## Test plan
- [x] Both target tests behave correctly: web_fetch passes; swebench-missing now **skips** (swebench importable locally) instead of failing
- [x] ruff + `test_tier_audit.py --strict` clean
- [ ] Full-suite `pytest -q` from rootdir → **expect 0 failures locally** (the win: my local suite had 2; now 0) → CI-green-ping on completion

Test-only, no `src/` change. (Untracked failures — fixed per the "fix the real ones, don't file issues" steer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)