### PR TITLE
fix(chat): inline CUI requires a TTY stdout, not just stdin

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -218,6 +218,18 @@ def _reset_project_state(project_root: Path, *, confirm: bool = True) -> bool:
     return True
 
 
+def _inline_interactive(*, cui: bool, stdin_isatty: bool, stdout_isatty: bool) -> bool:
+    """Whether the inline CUI is the surface for this run.
+
+    True only when not ``--cui`` and BOTH std streams are TTYs: the inline CUI
+    reads keys from stdin and renders a live region to stdout, so a piped/
+    redirected stdout (``reyn chat | tee``) must fall back to the plain renderer
+    rather than write cursor/ANSI escapes into the pipe. The single source for
+    both the log redirect and the renderer choice so they never diverge.
+    """
+    return not cui and stdin_isatty and stdout_isatty
+
+
 def _setup_interactive_logging(project_root: Path) -> None:
     """Route root-logger output to .reyn/logs/reyn.log for the interactive CUI.
 
@@ -272,14 +284,26 @@ def run(args: argparse.Namespace) -> None:
 
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
 
-    # The interactive inline CUI owns the terminal as a live region. Route the
-    # root logger to a file so library warnings and caught-exception tracebacks
-    # (e.g. an LLM APIConnectionError that session.py logs via logger.exception)
-    # don't leak into — and corrupt/alarm — the chat UI. --cui / non-TTY keep
-    # logging on stderr (debuggable / pipeable). Set before config load so early
-    # WARNING records are captured. (Restores the redirect the Textual TUI had;
-    # dropped in the inline-CUI cutover #2195.)
-    if not getattr(args, "cui", False) and sys.stdin.isatty():
+    # The inline CUI owns the terminal as a live region, which needs BOTH a TTY
+    # stdin (to read keys) AND a TTY stdout (to render the bottom live region).
+    # With stdout piped/redirected (e.g. `reyn chat | tee`) the prompt_toolkit
+    # Application would write cursor/ANSI escapes into the pipe, so fall back to
+    # the plain renderer there. This single predicate gates BOTH the log redirect
+    # and the renderer choice (below) so "inline CUI active ⟺ logging redirected"
+    # stays invariant — they must not diverge.
+    is_interactive = _inline_interactive(
+        cui=getattr(args, "cui", False),
+        stdin_isatty=sys.stdin.isatty(),
+        stdout_isatty=sys.stdout.isatty(),
+    )
+
+    # Route the root logger to a file so library warnings and caught-exception
+    # tracebacks (e.g. an LLM APIConnectionError that session.py logs via
+    # logger.exception) don't leak into — and corrupt/alarm — the chat UI.
+    # --cui / non-TTY keep logging on stderr (debuggable / pipeable). Set before
+    # config load so early WARNING records are captured. (Restores the redirect
+    # the Textual TUI had; dropped in the inline-CUI cutover #2195.)
+    if is_interactive:
         _setup_interactive_logging(project_root)
 
     # PR-resume-ux β U3: handle --reset before constructing state_log so
@@ -453,7 +477,8 @@ def run(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    is_interactive = not getattr(args, "cui", False) and sys.stdin.isatty()
+    # is_interactive computed once above (TTY stdin AND stdout, no --cui) so the
+    # renderer choice and the log redirect can never diverge.
     skip_restore = getattr(args, "no_restore", False)
     if skip_restore:
         print(

--- a/tests/test_chat_inline_interactive_gate.py
+++ b/tests/test_chat_inline_interactive_gate.py
@@ -1,0 +1,30 @@
+"""Tier 2: the inline-CUI gate requires a TTY on BOTH std streams.
+
+The inline CUI renders a live region to stdout, so it must not be selected when
+stdout is piped/redirected (`reyn chat | tee`) even if stdin is a TTY — otherwise
+the prompt_toolkit Application writes cursor/ANSI escapes into the pipe. This pins
+the single predicate that gates both the renderer choice and the log redirect.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.cli.commands.chat import _inline_interactive
+
+
+def test_inline_active_only_when_both_streams_are_tty() -> None:
+    """Tier 2: interactive iff not --cui and stdin AND stdout are both TTYs."""
+    assert _inline_interactive(cui=False, stdin_isatty=True, stdout_isatty=True)
+
+
+def test_piped_stdout_falls_back_to_plain_even_with_tty_stdin() -> None:
+    """Tier 2: `reyn chat | tee` (tty stdin, piped stdout) is NOT inline."""
+    assert not _inline_interactive(cui=False, stdin_isatty=True, stdout_isatty=False)
+
+
+def test_piped_stdin_is_not_inline() -> None:
+    """Tier 2: a non-TTY stdin (scripted input) is never the inline CUI."""
+    assert not _inline_interactive(cui=False, stdin_isatty=False, stdout_isatty=True)
+
+
+def test_cui_flag_forces_plain_even_on_a_full_tty() -> None:
+    """Tier 2: --cui opts out of the inline CUI regardless of TTY state."""
+    assert not _inline_interactive(cui=True, stdin_isatty=True, stdout_isatty=True)


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-1 の **C1（wrong-mode）**。lead-coder の PR3a review-miss を mining が捕捉、本人 triage で「`and sys.stdout.isatty()` 追加」を私に assign。1 bug = 1 PR。

## Bug（primary evidence・実コード verify 済）

`chat.py:456`:
```python
is_interactive = not getattr(args, "cui", False) and sys.stdin.isatty()
```
stdout を確認していないため `reyn chat | tee out.txt`（stdin=TTY, stdout=pipe）で `is_interactive=True` → inline renderer + `run_inline_input`（prompt_toolkit Application）が **piped stdout に対して走る** → cursor/ANSI escape が consumer の stream に書かれ garbled（非 TTY 出力で Application 自体が落ちる可能性も）。

## Fix（single seam・invariant 保持）

`sys.stdout.isatty()` を必須条件に追加。さらに completeness の観点で、predicate を `_inline_interactive()` helper に集約し**一度だけ計算 → log redirect（旧 282）と renderer choice（旧 456）の両方で再利用**。これにより mining team が指摘した「`is_interactive` と logging-redirect は同一 predicate であるべき」invariant（inline CUI active ⟺ logging redirected）を、片方だけ patch して divergence を生む事故なく保持。

permission prompt / ask_user の interactivity 信号（perm_resolver `interactive=`, `non_interactive=`）は **stdin-only のまま**（user は stdout が pipe でも stdin で回答可能＝正しい）。

`repl.py:157` の `uses_app_input() and sys.stdin.isatty()` は belt-and-suspenders（renderer choice が単一 authoritative seam ＝ plain renderer なら `uses_app_input()=False` で 157 は inline path を取れない）ゆえ変更不要。

## Test plan

- [x] Tier 2 `tests/test_chat_inline_interactive_gate.py`: `_inline_interactive` の 4-way truth table（both-tty=True / piped-stdout=False（bug case）/ piped-stdin=False / --cui=False）
- [x] 回帰: `test_chat_cli_flags` + `test_inline_interactive_logging`（redirect 経路）+ 本 test = 13 passed
- [x] ruff / tier-audit --strict / verify_module_docstrings green

## Tier self-check

Tier 2 4 件、pure 述語の behavioral assertion。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
