### PR TITLE
feat(#2103): C2 — fail-closed cap-walk over topology profile bindings (gate-6 + gate-2)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2580,9 +2580,13 @@ class AgentRegistry:
         envelope, never re-grant (structural: one more conjunct in ``all(...)``).
         ``sid=None`` or no file → byte-identical (inert).
 
-        A bound-but-missing or malformed profile file is surfaced (stderr) and
-        skipped — a typo must not silently widen capability, but it also must not
-        crash session construction.
+        **#2103 C2 (gate-6) fail-closed cap-walk:** a DECLARED topology binding whose
+        profile file is ABSENT or MALFORMED is surfaced (stderr) and composes the
+        restrictive ``_delegate`` floor — it FAILS CLOSED, not skips, so a deleted /
+        corrupt narrowing cannot silently widen the member (delete-to-uncap). This is
+        distinct from *no binding declared* (``profile_for`` → None), which correctly
+        skips (present-but-unrestricted). Existence (file present vs absent) is the
+        discriminator, mirroring the lineage #2161 fix. It never crashes construction.
         """
         from reyn.security.permissions.capability_profile import (
             compose_resolved,
@@ -2595,24 +2599,43 @@ class AgentRegistry:
         for topo in self.topologies_for_agent(agent):
             name = topo.profile_for(agent)
             if not name:
+                # No binding DECLARED for this member in this topology → present-but-
+                # unrestricted, nothing to impose (the analog of #2161's present-but-
+                # parent_ctx-None skip). Distinct from a DECLARED-but-unresolvable
+                # binding below, which fails CLOSED.
                 continue
             path = self._capability_profile_dir / f"{name}.yaml"
             if not path.is_file():
+                # #2103 C2 (gate-6, generalising #2161): a binding IS declared (the
+                # member is meant to be NARROWED by {name}) but its profile file is
+                # ABSENT (purged / typo / archived-then-GC'd). FAIL CLOSED — compose the
+                # restrictive _delegate floor, NOT skip. Skipping is the fail-OPEN
+                # escalation: the declared narrowing silently vanishes → the member
+                # resolves WIDER than intended (delete-the-profile-to-uncap-the-member).
+                # Existence (file present vs absent) distinguishes this from the
+                # no-binding-declared skip above. Mirror of the lineage #2161 fix.
                 import sys
                 print(
                     f"warning: capability_profile {name!r} (bound in topology "
-                    f"{topo.name!r}) not found at {path}",
+                    f"{topo.name!r}) not found at {path} — failing closed (floor)",
                     file=sys.stderr,
                 )
+                resolved.append(resolve_profile(load_delegate_profile(self._project_root)))
                 continue
             try:
                 prof = load_capability_profile(path)
             except Exception as e:  # noqa: BLE001 — hand-edited yaml, surface not crash
+                # #2103 C2 (gate-6): a declared binding whose file is PRESENT but
+                # MALFORMED is likewise unresolvable → FAIL CLOSED (floor), not skip — a
+                # corrupt narrowing must not silently widen the member. (It also must
+                # not crash session construction, hence floor-and-continue not raise.)
                 import sys
                 print(
-                    f"warning: skipping malformed capability_profile {path.name}: {e}",
+                    f"warning: malformed capability_profile {path.name}: {e} "
+                    "— failing closed (floor)",
                     file=sys.stderr,
                 )
+                resolved.append(resolve_profile(load_delegate_profile(self._project_root)))
                 continue
             resolved.append(resolve_profile(prof))
 

--- a/tests/test_2103_C2_fail_closed_capwalk_1953.py
+++ b/tests/test_2103_C2_fail_closed_capwalk_1953.py
@@ -1,0 +1,135 @@
+"""Tier 2: #2103 C2 — fail-closed cap-walk over topology profile bindings (gate-6 + gate-2).
+
+gate-6 (generalising the #2161 lineage fix to the topology-profile path): a DECLARED
+topology capability_profile binding whose profile file is ABSENT or MALFORMED must FAIL
+CLOSED — compose the restrictive _delegate floor, NOT silently skip. Skipping is the
+fail-OPEN escalation (delete/corrupt the profile → the declared narrowing vanishes → the
+member resolves WIDER than intended). The discriminator vs a benign skip is EXISTENCE: a
+binding declared-but-unresolvable fails closed; NO binding declared stays unrestricted
+(present-but-unrestricted, byte-identical — the analog of #2161's present-but-None skip).
+
+gate-2 (can_send member-restriction): a topology's permit() edges are confined to its
+members; since C1 restricts an LLM-created topology's members to the creator's spawn
+subtree, the edges are confined to the subtree by construction — no broader reach-check
+(lead Q2 steer). Confirmed here.
+
+The cascade live-prune of a purged member's profiles[member] (sandbox_2's #2162) is
+verified by tests/test_cascade_profile_preserve_2103.py (referenced, not duplicated).
+
+Real AgentRegistry + StateLog + on-disk topology/profile YAML + RouterHostAdapter (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import tool_contextually_denied
+from tests._support.router_host_adapter import make_adapter
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log
+    )
+
+
+def _bind(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    """Write a topology binding `member`→`profile` and the profile YAML (on disk, no mock)."""
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / f"{member}.yaml").write_text(
+        f"name: {member}\nkind: network\nmembers: [{member}, peer]\nprofiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+def _profile_path(tmp_path: Path, profile: str) -> Path:
+    return tmp_path / ".reyn" / "capability_profiles" / f"{profile}.yaml"
+
+
+# ── gate-6: declared-but-unresolvable binding → fail closed ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_bound_profile_fails_closed(tmp_path):
+    """Tier 2: (LOAD-BEARING falsification) a member bound to a profile whose file is then
+    DELETED (purge / typo) still resolves CAPPED (the _delegate floor), NOT widened to
+    unrestricted. RED if the missing-file branch skips (continue) instead of composing the
+    floor — the skip is the delete-to-uncap fail-open escalation #2161 closed for lineage."""
+    _bind(tmp_path, member="m", profile="narrow",
+          body="name: narrow\ntool_deny: [marker_tool]\n")
+    reg = _registry(tmp_path)
+    reg.create("m")
+    reg.create("peer")
+
+    # control: with the profile present, the declared narrowing resolves
+    c0, _ = reg.resolved_profile_for("m")
+    assert c0 is not None
+    assert tool_contextually_denied(c0, "marker_tool")
+
+    # purge the bound profile file → the declared narrowing is now unresolvable
+    _profile_path(tmp_path, "narrow").unlink()
+
+    # FAIL CLOSED: still capped (floor), NOT None/unrestricted
+    c1, _ = reg.resolved_profile_for("m")
+    assert c1 is not None  # a skip would yield None (no layer) = unrestricted = ESCALATION
+    assert tool_contextually_denied(c1, "sandboxed_exec")  # a floored ("spawn"-peer) class
+    assert tool_contextually_denied(c1, "agent_spawn")     # the spawn class, floored
+
+
+@pytest.mark.asyncio
+async def test_malformed_bound_profile_fails_closed(tmp_path):
+    """Tier 2: a declared binding whose profile file is PRESENT but MALFORMED is likewise
+    unresolvable → FAIL CLOSED (floor), not skip. RED if the malformed branch skips."""
+    _bind(tmp_path, member="m", profile="broken", body="name: broken\ntool_deny: [marker_tool]\n")
+    reg = _registry(tmp_path)
+    reg.create("m")
+    reg.create("peer")
+    # corrupt the YAML (a mapping value that won't parse into a profile)
+    _profile_path(tmp_path, "broken").write_text(": : not valid yaml : :\n", encoding="utf-8")
+
+    c, _ = reg.resolved_profile_for("m")
+    assert c is not None  # fail-closed, not skipped-to-None
+    assert tool_contextually_denied(c, "sandboxed_exec")
+
+
+@pytest.mark.asyncio
+async def test_no_binding_declared_stays_unrestricted(tmp_path):
+    """Tier 2: (the discriminator) a member with NO topology binding declared resolves
+    UNRESTRICTED (None, byte-identical to pre-#1827) — fail-closed must fire ONLY on a
+    declared-but-unresolvable binding, never on the benign no-binding case. RED if gate-6
+    over-broadly floors an unbound member (the over-restriction failure mode)."""
+    reg = _registry(tmp_path)
+    reg.create("solo")
+
+    contextual, excluded = reg.resolved_profile_for("solo")
+    assert contextual is None and excluded == frozenset()
+
+
+# ── gate-2: edges confined to (subtree) members ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_topology_create_edges_confined_to_subtree_members(tmp_path):
+    """Tier 2: a topology_create'd network permits messaging only AMONG its members — and
+    since C1 restricts members to the creator's spawn subtree, the edges are confined to
+    the subtree by construction (gate-2, no broader reach-check). An agent outside the
+    topology shares no edge with a member."""
+    reg = _registry(tmp_path)
+    reg.create("coord")
+    await reg.create_agent("worker", parent="coord")
+    reg.create("outsider")  # operator-top, not wired by coord
+    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+
+    res = await adapter.create_topology(name="org", kind="network", members=["coord", "worker"])
+    assert res["status"] == "created"
+
+    assert reg.permit("coord", "worker")        # edge within the (subtree) members
+    assert not reg.permit("coord", "outsider")  # no edge to a non-member outside the topology


### PR DESCRIPTION
**[e2e-coder]** — #2103 **C2** (fail-closed cap-walk), the gate-6 hardening lead pre-registered as a required C property. **No-merge** until lead close-review + tui verify.

## What
Generalises the **#2161** lineage fail-closed fix to the **topology-profile** cap-walk in `resolved_profile_for`.

- **gate-6 (fail-closed):** a **declared** topology `capability_profile` binding whose profile file is **absent or malformed** now composes the restrictive `_delegate` floor instead of silently `continue`-ing. Skipping was the fail-**open** escalation (delete/corrupt the bound profile → the declared narrowing vanishes → the member resolves **wider** than intended = delete-to-uncap). The discriminator vs a benign skip is **existence**: declared-but-unresolvable → fail-closed; **no** binding declared (`profile_for → None`) → present-but-unrestricted (byte-identical to pre-#1827, the analog of #2161's present-but-None skip).
- **gate-2 (can_send member-restriction):** confirmed — a topology's `permit()` edges are confined to its members, and since C1 restricts an LLM-created topology's members to the creator's spawn subtree, edges are subtree-confined **by construction** (no broader reach-check, per the Q2 steer). Test-only, no new code.
- **#2162 verify:** the cascade live-prune of `profiles[member]` on purge (sandbox_2's lane) is **verified by `tests/test_cascade_profile_preserve_2103.py`** — referenced, not re-implemented (per lead directive).

## Tests (Tier 2; real AgentRegistry + StateLog + on-disk YAML, no mocks)
- **LOAD-BEARING** missing-profile fail-closed falsification: bind → delete profile file → resolve → **still capped, not widened** — **verified RED when reverted to skip**, GREEN restored
- malformed-profile fail-closed variant
- the **no-binding-declared discriminator** (an unbound member stays unrestricted — fail-closed must not over-floor)
- gate-2 edge-confinement confirmation

## CI (all green locally)
- `ruff check src tests scripts` — clean
- `scripts/test_tier_audit.py --strict` — OK
- `pytest` (rootdir) — **8492 passed**; the only 4 failures (`gateway/*` entry-points + `reyn_api_relocate`) are **pre-existing on clean main** (entry-point/packaging env quirks, unrelated). No replay/baseline churn (C2 adds no tool; touches only `resolved_profile_for`).

## Scope / sequencing
The spawn-**lineage** name-reuse-after-purge gap (**#2166**, tui-found in C1 live-verify) is a **distinct representation** (`_spawn_lineage` + `is_spawn_descendant`, **not** the topology-profile path C2 touches) → handled next as **C2b: identity-keyed lineage** (lead-triaged: key on a stable identity, not prune-on-purge). C2's topology-profile fail-closed is **non-overlapping** with that fix.

## Test plan
- [x] Full rootdir pytest (8492 passed; 4 pre-existing unrelated)
- [x] ruff full-tree + tier-audit
- [x] gate-6 fail-closed falsification verified RED-when-reverted-to-skip
- [x] #2162 cascade-preserve verified (sandbox_2's test passes)
- [ ] (lead) close-review the fail-closed compose-target (`_delegate` floor) + the declared-vs-no-binding discriminator
- [ ] (tui) optional verify — gate-6 is a resolve-path Tier-2; no new LLM surface

Refs #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)