### PR TITLE
fix(#2154): emit session_vanished (cause-parameterized) + reconstruction symmetry

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1169,6 +1169,24 @@ class AgentRegistry:
             created[key] = seq  # a create is unique; last-write-wins is moot
         return created
 
+    def _session_vanished_map(self) -> "dict[tuple[str, str], int]":
+        """#2154: per (agent, sid), the latest ``session_vanished`` seq from the WAL —
+        the destroy-side mirror of the ``session_spawned`` create-cut in
+        ``_created_at_map``. Reconstruction drops a session that vanished at-or-before
+        the cut (it was gone as-of-cut). Empty without a WAL."""
+        vanished: dict[tuple[str, str], int] = {}
+        if self._state_log is None:
+            return vanished
+        for entry in self._state_log.iter_from(0):
+            if entry.get("kind") != "session_vanished":
+                continue
+            name = entry.get("name")
+            sid = entry.get("sid")
+            seq = entry.get("seq")
+            if isinstance(name, str) and isinstance(sid, str) and isinstance(seq, int):
+                vanished[(name, sid)] = seq  # last wins = the latest vanish
+        return vanished
+
     def _drop_agent(self, name: str) -> None:
         """#2103: tear down an agent created after the rewind cut. A post-cut agent
         has NO pre-cut generations → nothing to preserve → a clean drop (vs the
@@ -1317,9 +1335,11 @@ class AgentRegistry:
         — a restore-failure must not leave the dir dropped). The connection-release
         (quiesce + backend close) still happens here, because it MUST precede the
         ``_restore_task_active`` file-swap (that is the lock fix)."""
-        await self.remove_session(name, sid, purge_dir=purge_dir)
+        await self.remove_session(name, sid, purge_dir=purge_dir, record=False)
 
-    async def remove_session(self, name: str, sid: str, *, purge_dir: bool = True) -> bool:
+    async def remove_session(
+        self, name: str, sid: str, *, purge_dir: bool = True, record: bool = True,
+    ) -> bool:
         """#2103 S1bc: tear down a SPAWNED (non-main) session — the single teardown
         seam used by BOTH the rewind as-of-cut DROP (``_drop_session``) AND the
         ephemeral auto-vanish. Quiesces + closes the session's per-session Task backend,
@@ -1386,6 +1406,15 @@ class AgentRegistry:
                 removed = True
         elif self._session_state_dir(name, sid).is_dir():
             removed = True  # dir present; destructive purge deferred to the caller (#2125)
+        # #2154: a GENUINE vanish (ephemeral auto-vanish / explicit removal) emits
+        # session_vanished — the create↔destroy WAL symmetry (the destroy-side mirror
+        # of session_spawned). The rewind-reconstruction caller (_drop_session) passes
+        # record=False: a reconstruction-drop UNDOES history, so recording it would
+        # pollute the append-only WAL and corrupt as-of-cut reconstruction.
+        if removed and record and self._state_log is not None:
+            await self._state_log.append(
+                "session_vanished", entity_kind="session", name=name, sid=sid,
+            )
         return removed
 
     def _surviving_rewind_backend(self) -> "object | None":
@@ -1452,6 +1481,7 @@ class AgentRegistry:
         # it MUST precede _restore_task_active (the lock fix).
         deferred_session_purges: list[tuple[str, str]] = []
         created_at = self._created_at_map()   # #2103: as-of-cut DROP input (empty → no-op)
+        sess_vanished = self._session_vanished_map()  # #2154: as-of-cut session destroy-cut
         # #2103 S2: agent-lifecycle reconstruction (re-materialise / hide / purge) —
         # all inert until S2b emits the events.
         ag_created, ag_archived, ag_purged = self._agent_lifecycle()
@@ -1480,8 +1510,16 @@ class AgentRegistry:
                 continue
             for sid in self._discover_session_ids(name):
                 # A session spawned after the cut → drop just that session.
+                # #2154: OR a session that VANISHED at-or-before the cut (it was gone
+                # as-of-cut) — the destroy-side mirror of the spawn-cut. A genuine
+                # vanish normally already rmtree'd the dir (so discovery won't surface
+                # it); this guard keeps reconstruction correct if a dir SURVIVES its
+                # vanish (a crash mid-rmtree, or a future session re-materialise seam).
                 sess_seq = created_at.get(("session", name, sid))
-                if sess_seq is not None and sess_seq > drop_cut:
+                van_seq = sess_vanished.get((name, sid))
+                spawned_after_cut = sess_seq is not None and sess_seq > drop_cut
+                vanished_by_cut = van_seq is not None and van_seq <= drop_cut
+                if spawned_after_cut or vanished_by_cut:
                     # #2125: detach now (quiesce + close the Task-backend connection
                     # so _restore_task_active doesn't hit "database is locked"); defer
                     # the destructive rmtree until the restores below succeed.

--- a/tests/test_session_vanished_emit_2154.py
+++ b/tests/test_session_vanished_emit_2154.py
@@ -1,0 +1,126 @@
+"""Tier 2: OS invariant — #2154 session_vanished emit + reconstruction symmetry.
+
+session_vanished is a registered WAL kind whose doc claims it's emitted, but
+remove_session never appended it (the create↔destroy asymmetry tui-coder mined:
+session_spawned IS appended, session_vanished was not). Two-part fix:
+
+1. EMIT, cause-parameterized: remove_session is the shared teardown seam for BOTH
+   the genuine vanish (ephemeral auto-vanish / explicit removal → MUST record) and
+   the rewind-reconstruction drop (_drop_session → must NOT record: a drop undoes
+   history, recording it would pollute the append-only WAL + corrupt as-of-cut
+   reconstruction). _drop_session passes record=False; genuine callers default to
+   record=True. The destroy-side mirror of session_spawned.
+
+2. RECONSTRUCTION symmetry: _materialize_rewind consumes session_vanished
+   (latest-≤-cut-wins) so a session vanished at-or-before the cut reconstructs as
+   GONE. A genuine vanish normally rmtree's the dir (discovery won't surface it), so
+   this guard is load-bearing when a dir SURVIVES its vanish (crash mid-rmtree, or a
+   future session re-materialise seam).
+
+Real AgentRegistry + StateLog + Session (no mocks), mirroring the production
+scoped_session_factory (registry threaded into each Session).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log,
+                    registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _vanished_sids(log: StateLog, name: str) -> list[str]:
+    return [
+        e.get("sid") for e in log.iter_from(0)
+        if e.get("kind") == "session_vanished" and e.get("name") == name
+    ]
+
+
+@pytest.mark.asyncio
+async def test_genuine_ephemeral_vanish_emits_session_vanished(tmp_path):
+    """Tier 2: the genuine ephemeral auto-vanish emits session_vanished (the create↔
+    destroy WAL symmetry — was the missing half). Falsifies the doc-claimed-but-never-
+    emitted defect."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+
+    eph = reg._peek_session("alice", sid)
+    eph._maybe_schedule_ephemeral_vanish()
+    if eph._vanish_task is not None:
+        await eph._vanish_task
+
+    assert sid in _vanished_sids(reg.state_log, "alice")  # destroy recorded
+
+
+@pytest.mark.asyncio
+async def test_reconstruction_drop_does_not_emit_session_vanished(tmp_path):
+    """Tier 2: the rewind-reconstruction drop (_drop_session) does NOT emit
+    session_vanished — a drop undoes history; recording it would pollute the WAL and
+    corrupt as-of-cut reconstruction (the cause-separation, record=False)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    assert sid not in _vanished_sids(reg.state_log, "alice")  # spawn alone: none
+
+    await reg._drop_session("alice", sid)
+
+    assert _vanished_sids(reg.state_log, "alice") == []  # reconstruction: no WAL pollution
+
+
+@pytest.mark.asyncio
+async def test_session_vanished_before_cut_reconstructs_gone(tmp_path):
+    """Tier 2: reconstruction symmetry — a session whose session_vanished is at-or-
+    before the cut reconstructs as GONE even though it SURVIVES in the registry (the
+    record landed but the teardown didn't complete: crash mid-rmtree / future
+    re-materialise). The destroy-side mirror of the spawn-cut; latest-≤-cut-wins."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    log = reg.state_log
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")  # spawn ≤ cut, live
+    assert sid in reg.session_ids("alice")                    # present (public surface)
+    # the vanish was RECORDED but the session survives (teardown didn't finish).
+    await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)
+
+    # cut at/after the vanish → gone as-of-cut → reconstruction drops it.
+    await reg._materialize_rewind(
+        reconstruct_seq=log.current_seq, workspace_at_or_below=log.current_seq,
+    )
+
+    assert sid not in reg.session_ids("alice")                # reconstructs gone
+
+
+@pytest.mark.asyncio
+async def test_session_vanished_after_cut_survives_reconstruction(tmp_path):
+    """Tier 2: the cut boundary — a session whose session_vanished is AFTER the cut
+    still existed as-of-cut, so reconstruction must NOT drop it for the vanish
+    (latest-≤-cut-wins: a future vanish does not apply)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    log = reg.state_log
+    sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    cut = log.current_seq                                     # cut = after the spawn
+    await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)  # > cut
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+
+    assert sid in reg.session_ids("alice")                    # existed as-of-cut → kept


### PR DESCRIPTION
**[dogfood-coder]** — #2154 (tui's live-verify finding): `session_vanished` is a registered WAL kind whose doc claims it's emitted, but `remove_session` never appended it — the create↔destroy asymmetry tui-coder mined (`session_spawned` IS appended at `registry.py:2111`; the destroy side was unrecorded). Same emit-on-mutation / suppress-on-reconstruction pattern as #2153.

## Two-part fix

### Part 1 — EMIT, cause-parameterized
`remove_session` is the shared teardown seam called by BOTH:
- the **genuine vanish** (ephemeral auto-vanish `session.py:3549` / explicit removal) → **MUST record** (`record=True`, default), and
- the **rewind-reconstruction drop** (`_drop_session`) → **MUST NOT record** (`record=False`).

A reconstruction-drop *undoes* history; recording it would pollute the append-only WAL and corrupt as-of-cut reconstruction. So `_drop_session` passes `record=False`; genuine callers default to `record=True`. Emits only when something was actually removed. Payload mirrors `session_spawned` (`entity_kind=session, name, sid`).

### Part 2 — RECONSTRUCTION symmetry
`_materialize_rewind` now consumes `session_vanished` via `_session_vanished_map()` (latest-≤-cut-wins) — a session whose vanish seq ≤ cut reconstructs as GONE. The destroy-side mirror of the `session_spawned` create-cut (`_created_at_map`).

## Flow-trace finding (verify-reproduce-first — honest scoping)

I traced the resurrection risk on both axes before building part 2:
- **Replay axis**: `AgentSnapshot` is per-`(agent, session_id)` — it has **no in-snapshot session registry** that `session_spawned` populates and `session_vanished` would clear (`apply_events` routes entries to one session, it doesn't track a set). So there's no snapshot-replay resurrection.
- **Disk axis**: the session-set is disk-derived (`_discover_session_ids`), and a genuine vanish rmtree's the dir — so a vanished session is already absent from discovery.

⇒ Part 2 is therefore a **forward-robustness guard**, not a fix for a reproduced live resurrection: its trigger is a session dir **surviving** its vanish (a crash mid-rmtree, or the future session re-materialise seam — sessions are drop-only today). It's cheap, additive (the normal purge-on-vanish path never reaches it: discovery won't surface a purged session), mirrors the #2153 topology latest-≤-cut pattern, and makes the invariant hold by construction before re-materialise lands. Falsified directly by simulating a surviving session whose vanish was recorded.

(Out of scope, tracked in **#2159**: agent purge `rmtree`s the agent dir subsuming its sessions without per-session `session_vanished` — the session analog of the topology cascade-emit, not part of this seam.)

## Test plan

Tier-2 (`tests/test_session_vanished_emit_2154.py`, real `AgentRegistry` + `StateLog` + `Session`, no mocks; assertions on public surfaces `session_ids` / the WAL):

- [x] `test_genuine_ephemeral_vanish_emits_session_vanished` — genuine vanish records `session_vanished` (the missing half; makes the existing ephemeral test's doc-claim true)
- [x] `test_reconstruction_drop_does_not_emit_session_vanished` — `_drop_session` does NOT emit (cause-separation; no WAL pollution)
- [x] `test_session_vanished_before_cut_reconstructs_gone` — vanish ≤ cut + surviving session → reconstructs GONE
- [x] `test_session_vanished_after_cut_survives_reconstruction` — vanish > cut → existed as-of-cut → kept (the boundary)

CI gates:
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_session_vanished_emit_2154.py` — 4 OK, 0 errors
- [x] `pytest -n auto` — 8442 passed, 21 skipped, 3 xfailed
- [x] session/rewind/registry regression (`-k session or rewind or registry or vanish or ephemeral`): 809 passed

### Tier rule self-check
- [x] docstrings declare Tier (line 1 `Tier 2:`)
- [x] no Tier-4 (public-surface asserts: `session_ids` + WAL reads; no private-state / format pins)
- [x] real instances (no MagicMock)
- [x] each test = exactly one Tier (2 — OS invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
