### PR TITLE
feat(tui): inline CUI tool-result summaries + drop false esc affordance (#2205)

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -281,6 +281,46 @@ def _summarize_args(args) -> str:
     return _short(args)
 
 
+def summarize_tool_result(tool, result) -> str:
+    """Human one-line summary of a tool result (CC-style, e.g. ``Read 42 lines``).
+
+    Best-effort per tool name / result shape; ALWAYS degrades gracefully — any
+    unrecognised shape (or an error reading it) falls back to a truncated repr,
+    so it never raises and never loses the result entirely.
+    """
+    try:
+        return _summarize_result(tool, result)
+    except Exception:
+        return _short(result, 80)
+
+
+def _summarize_result(tool, result) -> str:
+    t = (tool or "").lower()
+    if result is None or result == "":
+        return "done"
+    if isinstance(result, list):
+        n = len(result)
+        word = "result" if "search" in t else "item"
+        return f"{n} {word}{'' if n == 1 else 's'}"
+    if isinstance(result, dict):
+        op = result.get("op")
+        path = result.get("path")
+        status = result.get("status")
+        if op == "read" or ("read" in t and "content" in result):
+            content = result.get("content")
+            if isinstance(content, str):
+                lines = content.count("\n") + (1 if content else 0)
+                more = " (truncated)" if status == "truncated" else ""
+                return f"Read {lines} lines{more}"
+        if op in ("write", "create"):
+            return f"Wrote {path}" if path else "Wrote file"
+        if op == "edit":
+            return f"Edited {path}" if path else "Edited file"
+        if status:
+            return str(status)
+    return _short(result, 80)
+
+
 def format_inline_message(msg: OutboxMessage):
     """Pure formatter: OutboxMessage → rich Text (the inline CC-style line).
 
@@ -302,9 +342,8 @@ def format_inline_message(msg: OutboxMessage):
             (" ⏺ ", _CC_ACCENT), (tool, "bold"), (f"({args})", _CC_DIM)
         )
     if kind == "tool_call_completed":
-        return Text.assemble(
-            ("   ⎿ ", _CC_DIM), (_short(meta.get("result"), 80), _CC_DIM)
-        )
+        summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
+        return Text.assemble(("   ⎿ ", _CC_DIM), (summary, _CC_DIM))
     if kind == "tool_call_failed":
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
         return Text.assemble(
@@ -379,7 +418,7 @@ class InlineChatRenderer(ChatRenderer):
         elapsed = int(time.monotonic() - self._think_start)
         return HTML(
             f'<style fg="{_CC_ACCENT}">{frame}</style> '
-            f'<style fg="{_CC_DIM}">Working… {elapsed}s · esc to interrupt</style>'
+            f'<style fg="{_CC_DIM}">Working… {elapsed}s</style>'
         )
 
     def uses_app_input(self) -> bool:

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -1,0 +1,68 @@
+"""Tier 2: tool-result summary — CC-style one-liners + graceful fallback.
+
+`summarize_tool_result` turns a raw op result into a human line (``Read 42
+lines``) per tool/shape, and ALWAYS degrades gracefully on an unknown / empty /
+oversized / malformed result (never raises, never dumps raw for a known shape).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.repl.renderer import summarize_tool_result
+
+
+def test_file_read_reports_line_count() -> None:
+    """Tier 2: a file read summarises to 'Read N lines'."""
+    out = summarize_tool_result(
+        "file__read", {"op": "read", "status": "ok", "content": "a\nb\nc"}
+    )
+    assert out == "Read 3 lines"
+
+
+def test_file_read_truncated_is_flagged() -> None:
+    """Tier 2: a truncated read says so."""
+    out = summarize_tool_result(
+        "file__read", {"op": "read", "status": "truncated", "content": "x\ny"}
+    )
+    assert "truncated" in out
+
+
+def test_file_write_and_edit_name_the_path() -> None:
+    """Tier 2: write / edit name the path."""
+    assert summarize_tool_result("file__write", {"op": "write", "path": "f.py"}) == "Wrote f.py"
+    assert summarize_tool_result("file__edit", {"op": "edit", "path": "g.py"}) == "Edited g.py"
+
+
+def test_web_search_counts_results() -> None:
+    """Tier 2: a search list summarises to 'N results'."""
+    assert summarize_tool_result("web__search", ["a", "b", "c"]) == "3 results"
+
+
+def test_generic_list_counts_items_with_pluralisation() -> None:
+    """Tier 2: a generic list → 'N items', singular for one."""
+    assert summarize_tool_result("anything", [1, 2]) == "2 items"
+    assert summarize_tool_result("anything", ["only"]) == "1 item"
+
+
+def test_dict_with_status_shows_status() -> None:
+    """Tier 2: an opaque dict with a status field shows the status."""
+    assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"
+
+
+def test_empty_or_none_reports_done() -> None:
+    """Tier 2: empty / None result → 'done', not a blank line."""
+    assert summarize_tool_result("x", None) == "done"
+    assert summarize_tool_result("x", "") == "done"
+
+
+def test_oversized_result_is_truncated_one_line() -> None:
+    """Tier 2: a huge / multiline result collapses to a truncated single line."""
+    out = summarize_tool_result("x", "z" * 500 + "\ntail")
+    assert "\n" not in out
+    assert "…" in out
+    assert "tail" not in out
+
+
+def test_unknown_shape_degrades_without_raising() -> None:
+    """Tier 2: a malformed/unknown result returns a string, never raises."""
+    weird = {"op": object(), "nested": [object()]}
+    out = summarize_tool_result("x", weird)
+    assert isinstance(out, str) and out  # some non-empty summary, no crash


### PR DESCRIPTION
**[tui-coder]** — follow-up ① of #2205 (lead-coder GO, ROI-high). Base = current main `cef12788` (master-adapted; task #2187 non-overlap, clean).

## Changes (renderer-only, pure)
- **Tool-result summaries**: `tool_call_completed` now renders a CC-style human line via a new pure `summarize_tool_result(tool, result)`:
  - file read → `Read N lines` (`(truncated)` when partial); write/edit → `Wrote {path}` / `Edited {path}`
  - search → `N results`; generic list → `N items` (singular for 1)
  - opaque dict with `status` → the status; **unknown / empty / oversized / malformed** → graceful truncated-repr fallback (never raises, never loses the result)
  - was: raw `⎿ {'kind':'file','op':'read',...}` → now: `⎿ Read 223 lines`
- **Honesty fix (per review)**: the working indicator said `Working… Ns · esc to interrupt` but **no esc→turn-interrupt wiring exists** (false affordance). Dropped the `· esc to interrupt` text; it returns when esc-interrupt is actually wired (promoted to the next follow-up ②).

## Test plan
- [x] e2e (litellm proxy): `read pyproject.toml` → `⎿ Read 223 lines`; working row shows `Working… Ns` (no false esc affordance)
- [x] graceful fallback: unknown/empty/huge/malformed shapes summarised without raising (Tier 2)
- [x] no regression: PR2 tool-row + indicator tests still green (string results still summarise correctly via fallback)
- [x] 4 gates: ruff `src tests` / verify_module_docstrings / tier-audit `--strict` / 40 inline tests

**Tier self-check**: `test_inline_tool_result_summary.py` is Tier 2 — pure `summarize_tool_result()` over plain values incl. unknown/empty/huge edges, public return surface, no mocks / private-state / format-pin.

## Next (#2205 backlog)
② esc-interrupt (promoted high — wires real turn cancellation, restores the text), then ③ model picker / ④ right-panel tabs / ⑤ noise-filter, ROI order, 1 follow-up = 1 plan-first PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
