### PR TITLE
refactor(#2074): S2 — route per-agent SKILL allowlist onto the live ∩ (byte-identical)

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -536,9 +536,13 @@ class RouterHostAdapter:
         PR-N3: chat_compactor skill retired — compaction is now OS-internal.)
         """
         avail = self._skill_enumerate_fn({"skill_router"})
-        if self._allowed_skills is not None:
-            allow = set(self._allowed_skills)
-            avail = [s for s in avail if s.get("name") in allow]
+        # #2074 S2: catalog-visibility shares the SKILL ∩ decision with the spawn
+        # gates (skill_allowed → ProfileLayer), preserving the visibility⇔spawn
+        # coupling. Byte-identical to the legacy inline allowlist filter
+        # (None = unrestricted ⇒ no filtering). skill_router is already excluded
+        # above, so its exemption is preserved.
+        from reyn.security.permissions.effective import skill_allowed
+        avail = [s for s in avail if skill_allowed(self._allowed_skills, s.get("name"))]
         return avail
 
     def list_available_agents(self) -> list[dict]:

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -205,13 +205,43 @@ class SandboxLayer:
         return True
 
 
+@dataclass(frozen=True)
+class _AllowlistSource:
+    """A minimal :class:`ProfileLayer` source carrying just the per-agent
+    allowlists (#2074 S2). Lets a caller route an already-extracted
+    ``allowed_skills`` / ``allowed_mcp`` through ``ProfileLayer`` (the single
+    SKILL/MCP-axis decision) without synthesizing a full ``AgentProfile``.
+    ``None`` = unrestricted on that axis (⊤). Duck-typed by ProfileLayer
+    (``.allowed_skills`` / ``.allowed_mcp``). S4a repoints the per-agent layer at
+    the unified capability spec."""
+
+    allowed_skills: "frozenset[str] | None" = None
+    allowed_mcp: "frozenset[str] | None" = None
+
+
 class ProfileLayer:
     """The ALLOWLIST layer: ``AgentProfile`` agent-level allowlists. ``None`` means
     no per-agent restriction (⊤). Generalizes the existing ``allowed_mcp`` ∩
     precedent (agent-list ∩ project) to the unified model."""
 
-    def __init__(self, profile: "AgentProfile | None") -> None:
+    def __init__(self, profile: "AgentProfile | _AllowlistSource | None") -> None:
         self._profile = profile
+
+    @classmethod
+    def from_allowlists(
+        cls,
+        *,
+        allowed_skills: "object | None" = None,
+        allowed_mcp: "object | None" = None,
+    ) -> "ProfileLayer":
+        """Build a per-agent layer from raw allowlists (#2074 S2). ``None`` =
+        unrestricted on that axis; an empty / non-empty collection narrows to
+        exactly its members — byte-identical to the legacy inline check
+        ``allowed is None or value in allowed``."""
+        return cls(_AllowlistSource(
+            allowed_skills=frozenset(allowed_skills) if allowed_skills is not None else None,
+            allowed_mcp=frozenset(allowed_mcp) if allowed_mcp is not None else None,
+        ))
 
     def allows(self, axis: CapabilityAxis, value: Any) -> bool:
         pr = self._profile
@@ -295,6 +325,25 @@ def tool_contextually_denied(
     if contextual is None:
         return False
     return not ContextualLayer(contextual).allows(CapabilityAxis.TOOL, effective_name)
+
+
+def skill_allowed(allowed_skills: "object | None", skill_name: str) -> bool:
+    """The single per-agent SKILL-axis ∩ decision (#2074 S2).
+
+    Routes the per-agent ``allowed_skills`` allowlist through ``ProfileLayer`` so
+    the skill-spawn gates (skill_runner) AND the catalog filter (router host)
+    share ONE enforcement path — completing #1199's ∩ convergence for the SKILL
+    axis (previously an inline check that bypassed the ∩).
+
+    Byte-identical to the legacy ``allowed_skills is None or name in
+    allowed_skills``: ``None`` = unrestricted (⊤); ``[]`` = nothing allowed;
+    ``[a,b]`` = only those. ``skill_router`` is never passed here (it is excluded
+    from the catalog upstream and is never a spawn target), preserving its
+    exemption. S3 extends this gate with the contextual SKILL layer.
+    """
+    return EffectivePermission(
+        [ProfileLayer.from_allowlists(allowed_skills=allowed_skills)]
+    ).allows(CapabilityAxis.SKILL, skill_name)
 
 
 def _path_under(path_str: str, root: str) -> bool:

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -245,11 +245,12 @@ class SkillRunner:
             ))
             return None
 
-        # PR15: defense-in-depth allowlist check.
-        if (
-            self._allowed_skills is not None
-            and skill_name not in self._allowed_skills
-        ):
+        # PR15 → #2074 S2: the per-agent SKILL allowlist now routes through the
+        # live ∩ (skill_allowed → ProfileLayer), the single SKILL-axis decision
+        # shared with spawn-path B + the catalog filter. Byte-identical to the
+        # legacy inline check (None = unrestricted / [] = none / [a,b] = only).
+        from reyn.security.permissions.effective import skill_allowed
+        if not skill_allowed(self._allowed_skills, skill_name):
             await self._put_outbox(SkillOutboundMessage(
                 kind="error",
                 text=(
@@ -573,11 +574,9 @@ class SkillRunner:
                 "data": {"error": f"invalid skill spec: {spec}"},
             }
 
-        # PR15: allowlist check — same defense as spawn().
-        if (
-            self._allowed_skills is not None
-            and skill_name not in self._allowed_skills
-        ):
+        # PR15 → #2074 S2: same SKILL ∩ decision as spawn-path A (skill_allowed).
+        from reyn.security.permissions.effective import skill_allowed
+        if not skill_allowed(self._allowed_skills, skill_name):
             self._events.emit(
                 "skill_spawn_refused",
                 reason="allowlist", skill=skill_name, agent=self._agent_name,

--- a/tests/test_2074_s2_skill_gate.py
+++ b/tests/test_2074_s2_skill_gate.py
@@ -1,0 +1,163 @@
+"""Tier 1: #2074 S2 — the per-agent SKILL allowlist routes onto the live ∩.
+
+S2 replaces the three inline ``allowed_skills`` checks (skill_runner spawn gate A
++ B, router-host catalog filter) with one shared decision — ``skill_allowed`` →
+``EffectivePermission([ProfileLayer])`` — completing #1199's ∩ convergence for the
+SKILL axis. The change is **byte-identical**: ``None`` = unrestricted, ``[]`` =
+none allowed, ``[a,b]`` = only those; ``skill_router`` stays exempt (excluded
+upstream, never a spawn target).
+
+Byte-identical regression for the 3 sites lives in the existing allowlist tests
+(test_skill_runner_pre_spawn_validation.py + the list_available_skills tests),
+which still pass unchanged. THIS file pins the new shared seam + the falsify
+linkage: ``skill_allowed`` IS the ``ProfileLayer`` SKILL decision, so breaking
+``ProfileLayer.allows(SKILL)`` breaks every routed site (held-oracle ×3 — see the
+falsify note at the bottom).
+
+No mocks: real ProfileLayer / EffectivePermission / AgentProfile + the pure
+``skill_allowed`` seam.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from test_skill_runner_invariants import _make_runner
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    EffectivePermission,
+    ProfileLayer,
+    skill_allowed,
+)
+
+AX = CapabilityAxis
+
+
+# ── the seam's byte-identical allowlist matrix ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "allowed, name, expected",
+    [
+        (None, "anything", True),       # None = unrestricted (⊤)
+        ([], "anything", False),        # [] = nothing allowed
+        (["a", "b"], "a", True),        # listed → allowed
+        (["a", "b"], "z", False),       # not listed → refused
+    ],
+)
+def test_skill_allowed_matrix(allowed, name, expected) -> None:
+    """Tier 1: skill_allowed is byte-identical to the legacy ``allowed is None or
+    name in allowed`` across the None / [] / [a,b] matrix."""
+    assert skill_allowed(allowed, name) is expected
+
+
+# ── falsify linkage: skill_allowed IS the ProfileLayer ∩ decision ───────────
+
+
+@pytest.mark.parametrize("allowed", [None, [], ["a"], ["a", "b"]])
+@pytest.mark.parametrize("name", ["a", "b", "z"])
+def test_skill_allowed_is_the_profilelayer_decision(allowed, name) -> None:
+    """Tier 1: skill_allowed delegates to EffectivePermission([ProfileLayer]) on the
+    SKILL axis — the single decision the 3 routed sites share. So breaking
+    ``ProfileLayer.allows(SKILL)`` changes this AND every routed site together
+    (the held-oracle linkage that makes the falsify ×3 bite)."""
+    via_layer = EffectivePermission(
+        [ProfileLayer.from_allowlists(allowed_skills=allowed)]
+    ).allows(AX.SKILL, name)
+    assert skill_allowed(allowed, name) is via_layer
+
+
+@pytest.mark.parametrize("allowed", [None, [], ["a"], ["a", "b"]])
+@pytest.mark.parametrize("name", ["a", "b", "z"])
+def test_from_allowlists_matches_agentprofile_source(allowed, name) -> None:
+    """Tier 1: ProfileLayer.from_allowlists(allowed_skills=L) is byte-identical to
+    ProfileLayer(AgentProfile(allowed_skills=L)) on the SKILL axis — the S2 factory
+    introduces no semantic drift from the existing AgentProfile-backed layer."""
+    from_factory = ProfileLayer.from_allowlists(allowed_skills=allowed).allows(AX.SKILL, name)
+    from_profile = ProfileLayer(
+        AgentProfile(name="_", allowed_skills=allowed)
+    ).allows(AX.SKILL, name)
+    assert from_factory is from_profile
+
+
+def test_skill_allowed_does_not_constrain_other_axes() -> None:
+    """Tier 1: the per-agent layer from from_allowlists(allowed_skills=...) is ⊤ on
+    non-SKILL axes (S2 touches SKILL only; MCP stays on AgentLayer)."""
+    layer = ProfileLayer.from_allowlists(allowed_skills=[])  # narrow SKILL to none
+    assert layer.allows(AX.MCP, "any-server") is True
+    assert layer.allows(AX.TOOL, "any-tool") is True
+
+
+# ── held-oracle ×3: each routed SITE enforces via the seam (real instances) ──
+
+
+def test_site1_spawn_gate_refuses_disallowed_skill() -> None:
+    """Tier 2: spawn gate A (SkillRunner.spawn) — with allowed_skills set, spawning
+    an un-listed skill is refused (returns None + skill_spawn_refused) via the
+    routed seam. Falsifiable: break ProfileLayer.allows(SKILL) → 'denied' becomes
+    allowed → not refused → RED."""
+    runner, events, _outbox, _completed = _make_runner(allowed_skills=["allowed_one"])
+
+    async def _run():
+        result = await runner.spawn({"skill": "denied_one", "input": {"x": 1}})
+        assert result is None  # allowlist gate refuses before load
+        assert "skill_spawn_refused" in [e.type for e in events.all()]
+
+    asyncio.run(_run())
+
+
+def test_site2_run_skill_awaitable_refuses_disallowed_skill() -> None:
+    """Tier 2: spawn gate B (SkillRunner.run_skill_awaitable) — same routed seam;
+    a disallowed skill returns the allowlist error dict + event. Falsifiable as
+    site 1."""
+    runner, events, _outbox, _completed = _make_runner(allowed_skills=["allowed_one"])
+
+    async def _run():
+        result = await runner.run_skill_awaitable(
+            {"skill": "denied_one", "input": {"x": 1}}, chain_id="c1"
+        )
+        assert result["status"] == "error"
+        assert "not in allowed_skills" in result["data"]["error"]
+        assert "skill_spawn_refused" in [e.type for e in events.all()]
+
+    asyncio.run(_run())
+
+
+def _catalog_host(allowed_skills, enumerated):
+    """A real RouterHostAdapter exercising only list_available_skills via its two
+    real inputs (the _skill_enumerate_fn DI seam + _allowed_skills) — no collaborator
+    mocks, no 30-arg construction. ``enumerated`` is what enumerate returns (the
+    router is already excluded upstream by the {skill_router} exclude arg)."""
+    host = RouterHostAdapter.__new__(RouterHostAdapter)
+    host._allowed_skills = allowed_skills
+    host._skill_enumerate_fn = lambda exclude: list(enumerated)
+    return host
+
+
+def test_site3_catalog_filter_routes_through_seam() -> None:
+    """Tier 2: catalog filter (RouterHostAdapter.list_available_skills) — visibility
+    shares the routed seam; an un-listed skill is filtered out, preserving the
+    visibility⇔spawn coupling. Falsifiable: break the seam → 'drop' kept / 'keep'
+    dropped → RED."""
+    host = _catalog_host(["keep"], [{"name": "keep"}, {"name": "drop"}])
+    assert [s["name"] for s in host.list_available_skills()] == ["keep"]
+
+
+def test_site3_catalog_none_is_unrestricted() -> None:
+    """Tier 2: allowed_skills=None → no catalog filtering (byte-identical to the
+    legacy `if self._allowed_skills is not None` guard)."""
+    host = _catalog_host(None, [{"name": "a"}, {"name": "b"}])
+    assert [s["name"] for s in host.list_available_skills()] == ["a", "b"]
+
+
+# ── FALSIFY NOTE (held-oracle ×3, run + reverted during S2 build) ───────────
+# Breaking the new path `ProfileLayer.allows(SKILL)` (e.g. invert the membership
+# to `value not in pr.allowed_skills`) turns all routed enforcement RED:
+#   - test_skill_allowed_matrix + the linkage tests above, AND
+#   - the 3 routed sites' existing tests:
+#       spawn gate A/B → tests/test_skill_runner_pre_spawn_validation.py
+#       catalog filter → the list_available_skills allowlist tests
+# Confirmed CLEAN red on the break, green on revert (byte-identical + falsifiable).


### PR DESCRIPTION
**[e2e-coder]** — #2074 stage **S2** (load-bearing). Completes #1199's ∩ convergence for the SKILL axis. Lead-approved slicing on #2074; S1 (#2075) merged. No-merge — lead close-reviews.

## What (byte-identical)

The per-agent SKILL allowlist previously bypassed the ∩ (three inline `allowed_skills` checks). S2 routes all three through **one shared decision**:

- `effective.py`: + `ProfileLayer.from_allowlists()` (+ `_AllowlistSource`) — routes an extracted `allowed_skills` through `ProfileLayer` without synthesizing a full `AgentProfile`; + `skill_allowed()` — the single SKILL-axis ∩ seam (mirrors the `tool_contextually_denied` single-seam pattern).
- The 3 sites now call `skill_allowed(self._allowed_skills, name)`:
  1. spawn gate A — `skill_runner.spawn`
  2. spawn gate B — `skill_runner.run_skill_awaitable`
  3. catalog filter — `router_host_adapter.list_available_skills`

**Preserved exactly**: `None`=unrestricted / `[]`=none / `[a,b]`=only; `skill_router` exempt (excluded upstream, never a spawn target); spawn⇔catalog coupling (one decision); diagnostics (`skill_spawn_refused` + error text). **MCP untouched** (already on the ∩ via `AgentLayer.MCP`). **∩-core unchanged**.

## Held-oracle ×3 (falsify-tested)

Breaking `ProfileLayer.allows(SKILL)` (invert membership) turns **all three routed sites RED** — site1 spawn gate, site2 run_skill_awaitable, site3 catalog filter — plus the seam matrix. Verified CLEAN red on the break, green on revert. Proves each site enforces via the seam, not a bypassed inline check.

## Test plan

- [x] `tests/test_2074_s2_skill_gate.py`: seam matrix + ProfileLayer-decision linkage + `from_allowlists`≡`AgentProfile` equivalence + the **3 site oracles** (real SkillRunner via `_make_runner`; real `list_available_skills` via its 2 DI inputs)
- [x] **Falsify ×3** — break `ProfileLayer.allows(SKILL)` → site1/site2/site3 + seam all RED; reverted → green
- [x] Byte-identical regression — existing allowlist tests (`test_skill_runner_pre_spawn_validation.py`, `test_skill_runner_invariants.py`) pass unchanged
- [x] `ruff check` — clean · `test_tier_audit.py --strict` — 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8194 passed, 18 skipped, 3 xfailed** (+33 S2 tests)

## Next

S3 (contextual SKILL/MCP alignment) → S4a (identity factor + MCP source migration) → S4b (naming/doc). Then #2074 lands → hot-reload (#2073) unblocks.

Refs #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)