### PR TITLE
feat(#2187): Stage 5d — recovery reconciliation (the final #2187 stage)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -971,10 +971,16 @@ class AgentRegistry:
         # unchanged); a spawned session is recreated via spawn_session(name, sid)
         # — which re-applies the S5 path fixup — then re-adopts its state. Its
         # run-loop starts lazily on attach_session (S4a), so no auto-run here.
+        # #2187 5d: a session with a recovery-ACTIONABLE subscription MUST be instantiated
+        # even with an empty snapshot — else a delegate that consumed its inbox then
+        # crashed (RUNNING task, empty inbox) would never be re-woken (finding 3). Bounded:
+        # only §3.6-actionable tasks (an awaited>0 idle parent is NOT instantiated).
+        recovery_work = await self._compute_recovery_work()
         for (name, sid), snap in all_snaps.items():
             if (not snap.inbox
                     and not snap.pending_chains
-                    and not snap.outstanding_interventions):
+                    and not snap.outstanding_interventions
+                    and sid not in recovery_work):
                 continue
             if sid == _DEFAULT_SID:
                 session = self.get_or_load(name)
@@ -987,6 +993,9 @@ class AgentRegistry:
                 if session is not None:
                     session.restore_state(snap)
 
+        # #2187 §3.6 (5d): the RE-DELIVERY half — now that the actionable sessions are
+        # live, re-publish their missed events through each session's OWN production waker.
+        await self._redeliver_recovery_wakes(recovery_work)
         return snapshots
 
     # ── Global rewind (ADR-0038 Stage 1c-2, D2 consistent-cut) ──────────────
@@ -1318,31 +1327,99 @@ class AgentRegistry:
         self._task_subscriptions.apply(kind, seq, fields)
 
     async def _reconcile_subscriptions_after_recovery(self) -> "list[str]":
-        """#2187 Stage 4: the recovery RE-READ seam (the backend-master recovery model:
-        re-subscribe, then re-read the current external task-state, catching up by
-        re-reading). The subscription (the Reyn-internal binding) is already restored by
-        the WAL replay in ``restore_all``; the backend is the external MASTER of
-        task-STATE and is NOT rewound — so on recovery the binding may name a task whose
-        backend state moved (or vanished) while Reyn was down.
+        """#2187 recovery RE-READ + PRUNE (the backend-master recovery model: re-subscribe,
+        then re-read the current external task-state). The subscription (the Reyn-internal
+        binding) is already restored by the WAL replay in ``restore_all``; the backend is
+        the external MASTER of task-STATE and is NOT rewound — so on recovery the binding
+        may name a task whose backend state moved (or vanished) while Reyn was down.
 
-        Stage 4 establishes the seam + a coherence pass: it returns the STALE bindings —
-        subscriptions whose task the backend no longer holds (the external master dropped
-        it) — and logs a summary. The FULL reconciliation — diff the re-read state against
-        the binding and RE-PUBLISH the missed state-change events to the re-subscribed
-        session (via ``publish_task_event``) / prune the stale bindings — is Stage 5: the
-        typed-state lifecycle drives WHICH events to re-deliver, so it is built there, on
-        this seam (the returned stale set is its input)."""
+        Stage 5d — the PRUNE half (runs here, BEFORE session instantiation, since it needs
+        no live session): re-read each binding; a STALE one (the backend no longer holds
+        the task — the master dropped it) is PRUNED from the live registry (live-only,
+        self-healing — see ``SubscriptionRegistry.prune``). The RE-DELIVERY half (waking
+        the re-subscribed session for its actionable tasks, §3.6) runs AFTER session
+        instantiation, via each live session's own waker — ``_redeliver_recovery_wakes``.
+        Returns the pruned (stale) task ids (for the log / tests)."""
         task_ids = self._task_subscriptions.task_ids()
         if not task_ids:
             return []
         backend = self.task_backend  # the durable external master (built lazily)
         stale = [tid for tid in task_ids if await backend.get(tid) is None]
+        for tid in stale:
+            self._task_subscriptions.prune(tid)
         if stale:
             logger.info(
-                "#2187 recovery re-read: %d/%d subscription(s) name a task with no "
-                "backend state (stale binding — the external master dropped it); "
-                "Stage 5 reconciliation resolves these.", len(stale), len(task_ids))
+                "#2187 recovery reconcile: pruned %d/%d stale subscription(s) (the "
+                "external master no longer holds the task).", len(stale), len(task_ids))
         return stale
+
+    async def _recovery_action(self, backend, task) -> "str | None":
+        """#2187 §3.6 (5d): the 7-state recovery wake predicate → the ``publish_task_event``
+        event to re-deliver to the task's owner on recovery, or ``None`` (no wake).
+
+        - ``UNASSIGNED`` (no subscriber) / ``BLOCKED`` (DAG-driven, woken by the readiness
+          promote, not the subscription) / terminal (``DONE``/``FAILED``/``ABORTED``) → None.
+        - ``READY`` → ``ready`` (the assignee resumes execution).
+        - ``RUNNING`` → ``recovery_resume`` iff ``N_awaited == 0`` (the awaited children
+          settled while down → continue/complete) OR a child ``FAILED`` (recover); else
+          None (still blocked on running awaited children → idle, no busy-loop)."""
+        from reyn.runtime.services.task_wake import (  # noqa: PLC0415
+            TASK_EVENT_READY,
+            TASK_EVENT_RECOVERY_RESUME,
+        )
+        from reyn.task import TaskState  # noqa: PLC0415
+
+        if task.status is TaskState.READY:
+            return TASK_EVENT_READY
+        if task.status is TaskState.RUNNING:
+            counts = await backend.open_child_counts(task.task_id)
+            if counts.awaited == 0:
+                return TASK_EVENT_RECOVERY_RESUME
+            children = await backend.children_of(task.task_id)
+            if any(c.status is TaskState.FAILED for c in children):
+                return TASK_EVENT_RECOVERY_RESUME
+        return None
+
+    async def _compute_recovery_work(self) -> "dict[str, list]":
+        """#2187 5d: group the recovery-ACTIONABLE subscriptions by assignee sid
+        ``{sid → [(task, event), ...]}`` from the current backend state. Drives BOTH the
+        step-5 instantiate widening (a session with an actionable task MUST be
+        instantiated to be re-woken — finding 3: else a delegate that consumed its inbox
+        then crashed never resumes = "org builds but doesn't run" recurs after crash) AND
+        the re-delivery. Stale bindings are already pruned; an UNASSIGNED binding has no
+        owner."""
+        subs = self._task_subscriptions
+        backend = self.task_backend
+        out: "dict[str, list]" = {}
+        for tid in subs.task_ids():
+            assignee = subs.assignee_of(tid)
+            if assignee is None:
+                continue
+            task = await backend.get(tid)
+            if task is None:
+                continue
+            action = await self._recovery_action(backend, task)
+            if action is not None:
+                out.setdefault(assignee, []).append((task, action))
+        return out
+
+    async def _redeliver_recovery_wakes(self, recovery_work: dict) -> None:
+        """#2187 §3.6 (5d) re-delivery — AFTER session instantiation, via each LIVE
+        session's OWN ``task_waker`` (the production per-agent waker → delivery-equivalent
+        BY CONSTRUCTION; the session holds its agent_name, so no separate resolution, no
+        divergent path). Session-driven: for each live session, re-publish its actionable
+        tasks' events through the SAME ``publish_task_event`` seam production uses."""
+        if not recovery_work:
+            return
+        for _name, session in self._iter_named_sessions():
+            work = recovery_work.get(getattr(session, "_session_id", None))
+            if not work:
+                continue
+            waker = getattr(session, "_task_waker", None)
+            if waker is None:
+                continue
+            for task, event in work:
+                await waker.publish_task_event(event, task)
 
     async def _on_wal_append_capture(self, kind: str, seq: int, fields: dict) -> None:
         """Generic WAL post-append observer: per-step act-turn workspace capture.

--- a/src/reyn/runtime/services/task_wake.py
+++ b/src/reyn/runtime/services/task_wake.py
@@ -52,6 +52,13 @@ TASK_EVENT_READY = "ready"
 TASK_EVENT_ASSIGNED = "assigned"
 TASK_EVENT_TERMINAL = "terminal"
 TASK_EVENT_CHILD_SETTLED = "child_settled"
+# #2187 Stage 5d: the one-shot RECOVERY reconcile wake — delivered to a RUNNING task's
+# own owner (assignee) after a recovery/rewind, to RESUME it (re-read + act). Distinct
+# from child_settled (which wakes a PARENT about a child); here the task's owner resumes
+# the task itself.
+TASK_EVENT_RECOVERY_RESUME = "recovery_resume"
+
+WAKE_RECOVERY_KIND = "task_recovery_resume"
 
 
 class TaskWaker:
@@ -226,6 +233,21 @@ class TaskWaker:
             dependents=stuck_dependents,
         )
 
+    async def wake_recovery_resume(self, task: Any) -> None:
+        """#2187 §3.6 (5d): the one-shot RECOVERY reconcile wake — the task's own owner
+        (``task.assignee``) is woken to RESUME the task after a recovery/rewind (its
+        awaited children settled, or a child failed, while Reyn was down). The owner
+        re-reads the task's current state and acts (continue / complete — the
+        completion-join gate enforces correctness — / recover); an owner with nothing to
+        do simply yields (one-shot, not a loop)."""
+        await self._wake(
+            task.assignee, WAKE_RECOVERY_KIND,
+            f"[task] Recovery: resume task {task.task_id!r} ('{task.name}') — re-read its "
+            f"current state (its children settled, or a child failed, while you were "
+            f"down) and continue, complete, or recover via the task ops.",
+            task_id=task.task_id,
+        )
+
     async def publish_task_event(self, event_type: str, task: Any, **kwargs: Any) -> None:
         """#2187 Stage 4: the SINGLE publish → deliver seam. A task STATE-CHANGE event is
         delivered to the SUBSCRIBED session (the assignee or requester binding) via the
@@ -247,12 +269,14 @@ class TaskWaker:
             await self.notify_requester_decide(terminal_task=task, **kwargs)
         elif event_type == TASK_EVENT_CHILD_SETTLED:
             await self.wake_parent_on_child_settled(task, **kwargs)
+        elif event_type == TASK_EVENT_RECOVERY_RESUME:
+            await self.wake_recovery_resume(task)
         else:
             raise ValueError(f"unknown task event_type: {event_type!r}")
 
 
 __all__ = [
     "TASK_EVENT_ASSIGNED", "TASK_EVENT_READY", "TASK_EVENT_TERMINAL",
-    "TASK_EVENT_CHILD_SETTLED",
-    "TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND",
+    "TASK_EVENT_CHILD_SETTLED", "TASK_EVENT_RECOVERY_RESUME",
+    "TaskWaker", "WAKE_READY_KIND", "WAKE_REQUESTER_KIND", "WAKE_RECOVERY_KIND",
 ]

--- a/src/reyn/task/subscription.py
+++ b/src/reyn/task/subscription.py
@@ -120,6 +120,15 @@ class SubscriptionRegistry:
         """The UNASSIGNED tasks (no assignee) — the pending-assignment queue."""
         return [tid for tid, rec in self._subs.items() if rec.assignee is None]
 
+    def prune(self, task_id: str) -> bool:
+        """Drop a binding from the LIVE registry (#2187 5d recovery reconciliation) —
+        used when the backend (the task-STATE master) no longer holds the task, so the
+        subscription is STALE. Live-only (no WAL event): the reconciliation re-runs on
+        every recovery, so a still-stale binding is re-pruned (idempotent self-heal); an
+        un-deleted task re-binds on its next ``task_subscribed`` — durable freezing would
+        be wrong under backend-master. Returns True if a binding was removed."""
+        return self._subs.pop(task_id, None) is not None
+
 
 class SubscriptionWriter:
     """The op-layer seam that appends the task SUBSCRIPTION WAL kinds — the Reyn-internal

--- a/tests/test_2187_stage5d_reconciliation.py
+++ b/tests/test_2187_stage5d_reconciliation.py
@@ -1,0 +1,187 @@
+"""Tier 2: #2187 Stage 5d — the recovery reconciliation (the backend-master recovery
+model: re-subscribe, re-read the current external task-state, catch up).
+
+PRUNE half (before session instantiation): a STALE binding (the backend no longer holds
+the task — the master dropped it) is pruned live (self-healing). RE-DELIVERY half (the
+§3.6 7-state predicate, after instantiation, via each live session's OWN waker): a READY
+subscription re-delivers ``ready``; a RUNNING task whose awaited children settled (or a
+child failed) re-delivers ``recovery_resume``; a RUNNING task still blocked on an open
+awaited child re-delivers NOTHING (idle, no busy-loop). The phantom-not-cascaded backend
+invariant (the 5b-deferred pin) is here too.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.task import (
+    SqliteTaskBackend,
+    Task,
+    TaskLinkType,
+    TaskRequesterKind,
+    TaskState,
+)
+from reyn.task.subscription import SubscriptionRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+def _reg(tmp_path):
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return state_log, AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log)
+
+
+async def _bind(state_log, tid, *, assignee, requester="root", kind="session"):
+    await state_log.append("task_subscribed", task_id=tid, assignee=assignee,
+                           requester=requester, requester_kind=kind)
+
+
+def _task(tid, *, status=TaskState.READY, assignee="s1", requester="root",
+          kind=TaskRequesterKind.SESSION, link=TaskLinkType.AWAITED):
+    return Task(task_id=tid, name=tid, assignee=assignee, requester=requester,
+                requester_kind=kind, status=status, link_type=link)
+
+
+# ── PRUNE half ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_binding_is_pruned(tmp_path: Path):
+    """Tier 2: a subscription whose task the backend no longer holds is PRUNED from the
+    live registry (RED if prune is dropped — the stale binding would persist)."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "t-live", assignee="s1")
+    await _bind(state_log, "t-gone", assignee="s1")
+    await reg.task_backend.create(_task("t-live"))  # backend holds only t-live
+
+    pruned = await reg._reconcile_subscriptions_after_recovery()
+
+    assert pruned == ["t-gone"]
+    assert not reg.task_subscriptions.exists("t-gone")  # PRUNED
+    assert reg.task_subscriptions.exists("t-live")       # the live binding stays
+
+
+# ── RE-DELIVERY predicate (§3.6, 7-state) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ready_subscription_redelivers_ready(tmp_path: Path):
+    """Tier 2: a READY task's owner is re-woken to execute (event ``ready``)."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "t-ready", assignee="s1")
+    await reg.task_backend.create(_task("t-ready", status=TaskState.READY))
+    work = await reg._compute_recovery_work()
+    assert [(t.task_id, ev) for (t, ev) in work.get("s1", [])] == [("t-ready", "ready")]
+
+
+@pytest.mark.asyncio
+async def test_running_with_no_open_children_redelivers_recovery_resume(tmp_path: Path):
+    """Tier 2: a RUNNING task whose awaited children settled (N_awaited==0) re-delivers
+    ``recovery_resume`` (the owner resumes — continue/complete)."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "t-run", assignee="s1")
+    await reg.task_backend.create(_task("t-run", status=TaskState.RUNNING))
+    work = await reg._compute_recovery_work()
+    assert [ev for (_t, ev) in work.get("s1", [])] == ["recovery_resume"]
+
+
+@pytest.mark.asyncio
+async def test_running_blocked_on_open_awaited_child_redelivers_nothing(tmp_path: Path):
+    """Tier 2: a RUNNING task still blocked on an OPEN awaited child is NOT re-woken
+    (idle — §3.6, no busy-loop). RED if the awaited>0 guard is dropped."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "P", assignee="s1")
+    await _bind(state_log, "C", assignee="s1", requester="P", kind="task")
+    await reg.task_backend.create(_task("P", status=TaskState.RUNNING))
+    await reg.task_backend.create(_task("C", status=TaskState.RUNNING,
+                                        kind=TaskRequesterKind.TASK, requester="P",
+                                        link=TaskLinkType.AWAITED))
+    work = await reg._compute_recovery_work()
+    # P is NOT woken — it idles on its open awaited child C (C itself, RUNNING+childless,
+    # is its own actionable resume; the assertion isolates P's idleness).
+    assert [ev for (t, ev) in work.get("s1", []) if t.task_id == "P"] == []
+
+
+@pytest.mark.asyncio
+async def test_redelivery_uses_each_live_sessions_own_waker(tmp_path: Path):
+    """Tier 2: re-delivery is SESSION-DRIVEN through each live session's OWN task_waker
+    (the production waker → equivalence by construction) — only the matching session's
+    work is delivered, via its publish_task_event seam."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "t-ready", assignee="s1")
+    await reg.task_backend.create(_task("t-ready", status=TaskState.READY))
+    work = await reg._compute_recovery_work()
+
+    class _RecWaker:
+        def __init__(self):
+            self.events: list[tuple[str, str]] = []
+
+        async def publish_task_event(self, event, task, **kw):
+            self.events.append((event, task.task_id))
+
+    waker = _RecWaker()
+    reg._sessions["agentA"] = {"s1": type("S", (), {"_session_id": "s1", "_task_waker": waker})()}
+
+    await reg._redeliver_recovery_wakes(work)
+    assert waker.events == [("ready", "t-ready")]
+
+
+# ── phantom-not-cascaded (the 5b-deferred pin, in-scope here) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_phantom_binding_child_is_not_abort_cascaded(tmp_path: Path):
+    """Tier 2: 5b-deferred pin — under backend-master the backend ROW is the existence
+    authority — abort does NOT cascade through a PHANTOM node (a subscription binding
+    whose backend row is absent), so a real grandchild under a phantom is NOT aborted.
+    RED if abort walked the binding ignoring backend existence (the OLD reader-only walk)."""
+    cp = SubscriptionRegistry()
+    backend = SqliteTaskBackend(str(tmp_path / "t.db"), subscription_reader=cp)
+    # bindings: R (root) → Ph (phantom: binding only, NO row) → G (real grandchild row).
+    cp.apply("task_subscribed", 1, {"task_id": "R", "assignee": "s", "requester": "root",
+                                     "requester_kind": "session"})
+    cp.apply("task_subscribed", 2, {"task_id": "Ph", "assignee": "s", "requester": "R",
+                                    "requester_kind": "task"})
+    cp.apply("task_subscribed", 3, {"task_id": "G", "assignee": "s", "requester": "Ph",
+                                    "requester_kind": "task"})
+    await backend.create(_task("R"))  # R has a row
+    await backend.create(_task("G", status=TaskState.READY))  # G has a row; Ph does NOT
+
+    aborted = {t.task_id for t in await backend.abort("R")}
+
+    assert aborted == {"R"}  # only R — the phantom Ph is not followed, so G is unreached
+    assert (await backend.get("G")).status is TaskState.READY  # G untouched
+    backend.close()
+
+
+# ── time-travel coherence: reconcile re-adapts to CURRENT backend state ─────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_readapts_to_current_backend_state(tmp_path: Path):
+    """Tier 2: the reconcile re-reads CURRENT backend state (not a frozen view) — a parent
+    that was idle (open awaited child) becomes actionable once that child reaches DONE, so
+    a later reconcile picks it up. This is the backend-master recovery/time-travel
+    coherence (the subscription is rewound; the backend state is re-read, not rewound)."""
+    state_log, reg = _reg(tmp_path)
+    await _bind(state_log, "P", assignee="s1")
+    await _bind(state_log, "C", assignee="s1", requester="P", kind="task")
+    await reg.task_backend.create(_task("P", status=TaskState.RUNNING))
+    await reg.task_backend.create(_task("C", status=TaskState.RUNNING,
+                                        kind=TaskRequesterKind.TASK, requester="P"))
+    # idle: P blocked on the open awaited child C.
+    before = await reg._compute_recovery_work()
+    assert [ev for (t, ev) in before.get("s1", []) if t.task_id == "P"] == []
+
+    # the child settles in the backend (the external master advances)
+    await reg.task_backend.update_status("C", "done", caller_session_id="s1")
+
+    work = await reg._compute_recovery_work()
+    # P now actionable — the reconcile re-read the CURRENT (advanced) state, not a frozen one.
+    assert [ev for (t, ev) in work.get("s1", []) if t.task_id == "P"] == ["recovery_resume"]


### PR DESCRIPTION
**[e2e-coder]** — #2187 backend-master Stage 5d: the recovery reconciliation — the **FINAL stage** of #2187 (off main, post Stage 5c merge #2197). Turns the Stage-4b re-read seam into a complete *detect + actually-deliver* reconciliation, built on 5b's `open_child_counts` + 5c's `publish_task_event` seam.

## The backend-master recovery model

On recovery/rewind, the Reyn-internal **subscription** (the binding) is replayed from the WAL (and rewound); the **backend** is the external MASTER of task-STATE and is NOT rewound. So the binding may name a task whose state advanced (or vanished) while Reyn was down. The reconciliation catches up *by re-reading the current backend state*.

## ① Prune half (before session instantiation)

A STALE binding — the backend no longer holds the task (the master dropped it) — is **pruned** from the live registry (`SubscriptionRegistry.prune`). **Live-only** (no WAL event): the reconcile re-runs every recovery, so a still-stale binding is re-pruned (idempotent self-heal); an un-deleted task re-binds on its next `task_subscribed`. Durable freezing would be wrong under backend-master.

## ② Re-delivery half (after session instantiation) — the §3.6 7-state predicate

`_recovery_action` enumerates **all 7 states**: UNASSIGNED (no subscriber) / BLOCKED (DAG-driven) / terminal → no wake; **READY** → re-deliver `ready` (execute); **RUNNING** → `recovery_resume` iff `N_awaited==0` (awaited children settled → continue/complete) OR a child FAILED (recover), else **no wake** (still blocked on an awaited child → idle, §3.6 no busy-loop).

**Delivery equivalence — by construction** (resolving the wiring): re-delivery runs *after* step-5 session instantiation, **session-driven**, through each live session's **OWN `task_waker`** (the production per-agent waker) via the SAME `publish_task_event` seam — so it is not a divergent parallel delivery, and no agent_name resolution is needed (the session holds it). New event `recovery_resume` (P7 OS-level).

**Finding 3 — the load-bearing fix**: a session with a recovery-actionable subscription **MUST** be instantiated even with an empty snapshot — else a delegate that consumed its inbox then crashed (RUNNING task, empty inbox) would never resume = "org builds but doesn't run" recurs after a crash. The step-5 instantiate condition is widened to include recovery-actionable sessions (bounded: only §3.6-actionable; an `awaited>0` idle parent is not instantiated).

## ③ Phantom-not-cascaded pin (the 5b-deferred commitment)

Under backend-master the backend ROW is the existence authority: abort does **not** cascade through a phantom node (a binding whose backend row is absent), so a real grandchild under a phantom is not aborted. Pinned here (reconciliation is the in-scope home).

## Test plan

- [x] `tests/test_2187_stage5d_reconciliation.py` (NEW): stale → pruned; READY → `ready`; RUNNING N_awaited==0 → `recovery_resume`; RUNNING blocked on an open awaited child → no wake (idle); re-delivery via each live session's OWN waker; **phantom-not-cascaded**; time-travel re-adaptation (reconcile re-reads CURRENT advanced state). **Falsify-verified RED** (cp-bak restore) when the prune / the awaited-idle guard / the phantom existence-skip are stripped.
- [x] Full registry/recovery/task/2107/a2a/sqlite suite green (966).
- [x] Full suite green except the 4 known editable-install env quirks (absent in clean CI).
- [x] All 4 CI gates: `ruff` / `test_tier_audit.py --strict` / `verify_module_docstrings.py` clean.

## #2187 backend-master — COMPLETE

This lands the final stage. The full arc: generation-drop + ownership=subscription→WAL + dogfood-fix (1-3, #2190) · pub/sub + recovery seam (4, #2191) · 7-state migration + retention (5a, #2192) · children_of + link-type + counts (5b, #2194) · completion-join + reconciler (5c, #2197) · recovery reconciliation (5d, this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
