### PR TITLE
refactor(#2093): SessionFactoryConfig bundle — completeness-by-construction for the 5 factory sites

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -142,6 +142,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
         from reyn.core.events.state_log import StateLog
         from reyn.interfaces.cli.invocation_context import InvocationContext
         from reyn.runtime.budget.budget import BudgetTracker
+        from reyn.runtime.factory_config import SessionFactoryConfig
         from reyn.runtime.profile import AgentProfile
         from reyn.runtime.registry import AgentRegistry
         from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -214,14 +215,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 events_config=session_cfg.config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,
-                sandbox_config=session_cfg.config.sandbox,
-                multimodal_config=session_cfg.config.multimodal,
-                tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
-                action_retrieval_config=session_cfg.config.action_retrieval,
-                chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
-                embedding_config=session_cfg.config.embedding,
-                router_config=session_cfg.config.llm.router,  # #1829 S3b
-                retry_config=session_cfg.config.llm.retry,  # #1835
+                # #2093: the uniform reyn.yaml-derived per-session config bundle.
+                factory_config=SessionFactoryConfig.from_config(session_cfg.config),
                 agent_id=session_cfg.config.agent.id,
                 # #1402: scoped surface passed EXPLICITLY (required by
                 # build_scoped_chat_session). chainlit's current behaviour
@@ -245,9 +240,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
             project_root=project_root,
             session_factory=_session_factory,
             state_log=state_log,
-            delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
-            workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
-            act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
+            # #2093: the uniform reyn.yaml-derived registry config bundle.
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
         )
         registry_ref.append(registry)
         _REGISTRY = registry

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -330,6 +330,7 @@ def run(args: argparse.Namespace) -> None:
     from reyn.core.events.state_log import StateLog
     from reyn.interfaces.repl.repl import run_repl
     from reyn.runtime.budget.budget import BudgetTracker
+    from reyn.runtime.factory_config import SessionFactoryConfig
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -455,15 +456,11 @@ def run(args: argparse.Namespace) -> None:
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,
-            sandbox_config=session_cfg.config.sandbox,
-            hooks_config=session_cfg.config.hooks,  # #1800 slice 5b
-            multimodal_config=session_cfg.config.multimodal,
-            tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
-            action_retrieval_config=session_cfg.config.action_retrieval,
-            chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
-            embedding_config=session_cfg.config.embedding,
-            router_config=session_cfg.config.llm.router,  # #1829 S3b
-            retry_config=session_cfg.config.llm.retry,  # #1835
+            hooks_config=session_cfg.config.hooks,  # #1800 slice 5b (pass-through, not bundled)
+            # #2093: the uniform reyn.yaml-derived per-session config bundle (sandbox /
+            # multimodal / action_retrieval / embedding / router / retry /
+            # op-loop-skills / tool-use-scheme) — one source point for all five sites.
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
@@ -508,11 +505,11 @@ def run(args: argparse.Namespace) -> None:
         project_root=project_root,
         session_factory=_session_factory,
         state_log=state_log,
-        delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
+        # #2093: the uniform reyn.yaml-derived registry config bundle (workspace_capture
+        # / act_turn_capture / delegation_capability_default) — one source point.
+        factory_config=SessionFactoryConfig.from_config(session_cfg.config),
         environment_backend=env_backend,   # #1544: container shadow-git runs via this
         workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
-        workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
-        act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
     )
 
     name = args.agent_name or DEFAULT_AGENT_NAME

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -400,6 +400,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     """
     import asyncio
     import shutil
+    from dataclasses import replace
     from pathlib import Path
 
     from reyn.config import _find_project_root, load_config, load_project_context
@@ -408,6 +409,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     from reyn.llm.model_resolver import ModelResolver
     from reyn.mcp.server import send_to_agent_impl
     from reyn.runtime.budget.budget import BudgetTracker
+    from reyn.runtime.factory_config import SessionFactoryConfig
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -472,12 +474,15 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 events_config=config.events,
                 state_log=None,  # no WAL for dogfood dispatch
                 budget_tracker=budget_tracker,
-                sandbox_config=config.sandbox,
-                hooks_config=config.hooks,  # #1800 slice 5b
-                multimodal_config=config.multimodal,
-                tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
-                action_retrieval_config=config.action_retrieval,
-                chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
+                hooks_config=config.hooks,  # #1800 slice 5b (pass-through, not bundled)
+                # #2093: the uniform per-session config bundle. dogfood deliberately
+                # keeps embedding_config=None (the documented gap — it had
+                # action_retrieval but not its sibling embedding), preserved via
+                # replace() as an EXPLICIT, visible deviation (not a silent miss) →
+                # behavior byte-identical to before the bundle.
+                factory_config=replace(
+                    SessionFactoryConfig.from_config(config), embedding_config=None,
+                ),
                 # #1289: same backend instance to both seams (single-shared-sandbox).
                 environment_backend=env_backend,
                 sandbox_backend=env_backend,
@@ -488,9 +493,6 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # fixes the #187 wrong-FS class (file ops were rooting on host
                 # cwd while env_backend pointed at the container). chat.py uses
                 # the same ws_base_dir/ws_state_dir pattern.
-                embedding_config=None,  # gap: dogfood omitted embedding_config (had action_retrieval but not its sibling) → preserved as None
-                router_config=config.llm.router,  # #1829 S3b
-                retry_config=config.llm.retry,  # #1835
                 eager_embedding_build=False,
                 agent_id=None,
                 exclude_tools=None,
@@ -508,11 +510,10 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             project_root=project_root,
             session_factory=_session_factory,
             state_log=None,
-            delegation_capability_default=config.delegation.capability_default,  # #2081
+            # #2093: the uniform reyn.yaml-derived registry config bundle.
+            factory_config=SessionFactoryConfig.from_config(config),
             environment_backend=env_backend,   # #1544: container shadow-git
             workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
-            workspace_capture=config.time_travel.workspace_capture,  # #1582 opt-out
-            act_turn_capture=config.time_travel.act_turn_capture,  # #1560 opt-in
         )
         _reg_cell.append(reg)
         return reg

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -325,6 +325,7 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.server import serve_stdio
     from reyn.runtime.budget.budget import BudgetTracker
+    from reyn.runtime.factory_config import SessionFactoryConfig
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -421,18 +422,10 @@ def run_serve(args: argparse.Namespace) -> None:
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,
-            # Same fix as web/deps.py: A2A / MCP-serve Session factory
-            # was missing ``sandbox_config`` propagation. Without it, the
-            # operator's reyn.yaml ``sandbox.backend`` selection (e.g.
-            # ``noop``) never reaches the sandboxed_exec handler.
-            sandbox_config=session_cfg.config.sandbox,
-            multimodal_config=session_cfg.config.multimodal,
-            tool_calls_op_loop_skills=session_cfg.config.tool_calls_op_loop_skills,
-            action_retrieval_config=session_cfg.config.action_retrieval,
-            chat_tool_use_scheme=session_cfg.config.tool_use.chat,  # #1593 PR-2
-            embedding_config=session_cfg.config.embedding,
-            router_config=session_cfg.config.llm.router,  # #1829 S3b
-            retry_config=session_cfg.config.llm.retry,  # #1835
+            # #2093: the uniform reyn.yaml-derived per-session config bundle. (The same
+            # sandbox_config the A2A/MCP-serve factory once dropped — now it's in the
+            # bundle, so it can't be missed here.)
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
             # #1402: scoped capability surface, passed EXPLICITLY (required by
             # build_scoped_chat_session). The stdio-MCP factory's current
             # behaviour — defaults that document the gaps, NOT new capabilities
@@ -456,9 +449,8 @@ def run_serve(args: argparse.Namespace) -> None:
         project_root=project_root,
         session_factory=_session_factory,
         state_log=state_log,
-        delegation_capability_default=session_cfg.config.delegation.capability_default,  # #2081
-        workspace_capture=session_cfg.config.time_travel.workspace_capture,  # #1582 opt-out
-        act_turn_capture=session_cfg.config.time_travel.act_turn_capture,  # #1560 opt-in
+        # #2093: the uniform reyn.yaml-derived registry config bundle.
+        factory_config=SessionFactoryConfig.from_config(session_cfg.config),
     )
 
     timeout = float(getattr(args, "timeout", 60.0) or 60.0)

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -262,6 +262,7 @@ def _get_registry():
     global _registry
     if _registry is None:
         from reyn.config import load_project_context
+        from reyn.runtime.factory_config import SessionFactoryConfig
         from reyn.runtime.profile import AgentProfile
         from reyn.runtime.registry import AgentRegistry
         from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -323,22 +324,11 @@ def _get_registry():
                 events_config=config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,
-                # B52 retro fix: A2A-side Session was missing
-                # ``sandbox_config`` propagation — ``reyn.yaml`` ``sandbox.backend``
-                # set in reyn.local.yaml never reached the sandboxed_exec
-                # handler via the chat-router path. Cron-side
-                # ``web/server.py`` already passes this; the A2A factory
-                # was the only gap. Surfaced by B52 W3-S5 retest where
-                # ``sandbox.backend: noop`` config loaded correctly but
-                # the runtime kept using Seatbelt.
-                sandbox_config=config.sandbox,
-                multimodal_config=config.multimodal,
-                tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
-                action_retrieval_config=config.action_retrieval,
-                chat_tool_use_scheme=config.tool_use.chat,  # #1593 PR-2
-                embedding_config=config.embedding,
-                router_config=config.llm.router,  # #1829 S3b
-                retry_config=config.llm.retry,  # #1835
+                # #2093: the uniform reyn.yaml-derived per-session config (sandbox /
+                # multimodal / action_retrieval / embedding / router / retry /
+                # op-loop-skills / tool-use-scheme) — one bundle, so a new uniform arg
+                # can't be missed here (the sandbox_config B52 drift class is gone).
+                factory_config=SessionFactoryConfig.from_config(config),
                 eager_embedding_build=_eager_embedding_build,
                 # #1401: the 3 scoped capabilities, filled from the CLI override
                 # holder (env-backend INSTANCE → both FS+exec seams = single-shared
@@ -383,15 +373,15 @@ def _get_registry():
             project_root=root,
             session_factory=_session_factory,
             state_log=state_log,
-            delegation_capability_default=config.delegation.capability_default,  # #2081
+            # #2093: the uniform reyn.yaml-derived registry config (workspace_capture /
+            # act_turn_capture / delegation_capability_default) — one bundle, so a new
+            # one can't be missed here (the delegation_capability_default #2081 drift).
+            factory_config=SessionFactoryConfig.from_config(config),
             # #1544: container shadow-git. ``_scoped`` is local to the session
             # factory above; fetch the overrides at this scope via the accessor.
             environment_backend=get_cli_scoped_overrides().environment_backend,
             # #1557 gap-#1: shadow git-dir under --state-dir (same accessor scope).
             workspace_state_dir=get_cli_scoped_overrides().workspace_state_dir,
-            # #1582: time-travel workspace-capture opt-out (reyn.yaml config).
-            workspace_capture=config.time_travel.workspace_capture,
-            act_turn_capture=config.time_travel.act_turn_capture,  # #1560 opt-in
         )
         registry_ref.append(registry)
         _registry = registry

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -1,0 +1,61 @@
+"""#2093: the shared session-factory config bundle — completeness-by-construction.
+
+The five session-factory sites (cli/chat, cli/dogfood, web/deps, chainlit, cli/mcp)
+each thread a set of UNIFORM, reyn.yaml-config-derived args identically into
+``build_scoped_chat_session`` (8) and ``AgentRegistry`` (3). Historically a new uniform
+arg had to be added at all five sites by hand — and was silently missed at one
+(``sandbox_config`` at the A2A factory; ``delegation_capability_default`` at
+``mcp.py``).
+
+``SessionFactoryConfig.from_config`` is the SINGLE point that maps ``ReynConfig`` →
+those uniform args. Every site builds the bundle once and passes it to both consumers,
+which read their part. A new uniform arg is added in ONE place (the dataclass +
+``from_config``) and reaches all five sites — type-enforced, so it cannot be missed.
+
+This is deliberately ONLY the uniform config-derived args. Per-SITE args that
+legitimately differ (model / resolver / state_log / the env+sandbox backends /
+workspace dirs / contextual_permission / agent_id / allowed_mcp / task_backend /
+router_max_iterations / non_interactive / eager_embedding_build) stay explicit
+per-site params — they are NOT a drift class.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SessionFactoryConfig:
+    """The uniform, config-derived session-factory args (see module docstring)."""
+
+    # ── build_scoped_chat_session uniform config (8) ────────────────────────
+    sandbox_config: Any
+    multimodal_config: Any
+    action_retrieval_config: Any
+    embedding_config: Any
+    router_config: Any
+    retry_config: Any
+    tool_calls_op_loop_skills: "list[str] | None"
+    chat_tool_use_scheme: str
+    # ── AgentRegistry uniform config (3) ────────────────────────────────────
+    workspace_capture: bool
+    act_turn_capture: bool
+    delegation_capability_default: str
+
+    @classmethod
+    def from_config(cls, config: Any) -> "SessionFactoryConfig":
+        """The single mapping point ``ReynConfig`` → the uniform factory args. Add a
+        new uniform arg HERE (and as a field above) → all five factory sites get it."""
+        return cls(
+            sandbox_config=config.sandbox,
+            multimodal_config=config.multimodal,
+            action_retrieval_config=config.action_retrieval,
+            embedding_config=config.embedding,
+            router_config=config.llm.router,
+            retry_config=config.llm.retry,
+            tool_calls_op_loop_skills=config.tool_calls_op_loop_skills,
+            chat_tool_use_scheme=config.tool_use.chat,
+            workspace_capture=config.time_travel.workspace_capture,
+            act_turn_capture=config.time_travel.act_turn_capture,
+            delegation_capability_default=config.delegation.capability_default,
+        )

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -124,6 +124,7 @@ class AgentRegistry:
         workspace_capture: bool = True,
         act_turn_capture: bool = False,
         delegation_capability_default: str = "inherit",
+        factory_config: "object | None" = None,
     ) -> None:
         """
         session_factory: returns a configured Session given an AgentProfile.
@@ -137,6 +138,16 @@ class AgentRegistry:
             live (current behaviour, no deeper retention). When deeper, clamps the
             truncation floor + GCs generations/blobs to the configured window.
         """
+        # #2093: when the shared SessionFactoryConfig bundle is provided (the 5
+        # frontend factory sites pass it), it SUPPLIES the uniform config-derived args
+        # (workspace_capture / act_turn_capture / delegation_capability_default) — so a
+        # new one is added in one place (the bundle) and can't be missed at a site
+        # (delegation_capability_default was the drift). The individual params remain
+        # for the utility / test callers (which use defaults), keeping them unchanged.
+        if factory_config is not None:
+            workspace_capture = factory_config.workspace_capture
+            act_turn_capture = factory_config.act_turn_capture
+            delegation_capability_default = factory_config.delegation_capability_default
         self._dir = project_root / ".reyn" / "agents"
         self._dir.mkdir(parents=True, exist_ok=True)
         self._topology_dir = project_root / ".reyn" / TOPOLOGY_DIRNAME

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from reyn.runtime.agent import Agent
+from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.session import Session
 
 if TYPE_CHECKING:
@@ -59,18 +60,14 @@ def build_scoped_chat_session(
     eager_embedding_build: bool,  # build the action embedding index up-front
     allowed_mcp: list[str] | None,  # per-profile MCP allow-list
     task_backend: Any,  # #1953 slice R — session-scoped Task backend instance. I-5=(A): cli/chat + MCP pass a per-session sqlite (rewind-participating); A2A/web passes None (the process-singleton A2A surface is read directly, NOT threaded here, so A2A tasks stay durable but un-rewound). None → op-runtime in-memory fallback (_BACKEND)
-    # ── per-session config (required: should be UNIFORM across factories) ──
-    # These are reyn.yaml-derived config every factory loads the same way; the
-    # sandbox_config + multimodal_config drifts each previously needed a
-    # dedicated uniformity point-test (now subsumed by the src/-wide invariant).
-    sandbox_config: Any,  # SandboxConfig | None — exec-tool gating string
-    multimodal_config: Any,  # MultimodalConfig | None
-    action_retrieval_config: Any,  # ActionRetrievalConfig | None
-    embedding_config: Any,  # EmbeddingConfig | None
-    router_config: Any,  # #1829 S3b RouterConfig | None — reyn.yaml llm.router.*
-    retry_config: Any,  # #1835 RetryConfig | None — reyn.yaml llm.retry.*
-    tool_calls_op_loop_skills: list[str] | None,  # #1212 op-loop gate
-    chat_tool_use_scheme: str,  # #1593 PR-2 config.tool_use.chat — chat-layer ToolUseScheme name (UNIFORM: every frontend resolves the same reyn.yaml value)
+    # ── per-session config — the UNIFORM, reyn.yaml-derived bundle (#2093) ──
+    # All eight previously-individual uniform args (sandbox_config / multimodal_config
+    # / action_retrieval_config / embedding_config / router_config / retry_config /
+    # tool_calls_op_loop_skills / chat_tool_use_scheme) now arrive as ONE bundle, built
+    # once per frontend via SessionFactoryConfig.from_config — so a new uniform arg is
+    # added in one place and reaches all five factory sites (completeness-by-
+    # construction; the sandbox_config drift class is structurally prevented).
+    factory_config: "SessionFactoryConfig",
     # ── common base (pass-through; session identity/infra, not a drift surface) ──
     **base: Any,
 ) -> Session:
@@ -92,7 +89,7 @@ def build_scoped_chat_session(
         permission_resolver=base.get("permission_resolver"),
         workspace_base_dir=workspace_base_dir,
         workspace_state_dir=workspace_state_dir,
-        sandbox_config=sandbox_config,
+        sandbox_config=factory_config.sandbox_config,
         sandbox_backend=sandbox_backend,
         environment_backend=environment_backend,
     )
@@ -122,13 +119,13 @@ def build_scoped_chat_session(
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
         task_backend=task_backend,  # #1953 slice R
-        sandbox_config=sandbox_config,
-        multimodal_config=multimodal_config,
-        action_retrieval_config=action_retrieval_config,
-        embedding_config=embedding_config,
-        router_config=router_config,
-        retry_config=retry_config,  # #1835
-        tool_calls_op_loop_skills=tool_calls_op_loop_skills,
-        chat_tool_use_scheme=chat_tool_use_scheme,
+        sandbox_config=factory_config.sandbox_config,
+        multimodal_config=factory_config.multimodal_config,
+        action_retrieval_config=factory_config.action_retrieval_config,
+        embedding_config=factory_config.embedding_config,
+        router_config=factory_config.router_config,
+        retry_config=factory_config.retry_config,  # #1835
+        tool_calls_op_loop_skills=factory_config.tool_calls_op_loop_skills,
+        chat_tool_use_scheme=factory_config.chat_tool_use_scheme,
         **base,
     )

--- a/tests/test_2093_factory_config_bundle.py
+++ b/tests/test_2093_factory_config_bundle.py
@@ -1,0 +1,49 @@
+"""Tier 2: #2093 — the SessionFactoryConfig bundle is a byte-identical consolidation.
+
+The five session-factory sites previously threaded 11 uniform, config-derived args by
+hand into build_scoped_chat_session (8) + AgentRegistry (3) — a per-arg propagation gap
+that twice silently missed a site (sandbox_config, delegation_capability_default). The
+bundle's ``from_config`` is now the single mapping point.
+
+This pins the consolidation as byte-identical: every bundle field resolves to the EXACT
+same config source the sites passed before (object identity, so no value can drift). A
+wrong/missing mapping in from_config → RED, naming the field.
+"""
+from __future__ import annotations
+
+from reyn.config.loader import load_config
+from reyn.runtime.factory_config import SessionFactoryConfig
+
+
+def test_from_config_maps_each_field_to_its_config_source() -> None:
+    """Tier 2: each bundle field is the SAME object the factories read directly — the
+    byte-identical mapping. (A typo'd source in from_config breaks the matching
+    identity assertion.)"""
+    config = load_config()
+    fc = SessionFactoryConfig.from_config(config)
+
+    # build_scoped_chat_session uniform config (8)
+    assert fc.sandbox_config is config.sandbox
+    assert fc.multimodal_config is config.multimodal
+    assert fc.action_retrieval_config is config.action_retrieval
+    assert fc.embedding_config is config.embedding
+    assert fc.router_config is config.llm.router
+    assert fc.retry_config is config.llm.retry
+    assert fc.tool_calls_op_loop_skills is config.tool_calls_op_loop_skills
+    assert fc.chat_tool_use_scheme == config.tool_use.chat
+    # AgentRegistry uniform config (3)
+    assert fc.workspace_capture == config.time_travel.workspace_capture
+    assert fc.act_turn_capture == config.time_travel.act_turn_capture
+    assert fc.delegation_capability_default == config.delegation.capability_default
+
+
+def test_bundle_is_frozen() -> None:
+    """Tier 2: the bundle is immutable (a frozen dataclass) — a site can't mutate a
+    shared bundle and leak the change to another consumer."""
+    import dataclasses
+
+    import pytest
+
+    fc = SessionFactoryConfig.from_config(load_config())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        fc.delegation_capability_default = "deny"  # type: ignore[misc]

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -102,6 +102,45 @@ def _chatsession_call_sites() -> list[str]:
     return sites
 
 
+def _has_factory_config_kw(call: "ast.Call") -> bool:
+    return any(k.arg == "factory_config" for k in call.keywords)
+
+
+def test_registry_gets_the_bundle_wherever_the_session_factory_does() -> None:
+    """Tier 2: #2093 — by-CONSTRUCTION on the AgentRegistry side too. A production
+    factory file calls ``build_scoped_chat_session(factory_config=…)``; it MUST also
+    pass ``factory_config`` to its ``AgentRegistry(…)`` — otherwise the registry's
+    uniform config args (workspace_capture / act_turn_capture /
+    delegation_capability_default — the EXACT arg #2093 protects) silently default.
+
+    The ``build_scoped_chat_session(factory_config=)`` call is the production-factory
+    signal, so the 60+ test/utility ``AgentRegistry`` callers (which never call
+    build_scoped_chat_session, and legitimately use the individual params / defaults)
+    are untouched. Falsifiable: a factory file that builds the bundle for the session
+    but omits it from its AgentRegistry fails here, naming file:line."""
+    offenders: list[str] = []
+    for py in sorted(_SRC.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        builds_factory_bundle = False
+        registry_calls: list[tuple[int, bool]] = []
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+                continue
+            if node.func.id == "build_scoped_chat_session" and _has_factory_config_kw(node):
+                builds_factory_bundle = True
+            elif node.func.id == "AgentRegistry":
+                registry_calls.append((node.lineno, _has_factory_config_kw(node)))
+        if builds_factory_bundle:
+            rel = str(py.relative_to(_SRC))
+            offenders += [f"{rel}:{ln}" for ln, has_fc in registry_calls if not has_fc]
+    assert not offenders, (
+        "a production factory passes factory_config to build_scoped_chat_session but "
+        "NOT to its AgentRegistry — the registry's uniform config args (incl. "
+        "delegation_capability_default) silently default (#2093 drift class): "
+        f"{offenders}"
+    )
+
+
 def test_chatsession_constructed_only_in_scoped_factory() -> None:
     """Tier 2: #1402 — within src/reyn, ``Session(...)`` is constructed ONLY
     in scoped_session_factory.py; every frontend routes through

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -32,9 +32,11 @@ construction-wiring invariant).
 from __future__ import annotations
 
 import ast
+import dataclasses
 import inspect
 from pathlib import Path
 
+from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.scoped_session_factory import build_scoped_chat_session
 
 _SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
@@ -42,8 +44,10 @@ _SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
 # The ONE module allowed to construct Session directly.
 _FACTORY_REL = "runtime/scoped_session_factory.py"
 
-# The drift surface: scoped capability + per-session config params that MUST stay
-# required so no factory can silently omit one.
+# The drift surface, part 1: the PER-SITE scoped capability params that legitimately
+# differ per frontend — they MUST stay required (no default) so a factory cannot
+# silently omit one. Plus ``factory_config`` (the #2093 bundle) — also required, so a
+# factory cannot omit the uniform-config bundle.
 _REQUIRED_SCOPED = frozenset({
     # scoped capability (per-frontend; explicit even when None/off)
     "environment_backend",
@@ -58,14 +62,28 @@ _REQUIRED_SCOPED = frozenset({
     "eager_embedding_build",
     "allowed_mcp",
     "task_backend",  # #1953 slice R: per-session Task backend (per-frontend scoped — I-5=(A))
-    # per-session config (should be UNIFORM across factories)
+    "factory_config",  # #2093: the uniform config bundle — required, can't be omitted
+})
+
+# The drift surface, part 2 (#2093): the UNIFORM, config-derived args that every site
+# threads identically. They moved OFF build_scoped_chat_session's signature INTO the
+# SessionFactoryConfig bundle (built once via from_config) — so a new uniform arg is
+# added in ONE place and reaches all five sites. The completeness invariant is now
+# "these are SessionFactoryConfig fields" (a new one missing from the bundle = drift).
+_BUNDLED_UNIFORM = frozenset({
+    # → build_scoped_chat_session (8)
     "sandbox_config",
     "multimodal_config",
     "action_retrieval_config",
     "embedding_config",
-    "router_config",  # #1829 S3b reyn.yaml llm.router.* (per-session, UNIFORM)
+    "router_config",  # #1829 S3b
+    "retry_config",  # #1835
     "tool_calls_op_loop_skills",
-    "chat_tool_use_scheme",  # #1593 PR-2 per-layer chat scheme selector
+    "chat_tool_use_scheme",  # #1593 PR-2
+    # → AgentRegistry (3) — where delegation_capability_default drifted (#2081)
+    "workspace_capture",
+    "act_turn_capture",
+    "delegation_capability_default",
 })
 
 
@@ -123,3 +141,22 @@ def test_scoped_params_are_required_no_default() -> None:
             f"{pname} must be REQUIRED (no default) — a default re-opens "
             "silent-omission drift (#1402 completeness-by-construction)"
         )
+
+
+def test_uniform_config_is_single_sourced_in_the_bundle() -> None:
+    """Tier 2: #2093 — the UNIFORM, config-derived factory args are SessionFactoryConfig
+    fields (the single mapping point ``from_config``), so a new uniform arg is added in
+    ONE place and reaches all five sites. A uniform arg NOT in the bundle re-opens the
+    per-arg propagation drift (sandbox_config / delegation_capability_default) — this
+    fails, naming it."""
+    fields = {f.name for f in dataclasses.fields(SessionFactoryConfig)}
+    missing = _BUNDLED_UNIFORM - fields
+    assert not missing, (
+        f"uniform config args missing from SessionFactoryConfig {sorted(missing)} — "
+        "re-opens the per-arg propagation drift; add them as bundle fields + in from_config"
+    )
+    # the bundle holds ONLY the uniform args (no per-site scoped capability leaked in)
+    assert not (fields & _REQUIRED_SCOPED), (
+        f"per-site scoped args leaked into the bundle {sorted(fields & _REQUIRED_SCOPED)} — "
+        "those legitimately differ per site and must stay explicit params"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #2093 (lead-dispatched, free-capacity while the per-session config grain settles). Pure byte-identical consolidation. No-merge — close-review. Structure quick-reviewed + confirmed by lead.

## What

The 5 session-factory sites (cli/chat, cli/dogfood, web/deps, chainlit, cli/mcp) each threaded **11 uniform, config-derived args** by hand into `build_scoped_chat_session` (8) + `AgentRegistry` (3) — the per-arg propagation gap that twice silently missed a site (`sandbox_config` at the A2A factory; `delegation_capability_default` at `mcp.py:455`).

**`SessionFactoryConfig` (new) + `from_config(config)` is the single mapping point.** Each site builds it once; both consumers read their part:
- `build_scoped_chat_session`: the 8 uniform params → one **required** `factory_config` param (unpacked internally) — a factory can't omit the bundle.
- `AgentRegistry`: an **optional** `factory_config` supplies the 3 uniform config args; the individual params remain (defaults) for the 60+ utility/test callers — **untouched**.

A new uniform arg → added in **one place** → reaches all 5 sites, **type-enforced**. Per-site args that legitimately differ (model/resolver/state_log/backends/workspace-dirs/contextual_permission/agent_id/allowed_mcp/task_backend/router_max_iterations/non_interactive/eager_embedding_build) stay explicit — **not** bundled.

## Byte-identical

Each `from_config` field resolves to the **exact** config source the sites passed before (object identity). The one existing deviation — dogfood's deliberate `embedding_config=None` (documented gap) — is preserved **explicitly** via `replace()` (a visible deviation, not a silent miss). Not fixing the dogfood gap here (behavior change; lead tracking separately).

## Test plan

- [x] `test_scoped_session_factory_invariant_1402` (updated): the completeness invariant now also asserts the 11 uniform args are `SessionFactoryConfig` fields + `factory_config` is a required `build_scoped_chat_session` param + no per-site arg leaked into the bundle.
- [x] `test_2093_factory_config_bundle` (new): `from_config` maps each field to its exact config source (byte-identical, object identity, falsifies a wrong mapping); the bundle is frozen.
- [x] AST-wiring tests (`1431`, `1401`) green (per-site args unchanged)
- [x] `ruff check src tests scripts` clean (the I001 import-churn from local imports — `--fix`'d) · `test_tier_audit.py --strict` 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8311 passed, 18 skipped, 3 xfailed**

Sets up the factory-args path the per-session config work will slot into. Refs #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)