### PR TITLE
fix(#2259 PR-1): config-as-snapshot — fix the config-recovery truncation data-loss bug

### DIFF
--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -1,0 +1,114 @@
+"""Config-as-snapshot generations — full-state config registries, keyed by boundary seq.
+
+#2259 PR-1. Config recovery used to ride `config_changed` WAL events, but the WAL is
+truncated below floor = min(agent applied_seq) and config was in no snapshot — so a registry
+whose latest change fell below the floor was silently LOST on reconstruct (a real data-loss
+bug). The fix mirrors `SnapshotGenerationStore`: config is already FULL-STATE (the whole
+registry `.yaml`), so it IS a snapshot. Each config mutation records a full-state generation
+keyed by the WAL head at that point; generations are files (a base), NOT truncatable WAL
+events, so they SURVIVE truncation. Reconstruct as-of-cut = the latest generation ≤ cut (no
+forward-replay — each generation is complete).
+
+Layout: `<generations_dir>/<safe-rel>@<seq>.yaml`, where `<safe-rel>` encodes the registry's
+`.reyn`-relative path (e.g. `config/mcp.yaml` → `config__mcp.yaml`).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_GEN_RE = re.compile(r"^(?P<rel>.+)@(?P<seq>\d+)\.yaml$")
+
+
+def _encode(rel_path: str) -> str:
+    """`config/mcp.yaml` → `config__mcp.yaml` (path-segment-safe single filename)."""
+    return rel_path.replace("/", "__")
+
+
+def _decode(safe_rel: str) -> str:
+    return safe_rel.replace("__", "/")
+
+
+class ConfigGenerationStore:
+    """Directory of full config-registry generations keyed by (`.reyn`-relative path, seq).
+
+    Each generation is the COMPLETE registry state (the whole `.yaml` content) at the WAL
+    head when it was recorded, so reconstruct is "latest generation ≤ cut" with no
+    forward-replay, and a generation survives WAL truncation (it is a base, not an event).
+    """
+
+    def __init__(self, generations_dir: Path) -> None:
+        self._dir = Path(generations_dir)
+
+    def _path_for(self, rel_path: str, seq: int) -> Path:
+        return self._dir / f"{_encode(rel_path)}@{seq}.yaml"
+
+    def record(self, rel_path: str, content: dict, seq: int) -> Path:
+        """Persist `content` as the generation for `rel_path` at `seq` (atomic; idempotent
+        per (rel_path, seq) — re-recording overwrites). The recovery TRUTH for this registry."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(rel_path, seq)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            yaml.dump(content, allow_unicode=True, default_flow_style=False),
+            encoding="utf-8",
+        )
+        tmp.replace(path)
+        return path
+
+    def _entries(self) -> "dict[str, list[int]]":
+        """Per `.reyn`-relative path → sorted generation seqs present on disk."""
+        out: dict[str, list[int]] = {}
+        if not self._dir.is_dir():
+            return out
+        for child in self._dir.iterdir():
+            m = _GEN_RE.match(child.name)
+            if not m:
+                continue
+            out.setdefault(_decode(m.group("rel")), []).append(int(m.group("seq")))
+        for seqs in out.values():
+            seqs.sort()
+        return out
+
+    def paths(self) -> "list[str]":
+        """All config relative-paths that have at least one generation."""
+        return list(self._entries().keys())
+
+    def latest_at_or_below(self, rel_path: str, cut: int) -> "tuple[int, dict] | None":
+        """The (seq, content) of the highest generation for `rel_path` with seq ≤ cut, or
+        None when the registry did not exist as-of-cut (its first generation is after cut)."""
+        seqs = [s for s in self._entries().get(rel_path, ()) if s <= cut]
+        if not seqs:
+            return None
+        seq = seqs[-1]
+        content = yaml.safe_load(
+            self._path_for(rel_path, seq).read_text(encoding="utf-8")
+        )
+        return seq, content if isinstance(content, dict) else {}
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Drop generations with seq < `min_keep_seq` — EXCEPT, per registry, the single
+        highest generation < `min_keep_seq` (the truncation-surviving BASE: a rewind target
+        is always ≥ the WAL floor, and config-as-of-floor may be the last change from BEFORE
+        the floor, so that base must survive). This is the difference from
+        `SnapshotGenerationStore.prune_below`, which can drop everything < floor because the
+        floor itself always carries an agent snapshot. Returns the count dropped."""
+        dropped = 0
+        for rel_path, seqs in self._entries().items():
+            below = [s for s in seqs if s < min_keep_seq]
+            if len(below) <= 1:
+                continue  # nothing to drop, or only the base (keep it)
+            # keep the highest below-floor seq (the base); drop the rest below it.
+            for s in below[:-1]:
+                p = self._path_for(rel_path, s)
+                try:
+                    p.unlink()
+                    dropped += 1
+                except OSError:
+                    pass
+        return dropped
+
+
+__all__ = ["ConfigGenerationStore"]

--- a/src/reyn/core/events/config_recovery.py
+++ b/src/reyn/core/events/config_recovery.py
@@ -1,12 +1,12 @@
-"""Config-recovery emit helper — the single producer-side seam for ``config_changed``.
+"""Config-recovery producer seam — record a config registry as a truncation-surviving snapshot.
 
-#2248 PR-A2. A recovery-core `.reyn/config` registry (mcp / cron / hooks / approvals /
-index-sources) is reconstructed by WAL replay (``AgentRegistry._reconcile_config_as_of_cut``).
-The producer side is this one helper: a dedicated config op calls it AFTER persisting its
-`.yaml`, passing the registry's `.reyn`-relative path + its FULL post-mutation content, so the
-yaml becomes a derived projection and the WAL event is the recovery truth. Centralised here so
-every emit site (and the registry's own ``record_config_change``) shares one format — the
-config-change vocabulary lives in exactly one place.
+#2259 PR-1. A recovery-core `.reyn/config` registry (mcp / cron / hooks / index-sources) is
+reconstructed by restoring the latest config GENERATION ≤ the rewind target. The producer
+side is this one helper: a dedicated config op calls it AFTER persisting its `.yaml`, passing
+the persisted absolute path + its FULL post-mutation content; the helper writes a full-state
+generation keyed by the current WAL head (a base that survives WAL truncation — unlike the
+former `config_changed` WAL event, which the truncation could silently drop). Centralised
+here so every emit site shares one path-key + seq-key convention.
 """
 from __future__ import annotations
 
@@ -18,12 +18,10 @@ if TYPE_CHECKING:
 
 
 def reyn_relative_path(path) -> str | None:
-    """The portion of a config path BELOW the project ``.reyn/`` dir — the key a
-    ``config_changed`` event uses (reconstruct writes ``content`` back to
-    ``<.reyn>/<rel>``). E.g. ``…/.reyn/mcp.yaml`` → ``mcp.yaml``;
-    ``…/.reyn/config/mcp.yaml`` → ``config/mcp.yaml`` (robust across the #2248 §6 reorg).
-    None when the path is not under a ``.reyn/`` dir (operator-owned / out of recovery-core
-    → not WAL-tracked)."""
+    """The portion of a config path BELOW the project ``.reyn/`` dir — the key a config
+    generation is filed under (reconstruct restores ``content`` back to ``<.reyn>/<rel>``).
+    E.g. ``…/.reyn/config/mcp.yaml`` → ``config/mcp.yaml``. None when the path is not under a
+    ``.reyn/`` dir (operator-owned / out of recovery-core → not tracked)."""
     parts = Path(path).parts
     if ".reyn" not in parts:
         return None
@@ -32,12 +30,35 @@ def reyn_relative_path(path) -> str | None:
     return "/".join(rel) if rel else None
 
 
-async def record_config_change(
-    state_log: "StateLog | None", rel_path: str, content: dict,
+def reyn_root(path) -> "Path | None":
+    """The ``.reyn/`` directory an absolute config path lives under (the generation-store
+    anchor: generations go in ``<.reyn>/config/generations/``)."""
+    p = Path(path)
+    for ancestor in (p, *p.parents):
+        if ancestor.name == ".reyn":
+            return ancestor
+    return None
+
+
+def config_generations_dir(reyn_dir: "Path") -> "Path":
+    """The config-generation store directory under a ``.reyn/`` dir."""
+    return Path(reyn_dir) / "config" / "generations"
+
+
+async def record_config_generation(
+    state_log: "StateLog | None", config_abs_path, content: dict,
 ) -> None:
-    """Emit a durable ``config_changed`` for the registry at ``rel_path`` (`.reyn`-relative)
-    carrying its FULL post-mutation ``content``. No-op when ``state_log`` is None (the opt-in /
-    non-persistence contract — tests / non-chat). Call it AFTER the `.yaml` is persisted."""
+    """Record the FULL config state as a generation keyed by the current WAL head — the
+    truncation-surviving recovery base for this registry. No-op when ``state_log`` is None
+    (the opt-in / non-persistence contract) or the path is not under ``.reyn/``. Call it
+    AFTER the `.yaml` is persisted. (Async to match the call sites; the write is synchronous.)"""
     if state_log is None:
         return
-    await state_log.append("config_changed", path=rel_path, content=content)
+    rel = reyn_relative_path(config_abs_path)
+    root = reyn_root(config_abs_path)
+    if rel is None or root is None:
+        return
+    from reyn.core.events.config_generations import ConfigGenerationStore  # noqa: PLC0415
+    ConfigGenerationStore(config_generations_dir(root)).record(
+        rel, content, state_log.current_seq,
+    )

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -114,13 +114,8 @@ WAL_EVENT_KINDS = (
     # live SubscriptionRegistry (subscription.py) — as-of-cut reconstruction by replay.
     "task_subscribed",
     "task_rebound",
-    # NEW (#2248 PR-A) — config registry change for recovery-core `.reyn/config/`
-    # (mcp / cron / hooks / approvals / index-sources). Carries the registry's relative
-    # path + its FULL post-mutation content (re-materialisable, latest-≤-cut-wins, no
-    # delta-fold — uniform with topology_*). OS-level + P7-safe: `path`/`content` are
-    # opaque (the OS writes `content` to `<.reyn>/<path>` on reconstruct, no registry
-    # semantics). apply_events no-ops it (config-set state, not AgentSnapshot STATE).
-    "config_changed",
+    # (#2248 PR-A added `config_changed` here; #2259 PR-1 removed it — config recovery is now
+    # a truncation-surviving GENERATION, not a truncatable WAL event. See config_generations.py.)
 )
 
 

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -108,11 +108,11 @@ class OpContext:
     # (e.g. chat router, CLI commands).
     run_id: str | None = None
 
-    # #2248 PR-A2: the process-shared WAL, threaded so a recovery-core config op
-    # (mcp_install / mcp_drop / index_drop) can emit a ``config_changed`` event after
-    # persisting its `.yaml` — making the yaml a derived projection of the WAL truth.
-    # None outside a persistence-enabled chat/skill context (tests / non-chat) → the op
-    # skips the emit (the opt-in contract, same as the dispatcher's step-event gate).
+    # #2259 PR-1: the process-shared WAL, threaded so a recovery-core config op
+    # (mcp_install / mcp_drop / index_drop) can record a config GENERATION (keyed by the
+    # WAL head) after persisting its `.yaml` — making the yaml a derived projection of the
+    # generation truth. None outside a persistence-enabled chat/skill context (tests /
+    # non-chat) → the op skips it (the opt-in contract, same as the step-event gate).
     state_log: "StateLog | None" = None
 
     # FP-0022 follow-up: declarative SSL config for web_fetch and MCP registry.

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -73,18 +73,13 @@ async def handle(
     drop_result = await backend.drop(op.source)
     removed_from_manifest = await manifest.remove(op.source)
 
-    # #2248 PR-A2: WAL the FULL post-drop sources registry so it recovers via replay
-    # (the yaml is a derived projection). Keyed by the `.reyn`-relative path; skipped
-    # when outside the project `.reyn` (operator-owned) or there is no WAL.
-    from reyn.core.events.config_recovery import (  # noqa: PLC0415
-        record_config_change,
-        reyn_relative_path,
+    # #2259 PR-1: record the FULL post-drop sources registry as a truncation-surviving config
+    # generation so it recovers (the yaml is a derived projection). The helper guards
+    # internally — no-op when there is no WAL or the path is outside the project `.reyn`.
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(
+        getattr(ctx, "state_log", None), manifest.path, await manifest.snapshot(),
     )
-    _rel = reyn_relative_path(manifest.path)
-    if _rel is not None:
-        await record_config_change(
-            getattr(ctx, "state_log", None), _rel, await manifest.snapshot(),
-        )
 
     # Emit P6 event (audit trail)
     ctx.events.emit(

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -242,16 +242,11 @@ async def handle(
             del existing["mcp"]
     _write_yaml_config(config_path, existing)
 
-    # #2248 PR-A2: WAL the FULL post-state so the mcp registry recovers via replay (the
-    # yaml is a derived projection). Keyed by the `.reyn`-relative path; skipped when the
-    # target is outside the project `.reyn` (operator-owned) or there is no WAL.
-    from reyn.core.events.config_recovery import (  # noqa: PLC0415
-        record_config_change,
-        reyn_relative_path,
-    )
-    _rel = reyn_relative_path(config_path)
-    if _rel is not None:
-        await record_config_change(getattr(ctx, "state_log", None), _rel, existing)
+    # #2259 PR-1: record the FULL post-state as a truncation-surviving config generation so
+    # the mcp registry recovers (the yaml is a derived projection). The helper guards
+    # internally — no-op when there is no WAL or the path is outside the project `.reyn`.
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), config_path, existing)
 
     # ── 5. Clean up secrets when requested ─────────────────────────────
     cleared_keys: list[str] = []

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -519,16 +519,11 @@ async def handle(
 
     _write_yaml_config(config_path, existing)
 
-    # #2248 PR-A2: WAL the FULL post-state so the mcp registry recovers via replay (the
-    # yaml is a derived projection of this event). Keyed by the `.reyn`-relative path;
-    # skipped when the target is outside the project `.reyn` (operator-owned) or no WAL.
-    from reyn.core.events.config_recovery import (  # noqa: PLC0415
-        record_config_change,
-        reyn_relative_path,
-    )
-    _rel = reyn_relative_path(config_path)
-    if _rel is not None:
-        await record_config_change(getattr(ctx, "state_log", None), _rel, existing)
+    # #2259 PR-1: record the FULL post-state as a truncation-surviving config generation so
+    # the mcp registry recovers (the yaml is a derived projection). The helper guards
+    # internally — no-op when there is no WAL or the path is outside the project `.reyn`.
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), config_path, existing)
 
     installed_path = str(config_path)
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1532,57 +1532,42 @@ class AgentRegistry:
                 topo.save(path)
                 self._topologies[name] = topo
 
-    async def record_config_change(self, rel_path: str, content: dict) -> None:
-        """#2248 PR-A: WAL the full post-mutation content of a recovery-core config
-        registry, keyed by its `.reyn`-relative path. The single emission chokepoint for
-        config recovery (mirrors `_emit_topology`): a dedicated config op calls this AFTER
-        persisting its `.yaml`, so the registry is reconstructable by WAL replay. The yaml
-        on disk is thus a DERIVED projection — `content` here is the recovery truth.
-        No-op without a WAL (the opt-in / test contract). Delegates to the shared
-        producer-side seam so every emit site uses one format (#2248 PR-A2)."""
-        from reyn.core.events.config_recovery import (  # noqa: PLC0415
-            record_config_change as _emit,
-        )
-        await _emit(self._state_log, rel_path, content)
+    def _config_generation_store(self):
+        """The config-as-snapshot generation store (#2259 PR-1). Full-state config
+        generations under ``.reyn/config/generations/`` — truncation-surviving bases (they
+        replace the truncatable `config_changed` WAL event that lost config below the floor)."""
+        from reyn.core.events.config_generations import ConfigGenerationStore  # noqa: PLC0415
+        from reyn.core.events.config_recovery import config_generations_dir  # noqa: PLC0415
+        return ConfigGenerationStore(config_generations_dir(self._project_root / ".reyn"))
 
-    def _config_lifecycle(self) -> "dict[str, list[tuple[int, dict]]]":
-        """#2248 PR-A: one WAL scan → per config relative-path, its ordered
-        ``(seq, content)`` from ``config_changed`` events (content = the FULL registry
-        state at that point). WAL-sourced only (never the rotated audit log). Only paths
-        that appear here are WAL-tracked → only these are touched by reconstruction; an
-        operator-owned / pre-feature yaml with no event is invisible and left alone. Empty
-        without a WAL."""
-        events: dict[str, list[tuple[int, dict]]] = {}
+    async def record_config_change(self, rel_path: str, content: dict) -> None:
+        """#2259 PR-1: record the FULL post-mutation content of a recovery-core config
+        registry as a truncation-surviving generation keyed by the current WAL head. A
+        dedicated config op calls this AFTER persisting its `.yaml`; the yaml is a derived
+        projection — the generation is the recovery base (it survives WAL truncation, unlike
+        the former `config_changed` event). No-op without a WAL (the opt-in / test contract)."""
         if self._state_log is None:
-            return events
-        for entry in self._state_log.iter_from(0):
-            if entry.get("kind") != "config_changed":
-                continue
-            path = entry.get("path")
-            seq = entry.get("seq")
-            content = entry.get("content")
-            if not isinstance(path, str) or not isinstance(seq, int):
-                continue
-            events.setdefault(path, []).append((seq, content if isinstance(content, dict) else {}))
-        return events
+            return
+        self._config_generation_store().record(
+            rel_path, content, self._state_log.current_seq,
+        )
 
     def _reconcile_config_as_of_cut(self, cut: int) -> None:
-        """#2248 PR-A: reconstruct the recovery-core config registries as-of-cut from the
-        ``config_changed`` WAL (WAL-sourced only). Per WAL-tracked path, the LATEST event
-        with seq ≤ cut decides the on-disk content (latest-≤-cut wins, FULL state, no
-        delta-fold — uniform with `_reconcile_topologies_as_of_cut`). A path whose first
-        event is AFTER the cut didn't exist as-of-cut → removed. Only WAL-tracked paths are
-        touched; inert without events. The yaml is a derived projection re-materialised
-        here from the recovery truth."""
+        """#2259 PR-1: reconstruct the recovery-core config registries as-of-cut from the
+        config GENERATIONS (truncation-surviving, full-state). Per registry, restore the
+        LATEST generation with seq ≤ cut (each generation is complete — no forward-replay). A
+        registry whose first generation is AFTER the cut didn't exist as-of-cut → removed.
+        Only generation-tracked registries are touched (operator-owned / pre-feature yaml with
+        no generation is left alone). This survives WAL truncation — the bug the former
+        event-replay reconstruct had (config_changed below the floor was lost)."""
         import yaml  # noqa: PLC0415 — local, matching the file convention
 
-        for rel_path, evs in self._config_lifecycle().items():
-            latest = max(
-                (e for e in evs if e[0] <= cut), key=lambda e: e[0], default=None,
-            )
+        store = self._config_generation_store()
+        for rel_path in store.paths():
+            latest = store.latest_at_or_below(rel_path, cut)
             abs_path = (self._project_root / ".reyn" / rel_path).resolve()
             if latest is None:
-                # First written after the cut → didn't exist as-of-cut → drop.
+                # First generation after the cut → didn't exist as-of-cut → drop.
                 if abs_path.is_file():
                     abs_path.unlink()
             else:
@@ -1819,8 +1804,8 @@ class AgentRegistry:
         # archived-state (rewind-before-archive → active; rewind-after → archived).
         self._reconcile_archived_as_of_cut(ag_archived, drop_cut)
         self._reconcile_topologies_as_of_cut(drop_cut)
-        # #2248 PR-A: rebuild the recovery-core config registries (mcp/cron/hooks/…)
-        # as-of-cut from the config_changed WAL — same latest-≤-cut-wins model as topology.
+        # #2259 PR-1: rebuild the recovery-core config registries (mcp/cron/hooks/…)
+        # as-of-cut from the config GENERATIONS — same latest-≤-cut-wins model as topology.
         self._reconcile_config_as_of_cut(drop_cut)
         # #2103 B (the rewind LINCHPIN): rebuild the spawn lineage as-of-cut from the
         # agent_created records — a re-materialised child REGAINS its ⊆-parent cap and a
@@ -1976,6 +1961,10 @@ class AgentRegistry:
             anchors = self.anchor_store
             if anchors is not None:
                 anchors.prune_below(floor)                  # AnchorStore (sync)
+            # #2259 PR-1: GC config generations on the SAME boundary — but the store keeps,
+            # per registry, the nearest gen BELOW the floor (the truncation-surviving base),
+            # so config-as-of-floor stays reconstructable (the bug the event-replay had).
+            self._config_generation_store().prune_below(floor)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("Stage 1e generation GC failed (floor=%d): %s", floor, e)
         # #1954 slice 2: WAL-window-bounded auto-purge of archived agents — run

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -558,8 +558,8 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     @property
     def state_log(self) -> Any:
-        """The process-shared WAL (StateLog) or None — #2248 PR-A2: threaded into the
-        ToolContext so a recovery-core config tool emits ``config_changed``."""
+        """The process-shared WAL (StateLog) or None — #2259 PR-1: threaded into the
+        ToolContext so a recovery-core config tool records a config generation."""
         ...
 
     def list_available_skills(self) -> list[dict]:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -323,7 +323,7 @@ class RouterHostAdapter:
         self._resolver = resolver
         self._memory = memory
         self._journal = journal
-        self._state_log = state_log  # #2248 PR-A2: WAL for config_changed emit
+        self._state_log = state_log  # #2259 PR-1: WAL head for config generation emit
         self._registry = agent_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
@@ -539,8 +539,8 @@ class RouterHostAdapter:
 
     @property
     def state_log(self) -> Any:
-        """The process-shared WAL (StateLog) or None — #2248 PR-A2: threaded into the
-        ToolContext so a recovery-core config tool emits ``config_changed``."""
+        """The process-shared WAL (StateLog) or None — #2259 PR-1: threaded into the
+        ToolContext so a recovery-core config tool records a config generation."""
         return self._state_log
 
     @property

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1612,7 +1612,7 @@ class Session:
             threat_scan=self._safety.threat_scan,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
-            state_log=self._state_log,  # #2248 PR-A2 → config_changed emit from config ops
+            state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
             # #1953 dynamic-wire: thread the REAL session id + Task backend so
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
             session_id=self._session_id,

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -485,8 +485,8 @@ class PermissionResolver:
             return {}
 
     def _persist(self, key: str, approved: bool) -> None:
-        # #2248: approvals.yaml is PERSIST, not recovery-core — so NO `config_changed` emit
-        # here (unlike mcp/cron/hooks/index). Approvals are a USER-authored security decision
+        # #2248: approvals.yaml is PERSIST, not recovery-core — so NO config generation
+        # recorded here (unlike mcp/cron/hooks/index). Approvals are a USER-authored security decision
         # (granted via a permission prompt; revoked via the web/CLI surfaces) — never
         # agent-authored — so a rewind must NOT revert them; they survive rewind like
         # `memory/`. Owner-confirmed reclassification (config → persist).

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -181,16 +181,11 @@ def _write_dynamic_cron(path: Path, data: dict) -> None:
 
 
 async def _emit_cron_config_change(ctx: ToolContext, path: Path, data: dict) -> None:
-    """#2248 PR-A2: WAL the FULL post-mutation cron registry so it recovers via
-    replay (the yaml is a derived projection). Keyed by the `.reyn`-relative path;
-    skipped when outside the project `.reyn` or there is no WAL."""
-    from reyn.core.events.config_recovery import (  # noqa: PLC0415
-        record_config_change,
-        reyn_relative_path,
-    )
-    _rel = reyn_relative_path(path)
-    if _rel is not None:
-        await record_config_change(getattr(ctx, "state_log", None), _rel, data)
+    """#2259 PR-1: record the FULL post-mutation cron registry as a truncation-surviving
+    config generation so it recovers (the yaml is a derived projection). The helper guards
+    internally — no-op when there is no WAL or the path is outside the project `.reyn`."""
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), path, data)
 
 
 def _jobs_list(data: dict) -> list:

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -96,7 +96,7 @@ async def _handle_drop_source(
             ),
             permission_resolver=ctx.permission_resolver,
             skill_name="drop_source",
-            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
+            state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),
         )

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -170,16 +170,11 @@ async def _handle_hooks_add(args: Mapping[str, Any], ctx: ToolContext) -> ToolRe
     data["hooks"] = hooks
     _write_hooks(path, data)
 
-    # #2248 PR-A2: WAL the FULL post-mutation hooks registry so it recovers via
-    # replay (the yaml is a derived projection). Keyed by the `.reyn`-relative path;
-    # skipped when outside the project `.reyn` or there is no WAL.
-    from reyn.core.events.config_recovery import (  # noqa: PLC0415
-        record_config_change,
-        reyn_relative_path,
-    )
-    _rel = reyn_relative_path(path)
-    if _rel is not None:
-        await record_config_change(getattr(ctx, "state_log", None), _rel, data)
+    # #2259 PR-1: record the FULL post-mutation hooks registry as a truncation-surviving
+    # config generation so it recovers (the yaml is a derived projection). The helper guards
+    # internally — no-op when there is no WAL or the path is outside the project `.reyn`.
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), path, data)
 
     # Schedule the reload — the HotReloader applies the S2b hooks seam at the turn
     # boundary (1 turn = 1 config snapshot; never mid-turn).

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -132,7 +132,7 @@ async def _handle_mcp_drop_server_op(
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
             skill_name="mcp_drop_server",
-            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
+            state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),
         )

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -124,7 +124,7 @@ async def _handle_mcp_install_op(
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
             skill_name="mcp_install",
-            state_log=getattr(ctx, "state_log", None),  # #2248 PR-A2: config_changed emit
+            state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
         )
 
     return await mcp_install_handle(op=op, ctx=legacy_ctx, caller="control_ir")

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -287,11 +287,11 @@ class ToolContext:
     # session). None in non-session/test contexts → the tool falls back to the
     # process-wide get_active_hot_reloader().
     hot_reloader: Any | None = None
-    # #2248 PR-A2: the process-shared WAL (StateLog), threaded from the calling
+    # #2259 PR-1: the process-shared WAL (StateLog), threaded from the calling
     # session so a recovery-core config tool handler (cron / hooks) — and the
-    # OpContext it builds for an op handler (mcp_install / index_drop) — can emit a
-    # ``config_changed`` event after persisting its `.yaml`. None in non-session /
-    # test contexts → the handler skips the emit (the opt-in contract).
+    # OpContext it builds for an op handler (mcp_install / index_drop) — can record a
+    # config GENERATION (keyed by the WAL head) after persisting its `.yaml`. None in
+    # non-session / test contexts → the handler skips it (the opt-in contract).
     state_log: Any | None = None                     # StateLog | None
 
 

--- a/tests/test_2248_config_wal_reconstruct.py
+++ b/tests/test_2248_config_wal_reconstruct.py
@@ -1,11 +1,12 @@
-"""Tier 2: OS invariant — #2248 PR-A config-registry rewind-reconstruction.
+"""Tier 2: OS invariant — #2259 config-registry rewind-reconstruction (generation model).
 
-Recovery-core `.reyn/config` registries become rewind-durable: `record_config_change` emits a
-`config_changed` WAL event carrying the registry's `.reyn`-relative path + its FULL
-post-mutation content. `_reconcile_config_as_of_cut` reconstructs each WAL-tracked config path
-AS-OF-CUT (latest-≤-cut wins, full content, no delta-fold) — so the `.yaml` is a DERIVED
-projection re-materialised from the WAL truth, never an independent source of truth (the #2248
-load-bearing invariant). Mirrors the topology-lifecycle model.
+Recovery-core `.reyn/config` registries are rewind-durable: `record_config_change` records a
+full-state config GENERATION keyed by the WAL head, filed under the registry's `.reyn`-relative
+path. `_reconcile_config_as_of_cut` reconstructs each generation-tracked config path AS-OF-CUT
+(latest-≤-cut wins, full content, no delta-fold) — so the `.yaml` is a DERIVED projection
+re-materialised from the generation truth, never an independent source of truth (the #2259
+load-bearing invariant). Each generation is a truncation-surviving base (unlike the former
+`config_changed` WAL event the truncation could drop).
 
 Real AgentRegistry + StateLog + on-disk yaml (no mocks).
 """
@@ -37,12 +38,14 @@ def _read_yaml(p: Path):
 
 @pytest.mark.asyncio
 async def test_config_reconstructs_to_latest_at_or_below_cut(tmp_path):
-    """Tier 2: per config path the LATEST config_changed with seq ≤ cut wins — the yaml is
+    """Tier 2: per config path the LATEST generation with seq ≤ cut wins — the yaml is
     re-materialised to that FULL content, NOT the on-disk (post-cut) state. RED if reconcile
-    trusted the on-disk yaml as the source of truth, or used the absolute-latest event."""
+    trusted the on-disk yaml as the source of truth, or used the absolute-latest generation."""
     reg = _make_registry(tmp_path)
     await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"a": {"command": "x"}}}})
     cut = reg.state_log.current_seq
+    # bump the WAL head so the later mutation files a DISTINCT generation (seq > cut):
+    await reg.state_log.append("inbox_put", n=0)
     # a later mutation (after the cut) — the live on-disk state the op would have written:
     await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"a": {}, "b": {}}}})
     p = tmp_path / ".reyn" / "config" / "mcp.yaml"
@@ -52,47 +55,37 @@ async def test_config_reconstructs_to_latest_at_or_below_cut(tmp_path):
     reg._reconcile_config_as_of_cut(cut)
 
     assert _read_yaml(p) == {"mcp": {"servers": {"a": {"command": "x"}}}}, \
-        "yaml must be re-materialised from the WAL event ≤ cut, not the live post-cut state"
+        "yaml must be re-materialised from the generation ≤ cut, not the live post-cut state"
 
 
 @pytest.mark.asyncio
 async def test_config_path_first_written_after_cut_is_removed(tmp_path):
-    """Tier 2: a config path whose FIRST config_changed is AFTER the cut did not exist
+    """Tier 2: a config path whose FIRST generation is AFTER the cut did not exist
     as-of-cut → reconcile removes its yaml. RED if a registry created after a rewind point
     survived a rewind to before it existed."""
     reg = _make_registry(tmp_path)
-    await reg.record_config_change("config/cron.yaml", {"cron": {"jobs": [{"name": "j"}]}})  # seq 1 > cut 0
+    # bump the head so the only generation is filed at seq > 0 (the cut below).
+    await reg.state_log.append("inbox_put", n=0)
+    await reg.record_config_change("config/cron.yaml", {"cron": {"jobs": [{"name": "j"}]}})
     p = tmp_path / ".reyn" / "config" / "cron.yaml"
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(yaml.dump({"cron": {"jobs": [{"name": "j"}]}}), encoding="utf-8")
 
-    reg._reconcile_config_as_of_cut(0)  # cut BEFORE the only config event
+    reg._reconcile_config_as_of_cut(0)  # cut BEFORE the only generation
 
     assert not p.exists(), "a config path first written after the cut is removed on reconstruct"
 
 
 @pytest.mark.asyncio
-async def test_record_config_change_emits_durable_wal_event(tmp_path):
-    """Tier 2: record_config_change appends a durable config_changed carrying path+content
-    (the recovery truth). RED if the seam didn't WAL the change — config would be invisible to
-    replay = a silent recovery gap."""
+async def test_record_config_change_records_durable_generation(tmp_path):
+    """Tier 2: record_config_change writes a durable full-state generation carrying the content
+    (the recovery truth) reconstructable as-of-cut. RED if the seam didn't record the change —
+    config would be invisible to reconstruct = a silent recovery gap."""
     reg = _make_registry(tmp_path)
     await reg.record_config_change("config/hooks.yaml", {"hooks": [{"on": "turn_start"}]})
+    cut = reg.state_log.current_seq
 
-    [entry] = [e for e in reg.state_log.iter_from(0) if e.get("kind") == "config_changed"]
-    assert entry["path"] == "config/hooks.yaml"
-    assert entry["content"] == {"hooks": [{"on": "turn_start"}]}
-
-
-@pytest.mark.asyncio
-async def test_config_changed_does_not_corrupt_agent_snapshot(tmp_path):
-    """Tier 2: config_changed is config-set state, NOT AgentSnapshot STATE — apply_events
-    no-ops it (uniform with topology_*). RED if it leaked into snapshot replay."""
-    from reyn.core.events.agent_snapshot import AgentSnapshot
-
-    snap = AgentSnapshot.empty("a")
-    snap.apply_events([
-        {"seq": 1, "kind": "config_changed", "path": "mcp.yaml", "content": {"mcp": {}}},
-    ])
-    assert snap.inbox == [] and snap.pending_chains == {}, \
-        "config_changed must not mutate AgentSnapshot state"
+    p = tmp_path / ".reyn" / "config" / "hooks.yaml"
+    reg._reconcile_config_as_of_cut(cut)
+    assert _read_yaml(p) == {"hooks": [{"on": "turn_start"}]}, \
+        "the recorded generation must reconstruct the content as-of-cut"

--- a/tests/test_2248_pr_a2_config_emission.py
+++ b/tests/test_2248_pr_a2_config_emission.py
@@ -1,11 +1,11 @@
-"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission (end-to-end, REAL producer).
+"""Tier 2: OS invariant — #2259 config-recovery emission (end-to-end, REAL producer).
 
 A real config op (``mcp_drop_server``) — handed a ``state_log`` via its OpContext (the
-production wiring: session → RouterHostAdapter → ToolContext → adapter → OpContext) — emits a
-``config_changed`` WAL event carrying the FULL post-mutation mcp registry content after it
-persists ``.reyn/mcp.yaml``. ``AgentRegistry._reconcile_config_as_of_cut`` then reverts the
-registry on a rewind. This proves config-recovery with a REAL producer (not a test-only
-``record_config_change`` call): drop a server → it's in the WAL → rewind → it's back.
+production wiring: session → RouterHostAdapter → ToolContext → adapter → OpContext) — records a
+full-state config GENERATION carrying the FULL post-mutation mcp registry content after it
+persists ``.reyn/config/mcp.yaml``. ``AgentRegistry._reconcile_config_as_of_cut`` then reverts
+the registry on a rewind. This proves config-recovery with a REAL producer (not a test-only
+``record_config_generation`` call): drop a server → its generation is recorded → rewind → it's back.
 
 Real PermissionResolver + StateLog + AgentRegistry + on-disk yaml (no mocks).
 """
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from reyn.core.events.config_recovery import record_config_change
+from reyn.core.events.config_recovery import record_config_generation
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.runtime.registry import AgentRegistry
@@ -41,11 +41,11 @@ def _no_factory(_profile):
 
 
 @pytest.mark.asyncio
-async def test_real_mcp_drop_emits_config_changed_and_rewind_restores(tmp_path):
-    """Tier 2: a REAL mcp_drop op (state_log threaded into OpContext) emits config_changed
-    with the full post-drop mcp content; a rewind to before the drop reconstructs the dropped
-    server from the WAL. RED if the op didn't emit (config invisible to replay) or reconstruct
-    trusted the on-disk post-drop yaml."""
+async def test_real_mcp_drop_records_generation_and_rewind_restores(tmp_path):
+    """Tier 2: a REAL mcp_drop op (state_log threaded into OpContext) records a config
+    generation with the full post-drop mcp content; a rewind to before the drop reconstructs the
+    dropped server from the generation. RED if the op didn't record (config invisible to recovery)
+    or reconstruct trusted the on-disk post-drop yaml."""
     from reyn.core.op_runtime.mcp_drop_server import handle as drop_handle
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
@@ -56,9 +56,11 @@ async def test_real_mcp_drop_emits_config_changed_and_rewind_restores(tmp_path):
         "brave": {"command": "uvx", "args": ["brave-mcp"]},
     }}}
     mcp_path.write_text(yaml.dump(two_servers), encoding="utf-8")
-    # the prior install's config_changed (pre-drop state) — the seq we rewind to:
-    await record_config_change(state_log, "config/mcp.yaml", two_servers)
+    # the prior install's generation (pre-drop state) — the seq we rewind to:
+    await record_config_generation(state_log, str(mcp_path), two_servers)
     cut = state_log.current_seq
+    # bump the WAL head so the drop's generation is filed at a DISTINCT seq > cut.
+    await state_log.append("inbox_put", n=0)
 
     resolver = PermissionResolver(
         config_permissions={}, project_root=tmp_path, interactive=False,
@@ -85,16 +87,17 @@ async def test_real_mcp_drop_emits_config_changed_and_rewind_restores(tmp_path):
     result = await drop_handle(op=op, ctx=ctx, caller="control_ir")
     assert result["status"] == "ok"
 
-    # 1) the REAL op emitted config_changed carrying the FULL post-drop registry state.
-    [ev] = [e for e in state_log.iter_from(cut + 1) if e.get("kind") == "config_changed"]
-    assert ev["path"] == "config/mcp.yaml"
-    assert set(ev["content"]["mcp"]["servers"]) == {"filesystem"}
+    # 1) the REAL op recorded a generation carrying the FULL post-drop registry state, AND the
+    #    live yaml dropped brave. The generation reconstructs the post-drop state as-of-now.
     assert "brave" not in yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
-
-    # 2) rewind to before the drop → reconstruct restores brave from the WAL truth.
     reg = AgentRegistry(
         project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
     )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    post_drop = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
+    assert set(post_drop) == {"filesystem"}, "the op's generation reconstructs the post-drop state"
+
+    # 2) rewind to before the drop → reconstruct restores brave from the generation truth.
     reg._reconcile_config_as_of_cut(cut)
     restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
     assert set(restored) == {"filesystem", "brave"}, "rewind reconstructs the dropped server"

--- a/tests/test_2248_pr_a2_emit_cron.py
+++ b/tests/test_2248_pr_a2_emit_cron.py
@@ -1,13 +1,13 @@
-"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the cron registry.
+"""Tier 2: OS invariant — #2259 config-recovery emission for the cron registry.
 
 The REAL cron tool handlers (``_handle_cron_register`` / ``_set_enabled`` /
 ``_handle_cron_unregister``) — handed a ``state_log`` via their ToolContext (the
-production wiring: session → ToolContext) — emit a ``config_changed`` WAL event
+production wiring: session → ToolContext) — record a full-state config GENERATION
 carrying the FULL post-mutation cron registry content after they persist
-``.reyn/cron.yaml``. The yaml is a derived projection; the WAL event is the
-recovery truth.
+``.reyn/config/cron.yaml``. The yaml is a derived projection; the generation is the
+recovery truth (it reconstructs the registry as-of-cut and survives WAL truncation).
 
-Real StateLog + real handlers + on-disk yaml (no mocks).
+Real StateLog + real handlers + real AgentRegistry + on-disk yaml (no mocks).
 """
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ import pytest
 import yaml
 
 from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
 from reyn.tools.cron import (
     _handle_cron_register,
     _handle_cron_unregister,
@@ -37,6 +38,10 @@ class _Workspace:
         self.base_dir = base_dir
 
 
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
 def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
     return ToolContext(
         events=_Events(),
@@ -47,22 +52,25 @@ def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
     )
 
 
-def _config_changed(state_log: StateLog, after_seq: int) -> list[dict]:
-    return [
-        e
-        for e in state_log.iter_from(after_seq + 1)
-        if e.get("kind") == "config_changed"
-    ]
+def _reconstructed_cron(tmp_path: Path, state_log: StateLog) -> dict:
+    """Reconstruct the cron registry from its generation as-of the current WAL head — the
+    recovery truth re-materialised onto disk (the post-mutation full state)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    return yaml.safe_load(
+        (tmp_path / ".reyn" / "config" / "cron.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.mark.asyncio
-async def test_cron_register_emits_config_changed_full_content(tmp_path):
-    """Tier 2: a REAL cron_register (state_log threaded into ToolContext) emits
-    config_changed with the FULL post-register cron content keyed by the
-    `.reyn`-relative path. RED if the handler didn't emit after persisting."""
+async def test_cron_register_records_generation_full_content(tmp_path):
+    """Tier 2: a REAL cron_register (state_log threaded into ToolContext) records a generation
+    with the FULL post-register cron content — reconstructable as-of-cut. RED if the handler
+    didn't record after persisting."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     ctx = _ctx(tmp_path, state_log)
-    before = state_log.current_seq
 
     result = await _handle_cron_register(
         {
@@ -76,23 +84,21 @@ async def test_cron_register_emits_config_changed_full_content(tmp_path):
     )
     assert result["status"] == "ok"
 
-    [ev] = _config_changed(state_log, before)
-    assert ev["path"] == "config/cron.yaml"
-    jobs = ev["content"]["cron"]["jobs"]
-    [job] = [j for j in jobs if j.get("name") == "morning_news"]
+    content = _reconstructed_cron(tmp_path, state_log)
+    [job] = [j for j in content["cron"]["jobs"] if j.get("name") == "morning_news"]
     assert job["to"] == "news_agent"
     assert job["schedule"] == "0 9 * * *"
-    # the yaml is a derived projection of the same content
+    # the live yaml is a derived projection of the same content
     on_disk = yaml.safe_load(
         (tmp_path / ".reyn" / "config" / "cron.yaml").read_text(encoding="utf-8")
     )
-    assert ev["content"] == on_disk
+    assert content == on_disk
 
 
 @pytest.mark.asyncio
-async def test_cron_disable_emits_full_post_state(tmp_path):
-    """Tier 2: a REAL cron disable emits config_changed carrying the FULL post-
-    mutation registry (the disabled job present with enabled=False), not a delta."""
+async def test_cron_disable_records_full_post_state(tmp_path):
+    """Tier 2: a REAL cron disable records a generation carrying the FULL post-mutation registry
+    (the disabled job present with enabled=False), not a delta."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     ctx = _ctx(tmp_path, state_log)
     await _handle_cron_register(
@@ -105,20 +111,18 @@ async def test_cron_disable_emits_full_post_state(tmp_path):
         },
         ctx,
     )
-    before = state_log.current_seq
 
     await _set_enabled({"name": "weekly"}, ctx, enabled=False)
 
-    [ev] = _config_changed(state_log, before)
-    assert ev["path"] == "config/cron.yaml"
-    [job] = [j for j in ev["content"]["cron"]["jobs"] if j["name"] == "weekly"]
+    content = _reconstructed_cron(tmp_path, state_log)
+    [job] = [j for j in content["cron"]["jobs"] if j["name"] == "weekly"]
     assert job["enabled"] is False
 
 
 @pytest.mark.asyncio
-async def test_cron_unregister_emits_full_post_state(tmp_path):
-    """Tier 2: a REAL cron unregister emits config_changed carrying the FULL post-
-    removal registry (the removed job absent from content)."""
+async def test_cron_unregister_records_full_post_state(tmp_path):
+    """Tier 2: a REAL cron unregister records a generation carrying the FULL post-removal
+    registry (the removed job absent from content)."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     ctx = _ctx(tmp_path, state_log)
     await _handle_cron_register(
@@ -131,11 +135,9 @@ async def test_cron_unregister_emits_full_post_state(tmp_path):
         },
         ctx,
     )
-    before = state_log.current_seq
 
     await _handle_cron_unregister({"name": "gone"}, ctx)
 
-    [ev] = _config_changed(state_log, before)
-    assert ev["path"] == "config/cron.yaml"
-    names = [j.get("name") for j in ev["content"]["cron"]["jobs"]]
+    content = _reconstructed_cron(tmp_path, state_log)
+    names = [j.get("name") for j in content["cron"]["jobs"]]
     assert "gone" not in names

--- a/tests/test_2248_pr_a2_emit_hooks.py
+++ b/tests/test_2248_pr_a2_emit_hooks.py
@@ -1,12 +1,12 @@
-"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the hooks registry.
+"""Tier 2: OS invariant — #2259 config-recovery emission for the hooks registry.
 
 The REAL ``_handle_hooks_add`` handler — handed a ``state_log`` via its ToolContext
-(the production wiring: session → ToolContext) — emits a ``config_changed`` WAL
-event carrying the FULL post-mutation hooks registry content after it persists
-``.reyn/hooks.yaml``. The yaml is a derived projection; the WAL event is the
-recovery truth.
+(the production wiring: session → ToolContext) — records a full-state config GENERATION
+carrying the FULL post-mutation hooks registry content after it persists
+``.reyn/config/hooks.yaml``. The yaml is a derived projection; the generation is the
+recovery truth (it reconstructs the registry as-of-cut and survives WAL truncation).
 
-Real StateLog + real handler + on-disk yaml (no mocks).
+Real StateLog + real handler + real AgentRegistry + on-disk yaml (no mocks).
 """
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
 from reyn.tools.hooks import _handle_hooks_add
 from reyn.tools.types import ToolContext
 
@@ -32,6 +33,10 @@ class _Workspace:
         self.base_dir = base_dir
 
 
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
 def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
     return ToolContext(
         events=_Events(),
@@ -43,13 +48,12 @@ def _ctx(base_dir: Path, state_log: StateLog) -> ToolContext:
 
 
 @pytest.mark.asyncio
-async def test_hooks_add_emits_config_changed_full_content(tmp_path):
-    """Tier 2: a REAL hooks_add (state_log threaded into ToolContext) emits
-    config_changed with the FULL post-add hooks content keyed by the
-    `.reyn`-relative path. RED if the handler didn't emit after persisting."""
+async def test_hooks_add_records_generation_full_content(tmp_path):
+    """Tier 2: a REAL hooks_add (state_log threaded into ToolContext) records a generation with
+    the FULL post-add hooks content — reconstructable as-of-cut. RED if the handler didn't record
+    after persisting."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     ctx = _ctx(tmp_path, state_log)
-    before = state_log.current_seq
 
     result = await _handle_hooks_add(
         {"on": "turn_end", "message": "keep going", "wake": True, "name": "loop"},
@@ -58,18 +62,14 @@ async def test_hooks_add_emits_config_changed_full_content(tmp_path):
     assert result["status"] == "ok"
     assert result["added"] is True
 
-    [ev] = [
-        e
-        for e in state_log.iter_from(before + 1)
-        if e.get("kind") == "config_changed"
-    ]
-    assert ev["path"] == "config/hooks.yaml"
-    hooks = ev["content"]["hooks"]
-    [hook] = [h for h in hooks if h.get("name") == "loop"]
-    assert hook["on"] == "turn_end"
-    assert hook["template_push"]["message"] == "keep going"
-    # the yaml is a derived projection of the same content
-    on_disk = yaml.safe_load(
+    # reconstruct from the generation as-of the current head — the recovery truth onto disk.
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    content = yaml.safe_load(
         (tmp_path / ".reyn" / "config" / "hooks.yaml").read_text(encoding="utf-8")
     )
-    assert ev["content"] == on_disk
+    [hook] = [h for h in content["hooks"] if h.get("name") == "loop"]
+    assert hook["on"] == "turn_end"
+    assert hook["template_push"]["message"] == "keep going"

--- a/tests/test_2248_pr_a2_emit_index_sources.py
+++ b/tests/test_2248_pr_a2_emit_index_sources.py
@@ -1,12 +1,12 @@
-"""Tier 2: OS invariant — #2248 PR-A2 config-recovery emission for the index-sources registry.
+"""Tier 2: OS invariant — #2259 config-recovery emission for the index-sources registry.
 
 The REAL ``index_drop`` op handler — handed a ``state_log`` via its OpContext (the
-production wiring: session → ToolContext → drop_source adapter → OpContext) — emits
-a ``config_changed`` WAL event carrying the FULL post-drop sources registry content
-after the SourceManifest persists ``.reyn/index/sources.yaml``. The yaml is a derived
-projection; the WAL event is the recovery truth.
+production wiring: session → ToolContext → drop_source adapter → OpContext) — records
+a full-state config GENERATION carrying the FULL post-drop sources registry content
+after the SourceManifest persists ``.reyn/config/index/sources.yaml``. The yaml is a
+derived projection; the generation is the recovery truth (reconstructable as-of-cut).
 
-Real StateLog + real op handler + real SourceManifest + on-disk yaml (no mocks).
+Real StateLog + real op handler + real SourceManifest + real AgentRegistry + on-disk yaml.
 """
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.core.op_runtime.index_drop import handle as drop_handle
 from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import IndexDropIROp
 
 
@@ -34,12 +35,16 @@ class _Workspace:
         self.base_dir = base_dir
 
 
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
 @pytest.mark.asyncio
-async def test_index_drop_emits_config_changed_full_sources(tmp_path):
-    """Tier 2: a REAL index_drop op (state_log threaded into OpContext) emits
-    config_changed carrying the FULL post-drop sources registry (the dropped source
-    absent, the surviving one present) keyed by the `.reyn`-relative path. RED if the
-    op didn't emit after the manifest persisted sources.yaml."""
+async def test_index_drop_records_generation_full_sources(tmp_path):
+    """Tier 2: a REAL index_drop op (state_log threaded into OpContext) records a generation
+    carrying the FULL post-drop sources registry (the dropped source absent, the surviving one
+    present) — reconstructable as-of-cut. RED if the op didn't record after the manifest
+    persisted sources.yaml."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
     # Seed the real manifest with two sources (persists .reyn/index/sources.yaml).
@@ -50,7 +55,6 @@ async def test_index_drop_emits_config_changed_full_sources(tmp_path):
     await manifest.upsert(
         SourceEntry(name="code", description="python", path="src/**/*.py")
     )
-    before = state_log.current_seq
 
     ctx = OpContext(
         workspace=_Workspace(base_dir=tmp_path),
@@ -66,16 +70,14 @@ async def test_index_drop_emits_config_changed_full_sources(tmp_path):
     result = await drop_handle(op=op, ctx=ctx, caller="control_ir")
     assert result["removed"] is True
 
-    [ev] = [
-        e
-        for e in state_log.iter_from(before + 1)
-        if e.get("kind") == "config_changed"
-    ]
-    assert ev["path"] == "config/index/sources.yaml"
-    assert set(ev["content"]) == {"docs"}
-    assert ev["content"]["docs"]["description"] == "user docs"
-    # the yaml is a derived projection of the same content
-    on_disk = yaml.safe_load(
+    # the op recorded a generation → reconstruct as-of the current head re-materialises the
+    # FULL post-drop sources registry onto disk (the recovery truth).
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    content = yaml.safe_load(
         (tmp_path / ".reyn" / "config" / "index" / "sources.yaml").read_text(encoding="utf-8")
     )
-    assert ev["content"] == on_disk
+    assert set(content) == {"docs"}
+    assert content["docs"]["description"] == "user docs"

--- a/tests/test_2248_prb_config_path_consistency.py
+++ b/tests/test_2248_prb_config_path_consistency.py
@@ -1,15 +1,13 @@
-"""Tier 2: OS invariant — #2248 PR-B config-path consistency (A2↔B round-trip, REAL producer).
+"""Tier 2: OS invariant — #2259 config-path consistency (round-trip, REAL producer).
 
-PR-B relocates the recovery-core config registries from ``.reyn/<name>.yaml`` to
-``.reyn/config/<name>.yaml``. The hazard this guards is split-brain: a config op whose LIVE
-write moves to ``config/`` but whose ``config_changed`` WAL key (or the registry's rewind
-write-back path) does NOT — live writes at the new path, recovery at the old.
+The recovery-core config registries live at ``.reyn/config/<name>.yaml``. The hazard this guards
+is split-brain: a config op whose LIVE write moves to ``config/`` but whose generation KEY (or
+the registry's rewind write-back path) does NOT — live writes at the new path, recovery at the old.
 
-This is the same shape as ``test_2248_pr_a2_config_emission`` but pinned to the NEW path: a REAL
-``mcp_drop_server`` op writes to ``.reyn/config/mcp.yaml``, emits ``config_changed`` keyed
+A REAL ``mcp_drop_server`` op writes to ``.reyn/config/mcp.yaml``, records a generation keyed
 ``"config/mcp.yaml"`` (``reyn_relative_path`` returns the path BELOW ``.reyn/``), and
 ``AgentRegistry._reconcile_config_as_of_cut`` reconstructs to the NEW path on rewind — proving
-the write-path, the WAL key, and the rewind write-back all agree (no split-brain).
+the write-path, the generation key, and the rewind write-back all agree (no split-brain).
 
 Real PermissionResolver + StateLog + AgentRegistry + on-disk yaml (no mocks).
 """
@@ -18,7 +16,7 @@ from __future__ import annotations
 import pytest
 import yaml
 
-from reyn.core.events.config_recovery import record_config_change, reyn_relative_path
+from reyn.core.events.config_recovery import record_config_generation, reyn_relative_path
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.runtime.registry import AgentRegistry
@@ -54,12 +52,12 @@ def test_reyn_relative_path_follows_the_config_move():
 
 
 @pytest.mark.asyncio
-async def test_real_mcp_drop_writes_config_subdir_emits_keyed_path_and_rewind_restores(
+async def test_real_mcp_drop_writes_config_subdir_keyed_path_and_rewind_restores(
     tmp_path,
 ):
-    """Tier 2: a REAL mcp_drop op writes ``.reyn/config/mcp.yaml``, emits config_changed keyed
+    """Tier 2: a REAL mcp_drop op writes ``.reyn/config/mcp.yaml``, records a generation keyed
     ``config/mcp.yaml``, and a rewind reconstructs to the SAME new path. RED on split-brain
-    (live write moved but WAL key / rewind write-back still pointed at the old ``.reyn/mcp.yaml``)."""
+    (live write moved but generation key / rewind write-back still pointed at old ``.reyn/mcp.yaml``)."""
     from reyn.core.op_runtime.mcp_drop_server import handle as drop_handle
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
@@ -71,9 +69,11 @@ async def test_real_mcp_drop_writes_config_subdir_emits_keyed_path_and_rewind_re
         "brave": {"command": "uvx", "args": ["brave-mcp"]},
     }}}
     mcp_path.write_text(yaml.dump(two_servers), encoding="utf-8")
-    # the prior install's config_changed (pre-drop state) — the seq we rewind to:
-    await record_config_change(state_log, "config/mcp.yaml", two_servers)
+    # the prior install's generation (pre-drop state) — the seq we rewind to:
+    await record_config_generation(state_log, str(mcp_path), two_servers)
     cut = state_log.current_seq
+    # bump the WAL head so the drop's generation is filed at a DISTINCT seq > cut.
+    await state_log.append("inbox_put", n=0)
 
     resolver = PermissionResolver(
         config_permissions={}, project_root=tmp_path, interactive=False,
@@ -102,15 +102,17 @@ async def test_real_mcp_drop_writes_config_subdir_emits_keyed_path_and_rewind_re
     assert mcp_path.is_file(), "op wrote to .reyn/config/mcp.yaml"
     assert not (tmp_path / ".reyn" / "mcp.yaml").exists(), "no split-brain write at old path"
 
-    # 2) the REAL op emitted config_changed keyed by the NEW .reyn-relative path.
-    [ev] = [e for e in state_log.iter_from(cut + 1) if e.get("kind") == "config_changed"]
-    assert ev["path"] == "config/mcp.yaml"
-    assert set(ev["content"]["mcp"]["servers"]) == {"filesystem"}
-
-    # 3) rewind reconstructs to the SAME new path from the WAL truth (no old-path resurrection).
+    # 2) the REAL op recorded a generation keyed by the NEW .reyn-relative path — reconstruct
+    #    at the current head re-materialises the post-drop registry at the SAME new path.
     reg = AgentRegistry(
         project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
     )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    post_drop = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
+    assert set(post_drop) == {"filesystem"}, "the op's generation keys the NEW path"
+    assert not (tmp_path / ".reyn" / "mcp.yaml").exists(), "no old-path generation write-back"
+
+    # 3) rewind reconstructs to the SAME new path from the generation truth (no old-path resurrection).
     reg._reconcile_config_as_of_cut(cut)
     restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
     assert set(restored) == {"filesystem", "brave"}, "rewind reconstructs at .reyn/config/mcp.yaml"

--- a/tests/test_2259_config_truncation_bug.py
+++ b/tests/test_2259_config_truncation_bug.py
@@ -1,0 +1,65 @@
+"""Tier 2: #2259 — the PR-A2 config-recovery TRUNCATION bug (RED on main, GREEN under fix).
+
+PR-A2 made config recovery read ONLY `config_changed` WAL events; the WAL is truncated below
+floor = min(agent applied_seq); `config_changed` is NOT exempt from truncation and config is
+in NO snapshot. ⇒ a registry whose latest `config_changed` falls below the truncation floor is
+silently LOST on reconstruct: events alone cannot reconstruct config because events get
+truncated. The fix is config-as-snapshot (full-state, survives truncation, like the agent
+snapshot).
+
+This test asserts the CORRECT as-of-cut config. It is RED on current main (the bug) and the
+GREEN target once config is a truncation-surviving snapshot.
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+@pytest.mark.asyncio
+async def test_config_survives_wal_truncation_below_its_seq(tmp_path):
+    """Tier 2: a config set at an early seq, then truncated below the agents' floor, must
+    still be reconstructable on a rewind to a cut ≥ its seq. RED on main: config_changed@early
+    is truncated → reconstruct loses it (the registry is dropped). GREEN under config-as-
+    snapshot: the full config state survives truncation as a base, like the agent snapshot."""
+    sl = StateLog(tmp_path / ".reyn" / "config" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=sl,
+    )
+    mcp_path = tmp_path / ".reyn" / "config" / "mcp.yaml"
+    mcp_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # seq 1: install MCP server A.  This is the as-of state we'll rewind to.
+    await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"A": {}}}})
+    cut = sl.current_seq  # == 1
+
+    # the agents advance far past it (filler events → the truncation floor climbs).
+    for i in range(120):
+        await sl.append("inbox_put", n=i)
+
+    # a LATER config change (post-floor) — add server B.
+    await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"A": {}, "B": {}}}})
+    mcp_path.write_text(  # the live on-disk state mirrors the latest change
+        yaml.dump({"mcp": {"servers": {"A": {}, "B": {}}}}), encoding="utf-8",
+    )
+
+    # GC truncates the WAL below floor 100 (= min agent applied_seq) → config_changed@1 GONE.
+    stats = await sl.truncate_below(100)
+    assert stats["dropped"] >= 1, "the early config_changed should have been truncated"
+
+    # rewind to cut=1: config should reconstruct to {A} (its state as-of seq 1).
+    reg._reconcile_config_as_of_cut(cut)
+
+    assert mcp_path.is_file(), "config must survive the rewind (RED on main: truncated → dropped)"
+    restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))
+    assert set(restored["mcp"]["servers"]) == {"A"}, (
+        "rewind to seq 1 must restore config {A} — but config_changed@1 was truncated below "
+        "the floor and config is in no snapshot, so events-alone reconstruct LOSES it (the bug)"
+    )

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -210,7 +210,7 @@ async def test_mcp_yaml_write_requires_explicit_decl_recovery_core(tmp_path):
     """Tier 2: #2248 PR-C SUPERSEDES #571 protect-at-use for the mcp config — writing the
     install target ``.reyn/config/mcp.yaml`` now REQUIRES an explicit file.write declaration:
     it is under the recovery-core ``config/`` prefix, so a decl-less write is denied (a raw
-    write would change config WITHOUT the ``config_changed`` WAL event = a recovery gap). The
+    write would change config WITHOUT recording the config generation = a recovery gap). The
     dedicated mcp_install op supplies that explicit decl + writes via its own write_text, so
     the legit path is unaffected (see test_permission_gate_passes_with_explicit_decl).
     ``.reyn/approvals.yaml`` (top-level persist) likewise requires an explicit grant."""

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -259,10 +259,10 @@ def test_canonical_protected_lists_stay_in_sync():
 async def test_mcp_cron_config_reprotected_by_recovery_core_prefix(tmp_path, monkeypatch):
     """Tier 2: #2248 PR-C SUPERSEDES the #571 protect-at-use carve-out for config files.
     Post-PR-A2 ``.reyn/config/`` is RECOVERY-CORE: a raw file.write to config/mcp.yaml would
-    change config WITHOUT emitting the ``config_changed`` WAL event (= a recovery gap — the
-    change wouldn't be reconstructed/reverted on rewind). So §4 re-protects the whole
+    change config WITHOUT recording the config generation (= a recovery gap — the change
+    wouldn't be reconstructed/reverted on rewind). So §4 re-protects the whole
     ``config/`` prefix: a raw broad-zone write is now DENIED on both enforcement paths,
-    forcing the dedicated WAL-emitting op (mcp_install/drop, cron_register — which declare
+    forcing the dedicated generation-recording op (mcp_install/drop, cron_register — which declare
     the path explicitly). The #571 "use-gate makes the carve-out redundant" judgment is
     obsolete now that config is recovery-core.
 


### PR DESCRIPTION
**[e2e-coder]** — #2259 PR-1 of 3 (NOT the finish line — PR-2 async core + PR-3 recovery-semantics follow). Fixes a **real data-loss bug** in merged config-recovery (PR-A/A2), owner-found.

## The bug (reproduced RED on main)
Config recovery read only `config_changed` WAL events; the WAL truncates below floor = min(agent applied_seq); `config_changed` is **not** exempt + config is in **no** snapshot ⇒ a registry whose latest change fell below the floor is **silently lost** on reconstruct. `tests/test_2259_config_truncation_bug.py`: set MCP A @ early seq → advance → truncate past it → rewind → on main the mcp.yaml is **dropped**. Events alone can't reconstruct config because events get truncated. (My PR-A gap: config-as-WAL-event without the truncation lifecycle.)

## The fix: config-as-snapshot (mirror the agent snapshot)
Config `.yaml` is already full-state, so it **is** a snapshot:
- **`ConfigGenerationStore`** — full config generations `.reyn/config/generations/<safe-rel>@<seq>.yaml`, a FILE base (not a truncatable event) → **survives truncation**. Reconstruct = latest gen ≤ cut (each complete, no forward-replay). **`prune_below` keeps the nearest gen below the floor** (the truncation-surviving base — the key difference from `SnapshotGenerationStore`).
- registry: `record_config_change` → generation; `_reconcile_config_as_of_cut` → latest gen ≤ cut; Stage-1e GC prunes config gens (keep-base). Removed the `config_changed` WAL kind + the event-replay reconcile.
- the 5 config ops record a generation (via `record_config_generation`) instead of emitting an event.

In-memory config stays immediate; the generation is the durable recovery base. **Under the current await model** — the async-decoupled core is PR-2.

## Test plan
- [x] **RED→GREEN**: `test_2259_config_truncation_bug.py` RED on main → GREEN here (config survives truncation + reconstructs as-of-cut)
- [x] PR-A/A2 config-recovery tests reworked from the event mechanism → the generation mechanism — **recovery coverage preserved, not gutted** (the reconstruct tests still assert recovery via generations); deleted only the `config_changed-doesn't-corrupt-snapshot` test (kind gone)
- [x] Zero `config_changed`-as-event refs (the kept registry method name aside); ruff / tier-audit / module-docstrings clean
- [x] Full suite — **7475 passed**, 4 pre-existing (gateway/`reyn.safe`) only, zero new
- [x] Independently re-verified the sub-agent's emit-swaps + test rework (the data-loss-fix discipline)

## Tracked under #2259 — NOT done until PR-3
PR-2 = async-decoupled core (seq-in-worker, no-await, no-lock); PR-3 = recovery/relaxed-durability semantics. §4 durable-write-failure decided (retry-transient → escalate-persistent, reuse a standard retry helper) for PR-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)