### PR TITLE
feat(1800-5b): the awaited HookDispatcher + wire the 4 lifecycle points

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -32,6 +32,7 @@ models:
 | `web` | map | SSL settings for `web_fetch` and MCP registry calls. See below. |
 | `eval` | map | Trace exporter backends for `reyn eval`. See below. |
 | `sandbox` | map | Sandboxed-exec backend selection, unsupported-platform policy, and the agent-level sandbox policy. See below. |
+| `hooks` | list | Agent-lifecycle hooks (#1800) — push / shell hooks at lifecycle points. See below. |
 | `action_retrieval` | map | Universal catalog visibility + retrieval settings. See below. |
 | `embedding` | map | RAG embedding model classes and batch settings. See below. |
 | `chat` | map | Chat-session compaction settings. See below. |
@@ -576,6 +577,31 @@ eval:
 | `ietf_audit` | IETF Agent Audit Trail draft format written to `path`. |
 
 All exporters are fire-and-forget: export failures are logged but do not abort the skill run.
+
+## `hooks` block
+
+Agent-lifecycle hooks (#1800) — a thin operator layer over the unified inbox and
+the P6 lifecycle. A **list** of entries; each fires at a lifecycle point (`on`)
+and is **either** a `push` (inject an attributed `[hook:<point>]` message) **or**
+a `shell` (run an external command — sandbox-gated, output ignored). Hooks never
+silently mutate tool results; pushes are new, attributed, evented messages.
+
+```yaml
+hooks:
+  - on: turn_end                 # turn_start | turn_end | session_start | session_end
+    push:
+      message: "Turn complete — consider the next step."
+      wake: false                # false = passive context (C); true = start a turn (E)
+      push_when: "true"          # optional Jinja2 → bool; false skips the push
+  - on: session_start
+    shell: "echo session-started >> /tmp/reyn-hooks.log"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `on` | string | _required_ | Lifecycle point: `turn_start`, `turn_end`, `session_start`, `session_end` (skill/task points land in a later slice). |
+| `push` | map | _none_ | Inbox-push hook (mutually exclusive with `shell`). `message` (Jinja2 → text), `wake` (bool/Jinja2, default `true`: `true` starts a new turn = self-continuation; `false` rides along with the next turn as passive context), `push_when` (Jinja2 → bool, default `true`; `false` skips). |
+| `shell` | string | _none_ | A shell command to run as a pure side-effect (mutually exclusive with `push`). Sandbox-gated + consent-allowlisted; stdout/stderr are logs, never parsed. |
 
 ## `sandbox` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -697,6 +697,29 @@
 
 
 # -----------------------------------------------------------------------------
+# hooks: agent-lifecycle hooks (#1800) — a thin operator layer over the inbox +
+# the P6 lifecycle. A list of entries; each fires at a lifecycle point (``on``)
+# and is EITHER a ``push`` (inject an attributed ``[hook:<point>]`` message) OR a
+# ``shell`` (run an external command, sandbox-gated, output ignored).
+#
+#   on:        turn_start | turn_end | session_start | session_end
+#              (skill_*/task_* points land in a later slice)
+#   push:      message:   Jinja2 template → the message text
+#              wake:      true  → start a new turn (self-continuation)   [default]
+#                         false → ride along with the next turn (passive context)
+#              push_when: Jinja2 → bool; false skips the push (conditional)
+#   shell:     a command string (mutually exclusive with ``push``)
+# -----------------------------------------------------------------------------
+# hooks:
+#   - on: turn_end
+#     push:
+#       message: "Turn complete — consider the next step."
+#       wake: false
+#   - on: session_start
+#     shell: "echo session-started >> /tmp/reyn-hooks.log"
+
+
+# -----------------------------------------------------------------------------
 # self_improvement: skill_improver behavior knobs.
 #
 #   on_propose:   ask_user (default; pause + prompt before applying)

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -481,6 +481,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         skill_search=_build_skill_search_config(merged.get("skill_search")),
         eval=_build_eval_config(merged.get("eval")),
         sandbox=_build_sandbox_config(merged.get("sandbox")),
+        # #1800 slice 5b: the raw ``hooks:`` block, passed through (parsed by
+        # ``load_hooks`` at Session construction). None/absent → empty list.
+        hooks=merged.get("hooks") or [],
         self_improvement=_build_self_improvement_config(merged.get("self_improvement")),
         action_retrieval=_build_action_retrieval_config(merged.get("action_retrieval")),
         cron=_build_cron_config(merged.get("cron")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -266,6 +266,10 @@ class ReynConfig:
     # FP-0017: sandbox backend selection + unsupported-platform policy.
     # Default: auto-select the best available backend for this platform.
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
+    # #1800 slice 5b: the raw ``hooks:`` block (a list of hook entries). Kept raw
+    # here and parsed via ``load_hooks`` at Session construction. Empty (default)
+    # → empty registry → the HookDispatcher is a no-op.
+    hooks: list = field(default_factory=list)
     # FP-0006 B+D: skill_improver behavior knobs (on_propose gate + max_versions cap).
     self_improvement: SelfImprovementConfig = field(default_factory=SelfImprovementConfig)
     # FP-0034: universal catalog gating + action retrieval (D13 / D14).

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -1,0 +1,119 @@
+"""reyn.hooks.dispatcher — the awaited HookDispatcher (#1800 slice 5b).
+
+The integration core of the agent-lifecycle-hook system. Unlike a P6 EventLog
+subscriber (sync-inline, cannot ``await``), the dispatcher is a **first-class
+``await``ed dispatch** invoked at the session/turn lifecycle points: it can
+``await`` the inbox push (E), the next-turn staging (C), and the shell run (F).
+
+Per-hook isolation: a hook that raises is logged and skipped; its siblings and
+the lifecycle point itself proceed. ``dispatch()`` never propagates an exception
+out — a misbehaving hook can never break the run-loop.
+
+No-hooks equivalence (the critical property): an empty registry makes
+``dispatch()`` a no-op (the ``hooks_for`` loop body never runs), so the run-loop
+is byte-identical to a hooks-free build.
+
+The three Session seams the dispatcher needs are injected as bound callables
+(DI), so the dispatcher is decoupled from ``Session`` and unit-testable against a
+real Session's methods (no mocks):
+
+- ``put_inbox(kind, payload)``           — E (wake=true): a turn trigger.
+- ``stage_next_turn_context(kind, payload)`` — C (wake=false): a passive ride-along.
+- ``run_shell(command, event_context, **sandbox)`` — F: an external side-effect.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.render import render_push
+from reyn.hooks.schema import HookDef
+from reyn.hooks.shell_runner import run_shell_hook
+
+_log = logging.getLogger(__name__)
+
+# The inbox kind for an E (wake=true) hook trigger. Routed by the run-loop to
+# ``Session._handle_hook_message`` (system-role ``[hook:name]`` + one turn).
+HOOK_INBOX_KIND = "hook"
+
+# The kind stored on a staged C (wake=false) ride-along entry; the staged-context
+# consumer reads ``payload["name"]`` for the ``[hook:name]`` attribution.
+HOOK_STAGE_KIND = "hook"
+
+PutInbox = Callable[[str, dict], Awaitable[Any]]
+StageContext = Callable[[str, dict], Awaitable[Any]]
+RunShell = Callable[..., Awaitable[Any]]
+
+
+class HookDispatcher:
+    """Awaited dispatch of lifecycle hooks (#1800 slice 5b)."""
+
+    def __init__(
+        self,
+        registry: HookRegistry,
+        *,
+        put_inbox: PutInbox,
+        stage_next_turn_context: StageContext,
+        run_shell: RunShell = run_shell_hook,
+        sandbox_config: Any = None,
+        sandbox_backend: Any = None,
+    ) -> None:
+        self._registry = registry
+        self._put_inbox = put_inbox
+        self._stage_next_turn_context = stage_next_turn_context
+        self._run_shell = run_shell
+        self._sandbox_config = sandbox_config
+        self._sandbox_backend = sandbox_backend
+
+    async def dispatch(self, point: str, template_vars: dict) -> None:
+        """Run every hook registered for ``point`` (registration order).
+
+        Per-hook ``try/except``: a raising hook is logged + skipped; siblings and
+        the lifecycle point proceed. Never propagates out of ``dispatch()``.
+        Empty registry → the loop body never runs → byte-identical no-op.
+        """
+        for hook in self._registry.hooks_for(point):
+            try:
+                await self._dispatch_one(hook, point, template_vars)
+            except Exception as exc:  # noqa: BLE001 — per-hook isolation boundary
+                _log.warning(
+                    "Hook at point %r raised — skipped (siblings proceed). "
+                    "hook=%r error=%s: %s",
+                    point, hook, type(exc).__name__, exc,
+                )
+
+    async def _dispatch_one(self, hook: HookDef, point: str, template_vars: dict) -> None:
+        """Dispatch a single hook by type (push C/E vs shell F)."""
+        if hook.push is not None:
+            resolved = render_push(hook.push, template_vars)
+            if not resolved.push_when:
+                return  # conditional push guard (or a render failure — fail-safe)
+            # Attribution name: the lifecycle point (HookDef carries no separate
+            # name field). Consumed as the ``[hook:<name>]`` system-role prefix.
+            payload = {"name": point, "text": resolved.message}
+            if resolved.wake:
+                # E — a turn trigger (self-continuation). Routed to
+                # _handle_hook_message, which renders the system-role
+                # [hook:name] message + runs one turn. wake=True so
+                # _drain_to_wake treats it as the trigger.
+                await self._put_inbox(HOOK_INBOX_KIND, {**payload, "wake": True})
+            else:
+                # C — a passive ride-along: stage directly into next-turn context
+                # (the 4b staging API), NOT via the inbox (a wake=false-only inbox
+                # push would never drain alone — Decision A). Rides along with the
+                # next turn as a system-role [hook:name] message.
+                await self._stage_next_turn_context(HOOK_STAGE_KIND, payload)
+        elif hook.shell is not None:
+            # F — an external side-effect. Output ignored; never raises (the
+            # runner logs + returns). Backend: the injected instance, else
+            # run_shell_hook resolves get_default_backend(sandbox_config).
+            await self._run_shell(
+                hook.shell,
+                template_vars,
+                sandbox_backend=self._sandbox_backend,
+                sandbox_config=self._sandbox_config,
+            )
+
+
+__all__ = ["HookDispatcher", "HOOK_INBOX_KIND", "HOOK_STAGE_KIND"]

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -456,6 +456,7 @@ def run(args: argparse.Namespace) -> None:
             state_log=state_log,
             budget_tracker=budget_tracker,
             sandbox_config=session_cfg.config.sandbox,
+            hooks_config=session_cfg.config.hooks,  # #1800 slice 5b
             multimodal_config=session_cfg.config.multimodal,
             tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
             action_retrieval_config=session_cfg.config.action_retrieval,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -473,6 +473,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 state_log=None,  # no WAL for dogfood dispatch
                 budget_tracker=budget_tracker,
                 sandbox_config=config.sandbox,
+                hooks_config=config.hooks,  # #1800 slice 5b
                 multimodal_config=config.multimodal,
                 tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
                 action_retrieval_config=config.action_retrieval,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -474,6 +474,14 @@ def _new_chain_id() -> str:
     return uuid.uuid4().hex
 
 
+def _format_hook_attribution(name: str, text: str) -> str:
+    """Render an attributed hook message (#1800 slice 5b). The single source for
+    the ``[hook:<name>]`` system-role prefix, shared by the staged-context
+    consumer (C — wake=false ride-along) and ``_handle_hook_message`` (E —
+    wake=true trigger) so the two paths can never drift."""
+    return f"[hook:{name}] {text}"
+
+
 def _read_memory_index(path: Path) -> str:
     """Return MEMORY.md contents at `path` or empty string if absent."""
     try:
@@ -779,6 +787,10 @@ class Session:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         sandbox_config: "SandboxConfig | None" = None,
+        # #1800 slice 5b: the resolved ``hooks:`` config block (the parsed list,
+        # mirroring sandbox_config's seam). None/absent → empty registry → every
+        # HookDispatcher.dispatch() is a no-op (the no-hooks equivalence property).
+        hooks_config: "object | None" = None,
         # #1200 PR-F1 (agent-level-uniform backend, FS seam): the agent's
         # EnvironmentBackend INSTANCE, threaded to the chat Workspace so chat's
         # file ops run on the SAME backend as the OSRuntime path. None → HostBackend (the
@@ -1220,6 +1232,25 @@ class Session:
         # durably in the snapshot (decision B) via _journal; restored by
         # restore_state.  Cleared (durably) after injection at the trigger turn.
         self._next_turn_context: list[dict] = []
+
+        # #1800 slice 5b: the awaited HookDispatcher. Hooks load from the resolved
+        # ``hooks:`` block; None/absent → empty registry → every dispatch() is a
+        # no-op (run-loop byte-identical to a hooks-free build). Constructed
+        # unconditionally so the 4 lifecycle dispatch() sites are uniform.
+        from reyn.hooks.dispatcher import HookDispatcher
+        from reyn.hooks.loader import load_hooks
+        from reyn.hooks.registry import HookRegistry as _HookRegistry
+        self._hook_registry = (
+            load_hooks(hooks_config) if hooks_config is not None else _HookRegistry([])
+        )
+        self._hook_dispatcher = HookDispatcher(
+            self._hook_registry,
+            put_inbox=self._put_inbox,
+            stage_next_turn_context=self._stage_next_turn_context,
+            sandbox_config=self._sandbox_config,
+            sandbox_backend=self._sandbox_backend,
+        )
+
         # Per-agent SkillRegistry — lazily constructed on first skill run.
         # Tracks active skill_run_ids and emits skill lifecycle events.
         # Truncation auto-trigger flows through registry.truncate_wal_if_eligible
@@ -2810,6 +2841,15 @@ class Session:
             await self._journal.consume_inbox(msg_id=msg_id)
         return kind, payload
 
+    async def _stage_next_turn_context(self, kind: str, payload: dict) -> None:
+        """Stage a wake=false ride-along (C) into next-turn context, durably
+        (B=persist): append to the in-memory buffer + record the WAL/snapshot
+        entry. Shared by ``_drain_to_wake`` (inbox ride-alongs) and the
+        ``HookDispatcher`` (#1800 slice 5b — direct C-staging that bypasses the
+        inbox). Byte-behavior-identical extraction of the prior inline pair."""
+        self._next_turn_context.append({"kind": kind, "payload": payload})
+        await self._journal.record_next_turn_context_staged(kind=kind, payload=payload)
+
     async def _drain_to_wake(
         self,
     ) -> tuple[list[tuple[str, dict]], tuple[str, dict]] | tuple[None, None]:
@@ -2880,10 +2920,7 @@ class Session:
             # for the trigger.  This closes the gap: without this, a crash
             # in the blocking wait would lose the consumed-but-not-persisted
             # ride-along.
-            self._next_turn_context.append({"kind": kind0, "payload": p0})
-            await self._journal.record_next_turn_context_staged(
-                kind=kind0, payload=p0,
-            )
+            await self._stage_next_turn_context(kind0, p0)
             ride_alongs.append((kind0, p0))
 
             # Non-blocking drain: collect additional wake=false messages until
@@ -2912,12 +2949,7 @@ class Session:
 
                 # wake=false via non-blocking path: stage durably before
                 # accumulating (same B=persist guarantee as the outer path).
-                self._next_turn_context.append(
-                    {"kind": kind_nb, "payload": p_nb}
-                )
-                await self._journal.record_next_turn_context_staged(
-                    kind=kind_nb, payload=p_nb,
-                )
+                await self._stage_next_turn_context(kind_nb, p_nb)
                 ride_alongs.append((kind_nb, p_nb))
 
     def restore_state(self, snapshot: AgentSnapshot) -> None:
@@ -3059,6 +3091,12 @@ class Session:
             kind=kind,
             chain_id=payload.get("chain_id"),
         )
+        # #1800 slice 5b: turn_start lifecycle hooks.
+        await self._hook_dispatcher.dispatch(
+            "turn_start",
+            {"point": "turn_start", "agent_name": self.agent_name,
+             "kind": kind, "chain_id": payload.get("chain_id")},
+        )
         # ADR-0038 Stage 1c: busy until this turn settles (its WAL appends done).
         self._turn_idle.clear()
         try:
@@ -3082,6 +3120,13 @@ class Session:
                 # surface as an OS-originated message + one router turn so the LLM
                 # acts via ordinary task ops (P7 — no decision vocabulary).
                 await self._handle_task_wake(payload)
+            elif kind == "hook":  # HOOK_INBOX_KIND (#1800 slice 5b)
+                # E (wake=true) lifecycle-hook push delivered as a turn trigger:
+                # a system-role [hook:name] message + one router turn (self-
+                # continuation). The attribution + wake binding ride in the
+                # payload (race-free; the slice-7 valve can count hook-driven
+                # turns, and the audit trail attributes the turn to the hook).
+                await self._handle_hook_message(payload)
         finally:
             self._turn_idle.set()
         return True
@@ -3095,12 +3140,40 @@ class Session:
             chain_id=payload.get("chain_id") or _new_chain_id(),
         )
 
+    async def _handle_hook_message(self, payload: dict) -> None:
+        """#1800 slice 5b: surface an E (wake=true) lifecycle-hook push as one
+        router turn (self-continuation). The push is appended as an attributed
+        system-role ``[hook:name]`` message — a NEW message (fidelity: never a
+        silent mutation of an existing one) using the shared
+        ``_format_hook_attribution`` helper so C and E cannot drift — then a
+        single router turn runs."""
+        name = payload.get("name", "hook")
+        text = payload.get("text", "")
+        chain_id = payload.get("chain_id") or _new_chain_id()
+        self._append_history(ChatMessage(
+            role="system",
+            content=_format_hook_attribution(name, text),
+            ts=_now_iso(),
+            meta={"chain_id": chain_id},
+        ))
+        try:
+            await self._run_router_loop(text, chain_id)
+        except RouterCapExceeded as exc:
+            await self._emit_router_cap_exhausted_user(
+                exc, chain_id=chain_id, user_text=text,
+            )
+
     async def run(self) -> None:
         self._chat_events.emit("chat_started", agent_name=self.agent_name, model=self.model)
         # #1800 slice 5a: session lifecycle audit event (P6). Emitted alongside
         # chat_started; marks the boundary of the session's resource scope so
         # slice 5b can attach the session_start hook here.
         self._chat_events.emit("session_started", agent_name=self.agent_name)
+        # #1800 slice 5b: session_start lifecycle hooks.
+        await self._hook_dispatcher.dispatch(
+            "session_start",
+            {"point": "session_start", "agent_name": self.agent_name},
+        )
 
         # #1830 / FP-0052: warn if the startup model is above the cost threshold.
         # Fires once per session per model class (de-duped in maybe_emit_model_cost_warn).
@@ -3116,6 +3189,13 @@ class Session:
             # #1800 slice 5a: session lifecycle audit event (P6). Emitted alongside
             # chat_stopped; marks the end of the session's resource scope.
             self._chat_events.emit("session_completed", agent_name=self.agent_name)
+            # #1800 slice 5b: session_end lifecycle hooks (F's natural resource
+            # scope). The run-loop has exited, so an E push here is not drained
+            # (harmless); session_end is the C/F point in practice.
+            await self._hook_dispatcher.dispatch(
+                "session_end",
+                {"point": "session_end", "agent_name": self.agent_name},
+            )
             await self._put_outbox(OutboxMessage(kind="__end__", text=""))
 
     async def _drain_on_shutdown(self) -> None:
@@ -3198,7 +3278,7 @@ class Session:
                 hook_text = payload_data.get("text", "")
                 self._append_history(ChatMessage(
                     role="system",
-                    content=f"[hook:{hook_name}] {hook_text}",
+                    content=_format_hook_attribution(hook_name, hook_text),
                     ts=_now_iso(),
                 ))
             self._next_turn_context.clear()
@@ -4905,6 +4985,15 @@ class Session:
         # turn independent of which terminal path the loop took, and so the
         # chain_id (known to _run_router_loop) is in scope.
         self._chat_events.emit("turn_completed", chain_id=chain_id)
+        # #1800 slice 5b: turn_end lifecycle hooks. E (wake=true) self-continuation
+        # fires here — the hook pushes a wake=true trigger that the next
+        # run_one_iteration drains as a new turn (bounded by the slice-7 valve).
+        # C (stage) / F (shell) also fire.
+        await self._hook_dispatcher.dispatch(
+            "turn_end",
+            {"point": "turn_end", "agent_name": self.agent_name,
+             "chain_id": chain_id, "user_text": user_text},
+        )
         # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
         # user message is this checkpoint's anchor for the rewind-timeline preview.
         # #1533 2c: the FULL message is persisted alongside (edit-prefill source).

--- a/tests/test_hook_dispatcher_1800_5b.py
+++ b/tests/test_hook_dispatcher_1800_5b.py
@@ -1,0 +1,214 @@
+"""Tier 2: #1800 slice 5b — the awaited HookDispatcher.
+
+The dispatcher routes a lifecycle hook by type: push wake=true (E) → inbox
+trigger; push wake=false (C) → next-turn staging; shell (F) → run_shell. Per-hook
+isolation (a raising hook is skipped, siblings proceed) and the no-hooks no-op
+equivalence are the load-bearing safety properties.
+
+Policy (docs/deep-dives/contributing/testing.md):
+- Real Session / HookRegistry / HookDef / EventLog / StateLog. The dispatcher's
+  three Session seams are injected; the routing units use plain recording async
+  callables (real instances, NOT MagicMock/AsyncMock) — exactly the DI surface.
+- The Session-level tests use a real Session; only the LLM boundary
+  (_loop_driver.run_turn) is replaced with a plain async noop where a turn runs.
+- No private-state assertions; no format/shape pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef, PushBlock
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Recording async callables — real instances (not mocks) for the injected seams
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A real recording async callable. Captures (args, kwargs) per call; an
+    optional ``raises`` makes it throw (to exercise per-hook isolation)."""
+
+    def __init__(self, *, raises: BaseException | None = None) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+        self._raises = raises
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self._raises is not None:
+            raise self._raises
+
+    @property
+    def kinds(self) -> list:
+        """The first positional arg of each call (the inbox/stage kind, or the
+        shell command) — content for assertions instead of a len() pin."""
+        return [a[0] for (a, _k) in self.calls]
+
+
+def _dispatcher(hooks: list[HookDef], **seams) -> tuple[HookDispatcher, dict]:
+    """Build a HookDispatcher over ``hooks`` with recording seams (overridable)."""
+    seams.setdefault("put_inbox", _Recorder())
+    seams.setdefault("stage_next_turn_context", _Recorder())
+    seams.setdefault("run_shell", _Recorder())
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage_next_turn_context"],
+        run_shell=seams["run_shell"],
+    )
+    return disp, seams
+
+
+# ---------------------------------------------------------------------------
+# Routing units (recording seams)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_push_wake_true_routes_to_inbox_E():
+    """Tier 2: a push wake=true hook (E) routes to put_inbox as a turn trigger,
+    carrying the [hook:name] attribution + wake=True; C-staging is NOT used."""
+    hook = HookDef(on="turn_end", push=PushBlock(message="continue", wake=True))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_end", {})
+
+    assert seams["put_inbox"].kinds == ["hook"]
+    (args, _k), = seams["put_inbox"].calls
+    _kind, payload = args
+    assert payload["wake"] is True
+    assert payload["name"] == "turn_end"      # attribution = the lifecycle point
+    assert payload["text"] == "continue"
+    assert seams["stage_next_turn_context"].calls == []   # E never stages
+
+
+@pytest.mark.asyncio
+async def test_push_wake_false_routes_to_staging_C():
+    """Tier 2: a push wake=false hook (C) stages next-turn context directly (the
+    4b staging seam), NOT the inbox (a passive ride-along never triggers)."""
+    hook = HookDef(on="turn_start", push=PushBlock(message="ctx note", wake=False))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_start", {})
+
+    assert seams["stage_next_turn_context"].kinds == ["hook"]
+    (args, _k), = seams["stage_next_turn_context"].calls
+    _kind, payload = args
+    assert payload["name"] == "turn_start"
+    assert payload["text"] == "ctx note"
+    assert seams["put_inbox"].calls == []                 # C never triggers
+
+
+@pytest.mark.asyncio
+async def test_shell_routes_to_run_shell_F():
+    """Tier 2: a shell hook (F) invokes run_shell with the command + the event
+    context (the observable side-effect); no push paths are taken."""
+    hook = HookDef(on="session_start", shell="echo hi")
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("session_start", {"point": "session_start"})
+
+    assert seams["run_shell"].kinds == ["echo hi"]
+    (args, kwargs), = seams["run_shell"].calls
+    assert args[1] == {"point": "session_start"}          # event context forwarded
+    assert seams["put_inbox"].calls == []
+    assert seams["stage_next_turn_context"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_push_when_false_skips_the_push():
+    """Tier 2: push_when rendering to false skips the push entirely — neither the
+    inbox nor staging is touched (the conditional-push guard)."""
+    hook = HookDef(on="turn_end", push=PushBlock(message="x", push_when="false"))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_end", {})
+
+    assert seams["put_inbox"].calls == []
+    assert seams["stage_next_turn_context"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_throwing_hook_isolated_siblings_proceed():
+    """Tier 2: a raising hook is logged + skipped; its siblings still run and
+    dispatch() never propagates the exception (the per-hook isolation property)."""
+    raising = _Recorder(raises=RuntimeError("boom"))
+    hooks = [
+        HookDef(on="turn_end", shell="first"),    # this one raises
+        HookDef(on="turn_end", shell="second"),   # must still run
+    ]
+    disp, _seams = _dispatcher(hooks, run_shell=raising)
+
+    # must NOT raise out of dispatch()
+    await disp.dispatch("turn_end", {})
+
+    assert raising.kinds == ["first", "second"]   # sibling ran after the raise
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_dispatch_is_noop():
+    """Tier 2: an empty registry makes dispatch() a pure no-op — none of the three
+    seams is touched (the no-hooks equivalence property, dispatcher level)."""
+    disp, seams = _dispatcher([])
+
+    for point in ("session_start", "turn_start", "turn_end", "session_end"):
+        await disp.dispatch(point, {})
+
+    assert seams["put_inbox"].calls == []
+    assert seams["stage_next_turn_context"].calls == []
+    assert seams["run_shell"].calls == []
+
+
+# ---------------------------------------------------------------------------
+# Real-Session integration: no-hooks equivalence + config round-trip
+# ---------------------------------------------------------------------------
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return Session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_session_no_hooks_dispatch_is_noop(tmp_path):
+    """Tier 2: a real Session with no hooks_config → its dispatcher fires at every
+    lifecycle point as a no-op: nothing is pushed to the inbox and nothing is
+    staged (run-loop byte-identical to a hooks-free build)."""
+    session = _make_session(tmp_path, hooks_config=None)
+
+    for point in ("session_start", "turn_start", "turn_end", "session_end"):
+        await session._hook_dispatcher.dispatch(point, {})
+
+    # No E trigger pushed to the (public) inbox at any point — the no-op signal.
+    assert session.inbox.empty()
+
+
+@pytest.mark.asyncio
+async def test_real_session_config_roundtrip_E_reaches_inbox(tmp_path):
+    """Tier 2: a NON-DEFAULT hooks_config (a real wake=true hook) threads through
+    the production Session seam → load_hooks → the dispatcher → dispatch() pushes
+    the attributed [hook:name] message to the real Session inbox. Proves the
+    config→dispatcher→inbox path end-to-end on a real Session."""
+    hooks_config = [
+        {"on": "turn_end", "push": {"message": "self-continue", "wake": True}},
+    ]
+    session = _make_session(tmp_path, hooks_config=hooks_config)
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+
+    # The hook reaching the inbox proves the config parsed + loaded + dispatched
+    # (an unloaded hook would leave the inbox empty → get_nowait would raise).
+    kind, payload = session.inbox.get_nowait()
+    assert kind == "hook"
+    assert payload["wake"] is True
+    assert payload["text"] == "self-continue"
+    assert payload["name"] == "turn_end"


### PR DESCRIPTION
**[e2e-coder]** — #1800 slice 5b: the awaited **HookDispatcher** (the integration core of the agent-lifecycle-hook system). Impl-of-settled-design (the #1800 CONVERGED + RESOLVED comments); foundational slices A/B/C/4a/4b/5a all merged. skill/task points = 5c (deferred).

## What
The dispatcher is a first-class **`await`ed** dispatch at the lifecycle points (NOT an EventLog subscriber — it must `await` the inbox push / staging / shell). `async dispatch(point, vars)`:
- iterate `registry.hooks_for(point)` in registration order; **per-hook `try/except`** (a raising hook is logged + skipped; siblings + the point proceed; never propagates out).
- `render_push` resolves `push_when` (skip if false) + `wake`; branch by type:
  - **push wake=true (E)** → `_put_inbox(kind="hook", {name, text, wake=True})` — a turn trigger (self-continuation), routed to the new `_handle_hook_message`.
  - **push wake=false (C)** → `_stage_next_turn_context` (the 4b API), **not** the inbox (a passive ride-along never drains alone — Decision A).
  - **shell (F)** → `run_shell` (output ignored; backend resolved by `run_shell_hook`).

## Key design calls (your review axes)
1. **Constructor (DI, approved):** `HookDispatcher(registry, *, put_inbox, stage_next_turn_context, run_shell, sandbox_config, sandbox_backend)` — real bound Session methods, no MagicMock. `_stage_next_turn_context` is a **byte-behavior-identical extraction** of the `_drain_to_wake` append+record pair (4a/4b equivalence stays green — verified).
2. **Where hooks load:** `RootConfig.hooks` (raw `hooks:` block, mirror `sandbox`) → loader pass-through → `hooks_config` threaded into `Session.__init__` → `load_hooks` → registry → dispatcher. **None/absent → empty registry → every `dispatch()` is a no-op** (the equivalence property). Constructed unconditionally so the 4 wirings are uniform.
3. **E-routing = Option B** (per your steer): `kind=="hook"` inbox trigger + `_handle_hook_message` (mirror `_handle_skill_completed`) renders the **system-role** `[hook:name]` message + runs a turn. Binds E's content to its trigger (race-free; the slice-7 valve can count hook-driven turns) — vs Option A's fake `user` trigger which breaks the valve + races the staged-buffer clear. The `[hook:name]` formatter is **shared** by C (staged-context consumer) and E (one helper, can't drift).
   - *Follow-up (noted, non-blocking):* applying pending staged-C on E's own turn.

## Completeness follow-up (tracked, per your note)
`hooks_config` is threaded at the **live-exercised** entries (chat.py + dogfood.py) so there's a real production call-site + a round-trip test. The other 4 `sandbox_config` sites are a uniform one-liner each, deferred to a follow-up: `web/deps.py` · `chainlit/app.py` · `repl` · `mcp.py`.

## Tests (Tier 2, no mocks)
Routing units use real `HookDef`/`HookRegistry` + recording async seams (the DI surface); the Session tests use a **real Session** (LLM boundary unfaked — these don't run a turn). Cover: E→inbox, C→staging, F→run_shell, push_when→skip, throwing-hook isolated, empty-registry no-op, + a **real-Session config round-trip with a NON-DEFAULT hook** (config → dispatcher → inbox).

## Done gate (all three from repo root)
- [x] `ruff check` clean (all changed files)
- [x] `test_tier_audit.py --strict` → 8/8 OK
- [x] **Full `pytest`**: **8108 passed**, 4 failed. The 4 are `test_1800_hook_shell_runner` — **pre-existing full-suite event-loop ordering-pollution** (those tests use the deprecated manual `get_event_loop().run_until_complete`): they **pass in isolation**, my async tests don't pollute them, and **origin/main's full suite fails the identical 4** (verified via a clean worktree run: main = same 4). Pass-count delta 8108−8100 = my 8 new tests. My change adds **zero** new failures.

Refs #1800. Don't merge — your close review (construction-forwarding / `await` correctness / no-op equivalence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)