### PR TITLE
fix(#2137): PITR restore re-runs schema migration (single-source _migrate, robust restore)

### DIFF
--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -129,6 +129,10 @@ The WAL (`StateLog`, `.reyn/state/wal.jsonl`) and the P6 audit event log (`Event
 
 Do not conflate or merge the two logs. See [Events](events.md) for details.
 
+### Restore and schema migration
+
+`restore_to_seq` re-runs the schema migration on the restored generation (via the shared `_migrate_columns` helper, the same one `_open` uses on first open), bringing any restored generation to the current schema. This means a generation snapshotted before an additive column was introduced is automatically upgraded on restore — there is no "old schema is frozen in the snapshot" risk. The migration is idempotent: the `PRAGMA table_info` guard skips any column that already exists, so re-running it over a current-schema generation is a safe no-op. Robust to additive schema evolution by construction.
+
 ---
 
 ## Cost and the runtime-only opt-out

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -136,30 +136,48 @@ class SqliteTaskBackend:
             Path(self._db_path).parent / "task-generations"
         )
 
+    @staticmethod
+    def _migrate_columns(conn: sqlite3.Connection) -> None:
+        """Apply all additive column migrations to ``tasks`` that ``CREATE TABLE IF
+        NOT EXISTS`` cannot handle on its own (it does not add missing columns to an
+        already-existing table).  Safe no-op on a current-schema table: the
+        ``PRAGMA table_info`` guard skips any column that already exists.
+
+        Called from ``_open(init_schema=True)`` (first open / schema init) AND from
+        ``restore_to_seq`` (after the file-swap reopen), so every restored generation
+        is brought to the current schema — robust to additive schema evolution by
+        construction."""
+        existing = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+        # #1953 slice P2: additive migration for DBs created before tools / result.
+        for col in ("tools", "result"):
+            if col not in existing:
+                conn.execute(f"ALTER TABLE tasks ADD COLUMN {col} TEXT")
+        # #1953 §16 (recursive-request): additive migration for pre-existing DBs —
+        # a row created before this column is a session-owned task by definition
+        # (the only kind that existed), so the 'session' default is correct.
+        if "requester_kind" not in existing:
+            conn.execute(
+                "ALTER TABLE tasks ADD COLUMN requester_kind "
+                "TEXT NOT NULL DEFAULT 'session'")
+        conn.commit()
+
     def _open(self, *, init_schema: bool = False) -> sqlite3.Connection:
         """Open (or reopen, after a restore file-swap) the live connection with
-        the backend's fixed pragmas. ``init_schema`` only on first open — a
-        restored generation already carries the schema."""
+        the backend's fixed pragmas.  ``init_schema=True`` on first open: creates
+        tables (``CREATE TABLE IF NOT EXISTS`` is idempotent) and runs
+        ``_migrate_columns`` to bring any pre-existing DB to the current schema.
+        ``init_schema=False`` (restore path) skips table creation — ``restore_to_seq``
+        calls ``_migrate_columns`` directly on the fresh connection after the file-swap,
+        ensuring every restored generation is at the current schema."""
         conn = sqlite3.connect(self._db_path, check_same_thread=False)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=0")
         if init_schema:
             conn.executescript(_SCHEMA)
-            # #1953 slice P2: additive migration for DBs created before the
-            # tools / result columns (CREATE TABLE IF NOT EXISTS won't add them).
-            existing = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
-            for col in ("tools", "result"):
-                if col not in existing:
-                    conn.execute(f"ALTER TABLE tasks ADD COLUMN {col} TEXT")
-            # #1953 §16 (recursive-request): additive migration for pre-existing DBs —
-            # a row created before this column is a session-owned task by definition
-            # (the only kind that existed), so the 'session' default is correct.
-            if "requester_kind" not in existing:
-                conn.execute(
-                    "ALTER TABLE tasks ADD COLUMN requester_kind "
-                    "TEXT NOT NULL DEFAULT 'session'")
-            conn.commit()
+            # Single-source migration helper — also called from restore_to_seq so
+            # both open and restore paths share the same column-addition logic.
+            self._migrate_columns(conn)
         return conn
 
     def close(self) -> None:
@@ -190,8 +208,11 @@ class SqliteTaskBackend:
         passes the nearest active seq <= the rewind target). Closes the live
         connection, copies the (WAL-less) generation file over the db path, drops
         any stale ``-wal``/``-shm`` side-files so the old WAL is not replayed over
-        the restored copy, then reopens. Re-runnable (idempotent under the
-        rewind keystone). Defensive no-op if the generation is missing."""
+        the restored copy, then reopens with ``_migrate_columns`` so the restored
+        generation is always at the current schema — robust to additive schema
+        evolution between when the generation was snapshotted and now. Re-runnable
+        (idempotent under the rewind keystone). Defensive no-op if the generation
+        is missing."""
         src = self._gens.gen_path(seq)
         async with self._lock:
             if not src.exists():
@@ -203,6 +224,7 @@ class SqliteTaskBackend:
                 if stale.exists():
                     stale.unlink()
             self._conn = self._open()
+            self._migrate_columns(self._conn)
 
     async def generation_seqs(self) -> list[int]:
         async with self._lock:

--- a/tests/test_2137_restore_schema_migration.py
+++ b/tests/test_2137_restore_schema_migration.py
@@ -1,0 +1,106 @@
+"""Tier 2: #2137 — restore_to_seq re-runs schema migration via _migrate_columns.
+
+Invariant: a generation snapshotted before an additive column existed is
+automatically brought to the current schema on restore, so _row_to_task (and any
+reader that accesses the column) never hits an OperationalError or KeyError on the
+restored db.
+
+Mechanism under test: SqliteTaskBackend.restore_to_seq calls _migrate_columns on the
+freshly reopened connection after the file-swap — the same helper _open uses on first
+open.  The test constructs a cross-version restore scenario directly: create a backend,
+snapshot a generation at seq 1, then open the generation file with a raw sqlite3
+connection and DROP the requester_kind column to simulate a pre-column snapshot.
+Restore to that generation and assert the column is re-added and a task with a
+NON-default requester_kind (TaskRequesterKind.TASK) is readable.
+
+Falsification (documented below): removing the _migrate_columns call from
+restore_to_seq causes the test to go RED with an OperationalError on the INSERT
+(missing column) or on the SELECT (_row_to_task accesses requester_kind by name).
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from reyn.task import Task, TaskState
+from reyn.task.model import TaskRequesterKind
+from reyn.task.sqlite_backend import SqliteTaskBackend
+
+
+@pytest.mark.asyncio
+async def test_restore_re_runs_schema_migration_cross_version(tmp_path):
+    """Tier 2: restore_to_seq re-migrates a pre-column generation — non-default
+    requester_kind survives round-trip through a cross-version restore.
+
+    Setup:
+      1. Create a backend and snapshot a generation at seq 1 (current schema,
+         with requester_kind).
+      2. Surgically remove the requester_kind column from the generation FILE via a
+         raw sqlite3 connection, simulating a snapshot taken before that column was
+         added (the generation file is an independent copy — editing it does not
+         touch the live db).
+      3. restore_to_seq(1) — should replace the live db with the old-schema file and
+         then call _migrate_columns, re-adding the column.
+      4. Insert a task with requester_kind=TaskRequesterKind.TASK (non-default;
+         the default is 'session') and read it back via get() / _row_to_task.
+      5. Assert the returned task carries the non-default value — proves the column
+         exists and is wired end-to-end.
+
+    Falsification: with the _migrate_columns call removed from restore_to_seq, step 4
+    raises sqlite3.OperationalError ("table tasks has no column named requester_kind")
+    because the restored db still lacks the column — test goes RED, confirming the
+    call is load-bearing.
+    """
+    db_path = tmp_path / "tasks.db"
+    b = SqliteTaskBackend(db_path)
+
+    # Populate a task at seq 1 and snapshot.
+    await b.create(Task(
+        task_id="pre-col-task",
+        name="pre",
+        assignee="s",
+        requester="r",
+        status=TaskState.PENDING,
+    ))
+    await b.snapshot_generation(1)
+
+    # Locate the generation file and surgically remove requester_kind to simulate a
+    # pre-column snapshot.  We use a raw sqlite3 connection on the GENERATION FILE
+    # (not the live db) so the live connection is unaffected.
+    gen_file = b._gens.gen_path(1)
+    assert gen_file.exists(), "generation file must exist after snapshot_generation"
+    with sqlite3.connect(str(gen_file)) as raw:
+        # Verify the column exists before we remove it (guards the test setup).
+        cols_before = {r[1] for r in raw.execute("PRAGMA table_info(tasks)").fetchall()}
+        assert "requester_kind" in cols_before, (
+            "generation file should have requester_kind before we strip it"
+        )
+        raw.execute("ALTER TABLE tasks DROP COLUMN requester_kind")
+        raw.commit()
+        cols_after = {r[1] for r in raw.execute("PRAGMA table_info(tasks)").fetchall()}
+        assert "requester_kind" not in cols_after, (
+            "requester_kind must be gone after DROP COLUMN (simulates pre-column snapshot)"
+        )
+
+    # Restore to the stripped generation — _migrate_columns must re-add the column.
+    await b.restore_to_seq(1)
+
+    # After restore the live db should be at the current schema.  Insert a task with
+    # a NON-default requester_kind to prove the column is present AND correctly wired
+    # through _row_to_task.
+    await b.create(Task(
+        task_id="post-restore-task",
+        name="post",
+        assignee="s",
+        requester="r",
+        requester_kind=TaskRequesterKind.TASK,   # non-default (default='session')
+        status=TaskState.PENDING,
+    ))
+    fetched = await b.get("post-restore-task")
+    assert fetched is not None, "task must be readable after restore"
+    assert fetched.requester_kind == TaskRequesterKind.TASK, (
+        f"non-default requester_kind must round-trip; got {fetched.requester_kind!r}"
+    )
+
+    b.close()


### PR DESCRIPTION
**[lead-coder]** — I dispatched and own this PR. Implements owner-approved robustification of PITR restore per issue #2137 (reopened).

## Summary

- **Single-source extraction**: The additive-column migration that was inlined in `_open`'s `init_schema` block is extracted into a new `_migrate_columns(conn)` staticmethod — the single definition of the column migration logic for `tools`, `result`, and `requester_kind`.
- **Both paths covered**: `_migrate_columns` is called from `_open(init_schema=True)` (existing first-open path, unchanged behavior) AND from `restore_to_seq` (after the file-swap reopen, new call). A restored generation is now always brought to the current schema.
- **No backward-compat hacks**: Clean extraction — no shims, no duplication. The inline logic in `_open` is replaced by a single call to the helper.
- **Idempotent by construction**: `_migrate_columns` uses `PRAGMA table_info` to skip any column that already exists. `_SCHEMA` CREATE statements are all `IF NOT EXISTS`. Re-running on a current-schema DB is a safe no-op.

## Mechanism

```
_open(init_schema=True)  ──┐
                            ├─► _migrate_columns(conn)  [single definition]
restore_to_seq(seq)     ──┘        ALTER TABLE tasks ADD COLUMN ... (guarded)
```

The stale comment `"a restored generation already carries the schema"` has been updated in `_open`'s docstring to reflect the new contract.

## Falsifiable test + RED-when-stripped result

`tests/test_2137_restore_schema_migration.py` — Tier 2, real backend, no mocks, non-default value:

1. Creates a backend, snapshots seq 1 (current schema with `requester_kind`).
2. Opens the **generation file** (not the live db) with a raw `sqlite3` connection and `ALTER TABLE tasks DROP COLUMN requester_kind` — simulates a pre-column snapshot on disk.
3. Calls `restore_to_seq(1)`.
4. Inserts a task with `requester_kind=TaskRequesterKind.TASK` (non-default; default is `'session'`) and reads it back via `get()`.
5. Asserts the returned task carries `TaskRequesterKind.TASK`.

**RED-when-stripped**: With the `_migrate_columns` call removed from `restore_to_seq`, step 4 raises:
```
sqlite3.OperationalError: table tasks has no column named requester_kind
```
Confirmed manually before opening this PR.

## Doc

`docs/concepts/runtime/time-travel.md` — new "Restore and schema migration" subsection (after the WAL vs audit-event table) documents the robust invariant, framed as an architectural guarantee.

## Gate results

- `ruff check src tests` — ✓ All checks passed
- `python scripts/test_tier_audit.py --strict tests/test_2137_restore_schema_migration.py` — ✓ 1 test, 0 errors
- `pytest tests/ -k "task or rewind or sqlite or restore"` (excluding fastapi-dependent tests not relevant to this change) — ✓ 381 passed, 15 skipped

## Test plan

- [x] `ruff check src tests` passes
- [x] `python scripts/test_tier_audit.py --strict tests/test_2137_restore_schema_migration.py` passes
- [x] `pytest tests/test_2137_restore_schema_migration.py -v` — 1 PASSED
- [x] `pytest tests/ -k "task or rewind or sqlite or restore"` — 381 passed
- [x] Falsification confirmed: `OperationalError: table tasks has no column named requester_kind` when `_migrate_columns` call is absent from `restore_to_seq`
- [x] `_SCHEMA` CREATE statements verified all `IF NOT EXISTS` — confirmed idempotent

Fixes #2137