### PR TITLE
[tui-coder] fix(inline-cui): echo the user's submitted message into the scrollback

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -323,6 +323,15 @@ async def run_inline_input(registry, renderer) -> None:
         if stripped in ("/quit", "/exit"):
             event.app.create_background_task(_quit(registry, event.app, quitting))
         else:
+            # Echo the submitted line into the scrollback BEFORE the turn runs.
+            # The live input field is cleared on submit (buf.reset above), so
+            # without this the user's own message never appears in the
+            # conversation (only the agent reply does). kind="user" persists (not
+            # a transient status), and the output loop drains the outbox FIFO, so
+            # it lands just above the agent reply — mirroring the PromptSession
+            # path, where the typed line stays committed in the terminal.
+            from reyn.runtime.outbox import OutboxMessage
+            registry.repl_outbox.put_nowait(OutboxMessage(kind="user", text=stripped))
             event.app.create_background_task(_submit(registry, stripped))
 
     @kb.add("down", filter=has_focus(input_win))

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -252,8 +252,10 @@ _CC_ERR = "#f97066"
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 # Per-kind leading marker for the inline CC-style stream. The agent / skill /
-# intervention lines lead with ⏺; tool/trace detail lines lead with ⎿.
+# intervention lines lead with ⏺; tool/trace detail lines lead with ⎿; the user's
+# own submitted line is echoed with the > input marker.
 _CC_MARKER = {
+    "user": " > ",
     "agent": " ⏺ ",
     "status": " · ",
     "error": " ✗ ",
@@ -359,6 +361,10 @@ def format_inline_message(msg: OutboxMessage):
     marker = _CC_MARKER.get(kind)
     if marker is None:
         return Text(text)
+    if kind == "user":
+        # The user's own submitted line, echoed into the scrollback (the inline
+        # input field clears on submit, so without this the message vanishes).
+        return Text.assemble((marker, _CC_ACCENT), (text, _CC_DIM))
     if kind == "agent":
         return Text.assemble((marker, _CC_ACCENT), (text, ""))
     if kind == "status":

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -26,6 +26,15 @@ def _plain(kind: str, text: str, meta: dict | None = None) -> str:
     ).plain
 
 
+def test_user_echo_leads_with_input_marker_and_keeps_text() -> None:
+    """Tier 2: the user's own submitted line is echoed with the > input marker
+    and its text — so the message stays visible in the conversation after the
+    inline input field clears on submit."""
+    out = _plain("user", "what files changed?")
+    assert ">" in out
+    assert "what files changed?" in out
+
+
 def test_agent_line_leads_with_dot_marker_and_keeps_text() -> None:
     """Tier 2: an agent message renders with the ⏺ marker and its text."""
     out = _plain("agent", "hello world")


### PR DESCRIPTION
**[tui-coder]** — owner-reported: the user's input message wasn't appearing in the conversation.

## Bug

In the interactive inline CUI (the default `reyn chat` surface), the conversation showed only the agent reply + tool rows — **the user's own typed message never appeared**. The inline input lives in a live region at the bottom that is cleared on submit (`buf.reset`), so the typed line vanished and was never committed to scrollback. Each turn read as a disembodied reply with no visible prompt.

(The `--cui` / PromptSession path is unaffected — prompt_toolkit leaves the typed line committed on screen.)

## Fix

- `_accept` now puts an `OutboxMessage(kind="user", ...)` on the `repl_outbox` **before** launching the turn, so the line is drained + rendered just above the agent reply (the output loop drains FIFO).
- The inline renderer gains a `"user"` kind — echoed with the `>` input marker (matching the input prompt) — and it **persists** (not a transient `status`/`trace`, so the next message doesn't erase it; same lesson as the F2 intervention-echo fix).

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — all clean
- [x] Render + inline regression: 110 passed, 2 skipped
- [x] **Live tmux (litellm proxy)** — primary evidence: two turns now render as a thread:
  ```
   > Reply with just the word cherry.
   ⏺ skill__direct_llm(text=Reply with just the wor…)
     ⎿ finished
   ⏺ cherry.
   > Now say grape.
   ⏺ skill__direct_llm(text=Now say grape.)
     ⎿ finished
   ⏺ grape.
  ```
  User messages are visible and correctly ordered before each reply.

## Tier self-check

Render test is Tier 2 (real `OutboxMessage`, public `.plain` surface, no mocks). The emit path is covered by the live tmux verify (closure inside `run_inline_input`, not unit-extractable without over-engineering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
