### PR TITLE
fix(#2103): explicit bare-only floor set — #2111 SoT-completeness guard

### DIFF
--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -245,6 +245,17 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     "spawn": frozenset({"session_spawn"}),
 }
 
+# Intentionally BARE-ONLY floored names: router-only tools with NO invoke_action
+# (universal-catalog) route, so ``unwrapped_tool_name`` returns None and the entry IS
+# already the sole invocable form (floored by its own name, no qualified→bare alias to
+# derive). Declared explicitly so the SoT-completeness guard distinguishes an
+# *intentional* bare-only entry from a *malformed* qualified name — a typo or a missing
+# ``_OPERATION_RULES`` entry whose unwrap silently returns None would otherwise floor a
+# non-existent form, leaving the real route UNGUARDED (the #2111 gap-class, in the
+# opposite direction). Invariant (enforced by tests/test_2111_floor_alias_completeness):
+# every name in ``_FLOORED_QUALIFIED`` either unwraps to a bare alias OR is listed here.
+_FLOORED_BARE_ONLY: "frozenset[str]" = frozenset({"session_spawn"})
+
 
 def _with_unwrapped_aliases(qualified: "frozenset[str]") -> "frozenset[str]":
     """Each qualified name PLUS its bare unwrapped alias (from the invoke_action

--- a/tests/test_2111_floor_alias_completeness.py
+++ b/tests/test_2111_floor_alias_completeness.py
@@ -29,6 +29,7 @@ import pytest
 from reyn.runtime.registry import AgentRegistry
 from reyn.security.permissions.capability_profile import (
     _BUILTIN_UNTRUSTED_DENY,
+    _FLOORED_BARE_ONLY,
     _FLOORED_QUALIFIED,
     builtin_untrusted_profile,
     resolve_profile,
@@ -68,6 +69,35 @@ def test_every_floored_tool_has_both_forms_in_the_floor() -> None:
                     f"{cls}: bare alias {bare!r} of {q!r} missing from floor — the live "
                     "gate receives the bare form (#2111 regression)"
                 )
+
+
+def test_floored_entries_are_qualified_or_explicitly_bare_only() -> None:
+    """Tier 2: #2111 SoT-completeness guard (the OTHER gap direction). Every name in
+    _FLOORED_QUALIFIED either unwraps to a bare alias (a real invoke_action route, so
+    derivation covers the live-gate form) OR is in the explicit _FLOORED_BARE_ONLY
+    allowlist. This converts the prior silent ``if bare is not None`` skip into an
+    enforced check: a MALFORMED qualified entry (typo / missing _OPERATION_RULES entry
+    whose unwrap unexpectedly returns None, not declared bare-only) → RED, instead of
+    silently flooring a non-existent form and leaving the real route unguarded."""
+    for cls, qualifieds in _FLOORED_QUALIFIED.items():
+        for q in qualifieds:
+            unwraps = unwrapped_tool_name(q) is not None
+            assert unwraps or q in _FLOORED_BARE_ONLY, (
+                f"{cls}: {q!r} neither unwraps to a bare alias nor is declared in "
+                f"_FLOORED_BARE_ONLY — a malformed floor entry would guard a "
+                f"non-existent form, leaving the real route unguarded (#2111 SoT gap)"
+            )
+
+
+def test_bare_only_set_entries_have_no_qualified_route() -> None:
+    """Tier 2: the inverse — nothing in _FLOORED_BARE_ONLY actually unwraps. A name with
+    a real invoke_action route mis-declared bare-only would bypass the derivation that
+    keeps its bare+qualified forms in lockstep; force it back onto _FLOORED_QUALIFIED."""
+    for name in _FLOORED_BARE_ONLY:
+        assert unwrapped_tool_name(name) is None, (
+            f"{name!r} is declared bare-only but has an invoke_action route — remove it "
+            f"from _FLOORED_BARE_ONLY and let _with_unwrapped_aliases derivation cover it"
+        )
 
 
 def test_session_spawn_is_floored() -> None:


### PR DESCRIPTION
**[e2e-coder]** — #2103 follow-on (lead-sequenced "light bare-only-set first" hygiene). Tightens the #2111 capability-floor SoT against the opposite gap-direction.

## Context
The capability floor's `_FLOORED_QUALIFIED` derives bare aliases from the invoke_action unwrap SoT (`unwrapped_tool_name`) — complete-by-construction (#2111). For a **bare-only** router tool (`session_spawn` — no invoke_action route) the unwrap returns `None`, and the prior completeness test silently skipped its bare-alias check (`if bare is not None`).

## The gap that silent skip hid
A **malformed** qualified entry — a typo, or a qualified name whose `_OPERATION_RULES` entry is missing so `unwrapped_tool_name` unexpectedly returns `None` — would be floored only under that (non-existent) name, leaving the **real** invocable form unguarded. The `if bare is not None` skip meant **no test failure**.

## Fix
- `_FLOORED_BARE_ONLY = {session_spawn}` — the explicit allowlist of *intentional* bare-only floored names, co-located with the SoT.
- **Guard test**: every `_FLOORED_QUALIFIED` name either unwraps to a bare alias OR is declared in `_FLOORED_BARE_ONLY` → a malformed entry is RED instead of silently flooring a non-existent form.
- **Inverse test**: nothing declared bare-only actually unwraps (a name with a real route mis-declared bare-only would bypass the lockstep derivation → force it back onto `_FLOORED_QUALIFIED`).

Matches the established #2111 pattern (`tests/test_2111_floor_alias_completeness.py` already imports the private SoT constants for invariant checks).

## Test plan
- [x] `pytest -q` full suite from rootdir — **8436 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] `tests/test_2111_floor_alias_completeness.py` — 56 passed (2 new guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)