### PR TITLE
[tui-coder] fix(router): cancel branch emitted the max_iterations error by copy-paste

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2470,15 +2470,16 @@ class RouterLoop:
                 continue  # re-enter inner for loop with extended limit
          break  # no extension granted or no on_limit — exit outer while
 
-        # Cancelled path (user-initiated): canned decision-enabling error.
+        # Cancelled path (user-initiated esc / cancel_inflight): an acknowledgement,
+        # not an error. This branch previously emitted the max_iterations error
+        # text by copy-paste — a bug every cancel consumer hit (inline esc + web
+        # ws cancel). max_iterations exhaustion takes the limit-deny / on_limit
+        # path below (where _loop_cancelled is False), never this branch, so this
+        # message is cancel-only.
         if _loop_cancelled:
             await self.host.put_outbox(
-                kind="error",
-                text=(
-                    f"Router loop exceeded max iterations ({self.max_iterations}). "
-                    f"Configure safety.on_limit.mode=interactive or auto_extend to "
-                    f"extend, or increase safety.loop.max_router_iterations."
-                ),
+                kind="status",
+                text="✗ turn interrupted",
                 meta={"chain_id": self.chain_id},
             )
             return self._total_usage

--- a/tests/test_turn_cancel_1468.py
+++ b/tests/test_turn_cancel_1468.py
@@ -114,6 +114,30 @@ async def test_turn_cancelled_event_emitted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_surfaces_interrupted_ack_not_max_iterations_error() -> None:
+    """Tier 2: #1468 — a user cancel surfaces a "turn interrupted" acknowledgement
+    on the outbox, NOT the max_iterations error. Regression: the _loop_cancelled
+    branch copy-pasted the max_iterations error text, so every cancel consumer
+    (inline esc + web ws cancel) saw a misleading "exceeded max iterations" line."""
+    host = _CancellableHost()
+    host.arm_cancel_after(0)  # cancel at the first iteration boundary
+    llm = _ScriptedLLM([text_result("unreached")])
+    loop = _loop(host, llm)
+    await loop.run_loop(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        _univ_enabled=False,
+    )
+    # A cancel acknowledgement was surfaced (status, not error)...
+    ack = [m for m in host.outbox if "interrupted" in m["text"].lower()]
+    assert ack, f"expected a 'turn interrupted' ack, got {host.outbox}"
+    assert ack[0]["kind"] == "status"
+    # ...and NOT the misleading max_iterations error (the copy-paste bug).
+    assert not any("max iteration" in m["text"].lower() for m in host.outbox)
+    assert not any(m["kind"] == "error" for m in host.outbox)
+
+
+@pytest.mark.asyncio
 async def test_cancel_after_one_iteration_allows_first_llm_call() -> None:
     """Tier 2: #1468 — cancel armed after iteration 1 lets the first LLM call
     complete (= cooperative: cancel fires at boundary, not mid-call).


### PR DESCRIPTION
**[tui-coder]** — standalone correctness fix split out of #236 ② (inline esc-interrupt); lands independently per lead-coder's (A) decision.

## Bug

`RouterLoop.run_loop()`'s user-cancel branch (`_loop_cancelled`) emitted the **max_iterations error text** — a copy-paste of the exhaustion path directly below it:

```python
# Cancelled path (user-initiated): canned decision-enabling error.
if _loop_cancelled:
    await self.host.put_outbox(kind="error",
        text=f"Router loop exceeded max iterations ({self.max_iterations}). ...")
```

So a plain **user cancel** surfaced a misleading *"Router loop exceeded max iterations"* error. Every cancel consumer hits it — the **existing web ws `cancel_inflight`** path, and any turn-interrupt UI. (max_iterations exhaustion takes the limit-deny / on_limit path below, where `_loop_cancelled` is False — never this branch — so the message is cancel-only.)

## Fix

Emit a `status` **"✗ turn interrupted"** acknowledgement instead.

## Test

Regression test in `test_turn_cancel_1468.py` (real `RouterLoop` + `FakeRouterHost`, no mocks): arms a cooperative cancel, asserts the outbox carries the "turn interrupted" status and **neither** the max_iterations text **nor** an `error` kind.

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] `test_turn_cancel_1468.py` — 10 passed
- [x] **Falsify-checked**: reverting the one-line fix turns the new assertion red (line 133)
- [x] Live-observed via the inline esc-interrupt spike (held separately): a user cancel now shows "✗ turn interrupted", not the max-iterations error

## Context

Found while wiring inline esc-interrupt (#236 ②). Per lead-coder, the inline esc **UX** is held (cooperative cancel can't interrupt a mid-flight LLM call — a misleading affordance) and tracked separately for a hard-cancel re-design. This router fix stands alone and also corrects the **live web ws cancel** path, so it lands now.

## Tier self-check

Tier 2 (OS-invariant): real `RouterLoop` driven through its cancel boundary, public outbox-surface asserts, no mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
