### PR TITLE
feat(#2107): §16 B1.5 — a self-continuation preserves the execution context

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -33,6 +33,7 @@ from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.snapshot_generations import SnapshotGenerationStore
 from reyn.core.events.state_log import StateLog
+from reyn.hooks.dispatcher import HOOK_INBOX_KIND
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.agent import Agent
 from reyn.runtime.budget.budget import (
@@ -3531,14 +3532,37 @@ class Session:
           closes hole (i) recovery-create). None for a session-requester recovery (a
           top-level request's recovery stays session-owned). NOTE: NOT ``meta.task_id``
           here — that names the FAILED dependent, not the manager.
-        - any other trigger (user / hook): CLEAR (session-owned creates)."""
+
+        Every trigger kind ``run_one_iteration`` can dispatch is classified
+        explicitly (complete-by-construction — §16 B1.5, the iteration-cap orphan
+        tui found: a hook self-continuation while executing T hit the old else→reset
+        and orphaned a post-cap sub-task). The three bands:
+        - SET (a task wake introduces the task context): the two above.
+        - PRESERVE (a self-continuation / a response to the agent's OWN prior action —
+          NOT a new context, so the current execution context must survive): ``hook``
+          (the #1800 self-continuation), ``agent_response`` (a reply to a request THIS
+          agent sent), ``skill_completed`` (a skill THIS agent spawned finished). These
+          never switch tasks, so preserving is interleaving-safe.
+        - RESET→None (a genuinely NEW external context = session-owned creates):
+          ``user``, ``agent_request`` (an INCOMING peer ask). An unknown future kind
+          falls here — fail-safe to session-owned (a mis-own/leak is worse than an
+          orphan); a new self-continuation kind must be added to the PRESERVE set.
+
+        Linger note (B1.5, considered + accepted): a post-completion hook can preserve
+        current=T past T's completion. Functionally harmless — §16 B2's
+        ownership-cascade fires on ABORT (a COMPLETED T is skipped), and a
+        linger-owned sub-task's own recovery still routes to T's assignee. The
+        clear-on-terminal alternative adds op→session coupling for no functional gain,
+        so it is intentionally NOT done."""
         meta = payload.get("meta", {})
         if kind == WAKE_READY_KIND:
             self._current_task_id = meta.get("task_id")
         elif kind == WAKE_REQUESTER_KIND:
             self._current_task_id = meta.get("managing_task_id")
+        elif kind in (HOOK_INBOX_KIND, "agent_response", "skill_completed"):
+            pass  # PRESERVE: self-continuation / response to the agent's own action
         else:
-            self._current_task_id = None
+            self._current_task_id = None  # user / agent_request / unknown → new context
 
     async def _handle_task_wake(self, payload: dict) -> None:
         """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /

--- a/tests/test_2107_B15_preserve_self_continuation_1953.py
+++ b/tests/test_2107_B15_preserve_self_continuation_1953.py
@@ -1,0 +1,105 @@
+"""Tier 2: #2107 §16 B1.5 — a self-continuation preserves the execution context.
+
+tui (live) found: while a session executes a task-as-request T, an iteration-cap
+turn boundary → a HOOK self-continuation (#1800 slice-5b, kind="hook") re-enters
+run_one_iteration; the old _stamp else-branch reset current_task_id=None → a sub-task
+created on that continuation turn ORPHANED (requester=session), which §16 B2's
+list(requester==T) ownership-cascade would then MISS.
+
+B1.5 classifies EVERY trigger kind run_one_iteration dispatches (complete-by-
+construction), in three bands:
+  - SET (a task wake introduces the context): task_ready, task_dependency_aborted.
+  - PRESERVE (a self-continuation / a response to the agent's OWN prior action — not a
+    new context): hook, agent_response, skill_completed.
+  - RESET→None (a genuinely NEW external context): user, agent_request (+ unknown,
+    fail-safe to session-owned).
+Interleaving-safe: only a task_ready switches tasks, so the PRESERVE bands cannot
+leak T1 into a T2 turn.
+
+Tests assert on the BUILT op-ctx (public builder output) / the created task, not
+private state. The headline goes RED if _stamp resets on a hook self-continuation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime import task as taskmod
+from reyn.hooks.dispatcher import HOOK_INBOX_KIND
+from reyn.runtime.services.task_wake import WAKE_READY_KIND
+from reyn.runtime.session import Session
+from reyn.task import InMemoryTaskBackend, TaskRequesterKind
+from tests._support.router_host_adapter import make_adapter
+
+
+def _create_op(name, *, deps=None):
+    return SimpleNamespace(name=name, description=f"do {name}", deps=list(deps or []),
+                           assignee=None, origin=None, parent_id=None)
+
+
+def _session(tmp_path: Path) -> Session:
+    return Session(agent_name="alice", state_log=StateLog(tmp_path / "wal.jsonl"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_hook_self_continuation_create_is_owned_by_executing_task(tmp_path):
+    """Tier 2: §16 B1.5 headline — while executing T, a HOOK self-continuation turn
+    PRESERVES current=T, so a sub-task created on it is OWNED by T (through the REAL
+    adapter op-ctx builder), NOT orphaned to the session. This is tui's iteration-cap
+    scenario (the cap ends the turn → a hook self-continuation resumes). FALSIFY: if
+    _stamp resets current_task_id on a hook turn → the sub-task falls to
+    requester=session → RED."""
+    s = _session(tmp_path)
+    b = InMemoryTaskBackend()
+
+    # the session is executing task-as-request T (set by the task_ready wake).
+    s._stamp_execution_context(WAKE_READY_KIND, {"meta": {"task_id": "T-exec"}})
+    # the capped turn ends → a hook self-continuation resumes the SAME execution.
+    s._stamp_execution_context(HOOK_INBOX_KIND, {"text": "continue working on T"})
+
+    # a sub-task created on the hook-continuation turn (real adapter builder) is T-owned.
+    adapter = make_adapter(agent_name="alice", task_backend=b, session_id="main",
+                           current_task_id_fn=lambda: s._current_task_id)
+    ctx = adapter.make_router_op_context()
+    res = await taskmod._create(_create_op("sub-on-hook"), ctx, "control_ir")
+    sub = await b.get(res["task"]["task_id"])
+    assert sub.requester == "T-exec"  # owned by T, not orphaned (RED if hook resets)
+    assert sub.requester_kind is TaskRequesterKind.TASK
+
+
+@pytest.mark.asyncio
+async def test_stamp_classifies_every_trigger_kind_complete_by_construction(tmp_path):
+    """Tier 2: §16 B1.5 — EVERY trigger kind run_one_iteration dispatches is classified
+    (no kind falls into the wrong band). Asserts on the built op-ctx (public output).
+    SET on task wakes, PRESERVE on self-continuations (hook/agent_response/
+    skill_completed), RESET on new contexts (user/agent_request) + an unknown
+    (fail-safe to session-owned)."""
+    s = _session(tmp_path)
+
+    def current() -> "str | None":
+        return s._make_router_op_context().current_task_id
+
+    # SET: a task_ready wake introduces the execution context.
+    s._stamp_execution_context(WAKE_READY_KIND, {"meta": {"task_id": "T"}})
+    assert current() == "T"
+
+    # PRESERVE: self-continuations keep T (the B1.5 fix).
+    for k in (HOOK_INBOX_KIND, "agent_response", "skill_completed"):
+        s._stamp_execution_context(k, {})
+        assert current() == "T", f"{k} must PRESERVE the execution context"
+
+    # RESET: a genuinely new external context clears to session-owned.
+    for k in ("user", "agent_request", "some_unknown_future_kind"):
+        s._stamp_execution_context(WAKE_READY_KIND, {"meta": {"task_id": "T"}})  # re-arm
+        s._stamp_execution_context(k, {})
+        assert current() is None, f"{k} must RESET to session-owned"


### PR DESCRIPTION
**[e2e-coder]** — §16 **B1.5** (recursive-request): a self-continuation preserves the execution context. tui-found gap, lead-confirmed; **before B2** (so B2's `list(requester==T)` cascade gets the continuation-created sub-tasks). Stacked on B1 (#2141, merged).

## The gap (tui live)
While a session executes a task-as-request **T**, the iteration-cap ends the turn → a **hook self-continuation** (#1800 slice-5b, `kind="hook"`) re-enters `run_one_iteration`. The old `_stamp` else-branch reset `current_task_id=None` → a sub-task created on that continuation turn **orphaned** (`requester=session`), which §16 B2's ownership-cascade would then **miss**. (The iteration-cap itself is intra-turn — `handle_limit_exceeded` runs within one `_run_with_shrink` under one stamp; the orphaning continuation is the hook turn *after* the capped turn ends.)

## Fix — classify every trigger kind (complete-by-construction)
Enumerated all 7 kinds `run_one_iteration` dispatches and classified each against its handler's semantics:
- **SET** (a task wake introduces the context): `task_ready`, `task_dependency_aborted`.
- **PRESERVE** (a self-continuation / a response to the agent's **own** prior action — not a new context): `hook` (the #1800 self-continuation), `agent_response` ("Process an *incoming* agent_response" to delegations *this* agent sent), `skill_completed` (a skill *this* agent spawned finished).
- **RESET→None** (a genuinely **new external context**): `user`, `agent_request` ("Process an *incoming* agent_request" — an inbound peer ask). An **unknown** future kind falls here — fail-safe to session-owned (a mis-own/leak is worse than an orphan; a new self-continuation kind must be added to PRESERVE).

**Interleaving-safe**: only `task_ready` switches tasks, so the PRESERVE bands cannot leak T1 into a T2 turn.

## Linger (considered + accepted, not fixed)
A post-completion hook can preserve `current=T` past T's completion. **Functionally harmless** — B2's ownership-cascade fires on **abort** (a completed T is skipped), and a linger-owned sub-task's own recovery still routes to T's assignee. The clear-on-terminal alternative adds op→session coupling for zero functional gain → intentionally **not** done (lead-confirmed (a) over (b)).

## Verification
- **Headline test**: a hook self-continuation while executing T → a sub-task created (through the **real adapter** op-ctx builder) is **owned by T**, not orphaned. **Verified RED-when-stripped** (reset-on-self-continuation → fails).
- **Complete-partition test**: every kind classified (SET / PRESERVE {hook, agent_response, skill_completed} / RESET {user, agent_request, unknown}) — asserts on the built op-ctx (public output).
- Gates: B1.5 + §16 suite (38 passed); broad sweep (1277 passed; the 3 `gateway/*` failures are the known stale-local-tree artifacts, unrelated); tier-audit `--strict` 7854/0; ruff full-tree clean.

## Test plan
- [x] `pytest` B1.5 + §16 suite (38 passed) + broad sweep (1277 passed)
- [x] Falsification verified (reset-on-self-continuation → RED)
- [x] `ruff check` clean + `scripts/test_tier_audit.py --strict` 0 errors
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify: the iteration-cap repro — a post-cap sub-task during T's execution is owned by T (not the requester=main orphan tui originally saw)

Next: B2 (§18 ownership-cascade). Design-gated: patch → close-review → tui live-verify → merge. **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
