### PR TITLE
feat(inline): host closed-set interventions in the above region (PR-F2)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -17,6 +17,7 @@ actionable model picker (selecting a class) is a follow-up.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -36,6 +37,7 @@ from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.patch_stdout import patch_stdout
 
+from reyn.interfaces.inline.intervention_region import build_intervention_element
 from reyn.interfaces.inline.region import Region
 from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
 
@@ -163,10 +165,12 @@ async def run_inline_input(registry, renderer) -> None:
     # app.exit() — the second raises "Return value already set". _quit checks+sets
     # this before its first await, so only one ever runs to app.exit().
     quitting: dict = {}
-    # Above-input interactive region (framework skeleton): hosts typed-input
-    # interventions / command UIs in later slices. Zero consumers here, so it has
-    # no elements → not visible → collapses → inert (existing behaviour unchanged).
+    # Above-input interactive region: hosts the active closed-set intervention
+    # (confirm / select / grant-deny) as a selectable list, poll-driven off the
+    # session head (like the status chips). Free-text interventions keep using the
+    # input field, so they get no element. Empty region collapses (inert).
     above_region = Region()
+    iv_holder: dict = {"iv_id": None}  # which intervention the region is showing
 
     def _working_frags() -> list:
         return working_line(
@@ -381,6 +385,48 @@ async def run_inline_input(registry, renderer) -> None:
     def _region_esc(event) -> None:
         event.app.layout.focus(input_win)
 
+    async def _deliver_choice(choice_id: str) -> None:
+        s = registry.attached_session()
+        if s is not None:
+            try:
+                await s.answer_oldest_intervention_choice(choice_id)
+            except Exception:
+                logger.exception("inline: delivering intervention choice failed")
+
+    def _sync_intervention_region() -> None:
+        """Sync the above-region with the session's head closed-set intervention.
+
+        Poll-driven (like the status chips). When a new closed-set intervention is
+        pending, register a selector element + auto-focus it; when it resolves /
+        is gone, clear it and hand focus back to the input. Inert when nothing is
+        pending — same as an empty region.
+        """
+        s = registry.attached_session()
+        head = s.interventions.head() if s is not None else None
+        head_id = head.id if (head is not None and getattr(head, "choices", None)) else None
+        if head_id == iv_holder["iv_id"]:
+            return
+        above_region.clear()
+        iv_holder["iv_id"] = head_id
+        if head_id is None:
+            app.layout.focus(input_win)
+            return
+        element = build_intervention_element(
+            head, lambda cid: app.create_background_task(_deliver_choice(cid))
+        )
+        if element is not None:
+            above_region.register(element)
+            app.layout.focus(above_region_win)
+
+    async def _intervention_poll() -> None:
+        while True:
+            await asyncio.sleep(0.15)
+            try:
+                _sync_intervention_region()
+                app.invalidate()
+            except Exception:
+                logger.exception("inline: intervention region poll failed")
+
     body = HSplit(
         [working, above_region_box, top_rule, inputrow, bottom_rule, status_win,
          dropdown]
@@ -395,8 +441,12 @@ async def run_inline_input(registry, renderer) -> None:
     # above the live input region instead of corrupting it — mirrors the
     # PromptSession path. Renderer output (sys.__stdout__ via run_in_terminal in
     # _output_loop) is unaffected.
-    with patch_stdout():
-        await app.run_async()
+    poll_task = asyncio.create_task(_intervention_poll())
+    try:
+        with patch_stdout():
+            await app.run_async()
+    finally:
+        poll_task.cancel()
 
 
 async def _submit(registry, text: str) -> None:

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -385,14 +385,6 @@ async def run_inline_input(registry, renderer) -> None:
     def _region_esc(event) -> None:
         event.app.layout.focus(input_win)
 
-    async def _deliver_choice(choice_id: str) -> None:
-        s = registry.attached_session()
-        if s is not None:
-            try:
-                await s.answer_oldest_intervention_choice(choice_id)
-            except Exception:
-                logger.exception("inline: delivering intervention choice failed")
-
     def _sync_intervention_region() -> None:
         """Sync the above-region with the session's head closed-set intervention.
 
@@ -412,7 +404,10 @@ async def run_inline_input(registry, renderer) -> None:
             app.layout.focus(input_win)
             return
         element = build_intervention_element(
-            head, lambda cid: app.create_background_task(_deliver_choice(cid))
+            head,
+            lambda cid, label: app.create_background_task(
+                _deliver_intervention_choice(registry, cid, label)
+            ),
         )
         if element is not None:
             above_region.register(element)
@@ -447,6 +442,34 @@ async def run_inline_input(registry, renderer) -> None:
             await app.run_async()
     finally:
         poll_task.cancel()
+
+
+async def _deliver_intervention_choice(registry, choice_id: str, label: str) -> None:
+    """Deliver a region-selected intervention choice + echo it to scrollback.
+
+    The chosen choice id is delivered authoritatively (choice_id_override). On
+    success, a uniform ``answered: <label>`` line is put on the outbox so EVERY
+    resolved intervention leaves a trace in the conversation — not just the ones
+    (like permission) whose side effect happens to be visible. ask_user /
+    safety-limit interventions otherwise vanish from scrollback on resolution.
+    """
+    s = registry.attached_session()
+    if s is None:
+        return
+    try:
+        delivered = await s.answer_oldest_intervention_choice(choice_id)
+    except Exception:
+        logger.exception("inline: delivering intervention choice failed")
+        return
+    if delivered:
+        from reyn.runtime.outbox import OutboxMessage
+        # kind="intervention" (not "status") so the echo PERSISTS in scrollback:
+        # "status"/"trace" are transient (cleared by the next message), and the
+        # intervention_resolved event fires right after, so a status echo would be
+        # erased before the user sees it.
+        registry.repl_outbox.put_nowait(
+            OutboxMessage(kind="intervention", text=f"answered: {label}")
+        )
 
 
 async def _submit(registry, text: str) -> None:

--- a/src/reyn/interfaces/inline/intervention_region.py
+++ b/src/reyn/interfaces/inline/intervention_region.py
@@ -1,0 +1,61 @@
+"""Intervention consumer of the inline region framework.
+
+A closed-set intervention (confirm / select / grant-deny — anything with
+``choices``) is hosted in the above-input region as a selectable list: one row
+per choice, Enter delivers the chosen choice id authoritatively (via
+``Session.answer_oldest_intervention_choice``, reusing the choice_id_override
+path). Free-text interventions keep using the normal input field, so they get no
+region element.
+
+The region is poll-driven (like the status chips): the app reads the session's
+head intervention each refresh and syncs the element — built here, never reaching
+into prompt_toolkit so the mapping is unit-testable.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+
+class InterventionElement:
+    """A RegionElement for one closed-set intervention.
+
+    ``lines()`` are the choice labels (the selectable rows); ``on_select(row)``
+    fires ``on_choose`` with that choice's id. ``iv_id`` ties the element to its
+    intervention so the poll sync can tell when it has been resolved/replaced.
+    """
+
+    def __init__(
+        self,
+        iv_id: str,
+        choices: list[tuple[str, str]],
+        on_choose: Callable[[str], None],
+    ) -> None:
+        # choices: [(choice_id, label), ...]
+        self._iv_id = iv_id
+        self._choices = list(choices)
+        self._on_choose = on_choose
+
+    @property
+    def iv_id(self) -> str:
+        return self._iv_id
+
+    def lines(self) -> list[str]:
+        return [label for _, label in self._choices]
+
+    def on_select(self, row: int) -> None:
+        if 0 <= row < len(self._choices):
+            self._on_choose(self._choices[row][0])
+
+
+def build_intervention_element(iv, on_choose: Callable[[str], None]):
+    """Build an :class:`InterventionElement` for a closed-set intervention, or
+    None for a free-text one (no choices → handled by the input field).
+
+    ``iv`` is a UserIntervention (read for ``id`` + ``choices``); kept duck-typed
+    so the mapping is testable with a plain stand-in.
+    """
+    choices = getattr(iv, "choices", None) or []
+    if not choices:
+        return None
+    rows = [(c.id, c.label) for c in choices]
+    return InterventionElement(iv.id, rows, on_choose)

--- a/src/reyn/interfaces/inline/intervention_region.py
+++ b/src/reyn/interfaces/inline/intervention_region.py
@@ -28,7 +28,7 @@ class InterventionElement:
         self,
         iv_id: str,
         choices: list[tuple[str, str]],
-        on_choose: Callable[[str], None],
+        on_choose: Callable[[str, str], None],
     ) -> None:
         # choices: [(choice_id, label), ...]
         self._iv_id = iv_id
@@ -44,10 +44,11 @@ class InterventionElement:
 
     def on_select(self, row: int) -> None:
         if 0 <= row < len(self._choices):
-            self._on_choose(self._choices[row][0])
+            choice_id, label = self._choices[row]
+            self._on_choose(choice_id, label)
 
 
-def build_intervention_element(iv, on_choose: Callable[[str], None]):
+def build_intervention_element(iv, on_choose: Callable[[str, str], None]):
     """Build an :class:`InterventionElement` for a closed-set intervention, or
     None for a free-text one (no choices → handled by the input field).
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4350,6 +4350,19 @@ class Session:
         """Thin wrapper → InterventionHandler.maybe_answer."""
         return await self._intervention_handler.maybe_answer(text)
 
+    async def answer_oldest_intervention_choice(self, choice_id: str) -> bool:
+        """Deliver a chosen choice id to the oldest pending intervention.
+
+        The inline region selector calls this when the user picks a choice: the
+        id is authoritative (bypasses text/hotkey ``match_choice``), reusing the
+        same ``choice_id_override`` path A2A peer answers use. Returns False when
+        nothing is pending. A public UI seam for closed-set typed-input.
+        """
+        iv = self._interventions.head()
+        if iv is None:
+            return False
+        return await self._deliver_answer_to(iv, "", choice_id_override=choice_id)
+
     async def _deliver_answer_to(
         self,
         iv: UserIntervention,

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -77,6 +77,10 @@ class UserIntervention:
     detail: str = ""                                                   # optional second-line context
     choices: list[InterventionChoice] = field(default_factory=list)
     suggestions: list[str] = field(default_factory=list)               # ask_user only
+    # HTML-like input type a typed-input UI renders by (text / select / confirm /
+    # grant-deny / …). "" = infer from shape (no choices → free text; choices →
+    # a closed-set selector). Backward-compatible: existing callers leave it "".
+    input_type: str = ""
     run_id: str | None = None
     skill_name: str | None = None
     # issue #268: identifies the channel that initiated this intervention
@@ -94,6 +98,17 @@ class UserIntervention:
     def __post_init__(self) -> None:
         if self.future is None:
             self.future = _make_placeholder_future()
+
+    @property
+    def effective_input_type(self) -> str:
+        """The input type a UI should render by, inferring when unset.
+
+        Explicit ``input_type`` wins; otherwise a closed-set (has ``choices``) is
+        a ``select`` and an empty one is free ``text``.
+        """
+        if self.input_type:
+            return self.input_type
+        return "select" if self.choices else "text"
 
     def to_dict(self) -> dict:
         """Serialize persistent fields for crash-recovery storage.
@@ -117,6 +132,8 @@ class UserIntervention:
             "skill_name": self.skill_name,
             "id": self.id,
         }
+        if self.input_type:
+            out["input_type"] = self.input_type
         if self.origin_channel_id is not None:
             out["origin_channel_id"] = self.origin_channel_id
         return out
@@ -141,6 +158,7 @@ class UserIntervention:
             detail=data.get("detail", ""),
             choices=choices,
             suggestions=list(data.get("suggestions") or []),
+            input_type=data.get("input_type", ""),
             run_id=data.get("run_id"),
             skill_name=data.get("skill_name"),
             origin_channel_id=data.get("origin_channel_id"),

--- a/tests/test_inline_intervention_region.py
+++ b/tests/test_inline_intervention_region.py
@@ -1,0 +1,114 @@
+"""Tier 2: intervention typed-input region consumer (F2 mechanism).
+
+A closed-set intervention (has choices) maps to an InterventionElement whose rows
+are the choice labels and whose select delivers the chosen choice id; a free-text
+intervention (no choices) maps to None (it keeps the input field). Also pins the
+UserIntervention input_type field: explicit value wins, else inferred from shape,
+and it round-trips through to_dict/from_dict.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.intervention_region import (
+    InterventionElement,
+    build_intervention_element,
+)
+from reyn.runtime.session import Session
+from reyn.user_intervention import InterventionChoice, UserIntervention
+
+
+def _iv(choices: list[tuple[str, str]]):
+    return SimpleNamespace(
+        id="iv1",
+        choices=[SimpleNamespace(id=cid, label=label) for cid, label in choices],
+    )
+
+
+def test_element_rows_are_choice_labels() -> None:
+    """Tier 2: the element's selectable rows are the choice labels."""
+    el = InterventionElement("iv1", [("yes", "[y]es"), ("no", "[n]o")], lambda c: None)
+    assert el.lines() == ["[y]es", "[n]o"]
+    assert el.iv_id == "iv1"
+
+
+def test_select_delivers_the_chosen_choice_id() -> None:
+    """Tier 2: selecting a row fires on_choose with that row's choice id."""
+    chosen: list[str] = []
+    el = InterventionElement(
+        "iv1", [("yes", "[y]es"), ("no", "[n]o")], chosen.append
+    )
+    el.on_select(1)
+    assert chosen == ["no"]
+    el.on_select(99)  # out of range → no delivery
+    assert chosen == ["no"]
+
+
+def test_build_element_for_closed_set_and_none_for_free_text() -> None:
+    """Tier 2: a closed-set iv builds an element; a free-text iv (no choices)
+    builds None (it uses the input field instead)."""
+    el = build_intervention_element(_iv([("a", "[a]"), ("b", "[b]")]), lambda c: None)
+    assert el is not None
+    assert el.lines() == ["[a]", "[b]"]
+    assert build_intervention_element(_iv([]), lambda c: None) is None
+
+
+def test_effective_input_type_explicit_wins_else_inferred() -> None:
+    """Tier 2: input_type explicit wins; else inferred (choices→select, none→text)."""
+    text_iv = UserIntervention(kind="ask_user", prompt="q")
+    assert text_iv.effective_input_type == "text"
+    select_iv = UserIntervention(
+        kind="permission.file", prompt="ok?",
+        choices=[InterventionChoice(id="y", label="[y]es", hotkey="y")],
+    )
+    assert select_iv.effective_input_type == "select"
+    explicit = UserIntervention(kind="ask_user", prompt="q", input_type="confirm")
+    assert explicit.effective_input_type == "confirm"
+
+
+def test_input_type_round_trips_through_dict() -> None:
+    """Tier 2: a non-default input_type survives to_dict/from_dict."""
+    iv = UserIntervention(kind="ask_user", prompt="q", input_type="grant-deny")
+    restored = UserIntervention.from_dict(iv.to_dict())
+    assert restored.input_type == "grant-deny"
+    # default stays "" and is omitted from the dict (backward-compat)
+    plain = UserIntervention(kind="ask_user", prompt="q")
+    assert "input_type" not in plain.to_dict()
+    assert UserIntervention.from_dict(plain.to_dict()).input_type == ""
+
+
+@pytest.mark.asyncio
+async def test_answer_oldest_intervention_choice_delivers_authoritatively(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the region's choice-id seam resolves the head intervention with
+    the chosen id (authoritative — no text/hotkey match needed)."""
+    monkeypatch.chdir(tmp_path)
+    session = Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+    session.register_intervention_listener("test")
+    iv = UserIntervention(
+        kind="permission.file", prompt="ok?",
+        choices=[
+            InterventionChoice(id="yes", label="[y]es", hotkey="y"),
+            InterventionChoice(id="no", label="[n]o", hotkey="n"),
+        ],
+    )
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(session._dispatch_intervention(iv))
+    for _ in range(200):  # wait until the iv is pending
+        if session.interventions.list_active():
+            break
+        await asyncio.sleep(0.01)
+
+    delivered = await session.answer_oldest_intervention_choice("no")
+    assert delivered is True
+    answer = await asyncio.wait_for(task, timeout=2.0)
+    assert answer.choice_id == "no"

--- a/tests/test_inline_intervention_region.py
+++ b/tests/test_inline_intervention_region.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.app import _deliver_intervention_choice
 from reyn.interfaces.inline.intervention_region import (
     InterventionElement,
     build_intervention_element,
@@ -31,27 +32,29 @@ def _iv(choices: list[tuple[str, str]]):
 
 def test_element_rows_are_choice_labels() -> None:
     """Tier 2: the element's selectable rows are the choice labels."""
-    el = InterventionElement("iv1", [("yes", "[y]es"), ("no", "[n]o")], lambda c: None)
+    el = InterventionElement(
+        "iv1", [("yes", "[y]es"), ("no", "[n]o")], lambda c, lbl: None
+    )
     assert el.lines() == ["[y]es", "[n]o"]
     assert el.iv_id == "iv1"
 
 
-def test_select_delivers_the_chosen_choice_id() -> None:
-    """Tier 2: selecting a row fires on_choose with that row's choice id."""
-    chosen: list[str] = []
+def test_select_delivers_the_chosen_choice_id_and_label() -> None:
+    """Tier 2: selecting a row fires on_choose with that row's (id, label)."""
+    chosen: list[tuple[str, str]] = []
     el = InterventionElement(
-        "iv1", [("yes", "[y]es"), ("no", "[n]o")], chosen.append
+        "iv1", [("yes", "[y]es"), ("no", "[n]o")], lambda c, lbl: chosen.append((c, lbl))
     )
     el.on_select(1)
-    assert chosen == ["no"]
+    assert chosen == [("no", "[n]o")]
     el.on_select(99)  # out of range → no delivery
-    assert chosen == ["no"]
+    assert chosen == [("no", "[n]o")]
 
 
 def test_build_element_for_closed_set_and_none_for_free_text() -> None:
     """Tier 2: a closed-set iv builds an element; a free-text iv (no choices)
     builds None (it uses the input field instead)."""
-    el = build_intervention_element(_iv([("a", "[a]"), ("b", "[b]")]), lambda c: None)
+    el = build_intervention_element(_iv([("a", "[a]"), ("b", "[b]")]), lambda c, lbl: None)
     assert el is not None
     assert el.lines() == ["[a]", "[b]"]
     assert build_intervention_element(_iv([]), lambda c: None) is None
@@ -112,3 +115,43 @@ async def test_answer_oldest_intervention_choice_delivers_authoritatively(
     assert delivered is True
     answer = await asyncio.wait_for(task, timeout=2.0)
     assert answer.choice_id == "no"
+
+
+class _AnsweringSession:
+    def __init__(self, *, ok: bool) -> None:
+        self._ok = ok
+        self.delivered: list[str] = []
+
+    async def answer_oldest_intervention_choice(self, choice_id: str) -> bool:
+        self.delivered.append(choice_id)
+        return self._ok
+
+
+@pytest.mark.asyncio
+async def test_deliver_choice_echoes_answer_to_scrollback() -> None:
+    """Tier 2: a delivered choice is sent authoritatively AND a uniform
+    'answered: <label>' status line is put on the outbox (so every resolved
+    intervention leaves a scrollback trace, not just permission's side effect)."""
+    session = _AnsweringSession(ok=True)
+    queue: asyncio.Queue = asyncio.Queue()
+    registry = SimpleNamespace(attached_session=lambda: session, repl_outbox=queue)
+
+    await _deliver_intervention_choice(registry, "just_path", "[j]ust this path always")
+
+    assert session.delivered == ["just_path"]  # authoritative id delivered
+    msg = queue.get_nowait()
+    # persistent kind (not the transient "status", which the next message erases)
+    assert msg.kind == "intervention"
+    assert "answered:" in msg.text
+    assert "[j]ust this path always" in msg.text
+
+
+@pytest.mark.asyncio
+async def test_deliver_choice_no_echo_when_nothing_delivered() -> None:
+    """Tier 2: no echo when delivery reports nothing resolved (no false trace)."""
+    queue: asyncio.Queue = asyncio.Queue()
+    registry = SimpleNamespace(
+        attached_session=lambda: _AnsweringSession(ok=False), repl_outbox=queue
+    )
+    await _deliver_intervention_choice(registry, "x", "lbl")
+    assert queue.empty()


### PR DESCRIPTION
**[tui-coder]** — region framework **PR-F2（intervention typed-input）**。#2223 設計どおり、lead GO 済。staged F2。F1 merged の上。

## What

closed-set intervention（confirm / select / grant-deny ＝ choices あり）を above-region に selectable list で表示、↑↓ 選択・Enter で回答。free-text は input 欄継続。

- **`UserIntervention.input_type`**（HTML 風: text/select/confirm/grant-deny…、""=shape 推論）+ `effective_input_type` property + to_dict/from_dict round-trip（後方互換: default "" は dict から省略）。
- **`Session.answer_oldest_intervention_choice(choice_id)`** — public UI seam、選択 id を **authoritative 配送**（既存 `choice_id_override` path 再利用＝text/hotkey match 不要、A2A peer と同一配送機構）。lead の「既存 path 整合」確認点に対応。
- **`intervention_region.py`**: `InterventionElement`（iv.choices から構築の RegionElement）+ `build_intervention_element`（free-text は None）。
- **`run_inline_input`** が session head intervention を毎 tick poll（status chips と同方式）→ element register/clear + 新規 prompt で auto-focus。**pending 無い時 inert**（common path 不変）。plain/--cui/backend 不変。

## Test plan

- [x] Tier 2 `tests/test_inline_intervention_region.py`（6件）: element rows=choice labels / select→choice id 配送 / build（closed-set→element, free-text→None）/ effective_input_type（explicit/inferred）/ input_type round-trip / **seam integration**（real session が head iv を選択 id で resolve、`answer.choice_id` 確認）
- [x] 回帰: inline + intervention + user_intervention serialization 189 + 33 passed（input_type field / seam で破壊なし）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [ ] (deferred — proxy down) live tmux verify: cost-warn confirm を region 表示→↑↓選択→answer 配送（owner の proxy 復帰待ち、turn 不要ゆえ weak-model 無関係）。interactive poll/auto-focus 配線は構築検証 + inert-when-idle property で担保、live は proxy 復帰時

## Tier self-check

Tier 2 6件、behavioral（element mapping / seam の choice_id / round-trip）。format-pin / mock（real Session + SimpleNamespace stand-in）/ private-state assert なし（`_dispatch_intervention` は既存 test と同じ dispatch setup）。`--strict` green。interactive 配線（poll/auto-focus）は unit 不能ゆえ tmux deferred を明記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
