### PR TITLE
fix(#2226): exists-based _hydrate_binding reflects an explicit unbind (Slice 1)

### DIFF
--- a/src/reyn/task/backend.py
+++ b/src/reyn/task/backend.py
@@ -202,9 +202,13 @@ class InMemoryTaskBackend:
         for, so the stored-column value is the fallback. No-op when there is no
         reader."""
         if task is not None and self._subscription_reader is not None:
-            a = self._subscription_reader.assignee_of(task.task_id)
-            if a is not None:
-                task.assignee = a
+            if self._subscription_reader.exists(task.task_id):
+                # The record is authoritative — apply its assignee even when None (an
+                # explicit unbind → UNASSIGNED, #2226). A bare ``assignee_of() is None``
+                # check had fallen back to the stored placeholder, so a re-queued task
+                # kept reading its OLD binding. A non-existent record (direct construction
+                # / no writer) keeps the stored value (the fallback).
+                task.assignee = self._subscription_reader.assignee_of(task.task_id)
             r = self._subscription_reader.requester_of(task.task_id)
             if r is not None:
                 task.requester = r

--- a/src/reyn/task/sqlite_backend.py
+++ b/src/reyn/task/sqlite_backend.py
@@ -151,9 +151,13 @@ class SqliteTaskBackend:
         record for, so the stored-column value is the fallback. No-op when there
         is no reader."""
         if task is not None and self._subscription_reader is not None:
-            a = self._subscription_reader.assignee_of(task.task_id)
-            if a is not None:
-                task.assignee = a
+            if self._subscription_reader.exists(task.task_id):
+                # The record is authoritative — apply its assignee even when None (an
+                # explicit unbind → UNASSIGNED, #2226). A bare ``assignee_of() is None``
+                # check had fallen back to the stored placeholder, so a re-queued task
+                # kept reading its OLD binding. A non-existent record (direct construction
+                # / no writer) keeps the stored value (the fallback).
+                task.assignee = self._subscription_reader.assignee_of(task.task_id)
             r = self._subscription_reader.requester_of(task.task_id)
             if r is not None:
                 task.requester = r

--- a/tests/test_2226_unbind_hydrate.py
+++ b/tests/test_2226_unbind_hydrate.py
@@ -1,0 +1,61 @@
+"""Tier 2: #2226 — the read-through reflects an explicit unbind (assignee → None).
+
+The #2224 pending-queue rebinds a task's assignee via the WAL subscription
+(``record_rebound``). An explicit UNBIND — ``record_rebound(assignee=None)``, the §67
+re-queue primitive — must make the read-through report ``assignee is None`` (UNASSIGNED)
+on BOTH backends. Before #2226 ``_hydrate_binding`` overlaid only a NON-None subscription
+assignee, so an unbind fell back to the STORED placeholder (the old binding the in-memory
+backend kept, or the sqlite ``""`` placeholder) → the task kept reading its OLD assignee
+instead of becoming unassigned. The exists-based hydrate (a record's assignee is
+authoritative, including ``None``) is the fix; this also normalizes the cross-backend read
+of a #2224 UNASSIGNED task (both overlay the subscription's ``None``).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.task import InMemoryTaskBackend, SqliteTaskBackend, Task, TaskState
+from reyn.task.subscription import SubscriptionRegistry
+from tests._support.task_subscription import SubscriptionBackend
+
+
+def _backend(which: str, cp: SubscriptionRegistry, tmp_path):
+    real = (
+        InMemoryTaskBackend(subscription_reader=cp) if which == "inmem"
+        else SqliteTaskBackend(str(tmp_path / "tasks.db"), subscription_reader=cp)
+    )
+    return SubscriptionBackend(real, cp)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("which", ["inmem", "sqlite"])
+async def test_explicit_unbind_reads_as_unassigned(which, tmp_path):
+    """Tier 2: ``record_rebound(assignee=None)`` → ``get(task).assignee is None`` on BOTH
+    backends. RED before #2226: the non-None-only overlay fell back to the stored
+    placeholder — the kept old binding (in-memory) or ``""`` (sqlite) — so the unbind was
+    invisible and the task still read its old assignee."""
+    cp = SubscriptionRegistry()
+    backend = _backend(which, cp, tmp_path)
+    # an ASSIGNED task — the binding (assignee=sess-A) is recorded on create.
+    await backend.create(Task(task_id="t1", name="t", assignee="sess-A", requester="root",
+                              status=TaskState.RUNNING))
+    assert (await backend.get("t1")).assignee == "sess-A"
+    # explicit unbind (the §67 re-queue primitive): record_rebound(assignee=None).
+    cp.apply("task_rebound", 999, {"task_id": "t1", "assignee": None})
+    got = await backend.get("t1")
+    assert got.assignee is None, f"unbind not reflected — read {got.assignee!r}, expected None"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("which", ["inmem", "sqlite"])
+async def test_unassigned_task_reads_none_uniformly(which, tmp_path):
+    """Tier 2: a #2224 UNASSIGNED task (created with assignee=None → the subscription
+    records None) reads ``assignee is None`` on BOTH backends — the cross-backend
+    normalization (sqlite previously fell back to its ``""`` placeholder)."""
+    cp = SubscriptionRegistry()
+    backend = _backend(which, cp, tmp_path)
+    await backend.create(Task(task_id="u1", name="u", assignee=None, requester="root",
+                              status=TaskState.UNASSIGNED))
+    got = await backend.get("u1")
+    assert got.assignee is None, f"unassigned read {got.assignee!r}, expected None"
+    assert got.status is TaskState.UNASSIGNED


### PR DESCRIPTION
**[e2e-coder]** — #2226 **Slice 1**: exists-based `_hydrate_binding` reflects an explicit unbind (`assignee → None`). Lead-confirmed scope: the mechanical hydrate-fix only; the re-queue primitive + owner-disappeared trigger defer to the recovery-leg follow-up (tracked at #2226).

## The seam

`_hydrate_binding` (both backends) overlaid the WAL-subscription binding onto a fetched Task **only when the subscription assignee was non-None** (`if a is not None: task.assignee = a`). So an explicit unbind — `record_rebound(assignee=None)`, the §67 re-queue primitive — fell back to the **stored placeholder**: the kept old binding (in-memory) or the sqlite `""` placeholder. The task kept reading its OLD assignee instead of becoming UNASSIGNED. The same fall-back caused a #2224 UNASSIGNED task to read inconsistently across backends (None in-memory vs `""` sqlite).

## The fix

A subscription **record is authoritative** — apply its assignee even when `None` (an explicit unbind / UNASSIGNED), gated on `reader.exists(task_id)`. A non-existent record (direct construction / no writer) still keeps the stored value (the fallback is preserved for that case). One change, both backends, resolves:

- **unbind seam** — `record_rebound(None)` now reads `assignee=None` (the working re-queue primitive).
- **cross-backend normalization** — a #2224 UNASSIGNED task (its subscription records `None`) reads `None` on both the in-memory and sqlite backends.

## Real caller today

This isn't an unproven method — its caller exists now: #2224's UNASSIGNED tasks (created via `task.create` with no assignee) are read through `_hydrate_binding` on every `get`/`list`, and now read `None` consistently.

## Deferred (with its caller)

The §67 **re-queue behavior** (the owner-disappeared auto-trigger + a backend re-queue primitive) lands in the recovery-leg follow-up, where the 5d recovery auto-detection is the primitive's production callsite (a new method needs a production caller). The owner-gone detection is deep in 5d recovery semantics + proxy-gated, so it co-designs with the recovery-leg live A/B — a reasoned defer. No manual `task.release`/`unassign` op (not in §27-31 — unrequested).

## Test plan

- [x] **`tests/test_2226_unbind_hydrate.py`** (NEW, Tier 2, 4 cases = 2 tests × {in-memory, sqlite}): `record_rebound(None)` → `get().assignee is None` on both backends; a #2224 UNASSIGNED task reads `None` uniformly. **Falsify-verified RED** on BOTH backends when the hydrate is reverted to non-None-only (the unbind falls back to the kept old binding / `""`).
- [x] All 4 CI gates: `ruff check src tests` ✓; `test_tier_audit.py --strict` ✓ (2 tests); `verify_module_docstrings.py` ✓; **full rootdir `pytest`** ✓ — the hydrate change (a core read-path) introduces **zero new failures**; the only 4 failures are the pre-existing env quirks (gateway entry-points ×3, `reyn.safe` relocate) verified on clean main + green in CI's proper install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
