### PR TITLE
test(#2123): note the migration-equivalence golden is a deliberate dispatch-membership gate

### DIFF
--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -21,6 +21,12 @@ from reyn.tools import get_default_registry
 # The pre-#2123 REGISTRY_DISPATCH_TOOLS membership (the hand-maintained frozenset) MINUS
 # `read_tool_result` (#1449 retired dead drift: unregistered + unadvertised → unreachable;
 # removed as zero-behavior-change cleanup). This golden is the no-behavior-change oracle.
+#
+# NOTE: this golden also DOUBLES as a deliberate dispatch-membership gate. A change to any
+# tool's ``router_dispatched`` flag flips the derived set, so this test goes RED — that is
+# the gate WORKING, not a break: update this golden INTENTIONALLY (with the membership
+# change) when adding/removing a dispatch-routed tool, the same way #1822 / #2111 / #1056
+# require deliberate updates to their exhaustiveness lists.
 _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "list_skills", "describe_skill", "list_agents", "describe_agent", "delegate_to_agent",
     "session_spawn", "agent_spawn", "topology_create",


### PR DESCRIPTION
**[e2e-coder]** — trivial **comment-only** follow-on addressing lead's non-blocking note on #2173 (deferred from the approved-merging PR to avoid racing a post-approval push). **No-merge** until lead glance.

## What
Adds a clarifying note to the `_EXPECTED_DISPATCH` golden in `test_2123_router_dispatch_sot_1953.py`: it doubles as a **deliberate dispatch-membership gate** — a `router_dispatched` flag change flips the derived set → this test goes RED, which is the gate *working* (update the golden intentionally with the membership change), **not a break**. Mirrors the #1822 / #2111 / #1056 exhaustiveness-list update discipline.

Comment-only; no logic/behavior change.

## Test plan
- [x] test file passes (5); ruff + tier-audit clean
- [ ] (lead) glance — comment-only

Refs #2123