### PR TITLE
refactor(#2074): S1 — extend capability spec to SKILL/MCP axes (additive, inert)

### DIFF
--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -1,18 +1,24 @@
-"""Capability profile (#1827 S2a) — the named role spec + its pure resolver.
+"""Capability profile (#1827 S2a; unified spec #2074) — the named spec + resolver.
 
 A ``capability_profile`` is a named, declarative narrowing of an agent's
 capabilities, loaded from ``.reyn/capability_profiles/<name>.yaml``. It is the
-single source for BOTH #1827 axes:
+**single capability-narrowing primitive** across all #1199 ∩ axes (#2074):
 
-- **authority (enforcement, axis A)** → a :class:`ContextualPermission`
-  (``tool_allow`` / ``tool_deny``) that rides the live ∩-gate (S1.5, #1884).
-- **visibility (cognitive, axis B)** → an ``excluded_categories`` set derived
-  from ``categories`` against the canonical 12-entry catalog.
+- **authority (enforcement)** → a :class:`ContextualPermission` carrying the
+  TOOL / SKILL / MCP axes (``*_allow`` / ``*_deny``) that ride the live ∩-gate.
+- **visibility (cognitive)** → an ``excluded_categories`` set derived from
+  ``categories`` against the canonical catalog.
 
-This module is PURE — schema + loader + resolver + compose. It is **unwired**:
-no binding to topology / delegate / ephemeral yet (S2b/S3 wire it through the
-``scoped_session_factory`` #1402 single-source). With no profile applied the
-session is byte-identical to pre-#1827.
+One primitive feeds TWO binding adapters (#2074): per-context (topology /
+delegate / untrusted-auto, composable) and per-agent-default (AgentProfile's
+allowlist baseline, #2074 S2/S4a). Both feed the UNCHANGED ``EffectivePermission``
+∩ — the spec is separated from the binding.
+
+This module is PURE — schema + loader + resolver + compose. Enforcement wiring
+lives in the binding adapters: the TOOL axis rides the live gate today; SKILL /
+MCP axes are carried by the resolver (#2074 S1) and consumed by the per-agent
+adapter (S2) + ContextualLayer (S3). With no profile applied the session is
+byte-identical to pre-#1827.
 
 The resolver never *grants* — both products are restrict-only:
 ``ContextualPermission`` is an ∩ term (never-elevate is the ``all()`` in
@@ -32,12 +38,17 @@ from reyn.tools.universal_catalog import CATEGORIES
 class CapabilityProfile:
     """A named capability narrowing (loaded from YAML).
 
+    The single narrowing primitive across all #1199 ∩ axes (#2074):
+
     - ``categories`` — the catalog categories to KEEP VISIBLE (axis B). ``None``
       = no visibility narrowing (show everything). An explicit (possibly empty)
       tuple narrows the view to that set.
-    - ``tool_allow`` — the tools to permit (axis A allow-list). ``None`` =
-      unconstrained (deny-list only).
-    - ``tool_deny`` — the tools to forbid (axis A).
+    - ``tool_allow`` / ``tool_deny`` — the TOOL axis (allow-list / deny-list).
+    - ``skill_allow`` / ``skill_deny`` — the SKILL axis (#2074 S1). ``skill_allow``
+      None = unrestricted; ``()`` = none allowed; a set = only those. This matches
+      ``AgentProfile.allowed_skills`` semantics exactly (None / [] / [a,b]) so the
+      per-agent binding adapter (#2074 S2/S4a) routes through it byte-identically.
+    - ``mcp_allow`` / ``mcp_deny`` — the MCP axis (#2074 S1), same allow/deny shape.
 
     Tuples (not sets) so the dataclass stays frozen/hashable; the resolver
     converts to frozensets.
@@ -48,6 +59,11 @@ class CapabilityProfile:
     categories: "tuple[str, ...] | None" = None
     tool_allow: "tuple[str, ...] | None" = None
     tool_deny: "tuple[str, ...]" = ()
+    # #2074 S1 — the SKILL / MCP axes of the unified spec (additive).
+    skill_allow: "tuple[str, ...] | None" = None
+    skill_deny: "tuple[str, ...]" = ()
+    mcp_allow: "tuple[str, ...] | None" = None
+    mcp_deny: "tuple[str, ...]" = ()
 
 
 def _as_tuple(value: "object | None") -> "tuple[str, ...] | None":
@@ -77,6 +93,11 @@ def load_capability_profile(path: "str | Path") -> CapabilityProfile:
         categories=_as_tuple(data["categories"]) if "categories" in data else None,
         tool_allow=_as_tuple(data["tool_allow"]) if "tool_allow" in data else None,
         tool_deny=_as_tuple(data.get("tool_deny")) or (),
+        # #2074 S1 — SKILL / MCP axes (additive; absent → None/() = ⊤).
+        skill_allow=_as_tuple(data["skill_allow"]) if "skill_allow" in data else None,
+        skill_deny=_as_tuple(data.get("skill_deny")) or (),
+        mcp_allow=_as_tuple(data["mcp_allow"]) if "mcp_allow" in data else None,
+        mcp_deny=_as_tuple(data.get("mcp_deny")) or (),
     )
 
 
@@ -85,7 +106,8 @@ def resolve_profile(
 ) -> "tuple[ContextualPermission, frozenset[str]]":
     """Resolve a profile into ``(ContextualPermission, excluded_categories)``.
 
-    - enforcement: ``ContextualPermission(tool_allow, tool_deny)`` — the S1 ∩ term.
+    - enforcement: a ``ContextualPermission`` carrying the TOOL / SKILL / MCP axes
+      (``*_allow`` / ``*_deny``) — the ∩ term (#2074 S1 adds SKILL / MCP).
     - view: ``excluded_categories = CATEGORIES − categories`` when ``categories``
       is set; ``∅`` (no view narrowing) when ``categories is None``.
 
@@ -98,6 +120,15 @@ def resolve_profile(
             frozenset(profile.tool_allow) if profile.tool_allow is not None else None
         ),
         tool_deny=frozenset(profile.tool_deny),
+        # #2074 S1 — SKILL / MCP axes (carried; ContextualLayer enforces them in S3).
+        skill_allow=(
+            frozenset(profile.skill_allow) if profile.skill_allow is not None else None
+        ),
+        skill_deny=frozenset(profile.skill_deny),
+        mcp_allow=(
+            frozenset(profile.mcp_allow) if profile.mcp_allow is not None else None
+        ),
+        mcp_deny=frozenset(profile.mcp_deny),
     )
     if profile.categories is None:
         excluded_categories: "frozenset[str]" = frozenset()
@@ -111,28 +142,43 @@ def compose_resolved(
 ) -> "tuple[ContextualPermission, frozenset[str]]":
     """Compose N resolved profiles, most-restrictive-wins (#1827 multi-membership).
 
-    Monotonic with the S1 ∩ model: **union of denials, intersection of allows**.
-    - ``tool_deny`` → union (any profile's deny wins).
-    - ``tool_allow`` → intersection of the *set* allow-lists (``None`` = ⊤, skipped);
-      a tool stays allowed only if every constraining profile allows it.
+    Monotonic with the ∩ model: **union of denials, intersection of allows** —
+    applied uniformly to every axis (#2074 S1: TOOL / SKILL / MCP).
+    - ``*_deny`` → union (any profile's deny wins).
+    - ``*_allow`` → intersection of the *set* allow-lists (``None`` = ⊤, skipped);
+      a value stays allowed only if every constraining profile allows it.
     - ``excluded_categories`` → union (any profile's hide wins).
 
     Empty input → an inert ``(ContextualPermission(), ∅)``.
     """
-    deny: "set[str]" = set()
+    contexts = [c for (c, _excl) in resolved]
+
+    def _compose_axis(
+        allow_attr: str, deny_attr: str
+    ) -> "tuple[frozenset[str] | None, frozenset[str]]":
+        """Union the per-axis denies; intersect the per-axis allow-lists (None=⊤=skip)."""
+        deny: "set[str]" = set()
+        allow_sets: "list[frozenset[str]]" = []
+        for c in contexts:
+            deny |= set(getattr(c, deny_attr))
+            allow = getattr(c, allow_attr)
+            if allow is not None:
+                allow_sets.append(allow)
+        combined_allow = frozenset.intersection(*allow_sets) if allow_sets else None
+        return combined_allow, frozenset(deny)
+
+    tool_allow, tool_deny = _compose_axis("tool_allow", "tool_deny")
+    skill_allow, skill_deny = _compose_axis("skill_allow", "skill_deny")
+    mcp_allow, mcp_deny = _compose_axis("mcp_allow", "mcp_deny")
     excluded: "set[str]" = set()
-    allow_sets: "list[frozenset[str]]" = []
-    for contextual, excl in resolved:
-        deny |= set(contextual.tool_deny)
+    for _c, excl in resolved:
         excluded |= set(excl)
-        if contextual.tool_allow is not None:
-            allow_sets.append(contextual.tool_allow)
-    if allow_sets:
-        combined_allow: "frozenset[str] | None" = frozenset.intersection(*allow_sets)
-    else:
-        combined_allow = None
     return (
-        ContextualPermission(tool_allow=combined_allow, tool_deny=frozenset(deny)),
+        ContextualPermission(
+            tool_allow=tool_allow, tool_deny=tool_deny,
+            skill_allow=skill_allow, skill_deny=skill_deny,
+            mcp_allow=mcp_allow, mcp_deny=mcp_deny,
+        ),
         frozenset(excluded),
     )
 

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -231,13 +231,22 @@ class ContextualPermission:
     from a delegation / topology role / ephemeral profile (later slices wire those
     sources) and carried on ``OpContext.contextual_permission``.
 
-    S1 covers the TOOL axis: ``tool_allow`` (None = unconstrained) ∩ ``¬tool_deny``.
-    Further axes are added as later slices wire them — until then this term is ⊤
-    on those axes (never narrows).
+    Per-axis ``*_allow`` (None = unconstrained ⊤) ∩ ``¬*_deny``. The TOOL axis is
+    enforced by :class:`ContextualLayer` today; the SKILL / MCP axes are **carried
+    but not yet enforced** by ContextualLayer (the unified-spec resolver #2074 S1
+    populates them; #2074 S3 wires ContextualLayer to consume them — until then
+    this term is ⊤ on SKILL/MCP, so adding the fields changes no gate outcome).
     """
 
     tool_allow: "frozenset[str] | None" = None
     tool_deny: "frozenset[str]" = field(default_factory=frozenset)
+    # #2074 S1 (additive, inert): the SKILL / MCP axes of the unified capability
+    # spec. Carried here so one resolved term covers all axes; ContextualLayer
+    # still enforces only TOOL (S3 wires SKILL/MCP). Inert defaults = ⊤.
+    skill_allow: "frozenset[str] | None" = None
+    skill_deny: "frozenset[str]" = field(default_factory=frozenset)
+    mcp_allow: "frozenset[str] | None" = None
+    mcp_deny: "frozenset[str]" = field(default_factory=frozenset)
 
 
 class ContextualLayer:

--- a/tests/test_2074_s1_capability_spec_axes.py
+++ b/tests/test_2074_s1_capability_spec_axes.py
@@ -1,0 +1,138 @@
+"""Tier 1: #2074 S1 — the unified capability spec gains SKILL / MCP axes (additive, inert).
+
+S1 extends the capability spec (CapabilityProfile) + its resolver/compose + loader
+with the SKILL and MCP axes alongside the existing TOOL / category axes, so ONE
+spec covers all #1199 ∩ axes. It is strictly **additive and inert**: the new axes
+are carried on the resolved ContextualPermission but ``ContextualLayer`` still
+enforces only TOOL (the SKILL/MCP binding is #2074 S2/S3). So a profile that sets
+skill/mcp narrowing changes NO gate outcome yet — proven here.
+
+No mocks: real CapabilityProfile / ContextualPermission / ContextualLayer + the
+pure resolver/compose/loader functions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.security.permissions.capability_profile import (
+    CapabilityProfile,
+    compose_resolved,
+    load_capability_profile,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    ContextualLayer,
+    ContextualPermission,
+)
+
+AX = CapabilityAxis
+
+
+# ── resolve: the new axes flow onto the ContextualPermission ────────────────
+
+
+def test_resolve_populates_skill_and_mcp_axes() -> None:
+    """Tier 1: resolve_profile carries skill/mcp allow/deny onto the ContextualPermission."""
+    prof = CapabilityProfile(
+        name="p",
+        skill_allow=("a", "b"),
+        skill_deny=("c",),
+        mcp_allow=("srv1",),
+        mcp_deny=("srv2",),
+    )
+    ctx, _excluded = resolve_profile(prof)
+    assert ctx.skill_allow == frozenset({"a", "b"})
+    assert ctx.skill_deny == frozenset({"c"})
+    assert ctx.mcp_allow == frozenset({"srv1"})
+    assert ctx.mcp_deny == frozenset({"srv2"})
+
+
+def test_resolve_skill_mcp_default_inert() -> None:
+    """Tier 1: a profile with no skill/mcp keys resolves to ⊤ on those axes
+    (allow=None, deny=∅) — the additive default narrows nothing."""
+    ctx, _ = resolve_profile(CapabilityProfile(name="p", tool_deny=("t",)))
+    assert ctx.skill_allow is None and ctx.skill_deny == frozenset()
+    assert ctx.mcp_allow is None and ctx.mcp_deny == frozenset()
+    # the existing TOOL axis is unaffected
+    assert ctx.tool_deny == frozenset({"t"})
+
+
+# ── loader: forward-compat parse of the new keys ────────────────────────────
+
+
+def test_loader_parses_skill_mcp_keys(tmp_path: Path) -> None:
+    """Tier 1: the loader parses skill_allow/skill_deny/mcp_allow/mcp_deny."""
+    p = tmp_path / "p.yaml"
+    p.write_text(
+        "skill_allow: [x, y]\nskill_deny: [z]\nmcp_allow: [m1]\nmcp_deny: [m2]\n",
+        encoding="utf-8",
+    )
+    prof = load_capability_profile(p)
+    assert prof.skill_allow == ("x", "y")
+    assert prof.skill_deny == ("z",)
+    assert prof.mcp_allow == ("m1",)
+    assert prof.mcp_deny == ("m2",)
+
+
+def test_loader_absent_skill_mcp_is_none_empty(tmp_path: Path) -> None:
+    """Tier 1: absent skill/mcp keys → None/() (forward-compat; pre-#2074 yaml unaffected)."""
+    p = tmp_path / "p.yaml"
+    p.write_text("tool_deny: [foo]\n", encoding="utf-8")
+    prof = load_capability_profile(p)
+    assert prof.skill_allow is None and prof.skill_deny == ()
+    assert prof.mcp_allow is None and prof.mcp_deny == ()
+
+
+# ── compose: the same monotonic rule applies to the new axes ────────────────
+
+
+def test_compose_unions_denies_and_intersects_allows_per_axis() -> None:
+    """Tier 1: compose_resolved applies union-of-deny + intersection-of-allow to the
+    SKILL/MCP axes, identically to TOOL (most-restrictive-wins across profiles)."""
+    a = resolve_profile(CapabilityProfile(name="a", skill_allow=("x", "y"), skill_deny=("d1",), mcp_deny=("m1",)))
+    b = resolve_profile(CapabilityProfile(name="b", skill_allow=("y", "z"), skill_deny=("d2",), mcp_deny=("m2",)))
+    composed, _excluded = compose_resolved([a, b])
+    # allow → intersection
+    assert composed.skill_allow == frozenset({"y"})
+    # deny → union
+    assert composed.skill_deny == frozenset({"d1", "d2"})
+    assert composed.mcp_deny == frozenset({"m1", "m2"})
+    # mcp_allow: neither constrained → ⊤
+    assert composed.mcp_allow is None
+
+
+def test_compose_empty_is_inert() -> None:
+    """Tier 1: composing nothing yields an inert all-⊤ ContextualPermission."""
+    composed, excluded = compose_resolved([])
+    assert composed.skill_allow is None and composed.skill_deny == frozenset()
+    assert composed.mcp_allow is None and composed.mcp_deny == frozenset()
+    assert composed.tool_allow is None and composed.tool_deny == frozenset()
+    assert excluded == frozenset()
+
+
+# ── INERTNESS: ContextualLayer still enforces ONLY TOOL (S1 changes no gate) ─
+
+
+def test_contextual_layer_does_not_yet_enforce_skill_or_mcp() -> None:
+    """Tier 1: the load-bearing inertness proof — even a ContextualPermission that
+    DENIES a skill/mcp value is ⊤ on those axes through ContextualLayer (S1 carries
+    the axes; S3 wires enforcement). So S1 cannot change any SKILL/MCP gate outcome."""
+    ctx = ContextualPermission(
+        skill_allow=frozenset({"only-this"}),
+        skill_deny=frozenset({"banned"}),
+        mcp_allow=frozenset({"only-srv"}),
+        mcp_deny=frozenset({"banned-srv"}),
+    )
+    layer = ContextualLayer(ctx)
+    # SKILL / MCP: not enforced by ContextualLayer yet → always allowed (⊤)
+    assert layer.allows(AX.SKILL, "banned") is True
+    assert layer.allows(AX.SKILL, "anything") is True
+    assert layer.allows(AX.MCP, "banned-srv") is True
+
+
+def test_contextual_layer_still_enforces_tool() -> None:
+    """Tier 1: TOOL enforcement is unchanged by S1 (no regression on the live axis)."""
+    layer = ContextualLayer(ContextualPermission(tool_deny=frozenset({"danger"})))
+    assert layer.allows(AX.TOOL, "danger") is False
+    assert layer.allows(AX.TOOL, "safe") is True


### PR DESCRIPTION
**[e2e-coder]** — #2074 stage **S1** of the capability-narrowing unification (one spec / all axes / two binding adapters → unchanged ∩-core). Lead-approved slicing on #2074. No-merge — staged build, lead close-reviews each stage.

## What (S1 = additive + inert)

Extends the capability spec so ONE primitive covers all #1199 ∩ axes. **Nothing consumes the new axes yet** — strictly inert, no gate outcome changes.

- `CapabilityProfile`: + `skill_allow`/`skill_deny` + `mcp_allow`/`mcp_deny` (alongside `tool_allow`/`tool_deny` + `categories`). The skill allow-list semantics (`None`=unrestricted / `[]`=none / `[a,b]`=only) **match `AgentProfile.allowed_skills` exactly** → the per-agent binding adapter (S2/S4a) routes through it byte-identically.
- `ContextualPermission`: carries the SKILL/MCP axes (inert defaults = ⊤).
- `resolve_profile`: populates them. `compose_resolved`: composes every axis uniformly (union-of-deny, intersection-of-allow) via a per-axis helper.
- loader: parses the new keys (forward-compat — absent → None/() → ⊤; pre-#2074 yaml unaffected).
- `ContextualLayer`: **UNCHANGED** — still enforces only TOOL. SKILL/MCP are carried, not consumed (S2 = per-agent adapter; S3 = contextual adapter).

**∩-core (`EffectivePermission.allows` `all()` conjunction): untouched.**

## Why inert is provable

`ContextualLayer.allows(SKILL/MCP, …)` returns ⊤ even when the resolved term denies the value (test `test_contextual_layer_does_not_yet_enforce_skill_or_mcp`) — so no SKILL/MCP gate outcome can change in S1.

## Test plan

- [x] New `tests/test_2074_s1_capability_spec_axes.py` (Tier 1): resolve/loader/compose for the new axes + **inertness proof** + TOOL no-regression
- [x] Capability/effective/contextual/permission/skill sweep — `336 passed, 1 skipped`
- [x] `ruff check` (changed files) — clean
- [x] `scripts/test_tier_audit.py --strict` — 7649 OK / 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8161 passed, 18 skipped, 3 xfailed** (+8 S1 tests)

## Next stages (this branch, no-merge per stage)

S2 (byte-identical SKILL routing onto the live ∩, falsify ×3) → S3 (contextual alignment) → S4a (identity factor + MCP source migration) → S4b (naming/doc). Then #2074 lands → hot-reload (#2073) unblocks.

Refs #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)