### PR TITLE
fix(#2115): /rewind reports actual in-flight disposition + close the quiescence append-race

### DIFF
--- a/src/reyn/interfaces/chainlit_app/rewind_actions.py
+++ b/src/reyn/interfaces/chainlit_app/rewind_actions.py
@@ -82,10 +82,22 @@ async def handle_rewind_checkout(registry, seq: int) -> str:
     except Exception as exc:  # noqa: BLE001 — surface the reason to the user
         return f"⏪ checkout failed: {exc}"
     agents = result.get("agents", [])
-    return (
+    # #2115: report the ACTUAL in-flight disposition (cancelled vs
+    # finished-before-the-cancel-landed) — not a hardcoded "cancelled".
+    summary = (
         f"⏪ checked out to seq {result.get('target_n', seq)} "
-        f"· {len(agents)} agent(s) reset · in-flight cancelled"
+        f"· {len(agents)} agent(s) reset"
     )
+    c = result.get("in_flight_cancelled", 0)
+    f = result.get("in_flight_finished", 0)
+    bits = []
+    if c:
+        bits.append(f"{c} in-flight cancelled")
+    if f:
+        bits.append(f"{f} in-flight finished")
+    if bits:
+        summary += " · " + ", ".join(bits)
+    return summary
 
 
 def resolve_edit_target(registry, seq: int) -> dict:

--- a/src/reyn/interfaces/slash/rewind.py
+++ b/src/reyn/interfaces/slash/rewind.py
@@ -54,11 +54,22 @@ async def rewind_cmd(session: "object", args: str) -> None:
         return
 
     agents = result.get("agents", [])
-    await reply(
-        session,
+    # #2115: report the ACTUAL in-flight disposition (cancelled vs
+    # finished-before-the-cancel-landed) — not a hardcoded "cancelled" literal.
+    summary = (
         f"⏪ checked out to seq {result.get('target_n', target)} "
-        f"· {len(agents)} agent(s) reset · in-flight cancelled",
+        f"· {len(agents)} agent(s) reset"
     )
+    cancelled = result.get("in_flight_cancelled", 0)
+    finished = result.get("in_flight_finished", 0)
+    bits = []
+    if cancelled:
+        bits.append(f"{cancelled} in-flight cancelled")
+    if finished:
+        bits.append(f"{finished} in-flight finished")
+    if bits:
+        summary += " · " + ", ".join(bits)
+    await reply(session, summary)
 
 
 __all__ = ["rewind_cmd"]

--- a/src/reyn/interfaces/tui/app.py
+++ b/src/reyn/interfaces/tui/app.py
@@ -2764,13 +2764,22 @@ class ReynTUIApp(App):
             return
         if conv is not None:
             agents = result.get("agents", [])
-            conv.render_message(OutboxMessage(
-                kind="system",
-                text=(
-                    f"⏪ checked out to seq {result.get('target_n', target_seq)} "
-                    f"· {len(agents)} agent(s) reset · in-flight cancelled"
-                ),
-            ))
+            # #2115: report the ACTUAL in-flight disposition (cancelled vs
+            # finished-before-the-cancel-landed) — not a hardcoded "cancelled".
+            _text = (
+                f"⏪ checked out to seq {result.get('target_n', target_seq)} "
+                f"· {len(agents)} agent(s) reset"
+            )
+            _c = result.get("in_flight_cancelled", 0)
+            _f = result.get("in_flight_finished", 0)
+            _bits = []
+            if _c:
+                _bits.append(f"{_c} in-flight cancelled")
+            if _f:
+                _bits.append(f"{_f} in-flight finished")
+            if _bits:
+                _text += " · " + ", ".join(_bits)
+            conv.render_message(OutboxMessage(kind="system", text=_text))
             # The checkout cancels in-flight work + resets the agent(s), which
             # orphans the bottom async-strip rows: the pre-rewind skill-run
             # entries' completion no longer routes to the strip (the agent was

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -78,6 +78,17 @@ ARCHIVED_MARKER = ".archived"
 # foundation tests do). Inert until S2b emits the events.
 _LIFECYCLE_CREATE_KINDS = frozenset({"agent_created"})
 
+
+def _count_inflight_disposition(tasks: "list") -> "tuple[int, int]":
+    """#2115: classify settled in-flight skill tasks → (cancelled, finished). A task
+    cancelled at an await reports ``cancelled()``; one that RETURNED before the
+    cancel landed is ``done()`` and not cancelled = finished (it won the cancel
+    race). Powers the TRUTHFUL /rewind summary (vs the old hardcoded "in-flight
+    cancelled" literal that lied about finished runs, #2115)."""
+    cancelled = sum(1 for t in tasks if t.cancelled())
+    finished = sum(1 for t in tasks if t.done() and not t.cancelled())
+    return cancelled, finished
+
 # ADR-0038 1f: WAL-entry-kind → rewind-point boundary label. All inputs are
 # OS-level ``WAL_EVENT_KINDS`` (P7-safe — no skill/domain strings). The three
 # output labels are the D6 Phase-1 granularity (turn / plan-step / phase).
@@ -804,10 +815,15 @@ class AgentRegistry:
         self._rewind_in_progress = True
         try:
             sessions = self._iter_sessions()
+            # #2115: snapshot the in-flight skill tasks BEFORE the cancel, so the
+            # summary reports their TRUE disposition (cancelled vs
+            # finished-before-the-cancel-landed) instead of a hardcoded "cancelled"
+            # literal — a skill that already returned wins the cancel race.
+            inflight_tasks = [t for s in sessions for t in s.running_skills.values()]
             # 2. all-cancel (stop-world).
             for session in sessions:
                 await session.cancel_inflight()
-            # 3. all-quiesce (settle every WAL-append task).
+            # 3. all-quiesce (re-drain to a fixpoint — no append lands past the reset).
             for session in sessions:
                 await session.await_quiescent()
             # 4. single global reset-record; supersedes = prior active head (audit).
@@ -819,10 +835,16 @@ class AgentRegistry:
             agents = await self._materialize_rewind(
                 reconstruct_seq=reset_seq, workspace_at_or_below=seq,
             )
+            # #2115: the ACTUAL in-flight disposition (truthful rewind summary).
+            in_flight_cancelled, in_flight_finished = _count_inflight_disposition(
+                inflight_tasks
+            )
             return {
                 "target_n": seq,
                 "reset_seq": reset_seq,
                 "agents": agents,
+                "in_flight_cancelled": in_flight_cancelled,
+                "in_flight_finished": in_flight_finished,
             }
         finally:
             self._rewind_in_progress = False

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -86,6 +86,12 @@ from reyn.user_intervention import (
 
 ROUTER_SKILL_NAME = "skill_router"
 
+# #2115: cap for await_quiescent's re-drain loop. In-flight WAL-append tasks are
+# finite + cancel-requested + spawn no new user-work under a rewind, so the drain
+# converges in 1-2 rounds; the cap is purely a guard against a pathological spin
+# (logged, never silently looped).
+_QUIESCE_MAX_ROUNDS = 50
+
 # Localized user-facing messages for the router retry-exhausted fallback (F8).
 # Keys are BCP-47-style language codes matching config `output_language`.
 # Unsupported codes fall back to "en".
@@ -2148,27 +2154,38 @@ class Session:
         #    in-progress before this returns. On reconstruct, restore() re-arms a
         #    fresh watchdog from the recovered snapshot, so cancelling is reversible.
         await self._chains.cancel_and_join_timers()
-        # 3. cancel tracked fire-and-forget WAL-append tasks, then join. Cancel
-        #    (not join-only) is required: the intervention-dispatch task awaits the
-        #    user-answer future indefinitely, so a bare join would hang here. These
-        #    tasks are documented drop-safe (a dropped append is harmlessly
-        #    reconstructed on restore), so cancelling is correct. await_quiescent
-        #    owns this internal plumbing itself — independent of cancel_inflight.
-        for task in list(self._inflight_wal_tasks):
-            if not task.done():
-                task.cancel()
-        # 4. join cancelled skill / plan tasks (cancelled by the prior
-        #    cancel_inflight) + the now-cancelled fire-and-forget tasks. Each is an
-        #    append-capable spawned task that must settle before the reset-record.
-        pending = [
-            t for t in (
-                *self.running_skills.values(),
-                *self._inflight_wal_tasks,
-            )
-            if not t.done()
-        ]
-        if pending:
+        # 3-4. RE-DRAIN LOOP (#2115): cancel the tracked fire-and-forget WAL tasks
+        #    (cancel — not join-only — is required: the intervention-dispatch task
+        #    awaits the user-answer future indefinitely; the tasks are drop-safe so
+        #    cancelling is correct) + join the append-capable tasks (running_skills +
+        #    _inflight_wal_tasks), then RE-CHECK. A joined task may schedule a NEW
+        #    tracked append (or re-spawn) DURING the gather — which the prior
+        #    one-shot snapshot would miss (the join↔append race that let a
+        #    skill_completed land PAST the reset-record, #2115). Loop to a fixpoint
+        #    (both sets fully drained) so no append can land after this returns —
+        #    vector-agnostic: closes any append-scheduled-during-quiescence path,
+        #    subsuming the _inflight_wal_tasks special-case. On reconstruct, restore()
+        #    re-arms timers from the recovered snapshot, so cancelling is reversible.
+        for _ in range(_QUIESCE_MAX_ROUNDS):
+            for task in list(self._inflight_wal_tasks):
+                if not task.done():
+                    task.cancel()
+            pending = [
+                t for t in (
+                    *self.running_skills.values(),
+                    *self._inflight_wal_tasks,
+                )
+                if not t.done()
+            ]
+            if not pending:
+                break
             await asyncio.gather(*pending, return_exceptions=True)
+        else:
+            logger.warning(
+                "await_quiescent: WAL-append tasks did not drain to a fixpoint in "
+                "%d rounds — a straggler append may race the reset-record",
+                _QUIESCE_MAX_ROUNDS,
+            )
         # 5. re-confirm turn-idle — a joined task may have enqueued a follow-up
         #    turn; with cancel already requested it breaks immediately, so this
         #    settles. The double wait closes the join↔turn race.
@@ -2182,6 +2199,12 @@ class Session:
         escape ``await_quiescent`` and could append past a rewind reset-record.
         Tracking them in ``_inflight_wal_tasks`` (with discard-on-done to keep the
         set bounded) makes them joinable. Returns the task for call-site chaining.
+
+        #2115 CONVENTION: every async WAL-append spawned outside the current turn —
+        ESPECIALLY any skill-completion append — MUST be tracked here (or run within
+        a ``running_skills`` task) so ``await_quiescent``'s re-drain joins it before
+        the rewind reset-record. A new untracked append path would leak past a
+        rewind (the #2115 bug class).
         """
         self._inflight_wal_tasks.add(task)
         task.add_done_callback(self._inflight_wal_tasks.discard)

--- a/tests/test_rewind_inflight_disposition_2115.py
+++ b/tests/test_rewind_inflight_disposition_2115.py
@@ -1,0 +1,85 @@
+"""Tier 2: OS invariant — #2115 /rewind-cancel truthfulness + the await_quiescent
+re-drain (no WAL append lands past the reset-record).
+
+(1) Truthfulness: the rewind summary's in-flight disposition counts a cancelled
+    task vs a finished-before-the-cancel-landed task (vs the old hardcoded
+    "in-flight cancelled" literal that lied about finished runs).
+(2) Re-drain: await_quiescent loops to a fixpoint, so an append SCHEDULED DURING
+    the join (the join↔append race that let a skill_completed leak past the
+    reset-record) is still joined before quiescence returns — vector-agnostic.
+
+Real Session + StateLog (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import _count_inflight_disposition
+from reyn.runtime.session import Session
+
+
+@pytest.mark.asyncio
+async def test_inflight_disposition_counts_cancelled_vs_finished():
+    """Tier 2: a finished-before-cancel task counts as finished (NOT cancelled) —
+    the truthful disposition the /rewind summary now reports."""
+    async def _finishes() -> None:
+        return None
+
+    async def _hangs() -> None:
+        await asyncio.sleep(60)
+
+    finished_t = asyncio.ensure_future(_finishes())
+    await asyncio.gather(finished_t, return_exceptions=True)   # let it complete
+    hung_t = asyncio.ensure_future(_hangs())
+    hung_t.cancel()
+    await asyncio.gather(hung_t, return_exceptions=True)        # settle the cancel
+
+    cancelled, finished = _count_inflight_disposition([finished_t, hung_t])
+    assert cancelled == 1
+    assert finished == 1
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="t",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_await_quiescent_redrains_append_scheduled_during_join(tmp_path):
+    """Tier 2: await_quiescent re-drains to a fixpoint — a follow-up WAL-append task
+    scheduled DURING the join (the #2115 join↔append race) is still joined before
+    quiescence returns, so no append can land past the reset-record. A one-shot
+    gather (the old code) would leave the follow-up pending."""
+    session = _make_session(tmp_path)
+    follow_up: list[asyncio.Task] = []
+
+    async def _second() -> None:
+        await asyncio.sleep(60)   # hangs — only the re-drain's cancel settles it
+
+    async def _first() -> None:
+        try:
+            await asyncio.sleep(60)
+        finally:
+            # Scheduled WHILE _first is being joined (after a one-shot snapshot
+            # would have been taken) — the race the re-drain must catch.
+            follow_up.append(
+                session._track_wal_task(asyncio.ensure_future(_second()))
+            )
+
+    session._track_wal_task(asyncio.ensure_future(_first()))
+    await asyncio.sleep(0)   # let _first reach its await point before quiescence cancels it
+
+    await session.await_quiescent()
+
+    # The re-drain cancelled+joined the follow-up scheduled during the join, so it
+    # is SETTLED (done) when quiescence returns. A one-shot gather would miss it →
+    # it'd still be pending (not done). (Public task state — no private-set assert.)
+    assert follow_up and follow_up[0].done()


### PR DESCRIPTION
**[dogfood-coder]** — #2115 (the /rewind-cancel truthfulness + effect-leak tail), per the design approved on #2115. No-merge — lead close-review.

## Two fixes
**(1) Truthfulness** — `/rewind` printed "· in-flight cancelled" UNCONDITIONALLY (hardcoded in slash/tui/chainlit). A skill that returned before the cancel landed FINISHED, not cancelled. Now `checkout()` measures the real disposition (`_count_inflight_disposition` over the in-flight tasks' final states — `cancelled()` vs `done()`-not-cancelled) + returns `in_flight_cancelled`/`in_flight_finished`; the 3 summary surfaces report it (e.g. "· 2 in-flight finished" / "· 1 in-flight cancelled", or nothing if none).

**(2) Effect-leak tail** — a `skill_completed` inbox_put could land at seq **S > the reset-record R** (a **join↔append race**: an append scheduled during `await_quiescent`'s one-shot gather escaped the join) → `is_active(S)` → replayed on crash-recovery = P6 contamination. `await_quiescent` is now a **re-drain loop** (cancel+join → re-check until both sets [`running_skills` ∪ `_inflight_wal_tasks`] are empty, bounded by `_QUIESCE_MAX_ROUNDS`) → no append can land after it returns. **Vector-agnostic** (the flow-trace confirmed the *mechanism*, not a specific vector — your reconciliation), subsumes the `_inflight_wal_tasks` special-case. + a **convention comment** at `_track_wal_task` (future skill-completion appends MUST be tracked so the re-drain catches them — the future-untracked-path guard, your shift-left lean).

Workspace (P5) was already safe (`restore_to_seq` git-resets); the leak was confined to the WAL inbox channel.

## Verify (all 3 gates, on origin/main @ a942070c + this)
- #2115 (2) + rewind/checkout/quiescence/concurrent-rewind regression → **23 passed**.
- **Full `-n auto` → 8397 passed, 0 failed** (the `await_quiescent` re-drain — the shared rewind + crash-recovery quiescence path — regresses nothing).
- `ruff` clean; `tier-audit` 0 errors. Cherry-picked clean onto current main.

## Tests (Tier 2, real Session + StateLog)
- disposition counts cancelled-vs-finished (the truthfulness basis).
- re-drain settles a follow-up append scheduled during the join (a one-shot gather would leave it pending → not done) — public task state, no private-set assert.

## Tier-rule self-check
- Docstrings exactly `Tier 2:` ✓ · Tier-4: none (dropped a private-state `._inflight_wal_tasks` assert → public `task.done()`) ✓ · Invariant weakening: none (re-drain is strictly more thorough than the one-shot; full suite green) ✓ · Mocks: none ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
