### PR TITLE
feat(1800-5c): skill/task lifecycle hook points (the last #1800 hook slice)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -591,7 +591,7 @@ silently mutate tool results; pushes are new, attributed, evented messages.
 ```yaml
 hooks:
   - name: next_step              # optional → the [hook:next_step] attribution (absent → the point)
-    on: turn_end                 # turn_start | turn_end | session_start | session_end
+    on: turn_end                 # turn_start|turn_end|session_start|session_end|skill_start|skill_end|task_start|task_end
     push:
       message: "Turn complete — consider the next step."
       wake: false                # false = passive context (C); true = start a turn (E)
@@ -602,7 +602,7 @@ hooks:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `on` | string | _required_ | Lifecycle point: `turn_start`, `turn_end`, `session_start`, `session_end` (skill/task points land in a later slice). |
+| `on` | string | _required_ | Lifecycle point: `turn_start`, `turn_end`, `session_start`, `session_end`, `skill_start`, `skill_end`, `task_start`, `task_end`. |
 | `name` | string | _the point_ | Optional operator label surfaced as the `[hook:<name>]` attribution prefix on a push. Absent → defaults to the hook-point (e.g. `[hook:turn_end]`). |
 | `push` | map | _none_ | Inbox-push hook (mutually exclusive with `shell`). `message` (Jinja2 → text), `wake` (bool/Jinja2, default `true`: `true` starts a new turn = self-continuation; `false` rides along with the next turn as passive context), `push_when` (Jinja2 → bool, default `true`; `false` skips). |
 | `shell` | string | _none_ | A shell command to run as a pure side-effect (mutually exclusive with `push`). Sandbox-gated + consent-allowlisted; stdout/stderr are logs, never parsed. |

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -703,8 +703,8 @@
 # and is EITHER a ``push`` (inject an attributed ``[hook:<point>]`` message) OR a
 # ``shell`` (run an external command, sandbox-gated, output ignored).
 #
-#   on:        turn_start | turn_end | session_start | session_end
-#              (skill_*/task_* points land in a later slice)
+#   on:        turn_start | turn_end | session_start | session_end |
+#              skill_start | skill_end | task_start | task_end
 #   push:      message:   Jinja2 template → the message text
 #              wake:      true  → start a new turn (self-continuation)   [default]
 #                         false → ride along with the next turn (passive context)

--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -142,6 +142,7 @@ class ControlIRExecutor:
         sandbox_backend: "SandboxBackend | None" = None,
         task_backend: Any = None,  # #1953 slice 3a: session-scoped Task backend instance
         task_waker: Any = None,  # #1953 slice 7: the OS TaskWaker driver
+        hook_dispatcher: Any = None,  # #1800 slice 5c: the HookDispatcher
         session_id: Any = None,  # #1953 slice 3: caller session identity (single-writer key)
         multimodal_config: "MultimodalConfig | None" = None,
         media_store: "MediaStore | None" = None,
@@ -188,6 +189,7 @@ class ControlIRExecutor:
         self._contextual_permission = contextual_permission  # #1912b
         self._task_backend = task_backend  # #1953 slice 3a
         self._task_waker = task_waker  # #1953 slice 7
+        self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c
         self._task_session_id = session_id  # #1953 slice 3
         # FP-0008 #1115 Stage 2: per-run injected exec backend instance. When
         # set (a dual-Protocol container backend), it takes precedence over
@@ -506,6 +508,7 @@ class ControlIRExecutor:
             task_backend=self._task_backend,
             # #1953 slice 7: the OS TaskWaker (abort/failed/ready → session wake).
             task_waker=self._task_waker,
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
             # #1953 slice 3: caller session identity (Task single-writer key).
             session_id=self._task_session_id,
             # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy

--- a/src/reyn/core/kernel/preprocessor_executor.py
+++ b/src/reyn/core/kernel/preprocessor_executor.py
@@ -116,6 +116,7 @@ class PreprocessorExecutor:
         contextual_permission: "object | None" = None,  # #1912b: per-session capability narrowing → run_op/iterate gate
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend
         task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver
+        hook_dispatcher: "object | None" = None,  # #1800 slice 5c: the HookDispatcher
         session_id: "str | None" = None,  # #1953 slice 3: caller session identity (single-writer key)
     ) -> None:
         self._skill = skill
@@ -150,6 +151,7 @@ class PreprocessorExecutor:
         self._contextual_permission = contextual_permission  # #1912b
         self._task_backend = task_backend  # #1953 slice 3a
         self._task_waker = task_waker  # #1953 slice 7
+        self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c
         self._task_session_id = session_id  # #1953 slice 3
 
     @property
@@ -199,6 +201,7 @@ class PreprocessorExecutor:
             contextual_permission=self._contextual_permission,  # #1912b
             task_backend=self._task_backend,  # #1953 slice 3a
             task_waker=self._task_waker,  # #1953 slice 7
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
             session_id=self._task_session_id,  # #1953 slice 3
         )
 

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -81,6 +81,7 @@ class OSRuntime:
         contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase RouterLoop + control-IR gates
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend → control-IR + preprocessor op gates
         task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker → control-IR + preprocessor op ctx
+        hook_dispatcher: "object | None" = None,  # #1800 slice 5c: HookDispatcher → control-IR + preprocessor op ctx
         task_session_id: "str | None" = None,  # #1953 slice 3: caller session identity (Task single-writer key)
         router_config: "object | None" = None,  # #1829 S3b: reyn.yaml llm.router.*
         retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.*
@@ -235,6 +236,7 @@ class OSRuntime:
             contextual_permission=contextual_permission,  # #1912b: control-IR op gate
             task_backend=task_backend,  # #1953 slice 3a
             task_waker=task_waker,  # #1953 slice 7
+            hook_dispatcher=hook_dispatcher,  # #1800 slice 5c
             session_id=task_session_id,  # #1953 slice 3
             sandbox_backend=sandbox_backend,
             multimodal_config=multimodal_config,
@@ -262,6 +264,7 @@ class OSRuntime:
             contextual_permission=contextual_permission,  # #1912b: preprocessor run_op/iterate gate
             task_backend=task_backend,  # #1953 slice 3a
             task_waker=task_waker,  # #1953 slice 7
+            hook_dispatcher=hook_dispatcher,  # #1800 slice 5c
             session_id=task_session_id,  # #1953 slice 3
         )
         # FP-0020 Component A: all mutable run-scope state encapsulated in RunState.

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -191,6 +191,14 @@ class OpContext:
     # inject a recording waker to verify the call-site fires.
     task_waker: "object | None" = None
 
+    # #1800 slice 5c: the awaited HookDispatcher (the Session's instance, with the
+    # loaded hooks registry + the _put_inbox/_stage/_run_shell seams from 5b),
+    # threaded down the SAME Session → router / kernel chain as task_waker. The
+    # task op handlers (_create → task_start, _update_status→COMPLETED → task_end)
+    # call ``ctx.hook_dispatcher.dispatch(...)``. None = no-op (direct/test
+    # construction or no hooks) → the dispatch site is skipped.
+    hook_dispatcher: "object | None" = None
+
     # #1953 slice 3 (rework): the caller's session identity (#1814 per-contextId
     # routing-key ``Session._session_id``), threaded down the same chain. This is
     # the single-writer key for Task ``update_status`` — the backend CAS-rejects

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -214,6 +214,16 @@ async def _create(op, ctx: OpContext, caller) -> dict:
             and created.assignee != created.requester):
         await waker.wake_assigned(
             created, fenced_description=_fence_text(ctx, created.description))
+    # #1800 slice 5c: task_start lifecycle hooks — the task has been created
+    # (backend.create + the P6 audit). None dispatcher (direct/test construction
+    # or no hooks) → no-op.
+    hook_dispatcher = getattr(ctx, "hook_dispatcher", None)
+    if hook_dispatcher is not None:
+        await hook_dispatcher.dispatch(
+            "task_start",
+            {"point": "task_start", "task_id": created.task_id,
+             "name": created.name, "assignee": created.assignee},
+        )
     return _ok("task.create", task=created.to_dict())
 
 
@@ -247,6 +257,15 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
             if waker is not None:
                 await waker.wake_ready_dependent(
                     p, fenced_description=_fence_text(ctx, p.description))
+        # #1800 slice 5c: task_end lifecycle hooks — the task reached COMPLETED.
+        # None dispatcher → no-op. (Aborted tasks terminate via the separate
+        # _abort handler — see the task_end symmetry note there.)
+        hook_dispatcher = getattr(ctx, "hook_dispatcher", None)
+        if hook_dispatcher is not None:
+            await hook_dispatcher.dispatch(
+                "task_end",
+                {"point": "task_end", "task_id": task.task_id, "status": "completed"},
+            )
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
         # doesn't satisfy a dependency edge → route the disposition to the parent's
@@ -421,6 +440,18 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
     # dependent gets a recovery decision (the OQ-7/H5 gap-close). The cascade's
     # descendants have an in-subtree (now terminal) parent → the guard skips them.
     await _route_terminal_to_parent(ctx, _backend(ctx), root, disposition="aborted")
+    # #1800 slice 5c: task_end lifecycle hooks for the aborted sub-tree — SYMMETRIC
+    # with task_start (at create) + task_end (at COMPLETED): every started task
+    # fires an end. ``status="aborted"`` lets an operator discriminate completion
+    # from abort. Mirrors the task_disposition loop above (one per aborted task).
+    # None dispatcher → no-op.
+    hook_dispatcher = getattr(ctx, "hook_dispatcher", None)
+    if hook_dispatcher is not None:
+        for t in aborted:
+            await hook_dispatcher.dispatch(
+                "task_end",
+                {"point": "task_end", "task_id": t.task_id, "status": "aborted"},
+            )
     return _ok("task.abort", task=root.to_dict())
 
 

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -68,6 +68,7 @@ def build_router_op_context(
     # CAS (the no-bypass-by-construction invariant requires the REAL session_id).
     session_id: str | None = None,
     task_backend: Any = None,
+    hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -147,4 +148,5 @@ def build_router_op_context(
         # gate enforces byte-equal to the phase path (no None-placeholder mask).
         session_id=session_id,
         task_backend=task_backend,
+        hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -148,6 +148,7 @@ class RouterHostAdapter:
         # ops hit the SAME assignee/requester gate as the phase path (no None mask).
         session_id: str | None = None,
         task_backend: Any = None,
+        hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator configured
         # ``action_retrieval.embedding_class`` AND Session built a
@@ -274,6 +275,7 @@ class RouterHostAdapter:
         self._contextual_permission = contextual_permission
         self._session_id = session_id  # #1953 dynamic-wire: task.* CAS gate key
         self._task_backend = task_backend  # #1953 dynamic-wire: session-scoped Task backend
+        self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c: task_start/end dispatch
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
@@ -1533,6 +1535,7 @@ class RouterHostAdapter:
             # task.* CAS gate enforces (no None-placeholder mask-pass).
             session_id=self._session_id,
             task_backend=self._task_backend,
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1502,6 +1502,7 @@ class Session:
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
             session_id=self._session_id,
             task_backend=self._task_backend,
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: task_start/end (router path)
             agent_name=self.agent_name,
             agent_role=self._agent_role,
             output_language=self.output_language,
@@ -3496,6 +3497,7 @@ class Session:
                 state_log=self._state_log,
                 truncate_eligible_hook=hook,
                 session_id=self._session_id,  # FP-0043 S5: per-session WAL routing
+                hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: skill_start/end
             )
         return self._skill_registry
 
@@ -3525,6 +3527,7 @@ class Session:
             task_backend=self._task_backend,  # #1953 slice 3a: session-scoped Task backend
             task_waker=self._task_waker,  # #1953 slice 7: the OS TaskWaker driver
             task_session_id=self._session_id,  # #1953 slice 3: caller session identity (single-writer key)
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: task_start/end (phase path)
             mcp_servers=mcp_servers,
             intervention_bus=intervention_bus,
             subscribers=subscribers,
@@ -4752,6 +4755,7 @@ class Session:
             ),
             agent_id=self._agent_id,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -60,6 +60,7 @@ class SkillRegistry:
         state_log: "StateLog | None" = None,
         truncate_eligible_hook: Callable[[], Awaitable[None]] | None = None,
         session_id: str = "main",
+        hook_dispatcher: "object | None" = None,
     ) -> None:
         """
         truncate_eligible_hook: optional async callback fired *after* each
@@ -83,6 +84,10 @@ class SkillRegistry:
         self._skills_dir = self._state_dir / "skills"
         self._state_log = state_log
         self._truncate_hook = truncate_eligible_hook
+        # #1800 slice 5c: the Session's HookDispatcher (threaded in by the Session
+        # that owns this registry). start() → skill_start, complete() → skill_end.
+        # None = no dispatcher (direct/test construction or no hooks) → no-op.
+        self._hook_dispatcher = hook_dispatcher
         # In-memory cache: run_id → SkillSnapshot. Populated on start() /
         # load_active(); cleared on complete().
         self._snapshots: dict[str, SkillSnapshot] = {}
@@ -180,6 +185,14 @@ class SkillRegistry:
             snap.last_phase_applied_seq = seq
         self._save(snap)
         self._snapshots[run_id] = snap
+        # #1800 slice 5c: skill_start lifecycle hooks — fired AFTER the
+        # skill_started WAL event (mirrors 5b's emit-then-dispatch). None
+        # dispatcher (direct/test construction or no hooks) → no-op.
+        if self._hook_dispatcher is not None:
+            await self._hook_dispatcher.dispatch(
+                "skill_start",
+                {"point": "skill_start", "run_id": run_id, "skill_name": skill_name},
+            )
         return snap
 
     async def advance_phase(
@@ -260,6 +273,18 @@ class SkillRegistry:
                 target=self._agent_name,
                 agent=self._agent_name,
                 run_id=run_id,
+            )
+        # #1800 slice 5c: skill_end lifecycle hooks — after the skill_completed /
+        # skill_discarded WAL event, BEFORE the snapshot teardown so the ctx is
+        # valid. None dispatcher → no-op. NOTE: an interrupted/errored skill run
+        # emits ``skill_run_interrupted`` and BYPASSES complete() (run_orchestrator),
+        # so skill_end fires for success / discarded / WorkflowAborted only — the
+        # interrupt-branch asymmetry is a tracked 5c follow-up (firing skill_end
+        # there needs the dispatcher at the orchestrator branch, a broader change).
+        if self._hook_dispatcher is not None:
+            await self._hook_dispatcher.dispatch(
+                "skill_end",
+                {"point": "skill_end", "run_id": run_id, "status": status},
             )
         snap_path = self._skills_dir / f"{run_id}.snapshot.json"
         try:

--- a/src/reyn/skill/skill_runtime.py
+++ b/src/reyn/skill/skill_runtime.py
@@ -56,6 +56,7 @@ class SkillRuntime:
         contextual_permission: "object | None" = None,  # #1912: per-session capability narrowing → phase/control-IR gates (None = byte-identical)
         task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend
         task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver
+        hook_dispatcher: "object | None" = None,  # #1800 slice 5c: task_start/end (phase path)
         task_session_id: "str | None" = None,  # #1953 slice 3: caller session identity (Task single-writer key)
         mcp_servers: dict | None = None,
         python_allowed_modules: list[str] | None = None,
@@ -99,6 +100,7 @@ class SkillRuntime:
         self._contextual_permission = contextual_permission
         self._task_backend = task_backend  # #1953 slice 3a
         self._task_waker = task_waker  # #1953 slice 7
+        self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c
         self._task_session_id = task_session_id  # #1953 slice 3
         self._resolver = resolver or ModelResolver({})
         self._permission_resolver = permission_resolver
@@ -325,6 +327,7 @@ class SkillRuntime:
             contextual_permission=self._contextual_permission,  # #1912
             task_backend=self._task_backend,  # #1953 slice 3a
             task_waker=self._task_waker,  # #1953 slice 7
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
             task_session_id=self._task_session_id,  # #1953 slice 3
 
             environment_backend=self._environment_backend,

--- a/tests/test_hook_skill_task_points_1800_5c.py
+++ b/tests/test_hook_skill_task_points_1800_5c.py
@@ -22,9 +22,14 @@ from types import SimpleNamespace
 
 import pytest
 
+from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
+from reyn.core.kernel.control_ir_executor import ControlIRExecutor
+from reyn.core.kernel.preprocessor_executor import PreprocessorExecutor
 from reyn.core.op_runtime import task as taskmod
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.session import Session
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.skill.skill_registry import SkillRegistry
 from reyn.task import InMemoryTaskBackend
 
@@ -169,3 +174,38 @@ def test_session_router_op_contexts_carry_the_live_dispatcher(tmp_path):
     assert isinstance(direct.hook_dispatcher, HookDispatcher)
     # …and it is the SAME single instance on both router flows (no flow misses it).
     assert direct.hook_dispatcher is via_adapter.hook_dispatcher
+
+
+# --- live threading: the PHASE path (kernel chain) forwards to OpContext -----
+# Mirror tests/test_task_backend_threading_1953.py (the established ctx-build seam
+# completeness gate) so a refactor dropping hook_dispatcher on the phase leg —
+# silently disabling task_start/end in phases — is caught (RED), not just traced.
+
+
+def test_control_ir_executor_threads_hook_dispatcher_to_opcontext():
+    """Tier 2: ControlIRExecutor._build_ctx propagates hook_dispatcher to the
+    OpContext (the control-IR leg of the phase-path forwarding)."""
+    events = EventLog()
+    ws = Workspace(events=events)
+    sentinel = object()
+    ex = ControlIRExecutor(
+        workspace=ws, events=events, permission_resolver=None,
+        skill_name="s", chain_id="c", hook_dispatcher=sentinel,
+    )
+    ctx = ex._build_ctx(PermissionDecl(), "phase-1")
+    assert ctx.hook_dispatcher is sentinel
+
+
+def test_preprocessor_executor_threads_hook_dispatcher_to_opcontext():
+    """Tier 2: PreprocessorExecutor._build_op_ctx propagates hook_dispatcher to
+    the OpContext (the preprocessor leg — the phase path's second ctx-build seam)."""
+    events = EventLog()
+    ws = Workspace(events=events)
+    sentinel = object()
+    skill = SimpleNamespace(name="s", permissions=PermissionDecl())
+    ex = PreprocessorExecutor(
+        skill=skill, workspace=ws, model="standard", events=events,
+        subscribers=[], resolver=SimpleNamespace(), hook_dispatcher=sentinel,
+    )
+    ctx = ex._build_op_ctx(SimpleNamespace(name="phase-1"), 0)
+    assert ctx.hook_dispatcher is sentinel

--- a/tests/test_hook_skill_task_points_1800_5c.py
+++ b/tests/test_hook_skill_task_points_1800_5c.py
@@ -1,0 +1,171 @@
+"""Tier 2: #1800 slice 5c — skill/task lifecycle hook points + live threading.
+
+5b wired the 4 session/turn points. 5c wires the remaining 4 — skill_start/end,
+task_start/end — at the async execution points (SkillRegistry.start/complete;
+op_runtime/task.py _create / _update_status→COMPLETED / _abort). Those points are
+NOT in Session, so the Session's HookDispatcher is THREADED into them (SkillRegistry
+ctor; OpContext via the shared build_router_op_context + the kernel chain).
+
+The construction-forwarding axis (lead): the dispatch must fire on the REAL
+execution path with the LIVE instance — not a None no-op. So these tests run the
+actual SkillRegistry/task-op code with a threaded recording dispatcher (the real
+path fires it), and prove the Session forwards its live instance into the router
+OpContext (both callers).
+
+No MagicMock: real SkillRegistry / InMemoryTaskBackend / Session + a recording
+dispatcher (a real instance, the injected seam). Tier declared; unpack idiom.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.session import Session
+from reyn.skill.skill_registry import SkillRegistry
+from reyn.task import InMemoryTaskBackend
+
+
+class _RecordingDispatcher:
+    """A real recording HookDispatcher stand-in (the injected seam) — records each
+    dispatch(point, vars)."""
+
+    def __init__(self) -> None:
+        self.dispatched: list[tuple[str, dict]] = []
+
+    async def dispatch(self, point: str, template_vars: dict) -> None:
+        self.dispatched.append((point, template_vars))
+
+    @property
+    def points(self) -> list[str]:
+        return [p for (p, _v) in self.dispatched]
+
+
+def _task_ctx(backend, dispatcher, *, session: str = "sess") -> SimpleNamespace:
+    return SimpleNamespace(
+        task_backend=backend, session_id=session, agent_id="a", events=None,
+        task_waker=None, threat_scan=None, hook_dispatcher=dispatcher,
+    )
+
+
+# --- skill points (real SkillRegistry) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skill_registry_start_and_complete_fire_points(tmp_path):
+    """Tier 2: a real SkillRegistry.start fires skill_start and .complete fires
+    skill_end via the threaded dispatcher (the real execution path)."""
+    rec = _RecordingDispatcher()
+    reg = SkillRegistry(
+        agent_name="a", agent_state_dir=tmp_path, state_log=None, hook_dispatcher=rec,
+    )
+
+    await reg.start(run_id="r1", skill_name="my_skill", skill_input={})
+    await reg.complete(run_id="r1")
+
+    assert rec.points == ["skill_start", "skill_end"]
+    # ctx carries the run/skill identity for templates
+    (_p0, start_vars), (_p1, end_vars) = rec.dispatched
+    assert start_vars["run_id"] == "r1" and start_vars["skill_name"] == "my_skill"
+    assert end_vars["run_id"] == "r1" and end_vars["status"] == "completed"
+
+
+# --- task points (real op_runtime/task.py via OpContext) --------------------
+
+
+@pytest.mark.asyncio
+async def test_task_create_fires_task_start():
+    """Tier 2: a real _create fires task_start via ctx.hook_dispatcher."""
+    rec = _RecordingDispatcher()
+    ctx = _task_ctx(InMemoryTaskBackend(), rec)
+    await taskmod._create(
+        SimpleNamespace(name="t", assignee="sess", requester="sess",
+                        origin="self", description="d", deps=[]),
+        ctx, "control_ir",
+    )
+    assert "task_start" in rec.points
+
+
+@pytest.mark.asyncio
+async def test_task_update_status_completed_fires_task_end():
+    """Tier 2: a real _update_status → COMPLETED fires task_end (status completed)."""
+    rec = _RecordingDispatcher()
+    backend = InMemoryTaskBackend()
+    ctx = _task_ctx(backend, rec)
+    created = await taskmod._create(
+        SimpleNamespace(name="t", assignee="sess", requester="sess",
+                        origin="self", description="d", deps=[]),
+        ctx, "control_ir",
+    )
+    tid = created["task"]["task_id"]
+
+    await taskmod._update_status(
+        SimpleNamespace(task_id=tid, status="completed"), ctx, "control_ir")
+
+    end = [(p, v) for (p, v) in rec.dispatched if p == "task_end"]
+    assert end and end[-1][1]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_task_abort_fires_task_end_aborted():
+    """Tier 2: a real _abort fires task_end with status=aborted (symmetric with
+    create→task_start, for every started task in the aborted sub-tree)."""
+    rec = _RecordingDispatcher()
+    backend = InMemoryTaskBackend()
+    ctx = _task_ctx(backend, rec)
+    created = await taskmod._create(
+        SimpleNamespace(name="t", assignee="sess", requester="sess",
+                        origin="self", description="d", deps=[]),
+        ctx, "control_ir",
+    )
+    tid = created["task"]["task_id"]
+
+    await taskmod._abort(SimpleNamespace(task_id=tid, reason="done"), ctx, "control_ir")
+
+    aborted_ends = [v for (p, v) in rec.dispatched if p == "task_end" and v["status"] == "aborted"]
+    assert any(v["task_id"] == tid for v in aborted_ends)
+
+
+@pytest.mark.asyncio
+async def test_no_dispatcher_is_noop():
+    """Tier 2: a None dispatcher on the ctx → the task op runs, no dispatch, no
+    error (the no-op equivalence at the dispatch sites)."""
+    ctx = _task_ctx(InMemoryTaskBackend(), None)
+    res = await taskmod._create(
+        SimpleNamespace(name="t", assignee="sess", requester="sess",
+                        origin="self", description="d", deps=[]),
+        ctx, "control_ir",
+    )
+    assert res["status"] == "ok"
+
+
+# --- live threading: the Session forwards its instance into the router OpContext
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="fwd-agent",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+
+def test_session_router_op_contexts_carry_the_live_dispatcher(tmp_path):
+    """Tier 2: construction-forwarding — BOTH router-OpContext callers forward the
+    Session's LIVE dispatcher instance (not None) — the Session-direct
+    _make_router_op_context AND the RouterHostAdapter — so task ops on either flow
+    can fire the hooks."""
+    from reyn.hooks.dispatcher import HookDispatcher
+
+    session = _make_session(tmp_path)
+
+    direct = session._make_router_op_context()
+    via_adapter = session._router_host.make_router_op_context()
+
+    # both callers forward a real, LIVE HookDispatcher (not a None no-op)…
+    assert isinstance(direct.hook_dispatcher, HookDispatcher)
+    # …and it is the SAME single instance on both router flows (no flow misses it).
+    assert direct.hook_dispatcher is via_adapter.hook_dispatcher


### PR DESCRIPTION
**[e2e-coder]** — #1800 slice 5c: the remaining 4 lifecycle hook points (skill_start/end, task_start/end). The **last** hook slice — the arc is complete on merge (modulo the owner-deferred shell-hook-push). Your close-review on the construction-forwarding (no None-noop on the live path) + the symmetry resolutions.

## Attach points (async execution points, not the sync WAL append)
- **skill_start / skill_end** → `SkillRegistry.start` / `complete` (after the `skill_started`/`skill_completed` WAL event).
- **task_start** → `op_runtime/task.py:_create` (after `backend.create`).
- **task_end** → `_update_status`→COMPLETED (`status="completed"`) **AND** `_abort` (`status="aborted"`, per aborted sub-tree task).

## Construction-forwarding (the load-bearing axis)
The points are in SkillRegistry / op_runtime/task.py, **not** Session — so the Session's HookDispatcher **instance** (5b's registry + seams, built in `Session.__init__`) is threaded in:
- **SKILL**: `SkillRegistry.__init__` gets `hook_dispatcher`; Session passes `self._hook_dispatcher` (session.py:3493).
- **TASK / router path**: the **single shared `build_router_op_context`** gains a `hook_dispatcher` param; **BOTH callers** pass it — `Session._make_router_op_context` AND `RouterHostAdapter.make_router_op_context` (your catch — complete-by-construction, neither flow can miss it).
- **TASK / phase path**: the kernel chain (`SkillRuntime → runtime → control_ir_executor + preprocessor_executor → OpContext`), mirroring `task_waker`.
- `OpContext` gains a `hook_dispatcher` field. All **None-guarded** → direct/test construction or no hooks = no-op (5b equivalence preserved).

## Symmetry resolutions (verified, observed-not-inferred)
- **task_end SYMMETRIC**: fires on COMPLETED (in `_update_status`) AND ABORTED (in `_abort`, per sub-tree task) — every started task fires an end; the operator discriminates via `status`. (Your preference: symmetric since it's a cheap add mirroring the existing `task_disposition` loop.)
- **skill_end ASYMMETRY flagged + tracked follow-up**: `run_orchestrator` calls `complete()` only when `exc_type is None or WorkflowAbortedError`; interrupted/errored runs emit `skill_run_interrupted` and BYPASS `complete()` → skill_end doesn't fire there. Firing it needs the dispatcher at the orchestrator interrupt branch (a broader change, out of 5c's clean-attach scope).

## Tests (Tier 2, no mocks; the REAL execution path fires the threaded dispatcher)
- real `SkillRegistry.start`/`complete` → skill_start/end; real `_create`/`_update_status→COMPLETED`/`_abort` → task_start/task_end (completed + aborted); None dispatcher → no-op.
- **construction-forwarding test**: BOTH router OpContext callers forward the **same live HookDispatcher instance** (not a None no-op).

## Done gate (all three, repo root)
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` → 6/6 OK
- [x] **Full `pytest`: 8128 passed, 0 failed** (clean; `--timeout`-guarded). 445 existing hook/task/skill/1953/1800 tests stay green — the None-guarded threading is back-compatible.

Refs #1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)