### PR TITLE
test(#1765): harden c_staging drain-wait poll to the snapshot-durable condition

### DIFF
--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -384,12 +384,15 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
     # stage it durably, then block waiting for a trigger (Decision A).
     drain_task = asyncio.create_task(session._drain_to_wake())
 
-    # Wait until the drain has DURABLY staged the C. The WAL append fsyncs OFF the event
-    # loop (#1765), so it completes on a worker thread — a fixed yield count (await sleep(0))
-    # would race that async fsync. Poll the durable condition instead (the same wait-for-
-    # condition discipline #1751 adopted when fsync moved off-loop).
+    # Wait until the drain has DURABLY staged the C. Both the WAL append AND the snapshot
+    # save fsync OFF the event loop (#1765 1a-i/1a-ii) on a worker thread, and the snapshot
+    # save lands strictly AFTER the WAL append — so polling the WAL event would break in the
+    # sub-step gap before the off-loop snapshot save completes, racing the n_snap assertion
+    # below. Poll the STRONGER condition the test actually asserts — the on-disk snapshot
+    # holding the entry — which implies the WAL is already durable too (the wait-for-condition
+    # discipline #1751 adopted when fsync moved off-loop).
     for _ in range(400):
-        if any(e.get("kind") == "next_turn_context_staged" for e in _wal_events(tmp_path)):
+        if AgentSnapshot.load(session.agent_name, session._snapshot_path).next_turn_context:
             break
         await asyncio.sleep(0.005)
 


### PR DESCRIPTION
**[e2e-coder]** — fixes the intermittent `test_c_staging_durable_during_drain_wait` failure on pytest 3.12 (`Snapshot must hold 1 next_turn_context entry DURING drain wait; got 0`) that lead flagged on #2251's CI.

## Root cause — a sub-step race widened by 1a-ii's off-loop snapshot save
The test polled for the WAL `next_turn_context_staged` event, then asserted the **on-disk snapshot** holds the entry. But `record_next_turn_context_staged` does `await wal_append` (step 1) → … → `await self.save()` (step 4), and **#1765 1a-ii (#2247) made `save()` off-loop** — so the WAL event becomes durable strictly *before* the snapshot save completes. The WAL-event poll could break in that sub-step gap, before the off-loop snapshot save landed → `n_snap == 0`.

## Not a durability regression
The guarantee is intact: `record_next_turn_context_staged` awaits **both** the WAL append and the snapshot save, and the drain awaits that method before blocking — so when the drain is blocking, both are durable. This was purely the **test polling the weaker condition** (the WAL event) than it asserts (the snapshot). Answering lead's (a)-vs-(b): it's (a) a test-race, *exposed/widened by* the (b) off-loop change — but the "durable during drain" guarantee itself holds.

## Fix
Poll the **on-disk snapshot** (the stronger condition the test actually asserts), which implies the WAL is already durable. Verified non-flaky over repeated runs (5/5 local).

## Test plan
- [x] `pytest test_c_staging_durable_during_drain_wait` ×5 — all pass
- [x] ruff clean
- [x] CI full suite is the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)