### PR TITLE
feat(#2107): §16 slice A — recursive-request repr + recovery resolve

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -208,6 +208,18 @@ class OpContext:
     # session identity (direct construction / OS-internal callers).
     session_id: "str | None" = None
 
+    # #1953 §16 (recursive-request): the task_id the caller is currently EXECUTING
+    # as a task-as-request, when this op-ctx is built for a turn the OS woke to
+    # execute an assigned task. ``task.create`` reads this to derive ownership: set
+    # → the new sub-task is owned by this task (``requester=current_task_id``,
+    # ``requester_kind=task``); None → a top-level/session-owned task
+    # (``requester=session_id``, ``requester_kind=session``). OS-SET from the
+    # execution context (NOT an op field — the recursive-request invariant requires
+    # the LLM cannot mark ownership). This is the STABLE seam: its SOURCE evolves
+    # (execute-wake meta now; a persistent session-assignment later) but the
+    # ``_create`` read-side stays fixed. None = not executing a task-as-request.
+    current_task_id: "str | None" = None
+
 
 def sandbox_policy_from_ctx(ctx: "OpContext") -> "SandboxPolicy | None":
     """Build the ``SandboxPolicy`` from ``ctx.default_sandbox_policy`` (the

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -26,6 +26,7 @@ from reyn.task import (
     TaskCycleError,
     TaskDepNotFoundError,
     TaskOrigin,
+    TaskRequesterKind,
     TaskState,
 )
 from reyn.task.model import TERMINAL_STATES
@@ -171,11 +172,27 @@ async def _authorize(op_kind: str, ctx: OpContext, backend, task_id: str, role: 
 
 
 async def _create(op, ctx: OpContext, caller) -> dict:
-    # requester = the caller's session (the origin / assigner, §model "requester=self").
+    # §16 recursive-request: requester + requester_kind are OS-SET from the caller's
+    # EXECUTION context — NEVER an op field, so the LLM cannot mark ownership to
+    # mis-route a later recovery (the §16 security invariant). When the caller is
+    # executing a task-as-request (``ctx.current_task_id`` set by the OS for that
+    # turn), the new sub-task is OWNED by that task (``requester`` = the task id,
+    # ``requester_kind`` = task). Otherwise it is a top-level / session-owned task
+    # (``requester`` = the caller session, kind = session — the original model).
     # cross-session delegation supplies a different ``assignee``; a self-task defaults
-    # the assignee to the caller. parent_id (optional, absorbs the old create_subtask)
-    # must reference a task the CALLER owns as requester (tree decomposition, §12).
-    requester = _caller_session(ctx)
+    # the assignee to the caller SESSION (the executor — NOT the requester, which is
+    # now a task id in the recursive case; a task-id assignee would break the
+    # single-writer CAS ``assignee == caller_session_id``). parent_id (optional,
+    # absorbs the old create_subtask) must reference a task the CALLER owns as
+    # requester (tree decomposition, §12).
+    caller_session = _caller_session(ctx)
+    current_task_id = getattr(ctx, "current_task_id", None)
+    if current_task_id:
+        requester = current_task_id
+        requester_kind = TaskRequesterKind.TASK
+    else:
+        requester = caller_session
+        requester_kind = TaskRequesterKind.SESSION
     parent_id = getattr(op, "parent_id", None)
     if parent_id:
         parent = await _backend(ctx).get(parent_id)
@@ -186,8 +203,9 @@ async def _create(op, ctx: OpContext, caller) -> dict:
     task = Task(
         task_id=uuid.uuid4().hex,
         name=op.name,
-        assignee=(getattr(op, "assignee", None) or requester),
+        assignee=(getattr(op, "assignee", None) or caller_session),
         requester=requester,
+        requester_kind=requester_kind,
         origin=TaskOrigin(getattr(op, "origin", "self") or "self"),
         description=op.description,
         parent_id=parent_id,
@@ -376,18 +394,35 @@ async def _route_terminal_to_requester(
     if not stuck:
         return
     requester = terminal_task.requester
+    # §16 recursive-request: resolve the notify-TARGET session. A ``session``
+    # requester IS the target (the original S1 path). A ``task`` requester (a
+    # task-as-request owns this dependent's failed task) resolves to that task's
+    # ASSIGNEE — the managing session that owns + executes the request (parent ==
+    # requester by construction → no drift). One hop suffices: an assignee is always
+    # a session, never another task. This is the recursive generalization of S1.
+    requester_session = requester
+    if terminal_task.requester_kind is TaskRequesterKind.TASK:
+        owner = await backend.get(requester)
+        requester_session = owner.assignee if owner is not None else None
     events = getattr(ctx, "events", None)
     if events is not None:
-        # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation).
+        # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation). The
+        # event records the TRUE owner (``requester`` — a session or a task id) for
+        # audit; the wake goes to the resolved managing session below.
         events.emit(
             "task_dependency_aborted", task_id=terminal_task.task_id,
             disposition=disp, requester=requester,
             dependents=[d.task_id for d in stuck],
         )
+    if requester_session is None:
+        # The owning task-as-request is gone → no managing session to wake. The
+        # ownership-cascade (slice B) aborts such orphaned dependents; here the audit
+        # has fired, so drop the wake (cf. S1's bare-no-live-session drop).
+        return
     waker = getattr(ctx, "task_waker", None)
     if waker is not None:
         await waker.notify_requester_decide(
-            requester_session=requester, terminal_task=terminal_task,
+            requester_session=requester_session, terminal_task=terminal_task,
             dependents=stuck, disposition=disp,
         )
 

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -70,6 +70,7 @@ def build_router_op_context(
     task_backend: Any = None,
     task_waker: Any = None,  # #2107: OS TaskWaker so a router task.* terminal wakes the requester
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
+    current_task_id: str | None = None,  # #1953 §16: the task this turn is executing → task.create ownership
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -151,4 +152,5 @@ def build_router_op_context(
         task_backend=task_backend,
         task_waker=task_waker,  # #2107: a router task.* terminal wakes the requester
         hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
+        current_task_id=current_task_id,  # #1953 §16: ownership-derivation context
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -116,6 +116,7 @@ class RouterHostAdapter:
         agent_registry: Any,                    # AgentRegistry | None
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
+        current_task_id_fn: "Callable[[], str | None] | None" = None,     # #1953 §16
         skill_enumerate_fn: Callable[[set], list],
         agent_workspace_dir: Path,
         # File op callbacks
@@ -320,6 +321,7 @@ class RouterHostAdapter:
         self._registry = agent_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
+        self._current_task_id_fn = current_task_id_fn      # #1953 §16
         self._skill_enumerate_fn = skill_enumerate_fn
         self._workspace_dir = Path(agent_workspace_dir)
         # File callbacks
@@ -1619,6 +1621,14 @@ class RouterHostAdapter:
             # recovery wake was silently skipped (ctx.task_waker=None).
             task_waker=self._task_waker,
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
+            # #1953 §16: the per-turn execution context (set by the session in
+            # run_one_iteration). Read via the callback — it varies per turn, so the
+            # fixed init value would be stale (cf. live_session_id_fn). None when the
+            # session is not executing an assigned task → task.create stays
+            # session-owned (the original model).
+            current_task_id=(
+                self._current_task_id_fn() if self._current_task_id_fn else None
+            ),
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -70,6 +70,7 @@ from reyn.runtime.services import (
 )
 from reyn.runtime.services.a2a_handler import A2AHandler
 from reyn.runtime.services.chain_manager import _PendingChain
+from reyn.runtime.services.task_wake import WAKE_READY_KIND
 from reyn.runtime.session_buses import AgentRequestBus, ChatInterventionBus
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
@@ -922,6 +923,13 @@ class Session:
         # falls back to its in-memory backend (tests / direct construction).
         self._task_backend = task_backend
         self._task_waker = task_waker  # #1953 slice 7
+        # #1953 §16 (recursive-request): the task_id this session is currently
+        # EXECUTING as a task-as-request, set per-turn from an execute-wake's meta
+        # (run_one_iteration). Read by the router op-ctx builders so task.create
+        # derives ownership (requester=<this task>). None = not executing an assigned
+        # task (a user / hook / recovery turn). Slice B extends the lifetime to a
+        # persistent assignment spanning continuation + recovery turns.
+        self._current_task_id: "str | None" = None
         # #1827 S4b (context-auto): lazily-resolved minimal _untrusted profile
         # ContextualPermission, composed into the per-turn narrowing while
         # untrusted external content is live in context. None until first needed.
@@ -1596,6 +1604,9 @@ class Session:
             # spawn guard.
             record_spawned_task=self.record_spawned_task,
             live_session_id_fn=lambda: self._session_id,
+            # #1953 §16: the per-turn execution context (set in run_one_iteration),
+            # read at op-ctx-build time so a router task.create derives ownership.
+            current_task_id_fn=lambda: self._current_task_id,
             skill_enumerate_fn=enumerate_available_skills,
             agent_workspace_dir=self.workspace_dir,
             file_read=self._file_read,
@@ -3403,6 +3414,20 @@ class Session:
             # shutdown sentinel
             return False
         kind, payload = trigger
+        # #1953 §16 (recursive-request): stamp this session's current execution
+        # context. A turn the OS woke to EXECUTE an assigned task (``task_ready``)
+        # carries that task_id in its wake meta → set it so ``task.create`` during
+        # this turn derives ownership (requester=<this task>, requester_kind=task).
+        # Every other trigger (user / hook / recovery ``task_dependency_aborted``)
+        # CLEARS it — a per-turn lifetime. NOTE the recovery wake is deliberately
+        # excluded: its meta names the FAILED dependent, not the managing
+        # task-as-request, so stamping it would mis-own a recovery-create. Both the
+        # recovery-create and multi-turn-execution contexts are closed by slice B's
+        # persistent assignment (the SOURCE evolves; this set-point is the seam).
+        self._current_task_id = (
+            payload.get("meta", {}).get("task_id")
+            if kind == WAKE_READY_KIND else None
+        )
         # #1800 slice 7: the loop valve. Bound hook self-continuation at the
         # SINGLE seam — before any per-turn work (sender attribution / turn_started
         # emit / turn_start dispatch / kind dispatch). A human user turn re-arms
@@ -5083,6 +5108,7 @@ class Session:
             agent_id=self._agent_id,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
+            current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3414,20 +3414,9 @@ class Session:
             # shutdown sentinel
             return False
         kind, payload = trigger
-        # #1953 §16 (recursive-request): stamp this session's current execution
-        # context. A turn the OS woke to EXECUTE an assigned task (``task_ready``)
-        # carries that task_id in its wake meta → set it so ``task.create`` during
-        # this turn derives ownership (requester=<this task>, requester_kind=task).
-        # Every other trigger (user / hook / recovery ``task_dependency_aborted``)
-        # CLEARS it — a per-turn lifetime. NOTE the recovery wake is deliberately
-        # excluded: its meta names the FAILED dependent, not the managing
-        # task-as-request, so stamping it would mis-own a recovery-create. Both the
-        # recovery-create and multi-turn-execution contexts are closed by slice B's
-        # persistent assignment (the SOURCE evolves; this set-point is the seam).
-        self._current_task_id = (
-            payload.get("meta", {}).get("task_id")
-            if kind == WAKE_READY_KIND else None
-        )
+        # #1953 §16 (recursive-request): stamp this session's per-turn execution
+        # context from the trigger (the SOURCE of OpContext.current_task_id).
+        self._stamp_execution_context(kind, payload)
         # #1800 slice 7: the loop valve. Bound hook self-continuation at the
         # SINGLE seam — before any per-turn work (sender attribution / turn_started
         # emit / turn_start dispatch / kind dispatch). A human user turn re-arms
@@ -3522,6 +3511,25 @@ class Session:
         finally:
             self._turn_idle.set()
         return True
+
+    def _stamp_execution_context(self, kind: str, payload: dict) -> None:
+        """#1953 §16 (recursive-request): set the per-turn execution context read by
+        the router op-ctx builders (→ ``OpContext.current_task_id``) so a
+        ``task.create`` during this turn derives ownership (requester=<this task>,
+        requester_kind=task).
+
+        A turn the OS woke to EXECUTE an assigned task (``task_ready`` =
+        ``WAKE_READY_KIND``) carries that task_id in its wake meta → stamp it. Every
+        other trigger (user / hook / and the recovery ``task_dependency_aborted``
+        wake) CLEARS it — a per-turn lifetime. The recovery wake is DELIBERATELY
+        excluded: its meta names the FAILED dependent, not the managing
+        task-as-request, so stamping it would mis-own a recovery-create. The
+        recovery-create + multi-turn-execution contexts are closed by slice B's
+        persistent assignment (the SOURCE evolves; this is the set-point seam)."""
+        self._current_task_id = (
+            payload.get("meta", {}).get("task_id")
+            if kind == WAKE_READY_KIND else None
+        )
 
     async def _handle_task_wake(self, payload: dict) -> None:
         """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /

--- a/src/reyn/task/__init__.py
+++ b/src/reyn/task/__init__.py
@@ -21,6 +21,7 @@ from reyn.task.model import (
     TaskCycleError,
     TaskDepNotFoundError,
     TaskOrigin,
+    TaskRequesterKind,
     TaskState,
 )
 from reyn.task.sqlite_backend import SqliteTaskBackend
@@ -29,6 +30,7 @@ __all__ = [
     "Task",
     "TaskState",
     "TaskOrigin",
+    "TaskRequesterKind",
     "TERMINAL_STATES",
     "TaskCycleError",
     "TaskDepNotFoundError",

--- a/src/reyn/task/model.py
+++ b/src/reyn/task/model.py
@@ -82,6 +82,26 @@ class TaskOrigin(str, Enum):
     EXTERNAL = "external"
 
 
+class TaskRequesterKind(str, Enum):
+    """What kind of entity the ``requester`` routing-key names (#1953 §16
+    recursive-request model).
+
+    ``session`` — a session owns the request (the original model: a top-level
+    task requested by a session; ``requester`` is a session routing-key).
+    ``task`` — a *task-as-request* owns this sub-task; ``requester`` is that
+    task's ``task_id``. Recovery routing resolves a ``task`` requester to its
+    ASSIGNEE (the managing session) before waking — the recursive generalization
+    of §16 S1 (route to the requester; if it is a task, resolve to its assignee).
+
+    OS-SET at create from the caller's execution context + IMMUTABLE for the
+    Task's life — no LLM/op sets or mutates it, so it cannot be mis-marked to
+    mis-route a recovery (the §16 security invariant).
+    """
+
+    SESSION = "session"
+    TASK = "task"
+
+
 @dataclass
 class Task:
     """One trackable work-unit.
@@ -100,6 +120,7 @@ class Task:
     name: str
     assignee: str
     requester: str
+    requester_kind: TaskRequesterKind = TaskRequesterKind.SESSION  # §16: session-owned vs task-as-request owned
     origin: TaskOrigin = TaskOrigin.SELF
     status: TaskState = TaskState.PENDING
     description: str | None = None
@@ -119,6 +140,7 @@ class Task:
             "name": self.name,
             "assignee": self.assignee,
             "requester": self.requester,
+            "requester_kind": self.requester_kind.value,
             "origin": self.origin.value,
             "status": self.status.value,
             "description": self.description,

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -45,6 +45,7 @@ from reyn.task.model import (
     TaskCycleError,
     TaskDepNotFoundError,
     TaskOrigin,
+    TaskRequesterKind,
     TaskState,
     _now_iso,
 )
@@ -60,6 +61,7 @@ CREATE TABLE IF NOT EXISTS tasks(
   name TEXT NOT NULL,
   assignee TEXT NOT NULL,
   requester TEXT NOT NULL,
+  requester_kind TEXT NOT NULL DEFAULT 'session',
   origin TEXT NOT NULL,
   status TEXT NOT NULL,
   description TEXT,
@@ -106,8 +108,8 @@ CREATE TABLE IF NOT EXISTS task_comments(
 """
 
 _TASK_COLUMNS = (
-    "task_id, name, assignee, requester, origin, status, description, created_by, "
-    "parent_id, awaiting_since, tools, result, created_at, updated_at"
+    "task_id, name, assignee, requester, requester_kind, origin, status, description, "
+    "created_by, parent_id, awaiting_since, tools, result, created_at, updated_at"
 )
 
 
@@ -150,6 +152,13 @@ class SqliteTaskBackend:
             for col in ("tools", "result"):
                 if col not in existing:
                     conn.execute(f"ALTER TABLE tasks ADD COLUMN {col} TEXT")
+            # #1953 §16 (recursive-request): additive migration for pre-existing DBs —
+            # a row created before this column is a session-owned task by definition
+            # (the only kind that existed), so the 'session' default is correct.
+            if "requester_kind" not in existing:
+                conn.execute(
+                    "ALTER TABLE tasks ADD COLUMN requester_kind "
+                    "TEXT NOT NULL DEFAULT 'session'")
             conn.commit()
         return conn
 
@@ -288,6 +297,7 @@ class SqliteTaskBackend:
             name=row["name"],
             assignee=row["assignee"],
             requester=row["requester"],
+            requester_kind=TaskRequesterKind(row["requester_kind"]),
             origin=TaskOrigin(row["origin"]),
             status=TaskState(row["status"]),
             description=row["description"],
@@ -333,11 +343,11 @@ class SqliteTaskBackend:
             self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 f"INSERT INTO tasks({_TASK_COLUMNS}) "
-                f"VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                f"VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     task.task_id, task.name, task.assignee, task.requester,
-                    task.origin.value, task.status.value, task.description,
-                    task.created_by, task.parent_id, task.awaiting_since,
+                    task.requester_kind.value, task.origin.value, task.status.value,
+                    task.description, task.created_by, task.parent_id, task.awaiting_since,
                     json.dumps(task.tools) if task.tools else None, task.result,
                     task.created_at, task.updated_at,
                 ),

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -85,6 +85,7 @@ def make_adapter(
     task_backend: object = None,  # #1953 / #2107: session-scoped Task backend
     task_waker: object = None,    # #2107: OS TaskWaker (router task.* terminal → requester wake)
     session_id: "str | None" = None,
+    current_task_id_fn: "object | None" = None,  # #1953 §16: per-turn execution context
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -141,4 +142,5 @@ def make_adapter(
         task_backend=task_backend,
         task_waker=task_waker,
         session_id=session_id,
+        current_task_id_fn=current_task_id_fn,
     )

--- a/tests/test_2107_sliceA_recursive_request_1953.py
+++ b/tests/test_2107_sliceA_recursive_request_1953.py
@@ -1,0 +1,178 @@
+"""Tier 2: #2107 §16 slice A — recursive-request repr + recovery resolve.
+
+The recursive-request model lets a *task* (not only a session) own a request: a
+sub-task created while a session executes a task-as-request T is OWNED by T
+(``requester == T.task_id``, ``requester_kind == task``), OS-set from the
+execution context (``OpContext.current_task_id``) — never an op field, so the LLM
+cannot mark ownership to mis-route a later recovery (the §16 invariant).
+
+Recovery generalizes S1 (route to the requester): when the requester is a TASK,
+resolve it to its ASSIGNEE — the managing session that owns + executes the
+request — and wake THAT session (one hop; an assignee is always a session).
+
+Tests (real backends + the real TaskWaker / AgentRegistry / route path, no mocks,
+no hand-fed requester keys — the ownership comes from the live create-path):
+
+  - full-live-path: a sub-task whose requester is a task-as-request fails → the
+    recovery resolves to + wakes the managing session (T's assignee). FALSIFY:
+    strip the task→assignee resolve branch → the wake targets a bare task-id with
+    no live session → the managing session stays unwoken (RED).
+  - create-derivation (both branches): ``current_task_id`` set → requester=that
+    task / kind=task; unset → requester=caller-session / kind=session (the
+    original model, preserved).
+  - sqlite round-trip of the NON-DEFAULT ``requester_kind=task`` (set→reload→get).
+
+KNOWN holes (no-regression in slice A; closed by slice B's persistent assignment):
+  (i)  recovery-create — a replacement created on a recovery turn currently falls
+       to requester=session (the recovery wake names the failed dependent, not the
+       managing task-as-request), so it is not owned by T.
+  (ii) multi-turn execution — a sub-task created on a continuation activation (no
+       fresh execute-wake) falls to requester=session.
+Both only bite slice B's list(requester==T) ownership-cascade; slice A is additive
+(parent_id intact, no cascade yet) so a hole-orphan just stays on the S1
+session-path = today's behavior.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services.task_wake import WAKE_REQUESTER_KIND, TaskWaker
+from reyn.runtime.session import Session
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskRequesterKind, TaskState
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """Real AgentRegistry + on-disk agent + real Session factory (no mocks)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+async def _cancel_running(reg: AgentRegistry) -> None:
+    tasks = reg.running_tasks()
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _create_op(name, *, deps=None, assignee=None, origin=None):
+    return SimpleNamespace(name=name, description=f"do {name}", deps=list(deps or []),
+                           assignee=assignee, origin=origin, parent_id=None)
+
+
+def _ctx(backend, *, session_id="executor", current_task_id=None, waker=None):
+    return SimpleNamespace(session_id=session_id, agent_id="alice", events=None,
+                           task_backend=backend, task_waker=waker,
+                           current_task_id=current_task_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_subtask_create_derives_task_ownership_from_execution_context():
+    """Tier 2: the live create-path derives requester + requester_kind from the
+    caller's execution context — NOT from an op field. With current_task_id set the
+    sub-task is owned by that task (requester=task, kind=task); unset it is
+    session-owned (the original model). No hand-fed requester key."""
+    b = InMemoryTaskBackend()
+
+    # executing task-as-request T (no waker → no born-startable wake noise).
+    res_sub = await taskmod._create(
+        _create_op("sub"), _ctx(b, session_id="executor", current_task_id="T-id"), "control_ir")
+    assert res_sub["status"] == "ok"
+    sub = await b.get(res_sub["task"]["task_id"])
+    # ownership = the executing task, kind=task (the live derivation, not the caller).
+    assert sub.requester == "T-id"
+    assert sub.requester_kind is TaskRequesterKind.TASK
+    # assignee is still the EXECUTOR SESSION (not the task id — the single-writer CAS).
+    assert sub.assignee == "executor"
+
+    # a top-level create (no execution context) stays session-owned.
+    res_top = await taskmod._create(
+        _create_op("top"), _ctx(b, session_id="executor", current_task_id=None), "control_ir")
+    top = await b.get(res_top["task"]["task_id"])
+    assert top.requester == "executor"
+    assert top.requester_kind is TaskRequesterKind.SESSION
+
+
+@pytest.mark.asyncio
+async def test_failed_subtask_recovery_wakes_managing_session_full_live_path(tmp_path):
+    """Tier 2: the headline full-live-path. A sub-task U owned by a task-as-request T
+    (live create-path) fails with a still-alive dependent → recovery resolves U's TASK
+    requester to T's ASSIGNEE (the managing session) and wakes it. Real registry +
+    real TaskWaker + real route path; the requester value comes from the live create
+    (no hand-feeding). FALSIFY: strip the kind==TASK→assignee resolve branch → the
+    notify targets T's bare task-id (no live session) → the managing session stays
+    unwoken (the assertion below goes RED)."""
+    reg = _make_registry(tmp_path)
+    managing = reg.get_or_load("alice")            # the live managing session (sid "main")
+    assert managing.inbox.empty()
+    b = InMemoryTaskBackend()
+
+    # T = the task-as-request, assigned to (executed by) the live managing session.
+    T = Task(task_id="T-req", name="T", assignee="main", requester="a2a:client",
+             status=TaskState.IN_PROGRESS)
+    await b.create(T)
+
+    # U = a sub-task created WHILE executing T → owned by T via the live create-path.
+    res_u = await taskmod._create(
+        _create_op("U"), _ctx(b, session_id="worker", current_task_id="T-req"), "control_ir")
+    u_id = res_u["task"]["task_id"]
+    u = await b.get(u_id)
+    assert u.requester == "T-req" and u.requester_kind is TaskRequesterKind.TASK  # live value
+
+    # V depends on U (a still-alive dependent), then U fails → recovery must fire.
+    await taskmod._create(
+        _create_op("V", deps=[u_id]), _ctx(b, session_id="worker"), "control_ir")
+    await b.update_status(u_id, TaskState.FAILED, caller_session_id="worker")
+
+    waker = TaskWaker(reg, "alice")
+    try:
+        await taskmod._route_terminal_to_requester(
+            _ctx(b, waker=waker), b, await b.get(u_id), disposition="failed")
+        # resolved to T.assignee = the LIVE managing session, and woken there.
+        assert not managing.inbox.empty(), "managing session (T.assignee) was not woken"
+        kind, payload = managing.inbox.get_nowait()
+        assert kind == WAKE_REQUESTER_KIND
+        assert u_id in payload["text"]
+    finally:
+        await _cancel_running(reg)
+
+
+@pytest.mark.asyncio
+async def test_requester_kind_task_round_trips_through_sqlite(tmp_path):
+    """Tier 2: the NON-DEFAULT requester_kind=task survives a sqlite set→reload→get
+    (a default 'session' round-trip would pass trivially even if the column were
+    ignored — this proves persistence)."""
+    db = tmp_path / "tasks.db"
+    b = SqliteTaskBackend(db)
+    await b.create(Task(task_id="owned", name="owned", assignee="s", requester="T-owner",
+                        requester_kind=TaskRequesterKind.TASK))
+    b.close()
+
+    reopened = SqliteTaskBackend(db)
+    got = await reopened.get("owned")
+    assert got is not None
+    assert got.requester == "T-owner"
+    assert got.requester_kind is TaskRequesterKind.TASK
+    reopened.close()

--- a/tests/test_2107_sliceA_recursive_request_1953.py
+++ b/tests/test_2107_sliceA_recursive_request_1953.py
@@ -44,7 +44,11 @@ from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime import task as taskmod
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
-from reyn.runtime.services.task_wake import WAKE_REQUESTER_KIND, TaskWaker
+from reyn.runtime.services.task_wake import (
+    WAKE_READY_KIND,
+    WAKE_REQUESTER_KIND,
+    TaskWaker,
+)
 from reyn.runtime.session import Session
 from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskRequesterKind, TaskState
 
@@ -157,6 +161,37 @@ async def test_failed_subtask_recovery_wakes_managing_session_full_live_path(tmp
         assert u_id in payload["text"]
     finally:
         await _cancel_running(reg)
+
+
+@pytest.mark.asyncio
+async def test_execution_context_threads_through_real_opctx_builder(tmp_path):
+    """Tier 2: the #2134 L3 enumerate-all-builders class, applied to the
+    SOURCE→builder threading. Stamping the session's per-turn execution context (via
+    the real seam, as run_one_iteration does on a ``task_ready`` wake) makes the REAL
+    chat op-ctx builder (``Session._make_router_op_context``) carry
+    ``current_task_id`` — so a router task.create derives ownership. The recovery wake
+    (``task_dependency_aborted``) does NOT stamp (its meta names the failed dependent,
+    not the managing task-as-request) → the build stays session-owned (hole (i),
+    by-design). Asserts on the BUILT ctx (the public builder output), not private
+    state. Falsified by a builder that drops the field (the unit-green/live-broken L3
+    failure that cost 3 misses in #2134)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    s = Session(agent_name="alice", state_log=state_log)
+
+    # execute-wake (task_ready) stamps → the real builder threads it onto the ctx.
+    s._stamp_execution_context(WAKE_READY_KIND, {"meta": {"task_id": "T-exec"}})
+    ctx_exec = s._make_router_op_context()
+    assert ctx_exec.current_task_id == "T-exec"
+
+    # recovery wake (task_dependency_aborted) does NOT stamp → session-owned build.
+    s._stamp_execution_context(WAKE_REQUESTER_KIND, {"meta": {"task_id": "U-failed"}})
+    ctx_recovery = s._make_router_op_context()
+    assert ctx_recovery.current_task_id is None
+
+    # a plain user turn clears it too (per-turn lifetime).
+    s._stamp_execution_context("user", {"text": "hi"})
+    ctx_user = s._make_router_op_context()
+    assert ctx_user.current_task_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_2107_sliceA_recursive_request_1953.py
+++ b/tests/test_2107_sliceA_recursive_request_1953.py
@@ -195,6 +195,32 @@ async def test_execution_context_threads_through_real_opctx_builder(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_adapter_builder_threads_current_task_id_live_router_path():
+    """Tier 2: #2134 L3 — the LIVE builder. Router-dispatched task ops build their
+    op-ctx via RouterHostAdapter.make_router_op_context (NOT the chat
+    Session._make_router_op_context), and the adapter reads the per-turn execution
+    context through a current_task_id_fn callback (varies per turn, like
+    live_session_id_fn). This is the exact builder that dropped task_waker in #2107 —
+    so it MUST be CI-pinned for current_task_id too. Mirrors
+    test_router_opctx_threads_task_waker_so_chat_abort_wakes_requester. Goes through
+    the REAL make_router_op_context. FALSIFY: strip the adapter's current_task_id
+    pass-through → ctx.current_task_id is None → RED (the chat-builder test stays
+    GREEN — which is exactly why this separate live-builder test is required)."""
+    from tests._support.router_host_adapter import make_adapter
+
+    adapter = make_adapter(agent_name="alice", session_id="worker",
+                           current_task_id_fn=lambda: "T-exec")
+    ctx = adapter.make_router_op_context()
+    assert ctx.current_task_id == "T-exec"  # the live-builder wire
+
+    # no execution context (top-level / user turn) → session-owned build.
+    adapter_none = make_adapter(agent_name="alice", session_id="worker",
+                                current_task_id_fn=lambda: None)
+    ctx_none = adapter_none.make_router_op_context()
+    assert ctx_none.current_task_id is None
+
+
+@pytest.mark.asyncio
 async def test_requester_kind_task_round_trips_through_sqlite(tmp_path):
     """Tier 2: the NON-DEFAULT requester_kind=task survives a sqlite set→reload→get
     (a default 'session' round-trip would pass trivially even if the column were


### PR DESCRIPTION
**[e2e-coder]** — §16 recursive-request **slice A**: a task (not only a session) can own a request. Owner-GO'd; design + A/B/C slicing approved by lead-coder + owner.

## What
A sub-task created while a session executes a **task-as-request** T is **owned by T** (`requester = T.task_id`, `requester_kind = task`), **OS-SET** from the execution context (`OpContext.current_task_id`) — **never an op field**, so the LLM cannot mark ownership to mis-route a later recovery (the §16 security invariant). Recovery **generalizes S1** (route to the requester): a `task` requester resolves to its **assignee** = the managing session → wake it (one hop; an assignee is always a session, never another task; parent == requester by construction → no S1 drift).

## Mechanism (the stable seam)
`OpContext.current_task_id` is the stable seam; its **SOURCE evolves** (execute-wake meta now → a persistent session-assignment in slice B). The `_create` read-side and the recovery-resolve stay fixed.

- **model** — `TaskRequesterKind` enum (`session`|`task`) + `Task.requester_kind` (default `session`, additive) + `to_dict`
- **context** — `OpContext.current_task_id`
- **task op** — `_create` derives `requester`/`requester_kind` from `current_task_id`; **assignee now defaults to the caller SESSION** (not `requester` — a task-id assignee would break the single-writer CAS); `_route_terminal_to_requester` resolves `kind==task` → the owner task's assignee
- **source wiring** — execute-wake (`task_ready`) `meta.task_id` → session per-turn state (`run_one_iteration`) → **both** op-ctx builders (RouterHostAdapter via a `current_task_id_fn` callback + the chat `_make_router_op_context`). Enumerating ALL builders is the #2134 L3 lesson (a single missed builder = a silent `None`). The recovery wake (`task_dependency_aborted`) deliberately does **not** stamp it (its meta names the failed dependent, not the managing task — see hole (i)).
- **sqlite** — `requester_kind` column + additive migration (pre-existing rows = `session` by definition) + round-trip

## Additive — no regression
`parent_id` stays intact; there is **no ownership-cascade yet** (that's slice B). A top-level / non-execute-wake create stays session-owned exactly as today.

## Known holes (no-regression in A; closed by slice B's persistent assignment)
- **(i) recovery-create** — a replacement created on a recovery turn falls to `requester=session` (the recovery wake names the failed dependent, not the managing task-as-request).
- **(ii) multi-turn execution** — a sub-task created on a continuation activation (no fresh execute-wake) falls to `requester=session`.

Both only bite slice B's `list(requester==T)` ownership-cascade; in slice A a hole-orphan just stays on the S1 session-path = today's behavior. Lead is tracking these on the §16 task; slice B's persistent assignment (the SOURCE generalization) closes both by construction.

## Verification
- **Falsifiable full-live-path test** (real registry + real `TaskWaker` + real route path, no mocks, **no hand-fed requester keys** — the ownership comes from the live create-path): a sub-task owned by a task-as-request fails with a live dependent → recovery resolves to + wakes the **managing session** (T's assignee). **Verified RED-when-stripped**: removing the `kind==task → assignee` resolve branch → the wake targets a bare task-id with no live session → `wake dropped` → the managing session stays unwoken (test fails).
- create-derivation both branches (`current_task_id` set → task / unset → session) + sqlite **non-default** (`task`) round-trip.
- Gates: `pytest` broad session/router/task sweep (1102 passed) + ruff full-tree (clean) + `scripts/test_tier_audit.py --strict` (7847 inspected, 0 errors). Full rootdir `pytest` running.

## Test plan
- [x] `pytest` slice-A + §16 suite (48 passed) + broad consumer sweep (1102 passed)
- [x] Falsification verified (strip task→assignee resolve → RED)
- [x] `ruff check src tests scripts` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 errors
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify: a task-as-request's sub-task fails → the managing session is woken (not a phantom task-id)

Design-gated: patch → close-review (lead) → tui live-verify → merge → slice B. **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
