### PR TITLE
fix(runtime): registry.shutdown force-cancels a turn stuck mid-LLM-call so /quit can't hang

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -60,6 +60,12 @@ from .profile import PROFILE_FILENAME, AgentProfile
 from .topology import TOPOLOGY_DIRNAME, Topology, _validate_topology_name
 
 DEFAULT_AGENT_NAME = "default"
+
+# shutdown() grace window: how long to let session.run loops drain cooperatively
+# (notice the shutdown sentinel at a turn boundary) before hard-cancelling any
+# that are still stuck — e.g. blocked mid-LLM-call on a slow/hung provider, which
+# never reaches the boundary to see the sentinel. Keeps /quit from hanging.
+_SHUTDOWN_GRACE_S = 3.0
 # FP-0043 Stage 3: the implicit per-agent session id. Single-session paths
 # resolve to this id, keeping N=1 behaviour byte-identical. Spawned sessions get
 # generated ids (Stage 4 routes inbound messages to non-default sessions).
@@ -2696,18 +2702,38 @@ class AgentRegistry:
         return out
 
     async def shutdown(self) -> None:
-        """Best-effort: stop all loaded sessions, then await tasks."""
+        """Best-effort: stop all loaded sessions, then await/cancel their tasks.
+
+        Cooperative first: each session.run loop notices the shutdown sentinel
+        (agent.shutdown) at its next turn boundary; a short grace window lets a
+        non-stuck session drain that way (the common idle / fast-turn /quit is
+        unaffected — the sentinel is processed well within the grace). Any run
+        task still alive after the grace is *stuck* — e.g. blocked mid-LLM-call on
+        a slow/hung provider that never reaches the boundary to see the sentinel —
+        so it is hard-cancelled. The CancelledError lands on the `acompletion`
+        await (a safe cancel point: completed turns already wrote their WAL /
+        history inline, and the cancelled turn simply didn't complete — no partial
+        write), so shutdown always returns instead of hanging on /quit.
+        """
         for name, agent in self._iter_named_sessions():
             try:
                 await agent.shutdown()
             except Exception as exc:
                 logger.warning("agent shutdown failed for %r: %s", name, exc)
-        # Cancel forwarders so they don't block on a queue that won't refill
+        # Cancel forwarders so they don't block on a queue that won't refill.
         for t in self._forward_tasks.values():
             if not t.done():
                 t.cancel()
-        if self.running_tasks():
-            await asyncio.gather(*self.running_tasks(), return_exceptions=True)
+        tasks = self.running_tasks()
+        if not tasks:
+            return
+        # Cooperative grace, then hard-cancel any straggler (cancelled forwarders
+        # finish immediately; a stuck session.run lands in `pending`).
+        _done, pending = await asyncio.wait(tasks, timeout=_SHUTDOWN_GRACE_S)
+        for t in pending:
+            t.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
     def loaded_names(self) -> list[str]:
         return list(self._sessions.keys())

--- a/tests/test_shutdown_force_cancel.py
+++ b/tests/test_shutdown_force_cancel.py
@@ -1,0 +1,56 @@
+"""Tier 2: registry.shutdown hard-cancels a stuck run task so /quit can't hang.
+
+A session.run task blocked mid-LLM-call (slow/hung provider) never reaches the
+turn boundary to see the cooperative shutdown sentinel. Before the fix,
+shutdown awaited it forever (the owner-reported /quit hang). Now shutdown gives a
+short grace, then hard-cancels the straggler. This injects a never-completing run
+task and asserts shutdown returns promptly (it would TimeoutError if it hung) and
+the stuck task is cancelled.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import reyn.runtime.registry as registry_mod
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    # session_factory is never invoked here — no session is spawned; we inject a
+    # stuck run task directly to model "a turn blocked mid-LLM-call".
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda profile: None,
+        state_log=state_log,
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_force_cancels_a_stuck_run_task(tmp_path) -> None:
+    """Tier 2: shutdown returns (grace + hard-cancel) instead of hanging on a
+    run task that never completes; the stuck task ends up cancelled."""
+    reg = _registry(tmp_path)
+    saved_grace = registry_mod._SHUTDOWN_GRACE_S
+    registry_mod._SHUTDOWN_GRACE_S = 0.05  # short grace → fast, deterministic test
+    stuck = asyncio.ensure_future(asyncio.Event().wait())  # never completes
+    reg._tasks[("stuck", "main")] = stuck
+    try:
+        # wait_for raises TimeoutError if shutdown hangs (the pre-fix behaviour).
+        await asyncio.wait_for(reg.shutdown(), timeout=2.0)
+        assert stuck.cancelled()
+    finally:
+        registry_mod._SHUTDOWN_GRACE_S = saved_grace
+        if not stuck.done():
+            stuck.cancel()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_returns_quickly_when_no_tasks(tmp_path) -> None:
+    """Tier 2: the common path (nothing running) returns without waiting the
+    grace — no added /quit latency for an idle session."""
+    reg = _registry(tmp_path)
+    await asyncio.wait_for(reg.shutdown(), timeout=1.0)


### PR DESCRIPTION
**[tui-coder]** — owner-reported 真 hang の root-cause fix（場当たりでなく正しい修正）。lead-coder の PR-A assignment（broker, 4 review-critical 点）に対応。

## Root cause

`AgentRegistry.shutdown()` は agent.shutdown()（cooperative sentinel）を出した後、forwarders は cancel するが **session.run tasks は `await asyncio.gather(...)` で待つだけ＝cancel しない**。LLM call (`acompletion`) で stuck したターンは turn 境界に到達せず sentinel を見ないため、`gather` が永久 await → `/quit` が force-quit できず hang（owner の「止まらない」, 実測 137s 後も解けず）。#2208 の log-flood とは別の真 hang。

## Fix（graceful-first → hard-cancel）

```python
tasks = self.running_tasks()
if not tasks:
    return
# Cooperative grace, then hard-cancel any straggler.
_done, pending = await asyncio.wait(tasks, timeout=_SHUTDOWN_GRACE_S)  # 3.0s
for t in pending:
    t.cancel()
if pending:
    await asyncio.gather(*pending, return_exceptions=True)
```

`_SHUTDOWN_GRACE_S = 3.0`（module const, sensible default）。

## lead-coder review-critical 4 点

1. **graceful-first** — 即 hard-cancel せず grace 内で sentinel 到達を待つ。committed op / 非 stuck の fast-turn は猶予内に drain（common path 不変）。
2. **state-safety** — hard-cancel は `acompletion` await（safe cancel point）に CancelledError が落ちる。完了済ターンは WAL/history を inline 書込済、cancel されたターンは「完了しなかった」だけで partial-write なし。crash-recovery が controlled-cancel を吸収。
3. **web/mcp/--cui 回帰なし** — 非 stuck の graceful path（grace 内 drain）は従来と同挙動。idle / fast-turn /quit に追加 latency なし（no-task は即 return）。
4. **falsify** — fix を旧 unconditional gather に戻すと stuck-task test が `TimeoutError`（= hang 再現）、fix 復元で pass。決定的に確認済。

## Test plan

- [x] Tier 2 `tests/test_shutdown_force_cancel.py`（2 tests）: stuck run task inject → shutdown が grace 内 return + cancel（hang なら `wait_for` TimeoutError で fail）／ idle path（no tasks）は grace 待たず即 return
- [x] falsify: fix revert → stuck test `TimeoutError`、restore → pass（reverse-edit、git checkout 不使用）
- [x] registry/session lifecycle 回帰: 45 passed（multi_session / restore / cache / session_drop / lifecycle_emit / run_registry_persist / scoped_session_factory_invariant）
- [x] 非 stuck `--cui` /quit 不変（fast `agent> pong` + cost summary、追加 latency なし）
- [ ] (skipped — non-deterministic) 実 137s gemini slow-response の e2e 再現は不安定（fake hang server は litellm/httpx が ~2s で timeout し stuck しない、active iterating turn は fast-exit）。決定的 unit test で代替。

## Tier self-check

Tier 2 のみ。format-pin（`len()<N`）/ mock / private-state assert なし。`_tasks` への代入は scenario **setup**（assertion でない）、assert は `stuck.cancelled()`（public task API）+ shutdown-returns-fast（behavior）。`--strict` audit green。

CI 4 gate local green: ruff / verify_module_docstrings / test_tier_audit --strict / pytest。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
