### PR TITLE
feat(#2073): per-agent-hooks add-on — per-agent hooks layer on the COMBINE (#2073 final)

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -531,6 +531,27 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
     return expand_env(merged)
 
 
+def load_per_agent_hooks(
+    project_root: "Path | None", agent_name: str
+) -> list:
+    """Load the per-agent runtime hooks layer (#2073 per-agent-hooks add-on) — ONLY
+    ``.reyn/agents/<name>/hooks.yaml``.
+
+    Same IN-set grain as the global ``.reyn/hooks.yaml`` (runtime-mutable,
+    hot-reloadable) but scoped to one agent — read DIRECTLY here (not via
+    :func:`load_hot_reload_config`, which is the top-level ``.reyn/*.yaml`` set),
+    mirroring how the per-agent ``profile.yaml`` is read. ``${VAR}`` interpolation is
+    applied to match the global layer. Returns the raw ``hooks:`` list (``[]`` when the
+    file or key is absent — a no-op layer, never an error).
+    """
+    root = (project_root or Path.cwd()).resolve()
+    raw = _load_yaml(root / ".reyn" / "agents" / agent_name / "hooks.yaml")
+    from reyn.security.secrets.interpolation import expand_env
+    data = expand_env(raw)
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    return hooks if isinstance(hooks, list) else []
+
+
 def _build_external_transports_config(raw: object):
     """Parse the ``external_transports:`` section (FP-0041 #489 PR-D2).
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2872,43 +2872,60 @@ class Session:
         hr.register_seam("hooks", self._reapply_hooks)  # #2073 S2b (global hooks)
 
     def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
-        """Build the LAYERED hook registry (#2073 S2b): the reyn.yaml startup layer
-        (``self._startup_hooks_raw``, captured once at boot — the OUT-set, never
-        re-read on a reload) ∪ the ``.reyn/hooks.yaml`` runtime layer (from the
-        IN-set). Rebuilding from scratch each call means a removed runtime hook simply
-        isn't in the new registry (removal handled by construction — unlike cron's
-        add-only seam).
+        """Build the LAYERED hook registry — the three-layer COMBINE (#2073 S2b + the
+        per-agent-hooks add-on), ADDITIVE in order startup → runtime → per-agent:
 
-        **Boot resilience (#2073 S2b):** ``load_hooks`` raises ``HookConfigError`` on
-        a malformed layer. On the RELOAD path validate-before-apply rejects a bad
-        runtime layer first, so this won't raise there — but BOOT also calls this
-        (with the boot-read runtime layer) and has no validate gate. So a malformed
-        ``.reyn/hooks.yaml`` (e.g. one the S3 LLM-op wrote — rejected on reload but
-        PERSISTED to disk) must NOT crash the next boot. When a non-empty runtime
-        layer fails, degrade to STARTUP-only + a loud warning (the operator's reyn.yaml
-        always loads; a bad agent-written runtime never bricks boot). A failure with
-        no runtime layer is the operator's reyn.yaml → it propagates (fail loud)."""
+        - **startup** — the reyn.yaml hooks (``self._startup_hooks_raw``, captured once
+          at boot, the restart-only OUT-set, never re-read on a reload);
+        - **runtime** — the global ``.reyn/hooks.yaml`` (from the IN-set);
+        - **per-agent** — ``.reyn/agents/<name>/hooks.yaml`` (read directly here, same
+          IN-set grain but scoped per agent).
+
+        Rebuilding from scratch each call means a removed hook (runtime or per-agent)
+        simply isn't in the new registry — removal handled by construction.
+
+        **Per-LAYER boot resilience (the add-on refinement):** ``load_hooks`` raises
+        ``HookConfigError`` on a malformed layer, and BOTH boot AND the reload path call
+        this — a malformed persisted ``.reyn/hooks.yaml`` or per-agent file must NOT
+        crash boot, NOR may one bad UNTRUSTED layer drop a good sibling. So the trusted
+        startup layer (reyn.yaml — the operator's) must load (a failure propagates =
+        fail loud), then each untrusted layer is try-added INDEPENDENTLY: a bad runtime
+        keeps startup ∪ per-agent; a bad per-agent keeps startup ∪ runtime; each bad
+        layer is dropped + warned. (On the reload path validate-before-apply also rejects
+        a bad runtime layer up front; this is the boot + defence-in-depth guard.)"""
         from reyn.hooks.loader import HookConfigError, load_hooks
         runtime = (in_set or {}).get("hooks") or []
         runtime_list = list(runtime) if isinstance(runtime, list) else []
-        startup = list(self._startup_hooks_raw)
-        if not runtime_list:
-            return load_hooks(startup)  # startup-only; a failure is the operator's, raise
-        try:
-            return load_hooks(startup + runtime_list)
-        except HookConfigError as exc:
-            logger.warning(
-                "config hot-reload: malformed .reyn/hooks.yaml — runtime hooks "
-                "skipped, booting with the reyn.yaml startup hooks only: %s", exc,
-            )
-            return load_hooks(startup)
+        per_agent_list = self._read_per_agent_hooks()
+        combined = list(self._startup_hooks_raw)
+        registry = load_hooks(combined)  # trusted startup must load — else fail loud
+        for label, layer in (("runtime", runtime_list), ("per-agent", per_agent_list)):
+            if not layer:
+                continue
+            try:
+                registry = load_hooks(combined + layer)  # validate the cumulative add
+                combined = combined + layer
+            except HookConfigError as exc:
+                logger.warning(
+                    "config hot-reload: malformed %s hooks layer — skipped, keeping "
+                    "the valid hook layers: %s", label, exc,
+                )
+        return registry
+
+    def _read_per_agent_hooks(self) -> list:
+        """Read the per-agent runtime hooks layer for the COMBINE (#2073 per-agent
+        add-on) — ``.reyn/agents/<name>/hooks.yaml``, read directly (like the per-agent
+        profile.yaml, not via the top-level IN-set loader). ``[]`` when absent."""
+        from reyn.config.loader import load_per_agent_hooks
+        return load_per_agent_hooks(self._hot_reload_project_root(), self.agent_name)
 
     async def _reapply_hooks(self, in_set: dict) -> bool:
-        """Reapply the runtime hooks layer (#2073 S2b) — re-read .reyn/hooks.yaml,
+        """Reapply the hook layers (#2073 S2b + per-agent add-on) — re-read the global
+        .reyn/hooks.yaml (IN-set) AND the per-agent .reyn/agents/<name>/hooks.yaml,
         re-combine with the FIXED reyn.yaml startup layer, and swap the dispatcher's
         registry. The dispatcher reads its registry fresh per dispatch, so the swap
         propagates to every holder. The startup layer is never re-read (safety
-        boundary). Always rebuilds (handles add / change / remove of runtime hooks)."""
+        boundary). Always rebuilds (handles add / change / remove of either layer)."""
         self._hook_dispatcher.replace_registry(self._build_hook_registry(in_set))
         return True
 

--- a/tests/test_2073_per_agent_hooks.py
+++ b/tests/test_2073_per_agent_hooks.py
@@ -1,0 +1,180 @@
+"""Tier 2: #2073 per-agent-hooks add-on — the per-agent hooks layer on the COMBINE.
+
+The LAST #2073 piece (owner GO #2, additive). The hook registry is now a THREE-layer
+additive COMBINE in order startup → runtime → per-agent:
+
+- startup    — reyn.yaml hooks (OUT-set, captured at boot, never re-read);
+- runtime    — global .reyn/hooks.yaml (IN-set, hot-reloadable);
+- per-agent  — .reyn/agents/<name>/hooks.yaml (same IN-set grain, scoped per agent,
+               read directly like the per-agent profile.yaml).
+
+Boot resilience is now per-LAYER: the trusted startup layer must load (fail loud),
+then each UNTRUSTED layer (runtime, per-agent) is try-added INDEPENDENTLY — a bad
+runtime keeps startup ∪ per-agent; a bad per-agent keeps startup ∪ runtime. No single
+bad untrusted layer crashes boot OR drops a good sibling layer.
+
+No mocks: load_per_agent_hooks is a pure loader; the layered boot + reapply run on a
+real Session, observed via the public inbox (E-hooks push there).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.loader import load_hot_reload_config, load_per_agent_hooks
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+
+_AGENT = "pa-agent"
+_HOOK = "hooks:\n  - on: turn_end\n    template_push:\n      message: {msg}\n      wake: true\n"
+_STARTUP = [{"on": "turn_end", "template_push": {"message": "startup", "wake": True}}]
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return Session(
+        agent_name=_AGENT,
+        state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+    )
+
+
+def _write_runtime(tmp_path: Path, msg: str) -> None:
+    (tmp_path / ".reyn").mkdir(exist_ok=True)
+    (tmp_path / ".reyn" / "hooks.yaml").write_text(_HOOK.format(msg=msg), encoding="utf-8")
+
+
+def _write_per_agent(tmp_path: Path, msg: str) -> Path:
+    agent_dir = tmp_path / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "hooks.yaml"
+    path.write_text(_HOOK.format(msg=msg), encoding="utf-8")
+    return path
+
+
+async def _drain_texts(session: Session) -> set:
+    texts = set()
+    while not session.inbox.empty():
+        _kind, payload = session.inbox.get_nowait()
+        texts.add(payload.get("text"))
+    return texts
+
+
+# ── the per-agent loader (read directly, not via the top-level IN-set) ──────
+
+
+def test_load_per_agent_hooks_reads_scoped_file(tmp_path: Path) -> None:
+    """Tier 2: load_per_agent_hooks reads .reyn/agents/<name>/hooks.yaml's hooks list."""
+    _write_per_agent(tmp_path, "agent")
+    hooks = load_per_agent_hooks(tmp_path, _AGENT)
+    assert [h.get("on", h.get(True)) for h in hooks] == ["turn_end"]
+
+
+def test_load_per_agent_hooks_absent_is_empty(tmp_path: Path) -> None:
+    """Tier 2: an absent per-agent file (or dir) yields [] — a no-op layer, never error."""
+    assert load_per_agent_hooks(tmp_path, _AGENT) == []
+
+
+# ── the three-layer additive COMBINE (boot) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_boot_combines_all_three_layers_additively(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: at boot the dispatcher carries ALL THREE layers — reyn.yaml startup ∪
+    global .reyn/hooks.yaml runtime ∪ per-agent .reyn/agents/<name>/hooks.yaml.
+    Dispatching turn_end fires all three (additive; observed via the inbox)."""
+    monkeypatch.chdir(tmp_path)
+    _write_runtime(tmp_path, "runtime")
+    _write_per_agent(tmp_path, "agent")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "runtime", "agent"}
+
+
+@pytest.mark.asyncio
+async def test_boot_per_agent_only_no_runtime(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a per-agent layer fires even with no global runtime layer present
+    (startup ∪ per-agent)."""
+    monkeypatch.chdir(tmp_path)
+    _write_per_agent(tmp_path, "agent")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "agent"}
+
+
+# ── the reapply seam re-reads the per-agent layer ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reapply_rereads_per_agent_layer(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the hooks reapply seam re-reads the per-agent .reyn/agents/<name>/hooks.yaml
+    (alongside the global runtime layer) — a changed per-agent file reloads while the
+    fixed reyn.yaml startup layer persists."""
+    monkeypatch.chdir(tmp_path)
+    _write_runtime(tmp_path, "runtime")
+    _write_per_agent(tmp_path, "agent_v1")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+
+    _write_per_agent(tmp_path, "agent_v2")  # operator/LLM rewrites the per-agent layer
+    changed = await session._reapply_hooks(load_hot_reload_config(tmp_path))
+    assert changed is True
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    texts = await _drain_texts(session)
+    assert texts == {"startup", "runtime", "agent_v2"}  # per-agent reloaded
+    assert "agent_v1" not in texts                       # the old per-agent hook is gone
+
+
+@pytest.mark.asyncio
+async def test_reapply_handles_per_agent_removal(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: removing the per-agent file reloads back to startup ∪ runtime — removal
+    is handled by the rebuild-from-scratch COMBINE."""
+    monkeypatch.chdir(tmp_path)
+    _write_runtime(tmp_path, "runtime")
+    path = _write_per_agent(tmp_path, "agent")
+    session = _make_session(tmp_path, hooks_config=_STARTUP)
+
+    path.unlink()  # per-agent hooks removed
+    await session._reapply_hooks(load_hot_reload_config(tmp_path))
+
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "runtime"}  # per-agent gone
+
+
+# ── per-LAYER independent boot resilience (the add-on refinement) ───────────
+
+
+@pytest.mark.asyncio
+async def test_bad_per_agent_keeps_startup_and_runtime(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a malformed per-agent layer degrades INDEPENDENTLY — it is dropped while
+    startup ∪ runtime are kept (a bad per-agent file can't drop the good sibling layers
+    or crash boot)."""
+    monkeypatch.chdir(tmp_path)
+    _write_runtime(tmp_path, "runtime")
+    # malformed per-agent: a hook with no scheme → load_hooks raises
+    agent_dir = tmp_path / ".reyn" / "agents" / _AGENT
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "hooks.yaml").write_text("hooks:\n  - on: turn_end\n", encoding="utf-8")
+
+    session = _make_session(tmp_path, hooks_config=_STARTUP)  # must NOT raise
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    assert await _drain_texts(session) == {"startup", "runtime"}  # good layers kept
+
+
+@pytest.mark.asyncio
+async def test_bad_runtime_keeps_startup_and_per_agent(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the independent-degrade refinement — a malformed RUNTIME layer is dropped
+    while startup ∪ PER-AGENT are kept (pre-add-on the runtime failure degraded to
+    startup-ONLY, dropping a good per-agent sibling; now each untrusted layer degrades
+    on its own)."""
+    monkeypatch.chdir(tmp_path)
+    # malformed global runtime: a hook with no scheme → load_hooks raises
+    (tmp_path / ".reyn").mkdir()
+    (tmp_path / ".reyn" / "hooks.yaml").write_text("hooks:\n  - on: turn_end\n", encoding="utf-8")
+    _write_per_agent(tmp_path, "agent")  # a GOOD per-agent layer
+
+    session = _make_session(tmp_path, hooks_config=_STARTUP)  # must NOT raise
+    await session._hook_dispatcher.dispatch("turn_end", {})
+    texts = await _drain_texts(session)
+    assert texts == {"startup", "agent"}  # the good per-agent sibling is NOT dropped


### PR DESCRIPTION
**[e2e-coder]** — #2073 hot-reload, the **per-agent-hooks add-on** (owner GO #2, additive) — the **LAST #2073 piece**. S4 (#2086) merged. No-merge — close-review. Design CONFIRMED by lead (all 4).

## What

The hook registry becomes a **three-layer additive COMBINE** in order **startup → runtime → per-agent**:

| layer | source | trust | reloadable |
|---|---|---|---|
| startup | reyn.yaml hooks | trusted (OUT-set, captured at boot, never re-read) | no |
| runtime | global `.reyn/hooks.yaml` | untrusted (IN-set) | yes |
| **per-agent** (NEW) | `.reyn/agents/<name>/hooks.yaml` | untrusted (IN-set grain, scoped per agent) | yes |

- **Source** = `.reyn/agents/<name>/hooks.yaml` (read directly like the per-agent `profile.yaml`, **not** via `load_hot_reload_config`). Mirrors the global hooks file's grain; keeps `profile.yaml` for identity + the #2074 capability spec (no concern-mixing).
- **Hot-reloadable via the SAME seam**: `_reapply_hooks` → `_build_hook_registry` now re-reads the per-agent file too (add / change / remove via rebuild-from-scratch).
- **Per-LAYER independent boot resilience** (refines the S2b runtime→startup-only degrade): the **trusted startup must load** (fail loud); then each untrusted layer is **try-added independently** — a bad runtime keeps `startup ∪ per-agent`; a bad per-agent keeps `startup ∪ runtime`. No single bad untrusted layer crashes boot **or** drops a good sibling.
- **Scope** (per lead): the add-on does the per-agent LAYER (operator-defined per-agent hooks fire + hot-reload). `hooks_add` (S3) stays **global**; the scope-aware per-agent `hooks_add` write-target is a noted follow-up.

## Test plan

- [x] `tests/test_2073_per_agent_hooks.py` (Tier 2): the loader (read + absent→[]); the 3-layer additive boot fire; per-agent-only; reapply re-read + per-agent removal; **per-LAYER degrade falsify** — bad per-agent keeps `startup∪runtime`, **bad runtime keeps `startup∪per-agent`** (the independent-degrade refinement, pre-add-on would have dropped the good per-agent sibling).
- [x] S2b regression green (incl. the existing malformed-runtime boot-resilience test — backward compatible)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8286 passed, 18 skipped, 3 xfailed**

## #2073 COMPLETE on merge

The full config hot-reload: **HotReloader + seams + global+per-agent hooks + the safe LLM-op self-reload**.

Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)