### PR TITLE
refactor(#2123): derive REGISTRY_DISPATCH_TOOLS from a router_dispatched SoT + cross-seam guard

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1249,6 +1249,19 @@ def _apply_tool_exclusions(
 # RouterLoop
 # ---------------------------------------------------------------------------
 
+def _derive_registry_dispatch_tools() -> "frozenset[str]":
+    """#2123: the dispatch set DERIVED from the per-tool ``router_dispatched`` flag —
+    the single SoT replacing the old hand-maintained frozenset. Computed once at class
+    definition from the default registry (no cycle: ``reyn.tools`` does not import
+    ``router_loop``)."""
+    from reyn.tools import get_default_registry
+    reg = get_default_registry()
+    return frozenset(
+        d.name for d in (reg.lookup(n) for n in reg.names())
+        if d is not None and d.router_dispatched
+    )
+
+
 class RouterLoop:
     """Drives the chat router via native LLM tool_use.
 
@@ -3293,101 +3306,15 @@ class RouterLoop:
     # RouterCallerState callable fields populated by ``_build_router_caller_state``.
     # Tools NOT in this set fall through to the legacy if/elif tree below; the
     # set expands cluster-by-cluster as Phase 3.5 lands the remaining adapters.
-    REGISTRY_DISPATCH_TOOLS: frozenset[str] = frozenset({
-        # Phase 3 step 2 (commit 649a426)
-        "list_skills", "describe_skill", "list_agents", "describe_agent",
-        "delegate_to_agent",
-        # #2120 (tui live-probe): session_spawn was registered + floored +
-        # advertised (build_tools B2b) but dispatch was missing here → the LLM
-        # called it and hit {"error": "unhandled tool: session_spawn"} (same
-        # advertised-but-not-dispatched class as read_tool_result / recall). Its
-        # registry handler (tools/session_spawn.py) delegates via
-        # RouterCallerState.spawn_session_fn → host.spawn_session.
-        "session_spawn",
-        # #2103 B-tool: agent_spawn — registry handler (tools/agent_spawn.py) delegates
-        # via RouterCallerState.spawn_agent_fn → host.spawn_agent (create_agent(parent)
-        # + OS-set lineage). Dispatched here so the advertised router=allow tool reaches
-        # its handler (the #2120 advertised-but-not-dispatched lesson).
-        "agent_spawn",
-        # #2103 C1: topology_create — registry handler (tools/topology_create.py)
-        # delegates via RouterCallerState.topology_create_fn → host.create_topology
-        # (subtree-restricted member forge-guard + registry.create_topology emit seam).
-        # Dispatched here so the advertised router=allow tool reaches its handler.
-        "topology_create",
-        # Phase 3.5-D — zero-diff handlers (reyn_src + web).
-        # reyn_src handlers are literal copies of RouterHostAdapter helpers;
-        # web handlers delegate to op_runtime.web with a synthesized OpContext
-        # that the read-only handlers don't consult (= behavior preserved).
-        "reyn_src_list", "reyn_src_read",
-        "web_search", "web_fetch",
-        # B49 Step 2 verify (2026-05-22, post-PR #424): `read_tool_result`
-        # was surfaced to the router LLM via `router_tools.build_tools()`
-        # E3, but execution dispatch was missing here. The LLM saw the
-        # tool, called it (= 2/3 shots in N=3 verify), then hit
-        # `{"error": "unhandled tool: read_tool_result"}` → router empty
-        # response → empty reply. Dispatch wiring belongs in the same
-        # registry-path family as web_fetch / read_file / recall.
-        "read_tool_result",
-        # Phase 3.5-A+C — file cluster.  Handlers consume
-        # RouterCallerState.op_context_factory (= host.make_router_op_context)
-        # so op_runtime sees the operator-declared PermissionDecl /
-        # Workspace, matching legacy router-branch behavior.
-        # _normalise_router_tool_result unwraps read_file / list_directory
-        # to the bare-content / bare-list shapes the host adapter returned.
-        "read_file", "write_file", "delete_file", "list_directory",
-        # #1092 PR-B (FD1): phase-side fine file kinds. edit_file / glob_files /
-        # grep_files are registry ToolDefinitions (tools/file.py, registered in
-        # tools/__init__.py) that the chat router never exposed as router tools
-        # (chat uses list_directory), but they are in the phase default
-        # allowed_ops (#1240). When a phase drives RouterLoop via run_loop, its
-        # op catalog advertises these, so _invoke_router_tool must route them
-        # through the same registry path — closing the dispatch gap that the
-        # obviated op-exec seam (ADR-0036) would otherwise have needed a host
-        # hook for. Chat is unaffected (chat build_tools never lists them).
-        "edit_file", "glob_files", "grep_files",
-        # Phase 3.5-B-light — invoke_skill.  Handler delegates via
-        # RouterCallerState.run_skill_fn (= chain_id pre-bound) so PR14
-        # multi-hop chain semantics propagate into nested run_skill /
-        # delegate_to_agent paths.  Defense Layer B (skill-name
-        # validation) is applied inside the handler.
-        "invoke_skill",
-        # Phase 3.5-B-mid — mcp cluster.  Handlers access the
-        # RouterHostAdapter via ctx.router_state.host so the session-
-        # level MCPClient cache is preserved (= no per-call re-handshake
-        # when the LLM repeatedly calls list_mcp_tools / call_mcp_tool).
-        # _normalise_router_tool_result unwraps list_mcp_servers and
-        # list_mcp_tools dict envelopes back to bare list shape.
-        "list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool",
-        # Phase 3.5-B-heavy — memory cluster.  Handlers delegate via
-        # RouterCallerState.{list_memory_fn, read_memory_body_fn,
-        # remember_fn, forget_fn} bound to RouterLoop's private helpers
-        # which consume the agent-aware ``host.get_memory_index()`` /
-        # ``host.memory_path`` paths.  This preserves per-agent memory
-        # privacy that the registry handlers' filesystem-direct fallback
-        # cannot guarantee.
-        "list_memory", "read_memory_body",
-        "remember_shared", "remember_agent", "forget_memory",
-        # H1/H2: RAG tools (ADR-0033 Phase 1, B17-S6-1 / B17-S8-2 fix).
-        # Handlers in src/reyn/tools/recall.py and src/reyn/tools/drop_source.py
-        # delegate to op_runtime.recall / op_runtime.index_drop via execute_op.
-        # OpContext is constructed from ctx.router_state.op_context_factory
-        # (= host.make_router_op_context) so the permission resolver and
-        # intervention_bus are present for the index_drop gate.
-        "recall", "drop_source",
-        # #272/#1128: voluntary history compaction (handler → execute_op → compact op).
-        "compact",
-        # FP-0034 Phase 1: universal catalog wrappers.  Handlers in
-        # src/reyn/tools/universal_catalog.py — list_actions enumerates
-        # via ctx.router_state, describe_action / invoke_action route
-        # via universal_dispatch.  search_actions stays included for
-        # registry-completeness even though router_tools.build_tools
-        # currently excludes it from the LLM-visible tools= list
-        # (= Phase 2 wires the §D14 visibility gate + the real handler;
-        # listing it here is harmless because the catalog already
-        # filters it out before the LLM can call it).
-        "list_actions", "search_actions",
-        "describe_action", "invoke_action",
-    })
+    # #2123: DERIVED from the per-tool ``router_dispatched`` flag (single SoT), not a
+    # hand-maintained frozenset. A tool routing through the unified registry dispatch
+    # path (``_invoke_via_registry``) sets ``router_dispatched=True`` on its
+    # ToolDefinition; this set is computed from those flags at class-definition time.
+    # Kills the 3-place-wiring drift (#2120 advertise-miss / #2122 dispatch-miss /
+    # read_tool_result advertised-but-unhandled): a new router-only tool is dispatch-
+    # wired by one flag, and the cross-seam guard asserts every ADVERTISED bare router
+    # tool carries it. Per-tool rationale now lives on each ToolDefinition.
+    REGISTRY_DISPATCH_TOOLS: "frozenset[str]" = _derive_registry_dispatch_tools()
 
     async def _build_action_embedding_index_background(
         self, idx: Any, provider: Any, model_class: str,

--- a/src/reyn/tools/agent_spawn.py
+++ b/src/reyn/tools/agent_spawn.py
@@ -66,6 +66,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 AGENT_SPAWN = ToolDefinition(
     name="agent_spawn",
+    router_dispatched=True,
     description=_AGENT_SPAWN_DESCRIPTION,
     parameters=_AGENT_SPAWN_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/catalog.py
+++ b/src/reyn/tools/catalog.py
@@ -90,6 +90,7 @@ async def _handle_list_skills(args: Mapping[str, Any], ctx: ToolContext) -> Tool
 
 LIST_SKILLS = ToolDefinition(
     name="list_skills",
+    router_dispatched=True,
     description=_LIST_SKILLS_DESCRIPTION,
     parameters=_LIST_SKILLS_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -145,6 +146,7 @@ async def _handle_describe_skill(args: Mapping[str, Any], ctx: ToolContext) -> T
 
 DESCRIBE_SKILL = ToolDefinition(
     name="describe_skill",
+    router_dispatched=True,
     description=_DESCRIBE_SKILL_DESCRIPTION,
     parameters=_DESCRIBE_SKILL_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -201,6 +203,7 @@ async def _handle_list_agents(args: Mapping[str, Any], ctx: ToolContext) -> Tool
 
 LIST_AGENTS = ToolDefinition(
     name="list_agents",
+    router_dispatched=True,
     description=_LIST_AGENTS_DESCRIPTION,
     parameters=_LIST_AGENTS_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -254,6 +257,7 @@ async def _handle_describe_agent(args: Mapping[str, Any], ctx: ToolContext) -> T
 
 DESCRIBE_AGENT = ToolDefinition(
     name="describe_agent",
+    router_dispatched=True,
     description=_DESCRIBE_AGENT_DESCRIPTION,
     parameters=_DESCRIBE_AGENT_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -85,6 +85,7 @@ async def _handle_compact(args: Mapping[str, Any], ctx: ToolContext) -> ToolResu
 
 COMPACT = ToolDefinition(
     name="compact",
+    router_dispatched=True,
     description=_COMPACT_DESCRIPTION,
     parameters=_COMPACT_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/delegate_to_agent.py
+++ b/src/reyn/tools/delegate_to_agent.py
@@ -140,6 +140,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 DELEGATE_TO_AGENT = ToolDefinition(
     name="delegate_to_agent",
+    router_dispatched=True,
     description=_DELEGATE_TO_AGENT_DESCRIPTION,
     parameters=_DELEGATE_TO_AGENT_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -105,6 +105,7 @@ async def _handle_drop_source(
 
 DROP_SOURCE = ToolDefinition(
     name="drop_source",
+    router_dispatched=True,
     description=_DROP_SOURCE_DESCRIPTION,
     parameters=_DROP_SOURCE_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -362,6 +362,7 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 READ_FILE = ToolDefinition(
     name="read_file",
+    router_dispatched=True,
     description=_READ_FILE_DESCRIPTION,
     parameters=_READ_FILE_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -372,6 +373,7 @@ READ_FILE = ToolDefinition(
 
 WRITE_FILE = ToolDefinition(
     name="write_file",
+    router_dispatched=True,
     description=_WRITE_FILE_DESCRIPTION,
     parameters=_WRITE_FILE_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -382,6 +384,7 @@ WRITE_FILE = ToolDefinition(
 
 DELETE_FILE = ToolDefinition(
     name="delete_file",
+    router_dispatched=True,
     description=_DELETE_FILE_DESCRIPTION,
     parameters=_DELETE_FILE_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -392,6 +395,7 @@ DELETE_FILE = ToolDefinition(
 
 EDIT_FILE = ToolDefinition(
     name="edit_file",
+    router_dispatched=True,
     description=_EDIT_FILE_DESCRIPTION,
     parameters=_EDIT_FILE_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -402,6 +406,7 @@ EDIT_FILE = ToolDefinition(
 
 LIST_DIRECTORY = ToolDefinition(
     name="list_directory",
+    router_dispatched=True,
     description=_LIST_DIRECTORY_DESCRIPTION,
     parameters=_LIST_DIRECTORY_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -412,6 +417,7 @@ LIST_DIRECTORY = ToolDefinition(
 
 GREP_FILES = ToolDefinition(
     name="grep_files",
+    router_dispatched=True,
     description=_GREP_FILES_DESCRIPTION,
     parameters=_GREP_FILES_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -422,6 +428,7 @@ GREP_FILES = ToolDefinition(
 
 GLOB_FILES = ToolDefinition(
     name="glob_files",
+    router_dispatched=True,
     description=_GLOB_FILES_DESCRIPTION,
     parameters=_GLOB_FILES_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -208,6 +208,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 INVOKE_SKILL = ToolDefinition(
     name="invoke_skill",
+    router_dispatched=True,
     description=_INVOKE_SKILL_DESCRIPTION,
     parameters=_INVOKE_SKILL_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -457,6 +457,7 @@ async def _handle_describe_mcp_tool(
 
 LIST_MCP_SERVERS = ToolDefinition(
     name="list_mcp_servers",
+    router_dispatched=True,
     description=_LIST_MCP_SERVERS_DESCRIPTION,
     parameters=_LIST_MCP_SERVERS_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -467,6 +468,7 @@ LIST_MCP_SERVERS = ToolDefinition(
 
 LIST_MCP_TOOLS = ToolDefinition(
     name="list_mcp_tools",
+    router_dispatched=True,
     description=_LIST_MCP_TOOLS_DESCRIPTION,
     parameters=_LIST_MCP_TOOLS_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -478,6 +480,7 @@ LIST_MCP_TOOLS = ToolDefinition(
 
 CALL_MCP_TOOL = ToolDefinition(
     name="call_mcp_tool",
+    router_dispatched=True,
     description=_CALL_MCP_TOOL_DESCRIPTION,
     parameters=_CALL_MCP_TOOL_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),
@@ -490,6 +493,7 @@ CALL_MCP_TOOL = ToolDefinition(
 
 DESCRIBE_MCP_TOOL = ToolDefinition(
     name="describe_mcp_tool",
+    router_dispatched=True,
     description=_DESCRIBE_MCP_TOOL_DESCRIPTION,
     parameters=_DESCRIBE_MCP_TOOL_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -613,6 +613,7 @@ def _regenerate_index(ctx: ToolContext, mem_dir: Path, index_path: Path) -> None
 
 LIST_MEMORY = ToolDefinition(
     name="list_memory",
+    router_dispatched=True,
     description=_LIST_MEMORY_DESCRIPTION,
     parameters=_LIST_MEMORY_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -624,6 +625,7 @@ LIST_MEMORY = ToolDefinition(
 
 READ_MEMORY_BODY = ToolDefinition(
     name="read_memory_body",
+    router_dispatched=True,
     description=_READ_MEMORY_BODY_DESCRIPTION,
     parameters=_READ_MEMORY_BODY_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -635,6 +637,7 @@ READ_MEMORY_BODY = ToolDefinition(
 
 REMEMBER_SHARED = ToolDefinition(
     name="remember_shared",
+    router_dispatched=True,
     description=_REMEMBER_SHARED_DESCRIPTION,
     parameters=_REMEMBER_SHARED_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -645,6 +648,7 @@ REMEMBER_SHARED = ToolDefinition(
 
 REMEMBER_AGENT = ToolDefinition(
     name="remember_agent",
+    router_dispatched=True,
     description=_REMEMBER_AGENT_DESCRIPTION,
     parameters=_REMEMBER_AGENT_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure
@@ -655,6 +659,7 @@ REMEMBER_AGENT = ToolDefinition(
 
 FORGET_MEMORY = ToolDefinition(
     name="forget_memory",
+    router_dispatched=True,
     description=_FORGET_MEMORY_DESCRIPTION,
     parameters=_FORGET_MEMORY_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),  # Type C closure

--- a/src/reyn/tools/recall.py
+++ b/src/reyn/tools/recall.py
@@ -192,6 +192,7 @@ async def _handle_recall(args: Mapping[str, Any], ctx: ToolContext) -> ToolResul
 
 RECALL = ToolDefinition(
     name="recall",
+    router_dispatched=True,
     description=_RECALL_DESCRIPTION,
     parameters=_RECALL_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/reyn_src.py
+++ b/src/reyn/tools/reyn_src.py
@@ -245,6 +245,7 @@ async def _handle_grep(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 REYN_SRC_LIST = ToolDefinition(
     name="reyn_src_list",
+    router_dispatched=True,
     description=_REYN_SRC_LIST_DESCRIPTION,
     parameters=_REYN_SRC_LIST_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),
@@ -255,6 +256,7 @@ REYN_SRC_LIST = ToolDefinition(
 
 REYN_SRC_READ = ToolDefinition(
     name="reyn_src_read",
+    router_dispatched=True,
     description=_REYN_SRC_READ_DESCRIPTION,
     parameters=_REYN_SRC_READ_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/session_spawn.py
+++ b/src/reyn/tools/session_spawn.py
@@ -84,6 +84,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 SESSION_SPAWN = ToolDefinition(
     name="session_spawn",
+    router_dispatched=True,
     description=_SESSION_SPAWN_DESCRIPTION,
     parameters=_SESSION_SPAWN_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/topology_create.py
+++ b/src/reyn/tools/topology_create.py
@@ -124,6 +124,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 TOPOLOGY_CREATE = ToolDefinition(
     name="topology_create",
+    router_dispatched=True,
     description=_TOPOLOGY_CREATE_DESCRIPTION,
     parameters=_TOPOLOGY_CREATE_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -332,6 +332,17 @@ class ToolDefinition:
     # P7: a generic OS-level bool the tool sets — not a hardcoded tool-name list.
     returns_external_content: bool = False
 
+    # #2123: the tool declares it routes through the unified registry dispatch path
+    # (RouterLoop._invoke_via_registry) — i.e. it belongs in REGISTRY_DISPATCH_TOOLS,
+    # which is DERIVED from this flag (single SoT), not a hand-maintained frozenset.
+    # The drift class this kills: a router-only tool advertised at build_tools but
+    # missing from the dispatch set (→ "unhandled tool"), wired at one seam but not
+    # the others (#2120 / #2122 / read_tool_result). The cross-seam guard asserts
+    # every ADVERTISED bare router tool has this flag. P7: a generic OS-level bool the
+    # tool sets — not a hardcoded tool-name list. False = dispatched elsewhere
+    # (op-runtime / other path) or not router-dispatched.
+    router_dispatched: bool = False
+
     # Per-call schema enrichment hook (= ADR-0026 M4 Phase 3).
     # When set, callers (= build_tools / phase catalog builder) invoke
     # this hook AFTER render_for_router/render_for_phase to inject

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1529,6 +1529,7 @@ def _augment_suggestions(
 
 LIST_ACTIONS = ToolDefinition(
     name="list_actions",
+    router_dispatched=True,
     description=_LIST_ACTIONS_DESCRIPTION,
     parameters=_LIST_ACTIONS_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),
@@ -1540,6 +1541,7 @@ LIST_ACTIONS = ToolDefinition(
 
 SEARCH_ACTIONS = ToolDefinition(
     name="search_actions",
+    router_dispatched=True,
     description=_SEARCH_ACTIONS_DESCRIPTION,
     parameters=_SEARCH_ACTIONS_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),
@@ -1551,6 +1553,7 @@ SEARCH_ACTIONS = ToolDefinition(
 
 DESCRIBE_ACTION = ToolDefinition(
     name="describe_action",
+    router_dispatched=True,
     description=_DESCRIBE_ACTION_DESCRIPTION,
     parameters=_DESCRIBE_ACTION_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),
@@ -1562,6 +1565,7 @@ DESCRIBE_ACTION = ToolDefinition(
 
 INVOKE_ACTION = ToolDefinition(
     name="invoke_action",
+    router_dispatched=True,
     description=_INVOKE_ACTION_DESCRIPTION,
     parameters=_INVOKE_ACTION_PARAMETERS,
     gates=ToolGates(router="allow", phase="deny"),

--- a/src/reyn/tools/web_fetch.py
+++ b/src/reyn/tools/web_fetch.py
@@ -111,6 +111,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 WEB_FETCH = ToolDefinition(
     name="web_fetch",
+    router_dispatched=True,
     description=_WEB_FETCH_DESCRIPTION,
     parameters=_WEB_FETCH_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -111,6 +111,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
 WEB_SEARCH = ToolDefinition(
     name="web_search",
+    router_dispatched=True,
     description=_WEB_SEARCH_DESCRIPTION,
     parameters=_WEB_SEARCH_PARAMETERS,
     gates=ToolGates(router="allow", phase="allow"),

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -1,0 +1,102 @@
+"""Tier 2: #2123 — REGISTRY_DISPATCH_TOOLS derived from the router_dispatched SoT.
+
+The router-only-tool 3-seam wiring (register → advertise → dispatch) recurrently drifted
+(#2120 advertise-miss, #2122 dispatch-miss, read_tool_result advertised-but-unhandled).
+This refactor makes the dispatch seam DERIVED from a single per-tool flag
+(`ToolDefinition.router_dispatched`) and adds the feasible cross-seam guard
+(advertised ⟹ dispatched), so a new router-only tool is dispatch-wired by one flag and
+the drift class is caught structurally.
+
+These tests are the review gates:
+- migration-equivalence (no behavior change): the derived set == the old hand-maintained
+  frozenset MINUS the one documented dead-drift removal (`read_tool_result`, #1449).
+- the cross-seam guard: every advertised bare router tool is dispatch-routed.
+"""
+from __future__ import annotations
+
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.router_tools import build_tools
+from reyn.tools import get_default_registry
+
+# The pre-#2123 REGISTRY_DISPATCH_TOOLS membership (the hand-maintained frozenset) MINUS
+# `read_tool_result` (#1449 retired dead drift: unregistered + unadvertised → unreachable;
+# removed as zero-behavior-change cleanup). This golden is the no-behavior-change oracle.
+_EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
+    "list_skills", "describe_skill", "list_agents", "describe_agent", "delegate_to_agent",
+    "session_spawn", "agent_spawn", "topology_create",
+    "reyn_src_list", "reyn_src_read",
+    "web_search", "web_fetch",
+    "read_file", "write_file", "delete_file", "list_directory",
+    "edit_file", "glob_files", "grep_files",
+    "invoke_skill",
+    "list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool",
+    "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
+    "recall", "drop_source", "compact",
+    "list_actions", "search_actions", "describe_action", "invoke_action",
+})
+
+_SK = [{"name": "s1", "description": "d", "category": "general"}]
+_AG = [{"name": "a1", "description": "d"}]
+_MCP = [{"name": "fs", "description": "Filesystem MCP server"}]
+
+
+def _advertised_bare_router_tools() -> "set[str]":
+    """Bare (non-qualified) router-tool names build_tools advertises across the broadest
+    surface (all gates open, wrappers both ways) — what the LLM can actually call."""
+    names: set[str] = set()
+    for wrappers in (True, False):
+        tools = build_tools(
+            _SK, _AG,
+            file_permissions={"read": ["src"], "write": ["out"]},
+            mcp_servers=_MCP, universal_wrappers_enabled=wrappers, compact_visible=True,
+        )
+        names |= {t["function"]["name"] for t in tools}
+    return {n for n in names if "__" not in n}  # qualified aliases route via invoke_action
+
+
+def test_dispatch_set_is_migration_equivalent():
+    """Tier 2: (no-behavior-change oracle) the DERIVED REGISTRY_DISPATCH_TOOLS equals the
+    pre-refactor hand-maintained set minus the one documented dead-drift removal
+    (read_tool_result). RED if the derivation adds/drops any tool vs the frozen baseline."""
+    assert RouterLoop.REGISTRY_DISPATCH_TOOLS == _EXPECTED_DISPATCH
+
+
+def test_dispatch_set_derives_from_router_dispatched_flag():
+    """Tier 2: the set IS the per-tool router_dispatched SoT — it equals exactly the
+    registry tools carrying the flag (no hand-maintained drift from the markers)."""
+    reg = get_default_registry()
+    from_flag = {
+        d.name for d in (reg.lookup(n) for n in reg.names())
+        if d is not None and d.router_dispatched
+    }
+    assert RouterLoop.REGISTRY_DISPATCH_TOOLS == from_flag
+
+
+def test_read_tool_result_dead_drift_removed():
+    """Tier 2: read_tool_result (#1449 retired) is no longer in the dispatch set — the
+    Q2 dead-drift resolution. RED if it ever re-enters (a non-registry name can't carry
+    the flag, so the derivation excludes it by construction)."""
+    assert "read_tool_result" not in RouterLoop.REGISTRY_DISPATCH_TOOLS
+
+
+def test_advertised_bare_router_tool_implies_dispatched():
+    """Tier 2: (THE cross-seam guard — the recurrence-killer) every bare router tool that
+    build_tools ADVERTISES is in REGISTRY_DISPATCH_TOOLS, so the LLM can never call an
+    advertised tool that falls through to 'unhandled tool' (#2120 / read_tool_result
+    class). Introspects build_tools OUTPUT → condition-agnostic (covers all advertise
+    blocks). RED if a tool is advertised but not dispatch-routed."""
+    advertised = _advertised_bare_router_tools()
+    undispatched = sorted(advertised - RouterLoop.REGISTRY_DISPATCH_TOOLS)
+    assert not undispatched, (
+        f"advertised but NOT dispatch-routed (would hit 'unhandled tool'): {undispatched}"
+    )
+
+
+def test_every_dispatch_name_is_a_registry_tool_with_flag():
+    """Tier 2: (Q3 derivation integrity) every dispatch name resolves to a registry
+    ToolDefinition carrying router_dispatched=True — no hardcoded/non-registry residual."""
+    reg = get_default_registry()
+    for name in RouterLoop.REGISTRY_DISPATCH_TOOLS:
+        d = reg.lookup(name)
+        assert d is not None, f"dispatch name {name!r} is not a registry ToolDefinition"
+        assert d.router_dispatched, f"{name!r} dispatched but router_dispatched is False"


### PR DESCRIPTION
**[e2e-coder]** — #2123 router-wiring refactor (lead-designed, self-dispatched in the post-#2103 lull). **No-merge** until lead close-review. Recurrence-prevention for the "router-only tool wired at one seam but not the others" defect class.

## What
A router-only tool must be hand-wired at **3 seams** (register / advertise / dispatch); missing dispatch breaks it silently with no test catching it (#2120 advertise-miss, #2122 dispatch-miss, read_tool_result advertised-but-unhandled).

- **(a) Single SoT**: `ToolDefinition.router_dispatched: bool` (P7-clean, mirrors `returns_external_content`). `REGISTRY_DISPATCH_TOOLS` is now **derived** from the flag at class-definition (`_derive_registry_dispatch_tools()` over the default registry — no cycle: `reyn.tools` doesn't import `router_loop`) instead of a 95-line hand-maintained frozenset. The 36 dispatched tools self-declare the flag; the per-tool rationale moves onto each `ToolDefinition`.
  - *Marker is necessary* (not gates-derivable): the dispatch set is a strict subset of `gates(router|phase=allow)`, which over-includes 29 op-runtime/phase tools (task.*, cron_*, mcp_install*, sandboxed_exec, …).
- **(b) The feasible cross-seam guard** (the recurrence-killer): a test asserts every bare router tool `build_tools` **advertises** ⟹ is in `REGISTRY_DISPATCH_TOOLS`. It introspects the build_tools **output**, so it's condition-agnostic (covers all 29 advertise blocks + their conditionals) — catches the advertised-but-unhandled class without the infeasible "every router=allow ⟹ advertised" blanket.
- **(c) collapse-uniform-advertise-blocks** — deferred as optional DX (per lead's Q1; the guard catches drift regardless, conditional blocks stay custom).

## Q2 drift resolution (lead: enumerate + resolve)
The guard surfaced exactly **one** drift — `read_tool_result` (#1449 retired: unregistered + unadvertised → unreachable, a dead frozenset entry). **Resolved by removal** (zero behavior change, single-SoT-clean, no residual — lead-confirmed). No live advertised-but-undispatched drift remained.

## Q3
All 36 remaining dispatch names resolve to registry `ToolDefinition`s carrying the flag (asserted).

## Tests (Tier 2; no mocks)
- **migration-equivalence oracle** (the no-behavior-change gate): derived == the pre-refactor frozenset **minus** `read_tool_result`
- derive-from-flag consistency · dead-drift removal · Q3 derivation integrity
- **the cross-seam guard** — **verified RED when a marker is stripped** (the tool goes advertised-but-undispatched)

## CI (green locally)
- `ruff check src tests scripts` — clean · `tier_audit --strict` — OK
- `pytest` (rootdir) — **8509 passed**; only the 4 pre-existing `gateway/*`+`reyn_api_relocate` env-quirk failures. The #2122 session_spawn membership + catalog/dispatch tests unchanged = the **no-behavior-change proof**.

## Test plan
- [x] Full rootdir pytest (8509 passed; 4 pre-existing)
- [x] ruff + tier-audit
- [x] migration-equivalence oracle green; cross-seam guard verified RED-when-stripped
- [x] Q2 drift enumerated (read_tool_result, removed) + Q3 verified
- [ ] (lead) close-review the derivation + the dead-drift removal + the guard

Closes #2123

🤖 Generated with [Claude Code](https://claude.com/claude-code)