### PR TITLE
feat(#2187): Stage 5c — completion-join gate + child_settled waker reconciler

### DIFF
--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -141,6 +141,29 @@ def _not_found(kind: str, task_id: str) -> dict:
     return {"kind": kind, "status": "error", "error": f"task {task_id!r} not found"}
 
 
+def _open_children_error(task_id: str, counts) -> dict:
+    """Decision-enabling error (#2187 §3.4, 5c completion-join): a task may not reach
+    DONE while it still owns open (non-terminal) children — the whole decomposition
+    tree must complete first. NOT a raised exception: the LLM gets the structured
+    error and decides (wait — it is re-woken by the child_settled reconcile when its
+    children settle — or abort the children), exactly like ``_reject_unknown_assignee``."""
+    return {
+        "kind": "task.update_status",
+        "status": "error",
+        "error": {
+            "kind": "open_children",
+            "message": (
+                f"Cannot complete task {task_id!r}: {counts.awaited} awaited "
+                f"+ {counts.background} background child task(s) are still open. Wait "
+                f"for them to finish (you will be re-woken when they settle), or abort "
+                f"them — then complete."
+            ),
+            "awaited": counts.awaited,
+            "background": counts.background,
+        },
+    }
+
+
 def _edge_error(op_kind: str, err: Exception) -> dict:
     """Decision-enabling error result for a rejected dependency edge (#1953 slice
     6, OQ-5): a structured ``status="error"`` dict (the edge + cycle path), NOT a
@@ -306,6 +329,16 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
         "task.update_status", ctx, _backend(ctx), op.task_id, "assignee")
     if denied is not None:
         return denied
+    # #2187 §3.4 (5c) completion-join: RUNNING → DONE only when the decomposition tree
+    # is complete (no open child of EITHER link type — awaited gates execution, but the
+    # final DONE requires the whole tree terminal). Attempting DONE with open children
+    # returns a DECISION-ENABLING error (the parent waits — it is re-woken by the
+    # child_settled reconcile when its children settle — or aborts them); the LLM is not
+    # stopped. The check is the task's OWN children, before the backend applies DONE.
+    if op.status == TaskState.DONE.value:
+        counts = await _backend(ctx).open_child_counts(op.task_id)
+        if counts.awaited + counts.background > 0:
+            return _open_children_error(op.task_id, counts)
     task = await _backend(ctx).update_status(op.task_id, op.status)
     if task is None:
         return _not_found("task.update_status", op.task_id)
@@ -340,11 +373,19 @@ async def _update_status(op, ctx: OpContext, caller) -> dict:
                 "task_end",
                 {"point": "task_end", "task_id": task.task_id, "status": "done"},
             )
+        # #2187 §3.5 (5c): a DONE *decomposition child* (requester_kind=TASK) reconciles
+        # its PARENT (the child_settled waker — the parent's awaited/total counts may have
+        # crossed 0). A top-level DONE (requester_kind=SESSION) has no decomposition parent
+        # and must NOT route to the requester (DONE is not a recovery trigger — only the
+        # DAG promotion above applies, as before 5c).
+        if task.requester_kind is TaskRequesterKind.TASK:
+            await _settle_terminal(ctx, _backend(ctx), task, disposition="done")
     elif task.status is TaskState.FAILED:
         # slice 6-ext §C: a non-completed terminal (the assignee declared `failed`)
         # doesn't satisfy a dependency edge → route the disposition to the task's
-        # REQUESTER to decide recovery (§16; the OQ-7/H5 gap-close, #2107).
-        await _route_terminal_to_requester(ctx, _backend(ctx), task, disposition="failed")
+        # OWNER to decide recovery (§16; the OQ-7/H5 gap-close, #2107). #2187 5c: the
+        # requester_kind-exclusive routing (TASK→child_settled, SESSION→requester).
+        await _settle_terminal(ctx, _backend(ctx), task, disposition="failed")
     return _ok("task.update_status", task=task.to_dict())
 
 
@@ -402,6 +443,61 @@ async def _emit_readiness_if_changed(ctx: OpContext, task, before_status, trigge
         if waker is not None:
             await waker.publish_task_event(  # #2187 Stage 4: pub/sub seam ("ready")
                 "ready", task, fenced_description=_fence_text(ctx, task.description))
+
+
+async def _settle_terminal(ctx: OpContext, backend, task, *, disposition: str) -> None:
+    """Route a task's terminal transition to its OWNER, EXCLUSIVELY by requester_kind
+    (#2187 §3.5, 5c) — so no owner is double-woken by construction:
+
+    - ``requester_kind=TASK`` (a decomposition child): wake the PARENT's managing
+      session via the ``child_settled`` reconcile-wake. ONE wake subsumes both
+      dependent-recovery (it carries the disposition + the child's stuck dependents)
+      AND completion-driving (the parent's open-child counts). Mutually-exclusive
+      firing (decision 3 — ``total`` subsumes ``awaited``): ``total==0`` → the parent
+      may complete; ``elif awaited==0`` → the parent is unblocked, continue; ``elif``
+      the child failed/aborted → recover its stuck dependents; ``else`` the parent is
+      still blocked on awaited children with no failure → no wake (§3.5: it idles).
+      A phantom parent (binding present, backend row absent) → audit + drop the wake
+      (the 5d reconciliation domain). A ``requester_kind=TASK`` task is always
+      SELF-origin (a sub-task is internal), so there is no EXTERNAL-webhook path here.
+    - ``requester_kind=SESSION`` (a top-level request): the existing requester
+      recovery (``_route_terminal_to_requester`` — unchanged, incl. EXTERNAL)."""
+    if task.requester_kind is not TaskRequesterKind.TASK:
+        await _route_terminal_to_requester(ctx, backend, task, disposition=disposition)
+        return
+    events = getattr(ctx, "events", None)
+    parent = await backend.get(task.requester)
+    if parent is None:
+        # phantom parent — no managing session to wake (the 5d reconciliation domain).
+        if events is not None:
+            events.emit("task_child_settled", task_id=task.task_id,
+                        parent=task.requester, disposition=disposition, reason="phantom")
+        return
+    counts = await backend.open_child_counts(parent.task_id)
+    failed = disposition != TaskState.DONE.value
+    if counts.awaited + counts.background == 0:
+        reason = "final_completion"
+    elif counts.awaited == 0:
+        reason = "continue"
+    elif failed:
+        reason = "recovery"
+    else:
+        reason = None  # still blocked on awaited children, no failure → the parent idles
+    if events is not None:
+        # Generic P6 audit (P7; NOT a WAL closed-vocab kind).
+        events.emit("task_child_settled", task_id=task.task_id, parent=parent.task_id,
+                    disposition=disposition, reason=reason or "idle",
+                    awaited=counts.awaited, background=counts.background)
+    if reason is None:
+        return
+    stuck = [d.task_id for d in await backend.dependents(task.task_id)
+             if d.status not in TERMINAL_STATES]
+    waker = getattr(ctx, "task_waker", None)
+    if waker is not None:
+        await waker.publish_task_event(
+            "child_settled", parent, child_task=task, disposition=disposition,
+            reason=reason, awaited=counts.awaited, background=counts.background,
+            stuck_dependents=stuck)
 
 
 async def _route_terminal_to_requester(
@@ -555,11 +651,12 @@ async def _abort(op, ctx: OpContext, caller) -> dict:
                 requester=t.requester, origin=t.origin.value, root=op.task_id,
             )
     root = aborted[0]
-    # §16 (#2107): route the aborted root to its REQUESTER so a stuck sibling dependent
-    # gets a recovery decision (the OQ-7/H5 gap-close). A root self-task is now notified
+    # §16 (#2107): route the aborted root to its OWNER so a stuck sibling dependent gets
+    # a recovery decision (the OQ-7/H5 gap-close). A root self-task is now notified
     # (previously dropped on the missing parent_id). The cascade's descendants are
-    # themselves terminal → _route_terminal_to_requester finds no stuck dependents for them.
-    await _route_terminal_to_requester(ctx, _backend(ctx), root, disposition="aborted")
+    # themselves terminal → no stuck dependents for them. #2187 5c: requester_kind-
+    # exclusive routing (TASK→child_settled reconcile, SESSION→requester recovery).
+    await _settle_terminal(ctx, _backend(ctx), root, disposition="aborted")
     # #1800 slice 5c: task_end lifecycle hooks for the aborted sub-tree — SYMMETRIC
     # with task_start (at create) + task_end (at COMPLETED): every started task
     # fires an end. ``status="aborted"`` lets an operator discriminate completion

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -44,11 +44,14 @@ WAKE_REQUESTER_KIND = "task_dependency_aborted"
 # #2187 Stage 4: the task STATE-CHANGE event vocabulary the single publish→deliver seam
 # (``TaskWaker.publish_task_event``) routes on. ``ready``/``assigned`` deliver to the
 # ASSIGNEE subscriber (execute); ``terminal`` delivers to the REQUESTER subscriber
-# (decide recovery). This is the existing local set — an external backend may extend it
+# (decide recovery). #2187 Stage 5c: ``child_settled`` delivers to a decomposition
+# PARENT's managing session (its assignee) when a child settles — the §3.5 waker
+# reconciler. This is the existing local set — an external backend may extend it
 # at integration time.
 TASK_EVENT_READY = "ready"
 TASK_EVENT_ASSIGNED = "assigned"
 TASK_EVENT_TERMINAL = "terminal"
+TASK_EVENT_CHILD_SETTLED = "child_settled"
 
 
 class TaskWaker:
@@ -189,6 +192,40 @@ class TaskWaker:
             managing_task_id=managing_task_id,
         )
 
+    async def wake_parent_on_child_settled(
+        self, parent: Any, *, child_task: Any, disposition: str, reason: str,
+        awaited: int, background: int, stuck_dependents: "list[str]",
+    ) -> None:
+        """#2187 §3.5 (5c): a decomposition child of ``parent`` settled — wake the
+        parent's managing session (``parent.assignee``). ONE wake subsumes recovery +
+        completion-driving (the requester_kind-exclusive routing). ``reason``:
+        ``final_completion`` (all children terminal → the parent may complete),
+        ``continue`` (awaited children cleared → the parent is unblocked), ``recovery``
+        (a child failed/aborted → recover its stuck dependents). The parent acts via
+        ordinary task ops (complete / continue / repoint / abort) — P7, no decision
+        vocabulary."""
+        lines = [
+            f"[task] A child of your task {parent.task_id!r} ('{parent.name}') settled: "
+            f"task {child_task.task_id!r} ('{child_task.name}') reached {disposition!r}."
+        ]
+        if stuck_dependents:
+            lines.append(
+                f"These dependents are now stuck: {stuck_dependents} — recover via task "
+                f"ops (repoint to a substitute, remove the edge, fail them, or handle the "
+                f"work yourself)."
+            )
+        lines.append(f"Your open children now: {awaited} awaited + {background} background.")
+        if reason == "final_completion":
+            lines.append("All children are terminal — you may now complete this task.")
+        elif reason == "continue":
+            lines.append("The awaited children have cleared — continue your work.")
+        await self._wake(
+            parent.assignee, WAKE_REQUESTER_KIND, " ".join(lines),
+            task_id=parent.task_id, child_task_id=child_task.task_id,
+            disposition=disposition, reason=reason, awaited=awaited, background=background,
+            dependents=stuck_dependents,
+        )
+
     async def publish_task_event(self, event_type: str, task: Any, **kwargs: Any) -> None:
         """#2187 Stage 4: the SINGLE publish → deliver seam. A task STATE-CHANGE event is
         delivered to the SUBSCRIBED session (the assignee or requester binding) via the
@@ -208,11 +245,14 @@ class TaskWaker:
             await self.wake_assigned(task, **kwargs)
         elif event_type == TASK_EVENT_TERMINAL:
             await self.notify_requester_decide(terminal_task=task, **kwargs)
+        elif event_type == TASK_EVENT_CHILD_SETTLED:
+            await self.wake_parent_on_child_settled(task, **kwargs)
         else:
             raise ValueError(f"unknown task event_type: {event_type!r}")
 
 
 __all__ = [
     "TASK_EVENT_ASSIGNED", "TASK_EVENT_READY", "TASK_EVENT_TERMINAL",
+    "TASK_EVENT_CHILD_SETTLED",
     "TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND",
 ]

--- a/tests/test_2187_stage5c_completion_join.py
+++ b/tests/test_2187_stage5c_completion_join.py
@@ -1,0 +1,164 @@
+"""Tier 2: #2187 Stage 5c — the completion-join gate + the child_settled reconciler.
+
+(1) completion-join: a task may reach DONE only when its decomposition tree is complete
+(no open child of EITHER link type — awaited gates execution, but the final DONE requires
+the whole tree terminal). Attempting DONE with open children returns a DECISION-ENABLING
+error (the LLM is not stopped — it waits or aborts the children).
+
+(2) child_settled reconciler: when a decomposition child settles, its PARENT is woken via
+the requester_kind-EXCLUSIVE routing (TASK → child_settled alone, subsuming recovery; no
+double-wake by construction). Mutually-exclusive firing: total==0 → final completion;
+elif awaited==0 → continue; elif the child failed → recovery; else the parent idles.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.op_runtime import task as taskmod
+from reyn.task import (
+    InMemoryTaskBackend,
+    Task,
+    TaskLinkType,
+    TaskRequesterKind,
+    TaskState,
+)
+from reyn.task.subscription import SubscriptionRegistry
+from tests._support.task_subscription import SubscriptionBackend
+
+
+class _RecWaker:
+    """Records publish_task_event(event_type, task, **kwargs) — the real dispatch seam."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict]] = []
+
+    def resolves(self, session_id: str) -> bool:
+        return True
+
+    async def publish_task_event(self, event_type, task, **kwargs) -> None:
+        self.events.append((event_type, task.task_id, kwargs))
+
+
+def _ctx(backend, waker, caller):
+    return SimpleNamespace(
+        session_id=caller, agent_id="agentA", events=None, task_backend=backend,
+        task_waker=waker, task_subscription_writer=None, current_task_id=None,
+        hook_dispatcher=None)
+
+
+def _child(tid, parent, link, *, assignee, status=TaskState.READY):
+    return Task(task_id=tid, name=tid, assignee=assignee, requester=parent,
+                requester_kind=TaskRequesterKind.TASK, link_type=link, status=status)
+
+
+async def _backend_with(*tasks):
+    cp = SubscriptionRegistry()
+    b = SubscriptionBackend(InMemoryTaskBackend(subscription_reader=cp), cp)
+    for t in tasks:
+        await b.create(t)
+    return b
+
+
+async def _complete(backend, waker, task_id, assignee, *, status="done"):
+    return await taskmod._update_status(
+        SimpleNamespace(task_id=task_id, status=status), _ctx(backend, waker, assignee),
+        "control_ir")
+
+
+# ── (1) completion-join gate ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_completion_join_blocks_done_with_open_awaited_child():
+    """Tier 2: a parent with an OPEN AWAITED child cannot reach DONE — a decision-
+    enabling open_children error (RED if the completion-join gate is stripped)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA"))
+    res = await _complete(b, _RecWaker(), "P", "sP")
+    assert res["status"] == "error" and res["error"]["kind"] == "open_children", res
+    assert res["error"]["awaited"] == 1 and res["error"]["background"] == 0
+    # the parent did NOT transition — still completable later.
+    assert (await b.get("P")).status is not TaskState.DONE
+
+
+@pytest.mark.asyncio
+async def test_completion_join_blocks_done_with_open_background_child():
+    """Tier 2: a BACKGROUND child also blocks the final DONE (the whole tree must be
+    terminal — background never blocks execution, but it gates completion)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("B", "P", TaskLinkType.BACKGROUND, assignee="sB"))
+    res = await _complete(b, _RecWaker(), "P", "sP")
+    assert res["status"] == "error" and res["error"]["kind"] == "open_children", res
+    assert res["error"]["background"] == 1
+
+
+@pytest.mark.asyncio
+async def test_completion_join_allows_done_when_no_open_children():
+    """Tier 2: with the tree complete (children terminal / none), DONE succeeds."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA", status=TaskState.DONE))
+    res = await _complete(b, _RecWaker(), "P", "sP")
+    assert res["status"] == "ok", res
+    assert (await b.get("P")).status is TaskState.DONE
+
+
+# ── (2) child_settled reconciler ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_awaited_child_done_wakes_parent_final_when_last():
+    """Tier 2: completing the last awaited child reconciles the parent with
+    reason=final_completion (total==0 → the parent may complete)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA"))
+    w = _RecWaker()
+    await _complete(b, w, "A", "sA")
+    assert w.events == [("child_settled", "P", w.events[0][2])]
+    assert w.events[0][2]["reason"] == "final_completion"
+
+
+@pytest.mark.asyncio
+async def test_awaited_cleared_but_background_open_wakes_parent_continue():
+    """Tier 2: clearing the awaited child while a background child is still open wakes
+    the parent with reason=continue (awaited==0 but total>0 — unblocked, not complete)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA"),
+        _child("B", "P", TaskLinkType.BACKGROUND, assignee="sB"))
+    w = _RecWaker()
+    await _complete(b, w, "A", "sA")
+    assert w.events[-1][0] == "child_settled" and w.events[-1][2]["reason"] == "continue"
+
+
+@pytest.mark.asyncio
+async def test_open_awaited_sibling_means_parent_not_woken():
+    """Tier 2: completing one awaited child while another awaited child is still open
+    does NOT wake the parent (awaited>0, no failure → the parent idles, §3.5)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA"),
+        _child("A2", "P", TaskLinkType.AWAITED, assignee="sA2"))
+    w = _RecWaker()
+    await _complete(b, w, "A", "sA")
+    assert w.events == []
+
+
+@pytest.mark.asyncio
+async def test_failed_task_child_routes_only_to_child_settled_no_double_wake():
+    """Tier 2: a FAILED decomposition child routes EXCLUSIVELY to child_settled — NOT
+    also the legacy terminal/notify_requester_decide path (the requester_kind-exclusive
+    routing eliminates the double-wake by construction)."""
+    b = await _backend_with(
+        Task(task_id="P", name="p", assignee="sP", requester="root"),
+        _child("A", "P", TaskLinkType.AWAITED, assignee="sA"))
+    w = _RecWaker()
+    await _complete(b, w, "A", "sA", status="failed")
+    kinds = [e[0] for e in w.events]
+    assert kinds == ["child_settled"]  # exactly one wake, not ["terminal", "child_settled"]
+    assert "terminal" not in kinds


### PR DESCRIPTION
**[e2e-coder]** — #2187 backend-master Stage 5c: the completion-join gate + the `child_settled` waker reconciler (off main, post Stage 5b merge #2194). **Finding C — the only substantially-new semantics in #2187** (the RUNNING→DONE completion invariant). Built on 5b's `open_child_counts`.

## ① Completion-join gate (the new invariant)

A task may reach **DONE only when its decomposition tree is complete** — no open child of *either* link type (`awaited + background == 0`). Attempting DONE with open children returns a **decision-enabling error** (`open_children`, the `_reject_unknown_assignee` pattern): the LLM is **not stopped** — it waits (it is re-woken by the reconciler when its children settle) or aborts the children. The check is in `_update_status`, on the task's own children, *before* the backend applies DONE.

(Confirmed with lead: `background` blocks the **final** DONE too — it never blocks execution, but the whole tree must be terminal to complete.)

## ② `child_settled` reconciler-wake (§3.5)

When a decomposition child settles, its **parent** is reconciled — woken via the new `child_settled` event on the `publish_task_event` seam, delivered to the parent's managing session (`parent.assignee`).

**requester_kind-EXCLUSIVE routing** (eliminates the double-wake *by construction* — lead's decision 2): a `requester_kind=TASK` terminal routes to `child_settled` **alone**, which subsumes dependent-recovery (it carries the disposition + the child's stuck dependents) *and* drives completion (the parent's open-child counts). A `requester_kind=SESSION` terminal keeps the existing `notify_requester_decide` recovery. (A `requester_kind=TASK` task is always SELF-origin — a sub-task is internal — so no EXTERNAL-webhook path is reachable on the TASK branch.)

**Mutually-exclusive firing** (decision 3 — `total` subsumes `awaited`): `total==0` → final_completion (the parent may complete); `elif awaited==0` → continue (unblocked); `elif` the child failed/aborted → recovery; `else` the parent is still blocked on awaited children with no failure → **no wake** (it idles, §3.5: no busy-loop). A phantom parent (binding present, row absent) → audit + drop the wake (the 5d reconciliation domain).

DONE only reconciles for a `requester_kind=TASK` child (a top-level DONE has no decomposition parent and must not route to the requester — that was a recovery-only path).

## Test plan

- [x] `tests/test_2187_stage5c_completion_join.py` (NEW):
  - completion-join blocks DONE with an open awaited **or** background child; allows it when the tree is complete. **Falsify-verified RED** when the gate is stripped (cp-bak restore).
  - reconciler: last awaited child DONE → parent `final_completion`; awaited cleared with a background open → `continue`; an open awaited sibling → **no wake** (idle); a FAILED TASK-child routes to `child_settled` **only** (the no-double-wake assertion — `terminal` is absent).
- [x] Full task/2107/waker/slice6ext/a2a/sqlite/hook suite green (474) — the requester_kind-exclusive routing is behaviour-preserving for SESSION-requesters (DONE no longer mis-routes to the requester recovery).
- [x] Full suite green except the 4 known editable-install env quirks (absent in clean CI).
- [x] `ruff check` clean; `test_tier_audit.py --strict` clean; `verify_module_docstrings.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
