### PR TITLE
fix(inline): contain quit double-fire and silent submit failure (A1+F2)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -17,6 +17,7 @@ actionable model picker (selecting a class) is a follow-up.
 """
 from __future__ import annotations
 
+import logging
 import time
 
 from prompt_toolkit.application import Application, get_app
@@ -36,6 +37,8 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
+
+logger = logging.getLogger(__name__)
 
 # Status-row chips, in display order.
 _CHIPS = ["model", "agents", "skills", "cost", "ctx"]
@@ -143,6 +146,11 @@ async def run_inline_input(registry, renderer) -> None:
     # sel: which chip; open: detail/picker shown; row: cursor within an
     # actionable picker (model). row is reset to 0 when a picker opens.
     menu = {"sel": 0, "open": False, "row": 0}
+    # Guards against a second quit (rapid Ctrl-C / `/quit` then Ctrl-C) racing the
+    # first: shutdown has a grace window, so two _quit tasks could both reach
+    # app.exit() — the second raises "Return value already set". _quit checks+sets
+    # this before its first await, so only one ever runs to app.exit().
+    quitting: dict = {}
 
     def _working_frags() -> list:
         return working_line(
@@ -248,7 +256,7 @@ async def run_inline_input(registry, renderer) -> None:
         # plain text, intervention answers, other slash — flows through
         # submit_user_text and routes inside the session unchanged.
         if stripped in ("/quit", "/exit"):
-            event.app.create_background_task(_quit(registry, event.app))
+            event.app.create_background_task(_quit(registry, event.app, quitting))
         else:
             event.app.create_background_task(_submit(registry, stripped))
 
@@ -314,7 +322,7 @@ async def run_inline_input(registry, renderer) -> None:
     @kb.add("c-d")
     @kb.add("c-q")
     def _quit_key(event) -> None:
-        event.app.create_background_task(_quit(registry, event.app))
+        event.app.create_background_task(_quit(registry, event.app, quitting))
 
     body = HSplit([working, top_rule, inputrow, bottom_rule, status_win, dropdown])
     app: Application = Application(
@@ -333,10 +341,32 @@ async def run_inline_input(registry, renderer) -> None:
 
 async def _submit(registry, text: str) -> None:
     s = registry.attached_session()
-    if s is not None:
+    if s is None:
+        return
+    # Launched as a background task, so an uncaught error here goes to asyncio's
+    # exception handler (invisible above the live app) and the user sees the input
+    # field clear with no response — a silent failure. Contain it: log + surface a
+    # visible error line via the outbox the output loop already drains.
+    try:
         await s.submit_user_text(text)
+    except Exception:
+        logger.exception("inline submit failed")
+        try:
+            from reyn.runtime.outbox import OutboxMessage
+            registry.repl_outbox.put_nowait(
+                OutboxMessage(kind="error", text="input could not be submitted (see logs)")
+            )
+        except Exception:
+            pass
 
 
-async def _quit(registry, app) -> None:
+async def _quit(registry, app, state: dict) -> None:
+    # Idempotent: shutdown has a grace window, so a second quit (rapid Ctrl-C /
+    # `/quit` then Ctrl-C) could race the first to app.exit() ("Return value
+    # already set"). The check+set is synchronous (before the first await), so in
+    # the single-threaded loop only the first task proceeds to app.exit().
+    if state.get("quitting"):
+        return
+    state["quitting"] = True
     await registry.shutdown()
     app.exit()

--- a/tests/test_inline_app_bgtask.py
+++ b/tests/test_inline_app_bgtask.py
@@ -1,0 +1,59 @@
+"""Tier 2: inline app background-task robustness (_submit / _quit).
+
+Both are launched via create_background_task from key bindings, so an uncaught
+error or a double-fire is invisible/harmful: a failing _submit silently drops the
+input, and a second _quit racing the first hits app.exit() twice ("Return value
+already set"). These pin the contained behaviour with real instances (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.interfaces.inline.app import _quit, _submit
+
+
+class _RaisingSession:
+    async def submit_user_text(self, text: str) -> None:
+        raise RuntimeError("simulated submit failure")
+
+
+@pytest.mark.asyncio
+async def test_submit_surfaces_error_instead_of_failing_silently() -> None:
+    """Tier 2: a submit_user_text failure is contained and surfaced as an error
+    line on the outbox, not swallowed by the background-task exception handler."""
+    registry = SimpleNamespace(
+        attached_session=lambda: _RaisingSession(),
+        repl_outbox=asyncio.Queue(),
+    )
+    await _submit(registry, "hello")  # must not raise out of the background task
+    msg = registry.repl_outbox.get_nowait()
+    assert msg.kind == "error"
+    assert msg.text  # a non-empty, user-visible message
+
+
+class _CountingApp:
+    def __init__(self) -> None:
+        self.exit_calls = 0
+
+    def exit(self) -> None:
+        self.exit_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_quit_is_idempotent_under_rapid_double_quit() -> None:
+    """Tier 2: two concurrent _quit (rapid Ctrl-C / `/quit` then Ctrl-C) call
+    app.exit() exactly once — the shared guard dedups before the first await."""
+    async def _shutdown() -> None:
+        return None
+
+    registry = SimpleNamespace(shutdown=_shutdown)
+    app = _CountingApp()
+    state: dict = {}
+    await asyncio.gather(
+        _quit(registry, app, state),
+        _quit(registry, app, state),
+    )
+    assert app.exit_calls == 1


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-2 の **A1+F2 bundle**（lead-approved「app.py bg-task robustness」1PR）。両方 keybinding background-task の堅牢化。

## Bugs（primary evidence・実コード verify 済）

- **A1（noisy error）**: `_quit` は `registry.shutdown()`（grace window あり）→ `app.exit()`。連打 quit（Ctrl-C 二度／`/quit` 後 Ctrl-C）で 2 つ目の `_quit` が 1 つ目と race し `app.exit()` 二重呼び → prompt_toolkit が **"Return value already set"** を raise（traceback が patch_stdout 上に表示）。
- **F2（silent no-op）**: `_submit` の `submit_user_text` が raise すると background-task の例外は asyncio exception handler 行き（live app 上に不可視）→ user は入力欄が消えるだけで無反応＝**silent failure**。

## Fix

- **A1**: `_quit` を idempotent に（共有 `quitting` guard を first await の前に同期 check+set ＝ single-threaded loop で 1 task だけ `app.exit()` 到達）。
- **F2**: `_submit` を try/except で包み、log + **outbox に kind="error" の可視行を put**（output loop が既に drain）→ user に失敗が見える。`except Exception` ゆえ CancelledError は伝播。

## Test plan

- [x] Tier 2 `tests/test_inline_app_bgtask.py`（real instances・no mock）: raising session で `_submit` → outbox に kind="error"・例外伝播なし／concurrent 2× `_quit` → `app.exit()` ちょうど 1 回
- [x] 回帰: inline app/menu suite 17 passed
- [x] ruff / tier-audit --strict / verify_module_docstrings green

## Tier self-check

Tier 2 2 件、behavioral（outbox kind / exit 回数）。format-pin（`len()==N`）/ mock（SimpleNamespace + 手書き real class）/ private-state assert なし。`exit_calls == 1` は count behavioral（format-pin でない）、`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
