### PR TITLE
feat(#2103): C3 — operator spawn-tree bounds (safety.spawn.max_depth/max_children)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -416,6 +416,9 @@ safety:
     fence_enabled: true        # structurally fence untrusted content as data
     block_severity: block      # min severity that blocks at write seams: block | warn
     custom_patterns: []        # operator [regex, id, scope, severity] extensions
+  spawn:
+    max_depth: 10              # max LLM spawn-lineage chain depth (agent_spawn); 0 = unlimited
+    max_children: 20           # max fan-out: direct children per parent AND topology size; 0 = unlimited
 ```
 
 ### `safety.loop` fields
@@ -460,6 +463,15 @@ Content-layer threat defense: inspects untrusted content for prompt-injection be
 | `safety.threat_scan.fence_enabled` | bool | `true` | Structurally fence untrusted content (random-id markers + control-token strip + unicode normalization) so the LLM treats it as data, not instructions. For *which* content this applies to, see [Security: what gets structurally fenced](../../concepts/agent-engineering/security.md#what-gets-structurally-fenced). |
 | `safety.threat_scan.block_severity` | string | `block` | Minimum severity that BLOCKS at agent-write seams (memory write / skill install). `block` = only `block`-severity patterns; `warn` = warn-severity also blocks (stricter). |
 | `safety.threat_scan.custom_patterns` | list | `[]` | Operator pattern extensions, each `[regex, id, scope, severity]`. Merged into the built-in catalog for scans. |
+
+### `safety.spawn` fields
+
+Operator bounds on the LLM spawn tree (#2103 C3) — a DoS guard so an agent cannot mint an unbounded org. Set in `reyn.yaml` (the restart-only OUT layer): an LLM has no runtime path to raise its own limit. Enforced at the LLM spawn **seams** (`agent_spawn`, `topology_create`); the operator CLI create path is unbounded (authority). Defense-by-default (non-zero) — there is no backward-compat spawn tree to break.
+
+| Path | Type | Default | Description |
+|------|------|---------|-------------|
+| `safety.spawn.max_depth` | int | `10` | Maximum spawn-lineage chain depth (operator-top = 0; each `agent_spawn` +1). A spawn whose child would exceed this is rejected. `0` = unlimited. |
+| `safety.spawn.max_children` | int | `20` | Maximum fan-out: governs BOTH the direct spawn-children per parent (`agent_spawn`) AND the member count of a `topology_create`d topology (org size). A spawn / wire that would exceed it is rejected. `0` = unlimited. |
 
 ## `time_travel` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -598,6 +598,9 @@
 #     fence_enabled: true           # structurally fence untrusted content as data
 #     block_severity: block         # min severity that blocks at write seams: block | warn
 #     custom_patterns: []           # operator [regex, id, scope, severity] extensions
+#   spawn:                          # #2103 C3: operator bounds on the LLM spawn tree (DoS guard)
+#     max_depth: 10                 # max spawn-lineage chain depth (agent_spawn); 0 = unlimited
+#     max_children: 20              # max fan-out: direct children per parent AND topology size; 0 = unlimited
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -214,6 +214,38 @@ class CostWarnConfig:
 
 
 @dataclass
+class SpawnConfig:
+    """`safety.spawn:` — operator bounds on the LLM spawn tree (#2103 C3).
+
+    A DoS guard: the LLM spawn primitives (``agent_spawn`` create a child,
+    ``topology_create`` wire an org) must not let an agent mint an unbounded
+    spawn tree. These caps are **operator-set in reyn.yaml** (the restart-only OUT
+    layer) — an LLM has no runtime path to raise its own limit (a self-raisable
+    limit is no limit). Enforced at the LLM spawn SEAMS (host adapter): an operator
+    creating agents via the CLI is unbounded (authority), consistent with the C1
+    subtree forge-guard scope.
+
+    Defense-by-default: non-zero defaults protect out of the box (there is no
+    backward-compat spawn-tree to break — the primitives are new in #2103). Raise
+    them in reyn.yaml when an org legitimately needs a deeper / wider tree.
+
+    Fields:
+        max_depth:
+            Maximum spawn-LINEAGE chain depth (operator-top = 0; a child spawned
+            under it = 1; …). A spawn that would make the new child's depth exceed
+            this is rejected. ``0`` = unlimited.
+        max_children:
+            Maximum FAN-OUT. Governs BOTH (a) the number of direct spawn-children a
+            single parent may have (``agent_spawn``) AND (b) the member count of a
+            ``topology_create``d topology (org size). A spawn/wire that would exceed
+            it is rejected. ``0`` = unlimited.
+    """
+
+    max_depth: int = 10
+    max_children: int = 20
+
+
+@dataclass
 class SafetyConfig:
     """`safety:` — unified, user-facing namespace for stop conditions.
 
@@ -243,6 +275,7 @@ class SafetyConfig:
     timeout: TimeoutConfig = field(default_factory=TimeoutConfig)
     on_limit: OnLimitConfig = field(default_factory=OnLimitConfig)
     threat_scan: ThreatScanConfig = field(default_factory=ThreatScanConfig)
+    spawn: SpawnConfig = field(default_factory=SpawnConfig)  # #2103 C3: spawn-tree bounds
 
 
 @dataclass
@@ -644,8 +677,17 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         block_severity=str(threat_scan_raw.get("block_severity", ts_defaults.block_severity)),
         custom_patterns=list(custom_patterns_raw) if isinstance(custom_patterns_raw, list) else list(ts_defaults.custom_patterns),
     )
+    spawn_raw = raw.get("spawn") or {}
+    if not isinstance(spawn_raw, dict):
+        spawn_raw = {}
+    spawn_defaults = SpawnConfig()
+    spawn = SpawnConfig(
+        max_depth=int(spawn_raw.get("max_depth", spawn_defaults.max_depth)),
+        max_children=int(spawn_raw.get("max_children", spawn_defaults.max_children)),
+    )
     return SafetyConfig(
         loop=loop, timeout=timeout, on_limit=on_limit, threat_scan=threat_scan,
+        spawn=spawn,
     )
 
 

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -37,10 +37,14 @@ class SessionFactoryConfig:
     retry_config: Any
     tool_calls_op_loop_skills: "list[str] | None"
     chat_tool_use_scheme: str
-    # ── AgentRegistry uniform config (3) ────────────────────────────────────
+    # ── AgentRegistry uniform config (5) ────────────────────────────────────
     workspace_capture: bool
     act_turn_capture: bool
     delegation_capability_default: str
+    # #2103 C3: operator spawn-tree bounds (safety.spawn.*) — the LLM spawn seams
+    # enforce these; 0 = unlimited.
+    max_spawn_depth: int
+    max_spawn_children: int
 
     @classmethod
     def from_config(cls, config: Any) -> "SessionFactoryConfig":
@@ -58,4 +62,6 @@ class SessionFactoryConfig:
             workspace_capture=config.time_travel.workspace_capture,
             act_turn_capture=config.time_travel.act_turn_capture,
             delegation_capability_default=config.delegation.capability_default,
+            max_spawn_depth=config.safety.spawn.max_depth,
+            max_spawn_children=config.safety.spawn.max_children,
         )

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -150,6 +150,8 @@ class AgentRegistry:
         workspace_capture: bool = True,
         act_turn_capture: bool = False,
         delegation_capability_default: str = "inherit",
+        max_spawn_depth: int = 0,
+        max_spawn_children: int = 0,
         factory_config: "object | None" = None,
         create_event_kinds: "frozenset[str] | None" = None,
     ) -> None:
@@ -175,6 +177,14 @@ class AgentRegistry:
             workspace_capture = factory_config.workspace_capture
             act_turn_capture = factory_config.act_turn_capture
             delegation_capability_default = factory_config.delegation_capability_default
+            max_spawn_depth = factory_config.max_spawn_depth
+            max_spawn_children = factory_config.max_spawn_children
+        # #2103 C3: operator spawn-tree bounds (safety.spawn.*), enforced at the LLM
+        # spawn seams (host adapter). 0 = unlimited. Util/test callers default to
+        # unlimited (byte-identical); the 5 frontend factory sites supply them via the
+        # factory_config bundle.
+        self._max_spawn_depth = max_spawn_depth
+        self._max_spawn_children = max_spawn_children
         self._dir = project_root / ".reyn" / "agents"
         self._dir.mkdir(parents=True, exist_ok=True)
         self._topology_dir = project_root / ".reyn" / TOPOLOGY_DIRNAME
@@ -526,6 +536,72 @@ class AgentRegistry:
                 return False
             seen.add(pname)
             cursor = pname
+
+    # ── #2103 C3: operator spawn-tree bounds (safety.spawn.*) ───────────────────────
+    # Computed over the SAME identity-keyed lineage as the cap-walk, so a stale
+    # (name-reused) edge does not inflate the counts. Enforced at the LLM spawn SEAMS
+    # (host adapter) only — the operator CLI create path is unbounded (authority).
+
+    def spawn_depth(self, agent: str) -> int:
+        """#2103 C3: the spawn-lineage chain depth of ``agent`` (an operator-top agent =
+        0; each spawn edge +1). Walks ``_spawn_lineage`` to the root; a STALE edge
+        (name-reused parent → frozen identity ≠ current) terminates the walk — the chain
+        is broken there, so a purged+reused ancestor does not inflate the depth."""
+        depth = 0
+        cursor = agent
+        seen: "set[str]" = set()
+        while True:
+            edge = self._spawn_lineage.get(cursor)
+            if edge is None:
+                return depth
+            pname, pseq = edge
+            if pseq is not None and self._agent_create_seq.get(pname) != pseq:
+                return depth  # stale edge → chain broken
+            if pname in seen:
+                return depth
+            seen.add(pname)
+            depth += 1
+            cursor = pname
+
+    def spawn_child_count(self, parent: str) -> int:
+        """#2103 C3: the number of LIVE direct spawn-children of ``parent`` — edges whose
+        parent NAME matches AND whose frozen identity matches ``parent``'s current
+        identity (a stale name-reuse edge from an orphan of a PRIOR same-named parent is
+        excluded; an untracked-parent edge is counted by name)."""
+        pid = self._agent_create_seq.get(parent)
+        n = 0
+        for _child, (pname, pseq) in self._spawn_lineage.items():
+            if pname == parent and (pseq is None or pseq == pid):
+                n += 1
+        return n
+
+    def spawn_would_exceed_limits(self, parent: str) -> "str | None":
+        """#2103 C3: a reject-reason if an ``agent_spawn`` under ``parent`` would exceed
+        the operator spawn bounds (``safety.spawn.*``), else None. Called by the LLM
+        spawn SEAM (host adapter); the operator CLI create path does NOT call it
+        (authority). ``0`` limits = unlimited (the check is skipped)."""
+        if self._max_spawn_depth and self.spawn_depth(parent) + 1 > self._max_spawn_depth:
+            return (
+                f"spawn-limit: max_depth={self._max_spawn_depth} would be exceeded "
+                f"(parent {parent!r} is at spawn-depth {self.spawn_depth(parent)})"
+            )
+        if self._max_spawn_children and self.spawn_child_count(parent) >= self._max_spawn_children:
+            return (
+                f"spawn-limit: max_children={self._max_spawn_children} would be exceeded "
+                f"(parent {parent!r} already has {self.spawn_child_count(parent)} children)"
+            )
+        return None
+
+    def topology_size_exceeds_limit(self, member_count: int) -> "str | None":
+        """#2103 C3: a reject-reason if a ``topology_create`` with ``member_count`` members
+        would exceed ``max_children`` (the fan-out bound governs topology size too), else
+        None. ``0`` = unlimited."""
+        if self._max_spawn_children and member_count > self._max_spawn_children:
+            return (
+                f"spawn-limit: max_children={self._max_spawn_children} would be exceeded "
+                f"(topology has {member_count} members)"
+            )
+        return None
 
     async def create_agent(
         self, name: str, *, role: str = "", parent: "str | None" = None

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -978,6 +978,12 @@ class RouterHostAdapter:
                 "this context."
             )
         parent = self._agent_name
+        # #2103 C3: operator spawn-tree bound (safety.spawn.*) — reject a spawn that
+        # would exceed max_depth / max_children. LLM-seam only (the operator CLI create
+        # path does not route here → unbounded = authority, consistent with C1).
+        limit_reason = self._registry.spawn_would_exceed_limits(parent)
+        if limit_reason is not None:
+            return {"status": "error", "kind": "spawn_limit_exceeded", "error": limit_reason}
         try:
             await self._registry.create_agent(name, role=role, parent=parent)
         except FileExistsError:
@@ -1025,6 +1031,11 @@ class RouterHostAdapter:
             )
         creator = self._agent_name
         members = list(members)
+        # #2103 C3: operator spawn-tree bound (safety.spawn.*) — max_children governs
+        # topology SIZE too (org fan-out). LLM-seam only (operator CLI unbounded).
+        size_reason = self._registry.topology_size_exceeds_limit(len(members))
+        if size_reason is not None:
+            return {"status": "error", "kind": "spawn_limit_exceeded", "error": size_reason}
         outside = [
             m for m in members if not self._registry.is_spawn_descendant(m, creator)
         ]

--- a/tests/test_2103_C3_spawn_limits_1953.py
+++ b/tests/test_2103_C3_spawn_limits_1953.py
@@ -1,0 +1,139 @@
+"""Tier 2: #2103 C3 — operator spawn-tree bounds (safety.spawn.max_depth/max_children).
+
+A DoS guard on the LLM spawn primitives: an agent must not mint an unbounded spawn tree.
+The bounds are OPERATOR-set in reyn.yaml (the restart-only OUT layer) — an LLM has no
+runtime path to raise its own limit (a self-raisable limit is no limit). Enforced at the
+LLM spawn SEAMS (host adapter): agent_spawn (depth + fan-out) and topology_create (org
+size = fan-out). The operator CLI create path is unbounded (authority), consistent with
+the C1 subtree forge-guard scope.
+
+Real AgentRegistry + StateLog + RouterHostAdapter + the real config loader (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from tests._support.router_host_adapter import make_adapter
+
+
+def _registry(tmp_path: Path, *, max_depth: int = 0, max_children: int = 0) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log,
+        max_spawn_depth=max_depth, max_spawn_children=max_children,
+    )
+
+
+# ── the LOAD-BEARING no-self-raise gate ─────────────────────────────────────────────
+
+
+def test_safety_spawn_is_restart_only_not_self_raisable():
+    """Tier 2: (LOAD-BEARING) safety.spawn lives in reyn.yaml, which is NOT a hot-reload
+    file — so the bound is restart-only OUT-set and an LLM cannot raise its own limit at
+    runtime (a self-raisable limit is no limit). RED if reyn.yaml is ever added to the
+    hot-reload set (= safety.* becomes runtime-mutable)."""
+    from reyn.config.loader import _HOT_RELOAD_FILES
+    assert "reyn.yaml" not in _HOT_RELOAD_FILES
+    assert "reyn.local.yaml" not in _HOT_RELOAD_FILES
+    # the hot-reload set is the narrow IN-layer (mcp/cron/hooks) — none carry safety.*
+    assert set(_HOT_RELOAD_FILES) == {"mcp.yaml", "cron.yaml", "hooks.yaml"}
+
+
+def test_config_loader_parses_safety_spawn():
+    """Tier 2: safety.spawn.{max_depth,max_children} round-trips through the real loader
+    (defense-by-default non-zero defaults; operator override honoured)."""
+    from reyn.config.chat import SafetyConfig, _build_safety_config
+    assert SafetyConfig().spawn.max_depth > 0 and SafetyConfig().spawn.max_children > 0
+    built = _build_safety_config({"spawn": {"max_depth": 3, "max_children": 4}})
+    assert built.spawn.max_depth == 3 and built.spawn.max_children == 4
+
+
+# ── max_depth enforcement (agent_spawn) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_rejected_beyond_max_depth(tmp_path):
+    """Tier 2: (LOAD-BEARING) a spawn whose child would exceed max_depth is rejected at the
+    host seam; a spawn AT the limit is allowed. RED if the depth bound isn't enforced."""
+    reg = _registry(tmp_path, max_depth=2)
+    await reg.create_agent("a0")                    # depth 0
+    await reg.create_agent("a1", parent="a0")       # depth 1
+    await reg.create_agent("a2", parent="a1")       # depth 2 (== max)
+
+    # boundary: spawning under a1 (depth 1) → child depth 2 == max → ALLOWED
+    res_ok = await make_adapter(agent_name="a1", agent_registry=reg).spawn_agent(
+        name="a1b", role="")
+    assert res_ok["status"] == "spawned"
+
+    # spawning under a2 (depth 2) → child depth 3 > max → REJECTED
+    res = await make_adapter(agent_name="a2", agent_registry=reg).spawn_agent(
+        name="a3", role="")
+    assert res["status"] == "error"
+    assert res["kind"] == "spawn_limit_exceeded"
+
+
+# ── max_children enforcement (agent_spawn fan-out) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_rejected_beyond_max_children(tmp_path):
+    """Tier 2: (LOAD-BEARING) a parent may spawn up to max_children direct children; the
+    next is rejected. RED if the fan-out bound isn't enforced."""
+    reg = _registry(tmp_path, max_children=2)
+    await reg.create_agent("p")
+    adapter = make_adapter(agent_name="p", agent_registry=reg)
+
+    assert (await adapter.spawn_agent(name="c1", role=""))["status"] == "spawned"
+    assert (await adapter.spawn_agent(name="c2", role=""))["status"] == "spawned"
+    res = await adapter.spawn_agent(name="c3", role="")  # 3rd > max_children=2
+    assert res["status"] == "error"
+    assert res["kind"] == "spawn_limit_exceeded"
+
+
+# ── max_children enforcement (topology_create size) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_topology_create_rejected_beyond_max_children(tmp_path):
+    """Tier 2: (LOAD-BEARING) max_children governs topology SIZE too — a topology with more
+    members than max_children is rejected; at-limit is allowed. RED if the size bound isn't
+    enforced. (Members are operator-created so the SIZE check, not the subtree guard,
+    fires.)"""
+    reg = _registry(tmp_path, max_children=2)
+    await reg.create_agent("coord")
+    await reg.create_agent("w1", parent="coord")
+    await reg.create_agent("w2", parent="coord")
+    await reg.create_agent("w3", parent="coord")
+    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+
+    res = await adapter.create_topology(
+        name="big", kind="network", members=["coord", "w1", "w2", "w3"],  # 4 > 2
+    )
+    assert res["status"] == "error"
+    assert res["kind"] == "spawn_limit_exceeded"
+
+    res_ok = await adapter.create_topology(
+        name="small", kind="network", members=["coord", "w1"],  # 2 == max
+    )
+    assert res_ok["status"] == "created"
+
+
+# ── operator-CLI scope: unbounded (authority) ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_operator_create_agent_is_unbounded(tmp_path):
+    """Tier 2: (boundary control) the operator CLI create path (registry.create_agent
+    directly, not the host seam) is UNBOUNDED — a deep chain past max_depth succeeds.
+    The bound applies to the LLM seam only (authority, consistent with C1)."""
+    reg = _registry(tmp_path, max_depth=1, max_children=1)
+    await reg.create_agent("o0")
+    await reg.create_agent("o1", parent="o0")
+    await reg.create_agent("o2", parent="o1")  # depth 2 > max_depth=1, operator → allowed
+    await reg.create_agent("o3", parent="o2")  # depth 3, still allowed
+    assert reg.exists("o3")
+    assert reg.spawn_depth("o3") == 3  # the chain was built unbounded


### PR DESCRIPTION
**[e2e-coder]** — #2103 **C3** = the LAST spawn-arc slice: a DoS guard bounding the LLM spawn tree. **No-merge** until lead close-review. Built per the lead-approved design + Q1/Q2/Q3 steer.

## What
An LLM must not mint an unbounded spawn tree via `agent_spawn` / `topology_create`. New operator-set bounds:
- **`safety.spawn.max_depth`** (default 10) — max spawn-lineage chain depth.
- **`safety.spawn.max_children`** (default 20) — max fan-out: direct children per parent (`agent_spawn`) AND topology member count (`topology_create`).

## Design (lead-approved)
- **Config plumbing**: `SpawnConfig`→`SafetyConfig` (config/chat.py + `_build_safety_config`), threaded via `SessionFactoryConfig.from_config`→`AgentRegistry` (mirroring `delegation_capability_default`).
- **Q2 — defense-by-default** (non-zero): no backward-compat spawn tree to break (primitives are new in #2103); owner-tunable in reyn.yaml.
- **No-self-raise BY CONSTRUCTION** (the LOAD-BEARING gate): `safety.spawn` lives in reyn.yaml, which is **not** in `_HOT_RELOAD_FILES` (IN-layer = mcp/cron/hooks) → restart-only OUT-set, so an LLM has no runtime path to raise its own limit. Asserted as a test (RED if reyn.yaml ever becomes hot-reloadable).
- **Q3 — enforcement at the LLM spawn seams** (host adapter), LLM-bounded / operator-CLI **unbounded** (authority, consistent with C1's subtree-guard scope):
  - `agent_spawn` → `spawn_would_exceed_limits(parent)`: `depth(parent)+1 ≤ max_depth` AND `child_count(parent) < max_children`.
  - **Q1** — `topology_create` → `topology_size_exceeds_limit`: members ≤ `max_children` (fan-out governs topology size too).
  - Exceed → `{kind: "spawn_limit_exceeded"}` hard reject (a DoS deny, **not** the `safety.on_limit` checkpoint).
- The depth/child-count helpers walk the **same identity-keyed lineage** as C2b, so a stale name-reuse edge doesn't inflate the counts.

## Tests (Tier 2; real AgentRegistry + StateLog + RouterHostAdapter + real loader, no mocks)
- **no-self-raise** restart-only assertion (`reyn.yaml ∉ _HOT_RELOAD_FILES`) + loader round-trip
- **LOAD-BEARING** enforcement falsifications: depth / fan-out / topology-size — at-limit allowed + limit+1 rejected, **all verified RED when the host-seam check is stripped**
- operator-CLI-unbounded boundary control

## CI (all green locally)
- `ruff check src tests scripts` — clean
- `scripts/test_tier_audit.py --strict` — 6/6 OK
- `pytest` (rootdir) — **8502 passed**; the only 4 failures (`gateway/*` + `reyn_api_relocate`) are **pre-existing on clean main** (env quirks). Config-mirror (#1056) updated: `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md` document `safety.spawn` (the full-suite caught the missing mirror — the new-config-field analog of the new-tool invariant).

## Test plan
- [x] Full rootdir pytest (8502 passed; 4 pre-existing unrelated)
- [x] ruff full-tree + tier-audit
- [x] depth/fan-out/topology-size enforcement verified RED-when-stripped
- [x] no-self-raise restart-only asserted
- [ ] (lead) close-review the bounds + the no-self-raise gate + defaults (owner-tunable)

After this lands, the #2103 spawn arc is complete (A + session-spawn + B-core + B-tool + C1 + C2 + C2b + C3).

Refs #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)