### PR TITLE
feat(#2187): Stage 5a — 7-state lifecycle migration + ARCHIVED retention separation

### DIFF
--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -264,12 +264,12 @@ async def _create(op, ctx: OpContext, caller) -> dict:
     # EXECUTE it now (the create-time counterpart of the dep-completion wake). A
     # born deps-less op-created task is PENDING (the default kept by the backend);
     # only a born-BLOCKED task (unmet deps) carries BLOCKED — so "born-ready" =
-    # not-blocked = PENDING|READY. A self-task (assignee == requester) needs no
+    # not-blocked = READY. A self-task (assignee == requester) needs no
     # wake (the creator is the executor); a born-BLOCKED task is woken later when
     # its deps clear (recompute_readiness → wake_ready_dependent).
     waker = getattr(ctx, "task_waker", None)
     if (waker is not None
-            and created.status in (TaskState.PENDING, TaskState.READY)
+            and created.status is TaskState.READY
             and created.assignee != created.requester):
         # #2187 Stage 4: publish the state-change through the single pub/sub seam
         # (event_type "assigned"; delivered to the assignee subscriber to execute).
@@ -304,11 +304,11 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
     if task is None:
         return _not_found("task.update_status", op.task_id)
     _audit(ctx, "task.update_status", op.task_id, status=op.status)
-    # OQ-3: a predecessor reaching `completed` drives DAG readiness (OS scheduling,
+    # OQ-3: a predecessor reaching `done` drives DAG readiness (OS scheduling,
     # P3) — recompute its dependents and flip any fully-satisfied one blocked→ready
-    # via the OS-authority backend method (no assignee CAS). `completed` only;
-    # failed/aborted/archived deps don't satisfy an edge (H5/OQ-7 → slice 7).
-    if task.status is TaskState.COMPLETED:
+    # via the OS-authority backend method (no assignee CAS). `done` only;
+    # failed/aborted deps don't satisfy an edge (H5/OQ-7 → slice 7).
+    if task.status is TaskState.DONE:
         promoted = await _backend(ctx).recompute_readiness(op.task_id)
         events = getattr(ctx, "events", None)
         waker = getattr(ctx, "task_waker", None)
@@ -325,14 +325,14 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
             if waker is not None:
                 await waker.publish_task_event(  # #2187 Stage 4: pub/sub seam ("ready")
                     "ready", p, fenced_description=_fence_text(ctx, p.description))
-        # #1800 slice 5c: task_end lifecycle hooks — the task reached COMPLETED.
+        # #1800 slice 5c: task_end lifecycle hooks — the task reached DONE.
         # None dispatcher → no-op. (Aborted tasks terminate via the separate
         # _abort handler — see the task_end symmetry note there.)
         hook_dispatcher = getattr(ctx, "hook_dispatcher", None)
         if hook_dispatcher is not None:
             await hook_dispatcher.dispatch(
                 "task_end",
-                {"point": "task_end", "task_id": task.task_id, "status": "completed"},
+                {"point": "task_end", "task_id": task.task_id, "status": "done"},
             )
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)

--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -171,12 +171,12 @@ def _list_skill_lines(session: "Session") -> list[str]:
 
 # Dynamic Tasks are PERSISTENT trackable work-units (the point of the
 # dynamic-task model), so the Tasks section shows the FULL plan WITH status —
-# active + completed + failed + aborted — so the user sees progress ("3/6 done")
-# and deps referencing completed tasks stay intact. Only ``archived`` (the
-# user-dismissed state) is hidden. NB the skill-runs section keeps its own
-# running-only filter (ephemeral runs, not trackable plans = different
-# semantics); the split is intentional (#2036 review).
-_HIDDEN_TASK_STATUSES = frozenset({"archived"})
+# active + completed + failed — so the user sees progress ("3/6 done") and deps
+# referencing completed tasks stay intact. Only SOFT-DELETED tasks (``archived_at``
+# set — abort dismisses a task by setting it alongside the ABORTED lifecycle state,
+# #2187) are hidden. NB the skill-runs section keeps its own running-only filter
+# (ephemeral runs, not trackable plans = different semantics); the split is
+# intentional (#2036 review).
 
 
 async def _list_dynamic_task_lines(session: "Session") -> list[str]:
@@ -184,9 +184,9 @@ async def _list_dynamic_task_lines(session: "Session") -> list[str]:
 
     Reads ``session.task_backend`` (#1953 slice R). Returns ``[]`` when the
     session carries no backend. Shows the full plan WITH status (active +
-    completed + failed + aborted) so the user sees progress + intact deps; only
-    ``archived`` tasks are hidden. Each task is formatted in the same idiom as
-    ``_list_skill_lines``.
+    completed + failed) so the user sees progress + intact deps; only
+    SOFT-DELETED tasks (``archived_at`` set, #2187) are hidden. Each task is
+    formatted in the same idiom as ``_list_skill_lines``.
     """
     backend = getattr(session, "task_backend", None)
     if backend is None:
@@ -195,7 +195,7 @@ async def _list_dynamic_task_lines(session: "Session") -> list[str]:
     lines: list[str] = []
     for task in tasks:
         status = getattr(task.status, "value", task.status)
-        if status in _HIDDEN_TASK_STATUSES:
+        if getattr(task, "archived_at", None) is not None:  # soft-deleted (retention) — hidden
             continue
         deps = list(getattr(task, "deps", []) or [])
         if deps:

--- a/src/reyn/interfaces/web/a2a_task_view.py
+++ b/src/reyn/interfaces/web/a2a_task_view.py
@@ -23,14 +23,13 @@ from reyn.task.model import TaskState
 # lie), while only **external-input / auth** blocks map to
 # ``input-required`` / ``auth-required`` (H3).
 _TASK_STATE_TO_A2A: dict[str, str] = {
-    "pending": "submitted",
+    "unassigned": "submitted",
     "ready": "submitted",
-    "in_progress": "working",
+    "running": "working",
     "blocked": "input-required",   # interim — see note above (slice 7)
-    "completed": "completed",
+    "done": "completed",
     "failed": "failed",
-    "aborted": "canceled",
-    "archived": "canceled",        # abort = delete → archived → A2A canceled
+    "aborted": "canceled",         # abort (soft-delete is the orthogonal archived_at marker, not a state)
 }
 
 # The legal A2A TaskState values this mapper may emit (drift guard for the

--- a/src/reyn/interfaces/web/a2a_webhook_registry.py
+++ b/src/reyn/interfaces/web/a2a_webhook_registry.py
@@ -106,8 +106,10 @@ async def sweep_dispositions(task_backend, registry: A2AWebhookRegistry, *, post
     # production; tests inject a real recording callable (no mocks).
     post = post_fn if post_fn is not None else post_webhook
 
-    archived = await task_backend.list(status="archived")
-    external = [t for t in archived if t.origin == TaskOrigin.EXTERNAL]
+    # #2187: the sweep is a LIFECYCLE signal (abort → A2A canceled notify), so it
+    # keys on the ABORTED state — not the orthogonal archived_at retention marker.
+    aborted = await task_backend.list(status="aborted")
+    external = [t for t in aborted if t.origin == TaskOrigin.EXTERNAL]
     registry.reconcile_notified({t.task_id for t in external})
 
     fired = 0

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -705,7 +705,7 @@ async def _escalate_to_task(
                 result=narration or "(no narration captured)",
             )
             # #1981 P2: reflect the terminal onto the canonical Task (assignee CAS,
-            # race-safe — an A2A Cancel that archived first wins via terminal-guard).
+            # race-safe — an A2A Cancel that aborted first wins via terminal-guard).
             await _reflect_task_status(task_backend, monitor_task_id, "done")
         except Exception as exc:  # noqa: BLE001
             logger.exception("a2a auto-escalation monitor raised")
@@ -908,7 +908,7 @@ async def _handle_answer_injection(
         # the public-status mirror.
         run_registry.update(task_id, status="running")
         # #1981 P3: reflect the answered state onto the canonical Task
-        # (blocked → in_progress) so GetTask leaves input-required, matching the
+        # (blocked → running) so GetTask leaves input-required, matching the
         # RunEntry mirror. The iv resolution itself stays Session-owned.
         await _reflect_task_status(task_backend, task_id, "running")
         result = {"task_id": task_id, "answered": True}
@@ -1096,15 +1096,15 @@ class _A2AProgressBridge:
 async def _reflect_task_status(task_backend, task_id: str, status: str) -> None:
     """Reflect the A2A execution's status onto the canonical Task (#1953 slice 5b
     terminal reflection, generalized for #1981 to drive the interactive
-    ``blocked`` / ``in_progress`` transitions too).
+    ``blocked`` / ``running`` transitions too).
 
     The single-writer is the Task's **assignee session** (the run executes on it),
     so the immutable ``assignee`` read off the Task IS the CAS caller — this is the
     assignee's own status write, not a foreign one (single-writer hygiene). Used
-    for: terminal (completed / failed) on run end, ``blocked`` on ask_user
-    dispatch, ``in_progress`` on answer.
+    for: terminal (done / failed) on run end, ``blocked`` on ask_user
+    dispatch, ``running`` on answer.
 
-    Best-effort and **race-safe**: if an A2A ``Cancel`` already archived the Task,
+    Best-effort and **race-safe**: if an A2A ``Cancel`` already aborted the Task,
     the terminal-guard rejects this write (``PermissionError``) — the abort wins
     and the disposition sweep, not this reflection, notifies the requester. A
     missing backend, unknown task, or assignee-less task is a no-op. Reflection is
@@ -1186,7 +1186,7 @@ async def _handle_async_mode(
     its terminal outcome onto the Task. The single-writer of the Task's status is
     the assignee session (``a2a_session_id(context_id)``), which is exactly the
     session the background ``_run`` executes on — so the reflection update passes
-    the fixed-equality CAS. An A2A ``Cancel`` that archived the Task first wins:
+    the fixed-equality CAS. An A2A ``Cancel`` that aborted the Task first wins:
     the reflection is then rejected by the terminal-guard (race-safe).
     """
     from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: PLC0415
@@ -1313,7 +1313,7 @@ async def get_task(
 ) -> dict:
     """A2A GetTask — poll a Task's status from the Task backend (#1953 slice 5a).
     Returns the spec A2A Task envelope (Task-vocab state). The path param is the
-    ``task_id``. A terminal/archived task returns its envelope (status=canceled),
+    ``task_id``. A terminal task returns its envelope (an aborted task → status=canceled),
     a tombstone rather than 404; a genuinely-unknown id is 404."""
     task = await task_backend.get(run_id)
     if task is None:

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -706,7 +706,7 @@ async def _escalate_to_task(
             )
             # #1981 P2: reflect the terminal onto the canonical Task (assignee CAS,
             # race-safe — an A2A Cancel that archived first wins via terminal-guard).
-            await _reflect_task_status(task_backend, monitor_task_id, "completed")
+            await _reflect_task_status(task_backend, monitor_task_id, "done")
         except Exception as exc:  # noqa: BLE001
             logger.exception("a2a auto-escalation monitor raised")
             run_registry.update(monitor_task_id, status="failed", error=str(exc))
@@ -910,7 +910,7 @@ async def _handle_answer_injection(
         # #1981 P3: reflect the answered state onto the canonical Task
         # (blocked → in_progress) so GetTask leaves input-required, matching the
         # RunEntry mirror. The iv resolution itself stays Session-owned.
-        await _reflect_task_status(task_backend, task_id, "in_progress")
+        await _reflect_task_status(task_backend, task_id, "running")
         result = {"task_id": task_id, "answered": True}
     else:
         result = {
@@ -1156,7 +1156,7 @@ async def _create_a2a_task(
             assignee=a2a_session_id(context_id),
             requester="external",
             origin=TaskOrigin.EXTERNAL,
-            status=TaskState.IN_PROGRESS,
+            status=TaskState.RUNNING,
         )
     )
     if webhook_url and webhook_registry is not None:
@@ -1259,7 +1259,7 @@ async def _handle_async_mode(
                 status="completed",
                 result=result.get("reply", ""),
             )
-            await _reflect_task_status(task_backend, run_id, "completed")
+            await _reflect_task_status(task_backend, run_id, "done")
             if webhook_url:
                 from reyn.interfaces.web.notifications import post_webhook  # noqa: PLC0415
                 await post_webhook(

--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -210,7 +210,7 @@ class InMemoryTaskBackend:
         # an initial-status derivation, not a post-hoc status flip (OQ-2) — deps-less
         # tasks (e.g. the A2A create path) keep their requested status.
         if task.deps and not all(
-            self._tasks[d].status == TaskState.COMPLETED for d in task.deps
+            self._tasks[d].status == TaskState.DONE for d in task.deps
         ):
             task.status = TaskState.BLOCKED
         self._tasks[task.task_id] = task
@@ -274,7 +274,7 @@ class InMemoryTaskBackend:
         # A dep is satisfied when it exists + is completed. No deps → vacuously
         # satisfied (the #1953 slice 6-ext I-1 case: an ordering-free task is ready).
         return all(
-            d in self._tasks and self._tasks[d].status == TaskState.COMPLETED
+            d in self._tasks and self._tasks[d].status == TaskState.DONE
             for d in task.deps
         )
 
@@ -291,14 +291,14 @@ class InMemoryTaskBackend:
         graph → promote-only (``allow_demote=False``, consistent with the OQ-2
         pure-topology rule that a mere edge change does not re-block a non-blocked
         task); ``repoint`` is a material re-wire → full re-derive (``allow_demote=True``)."""
-        if task.status not in (TaskState.PENDING, TaskState.READY, TaskState.BLOCKED):
+        if task.status not in (TaskState.READY, TaskState.BLOCKED):
             return None
         satisfied = self._all_deps_satisfied(task)
         if satisfied and task.status is TaskState.BLOCKED:
             task.status = TaskState.READY
             task.updated_at = _now_iso()
             return "ready"
-        if allow_demote and not satisfied and task.status in (TaskState.PENDING, TaskState.READY):
+        if allow_demote and not satisfied and task.status is TaskState.READY:
             task.status = TaskState.BLOCKED
             task.updated_at = _now_iso()
             return "blocked"
@@ -395,9 +395,14 @@ class InMemoryTaskBackend:
                     subtree.append(tid)
                     frontier.append(tid)
         aborted: list[Task] = []
+        now = _now_iso()
         for tid in subtree:
-            self._tasks[tid].status = TaskState.ARCHIVED
-            self._tasks[tid].updated_at = _now_iso()
+            self._tasks[tid].status = TaskState.ABORTED
+            # #2187: soft-delete is the orthogonal retention dimension (archived_at),
+            # not a state — abort sets BOTH the ABORTED lifecycle state and the
+            # retention marker (preserves the hidden-from-list UX of the old ARCHIVED).
+            self._tasks[tid].archived_at = now
+            self._tasks[tid].updated_at = now
             aborted.append(self._tasks[tid])
         # #2107 S2 (origin-split): an EXTERNAL terminal's dep-DAG DEPENDENTS can't be
         # recovered — the external requester gives up (no in-session re-wire; that is the

--- a/src/reyn/task/model.py
+++ b/src/reyn/task/model.py
@@ -16,27 +16,31 @@ def _now_iso() -> str:
 
 
 class TaskState(str, Enum):
-    """Lifecycle states (#1953 §0-Q1).
+    """Lifecycle — 7 base states (#2187 §3.4).
 
-    ``ready`` = DAG-unblocked but not yet started; ``archived`` = soft-deleted
-    (WAL-window auto-purge eligible, §24). A2A mapping lives in the A2A layer:
-    ready→submitted, in_progress→working, blocked→input-required/auth-required,
-    completed→completed, failed→failed, aborted→canceled, archived→(internal).
+    ``unassigned`` = no assignee yet (the pending-assignment queue); ``blocked`` =
+    DAG deps not all terminal; ``ready`` = DAG-unblocked + assigned but not yet
+    started; ``running`` = the assignee is executing; ``done``/``failed``/``aborted``
+    are terminal. "Waiting on children" / "deciding" are NOT base states — they are
+    derived from the open-child counts (``N_awaited``/``N_background``) over a
+    ``running`` task (#2187 §3.4). Soft-delete is the orthogonal retention dimension
+    (``Task.archived_at``), not a state. A2A mapping lives in the A2A layer:
+    ready→submitted, running→working, blocked→input-required/auth-required,
+    done→completed, failed→failed, aborted→canceled.
     """
 
-    PENDING = "pending"
-    READY = "ready"
-    IN_PROGRESS = "in_progress"
+    UNASSIGNED = "unassigned"
     BLOCKED = "blocked"
-    COMPLETED = "completed"
+    READY = "ready"
+    RUNNING = "running"
+    DONE = "done"
     FAILED = "failed"
     ABORTED = "aborted"
-    ARCHIVED = "archived"
 
 
 # Terminal states never transition further (single-writer is moot once here).
 TERMINAL_STATES: frozenset[TaskState] = frozenset(
-    {TaskState.COMPLETED, TaskState.FAILED, TaskState.ABORTED, TaskState.ARCHIVED}
+    {TaskState.DONE, TaskState.FAILED, TaskState.ABORTED}
 )
 
 
@@ -125,10 +129,11 @@ class Task:
     requester: str
     requester_kind: TaskRequesterKind = TaskRequesterKind.SESSION  # §16: session-owned vs task-as-request owned (the ownership edge)
     origin: TaskOrigin = TaskOrigin.SELF
-    status: TaskState = TaskState.PENDING
+    status: TaskState = TaskState.READY
     description: str | None = None
     created_by: str | None = None  # audit provenance (§0-Q3); operative notify = requester
     awaiting_since: float | None = None  # R-D16 WAL-floor exclusion (set while blocked)
+    archived_at: str | None = None  # soft-delete retention marker (#2187): orthogonal to the lifecycle state — set alongside ABORTED by abort(); the §24 purge-window + the list hidden-filter key on it
     deps: list[str] = field(default_factory=list)  # depends-on task_ids (DAG, §13)
     tools: list[str] = field(default_factory=list)  # narrowed tool set for the exec engine (#1953 slice P2)
     result: str | None = None  # exec-layer output captured on completion (#1953 slice P2)
@@ -145,6 +150,7 @@ class Task:
             "requester_kind": self.requester_kind.value,
             "origin": self.origin.value,
             "status": self.status.value,
+            "archived_at": self.archived_at,
             "description": self.description,
             "created_by": self.created_by,
             "awaiting_since": self.awaiting_since,

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -69,6 +69,9 @@ CREATE TABLE IF NOT EXISTS tasks(
   unblock_predicate TEXT,
   tools TEXT,
   result TEXT,
+  -- #2187: soft-delete retention marker, orthogonal to the lifecycle `status`
+  -- (set alongside ABORTED by abort(); the list hidden-filter keys on it).
+  archived_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -107,7 +110,7 @@ CREATE TABLE IF NOT EXISTS task_comments(
 
 _TASK_COLUMNS = (
     "task_id, name, origin, status, description, "
-    "created_by, awaiting_since, tools, result, created_at, updated_at"
+    "created_by, awaiting_since, tools, result, archived_at, created_at, updated_at"
 )
 
 
@@ -162,7 +165,8 @@ class SqliteTaskBackend:
         schema evolution by construction."""
         existing = {r[1] for r in conn.execute("PRAGMA table_info(tasks)").fetchall()}
         # #1953 slice P2: additive migration for DBs created before tools / result.
-        for col in ("tools", "result"):
+        # #2187: archived_at (the soft-delete retention marker) for pre-#2187 DBs.
+        for col in ("tools", "result", "archived_at"):
             if col not in existing:
                 conn.execute(f"ALTER TABLE tasks ADD COLUMN {col} TEXT")
         # #2187 backend-master (2c-iii): the task BINDING moved to the WAL-derived
@@ -233,7 +237,7 @@ class SqliteTaskBackend:
             row = self._conn.execute(
                 "SELECT status FROM tasks WHERE task_id=?", (d,)
             ).fetchone()
-            if row is None or row["status"] != TaskState.COMPLETED.value:
+            if row is None or row["status"] != TaskState.DONE.value:
                 return False
         return True
 
@@ -252,16 +256,12 @@ class SqliteTaskBackend:
         if row is None:
             return None
         status = row["status"]
-        if status not in (
-            TaskState.PENDING.value, TaskState.READY.value, TaskState.BLOCKED.value
-        ):
+        if status not in (TaskState.READY.value, TaskState.BLOCKED.value):
             return None
         satisfied = self._all_deps_completed(task_id)
         if satisfied and status == TaskState.BLOCKED.value:
             new = TaskState.READY.value
-        elif allow_demote and not satisfied and status in (
-            TaskState.PENDING.value, TaskState.READY.value
-        ):
+        elif allow_demote and not satisfied and status == TaskState.READY.value:
             new = TaskState.BLOCKED.value
         else:
             return None
@@ -289,6 +289,7 @@ class SqliteTaskBackend:
             description=row["description"],
             created_by=row["created_by"],
             awaiting_since=row["awaiting_since"],
+            archived_at=row["archived_at"],
             deps=self._deps(row["task_id"]),
             tools=json.loads(row["tools"]) if row["tools"] else [],
             result=row["result"],
@@ -322,18 +323,18 @@ class SqliteTaskBackend:
                     ).fetchone() or {"status": None})["status"]
                     for dep in task.deps
                 ]
-                if not all(s == TaskState.COMPLETED.value for s in dep_statuses):
+                if not all(s == TaskState.DONE.value for s in dep_statuses):
                     status = TaskState.BLOCKED
             task.status = status
             self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 f"INSERT INTO tasks({_TASK_COLUMNS}) "
-                f"VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                f"VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     task.task_id, task.name, task.origin.value, task.status.value,
                     task.description, task.created_by, task.awaiting_since,
                     json.dumps(task.tools) if task.tools else None, task.result,
-                    task.created_at, task.updated_at,
+                    task.archived_at, task.created_at, task.updated_at,
                 ),
             )
             for dep in task.deps:
@@ -588,10 +589,14 @@ class SqliteTaskBackend:
                             to_abort.append(dep)
                             dep_frontier.append(dep)
             self._conn.execute("BEGIN IMMEDIATE")
+            now = _now_iso()
             for tid in to_abort:
+                # #2187: abort sets BOTH the ABORTED lifecycle state and archived_at
+                # (the orthogonal soft-delete retention marker — preserves the
+                # hidden-from-list UX of the old ARCHIVED state).
                 self._conn.execute(
-                    "UPDATE tasks SET status=?, updated_at=? WHERE task_id=?",
-                    (TaskState.ARCHIVED.value, _now_iso(), tid),
+                    "UPDATE tasks SET status=?, archived_at=?, updated_at=? WHERE task_id=?",
+                    (TaskState.ABORTED.value, now, now, tid),
                 )
                 self._emit(tid, "aborted", root=task_id)
             self._conn.commit()

--- a/tests/cli/test_tasks_slash_dynamic_status_kill.py
+++ b/tests/cli/test_tasks_slash_dynamic_status_kill.py
@@ -50,7 +50,7 @@ async def _seed_task(backend: InMemoryTaskBackend) -> str:
         name="ingest_raw_csv",
         assignee="sess-1",
         requester="req",
-        status=TaskState.IN_PROGRESS,
+        status=TaskState.RUNNING,
     )
     await backend.create(task)
     return task.task_id
@@ -70,7 +70,7 @@ async def test_tasks_status_resolves_dynamic_task() -> None:
     out = session.replies[-1]
     assert "no task matches" not in out
     assert "ingest_raw_csv" in out
-    assert "in_progress" in out
+    assert "running" in out
 
 
 @pytest.mark.asyncio
@@ -86,7 +86,7 @@ async def test_tasks_kill_aborts_dynamic_task() -> None:
     # The real backend transitioned the task out of the runnable set.
     task = await backend.get(task_id)
     assert task is not None
-    assert getattr(task.status, "value", task.status) == "archived"
+    assert getattr(task.status, "value", task.status) == "aborted"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_tasks_slash_dynamic_view.py
+++ b/tests/cli/test_tasks_slash_dynamic_view.py
@@ -54,7 +54,7 @@ class _CaptureSession:
 async def _seed_tasks(backend: InMemoryTaskBackend) -> None:
     """Two dynamic tasks with a real dependency: ``build`` -> depends on ``plan``.
 
-    ``plan`` is IN_PROGRESS; ``build`` is born with a dep on the not-yet-completed
+    ``plan`` is RUNNING; ``build`` is born with a dep on the not-yet-done
     ``plan`` so the backend derives it as BLOCKED (both non-terminal → both shown).
     """
     plan = Task(
@@ -147,7 +147,7 @@ async def test_tasks_list_no_backend_falls_back_to_skill_only():
 
 
 @pytest.mark.asyncio
-async def test_tasks_list_shows_completed_hides_only_archived():
+async def test_tasks_list_shows_done_hides_soft_deleted():
     """Tier 2: the Tasks section shows the full plan WITH status (#2036) — a
     DONE task is SHOWN (so the user sees "done" progress + deps to it stay
     intact); only a SOFT-DELETED task (``archived_at`` set, #2187 — the orthogonal

--- a/tests/cli/test_tasks_slash_dynamic_view.py
+++ b/tests/cli/test_tasks_slash_dynamic_view.py
@@ -62,7 +62,7 @@ async def _seed_tasks(backend: InMemoryTaskBackend) -> None:
         name="plan",
         assignee="sess-1",
         requester="req",
-        status=TaskState.IN_PROGRESS,
+        status=TaskState.RUNNING,
     )
     await backend.create(plan)
     build = Task(
@@ -92,7 +92,7 @@ async def test_tasks_list_includes_dynamic_tasks():
     # Each dynamic task surfaces name + short (8-char) id + status.
     assert "plan" in out
     assert "plan-aaa" in out  # task_id[:8]
-    assert "status: in_progress" in out
+    assert "status: running" in out
     assert "build" in out
     assert "build-bb" in out  # task_id[:8]
     # The dependency edge is summarised by the depended-on short id.
@@ -149,28 +149,30 @@ async def test_tasks_list_no_backend_falls_back_to_skill_only():
 @pytest.mark.asyncio
 async def test_tasks_list_shows_completed_hides_only_archived():
     """Tier 2: the Tasks section shows the full plan WITH status (#2036) — a
-    COMPLETED task is SHOWN (so the user sees "done" progress + deps to it stay
-    intact); only an ARCHIVED (user-dismissed) task is hidden. The split is
-    intentional vs the skill-runs section's running-only filter."""
+    DONE task is SHOWN (so the user sees "done" progress + deps to it stay
+    intact); only a SOFT-DELETED task (``archived_at`` set, #2187 — the orthogonal
+    retention marker abort() sets) is hidden. The split is intentional vs the
+    skill-runs section's running-only filter."""
     backend = InMemoryTaskBackend()
     # deps-less tasks → the backend honors the given status (no readiness derive).
     await backend.create(Task(
         task_id="done-cccccccc-0003", name="done-step", assignee="sess-1",
-        requester="req", status=TaskState.COMPLETED,
+        requester="req", status=TaskState.DONE,
     ))
     await backend.create(Task(
         task_id="arch-dddddddd-0004", name="archived-step", assignee="sess-1",
-        requester="req", status=TaskState.ARCHIVED,
+        requester="req", status=TaskState.ABORTED,
+        archived_at="2026-01-01T00:00:00+00:00",  # #2187: the soft-delete marker → hidden
     ))
     session = _CaptureSession(task_backend=backend)
 
     await _list_tasks(session)
 
     out = session.replies[-1]
-    # COMPLETED task surfaces WITH its status (progress visibility).
+    # DONE task surfaces WITH its status (progress visibility).
     assert "done-step" in out
-    assert "status: completed" in out
-    # ARCHIVED task is hidden.
+    assert "status: done" in out
+    # SOFT-DELETED task (archived_at set) is hidden.
     assert "archived-step" not in out
     assert "arch-ddd" not in out
 

--- a/tests/test_2107_B1_recovery_stamp_1953.py
+++ b/tests/test_2107_B1_recovery_stamp_1953.py
@@ -89,7 +89,7 @@ async def test_recovery_create_on_task_as_request_is_owned_by_it_full_live_path(
 
     # T = the task-as-request, executed by the managing session.
     await b.create(Task(task_id="T-req", name="T", assignee="main", requester="a2a:client",
-                        status=TaskState.IN_PROGRESS))
+                        status=TaskState.RUNNING))
     # U owned by T (live create-path), a dependent V, then U fails.
     res_u = await taskmod._create(
         _create_op("U"), _ctx(b, session_id="worker", current_task_id="T-req"), "control_ir")
@@ -134,7 +134,7 @@ async def test_session_requester_recovery_stays_session_owned(tmp_path):
 
     # a flat self-task plan whose requester is the session "main" (the S1 path).
     await b.create(Task(task_id="b2", name="b2", assignee="main", requester="main",
-                        status=TaskState.IN_PROGRESS))
+                        status=TaskState.RUNNING))
     await b.create(Task(task_id="b3", name="b3", assignee="main", requester="main", deps=["b2"]))
     await b.update_status("b2", TaskState.FAILED, caller_session_id="main")
 

--- a/tests/test_2107_B2_ownership_cascade_1953.py
+++ b/tests/test_2107_B2_ownership_cascade_1953.py
@@ -70,7 +70,7 @@ async def test_ownership_cascade_aborts_owned_subtasks_recursively(backend):
     recursively (X → owned U → owned-of-U W, depth 2), via the live create-path's
     requester edges. RED if the ownership BFS edge is absent — U/W would survive."""
     await backend.create(Task(task_id="X", name="X", assignee="sX", requester="client",
-                              status=TaskState.IN_PROGRESS))
+                              status=TaskState.RUNNING))
     res_u = await taskmod._create(
         _create_op("U"), _ctx(backend, session_id="sX", current_task_id="X"), "control_ir")
     u_id = res_u["task"]["task_id"]
@@ -88,7 +88,7 @@ async def test_ownership_cascade_aborts_owned_subtasks_recursively(backend):
     ids = {t.task_id for t in aborted}
     assert {"X", u_id, w_id} <= ids  # the whole ownership subtree, recursively
     for tid in ("X", u_id, w_id):
-        assert (await backend.get(tid)).status is TaskState.ARCHIVED
+        assert (await backend.get(tid)).status is TaskState.ABORTED
 
 
 @pytest.mark.asyncio
@@ -100,13 +100,13 @@ async def test_collision_guard_session_requester_is_not_cascaded(backend):
     gather drops the marker guard (bare requester==X → S wrongly archived)."""
     # X = the aborted task; S = a SESSION-requester whose requester string == X's id.
     await backend.create(Task(task_id="collide", name="X", assignee="sX", requester="root",
-                              status=TaskState.IN_PROGRESS))
+                              status=TaskState.RUNNING))
     await backend.create(Task(task_id="S", name="S", assignee="sS", requester="collide",
                               requester_kind=TaskRequesterKind.SESSION,
-                              status=TaskState.IN_PROGRESS))
+                              status=TaskState.RUNNING))
 
     aborted = await backend.abort("collide")
     ids = {t.task_id for t in aborted}
     assert "collide" in ids
     assert "S" not in ids  # the marker guard — NOT cascaded despite the id collision
-    assert (await backend.get("S")).status is TaskState.IN_PROGRESS  # survived
+    assert (await backend.get("S")).status is TaskState.RUNNING  # survived

--- a/tests/test_2107_s2_external_origin_split.py
+++ b/tests/test_2107_s2_external_origin_split.py
@@ -26,12 +26,12 @@ from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
 from reyn.task.model import TaskOrigin
 
 
-def _ext(task_id, *, deps=None, status=TaskState.PENDING, assignee="a2a:ctx-1"):
+def _ext(task_id, *, deps=None, status=TaskState.READY, assignee="a2a:ctx-1"):
     return Task(task_id=task_id, name=task_id, assignee=assignee, requester="a2a:ctx-1",
                 origin=TaskOrigin.EXTERNAL, status=status, deps=list(deps or []))
 
 
-def _self(task_id, *, deps=None, status=TaskState.PENDING):
+def _self(task_id, *, deps=None, status=TaskState.READY):
     return Task(task_id=task_id, name=task_id, assignee="main", requester="main",
                 origin=TaskOrigin.SELF, status=status, deps=list(deps or []))
 
@@ -54,14 +54,14 @@ async def test_external_abort_cascades_to_transitive_dependents(backend):
     """Tier 2: aborting an EXTERNAL task archives its TRANSITIVE dep-DAG dependents
     (X ← Y ← Z) — they can't be recovered, so they give up with it. Catches the direct
     backend.abort triggers (A2A cancel / agent abort / /tasks kill) by construction."""
-    await backend.create(_ext("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_ext("X", status=TaskState.RUNNING))
     await backend.create(_ext("Y", deps=["X"]))
     await backend.create(_ext("Z", deps=["Y"]))
 
     await backend.abort("X")
 
     for tid in ("X", "Y", "Z"):
-        assert (await backend.get(tid)).status is TaskState.ARCHIVED
+        assert (await backend.get(tid)).status is TaskState.ABORTED
 
 
 @pytest.mark.asyncio
@@ -69,13 +69,13 @@ async def test_internal_abort_does_not_cascade_to_dependents(backend):
     """Tier 2: origin-split — a SELF (internal) abort does NOT abort its dependents (they
     recover via the requester wake, §16 S1). Strip the origin gate → the dependent would
     be wrongly archived → RED."""
-    await backend.create(_self("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_self("X", status=TaskState.RUNNING))
     await backend.create(_self("Y", deps=["X"]))
 
     await backend.abort("X")
 
-    assert (await backend.get("X")).status is TaskState.ARCHIVED
-    assert (await backend.get("Y")).status is not TaskState.ARCHIVED  # NOT cascaded
+    assert (await backend.get("X")).status is TaskState.ABORTED
+    assert (await backend.get("Y")).status is not TaskState.ABORTED  # NOT cascaded
 
 
 @pytest.mark.asyncio
@@ -93,8 +93,8 @@ async def test_external_failed_path_aborts_dependents_via_route(backend):
     await taskmod._route_terminal_to_requester(ctx, backend, terminal, disposition="failed")
 
     assert (await backend.get("X")).status is TaskState.FAILED  # X itself stays failed
-    assert (await backend.get("Y")).status is TaskState.ARCHIVED
-    assert (await backend.get("Z")).status is TaskState.ARCHIVED
+    assert (await backend.get("Y")).status is TaskState.ABORTED
+    assert (await backend.get("Z")).status is TaskState.ABORTED
 
 
 # ── the LIVE path: the REAL cancel_task endpoint → archived → the REAL sweep → webhooks ──
@@ -112,7 +112,7 @@ async def test_live_cancel_endpoint_cascades_then_sweep_fires_webhooks(tmp_path)
     from reyn.interfaces.web.routers.a2a import cancel_task
 
     backend = InMemoryTaskBackend()
-    await backend.create(_ext("X", status=TaskState.IN_PROGRESS))
+    await backend.create(_ext("X", status=TaskState.RUNNING))
     await backend.create(_ext("Y", deps=["X"]))
     await backend.create(_ext("Z", deps=["Y"]))
 
@@ -122,7 +122,7 @@ async def test_live_cancel_endpoint_cascades_then_sweep_fires_webhooks(tmp_path)
     # the REAL cancel endpoint (the A2A client's remove-op) — direct backend.abort.
     await cancel_task("X", task_backend=backend)
     for tid in ("X", "Y", "Z"):
-        assert (await backend.get(tid)).status is TaskState.ARCHIVED  # the cascade
+        assert (await backend.get(tid)).status is TaskState.ABORTED  # the cascade
 
     posted: list[dict] = []
 

--- a/tests/test_2107_sliceA_recursive_request_1953.py
+++ b/tests/test_2107_sliceA_recursive_request_1953.py
@@ -137,7 +137,7 @@ async def test_failed_subtask_recovery_wakes_managing_session_full_live_path(tmp
 
     # T = the task-as-request, assigned to (executed by) the live managing session.
     T = Task(task_id="T-req", name="T", assignee="main", requester="a2a:client",
-             status=TaskState.IN_PROGRESS)
+             status=TaskState.RUNNING)
     await b.create(T)
 
     # U = a sub-task created WHILE executing T → owned by T via the live create-path.

--- a/tests/test_2187_stage4_pubsub.py
+++ b/tests/test_2187_stage4_pubsub.py
@@ -40,7 +40,7 @@ class _RoutingWaker(TaskWaker):
 
 
 def _task(tid):
-    return Task(task_id=tid, name=tid, assignee="s1", requester="s1", status=TaskState.PENDING)
+    return Task(task_id=tid, name=tid, assignee="s1", requester="s1", status=TaskState.READY)
 
 
 @pytest.mark.asyncio

--- a/tests/test_2187_stage5a_lifecycle.py
+++ b/tests/test_2187_stage5a_lifecycle.py
@@ -1,0 +1,59 @@
+"""Tier 2: #2187 Stage 5a — retention is orthogonal to the lifecycle state.
+
+The old single ARCHIVED state split into two orthogonal axes: the ABORTED lifecycle
+state and the ``archived_at`` soft-delete retention marker. ``abort()`` is the
+soft-delete — it sets BOTH: the task reaches ABORTED *and* gets stamped archived_at
+(so the list hidden-filter, which now keys on archived_at, still hides it = the old
+UX). This pins that abort sets the marker (RED if abort stops stamping archived_at —
+the soft-deleted task would resurface in the list) and that the marker is durable
+across a sqlite reload (RED if the column is dropped from INSERT / _row_to_task).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
+from reyn.task.subscription import SubscriptionRegistry
+from tests._support.task_subscription import SubscriptionBackend
+
+
+@pytest.mark.asyncio
+async def test_abort_sets_both_aborted_state_and_archived_at_inmem():
+    """Tier 2: in-memory abort sets BOTH the ABORTED state and the archived_at
+    retention marker (the two orthogonal axes), so the task is soft-deleted."""
+    backend = InMemoryTaskBackend()
+    await backend.create(Task(task_id="t1", name="t", assignee="s", requester="s"))
+    # Before abort: a live task carries no retention marker.
+    assert (await backend.get("t1")).archived_at is None
+
+    aborted = await backend.abort("t1")
+
+    assert aborted and aborted[0].status is TaskState.ABORTED
+    # RED if abort stops stamping archived_at (→ the task would no longer be hidden).
+    assert aborted[0].archived_at is not None
+    got = await backend.get("t1")
+    assert got.status is TaskState.ABORTED and got.archived_at is not None
+
+
+@pytest.mark.asyncio
+async def test_abort_archived_at_is_durable_across_sqlite_reload(tmp_path):
+    """Tier 2: the archived_at retention marker survives a sqlite close + reopen — the
+    soft-delete is durable, not an in-memory flag (RED if the column is dropped from
+    the INSERT column list or _row_to_task)."""
+    path = str(tmp_path / "tasks.db")
+    cp = SubscriptionRegistry()
+    backend = SubscriptionBackend(SqliteTaskBackend(path, subscription_reader=cp), cp)
+    await backend.create(Task(task_id="t1", name="t", assignee="s", requester="s"))
+
+    aborted = await backend.abort("t1")
+    assert aborted and aborted[0].status is TaskState.ABORTED
+    assert aborted[0].archived_at is not None
+    backend.close()
+
+    reopened = SqliteTaskBackend(path, subscription_reader=cp)
+    got = await reopened.get("t1")
+    assert got is not None
+    assert got.status is TaskState.ABORTED
+    # RED if archived_at is not persisted (the soft-delete would be lost on restart).
+    assert got.archived_at is not None
+    reopened.close()

--- a/tests/test_a2a_disposition_sweep_1953.py
+++ b/tests/test_a2a_disposition_sweep_1953.py
@@ -1,13 +1,13 @@
 """Tier 2: #1953 slice 5a-2 — A2A disposition sweep (backend-derived webhook).
 
-The periodic sweep notifies the external requester of every archived
+The periodic sweep notifies the external requester of every aborted
 ``origin=external`` Task via its registered webhook, exactly once, retrying
 failures, bounded by construction. Real Task backend + a real recording poster
 (no mocks). The webhook channel map is A2A-owned (P7 — never on the Task).
 
 Falsification:
-- (a) an archived external task with a registered webhook → fires once;
-- (b) an archived self-origin task → never fires;
+- (a) an aborted external task with a registered webhook → fires once;
+- (b) an aborted self-origin task → never fires;
 - (c) a second sweep pass → no re-fire (notified-set);
 - (d) a failed POST → not notified → retried next sweep;
 - (e) the notified-set self-prunes hard-deleted task_ids (bounded);
@@ -39,19 +39,19 @@ class _RecordingPoster:
         return SimpleNamespace(ok=self._ok)
 
 
-async def _archived(backend, task_id, ctx, origin):
-    """Seed an archived task assigned to the context's session."""
+async def _aborted(backend, task_id, ctx, origin):
+    """Seed an aborted task assigned to the context's session."""
     await backend.create(Task(task_id=task_id, name="n", assignee=a2a_session_id(ctx),
                               requester="ext", origin=origin, status=TaskState.ABORTED))
 
 
 @pytest.mark.asyncio
 async def test_sweep_fires_for_external_and_not_for_self():
-    """Tier 2: an archived external task with a registered webhook fires (a);
-    an archived self-origin task never fires (b)."""
+    """Tier 2: an aborted external task with a registered webhook fires (a);
+    an aborted self-origin task never fires (b)."""
     backend = InMemoryTaskBackend()
-    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
-    await _archived(backend, "self-1", "ctx-b", TaskOrigin.SELF)
+    await _aborted(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _aborted(backend, "self-1", "ctx-b", TaskOrigin.SELF)
     reg = A2AWebhookRegistry()
     reg.register_webhook("ctx-a", "https://client.example/hook")
     reg.register_webhook("ctx-b", "https://client.example/hook")  # self still excluded
@@ -71,7 +71,7 @@ async def test_sweep_fires_for_external_and_not_for_self():
 async def test_sweep_does_not_refire_on_second_pass():
     """Tier 2: (c): a notified task is not re-fired on the next sweep."""
     backend = InMemoryTaskBackend()
-    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _aborted(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
     reg = A2AWebhookRegistry()
     reg.register_webhook("ctx-a", "https://client.example/hook")
     poster = _RecordingPoster()
@@ -89,7 +89,7 @@ async def test_sweep_retries_failed_post():
     """Tier 2: (d): a failed POST leaves the task un-notified → retried next sweep
     (§24 forward-progress with retry)."""
     backend = InMemoryTaskBackend()
-    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _aborted(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
     reg = A2AWebhookRegistry()
     reg.register_webhook("ctx-a", "https://client.example/hook")
 
@@ -107,7 +107,7 @@ async def test_sweep_skips_context_without_registered_webhook():
     """Tier 2: an external task whose context has no webhook (e.g. pre-5b) is
     skipped (no channel) — no crash, no notify."""
     backend = InMemoryTaskBackend()
-    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _aborted(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
     reg = A2AWebhookRegistry()  # no webhook registered
     poster = _RecordingPoster()
 
@@ -120,7 +120,7 @@ async def test_reconcile_prunes_hard_deleted_notified():
     """Tier 2: (e): the notified-set self-prunes a task_id no longer present
     (hard-deleted) — bounded by construction."""
     backend = InMemoryTaskBackend()
-    await _archived(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
+    await _aborted(backend, "ext-1", "ctx-a", TaskOrigin.EXTERNAL)
     reg = A2AWebhookRegistry()
     reg.register_webhook("ctx-a", "https://client.example/hook")
     reg.mark_notified("gone-task")  # a task no longer in the backend

--- a/tests/test_a2a_disposition_sweep_1953.py
+++ b/tests/test_a2a_disposition_sweep_1953.py
@@ -42,7 +42,7 @@ class _RecordingPoster:
 async def _archived(backend, task_id, ctx, origin):
     """Seed an archived task assigned to the context's session."""
     await backend.create(Task(task_id=task_id, name="n", assignee=a2a_session_id(ctx),
-                              requester="ext", origin=origin, status=TaskState.ARCHIVED))
+                              requester="ext", origin=origin, status=TaskState.ABORTED))
 
 
 @pytest.mark.asyncio

--- a/tests/test_a2a_list_tasks_1811.py
+++ b/tests/test_a2a_list_tasks_1811.py
@@ -26,7 +26,7 @@ _SEED_COUNTER = [0]
 
 
 async def _seed(backend: InMemoryTaskBackend, session_id: str, n: int, *,
-                status: TaskState = TaskState.IN_PROGRESS):
+                status: TaskState = TaskState.RUNNING):
     """Create ``n`` Tasks assigned to ``session_id`` (the contextId's session),
     with globally-unique task_ids + deterministic strictly-increasing created_at
     so the keyset order is fully known across multiple seed calls."""
@@ -104,10 +104,10 @@ async def test_tasks_list_filters_by_status():
     """Tier 2: status narrows the set (matched against the Task-state vocab)."""
     backend = InMemoryTaskBackend()
     sid = a2a_session_id("ctx-st")
-    done = {t.task_id for t in await _seed(backend, sid, 2, status=TaskState.COMPLETED)}
-    await _seed(backend, sid, 3, status=TaskState.IN_PROGRESS)
+    done = {t.task_id for t in await _seed(backend, sid, 2, status=TaskState.DONE)}
+    await _seed(backend, sid, 3, status=TaskState.RUNNING)
 
-    result = await _list(backend, "alice", contextId="ctx-st", status="completed")
+    result = await _list(backend, "alice", contextId="ctx-st", status="done")
     returned = {t["id"] for t in result["tasks"]}
 
     assert returned == done

--- a/tests/test_a2a_runentry_task_migration_1981.py
+++ b/tests/test_a2a_runentry_task_migration_1981.py
@@ -9,7 +9,7 @@ that still read/wrote RunEntry directly:
     an A2A Cancel (which archives the Task without touching `RunEntry.status`)
     closes the stream (it would otherwise hang forever).
   - **P3 reflect** — an ask_user dispatch reflects the Task → `blocked`, and an
-    answer reflects it → `in_progress`, keeping GetTask coherent with the
+    answer reflects it → `running`, keeping GetTask coherent with the
     RunEntry input-required mirror. The iv resolution itself stays Session-owned
     (#292 α).
 
@@ -90,7 +90,7 @@ def _sse_client(run_registry, task_backend):
 
 
 def test_sse_closes_when_task_is_terminal_even_if_runentry_running():
-    """Tier 2: #1981 P1 — an archived Task (A2A Cancel) closes the SSE stream even
+    """Tier 2: #1981 P1 — an aborted Task (A2A Cancel) closes the SSE stream even
     though `RunEntry.status` is still "running" (Cancel never touches it). Reading
     the RunEntry alone (pre-#1981) would loop forever; the test completing proves
     the Task authority is consulted."""
@@ -163,14 +163,14 @@ async def test_iv_dispatch_without_task_backend_is_noop():
     assert rr.get(entry.run_id).status == "input-required"
 
 
-# ── P3: answer reflects Task → in_progress (mechanism) ──────────────────────
+# ── P3: answer reflects Task → running (mechanism) ──────────────────────
 
 
 @pytest.mark.asyncio
-async def test_reflect_blocked_task_to_in_progress():
+async def test_reflect_blocked_task_to_running():
     """Tier 2: #1981 P3 — the reflection helper moves a blocked Task →
-    in_progress on answer (the assignee's own status write). RED if the blocked→
-    in_progress reflection is dropped (GetTask would stay input-required)."""
+    running on answer (the assignee's own status write). RED if the blocked→
+    running reflection is dropped (GetTask would stay input-required)."""
     tb = InMemoryTaskBackend()
     await tb.create(_a2a_task("t-ans", "ctx-ans", status=TaskState.BLOCKED))
 
@@ -181,11 +181,11 @@ async def test_reflect_blocked_task_to_in_progress():
 
 @pytest.mark.asyncio
 async def test_reflect_status_on_terminal_task_is_swallowed():
-    """Tier 2: reflecting onto an already-archived (cancelled) Task is rejected by
+    """Tier 2: reflecting onto an already-aborted (cancelled) Task is rejected by
     the terminal-guard and swallowed — the abort wins (race-safe)."""
     tb = InMemoryTaskBackend()
     await tb.create(_a2a_task("t-term", "ctx-t", status=TaskState.RUNNING))
-    await tb.abort("t-term")  # A2A Cancel archived it first
+    await tb.abort("t-term")  # A2A Cancel aborted it first
 
     # Must not raise even though the Task is terminal.
     await a2a_mod._reflect_task_status(tb, "t-term", "blocked")

--- a/tests/test_a2a_runentry_task_migration_1981.py
+++ b/tests/test_a2a_runentry_task_migration_1981.py
@@ -38,7 +38,7 @@ from reyn.task import InMemoryTaskBackend, Task, TaskOrigin, TaskState  # noqa: 
 from reyn.user_intervention import UserIntervention  # noqa: E402
 
 
-def _a2a_task(task_id, ctx, status=TaskState.IN_PROGRESS):
+def _a2a_task(task_id, ctx, status=TaskState.RUNNING):
     return Task(task_id=task_id, name="n", assignee=a2a_session_id(ctx),
                 requester="external", origin=TaskOrigin.EXTERNAL, status=status)
 
@@ -105,7 +105,7 @@ def test_sse_closes_when_task_is_terminal_even_if_runentry_running():
     backend = InMemoryTaskBackend()
     loop = asyncio.new_event_loop()
     loop.run_until_complete(
-        backend.create(_a2a_task(entry.run_id, "ctx-sse", status=TaskState.ARCHIVED)))
+        backend.create(_a2a_task(entry.run_id, "ctx-sse", status=TaskState.ABORTED)))
 
     client = _sse_client(registry, backend)
     try:
@@ -174,9 +174,9 @@ async def test_reflect_blocked_task_to_in_progress():
     tb = InMemoryTaskBackend()
     await tb.create(_a2a_task("t-ans", "ctx-ans", status=TaskState.BLOCKED))
 
-    await a2a_mod._reflect_task_status(tb, "t-ans", "in_progress")
+    await a2a_mod._reflect_task_status(tb, "t-ans", "running")
 
-    assert (await tb.get("t-ans")).status is TaskState.IN_PROGRESS
+    assert (await tb.get("t-ans")).status is TaskState.RUNNING
 
 
 @pytest.mark.asyncio
@@ -184,9 +184,9 @@ async def test_reflect_status_on_terminal_task_is_swallowed():
     """Tier 2: reflecting onto an already-archived (cancelled) Task is rejected by
     the terminal-guard and swallowed — the abort wins (race-safe)."""
     tb = InMemoryTaskBackend()
-    await tb.create(_a2a_task("t-term", "ctx-t", status=TaskState.IN_PROGRESS))
+    await tb.create(_a2a_task("t-term", "ctx-t", status=TaskState.RUNNING))
     await tb.abort("t-term")  # A2A Cancel archived it first
 
     # Must not raise even though the Task is terminal.
     await a2a_mod._reflect_task_status(tb, "t-term", "blocked")
-    assert (await tb.get("t-term")).status is TaskState.ARCHIVED
+    assert (await tb.get("t-term")).status is TaskState.ABORTED

--- a/tests/test_a2a_task_reflection_1953.py
+++ b/tests/test_a2a_task_reflection_1953.py
@@ -27,7 +27,7 @@ from reyn.task import InMemoryTaskBackend, Task, TaskOrigin, TaskState
 def _a2a_task(backend, task_id, sid):
     return backend.create(
         Task(task_id=task_id, name="n", assignee=sid, requester="external",
-             origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS)
+             origin=TaskOrigin.EXTERNAL, status=TaskState.RUNNING)
     )
 
 
@@ -39,10 +39,10 @@ async def test_completed_run_reflects_onto_task():
     sid = a2a_session_id("ctx-r")
     await _a2a_task(backend, "t-1", sid)
 
-    await _reflect_task_status(backend, "t-1", "completed")
+    await _reflect_task_status(backend, "t-1", "done")
 
     refreshed = await backend.get("t-1")
-    assert refreshed is not None and refreshed.status is TaskState.COMPLETED
+    assert refreshed is not None and refreshed.status is TaskState.DONE
 
 
 @pytest.mark.asyncio
@@ -55,10 +55,10 @@ async def test_reflection_after_abort_is_swallowed_and_abort_wins():
     await _a2a_task(backend, "t-1", sid)
 
     aborted = await backend.abort("t-1")  # requester cancels first → archived
-    assert aborted and aborted[0].status is TaskState.ARCHIVED
+    assert aborted and aborted[0].status is TaskState.ABORTED
 
     # Must NOT raise even though the Task is terminal (best-effort reflection).
-    await _reflect_task_status(backend, "t-1", "completed")
+    await _reflect_task_status(backend, "t-1", "done")
 
     refreshed = await backend.get("t-1")
-    assert refreshed is not None and refreshed.status is TaskState.ARCHIVED
+    assert refreshed is not None and refreshed.status is TaskState.ABORTED

--- a/tests/test_a2a_task_view_1953.py
+++ b/tests/test_a2a_task_view_1953.py
@@ -35,12 +35,12 @@ def test_map_targets_are_legal_a2a_states():
 
 def test_key_state_mappings():
     """Tier 2: the load-bearing mappings (Task vocab → A2A), incl. the interim
-    blocked→input-required (slice 7 splits it) and abort=delete archived→canceled."""
-    assert task_state_to_a2a("in_progress") == "working"
-    assert task_state_to_a2a("completed") == "completed"
+    blocked→input-required (slice 7 splits it) and abort→canceled (#2187: soft-delete
+    is the orthogonal archived_at marker, not a state)."""
+    assert task_state_to_a2a("running") == "working"
+    assert task_state_to_a2a("done") == "completed"
     assert task_state_to_a2a("failed") == "failed"
     assert task_state_to_a2a("aborted") == "canceled"
-    assert task_state_to_a2a("archived") == "canceled"
     assert task_state_to_a2a("blocked") == "input-required"  # interim (slice 7)
     # unknown → safe non-terminal default.
     assert task_state_to_a2a("some-future-state") == "working"
@@ -50,7 +50,7 @@ def test_to_a2a_task_envelope_shape():
     """Tier 2: the envelope = {kind:task, id, status:{state,timestamp}, contextId}
     with contextId recovered from the assignee's session_id (A2A reverse map)."""
     task = Task(task_id="t-1", name="n", assignee="a2a:ctx-7", requester="r",
-                origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS)
+                origin=TaskOrigin.EXTERNAL, status=TaskState.RUNNING)
     env = to_a2a_task(task)
     assert env["kind"] == "task"
     assert env["id"] == "t-1"

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -95,7 +95,7 @@ def test_get_task_returns_a2a_envelope_from_task_backend() -> None:
         body = r.json()
         assert body["kind"] == "task"
         assert body["id"] == "t-1"
-        assert body["status"]["state"] == "working"  # in_progress → working
+        assert body["status"]["state"] == "working"  # running → working
         assert body["contextId"] == "ctx-7"
         assert "run_id" not in body
     finally:
@@ -126,8 +126,8 @@ def test_get_task_returns_404_for_unknown_run() -> None:
 
 def test_cancel_task_aborts_task_in_backend() -> None:
     """Tier 2: (#1953 slice 5a) POST /a2a/tasks/{task_id}/cancel = the external
-    requester's remove-op → task.abort (cooperative-terminal → archived). The
-    response is the archived Task's A2A envelope (status=canceled)."""
+    requester's remove-op → task.abort (cooperative-terminal → aborted). The
+    response is the aborted Task's A2A envelope (status=canceled)."""
     import asyncio
 
     from reyn.task import InMemoryTaskBackend, Task, TaskState
@@ -144,9 +144,9 @@ def test_cancel_task_aborts_task_in_backend() -> None:
         body = r.json()
         assert body["kind"] == "task"
         assert body["id"] == "t-1"
-        assert body["status"]["state"] == "canceled"  # archived → canceled
+        assert body["status"]["state"] == "canceled"  # aborted → canceled
 
-        # backend task is archived (the abort terminal).
+        # backend task is aborted (the abort terminal).
         refreshed = loop.run_until_complete(backend.get("t-1"))
         assert refreshed is not None and refreshed.status is TaskState.ABORTED
     finally:

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -87,7 +87,7 @@ def test_get_task_returns_a2a_envelope_from_task_backend() -> None:
     backend = InMemoryTaskBackend()
     asyncio.new_event_loop().run_until_complete(
         backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-7",
-                            requester="r", status=TaskState.IN_PROGRESS)))
+                            requester="r", status=TaskState.RUNNING)))
     client = _make_client_with_registry(RunRegistry(), task_backend=backend)
     try:
         r = client.get("/a2a/tasks/t-1")
@@ -136,7 +136,7 @@ def test_cancel_task_aborts_task_in_backend() -> None:
     loop = asyncio.new_event_loop()
     loop.run_until_complete(
         backend.create(Task(task_id="t-1", name="n", assignee="a2a:ctx-1",
-                            requester="r", status=TaskState.IN_PROGRESS)))
+                            requester="r", status=TaskState.RUNNING)))
     client = _make_client_with_registry(RunRegistry(), task_backend=backend)
     try:
         r = client.post("/a2a/tasks/t-1/cancel")
@@ -148,7 +148,7 @@ def test_cancel_task_aborts_task_in_backend() -> None:
 
         # backend task is archived (the abort terminal).
         refreshed = loop.run_until_complete(backend.get("t-1"))
-        assert refreshed is not None and refreshed.status is TaskState.ARCHIVED
+        assert refreshed is not None and refreshed.status is TaskState.ABORTED
     finally:
         _restore_overrides()
 

--- a/tests/test_hook_skill_task_points_1800_5c.py
+++ b/tests/test_hook_skill_task_points_1800_5c.py
@@ -96,7 +96,7 @@ async def test_task_create_fires_task_start():
 
 @pytest.mark.asyncio
 async def test_task_update_status_completed_fires_task_end():
-    """Tier 2: a real _update_status → COMPLETED fires task_end (status completed)."""
+    """Tier 2: a real _update_status → DONE fires task_end (status done)."""
     rec = _RecordingDispatcher()
     backend = InMemoryTaskBackend()
     ctx = _task_ctx(backend, rec)
@@ -108,10 +108,10 @@ async def test_task_update_status_completed_fires_task_end():
     tid = created["task"]["task_id"]
 
     await taskmod._update_status(
-        SimpleNamespace(task_id=tid, status="completed"), ctx, "control_ir")
+        SimpleNamespace(task_id=tid, status="done"), ctx, "control_ir")
 
     end = [(p, v) for (p, v) in rec.dispatched if p == "task_end"]
-    assert end and end[-1][1]["status"] == "completed"
+    assert end and end[-1][1]["status"] == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_backend_threading_1953.py
+++ b/tests/test_task_backend_threading_1953.py
@@ -124,7 +124,7 @@ async def test_cas_reject_end_to_end_through_op_layer(tmp_path: Path):
 
     # the assignee session writes.
     ok = await taskmod._update_status(
-        SimpleNamespace(task_id=task_id, status="in_progress", reason=None), ctx_a, "control_ir")
+        SimpleNamespace(task_id=task_id, status="running", reason=None), ctx_a, "control_ir")
     assert ok["status"] == "ok"
 
     # a non-assignee session is rejected by the CAS — now the op-layer returns a

--- a/tests/test_task_dag_slice6_1953.py
+++ b/tests/test_task_dag_slice6_1953.py
@@ -35,7 +35,7 @@ from reyn.task import (
 from reyn.task.backend import find_cycle_path
 
 
-def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess", requester="req"):
+def _task(task_id, *, deps=None, status=TaskState.READY, assignee="sess", requester="req"):
     return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
                 status=status, deps=list(deps or []))
 
@@ -123,7 +123,7 @@ async def test_dangling_dep_rejected_on_create(backend):
 async def test_create_with_incomplete_deps_is_born_blocked(backend):
     """Tier 2b: a task born with not-all-completed deps is OS-derived blocked."""
     await backend.create(_task("d"))  # pending, not completed
-    await backend.create(_task("a", deps=["d"], status=TaskState.PENDING))
+    await backend.create(_task("a", deps=["d"], status=TaskState.READY))
     assert (await backend.get("a")).status is TaskState.BLOCKED
 
 
@@ -131,8 +131,8 @@ async def test_create_with_incomplete_deps_is_born_blocked(backend):
 async def test_create_without_deps_keeps_requested_status(backend):
     """Tier 2b: a deps-less create keeps its requested status (the A2A path is
     unaffected — OQ-2: birth-derivation only fires when deps are present)."""
-    await backend.create(_task("a", status=TaskState.IN_PROGRESS))
-    assert (await backend.get("a")).status is TaskState.IN_PROGRESS
+    await backend.create(_task("a", status=TaskState.RUNNING))
+    assert (await backend.get("a")).status is TaskState.RUNNING
 
 
 @pytest.mark.asyncio
@@ -140,9 +140,9 @@ async def test_create_with_already_completed_deps_not_blocked(backend):
     """Tier 2b: if every born-with dep is already completed, the task is not
     born-blocked (nothing to wait for)."""
     await backend.create(_task("d", assignee="sd"))
-    await backend.update_status("d", "completed", caller_session_id="sd")
-    await backend.create(_task("a", deps=["d"], status=TaskState.PENDING))
-    assert (await backend.get("a")).status is TaskState.PENDING
+    await backend.update_status("d", "done", caller_session_id="sd")
+    await backend.create(_task("a", deps=["d"], status=TaskState.READY))
+    assert (await backend.get("a")).status is TaskState.READY
 
 
 # ── completion-driven readiness (OQ-3) ──────────────────────────────────────
@@ -155,7 +155,7 @@ async def test_completed_predecessor_promotes_satisfied_dependent(backend):
     await backend.create(_task("d", assignee="sd"))
     await backend.create(_task("a", deps=["d"]))
     assert (await backend.get("a")).status is TaskState.BLOCKED
-    await backend.update_status("d", "completed", caller_session_id="sd")
+    await backend.update_status("d", "done", caller_session_id="sd")
     promoted = await backend.recompute_readiness("d")
     assert [t.task_id for t in promoted] == ["a"]
     assert (await backend.get("a")).status is TaskState.READY
@@ -167,7 +167,7 @@ async def test_partially_satisfied_dependent_stays_blocked(backend):
     await backend.create(_task("d1", assignee="s1"))
     await backend.create(_task("d2", assignee="s2"))
     await backend.create(_task("a", deps=["d1", "d2"]))
-    await backend.update_status("d1", "completed", caller_session_id="s1")
+    await backend.update_status("d1", "done", caller_session_id="s1")
     promoted = await backend.recompute_readiness("d1")
     assert promoted == []
     assert (await backend.get("a")).status is TaskState.BLOCKED
@@ -180,7 +180,7 @@ async def test_recompute_is_os_authority_no_assignee_session(backend):
     session, yet the OS promotes it with no session context."""
     await backend.create(_task("d", assignee="sd"))
     await backend.create(_task("a", deps=["d"], assignee="sa"))
-    await backend.update_status("d", "completed", caller_session_id="sd")
+    await backend.update_status("d", "done", caller_session_id="sd")
     promoted = await backend.recompute_readiness("d")  # no caller identity at all
     assert [t.task_id for t in promoted] == ["a"]
 
@@ -193,7 +193,7 @@ async def test_readiness_and_edges_persist_across_sqlite_reload(tmp_path):
     b = SqliteTaskBackend(path)
     await b.create(_task("d", assignee="sd"))
     await b.create(_task("a", deps=["d"]))
-    await b.update_status("d", "completed", caller_session_id="sd")
+    await b.update_status("d", "done", caller_session_id="sd")
     await b.recompute_readiness("d")
     b.close()
 
@@ -282,7 +282,7 @@ async def test_op_update_status_completion_drives_readiness_and_emits_p6():
     await b.create(_task("a", deps=["d"], assignee="sa"))
     # Complete d (ctx.session_id must equal d's assignee for the CAS).
     res = await taskmod._update_status(
-        SimpleNamespace(task_id="d", status="completed"),
+        SimpleNamespace(task_id="d", status="done"),
         _opctx(b, events=rec, session_id="sd"), "control_ir")
     assert res["status"] == "ok"
     # a was promoted → exactly one task_readiness event for a (behavioral, not a
@@ -301,7 +301,7 @@ async def test_op_update_status_non_completion_does_not_recompute():
     await b.create(_task("d", assignee="sd"))
     await b.create(_task("a", deps=["d"], assignee="sa"))
     await taskmod._update_status(
-        SimpleNamespace(task_id="d", status="in_progress"),
+        SimpleNamespace(task_id="d", status="running"),
         _opctx(b, events=rec, session_id="sd"), "control_ir")
     assert [k for k, _ in rec.events if k == "task_readiness"] == []
     assert (await b.get("a")).status is TaskState.BLOCKED

--- a/tests/test_task_ops_gate_equivalence_1953.py
+++ b/tests/test_task_ops_gate_equivalence_1953.py
@@ -106,7 +106,7 @@ async def test_assignee_update_status_via_invoke_action_allowed():
     backend = InMemoryTaskBackend()
     task_id = await _task_assigned_to(backend, "sess-B")
     ctx = _router_ctx(_op_ctx("sess-B", backend))  # caller == assignee
-    result = await _UPDATE({"task_id": task_id, "status": "in_progress"}, ctx)
+    result = await _UPDATE({"task_id": task_id, "status": "running"}, ctx)
     assert result.get("status") == "ok", result
 
 
@@ -120,7 +120,7 @@ async def test_none_session_id_masks_and_rejects_even_the_assignee():
     backend = InMemoryTaskBackend()
     task_id = await _task_assigned_to(backend, "sess-B")
     ctx = _router_ctx(_op_ctx(None, backend))  # the mask: session_id is None
-    result = await _UPDATE({"task_id": task_id, "status": "in_progress"}, ctx)
+    result = await _UPDATE({"task_id": task_id, "status": "running"}, ctx)
     assert result.get("status") == "denied", result
 
 
@@ -167,7 +167,7 @@ async def test_router_opctx_threads_task_waker_so_chat_abort_wakes_requester():
     backend = InMemoryTaskBackend()
     # a self-task plan whose requester is the chat session ("main", _DEFAULT_SID).
     await backend.create(Task(task_id="t2", name="t2", assignee="main", requester="main",
-                              status=TaskState.IN_PROGRESS, deps=[]))
+                              status=TaskState.RUNNING, deps=[]))
     await backend.create(Task(task_id="t3", name="t3", assignee="main", requester="main",
                               deps=["t2"]))
 

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -69,7 +69,7 @@ def test_union_validates_every_task_kind():
     adapter = TypeAdapter(ControlIROp)
     samples = {
         "task.create": {"kind": "task.create", "name": "n"},
-        "task.update_status": {"kind": "task.update_status", "task_id": "t", "status": "in_progress"},
+        "task.update_status": {"kind": "task.update_status", "task_id": "t", "status": "running"},
         "task.get": {"kind": "task.get", "task_id": "t"},
         "task.list": {"kind": "task.list"},
         "task.add_dependency": {"kind": "task.add_dependency", "task_id": "t", "depends_on": "u"},
@@ -150,12 +150,12 @@ async def test_update_status_single_writer_is_assignee_session():
 
     # the assignee session (session_id == assignee) may write.
     updated = await taskmod._update_status(
-        SimpleNamespace(task_id=task_id, status="in_progress", reason=None),
+        SimpleNamespace(task_id=task_id, status="running", reason=None),
         SimpleNamespace(session_id="sess-A", agent_id="a", events=None, task_backend=backend),
         "control_ir",
     )
     assert updated["status"] == "ok"
-    assert updated["task"]["status"] == "in_progress"
+    assert updated["task"]["status"] == "running"
 
     # RED if the single-writer CAS is dropped: a non-assignee session is rejected — now
     # the op-layer returns a "denied" result (the gate moved from a backend raise to the
@@ -214,12 +214,12 @@ async def test_abort_archives_and_rejects_assignee_straggler():
     aborted = await taskmod._abort(
         SimpleNamespace(task_id=task_id, reason="don't need it"),
         SimpleNamespace(session_id="R", agent_id="r", events=None), "control_ir")
-    assert aborted["task"]["status"] == "archived"
+    assert aborted["task"]["status"] == "aborted"
 
     # the assignee's straggler write is rejected by the terminal state.
     with pytest.raises(PermissionError):
         await taskmod._update_status(
-            SimpleNamespace(task_id=task_id, status="completed", reason=None),
+            SimpleNamespace(task_id=task_id, status="done", reason=None),
             SimpleNamespace(session_id="A", agent_id="a", events=None), "control_ir")
 
 

--- a/tests/test_task_slice6ext_1953.py
+++ b/tests/test_task_slice6ext_1953.py
@@ -31,7 +31,7 @@ from reyn.task import (
 )
 
 
-def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
+def _task(task_id, *, deps=None, status=TaskState.READY, assignee="sess",
           requester="req", origin=None):
     kw = {} if origin is None else {"origin": origin}
     return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
@@ -49,7 +49,7 @@ def backend(request, tmp_path):
 
 
 async def _complete(backend, task_id, assignee):
-    await backend.update_status(task_id, "completed", caller_session_id=assignee)
+    await backend.update_status(task_id, "done", caller_session_id=assignee)
 
 
 # ── remove_dependency ───────────────────────────────────────────────────────
@@ -84,9 +84,9 @@ async def test_remove_last_dep_readies_i1(backend):
 @pytest.mark.asyncio
 async def test_remove_is_idempotent_on_missing_edge(backend):
     """Tier 2: removing an absent edge is a no-op (no raise, no status flip)."""
-    await backend.create(_task("a", status=TaskState.IN_PROGRESS))
+    await backend.create(_task("a", status=TaskState.RUNNING))
     task = await backend.remove_dependency("a", "never-there")
-    assert task is not None and task.status is TaskState.IN_PROGRESS
+    assert task is not None and task.status is TaskState.RUNNING
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,7 @@ async def test_repoint_demotes_when_new_edge_unsatisfied(backend):
     await _complete(backend, "x", "sx")
     await backend.create(_task("y", assignee="sy"))         # incomplete
     await backend.create(_task("a", deps=["x"]))            # x completed → PENDING (pre-run, demotable)
-    assert (await backend.get("a")).status is TaskState.PENDING
+    assert (await backend.get("a")).status is TaskState.READY
 
     await backend.repoint_dependency("a", "x", "y")         # now depends on incomplete y
     assert (await backend.get("a")).status is TaskState.BLOCKED
@@ -164,13 +164,13 @@ async def test_derive_readiness_leaves_in_progress_untouched(backend):
     await _complete(backend, "x", "sx")
     await backend.create(_task("y", assignee="sy"))         # incomplete
     await backend.create(_task("a", deps=["x"], assignee="sa"))
-    await backend.update_status("a", "in_progress", caller_session_id="sa")
-    assert (await backend.get("a")).status is TaskState.IN_PROGRESS
+    await backend.update_status("a", "running", caller_session_id="sa")
+    assert (await backend.get("a")).status is TaskState.RUNNING
 
     await backend.repoint_dependency("a", "x", "y")         # new incomplete dep
     # untouched: the assignee owns the run, OS does not yank it back to blocked.
     a = await backend.get("a")
-    assert a.status is TaskState.IN_PROGRESS and a.deps == ["y"]
+    assert a.status is TaskState.RUNNING and a.deps == ["y"]
 
 
 @pytest.mark.asyncio
@@ -191,7 +191,7 @@ async def test_repoint_persists_across_sqlite_reload(tmp_path):
     b = SqliteTaskBackend(path)
     await b.create(_task("x", assignee="sx"))
     await b.create(Task(task_id="y", name="y", assignee="sy", requester="r",
-                        status=TaskState.COMPLETED))
+                        status=TaskState.DONE))
     await b.create(_task("a", deps=["x"]))                  # born-blocked
     await b.repoint_dependency("a", "x", "y")               # → ready (y completed)
     b.close()
@@ -287,7 +287,7 @@ async def test_op_abort_routes_disposition_to_requester():
     b = InMemoryTaskBackend()
     rec = _Rec()
     waker = _RecordingWaker()
-    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))
 
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
@@ -307,7 +307,7 @@ async def test_op_failed_routes_disposition_to_requester():
     task's REQUESTER."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
-    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))
 
     # failed is assignee-gated → caller must be B's assignee.
@@ -326,7 +326,7 @@ async def test_op_abort_root_routes_to_requester():
     dependents. Now the requester (always present) is woken to recover."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
-    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.IN_PROGRESS))
+    await b.create(_task("B", assignee="sB", requester="req", status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="sA", requester="req"))  # root, no parent
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
                          _opctx(b, waker=waker, session_id="req"), "control_ir")
@@ -344,9 +344,9 @@ async def test_2107_flat_self_task_plan_mid_failure_notifies_requester():
     (restore `if not parent_id: return`) → no requester notify → RED."""
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
-    await b.create(_task("t1", assignee="me", requester="me", status=TaskState.COMPLETED))
+    await b.create(_task("t1", assignee="me", requester="me", status=TaskState.DONE))
     await b.create(_task("t2", deps=["t1"], assignee="me", requester="me",
-                         status=TaskState.IN_PROGRESS))
+                         status=TaskState.RUNNING))
     await b.create(_task("t3", deps=["t2"], assignee="me", requester="me"))
     await b.create(_task("t4", deps=["t3"], assignee="me", requester="me"))
     await taskmod._abort(SimpleNamespace(task_id="t2", reason=None),
@@ -367,7 +367,7 @@ async def test_external_origin_skips_internal_requester_wake():
     b = InMemoryTaskBackend()
     waker = _RecordingWaker()
     await b.create(_task("B", assignee="sB", requester="a2a:client",
-                         origin=TaskOrigin.EXTERNAL, status=TaskState.IN_PROGRESS))
+                         origin=TaskOrigin.EXTERNAL, status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="sA", requester="a2a:client",
                          origin=TaskOrigin.EXTERNAL))
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),

--- a/tests/test_task_sqlite_backend_1953.py
+++ b/tests/test_task_sqlite_backend_1953.py
@@ -92,10 +92,10 @@ async def test_update_status_single_writer_is_assignee_session(tmp_path):
     await backend.create(Task(task_id="t", name="n", assignee="sess-A", requester="r"))
 
     # The assignee session writes freely (any number of turns — no claim/version).
-    s1 = await backend.update_status("t", "in_progress", caller_session_id="sess-A")
-    assert s1 is not None and s1.status is TaskState.IN_PROGRESS
-    s2 = await backend.update_status("t", "completed", caller_session_id="sess-A")
-    assert s2 is not None and s2.status is TaskState.COMPLETED
+    s1 = await backend.update_status("t", "running", caller_session_id="sess-A")
+    assert s1 is not None and s1.status is TaskState.RUNNING
+    s2 = await backend.update_status("t", "done", caller_session_id="sess-A")
+    assert s2 is not None and s2.status is TaskState.DONE
 
     # A non-assignee session is rejected — single-writer CAS holds.
     with pytest.raises(PermissionError):
@@ -103,7 +103,7 @@ async def test_update_status_single_writer_is_assignee_session(tmp_path):
 
     # State is unchanged by the rejected write.
     after = await backend.get("t")
-    assert after is not None and after.status is TaskState.COMPLETED
+    assert after is not None and after.status is TaskState.DONE
     backend.close()
 
 
@@ -111,7 +111,7 @@ async def test_update_status_single_writer_is_assignee_session(tmp_path):
 async def test_update_status_unknown_task_returns_none(tmp_path):
     """Tier 2: update on a missing task returns None (not a CAS reject)."""
     backend = SqliteTaskBackend(_db(tmp_path))
-    assert await backend.update_status("nope", "in_progress", caller_session_id="x") is None
+    assert await backend.update_status("nope", "running", caller_session_id="x") is None
     backend.close()
 
 
@@ -131,7 +131,7 @@ async def test_awaiting_and_abort_persist_and_emit_events(tmp_path):
     got = await reopened.get("t")
     assert got is not None
     assert got.awaiting_since == 999.0
-    assert got.status is TaskState.ARCHIVED  # abort = delete → archived
+    assert got.status is TaskState.ABORTED  # abort = delete → archived
 
     kinds = [e["kind"] for e in await reopened.events("t")]
     assert kinds == ["created", "awaiting_set", "aborted"]
@@ -162,10 +162,10 @@ async def test_abort_down_cascade_and_sibling_intact(tmp_path):
     # whole sub-tree archived (recursive, leaf-terminal).
     for tid in ("p", "c1", "c2"):
         t = await backend.get(tid)
-        assert t is not None and t.status is TaskState.ARCHIVED, tid
+        assert t is not None and t.status is TaskState.ABORTED, tid
     # RED if abort whole-session-cancelled: the sibling task A also owns is intact.
     sib = await backend.get("sib")
-    assert sib is not None and sib.status is TaskState.PENDING
+    assert sib is not None and sib.status is TaskState.READY
     backend.close()
 
 

--- a/tests/test_task_waker_slice7_1953.py
+++ b/tests/test_task_waker_slice7_1953.py
@@ -24,7 +24,7 @@ from reyn.runtime.services.task_wake import TaskWaker
 from reyn.task import InMemoryTaskBackend, Task, TaskState
 
 
-def _task(task_id, *, deps=None, status=TaskState.PENDING, assignee="sess",
+def _task(task_id, *, deps=None, status=TaskState.READY, assignee="sess",
           requester="req"):
     return Task(task_id=task_id, name=task_id, assignee=assignee, requester=requester,
                 status=status, deps=list(deps or []))
@@ -121,7 +121,7 @@ async def test_completed_wakes_promoted_dependent():
     reg = _RecRegistry()
     await b.create(_task("d", assignee="a2a:sd"))
     await b.create(_task("a", deps=["d"], assignee="a2a:sa"))  # born-blocked
-    await taskmod._update_status(SimpleNamespace(task_id="d", status="completed"),
+    await taskmod._update_status(SimpleNamespace(task_id="d", status="done"),
                                  _ctx(b, TaskWaker(reg, "alice"), session_id="a2a:sd"),
                                  "control_ir")
     assert ("alice", "a2a", "sa") in reg.resolved
@@ -134,7 +134,7 @@ async def test_abort_wakes_requester():
     b = InMemoryTaskBackend()
     reg = _RecRegistry()
     await b.create(_task("B", assignee="a2a:sB", requester="a2a:sReq",
-                         status=TaskState.IN_PROGRESS))
+                         status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="a2a:sA", requester="a2a:sReq"))
     # abort is requester-gated → the requester is the caller.
     await taskmod._abort(SimpleNamespace(task_id="B", reason=None),
@@ -155,10 +155,10 @@ async def test_recovery_loop_abort_then_requester_repoint_wakes_both():
     reg = _RecRegistry()
     waker = TaskWaker(reg, "alice")
     await b.create(_task("B", assignee="a2a:sB", requester="a2a:sReq",
-                         status=TaskState.IN_PROGRESS))
+                         status=TaskState.RUNNING))
     await b.create(_task("A", deps=["B"], assignee="a2a:sA", requester="a2a:sReq"))  # blocked on B
     await b.create(_task("Bsub", assignee="a2a:sBsub", requester="a2a:sReq",
-                         status=TaskState.COMPLETED))
+                         status=TaskState.DONE))
     ctx = _ctx(b, waker, session_id="a2a:sReq")  # the requester owns + drives B/A/Bsub
 
     # 1. abort B → the REQUESTER is woken to decide.

--- a/tests/test_task_wakes_execution_fence_1953.py
+++ b/tests/test_task_wakes_execution_fence_1953.py
@@ -201,5 +201,5 @@ async def test_dep_completion_wakes_dependent_with_full_fenced_description():
     reg.session.inbox.clear()  # ignore create-time activity; assert on the wake below
     # the dep's assignee (req-sess) completes it → drives readiness → wakes dependent.
     await taskmod._update_status(
-        SimpleNamespace(task_id=dep_id, status="completed"), ctx, "control_ir")
+        SimpleNamespace(task_id=dep_id, status="done"), ctx, "control_ir")
     _assert_executes_and_fences(_last_wake_text(reg))


### PR DESCRIPTION
**[e2e-coder]** — #2187 backend-master Stage 5a: the 7-state lifecycle migration + the ARCHIVED→retention separation (off main, post Stage 4 merge #2191). First of the 4 sub-stages (5a migration → 5b children_of+link-type+counts → 5c completion-join+waker reconciler → 5d full reconciliation), per lead's accepted design (#2187).

## The migration (8 → 7 states)

`TaskState` is now the #2187 §3.4 base set — **UNASSIGNED · BLOCKED · READY · RUNNING · DONE · FAILED · ABORTED** — replacing the old 8:

- **PENDING ≡ READY merged** (lead finding A: behaviourally identical, only provenance differed) → `PENDING` gone, all become `READY`.
- **IN_PROGRESS → RUNNING**, **COMPLETED → DONE** (rename, clean end-state values).
- **ARCHIVED → ABORTED + retention** (lead finding B: `ABORTED` was a dead enum, `abort()` actually set `ARCHIVED`; the single ARCHIVED state did double-duty = lifecycle-terminal + soft-delete).
- **UNASSIGNED** added (forward-looking, wired in the deferred dogfood ② pending-queue).

"Waiting on children" / "deciding" are **not** base states — they are derived from the open-child counts over a `running` task (5b/5c).

## The retention separation (finding B)

Soft-delete is now an **orthogonal dimension** (`Task.archived_at`), not a state:

- `abort()` (in-memory + sqlite) sets **BOTH** the `ABORTED` lifecycle state **and** `archived_at` — preserving the old hidden-from-list UX.
- The **/tasks hidden-filter** now keys on `archived_at` (a task is hidden because it was soft-deleted, not because of its lifecycle state).
- The **A2A webhook sweep** keys on `status="aborted"` (a **lifecycle** signal — abort → A2A canceled notify — per lead's refinement, *not* the retention marker).
- sqlite: `archived_at` column added (schema + `_TASK_COLUMNS` + additive `_migrate_columns` + `_row_to_task` + INSERT).

## P7 / vocabulary hygiene

The string-value rename was carefully scoped to **TaskState** values. The **RunEntry** run-status (`run_registry.update(status="completed"/"running")`), the **skill-run** status, and the **A2A protocol** states (`task_state_to_a2a(...) == "completed"`) are *separate vocabularies* and legitimately keep their words — they were left untouched.

## Out of scope (subsequent sub-stages)

- **children_of(pid)** + the collision-safe filter (finding D) → **5b**.
- **completion-join** decision-enabling error (finding C, the only substantially-new semantics) → **5c**.

## Test plan

- [x] `tests/test_2187_stage5a_lifecycle.py` (NEW): abort sets BOTH `ABORTED` + `archived_at` (in-memory) and the marker is durable across a sqlite close+reopen. **Falsify-verified RED** when the `archived_at` stamp is stripped from `abort()`.
- [x] Migrated the task/a2a/slash/hook test suite to the new vocabulary (separating the RunEntry/skill/A2A-protocol literals that stay).
- [x] Full suite green except the 4 known editable-install env quirks (3 gateway entry-point + `reyn_api_relocate[reyn.safe]`), absent in clean CI: **8485 passed**.
- [x] `ruff check` clean on all 30 changed files + the new test; `test_tier_audit.py --strict` clean (143 OK, 0 Tier-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
