### PR TITLE
feat(1800): hook config schema + loader + registry (slice A)

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -1,0 +1,21 @@
+"""reyn.hooks — agent lifecycle hook config: schema, loader, registry (#1800 slice A).
+
+Exposes:
+    HookDef        — typed model for a single hook definition.
+    PushBlock      — typed model for the inbox-push sub-schema.
+    HookRegistry   — ordered store; query via hooks_for(point).
+    load_hooks     — parse the ``hooks:`` list from a raw config dict
+                     and return a ready ``HookRegistry``.
+    HookConfigError — raised for config validation failures.
+"""
+from reyn.hooks.loader import load_hooks
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookConfigError, HookDef, PushBlock
+
+__all__ = [
+    "HookDef",
+    "PushBlock",
+    "HookRegistry",
+    "HookConfigError",
+    "load_hooks",
+]

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -1,0 +1,224 @@
+"""reyn.hooks.loader — parse and validate the ``hooks:`` config block (#1800 slice A).
+
+Entry point: ``load_hooks(raw)`` — accepts the raw value of the ``hooks:``
+key from a reyn.yaml dict and returns a ``HookRegistry``.
+
+Validation is *structural only* (field presence, types, hook-point membership,
+push/shell mutual-exclusion).  Template *semantics* are not validated here —
+rendering is a later slice.
+
+Validation errors raise ``HookConfigError`` with a decision-enabling message
+that names the entry index and the failing field so the operator can fix the
+config immediately.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import (
+    ALLOWED_HOOK_POINTS,
+    HookConfigError,
+    HookDef,
+    PushBlock,
+)
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_push_block(raw: object, entry_index: int) -> PushBlock:
+    """Validate and convert the ``push:`` sub-dict to a ``PushBlock``.
+
+    All Jinja2 template strings are stored raw; no rendering here.
+    """
+    if not isinstance(raw, dict):
+        raise HookConfigError(
+            f"hooks[{entry_index}].push must be a mapping, "
+            f"got {type(raw).__name__!r}."
+        )
+
+    # Required: message
+    message = raw.get("message")
+    if message is None:
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.message is required."
+        )
+    if not isinstance(message, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.message must be a string, "
+            f"got {type(message).__name__!r}."
+        )
+    if not message.strip():
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.message must not be empty."
+        )
+
+    # Optional: wake (bool or Jinja2 template string → bool, default True)
+    raw_wake = raw.get("wake", True)
+    if not isinstance(raw_wake, (bool, str)):
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.wake must be a bool or template string, "
+            f"got {type(raw_wake).__name__!r}."
+        )
+    wake: bool | str = raw_wake
+
+    # Optional: push_when (Jinja2 template string → bool, default "true")
+    raw_push_when = raw.get("push_when", "true")
+    if not isinstance(raw_push_when, (bool, str)):
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.push_when must be a bool or template string, "
+            f"got {type(raw_push_when).__name__!r}."
+        )
+    # Normalise a plain bool to its string form so the type is uniform.
+    if isinstance(raw_push_when, bool):
+        push_when: str = "true" if raw_push_when else "false"
+    else:
+        push_when = raw_push_when
+
+    # Optional: session (template string or None)
+    raw_session = raw.get("session", None)
+    if raw_session is not None and not isinstance(raw_session, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].push.session must be a string or null, "
+            f"got {type(raw_session).__name__!r}."
+        )
+    session: str | None = raw_session if raw_session else None
+
+    return PushBlock(
+        message=message,
+        wake=wake,
+        push_when=push_when,
+        session=session,
+    )
+
+
+def _parse_entry(raw: object, entry_index: int) -> HookDef:
+    """Validate one raw hooks list entry and return a ``HookDef``."""
+    if not isinstance(raw, dict):
+        raise HookConfigError(
+            f"hooks[{entry_index}] must be a mapping, "
+            f"got {type(raw).__name__!r}."
+        )
+
+    # ── on (required) ──────────────────────────────────────────────────────
+    # YAML 1.1 (PyYAML default) parses the bare keyword ``on`` as boolean
+    # ``True``; quote-free ``on: skill_end`` in reyn.yaml becomes
+    # ``{True: 'skill_end', ...}``.  Try the string key first (= quoted
+    # ``"on"``), then fall back to the boolean key ``True`` so that both
+    # ``on: skill_end`` and ``"on": skill_end`` work.
+    on_raw = raw.get("on", raw.get(True))
+    if on_raw is None:
+        raise HookConfigError(
+            f"hooks[{entry_index}].on is required."
+        )
+    if not isinstance(on_raw, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].on must be a string, "
+            f"got {type(on_raw).__name__!r}."
+        )
+    on_key = on_raw.strip().lower()
+    if on_key not in ALLOWED_HOOK_POINTS:
+        sorted_points = ", ".join(sorted(ALLOWED_HOOK_POINTS))
+        raise HookConfigError(
+            f"hooks[{entry_index}].on={on_raw!r} is not a recognised hook-point. "
+            f"Allowed: {sorted_points}."
+        )
+
+    # ── push / shell mutual-exclusion ──────────────────────────────────────
+    has_push = "push" in raw
+    has_shell = "shell" in raw
+
+    if has_push and has_shell:
+        raise HookConfigError(
+            f"hooks[{entry_index}]: 'push' and 'shell' are mutually exclusive; "
+            f"specify exactly one."
+        )
+    if not has_push and not has_shell:
+        raise HookConfigError(
+            f"hooks[{entry_index}]: exactly one of 'push' or 'shell' is required."
+        )
+
+    # ── push block ─────────────────────────────────────────────────────────
+    push_block: PushBlock | None = None
+    if has_push:
+        push_block = _parse_push_block(raw["push"], entry_index)
+
+    # ── shell ──────────────────────────────────────────────────────────────
+    shell: str | None = None
+    if has_shell:
+        shell_raw = raw["shell"]
+        if not isinstance(shell_raw, str):
+            raise HookConfigError(
+                f"hooks[{entry_index}].shell must be a string, "
+                f"got {type(shell_raw).__name__!r}."
+            )
+        if not shell_raw.strip():
+            raise HookConfigError(
+                f"hooks[{entry_index}].shell must not be empty."
+            )
+        shell = shell_raw
+
+    # ── matcher (optional, reserved) ───────────────────────────────────────
+    matcher_raw = raw.get("matcher", None)
+    if matcher_raw is not None and not isinstance(matcher_raw, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].matcher must be a string or null, "
+            f"got {type(matcher_raw).__name__!r}."
+        )
+    matcher: str | None = matcher_raw if matcher_raw else None
+
+    return HookDef(
+        on=on_key,
+        push=push_block,
+        shell=shell,
+        matcher=matcher,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public loader
+# ---------------------------------------------------------------------------
+
+
+def load_hooks(raw: object) -> HookRegistry:
+    """Parse and validate the ``hooks:`` value from a reyn.yaml dict.
+
+    Parameters
+    ----------
+    raw:
+        The value of the ``hooks:`` key from the config dict.  May be
+        ``None`` (absent), an empty list, or a list of hook dicts.
+        Any other type is logged as a warning and treated as empty.
+
+    Returns
+    -------
+    HookRegistry
+        A ready registry containing all validated ``HookDef`` objects in
+        registration (list) order.
+
+    Raises
+    ------
+    HookConfigError
+        On structural validation failure.  The message names the offending
+        entry index and the failing constraint so the operator can fix it.
+    """
+    if raw is None:
+        return HookRegistry([])
+
+    if not isinstance(raw, list):
+        _log.warning(
+            "config key 'hooks' must be a list; got %s — ignoring it.",
+            type(raw).__name__,
+        )
+        return HookRegistry([])
+
+    defs: list[HookDef] = []
+    for idx, entry in enumerate(raw):
+        defs.append(_parse_entry(entry, idx))
+
+    return HookRegistry(defs)

--- a/src/reyn/hooks/registry.py
+++ b/src/reyn/hooks/registry.py
@@ -1,0 +1,57 @@
+"""reyn.hooks.registry — in-memory hook registry (#1800 slice A).
+
+``HookRegistry`` stores ``HookDef`` objects in registration order and
+exposes a single query method: ``hooks_for(point)`` returns the ordered
+list of hooks registered for a given lifecycle point.
+
+Registration order is preserved (list semantics, not dict/set).  Multiple
+hooks at the same point are run in the order they appear in reyn.yaml.
+"""
+from __future__ import annotations
+
+from reyn.hooks.schema import HookDef
+
+
+class HookRegistry:
+    """Ordered store of ``HookDef`` objects, queryable by hook-point.
+
+    Parameters
+    ----------
+    defs:
+        Ordered sequence of validated ``HookDef`` objects (typically
+        produced by ``load_hooks``).  Stored in the order given.
+    """
+
+    def __init__(self, defs: list[HookDef]) -> None:
+        self._defs: list[HookDef] = list(defs)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def hooks_for(self, point: str) -> list[HookDef]:
+        """Return all hooks registered for *point* in registration order.
+
+        Parameters
+        ----------
+        point:
+            A lifecycle hook-point name (e.g. ``"turn_end"``).  Unknown
+            points return an empty list (no error) — forward-compat for
+            new points not yet in ``ALLOWED_HOOK_POINTS``.
+
+        Returns
+        -------
+        list[HookDef]
+            Possibly empty; order matches the order in reyn.yaml.
+        """
+        return [d for d in self._defs if d.on == point]
+
+    # ------------------------------------------------------------------
+    # Dunder helpers (for tests / repr)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._defs)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"HookRegistry({self._defs!r})"

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -1,0 +1,116 @@
+"""reyn.hooks.schema — typed models for hook definitions (#1800 slice A).
+
+Defines ``HookDef`` (a single hook entry from the ``hooks:`` config block)
+and ``PushBlock`` (the inline inbox-push sub-schema).  Template strings are
+stored **raw** — rendering is a later slice.
+
+Hook-point identifiers are normalised lowercase; the allowed set is the
+starter set agreed in #1800:
+
+    turn_start   turn_end
+    session_start  session_end
+    skill_start  skill_end
+    task_start   task_end
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Union
+
+# ---------------------------------------------------------------------------
+# Allowed hook-points (starter set — #1800 CONVERGED DESIGN)
+# ---------------------------------------------------------------------------
+
+ALLOWED_HOOK_POINTS: frozenset[str] = frozenset({
+    "turn_start",
+    "turn_end",
+    "session_start",
+    "session_end",
+    "skill_start",
+    "skill_end",
+    "task_start",
+    "task_end",
+})
+
+
+# ---------------------------------------------------------------------------
+# Validation error
+# ---------------------------------------------------------------------------
+
+
+class HookConfigError(ValueError):
+    """Raised when a ``hooks:`` entry fails structural validation.
+
+    The message is decision-enabling: it names the offending entry index,
+    the failing field, and a remediation hint so the operator can fix the
+    config without reading source.
+    """
+
+
+# ---------------------------------------------------------------------------
+# PushBlock — inbox-push sub-schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PushBlock:
+    """Inbox-push directive for a hook definition.
+
+    Stores Jinja2 templates as **raw strings** (rendering is slice B).
+
+    Fields
+    ------
+    message:
+        Jinja2 template string that renders to the message content to push
+        into the session inbox.  Required.
+    wake:
+        Controls whether the pushed message triggers a new turn (``True``)
+        or rides along with the next scheduled turn (``False``).  May be a
+        plain bool or a Jinja2 template string that renders to a bool.
+        Default: ``True`` (the push-and-wake / self-continuation path,
+        matching the dominant use-case E from the design).
+    push_when:
+        Optional Jinja2 template string that renders to a bool.  When
+        ``False`` the push is skipped entirely (conditional push). Default
+        ``"true"`` (always push).
+    session:
+        Optional Jinja2 template string or static session identifier.
+        When absent the runtime will default to the current session.
+    """
+
+    message: str
+    wake: Union[bool, str] = True
+    push_when: str = "true"
+    session: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# HookDef — the top-level hook entry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HookDef:
+    """A single lifecycle hook definition.
+
+    Exactly one of ``push`` or ``shell`` must be set (validated by the
+    loader, not by the dataclass itself — the dataclass is a plain data
+    container).
+
+    Fields
+    ------
+    on:
+        Hook-point name — one of ``ALLOWED_HOOK_POINTS``.
+    push:
+        Inbox-push hook block.  Mutually exclusive with ``shell``.
+    shell:
+        Shell command to run.  Stored raw; the runner is a later slice.
+        Mutually exclusive with ``push``.
+    matcher:
+        Reserved optional filter string.  Not interpreted in this slice.
+    """
+
+    on: str
+    push: PushBlock | None = field(default=None)
+    shell: str | None = field(default=None)
+    matcher: str | None = field(default=None)

--- a/tests/test_1800_hook_config_schema.py
+++ b/tests/test_1800_hook_config_schema.py
@@ -1,0 +1,372 @@
+"""Tests for #1800 slice A — hook config schema + loader + registry.
+
+Coverage plan
+-------------
+Tier 1 (contract): ``reyn.yaml hooks:`` schema acceptance/rejection
+  + ``HookDef`` / ``PushBlock`` shape
+  + ``HookRegistry.hooks_for`` registration-order preservation.
+Load-from-disk round-trip: a tmp ``reyn.yaml`` with a ``hooks:`` block →
+  ``HookRegistry`` with expected ``HookDef`` objects using non-default
+  values for every optional field so an unwired field would fail the test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.hooks import (
+    HookConfigError,
+    HookDef,
+    HookRegistry,
+    PushBlock,
+    load_hooks,
+)
+from reyn.hooks.schema import ALLOWED_HOOK_POINTS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw_push(
+    *,
+    on: str = "turn_end",
+    message: str = "test message",
+    wake: bool | str = True,
+    push_when: str = "true",
+    session: str | None = None,
+    matcher: str | None = None,
+) -> dict:
+    """Build a raw push-hook dict (valid by default)."""
+    push: dict = {"message": message, "wake": wake, "push_when": push_when}
+    if session is not None:
+        push["session"] = session
+    entry: dict = {"on": on, "push": push}
+    if matcher is not None:
+        entry["matcher"] = matcher
+    return entry
+
+
+def _raw_shell(*, on: str = "session_end", command: str = "echo done") -> dict:
+    """Build a raw shell-hook dict (valid by default)."""
+    return {"on": on, "shell": command}
+
+
+# ===========================================================================
+# Tier 1 — Contract: HookDef shape
+# ===========================================================================
+
+
+def test_hookdef_push_shape() -> None:
+    """Tier 1: ``HookDef`` with a ``PushBlock`` carries the expected fields."""
+    push = PushBlock(
+        message="{{ event.name }}",
+        wake="{{ ctx.needs_wake }}",
+        push_when="{{ ctx.condition }}",
+        session="session-abc",
+    )
+    hd = HookDef(on="turn_end", push=push, shell=None, matcher="my-matcher")
+
+    assert hd.on == "turn_end"
+    assert hd.push is push
+    assert hd.push.message == "{{ event.name }}"
+    assert hd.push.wake == "{{ ctx.needs_wake }}"
+    assert hd.push.push_when == "{{ ctx.condition }}"
+    assert hd.push.session == "session-abc"
+    assert hd.matcher == "my-matcher"
+    assert hd.shell is None
+
+
+def test_hookdef_shell_shape() -> None:
+    """Tier 1: ``HookDef`` with a shell command carries the expected fields."""
+    hd = HookDef(on="session_end", shell="scripts/cleanup.sh", push=None)
+
+    assert hd.on == "session_end"
+    assert hd.shell == "scripts/cleanup.sh"
+    assert hd.push is None
+
+
+def test_hookdef_is_frozen() -> None:
+    """Tier 1: ``HookDef`` and ``PushBlock`` are immutable (frozen dataclasses)."""
+    hd = HookDef(on="skill_start", shell="echo hi")
+    with pytest.raises(Exception):  # FrozenInstanceError
+        hd.on = "skill_end"  # type: ignore[misc]
+
+    pb = PushBlock(message="hi")
+    with pytest.raises(Exception):
+        pb.message = "changed"  # type: ignore[misc]
+
+
+# ===========================================================================
+# Tier 1 — Contract: valid hook definitions accepted
+# ===========================================================================
+
+
+def test_load_hooks_all_allowed_points_accepted() -> None:
+    """Tier 1: every point in ``ALLOWED_HOOK_POINTS`` is accepted by the loader."""
+    for point in ALLOWED_HOOK_POINTS:
+        raw = [_raw_push(on=point)]
+        registry = load_hooks(raw)
+        hooks = registry.hooks_for(point)
+        (hd,) = hooks  # exactly one hook returned — unpack fails on zero or many
+        assert hd.on == point
+
+
+def test_load_hooks_push_minimal_valid() -> None:
+    """Tier 1: a push hook with only required ``message`` is accepted."""
+    raw = [{"on": "turn_end", "push": {"message": "hello"}}]
+    registry = load_hooks(raw)
+    hooks = registry.hooks_for("turn_end")
+    (hd,) = hooks  # exactly one — unpack enforces count
+    assert hd.push is not None
+    assert hd.push.message == "hello"
+    # Defaults
+    assert hd.push.wake is True
+    assert hd.push.push_when == "true"
+    assert hd.push.session is None
+
+
+def test_load_hooks_push_all_fields_accepted() -> None:
+    """Tier 1: a push hook with all optional fields is accepted and parsed correctly."""
+    raw = [
+        {
+            "on": "skill_end",
+            "push": {
+                "message": "{{ skill.name }} finished",
+                "wake": "{{ ctx.wake_needed }}",
+                "push_when": "{{ ctx.should_push }}",
+                "session": "{{ ctx.target_session }}",
+            },
+            "matcher": "my-skill-filter",
+        }
+    ]
+    registry = load_hooks(raw)
+    hooks = registry.hooks_for("skill_end")
+    (hd,) = hooks  # exactly one — unpack enforces count
+    assert hd.push is not None
+    assert hd.push.message == "{{ skill.name }} finished"
+    assert hd.push.wake == "{{ ctx.wake_needed }}"
+    assert hd.push.push_when == "{{ ctx.should_push }}"
+    assert hd.push.session == "{{ ctx.target_session }}"
+    assert hd.matcher == "my-skill-filter"
+
+
+def test_load_hooks_shell_valid() -> None:
+    """Tier 1: a shell hook is accepted and stores the command raw."""
+    raw = [{"on": "session_end", "shell": "scripts/cleanup.sh --force"}]
+    registry = load_hooks(raw)
+    hooks = registry.hooks_for("session_end")
+    (hd,) = hooks  # exactly one — unpack enforces count
+    assert hd.shell == "scripts/cleanup.sh --force"
+    assert hd.push is None
+
+
+def test_load_hooks_push_wake_bool_false_accepted() -> None:
+    """Tier 1: push.wake=False (ride-along mode) is accepted."""
+    raw = [{"on": "turn_start", "push": {"message": "context note", "wake": False}}]
+    registry = load_hooks(raw)
+    hd = registry.hooks_for("turn_start")[0]
+    assert hd.push is not None
+    assert hd.push.wake is False
+
+
+def test_load_hooks_none_returns_empty_registry() -> None:
+    """Tier 1: ``load_hooks(None)`` (= absent ``hooks:`` key) returns an empty registry."""
+    registry = load_hooks(None)
+    assert registry.hooks_for("turn_end") == []  # behavioral: no hooks registered
+
+
+def test_load_hooks_empty_list_returns_empty_registry() -> None:
+    """Tier 1: ``load_hooks([])`` returns an empty registry."""
+    registry = load_hooks([])
+    assert registry.hooks_for("session_start") == []  # behavioral: no hooks registered
+
+
+# ===========================================================================
+# Tier 1 — Contract: invalid definitions rejected
+# ===========================================================================
+
+
+def test_load_hooks_bad_hook_point_rejected() -> None:
+    """Tier 1: an unrecognised ``on:`` value raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="not a recognised hook-point"):
+        load_hooks([{"on": "phase_start", "shell": "echo hi"}])
+
+
+def test_load_hooks_missing_on_field_rejected() -> None:
+    """Tier 1: a hook entry missing ``on`` raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="on is required"):
+        load_hooks([{"shell": "echo hi"}])
+
+
+def test_load_hooks_both_push_and_shell_rejected() -> None:
+    """Tier 1: specifying both ``push`` and ``shell`` raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="mutually exclusive"):
+        load_hooks(
+            [
+                {
+                    "on": "turn_end",
+                    "push": {"message": "hi"},
+                    "shell": "echo hi",
+                }
+            ]
+        )
+
+
+def test_load_hooks_neither_push_nor_shell_rejected() -> None:
+    """Tier 1: an entry with neither ``push`` nor ``shell`` raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="exactly one of"):
+        load_hooks([{"on": "turn_end"}])
+
+
+def test_load_hooks_push_missing_message_rejected() -> None:
+    """Tier 1: a push block without ``message`` raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="message is required"):
+        load_hooks([{"on": "turn_end", "push": {}}])
+
+
+def test_load_hooks_push_empty_message_rejected() -> None:
+    """Tier 1: a push block with empty ``message`` raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="must not be empty"):
+        load_hooks([{"on": "turn_end", "push": {"message": "   "}}])
+
+
+def test_load_hooks_shell_empty_command_rejected() -> None:
+    """Tier 1: a shell hook with empty command raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="must not be empty"):
+        load_hooks([{"on": "session_end", "shell": ""}])
+
+
+def test_load_hooks_push_wake_wrong_type_rejected() -> None:
+    """Tier 1: ``push.wake`` with an invalid type (int) raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="push.wake must be a bool or template string"):
+        load_hooks([{"on": "turn_end", "push": {"message": "hi", "wake": 42}}])
+
+
+def test_load_hooks_entry_not_a_mapping_rejected() -> None:
+    """Tier 1: a non-mapping entry in the hooks list raises ``HookConfigError``."""
+    with pytest.raises(HookConfigError, match="must be a mapping"):
+        load_hooks(["not-a-dict"])
+
+
+def test_load_hooks_non_list_hooks_value_silently_empty(caplog: pytest.LogCaptureFixture) -> None:
+    """Tier 1: a non-list ``hooks:`` value logs a warning and returns an empty registry."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        registry = load_hooks({"on": "turn_end", "push": {"message": "hi"}})
+    assert registry.hooks_for("turn_end") == []  # behavioral: no hooks despite non-empty input
+    assert "must be a list" in caplog.text
+
+
+def test_load_hooks_error_message_includes_entry_index() -> None:
+    """Tier 1: ``HookConfigError`` for the second entry names index [1]."""
+    try:
+        load_hooks(
+            [
+                {"on": "turn_end", "push": {"message": "ok"}},
+                {"on": "bad_point", "shell": "echo"},
+            ]
+        )
+        raise AssertionError("should have raised")
+    except HookConfigError as exc:
+        assert "[1]" in str(exc)
+
+
+# ===========================================================================
+# Tier 1 — Contract: HookRegistry registration-order preservation
+# ===========================================================================
+
+
+def test_registry_hooks_for_preserves_registration_order() -> None:
+    """Tier 1: ``hooks_for`` returns hooks in registration (list) order."""
+    raw = [
+        {"on": "turn_end", "push": {"message": "first"}},
+        {"on": "skill_start", "shell": "echo a"},
+        {"on": "turn_end", "push": {"message": "second"}},
+        {"on": "turn_end", "shell": "echo b"},
+    ]
+    registry = load_hooks(raw)
+    hooks = registry.hooks_for("turn_end")
+    # Exactly three hooks at turn_end — use unpack-enforcement so extra/missing fails
+    first, second, third = hooks
+    # Order: first push → second push → shell
+    assert first.push is not None and first.push.message == "first"
+    assert second.push is not None and second.push.message == "second"
+    assert third.shell == "echo b"
+
+
+def test_registry_hooks_for_unknown_point_returns_empty() -> None:
+    """Tier 1: ``hooks_for`` with an unknown point returns an empty list (no error)."""
+    raw = [{"on": "turn_end", "shell": "echo hi"}]
+    registry = load_hooks(raw)
+    assert registry.hooks_for("agent_start") == []
+
+
+def test_registry_hooks_for_no_match_returns_empty() -> None:
+    """Tier 1: ``hooks_for`` returns an empty list when no hooks match the point."""
+    raw = [{"on": "turn_end", "shell": "echo hi"}]
+    registry = load_hooks(raw)
+    assert registry.hooks_for("skill_start") == []
+
+
+# ===========================================================================
+# Load-from-disk round-trip
+# ===========================================================================
+
+
+def test_load_hooks_round_trip_from_yaml(tmp_path: Path) -> None:
+    """Tier 1: a ``hooks:`` block in reyn.yaml round-trips to the expected
+    ``HookDef`` registry.  Every optional field is set to a non-default value
+    so an unwired field would cause the assertion to fail.
+    """
+    import yaml
+
+    yaml_content = """
+hooks:
+  - on: skill_end
+    push:
+      message: "skill {{ skill.name }} done"
+      wake: false
+      push_when: "{{ ctx.should_notify }}"
+      session: "{{ ctx.target_session }}"
+    matcher: skill-done-filter
+
+  - on: session_start
+    shell: "scripts/on-session-start.sh"
+    matcher: session-filter
+""".lstrip()
+
+    reyn_yaml = tmp_path / "reyn.yaml"
+    reyn_yaml.write_text(yaml_content, encoding="utf-8")
+
+    raw_cfg = yaml.safe_load(reyn_yaml.read_text(encoding="utf-8"))
+    registry = load_hooks(raw_cfg.get("hooks"))
+
+    # ── Hook 1: push hook at skill_end ────────────────────────────────────
+    skill_end_hooks = registry.hooks_for("skill_end")
+    (h1,) = skill_end_hooks  # exactly one — unpack enforces count
+    assert h1.on == "skill_end"
+    assert h1.push is not None
+    assert h1.push.message == "skill {{ skill.name }} done"
+    # non-default wake=False (default is True)
+    assert h1.push.wake is False
+    # non-default push_when template (default is "true")
+    assert h1.push.push_when == "{{ ctx.should_notify }}"
+    # non-default session template (default is None)
+    assert h1.push.session == "{{ ctx.target_session }}"
+    # non-default matcher (default is None)
+    assert h1.matcher == "skill-done-filter"
+
+    # ── Hook 2: shell hook at session_start ───────────────────────────────
+    session_start_hooks = registry.hooks_for("session_start")
+    (h2,) = session_start_hooks  # exactly one — unpack enforces count
+    assert h2.on == "session_start"
+    assert h2.shell == "scripts/on-session-start.sh"
+    assert h2.push is None
+    assert h2.matcher == "session-filter"
+
+    # ── Hooks at other points are empty (no stray registrations) ─────────
+    assert registry.hooks_for("turn_end") == []
+    assert registry.hooks_for("task_start") == []
+    assert registry.hooks_for("turn_start") == []


### PR DESCRIPTION
**[per-PR-coder]** — dispatched #1800 slice A (hook config schema + loader + registry). Additive foundational slice; zero changes to existing OS code.

Closes (partial): #1800

## Summary

- New `src/reyn/hooks/` package implementing the data layer for #1800 agent lifecycle hooks.
- **`HookDef` + `PushBlock`** — frozen dataclasses for the two hook types (push/inbox and shell). Templates stored raw (rendering is slice B).
- **`load_hooks(raw)`** — validates the `hooks:` list from a reyn.yaml dict; raises `HookConfigError` with decision-enabling messages. Handles PyYAML's YAML 1.1 `on`→`True` boolean coercion transparently.
- **`HookRegistry`** — ordered store; `hooks_for(point)` returns hooks in registration order.
- **Starter hook-point set** (from #1800 CONVERGED DESIGN): `turn_start`, `turn_end`, `session_start`, `session_end`, `skill_start`, `skill_end`, `task_start`, `task_end`.
- **`wake` default = `True`** — push-and-wake (use-case E, self-continuation) is the dominant use; ride-along (`wake=False`) is an explicit opt-in.

## Design choices

- P7-aligned: zero skill-specific strings in the new package; no changes to any existing OS module.
- Templates stored raw (Jinja2 rendering is slice B); structural validation only.
- YAML 1.1 `on` key: PyYAML parses bare `on` as boolean `True`; loader checks `raw.get("on", raw.get(True))` so both quoted and unquoted YAML work.
- `wake` default `True` rationale: the inbox-push hook's dominant use case from the design (use-case E = self-continuation / `turn_end` wake) requires `wake=True`; ride-along (use-case C) requires `wake=False` as an explicit opt-in. Default follows the majority path.

## Test plan

- [x] (automated) `ruff check src tests` — 0 errors
- [x] (automated) `python scripts/test_tier_audit.py --strict tests/test_1800_hook_config_schema.py` — 25/25 OK, 0 Tier 4 violations
- [x] (automated) `pytest tests/test_1800_hook_config_schema.py` — 25/25 passed
- [x] (automated) `pytest tests/test_safety_config.py tests/test_config_cascade.py tests/test_config_loader_malformed.py` — all passed (no regressions in config module)
- [x] (skipped — no interactive UI changes) Visual/TUI verification: this slice is pure data/logic with no UI surface; visual verification N/A.
- [x] (skipped — no runtime dispatch) Live dogfood: hook dispatch is a later slice; this slice is parse-only with no runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>