### PR TITLE
refactor(#2074): S4a — MCP source migration + per-context MCP + identity factor (byte-identical)

### DIFF
--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -160,6 +160,7 @@ async def handle(op: MCPIROp, ctx: OpContext, caller: Literal["preprocessor", "c
             raise RuntimeError("mcp op requires intervention_bus on OpContext")
         await ctx.permission_resolver.require_mcp(
             ctx.permission_decl, op.server, ctx.intervention_bus,
+            contextual=getattr(ctx, "contextual_permission", None),  # #2074 S4a
         )
     return await _execute(op, ctx)
 

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -29,8 +29,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    from reyn.security.permissions.capability_profile import CapabilityProfile
 
 PROFILE_FILENAME = "profile.yaml"
 
@@ -101,6 +105,24 @@ class AgentProfile:
         path.write_text(
             yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
             encoding="utf-8",
+        )
+
+    def default_profile(self) -> "CapabilityProfile":
+        """The agent's default capability spec (#2074 S4a) — the canonical unified
+        representation of this agent's per-agent baseline narrowing.
+
+        The profile.yaml user keys stay ``allowed_skills`` / ``allowed_mcp`` (the
+        natural operator surface); this maps them onto the unified spec's
+        ``skill_allow`` / ``mcp_allow`` axes (the INTERNAL representation, no
+        user-facing rename). ``None`` allowlists pass through as ``None`` (= ⊤,
+        unrestricted). #2074 S4b repoints the per-agent ∩ layers to read this spec
+        object so one primitive feeds both binding adapters."""
+        from reyn.security.permissions.capability_profile import CapabilityProfile
+
+        return CapabilityProfile(
+            name=self.name,
+            skill_allow=tuple(self.allowed_skills) if self.allowed_skills is not None else None,
+            mcp_allow=tuple(self.allowed_mcp) if self.allowed_mcp is not None else None,
         )
 
 

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -142,13 +142,12 @@ class AgentLayer:
                 or self._approved(axis, value)
             )
         if axis is CapabilityAxis.MCP:
-            # #1199 S3.1b: faithful to require_mcp (permissions.py:1248+1253) —
-            # the per-skill grant (``decl.mcp``) AND the per-skill allowlist
-            # (``decl.allowed_mcp``: None = no restriction). The per-AGENT
-            # allowlist (AgentProfile.allowed_mcp) is the separate ProfileLayer.
-            in_grant = value in d.mcp
-            in_allowlist = d.allowed_mcp is None or value in d.allowed_mcp
-            return in_grant and in_allowlist
+            # #1199 S3.1b: the per-skill GRANT (``decl.mcp``). #2074 S4a moved the
+            # per-agent allowlist (``decl.allowed_mcp``) OUT to a ProfileLayer in
+            # require_mcp (symmetric with SKILL) — so the full ∩ is now
+            # ``AgentLayer(grant) ∩ ProfileLayer(allowlist) ∩ ContextualLayer``,
+            # byte-identical to the prior ``grant ∩ allowlist`` (∩ associative).
+            return value in d.mcp
         if axis is CapabilityAxis.SECRET_WRITE:
             # #1199 S3.1b-2c: faithful to require_secret_write — a specific key OR
             # the "*" wildcard (runtime-determined keys, gated by the per-value
@@ -307,8 +306,12 @@ class ContextualLayer:
             # narrow SKILL (= every production context today).
             in_allow = c.skill_allow is None or value in c.skill_allow
             return in_allow and value not in c.skill_deny
-        # MCP is consumed in #2074 S4a (paired with the require_mcp gate wiring);
-        # until then the contextual MCP axis is ⊤ (never narrows).
+        if axis is CapabilityAxis.MCP:
+            # #2074 S4a: per-context MCP narrowing (paired with the require_mcp
+            # gate wiring). ⊤ when unset (mcp_allow=None + empty mcp_deny) →
+            # byte-identical for any context that does not narrow MCP.
+            in_allow = c.mcp_allow is None or value in c.mcp_allow
+            return in_allow and value not in c.mcp_deny
         return True
 
 

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1421,29 +1421,54 @@ class PermissionResolver:
 
     async def require_mcp(
         self, decl: PermissionDecl, server: str, bus: RequestBus,
+        *, contextual: "object | None" = None,
     ) -> None:
-        # #1199 S3.1b (the migration anchor): the static MCP authority —
-        # decl.mcp ∩ decl.allowed_mcp — now flows through the unified
-        # EffectivePermission model (AgentLayer.MCP), the single conjunctive-∩
-        # source, instead of two inline checks. Byte-identical DECISION; the two
-        # diagnostics below are preserved (same messages + order). Local import
-        # avoids the effective.py → permissions.py circular. The interactive
-        # _approve prompt remains the separate runtime gate (not part of the ∩).
+        # #1199 S3.1b: the static MCP authority flows through the unified
+        # EffectivePermission ∩. #2074 S4a unifies the per-agent MCP allowlist
+        # into a ``ProfileLayer`` (symmetric with the SKILL axis), and adds an
+        # optional per-session ``ContextualLayer`` (MCP contextual narrowing,
+        # ⊤-when-unset). The full ∩ is now:
+        #   AgentLayer(decl.mcp grant) ∩ ProfileLayer(decl.allowed_mcp allowlist)
+        #     ∩ ContextualLayer(contextual)
+        # which is byte-identical to the prior ``grant ∩ allowlist`` when
+        # ``contextual`` does not narrow MCP (∩ associative). The three diagnostics
+        # below distinguish the failing layer (mirrors require_tool), preserving
+        # the original allowlist + declared messages exactly. Local import avoids
+        # the effective.py → permissions.py circular. ``_approve`` remains the
+        # separate runtime gate (not part of the ∩).
         from reyn.security.permissions.effective import (
             AgentLayer,
             CapabilityAxis,
+            ContextualLayer,
             EffectivePermission,
+            ProfileLayer,
         )
 
-        if not EffectivePermission([AgentLayer(decl)]).allows(
-            CapabilityAxis.MCP, server
-        ):
-            # PR37: per-agent allowlist check (narrower than project config).
+        layers: list = [
+            AgentLayer(decl),
+            ProfileLayer.from_allowlists(allowed_mcp=decl.allowed_mcp),
+        ]
+        if contextual is not None:
+            layers.append(ContextualLayer(contextual))
+        if not EffectivePermission(layers).allows(CapabilityAxis.MCP, server):
+            # Decision-enabling deny, distinguishing the failing layer (order
+            # preserves the pre-S4a allowlist-then-declared messages byte-identically;
+            # the contextual branch is NEW + only fires when a context narrows MCP):
+            # 1. per-agent allowlist (ProfileLayer) — "not in allowed_mcp"
             if decl.allowed_mcp is not None and server not in decl.allowed_mcp:
                 raise PermissionError(
                     f"MCP server {server!r} not in allowed_mcp for caller "
                     f"(agent allowlist exhausted)"
                 )
+            # 2. per-session contextual narrowing (ContextualLayer) — NEW (#2074 S4a)
+            if contextual is not None and not ContextualLayer(contextual).allows(
+                CapabilityAxis.MCP, server
+            ):
+                raise PermissionError(
+                    f"MCP server {server!r} is blocked by the active capability "
+                    f"context (delegation / topology / ephemeral narrowing)."
+                )
+            # 3. per-skill grant (AgentLayer) — "not declared in skill permissions"
             raise PermissionError(
                 f"MCP server {server!r} not declared in skill permissions. "
                 f"Add `permissions:\\n  mcp: [{server}]` to the skill.md frontmatter."

--- a/tests/test_1199_s31b_mcp_cutover.py
+++ b/tests/test_1199_s31b_mcp_cutover.py
@@ -12,6 +12,7 @@ from reyn.security.permissions.effective import (
     AgentLayer,
     CapabilityAxis,
     EffectivePermission,
+    ProfileLayer,
     SandboxLayer,
 )
 from reyn.security.permissions.permissions import PermissionDecl
@@ -20,21 +21,41 @@ from reyn.security.sandbox.policy import SandboxPolicy
 AX = CapabilityAxis
 
 
-def test_agent_layer_mcp_intersects_decl_mcp_and_allowed_mcp() -> None:
-    """Tier 2: AgentLayer.MCP = decl.mcp ∩ decl.allowed_mcp (the S3.1b fix,
-    faithful to require_mcp 1248+1253)."""
-    # in grant + allowlist → permitted
-    assert AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
-    # in grant but allowlist excludes → denied (the decl.allowed_mcp conjunct)
-    assert not AgentLayer(
-        PermissionDecl(mcp=["fs", "web"], allowed_mcp=["fs"])
-    ).allows(AX.MCP, "web")
-    # allowlist None → no per-skill filter, decl.mcp only
-    assert AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=None)).allows(AX.MCP, "fs")
-    # not in decl.mcp → denied even if allowlist includes it
+def _mcp_gate(decl):
+    """The require_mcp MCP ∩ stack (#2074 S4a): AgentLayer(grant) ∩
+    ProfileLayer(per-agent allowlist). Mirrors permissions.require_mcp."""
+    return EffectivePermission(
+        [AgentLayer(decl), ProfileLayer.from_allowlists(allowed_mcp=decl.allowed_mcp)]
+    )
+
+
+def test_agent_layer_mcp_is_grant_only_after_s4a() -> None:
+    """Tier 2: #2074 S4a moved the per-agent allowlist OUT of AgentLayer.MCP — the
+    layer is now the GRANT only (decl.mcp); the allowlist (decl.allowed_mcp) is a
+    separate ProfileLayer (symmetric with the SKILL axis)."""
+    # grant-only: in decl.mcp → True regardless of allowed_mcp (allowlist not here)
+    assert AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=[])).allows(AX.MCP, "fs")
+    # not in decl.mcp → denied (the grant)
     assert not AgentLayer(PermissionDecl(mcp=[], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
+    # the allowlist now lives on ProfileLayer
+    assert ProfileLayer.from_allowlists(allowed_mcp=["fs"]).allows(AX.MCP, "fs")
+    assert not ProfileLayer.from_allowlists(allowed_mcp=["fs"]).allows(AX.MCP, "web")
+
+
+def test_mcp_gate_full_intersection_preserved() -> None:
+    """Tier 2: the FULL require_mcp ∩ (AgentLayer ∩ ProfileLayer) reproduces the
+    pre-S4a ``decl.mcp ∩ decl.allowed_mcp`` decision byte-identically (∩ associative
+    — the migration changed the decomposition, not the gate outcome)."""
+    # in grant + allowlist → permitted
+    assert _mcp_gate(PermissionDecl(mcp=["fs"], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
+    # in grant but allowlist excludes → denied
+    assert not _mcp_gate(PermissionDecl(mcp=["fs", "web"], allowed_mcp=["fs"])).allows(AX.MCP, "web")
+    # allowlist None → no per-agent filter, decl.mcp only
+    assert _mcp_gate(PermissionDecl(mcp=["fs"], allowed_mcp=None)).allows(AX.MCP, "fs")
+    # not in decl.mcp → denied even if allowlist includes it
+    assert not _mcp_gate(PermissionDecl(mcp=[], allowed_mcp=["fs"])).allows(AX.MCP, "fs")
     # allowlist=[] blocks all
-    assert not AgentLayer(PermissionDecl(mcp=["fs"], allowed_mcp=[])).allows(AX.MCP, "fs")
+    assert not _mcp_gate(PermissionDecl(mcp=["fs"], allowed_mcp=[])).allows(AX.MCP, "fs")
 
 
 def test_approval_folded_inside_agent_layer_is_restricted_by_conjunction() -> None:

--- a/tests/test_2074_s1_capability_spec_axes.py
+++ b/tests/test_2074_s1_capability_spec_axes.py
@@ -114,19 +114,9 @@ def test_compose_empty_is_inert() -> None:
 # ── INERTNESS: ContextualLayer still enforces ONLY TOOL (S1 changes no gate) ─
 
 
-def test_contextual_layer_does_not_yet_enforce_mcp() -> None:
-    """Tier 1: the MCP contextual axis is still carried-but-not-enforced — a
-    ContextualPermission that DENIES an mcp value is ⊤ on MCP through
-    ContextualLayer (S1 carries the axis; #2074 S4a wires MCP enforcement, paired
-    with the require_mcp gate). (SKILL is now enforced by S3 — see
-    test_2074_s3_contextual_skill.py.)"""
-    ctx = ContextualPermission(
-        mcp_allow=frozenset({"only-srv"}),
-        mcp_deny=frozenset({"banned-srv"}),
-    )
-    layer = ContextualLayer(ctx)
-    assert layer.allows(AX.MCP, "banned-srv") is True
-    assert layer.allows(AX.MCP, "anything") is True
+# (The S1 MCP-inertness proof was removed in #2074 S4a, which wires the
+# contextual MCP axis — see test_2074_s4a_mcp_unify.py for the MCP enforcement +
+# ⊤-when-unset tests. SKILL enforcement landed in S3.)
 
 
 def test_contextual_layer_still_enforces_tool() -> None:

--- a/tests/test_2074_s4a_mcp_unify.py
+++ b/tests/test_2074_s4a_mcp_unify.py
@@ -1,0 +1,143 @@
+"""Tier 1/2: #2074 S4a — MCP source migration + per-context MCP + identity factor.
+
+S4a completes the MCP axis of the unification:
+- **MCP source migration**: the per-agent MCP allowlist moves OUT of
+  ``AgentLayer.MCP`` (now grant-only) INTO a ``ProfileLayer`` in ``require_mcp``
+  (symmetric with SKILL). Byte-identical at the gate (∩ associative) — guarded by
+  the existing require_mcp suite (test_permissions.py) + test_1199_s31b_mcp_cutover.
+- **per-context MCP**: ``ContextualLayer`` now enforces the MCP axis, and
+  ``require_mcp`` adds it (⊤-when-unset — byte-identical for any context that does
+  not narrow MCP). Mirrors S3's SKILL.
+- **identity factor**: ``AgentProfile.default_profile()`` exposes the canonical
+  unified capability spec (maps the user-facing allowed_skills/allowed_mcp onto the
+  internal skill_allow/mcp_allow; no user-facing rename).
+
+No mocks: real ContextualPermission / ContextualLayer / PermissionResolver (via
+the support factory) / AgentProfile / CapabilityProfile.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    ContextualLayer,
+    ContextualPermission,
+)
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+from tests._support.permissions import make_resolver as _make_resolver
+
+AX = CapabilityAxis
+
+
+class _AutoDenyBus(InterventionBus):
+    """Real auto-denying bus (the config-explicit tests never reach it)."""
+
+    def __init__(self) -> None:
+        self.requests: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.requests.append(iv)
+        return InterventionAnswer(choice_id="no")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── ContextualLayer now enforces the MCP axis ───────────────────────────────
+
+
+def test_contextual_layer_mcp_deny() -> None:
+    """Tier 1: a contextual mcp_deny narrows MCP through ContextualLayer."""
+    layer = ContextualLayer(ContextualPermission(mcp_deny=frozenset({"banned-srv"})))
+    assert layer.allows(AX.MCP, "banned-srv") is False
+    assert layer.allows(AX.MCP, "other-srv") is True
+
+
+def test_contextual_layer_mcp_allow() -> None:
+    """Tier 1: a contextual mcp_allow restricts MCP to its members."""
+    layer = ContextualLayer(ContextualPermission(mcp_allow=frozenset({"only-srv"})))
+    assert layer.allows(AX.MCP, "only-srv") is True
+    assert layer.allows(AX.MCP, "other-srv") is False
+
+
+def test_contextual_layer_mcp_top_when_unset() -> None:
+    """Tier 1: ⊤-when-unset — a context that does not narrow MCP allows all."""
+    assert ContextualLayer(ContextualPermission()).allows(AX.MCP, "anything") is True
+    assert ContextualLayer(None).allows(AX.MCP, "anything") is True
+
+
+# ── require_mcp: per-context MCP enforcement (gate) ─────────────────────────
+
+
+def test_require_mcp_contextual_deny_blocks(tmp_path) -> None:
+    """Tier 2: a contextual mcp_deny refuses a server the per-agent layer grants,
+    with the NEW decision-enabling 'active capability context' message (#2074 S4a)."""
+    resolver = _make_resolver(tmp_path, config={"mcp.fs": "allow"})
+    decl = PermissionDecl(mcp=["fs"], allowed_mcp=None)  # granted + no per-agent narrowing
+    ctx = ContextualPermission(mcp_deny=frozenset({"fs"}))
+    with pytest.raises(PermissionError, match="active capability context"):
+        _run(resolver.require_mcp(decl, "fs", _AutoDenyBus(), contextual=ctx))
+
+
+def test_require_mcp_contextual_none_unchanged(tmp_path) -> None:
+    """Tier 2: contextual=None → byte-identical (a granted server passes)."""
+    resolver = _make_resolver(tmp_path, config={"mcp.fs": "allow"})
+    decl = PermissionDecl(mcp=["fs"], allowed_mcp=None)
+    _run(resolver.require_mcp(decl, "fs", _AutoDenyBus(), contextual=None))  # no raise
+
+
+def test_require_mcp_contextual_unset_is_top(tmp_path) -> None:
+    """Tier 2: a context that does not narrow MCP is ⊤ — granted server still passes
+    (the load-bearing ⊤-when-unset property)."""
+    resolver = _make_resolver(tmp_path, config={"mcp.fs": "allow"})
+    decl = PermissionDecl(mcp=["fs"], allowed_mcp=None)
+    empty = ContextualPermission()  # no mcp narrowing
+    _run(resolver.require_mcp(decl, "fs", _AutoDenyBus(), contextual=empty))  # no raise
+
+
+def test_require_mcp_contextual_does_not_regrant_allowlist(tmp_path) -> None:
+    """Tier 2: a permissive contextual cannot RE-GRANT a server the per-agent
+    allowlist denies (∩ never-elevate). allowed_mcp=[] blocks 'fs' regardless of
+    an empty/permissive context."""
+    resolver = _make_resolver(tmp_path, config={"mcp.fs": "allow"})
+    decl = PermissionDecl(mcp=["fs"], allowed_mcp=[])  # per-agent allowlist blocks all
+    with pytest.raises(PermissionError, match="allowed_mcp"):
+        _run(resolver.require_mcp(decl, "fs", _AutoDenyBus(), contextual=ContextualPermission()))
+
+
+# ── identity factor: AgentProfile.default_profile() ─────────────────────────
+
+
+def test_default_profile_maps_allowlists_to_spec() -> None:
+    """Tier 1: default_profile() maps the user-facing allowed_skills/allowed_mcp
+    onto the unified spec's skill_allow/mcp_allow (internal representation)."""
+    prof = AgentProfile(name="a", allowed_skills=["s1", "s2"], allowed_mcp=["m1"])
+    spec = prof.default_profile()
+    assert spec.skill_allow == ("s1", "s2")
+    assert spec.mcp_allow == ("m1",)
+    assert spec.name == "a"
+
+
+def test_default_profile_none_passthrough() -> None:
+    """Tier 1: None allowlists pass through as None (= ⊤, unrestricted)."""
+    spec = AgentProfile(name="a").default_profile()
+    assert spec.skill_allow is None
+    assert spec.mcp_allow is None
+
+
+# ── FALSIFY NOTE (held-oracle ×3, run + reverted during S4a build) ──────────
+# 1. MCP source migration byte-identical: break AgentLayer.MCP (re-add the
+#    allowlist) or ProfileLayer MCP → test_permissions.py require_mcp suite +
+#    test_1199_s31b_mcp_cutover (_mcp_gate matrix) go RED.
+# 2. MCP contextual: break ContextualLayer.allows(MCP) (force ⊤) →
+#    test_contextual_layer_mcp_deny/_allow + test_require_mcp_contextual_deny_blocks
+#    go RED, while ⊤-when-unset + byte-identical tests stay GREEN.
+# 3. Both deny messages preserved: test_permissions.py (allowed_mcp + not declared)
+#    + test_require_mcp_contextual_deny_blocks (active capability context).
+# Confirmed CLEAN red on each break, green on revert.


### PR DESCRIPTION
**[e2e-coder]** — #2074 stage **S4a** (byte-identical-sensitive — design-call confirmed with lead). Completes the MCP axis of the unification. S1/S2/S3 merged. No-merge — lead close-reviews.

## What (byte-identical)

- **MCP source migration**: `AgentLayer.MCP` is now the **grant only** (`decl.mcp`); the per-agent allowlist (`decl.allowed_mcp`) moves to a `ProfileLayer` in `require_mcp` (symmetric with SKILL). The full gate ∩ — `AgentLayer(grant) ∩ ProfileLayer(allowlist) ∩ ContextualLayer` — is byte-identical to the prior `grant∩allowlist` (∩ associative). `require_mcp` is the **only** MCP-axis gate, so nothing depends on `AgentLayer.MCP`'s standalone shape.
- **per-context MCP**: `ContextualLayer` now enforces MCP; `require_mcp` adds it (`mcp.py` passes `ctx.contextual_permission`). ⊤-when-unset → byte-identical. Mirrors S3 SKILL.
- **deny messages**: 3-way (allowlist / contextual / grant) preserving the original `"not in allowed_mcp"` + `"not declared in skill permissions"` exactly; the contextual message is new.
- **identity factor** (additive): `AgentProfile.default_profile()` exposes the canonical unified spec, mapping the user-facing `allowed_skills`/`allowed_mcp` onto the internal `skill_allow`/`mcp_allow` — **no user-facing rename; profile.yaml keys stay**. S4b repoints the per-agent layers to read this spec object.

**∩-core unchanged.**

## Held-oracle ×3 (falsify, verified + reverted)

1. **MCP migration byte-identical** — break `ProfileLayer.allows(MCP)` → `test_permissions` require_mcp allowlist guard + `test_1199` decomposition RED (4).
2. **MCP contextual ⊤-when-unset** — break `ContextualLayer.allows(MCP)` → contextual-deny RED (3), ⊤-when-unset + byte-identical GREEN.
3. **Both deny messages** — guarded by `test_permissions` (allowlist + not-declared) + the new contextual-message test.

## Test plan

- [x] `tests/test_2074_s4a_mcp_unify.py`: ContextualLayer MCP matrix + require_mcp contextual gate (deny + ⊤-when-unset + never-regrant + new message) + `default_profile()`
- [x] **Falsify ×3** (above) — each break CLEAN red, reverted
- [x] Byte-identical regression — **`test_permissions.py` require_mcp suite passes unchanged** (the decision + both messages); updated `test_1199_s31b_mcp_cutover` (AgentLayer grant-only + full-∩ matrix); removed the obsolete S1 MCP-inertness test (MCP now enforced)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8212 passed, 18 skipped, 3 xfailed**

## Next

S4b: repoint the per-agent layers to read the `default_profile()` spec object + representation alignment + doc the one-spec/two-binding model (byte-identical-sensitive per our discussion — not a cosmetic rubber-stamp; I'll falsify the layer-rewiring). Then **#2074 lands → hot-reload (#2073) unblocks**.

Refs #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)