### PR TITLE
fix(repl): register intervention listener so ask_user works in reyn chat (cutover regression)

### DIFF
--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -155,6 +155,21 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
     # a follow-up. Used by both input paths (app working row / toolbar spinner).
     attached.subscribe_chat_events(renderer.on_chat_event)
 
+    # Register the REPL as the session's intervention listener so ask_user /
+    # cost-warn confirm / permission prompts actually surface and can be answered
+    # (the session is built with enforce_listener_presence=True, so without a
+    # registered listener every intervention short-circuits to an empty answer =
+    # silent auto-refuse). DEFAULT_CHAT_CHANNEL_ID ("tui") mirrors the listener the
+    # Textual TUI registered before the inline cutover and the chainlit mount.
+    # Single-agent scope (same as the chat-events subscription above); agent-switch
+    # re-registration is the shared follow-up. AttributeError-guarded for stripped
+    # test sessions.
+    from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+    try:
+        attached.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    except AttributeError:
+        pass
+
     renderer.banner(attached.agent_name)
 
     # `set` = "no reply pending" (the input loop's pacing gate is open).
@@ -192,6 +207,10 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
         )
     finally:
         attached.unsubscribe_chat_events(renderer.on_chat_event)
+        try:
+            attached.unregister_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+        except AttributeError:
+            pass
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)

--- a/tests/test_repl_intervention_listener.py
+++ b/tests/test_repl_intervention_listener.py
@@ -1,0 +1,33 @@
+"""Tier 2: the REPL must register an intervention listener so ask_user surfaces.
+
+A chat Session is built with enforce_listener_presence=True, so with NO listener
+registered every intervention (ask_user / cost-warn confirm / permission prompt)
+short-circuits to an empty answer — a silent auto-refuse. run_repl registers
+DEFAULT_CHAT_CHANNEL_ID on the attached session to restore the listener the
+Textual TUI registered before the inline cutover dropped it. This pins the
+contract the fix relies on: enforcement is on, and registering that channel id
+flips has_active_listener so interventions surface instead of auto-refusing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+
+
+def test_chat_session_auto_refuses_until_repl_listener_is_registered(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a chat session enforces listener presence (no listener → auto-
+    refuse); registering the REPL's channel id makes interventions surface."""
+    session = Session(
+        agent_name="default", state_log=StateLog(tmp_path / "wal.jsonl")
+    )
+    # Production config: fail-closed when nothing is listening.
+    assert session.interventions.is_listener_enforcement_enabled()
+    # The regression: with no listener wired, every intervention auto-refuses.
+    assert not session.interventions.has_active_listener()
+    # What run_repl now does on the attached session.
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    assert session.interventions.has_active_listener()


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-2 の **F1（HIGH・cutover regression、私が #2195 で混入）**。最優先。1 bug = 1 PR。

## Bug（primary evidence・git history で regression confirm 済）

inline-CUI cutover `eff08169`（#2195）が Textual TUI の `session.register_intervention_listener("tui")`（`tui/app.py:1325`）を削除したが、`run_repl` に等価の登録を**追加し忘れた**。

chat session は `session.py:1491` で `enforce_listener_presence=True` 構築。`intervention_registry.py:282`:
```python
if self._enforce_listener_presence and not self._listeners:
    return InterventionAnswer(text="")   # silent auto-refuse
```
→ listener 未登録だと **ask_user / high-cost-model confirm / permission・consent prompt が全て無言で auto-refuse**（user は prompt を見えず、skill は `""` を受け取る）。`run_repl` は inline と plain `--cui` の共有ゆえ**両 path 影響**。

runtime verify: 素の `Session()` で `is_listener_enforcement_enabled()=True` / register 前 `has_active_listener()=False` / `register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)` 後 `True`。

## 私の ③ cost-warn 主張の訂正

PR #2211（③、merged）で私は cost-warn confirm が「inline app に render + 応答可能」と primary-evidence 主張しました。**これは不正確**でした: dispatch 委譲は追ったが listener 配線を確認しておらず、実際は listener 不在で confirm は auto-refuse（= switch は **fail-closed でキャンセル**＝cost-warn は **bypass されない**ので安全側は保たれるが、user は confirm を見えない／high-cost への切替が常に不可）。本 F1 fix で confirm が正しく surface するようになります。`[[feedback_safety_net_coverage_wiring_sufficiency_verify]]`（委譲は追ったが production wiring の実在未確認）の教訓事例。

## Fix

`run_repl` の attached session に `DEFAULT_CHAT_CHANNEL_ID`（"tui"、Textual と chainlit と同じ id）を register、teardown で unregister（chainlit mount を mirror）。AttributeError-guard（stripped test session）。single-agent scope（chat-events subscription と同様）、agent-switch 再登録は E1 と共通の follow-up。

## Test plan

- [x] Tier 2 `tests/test_repl_intervention_listener.py`: chat session が listener enforcement on ＋ listener 不在で auto-refuse ＋ `DEFAULT_CHAT_CHANNEL_ID` 登録で `has_active_listener` True（public surface のみ：`session.interventions.has_active_listener` / `is_listener_enforcement_enabled` / `register_intervention_listener`）
- [x] run_repl の登録 call site は read で検証（chainlit の 2-line mirror）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [ ] (skipped — proxy down) 実 LLM e2e での ask_user 往復 live step-through。contract は上記 Tier 2 + git-regression evidence で pin、proxy 復帰時 or owner 手元で確認可

## Tier self-check

Tier 2 1 件、public-surface behavioral。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
