### PR TITLE
fix(session): contain a raising slash handler so it can't kill the run loop (F3)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5062,7 +5062,20 @@ class Session:
         # read-only, best-effort — the try/except ensures a CPython internals
         # change never breaks slash dispatch).
         pre_size = self.outbox.qsize()
-        await slash_cmd.handler(self, args)
+        try:
+            await slash_cmd.handler(self, args)
+        except Exception:
+            # A slash handler raising must not kill the session run loop: run()'s
+            # `while await run_one_iteration()` has no `except`, so an uncaught
+            # error here ends session.run() and silently drops every later inbox
+            # message (the front-end keeps accepting input but never replies).
+            # Surface a clean error and treat the command as consumed so the loop
+            # continues. (CancelledError is BaseException → shutdown still cancels.)
+            logger.exception("slash handler /%s failed", cmd)
+            await self._put_outbox(OutboxMessage(
+                kind="error", text=f"/{cmd} failed (see logs)",
+            ))
+            return True
         try:
             new_items = list(self.outbox._queue)[pre_size:]  # type: ignore[attr-defined]
             had_error = any(

--- a/tests/test_slash_handler_crash_containment.py
+++ b/tests/test_slash_handler_crash_containment.py
@@ -1,0 +1,59 @@
+"""Tier 2: a raising slash handler is contained, not fatal to the session loop.
+
+session.run()'s `while await run_one_iteration(): pass` has no `except`, so an
+uncaught error from a slash handler propagates out and ends the session run loop —
+the front-end keeps accepting input but never replies again. Slash dispatch now
+wraps the handler call: it surfaces a clean error and treats the command as
+consumed so the loop continues.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+
+
+def _drain_outbox(session: Session) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+@pytest.mark.asyncio
+async def test_raising_slash_handler_is_contained_not_fatal(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: a slash handler that raises is caught — dispatch reports the
+    command consumed (loop survives) and emits an error line."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    async def _boom(sess: Session, args: str) -> None:
+        raise RuntimeError("handler exploded")
+
+    from reyn.interfaces.slash import REGISTRY, SlashCommand
+
+    # Register a throwaway raising command; monkeypatch auto-removes it at teardown.
+    monkeypatch.setitem(
+        REGISTRY._commands,
+        "__f3boom__",
+        SlashCommand(name="__f3boom__", summary="test", handler=_boom),
+    )
+
+    # Before the fix this raised RuntimeError out of dispatch (→ killed run()).
+    consumed = await session._maybe_handle_slash("/__f3boom__")
+    assert consumed is True  # handled → the run loop continues
+    assert any(m.kind == "error" for m in _drain_outbox(session))


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-2 の **F3（LOW-MED, session-loop death）**。lead-approved「F3 単独」。1 bug = 1 PR。

## Bug（primary evidence・実コード verify 済）

`session.run()`（session.py:3722）の `while await self.run_one_iteration(): pass` は `try/finally` のみで **`except` 無し**。`_maybe_handle_slash` の `await slash_cmd.handler(self, args)`（session.py:5065）は call 自体が try/except されておらず、slash handler が予期せぬ例外を raise すると `_maybe_handle_slash` → `run_one_iteration` → while loop を抜け → **`session.run()` が死亡**。front-end は input を受け続けるが session は以後 message を処理せず（silent death、無シグナル）。

## Fix

handler call を try/except で包み、log + clean な `kind="error"` 行を surface + `return True`（consumed）で loop 継続。`except Exception` ゆえ CancelledError は伝播し shutdown の cancel は不変。

## Test plan

- [x] Tier 2 `tests/test_slash_handler_crash_containment.py`: throwaway raising command を REGISTRY に登録（monkeypatch auto-clean）→ `_maybe_handle_slash` が consumed=True を返し error 行を emit（修正前は RuntimeError が dispatch を抜けて fail）
- [x] 回帰: slash dispatch suite（multi_line/memory/agent/model/see_also/nested_skill）43 passed
- [x] ruff / tier-audit --strict / verify_module_docstrings green

## Tier self-check

Tier 2、behavioral（consumed フラグ + error kind）。format-pin / mock（real Session + 手書き handler）/ private-state assert なし（`REGISTRY._commands` は monkeypatch setup、assertion でない）。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
