### PR TITLE
feat(#2103 S1bc-exec): correlate spawned-session results — trusted kind=spawned_session header

### DIFF
--- a/src/reyn/runtime/services/a2a_handler.py
+++ b/src/reyn/runtime/services/a2a_handler.py
@@ -74,6 +74,19 @@ def _new_chain_id() -> str:
     return str(uuid.uuid4())
 
 
+_SPAWN_TASK_SUMMARY_MAX = 120
+
+
+def _summarize_task(task: str) -> str:
+    """#2103 S1bc-exec: a single-line, length-capped summary of the spawner's original
+    request for the trusted ``task=`` header. The task is TRUSTED (the spawner's own
+    request from its record), so this only flattens whitespace + truncates — no fencing."""
+    flat = " ".join((task or "").split())
+    if len(flat) > _SPAWN_TASK_SUMMARY_MAX:
+        return flat[: _SPAWN_TASK_SUMMARY_MAX - 1] + "…"
+    return flat
+
+
 # Localized user-facing message when a peer agent's reply signals failure (B2-H2).
 _PEER_REPLY_FAILED_MSG: dict[str, str] = {
     "ja": (
@@ -176,6 +189,10 @@ class A2AHandler:
         # FP-0050/#1822 S4b (EP5, Class A): content-threat scan + fence config.
         # Inbound peer text (request/response) is fenced before entering history.
         threat_scan: "object | None" = None,
+        # #2103 S1bc-exec: this session's LIVE sid (for the responder_sid tag when a
+        # spawned session replies) + the spawner's trusted spawned-task lookup.
+        session_id_fn: "Callable[[], str | None] | None" = None,
+        lookup_spawned_task: "Callable[[str | None], str | None] | None" = None,
     ) -> None:
         self._events = event_log
         self._chains = chain_manager
@@ -192,6 +209,8 @@ class A2AHandler:
         self._reset_router_turn_counter = reset_router_turn_counter
         self._send_request_callback = send_request_callback
         self._send_response_callback = send_response_callback
+        self._session_id_fn = session_id_fn            # #2103 S1bc-exec
+        self._lookup_spawned_task = lookup_spawned_task  # #2103 S1bc-exec
         self._on_chain_timeout_fire = on_chain_timeout_fire
         self._emit_router_cap_exhausted_fn = emit_router_cap_exhausted_fn
 
@@ -302,8 +321,15 @@ class A2AHandler:
             from_agent=self.agent_name, to_agent=to,
             depth=depth, chain_id=chain_id,
         )
+        # #2103 S1bc-exec: when THIS responder is a SPAWNED (non-main) session, tag the
+        # response with its own sid — the correlation key the receiver matches against its
+        # trusted spawned-task record. A main/normal-delegate responder tags None (no
+        # spawn correlation), so only spawned-session results carry it.
+        responder_sid = self._session_id_fn() if self._session_id_fn else None
+        if responder_sid in (None, "main"):
+            responder_sid = None
         await self._send_response_callback(
-            to, self.agent_name, response, depth, chain_id,
+            to, self.agent_name, response, depth, chain_id, responder_sid,
         )
 
     def _fence_inbound(self, text: str) -> str:
@@ -483,19 +509,40 @@ class A2AHandler:
         # FP-0050/#1822 S4b (EP5, Class A): fence + scan the untrusted peer reply
         # before it enters history. Only the history-bound copy is fenced; the
         # raw ``response`` stays for chain-resolution routing below.
-        injected_text = (
-            f"[task_completed] kind=agent "
-            f"from={from_agent or '<unknown>'} chain_id={chain_id}\n"
-            f"reply: {self._fence_inbound(response)}"
+        # #2103 S1bc-exec: a result from a session THIS agent SPAWNED (correlated by the
+        # responder's sid against our OWN trusted spawn record) renders a distinct
+        # kind=spawned_session header so the LLM reads it as "my spawned session finished
+        # task <T>", not an inbound from a peer agent. SECURITY SPLIT: the header (sid +
+        # task) is OS-generated TRUSTED framing — the task is OUR own request from the
+        # record, NOT the spawned session's echo (which a compromised sub-session could
+        # forge); ONLY the reply stays _fence_inbound'd (untrusted output). A spoofed /
+        # unknown sid → lookup miss → the plain kind=agent fallback (still fenced).
+        responder_sid = payload.get("responder_sid")
+        spawned_task = (
+            self._lookup_spawned_task(responder_sid) if self._lookup_spawned_task else None
         )
-        self._append_history(
-            "user", injected_text, _now_iso(),
-            {
+        if spawned_task is not None:
+            injected_text = (
+                f"[task_completed] kind=spawned_session sid={responder_sid} "
+                f"task={_summarize_task(spawned_task)} chain_id={chain_id}\n"
+                f"reply: {self._fence_inbound(response)}"
+            )
+            history_meta = {
+                "source": "spawned_session_result",
+                "spawned_sid": responder_sid, "depth": depth, "chain_id": chain_id,
+            }
+        else:
+            injected_text = (
+                f"[task_completed] kind=agent "
+                f"from={from_agent or '<unknown>'} chain_id={chain_id}\n"
+                f"reply: {self._fence_inbound(response)}"
+            )
+            history_meta = {
                 "source": "agent_response",
                 "from_agent": from_agent, "depth": depth,
                 "chain_id": chain_id,
-            },
-        )
+            }
+        self._append_history("user", injected_text, _now_iso(), history_meta)
         self._events.emit(
             "agent_response_received",
             from_agent=from_agent, depth=depth, chain_id=chain_id,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -114,6 +114,8 @@ class RouterHostAdapter:
         memory: Any,                            # MemoryService
         journal: Any,                           # SnapshotJournal
         agent_registry: Any,                    # AgentRegistry | None
+        record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
+        live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
         skill_enumerate_fn: Callable[[set], list],
         agent_workspace_dir: Path,
         # File op callbacks
@@ -314,6 +316,8 @@ class RouterHostAdapter:
         self._memory = memory
         self._journal = journal
         self._registry = agent_registry
+        self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
+        self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
         self._skill_enumerate_fn = skill_enumerate_fn
         self._workspace_dir = Path(agent_workspace_dir)
         # File callbacks
@@ -931,9 +935,30 @@ class RouterHostAdapter:
                 "session_spawn requires a registry (multi-session host) — unavailable "
                 "in this context."
             )
+        # #2103 S1bc-exec GAP A guard: only the MAIN session may spawn. A spawned
+        # (non-main) session's result would route back by AGENT NAME to the agent's main
+        # session — NOT to this spawning sid — i.e. a silent misroute. Routing to a
+        # specific (agent, sid) is the first-class non-main addressing tracked in #2130;
+        # until then, refuse rather than misroute. Read the LIVE sid (the constructor's
+        # cached session_id is stale for spawned sessions, stamped post-construction).
+        live_sid = self._live_session_id_fn() if self._live_session_id_fn else self._session_id
+        if live_sid not in (None, "main"):  # "main" = registry._DEFAULT_SID (avoid the import cycle)
+            return {
+                "status": "error",
+                "kind": "nested_spawn_unsupported",
+                "error": (
+                    "session_spawn is only available from the main session: a spawned "
+                    "session's result can't yet route back to a non-main spawner "
+                    "(first-class (agent,sid) addressing — #2130)."
+                ),
+            }
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
         )
+        # #2103 S1bc-exec: record sid→task BEFORE submitting, so a fast result finds the
+        # trusted task on return (else it falls back to the kind=agent rendering).
+        if self._record_spawned_task is not None:
+            self._record_spawned_task(sid, request)
         session = self._registry.ensure_session_running(self._agent_name, sid)
         if session is not None:
             await session.submit_agent_request(

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 import uuid
+from collections import OrderedDict
 from typing import Any, Awaitable, Callable, Literal
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,12 @@ ROUTER_SKILL_NAME = "skill_router"
 # converges in 1-2 rounds; the cap is purely a guard against a pathological spin
 # (logged, never silently looped).
 _QUIESCE_MAX_ROUNDS = 50
+
+# #2103 S1bc-exec: cap on the in-flight spawned-task correlation record (sid → task).
+# Each entry is evicted when its result routes back; this cap bounds the pathological
+# case where results never arrive (spawned crash / lost reply) so the map can't grow
+# unbounded. Holds only pending spawns whose result hasn't returned.
+_MAX_SPAWNED_TASKS = 256
 
 # Localized user-facing messages for the router retry-exhausted fallback (F8).
 # Keys are BCP-47-style language codes matching config `output_language`.
@@ -1339,6 +1346,13 @@ class Session:
         self.history: list[ChatMessage] = []
         self.inbox: asyncio.Queue = asyncio.Queue()
         self.outbox: asyncio.Queue = asyncio.Queue()
+        # #2103 S1bc-exec: sid → original-task record for sessions THIS session spawned.
+        # When a spawned session's result routes back, the result header renders
+        # ``task=<the spawner's OWN request>`` from THIS trusted record (keyed by the
+        # spawned sid) — never the spawned session's echo (which a compromised sub-session
+        # could forge into trusted framing). Bounded-by-construction: evicted on result
+        # arrival; a max-size cap (evict-oldest) caps a never-arriving result.
+        self._spawned_tasks: "OrderedDict[str, str]" = OrderedDict()
         # Detached by default — AgentRegistry.attach() flips this on. Outbox
         # `status`/`trace` emissions are dropped while detached so background
         # agents don't accumulate display noise.
@@ -1575,6 +1589,12 @@ class Session:
             memory=self._memory,
             journal=self._journal,
             agent_registry=self._registry,
+            # #2103 S1bc-exec: record a spawned session's sid→task (the trusted result
+            # header source) + read this session's LIVE sid (the cached session_id above
+            # is stale for spawned sessions, stamped post-construction) for the non-main
+            # spawn guard.
+            record_spawned_task=self.record_spawned_task,
+            live_session_id_fn=lambda: self._session_id,
             skill_enumerate_fn=enumerate_available_skills,
             agent_workspace_dir=self.workspace_dir,
             file_read=self._file_read,
@@ -1815,6 +1835,11 @@ class Session:
             set_router_loop_delegations=lambda v: setattr(self, "_router_loop_delegations", v),
             get_router_loop_agent_replies=lambda: self._router_loop_agent_replies,
             set_router_loop_agent_replies=lambda v: setattr(self, "_router_loop_agent_replies", v),
+            # #2103 S1bc-exec: read this session's LIVE sid (spawned sessions are stamped
+            # post-construction, so a cached value would be stale) for the responder_sid
+            # tag; + the trusted spawned-task lookup for rendering a returning result.
+            session_id_fn=lambda: self._session_id,
+            lookup_spawned_task=self.lookup_and_evict_spawned_task,
         )
 
         # session.py refactor PR-1: ContextBudgetAdvisor owns the five
@@ -2782,18 +2807,30 @@ class Session:
     async def _a2a_send_response(
         self,
         to: str, from_agent: str, response: str, depth: int, chain_id: str,
+        responder_sid: "str | None" = None,
     ) -> None:
         """Transport callback: submit agent_response to ``to``.
 
         Silently drops when the target no longer exists (race on shutdown).
+        ``responder_sid`` (#2103 S1bc-exec) carries the responder's own sid when it is a
+        spawned session, so the receiver can correlate the result to its spawn record.
         """
-        if self._registry is None or not self._registry.exists(to):
+        if self._registry is None:
+            # #2103 S1bc-exec hardening: a result-routing path that silently no-ops on an
+            # unwired registry is a bad failure mode — fail LOUD (logged) so a mis-wiring
+            # surfaces. Production wires the registry; this guards the regression.
+            logger.warning(
+                "a2a response to %r dropped: session has no registry wired (mis-wiring; "
+                "the result-routing path is inert)", to,
+            )
+            return
+        if not self._registry.exists(to):
             return
         target = self._registry.get_or_load(to)
         await self._registry.ensure_running(to)
         await target.submit_agent_response(
             from_agent=from_agent, response=response,
-            depth=depth, chain_id=chain_id,
+            depth=depth, chain_id=chain_id, responder_sid=responder_sid,
         )
 
     def load_history(self) -> None:
@@ -2839,11 +2876,36 @@ class Session:
 
     async def submit_agent_response(
         self, *, from_agent: str, response: str, depth: int, chain_id: str,
+        responder_sid: "str | None" = None,
     ) -> None:
         await self._put_inbox("agent_response", {
             "from_agent": from_agent, "response": response, "depth": depth,
             "chain_id": chain_id,
+            # #2103 S1bc-exec: the responder's own session id when it is a SPAWNED
+            # (non-main) session — the correlation key the receiver matches against its
+            # _spawned_tasks record to render the trusted "task=" header.
+            "responder_sid": responder_sid,
         })
+
+    # ── #2103 S1bc-exec: spawned-task correlation record (bounded) ──────────────
+
+    def record_spawned_task(self, sid: str, task: str) -> None:
+        """Record a session-I-spawned's ``sid → task`` BEFORE submitting it, so when its
+        result routes back the header renders ``task=<my OWN request>`` from this TRUSTED
+        record (not the spawned session's echo). Bounded: evicted on result arrival;
+        ``_MAX_SPAWNED_TASKS`` cap evicts oldest so a never-arriving result can't grow it."""
+        self._spawned_tasks[sid] = task
+        self._spawned_tasks.move_to_end(sid)
+        while len(self._spawned_tasks) > _MAX_SPAWNED_TASKS:
+            self._spawned_tasks.popitem(last=False)  # evict oldest in-flight
+
+    def lookup_and_evict_spawned_task(self, sid: "str | None") -> "str | None":
+        """The TRUSTED task for a spawned ``sid``, or None (not one I spawned / already
+        consumed). Evict-on-read — a result is consumed once; a spoofed/unknown sid → None
+        → the caller renders the safe ``kind=agent`` fallback (still fenced)."""
+        if not sid:
+            return None
+        return self._spawned_tasks.pop(sid, None)
 
     async def shutdown(self) -> None:
         # `shutdown` is a control signal, not recovery state — skip WAL/snapshot.

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -57,54 +57,108 @@ def _scripted_llm():
     return _fake_llm
 
 
-@pytest.mark.asyncio
-async def test_main_spawn_result_routes_back_as_fenced_inbound(tmp_path, monkeypatch):
-    """Tier 2: S1bc-exec verification — a MAIN-session spawner's spawned-session result
-    routes back via the fenced A2A response bus and lands in the spawner's history as a fenced
-    ``[task_completed] kind=agent`` entry carrying the chain_id (the correlation channel).
+async def _find_history(session, needle: str):
+    for _ in range(40):  # ~2s bounded
+        for m in session.history:
+            txt = m.content if isinstance(m.content, str) else str(m.content)
+            if needle in txt:
+                return m, txt
+        await asyncio.sleep(0.05)
+    return None, ""
 
-    GAP B is asserted in-line: the entry's ``from`` is the agent's OWN name (spawn passes
-    from_agent=agent_name), NOT the spawned sid — so it is not yet correlatable to the
-    specific spawn. That is the primary S1bc-exec work (the rendering)."""
+
+@pytest.mark.asyncio
+async def test_main_spawn_result_routes_back_correlated_as_spawned_session(tmp_path, monkeypatch):
+    """Tier 2: S1bc-exec — a MAIN-session spawner's spawned-session result routes back via
+    the fenced A2A bus and lands as a CORRELATABLE ``[task_completed] kind=spawned_session
+    sid=<sid> task=<TRUSTED task> chain_id=<cid>`` entry (the GAP B correlation rendering).
+
+    The task in the header is the spawner's OWN request from its trusted record (NOT the
+    spawned session's echo); only the reply is fenced. Without the record-lookup render
+    branch this would be the uncorrelatable ``kind=agent from=<self>`` (the original gap)."""
     monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")  # the spawner (main session)
 
-    # main spawns a session for a task (the real action-layer seam).
     sid = await reg.spawn_session_recorded("worker", mode="persistent")
     spawned = reg.ensure_session_running("worker", sid)
     assert spawned is not None
+    # the spawner records the trusted sid→task (= what the adapter does at spawn time).
+    main.record_spawned_task(sid, "summarize the Q3 report")
 
     chain_id = "chain-spawn-verify-1"
-    # The spawned session completes its task and routes the result back — this is the
-    # EXACT call the run-loop's agent_request handler makes on completion
-    # (a2a_handler.py:451). It goes through the real registry routing:
-    # _a2a_send_response → registry.get_or_load(agent) + ensure_running → submit_agent_response.
+    # The spawned session completes + routes the result back (the run-loop's completion
+    # call, a2a_handler:451) through the real registry routing. send_agent_response tags
+    # responder_sid=<the spawned session's own sid> automatically.
     await spawned._send_agent_response(
         to="worker", response="TASK RESULT: did the thing", depth=0, chain_id=chain_id,
     )
 
-    # main's run-loop processes the routed agent_response → handle_agent_response appends
-    # the fenced [task_completed] entry (pre-LLM-branch, so it lands regardless of the
-    # scripted continuation). Poll the spawner's history for it (bounded).
-    async def _find_entry():
-        for _ in range(40):  # ~2s bounded
-            for m in main.history:
-                txt = m.content if isinstance(m.content, str) else str(m.content)
-                if "[task_completed] kind=agent" in txt and "TASK RESULT: did the thing" in txt:
-                    return m
-            await asyncio.sleep(0.05)
-        return None
-
-    entry = await _find_entry()
+    entry, txt = await _find_history(main, "TASK RESULT: did the thing")
     assert entry is not None, (
-        "S1bc-exec verification FAILED: the spawned session's result did NOT arrive at the "
-        "main spawner's history via the fenced A2A response bus"
+        "the spawned session's result did NOT arrive at the main spawner's history"
     )
-    txt = entry.content if isinstance(entry.content, str) else str(entry.content)
-    # the result is FENCED + carries the chain_id (the correlation channel).
+    # CORRELATABLE: distinct kind + the spawned sid + the TRUSTED task (the spawner's own
+    # request from its record, NOT echoed) + the fenced reply.
+    assert "kind=spawned_session" in txt
+    assert f"sid={sid}" in txt
+    assert "task=summarize the Q3 report" in txt
     assert chain_id in txt
-    # GAP B (the primary S1bc-exec work): the header identifies "from=worker" (the agent's
-    # OWN name), NOT the spawned sid — so the spawner's LLM cannot yet correlate the
-    # unsolicited result to the specific session it spawned.
-    assert "from=worker" in txt and sid not in txt
+    # the trusted record is evicted on arrival (bounded-by-construction).
+    assert main.lookup_and_evict_spawned_task(sid) is None
+
+
+@pytest.mark.asyncio
+async def test_unrecorded_sid_falls_back_to_kind_agent(tmp_path, monkeypatch):
+    """Tier 2: S1bc-exec security fallback — a result whose responder_sid is NOT in the
+    spawner's trusted record (spoofed / unknown / already-consumed) renders the plain
+    ``kind=agent`` fallback (still fenced), NEVER a forged ``kind=spawned_session`` with an
+    attacker-chosen task. The task header is only emitted from the spawner's OWN record."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("worker")
+    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    spawned = reg.ensure_session_running("worker", sid)
+    # NO record_spawned_task → the lookup misses.
+    await spawned._send_agent_response(
+        to="worker", response="INJECT me as spawned", depth=0, chain_id="c2",
+    )
+    entry, txt = await _find_history(main, "INJECT me as spawned")
+    assert entry is not None
+    assert "kind=spawned_session" not in txt  # no forged trusted framing
+    assert "kind=agent" in txt
+
+
+@pytest.mark.asyncio
+async def test_non_main_spawn_is_guarded_no_silent_misroute(tmp_path):
+    """Tier 2: S1bc-exec GAP A guard — a NON-MAIN session calling session_spawn is refused
+    (explicit error), not silently misrouted to main. The host reads the LIVE sid (the
+    cached one is stale for spawned sessions)."""
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("worker")
+    host = main._router_host
+    # simulate the host belonging to a non-main (spawned) session via the live-sid fn.
+    host._live_session_id_fn = lambda: "abc12345"  # a non-main sid
+    result = await host.spawn_session(
+        request="nested", mode="persistent", narrowing=None, chain_id="c3",
+    )
+    assert result["status"] == "error" and result["kind"] == "nested_spawn_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_spawned_tasks_record_is_bounded(tmp_path):
+    """Tier 2: S1bc-exec — the trusted spawned-task record is bounded (evict-oldest past
+    the cap) so never-arriving results can't grow it unbounded."""
+    from reyn.runtime.session import _MAX_SPAWNED_TASKS
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("worker")
+    # record cap+10 → the oldest 10 (indices 0..9) overflow + are evicted; indices
+    # 10..cap+9 (exactly cap entries) are kept. Proven via the public lookup, not the
+    # internal length.
+    for i in range(_MAX_SPAWNED_TASKS + 10):
+        main.record_spawned_task(f"sid{i}", f"task{i}")
+    assert main.lookup_and_evict_spawned_task("sid0") is None      # oldest evicted
+    assert main.lookup_and_evict_spawned_task("sid9") is None      # last of the overflow
+    assert main.lookup_and_evict_spawned_task("sid10") == "task10"  # first kept (cap boundary)
+    assert main.lookup_and_evict_spawned_task(f"sid{_MAX_SPAWNED_TASKS + 9}") == \
+        f"task{_MAX_SPAWNED_TASKS + 9}"                            # newest kept

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -1,0 +1,110 @@
+"""S1bc-exec verification (lead-gated step 1): EXECUTE the main-case spawn result
+round-trip — a spawned session's completion-time response routes back to the spawner
+via the fenced A2A response bus and lands as a correlatable fenced inbound.
+
+This is the verification the de-scope was gated on: the trace shows the result-routing
+largely EXISTS (handle_agent_response unconditionally appends a fenced ``[task_completed]
+kind=agent`` history entry), but it must be EXECUTED end-to-end, not just code-read.
+
+It also pins the concrete GAP B finding: spawn submits ``from_agent=<the agent's own
+name>``, so the rendered header is "from=<self>" with NO spawned sid / task ref — not
+LLM-correlatable as "the session you spawned for <task>". The PRIMARY S1bc-exec work is
+the correlation rendering, not the routing.
+
+Real AgentRegistry + a real Session factory + a scripted call_llm_tools (no network) —
+the actual registry routing path (_a2a_send_response → submit_agent_response → the
+session run-loop's handle_agent_response).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        # wire the registry back-reference (= what production frontends pass) so the
+        # A2A response callback (_a2a_send_response) can route — without it the
+        # response is silently dropped (registry is None).
+        return Session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg  # set BEFORE any session is constructed (get_or_load / spawn)
+    reg.create("worker")
+    return reg
+
+
+def _scripted_llm():
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
+
+
+@pytest.mark.asyncio
+async def test_main_spawn_result_routes_back_as_fenced_inbound(tmp_path, monkeypatch):
+    """Tier 2: S1bc-exec verification — a MAIN-session spawner's spawned-session result
+    routes back via the fenced A2A response bus and lands in the spawner's history as a fenced
+    ``[task_completed] kind=agent`` entry carrying the chain_id (the correlation channel).
+
+    GAP B is asserted in-line: the entry's ``from`` is the agent's OWN name (spawn passes
+    from_agent=agent_name), NOT the spawned sid — so it is not yet correlatable to the
+    specific spawn. That is the primary S1bc-exec work (the rendering)."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("worker")  # the spawner (main session)
+
+    # main spawns a session for a task (the real action-layer seam).
+    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    spawned = reg.ensure_session_running("worker", sid)
+    assert spawned is not None
+
+    chain_id = "chain-spawn-verify-1"
+    # The spawned session completes its task and routes the result back — this is the
+    # EXACT call the run-loop's agent_request handler makes on completion
+    # (a2a_handler.py:451). It goes through the real registry routing:
+    # _a2a_send_response → registry.get_or_load(agent) + ensure_running → submit_agent_response.
+    await spawned._send_agent_response(
+        to="worker", response="TASK RESULT: did the thing", depth=0, chain_id=chain_id,
+    )
+
+    # main's run-loop processes the routed agent_response → handle_agent_response appends
+    # the fenced [task_completed] entry (pre-LLM-branch, so it lands regardless of the
+    # scripted continuation). Poll the spawner's history for it (bounded).
+    async def _find_entry():
+        for _ in range(40):  # ~2s bounded
+            for m in main.history:
+                txt = m.content if isinstance(m.content, str) else str(m.content)
+                if "[task_completed] kind=agent" in txt and "TASK RESULT: did the thing" in txt:
+                    return m
+            await asyncio.sleep(0.05)
+        return None
+
+    entry = await _find_entry()
+    assert entry is not None, (
+        "S1bc-exec verification FAILED: the spawned session's result did NOT arrive at the "
+        "main spawner's history via the fenced A2A response bus"
+    )
+    txt = entry.content if isinstance(entry.content, str) else str(entry.content)
+    # the result is FENCED + carries the chain_id (the correlation channel).
+    assert chain_id in txt
+    # GAP B (the primary S1bc-exec work): the header identifies "from=worker" (the agent's
+    # OWN name), NOT the spawned sid — so the spawner's LLM cannot yet correlate the
+    # unsolicited result to the specific session it spawned.
+    assert "from=worker" in txt and sid not in txt

--- a/tests/test_a2a_handler_invariants.py
+++ b/tests/test_a2a_handler_invariants.py
@@ -141,10 +141,11 @@ def _build_handler(
 
     async def _send_response_callback(
         to: str, from_agent: str, response: str, depth: int, chain_id: str,
+        responder_sid: "str | None" = None,
     ) -> None:
         responses_sent.append({
             "to": to, "from_agent": from_agent, "response": response,
-            "depth": depth, "chain_id": chain_id,
+            "depth": depth, "chain_id": chain_id, "responder_sid": responder_sid,
         })
 
     async def _on_chain_timeout_fire(chain_id: str) -> None:

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -354,7 +354,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     upstream_session = Session(agent_name="upstream_agent")
     upstream_received: list[dict] = []
 
-    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
+    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id, responder_sid=None):
         upstream_received.append({
             "from_agent": from_agent,
             "response": response,
@@ -880,7 +880,7 @@ async def test_agent_request_empty_router_reply_sends_marker_upstream(
     upstream_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
-    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
+    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id, responder_sid=None):
         upstream_received.append({
             "from_agent": from_agent,
             "response": response,
@@ -946,7 +946,7 @@ async def test_agent_request_router_cap_exhausted_sends_marker_upstream(
     upstream_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
-    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
+    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id, responder_sid=None):
         upstream_received.append({
             "from_agent": from_agent,
             "response": response,
@@ -1081,7 +1081,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     origin_session = Session(agent_name="origin_agent")
     upstream_received: list[dict] = []
 
-    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id):
+    async def _fake_submit_agent_response(*, from_agent, response, depth, chain_id, responder_sid=None):
         upstream_received.append({
             "from_agent": from_agent,
             "response": response,


### PR DESCRIPTION
**[e2e-coder]** — S1bc-exec result-routing, the highest-utility #2103 follow-on. Recon → design-call → executed verification → patch, all on lead's finalized shape.

## What the verification found (already merged-quality infra in commit 1)
The result-routing **already exists** — a spawned session's completion-time response routes back via the fenced A2A response bus and lands in the spawner's history. Confirmed by a **real 2-session round-trip test** (no stubs). The gap was **correlation**: it rendered `[task_completed] kind=agent from=<the agent's own name>` with no spawned sid → the spawner's LLM saw a result "from itself", uncorrelatable to the spawn it made (GAP B).

## The fix
A returning spawned-session result now renders a distinctly-kinded, correlatable entry:
```
[task_completed] kind=spawned_session sid=<sid> task=<task summary> chain_id=<cid>
reply: <fenced result>
```

**Security split (lead-reviewed):** the header (sid + task) is OS-generated **trusted** framing — the task is the spawner's **own request**, read from its **own record** keyed by the spawned sid, **never** the spawned session's echo (which a compromised sub-session could forge into trusted framing). **Only the reply** stays `_fence_inbound`'d.

- `Session._spawned_tasks`: a **bounded** sid→task record (record-before-submit; evict-on-arrival; `_MAX_SPAWNED_TASKS` cap evicts oldest). sids are random `uuid4` → a spoofed sid misses the record → **safe `kind=agent` fallback** (still fenced).
- `responder_sid` threaded through the response path; a spawned (non-main) responder tags its own sid, main/delegate responders tag None.
- **GAP A guard:** a NON-MAIN session calling `session_spawn` is **refused** (explicit error, not a silent misroute to main). Reads the **live** session sid (the adapter's cached one is stale for spawned sessions). Non-main `(agent,sid)` addressing → **#2130**.
- Hardening: `_a2a_send_response` **logs** (no longer silently drops) when the registry is unwired.

## Tests (real 2-session harness)
- correlation render (`kind=spawned_session` + sid + trusted task + fenced reply + eviction)
- **security fallback** — unrecorded/spoofed sid → `kind=agent`, **falsified RED** by stripping the lookup (the correlation branch goes RED, the fallback stays green)
- the non-main guard; the bounded record (cap proven via public eviction)

## Test plan
- [x] `pytest -q` full suite from rootdir — **8448 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] correlation render-branch falsified RED-when-stripped
- [x] (tui) live re-verify: a spawned session's result appears to the spawner as `kind=spawned_session sid=<sid> task=<…>` with the reply fenced — **PASS** (tui-coder, stronger model; evidence in comment)

Close-review focus (per lead): record-not-echo, the bound, the spoof→fallback, the trusted/fenced split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)