### PR TITLE
fix(tui): inline CUI leaked log tracebacks + litellm banners into the chat UI

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -218,6 +218,36 @@ def _reset_project_state(project_root: Path, *, confirm: bool = True) -> bool:
     return True
 
 
+def _setup_interactive_logging(project_root: Path) -> None:
+    """Route root-logger output to .reyn/logs/reyn.log for the interactive CUI.
+
+    The inline CUI owns the terminal; a log record reaching a StreamHandler
+    (stderr) would print into the live chat region — at best noise (litellm
+    warnings), at worst an alarming full traceback from a caught error. Sending
+    logs to a file keeps the UI clean while preserving them for debugging. Called
+    once, before load_project_context (which may emit WARNING records), so the
+    file handler is in place before the first log call.
+    """
+    import logging
+    log_dir = project_root / ".reyn" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        filename=str(log_dir / "reyn.log"),
+        level=logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,  # safe: the interactive path has no prior logging setup
+    )
+    # litellm prints its own banners ("Give Feedback / Get Help", "LiteLLM.Info")
+    # directly to stderr on a provider error — NOT via logging, so the file
+    # redirect above does not catch them. Suppress them so a provider error
+    # surfaces as just our clean classified message, not a wall of litellm noise.
+    try:
+        import litellm
+        litellm.suppress_debug_info = True
+    except Exception:  # noqa: BLE001 — best-effort; never block startup on this
+        pass
+
+
 def run(args: argparse.Namespace) -> None:
     from reyn.config import _find_project_root, load_project_context
     from reyn.core.events.state_log import StateLog
@@ -241,6 +271,16 @@ def run(args: argparse.Namespace) -> None:
     safety = session_cfg.safety_for(args)
 
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
+
+    # The interactive inline CUI owns the terminal as a live region. Route the
+    # root logger to a file so library warnings and caught-exception tracebacks
+    # (e.g. an LLM APIConnectionError that session.py logs via logger.exception)
+    # don't leak into — and corrupt/alarm — the chat UI. --cui / non-TTY keep
+    # logging on stderr (debuggable / pipeable). Set before config load so early
+    # WARNING records are captured. (Restores the redirect the Textual TUI had;
+    # dropped in the inline-CUI cutover #2195.)
+    if not getattr(args, "cui", False) and sys.stdin.isatty():
+        _setup_interactive_logging(project_root)
 
     # PR-resume-ux β U3: handle --reset before constructing state_log so
     # we don't open a freshly-written WAL just to delete it.

--- a/tests/test_inline_interactive_logging.py
+++ b/tests/test_inline_interactive_logging.py
@@ -1,0 +1,47 @@
+"""Tier 2: interactive CUI routes logging to a file (no traceback leak into UI).
+
+The inline CUI owns the terminal; a caught-error traceback logged via
+logger.exception (or a litellm banner) must NOT print into the live chat region.
+`_setup_interactive_logging` redirects the root logger to .reyn/logs/reyn.log and
+quiets litellm's direct banners. Global logging/litellm state is saved+restored
+so the assertion does not leak into the rest of the suite.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+
+
+def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
+    """Tier 2: a WARNING record lands in .reyn/logs/reyn.log, not on stderr."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+        targets = [getattr(h, "baseFilename", None) for h in root.handlers]
+        assert str(log_file) in targets  # a FileHandler now targets the reyn log
+
+        logging.getLogger("reyn.canary").warning("canary-marker-7f3a")
+        for h in root.handlers:
+            h.flush()
+        assert "canary-marker-7f3a" in log_file.read_text()
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_interactive_logging_quiets_litellm_banners(tmp_path) -> None:
+    """Tier 2: litellm's direct stderr banners are suppressed for the CUI."""
+    import litellm
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    saved_suppress = getattr(litellm, "suppress_debug_info", False)
+    try:
+        _setup_interactive_logging(tmp_path)
+        assert litellm.suppress_debug_info is True
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        litellm.suppress_debug_info = saved_suppress


### PR DESCRIPTION
**[tui-coder]** — **urgent fix for an owner-reported regression** (base = current main `e0924d45`). The owner ran `reyn chat` in a dogfood checkout and on an LLM provider error the UI "behaved oddly / wouldn't stop".

## Root cause (my #2195 cutover regression)
The inline-CUI cutover (#2195) removed the Textual TUI's `_setup_pre_tui_logging` (which routed the root logger to a file). Without it, the **interactive inline CUI printed root-logger output directly into the live chat region**. On an LLM error, `session.py:_handle_user_message` catches it and calls `logger.exception(...)` — which dumped a **full Python traceback** into the UI. litellm **also** prints "Give Feedback / Get Help" / "LiteLLM.Info" banners **directly to stderr** (not via logging), flooding the UI further. The user got a wall of traceback+banners instead of the clean classified error — looking broken/hung.

## Fix (restore redirect for the interactive path only)
- `_setup_interactive_logging(project_root)`: route root logger → `.reyn/logs/reyn.log` (caught-error tracebacks / lib warnings stay out of the UI, preserved for debugging) + `litellm.suppress_debug_info = True` (its banners print directly, not via logging).
- Called only when interactive (`not --cui and isatty()`). `--cui` / non-TTY keep stderr logging (debuggable / pipeable). Mirrors the pre-cutover Textual behaviour.

## Reproduction & verification (litellm proxy on a dead port → APIConnectionError)
- **Before**: full `litellm.InternalServerError` traceback + ~6× "Give Feedback / Get Help" banners in the chat region.
- **After**: just `✗ router failed: [provider error] litellm.InternalServerError: … Connection error. LiteLLM Retried: 1 times • retry or check provider status` — clean, actionable; full traceback now in `.reyn/logs/reyn.log` (verified 3 error lines).
- `/quit` exits cleanly (~3s drain); `--cui` unaffected.

## Note on "wouldn't stop"
I could **not** reproduce a separate process-hang: `/quit` (and Ctrl-C/D/Q) tear down cleanly in every test, including quitting mid-retry. The "止まらない" was most likely the traceback/banner flood making the UI look stuck. If a true hang recurs after this fix, I'll dig further with the exact repro.

## Test plan
- [x] e2e: APIConnectionError → clean `✗ router failed: …` (no traceback, no banners); traceback in `.reyn/logs/reyn.log`; `/quit` exits
- [x] `--cui` plain unaffected; chat flag tests (7) green
- [x] Tier 2: `_setup_interactive_logging` redirects a WARNING to the log file + sets litellm suppress (global logging state saved/restored for isolation)
- [x] 4 gates: ruff / verify_module_docstrings / tier-audit `--strict` / tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
