### PR TITLE
feat(#2104) PR1: skill-unification — synchronize chat-mode skill dispatch (retire spawn_skill)

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -707,21 +707,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def run_skill_awaitable(self, *, skill: str, input: dict,
                                    chain_id: str) -> dict: ...
 
-    # FP-0012: non-blocking skill dispatch. Chat-mode hosts return
-    # ``{status: "spawned", run_id, chain_id, note}`` immediately and
-    # deliver completion via the ``skill_completed`` inbox kind. Hosts
-    # that don't support spawn semantics (e.g. blocking phase sub-loops) leave
-    # this method un-bound (= duck-typing / hasattr check) so the
-    # invoke_skill handler falls back to ``run_skill_awaitable``.
-    async def spawn_skill(self, *, skill: str, input: dict,
-                          chain_id: str) -> dict: ...
-
     async def send_to_agent(self, *, to: str, request: str, depth: int,
                             chain_id: str) -> None: ...
 
     # #2103 S1bc: spawn a fresh-context session under THIS agent for a task.
     # Multi-session hosts (the chat RouterHostAdapter) implement it; others leave
-    # it unbound (= hasattr-guarded at caller-state build, like spawn_skill).
+    # it unbound (= hasattr-guarded at caller-state build).
     async def spawn_session(self, *, request: str, mode: str,
                             narrowing: "dict | None", chain_id: str) -> dict: ...
 
@@ -3650,22 +3641,9 @@ class RouterLoop:
                 skill=skill, input=input, chain_id=self.chain_id,
             )
 
-        # FP-0012: non-blocking spawn binding. Only chat-mode hosts
-        # implement ``spawn_skill``; a host that lacks it leaves this None
-        # and invoke_skill falls back to run_skill_fn (= blocking).
-        _spawn_skill_bound: Any = None
-        if hasattr(self.host, "spawn_skill") and callable(
-            getattr(self.host, "spawn_skill", None)
-        ):
-            async def _spawn_skill_bound_impl(*, skill: str, input: dict) -> Any:
-                return await self.host.spawn_skill(
-                    skill=skill, input=input, chain_id=self.chain_id,
-                )
-            _spawn_skill_bound = _spawn_skill_bound_impl
-
         # #2103 S1bc: session-spawn binding. Only multi-session hosts (the chat
         # RouterHostAdapter) implement ``spawn_session``; a host without it leaves
-        # this None (= duck-typed, like spawn_skill). chain_id pre-bound.
+        # this None (= duck-typed / hasattr-guarded). chain_id pre-bound.
         _spawn_session_bound: Any = None
         if hasattr(self.host, "spawn_session") and callable(
             getattr(self.host, "spawn_session", None)
@@ -3723,11 +3701,9 @@ class RouterLoop:
             # Skill invocation bridge (= for invoke_skill handler;
             # Phase 3.5-B-light) — chain_id pre-bound to preserve PR14
             # multi-hop chain semantics. Phase sub-loops keep using this for
-            # blocking step execution; chat-mode prefers spawn_skill_fn.
+            # #2104 PR1: synchronous skill execution for all callers (chat-mode and
+            # blocking sub-loop alike). run_skill_fn is the single invoke path.
             run_skill_fn=_run_skill_bound,
-            # FP-0012: non-blocking spawn binding for chat-mode invoke_skill.
-            # None for blocking phase sub-loop hosts (= no spawn_skill method on host).
-            spawn_skill_fn=_spawn_skill_bound,
             # #2103 S1bc: session-spawn dispatch (None for non-multi-session hosts).
             spawn_session_fn=_spawn_session_bound,
             # Memory tool bridges (= for memory cluster handlers;

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -79,10 +79,6 @@ class RouterHostAdapter:
         Async callback ``(server: str, tool: str, args: dict) -> dict``.
     run_skill_awaitable:
         Async callback ``(*, skill: str, input: dict, chain_id: str) -> dict``.
-    spawn_skill:
-        Async callback ``(*, skill, input, chain_id) -> dict`` — FP-0012
-        non-blocking dispatch returning the spawn-ack
-        ``{status: "spawned", run_id, chain_id, note}`` immediately.
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -131,7 +127,6 @@ class RouterHostAdapter:
         mcp_call_tool: Callable[..., Awaitable[dict]],
         # Action callbacks
         run_skill_awaitable: Callable[..., Awaitable[dict]],
-        spawn_skill: Callable[..., Awaitable[dict]],
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
         append_history: Callable,
@@ -336,7 +331,6 @@ class RouterHostAdapter:
         self._mcp_call_tool_cb = mcp_call_tool
         # Action callbacks
         self._run_skill_awaitable_cb = run_skill_awaitable
-        self._spawn_skill_cb = spawn_skill
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
         self._append_history_cb = append_history
@@ -897,18 +891,6 @@ class RouterHostAdapter:
     async def run_skill_awaitable(self, *, skill: str, input: dict,
                                    chain_id: str) -> dict:
         return await self._run_skill_awaitable_cb(
-            {"skill": skill, "input": input}, chain_id=chain_id,
-        )
-
-    async def spawn_skill(self, *, skill: str, input: dict,
-                          chain_id: str) -> dict:
-        """FP-0012 non-blocking spawn — returns immediately with the
-        ``{status: "spawned", run_id, chain_id, note}`` ack. The skill
-        runs in the background; completion arrives via the
-        ``skill_completed`` inbox kind. See ``Session.spawn_skill``
-        for the underlying implementation.
-        """
-        return await self._spawn_skill_cb(
             {"skill": skill, "input": input}, chain_id=chain_id,
         )
 

--- a/src/reyn/runtime/services/skill_plan_glue.py
+++ b/src/reyn/runtime/services/skill_plan_glue.py
@@ -6,8 +6,6 @@ loop and handles chain timeout lifecycle:
   - handle_skill_completed(payload)
   - drain_skill_completed_inbox(deadline)
   - on_chain_timeout_fire(chain_id)
-  - spawn_skill_for_router(spec, chain_id)
-  - spawn_skill(spec, chain_id)
   - enqueue_plan_completed(**kw)
 
 Public-surface note: ``drain_skill_completed_inbox`` is called from
@@ -261,14 +259,3 @@ class SkillPlanGlue:
                 meta={"chain_id": chain_id},
             ))
 
-    # ── Skill spawning delegation ─────────────────────────────────────────────
-
-    async def spawn_skill_for_router(
-        self, spec: dict, *, chain_id: str
-    ) -> dict:
-        """Thin delegation to SkillRunner.spawn_for_router (FP-0019 Wave 1b)."""
-        return await self._skill_runner.spawn_for_router(spec, chain_id=chain_id)
-
-    async def spawn_skill(self, spec: dict, *, chain_id: str | None = None) -> None:
-        """Thin delegation to SkillRunner.spawn (FP-0019 Wave 1b)."""
-        await self._skill_runner.spawn(spec, chain_id=chain_id)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1619,7 +1619,6 @@ class Session:
             mcp_list_tools=self._mcp_list_tools,
             mcp_call_tool=self._mcp_call_tool,
             run_skill_awaitable=self._skill_runner.run_skill_awaitable,
-            spawn_skill=self._skill_runner.spawn_for_router,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -4985,20 +4984,6 @@ class Session:
     # cli-redesign plan. ``_resolve_run_id`` / ``_resolve_intervention_id``
     # / ``_deliver_answer_to`` stay here as session-state helpers the slash
     # modules call back into.
-
-    # ── skill spawn (FP-0019 Wave 1b) ───────────────────────────────────────────
-    # Business logic lives in SkillRunner. Session keeps thin delegating
-    # methods for backward compat with any remaining internal callers.
-
-    async def _spawn_skill_for_router(
-        self, spec: dict, *, chain_id: str
-    ) -> dict:
-        """Forwarding → SkillPlanGlue.spawn_skill_for_router (PR-4)."""
-        return await self._skill_plan_glue.spawn_skill_for_router(spec, chain_id=chain_id)
-
-    async def _spawn_skill(self, spec: dict, *, chain_id: str | None = None) -> None:
-        """Forwarding → SkillPlanGlue.spawn_skill (PR-4)."""
-        await self._skill_plan_glue.spawn_skill(spec, chain_id=chain_id)
 
     async def _enqueue_skill_completed(
         self,

--- a/src/reyn/skill/skill_runner.py
+++ b/src/reyn/skill/skill_runner.py
@@ -476,15 +476,17 @@ class SkillRunner:
     async def spawn_for_router(self, spec: dict, *, chain_id: str) -> dict:
         """Non-blocking router-side spawn entry point.
 
-        Extracted from ``Session._spawn_skill_for_router``.  Wraps
-        :meth:`spawn` and returns the spawn-ack dict the router LLM
-        consumes via ``invoke_skill``'s tool_result.
+        NOTE: as of #2104 PR1, invoke_skill no longer calls this path —
+        chat-mode dispatch is now synchronous via run_skill_awaitable.
+        This method is preserved for PR2 cleanup and is dead code in
+        production. It remains the entry point for direct callers in
+        tests that exercise pre-spawn validation.
+
+        Wraps :meth:`spawn` and returns the spawn-ack dict.
 
         When :meth:`spawn` rejects pre-spawn (= input_schema violation
         / skill not found / load error), the structured error dict it
-        returns is forwarded verbatim so the router LLM sees a sync
-        tool_result with schema_hint in the same turn as its wrong
-        invoke_action call.
+        returns is forwarded verbatim.
         """
         before = set(self.running_skills.keys())
         spawn_result = await self.spawn(spec, chain_id=chain_id)

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -114,16 +114,13 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     that the op_runtime fallback path drops.  Defense Layer B
     (= skill name validation against ``available_skills``) is also
     applied here so a hallucinated skill name is rejected before the
-    sub-skill task spawns.
+    sub-skill task runs.
 
-    FP-0012 chat-mode preference: when ``rs.spawn_skill_fn`` is
-    populated (= chat-mode RouterLoop, Session host), prefer the
-    non-blocking spawn path. The handler returns the spawn-ack
-    ``{status: "spawned", run_id, chain_id, note}`` immediately and the
-    background task delivers completion via the ``skill_completed``
-    inbox kind. Blocking phase sub-loop RouterLoops leave ``spawn_skill_fn=None``
-    so their steps keep blocking semantics (= step's LLM sees the actual
-    skill result and can synthesize the next step's input).
+    Skills run synchronously inline (#2104 PR1 skill-unification): the
+    handler blocks until the skill finishes and returns the result directly
+    (``{status: "finished"|"error", data: ...}``). The spawn path
+    (FP-0012) is retired — chat-mode parallelism is handled by
+    session-spawn (#2131) instead.
 
     Fallback (= phase-side dispatch / test sites): build a transient
     RunSkillIROp + minimal OpContext and call op_runtime.run_skill.handle
@@ -133,11 +130,9 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     rs = ctx.router_state
 
     # Router path — delegate via the populated callable (chain_id bound)
-    if rs is not None and (
-        rs.spawn_skill_fn is not None or rs.run_skill_fn is not None
-    ):
+    if rs is not None and rs.run_skill_fn is not None:
         # Defense Layer B: validate skill name against available_skills
-        # so hallucinated names raise before spawning. Mirrors the
+        # so hallucinated names raise before the skill runs. Mirrors the
         # explicit check in the legacy RouterLoop branch (now removed).
         skill_name = args["name"]
         if rs.available_skills:
@@ -147,13 +142,8 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
                     f"skill {skill_name!r} not found; "
                     f"available: {sorted(available)}"
                 )
-        # FP-0012: prefer non-blocking spawn when chat-mode binding is
-        # active. Blocking sub-loops fall through to run_skill_fn (blocking).
-        if rs.spawn_skill_fn is not None:
-            return await rs.spawn_skill_fn(
-                skill=skill_name,
-                input=args["input"],
-            )
+        # #2104 PR1: synchronous inline execution — run_skill_fn blocks
+        # until the skill finishes and returns the result directly.
         return await rs.run_skill_fn(
             skill=skill_name,
             input=args["input"],

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -69,7 +69,7 @@ class RouterCallerState:
     # fresh-context session under the agent (rewind-tracked via session_spawned),
     # applies the per-session capability narrowing (S1a), and submits the task.
     # Bound by RouterLoop with chain_id pre-bound; None when the host doesn't
-    # support session-spawn (= duck-typed, like spawn_skill_fn).
+    # support session-spawn (= duck-typed / hasattr-guarded at caller-state build).
     spawn_session_fn: Callable[..., Awaitable[Any]] | None = None
 
     # Session-scoped chain identity (= for plan tool, delegate
@@ -118,21 +118,10 @@ class RouterCallerState:
     # op_runtime caller="control_ir" would not carry chain_id and PR14
     # pending_chain semantics would break for sub-skill delegations.
     #
-    # FP-0012: blocking call — used by blocking phase sub-loop steps that need the
-    # nested skill's result inline to feed the next step. Chat-mode now
-    # prefers ``spawn_skill_fn`` (below) for non-blocking dispatch.
+    # #2104 PR1 skill-unification: both chat-mode and blocking sub-loop
+    # paths now use run_skill_fn (synchronous inline). The spawn path
+    # (FP-0012 spawn_skill_fn) is retired.
     run_skill_fn: Callable[..., Awaitable[Any]] | None = None
-
-    # FP-0012: non-blocking skill dispatch callback. When set, the
-    # ``invoke_skill`` handler prefers this over ``run_skill_fn`` and
-    # returns the spawn-ack dict (``{status: "spawned", run_id,
-    # chain_id, note}``) immediately. The actual skill task runs in
-    # the background; completion is delivered to the chat router via
-    # the ``"skill_completed"`` inbox kind which injects a user-role
-    # message into the existing conversation thread for narration.
-    # Blocking phase sub-loop RouterLoops bind this to None so their
-    # steps keep blocking semantics via ``run_skill_fn``.
-    spawn_skill_fn: Callable[..., Awaitable[Any]] | None = None
 
     # RouterLoopHost reference for handlers that need duck-typed access
     # to host methods not covered by individual callable fields (=

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1448,7 +1448,7 @@ async def _handle_invoke_action(
       3. Invoke target.handler(transformed_args, ctx).
 
     The ToolContext is forwarded verbatim so router_state callbacks
-    (= run_skill_fn / spawn_skill_fn / send_to_agent / op_context_factory
+    (= run_skill_fn / send_to_agent / op_context_factory
     / list_memory_fn / etc.) reach the target handler as if the caller
     had invoked it directly. This is what makes invoke_action a
     transparent wrapper rather than a separate execution path.

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -49,17 +49,6 @@ async def null_run_skill(spec, *, chain_id) -> dict:
     return {"status": "finished", "data": {}}
 
 
-async def null_spawn_skill(spec, *, chain_id) -> dict:
-    """FP-0012: spawn-ack stub for adapter tests."""
-    return {
-        "status": "spawned",
-        "run_id": "test-run-id",
-        "chain_id": chain_id,
-        "skill": spec.get("skill", ""),
-        "note": "test stub",
-    }
-
-
 async def null_send_to_agent(*, to, request, depth, chain_id) -> None:
     pass
 
@@ -131,7 +120,6 @@ def make_adapter(
         mcp_list_tools=null_mcp_list_tools,
         mcp_call_tool=null_mcp_call_tool,
         run_skill_awaitable=null_run_skill,
-        spawn_skill=null_spawn_skill,
         send_to_agent=null_send_to_agent,
         put_outbox=null_put_outbox,
         append_history=null_append_history,

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -76,7 +76,6 @@ def _make_adapter(
         mcp_list_tools=_noop_callable,
         mcp_call_tool=_noop_callable,
         run_skill_awaitable=_noop_callable,
-        spawn_skill=_noop_callable,
         send_to_agent=_noop_callable,
         put_outbox=_noop_callable,
         append_history=_noop_callable,

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -47,7 +47,7 @@ def _mk_host_with_kwargs():
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop, file_list_directory=_noop,
         file_regenerate_index=_noop, mcp_list_servers=_noop, mcp_list_tools=_noop,
-        mcp_call_tool=_noop, run_skill_awaitable=_noop, spawn_skill=_noop, send_to_agent=_noop,
+        mcp_call_tool=_noop, run_skill_awaitable=_noop, send_to_agent=_noop,
         put_outbox=_noop, append_history=_noop,
         delegation_tracker=lambda: [], agent_replies_tracker=lambda: [],
         turn_budget_engine=None, environment_backend=None,

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -64,10 +64,6 @@ async def _null_run_skill(spec, *, chain_id) -> dict:
     return {"status": "finished", "data": {}}
 
 
-async def _null_spawn_skill(spec, *, chain_id) -> dict:
-    return {"status": "spawned", "run_id": "x", "chain_id": chain_id, "skill": "", "note": ""}
-
-
 async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
     pass
 
@@ -148,7 +144,6 @@ def _make_adapter(
         mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -58,10 +58,6 @@ async def _null_run_skill(spec, *, chain_id) -> dict:
     return {"status": "finished", "data": {}}
 
 
-async def _null_spawn_skill(spec, *, chain_id) -> dict:
-    return {"status": "spawned", "run_id": "x", "chain_id": chain_id, "skill": "", "note": ""}
-
-
 async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
     pass
 
@@ -122,7 +118,6 @@ def _make_adapter_with_mcp(
         mcp_list_tools=mcp_list_tools_cb,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -64,16 +64,6 @@ async def _null_run_skill(spec, *, chain_id) -> dict:
     return {"status": "finished", "data": {}}
 
 
-async def _null_spawn_skill(spec, *, chain_id) -> dict:
-    return {
-        "status": "spawned",
-        "run_id": "x",
-        "chain_id": chain_id,
-        "skill": "",
-        "note": "",
-    }
-
-
 async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
     pass
 
@@ -164,7 +154,6 @@ def _make_adapter(
         mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -591,7 +580,6 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -51,7 +51,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_list_directory=_noop, file_regenerate_index=_noop,
         mcp_list_servers=_noop, mcp_list_tools=_noop, mcp_call_tool=_noop,
-        run_skill_awaitable=_noop, spawn_skill=_noop, send_to_agent=_noop,
+        run_skill_awaitable=_noop, send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),
         append_history=lambda msg: history.append(msg),
         delegation_tracker=lambda: [],

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -80,9 +80,6 @@ from tests._support.router_host_adapter import (
 from tests._support.router_host_adapter import (
     null_send_to_agent as _null_send_to_agent,
 )
-from tests._support.router_host_adapter import (
-    null_spawn_skill as _null_spawn_skill,
-)
 
 # ---------------------------------------------------------------------------
 # Test 1: Protocol conformance (runtime_checkable isinstance)
@@ -198,7 +195,6 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=fake_send,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -275,7 +271,6 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -339,7 +334,6 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -402,7 +396,6 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         run_skill_awaitable=_null_run_skill,
-        spawn_skill=_null_spawn_skill,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -164,69 +164,46 @@ def test_user_message_chitchat_appended_to_history(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Test 2: invoke_skill e2e
+# Test 2: invoke_skill e2e (synchronous — #2104 PR1 skill-unification)
 # ---------------------------------------------------------------------------
 
 def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
-    """Tier 1: Session→RouterLoop invoke_skill — round 1 spawns skill (FP-0012 non-blocking) and the router exits on spawn-ack. AsyncMock required for the e2e path.
+    """Tier 1: Session→RouterLoop invoke_skill — synchronous inline result (#2104 PR1).
 
-    Post-H3-ablation contract (= dogfood B32 §4.2 + H3 ablation diagnosis):
-    invoke_skill / invoke_action returning the spawn-ack
-    ``{status: "spawned", run_id, chain_id, note}`` causes the router
-    loop to exit immediately rather than continuing for a second LLM
-    round. The previous behaviour — accumulating the spawn-ack into
-    messages and asking the LLM to compose an acknowledgment — was the
-    race condition observed in B32 W3 S1 (= `(answered)` workaround in
-    llm.py:821 caused the LLM to hallucinate a generic reply before the
-    skill output was available).
+    Contract (#2104 skill-unification): chat-mode invoke_skill now returns
+    the synchronous result ``{status: "finished"|"error", data: ...}``
+    inline, NOT the spawn-ack ``{status: "spawned", ...}``.  The router LLM
+    receives the real skill output as the tool_result and narrates from it
+    directly in the same turn.
 
-    The skill_completed inbox path (= ``_handle_skill_completed``
-    re-engaging the router with the real skill output) is the
-    sanctioned reply path post-H3. That path is exercised by
-    ``test_skill_completed_inbox_enqueued_on_finish`` in
-    test_session_invariants.py.
+    Falsifiable: the key behavioral change is that run_skill_awaitable is
+    called (NOT spawn_skill), and the tool_result visible to round 2 is
+    the synchronous {status: "finished"} dict.
 
-    2026-05-17 N3 update: prior to this revision the spawn-ack turn
-    produced NO agent message at all — the user saw silence between
-    request and the eventual ``[task_completed]``. The OS now emits a
-    deterministic synthetic acknowledgment via ``put_outbox(kind="agent")``
-    before the early-exit. This restores the user-visible feedback
-    without re-introducing the B32 race condition: the message is
-    OS-composed (= not LLM-composed), so it cannot fabricate skill
-    output that hasn't happened yet. See ``_SPAWN_ACK_MSG`` in
-    ``router_loop.py`` for the i18n template.
-
-    Script: round 1 invoke_action returning a spawn-ack; no round 2
-    needed (= router exits on spawn-ack via the H3 check). Mock
-    chat-mode dispatch via ``host.spawn_skill``.
-
-    Assertions: spawn fired; ``invoke_skill_spawn_ack_exit`` event
-    emitted; outbox carries exactly one deterministic OS-composed
-    agent message hinting at ``/tasks``.
+    Script: round 1 LLM calls invoke_action(skill__some_skill); fake
+    run_skill_awaitable returns a finished result; round 2 LLM produces a
+    text reply. Assert: run_skill_awaitable was called; the router completes
+    round 2; result is not a spawn-ack.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    spawn_called = {"called": False}
+    run_skill_called = {"called": False}
+    run_skill_result = {"status": "finished", "data": {"answer": "42"}}
+
+    async def fake_run_skill_awaitable(*, skill, input, chain_id):
+        run_skill_called["called"] = True
+        return run_skill_result
 
     rounds = [
         _tool_result([{"name": "invoke_action", "args": {
             "action_name": "skill__some_skill",
             "args": {"input": {"type": "test", "data": {}}},
         }}]),
-        # No round 2: H3 patch exits the loop on spawn-ack.
+        # Round 2: LLM narrates the synchronous skill result.
+        _text_result("The skill finished with answer 42."),
     ]
-
-    async def fake_adapter_spawn_skill(*, skill, input, chain_id):
-        spawn_called["called"] = True
-        return {
-            "status": "spawned",
-            "run_id": "20260510T000000Z_some_skill_aaaa",
-            "chain_id": chain_id,
-            "skill": skill,
-            "note": "Running in the background. I will notify you when it completes. Use /tasks to check progress.",
-        }
 
     call_count = {"n": 0}
 
@@ -236,7 +213,9 @@ def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
         return result
 
     monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm)
-    monkeypatch.setattr(session.router_host, "spawn_skill", fake_adapter_spawn_skill)
+    monkeypatch.setattr(
+        session.router_host, "run_skill_awaitable", fake_run_skill_awaitable,
+    )
     monkeypatch.setattr(
         session.router_host,
         "list_available_skills",
@@ -248,30 +227,19 @@ def test_user_message_invoke_skill_e2e(tmp_path, monkeypatch):
 
     _run(run())
 
-    assert spawn_called["called"], "Skill should have been spawned"
-    # Post-N3 contract: spawn-ack turn emits exactly ONE deterministic
-    # OS-composed agent message hinting at /tasks. The full
-    # narration of the skill output still comes later via the
-    # skill_completed inbox → _handle_skill_completed path; this
-    # message is just the user-visible "your request started" signal.
+    assert run_skill_called["called"], (
+        "#2104: run_skill_awaitable must have been called for synchronous dispatch"
+    )
+    # Synchronous path: the router LLM runs round 2 and produces an agent message.
     msgs = _drain_outbox(session)
     agent_msgs = [m for m in msgs if m.kind == "agent"]
-    (ack,) = agent_msgs
-    assert "/tasks" in ack.text, (
-        f"Spawn-ack message must mention /tasks (the user's only "
-        f"in-flight tracking surface). Got: {ack.text!r}"
-    )
-    assert ack.meta.get("source") == "spawn_ack", (
-        f"Spawn-ack message must carry meta.source='spawn_ack' so "
-        f"downstream consumers can distinguish it from LLM-composed "
-        f"replies. Got meta={ack.meta!r}"
-    )
-    # H3 audit event: the spawn-ack exit must have fired exactly once.
-    emitted = [
-        e for e in session._chat_events.all()
-        if e.type == "invoke_skill_spawn_ack_exit"
-    ]
-    (only_event,) = emitted
+    assert agent_msgs, "Router must emit at least one agent message after synchronous skill result"
+    # The result must NOT be a spawn-ack (= the key behavioral change).
+    for msg in agent_msgs:
+        assert msg.meta.get("source") != "spawn_ack", (
+            "#2104: synchronous path must not emit spawn_ack messages; "
+            f"got meta={msg.meta!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -1196,11 +1196,11 @@ async def test_run_skill_awaitable_returns_status_data_no_outbox(
 ):
     """Tier 2: _run_skill_awaitable (= plan-mode blocking path) returns {status, data} and does NOT push to outbox.
 
-    FP-0011 invariant (replaces B4-H1) + FP-0012 scope clarification:
-    _run_skill_awaitable is preserved as the plan-mode blocking call
-    site (sequential step execution needs the result inline). Chat-mode
-    invoke_skill now uses ``_spawn_skill_for_router`` instead — see
-    ``test_spawn_skill_for_router_returns_spawn_ack`` for that contract.
+    FP-0011 invariant (replaces B4-H1): _run_skill_awaitable is the
+    synchronous blocking call site used by both plan-mode step execution
+    and chat-mode invoke_skill (#2104 PR1 skill-unification).
+    The result is returned inline to the caller; the router LLM sees it
+    as the tool_result and narrates from there.
 
     The blocking awaitable's only side effect on success is the
     skill_run_completed event + accumulate; MUST NOT push to outbox /
@@ -1265,90 +1265,22 @@ async def test_run_skill_awaitable_returns_status_data_no_outbox(
     )
 
 
-@pytest.mark.asyncio
-async def test_spawn_skill_for_router_returns_spawn_ack(
-    tmp_path, monkeypatch
-):
-    """Tier 2: FP-0012 — chat-mode router-side invoke_skill returns spawn ack.
-
-    Contract: ``_spawn_skill_for_router`` returns the
-    ``{status: "spawned", run_id, chain_id, skill, note}`` ack
-    immediately (= no blocking on the actual skill task). The skill task
-    is queued via ``running_skills``; completion arrives via the
-    ``skill_completed`` inbox kind, NOT inline.
-
-    Observation: read the return value (= what the LLM sees as
-    tool_result) and ``running_skills`` (= the actual asyncio task
-    bookkeeping). We don't await the skill — the test just verifies the
-    spawn handshake.
-    """
-    monkeypatch.chdir(tmp_path)
-
-    import reyn.runtime.session as session_mod
-
-    dummy_skill_dir = tmp_path / "dummy_skill"
-    dummy_skill_dir.mkdir()
-
-    def _fake_resolve(skill_name):
-        return dummy_skill_dir, tmp_path
-
-    def _fake_load_dsl_skill(path, *, skill_root):
-        return object()
-
-    monkeypatch.setattr(session_mod, "resolve_skill_path", _fake_resolve)
-    monkeypatch.setattr(session_mod, "load_dsl_skill", _fake_load_dsl_skill)
-
-    session = _make_session(tmp_path)
-    session.is_attached = True
-
-    # Fake _build_agent so the spawned task does not actually run a real
-    # skill (= keeps the test lightweight; we cancel the task at the end).
-    class _NeverEndAgent:
-        async def run(self, *_a, **_kw):
-            await asyncio.sleep(60)  # never reached — task is cancelled below
-
-    session._build_agent = lambda **kw: _NeverEndAgent()
-
-    spec = {"skill": "direct_llm", "input": {"type": "llm_request", "data": {}}}
-    ret = await session._spawn_skill_for_router(spec, chain_id="chain-fp0012-001")
-
-    # Spawn-ack contract.
-    assert ret["status"] == "spawned", f"unexpected status: {ret!r}"
-    assert ret["chain_id"] == "chain-fp0012-001"
-    assert ret["skill"] == "direct_llm"
-    assert "run_id" in ret and ret["run_id"]
-    assert "note" in ret and "/tasks" in ret["note"]
-
-    # The asyncio task must be tracked in running_skills under the
-    # returned run_id so /tasks list / /skill discard can reach it.
-    run_id = ret["run_id"]
-    assert run_id in session.running_skills, (
-        f"FP-0012: spawn must register run_id in running_skills; "
-        f"got keys: {list(session.running_skills.keys())}"
-    )
-
-    # Cleanup: cancel the long-sleep task.
-    task = session.running_skills[run_id]
-    task.cancel()
-    try:
-        await task
-    except (asyncio.CancelledError, Exception):  # noqa: BLE001
-        pass
+# ---------------------------------------------------------------------------
+# #2104 PR1: synchronous inline invoke_skill result contract
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_skill_completed_inbox_enqueued_on_finish(tmp_path, monkeypatch):
-    """Tier 2: FP-0012 — _run_one_skill enqueues skill_completed inbox on finish.
+async def test_invoke_skill_returns_synchronous_result(tmp_path, monkeypatch):
+    """Tier 2: #2104 PR1 — chat-mode invoke_skill returns synchronous result, NOT spawn-ack.
 
-    Contract: when a background-spawned skill finishes (terminal status),
-    the ``skill_completed`` inbox kind is appended with the structured
-    payload ``{run_id, skill, chain_id, status, data}`` so the chat
-    ``run()`` loop can drive narration on its next iteration.
+    Contract: run_skill_awaitable is the single invoke path for chat-mode
+    skills. The handler returns ``{status: "finished"|"error", data: ...}``
+    inline — not the spawn-ack ``{status: "spawned", ...}`` that FP-0012
+    produced.
 
-    Observation: read ``session.inbox`` (= public asyncio.Queue) directly
-    after _run_one_skill returns — the message must be present with the
-    expected shape. WAL append is exercised transparently by
-    SnapshotJournal.append_inbox.
+    Falsifiable: assert status != "spawned". If the spawn path were still
+    active, the returned dict would have status=="spawned".
     """
     monkeypatch.chdir(tmp_path)
 
@@ -1358,8 +1290,8 @@ async def test_skill_completed_inbox_enqueued_on_finish(tmp_path, monkeypatch):
     dummy_skill_dir = tmp_path / "dummy_skill"
     dummy_skill_dir.mkdir()
 
-    # FP-0019 Wave 1b: _run_one_skill now lives in SkillRunner, so patch
-    # resolve_skill_path / load_dsl_skill in the skill_runner module.
+    # Patch in the skill_runner module (that is where run_skill_awaitable
+    # calls resolve_skill_path / load_dsl_skill at import time).
     monkeypatch.setattr(
         skill_runner_mod, "resolve_skill_path",
         lambda name: (dummy_skill_dir, tmp_path),
@@ -1372,35 +1304,85 @@ async def test_skill_completed_inbox_enqueued_on_finish(tmp_path, monkeypatch):
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    fake_result = RunResult(
-        data={"path": "reyn/project/foo/skill.md"},
-        status="finished",
-    )
-    # Patch build_agent_fn on SkillRunner (FP-0019 Wave 1b).
+    expected_data = {"result": "skill_done"}
+    fake_result = RunResult(data=expected_data, status="finished")
     session._skill_runner._build_agent_fn = lambda run_id, skill_name, **kw: _FakeAgent(fake_result)
 
-    run_id = "20260510T100000Z_direct_llm_aaaa"
-    session.running_skills_started_at[run_id] = 0.0
-    session.running_skills_chain[run_id] = "chain-fp0012-002"
-
-    # Drain any prior messages so the assertion below sees only what we enqueue.
-    while not session.inbox.empty():
-        session.inbox.get_nowait()
-
-    await session._skill_runner._run_one_skill(
-        run_id, "direct_llm",
-        {"type": "llm_request", "data": {}},
-        chain_id="chain-fp0012-002",
+    spec = {"skill": "some_skill", "input": {"type": "t", "data": {}}}
+    ret = await session._skill_runner.run_skill_awaitable(
+        spec, chain_id="chain-2104-001",
     )
 
-    # The inbox must contain exactly one skill_completed message.
-    kind, payload = await asyncio.wait_for(session.inbox.get(), timeout=1.0)
-    assert kind == "skill_completed", f"expected skill_completed, got {kind!r}"
-    assert payload["run_id"] == run_id
-    assert payload["skill"] == "direct_llm"
-    assert payload["status"] == "finished"
-    assert payload["chain_id"] == "chain-fp0012-002"
-    assert payload["data"] == {"path": "reyn/project/foo/skill.md"}
+    # Contract 1: result is synchronous (not a spawn-ack).
+    assert ret.get("status") != "spawned", (
+        f"#2104: invoke_skill must not return spawn-ack; got status={ret.get('status')!r}"
+    )
+    assert ret == {"status": "finished", "data": expected_data}, (
+        f"#2104: synchronous result shape mismatch; got {ret!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invoke_skill_cancellation_returns_error_result(tmp_path, monkeypatch):
+    """Tier 2: #2104 PR1 Q3 — cancelling the task while run_skill_awaitable is blocking returns an error result.
+
+    Contract: run_skill_awaitable catches CancelledError and returns
+    ``{status: "error", data: {error: "cancelled"}}`` so the router LLM
+    sees a structured error result (NOT a spawn-ack). The awaitable does NOT
+    re-raise, which keeps the synchronous inline path clean.
+
+    Falsifiable: if the cancel were silently swallowed (returning "finished"),
+    the test assertion on status=="error" would fail.
+
+    Note: Ctrl-C / Ctrl-C live TUI verification (full turn cancellation) is
+    flagged for tui-coder and requires tmux live verify — this test covers
+    the asyncio-level cancellation handling only.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    import reyn.skill.skill_runner as skill_runner_mod
+
+    dummy_skill_dir = tmp_path / "dummy_skill"
+    dummy_skill_dir.mkdir()
+
+    monkeypatch.setattr(
+        skill_runner_mod, "resolve_skill_path",
+        lambda name: (dummy_skill_dir, tmp_path),
+    )
+    monkeypatch.setattr(
+        skill_runner_mod, "load_dsl_skill",
+        lambda path, *, skill_root: object(),
+    )
+
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    # Build an agent that blocks indefinitely — the cancel must interrupt it.
+    class _NeverDoneAgent:
+        async def run(self, *_a, **_kw):
+            await asyncio.sleep(60)
+
+    session._skill_runner._build_agent_fn = lambda run_id, skill_name, **kw: _NeverDoneAgent()
+
+    spec = {"skill": "some_skill", "input": {"type": "t", "data": {}}}
+
+    async def _call():
+        return await session._skill_runner.run_skill_awaitable(
+            spec, chain_id="chain-2104-cancel",
+        )
+
+    task = asyncio.ensure_future(_call())
+    # Give the task a chance to start and enter the blocking await.
+    await asyncio.sleep(0)
+    task.cancel()
+    # run_skill_awaitable catches CancelledError → structured error result (not re-raise)
+    ret = await asyncio.wait_for(task, timeout=2.0)
+    assert ret["status"] == "error", (
+        f"#2104 Q3: run_skill_awaitable must return status==error on cancel; got {ret!r}"
+    )
+    assert "cancelled" in ret["data"].get("error", ""), (
+        f"#2104 Q3: cancel error data must contain 'cancelled'; got {ret!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[lead-coder]** — PR1 = Slice A (core synchronous flip + spawn_skill removal). PR2 follows separately (dead async infra cleanup).

## Summary

- **Retires FP-0012 spawn path**: deletes `spawn_skill` / `spawn_skill_fn` everywhere (RouterHostAdapter method, RouterLoopHost Protocol declaration, RouterCallerState field, session forwarding methods, SkillPlanGlue delegation methods, duck-type binding block in `_build_router_caller_state`).
- **Synchronizes chat-mode invoke_skill**: `invoke_skill._handle` now falls through unconditionally to `run_skill_fn` (= `host.run_skill_awaitable`). The router LLM receives the real skill result inline and narrates directly, with no spawn-ack detour.
- **Tests**: replaced spawn-ack e2e test with synchronous-result variant (falsifiable: asserts `status != "spawned"` and no `spawn_ack` meta); added Tier 2 tests for inline result shape and cancellation handling.

## PR2 scope (explicitly NOT touched — dead but harmless)

`run_skill_fn` never returns `status=="spawned"` so the H3 spawn-ack exit guard is unreachable dead code. These stay for PR2:
- H3 spawn-ack exit block in `router_loop.py` (~line 2388–2486)
- `skill_completed` inbox kind + drain + `_enqueue_skill_completed`
- `running_skills` tracking dict
- `/tasks` skill section
- MCP/A2A drain
- Docs

## Q3 Ctrl-C cancellation

`run_skill_awaitable` catches `CancelledError` and returns `{status: "error", data: {error: "cancelled"}}` — test `test_invoke_skill_cancellation_returns_error_result` covers the asyncio-level path. **Live TUI Ctrl-C verification (full turn cancel propagation) is flagged for tui-coder** — requires tmux live verify.

## Gate results

- `ruff check src tests` ✓
- `python scripts/test_tier_audit.py --strict <changed test files>` ✓ (78 tests, 0 Tier-4 errors)
- `pytest tests/ -k "skill or invoke or router or session"` ✓ (1602 passed, 0 regressions vs main; 1 pre-existing fastapi-missing skip)

## Test plan

- [x] ruff ✓
- [x] tier-audit ✓
- [x] pytest targeted scope ✓
- [x] `test_invoke_skill_returns_synchronous_result` — asserts `status != "spawned"` and exact `{status: "finished", data: ...}` shape
- [x] `test_user_message_invoke_skill_e2e` — asserts `run_skill_awaitable` called, no `spawn_ack` meta
- [x] `test_invoke_skill_cancellation_returns_error_result` — asserts cancel → `{status: "error", data: {error: "cancelled"}}`
- [ ] Live TUI Ctrl-C verify (tui-coder tmux) — flagged, not blocking merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)