### PR TITLE
docs(hard-rules): add recovery-feature PR gate (truncate-falsify test)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Single format for all phases:
 - ALWAYS validate LLM output (Transition + Finish above)
 - ALWAYS emit events for state changes (P6)
 - **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `ControlIROp` union derives from the same map). New op kinds get a section in the reference in the same PR.
+- **Recovery-feature PR gate**: any PR adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths) MUST include a truncate-falsify test verifying the reconstruction source survives WAL truncation below its source events (set X → truncate past X's events → reconstruct → assert X survives). WAL-event-derived recovery state that isn't snapshot-backed is a silent data-loss vector. Same PR, not a follow-up. (Motivated by #2259/#2260.)
 
 ## Testing policy (READ BEFORE WRITING TESTS)
 


### PR DESCRIPTION
**[docs-maintainer]** — hard rule addition to CLAUDE.md

## Summary

- Adds a **Recovery-feature PR gate** to the Hard "NEVER" rules section of `CLAUDE.md`, adjacent to the existing `control-ir.md ↔ OP_KIND_MODEL_MAP` sync rule
- Any PR adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths) must include a truncate-falsify test verifying the reconstruction source survives WAL truncation below its source events
- Same mechanically-checkable pattern as the existing op-kind-sync gate: reviewers can verify compliance at PR time, not post-merge

## Motivation

Two real bugs discovered this session motivate this gate:
- **#2259**: config recovery state lost on WAL truncation
- **#2260**: agent-identity escalation-on-rewind security bug (recovery state not snapshot-backed)

Both were missed because no explicit PR review checklist required a truncate-falsify test for recovery-feature PRs. Lead-coder confirmed CLAUDE.md hard rules is the right home (broker msg 2026-06-28T06:40:08Z).

## Test plan

- [x] (skipped — docs-only change; no runnable tests. CI gates: ruff/pytest not applicable to CLAUDE.md)
- [x] Wording matches lead-coder's suggested draft verbatim (with `#2259/#2260` reference appended)
- [x] Placement: immediately after the `control-ir.md` sync rule bullet in "Hard NEVER rules" section — the two mechanically-checkable PR gates now sit together

🤖 Generated with [Claude Code](https://claude.com/claude-code)