### PR TITLE
feat(#2103): generic as-of-cut DROP primitive — rewind-reconstruction foundation (S1bc→S2a)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -133,6 +133,7 @@ class AgentRegistry:
         act_turn_capture: bool = False,
         delegation_capability_default: str = "inherit",
         factory_config: "object | None" = None,
+        create_event_kinds: "frozenset[str] | None" = None,
     ) -> None:
         """
         session_factory: returns a configured Session given an AgentProfile.
@@ -173,6 +174,14 @@ class AgentRegistry:
         # unchanged (it is a caller-provided closure, 60+ construction sites).
         self._delegation_capability_default = delegation_capability_default
         self._constructing_as_delegate = False
+        # #2103: WAL kinds the as-of-cut DROP primitive treats as entity-creates.
+        # Each such event carries {entity_kind: "agent"|"session", name, sid?}; on
+        # rewind, an entity whose create-event seq > the cut is torn down (it did
+        # not exist as-of-cut) instead of lingering as an empty-snapshot orphan.
+        # Empty by default → the primitive is a byte-identical no-op until
+        # session_spawned (S1bc) / agent_created (S2) register their kinds. The
+        # create-side inverse of the #1954 archive (delete-side).
+        self._create_event_kinds = create_event_kinds or frozenset()
         # FP-0043 Stage 3: the Registry holds N conversation Sessions per Agent.
         # Identity (the Agent value object, S2) is shared per name; the
         # conversation instances (= today's Session, inbox+run-loop+history)
@@ -1062,6 +1071,45 @@ class AgentRegistry:
             )
         return self._anchor_store
 
+    def _created_at_map(self) -> "dict[tuple[str, str, str], int]":
+        """#2103: (entity_kind, name, sid) → the WAL seq at which the entity was
+        created, scanned from the registered create-event kinds. Empty when no
+        kinds are registered (the no-op default) or there is no WAL. Drives the
+        as-of-cut DROP primitive in ``_materialize_rewind``."""
+        if not self._create_event_kinds or self._state_log is None:
+            return {}
+        created: dict[tuple[str, str, str], int] = {}
+        for entry in self._state_log.iter_from(0):
+            if entry.get("kind") not in self._create_event_kinds:
+                continue
+            seq = entry.get("seq")
+            if not isinstance(seq, int):
+                continue
+            key = (
+                str(entry.get("entity_kind", "")),
+                str(entry.get("name", "")),
+                str(entry.get("sid", "")),
+            )
+            created[key] = seq  # a create is unique; last-write-wins is moot
+        return created
+
+    def _drop_agent(self, name: str) -> None:
+        """#2103: tear down an agent created after the rewind cut. A post-cut agent
+        has NO pre-cut generations → nothing to preserve → a clean drop (vs the
+        #1954 archive HIDE on the delete side). rmtree subsumes the agent's sessions
+        (they nest under the agent dir). Best-effort; never raises into rewind."""
+        import shutil
+        shutil.rmtree(self._dir / name, ignore_errors=True)
+
+    async def _drop_session(self, name: str, sid: str) -> None:
+        """#2103 seam: tear down a single spawned session created after the cut.
+        Wired in S1bc with ``session_spawned`` (e2e's session lifecycle =
+        ``remove_session``). Unreached in the foundation — no session create-kinds
+        are registered, so agent-level ``_drop_agent`` subsumes sessions."""
+        raise NotImplementedError(
+            "#2103: session-drop is wired with session_spawned (S1bc)"
+        )
+
     async def _materialize_rewind(
         self, *, reconstruct_seq: int, workspace_at_or_below: int,
     ) -> list[str]:
@@ -1086,8 +1134,28 @@ class AgentRegistry:
         # (one SSoT per agent) and is restored once below. Session discovery is from
         # disk (this is shared with crash-recovery, where sessions are not loaded).
         agents: list[str] = []
+        created_at = self._created_at_map()   # #2103: as-of-cut DROP input (empty → no-op)
+        # #2103: the existence cut is the rewind TARGET (``workspace_at_or_below`` =
+        # target_n), NOT ``reconstruct_seq`` (= R, the reset-record head). An entity
+        # whose create-seq > target didn't exist as-of-target → drop it. In crash
+        # recovery ``workspace_at_or_below`` = head, so create-seq > head is never
+        # true → no spurious drops (recovery reconstructs the present, not a rewind).
+        drop_cut = workspace_at_or_below
         for name in self.list_names():
+            # An agent created after the cut → tear it down (subsumes its sessions,
+            # nested under the agent dir) instead of leaving an empty-snapshot
+            # orphan. Reversible: a forward-checkout past the create re-materialises
+            # it from the agent_created WAL record.
+            agent_seq = created_at.get(("agent", name, ""))
+            if agent_seq is not None and agent_seq > drop_cut:
+                self._drop_agent(name)
+                continue
             for sid in self._discover_session_ids(name):
+                # A session spawned after the cut → drop just that session.
+                sess_seq = created_at.get(("session", name, sid))
+                if sess_seq is not None and sess_seq > drop_cut:
+                    await self._drop_session(name, sid)
+                    continue
                 store = self._store_for(name, sid)
                 snap = reconstruct(
                     name, store, self._state_log,

--- a/tests/test_rewind_drop_primitive_2103.py
+++ b/tests/test_rewind_drop_primitive_2103.py
@@ -1,0 +1,141 @@
+"""Tier 2: OS invariant — #2103 as-of-cut DROP primitive (rewind-reconstruction).
+
+The foundation for the spawn-primitive rewind-integration: on reconstruct-to-cut,
+an entity whose create-event WAL seq > the rewind target DID NOT exist as-of-cut,
+so it is torn down (dropped) instead of lingering as an empty-snapshot orphan on
+disk. The create-side INVERSE of the #1954 archive (delete-side HIDE).
+
+Standalone slice: driven by a SYNTHETIC create-event kind (no dependency on the
+real session_spawned/agent_created, which register into the same seam in S1bc/S2).
+Real AgentRegistry + StateLog + on-disk agents (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events import state_log as state_log_mod
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+_SYNTH_CREATE = "test_create_event"
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+        create_event_kinds=frozenset({_SYNTH_CREATE}),
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _allow_synth_kind(monkeypatch) -> None:
+    # Permit appending the synthetic create-event (state_log.append gates on the
+    # module-level WAL_EVENT_KINDS allowlist). pytest monkeypatch — not a mock.
+    monkeypatch.setattr(
+        state_log_mod, "WAL_EVENT_KINDS",
+        tuple(state_log_mod.WAL_EVENT_KINDS) + (_SYNTH_CREATE,),
+    )
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+async def _emit_create(log: StateLog, name: str, *, sid: str = "") -> int:
+    kind = "session" if sid else "agent"
+    return await log.append(_SYNTH_CREATE, entity_kind=kind, name=name, sid=sid)
+
+
+def _agent_dir(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name
+
+
+@pytest.mark.asyncio
+async def test_agent_created_after_cut_is_dropped(tmp_path, monkeypatch):
+    """Tier 2: rewind-to-before an agent's create DROPS it (the headline) — it
+    didn't exist as-of-cut, so it is torn down, not left as an empty-snapshot
+    orphan. Asserted against the real rewind_to → _materialize_rewind path."""
+    _allow_synth_kind(monkeypatch)
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "survivor")
+    _seed_agent(tmp_path, "victim")
+    log = reg.state_log
+    await _put(log, "survivor", "s1")        # seq 1 (the rewind target)
+    await _emit_create(log, "victim")        # seq 2 — victim created AFTER the cut
+    await _put(log, "victim", "v1")          # seq 3
+
+    result = await reg.rewind_to(1)          # cut = 1 < victim's create-seq 2
+
+    assert not _agent_dir(tmp_path, "victim").exists()   # dropped
+    assert "victim" not in reg.list_names()
+    assert "survivor" in result["agents"]                # untouched
+    assert _agent_dir(tmp_path, "survivor").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_agent_drop_subsumes_its_sessions(tmp_path, monkeypatch):
+    """Tier 2: dropping a post-cut agent tears down its sessions too (they nest
+    under the agent dir) — no orphaned session left behind."""
+    _allow_synth_kind(monkeypatch)
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "victim")
+    sess_dir = _agent_dir(tmp_path, "victim") / "state" / "sessions" / "task1"
+    sess_dir.mkdir(parents=True)
+    (sess_dir / "snapshot.json").write_text("{}", encoding="utf-8")
+    log = reg.state_log
+    await _put(log, "victim", "pre")         # seq 1 (the rewind target)
+    await _emit_create(log, "victim")        # seq 2 — created after the cut
+
+    await reg.rewind_to(1)
+
+    assert not _agent_dir(tmp_path, "victim").exists()   # agent gone
+    assert not sess_dir.exists()                         # + its session subsumed
+
+
+@pytest.mark.asyncio
+async def test_agent_without_create_event_is_never_dropped(tmp_path, monkeypatch):
+    """Tier 2: no-op safety — an agent with NO recorded create-event is never
+    dropped — only entities with a create-seq > cut are torn down, so a
+    pre-existing agent reconstructs as today."""
+    _allow_synth_kind(monkeypatch)
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "kept")            # seeded; no create-event emitted
+    log = reg.state_log
+    await _put(log, "kept", "a")             # seq 1
+    await _put(log, "kept", "b")             # seq 2
+
+    result = await reg.rewind_to(1)
+
+    assert _agent_dir(tmp_path, "kept").is_dir()   # not dropped (no create-event)
+    assert "kept" in result["agents"]
+
+
+@pytest.mark.asyncio
+async def test_agent_created_at_or_before_cut_is_kept(tmp_path, monkeypatch):
+    """Tier 2: boundary — an agent whose create-seq is at-or-below the cut existed
+    as-of-cut → kept (reconstructed), not dropped."""
+    _allow_synth_kind(monkeypatch)
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "victim")
+    log = reg.state_log
+    await _emit_create(log, "victim")        # seq 1 — created AT the cut
+    await _put(log, "victim", "v1")          # seq 2
+
+    result = await reg.rewind_to(1)          # cut == create-seq → existed as-of-cut
+
+    assert _agent_dir(tmp_path, "victim").is_dir()   # kept
+    assert "victim" in result["agents"]


### PR DESCRIPTION
**[dogfood-coder]** — #2103 foundation slice (the as-of-cut DROP primitive), per the design approved on #2103. No-merge — lead close-review. e2e: the `_drop_session` seam is yours to wire in S1bc (below).

## What
On reconstruct-to-cut, an entity whose create-event WAL seq > the rewind target did NOT exist as-of-cut → it is TORN DOWN (dropped) instead of lingering as an empty-snapshot orphan on disk. The **create-side inverse of the #1954 archive** (delete-side HIDE) — the unified create+delete lifecycle.

The gap (e2e's recon + my #1954 grounding): session/agent existence is **disk-derived** (`_discover_session_ids`/`list_names`), not WAL-reconstructed — so `_materialize_rewind` reconstructs a post-cut-created entity to an empty snapshot while its dir lingers = orphan.

## How (registry.py)
- **`create_event_kinds`** (constructor param, default empty → **byte-identical no-op**): the WAL kinds treated as entity-creates; each carries `{entity_kind: "agent"|"session", name, sid?}`.
- **`_created_at_map`**: scans the WAL for those kinds → `{(kind,name,sid) → create_seq}`.
- **`_materialize_rewind`**: the cut = **`workspace_at_or_below`** (the rewind TARGET), **not** `reconstruct_seq` (= R, the reset-record head). *Correctness*: an entity created at seq 2, rewind-to-1 → `2 > 1` drops it; using R≈4 would wrongly keep it. Crash-recovery uses `workspace_at_or_below = head` → `create_seq > head` never true → **no spurious drops**. An agent with `create_seq > cut` → `_drop_agent` (rmtree — subsumes its nested sessions); a session → `_drop_session`.
- **Drop vs hide**: a post-cut entity has NO pre-cut generations → nothing to keep → clean DROP (vs #1954 archive HIDE). Reversibility (forward-checkout re-create-from-WAL) lands in **S2** with `agent_created` carrying the config; this slice is the drop half.

## e2e seam (S1bc)
`_drop_session(name, sid)` raises `NotImplementedError` in the foundation — it's **unreached** (no session create-kinds registered → agent-level `_drop_agent` subsumes sessions). e2e wires it to `remove_session` in S1bc when `session_spawned` registers; `agent_created` (S2, me) registers the agent kind.

## Standalone + tests (Tier 2, real registry + StateLog)
Driven by a **synthetic create-event kind** (decoupled from session_spawned/agent_created):
- rewind-before-create → **DROPPED** (dir gone, absent from `list_names`) [headline].
- agent-drop **subsumes its sessions** (nested under the agent dir) [lead's completeness case].
- agent with **no create-event** → never dropped [no-op safety].
- created **at-or-before cut** → kept (reconstructed) [boundary].

## Verify (all 3 gates, on origin/main @ 0b60e979 + this)
- 4 #2103 tests + rewind/#1954-archive regression → **25 passed**.
- **Full `-n auto` → 8334 passed, 0 failed.**
- `ruff` clean; `tier-audit` 4/0/0.
- Cherry-picked onto current origin/main; the `__init__` conflict with #2081/#2093 params resolved as union.

## Forward deps (not this slice, per lead)
- **S2**: `agent_created` WAL event (config-complete → re-create-from-WAL reversibility) + the #1954-archive-WAL-logging residual.
- **S3-radar**: topology-membership cleanup on drop (when topology-create lands).

## Test plan
- [x] headline drop-after-cut; agent-subsumes-sessions; no-op safety; boundary
- [x] rewind/recovery regression (25 passed); full `-n auto` 0 failures; ruff; tier-audit 4/0/0

## Tier-rule self-check
- Docstrings: all 4 start exactly `Tier 2:` ✓
- Tier-4: none (no `len()==N` / format pins) ✓
- Invariant weakening: none — drop is additive; empty `create_event_kinds` → byte-identical ✓
- Mocks/private-state: none; `monkeypatch` of `WAL_EVENT_KINDS` (pytest fixture, not `unittest.mock.patch`) permits the synthetic kind ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
