### PR TITLE
feat(#2103): C2b — identity-keyed spawn lineage (name-reuse-after-purge, #2166)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -191,7 +191,26 @@ class AgentRegistry:
         # effective as a restrict-only conjunct → spawned ⊆ parent by construction,
         # recursively (no-escalation-via-spawn). WAL-carried on agent_created for
         # rewind-reconstruction.
-        self._spawn_lineage: "dict[str, str]" = {}
+        #
+        # #2103 C2b (#2166): the edge value is keyed on the parent's stable IDENTITY,
+        # not its reusable name — child → (parent_name, parent_identity). A purged +
+        # name-REUSED parent gets a NEW identity, so the orphan's stored edge identity
+        # mismatches → the edge is STALE → resolved_profile_for #2161-fail-closes and
+        # is_spawn_descendant rejects (fixes both consumers from one identity check;
+        # composes with #2161's absent-parent existence-check). The identity is minted
+        # in create_agent (the spawn seam): the agent_created WAL seq when a state_log
+        # is present, else an in-memory monotonic counter (Q1: every create_agent parent
+        # is identity-tracked → name-reuse always detected for real spawn lineages; a
+        # bare-``create()`` non-spawn parent has no identity → None → #2161 existence
+        # fallback, no false-positive, Q2).
+        self._spawn_lineage: "dict[str, tuple[str, int | None]]" = {}
+        # #2103 C2b: name → its CURRENT stable identity (the create_agent-minted token).
+        # Rebuilt as-of-cut on rewind (_materialize_rewind). A name-reused agent has a
+        # NEW token here, so a stored edge carrying the OLD token reads as stale.
+        self._agent_create_seq: "dict[str, int]" = {}
+        # #2103 C2b: the no-WAL identity source (monotonic; only used when state_log is
+        # None — there is no rewind to reconstruct against in that mode).
+        self._spawn_create_counter: int = 0
         # #2081: delegation policy. ``deny`` narrows an UNBOUND delegate with the
         # restrictive _delegate floor; ``inherit`` (default) = byte-identical to
         # pre-#2081. ``_constructing_as_delegate`` is the transient is_delegate
@@ -441,14 +460,19 @@ class AgentRegistry:
         re-set to a DIFFERENT parent is refused, and a self-link is rejected. Acyclic
         by construction — the parent pre-exists and the child is freshly created, so a
         child can never be an ancestor of its parent. Idempotent on the same parent
-        (rewind-reconstruction may replay the same edge)."""
+        (rewind-reconstruction may replay the same edge).
+
+        #2103 C2b: the edge stores ``(parent_name, parent_identity)`` — the parent's
+        identity FROZEN at spawn time (``_agent_create_seq.get(parent)``; None when the
+        parent was not minted via create_agent, e.g. a bare-``create()`` operator agent).
+        Immutability/cycle compare by NAME (the identity is metadata for staleness)."""
         if child == parent:
             raise ValueError(f"spawn-lineage self-link rejected: {child!r}")
         existing = self._spawn_lineage.get(child)
-        if existing is not None and existing != parent:
+        if existing is not None and existing[0] != parent:
             raise ValueError(
                 f"spawn-lineage for {child!r} is immutable "
-                f"(set to {existing!r}; refused re-set to {parent!r})")
+                f"(set to {existing[0]!r}; refused re-set to {parent!r})")
         # cycle-guard (B-core close-review note): the parent must not already be a
         # DESCENDANT of the child — walking the parent's lineage to the root must not
         # reach the child. Acyclic-by-construction holds for a fresh spawn (the parent
@@ -461,8 +485,9 @@ class AgentRegistry:
                 raise ValueError(
                     f"spawn-lineage cycle rejected: {parent!r} is a descendant of {child!r}")
             seen.add(cursor)
-            cursor = self._spawn_lineage.get(cursor)
-        self._spawn_lineage[child] = parent
+            _edge = self._spawn_lineage.get(cursor)
+            cursor = _edge[0] if _edge is not None else None
+        self._spawn_lineage[child] = (parent, self._agent_create_seq.get(parent))
 
     def is_spawn_descendant(self, agent: str, ancestor: str) -> bool:
         """#2103 C1: True iff ``agent`` is ``ancestor`` itself OR a transitive spawn-
@@ -475,17 +500,32 @@ class AgentRegistry:
         creator, so ``resolved_profile_for``'s live parent-conjunct (B-core) backstops
         the binding (it can only narrow within the member's ⊆-creator envelope, never
         re-grant past it). An agent with no lineage edge (operator-top) is in no one's
-        subtree but its own → an LLM cannot wire a non-descendant peer."""
+        subtree but its own → an LLM cannot wire a non-descendant peer.
+
+        #2103 C2b (#2166): a STALE edge — its parent name was purged + REUSED, so the
+        frozen parent identity no longer matches the current ``_agent_create_seq[name]``
+        — is a dangling link to a GONE identity, NOT a real ancestry. The walk stops at
+        it (returns False), so a name-reused agent is rejected as a forged ancestor (the
+        C1 forge-guard bypass tui found). A None identity (untracked parent) carries no
+        staleness signal → the link is honoured (the #2161 existence-check governs that
+        case at resolve time)."""
         if agent == ancestor:
             return True
-        cursor: "str | None" = self._spawn_lineage.get(agent)
+        cursor: str = agent
         seen: "set[str]" = set()
-        while cursor is not None and cursor not in seen:
-            if cursor == ancestor:
+        while True:
+            edge = self._spawn_lineage.get(cursor)
+            if edge is None:
+                return False
+            pname, pseq = edge
+            if pseq is not None and self._agent_create_seq.get(pname) != pseq:
+                return False  # stale (name-reused parent) → dangling, not a real link
+            if pname == ancestor:
                 return True
-            seen.add(cursor)
-            cursor = self._spawn_lineage.get(cursor)
-        return False
+            if pname in seen:
+                return False
+            seen.add(pname)
+            cursor = pname
 
     async def create_agent(
         self, name: str, *, role: str = "", parent: "str | None" = None
@@ -508,10 +548,16 @@ class AgentRegistry:
         profile = self.create(name, role=role)
         if parent is not None:
             self._record_spawn_lineage(name, parent)
+        # #2103 C2b: the parent's identity FROZEN at this spawn (the same value the edge
+        # stored) — carried on agent_created so a rewind reconstructs the edge with the
+        # parent-identity-AT-SPAWN (not the latest), so a rewind across a purge+name-reuse
+        # does not resurrect this child under the reused parent.
+        parent_seq = self._agent_create_seq.get(parent) if parent is not None else None
         if self._state_log is not None:
-            await self._state_log.append(
+            seq = await self._state_log.append(
                 "agent_created", entity_kind="agent", name=name, sid="",
                 parent=parent,  # #2103 B: lineage for rewind-reconstruction
+                parent_seq=parent_seq,  # #2103 C2b: parent identity-at-spawn (rewind)
                 profile={
                     "name": profile.name,
                     "role": profile.role,
@@ -520,6 +566,14 @@ class AgentRegistry:
                     "allowed_mcp": profile.allowed_mcp,
                 },
             )
+            # #2103 C2b: this agent's stable identity = its agent_created WAL seq.
+            self._agent_create_seq[name] = seq
+        else:
+            # #2103 C2b Q1: no-WAL fallback — a monotonic counter (no rewind to
+            # reconstruct against here), so a create_agent parent is ALWAYS identity-
+            # tracked and name-reuse is detected even without a state_log.
+            self._spawn_create_counter += 1
+            self._agent_create_seq[name] = self._spawn_create_counter
         return profile
 
     def remove(self, name: str, *, purge: bool = False) -> "list[tuple[str, Topology | None]]":
@@ -1277,18 +1331,21 @@ class AgentRegistry:
 
     def _agent_lifecycle(
         self,
-    ) -> "tuple[dict[str, tuple[int, dict, str | None]], dict[str, int], set[str]]":
+    ) -> "tuple[dict[str, tuple[int, dict, str | None, int | None]], dict[str, int], set[str]]":
         """#2103 S2: one WAL scan → the agent-lifecycle state (created, archived,
         purged):
-        - created: name → (create_seq, profile-payload, parent) from ``agent_created``
-          (the payload re-materialises the profile on a forward-checkout-past-drop;
-          ``parent`` (#2103 B) rebuilds the spawn lineage as-of-cut so a re-materialised
-          child regains its ⊆-parent cap — else escalation-on-rewind).
+        - created: name → (create_seq, profile-payload, parent, parent_seq) from
+          ``agent_created`` (the payload re-materialises the profile on a
+          forward-checkout-past-drop; ``parent`` (#2103 B) rebuilds the spawn lineage
+          as-of-cut so a re-materialised child regains its ⊆-parent cap — else
+          escalation-on-rewind; ``parent_seq`` (#2103 C2b) is the parent's identity
+          AT-SPAWN, so the rebuilt edge reads STALE if the parent name was later
+          purged+reused → no resurrection of the child under the reused parent).
         - archived: name → latest ``agent_archived`` seq (the as-of-cut hide hinge).
         - purged: names with an ``agent_purged`` event (fork A: permanent — never
           re-materialised at any cut).
         Empty without a WAL. Inert until S2b emits the events."""
-        created: dict[str, tuple[int, dict, "str | None"]] = {}
+        created: dict[str, tuple[int, dict, "str | None", "int | None"]] = {}
         archived: dict[str, int] = {}
         purged: set[str] = set()
         if self._state_log is None:
@@ -1302,10 +1359,12 @@ class AgentRegistry:
             if kind == "agent_created":
                 payload = entry.get("profile")
                 _parent = entry.get("parent")
+                _parent_seq = entry.get("parent_seq")  # #2103 C2b: parent identity-at-spawn
                 created[name] = (
                     seq,
                     payload if isinstance(payload, dict) else {},
                     _parent if isinstance(_parent, str) else None,
+                    _parent_seq if isinstance(_parent_seq, int) else None,
                 )
             elif kind == "agent_archived":
                 archived[name] = seq  # last wins = the latest archival
@@ -1575,7 +1634,7 @@ class AgentRegistry:
         # #2103 S2 re-materialise: an agent created ≤ cut, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
         # so a forward-checkout-past-drop brings it back (the inverse of the drop).
-        for _rname, (_rcseq, _rpayload, _rparent) in ag_created.items():
+        for _rname, (_rcseq, _rpayload, _rparent, _rpseq) in ag_created.items():
             if _rname in ag_purged:
                 continue  # fork A: purged = permanent, never re-materialised
             if _rcseq <= drop_cut and not (self._dir / _rname).is_dir():
@@ -1636,8 +1695,20 @@ class AgentRegistry:
         # edge for a present child (resolved_profile_for would then skip the
         # parent-conjunct → un-capped). Assigned directly (the WAL is the trusted source;
         # the forge/cycle guards already ran at spawn time).
+        #
+        # #2103 C2b: rebuild the identity map (name → create_seq) for present-as-of-cut
+        # agents FIRST, so the staleness check has the current identity to compare each
+        # edge's FROZEN parent identity against. The edge keeps the parent identity
+        # AT-SPAWN (the recorded ``parent_seq``, ``_pseq``); if the parent name was later
+        # purged + REUSED, the reused parent's create_seq differs → the edge reads STALE
+        # → resolved_profile_for fail-closes + is_spawn_descendant rejects = no
+        # resurrection of the orphan under the reused parent on a forward checkout.
+        self._agent_create_seq = {
+            _n: _s for _n, (_s, _payload, _p, _pseq) in ag_created.items()
+            if _s <= drop_cut and _n not in ag_purged and (self._dir / _n).is_dir()
+        }
         self._spawn_lineage = {
-            _n: _p for _n, (_s, _payload, _p) in ag_created.items()
+            _n: (_p, _pseq) for _n, (_s, _payload, _p, _pseq) in ag_created.items()
             if _p and _s <= drop_cut and _n not in ag_purged and (self._dir / _n).is_dir()
         }
         await self._restore_workspace_active(at_or_below=workspace_at_or_below)
@@ -2674,18 +2745,27 @@ class AgentRegistry:
         # with its OWN delegate-status (is_delegate=None → its construction transient)
         # at the agent envelope (no sid). A forged/absent lineage simply isn't here
         # (OS-set), so it cannot widen.
-        parent = self._spawn_lineage.get(agent)
-        if parent is not None:
-            if not (self._dir / parent).is_dir():
-                # #2161 (tui-found, pre-merge): the lineage edge points to an ABSENT
-                # parent (purged / archived-then-gone / crash / fs-delete) — the capping
-                # parent is gone, so ⊆-parent CANNOT be verified. FAIL CLOSED: compose
-                # the restrictive _delegate floor (NOT skip — skipping is the fail-open
-                # escalation: purge-the-parent-to-uncap-the-child). This is DISTINCT from
-                # a PRESENT-but-unrestricted parent (parent_ctx is None in the else
-                # branch → correctly skipped, no cap to impose). Checking EXISTENCE (not
-                # just parent_ctx is None) resolves that ambiguity. One seam → covers
-                # every cap-drop cause; the destroy-side mirror of the rewind rebuild.
+        edge = self._spawn_lineage.get(agent)
+        if edge is not None:
+            parent, parent_seq = edge
+            # #2103 C2b (#2166): the stored edge froze the parent's identity at spawn. If
+            # the parent name was purged + REUSED, the current identity differs → the edge
+            # is STALE (it points to a GONE identity, not the live same-named agent). Treat
+            # exactly like an absent parent: FAIL CLOSED. (A None frozen identity = a
+            # parent never minted via create_agent → no staleness signal → the absent-vs-
+            # present existence-check below governs, Q2 — no false-positive.)
+            stale = (
+                parent_seq is not None
+                and self._agent_create_seq.get(parent) != parent_seq
+            )
+            if stale or not (self._dir / parent).is_dir():
+                # #2161 (absent parent) + #2166 (name-reused → stale identity): the capping
+                # parent's identity is gone, so ⊆-parent CANNOT be verified. FAIL CLOSED:
+                # compose the restrictive _delegate floor (NOT skip — skipping is the
+                # fail-open escalation: purge/reuse-the-parent-to-uncap-the-child). DISTINCT
+                # from a PRESENT-but-unrestricted parent (parent_ctx is None in the else
+                # branch → correctly skipped, no cap to impose). One seam covers every
+                # cap-drop cause (purge, name-reuse, crash, fs-delete).
                 resolved.append(resolve_profile(load_delegate_profile(self._project_root)))
             else:
                 parent_ctx, parent_excl = self.resolved_profile_for(parent)

--- a/tests/test_2103_C2b_identity_keyed_lineage_1953.py
+++ b/tests/test_2103_C2b_identity_keyed_lineage_1953.py
@@ -1,0 +1,133 @@
+"""Tier 2: #2103 C2b — identity-keyed spawn lineage (name-reuse-after-purge, #2166).
+
+`_spawn_lineage` keys the parent edge on a stable IDENTITY (the create_agent-minted
+create-seq), not the reusable name. A purged + name-REUSED parent gets a NEW identity, so
+an orphan's stored edge (frozen at the OLD identity) reads STALE — defeating BOTH the
+name-reuse escalation vectors tui found in the C1 live-verify:
+
+- Probe A (forge-guard bypass): is_spawn_descendant(orphan, reused_name) must be False, so
+  the reused-name agent cannot topology_create-wire an agent it never spawned.
+- Probe B (capability escalation): resolved_profile_for(orphan) must FAIL CLOSED (the
+  stale edge → the _delegate floor), so the orphan does NOT inherit the new same-named
+  parent's (wider) capability.
+
+The identity is minted in create_agent — the PRODUCTION spawn seam (CLI / web / slash /
+agent_spawn all route through it). A bare ``reg.create()`` (non-spawn operator/test agent)
+is the accepted Q2 fallback: no identity → #2161 existence-check governs (no false-positive).
+
+The REWIND-across-reuse half (the destroy-side mirror) + the productionized probes are
+tui's lane; this file covers the LIVE registry behaviour. Real AgentRegistry + StateLog
++ RouterHostAdapter (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import tool_contextually_denied
+from tests._support.router_host_adapter import make_adapter
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log
+    )
+
+
+def _bind(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / f"{member}.yaml").write_text(
+        f"name: {member}\nkind: network\nmembers: [{member}, peer]\nprofiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+# ── identity assignment ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_agent_mints_distinct_identity_on_name_reuse(tmp_path):
+    """Tier 2: create_agent assigns a stable identity; a purged+recreated name gets a
+    DIFFERENT identity (the discriminator the staleness check keys on)."""
+    reg = _registry(tmp_path)
+    await reg.create_agent("coord")
+    id1 = reg._agent_create_seq["coord"]
+    await reg.archive_agent("coord", purge=True)
+    await reg.create_agent("coord")
+    id2 = reg._agent_create_seq["coord"]
+    assert id1 != id2  # name reused → new identity
+
+
+# ── probe A: forge-guard bypass (live) ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_name_reuse_after_purge_rejects_orphan_forge_guard(tmp_path):
+    """Tier 2: (LOAD-BEARING falsification, tui probe A) purge a create_agent'd spawn-parent
+    + reuse the name → is_spawn_descendant rejects the orphan (frozen edge identity ≠ the
+    reused parent's new identity), so the reused-name agent cannot topology_create-wire the
+    orphan it never spawned. RED on the name-keyed lineage (#2166)."""
+    reg = _registry(tmp_path)
+    await reg.create_agent("coord")                      # operator-top, identity-tracked
+    await reg.create_agent("worker", parent="coord")     # edge: worker → (coord, id1)
+    assert reg.is_spawn_descendant("worker", "coord")    # control: real descendant
+
+    await reg.archive_agent("coord", purge=True)
+    await reg.create_agent("coord")                      # name reused → NEW identity
+
+    assert not reg.is_spawn_descendant("worker", "coord")  # stale edge → not a descendant
+
+    # forge-guard: the reused-name coord cannot wire the orphan it never spawned
+    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    res = await adapter.create_topology(
+        name="grab", kind="network", members=["coord", "worker"],
+    )
+    assert res["status"] == "error"
+    assert res["kind"] == "member_outside_subtree"
+
+
+@pytest.mark.asyncio
+async def test_no_reuse_preserves_subtree_membership(tmp_path):
+    """Tier 2: (boundary control) WITHOUT name-reuse, the live edge identity still matches →
+    subtree membership preserved (the fix must not over-reject a genuine descendant)."""
+    reg = _registry(tmp_path)
+    await reg.create_agent("coord")
+    await reg.create_agent("worker", parent="coord")
+    assert reg.is_spawn_descendant("worker", "coord")
+    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    res = await adapter.create_topology(name="org", kind="network", members=["coord", "worker"])
+    assert res["status"] == "created"
+
+
+# ── probe B: capability escalation (live) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_name_reuse_after_purge_fails_closed_no_cap_escalation(tmp_path):
+    """Tier 2: (LOAD-BEARING falsification, tui probe B) an orphan capped ⊆ a purged parent
+    does NOT inherit a reused same-named parent's wider capability — the stale edge FAILS
+    CLOSED (the _delegate floor). RED on the name-keyed lineage (orphan would resolve under
+    the new coord → lose the old parent's deny)."""
+    # old coord bound to a profile that denies sandboxed_exec → worker ⊆ coord inherits it
+    _bind(tmp_path, member="coord", profile="tight",
+          body="name: tight\ntool_deny: [sandboxed_exec]\n")
+    reg = _registry(tmp_path)
+    await reg.create_agent("coord")
+    await reg.create_agent("worker", parent="coord")
+    c0, _ = reg.resolved_profile_for("worker")
+    assert c0 is not None and tool_contextually_denied(c0, "sandboxed_exec")  # capped ⊆ coord
+
+    await reg.archive_agent("coord", purge=True)
+    await reg.create_agent("coord")  # name reused → NEW identity (no tight binding now)
+
+    c1, _ = reg.resolved_profile_for("worker")
+    assert c1 is not None  # fail-closed, NOT skipped-to-unrestricted
+    assert tool_contextually_denied(c1, "sandboxed_exec")  # STILL denied (floor) — no escalation


### PR DESCRIPTION
**[e2e-coder]** — #2103 **C2b** = the **#2166** root fix (tui-found in C1 live-verify). **No-merge** until lead close-review + tui's rewind-path verify/test-fold.

## What
`_spawn_lineage` was keyed on the agent **NAME** + never identity-checked → purging a spawn-parent and **reusing the name** silently re-pointed the orphan's stale edge at the NEW same-named agent, defeating **both** consumers:
- **#2161's existence-check** passes for a present reused name → `resolved_profile_for` caps the orphan at the NEW (wider) parent = **cap escalation**.
- **C1's `is_spawn_descendant` forge-guard** treats the orphan as a descendant → the reused-name agent can `topology_create`-wire it = **forge-guard bypass**.

#2161 was an absent-only consumer-side patch; this is the **identity-keying root fix** (lead-triaged).

## Design (lead-approved representation + Q1/Q2 steer)
- Edge stores **`(parent_name, parent_IDENTITY)`** — the parent's identity **frozen at spawn**. New **`_agent_create_seq`** maps name → its **current** identity, minted in `create_agent`: the `agent_created` WAL seq when a state_log is present, **else an in-memory monotonic counter** (**Q1**: every `create_agent` parent is identity-tracked → name-reuse always detected for real spawn lineages).
- Staleness, one check, both consumers: **`edge LIVE iff _agent_create_seq[pname] == pseq`**. A reused name → new identity → stale → `is_spawn_descendant` rejects + `resolved_profile_for` **#2161-fail-closes** (unified with the absent-parent case).
- **Q2**: a bare-`create()` non-spawn parent has no identity → `None` → no staleness signal → **#2161 existence fallback** (no false-positive; the accepted non-spawn-flow limitation).

## Scope split (per lead: "5 live sites + hand tui the rewind tuple")
- **This PR (live path + the code)**: the 5 live sites + the `parent_seq` carry on `agent_created` + the `_agent_lifecycle` 4-tuple + the `_materialize_rewind` rebuild made repr-consistent (tuples) and correct via the **recorded** parent-identity-at-spawn (so a rewind across purge+reuse reads stale → no resurrection).
- **tui's lane (folds in / follow-on)**: the **rewind-path tests** (rewind-across-reuse non-resurrection + boundary) + the productionized **probes A/B**, and verification of the `_materialize_rewind` reconstruction (their #2158 symmetry expertise). ⚠️ **One nuance for tui to verify**: `_agent_lifecycle` aggregates `created[name]` last-wins across the whole log; a rewind to a cut *between* the two creates of a reused name keeps only the later (`> cut`) record → the orphan's parent reads absent → **#2161 fail-closed** (safe, but arguably over-strict for that rare cut — a pre-existing aggregation limitation, not a new regression; flagging for your reconstruction-symmetry call).

## Consumer audit (value-format change → tuple)
All 6 `_spawn_lineage` sites + the 2 `ag_created` unpack sites updated; full rootdir pytest verifies no rewind-consumer regression.

## Tests (Tier 2; real AgentRegistry + StateLog + RouterHostAdapter, no mocks)
- identity-on-reuse discriminator
- **LOAD-BEARING** live falsifications: **probe A** (forge-guard reject) + **probe B** (cap fail-closed, no escalation) — both **verified RED when the staleness check is stripped**, GREEN restored
- no-reuse boundary control (no over-rejection)

## CI (all green locally)
- `ruff check src tests scripts` — clean
- `scripts/test_tier_audit.py --strict` — 4/4 OK
- `pytest` (rootdir) — **8496 passed**; the only 4 failures (`gateway/*` + `reyn_api_relocate`) are **pre-existing on clean main** (env quirks, unrelated). No tool/replay/advertise churn.

## Test plan
- [x] Full rootdir pytest (8496 passed; 4 pre-existing)
- [x] ruff full-tree + tier-audit
- [x] probes A+B verified RED-when-staleness-stripped
- [ ] (lead) close-review the identity representation + the live/rewind split
- [ ] (tui) verify the `_materialize_rewind` reconstruction + fold the rewind-path tests + productionized probes A/B

Refs #2103, #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)