### PR TITLE
feat(tui): inline CUI custom-Application input driver (#2200 PR3a)

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -72,4 +72,10 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     #   the turn_end lifecycle hook (slice 5b). chain_id matches the turn's
     #   chain_id for cross-agent tracing.
     "turn_completed": frozenset({"chain_id"}),
+    # turn_settled: emitted in Session.run_one_iteration()'s finally for EVERY
+    #   turn kind (including slash / intervention short-circuits that return
+    #   before the router). Unlike turn_completed (router path only), this is the
+    #   reliable "the turn is done" signal for UI working-indicators. kind mirrors
+    #   turn_started; chain_id may be absent for non-user triggers.
+    "turn_settled": frozenset({"kind"}),
 }

--- a/src/reyn/interfaces/inline/__init__.py
+++ b/src/reyn/interfaces/inline/__init__.py
@@ -1,0 +1,1 @@
+"""Interactive inline CUI input driver (Claude Code-style)."""

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -1,0 +1,133 @@
+"""Claude Code-style interactive input driver for the inline CUI.
+
+A long-lived prompt_toolkit Application that drives input for the interactive
+(TTY) inline renderer: a rule-bar sandwiched input plus an animated working row.
+
+Integration: run_repl's `_output_loop` prints conversation output ABOVE this app
+via `run_in_terminal` (the app stays a live region at the bottom); user input is
+fed to the session via `submit_user_text`, so intervention answers / slash
+commands / new turns route through the session exactly as the PromptSession path
+did — the app never inspects the text. The navigable status menu + dropdowns are
+a follow-up (PR3b); this lands the input-driver swap with a static hint line.
+
+`--cui` / non-TTY keep the existing PromptSession `_input_loop` (plain invariance).
+"""
+from __future__ import annotations
+
+import time
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import (
+    ConditionalContainer,
+    HSplit,
+    Layout,
+    VSplit,
+    Window,
+)
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.patch_stdout import patch_stdout
+
+from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _SPINNER
+
+
+def working_line(thinking: bool, think_start: float, now: float) -> list:
+    """Pure: working-row fragments while a turn runs (empty list when idle).
+
+    The spinner frame derives from `now` so it advances smoothly regardless of
+    refresh jitter; elapsed is whole seconds since `think_start`.
+    """
+    if not thinking:
+        return []
+    frame = _SPINNER[int(now * 8) % len(_SPINNER)]
+    elapsed = max(0, int(now - think_start))
+    return [
+        (f"fg:{_CC_ACCENT}", f" {frame} "),
+        (f"fg:{_CC_DIM}", f"Working… {elapsed}s"),
+    ]
+
+
+async def run_inline_input(registry, renderer) -> None:
+    """Run the interactive inline input Application until the user quits.
+
+    Returns on quit (Ctrl-C/D/Q or /quit /exit) so run_repl can tear down (cost
+    summary) via its FIRST_COMPLETED wait.
+    """
+    attached = registry.attached_session()
+    history = FileHistory(str(attached.workspace_dir / ".input_history"))
+    buf = Buffer(multiline=False, history=history)
+
+    def _frags() -> list:
+        return working_line(
+            getattr(renderer, "_thinking", False),
+            getattr(renderer, "_think_start", 0.0),
+            time.monotonic(),
+        )
+
+    working = ConditionalContainer(
+        Window(FormattedTextControl(_frags), height=1),
+        filter=Condition(lambda: getattr(renderer, "_thinking", False)),
+    )
+    top_rule = Window(height=1, char="─", style=f"fg:{_CC_DIM}")
+    bottom_rule = Window(height=1, char="─", style=f"fg:{_CC_DIM}")
+    prompt_sym = Window(
+        FormattedTextControl([(f"fg:{_CC_ACCENT} bold", "> ")]), width=2, height=1
+    )
+    input_win = Window(BufferControl(buffer=buf), height=1)
+    inputrow = VSplit([prompt_sym, input_win])
+    hint = Window(
+        FormattedTextControl([(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]),
+        height=1,
+    )
+
+    kb = KeyBindings()
+
+    @kb.add("enter")
+    def _accept(event) -> None:
+        text = buf.text
+        buf.reset(append_to_history=True)
+        stripped = text.strip()
+        if not stripped:
+            return
+        # /quit /exit are intercepted here (mirrors _input_loop) so they tear the
+        # REPL down rather than dispatching as a no-op slash. Everything else —
+        # plain text, intervention answers, other slash commands — flows through
+        # submit_user_text, which routes it inside the session unchanged.
+        if stripped in ("/quit", "/exit"):
+            event.app.create_background_task(_quit(registry, event.app))
+        else:
+            event.app.create_background_task(_submit(registry, stripped))
+
+    @kb.add("c-c")
+    @kb.add("c-d")
+    @kb.add("c-q")
+    def _quit_key(event) -> None:
+        event.app.create_background_task(_quit(registry, event.app))
+
+    body = HSplit([working, top_rule, inputrow, bottom_rule, hint])
+    app: Application = Application(
+        layout=Layout(body, focused_element=input_win),
+        key_bindings=kb,
+        full_screen=False,
+        refresh_interval=0.1,
+    )
+    # patch_stdout so stray stdout/stderr (e.g. library warnings) prints cleanly
+    # above the live input region instead of corrupting it — mirrors the
+    # PromptSession path. Renderer output (sys.__stdout__ via run_in_terminal in
+    # _output_loop) is unaffected.
+    with patch_stdout():
+        await app.run_async()
+
+
+async def _submit(registry, text: str) -> None:
+    s = registry.attached_session()
+    if s is not None:
+        await s.submit_user_text(text)
+
+
+async def _quit(registry, app) -> None:
+    await registry.shutdown()
+    app.exit()

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -91,6 +91,13 @@ class ChatRenderer:
         """
         return None
 
+    def uses_app_input(self) -> bool:
+        """Whether this renderer drives input via its own prompt_toolkit
+        Application (rule-bar input) instead of the default PromptSession
+        `_input_loop`. Default False → the plain PromptSession path is used.
+        """
+        return False
+
 
 class ConsoleChatRenderer(ChatRenderer):
     _PREFIX = {
@@ -354,7 +361,9 @@ class InlineChatRenderer(ChatRenderer):
         if etype == "turn_started":
             self._thinking = True
             self._think_start = time.monotonic()
-        elif etype in ("turn_completed", "turn_cancelled"):
+        # turn_settled fires for every turn kind (incl. slash short-circuits);
+        # turn_completed/turn_cancelled are kept as belt-and-suspenders.
+        elif etype in ("turn_settled", "turn_completed", "turn_cancelled"):
             self._thinking = False
 
     def bottom_toolbar(self):
@@ -372,6 +381,11 @@ class InlineChatRenderer(ChatRenderer):
             f'<style fg="{_CC_ACCENT}">{frame}</style> '
             f'<style fg="{_CC_DIM}">Working… {elapsed}s · esc to interrupt</style>'
         )
+
+    def uses_app_input(self) -> bool:
+        # Interactive inline drives input via its own rule-bar Application
+        # (reyn.interfaces.inline.app.run_inline_input) on a TTY.
+        return True
 
     def _flush(self) -> None:
         s = self._buffer.getvalue()

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -135,18 +135,11 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
         raise RuntimeError("run_repl requires an attached agent; call registry.attach() first")
 
     history_path = attached.workspace_dir / ".input_history"
-    from prompt_toolkit.styles import Style
-    prompt_session: PromptSession[str] = PromptSession(
-        history=FileHistory(str(history_path)),
-        # Render the working-indicator toolbar as a dim status line, not the
-        # default heavy reversed bar.
-        style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
-    )
 
     # Drive the renderer's working indicator from the attached session's turn
     # lifecycle (turn_started → spinner, turn_completed → idle) via the narrow
     # subscribe API. Single-agent scope for now; agent-switch re-subscription is
-    # a follow-up.
+    # a follow-up. Used by both input paths (app working row / toolbar spinner).
     attached.subscribe_chat_events(renderer.on_chat_event)
 
     renderer.banner(attached.agent_name)
@@ -157,9 +150,24 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
     reply_seen: asyncio.Event = asyncio.Event()
     reply_seen.set()
 
-    inputs = asyncio.create_task(
-        _input_loop(registry, prompt_session, renderer, reply_seen)
-    )
+    # Interactive TTY inline renderer → its own rule-bar Application input
+    # driver. --cui / non-TTY (pipe / script) keep the PromptSession `_input_loop`
+    # (plain invariance + the piped reply_seen pacing). _output_loop is shared:
+    # run_in_terminal prints above whichever input is live.
+    if renderer.uses_app_input() and sys.stdin.isatty():
+        from reyn.interfaces.inline.app import run_inline_input
+        inputs = asyncio.create_task(run_inline_input(registry, renderer))
+    else:
+        from prompt_toolkit.styles import Style
+        prompt_session: PromptSession[str] = PromptSession(
+            history=FileHistory(str(history_path)),
+            # Working-indicator toolbar as a dim status line, not the default
+            # heavy reversed bar.
+            style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
+        )
+        inputs = asyncio.create_task(
+            _input_loop(registry, prompt_session, renderer, reply_seen)
+        )
     outputs = asyncio.create_task(
         _output_loop(registry, renderer, reply_seen)
     )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3564,6 +3564,14 @@ class Session:
                 await self._handle_hook_message(payload)
         finally:
             self._turn_idle.set()
+            # Symmetric turn-end lifecycle event. turn_completed fires only on
+            # the router path; turn_settled fires for EVERY turn kind (including
+            # slash / intervention short-circuits that return before the router),
+            # giving UI working-indicators driven by turn_started a reliable
+            # clear signal regardless of how the turn ended.
+            self._chat_events.emit(
+                "turn_settled", kind=kind, chain_id=payload.get("chain_id"),
+            )
         self._maybe_schedule_ephemeral_vanish()
         return True
 

--- a/tests/test_inline_pr3a_app.py
+++ b/tests/test_inline_pr3a_app.py
@@ -1,0 +1,70 @@
+"""Tier 2: inline app input driver — working-row fragments + input-path routing flag.
+
+The Application itself is an interactive driver verified live (e2e); here we pin
+the pure fragment builder and the renderer capability flag that selects the app
+input path. Assertions are on public return values, not whitespace/private state.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from reyn.interfaces.inline.app import working_line
+from reyn.interfaces.repl.renderer import (
+    ChatRenderer,
+    ConsoleChatRenderer,
+    InlineChatRenderer,
+)
+from reyn.schemas.models import Event
+
+
+def _evt(t: str) -> Event:
+    return Event(type=t, timestamp=datetime.now(timezone.utc), data={})
+
+
+def test_working_line_idle_is_empty() -> None:
+    """Tier 2: no working row when a turn is not running."""
+    assert working_line(False, 0.0, 5.0) == []
+
+
+def test_working_line_running_has_spinner_and_label() -> None:
+    """Tier 2: while running, the row carries a spinner glyph + 'Working…'."""
+    frags = working_line(True, 0.0, 3.0)
+    text = "".join(t for _, t in frags)
+    assert "Working" in text
+    assert "3s" in text          # elapsed = now - start
+    assert text.strip()[0] not in ("W",)  # a spinner glyph leads, not the label
+
+
+def test_working_line_elapsed_tracks_now_minus_start() -> None:
+    """Tier 2: elapsed seconds = floor(now - think_start)."""
+    text = "".join(t for _, t in working_line(True, 10.0, 17.4))
+    assert "7s" in text
+
+
+def test_working_line_never_negative_elapsed() -> None:
+    """Tier 2: a clock skew (now < start) clamps elapsed to 0, not negative."""
+    text = "".join(t for _, t in working_line(True, 10.0, 9.0))
+    assert "0s" in text
+    assert "-" not in text
+
+
+def test_inline_renderer_selects_app_input() -> None:
+    """Tier 2: the interactive inline renderer drives input via its own app."""
+    assert InlineChatRenderer().uses_app_input() is True
+
+
+def test_plain_renderers_keep_promptsession_path() -> None:
+    """Tier 2: plain / base renderers stay on the PromptSession _input_loop."""
+    assert ConsoleChatRenderer().uses_app_input() is False
+    assert ChatRenderer().uses_app_input() is False
+
+
+def test_turn_settled_clears_indicator_after_short_circuit_turn() -> None:
+    """Tier 2: turn_settled clears the working indicator even when no
+    turn_completed fired (slash / intervention short-circuit paths)."""
+    r = InlineChatRenderer()
+    r.on_chat_event(_evt("turn_started"))
+    assert r.bottom_toolbar() is not None
+    # A slash turn ends with turn_settled (no turn_completed) — must clear.
+    r.on_chat_event(_evt("turn_settled"))
+    assert r.bottom_toolbar() is None


### PR DESCRIPTION
**[tui-coder]** — PR3a of the inline CUI track (design #2200, lead-coder GO with PR3a/3b split). Lands the load-bearing **input-driver swap**: interactive inline now runs its own prompt_toolkit `Application` (rule-bar input + animated working row). The navigable status menu + dropdowns are PR3b.

## Changes
- **`reyn/interfaces/inline/app.py`** — `run_inline_input(registry, renderer)`: long-lived `Application` (`HSplit([working_row, top_rule, inputrow, bottom_rule, hint])`, `refresh_interval=0.1`, `app.run_async()`). Enter → `submit_user_text` (the app never inspects the text; intervention/slash/new-turn route inside the session unchanged); `/quit` `/exit` + `Ctrl-C/D/Q` → `registry.shutdown()` + `app.exit()`. `patch_stdout` so stray library stdout (e.g. litellm warnings) prints above the live region.
- **`run_repl`** branches on `renderer.uses_app_input()` (InlineChatRenderer=True) + `sys.stdin.isatty()`; else the existing PromptSession `_input_loop`. `_output_loop` unchanged (run_in_terminal prints above the live app — verified).
- **Pure `working_line()`** fragment builder → Tier 2 tested; the Application itself is verified live (e2e).

## ⚠️ Flag for review — a small CORE change beyond the input-driver scope
PR3a's prominent working row surfaced a **bug inherited from PR2**: `turn_started` had no symmetric clear on **slash / intervention short-circuit** paths (they return before the router, so `turn_completed` never fires) → the spinner stuck "Working… Ns" forever after `/model` etc.

Fix (minimal, invariant-enforced):
- `session.run_one_iteration()` finally emits a new **`turn_settled`** event — fires for *every* turn kind (paired with `turn_started`).
- Declared in `EVENT_AUDIT_REQUIREMENTS` (the FP-0021 audit-completeness invariant requires every emitted event be declared; `test_event_audit_invariants` passes).
- `InlineChatRenderer.on_chat_event` clears the indicator on `turn_settled` (keeps `turn_completed`/`turn_cancelled` as belt-and-suspenders).

I judged this in-scope for PR3a because the working row is unusable without it, but it touches the event contract — please confirm you're OK with it landing here vs split. (It also fixes the latent PR2 indicator-stuck bug.)

## Test plan
- [x] e2e (litellm proxy): rule-bar Application launches; Enter → reply renders above input; `/model` slash transparent; **indicator clears after slash** (was stuck pre-fix); normal turn `⏺ 391`; `/quit` → cost summary + clean exit; stray litellm warning printed cleanly (patch_stdout)
- [x] `--cui` plain unaffected (`agent> pong` + cost, PromptSession path)
- [x] turn_settled satisfies FP-0021 audit-completeness + lifecycle tests (7) green
- [x] 4 gates: ruff `src tests` / verify_module_docstrings / tier-audit `--strict` / 32 inline+lifecycle tests

**Tier self-check**: `test_inline_pr3a_app.py` is Tier 2 — pure `working_line()` returns + `uses_app_input()` flag + `on_chat_event`→`bottom_toolbar()` public surface, real `Event` instances, no mocks / private-state / format-pin.

## Known limitations (follow-ups)
- Working row text is "Working… Ns"; `esc to interrupt` is not yet wired (turn cancellation) — follow-up.
- Single-agent indicator scope; agent-switch re-subscribe — follow-up.
- PR3b: navigable status menu (↓ to menu, ←→ select, model/agents/skills/cost/context dropdowns) — sync data only per #2200 review (dynamic task-count poller deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
