### PR TITLE
feat(tui): curate #1953 task events in the events tab (dogfood-found)

### DIFF
--- a/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
@@ -191,6 +191,12 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "workflow_started", "workflow_finished", "workflow_aborted",
         "agent_message_sent", "agent_request_received", "agent_response_received",
     })),
+    # #1953 dynamic task-ops — the chat-log task events (ctx.events.emit). A
+    # dedicated group so task activity (create / dep-wire / readiness / abort
+    # disposition) can be isolated when debugging a multi-step plan.
+    ("task", frozenset({
+        "task_op", "task_readiness", "task_disposition", "task_dependency_aborted",
+    })),
     ("error", frozenset({
         "validation_error", "phase_retry", "permission_denied",
         "router_retry_exhausted", "tool_failed", "mcp_failed",
@@ -198,6 +204,9 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "recall_embed_failed", "postprocessor_step_failed", "workflow_aborted",
         "phase_failed", "skill_run_failed", "control_ir_failed",
         "web_search_failed", "normalization_error", "compaction_failed",
+        # #1953: a dependency abort leaving live dependents stuck — a
+        # recovery-relevant signal, so it also shows under the error filter.
+        "task_dependency_aborted",
         # W13 A#8: add events with hard-stop / terminal semantics that
         # were missing from the error filter.
         # ``safety_limit_checkpoint`` can carry a hard-stop signal
@@ -298,6 +307,16 @@ def _event_hint(ev: dict) -> str:
         rc = d.get("returncode")
         rc_part = "" if rc in (0, None) else f" rc={rc}"
         return f"{d.get('mode', 'shell')}: {cmd}" + ("…" if was_trunc else "") + rc_part
+    # #1953 dynamic task-ops — the chat-log task events.
+    if t == "task_op":
+        return f"{d.get('op', '')} [{str(d.get('task_id', ''))[:8]}]"
+    if t == "task_readiness":
+        return f"{str(d.get('task_id', ''))[:8]} → {d.get('to', '')}"
+    if t == "task_disposition":
+        return f"{d.get('disposition', '')} [{str(d.get('task_id', ''))[:8]}]"
+    if t == "task_dependency_aborted":
+        stuck = d.get("dependents") or []
+        return f"{d.get('disposition', '')}: {len(stuck)} dependent(s) stuck"
     if t in ("mcp_called", "mcp_completed"):
         suffix = " ✗" if d.get("is_error") else ""
         return f"{d.get('server', '')}.{d.get('tool', '')}{suffix}"

--- a/tests/cli/test_events_tab_task_hints.py
+++ b/tests/cli/test_events_tab_task_hints.py
@@ -1,0 +1,75 @@
+"""Tier 2: events-tab curation for the #1953 dynamic task-ops events.
+
+Dogfood-found (live `reyn chat`): the chat-log task events (`task_op`,
+`task_readiness`, `task_disposition`, `task_dependency_aborted`) had NO
+``_event_hint`` case (blank annotation) and were in NO filter group (couldn't be
+isolated; hidden under any non-"all" filter). These pin that each task event
+renders a useful hint and that the "task" filter group spans them.
+
+Exercises the public ``_event_hint`` + the ``_FILTER_GROUPS`` table directly —
+no mocks, no private state, no golden output.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.interfaces.tui.widgets.right_panel.events_tab import (  # noqa: E402
+    _FILTER_GROUPS,
+    _event_hint,
+)
+
+
+def _hint(t: str, data: dict) -> str:
+    return _event_hint({"type": t, "data": data})
+
+
+def test_task_op_hint_names_op_and_id() -> None:
+    """Tier 2: task_op hint surfaces the op kind + short task id."""
+    h = _hint("task_op", {"op": "task.create", "task_id": "d93abb2c4764420c"})
+    assert "task.create" in h
+    assert "d93abb2c" in h
+
+
+def test_task_readiness_hint_shows_transition() -> None:
+    """Tier 2: task_readiness hint shows the id and the target state."""
+    h = _hint("task_readiness", {"task_id": "ea51deed3056", "to": "ready"})
+    assert "ea51deed" in h
+    assert "ready" in h
+
+
+def test_task_disposition_hint_shows_disposition() -> None:
+    """Tier 2: task_disposition hint surfaces the terminal disposition + id."""
+    h = _hint("task_disposition", {"disposition": "aborted", "task_id": "b4ee8c67abcd"})
+    assert "aborted" in h
+    assert "b4ee8c67" in h
+
+
+def test_task_dependency_aborted_hint_counts_stuck_dependents() -> None:
+    """Tier 2: task_dependency_aborted hint surfaces how many dependents are stuck
+    (the recovery-relevant signal)."""
+    h = _hint("task_dependency_aborted", {
+        "disposition": "aborted",
+        "dependents": ["ea51deed3056", "fdff67f6e500"],
+    })
+    assert "aborted" in h
+    assert "2" in h
+
+
+def test_task_events_are_filterable() -> None:
+    """Tier 2: the four chat-log task events live in the "task" filter group, and
+    task_dependency_aborted also surfaces under "error" (stuck-dependent signal)."""
+    groups = {label: members for label, members in _FILTER_GROUPS}
+    assert "task" in groups
+    for t in ("task_op", "task_readiness", "task_disposition", "task_dependency_aborted"):
+        assert t in groups["task"], f"{t} missing from the task filter group"
+    assert "task_dependency_aborted" in groups["error"]
+
+
+def test_unknown_task_event_does_not_crash() -> None:
+    """Tier 2: an unrecognized type still returns a string (blank), never raises."""
+    assert isinstance(_hint("task_some_future_event", {"x": 1}), str)


### PR DESCRIPTION
**[tui-coder]** — dogfood-found TUI-lane coverage gap (surfaced to lead; my lane, additive). The #1953 dynamic task-ops events were **uncurated in the events tab**.

## Found via
Live `reyn chat` (weak model, production default) mining: built a flat task plan (`task__create` + `task__add_dependency`) and aborted a task. The generated chat-log task events (`task_op` / `task_readiness` / `task_disposition` / `task_dependency_aborted`) showed in the events tab under "all" with the type name **but no hint detail**, and were in **no filter group** (couldn't be isolated; hidden under any non-"all" filter).

## What changed (events_tab.py — additive)
- **`_event_hint` cases** for the 4 chat-log task events:
  - `task_op` → `"task.create [d93abb2c]"`
  - `task_readiness` → `"ea51deed → ready"`
  - `task_disposition` → `"aborted [b4ee8c67]"`
  - `task_dependency_aborted` → `"aborted: N dependent(s) stuck"` (surfaces the recovery-relevant stuck count)
- New **"task" filter group** spanning the four — isolate task activity when debugging a multi-step plan.
- `task_dependency_aborted` also added to the **"error"** group (it signals stuck dependents).

No behavior change beyond rendering/filtering; events already flowed (this curates them).

## Test plan
- [x] `pytest tests/cli/test_events_tab_task_hints.py` — 6 Tier-2 (each task event renders a useful hint; the four are in the "task" group; task_dependency_aborted also in "error"; unknown type → blank, no crash).
- [x] `pytest tests/cli/test_events_tab_cjk_hint.py` green (no regression).
- [x] `pytest tests/cli` green.
- [x] `ruff` + `tier_audit --strict` clean.
- [ ] (skipped — display verify) live events-tab render of the new hints — the hint strings are unit-pinned + the events-tab render path was live-verified in the #2095 e2e; chord-nav to a specific tab is flaky via send-keys (Ctrl+digit, separate known limit).

Doc follow-up: events.md reference lacks the #1953 task events — flagged to docs-maintainer.

**Tier self-check:** 6 Tier-2 (public `_event_hint` + `_FILTER_GROUPS` exercised directly; behavior on content, no size/format pins, no private state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
