### PR TITLE
fix(#2103): cascade preserves surviving members' capability_profile bindings (escalation guard)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2830,12 +2830,23 @@ class AgentRegistry:
                 self.remove_topology(name)
                 changes.append((name, None))
                 continue
+            # #2103: PRESERVE surviving members' capability_profile bindings — drop
+            # ONLY the removed member's. Rebuilding without profiles wiped EVERY
+            # binding, so purging one member silently changed a SURVIVOR's effective
+            # capability (resolved_profile_for treats a missing binding as no-narrowing
+            # = full ⊆-parent cap → a widen/escalation in the narrowing-binding case).
+            # Dropping the removed member's entry also keeps Topology.__post_init__
+            # happy (it rejects profiles bound to non-members) → reconstruction-safe.
+            new_profiles = {
+                m: p for m, p in topo.profiles.items() if m != agent
+            }
             new_topo = Topology(
                 name=topo.name,
                 kind=topo.kind,
                 members=new_members,
                 leader=topo.leader,
                 created_at=topo.created_at,
+                profiles=new_profiles,
             )
             new_topo.save(self._topology_dir / f"{name}.yaml")
             self._topologies[name] = new_topo

--- a/tests/test_cascade_profile_preserve_2103.py
+++ b/tests/test_cascade_profile_preserve_2103.py
@@ -1,0 +1,73 @@
+"""Tier 2: OS invariant — #2103 cascade preserves surviving members' cap-profiles.
+
+_cascade_agent_removal (fired when an agent is purged) drops the purged agent from
+every topology it's a member of. It rebuilt the shrunk topology WITHOUT profiles →
+it wiped EVERY capability_profile binding, so purging one member silently changed a
+SURVIVOR's effective capability: resolved_profile_for treats a missing binding as
+no-narrowing (full ⊆-parent cap), so a survivor's narrowing binding being dropped is
+a widen/escalation. The cascade must drop ONLY the removed member's binding and
+preserve the survivors'.
+
+Real AgentRegistry + StateLog + on-disk topologies (no mocks); assertions on the
+public get_topology surface.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.topology import Topology
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agents(tmp_path: Path, *names: str) -> None:
+    for name in names:
+        AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+@pytest.mark.asyncio
+async def test_purge_preserves_survivor_profile_drops_removed(tmp_path):
+    """Tier 2: purging member A drops A's capability_profile binding but PRESERVES
+    survivor B's — so an unrelated-member purge does not silently widen B's effective
+    capability (the escalation guard). RED with the old wipe-all-profiles rebuild."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b", "c")
+    await reg.create_topology(
+        Topology.new("net", kind="network", members=["a", "b", "c"],
+                     profiles={"a": "pa", "b": "pb"}),
+    )
+
+    await reg.archive_agent("a", purge=True)   # cascade shrinks "net" → [b, c]
+
+    topo = reg.get_topology("net")
+    assert set(topo.members) == {"b", "c"}
+    assert topo.profiles == {"b": "pb"}        # a dropped, b PRESERVED (not wiped)
+
+
+@pytest.mark.asyncio
+async def test_purge_without_profiles_is_noop_on_profiles(tmp_path):
+    """Tier 2: the no-binding case is unaffected — a topology with no cap-profiles
+    shrinks normally on a member purge (regression-free for the common case)."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b")
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))
+
+    await reg.archive_agent("a", purge=True)   # shrinks "net" → [b]
+
+    topo = reg.get_topology("net")
+    assert set(topo.members) == {"b"}
+    assert topo.profiles == {}                 # no bindings to begin with → still none


### PR DESCRIPTION
**[dogfood-coder]** — #2103 cascade escalation guard. Surfaced by e2e's C (topology_create) flag-3 review question; lands the `profiles[member]` live-prune in the cascade lane.

## Bug
`_cascade_agent_removal` (fired when an agent is purged) drops the purged agent from every topology it's a member of, rebuilding the shrunk topology. It rebuilt `new_topo` **without** `profiles` → `profiles` defaulted to `{}`, **wiping EVERY `capability_profile` binding** — not just the removed member's.

`resolved_profile_for` treats a member with no binding as no-narrowing (`(None, frozenset())` = full ⊆-parent cap — "No layer → byte-identical to pre-#1827"). So purging member A silently **changed a SURVIVOR B's effective capability**: B's narrowing binding was dropped → B widened. A capability **escalation** on an unrelated member's purge (the non-delegate / allow-default narrowing case; for a deny-default delegate it falls back to the `_delegate` floor = fail-safe, but still an unintended change).

## Fix
Drop **only** the removed member's binding; **preserve** the survivors':
```python
new_profiles = {m: p for m, p in topo.profiles.items() if m != agent}
new_topo = Topology(..., profiles=new_profiles)
```
Dropping the removed member's entry also satisfies `Topology.__post_init__` (it rejects profiles bound to non-members) → reconstruction-safe (no stale binding → purged-member).

## Coordination (lanes locked with e2e + lead)
- This is the **`profiles[member]` live-prune** companion to rewind-rebuild. Landing it here means **C2 only verifies it** (no double-implement), and **#2159 stays scoped to sessions** (the session_vanished cascade) — resolving lead's double-implement flag.
- **Orthogonal to C2's fail-closed cap-walk** (gate 6): that handles *binding present + referent absent → deny*; this handles *binding wrongly dropped → treated as unbound → widen*. Both needed, independent (confirmed with e2e).

## Test plan
Tier-2 (`tests/test_cascade_profile_preserve_2103.py`, real `AgentRegistry` + `StateLog`, no mocks; public `get_topology` surface):
- [x] `test_purge_preserves_survivor_profile_drops_removed` — purge A from `[a,b,c]` with `profiles={a,b}` → result `profiles == {b: pb}` (a dropped, b **preserved**). **RED-when-stripped verified** (revert the `profiles=` kwarg → fails).
- [x] `test_purge_without_profiles_is_noop_on_profiles` — no-binding common case unaffected.

CI gates:
- [x] `ruff check src tests` — All checks passed
- [x] `test_tier_audit.py --strict` — 2 OK, 0 errors
- [x] `pytest -n auto` — 8462 passed, 21 skipped, 3 xfailed
- [x] targeted regression (`-k topolog or cascade or registry or rewind or 1827`): 606 passed

### Tier rule self-check
- [x] docstrings declare Tier (line 1 `Tier 2:`)
- [x] no Tier-4 (public `get_topology` reads; no private-state / format pins)
- [x] real instances (no MagicMock); regression validated RED-when-stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
