### PR TITLE
feat(#2103): B-core — ⊆-parent capability cap (Decision A, no-escalation-via-spawn)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -184,6 +184,14 @@ class AgentRegistry:
         self._factory = session_factory
         self._state_log = state_log
         self._project_root = project_root
+        # #2103 B (agent-spawn, Decision A): the spawn lineage child→parent. OS-set at
+        # an agent-SPAWN (not plain create), set-once + immutable (a forged/repeat parent
+        # is rejected), acyclic-by-construction (the parent pre-exists; a new child can't
+        # be an ancestor). resolved_profile_for composes the parent's LIVE resolved
+        # effective as a restrict-only conjunct → spawned ⊆ parent by construction,
+        # recursively (no-escalation-via-spawn). WAL-carried on agent_created for
+        # rewind-reconstruction.
+        self._spawn_lineage: "dict[str, str]" = {}
         # #2081: delegation policy. ``deny`` narrows an UNBOUND delegate with the
         # restrictive _delegate floor; ``inherit`` (default) = byte-identical to
         # pre-#2081. ``_constructing_as_delegate`` is the transient is_delegate
@@ -425,6 +433,23 @@ class AgentRegistry:
         profile = AgentProfile.new(name, role=role)
         profile.save(self._dir / name)
         return profile
+
+    def _record_spawn_lineage(self, child: str, parent: str) -> None:
+        """#2103 B: OS-set the spawn lineage ``child → parent``, set-once + immutable.
+        The lineage is the no-escalation linchpin (resolved_profile_for caps the child
+        at ⊆ parent via it), so it must NOT be forgeable or mutable post-spawn: a
+        re-set to a DIFFERENT parent is refused, and a self-link is rejected. Acyclic
+        by construction — the parent pre-exists and the child is freshly created, so a
+        child can never be an ancestor of its parent. Idempotent on the same parent
+        (rewind-reconstruction may replay the same edge)."""
+        if child == parent:
+            raise ValueError(f"spawn-lineage self-link rejected: {child!r}")
+        existing = self._spawn_lineage.get(child)
+        if existing is not None and existing != parent:
+            raise ValueError(
+                f"spawn-lineage for {child!r} is immutable "
+                f"(set to {existing!r}; refused re-set to {parent!r})")
+        self._spawn_lineage[child] = parent
 
     async def create_agent(self, name: str, *, role: str = "") -> AgentProfile:
         """#2103 S2b: the action-layer CREATE seam — create the profile (sync) +
@@ -2435,6 +2460,24 @@ class AgentRegistry:
             ps = self._load_per_session_capability_profile(agent, sid)
             if ps is not None:
                 resolved.append(resolve_profile(ps))
+
+        # #2103 B (agent-spawn, Decision A): cap a SPAWNED agent at ⊆ its PARENT, LIVE +
+        # by construction. The parent's OWN resolved effective is composed as one more
+        # restrict-only conjunct; compose_resolved is a lattice-meet (∩ allow, ∪ deny),
+        # which is order-independent, so the child can never EXCEED the parent — even if
+        # the child's assigned subset is mis-specified wider, or a topology re-grants
+        # (the re-grant is bounded ONLY because this LIVE parent-conjunct caps it; a
+        # stale snapshot could not — this is why Decision A, not a persisted ⊆, is
+        # REQUIRED). Recursive: the parent's resolved already ∩'d ITS parent up to the
+        # operator-authorized top (lineage is acyclic → terminates). The parent resolves
+        # with its OWN delegate-status (is_delegate=None → its construction transient)
+        # at the agent envelope (no sid). A forged/absent lineage simply isn't here
+        # (OS-set), so it cannot widen.
+        parent = self._spawn_lineage.get(agent)
+        if parent is not None:
+            parent_ctx, parent_excl = self.resolved_profile_for(parent)
+            if parent_ctx is not None:
+                resolved.append((parent_ctx, parent_excl))
 
         if not resolved:
             return None, frozenset()

--- a/tests/test_2103_B_agent_spawn_lineage_cap_1953.py
+++ b/tests/test_2103_B_agent_spawn_lineage_cap_1953.py
@@ -1,0 +1,110 @@
+"""Tier 2: #2103 B — a spawned agent's capability is capped at ⊆ its PARENT (Decision A).
+
+agent-spawn records an OS-set, immutable spawn lineage (child → parent). resolved_profile_for
+composes the parent's LIVE resolved effective as one more restrict-only conjunct
+(compose_resolved is a lattice-meet: ∩ allow, ∪ deny — order-independent), so a spawned
+agent can NEVER exceed its parent — even with a mis-specified wider subset or a topology
+re-grant. The cap is LIVE (re-resolved each time), which is what makes the topology
+re-grant safe and is why Decision A (compose-parent) is REQUIRED over a persisted ⊆
+snapshot (which would go stale).
+
+The 4 falsifications (no mocks; real AgentRegistry + on-disk topology/profile YAML):
+  (a) wider subset → child still capped at parent (parent's deny propagates).
+  (b) DISCRIMINATOR — narrow the parent AFTER spawn → the child re-caps LIVE (GREEN
+      under A; RED under a persisted-⊆ snapshot, which is the whole point).
+  (c) a topology re-grant of a parent-denied tool is capped at the parent (∪-deny wins).
+  (d) the lineage is OS-set + immutable (a re-set to a different parent is refused) —
+      the forge-guard linchpin.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import ContextualPermission, tool_contextually_denied
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(project_root=tmp_path, session_factory=lambda profile: None)
+
+
+def _bind(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    """Bind ``member`` to a capability ``profile`` via a topology + write the profile YAML."""
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / f"{member}.yaml").write_text(
+        f"name: {member}\nkind: network\nmembers: [{member}, peer]\n"
+        f"profiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+def test_a_wider_subset_is_capped_at_parent(tmp_path: Path) -> None:
+    """Tier 2: (a) the parent denies sandboxed_exec; the child has NO own deny — yet the child
+    is capped at ⊆ parent via the live parent-conjunct, so it denies sandboxed_exec too.
+    RED if the parent-conjunct is absent (the child would not inherit the parent's deny)."""
+    _bind(tmp_path, member="P", profile="prole", body="name: prole\ntool_deny: [sandboxed_exec]\n")
+    reg = _registry(tmp_path)
+    reg._record_spawn_lineage("C", "P")
+
+    contextual, _ = reg.resolved_profile_for("C")
+    assert isinstance(contextual, ContextualPermission)
+    assert tool_contextually_denied(contextual, "sandboxed_exec")  # capped at parent
+
+
+def test_b_narrow_parent_after_spawn_recaps_live(tmp_path: Path) -> None:
+    """Tier 2: (b) DISCRIMINATOR — narrowing the PARENT after the spawn re-caps the child LIVE.
+    GREEN under Decision A (the parent is re-resolved on each child resolve); a
+    persisted-⊆ snapshot would NOT reflect the later narrowing → RED. This is the test
+    that distinguishes A from B (without it the suite passes under both)."""
+    _bind(tmp_path, member="P", profile="prole", body="name: prole\ntool_deny: [exec_x]\n")
+    reg = _registry(tmp_path)
+    reg._record_spawn_lineage("C", "P")
+    first, _ = reg.resolved_profile_for("C")
+    assert tool_contextually_denied(first, "exec_x")
+    assert not tool_contextually_denied(first, "exec_y")  # not yet denied
+
+    # the parent is narrowed FURTHER, after the spawn.
+    _bind(tmp_path, member="P", profile="prole",
+          body="name: prole\ntool_deny: [exec_x, exec_y]\n")
+    after, _ = reg.resolved_profile_for("C")
+    assert tool_contextually_denied(after, "exec_x")
+    assert tool_contextually_denied(after, "exec_y")  # LIVE re-cap (RED under a stale snapshot)
+
+
+def test_c_topology_regrant_is_capped_at_parent(tmp_path: Path) -> None:
+    """Tier 2: (c) a topology binding for the CHILD that allow-lists a parent-denied tool does
+    NOT re-grant it — the parent-conjunct's ∪-deny wins. A re-grant is bounded ONLY
+    because the live parent-conjunct caps it."""
+    _bind(tmp_path, member="P", profile="prole", body="name: prole\ntool_deny: [sandboxed_exec]\n")
+    # the child is bound to a profile that tries to ALLOW sandboxed_exec (a re-grant attempt).
+    _bind(tmp_path, member="C", profile="crole", body="name: crole\ntool_allow: [sandboxed_exec, read_file]\n")
+    reg = _registry(tmp_path)
+    reg._record_spawn_lineage("C", "P")
+
+    contextual, _ = reg.resolved_profile_for("C")
+    assert tool_contextually_denied(contextual, "sandboxed_exec")  # capped — re-grant refused
+
+
+def test_d_lineage_is_os_set_and_immutable(tmp_path: Path) -> None:
+    """Tier 2: (d) the lineage is the no-escalation linchpin, so it is set-once + immutable —
+    a re-set to a DIFFERENT parent is refused (the forge-guard). Idempotent on the same
+    parent (rewind-reconstruction may replay)."""
+    import pytest
+    reg = _registry(tmp_path)
+    reg._record_spawn_lineage("C", "P")
+    reg._record_spawn_lineage("C", "P")  # idempotent (same parent) — no error
+    with pytest.raises(ValueError):
+        reg._record_spawn_lineage("C", "EVIL")  # re-parent to escalate → refused
+    with pytest.raises(ValueError):
+        reg._record_spawn_lineage("X", "X")      # self-link → refused
+
+
+def test_unspawned_agent_has_no_parent_cap(tmp_path: Path) -> None:
+    """Tier 2: sanity — an agent with NO recorded lineage gets no parent-conjunct (byte-identical
+    to pre-#2103-B) — the cap requires the OS-set lineage, not anything the LLM supplies."""
+    reg = _registry(tmp_path)
+    assert reg.resolved_profile_for("solo") == (None, frozenset())


### PR DESCRIPTION
**[e2e-coder]** — #2103 **B-core**: the ⊆-parent capability cap (Decision A — no-escalation-via-spawn). Lead-steered split (i): the security cap reviewed in isolation; the agent_spawn tool + create-wiring + #2081 floor + lineage rewind-reconstruction follow as **B-tool**. Off origin/main @f9163c10.

## What
The load-bearing security core of agent-spawn: a spawned agent's effective capability is capped at **⊆ its parent, live + by construction**.

- `registry._spawn_lineage` (child→parent), **OS-set, set-once, immutable** via `_record_spawn_lineage` — a re-parent or self-link is **refused** (the forge-guard linchpin; the LLM never supplies the parent link). Acyclic by construction (parent pre-exists; child is new).
- `resolved_profile_for` composes the parent's **live** resolved effective as one more **restrict-only conjunct**. `compose_resolved` is a lattice-meet (∩ allow, ∪ deny) — **order-independent** — so the child can never *exceed* the parent, even with a mis-specified wider subset or a topology re-grant (the re-grant is bounded **only** because this live parent-conjunct caps it; a persisted-⊆ snapshot would go stale → **why Decision A is required**). **Recursive**: the parent's resolved already ∩'d ITS parent up to the operator-authorized top.

## Why this is safe to land alone
Inert in production until a caller records a lineage (the agent_spawn tool, B-tool) — **additive, byte-identical** for every existing (unspawned) agent.

## Verification (5 tests; real registry + on-disk topology/profile YAML)
- **(b) discriminator** — narrow the parent *after* spawn → the child re-caps **live** (GREEN under A; a stale-snapshot B would be RED — the test that distinguishes A from B).
- (a) wider-subset-capped; (c) topology-re-grant-capped (∪-deny wins); (d) lineage immutable (re-parent/self-link refused — forge-guard); unspawned-agent-no-cap (sanity).
- **Verified RED-when-stripped**: drop the parent-conjunct → the 3 cap tests fail; the lineage/sanity tests stay green.
- Gates: capability/profile/topology/2081/2103 sweep (375 passed); ruff clean; tier-audit `--strict` 0 (caught the exact-`Tier N:`-prefix docstring rule).

## Test plan
- [x] `pytest` B-core tests (5 passed) + capability/profile sweep (375 passed)
- [x] RED-when-stripped (parent-conjunct) verified
- [x] `ruff` clean + tier-audit 0
- [ ] Full rootdir `pytest -q` (running; will report)
- [ ] tui live-verify deferred to B-tool (no LLM-reachable spawn yet — B-core is inert until the tool records a lineage)

## Next: B-tool (security linchpin pre-flagged by lead)
agent_spawn LLM tool + create-via-spawn wiring + #2081 floor entries (agent_spawn/topology_create default-deny) + **the lineage carried on `agent_created` + reconstructed on rewind** (mirror sandbox_2 #2117/#2153). B-tool's falsification will include: spawn child → rewind across the spawn → forward-checkout → child **still ⊆ parent** (lineage survived the round-trip — else escalation-on-rewind).

Design-gated: B-core close-review → merge → B-tool → C (topology-create via sandbox_2's create_topology seam). **No self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
