### PR TITLE
docs(#2233): sync control-ir.md ask_user options/required (+ verify task.assign already documented)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -129,9 +129,13 @@ Pauses the phase and asks the user. The OS prints the question, reads stdin, and
 {
   "kind": "ask_user",
   "question": "Which model do you want to target?",
-  "suggestions": ["light", "standard", "strong"]
+  "suggestions": ["light", "standard", "strong"],
+  "options": ["light", "standard", "strong"],
+  "required": true
 }
 ```
+
+`suggestions` are free-text hints (the user may still type anything). `options` (PR-F3, #2233) is a **closed selectable set** — when non-empty, the frontend renders a **selector** over exactly those answers (empty → free-text input). `required` (default `true`) — when `false`, the user may dismiss without answering.
 
 ## `run_skill`
 


### PR DESCRIPTION
**[e2e-coder]** — control-ir.md op-reference doc-sync (lead-flagged tech-debt). One real gap fixed; the companion item was verified already-synced.

## Fixed: `ask_user` `options` + `required` (#2233)

PR-F3 (#2233, `c718a4cf`) added `options` (a closed selectable set → the frontend renders a selector; empty → free-text) and `required` to `AskUserIROp`, but the `## ask_user` JSON example still showed only `suggestions`. Added both fields to the example + a sentence on the `options`→selector / `required` semantics. Model ↔ doc now in sync.

## Verified already-synced (no change): `task.assign` (#2224)

The companion concern — that #2224's new `task.assign` op kind was undocumented (a CLAUDE.md strict-rule "new op kind → reference section in the same PR" gap) — does **not** hold on inspection. #2224 **did** document it:

- **Op table row** (`control-ir.md:47`): `task.assign | Assign a session to a Task (§27-31 …): claim an UNASSIGNED task or reassign … | UNASSIGNED → any session may claim; assigned → current-assignee-gated (owner hand-off)`
- **`## Task ops` § "Pending-assignment queue (§27-31)"**: "`task.assign` then binds a session: an UNASSIGNED task may be **claimed by any session**; an already-assigned task may be **reassigned only by its current assignee** … rebinds the WAL subscription, OS-derives the now-startable status, and wakes the new assignee."
- Plus the Roles paragraph (rebindable assignee via `task.assign`) and the Role-based-op-authority line.

Task ops use the **collective `## Task ops` reference section** (not per-op `## task.X` sections, unlike `ask_user`/`web_fetch`/etc.) — that section IS the reference, and `task.assign` is fully covered there. So #2224 satisfied the strict-rule; no task.assign change is needed. (Flagged to lead-coder — this corrects the "review miss" premise.)

## Test plan

- [x] `control-ir.md` ↔ `AskUserIROp` (`schemas/models.py`): the example now matches the model fields (`question`/`suggestions`/`options`/`required`).
- [x] Verified `task.assign` ↔ `OP_KIND_MODEL_MAP` + control-ir.md already in sync (table row + Task-ops prose).
- [x] Docs-only change; `docs build (strict)` CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
