### PR TITLE
refactor(#2074): S3 — per-context SKILL narrowing onto the unified ∩ (byte-identical)

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -536,13 +536,20 @@ class RouterHostAdapter:
         PR-N3: chat_compactor skill retired — compaction is now OS-internal.)
         """
         avail = self._skill_enumerate_fn({"skill_router"})
-        # #2074 S2: catalog-visibility shares the SKILL ∩ decision with the spawn
-        # gates (skill_allowed → ProfileLayer), preserving the visibility⇔spawn
-        # coupling. Byte-identical to the legacy inline allowlist filter
-        # (None = unrestricted ⇒ no filtering). skill_router is already excluded
-        # above, so its exemption is preserved.
+        # #2074 S2/S3: catalog-visibility shares the SKILL ∩ decision with the
+        # spawn gates (skill_allowed → ProfileLayer per-agent ∩ ContextualLayer
+        # per-context), preserving the visibility⇔spawn coupling. Byte-identical
+        # to the legacy inline allowlist filter (None = unrestricted ⇒ no
+        # filtering; a context that does not narrow SKILL ⇒ ⊤). skill_router is
+        # already excluded above, so its exemption is preserved.
         from reyn.security.permissions.effective import skill_allowed
-        avail = [s for s in avail if skill_allowed(self._allowed_skills, s.get("name"))]
+        avail = [
+            s for s in avail
+            if skill_allowed(
+                self._allowed_skills, s.get("name"),
+                contextual=self._contextual_permission,
+            )
+        ]
         return avail
 
     def list_available_agents(self) -> list[dict]:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1456,6 +1456,7 @@ class Session:
             make_subscribers=self._make_skill_subscribers,
             format_refusal=format_refusal_message,
             format_warn=format_warn_message,
+            contextual_permission=self._contextual_permission,  # #2074 S3
         )
 
         # F2: Delegation tracking for RouterLoop runs. Set to a list before

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -301,8 +301,14 @@ class ContextualLayer:
             in_allow = c.tool_allow is None or value in c.tool_allow
             not_denied = value not in c.tool_deny
             return in_allow and not_denied
-        # S1: only TOOL is constrained; other axes are ⊤ until later slices wire
-        # them (so the ∩ never narrows an axis the context does not yet cover).
+        if axis is CapabilityAxis.SKILL:
+            # #2074 S3: per-context SKILL narrowing. ⊤ when unset (skill_allow=None
+            # + empty skill_deny) → byte-identical for any context that does not
+            # narrow SKILL (= every production context today).
+            in_allow = c.skill_allow is None or value in c.skill_allow
+            return in_allow and value not in c.skill_deny
+        # MCP is consumed in #2074 S4a (paired with the require_mcp gate wiring);
+        # until then the contextual MCP axis is ⊤ (never narrows).
         return True
 
 
@@ -327,23 +333,36 @@ def tool_contextually_denied(
     return not ContextualLayer(contextual).allows(CapabilityAxis.TOOL, effective_name)
 
 
-def skill_allowed(allowed_skills: "object | None", skill_name: str) -> bool:
-    """The single per-agent SKILL-axis ∩ decision (#2074 S2).
+def skill_allowed(
+    allowed_skills: "object | None",
+    skill_name: str,
+    *,
+    contextual: "ContextualPermission | None" = None,
+) -> bool:
+    """The single SKILL-axis ∩ decision (#2074 S2/S3).
 
-    Routes the per-agent ``allowed_skills`` allowlist through ``ProfileLayer`` so
-    the skill-spawn gates (skill_runner) AND the catalog filter (router host)
-    share ONE enforcement path — completing #1199's ∩ convergence for the SKILL
-    axis (previously an inline check that bypassed the ∩).
+    Routes the per-agent ``allowed_skills`` allowlist (``ProfileLayer``) AND the
+    per-session contextual narrowing (``ContextualLayer``, #2074 S3) so the
+    skill-spawn gates (skill_runner) AND the catalog filter (router host) share
+    ONE enforcement path — completing #1199's ∩ convergence for the SKILL axis.
 
-    Byte-identical to the legacy ``allowed_skills is None or name in
-    allowed_skills``: ``None`` = unrestricted (⊤); ``[]`` = nothing allowed;
-    ``[a,b]`` = only those. ``skill_router`` is never passed here (it is excluded
-    from the catalog upstream and is never a spawn target), preserving its
-    exemption. S3 extends this gate with the contextual SKILL layer.
+    Per-agent (``allowed_skills``) byte-identical to the legacy ``allowed_skills
+    is None or name in allowed_skills``: ``None`` = unrestricted (⊤); ``[]`` =
+    nothing allowed; ``[a,b]`` = only those. ``skill_router`` is never passed here
+    (excluded from the catalog upstream + never a spawn target), preserving its
+    exemption.
+
+    Per-context (``contextual``, #2074 S3): ``None`` or a context that does not
+    narrow SKILL (``skill_allow=None`` + empty ``skill_deny``) → ⊤, so every
+    existing outcome is preserved (the contextual SKILL narrowing is NEW
+    capability that activates only when a bound profile sets it).
     """
-    return EffectivePermission(
-        [ProfileLayer.from_allowlists(allowed_skills=allowed_skills)]
-    ).allows(CapabilityAxis.SKILL, skill_name)
+    layers: "list[LayerView]" = [
+        ProfileLayer.from_allowlists(allowed_skills=allowed_skills)
+    ]
+    if contextual is not None:
+        layers.append(ContextualLayer(contextual))
+    return EffectivePermission(layers).allows(CapabilityAxis.SKILL, skill_name)
 
 
 def _path_under(path_str: str, root: str) -> bool:

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -127,12 +127,16 @@ class SkillRunner:
         make_subscribers: Callable[..., list],
         format_refusal: Callable[..., str],
         format_warn: Callable[..., str],
+        contextual_permission: "object | None" = None,
     ) -> None:
         self._events = event_log
         self._agent_name = agent_name
         self._output_language = output_language
         self._mcp_servers = mcp_servers
         self._allowed_skills = allowed_skills
+        # #2074 S3: per-session contextual SKILL narrowing (a ContextualPermission)
+        # threaded into the spawn-gate ∩. None → ⊤ (byte-identical to pre-S3).
+        self._contextual_permission = contextual_permission
         self._budget = budget
         self._state_log = state_log
         self._build_agent_fn = build_agent_fn
@@ -250,7 +254,7 @@ class SkillRunner:
         # shared with spawn-path B + the catalog filter. Byte-identical to the
         # legacy inline check (None = unrestricted / [] = none / [a,b] = only).
         from reyn.security.permissions.effective import skill_allowed
-        if not skill_allowed(self._allowed_skills, skill_name):
+        if not skill_allowed(self._allowed_skills, skill_name, contextual=self._contextual_permission):
             await self._put_outbox(SkillOutboundMessage(
                 kind="error",
                 text=(
@@ -576,7 +580,7 @@ class SkillRunner:
 
         # PR15 → #2074 S2: same SKILL ∩ decision as spawn-path A (skill_allowed).
         from reyn.security.permissions.effective import skill_allowed
-        if not skill_allowed(self._allowed_skills, skill_name):
+        if not skill_allowed(self._allowed_skills, skill_name, contextual=self._contextual_permission):
             self._events.emit(
                 "skill_spawn_refused",
                 reason="allowlist", skill=skill_name, agent=self._agent_name,

--- a/tests/test_2074_s1_capability_spec_axes.py
+++ b/tests/test_2074_s1_capability_spec_axes.py
@@ -114,21 +114,19 @@ def test_compose_empty_is_inert() -> None:
 # ── INERTNESS: ContextualLayer still enforces ONLY TOOL (S1 changes no gate) ─
 
 
-def test_contextual_layer_does_not_yet_enforce_skill_or_mcp() -> None:
-    """Tier 1: the load-bearing inertness proof — even a ContextualPermission that
-    DENIES a skill/mcp value is ⊤ on those axes through ContextualLayer (S1 carries
-    the axes; S3 wires enforcement). So S1 cannot change any SKILL/MCP gate outcome."""
+def test_contextual_layer_does_not_yet_enforce_mcp() -> None:
+    """Tier 1: the MCP contextual axis is still carried-but-not-enforced — a
+    ContextualPermission that DENIES an mcp value is ⊤ on MCP through
+    ContextualLayer (S1 carries the axis; #2074 S4a wires MCP enforcement, paired
+    with the require_mcp gate). (SKILL is now enforced by S3 — see
+    test_2074_s3_contextual_skill.py.)"""
     ctx = ContextualPermission(
-        skill_allow=frozenset({"only-this"}),
-        skill_deny=frozenset({"banned"}),
         mcp_allow=frozenset({"only-srv"}),
         mcp_deny=frozenset({"banned-srv"}),
     )
     layer = ContextualLayer(ctx)
-    # SKILL / MCP: not enforced by ContextualLayer yet → always allowed (⊤)
-    assert layer.allows(AX.SKILL, "banned") is True
-    assert layer.allows(AX.SKILL, "anything") is True
     assert layer.allows(AX.MCP, "banned-srv") is True
+    assert layer.allows(AX.MCP, "anything") is True
 
 
 def test_contextual_layer_still_enforces_tool() -> None:

--- a/tests/test_2074_s2_skill_gate.py
+++ b/tests/test_2074_s2_skill_gate.py
@@ -133,6 +133,7 @@ def _catalog_host(allowed_skills, enumerated):
     router is already excluded upstream by the {skill_router} exclude arg)."""
     host = RouterHostAdapter.__new__(RouterHostAdapter)
     host._allowed_skills = allowed_skills
+    host._contextual_permission = None  # #2074 S3: no per-context narrowing here
     host._skill_enumerate_fn = lambda exclude: list(enumerated)
     return host
 

--- a/tests/test_2074_s3_contextual_skill.py
+++ b/tests/test_2074_s3_contextual_skill.py
@@ -1,0 +1,137 @@
+"""Tier 1/2: #2074 S3 — per-context SKILL narrowing onto the unified ∩.
+
+S3 wires the contextual binding adapter for the SKILL axis: ContextualLayer now
+consumes the S1 ``skill_allow`` / ``skill_deny`` axes, and ``skill_allowed`` adds
+``ContextualLayer`` to its gate → ``EffectivePermission([ProfileLayer,
+ContextualLayer])``. Both spawn gates + the catalog filter pass the session's
+contextual_permission.
+
+**Byte-identical discipline (⊤-when-unset):** contextual SKILL narrowing is NEW
+capability, so it must be ⊤ whenever no bound context narrows SKILL —
+``contextual=None`` OR a context with ``skill_allow=None`` + empty ``skill_deny``.
+Then every pre-S3 (per-agent) outcome is unchanged; the existing S2 tests
+(test_2074_s2_skill_gate.py) still pass because they call skill_allowed without a
+contextual (= None = ⊤). New: a bound context that sets skill_allow/deny now
+narrows spawn + catalog.
+
+No mocks: real ContextualPermission / ContextualLayer / EffectivePermission +
+real SkillRunner (via _make_runner) + real list_available_skills.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from test_skill_runner_invariants import _make_runner
+
+from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    ContextualLayer,
+    ContextualPermission,
+    skill_allowed,
+)
+
+AX = CapabilityAxis
+
+
+# ── ContextualLayer now enforces the SKILL axis ─────────────────────────────
+
+
+def test_contextual_layer_skill_deny() -> None:
+    """Tier 1: a contextual skill_deny narrows SKILL through ContextualLayer."""
+    layer = ContextualLayer(ContextualPermission(skill_deny=frozenset({"banned"})))
+    assert layer.allows(AX.SKILL, "banned") is False
+    assert layer.allows(AX.SKILL, "other") is True
+
+
+def test_contextual_layer_skill_allow() -> None:
+    """Tier 1: a contextual skill_allow restricts SKILL to its members."""
+    layer = ContextualLayer(ContextualPermission(skill_allow=frozenset({"only"})))
+    assert layer.allows(AX.SKILL, "only") is True
+    assert layer.allows(AX.SKILL, "other") is False
+
+
+def test_contextual_layer_skill_top_when_unset() -> None:
+    """Tier 1: ⊤-when-unset — a context that does not narrow SKILL allows all."""
+    assert ContextualLayer(ContextualPermission()).allows(AX.SKILL, "anything") is True
+    assert ContextualLayer(None).allows(AX.SKILL, "anything") is True
+
+
+# ── skill_allowed gate composes per-agent ∩ per-context ─────────────────────
+
+
+def test_skill_allowed_contextual_none_matches_per_agent() -> None:
+    """Tier 1: contextual=None → the decision matches the S2 per-agent-only result
+    exactly (the contextual layer is ⊤ when absent — a permanent property)."""
+    assert skill_allowed(["a"], "a", contextual=None) is True
+    assert skill_allowed(["a"], "z", contextual=None) is False
+    assert skill_allowed(None, "anything", contextual=None) is True
+
+
+def test_skill_allowed_contextual_unset_is_top() -> None:
+    """Tier 1: a context that does not narrow SKILL is ⊤ — per-agent outcome
+    unchanged (the load-bearing byte-identical property)."""
+    empty = ContextualPermission()  # no skill narrowing
+    assert skill_allowed(None, "anything", contextual=empty) is True
+    assert skill_allowed(["a"], "a", contextual=empty) is True
+    assert skill_allowed(["a"], "z", contextual=empty) is False  # per-agent still applies
+
+
+def test_skill_allowed_contextual_deny_narrows_even_when_agent_allows() -> None:
+    """Tier 1: a contextual deny refuses a skill the per-agent layer allows
+    (∩ never-elevate: the most-restrictive layer wins)."""
+    ctx = ContextualPermission(skill_deny=frozenset({"dangerous"}))
+    # per-agent unrestricted (None) but contextual denies
+    assert skill_allowed(None, "dangerous", contextual=ctx) is False
+    assert skill_allowed(None, "safe", contextual=ctx) is True
+
+
+# ── site oracles: the spawn gate + catalog honor contextual SKILL narrowing ──
+
+
+def test_spawn_gate_honors_contextual_skill_deny() -> None:
+    """Tier 2: a SkillRunner with a contextual skill_deny refuses spawning the
+    denied skill even when the per-agent allowlist is unrestricted (None)."""
+    runner, events, _outbox, _completed = _make_runner(allowed_skills=None)
+    runner._contextual_permission = ContextualPermission(skill_deny=frozenset({"denied_ctx"}))
+
+    async def _run():
+        result = await runner.spawn({"skill": "denied_ctx", "input": {"x": 1}})
+        assert result is None
+        assert "skill_spawn_refused" in [e.type for e in events.all()]
+
+    asyncio.run(_run())
+
+
+def _catalog_host(allowed_skills, contextual, enumerated):
+    host = RouterHostAdapter.__new__(RouterHostAdapter)
+    host._allowed_skills = allowed_skills
+    host._contextual_permission = contextual
+    host._skill_enumerate_fn = lambda exclude: list(enumerated)
+    return host
+
+
+def test_catalog_honors_contextual_skill_deny() -> None:
+    """Tier 2: the catalog filter hides a contextually-denied skill (visibility
+    ⇔ spawn coupling preserved across the contextual layer)."""
+    ctx = ContextualPermission(skill_deny=frozenset({"hide_me"}))
+    host = _catalog_host(None, ctx, [{"name": "keep"}, {"name": "hide_me"}])
+    assert [s["name"] for s in host.list_available_skills()] == ["keep"]
+
+
+def test_catalog_no_contextual_is_unrestricted() -> None:
+    """Tier 2: no contextual (None) + no per-agent allowlist → no filtering
+    (byte-identical to pre-S3)."""
+    host = _catalog_host(None, None, [{"name": "a"}, {"name": "b"}])
+    assert [s["name"] for s in host.list_available_skills()] == ["a", "b"]
+
+
+# ── FALSIFY NOTE (held-oracle, run + reverted during S3 build) ──────────────
+# Breaking the new path `ContextualLayer.allows(SKILL)` (e.g. drop the SKILL
+# branch so it falls through to ⊤) turns the contextual-deny enforcement RED:
+#   - test_contextual_layer_skill_deny / _skill_allow
+#   - test_skill_allowed_contextual_deny_narrows_even_when_agent_allows
+#   - test_spawn_gate_honors_contextual_skill_deny + test_catalog_honors_contextual_skill_deny
+# while the ⊤-when-unset tests + all S2 (contextual=None) tests stay GREEN —
+# proving the new enforcement is real AND byte-identical when unset. Confirmed
+# CLEAN red on the break, green on revert.


### PR DESCRIPTION
**[e2e-coder]** — #2074 stage **S3**. Wires the contextual binding adapter for the SKILL axis (per-context half of #1199's ∩ convergence). Lead-approved slicing; S1 (#2075) + S2 (#2077) merged. No-merge — lead close-reviews.

## What (byte-identical, ⊤-when-unset)

- `effective.py`: `ContextualLayer.allows` now enforces **SKILL** (consumes the S1 `skill_allow`/`skill_deny`); `skill_allowed` gains an optional `contextual` → `EffectivePermission([ProfileLayer, ContextualLayer])`.
- The **3 SKILL sites** now pass the session `contextual_permission`: catalog filter (`router_host_adapter`, already held it) + both spawn gates (`skill_runner` gains a `contextual_permission` ctor param, threaded from `Session`).
- **MCP** contextual stays carried-but-unenforced — paired with the `require_mcp` gate + MCP source migration in **S4a** (no dead code; each stage's layer change is exercised by its gate).

**Byte-identical**: contextual SKILL narrowing is NEW capability — ⊤ whenever no bound context narrows SKILL (`contextual=None` OR `skill_allow=None` + empty `skill_deny`). Every pre-S3 per-agent outcome unchanged; **the S2 tests (contextual=None) pass untouched**. **∩-core unchanged**.

## Held-oracle (falsify)

Breaking `ContextualLayer.allows(SKILL)` (force ⊤) turns contextual-deny enforcement RED at: the layer, the composed gate, and **both sites** (spawn + catalog) — while the ⊤-when-unset tests + all S2 tests stay GREEN. Proves the new enforcement is real AND byte-identical when unset. Verified, then reverted.

## Test plan

- [x] `tests/test_2074_s3_contextual_skill.py`: ContextualLayer SKILL matrix (deny/allow/⊤-unset) + composed gate (deny narrows even when per-agent allows; ⊤-when-unset) + 2 site oracles (spawn + catalog honor contextual deny)
- [x] **Falsify** — break `ContextualLayer.allows(SKILL)` → layer/gate/spawn/catalog RED (5), ⊤-unset + S2 GREEN; reverted
- [x] Byte-identical regression — S1/S2 tests + `test_skill_runner_pre_spawn_validation` + `test_contextual_permission_1827` + `test_context_auto_1827_s4b` pass (updated: S1 inertness test → MCP-only since SKILL now enforced; S2 catalog helper sets the new `_contextual_permission` attr)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8203 passed, 18 skipped, 3 xfailed**

## Next

S4a (identity factor: AgentProfile = identity + default-spec ref; MCP source migration + `require_mcp` + ContextualLayer) → S4b (naming/doc). Then #2074 lands → hot-reload (#2073) unblocks.

Refs #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)