### PR TITLE
docs(#2248 A2-cont): approvals = persist, not recovery-core (reclassify)

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -453,12 +453,11 @@ class PermissionResolver:
             return {}
 
     def _persist(self, key: str, approved: bool) -> None:
-        # #2248 A2-cont: config-recovery (`config_changed`) emit is deliberately NOT wired
-        # here. Approvals are USER-authored (granted in response to a permission prompt) —
-        # not agent-authored like mcp/cron/hooks/index — so they likely belong in the
-        # PERSIST category (survive rewind, never silently un-granted), NOT recovery-core.
-        # Provenance + the rewind-semantics decision are under review before any emit; this
-        # is the logged gap, not a silent cap. See #2248.
+        # #2248: approvals.yaml is PERSIST, not recovery-core — so NO `config_changed` emit
+        # here (unlike mcp/cron/hooks/index). Approvals are a USER-authored security decision
+        # (granted via a permission prompt; revoked via the web/CLI surfaces) — never
+        # agent-authored — so a rewind must NOT revert them; they survive rewind like
+        # `memory/`. Owner-confirmed reclassification (config → persist).
         self._saved[key] = approved
         self._session[key] = approved
         try:


### PR DESCRIPTION
**[e2e-coder]** — #2248 A2-cont, the **reclassify-only** outcome (owner-confirmed; verify-not-build, as lead predicted).

## What
`approvals.yaml` is reclassified **recovery-core config → PERSIST** (survives rewind, alongside `memory/`). No `config_changed` emit — the sync/async wrinkle is dissolved by **exclusion**, not by a fragile fire-and-forget async emit.

## Why (provenance — primary evidence, on #2248)
ALL writers of `approvals.yaml` are user/operator-authored, never agent-authored:
- `PermissionResolver._persist` — user answers a permission prompt (6 sites, all `await bus.request(iv)` → grant).
- web router `DELETE /permissions` + CLI `permissions clear/remove` — operator revokes/clears.

So it fails the §1 criterion-(1) ("authored by the run, not the operator"). A rewind must **not** silently revert a user's "always allow X" security decision → it survives rewind, like `memory/`.

## Changes
- **Code**: finalizes the `permissions.py:_persist` comment from "under review" → the confirmed "persist, not recovery-core — user-authored security decision, survives rewind" wording. (Comment-only; no behavior change — there was never any emit wired for approvals.)
- **Contract**: the #2248 issue body (§1/§3/§4/§6) is updated to match (approvals moved to the persistent-knowledge row; removed from the §3 config-registry list, the §6 `config/` repoint, and the §4 write-gate).

## Result
Recovery-core config is now exactly the **4 agent-authored registries** (mcp/cron/hooks/index) — complete and clean. PR-A2's "4/5" was actually 4/4.

## Test plan
- [x] ruff — clean (comment-only)
- [x] No behavior change (approvals never emitted; this documents the deliberate exclusion). CI full suite runs as the gate.

## Follow-ups (tracked, not in this PR)
- `getattr→direct .state_log` fail-loud polish — needs a `state_log` property added to `phase_router_host` (the other `RouterLoopHost` impl) before the direct access is safe; separate small PR.
- Then per the §8 sequence: **PR-D** (git-layer deletion) → B → C → E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)