### PR TITLE
fix(#2128): per-AGENT Task-backend restore + disk-driven prune (retire the single pointer)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -268,13 +268,10 @@ class AgentRegistry:
         # tracked follow-up (#1544). Lazily built so non-chat / no-WAL callers
         # never touch git.
         self._workspace_store: WorkspaceVersionStore | None = None
-        # #1953 slice R: the rewind-participating per-session Task backend, pulled
-        # from the session at construction (the session owns it — threaded via
-        # build_scoped_chat_session). The rewind/recovery restore
-        # (_restore_task_active) reads it. I-5=(A): only a local cli/chat
-        # per-session backend lands here; the A2A/web singleton is never threaded
-        # into a session, so it stays None here and its tasks never rewind.
-        self._task_backend: object | None = None
+        # #2128: the single ``_task_backend`` pointer is RETIRED. The rewind/recovery
+        # restore derives every loaded agent's rewind backend at use-time
+        # (``_rewind_backends``), and the prune is disk-driven over on-disk agents — so
+        # no per-construction pointer is held (it was multi-AGENT-incorrect: last-wins).
         # ADR-0038 #1544: FS+exec backend. None / name!="container" → host mode
         # (host subprocess git runner). When container, git runs in-container via
         # backend.run with the container path context (the work-tree is
@@ -1597,17 +1594,10 @@ class AgentRegistry:
                     task.cancel()
         if self._sessions.get(name, {}).pop(sid, None) is not None:
             removed = True
-        # #2125 (interim, secondary): the registry's single ``_task_backend`` pointer is
-        # set to the LAST-constructed session's backend (1849) — under multi-session it
-        # may point to the one we just closed, which would leave _restore_task_active
-        # (1401) operating on a closed connection. Re-point it to a SURVIVING session's
-        # rewind backend (or None) now that the dropped session is out of the map. The
-        # full fix (a per-session backend map so every survivor is restorable, not just
-        # one) is the broader per-session-Task-backend root, tracked in #2128.
-        if session is not None:
-            tb = getattr(session, "task_backend", None)
-            if tb is not None and tb is self._task_backend:
-                self._task_backend = self._surviving_rewind_backend()
+        # #2128: no single-pointer re-point needed — _restore_task_active derives the
+        # rewind backends from the CURRENT loaded sessions at use-time, so a dropped
+        # session is simply no longer iterated (no dangling/closed-handle hazard). This
+        # subsumes the #2125 interim re-point.
         if purge_dir:
             if self._purge_session_dir(name, sid):
                 removed = True
@@ -1624,19 +1614,27 @@ class AgentRegistry:
             )
         return removed
 
-    def _surviving_rewind_backend(self) -> "object | None":
-        """#2125: the first loaded session's rewind-participating Task backend, or None.
+    def _rewind_backends(self) -> "list[object]":
+        """#2128: every LOADED agent's rewind-participating Task backend — ONE per agent.
 
-        Used to re-point the registry's single ``_task_backend`` after a session whose
-        backend it referenced is dropped+closed. Scans the CURRENT in-memory sessions
-        (the dropped one is already out of the map), so it never returns a closed handle.
+        Replaces the single ``_task_backend`` pointer (multi-session/multi-AGENT
+        incorrect: it held only the last-constructed session's backend, so the rewind
+        RESTORE reached only one agent). The ``tasks.db`` is agent-keyed + shared across
+        an agent's sessions, so one backend per agent covers that agent's file; restoring
+        via N session-objects would redundantly file-swap the shared db (the #2125
+        cross-connection lock). Derived at use-time from the CURRENT loaded sessions, so a
+        dropped session is no longer iterated — no dangling/closed handle (subsumes the
+        #2125 re-point). Restore needs a LIVE backend (it mutates the live connection), so
+        this is loaded-derived; the disk-driven prune (over on-disk agents) is separate.
         """
+        out: "list[object]" = []
         for sessions in self._sessions.values():
             for session in sessions.values():
                 tb = getattr(session, "task_backend", None)
                 if tb is not None and getattr(tb, "supports_rewind", False):
-                    return tb
-        return None
+                    out.append(tb)
+                    break  # one per agent — the file is shared across its sessions
+        return out
 
     def _purge_session_dir(self, name: str, sid: str) -> bool:
         """#2125: the destructive half of session teardown — rmtree the per-session
@@ -1820,16 +1818,19 @@ class AgentRegistry:
         un-rewound — the cross-session fan-out is tracked in #1997). No-ops when
         no backend is attached (e.g. crash-recovery before any session loads, so
         crash-recovery stays untouched) or when the backend opts out of rewind.
+
+        #2128: restore EVERY loaded agent's rewind backend (``_rewind_backends`` — one
+        per agent), not a single last-constructed pointer, so a multi-AGENT rewind
+        restores all of them. Restore mutates the live connection, so it is loaded-
+        derived (an unloaded agent isn't running; its db isn't live to restore).
         """
-        tb = self._task_backend
-        if tb is None or not getattr(tb, "supports_rewind", False):
-            return
-        active = [
-            s for s in await tb.generation_seqs()
-            if s <= at_or_below and is_active_seq(self._state_log, s)
-        ]
-        if active:
-            await tb.restore_to_seq(max(active))
+        for tb in self._rewind_backends():
+            active = [
+                s for s in await tb.generation_seqs()
+                if s <= at_or_below and is_active_seq(self._state_log, s)
+            ]
+            if active:
+                await tb.restore_to_seq(max(active))
 
     async def recover_rewind_if_needed(self) -> dict | None:
         """Re-materialise both substrates as-of-N after a crash mid-rewind (1d).
@@ -1944,19 +1945,26 @@ class AgentRegistry:
         the store (#1544 — no host-PATH git_available pre-gate).
         """
         try:
+            from reyn.task.generation_store import SqliteTaskGenerationStore
             for name in self.list_names():
                 # FP-0043 S5: prune EVERY session's generations (main + spawned),
                 # not just main — per-session generation dirs now exist.
                 for sid in self._discover_session_ids(name):
                     self._store_for(name, sid).prune_below(floor)  # SnapshotGenerationStore (sync)
+                # #2128: prune the agent's (agent-keyed) Task-substrate generations on the
+                # SAME boundary, DISK-driven so UNLOADED agents are covered too — the old
+                # single ``_task_backend`` pointer reached only the last-loaded agent,
+                # leaving every other agent's task-gen DBs unbounded. The store is a
+                # standalone no-connection class (pure unlink of task-gen-<seq>.db below
+                # the floor), so this never touches a loaded agent's live tasks.db
+                # connection. ``is_dir()`` guard FIRST — the store ctor mkdir's the dir,
+                # so without it a non-rewind agent would get an empty task-generations/.
+                task_gen_dir = self._dir / name / "state" / "task-generations"
+                if task_gen_dir.is_dir():
+                    SqliteTaskGenerationStore(task_gen_dir).prune_below(floor)  # sync, pure-fs
             ws = self.workspace_store
             if ws is not None:
                 await ws.prune_below(floor)
-            # #1953 slice R: prune Task-substrate generations on the SAME boundary
-            # (bounds the full-DB-copy storage to the retention window — flag #2).
-            tb = self._task_backend
-            if tb is not None and getattr(tb, "supports_rewind", False):
-                await tb.prune_generations_below(floor)
             # #1560 PR-3: act-turn op-content-log GC on the same boundary — drop
             # entries below the floor + unref the out-window op-trees (so auto-gc
             # reclaims them, the same bounded lifecycle generations get).
@@ -2268,14 +2276,10 @@ class AgentRegistry:
         attach_anchor = getattr(session, "attach_anchor_store", None)
         if anchors is not None and callable(attach_anchor):
             attach_anchor(anchors)
-        # #1953 slice R: pull the session's rewind-participating Task backend so
-        # the rewind/recovery restore (_restore_task_active) has a handle to the
-        # same per-session backend the session's cut_generation captures. Only a
-        # backend that opts into rewind is held (I-5=(A) per-session); a None /
-        # non-rewinding backend leaves the restore path inert.
-        tb = getattr(session, "task_backend", None)
-        if tb is not None and getattr(tb, "supports_rewind", False):
-            self._task_backend = tb
+        # #2128: no per-construction pointer set — the session's rewind backend is
+        # reachable via ``session.task_backend`` and derived at use-time by
+        # ``_rewind_backends`` (the restore path) keyed by the loaded sessions, so a
+        # multi-AGENT registry restores EVERY agent's backend, not just the last one.
         return session
 
     def spawn_session(self, name: str, sid: "str | None" = None) -> str:

--- a/src/reyn/task/factory.py
+++ b/src/reyn/task/factory.py
@@ -4,9 +4,11 @@ The session factory calls :func:`create_task_backend` to build the session-scope
 backend it injects into ``Session(task_backend=...)``. The choice is config-driven
 (``in-memory`` for tests / ephemeral, ``sqlite`` for durable) — never hardcoded.
 
-The sqlite ``path`` is session-scoped (one db per session, so the task store
-participates in that session's rewind window); the exact path is supplied by the
-caller that owns the session's state dir (finalized with §24). Path-agnostic here.
+The sqlite ``path`` is supplied by the caller. NOTE (#2128): the
+``per_session_sqlite_backend`` path below is AGENT-keyed
+(``.reyn/agents/<name>/state/tasks.db``) — one db file per AGENT, SHARED across that
+agent's sessions, NOT one db per session. The earlier "one db per session" wording was
+wrong; per-session isolation + the shared-file connection model are tracked in #2180.
 """
 from __future__ import annotations
 
@@ -36,16 +38,18 @@ def create_task_backend(kind: str | None = None, *, path: str | None = None):
 
 
 def per_session_sqlite_backend(agent_name: str) -> "SqliteTaskBackend":
-    """#1953 slice R, I-5=(A): a per-session sqlite Task backend at the agent's
-    default state dir — so in-session ``task.*`` ops are durable AND participate
-    in that session's rewind window (alongside runtime-snapshot + workspace).
+    """#1953 slice R, I-5=(A): the sqlite Task backend at the agent's default state
+    dir — so in-session ``task.*`` ops are durable AND participate in the rewind
+    window (alongside runtime-snapshot + workspace).
 
-    The path is the sibling of the Session's default ``_snapshot_path`` /
-    ``generations`` dir (``.reyn/agents/<name>/state/tasks.db``), centralized here
-    so the capture (``cut_generation``) and restore (``_restore_task_active``)
-    operate on the same db. Used by the single-tenant local frontends (cli/chat,
-    stdio-MCP); A2A/web pass ``None`` (the process-singleton A2A surface is read
-    directly, not threaded into a session — its tasks stay durable but un-rewound,
+    #2128 correction: the path is AGENT-keyed (``.reyn/agents/<name>/state/tasks.db``),
+    so it is ONE db file per AGENT, SHARED across that agent's sessions — NOT one db
+    per session (the function name + the old "per-session" wording are misleading; the
+    shared-file connection model + true per-session isolation are tracked in #2180).
+    Each session still constructs its OWN ``SqliteTaskBackend`` instance over this
+    shared path (N connections to one file). Used by the single-tenant local frontends
+    (cli/chat, stdio-MCP); A2A/web pass ``None`` (the process-singleton A2A surface is
+    read directly, not threaded into a session — its tasks stay durable but un-rewound,
     the cross-session fan-out tracked in #1997).
     """
     from pathlib import Path  # noqa: PLC0415

--- a/src/reyn/task/factory.py
+++ b/src/reyn/task/factory.py
@@ -1,8 +1,10 @@
 """Config-driven Task backend selection (#1953 slice 3a).
 
-The session factory calls :func:`create_task_backend` to build the session-scoped
-backend it injects into ``Session(task_backend=...)``. The choice is config-driven
-(``in-memory`` for tests / ephemeral, ``sqlite`` for durable) — never hardcoded.
+The session factory calls :func:`create_task_backend` to build the per-session backend
+INSTANCE it injects into ``Session(task_backend=...)`` (each session constructs its own
+backend object — note the sqlite DB FILE it opens is agent-keyed/shared, see below). The
+choice is config-driven (``in-memory`` for tests / ephemeral, ``sqlite`` for durable) —
+never hardcoded.
 
 The sqlite ``path`` is supplied by the caller. NOTE (#2128): the
 ``per_session_sqlite_backend`` path below is AGENT-keyed
@@ -32,7 +34,10 @@ def create_task_backend(kind: str | None = None, *, path: str | None = None):
         return InMemoryTaskBackend()
     if chosen == "sqlite":
         if not path:
-            raise ValueError("sqlite task backend requires a 'path' (session-scoped db)")
+            raise ValueError(
+                "sqlite task backend requires a 'path' "
+                "(#2128: agent-keyed db, shared across the agent's sessions)"
+            )
         return SqliteTaskBackend(path)
     raise ValueError(f"unknown task backend kind: {kind!r} (expected 'sqlite' or 'in-memory')")
 

--- a/tests/test_2103_s1bc_session_drop.py
+++ b/tests/test_2103_s1bc_session_drop.py
@@ -168,13 +168,15 @@ async def test_rewind_restore_failure_does_not_drop_the_session_dir(tmp_path) ->
 
 
 @pytest.mark.asyncio
-async def test_remove_session_closes_backend_and_repoints_pointer(tmp_path) -> None:
-    """Tier 2: #2125 — remove_session CLOSES the dropped session's per-session Task-backend
-    (a separate sqlite connection to the agent's shared tasks.db), releasing its lock so a
-    later _restore_task_active file-swap doesn't hit 'database is locked' (busy_timeout=0),
-    AND re-points the registry's single _task_backend off the now-closed handle to a
-    surviving session's backend. Strip the close()/re-point → the survivor pointer dangles
-    to a closed connection."""
+async def test_remove_session_closes_dropped_backend_restore_uses_survivor(tmp_path) -> None:
+    """Tier 2: #2125 + #2128 — remove_session CLOSES the dropped session's per-session
+    Task-backend (a separate sqlite connection to the agent's shared tasks.db), releasing
+    its lock. With #2128, _restore_task_active derives the rewind backends from the CURRENT
+    loaded sessions (``_rewind_backends``), so the dropped session is simply no longer
+    iterated — restore touches the survivor, never the now-closed dropped handle (no
+    re-point pointer needed; the #2125 interim is subsumed). Strip the close() → restore on
+    a still-open shared file is fine; the load-bearing property is that the dropped session
+    is OUT of the derive set."""
     import sqlite3
 
     from reyn.task.factory import create_task_backend
@@ -194,7 +196,6 @@ async def test_remove_session_closes_backend_and_repoints_pointer(tmp_path) -> N
         task_backend=dropped_backend, cancel_inflight=_noop, await_quiescent=_noop,
     )
     reg._sessions["worker"] = {"main": main, "s1": spawned}
-    reg._task_backend = dropped_backend  # the single pointer → last-constructed (spawned)
     _make_session_dir(reg, "worker", "s1")
     # a captured generation on the SURVIVOR at an active WAL seq → _restore_task_active
     # has real work that touches the backend's connection (else it no-ops without probing).
@@ -206,8 +207,8 @@ async def test_remove_session_closes_backend_and_repoints_pointer(tmp_path) -> N
     # the dropped backend's connection is closed (a public DB read now raises) → lock released.
     with pytest.raises(sqlite3.ProgrammingError):
         await dropped_backend.get("any-task-id")
-    # the registry's single task-backend pointer was re-pointed off the now-closed dropped
-    # backend to the surviving session's backend: _restore_task_active restores the
-    # survivor's generation without error. A pointer still dangling to the closed dropped
+    # #2128: _restore_task_active derives from the loaded sessions — only the survivor
+    # remains, so its generation is restored without error and the closed dropped backend
+    # is never touched (it's out of _sessions). A path that still reached the dropped
     # connection would raise ProgrammingError inside restore_to_seq.
     await reg._restore_task_active(at_or_below=seq)

--- a/tests/test_2128_per_session_task_backend_1953.py
+++ b/tests/test_2128_per_session_task_backend_1953.py
@@ -1,0 +1,150 @@
+"""Tier 2: #2128 — per-session/multi-AGENT Task-backend restore + prune correctness.
+
+The registry's single ``_task_backend`` pointer was last-wins (one agent's backend), so:
+- RESTORE (`_restore_task_active`) reached only the last-constructed agent → a multi-AGENT
+  rewind left every OTHER agent's task substrate un-restored.
+- PRUNE (`_prune_generations_below`) touched only that one backend → every other agent's
+  ``task-generations/`` grew unbounded, INCLUDING agents with NO loaded session.
+
+The fix: RESTORE derives every LOADED agent's rewind backend at use-time
+(``_rewind_backends``, one per agent — the tasks.db is agent-keyed/shared); PRUNE is
+DISK-driven over ``list_names()`` so it covers UNLOADED agents too (a path-based
+``SqliteTaskGenerationStore`` — pure unlink, no live connection touched).
+
+Real AgentRegistry + StateLog + real SqliteTaskBackend / on-disk generation files (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.task import Task, TaskState
+from reyn.task.factory import create_task_backend
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _active_seq(log: StateLog, agent: str, text: str) -> int:
+    return await log.append("inbox_put", target=agent, msg_id=text, msg_kind="user",
+                            payload={"text": text})
+
+
+def _task(tid: str) -> Task:
+    return Task(task_id=tid, name=tid, assignee="s", requester="r", status=TaskState.PENDING)
+
+
+# ── restore: every loaded AGENT's backend (not just the last-constructed) ────────────
+
+
+@pytest.mark.asyncio
+async def test_restore_touches_every_loaded_agents_backend(tmp_path):
+    """Tier 2: (LOAD-BEARING) a multi-AGENT rewind restores EVERY loaded agent's task
+    backend — each reverts to its captured generation. RED on the single-pointer (only the
+    last-constructed agent's backend was restored; the other agent's post-generation task
+    would survive)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "agenta")
+    _seed_agent(tmp_path, "agentb")
+    # agent-keyed paths (distinct parent dirs → distinct task-generations/ dirs), as in
+    # production .reyn/agents/<name>/state/tasks.db.
+    (tmp_path / "a" / "state").mkdir(parents=True)
+    (tmp_path / "b" / "state").mkdir(parents=True)
+    back_a = create_task_backend("sqlite", path=str(tmp_path / "a" / "state" / "tasks.db"))
+    back_b = create_task_backend("sqlite", path=str(tmp_path / "b" / "state" / "tasks.db"))
+
+    # each agent: a kept task captured in a generation at an ACTIVE seq, then a live task
+    # created AFTER the generation (which a restore must revert away).
+    seq_a = await _active_seq(reg.state_log, "agenta", "a")
+    await back_a.create(_task("keep_a"))
+    await back_a.snapshot_generation(seq_a)
+    await back_a.create(_task("live_a"))
+    seq_b = await _active_seq(reg.state_log, "agentb", "b")
+    await back_b.create(_task("keep_b"))
+    await back_b.snapshot_generation(seq_b)
+    await back_b.create(_task("live_b"))
+
+    reg._sessions["agenta"] = {"main": SimpleNamespace(task_backend=back_a)}
+    reg._sessions["agentb"] = {"main": SimpleNamespace(task_backend=back_b)}
+
+    await reg._restore_task_active(at_or_below=max(seq_a, seq_b))
+
+    # BOTH backends restored to their generation → kept tasks present, live tasks reverted
+    assert await back_a.get("keep_a") is not None
+    assert await back_a.get("live_a") is None
+    assert await back_b.get("keep_b") is not None
+    assert await back_b.get("live_b") is None  # RED on single-pointer (agentb un-restored)
+
+
+@pytest.mark.asyncio
+async def test_rewind_backends_one_per_agent(tmp_path):
+    """Tier 2: `_rewind_backends` returns ONE backend per loaded agent (the tasks.db is
+    agent-keyed/shared across an agent's sessions, so restoring it N times would redundantly
+    file-swap the shared db + risk the #2125 cross-connection lock)."""
+    reg = _make_registry(tmp_path)
+    back_a = create_task_backend("sqlite", path=str(tmp_path / "a.db"))
+    back_a2 = create_task_backend("sqlite", path=str(tmp_path / "a.db"))  # 2nd session, same agent
+    back_b = create_task_backend("sqlite", path=str(tmp_path / "b.db"))
+    reg._sessions["agenta"] = {
+        "main": SimpleNamespace(task_backend=back_a),
+        "s1": SimpleNamespace(task_backend=back_a2),
+    }
+    reg._sessions["agentb"] = {"main": SimpleNamespace(task_backend=back_b)}
+    backs = reg._rewind_backends()
+    # one per AGENT, not one per session: agentb's backend present, and EXACTLY ONE of
+    # agenta's two same-agent session backends (not both → no redundant double file-swap).
+    assert back_b in backs
+    assert (back_a in backs) != (back_a2 in backs)
+
+
+# ── prune: covers UNLOADED agents (the Q4 unbounded-growth fix) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prune_covers_unloaded_agents_task_generations(tmp_path):
+    """Tier 2: (LOAD-BEARING) `_prune_generations_below` prunes the task-generations of
+    EVERY on-disk agent — including one with NO loaded session — so an unloaded agent's
+    task-gen DBs don't grow unbounded. RED on the single-pointer (it reached at most one
+    loaded agent; the unloaded agent's below-floor generation survived)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "loaded")
+    _seed_agent(tmp_path, "unloaded")
+    # both agents have on-disk task-generations: one below the floor (prune), one at/above (keep)
+    for name in ("loaded", "unloaded"):
+        gd = tmp_path / ".reyn" / "agents" / name / "state" / "task-generations"
+        gd.mkdir(parents=True)
+        (gd / "task-gen-1.db").write_bytes(b"x")   # below floor 3 → prune
+        (gd / "task-gen-5.db").write_bytes(b"x")   # at/above floor 3 → keep
+    # only "loaded" has a live session; "unloaded" exists on disk only
+    reg._sessions["loaded"] = {"main": SimpleNamespace(task_backend=None)}
+
+    await reg._prune_generations_below(3)
+
+    for name in ("loaded", "unloaded"):
+        gd = tmp_path / ".reyn" / "agents" / name / "state" / "task-generations"
+        assert not (gd / "task-gen-1.db").exists(), f"{name}: below-floor gen not pruned"
+        assert (gd / "task-gen-5.db").exists(), f"{name}: at-floor gen wrongly pruned"
+
+
+@pytest.mark.asyncio
+async def test_prune_skips_agents_without_a_task_generations_dir(tmp_path):
+    """Tier 2: (the is_dir() guard) an agent with NO task-generations dir (non-rewind / never
+    snapshotted) is a no-op — prune must NOT create an empty task-generations/ for it (the
+    store ctor mkdir's the dir, so the guard is mandatory)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "bare")
+    await reg._prune_generations_below(3)
+    assert not (tmp_path / ".reyn" / "agents" / "bare" / "state" / "task-generations").exists()


### PR DESCRIPTION
**[e2e-coder]** — #2128 (owner-confirmed roi:high, design-first) — multi-AGENT correctness for the rewind task-backend restore + prune. **No-merge** until lead close-review (with the framework-consistency check). Builds on #2125's interim.

## The bug
The registry's single `_task_backend` pointer is **last-wins** (the last-constructed rewind session's backend), so under multi-AGENT it references only one agent:
- **restore** (`_restore_task_active`) restored only that agent → a multi-agent rewind left every other agent's task substrate un-restored.
- **prune** (`_prune_generations_below`) pruned only that backend → every other agent's `task-generations/` grew unbounded, **including agents with no loaded session**.

**Synthesis correction to the issue framing** (caught in flow-trace): the `tasks.db` + `task-generations/` are **agent-keyed** (`.reyn/agents/<name>/state/`), shared across an agent's sessions — so the bug is across **agents**, not same-agent sessions; and prune already iterated per-session for the *snapshot* dirs — only the *task-backend* line was single-pointer.

## Fix (lead-approved Q1-4)
- **RESTORE (loaded-derived):** new `_rewind_backends()` derives **one** rewind backend **per loaded agent** at use-time (agent-keyed file; restoring via N session-objects would redundantly file-swap the shared db = the #2125 lock). Restore mutates the live connection → loaded-derived is correct.
- **PRUNE (disk-driven, Q4):** iterate `list_names()` (every on-disk agent, **loaded or not**) and prune each agent's `task-generations/` via a standalone `SqliteTaskGenerationStore` (pure unlink of `task-gen-<seq>.db` below the floor — **no live connection touched**, lead-verified). Mandatory `is_dir()` guard precedes construction (the ctor mkdir's the dir).
- **RETIRED** the single `_task_backend` pointer (decl + `_construct_session` write), `_surviving_rewind_backend`, and the **#2125 interim re-point** — derive-at-use-time subsumes them (a dropped session is out of `_sessions` → not iterated → no dangling/closed handle).
- **factory.py docstrings** corrected: agent-keyed (one db per **agent**, shared), not "one db per session" (the audit-flagged contradiction).

## Scope
The shared-`tasks.db`-via-N-connections coherence (the deeper connection-model rework) is **out of scope** → tracked in **#2180** (roi:medium, filed).

## Tests (Tier 2; real AgentRegistry + SqliteTaskBackend + on-disk generation files, no mocks)
- **LOAD-BEARING** 2-AGENT restore (both agents' backends revert) — **RED on the single-pointer**
- `_rewind_backends` one-per-agent (behavioral; same-agent sessions dedup)
- **Q4 UNLOADED-agent prune coverage** (both agents' below-floor task-gens pruned) — **RED on loaded-only**
- the `is_dir()`-guard (no empty dir for a non-rewind agent)
- the #2125 close-on-drop test reframed to derive-at-use-time

All falsifications **verified RED** on the single/loaded-only revert, GREEN restored.

## CI (green locally)
- `ruff` clean · `tier_audit --strict` OK (the `len()==N` reframed to a behavioral membership assertion) · `pytest` (rootdir) **8520 passed** (only the 4 pre-existing `gateway/*`+`reyn_api_relocate` env-quirks). The #2125 + rewind/prune suites pass = no-behavior-change for the single-agent path.

## Test plan
- [x] Full rootdir pytest (8520 passed; 4 pre-existing)
- [x] ruff + tier-audit
- [x] 2-agent restore + unloaded-prune verified RED-on-single/loaded-only
- [x] #2180 filed (Q2 connection-model) + factory docstring fixed
- [ ] (lead) close-review WITH framework-consistency (the multi-agent iterate-all + the disk-driven prune safety)

Closes #2128 · Refs #2125, #2180