### PR TITLE
feat(#2095): name the hook in the shell-hook consent prompt (P2)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -131,6 +131,7 @@ class HookDispatcher:
                 sandbox_backend=self._sandbox_backend,
                 sandbox_config=self._sandbox_config,
                 consent_bus=self._consent_bus_now(),
+                hook_name=hook.name,
             )
         elif hook.shell_push is not None:
             # shell_push (#2069) — a shell command whose STDOUT is a JSON
@@ -147,6 +148,7 @@ class HookDispatcher:
                 sandbox_config=self._sandbox_config,
                 capture_stdout=True,
                 consent_bus=self._consent_bus_now(),
+                hook_name=hook.name,
             )
             resolved = _parse_shell_push(stdout)
             if resolved is not None:

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -164,6 +164,7 @@ async def _check_consent(
     allowlist_path: Path,
     *,
     consent_bus: "RequestBus | None" = None,
+    hook_name: str | None = None,
 ) -> bool:
     """Return True if *command* is approved to run.
 
@@ -198,7 +199,9 @@ async def _check_consent(
     # An answerable surface is attached → route the consent through the unified
     # intervention bus (#2095). The allowlist remains the "always" persistence.
     if consent_bus is not None:
-        return await _prompt_consent_via_bus(command, allowlist_path, consent_bus)
+        return await _prompt_consent_via_bus(
+            command, allowlist_path, consent_bus, hook_name,
+        )
 
     # No consent bus → preserve the exact pre-#2095 behavior below.
     is_tty = sys.stdin.isatty()
@@ -235,7 +238,7 @@ async def _check_consent(
 
 
 async def _prompt_consent_via_bus(
-    command: str, allowlist_path: Path, bus: "RequestBus",
+    command: str, allowlist_path: Path, bus: "RequestBus", hook_name: str | None = None,
 ) -> bool:
     """Prompt for shell-hook consent through the unified intervention bus (#2095).
 
@@ -243,6 +246,11 @@ async def _prompt_consent_via_bus(
     permission-prompts use, so the prompt surfaces wherever interventions do
     (the TUI Pending tab, stdin for ``reyn run``, etc.) — not the stdin
     ``print``/``input`` that is invisible under a Textual app.
+
+    ``hook_name`` (#2095 P2): the operator's ``HookDef.name`` when set, so the
+    prompt identifies WHICH configured hook is asking (vs a generic "a shell
+    hook"). Shell hooks are always operator-config (``hooks_add`` can only write
+    ``template_push``), so no agent-vs-operator source label is shown.
 
     Choice mapping (``shell_hook_choices``): ``ALWAYS`` records to the allowlist
     (the "always" persistence); ``YES`` allows this run only; ``NO`` / unknown /
@@ -252,9 +260,10 @@ async def _prompt_consent_via_bus(
     from reyn.intervention_choices import ALWAYS, YES, shell_hook_choices
     from reyn.user_intervention import UserIntervention
 
+    who = f"Shell hook {hook_name!r}" if hook_name else "A shell hook"
     iv = UserIntervention(
         kind="permission.shell_hook",
-        prompt="A shell hook wants to run a command",
+        prompt=f"{who} wants to run a command",
         detail=f"$ {command}",
         choices=shell_hook_choices(),
     )
@@ -288,6 +297,7 @@ async def run_shell_hook(
     allowlist_path: Path | None = None,
     capture_stdout: bool = False,
     consent_bus: "RequestBus | None" = None,
+    hook_name: str | None = None,
 ) -> str | None:
     """Run a shell hook command under the sandbox + consent gate.
 
@@ -341,6 +351,10 @@ async def run_shell_hook(
         has a live intervention listener; ``None`` (incl. headless / CI /
         plain mcp-serve / ``reyn run`` with no listener) preserves the pre-#2095
         stdin / fail-closed gate.
+    hook_name:
+        The hook's ``HookDef.name`` (#2095 P2), surfaced in the consent prompt
+        so the user sees WHICH configured hook is asking. ``None`` → a generic
+        "a shell hook" prompt. Only used on the ``consent_bus`` path.
 
     Returns
     -------
@@ -363,6 +377,7 @@ async def run_shell_hook(
             command,
             resolved_allowlist,
             consent_bus=consent_bus,
+            hook_name=hook_name,
         )
     except Exception as exc:
         _log.error("shell-hook: consent check error for %r: %s", command, exc)

--- a/tests/test_2095_shell_hook_consent_bus.py
+++ b/tests/test_2095_shell_hook_consent_bus.py
@@ -97,6 +97,28 @@ async def test_consent_bus_always_records_and_runs(
 
 
 @pytest.mark.asyncio
+async def test_consent_prompt_names_the_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: #2095 P2 — when a ``hook_name`` is supplied, the consent prompt
+    identifies WHICH hook is asking; without one it stays generic."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    marker = tmp_path / "ran.txt"
+    command = _marker_command(marker)
+
+    named = _RecordingBus(NO)
+    await _run(command, allowlist, consent_bus=named, hook_name="nightly-sync")
+    assert "nightly-sync" in named.seen[0].prompt
+
+    anon = _RecordingBus(NO)
+    await _run(command, allowlist, consent_bus=anon, hook_name=None)
+    assert "nightly-sync" not in anon.seen[0].prompt
+    assert "shell hook" in anon.seen[0].prompt.lower()
+
+
+@pytest.mark.asyncio
 async def test_consent_bus_yes_runs_without_persisting(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -193,21 +215,23 @@ async def test_accept_env_short_circuits_before_bus(
 
 
 class _RecordingShell:
-    """A real run_shell seam that records the consent_bus it was handed."""
+    """A real run_shell seam that records the consent_bus + hook_name it got."""
 
     def __init__(self) -> None:
         self.consent_buses: list[object] = []
+        self.hook_names: list[object] = []
 
     async def __call__(self, *args, **kwargs):
         self.consent_buses.append(kwargs.get("consent_bus"))
+        self.hook_names.append(kwargs.get("hook_name"))
         return None
 
 
-def _shell_exec_dispatcher(*, gate, run_shell, bus) -> HookDispatcher:
+def _shell_exec_dispatcher(*, gate, run_shell, bus, hook_name="e2e-probe") -> HookDispatcher:
     async def _noop(*_a, **_k):
         return None
 
-    reg = HookRegistry([HookDef(on="turn_end", shell_exec="echo hi")])
+    reg = HookRegistry([HookDef(on="turn_end", name=hook_name, shell_exec="echo hi")])
     return HookDispatcher(
         reg,
         put_inbox=_noop,
@@ -229,6 +253,8 @@ async def test_dispatcher_passes_bus_when_listener_present() -> None:
     await disp.dispatch("turn_end", {})
 
     assert shell.consent_buses == [bus]
+    # The dispatcher wires the hook's name through for the consent prompt (P2).
+    assert shell.hook_names == ["e2e-probe"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — #2095 **P2** (builds on merged P1 #2098; scope confirmed with lead). Names the hook in the shell-hook consent prompt.

## What changed
The P1 consent modal said a generic **"A shell hook wants to run a command"**. P2 threads the operator's `HookDef.name` through `dispatcher → run_shell_hook → _prompt_consent_via_bus` so the prompt identifies which configured hook is asking:

> **Shell hook `'nightly-sync'` wants to run a command**
> `$ <command>`

Falls back to the generic wording when the hook has no `name`.

## Why name, not source
Shell hooks are **always operator-config** — `hooks_add` (the only agent hooks-write op) can only emit `template_push`, never `shell_exec`/`shell_push`. So an agent-vs-operator "source" label would be a constant ("operator") = noise, not signal. The **name** is the useful provenance (confirmed with lead). The deeper `HookDef.source` field (a loader/registry refactor) is deferred until/unless `hooks_add` is extended to shell.

## Test plan
- [x] `pytest tests/test_2095_shell_hook_consent_bus.py` — 9 Tier-2 (incl. P2: prompt names the hook when `hook_name` set + stays generic without; dispatcher wires `hook.name` to the runner).
- [x] hook-runner + dispatcher + shell_push + attribution suites green.
- [x] `ruff check` + `tier_audit --strict` clean.
- [ ] (deferred to a combined P2+P3 live check at lane close) tmux-e2e of the **named** prompt — P1's tmux-e2e already proved the modal renders `iv.prompt` live (the named string is a unit-verified interpolation of that same path); P3 adds a new surface that warrants its own live check, so I'll verify both in one real-terminal pass.

**Tier self-check:** +2 Tier-2 (behavior via the real `_RecordingBus` prompt text + the dispatcher→runner wire through a real `_RecordingShell`); no size/format pins, no private-state asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
