### PR TITLE
feat(inline): #2205 ③ actionable model picker in the status menu

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -39,6 +39,21 @@ from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNE
 
 # Status-row chips, in display order.
 _CHIPS = ["model", "agents", "skills", "cost", "ctx"]
+# Chips whose dropdown is an actionable picker (↑↓ a row, enter applies) rather
+# than a read-only detail panel. Today only the model picker.
+_ACTIONABLE = frozenset({"model"})
+
+
+def model_switch_text(model_classes: list, row: int) -> str | None:
+    """Pure: the slash command a model-picker Enter submits for the row.
+
+    Returns ``/model <class>`` for an in-range row, or None (out of range /
+    empty list) so the caller submits nothing. The switch itself — cost-warn
+    confirm, budget rebuild — is the existing ``/model`` slash path.
+    """
+    if 0 <= row < len(model_classes):
+        return f"/model {model_classes[row]}"
+    return None
 
 
 def working_line(thinking: bool, think_start: float, now: float) -> list:
@@ -71,11 +86,14 @@ def status_chips(model: str, n_agents: int, n_skills: int, cost_usd: float,
 
 
 def dropdown_lines(label: str, *, model: str, agent_names: list, attached_name,
-                   skill_run_ids: list, usage: tuple, cost_usd: float) -> list:
-    """Pure: read-only detail lines for an opened status chip.
+                   skill_run_ids: list, usage: tuple, cost_usd: float,
+                   model_classes: list | None = None) -> list:
+    """Pure: detail/picker lines for an opened status chip.
 
-    Lines starting with ``▸`` mark the focused/attached entry. `usage` is
-    ``(prompt, completion, total)`` token counts.
+    Lines starting with ``▸`` mark the focused/attached/current entry. `usage` is
+    ``(prompt, completion, total)`` token counts. For ``model`` the lines are the
+    selectable classes (current marked ``▸``); with no configured classes it
+    falls back to the read-only current-model hint.
     """
     if label == "agents":
         if not agent_names:
@@ -90,7 +108,9 @@ def dropdown_lines(label: str, *, model: str, agent_names: list, attached_name,
             f"cost ${cost_usd:.4f}",
         ]
     if label == "model":
-        return [f"current: {model}", "change with /model"]
+        if not model_classes:
+            return [f"current: {model}", "change with /model"]
+        return [f"▸ {c}" if c == model else f"  {c}" for c in model_classes]
     return ["(no detail)"]
 
 
@@ -102,6 +122,7 @@ def _snapshot(registry):
     u = s.total_usage
     return {
         "model": s.model,
+        "model_classes": list(s.known_model_classes()),
         "agent_names": list(registry.loaded_names()),
         "attached_name": registry.attached_name,
         "skill_run_ids": list(s.running_skills.keys()),
@@ -119,7 +140,9 @@ async def run_inline_input(registry, renderer) -> None:
     attached = registry.attached_session()
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
     buf = Buffer(multiline=False, history=history)
-    menu = {"sel": 0, "open": False}
+    # sel: which chip; open: detail/picker shown; row: cursor within an
+    # actionable picker (model). row is reset to 0 when a picker opens.
+    menu = {"sel": 0, "open": False, "row": 0}
 
     def _working_frags() -> list:
         return working_line(
@@ -146,7 +169,7 @@ async def run_inline_input(registry, renderer) -> None:
             label, model=snap["model"], agent_names=snap["agent_names"],
             attached_name=snap["attached_name"],
             skill_run_ids=snap["skill_run_ids"], usage=snap["usage"],
-            cost_usd=snap["cost_usd"],
+            cost_usd=snap["cost_usd"], model_classes=snap["model_classes"],
         )
 
     def status_fragments() -> list:
@@ -169,6 +192,8 @@ async def run_inline_input(registry, renderer) -> None:
             frags.append(("", " "))
         if not focused:
             hint = "  [↓ menu · ↑ history · /quit]"
+        elif menu["open"] and _CHIPS[menu["sel"]] in _ACTIONABLE:
+            hint = "  [↑↓ select · enter switch · esc close]"
         elif menu["open"]:
             hint = "  [esc / ↑ close]"
         else:
@@ -184,12 +209,17 @@ async def run_inline_input(registry, renderer) -> None:
         snap = _snapshot(registry)
         if snap is None:
             return []
+        actionable = _CHIPS[menu["sel"]] in _ACTIONABLE
         out: list = []
         for i, ln in enumerate(_current_dropdown_lines(snap)):
             if i:
                 out.append(("", "\n"))
-            style = _CC_DONE if ln.startswith("▸") else _CC_DIM
-            out.append((f"fg:{style}", f"   {ln}"))
+            if actionable and i == menu["row"]:
+                # picker cursor: reverse-highlight the selectable row
+                out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
+            else:
+                style = _CC_DONE if ln.startswith("▸") else _CC_DIM
+                out.append((f"fg:{style}", f"   {ln}"))
         return out
 
     def dropdown_height() -> Dimension:
@@ -226,12 +256,26 @@ async def run_inline_input(registry, renderer) -> None:
     def _to_menu(event) -> None:
         event.app.layout.focus(status_win)
 
+    def _actionable_open() -> bool:
+        return menu["open"] and _CHIPS[menu["sel"]] in _ACTIONABLE
+
     @kb.add("up", filter=has_focus(status_win))
     def _menu_up(event) -> None:
-        if menu["open"]:
+        # In an open picker, ↑ moves the cursor up; at the top row it closes.
+        if _actionable_open() and menu["row"] > 0:
+            menu["row"] -= 1
+        elif menu["open"]:
             menu["open"] = False
         else:
             event.app.layout.focus(input_win)
+
+    @kb.add("down", filter=has_focus(status_win))
+    def _menu_down(event) -> None:
+        if _actionable_open():
+            snap = _snapshot(registry)
+            n = len(snap["model_classes"]) if snap else 0
+            if n:
+                menu["row"] = min(menu["row"] + 1, n - 1)
 
     @kb.add("escape", filter=has_focus(status_win))
     def _menu_esc(event) -> None:
@@ -252,7 +296,19 @@ async def run_inline_input(registry, renderer) -> None:
 
     @kb.add("enter", filter=has_focus(status_win))
     def _menu_enter(event) -> None:
-        menu["open"] = not menu["open"]
+        # Read-only chip: enter toggles the detail panel. Actionable picker:
+        # when open, enter applies the cursor row via the existing /model slash
+        # path (cost-warn + budget rebuild reused); when closed, it opens.
+        if _actionable_open():
+            snap = _snapshot(registry)
+            classes = snap["model_classes"] if snap else []
+            text = model_switch_text(classes, menu["row"])
+            if text is not None:
+                event.app.create_background_task(_submit(registry, text))
+            menu["open"] = False
+        else:
+            menu["open"] = not menu["open"]
+            menu["row"] = 0
 
     @kb.add("c-c")
     @kb.add("c-d")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1968,6 +1968,15 @@ class Session:
     def model(self) -> str:
         return self._model_override if self._model_override is not None else self._agent.model
 
+    def known_model_classes(self) -> list[str]:
+        """Operator-configured model classes selectable via ``/model <class>``.
+
+        The same list ``/model`` (no-arg) prints under ``available:``. Lets a UI
+        offer an actionable model picker without reaching into the resolver; the
+        switch itself stays the ``/model`` slash path (cost-warn + budget rebuild).
+        """
+        return self._resolver.known_classes()
+
     def _rebuild_turn_budget_engine_for_model(self) -> None:
         """#1752: rebuild the chat turn_budget engine for the active model.
 

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -1,12 +1,17 @@
-"""Tier 2: inline status-menu pure builders — chips + read-only dropdown lines.
+"""Tier 2: inline status-menu pure builders — chips + dropdown lines + picker.
 
 The navigable menu / focus handling is interactive (verified live, e2e); here we
-pin the pure data→display mapping that feeds the status row and each chip's
-read-only dropdown. Plain-value inputs keep these decoupled from the Session.
+pin the pure data→display mapping that feeds the status row, each chip's detail
+dropdown, and the model picker's row→/model command. Plain-value inputs keep
+these decoupled from the Session.
 """
 from __future__ import annotations
 
-from reyn.interfaces.inline.app import dropdown_lines, status_chips
+from reyn.interfaces.inline.app import (
+    dropdown_lines,
+    model_switch_text,
+    status_chips,
+)
 
 
 def test_status_chips_has_five_labelled_values() -> None:
@@ -64,7 +69,8 @@ def test_cost_dropdown_shows_token_breakdown() -> None:
 
 
 def test_model_dropdown_shows_current_and_change_hint() -> None:
-    """Tier 2: model panel shows the current class + how to change it."""
+    """Tier 2: with no configured classes, model panel falls back to the current
+    class + how to change it."""
     lines = dropdown_lines(
         "model", model="flash-lite", agent_names=[], attached_name=None,
         skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
@@ -72,3 +78,28 @@ def test_model_dropdown_shows_current_and_change_hint() -> None:
     joined = " ".join(lines)
     assert "flash-lite" in joined
     assert "/model" in joined
+
+
+def test_model_picker_lists_classes_marking_current() -> None:
+    """Tier 2: with configured classes, the model panel is a picker — one row
+    per class, the current class marked ▸, others not."""
+    lines = dropdown_lines(
+        "model", model="standard", agent_names=[], attached_name=None,
+        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
+        model_classes=["light", "standard", "strong"],
+    )
+    assert any(ln.startswith("▸") and "standard" in ln for ln in lines)
+    assert any("light" in ln and not ln.startswith("▸") for ln in lines)
+    assert any("strong" in ln and not ln.startswith("▸") for ln in lines)
+    # the picker (one row per class), not the no-classes fallback hint
+    assert not any("change with" in ln for ln in lines)
+
+
+def test_model_switch_text_for_selected_row() -> None:
+    """Tier 2: the picker's Enter submits the existing /model slash for the
+    cursor row; an out-of-range row submits nothing."""
+    classes = ["light", "standard", "strong"]
+    assert model_switch_text(classes, 0) == "/model light"
+    assert model_switch_text(classes, 2) == "/model strong"
+    assert model_switch_text(classes, 3) is None
+    assert model_switch_text([], 0) is None


### PR DESCRIPTION
**[tui-coder]** — #2205 follow-up ③（actionable model picker）。lead-coder GO 済（reuse-first design accept + cost-warn verification note）。1 follow-up = 1 PR。

## What

status メニューの **model chip dropdown を navigable picker に**: ↓ で menu 降下 → model chip で Enter → ↑↓ で configured model class を選択 → Enter で適用。他 chip（agents/skills/cost/ctx）は read-only のまま。

## How（reuse-first・P7 clean・新 switch logic ゼロ）

選択の適用は `submit_user_text("/model <class>")` で **既存 `/model` slash handler を通す**だけ。これにより:
- class validation（`resolver.is_known_class`）
- **#1830 high-cost-model の blocking confirm**
- turn-budget rebuild（`_rebuild_turn_budget_engine_for_model`）

が**全て再利用**される。picker 側に switch ロジックを一切持たない。

accessor は薄い `Session.known_model_classes() → resolver.known_classes()` のみ追加（enumeration 用、`_resolver` 全露出ではない）。`session.model`（既存 property）が現在 class（override-or-default）を返すので current marking はそれを使用。configured class が無い構成では従来の current-model ヒントに fallback。

## cost-warn が bypass されないことの確認（lead-coder note への回答）

**primary evidence**: cost-warn の confirm は `model_cost_warn.py:130` → `session._handle_chat_limit_checkpoint` → **`session._dispatch_intervention`** に委譲される。これは inline app が PR1 から既に処理している **intervention seam そのもの**（ask_user と同一機構）。つまり picker 経由でも `/model <expensive>` の y/n confirm は通常の intervention として inline 入力に render + 応答される＝**bypass されない**。新しい confirm 経路を作っていないため、cost-warn は構造的に温存される。

## Test plan

- [x] Tier 2 pure（`tests/test_inline_pr3b_status_menu.py`）: model picker が class を列挙し current を ▸ marking ／ configured class 無しで fallback ヒント ／ `model_switch_text(classes, row)` が `/model <class>`・range 外で None
- [x] 既存 `test_model_dropdown_shows_current_and_change_hint` は `model_classes` 未指定 → fallback path で後方互換 pass
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [x] 回帰: inline suite 42 + /model slash 12 + intervention 20 passed
- [x] full pytest（local .venv、CI 相当）— green（※ローカルは literalai-0.1.201 が site-packages に top-level `tests/` を誤同梱し repo の tests namespace を shadow する env 汚染があり、これを除去してから実行。PR とは無関係の env issue）
- [ ] (skipped — proxy down) 実 LLM e2e での `/model <expensive>` ライブ step-through。cost-warn bypass 不在は上記 primary evidence（intervention 委譲）で構造的に保証。proxy 復帰時 or owner 手元で確認可。

## Tier self-check

Tier 2 pure のみ。format-pin（`len()==N`）除去済（behavioral assertion に置換）、mock なし、private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
