### PR TITLE
feat(tui): inline CUI navigable status menu (#2200 PR3b)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -1,24 +1,27 @@
 """Claude Code-style interactive input driver for the inline CUI.
 
 A long-lived prompt_toolkit Application that drives input for the interactive
-(TTY) inline renderer: a rule-bar sandwiched input plus an animated working row.
+(TTY) inline renderer: a rule-bar sandwiched input, an animated working row, and
+a navigable status menu (↓ to focus, ←→ to select a chip, enter to open a
+read-only detail dropdown, ↑/esc to go back).
 
 Integration: run_repl's `_output_loop` prints conversation output ABOVE this app
 via `run_in_terminal` (the app stays a live region at the bottom); user input is
 fed to the session via `submit_user_text`, so intervention answers / slash
 commands / new turns route through the session exactly as the PromptSession path
-did — the app never inspects the text. The navigable status menu + dropdowns are
-a follow-up (PR3b); this lands the input-driver swap with a static hint line.
+did — the app never inspects the text.
 
 `--cui` / non-TTY keep the existing PromptSession `_input_loop` (plain invariance).
+The status menu reads live values through public sync accessors only; an
+actionable model picker (selecting a class) is a follow-up.
 """
 from __future__ import annotations
 
 import time
 
-from prompt_toolkit.application import Application
+from prompt_toolkit.application import Application, get_app
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.filters import Condition, has_focus
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import (
@@ -29,9 +32,13 @@ from prompt_toolkit.layout import (
     Window,
 )
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.patch_stdout import patch_stdout
 
-from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _SPINNER
+from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
+
+# Status-row chips, in display order.
+_CHIPS = ["model", "agents", "skills", "cost", "ctx"]
 
 
 def working_line(thinking: bool, think_start: float, now: float) -> list:
@@ -50,6 +57,59 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
     ]
 
 
+def status_chips(model: str, n_agents: int, n_skills: int, cost_usd: float,
+                 total_tokens: int) -> list:
+    """Pure: (label, value) status chips from plain live values."""
+    ctx = f"{total_tokens // 1000}k" if total_tokens >= 1000 else str(total_tokens)
+    return [
+        ("model", str(model)),
+        ("agents", str(n_agents)),
+        ("skills", str(n_skills)),
+        ("cost", f"${cost_usd:.4f}"),
+        ("ctx", ctx),
+    ]
+
+
+def dropdown_lines(label: str, *, model: str, agent_names: list, attached_name,
+                   skill_run_ids: list, usage: tuple, cost_usd: float) -> list:
+    """Pure: read-only detail lines for an opened status chip.
+
+    Lines starting with ``▸`` mark the focused/attached entry. `usage` is
+    ``(prompt, completion, total)`` token counts.
+    """
+    if label == "agents":
+        if not agent_names:
+            return ["(none)"]
+        return [f"▸ {n}" if n == attached_name else f"  {n}" for n in agent_names]
+    if label == "skills":
+        return [f"  {r}" for r in skill_run_ids] or ["(no running skills)"]
+    if label in ("cost", "ctx"):
+        p, c, t = usage
+        return [
+            f"prompt {p}", f"completion {c}", f"total {t}",
+            f"cost ${cost_usd:.4f}",
+        ]
+    if label == "model":
+        return [f"current: {model}", "change with /model"]
+    return ["(no detail)"]
+
+
+def _snapshot(registry):
+    """Read live status values off the attached session via sync accessors."""
+    s = registry.attached_session()
+    if s is None:
+        return None
+    u = s.total_usage
+    return {
+        "model": s.model,
+        "agent_names": list(registry.loaded_names()),
+        "attached_name": registry.attached_name,
+        "skill_run_ids": list(s.running_skills.keys()),
+        "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
+        "cost_usd": s.total_cost_usd,
+    }
+
+
 async def run_inline_input(registry, renderer) -> None:
     """Run the interactive inline input Application until the user quits.
 
@@ -59,8 +119,9 @@ async def run_inline_input(registry, renderer) -> None:
     attached = registry.attached_session()
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
     buf = Buffer(multiline=False, history=history)
+    menu = {"sel": 0, "open": False}
 
-    def _frags() -> list:
+    def _working_frags() -> list:
         return working_line(
             getattr(renderer, "_thinking", False),
             getattr(renderer, "_think_start", 0.0),
@@ -68,7 +129,7 @@ async def run_inline_input(registry, renderer) -> None:
         )
 
     working = ConditionalContainer(
-        Window(FormattedTextControl(_frags), height=1),
+        Window(FormattedTextControl(_working_frags), height=1),
         filter=Condition(lambda: getattr(renderer, "_thinking", False)),
     )
     top_rule = Window(height=1, char="─", style=f"fg:{_CC_DIM}")
@@ -78,28 +139,120 @@ async def run_inline_input(registry, renderer) -> None:
     )
     input_win = Window(BufferControl(buffer=buf), height=1)
     inputrow = VSplit([prompt_sym, input_win])
-    hint = Window(
-        FormattedTextControl([(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]),
-        height=1,
+
+    def _current_dropdown_lines(snap) -> list:
+        label = _CHIPS[menu["sel"]]
+        return dropdown_lines(
+            label, model=snap["model"], agent_names=snap["agent_names"],
+            attached_name=snap["attached_name"],
+            skill_run_ids=snap["skill_run_ids"], usage=snap["usage"],
+            cost_usd=snap["cost_usd"],
+        )
+
+    def status_fragments() -> list:
+        snap = _snapshot(registry)
+        if snap is None:
+            return [(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]
+        chips = status_chips(
+            snap["model"], len(snap["agent_names"]), len(snap["skill_run_ids"]),
+            snap["cost_usd"], snap["usage"][2],
+        )
+        focused = get_app().layout.has_focus(status_win)
+        frags: list = []
+        for i, (label, val) in enumerate(chips):
+            open_mark = " ▾" if (focused and menu["open"] and i == menu["sel"]) else ""
+            text = f" {label} {val}{open_mark} "
+            if focused and i == menu["sel"]:
+                frags.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", text))
+            else:
+                frags.append((f"fg:{_CC_DIM}", text))
+            frags.append(("", " "))
+        if not focused:
+            hint = "  [↓ menu · ↑ history · /quit]"
+        elif menu["open"]:
+            hint = "  [esc / ↑ close]"
+        else:
+            hint = "  [↑ input · ←→ select · enter open]"
+        frags.append((f"fg:{_CC_DIM}", hint))
+        return frags
+
+    status_win = Window(
+        FormattedTextControl(status_fragments, focusable=True), height=1
+    )
+
+    def dropdown_frags() -> list:
+        snap = _snapshot(registry)
+        if snap is None:
+            return []
+        out: list = []
+        for i, ln in enumerate(_current_dropdown_lines(snap)):
+            if i:
+                out.append(("", "\n"))
+            style = _CC_DONE if ln.startswith("▸") else _CC_DIM
+            out.append((f"fg:{style}", f"   {ln}"))
+        return out
+
+    def dropdown_height() -> Dimension:
+        snap = _snapshot(registry)
+        if snap is None:
+            return Dimension.exact(0)
+        return Dimension.exact(len(_current_dropdown_lines(snap)))
+
+    dropdown = ConditionalContainer(
+        Window(FormattedTextControl(dropdown_frags), height=dropdown_height),
+        filter=Condition(
+            lambda: menu["open"] and get_app().layout.has_focus(status_win)
+        ),
     )
 
     kb = KeyBindings()
 
-    @kb.add("enter")
+    @kb.add("enter", filter=has_focus(input_win))
     def _accept(event) -> None:
         text = buf.text
         buf.reset(append_to_history=True)
         stripped = text.strip()
         if not stripped:
             return
-        # /quit /exit are intercepted here (mirrors _input_loop) so they tear the
-        # REPL down rather than dispatching as a no-op slash. Everything else —
-        # plain text, intervention answers, other slash commands — flows through
-        # submit_user_text, which routes it inside the session unchanged.
+        # /quit /exit tear the REPL down (mirrors _input_loop); everything else —
+        # plain text, intervention answers, other slash — flows through
+        # submit_user_text and routes inside the session unchanged.
         if stripped in ("/quit", "/exit"):
             event.app.create_background_task(_quit(registry, event.app))
         else:
             event.app.create_background_task(_submit(registry, stripped))
+
+    @kb.add("down", filter=has_focus(input_win))
+    def _to_menu(event) -> None:
+        event.app.layout.focus(status_win)
+
+    @kb.add("up", filter=has_focus(status_win))
+    def _menu_up(event) -> None:
+        if menu["open"]:
+            menu["open"] = False
+        else:
+            event.app.layout.focus(input_win)
+
+    @kb.add("escape", filter=has_focus(status_win))
+    def _menu_esc(event) -> None:
+        if menu["open"]:
+            menu["open"] = False
+        else:
+            event.app.layout.focus(input_win)
+
+    @kb.add("left", filter=has_focus(status_win))
+    def _menu_left(event) -> None:
+        if not menu["open"]:
+            menu["sel"] = (menu["sel"] - 1) % len(_CHIPS)
+
+    @kb.add("right", filter=has_focus(status_win))
+    def _menu_right(event) -> None:
+        if not menu["open"]:
+            menu["sel"] = (menu["sel"] + 1) % len(_CHIPS)
+
+    @kb.add("enter", filter=has_focus(status_win))
+    def _menu_enter(event) -> None:
+        menu["open"] = not menu["open"]
 
     @kb.add("c-c")
     @kb.add("c-d")
@@ -107,7 +260,7 @@ async def run_inline_input(registry, renderer) -> None:
     def _quit_key(event) -> None:
         event.app.create_background_task(_quit(registry, event.app))
 
-    body = HSplit([working, top_rule, inputrow, bottom_rule, hint])
+    body = HSplit([working, top_rule, inputrow, bottom_rule, status_win, dropdown])
     app: Application = Application(
         layout=Layout(body, focused_element=input_win),
         key_bindings=kb,

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -1,0 +1,74 @@
+"""Tier 2: inline status-menu pure builders — chips + read-only dropdown lines.
+
+The navigable menu / focus handling is interactive (verified live, e2e); here we
+pin the pure data→display mapping that feeds the status row and each chip's
+read-only dropdown. Plain-value inputs keep these decoupled from the Session.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.app import dropdown_lines, status_chips
+
+
+def test_status_chips_has_five_labelled_values() -> None:
+    """Tier 2: the status row exposes model/agents/skills/cost/ctx with values."""
+    chips = status_chips("flash-lite", 2, 1, 0.0123, 12800)
+    labels = [lbl for lbl, _ in chips]
+    assert labels == ["model", "agents", "skills", "cost", "ctx"]
+    by = dict(chips)
+    assert by["model"] == "flash-lite"
+    assert by["agents"] == "2"
+    assert by["skills"] == "1"
+    assert by["cost"] == "$0.0123"
+
+
+def test_ctx_abbreviates_thousands_but_not_small_counts() -> None:
+    """Tier 2: ctx shows 'Nk' at >=1000 tokens, the raw count below."""
+    assert dict(status_chips("m", 0, 0, 0.0, 12800))["ctx"] == "12k"
+    assert dict(status_chips("m", 0, 0, 0.0, 500))["ctx"] == "500"
+
+
+def test_agents_dropdown_marks_attached() -> None:
+    """Tier 2: the agents panel marks the attached agent with ▸."""
+    lines = dropdown_lines(
+        "agents", model="m", agent_names=["default", "researcher"],
+        attached_name="default", skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
+    )
+    assert any(ln.startswith("▸") and "default" in ln for ln in lines)
+    assert any("researcher" in ln and not ln.startswith("▸") for ln in lines)
+
+
+def test_skills_dropdown_lists_runs_or_empty_message() -> None:
+    """Tier 2: skills panel lists run ids, or a clear empty message."""
+    lines = dropdown_lines(
+        "skills", model="m", agent_names=[], attached_name=None,
+        skill_run_ids=["run_abcd", "run_ef01"], usage=(0, 0, 0), cost_usd=0.0,
+    )
+    assert any("run_abcd" in ln for ln in lines)
+    empty = dropdown_lines(
+        "skills", model="m", agent_names=[], attached_name=None,
+        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
+    )
+    assert any("no running skills" in ln for ln in empty)
+
+
+def test_cost_dropdown_shows_token_breakdown() -> None:
+    """Tier 2: cost/ctx panel shows the prompt/completion/total breakdown."""
+    lines = dropdown_lines(
+        "cost", model="m", agent_names=[], attached_name=None,
+        skill_run_ids=[], usage=(100, 5, 105), cost_usd=0.01,
+    )
+    joined = " ".join(lines)
+    assert "prompt 100" in joined
+    assert "completion 5" in joined
+    assert "total 105" in joined
+
+
+def test_model_dropdown_shows_current_and_change_hint() -> None:
+    """Tier 2: model panel shows the current class + how to change it."""
+    lines = dropdown_lines(
+        "model", model="flash-lite", agent_names=[], attached_name=None,
+        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
+    )
+    joined = " ".join(lines)
+    assert "flash-lite" in joined
+    assert "/model" in joined


### PR DESCRIPTION
**[tui-coder]** — PR3b of the inline CUI track (design #2200, lead-coder GO for the sync-data scope). Adds the **navigable status menu** to the inline Application from PR3a.

## Changes (only `inline/app.py` + a new test)
- **Navigable status row**: ↓ focuses the menu, ←→ select a chip, enter opens a read-only detail dropdown, ↑/esc close / go back to input. Focus handled via `has_focus` key-binding filters; the input/submit path is untouched.
- **Live chips (public sync accessors)**: `model` (`session.model` class), `agents` (`len(registry.loaded_names())`), `skills` (`len(session.running_skills)`), `cost` (`session.total_cost_usd`), `ctx` (`session.total_usage` total, abbreviated `Nk`).
- **Read-only dropdowns**: agents → names with the attached one marked `▸`; skills → run ids (or empty message); cost/ctx → prompt/completion/total token breakdown; model → current class + "change with /model".
- Pure `status_chips()` / `dropdown_lines()` over **plain values** (decoupled from Session) → Tier 2 tested.

## Per #2200 review
- mode chip **dropped** (no backend accessor).
- model = **class name** (no `_resolver` exposure).
- dynamic task-count **poller deferred** (follow-up); chips use sync data only.

## Test plan
- [x] e2e (litellm proxy): status row shows live `model standard · agents 1 · skills 0 · cost $.. · ctx ..`; ↓ focuses, → selects `agents`, enter opens dropdown `▸ default` (attached marked); esc/↑ returns to input; input still works after (`⏺ 42`); chips update live (cost/ctx after a turn)
- [x] `--cui` plain unaffected (`agent> pong` + cost)
- [x] 4 gates: ruff `src tests` / verify_module_docstrings / tier-audit `--strict` / 31 inline tests (PR3b 6 + PR3a 7 + PR2 9 + cutover 9)

**Tier self-check**: `test_inline_pr3b_status_menu.py` is Tier 2 — pure builders over plain values, public return surfaces, no mocks / private-state / format-pin.

## Follow-ups
- **Actionable model picker** (select a class from the menu → `/model`) needs a public `known_model_classes()` accessor on Session (avoid `_resolver` exposure) — deferred.
- `esc to interrupt` (turn cancellation), agent-switch indicator re-subscribe, dynamic task-count poller, tool-result CC-style summaries, noise filter — tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
