### PR TITLE
test(#1800): convert test_1800_hook_shell_runner off deprecated get_event_loop()

### DIFF
--- a/tests/test_1800_hook_shell_runner.py
+++ b/tests/test_1800_hook_shell_runner.py
@@ -21,7 +21,6 @@ Filesystem isolation: allowlist tests point at a tmp_path file so
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 from pathlib import Path
@@ -37,11 +36,6 @@ from reyn.security.sandbox import NoopBackend, SandboxPolicy
 # Python interpreter (same executable running pytest) — keeps tests hermetic
 # across venvs.
 _PY = sys.executable
-
-
-def _run(coro):
-    """Run a coroutine synchronously (avoids asyncio.run() in test bodies)."""
-    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 def _noop_backend() -> NoopBackend:
@@ -70,7 +64,8 @@ def test_run_shell_hook_exported_from_reyn_hooks() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_output_ignored_returns_none(
+@pytest.mark.asyncio
+async def test_output_ignored_returns_none(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tier 1: a command that writes JSON to stdout is NOT parsed as a push
@@ -89,15 +84,13 @@ def test_output_ignored_returns_none(
     )
     command = f"{_PY} -c \"{script}\""
 
-    result = _run(
-        run_shell_hook(
-            command,
-            event_context={"event": "turn_end"},
-            timeout_seconds=10,
-            sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(),
-            allowlist_path=allowlist,
-        )
+    result = await run_shell_hook(
+        command,
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=allowlist,
     )
 
     assert result is None
@@ -108,7 +101,8 @@ def test_output_ignored_returns_none(
 # ---------------------------------------------------------------------------
 
 
-def test_json_context_delivered_on_stdin(
+@pytest.mark.asyncio
+async def test_json_context_delivered_on_stdin(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tier 1: the hook subprocess receives event_context serialised as JSON on
@@ -130,15 +124,13 @@ def test_json_context_delivered_on_stdin(
     )
     command = f"{_PY} -c \"{script}\""
 
-    _run(
-        run_shell_hook(
-            command,
-            event_context={"event": "skill_end", "skill": "my-skill"},
-            timeout_seconds=10,
-            sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(),
-            allowlist_path=allowlist,
-        )
+    await run_shell_hook(
+        command,
+        event_context={"event": "skill_end", "skill": "my-skill"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=allowlist,
     )
 
     # The hook wrote the event name to the marker file — context was delivered.
@@ -151,7 +143,8 @@ def test_json_context_delivered_on_stdin(
 # ---------------------------------------------------------------------------
 
 
-def test_timeout_returns_none_no_crash(
+@pytest.mark.asyncio
+async def test_timeout_returns_none_no_crash(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tier 1: a command that sleeps past the timeout returns None and does not
@@ -165,15 +158,13 @@ def test_timeout_returns_none_no_crash(
     # sleep for 60 s but timeout is 1 s → times out.
     command = f"{_PY} -c \"import time; time.sleep(60)\""
 
-    result = _run(
-        run_shell_hook(
-            command,
-            event_context={"event": "session_end"},
-            timeout_seconds=1,
-            sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(timeout=1),
-            allowlist_path=allowlist,
-        )
+    result = await run_shell_hook(
+        command,
+        event_context={"event": "session_end"},
+        timeout_seconds=1,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(timeout=1),
+        allowlist_path=allowlist,
     )
 
     assert result is None
@@ -184,7 +175,8 @@ def test_timeout_returns_none_no_crash(
 # ---------------------------------------------------------------------------
 
 
-def test_nonapproved_command_nontty_refused(
+@pytest.mark.asyncio
+async def test_nonapproved_command_nontty_refused(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tier 1: a non-allowlisted command in a non-TTY environment without
@@ -203,15 +195,13 @@ def test_nonapproved_command_nontty_refused(
 
     command = f"{_PY} -c \"pass\""
 
-    result = _run(
-        run_shell_hook(
-            command,
-            event_context={"event": "session_start"},
-            timeout_seconds=10,
-            sandbox_backend=_noop_backend(),
-            sandbox_policy=_policy(),
-            allowlist_path=allowlist,
-        )
+    result = await run_shell_hook(
+        command,
+        event_context={"event": "session_start"},
+        timeout_seconds=10,
+        sandbox_backend=_noop_backend(),
+        sandbox_policy=_policy(),
+        allowlist_path=allowlist,
     )
 
     # Refused — fail-closed.


### PR DESCRIPTION
**[dogfood-coder]** — #2049-class test-robustness fix (settled mechanical, low-priority/non-blocking). No-merge — lead reviews.

## What

`tests/test_1800_hook_shell_runner.py` drove its 4 coroutine tests through a manual helper:

```python
def _run(coro):
    return asyncio.get_event_loop().run_until_complete(coro)
```

Converted those 4 to the house pattern (`@pytest.mark.asyncio async def` + `await`), mirroring `tests/test_hook_dispatcher_1800_5b.py` and #2049. Dropped the `_run` helper and the now-unused `import asyncio`. The 1 synchronous export-check test is unchanged. Net −10 lines (36 ins / 46 del).

## Why

`asyncio.get_event_loop()` is deprecated and fragile to event-loop state left by a prior test sharing the same (xdist) worker process. Depending on that prior state it either **warns** (`DeprecationWarning: There is no current event loop`, py3.12 — auto-creates a loop, test still passes) or returns a **closed loop** (`RuntimeError: Event loop is closed`, hard failure). The house `@pytest.mark.asyncio` fixture owns a fresh per-test loop and never calls `get_event_loop()`, eliminating both modes.

## Verify (primary evidence)

xdist installed locally so the full suite runs CI-faithfully (`-n auto`); py3.12.7.

| Run | Result |
|---|---|
| Isolation (`pytest tests/test_1800_hook_shell_runner.py`) | **5 passed** |
| Full `-n auto`, **old** code | this file passes but emits `test_1800_hook_shell_runner.py:44: DeprecationWarning: There is no current event loop` — **9 warnings** |
| Full `-n auto`, **new** code (clean env) | **exit 0 · 8093 passed · 0 failed**; this file clean (no warning, no failure) — **8 warnings** |
| `ruff check tests/test_1800_hook_shell_runner.py` + `ruff check src tests` | All checks passed |
| `python scripts/test_tier_audit.py --strict tests/test_1800_hook_shell_runner.py` | 5 inspected, 0 errors, 0 warnings |

The RED→GREEN delta is exactly the one shell_runner `DeprecationWarning` (9→8); the full suite is otherwise 0-failures.

## ⚠️ Honest note on the dispatch premise

On **py3.12 + my `-n auto` distribution**, the old pattern manifested as a **DeprecationWarning, not a hard failure** — shell_runner's tests were in the *passed* bucket. The hard-failure manifestation the dispatch described (`Event loop is closed`; also py3.13 where `get_event_loop()` *raises*, and any `filterwarnings=error`) is **distribution/env-dependent** — which is precisely why those failures are *spurious*. This conversion removes the deprecated call entirely, so it fixes the warning case *and* every failure case. (I verified warning-elimination + green gates, not a reproduced shell_runner hard-failure on this HEAD.)

## Note: my initial "4 unrelated failures" report was a LOCAL-ENV artifact (corrected)

While verifying I first saw 4 unrelated `-n auto` failures (gateway entry-points ×3 + `reyn.api.relocate[reyn.safe]` ×1) and flagged them as possibly pre-existing on `origin/main`. **That was wrong** — I traced all 4 to my own stale local env, none to `origin/main`:
- 3 gateway = stale editable-install entry-point metadata → fixed by `pip install -e .`.
- 1 `reyn.safe` = a pre-#311 `src/reyn/safe/` leftover containing only `.pyc` caches (untracked, not on `origin/main`), which made `import reyn.safe` resolve as a namespace package → broke the clean-break assertion. Fixed by removing the leftover.

After both, the full `-n auto` suite is **0 failures (8093 passed)**. `origin/main` is clean; there is no pre-existing failure set to chase.

## Test plan

- [x] Converted file passes in isolation (5 passed)
- [x] Full `-n auto` suite (clean env): exit 0, 8093 passed, 0 failed; this file's DeprecationWarning eliminated (9→8)
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean (5/5, 0 errors)

## Tier-rule self-check
- Docstrings: all 5 retain `Tier 1:` first line ✓
- Tier-4 violations: none (no `len()==N`, no format pins) ✓
- Invariant weakening: none — assertions byte-identical; only the loop driver changed ✓
- Mocks/private-state: none added ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
