### PR TITLE
feat(#2103): S1bc — session_spawn LLM tool + rewind-safe spawn foundation

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -77,6 +77,15 @@ WAL_EVENT_KINDS = (
     "agent_created",
     "agent_archived",
     "agent_purged",
+    # NEW (#2103 S1bc) — LLM session-spawn lifecycle. ``session_spawned`` is a #2103
+    # CREATE-event (unioned into the registry's _LIFECYCLE_CREATE_KINDS): it carries
+    # {entity_kind:"session", name, sid, mode, narrowing} and its own seq = the
+    # create-seq the as-of-cut DROP primitive keys off (a session spawned after a
+    # rewind cut is dropped, not left an empty orphan); mode+narrowing make it
+    # config-complete (uniform with agent_created, re-materialisable). ``session_
+    # vanished`` records the ephemeral auto-vanish / explicit teardown. OS-level (P7).
+    "session_spawned",
+    "session_vanished",
 )
 
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -72,11 +72,12 @@ _DEFAULT_SID = "main"
 # rewind/GC substrate (list_names stays the literal all-on-disk set).
 ARCHIVED_MARKER = ".archived"
 
-# #2103 S2: the agent-lifecycle WAL create-kind recognised by the as-of-cut DROP /
-# re-materialise primitive by default (session_spawned is added by e2e's S1bc).
-# A registry built with an explicit ``create_event_kinds`` overrides this (the
-# foundation tests do). Inert until S2b emits the events.
-_LIFECYCLE_CREATE_KINDS = frozenset({"agent_created"})
+# #2103: the lifecycle WAL create-kinds recognised by the as-of-cut DROP /
+# re-materialise primitive by default. One registration point (no per-construction-
+# site arg → no #2093 propagation drift): S2 added agent_created; S1bc adds
+# session_spawned. A registry built with an explicit ``create_event_kinds`` overrides
+# this (the foundation tests do). Inert until the events are emitted.
+_LIFECYCLE_CREATE_KINDS = frozenset({"agent_created", "session_spawned"})
 
 
 def _count_inflight_disposition(tasks: "list") -> "tuple[int, int]":
@@ -1238,13 +1239,45 @@ class AgentRegistry:
                 marker.unlink()
 
     async def _drop_session(self, name: str, sid: str) -> None:
-        """#2103 seam: tear down a single spawned session created after the cut.
-        Wired in S1bc with ``session_spawned`` (e2e's session lifecycle =
-        ``remove_session``). Unreached in the foundation — no session create-kinds
-        are registered, so agent-level ``_drop_agent`` subsumes sessions."""
-        raise NotImplementedError(
-            "#2103: session-drop is wired with session_spawned (S1bc)"
-        )
+        """#2103 S1bc: tear down a single spawned session created after the rewind cut
+        (the primitive's seam, now wired). Delegates to ``remove_session`` — the single
+        session-teardown used by BOTH this rewind-drop AND the ephemeral auto-vanish. A
+        post-cut session has no pre-cut generations → a clean drop (vs the #1954 archive
+        HIDE on the delete side). Reversible: a forward-checkout past the spawn would
+        re-materialise it from the config-complete ``session_spawned`` WAL record (the
+        session re-materialise seam is a follow-up; sessions are drop-only today)."""
+        self.remove_session(name, sid)
+
+    def remove_session(self, name: str, sid: str) -> bool:
+        """#2103 S1bc: tear down a SPAWNED (non-main) session — the single teardown
+        seam used by BOTH the rewind as-of-cut DROP (``_drop_session``) AND the
+        ephemeral auto-vanish. Cancels the ``(name, sid)`` run-loop + forwarder tasks,
+        drops it from the in-memory map, and removes its on-disk per-session state dir
+        (``state/sessions/<enc(sid)>/``). Returns True iff anything was removed.
+
+        Full teardown (rmtree) is correct: the global WAL is the durable source — the
+        ``session_spawned`` create-record + the session's session_id-routed entries
+        survive (the per-session dir is the snapshot/generations CACHE), so a
+        forward-checkout re-materialises from the WAL, not the dir. The MAIN session
+        (``_DEFAULT_SID``) is the agent's primary and is NOT removable here (its
+        lifecycle is ``registry.remove``). A no-op for an unknown ``(name, sid)``."""
+        if sid == _DEFAULT_SID:
+            raise ValueError("cannot remove the main session via remove_session")
+        removed = False
+        for task_dict in (self._tasks, self._forward_tasks):
+            task = task_dict.pop((name, sid), None)
+            if task is not None:
+                removed = True
+                if not task.done():
+                    task.cancel()
+        if self._sessions.get(name, {}).pop(sid, None) is not None:
+            removed = True
+        state_dir = self._session_state_dir(name, sid)  # sid != main → sessions/<enc>/
+        if state_dir.is_dir():
+            import shutil
+            shutil.rmtree(state_dir, ignore_errors=True)
+            removed = True
+        return removed
 
     async def _materialize_rewind(
         self, *, reconstruct_seq: int, workspace_at_or_below: int,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1275,8 +1275,14 @@ class AgentRegistry:
         state_dir = self._session_state_dir(name, sid)  # sid != main → sessions/<enc>/
         if state_dir.is_dir():
             import shutil
-            shutil.rmtree(state_dir, ignore_errors=True)
-            removed = True
+            try:
+                shutil.rmtree(state_dir)
+                removed = True
+            except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
+                logger.warning(
+                    "#2103: teardown of session %r/%r left state on disk: %s",
+                    name, sid, e,
+                )
         return removed
 
     async def _materialize_rewind(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1897,6 +1897,36 @@ class AgentRegistry:
         self._sessions.setdefault(name, {})[new_sid] = session
         return new_sid
 
+    async def spawn_session_recorded(
+        self, name: str, *, mode: str = "persistent",
+        narrowing: "dict | None" = None,
+    ) -> str:
+        """#2103 S1bc: the action-layer SESSION-SPAWN seam — spawn a fresh-context
+        session under ``name`` (sync ``spawn_session``) + persist the spawner's
+        per-session capability narrowing (workspace-backed P5 config.yaml, the #2103
+        S1a layer) + emit ``session_spawned`` so rewind tracks/drops/re-materialises
+        it. Mirrors ``create_agent`` (the agent CREATE seam): the mechanism stays sync;
+        the event marks the LLM action. ``session_spawned`` is config-complete
+        (mode + narrowing) for symmetric re-materialise. Returns the new sid.
+
+        Does NOT submit a task — that is the caller (the spawn op), separable from the
+        record. Emit no-ops without a WAL."""
+        sid = self.spawn_session(name)
+        if narrowing:
+            import yaml
+            cfg_path = self._session_state_dir(name, sid) / "config.yaml"
+            cfg_path.parent.mkdir(parents=True, exist_ok=True)
+            cfg_path.write_text(
+                yaml.safe_dump({"name": f"_session_{sid}", **narrowing}),
+                encoding="utf-8",
+            )
+        if self._state_log is not None:
+            await self._state_log.append(
+                "session_spawned", entity_kind="session", name=name, sid=sid,
+                mode=mode, narrowing=narrowing,
+            )
+        return sid
+
     async def ensure_running(self, name: str) -> "object":
         """Load + start session.run() + forwarder for `name` without
         changing the user-attached pointer. Used for agent-to-agent

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -719,6 +719,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def send_to_agent(self, *, to: str, request: str, depth: int,
                             chain_id: str) -> None: ...
 
+    # #2103 S1bc: spawn a fresh-context session under THIS agent for a task.
+    # Multi-session hosts (the chat RouterHostAdapter) implement it; others leave
+    # it unbound (= hasattr-guarded at caller-state build, like spawn_skill).
+    async def spawn_session(self, *, request: str, mode: str,
+                            narrowing: "dict | None", chain_id: str) -> dict: ...
+
     async def put_outbox(self, *, kind: str, text: str,
                          meta: dict) -> None: ...
 
@@ -3650,6 +3656,22 @@ class RouterLoop:
                 )
             _spawn_skill_bound = _spawn_skill_bound_impl
 
+        # #2103 S1bc: session-spawn binding. Only multi-session hosts (the chat
+        # RouterHostAdapter) implement ``spawn_session``; a host without it leaves
+        # this None (= duck-typed, like spawn_skill). chain_id pre-bound.
+        _spawn_session_bound: Any = None
+        if hasattr(self.host, "spawn_session") and callable(
+            getattr(self.host, "spawn_session", None)
+        ):
+            async def _spawn_session_bound_impl(
+                *, request: str, mode: str, narrowing: "dict | None" = None,
+            ) -> dict:
+                return await self.host.spawn_session(
+                    request=request, mode=mode, narrowing=narrowing,
+                    chain_id=self.chain_id,
+                )
+            _spawn_session_bound = _spawn_session_bound_impl
+
         # FP-0034 Phase 2 prep: snapshot indexed RAG corpora for the
         # universal catalog's rag_corpus enumeration. SourceManifest
         # caches the parsed YAML in-process so this is O(1) when the
@@ -3699,6 +3721,8 @@ class RouterLoop:
             # FP-0012: non-blocking spawn binding for chat-mode invoke_skill.
             # None for blocking phase sub-loop hosts (= no spawn_skill method on host).
             spawn_skill_fn=_spawn_skill_bound,
+            # #2103 S1bc: session-spawn dispatch (None for non-multi-session hosts).
+            spawn_session_fn=_spawn_session_bound,
             # Memory tool bridges (= for memory cluster handlers;
             # Phase 3.5-B-heavy) — bound to RouterLoop's private helpers
             # so registry handlers consume the same agent-aware

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -915,6 +915,42 @@ class RouterHostAdapter:
         if tracker is not None:
             tracker.append({"to": to, "request": request})
 
+    async def spawn_session(self, *, request: str, mode: str,
+                            narrowing: "dict | None", chain_id: str) -> dict:
+        """#2103 S1bc: spawn a fresh-context SESSION under THIS agent for a task.
+
+        Spawns + records the session (rewind-tracked via ``session_spawned`` +
+        per-session capability narrowing, the action-layer ``spawn_session_recorded``
+        seam), starts its run-loop (FP-0043 4b-2 ``ensure_session_running``), and
+        submits the task to it — the spawned session RUNS the task in isolation. The
+        result stays in the session; routing it BACK to the spawner is the S1bc-exec
+        follow-on (FP-0043 Stage-4 non-main routing), so this is async-dispatch posture
+        (returns a spawn-ack)."""
+        if self._registry is None:
+            raise RuntimeError(
+                "session_spawn requires a registry (multi-session host) — unavailable "
+                "in this context."
+            )
+        sid = await self._registry.spawn_session_recorded(
+            self._agent_name, mode=mode, narrowing=narrowing,
+        )
+        session = self._registry.ensure_session_running(self._agent_name, sid)
+        if session is not None:
+            await session.submit_agent_request(
+                from_agent=self._agent_name, request=request, depth=0,
+                chain_id=chain_id,
+            )
+        return {
+            "status": "spawned",
+            "sid": sid,
+            "mode": mode,
+            "note": (
+                "Fresh session spawned + task submitted; it runs in isolation. The "
+                "result stays in the spawned session — routing it back is a follow-on "
+                "(FP-0043 Stage-4)."
+            ),
+        }
+
     def append_history_entry(
         self,
         *,

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -236,6 +236,13 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     "mcp-install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
     }),
+    # session/agent spawn — no spawning sub-sessions from untrusted content / an
+    # unbound delegate (#2103 S1bc: unbounded sub-session spawn is a DoS vector; the
+    # ⊆-parent model blocks escalation, but spawning itself is restrict-floored like
+    # re-delegation). ``session_spawn`` is a router-only tool with NO invoke_action
+    # route today, so it is BARE-ONLY (no qualified→bare unwrap alias); a future
+    # qualified route would be floored by the same _with_unwrapped_aliases derivation.
+    "spawn": frozenset({"session_spawn"}),
 }
 
 
@@ -353,6 +360,7 @@ _FLOORED_AUDIT_SEVERITY: "dict[str, str]" = {
     "exec": "HIGH",
     "mcp-install": "HIGH",
     "memory-write": "MED",
+    "spawn": "HIGH",  # #2103: unbounded sub-session spawn (DoS) — peer of re-delegation
 }
 DELEGATION_AUDIT_CLASSES: "dict[str, tuple[str, frozenset[str]]]" = {
     cls: (_FLOORED_AUDIT_SEVERITY[cls], tools)

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -100,6 +100,7 @@ def get_default_registry() -> ToolRegistry:
         REYN_SRC_READ,
     )
     from reyn.tools.sandboxed_exec import SANDBOXED_EXEC
+    from reyn.tools.session_spawn import SESSION_SPAWN
 
     # FP-0034 PR-3a: universal catalog wrappers (registered in registry;
     # not yet added to router build_tools() — that lands in PR-3b).
@@ -169,6 +170,7 @@ def get_default_registry() -> ToolRegistry:
     registry.register(ASK_USER)
     # ── Router-only capabilities (gates.router=allow, gates.phase=deny) ──
     registry.register(DELEGATE_TO_AGENT)
+    registry.register(SESSION_SPAWN)
     registry.register(REYN_SRC_LIST)
     registry.register(REYN_SRC_READ)
     # FP-0041 #489 PR-B2: cron action category (= LLM-callable cron

--- a/src/reyn/tools/session_spawn.py
+++ b/src/reyn/tools/session_spawn.py
@@ -1,0 +1,94 @@
+"""session_spawn ToolDefinition — #2103 S1bc (LLM session-spawn primitive).
+
+Router-only (gates.router=allow, gates.phase=deny). Async-dispatch posture: the LLM
+spawns a FRESH-context session under its own agent to run a task in isolation; the
+handler calls ctx.router_state.spawn_session_fn(...) and returns a spawn-ack. The
+spawned session RUNS the task (its run-loop is started); the result stays in the
+spawned session — routing it back to the spawner is the S1bc-exec follow-on (FP-0043
+Stage-4 non-main routing).
+
+Scope-time mode (the owner's explicit spawn-time choice): ``mode`` is ephemeral |
+persistent. Both are rewind-safe (a session spawned after a rewind cut is dropped). The
+ephemeral auto-vanish (after the task) is the immediate-next sub-slice; the mode is
+recorded now (on the ``session_spawned`` WAL event).
+
+``narrowing`` (optional) is a per-session capability narrowing (restrict-only, the
+#2103 S1a 4th COMBINE layer) — a capability_profile subset the spawner imposes on the
+sub-session; it is workspace-backed (config.yaml) + composed at construction.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_SESSION_SPAWN_DESCRIPTION = (
+    "Spawn a fresh-context session under your agent to run a task in isolation. "
+    "Choose mode='ephemeral' (auto-vanishes after the task) or 'persistent'. "
+    "Optionally narrow the sub-session's capabilities (restrict-only). The session "
+    "runs the task; its result stays in that session."
+)
+
+_SESSION_SPAWN_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "request": {
+            "type": "string",
+            "description": "The task for the fresh-context session to run.",
+        },
+        "mode": {
+            "type": "string",
+            "enum": ["ephemeral", "persistent"],
+            "default": "persistent",
+            "description": (
+                "ephemeral = the session auto-vanishes after its task; "
+                "persistent = it stays. Chosen at spawn time."
+            ),
+        },
+        "narrowing": {
+            "type": "object",
+            "description": (
+                "Optional per-session capability narrowing (restrict-only, cannot "
+                "widen your envelope): a capability_profile subset, e.g. "
+                "{\"tool_deny\": [\"sandboxed_exec\"]}."
+            ),
+        },
+    },
+    "required": ["request"],
+}
+
+
+async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Dispatch to RouterCallerState.spawn_session_fn (#2103 S1bc).
+
+    Async-dispatch posture: returns a spawn-ack immediately; the spawned session runs
+    the task in isolation. Raises RuntimeError when the host doesn't support
+    session-spawn (= mis-wiring / a non-multi-session host)."""
+    rs = ctx.router_state
+    if rs is None or rs.spawn_session_fn is None:
+        raise RuntimeError(
+            "session_spawn requires ctx.router_state.spawn_session_fn — unavailable "
+            "(host does not support session-spawn / mis-wired dispatcher)."
+        )
+    mode = args.get("mode", "persistent")
+    if mode not in ("ephemeral", "persistent"):
+        return {
+            "status": "error",
+            "kind": "invalid_mode",
+            "error": f"mode must be 'ephemeral' or 'persistent', got {mode!r}.",
+        }
+    return await rs.spawn_session_fn(
+        request=args["request"], mode=mode, narrowing=args.get("narrowing"),
+    )
+
+
+SESSION_SPAWN = ToolDefinition(
+    name="session_spawn",
+    description=_SESSION_SPAWN_DESCRIPTION,
+    parameters=_SESSION_SPAWN_PARAMETERS,
+    gates=ToolGates(router="allow", phase="deny"),
+    handler=_handle,
+    category="delegation",
+    purity="side_effect",
+    dispatch_kind="async",  # the spawned session runs the task; result not returned inline
+)

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -65,6 +65,13 @@ class RouterCallerState:
     # handlers that need to interact with chain / task lifecycle)
     send_to_agent: Callable[..., Awaitable[Any]] | None = None
 
+    # #2103 S1bc: session-spawn dispatch. The session_spawn handler spawns a
+    # fresh-context session under the agent (rewind-tracked via session_spawned),
+    # applies the per-session capability narrowing (S1a), and submits the task.
+    # Bound by RouterLoop with chain_id pre-bound; None when the host doesn't
+    # support session-spawn (= duck-typed, like spawn_skill_fn).
+    spawn_session_fn: Callable[..., Awaitable[Any]] | None = None
+
     # Session-scoped chain identity (= for plan tool, delegate
     # tool, etc.)
     chain_id: str | None = None

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -164,7 +164,8 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "exec__sandboxed_exec, delete_file, file__delete, memory_operation__remember_shared, "
         "memory_operation__remember_agent, memory_operation__forget, remember_shared, "
         "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
-        "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local]\n",
+        "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "
+        "session_spawn]\n",  # #2103: the spawn class too
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")

--- a/tests/test_2103_s1bc_session_drop.py
+++ b/tests/test_2103_s1bc_session_drop.py
@@ -1,0 +1,133 @@
+"""Tier 2: #2103 S1bc — session-spawn rewind-drop + the remove_session teardown seam.
+
+Wires the session side of the #2103 as-of-cut DROP primitive: ``session_spawned`` is a
+real CREATE-event (unioned into ``_LIFECYCLE_CREATE_KINDS``); on rewind-to-before-spawn
+the primitive calls ``_drop_session`` → ``remove_session`` to tear the session down (no
+empty-snapshot orphan). The teardown is full (rmtree) — the global WAL is the durable
+source (the session_spawned record + session_id-routed entries survive), so a
+forward-checkout re-materialises from the WAL, not the dir.
+
+Real AgentRegistry + StateLog + on-disk session dirs (no mocks); the real rewind_to →
+_materialize_rewind path.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import WAL_EVENT_KINDS, StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _LIFECYCLE_CREATE_KINDS, AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    # default create_event_kinds → _LIFECYCLE_CREATE_KINDS (includes session_spawned)
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _make_session_dir(reg: AgentRegistry, name: str, sid: str) -> Path:
+    d = reg._session_state_dir(name, sid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "snapshot.json").write_text("{}", encoding="utf-8")
+    return d
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append("inbox_put", target=agent, msg_id=text, msg_kind="user",
+                            payload={"text": text})
+
+
+async def _spawn_event(log: StateLog, name: str, sid: str) -> int:
+    return await log.append(
+        "session_spawned", entity_kind="session", name=name, sid=sid,
+        mode="ephemeral", narrowing=None,
+    )
+
+
+# ── the kinds are registered ────────────────────────────────────────────────
+
+
+def test_session_spawned_is_a_registered_create_kind() -> None:
+    """Tier 2: session_spawned is in BOTH the WAL allowlist (appendable) AND the
+    lifecycle create-event set (drives the as-of-cut drop), alongside agent_created."""
+    assert "session_spawned" in WAL_EVENT_KINDS
+    assert "session_vanished" in WAL_EVENT_KINDS
+    assert "session_spawned" in _LIFECYCLE_CREATE_KINDS
+    assert "agent_created" in _LIFECYCLE_CREATE_KINDS  # union preserved (no clobber)
+
+
+# ── rewind-drop via the real primitive ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_spawned_after_cut_is_dropped(tmp_path) -> None:
+    """Tier 2: the headline — rewind-to-before a session's spawn DROPS it (no orphan
+    dir), via the real rewind_to → _materialize_rewind → _drop_session → remove_session."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "worker")
+    victim_dir = _make_session_dir(reg, "worker", "task1")
+    log = reg.state_log
+    await _put(log, "worker", "pre")              # seq 1 (the rewind target)
+    await _spawn_event(log, "worker", "task1")    # seq 2 — spawned AFTER the cut
+
+    await reg.rewind_to(1)                         # cut = 1 < spawn-seq 2
+
+    assert not victim_dir.exists()                # the spawned session torn down
+    assert reg.get_session("worker", "task1") is None
+
+
+@pytest.mark.asyncio
+async def test_session_spawned_at_or_before_cut_is_kept(tmp_path) -> None:
+    """Tier 2: boundary — a session spawned at-or-below the cut existed as-of-cut →
+    kept (reconstructed), not dropped."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "worker")
+    kept_dir = _make_session_dir(reg, "worker", "task1")
+    log = reg.state_log
+    await _spawn_event(log, "worker", "task1")    # seq 1 — spawned AT the cut
+    await _put(log, "worker", "v1")               # seq 2
+
+    await reg.rewind_to(1)                         # cut == spawn-seq → existed as-of-cut
+
+    assert kept_dir.is_dir()                       # kept
+
+
+# ── remove_session — the teardown seam ──────────────────────────────────────
+
+
+def test_remove_session_tears_down_spawned(tmp_path) -> None:
+    """Tier 2: remove_session drops a spawned session in-memory + on-disk; get_session
+    then None."""
+    reg = _make_registry(tmp_path)
+    reg._sessions.setdefault("worker", {})["s1"] = SimpleNamespace()
+    d = _make_session_dir(reg, "worker", "s1")
+    assert reg.remove_session("worker", "s1") is True
+    assert reg.get_session("worker", "s1") is None
+    assert not d.exists()
+
+
+def test_remove_session_refuses_main(tmp_path) -> None:
+    """Tier 2: the main session is the agent's — not removable via this seam."""
+    reg = _make_registry(tmp_path)
+    with pytest.raises(ValueError, match="cannot remove the main session"):
+        reg.remove_session("worker", "main")
+
+
+def test_remove_session_unknown_is_noop(tmp_path) -> None:
+    """Tier 2: unknown (name, sid) → False (idempotent — the rewind drop can call it
+    without pre-checking existence)."""
+    reg = _make_registry(tmp_path)
+    assert reg.remove_session("worker", "never") is False

--- a/tests/test_2103_s1bc_session_spawn_tool.py
+++ b/tests/test_2103_s1bc_session_spawn_tool.py
@@ -1,0 +1,137 @@
+"""Tier 2: #2103 S1bc — the session_spawn tool + the spawn_session_recorded seam.
+
+session_spawn (router-only, async-dispatch) spawns a fresh-context session under the
+agent + records it (config-complete session_spawned + per-session config.yaml narrowing)
++ submits the task. The spawned session RUNS the task; routing the result BACK is the
+S1bc-exec follow-on (Stage-4), so the tool returns a spawn-ack (#1822 not-external).
+
+No mocks: real AgentRegistry + a real Session factory + StateLog for the seam; a
+recording callback for the handler→dispatch wiring (the run-loop e2e is the integration,
+exercised by the broad suite).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.tools.session_spawn import SESSION_SPAWN, _handle
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        return Session(agent_name=profile.name, state_log=state_log)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    reg.create("worker")
+    return reg
+
+
+# ── spawn_session_recorded — the action-layer seam ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_emits_config_complete_event(tmp_path: Path) -> None:
+    """Tier 2: spawn_session_recorded emits a config-complete session_spawned WAL event
+    (entity_kind/name/sid/mode/narrowing) — the create-record the rewind primitive +
+    a future re-materialise read. (The narrowing's runtime EFFECT is asserted via the
+    S1a public surface in the next test.)"""
+    reg = _registry(tmp_path)
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="ephemeral", narrowing={"tool_deny": ["sandboxed_exec"]},
+    )
+    ev = next(
+        e for e in reg.state_log.iter_from(0)
+        if e.get("kind") == "session_spawned" and e.get("sid") == sid
+    )
+    assert ev["entity_kind"] == "session" and ev["name"] == "worker"
+    assert ev["mode"] == "ephemeral" and ev["narrowing"] == {"tool_deny": ["sandboxed_exec"]}
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_narrowing_applies_via_s1a(tmp_path: Path) -> None:
+    """Tier 2: the written config.yaml is the #2103 S1a per-session layer — the
+    spawned session's resolved capability is narrowed (restrict-only)."""
+    reg = _registry(tmp_path)
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", narrowing={"tool_deny": ["delete_file"]},
+    )
+    contextual, _ = reg.resolved_profile_for("worker", sid=sid)
+    assert contextual is not None and "delete_file" in contextual.tool_deny
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_no_narrowing_is_inert(tmp_path: Path) -> None:
+    """Tier 2: no narrowing → the per-session S1a layer stays inert (resolved_profile_for
+    is (None, ∅), the public surface), but session_spawned is still emitted
+    (rewind-tracking is unconditional)."""
+    reg = _registry(tmp_path)
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", narrowing=None)
+    assert reg.resolved_profile_for("worker", sid=sid) == (None, frozenset())  # inert
+    assert any(e.get("kind") == "session_spawned" for e in reg.state_log.iter_from(0))
+
+
+# ── the tool: registration + schema + handler dispatch ──────────────────────
+
+
+def test_session_spawn_registered_with_schema() -> None:
+    """Tier 2: session_spawn is router-callable + its schema gates the spawn-time mode
+    (ephemeral|persistent) + requires request."""
+    from reyn.tools import get_default_registry
+    assert "session_spawn" in get_default_registry()
+    params = SESSION_SPAWN.parameters
+    assert params["properties"]["mode"]["enum"] == ["ephemeral", "persistent"]
+    assert params["required"] == ["request"]
+    assert SESSION_SPAWN.gates.router == "allow" and SESSION_SPAWN.gates.phase == "deny"
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatches_to_spawn_session_fn() -> None:
+    """Tier 2: the handler forwards (request, mode, narrowing) to
+    spawn_session_fn and returns its ack (the tool→callback wiring)."""
+    seen: dict = {}
+
+    async def _fake_spawn_session_fn(*, request, mode, narrowing):
+        seen.update(request=request, mode=mode, narrowing=narrowing)
+        return {"status": "spawned", "sid": "abc", "mode": mode}
+
+    ctx = ToolContext(
+        events=None, permission_resolver=None, workspace=None, caller_kind="router",
+        router_state=RouterCallerState(spawn_session_fn=_fake_spawn_session_fn),
+    )
+    result = await _handle({"request": "do X", "mode": "ephemeral"}, ctx)
+    assert seen == {"request": "do X", "mode": "ephemeral", "narrowing": None}
+    assert result["status"] == "spawned" and result["sid"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_handle_rejects_invalid_mode() -> None:
+    """Tier 2: an out-of-enum mode → error-shape (no dispatch)."""
+    async def _never(**_kw):
+        raise AssertionError("must not dispatch on invalid mode")
+
+    ctx = ToolContext(
+        events=None, permission_resolver=None, workspace=None, caller_kind="router",
+        router_state=RouterCallerState(spawn_session_fn=_never),
+    )
+    result = await _handle({"request": "x", "mode": "bogus"}, ctx)
+    assert result["status"] == "error" and result["kind"] == "invalid_mode"
+
+
+@pytest.mark.asyncio
+async def test_handle_requires_spawn_session_fn() -> None:
+    """Tier 2: a host without session-spawn support → RuntimeError (mis-wiring), not a
+    silent success."""
+    ctx = ToolContext(
+        events=None, permission_resolver=None, workspace=None, caller_kind="router",
+        router_state=RouterCallerState(spawn_session_fn=None),
+    )
+    with pytest.raises(RuntimeError, match="spawn_session_fn"):
+        await _handle({"request": "x"}, ctx)

--- a/tests/test_2111_floor_alias_completeness.py
+++ b/tests/test_2111_floor_alias_completeness.py
@@ -55,18 +55,27 @@ def _all_floored_forms() -> list[str]:
 
 
 def test_every_floored_tool_has_both_forms_in_the_floor() -> None:
-    """Tier 2: each floored qualified name AND its bare unwrapped alias (from the
-    invoke_action SoT) is in the floor. A future floored tool whose bare alias is
-    missing → RED (the gap-class guard)."""
+    """Tier 2: each floored name is in the floor — AND, for a name with an
+    invoke_action route, its bare unwrapped alias too (the live gate receives the bare
+    form; a missing alias → RED, the gap-class guard). A BARE-ONLY router tool (no
+    qualified route, e.g. session_spawn) has no alias and is floored by its own name."""
     for cls, qualifieds in _FLOORED_QUALIFIED.items():
         for q in qualifieds:
-            assert q in _BUILTIN_UNTRUSTED_DENY, f"{cls}: qualified {q!r} missing from floor"
+            assert q in _BUILTIN_UNTRUSTED_DENY, f"{cls}: {q!r} missing from floor"
             bare = unwrapped_tool_name(q)
-            assert bare is not None, f"{cls}: {q!r} has no unwrap alias in the SoT"
-            assert bare in _BUILTIN_UNTRUSTED_DENY, (
-                f"{cls}: bare alias {bare!r} of {q!r} missing from floor — the live gate "
-                "receives the bare form (#2111 regression)"
-            )
+            if bare is not None:  # has an invoke_action route → its bare alias must floor too
+                assert bare in _BUILTIN_UNTRUSTED_DENY, (
+                    f"{cls}: bare alias {bare!r} of {q!r} missing from floor — the live "
+                    "gate receives the bare form (#2111 regression)"
+                )
+
+
+def test_session_spawn_is_floored() -> None:
+    """Tier 2: #2103 S1bc — session_spawn (a new spawning capability) is in the floor,
+    so an unbound-delegate-under-deny / untrusted-content turn cannot spawn unbounded
+    sub-sessions (DoS). (Live-gate denial across both floors is covered by the
+    parametrized tests below, which enumerate session_spawn via _all_floored_forms.)"""
+    assert "session_spawn" in _BUILTIN_UNTRUSTED_DENY
 
 
 def test_bare_memory_write_aliases_present() -> None:

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -44,6 +44,10 @@ _NOT_EXTERNAL = {
     # sub-agent's output. The peer reply arrives via the A3 inbound seam
     # (EP5, handle_agent_response → history) and is fenced there in S4.
     "delegate_to_agent",
+    # #2103 S1bc: session_spawn → async dispatch, returns a "spawned" ACK
+    # {status, sid, mode}, not the spawned session's output (result-routing-back is
+    # the S1bc-exec/Stage-4 follow-on, fenced there).
+    "session_spawn",
     # — writes / installs / deletes: return status, not external content —
     "write_file", "edit_file", "delete_file", "drop_source",
     "remember_shared", "remember_agent", "forget_memory",


### PR DESCRIPTION
**[e2e-coder]** — #2103 spawn-primitives, **S1bc** (session-spawn). Foundation + tool together per the cleared gate (no orphaned-session rewind-gap). Builds on S1a (#2106, merged) + dogfood's as-of-cut primitive (#2114) + agent lifecycle (#2117/#2118). No-merge — close-review.

## Scope (B, lead-confirmed)

The LLM `session_spawn` tool: spawn a fresh-context session under the agent + **configure** (the #2103 S1a per-session capability narrowing) + **submit** the task. The spawned session **runs** the task (run-loop started via `ensure_session_running`, FP-0043 4b-2). Routing the result **back** to the spawner is the **S1bc-exec follow-on** (FP-0043 Stage-4 non-main routing) — so the tool is async-dispatch (spawn-ack; #1822 not-external). No throwaway stopgap.

## What

**Rewind-safe foundation** (the gate-critical half): `session_spawned`/`session_vanished` WAL kinds (`session_spawned` = config-complete `{entity_kind, name, sid, mode, narrowing}`); `session_spawned` unioned into `_LIFECYCLE_CREATE_KINDS` (one registration point, no per-site arg); `remove_session` (rmtree teardown — the global WAL is the durable source); `_drop_session` → `remove_session` (was the #2114 stub). So **rewind-to-before-spawn drops the session** via the real `rewind_to` path — no empty-snapshot orphan.

**The tool** (the surface): `spawn_session_recorded` action-seam (spawn + write per-session `config.yaml` + emit `session_spawned`, mirrors `create_agent`); `SESSION_SPAWN` ToolDefinition; `RouterCallerState.spawn_session_fn` + the router_loop binding + the `RouterLoopHost.spawn_session` protocol; `RouterHostAdapter.spawn_session`.

`ephemeral|persistent` mode is the owner's spawn-time choice (recorded; both rewind-safe). The ephemeral **auto-vanish** (after-task teardown) is the immediate-next sub-slice ((D) — `chain_resolve` isn't a clean hook; lead-blessed).

## Test plan

- [x] `tests/test_2103_s1bc_session_drop.py`: rewind-to-before-spawn → dropped (real `rewind_to`); boundary kept; `remove_session` unit. (+ #2114 regression green.)
- [x] `tests/test_2103_s1bc_session_spawn_tool.py`: `spawn_session_recorded` emits config-complete `session_spawned` + narrowing applies via the S1a public surface + inert without narrowing; the tool registration/schema (mode enum); the handler→`spawn_session_fn` dispatch + invalid-mode + missing-fn guards.
- [x] `#1822` classifies `session_spawn` not-external (async ack).
- [x] `ruff` clean · `test_tier_audit.py --strict` — 0 errors
- [x] Full suite `pytest -q -n auto --timeout=120` — **8430 passed, 18 skipped, 3 xfailed**

## Follow-ons (recorded on #2103)

- **ephemeral auto-vanish** sub-slice (after-task teardown).
- **S1bc-exec**: the result-routing-back (FP-0043 Stage-4 non-main routing).

Coordinated with dogfood (the as-of-cut primitive owner): `session_spawned` is config-complete + uniform with `agent_created`; `_drop_session`→`remove_session` is mine; the `_LIFECYCLE_CREATE_KINDS` union is reconciled. Refs #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)