### PR TITLE
docs(testing): callout no-parenthetical-before-colon tier-docstring trap

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -529,7 +529,7 @@ When adding a new LLM-dependent OS path:
 - [ ] If the feature derives from a P1–P8 invariant, add a Tier 2 test for it
 - [ ] If the feature changes a public contract (yaml schema, events payload, DSL section), update / add a Tier 1 test
 - [ ] Verify no `current_datetime=datetime.now()` — always `REPLAY_DATETIME`
-- [ ] Each test has a one-line docstring naming its tier (e.g. `"""Tier 3a: ..."""`)
+- [ ] Each test has a one-line docstring naming its tier (e.g. `"""Tier 3a: ..."""`). The exact format is `Tier N:` or `Tier Na:` — any text between the tier designation and the colon fails the audit (e.g. `"""Tier 2 (MUST-1): ..."""` → fail; fix: `"""Tier 2: (MUST-1) ..."""`)
 
 ---
 
@@ -541,7 +541,7 @@ Use it as a pre-commit check when adding new tests, for a Tier 4 violation sweep
 
 Detection rules (6):
 
-- Missing Tier docstring
+- Missing or malformed Tier docstring (regex: `^Tier [123][abc]?:` — colon must follow directly)
 - Format pinning (line count / char count / exact length = Tier 4 violation)
 - Private state assertion
 - MagicMock / AsyncMock / patch usage

--- a/docs/reference/test-tier-audit.md
+++ b/docs/reference/test-tier-audit.md
@@ -42,8 +42,19 @@ def test_something():
 ```
 
 The Tier label (`Tier 1`, `Tier 2`, `Tier 3a`, `Tier 3b`) must appear at the
-start of the first docstring line. Functions without a docstring, or with a
-docstring that does not start with a Tier label, trigger this error.
+start of the first docstring line, followed immediately by a colon
+(`^Tier [123][abc]?:`). Functions without a docstring, or with a
+docstring that does not match this pattern, trigger this error.
+
+**Common footgun:** a qualifier between the tier and the colon fails the audit:
+
+```python
+# FAIL — parenthetical before the colon
+"""Tier 2 (MUST-1): checks the invariant."""
+
+# PASS — qualifier after the colon
+"""Tier 2: (MUST-1) checks the invariant."""
+```
 
 **Why:** Without the Tier label, there is no way to know whether a test
 belongs at all (Tier 4 = do not write) or what contract it is asserting.


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

The tier-audit script uses `^Tier [123][abc]?:` — meaning any text between the tier designation and the colon (e.g. `"""Tier 2 (MUST-1): ..."""`) fails the audit while `pytest` passes silently. This pytest-green-but-CI-red footgun was undocumented in both testing.md and the test-tier-audit.md reference.

- **`docs/deep-dives/contributing/testing.md`**: updated docstring checklist bullet to state the exact format requirement + anti-pattern example; updated detection-rules list to say "missing or malformed" with the regex
- **`docs/reference/test-tier-audit.md`** Rule 1: added FAIL/PASS code block showing the qualifier-before-vs-after-colon distinction

Verified from `scripts/test_tier_audit.py`: `TIER_DOCSTRING_RE = re.compile(r"^Tier [123][abc]?:", re.IGNORECASE)`. Reported by dogfood-coder.

## Test plan

- [x] `mkdocs build --strict` → 0 warnings, no Aborted
- [x] Regex verified from primary source (`scripts/test_tier_audit.py`)
- [x] Both affected doc surfaces updated (deep-dive policy + reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)