### PR TITLE
fix(#2072): wire cross-session hook push (route to resolved.session)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -62,10 +62,19 @@ class HookDispatcher:
         consent_bus: Any = None,
         consent_gate: "Callable[[], bool] | None" = None,
         emit_event: "Callable[..., Any] | None" = None,
+        cross_session_put: "Callable[..., Any] | None" = None,
+        current_session_id: "str | None" = None,
     ) -> None:
         self._registry = registry
         self._put_inbox = put_inbox
         self._stage_next_turn_context = stage_next_turn_context
+        # #2072: cross-session push routing. ``cross_session_put(target_sid, kind, payload,
+        # wake=...)`` delivers a push to ANOTHER session's inbox (the canonical wake-triple);
+        # ``current_session_id`` identifies THIS session so a push naming it (or naming none)
+        # stays local. None ``cross_session_put`` (e.g. unit tests / no registry) → the push
+        # always stays local — the pre-#2072 behaviour, no-op-equivalent.
+        self._cross_session_put = cross_session_put
+        self._current_session_id = current_session_id
         self._run_shell = run_shell
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
@@ -171,6 +180,17 @@ class HookDispatcher:
         # else the lifecycle point (slice-5b default) — the ``[hook:<name>]``
         # system-role prefix (shared E + C renderer).
         payload = {"name": hook.name or point, "text": resolved.message}
+        # #2072: cross-session push. A ``resolved.session`` naming a DIFFERENT session routes
+        # to THAT session's inbox (the canonical wake-triple); ``wake`` rides in the payload
+        # so the target processes it the same way the current session would (wake → triggers a
+        # turn; else → a passive ride-along on the target's next turn). No target / same
+        # session / no cross-session capability → the local path below (unchanged).
+        target = resolved.session.strip() if resolved.session else None
+        if (target and self._cross_session_put is not None
+                and target != self._current_session_id):
+            await self._cross_session_put(
+                target, HOOK_INBOX_KIND, {**payload, "wake": resolved.wake}, wake=resolved.wake)
+            return
         if resolved.wake:
             # E — a turn trigger (self-continuation): _put_inbox wake=True →
             # _drain_to_wake treats it as the trigger → _handle_hook_message.
@@ -195,11 +215,9 @@ def _parse_shell_push(stdout: str | None) -> ResolvedPush | None:
     WARNING and return ``None`` so the dispatcher skips the push and the run
     proceeds — symmetric with ``render_push``'s ``push_when=False`` safety net.
 
-    ``session`` is parsed and carried on the ``ResolvedPush`` for uniformity with
-    ``template_push`` (forward-compat). Cross-session routing is **not wired** in
-    this slice — the dispatcher pushes to the current session and ignores
-    ``resolved.session``, so a ``session`` value is a no-op today (tracked
-    follow-up), exactly as for ``template_push``.
+    ``session`` is parsed and carried on the ``ResolvedPush`` and (since #2072) ROUTED:
+    a ``session`` naming a different live session delivers the push to THAT session's
+    inbox (cross-session), exactly as for ``template_push``; ``null``/empty stays local.
     """
     if not stdout or not stdout.strip():
         return None

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1299,6 +1299,10 @@ class Session:
             self._build_hook_registry(_boot_in_set),
             put_inbox=self._put_inbox,
             stage_next_turn_context=self._stage_next_turn_context,
+            # #2072: route a push whose `session` names a different session to THAT session
+            # (cross-session); `current_session_id` keeps a self/unnamed push local.
+            cross_session_put=self._cross_session_hook_put,
+            current_session_id=self._session_id,
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
@@ -3255,6 +3259,33 @@ class Session:
     # SnapshotJournal; pending_chains lifecycle moved to ChainManager.
     # The methods below are thin delegators kept for the session-internal
     # call sites (inbox enqueue + dequeue, restoration orchestration).
+
+    async def _cross_session_hook_put(
+        self, target_session_id: str, kind: str, payload: dict, *, wake: bool
+    ) -> None:
+        """#2072: deliver a hook push to ANOTHER session of this agent (cross-session push).
+
+        The canonical wake-triple (``resolve_session`` / ``get_session`` → ``_put_inbox`` →
+        ``ensure_session_running``) — the same pattern TaskWaker / webhook_routing use. A
+        ``transport:native`` target resolves via ``resolve_session``; a bare sid via
+        ``get_session``. A target naming no live session is logged + dropped (the push is
+        best-effort — a cross-session push to an absent peer must never crash the source run).
+        Only a ``wake`` push boots the target's run-loop; a passive ride-along waits for the
+        target's next turn."""
+        reg = self._registry
+        if ":" in target_session_id:
+            transport, _, native = target_session_id.partition(":")
+            target = reg.resolve_session(self.agent_name, transport, native)
+        else:
+            target = reg.get_session(self.agent_name, target_session_id)
+        if target is None:
+            logger.warning(
+                "cross-session hook push: no live session %r for agent %r — dropped",
+                target_session_id, self.agent_name)
+            return
+        await target._put_inbox(kind, payload)
+        if wake:
+            reg.ensure_session_running(self.agent_name, target_session_id)
 
     async def _put_inbox(self, kind: str, payload: dict) -> str:
         """Append `inbox_put` to WAL via journal, then queue on the async

--- a/tests/test_2072_cross_session_push.py
+++ b/tests/test_2072_cross_session_push.py
@@ -1,0 +1,90 @@
+"""Tier 2: #2072 — cross-session hook push routing.
+
+A push's ``session`` field was parsed + carried on the ResolvedPush but IGNORED: the
+dispatcher always pushed to the CURRENT session (a documented no-op). #2072 wires it — a
+``session`` naming a DIFFERENT session routes the push to THAT session's inbox (the canonical
+wake-triple via the injected cross-session seam); ``null`` / empty / self stays LOCAL.
+
+Real recording seams (no mocks), mirroring ``test_hook_dispatcher_1800_5b``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef, PushBlock
+
+
+class _Recorder:
+    """A real recording async callable (not a mock) — captures (args, kwargs) per call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def __call__(self, *args, **kwargs) -> None:
+        self.calls.append((args, kwargs))
+
+
+def _dispatcher(hooks, *, current_session_id="me"):
+    seams = {"put_inbox": _Recorder(), "stage": _Recorder(), "cross": _Recorder()}
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage"],
+        cross_session_put=seams["cross"],
+        current_session_id=current_session_id,
+    )
+    return disp, seams
+
+
+@pytest.mark.asyncio
+async def test_cross_session_push_routes_to_target_not_current():
+    """Tier 2: a push naming a DIFFERENT session delivers via the cross-session seam to that
+    session, carrying the target sid + the wake flag — and does NOT land in the current
+    session's inbox. RED if ``resolved.session`` is ignored (the pre-#2072 no-op: the push
+    falls into the current session)."""
+    hook = HookDef(on="turn_end",
+                   template_push=PushBlock(message="hi peer", wake=True, session="peer-sid"))
+    disp, seams = _dispatcher([hook], current_session_id="me")
+
+    await disp.dispatch("turn_end", {})
+
+    # exactly-one via tuple-unpack (the dispatcher idiom) — RED if zero or many
+    (args, kwargs), = seams["cross"].calls
+    assert args[0] == "peer-sid", "must target the named session"
+    payload = args[2]
+    assert payload["text"] == "hi peer" and payload["wake"] is True
+    assert kwargs.get("wake") is True, "the wake flag must reach the cross-session put"
+    assert seams["put_inbox"].calls == [], "must NOT land in the current session's inbox"
+    assert seams["stage"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_session_stays_local():
+    """Tier 2: a push with no ``session`` stays LOCAL (the current session's inbox). RED if a
+    null-session push wrongly routes through the cross-session seam."""
+    hook = HookDef(on="turn_end", template_push=PushBlock(message="self note", wake=True))
+    disp, seams = _dispatcher([hook], current_session_id="me")
+
+    await disp.dispatch("turn_end", {})
+
+    (args, _k), = seams["put_inbox"].calls  # exactly one local push
+    assert args[1]["text"] == "self note"
+    assert seams["cross"].calls == [], "a null-session push must NOT go cross-session"
+
+
+@pytest.mark.asyncio
+async def test_self_session_stays_local():
+    """Tier 2: a push naming the CURRENT session stays local — no needless cross-session hop
+    (the current session is reached directly). RED if a self-named push takes the
+    cross-session path."""
+    hook = HookDef(on="turn_end",
+                   template_push=PushBlock(message="me note", wake=True, session="me"))
+    disp, seams = _dispatcher([hook], current_session_id="me")
+
+    await disp.dispatch("turn_end", {})
+
+    (args, _k), = seams["put_inbox"].calls  # exactly one local push, no cross-session hop
+    assert args[1]["text"] == "me note"
+    assert seams["cross"].calls == []


### PR DESCRIPTION
**[e2e-coder]** — #2072: wire the cross-session hook push (the dispatcher ignored `resolved.session`). Silent-gap correctness — declared but inert, the same class as the cost-warn #2230 gap. Falsify-first; gap was clear (no plan-first needed, per lead).

## The gap (primary evidence)

A push's `session` field (`template_push` / `shell_push` → `PushBlock` → `ResolvedPush`) is parsed and forward-compat carried, but `HookDispatcher._push_resolved` always pushed to the CURRENT session (`self._put_inbox` / `self._stage_next_turn_context`) and **ignored `resolved.session`** — documented inline as a no-op ("the dispatcher pushes to the current session and ignores `resolved.session`, so a `session` value is a no-op today"). So a cross-session push always landed in the current session.

## The fix

`HookDispatcher._push_resolved` now routes a push whose `session` names a **different** live session to THAT session's inbox, via an injected `cross_session_put` seam; `null` / empty / the current session stays local (unchanged). The session provides `_cross_session_hook_put` — the **canonical wake-triple** (`resolve_session` / `get_session` → `_put_inbox` → `ensure_session_running`), the same pattern `TaskWaker` / `webhook_routing` use; a `transport:native` target resolves via `resolve_session`, a bare sid via `get_session`. The `wake` flag rides in the payload (target processes it the same way the current session would; only `wake` boots the target's run-loop). Best-effort: a target naming no live session is logged + dropped (a cross-session push to an absent peer must never crash the source run). The `cross_session_put` seam **defaults to None**, so existing `HookDispatcher` callers are unaffected (no-op-equivalent).

## Test plan

- [x] **`tests/test_2072_cross_session_push.py`** (NEW, Tier 2, 3 tests, real recording seams — no mocks, mirroring `test_hook_dispatcher_1800_5b`): a cross-session push routes to the cross-session seam with the target sid + wake flag and does NOT land in the current inbox (**falsify-verified RED** when the routing branch is stripped — the push falls into the current session, the pre-#2072 no-op); a null-`session` push stays local; a self-named push stays local (no needless hop).
- [x] Updated the stale `_parse_shell_push` docstring ("not wired" → "ROUTED since #2072").
- [x] All 4 CI gates: `ruff` ✓; `test_tier_audit.py --strict` ✓ (a first pass had `len(...) == N` count-pins → switched to the tuple-unpack exactly-one idiom); `verify_module_docstrings.py` ✓; **full rootdir `pytest`** ✓ — 7484 passed, **zero new failures** (only the 4 pre-existing env quirks: gateway entry-points ×3, `reyn.safe` relocate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
