### PR TITLE
feat(#2095): surface auto-run shell hooks as a P6 event (P3)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -61,6 +61,7 @@ class HookDispatcher:
         sandbox_backend: Any = None,
         consent_bus: Any = None,
         consent_gate: "Callable[[], bool] | None" = None,
+        emit_event: "Callable[..., Any] | None" = None,
     ) -> None:
         self._registry = registry
         self._put_inbox = put_inbox
@@ -68,6 +69,10 @@ class HookDispatcher:
         self._run_shell = run_shell
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
+        # #2095 P3: P6-event sink for shell-hook executions, so an auto-run
+        # (allowlisted) shell hook surfaces in the events tab instead of being a
+        # silent side-effect. None → no emission (e.g. unit tests).
+        self._emit_event = emit_event
         # #2095: the session RequestBus + a LIVE "is a listener attached?" gate,
         # forwarded to the shell-hook consent gate so a not-yet-allowlisted
         # command's prompt surfaces on the answering surface (TUI Pending tab)
@@ -132,6 +137,7 @@ class HookDispatcher:
                 sandbox_config=self._sandbox_config,
                 consent_bus=self._consent_bus_now(),
                 hook_name=hook.name,
+                emit_event=self._emit_event,
             )
         elif hook.shell_push is not None:
             # shell_push (#2069) — a shell command whose STDOUT is a JSON
@@ -149,6 +155,7 @@ class HookDispatcher:
                 capture_stdout=True,
                 consent_bus=self._consent_bus_now(),
                 hook_name=hook.name,
+                emit_event=self._emit_event,
             )
             resolved = _parse_shell_push(stdout)
             if resolved is not None:

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -55,7 +55,7 @@ import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from reyn.config import SandboxConfig
@@ -298,6 +298,7 @@ async def run_shell_hook(
     capture_stdout: bool = False,
     consent_bus: "RequestBus | None" = None,
     hook_name: str | None = None,
+    emit_event: "Callable[..., Any] | None" = None,
 ) -> str | None:
     """Run a shell hook command under the sandbox + consent gate.
 
@@ -355,6 +356,13 @@ async def run_shell_hook(
         The hook's ``HookDef.name`` (#2095 P2), surfaced in the consent prompt
         so the user sees WHICH configured hook is asking. ``None`` → a generic
         "a shell hook" prompt. Only used on the ``consent_bus`` path.
+    emit_event:
+        Optional ``(event_type, **data)`` sink (#2095 P3), wired to the session
+        event log. Called once with ``hook_shell_executed`` immediately after the
+        command actually runs (consent passed + executed) — so an auto-run
+        (allowlisted / accepted) hook, otherwise a silent side-effect, surfaces in
+        the TUI events tab. NOT called when consent is refused or the command is
+        skipped (then nothing ran). Best-effort: a sink error never breaks the run.
 
     Returns
     -------
@@ -426,6 +434,20 @@ async def run_shell_hook(
             stdin=stdin_bytes,
             cwd=cwd,
         )
+
+        # #2095 P3: the command actually ran (consent passed) — surface it as a
+        # P6 event so an auto-run (allowlisted) shell hook isn't a silent
+        # side-effect. Best-effort: a sink error must not break the run.
+        if emit_event is not None:
+            try:
+                emit_event(
+                    "hook_shell_executed",
+                    command=command,
+                    mode=("shell_push" if capture_stdout else "shell_exec"),
+                    returncode=result.returncode,
+                )
+            except Exception as exc:  # noqa: BLE001 — telemetry is best-effort
+                _log.debug("shell-hook: emit_event failed for %r: %s", command, exc)
 
         # stderr is ALWAYS logs. stdout is logs for shell_exec; for shell_push
         # (capture_stdout) it is the JSON push-directive the caller parses — so

--- a/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
@@ -169,6 +169,8 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "mcp_server_installed", "act_executed",
         "web_fetch_started", "web_search_started",
         "web_search_completed", "web_search_failed",
+        # #2095 P3: a shell hook ran a command (incl. silent auto-runs).
+        "hook_shell_executed",
     })),
     # RAG (ADR-0033) — embed / recall / index lifecycle. Separate group so a
     # noisy embed_progress stream can be filtered in/out independently.
@@ -289,6 +291,13 @@ def _event_hint(ev: dict) -> str:
     if t == "tool_failed":
         msg, was_trunc = _truncate_to_cells(str(d.get("message", "")), 25)
         return f"{d.get('tool', '')}: {msg}" + ("…" if was_trunc else "")
+    if t == "hook_shell_executed":
+        # #2095 P3: surface a shell-hook command run (incl. silent auto-runs).
+        # The command is untrusted-length operator text → CJK-aware truncate.
+        cmd, was_trunc = _truncate_to_cells(str(d.get("command", "")), 40)
+        rc = d.get("returncode")
+        rc_part = "" if rc in (0, None) else f" rc={rc}"
+        return f"{d.get('mode', 'shell')}: {cmd}" + ("…" if was_trunc else "") + rc_part
     if t in ("mcp_called", "mcp_completed"):
         suffix = " ✗" if d.get("is_error") else ""
         return f"{d.get('server', '')}.{d.get('tool', '')}{suffix}"

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1279,6 +1279,11 @@ class Session:
             # Lambda defers the lookup: ``self._interventions`` is constructed
             # below this point, and the gate is only called at dispatch time.
             consent_gate=lambda: self._interventions.has_active_listener(),
+            # #2095 P3: P6-event sink so an auto-run (allowlisted) shell hook
+            # surfaces in the events tab instead of being a silent side-effect.
+            # Lambda defers ``self._chat_events`` (assigned below this point);
+            # only called at dispatch time.
+            emit_event=lambda et, **d: self._chat_events.emit(et, **d),
         )
         # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
         # reapply seam can unschedule jobs removed from the runtime file WITHOUT

--- a/tests/test_2095_p3_shell_activity.py
+++ b/tests/test_2095_p3_shell_activity.py
@@ -1,0 +1,163 @@
+"""Tier 2: #2095 P3 — a shell-hook execution surfaces as a P6 event.
+
+When a shell hook actually runs (consent passed — incl. a silent allowlisted /
+accepted auto-run), the runner emits ``hook_shell_executed`` through the session
+event sink so the events tab shows it instead of it being an invisible
+side-effect. A refused / skipped hook (nothing ran) emits nothing.
+
+No mocks: a real ``_RecordingEvents`` callable implements the sink contract; a
+real ``NoopBackend`` executes the command; the allowlist is a real tmp file. The
+events-tab hint is exercised through the real ``_event_hint`` renderer.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef
+from reyn.hooks.shell_runner import run_shell_hook
+from reyn.interfaces.tui.widgets.right_panel.events_tab import _event_hint
+from reyn.security.sandbox import NoopBackend, SandboxPolicy
+
+_PY = sys.executable
+
+
+class _RecordingEvents:
+    """A real ``emit_event(type, **data)`` sink (NOT a mock)."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def __call__(self, event_type: str, **data) -> None:
+        self.events.append((event_type, data))
+
+
+def _policy() -> SandboxPolicy:
+    return SandboxPolicy(network=False, allow_subprocess=False, timeout_seconds=10)
+
+
+async def _run(command: str, allowlist: Path, **kw):
+    return await run_shell_hook(
+        command,
+        event_context={"event": "turn_end"},
+        timeout_seconds=10,
+        sandbox_backend=NoopBackend(),
+        sandbox_policy=_policy(),
+        allowlist_path=allowlist,
+        **kw,
+    )
+
+
+def _executed(sink: _RecordingEvents) -> list[dict]:
+    return [d for t, d in sink.events if t == "hook_shell_executed"]
+
+
+@pytest.mark.asyncio
+async def test_runner_emits_on_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: an approved shell-hook run emits ``hook_shell_executed`` carrying
+    the command, mode and (zero) returncode."""
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")  # auto-approve → it runs
+    allowlist = tmp_path / "a.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    sink = _RecordingEvents()
+    cmd = f'{_PY} -c "pass"'
+
+    await _run(cmd, allowlist, emit_event=sink)
+
+    ev = _executed(sink)
+    assert ev, "an executed shell hook must emit hook_shell_executed"
+    assert ev[0]["command"] == cmd
+    assert ev[0]["mode"] == "shell_exec"
+    assert ev[0]["returncode"] == 0
+
+
+@pytest.mark.asyncio
+async def test_runner_emits_returncode_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: a non-zero exit still emits the event with the real returncode (the
+    command ran — it just failed)."""
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    allowlist = tmp_path / "a.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    sink = _RecordingEvents()
+
+    await _run(f'{_PY} -c "import sys; sys.exit(3)"', allowlist, emit_event=sink)
+
+    ev = _executed(sink)
+    assert ev and ev[0]["returncode"] == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_no_emit_when_consent_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: a refused consent (non-TTY, no accept flag, no bus → fail-closed)
+    runs nothing, so NO ``hook_shell_executed`` is emitted."""
+    monkeypatch.delenv("REYN_ACCEPT_HOOKS", raising=False)
+    monkeypatch.setattr("sys.stdin", _NonTTY())
+    allowlist = tmp_path / "a.json"
+    allowlist.write_text("[]", encoding="utf-8")
+    sink = _RecordingEvents()
+
+    await _run(f'{_PY} -c "pass"', allowlist, emit_event=sink)
+
+    assert sink.events == [], "a skipped hook must not emit an execution event"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_threads_emit_event() -> None:
+    """Tier 2: the dispatcher wires its ``emit_event`` sink through to the runner."""
+    seen: dict = {}
+
+    async def fake_run(*_a, **kwargs):
+        seen.update(kwargs)
+        return None
+
+    async def _noop(*_a, **_k):
+        return None
+
+    sink = _RecordingEvents()
+    reg = HookRegistry([HookDef(on="turn_end", shell_exec="echo hi")])
+    disp = HookDispatcher(
+        reg, put_inbox=_noop, stage_next_turn_context=_noop,
+        run_shell=fake_run, emit_event=sink,
+    )
+
+    await disp.dispatch("turn_end", {})
+
+    assert seen.get("emit_event") is sink
+
+
+def test_event_hint_renders_shell_execution() -> None:
+    """Tier 2: the events-tab hint summarizes a hook_shell_executed event, and a
+    non-zero returncode surfaces."""
+    ok = _event_hint({
+        "type": "hook_shell_executed",
+        "data": {"command": "echo hi", "mode": "shell_exec", "returncode": 0},
+    })
+    assert "echo hi" in ok
+    assert "shell_exec" in ok
+    assert "rc=" not in ok  # a clean exit shows no rc suffix
+
+    failed = _event_hint({
+        "type": "hook_shell_executed",
+        "data": {"command": "x", "mode": "shell_exec", "returncode": 3},
+    })
+    assert "rc=3" in failed
+
+
+class _NonTTY:
+    """Minimal ``sys.stdin`` replacement reporting non-TTY."""
+
+    def isatty(self) -> bool:
+        return False
+
+    def read(self, *_):
+        return ""


### PR DESCRIPTION
**[tui-coder]** — #2095 **P3** (off merged main; independent of P2 — they add distinct kwargs to the same `_run_shell` calls, trivial merge). Surfaces silently auto-run shell hooks.

## Why
After a shell hook is allowlisted/accepted, it runs every turn with **zero visibility** (confirmed in the P1 tmux-e2e: a 3rd turn ran the hook silently, nothing shown). That's the gap lead named: "a notification/activity surface for GATED hooks that auto-run without a prompt (else they're invisible)."

## What changed
Per P6 (events = audit truth), a shell hook running a command is a state-affecting side-effect → emit a **`hook_shell_executed`** event:
- **runner**: an `emit_event(type, **data)` sink, called once right after the command executes (consent passed) with `command` / `mode` (shell_exec|shell_push) / `returncode`. NOT called when consent is refused/skipped (nothing ran). Best-effort (a sink error never breaks the run).
- **dispatcher**: an `emit_event` seam threaded to both `_run_shell` calls.
- **session**: wires `emit_event` to `_chat_events.emit` (deferred lambda — `_chat_events` is constructed after the dispatcher).
- **events tab**: a `_event_hint` case ("`shell_exec: <cmd>`", `rc=N` on failure, CJK-aware truncate) + `hook_shell_executed` added to the **tool** filter group.

The event carries the **command** (the actionable info), not the hook name — so P3 is independent of P2's name threading (name enrichment composes later if wanted).

## Test plan
- [x] `pytest tests/test_2095_p3_shell_activity.py` — 5 Tier-2 (runner emits on execution w/ command+mode+rc; emits real returncode on failure; **no emit when consent refused**; dispatcher threads the sink; events-tab hint renders + surfaces non-zero rc).
- [x] hook-runner / dispatcher / shell_push suites + `test_events_tab_cjk_hint` green.
- [x] `pytest tests/cli` green (session emit_event lambda + events_tab).
- [x] `ruff check` + `tier_audit --strict` clean.
- [ ] (combined P2+P3 live check at lane close) tmux-e2e: allowlisted hook auto-runs → events tab shows the `hook_shell_executed` line. P1's e2e already proved runner→session event flow live; this confirms the events-tab rendering of the new type.

**Tier self-check:** 5 Tier-2 (real `_RecordingEvents` sink + real `NoopBackend` + the real `_event_hint` renderer; behavior asserted on event data + hint text; no size/format pins, no private state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
