### PR TITLE
docs(runtime): fix §16 requester routing — S1 stale contradiction + event fields

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -558,22 +558,27 @@ Completion-recompute (relax → only promotes), `remove` (relax), and `repoint`
 (may demote or promote) all share it. A readiness change emits a generic P6
 `task_readiness` event.
 
-**Disposition → parent routing (slice 6-ext).** When a task reaches a
+**Disposition → requester routing (§16, S1 #2134).** When a task reaches a
 non-`completed` terminal (`aborted` via `task.abort`, `failed` via
 `task.update_status`, or `cap_exceeded` on a per-Task budget cap-hit) and has
-**still-alive dependents**, the OS routes the disposition to the task's **parent
-session** (`parent_id`'s assignee) to decide recovery — the parent re-wires via
-ordinary ops (`repoint` / `remove` / fail / support-self), **not** a `decision=`
-vocabulary (P7). The **disposition** is carried first-class (in both the P6
-`task_dependency_aborted` event and the parent payload) so a budget `cap_exceeded`
-is never conflated with a genuine error `failed` (slice 8). A root task (no parent)
-or an already-terminal parent routes nothing (the parent's own cascade subsumes it).
+**still-alive dependents**, the OS notifies the task's **requester** (the §16
+disposition notify-target — the request-owner) to decide recovery — the requester
+re-wires via ordinary ops (`repoint` / `remove` / fail / support-self), **not** a
+`decision=` vocabulary (P7). If the requester is a **task** (`requester_kind=TASK`
+— a task-as-request owns the failed dependent), the OS resolves one hop to that
+task's **assignee** (the managing session) before waking. The **requester is always
+present** (every task carries one), so a root task is notified too — the prior
+`parent_id`-keyed routing silently dropped root-task recovery wakes (#2107). The
+**disposition** is carried first-class (in both the P6 `task_dependency_aborted`
+event and the requester payload) so a budget `cap_exceeded` is never conflated with
+a genuine error `failed` (slice 8). External-origin tasks route via the A2A/webhook
+channel rather than an in-session wake.
 
 **Per-Task budget cap (slice 8).** `record_cost(task_id, delta)` accumulates an
 LLM call's cost onto the Task's `cost_accum`; when it crosses the Task's
 `budget_cap` (an INDEPENDENT cap dimension, enforced alongside the session / daily
 caps — the tighter hits first), the OS force-terminates the task (abort-like) and
-routes the `cap_exceeded` disposition through the SAME parent-LLM seam — so one
+routes the `cap_exceeded` disposition through the SAME requester-LLM seam — so one
 recovery mechanism resolves both a terminal-dependency and a cap-hit. (The
 production wiring of the LLM cost recorder to `record_cost` co-lands with the
 task-execution engine in a later slice.)
@@ -582,7 +587,7 @@ task-execution engine in a later slice.)
 driver) turns these dispositions into actual session **wakes** via the canonical
 `resolve_session → _put_inbox → ensure_session_running` triple: a promoted
 dependent (on a predecessor `completed` OR a recovery `repoint`/`remove`) is woken
-with a `task_ready` inbox message; a parent is woken with `task_dependency_aborted`.
+with a `task_ready` inbox message; a requester (or its managing session) is woken with `task_dependency_aborted`.
 Both surface to the woken session's LLM as one router turn (OS-generic inbox kinds,
 P7) so it resumes / recovers via ordinary task ops. A **loopless** session (A2A /
 MCP, no run-loop) is booted by `ensure_session_running`; a looped one is an

--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -115,7 +115,7 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 | `task_op` | 任意のタスク変更操作が完了したとき（create / update-status / complete / abort） | `op`（op 種類文字列）、`task_id`、op 固有フィールド |
 | `task_readiness` | タスクが `ready` または `blocked` に遷移したとき（OS の再導出で readiness が変化） | `task_id`、`to`（`"ready"` または `"blocked"`）、`trigger`（変化を引き起こした op の task_id） |
 | `task_disposition` | 中断されたサブツリー内の各タスクが終端状態に達したとき | `task_id`、`disposition`（`"aborted"`）、`requester`、`origin`、`root`（ルート abort op の task_id） |
-| `task_dependency_aborted` | タスクの依存先が非完了終端に達し、親セッションが復旧を決定する必要があるとき | `task_id`（終端タスク）、`disposition`、`parent_id`、`parent_session`、`dependents`（stuck 状態の task_id リスト） |
+| `task_dependency_aborted` | タスクの依存先が非完了終端に達し、リクエスターが復旧を決定する必要があるとき（§16） | `task_id`（終端タスク）、`disposition`、`requester`（セッション or タスク id — §16 通知ターゲット）、`dependents`（stuck 状態の task_id リスト） |
 
 ## agent 間メッセージング
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -118,7 +118,7 @@ Events emitted by the task Control IR ops (`task.py`).
 | `task_op` | Any mutating task operation completes (create / update-status / complete / abort) | `op` (op kind string), `task_id`, plus op-specific fields |
 | `task_readiness` | A task transitions to `ready` or `blocked` (OS re-derive changed readiness) | `task_id`, `to` (`"ready"` or `"blocked"`), `trigger` (task_id of the op that caused the change) |
 | `task_disposition` | Each task in an aborted subtree reaches its terminal disposition | `task_id`, `disposition` (`"aborted"`), `requester`, `origin`, `root` (task_id of the root abort op) |
-| `task_dependency_aborted` | A task's dependency reached a non-completed terminal; its parent session is notified to decide recovery | `task_id` (the terminal task), `disposition`, `parent_id`, `parent_session`, `dependents` (list of task_ids that are now stuck) |
+| `task_dependency_aborted` | A task's dependency reached a non-completed terminal; its requester is notified to decide recovery (§16) | `task_id` (the terminal task), `disposition`, `requester` (session or task id — the §16 notify-target), `dependents` (list of task_ids that are now stuck) |
 
 ## Agent-to-agent messaging
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- `control-ir.md`: Rewrites the stale "Disposition → parent routing" section that S1 (#2134) left as an internal contradiction — the abort section above it already carried correct §16/requester text, but this named subsection still said `parent_id`'s assignee. Now documents the full §16 model: route to requester; if `requester_kind=TASK`, resolve one hop to that task's assignee; root tasks notified (#2107 silence gap fixed by S1); external tasks via A2A/webhook channel. Also fixes two adjacent stale "parent" references in the budget-cap and TaskWaker paragraphs.
- `events.md` + `events.ja.md`: `task_dependency_aborted` event row — drops `parent_id`/`parent_session` fields, replaces with `requester` (session or task id) per the S1 impl (`_route_terminal_to_requester` emit in `src/reyn/core/op_runtime/task.py`).

Verified impl against `feat/1953-s16-recursive-sliceA` @ 07c53177.

**Merge gate**: after slice A (#1953) merges (so docs match merged code, not a pending PR). Lead-coder dispatch.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (0 warnings, exit 0)
- [x] Impl fields verified from `_route_terminal_to_requester` emit: `task_id`, `disposition`, `requester`, `dependents` — no `parent_id`/`parent_session`
- [x] Page drop: zero (no nav changes, edits are inline)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)