### PR TITLE
feat(1800): shell-hook runner + $REYN_HOOK_OUTPUT contract (slice C)

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -1,7 +1,8 @@
-"""reyn.hooks — agent lifecycle hook config: schema, loader, registry, renderer.
+"""reyn.hooks — agent lifecycle hook config: schema, loader, registry, renderer, runner.
 
 Slice A (#1800): schema + loader + registry.
 Slice B (#1800): Jinja2 push-directive renderer.
+Slice C (#1800): shell-hook runner (side-effect only; output ignored).
 
 Exposes:
     HookDef        — typed model for a single hook definition.
@@ -12,11 +13,13 @@ Exposes:
     HookConfigError — raised for config validation failures.
     ResolvedPush   — fully-rendered push directive (slice B).
     render_push    — render a ``PushBlock`` against a context dict (slice B).
+    run_shell_hook — execute a shell HookDef command (slice C).
 """
 from reyn.hooks.loader import load_hooks
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.render import ResolvedPush, render_push
 from reyn.hooks.schema import HookConfigError, HookDef, PushBlock
+from reyn.hooks.shell_runner import run_shell_hook
 
 __all__ = [
     "HookDef",
@@ -26,4 +29,5 @@ __all__ = [
     "load_hooks",
     "ResolvedPush",
     "render_push",
+    "run_shell_hook",
 ]

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -1,0 +1,348 @@
+"""reyn.hooks.shell_runner — execute a shell HookDef command (#1800 slice C).
+
+Contract
+--------
+* **Input to the subprocess**: event + context serialised as JSON → subprocess stdin.
+* **Output from the subprocess**: IGNORED — stdout / stderr are treated as logs
+  only.  The runner returns ``None`` (pure side-effect); the OS does not consume
+  hook output.
+* **Timeout** (default 60 s, overridable per-hook via ``timeout_seconds``).
+  Timeout / non-zero exit → log only; the runner NEVER crashes the agent.
+
+Push from shell hooks is **deferred** — revisit when needed.  Shell hooks =
+external resource control only.
+
+Sandbox (CRITICAL)
+------------------
+The hook command runs through the **same** :mod:`reyn.security.sandbox`
+backend that the ``sandboxed_exec`` op uses::
+
+    backend = sandbox_backend or get_default_backend(sandbox_config)
+    result = await backend.run(argv, policy, stdin=..., cwd=...)
+
+No new subprocess machinery is introduced.  When the caller passes
+``sandbox_backend=None`` and ``sandbox_config=None``, the factory auto-selects
+``SeatbeltBackend`` (macOS), ``LandlockBackend`` (Linux), or ``NoopBackend``
+as a last-resort fallback with a loud warning — same as ``sandboxed_exec``.
+
+Consent + allowlist (Hermes-style)
+------------------------------------
+Allowlist lives at ``~/.reyn/shell-hooks-allowlist.json`` (env-var override:
+``REYN_SHELL_HOOKS_ALLOWLIST``).  Each entry records:
+
+    {
+        "command": "<raw command string>",
+        "approved_at": "<ISO-8601>",
+        "script_mtime": <float or null>
+    }
+
+Rules:
+
+* **TTY** (``sys.stdin.isatty()``): if the command is not in the allowlist (or
+  its script mtime has changed), prompt the operator; record approval.
+* **Non-TTY without REYN_ACCEPT_HOOKS=1**: refuse to run + log (fail-closed).
+* **REYN_ACCEPT_HOOKS=1**: bypass the TTY check (for CI); record approval.
+* Mtime drift: if the command's first token resolves to an existing file AND its
+  mtime differs from the stored ``script_mtime``, treat as un-approved.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.config import SandboxConfig
+    from reyn.security.sandbox import SandboxBackend
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants / env-var paths
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ALLOWLIST_PATH = Path.home() / ".reyn" / "shell-hooks-allowlist.json"
+
+
+def _allowlist_path() -> Path:
+    """Return the allowlist path, consulting REYN_SHELL_HOOKS_ALLOWLIST first."""
+    env = os.environ.get("REYN_SHELL_HOOKS_ALLOWLIST")
+    if env:
+        return Path(env)
+    return _DEFAULT_ALLOWLIST_PATH
+
+
+# ---------------------------------------------------------------------------
+# Allowlist helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_allowlist(path: Path) -> list[dict]:
+    """Load the allowlist JSON, returning an empty list on any error."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if isinstance(data, list):
+            return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    return []
+
+
+def _save_allowlist(path: Path, entries: list[dict]) -> None:
+    """Persist the allowlist, creating parent dirs as needed."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    except OSError as exc:
+        _log.warning("shell-hook allowlist: could not save %s: %s", path, exc)
+
+
+def _script_mtime(command: str) -> float | None:
+    """Return the mtime of the first token of *command* if it is an existing file."""
+    try:
+        first_token = shlex.split(command)[0]
+        p = Path(first_token).expanduser()
+        if p.exists() and p.is_file():
+            return p.stat().st_mtime
+    except (ValueError, OSError):
+        pass
+    return None
+
+
+def _is_approved(command: str, entries: list[dict]) -> bool:
+    """Return True iff *command* has a current (no mtime drift) allowlist entry."""
+    current_mtime = _script_mtime(command)
+    for entry in entries:
+        if entry.get("command") != command:
+            continue
+        stored_mtime = entry.get("script_mtime")
+        # Mtime drift: stored mtime differs from current file mtime → un-approved.
+        if current_mtime is not None and stored_mtime is not None:
+            if abs(float(stored_mtime) - current_mtime) > 0.01:
+                _log.warning(
+                    "shell-hook: script mtime changed for %r (was %.3f, now %.3f) — "
+                    "re-approval required.",
+                    command,
+                    stored_mtime,
+                    current_mtime,
+                )
+                return False
+        return True
+    return False
+
+
+def _record_approval(command: str, path: Path) -> None:
+    """Add / update an allowlist entry for *command*."""
+    entries = _load_allowlist(path)
+    current_mtime = _script_mtime(command)
+    # Remove any existing entry for the same command.
+    entries = [e for e in entries if e.get("command") != command]
+    entries.append({
+        "command": command,
+        "approved_at": datetime.now(tz=timezone.utc).isoformat(),
+        "script_mtime": current_mtime,
+    })
+    _save_allowlist(path, entries)
+
+
+# ---------------------------------------------------------------------------
+# Consent gate
+# ---------------------------------------------------------------------------
+
+
+def _check_consent(command: str, allowlist_path: Path) -> bool:
+    """Return True if *command* is approved to run.
+
+    TTY (interactive): prompt on first use or mtime drift; record approval.
+    Non-TTY: requires REYN_ACCEPT_HOOKS=1 or a current allowlist entry.
+    """
+    entries = _load_allowlist(allowlist_path)
+
+    if _is_approved(command, entries):
+        return True
+
+    # Not approved — decide based on environment.
+    accept_env = os.environ.get("REYN_ACCEPT_HOOKS", "").strip() == "1"
+    is_tty = sys.stdin.isatty()
+
+    if accept_env:
+        # CI / non-TTY accept path: record and proceed.
+        _log.info("shell-hook: REYN_ACCEPT_HOOKS=1 — auto-approving %r", command)
+        _record_approval(command, allowlist_path)
+        return True
+
+    if is_tty:
+        # Interactive prompt.
+        print(
+            f"\nReyn shell hook: the following command has not been approved:\n\n"
+            f"  {command}\n\n"
+            "Allow this command to run under the Reyn sandbox? [y/N] ",
+            end="",
+            flush=True,
+        )
+        try:
+            answer = input().strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+        if answer in ("y", "yes"):
+            _record_approval(command, allowlist_path)
+            _log.info("shell-hook: operator approved %r", command)
+            return True
+        _log.warning("shell-hook: operator declined %r — skipping.", command)
+        return False
+
+    # Non-TTY, no accept flag, not pre-approved → fail-closed.
+    _log.warning(
+        "shell-hook REFUSED (fail-closed): %r is not in the allowlist and "
+        "REYN_ACCEPT_HOOKS=1 is not set. To allow in non-interactive / CI "
+        "environments, set REYN_ACCEPT_HOOKS=1 or pre-approve the command "
+        "interactively first.",
+        command,
+    )
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def run_shell_hook(
+    command: str,
+    event_context: dict,
+    *,
+    timeout_seconds: int = 60,
+    cwd: str | None = None,
+    sandbox_backend: "SandboxBackend | None" = None,
+    sandbox_config: "SandboxConfig | None" = None,
+    sandbox_policy: "SandboxPolicy | None" = None,
+    allowlist_path: Path | None = None,
+) -> None:
+    """Run a shell hook command as a pure side-effect.
+
+    The hook receives event + context as JSON on stdin.  Its output (stdout /
+    stderr) is treated as logs only and **never parsed**.  The OS does not
+    consume hook output.  Push from shell hooks is deferred.
+
+    Parameters
+    ----------
+    command:
+        The raw shell command string from ``HookDef.shell``.  Split via
+        ``shlex.split``; executed with ``shell=False`` (no shell injection).
+    event_context:
+        Dict serialised as JSON and passed to the subprocess on stdin.
+    timeout_seconds:
+        Wall-clock cap; default 60 s.
+    cwd:
+        Working directory for the subprocess.  Defaults to None (inherit).
+    sandbox_backend:
+        A pre-constructed :class:`~reyn.security.sandbox.SandboxBackend`
+        instance.  When ``None``, ``get_default_backend(sandbox_config)`` is
+        called to select the platform backend.
+    sandbox_config:
+        :class:`~reyn.config.SandboxConfig` forwarded to
+        ``get_default_backend``.  Used only when *sandbox_backend* is None.
+    sandbox_policy:
+        The :class:`~reyn.security.sandbox.policy.SandboxPolicy` to enforce.
+        When ``None``, a default policy (no network + no subprocess) is built.
+    allowlist_path:
+        Override the allowlist file path (used by tests to point at a tmp
+        file).  Defaults to ``~/.reyn/shell-hooks-allowlist.json`` (or the
+        ``REYN_SHELL_HOOKS_ALLOWLIST`` env var).
+
+    Returns
+    -------
+    None
+        Always.  Output is ignored; the runner is a pure side-effect call.
+
+    Notes
+    -----
+    **Never raises** — all errors (timeout, non-zero exit, consent refusal)
+    are logged and the function returns so the agent is never blocked by a
+    hook failure.
+    """
+    resolved_allowlist = allowlist_path if allowlist_path is not None else _allowlist_path()
+
+    # --- Consent gate (fail-closed in non-TTY without accept flag) --------
+    try:
+        approved = _check_consent(command, resolved_allowlist)
+    except Exception as exc:
+        _log.error("shell-hook: consent check error for %r: %s", command, exc)
+        return
+
+    if not approved:
+        return
+
+    # --- Split command (shlex; shell=False enforced by the backend) -------
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        _log.error("shell-hook: invalid command %r: %s", command, exc)
+        return
+
+    if not argv:
+        _log.error("shell-hook: empty argv after shlex.split(%r)", command)
+        return
+
+    # --- Resolve sandbox backend ------------------------------------------
+    # Import here so the module is importable without the sandbox package in
+    # contexts where only the schema / allowlist code is needed.
+    from reyn.security.sandbox import SandboxPolicy as _SandboxPolicy
+    from reyn.security.sandbox import get_default_backend
+
+    backend = sandbox_backend if sandbox_backend is not None else get_default_backend(sandbox_config)
+
+    # Build a safe default policy when none is supplied.
+    policy: SandboxPolicy = (
+        sandbox_policy
+        if sandbox_policy is not None
+        else _SandboxPolicy(
+            network=False,
+            allow_subprocess=False,
+            timeout_seconds=timeout_seconds,
+        )
+    )
+
+    # --- Run via backend (same abstraction as sandboxed_exec.py) ----------
+    try:
+        stdin_bytes = json.dumps(event_context, default=str).encode("utf-8")
+
+        result = await backend.run(
+            argv,
+            policy,
+            stdin=stdin_bytes,
+            cwd=cwd,
+        )
+
+        # stdout / stderr are LOGS — never parsed.
+        if result.stdout.strip():
+            _log.debug(
+                "shell-hook %r stdout (logged, not parsed): %s",
+                command,
+                result.stdout[:200].decode("utf-8", errors="replace"),
+            )
+        if result.stderr.strip():
+            _log.debug(
+                "shell-hook %r stderr (logged, not parsed): %s",
+                command,
+                result.stderr[:200].decode("utf-8", errors="replace"),
+            )
+
+        if result.returncode not in (0,):
+            stderr_snippet = result.stderr[:200].decode("utf-8", errors="replace").strip()
+            _log.warning(
+                "shell-hook %r exited %d (stderr: %s).",
+                command,
+                result.returncode,
+                stderr_snippet or "<empty>",
+            )
+
+    except Exception as exc:
+        _log.error("shell-hook %r: unexpected error: %s", command, exc)

--- a/tests/test_1800_hook_shell_runner.py
+++ b/tests/test_1800_hook_shell_runner.py
@@ -1,0 +1,236 @@
+"""Tests for #1800 slice C — shell-hook runner (side-effect only; output ignored).
+
+Coverage
+--------
+All tests use REAL subprocesses (``python -c`` one-liners) — no mocks of
+collaborators.  The sandbox backend is NoopBackend (always available on every
+platform), which exercises the real backend.run() path without requiring
+platform-specific setup.
+
+Tier 1 — Contract:
+  - ``run_shell_hook`` is exported from ``reyn.hooks`` (public API surface).
+  - A command that writes JSON to stdout is NOT parsed — output is ignored;
+    run_shell_hook returns None (pure side-effect).
+  - A command that reads stdin receives valid JSON context.
+  - A command whose sleep exceeds the timeout → returns None, no crash.
+  - Non-allowlisted command in non-TTY without REYN_ACCEPT_HOOKS → refuses
+    (fail-closed) and returns None.
+
+Filesystem isolation: allowlist tests point at a tmp_path file so
+``~/.reyn/shell-hooks-allowlist.json`` is never touched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.security.sandbox import NoopBackend, SandboxPolicy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Python interpreter (same executable running pytest) — keeps tests hermetic
+# across venvs.
+_PY = sys.executable
+
+
+def _run(coro):
+    """Run a coroutine synchronously (avoids asyncio.run() in test bodies)."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _noop_backend() -> NoopBackend:
+    return NoopBackend()
+
+
+def _policy(timeout: int = 10) -> SandboxPolicy:
+    return SandboxPolicy(network=False, allow_subprocess=False, timeout_seconds=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Contract: run_shell_hook is part of the public reyn.hooks API
+# ---------------------------------------------------------------------------
+
+
+def test_run_shell_hook_exported_from_reyn_hooks() -> None:
+    """Tier 1: run_shell_hook is re-exported from reyn.hooks (public API surface)."""
+    import reyn.hooks as hooks
+
+    assert hasattr(hooks, "run_shell_hook")
+    assert callable(hooks.run_shell_hook)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Contract: output is ignored — run_shell_hook always returns None
+# ---------------------------------------------------------------------------
+
+
+def test_output_ignored_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a command that writes JSON to stdout is NOT parsed as a push
+    directive — run_shell_hook returns None regardless of output content.
+    REYN_ACCEPT_HOOKS=1 simulates CI mode.
+    """
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    allowlist = tmp_path / "allowlist.json"
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+
+    # Write a valid-looking push directive JSON to stdout — must be ignored.
+    script = (
+        "import json, sys; "
+        "sys.stdout.write(json.dumps({'message': 'should be ignored', 'wake': True}))"
+    )
+    command = f"{_PY} -c \"{script}\""
+
+    result = _run(
+        run_shell_hook(
+            command,
+            event_context={"event": "turn_end"},
+            timeout_seconds=10,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(),
+            allowlist_path=allowlist,
+        )
+    )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Contract: JSON context is delivered on stdin
+# ---------------------------------------------------------------------------
+
+
+def test_json_context_delivered_on_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: the hook subprocess receives event_context serialised as JSON on
+    stdin.  A command that reads stdin + exits with code 0 iff the JSON is
+    valid confirms delivery.  Exit code 0 = context arrived; non-zero = did not.
+    """
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    # Write a marker file if stdin contains valid JSON with the expected key.
+    marker = tmp_path / "context_received.txt"
+    allowlist = tmp_path / "allowlist.json"
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+
+    script = (
+        "import json, sys; "
+        f"data = json.loads(sys.stdin.read()); "
+        f"open({str(marker)!r}, 'w').write(data.get('event', '')) "
+        "if 'event' in data else None"
+    )
+    command = f"{_PY} -c \"{script}\""
+
+    _run(
+        run_shell_hook(
+            command,
+            event_context={"event": "skill_end", "skill": "my-skill"},
+            timeout_seconds=10,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(),
+            allowlist_path=allowlist,
+        )
+    )
+
+    # The hook wrote the event name to the marker file — context was delivered.
+    assert marker.exists(), "hook did not receive event_context on stdin"
+    assert marker.read_text() == "skill_end"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Contract: timeout returns None, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_returns_none_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a command that sleeps past the timeout returns None and does not
+    crash or raise — the runner absorbs the timeout gracefully.
+    """
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    allowlist = tmp_path / "allowlist.json"
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+
+    # sleep for 60 s but timeout is 1 s → times out.
+    command = f"{_PY} -c \"import time; time.sleep(60)\""
+
+    result = _run(
+        run_shell_hook(
+            command,
+            event_context={"event": "session_end"},
+            timeout_seconds=1,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(timeout=1),
+            allowlist_path=allowlist,
+        )
+    )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Contract: consent fail-closed (non-allowlisted, non-TTY, no flag)
+# ---------------------------------------------------------------------------
+
+
+def test_nonapproved_command_nontty_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a non-allowlisted command in a non-TTY environment without
+    REYN_ACCEPT_HOOKS=1 is refused (fail-closed) and returns None.
+    """
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    allowlist = tmp_path / "allowlist.json"
+    # Ensure allowlist is empty (no pre-existing approval).
+    allowlist.write_text("[]", encoding="utf-8")
+
+    # Simulate non-TTY: monkeypatch sys.stdin.isatty to return False.
+    monkeypatch.setattr("sys.stdin", _FakeTTY(is_tty=False))
+    # Ensure accept flag is NOT set.
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+
+    command = f"{_PY} -c \"pass\""
+
+    result = _run(
+        run_shell_hook(
+            command,
+            event_context={"event": "session_start"},
+            timeout_seconds=10,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(),
+            allowlist_path=allowlist,
+        )
+    )
+
+    # Refused — fail-closed.
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Helper: fake stdin object with configurable isatty()
+# ---------------------------------------------------------------------------
+
+
+class _FakeTTY:
+    """Minimal sys.stdin replacement for TTY-check tests."""
+
+    def __init__(self, *, is_tty: bool) -> None:
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+    def read(self, *_):
+        return ""


### PR DESCRIPTION
**[per-PR-coder]** — #1800 slice C simplified: shell hooks = side-effect only, output ignored.

## Summary

- **Owner scope simplification applied** (issuecomment-4773744053): shell hooks = external resource control only; push from shell hooks deferred.
- **Removed**: `PushDirective`, `$REYN_HOOK_OUTPUT` temp-file contract, push-directive parsing, `os.environ` mutation (the racy global-env threading that hold reason #2 flagged).
- **`run_shell_hook` now returns `None` always** — pure side-effect. The OS does not consume hook output.
- **Sandbox approach unchanged**: `backend = sandbox_backend or get_default_backend(sandbox_config)` → `backend.run(argv, policy, stdin=..., cwd=...)` — exact same abstraction as `sandboxed_exec.py`; no new subprocess machinery, no bypass.
- **Kept**: consent + allowlist (Hermes-style; `~/.reyn/shell-hooks-allowlist.json`; `REYN_ACCEPT_HOOKS=1`; fail-closed non-TTY); per-hook timeout; robustness (never raises).

## Changed files

| File | Change |
|---|---|
| `src/reyn/hooks/shell_runner.py` | Rewritten — remove `PushDirective`, temp-file, os.environ mutation; return `None` always |
| `src/reyn/hooks/__init__.py` | Export `run_shell_hook` (no `PushDirective`) |
| `tests/test_1800_hook_shell_runner.py` | Rewritten — 4 Tier 1 tests; drop push-directive tests |

## Sandbox approach (for lead-coder security review)

```python
backend = sandbox_backend if sandbox_backend is not None else get_default_backend(sandbox_config)
result = await backend.run(argv, policy, stdin=stdin_bytes, cwd=cwd)
# stdout / stderr are LOGS — never parsed
```

- No `os.environ` mutation (the racy global-env threading from the previous version is gone — now irrelevant since there is no `$REYN_HOOK_OUTPUT`).
- No new subprocess machinery. Backend selection: `SeatbeltBackend` (macOS) / `LandlockBackend` (Linux) / `NoopBackend` fallback with warning — same as `sandboxed_exec`.
- `shlex.split` + `shell=False` enforced by the backend.

## Tests (4 Tier 1 — real subprocesses, NoopBackend)

1. `test_run_shell_hook_exported_from_reyn_hooks` — public API surface check.
2. `test_output_ignored_returns_none` — command writes JSON to stdout; result is `None` (output ignored, not parsed as push directive).
3. `test_json_context_delivered_on_stdin` — command reads stdin; marker file written iff valid JSON context arrived.
4. `test_timeout_returns_none_no_crash` — command sleeps past timeout; returns `None`, no crash.
5. `test_nonapproved_command_nontty_refused` — non-allowlisted, non-TTY, no `REYN_ACCEPT_HOOKS` → fail-closed, returns `None`.

## Test plan

- [x] `ruff check src tests` — passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_1800_hook_shell_runner.py` — 5/5 OK, 0 Tier-4 errors
- [x] `pytest tests/test_1800_hook_shell_runner.py -v` — 5 passed in 1.19s

Ref: #1800 (scope simplification at issuecomment-4773744053; lead-coder hold at issuecomment-4769388017).