### PR TITLE
docs(#2103): LLM spawn-arc concept docs (agent_spawn / session_spawn / topology_create)

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -271,6 +271,7 @@ nav:
           - concepts/multi-agent/multi-agent.md
           - concepts/multi-agent/a2a.md
           - concepts/multi-agent/topology.md
+          - concepts/multi-agent/org-design.md
       - Data & retrieval:
           - concepts/data-retrieval/rag.md
           - concepts/data-retrieval/memory.md

--- a/docs/concepts/architecture/architecture.md
+++ b/docs/concepts/architecture/architecture.md
@@ -265,6 +265,26 @@ Session is similarly decomposed into services under `chat/services/`:
   `memory_service.py`, `router_host_adapter.py`, `snapshot_journal.py`
 - `a2a_handler.py`, `intervention_handler.py`, `auto_resume_handler.py`
 
+### LLM org-design tools
+
+An LLM running in the router can build a live multi-agent organisation at
+runtime using three primitives: `agent_spawn` (create a child agent capped at
+⊆ its own capability), `session_spawn` (start a fresh-context sub-session for
+an isolated task), and `topology_create` (wire its spawn subtree into a named
+communication topology and optionally narrow member capabilities).
+
+These are router-only decisions — they sit above the transport layer and above
+Phase execution. The OS enforces that spawned agents cannot escalate their
+capabilities beyond the spawner (the ⊆-parent model; see
+[permission-model](../runtime/permission-model.md#llm-spawn-capability-model)).
+
+This surface is distinct from the operator CLI and Topology YAML, which let a
+human define org structure in configuration. Both coexist: an
+operator-authored topology governs agents already configured in it; the LLM's
+`topology_create` only wires agents in its own spawn subtree.
+
+See [Concepts: LLM org-design tools](../multi-agent/org-design.md).
+
 ### Transport vs agent scoping
 
 Two concepts that appear to affect what an agent "can do" operate at different layers and must not be conflated:
@@ -286,3 +306,4 @@ The practical consequence: when a code path appears to "lack a capability," the 
 - [Reference: llm-output-contract](../../reference/runtime/llm-output-contract.md) — the LLM JSON shape
 - [Reference: events](../../reference/runtime/events.md) — event types
 - [Agent engineering — seven lenses](../agent-engineering/index.md) — the same architecture through external engineering perspectives
+- [Concepts: LLM org-design tools](../multi-agent/org-design.md) — `agent_spawn` / `session_spawn` / `topology_create` primitives

--- a/docs/concepts/multi-agent/org-design.md
+++ b/docs/concepts/multi-agent/org-design.md
@@ -1,0 +1,189 @@
+---
+type: concept
+topic: multi-agent
+audience: [human, agent]
+---
+
+# LLM org-design tools
+
+Reyn gives an LLM three primitives for building a live multi-agent
+organisation at runtime:
+
+| Tool | What it does |
+|------|-------------|
+| `agent_spawn` | Create a child agent with a name + role, capped at ⊆ your capabilities |
+| `session_spawn` | Start a fresh-context sub-session to run a task in isolation |
+| `topology_create` | Wire agents you spawned into a communication topology and optionally narrow each member's capabilities |
+
+These tools are **router-only** (not available inside a Phase): they are
+org-design decisions made by the running agent, not instructions authored in a
+skill.
+
+> **Distinct from the operator topology tools.** The [operator CLI
+> (`reyn topology`)](../../reference/cli/topology.md) and
+> [Topology YAML](../../reference/dsl/topology-yaml.md) let a *human operator*
+> define the org structure up front in configuration. The tools on this page let
+> the *LLM itself* design the org at runtime — they are complementary, not
+> competing, surfaces. An operator-authored topology remains the authority for
+> any agent that is already a member; the LLM can only build within its own
+> spawn subtree.
+
+---
+
+## `agent_spawn` — create a child agent
+
+```text
+agent_spawn(name: str, role: str = "")
+```
+
+Creates a new agent in the registry under your authority. The new agent's
+spawn lineage is set by the OS, not by the LLM (forge-guard: the LLM
+never supplies the parent link). The new agent's effective capability is
+**capped at a subset of yours by construction** — it can never do anything
+you cannot (see [⊆-parent capability model](../runtime/permission-model.md#llm-spawn-capability-model)).
+
+Use `agent_spawn` to design the *identity* layer of your org: who exists
+and what their role is. To control *who-can-talk-to-whom* and narrow
+capabilities further, use `topology_create`.
+
+### What the return value tells you
+
+`agent_spawn` returns a spawn-ack (synchronous) — the agent is created and
+registered before the tool returns. The ack includes the new agent's name
+so you can reference it in a subsequent `topology_create` call.
+
+---
+
+## `session_spawn` — run a task in a fresh context
+
+```text
+session_spawn(request: str, mode: "ephemeral" | "persistent" = "persistent",
+              narrowing: dict | None = None)
+```
+
+Starts a new Session under your current agent to run `request` in
+isolation — a blank context window, independent workspace, with no memory
+of this conversation. The spawned session begins immediately; this tool
+returns a spawn-ack rather than waiting for the task to complete (async
+dispatch).
+
+**`mode`**:
+
+- `ephemeral` — the session auto-vanishes after its task completes. Use
+  for one-shot work where you want no lingering state.
+- `persistent` — the session stays registered after the task. Use when
+  you need to refer back to it or continue work there.
+
+**`narrowing`** (optional): a capability-profile subset imposed on the
+sub-session at construction time. Restrict-only — you cannot grant the
+sub-session capabilities beyond your own. Example:
+
+```json
+{"tool_deny": ["sandboxed_exec"]}
+```
+
+Both modes are rewind-safe: a session spawned after a rewind cut is
+dropped during rewind reconstruction.
+
+---
+
+## `topology_create` — wire and narrow your spawn subtree
+
+```text
+topology_create(
+    name: str,
+    kind: "network" | "team" | "pipeline",
+    members: list[str],
+    leader: str | None = None,      # required for kind=team
+    profiles: dict[str, str] | None = None,
+)
+```
+
+Creates a named communication topology from agents **in your spawn
+subtree** (yourself plus any agent you created via `agent_spawn`,
+transitively). The `can_send(A, B)` rule follows the same three kinds as
+operator-authored topologies:
+
+| Kind | Who can send to whom |
+|------|----------------------|
+| `network` | Every member ↔ every member |
+| `team` | Only through the leader — peer ↔ peer is forbidden |
+| `pipeline` | Each member → next member only |
+
+### `profiles` — narrow member capabilities
+
+`profiles` maps an agent name to a `capability_profile` name. A bound
+member's session is restricted by that profile on top of the existing
+⊆-parent cap — it can only narrow *within* the envelope it already has,
+never widen it. Profiles are loaded from `.reyn/capability_profiles/<name>.yaml`.
+
+```json
+{
+  "worker_a": "read_only",
+  "worker_b": "no_subprocess"
+}
+```
+
+### Spawn-subtree restriction (forge-guard)
+
+You may only include agents in your own spawn subtree as members. The OS
+enforces this at the topology-create seam — an attempt to wire an agent
+you did not create (or that is not a transitive spawn-child of yours) is
+rejected. This keeps profile bindings safe by construction: every bound
+member is already ⊆ you via the lineage conjunct, so a binding can only
+narrow within that envelope.
+
+The topology is WAL-tracked so it survives crash recovery and rewind.
+
+---
+
+## Putting it together: a typical org-design flow
+
+```text
+# 1. Create team members
+agent_spawn(name="researcher", role="gather background on topic X")
+agent_spawn(name="writer",     role="draft the section from findings")
+
+# 2. Wire them and optionally narrow
+topology_create(
+    name="research_team",
+    kind="team",
+    leader="researcher",   # researcher coordinates writer
+    members=["researcher", "writer"],
+    profiles={"writer": "no_subprocess"},
+)
+
+# 3. Spawn an isolated task for a one-off need
+session_spawn(
+    request="translate the draft to Japanese",
+    mode="ephemeral",
+)
+```
+
+---
+
+## Operator-set bounds on the LLM spawn tree
+
+An operator can bound how large an LLM-designed org can grow using
+`safety.spawn` in `reyn.yaml`. These are DoS guards — they prevent an
+agent from minting an unbounded organisation. The LLM has no runtime path
+to raise its own limit (the config is the restart-only OUT layer):
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `safety.spawn.max_depth` | `10` | Maximum spawn-lineage chain depth (0 = unlimited) |
+| `safety.spawn.max_children` | `20` | Maximum direct spawn-children per parent, and maximum member count in a `topology_create` call |
+
+Reaches the limit → the spawn or topology-create is rejected. `0` = unlimited.
+
+See [reyn-yaml § safety.spawn](../../reference/config/reyn-yaml.md#safetyspawn-fields) for full schema.
+
+---
+
+## See also
+
+- [⊆-parent capability model](../runtime/permission-model.md#llm-spawn-capability-model) — how the no-escalation-via-spawn security property is enforced
+- [Concepts: topology (operator)](../multi-agent/topology.md) — the human-CLI org-design surface
+- [Concepts: sessions](../multi-agent/sessions.md) — what a session owns; ephemeral / persistent lifecycle
+- [Reference: reyn-yaml § safety.spawn](../../reference/config/reyn-yaml.md#safetyspawn-fields) — operator bounds
+- [Reference: Topology YAML](../../reference/dsl/topology-yaml.md) — operator topology YAML schema

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -546,6 +546,63 @@ Two distinct concepts both use the word "layers" in this document. They answer d
 
 They operate in sequence: authorization resolution (AgentLayer) determines whether the skill's declaration and approvals cover a capability; then the conjunctive intersection applies any active sandbox or profile restrictions. An approved capability can still be denied by `SandboxLayer` or `ProfileLayer` — grant-back is forbidden.
 
+## LLM spawn capability model {#llm-spawn-capability-model}
+
+When an LLM uses `agent_spawn` or `topology_create` to build an org at runtime,
+the resulting agents and topology members operate under a **⊆-parent capability
+model**: every spawned agent's effective capability is capped at a subset of its
+spawner's, recursively, with no path to escalate via spawn.
+
+### How the cap is enforced
+
+The OS, not the LLM, sets the spawn lineage. When `agent_spawn` creates a new
+agent, the registry records `parent=<spawner>` from the calling context — the
+LLM never supplies this link (forge-guard). At gate time, the spawned agent's
+`ContextualLayer` composes the spawner's **live resolved effective capability**
+as a restrict-only conjunct:
+
+```
+child_effective ⊆ parent_effective   (structural, by construction)
+```
+
+Because `ContextualLayer` is restrict-only (it feeds the `all(...)` conjunction
+— see [conjunctive restrict model](#effective-permission-conjunctive-restrict-model)),
+the child cannot exceed the parent on any axis. This holds recursively: a
+grandchild is capped at ⊆ the child, which is itself ⊆ the parent.
+
+The `#2081 _delegate` floor also applies to spawned agents: an unbound spawned
+agent receives the least-privilege `_delegate` profile unless a `topology_create`
+binding explicitly re-grants within the ⊆-parent envelope.
+
+### No-escalation-via-spawn: the closed class
+
+Four specific escalation avenues are closed by construction:
+
+| Escalation avenue | Closed by |
+|---|---|
+| Live spawn (new agent exceeds spawner) | `ContextualLayer` parent-conjunct at gate time |
+| Rewind drop (lineage lost, constraint lifted) | Lineage is WAL-tracked; rewind reconstruction restores the parent link |
+| Absent parent (parent purged, constraint lifted) | Absent-parent path fails closed — gate treats missing lineage as deny |
+| Name reuse (new agent reuses purged name, fresh identity) | Identity-keyed lineage: the OS key is not the name but an internal ID; a re-used name cannot inherit the prior agent's purged lineage |
+
+### `topology_create` profiles stay inside the envelope
+
+When `topology_create` assigns a `capability_profile` to a member, the profile
+is a further **narrowing within the ⊆-parent envelope** — it can only restrict,
+never re-grant. Because every member of a topology must already be in the
+creator's spawn subtree (subtree-restriction gate), the profile binding is safe
+by construction: it can at most reach the envelope the lineage conjunct already
+established.
+
+### Operator bounds on spawn tree size
+
+The ⊆-parent model governs *what* a spawned agent can do. Separately,
+`safety.spawn.max_depth` and `safety.spawn.max_children` govern *how many*
+agents an LLM may spawn — DoS guards so an agent cannot mint an unbounded org.
+See [reyn-yaml § safety.spawn](../../reference/config/reyn-yaml.md#safetyspawn-fields).
+
+---
+
 ## What the permission system is NOT
 
 - **Not a Linux capability sandbox.** A Python step in `mode: unsafe` runs as the same user; reyn doesn't sandbox the kernel.
@@ -561,3 +618,4 @@ They operate in sequence: authorization resolution (AgentLayer) determines wheth
 - [Reference: `reyn mcp`](../../reference/cli/mcp.md) — `install` subcommand and `mcp_install` gate interaction
 - [How-to: manage permissions](../../guide/for-users/manage-permissions.md)
 - [Concepts: Capability profile](../runtime/capability-profile.md) — per-agent ProfileLayer spec (skill / MCP / tool / category axes) and agent self-edit guide
+- [Concepts: LLM org-design tools](../multi-agent/org-design.md) — `agent_spawn` / `session_spawn` / `topology_create` and the ⊆-parent model in practice

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -570,7 +570,7 @@ Because `ContextualLayer` is restrict-only (it feeds the `all(...)` conjunction
 the child cannot exceed the parent on any axis. This holds recursively: a
 grandchild is capped at ⊆ the child, which is itself ⊆ the parent.
 
-The `#2081 _delegate` floor also applies to spawned agents: an unbound spawned
+The default-deny `_delegate` floor also applies to spawned agents: an unbound spawned
 agent receives the least-privilege `_delegate` profile unless a `topology_create`
 binding explicitly re-grants within the ⊆-parent envelope.
 

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -704,6 +704,22 @@ Cross-surface `ask_user` and permission routing — the same prompt reaches the 
 
 ---
 
+### LLM org-design (runtime spawn primitives)
+
+Three router-only tools the LLM uses to build a live organisation at runtime — distinct from the operator CLI / Topology YAML surface (which defines structure up front in configuration).
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| `agent_spawn` | Create a new agent (name + role) under the calling agent's authority; capabilities capped at ⊆ the spawner's by construction; spawn lineage is OS-set / identity-keyed (forge-guarded) | [Concepts: LLM org-design tools](concepts/multi-agent/org-design.md) |
+| `session_spawn` | Start a fresh-context sub-session under the calling agent to run a task in isolation; `mode=ephemeral` auto-vanishes after the task, `mode=persistent` stays; optional `narrowing` (restrict-only) at spawn time | [Concepts: LLM org-design tools](concepts/multi-agent/org-design.md) |
+| `topology_create` | Wire agents in the caller's spawn subtree into a named topology (`network` / `team` / `pipeline`) and optionally bind members to capability profiles (narrowing within the ⊆-parent envelope); subtree-restriction gate enforced by OS | [Concepts: LLM org-design tools](concepts/multi-agent/org-design.md) |
+| ⊆-parent capability model | Spawned agent effective capability = parent's live effective ∩ assigned profile; recursive no-escalation-via-spawn; closed across four stale-lineage axes (live, rewind-drop, absent-parent, name-reuse) | [Concepts: permission model § LLM spawn](concepts/runtime/permission-model.md#llm-spawn-capability-model) |
+| Operator spawn-tree bounds | `safety.spawn.max_depth` (chain depth) + `safety.spawn.max_children` (fan-out + topology member count) — DoS guard; LLM cannot self-raise its limit | [reyn-yaml § safety.spawn](reference/config/reyn-yaml.md#safetyspawn-fields) |
+
+> **Differentiation vs general agents:** the LLM designs the org structure at runtime — not free-form (every spawned agent is capability-capped at ⊆ the spawner, recursively), not pre-wired (the org emerges from the task), and fully rewind-safe (lineage is WAL-tracked; spawn and topology events survive crash recovery).
+
+---
+
 ### Task system
 
 The dynamic work-unit model: small composable ops the LLM reaches for as structure emerges, instead of an upfront plan.


### PR DESCRIPTION
**[docs-maintainer]** — Dispatch from lead-coder: document the #2103 spawn-arc final state.

## Summary

- **NEW** `docs/concepts/multi-agent/org-design.md` — full concept reference for the three LLM org-design primitives (`agent_spawn`, `session_spawn`, `topology_create`), including ⊆-parent model, operator spawn-tree bounds, typical flow example, and cross-links to operator topology docs.
- **`docs/concepts/runtime/permission-model.md`** — new § "LLM spawn capability model": no-escalation-via-spawn security property, the four stale-lineage axes it closes (live / rewind-drop / absent-parent / name-reuse), how `topology_create` profiles stay inside the ⊆-parent envelope, and DoS-guard bounds.
- **`docs/concepts/architecture/architecture.md`** — new subsection in Kernel runtime layers positioning the three spawn primitives and distinguishing them from the operator topology surface.
- **`docs/feature-map.md`** — new "LLM org-design" feature group (5 rows: `agent_spawn` / `session_spawn` / `topology_create` / ⊆-parent model / operator bounds).
- **`.mkdocs/mkdocs.yml`** — `org-design.md` added to Multi-agent nav group.

## Constraint: HELD

`safety.spawn` **enforcement narrative** (on_limit framework) is explicitly omitted — #2175 is reworking the enforcement from hard-reject to on_limit; the `reyn.yaml` config keys are stable and linked as-is from `reyn-yaml.md`.

## Evidence

- Tool implementations verified against `src/reyn/tools/{agent_spawn,session_spawn,topology_create}.py` on origin/main.
- ⊆-parent model verified against `src/reyn/security/permissions/capability_profile.py` and `#2103` completion record (issuecomment-4801899428).
- `mkdocs build --strict` passes (no new WARNING/Aborted; existing INFO-level JA parity gaps pre-date this PR).
- `ruff check src tests` clean.
- No inline `#PR` / `FP-` refs in operator doc body (no-history-refs rule).

## Test plan

- [x] `mkdocs build --strict` — passes locally, no new errors
- [x] `ruff check src tests` — clean
- [x] All links in new doc verified against origin/main file tree
- [x] Cross-links to `permission-model.md#llm-spawn-capability-model` and `reyn-yaml.md#safetyspawn-fields` confirmed resolving (anchors present on origin/main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)