### PR TITLE
docs(runtime): config hot-reload concept doc (EN+JA) + feature-map + capability-profile update

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -250,6 +250,7 @@ nav:
           - concepts/runtime/workspace.md
           - concepts/runtime/events.md
           - concepts/runtime/hooks.md
+          - concepts/runtime/config-hot-reload.md
           - concepts/runtime/time-travel.md
           - concepts/runtime/durability-scope.md
           - concepts/runtime/permission-model.md

--- a/docs/concepts/runtime/capability-profile.ja.md
+++ b/docs/concepts/runtime/capability-profile.ja.md
@@ -117,9 +117,14 @@ effective = AgentLayer ∩ SandboxLayer ∩ ProfileLayer ∩ ContextualLayer
 
 ## リロード
 
-両ファイルの変更は**次のセッション起動時**に有効になります。ファイルはセッション構築時に 1 回読み込まれ、実行中のセッションはメモリ内コピーを使用します。
+両サーフェスは**ターン境界でのホットリロード**をサポートしています（ライブ、再起動不要）:
 
-ターン境界でのホットリロードは計画中です。
+- **ContextualLayer** — `.reyn/capability_profiles/<name>.yaml` の変更は `per_agent_capability` リアプライシームによって取得され、`AgentProfile` を再読み込みしてセッションが所有する 3 つのホルダー（session / skill_runner / router_host）の `allowed_skills` / `allowed_mcp` を更新します。
+- **ProfileLayer** — `.reyn/agents/<name>/profile.yaml` の変更も同じシームによってリロードされます。
+
+両ファイルは IN-set（`.reyn/*.yaml` グレイン）です。`/reload` または `hooks_add` LLM-op でリロードをトリガーできます。完全なリロードサイクル（timing-B セーフポイント、適用前バリデーション、P6 イベント）については [コンセプト: Config ホットリロード](config-hot-reload.md) を参照してください。
+
+ペーエージェントフックレイヤー（`.reyn/agents/<name>/hooks.yaml`）も、`hooks` リアプライシームを経由して同じターン境界でリロードされます — `hooks` COMBINE はリロードのたびに startup + runtime + per-agent レイヤーを再読み込みします。
 
 ## スキーマ例
 

--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -140,10 +140,22 @@ natural `allowed_skills` / `allowed_mcp` keys (no YAML rename).
 
 ## Reload
 
-Changes to both files take effect at **next session startup**. The files are
-loaded once at session construction; running sessions use their in-memory copy.
+Both surfaces support **turn-boundary hot-reload** (live, no restart needed):
 
-Turn-boundary hot-reload is planned.
+- **ContextualLayer** — changes to `.reyn/capability_profiles/<name>.yaml` are
+  picked up by the `per_agent_capability` reapply seam, which re-reads the
+  `AgentProfile` and updates `allowed_skills` / `allowed_mcp` on all three
+  holders the Session owns (session / skill_runner / router_host).
+- **ProfileLayer** — changes to `.reyn/agents/<name>/profile.yaml` are reloaded
+  by the same seam.
+
+Both files are IN-set (`.reyn/*.yaml` grain). Trigger a reload with `/reload` or
+via the `hooks_add` LLM-op. See [Concepts: Config hot-reload](config-hot-reload.md)
+for the full reload cycle (timing-B safe-point, validate-before-apply, P6 event).
+
+The per-agent hooks layer (`.reyn/agents/<name>/hooks.yaml`) is also reloaded at
+the same turn boundary via the `hooks` reapply seam — the `hooks` COMBINE
+re-reads startup + runtime + per-agent layers on every reload.
 
 ## Schema example
 

--- a/docs/concepts/runtime/config-hot-reload.ja.md
+++ b/docs/concepts/runtime/config-hot-reload.ja.md
@@ -1,0 +1,120 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [config hot-reload, hot-reload, IN-set, OUT-set, HotReloader, hooks_add, /reload, mcp.yaml, cron.yaml, hooks.yaml, reyn.yaml, turn boundary, config_reloaded, reapply seam, hooks layer, per-agent hooks, write-gate]
+---
+
+# Config ホットリロード
+
+Reyn のコンフィグは、ミュータビリティのルールが異なる 2 つのセットに分かれています。ホットリロード機能は、プロセスを再起動することなく、ランタイムでミュータブルなセットをセーフポイントで再読み込みします。
+
+## IN-set vs OUT-set（ライトゲート境界）
+
+| セット | ファイル | ミュータブルなタイミング |
+|--------|---------|----------------------|
+| **IN-set**（ランタイムミュータブル） | `.reyn/mcp.yaml`、`.reyn/cron.yaml`、`.reyn/hooks.yaml` | ターン境界でのホットリロード |
+| **OUT-set**（再起動のみ） | `reyn.yaml`（セキュリティ / パーミッション / サンドボックス / バジェット / ループバルブ） | プロセス再起動のみ |
+
+境界は構造的なものです: `load_hot_reload_config` は `.reyn/*.yaml` の IN-set ファイルのみを開きます。ホットリロード — および それをトリガーする LLM-op — は、ローダーがそれらのファイルを開かないため、OUT-set に触れることは構造上不可能です。
+
+## HotReloader の仕組み
+
+### ターン境界セーフポイント（timing-B）
+
+トリガーは `request_reload(source=…)` を呼び出してリロードを**スケジュール**しますが、即時には適用しません。リロードは `apply_pending()` で適用されます。これはターン境界（finish-reason=stop — `turn_end` セーフポイント）で呼び出されます。1 ターン内の複数のトリガーは 1 回の適用に集約されます: **1 ターン = 1 コンフィグスナップショット**。次のターンは新しいコンフィグで実行されます。
+
+### 適用前バリデーション（validate-before-apply）
+
+リアプライシームが実行される前に、IN-set の構造チェックが行われます。不正な IN-set（cron ジョブの形式が不正、hooks YAML が不正など）は**リロード全体を拒否**します — シームは実行されず、ライブコンフィグは変更されません。拒否時には `config_reloaded` P6 イベントは発行されません（状態変化が発生していないため）。
+
+### P6 イベント
+
+成功した適用後、`config_reloaded` が以下の情報と共に発行されます:
+
+- `source` — `"operator"`（`/reload` 経由）または `"llm_op"`（`hooks_add` 経由）
+- `components` — 変更されたシーム名のリスト
+- `failed` — 例外が発生したシーム名のリスト
+
+すべてのコンフィグ変更は、イベント化されたリプレイ可能な状態変化です（P6）。
+
+### ブート耐性（Boot resilience）
+
+`.reyn/` ディレクトリが存在しない、またはファイルが欠落している場合、そのコンポーネントには `{}` が返されます — no-op のリロードとなり、エラーにはなりません。リロードでセッションがクラッシュすることはありません。
+
+## コンポーネントごとのリアプライシーム
+
+5 つのシームがセッション構築時に `HotReloader` に登録されます。すべてのシームはリロードのたびに実行されます:
+
+| シーム | 動作 |
+|--------|------|
+| `cron` | 存在するジョブを追加 / 置換（名前でべき等）。**リムーバルディフ**: `_runtime_cron_names` で追跡されていて再読み込みされた `.reyn/cron.yaml` にないジョブはスケジュール解除されます。スタートアップ（`reyn.yaml`）の cron ジョブは削除不可。 |
+| `mcp` | 既存のターン境界リフレッシュチェーン経由で MCP サーバーを再プローブします。インメモリツールキャッシュが変更されたかどうかを報告します。 |
+| `per_agent_capability` | `.reyn/agents/<name>/profile.yaml` を再読み込みし、セッションが所有する 3 つのホルダー（session / skill_runner / router_host）の `allowed_skills` / `allowed_mcp` を更新します。 |
+| `new_agent` | 確認用の no-op: エージェント検出はファイルシステムライブ（`AgentRegistry` は呼び出しごとに `.reyn/agents/` を走査）のため、新しいエージェントはリロードなしで既に可視です。明示的なシームとしてアカウンティングのために保持。 |
+| `hooks` | グローバルの `.reyn/hooks.yaml` + ペーエージェントの `.reyn/agents/<name>/hooks.yaml` を再読み込みし、固定のスタートアップレイヤーと再結合し、フックディスパッチャーのレジストリを交換します。 |
+
+## フック 3 レイヤー COMBINE
+
+フックレジストリは 3 つのレイヤーから順番に加算的に構築されます:
+
+| レイヤー | ファイル | セット | リロード時の動作 |
+|---------|---------|------|----------------|
+| **startup** | `reyn.yaml` | OUT-set | ブート時に 1 回キャプチャ; 再読み込みしない |
+| **runtime** | `.reyn/hooks.yaml` | IN-set | リロードのたびに再読み込み |
+| **per-agent** | `.reyn/agents/<name>/hooks.yaml` | IN-set | リロードのたびに再読み込み |
+
+COMBINE は加算的です: `startup ∪ runtime ∪ per-agent`。削除されたフックは再構築されたレジストリに存在しない — 削除は再構築によって処理されます（明示的な削除ステップは不要）。
+
+**レイヤーごとのブート耐性。** 信頼されたスタートアップレイヤー（`reyn.yaml`、オペレーター管理）は読み込まれる必要があります — 失敗はフェイルラウドです。各 untrusted レイヤー（runtime、per-agent）は独立して try-add されます:
+
+- 不正な runtime レイヤーは `startup ∪ per-agent` を維持し、不正なレイヤーはドロップ + 警告されます。
+- 不正な per-agent レイヤーは `startup ∪ runtime` を維持し、不正なレイヤーはドロップ + 警告されます。
+
+リロードパスでは、validate-before-apply も不正な runtime レイヤーを事前に拒否します（多層防御）。
+
+## トリガー
+
+### オペレーター: `/reload`
+
+`/reload` スラッシュコマンドは、次のターン境界でリロードをスケジュールします。
+
+```
+/reload
+```
+
+OUT-set（`reyn.yaml`）には触れません。リロードがスケジュールされ次のターン境界で適用されるという確認メッセージが返ります。
+
+### エージェント自己リロード: `hooks_add`
+
+`hooks_add` LLM-op は、`.reyn/hooks.yaml` にプッシュフックを書き込み、リロードをスケジュールします。フックは `hooks` リアプライシームを経由して次のターン境界で有効になります。
+
+`hooks_add` パラメーター:
+
+| パラメーター | 必須 | 説明 |
+|------------|------|------|
+| `on` | はい | ライフサイクルポイント: `turn_start`、`turn_end`、`session_start`、`session_end`、`skill_start`、`skill_end`、`task_start`、`task_end` |
+| `message` | はい | プッシュメッセージ（Jinja2 テンプレート使用可能） |
+| `wake` | いいえ | `true` → 新しいターンを開始（自己継続、`safety.loop.max_hook_driven_turns` で制限）; `false` → 次のターンのコンテキストとして乗る。デフォルト `true`。 |
+| `push_when` | いいえ | Jinja2 → bool ガード; false にレンダリングされた場合にプッシュをスキップ。 |
+| `name` | いいえ | 履歴の `[hook:name]` アトリビューションプレフィックスとして表示されるラベル。 |
+
+ツールはライトゲートされています: 呼び出し側のスキルは `permissions.tool` に `hooks_add` を宣言する必要があり、ケイパビリティプロファイルの `tool_deny` でそれを拒否できます。
+
+## セーフティストーリー
+
+ホットリロードは 5 層の構造によって安全です:
+
+1. **構造的ライトゲート。** `load_hot_reload_config` は `reyn.yaml` を開きません。`hooks_add` は書き込み先を `.reyn/hooks.yaml` にハードコードしています — パスは LLM の入力から導出されることはありません。LLM がトリガーするリロードは構造的に OUT-set に触れることができません。
+2. **適用前バリデーション。** 不正な IN-set はリロード全体をアトミックに拒否します — ハーフアプライはなく、ライブコンフィグは変更されません。
+3. **ブート耐性。** untrusted レイヤーのレイヤーごとの独立した try-add: 不正なレイヤーはブートのクラッシュや兄弟レイヤーのドロップなしにドロップ + 警告されます。
+4. **サンドボックス + ループバルブ。** フックの `wake:true` ループは `safety.loop.max_hook_driven_turns` で制限されます。サンドボックスはシェルフック実行を保護します。
+5. **ケイパビリティプロファイル拒否。** ケイパビリティプロファイルの `tool_deny: [hooks_add]` はエージェントがフックを追加することを防ぎます — ∩ モデルを通じてエージェントごとに機能を無効化できます。[ケイパビリティプロファイル](capability-profile.md)を参照してください。
+
+## 参照
+
+- [コンセプト: フック](hooks.md) — 8 つのライフサイクルポイント、push/shell スキーム、ウェイクループの動作
+- [コンセプト: ケイパビリティプロファイル](capability-profile.md) — `hooks_add` の `tool_deny` ゲート; per-agent-capability リアプライシーム
+- [コンセプト: パーミッションモデル](permission-model.md) — ∩ モデルとライトゲート境界
+- [リファレンス: reyn.yaml § hooks](../../reference/config/reyn-yaml.md#hooks-block) — スタートアップフックコンフィグ（OUT-set）
+- [リファレンス: イベント](../../reference/runtime/events.md) — `config_reloaded` P6 イベント

--- a/docs/concepts/runtime/config-hot-reload.md
+++ b/docs/concepts/runtime/config-hot-reload.md
@@ -1,0 +1,150 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [config hot-reload, hot-reload, IN-set, OUT-set, HotReloader, hooks_add, /reload, mcp.yaml, cron.yaml, hooks.yaml, reyn.yaml, turn boundary, config_reloaded, reapply seam, hooks layer, per-agent hooks, write-gate]
+---
+
+# Config hot-reload
+
+Reyn's config is split into two sets with different mutability rules. The
+hot-reload mechanism re-reads the runtime-mutable set at a safe-point without a
+process restart.
+
+## IN-set vs OUT-set (the write-gate boundary)
+
+| Set | Files | Mutable at… |
+|-----|-------|-------------|
+| **IN-set** (runtime-mutable) | `.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/hooks.yaml` | Hot-reload at turn boundary |
+| **OUT-set** (restart-only) | `reyn.yaml` (security / permissions / sandbox / budget / loop valve) | Process restart only |
+
+The boundary is structural: `load_hot_reload_config` opens only the `.reyn/*.yaml`
+IN-set files. A hot-reload — and any LLM-op that triggers one — can never touch
+the OUT-set, because the loader never opens those files.
+
+## HotReloader mechanics
+
+### Turn-boundary safe-point (timing-B)
+
+A trigger calls `request_reload(source=…)`, which **schedules** the reload but
+does not apply it immediately. The reload applies at `apply_pending()`, called
+at the turn boundary (finish-reason=stop — the `turn_end` safe-point). Multiple
+triggers within one turn collapse into a single apply: **1 turn = 1 config
+snapshot**; the next turn runs under the new config.
+
+### Validate-before-apply
+
+Before any reapply seam runs, the IN-set is checked structurally. A malformed
+IN-set (bad cron job shape, malformed hooks YAML) **rejects the whole reload** —
+no seam runs, the live config is unchanged. The `config_reloaded` P6 event is not
+emitted on rejection (no state change occurred).
+
+### P6 event
+
+On a successful apply, `config_reloaded` is emitted with:
+
+- `source` — `"operator"` (from `/reload`) or `"llm_op"` (from `hooks_add`)
+- `components` — list of changed seam names
+- `failed` — list of seam names that raised
+
+Every config change is an evented, replay-capable state change (P6).
+
+### Boot resilience
+
+An absent `.reyn/` directory or missing file yields `{}` for that component — a
+no-op reload, never an error. A reload can never crash the session.
+
+## Per-component reapply seams
+
+Five seams are registered on the `HotReloader` at session construction. All five
+run on every reload:
+
+| Seam | What it does |
+|------|--------------|
+| `cron` | Adds / replaces present jobs (idempotent by name). **Removal-diff**: jobs tracked in `_runtime_cron_names` that are absent from the re-read `.reyn/cron.yaml` are unscheduled. Startup (`reyn.yaml`) cron jobs are never removable. |
+| `mcp` | Re-probes MCP servers via the existing turn-boundary refresh chain. Reports whether the in-memory tool cache changed. |
+| `per_agent_capability` | Re-reads `.reyn/agents/<name>/profile.yaml` and updates `allowed_skills` / `allowed_mcp` on the three holders the Session owns (session / skill_runner / router_host). |
+| `new_agent` | Confirming no-op: agent discovery is filesystem-live (the `AgentRegistry` walks `.reyn/agents/` per call), so a newly added agent is already visible without a reload step. Kept as an explicit seam for accounting. |
+| `hooks` | Re-reads global `.reyn/hooks.yaml` + per-agent `.reyn/agents/<name>/hooks.yaml`, re-combines with the fixed startup layer, and swaps the hook dispatcher's registry. |
+
+## Hooks three-layer COMBINE
+
+The hook registry is built additively from three layers, in order:
+
+| Layer | File | Set | On reload |
+|-------|------|-----|-----------|
+| **startup** | `reyn.yaml` | OUT-set | Captured once at boot; never re-read |
+| **runtime** | `.reyn/hooks.yaml` | IN-set | Re-read on every reload |
+| **per-agent** | `.reyn/agents/<name>/hooks.yaml` | IN-set | Re-read on every reload |
+
+The COMBINE is additive: `startup ∪ runtime ∪ per-agent`. A removed hook is
+absent from the rebuilt registry — removal is handled by reconstruction (no
+explicit remove step).
+
+**Per-layer boot resilience.** The trusted startup layer (`reyn.yaml`, operator-
+controlled) must load — a failure is fail-loud. Each untrusted layer (runtime,
+per-agent) is try-added independently:
+
+- A bad runtime layer keeps `startup ∪ per-agent`; the bad layer is dropped + warned.
+- A bad per-agent layer keeps `startup ∪ runtime`; the bad layer is dropped + warned.
+
+On the reload path, validate-before-apply also rejects a bad runtime layer up
+front (defense-in-depth).
+
+## Triggers
+
+### Operator: `/reload`
+
+The `/reload` slash command schedules a reload at the next turn boundary.
+
+```
+/reload
+```
+
+The OUT-set (`reyn.yaml`) is never touched. Responds with a confirmation that
+the reload is scheduled and will apply at the next turn boundary.
+
+### Agent self-reload: `hooks_add`
+
+The `hooks_add` LLM-op writes a push hook to `.reyn/hooks.yaml` and schedules a
+reload. The hook takes effect at the next turn boundary via the `hooks` reapply
+seam.
+
+`hooks_add` parameters:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `on` | yes | Lifecycle point: `turn_start`, `turn_end`, `session_start`, `session_end`, `skill_start`, `skill_end`, `task_start`, `task_end` |
+| `message` | yes | Push message (Jinja2 template allowed) |
+| `wake` | no | `true` → starts a new turn (self-continuation, bounded by `safety.loop.max_hook_driven_turns`); `false` → rides along as context with the next turn. Default `true`. |
+| `push_when` | no | Jinja2 → bool guard; the push is skipped when this renders false. |
+| `name` | no | Label surfaced as `[hook:name]` attribution prefix in history. |
+
+The tool is write-gated: the calling skill must declare `hooks_add` in
+`permissions.tool`, and the capability profile `tool_deny` can deny it.
+
+## Safety story
+
+Hot-reload is safe-by-construction through five layers:
+
+1. **Write-gate by construction.** `load_hot_reload_config` never opens `reyn.yaml`.
+   `hooks_add` hardcodes the write target to `.reyn/hooks.yaml` — the path is never
+   derived from LLM input. An LLM-triggered reload structurally cannot touch the
+   OUT-set.
+2. **Validate-before-apply.** A malformed IN-set rejects the whole reload atomically —
+   no half-apply, live config unchanged.
+3. **Boot resilience.** Per-layer independent try-add for untrusted layers: a bad
+   layer drops + warns without crashing boot or dropping sibling layers.
+4. **Sandbox + loop valve.** Hook `wake:true` loops are bounded by
+   `safety.loop.max_hook_driven_turns`. The sandbox guards shell hook execution.
+5. **Capability-profile deny.** `tool_deny: [hooks_add]` in a capability profile
+   prevents the agent from adding hooks — the feature can be disabled per-agent via
+   the ∩ model. See [Capability profile](capability-profile.md).
+
+## See also
+
+- [Concepts: Hooks](hooks.md) — the 8 lifecycle points, push/shell schemes, wake-loop behavior
+- [Concepts: Capability profile](capability-profile.md) — `tool_deny` gate for `hooks_add`; per-agent-capability reapply seam
+- [Concepts: Permission model](permission-model.md) — the ∩ model and the write-gate boundary
+- [Reference: reyn.yaml § hooks](../../reference/config/reyn-yaml.md#hooks-block) — startup hooks config (OUT-set)
+- [Reference: Events](../../reference/runtime/events.md) — `config_reloaded` P6 event

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -505,6 +505,7 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `skill_resume` | Crash-resume behaviour for skill runs | [Skill Resume](concepts/skills/skill-resume.md) |
 | `action_retrieval` | Action-catalog `search_actions` retrieval tuning | [Universal catalog](concepts/tools-integrations/universal-catalog.md) |
 | `hooks` | Agent-lifecycle push/shell hooks at 8 points (`turn_start/end`, `session_start/end`, `skill_start/end`, `task_start/end`). `push` mode: `wake:false` passive context ride-along, or `wake:true` self-continuation bounded by `safety.loop.max_hook_driven_turns`. `shell`: sandbox-gated side-effect, output ignored. Hooks emit attributed `[hook:name]` messages — history is never silently mutated. | [reyn-yaml § hooks](reference/config/reyn-yaml.md#hooks-block) |
+| Config hot-reload | Runtime re-read of the IN-set (`.reyn/mcp.yaml` / `cron.yaml` / `hooks.yaml`) at the turn boundary without a process restart. OUT-set (`reyn.yaml`: security / budget / loop valve) is restart-only — the file-split is the structural write-gate. Two triggers: operator `/reload` and agent `hooks_add` LLM-op. Validate-before-apply + per-layer boot resilience + sandbox/loop-valve = safe-by-construction. | [Concepts: Config hot-reload](concepts/runtime/config-hot-reload.md) |
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder dispatch (owner-requested): config hot-reload docs for the landed #2073 arc.

## Summary

- **New**: `docs/concepts/runtime/config-hot-reload.md` + `.ja.md` — full concept doc for the hot-reload mechanism
- **Updated**: `docs/feature-map.md` — Config hot-reload row added after hooks
- **Updated**: `docs/concepts/runtime/capability-profile.md` + `.ja.md` — reload section: turn-boundary hot-reload is now LIVE (not planned); per-agent hooks layer documented
- **Nav**: `config-hot-reload.md` inserted after `hooks.md` in Runtime section

## Content coverage (all grounded in landed code)

- IN/OUT file-split: `.reyn/mcp.yaml` / `cron.yaml` / `hooks.yaml` (IN-set, hot-reloadable) vs `reyn.yaml` (OUT-set, restart-only) — `load_hot_reload_config` is the structural write-gate
- HotReloader: timing-B (turn boundary safe-point, 1 turn = 1 snapshot), validate-before-apply (whole-reject on malformed), `config_reloaded` P6 event, boot resilience
- 5 reapply seams: `cron` (+ removal-diff) / `mcp` / `per_agent_capability` / `new_agent` (no-op, filesystem-live) / `hooks`
- Hooks 3-layer COMBINE: startup (`reyn.yaml`, OUT-set) ∪ runtime (`.reyn/hooks.yaml`) ∪ per-agent (`.reyn/agents/<name>/hooks.yaml`), additive, per-layer boot resilience
- Triggers: `/reload` operator slash command + `hooks_add` LLM-op (write-gated by construction)
- Safety story: 5 layers (write-gate + validate + boot-resilience + sandbox/loop-valve + capability-deny)
- Agent-discoverable: `search_hints` + `audience: [human, agent]`; `hooks_add` op parameters table; cross-links to permission-model + capability-profile + hooks

## Primary sources read

- `src/reyn/runtime/hot_reload.py` — `HotReloader`, `validate_in_set`, `load_hot_reload_config`
- `src/reyn/tools/hooks.py` — `hooks_add` handler, write-gate, path hardcoding
- `src/reyn/runtime/session.py` L2857–3000 — `_register_hot_reload_seams`, `_build_hook_registry`, all 5 `_reapply_*` methods
- `src/reyn/interfaces/slash/reload.py` — `/reload` slash command
- `src/reyn/config/loader.py` — `_HOT_RELOAD_FILES`, `load_hot_reload_config`, `load_per_agent_hooks`

## CI gates

- `ruff check src tests` — ✅ all checks passed
- `mkdocs build --strict` — ✅ clean (0 WARNINGs; pre-existing INFO anchor notes in JA reference files unaffected)

## Test plan

- [x] `ruff check src tests` — passed
- [x] `mkdocs build --strict` — clean build, no new warnings
- [x] Nav: `config-hot-reload.md` reachable from Runtime section
- [x] feature-map row links to `concepts/runtime/config-hot-reload.md`
- [x] capability-profile.md reload section cross-links to `config-hot-reload.md`
- [x] No `#issue` refs in user-facing doc body (no-history-refs rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)