### PR TITLE
fix(tui): clear async strip on rewind checkout (dogfood-found orphan)

### DIFF
--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -2771,6 +2771,13 @@ class ReynTUIApp(App):
                     f"· {len(agents)} agent(s) reset · in-flight cancelled"
                 ),
             ))
+            # The checkout cancels in-flight work + resets the agent(s), which
+            # orphans the bottom async-strip rows: the pre-rewind skill-run
+            # entries' completion no longer routes to the strip (the agent was
+            # reset), so they'd otherwise hang as ⟳-in-flight forever with a
+            # growing elapsed counter. Reconcile by clearing the strip — same
+            # rationale as the Ctrl+L (ConversationView.clear) path.
+            conv.clear_async_tasks()
 
     def _prefill_edit(self, seq: int) -> None:
         """Load checkpoint ``seq``'s FULL user message into the InputBar (2c).

--- a/tests/cli/test_rewind_clears_async_strip.py
+++ b/tests/cli/test_rewind_clears_async_strip.py
@@ -1,0 +1,59 @@
+"""Tier 2: a rewind checkout clears the bottom async strip (orphan-fix).
+
+Dogfood-found (live `/rewind`): after a checkout that resets the agent + cancels
+in-flight work, the AsyncStackPanel kept the pre-rewind skill-run rows shown as
+⟳-in-flight forever (growing elapsed) — their completion no longer routed to the
+strip because the rewind orphaned the tracking. `_do_checkout` now reconciles by
+clearing the strip (same as the Ctrl+L / ConversationView.clear path).
+
+Real `ReynTUIApp` + real `ConversationView` + a real ``checkout``-shaped registry
+double (no mocks); asserts via the public ``async_stack_snapshot()`` surface.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+
+class _CheckoutRegistry:
+    """Real registry double exposing only the ``checkout`` _do_checkout calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    async def checkout(self, seq: int) -> dict:
+        self.calls.append(seq)
+        return {"agents": ["t"], "target_n": seq}
+
+
+@pytest.mark.asyncio
+async def test_rewind_checkout_clears_async_strip() -> None:
+    """Tier 2: ``_do_checkout`` clears the async strip so pre-rewind in-flight
+    rows don't hang as ⟳-forever after the agent reset."""
+    from reyn.interfaces.tui.app import ReynTUIApp
+    from reyn.interfaces.tui.widgets import ConversationView
+
+    app = ReynTUIApp(registry=None, agent_name="t", model="m", budget_tracker=None)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        conv = app.query_one("#conversation", ConversationView)
+        conv.add_async_task("run-1", "direct_llm")
+        conv.add_async_task("run-2", "direct_llm")
+        await pilot.pause()
+        running = [s for s in conv.async_stack_snapshot() if not s["is_overflow"]]
+        assert running, "tasks should be present in the strip pre-rewind"
+
+        # The rewind path reads self._agent_registry; inject the checkout double.
+        app._agent_registry = _CheckoutRegistry()
+        await app._do_checkout(6)
+        await pilot.pause()
+
+        assert conv.async_stack_snapshot() == [], (
+            "a rewind checkout must clear the orphaned async-strip rows"
+        )


### PR DESCRIPTION
**[tui-coder]** — dogfood-found (live `/rewind`): the bottom async strip orphans skill-run rows after a rewind. Lead-triaged finding #8(a) (my lane); (b) the OS-side cancel-vs-finished is lead's separate triage.

## The bug (trace-grounded)
`reyn chat` → spawn async `direct_llm` skill runs → `/rewind` to an earlier checkpoint while they're in-flight. The checkout reports "checked out · N agent(s) reset · in-flight cancelled", but the strip keeps showing those runs as ⟳-in-flight **forever, with a growing elapsed counter** (observed 1m13s → 3m+). Ground truth (events log, same run_ids): all `skill_run_completed` (finished). The rewind's agent-reset **orphans the strip's run-tracking** — the runs' completion no longer routes to the strip (the agent was reset), so `remove_async_task` never fires → permanent stale rows.

## Fix
`_do_checkout` (the rewind/checkout path) now calls the existing **`conv.clear_async_tasks()`** after a successful checkout — the same reconciliation the Ctrl+L (`ConversationView.clear`) path already does. A checkout cancels/orphans all in-flight work + resets the agent(s), so the pre-rewind strip rows are stale by definition; clearing them reconciles the strip with the post-rewind state. One line + a comment; the clear mechanism + snapshot surface already existed.

## Test plan
- [x] `pytest tests/cli/test_rewind_clears_async_strip.py` — 1 Tier-2 (real `ReynTUIApp` + real `ConversationView` + a real `checkout`-shaped registry double; add 2 async tasks → `_do_checkout` → assert `async_stack_snapshot() == []`). Falsifying: without the clear, the rows persist.
- [x] `pytest tests/cli -k "async_stack or rewind"` — 84 pass (no regression).
- [x] `pytest tests/cli` — green.
- [x] `ruff` + `tier_audit --strict` clean.
- [ ] Live re-verify on the fix branch (the repro that found it) — pending; the unit test deterministically pins `_do_checkout → strip cleared`, and `action_rewind_confirm` is a trivial delegation to `_do_checkout`, so the wiring is covered.

**Tier self-check:** 1 Tier-2 (public `async_stack_snapshot()` surface + real app/conv/registry-double, no mocks, no private-state assert, no format pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
