### PR TITLE
docs(#2248 PR-E): canonical .reyn/ directory-layout reference (closes §8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,9 @@ and run the checklist below before continuing:
 - **Why constrain the LLM (P4)**: `docs/concepts/architecture/llm-as-decision-engine.md`
 - **Workspace** (P5): `docs/concepts/runtime/workspace.md`
 - **Events / replay** (P6): `docs/concepts/runtime/events.md`
+- **`.reyn/` directory layout** (what's recovery-core vs persist/audit/cache/outside, the
+  recovery-core write-gate, where new subsystem data goes):
+  `docs/reference/runtime/reyn-dir-layout.md`
 - **Permission model**: `docs/concepts/runtime/permission-model.md`
 - **Input handling, ask_user, Phase Preprocessor (run_op / iterate / validate
   / lint_plan / python)**: read the corresponding stdlib skill (`skill_router`,

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -283,7 +283,9 @@ mindmap
 #### Crash Recovery
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
-| WAL state log | `step_started` / `step_completed` / `step_failed` written to `.reyn/state/wal.jsonl` (`StateLog`); fsync'd per append (synchronous durability for recovery). Truncatable after snapshot. **Not** the audit trail — see Event System (P6). | [Skill Resume](concepts/skills/skill-resume.md) |
+| `.reyn/` layout + recovery-core classification | Which `.reyn/` subtrees are recovery-core (`state/` + `config/`) vs persist / audit / cache / outside; the recovery-core write-gate (mutate config via dedicated ops, never raw `file.write`) | [.reyn/ directory layout](reference/runtime/reyn-dir-layout.md) |
+| Config recovery (`config_changed`) | Config registries (`.reyn/config/`: mcp/cron/hooks/index) reconstruct by replaying `config_changed` WAL events emitted by their dedicated ops; the `.yaml` is a derived projection | [.reyn/ directory layout](reference/runtime/reyn-dir-layout.md) |
+| WAL state log | `step_started` / `step_completed` / `step_failed` written to `.reyn/state/wal.jsonl` (`StateLog`); fsync'd per append (off the event loop via the shared DurabilityWorker). Truncatable after snapshot. **Not** the audit trail — see Event System (P6). | [Skill Resume](concepts/skills/skill-resume.md) |
 | Forward-replay resume | `SkillResumeAnalyzer` reconstructs run state from state log | [Skill Resume](concepts/skills/skill-resume.md) |
 | `CommittedStep` memo | Replay recorded op results on resume without re-invoking | [Skill Resume](concepts/skills/skill-resume.md) |
 | World-op bypass | Transient ops (web_search, web_fetch) re-execute fresh on resume | [Skill Resume](concepts/skills/skill-resume.md) |

--- a/docs/guide/for-skill-authors/phase-mechanics/persist-state.md
+++ b/docs/guide/for-skill-authors/phase-mechanics/persist-state.md
@@ -12,15 +12,11 @@ applies_to: [.reyn/, reyn.yaml]
 ## What lives under `.reyn/`
 
 `.reyn/` is an **opaque runtime-state directory** — treat it as tool-managed, not human-edited.
-
-| Path | Purpose | Default git status |
-|------|---------|--------------------|
-| `.reyn/approvals.yaml` | Saved permission approvals | gitignore |
-| `.reyn/events/` | Per-run event JSONL logs | gitignore |
-| `.reyn/agents/` | Per-agent profiles, chat history, state | gitignore |
-| `.reyn/eval-results/` | Eval results per skill | gitignore |
-| `.reyn/memory/` | Project-scoped memory | depends on the team |
-| `.reyn/state/` | WAL + budget ledger (crash recovery) | gitignore |
+The full per-subtree inventory + classification (recovery-core `state/`+`config/`, persist
+`memory/`+`approvals.yaml`, audit `events/`, derived `cache/`, operator-owned outside) is the
+canonical **[The `.reyn/` directory layout](../../../reference/runtime/reyn-dir-layout.md)** —
+including the **recovery-core write-gate** (mutate config via the dedicated ops, never a raw
+`file.write` to `.reyn/config/` or `.reyn/state/`).
 
 `reyn.yaml` (the project config) is checked in. Personal overrides go in
 `reyn.local.yaml` (gitignored, project root) — not in `.reyn/config.yaml`.

--- a/docs/reference/config/state-dir.md
+++ b/docs/reference/config/state-dir.md
@@ -11,37 +11,11 @@ Per-project state. Location: `<project_root>/.reyn/` — fixed. (There is no `st
 
 ## Layout
 
-```
-.reyn/
-├── approvals.yaml                          # persistent permission approvals
-├── events/                                 # all event JSONL logs
-│   ├── direct/                             # skill runs from `reyn run`
-│   │   └── skill_runs/<YYYY-MM>/
-│   │       └── <ts>_<skill>.jsonl
-│   └── agents/<name>/                      # skill runs + chat events from an agent
-│       ├── skill_runs/<YYYY-MM>/
-│       │   └── <ts>_<skill>.jsonl
-│       └── chat/<YYYY-MM>/                 # chat session events (rotated by size/age)
-│           └── <ts>.jsonl
-├── agents/<name>/                          # per-agent workspace (one dir per agent)
-│   ├── profile.yaml                        # agent name, role, allowed_skills
-│   ├── history.jsonl                       # append-only conversation log
-│   ├── memory/                             # agent-scoped memory
-│   │   ├── MEMORY.md
-│   │   └── <name>.md
-│   └── state/                              # WAL skill-run snapshots
-│       └── skills/<run_id>.snapshot.json
-├── skill-versions/<name>/                  # skill version snapshots
-│   └── v<N>.md
-├── eval-results/<skill>/                   # `reyn eval run` result files
-│   └── <timestamp>.jsonl
-├── state/                                  # process-global persistent state
-│   ├── budget_ledger.jsonl                 # durable budget ledger (daily/monthly/per-agent + spawn caps)
-│   └── budget_state.json                   # throttled best-effort cache over the ledger
-└── memory/                                 # project-scope memory
-    ├── MEMORY.md
-    └── <name>.md
-```
+The canonical `.reyn/` directory layout — every subtree, the recovery-core /
+persist / audit / cache / outside classification, and the recovery-core write-gate — is
+documented in **[The `.reyn/` directory layout](../runtime/reyn-dir-layout.md)**. See there
+for the full tree and "where a new subsystem puts its data". This page covers `--state-dir`
+routing specifically.
 
 **Note:** `.reyn/config.yaml` has been removed.
 Personal config overrides now live in `reyn.local.yaml` (gitignored, project root).

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -28,7 +28,7 @@ Everything else is excluded, by one of four reasons:
 | **cache** (derived) | rebuilt after restore | `cache/` (`index/`, `action_index/`, `registry-cache/`, `*_cursor`) |
 | **outside** (operator/user-owned) | not Reyn-managed for time-travel | `reyn.yaml`, `secrets.env`, `oauth_tokens.json`, `capability_profiles/` |
 
-## Canonical layout (post-#2248)
+## Canonical layout
 
 ```
 .reyn/
@@ -61,10 +61,11 @@ Everything else is excluded, by one of four reasons:
 **operator/user-owned** and live under the project root / `.reyn/` but are **outside**
 Reyn's time-travel — they are never captured or reverted.
 
-### Move map (#2248 — clean break, no migration)
+### Move map (clean break, no migration)
 
 The reorg has **no backward-compat shim**: old top-level paths simply stop being
-read/written. Anyone with a pre-#2248 `.reyn/` should know things moved:
+read/written. Anyone with an older `.reyn/` (config files directly under `.reyn/`, caches
+mixed in at the top level) should know things moved:
 
 | Was | Now |
 |---|---|

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -1,0 +1,141 @@
+# The `.reyn/` directory layout
+
+This is the canonical reference for what lives under a project's `.reyn/` directory:
+the five-way classification of every subtree, which subtrees are **recovery-core**
+(captured + restored by time-travel), the **write-gate** rule a skill author hits, and
+where a new subsystem should put its data.
+
+`.reyn/` holds Reyn's own plumbing under the project root. The organizing principle is
+**ownership + recovery role**: Reyn time-travels the state it *authors* and that *affects
+its in-memory runtime* — not the user's project files, and not operator-owned config.
+
+> **Rewind mechanics** (how recovery-core is reconstructed — WAL replay + snapshot
+> generations, seq addressing, rewind-record append, atomicity) live in
+> [Time travel](../../concepts/runtime/time-travel.md). This doc owns *what is in `.reyn/`*;
+> that doc owns *how rewind works*.
+
+## Classification
+
+A `.reyn/` subtree is **recovery-core** iff it (1) is authored by the run (agent/runtime,
+not the operator) **and** (2) affects in-memory runtime state that recovery reconstructs.
+Everything else is excluded, by one of four reasons:
+
+| Category | Handling on rewind / recovery | Subtrees |
+|---|---|---|
+| **recovery-core** | captured + restored (reconstructed) | `state/`, `config/` |
+| **persist** (knowledge / decisions) | survives rewind — never reverted | `memory/`, `approvals.yaml` |
+| **audit** (write-only record) | kept as a record, never restored | `events/`, `traces/`, `logs/`, `audit-trail/`, `tool-results/`, `media/` |
+| **cache** (derived) | rebuilt after restore | `cache/` (`index/`, `action_index/`, `registry-cache/`, `*_cursor`) |
+| **outside** (operator/user-owned) | not Reyn-managed for time-travel | `reyn.yaml`, `secrets.env`, `oauth_tokens.json`, `capability_profiles/` |
+
+## Canonical layout (post-#2248)
+
+```
+.reyn/
+├── state/                  RECOVERY-CORE — run-authored, reconstructs in-memory state
+│   ├── wal.jsonl           the WAL (append-only, seq'd) — the recovery TRUTH
+│   ├── tasks.db            the task backend (sqlite)
+│   └── budget_ledger.jsonl the cost ledger
+├── agents/<name>/state/    RECOVERY-CORE (per-agent) — reconstructed alongside the WAL
+│   ├── snapshot.json       the agent's runtime snapshot (a derived projection of the WAL)
+│   ├── generations/        snapshot generations (gen-<seq>.json) — the PITR base
+│   └── sessions/<sid>/     per-spawned-session snapshot + generations
+├── config/                 RECOVERY-CORE — agent-managed registries (reconstructed by replay)
+│   ├── mcp.yaml            MCP servers   (mcp_install / mcp_drop_server)
+│   ├── cron.yaml           cron jobs     (cron_register / …)
+│   ├── hooks.yaml          push hooks    (hooks_add)
+│   ├── integrations.yaml   integrations
+│   └── index/sources.yaml  index source manifest (index ops)
+├── memory/                 PERSIST — agent knowledge; survives rewind, never reverted
+├── approvals.yaml          PERSIST — user-authored permission grants; survive rewind
+├── events/ traces/ logs/   AUDIT — append-only forensic record; never restored
+│   audit-trail/ tool-results/ media/
+├── cache/                  DERIVED — rebuilt after restore
+│   ├── index/              rag index data (sqlite)
+│   ├── action_index/       action-index db
+│   └── registry-cache/     mcp registry cache
+└── topologies/             RECOVERY-CORE — agent topologies (reconstructed from topology_* WAL)
+```
+
+`reyn.yaml`, `secrets.env`, `oauth_tokens.json`, and `capability_profiles/` are
+**operator/user-owned** and live under the project root / `.reyn/` but are **outside**
+Reyn's time-travel — they are never captured or reverted.
+
+### Move map (#2248 — clean break, no migration)
+
+The reorg has **no backward-compat shim**: old top-level paths simply stop being
+read/written. Anyone with a pre-#2248 `.reyn/` should know things moved:
+
+| Was | Now |
+|---|---|
+| `.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/hooks.yaml`, `.reyn/integrations.yaml` | `.reyn/config/<x>.yaml` |
+| `.reyn/index/sources.yaml` | `.reyn/config/index/sources.yaml` |
+| `.reyn/index/` (data), `.reyn/action_index/`, `.reyn/registry-cache/` | `.reyn/cache/…` |
+| `.reyn/approvals.yaml` | **unchanged** (top-level — it is *persist*, not recovery-core config) |
+
+## <a id="recovery-core"></a>Recovery-core: what the WAL + snapshot generators write
+
+Recovery-core has two tiers — **authoritative** and **derived** — both reconstructed by the
+same rewind path (WAL replay + snapshot generations — see
+[Time travel](../../concepts/runtime/time-travel.md)):
+
+- **Authoritative** (the recovery TRUTH — write-gated):
+  - `.reyn/state/wal.jsonl` — the append-only, seq'd WAL: the complete event history
+    everything else is replayed from. Also `.reyn/state/tasks.db`,
+    `.reyn/state/budget_ledger.jsonl`.
+  - `.reyn/config/<x>.yaml` — the agent-edited registries. Each mutation goes through a
+    dedicated op that emits a `config_changed` WAL event; the `.yaml` is a derived
+    projection of that event, re-materialised on rewind.
+- **Derived** (reconstructable from the authoritative state — NOT write-gated):
+  - `.reyn/agents/<name>/state/`: `snapshot.json`, `generations/gen-<seq>.json`,
+    `sessions/<sid>/…`. Snapshots sit under a `state/` segment but are **derived** — a
+    snapshot is re-materialised from WAL replay (fall back to an earlier generation, or
+    replay from genesis). A corrupted snapshot is therefore *recoverable*, not data loss —
+    the same reconstructability logic as `cache/`. (This is why the write-gate, below,
+    covers only the authoritative tier.)
+
+## The recovery-core write-gate (the rule you hit as a skill author)
+
+**A raw `file.write` to `.reyn/config/` or `.reyn/state/` is DENIED.** The
+**authoritative** recovery-core (the WAL at `.reyn/state/` + the `.reyn/config/` registries —
+see [above](#recovery-core)) must be mutated through a **dedicated op that emits a WAL
+event** — never a generic `file.write` — so the change is captured in the recovery replay
+stream (otherwise a rewind could not reconstruct or revert it). The directory boundary *is*
+the write-gate boundary. (The *derived* per-agent snapshots under `.reyn/agents/<name>/state/`
+are reconstructable from the WAL, so they are not write-gated — a corrupted snapshot is
+recoverable, not data loss.)
+
+To change config, call the dedicated op (which writes the `.yaml` **and** emits
+`config_changed`):
+
+- MCP servers → `mcp_install` / `mcp_drop_server`
+- cron → `cron_register` / `cron_unregister` / `cron_enable`
+- hooks → `hooks_add`
+- index sources → the index ops
+
+`approvals.yaml` (top-level *persist*) is likewise write-gated — it is written only via the
+permission-approval flow (`_persist`), never a raw `file.write`. `memory/`, `cache/`, and
+other non-recovery-core `.reyn/` paths are ordinary writable zones.
+
+## Where does a new subsystem put its data?
+
+Ask the two recovery-core questions:
+
+1. **Is it run-authored AND does it affect in-memory runtime state that recovery
+   reconstructs?** → **recovery-core**: put it under `state/` (and write it through a
+   WAL-emitting durable path or a dedicated op — never a raw `file.write`). If it's a
+   config-style registry the agent mutates, put it under `config/` and give it a dedicated
+   op that emits `config_changed`.
+2. Otherwise pick the exclusion that fits:
+   - rebuildable from other state → `cache/`
+   - a write-only forensic record → `events/` (or a sibling audit dir)
+   - knowledge / a decision that must **survive** rewind → `memory/` (persist)
+   - operator/user-owned → it does not belong under Reyn's managed tree.
+
+When in doubt, do **not** default to recovery-core — an over-broad recovery-core entry
+either bloats capture or, if it can't be reconstructed, breaks rewind.
+
+## See also
+
+- [Time travel](../../concepts/runtime/time-travel.md) — rewind/fork/PITR mechanics.
+- [State directory](../config/state-dir.md) — `--state-dir` routing.


### PR DESCRIPTION
**[e2e-coder]** — #2248 PR-E, the final piece (§7). The canonical `.reyn/` layout reference, closing the §8 epic.

## What
Adds **`docs/reference/runtime/reyn-dir-layout.md`** — the single source for:
- The **five-way classification** (recovery-core / persist / audit / cache / outside) + the §1 criterion.
- The canonical **post-#2248 tree** + the **clean-break move map** (config → `.reyn/config/`, caches → `.reyn/cache/`, approvals stays top-level — no migration shim).
- The **authoritative-vs-derived** recovery-core split: the WAL (`.reyn/state/wal.jsonl`) + config registries are *authoritative* (write-gated); per-agent snapshots under `.reyn/agents/<name>/state/` are *derived* (reconstructable from the WAL, like `cache/`), so **not** write-gated — a corrupted snapshot is recoverable, not data loss. (Per lead's framing — principled, not just pragmatic.)
- The **recovery-core write-gate** rule a skill author hits: raw `file.write` to `config/`/`state/` is denied; mutate config via the dedicated ops (`mcp_install`/`cron_register`/…) which emit `config_changed`.
- **"Where does a new subsystem put its data?"** guidance.

## Consolidation + cross-links (§7)
- The stale Layout tree in `docs/reference/config/state-dir.md` and the inventory table in `persist-state.md` → **redirect links** to the canonical doc.
- Cross-linked from **CLAUDE.md** (Tier-2 "When in doubt") and **docs/feature-map.md** (Crash Recovery: the layout doc + a `config_changed` recovery entry; also corrected the WAL row to note the off-loop `DurabilityWorker` fsync).

## Boundary with the time-travel doc (@docs-maintainer)
This doc owns *what is in `.reyn/`* (classification + write-gate); `time-travel.md` owns *how rewind works* (WAL+snapshot mechanics). Cross-referenced via the `#recovery-core` anchor — no overlap. **docs-maintainer**: requesting your boundary sign-off (the recovery-core file list + the anchor) as a review here — note your earlier `config_changed`/`config/` zero-hits was a stale local tree; both are on current main (`config_recovery.py:43`, `mcp_drop_server.py:60`) post-#2249/#2256.

## Notes
- Doc-only; no code/tests. Code fences balanced (no mermaid). The only doc-sync pytest gate (control-ir.md ↔ OP_KIND_MODEL_MAP) is unaffected.

Sequence: D → B → C → **E (this)** = #2248 §8 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)