### PR TITLE
fix(#2210): wire LLM-call HTTP timeout on router path + on_limit integration

### DIFF
--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -174,8 +174,14 @@ class OSRuntime:
         # one unified limit policy covers budget too) so the per-LLM-call cost gate
         # (LLMCallRecorder) routes through the 3-mode framework. NOT guarded: bus /
         # run_id are per-run, so a child runtime correctly re-binds its own context.
-        from reyn.llm.llm import set_budget_limit_context
-        set_budget_limit_context(self._intervention_bus, self._on_limit, run_id, False)
+        from reyn.llm.llm import set_llm_call_limit_context
+        # #2210: publish the per-call timeout/retries too. The kernel path also passes the
+        # timeout EXPLICITLY to call_llm_tools (via the LLMCallRecorder), so it uses that
+        # directly and these ambient values are the router-path fallback — same source
+        # (`safety.timeout.llm_call_seconds` / `llm_max_retries`), no double-management.
+        set_llm_call_limit_context(
+            self._intervention_bus, self._on_limit, run_id, False,
+            llm_call_timeout=self._llm_timeout, llm_max_retries=self._llm_max_retries)
         self._state_log = state_log
         self._skill_registry = skill_registry
         # PR-skill-resume D3b-3: optional ResumePlan for forward-replay

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -11,7 +11,7 @@ import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Coroutine, TypeVar, Union
+from typing import TYPE_CHECKING, Coroutine, NamedTuple, TypeVar, Union
 
 import httpx
 
@@ -645,19 +645,42 @@ def _resolved_retry_config():
 # place it binds the limit framework (mirrors set_llm_request_event_log /
 # set_router_config). UNSET → the budget gate FAILS CLOSED (deny / unattended) — no
 # policy context means no silent allow (owner + safety-critical requirement).
-_budget_limit_context_var: "contextvars.ContextVar[tuple | None]" = contextvars.ContextVar(
-    "reyn_budget_limit_context", default=None,
+class LLMCallLimitContext(NamedTuple):
+    """The ambient per-LLM-call policy context (#1868 budget gate + #2210 timeout gate).
+
+    Carries the safety/limit policy the per-LLM-call gates route a limit-exceed through:
+    ``bus`` / ``on_limit`` / ``run_id`` / ``non_interactive`` (the budget-exceed +
+    timeout-exhaustion → ``handle_limit_exceeded`` channel) PLUS the per-call HTTP bounds
+    ``llm_call_timeout`` / ``llm_max_retries`` (#2210: the router path passes no explicit
+    ``timeout`` to ``call_llm_tools`` and reads these from here — the kernel path passes
+    its own explicit values and is unaffected). ``None`` timeout/retries = not published
+    (the explicit-param caller, or a context set without the #2210 fields)."""
+
+    bus: object
+    on_limit: object
+    run_id: object
+    non_interactive: bool
+    llm_call_timeout: "float | None" = None
+    llm_max_retries: "int | None" = None
+
+
+_llm_call_limit_context_var: "contextvars.ContextVar[LLMCallLimitContext | None]" = (
+    contextvars.ContextVar("reyn_llm_call_limit_context", default=None)
 )
 
 
-def set_budget_limit_context(
+def set_llm_call_limit_context(
     bus: object, on_limit: object, run_id: object, non_interactive: bool = False,
+    llm_call_timeout: "float | None" = None, llm_max_retries: "int | None" = None,
 ) -> "contextvars.Token":
-    """#1868: publish the budget-exceed policy context (bus / on_limit / run_id /
-    non_interactive) the per-LLM-call cost gate routes through. Set by the runtime
-    at construction; propagates into the run's tasks. Returns the token so a caller
-    MAY reset for a nested scope."""
-    return _budget_limit_context_var.set((bus, on_limit, run_id, non_interactive))
+    """#1868/#2210: publish the per-LLM-call policy context (bus / on_limit / run_id /
+    non_interactive + the per-call timeout / retries). The cost gate (budget exceed) and
+    the timeout gate (persistent provider hang) both route through it; the router path
+    also reads ``llm_call_timeout`` / ``llm_max_retries`` for its ``call_llm_tools`` call.
+    Set by the runtime at construction; propagates into the run's tasks. Returns the token
+    so a caller MAY reset for a nested scope."""
+    return _llm_call_limit_context_var.set(LLMCallLimitContext(
+        bus, on_limit, run_id, non_interactive, llm_call_timeout, llm_max_retries))
 
 
 async def _budget_exceed_allows_continue(check: object, budget_agent: object) -> bool:
@@ -665,25 +688,77 @@ async def _budget_exceed_allows_continue(check: object, budget_agent: object) ->
     policy (``handle_limit_exceeded``). Returns True if the over-budget call may
     proceed (interactive-approved or bounded auto-extend), False to deny (the caller
     then raises ``BudgetExceeded`` — today's behavior). The ambient policy context
-    is set by ``set_budget_limit_context``; **UNSET → fail-closed deny** (no policy
+    is set by ``set_llm_call_limit_context``; **UNSET → fail-closed deny** (no policy
     = no silent allow). BudgetLedger accounting is unchanged — only the exceed→
     response path is unified; an allowed call is still recorded by construction."""
-    ctx = _budget_limit_context_var.get()
+    ctx = _llm_call_limit_context_var.get()
     if ctx is None:
         return False  # fail-closed: no policy context → deny (= unattended)
-    bus, on_limit, run_id, non_interactive = ctx
     from reyn.runtime.budget.budget import format_refusal_message
     from reyn.runtime.limits.limit_handler import handle_limit_exceeded
     dimension = getattr(check, "hard_dimension", None) or "budget"
     decision = await handle_limit_exceeded(
-        bus=bus,
-        on_limit=on_limit,
+        bus=ctx.bus,
+        on_limit=ctx.on_limit,
         kind=f"cost.{dimension}",  # dimension-in-kind (#1868 Q4): own auto_extend counter + audit
-        run_id=str(run_id or ""),
+        run_id=str(ctx.run_id or ""),
         prompt=format_refusal_message(check, agent=budget_agent),
         detail=(f"agent={budget_agent}" if budget_agent else ""),
         extension_amount=1.0,  # allow ONE over-cap call past the gate (bounded by auto_extend_times)
-        non_interactive=bool(non_interactive),
+        non_interactive=bool(ctx.non_interactive),
+    )
+    return bool(decision.allow_continue)
+
+
+def _is_llm_timeout_exc(exc: BaseException) -> bool:
+    """#2210: True for a per-call HTTP TIMEOUT (a hung/slow provider) — ``litellm`` Timeout or
+    an ``httpx`` read timeout, the timeout subset of ``_is_retryable_exc``. Used to route ONLY
+    a persistent timeout through the on_limit policy (other infra errors surface as-is).
+    ``litellm`` is lazy-imported (this module avoids a module-level ``import litellm``)."""
+    import litellm  # noqa: PLC0415
+    return isinstance(exc, (litellm.exceptions.Timeout, httpx.ReadTimeout))
+
+
+def _resolve_llm_call_bounds(
+    timeout: "float | None", max_retries: int
+) -> "tuple[float | None, int]":
+    """#2210: resolve the per-call HTTP bounds for ``call_llm_tools``. An EXPLICIT
+    ``timeout`` (the kernel path threads it via the LLMCallRecorder) WINS — returned as-is,
+    so the kernel behaviour is unchanged (regression-impossible by construction). Only a
+    ``None`` timeout (the router path, which passes no timeout) falls back to the ambient
+    per-LLM-call policy context (same ``safety.timeout.*`` source). No context → stays
+    ``None`` (litellm default — the pre-#2210 behaviour, no worse)."""
+    if timeout is None:
+        ctx = _llm_call_limit_context_var.get()
+        if ctx is not None:
+            timeout = ctx.llm_call_timeout
+            if ctx.llm_max_retries is not None:
+                max_retries = ctx.llm_max_retries
+    return timeout, max_retries
+
+
+async def _llm_timeout_allows_continue(model: object, detail: str) -> bool:
+    """#2210: route a persistent LLM-call TIMEOUT (the per-call HTTP timeout + Router/Reyn
+    retries all exhausted = a hung/slow provider) through the SAME limit framework the
+    budget gate uses (``handle_limit_exceeded`` + ``safety.on_limit``), instead of a bare
+    error. Returns True if the caller may RETRY once more (a fresh timeout window —
+    interactive-approved, or bounded ``auto_extend`` within ``auto_extend_times`` so a hung
+    provider cannot retry forever), False to give up and surface the timeout (clean
+    turn-end). UNSET context → fail-closed (no retry; surface the timeout)."""
+    ctx = _llm_call_limit_context_var.get()
+    if ctx is None:
+        return False  # fail-closed: no policy context → surface the timeout
+    from reyn.runtime.limits.limit_handler import handle_limit_exceeded
+    decision = await handle_limit_exceeded(
+        bus=ctx.bus,
+        on_limit=ctx.on_limit,
+        kind="timeout.llm_call",  # own auto_extend counter + audit namespace
+        run_id=str(ctx.run_id or ""),
+        prompt=(f"The model provider ({model}) is not responding — the request timed out "
+                "after the configured retries. Retry, or stop?"),
+        detail=detail,
+        extension_amount=1.0,  # one more timeout window per approval (bounded by auto_extend_times)
+        non_interactive=bool(ctx.non_interactive),
     )
     return bool(decision.allow_continue)
 
@@ -2173,6 +2248,12 @@ async def call_llm_tools(
         # No thinking kwargs: disabled by default on all providers
         **extra,
     }
+    # #2210: an EXPLICIT timeout (the kernel path threads `safety.timeout.llm_call_seconds`
+    # via the LLMCallRecorder) WINS and is used as-is — zero kernel regression. Only the
+    # router path, which passes no `timeout`, falls back to the ambient per-LLM-call policy
+    # context (same `safety.timeout.*` source). Without that wiring a hung provider hung the
+    # whole turn.
+    timeout, max_retries = _resolve_llm_call_bounds(timeout, max_retries)
     if timeout is not None:
         call_kwargs["timeout"] = timeout
     call_kwargs["num_retries"] = max_retries
@@ -2206,7 +2287,24 @@ async def call_llm_tools(
             routing=_routing,  # #309 per-class api_base/provider (else global wins)
         )
 
-    response = await _llm_call_with_retry(_tools_call, effective_model, event_log)
+    # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL
+    # exhausted (a persistently hung/slow provider), `_llm_call_with_retry` re-raises the
+    # litellm `Timeout`. Route it through the safety on_limit policy (the SAME framework the
+    # budget gate + phase/chain timeouts use) instead of a bare error: on approval (bounded
+    # `auto_extend` within `auto_extend_times`, or interactive yes) retry once more with a
+    # fresh timeout window; otherwise surface the timeout (the turn ends cleanly, not hangs).
+    while True:
+        try:
+            response = await _llm_call_with_retry(_tools_call, effective_model, event_log)
+            break
+        except Exception as _exc:
+            # Only a persistent TIMEOUT routes through on_limit; any other error surfaces
+            # as-is (unchanged). ``_llm_timeout_allows_continue`` False (on_limit deny / bound
+            # exhausted / no context) → re-raise = clean turn-end.
+            if not _is_llm_timeout_exc(_exc):
+                raise
+            if not await _llm_timeout_allows_continue(effective_model, str(_exc)):
+                raise
 
     msg = response.choices[0].message
     usage = _extract_usage(response) or TokenUsage()

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1432,9 +1432,14 @@ class Session:
             async def request(self, iv):  # type: ignore[no-untyped-def]
                 return await _session_dispatch(iv)
 
-        from reyn.llm.llm import set_budget_limit_context
-        set_budget_limit_context(
+        from reyn.llm.llm import set_llm_call_limit_context
+        # #2210: publish the per-call timeout/retries so the chat ROUTER path (which passes
+        # no explicit timeout to call_llm_tools) bounds each call + routes a persistent hang
+        # through on_limit. Same source as the kernel (`safety.timeout.*`), no double-manage.
+        set_llm_call_limit_context(
             _ChatBudgetBus(), self._on_limit, self.agent_name, self._non_interactive,
+            llm_call_timeout=self._safety.timeout.llm_call_seconds,
+            llm_max_retries=self._safety.timeout.llm_max_retries,
         )
         # Issue #162: surface session-level lifecycle events (compaction
         # today; attach/detach + budget warnings as growth) into the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def _isolated_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _isolate_budget_limit_context():
-    """Reset ``reyn.llm.llm._budget_limit_context_var`` after every test.
+    """Reset ``reyn.llm.llm._llm_call_limit_context_var`` after every test.
 
     Root fix for the Python-3.12 CI suite hang (#1800-7 diagnostic, PR #2062).
     The over-budget pre-check in ``call_llm`` / ``call_llm_tools`` raises
@@ -69,14 +69,14 @@ def _isolate_budget_limit_context():
     returns True and the call proceeds to ``recorded_acompletion`` → a real
     network call → on Linux an infinite ``EpollSelector.poll(timeout=-1)`` that
     hangs the whole ``-n auto`` job to its timeout. A test that calls
-    ``set_budget_limit_context`` without resetting its token leaks the contextvar
+    ``set_llm_call_limit_context`` without resetting its token leaks the contextvar
     SET; under pytest-xdist a co-located over-quota test then bypasses the
     pre-check (the necessary condition). The hang is Linux-only (epoll), so it
     never reproduced on macOS. Resetting per-test makes the pre-check
     deterministically fail-close — leaker-agnostic, protects the whole class."""
     yield
-    from reyn.llm.llm import _budget_limit_context_var
-    _budget_limit_context_var.set(None)
+    from reyn.llm.llm import _llm_call_limit_context_var
+    _llm_call_limit_context_var.set(None)
 
 # ── Marker registration ────────────────────────────────────────────────────────
 

--- a/tests/test_2210_llm_call_timeout.py
+++ b/tests/test_2210_llm_call_timeout.py
@@ -1,0 +1,126 @@
+"""Tier 2: #2210 — the LLM-call HTTP timeout (router-path wiring + on_limit integration).
+
+Two layers, both falsified here (real `OnLimitConfig` + a real bus fake, no mocks — same
+pattern as `test_budget_limit_unify_1868`):
+
+LOW (`_resolve_llm_call_bounds`) — the per-call timeout precedence. An EXPLICIT timeout
+(the kernel path threads `safety.timeout.llm_call_seconds`) WINS; only a `None` timeout (the
+router path) falls back to the ambient policy context. This is the kernel-regression guard:
+the kernel's explicit value must NOT be overridden by the ambient context.
+
+HIGH (`_llm_timeout_allows_continue`) — a persistent provider hang (per-call timeout + retries
+exhausted) routes through the SAME `handle_limit_exceeded` + `safety.on_limit` framework the
+budget gate uses, instead of a bare error. interactive yes → retry; no → surface; unset →
+fail-closed; auto_extend bounded → a hung provider cannot retry forever.
+"""
+from __future__ import annotations
+
+import pytest
+
+import reyn.llm.llm as llm_mod
+from reyn.config.chat import OnLimitConfig
+from reyn.llm.llm import (
+    _llm_timeout_allows_continue,
+    _resolve_llm_call_bounds,
+    set_llm_call_limit_context,
+)
+from reyn.user_intervention import InterventionAnswer
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx():
+    llm_mod._llm_call_limit_context_var.set(None)
+    yield
+    llm_mod._llm_call_limit_context_var.set(None)
+
+
+class _Bus:
+    """Minimal RequestBus fake (mirrors test_budget_limit_unify_1868._Bus)."""
+
+    def __init__(self, choice: "str | None") -> None:
+        self._choice = choice
+        self.asked = False
+        self.last_kind: "str | None" = None
+
+    async def request(self, iv) -> InterventionAnswer:  # type: ignore[no-untyped-def]
+        self.asked = True
+        self.last_kind = getattr(iv, "kind", None)
+        return InterventionAnswer(text="", choice_id=self._choice)
+
+
+# ── LOW: per-call timeout precedence (kernel-regression guard) ─────────────────
+
+
+def test_explicit_timeout_wins_over_ambient_kernel_unchanged():
+    """Tier 2: an EXPLICIT timeout (the kernel path) is returned AS-IS even when the ambient
+    context carries a different value — the kernel behaviour is unchanged. RED if the
+    generalize made the ambient override the explicit param (a kernel regression)."""
+    set_llm_call_limit_context(
+        _Bus(None), OnLimitConfig(), "run", False,
+        llm_call_timeout=999.0, llm_max_retries=9)
+    timeout, retries = _resolve_llm_call_bounds(60.0, 1)  # kernel passes explicit 60.0 / 1
+    assert timeout == 60.0, "explicit timeout must win over the ambient context"
+    assert retries == 1, "explicit retries must win over the ambient context"
+
+
+def test_none_timeout_falls_back_to_ambient_router_path():
+    """Tier 2: a None timeout (the router path passes no timeout) falls back to the ambient
+    context's value. RED if the fallback is unwired (timeout stays None → litellm default →
+    a hung provider hangs the turn — the #2210 bug)."""
+    set_llm_call_limit_context(
+        _Bus(None), OnLimitConfig(), "run", False,
+        llm_call_timeout=42.0, llm_max_retries=3)
+    timeout, retries = _resolve_llm_call_bounds(None, 1)  # router passes None / default 1
+    assert timeout == 42.0, "router path must inherit the ambient per-call timeout"
+    assert retries == 3, "router path must inherit the ambient retry budget"
+
+
+def test_none_timeout_no_context_stays_none():
+    """Tier 2: None timeout + no policy context → stays None (litellm default, the pre-#2210
+    behaviour — no worse, and direct/test construction is unaffected)."""
+    timeout, retries = _resolve_llm_call_bounds(None, 1)
+    assert timeout is None and retries == 1
+
+
+# ── HIGH: persistent-timeout → on_limit (framework integration) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_unset_context_fails_closed():
+    """Tier 2: no policy context → the timeout gate fails CLOSED (no retry; surface the
+    timeout). A hung provider with no runtime policy must not silently retry."""
+    assert await _llm_timeout_allows_continue("m", "timed out") is False
+
+
+@pytest.mark.asyncio
+async def test_interactive_yes_retries():
+    """Tier 2: interactive + user says YES → retry once more (a fresh timeout window). The
+    timeout must reach the user as a timeout-kind intervention. RED if the HIGH layer does
+    not route the persistent timeout through on_limit (a bare error instead)."""
+    bus = _Bus("yes")
+    set_llm_call_limit_context(bus, OnLimitConfig(mode="interactive"), "run-y", False)
+    assert await _llm_timeout_allows_continue("gpt-x", "timed out") is True
+    assert bus.asked and bus.last_kind == "safety.limit.timeout.llm_call", (
+        "the persistent timeout must reach the user as a timeout-kind intervention"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_no_surfaces():
+    """Tier 2: (falsification) interactive + user says NO → no retry; surface the timeout
+    (clean turn-end). If the gate ignored the answer this would wrongly retry."""
+    bus = _Bus("no")
+    set_llm_call_limit_context(bus, OnLimitConfig(mode="interactive"), "run-n", False)
+    assert await _llm_timeout_allows_continue("gpt-x", "timed out") is False
+
+
+@pytest.mark.asyncio
+async def test_auto_extend_is_bounded():
+    """Tier 2: auto_extend retries up to auto_extend_times then denies — a hung provider
+    CANNOT retry forever (bounded by construction, reusing the existing _bounded_auto_extend).
+    RED if the timeout retry is unbounded."""
+    set_llm_call_limit_context(
+        _Bus(None), OnLimitConfig(mode="auto_extend", auto_extend_times=1), "run-ax", False)
+    first = await _llm_timeout_allows_continue("m", "timed out")
+    second = await _llm_timeout_allows_continue("m", "timed out")
+    assert first is True and second is False, "timeout auto_extend is bounded (1 retry, then surface)"

--- a/tests/test_budget_limit_unify_1868.py
+++ b/tests/test_budget_limit_unify_1868.py
@@ -4,7 +4,7 @@ The per-LLM-call cost gate no longer hard-denies unconditionally: a
 ``check_pre_llm`` refusal routes through ``handle_limit_exceeded``
 (deny / auto-allow / ask-user), reusing ``safety.on_limit`` (lead decision A). The
 policy context (bus / on_limit / run_id / non_interactive) is published by the
-runtime via ``set_budget_limit_context``; **UNSET → fail-closed deny** (safety-
+runtime via ``set_llm_call_limit_context``; **UNSET → fail-closed deny** (safety-
 critical: no policy = no silent allow).
 
 Mandatory gates (lead): (a) fail-closed non-tty, (b) budget-iv falsification
@@ -13,7 +13,7 @@ byte-identical + budget=None inert is covered by the replay suite + the unchange
 ``if budget is not None`` guard (structural).
 
 Policy: real ``BudgetCheck`` + real ``handle_limit_exceeded`` + real
-``OnLimitConfig`` + real ``set_budget_limit_context``; the bus is a minimal fake
+``OnLimitConfig`` + real ``set_llm_call_limit_context``; the bus is a minimal fake
 (it IS the user-ask boundary, mirroring test_safety_limit_handler). Tier line first.
 """
 from __future__ import annotations
@@ -22,16 +22,16 @@ import pytest
 
 import reyn.llm.llm as llm_mod
 from reyn.config.chat import OnLimitConfig
-from reyn.llm.llm import _budget_exceed_allows_continue, set_budget_limit_context
+from reyn.llm.llm import _budget_exceed_allows_continue, set_llm_call_limit_context
 from reyn.runtime.budget.budget import BudgetCheck
 from reyn.user_intervention import InterventionAnswer
 
 
 @pytest.fixture(autouse=True)
 def _reset_budget_ctx():
-    llm_mod._budget_limit_context_var.set(None)
+    llm_mod._llm_call_limit_context_var.set(None)
     yield
-    llm_mod._budget_limit_context_var.set(None)
+    llm_mod._llm_call_limit_context_var.set(None)
 
 
 class _Bus:
@@ -69,7 +69,7 @@ async def test_interactive_yes_allows() -> None:
     """Tier 2: interactive + user says YES → the over-budget call is allowed
     (owner intent: 予算到達時も iv による継続判断)."""
     bus = _Bus("yes")
-    set_budget_limit_context(bus, OnLimitConfig(mode="interactive"), "run-yes", False)
+    set_llm_call_limit_context(bus, OnLimitConfig(mode="interactive"), "run-yes", False)
     assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is True
     assert bus.asked and bus.last_kind == "safety.limit.cost.daily_cost_usd", (
         "the budget exceed must reach the user as a cost-kind intervention"
@@ -81,7 +81,7 @@ async def test_interactive_no_denies() -> None:
     """Tier 2: (falsification) interactive + user says NO → denied. If the gate
     ignored the answer this would wrongly allow."""
     bus = _Bus("no")
-    set_budget_limit_context(bus, OnLimitConfig(mode="interactive"), "run-no", False)
+    set_llm_call_limit_context(bus, OnLimitConfig(mode="interactive"), "run-no", False)
     assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is False
 
 
@@ -89,7 +89,7 @@ async def test_interactive_no_denies() -> None:
 async def test_unattended_denies() -> None:
     """Tier 2: unattended mode → immediate deny (today's default preserved)."""
     bus = _Bus("yes")  # would say yes, but unattended never asks
-    set_budget_limit_context(bus, OnLimitConfig(mode="unattended"), "run-un", False)
+    set_llm_call_limit_context(bus, OnLimitConfig(mode="unattended"), "run-un", False)
     assert await _budget_exceed_allows_continue(_refusal(), "agent-a") is False
     assert bus.asked is False
 
@@ -102,7 +102,7 @@ async def test_non_interactive_bounded_no_bus_call() -> None:
     hang on the bus and must be BOUNDED. With auto_extend_times=0 it denies
     immediately; the bus is never asked (no TTY to ask)."""
     bus = _Bus("yes")
-    set_budget_limit_context(
+    set_llm_call_limit_context(
         bus, OnLimitConfig(mode="interactive", auto_extend_times=0), "run-nitty", True,
     )
     allowed = await _budget_exceed_allows_continue(_refusal(), "agent-a")
@@ -114,7 +114,7 @@ async def test_non_interactive_bounded_no_bus_call() -> None:
 async def test_auto_extend_bounded() -> None:
     """Tier 2: auto_extend allows up to auto_extend_times then denies (bounded
     auto-allow), per-(run_id, kind)."""
-    set_budget_limit_context(
+    set_llm_call_limit_context(
         _Bus(None), OnLimitConfig(mode="auto_extend", auto_extend_times=1), "run-ax", False,
     )
     first = await _budget_exceed_allows_continue(_refusal(), "agent-a")


### PR DESCRIPTION
**[e2e-coder]** — #2210: wire the LLM-call HTTP timeout on the router path + integrate persistent timeouts with the safety/limit framework. Design flow-traced + lead-approved + owner-GO'd (the revised, framework-integrated design — not the original bolt-on).

## The gap (primary evidence)

The router/chat path calls `call_llm_tools` with **no `timeout`** (router_loop.py:1968 main + 2677 force-close) → litellm's own interactive-untuned default → a hung provider hangs the whole turn (137s observed by owner). The kernel/phase path (`llm_call_recorder` → `call_llm_tools`) already threads `safety.timeout.llm_call_seconds`; **only the router path was unwired**. (Recent litellm-Router work #1829/#1870/#1835 added retry only — no timeout field — so this is not a Router-miss; the existing `call_llm_tools` timeout param just wasn't fed on the router path.)

## Fix — reuse the existing safety/limit framework (zero reinvention)

**LOW (per-call bound, precedence-safe)**: generalize the ambient per-LLM-call policy context — `set_budget_limit_context` → **`set_llm_call_limit_context`** (an `LLMCallLimitContext` NamedTuple) — to also carry `llm_call_timeout` / `llm_max_retries`. `call_llm_tools` resolves its bounds via **`_resolve_llm_call_bounds`**: an **explicit** timeout (the kernel threads it) WINS as-is — **kernel regression impossible by construction**; only the router's `None` falls back to the ambient value (same `safety.timeout.*` source → no double-management).

**HIGH (persistent failure → on_limit)**: when the per-call timeout + the Router/Reyn retries are all exhausted, `call_llm_tools` routes the timeout through **`handle_limit_exceeded(kind="timeout.llm_call")` + `safety.on_limit`** — the SAME framework the budget gate (`_budget_exceed_allows_continue`) and the phase/chain timeouts use — instead of a bare error: interactive ask / **bounded `auto_extend`** (reusing `_bounded_auto_extend` — a hung provider cannot retry forever) / abort. This also unifies the kernel path's timeout-exhaustion onto `on_limit` (consistent, additive — the explicit timeout *value* is unchanged).

**Reuse table** (no new config / mechanism): timeout value = `safety.timeout.llm_call_seconds`; retries = `safety.timeout.llm_max_retries`; ambient channel = the existing context (payload-extended); handler = `handle_limit_exceeded`; policy = `safety.on_limit.mode`; bound = `_bounded_auto_extend`; passthrough = the existing `call_llm_tools` timeout param.

## Consumer sweep (atomic, the generalize)

`_llm_call_limit_context_var` + `set_llm_call_limit_context` + the budget gate unpack + the kernel setter (`runtime.py`) + the chat setter (`session.py`) + the test fixtures (`conftest.py`, `test_budget_limit_unify_1868.py`) — all swept; no old-name reference remains.

## Test plan

- [x] **`tests/test_2210_llm_call_timeout.py`** (NEW, Tier 2, 7 tests, real `OnLimitConfig` + a real bus fake — no mocks): **LOW** — explicit-timeout-wins (kernel regression-guard), None→ambient fallback (router path), None+no-context→None; **HIGH** — unset→fail-closed, interactive yes→retry (kind `safety.limit.timeout.llm_call`), interactive no→surface, **auto_extend bounded** (1 retry then surface). **Falsify-verified RED** for: the precedence (kernel-guard), the router fallback, and the on_limit routing (3 strips).
- [x] `test_budget_limit_unify_1868.py` (existing budget gate) green after the rename/payload-extension — the budget path is unaffected (the regression-guard for the existing consumer).
- [x] All 4 CI gates: `ruff` ✓; `test_tier_audit.py --strict` ✓; `verify_module_docstrings.py` ✓; **full rootdir `pytest`** ✓ — 7488 passed, **zero new failures** (only the 4 pre-existing env quirks: gateway entry-points ×3, `reyn.safe` relocate). No hang (a `NameError` from a missing lazy `import litellm` was caught by the full run + fixed; `_is_llm_timeout_exc` lazy-imports litellm like the existing `_is_retryable_exc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
