### PR TITLE
fix(#2111): CRITICAL — capability floor denies every invocable form (bare + qualified)

### DIFF
--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -211,7 +211,17 @@ UNTRUSTED_PROFILE_NAME: "str" = "_untrusted"
 # Grouped by CLASS (#2081 S3): the runtime FLOOR is the flat union below; the
 # delegation-unsafe AUDIT (DELEGATION_AUDIT_CLASSES) derives its FLOORED classes +
 # severities from these same groups — so the floor and the audit cannot drift apart.
-_FLOORED_DENY_CLASSES: "dict[str, frozenset[str]]" = {
+#
+# #2111 (CRITICAL fix): each class is defined by its QUALIFIED (universal-catalog)
+# names; the bare/unwrapped aliases are DERIVED from the invoke_action unwrap
+# source-of-truth (``unwrapped_tool_name``) — so EVERY invocable form (bare AND
+# qualified) is denied on EVERY scheme path, COMPLETE-BY-CONSTRUCTION. (The prior
+# manual lists missed the bare memory-write + mcp-install aliases — a delegate / an
+# untrusted-content turn could call bare ``remember_shared`` and persist to shared
+# memory. Deriving kills that gap-class at the root: a new floored tool can't miss
+# its alias.) Shared by BOTH floors (builtin_untrusted_profile + builtin_delegate_
+# profile), so this closes the gap on both surfaces.
+_FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     # memory writes / deletes — no persistence from untrusted content
     "memory-write": frozenset({
         "memory_operation__remember_shared",
@@ -219,13 +229,30 @@ _FLOORED_DENY_CLASSES: "dict[str, frozenset[str]]" = {
         "memory_operation__forget",
     }),
     # re-delegation — no spawning peers from untrusted content
-    "re-delegation": frozenset({"multi_agent__delegate", "delegate_to_agent"}),
+    "re-delegation": frozenset({"multi_agent__delegate"}),
     # code execution
-    "exec": frozenset({"exec__sandboxed_exec", "sandboxed_exec"}),
+    "exec": frozenset({"exec__sandboxed_exec"}),
     # MCP install — no installing servers from untrusted content
     "mcp-install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
     }),
+}
+
+
+def _with_unwrapped_aliases(qualified: "frozenset[str]") -> "frozenset[str]":
+    """Each qualified name PLUS its bare unwrapped alias (from the invoke_action
+    source-of-truth) — every invocable form, complete-by-construction (#2111)."""
+    from reyn.tools.universal_dispatch import unwrapped_tool_name
+    forms = set(qualified)
+    for q in qualified:
+        bare = unwrapped_tool_name(q)
+        if bare is not None:
+            forms.add(bare)
+    return frozenset(forms)
+
+
+_FLOORED_DENY_CLASSES: "dict[str, frozenset[str]]" = {
+    cls: _with_unwrapped_aliases(q) for cls, q in _FLOORED_QUALIFIED.items()
 }
 _BUILTIN_UNTRUSTED_DENY: "frozenset[str]" = frozenset().union(*_FLOORED_DENY_CLASSES.values())
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -518,12 +518,28 @@ def known_qualified_name_for_category(category: str) -> tuple[str, ...]:
     )
 
 
+def unwrapped_tool_name(qualified_name: str) -> "str | None":
+    """The bare/unwrapped tool name a ``qualified_name`` (universal-catalog
+    ``category__verb``) resolves to via ``invoke_action`` — the SOURCE OF TRUTH for
+    the qualified↔bare alias (e.g. ``memory_operation__remember_shared`` →
+    ``remember_shared``, ``mcp__install_registry`` → ``mcp_install_registry``).
+    ``None`` when the name has no static operation rule.
+
+    The live capability gate matches the *effective resolved name*, which differs by
+    scheme (some paths present the qualified catalog name, invoke_action unwraps to the
+    bare name). Capability floors that must deny a tool on EVERY path derive both forms
+    from here (complete-by-construction) — see #2111."""
+    rule = _OPERATION_RULES.get(qualified_name)
+    return rule[0] if rule is not None else None
+
+
 __all__ = [
     "ResolvedAction",
     "UnknownActionError",
     "resolve_invoke_action",
     "resolve_describe_action",
     "suggest_similar_names",
+    "unwrapped_tool_name",
     "KNOWN_STATIC_QUALIFIED_NAMES",
     "known_qualified_name_for_category",
 ]

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -156,11 +156,15 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "name: t\nkind: network\nmembers: [worker, peer]\nprofiles:\n  worker: tight\n",
         encoding="utf-8",
     )
+    # genuinely tight: deny BOTH the qualified catalog names AND the bare unwrapped
+    # aliases (#2111 — the audit taxonomy covers every invocable form, so a profile
+    # denying only the qualified form would still re-grant the bare one).
     (_profiles(tmp_path) / "tight.yaml").write_text(
         "name: tight\ntool_deny: [delegate_to_agent, multi_agent__delegate, sandboxed_exec, "
         "exec__sandboxed_exec, delete_file, file__delete, memory_operation__remember_shared, "
-        "memory_operation__remember_agent, memory_operation__forget, mcp__install_registry, "
-        "mcp__install_package, mcp__install_local]\n",
+        "memory_operation__remember_agent, memory_operation__forget, remember_shared, "
+        "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
+        "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local]\n",
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")

--- a/tests/test_2111_floor_alias_completeness.py
+++ b/tests/test_2111_floor_alias_completeness.py
@@ -1,0 +1,118 @@
+"""Tier 2: #2111 — the capability FLOOR denies EVERY invocable form (bare + qualified).
+
+CRITICAL security regression (tui live-probe): under delegation.capability_default=deny
+a delegate called bare ``remember_shared`` → it executed → persisted to shared memory.
+The floor's memory-write + mcp-install classes listed only the QUALIFIED catalog names
+(``memory_operation__remember_shared``), missing the bare unwrapped aliases the live
+gate actually receives. ONE root (the shared ``_FLOORED_DENY_CLASSES``), TWO surfaces:
+both ``builtin_untrusted_profile`` (#1827, always-on while untrusted content is live —
+the prompt-injection persistence surface) and ``builtin_delegate_profile`` (#2081).
+
+Fix: the floored classes are defined by their qualified names + the bare aliases are
+DERIVED from the invoke_action unwrap source-of-truth (``unwrapped_tool_name``) →
+complete-by-construction.
+
+Two guards:
+- completeness-invariant: every floored tool's bare AND qualified form ∈ the floor,
+  enumerated FROM the unwrap SoT (a future floored tool missing its alias → RED).
+- live-gate falsify: a REAL ContextualPermission from each floor, through the REAL
+  contextual gate seam (``tool_contextually_denied`` — the exact fn router_loop +
+  op-runtime call) → each form DENIED under the floor, ALLOWED under inherit/no-floor.
+  Drop a bare alias from the floor → the gate lets it through → RED (non-tautological).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.capability_profile import (
+    _BUILTIN_UNTRUSTED_DENY,
+    _FLOORED_QUALIFIED,
+    builtin_untrusted_profile,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import tool_contextually_denied
+from reyn.tools.universal_dispatch import unwrapped_tool_name
+
+
+def _all_floored_forms() -> list[str]:
+    """Every invocable form (qualified + bare unwrapped alias) of every floored tool,
+    enumerated FROM the unwrap source-of-truth — the test's expectation is derived, not
+    hand-listed, so a new floored tool is covered automatically."""
+    forms: set[str] = set()
+    for qualifieds in _FLOORED_QUALIFIED.values():
+        for q in qualifieds:
+            forms.add(q)
+            bare = unwrapped_tool_name(q)
+            if bare is not None:
+                forms.add(bare)
+    return sorted(forms)
+
+
+# ── completeness-invariant (SoT-derived) ────────────────────────────────────
+
+
+def test_every_floored_tool_has_both_forms_in_the_floor() -> None:
+    """Tier 2: each floored qualified name AND its bare unwrapped alias (from the
+    invoke_action SoT) is in the floor. A future floored tool whose bare alias is
+    missing → RED (the gap-class guard)."""
+    for cls, qualifieds in _FLOORED_QUALIFIED.items():
+        for q in qualifieds:
+            assert q in _BUILTIN_UNTRUSTED_DENY, f"{cls}: qualified {q!r} missing from floor"
+            bare = unwrapped_tool_name(q)
+            assert bare is not None, f"{cls}: {q!r} has no unwrap alias in the SoT"
+            assert bare in _BUILTIN_UNTRUSTED_DENY, (
+                f"{cls}: bare alias {bare!r} of {q!r} missing from floor — the live gate "
+                "receives the bare form (#2111 regression)"
+            )
+
+
+def test_bare_memory_write_aliases_present() -> None:
+    """Tier 2: the exact tui-probe regression — bare memory-write aliases are denied
+    (the form that slipped through and persisted to shared memory)."""
+    assert {"remember_shared", "remember_agent", "forget_memory"} <= _BUILTIN_UNTRUSTED_DENY
+
+
+# ── live-gate falsify: REAL ContextualPermission through the REAL gate seam ──
+
+
+@pytest.mark.parametrize("tool", _all_floored_forms())
+def test_untrusted_floor_denies_every_form_at_the_live_gate(tool: str) -> None:
+    """Tier 2: the #1827 untrusted-content floor (auto-applied while untrusted content
+    is live) DENIES every floored form (bare + qualified) at the real contextual gate.
+    Drop a bare alias → the gate lets it through → RED."""
+    contextual, _ = resolve_profile(builtin_untrusted_profile())
+    assert tool_contextually_denied(contextual, tool), (
+        f"untrusted floor does NOT deny {tool!r} at the live gate (#2111)"
+    )
+
+
+@pytest.mark.parametrize("tool", _all_floored_forms())
+def test_delegate_floor_denies_every_form_via_real_resolution(tool: str, tmp_path: Path) -> None:
+    """Tier 2: the #2081 delegate floor — through the REAL registry resolution path
+    (resolved_profile_for(is_delegate=True) under deny → ContextualPermission) → the
+    real gate seam DENIES every form. (Not a hand-built profile: the production path.)"""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None,
+        delegation_capability_default="deny",
+    )
+    contextual, _ = reg.resolved_profile_for("worker", is_delegate=True)
+    assert contextual is not None
+    assert tool_contextually_denied(contextual, tool), (
+        f"delegate floor does NOT deny {tool!r} at the live gate (#2111)"
+    )
+
+
+@pytest.mark.parametrize("tool", _all_floored_forms())
+def test_inherit_allows_every_form(tool: str, tmp_path: Path) -> None:
+    """Tier 2: regression — under capability_default=inherit (the default), an unbound
+    delegate gets NO floor → the gate ALLOWS every form (the floor is what denies; a
+    fix that over-denies under inherit would break byte-identical pre-#2081)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None,
+        delegation_capability_default="inherit",
+    )
+    contextual, _ = reg.resolved_profile_for("worker", is_delegate=True)
+    assert not tool_contextually_denied(contextual, tool)  # contextual is None → allowed


### PR DESCRIPTION
**[e2e-coder]** — CRITICAL security fix for #2111 (tui-filed, primary-evidence live-probe). I'm the #2081 author. No-merge — lead close-review against tui's repro (/tmp/reyn-2081e); tui re-runs the live probe to confirm denial.

## The defect

Under `delegation.capability_default=deny`, a delegate called **bare** `remember_shared` → it **executed** → persisted to shared memory (ZEBRA9). The shared `_FLOORED_DENY_CLASSES` memory-write + mcp-install classes listed only the **qualified** catalog names (`memory_operation__remember_shared`), missing the **bare** unwrapped aliases the live gate (`tool_contextually_denied`, exact-match) actually receives. Violated the file's own contract (capability_profile.py:208).

**One root, two surfaces** (`_BUILTIN_UNTRUSTED_DENY = union(_FLOORED_DENY_CLASSES)`): both `builtin_untrusted_profile` (#1827, always-on while untrusted content is live — the **prompt-injection persistence** surface, arguably higher-severity) and `builtin_delegate_profile` (#2081). One fix closes both.

## Fix — complete-by-construction

The floored classes are defined by their **qualified** names (`_FLOORED_QUALIFIED`); the bare aliases are **derived** from the invoke_action unwrap **source-of-truth** — a new public `unwrapped_tool_name(qualified)` over `_OPERATION_RULES`. `_with_unwrapped_aliases` adds each qualified name's bare alias → every invocable form denied on every scheme path. **A future floored tool cannot miss its alias** — the gap-class is killed at the root. (`universal_dispatch` is a stdlib-only leaf → no import cycle.)

## Test plan

- [x] **completeness-invariant** (Tier 2): every floored tool's bare AND qualified form ∈ the floor, enumerated **from the unwrap SoT** (future miss → RED).
- [x] **live-gate falsify** (parametrized over every floored form × BOTH floors): a **real** ContextualPermission — `builtin_untrusted_profile` + the real registry `resolved_profile_for(is_delegate=True)` delegate floor — through the **real gate seam** `tool_contextually_denied` DENIES every form; inherit ALLOWS (regression). **Verified RED** when the bare aliases are stripped (non-tautological).
- [x] `test_2081_s3` tight-profile updated (the audit taxonomy now covers every form — a profile denying only qualified would re-grant the bare; same gap class).
- [x] #2081 S2/S3 + #2103 S1a + #1827 capability regression green
- [x] `ruff` clean · `test_tier_audit.py --strict` 0/0
- [x] Full suite `pytest -q -n auto --timeout=120` — **8405 passed, 18 skipped, 3 xfailed**

Refs #2111

🤖 Generated with [Claude Code](https://claude.com/claude-code)