### PR TITLE
feat(#2073): S2b — global hooks reapply seam (.reyn/hooks.yaml, layered)

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -504,7 +504,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
 # permission / sandbox / budget / the loop valve / state-coupled runtime) is loaded
 # ONCE at startup by ``load_config`` and is restart-only; the file-split IS the
 # write-gate boundary (owner-confirmed #2073). Keep this list narrow + explicit.
-_HOT_RELOAD_FILES: tuple[str, ...] = ("mcp.yaml", "cron.yaml")
+_HOT_RELOAD_FILES: tuple[str, ...] = ("mcp.yaml", "cron.yaml", "hooks.yaml")
 
 
 def load_hot_reload_config(project_root: "Path | None" = None) -> dict:

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -67,6 +67,14 @@ class HookDispatcher:
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
 
+    def replace_registry(self, registry: HookRegistry) -> None:
+        """Swap the live hook registry (#2073 S2b config hot-reload). ``dispatch()``
+        reads ``self._registry`` fresh on every lifecycle point, so a single swap
+        here propagates to every holder of this dispatcher instance — no re-threading
+        through the kernel/router seams. Used by the Session's hooks reapply seam to
+        install ``startup ∪ re-read-runtime`` hooks at the turn boundary."""
+        self._registry = registry
+
     async def dispatch(self, point: str, template_vars: dict) -> None:
         """Run every hook registered for ``point`` (registration order).
 

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -58,6 +58,16 @@ def validate_in_set(in_set: "dict") -> "str | None":
     mcp = in_set.get("mcp")
     if mcp is not None and not isinstance(mcp, dict):
         return "mcp section must be a mapping"
+    hooks = in_set.get("hooks")
+    if hooks is not None:
+        # #2073 S2b: validate the runtime hooks shape via the real loader so a
+        # malformed .reyn/hooks.yaml rejects the whole reload (atomic) rather than
+        # raising inside the reapply seam.
+        from reyn.hooks import HookConfigError, load_hooks
+        try:
+            load_hooks(hooks)
+        except HookConfigError as exc:
+            return f"hooks: {exc}"
     return None
 
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2864,14 +2864,31 @@ class Session:
         re-read on a reload) ∪ the ``.reyn/hooks.yaml`` runtime layer (from the
         IN-set). Rebuilding from scratch each call means a removed runtime hook simply
         isn't in the new registry (removal handled by construction — unlike cron's
-        add-only seam). ``load_hooks`` validates; a bad runtime layer is caught
-        earlier by validate-before-apply (so this won't raise on the reload path)."""
-        from reyn.hooks.loader import load_hooks
+        add-only seam).
+
+        **Boot resilience (#2073 S2b):** ``load_hooks`` raises ``HookConfigError`` on
+        a malformed layer. On the RELOAD path validate-before-apply rejects a bad
+        runtime layer first, so this won't raise there — but BOOT also calls this
+        (with the boot-read runtime layer) and has no validate gate. So a malformed
+        ``.reyn/hooks.yaml`` (e.g. one the S3 LLM-op wrote — rejected on reload but
+        PERSISTED to disk) must NOT crash the next boot. When a non-empty runtime
+        layer fails, degrade to STARTUP-only + a loud warning (the operator's reyn.yaml
+        always loads; a bad agent-written runtime never bricks boot). A failure with
+        no runtime layer is the operator's reyn.yaml → it propagates (fail loud)."""
+        from reyn.hooks.loader import HookConfigError, load_hooks
         runtime = (in_set or {}).get("hooks") or []
-        combined = list(self._startup_hooks_raw)
-        if isinstance(runtime, list):
-            combined += list(runtime)
-        return load_hooks(combined)
+        runtime_list = list(runtime) if isinstance(runtime, list) else []
+        startup = list(self._startup_hooks_raw)
+        if not runtime_list:
+            return load_hooks(startup)  # startup-only; a failure is the operator's, raise
+        try:
+            return load_hooks(startup + runtime_list)
+        except HookConfigError as exc:
+            logger.warning(
+                "config hot-reload: malformed .reyn/hooks.yaml — runtime hooks "
+                "skipped, booting with the reyn.yaml startup hooks only: %s", exc,
+            )
+            return load_hooks(startup)
 
     async def _reapply_hooks(self, in_set: dict) -> bool:
         """Reapply the runtime hooks layer (#2073 S2b) — re-read .reyn/hooks.yaml,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1248,13 +1248,19 @@ class Session:
         # no-op (run-loop byte-identical to a hooks-free build). Constructed
         # unconditionally so the 4 lifecycle dispatch() sites are uniform.
         from reyn.hooks.dispatcher import HookDispatcher
-        from reyn.hooks.loader import load_hooks
-        from reyn.hooks.registry import HookRegistry as _HookRegistry
-        self._hook_registry = (
-            load_hooks(hooks_config) if hooks_config is not None else _HookRegistry([])
+        # #2073 S2b: hooks are LAYERED — the reyn.yaml startup layer (OUT-set,
+        # captured once here, NEVER re-read on a reload) ∪ the .reyn/hooks.yaml
+        # runtime layer (IN-set, hot-reloadable; the LLM-op writes it in S3).
+        # _build_hook_registry combines them; the boot registry includes the runtime
+        # layer too (active from session start, mirroring .reyn/mcp.yaml), and the
+        # hooks reapply seam re-reads only the runtime layer + re-combines.
+        self._startup_hooks_raw: list = hooks_config if isinstance(hooks_config, list) else []
+        from reyn.config.loader import load_hot_reload_config as _load_in_set
+        _boot_in_set = _load_in_set(
+            getattr(self._registry, "_project_root", None) or Path.cwd()
         )
         self._hook_dispatcher = HookDispatcher(
-            self._hook_registry,
+            self._build_hook_registry(_boot_in_set),
             put_inbox=self._put_inbox,
             stage_next_turn_context=self._stage_next_turn_context,
             sandbox_config=self._sandbox_config,
@@ -2850,6 +2856,31 @@ class Session:
         hr.register_seam("mcp", self._reapply_mcp)
         hr.register_seam("per_agent_capability", self._reapply_per_agent_capability)
         hr.register_seam("new_agent", self._reapply_new_agent)
+        hr.register_seam("hooks", self._reapply_hooks)  # #2073 S2b (global hooks)
+
+    def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
+        """Build the LAYERED hook registry (#2073 S2b): the reyn.yaml startup layer
+        (``self._startup_hooks_raw``, captured once at boot — the OUT-set, never
+        re-read on a reload) ∪ the ``.reyn/hooks.yaml`` runtime layer (from the
+        IN-set). Rebuilding from scratch each call means a removed runtime hook simply
+        isn't in the new registry (removal handled by construction — unlike cron's
+        add-only seam). ``load_hooks`` validates; a bad runtime layer is caught
+        earlier by validate-before-apply (so this won't raise on the reload path)."""
+        from reyn.hooks.loader import load_hooks
+        runtime = (in_set or {}).get("hooks") or []
+        combined = list(self._startup_hooks_raw)
+        if isinstance(runtime, list):
+            combined += list(runtime)
+        return load_hooks(combined)
+
+    async def _reapply_hooks(self, in_set: dict) -> bool:
+        """Reapply the runtime hooks layer (#2073 S2b) — re-read .reyn/hooks.yaml,
+        re-combine with the FIXED reyn.yaml startup layer, and swap the dispatcher's
+        registry. The dispatcher reads its registry fresh per dispatch, so the swap
+        propagates to every holder. The startup layer is never re-read (safety
+        boundary). Always rebuilds (handles add / change / remove of runtime hooks)."""
+        self._hook_dispatcher.replace_registry(self._build_hook_registry(in_set))
+        return True
 
     def _hot_reload_project_root(self) -> "Path":
         """The project root for IN-set re-reads (same source the HotReloader uses)."""

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -88,10 +88,11 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent", allowed_ski
 
 
 def test_seams_registered_on_the_reloader(tmp_path: Path) -> None:
-    """Tier 2: the Session registers its 4 reapply seams on the HotReloader."""
+    """Tier 2: the Session registers its reapply seams on the HotReloader (the 4 S2
+    seams + the S2b hooks seam)."""
     session = _make_session(tmp_path)
     names = [name for (name, _fn) in session._hot_reloader._seams]
-    assert names == ["cron", "mcp", "per_agent_capability", "new_agent"]
+    assert names == ["cron", "mcp", "per_agent_capability", "new_agent", "hooks"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_2073_s2b_hooks_seam.py
+++ b/tests/test_2073_s2b_hooks_seam.py
@@ -1,0 +1,155 @@
+"""Tier 2: #2073 S2b — global hooks reapply seam (.reyn/hooks.yaml, layered).
+
+S2b makes hooks hot-reloadable via a LAYERED model: the reyn.yaml startup layer
+(OUT-set, captured once at boot, never re-read) ∪ the .reyn/hooks.yaml runtime layer
+(IN-set, hot-reloadable; the LLM-op writes it in S3). The dispatcher reads its
+registry fresh per dispatch, so HookDispatcher.replace_registry(startup ∪ re-read-
+runtime) swaps the live hooks at the turn boundary, preserving the startup layer.
+
+No mocks: validate is a pure function; replace_registry is exercised through a real
+HookDispatcher; the layered boot + reapply run on a real Session, observed via the
+public inbox (E-hooks push there).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.loader import load_hooks
+from reyn.runtime.hot_reload import validate_in_set
+from reyn.runtime.session import Session
+
+_HOOK = "hooks:\n  - on: turn_end\n    template_push:\n      message: {msg}\n      wake: true\n"
+
+
+# ── validate-before-apply: the hooks-shape check (atomic reject) ────────────
+
+
+def test_validate_accepts_good_hooks() -> None:
+    """Tier 2: a well-formed runtime hooks list validates (None)."""
+    assert validate_in_set(
+        {"hooks": [{"on": "turn_end", "template_push": {"message": "hi"}}]}
+    ) is None
+
+
+def test_validate_rejects_bad_hooks() -> None:
+    """Tier 2: a malformed .reyn/hooks.yaml (no scheme) is rejected via the real
+    loader → the whole reload is rejected atomically."""
+    reason = validate_in_set({"hooks": [{"on": "turn_end"}]})  # missing the scheme
+    assert reason is not None and "hooks:" in reason
+
+
+# ── HookDispatcher.replace_registry swaps the live registry ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_replace_registry_swaps_live() -> None:
+    """Tier 2: replace_registry swaps the registry the dispatcher reads on the NEXT
+    dispatch (no re-threading) — the new hooks fire, the old ones don't."""
+    pushed: list = []
+
+    async def put_inbox(kind, payload):
+        pushed.append(payload["text"])
+
+    async def stage(kind, payload):
+        pass
+
+    disp = HookDispatcher(
+        load_hooks([{"on": "turn_end", "template_push": {"message": "old", "wake": True}}]),
+        put_inbox=put_inbox, stage_next_turn_context=stage,
+    )
+    await disp.dispatch("turn_end", {})
+    assert pushed == ["old"]
+
+    disp.replace_registry(
+        load_hooks([{"on": "turn_end", "template_push": {"message": "new", "wake": True}}])
+    )
+    await disp.dispatch("turn_end", {})
+    assert pushed == ["old", "new"]  # the swap took effect on the next dispatch
+
+
+# ── layered boot + reapply on a real Session (observed via the inbox) ───────
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return Session(
+        agent_name="s2b-agent",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+    )
+
+
+async def _drain_texts(session: Session) -> set:
+    texts = set()
+    while not session.inbox.empty():
+        _kind, payload = session.inbox.get_nowait()
+        texts.add(payload.get("text"))
+    return texts
+
+
+@pytest.mark.asyncio
+async def test_boot_layers_startup_and_runtime(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: at boot the dispatcher carries BOTH the reyn.yaml startup hook AND the
+    .reyn/hooks.yaml runtime hook (active from session start, mirroring .reyn/mcp.yaml).
+    Dispatching turn_end fires both (observed via the inbox)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(_HOOK.format(msg="runtime"), encoding="utf-8")
+    session = _make_session(
+        tmp_path,
+        hooks_config=[{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}],
+    )
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "runtime"}
+
+
+@pytest.mark.asyncio
+async def test_reapply_recombines_runtime_preserving_startup(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the hooks reapply seam re-reads ONLY the runtime layer + re-combines
+    with the FIXED startup — a changed .reyn/hooks.yaml reloads while the reyn.yaml
+    startup hook persists (the safety boundary: reyn.yaml is never re-read)."""
+    from reyn.config.loader import load_hot_reload_config
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(_HOOK.format(msg="runtime_v1"), encoding="utf-8")
+    session = _make_session(
+        tmp_path,
+        hooks_config=[{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}],
+    )
+
+    # operator/LLM-op rewrites the runtime layer; reapply at the boundary
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(_HOOK.format(msg="runtime_v2"), encoding="utf-8")
+    changed = await session._reapply_hooks(load_hot_reload_config(tmp_path))
+    assert changed is True
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    texts = await _drain_texts(session)
+    assert texts == {"startup", "runtime_v2"}  # startup preserved, runtime reloaded
+    assert "runtime_v1" not in texts            # the old runtime hook is gone
+
+
+@pytest.mark.asyncio
+async def test_reapply_handles_runtime_removal(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: removing all runtime hooks (.reyn/hooks.yaml emptied) reloads back to
+    startup-only — removal is handled by the rebuild-from-scratch (unlike cron's
+    add-only seam)."""
+    from reyn.config.loader import load_hot_reload_config
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(_HOOK.format(msg="runtime"), encoding="utf-8")
+    session = _make_session(
+        tmp_path,
+        hooks_config=[{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}],
+    )
+
+    (tmp_path / ".reyn" / "hooks.yaml").write_text("hooks: []\n", encoding="utf-8")  # runtime removed
+    await session._reapply_hooks(load_hot_reload_config(tmp_path))
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup"}  # back to startup-only

--- a/tests/test_2073_s2b_hooks_seam.py
+++ b/tests/test_2073_s2b_hooks_seam.py
@@ -153,3 +153,25 @@ async def test_reapply_handles_runtime_removal(tmp_path: Path, monkeypatch) -> N
 
     await session._hook_dispatcher.dispatch("turn_end", {})
     assert await _drain_texts(session) == {"startup"}  # back to startup-only
+
+
+@pytest.mark.asyncio
+async def test_boot_resilience_malformed_runtime_degrades_to_startup(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: BOOT resilience — a malformed .reyn/hooks.yaml (e.g. one the S3 LLM-op
+    wrote, rejected on reload but PERSISTED) must NOT crash Session construction. The
+    boot degrades to the reyn.yaml startup hooks only (a loud warning), so the agent
+    can't brick its own boot by writing a bad runtime layer."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    # malformed: a hook with no scheme (template_push/shell_exec/shell_push) → load_hooks raises
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(
+        "hooks:\n  - on: turn_end\n", encoding="utf-8",
+    )
+    # construction must NOT raise (the bug was: unguarded boot load_hooks crashes here)
+    session = _make_session(
+        tmp_path,
+        hooks_config=[{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}],
+    )
+    # booted startup-only: dispatch fires the startup hook, not the (skipped) runtime
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup"}


### PR DESCRIPTION
**[e2e-coder]** — #2073 hot-reload, stage **S2b** (global hooks). S2 (#2083) merged; layering design-call confirmed by lead (COMBINE + boot-load). No-merge — lead close-reviews.

## What (layered: startup ∪ runtime)

Makes hooks hot-reloadable via a LAYERED model (owner-approved `.reyn/hooks.yaml` source):

- **`config/loader.py`**: `.reyn/hooks.yaml` → `_HOT_RELOAD_FILES` (`load_hot_reload_config` surfaces `in_set["hooks"]`).
- **`hooks/dispatcher.py`**: `HookDispatcher.replace_registry(registry)` — the dispatcher reads its registry fresh per dispatch, so **one swap propagates to every holder** (no re-threading).
- **`session.py`**: hooks are **layered** — reyn.yaml startup (OUT-set, captured once at boot as `_startup_hooks_raw`, **never re-read**) ∪ `.reyn/hooks.yaml` runtime (IN-set). `_build_hook_registry(in_set)` = `load_hooks(startup ∪ runtime)`; the dispatcher **boots with it** (runtime active from session start, mirroring `.reyn/mcp.yaml`); the reapply seam re-reads **only the runtime layer** + re-combines + `replace_registry`. Rebuild-from-scratch handles add/change/**remove**.
- **`hot_reload.py`** `validate_in_set`: + hooks-shape via the real `load_hooks` (`HookConfigError` → reject the whole reload atomically).

## Safety

reyn.yaml (startup) is captured at boot + **never re-read** on a reload — only `.reyn/hooks.yaml` re-reads. The LLM-op (S3) writes `.reyn/hooks.yaml` **only** (runtime layer; reyn.yaml stays untouchable) → bounded autonomous hook-expansion.

## Test plan

- [x] `tests/test_2073_s2b_hooks_seam.py` (Tier 2): validate accept/reject + `replace_registry` live-swap + **boot layers startup∪runtime** + **reapply recombines** (startup preserved, runtime reloaded, old runtime gone) + **runtime removal → startup-only**. Behavior via the public inbox.
- [x] Hook regression (5b dispatcher, config-schema, attribution) green — the dispatcher-construction change is compatible
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8265 passed, 18 skipped, 3 xfailed** (+6 S2b)

## Next

S3 — LLM-op trigger (a control-IR op, write-gated to `.reyn/*.yaml` only — the agent self-reloads; OUT-set untouchable) → S4 — hardening (incl. the cron/MCP removal-diff lead flagged; note: the hooks seam already handles removal via rebuild). Per-agent-hooks add-on still held.

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)