### PR TITLE
feat(1800-7): the hook-driven-turn loop valve (bound self-continuation)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -399,6 +399,7 @@ safety:
     max_router_calls_per_turn: 3 # chat-router calls per user turn
     max_router_iterations: 5   # LLM tool-call iterations per user turn (CLI --max-iterations overrides)
     max_tool_calls_per_turn: 50 # max tool_calls honoured from ONE completion (cost-bound); 0 = unlimited
+    max_hook_driven_turns: 25  # #1800 loop valve: cap hook self-continuation; resets on user turn; 0 = unlimited
     max_agent_hops: 3          # maximum delegation depth
   timeout:
     llm_call_seconds: 60       # per-call HTTP timeout (--llm-timeout)
@@ -426,6 +427,7 @@ safety:
 | `safety.loop.max_router_calls_per_turn` | int | `3` | — | Chat-router invocations per user turn. `0` = unlimited. |
 | `safety.loop.max_router_iterations` | int | `5` | `--max-iterations` | Maximum LLM tool-call iterations per user turn. CLI `--max-iterations` overrides when provided; `reyn run-once` uses CLI default of 80. |
 | `safety.loop.max_tool_calls_per_turn` | int | `50` | — | Cost-bound: maximum `tool_calls` honoured from a SINGLE LLM completion. A degenerate completion can emit thousands (observed 3451); the OS processes only the first N, drops the overflow, and appends a re-grounding notice. `0` = unlimited. |
+| `safety.loop.max_hook_driven_turns` | int | `25` | — | #1800 loop valve: caps hook self-continuation. Each hook-originated (`kind="hook"`) turn counts 1; the counter resets on each human user turn. When the count would exceed the cap the next hook turn hits the `safety.on_limit` checkpoint (warn → ask_user → abort) instead of running — a backstop that does not obstruct intentional loop-engineering. `0` = unlimited. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
 | `safety.loop.skill_calls_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) spawn cap. `hard_limit` + `warn_ratio` sub-fields. Hybrid: loop-detection semantics, budget-style user approval on hit. |
 | `safety.loop.skill_tokens_per_chain` | map | `{}` (unlimited) | — | Per-(chain, skill) token cap. `hard_limit` + `warn_ratio` sub-fields. |

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -555,6 +555,7 @@
 #     max_router_calls_per_turn: 3
 #     max_router_iterations: 5  # max LLM tool-call iterations per user turn; CLI --max-iterations overrides
 #     max_tool_calls_per_turn: 50  # cost-bound: max tool_calls honoured from ONE completion; 0 = unlimited
+#     max_hook_driven_turns: 25  # #1800 loop valve: cap hook self-continuation per user turn; resets on user turn; 0 = unlimited
 #     max_agent_hops: 3
 #     # plan() tool call parse-error self-correction (B51 NF-W6-3). 0 = disable.
 #     plan_invalid_retries: 1

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -57,6 +57,17 @@ class LoopConfig:
             (un-executed, un-appended), and appends a single re-grounding notice.
             Default ``50`` is generous headroom over legitimate parallel tool use
             (observed < 10) yet ~70x below the runaway. ``0`` = unlimited.
+        max_hook_driven_turns:
+            #1800 slice 7: the loop valve. Caps hook self-continuation — an
+            ``E`` (wake=true) hook firing at ``turn_end`` triggers a new turn,
+            which can fire another, … This bounds that chain: each
+            hook-originated (``kind="hook"``) turn counts 1; the counter resets
+            on each human user turn (``kind="user"`` re-arms the budget). When
+            the count would exceed the cap the next hook turn hits the
+            ``safety.on_limit`` checkpoint (warn → ask_user → abort) instead of
+            running. A backstop only — does NOT obstruct intentional
+            loop-engineering (the operator raises the cap). Default ``25``
+            aligns with ``max_phase_visits``. ``0`` = unlimited.
     """
 
     max_act_turns_per_phase: int = 10
@@ -65,6 +76,7 @@ class LoopConfig:
     max_agent_hops: int = 3
     max_router_iterations: int = 5
     max_tool_calls_per_turn: int = 50
+    max_hook_driven_turns: int = 25
     skill_calls_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
     skill_tokens_per_chain: CostLimitConfig = field(default_factory=CostLimitConfig)
 
@@ -563,6 +575,9 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
         max_tool_calls_per_turn=int(loop_raw.get(
             "max_tool_calls_per_turn", loop_defaults.max_tool_calls_per_turn,
+        )),
+        max_hook_driven_turns=int(loop_raw.get(
+            "max_hook_driven_turns", loop_defaults.max_hook_driven_turns,
         )),
         skill_calls_per_chain=_build_cost_limit(
             loop_raw.get("skill_calls_per_chain")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1154,6 +1154,10 @@ class Session:
         # `_handle_limit_checkpoint`. Cleared on turn / chain boundary
         # by the relevant call sites.
         self._safety_extensions: dict[str, float] = {}
+        # #1800 slice 7: the loop-valve counter — hook-driven (kind="hook") turns
+        # since the last human user turn. In-memory only (NOT snapshot-persisted);
+        # resets on each user turn (re-arm). Bounds hook self-continuation.
+        self._hook_driven_turns: int = 0
         # PR15: optional skill allowlist sourced from profile.allowed_skills.
         # None = unrestricted (default, BC). Empty list = router runs but no
         # skill spawn. stdlib router/compactor are NOT subject to this — they're
@@ -3071,6 +3075,41 @@ class Session:
             # shutdown sentinel
             return False
         kind, payload = trigger
+        # #1800 slice 7: the loop valve. Bound hook self-continuation at the
+        # SINGLE seam — before any per-turn work (sender attribution / turn_started
+        # emit / turn_start dispatch / kind dispatch). A human user turn re-arms
+        # the budget; each hook-originated (kind="hook") turn increments it. When
+        # the count exceeds the effective cap, the on_limit checkpoint fires
+        # (warn → ask_user → abort); if it does not extend, the over-limit hook
+        # turn is SUPPRESSED ENTIRELY (no turn_started, no turn_start E-hook
+        # re-trigger that would circumvent the bound, no _handle_hook_message) and
+        # the run-loop returns — the session stays alive + idle for the next real
+        # trigger. Monotonic counter + finite cap + reset-on-user-turn ⇒ finite.
+        if kind == "user":
+            self._hook_driven_turns = 0
+        elif kind == "hook":
+            self._hook_driven_turns += 1
+            _base_cap = self._safety.loop.max_hook_driven_turns
+            if _base_cap > 0:
+                _cap = _base_cap + int(self._safety_extensions.get("hook_driven_turns", 0.0))
+                if self._hook_driven_turns > _cap:
+                    decision = await self._handle_chat_limit_checkpoint(
+                        kind="hook_driven_turns",
+                        prompt=(
+                            f"Hook self-continuation reached the cap of {_cap} "
+                            f"consecutive hook-driven turns. Allow more?"
+                        ),
+                        detail=f"count={self._hook_driven_turns} cap={_cap}",
+                        extension_amount=float(_base_cap),
+                    )
+                    if not decision.allow_continue:
+                        # Bound reached + not extended → suppress this hook turn.
+                        # The chain stops here; the session survives (idle).
+                        return True
+                    # allow_continue: the checkpoint accumulated the extension into
+                    # self._safety_extensions["hook_driven_turns"], raising the
+                    # effective cap so this + subsequent turns proceed until the
+                    # new bound (no re-prompt every turn).
         # FP-0041 (#489) PR-A: humanic dispatch attribution.
         # If this inbox item carries a ``sender`` (= new envelope
         # convention: who/what produced this message — e.g.

--- a/tests/test_hook_loop_valve_1800_7.py
+++ b/tests/test_hook_loop_valve_1800_7.py
@@ -1,0 +1,149 @@
+"""Tier 2: #1800 slice 7 — the hook-driven-turn loop valve.
+
+An E (wake=true) hook fires at turn_end → a new turn → which can fire another …
+The valve bounds that chain at the single seam (the top of run_one_iteration,
+before any per-turn work): each hook-originated (kind="hook") turn increments a
+counter; a human user turn resets it; over the cap the over-limit hook turn is
+suppressed after the on_limit checkpoint declines — the session stays alive/idle.
+
+Policy (docs/deep-dives/contributing/testing.md):
+- Real Session / EventLog / StateLog / SafetyConfig. Only the LLM boundary
+  (_loop_driver.run_turn) is replaced with a plain async recorder. No MagicMock.
+- The valve is driven by manual kind="hook" inbox triggers (isolating it from the
+  dispatcher); no hooks are configured, so dispatch() at turn_end is a no-op and
+  never injects extra triggers.
+- on_limit=unattended → the checkpoint denies deterministically (no bus). Events
+  observed via the public EventLog subscriber; no private-state assertions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+
+
+def _make_session(tmp_path: Path, *, cap: int) -> Session:
+    safety = SafetyConfig(
+        loop=LoopConfig(max_hook_driven_turns=cap),
+        on_limit=OnLimitConfig(mode="unattended"),   # deny deterministically, no bus
+    )
+    return Session(
+        agent_name="valve-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        safety=safety,
+    )
+
+
+def _fake_run_turn(session: Session) -> list[str]:
+    """Replace the LLM boundary with a recorder of the per-turn user_text. The
+    recorded texts are the observable proof of which turns actually ran."""
+    ran: list[str] = []
+
+    async def _noop(user_text: str, chain_id: str) -> None:
+        ran.append(user_text)
+
+    session._loop_driver.run_turn = _noop  # type: ignore[method-assign]
+    return ran
+
+
+def _collect_events(session: Session) -> list[dict]:
+    collected: list[dict] = []
+
+    def _sub(event) -> None:  # Event → flat dict (the house-style accessor)
+        collected.append({"type": event.type, **event.data})
+
+    session._chat_events.add_subscriber(_sub)
+    return collected
+
+
+def _checkpoint_kinds(events: list[dict]) -> list:
+    return [e.get("kind") for e in events if e["type"] == "safety_limit_checkpoint"]
+
+
+async def _push_hook(session: Session, text: str, *, wake: bool = True) -> None:
+    await session._put_inbox("hook", {"name": "turn_end", "text": text, "wake": wake})
+
+
+async def _push_user(session: Session, text: str) -> None:
+    await session._put_inbox("user", {"text": text, "wake": True, "chain_id": "c"})
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_hooks_valve_never_engages(tmp_path):
+    """Tier 2: with only human user turns (no hook triggers), the valve never
+    engages — every turn runs and no safety checkpoint fires (no-op equivalence
+    for the hooks-free path)."""
+    session = _make_session(tmp_path, cap=2)
+    ran = _fake_run_turn(session)
+    events = _collect_events(session)
+
+    await _push_user(session, "u1")
+    await _push_user(session, "u2")
+    await session.run_one_iteration()
+    await session.run_one_iteration()
+
+    assert ran == ["u1", "u2"]                     # both user turns ran
+    assert _checkpoint_kinds(events) == []         # valve never tripped
+
+
+@pytest.mark.asyncio
+async def test_hook_loop_exceeding_cap_is_suppressed(tmp_path):
+    """Tier 2: a hook chain exceeding the cap trips the checkpoint and the
+    over-limit hook turn is SUPPRESSED (does not run) — the chain stops, finite."""
+    session = _make_session(tmp_path, cap=2)
+    ran = _fake_run_turn(session)
+    events = _collect_events(session)
+
+    for text in ("h1", "h2", "h3"):
+        await _push_hook(session, text)
+    for _ in range(3):
+        await session.run_one_iteration()
+
+    # h1, h2 ran (count 1, 2 ≤ cap); h3 (count 3 > cap) suppressed.
+    assert ran == ["h1", "h2"]
+    assert "hook_driven_turns" in _checkpoint_kinds(events)   # valve trip evented
+
+
+@pytest.mark.asyncio
+async def test_counter_resets_on_user_turn(tmp_path):
+    """Tier 2: a human user turn re-arms the budget — a hook that would exceed the
+    cap runs after an intervening user turn resets the counter."""
+    session = _make_session(tmp_path, cap=1)
+    ran = _fake_run_turn(session)
+
+    await _push_hook(session, "h1")     # count 1 ≤ 1 → runs
+    await _push_user(session, "u1")     # resets the counter to 0
+    await _push_hook(session, "h2")     # count 1 again (NOT 2) → runs
+    for _ in range(3):
+        await session.run_one_iteration()
+
+    # without the reset, h2 would be count 2 > 1 → suppressed. Its presence proves
+    # the user turn re-armed the budget.
+    assert ran == ["h1", "u1", "h2"]
+
+
+@pytest.mark.asyncio
+async def test_c_ride_alongs_do_not_increment(tmp_path):
+    """Tier 2: a wake=false ride-along (C) drained alongside a trigger does NOT
+    count toward the valve — only the kind="hook" trigger does. With cap=1, a C
+    riding with the first hook leaves the first hook running (count 1, not 2)."""
+    session = _make_session(tmp_path, cap=1)
+    ran = _fake_run_turn(session)
+
+    await _push_hook(session, "c0", wake=False)   # a C ride-along (wake=false)
+    await _push_hook(session, "h1", wake=True)    # the trigger → count 1 ≤ 1 → runs
+    await _push_hook(session, "h2", wake=True)    # count 2 > 1 → suppressed
+    for _ in range(2):
+        await session.run_one_iteration()
+
+    # h1 ran ⇒ the wake=false C did NOT increment (else count would be 2 → h1
+    # suppressed). h2 suppressed by the cap.
+    assert ran == ["h1"]


### PR DESCRIPTION
**[e2e-coder]** — #1800 slice 7: the loop valve. Re-sequenced before slice 6 because my 5b shipped E-at-`turn_end` **unbounded** (a wake=true hook fires at turn_end → a new turn → which fires another …). This bounds that chain, **provably finite**. Safety-critical — your close review (counting / reset / checkpoint-integration).

## Design (your confirm + refinement)
- **Config:** `safety.loop.max_hook_driven_turns` (default **25**, aligns `max_phase_visits`; `0` = unlimited). Documented in the example + reference; **wired in the loader** (`_build_*` reads the key) — the schema-enforcement guard caught the missing read (a real round-trip gap; now `set 26 → reload 26`).
- **Counter:** a dedicated in-memory `Session._hook_driven_turns` (NOT the router-cap/budget counter — different semantics: persists across hook turns, resets on user turns). **Not snapshot-persisted** (per your (d) — avoids the disposition-map surface).
- **Counting point = your refinement:** the **single seam at the TOP of `run_one_iteration`**, right after the trigger is consumed, **before** `turn_started` / `turn_start` dispatch / kind dispatch. `kind=="user"` resets; `kind=="hook"` increments. Over the **effective cap** (base + `on_limit` auto-extensions) → `_handle_chat_limit_checkpoint`; on deny → early **`return True`** suppresses the ENTIRE over-limit hook turn (no orphan `turn_started`, no `turn_start` E-hook re-trigger circumventing the bound, no `_handle_hook_message`). Top placement bounds **all** hook-driven turns uniformly + fires the checkpoint once → loop idle.

## Verify points (all confirmed)
- **(a)** `kind` is a freeform machine-readable identifier (`safety.limit.<kind>` namespace) → `"hook_driven_turns"` routes cleanly.
- **(b)** the trip is **evented** (P6) via the checkpoint's existing `safety_limit_checkpoint` event.
- **(c)** ⚠️ deny ≠ session abort: `handle_limit_exceeded` **returns a `LimitDecision`, never raises/exits** — so deny → my `return True` skips the hook turn and the run-loop continues → **the session stays alive + idle** for the next real trigger. (vs router-cap's `raise`, which ends a turn.)
- **(d)** in-memory session attr, no snapshot-persist.

## Tests (Tier 2, no mocks; real Session, LLM boundary faked, valve driven by manual `kind="hook"` triggers)
- [x] (a) no hooks → valve never engages (no checkpoint)
- [x] (b) chain exceeding the cap → checkpoint fires + over-limit hook turn **suppressed**
- [x] (c) counter **resets on a user turn** (re-arm)
- [x] (d) wake=false **C ride-alongs don't increment** (only `kind="hook"` triggers do)

## Done gate (all three from repo root)
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` → 4/4 OK
- [x] **Full `pytest`: 8112 passed, 4 failed** — the 4 are `test_1800_hook_shell_runner` (the same **pre-existing** full-suite event-loop ordering-pollution from 5b, identical on `origin/main`). **0 non-shell-runner failures** — zero new failures.

Bounded-by-construction: monotonic counter + finite cap + reset-on-user-turn. Refs #1800. Don't merge — your close review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)