### PR TITLE
feat(#2187): backend-master Stage 4 — pub/sub seam + recovery re-read seam

### DIFF
--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -271,8 +271,10 @@ async def _create(op, ctx: OpContext, caller) -> dict:
     if (waker is not None
             and created.status in (TaskState.PENDING, TaskState.READY)
             and created.assignee != created.requester):
-        await waker.wake_assigned(
-            created, fenced_description=_fence_text(ctx, created.description))
+        # #2187 Stage 4: publish the state-change through the single pub/sub seam
+        # (event_type "assigned"; delivered to the assignee subscriber to execute).
+        await waker.publish_task_event(
+            "assigned", created, fenced_description=_fence_text(ctx, created.description))
     # #1800 slice 5c: task_start lifecycle hooks — the task has been created
     # (backend.create + the P6 audit). None dispatcher (direct/test construction
     # or no hooks) → no-op.
@@ -321,8 +323,8 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
             # item 4: deliver the full description as fenced DATA (the trusted-OS
             # execute framing lives in the waker).
             if waker is not None:
-                await waker.wake_ready_dependent(
-                    p, fenced_description=_fence_text(ctx, p.description))
+                await waker.publish_task_event(  # #2187 Stage 4: pub/sub seam ("ready")
+                    "ready", p, fenced_description=_fence_text(ctx, p.description))
         # #1800 slice 5c: task_end lifecycle hooks — the task reached COMPLETED.
         # None dispatcher → no-op. (Aborted tasks terminate via the separate
         # _abort handler — see the task_end symmetry note there.)
@@ -392,8 +394,8 @@ async def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigge
     if task.status is TaskState.READY:
         waker = getattr(ctx, "task_waker", None)
         if waker is not None:
-            await waker.wake_ready_dependent(
-                task, fenced_description=_fence_text(ctx, task.description))
+            await waker.publish_task_event(  # #2187 Stage 4: pub/sub seam ("ready")
+                "ready", task, fenced_description=_fence_text(ctx, task.description))
 
 
 async def _route_terminal_to_requester(
@@ -476,8 +478,11 @@ async def _route_terminal_to_requester(
         return
     waker = getattr(ctx, "task_waker", None)
     if waker is not None:
-        await waker.notify_requester_decide(
-            requester_session=requester_session, terminal_task=terminal_task,
+        # #2187 Stage 4: publish the terminal state-change through the single pub/sub
+        # seam (delivered to the requester subscriber to decide recovery).
+        await waker.publish_task_event(
+            "terminal", terminal_task,
+            requester_session=requester_session,
             dependents=stuck, disposition=disp, managing_task_id=managing_task_id,
         )
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -910,6 +910,9 @@ class AgentRegistry:
             self._state_log.iter_from(0),
             is_active=lambda s: is_active_seq(self._state_log, s),
         )
+        # #2187 Stage 4: the recovery RE-READ seam — the binding is restored above; now
+        # re-read the CURRENT backend task-state (the external master, not rewound).
+        await self._reconcile_subscriptions_after_recovery()
 
         # 1. Load snapshots — main (legacy path) + per-session (spawned).
         # FP-0043 Stage 5: ``snapshots`` (name → MAIN AgentSnapshot) is the
@@ -1313,6 +1316,33 @@ class AgentRegistry:
         SubscriptionRegistry current. Applies each durable subscription WAL append
         (non-subscription kinds are ignored by ``apply``)."""
         self._task_subscriptions.apply(kind, seq, fields)
+
+    async def _reconcile_subscriptions_after_recovery(self) -> "list[str]":
+        """#2187 Stage 4: the recovery RE-READ seam (the backend-master recovery model:
+        re-subscribe, then re-read the current external task-state, catching up by
+        re-reading). The subscription (the Reyn-internal binding) is already restored by
+        the WAL replay in ``restore_all``; the backend is the external MASTER of
+        task-STATE and is NOT rewound — so on recovery the binding may name a task whose
+        backend state moved (or vanished) while Reyn was down.
+
+        Stage 4 establishes the seam + a coherence pass: it returns the STALE bindings —
+        subscriptions whose task the backend no longer holds (the external master dropped
+        it) — and logs a summary. The FULL reconciliation — diff the re-read state against
+        the binding and RE-PUBLISH the missed state-change events to the re-subscribed
+        session (via ``publish_task_event``) / prune the stale bindings — is Stage 5: the
+        typed-state lifecycle drives WHICH events to re-deliver, so it is built there, on
+        this seam (the returned stale set is its input)."""
+        task_ids = self._task_subscriptions.task_ids()
+        if not task_ids:
+            return []
+        backend = self.task_backend  # the durable external master (built lazily)
+        stale = [tid for tid in task_ids if await backend.get(tid) is None]
+        if stale:
+            logger.info(
+                "#2187 recovery re-read: %d/%d subscription(s) name a task with no "
+                "backend state (stale binding — the external master dropped it); "
+                "Stage 5 reconciliation resolves these.", len(stale), len(task_ids))
+        return stale
 
     async def _on_wal_append_capture(self, kind: str, seq: int, fields: dict) -> None:
         """Generic WAL post-append observer: per-step act-turn workspace capture.

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -41,6 +41,15 @@ WAKE_READY_KIND = "task_ready"
 # the stale "parent" vocabulary (recovery now notifies the requester, not a parent).
 WAKE_REQUESTER_KIND = "task_dependency_aborted"
 
+# #2187 Stage 4: the task STATE-CHANGE event vocabulary the single publish→deliver seam
+# (``TaskWaker.publish_task_event``) routes on. ``ready``/``assigned`` deliver to the
+# ASSIGNEE subscriber (execute); ``terminal`` delivers to the REQUESTER subscriber
+# (decide recovery). This is the existing local set — an external backend may extend it
+# at integration time.
+TASK_EVENT_READY = "ready"
+TASK_EVENT_ASSIGNED = "assigned"
+TASK_EVENT_TERMINAL = "terminal"
+
 
 class TaskWaker:
     """Wakes a sibling session (same agent) on a dep-graph disposition (#1953 sl.7)."""
@@ -180,5 +189,30 @@ class TaskWaker:
             managing_task_id=managing_task_id,
         )
 
+    async def publish_task_event(self, event_type: str, task: Any, **kwargs: Any) -> None:
+        """#2187 Stage 4: the SINGLE publish → deliver seam. A task STATE-CHANGE event is
+        delivered to the SUBSCRIBED session (the assignee or requester binding) via the
+        local waker delivery. The local op publishes here on a state change (the existing
+        per-event waker calls, now routed through one path); an external backend
+        (Jira / A2A webhook) plugs into the SAME seam — external-ready (the full external
+        integration + catch-up reconciliation is subsequent). Routes by ``event_type`` to
+        the existing delivery (the local pub/sub formalized; behaviour unchanged):
+        - ``ready`` / ``assigned`` → the ASSIGNEE subscriber executes the task;
+        - ``terminal`` → the REQUESTER subscriber decides recovery for its stuck
+          dependents (``kwargs``: requester_session / dependents / disposition /
+          managing_task_id). The event vocabulary is the existing local set; an external
+          backend may extend it at integration time."""
+        if event_type == TASK_EVENT_READY:
+            await self.wake_ready_dependent(task, **kwargs)
+        elif event_type == TASK_EVENT_ASSIGNED:
+            await self.wake_assigned(task, **kwargs)
+        elif event_type == TASK_EVENT_TERMINAL:
+            await self.notify_requester_decide(terminal_task=task, **kwargs)
+        else:
+            raise ValueError(f"unknown task event_type: {event_type!r}")
 
-__all__ = ["TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND"]
+
+__all__ = [
+    "TASK_EVENT_ASSIGNED", "TASK_EVENT_READY", "TASK_EVENT_TERMINAL",
+    "TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND",
+]

--- a/tests/test_2187_dogfood_assignee_validation.py
+++ b/tests/test_2187_dogfood_assignee_validation.py
@@ -37,6 +37,12 @@ class _StubWaker:
     async def wake_assigned(self, *a, **k) -> None:
         pass
 
+    async def publish_task_event(self, event_type, task, **kwargs) -> None:
+        # #2187 Stage 4: the op publishes through the single seam; route the assigned
+        # event to wake_assigned (the born-startable delegated-task wake).
+        if event_type == "assigned":
+            await self.wake_assigned(task, **kwargs)
+
 
 def _ctx(*, waker=None, caller="s1"):
     return SimpleNamespace(

--- a/tests/test_2187_stage4_pubsub.py
+++ b/tests/test_2187_stage4_pubsub.py
@@ -1,0 +1,84 @@
+"""Tier 2: #2187 backend-master Stage 4 — the pub/sub seam + the recovery re-read seam.
+
+(4a) ``TaskWaker.publish_task_event`` is the single publish→deliver seam: a task
+state-change event routes by ``event_type`` to the existing waker delivery (ready /
+assigned → the assignee executes; terminal → the requester decides) — the local op and
+an external backend publish through the SAME path.
+
+(4b) ``AgentRegistry._reconcile_subscriptions_after_recovery`` is the recovery RE-READ
+seam: after the WAL subscription replay restores the binding, it re-reads the CURRENT
+backend task-state (the external master, not rewound) and returns the STALE bindings —
+subscriptions whose task the backend no longer holds. (The full reconciliation —
+re-publish missed events / prune — is Stage 5.)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services.task_wake import TaskWaker
+from reyn.task import Task, TaskState
+
+
+class _RoutingWaker(TaskWaker):
+    """Records which delivery method publish_task_event routes to (the real dispatch)."""
+
+    def __init__(self) -> None:  # noqa: D401 — no super (no registry needed for the dispatch test)
+        self.routed: list[tuple[str, str]] = []
+
+    async def wake_ready_dependent(self, task, **kwargs) -> None:
+        self.routed.append(("ready", task.task_id))
+
+    async def wake_assigned(self, task, **kwargs) -> None:
+        self.routed.append(("assigned", task.task_id))
+
+    async def notify_requester_decide(self, *, terminal_task, **kwargs) -> None:
+        self.routed.append(("terminal", terminal_task.task_id))
+
+
+def _task(tid):
+    return Task(task_id=tid, name=tid, assignee="s1", requester="s1", status=TaskState.PENDING)
+
+
+@pytest.mark.asyncio
+async def test_publish_task_event_routes_by_type():
+    """Tier 2: the single seam routes each event_type to the matching delivery (ready/
+    assigned → the assignee execute; terminal → the requester decide)."""
+    w = _RoutingWaker()
+    await w.publish_task_event("ready", _task("t1"))
+    await w.publish_task_event("assigned", _task("t2"))
+    await w.publish_task_event("terminal", _task("t3"), requester_session="r", dependents=[])
+    assert w.routed == [("ready", "t1"), ("assigned", "t2"), ("terminal", "t3")]
+
+
+@pytest.mark.asyncio
+async def test_publish_task_event_rejects_unknown_type():
+    """Tier 2: an unknown event_type is a hard error (the seam's closed local vocabulary;
+    external extensions add their kinds explicitly)."""
+    with pytest.raises(ValueError):
+        await _RoutingWaker().publish_task_event("frobnicate", _task("t1"))
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_after_recovery_returns_stale_bindings(tmp_path: Path):
+    """Tier 2: the recovery re-read seam — a subscription whose task the backend (the
+    external master) no longer holds is returned as a STALE binding; a live one is not."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory, state_log=state_log)
+    # restore the binding for two tasks (the #1560 observer applies each append live).
+    await state_log.append("task_subscribed", task_id="t-live", assignee="s1",
+                           requester="s1", requester_kind="session")
+    await state_log.append("task_subscribed", task_id="t-gone", assignee="s1",
+                           requester="s1", requester_kind="session")
+    # the backend (external master) holds only t-live.
+    await reg.task_backend.create(_task("t-live"))
+
+    stale = await reg._reconcile_subscriptions_after_recovery()
+    assert stale == ["t-gone"]  # t-gone's binding outlived its backend state

--- a/tests/test_task_ops_gate_equivalence_1953.py
+++ b/tests/test_task_ops_gate_equivalence_1953.py
@@ -158,6 +158,12 @@ async def test_router_opctx_threads_task_waker_so_chat_abort_wakes_requester():
         async def notify_requester_decide(self, **kw) -> None:
             self.calls.append(kw)
 
+        async def publish_task_event(self, event_type, task, **kwargs) -> None:
+            # #2187 Stage 4: the op publishes through the single seam; route the
+            # terminal event to the recorded requester-notify.
+            if event_type == "terminal":
+                await self.notify_requester_decide(terminal_task=task, **kwargs)
+
     backend = InMemoryTaskBackend()
     # a self-task plan whose requester is the chat session ("main", _DEFAULT_SID).
     await backend.create(Task(task_id="t2", name="t2", assignee="main", requester="main",

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -228,6 +228,13 @@ class _RecordingWaker:
             "managing_task_id": managing_task_id,
         })
 
+    async def publish_task_event(self, event_type, task, **kwargs):
+        """#2187 Stage 4: mirror TaskWaker.publish_task_event's dispatch — the op now
+        publishes through the single seam; route the terminal event to the recorded
+        requester-notify (this stub records only the §16 requester-decide path)."""
+        if event_type == "terminal":
+            await self.notify_requester_decide(terminal_task=task, **kwargs)
+
 
 def _opctx(backend, *, events=None, waker=None, session_id="req"):
     return SimpleNamespace(session_id=session_id, agent_id="a",


### PR DESCRIPTION
**[e2e-coder]** — #2187 backend-master Stage 4: the pub/sub seam + the recovery re-read seam (off main, post Stage 1-3 merge #2190).

## The model

Under backend-master, the **backend is the external master of task-STATE**; Reyn *requests* changes and *subscribes* to state-change events. Stage 2 put the **subscription** (the Reyn-internal task↔session binding) in the WAL; Stage 4 formalizes how state-change events are **delivered** to the subscribed session, and the **recovery** path where a restored subscriber re-reads the current external state.

The existing `TaskWaker` already *is* the local pub/sub delivery (`wake_ready_dependent`/`wake_assigned` → the assignee subscriber; `notify_requester_decide` → the requester subscriber, keyed by the subscription). So Stage 4 leverages it — minimal new code.

## 4a — the thin `publish_task_event` seam
A single publish→deliver path: a task STATE-CHANGE event is delivered to the subscribed session via the existing waker delivery.
- `TaskWaker.publish_task_event(event_type, task, **kwargs)` routes by `event_type` (`ready`/`assigned` → the assignee executes; `terminal` → the requester decides) to the existing waker methods. Vocabulary `TASK_EVENT_READY/ASSIGNED/TERMINAL` is the local set, extensible for external backends.
- The task ops' 4 waker call-sites now publish through this **one** path — **behaviour unchanged** (it dispatches to the same methods). The local op publishes here; an **external backend (Jira/A2A webhook) plugs into the SAME seam** — external-ready.

## 4b — the recovery re-read seam
`AgentRegistry._reconcile_subscriptions_after_recovery()` (called in `restore_all`, right after the WAL subscription replay): re-reads the current backend task-state (the master, not rewound) for each restored subscription and returns the **stale bindings** — subscriptions whose task the backend no longer holds (the external master dropped it). The **full reconciliation** (diff the re-read state vs the binding → re-publish missed events via `publish_task_event` / prune stale) is **Stage 5** (the typed-state lifecycle drives *which* events to re-deliver), built on this seam.

## Subsequent (not this PR)
The full external (Jira) integration + the catch-up reconciliation = Stage 5 (lifecycle 7-state); the deferred dogfood ② (pending-assignment queue).

## Test plan
- [x] `tests/test_2187_stage4_pubsub.py`: `publish_task_event` routes each event_type to the matching delivery + rejects an unknown type; the recovery re-read seam returns a stale binding (and not a live one).
- [x] Behaviour unchanged: the task/waker/2107/dogfood sweep green (434) — the seam dispatches to the same methods (test stub wakers gained a mirroring `publish_task_event`).
- [x] Recovery coherence: the registry/recovery/restore/rewind/subscription suite green (639) — `reconcile` runs in `restore_all` without regression.
- [x] Full suite green except the 4 known editable-install env quirks (absent in clean CI).
- [x] `ruff check src tests scripts` clean; `test_tier_audit.py --strict` on the new test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
