### PR TITLE
feat(#2103) S2b: agent-lifecycle EMIT seam — wire the lifecycle WAL events

### DIFF
--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -8,6 +8,7 @@ prompts via `reyn agent new`.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from pathlib import Path
 
@@ -125,18 +126,29 @@ def _cmd_list(args: argparse.Namespace) -> None:
 
 
 def _cmd_new(args: argparse.Namespace) -> None:
+    # #2103 S2b: route through the registry create-seam (create_agent) so a
+    # CLI-created agent emits agent_created (rewind-trackable) — and so EVERY
+    # creation surface goes through the one canonical seam (this also fixes the
+    # prior AgentProfile.save-direct bypass). reg.create() is a safe superset of
+    # the old path (validate + create + save); existence is now profile-based
+    # (reg.exists) rather than dir-based — the canonical registry check. The WAL
+    # (read-only scan → current_seq) is attached so the emit records an accurate seq.
+    def _no_factory(profile):
+        raise RuntimeError("session factory not used in agent CLI")
+    wal_path = Path.cwd() / ".reyn" / "state" / "wal.jsonl"
+    state_log = StateLog(wal_path) if wal_path.is_file() else None
+    reg = AgentRegistry(
+        project_root=Path.cwd(), session_factory=_no_factory, state_log=state_log,
+    )
+    target = _agents_dir() / args.name
     try:
-        _validate_agent_name(args.name)
-    except ValueError as e:
+        asyncio.run(reg.create_agent(args.name, role=args.role))
+    except ValueError as e:                       # invalid name
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(2)
-    base = _agents_dir()
-    target = base / args.name
-    if target.exists():
+    except FileExistsError:
         print(f"Error: agent {args.name!r} already exists at {target}", file=sys.stderr)
         sys.exit(1)
-    profile = AgentProfile.new(name=args.name, role=args.role)
-    profile.save(target)
     print(f"Created agent {args.name!r} at {target}")
     if args.role:
         print(f"  role: {args.role.strip().splitlines()[0]}")
@@ -178,7 +190,10 @@ def _cmd_rm(args: argparse.Namespace) -> None:
     reg = AgentRegistry(
         project_root=Path.cwd(), session_factory=_no_factory, state_log=state_log,
     )
-    reg.remove(args.name, purge=purge)
+    # #2103 S2b: route the delete through archive_agent (emit agent_archived |
+    # agent_purged) so rewind reconstructs the as-of-cut archived-state / honors the
+    # permanent purge. asyncio.run — the CLI is a sync top-level (no running loop).
+    asyncio.run(reg.archive_agent(args.name, purge=purge))
     print(f"{'Purged' if purge else 'Archived'} agent {args.name!r}")
 
 

--- a/src/reyn/interfaces/slash/agent.py
+++ b/src/reyn/interfaces/slash/agent.py
@@ -75,7 +75,7 @@ async def _create_agent(session: "Session", name: str) -> None:
         await reply_error(session, _NO_REGISTRY)
         return
     try:
-        session._registry.create(name)
+        await session._registry.create_agent(name)  # #2103 S2b: emit agent_created
     except FileExistsError:
         await reply_error(
             session,

--- a/src/reyn/interfaces/web/routers/agents.py
+++ b/src/reyn/interfaces/web/routers/agents.py
@@ -73,7 +73,7 @@ async def create_agent(
 ) -> AgentDetail:
     """Create a new agent with the given name and optional role."""
     try:
-        profile = registry.create(body.name, role=body.role or "")
+        profile = await registry.create_agent(body.name, role=body.role or "")  # #2103 S2b: emit agent_created
     except FileExistsError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -126,7 +126,7 @@ async def delete_agent(name: str, registry=Depends(get_registry)) -> None:
             detail=f"Agent {name!r} not found.",
         )
     try:
-        registry.remove(name)
+        await registry.archive_agent(name)  # #2103 S2b: emit agent_archived
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -414,6 +414,28 @@ class AgentRegistry:
         profile.save(self._dir / name)
         return profile
 
+    async def create_agent(self, name: str, *, role: str = "") -> AgentProfile:
+        """#2103 S2b: the action-layer CREATE seam — create the profile (sync) +
+        emit ``agent_created`` so rewind can track / reconstruct / drop the agent
+        (the create-side of the as-of-cut lifecycle, #2114/#2117). Every creation
+        SURFACE (CLI / web / slash + the spawn op) routes through this ONE seam, so
+        no surface can miss the emit (rewind-completeness). Emit no-ops without a
+        WAL. The mechanism (sync ``create``) stays separate — the event marks the
+        user/LLM action, not the file write."""
+        profile = self.create(name, role=role)
+        if self._state_log is not None:
+            await self._state_log.append(
+                "agent_created", entity_kind="agent", name=name, sid="",
+                profile={
+                    "name": profile.name,
+                    "role": profile.role,
+                    "created_at": profile.created_at,
+                    "allowed_skills": profile.allowed_skills,
+                    "allowed_mcp": profile.allowed_mcp,
+                },
+            )
+        return profile
+
     def remove(self, name: str, *, purge: bool = False) -> None:
         """Delete an agent. Default (#1954 Option A) = ARCHIVE (soft-delete): the
         runtime PITR generations are kept in place so rewind-to-before-delete
@@ -460,6 +482,19 @@ class AgentRegistry:
             # window (slice 2).
             seq = self._state_log.current_seq if self._state_log is not None else 0
             (target / ARCHIVED_MARKER).write_text(str(seq), encoding="utf-8")
+
+    async def archive_agent(self, name: str, *, purge: bool = False) -> None:
+        """#2103 S2b: the action-layer DELETE seam — archive (or purge) the agent
+        (sync ``remove``) + emit the lifecycle event (``agent_archived`` |
+        ``agent_purged``) so rewind reconstructs the as-of-cut archived-state and
+        honors the permanent purge (fork A). The ONE delete seam the action-layer
+        callers (CLI / web + the spawn op) route through. Emit no-ops without a WAL."""
+        self.remove(name, purge=purge)
+        if self._state_log is not None:
+            await self._state_log.append(
+                "agent_purged" if purge else "agent_archived",
+                entity_kind="agent", name=name,
+            )
 
     def recent_user_message(self, name: str) -> str:
         """Return the most recent user-role text from the agent's history, or "".
@@ -1231,7 +1266,6 @@ class AgentRegistry:
                 continue  # fork A: purged = permanent, never re-materialised
             if _rcseq <= drop_cut and not (self._dir / _rname).is_dir():
                 self._rematerialise_agent(_rname, _rpayload)
-        agents: list[str] = []
         for name in self.list_names():
             # An agent created after the cut — OR purged (fork A: permanent) — is
             # torn down (subsumes its nested sessions) instead of reconstructed.

--- a/tests/test_agent_lifecycle_emit_2103_s2b.py
+++ b/tests/test_agent_lifecycle_emit_2103_s2b.py
@@ -1,0 +1,103 @@
+"""Tier 2: OS invariant — #2103 S2b agent-lifecycle EMIT seam (action layer).
+
+The emit side that feeds the S2a consume side (#2117): the action-layer seams
+`AgentRegistry.create_agent()` / `archive_agent()` emit agent_created /
+agent_archived / agent_purged so rewind can track / reconstruct / drop the agent
+across its full lifecycle. create()/remove() stay SYNC (the mechanism); the seams
+are the ONE place the emit lives (every creation/deletion surface routes through
+them — no scatter). Real AgentRegistry + StateLog (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def _events(reg: AgentRegistry, kind: str) -> list[dict]:
+    return [e for e in reg.state_log.iter_from(0) if e.get("kind") == kind]
+
+
+def _agent_dir(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name
+
+
+@pytest.mark.asyncio
+async def test_create_agent_emits_agent_created_with_config(tmp_path):
+    """Tier 2: create_agent creates the profile (on disk) AND emits agent_created
+    carrying the profile config — the record rewind re-materialises from."""
+    reg = _make_registry(tmp_path)
+    await reg.create_agent("helper", role="my role")
+
+    assert _agent_dir(tmp_path, "helper").is_dir()
+    created = _events(reg, "agent_created")
+    assert [e.get("name") for e in created] == ["helper"]
+    assert created[0]["profile"]["role"] == "my role"
+
+
+@pytest.mark.asyncio
+async def test_created_agent_dropped_on_rewind_before_create(tmp_path):
+    """Tier 2: an agent created via create_agent (emit) is dropped by a rewind to
+    before its create (consume) — the emit→consume path end-to-end."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "survivor")
+    await _put(reg.state_log, "survivor", "s1")     # seq 1 (the cut target)
+    await reg.create_agent("ephemeral", role="task")  # seq 2 — agent_created
+
+    assert _agent_dir(tmp_path, "ephemeral").is_dir()
+    await reg.rewind_to(1)                            # cut 1 < create-seq 2
+
+    assert not _agent_dir(tmp_path, "ephemeral").exists()   # dropped
+    assert "survivor" in reg.list_names()
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_emits_agent_archived(tmp_path):
+    """Tier 2: archive_agent emits agent_archived (the rewind-reconstruction
+    source) and the agent is archived (hidden from the active listing, kept on
+    disk)."""
+    reg = _make_registry(tmp_path)
+    await reg.create_agent("a")
+    await reg.archive_agent("a")
+
+    assert [e.get("name") for e in _events(reg, "agent_archived")] == ["a"]
+    assert "a" not in reg.list_active_names()
+    assert "a" in reg.list_names()
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_purge_emits_agent_purged(tmp_path):
+    """Tier 2: archive_agent(purge=True) emits agent_purged and hard-deletes the
+    agent dir (the permanent-purge action, fork A)."""
+    reg = _make_registry(tmp_path)
+    await reg.create_agent("a")
+    await reg.archive_agent("a", purge=True)
+
+    assert [e.get("name") for e in _events(reg, "agent_purged")] == ["a"]
+    assert not _agent_dir(tmp_path, "a").exists()


### PR DESCRIPTION
**[dogfood-coder]** — #2103 S2b (the EMIT side), feeding the merged S2a consume (#2117). No-merge — lead close-review. Per the emit-at-action-layer decision (NOT the ~95-site async-flip — sizing caught that).

## What
Action-layer seams emit the lifecycle WAL events so rewind tracks/reconstructs the agent across its full lifecycle:
- **`create_agent()`** (async): sync `create()` + emit `agent_created` (carrying the profile config the consume side re-materialises from).
- **`archive_agent()`** (async): sync `remove()` + emit `agent_archived | agent_purged`.
- **`create()`/`remove()` stay SYNC** (the mechanism) — no ~95-site async-flip; the seam is the ONE place the emit lives (no scatter — the #2093 lesson).

## Callers routed through the seams (~5 production surfaces)
- web `POST /agents` (create) + `DELETE` (remove); slash `/agent new`; CLI `agent new` (`_cmd_new`) + `agent rm` (`_cmd_rm`). CLI wraps `asyncio.run` (sync top-level).
- **`_cmd_new` bonus**: it previously created via `AgentProfile.save`-direct (bypassing `reg.create()` → a creation surface that would've missed the emit). Now routed through `create_agent` → all creation surfaces go through the one seam. Verified `reg.create()` is a **safe superset** (same validate+create+save; existence is now profile-based `reg.exists`, the canonical check — preserved/improved).
- e2e's future agent-spawn op routes through `create_agent` (no async-`create()`-signature change for them — the reason we avoided the async-flip).

## Carry-overs (lead's #2117 notes)
- (1) removed the redundant `agents=[]` in `_materialize_rewind`. ✓
- (2) the `_LIFECYCLE_CREATE_KINDS` ⨯ e2e's `CREATE_EVENT_KINDS` union — e2e's `session_spawned` constant isn't landed yet, so nothing to union; the 2nd-lander reconciles (noted).

## Verify (all 3 gates, on origin/main @ 551649fd + this)
- S2b (4) + S2a + foundation + #1954 regression → **19 passed**.
- **Full `-n auto` → 8395 passed, 0 failed** (the web/slash/CLI caller changes break nothing).
- `ruff` clean; `tier-audit` 0 errors. Cherry-picked clean onto current main.

## Tests (Tier 2)
create_agent emits agent_created w/ config; created agent dropped on rewind-before-create (emit→consume e2e); archive_agent emits agent_archived; purge emits agent_purged.

## Tier-rule self-check
- Docstrings exactly `Tier 2:` ✓ · Tier-4: none (behavioral assertions, no count pins) ✓ · Invariant weakening: none ✓ · Mocks/private-state: none ✓

## Closes the S2 arc
With S2a (#2117, consume) + S2b (emit), the **full agent create/archive/purge lifecycle is now WAL-logged + rewind-reconstructed** — on the #2114 foundation, closing the #1954-archive residual. e2e's `session_spawned` (S1bc) registers into the same seam + consume path when their spawn op lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
