### PR TITLE
feat(#2103): A — ephemeral spawned session auto-vanishes after its task

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2006,6 +2006,13 @@ class AgentRegistry:
         Does NOT submit a task — that is the caller (the spawn op), separable from the
         record. Emit no-ops without a WAL."""
         sid = self.spawn_session(name)
+        if mode == "ephemeral":
+            # #2103: mark the live session so it auto-vanishes once its task is done
+            # (Session._maybe_schedule_ephemeral_vanish, via this registry's
+            # remove_session teardown seam). Persistent spawns leave the flag False.
+            ephemeral_session = self._peek_session(name, sid)
+            if ephemeral_session is not None:
+                ephemeral_session._ephemeral = True
         if narrowing:
             import yaml
             cfg_path = self._session_state_dir(name, sid) / "config.yaml"

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -931,6 +931,13 @@ class Session:
         # task (a user / hook / recovery turn). Slice B extends the lifetime to a
         # persistent assignment spanning continuation + recovery turns.
         self._current_task_id: "str | None" = None
+        # #2103: a spawned EPHEMERAL session (spawn-time mode="ephemeral") auto-vanishes
+        # once its task is done. Set post-construction by the registry on an ephemeral
+        # spawn; the main session + persistent spawns leave it False. ``_vanish_scheduled``
+        # guards against a double-schedule across turns.
+        self._ephemeral: bool = False
+        self._vanish_scheduled: bool = False
+        self._vanish_task: "asyncio.Task | None" = None
         # #1827 S4b (context-auto): lazily-resolved minimal _untrusted profile
         # ContextualPermission, composed into the per-turn narrowing while
         # untrusted external content is live in context. None until first needed.
@@ -3510,7 +3517,36 @@ class Session:
                 await self._handle_hook_message(payload)
         finally:
             self._turn_idle.set()
+        self._maybe_schedule_ephemeral_vanish()
         return True
+
+    def _maybe_schedule_ephemeral_vanish(self) -> None:
+        """#2103: an ephemeral spawned session auto-vanishes once its task is done —
+        the turn completed and no further trigger is queued (the inbox is drained, so
+        the run-loop is about to idle-block). Schedules a DETACHED teardown via the
+        registry's ``remove_session`` seam (the SAME teardown the rewind as-of-cut drop
+        uses): it quiesces + closes the per-session Task backend, cancels this idle
+        run-loop, drops the session, emits ``session_vanished``, and purges the dir.
+        Detached (not awaited here) because ``remove_session`` cancels THIS run-loop
+        task — running it inline would cancel the caller. Idempotent (the
+        ``_vanish_scheduled`` guard). The main session + persistent spawns are never
+        ``_ephemeral`` → unaffected.
+
+        Boundary (close-review note): "task done" = the inbox is empty at turn end. A
+        spawned ephemeral session that DELEGATES and awaits an ``agent_response`` would
+        have a transiently-empty inbox between turns; the basic isolated-task spawn
+        (the #2103 S1bc use case) does not. A fuller "no awaited work" predicate
+        (pending chains / live §16 tasks) is a follow-on if the await-then-resume
+        ephemeral pattern is exercised."""
+        if (not self._ephemeral or self._vanish_scheduled
+                or self._registry is None or not self.inbox.empty()):
+            return
+        self._vanish_scheduled = True
+        # Keep a strong ref (self._vanish_task) so the task is not GC'd before it runs
+        # (it self-cancels this run-loop, so it is otherwise unreferenced).
+        self._vanish_task = asyncio.create_task(
+            self._registry.remove_session(self.agent_name, self._session_id)
+        )
 
     def _stamp_execution_context(self, kind: str, payload: dict) -> None:
         """#1953 §16 (recursive-request): set the per-turn execution context read by

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3532,14 +3532,21 @@ class Session:
         ``_vanish_scheduled`` guard). The main session + persistent spawns are never
         ``_ephemeral`` → unaffected.
 
-        Boundary (close-review note): "task done" = the inbox is empty at turn end. A
-        spawned ephemeral session that DELEGATES and awaits an ``agent_response`` would
-        have a transiently-empty inbox between turns; the basic isolated-task spawn
-        (the #2103 S1bc use case) does not. A fuller "no awaited work" predicate
-        (pending chains / live §16 tasks) is a follow-on if the await-then-resume
-        ephemeral pattern is exercised."""
+        "Task done" = the inbox is drained AND there is no AWAITED work whose resume
+        arrives OUTSIDE the now-empty inbox: a pending delegation chain (an
+        ``agent_response`` is still coming — ``self._chains``) or a live task-as-request
+        execution (``self._current_task_id``). Without these guards a spawned ephemeral
+        session that DELEGATES + awaits a response has a transiently-empty inbox
+        mid-await → it would vanish (dir purged + ``session_vanished``) before the
+        response lands = silent + destructive. A spawned session CAN reach delegate +
+        await (it has the full ChainManager + send_to_agent wiring), so the guard is
+        load-bearing, not theoretical."""
         if (not self._ephemeral or self._vanish_scheduled
                 or self._registry is None or not self.inbox.empty()):
+            return
+        # awaited-work guard (delegate-then-await / live §16 task): the resume arrives
+        # outside the now-empty inbox, so emptiness alone is not "done".
+        if self._current_task_id is not None or self._chains.all_chain_ids():
             return
         self._vanish_scheduled = True
         # Keep a strong ref (self._vanish_task) so the task is not GC'd before it runs

--- a/tests/test_2103_A_ephemeral_auto_vanish_1953.py
+++ b/tests/test_2103_A_ephemeral_auto_vanish_1953.py
@@ -79,6 +79,34 @@ async def test_ephemeral_spawn_auto_vanishes_persistent_survives(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_ephemeral_does_not_vanish_while_awaiting_delegation(tmp_path):
+    """Tier 2: #2103 A — the awaited-work guard. A spawned ephemeral session that has
+    DELEGATED and awaits a peer ``agent_response`` (a pending chain) has a
+    transiently-empty inbox mid-await; it must NOT vanish (purging its dir + emitting
+    session_vanished before the response lands = silent + destructive). A spawned
+    session has the full ChainManager + send_to_agent wiring, so this is reachable. RED
+    if the awaited-work guard is dropped (it vanishes mid-await)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    eph = reg._peek_session("alice", sid)
+
+    # the spawned session delegated to a peer + awaits its response (pending chain;
+    # the inbox is transiently empty between the delegate-send and the response).
+    await eph._chains.register(chain_id="c1", from_user=False, depth=1,
+                               original_text="sub", sender="alice", waiting_on={"peer"})
+    eph._maybe_schedule_ephemeral_vanish()
+    # drain any (erroneously) scheduled teardown so the assertion reflects the true
+    # outcome — without this a stripped guard would schedule a DETACHED vanish that
+    # hasn't run yet at the assert, hiding the regression.
+    if eph._vanish_task is not None:
+        await eph._vanish_task
+
+    # the guard held: NOT vanished mid-await (public surface).
+    assert sid in reg.session_ids("alice")
+
+
+@pytest.mark.asyncio
 async def test_ephemeral_vanish_scheduled_once(tmp_path):
     """Tier 2: #2103 A — the schedule is idempotent: a multi-turn ephemeral session
     that hits the post-turn check twice tears down ONCE (no double-teardown error), and

--- a/tests/test_2103_A_ephemeral_auto_vanish_1953.py
+++ b/tests/test_2103_A_ephemeral_auto_vanish_1953.py
@@ -1,0 +1,98 @@
+"""Tier 2: #2103 A — a spawned EPHEMERAL session auto-vanishes once its task is done.
+
+session-spawn records a spawn-time ``mode`` (ephemeral | persistent). This slice wires
+the ephemeral LIFECYCLE: the registry marks an ephemeral spawn, and the session, after a
+turn that leaves the inbox drained (its task done, the run-loop about to idle-block),
+schedules a DETACHED teardown via the registry ``remove_session`` seam (the SAME teardown
+the rewind as-of-cut drop uses) — drops the session, closes its per-session Task backend,
+emits ``session_vanished``, purges the dir. A PERSISTENT spawn survives.
+
+Real AgentRegistry + Session (no mocks; the factory passes ``registry`` exactly as the
+production scoped_session_factory does, via ``**base``). Assertions are on the PUBLIC
+``registry.session_ids`` surface (the observable: vanished vs survived) — not internal
+flags. FALSIFY: drop the registry ephemeral mark OR the
+``_maybe_schedule_ephemeral_vanish`` trigger → the ephemeral session survives → RED.
+
+Live-path note (close-review / tui): the trigger fires from ``run_one_iteration``'s
+turn-end (after the ``finally``). These tests invoke that seam directly (every turn kind
+otherwise needs a live LLM); the full run_one_iteration → vanish path is for tui
+live-verify (the §16 B1 precedent — automated test simulates the post-turn call, tui
+verifies the live run-loop).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """Real AgentRegistry whose factory passes ``registry=reg`` to each Session —
+    mirroring the production scoped_session_factory (so a spawned session has the
+    ``_registry`` ref its auto-vanish needs)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log,
+                    registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_spawn_auto_vanishes_persistent_survives(tmp_path):
+    """Tier 2: #2103 A — once its task is done (inbox drained), an ephemeral spawn
+    auto-vanishes (gone from the public ``session_ids``); a persistent spawn survives.
+    RED if the ephemeral mark or the vanish trigger is dropped (it would survive)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")  # the live main session
+
+    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    per_sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    live = reg.session_ids("alice")
+    assert eph_sid in live and per_sid in live  # both live initially (public surface)
+
+    # task done (inbox drained) → fire the post-turn ephemeral check on both sessions.
+    eph = reg._peek_session("alice", eph_sid)
+    per = reg._peek_session("alice", per_sid)
+    eph._maybe_schedule_ephemeral_vanish()
+    per._maybe_schedule_ephemeral_vanish()
+    # await the ephemeral teardown; the persistent session scheduled nothing.
+    vanish = eph._vanish_task
+    if vanish is not None:
+        await vanish
+
+    live_after = reg.session_ids("alice")
+    assert eph_sid not in live_after   # vanished
+    assert per_sid in live_after        # survived (the ephemeral guard held)
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_vanish_scheduled_once(tmp_path):
+    """Tier 2: #2103 A — the schedule is idempotent: a multi-turn ephemeral session
+    that hits the post-turn check twice tears down ONCE (no double-teardown error), and
+    vanishes. RED if the guard is dropped (a second teardown of an already-dropped
+    session)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    eph = reg._peek_session("alice", sid)
+
+    eph._maybe_schedule_ephemeral_vanish()
+    eph._maybe_schedule_ephemeral_vanish()  # second post-turn check — must not re-schedule
+    vanish = eph._vanish_task
+    if vanish is not None:
+        await vanish
+
+    assert sid not in reg.session_ids("alice")  # vanished exactly once, cleanly


### PR DESCRIPTION
**[e2e-coder]** — #2103 slice **A**: ephemeral spawned session auto-vanishes after its task. Lead-steered (i): A first, then the capability-model design-call. Off origin/main @d826007c.

## What
session-spawn already recorded the spawn-time `mode` (ephemeral | persistent) on the `session_spawned` WAL event; S1bc also staged the **teardown primitive** (`remove_session`, shared with the rewind as-of-cut drop) + the `session_vanished` event. This slice wires the only missing piece — the ephemeral **lifecycle trigger**.

- `registry.spawn_session_recorded` marks the live session `._ephemeral` when `mode=="ephemeral"` (persistent leaves it `False`; main is never ephemeral).
- `Session._maybe_schedule_ephemeral_vanish` (called at `run_one_iteration`'s turn-end, after the `finally`): when `._ephemeral` and the inbox is drained (task done, run-loop about to idle-block), schedules a **detached** `remove_session` — quiesce + close per-session Task backend + drop + emit `session_vanished` + purge dir. Detached because `remove_session` cancels *this* run-loop task; `_vanish_scheduled` makes it once-only; a strong ref (`_vanish_task`) prevents GC.

## Verification
- **Real registry + Session** (the factory passes `registry` exactly as the production `scoped_session_factory` does via `**base` — so a spawned session has the `_registry` ref the vanish needs; verified that wiring). Assertions on the **public `session_ids`** surface (observable: vanished vs survived), not internal flags.
- ephemeral spawn auto-vanishes / persistent survives; schedule idempotent. **Verified RED-when-stripped** (drop the mark → ephemeral survives).
- Gates: broad registry/session/spawn/rewind sweep (845 passed); ruff full-tree clean; `scripts/test_tier_audit.py --strict` 0 errors.

## Boundary (close-review note)
"task done" = inbox empty at turn end. The basic isolated-task spawn (the S1bc use case) drains cleanly; a *delegate-then-await-response* ephemeral pattern (transiently-empty inbox between turns) wants a fuller "no awaited work" predicate — a follow-on if that pattern is exercised. Also the rare ephemeral+hook-cap-suppressed turn early-returns before the check (edge).

## L3 / live-path note
The `run_one_iteration` → vanish **call-site** (one line after the turn's `finally`) isn't cheaply unit-testable (every turn kind needs a live LLM), so the tests invoke that seam directly and the full run-loop → vanish path is for **tui live-verify** — the §16 B1 precedent (automated test simulates the post-turn call; tui verifies the live run-loop). Flagging proactively.

## Test plan
- [x] `pytest` slice-A test (2 passed) + broad sweep (845 passed)
- [x] Falsification verified (strip the mark → RED)
- [x] `ruff` clean + tier-audit 0 errors
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify: spawn ephemeral → it runs its task → auto-vanishes (session_vanished); spawn persistent → survives

Next: the capability-model design-call (B/C foundation; flow-trace-first). Design-gated: patch → close-review → tui live-verify → merge. **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
