### PR TITLE
feat(#2248 PR-A): config_changed WAL event + rewind reconstruct (foundation)

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -114,6 +114,13 @@ WAL_EVENT_KINDS = (
     # live SubscriptionRegistry (subscription.py) — as-of-cut reconstruction by replay.
     "task_subscribed",
     "task_rebound",
+    # NEW (#2248 PR-A) — config registry change for recovery-core `.reyn/config/`
+    # (mcp / cron / hooks / approvals / index-sources). Carries the registry's relative
+    # path + its FULL post-mutation content (re-materialisable, latest-≤-cut-wins, no
+    # delta-fold — uniform with topology_*). OS-level + P7-safe: `path`/`content` are
+    # opaque (the OS writes `content` to `<.reyn>/<path>` on reconstruct, no registry
+    # semantics). apply_events no-ops it (config-set state, not AgentSnapshot STATE).
+    "config_changed",
 )
 
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1709,6 +1709,66 @@ class AgentRegistry:
                 topo.save(path)
                 self._topologies[name] = topo
 
+    async def record_config_change(self, rel_path: str, content: dict) -> None:
+        """#2248 PR-A: WAL the full post-mutation content of a recovery-core config
+        registry, keyed by its `.reyn`-relative path. The single emission chokepoint for
+        config recovery (mirrors `_emit_topology`): a dedicated config op calls this AFTER
+        persisting its `.yaml`, so the registry is reconstructable by WAL replay. The yaml
+        on disk is thus a DERIVED projection — `content` here is the recovery truth.
+        No-op without a WAL (the opt-in / test contract)."""
+        if self._state_log is None:
+            return
+        await self._state_log.append("config_changed", path=rel_path, content=content)
+
+    def _config_lifecycle(self) -> "dict[str, list[tuple[int, dict]]]":
+        """#2248 PR-A: one WAL scan → per config relative-path, its ordered
+        ``(seq, content)`` from ``config_changed`` events (content = the FULL registry
+        state at that point). WAL-sourced only (never the rotated audit log). Only paths
+        that appear here are WAL-tracked → only these are touched by reconstruction; an
+        operator-owned / pre-feature yaml with no event is invisible and left alone. Empty
+        without a WAL."""
+        events: dict[str, list[tuple[int, dict]]] = {}
+        if self._state_log is None:
+            return events
+        for entry in self._state_log.iter_from(0):
+            if entry.get("kind") != "config_changed":
+                continue
+            path = entry.get("path")
+            seq = entry.get("seq")
+            content = entry.get("content")
+            if not isinstance(path, str) or not isinstance(seq, int):
+                continue
+            events.setdefault(path, []).append((seq, content if isinstance(content, dict) else {}))
+        return events
+
+    def _reconcile_config_as_of_cut(self, cut: int) -> None:
+        """#2248 PR-A: reconstruct the recovery-core config registries as-of-cut from the
+        ``config_changed`` WAL (WAL-sourced only). Per WAL-tracked path, the LATEST event
+        with seq ≤ cut decides the on-disk content (latest-≤-cut wins, FULL state, no
+        delta-fold — uniform with `_reconcile_topologies_as_of_cut`). A path whose first
+        event is AFTER the cut didn't exist as-of-cut → removed. Only WAL-tracked paths are
+        touched; inert without events. The yaml is a derived projection re-materialised
+        here from the recovery truth."""
+        import yaml  # noqa: PLC0415 — local, matching the file convention
+
+        for rel_path, evs in self._config_lifecycle().items():
+            latest = max(
+                (e for e in evs if e[0] <= cut), key=lambda e: e[0], default=None,
+            )
+            abs_path = (self._project_root / ".reyn" / rel_path).resolve()
+            if latest is None:
+                # First written after the cut → didn't exist as-of-cut → drop.
+                if abs_path.is_file():
+                    abs_path.unlink()
+            else:
+                abs_path.parent.mkdir(parents=True, exist_ok=True)
+                abs_path.write_text(
+                    yaml.dump(
+                        latest[1], allow_unicode=True, default_flow_style=False,
+                    ),
+                    encoding="utf-8",
+                )
+
     async def _drop_session(self, name: str, sid: str, *, purge_dir: bool = True) -> None:
         """#2103 S1bc: tear down a single spawned session created after the rewind cut
         (the primitive's seam, now wired). Delegates to ``remove_session`` — the single
@@ -1936,6 +1996,9 @@ class AgentRegistry:
         # archived-state (rewind-before-archive → active; rewind-after → archived).
         self._reconcile_archived_as_of_cut(ag_archived, drop_cut)
         self._reconcile_topologies_as_of_cut(drop_cut)
+        # #2248 PR-A: rebuild the recovery-core config registries (mcp/cron/hooks/…)
+        # as-of-cut from the config_changed WAL — same latest-≤-cut-wins model as topology.
+        self._reconcile_config_as_of_cut(drop_cut)
         # #2103 B (the rewind LINCHPIN): rebuild the spawn lineage as-of-cut from the
         # agent_created records — a re-materialised child REGAINS its ⊆-parent cap and a
         # dropped/post-cut child's edge is gone. A FULL rebuild (not an incremental

--- a/tests/test_2248_config_wal_reconstruct.py
+++ b/tests/test_2248_config_wal_reconstruct.py
@@ -1,0 +1,98 @@
+"""Tier 2: OS invariant — #2248 PR-A config-registry rewind-reconstruction.
+
+Recovery-core `.reyn/config` registries become rewind-durable: `record_config_change` emits a
+`config_changed` WAL event carrying the registry's `.reyn`-relative path + its FULL
+post-mutation content. `_reconcile_config_as_of_cut` reconstructs each WAL-tracked config path
+AS-OF-CUT (latest-≤-cut wins, full content, no delta-fold) — so the `.yaml` is a DERIVED
+projection re-materialised from the WAL truth, never an independent source of truth (the #2248
+load-bearing invariant). Mirrors the topology-lifecycle model.
+
+Real AgentRegistry + StateLog + on-disk yaml (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory,
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+    )
+
+
+def _read_yaml(p: Path):
+    return yaml.safe_load(p.read_text(encoding="utf-8")) if p.is_file() else None
+
+
+@pytest.mark.asyncio
+async def test_config_reconstructs_to_latest_at_or_below_cut(tmp_path):
+    """Tier 2: per config path the LATEST config_changed with seq ≤ cut wins — the yaml is
+    re-materialised to that FULL content, NOT the on-disk (post-cut) state. RED if reconcile
+    trusted the on-disk yaml as the source of truth, or used the absolute-latest event."""
+    reg = _make_registry(tmp_path)
+    await reg.record_config_change("mcp.yaml", {"mcp": {"servers": {"a": {"command": "x"}}}})
+    cut = reg.state_log.current_seq
+    # a later mutation (after the cut) — the live on-disk state the op would have written:
+    await reg.record_config_change("mcp.yaml", {"mcp": {"servers": {"a": {}, "b": {}}}})
+    p = tmp_path / ".reyn" / "mcp.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.dump({"mcp": {"servers": {"a": {}, "b": {}}}}), encoding="utf-8")
+
+    reg._reconcile_config_as_of_cut(cut)
+
+    assert _read_yaml(p) == {"mcp": {"servers": {"a": {"command": "x"}}}}, \
+        "yaml must be re-materialised from the WAL event ≤ cut, not the live post-cut state"
+
+
+@pytest.mark.asyncio
+async def test_config_path_first_written_after_cut_is_removed(tmp_path):
+    """Tier 2: a config path whose FIRST config_changed is AFTER the cut did not exist
+    as-of-cut → reconcile removes its yaml. RED if a registry created after a rewind point
+    survived a rewind to before it existed."""
+    reg = _make_registry(tmp_path)
+    await reg.record_config_change("cron.yaml", {"cron": {"jobs": [{"name": "j"}]}})  # seq 1 > cut 0
+    p = tmp_path / ".reyn" / "cron.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.dump({"cron": {"jobs": [{"name": "j"}]}}), encoding="utf-8")
+
+    reg._reconcile_config_as_of_cut(0)  # cut BEFORE the only config event
+
+    assert not p.exists(), "a config path first written after the cut is removed on reconstruct"
+
+
+@pytest.mark.asyncio
+async def test_record_config_change_emits_durable_wal_event(tmp_path):
+    """Tier 2: record_config_change appends a durable config_changed carrying path+content
+    (the recovery truth). RED if the seam didn't WAL the change — config would be invisible to
+    replay = a silent recovery gap."""
+    reg = _make_registry(tmp_path)
+    await reg.record_config_change("hooks.yaml", {"hooks": [{"on": "turn_start"}]})
+
+    [entry] = [e for e in reg.state_log.iter_from(0) if e.get("kind") == "config_changed"]
+    assert entry["path"] == "hooks.yaml"
+    assert entry["content"] == {"hooks": [{"on": "turn_start"}]}
+
+
+@pytest.mark.asyncio
+async def test_config_changed_does_not_corrupt_agent_snapshot(tmp_path):
+    """Tier 2: config_changed is config-set state, NOT AgentSnapshot STATE — apply_events
+    no-ops it (uniform with topology_*). RED if it leaked into snapshot replay."""
+    from reyn.core.events.agent_snapshot import AgentSnapshot
+
+    snap = AgentSnapshot.empty("a")
+    snap.apply_events([
+        {"seq": 1, "kind": "config_changed", "path": "mcp.yaml", "content": {"mcp": {}}},
+    ])
+    assert snap.inbox == [] and snap.pending_chains == {}, \
+        "config_changed must not mutate AgentSnapshot state"


### PR DESCRIPTION
**[e2e-coder]** — #2248 PR-A (foundational). Makes the recovery-core `.reyn/config` registries reconstructable by WAL replay (no git, per §5), mirroring the existing `topology_*` lifecycle model.

## Scope: mechanism + reconstruct + seam (falsify-verified)
This lands the **mechanism**; the per-registry **emission wiring** is PR-A2 (see below). Until emission lands, the reconstruct is inert (nothing emits `config_changed` yet) — clean staging, exactly as 1a-i (#2246) preceded 1a-ii (#2247).

- **`config_changed` WAL kind** (`state_log.py`): carries the registry's `.reyn`-relative `path` + its FULL post-mutation `content`. **P7-clean** — both opaque; the OS writes `content` to `<.reyn>/<path>` on reconstruct, no registry semantics. `apply_events` no-ops it (config-set state, not AgentSnapshot STATE).
- **`record_config_change(rel_path, content)`** — the single emission chokepoint (mirrors `_emit_topology`): a dedicated config op calls it AFTER persisting its `.yaml`, so **the yaml is a DERIVED projection and the WAL event is the recovery truth** (the §2248 load-bearing invariant lead flagged to scrutinize).
- **`_config_lifecycle` + `_reconcile_config_as_of_cut`** — per WAL-tracked path, the LATEST `config_changed` with seq ≤ cut wins (full content, no delta-fold); a path first written after the cut is removed. Only WAL-tracked paths are touched (operator-owned / pre-feature yaml left alone). Hooked into `_materialize_rewind` next to `_reconcile_topologies_as_of_cut`.

## Diligence (the completeness invariants I committed to on #2248)
- **#2 (config = WAL-derived projection):** `record_config_change` is the seam that makes the yaml a projection; reconstruct re-materialises from the WAL truth, never trusts the on-disk yaml. Falsify-verified RED-when-stripped.
- **Rewind-list (#2236):** `list_rewind_points` is built from checkpoint/generation boundary seqs → `config_changed` won't pollute or mis-bucket the list (reconstruct-tracked, not a selectable point; revisitable UX for tui-coder).
- **WAL-kind registration-completeness:** full rootdir suite run — the new kind trips no repo-wide invariant.

## PR-A2 (the heterogeneous emission wiring — next)
`state_log` is reachable from **none** of the 5 config mutation sites (OpContext / ToolContext / PermissionResolver all lack it). Wiring `record_config_change` into mcp_install/drop, cron, hooks, approvals, index-sources needs threading across 3 context types — a distinct reviewable unit. PR-A2 activates config recovery-core end-to-end.

## Test plan
- [x] `pytest tests/test_2248_config_wal_reconstruct.py` (4) — green
- [x] Both reconstruct tests verified **RED** when the cut-filter is stripped, then restored
- [x] ruff / tier-audit (`--strict`) / verify_module_docstrings — clean (fixed a `len()==N` count-pin → tuple-unpack)
- [x] rewind/recovery/topology/reconstruct sweep — 286 passed
- [x] Full rootdir suite — 7495 passed; 4 failures are pre-existing (gateway entry-point + `reyn.safe` import-relocation, import-order sensitive) — reproduce on clean tree, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)