### PR TITLE
feat(#2103) S2a: agent-lifecycle rewind-reconstruction (consume side)

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -69,6 +69,14 @@ WAL_EVENT_KINDS = (
     # the abandoned future is retained as an inactive branch (reconstruct honors
     # the active path). A non-state marker — apply_events no-ops it.
     "rewind",
+    # NEW (#2103 S2) — agent-lifecycle events for rewind-reconstruction. The
+    # as-of-cut DROP primitive (#2114) + S2 reconstruct EXISTENCE from these:
+    # created → re-materialise (≤cut) or drop (>cut); archived → hide-as-of-cut;
+    # purged → permanent (out-of-time-travel, fork A — never re-materialised).
+    # apply_events no-ops them (existence-affecting, not snapshot STATE).
+    "agent_created",
+    "agent_archived",
+    "agent_purged",
 )
 
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -72,6 +72,12 @@ _DEFAULT_SID = "main"
 # rewind/GC substrate (list_names stays the literal all-on-disk set).
 ARCHIVED_MARKER = ".archived"
 
+# #2103 S2: the agent-lifecycle WAL create-kind recognised by the as-of-cut DROP /
+# re-materialise primitive by default (session_spawned is added by e2e's S1bc).
+# A registry built with an explicit ``create_event_kinds`` overrides this (the
+# foundation tests do). Inert until S2b emits the events.
+_LIFECYCLE_CREATE_KINDS = frozenset({"agent_created"})
+
 # ADR-0038 1f: WAL-entry-kind → rewind-point boundary label. All inputs are
 # OS-level ``WAL_EVENT_KINDS`` (P7-safe — no skill/domain strings). The three
 # output labels are the D6 Phase-1 granularity (turn / plan-step / phase).
@@ -181,7 +187,10 @@ class AgentRegistry:
         # Empty by default → the primitive is a byte-identical no-op until
         # session_spawned (S1bc) / agent_created (S2) register their kinds. The
         # create-side inverse of the #1954 archive (delete-side).
-        self._create_event_kinds = create_event_kinds or frozenset()
+        self._create_event_kinds = (
+            create_event_kinds if create_event_kinds is not None
+            else _LIFECYCLE_CREATE_KINDS
+        )
         # FP-0043 Stage 3: the Registry holds N conversation Sessions per Agent.
         # Identity (the Agent value object, S2) is shared per name; the
         # conversation instances (= today's Session, inbox+run-loop+history)
@@ -1097,9 +1106,79 @@ class AgentRegistry:
         """#2103: tear down an agent created after the rewind cut. A post-cut agent
         has NO pre-cut generations → nothing to preserve → a clean drop (vs the
         #1954 archive HIDE on the delete side). rmtree subsumes the agent's sessions
-        (they nest under the agent dir). Best-effort; never raises into rewind."""
+        (they nest under the agent dir). Best-effort, but a failure is LOGGED (not
+        silently swallowed) so a stuck teardown is visible (#2114 review note)."""
         import shutil
-        shutil.rmtree(self._dir / name, ignore_errors=True)
+        try:
+            shutil.rmtree(self._dir / name)
+        except FileNotFoundError:
+            pass  # already gone — fine
+        except OSError as e:  # noqa: BLE001 — best-effort; never raise into rewind
+            logger.warning("#2103: drop of agent %r failed (left on disk): %s", name, e)
+
+    def _agent_lifecycle(
+        self,
+    ) -> "tuple[dict[str, tuple[int, dict]], dict[str, int], set[str]]":
+        """#2103 S2: one WAL scan → the agent-lifecycle state (created, archived,
+        purged):
+        - created: name → (create_seq, profile-payload) from ``agent_created`` (the
+          payload re-materialises the profile on a forward-checkout-past-drop).
+        - archived: name → latest ``agent_archived`` seq (the as-of-cut hide hinge).
+        - purged: names with an ``agent_purged`` event (fork A: permanent — never
+          re-materialised at any cut).
+        Empty without a WAL. Inert until S2b emits the events."""
+        created: dict[str, tuple[int, dict]] = {}
+        archived: dict[str, int] = {}
+        purged: set[str] = set()
+        if self._state_log is None:
+            return created, archived, purged
+        for entry in self._state_log.iter_from(0):
+            kind = entry.get("kind")
+            name = entry.get("name")
+            seq = entry.get("seq")
+            if not isinstance(name, str) or not isinstance(seq, int):
+                continue
+            if kind == "agent_created":
+                payload = entry.get("profile")
+                created[name] = (seq, payload if isinstance(payload, dict) else {})
+            elif kind == "agent_archived":
+                archived[name] = seq  # last wins = the latest archival
+            elif kind == "agent_purged":
+                purged.add(name)
+        return created, archived, purged
+
+    def _rematerialise_agent(self, name: str, profile_payload: dict) -> None:
+        """#2103 S2: re-create a dropped agent's profile from its ``agent_created``
+        record (the inverse of ``_drop_agent``), so a forward-checkout past the
+        create brings the agent back. Its per-agent generations were rmtree'd on the
+        drop, so the subsequent reconstruct replays the WAL from 0 for it — correct,
+        just unoptimised for this rare forward-checkout-past-drop path."""
+        prof = AgentProfile(
+            name=name,
+            role=str(profile_payload.get("role", "")),
+            created_at=str(profile_payload.get("created_at", "")),
+            allowed_skills=profile_payload.get("allowed_skills"),
+            allowed_mcp=profile_payload.get("allowed_mcp"),
+        )
+        prof.save(self._dir / name)
+
+    def _reconcile_archived_as_of_cut(
+        self, archived: "dict[str, int]", cut: int,
+    ) -> None:
+        """#2103 S2: rewrite each present agent's ``.archived`` tombstone to the
+        as-of-cut archived-state — archived iff its latest ``agent_archived`` seq ≤
+        cut. So rewind-before-archive → active (marker cleared); rewind-after →
+        archived (marker present). Inert when no ``agent_archived`` events exist
+        (the #1954 file-only tombstone is left untouched)."""
+        for name, aseq in archived.items():
+            target = self._dir / name
+            if not target.is_dir():
+                continue
+            marker = target / ARCHIVED_MARKER
+            if aseq <= cut:
+                marker.write_text(str(aseq), encoding="utf-8")
+            elif marker.is_file():
+                marker.unlink()
 
     async def _drop_session(self, name: str, sid: str) -> None:
         """#2103 seam: tear down a single spawned session created after the cut.
@@ -1135,19 +1214,31 @@ class AgentRegistry:
         # disk (this is shared with crash-recovery, where sessions are not loaded).
         agents: list[str] = []
         created_at = self._created_at_map()   # #2103: as-of-cut DROP input (empty → no-op)
+        # #2103 S2: agent-lifecycle reconstruction (re-materialise / hide / purge) —
+        # all inert until S2b emits the events.
+        ag_created, ag_archived, ag_purged = self._agent_lifecycle()
         # #2103: the existence cut is the rewind TARGET (``workspace_at_or_below`` =
         # target_n), NOT ``reconstruct_seq`` (= R, the reset-record head). An entity
         # whose create-seq > target didn't exist as-of-target → drop it. In crash
         # recovery ``workspace_at_or_below`` = head, so create-seq > head is never
         # true → no spurious drops (recovery reconstructs the present, not a rewind).
         drop_cut = workspace_at_or_below
+        # #2103 S2 re-materialise: an agent created ≤ cut, NOT purged, currently
+        # ABSENT (dropped at a prior cut) → re-create from its agent_created record
+        # so a forward-checkout-past-drop brings it back (the inverse of the drop).
+        for _rname, (_rcseq, _rpayload) in ag_created.items():
+            if _rname in ag_purged:
+                continue  # fork A: purged = permanent, never re-materialised
+            if _rcseq <= drop_cut and not (self._dir / _rname).is_dir():
+                self._rematerialise_agent(_rname, _rpayload)
+        agents: list[str] = []
         for name in self.list_names():
-            # An agent created after the cut → tear it down (subsumes its sessions,
-            # nested under the agent dir) instead of leaving an empty-snapshot
-            # orphan. Reversible: a forward-checkout past the create re-materialises
-            # it from the agent_created WAL record.
+            # An agent created after the cut — OR purged (fork A: permanent) — is
+            # torn down (subsumes its nested sessions) instead of reconstructed.
+            # Reversible (create case): a forward-checkout past the create
+            # re-materialises it from the agent_created WAL record (the pass above).
             agent_seq = created_at.get(("agent", name, ""))
-            if agent_seq is not None and agent_seq > drop_cut:
+            if name in ag_purged or (agent_seq is not None and agent_seq > drop_cut):
                 self._drop_agent(name)
                 continue
             for sid in self._discover_session_ids(name):
@@ -1173,6 +1264,9 @@ class AgentRegistry:
                 # main → bare name (back-compat with single-session callers);
                 # spawned → "name/sid".
                 agents.append(name if sid == _DEFAULT_SID else f"{name}/{sid}")
+        # #2103 S2: rewrite present agents' .archived tombstones to the as-of-cut
+        # archived-state (rewind-before-archive → active; rewind-after → archived).
+        self._reconcile_archived_as_of_cut(ag_archived, drop_cut)
         await self._restore_workspace_active(at_or_below=workspace_at_or_below)
         await self._restore_task_active(at_or_below=workspace_at_or_below)
         return agents

--- a/tests/test_agent_lifecycle_rewind_2103_s2.py
+++ b/tests/test_agent_lifecycle_rewind_2103_s2.py
@@ -1,0 +1,128 @@
+"""Tier 2: OS invariant — #2103 S2 agent-lifecycle rewind-reconstruction (consume).
+
+On the merged #2114 drop-primitive foundation. S2 reconstructs agent EXISTENCE
+as-of-cut from the lifecycle WAL events:
+- agent_created → re-materialise (≤cut, absent) or drop (>cut, foundation).
+- agent_archived → hide-as-of-cut (rewrite the .archived tombstone).
+- agent_purged → PERMANENT (fork A, owner-decided): never re-materialised at ANY
+  cut (preserves the #1954 irreversible-purge / privacy intent).
+
+This is the CONSUME side — inert in production until S2b emits the events; here
+driven by emitting the (now-real) lifecycle WAL kinds directly. Real AgentRegistry
++ StateLog + on-disk agents (no mocks). _materialize_rewind is driven directly for
+precise as-of-cut control (the same path rewind_to + crash-recovery share).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import ARCHIVED_MARKER, AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    # default create_event_kinds → includes "agent_created" (_LIFECYCLE_CREATE_KINDS).
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str, role: str = "") -> None:
+    AgentProfile.new(name, role=role).save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _agent_dir(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name
+
+
+async def _emit_created(log: StateLog, name: str, *, role: str = "") -> int:
+    return await log.append(
+        "agent_created", entity_kind="agent", name=name, sid="",
+        profile={"name": name, "role": role},
+    )
+
+
+async def _emit_archived(log: StateLog, name: str) -> int:
+    return await log.append("agent_archived", entity_kind="agent", name=name)
+
+
+async def _emit_purged(log: StateLog, name: str) -> int:
+    return await log.append("agent_purged", entity_kind="agent", name=name)
+
+
+@pytest.mark.asyncio
+async def test_dropped_agent_rematerialised_from_agent_created(tmp_path):
+    """Tier 2: a dropped agent is RE-MATERIALISED from its agent_created record when
+    the cut is at-or-after its create-seq (the reversibility headline) — profile
+    restored, so a forward-checkout-past-drop brings the agent back."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "helper", role="my role")
+    log = reg.state_log
+    await _emit_created(log, "helper", role="my role")   # seq 1
+
+    reg._drop_agent("helper")                             # simulate prior-cut drop
+    assert not _agent_dir(tmp_path, "helper").exists()
+
+    await reg._materialize_rewind(
+        reconstruct_seq=log.current_seq, workspace_at_or_below=1,  # cut ≥ create
+    )
+
+    assert _agent_dir(tmp_path, "helper").is_dir()        # re-materialised
+    assert AgentProfile.load(_agent_dir(tmp_path, "helper")).role == "my role"
+
+
+@pytest.mark.asyncio
+async def test_archived_state_reconciled_as_of_cut(tmp_path):
+    """Tier 2: the .archived tombstone is rewritten to the as-of-cut archived-state —
+    rewind-before-archive → active (cleared); rewind-after → archived (present)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "a")
+    log = reg.state_log
+    await _emit_created(log, "a")        # seq 1
+    await _emit_archived(log, "a")       # seq 2
+
+    # cut before the archive → active (marker cleared).
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    assert not (_agent_dir(tmp_path, "a") / ARCHIVED_MARKER).exists()
+
+    # cut at/after the archive → archived (marker present).
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=2)
+    assert (_agent_dir(tmp_path, "a") / ARCHIVED_MARKER).is_file()
+
+
+@pytest.mark.asyncio
+async def test_purged_agent_is_permanent_never_rematerialised(tmp_path):
+    """Tier 2: fork A — a purged agent is PERMANENT, not re-materialised at ANY cut,
+    even rewind-to-before-the-purge (preserves the #1954 irreversible-purge intent)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "v")
+    log = reg.state_log
+    await _emit_created(log, "v")        # seq 1
+    await _emit_purged(log, "v")         # seq 2
+
+    # cut BEFORE the purge (1) — fork A still drops it (out-of-time-travel).
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    assert not _agent_dir(tmp_path, "v").exists()
+
+
+@pytest.mark.asyncio
+async def test_agent_without_lifecycle_events_unaffected(tmp_path):
+    """Tier 2: no-op — an agent with NO lifecycle events is neither dropped nor
+    re-materialised — reconstruct is byte-identical to pre-S2."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "keep")
+    log = reg.state_log
+    await log.append("inbox_put", target="keep", msg_id="x", msg_kind="user",
+                     payload={"text": "x"})           # seq 1 (non-lifecycle)
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+
+    assert _agent_dir(tmp_path, "keep").is_dir()       # untouched


### PR DESCRIPTION
**[dogfood-coder]** — #2103 S2a (the consume/reconstruction side), on the merged #2114 foundation. The S2-split lead confirmed (S2b = the async-API emit, coordinated with e2e). No-merge — lead close-review.

## What
Reconstructs agent EXISTENCE as-of-cut from the agent-lifecycle WAL events. CONSUME side — **inert in production until S2b emits the events** (the kind is default-on, but nothing emits yet → byte-identical). The create-side reversibility + the #1954-archive-WAL residual, realized.

## Behaviors (registry.py `_materialize_rewind`)
- **`agent_created` → RE-MATERIALISE** (the reversibility half; the foundation did the drop half): an agent created ≤ cut but absent (dropped at a prior cut) is re-created from its config-complete record (`_rematerialise_agent`) → forward-checkout-past-drop brings it back. *Its per-agent generations were rmtree'd on the drop → reconstruct replays the WAL from 0 for it; correct, unoptimized for that rare path — commented per the #2114 review note.*
- **`agent_archived` → archived-as-of-cut**: `_reconcile_archived_as_of_cut` rewrites the `.archived` tombstone (rewind-before-archive → active; after → archived). **Closes the #1954-archive-WAL residual** I flagged on #2102 (archive is now rewindable, not a bare non-rewound tombstone).
- **`agent_purged` → PERMANENT** (fork A, owner-decided): never re-materialised at ANY cut (even rewind-before-purge) — preserves the #1954 irreversible-purge / privacy intent.
- One **"active-as-of-cut"** composition: created ≤ cut ∧ not-archived-at-cut ∧ not-purged.

## Plumbing
- 3 kinds (`agent_created`/`agent_archived`/`agent_purged`) added to `WAL_EVENT_KINDS` — OS-level lifecycle, **P7-safe**; `apply_events` no-ops them (existence-affecting, not snapshot STATE — verified).
- Default `create_event_kinds = {agent_created}` (`_LIFECYCLE_CREATE_KINDS`) so drop/re-materialise recognises it in production. Inert until S2b emits.
- **Observability** (#2114 review note): `_drop_agent` now LOGS a failed rmtree instead of silent `ignore_errors`.

## Emit side = S2b (coordinated with e2e)
`create()`/`remove()` become async + emit the events (uniform with e2e's `session_spawned` in the spawn op; CLI `_cmd_rm` wraps `asyncio.run`). Sequenced so the API flips once. This S2a consume side lands first (inert, safe — same pattern as the foundation).

## Verify (all 3 gates, on origin/main @ 6bd79914 + this)
- S2a (4) + foundation + rewind + #1954-archive regression → **29 passed**.
- **Full `-n auto` → 8390 passed, 0 failed.**
- `ruff` clean; `tier-audit` 0 errors. Cherry-picked clean onto current main (no conflict).

## Tests (Tier 2, real registry + StateLog; real lifecycle kinds; `_materialize_rewind` driven directly for as-of-cut)
- re-materialise a dropped agent on a forward cut (profile restored) [reversibility headline].
- archived reconciled as-of-cut (before → active; after → archived).
- purge permanent (fork A — gone even before the purge).
- no-lifecycle-events → byte-identical (the no-op invariant).

## Tier-rule self-check
- Docstrings: all start exactly `Tier 2:` ✓
- Tier-4: none ✓ · Invariant weakening: none (inert until emit; existing rewind byte-identical) ✓ · Mocks/private-state: none ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
