### PR TITLE
fix(repl): contain a single message's render failure in _output_loop

### DIFF
--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -9,6 +9,7 @@ the input and output sides funnel through the registry.
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 
 from prompt_toolkit import PromptSession
@@ -20,6 +21,8 @@ from prompt_toolkit.patch_stdout import patch_stdout
 from reyn.runtime.registry import AgentRegistry  # #312 PR-A: registry stays in the runtime pkg
 
 from .renderer import ChatRenderer
+
+logger = logging.getLogger(__name__)
 
 
 async def _input_loop(
@@ -106,10 +109,20 @@ async def _output_loop(
         # before output and redrawn after — required for ANSI/Rich to render
         # cleanly without corrupting the prompt.
         # On a pipe: print plainly, no prompt redraw, no cursor escapes.
-        if is_tty and get_app_or_none() is not None:
-            await run_in_terminal(lambda m=msg: renderer.message(m))
-        else:
-            renderer.message(msg)
+        #
+        # Contain a single message's render failure: this loop is the sole
+        # consumer of repl_outbox, so an uncaught exception here would end the
+        # loop, trip run_repl's FIRST_COMPLETED wait, and tear down the whole
+        # REPL for one bad message. Log and continue instead (CancelledError is
+        # BaseException, so shutdown cancellation still propagates). reply_seen
+        # is still signalled below so the input pacing gate never hangs.
+        try:
+            if is_tty and get_app_or_none() is not None:
+                await run_in_terminal(lambda m=msg: renderer.message(m))
+            else:
+                renderer.message(msg)
+        except Exception:
+            logger.exception("output loop: render failed for message kind=%r", msg.kind)
         # Signal end-of-turn for the input loop's pacing gate. "agent" is
         # the canonical reply kind; "skill_done" / "error" also count as
         # turn-terminal so a skill-launch chat or a failed router round

--- a/tests/test_repl_output_loop_containment.py
+++ b/tests/test_repl_output_loop_containment.py
@@ -1,0 +1,52 @@
+"""Tier 2: _output_loop contains a single message's render failure.
+
+The output loop is the sole consumer of the registry's repl_outbox, so an
+uncaught exception while rendering one message would end the loop and tear the
+whole REPL down. This drives the loop with a real queue and a recorder renderer
+that raises on one poison message, and asserts later messages still render (the
+loop survived) — before the fix the exception propagated out of _output_loop.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.interfaces.repl.repl import _output_loop
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Recorder:
+    """A real renderer double: records rendered text, raises on a poison msg."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def message(self, msg: OutboxMessage) -> None:
+        if msg.text == "BOOM":
+            raise RuntimeError("simulated render failure")
+        self.seen.append(msg.text)
+
+
+@pytest.mark.asyncio
+async def test_output_loop_survives_a_render_exception() -> None:
+    """Tier 2: a message whose render raises is skipped; the loop keeps
+    draining and renders the messages after it."""
+    queue: asyncio.Queue = asyncio.Queue()
+    registry = SimpleNamespace(repl_outbox=queue)
+    renderer = _Recorder()
+    for text, kind in [
+        ("before", "agent"),
+        ("BOOM", "agent"),       # render raises here
+        ("after", "agent"),
+        ("", "__end__"),
+    ]:
+        await queue.put(OutboxMessage(kind=kind, text=text))
+
+    # Before the fix this raises RuntimeError out of the loop; after, it returns.
+    await asyncio.wait_for(_output_loop(registry, renderer), timeout=2.0)
+
+    assert "before" in renderer.seen
+    assert "after" in renderer.seen      # the loop continued past the failure
+    assert "BOOM" not in renderer.seen   # the failing render recorded nothing


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-1 の **B2（session-kill robustness）**。lead-coder triage で B2/B3 separate-PR の方針。1 bug = 1 PR。

## Bug（primary evidence・実コード verify 済）

`repl.py` の `_output_loop`（registry の `repl_outbox` 唯一の consumer）は各 message を例外処理なしで render:
```python
if is_tty and get_app_or_none() is not None:
    await run_in_terminal(lambda m=msg: renderer.message(m))
else:
    renderer.message(msg)
```
`renderer.message()` が 1 つの message で例外を投げると（malformed OutboxMessage、Rich が pathological string で raise 等）→ 例外が loop を抜け→`run_repl` の FIRST_COMPLETED wait が発火→両 task cancel→**REPL 全体 teardown**。= 1 つの不正 message でセッションが落ち、後続の queued message が全て失われる。

## Fix

render を try/except で包み、log + continue（loop は drain を継続）。`CancelledError` は BaseException ゆえ `except Exception` に捕まらず、shutdown 時の cancellation は従来通り伝播。`reply_seen.set()` は try の外（後段）に残すので、render 失敗時も input pacing gate は hang しない。

## Test plan

- [x] Tier 2 `tests/test_repl_output_loop_containment.py`: real queue + recorder renderer（poison message で raise）で `_output_loop` を駆動 → poison は skip され後続 message が render される（= loop 生存）。修正前は RuntimeError が loop を抜けて test fail。mock 不使用（real asyncio.Queue + 手書き recorder = real instance、SimpleNamespace で repl_outbox を保持）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [x] pytest green

## Tier self-check

Tier 2 1 件、behavioral（"before"/"after" rendered, "BOOM" skipped）。format-pin / unittest.mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
