### PR TITLE
fix(repl): correct _simple_status OutboxMessage import (REPL crash)

### DIFF
--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -120,7 +120,7 @@ async def _output_loop(
 
 def _simple_status(text: str):
     """Build a status OutboxMessage for inline rendering (no async needed)."""
-    from .outbox import OutboxMessage
+    from reyn.runtime.outbox import OutboxMessage
     return OutboxMessage(kind="status", text=text)
 
 

--- a/tests/test_repl_simple_status.py
+++ b/tests/test_repl_simple_status.py
@@ -1,0 +1,19 @@
+"""Tier 2: _simple_status builds a real status OutboxMessage.
+
+It is called from the REPL input loop's "no agent attached" path, so a broken
+import there crashes the whole REPL the moment the user types. This pins that
+_simple_status actually constructs an OutboxMessage (a wrong import module would
+raise ModuleNotFoundError when the function runs, not at module load).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.repl.repl import _simple_status
+from reyn.runtime.outbox import OutboxMessage
+
+
+def test_simple_status_returns_status_outbox_message() -> None:
+    """Tier 2: returns an OutboxMessage of kind 'status' carrying the text."""
+    msg = _simple_status("no agent attached; try :agents")
+    assert isinstance(msg, OutboxMessage)
+    assert msg.kind == "status"
+    assert msg.text == "no agent attached; try :agents"


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-1 の **B1（最高 severity・crash）**。lead-coder triage で GO（urgent tiny, 議論余地なし）。1 bug = 1 PR。

## Bug（primary evidence・実コード verify 済）

`repl.py:123` の `_simple_status`:
```python
from .outbox import OutboxMessage   # ← reyn/interfaces/repl/outbox.py は存在しない
```
正しいモジュールは `reyn.runtime.outbox`。import は関数内 deferred ゆえ module load では落ちず**呼ばれた瞬間に `ModuleNotFoundError`**。呼び出し元は `repl.py:78` の input-loop「no agent attached」path:
```python
renderer.message(_simple_status("no agent attached; try :agents"))
```
この行は EOFError/KeyboardInterrupt の try の外にあるため、例外は `_input_loop` を抜け→`asyncio.wait` FIRST_COMPLETED→両 task cancel→**REPL 全体が crash**。= no-agent-attached 状態で 1 文字打つとセッションが落ちる。

verify: `python -c "from reyn.interfaces.repl.repl import _simple_status; _simple_status('x')"` → 修正前 `ModuleNotFoundError`、修正後 `OK status 'x'`。

## Fix

import を実在モジュール `reyn.runtime.outbox` に向ける（1 行）。

## Test plan

- [x] Tier 2 `tests/test_repl_simple_status.py`: `_simple_status` が kind='status' の OutboxMessage を構築（修正前は呼び出し時に ModuleNotFoundError で fail）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [x] pytest green

## Tier self-check

Tier 2 1 件、behavioral（戻り値 contract）。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
