### PR TITLE
[tui-coder] feat(inline-cui): F5 — host the status menu dropdown on the region framework

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -38,8 +38,11 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.inline.intervention_region import build_intervention_element
-from reyn.interfaces.inline.region import Region
-from reyn.interfaces.inline.region_command import build_rewind_command_ui
+from reyn.interfaces.inline.region import DetailElement, Region
+from reyn.interfaces.inline.region_command import (
+    CommandUIElement,
+    build_rewind_command_ui,
+)
 from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
 
 logger = logging.getLogger(__name__)
@@ -62,16 +65,39 @@ def is_actionable_picker(label: str, model_classes) -> bool:
     return label in _ACTIONABLE and bool(model_classes)
 
 
-def model_switch_text(model_classes: list, row: int) -> str | None:
-    """Pure: the slash command a model-picker Enter submits for the row.
+def build_status_dropdown_element(label: str, *, snapshot_fn, on_submit):
+    """Build the region element for an opened status chip's dropdown.
 
-    Returns ``/model <class>`` for an in-range row, or None (out of range /
-    empty list) so the caller submits nothing. The switch itself — cost-warn
-    confirm, budget rebuild — is the existing ``/model`` slash path.
+    The model chip with configured classes → a :class:`CommandUIElement` picker
+    (each row submits ``/model <class>`` through the normal slash path — cost-warn
+    confirm + budget rebuild reused), so it shares the region's selection
+    mechanism with the /rewind picker and interventions. Every other chip (and
+    the model chip with no classes) → a read-only :class:`DetailElement` whose
+    rows are recomputed live from ``snapshot_fn`` (so cost / ctx / agents stay
+    current while the panel is open) and carry no cursor.
     """
-    if 0 <= row < len(model_classes):
-        return f"/model {model_classes[row]}"
-    return None
+    snap = snapshot_fn()
+    classes = list(snap["model_classes"]) if snap else []
+    if is_actionable_picker(label, classes):
+        rows = dropdown_lines(
+            label, model=snap["model"], agent_names=snap["agent_names"],
+            attached_name=snap["attached_name"], skill_run_ids=snap["skill_run_ids"],
+            usage=snap["usage"], cost_usd=snap["cost_usd"], model_classes=classes,
+        )
+        submit_texts = [f"/model {c}" for c in classes]
+        return CommandUIElement(rows, submit_texts, on_submit)
+
+    def detail_lines() -> list:
+        s = snapshot_fn()
+        if s is None:
+            return []
+        return dropdown_lines(
+            label, model=s["model"], agent_names=s["agent_names"],
+            attached_name=s["attached_name"], skill_run_ids=s["skill_run_ids"],
+            usage=s["usage"], cost_usd=s["cost_usd"], model_classes=s["model_classes"],
+        )
+
+    return DetailElement(detail_lines)
 
 
 def working_line(thinking: bool, think_start: float, now: float) -> list:
@@ -158,9 +184,15 @@ async def run_inline_input(registry, renderer) -> None:
     attached = registry.attached_session()
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
     buf = Buffer(multiline=False, history=history)
-    # sel: which chip; open: detail/picker shown; row: cursor within an
-    # actionable picker (model). row is reset to 0 when a picker opens.
-    menu = {"sel": 0, "open": False, "row": 0}
+    # sel: which chip; open: detail/picker shown. The dropdown's selectable
+    # cursor lives in `menu_region` (the below-input Region hosting the opened
+    # chip's element), not here — the same selection mechanism as the above-input
+    # region (interventions / the /rewind picker), unified in F5.
+    menu = {"sel": 0, "open": False}
+    # Below-input region: hosts the opened chip's dropdown as a region element —
+    # a CommandUIElement model picker (selectable) or a read-only DetailElement
+    # (live detail, no cursor). Empty (cleared) while the menu is closed.
+    menu_region = Region()
     # Guards against a second quit (rapid Ctrl-C / `/quit` then Ctrl-C) racing the
     # first: shutdown has a grace window, so two _quit tasks could both reach
     # app.exit() — the second raises "Return value already set". _quit checks+sets
@@ -193,15 +225,6 @@ async def run_inline_input(registry, renderer) -> None:
     )
     input_win = Window(BufferControl(buffer=buf), height=1)
     inputrow = VSplit([prompt_sym, input_win])
-
-    def _current_dropdown_lines(snap) -> list:
-        label = _CHIPS[menu["sel"]]
-        return dropdown_lines(
-            label, model=snap["model"], agent_names=snap["agent_names"],
-            attached_name=snap["attached_name"],
-            skill_run_ids=snap["skill_run_ids"], usage=snap["usage"],
-            cost_usd=snap["cost_usd"], model_classes=snap["model_classes"],
-        )
 
     def status_fragments() -> list:
         snap = _snapshot(registry)
@@ -237,16 +260,16 @@ async def run_inline_input(registry, renderer) -> None:
     )
 
     def dropdown_frags() -> list:
-        snap = _snapshot(registry)
-        if snap is None:
-            return []
-        actionable = is_actionable_picker(_CHIPS[menu["sel"]], snap["model_classes"])
+        # The opened chip's element lives in menu_region; render its live rows.
+        # The focus cursor is drawn only on a selectable row (the model picker) —
+        # a read-only DetailElement reports cursor_on_selectable False, so its
+        # detail panel shows no highlight, exactly as before.
+        draw_cursor = menu_region.cursor_on_selectable
         out: list = []
-        for i, ln in enumerate(_current_dropdown_lines(snap)):
+        for i, ln in enumerate(menu_region.lines()):
             if i:
                 out.append(("", "\n"))
-            if actionable and i == menu["row"]:
-                # picker cursor: reverse-highlight the selectable row
+            if draw_cursor and i == menu_region.cursor:
                 out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
             else:
                 style = _CC_DONE if ln.startswith("▸") else _CC_DIM
@@ -254,10 +277,7 @@ async def run_inline_input(registry, renderer) -> None:
         return out
 
     def dropdown_height() -> Dimension:
-        snap = _snapshot(registry)
-        if snap is None:
-            return Dimension.exact(0)
-        return Dimension.exact(len(_current_dropdown_lines(snap)))
+        return Dimension.exact(len(menu_region.lines()))
 
     dropdown = ConditionalContainer(
         Window(FormattedTextControl(dropdown_frags), height=dropdown_height),
@@ -310,30 +330,59 @@ async def run_inline_input(registry, renderer) -> None:
         event.app.layout.focus(status_win)
 
     def _actionable_open() -> bool:
-        return menu["open"] and _CHIPS[menu["sel"]] in _ACTIONABLE
+        # Open AND the opened chip's element is the selectable model picker (a
+        # CommandUIElement). Mirrors build_status_dropdown_element: only the model
+        # chip WITH configured classes builds a picker — every other chip (and the
+        # model chip with none) is a read-only DetailElement.
+        if not menu["open"]:
+            return False
+        snap = _snapshot(registry)
+        classes = snap["model_classes"] if snap else []
+        return is_actionable_picker(_CHIPS[menu["sel"]], classes)
+
+    def _menu_submit(text: str) -> None:
+        # A picker row was selected → close the menu and run /model <class> via the
+        # normal slash path (cost-warn confirm + budget rebuild reused).
+        _menu_close()
+        app.create_background_task(_submit(registry, text))
+
+    def _menu_open() -> None:
+        # Build the opened chip's element fresh and host it in menu_region. The
+        # picker rows are static (classes); a read-only panel's lines stay live.
+        menu["open"] = True
+        menu_region.clear()
+        menu_region.register(
+            build_status_dropdown_element(
+                _CHIPS[menu["sel"]],
+                snapshot_fn=lambda: _snapshot(registry),
+                on_submit=_menu_submit,
+            )
+        )
+
+    def _menu_close() -> None:
+        menu["open"] = False
+        menu_region.clear()
 
     @kb.add("up", filter=has_focus(status_win))
     def _menu_up(event) -> None:
-        # In an open picker, ↑ moves the cursor up; at the top row it closes.
-        if _actionable_open() and menu["row"] > 0:
-            menu["row"] -= 1
+        # In an open picker, ↑ moves the cursor up; at the top row it closes. A
+        # read-only panel has no cursor, so ↑ simply closes it.
+        if _actionable_open() and not menu_region.at_first_selectable:
+            menu_region.navigate(-1)
         elif menu["open"]:
-            menu["open"] = False
+            _menu_close()
         else:
             event.app.layout.focus(input_win)
 
     @kb.add("down", filter=has_focus(status_win))
     def _menu_down(event) -> None:
         if _actionable_open():
-            snap = _snapshot(registry)
-            n = len(snap["model_classes"]) if snap else 0
-            if n:
-                menu["row"] = min(menu["row"] + 1, n - 1)
+            menu_region.navigate(1)
 
     @kb.add("escape", filter=has_focus(status_win))
     def _menu_esc(event) -> None:
         if menu["open"]:
-            menu["open"] = False
+            _menu_close()
         else:
             event.app.layout.focus(input_win)
 
@@ -349,19 +398,15 @@ async def run_inline_input(registry, renderer) -> None:
 
     @kb.add("enter", filter=has_focus(status_win))
     def _menu_enter(event) -> None:
-        # Read-only chip: enter toggles the detail panel. Actionable picker:
-        # when open, enter applies the cursor row via the existing /model slash
-        # path (cost-warn + budget rebuild reused); when closed, it opens.
+        # Read-only chip: enter toggles the detail panel. Actionable picker: when
+        # open, enter applies the cursor row (region.select → on_submit → /model
+        # via the slash path); when closed, it opens the dropdown.
         if _actionable_open():
-            snap = _snapshot(registry)
-            classes = snap["model_classes"] if snap else []
-            text = model_switch_text(classes, menu["row"])
-            if text is not None:
-                event.app.create_background_task(_submit(registry, text))
-            menu["open"] = False
+            menu_region.select()
+        elif menu["open"]:
+            _menu_close()
         else:
-            menu["open"] = not menu["open"]
-            menu["row"] = 0
+            _menu_open()
 
     @kb.add("c-c")
     @kb.add("c-d")

--- a/src/reyn/interfaces/inline/region.py
+++ b/src/reyn/interfaces/inline/region.py
@@ -18,7 +18,7 @@ field, so it needs no region element.
 """
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Callable, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -28,11 +28,38 @@ class RegionElement(Protocol):
     ``lines()`` returns the element's current display rows (empty = nothing to
     show right now). ``on_select(row)`` is invoked with the 0-based row index
     within THIS element when the user activates the focused row.
+
+    An element may expose ``selectable`` (default True if absent): False marks a
+    read-only element whose rows carry no focus cursor and whose ``on_select`` is
+    inert — see :class:`DetailElement`. Consumers draw the cursor only on
+    selectable elements.
     """
 
     def lines(self) -> list[str]: ...
 
     def on_select(self, row: int) -> None: ...
+
+
+class DetailElement:
+    """A read-only RegionElement: live display rows, no selection.
+
+    ``lines_provider`` is called on every render, so the rows stay live (e.g. a
+    status detail panel reflecting current cost / token counts) without the
+    element being rebuilt. ``selectable=False`` tells the renderer to draw no
+    focus cursor and makes ``on_select`` a no-op — the panel is information, not
+    a picker.
+    """
+
+    selectable = False
+
+    def __init__(self, lines_provider: Callable[[], list[str]]) -> None:
+        self._lines_provider = lines_provider
+
+    def lines(self) -> list[str]:
+        return list(self._lines_provider())
+
+    def on_select(self, row: int) -> None:
+        return None
 
 
 class Region:
@@ -43,20 +70,25 @@ class Region:
         self._cursor = 0
 
     def register(self, element: RegionElement) -> None:
-        """Add an element and reset the focus cursor to the top."""
+        """Add an element and reset the focus cursor to the first selectable row."""
         self._elements.append(element)
-        self._cursor = 0
+        self._reset_cursor()
 
     def unregister(self, element: RegionElement) -> None:
         """Remove an element (idempotent) and reset the cursor."""
         if element in self._elements:
             self._elements.remove(element)
-        self._cursor = 0
+        self._reset_cursor()
 
     def clear(self) -> None:
         """Drop all elements (e.g. on teardown) and reset the cursor."""
         self._elements.clear()
         self._cursor = 0
+
+    @staticmethod
+    def _selectable(element: RegionElement) -> bool:
+        """A read-only element (``selectable=False``) carries no focus cursor."""
+        return getattr(element, "selectable", True)
 
     def _flat(self) -> list[tuple[RegionElement, int, str]]:
         """Flatten to ``(element, local_row, text)`` across all elements."""
@@ -65,6 +97,14 @@ class Region:
             for i, text in enumerate(element.lines()):
                 out.append((element, i, text))
         return out
+
+    def _selectable_indices(self) -> list[int]:
+        """Flattened-row indices that belong to a selectable element."""
+        return [i for i, (el, _, _) in enumerate(self._flat()) if self._selectable(el)]
+
+    def _reset_cursor(self) -> None:
+        sel = self._selectable_indices()
+        self._cursor = sel[0] if sel else 0
 
     @property
     def visible(self) -> bool:
@@ -76,19 +116,56 @@ class Region:
         """The focus cursor index across the flattened rows."""
         return self._cursor
 
+    @property
+    def at_first_selectable(self) -> bool:
+        """True when the cursor sits on the first selectable row (or none exist).
+
+        Lets a consumer treat ``↑`` at the top of a picker as "close" rather than
+        a no-op move, matching the pre-region status menu.
+        """
+        sel = self._selectable_indices()
+        return (not sel) or self._cursor == sel[0]
+
+    @property
+    def cursor_on_selectable(self) -> bool:
+        """True when the cursor sits on a selectable row (draw the highlight)."""
+        flat = self._flat()
+        if 0 <= self._cursor < len(flat):
+            return self._selectable(flat[self._cursor][0])
+        return False
+
     def lines(self) -> list[str]:
         """All display rows across the hosted elements, in registration order."""
         return [text for _, _, text in self._flat()]
 
     def navigate(self, delta: int) -> None:
-        """Move the focus cursor by ``delta`` rows, clamped to the row range."""
-        n = len(self._flat())
-        if n:
-            self._cursor = max(0, min(self._cursor + delta, n - 1))
+        """Move the cursor ``delta`` SELECTABLE rows, skipping read-only ones.
+
+        Magnitude is honoured (``delta=3`` advances three selectable rows) and
+        clamped to the selectable range; read-only (``DetailElement``) rows are
+        stepped over, never landed on. With no selectable rows the cursor is
+        inert — a read-only-only region cannot be navigated.
+        """
+        sel = self._selectable_indices()
+        if not sel:
+            return
+        if self._cursor in sel:
+            pos = sel.index(self._cursor)
+        else:
+            # cursor is on a read-only row: snap to the first selectable at/after
+            # it (or the last selectable before it) so delta moves from there.
+            after = [k for k, i in enumerate(sel) if i >= self._cursor]
+            pos = after[0] if after else len(sel) - 1
+        pos = max(0, min(pos + delta, len(sel) - 1))
+        self._cursor = sel[pos]
 
     def select(self) -> None:
-        """Activate the focused row → its owning element's ``on_select``."""
+        """Activate the focused row → its owning element's ``on_select``.
+
+        Inert on a read-only row (a non-selectable element is never activated).
+        """
         flat = self._flat()
         if 0 <= self._cursor < len(flat):
             element, local_row, _ = flat[self._cursor]
-            element.on_select(local_row)
+            if self._selectable(element):
+                element.on_select(local_row)

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -8,11 +8,23 @@ these decoupled from the Session.
 from __future__ import annotations
 
 from reyn.interfaces.inline.app import (
+    build_status_dropdown_element,
     dropdown_lines,
     is_actionable_picker,
-    model_switch_text,
     status_chips,
 )
+
+
+def _snap(**over):
+    """A status snapshot dict (build_status_dropdown_element's input)."""
+    base = {
+        "model": "standard",
+        "model_classes": ["light", "standard", "strong"],
+        "agent_names": ["default"], "attached_name": "default",
+        "skill_run_ids": [], "usage": (0, 0, 0), "cost_usd": 0.0,
+    }
+    base.update(over)
+    return base
 
 
 def test_model_chip_is_a_picker_only_with_classes() -> None:
@@ -104,11 +116,44 @@ def test_model_picker_lists_classes_marking_current() -> None:
     assert not any("change with" in ln for ln in lines)
 
 
-def test_model_switch_text_for_selected_row() -> None:
-    """Tier 2: the picker's Enter submits the existing /model slash for the
-    cursor row; an out-of-range row submits nothing."""
-    classes = ["light", "standard", "strong"]
-    assert model_switch_text(classes, 0) == "/model light"
-    assert model_switch_text(classes, 2) == "/model strong"
-    assert model_switch_text(classes, 3) is None
-    assert model_switch_text([], 0) is None
+def test_model_picker_element_submits_model_slash_on_select() -> None:
+    """Tier 2: F5 — the model chip with classes builds a selectable picker
+    element (a region CommandUIElement); selecting row N submits ``/model
+    <classN>`` through the slash path, sharing the region's selection mechanism
+    with the /rewind picker."""
+    submitted: list[str] = []
+    el = build_status_dropdown_element(
+        "model", snapshot_fn=_snap, on_submit=submitted.append,
+    )
+    assert any(ln.startswith("▸") and "standard" in ln for ln in el.lines())
+    el.on_select(0)
+    el.on_select(2)
+    assert submitted == ["/model light", "/model strong"]
+    el.on_select(9)  # out of range → no submit
+    assert submitted == ["/model light", "/model strong"]
+
+
+def test_read_only_chip_builds_non_selectable_live_detail() -> None:
+    """Tier 2: F5 — a non-picker chip builds a read-only DetailElement — no
+    cursor (selectable=False), inert on select, rows recomputed live from the
+    snapshot so the panel reflects current values while open."""
+    box = {"snap": _snap(cost_usd=0.01, usage=(100, 5, 105))}
+    el = build_status_dropdown_element(
+        "cost", snapshot_fn=lambda: box["snap"], on_submit=lambda _t: None,
+    )
+    assert el.selectable is False
+    assert any("total 105" in ln for ln in el.lines())
+    el.on_select(0)  # inert — no exception, nothing to submit
+    box["snap"] = _snap(cost_usd=0.02, usage=(200, 9, 209))
+    assert any("total 209" in ln for ln in el.lines())  # live
+
+
+def test_model_chip_without_classes_is_read_only_fallback() -> None:
+    """Tier 2: F5 — the model chip with no configured classes builds the
+    read-only fallback (non-selectable), not a picker."""
+    el = build_status_dropdown_element(
+        "model", snapshot_fn=lambda: _snap(model_classes=[]),
+        on_submit=lambda _t: None,
+    )
+    assert getattr(el, "selectable", True) is False
+    assert any("/model" in ln for ln in el.lines())

--- a/tests/test_inline_region_framework.py
+++ b/tests/test_inline_region_framework.py
@@ -7,7 +7,7 @@ rows, and dispatches select to the owning element. An empty region collapses
 """
 from __future__ import annotations
 
-from reyn.interfaces.inline.region import Region
+from reyn.interfaces.inline.region import DetailElement, Region
 
 
 class _Element:
@@ -79,3 +79,50 @@ def test_unregister_and_clear_collapse_the_region() -> None:
     region.clear()
     assert region.visible is False
     assert region.lines() == []
+
+
+def test_detail_element_is_live_and_non_selectable() -> None:
+    """Tier 2: F5 — DetailElement re-reads its provider on every lines() call (so
+    a status panel stays live) and is non-selectable with an inert on_select."""
+    box = {"rows": ["cost $0.01", "total 105"]}
+    el = DetailElement(lambda: box["rows"])
+    assert el.selectable is False
+    assert el.lines() == ["cost $0.01", "total 105"]
+    el.on_select(0)  # inert — no error, no state
+    box["rows"] = ["cost $0.02"]
+    assert el.lines() == ["cost $0.02"]  # live
+
+
+def test_navigate_skips_non_selectable_rows() -> None:
+    """Tier 2: F5 — the cursor steps over read-only (DetailElement) rows and never
+    lands on one; a read-only-only region cannot be navigated."""
+    ro = Region()
+    ro.register(DetailElement(lambda: ["info-a", "info-b"]))
+    assert ro.cursor_on_selectable is False
+    ro.navigate(1)
+    assert ro.cursor_on_selectable is False  # no selectable target to move to
+
+    mixed = Region()
+    mixed.register(DetailElement(lambda: ["detail-0"]))   # flat row 0 (read-only)
+    mixed.register(_Element(["pick-0", "pick-1"]))        # flat rows 1, 2 (selectable)
+    # the cursor resets to the first SELECTABLE row, skipping the detail row
+    assert mixed.cursor == 1
+    assert mixed.cursor_on_selectable is True
+    mixed.navigate(1)
+    assert mixed.cursor == 2
+    mixed.navigate(-5)            # clamps at the first selectable row, not row 0
+    assert mixed.cursor == 1
+    assert mixed.at_first_selectable is True
+
+
+def test_select_inert_until_a_selectable_row_exists() -> None:
+    """Tier 2: F5 — select on a read-only-only region is a no-op; once a
+    selectable element is added the cursor reaches it and select fires."""
+    el = _Element(["x"])
+    region = Region()
+    region.register(DetailElement(lambda: ["d0"]))
+    region.select()              # only a detail row → nothing activated
+    assert el.selected == []
+    region.register(el)          # cursor resets onto the selectable row
+    region.select()
+    assert el.selected == [0]


### PR DESCRIPTION
**[tui-coder]** — F5 of the inline-CUI region framework (the final slice; F1 listener wiring, F2 typed-input interventions, F3 ask_user options, F4 /rewind picker all merged). With F5 the framework hosts **all three** consumer kinds the owner vision called for: interventions + command-UIs + the status menu.

## What

The status menu's dropdown is now a **below-input `Region`** — the framework already named it the target (`region.py`: *"the below-input region (the status menu)"*). The bespoke `menu["row"]` picker cursor + `dropdown_frags` highlight machinery is replaced by the **same selection mechanism** interventions and the /rewind picker use. One selector, not two.

## How

- **Model picker (actionable)** → reuses F4's `CommandUIElement`; each row submits `/model <class>` through the existing slash path (cost-warn confirm + budget rebuild reused). Built by `build_status_dropdown_element`.
- **Read-only detail panels** (agents/skills/cost/ctx, and the model chip with no classes) → a new generic **`DetailElement`** (`selectable=False`) whose rows recompute **live** from the snapshot — panel stays current while open, carries no cursor.
- **`Region` is now selectable-aware**: `navigate` steps **over** read-only rows (never lands on one), magnitude preserved; `select` inert on a read-only row; `cursor_on_selectable` / `at_first_selectable` drive rendering + "↑ at top closes". Backward compatible — `selectable` defaults True (F1–F4 elements unaffected).
- Deletes `model_switch_text` (the picker submit now flows through `CommandUIElement.on_select` → `/model`).

## Sibling-sweep (lead-coder gate 2)

`model_switch_text` consumers: app.py + `test_inline_pr3b_status_menu.py` only (test updated to the new builder). `menu["row"]`: app.py-only. No silent breaks.

## Test plan

- [x] `ruff check` — clean
- [x] `verify_module_docstrings.py` — OK
- [x] `test_tier_audit.py --strict` (both test files) — clean
- [x] Targeted regression (inline/region/repl/status_menu): 110 passed, 2 skipped
- [x] **Behavior-preserving live tmux (gate 1, model classes configured)** — primary evidence:
  - ↓ focuses the menu (hint flips to `[↑ input · ←→ select · enter open]`)
  - ←→ moves the highlighted chip
  - **model picker** opens **below the status row**, lists classes with current `▸`-marked + a cursor; ↑↓ moves the cursor (row 0→2); Enter dispatches `/model claude-sonnet-thinking`, the status row updates, the dropdown closes
  - **read-only cost panel** opens below with live `prompt/completion/total/cost`, **no cursor highlight** (selectable=False); ↑ closes it
  - ↑ from the closed menu returns focus to the input
- [x] Region navigation **skips** non-selectable rows (gate 3) — unit-pinned + live-confirmed (read-only panel has no cursor)

## Tier self-check

Tier 2: real `Region` / `DetailElement` / `CommandUIElement`, public-surface asserts (`lines` / `selectable` / submit), no mocks. `--strict` audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
