### PR TITLE
feat(#2103): S1a — per-session-config 4th COMBINE layer (capability narrowing)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1956,24 +1956,31 @@ class AgentRegistry:
         return [t for t in self.list_topologies() if agent in t.members]
 
     def resolved_profile_for(
-        self, agent: str, *, is_delegate: "bool | None" = None
+        self, agent: str, *, is_delegate: "bool | None" = None, sid: "str | None" = None
     ) -> "tuple[object | None, frozenset[str]]":
-        """#1827 S3: the agent's effective contextual narrowing from its topology
-        capability_profile bindings.
+        """#1827 S3: the agent's effective contextual narrowing — the composition
+        (most-restrictive: ∪ deny, ∩ allow, ∪ excluded) of every restrict-only layer:
+        topology ``capability_profile`` bindings, the #2081 ``_delegate`` floor, and
+        (#2103 S1a) the per-session config.
 
-        Returns ``(ContextualPermission | None, excluded_categories)`` — the
-        composition (most-restrictive: ∪ deny, ∩ allow, ∪ excluded) of every
-        profile bound to ``agent`` across its topologies.
+        Returns ``(ContextualPermission | None, excluded_categories)``.
 
-        **No binding →** normally ``(None, frozenset())`` = byte-identical to
-        pre-#1827. **#2081 exception:** when this is an UNBOUND **delegate** load
-        (``is_delegate``) and ``delegation.capability_default=deny``, the
-        restrictive built-in ``_delegate`` floor is applied instead — a topology
-        binding would have REPLACED it (the binding is the re-grant; composition is
-        most-restrictive-wins and cannot re-grant). ``is_delegate=None`` (the
-        factory's construction-time call) falls back to the
-        ``_constructing_as_delegate`` transient; an explicit value (direct callers /
-        tests) wins.
+        **No layer →** ``(None, frozenset())`` = byte-identical to pre-#1827.
+
+        **#2081 `_delegate` floor:** when this is an UNBOUND-by-topology **delegate**
+        load (``is_delegate``) and ``delegation.capability_default=deny``, the
+        restrictive built-in ``_delegate`` floor is composed in — a topology binding
+        REPLACES it (the binding is the re-grant). ``is_delegate=None`` (the factory's
+        construction-time call) falls back to the ``_constructing_as_delegate``
+        transient; an explicit value wins.
+
+        **#2103 S1a per-session config:** when ``sid`` is given AND a per-session
+        ``config.yaml`` exists (``.reyn/agents/<name>/state/sessions/<sid>/config.yaml``
+        — the spawner-set, workspace-backed P5 narrowing), it composes in as an
+        ADDITIONAL restrict-only ∩ conjunct — folded into the single ContextualLayer
+        (no 4th EffectivePermission conjunct), so it can only narrow within the agent
+        envelope, never re-grant (structural: one more conjunct in ``all(...)``).
+        ``sid=None`` or no file → byte-identical (inert).
 
         A bound-but-missing or malformed profile file is surfaced (stderr) and
         skipped — a typo must not silently widen capability, but it also must not
@@ -2011,22 +2018,55 @@ class AgentRegistry:
                 continue
             resolved.append(resolve_profile(prof))
 
+        # #2081: an UNBOUND-by-topology delegate under delegation.capability_default=
+        # deny gets the restrictive _delegate floor (a topology binding REPLACES it —
+        # the binding is the re-grant). The delegate-ness propagates recursively (every
+        # A2A request-path load passes is_delegate=True regardless of the spawner's own
+        # status), so a re-granted coordinator's sub-delegate is STILL default-denied
+        # (no laundering). Appended as a conjunct so a per-session narrowing composes
+        # WITH it (not instead of it).
         if not resolved:
-            # #2081: an UNBOUND delegate under delegation.capability_default=deny
-            # gets the restrictive _delegate floor (a binding above would have
-            # replaced it). The delegate-ness propagates recursively — every A2A
-            # request-path load passes is_delegate=True regardless of the spawner's
-            # own status — so a re-granted coordinator's sub-delegate is STILL
-            # default-denied (no laundering).
             effective_delegate = (
                 self._constructing_as_delegate if is_delegate is None else is_delegate
             )
             if effective_delegate and self._delegation_capability_default == "deny":
-                return compose_resolved([
-                    resolve_profile(load_delegate_profile(self._project_root))
-                ])
+                resolved.append(resolve_profile(load_delegate_profile(self._project_root)))
+
+        # #2103 S1a: the per-session config is an ADDITIONAL restrict-only ∩ conjunct
+        # (the spawner-set, workspace-backed narrowing) — composed into the single
+        # ContextualLayer, never re-granting (structural). Inert when sid is None or
+        # no config.yaml exists → byte-identical.
+        if sid is not None:
+            ps = self._load_per_session_capability_profile(agent, sid)
+            if ps is not None:
+                resolved.append(resolve_profile(ps))
+
+        if not resolved:
             return None, frozenset()
         return compose_resolved(resolved)
+
+    def _load_per_session_capability_profile(
+        self, name: str, sid: str
+    ) -> "object | None":
+        """#2103 S1a: load the per-session capability narrowing for ``(name, sid)`` —
+        ``<session-state-dir>/config.yaml`` (a capability_profile YAML, sibling of the
+        per-session snapshot.json; workspace-backed P5). ``None`` when absent. A
+        malformed file is surfaced (stderr) and skipped — a typo must not crash
+        session construction, and (restrict-only) skipping it only WIDENS toward the
+        agent envelope, never past it."""
+        from reyn.security.permissions.capability_profile import load_capability_profile
+        path = self._session_state_dir(name, sid) / "config.yaml"
+        if not path.is_file():
+            return None
+        try:
+            return load_capability_profile(path)
+        except Exception as e:  # noqa: BLE001 — hand/LLM-written yaml, surface not crash
+            import sys
+            print(
+                f"warning: skipping malformed per-session config {path}: {e}",
+                file=sys.stderr,
+            )
+            return None
 
     def permit(self, from_agent: str, to_agent: str) -> bool:
         """Return True iff some shared topology permits from→to.

--- a/tests/test_2103_s1a_per_session_config.py
+++ b/tests/test_2103_s1a_per_session_config.py
@@ -1,0 +1,137 @@
+"""Tier 2: #2103 S1a — the per-session-config 4th COMBINE layer (capability narrowing).
+
+A spawner can narrow a spawned session's capability via a workspace-backed (P5)
+per-session ``config.yaml`` (``.reyn/agents/<name>/state/sessions/<sid>/config.yaml`` —
+a capability_profile YAML, sibling of the per-session snapshot). It composes via the
+EXISTING #2074 machinery (resolve_profile + compose_resolved ∩) folded into the single
+ContextualLayer — NO 4th EffectivePermission conjunct. Restrict-only is structural:
+ContextualLayer is one conjunct in ``all(...)``, so the per-session layer can only
+narrow within the agent envelope, never re-grant.
+
+S1a is the LAYER only (inert until a spawner writes the config — the session_spawn tool
+is S1bc). Tested directly via resolved_profile_for(name, sid=...).
+
+No mocks: a real AgentRegistry + real on-disk topology/profile/per-session YAML.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import ContextualPermission
+
+
+def _registry(tmp_path: Path, *, default: str = "inherit") -> AgentRegistry:
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda profile: None,
+        delegation_capability_default=default,
+    )
+
+
+def _write_per_session(reg: AgentRegistry, name: str, sid: str, body: str) -> None:
+    d = reg._session_state_dir(name, sid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _bind_topology(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / "t.yaml").write_text(
+        f"name: t\nkind: network\nmembers: [{member}, peer]\nprofiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+# ── the per-session narrowing applies ───────────────────────────────────────
+
+
+def test_per_session_config_narrows(tmp_path: Path) -> None:
+    """Tier 2: a per-session config.yaml narrows the session's capability (a denied
+    tool is denied in the resolved ContextualPermission)."""
+    reg = _registry(tmp_path)
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [sandboxed_exec]\n")
+    contextual, _ = reg.resolved_profile_for("worker", sid="task1")
+    assert isinstance(contextual, ContextualPermission)
+    assert "sandboxed_exec" in contextual.tool_deny
+
+
+def test_absent_per_session_is_inert(tmp_path: Path) -> None:
+    """Tier 2: sid given but NO config.yaml → (None, ∅), unchanged from no narrowing
+    (inert-until-spawn)."""
+    reg = _registry(tmp_path)
+    assert reg.resolved_profile_for("worker", sid="task1") == (None, frozenset())
+
+
+def test_sid_none_skips_per_session_layer(tmp_path: Path) -> None:
+    """Tier 2: sid=None (the default — every current caller) → per-session layer is
+    never consulted, even if a config.yaml happens to exist."""
+    reg = _registry(tmp_path)
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [sandboxed_exec]\n")
+    assert reg.resolved_profile_for("worker") == (None, frozenset())  # sid omitted
+
+
+# ── composes ∩ with the topology binding ────────────────────────────────────
+
+
+def test_composes_with_topology_binding(tmp_path: Path) -> None:
+    """Tier 2: the per-session narrowing composes (∪-deny) with the topology-bound
+    profile — both denials apply (one combined ContextualLayer)."""
+    _bind_topology(tmp_path, member="worker", profile="role",
+                   body="name: role\ntool_deny: [delete_file]\n")
+    reg = _registry(tmp_path)
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [sandboxed_exec]\n")
+    contextual, _ = reg.resolved_profile_for("worker", sid="task1")
+    assert {"delete_file", "sandboxed_exec"} <= contextual.tool_deny  # both layers
+
+
+# ── restrict-only: the per-session layer can NEVER re-grant ─────────────────
+
+
+def test_per_session_cannot_regrant_topology_deny(tmp_path: Path) -> None:
+    """Tier 2: restrict-only (structural) — a per-session config that allow-lists a
+    tool the TOPOLOGY denies does NOT re-grant it (∪-deny wins; the per-session layer
+    is one more conjunct, can only narrow)."""
+    _bind_topology(tmp_path, member="worker", profile="role",
+                   body="name: role\ntool_deny: [delete_file]\n")
+    reg = _registry(tmp_path)
+    # the per-session config tries to ALLOW delete_file (+ another) — must not re-grant
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_allow: [delete_file, read_file]\n")
+    contextual, _ = reg.resolved_profile_for("worker", sid="task1")
+    assert "delete_file" in contextual.tool_deny  # topology deny survives the allow-list
+
+
+# ── composes with the #2081 _delegate floor (delegate + per-session) ─────────
+
+
+def test_composes_with_delegate_floor(tmp_path: Path) -> None:
+    """Tier 2: an unbound delegate (deny) with a per-session config gets BOTH the
+    _delegate floor AND the per-session narrowing (the floor is a conjunct now, so the
+    per-session layer composes WITH it, not instead of it)."""
+    reg = _registry(tmp_path, default="deny")
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [read_file]\n")
+    contextual, _ = reg.resolved_profile_for("worker", sid="task1", is_delegate=True)
+    assert "delegate_to_agent" in contextual.tool_deny  # the _delegate floor
+    assert "read_file" in contextual.tool_deny           # the per-session narrowing
+
+
+def test_2081_floor_unchanged_when_sid_none(tmp_path: Path) -> None:
+    """Tier 2: #2081 regression — sid=None (every current caller) leaves the unbound-
+    delegate floor unchanged (the restructure is behavior-preserving)."""
+    from reyn.security.permissions.capability_profile import _BUILTIN_UNTRUSTED_DENY
+    reg = _registry(tmp_path, default="deny")
+    contextual, _ = reg.resolved_profile_for("solo", is_delegate=True)  # sid omitted
+    assert _BUILTIN_UNTRUSTED_DENY <= contextual.tool_deny
+
+
+def test_malformed_per_session_skipped(tmp_path: Path) -> None:
+    """Tier 2: a per-session config.yaml with invalid YAML syntax is skipped (surfaced
+    on stderr, not a crash); with no other layer → (None, ∅). Restrict-only safety:
+    skipping only widens toward the agent envelope, never past it."""
+    reg = _registry(tmp_path)
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [unclosed\n")  # invalid YAML
+    assert reg.resolved_profile_for("worker", sid="task1") == (None, frozenset())


### PR DESCRIPTION
**[e2e-coder]** — #2103 spawn-primitives, **S1a** — the per-session-config layer (the standalone-valuable first deliverable). Pre-gate cleared (dogfood-coder's durability vet), slicing approved, S1a design-call confirmed. No-merge — close-review.

## What

A spawner can narrow a (spawned) session's capability via a workspace-backed (P5) per-session config: `.reyn/agents/<name>/state/sessions/<sid>/config.yaml` (a capability_profile YAML, sibling of the per-session `snapshot.json`).

- **Reuses #2074** — `resolve_profile` + `compose_resolved` (∩) folds the per-session narrowing into the **single** `ContextualLayer` (no 4th `EffectivePermission` conjunct).
- **Restrict-only is structural** — `ContextualLayer` is one conjunct in `EffectivePermission.allows`'s `all(...)`, so the per-session layer can only narrow within the agent envelope, **never re-grant**.
- `resolved_profile_for` gains `sid` (keyword-only, default `None`). The **#2081 `_delegate` floor is now an appended conjunct** (not an early-return), so a per-session narrowing composes **with** the floor (delegate + per-session → floor ∩ per-session). Behavior-preserving for #2081 when `sid=None`.

**S1a is the LAYER only — inert until a spawner writes the config** (the `session_spawn` tool + its ephemeral lifecycle WAL = S1bc, landed **together** per the cleared gate, so a spawn tool never lands without its rewind-integration). `sid=None` (every current caller) → byte-identical.

## Test plan

- [x] `tests/test_2103_s1a_per_session_config.py` (Tier 2): narrows / inert-when-absent / `sid=None` skips / composes ∩ topology / **restrict-only can't re-grant a topology deny** (the key structural property) / composes with the #2081 floor / **#2081 floor unchanged when `sid=None`** (regression) / malformed-YAML skipped.
- [x] #2081 + #1827 capability regression green (the `resolved_profile_for` restructure is behavior-preserving)
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] Full suite `pytest -q -n auto --timeout=120` — **8322 passed, 18 skipped, 3 xfailed**

## Next

**S1bc** (session_spawn tool + ephemeral lifecycle WAL, together per the gate) → S2a/b (agent-spawn, dogfood owns the rewind-reconstruction) → S3 (topology-create) → S4. Refs #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)