### PR TITLE
fix(#2230): thread cost_warn config into the session so the warn/block gate fires

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -412,6 +412,7 @@ def run(args: argparse.Namespace) -> None:
             # resolves at session-construction time.
             task_backend=registry.task_backend,
             events_config=session_cfg.config.events,
+            cost_warn_config=session_cfg.config.cost_warn,  # #2230: wire the warn/block gate
             state_log=state_log,
             budget_tracker=budget_tracker,
             hooks_config=session_cfg.config.hooks,  # #1800 slice 5b (pass-through, not bundled)

--- a/src/reyn/runtime/model_cost_warn.py
+++ b/src/reyn/runtime/model_cost_warn.py
@@ -36,7 +36,7 @@ def maybe_emit_model_cost_warn(
     the trigger context (``"session_start"`` vs ``"model_override"``).
     """
     try:
-        cost_warn_cfg = session._config.cost_warn
+        cost_warn_cfg = session._cost_warn_config
         if not cost_warn_cfg.enabled:
             return
 
@@ -99,7 +99,7 @@ async def maybe_block_high_cost_model(
     The *explicit* non-interactive case above is the one place this fails closed.
     """
     try:
-        cost_warn_cfg = session._config.cost_warn
+        cost_warn_cfg = session._cost_warn_config
         if not cost_warn_cfg.enabled or not cost_warn_cfg.block_on_high_cost:
             return True
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from reyn.config import (  # noqa: F401
     ActionRetrievalConfig,
+    CostWarnConfig,
     EmbeddingConfig,
     EventsConfig,
     MultimodalConfig,
@@ -805,6 +806,11 @@ class Session:
         allowed_skills: list[str] | None = None,
         allowed_mcp: list[str] | None = None,
         events_config: EventsConfig | None = None,
+        # #2230: the resolved ``cost_warn:`` config so the high-cost model warn /
+        # block actually fires in production. Without it the session had no
+        # config to read and the gate silently no-op'd (fail-open). None →
+        # defaults (warn-only, block off) = the head-less / scripted equivalent.
+        cost_warn_config: CostWarnConfig | None = None,
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
@@ -1210,6 +1216,10 @@ class Session:
 
         # PR20: per-chat rotation policy. Defaults match EventsConfig.
         self._events_config = events_config or EventsConfig()
+        # #2230: read by model_cost_warn's warn/block gates. Always set (default
+        # when unthreaded) so the read can't AttributeError into a silent
+        # fail-open — the production bug this fixes.
+        self._cost_warn_config = cost_warn_config or CostWarnConfig()
 
         # PR21: WAL + per-agent snapshot for crash recovery. state_log is
         # process-shared (owned by AgentRegistry); when None, persistence

--- a/tests/cli/test_model_cost_block_1867.py
+++ b/tests/cli/test_model_cost_block_1867.py
@@ -69,13 +69,13 @@ class _FakeSession:
         non_interactive: bool = False,
         checkpoint_allows: bool = True,
     ) -> None:
-        self._config = type("Cfg", (), {
-            "cost_warn": CostWarnConfig(
-                enabled=True,
-                model_threshold_per_1m_input_usd=threshold,
-                block_on_high_cost=block,
-            ),
-        })()
+        # #2230: the production attribute the gate reads (was a fabricated
+        # ``_config`` wrapper that masked the unwired-in-production bug).
+        self._cost_warn_config = CostWarnConfig(
+            enabled=True,
+            model_threshold_per_1m_input_usd=threshold,
+            block_on_high_cost=block,
+        )
         self._resolver = _FakeResolver()
         self._chat_events = _FakeEventLog()
         self._non_interactive = non_interactive

--- a/tests/cli/test_model_cost_warn.py
+++ b/tests/cli/test_model_cost_warn.py
@@ -211,12 +211,11 @@ class _FakeSession:
     """Minimal session duck-type for maybe_emit_model_cost_warn."""
     def __init__(self, *, enabled: bool = True, threshold: float = 0.0) -> None:
         from reyn.config.chat import CostWarnConfig
-        self._config = type("Cfg", (), {
-            "cost_warn": CostWarnConfig(
-                enabled=enabled,
-                model_threshold_per_1m_input_usd=threshold,
-            ),
-        })()
+        # #2230: read off the production attribute (de-fabricated from _config).
+        self._cost_warn_config = CostWarnConfig(
+            enabled=enabled,
+            model_threshold_per_1m_input_usd=threshold,
+        )
         self._resolver = _FakeResolver()
         self._chat_events = _FakeEventLog()
 

--- a/tests/test_cost_warn_session_wiring_2230.py
+++ b/tests/test_cost_warn_session_wiring_2230.py
@@ -1,0 +1,62 @@
+"""Tier 2: the cost-warn config is threaded into the session (#2230).
+
+The high-cost-model warn (#1830) and block (#1867) read it off the session. It was
+never wired into the production-built session, so the read AttributeError'd into a
+silent fail-open: a configured ``block_on_high_cost`` let a high-cost switch
+through with no confirm. The pre-#2230 tests masked this by fabricating the config
+on a fake session. These use a REAL Session with the config threaded via its
+public ``cost_warn_config`` param, so removing the wiring (the param / the read)
+turns the block test RED — the production bug reproduced.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import CostWarnConfig
+from reyn.core.events.state_log import StateLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.model_cost_warn import maybe_block_high_cost_model
+from reyn.runtime.session import Session
+
+
+def _session(tmp_path, *, cost_warn: CostWarnConfig | None):
+    # "expensive" resolves to azure/gpt-4 (~$30/1M input → above the $5 threshold).
+    return Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "wal.jsonl"),
+        snapshot_path=tmp_path / "snap.json",
+        resolver=ModelResolver({"expensive": "azure/gpt-4"}),
+        cost_warn_config=cost_warn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_high_cost_block_fires_when_cost_warn_is_threaded(tmp_path) -> None:
+    """Tier 2: with block_on_high_cost threaded, a high-cost switch is blocked.
+
+    A non-interactive session fails closed (no confirm to show) — so a True
+    ``block_on_high_cost`` denies. Before #2230 the session had no threaded
+    config, the read fail-opened, and this returned True (allowed)."""
+    session = _session(
+        tmp_path,
+        cost_warn=CostWarnConfig(
+            enabled=True, block_on_high_cost=True,
+            model_threshold_per_1m_input_usd=5.0,
+        ),
+    )
+    session._non_interactive = True  # fail-closed path (no interactive checkpoint)
+    allowed = await maybe_block_high_cost_model(
+        session, "expensive", action="model_override"
+    )
+    assert allowed is False  # BLOCKED (the gate fired)
+
+
+@pytest.mark.asyncio
+async def test_default_cost_warn_does_not_block(tmp_path) -> None:
+    """Tier 2: with no cost-warn config (the safe default, block off), a switch is
+    allowed — the warn-only / head-less equivalence."""
+    session = _session(tmp_path, cost_warn=None)
+    allowed = await maybe_block_high_cost_model(
+        session, "expensive", action="model_override"
+    )
+    assert allowed is True  # not blocked (default is warn-only)


### PR DESCRIPTION
**[tui-coder]** — **#2230（cost-warn が production で全く動かない bug）の fix**。F2 #2229 の live-verify 中に発掘、lead triage で HIGH + de-fabricate + falsify-first 指示。

## Bug（primary evidence・確定済）

warn（#1830）も block（#1867）も `session._config.cost_warn` を読むが、**`session._config` は src の何処でも set されない**（git history で never-set）。両 gate の try/except 内で AttributeError → warn は silent fallback、block は `return True`（fail-open）。→ production `reyn chat` で **configured `block_on_high_cost` が効かず high-cost switch が無確認で通る**。tests は fake session に `_config` を捏造して PASS していた＝fixture が production gap を mask（= 今回の root cause class、F1 intervention-listener と同型）。

## Fix（events_config と同じ threading）

`Session(cost_warn_config=...)` param → `self._cost_warn_config`（**常に set**、default warn-only ゆえ read が fail-open しない）。chat.py が `session_cfg.config.cost_warn` を build_scoped_chat_session の `**base` 経由で渡す。gate は threaded attribute を読む。新機構なし、granular param（events_config 流儀）。

## Test（de-fabricate + falsify-first）

- **de-fabricate**: warn/block unit test の捏造 `_config` を production attribute `_cost_warn_config` に置換（gap を mask しない）。
- **falsify-first wiring test**（`test_cost_warn_session_wiring_2230.py`、REAL Session）: threaded `block_on_high_cost`=True + high-cost resolver（azure/gpt-4=$30/1M）→ block 発火（allowed=False）／default（未 thread）→ block 無し（allowed=True）。**falsify 実証**: read を phantom `_config` に戻すと block test が RED（fail-open 再現）、fix で GREEN。
- 回帰: session/chat/model/intervention 52 passed。
- ruff / tier-audit --strict / verify_module_docstrings green。

## Test plan

- [x] de-fabricated unit + falsify-first wiring test（RED-without-fix 実証）
- [x] 回帰 52 passed、4 gate green
- [ ] (follow-up) 実 tmux で `/model <expensive>` → cost-warn confirm 発火を live 確認（fix branch で即可、proxy 生存）。unit+falsify で論理確定済ゆえ bonus

## Tier self-check

Tier 2、behavioral（block 決定 allowed True/False）。mock なし（real Session + real ModelResolver + real CostWarnConfig）、format-pin / private-state assert なし（`_cost_warn_config` は test の real-attribute、production 経路 thread）。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
