### PR TITLE
feat(1800): hook push renderer — sandboxed Jinja2 + ResolvedPush (slice B)

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -1,4 +1,7 @@
-"""reyn.hooks — agent lifecycle hook config: schema, loader, registry (#1800 slice A).
+"""reyn.hooks — agent lifecycle hook config: schema, loader, registry, renderer.
+
+Slice A (#1800): schema + loader + registry.
+Slice B (#1800): Jinja2 push-directive renderer.
 
 Exposes:
     HookDef        — typed model for a single hook definition.
@@ -7,9 +10,12 @@ Exposes:
     load_hooks     — parse the ``hooks:`` list from a raw config dict
                      and return a ready ``HookRegistry``.
     HookConfigError — raised for config validation failures.
+    ResolvedPush   — fully-rendered push directive (slice B).
+    render_push    — render a ``PushBlock`` against a context dict (slice B).
 """
 from reyn.hooks.loader import load_hooks
 from reyn.hooks.registry import HookRegistry
+from reyn.hooks.render import ResolvedPush, render_push
 from reyn.hooks.schema import HookConfigError, HookDef, PushBlock
 
 __all__ = [
@@ -18,4 +24,6 @@ __all__ = [
     "HookRegistry",
     "HookConfigError",
     "load_hooks",
+    "ResolvedPush",
+    "render_push",
 ]

--- a/src/reyn/hooks/render.py
+++ b/src/reyn/hooks/render.py
@@ -1,0 +1,207 @@
+"""reyn.hooks.render — Jinja2 template rendering for hook push directives (#1800 slice B).
+
+Entry point: ``render_push(push, context)`` — renders a ``PushBlock``'s
+template fields against a runtime context dict and returns a ``ResolvedPush``
+frozen dataclass that the runtime consumes directly.
+
+Jinja2 environment
+------------------
+All rendering uses ``jinja2.sandbox.SandboxedEnvironment`` (never a plain
+``Environment``).  The sandbox blocks attribute-traversal escapes (e.g.
+``{{ ().__class__.__bases__ }}`` or ``{{ cycler.__init__.__globals__ }}``)
+that a plain environment would allow.  Templates render against untrusted
+operator-supplied config, so the sandbox is **non-negotiable**.
+
+Truthiness policy (``wake`` / ``push_when``)
+--------------------------------------------
+When a template renders to a string, it is converted to bool by explicit
+case-insensitive look-up:
+
+    True  ← "true", "1", "yes", "on"
+    False ← "false", "0", "no", "off", "" (empty string)
+
+Any other rendered string is a **render error** (see below).  A plain
+Python bool in the source config bypasses rendering and is used as-is.
+
+Fail-safe undefined-variable policy
+------------------------------------
+``jinja2.StrictUndefined`` would raise on any undefined variable, but for
+bool fields (``wake``, ``push_when``) this would crash the agent — the
+wrong failure mode.  The chosen policy:
+
+- ``message``: **``StrictUndefined``** — a blank message due to a typo'd
+  variable name is misleading; raise loudly and let the error safety-net
+  skip the push entirely (``push_when=False``).
+- ``wake`` / ``push_when`` / ``session``: **``Undefined``** (silent, renders
+  as empty string) — an empty string maps to ``False`` via the truthiness
+  table (fail-safe: don't wake / don't push on an undefined condition).
+  For ``session``, empty → ``None`` (fall back to the current session).
+
+Render-error safety net
+-----------------------
+A render error (Jinja2 ``TemplateError`` or an unrecognised boolean string)
+must **not** crash the agent.  On any exception in ``render_push``:
+
+- ``push_when`` is set to ``False`` (skip the push entirely — the safest
+  default; a broken condition should not trigger an unintended turn).
+- The error is logged at WARNING level with the push block repr so the
+  operator can diagnose it.
+- A ``ResolvedPush`` with ``push_when=False`` (and the other fields at
+  their safest defaults) is returned.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from jinja2 import StrictUndefined, TemplateError, Undefined
+from jinja2.sandbox import SandboxedEnvironment
+
+from reyn.hooks.schema import PushBlock
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Truthiness map
+# ---------------------------------------------------------------------------
+
+_TRUTHY: frozenset[str] = frozenset({"true", "1", "yes", "on"})
+_FALSY: frozenset[str] = frozenset({"false", "0", "no", "off", ""})
+
+
+def _str_to_bool(value: str, field: str) -> bool:
+    """Convert a rendered string to a Python bool via the truthiness table.
+
+    Raises ``ValueError`` for unrecognised values so the caller can wrap
+    them in the render-error safety net.
+    """
+    lowered = value.strip().lower()
+    if lowered in _TRUTHY:
+        return True
+    if lowered in _FALSY:
+        return False
+    raise ValueError(
+        f"Hook push field {field!r} rendered to an unrecognised boolean "
+        f"string {value!r}. Accepted (case-insensitive): "
+        f"true/1/yes/on → True; false/0/no/off/'' → False."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResolvedPush — the rendered push directive
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedPush:
+    """A fully-rendered hook push directive, ready for the runtime to act on.
+
+    Fields
+    ------
+    message:
+        The rendered message string to inject into the session inbox.
+    wake:
+        ``True`` if the pushed message should trigger a new agent turn
+        (use-case E — self-continuation); ``False`` if it should ride along
+        with the next scheduled turn (use-case C — additive context).
+    push_when:
+        ``False`` → skip this push entirely (conditional guard).
+        ``True``  → proceed with the push.
+    session:
+        Target session identifier, or ``None`` to use the current session.
+    """
+
+    message: str
+    wake: bool
+    push_when: bool
+    session: str | None
+
+
+# ---------------------------------------------------------------------------
+# Jinja2 environment factories
+# ---------------------------------------------------------------------------
+
+
+def _make_env_strict() -> SandboxedEnvironment:
+    """SandboxedEnvironment with StrictUndefined — for ``message``."""
+    return SandboxedEnvironment(undefined=StrictUndefined)
+
+
+def _make_env_silent() -> SandboxedEnvironment:
+    """SandboxedEnvironment with silent Undefined — for bool / session fields."""
+    return SandboxedEnvironment(undefined=Undefined)
+
+
+# ---------------------------------------------------------------------------
+# Core renderer
+# ---------------------------------------------------------------------------
+
+
+def render_push(push: PushBlock, context: dict) -> ResolvedPush:
+    """Render a ``PushBlock`` against ``context`` and return a ``ResolvedPush``.
+
+    Parameters
+    ----------
+    push:
+        The raw ``PushBlock`` from the hook config (templates stored as
+        strings).
+    context:
+        Runtime context dict — typically event + session metadata supplied
+        by the hook dispatcher.
+
+    Returns
+    -------
+    ResolvedPush
+        The fully-resolved push directive.  On any render failure the
+        returned object has ``push_when=False`` so the runtime skips the
+        push rather than crashing.
+    """
+    try:
+        return _render_push_inner(push, context)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "Hook push render failed — push will be skipped. "
+            "push=%r error=%s: %s",
+            push,
+            type(exc).__name__,
+            exc,
+        )
+        # Fail-safe: return a ResolvedPush that causes the push to be skipped.
+        return ResolvedPush(message="", wake=False, push_when=False, session=None)
+
+
+def _render_push_inner(push: PushBlock, context: dict) -> ResolvedPush:
+    """Inner renderer — may raise; callers should use ``render_push`` instead."""
+    env_strict = _make_env_strict()
+    env_silent = _make_env_silent()
+
+    # ── message (StrictUndefined — a blank message due to a typo is misleading) ──
+    message = env_strict.from_string(push.message).render(context)
+
+    # ── wake ──────────────────────────────────────────────────────────────────
+    if isinstance(push.wake, bool):
+        wake = push.wake
+    else:
+        rendered_wake = env_silent.from_string(push.wake).render(context)
+        wake = _str_to_bool(rendered_wake, "wake")
+
+    # ── push_when ─────────────────────────────────────────────────────────────
+    rendered_pw = env_silent.from_string(push.push_when).render(context)
+    push_when = _str_to_bool(rendered_pw, "push_when")
+
+    # ── session (render only if the template contains '{{', else static) ──────
+    session: str | None
+    if push.session is None:
+        session = None
+    elif "{{" in push.session:
+        rendered_session = env_silent.from_string(push.session).render(context)
+        session = rendered_session if rendered_session.strip() else None
+    else:
+        session = push.session if push.session.strip() else None
+
+    return ResolvedPush(
+        message=message,
+        wake=wake,
+        push_when=push_when,
+        session=session,
+    )

--- a/tests/test_1800_hook_render.py
+++ b/tests/test_1800_hook_render.py
@@ -1,0 +1,309 @@
+"""Tests for #1800 slice B — Jinja2 template rendering for hook push directives.
+
+Coverage plan
+-------------
+Tier 1 (contract): ``render_push`` public API shape + ``ResolvedPush`` fields.
+  - Happy path: render with real context → expected ``ResolvedPush`` using
+    NON-default values for every field (non-default bool passthrough, str
+    template for wake, session with template, push_when evaluated).
+  - Bool truthiness: all eight string tokens (true/1/yes/on, false/0/no/off)
+    + bool passthrough for ``wake`` (True / False directly).
+  - push_when=false template ⇒ resolved push_when is False.
+  - Sandbox proof: a malicious template that attempts to escape the sandbox
+    is blocked / rendered safe — proves ``SandboxedEnvironment`` is in effect.
+  - Undefined-variable behaviour per the declared policy:
+      * ``message`` with StrictUndefined → error caught, push_when=False fallback.
+      * ``wake`` / ``push_when`` with silent Undefined → empty string → False.
+  - session rendering: static passthrough, template rendering, empty → None.
+  - Render-error safety net: ``render_push`` returns ``push_when=False`` and
+    does not raise.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.render import ResolvedPush, render_push
+from reyn.hooks.schema import PushBlock
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _push(
+    *,
+    message: str = "hello {{ name }}",
+    wake: bool | str = False,
+    push_when: str = "true",
+    session: str | None = None,
+) -> PushBlock:
+    """Build a PushBlock with non-default wake (False) for isolation."""
+    return PushBlock(message=message, wake=wake, push_when=push_when, session=session)
+
+
+# ===========================================================================
+# Tier 1 — Contract: render_push public API + ResolvedPush shape
+# ===========================================================================
+
+
+def test_render_push_full_non_default_context() -> None:
+    """Tier 1: render_push with real context → ResolvedPush with all NON-default values.
+
+    All four fields use non-default values to catch any unwired field:
+    - message: rendered from template (non-empty, non-trivial)
+    - wake: False (non-default bool passthrough, not the default True)
+    - push_when: True (rendered from a conditional template evaluating to true)
+    - session: a static non-None session id
+    """
+    push = _push(
+        message="event={{ event.name }} skill={{ skill }}",
+        wake=False,
+        push_when="{{ ctx.should_push }}",
+        session="ses-abc-123",
+    )
+    ctx = {"event": {"name": "skill_end"}, "skill": "my_skill", "ctx": {"should_push": "yes"}}
+    result = render_push(push, ctx)
+
+    assert isinstance(result, ResolvedPush)
+    assert result.message == "event=skill_end skill=my_skill"
+    assert result.wake is False
+    assert result.push_when is True
+    assert result.session == "ses-abc-123"
+
+
+def test_render_push_wake_true_non_default() -> None:
+    """Tier 1: wake=True (non-default) passes through as bool without rendering."""
+    push = _push(message="msg", wake=True, push_when="true")
+    result = render_push(push, {})
+
+    assert result.wake is True
+    assert result.push_when is True
+
+
+# ===========================================================================
+# Tier 1 — Truthiness: string tokens + bool passthrough
+# ===========================================================================
+
+
+@pytest.mark.parametrize("token", ["true", "True", "TRUE", "1", "yes", "YES", "on", "ON"])
+def test_truthy_strings_resolve_to_true(token: str) -> None:
+    """Tier 1: all documented truthy string tokens render wake to True."""
+    push = _push(message="m", wake=token, push_when="true")
+    result = render_push(push, {})
+    assert result.wake is True
+
+
+@pytest.mark.parametrize("token", ["false", "False", "FALSE", "0", "no", "NO", "off", "OFF", ""])
+def test_falsy_strings_resolve_to_false(token: str) -> None:
+    """Tier 1: all documented falsy string tokens render wake to False."""
+    push = _push(message="m", wake=token, push_when="true")
+    result = render_push(push, {})
+    assert result.wake is False
+
+
+def test_bool_true_passthrough() -> None:
+    """Tier 1: wake=True (Python bool) bypasses string rendering."""
+    push = _push(message="m", wake=True, push_when="true")
+    result = render_push(push, {})
+    assert result.wake is True
+
+
+def test_bool_false_passthrough() -> None:
+    """Tier 1: wake=False (Python bool) bypasses string rendering."""
+    push = _push(message="m", wake=False, push_when="true")
+    result = render_push(push, {})
+    assert result.wake is False
+
+
+# ===========================================================================
+# Tier 1 — push_when=false stops the push
+# ===========================================================================
+
+
+def test_push_when_false_template() -> None:
+    """Tier 1: push_when template rendering to 'false' ⇒ push_when=False."""
+    push = _push(message="m", wake=False, push_when="{{ skip }}")
+    result = render_push(push, {"skip": "false"})
+    assert result.push_when is False
+
+
+def test_push_when_static_false() -> None:
+    """Tier 1: push_when='false' (static string) ⇒ push_when=False."""
+    push = _push(message="m", wake=False, push_when="false")
+    result = render_push(push, {})
+    assert result.push_when is False
+
+
+def test_push_when_conditional_evaluates_to_true() -> None:
+    """Tier 1: push_when Jinja2 conditional ⇒ True when condition holds."""
+    push = _push(
+        message="m",
+        wake=False,
+        push_when="{% if count > 0 %}true{% else %}false{% endif %}",
+    )
+    result = render_push(push, {"count": 3})
+    assert result.push_when is True
+
+
+def test_push_when_conditional_evaluates_to_false() -> None:
+    """Tier 1: push_when Jinja2 conditional ⇒ False when condition fails."""
+    push = _push(
+        message="m",
+        wake=False,
+        push_when="{% if count > 0 %}true{% else %}false{% endif %}",
+    )
+    result = render_push(push, {"count": 0})
+    assert result.push_when is False
+
+
+# ===========================================================================
+# Tier 1 — Sandbox proof: SandboxedEnvironment is in effect
+# ===========================================================================
+
+
+def test_sandbox_blocks_class_escape() -> None:
+    """Tier 1: sandbox proof — {{ ().__class__.__bases__ }} is blocked/safe.
+
+    SandboxedEnvironment raises SecurityError (or renders safely without
+    leaking real Python internals).  The critical property: ``render_push``
+    must not raise — it must activate the safety net and return
+    push_when=False.  The malicious template must NOT produce the literal
+    string representation of Python's type hierarchy.
+    """
+    push = _push(
+        message="{{ ().__class__.__bases__ }}",
+        wake=False,
+        push_when="true",
+    )
+    # render_push must not raise regardless of sandbox outcome
+    result = render_push(push, {})
+    # Safety net fires: the push is skipped
+    assert result.push_when is False
+    assert result.message == ""
+
+
+def test_sandbox_blocks_globals_escape() -> None:
+    """Tier 1: sandbox proof — {{ cycler.__init__.__globals__ }} is blocked/safe.
+
+    cycler is a Jinja2 built-in; __globals__ traversal is the classic
+    sandbox-escape vector.  SandboxedEnvironment blocks attribute access to
+    dunder names.  render_push must not raise and must return push_when=False.
+    """
+    push = _push(
+        message="{{ cycler.__init__.__globals__ }}",
+        wake=False,
+        push_when="true",
+    )
+    result = render_push(push, {})
+    assert result.push_when is False
+    assert result.message == ""
+
+
+def test_sandbox_allows_normal_attribute_access() -> None:
+    """Tier 1: sandbox allows safe attribute access on context objects."""
+
+    class _Evt:
+        name = "turn_end"
+
+    push = _push(message="{{ event.name }}", wake=False, push_when="true")
+    result = render_push(push, {"event": _Evt()})
+    assert result.message == "turn_end"
+    assert result.push_when is True
+
+
+# ===========================================================================
+# Tier 1 — Undefined-variable policy
+# ===========================================================================
+
+
+def test_message_undefined_var_triggers_safety_net() -> None:
+    """Tier 1: message with StrictUndefined — undefined var triggers error safety net.
+
+    Policy: message uses StrictUndefined; a typo'd variable should not silently
+    produce a blank message.  The render error is caught; push_when=False is
+    returned so the push is skipped.
+    """
+    push = _push(message="{{ no_such_var }}", wake=False, push_when="true")
+    result = render_push(push, {})
+    # Safety net: push is skipped, not raised
+    assert result.push_when is False
+    assert result.message == ""
+
+
+def test_wake_undefined_var_resolves_to_false() -> None:
+    """Tier 1: wake with undefined var → silent empty string → False (fail-safe).
+
+    Policy: wake uses silent Undefined; undefined → empty string → False (don't
+    wake on an undefined condition — the safer direction).
+    """
+    push = _push(message="m", wake="{{ no_such_wake }}", push_when="true")
+    result = render_push(push, {})
+    assert result.wake is False
+
+
+def test_push_when_undefined_var_resolves_to_false() -> None:
+    """Tier 1: push_when with undefined var → silent empty string → False (fail-safe).
+
+    Policy: push_when uses silent Undefined; undefined → empty string → False
+    (don't push on an undefined condition — the safer direction).
+    """
+    push = _push(message="m", wake=False, push_when="{{ no_such_condition }}")
+    result = render_push(push, {})
+    assert result.push_when is False
+
+
+# ===========================================================================
+# Tier 1 — session field rendering
+# ===========================================================================
+
+
+def test_session_static_passthrough() -> None:
+    """Tier 1: session without '{{' is used as-is (no rendering)."""
+    push = _push(message="m", wake=False, push_when="true", session="static-ses-007")
+    result = render_push(push, {})
+    assert result.session == "static-ses-007"
+
+
+def test_session_template_rendered() -> None:
+    """Tier 1: session containing '{{' is rendered against context."""
+    push = _push(message="m", wake=False, push_when="true", session="ses-{{ sid }}")
+    result = render_push(push, {"sid": "xyz"})
+    assert result.session == "ses-xyz"
+
+
+def test_session_none_resolves_to_none() -> None:
+    """Tier 1: session=None ⇒ resolved session=None (use current session)."""
+    push = _push(message="m", wake=False, push_when="true", session=None)
+    result = render_push(push, {})
+    assert result.session is None
+
+
+def test_session_template_undefined_var_resolves_to_none() -> None:
+    """Tier 1: session template with undefined var → empty string → None (fail-safe)."""
+    push = _push(message="m", wake=False, push_when="true", session="{{ no_such_sid }}")
+    result = render_push(push, {})
+    assert result.session is None
+
+
+# ===========================================================================
+# Tier 1 — Render-error safety net: render_push never raises
+# ===========================================================================
+
+
+def test_render_error_never_raises() -> None:
+    """Tier 1: render_push does not propagate exceptions; returns push_when=False."""
+    # Unrecognised boolean string → _str_to_bool raises ValueError
+    push = _push(message="m", wake="not-a-bool-value", push_when="true")
+    # Must not raise
+    result = render_push(push, {})
+    assert result.push_when is False
+
+
+def test_render_error_returns_safe_defaults() -> None:
+    """Tier 1: render failure returns the documented safe-default ResolvedPush fields."""
+    push = _push(message="{{ undefined_strict }}", wake=False, push_when="true")
+    result = render_push(push, {})
+    assert result.push_when is False
+    assert result.wake is False
+    assert result.message == ""
+    assert result.session is None


### PR DESCRIPTION
**[per-PR-coder]** — dispatched #1800 slice B: Jinja2 template rendering for hook push directives. Builds on the merged slice A (b06390a1).

## Summary

- New module `src/reyn/hooks/render.py` with `render_push(PushBlock, context) → ResolvedPush` using `jinja2.sandbox.SandboxedEnvironment` (never a plain `Environment`).
- `ResolvedPush` frozen dataclass: `message: str`, `wake: bool`, `push_when: bool`, `session: str | None`.
- `ResolvedPush` and `render_push` exported from `reyn.hooks.__init__`.

**Truthiness policy** (documented in module docstring):
- True ← "true" / "1" / "yes" / "on" (case-insensitive)
- False ← "false" / "0" / "no" / "off" / "" (empty)
- Plain Python `bool` bypasses rendering and is used directly.

**Undefined-variable policy** (fail-safe):
- `message`: `StrictUndefined` — a typo'd variable raises loudly; the error safety net catches it and returns `push_when=False` (push skipped, not propagated).
- `wake` / `push_when` / `session`: silent `Undefined` — renders to empty string → `False` / `None` (don't wake / don't push on an undefined condition).

**Render-error safety net**: any `TemplateError` or unrecognised bool string is caught, logged at WARNING, and `ResolvedPush(push_when=False)` is returned. The agent never crashes due to a malformed hook template.

**Sandbox**: `SandboxedEnvironment` blocks dunder attribute traversal (`__class__.__bases__`, `cycler.__init__.__globals__`). Proven by two dedicated tests.

## Test plan

- [x] `pytest tests/test_1800_hook_render.py` — 37 tests, all passing (verified locally).
- [x] `ruff check src tests` — clean (0 errors/warnings after auto-fix of I001).
- [x] `python scripts/test_tier_audit.py --strict tests/test_1800_hook_render.py` — 22 tests OK, 0 Tier-4 violations.
- [x] `pytest tests/` (excluding pre-existing fastapi/mcp optional-dep failures) — 7798 passed, 38 skipped, no new failures introduced.
- [x] (skipped — no LLM-dependent paths in this slice) Tier 3a replay test.

Closes (partial) #1800 slice B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)