### PR TITLE
fix(#2175): route C3 spawn-limits through the safety.on_limit framework (retire parallel hard-reject)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -575,33 +575,24 @@ class AgentRegistry:
                 n += 1
         return n
 
-    def spawn_would_exceed_limits(self, parent: str) -> "str | None":
-        """#2103 C3: a reject-reason if an ``agent_spawn`` under ``parent`` would exceed
-        the operator spawn bounds (``safety.spawn.*``), else None. Called by the LLM
-        spawn SEAM (host adapter); the operator CLI create path does NOT call it
-        (authority). ``0`` limits = unlimited (the check is skipped)."""
-        if self._max_spawn_depth and self.spawn_depth(parent) + 1 > self._max_spawn_depth:
-            return (
-                f"spawn-limit: max_depth={self._max_spawn_depth} would be exceeded "
-                f"(parent {parent!r} is at spawn-depth {self.spawn_depth(parent)})"
-            )
-        if self._max_spawn_children and self.spawn_child_count(parent) >= self._max_spawn_children:
-            return (
-                f"spawn-limit: max_children={self._max_spawn_children} would be exceeded "
-                f"(parent {parent!r} already has {self.spawn_child_count(parent)} children)"
-            )
-        return None
+    # #2175: the BASE operator spawn bounds (safety.spawn.*, config-set restart-only).
+    # Exposed so the LLM spawn SEAM (host adapter) can compute the EFFECTIVE limit
+    # (base + the on_limit per-operation extension) and route an exceed through the
+    # safety.on_limit checkpoint — exactly as the a2a_handler does over max_hop_depth +
+    # _safety_extensions (retiring C3's parallel hard-reject helpers). ``0`` = unlimited.
+    # The raw counts (spawn_depth / spawn_child_count above) stay the registry's source
+    # of truth; the effective-limit + checkpoint logic lives at the seam.
 
-    def topology_size_exceeds_limit(self, member_count: int) -> "str | None":
-        """#2103 C3: a reject-reason if a ``topology_create`` with ``member_count`` members
-        would exceed ``max_children`` (the fan-out bound governs topology size too), else
-        None. ``0`` = unlimited."""
-        if self._max_spawn_children and member_count > self._max_spawn_children:
-            return (
-                f"spawn-limit: max_children={self._max_spawn_children} would be exceeded "
-                f"(topology has {member_count} members)"
-            )
-        return None
+    @property
+    def max_spawn_depth(self) -> int:
+        """#2175: the operator base max spawn-lineage depth (0 = unlimited)."""
+        return self._max_spawn_depth
+
+    @property
+    def max_spawn_children(self) -> int:
+        """#2175: the operator base max fan-out — direct children + topology size
+        (0 = unlimited)."""
+        return self._max_spawn_children
 
     async def create_agent(
         self, name: str, *, role: str = "", parent: "str | None" = None

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -213,6 +213,13 @@ class RouterHostAdapter:
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
         intervention_bus_factory: Callable[[], Any] | None = None,
+        # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
+        # injected from Session (mirror the a2a_handler injection) so the spawn SEAM can
+        # route a spawn-limit exceed through the same mode-driven on_limit framework as
+        # max_agent_hops. None → no checkpoint wired (headless/test) → degrade to
+        # unattended (reject), the C3 hard-deny posture.
+        handle_chat_limit_checkpoint: "Callable[..., Any] | None" = None,
+        safety_extensions: "dict[str, float] | None" = None,
         # Issue #364 multi-modal cluster: media-size gate config (reyn.yaml
         # ``multimodal:`` section). Threaded into the OpContext built by
         # ``make_router_op_context`` so router-initiated web_fetch /
@@ -365,6 +372,11 @@ class RouterHostAdapter:
         # interactive (Layer 4) approval flow without crashing on
         # ``intervention_bus is None`` defensive guards.
         self._intervention_bus_factory = intervention_bus_factory
+        # #2175: spawn-limit on_limit checkpoint + the shared extension dict.
+        self._handle_chat_limit_checkpoint = handle_chat_limit_checkpoint
+        self._safety_extensions: "dict[str, float]" = (
+            safety_extensions if safety_extensions is not None else {}
+        )
         # Issue #364: store the gate config so make_router_op_context can
         # thread it into the OpContext for router-initiated binary ops.
         self._multimodal_config = multimodal_config
@@ -962,6 +974,27 @@ class RouterHostAdapter:
             ),
         }
 
+    async def _spawn_limit_checkpoint(
+        self, *, kind: str, prompt: str, detail: str,
+        extension_amount: float, run_id: str,
+    ) -> Any:
+        """#2175: route a spawn-limit exceed through the safety.on_limit checkpoint
+        (mode-driven: unattended=reject / interactive=ask / auto_extend). When no
+        checkpoint is wired (headless / test stub), degrade to UNATTENDED = reject (the
+        C3 hard-deny posture). On allow_continue the Session helper bumps the shared
+        ``_safety_extensions[kind]`` so a same-scope re-check won't re-prompt — the
+        no-self-raise invariant holds (the extension is human/operator-approved, the base
+        stays config-set restart-only)."""
+        if self._handle_chat_limit_checkpoint is None:
+            from reyn.runtime.limits.limit_handler import LimitDecision
+            return LimitDecision(
+                allow_continue=False, extension=0.0, reason="no_checkpoint_unattended",
+            )
+        return await self._handle_chat_limit_checkpoint(
+            kind=kind, prompt=prompt, detail=detail,
+            extension_amount=extension_amount, run_id=run_id,
+        )
+
     async def spawn_agent(self, *, name: str, role: str) -> dict:
         """#2103 B-tool: create a new AGENT under THIS agent (the spawner = parent).
 
@@ -978,12 +1011,66 @@ class RouterHostAdapter:
                 "this context."
             )
         parent = self._agent_name
-        # #2103 C3: operator spawn-tree bound (safety.spawn.*) — reject a spawn that
-        # would exceed max_depth / max_children. LLM-seam only (the operator CLI create
-        # path does not route here → unbounded = authority, consistent with C1).
-        limit_reason = self._registry.spawn_would_exceed_limits(parent)
-        if limit_reason is not None:
-            return {"status": "error", "kind": "spawn_limit_exceeded", "error": limit_reason}
+        # #2175: operator spawn-tree bounds (safety.spawn.*) routed through the
+        # safety.on_limit checkpoint (mode-driven: unattended=reject / interactive=ask the
+        # operator / auto_extend), exactly like a2a_handler's max_agent_hops over
+        # max_hop_depth + _safety_extensions. LLM-seam only (operator CLI create is
+        # unbounded = authority, C1). No-self-raise: the BASE is config-set restart-only;
+        # any extension is human/operator-approved, never LLM. DEPTH and FAN-OUT carry
+        # SEPARATE per-spawner extension keys so an approved widen of one does not silently
+        # widen the other (approval-scoping).
+        base_depth = self._registry.max_spawn_depth
+        if base_depth:
+            cur_depth = self._registry.spawn_depth(parent)
+            eff_depth = base_depth + int(
+                self._safety_extensions.get(f"max_spawn_depth:{parent}", 0.0)
+            )
+            if cur_depth + 1 > eff_depth:
+                decision = await self._spawn_limit_checkpoint(
+                    kind=f"max_spawn_depth:{parent}",
+                    prompt=(
+                        f"Spawn depth {cur_depth + 1} would exceed max_spawn_depth "
+                        f"({eff_depth}). Allow agent {parent!r} to spawn deeper?"
+                    ),
+                    detail=f"parent={parent} depth={cur_depth + 1} cap={eff_depth}",
+                    extension_amount=1.0,
+                    run_id=parent,
+                )
+                if not decision.allow_continue:
+                    return {
+                        "status": "error", "kind": "spawn_limit_exceeded",
+                        "error": (
+                            f"spawn-limit: max_spawn_depth={eff_depth} would be exceeded "
+                            f"(parent {parent!r} at spawn-depth {cur_depth}). "
+                            "→ Raise safety.spawn.max_depth to allow deeper spawn trees."
+                        ),
+                    }
+        base_children = self._registry.max_spawn_children
+        if base_children:
+            cur_children = self._registry.spawn_child_count(parent)
+            eff_children = base_children + int(
+                self._safety_extensions.get(f"max_spawn_fanout:{parent}", 0.0)
+            )
+            if cur_children >= eff_children:
+                decision = await self._spawn_limit_checkpoint(
+                    kind=f"max_spawn_fanout:{parent}",
+                    prompt=(
+                        f"Spawning would give {parent!r} {cur_children + 1} children, "
+                        f"exceeding max_spawn_children ({eff_children}). Allow?"
+                    ),
+                    detail=f"parent={parent} children={cur_children} cap={eff_children}",
+                    extension_amount=1.0,
+                    run_id=parent,
+                )
+                if not decision.allow_continue:
+                    return {
+                        "status": "error", "kind": "spawn_limit_exceeded",
+                        "error": (
+                            f"spawn-limit: max_spawn_children={eff_children} would be "
+                            f"exceeded (parent {parent!r} has {cur_children} children). "
+                            "→ Raise safety.spawn.max_children to allow wider fan-out."
+                        ),
+                    }
         try:
             await self._registry.create_agent(name, role=role, parent=parent)
         except FileExistsError:
@@ -1031,11 +1118,35 @@ class RouterHostAdapter:
             )
         creator = self._agent_name
         members = list(members)
-        # #2103 C3: operator spawn-tree bound (safety.spawn.*) — max_children governs
-        # topology SIZE too (org fan-out). LLM-seam only (operator CLI unbounded).
-        size_reason = self._registry.topology_size_exceeds_limit(len(members))
-        if size_reason is not None:
-            return {"status": "error", "kind": "spawn_limit_exceeded", "error": size_reason}
+        # #2175: max_children governs topology SIZE too (org fan-out), routed through the
+        # on_limit checkpoint. SEPARATE extension key from agent_spawn fan-out (approving a
+        # bigger org ≠ approving more direct children — different intents, Q3). A bulk
+        # create extends by the exact gap so the approval covers this topology.
+        base_children = self._registry.max_spawn_children
+        if base_children:
+            eff_members = base_children + int(
+                self._safety_extensions.get(f"max_topology_members:{creator}", 0.0)
+            )
+            if len(members) > eff_members:
+                decision = await self._spawn_limit_checkpoint(
+                    kind=f"max_topology_members:{creator}",
+                    prompt=(
+                        f"Topology {name!r} has {len(members)} members, exceeding "
+                        f"max_spawn_children ({eff_members}). Allow this org size?"
+                    ),
+                    detail=f"creator={creator} members={len(members)} cap={eff_members}",
+                    extension_amount=float(len(members) - eff_members),
+                    run_id=creator,
+                )
+                if not decision.allow_continue:
+                    return {
+                        "status": "error", "kind": "spawn_limit_exceeded",
+                        "error": (
+                            f"spawn-limit: max_spawn_children={eff_members} would be "
+                            f"exceeded (topology has {len(members)} members). "
+                            "→ Raise safety.spawn.max_children to allow larger orgs."
+                        ),
+                    }
         outside = [
             m for m in members if not self._registry.is_spawn_descendant(m, creator)
         ]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1580,6 +1580,11 @@ class Session:
         # last in __init__ because it receives callbacks that reference self
         # (all of which are bound methods, resolved at call time not here).
         self._router_host = RouterHostAdapter(
+            # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
+            # so the spawn SEAM (agent_spawn / topology_create) routes spawn-limit exceeds
+            # through the same mode-driven framework as a2a_handler's max_agent_hops.
+            handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
+            safety_extensions=self._safety_extensions,
             # #1092 PR-F1: the chat turn_budget engine (resolved-model, asserted).
             turn_budget_engine=_chat_turn_budget_engine,
             # FP-0050 / #1822 S2: content-threat scan + fence config.

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -76,10 +76,39 @@ def make_adapter(
     session_id: "str | None" = None,
     current_task_id_fn: "object | None" = None,  # #1953 §16: per-turn execution context
     agent_registry: object = None,  # #2103: real AgentRegistry for spawn/topology seams
+    on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
+    safety_extensions: "dict | None" = None,  # #2175: shared per-run extension dict
+    intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
         events = EventLog(subscribers=[])
+    # #2175: a REAL on_limit checkpoint (no mock) wrapping handle_limit_exceeded with a
+    # real OnLimitConfig + a real approving/declining bus, so spawn-limit tests exercise
+    # the actual framework. None on_limit + None answer → no checkpoint wired → the host
+    # adapter degrades to unattended (reject) — the C3 hard-deny posture.
+    _ext: dict = safety_extensions if safety_extensions is not None else {}
+    _checkpoint = None
+    if on_limit is not None:
+        from reyn.runtime.limits.limit_handler import handle_limit_exceeded
+
+        class _FixedAnswerBus:  # real callable bus (not a mock)
+            async def request(self, iv):  # noqa: ANN001
+                from reyn.user_intervention import InterventionAnswer
+                return InterventionAnswer(choice_id=intervention_answer)
+
+        _bus = _FixedAnswerBus() if intervention_answer is not None else None
+
+        async def _checkpoint_fn(*, kind, prompt, detail, extension_amount, run_id=None):
+            decision = await handle_limit_exceeded(
+                bus=_bus, on_limit=on_limit, kind=kind, run_id=run_id or "test",
+                prompt=prompt, detail=detail, extension_amount=extension_amount,
+            )
+            if decision.allow_continue:
+                _ext[kind] = _ext.get(kind, 0.0) + decision.extension
+            return decision
+
+        _checkpoint = _checkpoint_fn
     workspace = agent_workspace_dir or Path(".reyn") / "agents" / agent_name
     if memory is None:
         memory = MemoryService(
@@ -110,6 +139,8 @@ def make_adapter(
         memory=memory,
         journal=None,
         agent_registry=agent_registry,
+        handle_chat_limit_checkpoint=_checkpoint,  # #2175
+        safety_extensions=_ext,  # #2175
         skill_enumerate_fn=lambda exclude: [],
         agent_workspace_dir=workspace,
         file_read=null_file_read,

--- a/tests/test_2175_spawn_limits_on_limit_1953.py
+++ b/tests/test_2175_spawn_limits_on_limit_1953.py
@@ -1,0 +1,160 @@
+"""Tier 2: #2175 — spawn-limits routed through the safety.on_limit framework.
+
+C3's max_depth/max_children no longer hard-reject in parallel; they route through the
+SAME on_limit checkpoint as max_agent_hops (mode-driven: unattended=reject /
+interactive=ask the operator → extend-on-approval / auto_extend). The base limit stays
+operator-config-set (restart-only); the extension is human/operator-approved — the LLM
+never self-raises. DEPTH / agent-fan-out / topology-size carry SEPARATE per-spawner
+extension keys (approving one operation does not silently widen another).
+
+Real AgentRegistry + StateLog + RouterHostAdapter + the real handle_limit_exceeded /
+OnLimitConfig (no mocks; a real fixed-answer bus for the interactive path).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import OnLimitConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from tests._support.router_host_adapter import make_adapter
+
+
+def _registry(tmp_path: Path, *, max_depth: int = 0, max_children: int = 0) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log,
+        max_spawn_depth=max_depth, max_spawn_children=max_children,
+    )
+
+
+# ── unattended = reject (the C3 hard-deny posture, now via the framework) ────────────
+
+
+@pytest.mark.asyncio
+async def test_depth_unattended_rejects(tmp_path):
+    """Tier 2: on_limit=unattended → a spawn past max_depth rejects (the C3 limit+1
+    falsification, now expressed through the on_limit framework, not a parallel path)."""
+    reg = _registry(tmp_path, max_depth=2)
+    await reg.create_agent("a0")
+    await reg.create_agent("a1", parent="a0")
+    await reg.create_agent("a2", parent="a1")  # at depth 2 == max
+    adapter = make_adapter(agent_name="a2", agent_registry=reg,
+                           on_limit=OnLimitConfig(mode="unattended"))
+    res = await adapter.spawn_agent(name="a3", role="")  # depth 3 > 2
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
+
+
+# ── interactive = ask → approve → extend (the new posture) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_depth_interactive_approve_extends_and_proceeds(tmp_path):
+    """Tier 2: (LOAD-BEARING) on_limit=interactive + operator approves → the over-limit
+    spawn PROCEEDS, and the per-spawner extension is bumped so a re-spawn at that depth
+    won't re-prompt. RED if the checkpoint isn't consulted / approval isn't honored."""
+    reg = _registry(tmp_path, max_depth=2)
+    await reg.create_agent("a0")
+    await reg.create_agent("a1", parent="a0")
+    await reg.create_agent("a2", parent="a1")  # depth 2 == max
+    ext: dict = {}
+    adapter = make_adapter(
+        agent_name="a2", agent_registry=reg,
+        on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
+        safety_extensions=ext, intervention_answer="yes",
+    )
+    res = await adapter.spawn_agent(name="a3", role="")  # depth 3 > 2 → ask → approve
+    assert res["status"] == "spawned"
+    assert ext.get("max_spawn_depth:a2", 0) >= 1  # extension recorded (no re-prompt next)
+
+
+@pytest.mark.asyncio
+async def test_depth_interactive_decline_rejects(tmp_path):
+    """Tier 2: on_limit=interactive + operator declines → the spawn is rejected (the
+    decline path returns the spawn_limit_exceeded ack)."""
+    reg = _registry(tmp_path, max_depth=2)
+    await reg.create_agent("a0")
+    await reg.create_agent("a1", parent="a0")
+    await reg.create_agent("a2", parent="a1")
+    adapter = make_adapter(
+        agent_name="a2", agent_registry=reg,
+        on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
+        intervention_answer="no",
+    )
+    res = await adapter.spawn_agent(name="a3", role="")
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
+
+
+# ── auto_extend (the operator-opted budget) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fanout_auto_extend_then_exhausts(tmp_path):
+    """Tier 2: on_limit=auto_extend (times=1) → the over-limit child auto-extends once
+    (spawned), the next exhausts the budget and rejects."""
+    reg = _registry(tmp_path, max_children=2)
+    await reg.create_agent("p")
+    adapter = make_adapter(
+        agent_name="p", agent_registry=reg,
+        on_limit=OnLimitConfig(mode="auto_extend", auto_extend_times=1),
+        safety_extensions={},
+    )
+    assert (await adapter.spawn_agent(name="c1", role=""))["status"] == "spawned"
+    assert (await adapter.spawn_agent(name="c2", role=""))["status"] == "spawned"
+    # 3rd hits the cap → auto_extend grants once
+    assert (await adapter.spawn_agent(name="c3", role=""))["status"] == "spawned"
+    # 4th → budget exhausted → reject
+    res = await adapter.spawn_agent(name="c4", role="")
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
+
+
+# ── separate extension keys (Q3 approval-scoping) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fanout_and_topology_use_separate_extension_keys(tmp_path):
+    """Tier 2: approving an agent-spawn FAN-OUT widen does NOT silently widen TOPOLOGY
+    size — they key on separate extensions (max_spawn_fanout vs max_topology_members).
+    RED if a single shared key let one approval leak into the other operation."""
+    reg = _registry(tmp_path, max_children=2)
+    await reg.create_agent("coord")
+    await reg.create_agent("w1", parent="coord")
+    await reg.create_agent("w2", parent="coord")
+    ext: dict = {}
+    # approve a 3rd direct child (fan-out extension)
+    spawn_adapter = make_adapter(
+        agent_name="coord", agent_registry=reg,
+        on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
+        safety_extensions=ext, intervention_answer="yes",
+    )
+    assert (await spawn_adapter.spawn_agent(name="w3", role=""))["status"] == "spawned"
+    assert ext.get("max_spawn_fanout:coord", 0) >= 1
+    # topology-members extension is UNTOUCHED by the fan-out approval
+    assert ext.get("max_topology_members:coord", 0) == 0
+    # a 4-member topology (> base 2) under UNATTENDED → still rejected (its own key)
+    topo_adapter = make_adapter(
+        agent_name="coord", agent_registry=reg,
+        on_limit=OnLimitConfig(mode="unattended"), safety_extensions=ext,
+    )
+    res = await topo_adapter.create_topology(
+        name="org", kind="network", members=["coord", "w1", "w2", "w3"],
+    )
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
+
+
+# ── no-self-raise: base holds without an approval ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_approval_means_base_limit_holds(tmp_path):
+    """Tier 2: with no checkpoint wired (the LLM path can't approve its own extension) the
+    base operator limit holds — the over-limit spawn rejects. The extension only comes
+    from the operator-approved checkpoint, never the LLM (no-self-raise)."""
+    reg = _registry(tmp_path, max_depth=1)
+    await reg.create_agent("a0")
+    await reg.create_agent("a1", parent="a0")  # depth 1 == max
+    adapter = make_adapter(agent_name="a1", agent_registry=reg)  # no on_limit → no checkpoint
+    res = await adapter.spawn_agent(name="a2", role="")  # depth 2 > 1
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"


### PR DESCRIPTION
**[e2e-coder]** — #2175 (owner-directed, design-first) — integrates C3 spawn-limits with the `safety.on_limit` framework, retiring my parallel hard-reject. **No-merge** until lead close-review (with the framework-consistency check). Owning the C3 miss.

## The gap
C3's `max_depth`/`max_children` hard-rejected at the spawn seam via a parallel `spawn_limit_exceeded` path — but the **direct analog `max_agent_hops`** (both bound recursive spawn/delegation **tree depth**) already routes through `on_limit` (a2a_handler) with operator-approved per-chain extension. The hard-reject duplicated the framework + lost the config-driven postures.

## Fix (mirrors a2a_handler over `max_hop_depth` + `_safety_extensions`)
- Inject `handle_chat_limit_checkpoint` + the shared `safety_extensions` dict into `RouterHostAdapter` from Session (it already had the intervention bus factory — the injection path the design-call verified).
- `spawn_agent` / `create_topology` compute `effective = base + _safety_extensions[key]`; on exceed → the **on_limit checkpoint** (mode-driven: `unattended`=reject / `interactive`=ask the operator → extend-on-approval / `auto_extend`). Decline → the `spawn_limit_exceeded` ack (LLM-facing, unchanged) + the `safety_limit_checkpoint` audit event.
- **Retired** `registry.spawn_would_exceed_limits` / `topology_size_exceeds_limit`; the registry now exposes the base limits (`max_spawn_depth`/`max_spawn_children` properties) + raw counts; the **seam owns** effective-limit + checkpoint.

## Lead's Q1-4 (all applied)
- **Q1** ✓ host-adapter injection, check-at-seam (not run-loop), mirror a2a.
- **Q2** ✓ per-spawner keying `max_spawn_depth:{parent}`, `run_id={parent}`.
- **Q3** ✓ **SEPARATE** extension keys (`max_spawn_fanout:{agent}` vs `max_topology_members:{agent}`) — approving more children ≠ widening org size.
- **Q4** ✓ base config-set restart-only (the C3 no-self-raise test stays green); extension human/operator-approved never LLM; declined-ack `{kind: spawn_limit_exceeded}` kept + `safety_limit_checkpoint` emitted.

## Tests (Tier 2; real AgentRegistry + RouterHostAdapter + real `handle_limit_exceeded`/`OnLimitConfig`, no mocks)
- unattended=reject (the C3 limit+1, now via the framework) · interactive approve→extend→proceed · interactive decline→reject · auto_extend→exhaust · **separate-extension-keys** (fan-out approval doesn't widen topology) · **no-self-raise** (no approval → base holds)

## CI (green locally)
- `ruff` clean · `tier_audit --strict` OK · `pytest` (rootdir) **8516 passed** (only the 4 pre-existing `gateway/*`+`reyn_api_relocate` env-quirks). The existing C3 + lineage suites unchanged = no-behavior-change for the default (no-checkpoint=unattended) posture.

## Test plan
- [x] Full rootdir pytest (8516 passed; 4 pre-existing)
- [x] ruff + tier-audit
- [x] all on_limit modes + separate-keys + no-self-raise covered
- [ ] (lead) close-review WITH framework-consistency verification (the a2a mirror)

Closes #2175 · Refs #2103