### PR TITLE
feat(#2107): §16 S2 origin-split — abort an EXTERNAL terminal's dependents (+ webhook propagate)

### DIFF
--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -357,7 +357,19 @@ async def _route_terminal_to_requester(
     to the task's status value (the abort path) when not given explicitly. The wake is via
     ``OpContext.task_waker`` (None = no-op stub — only the P6 audit fires)."""
     if terminal_task.origin is not TaskOrigin.SELF:
-        return  # external → the webhook channel (§16 S2), not an internal session wake
+        # §16 S2 (origin-split): an EXTERNAL terminal gets no in-session recovery wake (no
+        # session to wake — the requester is an A2A/webhook stakeholder). Its stuck dep-DAG
+        # dependents can't be recovered, so abort them → the webhook sweep propagates each
+        # archived dependent to the A2A client. backend.abort's own EXTERNAL cascade then
+        # handles the transitive descendants. This covers the failed / cap_exceeded
+        # triggers (which mark X terminal WITHOUT calling backend.abort on X); the abort /
+        # cancel / kill triggers already feed backend.abort directly, so by the time we
+        # reach here on the abort path X's dependents are already archived → no-op
+        # (idempotent via the terminal-state filter).
+        for dep in await backend.dependents(terminal_task.task_id):
+            if dep.status not in TERMINAL_STATES:
+                await backend.abort(dep.task_id)
+        return
     disp = disposition or terminal_task.status.value
     deps_on_it = await backend.dependents(terminal_task.task_id)
     stuck = [d for d in deps_on_it if d.status not in TERMINAL_STATES]

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -30,6 +30,7 @@ from reyn.task.model import (
     Task,
     TaskCycleError,
     TaskDepNotFoundError,
+    TaskOrigin,
     TaskState,
     _now_iso,
 )
@@ -379,6 +380,7 @@ class InMemoryTaskBackend:
         # disposition event per task (UP-notify, 2b-2); [] if no such task.
         if task_id not in self._tasks:
             return []
+        root_origin = self._tasks[task_id].origin
         subtree: list[str] = [task_id]
         frontier = [task_id]
         while frontier:
@@ -392,6 +394,21 @@ class InMemoryTaskBackend:
             self._tasks[tid].status = TaskState.ARCHIVED
             self._tasks[tid].updated_at = _now_iso()
             aborted.append(self._tasks[tid])
+        # #2107 S2 (origin-split): an EXTERNAL terminal's dep-DAG DEPENDENTS can't be
+        # recovered — the external requester gives up (no in-session re-wire; that is the
+        # SELF path's requester wake, §16 S1). So abort them too, transitively: each
+        # dependent's own abort recurses for ITS dependents (a dep graph is single-origin
+        # — a dependency lives within one decomposition — so they are all EXTERNAL). The
+        # webhook sweep then propagates every archived dependent to the A2A client. The
+        # cascade lives HERE (one seam) so EVERY abort caller gets it by construction (the
+        # A2A cancel endpoint + /tasks kill abort the backend directly, bypassing the op
+        # layer). Bounded by the terminal-state idempotence (an already-archived task is
+        # skipped → no cycle / double-abort).
+        if root_origin is TaskOrigin.EXTERNAL:
+            for t in list(aborted):
+                for dep in await self.dependents(t.task_id):
+                    if dep.status not in TERMINAL_STATES:
+                        aborted.extend(await self.abort(dep.task_id, reason=reason))
         return aborted
 
     async def set_result(self, task_id: str, result: str) -> Task | None:

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -529,13 +529,15 @@ class SqliteTaskBackend:
         first) so the caller can emit a disposition event per task (UP-notify,
         2b-2); ``[]`` if no such task."""
         async with self._lock:
-            if self._conn.execute(
-                "SELECT 1 FROM tasks WHERE task_id=?", (task_id,)
-            ).fetchone() is None:
+            origin_row = self._conn.execute(
+                "SELECT origin FROM tasks WHERE task_id=?", (task_id,)
+            ).fetchone()
+            if origin_row is None:
                 return []
+            root_external = origin_row["origin"] == TaskOrigin.EXTERNAL.value
             # BFS the sub-tree (this task + all descendants via parent_id;
             # acyclic by construction, with a guard).
-            subtree: list[str] = [task_id]
+            to_abort: list[str] = [task_id]
             frontier = [task_id]
             while frontier:
                 pid = frontier.pop()
@@ -543,18 +545,43 @@ class SqliteTaskBackend:
                     "SELECT task_id FROM tasks WHERE parent_id=?", (pid,)
                 ).fetchall():
                     child = row["task_id"]
-                    if child not in subtree:
-                        subtree.append(child)
+                    if child not in to_abort:
+                        to_abort.append(child)
                         frontier.append(child)
+            # #2107 S2 (origin-split): an EXTERNAL terminal's dep-DAG DEPENDENTS can't be
+            # recovered — the external requester gives up (no in-session re-wire; that is
+            # the SELF path's requester wake, §16 S1). Abort them too, transitively (a dep
+            # graph is single-origin, so they are all EXTERNAL); the webhook sweep then
+            # propagates each archived dependent to the A2A client. The cascade lives in
+            # this ONE seam so every abort caller gets it by construction (the A2A cancel
+            # endpoint + /tasks kill abort the backend directly). Done as an in-lock BFS
+            # (NOT a recursive self.abort — the lock is not re-entrant); the non-terminal
+            # filter + the in-set guard bound it (no cycle / double-abort).
+            if root_external:
+                dep_frontier = list(to_abort)
+                while dep_frontier:
+                    tid = dep_frontier.pop()
+                    for row in self._conn.execute(
+                        "SELECT task_id FROM task_links WHERE depends_on=?", (tid,)
+                    ).fetchall():
+                        dep = row["task_id"]
+                        if dep in to_abort:
+                            continue
+                        srow = self._conn.execute(
+                            "SELECT status FROM tasks WHERE task_id=?", (dep,)
+                        ).fetchone()
+                        if srow is not None and srow["status"] not in _TERMINAL_VALUES:
+                            to_abort.append(dep)
+                            dep_frontier.append(dep)
             self._conn.execute("BEGIN IMMEDIATE")
-            for tid in subtree:
+            for tid in to_abort:
                 self._conn.execute(
                     "UPDATE tasks SET status=?, updated_at=? WHERE task_id=?",
                     (TaskState.ARCHIVED.value, _now_iso(), tid),
                 )
                 self._emit(tid, "aborted", root=task_id)
             self._conn.commit()
-            return [t for t in (self._fetch(tid) for tid in subtree) if t is not None]
+            return [t for t in (self._fetch(tid) for tid in to_abort) if t is not None]
 
 
     async def set_result(self, task_id: str, result: str) -> Task | None:

--- a/tests/test_2107_s2_external_origin_split.py
+++ b/tests/test_2107_s2_external_origin_split.py
@@ -1,0 +1,139 @@
+"""#2107 §16 S2 — the origin-split: an EXTERNAL-origin terminal's stuck dep-DAG
+DEPENDENTS are aborted (no in-session recovery — the external requester gives up), and
+the existing webhook sweep propagates each archived dependent to the A2A client. INTERNAL
+tasks keep the S1 requester-wake recovery (untouched).
+
+The cascade lives in ONE seam — ``backend.abort`` (origin-gated EXTERNAL) — so EVERY abort
+trigger gets it by construction. The trigger → seam table (all proven below):
+
+  | trigger                         | seam                                    |
+  | A2A client cancel (cancel_task) | backend.abort (direct)                  |
+  | agent abort op (_abort)         | backend.abort                           |
+  | /tasks kill (slash)             | backend.abort (direct)                  |
+  | assignee failed (_update_status)| _route_terminal_to_requester → backend.abort(deps) |
+
+Real backends (in-memory + sqlite) + the REAL cancel_task endpoint + the REAL sweep; no
+mocks (a recording webhook poster).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
+from reyn.task.model import TaskOrigin
+
+
+def _ext(task_id, *, deps=None, status=TaskState.PENDING, assignee="a2a:ctx-1"):
+    return Task(task_id=task_id, name=task_id, assignee=assignee, requester="a2a:ctx-1",
+                origin=TaskOrigin.EXTERNAL, status=status, deps=list(deps or []))
+
+
+def _self(task_id, *, deps=None, status=TaskState.PENDING):
+    return Task(task_id=task_id, name=task_id, assignee="main", requester="main",
+                origin=TaskOrigin.SELF, status=status, deps=list(deps or []))
+
+
+@pytest.fixture(params=["inmem", "sqlite"])
+def backend(request, tmp_path):
+    if request.param == "inmem":
+        yield InMemoryTaskBackend()
+    else:
+        b = SqliteTaskBackend(tmp_path / "s2.db")
+        yield b
+        b.close()
+
+
+# ── the cascade: backend.abort on an EXTERNAL root aborts the transitive dependents ──
+
+
+@pytest.mark.asyncio
+async def test_external_abort_cascades_to_transitive_dependents(backend):
+    """Tier 2: aborting an EXTERNAL task archives its TRANSITIVE dep-DAG dependents
+    (X ← Y ← Z) — they can't be recovered, so they give up with it. Catches the direct
+    backend.abort triggers (A2A cancel / agent abort / /tasks kill) by construction."""
+    await backend.create(_ext("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_ext("Y", deps=["X"]))
+    await backend.create(_ext("Z", deps=["Y"]))
+
+    await backend.abort("X")
+
+    for tid in ("X", "Y", "Z"):
+        assert (await backend.get(tid)).status is TaskState.ARCHIVED
+
+
+@pytest.mark.asyncio
+async def test_internal_abort_does_not_cascade_to_dependents(backend):
+    """Tier 2: origin-split — a SELF (internal) abort does NOT abort its dependents (they
+    recover via the requester wake, §16 S1). Strip the origin gate → the dependent would
+    be wrongly archived → RED."""
+    await backend.create(_self("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_self("Y", deps=["X"]))
+
+    await backend.abort("X")
+
+    assert (await backend.get("X")).status is TaskState.ARCHIVED
+    assert (await backend.get("Y")).status is not TaskState.ARCHIVED  # NOT cascaded
+
+
+@pytest.mark.asyncio
+async def test_external_failed_path_aborts_dependents_via_route(backend):
+    """Tier 2: the failed trigger — an EXTERNAL task declared `failed` (NOT backend.abort'd
+    on X itself) reaches _route_terminal_to_requester, whose EXTERNAL branch aborts X's
+    stuck dependents (feeding the same backend.abort cascade). X stays FAILED; Y, Z archived."""
+    await backend.create(_ext("X", status=TaskState.FAILED))
+    await backend.create(_ext("Y", deps=["X"]))
+    await backend.create(_ext("Z", deps=["Y"]))
+    ctx = SimpleNamespace(task_backend=backend, session_id="a2a:ctx-1", agent_id="a",
+                          events=None, task_waker=None)
+    terminal = await backend.get("X")
+
+    await taskmod._route_terminal_to_requester(ctx, backend, terminal, disposition="failed")
+
+    assert (await backend.get("X")).status is TaskState.FAILED  # X itself stays failed
+    assert (await backend.get("Y")).status is TaskState.ARCHIVED
+    assert (await backend.get("Z")).status is TaskState.ARCHIVED
+
+
+# ── the LIVE path: the REAL cancel_task endpoint → archived → the REAL sweep → webhooks ──
+
+
+@pytest.mark.asyncio
+async def test_live_cancel_endpoint_cascades_then_sweep_fires_webhooks(tmp_path):
+    """Tier 2: #2107 S2 LIVE PATH — the A2A client CANCELS an external task through the REAL
+    cancel_task endpoint (the trigger that bypasses the op-layer). Its dependents archive
+    (the backend.abort cascade), and the REAL disposition sweep then fires a webhook to the
+    A2A client for EVERY archived dependent — not just the cancelled root. A logic-trace
+    (op-layer only) would miss this; the live path proves the cancel → cascade → propagate
+    chain end-to-end."""
+    from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry, sweep_dispositions
+    from reyn.interfaces.web.routers.a2a import cancel_task
+
+    backend = InMemoryTaskBackend()
+    await backend.create(_ext("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_ext("Y", deps=["X"]))
+    await backend.create(_ext("Z", deps=["Y"]))
+
+    registry = A2AWebhookRegistry()
+    registry.register_webhook("ctx-1", "https://client.example/hook")  # for a2a:ctx-1
+
+    # the REAL cancel endpoint (the A2A client's remove-op) — direct backend.abort.
+    await cancel_task("X", task_backend=backend)
+    for tid in ("X", "Y", "Z"):
+        assert (await backend.get(tid)).status is TaskState.ARCHIVED  # the cascade
+
+    posted: list[dict] = []
+
+    async def _record_post(url, payload):
+        posted.append({"url": url, **payload})
+        return SimpleNamespace(ok=True)
+
+    fired = await sweep_dispositions(backend, registry, post_fn=_record_post)
+
+    # the sweep propagated EVERY archived dependent to the client (root + cascade), not 1.
+    notified_ids = {p["task_id"] for p in posted}
+    assert {"X", "Y", "Z"} <= notified_ids
+    assert fired >= 3
+    assert all(p["disposition"] == "aborted" for p in posted)


### PR DESCRIPTION
**[e2e-coder]** — §16 task-system recovery re-alignment, **slice 2** (owner-approved; flow-trace → design-call → this PR). The origin-split's EXTERNAL half.

## What S2 does
An external A2A request's terminal (abort/failed/cancel/kill) gets **no in-session recovery wake** — its requester is an A2A/webhook stakeholder, not a session (that wake is the SELF path, S1). Its stuck **dep-DAG dependents** can't be recovered, so they give up with it; the existing webhook sweep then propagates each archived dependent to the A2A client.

## Complete-by-construction: ONE seam, full trigger table
The cascade lives in **`backend.abort`** (origin-gated EXTERNAL) so every abort trigger gets it by construction. The **live-path enumeration** (per lead's completeness mandate) surfaced a **4th** trigger beyond the initial 3 — `/tasks kill` — another direct `backend.abort` a logic-trace would miss:

| trigger | seam |
|---|---|
| A2A client cancel (`cancel_task`) | `backend.abort` (direct) |
| agent abort op (`_abort`) | `backend.abort` |
| `/tasks kill` (slash) | `backend.abort` (direct) |
| assignee `failed` (`_update_status`) | `_route_terminal_to_requester` → `backend.abort(deps)` |

## Implementation
- **`backend.abort`** (InMemory recursive; **Sqlite in-lock BFS** — the lock isn't re-entrant): an EXTERNAL root also archives its **transitive** dep-DAG dependents (a dep graph is single-origin → all EXTERNAL → the recursion/BFS re-cascades), bounded by terminal-state idempotence.
- **`_route_terminal_to_requester` EXTERNAL branch**: the failed/cap_exceeded triggers (which mark X terminal *without* `backend.abort`'ing X) abort X's stuck dependents → the same seam; idempotent (no-op when the abort path already cascaded).
- **Webhook propagate = the existing `sweep_dispositions`** (fires for every archived `origin=external` task) — **no new webhook code**.
- **INTERNAL tasks untouched** (S1 requester-wake recovery).

## Tests (both backends + the REAL cancel endpoint + the REAL sweep, no mocks)
The cascade per trigger; the **live cancel→cascade→webhook** chain end-to-end; origin-gating — **falsified RED both ways** (strip cascade → external tests RED; the internal-no-cascade test stays green).

## Test plan
- [x] `pytest -q` full suite from rootdir — **8460 passed, 18 skipped, 3 xfailed, 0 failed**
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors, 0 warnings
- [x] cascade falsified RED-when-stripped (both backends, both seams, the live path)
- [ ] (tui) live-verify: cancel an external task with dependents → they abort → the webhook fires for each

Next: S3 (remove `parent_id`) — needs the §18 deletion-cascade **sub-design-call first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)