### PR TITLE
feat(inline): re-implement /copy (clipboard) for the inline CUI

### DIFF
--- a/src/reyn/interfaces/repl/_clipboard.py
+++ b/src/reyn/interfaces/repl/_clipboard.py
@@ -1,0 +1,68 @@
+"""Cross-platform clipboard helper for the inline CUI (`/copy`).
+
+Platform-agnostic: tries each known clipboard binary in order and returns the
+label of the first that succeeded. Users need only ONE on PATH; the function
+never raises — an empty ``tool_label`` means "no clipboard tool available;
+install pbcopy / xclip / wl-copy / xsel".
+"""
+from __future__ import annotations
+
+# Order of clipboard tools we try. First match that succeeds wins.
+# Each entry is (binary_name, argv_tail, label).
+_CLIPBOARD_TOOLS: tuple[tuple[str, list[str], str], ...] = (
+    ("pbcopy",   [],            "pbcopy"),                # macOS
+    ("wl-copy",  [],            "wl-copy"),               # Wayland
+    ("xclip",    ["-selection", "clipboard"], "xclip"),   # X11
+    ("xsel",     ["--clipboard", "--input"], "xsel"),     # X11 fallback
+    ("clip",     [],            "clip"),                  # Windows
+)
+
+
+def copy_to_clipboard(text: str) -> tuple[bool, str]:
+    """Pipe ``text`` to a platform clipboard tool. Returns ``(ok, tool_label)``.
+
+    Looked up via ``shutil.which`` so the user only needs one of the
+    binaries on PATH. We avoid hard-coding the OS because users may run,
+    e.g., xclip inside a Linux VM regardless of the host platform.
+
+    BLOCKING: ``subprocess.run`` is synchronous and can hold the calling
+    thread for up to ~2 s (timeout). Callers inside an async event loop
+    should use :func:`copy_to_clipboard_async` instead.
+    """
+    import shutil
+    import subprocess
+
+    for binary, tail, label in _CLIPBOARD_TOOLS:
+        path = shutil.which(binary)
+        if path is None:
+            continue
+        try:
+            subprocess.run(
+                [path, *tail],
+                input=text.encode("utf-8"),
+                check=True,
+                timeout=2.0,
+            )
+            return True, label
+        except Exception:
+            continue
+    return False, ""
+
+
+async def copy_to_clipboard_async(text: str) -> tuple[bool, str]:
+    """Async variant — off-loads :func:`copy_to_clipboard` to a thread executor.
+
+    The blocking subprocess (timeout=2 s) runs on the default executor so
+    the event loop stays free to drain other outbox events (streaming
+    chunks, status messages, traces). Without this off-load, a single
+    ``/copy`` could freeze the TUI for up to 2 seconds per clipboard
+    tool attempted.
+
+    Returns the same ``(ok, tool_label)`` shape as the sync version.
+    """
+    import asyncio
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, copy_to_clipboard, text)
+
+
+__all__ = ["copy_to_clipboard", "copy_to_clipboard_async"]

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from collections import deque
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import run_in_terminal
@@ -20,9 +21,58 @@ from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.runtime.registry import AgentRegistry  # #312 PR-A: registry stays in the runtime pkg
 
+from ._clipboard import copy_to_clipboard_async
 from .renderer import ChatRenderer
 
 logger = logging.getLogger(__name__)
+
+# How many recent agent replies `/copy` can target (1 = newest).
+_COPY_BUFFER_MAX = 20
+
+
+def _copy_target(recent_replies, arg: str) -> tuple[str | None, str]:
+    """Pure: resolve a ``/copy`` arg against the newest-first reply buffer.
+
+    Returns ``(text_to_copy, status)``. ``text_to_copy`` is None when there is
+    nothing to copy — ``status`` then explains why (list view / empty buffer /
+    bad arg / out of range). ``recent_replies[0]`` is the newest reply.
+    """
+    arg = (arg or "").strip()
+    n_buf = len(recent_replies)
+
+    def _plural(n: int) -> str:
+        return "reply" if n == 1 else "replies"
+
+    if arg == "list":
+        if not n_buf:
+            return None, "no replies buffered yet"
+        return None, f"{n_buf} {_plural(n_buf)} buffered (/copy N — 1 = newest)"
+    n = 1
+    if arg:
+        if not arg.isdigit() or int(arg) < 1:
+            return None, f"bad /copy arg {arg!r}; use a number (1 = newest) or 'list'"
+        n = int(arg)
+    if not n_buf:
+        return None, "no agent reply to copy yet"
+    if n > n_buf:
+        return None, f"only {n_buf} {_plural(n_buf)} buffered"
+    return recent_replies[n - 1], ""
+
+
+async def _handle_copy_sentinel(recent_replies, arg: str):
+    """Resolve a ``/copy`` request and return a status OutboxMessage to render.
+
+    Replaces the unhandled ``__copy_last_reply__`` sentinel (a silent no-op
+    before this) with a real clipboard copy + a visible result line.
+    """
+    text, status = _copy_target(recent_replies, arg)
+    if text is not None:
+        ok, tool = await copy_to_clipboard_async(text)
+        status = (
+            f"copied reply to clipboard ({tool})" if ok
+            else "no clipboard tool found — install pbcopy / xclip / wl-copy / xsel"
+        )
+    return _simple_status(status)
 
 
 async def _input_loop(
@@ -101,10 +151,19 @@ async def _output_loop(
     reply_seen: asyncio.Event | None = None,
 ) -> None:
     is_tty = sys.stdout.isatty()
+    # Newest-first ring of recent agent replies so `/copy [N]` can grab the
+    # latest (or an older) reply and pipe it to the system clipboard.
+    recent_replies: deque[str] = deque(maxlen=_COPY_BUFFER_MAX)
     while True:
         msg = await registry.repl_outbox.get()
         if msg.kind == "__end__":
             return
+        if msg.kind == "agent":
+            recent_replies.appendleft(msg.text)
+        elif msg.kind == "__copy_last_reply__":
+            # /copy sentinel: resolve + copy, then render the result as a status
+            # line instead of the (unhandled) sentinel — no more silent no-op.
+            msg = await _handle_copy_sentinel(recent_replies, msg.text)
         # On a real terminal: wrap in run_in_terminal so the prompt is cleared
         # before output and redrawn after — required for ANSI/Rich to render
         # cleanly without corrupting the prompt.

--- a/src/reyn/interfaces/slash/copy.py
+++ b/src/reyn/interfaces/slash/copy.py
@@ -1,25 +1,21 @@
 """/copy — copy an agent reply to the system clipboard.
 
-The TUI captures mouse events for its own widget interactions, which breaks
-terminal-native click-and-drag selection. Most terminals offer a modifier-
-key bypass (Option/Fn/Shift drag) but that's an awkward two-handed gesture
-when you just want to grab a response.
-
-ConversationView keeps a bounded ring of the most recent agent replies, so
-this command can target older ones too — not just the latest. The argument
-selects which reply (1 = newest, 2 = one before that, …).
+The inline CUI's output loop keeps a bounded ring of the most recent agent
+replies, so this command can target older ones too — not just the latest. The
+argument selects which reply (1 = newest, 2 = one before that, …).
 
 This command sends a sentinel ``__copy_last_reply__`` OutboxMessage with the
-parsed argument in ``text``; the TUI app intercepts it, fetches the right
-reply via ``ConversationView.reply_at(n)``, and pipes to the platform
-clipboard (``pbcopy`` / ``xclip`` / ``wl-copy`` / ``clip``).
+parsed argument in ``text``; the output loop intercepts it, picks the right
+reply from its ring, and pipes it to the platform clipboard (``pbcopy`` /
+``wl-copy`` / ``xclip`` / ``xsel`` / ``clip``), rendering the result as a
+status line.
 
 Usage::
 
     /copy            # copy the most recent agent reply
     /copy 2          # copy the reply before that (one turn back)
     /copy 3          # ... two turns back
-    /copy list       # show what's currently buffered
+    /copy list       # show how many replies are currently buffered
 """
 from __future__ import annotations
 

--- a/tests/test_copy_target_selection.py
+++ b/tests/test_copy_target_selection.py
@@ -1,0 +1,58 @@
+"""Tier 2: /copy reply selection (_copy_target).
+
+The output loop buffers recent agent replies newest-first; `/copy [N|list]`
+resolves which reply (or a list view / error) to act on. This pins that pure
+selection: newest by default, 1-based indexing back through the ring, a list
+view, and clean messages for empty buffer / out-of-range / bad args (no silent
+no-op, no clipboard call when there is nothing to copy).
+"""
+from __future__ import annotations
+
+from collections import deque
+
+from reyn.interfaces.repl.repl import _copy_target
+
+
+def test_default_selects_newest_reply() -> None:
+    """Tier 2: no arg → the newest reply (index 0)."""
+    text, status = _copy_target(deque(["newest", "older"]), "")
+    assert text == "newest"
+    assert status == ""
+
+
+def test_numeric_arg_indexes_back_one_based() -> None:
+    """Tier 2: /copy 2 → one reply back; 1 = newest."""
+    buf = deque(["r1", "r2", "r3"])
+    assert _copy_target(buf, "1")[0] == "r1"
+    assert _copy_target(buf, "2")[0] == "r2"
+    assert _copy_target(buf, "3")[0] == "r3"
+
+
+def test_empty_buffer_reports_nothing_to_copy() -> None:
+    """Tier 2: nothing buffered → no text, a clear status (not a clipboard call)."""
+    text, status = _copy_target(deque(), "")
+    assert text is None
+    assert "no agent reply" in status
+
+
+def test_out_of_range_reports_buffer_size() -> None:
+    """Tier 2: N beyond the buffer → no text, says how many are buffered."""
+    text, status = _copy_target(deque(["only"]), "5")
+    assert text is None
+    assert "only 1 reply" in status
+
+
+def test_list_shows_buffered_count() -> None:
+    """Tier 2: /copy list → a count view, never a copy."""
+    text, status = _copy_target(deque(["a", "b"]), "list")
+    assert text is None
+    assert "2 replies buffered" in status
+    assert _copy_target(deque(), "list")[1] == "no replies buffered yet"
+
+
+def test_bad_arg_is_rejected_clearly() -> None:
+    """Tier 2: a non-numeric / zero arg → a clear error, no copy."""
+    for bad in ("xyz", "0", "-1"):
+        text, status = _copy_target(deque(["r"]), bad)
+        assert text is None
+        assert "bad /copy arg" in status


### PR DESCRIPTION
**[tui-coder]** — owner-decided slash re-impl（② NEW fix-class、owner: 「/copy = 再実装」）。framework とは独立（clipboard、region 不要）。1 feature = 1 PR。

## Why

`/copy` は `__copy_last_reply__` sentinel を emit していたが、処理する Textual OutboxRouter は cutover で削除済 → inline CUI で silent no-op（lying UI）。output loop（既に全 outbox message を drain）で再実装。

## What

- **clipboard helper を recover**（`interfaces/repl/_clipboard.py`、pbcopy / wl-copy / xclip / xsel / clip、async off-load で遅い tool が loop を stall させない）＝Textual 非依存ゆえ verbatim 復元。
- `_output_loop` に **newest-first の bounded ring**（直近 agent reply、maxlen=20）を保持。
- `__copy_last_reply__` を intercept: target reply を解決（pure `_copy_target` — 既定 newest / 1-based で過去へ / `list` view / empty・out-of-range・bad-arg に clean error）→ copy → 結果を status 行で render（unhandled sentinel の代わり＝silent no-op 解消）。

## Test plan

- [x] Tier 2 `tests/test_copy_target_selection.py`: `_copy_target` の選択（newest / N-back 1-based / list / empty / out-of-range / bad-arg）6 cases
- [x] 回帰: inline/repl suite 93 passed（output-loop containment 含む、agent reply buffering 追加後も不変）
- [x] ruff / tier-audit --strict / verify_module_docstrings green（recover した _clipboard.py の module docstring は move-narrative 除去済で現状記述に書換）
- [ ] (skipped — env) 実 clipboard subprocess（pbcopy 等）の copy は recover した既存 helper（旧 TUI で稼働実績）。`_copy_target` の選択 logic を pin、clipboard 実コピーは手元で `/copy` 実走確認（owner/proxy 復帰時）

## Tier self-check

Tier 2 6 件、pure 選択 logic の behavioral（戻り値 (text, status)）。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
