### PR TITLE
feat(#2107): §16 B1 — recovery-create owned by the managing task-as-request

### DIFF
--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -401,9 +401,17 @@ async def _route_terminal_to_requester(
     # requester by construction → no drift). One hop suffices: an assignee is always
     # a session, never another task. This is the recursive generalization of S1.
     requester_session = requester
+    # §16 B1 (recursive-request): when the requester is a TASK, ``requester`` IS the
+    # managing task-as-request's id (T). Carry it to the wake so the managing session's
+    # recovery turn is stamped with current_task=T → a replacement it creates is OWNED
+    # by T (closes hole (i) recovery-create). None for a session-requester (a top-level
+    # request's recovery stays session-owned). Interleaving-precise: the recovery wake
+    # is task-specific (for T), so stamping current=T cannot leak into another task's turn.
+    managing_task_id = None
     if terminal_task.requester_kind is TaskRequesterKind.TASK:
         owner = await backend.get(requester)
         requester_session = owner.assignee if owner is not None else None
+        managing_task_id = requester
     events = getattr(ctx, "events", None)
     if events is not None:
         # Generic P6 (P7); NOT a WAL closed-vocab kind (WAL-vs-P6 separation). The
@@ -423,7 +431,7 @@ async def _route_terminal_to_requester(
     if waker is not None:
         await waker.notify_requester_decide(
             requester_session=requester_session, terminal_task=terminal_task,
-            dependents=stuck, disposition=disp,
+            dependents=stuck, disposition=disp, managing_task_id=managing_task_id,
         )
 
 

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -141,12 +141,18 @@ class TaskWaker:
         )
 
     async def notify_requester_decide(self, *, requester_session: str, terminal_task: Any,
-                                      dependents: "list[Any]", disposition: str | None = None) -> None:
+                                      dependents: "list[Any]", disposition: str | None = None,
+                                      managing_task_id: str | None = None) -> None:
         """§16 abort/failed/cap_exceeded-side: wake the REQUESTER (the request-owner) to
         decide recovery for its stuck dependents (it re-wires via ordinary task ops —
         repoint to a substitute / remove the edge / fail / handle itself; P7 — no decision
         vocabulary). ``disposition`` is the first-class terminal reason (#1953 slice 8
-        no-conflation: a budget ``cap_exceeded`` vs a genuine ``failed``)."""
+        no-conflation: a budget ``cap_exceeded`` vs a genuine ``failed``).
+
+        ``managing_task_id`` (§16 B1) is the task-as-request T that OWNS the stuck
+        dependents — set when the requester is a TASK (else None). Carried in the wake
+        meta so the woken managing session stamps current_task=T for its recovery turn
+        (a replacement it creates is then OWNED by T — closes hole (i) recovery-create)."""
         dep_ids = [d.task_id for d in dependents]
         disp = disposition or terminal_task.status.value
         await self._wake(
@@ -157,6 +163,7 @@ class TaskWaker:
             f"to a substitute, remove the dependency, fail them, or handle the work "
             f"yourself).",
             task_id=terminal_task.task_id, dependents=dep_ids, disposition=disp,
+            managing_task_id=managing_task_id,
         )
 
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -70,7 +70,7 @@ from reyn.runtime.services import (
 )
 from reyn.runtime.services.a2a_handler import A2AHandler
 from reyn.runtime.services.chain_manager import _PendingChain
-from reyn.runtime.services.task_wake import WAKE_READY_KIND
+from reyn.runtime.services.task_wake import WAKE_READY_KIND, WAKE_REQUESTER_KIND
 from reyn.runtime.session_buses import AgentRequestBus, ChatInterventionBus
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
@@ -3516,20 +3516,29 @@ class Session:
         """#1953 §16 (recursive-request): set the per-turn execution context read by
         the router op-ctx builders (→ ``OpContext.current_task_id``) so a
         ``task.create`` during this turn derives ownership (requester=<this task>,
-        requester_kind=task).
+        requester_kind=task). Per-turn + interleaving-precise: the context is exactly
+        the task the THIS turn's wake is about, so a session juggling T1/T2 never
+        mis-owns a create.
 
-        A turn the OS woke to EXECUTE an assigned task (``task_ready`` =
-        ``WAKE_READY_KIND``) carries that task_id in its wake meta → stamp it. Every
-        other trigger (user / hook / and the recovery ``task_dependency_aborted``
-        wake) CLEARS it — a per-turn lifetime. The recovery wake is DELIBERATELY
-        excluded: its meta names the FAILED dependent, not the managing
-        task-as-request, so stamping it would mis-own a recovery-create. The
-        recovery-create + multi-turn-execution contexts are closed by slice B's
-        persistent assignment (the SOURCE evolves; this is the set-point seam)."""
-        self._current_task_id = (
-            payload.get("meta", {}).get("task_id")
-            if kind == WAKE_READY_KIND else None
-        )
+        - ``task_ready`` (``WAKE_READY_KIND``, execute-wake): stamp the task to execute
+          (``meta.task_id``). Continuations are re-wakes (a completed sub-task promotes
+          T → ``wake_ready_dependent`` re-stamps current=T on resume), so multi-turn
+          execution is covered.
+        - ``task_dependency_aborted`` (``WAKE_REQUESTER_KIND``, recovery-wake): stamp the
+          MANAGING task-as-request (``meta.managing_task_id`` = T, set by
+          ``notify_requester_decide`` only when the requester is a TASK) — so a
+          REPLACEMENT the managing session creates this turn is owned by T (§16 B1,
+          closes hole (i) recovery-create). None for a session-requester recovery (a
+          top-level request's recovery stays session-owned). NOTE: NOT ``meta.task_id``
+          here — that names the FAILED dependent, not the manager.
+        - any other trigger (user / hook): CLEAR (session-owned creates)."""
+        meta = payload.get("meta", {})
+        if kind == WAKE_READY_KIND:
+            self._current_task_id = meta.get("task_id")
+        elif kind == WAKE_REQUESTER_KIND:
+            self._current_task_id = meta.get("managing_task_id")
+        else:
+            self._current_task_id = None
 
     async def _handle_task_wake(self, payload: dict) -> None:
         """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /

--- a/tests/test_2107_B1_recovery_stamp_1953.py
+++ b/tests/test_2107_B1_recovery_stamp_1953.py
@@ -1,0 +1,157 @@
+"""Tier 2: #2107 §16 B1 — recovery-create is owned by the managing task-as-request.
+
+Slice A left hole (i): a session recovering a task-as-request T's failed sub-task by
+CREATING a replacement got requester=session (the recovery wake names the FAILED
+dependent, not T), so the replacement was an ORPHAN — not owned/aborted with T. B1
+closes it (Option A, per-wake + interleaving-precise): the recovery wake
+(``task_dependency_aborted``) ALSO carries the managing task T (computed at the
+resolve site: requester_kind==TASK → owner), and ``_stamp_execution_context`` stamps
+current_task=T for that recovery turn → a replacement created on it is OWNED by T.
+
+Full-live-path (real registry + real TaskWaker + real route + the real adapter
+builder; no mocks, no hand-fed keys — ownership comes from the live create-path):
+route → the wake meta carries managing_task_id=T → stamp → a recovery-create through
+the REAL adapter op-ctx is owned by T. FALSIFY: strip the managing_task_id carry →
+the wake meta lacks it → stamp gets None → the replacement falls to requester=session
+(the slice-A orphan) → RED.
+
+Interleaving-precise: the recovery wake is task-specific (for T), so stamping
+current=T cannot leak into another task's turn (the reason Option A beats a
+persistent session-assignment — see the design-call flow-trace).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime import task as taskmod
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services.task_wake import WAKE_REQUESTER_KIND, TaskWaker
+from reyn.runtime.session import Session
+from reyn.task import InMemoryTaskBackend, Task, TaskRequesterKind, TaskState
+from tests._support.router_host_adapter import make_adapter
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+async def _cancel_running(reg: AgentRegistry) -> None:
+    tasks = reg.running_tasks()
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _create_op(name, *, deps=None):
+    return SimpleNamespace(name=name, description=f"do {name}", deps=list(deps or []),
+                           assignee=None, origin=None, parent_id=None)
+
+
+def _ctx(backend, *, session_id="worker", current_task_id=None, waker=None):
+    return SimpleNamespace(session_id=session_id, agent_id="alice", events=None,
+                           task_backend=backend, task_waker=waker,
+                           current_task_id=current_task_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_recovery_create_on_task_as_request_is_owned_by_it_full_live_path(tmp_path):
+    """Tier 2: §16 B1 — the headline. A sub-task U owned by a task-as-request T
+    (live create) fails with a stuck dependent → recovery wakes T's managing session,
+    the wake carries managing_task_id=T, the stamp sets current=T, and a REPLACEMENT
+    the managing session creates (through the REAL adapter builder) is OWNED by T.
+    FALSIFY: strip the managing_task_id carry → the replacement falls to
+    requester=session (the slice-A orphan) → RED."""
+    reg = _make_registry(tmp_path)
+    managing = reg.get_or_load("alice")            # the live managing session (sid "main")
+    b = InMemoryTaskBackend()
+
+    # T = the task-as-request, executed by the managing session.
+    await b.create(Task(task_id="T-req", name="T", assignee="main", requester="a2a:client",
+                        status=TaskState.IN_PROGRESS))
+    # U owned by T (live create-path), a dependent V, then U fails.
+    res_u = await taskmod._create(
+        _create_op("U"), _ctx(b, session_id="worker", current_task_id="T-req"), "control_ir")
+    u_id = res_u["task"]["task_id"]
+    assert (await b.get(u_id)).requester == "T-req"  # live ownership, not hand-fed
+    await taskmod._create(_create_op("V", deps=[u_id]), _ctx(b, session_id="worker"), "control_ir")
+    await b.update_status(u_id, TaskState.FAILED, caller_session_id="worker")
+
+    waker = TaskWaker(reg, "alice")
+    try:
+        # recovery routes to T's assignee (managing session) + carries the managing task.
+        await taskmod._route_terminal_to_requester(
+            _ctx(b, waker=waker), b, await b.get(u_id), disposition="failed")
+        kind, payload = managing.inbox.get_nowait()
+        assert kind == WAKE_REQUESTER_KIND
+        assert payload["meta"]["managing_task_id"] == "T-req"  # B1: the wake carries T
+
+        # the managing session enters its recovery turn → stamps current=T (as
+        # run_one_iteration does), then creates a REPLACEMENT through the REAL adapter
+        # op-ctx builder → the replacement is OWNED by T (hole (i) closed).
+        managing._stamp_execution_context(kind, payload)
+        adapter = make_adapter(agent_name="alice", task_backend=b, session_id="main",
+                               current_task_id_fn=lambda: managing._current_task_id)
+        rctx = adapter.make_router_op_context()
+        res_rep = await taskmod._create(_create_op("U-replacement"), rctx, "control_ir")
+        replacement = await b.get(res_rep["task"]["task_id"])
+        assert replacement.requester == "T-req"  # the recovery-create is owned by T
+        assert replacement.requester_kind is TaskRequesterKind.TASK
+    finally:
+        await _cancel_running(reg)
+
+
+@pytest.mark.asyncio
+async def test_session_requester_recovery_stays_session_owned(tmp_path):
+    """Tier 2: §16 B1 — the recovery wake for a SESSION-requester carries no managing
+    task (managing_task_id=None) → the recovery turn stays session-owned (a top-level
+    request's recovery is not mis-attributed to a task). Guards B1 against
+    over-stamping the session-requester path (S1 unchanged)."""
+    reg = _make_registry(tmp_path)
+    managing = reg.get_or_load("alice")
+    b = InMemoryTaskBackend()
+
+    # a flat self-task plan whose requester is the session "main" (the S1 path).
+    await b.create(Task(task_id="b2", name="b2", assignee="main", requester="main",
+                        status=TaskState.IN_PROGRESS))
+    await b.create(Task(task_id="b3", name="b3", assignee="main", requester="main", deps=["b2"]))
+    await b.update_status("b2", TaskState.FAILED, caller_session_id="main")
+
+    waker = TaskWaker(reg, "alice")
+    try:
+        await taskmod._route_terminal_to_requester(
+            _ctx(b, waker=waker), b, await b.get("b2"), disposition="failed")
+        kind, payload = managing.inbox.get_nowait()
+        assert kind == WAKE_REQUESTER_KIND
+        assert payload["meta"]["managing_task_id"] is None  # session-requester → no managing task
+        managing._stamp_execution_context(kind, payload)
+        # a create on this recovery turn stays session-owned.
+        res = await taskmod._create(
+            _create_op("fix"), _ctx(b, session_id="main",
+                                    current_task_id=managing._current_task_id), "control_ir")
+        fix = await b.get(res["task"]["task_id"])
+        assert fix.requester == "main"
+        assert fix.requester_kind is TaskRequesterKind.SESSION
+    finally:
+        await _cancel_running(reg)

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -219,12 +219,13 @@ class _RecordingWaker:
         self.calls: list[dict] = []
 
     async def notify_requester_decide(self, *, requester_session, terminal_task, dependents,
-                                      disposition=None):
+                                      disposition=None, managing_task_id=None):
         self.calls.append({
             "requester_session": requester_session,
             "terminal_task": terminal_task.task_id,
             "dependents": [d.task_id for d in dependents],
             "disposition": disposition,
+            "managing_task_id": managing_task_id,
         })
 
 
@@ -286,7 +287,8 @@ async def test_op_abort_routes_disposition_to_requester():
                          _opctx(b, events=rec, waker=waker, session_id="req"), "control_ir")
 
     assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
-                            "dependents": ["A"], "disposition": "aborted"}]
+                            "dependents": ["A"], "disposition": "aborted",
+                            "managing_task_id": None}]
     routed = [f for k, f in rec.events if k == "task_dependency_aborted"]
     assert routed and routed[0]["requester"] == "req" and routed[0]["dependents"] == ["A"]
     assert routed[0]["disposition"] == "aborted"
@@ -305,7 +307,8 @@ async def test_op_failed_routes_disposition_to_requester():
     await taskmod._update_status(SimpleNamespace(task_id="B", status="failed"),
                                  _opctx(b, waker=waker, session_id="sB"), "control_ir")
     assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
-                            "dependents": ["A"], "disposition": "failed"}]
+                            "dependents": ["A"], "disposition": "failed",
+                            "managing_task_id": None}]
 
 
 @pytest.mark.asyncio
@@ -321,7 +324,8 @@ async def test_op_abort_root_routes_to_requester():
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, waker=waker, session_id="req"), "control_ir")
     assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
-                            "dependents": ["A"], "disposition": "aborted"}]  # #2107: NOT dropped
+                            "dependents": ["A"], "disposition": "aborted",
+                            "managing_task_id": None}]  # #2107: NOT dropped
 
 
 @pytest.mark.asyncio
@@ -338,7 +342,8 @@ async def test_op_abort_with_terminal_parent_still_routes_to_requester():
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, waker=waker, session_id="req"), "control_ir")
     assert waker.calls == [{"requester_session": "req", "terminal_task": "B",
-                            "dependents": ["A"], "disposition": "aborted"}]
+                            "dependents": ["A"], "disposition": "aborted",
+                            "managing_task_id": None}]
 
 
 @pytest.mark.asyncio
@@ -360,7 +365,8 @@ async def test_2107_flat_self_task_plan_mid_failure_notifies_requester():
     # the requester ("me") is woken to recover the stuck dependent t3 (t4 sits blocked
     # behind t3, surfaced once t3 is recovered) — NOT dropped.
     assert waker.calls == [{"requester_session": "me", "terminal_task": "t2",
-                            "dependents": ["t3"], "disposition": "aborted"}]
+                            "dependents": ["t3"], "disposition": "aborted",
+                            "managing_task_id": None}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — §16 **B1** (recursive-request, Option A): a recovery-create is owned by the managing task-as-request. Lead-steered (Option A + split); closes slice-A hole (i). Stacked on slice A (#2136, merged).

## What
Slice A left **hole (i)**: a session recovering a task-as-request **T**'s failed sub-task by **creating a replacement** got `requester=session` — the recovery wake (`task_dependency_aborted`) names the *failed dependent*, not T — so the replacement was an **orphan**, not owned/aborted with T.

B1 closes it via **Option A** (per-wake + interleaving-precise). The design-call flow-trace was decisive: a session is the assignee of *many* tasks (interleaving is structural), so a **persistent** assignment slot would *leak* T1's context into a T2 turn = mis-own. The recovery wake is *task-specific* (for T), so stamping `current=T` on that turn is precise.

- `_route_terminal_to_requester` computes `managing_task_id` (= `requester` when `requester_kind==TASK` — already the resolved owner) and passes it to the wake.
- `notify_requester_decide` carries `managing_task_id` in the wake meta.
- `_stamp_execution_context` stamps `current_task=managing_task_id` for a `task_dependency_aborted` (recovery) turn — **not** `meta.task_id` (the failed dependent); `None` for a session-requester (a top-level request's recovery stays session-owned).

**Hole (ii) (multi-turn)** was already covered by re-wakes — a completed sub-task promotes T → `wake_ready_dependent` re-stamps `current=T` on resume (confirmed in the flow-trace) — so B1 is the only create-side change.

## Verification
- **Full-live-path falsifiable test** (real registry + real `TaskWaker` + real route + the **real adapter** op-ctx builder; no mocks, no hand-fed keys): route → the wake meta carries `managing_task_id=T` → stamp → a recovery-create through the real adapter is **owned by T**. **Verified RED-when-stripped**: removing the `managing_task_id` carry → the replacement falls to `requester=session` (the slice-A orphan) → the headline test fails **while the session-requester guard test stays green**.
- Plus the session-requester-stays-owned case (B1 doesn't over-stamp the S1 path).
- Consumer-sweep: `_RecordingWaker` double + its 5 exact-match asserts take `managing_task_id`.
- Gates: B1 + §16 suite (45 passed); broad session/router/task sweep (1106 passed); tier-audit `--strict` 7851/0; ruff full-tree clean.

## Test plan
- [x] `pytest` B1 + §16 suite (45 passed) + broad sweep (1106 passed)
- [x] Falsification verified (strip the managing_task_id carry → RED; session-requester guard stays green)
- [x] `ruff check src tests scripts` — clean
- [x] `scripts/test_tier_audit.py --strict` — 0 errors
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify: a task-as-request's sub-task fails → the managing session's recovery-create is owned by T (not an orphan)

Next: B2 (§18 ownership-cascade). Design-gated: patch → close-review → tui live-verify → merge. **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
