### PR TITLE
feat(#2073): S2 — per-component reapply seams + validate-before-apply

### DIFF
--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -35,6 +35,32 @@ _log = logging.getLogger(__name__)
 ReapplySeam = tuple[str, Callable[[dict], Awaitable[bool]]]
 
 
+def validate_in_set(in_set: "dict") -> "str | None":
+    """Validate-before-apply (#2073 S2): a structural check of the re-read IN-set.
+
+    Returns a reason string when the IN-set is malformed (→ the HotReloader REJECTS
+    the whole reload: no seam runs, the live config is unchanged = rollback), or
+    ``None`` when valid. Permissive — an absent component is a no-op — but rejects a
+    malformed shape so a half-written ``.reyn/*.yaml`` can never half-apply. The
+    component checks grow with the IN-set (hooks in S2b)."""
+    if not isinstance(in_set, dict):
+        return f"IN-set must be a mapping, got {type(in_set).__name__}"
+    cron = in_set.get("cron")
+    if cron is not None:
+        if not isinstance(cron, dict):
+            return "cron section must be a mapping"
+        jobs = cron.get("jobs")
+        if jobs is not None and not isinstance(jobs, list):
+            return "cron.jobs must be a list"
+        for j in jobs or []:
+            if not isinstance(j, dict) or not j.get("name") or not j.get("schedule"):
+                return "each cron job needs a name + schedule"
+    mcp = in_set.get("mcp")
+    if mcp is not None and not isinstance(mcp, dict):
+        return "mcp section must be a mapping"
+    return None
+
+
 class HotReloader:
     """Schedules + applies an IN-set config reload at the turn boundary (#2073)."""
 
@@ -44,10 +70,16 @@ class HotReloader:
         project_root: "Path | None",
         events: "object | None",
         seams: "list[ReapplySeam] | None" = None,
+        validate: "Callable[[dict], str | None] | None" = None,
     ) -> None:
         self._project_root = project_root
         self._events = events
         self._seams: list[ReapplySeam] = list(seams or [])
+        # #2073 S2: validate-before-apply. ``validate(in_set) -> reason | None`` — a
+        # non-None reason REJECTS the whole reload (no seam runs, live config
+        # unchanged = rollback), so a malformed IN-set can never half-apply. Defaults
+        # to the built-in structural :func:`validate_in_set`.
+        self._validate: "Callable[[dict], str | None]" = validate or validate_in_set
         self._pending = False
         self._pending_source: "str | None" = None
 
@@ -60,6 +92,11 @@ class HotReloader:
         """Register a per-component reapply seam (#2073 S2). ``fn(in_set)`` returns
         whether it changed anything; it must not raise (the applier isolates it)."""
         self._seams.append((name, fn))
+
+    def set_validate(self, fn: "Callable[[dict], str | None]") -> None:
+        """Set the validate-before-apply hook (#2073 S2): ``fn(in_set) -> reason |
+        None``; a non-None reason rejects the reload atomically (no seam runs)."""
+        self._validate = fn
 
     def request_reload(self, *, source: str) -> None:
         """Schedule a reload at the next turn boundary (operator command / LLM-op).
@@ -93,6 +130,18 @@ class HotReloader:
         # Safety boundary: re-read ONLY the IN-set (.reyn/*.yaml). The OUT-set
         # (reyn.yaml) is never opened here, so a reload cannot touch it.
         in_set = load_hot_reload_config(self._project_root)
+
+        # Validate-before-apply (atomicity): a malformed IN-set is REJECTED whole —
+        # no seam runs, the live config is unchanged (rollback). config_reloaded is
+        # NOT emitted (no state change occurred), only a warning.
+        if self._validate is not None:
+            reason = self._validate(in_set)
+            if reason:
+                _log.warning(
+                    "hot-reload REJECTED (invalid IN-set): %s — live config unchanged",
+                    reason,
+                )
+                return {"source": source, "rejected": reason, "applied": [], "failed": []}
 
         applied: list[str] = []
         failed: list[str] = []

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1640,6 +1640,13 @@ class Session:
             turn_cancel_fn=self._is_turn_cancel_requested,
         )
 
+        # #2073 S2: register the per-component hot-reload reapply seams now that the
+        # sub-components they orchestrate (skill_runner / router_host) exist. Each
+        # seam reapplies one IN-set component live at the turn boundary; the Session
+        # owns + orchestrates them (the multi-holder per-agent swap is one method
+        # here, not scattered captures). Hooks → S2b. Set validate-before-apply too.
+        self._register_hot_reload_seams()
+
         # FP-0019 Wave 1: synchronous head/body/tail compaction service.
         # #1128 PR-a: background task lifecycle removed; the session drives
         # compaction via force_compact_now() (pre-frame guard). All callbacks
@@ -2827,6 +2834,80 @@ class Session:
                 for name, tools in snapshot_after.items()
             },
         }
+
+    # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
+
+    def _register_hot_reload_seams(self) -> None:
+        """Register the per-component reapply seams + validate-before-apply on the
+        HotReloader (#2073 S2). Called once at construction after skill_runner +
+        router_host exist. Each seam reapplies one IN-set component live at the turn
+        boundary; the Session orchestrates them (it owns the sub-components). Hooks =
+        S2b (global .reyn/hooks.yaml); per-agent-hooks add-on = a separate decision."""
+        hr = self._hot_reloader
+        # validate-before-apply is the HotReloader's built-in structural check
+        # (hot_reload.validate_in_set) — no per-Session override needed.
+        hr.register_seam("cron", self._reapply_cron)
+        hr.register_seam("mcp", self._reapply_mcp)
+        hr.register_seam("per_agent_capability", self._reapply_per_agent_capability)
+        hr.register_seam("new_agent", self._reapply_new_agent)
+
+    def _hot_reload_project_root(self) -> "Path":
+        """The project root for IN-set re-reads (same source the HotReloader uses)."""
+        return getattr(self._registry, "_project_root", None) or Path.cwd()
+
+    async def _reapply_cron(self, in_set: dict) -> bool:
+        """Reapply .reyn/cron.yaml jobs to the live scheduler (#2073 S2). Idempotent
+        (add_job replaces by name). No active scheduler / no jobs → no-op."""
+        from reyn.runtime.cron import CronJob, get_active_scheduler
+        sched = get_active_scheduler()
+        if sched is None:
+            return False
+        jobs = (in_set.get("cron") or {}).get("jobs") or []
+        changed = False
+        for jd in jobs:
+            await sched.add_job(CronJob(
+                name=jd["name"], schedule=jd["schedule"], to=jd.get("to"),
+                message=jd.get("message"), enabled=jd.get("enabled", True),
+            ))
+            changed = True
+        return changed
+
+    async def _reapply_mcp(self, in_set: dict) -> bool:
+        """Reapply MCP servers (#2073 S2) — re-probe via the existing turn-boundary
+        refresh chain (which reads the re-read .reyn/mcp.yaml). Returns whether the
+        in-memory tool cache changed."""
+        result = await self.refresh_mcp_servers()
+        return bool(result.get("refreshed"))
+
+    async def _reapply_per_agent_capability(self, in_set: dict) -> bool:
+        """Reapply the per-agent capability (#2073 S2) — Session-orchestrated. Re-read
+        .reyn/agents/<name>/profile.yaml and update the per-agent allowlists on the 3
+        holders the Session owns (itself / skill_runner / router_host) from the new
+        AgentProfile (the #2074 unified per-agent spec). No profile / no change →
+        no-op. (Single-source-of-truth is a beauty-follow-up, out of hot-reload scope.)"""
+        from reyn.runtime.profile import AgentProfile
+        agent_dir = self._hot_reload_project_root() / ".reyn" / "agents" / self.agent_name
+        try:
+            prof = AgentProfile.load(agent_dir)
+        except (FileNotFoundError, OSError):
+            return False  # single-agent / no profile → nothing per-agent to reapply
+        if prof.allowed_skills == self._allowed_skills and prof.allowed_mcp == self._allowed_mcp:
+            return False  # unchanged
+        # Session orchestrates the multi-holder swap (the holders it owns).
+        self._allowed_skills = prof.allowed_skills
+        self._allowed_mcp = prof.allowed_mcp
+        self._skill_runner._allowed_skills = prof.allowed_skills   # SKILL spawn gate
+        self._router_host._allowed_skills = prof.allowed_skills    # SKILL catalog gate
+        self._router_host._allowed_mcp = prof.allowed_mcp          # MCP gate (decl source)
+        return True
+
+    async def _reapply_new_agent(self, in_set: dict) -> bool:
+        """New-agent reapply (#2073 S2) — a confirming no-op: agent discovery is
+        filesystem-live (AgentRegistry.list_names / get_or_load walk .reyn/agents/
+        per call), so a newly-added agent is already visible without a reload step.
+        Kept as an explicit seam so the IN-set component is accounted for, and a
+        future cached-roster would slot its refresh here."""
+        return False
 
     # ── PR21: state persistence helpers (WAL + snapshot) ─────────────────────
     # PR-refactor-session-1 wave 2: WAL/snapshot ownership moved to

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -1,0 +1,160 @@
+"""Tier 2: #2073 S2 — per-component reapply seams + validate-before-apply.
+
+S2 registers 4 reapply seams on the HotReloader (cron / MCP / per-agent-capability /
+new-agent), each reapplying one IN-set component live at the turn boundary, plus the
+validate-before-apply that rejects a malformed IN-set atomically (no seam runs, live
+config unchanged = rollback). Hooks are S2b.
+
+No mocks: the validate is a pure function; the reject path uses a real HotReloader +
+the real loader + a recording seam; the real seams run on a real (minimal) Session.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.hot_reload import HotReloader, validate_in_set
+from reyn.runtime.session import Session
+
+# ── validate-before-apply (the structural IN-set check) ─────────────────────
+
+
+def test_validate_accepts_valid_and_absent() -> None:
+    """Tier 2: a well-formed or empty IN-set validates (None = ok)."""
+    assert validate_in_set({}) is None
+    assert validate_in_set({"mcp": {"servers": {}}}) is None
+    assert validate_in_set(
+        {"cron": {"jobs": [{"name": "j", "schedule": "* * * * *"}]}}
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "bad, needle",
+    [
+        ([], "mapping"),                                       # not a dict
+        ({"cron": "nope"}, "cron section"),                    # cron not a mapping
+        ({"cron": {"jobs": "nope"}}, "cron.jobs must be a list"),
+        ({"cron": {"jobs": [{"message": "x"}]}}, "name + schedule"),  # job missing name/schedule
+        ({"mcp": "nope"}, "mcp section"),                      # mcp not a mapping
+    ],
+)
+def test_validate_rejects_malformed(bad, needle) -> None:
+    """Tier 2: a malformed IN-set returns a decision-enabling reason (→ the reload
+    is rejected before any seam runs)."""
+    reason = validate_in_set(bad)
+    assert reason is not None and needle in reason
+
+
+@pytest.mark.asyncio
+async def test_bad_in_set_is_rejected_no_seam_runs(tmp_path: Path) -> None:
+    """Tier 2: validate-before-apply rollback — a malformed .reyn/cron.yaml is
+    rejected whole: the registered seam is NOT called and no config_reloaded is
+    emitted (the live config is unchanged)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    # valid YAML, structurally bad (a named cron job missing its schedule — survives
+    # the loader's job-list merge but fails validate)
+    (reyn_dir / "cron.yaml").write_text("cron:\n  jobs:\n    - name: j1\n", encoding="utf-8")
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    calls: list = []
+
+    async def seam(in_set: dict) -> bool:
+        calls.append(in_set)
+        return True
+
+    hr.register_seam("cron", seam)
+    hr.request_reload(source="operator")
+    summary = await hr.apply_pending()
+
+    assert summary["rejected"]                 # the reload was rejected
+    assert calls == []                         # no seam ran (rollback)
+    assert [e.type for e in events.all() if e.type == "config_reloaded"] == []
+
+
+# ── the real reapply seams (real minimal Session) ──────────────────────────
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test-agent", allowed_skills=None) -> Session:
+    return Session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        allowed_skills=allowed_skills,
+    )
+
+
+def test_seams_registered_on_the_reloader(tmp_path: Path) -> None:
+    """Tier 2: the Session registers its 4 reapply seams on the HotReloader."""
+    session = _make_session(tmp_path)
+    names = [name for (name, _fn) in session._hot_reloader._seams]
+    assert names == ["cron", "mcp", "per_agent_capability", "new_agent"]
+
+
+@pytest.mark.asyncio
+async def test_cron_seam_reapplies_jobs_live(tmp_path: Path) -> None:
+    """Tier 2: the cron seam applies .reyn/cron.yaml jobs to the live scheduler."""
+    from reyn.runtime.cron import CronScheduler, set_active_scheduler
+
+    session = _make_session(tmp_path)
+    sched = CronScheduler([])
+    set_active_scheduler(sched)
+    try:
+        changed = await session._reapply_cron(
+            {"cron": {"jobs": [{"name": "j1", "schedule": "* * * * *",
+                                "to": "demo", "message": "hi"}]}},
+        )
+        assert changed is True
+        assert sched.get_job("j1") is not None  # applied live
+    finally:
+        set_active_scheduler(None)
+
+
+@pytest.mark.asyncio
+async def test_per_agent_capability_seam_enforces_new_profile(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the Session-orchestrated per-agent seam re-reads profile.yaml so the
+    SKILL gate enforces the new allowlist — BEHAVIOR, via the real spawn gate: after
+    the reapply (profile allows only skill_a), spawning an un-listed skill is refused.
+    This exercises the skill_runner holder the Session swapped (a holder the seam
+    missed would leave the old decision)."""
+    monkeypatch.chdir(tmp_path)  # project_root = cwd for the seam's profile re-read
+    agent = "test-agent"
+    prof_dir = tmp_path / ".reyn" / "agents" / agent
+    prof_dir.mkdir(parents=True)
+    (prof_dir / "profile.yaml").write_text(
+        "name: test-agent\nallowed_skills: [skill_a]\n", encoding="utf-8",
+    )
+    # before: unrestricted (allowed_skills None) → the gate would allow any skill
+    session = _make_session(tmp_path, agent_name=agent, allowed_skills=None)
+
+    changed = await session._reapply_per_agent_capability({})
+    assert changed is True
+
+    # behavior through the public spawn gate: an un-listed skill is now refused
+    # (the allowlist gate fires before skill-load, so skill_b need not exist).
+    result = await session._skill_runner.run_skill_awaitable(
+        {"skill": "skill_b", "input": {}}, chain_id="c1",
+    )
+    assert result["status"] == "error"
+    assert "not in allowed_skills" in result["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_per_agent_seam_noop_when_no_profile(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: no profile.yaml (single-agent) → the per-agent seam is a no-op."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path, agent_name="solo")
+    changed = await session._reapply_per_agent_capability({})
+    assert changed is False
+
+
+@pytest.mark.asyncio
+async def test_new_agent_seam_is_confirming_noop(tmp_path: Path) -> None:
+    """Tier 2: new-agent discovery is filesystem-live → the seam is a confirming
+    no-op (returns False; nothing to actively reapply)."""
+    session = _make_session(tmp_path)
+    changed = await session._reapply_new_agent({})
+    assert changed is False


### PR DESCRIPTION
**[e2e-coder]** — #2073 hot-reload, stage **S2** (per-component reapply seams). S1 (#2082) merged. No-merge — lead close-reviews. New feature — reuses existing live-apply seams + tests orchestration/behavior + the safety/atomicity invariants.

## What

Registers the IN-set reapply seams on the HotReloader + validate-before-apply. **Hooks → S2b** (the global `.reyn/hooks.yaml` source, owner-approved, sequenced after S2).

- **`hot_reload.py`** `validate_in_set(in_set)` — structural validate-before-apply (the HotReloader's default). A malformed IN-set is **rejected whole**: no seam runs, live config unchanged (rollback), no `config_reloaded`. + `set_validate` override.
- **`session.py`** — 4 reapply seams via `register_seam` (closures the Session owns), each `fn(in_set)→changed-bool`, isolated by the applier:
  - **cron**: `get_active_scheduler()` → `add_job(CronJob)` per `in_set["cron"]` (the existing live-apply path).
  - **mcp**: `Session.refresh_mcp_servers()` (the existing turn-boundary refresh chain).
  - **per_agent_capability**: **Session-orchestrated** — re-read `.reyn/agents/<name>/profile.yaml` → update `_allowed_skills`/`_allowed_mcp` on the **3 holders the Session owns** (itself / skill_runner / router_host) from the new `AgentProfile` (the #2074 unified spec). Single-source-of-truth = a noted beauty-follow-up, out of scope.
  - **new_agent**: a confirming no-op (agent discovery is filesystem-live).

## Test plan

- [x] `tests/test_2073_s2_reapply_seams.py` (Tier 2): validate accept/reject matrix + **reject-rollback** (bad IN-set → no seam runs, no event) + cron seam applies live (`get_job`) + per-agent seam enforces the new profile **through the real spawn gate** (behavior, not private state) + no-op seams + registration
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8259 passed, 18 skipped, 3 xfailed** (+12 S2; no regression)

## Next

S2b — global hooks seam: add `.reyn/hooks.yaml` to `_HOT_RELOAD_FILES` + `load_hooks` reads it + `HookDispatcher.replace_registry` + the hooks reapply seam (owner-approved). Then S3 (LLM-op trigger, write-gated to `.reyn/*.yaml`) + S4 (hardening). Per-agent-hooks add-on still held.

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)