### PR TITLE
fix(#2236): filter list_rewind_points to WAL retention floor

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1148,11 +1148,20 @@ class AgentRegistry:
         if self._state_log is None:
             return []
 
+        # #2236: compute the WAL retention floor using the SAME source as
+        # checkout() (lines 1044–1048) so the list and the checkout guard
+        # agree by construction.  Points below this floor would always be
+        # rejected by checkout — advertising them is misleading.
+        oldest = next(iter(self._state_log.iter_from(1)), None)
+        oldest_seq: int | None = oldest.get("seq") if oldest else None
+
         # Union of generation boundary seqs across every known agent. Default =
         # active branch only (1f); include_abandoned = all branches (Phase-2 tree).
         seqs: set[int] = set()
         for name in self.list_names():
             for s in self._store_for(name).seqs():
+                if oldest_seq is not None and s < oldest_seq:
+                    continue  # #2236: truncated out of WAL — not reachable
                 if include_abandoned or is_active_seq(self._state_log, s):
                     seqs.add(s)
         if not seqs:
@@ -1161,7 +1170,7 @@ class AgentRegistry:
         # One pass over the WAL to map boundary seq → (ts, kind). The audit
         # EventStore is NOT consulted — keeping WAL and audit decoupled.
         wal_at: dict[int, dict] = {}
-        for entry in self._state_log.iter_from(1):
+        for entry in self._state_log.iter_from(oldest_seq if oldest_seq is not None else 1):
             s = entry.get("seq")
             if isinstance(s, int) and s in seqs:
                 wal_at[s] = entry

--- a/tests/test_registry_list_rewind_points_1f.py
+++ b/tests/test_registry_list_rewind_points_1f.py
@@ -130,3 +130,74 @@ def test_list_rewind_points_empty_without_wal(tmp_path) -> None:
     """Tier 2: no WAL → empty list (no crash)."""
     reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory)
     assert reg.list_rewind_points() == []
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_excludes_truncated_seqs(tmp_path) -> None:
+    """Tier 2: #2236 — WAL-truncated checkpoint seqs are NOT advertised.
+
+    After truncation the checkout path rejects seqs below the oldest retained
+    seq with RewindBeyondRetentionError.  list_rewind_points() must agree by
+    construction — it must NEVER return a seq that checkout() would reject.
+
+    Setup mirrors the bug report: checkpoint generation at seq 1, then several
+    more WAL entries are appended (so seq 1 is no longer the highest), then
+    truncate below seq 2 so seq 1 is genuinely dropped.  list_rewind_points()
+    must NOT include seq 1 in its output.
+
+    Note: truncate_below() preserves the single highest seq even when it
+    falls below the requested floor (to avoid resetting the counter), so the
+    test ensures the WAL has entries above the truncation floor.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")  # seq 1 — gen recorded
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")  # seq 2 — no gen
+    s3 = await log.append("inbox_consume", target="alpha", msg_id="m3")  # seq 3 — no gen
+    # Only record a generation at s1; s2 and s3 are plain WAL entries that
+    # act as the "above-floor" anchor so truncate_below(2) actually drops s1.
+    _record_gen(reg, "alpha", s1)
+
+    # Drop seq 1; oldest kept becomes seq 2.  s2 and s3 remain as the watermark.
+    await log.truncate_below(2)
+
+    rows = reg.list_rewind_points()
+    listed_seqs = [r["seq"] for r in rows]
+    assert s1 not in listed_seqs, (
+        f"truncated seq {s1} must not be advertised "
+        f"(oldest kept is now >= {s2}); got {listed_seqs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_keeps_seqs_at_or_above_wal_floor(tmp_path) -> None:
+    """Tier 2: #2236 — seqs at or above the WAL floor remain advertised after truncation.
+
+    Partial truncation: only seqs strictly below the floor are dropped; seqs
+    at the floor or above remain reachable by checkout() and must still appear
+    in list_rewind_points().
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")  # will be truncated
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")  # oldest kept (gen)
+    s3 = await log.append("inbox_consume", target="alpha", msg_id="m3")  # above floor (gen)
+    # Also add a plain WAL entry at s4 so s3 is not the highest seq and
+    # truncate_below can freely drop s1 without the watermark-preservation
+    # heuristic interfering with s2 or s3.
+    await log.append("inbox_consume", target="alpha", msg_id="m4")       # seq 4 — no gen
+    for s in (s1, s2, s3):
+        _record_gen(reg, "alpha", s)
+
+    # Drop seq 1; oldest kept = seq 2.
+    await log.truncate_below(2)
+
+    rows = reg.list_rewind_points()
+    listed_seqs = [r["seq"] for r in rows]
+    assert s1 not in listed_seqs, f"truncated seq {s1} must not be advertised"
+    assert s2 in listed_seqs, f"seq {s2} at WAL floor must still be advertised"
+    assert s3 in listed_seqs, f"seq {s3} above WAL floor must still be advertised"


### PR DESCRIPTION
**[lead-coder]** — dispatched fix for #2236.

## Summary

- `AgentRegistry.list_rewind_points()` was advertising checkpoint seqs that `checkout()` would always reject with `RewindBeyondRetentionError` — the `/rewind` UI offered unreachable seq 8 when the WAL's oldest-kept was seq 9.
- Fix: filter the candidate seq set in `list_rewind_points()` to seqs >= the WAL retention floor, computed via the **exact same source** as the checkout guard: `next(iter(self._state_log.iter_from(1)), None)` → `oldest.get("seq")`. The list and the checkout path now agree by construction.
- The checkout rejection path, WAL retention semantics, and `truncate_below` behavior are **unchanged** — only the list producer is narrowed.
- Minor optimisation: the WAL scan pass now starts from `oldest_seq` instead of 1 (all entries below the floor were already excluded from `seqs`).

## Floor source reused (file:line)

`src/reyn/runtime/registry.py:1047–1048` (the `checkout()` guard):
```python
oldest = next(iter(self._state_log.iter_from(1)), None)
oldest_seq = oldest.get("seq") if oldest else None
```
The fix uses the identical pattern in `list_rewind_points()`.

## Falsify-first evidence

Two new Tier 2 tests added to `tests/test_registry_list_rewind_points_1f.py`:

- `test_list_rewind_points_excludes_truncated_seqs` — seq 1 (gen recorded, then truncated out) appears in the list **without** the fix, is absent **with** the fix. RED→GREEN confirmed.
- `test_list_rewind_points_keeps_seqs_at_or_above_wal_floor` — partial truncation: seq 1 (below floor) dropped, seqs 2 and 3 (at/above floor) retained. RED→GREEN confirmed.

## CI gates (all green locally)

- `ruff check src tests` — All checks passed
- `python scripts/test_tier_audit.py --strict tests/test_registry_list_rewind_points_1f.py` — 7 tests inspected, 0 errors
- `pytest tests/test_registry_list_rewind_points_1f.py tests/test_registry_rewind_to.py tests/test_anchor_text_1547.py tests/test_branch_registry_2a.py` — 34 passed

## Edge cases handled

- **Empty WAL** (`oldest` is None): `oldest_seq = None` → no filtering applied (no seqs are below any floor).
- **No checkpoints**: existing `if not seqs: return []` guard unchanged.
- **All truncated**: all generation seqs filtered out → returns `[]` (no crash).
- **WAL scan start**: narrowed to `oldest_seq` to skip the already-excluded range.

## Test plan

- [x] Falsify-first: both new tests go RED against unfixed code, GREEN with fix (manually verified by reverting the fix and running pytest).
- [x] All 34 related tests pass with the fix.
- [x] All 3 CI gates green locally.