### PR TITLE
feat(#2180): one shared Task backend (one connection) per agent

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -335,7 +335,6 @@ def run(args: argparse.Namespace) -> None:
     from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
     from reyn.security.permissions.permissions import PermissionResolver
-    from reyn.task import per_session_sqlite_backend  # #1953 slice R
 
     session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
@@ -450,9 +449,14 @@ def run(args: argparse.Namespace) -> None:
             registry=registry,  # back-reference for :agents / :attach + PR11 messaging
             allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
-            # #1953 slice R, I-5=(A): per-session sqlite Task backend → in-session
-            # task.* ops are durable + rewind with the session (local single-tenant).
-            task_backend=per_session_sqlite_backend(profile.name),
+            # #1953 slice R, I-5=(A): sqlite Task backend → in-session task.* ops are
+            # durable + rewind with the session (local single-tenant).
+            # #2180: the agent's SHARED backend (ONE connection per agent) via the
+            # registry's single construction seam — NOT a direct per_session_sqlite_backend
+            # (that opened an N+1 connection per session, the #2125 cross-connection write
+            # race). The factory closure captures ``registry`` (assigned below), so this
+            # resolves at session-construction time.
+            task_backend=registry.task_backend_for(profile.name),
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -330,7 +330,6 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
     from reyn.security.permissions.permissions import PermissionResolver
-    from reyn.task import per_session_sqlite_backend  # #1953 slice R
 
     session_cfg = InvocationContext.from_args(args)
     from reyn.interfaces.cli.credentials_check import verify_credentials_or_exit
@@ -415,10 +414,13 @@ def run_serve(args: argparse.Namespace) -> None:
             registry=registry,
             allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
-            # #1953 slice R, I-5=(A): stdio-MCP is single-tenant per process, so a
-            # per-session sqlite backend (rewind-participating) ≈ the singleton —
-            # durable in-session task state, opt-in rewind (flag #3 confirmed).
-            task_backend=per_session_sqlite_backend(profile.name),
+            # #1953 slice R, I-5=(A): stdio-MCP is single-tenant per process, so the
+            # agent's sqlite backend (rewind-participating) ≈ the singleton — durable
+            # in-session task state, opt-in rewind (flag #3 confirmed).
+            # #2180: the agent's SHARED backend via the registry's single construction
+            # seam (ONE connection per agent) — NOT a direct per_session_sqlite_backend
+            # (the N+1-connection #2125 race). The factory closure captures ``registry``.
+            task_backend=registry.task_backend_for(profile.name),
             events_config=session_cfg.config.events,
             state_log=state_log,
             budget_tracker=budget_tracker,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -681,6 +681,13 @@ class AgentRegistry:
             # runtime PITR generations (rewind-to-before-purge is intentionally
             # unsupported); the real escape hatch for a genuine delete.
             import shutil
+            # #2180: close + evict the agent's shared Task backend BEFORE the rmtree —
+            # this is the LIVE archive_agent(purge=True) teardown path (alongside
+            # _drop_agent + _purge_archived_below). Skipping it would strand a dangling
+            # connection over the deleted inode in ``_task_backends`` AND leave the cache
+            # entry, so a NEW agent reusing this name would get the stale handle and write
+            # to the wrong/deleted file (a name-reuse correctness hazard, not just a leak).
+            self._close_task_backend(name)
             shutil.rmtree(target)
             # PR12: a hard-deleted agent would leave dangling topology references,
             # so drop it from every topology (a team losing its leader / an
@@ -1551,9 +1558,10 @@ class AgentRegistry:
 
         ``purge_dir=False`` (the rewind path) defers the destructive on-disk rmtree to
         the caller, so it runs only AFTER the substrate restores succeed (#2125 atomicity
-        — a restore-failure must not leave the dir dropped). The connection-release
-        (quiesce + backend close) still happens here, because it MUST precede the
-        ``_restore_task_active`` file-swap (that is the lock fix)."""
+        — a restore-failure must not leave the dir dropped). The session is quiesced here
+        (in-flight task writes settle before teardown); #2180: the Task backend is NOT
+        closed on a session drop — it is agent-shared (one connection per agent), closed
+        only on agent teardown, so the surviving sessions keep using it."""
         await self.remove_session(name, sid, purge_dir=purge_dir, record=False)
 
     async def remove_session(
@@ -1561,22 +1569,22 @@ class AgentRegistry:
     ) -> bool:
         """#2103 S1bc: tear down a SPAWNED (non-main) session — the single teardown
         seam used by BOTH the rewind as-of-cut DROP (``_drop_session``) AND the
-        ephemeral auto-vanish. Quiesces + closes the session's per-session Task backend,
-        cancels the ``(name, sid)`` run-loop + forwarder tasks, drops it from the
-        in-memory map, and (``purge_dir``) removes its on-disk per-session state dir
-        (``state/sessions/<enc(sid)>/``). Returns True iff anything was removed.
+        ephemeral auto-vanish. Quiesces the session, cancels the ``(name, sid)`` run-loop +
+        forwarder tasks, drops it from the in-memory map, and (``purge_dir``) removes its
+        on-disk per-session state dir (``state/sessions/<enc(sid)>/``). Returns True iff
+        anything was removed.
 
-        #2125 (the differentiator: rewind-across-spawn): the per-session Task backend is a
-        SEPARATE ``sqlite3`` connection to the agent's shared ``tasks.db`` (one connection
-        per constructed session). Cancelling the run-loop WITHOUT closing that connection
-        left it open → ``_restore_task_active``'s ``restore_to_seq`` file-swap hit
-        "database is locked" (``busy_timeout=0``). So here we mirror the global-rewind
-        stop-world (``cancel_inflight`` + ``await_quiescent``, registry rewind_to 824-829 —
-        idempotent when rewind_to already quiesced; REQUIRED for the ephemeral caller,
-        which has no rewind orchestration) and then ``close()`` the backend — a
-        deterministic rollback of any open ``BEGIN IMMEDIATE`` + lock release. Closing is
-        safe because the backend is a per-session instance (not shared with the surviving
-        sessions, which keep their own connections to the same file).
+        #2180 (supersedes the #2125 per-session close): the Task backend is agent-SHARED —
+        ONE ``sqlite3`` connection per agent (registry-owned via ``task_backend_for``),
+        held by EVERY session of the agent. So this seam must NOT close it: closing on one
+        session's drop would strand every surviving sibling (use-after-close on the shared
+        connection). It only QUIESCES (``cancel_inflight`` + ``await_quiescent``, mirroring
+        the global-rewind stop-world — idempotent when rewind_to already quiesced; REQUIRED
+        for the ephemeral caller, which has no rewind orchestration) so any in-flight
+        ``BEGIN IMMEDIATE`` settles before teardown. The connection is closed only on agent
+        teardown (purge / rewind-drop, ``_close_task_backend``). With one connection ever,
+        the #2125 close-before-restore collapses: ``_restore_task_active`` file-swaps
+        through that single live connection's ``restore_to_seq``.
 
         Full teardown (rmtree) is correct: the global WAL is the durable source — the
         ``session_spawned`` create-record + the session's session_id-routed entries
@@ -1785,9 +1793,10 @@ class AgentRegistry:
                 spawned_after_cut = sess_seq is not None and sess_seq > drop_cut
                 vanished_by_cut = van_seq is not None and van_seq <= drop_cut
                 if spawned_after_cut or vanished_by_cut:
-                    # #2125: detach now (quiesce + close the Task-backend connection
-                    # so _restore_task_active doesn't hit "database is locked"); defer
-                    # the destructive rmtree until the restores below succeed.
+                    # #2125/#2180: detach now (quiesce in-flight writes; the agent-shared
+                    # Task backend is NOT closed on a session drop — one connection per
+                    # agent, so _restore_task_active file-swaps through that single live
+                    # connection); defer the destructive rmtree until the restores succeed.
                     await self._drop_session(name, sid, purge_dir=False)
                     deferred_session_purges.append((name, sid))
                     continue

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -272,6 +272,18 @@ class AgentRegistry:
         # restore derives every loaded agent's rewind backend at use-time
         # (``_rewind_backends``), and the prune is disk-driven over on-disk agents — so
         # no per-construction pointer is held (it was multi-AGENT-incorrect: last-wins).
+        # #2180: the agent's Task backend is now registry-OWNED, ONE per agent, built
+        # lazily + cached here (mirrors ``_workspace_store``'s registry-owned-lazy
+        # ownership, per-agent keyed like ``_sessions``). ALL of an agent's sessions
+        # share this single instance via ``task_backend_for`` (the single construction
+        # seam), so the per-instance ``asyncio.Lock`` serialises every write to the
+        # agent-keyed ``tasks.db`` (restores the ``busy_timeout=0`` premise that N
+        # per-session connections broke — #2125) and the ``restore_to_seq`` file-swap
+        # has no sibling connection to strand. Process-lifetime for a live agent (parity
+        # with ``_state_log``/``_workspace_store``, never closed — a bounded per-process
+        # leak, called out, not silently inherited); closed + evicted on agent PURGE /
+        # rewind-drop (``_close_task_backend``); KEPT on archive (recoverable / rewind).
+        self._task_backends: "dict[str, object]" = {}
         # ADR-0038 #1544: FS+exec backend. None / name!="container" → host mode
         # (host subprocess git runner). When container, git runs in-container via
         # backend.run with the container path context (the work-tree is
@@ -1386,6 +1398,9 @@ class AgentRegistry:
         (they nest under the agent dir). Best-effort, but a failure is LOGGED (not
         silently swallowed) so a stuck teardown is visible (#2114 review note)."""
         import shutil
+        # #2180: close + evict the agent's shared Task backend BEFORE rmtree so its
+        # single connection's handle on tasks.db is released ahead of the dir removal.
+        self._close_task_backend(name)
         try:
             shutil.rmtree(self._dir / name)
         except FileNotFoundError:
@@ -1572,8 +1587,16 @@ class AgentRegistry:
         if sid == _DEFAULT_SID:
             raise ValueError("cannot remove the main session via remove_session")
         removed = False
-        # #2125: quiesce + close the per-session Task-backend connection BEFORE teardown
-        # so its SQLite lock releases ahead of any _restore_task_active file-swap.
+        # #2125: quiesce the session BEFORE teardown so any in-flight task write
+        # completes ahead of a teardown / _restore_task_active file-swap.
+        # #2180: do NOT close the Task backend here — it is now agent-SHARED (one
+        # connection per agent, registry-owned via ``task_backend_for``), so closing it
+        # on one session's drop would strand every SURVIVING sibling session of the same
+        # agent (use-after-close on the shared connection). The connection is closed only
+        # on agent teardown (PURGE / rewind-drop) via ``_close_task_backend``. With one
+        # connection ever, the #2125 close-before-restore collapses: ``_restore_task_active``
+        # file-swaps through that single live connection's ``restore_to_seq`` (close →
+        # copy → reopen on the same instance) — no sibling connection to release first.
         session = self._peek_session(name, sid)
         if session is not None:
             cancel_inflight = getattr(session, "cancel_inflight", None)
@@ -1582,10 +1605,6 @@ class AgentRegistry:
             quiesce = getattr(session, "await_quiescent", None)
             if callable(quiesce):
                 await quiesce()
-            tb = getattr(session, "task_backend", None)
-            close = getattr(tb, "close", None) if tb is not None else None
-            if callable(close):
-                close()
         for task_dict in (self._tasks, self._forward_tasks):
             task = task_dict.pop((name, sid), None)
             if task is not None:
@@ -1613,6 +1632,47 @@ class AgentRegistry:
                 "session_vanished", entity_kind="session", name=name, sid=sid,
             )
         return removed
+
+    def task_backend_for(self, name: str) -> "object":
+        """#2180: the agent's SHARED Task backend — ONE per agent, built lazily + cached.
+
+        The SINGLE construction seam for every session of an agent: chat / stdio-MCP
+        session construction routes ``task_backend=`` through here (NOT a direct
+        ``create_task_backend`` / ``SqliteTaskBackend`` over the agent-keyed path — that
+        would open an N+1 connection and silently reintroduce the #2125 cross-connection
+        write race; #2180 removed the per-session helper that did so). Two
+        sessions of one agent therefore get the SAME instance (``is`` identity), so the
+        backend's per-instance ``asyncio.Lock`` serialises ALL of that agent's writes to
+        the agent-keyed ``tasks.db`` and the ``restore_to_seq`` file-swap is the only
+        connection touching the file. Path is registry-relative (``self._dir`` =
+        ``project_root/.reyn/agents``) — agent-keyed, consistent with the agent's other
+        per-agent substrate dirs (snapshots, task-generations). Lazy import avoids an
+        import cycle (task.factory → task.sqlite_backend)."""
+        tb = self._task_backends.get(name)
+        if tb is None:
+            from reyn.task.factory import create_task_backend  # noqa: PLC0415
+            path = self._dir / name / "state" / "tasks.db"
+            tb = create_task_backend("sqlite", path=str(path))
+            self._task_backends[name] = tb
+        return tb
+
+    def _close_task_backend(self, name: str) -> None:
+        """#2180: close + evict the agent's shared Task backend — the agent-teardown
+        half of the lifecycle (PURGE / rewind-drop, NOT last-session-drop, since the
+        backend is agent-shared). Releases the single connection's SQLite lock BEFORE
+        the agent dir is rmtree'd (so the file handle is gone first) and drops the dict
+        entry so a later same-name agent re-builds a fresh connection rather than
+        re-using a closed handle. Best-effort: a close failure is logged, never raised
+        into a teardown/rewind path."""
+        tb = self._task_backends.pop(name, None)
+        if tb is None:
+            return
+        close = getattr(tb, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception as e:  # noqa: BLE001 — best-effort; never raise into teardown
+                logger.warning("#2180: close of task backend for agent %r failed: %s", name, e)
 
     def _rewind_backends(self) -> "list[object]":
         """#2128: every LOADED agent's rewind-participating Task backend — ONE per agent.
@@ -1995,6 +2055,10 @@ class AgentRegistry:
                 seq = self._archived_seq(name)
                 if seq is None or seq >= floor:
                     continue
+                # #2180: close + evict the agent's shared Task backend before the hard
+                # rmtree (the archive KEPT it open; purge is the agent-teardown that
+                # closes it). Releases the connection's lock ahead of the dir removal.
+                self._close_task_backend(name)
                 shutil.rmtree(self._dir / name, ignore_errors=True)
                 # Now a permanent hard-delete → drop the (previously preserved)
                 # topology membership so no dangling reference is left behind.

--- a/src/reyn/task/__init__.py
+++ b/src/reyn/task/__init__.py
@@ -14,7 +14,7 @@ sqlite (slice 2), single-writer CAS + P6 events (slice 3), and the rest follow.
 from __future__ import annotations
 
 from reyn.task.backend import InMemoryTaskBackend, TaskBackend
-from reyn.task.factory import create_task_backend, per_session_sqlite_backend
+from reyn.task.factory import create_task_backend
 from reyn.task.model import (
     TERMINAL_STATES,
     Task,
@@ -38,5 +38,4 @@ __all__ = [
     "InMemoryTaskBackend",
     "SqliteTaskBackend",
     "create_task_backend",
-    "per_session_sqlite_backend",
 ]

--- a/src/reyn/task/factory.py
+++ b/src/reyn/task/factory.py
@@ -1,16 +1,16 @@
 """Config-driven Task backend selection (#1953 slice 3a).
 
-The session factory calls :func:`create_task_backend` to build the per-session backend
-INSTANCE it injects into ``Session(task_backend=...)`` (each session constructs its own
-backend object — note the sqlite DB FILE it opens is agent-keyed/shared, see below). The
-choice is config-driven (``in-memory`` for tests / ephemeral, ``sqlite`` for durable) —
-never hardcoded.
+A caller builds a Task backend via :func:`create_task_backend` — config-driven
+(``in-memory`` for tests / ephemeral, ``sqlite`` for durable), never hardcoded. The
+sqlite ``path`` is supplied by the caller.
 
-The sqlite ``path`` is supplied by the caller. NOTE (#2128): the
-``per_session_sqlite_backend`` path below is AGENT-keyed
-(``.reyn/agents/<name>/state/tasks.db``) — one db file per AGENT, SHARED across that
-agent's sessions, NOT one db per session. The earlier "one db per session" wording was
-wrong; per-session isolation + the shared-file connection model are tracked in #2180.
+#2180: the AGENT-keyed sqlite backend (``.reyn/agents/<name>/state/tasks.db`` — one db
+file per AGENT, SHARED across that agent's sessions) is constructed at exactly ONE seam,
+``AgentRegistry.task_backend_for``, which holds a SINGLE ``SqliteTaskBackend`` per agent
+(one connection). Sessions get that shared instance — they never construct an agent-keyed
+backend directly (a direct construction would open an N+1 connection and reintroduce the
+#2125 cross-connection write race). The earlier per-session ``per_session_sqlite_backend``
+helper that built N instances over the shared file was removed in #2180.
 """
 from __future__ import annotations
 
@@ -40,24 +40,3 @@ def create_task_backend(kind: str | None = None, *, path: str | None = None):
             )
         return SqliteTaskBackend(path)
     raise ValueError(f"unknown task backend kind: {kind!r} (expected 'sqlite' or 'in-memory')")
-
-
-def per_session_sqlite_backend(agent_name: str) -> "SqliteTaskBackend":
-    """#1953 slice R, I-5=(A): the sqlite Task backend at the agent's default state
-    dir — so in-session ``task.*`` ops are durable AND participate in the rewind
-    window (alongside runtime-snapshot + workspace).
-
-    #2128 correction: the path is AGENT-keyed (``.reyn/agents/<name>/state/tasks.db``),
-    so it is ONE db file per AGENT, SHARED across that agent's sessions — NOT one db
-    per session (the function name + the old "per-session" wording are misleading; the
-    shared-file connection model + true per-session isolation are tracked in #2180).
-    Each session still constructs its OWN ``SqliteTaskBackend`` instance over this
-    shared path (N connections to one file). Used by the single-tenant local frontends
-    (cli/chat, stdio-MCP); A2A/web pass ``None`` (the process-singleton A2A surface is
-    read directly, not threaded into a session — its tasks stay durable but un-rewound,
-    the cross-session fan-out tracked in #1997).
-    """
-    from pathlib import Path  # noqa: PLC0415
-
-    path = Path(".reyn") / "agents" / agent_name / "state" / "tasks.db"
-    return create_task_backend("sqlite", path=str(path))

--- a/tests/test_2103_s1bc_session_drop.py
+++ b/tests/test_2103_s1bc_session_drop.py
@@ -168,47 +168,43 @@ async def test_rewind_restore_failure_does_not_drop_the_session_dir(tmp_path) ->
 
 
 @pytest.mark.asyncio
-async def test_remove_session_closes_dropped_backend_restore_uses_survivor(tmp_path) -> None:
-    """Tier 2: #2125 + #2128 — remove_session CLOSES the dropped session's per-session
-    Task-backend (a separate sqlite connection to the agent's shared tasks.db), releasing
-    its lock. With #2128, _restore_task_active derives the rewind backends from the CURRENT
-    loaded sessions (``_rewind_backends``), so the dropped session is simply no longer
-    iterated — restore touches the survivor, never the now-closed dropped handle (no
-    re-point pointer needed; the #2125 interim is subsumed). Strip the close() → restore on
-    a still-open shared file is fine; the load-bearing property is that the dropped session
-    is OUT of the derive set."""
-    import sqlite3
-
+async def test_remove_session_keeps_shared_backend_open_survivor_usable(tmp_path) -> None:
+    """Tier 2: #2180 REVERSES the #2125 per-session close-on-drop. The Task backend is now
+    agent-SHARED — ONE instance/connection per agent (registry-owned via ``task_backend_for``),
+    so every session of the agent holds the SAME backend object. remove_session must therefore
+    NOT close it: closing on one session's drop would strand every SURVIVING sibling session
+    (use-after-close on the shared connection). After the drop the survivor keeps the SAME open
+    instance + the restore still works through it. RED if remove_session re-introduces the
+    close() (the survivor's read / the restore would raise ProgrammingError on a closed db)."""
     from reyn.task.factory import create_task_backend
 
     reg = _make_registry(tmp_path)
-    db = tmp_path / "tasks.db"
-    survivor_backend = create_task_backend("sqlite", path=str(db))
-    dropped_backend = create_task_backend("sqlite", path=str(db))  # 2nd connection, same file
+    db = tmp_path / "worker_tasks.db"
+    shared_backend = create_task_backend("sqlite", path=str(db))  # the ONE agent backend
 
     async def _noop() -> None:
         return None
 
+    # both sessions hold the SAME shared instance — the (A) agent-shared model.
     main = SimpleNamespace(
-        task_backend=survivor_backend, cancel_inflight=_noop, await_quiescent=_noop,
+        task_backend=shared_backend, cancel_inflight=_noop, await_quiescent=_noop,
     )
     spawned = SimpleNamespace(
-        task_backend=dropped_backend, cancel_inflight=_noop, await_quiescent=_noop,
+        task_backend=shared_backend, cancel_inflight=_noop, await_quiescent=_noop,
     )
     reg._sessions["worker"] = {"main": main, "s1": spawned}
     _make_session_dir(reg, "worker", "s1")
-    # a captured generation on the SURVIVOR at an active WAL seq → _restore_task_active
-    # has real work that touches the backend's connection (else it no-ops without probing).
+    # a captured generation at an active WAL seq → _restore_task_active has real work that
+    # touches the backend's connection (else it no-ops without probing).
     seq = await _put(reg.state_log, "worker", "x")
-    await survivor_backend.snapshot_generation(seq)
+    await shared_backend.snapshot_generation(seq)
 
     await reg.remove_session("worker", "s1")
 
-    # the dropped backend's connection is closed (a public DB read now raises) → lock released.
-    with pytest.raises(sqlite3.ProgrammingError):
-        await dropped_backend.get("any-task-id")
-    # #2128: _restore_task_active derives from the loaded sessions — only the survivor
-    # remains, so its generation is restored without error and the closed dropped backend
-    # is never touched (it's out of _sessions). A path that still reached the dropped
-    # connection would raise ProgrammingError inside restore_to_seq.
+    # the shared backend is STILL OPEN — the survivor can read/write through it (a closed
+    # connection would raise ProgrammingError here).
+    assert await shared_backend.get("any-task-id") is None
+    # #2128 + #2180: _restore_task_active derives from the loaded sessions (now resolving to
+    # the ONE shared instance) and restores through that still-open connection — no sibling
+    # to strand, the #2125 close-before-restore collapses to "one connection ever".
     await reg._restore_task_active(at_or_below=seq)

--- a/tests/test_2180_per_agent_task_backend_connection.py
+++ b/tests/test_2180_per_agent_task_backend_connection.py
@@ -181,6 +181,24 @@ async def test_agent_drop_closes_and_evicts_backend(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_purge_via_remove_closes_and_evicts_backend(tmp_path) -> None:
+    """Tier 2: (the THIRD agent-teardown path — lead-caught) ``remove(name, purge=True)``,
+    the live ``archive_agent(purge=True)`` hard-delete, closes + evicts the agent's shared
+    backend BEFORE its rmtree — alongside ``_drop_agent`` + ``_purge_archived_below``.
+    Without the close, the warmed cache entry keeps a dangling handle over the deleted inode
+    AND is never evicted → a NEW agent reusing the name gets the stale handle and writes to
+    the wrong/deleted file (a name-reuse correctness hazard, not just a leak). RED on the
+    version missing the line-684 close. Asserts closed (ProgrammingError) + evicted (a
+    re-create rebuilds a fresh instance)."""
+    reg = _registry(tmp_path)
+    first = reg.task_backend_for("worker")  # warm it (also creates the agent dir)
+    reg.remove("worker", purge=True)  # the hard-delete escape hatch
+    with pytest.raises(sqlite3.ProgrammingError):
+        await first.get("anything")  # closed → handle released ahead of the rmtree
+    assert reg.task_backend_for("worker") is not first  # evicted → rebuilt fresh
+
+
+@pytest.mark.asyncio
 async def test_concurrent_creates_through_shared_instance_all_land(tmp_path) -> None:
     """Tier 2: (A)'s one shared instance serialises concurrent writes on its single
     ``asyncio.Lock`` — N concurrent ``create``s through the agent's backend ALL land (no

--- a/tests/test_2180_per_agent_task_backend_connection.py
+++ b/tests/test_2180_per_agent_task_backend_connection.py
@@ -1,0 +1,193 @@
+"""Tier 2: #2180 — one SHARED Task backend (one connection) per agent.
+
+#2128 made the ``tasks.db`` agent-keyed but each SESSION still constructed its OWN
+``SqliteTaskBackend`` over the shared file → N connections, N independent
+``asyncio.Lock``s that don't serialise across connections (the #2125 "database is
+locked" source) + a ``restore_to_seq`` file-swap that strands sibling connections.
+
+#2180 (A): the agent's backend is registry-OWNED, ONE per agent, built lazily + cached,
+handed to every session of the agent via the SINGLE construction seam
+``AgentRegistry.task_backend_for``. One instance ⟹ one connection ⟹ the per-instance lock
+serialises every write (restores the ``busy_timeout=0`` premise) and ``restore_to_seq`` is
+the only connection touching the file. Closed + evicted on agent teardown (purge /
+rewind-drop), NOT on last-session-drop (it's agent-shared).
+
+Falsification (real ``AgentRegistry`` + real ``SqliteTaskBackend``, no mocks):
+- the N-connection write-race + restore file-swap are REAL and DETERMINISTIC (a sibling
+  connection makes a write / a restore raise "database is locked");
+- (A) removes both by construction: one instance per agent (``is`` identity), restore
+  through it is clean, the agent-shared task visibility is preserved.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.task import SqliteTaskBackend, Task
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=None,
+    )
+
+
+def _task(tid: str) -> Task:
+    return Task(task_id=tid, name=tid, assignee="x", requester="y")
+
+
+# ── (A) the single-seam invariant: one instance per agent ───────────────────
+
+
+def test_one_shared_backend_instance_per_agent(tmp_path) -> None:
+    """Tier 2: (LOAD-BEARING) ``task_backend_for`` returns the SAME instance for repeated
+    calls on one agent — so every session of the agent shares ONE connection (the
+    single-connection-by-construction invariant that removes the #2125 cross-connection
+    race). RED if the accessor built a fresh backend per call (the old per-session model
+    that opened N connections to the shared file)."""
+    reg = _registry(tmp_path)
+    first = reg.task_backend_for("worker")
+    second = reg.task_backend_for("worker")
+    assert first is second
+
+
+def test_distinct_agents_get_distinct_backends(tmp_path) -> None:
+    """Tier 2: the backend is per-AGENT keyed (like ``_sessions``), NOT a process
+    singleton — two agents get two distinct instances (their ``tasks.db`` files differ)."""
+    reg = _registry(tmp_path)
+    assert reg.task_backend_for("a") is not reg.task_backend_for("b")
+
+
+@pytest.mark.asyncio
+async def test_same_agent_task_visibility_is_shared(tmp_path) -> None:
+    """Tier 2: (no-regression) the agent-shared task-visibility semantic #2128 established
+    is preserved — a task written through the agent's backend is visible through that same
+    shared instance (= what EVERY session of the agent sees, since they all resolve to it),
+    and it lands at the agent-keyed path. RED if (A) had silently isolated per-session
+    state."""
+    reg = _registry(tmp_path)
+    backend = reg.task_backend_for("worker")
+    await backend.create(_task("t1"))
+    # every session of "worker" resolves to this same instance → all see t1.
+    assert reg.task_backend_for("worker") is backend
+    got = await backend.get("t1")
+    assert got is not None and got.task_id == "t1"
+    # agent-keyed path under project_root (shared across the agent's sessions).
+    assert (tmp_path / ".reyn" / "agents" / "worker" / "state" / "tasks.db").is_file()
+
+
+# ── the N-connection hazards are REAL + deterministic (why (A) is needed) ────
+
+
+@pytest.mark.asyncio
+async def test_two_connections_one_file_write_collides(tmp_path) -> None:
+    """Tier 2: the #2125 cross-connection WRITE race is real + deterministic. ``busy_timeout=0``
+    means a second connection's write fails IMMEDIATELY while another holds the file's write
+    lock — exactly the collision N per-session backend instances (N connections, N
+    independent locks) can hit. A held ``BEGIN IMMEDIATE`` on a sibling connection → a real
+    backend ``create`` raises "database is locked". (A)'s single instance makes this
+    impossible: the one ``asyncio.Lock`` serialises every write so two writes never overlap."""
+    db = tmp_path / "tasks.db"
+    backend = SqliteTaskBackend(str(db))
+    holder = sqlite3.connect(str(db))  # a sibling connection — the N-th instance's analog
+    holder.execute("PRAGMA busy_timeout=0")
+    holder.execute("BEGIN IMMEDIATE")  # hold the file's write lock
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            await backend.create(_task("t1"))
+    finally:
+        holder.rollback()
+        holder.close()
+        backend.close()
+
+
+@pytest.mark.asyncio
+async def test_restore_with_sibling_connection_raises_locked(tmp_path) -> None:
+    """Tier 2: (RED on N-instances) the restore file-swap hazard is real + deterministic.
+    ``restore_to_seq`` closes its connection, swaps the db file, drops the ``-wal``/``-shm``
+    side-files, then reopens with ``PRAGMA journal_mode=WAL`` — which needs the lock a SIBLING
+    connection still holds → "database is locked". So with N per-session connections a rewind
+    restore can FAIL outright. RED here, GREEN in the single-instance case below."""
+    db = tmp_path / "tasks.db"
+    primary = SqliteTaskBackend(str(db))
+    sibling = SqliteTaskBackend(str(db))  # the N-th connection (a 2nd session's backend)
+    await primary.create(_task("d1"))
+    await primary.snapshot_generation(5)  # gen 5 = {d1}
+    await primary.create(_task("d2"))
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            await primary.restore_to_seq(5)
+    finally:
+        sibling.close()
+        primary.close()
+
+
+@pytest.mark.asyncio
+async def test_restore_through_single_shared_instance_is_clean(tmp_path) -> None:
+    """Tier 2: (GREEN on (A)) with ONE instance per agent (no sibling connection), the same
+    ``restore_to_seq`` succeeds cleanly — it closes + reopens THE one connection and the
+    restored generation is correct (sees the snapshotted ``d1``, not the post-snapshot
+    ``d2``). The pair with the test above is the RED-on-N / GREEN-on-(A) falsification of the
+    restore hazard."""
+    reg = _registry(tmp_path)
+    backend = reg.task_backend_for("worker")  # the agent's SOLE instance
+    await backend.create(_task("d1"))
+    await backend.snapshot_generation(5)
+    await backend.create(_task("d2"))
+    await backend.restore_to_seq(5)  # no sibling → no lock
+    assert await backend.get("d2") is None     # restored past d2
+    assert await backend.get("d1") is not None  # d1 (in the generation) survives
+
+
+# ── close lifecycle: agent teardown closes + evicts (not last-session-drop) ──
+
+
+@pytest.mark.asyncio
+async def test_close_task_backend_closes_and_evicts(tmp_path) -> None:
+    """Tier 2: ``_close_task_backend`` (the agent-teardown half) CLOSES the connection (a
+    public read then raises ``ProgrammingError`` — the lock is released) AND evicts the cache
+    entry, so a later ``task_backend_for`` rebuilds a FRESH instance rather than handing back
+    a closed handle. RED if close didn't fire (read succeeds) or didn't evict (same closed
+    instance returned)."""
+    reg = _registry(tmp_path)
+    first = reg.task_backend_for("worker")
+    reg._close_task_backend("worker")
+    with pytest.raises(sqlite3.ProgrammingError):
+        await first.get("anything")  # closed → lock released
+    second = reg.task_backend_for("worker")
+    assert second is not first  # evicted → rebuilt
+
+
+@pytest.mark.asyncio
+async def test_agent_drop_closes_and_evicts_backend(tmp_path) -> None:
+    """Tier 2: the agent-teardown path (#2103 rewind-drop ``_drop_agent``, which rmtrees the
+    agent dir) closes + evicts the agent's shared backend BEFORE the rmtree — releasing the
+    connection's handle on ``tasks.db`` ahead of the dir removal. RED if the drop left the
+    connection open (a leaked handle over a removed dir) or kept the stale cache entry."""
+    reg = _registry(tmp_path)
+    first = reg.task_backend_for("worker")
+    reg._drop_agent("worker")
+    with pytest.raises(sqlite3.ProgrammingError):
+        await first.get("anything")  # closed by the drop
+    assert reg.task_backend_for("worker") is not first  # evicted
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creates_through_shared_instance_all_land(tmp_path) -> None:
+    """Tier 2: (A)'s one shared instance serialises concurrent writes on its single
+    ``asyncio.Lock`` — N concurrent ``create``s through the agent's backend ALL land (no
+    "database is locked"), the property the per-instance lock guarantees once there is only
+    ONE connection. (With the old N-connection model these would race the file lock.)"""
+    reg = _registry(tmp_path)
+    backend = reg.task_backend_for("worker")
+    await asyncio.gather(*(backend.create(_task(f"t{i}")) for i in range(12)))
+    for i in range(12):
+        assert await backend.get(f"t{i}") is not None


### PR DESCRIPTION
**[e2e-coder]** — **DO NOT MERGE until lead-coder close-review.** #2180 (roi:medium), the #2128 follow-up. Confirmed Option **(A)** with lead (one shared connection per agent), within-(A) picks analog-grounded + lead-approved.

## Problem
#2128 made `tasks.db` agent-keyed, but each **session** still constructed its **own** `SqliteTaskBackend` over the shared file → N connections, N independent `asyncio.Lock`s that don't serialise across connections (the #2125 *"database is locked"* source), plus a `restore_to_seq` file-swap that strands sibling connections.

## (A) — single shared connection per agent
The agent's backend is now **registry-owned**, **one per agent**, built lazily + cached, handed to every session via the single construction seam `AgentRegistry.task_backend_for` (mirrors `_workspace_store`'s registry-owned-lazy ownership; per-agent keyed like `_sessions`). One instance ⟹ one connection ⟹ the per-instance lock serialises every write (restores the `busy_timeout=0` premise) and `restore_to_seq` is the only connection touching the file.

**Ownership / close lifecycle** (mirroring the `_state_log`/`_workspace_store` analogs, per lead):
- Process-lifetime for a **live** agent — parity with `_state_log`/`_workspace_store` (never closed). ⚠️ a bounded per-process leak, **called out** (same as today's main backend), not silently inherited.
- Close + evict on agent **PURGE** / rewind-**drop** (`_close_task_backend`, wired into `_drop_agent` + `_purge_archived_below`, before the rmtree).
- **Kept** on archive (recoverable / rewind).
- **Consequential:** REMOVED the #2125 session-drop `tb.close()` (agent-shared now — closing on one session's drop would strand surviving siblings). The #2125 close-before-restore collapses to *"one connection ever."*

## Single-seam invariant — exhaustive construction-site audit
Per lead's raise-now completeness requirement, plain-grepped **all** backend-construction sites repo-wide. Only two construct the agent-keyed `tasks.db`, both now routed through `task_backend_for`:
- `src/reyn/interfaces/cli/commands/chat.py:455` → `registry.task_backend_for(profile.name)` ✓
- `src/reyn/interfaces/cli/commands/mcp.py:421` → `registry.task_backend_for(profile.name)` ✓

Out of scope (distinct substrates, **not** agent-keyed `tasks.db`):
- `src/reyn/interfaces/web/server.py:169` — A2A/web **process-singleton** at a *different path* (`.reyn/state/tasks.db`), already one connection.
- `dogfood.py:473` / `chainlit_app/app.py:214` / `web/deps.py:345` — pass `task_backend=None` → use the in-memory op-runtime fallback (`op_runtime/task.py:40`), no agent-keyed sqlite.

To make the invariant hold **by construction**, the now-dead `per_session_sqlite_backend` factory (its only two callers switched) was **removed** along with its export + imports — there is no longer any out-of-registry way to build an agent-keyed backend. `create_task_backend` stays (used by the registry seam + the web singleton).

## Falsification (deterministic; real `AgentRegistry` + real `SqliteTaskBackend`, no mocks)
`tests/test_2180_per_agent_task_backend_connection.py` (Tier 2):
- **write-race is real** — a held `BEGIN IMMEDIATE` on a sibling connection → a real backend `create` raises `database is locked` (the N-connection collision; (A)'s one lock makes it impossible).
- **restore file-swap: RED-on-N / GREEN-on-(A)** — with a sibling connection open, `restore_to_seq` raises `database is locked` (the WAL-mode reopen needs the lock the sibling holds); with the single shared instance it's clean (restores the generation correctly).
- **is-identity single-seam** — `task_backend_for(a) is task_backend_for(a)` (one connection by construction); distinct agents → distinct backends.
- **shared-visibility no-regression** — agent-shared task visibility (the #2128 semantic) preserved.
- **close+evict** on `_close_task_backend` and on the `_drop_agent` teardown path.
- **survivor-not-broken** — rewrote the existing #2125 close-on-drop test (`tests/test_2103_s1bc_session_drop.py`) to the **reversed** contract: remove_session keeps the shared backend open; the survivor + the restore still work.

**Verify-RED confirmed both ways:** strip the single-seam cache → 4 invariant tests RED; re-add the session-drop `close()` → survivor test RED (`Cannot operate on a closed database`).

## CI gates
- `ruff check src tests scripts` ✓
- `python scripts/test_tier_audit.py --strict <changed test files>` ✓ (17 inspected, 0 Tier-4)
- `pytest` (rootdir) — my change set fully green (8541 passed; all task/registry/session/cli tests + the new file pass). **4 pre-existing env failures** unrelated to this PR (`tests/gateway/*` entry-point resolution + `test_reyn_api_relocate_311.py::...[reyn.safe]`) — verified they fail **identically with my changes stashed** (editable-install metadata resolves against a different worktree). Not introduced here.

## Test plan
- [x] Falsification suite passes + verify-RED confirmed both directions (above).
- [x] ruff full-tree + tier-audit green.
- [x] Full rootdir pytest — change set green; 4 failures confirmed pre-existing (stash-verified).
- [ ] (lead) close-review of the #2128 interaction (`_rewind_backends`/`_restore_task_active`/disk-prune with the shared instance), the session-drop-close removal, and close-on-purge eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)