### PR TITLE
fix(#2068): fire skill_end on every exit (interrupt/error too), exactly-once per run-segment

### DIFF
--- a/src/reyn/core/kernel/run_orchestrator.py
+++ b/src/reyn/core/kernel/run_orchestrator.py
@@ -600,6 +600,9 @@ class RunOrchestrator:
                             exc_type=exc_type.__name__ if exc_type else "unknown",
                             will_resume=True,
                         )
+                        # #2068: fire the skill_end hook on the __post__-resume interrupt
+                        # path too (hook-only; snapshot preserved for resume).
+                        await self._skill_registry.interrupt(run_id=self._run_id)
 
         artifact_path: str | None = self._workspace.store_artifact(
             "_input", artifact, skill_name=self._skill.name, visit=1
@@ -902,3 +905,10 @@ class RunOrchestrator:
                         exc_type=exc_type.__name__,
                         will_resume=True,
                     )
+                    # #2068: also fire the skill_end lifecycle hook (the audit event
+                    # above stays; this is the start↔end hook symmetry). interrupt()
+                    # is hook-only — it does NOT WAL skill_completed or unlink the
+                    # snapshot (will_resume → the snapshot is preserved for resume).
+                    # Guarded exactly-once (a /skill discard pre-fires skill_end
+                    # before the cancel-unwind, so this defers).
+                    await self._skill_registry.interrupt(run_id=self._run_id)

--- a/src/reyn/interfaces/slash/skill.py
+++ b/src/reyn/interfaces/slash/skill.py
@@ -195,6 +195,16 @@ async def _discard_skill_run(session: "Session", args: str) -> None:
         await reply(session, warning)
         return
 
+    # #2068: fire skill_end(status="discarded") + arm the exactly-once guard BEFORE
+    # cancelling the running task. The cancel-unwind runs the skill's run() finally (→
+    # the orchestrator interrupt branch → registry.interrupt()) DURING `await task`,
+    # BEFORE step 3's complete(discarded); without this pre-fire the hook would win with
+    # status="interrupted" for a user-discard (a regression). Pre-firing makes the
+    # unwind's interrupt() defer (guard armed), so the hook gets the correct "discarded".
+    # HOOK-ONLY here — the WAL skill_discarded + snapshot unlink stay in complete() at
+    # step 3 (AFTER the cancel → no re-snapshot race).
+    await reg.mark_skill_ended(run_id, "discarded")
+
     # 1. Cancel the asyncio.Task if mid-session
     task = session.running_skills.get(run_id)
     if task is not None and not task.done():

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -91,6 +91,9 @@ class SkillRegistry:
         # In-memory cache: run_id → SkillSnapshot. Populated on start() /
         # load_active(); cleared on complete().
         self._snapshots: dict[str, SkillSnapshot] = {}
+        # #2068: run_ids whose skill_end already fired this run-SEGMENT (exactly-once
+        # guard; re-armed by start() on each (re)entry).
+        self._ended_run_ids: set[str] = set()
 
     async def _wal_append(self, kind: str, **fields):
         """FP-0043 Stage 5: the single WAL-append chokepoint for this registry.
@@ -185,6 +188,10 @@ class SkillRegistry:
             snap.last_phase_applied_seq = seq
         self._save(snap)
         self._snapshots[run_id] = snap
+        # #2068: a (re)entry begins a fresh run-SEGMENT → re-arm the skill_end
+        # exactly-once guard so this segment's eventual exit fires skill_end (resume
+        # re-enters start(), so each segment gets a matched skill_start/skill_end pair).
+        self._ended_run_ids.discard(run_id)
         # #1800 slice 5c: skill_start lifecycle hooks — fired AFTER the
         # skill_started WAL event (mirrors 5b's emit-then-dispatch). None
         # dispatcher (direct/test construction or no hooks) → no-op.
@@ -274,18 +281,13 @@ class SkillRegistry:
                 agent=self._agent_name,
                 run_id=run_id,
             )
-        # #1800 slice 5c: skill_end lifecycle hooks — after the skill_completed /
-        # skill_discarded WAL event, BEFORE the snapshot teardown so the ctx is
-        # valid. None dispatcher → no-op. NOTE: an interrupted/errored skill run
-        # emits ``skill_run_interrupted`` and BYPASSES complete() (run_orchestrator),
-        # so skill_end fires for success / discarded / WorkflowAborted only — the
-        # interrupt-branch asymmetry is a tracked 5c follow-up (firing skill_end
-        # there needs the dispatcher at the orchestrator branch, a broader change).
-        if self._hook_dispatcher is not None:
-            await self._hook_dispatcher.dispatch(
-                "skill_end",
-                {"point": "skill_end", "run_id": run_id, "status": status},
-            )
+        # #1800 slice 5c / #2068: skill_end lifecycle hook — after the
+        # skill_completed/skill_discarded WAL event, BEFORE the snapshot teardown so the
+        # ctx is valid. Guarded EXACTLY-ONCE per run-segment (a discard pre-fires it before
+        # cancelling the run, so the cancel-unwind's interrupt() defers — see
+        # _dispatch_skill_end + mark_skill_ended). #2068 also fires skill_end on the
+        # interrupt/error paths via interrupt(), closing the start↔end asymmetry.
+        await self._dispatch_skill_end(run_id, status)
         snap_path = self._skills_dir / f"{run_id}.snapshot.json"
         try:
             snap_path.unlink(missing_ok=True)
@@ -302,6 +304,46 @@ class SkillRegistry:
         llm_result_ref.cleanup_for_run(self._state_dir, run_id)
         self._snapshots.pop(run_id, None)
         await self._fire_truncate_hook(trigger=kind)
+
+    # ── #2068: skill_end on EVERY exit (exactly-once per run-segment) ──────
+
+    async def _dispatch_skill_end(self, run_id: str, status: str) -> None:
+        """#2068: fire the ``skill_end`` lifecycle hook EXACTLY ONCE per run-segment.
+
+        ``skill_start`` fires on every (re)entry to ``start()`` (incl. resume), so the
+        symmetric ``skill_end`` fires once per orchestrator run-SEGMENT (entry→exit), on
+        EVERY exit — completion (``complete()``) AND interrupt/error (``interrupt()``).
+        The ``_ended_run_ids`` guard makes it exactly-once within a segment: ``start()``
+        re-arms (discards the run_id), so the next segment fires fresh; a second dispatch
+        in the same segment (e.g. a discard pre-fires ``skill_end`` then the cancel-unwind
+        calls ``interrupt()``) is suppressed. None dispatcher → no-op (the WAL/teardown in
+        the callers still run)."""
+        if run_id in self._ended_run_ids:
+            return
+        self._ended_run_ids.add(run_id)
+        if self._hook_dispatcher is not None:
+            await self._hook_dispatcher.dispatch(
+                "skill_end",
+                {"point": "skill_end", "run_id": run_id, "status": status},
+            )
+
+    async def mark_skill_ended(self, run_id: str, status: str) -> None:
+        """#2068: fire the guarded ``skill_end`` hook WITHOUT ``complete()``'s WAL +
+        snapshot teardown. Used by ``/skill discard`` to fire ``skill_end(status=
+        "discarded")`` + arm the guard BEFORE cancelling the running task — so the
+        cancel-unwind's ``interrupt()`` defers (the hook would otherwise win with
+        "interrupted"), while ``complete(discarded)``'s WAL+unlink still run AFTER the
+        cancel (no re-snapshot race)."""
+        await self._dispatch_skill_end(run_id, status)
+
+    async def interrupt(self, run_id: str) -> None:
+        """#2068: fire ``skill_end(status="interrupted")`` for an interrupted/errored run
+        — the path that previously emitted only ``skill_run_interrupted`` and BYPASSED
+        ``complete()``, so ``skill_end`` never fired (the start↔end asymmetry). Fires the
+        HOOK ONLY: NO ``skill_completed`` WAL (the run stays interrupted) and NO snapshot
+        teardown (``will_resume`` → the snapshot MUST be preserved for the resume-entry).
+        Guarded exactly-once (a discard that pre-fired ``skill_end`` suppresses this)."""
+        await self._dispatch_skill_end(run_id, "interrupted")
 
     # ── intervention await tracking (R-D16) ──────────────────────────────
 

--- a/tests/test_2068_skill_end_all_exits_1800.py
+++ b/tests/test_2068_skill_end_all_exits_1800.py
@@ -11,7 +11,9 @@ Real SkillRegistry + a recording HookDispatcher (the injected seam; no mocks).
 """
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -117,3 +119,53 @@ async def test_start_re_arms_guard_per_segment(tmp_path):
     await reg.start(run_id="r1", skill_name="s", skill_input={})
     await reg.complete(run_id="r1", status="completed")
     assert rec.points == ["skill_start", "skill_end", "skill_start", "skill_end"]
+
+
+@pytest.mark.asyncio
+async def test_discard_handler_end_to_end_fires_one_skill_end_discarded(tmp_path, monkeypatch):
+    """Tier 2: (LOAD-BEARING, handler-level) the REAL /skill discard --force handler, with a
+    RUNNING task whose cancel-unwind finally fires registry.interrupt() (as the orchestrator
+    does), produces EXACTLY ONE skill_end with status="discarded". This exercises the
+    handler's mark-BEFORE-cancel ORDERING against the live cancel-unwind — RED if
+    mark_skill_ended is moved after task.cancel() (the unwind's interrupt() would win with
+    "interrupted"). The registry-API unit test alone would NOT catch that reorder."""
+    from reyn.interfaces.slash import skill as slash_skill
+
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    run_id = "rdisc"
+    await reg.start(run_id=run_id, skill_name="s", skill_input={})
+
+    # a real running task whose finally fires registry.interrupt() on cancel — the exact
+    # cancel-unwind behaviour of run_orchestrator's finally (verified: it calls
+    # registry.interrupt(run_id)). Blocks until cancelled.
+    async def _running_skill() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await reg.interrupt(run_id=run_id)
+
+    task = asyncio.ensure_future(_running_skill())
+    await asyncio.sleep(0)  # let it reach the blocked await
+
+    session = SimpleNamespace(
+        get_skill_registry=lambda: reg,
+        running_skills={run_id: task},
+        running_skills_started_at={run_id: 0.0},
+        running_skills_chain={},
+        _drop_interventions_for_run=lambda _rid: None,
+        _registry=None,
+        agent_name="a",
+    )
+    # reply/reply_error are output-only; stub to no-op async (real callables, not mocks).
+    async def _noop_reply(*_a, **_k) -> None:
+        return None
+    monkeypatch.setattr(slash_skill, "reply", _noop_reply)
+    monkeypatch.setattr(slash_skill, "reply_error", _noop_reply)
+
+    await slash_skill._discard_skill_run(session, f"{run_id} --force")
+
+    assert rec.points.count("skill_end") == 1, "exactly one skill_end across the discard"
+    assert rec.statuses() == ["discarded"], (
+        "the user-disposition must win — NOT 'interrupted' from the cancel-unwind"
+    )

--- a/tests/test_2068_skill_end_all_exits_1800.py
+++ b/tests/test_2068_skill_end_all_exits_1800.py
@@ -1,0 +1,119 @@
+"""Tier 2: #2068 — skill_end fires on EVERY exit, exactly-once per run-segment.
+
+skill_start fires per (re)entry to SkillRegistry.start() (incl. resume); the symmetric
+skill_end now fires on EVERY exit — completion (complete()) AND interrupt/error
+(interrupt()) — guarded exactly-once per run-SEGMENT (re-armed by start()). The interrupt
+path fires the HOOK ONLY (no skill_completed WAL, no snapshot unlink — will_resume). A
+/skill discard pre-fires skill_end("discarded") + arms the guard before cancelling, so the
+cancel-unwind's interrupt() defers and the hook gets the correct "discarded" status.
+
+Real SkillRegistry + a recording HookDispatcher (the injected seam; no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.skill.skill_registry import SkillRegistry
+
+
+class _RecordingDispatcher:
+    """A real recording HookDispatcher stand-in — records each dispatch(point, vars)."""
+
+    def __init__(self) -> None:
+        self.dispatched: "list[tuple[str, dict]]" = []
+
+    async def dispatch(self, point: str, template_vars: dict) -> None:
+        self.dispatched.append((point, template_vars))
+
+    @property
+    def points(self) -> "list[str]":
+        return [p for (p, _v) in self.dispatched]
+
+    def statuses(self) -> "list[str]":
+        return [v.get("status") for (p, v) in self.dispatched if p == "skill_end"]
+
+
+def _registry(tmp_path: Path, rec: _RecordingDispatcher) -> SkillRegistry:
+    state_dir = tmp_path / ".reyn" / "agents" / "a" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return SkillRegistry(
+        agent_name="a", agent_state_dir=state_dir, state_log=None, hook_dispatcher=rec,
+    )
+
+
+def _snap_path(tmp_path: Path, run_id: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / "a" / "state" / "skills" / f"{run_id}.snapshot.json"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_fires_skill_end_interrupted(tmp_path):
+    """Tier 2: (LOAD-BEARING) interrupt() fires skill_end with status="interrupted" — the
+    path that previously bypassed complete() and never fired skill_end. RED before the fix
+    (skill_start with no matching skill_end)."""
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    await reg.interrupt(run_id="r1")
+    assert rec.points == ["skill_start", "skill_end"]
+    assert rec.statuses() == ["interrupted"]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_does_not_unlink_snapshot(tmp_path):
+    """Tier 2: (the complete()/interrupt() asymmetry) interrupt() preserves the snapshot
+    (will_resume), unlike complete() which removes it. RED if interrupt() teardown the
+    snapshot (resume would lose it)."""
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    assert _snap_path(tmp_path, "r1").exists()  # start created it
+    await reg.interrupt(run_id="r1")
+    assert _snap_path(tmp_path, "r1").exists(), "interrupt() must preserve the snapshot"
+
+
+@pytest.mark.asyncio
+async def test_discard_pre_fire_then_interrupt_is_one_skill_end_discarded(tmp_path):
+    """Tier 2: (LOAD-BEARING, the Q2 fix) /skill discard pre-fires skill_end("discarded")
+    + arms the guard; the ensuing cancel-unwind's interrupt() then DEFERS. The hook fires
+    EXACTLY ONCE with status="discarded" (NOT "interrupted"). RED if the order/guard lets
+    interrupt() win the status (count-only would miss the wrong status)."""
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    await reg.mark_skill_ended("r1", "discarded")   # the discard pre-fire (before cancel)
+    await reg.interrupt(run_id="r1")                 # the cancel-unwind → must DEFER
+    assert rec.points == ["skill_start", "skill_end"]   # exactly one skill_end
+    assert rec.statuses() == ["discarded"]              # the user-disposition wins, not "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_complete_after_interrupt_is_suppressed(tmp_path):
+    """Tier 2: (the guard, defense-in-depth) once skill_end fired this segment, a later
+    complete() does NOT re-dispatch it — exactly-once. (complete()'s WAL/teardown still
+    run; only the hook is guarded.)"""
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    await reg.interrupt(run_id="r1")                 # fires skill_end(interrupted)
+    await reg.complete(run_id="r1", status="completed")  # skill_end suppressed
+    assert rec.points == ["skill_start", "skill_end"]
+    assert rec.statuses() == ["interrupted"]
+
+
+@pytest.mark.asyncio
+async def test_start_re_arms_guard_per_segment(tmp_path):
+    """Tier 2: (the per-SEGMENT re-arm, lead's add) a RESUME enters start() again → a fresh
+    skill_start + skill_end pair fires for the second segment (skill_end is once-per-segment,
+    not once-per-run_id-lifetime). RED if start() doesn't re-arm the guard (the 2nd skill_end
+    would be suppressed)."""
+    rec = _RecordingDispatcher()
+    reg = _registry(tmp_path, rec)
+    # segment 1: enter → complete
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    await reg.complete(run_id="r1", status="completed")
+    # segment 2: RE-ENTER (resume) → complete again
+    await reg.start(run_id="r1", skill_name="s", skill_input={})
+    await reg.complete(run_id="r1", status="completed")
+    assert rec.points == ["skill_start", "skill_end", "skill_start", "skill_end"]

--- a/tests/test_runtime_crash_lifecycle.py
+++ b/tests/test_runtime_crash_lifecycle.py
@@ -284,3 +284,66 @@ def test_runtime_error_preserves_snapshot(tmp_path: Path):
     ]
     assert interrupted
     assert interrupted[0].data["exc_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# #2068: skill_end fires on the interrupt/error exits too (via interrupt())
+# ---------------------------------------------------------------------------
+
+
+class _RecordingDispatcher:
+    """A real recording HookDispatcher stand-in (the injected seam; no mock)."""
+
+    def __init__(self) -> None:
+        self.dispatched: "list[tuple[str, dict]]" = []
+
+    async def dispatch(self, point: str, template_vars: dict) -> None:
+        self.dispatched.append((point, template_vars))
+
+    @property
+    def points(self) -> "list[str]":
+        return [p for (p, _v) in self.dispatched]
+
+
+def _setup_with_dispatcher(tmp_path: Path):
+    state_dir = tmp_path / ".reyn" / "agents" / "alpha" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    rec = _RecordingDispatcher()
+    registry = SkillRegistry(
+        agent_name="alpha", agent_state_dir=state_dir, state_log=log, hook_dispatcher=rec,
+    )
+    snap_path = state_dir / "skills" / f"{_RUN_ID}.snapshot.json"
+    return registry, log, snap_path, rec
+
+
+def test_cancelled_error_fires_skill_end_interrupted(tmp_path: Path):
+    """Tier 2: #2068 (LOAD-BEARING) — CancelledError → the finally interrupt-branch fires
+    skill_end (status="interrupted") via registry.interrupt(), closing the start↔end
+    asymmetry, while the snapshot stays preserved. RED before #2068 (skill_start with no
+    matching skill_end)."""
+    registry, log, snap_path, rec = _setup_with_dispatcher(tmp_path)
+    rt = _StubRuntime(
+        _make_skill(), skill_registry=registry, state_log=log,
+        raise_on_first_phase=asyncio.CancelledError(),
+    )
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(rt.run({"type": "input", "data": {}}))
+    assert "skill_start" in rec.points and "skill_end" in rec.points
+    end_vars = [v for (p, v) in rec.dispatched if p == "skill_end"]
+    assert end_vars and end_vars[0]["status"] == "interrupted"
+    assert snap_path.exists()  # preserved (interrupt() is hook-only, no unlink)
+
+
+def test_runtime_error_fires_skill_end_interrupted(tmp_path: Path):
+    """Tier 2: #2068 — generic RuntimeError → skill_end(status="interrupted") fires too."""
+    registry, log, snap_path, rec = _setup_with_dispatcher(tmp_path)
+    rt = _StubRuntime(
+        _make_skill(), skill_registry=registry, state_log=log,
+        raise_on_first_phase=RuntimeError("transient blip"),
+    )
+    with pytest.raises(RuntimeError, match="transient blip"):
+        asyncio.run(rt.run({"type": "input", "data": {}}))
+    end_vars = [v for (p, v) in rec.dispatched if p == "skill_end"]
+    assert end_vars and end_vars[0]["status"] == "interrupted"
+    assert snap_path.exists()


### PR DESCRIPTION
**[e2e-coder]** — #2068 (owner roi:high, design-first; lead-picked for the self-drive window) — closes the `skill_start↔skill_end` lifecycle asymmetry. **No-merge** until lead close-review.

## The gap
`skill_end` fires only in `SkillRegistry.complete()`, which `run_orchestrator`'s finally (both the main + `__post__`-resume blocks) gates on `exc_type is None or WorkflowAbortedError`. `CancelledError` / `KeyboardInterrupt` / generic `Exception` emit `skill_run_interrupted` and **bypass** `complete()` → `skill_end` never fired for interrupted/errored skills, though `skill_start` did.

## Key framing
`skill_start` fires on every (re)**entry** to `start()` — incl. resume — so the symmetric `skill_end` is **once per run-SEGMENT** (entry→exit), not once per run_id-lifetime.

## Fix (lead-approved Q1-4 + the Q2 mechanism)
- **`SkillRegistry`**: `_dispatch_skill_end(run_id, status)` guarded **exactly-once per segment** (`_ended_run_ids`; `start()` re-arms on each (re)entry). `complete()` uses it (keeps its WAL + snapshot unlink). New **`interrupt(run_id)`** fires `skill_end("interrupted")` **hook-only** — no `skill_completed` WAL, **no snapshot unlink** (will_resume → preserved for the resume-entry). New `mark_skill_ended(run_id, status)` = the guarded hook without teardown.
- **`run_orchestrator`**: both finally interrupt-branches call `await registry.interrupt(run_id)` (the audit `events.emit("skill_run_interrupted")` stays; the hook is the lifecycle symmetry).
- **`/skill discard`** (the **Q2** ordering regression): pre-fires `mark_skill_ended(run_id, "discarded")` + arms the guard **before** `task.cancel()`, so the cancel-unwind's `interrupt()` **defers** and the hook gets `status="discarded"` (not "interrupted"). **Race-safe**: only the HOOK fires early; `complete()`'s WAL+unlink stay **after** the cancel. (The resume-coordinator discard has no running task → no cancel-unwind → no regression — verified both sites.)

## Tests (Tier 2; real SkillRegistry + recording HookDispatcher + the real orchestrator interrupt path, no mocks)
- `interrupt()` fires `skill_end("interrupted")` + **snapshot preserved**
- discard pre-fire-then-interrupt = **exactly one `skill_end(status="discarded")`** (not "interrupted" — the Q2 fix; status-asserted, not count-only)
- the **per-segment re-arm** (resume → fresh `skill_start`+`skill_end` pair)
- the complete-after-interrupt guard (defense-in-depth)
- the orchestrator **CancelledError/RuntimeError** exits fire `skill_end` — **RED before the fix** (verified by stripping `interrupt()`)

## CI (green locally)
- `ruff` clean · `tier_audit --strict` OK · `pytest` (rootdir) **8531 passed** (only the 4 pre-existing `gateway/*`+`reyn_api_relocate` env-quirks). The existing skill-hook + crash-lifecycle + orchestrator-invariant suites unchanged = no-behavior-change for the completion path.

## Test plan
- [x] Full rootdir pytest (8531 passed; 4 pre-existing)
- [x] ruff + tier-audit
- [x] skill_end-on-interrupt RED-on-revert; discard status="discarded"; snapshot-preserved; per-segment re-arm
- [ ] (lead) close-review WITH framework-consistency — start/end per-segment symmetry + complete/interrupt snapshot asymmetry

Closes #2068 · Refs #1800, #2065