### PR TITLE
fix(#1765 1a-ii): route snapshot save off-loop via the shared DurabilityWorker

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -135,10 +135,12 @@ class AgentSnapshot:
             ),
         )
 
-    def save(self, path: Path) -> None:
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
+    def serialize(self) -> str:
+        """Serialise to a JSON string — SYNCHRONOUS, so it captures a consistent view of the
+        mutable state (inbox / chains / …) at the call instant. #1765 1a-ii splits this from
+        the durable write so an off-loop save snapshots the state here (sync) and only the
+        write+fsync runs off the event loop, with no risk of the state being mutated mid-write.
+        """
         payload = {
             "version": SNAPSHOT_VERSION,
             "session_id": self.session_id,  # FP-0043 S5 (additive; legacy load → "main")
@@ -150,11 +152,24 @@ class AgentSnapshot:
             "buffered_intervention_answers": self.buffered_intervention_answers,
             "next_turn_context": self.next_turn_context,
         }
+        return json.dumps(payload, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def write_durable(path: Path, data: str) -> None:
+        """Atomically + durably write pre-serialised snapshot ``data`` (tmp → fsync → rename).
+        Pure I/O (no mutable-state access), so it is safe to run OFF the event loop (#1765)."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.write(data)
             f.flush()
             os.fsync(f.fileno())
         tmp.replace(path)
+
+    def save(self, path: Path) -> None:
+        """Synchronous atomic save (serialise + durable write). Unchanged contract."""
+        self.write_durable(path, self.serialize())
 
     # ── replay (apply WAL entries to this snapshot) ─────────────────────
 

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -5,6 +5,7 @@ All WAL-recorded mutations go through here; in-memory readers go via the
 """
 from __future__ import annotations
 
+import asyncio
 import uuid
 from pathlib import Path
 
@@ -156,7 +157,7 @@ class SnapshotJournal:
             self._snapshot.inbox.append({
                 "id": msg_id, "kind": kind, "payload": full_payload,
             })
-            self.save()
+            await self.save()
         return msg_id
 
     async def consume_inbox(self, *, msg_id: str) -> None:
@@ -174,7 +175,7 @@ class SnapshotJournal:
         self._snapshot.inbox = [
             m for m in self._snapshot.inbox if m.get("id") != msg_id
         ]
-        self.save()
+        await self.save()
 
     async def record_chain_register(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_register`` to WAL and create the pending_chains entry.
@@ -194,7 +195,7 @@ class SnapshotJournal:
             "chain_id": chain_id,
             **{k: (list(v) if k == "waiting_on" else v) for k, v in fields.items()},
         }
-        self.save()
+        await self.save()
 
     async def record_chain_update(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_update`` to WAL and update waiting_on in snapshot.
@@ -213,7 +214,7 @@ class SnapshotJournal:
         if chain is not None:
             waiting_on = fields.get("waiting_on", [])
             chain["waiting_on"] = list(waiting_on)
-        self.save()
+        await self.save()
 
     async def record_chain_resolve(self, *, chain_id: str) -> None:
         """Append ``chain_resolve`` to WAL and remove the pending_chains entry.
@@ -227,7 +228,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.pending_chains.pop(chain_id, None)
-        self.save()
+        await self.save()
 
     async def record_chain_timeout_fired(self, *, chain_id: str) -> None:
         """Append ``chain_timeout_fired`` to WAL and remove the pending_chains entry.
@@ -241,7 +242,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.pending_chains.pop(chain_id, None)
-        self.save()
+        await self.save()
 
     # ── intervention persistence (PR-intervention-link L2) ────────────────
 
@@ -268,7 +269,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.outstanding_interventions[intervention_id] = iv_dict
-        self.save()
+        await self.save()
 
     async def record_intervention_resolved(
         self, *, intervention_id: str,
@@ -287,7 +288,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.outstanding_interventions.pop(intervention_id, None)
-        self.save()
+        await self.save()
 
     async def record_intervention_answer_buffered(
         self, *, run_id: str, text: str, choice_id: str | None,
@@ -313,7 +314,7 @@ class SnapshotJournal:
         self._snapshot.buffered_intervention_answers[run_id] = {
             "text": text, "choice_id": choice_id,
         }
-        self.save()
+        await self.save()
 
     async def record_intervention_answer_consumed(
         self, *, run_id: str,
@@ -336,7 +337,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.buffered_intervention_answers.pop(run_id, None)
-        self.save()
+        await self.save()
 
     async def record_next_turn_context_staged(
         self, *, kind: str, payload: dict,
@@ -357,7 +358,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.next_turn_context.append(entry)
-        self.save()
+        await self.save()
 
     async def record_next_turn_context_cleared(self) -> None:
         """Append ``next_turn_context_cleared`` to WAL + clear the buffer (#1800-4b).
@@ -374,7 +375,7 @@ class SnapshotJournal:
         )
         self._snapshot.applied_seq = seq
         self._snapshot.next_turn_context.clear()
-        self.save()
+        await self.save()
 
     # ── restore / persist ─────────────────────────────────────────────────
 
@@ -384,15 +385,40 @@ class SnapshotJournal:
         Mirrors the WAL/snapshot install portion of
         ``Session.restore_state`` (the asyncio queue repopulation and
         chain timeout re-arming remain the session's responsibility).
+
+        Persists synchronously: restore is a one-shot recovery write (not the hot
+        per-mutation path), so it keeps the original sync save rather than forcing an
+        async restore path. The off-loop routing (#1765 1a-ii) is for the frequent
+        per-mutation ``save()`` that would otherwise freeze the loop.
         """
         self._snapshot = snapshot
-        self.save()
-
-    def save(self) -> None:
-        """Persist the current snapshot to disk (atomic write via AgentSnapshot.save).
-
-        Mirrors ``Session._save_snapshot``.  Follows the existing
-        convention: no try/except — let I/O errors propagate (there is no
-        error-suppression in the original implementation).
-        """
         self._snapshot.save(self._snapshot_path)
+
+    async def save(self) -> None:
+        """Persist the current snapshot to disk (atomic write via AgentSnapshot).
+
+        #1765 Step 1a-ii: the snapshot is SERIALISED synchronously here — capturing a
+        consistent view of the mutable state (inbox / chains / …) at this instant — and only
+        the durable write+fsync is routed OFF the event loop, through the SAME serial
+        DurabilityWorker as the WAL (``state_log.submit_durable``). Two guarantees follow:
+
+        * **Loop-free fsync** — the snapshot fsync no longer freezes the event loop.
+        * **WAL → snapshot ordering** — every mutation method awaits its WAL append (durable)
+          BEFORE awaiting this save, and the worker is serial FIFO, so the snapshot's
+          ``applied_seq`` becomes durable only AFTER the WAL seq it records
+          (``applied_seq`` ≤ durable WAL seq). A crash can never leave a durable snapshot
+          pointing at a non-durable WAL entry.
+
+        No WAL (``state_log is None``: tests / non-chat) → the original synchronous save, so
+        the no-persistence contract is byte-identical. No try/except — I/O errors propagate
+        (unchanged from the original)."""
+        if self._state_log is None:
+            self._snapshot.save(self._snapshot_path)
+            return
+        data = self._snapshot.serialize()  # sync: consistent state captured before any await
+        path = self._snapshot_path
+
+        async def _write() -> None:
+            await asyncio.to_thread(AgentSnapshot.write_durable, path, data)
+
+        await self._state_log.submit_durable(_write)

--- a/tests/test_1765_snapshot_journal_off_loop.py
+++ b/tests/test_1765_snapshot_journal_off_loop.py
@@ -1,0 +1,130 @@
+"""Tier 2: #1765 Step 1a-ii — SnapshotJournal.save routed off the event loop.
+
+The per-mutation snapshot write+fsync is moved OFF the loop, through the SAME serial
+DurabilityWorker as the WAL (``state_log.submit_durable``). Two invariants are pinned, plus
+behavior-invariance:
+
+  * loop-free   — a slow snapshot write no longer freezes the event loop (a concurrent
+                  ticker keeps advancing). RED if ``save`` wrote inline (the pre-1a-ii sync
+                  path).
+  * WAL→snapshot ordering — the snapshot becomes durable only AFTER the WAL seq it records:
+                  observed at snapshot-write time, that ``applied_seq`` is ALREADY on disk in
+                  the WAL. RED if a mutation saved the snapshot before its WAL append (the
+                  ordering that a crash would otherwise expose as a snapshot pointing at a
+                  non-durable WAL entry).
+  * persist + recover — a mutation's snapshot is durable + consistent with the WAL; a fresh
+                  load after a simulated restart sees the mutated state at the right seq.
+
+Real instances (no mocks): a real StateLog + a real SnapshotJournal.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+
+def _journal(tmp_path: Path) -> tuple[SnapshotJournal, StateLog, Path]:
+    snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"
+    snap_path.parent.mkdir(parents=True, exist_ok=True)
+    sl = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    j = SnapshotJournal(agent_name="alpha", snapshot_path=snap_path, state_log=sl)
+    return j, sl, snap_path
+
+
+def _wal_seqs(sl: StateLog) -> list[int]:
+    p = Path(sl.path)  # the on-disk WAL file (public accessor)
+    if not p.exists():
+        return []
+    return [json.loads(ln)["seq"] for ln in p.read_text().splitlines() if ln.strip()]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_save_keeps_event_loop_free(tmp_path, monkeypatch):
+    """Tier 2: a slow snapshot write runs OFF the loop — a concurrent ticker keeps advancing
+    while a mutation's snapshot save is in its (slow) write+fsync. RED if save wrote inline on
+    the loop (the pre-1a-ii sync ``self._snapshot.save`` path would block the ticker)."""
+    j, sl, _ = _journal(tmp_path)
+
+    orig = AgentSnapshot.write_durable
+
+    def _slow_write(path, data):  # runs in to_thread when routed off-loop → loop stays free
+        time.sleep(0.1)
+        return orig(path, data)
+
+    monkeypatch.setattr(AgentSnapshot, "write_durable", staticmethod(_slow_write))
+
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        for _ in range(20):
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    ticker = asyncio.create_task(_ticker())
+    await j.append_inbox(kind="msg", payload={"text": "hi"})
+    assert ticks > 0, "the loop must keep running during the slow off-loop snapshot write"
+    await ticker
+    await sl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_durable_only_after_its_wal_seq(tmp_path, monkeypatch):
+    """Tier 2: WAL→snapshot ordering. At the instant the snapshot is written, the
+    ``applied_seq`` it records is ALREADY present in the on-disk WAL — i.e. the WAL append
+    became durable BEFORE the snapshot save. RED if a mutation saved the snapshot before (or
+    concurrently with) its WAL append: the snapshot would record a seq not yet (or never) in
+    the WAL, which a crash mid-mutation would expose."""
+    j, sl, _ = _journal(tmp_path)
+
+    orig = AgentSnapshot.write_durable
+    observations: list[tuple[int, list[int]]] = []
+
+    def _observing_write(path, data):
+        applied_seq = json.loads(data)["applied_seq"]
+        observations.append((applied_seq, _wal_seqs(sl)))  # WAL state AT snapshot-write time
+        return orig(path, data)
+
+    monkeypatch.setattr(AgentSnapshot, "write_durable", staticmethod(_observing_write))
+
+    await j.append_inbox(kind="msg", payload={"text": "a"})
+    await j.record_chain_register(
+        chain_id="c1",
+        fields={"origin_agent": "alpha", "origin_depth": 0,
+                "original_request": "r", "waiting_on": ["x"]},
+    )
+    await j.consume_inbox(msg_id=j.snapshot.inbox[0]["id"] if j.snapshot.inbox else "none")
+
+    assert observations, "snapshot saves must have run through the off-loop write"
+    for applied_seq, wal_at_write in observations:
+        assert applied_seq in wal_at_write, (
+            f"snapshot recorded applied_seq={applied_seq} but the WAL on disk was "
+            f"{wal_at_write} at write time — the WAL append must be durable FIRST"
+        )
+    await sl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mutation_persists_and_recovers(tmp_path):
+    """Tier 2: behavior-invariant + recovery. After mutations the durable snapshot reflects
+    the mutated state at the latest WAL seq; a fresh load (a simulated restart) sees it. RED
+    if the off-loop save dropped/raced a write (snapshot stale or applied_seq behind the WAL)."""
+    j, sl, snap_path = _journal(tmp_path)
+
+    await j.append_inbox(kind="msg", payload={"text": "first"})
+    await j.append_inbox(kind="msg", payload={"text": "second"})
+    await sl.aclose()
+
+    on_disk = AgentSnapshot.load("alpha", snap_path)
+    wal_max = max(_wal_seqs(sl))
+    assert on_disk.applied_seq == wal_max, "durable snapshot must sit at the latest WAL seq"
+    assert [m["kind"] for m in on_disk.inbox] == ["msg", "msg"]
+    assert [m["payload"]["text"] for m in on_disk.inbox] == ["first", "second"]


### PR DESCRIPTION
**[e2e-coder]** — #1765 Step 1a-ii. Follows 1a-i (#2246, WAL fsync off-loop). Autonomous GO from lead.

## What
The per-mutation snapshot `save()` did a synchronous `os.fsync` on the event loop, freezing the whole loop (TUI repaint + every concurrent session) for its duration. This routes it through the **same serial DurabilityWorker** as the WAL, via the existing `state_log.submit_durable` seam.

- `AgentSnapshot.save` split into `serialize()` (sync — captures a consistent view of the mutable inbox/chains state) + `write_durable()` (pure I/O, safe off-loop). Sync `save()` contract unchanged.
- `SnapshotJournal.save` is now async: serialises synchronously, submits only the write+fsync to the worker. 12 per-mutation callers `await self.save()`.
- `install()` (recovery restore) stays synchronous — a one-shot recovery write, not the hot path; avoids forcing an async restore path.

## WAL → snapshot ordering (the load-bearing invariant)
Each mutation awaits its WAL append (durable) **before** awaiting the snapshot save, and the worker is serial FIFO → the snapshot's `applied_seq` becomes durable only **after** the WAL seq it records (`applied_seq ≤ durable WAL seq`). A crash can never leave a durable snapshot pointing at a non-durable WAL entry.

## Scope
The high-frequency per-mutation `save()`. The checkpoint-boundary generation save (`SnapshotGenerationStore.record`, fired per turn/plan-step) **remains a sync fsync** — a noted lower-frequency follow-up candidate, called out so the residual loop-block isn't silent.

## Falsify (RED-when-stripped, both verified)
- **loop-free** — a slow snapshot write doesn't block a concurrent ticker. Verified RED with the pre-1a-ii inline sync save (`ticks == 0`).
- **WAL→snapshot ordering** — at snapshot-write time the recorded `applied_seq` is already on disk in the WAL. Verified RED when a mutation saves before its WAL append (`assert 1 in []`).
- **persist + recover** — a fresh load after a simulated restart sees the mutated state at the latest WAL seq.

## Test plan
- [x] `pytest tests/test_1765_snapshot_journal_off_loop.py` (3 new) + 1765 WAL/worker + journal/snapshot/recovery suites — 43 passed
- [x] Timing-sensitive recovery suites (`test_1800_c_staging`, `test_session_auto_resume`) — 11 passed
- [x] Both falsify strips verified RED, then restored
- [x] ruff (full tree `src tests scripts`) — clean
- [x] `test_tier_audit.py --strict` on the new test — OK 3/0/0
- [x] `verify_module_docstrings.py` on both changed src files — clean (no module-docstring touched)
- [x] Full suite — 7494 passed; 4 pre-existing failures (gateway entry-point + `reyn.safe` import-relocation, import-order sensitive) reproduce on the clean tree with this change stashed → **not introduced here**

🤖 Generated with [Claude Code](https://claude.com/claude-code)