### PR TITLE
fix(tui): /tasks status|kill resolve dynamic tasks (#2036 list-vs-action gap)

### DIFF
--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -79,15 +79,16 @@ def _format_elapsed(seconds: float) -> str:
     return f"{hours}h {mins:02d}m"
 
 
-def _resolve_task(
+async def _resolve_task(
     session: "Session", prefix: str,
 ) -> tuple[str | None, str, list[str]]:
-    """Resolve a run_id / plan_id from a prefix.
+    """Resolve a run_id / task_id from a prefix across both task families.
 
     Returns ``(resolved_id, kind, candidates)``:
-      - ``resolved_id`` is non-None iff exactly one match exists.
-      - ``kind`` is "skill" or "plan" or "" (when ambiguous / unmatched).
-      - ``candidates`` lists every match across both task families so the
+      - ``resolved_id`` is non-None iff exactly one match exists across BOTH
+        skill runs and dynamic tasks.
+      - ``kind`` is "skill" or "task" or "" (when ambiguous / unmatched).
+      - ``candidates`` lists every match (``skill:<id>`` / ``task:<id>``) so the
         caller can show a "did you mean?" hint.
     """
     prefix = prefix.strip()
@@ -95,9 +96,26 @@ def _resolve_task(
         return None, "", []
     skill_ids = list(getattr(session, "running_skills", {}).keys())
     skill_matches = [r for r in skill_ids if prefix in r]
-    candidates = [f"skill:{r}" for r in skill_matches]
+    # Dynamic tasks: /tasks (#2036) LISTS them, so status|kill must resolve the
+    # same ids the list shows — otherwise the user sees a task they can't act on
+    # (the list-vs-action gap this fixes).
+    task_matches: list[str] = []
+    backend = getattr(session, "task_backend", None)
+    if backend is not None:
+        try:
+            task_matches = [
+                t.task_id for t in await backend.list() if prefix in t.task_id
+            ]
+        except Exception:
+            task_matches = []
+    candidates = (
+        [f"skill:{r}" for r in skill_matches]
+        + [f"task:{t}" for t in task_matches]
+    )
     if len(candidates) == 1:
-        return skill_matches[0], "skill", candidates
+        if skill_matches:
+            return skill_matches[0], "skill", candidates
+        return task_matches[0], "task", candidates
     return None, "", candidates
 
 
@@ -197,7 +215,7 @@ async def _task_status(session: "Session", args: str) -> None:
     if not prefix:
         await reply_error(session, "Usage: /tasks status <run_id_prefix>")
         return
-    resolved, kind, candidates = _resolve_task(session, prefix)
+    resolved, kind, candidates = await _resolve_task(session, prefix)
     if resolved is None:
         if not candidates:
             await reply_error(session, f"no task matches {prefix!r}")
@@ -210,8 +228,34 @@ async def _task_status(session: "Session", args: str) -> None:
 
     if kind == "skill":
         await _skill_status(session, resolved)
+    elif kind == "task":
+        await _dynamic_task_status(session, resolved)
     else:
         await reply_error(session, f"unknown task kind for {resolved}")
+
+
+async def _dynamic_task_status(session: "Session", task_id: str) -> None:
+    """Render a dynamic task's state for /tasks status (#2036 follow-up)."""
+    backend = getattr(session, "task_backend", None)
+    task = await backend.get(task_id) if backend is not None else None
+    if task is None:
+        await reply_error(session, f"task {task_id} not found")
+        return
+    status = getattr(task.status, "value", task.status)
+    deps = list(getattr(task, "deps", []) or [])
+    out: list[str] = [
+        f"task {task.task_id}",
+        f"  name:    {task.name}",
+        f"  status:  {status}",
+        f"  deps:    {', '.join(d[:8] for d in deps) if deps else '(none)'}",
+    ]
+    if getattr(task, "description", None):
+        out.append(f"  detail:  {task.description}")
+    if getattr(task, "assignee", None):
+        out.append(f"  assignee: {task.assignee}")
+    if getattr(task, "result", None):
+        out.append(f"  result:  {task.result}")
+    await reply(session, "\n".join(out))
 
 
 async def _skill_status(session: "Session", run_id: str) -> None:
@@ -244,7 +288,7 @@ async def _kill_task(session: "Session", args: str) -> None:
     if not prefix:
         await reply_error(session, "Usage: /tasks kill <run_id_prefix>")
         return
-    resolved, kind, candidates = _resolve_task(session, prefix)
+    resolved, kind, candidates = await _resolve_task(session, prefix)
     if resolved is None:
         if not candidates:
             await reply_error(session, f"no task matches {prefix!r}")
@@ -261,5 +305,14 @@ async def _kill_task(session: "Session", args: str) -> None:
         # circular imports at module load time.
         from reyn.interfaces.slash.skill import _discard_skill_run
         await _discard_skill_run(session, resolved)
+    elif kind == "task":
+        # A dynamic task: abort it via the backend (#2036 follow-up). abort()
+        # transitions the task + its dependents out of the runnable set.
+        backend = getattr(session, "task_backend", None)
+        if backend is None:
+            await reply_error(session, f"no task backend; cannot kill {resolved}")
+            return
+        await backend.abort(resolved, reason="/tasks kill")
+        await reply(session, f"aborted task {resolved}")
     else:
         await reply_error(session, f"unknown task kind for {resolved}")

--- a/tests/cli/test_tasks_slash_dynamic_status_kill.py
+++ b/tests/cli/test_tasks_slash_dynamic_status_kill.py
@@ -1,0 +1,102 @@
+"""Tier 2: /tasks status|kill resolve + act on dynamic tasks (#2036 follow-up).
+
+Dogfood-found (live, real-terminal): /tasks (#2036) LISTS the dynamic tasks the
+chat LLM creates via ``task__create``, but ``_resolve_task`` matched only
+``running_skills`` — so ``/tasks status <task_id>`` / ``/tasks kill <task_id>``
+said "no task matches" for a task the list had just shown (the list-vs-action
+gap). These pin that status renders the dynamic task + kill aborts it.
+
+No mocks — a real :class:`InMemoryTaskBackend` + a Session-shaped capture
+exposing the public surface the handlers read (``task_backend`` /
+``running_skills`` / ``get_skill_registry``) + the ``_put_outbox`` reply seam.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.slash.tasks import _kill_task, _task_status
+from reyn.task import InMemoryTaskBackend, Task, TaskState
+
+
+class _CaptureSession:
+    """Session-shaped stand-in capturing the reply text the handlers emit."""
+
+    def __init__(self, *, running_skills=None, task_backend=None):
+        self.running_skills = running_skills or {}
+        self._task_backend = task_backend
+        self.replies: list[str] = []
+
+    @property
+    def task_backend(self):
+        return self._task_backend
+
+    def get_skill_registry(self):
+        return None
+
+    async def _put_outbox(self, message) -> None:
+        self.replies.append(message.text)
+
+
+async def _seed_task(backend: InMemoryTaskBackend) -> str:
+    task = Task(
+        task_id="task-aaaaaaaa-0001",
+        name="ingest_raw_csv",
+        assignee="sess-1",
+        requester="req",
+        status=TaskState.IN_PROGRESS,
+    )
+    await backend.create(task)
+    return task.task_id
+
+
+@pytest.mark.asyncio
+async def test_tasks_status_resolves_dynamic_task() -> None:
+    """Tier 2: ``/tasks status <dynamic_task_id>`` renders the task — not the
+    pre-fix "no task matches" (which fired because _resolve_task only knew skill
+    runs)."""
+    backend = InMemoryTaskBackend()
+    await _seed_task(backend)
+    session = _CaptureSession(task_backend=backend)
+
+    await _task_status(session, "task-aaa")
+
+    out = session.replies[-1]
+    assert "no task matches" not in out
+    assert "ingest_raw_csv" in out
+    assert "in_progress" in out
+
+
+@pytest.mark.asyncio
+async def test_tasks_kill_aborts_dynamic_task() -> None:
+    """Tier 2: ``/tasks kill <dynamic_task_id>`` aborts the task via the backend."""
+    backend = InMemoryTaskBackend()
+    task_id = await _seed_task(backend)
+    session = _CaptureSession(task_backend=backend)
+
+    await _kill_task(session, "task-aaa")
+
+    assert "aborted" in session.replies[-1].lower()
+    # The real backend transitioned the task out of the runnable set.
+    task = await backend.get(task_id)
+    assert task is not None
+    assert getattr(task.status, "value", task.status) == "archived"
+
+
+@pytest.mark.asyncio
+async def test_tasks_status_unmatched_dynamic_prefix_reports_no_match() -> None:
+    """Tier 2: a prefix matching neither a skill run nor a dynamic task still
+    reports "no task matches" (the resolver spans both families)."""
+    backend = InMemoryTaskBackend()
+    await _seed_task(backend)
+    session = _CaptureSession(task_backend=backend)
+
+    await _task_status(session, "zzzzzzzz")
+
+    assert "no task matches" in session.replies[-1]


### PR DESCRIPTION
**[tui-coder]** — **dogfood-found, live** (real-terminal). The high-value find from the dynamic-task-ops dogfood pass.

## The defect
`/tasks` (#2036) **lists** the dynamic tasks the chat LLM creates via `task__create`, but `_resolve_task` matched only `session.running_skills` — never `session.task_backend`. So `/tasks status <id>` and `/tasks kill <id>` reported **"no task matches"** for a task `/tasks` had *just listed*. Reproduced live: `/tasks` shows `ingest_raw_csv [1238d2eb]`, but `/tasks status 1238d2eb` → `✗ no task matches '1238d2eb'`. **The user sees tasks they can't act on** — a list-vs-action gap that only live dogfood surfaces (the #2036 review verified the LIST integration but not that status/kill resolve the listed tasks).

## Fix — completes the `/tasks` UX (listed tasks become actionable)
- `_resolve_task` → **async**; resolves dynamic tasks (`await task_backend.list()`, prefix-match `task_id`) *alongside* skill runs; `kind` is now `"skill"｜"task"` (dropped the dead `"plan"`); candidates span both families.
- `/tasks status`: `kind=="task"` → `_dynamic_task_status` renders via `backend.get` (name / status / deps / detail / assignee / result).
- `/tasks kill`: `kind=="task"` → `backend.abort(id, reason="/tasks kill")` + confirmation.

## Test plan
- [x] +3 Tier-2 tests (real `InMemoryTaskBackend` + Session-shaped capture, no mocks): status resolves+renders a dynamic task (not "no task matches"); kill aborts it (`backend.get` → status archived); an unmatched prefix still reports no-match
- [x] 9 tasks tests pass (3 new + 6 no-regression); `ruff check src tests` clean; `tier_audit --strict` 0
- [ ] (live re-verify in progress) real-terminal: recreate tasks → `/tasks status <id>` renders + `/tasks kill <id>` aborts — closing the dogfood loop

## Context
This closes the epic's task-ops UX (creation + list + **status + kill** all on the same ids). The dogfood also confirmed the epic's live end-to-end verify: the model creates 4 dep-linked tasks in a real production-default session and `/tasks` renders the dep chain correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
