### PR TITLE
feat(inline): region framework skeleton — generic above-input region (PR-F1)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -36,6 +36,7 @@ from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.patch_stdout import patch_stdout
 
+from reyn.interfaces.inline.region import Region
 from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,10 @@ async def run_inline_input(registry, renderer) -> None:
     # app.exit() — the second raises "Return value already set". _quit checks+sets
     # this before its first await, so only one ever runs to app.exit().
     quitting: dict = {}
+    # Above-input interactive region (framework skeleton): hosts typed-input
+    # interventions / command UIs in later slices. Zero consumers here, so it has
+    # no elements → not visible → collapses → inert (existing behaviour unchanged).
+    above_region = Region()
 
     def _working_frags() -> list:
         return working_line(
@@ -254,6 +259,28 @@ async def run_inline_input(registry, renderer) -> None:
         ),
     )
 
+    def above_region_frags() -> list:
+        out: list = []
+        for i, ln in enumerate(above_region.lines()):
+            if i:
+                out.append(("", "\n"))
+            if i == above_region.cursor:
+                out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
+            else:
+                out.append((f"fg:{_CC_DIM}", f"   {ln}"))
+        return out
+
+    def above_region_height() -> Dimension:
+        return Dimension.exact(len(above_region.lines()))
+
+    above_region_win = Window(
+        FormattedTextControl(above_region_frags, focusable=True),
+        height=above_region_height,
+    )
+    above_region_box = ConditionalContainer(
+        above_region_win, filter=Condition(lambda: above_region.visible)
+    )
+
     kb = KeyBindings()
 
     @kb.add("enter", filter=has_focus(input_win))
@@ -335,7 +362,29 @@ async def run_inline_input(registry, renderer) -> None:
     def _quit_key(event) -> None:
         event.app.create_background_task(_quit(registry, event.app, quitting))
 
-    body = HSplit([working, top_rule, inputrow, bottom_rule, status_win, dropdown])
+    # Above-region focus navigation (inert until a consumer registers an element,
+    # since the region stays invisible + unfocusable while empty). ↑↓ move the
+    # cursor, enter activates the focused row, esc returns to the input.
+    @kb.add("up", filter=has_focus(above_region_win))
+    def _region_up(event) -> None:
+        above_region.navigate(-1)
+
+    @kb.add("down", filter=has_focus(above_region_win))
+    def _region_down(event) -> None:
+        above_region.navigate(1)
+
+    @kb.add("enter", filter=has_focus(above_region_win))
+    def _region_select(event) -> None:
+        above_region.select()
+
+    @kb.add("escape", filter=has_focus(above_region_win))
+    def _region_esc(event) -> None:
+        event.app.layout.focus(input_win)
+
+    body = HSplit(
+        [working, above_region_box, top_rule, inputrow, bottom_rule, status_win,
+         dropdown]
+    )
     app: Application = Application(
         layout=Layout(body, focused_element=input_win),
         key_bindings=kb,

--- a/src/reyn/interfaces/inline/region.py
+++ b/src/reyn/interfaces/inline/region.py
@@ -1,0 +1,94 @@
+"""Generic stacked-element region for the inline CUI (above / below the input).
+
+A ``Region`` hosts UI elements that register themselves; it tracks a single focus
+cursor across the elements' flattened selectable rows and dispatches navigate /
+select to the owning element. An empty region is not visible, so an unused region
+collapses and is inert — the framework adds no behaviour until a consumer
+registers an element.
+
+This is the framework skeleton (PR-F1): the above-input region (interventions,
+command UIs like the /rewind selector) and the below-input region (the status
+menu) are both meant to be ``Region`` instances. Consumers (typed-input
+interventions etc.) arrive in later slices; until then a Region has zero elements
+and changes nothing.
+
+Closed-set inputs (select / confirm / grant-deny) are row-selectors and fit the
+``RegionElement`` protocol below. Free-text input keeps using the normal input
+field, so it needs no region element.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RegionElement(Protocol):
+    """One hosted UI element — a list of selectable rows + a select action.
+
+    ``lines()`` returns the element's current display rows (empty = nothing to
+    show right now). ``on_select(row)`` is invoked with the 0-based row index
+    within THIS element when the user activates the focused row.
+    """
+
+    def lines(self) -> list[str]: ...
+
+    def on_select(self, row: int) -> None: ...
+
+
+class Region:
+    """A focus-tracking stack of :class:`RegionElement`s."""
+
+    def __init__(self) -> None:
+        self._elements: list[RegionElement] = []
+        self._cursor = 0
+
+    def register(self, element: RegionElement) -> None:
+        """Add an element and reset the focus cursor to the top."""
+        self._elements.append(element)
+        self._cursor = 0
+
+    def unregister(self, element: RegionElement) -> None:
+        """Remove an element (idempotent) and reset the cursor."""
+        if element in self._elements:
+            self._elements.remove(element)
+        self._cursor = 0
+
+    def clear(self) -> None:
+        """Drop all elements (e.g. on teardown) and reset the cursor."""
+        self._elements.clear()
+        self._cursor = 0
+
+    def _flat(self) -> list[tuple[RegionElement, int, str]]:
+        """Flatten to ``(element, local_row, text)`` across all elements."""
+        out: list[tuple[RegionElement, int, str]] = []
+        for element in self._elements:
+            for i, text in enumerate(element.lines()):
+                out.append((element, i, text))
+        return out
+
+    @property
+    def visible(self) -> bool:
+        """True when any element has rows to show — else the region collapses."""
+        return any(element.lines() for element in self._elements)
+
+    @property
+    def cursor(self) -> int:
+        """The focus cursor index across the flattened rows."""
+        return self._cursor
+
+    def lines(self) -> list[str]:
+        """All display rows across the hosted elements, in registration order."""
+        return [text for _, _, text in self._flat()]
+
+    def navigate(self, delta: int) -> None:
+        """Move the focus cursor by ``delta`` rows, clamped to the row range."""
+        n = len(self._flat())
+        if n:
+            self._cursor = max(0, min(self._cursor + delta, n - 1))
+
+    def select(self) -> None:
+        """Activate the focused row → its owning element's ``on_select``."""
+        flat = self._flat()
+        if 0 <= self._cursor < len(flat):
+            element, local_row, _ = flat[self._cursor]
+            element.on_select(local_row)

--- a/tests/test_inline_region_framework.py
+++ b/tests/test_inline_region_framework.py
@@ -1,0 +1,81 @@
+"""Tier 2: the inline region framework (Region) — host/focus/navigate/select.
+
+The region hosts RegionElements, tracks one focus cursor across their flattened
+rows, and dispatches select to the owning element. An empty region collapses
+(not visible) so an unused region is inert. Pinned with a recording fake element
+(a real instance, no mocks).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.region import Region
+
+
+class _Element:
+    """A real RegionElement double: fixed rows, records on_select calls."""
+
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows
+        self.selected: list[int] = []
+
+    def lines(self) -> list[str]:
+        return list(self._rows)
+
+    def on_select(self, row: int) -> None:
+        self.selected.append(row)
+
+
+def test_empty_region_is_inert() -> None:
+    """Tier 2: with no elements the region is invisible and navigate/select no-op."""
+    region = Region()
+    assert region.visible is False
+    assert region.lines() == []
+    region.navigate(1)  # no rows → cursor stays
+    region.select()     # nothing to activate
+    assert region.cursor == 0
+
+
+def test_register_makes_region_visible_with_rows() -> None:
+    """Tier 2: a registered element with rows makes the region visible."""
+    region = Region()
+    region.register(_Element(["a", "b"]))
+    assert region.visible is True
+    assert region.lines() == ["a", "b"]
+
+
+def test_navigate_clamps_within_flattened_rows() -> None:
+    """Tier 2: the cursor moves across rows and clamps at both ends."""
+    region = Region()
+    region.register(_Element(["a", "b", "c"]))
+    region.navigate(1)
+    assert region.cursor == 1
+    region.navigate(5)            # clamps at the last row
+    assert region.cursor == 2
+    region.navigate(-10)          # clamps at the first row
+    assert region.cursor == 0
+
+
+def test_select_dispatches_to_owning_element_local_row() -> None:
+    """Tier 2: select activates the focused row on the right element, with the
+    element-local row index (cursor spans multiple elements)."""
+    e1 = _Element(["x0", "x1"])
+    e2 = _Element(["y0", "y1"])
+    region = Region()
+    region.register(e1)
+    region.register(e2)
+    region.navigate(3)            # cursor at flattened row 3 → e2's local row 1
+    region.select()
+    assert e2.selected == [1]
+    assert e1.selected == []
+
+
+def test_unregister_and_clear_collapse_the_region() -> None:
+    """Tier 2: removing elements makes the region invisible again."""
+    e = _Element(["a"])
+    region = Region()
+    region.register(e)
+    region.unregister(e)
+    assert region.visible is False
+    region.register(_Element(["b"]))
+    region.clear()
+    assert region.visible is False
+    assert region.lines() == []


### PR DESCRIPTION
**[tui-coder]** — above/below-input **region framework** の **PR-F1（skeleton）**。#2223 設計 APPROVE 済、lead GO。staged F1→F5 の第1スライス。

## What（consumer ゼロ＝既存挙動不変）

generic **`Region`** 抽象（`interfaces/inline/region.py`）:
- UI element が `register` し、region は flattened selectable rows 横断で **focus cursor 1つ**を track、`navigate`/`select` を owning element に dispatch。
- **空 region = not visible → collapse → inert**（未使用 region は何もしない）。
- closed-set input（select/confirm/grant-deny）は `RegionElement` protocol（`lines()` + `on_select(row)`）に適合。**free-text は input 欄を継続使用**ゆえ region element 不要。

inline Application layout に **above-input region を配線**（working row と input の間）+ ↑↓ navigate / enter select / esc→input の keybinding。**consumer ゼロゆえ region は空→invisible→unfocusable** = 既存挙動 byte-identical。consumer（typed-input intervention / /rewind selector / status-menu）は F2–F5。**plain / --cui / 非TTY 不変**（framework は inline 専用）。

## 設計対応（#2223 + lead 5観点）

- region API（register/visible/navigate/select/lines）= above/below 共通抽象（観点3）。
- F1 は skeleton（観点5 staged の最初）。typed-input dispatch / intervention 統一 / input_type field は F2。
- invariance（観点4）: inline Application 内のみ、backend 不変。

## Test plan

- [x] Tier 2 `tests/test_inline_region_framework.py`: empty=inert / register→visible / navigate clamp（element 横断）/ select が element-local row を dispatch / unregister・clear で collapse（real fake element、no mock）
- [x] inert 確認: 空 Region `visible=False`、app import OK
- [x] 回帰: inline app/menu suite 21 passed（既存挙動不変）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [ ] (skipped — interactive) live tmux 確認は F2（intervention consumer 追加＝可視化）時に cost-warn live-verify と併せて

## Tier self-check

Tier 2 5 件、behavioral（visible/cursor/dispatch）。format-pin / mock / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
