### PR TITLE
feat(#2073): S1 — HotReloader core (turn-boundary safe-point + config_reloaded event + /reload)

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -495,6 +495,42 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     return _cfg
 
 
+# ---------------------------------------------------------------------------
+# Hot-reload IN-set loader (#2073)
+# ---------------------------------------------------------------------------
+
+# The IN-set = the runtime-mutable ``.reyn/*.yaml`` registries (the only files the
+# hot-reload mechanism re-reads). The OUT-set (``reyn.yaml`` — security /
+# permission / sandbox / budget / the loop valve / state-coupled runtime) is loaded
+# ONCE at startup by ``load_config`` and is restart-only; the file-split IS the
+# write-gate boundary (owner-confirmed #2073). Keep this list narrow + explicit.
+_HOT_RELOAD_FILES: tuple[str, ...] = ("mcp.yaml", "cron.yaml")
+
+
+def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
+    """Load ONLY the hot-reloadable IN-set (the runtime-mutable ``.reyn/*.yaml``
+    registries) for a config hot-reload (#2073).
+
+    Distinct from :func:`load_config`: this reads **none** of the OUT-set
+    (``reyn.yaml`` / ``reyn.local.yaml`` / ``~/.reyn/config.yaml``) — those are
+    restart-only. Reading exactly ``.reyn/<f>`` for ``f`` in
+    :data:`_HOT_RELOAD_FILES` is the structural safety boundary: a hot-reload (and
+    the LLM-op that triggers it) can never touch the OUT-set, because this loader
+    never opens those files.
+
+    Returns the merged IN-set dict (``{"mcp": …, "cron": …}``) with ``${VAR}``
+    interpolation applied (mirrors ``load_config`` so MCP server secrets resolve).
+    An absent ``.reyn/`` dir or missing file yields ``{}`` for that component
+    (``_load_yaml`` returns ``{}`` on absence) — a no-op reload, never an error.
+    """
+    root = (project_root or Path.cwd()).resolve()
+    merged: dict = {}
+    for fname in _HOT_RELOAD_FILES:
+        merged = _merge(merged, _load_yaml(root / ".reyn" / fname))
+    from reyn.security.secrets.interpolation import expand_env
+    return expand_env(merged)
+
+
 def _build_external_transports_config(raw: object):
     """Parse the ``external_transports:`` section (FP-0041 #489 PR-D2).
 

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -250,6 +250,7 @@ from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.interfaces.slash import model as _model_mod  # noqa: E402, F401
 from reyn.interfaces.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.interfaces.slash import quit as _quit_mod  # noqa: E402, F401
+from reyn.interfaces.slash import reload as _reload_mod  # noqa: E402, F401
 from reyn.interfaces.slash import reset as _reset_mod  # noqa: E402, F401
 from reyn.interfaces.slash import rewind as _rewind_mod  # noqa: E402, F401
 from reyn.interfaces.slash import save as _save_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/reload.py
+++ b/src/reyn/interfaces/slash/reload.py
@@ -1,0 +1,49 @@
+"""``/reload`` — hot-reload the runtime IN-set config at the next turn boundary (#2073).
+
+Schedules a config hot-reload: the runtime-mutable IN-set (``.reyn/*.yaml`` —
+MCP servers, cron jobs, …) is re-read and reapplied at the **turn boundary**
+(finish-reason=stop), so the next turn runs under the new config (1 turn = 1 config
+snapshot, never mid-turn).
+
+The startup OUT-set (``reyn.yaml`` — security / permissions / sandbox / budget / the
+loop valve) is **restart-only** and is never touched by a hot-reload — the file-split
+is the structural write-gate boundary.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.interfaces.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+
+@slash(
+    "reload",
+    summary="Hot-reload runtime config (.reyn/*.yaml) at the next turn boundary",
+    usage="/reload",
+    see_also=("docs/concepts/runtime/permission-model.md",),
+)
+async def reload_cmd(session: "Session", args: str) -> None:
+    """``/reload`` — schedule a runtime config hot-reload.
+
+    The IN-set (``.reyn/*.yaml``) is re-read + reapplied at the next turn boundary;
+    the startup ``reyn.yaml`` is restart-only. Fail-loud if the reloader is absent.
+    """
+    reloader = getattr(session, "_hot_reloader", None)
+    if reloader is None:
+        await reply_error(
+            session,
+            "config hot-reload is not available in this session "
+            "(no hot-reloader wired).",
+        )
+        return
+
+    reloader.request_reload(source="operator")
+    await reply(
+        session,
+        "✓ Config reload scheduled — the runtime IN-set (.reyn/*.yaml) is re-read "
+        "and reapplied at the next turn boundary. (Startup config in reyn.yaml is "
+        "restart-only.)",
+    )

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -1,0 +1,119 @@
+"""HotReloader — IN-set config hot-reload at the turn boundary (#2073).
+
+The OUT-set (``reyn.yaml``: security / permission / sandbox / budget / the loop
+valve / state-coupled runtime) is loaded ONCE at startup and **never reloaded** —
+the HotReloader reads ONLY the IN-set (the runtime-mutable ``.reyn/*.yaml``
+registries, via :func:`reyn.config.loader.load_hot_reload_config`). The file-split
+IS the write-gate boundary (owner-confirmed): a reload — and the LLM-op that
+triggers one — can never touch the OUT-set, because the loader never opens it.
+
+Timing-B (owner-confirmed): a trigger **schedules** a reload
+(:meth:`request_reload`); it **applies** at the turn boundary (finish-reason=stop —
+the #1800 ``turn_end`` safe-point). 1 turn = 1 config snapshot, never mid-turn; the
+next turn runs under the new config.
+
+On apply: re-read the IN-set → reapply each registered component seam → emit the
+``config_reloaded`` P6 event → clear pending. **#2073 S1** establishes the
+orchestration + the safety boundary + the event + the operator trigger; the
+per-component reapply **seams are wired in S2** (this stage runs with none, so a
+reload is a re-read + event only).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from reyn.config.loader import load_hot_reload_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+# A component reapply seam: ``(name, async fn(in_set) -> changed: bool)``. #2073 S2
+# wires the per-component seams (mcp / cron / hooks / per-agent capability / …).
+ReapplySeam = tuple[str, Callable[[dict], Awaitable[bool]]]
+
+
+class HotReloader:
+    """Schedules + applies an IN-set config reload at the turn boundary (#2073)."""
+
+    def __init__(
+        self,
+        *,
+        project_root: "Path | None",
+        events: "object | None",
+        seams: "list[ReapplySeam] | None" = None,
+    ) -> None:
+        self._project_root = project_root
+        self._events = events
+        self._seams: list[ReapplySeam] = list(seams or [])
+        self._pending = False
+        self._pending_source: "str | None" = None
+
+    @property
+    def pending(self) -> bool:
+        """True iff a reload is scheduled and not yet applied."""
+        return self._pending
+
+    def register_seam(self, name: str, fn: "Callable[[dict], Awaitable[bool]]") -> None:
+        """Register a per-component reapply seam (#2073 S2). ``fn(in_set)`` returns
+        whether it changed anything; it must not raise (the applier isolates it)."""
+        self._seams.append((name, fn))
+
+    def request_reload(self, *, source: str) -> None:
+        """Schedule a reload at the next turn boundary (operator command / LLM-op).
+
+        Idempotent within a turn: repeated requests collapse into one apply (1 turn
+        = 1 config snapshot). ``source`` is recorded on the ``config_reloaded`` event
+        for the audit trail (e.g. ``"operator"`` / ``"llm_op"``)."""
+        self._pending = True
+        self._pending_source = source
+        _log.info(
+            "hot-reload scheduled (source=%s) — applies at the next turn boundary", source,
+        )
+
+    async def apply_pending(self) -> "dict | None":
+        """At the turn boundary: if a reload is pending, re-read the IN-set, reapply
+        each component seam, emit ``config_reloaded`` (P6), and clear pending.
+
+        Returns a summary ``{"source", "applied", "failed"}`` when a reload was
+        applied, or ``None`` when nothing was pending (the zero-overhead no-op — a
+        session that never reloads is byte-identical to a build without this).
+
+        Never raises out: a seam failure is logged + recorded under ``failed`` and
+        the turn loop proceeds (a misbehaving reload can never break the run-loop).
+        """
+        if not self._pending:
+            return None
+        source = self._pending_source
+        self._pending = False
+        self._pending_source = None
+
+        # Safety boundary: re-read ONLY the IN-set (.reyn/*.yaml). The OUT-set
+        # (reyn.yaml) is never opened here, so a reload cannot touch it.
+        in_set = load_hot_reload_config(self._project_root)
+
+        applied: list[str] = []
+        failed: list[str] = []
+        for name, fn in self._seams:
+            try:
+                if await fn(in_set):
+                    applied.append(name)
+            except Exception as exc:  # noqa: BLE001 — a seam never breaks the loop
+                _log.warning("hot-reload seam %r failed: %s", name, exc)
+                failed.append(name)
+
+        if self._events is not None:
+            # P6 audit (review-focus b): every config change is an evented,
+            # replay-capable state change.
+            self._events.emit(
+                "config_reloaded",
+                source=source or "unknown",
+                components=applied,
+                failed=failed,
+            )
+        return {"source": source, "applied": applied, "failed": failed}
+
+
+__all__ = ["HotReloader", "ReapplySeam"]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -445,8 +445,14 @@ _STATE_CHANGE_EVENT_MAPPINGS: dict[str, tuple[str, str]] = {
         "index_drop",
         "Indexed source '{source}' was removed.",
     ),
+    # Config hot-reload (#2073): the HotReloader emits this at the turn boundary
+    # after re-reading the IN-set (.reyn/*.yaml) + reapplying components, so the LLM
+    # sees that its runtime config changed (e.g. a newly-reloaded MCP server / hook).
+    "config_reloaded": (
+        "config_watcher",
+        "Reyn configuration was hot-reloaded (source: {source}).",
+    ),
     # Future emitter slots (= add when wired):
-    # "config_reloaded":  ("config_watcher", "Reyn configuration was updated."),
     # "sp_version_changed": ("sp_loader",   "Agent system prompt was updated to version {version}."),
 }
 
@@ -1307,6 +1313,14 @@ class Session:
         self._chat_events = EventLog(
             subscribers=[self._event_store],
             agent_id=self._agent_id,  # FP-0016 E: auto-inject agent_id into every event
+        )
+        # #2073 S1: the config hot-reloader. Reads ONLY the IN-set (.reyn/*.yaml);
+        # the OUT-set (reyn.yaml) is restart-only. Applies at the turn_end safe-point
+        # (apply_pending below). Per-component reapply seams are registered in S2.
+        from reyn.runtime.hot_reload import HotReloader
+        self._hot_reloader = HotReloader(
+            project_root=getattr(self._registry, "_project_root", None) or Path.cwd(),
+            events=self._chat_events,
         )
         # #1669: publish this session's EventLog as the ambient sink for the LLM
         # acompletion chokepoint, so every in-session LLM call emits an observable
@@ -5038,6 +5052,12 @@ class Session:
             {"point": "turn_end", "agent_name": self.agent_name,
              "chain_id": chain_id, "user_text": user_text},
         )
+        # #2073 S1: config hot-reload safe-point (Timing-B). A reload scheduled
+        # during/before this turn applies HERE — at the turn boundary
+        # (finish-reason=stop), never mid-turn — so the next turn runs under the new
+        # IN-set config (1 turn = 1 config snapshot). No-op (returns None) when no
+        # reload is pending → zero overhead on the happy path.
+        await self._hot_reloader.apply_pending()
         # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
         # user message is this checkpoint's anchor for the rewind-timeline preview.
         # #1533 2c: the FULL message is persisted alongside (edit-prefill source).

--- a/tests/test_2073_s1_hot_reloader.py
+++ b/tests/test_2073_s1_hot_reloader.py
@@ -1,0 +1,141 @@
+"""Tier 2: #2073 S1 — HotReloader core (safe-point orchestration + IN-set boundary).
+
+S1 establishes the config hot-reload skeleton: schedule (request_reload) → apply at
+the turn boundary (apply_pending) → re-read ONLY the IN-set (.reyn/*.yaml) → reapply
+each seam (none in S1) → emit config_reloaded (P6). The load-bearing safety invariant
+is the file-split: the loader NEVER reads the OUT-set (reyn.yaml), so a reload — and
+the LLM-op that triggers one — cannot touch security/budget/valve.
+
+No mocks: real EventLog / HotReloader / the real load_hot_reload_config loader.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.loader import load_hot_reload_config
+from reyn.core.events.events import EventLog
+from reyn.runtime.hot_reload import HotReloader
+
+# ── SAFETY: the IN-set boundary (the OUT-set is never read) ──────────────────
+
+
+def test_load_hot_reload_config_reads_only_in_set(tmp_path: Path) -> None:
+    """Tier 2: load_hot_reload_config reads ONLY the IN-set (.reyn/*.yaml). The
+    OUT-set (reyn.yaml security/budget/valve) is NEVER opened — the structural
+    write-gate boundary (review-focus d)."""
+    # OUT-set: reyn.yaml with security + budget keys
+    (tmp_path / "reyn.yaml").write_text(
+        "permissions:\n  shell: deny\nbudget:\n  daily_usd: 5\n", encoding="utf-8",
+    )
+    # IN-set: .reyn/mcp.yaml
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    (reyn_dir / "mcp.yaml").write_text(
+        "mcp:\n  servers:\n    fs:\n      type: stdio\n", encoding="utf-8",
+    )
+    in_set = load_hot_reload_config(tmp_path)
+    assert "mcp" in in_set                 # IN-set IS read
+    assert "permissions" not in in_set     # OUT-set NEVER read
+    assert "budget" not in in_set
+
+
+def test_load_hot_reload_config_absent_is_empty_noop(tmp_path: Path) -> None:
+    """Tier 2: no .reyn/ dir → {} (a no-op reload, never an error)."""
+    assert load_hot_reload_config(tmp_path) == {}
+
+
+# ── orchestration: schedule → apply → event → clear ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_nothing_pending_is_noop(tmp_path: Path) -> None:
+    """Tier 2: apply_pending with no scheduled reload returns None + emits nothing
+    (zero-overhead happy path)."""
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    assert hr.pending is False
+    assert await hr.apply_pending() is None
+    assert [e.type for e in events.all()] == []
+
+
+@pytest.mark.asyncio
+async def test_request_then_apply_emits_event_and_clears(tmp_path: Path) -> None:
+    """Tier 2: request_reload schedules; apply_pending re-reads the IN-set, emits the
+    config_reloaded P6 event (review-focus b), and clears pending."""
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    hr.request_reload(source="operator")
+    assert hr.pending is True
+
+    summary = await hr.apply_pending()
+    assert summary is not None and summary["source"] == "operator"
+    assert hr.pending is False
+    reloaded_sources = [
+        e.data["source"] for e in events.all() if e.type == "config_reloaded"
+    ]
+    assert reloaded_sources == ["operator"]  # exactly one reload, by the operator
+
+
+@pytest.mark.asyncio
+async def test_idempotent_within_turn(tmp_path: Path) -> None:
+    """Tier 2: multiple requests before a boundary collapse into ONE apply (1 turn =
+    1 config snapshot); the last source wins."""
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    hr.request_reload(source="a")
+    hr.request_reload(source="b")
+    summary = await hr.apply_pending()
+    assert summary["source"] == "b"
+    assert await hr.apply_pending() is None  # only one apply
+    # collapsed into a single apply (one event), last source wins
+    assert [
+        e.data["source"] for e in events.all() if e.type == "config_reloaded"
+    ] == ["b"]
+
+
+# ── seams: per-component reapply hook (S2 wires real seams) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_seams_called_with_in_set_and_isolated(tmp_path: Path) -> None:
+    """Tier 2: each registered seam is called with the re-read IN-set; a raising seam
+    is isolated (recorded under `failed`, never breaks the apply)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    (reyn_dir / "mcp.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    seen: dict = {}
+
+    async def good(in_set: dict) -> bool:
+        seen["in_set"] = in_set
+        return True
+
+    async def bad(in_set: dict) -> bool:
+        raise RuntimeError("boom")
+
+    hr.register_seam("good", good)
+    hr.register_seam("bad", bad)
+    hr.request_reload(source="llm_op")
+    summary = await hr.apply_pending()
+
+    assert summary["applied"] == ["good"]
+    assert summary["failed"] == ["bad"]
+    assert "mcp" in seen["in_set"]  # the seam received the re-read IN-set
+
+
+# ── wiring: the config_reloaded notification + the /reload command ──────────
+
+
+def test_config_reloaded_event_in_notification_map() -> None:
+    """Tier 2: config_reloaded is wired into the state-change notification map (so the
+    reload surfaces to the LLM), not just emitted to the log."""
+    from reyn.runtime.session import _STATE_CHANGE_EVENT_MAPPINGS
+    assert "config_reloaded" in _STATE_CHANGE_EVENT_MAPPINGS
+
+
+def test_reload_slash_command_registered() -> None:
+    """Tier 2: the operator /reload command is registered."""
+    from reyn.interfaces.slash import REGISTRY
+    assert REGISTRY.get("reload") is not None


### PR DESCRIPTION
**[e2e-coder]** — #2073 config hot-reload, stage **S1** (HotReloader core). Recon-confirmed + slicing lead-approved on #2073. No-merge — lead close-reviews. (New feature — reuses existing seams + tests the orchestration + safety invariants, not byte-identical.)

## What

Establishes the hot-reload orchestration skeleton + the OUT/IN safety boundary + the P6 event + the operator trigger. **Per-component reapply seams are S2** (S1 runs with none → a reload is a re-read + event).

- **`config/loader.py`** `load_hot_reload_config(project_root)` — reads **ONLY the IN-set** (`.reyn/*.yaml` runtime-mutable registries). The OUT-set (`reyn.yaml` security/budget/valve) is **never opened** — the file-split IS the write-gate boundary (owner-confirmed).
- **`runtime/hot_reload.py`** `HotReloader` — `request_reload(source)` schedules; `apply_pending()` applies at the turn boundary (re-read IN-set → reapply each seam → emit `config_reloaded` → clear pending). Idempotent within a turn (1 turn = 1 snapshot); seam failures isolated; `None` no-op when nothing pending.
- **`session.py`** — construct the HotReloader; `apply_pending()` at the **turn_end safe-point** (finish-reason=stop, the #1800 dispatch) — never mid-turn → the next turn runs under the new config. Wire the `config_reloaded` notification (the pre-stubbed slot).
- **`/reload`** slash command — operator trigger.

## Review focus (lead's a–d)

- **(a) Safe-point**: `apply_pending` at the turn_end boundary (finish-reason=stop); the LLM-op (S3) schedules mid-turn → applies at turn_end → the next (possibly hook-triggered) turn runs under new config. Never mid-turn.
- **(b) config_reloaded**: a real P6 event (`events.emit`, audited/replay-capable) + the notification-map slot.
- **(c) Reload-command**: `/reload` → `request_reload` → applies at the boundary.
- **(d) SAFETY by construction**: `load_hot_reload_config` opens only `.reyn/*.yaml`; **the OUT-set is structurally unreachable** by a reload — tested.

## Test plan

- [x] `tests/test_2073_s1_hot_reloader.py` (Tier 2): IN-set boundary (OUT-set never read) + schedule/apply/no-op + idempotency + config_reloaded P6 event + seam isolation + notification-map + `/reload` registration
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8247 passed, 18 skipped, 3 xfailed** (+8 S1; no regression — `apply_pending` is a None no-op on the happy path)

## Next

S2 — per-component reapply seams (cron/MCP confirm-done, hooks, **per-agent capability via `default_profile()` swap** [simplified by #2074], new-agent) registered on the HotReloader → S3 LLM-op trigger (write-gated to `.reyn/*.yaml`) → S4 hardening.

Per-agent-hooks add-on HELD (owner morning scope-confirm). 

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)