### PR TITLE
feat(#2073): S3 — LLM-op hooks-write self-reload trigger (write-gated, crown-jewel)

### DIFF
--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -175,4 +175,30 @@ class HotReloader:
         return {"source": source, "applied": applied, "failed": failed}
 
 
-__all__ = ["HotReloader", "ReapplySeam"]
+# ── process-wide active HotReloader (#2073 S3) ──────────────────────────────
+# The LLM-op hooks-write tool reaches the reloader to ``request_reload`` after
+# writing .reyn/hooks.yaml. Mirrors ``set_active_scheduler`` / ``get_active_scheduler``
+# (cron). NOTE (multi-session caveat, same as cron's single-scheduler): this is the
+# last-registered session's reloader; a per-session route (via ToolContext) is a
+# noted beauty-follow-up, out of S3 scope.
+_active_hot_reloader: "HotReloader | None" = None
+
+
+def set_active_hot_reloader(reloader: "HotReloader | None") -> None:
+    """Register / unregister the process-wide active HotReloader (#2073 S3)."""
+    global _active_hot_reloader
+    _active_hot_reloader = reloader
+
+
+def get_active_hot_reloader() -> "HotReloader | None":
+    """Return the active HotReloader, or None when unset."""
+    return _active_hot_reloader
+
+
+__all__ = [
+    "HotReloader",
+    "ReapplySeam",
+    "validate_in_set",
+    "set_active_hot_reloader",
+    "get_active_hot_reloader",
+]

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3127,6 +3127,7 @@ class RouterLoop:
             # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
+            hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
         )
         return [
             {
@@ -3573,6 +3574,7 @@ class RouterLoop:
                 router_state=rs,
                 # #1673: thread the config-aware resolver (see the sibling sites).
                 resolver=getattr(self.host, "resolver", None),
+                hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
             )
             list_actions_def = get_default_registry().lookup("list_actions")
             if list_actions_def is None:
@@ -3788,6 +3790,7 @@ class RouterLoop:
             # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
+            hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
         )
         result = await invoke_tool(get_default_registry(), name, args, tool_ctx)
         return self._normalise_router_tool_result(name, result)

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -270,9 +270,13 @@ class RouterHostAdapter:
         # → defaults (disabled-safe via the methods' guards).
         threat_scan: Any = None,
         contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → control-IR OpContext
+        hot_reloader: Any = None,  # #2073 S3: this session's HotReloader → tool ctx
     ) -> None:
         self._threat_scan = threat_scan
         self._contextual_permission = contextual_permission
+        # #2073 S3: exposed (public) so RouterLoop threads it onto the tool ctx, so a
+        # self-reload tool reloads THIS session (per-session, not a process global).
+        self.hot_reloader = hot_reloader
         self._session_id = session_id  # #1953 dynamic-wire: task.* CAS gate key
         self._task_backend = task_backend  # #1953 dynamic-wire: session-scoped Task backend
         self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c: task_start/end dispatch

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1523,6 +1523,7 @@ class Session:
             # FP-0050 / #1822 S2: content-threat scan + fence config.
             threat_scan=self._safety.threat_scan,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
+            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
             # #1953 dynamic-wire: thread the REAL session id + Task backend so
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
             session_id=self._session_id,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1323,11 +1323,15 @@ class Session:
         # #2073 S1: the config hot-reloader. Reads ONLY the IN-set (.reyn/*.yaml);
         # the OUT-set (reyn.yaml) is restart-only. Applies at the turn_end safe-point
         # (apply_pending below). Per-component reapply seams are registered in S2.
-        from reyn.runtime.hot_reload import HotReloader
+        from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
         self._hot_reloader = HotReloader(
             project_root=getattr(self._registry, "_project_root", None) or Path.cwd(),
             events=self._chat_events,
         )
+        # #2073 S3: publish as the process-wide active reloader so the hooks-write
+        # LLM-op can request_reload after writing .reyn/hooks.yaml (mirrors
+        # set_active_scheduler). Multi-session = last-registered wins (cron caveat).
+        set_active_hot_reloader(self._hot_reloader)
         # #1669: publish this session's EventLog as the ambient sink for the LLM
         # acompletion chokepoint, so every in-session LLM call emits an observable
         # `llm_request` event (non-message params) without threading events through

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -67,6 +67,7 @@ def get_default_registry() -> ToolRegistry:
         READ_FILE,
         WRITE_FILE,
     )
+    from reyn.tools.hooks import HOOKS_ADD
     from reyn.tools.invoke_skill import INVOKE_SKILL
     from reyn.tools.lint import LINT
     from reyn.tools.mcp import (
@@ -178,6 +179,9 @@ def get_default_registry() -> ToolRegistry:
     registry.register(CRON_LIST)
     registry.register(CRON_ENABLE)
     registry.register(CRON_DISABLE)
+    # #2073 S3: the hooks-write self-reload tool (the agent adds its own runtime
+    # hooks to .reyn/hooks.yaml + reloads at the turn boundary). Router-only.
+    registry.register(HOOKS_ADD)
     # FP-0038 (#171) S2 + S3: glob / grep for Reyn's own repo, mirroring
     # the file__glob / file__grep surfaces but scoped to the OS source tree.
     registry.register(REYN_SRC_GLOB)

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -172,8 +172,11 @@ async def _handle_hooks_add(args: Mapping[str, Any], ctx: ToolContext) -> ToolRe
 
     # Schedule the reload — the HotReloader applies the S2b hooks seam at the turn
     # boundary (1 turn = 1 config snapshot; never mid-turn).
+    # Per-session route (#2073 S3): reload THIS calling session's reloader (multi-agent
+    # correctness — the reloader is per-session, so a process-wide global would reload
+    # the wrong session). Fall back to the active reloader for non-session/test contexts.
     from reyn.runtime.hot_reload import get_active_hot_reloader
-    reloader = get_active_hot_reloader()
+    reloader = getattr(ctx, "hot_reloader", None) or get_active_hot_reloader()
     scheduled = reloader is not None
     if scheduled:
         reloader.request_reload(source="llm_op")

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -1,0 +1,198 @@
+"""Hooks ToolDefinitions — #2073 S3 (the LLM-op self-reload trigger).
+
+``hooks_add`` — the agent adds a push hook at an agent-lifecycle point, written to
+the RUNTIME hooks layer (``.reyn/hooks.yaml``) and applied at the next turn boundary
+via the S2b hooks reapply seam. The crown-jewel of config hot-reload: the agent
+expands its own hooks (autonomous capability-expansion), bounded by the safety
+trifecta + the existing hook safeguards:
+
+- **Write-gate by construction**: the tool writes ONLY the hardcoded
+  ``.reyn/hooks.yaml`` (the IN-set runtime layer). It takes the hook CONTENT, never a
+  path, so it is *structurally impossible* to aim at ``reyn.yaml`` (the restart-only
+  OUT-set: security / budget / the loop valve).
+- **validate-before-apply** (S2b) rejects a malformed reload; **boot-resilience**
+  (S2b) degrades a malformed persisted layer at the next boot. Plus write-time
+  validation here (a bad hook → an op error, not a silent bad write).
+- **Permission** is the TOOL axis: the calling skill must list ``hooks_add`` in
+  ``permissions.tool`` (``require_tool``) and the #2074 capability profile
+  (``tool_deny``) can deny self-reload. The damage is bounded — F is sandboxed, E is
+  loop-valved (``safety.loop.max_hook_driven_turns``), C is benign.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_HOOK_POINTS = [
+    "turn_start", "turn_end", "session_start", "session_end",
+    "skill_start", "skill_end", "task_start", "task_end",
+]
+
+_HOOKS_ADD_DESCRIPTION = (
+    "Add a push hook at an agent-lifecycle point (e.g. a turn_end self-continuation, "
+    "or a context-inject). The hook is written to your runtime hooks layer "
+    "(.reyn/hooks.yaml) and applied at the next turn boundary — it joins your existing "
+    "hooks additively. Use for self-directed continuation or recurring injected "
+    "context. Cannot touch startup config (reyn.yaml is restart-only)."
+)
+
+_HOOKS_ADD_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "on": {
+            "type": "string", "enum": _HOOK_POINTS,
+            "description": "The lifecycle point the hook fires at.",
+        },
+        "message": {
+            "type": "string",
+            "description": "The message pushed when the hook fires (a Jinja2 template is allowed).",
+        },
+        "wake": {
+            "type": "boolean",
+            "description": (
+                "true → the push starts a new turn (self-continuation, capability E); "
+                "false → it rides along with the next turn as context (capability C). "
+                "Default true."
+            ),
+        },
+        "push_when": {
+            "type": "string",
+            "description": "Optional Jinja2 → bool; when it renders false the push is skipped. Default 'true'.",
+        },
+        "name": {
+            "type": "string",
+            "description": "Optional label surfaced as the [hook:<name>] attribution prefix.",
+        },
+    },
+    "required": ["on", "message"],
+}
+
+
+# ── Storage helpers (= .reyn/hooks.yaml read/write) ─────────────────────────
+
+
+def _hooks_yaml_path(ctx: ToolContext) -> Path:
+    """The canonical ``.reyn/hooks.yaml`` path under the project root (HARDCODED —
+    the write target is never derived from LLM input)."""
+    root = getattr(ctx.workspace, "root", None) or getattr(ctx.workspace, "base_dir", None)
+    if root is None:
+        root = Path.cwd()
+    return Path(root) / ".reyn" / "hooks.yaml"
+
+
+def _normalize_on(h: object) -> object:
+    """Normalize the YAML-1.1 quirk where a bare ``on:`` key parses as boolean
+    ``True`` — map ``{True: pt}`` → ``{"on": pt}`` so dedup compares like-for-like."""
+    if isinstance(h, dict) and True in h and "on" not in h:
+        h = dict(h)
+        h["on"] = h.pop(True)
+    return h
+
+
+def _read_hooks(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_hooks(path: Path, data: dict) -> None:
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _hooks_list(data: dict) -> list:
+    hooks = data.get("hooks", [])
+    if not isinstance(hooks, list):
+        return []
+    return [_normalize_on(h) for h in hooks]
+
+
+async def _gate(ctx: ToolContext) -> None:
+    """Permission gate: ``require_file_write`` against the canonical .reyn/hooks.yaml.
+    TOOL-level authorisation already happened at skill-startup (``require_tool``
+    against the skill's ``permissions.tool``) + the #2074 capability profile. No-op
+    in unit-test contexts (``ctx.permission_resolver`` is None)."""
+    from reyn.security.permissions.permissions import PermissionDecl
+    if ctx.permission_resolver is None:
+        return
+    hooks_yaml_path = str(_hooks_yaml_path(ctx))
+    decl = PermissionDecl(file_write=[{"path": hooks_yaml_path, "scope": "just_path"}])
+    ctx.permission_resolver.session_approve_path(hooks_yaml_path, "hooks", "file.write")
+    await ctx.permission_resolver.require_file_write(decl, hooks_yaml_path, "hooks")
+
+
+# ── Handler ─────────────────────────────────────────────────────────────────
+
+
+async def _handle_hooks_add(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Add a push hook to the runtime layer (.reyn/hooks.yaml) + schedule a reload."""
+    on = str(args["on"])
+    message = str(args["message"])
+    wake = bool(args.get("wake", True))
+    push_when = args.get("push_when")
+    name = args.get("name")
+
+    template_push: dict = {"message": message, "wake": wake}
+    if push_when is not None:
+        template_push["push_when"] = str(push_when)
+    hook: dict = {"on": on, "template_push": template_push}
+    if name:
+        hook["name"] = str(name)
+
+    # Write-time validate (defense-in-depth; the reload's validate-before-apply also
+    # guards, and a persisted-malformed layer is handled by boot-resilience).
+    from reyn.hooks import HookConfigError, load_hooks
+    try:
+        load_hooks([hook])
+    except HookConfigError as exc:
+        return {"status": "error", "error": f"invalid hook: {exc}"}
+
+    await _gate(ctx)
+
+    # Persist to the FIXED .reyn/hooks.yaml (structurally cannot target reyn.yaml).
+    path = _hooks_yaml_path(ctx)
+    data = _read_hooks(path)
+    hooks = _hooks_list(data)
+    added = hook not in hooks  # dedup exact duplicates (idempotent re-add)
+    if added:
+        hooks.append(hook)
+    data["hooks"] = hooks
+    _write_hooks(path, data)
+
+    # Schedule the reload — the HotReloader applies the S2b hooks seam at the turn
+    # boundary (1 turn = 1 config snapshot; never mid-turn).
+    from reyn.runtime.hot_reload import get_active_hot_reloader
+    reloader = get_active_hot_reloader()
+    scheduled = reloader is not None
+    if scheduled:
+        reloader.request_reload(source="llm_op")
+
+    return {
+        "status": "ok",
+        "on": on,
+        "added": added,
+        "reload_scheduled": scheduled,
+        "path": str(path),
+    }
+
+
+HOOKS_ADD = ToolDefinition(
+    name="hooks_add",
+    description=_HOOKS_ADD_DESCRIPTION,
+    parameters=_HOOKS_ADD_PARAMETERS,
+    gates=ToolGates(router="allow", phase="deny"),
+    handler=_handle_hooks_add,
+    category="hooks",
+    purity="side_effect",
+)

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -272,6 +272,12 @@ class ToolContext:
     # "standard" (which litellm rejects with BadRequestError — the latent bug).
     # Also completes #1672 CAT-3 (tool sub-runs follow model_class_by_purpose).
     resolver: Any | None = None                      # ModelResolver | None
+    # #2073 S3: the CALLING session's HotReloader, so a self-reload tool
+    # (hooks_add) requests a reload on THIS session's reloader (per-session
+    # correctness in multi-agent — a process-wide global would reload the wrong
+    # session). None in non-session/test contexts → the tool falls back to the
+    # process-wide get_active_hot_reloader().
+    hot_reloader: Any | None = None
 
 
 # ToolHandler: async callable signature.

--- a/tests/test_2073_s3_hooks_write_op.py
+++ b/tests/test_2073_s3_hooks_write_op.py
@@ -79,6 +79,27 @@ async def test_hooks_add_schedules_reload(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_per_session_route_reloads_caller_not_the_global(tmp_path: Path) -> None:
+    """Tier 2: multi-session correctness (#2073 S3) — hooks_add reloads the CALLING
+    session's reloader (ctx.hot_reloader), NOT the process-wide last-registered one.
+    The reloader is per-session (unlike cron's single scheduler), so in multi-agent
+    agent A's self-added hook must take effect on A, not on the last-constructed B."""
+    caller = HotReloader(project_root=tmp_path, events=EventLog())   # the calling session (A)
+    other = HotReloader(project_root=tmp_path, events=EventLog())    # the last-registered (B)
+    set_active_hot_reloader(other)  # B is the process-wide active reloader
+
+    ctx = ToolContext(
+        events=EventLog(), permission_resolver=None,
+        workspace=SimpleNamespace(root=tmp_path), caller_kind="router",
+        hot_reloader=caller,  # the calling session threads its own reloader
+    )
+    await _handle_hooks_add({"on": "turn_end", "message": "a-hook"}, ctx)
+
+    assert caller.pending is True    # the caller (A) was reloaded
+    assert other.pending is False    # the global (B) was NOT (pre-fix bug)
+
+
+@pytest.mark.asyncio
 async def test_hooks_add_rejects_invalid_hook_no_write(tmp_path: Path) -> None:
     """Tier 2: write-time validate — a bad hook (invalid lifecycle point) returns an
     error and writes nothing."""

--- a/tests/test_2073_s3_hooks_write_op.py
+++ b/tests/test_2073_s3_hooks_write_op.py
@@ -1,0 +1,139 @@
+"""Tier 2: #2073 S3 — the LLM-op hooks-write self-reload trigger (crown-jewel).
+
+`hooks_add` lets the agent add a runtime push hook: it writes the FIXED
+.reyn/hooks.yaml (the IN-set runtime layer) + request_reload(source="llm_op") → the
+HotReloader applies the S2b hooks seam at the turn boundary. The write-gate is
+structural: the tool takes hook CONTENT, never a path, so it CANNOT aim at reyn.yaml
+(the restart-only OUT-set). Permission is the TOOL axis (require_tool + the #2074
+capability profile) — exercised at router dispatch, not in this handler.
+
+No mocks: real HotReloader / EventLog / Session / load_hooks; a real ToolContext
+(permission_resolver=None → the file-write gate is a no-op in-test, the standard
+tool-test contract). The crown-jewel E2E runs the full agent-adds-hook → reload →
+hook-fires path on a real Session, observed via the public inbox.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
+from reyn.runtime.session import Session
+from reyn.tools.hooks import HOOKS_ADD, _handle_hooks_add
+from reyn.tools.types import ToolContext
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_reloader():
+    """Reset the process-wide active reloader after each test (it's a global)."""
+    yield
+    set_active_hot_reloader(None)
+
+
+def _ctx(root: Path) -> ToolContext:
+    return ToolContext(
+        events=EventLog(), permission_resolver=None,
+        workspace=SimpleNamespace(root=root), caller_kind="router",
+    )
+
+
+# ── write-gate BY CONSTRUCTION (the crown-jewel falsify) ────────────────────
+
+
+def test_hooks_add_has_no_path_parameter() -> None:
+    """Tier 2: the tool takes hook CONTENT, never a path — so it is structurally
+    impossible to aim the write at reyn.yaml; the target is the hardcoded
+    .reyn/hooks.yaml."""
+    props = set(HOOKS_ADD.parameters["properties"])
+    assert "path" not in props
+    assert props == {"on", "message", "wake", "push_when", "name"}
+
+
+@pytest.mark.asyncio
+async def test_hooks_add_writes_in_set_only_not_reyn_yaml(tmp_path: Path) -> None:
+    """Tier 2: the op writes .reyn/hooks.yaml (IN-set) + leaves reyn.yaml (OUT-set)
+    untouched — the write-gate falsify (it CANNOT touch the OUT-set)."""
+    (tmp_path / "reyn.yaml").write_text("permissions:\n  shell: deny\n", encoding="utf-8")
+    out_before = (tmp_path / "reyn.yaml").read_text()
+    set_active_hot_reloader(HotReloader(project_root=tmp_path, events=EventLog()))
+
+    result = await _handle_hooks_add({"on": "turn_end", "message": "hi"}, _ctx(tmp_path))
+
+    assert result["status"] == "ok"
+    assert (tmp_path / ".reyn" / "hooks.yaml").exists()           # IN-set written
+    assert (tmp_path / "reyn.yaml").read_text() == out_before     # OUT-set untouched
+
+
+@pytest.mark.asyncio
+async def test_hooks_add_schedules_reload(tmp_path: Path) -> None:
+    """Tier 2: the op schedules a reload via the active HotReloader."""
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    set_active_hot_reloader(hr)
+    result = await _handle_hooks_add({"on": "turn_end", "message": "hi"}, _ctx(tmp_path))
+    assert result["reload_scheduled"] is True
+    assert hr.pending is True
+
+
+@pytest.mark.asyncio
+async def test_hooks_add_rejects_invalid_hook_no_write(tmp_path: Path) -> None:
+    """Tier 2: write-time validate — a bad hook (invalid lifecycle point) returns an
+    error and writes nothing."""
+    result = await _handle_hooks_add({"on": "not_a_point", "message": "hi"}, _ctx(tmp_path))
+    assert result["status"] == "error"
+    assert not (tmp_path / ".reyn" / "hooks.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_hooks_add_dedups_idempotent(tmp_path: Path) -> None:
+    """Tier 2: re-adding the same hook is idempotent (no duplicate accumulation)."""
+    set_active_hot_reloader(HotReloader(project_root=tmp_path, events=EventLog()))
+    await _handle_hooks_add({"on": "turn_end", "message": "hi"}, _ctx(tmp_path))
+    again = await _handle_hooks_add({"on": "turn_end", "message": "hi"}, _ctx(tmp_path))
+    assert again["added"] is False
+    import yaml
+    data = yaml.safe_load((tmp_path / ".reyn" / "hooks.yaml").read_text())
+    assert [h.get("on", h.get(True)) for h in data["hooks"]] == ["turn_end"]  # single entry
+
+
+def test_hooks_add_registered_as_a_tool() -> None:
+    """Tier 2: hooks_add is registered in the tool catalog (router-callable)."""
+    from reyn.tools import get_default_registry
+    assert "hooks_add" in get_default_registry()
+
+
+# ── crown-jewel E2E: agent adds a hook → reload → the hook fires ────────────
+
+
+@pytest.mark.asyncio
+async def test_e2e_agent_adds_hook_applies_at_boundary(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the full self-reload path — the agent calls hooks_add (writes
+    .reyn/hooks.yaml + request_reload on the session's active reloader); at the turn
+    boundary apply_pending runs the S2b hooks seam (re-combine startup ∪ runtime +
+    replace_registry); the newly-added hook then FIRES (observed via the inbox)."""
+    monkeypatch.chdir(tmp_path)
+    # Session construction registers itself as the active reloader (#2073 S3).
+    session = Session(
+        agent_name="s3-agent",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+    result = await _handle_hooks_add(
+        {"on": "turn_end", "message": "self-go", "wake": True}, _ctx(tmp_path),
+    )
+    assert result["reload_scheduled"] is True
+
+    # turn boundary: the scheduled reload applies the hooks seam.
+    await session._hot_reloader.apply_pending()
+
+    # the newly-added runtime hook now fires.
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    texts = set()
+    while not session.inbox.empty():
+        _kind, payload = session.inbox.get_nowait()
+        texts.add(payload.get("text"))
+    assert "self-go" in texts

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -50,6 +50,9 @@ _NOT_EXTERNAL = {
     "mcp_install", "mcp_install_local", "mcp_install_package",
     "mcp_install_registry", "mcp_drop_server",
     "cron_register", "cron_unregister", "cron_enable", "cron_disable",
+    # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a
+    # status dict (on / added / reload_scheduled / path), not external content.
+    "hooks_add",
     "lint",
     # — catalog / discovery (reyn-assembled or operator config) —
     "list_skills", "describe_skill", "list_agents", "describe_agent",


### PR DESCRIPTION
**[e2e-coder]** — #2073 hot-reload, stage **S3** (the crown-jewel: the agent self-reloads its own hooks). S2b (#2084) merged; design confirmed by lead. No-merge — crown-jewel close-review.

## What

The `hooks_add` tool lets the agent add a runtime push hook: write the FIXED `.reyn/hooks.yaml` + `request_reload(source="llm_op")` → the HotReloader applies the S2b hooks seam at the turn boundary.

- **`tools/hooks.py`** `HOOKS_ADD` + handler: builds a `template_push` hook from `{on, message, wake?, push_when?, name?}`, write-time validates (`load_hooks` → error on malformed), persists to `.reyn/hooks.yaml` (dedup), schedules the reload.
- **Write-gate BY CONSTRUCTION** (review-focus 1): the tool takes hook **content, never a path** — the write target is the hardcoded `.reyn/hooks.yaml`, so it is **structurally impossible to aim at reyn.yaml** (the restart-only OUT-set). Plus the `require_file_write` gate on that path.
- **Permission = TOOL axis** (review-focus 2): `require_tool` (the skill lists `hooks_add` in `permissions.tool`) + the **#2074 capability profile** (`tool_deny` denies self-reload). No dedicated `require_`, per your call.
- **`hot_reload.py`** `set_active_hot_reloader`/`get_active_hot_reloader` (mirrors cron's active-scheduler) so the tool reaches the reloader; Session registers at construction. **Multi-session caveat**: last-registered wins (same as cron's single-scheduler) — a per-session route (via ToolContext) is a noted beauty-follow-up, flagging for your review.

## Safety trifecta complete (review-focus 3)

write-gate (fixed path) + validate-before-apply (S2b) + boot-resilience (S2b) + the hook safeguards (F sandbox, E loop-valve, C benign) + capability-profile deny → the LLM-writes-config is **safe-by-construction**.

## Test plan

- [x] `tests/test_2073_s3_hooks_write_op.py` (Tier 2): **write-gate-by-construction** (no `path` param + reyn.yaml untouched — review-focus 4 falsify) + schedules reload + write-time validate-reject + dedup + tool registration + the **crown-jewel E2E** (agent adds a hook → reload at the boundary → the hook fires, real Session via inbox)
- [x] #1822 external-content classification updated (`hooks_add` → `_NOT_EXTERNAL`, internal status result)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8274 passed, 18 skipped, 3 xfailed**

## Next

S4 — hardening: the cron/MCP removal-diff (lead-flagged; note: hooks already handles removal via rebuild) + the per-component apply atomicity/rollback polish. Then the per-agent-hooks add-on (owner GO, additive; after S4). #2081 delegation-default separate.

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)