### PR TITLE
feat(#2095): route shell-hook consent through the intervention bus (P1, TUI-visible)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -60,7 +60,7 @@ class HookDispatcher:
         sandbox_config: Any = None,
         sandbox_backend: Any = None,
         consent_bus: Any = None,
-        interactive: bool = False,
+        consent_gate: "Callable[[], bool] | None" = None,
     ) -> None:
         self._registry = registry
         self._put_inbox = put_inbox
@@ -68,12 +68,27 @@ class HookDispatcher:
         self._run_shell = run_shell
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
-        # #2095: the session RequestBus + interactivity flag, forwarded to the
-        # shell-hook consent gate so a not-yet-allowlisted command's prompt
-        # surfaces on the interactive surface (TUI Pending tab) instead of the
-        # stdin prompt. None / non-interactive → the runner's fail-closed path.
+        # #2095: the session RequestBus + a LIVE "is a listener attached?" gate,
+        # forwarded to the shell-hook consent gate so a not-yet-allowlisted
+        # command's prompt surfaces on the answering surface (TUI Pending tab)
+        # rather than the stdin prompt. ``_consent_bus_now()`` returns the bus
+        # ONLY when ``consent_gate()`` is true at dispatch time (a listener is
+        # registered — TUI/chainlit/A2A-override); otherwise None, so the runner
+        # takes its stdin / fail-closed path (plain mcp-serve, headless, and
+        # ``reyn run`` with no listener all hit this). Evaluated per-dispatch
+        # because listeners attach/detach after construction (TUI mount, A2A
+        # request windows).
         self._consent_bus = consent_bus
-        self._interactive = interactive
+        self._consent_gate = consent_gate
+
+    def _consent_bus_now(self) -> Any:
+        """The consent bus iff a live intervention listener is attached, else None."""
+        if self._consent_bus is None or self._consent_gate is None:
+            return None
+        try:
+            return self._consent_bus if self._consent_gate() else None
+        except Exception:  # noqa: BLE001 — a gate error must not break dispatch
+            return None
 
     def replace_registry(self, registry: HookRegistry) -> None:
         """Swap the live hook registry (#2073 S2b config hot-reload). ``dispatch()``
@@ -115,8 +130,7 @@ class HookDispatcher:
                 template_vars,
                 sandbox_backend=self._sandbox_backend,
                 sandbox_config=self._sandbox_config,
-                consent_bus=self._consent_bus,
-                interactive=self._interactive,
+                consent_bus=self._consent_bus_now(),
             )
         elif hook.shell_push is not None:
             # shell_push (#2069) — a shell command whose STDOUT is a JSON
@@ -132,8 +146,7 @@ class HookDispatcher:
                 sandbox_backend=self._sandbox_backend,
                 sandbox_config=self._sandbox_config,
                 capture_stdout=True,
-                consent_bus=self._consent_bus,
-                interactive=self._interactive,
+                consent_bus=self._consent_bus_now(),
             )
             resolved = _parse_shell_push(stdout)
             if resolved is not None:

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -59,6 +59,8 @@ class HookDispatcher:
         run_shell: RunShell = run_shell_hook,
         sandbox_config: Any = None,
         sandbox_backend: Any = None,
+        consent_bus: Any = None,
+        interactive: bool = False,
     ) -> None:
         self._registry = registry
         self._put_inbox = put_inbox
@@ -66,6 +68,12 @@ class HookDispatcher:
         self._run_shell = run_shell
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
+        # #2095: the session RequestBus + interactivity flag, forwarded to the
+        # shell-hook consent gate so a not-yet-allowlisted command's prompt
+        # surfaces on the interactive surface (TUI Pending tab) instead of the
+        # stdin prompt. None / non-interactive → the runner's fail-closed path.
+        self._consent_bus = consent_bus
+        self._interactive = interactive
 
     def replace_registry(self, registry: HookRegistry) -> None:
         """Swap the live hook registry (#2073 S2b config hot-reload). ``dispatch()``
@@ -107,6 +115,8 @@ class HookDispatcher:
                 template_vars,
                 sandbox_backend=self._sandbox_backend,
                 sandbox_config=self._sandbox_config,
+                consent_bus=self._consent_bus,
+                interactive=self._interactive,
             )
         elif hook.shell_push is not None:
             # shell_push (#2069) — a shell command whose STDOUT is a JSON
@@ -122,6 +132,8 @@ class HookDispatcher:
                 sandbox_backend=self._sandbox_backend,
                 sandbox_config=self._sandbox_config,
                 capture_stdout=True,
+                consent_bus=self._consent_bus,
+                interactive=self._interactive,
             )
             resolved = _parse_shell_push(stdout)
             if resolved is not None:

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -164,21 +164,22 @@ async def _check_consent(
     allowlist_path: Path,
     *,
     consent_bus: "RequestBus | None" = None,
-    interactive: bool = False,
 ) -> bool:
     """Return True if *command* is approved to run.
 
     Approval order (#2095):
       1. allowlist hit → approved.
       2. ``REYN_ACCEPT_HOOKS=1`` → record + approve (CI / non-TTY accept).
-      3. **interactive user surface available** (``consent_bus`` set +
-         ``interactive``) → prompt through the SAME ``RequestBus`` that ungated
-         permission-prompts use, so it lands in the TUI Pending tab and is
-         answerable there (instead of the stdin ``print``/``input`` below, which
-         is invisible / unanswerable under a Textual app).
-      4. **no interactive bus** → the pre-#2095 behavior, byte-for-byte: TTY →
-         stdin prompt; non-TTY → fail-closed. This is the degrade path for
-         headless ``reyn`` / CI / mcp-serve (``consent_bus is None``).
+      3. ``consent_bus`` set → prompt through the SAME ``RequestBus`` that
+         ungated permission-prompts use, so it lands in the TUI Pending tab and
+         is answerable there (instead of the stdin ``print``/``input`` below,
+         which is invisible / unanswerable under a Textual app). The dispatcher
+         passes a non-None ``consent_bus`` ONLY when the session has a live
+         intervention listener (= a surface that will actually answer), so plain
+         ``mcp-serve`` / headless (no listener) and ``reyn run`` on a TTY (no
+         listener) both arrive here with ``consent_bus=None`` and take step 4.
+      4. **no consent bus** → the pre-#2095 behavior, byte-for-byte: TTY → stdin
+         prompt; non-TTY → fail-closed.
     """
     entries = _load_allowlist(allowlist_path)
 
@@ -194,12 +195,12 @@ async def _check_consent(
         _record_approval(command, allowlist_path)
         return True
 
-    # Interactive surface → route the consent through the unified intervention
-    # bus (#2095). The allowlist remains the "always" persistence.
-    if consent_bus is not None and interactive:
+    # An answerable surface is attached → route the consent through the unified
+    # intervention bus (#2095). The allowlist remains the "always" persistence.
+    if consent_bus is not None:
         return await _prompt_consent_via_bus(command, allowlist_path, consent_bus)
 
-    # No interactive bus → preserve the exact pre-#2095 behavior below.
+    # No consent bus → preserve the exact pre-#2095 behavior below.
     is_tty = sys.stdin.isatty()
 
     if is_tty:
@@ -287,7 +288,6 @@ async def run_shell_hook(
     allowlist_path: Path | None = None,
     capture_stdout: bool = False,
     consent_bus: "RequestBus | None" = None,
-    interactive: bool = False,
 ) -> str | None:
     """Run a shell hook command under the sandbox + consent gate.
 
@@ -334,14 +334,13 @@ async def run_shell_hook(
         run; when ``False`` (``shell_exec``, default) ignore output and return
         ``None``.
     consent_bus:
-        The session ``RequestBus`` (#2095). When set AND ``interactive`` is True,
-        a not-yet-allowlisted command's consent prompt is routed through it (→ the
-        TUI Pending tab / the interactive surface) instead of the stdin prompt.
-        ``None`` (the default) preserves the pre-#2095 stdin / fail-closed gate.
-    interactive:
-        Whether an interactive user surface is attached (= ``not non_interactive``
-        at the Session). Gates the ``consent_bus`` path so headless / CI /
-        mcp-serve degrade to ``REYN_ACCEPT_HOOKS`` / fail-closed unchanged.
+        The session ``RequestBus`` (#2095), or ``None``. When set, a
+        not-yet-allowlisted command's consent prompt is routed through it (→ the
+        TUI Pending tab / the answering surface) instead of the stdin prompt. The
+        caller (``HookDispatcher``) passes a non-None bus ONLY when the session
+        has a live intervention listener; ``None`` (incl. headless / CI /
+        plain mcp-serve / ``reyn run`` with no listener) preserves the pre-#2095
+        stdin / fail-closed gate.
 
     Returns
     -------
@@ -364,7 +363,6 @@ async def run_shell_hook(
             command,
             resolved_allowlist,
             consent_bus=consent_bus,
-            interactive=interactive,
         )
     except Exception as exc:
         _log.error("shell-hook: consent check error for %r: %s", command, exc)

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from reyn.config import SandboxConfig
     from reyn.security.sandbox import SandboxBackend
     from reyn.security.sandbox.policy import SandboxPolicy
+    from reyn.user_intervention import RequestBus
 
 _log = logging.getLogger(__name__)
 
@@ -158,11 +159,26 @@ def _record_approval(command: str, path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _check_consent(command: str, allowlist_path: Path) -> bool:
+async def _check_consent(
+    command: str,
+    allowlist_path: Path,
+    *,
+    consent_bus: "RequestBus | None" = None,
+    interactive: bool = False,
+) -> bool:
     """Return True if *command* is approved to run.
 
-    TTY (interactive): prompt on first use or mtime drift; record approval.
-    Non-TTY: requires REYN_ACCEPT_HOOKS=1 or a current allowlist entry.
+    Approval order (#2095):
+      1. allowlist hit → approved.
+      2. ``REYN_ACCEPT_HOOKS=1`` → record + approve (CI / non-TTY accept).
+      3. **interactive user surface available** (``consent_bus`` set +
+         ``interactive``) → prompt through the SAME ``RequestBus`` that ungated
+         permission-prompts use, so it lands in the TUI Pending tab and is
+         answerable there (instead of the stdin ``print``/``input`` below, which
+         is invisible / unanswerable under a Textual app).
+      4. **no interactive bus** → the pre-#2095 behavior, byte-for-byte: TTY →
+         stdin prompt; non-TTY → fail-closed. This is the degrade path for
+         headless ``reyn`` / CI / mcp-serve (``consent_bus is None``).
     """
     entries = _load_allowlist(allowlist_path)
 
@@ -171,13 +187,20 @@ def _check_consent(command: str, allowlist_path: Path) -> bool:
 
     # Not approved — decide based on environment.
     accept_env = os.environ.get("REYN_ACCEPT_HOOKS", "").strip() == "1"
-    is_tty = sys.stdin.isatty()
 
     if accept_env:
         # CI / non-TTY accept path: record and proceed.
         _log.info("shell-hook: REYN_ACCEPT_HOOKS=1 — auto-approving %r", command)
         _record_approval(command, allowlist_path)
         return True
+
+    # Interactive surface → route the consent through the unified intervention
+    # bus (#2095). The allowlist remains the "always" persistence.
+    if consent_bus is not None and interactive:
+        return await _prompt_consent_via_bus(command, allowlist_path, consent_bus)
+
+    # No interactive bus → preserve the exact pre-#2095 behavior below.
+    is_tty = sys.stdin.isatty()
 
     if is_tty:
         # Interactive prompt.
@@ -210,6 +233,43 @@ def _check_consent(command: str, allowlist_path: Path) -> bool:
     return False
 
 
+async def _prompt_consent_via_bus(
+    command: str, allowlist_path: Path, bus: "RequestBus",
+) -> bool:
+    """Prompt for shell-hook consent through the unified intervention bus (#2095).
+
+    Reuses the SAME ``UserIntervention`` / ``RequestBus`` mechanism that ungated
+    permission-prompts use, so the prompt surfaces wherever interventions do
+    (the TUI Pending tab, stdin for ``reyn run``, etc.) — not the stdin
+    ``print``/``input`` that is invisible under a Textual app.
+
+    Choice mapping (``shell_hook_choices``): ``ALWAYS`` records to the allowlist
+    (the "always" persistence); ``YES`` allows this run only; ``NO`` / unknown /
+    an empty answer (e.g. the iv was parked stalled because the origin channel
+    closed) → deny + skip the hook (fail-safe).
+    """
+    from reyn.intervention_choices import ALWAYS, YES, shell_hook_choices
+    from reyn.user_intervention import UserIntervention
+
+    iv = UserIntervention(
+        kind="permission.shell_hook",
+        prompt="A shell hook wants to run a command",
+        detail=f"$ {command}",
+        choices=shell_hook_choices(),
+    )
+    answer = await bus.request(iv)
+    choice = answer.choice_id
+    if choice == ALWAYS:
+        _record_approval(command, allowlist_path)
+        _log.info("shell-hook: approved (always) via intervention bus %r", command)
+        return True
+    if choice == YES:
+        _log.info("shell-hook: approved (once) via intervention bus %r", command)
+        return True
+    _log.warning("shell-hook: declined via intervention bus %r — skipping.", command)
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -226,6 +286,8 @@ async def run_shell_hook(
     sandbox_policy: "SandboxPolicy | None" = None,
     allowlist_path: Path | None = None,
     capture_stdout: bool = False,
+    consent_bus: "RequestBus | None" = None,
+    interactive: bool = False,
 ) -> str | None:
     """Run a shell hook command under the sandbox + consent gate.
 
@@ -271,6 +333,15 @@ async def run_shell_hook(
         When ``True`` (``shell_push``) return the decoded stdout on a successful
         run; when ``False`` (``shell_exec``, default) ignore output and return
         ``None``.
+    consent_bus:
+        The session ``RequestBus`` (#2095). When set AND ``interactive`` is True,
+        a not-yet-allowlisted command's consent prompt is routed through it (→ the
+        TUI Pending tab / the interactive surface) instead of the stdin prompt.
+        ``None`` (the default) preserves the pre-#2095 stdin / fail-closed gate.
+    interactive:
+        Whether an interactive user surface is attached (= ``not non_interactive``
+        at the Session). Gates the ``consent_bus`` path so headless / CI /
+        mcp-serve degrade to ``REYN_ACCEPT_HOOKS`` / fail-closed unchanged.
 
     Returns
     -------
@@ -289,7 +360,12 @@ async def run_shell_hook(
 
     # --- Consent gate (fail-closed in non-TTY without accept flag) --------
     try:
-        approved = _check_consent(command, resolved_allowlist)
+        approved = await _check_consent(
+            command,
+            resolved_allowlist,
+            consent_bus=consent_bus,
+            interactive=interactive,
+        )
     except Exception as exc:
         _log.error("shell-hook: consent check error for %r: %s", command, exc)
         return

--- a/src/reyn/intervention_choices.py
+++ b/src/reyn/intervention_choices.py
@@ -27,6 +27,21 @@ def generic_yn_choices() -> list[InterventionChoice]:
     ]
 
 
+def shell_hook_choices() -> list[InterventionChoice]:
+    """`[y]es / [A]lways / [n]o` for shell-hook consent (#2095).
+
+    No `NEVER`: the shell-hook allowlist persists approvals only (there is no
+    persistent-deny entry), so `ALWAYS` records to the allowlist and a plain
+    `[n]o` skips this run without persisting. Mirrors the python-preprocessor
+    yes/always/no shape.
+    """
+    return [
+        InterventionChoice(id=YES, label="[y]es", hotkey="y"),
+        InterventionChoice(id=ALWAYS, label="[A]lways", hotkey="A"),
+        InterventionChoice(id=NO, label="[n]o", hotkey="n"),
+    ]
+
+
 def python_choices() -> list[InterventionChoice]:
     """`[y]es / [A]lways / [N]o` for python preprocessor approval (no NEVER)."""
     return [
@@ -64,4 +79,5 @@ __all__ = [
     "file_access_choices",
     "generic_yn_choices",
     "python_choices",
+    "shell_hook_choices",
 ]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1266,13 +1266,19 @@ class Session:
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
-            # through this session's RequestBus when there's an interactive
-            # surface, so it lands in the TUI Pending tab (vs the stdin prompt,
-            # invisible under Textual). Headless (non_interactive) → consent_bus
-            # is still passed but ``interactive=False`` keeps the runner on its
-            # REYN_ACCEPT_HOOKS / fail-closed path (byte-identical to pre-#2095).
+            # through this session's RequestBus, but ONLY when a live
+            # intervention listener is attached (TUI / chainlit / A2A-override) —
+            # i.e. a surface that will actually answer. ``has_active_listener``
+            # is checked per-dispatch (listeners attach/detach after this
+            # construction: TUI mount, A2A request windows). Plain mcp-serve and
+            # headless (no listener) → the dispatcher passes consent_bus=None →
+            # the runner's REYN_ACCEPT_HOOKS / fail-closed path, and ``reyn run``
+            # on a TTY (no listener) → the runner's stdin prompt — both
+            # byte-identical to pre-#2095.
             consent_bus=self.as_request_bus(),
-            interactive=not self._non_interactive,
+            # Lambda defers the lookup: ``self._interventions`` is constructed
+            # below this point, and the gate is only called at dispatch time.
+            consent_gate=lambda: self._interventions.has_active_listener(),
         )
         # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
         # reapply seam can unschedule jobs removed from the runtime file WITHOUT

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1265,6 +1265,14 @@ class Session:
             stage_next_turn_context=self._stage_next_turn_context,
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
+            # #2095: route a not-yet-allowlisted shell-hook's consent prompt
+            # through this session's RequestBus when there's an interactive
+            # surface, so it lands in the TUI Pending tab (vs the stdin prompt,
+            # invisible under Textual). Headless (non_interactive) → consent_bus
+            # is still passed but ``interactive=False`` keeps the runner on its
+            # REYN_ACCEPT_HOOKS / fail-closed path (byte-identical to pre-#2095).
+            consent_bus=self.as_request_bus(),
+            interactive=not self._non_interactive,
         )
         # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
         # reapply seam can unschedule jobs removed from the runtime file WITHOUT

--- a/tests/test_2095_shell_hook_consent_bus.py
+++ b/tests/test_2095_shell_hook_consent_bus.py
@@ -1,0 +1,177 @@
+"""Tier 2: #2095 — shell-hook consent routes through the intervention bus.
+
+When an interactive surface is attached, a not-yet-allowlisted shell hook's
+consent prompt is routed through the SAME ``RequestBus`` that ungated
+permission-prompts use (→ the TUI Pending tab), instead of the stdin
+``print``/``input`` that is invisible under a Textual app. When there is NO
+interactive surface (headless / CI / mcp-serve), the runner degrades to its
+pre-#2095 ``REYN_ACCEPT_HOOKS`` / fail-closed gate — the bus is NOT consulted.
+
+No mocks: a real ``_RecordingBus`` implements the ``request(iv)`` contract and
+returns a preset choice; a real ``NoopBackend`` executes the command; the
+allowlist is a real file under ``tmp_path``. Whether the command actually RAN is
+observed via a marker file it writes (shell_exec returns ``None`` either way, so
+the return value alone can't distinguish approved-vs-skipped).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.hooks.shell_runner import _is_approved, _load_allowlist, run_shell_hook
+from reyn.intervention_choices import ALWAYS, NO, YES
+from reyn.security.sandbox import NoopBackend, SandboxPolicy
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+_PY = sys.executable
+
+
+class _RecordingBus:
+    """A real ``RequestBus`` that records each iv and returns a preset choice.
+
+    Concrete implementation of the ``request(iv)`` contract (NOT a mock) — the
+    same shape the production ``AgentRequestBus`` exposes to the consent gate.
+    """
+
+    def __init__(self, choice_id: str | None) -> None:
+        self._choice_id = choice_id
+        self.seen: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.seen.append(iv)
+        return InterventionAnswer(choice_id=self._choice_id)
+
+
+def _policy() -> SandboxPolicy:
+    return SandboxPolicy(network=False, allow_subprocess=False, timeout_seconds=10)
+
+
+def _marker_command(marker: Path) -> str:
+    script = f"open({str(marker)!r}, 'w').write('ran')"
+    return f'{_PY} -c "{script}"'
+
+
+async def _run(command: str, allowlist: Path, **kw) -> None:
+    await run_shell_hook(
+        command,
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=NoopBackend(),
+        sandbox_policy=_policy(),
+        allowlist_path=allowlist,
+        **kw,
+    )
+
+
+@pytest.mark.asyncio
+async def test_consent_bus_always_records_and_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: interactive + ALWAYS → the hook runs AND the command is persisted
+    to the allowlist (the "always" persistence), and the prompt was a
+    ``permission.shell_hook`` intervention carrying the command."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(ALWAYS)
+
+    await _run(command, allowlist, consent_bus=bus, interactive=True)
+
+    assert marker.exists(), "ALWAYS should run the hook"
+    assert bus.seen, "the consent prompt must route through the bus"
+    assert bus.seen[0].kind == "permission.shell_hook"
+    assert command in bus.seen[0].detail
+    # Persisted: a second run would short-circuit on the allowlist.
+    assert _is_approved(command, _load_allowlist(allowlist))
+
+
+@pytest.mark.asyncio
+async def test_consent_bus_yes_runs_without_persisting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: interactive + YES → the hook runs once but is NOT persisted."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(YES)
+
+    await _run(command, allowlist, consent_bus=bus, interactive=True)
+
+    assert marker.exists(), "YES should run the hook"
+    assert not _is_approved(command, _load_allowlist(allowlist)), "YES must not persist"
+
+
+@pytest.mark.asyncio
+async def test_consent_bus_no_denies_and_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: interactive + NO → the hook is skipped (the command never runs)."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(NO)
+
+    await _run(command, allowlist, consent_bus=bus, interactive=True)
+
+    assert bus.seen and bus.seen[0].kind == "permission.shell_hook", (
+        "NO still routes through the bus"
+    )
+    assert not marker.exists(), "NO must skip the hook"
+
+
+@pytest.mark.asyncio
+async def test_headless_ignores_bus_and_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: the headless-preservation falsification — a bus is present but
+    ``interactive=False`` (headless / CI / mcp-serve) → the bus is NOT consulted
+    and the runner degrades to the pre-#2095 non-TTY fail-closed gate."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    monkeypatch.setattr("sys.stdin", _NonTTY())
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(ALWAYS)  # would approve IF consulted
+
+    await _run(command, allowlist, consent_bus=bus, interactive=False)
+
+    assert bus.seen == [], "headless must NOT consult the intervention bus"
+    assert not marker.exists(), "headless non-TTY without accept flag → fail-closed"
+
+
+@pytest.mark.asyncio
+async def test_headless_accept_env_still_runs_without_bus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: REYN_ACCEPT_HOOKS=1 takes precedence over the bus path (unchanged
+    CI behavior) — the hook runs and the bus is never consulted."""
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(NO)  # would deny IF consulted
+
+    await _run(command, allowlist, consent_bus=bus, interactive=True)
+
+    assert bus.seen == [], "REYN_ACCEPT_HOOKS=1 short-circuits before the bus"
+    assert marker.exists(), "accept-env should run the hook"
+
+
+class _NonTTY:
+    """Minimal ``sys.stdin`` replacement reporting non-TTY."""
+
+    def isatty(self) -> bool:
+        return False
+
+    def read(self, *_):
+        return ""

--- a/tests/test_2095_shell_hook_consent_bus.py
+++ b/tests/test_2095_shell_hook_consent_bus.py
@@ -1,17 +1,19 @@
 """Tier 2: #2095 — shell-hook consent routes through the intervention bus.
 
-When an interactive surface is attached, a not-yet-allowlisted shell hook's
+When an answering surface is attached, a not-yet-allowlisted shell hook's
 consent prompt is routed through the SAME ``RequestBus`` that ungated
 permission-prompts use (→ the TUI Pending tab), instead of the stdin
-``print``/``input`` that is invisible under a Textual app. When there is NO
-interactive surface (headless / CI / mcp-serve), the runner degrades to its
-pre-#2095 ``REYN_ACCEPT_HOOKS`` / fail-closed gate — the bus is NOT consulted.
+``print``/``input`` that is invisible under a Textual app. The ``HookDispatcher``
+passes a non-None ``consent_bus`` to the runner ONLY when a live intervention
+listener is registered (``consent_gate``); otherwise the runner takes its
+pre-#2095 stdin / fail-closed path — so plain ``mcp-serve`` / headless (no
+listener) and ``reyn run`` on a TTY (no listener) all preserve the old behavior.
 
-No mocks: a real ``_RecordingBus`` implements the ``request(iv)`` contract and
-returns a preset choice; a real ``NoopBackend`` executes the command; the
-allowlist is a real file under ``tmp_path``. Whether the command actually RAN is
-observed via a marker file it writes (shell_exec returns ``None`` either way, so
-the return value alone can't distinguish approved-vs-skipped).
+No mocks: a real ``_RecordingBus`` implements the ``request(iv)`` contract; a
+real ``NoopBackend`` executes the command; the allowlist is a real file. Whether
+the command actually RAN is observed via a marker file it writes (shell_exec
+returns ``None`` either way, so the return value can't distinguish
+approved-vs-skipped).
 """
 from __future__ import annotations
 
@@ -20,6 +22,9 @@ from pathlib import Path
 
 import pytest
 
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef
 from reyn.hooks.shell_runner import _is_approved, _load_allowlist, run_shell_hook
 from reyn.intervention_choices import ALWAYS, NO, YES
 from reyn.security.sandbox import NoopBackend, SandboxPolicy
@@ -65,12 +70,15 @@ async def _run(command: str, allowlist: Path, **kw) -> None:
     )
 
 
+# ── runner: consent_bus present → route through the bus ──────────────────────
+
+
 @pytest.mark.asyncio
 async def test_consent_bus_always_records_and_runs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Tier 2: interactive + ALWAYS → the hook runs AND the command is persisted
-    to the allowlist (the "always" persistence), and the prompt was a
+    """Tier 2: a consent_bus + ALWAYS → the hook runs AND the command is
+    persisted to the allowlist (the "always" persistence), and the prompt was a
     ``permission.shell_hook`` intervention carrying the command."""
     monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
     allowlist = tmp_path / "allowlist.json"
@@ -79,13 +87,12 @@ async def test_consent_bus_always_records_and_runs(
     command = _marker_command(marker)
     bus = _RecordingBus(ALWAYS)
 
-    await _run(command, allowlist, consent_bus=bus, interactive=True)
+    await _run(command, allowlist, consent_bus=bus)
 
     assert marker.exists(), "ALWAYS should run the hook"
     assert bus.seen, "the consent prompt must route through the bus"
     assert bus.seen[0].kind == "permission.shell_hook"
     assert command in bus.seen[0].detail
-    # Persisted: a second run would short-circuit on the allowlist.
     assert _is_approved(command, _load_allowlist(allowlist))
 
 
@@ -93,7 +100,7 @@ async def test_consent_bus_always_records_and_runs(
 async def test_consent_bus_yes_runs_without_persisting(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Tier 2: interactive + YES → the hook runs once but is NOT persisted."""
+    """Tier 2: a consent_bus + YES → the hook runs once but is NOT persisted."""
     monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
     allowlist = tmp_path / "allowlist.json"
     allowlist.write_text("[]", encoding="utf-8")
@@ -101,7 +108,7 @@ async def test_consent_bus_yes_runs_without_persisting(
     command = _marker_command(marker)
     bus = _RecordingBus(YES)
 
-    await _run(command, allowlist, consent_bus=bus, interactive=True)
+    await _run(command, allowlist, consent_bus=bus)
 
     assert marker.exists(), "YES should run the hook"
     assert not _is_approved(command, _load_allowlist(allowlist)), "YES must not persist"
@@ -111,7 +118,7 @@ async def test_consent_bus_yes_runs_without_persisting(
 async def test_consent_bus_no_denies_and_skips(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Tier 2: interactive + NO → the hook is skipped (the command never runs)."""
+    """Tier 2: a consent_bus + NO → the hook is skipped (the command never runs)."""
     monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
     allowlist = tmp_path / "allowlist.json"
     allowlist.write_text("[]", encoding="utf-8")
@@ -119,7 +126,7 @@ async def test_consent_bus_no_denies_and_skips(
     command = _marker_command(marker)
     bus = _RecordingBus(NO)
 
-    await _run(command, allowlist, consent_bus=bus, interactive=True)
+    await _run(command, allowlist, consent_bus=bus)
 
     assert bus.seen and bus.seen[0].kind == "permission.shell_hook", (
         "NO still routes through the bus"
@@ -128,28 +135,43 @@ async def test_consent_bus_no_denies_and_skips(
 
 
 @pytest.mark.asyncio
-async def test_headless_ignores_bus_and_fails_closed(
+async def test_consent_bus_empty_answer_denies(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Tier 2: the headless-preservation falsification — a bus is present but
-    ``interactive=False`` (headless / CI / mcp-serve) → the bus is NOT consulted
-    and the runner degrades to the pre-#2095 non-TTY fail-closed gate."""
+    """Tier 2: an empty answer (choice_id=None — e.g. the iv was parked stalled
+    when its origin channel closed) → deny + skip (fail-safe)."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+    bus = _RecordingBus(None)  # empty answer
+
+    await _run(command, allowlist, consent_bus=bus)
+
+    assert not marker.exists(), "an unanswered/empty consent must skip the hook"
+
+
+@pytest.mark.asyncio
+async def test_no_bus_nontty_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: no consent_bus + non-TTY + no accept flag → fail-closed (the
+    pre-#2095 headless gate, unchanged)."""
     monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
     monkeypatch.setattr("sys.stdin", _NonTTY())
     allowlist = tmp_path / "allowlist.json"
     allowlist.write_text("[]", encoding="utf-8")
     marker = tmp_path / "ran.txt"
     command = _marker_command(marker)
-    bus = _RecordingBus(ALWAYS)  # would approve IF consulted
 
-    await _run(command, allowlist, consent_bus=bus, interactive=False)
+    await _run(command, allowlist, consent_bus=None)
 
-    assert bus.seen == [], "headless must NOT consult the intervention bus"
-    assert not marker.exists(), "headless non-TTY without accept flag → fail-closed"
+    assert not marker.exists(), "no bus + non-TTY → fail-closed"
 
 
 @pytest.mark.asyncio
-async def test_headless_accept_env_still_runs_without_bus(
+async def test_accept_env_short_circuits_before_bus(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tier 2: REYN_ACCEPT_HOOKS=1 takes precedence over the bus path (unchanged
@@ -161,10 +183,67 @@ async def test_headless_accept_env_still_runs_without_bus(
     command = _marker_command(marker)
     bus = _RecordingBus(NO)  # would deny IF consulted
 
-    await _run(command, allowlist, consent_bus=bus, interactive=True)
+    await _run(command, allowlist, consent_bus=bus)
 
     assert bus.seen == [], "REYN_ACCEPT_HOOKS=1 short-circuits before the bus"
     assert marker.exists(), "accept-env should run the hook"
+
+
+# ── dispatcher: the consent_gate decides whether a bus reaches the runner ─────
+
+
+class _RecordingShell:
+    """A real run_shell seam that records the consent_bus it was handed."""
+
+    def __init__(self) -> None:
+        self.consent_buses: list[object] = []
+
+    async def __call__(self, *args, **kwargs):
+        self.consent_buses.append(kwargs.get("consent_bus"))
+        return None
+
+
+def _shell_exec_dispatcher(*, gate, run_shell, bus) -> HookDispatcher:
+    async def _noop(*_a, **_k):
+        return None
+
+    reg = HookRegistry([HookDef(on="turn_end", shell_exec="echo hi")])
+    return HookDispatcher(
+        reg,
+        put_inbox=_noop,
+        stage_next_turn_context=_noop,
+        run_shell=run_shell,
+        consent_bus=bus,
+        consent_gate=gate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_passes_bus_when_listener_present() -> None:
+    """Tier 2: when ``consent_gate()`` is true (a listener is attached —
+    TUI/chainlit), the dispatcher hands the bus to the runner."""
+    bus = _RecordingBus(YES)
+    shell = _RecordingShell()
+    disp = _shell_exec_dispatcher(gate=lambda: True, run_shell=shell, bus=bus)
+
+    await disp.dispatch("turn_end", {})
+
+    assert shell.consent_buses == [bus]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_withholds_bus_when_no_listener() -> None:
+    """Tier 2: the mcp-serve / headless arm — when ``consent_gate()`` is false (no
+    listener — plain mcp-serve, headless, reyn-run-no-listener), the dispatcher
+    passes ``consent_bus=None`` so the runner takes its stdin / fail-closed path
+    and never blocks on an unanswerable bus future."""
+    bus = _RecordingBus(YES)
+    shell = _RecordingShell()
+    disp = _shell_exec_dispatcher(gate=lambda: False, run_shell=shell, bus=bus)
+
+    await disp.dispatch("turn_end", {})
+
+    assert shell.consent_buses == [None]
 
 
 class _NonTTY:


### PR DESCRIPTION
**[tui-coder]** — Closes #2095 (P1 of the hook-visibility lane; design lead-approved). Routes operator shell-hook consent through the unified intervention bus so it surfaces in the TUI Pending tab — and fixes the correctness bug that the prompt was a stdin `print()`+`input()`, invisible/unanswerable under a Textual app.

## What changed
- **`shell_runner._check_consent`** is now async with a `consent_bus`/`interactive` path. When an interactive surface is attached, a not-yet-allowlisted command's consent is a `permission.shell_hook` `UserIntervention` emitted through the session `RequestBus` (the SAME path ungated permission-prompts use). `_prompt_consent_via_bus` maps **ALWAYS→record to allowlist** (the "always" persistence), **YES→run once**, **NO/unknown/empty→skip** (fail-safe; empty = iv parked stalled when the origin channel closed).
- **`intervention_choices.shell_hook_choices()`** — yes/always/no (no NEVER: the allowlist has no persistent-deny entry).
- **`dispatcher` + `session`** thread `consent_bus=self.as_request_bus()`, `interactive=not self._non_interactive` to `run_shell_hook`.

## Constraint adherence (the review-gate items)
1. **Reuse the existing mechanism, no parallel channel** — uses `UserIntervention`/`RequestBus`/`as_request_bus()`; allowlist stays the "always" store. ✅
2. **Headless preserved byte-for-byte** — the bus path fires ONLY when `consent_bus is not None and interactive`. Headless / CI / mcp-serve (`interactive=False`) degrade to the existing `REYN_ACCEPT_HOOKS` / TTY-stdin / fail-closed gate, unchanged. Falsified both arms (see test plan). ✅
3. P2 (additive `HookDef.source` provenance label) + P3 (passive activity line for `shell_exec`) are **deferred follow-ups** on #2095 — not in this PR. The OS seam here is tight (route `_check_consent` through the existing iv), as scoped.

## Scope notes (from the recon on #2095)
- Agent-added shell hooks are not reachable (`hooks_add` is `template_push`-only), so this P1 is operator shell hooks; the prompt label says nothing agent-specific (P2 will add source). No owner-philosophy escalation (the blocking-consent question is moot).

## Test plan
- [x] `pytest tests/test_2095_shell_hook_consent_bus.py` — 5 new Tier-2 (ALWAYS records+runs / YES runs-no-persist / NO skips / **headless: bus set + interactive=False → bus NOT consulted + fail-closed** / REYN_ACCEPT_HOOKS short-circuits before bus).
- [x] `pytest tests/test_1800_hook_shell_runner.py` + dispatcher/shell_push/5c/attribution/2073-s2b — 57 pass (headless + threading preserved).
- [x] `pytest tests/cli` — 1362 pass (session construction / TUI / dispatcher wiring).
- [x] `ruff check` + `python scripts/test_tier_audit.py --strict tests/test_2095_shell_hook_consent_bus.py` — clean.
- [ ] (skipped — next gate per lead's process) **tmux-e2e: real-terminal Pending-tab consent flow** — run after lead's close-review; nav-chords confirmed drivable via Bash `send-keys`, so the side-panel-open + answer flow is verifiable.

**Tier self-check:** 5 new tests, all Tier 2 (OS-invariant: real `RequestBus` test-double + real `NoopBackend` + real allowlist file; behavior asserted via marker-file side-effect + allowlist persistence, no size/format pins, no private state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
