### PR TITLE
docs(runtime): add cross-version restore invariant to time-travel.md

### DIFF
--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -133,6 +133,8 @@ Do not conflate or merge the two logs. See [Events](events.md) for details.
 
 `restore_to_seq` re-runs the schema migration on the restored generation (via the shared `_migrate_columns` helper, the same one `_open` uses on first open), bringing any restored generation to the current schema. This means a generation snapshotted before an additive column was introduced is automatically upgraded on restore — there is no "old schema is frozen in the snapshot" risk. The migration is idempotent: the `PRAGMA table_info` guard skips any column that already exists, so re-running it over a current-schema generation is a safe no-op. Robust to additive schema evolution by construction.
 
+**Cross-version restore is supported by construction.** A snapshot written under an older column set (a generation captured before an additive column was introduced) restores cleanly — `restore_to_seq` re-runs the idempotent column migration after the file-swap reopen, bringing the restored database to the current schema automatically. There is no restriction to same-version generations: the idempotent migration is the guarantee.
+
 ---
 
 ## Cost and the runtime-only opt-out


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- Adds an explicit cross-version restore callout to `docs/concepts/runtime/time-travel.md` § "Restore and schema migration"
- States the invariant directly: a snapshot written under an older column set restores cleanly because `restore_to_seq` re-runs the idempotent `_migrate_columns` after the file-swap reopen
- No-history-refs framing: current-state invariant only, no change-history language

## Verification

- Impl anchor: `src/reyn/task/sqlite_backend.py:146-148` — `_migrate_columns` is called from both `_open(init_schema=True)` and `restore_to_seq` (docstring + code confirm)
- `mkdocs build --strict`: 0 warnings

## Test plan

- [x] mkdocs --strict clean (0 warnings, 0 errors)
- [x] Impl claim verified against `sqlite_backend.py:146-148`
- [x] No-history-refs: current-state framing only ("Cross-version restore is supported by construction")
- [x] Tier rule self-check: no tests added — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)