### PR TITLE
feat(tui): inline CUI tool rows + working indicator (#2198 PR2)

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+import time
 from io import StringIO
 
 from prompt_toolkit.formatted_text import HTML, AnyFormattedText
@@ -73,6 +74,22 @@ class ChatRenderer:
 
     def cost_summary(self, usage: TokenUsage, cost_usd: float | None) -> None:
         """Render token totals + estimated cost on shutdown."""
+
+    def on_chat_event(self, event) -> None:
+        """Hook for live session events (default no-op).
+
+        `run_repl` subscribes this to the attached session via
+        `Session.subscribe_chat_events`. Override to drive a working indicator.
+        Called synchronously on the session loop with an `Event` (`.type`/`.data`).
+        """
+
+    def bottom_toolbar(self):
+        """Optional prompt_toolkit bottom-toolbar content (default None = none).
+
+        Re-evaluated on every prompt refresh; return a live spinner here to
+        animate a working indicator while a turn runs.
+        """
+        return None
 
 
 class ConsoleChatRenderer(ChatRenderer):
@@ -224,6 +241,9 @@ _CC_DIM = "#6b7280"
 _CC_DONE = "#7ee787"
 _CC_ERR = "#f97066"
 
+# Braille spinner frames for the working indicator (bottom toolbar).
+_SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
 # Per-kind leading marker for the inline CC-style stream. The agent / skill /
 # intervention lines lead with ⏺; tool/trace detail lines lead with ⎿.
 _CC_MARKER = {
@@ -236,6 +256,24 @@ _CC_MARKER = {
 }
 
 
+def _short(v, n: int = 60) -> str:
+    """Collapse whitespace and truncate any value to a one-line summary."""
+    if v is None:
+        return ""
+    s = v if isinstance(v, str) else repr(v)
+    s = " ".join(s.split())
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _summarize_args(args) -> str:
+    """Compact ``k=v`` summary of a tool's args dict (or a bare value)."""
+    if not args:
+        return ""
+    if isinstance(args, dict):
+        return _short(", ".join(f"{k}={_short(v, 24)}" for k, v in args.items()))
+    return _short(args)
+
+
 def format_inline_message(msg: OutboxMessage):
     """Pure formatter: OutboxMessage → rich Text (the inline CC-style line).
 
@@ -244,7 +282,29 @@ def format_inline_message(msg: OutboxMessage):
     """
     from rich.text import Text
     kind = msg.kind
-    text = f"{_meta_prefix(msg.meta)}{msg.text}"
+    meta = msg.meta or {}
+
+    # Tool-call rows. The tool_call_* OutboxMessages arrive already in the pipe
+    # (ChatLifecycleForwarder); meta carries tool / args / result / error.
+    # PR2 renders every tool call; a noise filter (skip low-level read ops) is a
+    # tracked follow-up if dogfood shows it's too chatty (see #2198).
+    if kind == "tool_call_started":
+        tool = str(meta.get("tool", msg.text))
+        args = _summarize_args(meta.get("args"))
+        return Text.assemble(
+            (" ⏺ ", _CC_ACCENT), (tool, "bold"), (f"({args})", _CC_DIM)
+        )
+    if kind == "tool_call_completed":
+        return Text.assemble(
+            ("   ⎿ ", _CC_DIM), (_short(meta.get("result"), 80), _CC_DIM)
+        )
+    if kind == "tool_call_failed":
+        err = meta.get("error_message") or meta.get("error_kind") or msg.text
+        return Text.assemble(
+            ("   ⎿ ✗ ", _CC_ERR), (_short(err, 80), _CC_ERR)
+        )
+
+    text = f"{_meta_prefix(meta)}{msg.text}"
     marker = _CC_MARKER.get(kind)
     if marker is None:
         return Text(text)
@@ -285,6 +345,33 @@ class InlineChatRenderer(ChatRenderer):
             highlight=False, file=self._buffer, force_terminal=True,
         )
         self._transient_active = False
+        # Working-indicator state, driven by on_chat_event (turn_started/completed).
+        self._thinking = False
+        self._think_start = 0.0
+
+    def on_chat_event(self, event) -> None:
+        etype = getattr(event, "type", None)
+        if etype == "turn_started":
+            self._thinking = True
+            self._think_start = time.monotonic()
+        elif etype in ("turn_completed", "turn_cancelled"):
+            self._thinking = False
+
+    def bottom_toolbar(self):
+        """Animated working indicator while a turn runs (spinner + elapsed).
+
+        Re-evaluated on each prompt refresh; returns None when idle so no bar
+        shows. The frame is derived from the wall clock so it advances smoothly
+        regardless of refresh jitter.
+        """
+        if not self._thinking:
+            return None
+        frame = _SPINNER[int(time.monotonic() * 8) % len(_SPINNER)]
+        elapsed = int(time.monotonic() - self._think_start)
+        return HTML(
+            f'<style fg="{_CC_ACCENT}">{frame}</style> '
+            f'<style fg="{_CC_DIM}">Working… {elapsed}s · esc to interrupt</style>'
+        )
 
     def _flush(self) -> None:
         s = self._buffer.getvalue()

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -44,7 +44,13 @@ async def _input_loop(
         try:
             if is_tty:
                 with patch_stdout():
-                    text = await prompt_session.prompt_async(renderer.prompt_text())
+                    text = await prompt_session.prompt_async(
+                        renderer.prompt_text(),
+                        # Animated working indicator while a turn runs. None when
+                        # idle (default base renderer) → no toolbar shown.
+                        bottom_toolbar=renderer.bottom_toolbar,
+                        refresh_interval=0.1,
+                    )
             else:
                 # Piped / scripted stdin: skip prompt_toolkit entirely. It
                 # otherwise emits cursor-movement escapes (`\x1b[1A\x1b[K`)
@@ -129,7 +135,19 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
         raise RuntimeError("run_repl requires an attached agent; call registry.attach() first")
 
     history_path = attached.workspace_dir / ".input_history"
-    prompt_session: PromptSession[str] = PromptSession(history=FileHistory(str(history_path)))
+    from prompt_toolkit.styles import Style
+    prompt_session: PromptSession[str] = PromptSession(
+        history=FileHistory(str(history_path)),
+        # Render the working-indicator toolbar as a dim status line, not the
+        # default heavy reversed bar.
+        style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
+    )
+
+    # Drive the renderer's working indicator from the attached session's turn
+    # lifecycle (turn_started → spinner, turn_completed → idle) via the narrow
+    # subscribe API. Single-agent scope for now; agent-switch re-subscription is
+    # a follow-up.
+    attached.subscribe_chat_events(renderer.on_chat_event)
 
     renderer.banner(attached.agent_name)
 
@@ -152,6 +170,7 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
             {inputs, outputs}, return_when=asyncio.FIRST_COMPLETED,
         )
     finally:
+        attached.unsubscribe_chat_events(renderer.on_chat_event)
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1931,6 +1931,20 @@ class Session:
     def _accumulate(self, result) -> None:
         self._budget.accumulate(result)
 
+    def subscribe_chat_events(self, cb: "Callable[..., None]") -> None:
+        """Register ``cb`` for this session's chat events (narrow public API).
+
+        Encapsulates the internal EventLog so UI callers (e.g. the inline CUI
+        working indicator) subscribe without reaching into ``_chat_events``.
+        ``cb`` receives an ``Event`` (``.type`` / ``.data``) synchronously on the
+        session loop. Pair with :meth:`unsubscribe_chat_events`.
+        """
+        self._chat_events.add_subscriber(cb)
+
+    def unsubscribe_chat_events(self, cb: "Callable[..., None]") -> bool:
+        """Remove a callback registered via :meth:`subscribe_chat_events`."""
+        return self._chat_events.remove_subscriber(cb)
+
     @property
     def total_usage(self):
         return self._budget.total_usage

--- a/tests/test_inline_pr2_tool_rows.py
+++ b/tests/test_inline_pr2_tool_rows.py
@@ -1,0 +1,103 @@
+"""Tier 2: inline CC-style tool rows + working-indicator contract.
+
+Tool-call OutboxMessages render as ⏺ Tool(args) / ⎿ result / ⎿ ✗ error, and the
+working indicator turns on/off with the turn lifecycle. Assertions are on the
+public surfaces (`.plain`, `bottom_toolbar()`), not whitespace or private state.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from reyn.interfaces.repl.renderer import (
+    InlineChatRenderer,
+    format_inline_message,
+)
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+def _plain(kind: str, text: str, meta: dict) -> str:
+    return format_inline_message(
+        OutboxMessage(kind=kind, text=text, meta=meta)
+    ).plain
+
+
+def test_tool_started_shows_dot_tool_and_args() -> None:
+    """Tier 2: tool_call_started → ⏺ marker + tool name + arg summary."""
+    out = _plain("tool_call_started", "read_file",
+                 {"tool": "read_file", "args": {"path": "docs/x.md"}})
+    assert "⏺" in out
+    assert "read_file" in out
+    assert "docs/x.md" in out
+
+
+def test_tool_completed_shows_corner_and_result() -> None:
+    """Tier 2: tool_call_completed → ⎿ marker + result summary."""
+    out = _plain("tool_call_completed", "read_file",
+                 {"tool": "read_file", "result": "42 lines"})
+    assert "⎿" in out
+    assert "42 lines" in out
+
+
+def test_tool_failed_shows_cross_and_error() -> None:
+    """Tier 2: tool_call_failed → ⎿ ✗ marker + error message."""
+    out = _plain("tool_call_failed", "web_fetch",
+                 {"tool": "web_fetch", "error_message": "timeout"})
+    assert "⎿" in out
+    assert "✗" in out
+    assert "timeout" in out
+
+
+def test_long_result_is_truncated_to_one_line() -> None:
+    """Tier 2: an overlong / multiline result is collapsed to a one-line summary."""
+    out = _plain("tool_call_completed", "web_search",
+                 {"tool": "web_search", "result": "x" * 500 + "\nsecond line"})
+    assert "\n" not in out          # collapsed to one line
+    assert "…" in out               # and truncated
+    assert "second line" not in out  # the tail past the cap is dropped
+
+
+def test_started_with_no_args_renders_empty_parens() -> None:
+    """Tier 2: a tool with no args still renders cleanly (no crash, empty args)."""
+    out = _plain("tool_call_started", "list_skills", {"tool": "list_skills"})
+    assert "list_skills" in out
+
+
+def _evt(t: str) -> Event:
+    return Event(type=t, timestamp=datetime.now(timezone.utc), data={})
+
+
+def test_indicator_idle_shows_no_toolbar() -> None:
+    """Tier 2: with no turn running, the working indicator is absent."""
+    r = InlineChatRenderer()
+    assert r.bottom_toolbar() is None
+
+
+def test_indicator_on_during_turn_off_after() -> None:
+    """Tier 2: turn_started shows the indicator; turn_completed hides it."""
+    r = InlineChatRenderer()
+    r.on_chat_event(_evt("turn_started"))
+    tb = r.bottom_toolbar()
+    assert tb is not None
+    assert "Working" in tb.value  # HTML markup carries the label
+    r.on_chat_event(_evt("turn_completed"))
+    assert r.bottom_toolbar() is None
+
+
+def test_indicator_cleared_on_cancel() -> None:
+    """Tier 2: a cancelled turn also clears the indicator."""
+    r = InlineChatRenderer()
+    r.on_chat_event(_evt("turn_started"))
+    assert r.bottom_toolbar() is not None
+    r.on_chat_event(_evt("turn_cancelled"))
+    assert r.bottom_toolbar() is None
+
+
+def test_unrelated_event_does_not_toggle_indicator() -> None:
+    """Tier 2: a non-lifecycle event leaves indicator state unchanged."""
+    r = InlineChatRenderer()
+    r.on_chat_event(_evt("llm_request"))
+    assert r.bottom_toolbar() is None
+    r.on_chat_event(_evt("turn_started"))
+    r.on_chat_event(_evt("llm_response_received"))
+    assert r.bottom_toolbar() is not None  # still thinking


### PR DESCRIPTION
**[tui-coder]** — PR2 of the inline CUI track (design #2198, lead-coder GO). Makes the inline CUI "alive": tool rows + working indicator. Both fit the `run_repl` / `InlineChatRenderer` model — **no custom Application** (that's PR3).

## Changes
- **Tool rows**: `tool_call_started/completed/failed` (already delivered to `renderer.message()` via `ChatLifecycleForwarder`; previously plain-fallback) → `⏺ Tool(args)` / `⎿ result` / `⎿ ✗ error`. Pure additions to `format_inline_message`.
- **Working indicator**: braille spinner + elapsed in the `prompt_async` `bottom_toolbar`, on `turn_started` → off `turn_completed`/`turn_cancelled`. Driven via a new narrow `Session.subscribe_chat_events(cb)` / `unsubscribe_chat_events(cb)` (no raw `_chat_events`, per review #2).
- **run_repl wiring**: subscribe the attached session's events to `renderer.on_chat_event`; pass `bottom_toolbar` + `refresh_interval=0.1`; dim non-reverse toolbar style; unsubscribe on shutdown. Base renderer no-op hooks → `--cui` / non-TTY unaffected.

## Design decisions (per #2198 review)
1. **Tool-row noise** = render all → dogfood → filter. **TODO (no-debt follow-up)**: if low-level read ops (`file__read`/`list_skills`/`describe_skill`) are too chatty, add a meaningful-tool filter. Will split to its own issue if dogfood confirms.
2. **`_chat_events` access** = narrow `Session.subscribe_chat_events()` (encapsulated, no raw exposure).
3. **PR3 arch** = unchanged (in-place PromptSession→Application swap, separate PR + flow-trace).

## Known limitations (follow-ups)
- Tool result rows show the raw op dict truncated (`⎿ {'kind':'file',...}`); prettier per-tool summaries (CC's `⎿ Read N lines`) can ride the noise-filter follow-up.
- Working indicator is single-agent scoped (subscribes the attached session); agent-switch re-subscription is a follow-up.

## Test plan
- [x] e2e tool rows: `⏺ file__read(path=pyproject.toml)` / `⎿ {...}` stream as tools run (tmux, litellm proxy)
- [x] working spinner mid-turn: caught `⠙ Working… 11s · esc to interrupt` below the prompt during a multi-tool turn
- [x] `/quit` → cost summary + clean exit
- [x] `--cui` plain unaffected (`agent> pong` + cost, same run_repl)
- [x] 4 gates: ruff `src tests` / verify_module_docstrings / tier-audit `--strict` (fixed a `len()<N` format-pin) / 18 Tier 2 tests

**Tier self-check**: new test is Tier 2 — public `.plain` / `bottom_toolbar()` surfaces, real `OutboxMessage`/`Event` instances, no mocks / no private-state asserts / no format-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
