### PR TITLE
test(#2103): C3 — lock fan-out count to identity-keyed (purge+reuse, #2166 lens)

### DIFF
--- a/tests/test_2103_C3_spawn_limits_1953.py
+++ b/tests/test_2103_C3_spawn_limits_1953.py
@@ -94,6 +94,31 @@ async def test_spawn_rejected_beyond_max_children(tmp_path):
     assert res["kind"] == "spawn_limit_exceeded"
 
 
+@pytest.mark.asyncio
+async def test_fan_out_count_is_identity_keyed_not_name(tmp_path):
+    """Tier 2: (the #2166 lens, carried forward by tui) the fan-out count keys on the
+    parent's IDENTITY, not its name — an ORPHAN of a purged+reused parent does NOT count
+    against the reused same-named parent's fan-out, so the reused parent gets its full
+    budget (and is not charged for children it never spawned). RED if spawn_child_count
+    counted by name (the orphan would consume a slot of the reused parent)."""
+    reg = _registry(tmp_path, max_children=2)
+    await reg.create_agent("par")                     # par identity #1
+    await reg.create_agent("orphan", parent="par")    # edge orphan → (par, #1)
+    assert reg.spawn_child_count("par") == 1
+
+    await reg.archive_agent("par", purge=True)
+    await reg.create_agent("par")                     # name reused → par identity #2
+
+    # the orphan's edge froze identity #1 ≠ the reused par's #2 → not a child of the new par
+    assert reg.spawn_child_count("par") == 0          # identity-keyed (a name count → 1)
+
+    # so the reused par gets its FULL fan-out budget (not charged for the orphan)
+    adapter = make_adapter(agent_name="par", agent_registry=reg)
+    assert (await adapter.spawn_agent(name="n1", role=""))["status"] == "spawned"
+    assert (await adapter.spawn_agent(name="n2", role=""))["status"] == "spawned"
+    assert (await adapter.spawn_agent(name="n3", role=""))["status"] == "error"  # now at cap
+
+
 # ── max_children enforcement (topology_create size) ─────────────────────────────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — tiny **test-only** follow-on to the now-complete #2103 spawn arc, closing the loop tui raised in the C3 review (carrying the #2166 stale-lineage lens onto the spawn-limit COUNTS). **No-merge** until lead glance.

## What
A targeted Tier-2 that locks `spawn_child_count` to **identity-keyed** counting: an **orphan** of a purged + name-reused parent must NOT count against the reused same-named parent's fan-out.

`spawn_child_count` already keys on the parent's identity (the C2b staleness predicate — `pseq == _agent_create_seq[parent]`), so the orphan's edge (frozen at the OLD identity) is excluded and the reused parent gets its full budget. tui flagged this exact #2166-class concern in the #2171 review; lead verified the helpers walk the identity-keyed lineage. This test **locks it against a silent regression to name-counting** — **verified RED when the count drops the identity check**.

## Why a follow-on (not folded into #2171)
#2171 was already lead-approved + merging on CI green; I deferred this lock rather than race a post-approval push that would delay the arc-closing merge (the behavior was already correct + lead-verified + the shared predicate is exercised by C2b's `is_spawn_descendant` stale-edge tests). This adds the **direct** lock.

## CI (green locally)
- `ruff check` — clean · `tier_audit --strict` — OK · the lineage/C-arc suites pass (24). Test-only, no src change → no repo-wide-invariant surface.

## Test plan
- [x] new test passes; verified RED when `spawn_child_count` counts by name
- [x] ruff + tier-audit + lineage suites green
- [ ] (lead) glance — test-only lock

Refs #2103, #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)