### PR TITLE
feat(1800-4b): C next-turn-context staging — persist + inject wake=false ride-alongs

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -65,6 +65,14 @@ class AgentSnapshot:
     # is the runtime cache; this field is its on-disk durable form).
     # Each value is ``{"text": str, "choice_id": str | None}``.
     buffered_intervention_answers: dict[str, dict] = field(default_factory=dict)
+    # #1800 slice 4b: staged wake=false ride-along (C) messages waiting for
+    # the next wake=true trigger turn to consume them.  Persisted (decision B)
+    # so a crash while waiting for the trigger doesn't silently drop context
+    # that was already inbox_consumed.  The in-memory ``_next_turn_context``
+    # list in Session is the runtime cache; this field is its on-disk form.
+    # Each entry is ``{"kind": str, "payload": dict}`` (no msg_id — already
+    # consumed from the inbox before staging here).
+    next_turn_context: list[dict] = field(default_factory=list)
 
     # ── persistence ─────────────────────────────────────────────────────
 
@@ -122,6 +130,9 @@ class AgentSnapshot:
             buffered_intervention_answers=dict(
                 data.get("buffered_intervention_answers", {}) or {}
             ),
+            next_turn_context=list(
+                data.get("next_turn_context", []) or []
+            ),
         )
 
     def save(self, path: Path) -> None:
@@ -137,6 +148,7 @@ class AgentSnapshot:
             "active_skill_run_ids": self.active_skill_run_ids,
             "outstanding_interventions": self.outstanding_interventions,
             "buffered_intervention_answers": self.buffered_intervention_answers,
+            "next_turn_context": self.next_turn_context,
         }
         with tmp.open("w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
@@ -233,6 +245,13 @@ class AgentSnapshot:
             run_id = event.get("run_id")
             if run_id:
                 self.buffered_intervention_answers.pop(run_id, None)
+        # ── #1800 slice 4b: next-turn-context staging ───────────────────
+        elif kind == "next_turn_context_staged":
+            entry = event.get("entry")
+            if entry and isinstance(entry, dict):
+                self.next_turn_context.append(entry)
+        elif kind == "next_turn_context_cleared":
+            self.next_turn_context.clear()
         # skill_phase_advanced, step_started/completed/failed, skill_resumed
         # mutate per-skill snapshot only — no agent-level state change here.
         # Unknown kinds: no-op (forward compatibility for future kinds)

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -60,6 +60,10 @@ WAL_EVENT_KINDS = (
     # second crash before the resuming skill consumes it
     "intervention_answer_buffered",
     "intervention_answer_consumed",
+    # NEW (#1800 slice 4b) — next-turn-context staging for wake=false ride-alongs.
+    # Staged (persisted) before the trigger turn; cleared durably after injection.
+    "next_turn_context_staged",
+    "next_turn_context_cleared",
     # NEW (ADR-0038 Stage 1b) — user-facing time-travel rewind reset-record.
     # Append-only compensating record: moves the active pointer to ``target_n``;
     # the abandoned future is retained as an inactive branch (reconstruct honors

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -377,6 +377,44 @@ class SnapshotJournal:
         self._snapshot.buffered_intervention_answers.pop(run_id, None)
         self.save()
 
+    async def record_next_turn_context_staged(
+        self, *, kind: str, payload: dict,
+    ) -> None:
+        """Append ``next_turn_context_staged`` to WAL + add entry to buffer (#1800-4b).
+
+        Called when a wake=false ride-along is drained and staged for the
+        next turn.  Persisting durably (decision B) ensures the entry
+        survives a crash while the session waits for the trigger message.
+        """
+        if self._state_log is None:
+            return
+        entry = {"kind": kind, "payload": payload}
+        seq = await self._wal_append(
+            "next_turn_context_staged",
+            target=self._agent_name,
+            entry=entry,
+        )
+        self._snapshot.applied_seq = seq
+        self._snapshot.next_turn_context.append(entry)
+        self.save()
+
+    async def record_next_turn_context_cleared(self) -> None:
+        """Append ``next_turn_context_cleared`` to WAL + clear the buffer (#1800-4b).
+
+        Called after the staged entries are injected into history at the
+        start of the trigger's turn.  Clearing durably prevents re-injection
+        on a crash+restore that happens mid-turn.
+        """
+        if self._state_log is None:
+            return
+        seq = await self._wal_append(
+            "next_turn_context_cleared",
+            target=self._agent_name,
+        )
+        self._snapshot.applied_seq = seq
+        self._snapshot.next_turn_context.clear()
+        self.save()
+
     # ── restore / persist ─────────────────────────────────────────────────
 
     def install(self, snapshot: AgentSnapshot) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2846,10 +2846,15 @@ class Session:
         next step; no ``wake=false`` producers exist yet, so the collected
         list is returned but not consumed here.
 
-        #1800 slice 4b: ``ride_alongs`` are staged durably in
-        ``_next_turn_context`` by ``run_one_iteration`` before dispatching
-        to the handler.  Applied as attributed system-role context at the
-        trigger's ``_handle_user_message`` call.
+        #1800 slice 4b: each ``wake=false`` ride-along is staged durably
+        (B=persist) **here**, immediately after its ``inbox_consume``.
+        Staging in ``_drain_to_wake`` rather than in ``run_one_iteration``
+        closes the crash window: a crash while blocking-waiting for the
+        trigger (Decision A) leaves the C's already in the WAL + snapshot,
+        so restore_state recovers them.  ``run_one_iteration`` still
+        receives ``ride_alongs`` (4a contract) but no longer re-stages them.
+        The common path (no wake=false) never calls
+        ``record_next_turn_context_staged``, preserving 4a equivalence.
         """
         ride_alongs: list[tuple[str, dict]] = []
 
@@ -2870,7 +2875,15 @@ class Session:
             if p0.get("wake", True):
                 return ride_alongs, (kind0, p0)
 
-            # (d) wake=false ride-along: accumulate, then drain non-blocking.
+            # (d) wake=false ride-along: stage durably (B=persist) the
+            # moment it is consumed, BEFORE re-entering the blocking wait
+            # for the trigger.  This closes the gap: without this, a crash
+            # in the blocking wait would lose the consumed-but-not-persisted
+            # ride-along.
+            self._next_turn_context.append({"kind": kind0, "payload": p0})
+            await self._journal.record_next_turn_context_staged(
+                kind=kind0, payload=p0,
+            )
             ride_alongs.append((kind0, p0))
 
             # Non-blocking drain: collect additional wake=false messages until
@@ -2897,6 +2910,14 @@ class Session:
                 if p_nb.get("wake", True):
                     return ride_alongs, (kind_nb, p_nb)
 
+                # wake=false via non-blocking path: stage durably before
+                # accumulating (same B=persist guarantee as the outer path).
+                self._next_turn_context.append(
+                    {"kind": kind_nb, "payload": p_nb}
+                )
+                await self._journal.record_next_turn_context_staged(
+                    kind=kind_nb, payload=p_nb,
+                )
                 ride_alongs.append((kind_nb, p_nb))
 
     def restore_state(self, snapshot: AgentSnapshot) -> None:
@@ -3003,25 +3024,20 @@ class Session:
         directly.  With no ``wake=false`` messages ever enqueued (the current
         state — no wake=false producers exist yet), ``_drain_to_wake`` reduces
         to a single blocking get and the behaviour is identical to before.
+
+        #1800 slice 4b: ``_drain_to_wake`` now stages each wake=false
+        ride-along durably (B=persist) as it is consumed — see that method.
+        ``run_one_iteration`` receives ``ride_alongs`` for 4a contract
+        compatibility but no longer re-stages them.
         """
         # #1800 slice 4a/4b: drain up to the first wake=true trigger.
         # ride_alongs holds wake=false C messages accumulated before the
-        # trigger.  Stage them durably (decision B) before the trigger's turn
-        # runs so a crash-between-drain-and-turn doesn't lose them.
+        # trigger.  They are already staged durably by _drain_to_wake (4b);
+        # no further persist needed here.
         ride_alongs, trigger = await self._drain_to_wake()
         if trigger is None:
             # shutdown sentinel
             return False
-        # #1800 slice 4b: persist each ride-along into _next_turn_context
-        # durably BEFORE the trigger's turn starts.  Crash safety: if the
-        # process crashes after staging but before the trigger's turn
-        # finishes, restore_state re-loads them from the snapshot and the
-        # next run's trigger applies them.
-        for ra_kind, ra_payload in ride_alongs:
-            self._next_turn_context.append({"kind": ra_kind, "payload": ra_payload})
-            await self._journal.record_next_turn_context_staged(
-                kind=ra_kind, payload=ra_payload,
-            )
         kind, payload = trigger
         # FP-0041 (#489) PR-A: humanic dispatch attribution.
         # If this inbox item carries a ``sender`` (= new envelope

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1214,6 +1214,12 @@ class Session:
         # the (user_answered → process_crashed → skill_not_yet_resumed)
         # window is R-D12 follow-up.
         self._buffered_intervention_answers: dict[str, "InterventionAnswer"] = {}
+        # #1800 slice 4b: in-memory staging buffer for wake=false ride-along (C)
+        # messages drained by _drain_to_wake.  Entries are applied to the next
+        # trigger's turn as attributed system-role history entries.  Persisted
+        # durably in the snapshot (decision B) via _journal; restored by
+        # restore_state.  Cleared (durably) after injection at the trigger turn.
+        self._next_turn_context: list[dict] = []
         # Per-agent SkillRegistry — lazily constructed on first skill run.
         # Tracks active skill_run_ids and emits skill lifecycle events.
         # Truncation auto-trigger flows through registry.truncate_wal_if_eligible
@@ -2133,6 +2139,7 @@ class Session:
             outstanding_interventions      → self._interventions (clear)
                                              + self._restore_intervention_tasks
             buffered_intervention_answers  → self._buffered_intervention_answers
+            next_turn_context              → self._next_turn_context
             active_skill_run_ids           → self.running_skills (+ started_at / chain)
 
         The running_*/_inflight_wal_tasks task handles are already settled by
@@ -2157,6 +2164,8 @@ class Session:
             self._restore_intervention_tasks = []
         # buffered_intervention_answers
         self._buffered_intervention_answers.clear()
+        # next_turn_context (#1800-4b)
+        self._next_turn_context.clear()
         # active_skill_run_ids live mirrors (handles settled)
         self.running_skills.clear()
         self.running_skills_started_at.clear()
@@ -2837,8 +2846,10 @@ class Session:
         next step; no ``wake=false`` producers exist yet, so the collected
         list is returned but not consumed here.
 
-        TODO(#1800-4b): pass ``ride_alongs`` into _handle_user_message /
-        equivalent after this return to inject them as attributed context.
+        #1800 slice 4b: ``ride_alongs`` are staged durably in
+        ``_next_turn_context`` by ``run_one_iteration`` before dispatching
+        to the handler.  Applied as attributed system-role context at the
+        trigger's ``_handle_user_message`` call.
         """
         ride_alongs: list[tuple[str, dict]] = []
 
@@ -2911,6 +2922,14 @@ class Session:
                 text=ans.get("text", ""),
                 choice_id=ans.get("choice_id"),
             )
+        # #1800 slice 4b: restore the staged next-turn-context buffer. If the
+        # session crashed while holding staged C messages (waiting for a trigger),
+        # they are recovered from the snapshot so the trigger's next turn
+        # still sees the accumulated context.
+        self._next_turn_context = [
+            entry for entry in snapshot.next_turn_context
+            if isinstance(entry, dict)
+        ]
         # Re-enqueue interventions in FIFO insertion order (dict preserves
         # insertion order in py3.7+). Each restored iv gets a fresh future
         # and a watcher task so dispatch's finally clause fires
@@ -2985,14 +3004,24 @@ class Session:
         state — no wake=false producers exist yet), ``_drain_to_wake`` reduces
         to a single blocking get and the behaviour is identical to before.
         """
-        # #1800 slice 4a: drain up to the first wake=true trigger.
-        # ride_alongs is always [] today (no wake=false producers in slice 4a);
-        # it will be staged as attributed context in slice 4b.
+        # #1800 slice 4a/4b: drain up to the first wake=true trigger.
+        # ride_alongs holds wake=false C messages accumulated before the
+        # trigger.  Stage them durably (decision B) before the trigger's turn
+        # runs so a crash-between-drain-and-turn doesn't lose them.
         ride_alongs, trigger = await self._drain_to_wake()
         if trigger is None:
             # shutdown sentinel
             return False
-        # TODO(#1800-4b): pass ride_alongs into the handler for context staging.
+        # #1800 slice 4b: persist each ride-along into _next_turn_context
+        # durably BEFORE the trigger's turn starts.  Crash safety: if the
+        # process crashes after staging but before the trigger's turn
+        # finishes, restore_state re-loads them from the snapshot and the
+        # next run's trigger applies them.
+        for ra_kind, ra_payload in ride_alongs:
+            self._next_turn_context.append({"kind": ra_kind, "payload": ra_payload})
+            await self._journal.record_next_turn_context_staged(
+                kind=ra_kind, payload=ra_payload,
+            )
         kind, payload = trigger
         # FP-0041 (#489) PR-A: humanic dispatch attribution.
         # If this inbox item carries a ``sender`` (= new envelope
@@ -3123,6 +3152,25 @@ class Session:
         # starting a fresh router turn.
         if await self._maybe_answer_oldest_intervention(text):
             return
+
+        # #1800 slice 4b: apply any staged wake=false ride-along (C) context
+        # to this turn.  Injected AFTER the slash/intervention short-circuits
+        # so C messages only attach to an actually-running router turn (flow-
+        # trace §3 risk note: a slash-command short-circuit must NOT consume
+        # the staged C's — they wait for the real turn).
+        if self._next_turn_context:
+            for entry in self._next_turn_context:
+                hook_kind = entry.get("kind", "hook")
+                payload_data = entry.get("payload", {})
+                hook_name = payload_data.get("name", hook_kind)
+                hook_text = payload_data.get("text", "")
+                self._append_history(ChatMessage(
+                    role="system",
+                    content=f"[hook:{hook_name}] {hook_text}",
+                    ts=_now_iso(),
+                ))
+            self._next_turn_context.clear()
+            await self._journal.record_next_turn_context_cleared()
 
         # R-D4: chat turn boundary — opportunistically check WAL size and
         # truncate if it has grown past the safety-net threshold. Long-idle

--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -1,0 +1,421 @@
+"""Tests for #1800 slice 4b: wake=false ride-along (C) next-turn-context staging.
+
+Three test groups:
+
+1. **Tier 1 (contract) — trigger-turn history injection**: ride-alongs drained
+   before a wake=true trigger appear as attributed system-role ChatMessages in
+   history before the trigger's user message; ``_next_turn_context`` is cleared
+   after injection.
+
+2. **Tier 2 (OS invariant — B=persist durability)**: staging a C message
+   persists it in the snapshot (WAL + snapshot file); restore_state recovers it
+   in ``_next_turn_context``.
+
+3. **Tier 1 (contract) — slash/intervention short-circuit safety**: a slash
+   command short-circuit in ``_handle_user_message`` does NOT consume the staged
+   C messages; they wait for the real turn.
+
+Policy compliance (docs/deep-dives/contributing/testing.md):
+- No unittest.mock.MagicMock / AsyncMock / patch to fake collaborators.
+- Observations flow through: history list, StateLog.iter_from(), AgentSnapshot.load().
+- Each test docstring first line declares its Tier.
+- Count assertions use variable-binding idiom.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _text_result(text: str = "ok") -> LLMToolCallResult:
+    """Real LLMToolCallResult that makes RouterLoop emit a text reply."""
+    return LLMToolCallResult(
+        content=text,
+        tool_calls=[],
+        finish_reason="stop",
+        usage=_EMPTY_USAGE,
+    )
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    """Build a minimal Session with WAL + snapshot path."""
+    return Session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _wal_events(tmp_path: Path) -> list[dict]:
+    """Read all WAL events from the session state log."""
+    log = StateLog(tmp_path / "state.wal")
+    return list(log.iter_from(0))
+
+
+def _make_llm_stub_fn(result):  # type: ignore[no-untyped-def]
+    """Return a real async callable that mimics call_llm_tools. No mocks."""
+    if isinstance(result, list):
+        results = list(result)
+        idx = [0]
+
+        async def _stub(**kwargs) -> LLMToolCallResult:  # noqa: ANN202
+            i = idx[0]
+            idx[0] += 1
+            return results[i] if i < len(results) else results[-1]
+
+        return _stub
+
+    async def _stub(**kwargs) -> LLMToolCallResult:  # noqa: ANN202
+        return result
+
+    return _stub
+
+
+async def _run_n_turns_then_shutdown(
+    session: Session,
+    n: int,
+    timeout: float = 5.0,
+) -> None:
+    """Run the session loop until n turns complete, then shutdown."""
+    turns_done = [0]
+    original_run_one = session.run_one_iteration
+
+    async def _counting_run_one() -> bool:
+        result = await original_run_one()
+        if result:
+            turns_done[0] += 1
+        return result
+
+    session.run_one_iteration = _counting_run_one  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(session.run())
+    deadline = asyncio.get_event_loop().time() + timeout
+    while turns_done[0] < n:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(0.005)
+    await session.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=2.0)
+    except asyncio.TimeoutError:
+        run_task.cancel()
+        await asyncio.gather(run_task, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Group 1 — Tier 1: trigger-turn history injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c_staging_ride_alongs_injected_as_system_messages(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 1: [wake=false, wake=false, wake=true] → C's injected as system messages.
+
+    Contract: when a wake=true trigger is preceded by 2 wake=false ride-alongs,
+    the trigger's turn history contains the 2 C's as attributed system-role
+    ChatMessages before the trigger's user message.  ``_next_turn_context``
+    is empty after the turn.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    stub = _make_llm_stub_fn(_text_result("got it"))
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
+
+    # Two wake=false ride-alongs, then one wake=true trigger.
+    await session._put_inbox("hook", {"text": "context-a", "name": "hook_a", "wake": False})
+    await session._put_inbox("hook", {"text": "context-b", "name": "hook_b", "wake": False})
+    await session._put_inbox("user", {"text": "trigger-msg", "wake": True})
+
+    await _run_n_turns_then_shutdown(session, n=1)
+
+    # Find the system messages in history.
+    system_msgs = [m for m in session.history if m.role == "system"]
+
+    # There must be at least 2 system-role messages from the ride-alongs.
+    n_sys = len(system_msgs)
+    assert n_sys >= 2, (
+        f"Expected at least 2 system-role messages from ride-alongs; got {n_sys}: "
+        f"{[m.content for m in system_msgs]}"
+    )
+
+    # The first two must be attributed with [hook:hook_a] and [hook:hook_b].
+    sys_a, sys_b = system_msgs[0], system_msgs[1]
+    assert "[hook:hook_a]" in sys_a.content, (
+        f"First system message must be attributed [hook:hook_a]; got {sys_a.content!r}"
+    )
+    assert "[hook:hook_b]" in sys_b.content, (
+        f"Second system message must be attributed [hook:hook_b]; got {sys_b.content!r}"
+    )
+    assert "context-a" in sys_a.content, (
+        f"First system message must contain 'context-a'; got {sys_a.content!r}"
+    )
+    assert "context-b" in sys_b.content, (
+        f"Second system message must contain 'context-b'; got {sys_b.content!r}"
+    )
+
+    # The system messages must appear BEFORE the trigger's user message in history.
+    user_msgs = [m for m in session.history if m.role == "user"]
+    n_user = len(user_msgs)
+    assert n_user >= 1, f"Expected at least 1 user message; got {n_user}"
+
+    last_user = user_msgs[-1]
+    last_sys = system_msgs[-1]
+    history_roles = [m.role for m in session.history]
+    sys_idx = session.history.index(last_sys)
+    user_idx = session.history.index(last_user)
+    assert sys_idx < user_idx, (
+        f"System messages (idx={sys_idx}) must appear before trigger user message "
+        f"(idx={user_idx}); history roles: {history_roles}"
+    )
+
+    # _next_turn_context must be empty after the turn.
+    n_ntc = len(session._next_turn_context)
+    assert n_ntc == 0, (
+        f"_next_turn_context must be empty after turn; got {n_ntc} entries"
+    )
+
+
+@pytest.mark.asyncio
+async def test_c_staging_no_ride_alongs_no_system_messages(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 1: wake=true trigger with no preceding ride-alongs → no extra system messages.
+
+    The common path (no ride-alongs) must not inject any system-role messages
+    from the staging buffer.  Back-compat: existing turn behaviour unchanged.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    stub = _make_llm_stub_fn(_text_result("hello back"))
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
+
+    await session.submit_user_text("plain message")
+    await _run_n_turns_then_shutdown(session, n=1)
+
+    system_msgs = [m for m in session.history if m.role == "system"]
+    n_sys = len(system_msgs)
+    assert n_sys == 0, (
+        f"Expected no system-role messages from ride-alongs; got {n_sys}: "
+        f"{[m.content for m in system_msgs]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group 2 — Tier 2: B=persist durability — snapshot survives crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c_staging_persist_and_restore(tmp_path) -> None:
+    """Tier 2: (OS invariant — B=persist): staged C's survive snapshot+restore.
+
+    Contract (decision B): staging a wake=false ride-along writes it to the
+    WAL + snapshot durably.  A fresh Session restored from that snapshot
+    recovers the entries in ``_next_turn_context``.
+
+    Falsifiable: without persistence, restore_state would leave
+    ``_next_turn_context`` empty and this test would fail.
+    """
+    session = _make_session(tmp_path)
+
+    # Directly call the journal method to stage a ride-along entry.
+    await session._journal.record_next_turn_context_staged(
+        kind="hook",
+        payload={"name": "hook_a", "text": "ride-along context"},
+    )
+
+    # Verify the snapshot file contains the staged entry.
+    snapshot_on_disk = AgentSnapshot.load(
+        session.agent_name, session._snapshot_path,
+    )
+    n_ntc = len(snapshot_on_disk.next_turn_context)
+    assert n_ntc == 1, (
+        f"Snapshot must contain 1 next_turn_context entry after staging; got {n_ntc}"
+    )
+    (staged_entry,) = snapshot_on_disk.next_turn_context
+    assert staged_entry.get("kind") == "hook", (
+        f"Staged entry kind must be 'hook'; got {staged_entry!r}"
+    )
+    assert staged_entry.get("payload", {}).get("text") == "ride-along context", (
+        f"Staged entry payload text must be 'ride-along context'; got {staged_entry!r}"
+    )
+
+    # Simulate crash+restore: build a new Session and restore from the snapshot.
+    session2 = _make_session(tmp_path, agent_name="test_agent2")
+    # Reuse the same snapshot path as session (same agent_name — but load the snap directly).
+    recovered_snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
+    # Manually install the recovered snapshot's next_turn_context into session2.
+    # (In production, restore_state does this; we test restore_state directly below.)
+    session3 = _make_session(tmp_path, agent_name="test_agent3")
+    # Build a minimal snapshot with the staged entry.
+    restored_snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
+    # Call restore_state on a new session (same agent_name, same snapshot_path).
+    session4 = Session(
+        agent_name=session.agent_name,
+        state_log=StateLog(tmp_path / "state2.wal"),
+        snapshot_path=session._snapshot_path,
+    )
+    # restore_state expects the snapshot to already have next_turn_context.
+    session4.restore_state(restored_snap)
+
+    n_recovered = len(session4._next_turn_context)
+    assert n_recovered == 1, (
+        f"restore_state must recover 1 next_turn_context entry; got {n_recovered}"
+    )
+    (recovered_entry,) = session4._next_turn_context
+    assert recovered_entry.get("kind") == "hook", (
+        f"Recovered entry kind must be 'hook'; got {recovered_entry!r}"
+    )
+    assert recovered_entry.get("payload", {}).get("text") == "ride-along context", (
+        f"Recovered entry payload text; got {recovered_entry!r}"
+    )
+
+    # Verify WAL has next_turn_context_staged event.
+    events = _wal_events(tmp_path)
+    staged_events = [e for e in events if e.get("kind") == "next_turn_context_staged"]
+    n_staged = len(staged_events)
+    assert n_staged == 1, (
+        f"Expected 1 next_turn_context_staged WAL event; got {n_staged}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_c_staging_cleared_durably_after_injection(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: (OS invariant — B=persist): cleared durably → snapshot empty after turn.
+
+    After the trigger turn applies the staged entries, ``_next_turn_context``
+    is cleared durably in the snapshot.  A crash after the turn would NOT
+    re-inject the C messages on the next restart.
+
+    Falsifiable: without the clear WAL event, the snapshot would still hold
+    the entries after the turn and re-injection would occur on restore.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    stub = _make_llm_stub_fn(_text_result("done"))
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
+
+    await session._put_inbox("hook", {"text": "ctx", "name": "my_hook", "wake": False})
+    await session._put_inbox("user", {"text": "trigger", "wake": True})
+
+    await _run_n_turns_then_shutdown(session, n=1)
+
+    # WAL must contain next_turn_context_cleared event.
+    events = _wal_events(tmp_path)
+    cleared_events = [e for e in events if e.get("kind") == "next_turn_context_cleared"]
+    n_cleared = len(cleared_events)
+    assert n_cleared == 1, (
+        f"Expected 1 next_turn_context_cleared WAL event after turn; got {n_cleared}"
+    )
+
+    # Snapshot must have empty next_turn_context.
+    snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
+    n_ntc = len(snapshot.next_turn_context)
+    assert n_ntc == 0, (
+        f"Snapshot next_turn_context must be empty after turn; got {n_ntc}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_c_staging_decision_a_persist_while_waiting(tmp_path) -> None:
+    """Tier 1: wake=false messages alone → persisted while waiting for trigger.
+
+    Decision A (RESOLVED): C drained with no trigger yet → C's persisted
+    in _next_turn_context while waiting.
+
+    This exercises the path where ride_alongs are staged but the session
+    has not yet received a trigger.  The staging must be durable (WAL event +
+    snapshot) even before any turn runs.
+    """
+    session = _make_session(tmp_path)
+
+    # Stage directly as if _drain_to_wake returned ride-alongs with no trigger yet.
+    await session._journal.record_next_turn_context_staged(
+        kind="hook",
+        payload={"name": "waiting_hook", "text": "waiting-context"},
+    )
+    session._next_turn_context.append(
+        {"kind": "hook", "payload": {"name": "waiting_hook", "text": "waiting-context"}}
+    )
+
+    # Verify WAL event exists.
+    events = _wal_events(tmp_path)
+    staged_events = [e for e in events if e.get("kind") == "next_turn_context_staged"]
+    n_staged = len(staged_events)
+    assert n_staged == 1, (
+        f"Expected 1 next_turn_context_staged WAL event while waiting; got {n_staged}"
+    )
+
+    # Verify in-memory buffer holds the entry.
+    n_ntc = len(session._next_turn_context)
+    assert n_ntc == 1, (
+        f"_next_turn_context must hold 1 entry while waiting; got {n_ntc}"
+    )
+
+    # Verify snapshot file holds the entry.
+    snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
+    n_snap = len(snap.next_turn_context)
+    assert n_snap == 1, (
+        f"Snapshot next_turn_context must hold 1 entry while waiting; got {n_snap}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group 3 — Tier 1: slash/intervention short-circuit safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c_staging_slash_command_does_not_consume_staged(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 1: slash command short-circuit does NOT consume staged C messages.
+
+    Contract (flow-trace §3 risk note): a slash command in
+    ``_handle_user_message`` short-circuits before the injection point.
+    The staged C messages must still be in ``_next_turn_context`` after
+    the slash command returns (they wait for a real turn).
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Stage a C message manually.
+    session._next_turn_context.append(
+        {"kind": "hook", "payload": {"name": "pending_hook", "text": "pending-context"}}
+    )
+
+    # Call _handle_user_message with a slash command (e.g. /help, /list).
+    # We don't need LLM stubs since slash commands short-circuit before the LLM.
+    await session._handle_user_message("/help", chain_id="test-chain")
+
+    # The staged entries must still be in _next_turn_context.
+    n_ntc = len(session._next_turn_context)
+    assert n_ntc == 1, (
+        f"Slash command must NOT consume staged C messages; "
+        f"expected 1 entry in _next_turn_context, got {n_ntc}"
+    )

--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -1,19 +1,24 @@
 """Tests for #1800 slice 4b: wake=false ride-along (C) next-turn-context staging.
 
-Three test groups:
+Four test groups:
 
 1. **Tier 1 (contract) — trigger-turn history injection**: ride-alongs drained
    before a wake=true trigger appear as attributed system-role ChatMessages in
    history before the trigger's user message; ``_next_turn_context`` is cleared
    after injection.
 
-2. **Tier 2 (OS invariant — B=persist durability)**: staging a C message
-   persists it in the snapshot (WAL + snapshot file); restore_state recovers it
-   in ``_next_turn_context``.
+2. **Tier 2 (OS invariant — B=persist durability)**: C messages are staged
+   durably (WAL + snapshot) DURING ``_drain_to_wake`` — before the trigger
+   arrives — so a crash during the blocking wait does not lose them.
+   restore_state recovers them in ``_next_turn_context``.
 
 3. **Tier 1 (contract) — slash/intervention short-circuit safety**: a slash
    command short-circuit in ``_handle_user_message`` does NOT consume the staged
    C messages; they wait for the real turn.
+
+4. **Tier 2 (OS invariant — B=persist crash-window)**: falsifiable proof that
+   the B=persist gap is closed — C is durable DURING the drain-wait, not only
+   after ``run_one_iteration`` returns (the pre-fix location).
 
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock.MagicMock / AsyncMock / patch to fake collaborators.
@@ -341,46 +346,99 @@ async def test_c_staging_cleared_durably_after_injection(
 
 
 @pytest.mark.asyncio
-async def test_c_staging_decision_a_persist_while_waiting(tmp_path) -> None:
-    """Tier 1: wake=false messages alone → persisted while waiting for trigger.
+async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
+    """Tier 2: (OS invariant — B=persist): C staged in _drain_to_wake BEFORE trigger arrives.
 
-    Decision A (RESOLVED): C drained with no trigger yet → C's persisted
-    in _next_turn_context while waiting.
+    Falsifiable proof that the B=persist gap is fixed: a wake=false C is
+    persisted (WAL + snapshot) DURING _drain_to_wake — while the drain is
+    still blocking waiting for the trigger — NOT after run_one_iteration
+    returns.  A crash during that blocking wait must not lose the C.
 
-    This exercises the path where ride_alongs are staged but the session
-    has not yet received a trigger.  The staging must be durable (WAL event +
-    snapshot) even before any turn runs.
+    Mechanism under test: _drain_to_wake calls record_next_turn_context_staged
+    immediately after consuming a wake=false message, before re-entering the
+    blocking wait for the trigger.
+
+    Falsification: without the fix (staging only in run_one_iteration), the
+    WAL + snapshot would be empty while _drain_to_wake is blocked, and this
+    test would fail on the staged_events / n_snap assertions.
+
+    Test structure:
+    1. Enqueue one wake=false C into the inbox (no trigger).
+    2. Start _drain_to_wake as a concurrent task — it consumes the C, stages
+       it durably, then blocks waiting for the trigger (Decision A).
+    3. Yield briefly so the task can consume and stage the C.
+    4. While still blocking (no trigger sent), verify WAL + snapshot already
+       hold the staged entry.
+    5. Simulate crash+restore: load the snapshot into a new Session via
+       restore_state; verify _next_turn_context is recovered.
+    6. Cancel the drain task (simulating the crash).
     """
     session = _make_session(tmp_path)
 
-    # Stage directly as if _drain_to_wake returned ride-alongs with no trigger yet.
-    await session._journal.record_next_turn_context_staged(
-        kind="hook",
-        payload={"name": "waiting_hook", "text": "waiting-context"},
-    )
-    session._next_turn_context.append(
-        {"kind": "hook", "payload": {"name": "waiting_hook", "text": "waiting-context"}}
+    # Enqueue one wake=false C — no trigger follows.
+    await session._put_inbox(
+        "hook", {"name": "pre_trigger_hook", "text": "crash-window-context", "wake": False},
     )
 
-    # Verify WAL event exists.
+    # Start _drain_to_wake concurrently.  It will consume the wake=false C,
+    # stage it durably, then block waiting for a trigger (Decision A).
+    drain_task = asyncio.create_task(session._drain_to_wake())
+
+    # Yield control briefly to let the drain task consume the C and call
+    # record_next_turn_context_staged.  Multiple yields improve reliability
+    # across different event-loop scheduling policies.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # While _drain_to_wake is still blocking (no trigger sent), verify
+    # durability: WAL + snapshot must already contain the staged entry.
     events = _wal_events(tmp_path)
     staged_events = [e for e in events if e.get("kind") == "next_turn_context_staged"]
     n_staged = len(staged_events)
     assert n_staged == 1, (
-        f"Expected 1 next_turn_context_staged WAL event while waiting; got {n_staged}"
+        f"Expected 1 next_turn_context_staged WAL event DURING drain wait (no trigger sent); "
+        f"got {n_staged}.  Without the fix, staging happens only after _drain_to_wake "
+        f"returns (in run_one_iteration), so the WAL would still be empty here."
     )
 
-    # Verify in-memory buffer holds the entry.
-    n_ntc = len(session._next_turn_context)
-    assert n_ntc == 1, (
-        f"_next_turn_context must hold 1 entry while waiting; got {n_ntc}"
-    )
-
-    # Verify snapshot file holds the entry.
     snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     n_snap = len(snap.next_turn_context)
     assert n_snap == 1, (
-        f"Snapshot next_turn_context must hold 1 entry while waiting; got {n_snap}"
+        f"Snapshot must hold 1 next_turn_context entry DURING drain wait; got {n_snap}"
+    )
+    (snap_entry,) = snap.next_turn_context
+    assert snap_entry.get("kind") == "hook", (
+        f"Snapshot entry kind must be 'hook'; got {snap_entry!r}"
+    )
+    assert snap_entry.get("payload", {}).get("text") == "crash-window-context", (
+        f"Snapshot entry payload text must be 'crash-window-context'; got {snap_entry!r}"
+    )
+
+    # Simulate crash: cancel the drain task (= process killed while blocking).
+    drain_task.cancel()
+    await asyncio.gather(drain_task, return_exceptions=True)
+
+    # Simulate restore: a fresh Session restores from the snapshot.
+    # restore_state must recover the staged entry in _next_turn_context.
+    session2 = Session(
+        agent_name=session.agent_name,
+        state_log=StateLog(tmp_path / "state2.wal"),
+        snapshot_path=session._snapshot_path,
+    )
+    recovered_snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
+    session2.restore_state(recovered_snap)
+
+    n_recovered = len(session2._next_turn_context)
+    assert n_recovered == 1, (
+        f"restore_state must recover 1 next_turn_context entry after crash; "
+        f"got {n_recovered}"
+    )
+    (recovered_entry,) = session2._next_turn_context
+    assert recovered_entry.get("kind") == "hook", (
+        f"Recovered entry kind must be 'hook'; got {recovered_entry!r}"
+    )
+    assert recovered_entry.get("payload", {}).get("text") == "crash-window-context", (
+        f"Recovered entry payload text; got {recovered_entry!r}"
     )
 
 

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -94,6 +94,7 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
         "active_skill_run_ids": "session.running_skills (+ started_at / chain) cleared",
         "outstanding_interventions": "session._interventions.clear() + restore tasks",
         "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
+        "next_turn_context": "session._next_turn_context cleared",
     }
     assert set(disposition) == set(AgentSnapshot.__dataclass_fields__), (
         "AgentSnapshot fields changed — update reset_for_rewind (and this map) so "


### PR DESCRIPTION
**[per-PR-coder]** — #1800 slice 4b: persisted next-turn-context staging for wake=false (C) ride-along messages.

## Summary

- wake=false ride-along (C) messages drained by `_drain_to_wake` are now **staged durably** in `_next_turn_context` (decision B: snapshot-persisted via WAL, mirrors the `_buffered_intervention_answers` pattern) before the trigger's turn runs.
- Applied as **attributed `system`-role `ChatMessage`s** (`[hook:<name>] <text>`) at the trigger's `_handle_user_message` call — **after** the slash/intervention short-circuit guards (flow-trace §3 risk note: C messages must not be consumed by slash commands; they wait for a real router turn).
- After injection, `_next_turn_context` is **cleared durably** (WAL event + snapshot) so a crash mid-turn doesn't re-inject on the next restart.

## Changed files

| File | Change |
|---|---|
| `src/reyn/core/events/state_log.py` | Register `next_turn_context_staged` / `_cleared` in `WAL_EVENT_KINDS` |
| `src/reyn/core/events/agent_snapshot.py` | Add `next_turn_context: list[dict]` field; wire in `load`/`save`/`_apply_one` |
| `src/reyn/runtime/services/snapshot_journal.py` | Add `record_next_turn_context_staged` / `record_next_turn_context_cleared` methods |
| `src/reyn/runtime/session.py` | Add `_next_turn_context` buffer; wire persist, restore, inject, clear; remove `TODO(#1800-4b)` seam |
| `tests/test_1800_c_staging.py` | 6 new tests (real Session, no mocks) |

## Persist mechanism (decision B)

Mirrors `_buffered_intervention_answers` exactly:
- Two WAL event kinds: `next_turn_context_staged` (per ride-along; appended before the turn) and `next_turn_context_cleared` (once after injection).
- `AgentSnapshot.next_turn_context: list[dict]` — loaded/saved as part of the snapshot JSON (field absent in legacy snapshots → defaults to `[]`, additive / backward-compatible).
- `SnapshotJournal.record_next_turn_context_staged / _cleared` — WAL-append + snapshot-mutate + `save()` in one call, identical to the intervention-answer methods.
- `Session.restore_state` rehydrates `_next_turn_context` from the snapshot.
- `Session.reset_for_rewind` clears it (mirrors `_buffered_intervention_answers.clear()`).

## Apply-after-short-circuits design

```
_handle_user_message(text):
  if slash → return          ← C's untouched, waiting
  if intervention → return   ← C's untouched, waiting
  if _next_turn_context:     ← only here
      inject as system msgs
      clear durably
  ... router turn ...
```

## Test plan

- [x] `uv run pytest tests/test_1800_c_staging.py tests/test_1800_wake_drain.py -x -q` → 14/14 passed
- [x] `uv run ruff check src tests` → All checks passed
- [x] `uv run python scripts/test_tier_audit.py --strict tests/test_1800_c_staging.py` → 6/6 OK

Tests cover:
- [x] `[wake=false, wake=false, wake=true]` → 2 C's injected as attributed system msgs before trigger user msg; `_next_turn_context` cleared after
- [x] No ride-alongs → no extra system msgs (back-compat)
- [x] Tier 2 (B=persist): stage → snapshot → restore → recovered in `_next_turn_context`. Falsifiable.
- [x] Tier 2: cleared durably — WAL has `next_turn_context_cleared`, snapshot empty after turn
- [x] Decision A: C drained with no trigger → persisted while waiting
- [x] Slash command short-circuit does NOT consume staged C's

Ref #1800

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>