### PR TITLE
feat(#2103 Piece-2): topology-lifecycle rewind durability — WAL emit seams + as-of-cut reconstruction

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -86,6 +86,14 @@ WAL_EVENT_KINDS = (
     # vanished`` records the ephemeral auto-vanish / explicit teardown. OS-level (P7).
     "session_spawned",
     "session_vanished",
+    # NEW (#2103 Piece-2) — topology-lifecycle events for rewind-reconstruction of
+    # the topology config-set (create / update / remove). OS-level (topology is an
+    # OS concept), P7-safe; apply_events no-ops them (config-set existence/shape,
+    # not agent-snapshot STATE). Each create/update carries the FULL topology config
+    # → as-of-cut reconstruction is latest-≤-cut-wins (no delta-fold).
+    "topology_created",
+    "topology_updated",
+    "topology_removed",
 )
 
 

--- a/src/reyn/interfaces/cli/commands/topology.py
+++ b/src/reyn/interfaces/cli/commands/topology.py
@@ -8,6 +8,7 @@ AgentRegistry consults them when routing delegations.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from pathlib import Path
 
@@ -113,7 +114,7 @@ def _cmd_new(args: argparse.Namespace) -> None:
         topo = Topology.new(
             args.name, kind=args.kind, members=members, leader=args.leader,
         )
-        reg.add_topology(topo)
+        asyncio.run(reg.create_topology(topo))  # #2103: logged seam (WAL-tracked)
     except (ValueError, FileExistsError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -166,7 +167,7 @@ def _cmd_rm(args: argparse.Namespace) -> None:
             print("aborted")
             return
     try:
-        reg.remove_topology(args.name)
+        asyncio.run(reg.delete_topology(args.name))  # #2103: logged seam
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -176,7 +177,7 @@ def _cmd_rm(args: argparse.Namespace) -> None:
 def _cmd_add_member(args: argparse.Namespace) -> None:
     reg = _registry()
     try:
-        topo = reg.add_member(args.topology, args.agent)
+        topo = asyncio.run(reg.add_topology_member(args.topology, args.agent))  # #2103
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -186,7 +187,7 @@ def _cmd_add_member(args: argparse.Namespace) -> None:
 def _cmd_rm_member(args: argparse.Namespace) -> None:
     reg = _registry()
     try:
-        topo = reg.remove_member(args.topology, args.agent)
+        topo = asyncio.run(reg.remove_topology_member(args.topology, args.agent))  # #2103
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/reyn/interfaces/web/routers/topologies.py
+++ b/src/reyn/interfaces/web/routers/topologies.py
@@ -82,7 +82,7 @@ async def create_topology(
             members=body.members,
             leader=body.leader,
         )
-        registry.add_topology(topo)
+        await registry.create_topology(topo)  # #2103: logged seam (WAL-tracked)
     except FileExistsError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -113,7 +113,7 @@ async def get_topology(name: str, registry=Depends(get_registry)) -> TopologySum
 async def delete_topology(name: str, registry=Depends(get_registry)) -> None:
     """Remove a user-declared topology."""
     try:
-        registry.remove_topology(name)
+        await registry.delete_topology(name)  # #2103: logged seam (WAL-tracked)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -138,7 +138,7 @@ async def add_member(
 ) -> TopologySummary:
     """Add an agent to an existing topology."""
     try:
-        topo = registry.add_member(name, agent)
+        topo = await registry.add_topology_member(name, agent)  # #2103: logged seam
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except ValueError as exc:
@@ -160,7 +160,7 @@ async def remove_member(
 ) -> TopologySummary:
     """Remove an agent from a topology."""
     try:
-        topo = registry.remove_member(name, agent)
+        topo = await registry.remove_topology_member(name, agent)  # #2103: logged seam
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
     except ValueError as exc:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -448,7 +448,7 @@ class AgentRegistry:
             )
         return profile
 
-    def remove(self, name: str, *, purge: bool = False) -> None:
+    def remove(self, name: str, *, purge: bool = False) -> "list[tuple[str, Topology | None]]":
         """Delete an agent. Default (#1954 Option A) = ARCHIVE (soft-delete): the
         runtime PITR generations are kept in place so rewind-to-before-delete
         works within the retention window, plus a tombstone recording the archival
@@ -480,8 +480,9 @@ class AgentRegistry:
             shutil.rmtree(target)
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
-            # emptied topology is removed entirely).
-            self._cascade_agent_removal(name)
+            # emptied topology is removed entirely). #2103 MUST-1: return the
+            # cascade's topology changes so the async caller emits them logged.
+            return self._cascade_agent_removal(name)
         else:
             # #1954 Option A: archive-default. Keep generations in place (rewind
             # works) + tombstone with the archival WAL seq. Hidden from active
@@ -494,6 +495,7 @@ class AgentRegistry:
             # window (slice 2).
             seq = self._state_log.current_seq if self._state_log is not None else 0
             (target / ARCHIVED_MARKER).write_text(str(seq), encoding="utf-8")
+        return []  # archive does not cascade — topology membership preserved (#1954)
 
     async def archive_agent(self, name: str, *, purge: bool = False) -> None:
         """#2103 S2b: the action-layer DELETE seam — archive (or purge) the agent
@@ -501,12 +503,19 @@ class AgentRegistry:
         ``agent_purged``) so rewind reconstructs the as-of-cut archived-state and
         honors the permanent purge (fork A). The ONE delete seam the action-layer
         callers (CLI / web + the spawn op) route through. Emit no-ops without a WAL."""
-        self.remove(name, purge=purge)
+        cascade_changes = self.remove(name, purge=purge)
         if self._state_log is not None:
             await self._state_log.append(
                 "agent_purged" if purge else "agent_archived",
                 entity_kind="agent", name=name,
             )
+            # #2103 MUST-1: emit the purge cascade's topology changes through the
+            # logged seam so rewind reconstructs the topology config-set consistently.
+            for tname, topo in cascade_changes:
+                await self._emit_topology(
+                    "topology_removed" if topo is None else "topology_updated",
+                    tname, topo,
+                )
 
     def recent_user_message(self, name: str) -> str:
         """Return the most recent user-role text from the agent's history, or "".
@@ -1238,6 +1247,62 @@ class AgentRegistry:
             elif marker.is_file():
                 marker.unlink()
 
+    def _topology_lifecycle(
+        self,
+    ) -> "dict[str, list[tuple[int, str, dict | None]]]":
+        """#2103 Piece-2: one WAL scan → per WAL-TRACKED topology name, its ordered
+        lifecycle events ``(seq, kind, payload)`` from ``topology_created`` /
+        ``topology_updated`` / ``topology_removed`` (payload = FULL config; None for a
+        removal). Sourced from the WAL only — never the rotated #P6 audit log.
+        MUST-2: only names that appear here are WAL-tracked, so only these are touched
+        by reconstruction — pre-WAL/untracked topologies are invisible to this map and
+        left alone. Empty without a WAL."""
+        events: dict[str, list[tuple[int, str, dict | None]]] = {}
+        if self._state_log is None:
+            return events
+        for entry in self._state_log.iter_from(0):
+            kind = entry.get("kind")
+            if kind not in ("topology_created", "topology_updated", "topology_removed"):
+                continue
+            name = entry.get("name")
+            seq = entry.get("seq")
+            if not isinstance(name, str) or not isinstance(seq, int):
+                continue
+            payload = entry.get("topology") if kind != "topology_removed" else None
+            events.setdefault(name, []).append((seq, kind, payload))
+        return events
+
+    def _reconcile_topologies_as_of_cut(self, cut: int) -> None:
+        """#2103 Piece-2: reconstruct the topology config-set as-of-cut from the
+        lifecycle WAL (WAL-sourced only — never the rotated audit log). Per WAL-tracked
+        topology name, the LATEST event with seq ≤ cut decides: created/updated → exists
+        with that FULL config; removed (or no event ≤ cut, i.e. created-after-cut) →
+        gone. Reconcile both the on-disk YAML and the in-memory ``_topologies`` map.
+        MUST-2: ONLY WAL-tracked names are touched — untracked/pre-WAL topologies are
+        never created, mutated, or deleted here. Inert without lifecycle events."""
+        for name, evs in self._topology_lifecycle().items():
+            latest = max(
+                (e for e in evs if e[0] <= cut), key=lambda e: e[0], default=None,
+            )
+            path = self._topology_dir / f"{name}.yaml"
+            if latest is None or latest[1] == "topology_removed":
+                # Didn't exist as-of-cut (created-after-cut OR removed-≤-cut) → drop.
+                self._topologies.pop(name, None)
+                if path.is_file():
+                    path.unlink()
+            else:
+                payload = latest[2] or {}
+                topo = Topology(
+                    name=payload.get("name", name),
+                    kind=payload.get("kind", "network"),
+                    members=tuple(payload.get("members") or ()),
+                    leader=payload.get("leader"),
+                    created_at=payload.get("created_at", ""),
+                    profiles=dict(payload.get("profiles") or {}),
+                )
+                topo.save(path)
+                self._topologies[name] = topo
+
     async def _drop_session(self, name: str, sid: str, *, purge_dir: bool = True) -> None:
         """#2103 S1bc: tear down a single spawned session created after the rewind cut
         (the primitive's seam, now wired). Delegates to ``remove_session`` — the single
@@ -1443,6 +1508,7 @@ class AgentRegistry:
         # #2103 S2: rewrite present agents' .archived tombstones to the as-of-cut
         # archived-state (rewind-before-archive → active; rewind-after → archived).
         self._reconcile_archived_as_of_cut(ag_archived, drop_cut)
+        self._reconcile_topologies_as_of_cut(drop_cut)
         await self._restore_workspace_active(at_or_below=workspace_at_or_below)
         await self._restore_task_active(at_or_below=workspace_at_or_below)
         # #2125 (b)-split: the restores succeeded — NOW perform the deferred destructive
@@ -1639,9 +1705,9 @@ class AgentRegistry:
         # #1954 slice 2: WAL-window-bounded auto-purge of archived agents — run
         # OUTSIDE the generation-GC try so a workspace-git hiccup above never
         # blocks reclaiming archived state.
-        self._purge_archived_below(floor)
+        await self._purge_archived_below(floor)
 
-    def _purge_archived_below(self, floor: int) -> None:
+    async def _purge_archived_below(self, floor: int) -> None:
         """#1954 slice 2: hard-delete archived agents whose archival seq fell
         below the retention ``floor`` — the soft-delete left the WAL window, so
         rewind-to-before-delete is no longer possible → hard-delete is safe
@@ -1655,7 +1721,13 @@ class AgentRegistry:
                 shutil.rmtree(self._dir / name, ignore_errors=True)
                 # Now a permanent hard-delete → drop the (previously preserved)
                 # topology membership so no dangling reference is left behind.
-                self._cascade_agent_removal(name)
+                # #2103 MUST-1: emit the cascade's topology changes through the
+                # logged seam (async GC path → await the emits).
+                for tname, topo in self._cascade_agent_removal(name):
+                    await self._emit_topology(
+                        "topology_removed" if topo is None else "topology_updated",
+                        tname, topo,
+                    )
             except Exception as e:  # noqa: BLE001 — best-effort; never fail caller
                 logger.warning("#1954 archived auto-purge failed for %r: %s", name, e)
 
@@ -2538,23 +2610,87 @@ class AgentRegistry:
         self._topologies[topology_name] = new_topo
         return new_topo
 
-    def _cascade_agent_removal(self, agent: str) -> None:
+    # ── #2103 Piece-2: topology-lifecycle EMIT seams (rewind durability) ──────
+    # The create-side mirror of the agent-lifecycle seams (#2118). The sync
+    # add_topology/add_member/remove_member/remove_topology above are the MECHANISM
+    # (private internals); EVERY state-affecting topology mutation routes through a
+    # logged seam below so rewind reconstructs the topology config-set as-of-cut.
+    # MUST-1 invariant: a topology is fully-tracked or fully-untracked — a sync
+    # mutation on a tracked topology would diverge on reconstruction.
+
+    @staticmethod
+    def _topology_payload(topo: Topology) -> dict:
+        """#2103: serialise a Topology into a topology_created/updated WAL payload
+        (the FULL config → as-of-cut reconstruction is latest-≤-cut-wins)."""
+        return {
+            "name": topo.name,
+            "kind": topo.kind,
+            "members": list(topo.members),
+            "leader": topo.leader,
+            "created_at": topo.created_at,
+            "profiles": dict(topo.profiles),
+        }
+
+    async def _emit_topology(
+        self, kind: str, name: str, topo: "Topology | None",
+    ) -> None:
+        """#2103: emit a topology-lifecycle WAL event — the ONE logged path every
+        state-affecting topology mutator routes through. No-op without a WAL."""
+        if self._state_log is None:
+            return
+        fields: dict = {"name": name}
+        if topo is not None:
+            fields["topology"] = self._topology_payload(topo)
+        await self._state_log.append(kind, **fields)
+
+    async def create_topology(self, topo: Topology) -> None:
+        """#2103 logged CREATE seam: add_topology (sync) + emit topology_created.
+        Every creation surface (LLM tool / web / CLI) routes through this."""
+        self.add_topology(topo)
+        await self._emit_topology("topology_created", topo.name, topo)
+
+    async def add_topology_member(self, topology_name: str, agent: str) -> Topology:
+        """#2103 logged UPDATE seam: add_member (sync) + emit topology_updated."""
+        topo = self.add_member(topology_name, agent)
+        await self._emit_topology("topology_updated", topo.name, topo)
+        return topo
+
+    async def remove_topology_member(self, topology_name: str, agent: str) -> Topology:
+        """#2103 logged UPDATE seam: remove_member (sync) + emit topology_updated."""
+        topo = self.remove_member(topology_name, agent)
+        await self._emit_topology("topology_updated", topo.name, topo)
+        return topo
+
+    async def delete_topology(self, name: str) -> None:
+        """#2103 logged DELETE seam: remove_topology (sync) + emit topology_removed."""
+        self.remove_topology(name)
+        await self._emit_topology("topology_removed", name, None)
+
+    def _cascade_agent_removal(self, agent: str) -> "list[tuple[str, Topology | None]]":
         """Drop `agent` from every topology it's a member of.
 
         Team topologies losing their leader are removed entirely (a leader-less
         team is meaningless). Pipelines and networks shrink in place. Empty
         topologies are removed.
+
+        #2103 MUST-1: returns the topology mutations so the (async) caller emits
+        them through the logged path — else a tracked topology cascaded
+        synchronously would diverge on reconstruction. (name, None) = removed;
+        (name, new_topo) = updated.
         """
+        changes: list[tuple[str, Topology | None]] = []
         for name in list(self._topologies.keys()):
             topo = self._topologies[name]
             if agent not in topo.members:
                 continue
             if topo.kind == "team" and topo.leader == agent:
                 self.remove_topology(name)
+                changes.append((name, None))
                 continue
             new_members = tuple(m for m in topo.members if m != agent)
             if not new_members:
                 self.remove_topology(name)
+                changes.append((name, None))
                 continue
             new_topo = Topology(
                 name=topo.name,
@@ -2565,6 +2701,8 @@ class AgentRegistry:
             )
             new_topo.save(self._topology_dir / f"{name}.yaml")
             self._topologies[name] = new_topo
+            changes.append((name, new_topo))
+        return changes
 
 
 def _drain_queue(q: asyncio.Queue) -> None:

--- a/tests/test_topology_rewind_2103_piece2.py
+++ b/tests/test_topology_rewind_2103_piece2.py
@@ -1,0 +1,137 @@
+"""Tier 2: OS invariant — #2103 Piece-2 topology-lifecycle rewind-reconstruction.
+
+Topologies become rewind-durable: every state-affecting mutation routes through a
+logged seam (create_topology / add_topology_member / remove_topology_member /
+delete_topology + the agent-purge cascade) that emits a topology_created /
+topology_updated / topology_removed WAL event. _materialize_rewind then reconstructs
+the topology config-set AS-OF-CUT from those WAL events (latest-≤-cut-wins, full
+config per event) — sourced from the WAL only, never the rotated audit log.
+
+MUST-2 (scoping): reconstruction touches ONLY WAL-tracked topology names — a
+pre-WAL / untracked topology is never created, mutated, or deleted by rewind.
+MUST-1 (emit completeness): the agent-purge cascade routes through the same logged
+seam, so a sync cascade on a tracked topology cannot diverge on reconstruction.
+
+Real AgentRegistry + StateLog + on-disk topologies (no mocks). _materialize_rewind
+is driven directly for precise as-of-cut control (the path rewind_to + crash
+recovery share).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.topology import Topology
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agents(tmp_path: Path, *names: str) -> None:
+    for name in names:
+        AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+@pytest.mark.asyncio
+async def test_topology_created_after_cut_is_removed(tmp_path):
+    """Tier 2: a topology CREATED after the rewind cut does not exist as-of-cut —
+    reconstruction removes both its on-disk YAML and its in-memory entry."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b")
+    log = reg.state_log
+    await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
+                     payload={"text": "x"})                  # seq 1 (non-lifecycle)
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 2
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+
+    assert not reg.topology_exists("net")
+    assert not (tmp_path / ".reyn" / "topologies" / "net.yaml").exists()
+
+
+@pytest.mark.asyncio
+async def test_topology_update_after_cut_is_reverted(tmp_path):
+    """Tier 2: a member ADDED after the cut is reverted — the topology is restored to
+    its as-of-cut config (the latest topology_* event with seq ≤ cut wins)."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b", "c")
+    log = reg.state_log
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1
+    cut = log.current_seq
+    await reg.add_topology_member("net", "c")                # seq 2 (after cut)
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+
+    assert reg.topology_exists("net")
+    assert set(reg.get_topology("net").members) == {"a", "b"}  # c reverted
+
+
+@pytest.mark.asyncio
+async def test_topology_removed_after_cut_is_restored(tmp_path):
+    """Tier 2: a topology DELETED after the cut is RESTORED with its as-of-cut config —
+    the create event (≤ cut) wins over the later topology_removed (> cut)."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b")
+    log = reg.state_log
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1
+    cut = log.current_seq
+    await reg.delete_topology("net")                         # seq 2 (after cut)
+    assert not reg.topology_exists("net")                    # gone live
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+
+    assert reg.topology_exists("net")                        # restored
+    assert set(reg.get_topology("net").members) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_untracked_topology_untouched_by_rewind(tmp_path):
+    """Tier 2: MUST-2 — a pre-WAL / untracked topology (no lifecycle events) is left
+    untouched while a coexisting WAL-tracked topology is reconstructed — falsifies the
+    'rewind wipes everything' over-reach. Scoping is to WAL-tracked names only."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b")
+    log = reg.state_log
+    reg.add_topology(Topology.new("legacy", kind="network", members=["a", "b"]))  # NO WAL emit
+    await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
+                     payload={"text": "x"})                  # seq 1
+    await reg.create_topology(Topology.new("tracked", kind="network", members=["a", "b"]))  # seq 2
+
+    # cut before the tracked create → tracked removed, untracked survives.
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+
+    assert not reg.topology_exists("tracked")               # tracked: removed
+    assert reg.topology_exists("legacy")                    # untracked: untouched
+    assert set(reg.get_topology("legacy").members) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_purge_cascade_emits_topology_event(tmp_path):
+    """Tier 2: MUST-1 — purging a topology member routes the cascade mutation through
+    the logged seam — a topology-lifecycle WAL event is emitted, so a tracked topology
+    cannot diverge on reconstruction via a silent sync cascade."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b")
+    log = reg.state_log
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))
+
+    before = log.current_seq
+    await reg.archive_agent("a", purge=True)                 # cascade shrinks "net"
+
+    emitted = [
+        e for e in log.iter_from(before + 1)
+        if e.get("kind") in ("topology_updated", "topology_removed")
+    ]
+    assert emitted, "purge cascade must emit a topology-lifecycle WAL event (MUST-1)"


### PR DESCRIPTION
**[dogfood-coder]** — #2103 Piece-2: topology-lifecycle rewind **durability** (my lane per the lead split; e2e owns the topology-create LLM tool + ⊆-parent capability model).

## What

Topologies become rewind-durable. Today they're filesystem-derived and **not** rewound — a rewind across a topology mutation leaves a divergent topology config-set. This wires topologies into the same as-of-cut reconstruction the agent lifecycle (#2117/#2118) already uses.

- **EMIT**: every state-affecting topology mutation routes through a logged seam that emits a `topology_created` / `topology_updated` / `topology_removed` WAL event.
- **RECONSTRUCT**: `_materialize_rewind` → `_reconcile_topologies_as_of_cut(cut)` rebuilds the topology config-set from those events — **latest-≤-cut-wins, full config per event** (mirrors the agent S2 shape the lead approved).

## WAL-only emit + WAL-sourced reconstruction (owner's impl-checkpoint — confirmed)

Explicitly stated for review (no EventLog conflation):
- The `topology_*` emit goes through **`StateLog.append`** only — the WAL (`WAL_EVENT_KINDS`, fsync-per-append), **exactly like `agent_created`**. It does **not** also/instead route through the P6 `EventLog` (`.reyn/events/`, which rotates).
- `_reconcile_topologies_as_of_cut` sources reconstruction from **`StateLog.iter_from(0)`** (the WAL), **never** `.reyn/events/`.
- Rationale: the audit log rotates → sourcing rewind from it would silently break rewind-to-old-cut once entries rotate away. The WAL is the non-rotated, seq-ordered, fsync'd recovery log = the correct (and only) reconstruction source. (`state_log.py:8-9` documents the split.) Mirrors the `agent_created` precedent — this is a confirm, not a new path.

## MUST-1 — emit completeness ({site → seam} table)

Invariant: **a topology is fully-tracked or fully-untracked — a sync mutation on a tracked topology would diverge on reconstruction.** Every mutator routes through a logged seam. The sync `add_topology`/`remove_topology`/`add_member`/`remove_member` are the **mechanism** (private internals); the logged seams wrap them + emit.

| Mutation site | Routes through (logged seam) | Emits |
|---|---|---|
| LLM tool (create) / web `POST /topologies` (`topologies.py:85`) / CLI `topology new` (`topology.py:116`) | `create_topology` | `topology_created` |
| web `POST .../members/{agent}` (`topologies.py:141`) / CLI `add-member` (`topology.py:179`) | `add_topology_member` | `topology_updated` |
| web `DELETE .../members/{agent}` (`topologies.py:163`) / CLI `rm-member` (`topology.py:189`) | `remove_topology_member` | `topology_updated` |
| web `DELETE /topologies/{name}` (`topologies.py:116`) / CLI `rm` (`topology.py:169`) | `delete_topology` | `topology_removed` |
| **agent-purge cascade** (`_cascade_agent_removal`, fired from `archive_agent` purge + the `_purge_archived_below` auto-purge GC) | cascade now **returns** its changes; the async caller (`archive_agent` / `_purge_archived_below`) emits each | `topology_updated` (shrunk) / `topology_removed` (team-lost-leader / emptied) |

`_cascade_agent_removal(agent) -> list[tuple[str, Topology|None]]` — `(name, None)` = removed, `(name, new_topo)` = updated. `remove()` returns the cascade list (purge) / `[]` (archive — membership preserved, #1954). `_purge_archived_below` is now `async` (its sync→async flip rippled to its one caller `_prune_generations_below`, now `await`ed).

### EXTRA completeness check — ZERO direct-dict mutations outside seams

Grepped `self._topologies[...] =` / `del self._topologies[...]` across `src/`. All 7 hits are inside a mechanism method, the loader, the cascade, or the reconstruction — **none bypass the seams**:

| line | location | classification |
|---|---|---|
| reconstruction `_reconcile_topologies_as_of_cut` | WAL-sourced rebuild (intended) | ✓ |
| loader (`*.yaml` glob) | disk load | ✓ |
| `add_topology` / `remove_topology` / `add_member` / `remove_member` | mechanism (seam-internal) | ✓ |
| `_cascade_agent_removal` rebuild | cascade (captured + emitted by async caller) | ✓ |

Grepped all callers of the sync mutators: every one is inside a logged seam or the cascade. No un-seamed mutation source remains.

## MUST-2 — reconstruction scoped to WAL-tracked names only

`_reconcile_topologies_as_of_cut` iterates **only** the names returned by `_topology_lifecycle()` (= names with ≥1 `topology_*` WAL event). A pre-WAL / untracked topology has no events → invisible to the map → never created, mutated, or deleted by rewind. Falsified by `test_untracked_topology_untouched_by_rewind` (untracked + tracked coexisting: tracked reconstructed, untracked untouched).

## P7

`topology` / `agent` are OS-level vocabulary (not skill-specific strings) — P7-safe, same as the agent-lifecycle kinds.

## Test plan

Tier-2 (`tests/test_topology_rewind_2103_piece2.py`, real `AgentRegistry` + `StateLog`, no mocks):

- [x] `test_topology_created_after_cut_is_removed` — create-after-cut → removed (YAML + in-memory)
- [x] `test_topology_update_after_cut_is_reverted` — member-add-after-cut → reverted to as-of-cut config
- [x] `test_topology_removed_after_cut_is_restored` — delete-after-cut → **restored** with as-of-cut config
- [x] `test_untracked_topology_untouched_by_rewind` — **MUST-2** falsification (untracked + tracked coexist)
- [x] `test_purge_cascade_emits_topology_event` — **MUST-1** cascade routes through the logged seam

CI gates (all green, run locally):
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_topology_rewind_2103_piece2.py` — 5 OK, 0 errors
- [x] `pytest -n auto` — 8435 passed, 21 skipped, 3 xfailed
- [x] rebased onto current origin/main (f9163c10, #2152); post-rebase targeted suites + ruff green; #2152 ephemeral-vanish test passes alongside the `_purge_archived_below` async flip

### Tier rule self-check
- [x] docstrings declare Tier (line 1 `Tier 2:`)
- [x] no Tier-4 (no format pins / private-state asserts / golden files)
- [x] no invariant-weakening; real instances (no MagicMock)
- [x] new test belongs to exactly one Tier (2 — OS invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
