### PR TITLE
fix(inline): no picker cursor when the model dropdown has no classes (A2)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -47,6 +47,17 @@ _CHIPS = ["model", "agents", "skills", "cost", "ctx"]
 _ACTIONABLE = frozenset({"model"})
 
 
+def is_actionable_picker(label: str, model_classes) -> bool:
+    """Pure: whether a chip's open dropdown is an actionable picker right now.
+
+    The model chip is a picker only when it actually has classes to pick; with
+    none configured its dropdown is the read-only current-model fallback, which
+    has no selectable rows — so no cursor must be drawn on it (otherwise the
+    fallback lines look selectable but Enter does nothing).
+    """
+    return label in _ACTIONABLE and bool(model_classes)
+
+
 def model_switch_text(model_classes: list, row: int) -> str | None:
     """Pure: the slash command a model-picker Enter submits for the row.
 
@@ -217,7 +228,7 @@ async def run_inline_input(registry, renderer) -> None:
         snap = _snapshot(registry)
         if snap is None:
             return []
-        actionable = _CHIPS[menu["sel"]] in _ACTIONABLE
+        actionable = is_actionable_picker(_CHIPS[menu["sel"]], snap["model_classes"])
         out: list = []
         for i, ln in enumerate(_current_dropdown_lines(snap)):
             if i:

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -9,9 +9,18 @@ from __future__ import annotations
 
 from reyn.interfaces.inline.app import (
     dropdown_lines,
+    is_actionable_picker,
     model_switch_text,
     status_chips,
 )
+
+
+def test_model_chip_is_a_picker_only_with_classes() -> None:
+    """Tier 2: the model dropdown is an actionable picker (gets a cursor) only
+    when it has classes to pick; with none it's the read-only fallback."""
+    assert is_actionable_picker("model", ["light", "standard"]) is True
+    assert is_actionable_picker("model", []) is False  # fallback, no cursor
+    assert is_actionable_picker("agents", ["default"]) is False  # not actionable
 
 
 def test_status_chips_has_five_labelled_values() -> None:


### PR DESCRIPTION
**[tui-coder]** — bug-mining wave-2 の **A2（LOW cosmetic, picker false-affordance）**。lead-approved・#2219 merged で unblocked。wave-2 bug class クローズ。

## Bug（primary evidence・実コード verify 済）

model chip dropdown が configured classes 無しで開くと read-only fallback（"current: X" / "change with /model"）を表示するが、`dropdown_frags` は `actionable = _CHIPS[sel] in _ACTIONABLE` で **fallback 行にも picker cursor（reverse highlight）を描画** → 選択可能に見えるが Enter は無反応（false affordance、owner が lying slash で指摘したのと同 class）。

## Fix

cursor を「dropdown が実際に actionable picker（model chip **かつ** classes 実在）」の時のみ描画。pure helper `is_actionable_picker(label, model_classes)` で gate。navigation は既に empty-safe（`model_switch_text` が None 返し、`_menu_down` は空 list で no-op）。

## Test plan

- [x] Tier 2: `is_actionable_picker("model", [classes])`=True / `("model", [])`=False（fix）/ `("agents", [...])`=False
- [x] 回帰: inline picker/menu suite 16 passed
- [x] ruff / tier-audit --strict / verify_module_docstrings green

## Tier self-check

Tier 2、pure 述語の behavioral。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
