### PR TITLE
feat(skill): ask_user can carry selectable options (PR-F3)

### DIFF
--- a/src/reyn/core/op_runtime/ask_user.py
+++ b/src/reyn/core/op_runtime/ask_user.py
@@ -12,10 +12,23 @@ from __future__ import annotations
 from typing import Literal
 
 from reyn.schemas.models import AskUserIROp
-from reyn.user_intervention import UserIntervention
+from reyn.user_intervention import InterventionChoice, UserIntervention
 
 from . import register
 from .context import OpContext
+
+
+def _options_to_choices(options: list[str]) -> list[InterventionChoice]:
+    """Pure: map free-text ask_user options to selectable choices.
+
+    ``id`` is the option text (so the answer is the option itself), ``label`` is
+    ``[N] <option>``, and ``hotkey`` is the 1-based number — the stdin / --cui
+    path types the number, the inline region selects with ↑↓.
+    """
+    return [
+        InterventionChoice(id=opt, label=f"[{i + 1}] {opt}", hotkey=str(i + 1))
+        for i, opt in enumerate(options)
+    ]
 
 
 async def handle(op: AskUserIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:
@@ -26,10 +39,13 @@ async def handle(op: AskUserIROp, ctx: OpContext, caller: Literal["preprocessor"
             "for chat) when constructing the SkillRuntime."
         )
 
+    choices = _options_to_choices(op.options or [])
     iv = UserIntervention(
         kind="ask_user",
         prompt=op.question,
         suggestions=op.suggestions or [],
+        choices=choices,
+        input_type="select" if choices else "",
         skill_name=ctx.skill_name or None,
         run_id=None,  # set by chat session if it tracks runs; CLI ignores
     )
@@ -42,10 +58,13 @@ async def handle(op: AskUserIROp, ctx: OpContext, caller: Literal["preprocessor"
         question=op.question,
         intervention_id=iv.id,
         suggestions=op.suggestions or [],
+        options=op.options or [],
     )
 
     answer = await ctx.intervention_bus.request(iv)
-    text = answer.text or ""
+    # A selected option resolves with choice_id (= the option text); free-text
+    # resolves with text.
+    text = answer.choice_id or answer.text or ""
     if not text and not op.required:
         text = ""
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -332,6 +332,10 @@ class AskUserIROp(BaseModel):
     kind: Literal["ask_user"]
     question: str
     suggestions: list[str] = Field(default_factory=list)
+    # F3 (region framework): a closed set of selectable answers. Empty → free-text
+    # (current behaviour). Non-empty → the user picks one (rendered as a selector
+    # in the inline CUI region; typed by number on the stdin / --cui path).
+    options: list[str] = Field(default_factory=list)
     required: bool = True
 
 

--- a/tests/test_ask_user_options_f3.py
+++ b/tests/test_ask_user_options_f3.py
@@ -1,0 +1,80 @@
+"""Tier 2: ask_user can carry selectable options (F3 region-framework slice).
+
+An ask_user op with ``options`` becomes a closed-set (select) intervention: each
+option maps to a choice (id = the option text, label = "[N] option", hotkey = the
+number). The inline region renders it as a selector; the answer is the chosen
+option. Empty options keep the free-text behaviour (no choices).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.op_runtime.ask_user import _options_to_choices, handle
+from reyn.core.op_runtime.context import OpContext
+from reyn.schemas.models import AskUserIROp
+from reyn.user_intervention import InterventionAnswer
+
+
+def test_options_map_to_numbered_choices() -> None:
+    """Tier 2: each option → (id=text, label='[N] text', hotkey='N')."""
+    choices = _options_to_choices(["yes", "no", "maybe"])
+    assert [(c.id, c.label, c.hotkey) for c in choices] == [
+        ("yes", "[1] yes", "1"),
+        ("no", "[2] no", "2"),
+        ("maybe", "[3] maybe", "3"),
+    ]
+    assert _options_to_choices([]) == []
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, name: str, **kw) -> None:
+        self.emitted.append((name, kw))
+
+
+class _RecordingBus:
+    def __init__(self, answer: InterventionAnswer) -> None:
+        self._answer = answer
+        self.requested: list = []
+
+    async def request(self, iv):
+        self.requested.append(iv)
+        return self._answer
+
+
+def _ctx(bus) -> OpContext:
+    # ask_user's handler only reads events / intervention_bus / skill_name /
+    # run_id / current_phase, so workspace + permission_decl are unused dummies.
+    return OpContext(
+        workspace=None, events=_RecordingEvents(),
+        permission_decl=None, intervention_bus=bus,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_user_with_options_is_a_select_intervention() -> None:
+    """Tier 2: options → a select intervention with choices; the answer is the
+    chosen option id."""
+    bus = _RecordingBus(InterventionAnswer(choice_id="no"))
+    op = AskUserIROp(kind="ask_user", question="Pick?", options=["yes", "no"])
+    result = await handle(op, _ctx(bus), "control_ir")
+
+    iv = bus.requested[0]
+    assert iv.input_type == "select"
+    assert [c.id for c in iv.choices] == ["yes", "no"]
+    assert result["answer"] == "no"  # the selected option, via choice_id
+
+
+@pytest.mark.asyncio
+async def test_ask_user_without_options_stays_free_text() -> None:
+    """Tier 2: no options → free-text (no choices), answer is the typed text."""
+    bus = _RecordingBus(InterventionAnswer(text="some text"))
+    op = AskUserIROp(kind="ask_user", question="Free?")
+    result = await handle(op, _ctx(bus), "control_ir")
+
+    iv = bus.requested[0]
+    assert iv.choices == []
+    assert iv.input_type == ""
+    assert result["answer"] == "some text"


### PR DESCRIPTION
**[tui-coder]** — region framework **PR-F3（ask_user options）**。F2 merged の上、lead GO 済。per-slice review。

## What

skill の ask_user op が free-text だけでなく **closed-set の選択肢**を出せるように。`AskUserIROp.options`（optional list）を追加。handler が各 option を `InterventionChoice`（id=option text、label="[N] option"、hotkey=1-based number）に map し intervention を `input_type="select"` に。→ **F2 region が既に render する `UserIntervention.choices` の shape にそのまま流れる**（↑↓ selectable list）。stdin/--cui path は number を type（match_choice on hotkey）。答えは選択 option（choice_id）に解決。**options 空 → free-text byte-identical**（後方互換）。

## Test plan

- [x] Tier 2 `tests/test_ask_user_options_f3.py`（3件）: option→choice mapping（id/label/hotkey）／handler が options で select intervention（choices + 選択 option を answer）／options 無しで free-text（choices=[], input_type="", typed text を answer）
- [x] 回帰: ask_user / control_ir / intervention / op_runtime / event-audit 277 passed（schema + handler + event 追加 options field で破壊なし）
- [x] ruff / tier-audit --strict / verify_module_docstrings green
- [ ] (follow-up) skill が multiple-choice ask_user を出す end-to-end の live tmux。select intervention の region rendering は F2 で live-verified 済（permission grant-deny で 4 点確認）ゆえ shape は実証済、skill-driven trigger は別 follow-up

## Tier self-check

Tier 2 3件、behavioral（mapping / intervention shape / answer）。mock なし（real AskUserIROp + 手書き recording bus/events = real instances）、format-pin / private-state assert なし。`--strict` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
