### PR TITLE
refactor(#2074): S4b — per-agent layer reads the unified spec + doc (FINAL stage, closes #2074)

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -499,19 +499,41 @@ The authorization layers above answer: *"has this capability been granted?"* A s
 At gate time, a capability is permitted only if **every** active layer allows it:
 
 ```
-effective = AgentLayer ∩ SandboxLayer ∩ ProfileLayer
+effective = AgentLayer ∩ SandboxLayer ∩ ProfileLayer ∩ ContextualLayer
 allows(axis, value) = all(layer.allows(axis, value) for layer in layers)
 ```
 
-### The three restrict layers
+### The restrict layers
 
 | Layer | What it models | Role |
 |---|---|---|
 | **AgentLayer** | Skill declaration + default zone baseline + runtime approvals | Grant layer |
 | **SandboxLayer** | Runtime sandbox caps (paths, network, subprocess, env) | Restrict-only |
-| **ProfileLayer** | Agent-level allowlists (skills, MCP servers) | Restrict-only |
+| **ProfileLayer** | Per-agent capability narrowing — the agent's default capability spec | Restrict-only |
+| **ContextualLayer** | Per-session capability narrowing — delegation / topology / untrusted-auto | Restrict-only |
 
-`SandboxLayer` and `ProfileLayer` are **restrict-only**: they can narrow a permission, but cannot re-grant something the `AgentLayer` denied. This is a structural property of the conjunction (`all(...)`) — no layer's `False` can be overridden by any other layer.
+`SandboxLayer`, `ProfileLayer`, and `ContextualLayer` are **restrict-only**: they can narrow a permission, but cannot re-grant something the `AgentLayer` denied. This is a structural property of the conjunction (`all(...)`) — no layer's `False` can be overridden by any other layer.
+
+### One spec, two binding adapters (#2074)
+
+The two narrowing layers are **two bindings of one primitive**: both read a
+`CapabilityProfile` (the single capability-narrowing spec, covering the
+`skill` / `mcp` / `tool` axes + catalog-`category` visibility), separating the
+*spec* (what is narrowed) from the *binding* (when/how it is applied):
+
+- **`ProfileLayer` — per-agent default binding.** Reads the agent's
+  `AgentProfile.default_profile()` (a `CapabilityProfile`). The operator surface
+  stays the natural `allowed_skills` / `allowed_mcp` keys in
+  `.reyn/agents/<name>/profile.yaml`; these map onto the spec's `skill_allow` /
+  `mcp_allow` axes internally.
+- **`ContextualLayer` — per-session dynamic binding.** Reads a `CapabilityProfile`
+  resolved per-session from a delegation / topology role / untrusted-content
+  auto-profile (`.reyn/capability_profiles/<name>.yaml`), composable
+  (most-restrictive-wins) and subtractive-only.
+
+Both feed the **unchanged** conjunctive ∩ above. A `None` spec, or a `None`
+axis allow-list, is unrestricted (⊤) — so an agent/session with no narrowing is
+byte-identical to a build without the capability spec.
 
 ### How the two "layer" concepts relate
 

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -160,7 +160,7 @@ async def handle(op: MCPIROp, ctx: OpContext, caller: Literal["preprocessor", "c
             raise RuntimeError("mcp op requires intervention_bus on OpContext")
         await ctx.permission_resolver.require_mcp(
             ctx.permission_decl, op.server, ctx.intervention_bus,
-            contextual=getattr(ctx, "contextual_permission", None),  # #2074 S4a
+            contextual=ctx.contextual_permission,  # #2074 S4a/S4b (OpContext field)
         )
     return await _execute(op, ctx)
 

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -39,6 +39,7 @@ from reyn.security.permissions.permissions import (
 
 if TYPE_CHECKING:
     from reyn.runtime.profile import AgentProfile
+    from reyn.security.permissions.capability_profile import CapabilityProfile
     from reyn.security.permissions.permissions import PermissionDecl
     from reyn.security.sandbox.policy import SandboxPolicy
 
@@ -204,27 +205,18 @@ class SandboxLayer:
         return True
 
 
-@dataclass(frozen=True)
-class _AllowlistSource:
-    """A minimal :class:`ProfileLayer` source carrying just the per-agent
-    allowlists (#2074 S2). Lets a caller route an already-extracted
-    ``allowed_skills`` / ``allowed_mcp`` through ``ProfileLayer`` (the single
-    SKILL/MCP-axis decision) without synthesizing a full ``AgentProfile``.
-    ``None`` = unrestricted on that axis (⊤). Duck-typed by ProfileLayer
-    (``.allowed_skills`` / ``.allowed_mcp``). S4a repoints the per-agent layer at
-    the unified capability spec."""
-
-    allowed_skills: "frozenset[str] | None" = None
-    allowed_mcp: "frozenset[str] | None" = None
-
-
 class ProfileLayer:
-    """The ALLOWLIST layer: ``AgentProfile`` agent-level allowlists. ``None`` means
-    no per-agent restriction (⊤). Generalizes the existing ``allowed_mcp`` ∩
-    precedent (agent-list ∩ project) to the unified model."""
+    """The per-agent ALLOWLIST layer (#2074) — reads the agent's **default
+    capability spec** (a :class:`CapabilityProfile`) on the SKILL / MCP axes, so one
+    primitive (the unified spec) feeds both binding adapters (per-agent + per-context).
 
-    def __init__(self, profile: "AgentProfile | _AllowlistSource | None") -> None:
-        self._profile = profile
+    The spec is ``AgentProfile.default_profile()`` where the profile is available
+    (the canonical source), else built from already-extracted allowlists via
+    :meth:`from_allowlists` (byte-identical — the same ``skill_allow`` / ``mcp_allow``
+    values). A ``None`` spec, or a ``None`` axis allow-list, is unrestricted (⊤)."""
+
+    def __init__(self, spec: "CapabilityProfile | None") -> None:
+        self._spec = spec
 
     @classmethod
     def from_allowlists(
@@ -233,24 +225,27 @@ class ProfileLayer:
         allowed_skills: "object | None" = None,
         allowed_mcp: "object | None" = None,
     ) -> "ProfileLayer":
-        """Build a per-agent layer from raw allowlists (#2074 S2). ``None`` =
-        unrestricted on that axis; an empty / non-empty collection narrows to
-        exactly its members — byte-identical to the legacy inline check
-        ``allowed is None or value in allowed``."""
-        return cls(_AllowlistSource(
-            allowed_skills=frozenset(allowed_skills) if allowed_skills is not None else None,
-            allowed_mcp=frozenset(allowed_mcp) if allowed_mcp is not None else None,
+        """Build a per-agent layer from already-extracted ``allowed_skills`` /
+        ``allowed_mcp`` by wrapping them in the canonical capability spec (#2074 S4b).
+        Byte-identical to ``AgentProfile.default_profile()`` (same skill_allow/
+        mcp_allow values). ``None`` = unrestricted on that axis."""
+        from reyn.security.permissions.capability_profile import CapabilityProfile
+
+        return cls(CapabilityProfile(
+            name="_per_agent_default",
+            skill_allow=tuple(allowed_skills) if allowed_skills is not None else None,
+            mcp_allow=tuple(allowed_mcp) if allowed_mcp is not None else None,
         ))
 
     def allows(self, axis: CapabilityAxis, value: Any) -> bool:
-        pr = self._profile
-        if pr is None:
+        sp = self._spec
+        if sp is None:
             return True
         if axis is CapabilityAxis.SKILL:
-            return pr.allowed_skills is None or value in pr.allowed_skills
+            return sp.skill_allow is None or value in sp.skill_allow
         if axis is CapabilityAxis.MCP:
-            return pr.allowed_mcp is None or value in pr.allowed_mcp
-        return True  # profile constrains only skill / mcp
+            return sp.mcp_allow is None or value in sp.mcp_allow
+        return True  # the per-agent spec constrains only skill / mcp (allow-lists)
 
 
 @dataclass(frozen=True)
@@ -417,5 +412,7 @@ class EffectivePermission:
         return cls([
             AgentLayer(decl, approval_check=approval_check, file_zone_root=file_zone_root),
             SandboxLayer(sandbox_policy),
-            ProfileLayer(profile),
+            # #2074 S4b: the per-agent layer reads the agent's default capability
+            # spec (the unified primitive), not the AgentProfile directly.
+            ProfileLayer(profile.default_profile() if profile is not None else None),
         ])

--- a/tests/test_1199_effective_permission.py
+++ b/tests/test_1199_effective_permission.py
@@ -69,7 +69,9 @@ def test_falsification_removing_a_layer_regrants_a_denied_capability() -> None:
 
     # Same shape for a profile deny (skill allowlist):
     prof = AgentProfile(name="a", allowed_skills=["allowed_skill"])
-    eff = EffectivePermission([AgentLayer(PermissionDecl()), ProfileLayer(prof)])
+    eff = EffectivePermission(
+        [AgentLayer(PermissionDecl()), ProfileLayer(prof.default_profile())]
+    )
     assert eff.allows(AX.SKILL, "blocked_skill") is False
     assert EffectivePermission([AgentLayer(PermissionDecl())]).allows(
         AX.SKILL, "blocked_skill"
@@ -108,7 +110,7 @@ def test_unconstrained_axis_is_top() -> None:
     narrows the ∩ on those axes (the sandbox doesn't gate skills; the profile
     doesn't gate files)."""
     assert SandboxLayer(SandboxPolicy()).allows(AX.SKILL, "any") is True
-    assert ProfileLayer(AgentProfile(name="a")).allows(AX.FILE_WRITE, "/x") is True
+    assert ProfileLayer(AgentProfile(name="a").default_profile()).allows(AX.FILE_WRITE, "/x") is True
     # None layers are fully ⊤.
     assert SandboxLayer(None).allows(AX.FILE_WRITE, "/anything") is True
     assert ProfileLayer(None).allows(AX.MCP, "any-server") is True

--- a/tests/test_2074_s2_skill_gate.py
+++ b/tests/test_2074_s2_skill_gate.py
@@ -72,15 +72,16 @@ def test_skill_allowed_is_the_profilelayer_decision(allowed, name) -> None:
 
 @pytest.mark.parametrize("allowed", [None, [], ["a"], ["a", "b"]])
 @pytest.mark.parametrize("name", ["a", "b", "z"])
-def test_from_allowlists_matches_agentprofile_source(allowed, name) -> None:
+def test_from_allowlists_matches_default_profile_source(allowed, name) -> None:
     """Tier 1: ProfileLayer.from_allowlists(allowed_skills=L) is byte-identical to
-    ProfileLayer(AgentProfile(allowed_skills=L)) on the SKILL axis — the S2 factory
-    introduces no semantic drift from the existing AgentProfile-backed layer."""
+    reading the agent's spec ProfileLayer(AgentProfile(allowed_skills=L).default_profile())
+    on the SKILL axis — the #2074 S4b extracted-vs-spec read identity (default_profile().
+    skill_allow == allowed_skills), so the layer-rewiring introduces no drift."""
     from_factory = ProfileLayer.from_allowlists(allowed_skills=allowed).allows(AX.SKILL, name)
-    from_profile = ProfileLayer(
-        AgentProfile(name="_", allowed_skills=allowed)
+    from_spec = ProfileLayer(
+        AgentProfile(name="_", allowed_skills=allowed).default_profile()
     ).allows(AX.SKILL, name)
-    assert from_factory is from_profile
+    assert from_factory is from_spec
 
 
 def test_skill_allowed_does_not_constrain_other_axes() -> None:

--- a/tests/test_2074_s4b_spec_read.py
+++ b/tests/test_2074_s4b_spec_read.py
@@ -1,0 +1,89 @@
+"""Tier 1: #2074 S4b — the per-agent ProfileLayer reads the unified capability spec.
+
+S4b repoints the per-agent ∩ layer to read ``AgentProfile.default_profile()`` (a
+``CapabilityProfile`` — the single unified primitive) on its ``skill_allow`` /
+``mcp_allow`` axes, instead of the extracted ``allowed_skills`` / ``allowed_mcp``
+values (or the old ``_AllowlistSource``). This completes the one-spec / two-binding
+model: BOTH binding adapters (per-agent ProfileLayer + per-context ContextualLayer)
+now read a ``CapabilityProfile``.
+
+**Byte-identical**: ``default_profile().skill_allow == allowed_skills`` (same
+values), so the read-source rewiring changes no outcome — proven by the
+extracted-vs-spec identity below. The falsify is the spec-read itself: breaking
+``ProfileLayer.allows`` (the spec membership) turns the per-agent SKILL/MCP gates
+RED (the existing S2/S4a site + gate oracles).
+
+No mocks: real CapabilityProfile / AgentProfile / ProfileLayer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.profile import AgentProfile
+from reyn.security.permissions.capability_profile import CapabilityProfile
+from reyn.security.permissions.effective import CapabilityAxis, ProfileLayer
+
+AX = CapabilityAxis
+
+
+# ── ProfileLayer reads the spec's skill_allow / mcp_allow ───────────────────
+
+
+def test_profile_layer_reads_spec_skill_axis() -> None:
+    """Tier 1: ProfileLayer reads CapabilityProfile.skill_allow (None = ⊤)."""
+    layer = ProfileLayer(CapabilityProfile(name="p", skill_allow=("a",)))
+    assert layer.allows(AX.SKILL, "a") is True
+    assert layer.allows(AX.SKILL, "b") is False
+    # skill_allow None → unrestricted
+    assert ProfileLayer(CapabilityProfile(name="p")).allows(AX.SKILL, "anything") is True
+    # None spec → ⊤
+    assert ProfileLayer(None).allows(AX.SKILL, "anything") is True
+
+
+def test_profile_layer_reads_spec_mcp_axis() -> None:
+    """Tier 1: ProfileLayer reads CapabilityProfile.mcp_allow (None = ⊤)."""
+    layer = ProfileLayer(CapabilityProfile(name="p", mcp_allow=("srv",)))
+    assert layer.allows(AX.MCP, "srv") is True
+    assert layer.allows(AX.MCP, "other") is False
+    assert ProfileLayer(CapabilityProfile(name="p")).allows(AX.MCP, "anything") is True
+
+
+# ── default_profile() feeds the per-agent layer ─────────────────────────────
+
+
+def test_default_profile_feeds_profile_layer() -> None:
+    """Tier 1: ProfileLayer(agent.default_profile()) enforces the agent's
+    allowed_skills/allowed_mcp via the spec's skill_allow/mcp_allow."""
+    agent = AgentProfile(name="a", allowed_skills=["s1"], allowed_mcp=["m1"])
+    layer = ProfileLayer(agent.default_profile())
+    assert layer.allows(AX.SKILL, "s1") is True
+    assert layer.allows(AX.SKILL, "s2") is False
+    assert layer.allows(AX.MCP, "m1") is True
+    assert layer.allows(AX.MCP, "m2") is False
+
+
+# ── the read-source rewiring identity (the S4b falsify oracle) ──────────────
+
+
+@pytest.mark.parametrize("allowed", [None, [], ["a"], ["a", "b"]])
+@pytest.mark.parametrize("name", ["a", "b", "z"])
+def test_spec_read_matches_extracted_skill(allowed, name) -> None:
+    """Tier 1: reading the spec (default_profile().skill_allow) is byte-identical to
+    the extracted-allowlist read (from_allowlists) on SKILL — so S4b's layer
+    rewiring is byte-identical. Breaking ProfileLayer's spec-read flips BOTH."""
+    via_spec = ProfileLayer(
+        AgentProfile(name="_", allowed_skills=allowed).default_profile()
+    ).allows(AX.SKILL, name)
+    via_extracted = ProfileLayer.from_allowlists(allowed_skills=allowed).allows(AX.SKILL, name)
+    assert via_spec is via_extracted
+
+
+@pytest.mark.parametrize("allowed", [None, [], ["m1"], ["m1", "m2"]])
+@pytest.mark.parametrize("name", ["m1", "m2", "z"])
+def test_spec_read_matches_extracted_mcp(allowed, name) -> None:
+    """Tier 1: same read-source identity on the MCP axis (require_mcp's ProfileLayer)."""
+    via_spec = ProfileLayer(
+        AgentProfile(name="_", allowed_mcp=allowed).default_profile()
+    ).allows(AX.MCP, name)
+    via_extracted = ProfileLayer.from_allowlists(allowed_mcp=allowed).allows(AX.MCP, name)
+    assert via_spec is via_extracted


### PR DESCRIPTION
**[e2e-coder]** — #2074 **final stage S4b**. The per-agent `ProfileLayer` now reads the unified capability spec, completing the one-spec / two-binding-adapter model. S1–S4a merged. Closes #2074. No-merge — lead close-reviews.

## What (byte-identical; internal read-source convergence)

- `effective.py`: `ProfileLayer` reads a `CapabilityProfile` on its `skill_allow`/`mcp_allow` axes (was `_AllowlistSource`/`AgentProfile` fields). `_AllowlistSource` removed. `from_allowlists()` wraps extracted allowlists in the canonical spec — **byte-identical to `AgentProfile.default_profile()`** (same values). `EffectivePermission.of()` passes `profile.default_profile()`.
- **Both ∩ binding adapters now read a `CapabilityProfile`**: `ProfileLayer` (per-agent default) + `ContextualLayer` (per-context). One spec, two bindings — spec (what) separated from binding (when/how).
- `mcp.py`: `getattr(ctx,"contextual_permission")` → direct `ctx.contextual_permission` (defined OpContext field; lead's S4a note).
- **No user-facing rename** — profile.yaml keys stay `allowed_skills`/`allowed_mcp`; only the internal read-source converges.
- Doc: `permission-model.md` gains `ContextualLayer` in the ∩ + the one-spec/two-binding section.

**∩-core unchanged.**

## Held-oracle (falsify)

Break `ProfileLayer`'s spec-read (`skill_allow` membership) → the per-agent SKILL gates RED: the S2 seam + **all 3 site oracles** (spawn A/B + catalog) + the S4b spec-read tests. Proves the per-agent decision flows through the spec-read. Verified, reverted. Byte-identical proven by the **extracted-vs-spec read identity** (`default_profile().skill_allow == allowed_skills`) on SKILL + MCP.

## Test plan

- [x] `tests/test_2074_s4b_spec_read.py`: ProfileLayer reads the spec (skill/mcp) + `default_profile()` feeds it + the extracted-vs-spec identity (parametrized SKILL + MCP)
- [x] **Falsify** — break the spec-read → 8 RED (S2 seam + 3 site oracles + S4b); reverted → green
- [x] Byte-identical regression — `test_permissions` require_mcp suite + `test_1199` + S2/S3/S4a pass (updated `ProfileLayer(AgentProfile)` → `.default_profile()`)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8239 passed, 18 skipped, 3 xfailed**

## #2074 COMPLETE

S1 (spec) → S2 (SKILL ∩) → S3 (per-context SKILL) → S4a (MCP + identity) → **S4b (spec-read + doc)**. One capability primitive, two binding adapters, unchanged ∩-core, byte-identical throughout. On merge → **#2073 hot-reload + #2076 docs unblock**.

Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)