### PR TITLE
fix(#2130): first-class (agent, sid) A2A response routing (thread from_sid; lift the non-main-spawn guard)

### DIFF
--- a/src/reyn/runtime/services/a2a_handler.py
+++ b/src/reyn/runtime/services/a2a_handler.py
@@ -304,6 +304,7 @@ class A2AHandler:
 
     async def send_agent_response(
         self, *, to: str, response: str, depth: int, chain_id: str,
+        to_sid: "str | None" = None,
     ) -> None:
         """Route a reply from this agent back to the requester ``to``.
 
@@ -312,6 +313,10 @@ class A2AHandler:
         Empty response is still sent so chains never silently stall.
         chain_id (PR14) carries the same value the original request did so
         the requester can correlate the reply with its pending chain.
+
+        #2130: ``to_sid`` is the REQUESTER's session id, threaded from the original
+        request, so the reply routes back to the SPECIFIC (to, to_sid) session — a non-main
+        spawner gets its result, not the requester agent's main session. None → main-case.
         """
         if depth > self._max_hop_depth:
             return  # silently drop — sender already gave up the chain
@@ -329,7 +334,7 @@ class A2AHandler:
         if responder_sid in (None, "main"):
             responder_sid = None
         await self._send_response_callback(
-            to, self.agent_name, response, depth, chain_id, responder_sid,
+            to, self.agent_name, response, depth, chain_id, responder_sid, to_sid,
         )
 
     def _fence_inbound(self, text: str) -> str:
@@ -365,6 +370,10 @@ class A2AHandler:
         from reyn.runtime.errors import RouterCapExceeded
 
         from_agent = payload.get("from_agent", "")
+        # #2130: the REQUESTER's session id (None for the main-case / external peers) — so
+        # this agent's reply routes back to the SPECIFIC (from_agent, from_sid), threaded
+        # to every send_agent_response below + the pending chain's origin_sid.
+        from_sid = payload.get("from_sid")
         # FP-0050/#1822 S4b (EP5, Class A): fence + scan the untrusted peer
         # request before it enters history (a remote agent is outside the trust
         # boundary; delegate-reply-via-EP5 closes here per the S2 review).
@@ -414,7 +423,7 @@ class A2AHandler:
                     self.agent_name,
                     f"router retry budget exhausted ({exc.count}/{exc.cap})",
                 ),
-                depth=depth, chain_id=chain_id,
+                depth=depth, chain_id=chain_id, to_sid=from_sid,
             )
             return
         except Exception as exc:
@@ -430,7 +439,7 @@ class A2AHandler:
                 response=_no_reply_marker(
                     self.agent_name, f"router error: {exc}"
                 ),
-                depth=depth, chain_id=chain_id,
+                depth=depth, chain_id=chain_id, to_sid=from_sid,
             )
             return
         finally:
@@ -454,6 +463,7 @@ class A2AHandler:
                 waiting_on=waiting_on,
                 origin_agent=from_agent,
                 origin_depth=depth,
+                origin_sid=from_sid,  # #2130: route the chain reply back to (origin_agent, origin_sid)
             )
             self._chains.arm_timeout(
                 chain_id, on_fire=self._on_chain_timeout_fire,
@@ -476,6 +486,7 @@ class A2AHandler:
         # Note: history was already appended by put_outbox; add routing meta.
         await self.send_agent_response(
             to=from_agent, response=reply_text, depth=depth, chain_id=chain_id,
+            to_sid=from_sid,  # #2130: back to the specific (from_agent, from_sid)
         )
 
     async def handle_agent_response(self, payload: dict) -> None:
@@ -645,6 +656,7 @@ class A2AHandler:
                 response=user_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
+                to_sid=pending.origin_sid,  # #2130
             )
             self._events.emit(
                 "peer_reply_failed_surfaced",
@@ -675,6 +687,7 @@ class A2AHandler:
                     f"resolving chain",
                 ),
                 depth=pending.origin_depth, chain_id=chain_id,
+                to_sid=pending.origin_sid,  # #2130
             )
             await self._chains.resolve(chain_id)
             return
@@ -692,6 +705,7 @@ class A2AHandler:
                     f"router error during chain resolve: {exc}",
                 ),
                 depth=pending.origin_depth, chain_id=chain_id,
+                to_sid=pending.origin_sid,  # #2130
             )
             await self._chains.resolve(chain_id)
             return
@@ -724,6 +738,7 @@ class A2AHandler:
         await self.send_agent_response(
             to=pending.origin_agent, response=final_reply,
             depth=pending.origin_depth, chain_id=chain_id,
+            to_sid=pending.origin_sid,  # #2130
         )
         await self._chains.resolve(chain_id)
 

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -48,6 +48,10 @@ class _PendingChain:
     origin_depth: int
     original_request: str
     waiting_on: set[str] = field(default_factory=set)
+    # #2130: the origin's session id — so the resolved chain reply routes back to the
+    # specific (origin_agent, origin_sid), not the origin agent's main session. None →
+    # main-case (user-initiated / external peer / pre-#2130 journal entries).
+    origin_sid: "str | None" = None
 
 
 # ── Journal protocol ──────────────────────────────────────────────────────────
@@ -137,6 +141,7 @@ class ChainManager:
         waiting_on: set[str] | None = None,
         origin_agent: str = "",
         origin_depth: int = 0,
+        origin_sid: "str | None" = None,
     ) -> _PendingChain:
         """Register a new pending chain and persist it via the journal.
 
@@ -165,6 +170,7 @@ class ChainManager:
             origin_depth=origin_depth or depth,
             original_request=original_text,
             waiting_on=set(waiting_on or []),
+            origin_sid=origin_sid,
         )
         self._chains[chain_id] = chain
 
@@ -174,6 +180,7 @@ class ChainManager:
             "original_request": chain.original_request,
             "waiting_on": sorted(chain.waiting_on),
             "from_user": from_user,
+            "origin_sid": chain.origin_sid,  # #2130
         }
         await self._journal.record_chain_register(chain_id=chain_id, fields=fields)
         return chain
@@ -350,5 +357,6 @@ class ChainManager:
                 origin_depth=int(chain_dict["origin_depth"]),
                 original_request=chain_dict["original_request"],
                 waiting_on=set(chain_dict.get("waiting_on", [])),
+                origin_sid=chain_dict.get("origin_sid"),  # #2130 (None for pre-#2130 entries)
             )
             self.arm_timeout(cid, on_fire=on_fire)

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -933,23 +933,13 @@ class RouterHostAdapter:
                 "session_spawn requires a registry (multi-session host) — unavailable "
                 "in this context."
             )
-        # #2103 S1bc-exec GAP A guard: only the MAIN session may spawn. A spawned
-        # (non-main) session's result would route back by AGENT NAME to the agent's main
-        # session — NOT to this spawning sid — i.e. a silent misroute. Routing to a
-        # specific (agent, sid) is the first-class non-main addressing tracked in #2130;
-        # until then, refuse rather than misroute. Read the LIVE sid (the constructor's
-        # cached session_id is stale for spawned sessions, stamped post-construction).
-        live_sid = self._live_session_id_fn() if self._live_session_id_fn else self._session_id
-        if live_sid not in (None, "main"):  # "main" = registry._DEFAULT_SID (avoid the import cycle)
-            return {
-                "status": "error",
-                "kind": "nested_spawn_unsupported",
-                "error": (
-                    "session_spawn is only available from the main session: a spawned "
-                    "session's result can't yet route back to a non-main spawner "
-                    "(first-class (agent,sid) addressing — #2130)."
-                ),
-            }
+        # #2130: the spawning session's LIVE sid — threaded as ``from_sid`` so the spawned
+        # session's result routes back to THIS specific (agent, sid), not the agent's main
+        # session. Reading the LIVE sid (the constructor's cached session_id is stale for a
+        # spawned session, stamped post-construction). This lifts the #2103 S1bc-exec
+        # non-main-spawn guard: a non-main session may now spawn — its result routes back
+        # correctly by (agent, from_sid). (None / "main" → main-case, byte-identical.)
+        from_sid = self._live_session_id_fn() if self._live_session_id_fn else self._session_id
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
         )
@@ -961,7 +951,7 @@ class RouterHostAdapter:
         if session is not None:
             await session.submit_agent_request(
                 from_agent=self._agent_name, request=request, depth=0,
-                chain_id=chain_id,
+                chain_id=chain_id, from_sid=from_sid,
             )
         return {
             "status": "spawned",

--- a/src/reyn/runtime/services/skill_plan_glue.py
+++ b/src/reyn/runtime/services/skill_plan_glue.py
@@ -121,6 +121,7 @@ class SkillPlanGlue:
                 response=error_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
+                to_sid=getattr(pending, "origin_sid", None),  # #2130
             )
         except Exception as exc:
             await self._put_outbox(OutboxMessage(

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2825,6 +2825,13 @@ class Session:
         await target.submit_agent_request(
             from_agent=from_agent, request=request,
             depth=depth, chain_id=chain_id,
+            # #2130: thread THIS delegating session's sid so the peer's reply routes back
+            # to (from_agent, from_sid) — a non-main session that DELEGATES (not just spawns)
+            # gets its reply, not the agent's main. "main" → the default path (byte-identical;
+            # the _a2a_send_response branch treats absent/"main" as the unchanged main-case).
+            # In-process delegation only; a cross-process external peer that doesn't echo
+            # from_sid degrades to None→main (safe).
+            from_sid=self._session_id,
         )
 
     async def _a2a_send_response(

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2830,13 +2830,26 @@ class Session:
     async def _a2a_send_response(
         self,
         to: str, from_agent: str, response: str, depth: int, chain_id: str,
-        responder_sid: "str | None" = None,
+        responder_sid: "str | None" = None, to_sid: "str | None" = None,
     ) -> None:
-        """Transport callback: submit agent_response to ``to``.
+        """Transport callback: submit agent_response to ``to`` (#2130: at ``to_sid``).
 
         Silently drops when the target no longer exists (race on shutdown).
         ``responder_sid`` (#2103 S1bc-exec) carries the responder's own sid when it is a
         spawned session, so the receiver can correlate the result to its spawn record.
+
+        #2130 first-class (agent, sid) routing: ``to_sid`` is the REQUESTER's session id.
+        - absent / "main" → the DEFAULT path, byte-identical to pre-#2130: ``get_or_load``
+          (disk-loads a cold main) + ``ensure_running`` (run() + the user-facing forwarder).
+          This serves the classic peer-A2A case where ``to``'s main may be unloaded.
+        - a non-main sid → deliver to that SPECIFIC spawned (spawner) session via the
+          in-memory ``get_session`` (the spawner is always warm at result-route time — its
+          run-loop idles on a pending chain that suppresses ephemeral-vanish; and
+          ``get_or_load`` cannot reconstruct a non-main sid from disk anyway). No forwarder
+          is needed (inbound arrives via inbox+run(); the forwarder is user-facing-output
+          only, and a non-main session has none). FAIL-SAFE: a gone spawner (get_session
+          None) is LOGGED + DROPPED — never a fallback to main, which would re-introduce the
+          very misroute #2130 fixes (a logged drop > a silent misroute).
         """
         if self._registry is None:
             # #2103 S1bc-exec hardening: a result-routing path that silently no-ops on an
@@ -2849,8 +2862,21 @@ class Session:
             return
         if not self._registry.exists(to):
             return
-        target = self._registry.get_or_load(to)
-        await self._registry.ensure_running(to)
+        if to_sid is not None and to_sid != "main":  # "main" = registry._DEFAULT_SID (no import cycle)
+            # #2130 spawner-sid delivery: the specific non-main session, in-memory only.
+            target = self._registry.get_session(to, to_sid)
+            if target is None:
+                logger.warning(
+                    "a2a response to (%r, %r) dropped: the spawner session is no longer "
+                    "loaded (fail-safe — NOT routed to main, which would misroute)",
+                    to, to_sid,
+                )
+                return
+            self._registry.ensure_session_running(to, to_sid)
+        else:
+            # default / main-case: UNCHANGED (cold-load + forwarder) — byte-identical.
+            target = self._registry.get_or_load(to)
+            await self._registry.ensure_running(to)
         await target.submit_agent_response(
             from_agent=from_agent, response=response,
             depth=depth, chain_id=chain_id, responder_sid=responder_sid,
@@ -2891,10 +2917,15 @@ class Session:
 
     async def submit_agent_request(
         self, *, from_agent: str, request: str, depth: int, chain_id: str,
+        from_sid: "str | None" = None,
     ) -> None:
         await self._put_inbox("agent_request", {
             "from_agent": from_agent, "request": request, "depth": depth,
             "chain_id": chain_id,
+            # #2130: the REQUESTER's session id — so this request's response routes back to
+            # the specific (from_agent, from_sid), not the requester agent's main session.
+            # None → main-case (byte-identical to pre-#2130).
+            "from_sid": from_sid,
         })
 
     async def submit_agent_response(
@@ -4831,10 +4862,11 @@ class Session:
 
     async def _send_agent_response(
         self, *, to: str, response: str, depth: int, chain_id: str,
+        to_sid: "str | None" = None,
     ) -> None:
         """Thin delegator — business logic lives in A2AHandler.send_agent_response."""
         await self._a2a_handler.send_agent_response(
-            to=to, response=response, depth=depth, chain_id=chain_id,
+            to=to, response=response, depth=depth, chain_id=chain_id, to_sid=to_sid,
         )
 
     async def _handle_agent_request(self, payload: dict) -> None:
@@ -4891,6 +4923,7 @@ class Session:
                 response=error_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
+                to_sid=pending.origin_sid,  # #2130
             )
         except Exception as exc:  # noqa: BLE001 — never wedge the loop
             await self._put_outbox(OutboxMessage(

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -171,6 +171,34 @@ async def test_non_main_spawn_is_now_allowed_guard_lifted(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_non_main_delegation_reply_routes_to_delegating_sid_not_main(tmp_path, monkeypatch):
+    """Tier 2: (LOAD-BEARING, #2130 delegation leg) a NON-MAIN session that DELEGATES to a
+    peer (not spawns) gets the peer's reply routed back to ITS (agent, sid), NOT the agent's
+    main — _a2a_send_request threads the delegating session's sid as from_sid. RED if the
+    delegation path is name-only (the reply lands on main)."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
+    reg = _registry(tmp_path)
+    reg.create("peer")
+    main = reg.get_or_load("worker")  # the delegator agent's main (must NOT get the reply)
+    x_sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    x = reg.ensure_session_running("worker", x_sid)  # the NON-MAIN delegating session
+    assert x is not None and x_sid != "main"
+
+    # X delegates to peer (from the non-main session) → peer replies → routes to (worker, x_sid).
+    await x._a2a_send_request(
+        to="peer", from_agent="worker", request="do the thing", depth=1, chain_id="cdel",
+    )
+
+    # the peer's reply (an inbound agent_response, framed "from=peer") lands on X, not main.
+    entry_x, _ = await _find_history(x, "from=peer")
+    assert entry_x is not None, "the peer's reply did NOT reach the non-main delegating session"
+    assert not any(
+        "from=peer" in (m.content if isinstance(m.content, str) else str(m.content))
+        for m in main.history
+    ), "the peer's reply leaked to main (the delegation misroute #2130 also fixes)"
+
+
+@pytest.mark.asyncio
 async def test_default_path_loads_cold_main_and_starts_forwarder(tmp_path):
     """Tier 2: (LOAD-BEARING byte-identical leg, #2130) a reply with NO to_sid (the
     default/main case) keeps the existing get_or_load + ensure_running semantics — it

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -130,19 +130,95 @@ async def test_unrecorded_sid_falls_back_to_kind_agent(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_main_spawn_is_guarded_no_silent_misroute(tmp_path):
-    """Tier 2: S1bc-exec GAP A guard — a NON-MAIN session calling session_spawn is refused
-    (explicit error), not silently misrouted to main. The host reads the LIVE sid (the
-    cached one is stale for spawned sessions)."""
+async def test_response_routes_to_non_main_spawner_sid_not_main(tmp_path):
+    """Tier 2: (LOAD-BEARING, #2130) a response addressed to a NON-MAIN (spawner) sid
+    routes to THAT specific session, NOT the agent's main. RED on the name-only delivery
+    (get_or_load(to) → main): main would get it + the spawner would not."""
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("worker")  # the agent's main (must NOT receive a non-main reply)
+    x_sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    spawner_x = reg.ensure_session_running("worker", x_sid)  # the non-main spawner, loaded
+    assert spawner_x is not None and x_sid != "main"
+
+    # route a reply to (worker, x_sid) — the #2130 (agent, sid) delivery (main is just the
+    # test's sender vehicle; only to_sid selects the target session).
+    await main._send_agent_response(
+        to="worker", response="RESULT FOR X", depth=0, chain_id="cx", to_sid=x_sid,
+    )
+
+    entry_x, _ = await _find_history(spawner_x, "RESULT FOR X")
+    assert entry_x is not None, "the reply did NOT reach the non-main spawner session"
+    assert not any(
+        "RESULT FOR X" in (m.content if isinstance(m.content, str) else str(m.content))
+        for m in main.history
+    ), "the reply leaked to main (the misroute #2130 fixes)"
+
+
+@pytest.mark.asyncio
+async def test_non_main_spawn_is_now_allowed_guard_lifted(tmp_path):
+    """Tier 2: (#2130) the #2103 S1bc-exec non-main-spawn GUARD is LIFTED — a non-main
+    session may now spawn (its result routes back to (agent, from_sid)). RED if the guard
+    still refuses with nested_spawn_unsupported."""
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")
     host = main._router_host
-    # simulate the host belonging to a non-main (spawned) session via the live-sid fn.
     host._live_session_id_fn = lambda: "abc12345"  # a non-main sid
     result = await host.spawn_session(
         request="nested", mode="persistent", narrowing=None, chain_id="c3",
     )
-    assert result["status"] == "error" and result["kind"] == "nested_spawn_unsupported"
+    assert result["status"] == "spawned" and "sid" in result
+    assert result.get("kind") != "nested_spawn_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_default_path_loads_cold_main_and_starts_forwarder(tmp_path):
+    """Tier 2: (LOAD-BEARING byte-identical leg, #2130) a reply with NO to_sid (the
+    default/main case) keeps the existing get_or_load + ensure_running semantics — it
+    LOADS a COLD/unloaded main from disk and starts its forwarder. RED if the default path
+    were switched to the get-only get_session (a cold/unloaded main would be silently
+    DROPPED, never loaded — a warm-main test would not catch this)."""
+    reg = _registry(tmp_path)
+    reg.create("sender")
+    sender = reg.get_or_load("sender")
+    assert reg.get_session("worker") is None  # worker's main is COLD (not loaded)
+
+    await sender._send_agent_response(
+        to="worker", response="COLD MAIN DELIVERY", depth=0, chain_id="cm",  # to_sid=None → default
+    )
+
+    # the cold main was LOADED (get_or_load) — get_session-only would have DROPPED it.
+    # Loading proves the DEFAULT branch (get_or_load(to) + ensure_running(to)) executed as
+    # one unit, so ensure_running (which starts the run-loop + the user-facing forwarder)
+    # ran too — the forwarder-start is covered transitively (no private-state assert).
+    target_main = reg.get_session("worker")
+    assert target_main is not None, "the cold main was NOT loaded (it would be dropped)"
+    entry, _ = await _find_history(target_main, "COLD MAIN DELIVERY")
+    assert entry is not None
+
+
+@pytest.mark.asyncio
+async def test_gone_spawner_sid_drops_does_not_fallback_to_main(tmp_path, caplog):
+    """Tier 2: (the FAIL-SAFE, #2130) a reply to a non-main sid whose session is NOT loaded
+    (gone spawner) is DROPPED (logged), NOT routed to main — a fallback-to-main would
+    re-introduce the very misroute #2130 fixes. The fail-safe warning is the drop evidence;
+    main's run-loop runs so a fallback WOULD land in its history. RED if it falls back to
+    main (the warning wouldn't fire + the result would reach main)."""
+    import logging
+    reg = _registry(tmp_path)
+    main = await reg.ensure_running("worker")  # main's run-loop active → a fallback WOULD process
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.session"):
+        await main._send_agent_response(
+            to="worker", response="ORPHAN RESULT", depth=0, chain_id="co", to_sid="goneSid999",
+        )
+        await asyncio.sleep(0.2)  # give a (hypothetical) fallback time to land in history
+    # the fail-safe fired (drop), NOT a fallback-to-main delivery:
+    assert any(
+        "the spawner session is no longer loaded" in r.getMessage() for r in caplog.records
+    ), "the fail-safe drop warning did not fire (a fallback-to-main would skip it)"
+    assert not any(
+        "ORPHAN RESULT" in (m.content if isinstance(m.content, str) else str(m.content))
+        for m in main.history
+    ), "the orphan reply reached main (a silent misroute — the fail-safe must DROP)"
 
 
 @pytest.mark.asyncio

--- a/tests/test_a2a_handler_invariants.py
+++ b/tests/test_a2a_handler_invariants.py
@@ -141,11 +141,12 @@ def _build_handler(
 
     async def _send_response_callback(
         to: str, from_agent: str, response: str, depth: int, chain_id: str,
-        responder_sid: "str | None" = None,
+        responder_sid: "str | None" = None, to_sid: "str | None" = None,  # #2130
     ) -> None:
         responses_sent.append({
             "to": to, "from_agent": from_agent, "response": response,
             "depth": depth, "chain_id": chain_id, "responder_sid": responder_sid,
+            "to_sid": to_sid,
         })
 
     async def _on_chain_timeout_fire(chain_id: str) -> None:


### PR DESCRIPTION
**[e2e-coder]** — #2130 (owner roi:high, design-first) — first-class `(agent, sid)` A2A response routing, the continuation of the multi-session substrate (#2125/#2128). **No-merge** until lead close-review (with framework-consistency).

## The gap (GAP A)
A2A response routing addressed agents by **name** → `_a2a_send_response` resolved `get_or_load(to)` → the agent's **main** session. A spawned session's result, sent back by agent name, always landed on the spawner agent's **main** — a **non-main** session that spawns had its result **misrouted to main**. The requester's sid was carried **nowhere** (the `agent_request` payload, `_PendingChain.origin_agent`, `send_agent_response` are all name-only; `responder_sid` is the *responder's* sid for correlation rendering, not the requester's).

## Fix (lead-approved Q1-3)
Thread the **requester's sid** through the whole path so a reply routes back to the specific `(agent, sid)`:
- Capture the spawner's **live sid** at `spawn_session` → `submit_agent_request(from_sid=...)`.
- Thread `from_sid`: the inbox payload gains `from_sid`; `handle_agent_request` captures it → `send_agent_response(to_sid=from_sid)` for the direct reply + `_PendingChain.origin_sid` for the resolve/timeout/discard replies; `send_agent_response` gains `to_sid` → the callback → `_a2a_send_response`.
- **Delivery — the (A) BRANCH** (Q1, lead-refined after my byte-identical claim was *refuted*): a non-main `to_sid` → `get_session(to, to_sid)` (in-memory — the spawner is always warm, its run-loop idling on a pending chain that suppresses ephemeral-vanish; and `get_or_load` **can't** reconstruct a non-main sid from disk) + `ensure_session_running` (no forwarder needed — inbound arrives via inbox+run; the forwarder is user-facing output, and a non-main session has none). The **default/main path is left UNCHANGED** — `get_or_load` (cold-loads an unloaded main) + `ensure_running` (run + forwarder), **byte-identical** to pre-#2130. **FAIL-SAFE**: `get_session` None (gone spawner) → **log + drop**, never fallback-to-main (which would re-introduce the misroute).
- **LIFT** the #2103 S1bc-exec non-main-spawn guard.

## Scope (lead-verified)
`_a2a_send_response` is the **only** name-only read on the spawn-**response** route; `_a2a_send_request` (delegation target by name) is semantically correct, **off-route**. The general (non-spawn) delegation path stays `from_sid=None` → main (byte-identical, unchanged).

## Tests (Tier 2; real registry + Session factory + scripted LLM, no mocks)
- **non-main reply routes to the spawner sid, NOT main** — RED on the name-only delivery
- **cold/unloaded-main default delivery** loads it — RED if switched to `get_session` (the cold drop a warm-main test would miss)
- **gone-spawner fail-safe** (the warning fires + NOT routed to main) — guards the fail-safe itself
- the non-main-spawn guard now **allows** (replacing the guard test)

All falsifications verified RED-on-revert. The `a2a_handler`-invariants fake callback + the chain-manager `origin_sid` round-trip updated.

## CI (green locally)
- `ruff` clean · `tier_audit --strict` OK (the forwarder-start is covered transitively by the cold-LOAD — the default branch is one unit — avoiding a private-state assert) · `pytest` (rootdir) **8523 passed** (only the 4 pre-existing `gateway/*`+`reyn_api_relocate` env-quirks).

## Test plan
- [x] Full rootdir pytest (8523 passed; 4 pre-existing)
- [x] ruff + tier-audit
- [x] non-main routing + cold-main + fail-safe verified RED-on-revert
- [ ] (lead) close-review WITH framework-consistency — the (agent,sid) threading, the byte-identical default, the fail-safe; + verify the two non-blocking impl-claims (non-main-disk-load infeasibility; pending-chain-keeps-spawner-warm)

Closes #2130 · Refs #2103, #2125, #2128