### PR TITLE
docs(testing): note --import-mode=importlib for single-file runs with tests._support

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -498,6 +498,13 @@ ready:
    python -m pytest -q -n auto --timeout=120
    ```
    CI runs with `-n auto` (parallel workers) and `--timeout=120` (`pytest-timeout>=2.2`, a dev dep — `pip install -e ".[dev]"` installs it). Run locally with the same flags: a test that would hang in CI will fail-and-name the hanger within 120 s instead of blocking the run indefinitely.
+
+   > **Single-file invocation and `tests._support`:** running `pytest tests/path/to/test_foo.py` (without the full-suite `python -m pytest`) can raise `ModuleNotFoundError: No module named 'tests._support'` when the test imports from the `make_adapter` / `LLMReplay` harness. Root cause: `tests/` has no `__init__.py`, so pytest's default `prepend` import mode cannot resolve the `tests._support` namespace package from a single-file invocation. CI's full-suite collection resolves it. Fix for isolated runs:
+   > ```bash
+   > pytest --import-mode=importlib tests/path/to/test_foo.py
+   > ```
+   > A `ModuleNotFoundError` here is a local-env quirk, **not** a real test failure — do not fall back to structural-only verification before adding `--import-mode=importlib`.
+
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
    ruff check src tests        # add --fix for autofixable I001 / formatting

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -499,12 +499,6 @@ ready:
    ```
    CI runs with `-n auto` (parallel workers) and `--timeout=120` (`pytest-timeout>=2.2`, a dev dep — `pip install -e ".[dev]"` installs it). Run locally with the same flags: a test that would hang in CI will fail-and-name the hanger within 120 s instead of blocking the run indefinitely.
 
-   > **Single-file invocation and `tests._support`:** running `pytest tests/path/to/test_foo.py` (without the full-suite `python -m pytest`) can raise `ModuleNotFoundError: No module named 'tests._support'` when the test imports from the `make_adapter` / `LLMReplay` harness. Root cause: `tests/` has no `__init__.py`, so pytest's default `prepend` import mode cannot resolve the `tests._support` namespace package from a single-file invocation. CI's full-suite collection resolves it. Fix for isolated runs:
-   > ```bash
-   > pytest --import-mode=importlib tests/path/to/test_foo.py
-   > ```
-   > A `ModuleNotFoundError` here is a local-env quirk, **not** a real test failure — do not fall back to structural-only verification before adding `--import-mode=importlib`.
-
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
    ruff check src tests        # add --fix for autofixable I001 / formatting


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

Adds a callout under § "Before you push" → pytest gate: running `pytest tests/path/to/test_foo.py` (not the full-suite `python -m pytest`) raises `ModuleNotFoundError: No module named 'tests._support'` when the test imports from the `make_adapter`/`LLMReplay` harness. Root cause: `tests/` has no `__init__.py`; default `prepend` import mode can't resolve the namespace package from a single-file invocation. Fix: `pytest --import-mode=importlib <file>`. CI is unaffected.

Without this note peers mis-read the error as a real failure and fall back to structural-only verification instead of running the real strip→RED falsification.

Suggested by tui-coder (lead-routed). No API/behavior changes — docs only.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (0 warnings, exit 0)
- [x] Page drop: zero (no nav changes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)