### PR TITLE
fix(#2126): enforce per-session spawn narrowing — re-inject _contextual_permission with sid

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2014,6 +2014,19 @@ class AgentRegistry:
                 yaml.safe_dump({"name": f"_session_{sid}", **narrowing}),
                 encoding="utf-8",
             )
+            # #2126: ENFORCE the narrowing just written. The per-session capability
+            # layer (#1827 / #2103-S1a) only resolves WITH a sid, and every
+            # construction-time factory caller resolves sid=None — so the live spawned
+            # session's _contextual_permission (set once at construction) ignores its
+            # own config.yaml. Re-resolve WITH the sid and re-inject into the live
+            # session here, BEFORE the caller starts its run-loop, so the first turn
+            # gates against the narrowing. Without this the write above is inert
+            # (security-theater: narrowing accepted + persisted but never enforced).
+            session = self._peek_session(name, sid)
+            inject = getattr(session, "apply_per_session_narrowing", None)
+            if callable(inject):
+                contextual, excluded = self.resolved_profile_for(name, sid=sid)
+                inject(contextual, excluded)
         if self._state_log is not None:
             await self._state_log.append(
                 "session_spawned", entity_kind="session", name=name, sid=sid,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2229,6 +2229,35 @@ class Session:
         """
         self._journal.set_anchor_store(anchor_store)
 
+    def apply_per_session_narrowing(
+        self, contextual_permission: "object | None", excluded_categories,
+    ) -> None:
+        """#2126: re-inject the spawner-set per-session capability narrowing AFTER
+        spawn-time config resolution.
+
+        The #1827 / #2103-S1a per-session layer only composes when
+        ``resolved_profile_for`` is called WITH a ``sid`` — and no construction-time
+        factory caller passes one (every frontend resolves ``sid=None``), so the
+        narrowing a spawner writes to the session's ``config.yaml`` is otherwise never
+        enforced (``_contextual_permission`` is set once at construction from the
+        ``sid=None`` resolution). The registry calls this right after spawn-recording,
+        BEFORE the session's run-loop reads these into the live tool gate, so the first
+        turn already gates against the narrowing. Mirrors ``attach_workspace_store``: a
+        registry-driven post-construct injection.
+
+        ``contextual_permission`` is the FULL ``resolved_profile_for(name, sid=sid)``
+        composition (topology + delegate floor + per-session ∩), so it is overwritten —
+        it can only be MORE restrictive than the ``sid=None`` value it replaces (the
+        per-session config is an extra ∩ conjunct, never a re-grant). ``excluded_categories``
+        is UNIONED (never overwritten) so it composes with any construction-time view
+        narrowing (e.g. the #1667 eval ``reyn_source`` exclusions, which are not
+        capability-profile-derived).
+        """
+        self._contextual_permission = contextual_permission
+        self._excluded_categories = self._excluded_categories | frozenset(
+            excluded_categories or ()
+        )
+
     @property
     def current_snapshot(self) -> "AgentSnapshot":
         """Read-only view of the live in-memory AgentSnapshot (ADR-0038).

--- a/tests/test_2103_s1bc_session_spawn_tool.py
+++ b/tests/test_2103_s1bc_session_spawn_tool.py
@@ -41,8 +41,8 @@ def _registry(tmp_path: Path) -> AgentRegistry:
 async def test_spawn_session_recorded_emits_config_complete_event(tmp_path: Path) -> None:
     """Tier 2: spawn_session_recorded emits a config-complete session_spawned WAL event
     (entity_kind/name/sid/mode/narrowing) — the create-record the rewind primitive +
-    a future re-materialise read. (The narrowing's runtime EFFECT is asserted via the
-    S1a public surface in the next test.)"""
+    a future re-materialise read. (The narrowing's runtime EFFECT on the LIVE session is
+    asserted via the production path in the next test.)"""
     reg = _registry(tmp_path)
     sid = await reg.spawn_session_recorded(
         "worker", mode="ephemeral", narrowing={"tool_deny": ["sandboxed_exec"]},
@@ -56,15 +56,31 @@ async def test_spawn_session_recorded_emits_config_complete_event(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_spawn_session_recorded_narrowing_applies_via_s1a(tmp_path: Path) -> None:
-    """Tier 2: the written config.yaml is the #2103 S1a per-session layer — the
-    spawned session's resolved capability is narrowed (restrict-only)."""
+async def test_spawn_session_recorded_enforces_narrowing_on_live_session(tmp_path: Path) -> None:
+    """Tier 2: #2126 — the PRODUCTION path. spawn_session_recorded re-resolves the
+    spawned session's profile WITH its sid and re-injects it into the LIVE session, so the
+    run-loop tool gate enforces the spawner's narrowing.
+
+    The factory builds the session with the sid=None resolution (= every real frontend
+    caller), so before the #2126 re-inject the live session's narrowing was None despite
+    the written config.yaml — the write-wired/read-dead defect. The prior test asserted
+    via ``resolved_profile_for(sid=sid)``, which hand-feeds the sid the production path
+    never passes (a false-green; the per-session layer only loads with a sid). Here we
+    read the per-turn effective narrowing the live tool gate actually consults. Strip the
+    re-inject in spawn_session_recorded → the live gate sees no narrowing → RED."""
     reg = _registry(tmp_path)
     sid = await reg.spawn_session_recorded(
         "worker", mode="persistent", narrowing={"tool_deny": ["delete_file"]},
     )
-    contextual, _ = reg.resolved_profile_for("worker", sid=sid)
-    assert contextual is not None and "delete_file" in contextual.tool_deny
+    session = reg.get_session("worker", sid)
+    # the live tool gate reads _effective_contextual_for_turn(); a fresh spawned session
+    # has no untrusted-content history → it returns the injected _contextual_permission.
+    effective = session._effective_contextual_for_turn()
+    assert effective is not None, (
+        "#2126: the live spawned session must enforce the spawner's narrowing "
+        "(was None — write-wired/read-dead: config.yaml written but never re-injected)"
+    )
+    assert "delete_file" in effective.tool_deny
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #2126 (tui dogfood-lane, deterministic; lead grep-confirmed). The **third** write/register-wired-but-read/enforce-dead defect on the spawn foundation (after #2120 advertise + dispatch).

## Defect
`session_spawn`'s `narrowing` is **written** (per-session `config.yaml` + `session_spawned` WAL) but **never enforced**: the #1827/#2103-S1a per-session capability layer only composes when `resolved_profile_for` is called **with a sid**, and every construction-time factory caller resolves `sid=None`. So the live spawned session's `_contextual_permission` (set once at construction) ignores its own `config.yaml` — write-wired/read-dead.

**Impact (precise, not overstated)**: **NOT an escalation** — the combiner can't widen, the floor + the owner's ⊆-parent hold. What's lost: a spawner **can't restrict** a sub-session below its envelope (the narrowing silently no-ops). **HIGH** (an inert security control), not a critical exploit.

## Fix (lead's seam — option 1, re-inject post-write)
- **`Session.apply_per_session_narrowing(contextual, excluded)`** — the re-inject seam (mirrors `attach_workspace_store`). `_contextual_permission` is **overwritten** with the full `resolved_profile_for(name, sid=sid)` composition (strictly more restrictive — the per-session config is an extra ∩ conjunct, never a re-grant); `excluded_categories` is **unioned** (preserves the #1667 eval `reyn_source` exclusions, which aren't capability-profile-derived).
- **`spawn_session_recorded`** re-resolves with the sid after the `config.yaml` write and re-injects into the live session, **before** the caller starts the run-loop → the first turn gates against the narrowing.

## False-green test fixed
`test_spawn_session_recorded_narrowing_applies_via_s1a` asserted via `resolved_profile_for(sid=sid)` — which **hand-feeds the sid the production path never passes** (so it passed even with the bug). Repurposed into `test_spawn_session_recorded_enforces_narrowing_on_live_session`: asserts the **live** session via `_effective_contextual_for_turn()` (the seam the tool gate reads). **Falsified RED** by stripping the re-inject — the old hand-fed-sid test stayed green when stripped (the exact false-green class).

## Test plan
- [x] `pytest -q` full suite from rootdir — **8442 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] production-path test falsified RED-when-stripped (the old hand-fed-sid test did not)
- [ ] (tui) live re-verify: a spawned session with `narrowing` actually has the narrowed tool denied at the live gate (deterministic repro from #2126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)