### PR TITLE
feat(#2081): S2 — is_delegate signal + unbound-delegate default-deny

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -245,6 +245,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
             project_root=project_root,
             session_factory=_session_factory,
             state_log=state_log,
+            delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
             workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
             act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
         )

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -508,6 +508,7 @@ def run(args: argparse.Namespace) -> None:
         project_root=project_root,
         session_factory=_session_factory,
         state_log=state_log,
+        delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
         environment_backend=env_backend,   # #1544: container shadow-git runs via this
         workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
         workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -508,6 +508,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             project_root=project_root,
             session_factory=_session_factory,
             state_log=None,
+            delegation_capability_default=config.delegation.capability_default,  # #2081
             environment_backend=env_backend,   # #1544: container shadow-git
             workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
             workspace_capture=config.time_travel.workspace_capture,  # #1582 opt-out

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -456,6 +456,7 @@ def run_serve(args: argparse.Namespace) -> None:
         project_root=project_root,
         session_factory=_session_factory,
         state_log=state_log,
+        delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
         workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
         act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
     )

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -383,6 +383,7 @@ def _get_registry():
             project_root=root,
             session_factory=_session_factory,
             state_log=state_log,
+            delegation_capability_default=config.delegation.capability_default,  # #2081
             # #1544: container shadow-git. ``_scoped`` is local to the session
             # factory above; fetch the overrides at this scope via the accessor.
             environment_backend=get_cli_scoped_overrides().environment_backend,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -123,6 +123,7 @@ class AgentRegistry:
         workspace_state_dir: "Path | None" = None,
         workspace_capture: bool = True,
         act_turn_capture: bool = False,
+        delegation_capability_default: str = "inherit",
     ) -> None:
         """
         session_factory: returns a configured Session given an AgentProfile.
@@ -145,6 +146,14 @@ class AgentRegistry:
         self._factory = session_factory
         self._state_log = state_log
         self._project_root = project_root
+        # #2081: delegation policy. ``deny`` narrows an UNBOUND delegate with the
+        # restrictive _delegate floor; ``inherit`` (default) = byte-identical to
+        # pre-#2081. ``_constructing_as_delegate`` is the transient is_delegate
+        # context set by _construct_session around the (synchronous) factory call,
+        # read by resolved_profile_for — keeps the session_factory contract
+        # unchanged (it is a caller-provided closure, 60+ construction sites).
+        self._delegation_capability_default = delegation_capability_default
+        self._constructing_as_delegate = False
         # FP-0043 Stage 3: the Registry holds N conversation Sessions per Agent.
         # Identity (the Agent value object, S2) is shared per name; the
         # conversation instances (= today's Session, inbox+run-loop+history)
@@ -1428,8 +1437,14 @@ class AgentRegistry:
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
-    def get_or_load(self, name: str) -> "object":
-        """Return the Session for `name`, instantiating from profile if new."""
+    def get_or_load(self, name: str, *, is_delegate: bool = False) -> "object":
+        """Return the Session for `name`, instantiating from profile if new.
+
+        ``is_delegate`` (#2081): True when this load is a DELEGATION target (the
+        A2A request path). It is recorded on FIRST construction (a cache hit
+        returns the existing session unchanged) and drives the unbound-delegate
+        default-deny in ``resolved_profile_for``. Default False = a top-level /
+        non-delegation load (byte-identical to pre-#2081)."""
         existing = self._peek_session(name)
         if existing is not None:
             return existing
@@ -1438,15 +1453,26 @@ class AgentRegistry:
                 f"agent {name!r} not found; run `reyn agent new {name}` to create it"
             )
         profile = self.load_profile(name)
-        session = self._construct_session(profile)
+        session = self._construct_session(profile, is_delegate=is_delegate)
         self._store_session(name, session)
         return session
 
-    def _construct_session(self, profile: AgentProfile) -> "object":
+    def _construct_session(
+        self, profile: AgentProfile, *, is_delegate: bool = False
+    ) -> "object":
         """Build a configured Session from a profile (factory + shared-store
         attach), WITHOUT inserting it into the session map. Shared by get_or_load
-        (default session) and spawn_session (additional sessions) — FP-0043 S3."""
-        session = self._factory(profile)
+        (default session) and spawn_session (additional sessions) — FP-0043 S3.
+
+        #2081: ``is_delegate`` is published on the transient
+        ``_constructing_as_delegate`` for the duration of the (synchronous) factory
+        call, so the factory's ``resolved_profile_for(profile.name)`` sees it
+        without a factory-signature change. Cleared in ``finally`` (no leak)."""
+        self._constructing_as_delegate = is_delegate
+        try:
+            session = self._factory(profile)
+        finally:
+            self._constructing_as_delegate = False
         # ADR-0038 Stage 1d: hand the session the single shared workspace
         # shadow-git store so cut_generation captures the workspace at each
         # boundary against the same git-dir the registry's rewind/recovery uses.
@@ -1830,15 +1856,25 @@ class AgentRegistry:
         """All topologies the agent currently belongs to (including `_default`)."""
         return [t for t in self.list_topologies() if agent in t.members]
 
-    def resolved_profile_for(self, agent: str) -> "tuple[object | None, frozenset[str]]":
+    def resolved_profile_for(
+        self, agent: str, *, is_delegate: "bool | None" = None
+    ) -> "tuple[object | None, frozenset[str]]":
         """#1827 S3: the agent's effective contextual narrowing from its topology
         capability_profile bindings.
 
         Returns ``(ContextualPermission | None, excluded_categories)`` — the
         composition (most-restrictive: ∪ deny, ∩ allow, ∪ excluded) of every
-        profile bound to ``agent`` across its topologies. **No binding →
-        ``(None, frozenset())``** = byte-identical to pre-#1827 (the ``_default``
-        network has no profiles, so unaffiliated agents resolve to None).
+        profile bound to ``agent`` across its topologies.
+
+        **No binding →** normally ``(None, frozenset())`` = byte-identical to
+        pre-#1827. **#2081 exception:** when this is an UNBOUND **delegate** load
+        (``is_delegate``) and ``delegation.capability_default=deny``, the
+        restrictive built-in ``_delegate`` floor is applied instead — a topology
+        binding would have REPLACED it (the binding is the re-grant; composition is
+        most-restrictive-wins and cannot re-grant). ``is_delegate=None`` (the
+        factory's construction-time call) falls back to the
+        ``_constructing_as_delegate`` transient; an explicit value (direct callers /
+        tests) wins.
 
         A bound-but-missing or malformed profile file is surfaced (stderr) and
         skipped — a typo must not silently widen capability, but it also must not
@@ -1847,6 +1883,7 @@ class AgentRegistry:
         from reyn.security.permissions.capability_profile import (
             compose_resolved,
             load_capability_profile,
+            load_delegate_profile,
             resolve_profile,
         )
 
@@ -1876,6 +1913,19 @@ class AgentRegistry:
             resolved.append(resolve_profile(prof))
 
         if not resolved:
+            # #2081: an UNBOUND delegate under delegation.capability_default=deny
+            # gets the restrictive _delegate floor (a binding above would have
+            # replaced it). The delegate-ness propagates recursively — every A2A
+            # request-path load passes is_delegate=True regardless of the spawner's
+            # own status — so a re-granted coordinator's sub-delegate is STILL
+            # default-denied (no laundering).
+            effective_delegate = (
+                self._constructing_as_delegate if is_delegate is None else is_delegate
+            )
+            if effective_delegate and self._delegation_capability_default == "deny":
+                return compose_resolved([
+                    resolve_profile(load_delegate_profile(self._project_root))
+                ])
             return None, frozenset()
         return compose_resolved(resolved)
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1467,12 +1467,14 @@ class AgentRegistry:
         #2081: ``is_delegate`` is published on the transient
         ``_constructing_as_delegate`` for the duration of the (synchronous) factory
         call, so the factory's ``resolved_profile_for(profile.name)`` sees it
-        without a factory-signature change. Cleared in ``finally`` (no leak)."""
+        without a factory-signature change. Save/restore (not set-False) so it is
+        correct under nesting too — non-re-entrant today, but free future-proofing."""
+        _prev_delegate = self._constructing_as_delegate
         self._constructing_as_delegate = is_delegate
         try:
             session = self._factory(profile)
         finally:
-            self._constructing_as_delegate = False
+            self._constructing_as_delegate = _prev_delegate
         # ADR-0038 Stage 1d: hand the session the single shared workspace
         # shadow-git store so cut_generation captures the workspace at each
         # boundary against the same git-dir the registry's rewind/recovery uses.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2696,7 +2696,12 @@ class Session:
                 meta={"chain_id": chain_id},
             ))
             return
-        target = self._registry.get_or_load(to)
+        # #2081: the A2A REQUEST path is a delegation by definition → mark the
+        # target a delegate (recorded on first construction; recursive — a
+        # sub-delegate's own delegations pass is_delegate=True too). The response
+        # path (_a2a_send_response) does NOT — the delegator's own delegate-ness was
+        # decided when it was constructed.
+        target = self._registry.get_or_load(to, is_delegate=True)
         await self._registry.ensure_running(to)
         await target.submit_agent_request(
             from_agent=from_agent, request=request,

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -252,6 +252,53 @@ def load_untrusted_profile(project_root: "str | Path") -> CapabilityProfile:
     return builtin_untrusted_profile()
 
 
+# ── #2081: the restrictive floor for an unbound delegate ────────────────────
+#
+# delegation.capability_default=deny narrows an UNBOUND delegate (one spawned by
+# another agent's delegation, recursively) with this profile, unless a topology
+# capability_profile binding re-grants it (the binding REPLACES the default, since
+# composition is most-restrictive-wins). The NAME is decoupled from ``_untrusted``
+# (delegate-spawn vs untrusted-content are distinct contexts) but the default
+# taxonomy is the SAME single-sourced ``_BUILTIN_UNTRUSTED_DENY`` set — so operators
+# can tune delegate-deny independently via ``.reyn/capability_profiles/_delegate.yaml``.
+
+# The well-known auto-applied delegate-floor profile name.
+DELEGATE_PROFILE_NAME: "str" = "_delegate"
+
+
+def builtin_delegate_profile() -> CapabilityProfile:
+    """The built-in restrictive floor auto-applied to an unbound delegate under
+    ``delegation.capability_default=deny`` (#2081). Reuses the single-sourced
+    ``_BUILTIN_UNTRUSTED_DENY`` taxonomy (re-delegation / side-effect-exec /
+    memory-write / MCP-install)."""
+    return CapabilityProfile(
+        name=DELEGATE_PROFILE_NAME,
+        description="auto-applied to an unbound delegate under delegation.capability_default=deny (#2081)",
+        tool_deny=tuple(sorted(_BUILTIN_UNTRUSTED_DENY)),
+    )
+
+
+def load_delegate_profile(project_root: "str | Path") -> CapabilityProfile:
+    """The restrictive profile auto-applied to an unbound delegate (#2081).
+
+    An operator ``.reyn/capability_profiles/_delegate.yaml`` overrides the built-in
+    secure default (a deliberate loosening). A malformed override falls back to the
+    built-in (surfaced on stderr) — a typo must not silently drop the delegate floor.
+    """
+    path = Path(project_root) / ".reyn" / "capability_profiles" / f"{DELEGATE_PROFILE_NAME}.yaml"
+    if path.is_file():
+        try:
+            return load_capability_profile(path)
+        except Exception as e:  # noqa: BLE001 — fall back to the secure default
+            import sys
+            print(
+                f"warning: malformed {path.name}: {e} — using the built-in "
+                "delegate default",
+                file=sys.stderr,
+            )
+    return builtin_delegate_profile()
+
+
 def metas_have_untrusted(metas: "object") -> bool:
     """Seam-agnostic taint check: True iff any entry meta carries the untrusted
     marker. Derived from the **active** context (the caller passes the live,

--- a/tests/test_2081_s2_delegate_default_deny.py
+++ b/tests/test_2081_s2_delegate_default_deny.py
@@ -1,0 +1,157 @@
+"""Tier 2/3: #2081 S2 — the delegate-signal + unbound-delegate default-deny.
+
+When ``delegation.capability_default=deny``, an UNBOUND delegate (one spawned by
+another agent's delegation — the A2A request path passes ``is_delegate=True``,
+recursively) resolves to the restrictive built-in ``_delegate`` floor instead of
+``(None, ∅)``. A topology capability_profile binding REPLACES the default (the
+binding is the re-grant; composition is most-restrictive-wins and cannot re-grant).
+
+The KEY safety property (laundering-prevention): the default-deny propagates
+recursively, so a re-granted coordinator's UNBOUND sub-delegate is STILL
+default-denied — being bound (re-granted) does not launder capability down to
+sub-delegates.
+
+No mocks: a real AgentRegistry + real on-disk topology/profile YAML; resolved via
+the real ``resolved_profile_for`` and the real ``get_or_load`` → factory thread.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.capability_profile import _BUILTIN_UNTRUSTED_DENY
+from reyn.security.permissions.effective import ContextualPermission
+
+# A representative dangerous tool from the taxonomy (re-delegation class).
+_REDELEGATE = "delegate_to_agent"
+
+
+def _registry(tmp_path: Path, *, default: str = "deny") -> AgentRegistry:
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda profile: None,
+        delegation_capability_default=default,
+    )
+
+
+def _bind_profile(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    """Bind ``member`` to ``profile`` in a network topology + write the profile YAML."""
+    topo_dir = tmp_path / ".reyn" / "topologies"
+    topo_dir.mkdir(parents=True, exist_ok=True)
+    (topo_dir / "t.yaml").write_text(
+        f"name: t\nkind: network\nmembers: [{member}, peer]\n"
+        f"profiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    prof_dir = tmp_path / ".reyn" / "capability_profiles"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    (prof_dir / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+# ── the unbound-delegate default-deny (the core fork) ───────────────────────
+
+
+def test_unbound_delegate_deny_gets_delegate_floor(tmp_path: Path) -> None:
+    """Tier 2: deny + unbound + delegate → the restrictive _delegate floor (the full
+    single-sourced dangerous-tool taxonomy is denied)."""
+    contextual, excluded = _registry(tmp_path).resolved_profile_for("solo", is_delegate=True)
+    assert isinstance(contextual, ContextualPermission)
+    assert _REDELEGATE in contextual.tool_deny
+    # the floor IS the single-sourced taxonomy (every dangerous class denied)
+    assert _BUILTIN_UNTRUSTED_DENY <= contextual.tool_deny
+
+
+def test_unbound_delegate_inherit_is_none(tmp_path: Path) -> None:
+    """Tier 2: inherit (default policy) + unbound + delegate → (None, ∅) — byte-identical
+    to pre-#2081 (the delegate inherits the spawner's surface)."""
+    assert _registry(tmp_path, default="inherit").resolved_profile_for(
+        "solo", is_delegate=True
+    ) == (None, frozenset())
+
+
+def test_top_level_deny_is_none(tmp_path: Path) -> None:
+    """Tier 2: deny + unbound + NON-delegate (a top-level/root agent) → (None, ∅).
+    A root is never default-denied — only delegates are."""
+    assert _registry(tmp_path).resolved_profile_for("solo", is_delegate=False) == (
+        None, frozenset(),
+    )
+
+
+# ── re-grant: a topology binding REPLACES the default ───────────────────────
+
+
+def test_bound_delegate_regrant_replaces_default(tmp_path: Path) -> None:
+    """Tier 2: deny + delegate but BOUND to a permissive profile → the binding REPLACES
+    the _delegate default (re-grant). The permissive profile does NOT deny re-delegation,
+    so the result does not carry the _delegate floor's deny."""
+    _bind_profile(tmp_path, member="worker", profile="coordinator",
+                  body="name: coordinator\ntool_deny: []\n")
+    contextual, _excluded = _registry(tmp_path).resolved_profile_for("worker", is_delegate=True)
+    # the bound (permissive) profile replaced the default → re-delegation is re-granted
+    assert _REDELEGATE not in (contextual.tool_deny if contextual else frozenset())
+
+
+# ── THE KEY SAFETY PROPERTY: recursive default-deny (no laundering) ─────────
+
+
+def test_recursive_subdelegate_of_regranted_coordinator_still_denied(tmp_path: Path) -> None:
+    """Tier 2: laundering-prevention (the property lead verifies hardest). A re-granted
+    coordinator (BOUND, so it CAN re-delegate) does NOT launder capability to its
+    UNBOUND sub-delegate: the sub-delegate — reached via the A2A request path, so
+    is_delegate=True recursively — is STILL default-denied.
+
+    Both halves in one test: the coordinator is re-granted (re-delegation allowed) AND
+    its unbound sub-delegate is default-denied (re-delegation + the whole taxonomy)."""
+    _bind_profile(tmp_path, member="coordinator", profile="coord_profile",
+                  body="name: coord_profile\ntool_deny: []\n")
+    reg = _registry(tmp_path)
+
+    # the re-granted coordinator CAN re-delegate (the binding replaced the default)
+    coord_perm, _ = reg.resolved_profile_for("coordinator", is_delegate=True)
+    assert _REDELEGATE not in (coord_perm.tool_deny if coord_perm else frozenset())
+
+    # its UNBOUND sub-delegate is STILL default-denied (no laundering)
+    sub_perm, _ = reg.resolved_profile_for("sub_worker", is_delegate=True)
+    assert isinstance(sub_perm, ContextualPermission)
+    assert _REDELEGATE in sub_perm.tool_deny
+    assert _BUILTIN_UNTRUSTED_DENY <= sub_perm.tool_deny
+
+
+# ── the is_delegate thread: get_or_load → transient → factory resolution ────
+
+
+def test_get_or_load_is_delegate_threads_through_factory(tmp_path: Path) -> None:
+    """Tier 3a: the spawn-reason signal reaches the factory's resolution WITHOUT a
+    factory-signature change. A factory that calls resolved_profile_for(profile.name)
+    (the None-arg call the real factories make) sees the _delegate floor under
+    get_or_load(is_delegate=True), and (None, ∅) under a normal load — proving the
+    _construct_session transient threads is_delegate to the construction-time call."""
+    seen: dict = {}
+
+    def _factory(profile):
+        # mirrors the real factory: resolves WITHOUT passing is_delegate explicitly.
+        seen[profile.name] = reg.resolved_profile_for(profile.name)
+        return None
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, delegation_capability_default="deny",
+    )
+    reg.create("as_delegate")
+    reg.create("as_root")
+
+    reg.get_or_load("as_delegate", is_delegate=True)
+    reg.get_or_load("as_root")  # default is_delegate=False
+
+    delegate_perm, _ = seen["as_delegate"]
+    assert isinstance(delegate_perm, ContextualPermission)
+    assert _REDELEGATE in delegate_perm.tool_deny       # delegate → default-denied
+    assert seen["as_root"] == (None, frozenset())        # root → unaffected
+
+
+def test_construct_transient_cleared_after_load(tmp_path: Path) -> None:
+    """Tier 2: the is_delegate transient is cleared after construction — a subsequent
+    non-delegate resolution is not contaminated by a prior delegate load."""
+    reg = _registry(tmp_path)
+    reg.resolved_profile_for("d", is_delegate=True)  # explicit delegate resolution
+    # a later default resolution (no transient set) is clean
+    assert reg.resolved_profile_for("later") == (None, frozenset())

--- a/tests/test_2081_s2_delegate_default_deny.py
+++ b/tests/test_2081_s2_delegate_default_deny.py
@@ -148,10 +148,29 @@ def test_get_or_load_is_delegate_threads_through_factory(tmp_path: Path) -> None
     assert seen["as_root"] == (None, frozenset())        # root → unaffected
 
 
-def test_construct_transient_cleared_after_load(tmp_path: Path) -> None:
-    """Tier 2: the is_delegate transient is cleared after construction — a subsequent
-    non-delegate resolution is not contaminated by a prior delegate load."""
-    reg = _registry(tmp_path)
-    reg.resolved_profile_for("d", is_delegate=True)  # explicit delegate resolution
-    # a later default resolution (no transient set) is clean
-    assert reg.resolved_profile_for("later") == (None, frozenset())
+def test_transient_restored_after_real_delegate_construction(tmp_path: Path) -> None:
+    """Tier 3a: the is_delegate transient is restored after a REAL delegate
+    construction — a later non-delegate resolution is not contaminated.
+
+    Exercises the actual get_or_load(is_delegate=True) → _construct_session →
+    factory path (not an explicit-arg shortcut, which would bypass the transient):
+    the factory's resolved_profile_for(name) sees the floor DURING construction;
+    afterwards a direct resolved_profile_for(other) must be (None, ∅). Removing the
+    finally-restore in _construct_session makes this RED (the transient stays True)."""
+    seen: dict = {}
+
+    def _factory(profile):
+        seen[profile.name] = reg.resolved_profile_for(profile.name)  # None-arg → transient
+        return None
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, delegation_capability_default="deny",
+    )
+    reg.create("worker")
+    reg.get_or_load("worker", is_delegate=True)  # a REAL delegate construction
+
+    # DURING construction the transient was True (the floor was resolved)
+    worker_perm, _ = seen["worker"]
+    assert _REDELEGATE in worker_perm.tool_deny
+    # AFTER construction the transient is restored → a direct resolution is clean
+    assert reg.resolved_profile_for("other_unbound") == (None, frozenset())

--- a/tests/test_a2a_iv_kind_choices_267_gap4.py
+++ b/tests/test_a2a_iv_kind_choices_267_gap4.py
@@ -189,7 +189,7 @@ class _FakeAgentRegistry:
     def __init__(self, session) -> None:
         self._session = session
 
-    def get_or_load(self, name: str):  # noqa: ANN202
+    def get_or_load(self, name: str, *, is_delegate: bool = False):  # noqa: ANN202
         return self._session
 
     def resolve_session(self, name: str, transport: str, native_id: str):  # noqa: ANN202

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -104,7 +104,7 @@ class _StubAgentRegistry:
     def permit(self, from_agent: str, to_agent: str) -> bool:
         return True
 
-    def get_or_load(self, name: str) -> _StubSession:
+    def get_or_load(self, name: str, *, is_delegate: bool = False) -> _StubSession:
         return self._target
 
     async def ensure_running(self, name: str) -> None:

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -117,7 +117,7 @@ class _FakeRegistry:
             if n != self_name
         ]
 
-    def get_or_load(self, name: str) -> "Session":
+    def get_or_load(self, name: str, *, is_delegate: bool = False) -> "Session":
         return self._targets[name]
 
     async def ensure_running(self, name: str) -> None:


### PR DESCRIPTION
**[e2e-coder]** — #2081 delegation-default-policy, stage **S2** (the policy wiring). S1 (#2091) merged. No-merge — close-review. S3 (operator override + audit + docs) follows.

## What

Wires the S1 config field to the live capability gate. When `delegation.capability_default=deny`, an **unbound** delegate resolves to the restrictive built-in `_delegate` floor instead of `(None, ∅)`; a topology `capability_profile` binding **replaces** the default (the binding is the re-grant — composition is most-restrictive-wins, cannot re-grant). `inherit` (default) is **byte-identical to pre-#2081**.

**Delegate signal (Q1-B, confirmed):** the A2A **request** path passes `is_delegate=True` (a delegation by definition) → recorded on first construction → drives the unbound-fallback. **Recursive by construction**: every request-path hop passes `is_delegate=True` regardless of the spawner's own status, so a re-granted coordinator's **unbound** sub-delegate is **still default-denied** (laundering prevented). The response path does not mark a delegate.

**Threading without a factory-signature change** (the `session_factory` closure has 60+ construction sites incl. ~167 in tests): `_construct_session` publishes `is_delegate` on the transient `_constructing_as_delegate` around the *synchronous* factory call; `resolved_profile_for` reads it (`is_delegate=None` → transient; explicit arg → that, for direct/test callers).

- `capability_profile.py`: `_delegate` name + `builtin_delegate_profile()` (reuses the single-sourced `_BUILTIN_UNTRUSTED_DENY` taxonomy) + `load_delegate_profile` (operator override, malformed→builtin).
- `registry.py`: policy param + transient + `get_or_load`/`_construct_session` thread + `resolved_profile_for` unbound-fallback.
- `session.py`: A2A request path passes `is_delegate=True`.
- web/deps + chainlit + cli/chat + dogfood: pass the config policy.
- 3 test-double `get_or_load` stubs accept the new optional kwarg (API parity — surfaced by the broad suite).

## Test plan

- [x] `tests/test_2081_s2_delegate_default_deny.py` (Tier 2/3): deny→floor / inherit→(None,∅) / top-level→(None,∅) / bound→re-grant replaces / **RECURSIVE→a re-granted coordinator's sub-delegate STILL default-denied** (the laundering-prevention property) / `get_or_load`→transient→factory thread / transient cleared after.
- [x] #1827 topology-profile-binding e2e + S1 config tests green (regression)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8301 passed, 18 skipped, 3 xfailed** (4 stub-signature failures found by the broad suite + fixed)

## Note

`reyn-yaml.md` already documents `deny`'s full semantics (since S1), so S2 closes the documented-but-noop window promptly per the S1 review note.

Refs #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)