### PR TITLE
feat(#2248 PR-A2): emit config_changed from config ops (mcp/cron/hooks/index — 4/5)

### DIFF
--- a/src/reyn/core/events/config_recovery.py
+++ b/src/reyn/core/events/config_recovery.py
@@ -1,0 +1,43 @@
+"""Config-recovery emit helper — the single producer-side seam for ``config_changed``.
+
+#2248 PR-A2. A recovery-core `.reyn/config` registry (mcp / cron / hooks / approvals /
+index-sources) is reconstructed by WAL replay (``AgentRegistry._reconcile_config_as_of_cut``).
+The producer side is this one helper: a dedicated config op calls it AFTER persisting its
+`.yaml`, passing the registry's `.reyn`-relative path + its FULL post-mutation content, so the
+yaml becomes a derived projection and the WAL event is the recovery truth. Centralised here so
+every emit site (and the registry's own ``record_config_change``) shares one format — the
+config-change vocabulary lives in exactly one place.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.core.events.state_log import StateLog
+
+
+def reyn_relative_path(path) -> str | None:
+    """The portion of a config path BELOW the project ``.reyn/`` dir — the key a
+    ``config_changed`` event uses (reconstruct writes ``content`` back to
+    ``<.reyn>/<rel>``). E.g. ``…/.reyn/mcp.yaml`` → ``mcp.yaml``;
+    ``…/.reyn/config/mcp.yaml`` → ``config/mcp.yaml`` (robust across the #2248 §6 reorg).
+    None when the path is not under a ``.reyn/`` dir (operator-owned / out of recovery-core
+    → not WAL-tracked)."""
+    parts = Path(path).parts
+    if ".reyn" not in parts:
+        return None
+    i = len(parts) - 1 - parts[::-1].index(".reyn")  # the LAST `.reyn` component
+    rel = parts[i + 1:]
+    return "/".join(rel) if rel else None
+
+
+async def record_config_change(
+    state_log: "StateLog | None", rel_path: str, content: dict,
+) -> None:
+    """Emit a durable ``config_changed`` for the registry at ``rel_path`` (`.reyn`-relative)
+    carrying its FULL post-mutation ``content``. No-op when ``state_log`` is None (the opt-in /
+    non-persistence contract — tests / non-chat). Call it AFTER the `.yaml` is persisted."""
+    if state_log is None:
+        return
+    await state_log.append("config_changed", path=rel_path, content=content)

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from reyn.config import MultimodalConfig, SandboxConfig, WebConfig
     from reyn.core.events.events import EventLog
+    from reyn.core.events.state_log import StateLog
     from reyn.data.workspace.media_store import MediaStore
     from reyn.data.workspace.workspace import Workspace
     from reyn.llm.model_resolver import ModelResolver
@@ -106,6 +107,13 @@ class OpContext:
     # run scope. None when the OpContext is created outside a run scope
     # (e.g. chat router, CLI commands).
     run_id: str | None = None
+
+    # #2248 PR-A2: the process-shared WAL, threaded so a recovery-core config op
+    # (mcp_install / mcp_drop / index_drop) can emit a ``config_changed`` event after
+    # persisting its `.yaml` — making the yaml a derived projection of the WAL truth.
+    # None outside a persistence-enabled chat/skill context (tests / non-chat) → the op
+    # skips the emit (the opt-in contract, same as the dispatcher's step-event gate).
+    state_log: "StateLog | None" = None
 
     # FP-0022 follow-up: declarative SSL config for web_fetch and MCP registry.
     # Defaults to WebConfig() (= no override, falls through to env-var chain).

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -73,6 +73,19 @@ async def handle(
     drop_result = await backend.drop(op.source)
     removed_from_manifest = await manifest.remove(op.source)
 
+    # #2248 PR-A2: WAL the FULL post-drop sources registry so it recovers via replay
+    # (the yaml is a derived projection). Keyed by the `.reyn`-relative path; skipped
+    # when outside the project `.reyn` (operator-owned) or there is no WAL.
+    from reyn.core.events.config_recovery import (  # noqa: PLC0415
+        record_config_change,
+        reyn_relative_path,
+    )
+    _rel = reyn_relative_path(manifest.path)
+    if _rel is not None:
+        await record_config_change(
+            getattr(ctx, "state_log", None), _rel, await manifest.snapshot(),
+        )
+
     # Emit P6 event (audit trail)
     ctx.events.emit(
         "index_dropped",

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -242,6 +242,17 @@ async def handle(
             del existing["mcp"]
     _write_yaml_config(config_path, existing)
 
+    # #2248 PR-A2: WAL the FULL post-state so the mcp registry recovers via replay (the
+    # yaml is a derived projection). Keyed by the `.reyn`-relative path; skipped when the
+    # target is outside the project `.reyn` (operator-owned) or there is no WAL.
+    from reyn.core.events.config_recovery import (  # noqa: PLC0415
+        record_config_change,
+        reyn_relative_path,
+    )
+    _rel = reyn_relative_path(config_path)
+    if _rel is not None:
+        await record_config_change(getattr(ctx, "state_log", None), _rel, existing)
+
     # ── 5. Clean up secrets when requested ─────────────────────────────
     cleared_keys: list[str] = []
     if op.clear_secrets and env_keys:

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -519,6 +519,17 @@ async def handle(
 
     _write_yaml_config(config_path, existing)
 
+    # #2248 PR-A2: WAL the FULL post-state so the mcp registry recovers via replay (the
+    # yaml is a derived projection of this event). Keyed by the `.reyn`-relative path;
+    # skipped when the target is outside the project `.reyn` (operator-owned) or no WAL.
+    from reyn.core.events.config_recovery import (  # noqa: PLC0415
+        record_config_change,
+        reyn_relative_path,
+    )
+    _rel = reyn_relative_path(config_path)
+    if _rel is not None:
+        await record_config_change(getattr(ctx, "state_log", None), _rel, existing)
+
     installed_path = str(config_path)
 
     # ── 6. Emit mcp_server_installed event (P6) ───────────────────────────────

--- a/src/reyn/data/index/source_manifest.py
+++ b/src/reyn/data/index/source_manifest.py
@@ -129,6 +129,19 @@ class SourceManifest:
         ``None`` before the first load; updated on each cache miss /
         reload. Tests probe this to verify the cache-freshness contract."""
         return self._loaded_mtime
+
+    @property
+    def path(self) -> Path:
+        """The ``sources.yaml`` file SSoT path this manifest persists to
+        (#2248 PR-A2: the config-recovery emit site needs the persisted path)."""
+        return self._path
+
+    async def snapshot(self) -> dict[str, Any]:
+        """The FULL on-disk registry content — the same ``{name: entry.to_dict()}``
+        shape ``_atomic_write`` persists to ``sources.yaml`` (#2248 PR-A2: the
+        config-recovery emit needs the full post-mutation content, not a delta)."""
+        entries = await self.get_all()
+        return {name: entry.to_dict() for name, entry in entries.items()}
     def _is_cache_stale(self) -> bool:
         """Return True if sources.yaml has changed since the cache was loaded.
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1715,10 +1715,12 @@ class AgentRegistry:
         config recovery (mirrors `_emit_topology`): a dedicated config op calls this AFTER
         persisting its `.yaml`, so the registry is reconstructable by WAL replay. The yaml
         on disk is thus a DERIVED projection — `content` here is the recovery truth.
-        No-op without a WAL (the opt-in / test contract)."""
-        if self._state_log is None:
-            return
-        await self._state_log.append("config_changed", path=rel_path, content=content)
+        No-op without a WAL (the opt-in / test contract). Delegates to the shared
+        producer-side seam so every emit site uses one format (#2248 PR-A2)."""
+        from reyn.core.events.config_recovery import (  # noqa: PLC0415
+            record_config_change as _emit,
+        )
+        await _emit(self._state_log, rel_path, content)
 
     def _config_lifecycle(self) -> "dict[str, list[tuple[int, dict]]]":
         """#2248 PR-A: one WAL scan → per config relative-path, its ordered

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -556,6 +556,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
         """EventLog (has .emit(type: str, **data)) for tool dispatch events."""
         ...
 
+    @property
+    def state_log(self) -> Any:
+        """The process-shared WAL (StateLog) or None — #2248 PR-A2: threaded into the
+        ToolContext so a recovery-core config tool emits ``config_changed``."""
+        ...
+
     def list_available_skills(self) -> list[dict]:
         """Each entry: {name, description, routing?, category?}"""
         ...
@@ -2976,6 +2982,7 @@ class RouterLoop:
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
             hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
+            state_log=getattr(self.host, "state_log", None),  # #2248 PR-A2 (config emit)
         )
         return [
             {
@@ -3354,6 +3361,7 @@ class RouterLoop:
                 # #1673: thread the config-aware resolver (see the sibling sites).
                 resolver=getattr(self.host, "resolver", None),
                 hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
+                state_log=getattr(self.host, "state_log", None),  # #2248 PR-A2 (config emit)
             )
             list_actions_def = get_default_registry().lookup("list_actions")
             if list_actions_def is None:
@@ -3607,6 +3615,7 @@ class RouterLoop:
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
             hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
+            state_log=getattr(self.host, "state_log", None),  # #2248 PR-A2 (config emit)
         )
         result = await invoke_tool(get_default_registry(), name, args, tool_ctx)
         return self._normalise_router_tool_result(name, result)

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -109,6 +109,7 @@ class RouterHostAdapter:
         resolver: Any,                          # ModelResolver
         memory: Any,                            # MemoryService
         journal: Any,                           # SnapshotJournal
+        state_log: Any = None,                  # StateLog | None — #2248 PR-A2 (config emit)
         agent_registry: Any,                    # AgentRegistry | None
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
@@ -322,6 +323,7 @@ class RouterHostAdapter:
         self._resolver = resolver
         self._memory = memory
         self._journal = journal
+        self._state_log = state_log  # #2248 PR-A2: WAL for config_changed emit
         self._registry = agent_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
@@ -534,6 +536,12 @@ class RouterHostAdapter:
     def events(self) -> Any:
         """EventLog for dispatch_tool events."""
         return self._events
+
+    @property
+    def state_log(self) -> Any:
+        """The process-shared WAL (StateLog) or None — #2248 PR-A2: threaded into the
+        ToolContext so a recovery-core config tool emits ``config_changed``."""
+        return self._state_log
 
     @property
     def permission_resolver(self) -> Any:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1612,6 +1612,7 @@ class Session:
             threat_scan=self._safety.threat_scan,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
+            state_log=self._state_log,  # #2248 PR-A2 → config_changed emit from config ops
             # #1953 dynamic-wire: thread the REAL session id + Task backend so
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
             session_id=self._session_id,

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -453,6 +453,12 @@ class PermissionResolver:
             return {}
 
     def _persist(self, key: str, approved: bool) -> None:
+        # #2248 A2-cont: config-recovery (`config_changed`) emit is deliberately NOT wired
+        # here. Approvals are USER-authored (granted in response to a permission prompt) —
+        # not agent-authored like mcp/cron/hooks/index — so they likely belong in the
+        # PERSIST category (survive rewind, never silently un-granted), NOT recovery-core.
+        # Provenance + the rewind-semantics decision are under review before any emit; this
+        # is the logged gap, not a silent cap. See #2248.
         self._saved[key] = approved
         self._session[key] = approved
         try:

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -180,6 +180,19 @@ def _write_dynamic_cron(path: Path, data: dict) -> None:
     )
 
 
+async def _emit_cron_config_change(ctx: ToolContext, path: Path, data: dict) -> None:
+    """#2248 PR-A2: WAL the FULL post-mutation cron registry so it recovers via
+    replay (the yaml is a derived projection). Keyed by the `.reyn`-relative path;
+    skipped when outside the project `.reyn` or there is no WAL."""
+    from reyn.core.events.config_recovery import (  # noqa: PLC0415
+        record_config_change,
+        reyn_relative_path,
+    )
+    _rel = reyn_relative_path(path)
+    if _rel is not None:
+        await record_config_change(getattr(ctx, "state_log", None), _rel, data)
+
+
 def _jobs_list(data: dict) -> list:
     """Extract the cron.jobs list from a parsed yaml dict, defensive."""
     cron = data.get("cron", {})
@@ -270,7 +283,9 @@ async def _handle_cron_register(
             out_jobs.append(j)
     if not replaced:
         out_jobs.append(new_entry)
-    _write_dynamic_cron(path, _set_jobs_list(data, out_jobs))
+    written = _set_jobs_list(data, out_jobs)
+    _write_dynamic_cron(path, written)
+    await _emit_cron_config_change(ctx, path, written)
 
     # Live update if a scheduler is registered.
     from reyn.runtime.cron import CronJob, get_active_scheduler
@@ -306,7 +321,9 @@ async def _handle_cron_unregister(
     ]
     removed = len(out_jobs) < len(jobs)
     if removed:
-        _write_dynamic_cron(path, _set_jobs_list(data, out_jobs))
+        written = _set_jobs_list(data, out_jobs)
+        _write_dynamic_cron(path, written)
+        await _emit_cron_config_change(ctx, path, written)
 
     from reyn.runtime.cron import get_active_scheduler
     sched = get_active_scheduler()
@@ -397,7 +414,9 @@ async def _set_enabled(
         else:
             out_jobs.append(j)
     if found:
-        _write_dynamic_cron(path, _set_jobs_list(data, out_jobs))
+        written = _set_jobs_list(data, out_jobs)
+        _write_dynamic_cron(path, written)
+        await _emit_cron_config_change(ctx, path, written)
 
     from reyn.runtime.cron import get_active_scheduler
     sched = get_active_scheduler()

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -96,6 +96,7 @@ async def _handle_drop_source(
             ),
             permission_resolver=ctx.permission_resolver,
             skill_name="drop_source",
+            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),
         )

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -170,6 +170,17 @@ async def _handle_hooks_add(args: Mapping[str, Any], ctx: ToolContext) -> ToolRe
     data["hooks"] = hooks
     _write_hooks(path, data)
 
+    # #2248 PR-A2: WAL the FULL post-mutation hooks registry so it recovers via
+    # replay (the yaml is a derived projection). Keyed by the `.reyn`-relative path;
+    # skipped when outside the project `.reyn` or there is no WAL.
+    from reyn.core.events.config_recovery import (  # noqa: PLC0415
+        record_config_change,
+        reyn_relative_path,
+    )
+    _rel = reyn_relative_path(path)
+    if _rel is not None:
+        await record_config_change(getattr(ctx, "state_log", None), _rel, data)
+
     # Schedule the reload — the HotReloader applies the S2b hooks seam at the turn
     # boundary (1 turn = 1 config snapshot; never mid-turn).
     # Per-session route (#2073 S3): reload THIS calling session's reloader (multi-agent

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -132,6 +132,7 @@ async def _handle_mcp_drop_server_op(
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
             skill_name="mcp_drop_server",
+            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),
         )

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -124,6 +124,7 @@ async def _handle_mcp_install_op(
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
             skill_name="mcp_install",
+            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
         )
 
     return await mcp_install_handle(op=op, ctx=legacy_ctx, caller="control_ir")

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -287,6 +287,12 @@ class ToolContext:
     # session). None in non-session/test contexts → the tool falls back to the
     # process-wide get_active_hot_reloader().
     hot_reloader: Any | None = None
+    # #2248 PR-A2: the process-shared WAL (StateLog), threaded from the calling
+    # session so a recovery-core config tool handler (cron / hooks) — and the
+    # OpContext it builds for an op handler (mcp_install / index_drop) — can emit a
+    # ``config_changed`` event after persisting its `.yaml`. None in non-session /
+    # test contexts → the handler skips the emit (the opt-in contract).
+    state_log: Any | None = None                     # StateLog | None
 
 
 # ToolHandler: async callable signature.

--- a/tests/test_2248_pr_a2_config_emission.py
+++ b/tests/test_2248_pr_a2_config_emission.py
@@ -1,0 +1,100 @@
+"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission (end-to-end, REAL producer).
+
+A real config op (``mcp_drop_server``) — handed a ``state_log`` via its OpContext (the
+production wiring: session → RouterHostAdapter → ToolContext → adapter → OpContext) — emits a
+``config_changed`` WAL event carrying the FULL post-mutation mcp registry content after it
+persists ``.reyn/mcp.yaml``. ``AgentRegistry._reconcile_config_as_of_cut`` then reverts the
+registry on a rewind. This proves config-recovery with a REAL producer (not a test-only
+``record_config_change`` call): drop a server → it's in the WAL → rewind → it's back.
+
+Real PermissionResolver + StateLog + AgentRegistry + on-disk yaml (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.config_recovery import record_config_change
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.runtime.registry import AgentRegistry
+from reyn.schemas.models import MCPDropServerIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+class _StubWorkspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+class _Events:
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+@pytest.mark.asyncio
+async def test_real_mcp_drop_emits_config_changed_and_rewind_restores(tmp_path):
+    """Tier 2: a REAL mcp_drop op (state_log threaded into OpContext) emits config_changed
+    with the full post-drop mcp content; a rewind to before the drop reconstructs the dropped
+    server from the WAL. RED if the op didn't emit (config invisible to replay) or reconstruct
+    trusted the on-disk post-drop yaml."""
+    from reyn.core.op_runtime.mcp_drop_server import handle as drop_handle
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    mcp_path = tmp_path / ".reyn" / "mcp.yaml"
+    mcp_path.parent.mkdir(parents=True, exist_ok=True)
+    two_servers = {"mcp": {"servers": {
+        "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+        "brave": {"command": "uvx", "args": ["brave-mcp"]},
+    }}}
+    mcp_path.write_text(yaml.dump(two_servers), encoding="utf-8")
+    # the prior install's config_changed (pre-drop state) — the seq we rewind to:
+    await record_config_change(state_log, "mcp.yaml", two_servers)
+    cut = state_log.current_seq
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    canonical = str(mcp_path)
+    resolver.session_approve_path(canonical, "test", "file.write")
+    ctx = OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=PermissionDecl(
+            file_write=[{"path": canonical, "scope": "just_path"}],
+        ),
+        permission_resolver=resolver,
+        skill_name="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=state_log,  # the PR-A2 threading under test
+    )
+    # scope=None → auto-detect walks ("dynamic" = .reyn/mcp.yaml) first → the canonical
+    # recovery-core location.
+    op = MCPDropServerIROp(
+        kind="mcp_drop_server", server="brave", scope=None, clear_secrets=False,
+    )
+    result = await drop_handle(op=op, ctx=ctx, caller="control_ir")
+    assert result["status"] == "ok"
+
+    # 1) the REAL op emitted config_changed carrying the FULL post-drop registry state.
+    [ev] = [e for e in state_log.iter_from(cut + 1) if e.get("kind") == "config_changed"]
+    assert ev["path"] == "mcp.yaml"
+    assert set(ev["content"]["mcp"]["servers"]) == {"filesystem"}
+    assert "brave" not in yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
+
+    # 2) rewind to before the drop → reconstruct restores brave from the WAL truth.
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    reg._reconcile_config_as_of_cut(cut)
+    restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
+    assert set(restored) == {"filesystem", "brave"}, "rewind reconstructs the dropped server"

--- a/tests/test_2248_pr_a2_emit_cron.py
+++ b/tests/test_2248_pr_a2_emit_cron.py
@@ -1,0 +1,141 @@
+"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the cron registry.
+
+The REAL cron tool handlers (``_handle_cron_register`` / ``_set_enabled`` /
+``_handle_cron_unregister``) — handed a ``state_log`` via their ToolContext (the
+production wiring: session → ToolContext) — emit a ``config_changed`` WAL event
+carrying the FULL post-mutation cron registry content after they persist
+``.reyn/cron.yaml``. The yaml is a derived projection; the WAL event is the
+recovery truth.
+
+Real StateLog + real handlers + on-disk yaml (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.tools.cron import (
+    _handle_cron_register,
+    _handle_cron_unregister,
+    _set_enabled,
+)
+from reyn.tools.types import ToolContext
+
+
+class _Events:
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+class _Workspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
+    return ToolContext(
+        events=_Events(),
+        permission_resolver=None,  # unit-test context → _gate is a no-op
+        workspace=_Workspace(base_dir=base_dir),
+        caller_kind="router",
+        state_log=state_log,
+    )
+
+
+def _config_changed(state_log: StateLog, after_seq: int) -> list[dict]:
+    return [
+        e
+        for e in state_log.iter_from(after_seq + 1)
+        if e.get("kind") == "config_changed"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cron_register_emits_config_changed_full_content(tmp_path):
+    """Tier 2: a REAL cron_register (state_log threaded into ToolContext) emits
+    config_changed with the FULL post-register cron content keyed by the
+    `.reyn`-relative path. RED if the handler didn't emit after persisting."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    ctx = _ctx(tmp_path, state_log)
+    before = state_log.current_seq
+
+    result = await _handle_cron_register(
+        {
+            "name": "morning_news",
+            "to": "news_agent",
+            "message": "今日のまとめ",
+            "schedule": "0 9 * * *",
+            "enabled": True,
+        },
+        ctx,
+    )
+    assert result["status"] == "ok"
+
+    [ev] = _config_changed(state_log, before)
+    assert ev["path"] == "cron.yaml"
+    jobs = ev["content"]["cron"]["jobs"]
+    [job] = [j for j in jobs if j.get("name") == "morning_news"]
+    assert job["to"] == "news_agent"
+    assert job["schedule"] == "0 9 * * *"
+    # the yaml is a derived projection of the same content
+    on_disk = yaml.safe_load(
+        (tmp_path / ".reyn" / "cron.yaml").read_text(encoding="utf-8")
+    )
+    assert ev["content"] == on_disk
+
+
+@pytest.mark.asyncio
+async def test_cron_disable_emits_full_post_state(tmp_path):
+    """Tier 2: a REAL cron disable emits config_changed carrying the FULL post-
+    mutation registry (the disabled job present with enabled=False), not a delta."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    ctx = _ctx(tmp_path, state_log)
+    await _handle_cron_register(
+        {
+            "name": "weekly",
+            "to": "agent",
+            "message": "report",
+            "schedule": "0 9 * * MON",
+            "enabled": True,
+        },
+        ctx,
+    )
+    before = state_log.current_seq
+
+    await _set_enabled({"name": "weekly"}, ctx, enabled=False)
+
+    [ev] = _config_changed(state_log, before)
+    assert ev["path"] == "cron.yaml"
+    [job] = [j for j in ev["content"]["cron"]["jobs"] if j["name"] == "weekly"]
+    assert job["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_cron_unregister_emits_full_post_state(tmp_path):
+    """Tier 2: a REAL cron unregister emits config_changed carrying the FULL post-
+    removal registry (the removed job absent from content)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    ctx = _ctx(tmp_path, state_log)
+    await _handle_cron_register(
+        {
+            "name": "gone",
+            "to": "agent",
+            "message": "x",
+            "schedule": "0 9 * * *",
+            "enabled": True,
+        },
+        ctx,
+    )
+    before = state_log.current_seq
+
+    await _handle_cron_unregister({"name": "gone"}, ctx)
+
+    [ev] = _config_changed(state_log, before)
+    assert ev["path"] == "cron.yaml"
+    names = [j.get("name") for j in ev["content"]["cron"]["jobs"]]
+    assert "gone" not in names

--- a/tests/test_2248_pr_a2_emit_hooks.py
+++ b/tests/test_2248_pr_a2_emit_hooks.py
@@ -1,0 +1,75 @@
+"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the hooks registry.
+
+The REAL ``_handle_hooks_add`` handler — handed a ``state_log`` via its ToolContext
+(the production wiring: session → ToolContext) — emits a ``config_changed`` WAL
+event carrying the FULL post-mutation hooks registry content after it persists
+``.reyn/hooks.yaml``. The yaml is a derived projection; the WAL event is the
+recovery truth.
+
+Real StateLog + real handler + on-disk yaml (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.tools.hooks import _handle_hooks_add
+from reyn.tools.types import ToolContext
+
+
+class _Events:
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+class _Workspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
+    return ToolContext(
+        events=_Events(),
+        permission_resolver=None,  # unit-test context → _gate is a no-op
+        workspace=_Workspace(base_dir=base_dir),
+        caller_kind="router",
+        state_log=state_log,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hooks_add_emits_config_changed_full_content(tmp_path):
+    """Tier 2: a REAL hooks_add (state_log threaded into ToolContext) emits
+    config_changed with the FULL post-add hooks content keyed by the
+    `.reyn`-relative path. RED if the handler didn't emit after persisting."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    ctx = _ctx(tmp_path, state_log)
+    before = state_log.current_seq
+
+    result = await _handle_hooks_add(
+        {"on": "turn_end", "message": "keep going", "wake": True, "name": "loop"},
+        ctx,
+    )
+    assert result["status"] == "ok"
+    assert result["added"] is True
+
+    [ev] = [
+        e
+        for e in state_log.iter_from(before + 1)
+        if e.get("kind") == "config_changed"
+    ]
+    assert ev["path"] == "hooks.yaml"
+    hooks = ev["content"]["hooks"]
+    [hook] = [h for h in hooks if h.get("name") == "loop"]
+    assert hook["on"] == "turn_end"
+    assert hook["template_push"]["message"] == "keep going"
+    # the yaml is a derived projection of the same content
+    on_disk = yaml.safe_load(
+        (tmp_path / ".reyn" / "hooks.yaml").read_text(encoding="utf-8")
+    )
+    assert ev["content"] == on_disk

--- a/tests/test_2248_pr_a2_emit_index_sources.py
+++ b/tests/test_2248_pr_a2_emit_index_sources.py
@@ -1,0 +1,81 @@
+"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the index-sources registry.
+
+The REAL ``index_drop`` op handler — handed a ``state_log`` via its OpContext (the
+production wiring: session → ToolContext → drop_source adapter → OpContext) — emits
+a ``config_changed`` WAL event carrying the FULL post-drop sources registry content
+after the SourceManifest persists ``.reyn/index/sources.yaml``. The yaml is a derived
+projection; the WAL event is the recovery truth.
+
+Real StateLog + real op handler + real SourceManifest + on-disk yaml (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.index_drop import handle as drop_handle
+from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+from reyn.schemas.models import IndexDropIROp
+
+
+class _Events:
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+class _Workspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+@pytest.mark.asyncio
+async def test_index_drop_emits_config_changed_full_sources(tmp_path):
+    """Tier 2: a REAL index_drop op (state_log threaded into OpContext) emits
+    config_changed carrying the FULL post-drop sources registry (the dropped source
+    absent, the surviving one present) keyed by the `.reyn`-relative path. RED if the
+    op didn't emit after the manifest persisted sources.yaml."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    # Seed the real manifest with two sources (persists .reyn/index/sources.yaml).
+    manifest = get_source_manifest(tmp_path)
+    await manifest.upsert(
+        SourceEntry(name="docs", description="user docs", path=".reyn/memory/*.md")
+    )
+    await manifest.upsert(
+        SourceEntry(name="code", description="python", path="src/**/*.py")
+    )
+    before = state_log.current_seq
+
+    ctx = OpContext(
+        workspace=_Workspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=None,
+        permission_resolver=None,  # no gate in this unit-test context
+        skill_name="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=state_log,
+    )
+    op = IndexDropIROp(kind="index_drop", source="code")
+    result = await drop_handle(op=op, ctx=ctx, caller="control_ir")
+    assert result["removed"] is True
+
+    [ev] = [
+        e
+        for e in state_log.iter_from(before + 1)
+        if e.get("kind") == "config_changed"
+    ]
+    assert ev["path"] == "index/sources.yaml"
+    assert set(ev["content"]) == {"docs"}
+    assert ev["content"]["docs"]["description"] == "user docs"
+    # the yaml is a derived projection of the same content
+    on_disk = yaml.safe_load(
+        (tmp_path / ".reyn" / "index" / "sources.yaml").read_text(encoding="utf-8")
+    )
+    assert ev["content"] == on_disk


### PR DESCRIPTION
**[e2e-coder]** — #2248 PR-A2. Activates the PR-A (#2249) config-recovery mechanism by wiring the **producer side**: the recovery-core config registries emit `config_changed` after persisting their `.yaml`, so config reconstructs by WAL replay on rewind. **4 of 5 registries** here; approvals is a principled A2-cont follow-up (below).

## Threading (the design-sensitive core)
The dispatcher's `state_log` is gated to `caller_kind=="skill_phase"`, but config ops run from the **chat router** — so `state_log` is threaded into the config-op context path:
- `state_log` field on **OpContext** + **ToolContext** (opt-in, default None).
- **RouterHostAdapter** gains a `state_log` property (from the session's `_state_log`, passed at construction); `router_loop` threads it into the 3 ToolContext builds.
- the mcp + index tool adapters pass `state_log` into the OpContext they build.
- shared seam `core/events/config_recovery.py`: `record_config_change` + `reyn_relative_path` (the `.reyn`-relative key, robust across the §6 reorg). The registry's `record_config_change` delegates to it (one format).

## Emit sites (FULL post-mutation content, no delta-fold)
- `mcp_install` / `mcp_drop_server` → `mcp.yaml`
- `cron` register/unregister/enable → `cron.yaml`
- `hooks` add → `hooks.yaml`
- `index_drop` (manifest gains `path` + `snapshot()`) → `index/sources.yaml`

## Approvals (5th) — principled A2-cont, NOT a silent gap
`PermissionResolver._persist` is **sync** (6+ sync callers) while `record_config_change` is async; a fire-and-forget `create_task` emit would leave **approval-in-yaml-but-not-WAL** on a crash — the exact recovery hole we're closing (rejected). More fundamentally, **approvals are USER-authored** (granted via a permission prompt), unlike the agent-authored mcp/cron/hooks/index — so they likely belong in the **PERSIST** category (survive rewind, like `memory/`), **not recovery-core**. **A2-cont verifies the provenance + rewind-semantics before any emit** (likely a §1 reclassification, no wiring). Logged in code (`permissions.py:_persist`) + on #2248.

## Test plan
- [x] `tests/test_2248_pr_a2_config_emission.py` — REAL mcp_drop op emits `config_changed` (full post-drop content) → rewind reconstructs the dropped server. **Verified RED-when-stripped** (remove the op emit → no event → reconstruct can't restore)
- [x] per-registry emit-durable tests: cron (3) / hooks / index-sources
- [x] ruff (full tree `src tests scripts`) / tier-audit `--strict` / verify_module_docstrings — all green
- [x] Full rootdir suite — **7501 passed**; 4 failures pre-existing (gateway entry-point + `reyn.safe` import-relocation, import-order sensitive) — reproduce on clean tree, not introduced here
- [x] Reviewed the Sonnet sub-agent's index/cron/hooks wiring (source_manifest accessors + emit at each persist site)

Stacked on #2249 (merged). Follow-ups: A2-cont (approvals provenance/reclassify) → PR-D (git deletion) → B → C → E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)