### PR TITLE
feat(#2081): S3 — gateway:delegation-unsafe audit + _delegate concept doc (#2081 final)

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -112,6 +112,37 @@ execution, MCP install. Untrusted content can be read and reasoned about, but
 cannot drive irreversible actions. Override is a deliberate loosening — a
 malformed `_untrusted.yaml` falls back to the built-in (surfaced on stderr).
 
+## Default-deny delegation narrowing (#2081)
+
+A second built-in profile is auto-applied to a **delegated** agent when the
+operator opts into strict delegation:
+
+**Profile name:** `_delegate` (built-in restrictive default; overridable via
+`.reyn/capability_profiles/_delegate.yaml`). The name is decoupled from
+`_untrusted` (delegate-spawn vs untrusted-content are distinct contexts), but
+the default deny-set is the **same single-sourced taxonomy** — so operators tune
+delegate-deny independently.
+
+**Trigger:** `delegation.capability_default: deny` in reyn.yaml AND the agent is
+an **unbound delegate** — spawned by another agent's delegation (the A2A request
+path), with no topology `capability_profile` binding.
+
+**Effect:** the unbound delegate resolves to the `_delegate` floor instead of no
+narrowing. A topology binding **replaces** the default (the binding is the
+re-grant — composition is most-restrictive-wins and cannot re-grant). The
+default-deny propagates **recursively**: every delegation hop marks the target a
+delegate, so a re-granted coordinator's own unbound sub-delegate is still
+default-denied (no laundering).
+
+`delegation.capability_default: inherit` (the default) keeps a delegate
+inheriting the spawner's surface — byte-identical to pre-#2081.
+
+**Audit:** `reyn audit` (`gateway:delegation-unsafe`) flags, per dangerous class,
+a delegate-reachable bound profile (or the `_delegate.yaml` override) that
+re-grants a class (re-delegation / exec = HIGH; memory-write / destructive-FS =
+MED), and nudges (INFO) when `capability_default=inherit` while a topology
+permits delegation.
+
 ## Agent self-edit
 
 An agent can update either surface at runtime without requesting extra

--- a/src/reyn/interfaces/cli/commands/audit.py
+++ b/src/reyn/interfaces/cli/commands/audit.py
@@ -4,7 +4,7 @@ A STATIC, install-time / on-demand audit (distinct from the #1822 S1-S5 runtime
 content-threat scan). It READS skill / plugin code + config and pattern-scans them —
 it never imports or executes skill code. The OpenClaw ``audit-*`` analog.
 
-Three rules (lead-greenlit, #1864):
+Rules (lead-greenlit, #1864; #2081 S3 adds rule 4):
   1. **unsafe code/config** — reuse the #1822 ``threat_patterns`` catalog (static
      scan of each skill/plugin text file at the strict + exec scopes).
   2. **secrets permission** — ``~/.reyn/secrets.env`` is written chmod 600
@@ -15,6 +15,11 @@ Three rules (lead-greenlit, #1864):
      HIGH); MCP plugin configs are read directly: a ``command`` (subprocess spawn,
      HIGH), secret-looking ``env`` keys (+secrets, HIGH), a network ``url`` (egress,
      INFO), and every server is enumerated (INFO).
+  4. **delegation-unsafe** (#2081 S3) — a delegate-REACHABLE topology role (inbound
+     ``can_send`` target) whose bound capability_profile, or the ``_delegate.yaml``
+     override, re-grants a dangerous class (re-delegation / exec = HIGH; memory-write /
+     destructive-FS = MED); + an INFO posture nudge when ``delegation.capability_default
+     =inherit`` while a topology permits delegation.
 
 ``reyn audit [--skill <name>] [--json]`` → findings; **exit non-zero only on a
 block-severity (HIGH) finding** (CI-usable).
@@ -300,6 +305,94 @@ def _gateway_skill_ops(skill_dir: Path) -> list[Finding]:
     return findings
 
 
+def _gateway_delegation() -> list[Finding]:
+    """Rule 4 (#2081 S3): delegation-unsafe capability. The audit flags, per dangerous
+    CLASS (re-delegation / exec = HIGH; memory-write / destructive-FS = MED):
+
+    - a delegate-REACHABLE topology role — a member with an inbound ``can_send`` edge,
+      = a delegation target (the A2A request path is can_send-gated) — whose bound
+      capability_profile PERMITS the class. Reachability-precise (OPT-A): an
+      outbound-only role (e.g. a hierarchy's top coordinator) that legitimately holds
+      ``delegate_to_agent`` is NOT a delegation target, so it is NOT flagged — avoiding
+      a false HIGH (which would wrongly ``exit(1)`` / block a deploy).
+    - the ``_delegate.yaml`` override permitting a class — it IS the global delegate
+      floor, so a re-grant there applies to every unbound delegate (no reachability
+      needed).
+    - INFO posture: ``delegation.capability_default=inherit`` while a topology has any
+      delegation edge — delegates inherit the spawner's full capability (a nudge, not
+      a block; ``inherit`` is the default)."""
+    from reyn.security.permissions.capability_profile import (
+        DELEGATE_PROFILE_NAME,
+        DELEGATION_AUDIT_CLASSES,
+        load_capability_profile,
+        profile_permits,
+    )
+
+    findings: list[Finding] = []
+    root = Path.cwd()
+    try:
+        from reyn.config import load_config
+        cap_default = load_config().delegation.capability_default
+    except Exception as exc:  # never let config-load break the audit
+        return [Finding("reyn.yaml delegation:", "gateway:delegation-unsafe", _INFO,
+                        f"could not load delegation config: {exc}")]
+
+    topologies = []
+    topo_dir = root / ".reyn" / "topologies"
+    if topo_dir.is_dir():
+        from reyn.runtime.topology import Topology
+        for p in sorted(topo_dir.glob("*.yaml")):
+            try:
+                topologies.append(Topology.load(p))
+            except Exception:  # a malformed topology is surfaced by other paths
+                continue
+
+    # OPT-C: inherit + any delegation edge → a posture nudge (INFO, never a block).
+    if cap_default == "inherit" and any(t.edges() for t in topologies):
+        findings.append(Finding(
+            "reyn.yaml delegation:", "gateway:delegation-unsafe", _INFO,
+            "capability_default=inherit: delegated agents inherit the spawner's full "
+            "capability (incl. re-delegation / exec / memory-write). Set "
+            "delegation.capability_default=deny to apply the restrictive _delegate floor.",
+        ))
+
+    prof_dir = root / ".reyn" / "capability_profiles"
+
+    def _scan(profile, loc: str) -> None:
+        for cls, (sev, tools) in DELEGATION_AUDIT_CLASSES.items():
+            permitted = sorted(t for t in tools if profile_permits(profile, t))
+            if permitted:
+                findings.append(Finding(
+                    loc, "gateway:delegation-unsafe", sev,
+                    f"permits {cls} for a delegate: {permitted}",
+                ))
+
+    # OPT-A: per-class re-grant scan of delegate-REACHABLE bound profiles.
+    for topo in topologies:
+        targets = {x for x in topo.members if any(topo.can_send(y, x) for y in topo.members)}
+        for member in sorted(targets):
+            pname = topo.profiles.get(member)
+            if not pname:
+                continue
+            ppath = prof_dir / f"{pname}.yaml"
+            if not ppath.is_file():
+                continue
+            try:
+                _scan(load_capability_profile(ppath), f"topology {topo.name}/{member} (profile {pname})")
+            except Exception:
+                continue
+
+    # the _delegate.yaml override is the GLOBAL delegate floor — scan it always.
+    dpath = prof_dir / f"{DELEGATE_PROFILE_NAME}.yaml"
+    if dpath.is_file():
+        try:
+            _scan(load_capability_profile(dpath), f"capability_profiles/{DELEGATE_PROFILE_NAME}.yaml")
+        except Exception:
+            pass
+
+    return findings
+
+
 def _collect(only: str | None) -> list[Finding]:
     findings: list[Finding] = []
     for d in _skill_dirs(only):
@@ -309,6 +402,7 @@ def _collect(only: str | None) -> list[Finding]:
     findings.extend(_secrets_perm())
     if only is None:
         findings.extend(_gateway_mcp())
+        findings.extend(_gateway_delegation())  # #2081 S3
     return findings
 
 

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -299,6 +299,38 @@ def load_delegate_profile(project_root: "str | Path") -> CapabilityProfile:
     return builtin_delegate_profile()
 
 
+# ── #2081 S3: the delegation-unsafe AUDIT taxonomy ──────────────────────────
+#
+# ``reyn audit`` (gateway:delegation-unsafe) flags, per dangerous CLASS, a
+# delegate-REACHABLE bound capability_profile — or the ``_delegate.yaml`` override —
+# that PERMITS the class (a re-grant that widens an unbound delegate's floor). This is
+# the security-JUDGMENT taxonomy for the static audit; it is RELATED to but not
+# identical with the runtime ``_delegate`` FLOOR (``_BUILTIN_UNTRUSTED_DENY``): the
+# audit additionally covers destructive-FS (``delete_file``) — a delegate-reachable
+# concern even though the floor does not deny it — and assigns per-class severities
+# (the dogfood-coder taxonomy). (``mcp-install`` is in the floor but is not separately
+# audit-flagged here — under ``deny`` it is denied; the per-class audit focuses on the
+# confirmed dogfood-coder severity classes.)
+DELEGATION_AUDIT_CLASSES: "dict[str, tuple[str, frozenset[str]]]" = {
+    "re-delegation": ("HIGH", frozenset({"delegate_to_agent", "multi_agent__delegate"})),
+    "exec": ("HIGH", frozenset({"sandboxed_exec", "exec__sandboxed_exec"})),
+    "memory-write": ("MED", frozenset({
+        "remember_shared", "remember_agent", "forget_memory",
+        "memory_operation__remember_shared", "memory_operation__remember_agent",
+        "memory_operation__forget",
+    })),
+    "destructive-fs": ("MED", frozenset({"delete_file", "file__delete"})),
+}
+
+
+def profile_permits(profile: CapabilityProfile, tool: str) -> bool:
+    """Whether ``profile`` would PERMIT ``tool`` on the TOOL axis — the allow-list is
+    satisfied (None = unconstrained, else membership) AND it is not denied. The
+    delegation-unsafe audit's re-grant check (#2081 S3)."""
+    in_allow = profile.tool_allow is None or tool in profile.tool_allow
+    return in_allow and tool not in profile.tool_deny
+
+
 def metas_have_untrusted(metas: "object") -> bool:
     """Seam-agnostic taint check: True iff any entry meta carries the untrusted
     marker. Derived from the **active** context (the caller passes the live,

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -207,18 +207,27 @@ UNTRUSTED_PROFILE_NAME: "str" = "_untrusted"
 # and reasoned about but cannot drive irreversible actions. Both the qualified
 # catalog names and their unwrapped aliases are denied (the live gate matches the
 # effective resolved name, which differs by scheme / invoke_action unwrap).
-_BUILTIN_UNTRUSTED_DENY: "frozenset[str]" = frozenset({
+#
+# Grouped by CLASS (#2081 S3): the runtime FLOOR is the flat union below; the
+# delegation-unsafe AUDIT (DELEGATION_AUDIT_CLASSES) derives its FLOORED classes +
+# severities from these same groups — so the floor and the audit cannot drift apart.
+_FLOORED_DENY_CLASSES: "dict[str, frozenset[str]]" = {
     # memory writes / deletes — no persistence from untrusted content
-    "memory_operation__remember_shared",
-    "memory_operation__remember_agent",
-    "memory_operation__forget",
+    "memory-write": frozenset({
+        "memory_operation__remember_shared",
+        "memory_operation__remember_agent",
+        "memory_operation__forget",
+    }),
     # re-delegation — no spawning peers from untrusted content
-    "multi_agent__delegate", "delegate_to_agent",
+    "re-delegation": frozenset({"multi_agent__delegate", "delegate_to_agent"}),
     # code execution
-    "exec__sandboxed_exec", "sandboxed_exec",
+    "exec": frozenset({"exec__sandboxed_exec", "sandboxed_exec"}),
     # MCP install — no installing servers from untrusted content
-    "mcp__install_registry", "mcp__install_package", "mcp__install_local",
-})
+    "mcp-install": frozenset({
+        "mcp__install_registry", "mcp__install_package", "mcp__install_local",
+    }),
+}
+_BUILTIN_UNTRUSTED_DENY: "frozenset[str]" = frozenset().union(*_FLOORED_DENY_CLASSES.values())
 
 
 def builtin_untrusted_profile() -> CapabilityProfile:
@@ -303,24 +312,26 @@ def load_delegate_profile(project_root: "str | Path") -> CapabilityProfile:
 #
 # ``reyn audit`` (gateway:delegation-unsafe) flags, per dangerous CLASS, a
 # delegate-REACHABLE bound capability_profile — or the ``_delegate.yaml`` override —
-# that PERMITS the class (a re-grant that widens an unbound delegate's floor). This is
-# the security-JUDGMENT taxonomy for the static audit; it is RELATED to but not
-# identical with the runtime ``_delegate`` FLOOR (``_BUILTIN_UNTRUSTED_DENY``): the
-# audit additionally covers destructive-FS (``delete_file``) — a delegate-reachable
-# concern even though the floor does not deny it — and assigns per-class severities
-# (the dogfood-coder taxonomy). (``mcp-install`` is in the floor but is not separately
-# audit-flagged here — under ``deny`` it is denied; the per-class audit focuses on the
-# confirmed dogfood-coder severity classes.)
-DELEGATION_AUDIT_CLASSES: "dict[str, tuple[str, frozenset[str]]]" = {
-    "re-delegation": ("HIGH", frozenset({"delegate_to_agent", "multi_agent__delegate"})),
-    "exec": ("HIGH", frozenset({"sandboxed_exec", "exec__sandboxed_exec"})),
-    "memory-write": ("MED", frozenset({
-        "remember_shared", "remember_agent", "forget_memory",
-        "memory_operation__remember_shared", "memory_operation__remember_agent",
-        "memory_operation__forget",
-    })),
-    "destructive-fs": ("MED", frozenset({"delete_file", "file__delete"})),
+# that PERMITS the class (a re-grant that widens an unbound delegate's floor; the floor
+# is REPLACED by a binding, so even a floored class can be re-granted).
+#
+# The FLOORED classes (re-delegation / exec / mcp-install / memory-write) are
+# single-sourced from ``_FLOORED_DENY_CLASSES`` + the severity map below — so the audit
+# and the runtime floor cannot drift. ``destructive-fs`` is an explicit, documented
+# AUDIT-ONLY class (the intentional audit ⊋ floor delta): ``delete_file`` is a
+# delegate-reachable concern, but it is FILE_WRITE-permission-bounded so it is not on
+# the runtime floor — the audit surfaces it as a re-grant judgment regardless.
+_FLOORED_AUDIT_SEVERITY: "dict[str, str]" = {
+    "re-delegation": "HIGH",
+    "exec": "HIGH",
+    "mcp-install": "HIGH",
+    "memory-write": "MED",
 }
+DELEGATION_AUDIT_CLASSES: "dict[str, tuple[str, frozenset[str]]]" = {
+    cls: (_FLOORED_AUDIT_SEVERITY[cls], tools)
+    for cls, tools in _FLOORED_DENY_CLASSES.items()
+}
+DELEGATION_AUDIT_CLASSES["destructive-fs"] = ("MED", frozenset({"delete_file", "file__delete"}))
 
 
 def profile_permits(profile: CapabilityProfile, tool: str) -> bool:

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -1,0 +1,177 @@
+"""Tier 2: #2081 S3 — the gateway:delegation-unsafe audit (reachability-precise).
+
+`reyn audit` flags, per dangerous CLASS, a delegate-REACHABLE bound capability_profile
+(or the _delegate.yaml override) that re-grants the class — re-delegation/exec=HIGH,
+memory-write/destructive-FS=MED — plus an INFO posture nudge when capability_default=
+inherit while a topology permits delegation.
+
+The deciding property (OPT-A over OPT-B): reachability-precision. HIGH gates exit(1),
+so flagging a NON-delegate-target (e.g. a pipeline head that legitimately holds
+delegate_to_agent, outbound-only) would be a FALSE deploy-block. A delegation target =
+a member with an inbound can_send edge (the A2A request path is can_send-gated).
+
+No mocks: real Topology/CapabilityProfile YAML on disk + real load_config (tmp reyn.yaml)
++ the real audit rule function.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.cli.commands import audit
+
+_RULE = "gateway:delegation-unsafe"
+
+
+def _profiles(tmp_path: Path) -> Path:
+    d = tmp_path / ".reyn" / "capability_profiles"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _topos(tmp_path: Path) -> Path:
+    d = tmp_path / ".reyn" / "topologies"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _reyn_yaml(tmp_path: Path, capability_default: str) -> None:
+    (tmp_path / "reyn.yaml").write_text(
+        f"delegation:\n  capability_default: {capability_default}\n", encoding="utf-8",
+    )
+
+
+def _findings(monkeypatch, tmp_path: Path) -> list:
+    monkeypatch.chdir(tmp_path)
+    return audit._gateway_delegation()
+
+
+def _by(findings: list, *, severity: str | None = None, contains: str | None = None) -> list:
+    out = [f for f in findings if f.rule == _RULE]
+    if severity is not None:
+        out = [f for f in out if f.severity == severity]
+    if contains is not None:
+        out = [f for f in out if contains in f.detail or contains in f.location]
+    return out
+
+
+# ── OPT-A: a delegate-REACHABLE re-grant is flagged (per-class severity) ─────
+
+
+def test_reachable_role_regrant_flagged_high(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a delegate-reachable role (network member, inbound edge) bound to a
+    permissive profile that permits re-delegation → a HIGH finding."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [worker, peer]\nprofiles:\n  worker: loose\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "loose.yaml").write_text(
+        "name: loose\ntool_deny: []\n", encoding="utf-8",  # permits everything
+    )
+    high = _by(_findings(monkeypatch, tmp_path), severity="HIGH", contains="re-delegation")
+    assert high and "worker" in high[0].location
+
+
+def test_memory_write_regrant_is_med(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: per-class severity — a re-granted memory-write is MED (not HIGH)."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [worker, peer]\nprofiles:\n  worker: loose\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "loose.yaml").write_text("name: loose\ntool_deny: []\n", encoding="utf-8")
+    med = _by(_findings(monkeypatch, tmp_path), severity="MED", contains="memory-write")
+    assert med
+
+
+# ── OPT-A correctness: an outbound-only role is NOT a target → NOT flagged ───
+
+
+def test_outbound_only_head_not_flagged(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the deciding property — a pipeline HEAD (outbound-only, no inbound
+    can_send) bound to a profile permitting re-delegation is NOT a delegation target,
+    so it is NOT flagged. (OPT-B would false-flag it HIGH → a wrong exit(1) deploy-block.)"""
+    _reyn_yaml(tmp_path, "deny")
+    # pipeline a→b→c: `a` has NO inbound edge (not a delegation target).
+    (_topos(tmp_path) / "p.yaml").write_text(
+        "name: p\nkind: pipeline\nmembers: [a, b, c]\nprofiles:\n  a: loose\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "loose.yaml").write_text("name: loose\ntool_deny: []\n", encoding="utf-8")
+    # `a` is bound + permissive, but outbound-only → no per-class finding for it.
+    assert not _by(_findings(monkeypatch, tmp_path), contains="/a ")
+
+
+def test_pipeline_tail_target_is_flagged(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the pipeline TAIL (`c`, inbound from `b`) IS a delegation target — a
+    permissive binding there IS flagged (confirms the reachability scope is real, not
+    blanket-skip)."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "p.yaml").write_text(
+        "name: p\nkind: pipeline\nmembers: [a, b, c]\nprofiles:\n  c: loose\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "loose.yaml").write_text("name: loose\ntool_deny: []\n", encoding="utf-8")
+    assert _by(_findings(monkeypatch, tmp_path), severity="HIGH", contains="re-delegation")
+
+
+# ── the _delegate.yaml override is the global floor → scanned always ─────────
+
+
+def test_delegate_override_regrant_flagged(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a _delegate.yaml override that re-grants a class is flagged (it IS the
+    global delegate floor — every unbound delegate gets it; no reachability needed)."""
+    _reyn_yaml(tmp_path, "deny")
+    (_profiles(tmp_path) / "_delegate.yaml").write_text(
+        "name: _delegate\ntool_deny: []\n", encoding="utf-8",  # a fully-permissive override
+    )
+    findings = _by(_findings(monkeypatch, tmp_path), contains="_delegate.yaml")
+    assert any(f.severity == "HIGH" for f in findings)  # re-delegation/exec
+    assert any(f.severity == "MED" for f in findings)   # memory-write/destructive-FS
+
+
+# ── a DENYING delegate-reachable profile is safe → not flagged ──────────────
+
+
+def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a delegate-reachable role bound to a profile that DENIES the dangerous
+    tools is safe — no finding (the audit flags re-grants, not safe narrowings)."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [worker, peer]\nprofiles:\n  worker: tight\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "tight.yaml").write_text(
+        "name: tight\ntool_deny: [delegate_to_agent, multi_agent__delegate, sandboxed_exec, "
+        "exec__sandboxed_exec, remember_shared, remember_agent, forget_memory, delete_file, "
+        "file__delete, memory_operation__remember_shared, memory_operation__remember_agent, "
+        "memory_operation__forget]\n",
+        encoding="utf-8",
+    )
+    assert not _by(_findings(monkeypatch, tmp_path), contains="worker")
+
+
+# ── OPT-C: inherit posture nudge (INFO, never a block) ──────────────────────
+
+
+def test_inherit_with_delegation_edge_is_info(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: capability_default=inherit + a topology with a delegation edge → an INFO
+    posture nudge (delegates inherit full capability). Not HIGH — inherit is the default."""
+    _reyn_yaml(tmp_path, "inherit")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [a, b]\n", encoding="utf-8",
+    )
+    info = _by(_findings(monkeypatch, tmp_path), severity="INFO")
+    assert info and "inherit" in info[0].detail
+
+
+def test_deny_no_bindings_is_clean(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: deny + a topology with edges but no permissive bindings → no findings
+    (unbound delegates get the safe floor; nothing to flag)."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [a, b]\n", encoding="utf-8",
+    )
+    assert _by(_findings(monkeypatch, tmp_path)) == []

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -86,6 +86,19 @@ def test_memory_write_regrant_is_med(tmp_path: Path, monkeypatch) -> None:
     assert med
 
 
+def test_mcp_install_regrant_flagged_high(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: mcp-install is a floored class (single-sourced) → a re-granted
+    mcp-install is flagged HIGH. A `tool_deny: []` binding REPLACES the floor's deny,
+    so the delegate CAN install servers — capability escalation, peer of re-deleg/exec."""
+    _reyn_yaml(tmp_path, "deny")
+    (_topos(tmp_path) / "t.yaml").write_text(
+        "name: t\nkind: network\nmembers: [worker, peer]\nprofiles:\n  worker: loose\n",
+        encoding="utf-8",
+    )
+    (_profiles(tmp_path) / "loose.yaml").write_text("name: loose\ntool_deny: []\n", encoding="utf-8")
+    assert _by(_findings(monkeypatch, tmp_path), severity="HIGH", contains="mcp-install")
+
+
 # ── OPT-A correctness: an outbound-only role is NOT a target → NOT flagged ───
 
 
@@ -145,9 +158,9 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
     )
     (_profiles(tmp_path) / "tight.yaml").write_text(
         "name: tight\ntool_deny: [delegate_to_agent, multi_agent__delegate, sandboxed_exec, "
-        "exec__sandboxed_exec, remember_shared, remember_agent, forget_memory, delete_file, "
-        "file__delete, memory_operation__remember_shared, memory_operation__remember_agent, "
-        "memory_operation__forget]\n",
+        "exec__sandboxed_exec, delete_file, file__delete, memory_operation__remember_shared, "
+        "memory_operation__remember_agent, memory_operation__forget, mcp__install_registry, "
+        "mcp__install_package, mcp__install_local]\n",
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")


### PR DESCRIPTION
**[e2e-coder]** — #2081 delegation-default-policy, **S3** — the FINAL piece. S1 (#2091) + S2 (#2092) merged; the policy is live. No-merge — close-review → **#2081 complete**.

## What

**`gateway:delegation-unsafe` audit (OPT-A, reachability-precise — your call):** `reyn audit` flags, per dangerous **class**, a delegate-**reachable** topology role — a member with an **inbound `can_send` edge** (= a delegation target; the A2A request path is `can_send`-gated) — whose bound `capability_profile`, or the `_delegate.yaml` override (the global floor), **re-grants** the class: **re-delegation/exec = HIGH, memory-write/destructive-FS = MED**. Plus an **INFO** posture nudge when `capability_default=inherit` while a topology permits delegation.

**Why reachability-precision** (the deciding property): HIGH gates `exit(1)`, so flagging a **non-target** (e.g. a pipeline head / outbound-only coordinator that legitimately holds `delegate_to_agent`) would be a **false deploy-block**. Built by **reuse** of the existing topology API (`can_send` + per-member profile binding) — no new machinery. `deny` is **not** flagged (it's the safe setting).

- `capability_profile.py`: `DELEGATION_AUDIT_CLASSES` (per-class severity taxonomy) + `profile_permits`.
- `audit.py`: `_gateway_delegation` rule (registered in `_collect`) + rule-4 docstring.
- `docs/concepts/runtime/capability-profile.md`: a `_delegate` section mirroring `_untrusted` (discovery parity; the reyn-yaml.md operator reference landed in S1).

## Two reconciliation notes (non-blocking — your call for a fast-follow)

The **audit taxonomy** (`DELEGATION_AUDIT_CLASSES`) is intentionally your confirmed dogfood-coder classes (re-deleg/exec/memory-write/destructive-FS), which differs slightly from the runtime `_delegate` **floor** (`_BUILTIN_UNTRUSTED_DENY`): the audit **adds destructive-FS** (`delete_file` — a delegate-reachable concern, though the floor doesn't deny it) and **does not separately flag mcp-install** (which IS in the floor; under `deny` it's denied anyway). Documented inline. If you want them aligned (either add `delete_file` to the floor, or audit mcp-install), that's a quick follow-up — flagging for awareness.

## Test plan

- [x] `tests/test_2081_s3_delegation_audit.py` (Tier 2): reachable re-grant→HIGH / memory-write→MED / **outbound-only head NOT flagged** (the OPT-A false-block guard) / pipeline tail target IS flagged / `_delegate.yaml` override re-grant / a denying delegate-reachable profile is clean / inherit+edge→INFO / deny+no-bindings clean.
- [x] `test_reyn_audit_1864` regression green
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8309 passed, 18 skipped, 3 xfailed**

## #2081 COMPLETE on merge

The config-selectable delegation default-deny: the policy field (S1) + the `is_delegate` signal + recursive `_delegate` floor (S2) + the reachability-precise audit + concept doc (S3). The docs-maintainer follow-up (broader delegation-policy concept doc, grounded in landed impl) is yours to dispatch.

Refs #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)