### PR TITLE
feat(#2248 PR-C): write-gate generalized to {config/, state/} recovery-core prefixes

### DIFF
--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -94,12 +94,18 @@ _context_initialised: bool = False
 # permissions.py gate alone did not cover this enforcement path.
 #
 # Mirrors ``reyn.security.permissions.permissions._CANONICAL_PROTECTED_WRITE_PATHS``
-# — keep the two lists in sync (drift-guarded by
+# AND ``_RECOVERY_CORE_WRITE_PREFIXES`` — keep BOTH in sync (drift-guarded by
 # ``test_canonical_protected_lists_stay_in_sync``). They live in two
 # modules because this one runs in the python-harness subprocess where
 # importing the parent's permissions module is not always available.
+# #2248 PR-C: the recovery-core prefixes (config/index/sources.yaml is now covered by
+# the config/ prefix); approvals.yaml stays an explicit top-level entry (persist).
+_RECOVERY_CORE_WRITE_PREFIXES = (
+    ".reyn/config/",
+    ".reyn/state/",
+)
+
 _CANONICAL_PROTECTED_WRITE_PATHS = (
-    ".reyn/config/index/sources.yaml",
     ".reyn/approvals.yaml",
 )
 
@@ -189,6 +195,20 @@ def _is_canonical_protected_write(path: str) -> bool:
     return False
 
 
+def _is_under_recovery_core_prefix(path: str) -> bool:
+    """#2248 PR-C: True if ``path`` is under a recovery-core write-gate prefix
+    (``.reyn/config/`` or ``.reyn/state/``) — a raw file.write there requires an explicit
+    declaration (the dedicated WAL-emitting ops provide it), never the broad ``.reyn/``
+    default zone. Mirrors ``permissions._is_under_recovery_core_prefix``."""
+    abs_path = _os.path.realpath(path)
+    cwd = _os.getcwd()
+    for prefix in _RECOVERY_CORE_WRITE_PREFIXES:
+        root = _os.path.realpath(_os.path.join(cwd, prefix))
+        if abs_path == root or abs_path.startswith(root + _os.sep):
+            return True
+    return False
+
+
 def _is_explicitly_listed(path: str, allowed: tuple[str, ...]) -> bool:
     """Return True iff ``path`` exactly matches one of ``allowed`` entries.
 
@@ -208,9 +228,10 @@ def _check_write(path: str) -> None:
             "reyn.api.safe.file: permission context not initialised "
             f"(write attempted: {path!r})."
         )
-    # #571 collapse arc Phase 2: canonical protected paths require an
-    # explicit listing (= not the broad ``.reyn/`` parent-dir match).
-    if _is_canonical_protected_write(path):
+    # #571 collapse arc Phase 2 / #2248 PR-C: canonical protected paths AND any path
+    # under a recovery-core prefix (config/, state/) require an explicit listing
+    # (= not the broad ``.reyn/`` parent-dir match) — forcing the dedicated-op path.
+    if _is_canonical_protected_write(path) or _is_under_recovery_core_prefix(path):
         if not _is_explicitly_listed(path, _write_paths):
             raise PermissionError(
                 f"reyn.api.safe.file: write to {path!r} requires an explicit "

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -81,15 +81,28 @@ _DEFAULT_WRITE_ZONES = (".reyn",)
 # python step write one via the broad ``.reyn/`` default zone bypasses the
 # corresponding gate. The narrow exception preserves the broad ``.reyn/``
 # write zone for everything else (= chunkers, cursors, scratch state).
+# #2248 PR-C: recovery-core write-gate prefixes. A file.write under these prefixes is
+# NOT silently allowed by the broad ``.reyn/`` default zone — it must go through a
+# dedicated op that emits a WAL event (mcp_install/drop, cron_register, index_drop write
+# their `config/*.yaml` via an EXPLICIT file.write declaration; WAL/snapshot/tasks under
+# `state/` use their own durable paths, never a raw file.write). A generic PREFIX rule
+# (P7-clean — "deny raw file.write under the recovery-core prefixes", not a filename
+# list): the directory boundary IS the write-gate boundary. ``config/index/sources.yaml``
+# (formerly an explicit entry) is now covered by the ``config/`` prefix.
+_RECOVERY_CORE_WRITE_PREFIXES = (
+    ".reyn/config/",
+    ".reyn/state/",
+)
+
 _CANONICAL_PROTECTED_WRITE_PATHS = (
-    ".reyn/config/index/sources.yaml",
     # #1199 security fix: the persisted approval store. It is written ONLY via
     # the gated approval-decision mechanism (``_persist`` — which also emits the
-    # state_change audit signal). Without this carve-out it sits in the broad
-    # ``.reyn/`` default write zone, so a safe-mode file.write could inject an
-    # approval directly: bypassing the user-approval gate + the audit, and (since
-    # approvals load once into ``self._saved`` at startup) silently activating a
-    # never-approved grant on the NEXT run = approval-audit bypass.
+    # state_change audit signal). It is TOP-LEVEL (persist, #2248 A2-cont — not under
+    # the config/ recovery-core prefix), so it needs this explicit carve-out: without
+    # it a safe-mode file.write could inject an approval directly, bypassing the
+    # user-approval gate + the audit, and (since approvals load once into
+    # ``self._saved`` at startup) silently activating a never-approved grant on the
+    # NEXT run = approval-audit bypass.
     ".reyn/approvals.yaml",
 )
 
@@ -122,6 +135,23 @@ def _is_canonical_protected_write(path_str: str, base: "Path | None" = None) -> 
     return False
 
 
+def _is_under_recovery_core_prefix(path_str: str, base: "Path | None" = None) -> bool:
+    """#2248 PR-C: True if ``path_str`` is under a recovery-core write-gate prefix
+    (``.reyn/config/`` or ``.reyn/state/``). Such a write must NOT be silently allowed by
+    the broad ``.reyn/`` default zone — it goes through a dedicated WAL-emitting op (which
+    declares the path explicitly) rather than a raw ``file.write``."""
+    base = base or Path.cwd()
+    p = Path(path_str).expanduser()
+    resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
+    for prefix in _RECOVERY_CORE_WRITE_PREFIXES:
+        try:
+            resolved.relative_to((base / prefix).resolve())
+            return True
+        except ValueError:
+            pass
+    return False
+
+
 def _in_default_write_zone(path_str: str, base: "Path | None" = None) -> bool:
     """Return True if path falls within a default-granted write zone (.reyn/).
 
@@ -134,7 +164,9 @@ def _in_default_write_zone(path_str: str, base: "Path | None" = None) -> bool:
     downstream use-gate makes the config carve-out redundant).
     """
     base = base or Path.cwd()
-    if _is_canonical_protected_write(path_str, base):
+    if _is_canonical_protected_write(path_str, base) or _is_under_recovery_core_prefix(
+        path_str, base,
+    ):
         return False
     p = Path(path_str).expanduser()
     resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()

--- a/tests/test_2248_prc_write_gate_prefix.py
+++ b/tests/test_2248_prc_write_gate_prefix.py
@@ -1,0 +1,92 @@
+"""Tier 2: OS invariant — #2248 PR-C recovery-core write-gate PREFIXES.
+
+The protect-at-use carve-out is generalized from a few explicit files to the
+``{config/, state/}`` prefixes: a raw ``file.write`` under ``.reyn/config/`` or
+``.reyn/state/`` is NOT silently allowed by the broad ``.reyn/`` default zone — it must go
+through a dedicated op that declares the path explicitly (mcp_install/drop, cron_register,
+index_drop). The no-legit-op-blocked matrix proven here: a dedicated-op write (explicit
+decl) PASSES; a raw file.write to a recovery-core prefix is DENIED; ``approvals.yaml``
+(top-level persist) stays protected; ``memory/`` + ``cache/`` + other ``.reyn/`` paths stay
+default-granted (the prefix-deny must not over-reach).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.security.permissions.permissions import (
+    _in_default_write_zone,
+    _is_under_recovery_core_prefix,
+)
+
+
+def test_recovery_core_prefix_paths_excluded_from_default_zone(tmp_path, monkeypatch):
+    """Tier 2: a write under .reyn/config/ or .reyn/state/ is NOT in the default write zone
+    (so a raw file.write needs an explicit decl). RED if the prefix-deny were dropped — the
+    path would auto-grant via the broad .reyn/ zone = the recovery-core bypass gap."""
+    monkeypatch.chdir(tmp_path)
+    for rel in (
+        ".reyn/config/mcp.yaml", ".reyn/config/index/sources.yaml",
+        ".reyn/state/wal.jsonl", ".reyn/state/snapshot.json",
+    ):
+        assert _in_default_write_zone(rel) is False, f"{rel} must be excluded from default zone"
+        assert _is_under_recovery_core_prefix(rel) is True
+
+
+def test_non_recovery_core_reyn_paths_still_default_granted(tmp_path, monkeypatch):
+    """Tier 2: memory/ (persist), cache/ (derived), and other .reyn/ paths stay
+    default-granted — the prefix-deny must NOT over-reach. RED if it swept them in."""
+    monkeypatch.chdir(tmp_path)
+    for rel in (
+        ".reyn/memory/note.md", ".reyn/cache/index/x.db",
+        ".reyn/scratch.txt", ".reyn/events/log.jsonl",
+    ):
+        assert _in_default_write_zone(rel) is True, f"{rel} must stay default-granted"
+        assert _is_under_recovery_core_prefix(rel) is False
+
+
+def test_safe_file_denies_raw_write_under_recovery_core_prefix(tmp_path, monkeypatch):
+    """Tier 2: safe.file._check_write DENIES a raw write to .reyn/config/ or .reyn/state/
+    covered only by the broad .reyn/ parent-dir (no explicit listing) — forcing the
+    dedicated-op path. RED if the prefix-deny were removed (the .reyn/ zone would allow it)."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.api.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+    with pytest.raises(PermissionError):
+        safe_file._check_write(str(tmp_path / ".reyn" / "config" / "mcp.yaml"))
+    with pytest.raises(PermissionError):
+        safe_file._check_write(str(tmp_path / ".reyn" / "state" / "wal.jsonl"))
+
+
+def test_safe_file_accepts_config_write_with_explicit_decl(tmp_path, monkeypatch):
+    """Tier 2: the dedicated-op path — .reyn/config/mcp.yaml WITH an explicit file.write
+    decl PASSES (mcp_install/drop session-approve the exact path). RED if the prefix-deny
+    rejected even an explicitly-declared write = the no-legit-op-blocked invariant broken."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.api.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[
+            str(tmp_path / ".reyn"),
+            str(tmp_path / ".reyn" / "config" / "mcp.yaml"),  # the dedicated-op explicit decl
+        ],
+    )
+    safe_file._check_write(str(tmp_path / ".reyn" / "config" / "mcp.yaml"))  # must not raise
+
+
+def test_safe_file_allows_non_recovery_core_reyn_write(tmp_path, monkeypatch):
+    """Tier 2: a write to .reyn/memory/ or .reyn/cache/ PASSES via the broad .reyn/ zone —
+    not swept into the prefix-deny. RED if the prefix over-reached to all of .reyn/."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.api.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn")],
+    )
+    safe_file._check_write(str(tmp_path / ".reyn" / "memory" / "note.md"))  # must not raise
+    safe_file._check_write(str(tmp_path / ".reyn" / "cache" / "x.db"))  # must not raise

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -206,24 +206,21 @@ def _run(coro):
 
 
 @pytest.mark.asyncio
-async def test_mcp_yaml_write_is_default_granted_protect_at_use(tmp_path):
-    """Tier 2: #571 protect-at-use / #1316 — writing the mcp install target
-    ``.reyn/mcp.yaml`` needs NO explicit file.write declaration: it sits in the
-    default project write zone (removed from the protected carve-out because
-    writing it is inert without ``require_mcp`` at call time; the install-side
-    grant is ``permissions.mcp``, the use-side gate is ``require_mcp``). The
-    carved-out ``.reyn/approvals.yaml`` still requires an explicit grant.
-
-    (Pre-#1316, an mcp test with project_root ≠ cwd saw the mcp.yaml write DENIED
-    via the cwd-zone divergence — that latent bug is fixed; production
-    cwd=project_root always default-granted it, so this is production-faithful,
-    not a loosening.)"""
+async def test_mcp_yaml_write_requires_explicit_decl_recovery_core(tmp_path):
+    """Tier 2: #2248 PR-C SUPERSEDES #571 protect-at-use for the mcp config — writing the
+    install target ``.reyn/config/mcp.yaml`` now REQUIRES an explicit file.write declaration:
+    it is under the recovery-core ``config/`` prefix, so a decl-less write is denied (a raw
+    write would change config WITHOUT the ``config_changed`` WAL event = a recovery gap). The
+    dedicated mcp_install op supplies that explicit decl + writes via its own write_text, so
+    the legit path is unaffected (see test_permission_gate_passes_with_explicit_decl).
+    ``.reyn/approvals.yaml`` (top-level persist) likewise requires an explicit grant."""
     resolver = _make_resolver(tmp_path)  # project_root = tmp_path
-    # mcp.yaml under project_root/.reyn = default write zone → granted (no decl)
-    await resolver.require_file_write(
-        PermissionDecl(), str(tmp_path / ".reyn" / "config" / "mcp.yaml"), "mcp_install_test"
-    )
-    # contrast: the approval store IS carved out → still needs an explicit grant
+    # mcp.yaml under config/ = recovery-core prefix → a decl-less write is DENIED.
+    with pytest.raises(PermissionError):
+        await resolver.require_file_write(
+            PermissionDecl(), str(tmp_path / ".reyn" / "config" / "mcp.yaml"), "mcp_install_test"
+        )
+    # the approval store IS carved out → also needs an explicit grant
     with pytest.raises(PermissionError):
         await resolver.require_file_write(
             PermissionDecl(), str(tmp_path / ".reyn" / "approvals.yaml"), "t"

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -53,15 +53,15 @@ def test_other_reyn_paths_still_in_default_zone(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     for rel in (
         ".reyn/cache/events_cursor",
-        ".reyn/index/chunks.jsonl",
+        ".reyn/cache/index/chunks.jsonl",
         # #1199: .reyn/approvals.yaml MOVED to the protected set (was here) —
         # see test_require_file_write_rejects_approvals_yaml.
         ".reyn/events.jsonl",
         ".reyn/scratch/anything.txt",
-        # realignment: mcp.yaml + cron.yaml REMOVED from the carve-out
-        # (protect-at-use) — they are now ordinary default-zone writes.
-        ".reyn/config/mcp.yaml",
-        ".reyn/config/cron.yaml",
+        # #2248 PR-C: memory/ (persist) is NOT under a recovery-core prefix → still
+        # default-granted. (config/ + state/ are now prefix-protected — see
+        # test_2248_prc_write_gate_prefix; mcp.yaml/cron.yaml moved there in PR-B.)
+        ".reyn/memory/note.md",
     ):
         assert _in_default_write_zone(rel) is True, (
             f"{rel!r} should remain in the default write zone (non-canonical)"
@@ -242,24 +242,33 @@ def test_canonical_protected_lists_stay_in_sync():
     permissions module, so the constant is duplicated. This drift-guard pins
     them equal, so any future add/remove of a protected path must touch BOTH
     copies. Closes the recurrence class behind the #1199 gap, where
-    approvals.yaml was added to the parent list only.
+    approvals.yaml was added to the parent list only. #2248 PR-C: the same
+    drift-guard now also pins the recovery-core PREFIX lists in sync.
     """
     from reyn.api.safe.file import _CANONICAL_PROTECTED_WRITE_PATHS as safe_paths
+    from reyn.api.safe.file import _RECOVERY_CORE_WRITE_PREFIXES as safe_prefixes
+    from reyn.security.permissions.permissions import (
+        _RECOVERY_CORE_WRITE_PREFIXES as perm_prefixes,
+    )
 
     assert _CANONICAL_PROTECTED_WRITE_PATHS == safe_paths
+    assert perm_prefixes == safe_prefixes
 
 
 @pytest.mark.asyncio
-async def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch):
-    """Tier 2: realignment — .reyn/mcp.yaml and .reyn/cron.yaml are removed from the
-    carve-out (protect-at-use), so a broad-zone write to them is ALLOWED on both
-    enforcement paths. Safety holds downstream: using a server passes require_mcp
-    (op_runtime/mcp.py) and cron jobs fire only under a user-launched, op-gated
-    scheduler — so writing the config alone grants nothing usable.
+async def test_mcp_cron_config_reprotected_by_recovery_core_prefix(tmp_path, monkeypatch):
+    """Tier 2: #2248 PR-C SUPERSEDES the #571 protect-at-use carve-out for config files.
+    Post-PR-A2 ``.reyn/config/`` is RECOVERY-CORE: a raw file.write to config/mcp.yaml would
+    change config WITHOUT emitting the ``config_changed`` WAL event (= a recovery gap — the
+    change wouldn't be reconstructed/reverted on rewind). So §4 re-protects the whole
+    ``config/`` prefix: a raw broad-zone write is now DENIED on both enforcement paths,
+    forcing the dedicated WAL-emitting op (mcp_install/drop, cron_register — which declare
+    the path explicitly). The #571 "use-gate makes the carve-out redundant" judgment is
+    obsolete now that config is recovery-core.
 
-    Falsification contrast: .reyn/approvals.yaml (no downstream use-gate) is still
-    DENIED via the same broad zone — the removal is specific to mcp/cron, not a
-    blanket relaxation.
+    No legit op blocked: the dedicated ops write via their own write_text + an EXPLICIT
+    file.write decl, so they pass (proven in test_2248_prc_write_gate_prefix). approvals.yaml
+    (top-level persist) stays protected via its explicit carve-out.
     """
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
@@ -271,14 +280,15 @@ async def test_mcp_cron_now_allowed_after_carveout_removal(tmp_path, monkeypatch
     )
 
     for rel in (".reyn/config/mcp.yaml", ".reyn/config/cron.yaml"):
-        # permissions.py path: no explicit decl needed — now in the default zone.
-        assert _in_default_write_zone(rel) is True
-        assert _is_canonical_protected_write(rel) is False
-        await resolver.require_file_write(PermissionDecl(), rel, "skill_x")
-        # safe.file enforcement path: broad-zone prefix match is enough now.
-        safe_file._check_write(str(tmp_path / rel))
+        # permissions.py path: no longer in the default zone → a decl-less write is denied.
+        assert _in_default_write_zone(rel) is False
+        with pytest.raises(PermissionError, match="was not approved"):
+            await resolver.require_file_write(PermissionDecl(), rel, "skill_x")
+        # safe.file enforcement path: broad-zone prefix match is NOT enough now.
+        with pytest.raises(PermissionError):
+            safe_file._check_write(str(tmp_path / rel))
 
-    # contrast: approvals.yaml remains protected on both paths.
+    # contrast: approvals.yaml (top-level persist) remains protected on both paths.
     with pytest.raises(PermissionError, match="was not approved"):
         await resolver.require_file_write(PermissionDecl(), ".reyn/approvals.yaml", "skill_x")
     with pytest.raises(PermissionError, match="canonical protected path"):


### PR DESCRIPTION
**[e2e-coder]** — #2248 §4 write-gate. Generalizes the protected-write check from a few explicit files to the `.reyn/config/` and `.reyn/state/` **prefixes** (P7-clean generic rule — the directory boundary IS the write-gate boundary). A raw `file.write` under a recovery-core prefix is denied, forcing the dedicated WAL-emitting op.

## Both gates updated + kept in sync
- `security/permissions/permissions.py`: `_is_under_recovery_core_prefix` → `_in_default_write_zone` excludes the prefixes.
- `api/safe/file.py`: mirror → `_check_write` requires explicit listing.
- `approvals.yaml` stays an explicit top-level carve-out (persist, not under a prefix).
- Drift-guard test extended to pin **both** the canonical list AND the prefix list in sync.

## #571 carve-out reversal (the one judgment call — flagged for your explicit sign-off)
PR-C **supersedes** the #571 protect-at-use carve-out for mcp/cron config. Post-PR-A2 `config/` is **recovery-core**: a raw `file.write` to `config/mcp.yaml` would change config **without** the `config_changed` WAL event = a recovery gap (not reconstructed on rewind). #571's "use-gate makes write-protection redundant" reasoned about a *different* (permission/use) concern and is obsolete for the recovery-event requirement; the re-protection strictly **adds** to the downstream use-gate.

## No-legit-op-blocked completeness audit (primary evidence, per your gate)
Enumerated **all** writers of the recovery-core config files:
- mcp/cron/hooks/sources are written **only** by the dedicated ops: `_write_yaml_config` (mcp_install / mcp_drop_server / mcp_verbs), `_write_dynamic_cron` (cron handlers), `_write_hooks` (hooks handler), `source_manifest._atomic_write` (index_drop). **Zero stdlib-skill / flow / raw-`file.write` writers** (grep of `src/reyn/stdlib` + project skills = empty).
- The dedicated ops write via their **own `write_text`** (bypass the `file.write` gate) + an **explicit decl** (`require_file_write` passes) → re-protecting breaks nothing.
- `registry.py:1590` = the OS-internal `_reconcile_config_as_of_cut` reconstruct; `registry.py:2354` = a session `state/config.yaml` (OS spawn); `state/` WAL/snapshot via `state_log`/registry — **all OS-internal durable paths, never a raw `file.write`** → not false-denied.

⇒ The reversal is safe: only dedicated ops write the config files, and they pass.

## Test plan
- [x] `tests/test_2248_prc_write_gate_prefix.py` (5) — the no-legit-op-blocked matrix: dedicated-op-write-config/-OK / raw-file.write-to-{config,state}/-DENIED / approvals-protected / memory+cache+other-`.reyn/`-allowed
- [x] **RED-when-stripped verified** (strip the prefix-deny in both gates → the 3 deny tests fail)
- [x] 3 superseded #571 tests reframed (collapse_phase2 ×2 + mcp_install_op ×1) to the recovery-core re-protection
- [x] ruff / tier-audit / drift-guard — clean
- [x] Full suite — **7472 passed**, 4 pre-existing (gateway/`reyn.safe`) only, zero new

Sequence: D → B → **C (this)** → **E (layout doc)** closes §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)