### PR TITLE
docs(testing): correct CI pytest command — add -n auto + --timeout=120

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -495,8 +495,9 @@ ready:
 
 1. **pytest** — from the repo root (not a subset path) so collection matches CI:
    ```bash
-   python -m pytest tests/ -q
+   python -m pytest -q -n auto --timeout=120
    ```
+   CI runs with `-n auto` (parallel workers) and `--timeout=120` (`pytest-timeout>=2.2`, a dev dep — `pip install -e ".[dev]"` installs it). Run locally with the same flags: a test that would hang in CI will fail-and-name the hanger within 120 s instead of blocking the run indefinitely.
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
    ruff check src tests        # add --fix for autofixable I001 / formatting


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- Corrects the "Before you push" pytest gate command from `python -m pytest tests/ -q` to `python -m pytest -q -n auto --timeout=120` to match `.github/workflows/test.yml` exactly
- The old command was doubly stale: missing `-n auto` (parallel workers) and `--timeout=120` (`pytest-timeout>=2.2`, a dev dep made permanent on CI as of #1800-7 / #2060)
- Added one-line note explaining the timeout semantics: fail-and-name the hanger within 120 s instead of blocking indefinitely

Spotted as drift while processing e2e-coder FYI notification (2026-06-23).

## Test plan

- [x] Visual: updated command matches `python -m pytest -q -n auto --timeout=120` in `.github/workflows/test.yml`
- [x] `mkdocs build --strict` passes (no new warnings)
- [x] No page drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)