### PR TITLE
feat(#2107): §16 B2 — ownership-cascade (abort task-as-request → owned sub-tasks)

### DIFF
--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -31,6 +31,7 @@ from reyn.task.model import (
     TaskCycleError,
     TaskDepNotFoundError,
     TaskOrigin,
+    TaskRequesterKind,
     TaskState,
     _now_iso,
 )
@@ -381,12 +382,25 @@ class InMemoryTaskBackend:
         if task_id not in self._tasks:
             return []
         root_origin = self._tasks[task_id].origin
+        # DOWN-cascade closure: archive this task + every owned/decomposed descendant.
+        # An edge child→pid is followed when EITHER (a) parent_id==pid (the §12
+        # decomposition tree, legacy; removed in slice C) OR (b) requester==pid AND
+        # requester_kind==TASK (the §16/§18 ownership forest — a task-as-request owns
+        # its sub-tasks). The recursive sub-tasks (slice A/B1/B1.5) are
+        # requester=pid / parent_id=None, so (b) is what catches them — (a) alone
+        # misses them. The ``requester_kind==TASK`` guard is REQUIRED: a session
+        # routing-key (spawned-session uuid) can collide with a task-id uuid, so a
+        # bare requester==pid would wrongly cascade a session-requester task; the
+        # marker disambiguates → collision-safe. Acyclic (one requester/task, set at
+        # create to an earlier task) + the in-set guard → bounded, no double-abort.
         subtree: list[str] = [task_id]
         frontier = [task_id]
         while frontier:
             pid = frontier.pop()
             for tid, t in self._tasks.items():
-                if t.parent_id == pid and tid not in subtree:
+                owned = (t.requester == pid
+                         and t.requester_kind is TaskRequesterKind.TASK)
+                if (t.parent_id == pid or owned) and tid not in subtree:
                     subtree.append(tid)
                     frontier.append(tid)
         aborted: list[Task] = []

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -567,14 +567,26 @@ class SqliteTaskBackend:
             if origin_row is None:
                 return []
             root_external = origin_row["origin"] == TaskOrigin.EXTERNAL.value
-            # BFS the sub-tree (this task + all descendants via parent_id;
-            # acyclic by construction, with a guard).
+            # BFS the down-cascade closure: this task + every owned/decomposed
+            # descendant. An edge child→pid is followed when EITHER parent_id==pid
+            # (the §12 decomposition tree, legacy; removed in slice C) OR
+            # requester==pid AND requester_kind='task' (the §16/§18 ownership forest —
+            # a task-as-request owns its sub-tasks). The recursive sub-tasks (slice
+            # A/B1/B1.5) are requester=pid / parent_id=NULL, so the ownership edge is
+            # what catches them — parent_id alone misses them. The
+            # ``requester_kind='task'`` guard is REQUIRED: a session routing-key can
+            # collide with a task-id uuid, so a bare requester=pid would wrongly
+            # cascade a session-requester task; the marker disambiguates →
+            # collision-safe. Acyclic (one requester/task → earlier task) + the in-set
+            # guard → bounded. In-lock BFS (NOT recursive — the lock is not re-entrant).
             to_abort: list[str] = [task_id]
             frontier = [task_id]
             while frontier:
                 pid = frontier.pop()
                 for row in self._conn.execute(
-                    "SELECT task_id FROM tasks WHERE parent_id=?", (pid,)
+                    "SELECT task_id FROM tasks "
+                    "WHERE parent_id=? OR (requester=? AND requester_kind='task')",
+                    (pid, pid),
                 ).fetchall():
                     child = row["task_id"]
                     if child not in to_abort:

--- a/tests/test_2107_B2_ownership_cascade_1953.py
+++ b/tests/test_2107_B2_ownership_cascade_1953.py
@@ -1,0 +1,106 @@
+"""Tier 2: #2107 §16 B2 — the ownership-cascade (abort a task-as-request → its owned sub-tasks).
+
+§18: aborting a task-as-request X aborts everything X OWNS — ``list(requester==X
+AND requester_kind==task)`` — recursively. Unified into the existing down-cascade
+BFS (gather ``parent_id==pid OR (requester==pid AND requester_kind==task)``), so the
+ONE backend.abort seam serves every caller (the op, the A2A cancel endpoint, /tasks
+kill) by construction. Necessary because the recursive sub-tasks (slice A/B1/B1.5)
+are requester=X / parent_id=None — the legacy parent_id BFS misses them.
+
+Distinct from S2's dep-DAG dependent cascade (a different graph); UNGATED (owned
+PARTS are intrinsic to X, any origin — unlike S2's EXTERNAL-gated dependents).
+
+Tests (both backends, real create-path for the ownership edges — no hand-fed
+requester):
+  - recursive ownership cascade (depth ≥2): abort X → X + owned U + owned-of-U W all
+    archived. RED if the ownership edge is absent (U/W survive — parent_id=None).
+  - COLLISION GUARD: a SESSION-requester task whose session routing-key == a task_id
+    is NOT cascaded (the requester_kind==task marker disambiguates the uuid collision
+    requester_kind exists for). RED if the gather drops the marker guard.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskRequesterKind, TaskState
+
+
+def _create_op(name, *, deps=None):
+    return SimpleNamespace(name=name, description=f"do {name}", deps=list(deps or []),
+                           assignee=None, origin=None, parent_id=None)
+
+
+def _ctx(backend, *, session_id, current_task_id=None):
+    return SimpleNamespace(session_id=session_id, agent_id="a", events=None,
+                           task_backend=backend, task_waker=None,
+                           current_task_id=current_task_id)
+
+
+@pytest.fixture(params=["inmem", "sqlite"])
+def backend(request, tmp_path):
+    if request.param == "inmem":
+        yield InMemoryTaskBackend()
+    else:
+        b = SqliteTaskBackend(tmp_path / "tasks.db")
+        yield b
+        b.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_backend():
+    taskmod.reset_backend_for_test()
+    yield
+    taskmod.reset_backend_for_test()
+
+
+@pytest.mark.asyncio
+async def test_ownership_cascade_aborts_owned_subtasks_recursively(backend):
+    """Tier 2: §18 — aborting a task-as-request X archives its whole OWNERSHIP subtree
+    recursively (X → owned U → owned-of-U W, depth 2), via the live create-path's
+    requester edges (parent_id is None). RED if the ownership BFS edge is absent — U/W
+    would survive (the legacy parent_id BFS misses requester=X/parent_id=None
+    sub-tasks)."""
+    await backend.create(Task(task_id="X", name="X", assignee="sX", requester="client",
+                              status=TaskState.IN_PROGRESS))
+    res_u = await taskmod._create(
+        _create_op("U"), _ctx(backend, session_id="sX", current_task_id="X"), "control_ir")
+    u_id = res_u["task"]["task_id"]
+    res_w = await taskmod._create(
+        _create_op("W"), _ctx(backend, session_id="sU", current_task_id=u_id), "control_ir")
+    w_id = res_w["task"]["task_id"]
+
+    # live ownership (requester edges); the decomposition (parent_id) edge is absent.
+    u = await backend.get(u_id)
+    assert u.requester == "X" and u.requester_kind is TaskRequesterKind.TASK
+    assert u.parent_id is None
+    assert (await backend.get(w_id)).requester == u_id
+
+    aborted = await backend.abort("X")
+    ids = {t.task_id for t in aborted}
+    assert {"X", u_id, w_id} <= ids  # the whole ownership subtree, recursively
+    for tid in ("X", u_id, w_id):
+        assert (await backend.get(tid)).status is TaskState.ARCHIVED
+
+
+@pytest.mark.asyncio
+async def test_collision_guard_session_requester_is_not_cascaded(backend):
+    """Tier 2: §18 collision-safety — a SESSION-requester task whose session
+    routing-key happens to EQUAL the aborted task's id is NOT cascaded. The
+    ``requester_kind==task`` guard disambiguates the uuid collision (a spawned-session
+    uuid can equal a task-id uuid — the risk requester_kind exists for). RED if the
+    gather drops the marker guard (bare requester==X → S wrongly archived)."""
+    # X = the aborted task; S = a SESSION-requester whose requester string == X's id.
+    await backend.create(Task(task_id="collide", name="X", assignee="sX", requester="root",
+                              status=TaskState.IN_PROGRESS))
+    await backend.create(Task(task_id="S", name="S", assignee="sS", requester="collide",
+                              requester_kind=TaskRequesterKind.SESSION,
+                              status=TaskState.IN_PROGRESS))
+
+    aborted = await backend.abort("collide")
+    ids = {t.task_id for t in aborted}
+    assert "collide" in ids
+    assert "S" not in ids  # the marker guard — NOT cascaded despite the id collision
+    assert (await backend.get("S")).status is TaskState.IN_PROGRESS  # survived


### PR DESCRIPTION
**[e2e-coder]** — §16 **B2** (§18 ownership-cascade): abort a task-as-request → its owned sub-tasks, recursively. Lead-steered (unify + ungated + the marker guard). Stacked on B1/B1.5 (#2141/#2143, merged).

## What
Aborting a task-as-request **X** aborts everything **X owns** — its sub-tasks (`requester==X AND requester_kind==task`) — recursively. **Unified** into the existing down-cascade BFS (`gather parent_id==pid OR (requester==pid AND requester_kind==task)`) rather than a separate pass: coherent (both owned/decomposed edges) and it pre-stages slice C (parent_id drops → only the requester edge).

**Necessary** because the recursive sub-tasks (slice A/B1/B1.5) are `requester=X / parent_id=None` — the legacy `parent_id` BFS misses them. With B1 (recovery-create) + B1.5 (self-continuation) the ownership is now **complete**, so `list(requester==X)` catches all of X's sub-tasks.

## The three nails (design-call, lead-approved)
- **Trigger enumeration**: the cascade lives in the ONE `backend.abort` seam → all 3 callers (`_abort` op, A2A `cancel_task`, `/tasks kill`) + internal recursion get it by construction (direct-backend callers bypass the op layer — the seam **must** be the backend).
- **Separation from S2**: three distinct graphs — `parent_id` tree, `requester` ownership-forest (this), `deps` DAG (S2). **Ungated** (owned parts are intrinsic to X, any origin), distinct from S2's EXTERNAL-gated **dependents**. No double-abort (in-set guard + terminal-idempotence).
- **Bounded**: ownership is an acyclic forest (one requester/task, set at create to an **earlier** task → no cycle) + the in-set guard.

## Marker guard (collision-safety — must-have)
Gather by `requester==X AND requester_kind==task`, **not** bare `requester==X`: a spawned-session routing-key uuid can collide with a task-id uuid (the exact risk `requester_kind` exists for). The marker disambiguates → collision-safe by construction. *(Elegant: the slice-A marker's purpose now includes this cascade query.)*

## Both backends
- InMem: unions the ownership edge into the down-cascade BFS.
- Sqlite: adds `WHERE parent_id=? OR (requester=? AND requester_kind='task')` to the **in-lock** BFS (not recursive — the lock is not re-entrant, the S2 pattern).

## Verification
- **Ownership cascade** (both backends, depth ≥2, via the live create-path's requester edges): abort X → X + owned U + owned-of-U W all archived. **Verified RED-when-stripped** (drop the ownership edge → U/W survive).
- **Collision guard** (both backends): a session-requester task whose session-id == a task_id is **not** cascaded. **Verified RED-when-stripped** (drop the marker guard → it's wrongly archived).
- Gates: B2 + §16 suite (44 passed); broad task/backend/abort sweep (695 passed); tier-audit `--strict` 7856/0; ruff full-tree clean.

## Test plan
- [x] `pytest` B2 + §16 suite (44 passed) + broad sweep (695 passed)
- [x] Both falsifications verified (ownership edge → RED; marker guard → RED)
- [x] `ruff check` clean + `scripts/test_tier_audit.py --strict` 0 errors
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify: abort a task-as-request with live sub-tasks → the whole ownership subtree is archived (and a colliding session-requester task is not)

Next: slice C (remove parent_id + clean migration + docs→§16). Design-gated: patch → close-review → tui live-verify → merge. **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
