### PR TITLE
fix(repl): focus listeners follow the attached session across agent switches (E1+E2+F1-switch)

### DIFF
--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -149,26 +149,22 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
 
     history_path = attached.workspace_dir / ".input_history"
 
-    # Drive the renderer's working indicator from the attached session's turn
-    # lifecycle (turn_started → spinner, turn_completed → idle) via the narrow
-    # subscribe API. Single-agent scope for now; agent-switch re-subscription is
-    # a follow-up. Used by both input paths (app working row / toolbar spinner).
-    attached.subscribe_chat_events(renderer.on_chat_event)
-
-    # Register the REPL as the session's intervention listener so ask_user /
-    # cost-warn confirm / permission prompts actually surface and can be answered
-    # (the session is built with enforce_listener_presence=True, so without a
-    # registered listener every intervention short-circuits to an empty answer =
-    # silent auto-refuse). DEFAULT_CHAT_CHANNEL_ID ("tui") mirrors the listener the
-    # Textual TUI registered before the inline cutover and the chainlit mount.
-    # Single-agent scope (same as the chat-events subscription above); agent-switch
-    # re-registration is the shared follow-up. AttributeError-guarded for stripped
-    # test sessions.
+    # Bind the front-end listeners that must follow the FOCUSED session across
+    # agent switches, via the registry (it re-wires them on every /attach):
+    #  - the renderer's working-indicator chat-event callback (turn_started →
+    #    spinner, turn_settled → idle), used by both input paths, and
+    #  - the intervention listener channel so ask_user / cost-warn confirm /
+    #    permission prompts surface and can be answered. The session is built with
+    #    enforce_listener_presence=True, so without a registered listener every
+    #    intervention short-circuits to an empty answer (a silent auto-refuse);
+    #    DEFAULT_CHAT_CHANNEL_ID ("tui") mirrors the Textual TUI / chainlit mount.
+    # Binding here (not a direct subscribe to `attached`) is what makes both
+    # follow a `/attach <other>` instead of stranding on the initial session.
     from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
-    try:
-        attached.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
-    except AttributeError:
-        pass
+    registry.bind_focus_listeners(
+        on_chat_event=renderer.on_chat_event,
+        intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+    )
 
     renderer.banner(attached.agent_name)
 
@@ -206,11 +202,9 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
             {inputs, outputs}, return_when=asyncio.FIRST_COMPLETED,
         )
     finally:
-        attached.unsubscribe_chat_events(renderer.on_chat_event)
-        try:
-            attached.unregister_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
-        except AttributeError:
-            pass
+        # Unwire from the LIVE attached session (handles a switch before quit),
+        # then clear the binding.
+        registry.unbind_focus_listeners()
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -260,6 +260,14 @@ class AgentRegistry:
         self._tasks: dict[tuple[str, str], asyncio.Task] = {}         # (name,sid) -> session.run() task
         self._forward_tasks: dict[tuple[str, str], asyncio.Task] = {} # (name,sid) -> outbox forwarder
         self._attached: "tuple[str, str] | None" = None              # (name, sid) focus
+        # Focus-following front-end listeners (REPL/CUI): a chat-event callback
+        # (working indicator) and an intervention listener channel (ask_user) that
+        # must follow the attached session across agent switches. None until a
+        # front-end binds them; wired to the attached session on bind and re-wired
+        # on every attach so a `/attach <other>` doesn't strand them on the old
+        # session. Generic session-level listeners (not skill-specific).
+        self._focus_chat_listener: "Callable[..., None] | None" = None
+        self._focus_intervention_channel: str | None = None
         # WAL truncation throttle (skill resume design). monotonic ts of last
         # successful truncation attempt; ``None`` means no throttle is active.
         self._last_truncation_ts: float | None = None
@@ -2550,6 +2558,54 @@ class AgentRegistry:
             self._tasks[key] = asyncio.create_task(session.run())
         return session
 
+    def bind_focus_listeners(
+        self,
+        *,
+        on_chat_event: "Callable[..., None] | None" = None,
+        intervention_channel: str | None = None,
+    ) -> None:
+        """Bind front-end listeners that follow the focused (attached) session.
+
+        The interactive REPL/CUI binds its working-indicator chat-event callback
+        and its intervention listener channel here ONCE; the registry wires them
+        to the currently-attached session now and re-wires them on every
+        subsequent ``attach`` / ``attach_session`` so an agent switch never
+        strands them on the old session. Idempotent per front-end (one binding).
+        """
+        self._focus_chat_listener = on_chat_event
+        self._focus_intervention_channel = intervention_channel
+        self._wire_focus_listeners(self.attached_session())
+
+    def unbind_focus_listeners(self) -> None:
+        """Unwire the focus listeners from the live attached session and clear
+        the binding (front-end teardown). Uses the CURRENT attached session, so a
+        switch before teardown unwires the right one."""
+        self._unwire_focus_listeners(self.attached_session())
+        self._focus_chat_listener = None
+        self._focus_intervention_channel = None
+
+    def _wire_focus_listeners(self, session: "object | None") -> None:
+        if session is None:
+            return
+        if self._focus_chat_listener is not None:
+            session.subscribe_chat_events(self._focus_chat_listener)
+        if self._focus_intervention_channel is not None:
+            try:
+                session.register_intervention_listener(self._focus_intervention_channel)
+            except AttributeError:
+                pass
+
+    def _unwire_focus_listeners(self, session: "object | None") -> None:
+        if session is None:
+            return
+        if self._focus_chat_listener is not None:
+            session.unsubscribe_chat_events(self._focus_chat_listener)
+        if self._focus_intervention_channel is not None:
+            try:
+                session.unregister_intervention_listener(self._focus_intervention_channel)
+            except AttributeError:
+                pass
+
     async def attach(self, name: str) -> "object":
         """Switch the attached agent to `name`. Loads + starts session.run()
         and the outbox forwarder for the new agent if not already running.
@@ -2565,8 +2621,14 @@ class AgentRegistry:
                 # from the old session start dropping at the source
                 # (`Session._put_outbox` filters status/trace).
                 old_session.is_attached = False
+                # Move any focus-following front-end listeners off the old session.
+                self._unwire_focus_listeners(old_session)
 
         new_session.is_attached = True
+        if old != key:
+            # First attach or a genuine switch: wire the focus listeners to the
+            # now-focused session (no-op if no front-end bound any).
+            self._wire_focus_listeners(new_session)
         # Boot session.run() + forwarder on first attach. Keep them alive
         # across detach/re-attach cycles — shutdown drains via `running_tasks()`.
         if key not in self._tasks or self._tasks[key].done():
@@ -2606,7 +2668,10 @@ class AgentRegistry:
             old_session = self._peek_session(old[0], old[1])
             if old_session is not None:
                 old_session.is_attached = False
+                self._unwire_focus_listeners(old_session)
         target.is_attached = True
+        if old != key:
+            self._wire_focus_listeners(target)
         if key not in self._tasks or self._tasks[key].done():
             self._tasks[key] = asyncio.create_task(target.run())
         if key not in self._forward_tasks or self._forward_tasks[key].done():

--- a/tests/test_registry_focus_listener_rewire.py
+++ b/tests/test_registry_focus_listener_rewire.py
@@ -1,0 +1,67 @@
+"""Tier 2: focus-following front-end listeners re-wire on agent switch.
+
+The REPL binds session-level listeners (the working-indicator chat-event callback
+and the ask_user intervention listener) that must follow the ATTACHED session. If
+they stay bound to the initially-attached session, a `/attach <other>` leaves the
+spinner dead and interventions auto-refusing on the new agent. The registry
+re-wires them on every attach. The intervention listener's has_active_listener()
+is the public, observable proxy for the shared wire/unwire mechanism (the
+chat-event callback rides the same path).
+
+Real AgentRegistry + real Sessions (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return Session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_focus_listeners_follow_agent_switch(tmp_path) -> None:
+    """Tier 2: binding the intervention listener follows the focused session
+    across a switch — it lands on the newly-attached agent and leaves the old."""
+    reg = _registry(tmp_path)
+    try:
+        # Mirror chat.py → run_repl: attach the initial agent, then bind.
+        alpha = await reg.attach("alpha")
+        reg.bind_focus_listeners(
+            on_chat_event=lambda *a, **k: None,
+            intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+        )
+        # Bind wired the currently-focused session.
+        assert alpha.interventions.has_active_listener()
+
+        # /attach beta — the listener must follow the focus.
+        beta = await reg.attach("beta")
+        assert beta.interventions.has_active_listener(), "listener followed to beta"
+        assert not alpha.interventions.has_active_listener(), "and left alpha"
+
+        # Teardown unwires the LIVE (beta) session, not the original.
+        reg.unbind_focus_listeners()
+        assert not beta.interventions.has_active_listener()
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-2 の **E1+E2+F1-switch bundle**（lead-approved「agent-switch re-wire 1PR」）。1 cohesive fix = 1 PR。

## Bugs（primary evidence・実コード verify 済）

`run_repl` は working-indicator の chat-event callback と intervention listener を**初期 attached session にだけ**配線していた:
- **E1（HIGH）**: `/attach <other>` 後、renderer は旧 session にしか subscribe してないため新 agent の turn で **working spinner が dead**。`registry.attach()` に subscription 再配線がゼロ（grep 確認）。
- **E2（MED, latent）**: teardown が closed-over `attached`（初期 session）を unsubscribe＝switch 後は live でなく旧 session を外す → E1 修正後に subscriber leak。
- **F1-switch**: 直前の #2216 で restore した intervention listener も同じ single-agent 制約（switch で旧 session に取り残される）。

## Fix（registry に集約・両 attach path カバー＝single seam）

registry に focus-following listener binding を追加:
- `bind_focus_listeners(on_chat_event, intervention_channel)`: callback + channel を記録し現 focused session に配線。
- `attach()` / `attach_session()`: switch 時に旧 session を unwire・新 session を wire（**両 attach path** をカバー、completeness）。
- `unbind_focus_listeners()`: teardown で **live** attached session を unwire（switch 後でも正しい session を外す＝E2 解消）。

`run_repl` は直接 subscribe をやめ registry binding に delegate。binding は opt-in（default None）ゆえ **chainlit / mcp / web は不変**。chat-event cb と intervention listener は同一 `_wire`/`_unwire` path を通る。

## Test plan

- [x] Tier 2 `tests/test_registry_focus_listener_rewire.py`: real AgentRegistry + real Session 2体、attach alpha→bind→`has_active_listener()` True、attach beta で beta True・alpha False（listener が focus に追従）、unbind で live(beta) 解除（public surface のみ：`session.interventions.has_active_listener`）
- [x] 回帰: registry/attach/multi-session/intervention/shutdown 77 passed（core 変更ゆえ broad sweep）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [ ] (skipped — proxy down) 実 LLM e2e での `/attach` 後 spinner + ask_user live 確認。機構は Tier 2 + has_active_listener proxy で pin、proxy 復帰 or owner 手元で確認可

## Tier self-check

Tier 2 1 件、public-surface behavioral。format-pin / mock（real Session）/ private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
