### PR TITLE
test: remove dead _run helper in test_mcp_client (uncalled deprecated event-loop)

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -147,10 +147,6 @@ def patched_sdk():
 # ── tests ────────────────────────────────────────────────────────────────────
 
 
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
-
-
 def test_http_transport_round_trip(patched_sdk):
     """Tier 1: framework boundary (intentional SDK patch) — verifies HTTP transport config
     is forwarded correctly to the mcp SDK and that call_tool returns a valid result."""


### PR DESCRIPTION
**[dogfood-coder]** — follow-up to #2060 (lead-dispatched dead-code cleanup). No-merge — lead fast-reviews.

## What
Removed the entirely-unused module-level `_run(coro)` helper in `tests/test_mcp_client.py` (4-line deletion).

## Why
Flagged on #2060 as a dead `if False` branch. On closer look the **whole helper is dead**, not just the branch:
- **Zero in-file call sites** — every test uses its own local `_run_it()` + `asyncio.run(_run_it())`. (The `_run` grep that first suggested usage was matching `_run_it` as a substring.)
- **No cross-file import** (`grep` for `test_mcp_client import` / `_run` across `tests/` + `src/` → none).
- Its body was `asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)` → the deprecated branch never ran *and* the function itself was never called.

So rather than simplify the body to `return asyncio.run(coro)` (which would leave a clean-but-still-dead helper), I removed the whole thing — better serves the no-dead-code intent. (Heads-up'd lead on this scope refinement before opening.)

## Verify
- `pytest tests/test_mcp_client.py` → **11 passed**.
- ruff (file + `src tests`) → All checks passed.
- `test_tier_audit.py --strict` → 11 inspected, 0 errors, 0 warnings.
- Behavior-preserving + zero references (no in-file call site, no cross-file import) → cannot affect any other test, so a full `-n auto` run is disproportionate for an uncalled-helper deletion. `asyncio` import retained (used by `asyncio.run` ×8).

## FYI (left alone, per lead)
Two files use `asyncio.get_event_loop().time()` — `test_1800_wake_drain.py:90/92`, `test_1800_c_staging.py:111/113`. Distinct, lower-impact deprecation (timing read, not a coroutine driver); not touched per lead's call.

## Test plan
- [x] `pytest tests/test_mcp_client.py` (11 passed)
- [x] `ruff check src tests` (clean)
- [x] `test_tier_audit.py --strict` (11 / 0 errors / 0 warnings)

## Tier-rule self-check
- Docstrings: untouched (no test bodies changed) ✓
- Tier-4 violations: none ✓
- Invariant weakening: none — pure dead-code deletion, no assertions touched ✓
- Mocks/private-state: none added ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
