### PR TITLE
docs(feature-map): add hooks entry to Config section (#1800 arc)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -144,6 +144,7 @@ mindmap
       self_improvement
       skill_resume
       action_retrieval
+      hooks
     🔒 Permissions
       Tier 0-3 model
       4-layer resolution
@@ -503,6 +504,7 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `self_improvement` | Skill self-improvement (eval-plan-apply) settings | [reyn-yaml](reference/config/reyn-yaml.md) |
 | `skill_resume` | Crash-resume behaviour for skill runs | [Skill Resume](concepts/skills/skill-resume.md) |
 | `action_retrieval` | Action-catalog `search_actions` retrieval tuning | [Universal catalog](concepts/tools-integrations/universal-catalog.md) |
+| `hooks` | Agent-lifecycle push/shell hooks at 8 points (`turn_start/end`, `session_start/end`, `skill_start/end`, `task_start/end`). `push` mode: `wake:false` passive context ride-along, or `wake:true` self-continuation bounded by `safety.loop.max_hook_driven_turns`. `shell`: sandbox-gated side-effect, output ignored. Hooks emit attributed `[hook:name]` messages — history is never silently mutated. | [reyn-yaml § hooks](reference/config/reyn-yaml.md#hooks-block) |
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- Adds `hooks` row to `### Config` table in `docs/feature-map.md` covering the 8 lifecycle points (`turn_start/end`, `session_start/end`, `skill_start/end`, `task_start/end`) shipped in the #1800 arc (#2065)
- Adds `hooks` node to the `🔧 Config` mindmap branch
- Gap spotted via e2e-coder FYI notification (2026-06-23); GO authorized by e2e-coder

Row covers:
- 8 lifecycle points (turn/session/skill/task ×start/end)
- `push` mode: `wake:false` passive context ride-along / `wake:true` self-continuation (bounded by `safety.loop.max_hook_driven_turns`)
- `shell`: sandbox-gated side-effect, output ignored
- Attributed `[hook:name]` messages — history never silently mutated
- Shell-hook outbound PUSH is owner-deferred and NOT claimed here

**Needs implementer accuracy review from e2e-coder before merge** (same workflow as #2051 Task-system entry).

## Test plan

- [x] `mkdocs build --strict` passes (no new warnings; pre-existing JA INFO lines only)
- [x] No page drops
- [ ] e2e-coder implementer accuracy cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)