### PR TITLE
fix(#2107): recovery notifies the task REQUESTER, not the parent (§16 S1)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -516,11 +516,16 @@ whole sub-tree** (DOWN-cascade, §18). There is **no forced cancel** — the
 assignee's in-flight work is rejected by the **terminal-state guard** on
 `update_status` at its next write (so no straggler lands, and a sibling task's
 work is untouched). This is correct under 1:N (a session owns many tasks) and
-needs no cross-session machinery. **UP-notify** (§16): abort emits a generic P6
-`task_disposition` event per aborted task (carrying `task_id` / `requester` /
-`origin` / `disposition`); the A2A layer routes `origin=external` tasks to their
-external (webhook) channel — internal requesters need no notify (they own the
-tree, and the assignee discovers the abort via the terminal guard).
+needs no cross-session machinery. **UP-notify** (§16): a non-completed terminal
+(aborted / failed / cap_exceeded) with **still-alive dependents** notifies the task's
+**requester** (the §16 disposition notify-target — the request-owner) to decide recovery.
+For an `origin=self` (internal) task the requester's **session is woken** (the slice-7
+TaskWaker) so its LLM re-wires the stuck dependents via ordinary task ops (P7 — no
+`decision=` vocabulary); for an `origin=external` task the A2A layer routes it to the
+external (webhook) channel. The requester is always present, so a **root task is notified
+too** (#2107: the prior parent-keyed routing dropped roots). Abort also emits a generic
+P6 `task_disposition` event per aborted task (`task_id` / `requester` / `origin` /
+`disposition`).
 
 **States:** `pending` / `ready` / `in_progress` / `blocked` / `completed` /
 `failed` / `aborted` / `archived`.

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -268,9 +268,9 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
             )
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
-        # doesn't satisfy a dependency edge → route the disposition to the parent's
-        # session to decide recovery (the OQ-7/H5 gap-close).
-        await _route_terminal_to_parent(ctx, _backend(ctx), task, disposition="failed")
+        # doesn't satisfy a dependency edge → route the disposition to the task's
+        # REQUESTER to decide recovery (§16; the OQ-7/H5 gap-close, #2107).
+        await _route_terminal_to_requester(ctx, _backend(ctx), task, disposition="failed")
     return _ok("task.update_status", task=task.to_dict())
 
 
@@ -331,47 +331,51 @@ async def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigge
                 task, fenced_description=_fence_text(ctx, task.description))
 
 
-async def _route_terminal_to_parent(
+async def _route_terminal_to_requester(
     ctx: OpContext, backend, terminal_task, *, disposition: str | None = None,
 ) -> None:
-    """slice 6-ext §C: when a task reaches a non-completed terminal (aborted /
-    failed / cap_exceeded) and has STILL-ALIVE dependents, notify its parent's
-    session to decide recovery (the parent re-wires via ordinary ops — NOT a
-    `decision=` vocabulary, P7).
+    """§16 (#2107): when a task reaches a non-completed terminal (aborted / failed /
+    cap_exceeded) and has STILL-ALIVE dependents, notify its REQUESTER — the §16
+    disposition notify-target (the request-owner) — to decide recovery. The requester
+    re-wires via ordinary task ops (repoint to a substitute / remove the edge / fail
+    them / handle the work itself) — P7, no `decision=` vocabulary.
 
-    ``disposition`` is the **first-class** terminal reason carried in BOTH the P6
-    event and the parent payload (#1953 slice 8 no-conflation invariant): a
-    budget ``cap_exceeded`` must be distinguishable from a genuine error
-    ``failed`` — the parent's recovery differs, and a downstream reader must not
-    misread a cap-hit as an error. Defaults to the task's status value (the abort
-    path) when not given explicitly.
+    The requester is ALWAYS present (every task carries one), so a ROOT task is notified
+    too — this restores §16 and fixes #2107. The prior parent-keyed routing returned
+    early on ``if not parent_id`` (slice 6-ext §C), so a flat self-task plan's mid-task
+    failure SILENTLY DROPPED the recovery wake and left its dependents stuck.
 
-    The wake is via ``OpContext.task_waker`` (slice 7 real driver; None = no-op
-    stub — only the P6 audit fires). Guards: a root task (no parent) and a parent
-    that is itself terminal (its own cascade handles it) route nothing."""
+    Origin-gated to SELF (internal): a self-task's requester is a session → wake it. An
+    EXTERNAL task's requester is an A2A/webhook stakeholder (not a session); its
+    disposition rides the separate webhook channel (the abort-all-dependents + propagate
+    is formalized in §16 S2), so this internal-recovery wake leaves it to the webhook —
+    preserving the prior external behavior.
+
+    ``disposition`` is the **first-class** terminal reason carried in BOTH the P6 event
+    and the requester payload (#1953 slice 8 no-conflation): a budget ``cap_exceeded``
+    must stay distinguishable from a genuine ``failed`` — the recovery differs. Defaults
+    to the task's status value (the abort path) when not given explicitly. The wake is via
+    ``OpContext.task_waker`` (None = no-op stub — only the P6 audit fires)."""
+    if terminal_task.origin is not TaskOrigin.SELF:
+        return  # external → the webhook channel (§16 S2), not an internal session wake
     disp = disposition or terminal_task.status.value
-    parent_id = getattr(terminal_task, "parent_id", None)
-    if not parent_id:
-        return
     deps_on_it = await backend.dependents(terminal_task.task_id)
     stuck = [d for d in deps_on_it if d.status not in TERMINAL_STATES]
     if not stuck:
         return
-    parent = await backend.get(parent_id)
-    if parent is None or parent.status in TERMINAL_STATES:
-        return  # parent-gone guard (the parent's own cascade subsumes this)
+    requester = terminal_task.requester
     events = getattr(ctx, "events", None)
     if events is not None:
         # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation).
         events.emit(
             "task_dependency_aborted", task_id=terminal_task.task_id,
-            disposition=disp, parent_id=parent_id,
-            parent_session=parent.assignee, dependents=[d.task_id for d in stuck],
+            disposition=disp, requester=requester,
+            dependents=[d.task_id for d in stuck],
         )
     waker = getattr(ctx, "task_waker", None)
     if waker is not None:
-        await waker.notify_parent_decide(
-            parent_session=parent.assignee, terminal_task=terminal_task,
+        await waker.notify_requester_decide(
+            requester_session=requester, terminal_task=terminal_task,
             dependents=stuck, disposition=disp,
         )
 
@@ -426,8 +430,10 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
     # UP-notify (2b-2): emit a generic, term-neutral P6 disposition event per
     # aborted task carrying requester + origin. The A2A layer (slice 5) consumes
     # these and fires the external (webhook) channel for origin=external tasks
-    # (the persistent stakeholders); internal requesters need no notify (they own
-    # the tree + the assignee discovers the abort via the terminal-guard).
+    # (the persistent stakeholders). §16 (#2107): internal requesters ARE notified
+    # too — via _route_terminal_to_requester below (the requester's session is woken
+    # to recover stuck dependents). The prior "internal requesters need no notify"
+    # claim left a flat self-task plan's mid-task failure silently stuck.
     events = getattr(ctx, "events", None)
     if events is not None:
         for t in aborted:
@@ -436,10 +442,11 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
                 requester=t.requester, origin=t.origin.value, root=op.task_id,
             )
     root = aborted[0]
-    # slice 6-ext §C: route the aborted root to its parent so a stuck sibling
-    # dependent gets a recovery decision (the OQ-7/H5 gap-close). The cascade's
-    # descendants have an in-subtree (now terminal) parent → the guard skips them.
-    await _route_terminal_to_parent(ctx, _backend(ctx), root, disposition="aborted")
+    # §16 (#2107): route the aborted root to its REQUESTER so a stuck sibling dependent
+    # gets a recovery decision (the OQ-7/H5 gap-close). A root self-task is now notified
+    # (previously dropped on the missing parent_id). The cascade's descendants are
+    # themselves terminal → _route_terminal_to_requester finds no stuck dependents for them.
+    await _route_terminal_to_requester(ctx, _backend(ctx), root, disposition="aborted")
     # #1800 slice 5c: task_end lifecycle hooks for the aborted sub-tree — SYMMETRIC
     # with task_start (at create) + task_end (at COMPLETED): every started task
     # fires an end. ``status="aborted"`` lets an operator discriminate completion

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -68,6 +68,7 @@ def build_router_op_context(
     # CAS (the no-bypass-by-construction invariant requires the REAL session_id).
     session_id: str | None = None,
     task_backend: Any = None,
+    task_waker: Any = None,  # #2107: OS TaskWaker so a router task.* terminal wakes the requester
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
@@ -148,5 +149,6 @@ def build_router_op_context(
         # gate enforces byte-equal to the phase path (no None-placeholder mask).
         session_id=session_id,
         task_backend=task_backend,
+        task_waker=task_waker,  # #2107: a router task.* terminal wakes the requester
         hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -150,6 +150,7 @@ class RouterHostAdapter:
         # ops hit the SAME assignee/requester gate as the phase path (no None mask).
         session_id: str | None = None,
         task_backend: Any = None,
+        task_waker: Any = None,  # #1953 slice 7 / #2107: the OS TaskWaker for the router op-ctx
         hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator configured
@@ -281,6 +282,7 @@ class RouterHostAdapter:
         self.hot_reloader = hot_reloader
         self._session_id = session_id  # #1953 dynamic-wire: task.* CAS gate key
         self._task_backend = task_backend  # #1953 dynamic-wire: session-scoped Task backend
+        self._task_waker = task_waker  # #1953 slice 7 / #2107: OS TaskWaker for router task ops
         self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c: task_start/end dispatch
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
@@ -1611,6 +1613,11 @@ class RouterHostAdapter:
             # task.* CAS gate enforces (no None-placeholder mask-pass).
             session_id=self._session_id,
             task_backend=self._task_backend,
+            # #2107: thread the TaskWaker so a chat-router task.* terminal (abort/failed)
+            # actually WAKES the requester. It was the ONE op-ctx builder missing it
+            # (task_backend was #1953-wired here; task_waker was not), so the live chat
+            # recovery wake was silently skipped (ctx.task_waker=None).
+            task_waker=self._task_waker,
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
         )
 

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -28,7 +28,10 @@ guard). This in-process driver is distinct from the external A2A webhook *sweep*
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # The OS-generic inbox kinds (P7 — no skill/A2A vocabulary; the run-loop routes
 # them to a router turn). NOT added to the WAL closed vocab (WAL-vs-P6 separation).
@@ -47,12 +50,30 @@ class TaskWaker:
         self._agent_name = agent_name
 
     async def _wake(self, session_id: str, kind: str, text: str, **meta: Any) -> None:
-        """The canonical wake-triple. ``session_id`` is the assignee/parent
-        routing-key ``<transport>:<native_id>``; resolve the sibling session of
-        THIS agent, deliver the OS message, and ensure its run-loop runs (booting
-        a loopless A2A/MCP session; idempotent for a looped one)."""
-        transport, _, native_id = session_id.partition(":")
-        session = self._registry.resolve_session(self._agent_name, transport, native_id)
+        """The canonical wake-triple. Resolve the sibling session of THIS agent that
+        ``session_id`` names, deliver the OS message, and ensure its run-loop runs
+        (booting a loopless A2A/MCP session; idempotent for a looped one).
+
+        ``session_id`` is one of two forms:
+        - a **bare per-session sid** (e.g. ``"main"`` / ``_DEFAULT_SID`` or a spawned uuid)
+          — a self-task / chat requester. Resolved by the ``(agent, sid)`` lookup to the
+          LIVE session. It MUST NOT be partitioned on ``":"`` — ``"main".partition(":")``
+          → transport ``"main"`` / native ``""`` get-or-spawns a PHANTOM session and the
+          real session is never woken (#2107 S1 live-found: the live default-session inbox
+          stayed empty while a phantom got the wake).
+        - a **transport routing-key** ``"<transport>:<native_id>"`` (an A2A / MCP requester)
+          — the get-or-spawn routing-key mapping."""
+        if ":" in session_id:
+            transport, _, native_id = session_id.partition(":")
+            session = self._registry.resolve_session(self._agent_name, transport, native_id)
+        else:
+            session = self._registry.get_session(self._agent_name, session_id)
+            if session is None:
+                logger.warning(
+                    "task wake: no live session %r for agent %r — wake dropped",
+                    session_id, self._agent_name,
+                )
+                return
         await session._put_inbox(kind, {"text": text, "sender": "task:os", "meta": dict(meta)})
         self._registry.ensure_session_running(self._agent_name, session_id)
 

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -9,8 +9,8 @@ slice 6-ext stub) like ``task_backend``.
 Two drivers:
   - ``wake_ready_dependent(task)`` — complete-side: a dependent the OS promoted to
     ``ready`` is woken to continue its work.
-  - ``notify_parent_decide(...)`` — abort/failed-side: the parent of a terminal
-    task with stuck dependents is woken to decide recovery (it re-wires via
+  - ``notify_requester_decide(...)`` — abort/failed-side: the REQUESTER of a terminal
+    task with stuck dependents is woken to decide recovery (§16; it re-wires via
     ordinary task ops — NOT a ``decision=`` vocabulary, P7).
 
 Single-agent scope: a dependency lives WITHIN one decomposition = within one
@@ -33,7 +33,10 @@ from typing import Any
 # The OS-generic inbox kinds (P7 — no skill/A2A vocabulary; the run-loop routes
 # them to a router turn). NOT added to the WAL closed vocab (WAL-vs-P6 separation).
 WAKE_READY_KIND = "task_ready"
-WAKE_PARENT_KIND = "task_dependency_aborted"
+# §16: the requester-decide wake kind. The VALUE stays "task_dependency_aborted" (the
+# stable event-kind contract the run-loop + tui consume); only the constant name drops
+# the stale "parent" vocabulary (recovery now notifies the requester, not a parent).
+WAKE_REQUESTER_KIND = "task_dependency_aborted"
 
 
 class TaskWaker:
@@ -116,18 +119,18 @@ class TaskWaker:
             task_id=task.task_id,
         )
 
-    async def notify_parent_decide(self, *, parent_session: str, terminal_task: Any,
-                                   dependents: "list[Any]", disposition: str | None = None) -> None:
-        """Abort/failed/cap_exceeded-side: wake the parent to decide recovery for
-        its stuck dependents (it re-wires via ordinary task ops — repoint to a
-        substitute / remove the edge / fail / handle itself; P7 — no decision
-        vocabulary). ``disposition`` is the first-class terminal reason (#1953
-        slice 8 no-conflation: a budget ``cap_exceeded`` vs a genuine ``failed``)."""
+    async def notify_requester_decide(self, *, requester_session: str, terminal_task: Any,
+                                      dependents: "list[Any]", disposition: str | None = None) -> None:
+        """§16 abort/failed/cap_exceeded-side: wake the REQUESTER (the request-owner) to
+        decide recovery for its stuck dependents (it re-wires via ordinary task ops —
+        repoint to a substitute / remove the edge / fail / handle itself; P7 — no decision
+        vocabulary). ``disposition`` is the first-class terminal reason (#1953 slice 8
+        no-conflation: a budget ``cap_exceeded`` vs a genuine ``failed``)."""
         dep_ids = [d.task_id for d in dependents]
         disp = disposition or terminal_task.status.value
         await self._wake(
-            parent_session, WAKE_PARENT_KIND,
-            f"[task] A dependency of your sub-tasks reached {disp!r}: task "
+            requester_session, WAKE_REQUESTER_KIND,
+            f"[task] A dependency of your request reached {disp!r}: task "
             f"{terminal_task.task_id!r} ('{terminal_task.name}'). These dependents "
             f"are now stuck: {dep_ids}. Decide recovery using the task ops (repoint "
             f"to a substitute, remove the dependency, fail them, or handle the work "
@@ -136,4 +139,4 @@ class TaskWaker:
         )
 
 
-__all__ = ["TaskWaker", "WAKE_READY_KIND", "WAKE_PARENT_KIND"]
+__all__ = ["TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND"]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1575,6 +1575,7 @@ class Session:
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
             session_id=self._session_id,
             task_backend=self._task_backend,
+            task_waker=self._task_waker,  # #2107: thread the TaskWaker into the router op-ctx
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: task_start/end (router path)
             agent_name=self.agent_name,
             agent_role=self._agent_role,

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -82,6 +82,9 @@ def make_adapter(
     resolver: ModelResolver | None = None,
     turn_budget_engine: object = None,
     environment_backend: object = None,  # #1477: optional for sandbox-cwd tests
+    task_backend: object = None,  # #1953 / #2107: session-scoped Task backend
+    task_waker: object = None,    # #2107: OS TaskWaker (router task.* terminal → requester wake)
+    session_id: "str | None" = None,
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -135,4 +138,7 @@ def make_adapter(
         agent_replies_tracker=lambda: _replies,
         turn_budget_engine=turn_budget_engine,
         environment_backend=environment_backend,
+        task_backend=task_backend,
+        task_waker=task_waker,
+        session_id=session_id,
     )

--- a/tests/test_task_ops_gate_equivalence_1953.py
+++ b/tests/test_task_ops_gate_equivalence_1953.py
@@ -135,3 +135,43 @@ async def test_no_session_context_refuses_rather_than_mask():
     ctx = _tool_ctx(router_state=None)  # no router factory + no phase op_context
     result = await _UPDATE({"task_id": task_id, "status": "x"}, ctx)
     assert result.get("error_kind") == "no_session_context", result
+
+
+@pytest.mark.asyncio
+async def test_router_opctx_threads_task_waker_so_chat_abort_wakes_requester():
+    """Tier 2: #2107 LIVE chat path — make_router_op_context MUST thread the TaskWaker so a
+    chat task__abort actually WAKES the requester. task_waker was the ONE op-ctx field the
+    chat-router builder did not thread (the #1953 wire threaded task_backend but not
+    task_waker), so a live chat recovery wake was silently skipped (ctx.task_waker=None)
+    despite the routing + bare-sid fix being correct. This goes through the REAL
+    make_router_op_context (not a hand-built OpContext). Strip the wire → ctx.task_waker is
+    None → the requester is never woken → RED."""
+    from types import SimpleNamespace
+
+    from reyn.task import Task, TaskState
+    from tests._support.router_host_adapter import make_adapter
+
+    class _RecWaker:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def notify_requester_decide(self, **kw) -> None:
+            self.calls.append(kw)
+
+    backend = InMemoryTaskBackend()
+    # a self-task plan whose requester is the chat session ("main", _DEFAULT_SID).
+    await backend.create(Task(task_id="t2", name="t2", assignee="main", requester="main",
+                              status=TaskState.IN_PROGRESS, deps=[]))
+    await backend.create(Task(task_id="t3", name="t3", assignee="main", requester="main",
+                              deps=["t2"]))
+
+    waker = _RecWaker()
+    adapter = make_adapter(agent_name="alice", task_backend=backend,
+                           task_waker=waker, session_id="main")
+    ctx = adapter.make_router_op_context()
+
+    assert ctx.task_waker is waker  # the wire — the exact gap make_router_op_context had
+
+    # abort t2 through the REAL router op-ctx → the requester ("main") must be woken.
+    await taskmod._abort(SimpleNamespace(task_id="t2", reason=None), ctx, "control_ir")
+    assert waker.calls and waker.calls[0]["requester_session"] == "main"

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -1,17 +1,18 @@
-"""Tier 1/2: #1953 slice 6-ext — mutable dependency ops + abort/failed→parent routing.
+"""Tier 1/2: #1953 slice 6-ext — mutable dependency ops + abort/failed→REQUESTER routing.
 
 Extends slice 6 with `task.remove_dependency` / `task.repoint_dependency` (the
-parent's recovery moves) over the shared OS-authority readiness primitive
+requester's recovery moves) over the shared OS-authority readiness primitive
 (`_derive_readiness`: promote/demote across the pre-run states only), and routes a
-non-completed terminal (aborted/failed) with still-alive dependents to the parent's
-session (the OQ-7/H5 gap-close; the wake is the slice-7 TaskWaker, stubbed here via
-a recording waker). Real sqlite + in-memory backends; no mocks.
+non-completed terminal (aborted/failed) with still-alive dependents to the task's
+REQUESTER (§16 / #2107; the prior slice-6-ext parent-keyed routing dropped root tasks).
+The wake is the slice-7 TaskWaker, stubbed here via a recording waker. Real sqlite +
+in-memory backends; no mocks.
 
 Falsification per axis (CLEAN-RED): remove promotes a now-satisfied dependent +
 the I-1 last-dep case + idempotent + never-demotes; repoint cycle/dangling rejected
 ATOMICALLY (graph unchanged) + demote + promote + in_progress-untouched; the
-abort/failed routing fires the waker + P6 with the right parent/dependents, and the
-no-parent / parent-terminal guards route nothing.
+abort/failed routing fires the waker + P6 to the right REQUESTER/dependents, a ROOT
+self-task is NOT dropped (#2107), and an EXTERNAL-origin task skips the internal wake.
 """
 from __future__ import annotations
 
@@ -31,9 +32,10 @@ from reyn.task import (
 
 
 def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
-          requester="req", parent_id=None):
+          requester="req", parent_id=None, origin=None):
+    kw = {} if origin is None else {"origin": origin}
     return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
-                status=status, deps=list(deps or []), parent_id=parent_id)
+                status=status, deps=list(deps or []), parent_id=parent_id, **kw)
 
 
 @pytest.fixture(params=["inmem", "sqlite"])
@@ -211,15 +213,15 @@ class _Rec:
 
 
 class _RecordingWaker:
-    """A real (non-mock) injectable TaskWaker recording its parent-notify calls."""
+    """A real (non-mock) injectable TaskWaker recording its requester-notify calls (§16)."""
 
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
-    async def notify_parent_decide(self, *, parent_session, terminal_task, dependents,
-                                   disposition=None):
+    async def notify_requester_decide(self, *, requester_session, terminal_task, dependents,
+                                      disposition=None):
         self.calls.append({
-            "parent_session": parent_session,
+            "requester_session": requester_session,
             "terminal_task": terminal_task.task_id,
             "dependents": [d.task_id for d in dependents],
             "disposition": disposition,
@@ -271,59 +273,62 @@ async def test_op_remove_emits_readiness_on_promote():
 
 
 @pytest.mark.asyncio
-async def test_op_abort_routes_disposition_to_parent():
-    """Tier 2: aborting a task with a still-alive sibling dependent routes the
-    disposition to the parent's session (recording waker fired + P6)."""
+async def test_op_abort_routes_disposition_to_requester():
+    """Tier 2: §16 — aborting a task with a still-alive sibling dependent routes the
+    disposition to the task's REQUESTER (not the parent) — recording waker fired + P6."""
     b = InMemoryTaskBackend()
     rec = _Rec()
     waker = _RecordingWaker()
-    await b.create(_task("P", assignee="sP", requester="req", status=TaskState.IN_PROGRESS))
-    await b.create(_task("B", assignee="sB", requester="req", parent_id="P",
-                         status=TaskState.IN_PROGRESS))
-    await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))
 
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, events=rec, waker=waker, session_id="req"), "control_ir")
 
-    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B",
+    assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
                             "dependents": ["A"], "disposition": "aborted"}]
     routed = [f for k, f in rec.events if k == "task_dependency_aborted"]
-    assert routed and routed[0]["parent_session"] == "sP" and routed[0]["dependents"] == ["A"]
+    assert routed and routed[0]["requester"] == "req" and routed[0]["dependents"] == ["A"]
     assert routed[0]["disposition"] == "aborted"
 
 
 @pytest.mark.asyncio
-async def test_op_failed_routes_disposition_to_parent():
-    """Tier 2: a `failed` declaration (assignee) with dependents routes to parent."""
+async def test_op_failed_routes_disposition_to_requester():
+    """Tier 2: §16 — a `failed` declaration (assignee) with dependents routes to the
+    task's REQUESTER."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
-    await b.create(_task("P", assignee="sP", requester="req", status=TaskState.IN_PROGRESS))
-    await b.create(_task("B", assignee="sB", requester="req", parent_id="P",
-                         status=TaskState.IN_PROGRESS))
-    await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))
 
     # failed is assignee-gated → caller must be B's assignee.
     await taskmod._update_status(SimpleNamespace(task_id="B", status="failed"),
                                  _opctx(b, waker=waker, session_id="sB"), "control_ir")
-    assert waker.calls == [{"parent_session": "sP", "terminal_task": "B",
+    assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
                             "dependents": ["A"], "disposition": "failed"}]
 
 
 @pytest.mark.asyncio
-async def test_op_abort_root_without_parent_routes_nothing():
-    """Tier 2: a root task (no parent) routes nothing on abort."""
+async def test_op_abort_root_routes_to_requester():
+    """Tier 2: §16/#2107 — a ROOT task (no parent) with a stuck dependent DOES route
+    its disposition — to the REQUESTER. The prior parent-keyed routing dropped it (no
+    parent → `if not parent_id: return`), silently stranding a flat self-task plan's
+    dependents. Now the requester (always present) is woken to recover."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
     await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
-    await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))  # dependent, no common parent
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))  # root, no parent
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, waker=waker, session_id="req"), "control_ir")
-    assert waker.calls == []  # B.parent_id is None → no parent to mediate
+    assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
+                            "dependents": ["A"], "disposition": "aborted"}]  # #2107: NOT dropped
 
 
 @pytest.mark.asyncio
-async def test_op_abort_terminal_parent_routes_nothing():
-    """Tier 2: an already-terminal parent routes nothing (its own cascade subsumes)."""
+async def test_op_abort_with_terminal_parent_still_routes_to_requester():
+    """Tier 2: §16 — the parent's state is now IRRELEVANT — recovery keys on the
+    REQUESTER, not the parent. A task whose (vestigial) parent is already terminal still
+    routes its disposition to its requester (the prior parent-gone guard is gone)."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
     await b.create(_task("P", assignee="sP", requester="req", status=TaskState.ARCHIVED))
@@ -332,4 +337,44 @@ async def test_op_abort_terminal_parent_routes_nothing():
     await b.create(_task("A", deps=["B"], assignee="sA", requester="req", parent_id="P"))
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, waker=waker, session_id="req"), "control_ir")
-    assert waker.calls == []  # parent-gone guard
+    assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
+                            "dependents": ["A"], "disposition": "aborted"}]
+
+
+@pytest.mark.asyncio
+async def test_2107_flat_self_task_plan_mid_failure_notifies_requester():
+    """Tier 2: §16/#2107 repro — a FLAT self-task plan (t1→t2→t3→t4, all root, no
+    parent) whose middle task is aborted notifies the REQUESTER to recover the stuck
+    dependents — the wake fires; they are NOT silently stranded. The exact #2107 shape
+    (prior parent-keyed routing dropped it on the missing parent_id). Revert the re-key
+    (restore `if not parent_id: return`) → no requester notify → RED."""
+    b = InMemoryTaskBackend()
+    waker = _RecordingWaker()
+    await b.create(_task("t1", assignee="me", requester="me", status=TaskState.COMPLETED))
+    await b.create(_task("t2", deps=["t1"], assignee="me", requester="me",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("t3", deps=["t2"], assignee="me", requester="me"))
+    await b.create(_task("t4", deps=["t3"], assignee="me", requester="me"))
+    await taskmod._abort(SimpleNamespace(task_id="t2", reason=None),
+                         _opctx(b, waker=waker, session_id="me"), "control_ir")
+    # the requester ("me") is woken to recover the stuck dependent t3 (t4 sits blocked
+    # behind t3, surfaced once t3 is recovered) — NOT dropped.
+    assert waker.calls == [{"requester_session": "me", "terminal_task": "t2",
+                            "dependents": ["t3"], "disposition": "aborted"}]
+
+
+@pytest.mark.asyncio
+async def test_external_origin_skips_internal_requester_wake():
+    """Tier 2: §16 S1 boundary — an EXTERNAL-origin terminal task does NOT fire the
+    internal requester-session wake — its disposition rides the separate webhook channel
+    (the abort-all + propagate is §16 S2). S1 preserves the prior external behavior."""
+    from reyn.task.model import TaskOrigin
+    b = InMemoryTaskBackend()
+    waker = _RecordingWaker()
+    await b.create(_task("B", assignee="sB", requester="a2a:client",
+                         origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="sA", requester="a2a:client",
+                         origin=TaskOrigin.EXTERNAL))
+    await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
+                         _opctx(b, waker=waker, session_id="req"), "control_ir")
+    assert waker.calls == []  # external → webhook channel (S2), not an internal session wake

--- a/tests/test_task_waker_real_components_1953.py
+++ b/tests/test_task_waker_real_components_1953.py
@@ -131,3 +131,28 @@ async def test_wakes_resolve_distinct_sibling_sessions(tmp_path):
         assert parent is not depA
     finally:
         await _cancel_running(reg)
+
+
+@pytest.mark.asyncio
+async def test_bare_main_sid_requester_wakes_the_live_main_session(tmp_path):
+    """Tier 2: #2107 (S1 live-found) — a self-task / chat requester is the BARE sid "main"
+    (_DEFAULT_SID), NOT a transport:native routing-key. The wake must resolve it to the
+    LIVE main session, not partition "main" into a phantom "main:" routing-key session.
+    Asserts the LIVE main session's own inbox receives the disposition. Falsified by the
+    partition-misroute (the phantom session got it; the live main stayed empty — the
+    deterministic tui repro)."""
+    reg = _make_registry(tmp_path)
+    main = reg.get_or_load("alice")              # the live main session (sid=_DEFAULT_SID)
+    assert main.inbox.empty()                    # nothing queued yet
+    waker = TaskWaker(reg, "alice")
+    terminal = SimpleNamespace(task_id="B", name="do-B", status=TaskState.ABORTED)
+    deps = [SimpleNamespace(task_id="A")]
+    try:
+        await waker.notify_requester_decide(
+            requester_session="main", terminal_task=terminal, dependents=deps)
+        # delivered to the LIVE main session — NOT a phantom "main:" routing-key session.
+        assert not main.inbox.empty()
+        kind, payload = main.inbox.get_nowait()
+        assert kind == "task_dependency_aborted" and "B" in payload["text"]
+    finally:
+        await _cancel_running(reg)

--- a/tests/test_task_waker_real_components_1953.py
+++ b/tests/test_task_waker_real_components_1953.py
@@ -28,8 +28,8 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.task_wake import (
-    WAKE_PARENT_KIND,
     WAKE_READY_KIND,
+    WAKE_REQUESTER_KIND,
     TaskWaker,
 )
 from reyn.runtime.session import Session
@@ -60,7 +60,7 @@ async def _cancel_running(reg: AgentRegistry) -> None:
 
 
 @pytest.mark.asyncio
-async def test_notify_parent_decide_real_wake_triple(tmp_path):
+async def test_notify_requester_decide_real_wake_triple(tmp_path):
     """Tier 2: abort-side wake against the REAL registry+session — resolve yields a
     real (deterministic) Session, the disposition lands on its real inbox, and a
     run-loop boots."""
@@ -70,8 +70,8 @@ async def test_notify_parent_decide_real_wake_triple(tmp_path):
     deps = [SimpleNamespace(task_id="A")]
     before = len(reg.running_tasks())
     try:
-        await waker.notify_parent_decide(
-            parent_session="a2a:ctx-parent", terminal_task=terminal, dependents=deps)
+        await waker.notify_requester_decide(
+            requester_session="a2a:ctx-parent", terminal_task=terminal, dependents=deps)
 
         # real resolve — deterministic: same routing-key → same Session object
         parent = reg.resolve_session("alice", "a2a", "ctx-parent")
@@ -81,7 +81,7 @@ async def test_notify_parent_decide_real_wake_triple(tmp_path):
         # real delivery — the OS message is on the session's own asyncio inbox
         assert parent.inbox.qsize() >= 1
         kind, payload = parent.inbox.get_nowait()
-        assert kind == WAKE_PARENT_KIND
+        assert kind == WAKE_REQUESTER_KIND
         assert "B" in payload["text"] and "stuck" in payload["text"]
     finally:
         await _cancel_running(reg)
@@ -121,8 +121,8 @@ async def test_wakes_resolve_distinct_sibling_sessions(tmp_path):
     ready = SimpleNamespace(task_id="A", name="do-A", assignee="a2a:ctx-A",
                             status=TaskState.READY)
     try:
-        await waker.notify_parent_decide(
-            parent_session="a2a:ctx-parent", terminal_task=terminal,
+        await waker.notify_requester_decide(
+            requester_session="a2a:ctx-parent", terminal_task=terminal,
             dependents=[SimpleNamespace(task_id="A")])
         await waker.wake_ready_dependent(ready)
 

--- a/tests/test_task_waker_slice7_1953.py
+++ b/tests/test_task_waker_slice7_1953.py
@@ -4,12 +4,12 @@ Turns the dep-graph dispositions slice 6-ext emits into session wakes via the
 canonical wake-triple ``resolve_session → _put_inbox → ensure_session_running``.
 Verified with a real recording registry + recording session (no mocks):
 
-- ``wake_ready_dependent`` / ``notify_parent_decide`` each fire the 3-step triple
+- ``wake_ready_dependent`` / ``notify_requester_decide`` each fire the 3-step triple
   with the right OS-generic inbox kind + message;
 - the op layer wakes through it: a `completed` predecessor wakes its promoted
-  dependents; an `abort` / `failed` wakes the parent; a `repoint` that promotes a
-  dependent (the parent's recovery move) wakes it;
-- the **recovery loop** end-to-end: abort a dep → the parent is woken with
+  dependents; an `abort` / `failed` wakes the REQUESTER (§16); a `repoint` that promotes
+  a dependent (the requester's recovery move) wakes it;
+- the **recovery loop** end-to-end: abort a dep → the REQUESTER is woken with
   ``task_dependency_aborted`` → it repoints the stuck dependent onto a completed
   substitute → the dependent becomes `ready` AND is woken with ``task_ready``.
 """
@@ -81,15 +81,15 @@ async def test_wake_ready_dependent_fires_the_triple():
 
 
 @pytest.mark.asyncio
-async def test_notify_parent_decide_fires_the_triple():
-    """Tier 2: notify_parent_decide wakes the parent session with the disposition
+async def test_notify_requester_decide_fires_the_triple():
+    """Tier 2: notify_requester_decide wakes the requester session with the disposition
     + the stuck dependents."""
     reg = _RecRegistry()
     waker = TaskWaker(reg, "alice")
     terminal = SimpleNamespace(task_id="B", name="do-B", status=TaskState.ABORTED)
     deps = [SimpleNamespace(task_id="A")]
 
-    await waker.notify_parent_decide(parent_session="mcp:mcp", terminal_task=terminal,
+    await waker.notify_requester_decide(requester_session="mcp:mcp", terminal_task=terminal,
                                      dependents=deps)
 
     assert reg.resolved == [("alice", "mcp", "mcp")]
@@ -129,42 +129,44 @@ async def test_completed_wakes_promoted_dependent():
 
 
 @pytest.mark.asyncio
-async def test_abort_wakes_parent():
-    """Tier 2: aborting a task with a stuck dependent wakes the parent."""
+async def test_abort_wakes_requester():
+    """Tier 2: §16 — aborting a task with a stuck dependent wakes the task's REQUESTER."""
     b = InMemoryTaskBackend()
     reg = _RecRegistry()
-    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
-    await b.create(_task("B", assignee="a2a:sB", parent_id="P", status=TaskState.IN_PROGRESS))
-    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))
+    await b.create(_task("B", assignee="a2a:sB", requester="a2a:sReq",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", requester="a2a:sReq"))
+    # abort is requester-gated → the requester is the caller.
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
-                         _ctx(b, TaskWaker(reg, "alice")), "control_ir")
-    assert ("alice", "a2a", "sP") in reg.resolved
-    assert reg.inbox_of("alice", "a2a", "sP")[0][0] == "task_dependency_aborted"
+                         _ctx(b, TaskWaker(reg, "alice"), session_id="a2a:sReq"), "control_ir")
+    assert ("alice", "a2a", "sReq") in reg.resolved
+    assert reg.inbox_of("alice", "a2a", "sReq")[0][0] == "task_dependency_aborted"
 
 
 # ── 3. the recovery loop (end-to-end mechanism) ─────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_recovery_loop_abort_then_parent_repoint_wakes_both():
-    """Tier 2: the full dep-recovery loop — abort a dep → the parent is woken →
+async def test_recovery_loop_abort_then_requester_repoint_wakes_both():
+    """Tier 2: §16 — the full dep-recovery loop — abort a dep → the REQUESTER is woken →
     it repoints the stuck dependent onto a completed substitute → the dependent
     becomes ready AND is woken (the close-gate at the op-mechanism level)."""
     b = InMemoryTaskBackend()
     reg = _RecRegistry()
     waker = TaskWaker(reg, "alice")
-    await b.create(_task("P", assignee="a2a:sP", status=TaskState.IN_PROGRESS))
-    await b.create(_task("B", assignee="a2a:sB", parent_id="P", status=TaskState.IN_PROGRESS))
-    await b.create(_task("A", deps=["B"], assignee="a2a:sA", parent_id="P"))  # blocked on B
-    await b.create(_task("Bsub", assignee="a2a:sBsub", parent_id="P", status=TaskState.COMPLETED))
-    ctx = _ctx(b, waker)  # requester "req" owns P/B/A/Bsub
+    await b.create(_task("B", assignee="a2a:sB", requester="a2a:sReq",
+                         status=TaskState.IN_PROGRESS))
+    await b.create(_task("A", deps=["B"], assignee="a2a:sA", requester="a2a:sReq"))  # blocked on B
+    await b.create(_task("Bsub", assignee="a2a:sBsub", requester="a2a:sReq",
+                         status=TaskState.COMPLETED))
+    ctx = _ctx(b, waker, session_id="a2a:sReq")  # the requester owns + drives B/A/Bsub
 
-    # 1. abort B → the parent P is woken to decide.
+    # 1. abort B → the REQUESTER is woken to decide.
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None), ctx, "control_ir")
-    assert ("alice", "a2a", "sP") in reg.resolved
-    assert reg.inbox_of("alice", "a2a", "sP")[0][0] == "task_dependency_aborted"
+    assert ("alice", "a2a", "sReq") in reg.resolved
+    assert reg.inbox_of("alice", "a2a", "sReq")[0][0] == "task_dependency_aborted"
 
-    # 2. the parent's recovery move: repoint A from the aborted B onto the
+    # 2. the requester's recovery move: repoint A from the aborted B onto the
     #    completed substitute Bsub → A becomes ready and is woken.
     await taskmod._repoint_dependency(
         SimpleNamespace(task_id="A", from_depends_on="B", to_depends_on="Bsub"),

--- a/tests/test_task_wakes_execution_fence_1953.py
+++ b/tests/test_task_wakes_execution_fence_1953.py
@@ -59,6 +59,11 @@ class _RecordingRegistry:
     def resolve_session(self, agent_name: str, transport: str, native_id: str):
         return self.session
 
+    def get_session(self, agent_name: str, sid: str):
+        # #2107: the wake resolves a BARE sid (no "<transport>:") via the (agent, sid)
+        # lookup, not the transport:native partition.
+        return self.session
+
     def ensure_session_running(self, agent_name: str, session_id: str) -> None:
         self.ensure_calls.append(session_id)
 


### PR DESCRIPTION
**[e2e-coder]** — §16 task-system recovery re-alignment, **slice 1** (owner-approved; flow-trace → design-call → this PR). Closes **#2107**.

## The drift
slice 6-ext (PR #1995) re-keyed terminal recovery to `parent_id`: `_route_terminal_to_parent` routed a non-completed terminal's disposition to `parent.assignee` and **dropped root tasks** (`if not parent_id: return`). So a flat self-task plan's mid-task failure **silently stranded its dependents** (#2107), and the "internal requesters need no notify" claim contradicted §16.

## The fix (re-target, not re-architect — the §16 fields already exist)
Re-key to the **requester** (the §16 disposition notify-target — the request-owner), which is **always present** → root tasks are notified too:
- **`_route_terminal_to_parent` → `_route_terminal_to_requester`** (clean rename, no shim): notify `terminal_task.requester`. **Origin-gated to SELF**: a self-task's requester is a session → wake it; an EXTERNAL task's requester is an A2A/webhook stakeholder → its disposition rides the webhook channel (the abort-all + propagate is **§16 S2**) — preserving prior external behavior.
- **`notify_parent_decide` → `notify_requester_decide`** (`parent_session` → `requester_session`); `WAKE_PARENT_KIND` → `WAKE_REQUESTER_KIND` (the value `task_dependency_aborted` is unchanged — the consumed event-kind contract).
- Drop the **"internal requesters need no notify"** claim (code + `control-ir.md` → §16).
- Mechanism (per the design-call): the wake reuses the existing TaskWaker (a `[task] …decide recovery via task ops` message → the requester's LLM re-wires) — no new mechanism.

## Tests (real backends + wake seam, no mocks)
Re-aligned the slice-6-ext / slice-7 routing tests to requester-routing; **inverted** the root-drop test (`…_routes_nothing` → a root self-task **IS** notified); added a **flat-plan #2107 repro** (`t1→t2→t3→t4`, abort t2 → requester woken — **falsified RED** by restoring the root-drop) + an **EXTERNAL-origin guard** test (external skips the internal wake).

## Close-review criteria (per lead)
(a) re-keyed to `terminal_task.requester`, not `parent.assignee`; (b) root tasks no longer dropped; (c) "internal-no-notify" removed (code + control-ir.md); (d) the wake reaches the requester session; (e) clean rename, no shim.

## Test plan
- [x] `pytest -q` full suite from rootdir — **8451 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] #2107 repro falsified RED-when-reverted (restore the root-drop → no requester notify)
- [ ] (tui) live re-verify: a flat self-task plan's mid-task abort wakes the requester to recover (the recovery behavior is now exercisable)

Next: S2 (origin-split dispatch) → S3 (remove `parent_id`, with the §18 sub-design-call first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)