### PR TITLE
test(#2103 Piece-2): assert purge-cascade emits shrunk-membership payload (#2153 follow-up)

### DIFF
--- a/tests/test_topology_rewind_2103_piece2.py
+++ b/tests/test_topology_rewind_2103_piece2.py
@@ -128,10 +128,15 @@ async def test_purge_cascade_emits_topology_event(tmp_path):
     await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))
 
     before = log.current_seq
-    await reg.archive_agent("a", purge=True)                 # cascade shrinks "net"
+    await reg.archive_agent("a", purge=True)                 # cascade shrinks "net" → [b]
 
     emitted = [
         e for e in log.iter_from(before + 1)
         if e.get("kind") in ("topology_updated", "topology_removed")
     ]
     assert emitted, "purge cascade must emit a topology-lifecycle WAL event (MUST-1)"
+    # The emitted PAYLOAD must reflect the cascade's actual mutation (shrunk to {b}),
+    # not merely that *an* event fired — else reconstruction would diverge.
+    ev = emitted[-1]
+    assert ev["kind"] == "topology_updated"
+    assert set(ev["topology"]["members"]) == {"b"}


### PR DESCRIPTION
**[dogfood-coder]** — Trivial test-only follow-up to #2153 (merged b223b5e0). My test-strengthening commit landed ~1 min after the squash-merge, so it missed the squash — re-landing it here.

## What
Addresses lead's optional non-blocking nit on #2153: the MUST-1 purge-cascade test (`test_purge_cascade_emits_topology_event`) asserted only that *a* topology-lifecycle event fired (event-type-only). This strengthens it to assert the emitted **payload** reflects the cascade's actual mutation — purging `a` from network `net=[a,b]` must emit `topology_updated` with `members == {b}`.

Why it matters: an event firing by *name* doesn't prove *what it did* — a divergent payload would silently break reconstruction. This is the event-type-only-extrapolation trap; asserting the payload closes it.

Test-only; no production change. Foundation (#2153) already merged + verified.

## Test plan
- [x] `pytest tests/test_topology_rewind_2103_piece2.py` — 5 passed
- [x] `ruff check` — clean
- [x] `test_tier_audit.py --strict` — OK

### Tier rule self-check
- [x] docstring declares Tier (line 1 `Tier 2:`)
- [x] no Tier-4 (the membership-set assert is a behavioral payload check, not a format pin)
- [x] real instances (no MagicMock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)