### PR TITLE
fix(#2132): per-session narrowing covers all invocable forms (bidirectional alias)

### DIFF
--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -101,6 +101,19 @@ def load_capability_profile(path: "str | Path") -> CapabilityProfile:
     )
 
 
+def _expand_tool_forms(names: "tuple[str, ...]") -> "frozenset[str]":
+    """#2132: every name PLUS all its invocable forms (bare + qualified), so a per-session
+    TOOL deny/allow covers the dual-form tool on EVERY scheme path (the gate matches the
+    effective resolved name). Derived from the ``invoke_action`` SoT — complete-by-
+    construction, bidirectional (a name written in either form expands to both)."""
+    from reyn.tools.universal_dispatch import all_invocable_forms
+
+    forms: "set[str]" = set()
+    for name in names:
+        forms |= all_invocable_forms(name)
+    return frozenset(forms)
+
+
 def resolve_profile(
     profile: CapabilityProfile,
 ) -> "tuple[ContextualPermission, frozenset[str]]":
@@ -115,11 +128,18 @@ def resolve_profile(
     so do not reduce the excluded set (they are a no-op, not an error — the loader
     is forward-compat).
     """
+    # #2132: normalize the TOOL axis to ALL invocable forms (bare AND qualified). A
+    # spawner's narrowing may name a tool in either spelling, but the live gate matches
+    # the effective resolved name (scheme-dependent), so a deny/allow of bare
+    # ``delete_file`` must also cover native ``file__delete`` (and vice versa) — else a
+    # dual-form tool (file__* / mcp__*) is reachable via the unlisted form. The per-session
+    # analogue of the #2111 floor's qualified→bare derivation, but BIDIRECTIONAL.
     contextual = ContextualPermission(
         tool_allow=(
-            frozenset(profile.tool_allow) if profile.tool_allow is not None else None
+            _expand_tool_forms(profile.tool_allow)
+            if profile.tool_allow is not None else None
         ),
-        tool_deny=frozenset(profile.tool_deny),
+        tool_deny=_expand_tool_forms(profile.tool_deny),
         # #2074 S1 — SKILL / MCP axes (carried; ContextualLayer enforces them in S3).
         skill_allow=(
             frozenset(profile.skill_allow) if profile.skill_allow is not None else None

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -533,6 +533,35 @@ def unwrapped_tool_name(qualified_name: str) -> "str | None":
     return rule[0] if rule is not None else None
 
 
+# Reverse of the qualified→bare _OPERATION_RULES map (bare → qualified), built once.
+# Each bare tool has exactly one static qualified (universal-catalog) spelling.
+_BARE_TO_QUALIFIED: "Final[dict[str, str]]" = {
+    bare: qualified for qualified, (bare, _h) in _OPERATION_RULES.items()
+}
+
+
+def all_invocable_forms(name: str) -> "frozenset[str]":
+    """Every invocable form of a tool ``name`` — the bare AND the qualified
+    (universal-catalog ``category__verb``) spelling — derived from the ``invoke_action``
+    ``_OPERATION_RULES`` source of truth.
+
+    The live capability gate matches the EFFECTIVE resolved name, which differs by scheme
+    (some paths present the qualified catalog name; invoke_action unwraps to the bare
+    name). A deny/allow specified in EITHER form must therefore cover BOTH, or a dual-form
+    tool (``file__*`` / ``mcp__*``) is reachable via the unlisted spelling (#2132 — the
+    per-session-narrowing analogue of the #2111 floor's qualified→bare derivation, but
+    BIDIRECTIONAL because a spawner's narrowing may be written in either form). A name with
+    no static rule (a single-form tool) → just itself."""
+    forms = {name}
+    rule = _OPERATION_RULES.get(name)
+    if rule is not None:
+        forms.add(rule[0])  # name is qualified → add its bare alias
+    qualified = _BARE_TO_QUALIFIED.get(name)
+    if qualified is not None:
+        forms.add(qualified)  # name is bare → add its qualified alias
+    return frozenset(forms)
+
+
 __all__ = [
     "ResolvedAction",
     "UnknownActionError",
@@ -540,6 +569,7 @@ __all__ = [
     "resolve_describe_action",
     "suggest_similar_names",
     "unwrapped_tool_name",
+    "all_invocable_forms",
     "KNOWN_STATIC_QUALIFIED_NAMES",
     "known_qualified_name_for_category",
 ]

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -533,11 +533,19 @@ def unwrapped_tool_name(qualified_name: str) -> "str | None":
     return rule[0] if rule is not None else None
 
 
-# Reverse of the qualified→bare _OPERATION_RULES map (bare → qualified), built once.
-# Each bare tool has exactly one static qualified (universal-catalog) spelling.
-_BARE_TO_QUALIFIED: "Final[dict[str, str]]" = {
-    bare: qualified for qualified, (bare, _h) in _OPERATION_RULES.items()
-}
+# Reverse of the qualified→bare _OPERATION_RULES map (bare → {qualified, …}), built once.
+# A MULTIMAP, not 1:1: today each bare tool has a single qualified spelling, but building
+# the reverse as a set means a future SECOND qualified form for some bare tool can't
+# silently drop a spelling (which would re-open the completeness gap this closes — a
+# security path, so it must not depend on the 1:1 assumption holding).
+def _build_bare_to_qualified() -> "dict[str, frozenset[str]]":
+    acc: "dict[str, set[str]]" = {}
+    for qualified, (bare, _h) in _OPERATION_RULES.items():
+        acc.setdefault(bare, set()).add(qualified)
+    return {bare: frozenset(quals) for bare, quals in acc.items()}
+
+
+_BARE_TO_QUALIFIED: "Final[dict[str, frozenset[str]]]" = _build_bare_to_qualified()
 
 
 def all_invocable_forms(name: str) -> "frozenset[str]":
@@ -556,9 +564,9 @@ def all_invocable_forms(name: str) -> "frozenset[str]":
     rule = _OPERATION_RULES.get(name)
     if rule is not None:
         forms.add(rule[0])  # name is qualified → add its bare alias
-    qualified = _BARE_TO_QUALIFIED.get(name)
-    if qualified is not None:
-        forms.add(qualified)  # name is bare → add its qualified alias
+    qualified_forms = _BARE_TO_QUALIFIED.get(name)
+    if qualified_forms is not None:
+        forms |= qualified_forms  # name is bare → add ALL its qualified aliases (multimap)
     return frozenset(forms)
 
 

--- a/tests/test_2103_s1a_per_session_config.py
+++ b/tests/test_2103_s1a_per_session_config.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from reyn.runtime.registry import AgentRegistry
-from reyn.security.permissions.effective import ContextualPermission
+from reyn.security.permissions.effective import (
+    ContextualPermission,
+    tool_contextually_denied,
+)
 
 
 def _registry(tmp_path: Path, *, default: str = "inherit") -> AgentRegistry:
@@ -86,7 +89,10 @@ def test_composes_with_topology_binding(tmp_path: Path) -> None:
     reg = _registry(tmp_path)
     _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [sandboxed_exec]\n")
     contextual, _ = reg.resolved_profile_for("worker", sid="task1")
-    assert {"delete_file", "sandboxed_exec"} <= contextual.tool_deny  # both layers
+    # #2132: both layers AND both invocable forms of each (the gate matches the effective
+    # resolved name — the qualified catalog form must be denied too, not just the bare).
+    assert {"delete_file", "file__delete", "sandboxed_exec", "exec__sandboxed_exec"} \
+        <= contextual.tool_deny
 
 
 # ── restrict-only: the per-session layer can NEVER re-grant ─────────────────
@@ -102,7 +108,30 @@ def test_per_session_cannot_regrant_topology_deny(tmp_path: Path) -> None:
     # the per-session config tries to ALLOW delete_file (+ another) — must not re-grant
     _write_per_session(reg, "worker", "task1", "name: s\ntool_allow: [delete_file, read_file]\n")
     contextual, _ = reg.resolved_profile_for("worker", sid="task1")
-    assert "delete_file" in contextual.tool_deny  # topology deny survives the allow-list
+    # #2132: both invocable forms of the topology deny survive the allow-list.
+    assert {"delete_file", "file__delete"} <= contextual.tool_deny
+
+
+# ── #2132: per-session narrowing covers ALL invocable forms at the live gate ──
+
+
+def test_2132_per_session_deny_covers_both_forms_at_the_gate(tmp_path: Path) -> None:
+    """Tier 2: #2132 — a per-session ``tool_deny`` written in EITHER spelling denies BOTH
+    invocable forms at the REAL contextual gate. The bypass tui found:
+    ``narrowing=[delete_file]`` must deny the native ``file__delete`` the production
+    enumerate-all catalog advertises (the gate matches the effective resolved name).
+    Strip the ``_expand_tool_forms`` normalization → the unlisted form passes the gate → RED."""
+    reg = _registry(tmp_path)
+    _write_per_session(reg, "worker", "task1", "name: s\ntool_deny: [delete_file]\n")
+    contextual, _ = reg.resolved_profile_for("worker", sid="task1")
+    assert tool_contextually_denied(contextual, "delete_file")    # bare (specified)
+    assert tool_contextually_denied(contextual, "file__delete")   # native qualified — the gap
+
+    # the reverse direction: a qualified-specified deny covers the bare form too.
+    _write_per_session(reg, "worker", "task2", "name: s\ntool_deny: [file__delete]\n")
+    contextual2, _ = reg.resolved_profile_for("worker", sid="task2")
+    assert tool_contextually_denied(contextual2, "file__delete")  # qualified (specified)
+    assert tool_contextually_denied(contextual2, "delete_file")   # bare — both directions
 
 
 # ── composes with the #2081 _delegate floor (delegate + per-session) ─────────

--- a/tests/test_2103_s1bc_session_spawn_tool.py
+++ b/tests/test_2103_s1bc_session_spawn_tool.py
@@ -80,7 +80,10 @@ async def test_spawn_session_recorded_enforces_narrowing_on_live_session(tmp_pat
         "#2126: the live spawned session must enforce the spawner's narrowing "
         "(was None — write-wired/read-dead: config.yaml written but never re-injected)"
     )
-    assert "delete_file" in effective.tool_deny
+    # #2132: BOTH invocable forms must be denied — the bare ``delete_file`` AND the native
+    # qualified ``file__delete`` the production enumerate-all catalog advertises. Asserting
+    # only the bare form was the false-green that hid the partial enforcement.
+    assert {"delete_file", "file__delete"} <= effective.tool_deny
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — 🔴 security fix. The #2129 per-session spawn narrowing I merged was **partial** (tui deterministic).

## Defect
`resolve_profile` applied `tool_deny` / `tool_allow` **raw**, missing the alias normalization the #2111 floor has. So narrowing the bare `delete_file` did **not** deny the native `file__delete` the production enumerate-all catalog advertises → **bypassable** for any dual-form tool (`file__*` / `mcp__*`). The same #2111 gap-class on the per-session path: **WIRED but not COMPLETE**. Repro: `narrowing=['delete_file']` → `file__delete` DENIED=`False`.

## Fix
- **`universal_dispatch.all_invocable_forms(name)`**: every invocable form (bare + qualified) of a tool, derived **bidirectionally** from the `invoke_action` `_OPERATION_RULES` SoT (+ its reverse map). Unlike the floor's qualified→bare `unwrapped_tool_name`, a spawner's narrowing may be written in **either** form, so both directions are covered.
- **`resolve_profile`**: normalize the TOOL axis (`tool_deny` + `tool_allow`) through it → complete-by-construction on every scheme path, for **all** profiles (topology + per-session).
- **False-green tests fixed**: the #2129 enforcement test + the s1a layer tests asserted only the bare form → now assert **both** forms denied. Added a #2132 **live-gate** test (`tool_contextually_denied`) for both forms AND both spelling-directions, **falsified RED** by reverting the normalization (which also reds the corrected #2129 test — the false-green is now caught).

## Test plan
- [x] `pytest -q` full suite from rootdir — **8449 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] live-gate test falsified RED-when-reverted (both forms, both directions)
- [ ] (tui) re-verify: `narrowing=['delete_file']` → `file__delete` DENIED at the live gate (the deterministic repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)