### PR TITLE
fix(#2110): web_fetch emits a terminal failed event (mirror web_search)

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -61,7 +61,8 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 | `run_skill_started`、`skill_run_spawned`、`skill_run_failed` | `run_skill` op — `run_skill_started` は `skill_version_hash: str`（実行時の `skill.md` 内容の sha256 hex。`skill.md` が存在しない場合は `"unknown"`）を持つ |
 | `mcp_called`、`mcp_completed`、`mcp_failed` | MCP ツール op |
 | `mcp_server_installed` | `mcp_install` op — `name`、キー名のみ（値は含まない） |
-| `web_search_started`、`web_search_completed`、`web_search_failed`、`web_fetch_started` | 検索 op |
+| `web_search_started`、`web_search_completed`、`web_search_failed` | web_search op — `started`: `query`、`backend`; `completed`: `result_count` を追加; `failed`: `error` を追加 |
+| `web_fetch_started`、`web_fetch_completed`、`web_fetch_failed` | web_fetch op — `started`: `url`; `completed`: `url`、`status_code`、`content_length`、`extractor`; `failed`: `url`、`status`（`"timeout"` または `"error"`）、`error` |
 | `embed_progress` | `embed` op（Form B artifact 参照のみ）— バッチごとの `embedded: int`、`skipped: int` 累積カウント |
 | `recall_embed_failed` | `recall` op — embed サブ op が失敗したとき: `query`、`error` |
 | `index_dropped` | `index_drop` op — `source`、`chunks_dropped: int` |

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -61,7 +61,8 @@ Each Control IR op kind emits its own event:
 | `run_skill_started`, `skill_run_spawned`, `skill_run_failed` | `run_skill` op — `run_skill_started` carries `skill_version_hash: str` (sha256 hex of `skill.md` content at execution time; `"unknown"` if `skill.md` is absent) |
 | `mcp_called`, `mcp_completed`, `mcp_failed` | MCP tool ops |
 | `mcp_server_installed` | `mcp_install` op — `name`, key names only (no values) |
-| `web_search_started`, `web_search_completed`, `web_search_failed`, `web_fetch_started` | search ops |
+| `web_search_started`, `web_search_completed`, `web_search_failed` | web_search ops — `started`: `query`, `backend`; `completed`: adds `result_count`; `failed`: adds `error` |
+| `web_fetch_started`, `web_fetch_completed`, `web_fetch_failed` | web_fetch ops — `started`: `url`; `completed`: `url`, `status_code`, `content_length`, `extractor`; `failed`: `url`, `status` (`"timeout"` or `"error"`), `error` |
 | `embed_progress` | `embed` op (Form B artifact reference only) — `embedded: int`, `skipped: int` cumulative per batch |
 | `recall_embed_failed` | `recall` op — emitted when the embed sub-op fails; `query`, `error` |
 | `index_dropped` | `index_drop` op — `source`, `chunks_dropped: int` |

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -326,9 +326,11 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
                     "error": f"too many redirects (exceeded {_ssrf_guard.MAX_REDIRECTS})",
                 }
     except httpx.TimeoutException:
-        return {"kind": "web_fetch", "url": op.url, "status": "timeout",
-                "error": f"request timed out after {op.timeout}s"}
+        _timeout_msg = f"request timed out after {op.timeout}s"
+        ctx.events.emit("web_fetch_failed", url=op.url, status="timeout", error=_timeout_msg)
+        return {"kind": "web_fetch", "url": op.url, "status": "timeout", "error": _timeout_msg}
     except httpx.RequestError as exc:
+        ctx.events.emit("web_fetch_failed", url=op.url, status="error", error=str(exc))
         return {"kind": "web_fetch", "url": op.url, "status": "error", "error": str(exc)}
 
     content_type = response.headers.get("content-type", "")

--- a/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
+++ b/src/reyn/interfaces/tui/widgets/right_panel/events_tab.py
@@ -112,6 +112,8 @@ _EVENT_COLORS: dict[str, str] = {
     "postprocessor_step_failed":    _STATUS_ERROR,
     "tool_executed":               _EVENT_TOOL,
     "web_fetch_started":           _TEXT_MUTED,
+    "web_fetch_completed":         _TEXT_MUTED,
+    "web_fetch_failed":            _STATUS_ERROR,
     "web_search_started":          _TEXT_MUTED,
     "web_search_completed":        _TEXT_MUTED,
     "web_search_failed":           _STATUS_ERROR,
@@ -167,7 +169,8 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "tool_called", "tool_returned", "tool_failed", "tool_executed",
         "mcp_called", "mcp_completed", "mcp_failed",
         "mcp_server_installed", "act_executed",
-        "web_fetch_started", "web_search_started",
+        "web_fetch_started", "web_fetch_failed",
+        "web_search_started",
         "web_search_completed", "web_search_failed",
         # #2095 P3: a shell hook ran a command (incl. silent auto-runs).
         "hook_shell_executed",
@@ -203,7 +206,8 @@ _FILTER_GROUPS: list[tuple[str, frozenset]] = [
         "loop_limit_exceeded", "phase_budget_exceeded", "budget_exceeded",
         "recall_embed_failed", "postprocessor_step_failed", "workflow_aborted",
         "phase_failed", "skill_run_failed", "control_ir_failed",
-        "web_search_failed", "normalization_error", "compaction_failed",
+        "web_fetch_failed", "web_search_failed",
+        "normalization_error", "compaction_failed",
         # #1953: a dependency abort leaving live dependents stuck — a
         # recovery-relevant signal, so it also shows under the error filter.
         "task_dependency_aborted",
@@ -380,6 +384,11 @@ def _event_hint(ev: dict) -> str:
         return url + ("…" if was_trunc else "")
     if t == "web_fetch_completed":
         return f"HTTP {d.get('status_code', '')} {d.get('content_length', '')}b"
+    if t == "web_fetch_failed":
+        err, was_trunc = _truncate_to_cells(str(d.get("error", "")), 35)
+        status = d.get("status", "")
+        status_part = f"[{status}] " if status else ""
+        return f"{status_part}{err}" + ("…" if was_trunc else "")
     if t == "web_search_started":
         query, was_trunc = _truncate_to_cells(str(d.get("query", "")), 40)
         return query + ("…" if was_trunc else "")

--- a/tests/test_web_fetch_failed_event_2110.py
+++ b/tests/test_web_fetch_failed_event_2110.py
@@ -1,0 +1,234 @@
+"""Tier 2: web_fetch emits a terminal web_fetch_failed event on failure (#2110).
+
+A FAILED web_fetch previously emitted only ``web_fetch_started`` with no terminal
+event — leaving the fetch stuck in a perpetual "started" state in the TUI events
+tab. web_search already emits ``web_search_failed`` on failure; web_fetch now
+mirrors that pattern.
+
+Falsification: without the fix (the ``ctx.events.emit("web_fetch_failed", ...)``
+calls in the two failure branches of ``handle_web_fetch``), the assertions below
+that ``web_fetch_failed`` was emitted would go RED — only ``web_fetch_started``
+would appear in the event log.
+
+Real components:
+- Real ``EventLog`` (public ``.all()`` API — not private state).
+- Real ``OpContext`` wired with real ``PermissionResolver`` (permission_resolver=None
+  skips the per-host gate; the handler reaches the httpx layer and the fake
+  transport raises the expected exception).
+- Real ``WebFetchIROp``.
+- Fake HTTP transport: a real class that raises ``httpx.TimeoutException`` or
+  ``httpx.RequestError`` — same technique as ``test_web_fetch_download_cap_1913.py``
+  (``monkeypatch.setattr(httpx, "AsyncClient", ...)``, allowed per testing policy
+  §3.4: "monkeypatch.setattr with a real callable").
+
+No ``MagicMock``, ``AsyncMock``, or ``patch`` used.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.web import handle_web_fetch
+from reyn.schemas.models import WebFetchIROp
+
+
+def _make_ctx(events: EventLog) -> Any:
+    """Build a real OpContext wired with the given EventLog.
+
+    permission_resolver=None skips the per-host permission gate so the
+    test reaches the httpx transport layer (where the fake raises).
+    """
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    return OpContext(
+        workspace=type("W", (), {})(),  # type: ignore[arg-type]
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+    )
+
+
+class _TimeoutClient:
+    """Real fake AsyncClient that raises httpx.TimeoutException on stream()."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_TimeoutClient":
+        return self
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+    def stream(self, method: str, url: str) -> "_TimeoutStreamCtx":
+        return _TimeoutStreamCtx()
+
+
+class _TimeoutStreamCtx:
+    async def __aenter__(self) -> None:
+        raise httpx.TimeoutException("simulated timeout")
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+class _RequestErrorClient:
+    """Real fake AsyncClient that raises httpx.RequestError on stream()."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_RequestErrorClient":
+        return self
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+    def stream(self, method: str, url: str) -> "_RequestErrorStreamCtx":
+        return _RequestErrorStreamCtx()
+
+
+class _RequestErrorStreamCtx:
+    async def __aenter__(self) -> None:
+        raise httpx.RequestError("simulated connection refused")
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+# ── Timeout path ──────────────────────────────────────────────────────────────
+
+
+def test_failed_web_fetch_timeout_emits_web_fetch_failed(monkeypatch) -> None:
+    """Tier 2: a timed-out web_fetch emits a terminal web_fetch_failed event.
+
+    Falsification: without the fix, EventLog.all() would contain only
+    ``web_fetch_started`` and NO ``web_fetch_failed`` — the assertion on
+    the failed-event types list would be empty → RED.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
+
+    events = EventLog()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events), caller="control_ir"))
+
+    # Return shape: status=timeout
+    assert result["status"] == "timeout"
+    assert result["kind"] == "web_fetch"
+
+    emitted_types = [e.type for e in events.all()]
+
+    # started MUST be present (regression guard)
+    assert "web_fetch_started" in emitted_types
+
+    # terminal failed event MUST be present — this is the new invariant
+    failed_events = [e for e in events.all() if e.type == "web_fetch_failed"]
+    assert failed_events, (
+        "Expected a web_fetch_failed terminal event but none was emitted. "
+        f"Emitted: {emitted_types}"
+    )
+
+    # Payload shape check: url and status fields must be present
+    ev = failed_events[0]
+    assert ev.data.get("url") == "https://example.com"
+    assert ev.data.get("status") == "timeout"
+    assert "timed out" in ev.data.get("error", "")
+
+
+def test_failed_web_fetch_timeout_no_completed_event(monkeypatch) -> None:
+    """Tier 2: a timed-out web_fetch does NOT emit web_fetch_completed.
+
+    Completing and failing are mutually exclusive. Guards against a
+    regression where both events fire.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
+
+    events = EventLog()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events), caller="control_ir"))
+
+    emitted_types = [e.type for e in events.all()]
+    assert "web_fetch_completed" not in emitted_types, (
+        f"web_fetch_completed must not fire on timeout. Emitted: {emitted_types}"
+    )
+
+
+# ── RequestError path ─────────────────────────────────────────────────────────
+
+
+def test_failed_web_fetch_request_error_emits_web_fetch_failed(monkeypatch) -> None:
+    """Tier 2: a web_fetch that raises httpx.RequestError emits web_fetch_failed.
+
+    Falsification: without the fix, only ``web_fetch_started`` would appear
+    in the event log — the ``failed_events`` assertion would be empty → RED.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", _RequestErrorClient)
+
+    events = EventLog()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    result = asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events), caller="control_ir"))
+
+    # Return shape: status=error
+    assert result["status"] == "error"
+    assert result["kind"] == "web_fetch"
+
+    emitted_types = [e.type for e in events.all()]
+    assert "web_fetch_started" in emitted_types
+
+    failed_events = [e for e in events.all() if e.type == "web_fetch_failed"]
+    assert failed_events, (
+        "Expected a web_fetch_failed terminal event but none was emitted. "
+        f"Emitted: {emitted_types}"
+    )
+
+    ev = failed_events[0]
+    assert ev.data.get("url") == "https://example.com"
+    assert ev.data.get("status") == "error"
+    assert "connection refused" in ev.data.get("error", "")
+
+
+def test_failed_web_fetch_request_error_no_completed_event(monkeypatch) -> None:
+    """Tier 2: a web_fetch that raises RequestError does NOT emit web_fetch_completed."""
+    monkeypatch.setattr(httpx, "AsyncClient", _RequestErrorClient)
+
+    events = EventLog()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events), caller="control_ir"))
+
+    emitted_types = [e.type for e in events.all()]
+    assert "web_fetch_completed" not in emitted_types, (
+        f"web_fetch_completed must not fire on RequestError. Emitted: {emitted_types}"
+    )
+
+
+# ── Parity check: mirror web_search's pattern ─────────────────────────────────
+
+
+def test_web_fetch_started_precedes_web_fetch_failed(monkeypatch) -> None:
+    """Tier 2: web_fetch_started is emitted BEFORE web_fetch_failed (ordering).
+
+    Mirrors web_search's invariant where ``web_search_started`` always
+    precedes ``web_search_failed``.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
+
+    events = EventLog()
+    op = WebFetchIROp(kind="web_fetch", url="https://example.com")
+    asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events), caller="control_ir"))
+
+    all_events = events.all()
+    types = [e.type for e in all_events]
+
+    assert "web_fetch_started" in types
+    assert "web_fetch_failed" in types
+
+    started_idx = types.index("web_fetch_started")
+    failed_idx = types.index("web_fetch_failed")
+    assert started_idx < failed_idx, (
+        f"web_fetch_started ({started_idx}) must precede web_fetch_failed ({failed_idx})"
+    )


### PR DESCRIPTION
**[lead-coder]** — Implements #2110 (event-parity fix; low severity; pure observability gap).

## Mirror source

`web_search`'s pattern (`handle_web_search`, `op_runtime/web.py`):
```python
except Exception as exc:
    ctx.events.emit("web_search_failed", query=op.query, backend=op.backend, error=str(exc))
    return {..., "status": "error", ...}
```

## web_fetch failure paths (before → after)

Two bare `return` paths in `handle_web_fetch` emitted no terminal event:

| Path | Before | After |
|------|--------|-------|
| `httpx.TimeoutException` | `web_fetch_started` only (stuck) | + `web_fetch_failed(url, status="timeout", error=...)` |
| `httpx.RequestError` | `web_fetch_started` only (stuck) | + `web_fetch_failed(url, status="error", error=...)` |

## Changes

- **`src/reyn/core/op_runtime/web.py`**: emit `web_fetch_failed` on both exception paths, matching web_search's `(url, status, error)` payload shape.
- **`src/reyn/interfaces/tui/widgets/right_panel/events_tab.py`**: add `web_fetch_completed` (was in hint handler but not `_EVENT_COLORS`) + `web_fetch_failed` to `_EVENT_COLORS`, both filter groups (`tool`, `error`), and `_event_hint` case.
- **`docs/reference/runtime/events.md` + `events.ja.md`**: split the combined "search ops" row into separate `web_search_*` and `web_fetch_*` rows with payload descriptions.

## Falsifiable test (Tier 2)

`tests/test_web_fetch_failed_event_2110.py` — 5 tests:

1. **`test_failed_web_fetch_timeout_emits_web_fetch_failed`** — timeout path emits `web_fetch_failed`. **RED without fix**: `events.all()` contains only `web_fetch_started`; the `failed_events` assertion fails empty.
2. `test_failed_web_fetch_timeout_no_completed_event` — no `web_fetch_completed` on timeout.
3. **`test_failed_web_fetch_request_error_emits_web_fetch_failed`** — RequestError path emits `web_fetch_failed`. **RED without fix**: same.
4. `test_failed_web_fetch_request_error_no_completed_event` — no `web_fetch_completed` on RequestError.
5. `test_web_fetch_started_precedes_web_fetch_failed` — ordering invariant.

No `MagicMock`/`AsyncMock`/`patch` — uses `monkeypatch.setattr(httpx, "AsyncClient", ...)` with real fake classes (same technique as `test_web_fetch_download_cap_1913.py`), real `EventLog`, real `OpContext`.

## Gate results

- `ruff check src tests` — ✓ all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_web_fetch_failed_event_2110.py` — ✓ 5/5 OK, 0 errors
- `pytest tests/test_web_fetch_failed_event_2110.py tests/test_web_fetch_unified.py tests/test_web_fetch_download_cap_1913.py tests/test_web_search_unified.py tests/test_web_fetch_ssl_config.py tests/test_web_fetch_ssrf_redirect_1956.py` — ✓ 58 passed in 5.85s

Broader suite: 8189 passed, 7 pre-existing failures (fastapi/mcp optional-dep, unrelated to this PR — confirmed present on main before patch).

## Test plan

- [x] `ruff check src tests` — green
- [x] Tier audit — green (5/5 OK)
- [x] `pytest -k "web_fetch or web_search"` — 58 passed

Fixes #2110