### PR TITLE
feat(1800-6): per-hook [hook:name] attribution + fidelity

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -590,7 +590,8 @@ silently mutate tool results; pushes are new, attributed, evented messages.
 
 ```yaml
 hooks:
-  - on: turn_end                 # turn_start | turn_end | session_start | session_end
+  - name: next_step              # optional → the [hook:next_step] attribution (absent → the point)
+    on: turn_end                 # turn_start | turn_end | session_start | session_end
     push:
       message: "Turn complete — consider the next step."
       wake: false                # false = passive context (C); true = start a turn (E)
@@ -602,6 +603,7 @@ hooks:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `on` | string | _required_ | Lifecycle point: `turn_start`, `turn_end`, `session_start`, `session_end` (skill/task points land in a later slice). |
+| `name` | string | _the point_ | Optional operator label surfaced as the `[hook:<name>]` attribution prefix on a push. Absent → defaults to the hook-point (e.g. `[hook:turn_end]`). |
 | `push` | map | _none_ | Inbox-push hook (mutually exclusive with `shell`). `message` (Jinja2 → text), `wake` (bool/Jinja2, default `true`: `true` starts a new turn = self-continuation; `false` rides along with the next turn as passive context), `push_when` (Jinja2 → bool, default `true`; `false` skips). |
 | `shell` | string | _none_ | A shell command to run as a pure side-effect (mutually exclusive with `push`). Sandbox-gated + consent-allowlisted; stdout/stderr are logs, never parsed. |
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -712,7 +712,8 @@
 #   shell:     a command string (mutually exclusive with ``push``)
 # -----------------------------------------------------------------------------
 # hooks:
-#   - on: turn_end
+#   - name: next_step          # optional label → the [hook:next_step] attribution
+#     on: turn_end             #   (absent → defaults to the hook-point, e.g. [hook:turn_end])
 #     push:
 #       message: "Turn complete — consider the next step."
 #       wake: false

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -89,9 +89,10 @@ class HookDispatcher:
             resolved = render_push(hook.push, template_vars)
             if not resolved.push_when:
                 return  # conditional push guard (or a render failure — fail-safe)
-            # Attribution name: the lifecycle point (HookDef carries no separate
-            # name field). Consumed as the ``[hook:<name>]`` system-role prefix.
-            payload = {"name": point, "text": resolved.message}
+            # Attribution name (#1800 slice 6): the hook's operator label when
+            # set, else the lifecycle point (slice-5b default). Consumed as the
+            # ``[hook:<name>]`` system-role prefix (shared E + C renderer).
+            payload = {"name": hook.name or point, "text": resolved.message}
             if resolved.wake:
                 # E — a turn trigger (self-continuation). Routed to
                 # _handle_hook_message, which renders the system-role

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -172,8 +172,19 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
         )
     matcher: str | None = matcher_raw if matcher_raw else None
 
+    # ── name (optional, #1800 slice 6) — the [hook:name] attribution label; ──
+    # absent / blank → None (the dispatcher defaults it to the hook-point).
+    name_raw = raw.get("name", None)
+    if name_raw is not None and not isinstance(name_raw, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].name must be a string or null, "
+            f"got {type(name_raw).__name__!r}."
+        )
+    name: str | None = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else None
+
     return HookDef(
         on=on_key,
+        name=name,
         push=push_block,
         shell=shell,
         matcher=matcher,

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -101,6 +101,10 @@ class HookDef:
     ------
     on:
         Hook-point name — one of ``ALLOWED_HOOK_POINTS``.
+    name:
+        Optional operator label for the hook (#1800 slice 6). Surfaced as the
+        ``[hook:<name>]`` attribution prefix on a push. **Absent → the dispatcher
+        defaults it to the hook-point** (``on``), preserving slice-5b behavior.
     push:
         Inbox-push hook block.  Mutually exclusive with ``shell``.
     shell:
@@ -111,6 +115,7 @@ class HookDef:
     """
 
     on: str
+    name: str | None = field(default=None)
     push: PushBlock | None = field(default=None)
     shell: str | None = field(default=None)
     matcher: str | None = field(default=None)

--- a/tests/test_hook_attribution_1800_6.py
+++ b/tests/test_hook_attribution_1800_6.py
@@ -1,0 +1,159 @@
+"""Tier 2: #1800 slice 6 — per-hook ``[hook:name]`` attribution + fidelity.
+
+Slice 5b attributed every push as ``[hook:<point>]`` because the ``hooks:`` config
+was a nameless list. Slice 6 adds an OPTIONAL ``name`` to a hook entry; the
+dispatcher attributes with ``hook.name`` when set, else the lifecycle point
+(back-compat). The ``[hook:name]`` prefix is rendered by the single shared
+``_format_hook_attribution`` helper (centralized in 5b), so the E (inbox trigger)
+and C (staged ride-along) paths cannot drift.
+
+Fidelity: a push is an attributed NEW system-role message — never a silent
+mutation of existing history.
+
+Policy: real ``HookDef``/``HookRegistry``/``load_hooks`` + recording async seams
+for the dispatcher units; a real Session (LLM boundary faked) for the fidelity
+check. No MagicMock; Tier declared; unpack idiom.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.loader import load_hooks
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef, PushBlock
+from reyn.runtime.chat_message import ChatMessage, _now_iso
+from reyn.runtime.session import Session, _format_hook_attribution
+
+
+class _Recorder:
+    """A real recording async callable (the DI seam) — captures (args, kwargs)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def _dispatcher(hooks: list[HookDef]) -> tuple[HookDispatcher, dict]:
+    seams = {
+        "put_inbox": _Recorder(),
+        "stage_next_turn_context": _Recorder(),
+        "run_shell": _Recorder(),
+    }
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage_next_turn_context"],
+        run_shell=seams["run_shell"],
+    )
+    return disp, seams
+
+
+# --- loader -----------------------------------------------------------------
+
+
+def test_loader_captures_name_and_defaults_none():
+    """Tier 2: the loader captures an explicit ``name``; absent → ``None`` (the
+    dispatcher then defaults the attribution to the hook-point)."""
+    named = load_hooks([{"name": "my_cont", "on": "turn_end", "push": {"message": "x"}}])
+    assert named.hooks_for("turn_end")[0].name == "my_cont"
+    unnamed = load_hooks([{"on": "turn_end", "push": {"message": "x"}}])
+    assert unnamed.hooks_for("turn_end")[0].name is None
+
+
+def test_loader_rejects_non_string_name():
+    """Tier 2: a non-string ``name`` is a config error (mirrors the matcher
+    validation), not a silent coercion."""
+    from reyn.hooks.schema import HookConfigError
+
+    with pytest.raises(HookConfigError):
+        load_hooks([{"name": 123, "on": "turn_end", "push": {"message": "x"}}])
+
+
+# --- dispatcher attribution (named → name; unnamed → point) -----------------
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_uses_name_when_set():
+    """Tier 2: a named push hook attributes with the hook's ``name``."""
+    hook = HookDef(on="turn_end", name="my_cont", push=PushBlock(message="go", wake=True))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_end", {})
+
+    (args, _k), = seams["put_inbox"].calls
+    _kind, payload = args
+    assert payload["name"] == "my_cont"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_defaults_to_point_when_unnamed():
+    """Tier 2: an unnamed push hook defaults the attribution to the lifecycle
+    point — preserving slice-5b ``[hook:<point>]`` (back-compat)."""
+    hook = HookDef(on="turn_start", name=None, push=PushBlock(message="go", wake=False))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_start", {})
+
+    (args, _k), = seams["stage_next_turn_context"].calls
+    _kind, payload = args
+    assert payload["name"] == "turn_start"
+
+
+# --- shared renderer (E and C cannot drift) ---------------------------------
+
+
+def test_format_hook_attribution_brackets_the_name():
+    """Tier 2: the single shared renderer brackets the name as
+    ``[hook:<name>] <text>`` — used by BOTH the E ``_handle_hook_message`` and the
+    staged-C consumer, so the two paths render identically by construction."""
+    assert _format_hook_attribution("my_cont", "do it") == "[hook:my_cont] do it"
+    assert _format_hook_attribution("turn_end", "x") == "[hook:turn_end] x"
+
+
+# --- fidelity (E path, real Session) ----------------------------------------
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="attr-agent",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_E_hook_appends_named_system_message_preserving_history(tmp_path):
+    """Tier 2: fidelity — an E hook delivery appends a NEW system-role
+    ``[hook:name]`` message and leaves existing history byte-unchanged — a hook
+    can never silently mutate an existing message."""
+    session = _make_session(tmp_path)
+
+    async def _noop(user_text: str, chain_id: str) -> None:
+        pass
+
+    session._loop_driver.run_turn = _noop  # type: ignore[method-assign]
+
+    prior = ChatMessage(role="user", content="prior message", ts=_now_iso())
+    session._append_history(prior)
+    before = list(session.history)
+
+    await session._handle_hook_message(
+        {"name": "my_cont", "text": "continue", "chain_id": "c"},
+    )
+
+    # the pre-existing message is the SAME object, byte-unchanged (no mutation)
+    assert session.history[0] is before[0]
+    assert session.history[0].role == "user"
+    assert session.history[0].content == "prior message"
+    # a NEW system-role [hook:name] message was appended (added, not replaced)
+    appended = [m for m in session.history if m not in before]
+    assert any(
+        m.role == "system" and m.content == "[hook:my_cont] continue"
+        for m in appended
+    ), f"expected a [hook:my_cont] system message; got {[(m.role, m.content) for m in appended]}"


### PR DESCRIPTION
**[e2e-coder]** — #1800 slice 6: per-hook `[hook:name]` attribution + fidelity enforcement. Builds on 5b (which centralized the renderer → one change point). Your review, no-merge.

## What
Slice 5b attributed every push as `[hook:<point>]` (the `hooks:` config was a nameless list). Slice 6 adds an **optional operator label**:
- **schema:** `HookDef.name` (`str | None`, default `None`).
- **loader:** parse `name` (mirrors the optional `matcher`; non-string → `HookConfigError`; blank → `None`).
- **dispatcher:** attribute the push payload with **`hook.name or point`** — named → `[hook:<name>]`, unnamed → `[hook:<point>]` (**slice-5b back-compat by construction**).
- The `[hook:name]` prefix is rendered by the single shared `_format_hook_attribution` helper (centralized in 5b), so the **E** (`_handle_hook_message`) and **C** (staged consumer) paths render identically — one change point, can't drift.
- **docs:** `name` documented in `reyn.local.yaml.example` + `reyn-yaml.md` (example + table row).

## Fidelity
A push is an attributed **NEW system-role** message — never a silent mutation of existing history. The fidelity test asserts the pre-existing message is the **same object, byte-unchanged**, and a new `[hook:name]` system message is **added** (not replaced).

## Tests (Tier 2, no mocks)
Real `HookDef`/`HookRegistry`/`load_hooks` + recording async seams for the dispatcher units; a real Session (LLM boundary faked) for fidelity. Cover: loader captures name / defaults None / rejects non-string; dispatcher named→name, unnamed→point; the shared renderer brackets `[hook:name]`; the fidelity invariant.

## Done gate (all three, repo root)
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` → 6/6 OK
- [x] **Full `pytest`: 8122 passed, 0 failed** (clean — the #2060 + #2062 fixes cleared the prior pre-existing failures; `--timeout`-guarded so any future hang fail-names fast)

Refs #1800. After this: slice 5c (skill/task hook points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)