### PR TITLE
docs: add task management events to events.md reference (#1953)

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -106,6 +106,17 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 | `skill_run_spawned` | ルーターの決定から Skill が起動されたとき（`run_id`、`skill`） |
 | `skill_spawn_refused` | `_spawn_skill` が agent の `allowed_skills` にない Skill を拒否したとき。ペイロード: `reason="allowlist"`、`skill`、`agent` |
 
+## タスク管理
+
+タスク Control IR op（`task.py`）が発行するイベントです。
+
+| 種類 | タイミング | 主要なペイロード |
+|------|------|-------------|
+| `task_op` | 任意のタスク変更操作が完了したとき（create / update-status / complete / abort） | `op`（op 種類文字列）、`task_id`、op 固有フィールド |
+| `task_readiness` | タスクが `ready` または `blocked` に遷移したとき（OS の再導出で readiness が変化） | `task_id`、`to`（`"ready"` または `"blocked"`）、`trigger`（変化を引き起こした op の task_id） |
+| `task_disposition` | 中断されたサブツリー内の各タスクが終端状態に達したとき | `task_id`、`disposition`（`"aborted"`）、`requester`、`origin`、`root`（ルート abort op の task_id） |
+| `task_dependency_aborted` | タスクの依存先が非完了終端に達し、親セッションが復旧を決定する必要があるとき | `task_id`（終端タスク）、`disposition`、`parent_id`、`parent_session`、`dependents`（stuck 状態の task_id リスト） |
+
 ## agent 間メッセージング
 
 | 種類 | タイミング | 主要なペイロード |

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -109,6 +109,17 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 | `skill_spawn_refused` | `_spawn_skill` rejected a skill not in the agent's `allowed_skills`. Payload: `reason="allowlist"`, `skill`, `agent` |
 | `skill_node_started` | A skill-graph node began executing (sub-skill node in a composite skill graph). Payload: `node` (node id), `skill_path`. |
 
+## Task management
+
+Events emitted by the task Control IR ops (`task.py`).
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `task_op` | Any mutating task operation completes (create / update-status / complete / abort) | `op` (op kind string), `task_id`, plus op-specific fields |
+| `task_readiness` | A task transitions to `ready` or `blocked` (OS re-derive changed readiness) | `task_id`, `to` (`"ready"` or `"blocked"`), `trigger` (task_id of the op that caused the change) |
+| `task_disposition` | Each task in an aborted subtree reaches its terminal disposition | `task_id`, `disposition` (`"aborted"`), `requester`, `origin`, `root` (task_id of the root abort op) |
+| `task_dependency_aborted` | A task's dependency reached a non-completed terminal; its parent session is notified to decide recovery | `task_id` (the terminal task), `disposition`, `parent_id`, `parent_session`, `dependents` (list of task_ids that are now stuck) |
+
 ## Agent-to-agent messaging
 
 | Kind | When | Key payload |


### PR DESCRIPTION
**[docs-maintainer]** — doc gap fix flagged by tui-coder (dogfood-found).

## Summary

- `docs/reference/runtime/events.md` + `events.ja.md`: new **Task management** section documenting the 4 P6 events emitted by `task.py` that were absent from the reference.

## Gap details

`task_op`, `task_readiness`, `task_disposition`, `task_dependency_aborted` are real P6 events emitted by `src/reyn/core/op_runtime/task.py` (verified at emit sites L67/L251/L325/L366/L434). PR #2108 (open) adds TUI Events-tab hints + "task" filter group for these events — the reference doc gap is independent and should land before or alongside it.

## Accuracy verification

All 4 events and their payload fields sourced directly from `task.py` at origin/main:

| Event | Emission site | Key fields |
|-------|--------------|------------|
| `task_op` | L67 `_audit()` | `op`, `task_id`, op-specific |
| `task_readiness` | L251, L325 | `task_id`, `to`, `trigger` |
| `task_dependency_aborted` | L367 | `task_id`, `disposition`, `parent_id`, `parent_session`, `dependents` |
| `task_disposition` | L435 | `task_id`, `disposition`, `requester`, `origin`, `root` |

No inline `#issue` refs in docs (no-history-refs rule for reference/).

## Test plan

- [x] mkdocs --strict: 0 warnings, exit 0
- [x] ruff check src tests: N/A (docs-only)
- [x] Page drop: zero (no pages removed, no nav change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)