### PR TITLE
fix(repl): clean summary for a read result with no usable content

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -312,6 +312,11 @@ def _summarize_result(tool, result) -> str:
                 lines = content.count("\n") + (1 if content else 0)
                 more = " (truncated)" if status == "truncated" else ""
                 return f"Read {lines} lines{more}"
+            # A read whose content wasn't a usable string (e.g. None on an error
+            # result): prefer the status (handled below) if any, else a clean
+            # note — never fall through to dumping the raw dict repr.
+            if not status:
+                return "Read (no content)"
         if op in ("write", "create"):
             return f"Wrote {path}" if path else "Wrote file"
         if op == "edit":

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -17,6 +17,22 @@ def test_file_read_reports_line_count() -> None:
     assert out == "Read 3 lines"
 
 
+def test_read_with_none_content_no_status_is_clean_not_raw_repr() -> None:
+    """Tier 2: a read result whose content is None and carries no status gets a
+    clean note, not a raw-dict dump."""
+    out = summarize_tool_result("file__read", {"op": "read", "content": None})
+    assert out == "Read (no content)"
+    assert "{" not in out and "None" not in out
+
+
+def test_read_with_none_content_but_status_shows_status() -> None:
+    """Tier 2: a read that errored (content None) still surfaces its status."""
+    out = summarize_tool_result(
+        "file__read", {"op": "read", "content": None, "status": "error"}
+    )
+    assert out == "error"
+
+
 def test_file_read_truncated_is_flagged() -> None:
     """Tier 2: a truncated read says so."""
     out = summarize_tool_result(


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-1 の **B3（garbled output）**。lead-coder triage で B2/B3 separate-PR。1 bug = 1 PR。

## Bug（primary evidence・実コード verify 済）

`renderer.py:309-314` の read 分岐は content が str の時だけ `Read N lines` を返す:
```python
if op == "read" or ("read" in t and "content" in result):
    content = result.get("content")
    if isinstance(content, str):   # content=None はここで弾かれる
        ...
        return f"Read {lines} lines{more}"
# write/edit でもなく status も無いと…
return _short(result, 80)   # → raw dict repr
```
`op=="read"` だが `content` が None（error 時に content 未充填）かつ `status` 無しの場合、write/edit/status のどれにも当たらず `_short(result, 80)` に落ちて **`{'op': 'read', 'content': None}` の生 dict repr** が tool-row summary に表示される。

## Fix

read 分岐で content が str でない場合、status があれば後段の `if status: return str(status)` に委ね、無ければ clean な `"Read (no content)"` を返す（生 repl fallback に落とさない）。

## Test plan

- [x] Tier 2（`tests/test_inline_tool_result_summary.py` に追加）: read+content=None+status 無し → `"Read (no content)"`（生 repr でない）／ read+content=None+status="error" → `"error"`（status 温存）
- [x] 既存 summary suite 全 pass（11 passed、`Read N lines` 等の既存挙動不変）
- [x] ruff / tier-audit --strict / verify_module_docstrings green

## Tier self-check

Tier 2、behavioral（出力文字列の contract、`{` / `None` 不在 assert で生 repr 不在を確認）。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
