### PR TITLE
feat(#2073): S4 — hardening: cron removal-diff (+ MCP removal / atomicity confirmed)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1266,6 +1266,14 @@ class Session:
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
         )
+        # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
+        # reapply seam can unschedule jobs removed from the runtime file WITHOUT
+        # touching startup (reyn.yaml) jobs (the same startup/runtime layering as
+        # hooks). Seeded from the boot IN-set; updated each reload.
+        self._runtime_cron_names: set = {
+            j["name"] for j in ((_boot_in_set.get("cron") or {}).get("jobs") or [])
+            if isinstance(j, dict) and j.get("name")
+        }
 
         # Per-agent SkillRegistry — lazily constructed on first skill run.
         # Tracks active skill_run_ids and emits skill lifecycle events.
@@ -2909,20 +2917,34 @@ class Session:
         return getattr(self._registry, "_project_root", None) or Path.cwd()
 
     async def _reapply_cron(self, in_set: dict) -> bool:
-        """Reapply .reyn/cron.yaml jobs to the live scheduler (#2073 S2). Idempotent
-        (add_job replaces by name). No active scheduler / no jobs → no-op."""
+        """Reapply .reyn/cron.yaml jobs to the live scheduler (#2073 S2/S4). Adds /
+        replaces present jobs (add_job is idempotent by name) AND unschedules RUNTIME
+        jobs removed from the file since the last reapply (#2073 S4 removal-diff). Only
+        runtime (.reyn/cron.yaml) jobs are removable — startup (reyn.yaml) jobs are
+        never in ``self._runtime_cron_names`` so they are never unscheduled. No active
+        scheduler → no-op."""
         from reyn.runtime.cron import CronJob, get_active_scheduler
         sched = get_active_scheduler()
         if sched is None:
             return False
-        jobs = (in_set.get("cron") or {}).get("jobs") or []
+        jobs = [
+            j for j in ((in_set.get("cron") or {}).get("jobs") or [])
+            if isinstance(j, dict) and j.get("name")
+        ]
+        new_names = {j["name"] for j in jobs}
         changed = False
+        # S4 removal-diff: unschedule runtime jobs deleted from .reyn/cron.yaml.
+        for removed in self._runtime_cron_names - new_names:
+            if await sched.remove_job(removed):
+                changed = True
+        # Add / replace the present runtime jobs (idempotent).
         for jd in jobs:
             await sched.add_job(CronJob(
                 name=jd["name"], schedule=jd["schedule"], to=jd.get("to"),
                 message=jd.get("message"), enabled=jd.get("enabled", True),
             ))
             changed = True
+        self._runtime_cron_names = new_names  # track for the next reload's diff
         return changed
 
     async def _reapply_mcp(self, in_set: dict) -> bool:

--- a/tests/test_2073_s4_removal_diff.py
+++ b/tests/test_2073_s4_removal_diff.py
@@ -1,0 +1,96 @@
+"""Tier 2: #2073 S4 — hardening: the cron removal-diff (+ MCP removal / atomicity).
+
+S2's cron seam was add/change-only — a job removed from .reyn/cron.yaml stayed
+scheduled. S4 adds a removal-diff: the cron seam unschedules RUNTIME jobs deleted
+from the file (tracked via self._runtime_cron_names, seeded at boot, updated each
+reload) WITHOUT touching startup (reyn.yaml) jobs — the same startup/runtime layering
+as hooks. (MCP removal is handled by the re-probe rebuilding the cache from the
+current config; the hooks seam already handles removal via rebuild-from-scratch;
+atomicity is the S2 validate-before-apply whole-reload reject.)
+
+No mocks: a real Session (for the runtime-name tracking + the seam) + a real
+CronScheduler; behavior via the public get_job.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.cron import CronJob, CronScheduler, set_active_scheduler
+from reyn.runtime.session import Session
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_scheduler():
+    yield
+    set_active_scheduler(None)
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="s4-agent",
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+
+
+def _job(name: str) -> CronJob:
+    return CronJob(name=name, schedule="* * * * *", to="x", message="m")
+
+
+def _jd(name: str) -> dict:
+    return {"name": name, "schedule": "* * * * *", "to": "x", "message": "m"}
+
+
+@pytest.mark.asyncio
+async def test_cron_removal_diff_unschedules_removed_runtime_job(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a runtime job removed from .reyn/cron.yaml is unscheduled on reload —
+    while a STARTUP (reyn.yaml) job, never tracked as runtime, is left scheduled."""
+    monkeypatch.chdir(tmp_path)
+    sched = CronScheduler([_job("startup_job")])  # a pre-loaded startup job
+    set_active_scheduler(sched)
+    session = _make_session(tmp_path)  # no .reyn/cron.yaml at boot → runtime set empty
+
+    # the agent / operator adds a runtime job, then it's reapplied
+    await session._reapply_cron({"cron": {"jobs": [_jd("runtime_job")]}})
+    assert sched.get_job("runtime_job") is not None
+
+    # the runtime job is removed from the file + reload → unscheduled
+    await session._reapply_cron({"cron": {"jobs": []}})
+    assert sched.get_job("runtime_job") is None       # removed (the S4 diff)
+    assert sched.get_job("startup_job") is not None    # startup untouched
+
+
+@pytest.mark.asyncio
+async def test_boot_seeded_runtime_job_is_removable(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a runtime job present at boot (.reyn/cron.yaml) is tracked, so removing
+    it from the file + reloading unschedules it (the boot-seed of the removal-diff)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "cron.yaml").write_text(
+        "cron:\n  jobs:\n    - name: boot_job\n      schedule: '* * * * *'\n"
+        "      to: x\n      message: b\n",
+        encoding="utf-8",
+    )
+    sched = CronScheduler([_job("boot_job")])  # the web boot loaded it into the scheduler
+    set_active_scheduler(sched)
+    session = _make_session(tmp_path)  # _runtime_cron_names seeded with boot_job
+
+    await session._reapply_cron({"cron": {"jobs": []}})  # boot_job removed from the file
+    assert sched.get_job("boot_job") is None
+
+
+@pytest.mark.asyncio
+async def test_cron_reapply_change_then_keep_does_not_remove(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a runtime job that is still present across reloads is NOT removed
+    (the diff only unschedules jobs absent from the new file)."""
+    monkeypatch.chdir(tmp_path)
+    sched = CronScheduler([])
+    set_active_scheduler(sched)
+    session = _make_session(tmp_path)
+
+    await session._reapply_cron({"cron": {"jobs": [_jd("keep_me")]}})
+    await session._reapply_cron({"cron": {"jobs": [_jd("keep_me")]}})  # still present
+    assert sched.get_job("keep_me") is not None  # not removed


### PR DESCRIPTION
**[e2e-coder]** — #2073 hot-reload, stage **S4** (the final hardening). S3 (#2085) merged. No-merge — close-review. Then the per-agent-hooks add-on (the last piece) → #2073 complete.

## What

- **cron removal-diff** (the flagged item): the S2 cron seam was add/change-only — a job removed from `.reyn/cron.yaml` stayed scheduled. `_reapply_cron` now **unschedules runtime jobs deleted from the file** (`scheduler.remove_job`), tracked via `Session._runtime_cron_names` (seeded at boot from the IN-set, updated each reload). **Only runtime jobs are removable** — startup (reyn.yaml) jobs are never in the runtime set, so they're never unscheduled (the same startup/runtime layering as hooks).
- **MCP removal**: handled by the existing **re-probe** — `refresh_mcp_servers` rebuilds the tool cache from the *current* config, so a server removed from `.reyn/mcp.yaml` is no longer probed and its tools drop (no new code; FP-0037 refresh covers it).
- **hooks removal**: already handled in S2b (rebuild-from-scratch).
- **atomicity**: the S2 **validate-before-apply** rejects a malformed IN-set whole (no seam runs, live config unchanged) — the atomicity gate (existing `test_bad_in_set_is_rejected_no_seam_runs`).

## Test plan

- [x] `tests/test_2073_s4_removal_diff.py` (Tier 2): a removed runtime job is **unscheduled** while a **startup job persists** (falsify the removal); a boot-seeded runtime job is removable; a still-present job is not removed. Behavior via real Session + CronScheduler `get_job`.
- [x] S2 reapply-seam regression green
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors / 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8278 passed, 18 skipped, 3 xfailed**

## Next (the last #2073 piece)

The **per-agent-hooks add-on** (owner GO #2, additive): a per-agent hooks layer on S2b's COMBINE → `startup ∪ runtime ∪ per-agent` (all fire), source `.reyn/agents/<name>/hooks.yaml` or the profile.yaml hooks field, hot-reloadable via the same seam. I'll design-call you on the source choice when I reach it. Then **#2073 complete**.

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)