### PR TITLE
fix(#2259 PR-1b): agent-identity-as-snapshot — fix the lineage truncation escalation bug

### DIFF
--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -87,6 +87,11 @@ same rewind path (WAL replay + snapshot generations — see
   - `.reyn/config/<x>.yaml` — the agent-edited registries. Each mutation goes through a
     dedicated op that emits a `config_changed` WAL event; the `.yaml` is a derived
     projection of that event, re-materialised on rewind.
+  - `.reyn/state/agent_identity/<name>@<seq>.json` — per-agent identity + frozen spawn
+    lineage, recorded as a full-state generation at `create_agent` (#2259 PR-1b). A
+    truncation-surviving base (like the config generations): the `agent_created` WAL event is
+    dropped below the floor, so rewind reconstructs the ⊆-parent cap from the generation, not
+    the event — without it a long-lived agent's child runs un-capped on rewind.
 - **Derived** (reconstructable from the authoritative state — NOT write-gated):
   - `.reyn/agents/<name>/state/`: `snapshot.json`, `generations/gen-<seq>.json`,
     `sessions/<sid>/…`. Snapshots sit under a `state/` segment but are **derived** — a

--- a/src/reyn/core/events/agent_identity_generations.py
+++ b/src/reyn/core/events/agent_identity_generations.py
@@ -1,0 +1,116 @@
+"""Agent identity/lineage generations — per-agent full-state identity, keyed by create seq.
+
+#2259 PR-1b. Rewind used to rebuild ``_agent_create_seq`` + ``_spawn_lineage`` from the
+``agent_created`` WAL events, but the WAL is truncated below floor = min(agent applied_seq) and
+``agent_created`` is NOT exempt — so a long-lived agent whose ``agent_created`` fell below the
+floor lost its identity + lineage edge on rewind. A dropped lineage edge makes
+``resolved_profile_for`` skip the ⊆-parent conjunct → the child runs UN-capped = capability
+escalation-on-rewind (a security bug, not just data-loss).
+
+The fix mirrors ``ConfigGenerationStore`` (config-as-snapshot, #2259 PR-1): each agent's
+identity + lineage is FULL-STATE (``create_seq`` + the frozen spawn edge), so it IS a snapshot.
+Each ``create_agent`` records a generation keyed by the agent's create seq; generations are
+files (a base), NOT truncatable WAL events, so they SURVIVE truncation. Reconstruct as-of-cut =
+the latest generation ≤ cut per agent (no forward-replay — each generation is complete).
+
+Layout: ``<generations_dir>/<agent_name>@<seq>.json`` (agent names are already filesystem-safe
+— they key the ``.reyn/agents/<name>/`` dirs).
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_GEN_RE = re.compile(r"^(?P<name>.+)@(?P<seq>\d+)\.json$")
+
+
+class AgentIdentityGenerationStore:
+    """Directory of per-agent identity/lineage generations keyed by (agent name, create seq).
+
+    Each generation is the COMPLETE identity state for one agent — ``create_seq`` (its stable
+    identity) plus the frozen spawn edge (``spawn_parent`` + ``spawn_parent_seq``) — at the WAL
+    head when it was recorded, so reconstruct is "latest generation ≤ cut" with no
+    forward-replay, and a generation survives WAL truncation (it is a base, not an event).
+    """
+
+    def __init__(self, generations_dir: Path) -> None:
+        self._dir = Path(generations_dir)
+
+    def _path_for(self, name: str, seq: int) -> Path:
+        return self._dir / f"{name}@{seq}.json"
+
+    def record(
+        self, name: str, *, create_seq: int, spawn_parent: "str | None",
+        spawn_parent_seq: "int | None", seq: int,
+    ) -> Path:
+        """Persist ``name``'s identity + frozen lineage as the generation at ``seq`` (atomic;
+        idempotent per (name, seq) — re-recording overwrites). The recovery TRUTH for this
+        agent's identity (it survives WAL truncation, unlike the ``agent_created`` event)."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(name, seq)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps({
+                "create_seq": create_seq,
+                "spawn_parent": spawn_parent,
+                "spawn_parent_seq": spawn_parent_seq,
+            }),
+            encoding="utf-8",
+        )
+        tmp.replace(path)
+        return path
+
+    def _entries(self) -> "dict[str, list[int]]":
+        """Per agent name → sorted generation seqs present on disk."""
+        out: dict[str, list[int]] = {}
+        if not self._dir.is_dir():
+            return out
+        for child in self._dir.iterdir():
+            m = _GEN_RE.match(child.name)
+            if not m:
+                continue
+            out.setdefault(m.group("name"), []).append(int(m.group("seq")))
+        for seqs in out.values():
+            seqs.sort()
+        return out
+
+    def names(self) -> "list[str]":
+        """All agent names that have at least one identity generation."""
+        return list(self._entries().keys())
+
+    def latest_at_or_below(self, name: str, cut: int) -> "tuple[int, dict] | None":
+        """The (seq, identity-dict) of the highest generation for ``name`` with seq ≤ cut, or
+        None when the agent did not exist as-of-cut (its first generation is after cut)."""
+        seqs = [s for s in self._entries().get(name, ()) if s <= cut]
+        if not seqs:
+            return None
+        seq = seqs[-1]
+        data = json.loads(self._path_for(name, seq).read_text(encoding="utf-8"))
+        return seq, data if isinstance(data, dict) else {}
+
+    def prune_below(self, min_keep_seq: int) -> int:
+        """Drop generations with seq < ``min_keep_seq`` — EXCEPT, per agent, the single highest
+        generation < ``min_keep_seq`` (the truncation-surviving BASE: a rewind target is always
+        ≥ the WAL floor, and identity-as-of-floor is the create generation from BEFORE the
+        floor, so that base must survive). This is the crux carried over from
+        ``ConfigGenerationStore.prune_below`` — and the difference from
+        ``SnapshotGenerationStore.prune_below``, which can drop everything < floor because the
+        floor itself always carries an agent snapshot. Returns the count dropped."""
+        dropped = 0
+        for name, seqs in self._entries().items():
+            below = [s for s in seqs if s < min_keep_seq]
+            if len(below) <= 1:
+                continue  # nothing to drop, or only the base (keep it)
+            # keep the highest below-floor seq (the base); drop the rest below it.
+            for s in below[:-1]:
+                p = self._path_for(name, s)
+                try:
+                    p.unlink()
+                    dropped += 1
+                except OSError:
+                    pass
+        return dropped
+
+
+__all__ = ["AgentIdentityGenerationStore"]

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -628,6 +628,11 @@ class AgentRegistry:
             )
             # #2103 C2b: this agent's stable identity = its agent_created WAL seq.
             self._agent_create_seq[name] = seq
+            # #2259 PR-1b: ALSO persist identity + lineage as a truncation-surviving
+            # generation — the `agent_created` event above is dropped when the WAL is
+            # truncated below the floor, which would lose the ⊆-parent cap on rewind
+            # (escalation-on-rewind). The generation is the recovery base for identity.
+            self._record_agent_identity_generation(name, seq)
         else:
             # #2103 C2b Q1: no-WAL fallback — a monotonic counter (no rewind to
             # reconstruct against here), so a create_agent parent is ALWAYS identity-
@@ -1540,6 +1545,56 @@ class AgentRegistry:
         from reyn.core.events.config_recovery import config_generations_dir  # noqa: PLC0415
         return ConfigGenerationStore(config_generations_dir(self._project_root / ".reyn"))
 
+    def _agent_identity_generation_store(self):
+        """The agent-identity-as-snapshot generation store (#2259 PR-1b). Per-agent full-state
+        identity + frozen lineage under ``.reyn/state/agent_identity/`` — truncation-surviving
+        bases (they replace the truncatable `agent_created` WAL event that lost identity/lineage
+        below the floor → escalation-on-rewind). Same pattern as the config store (PR-1)."""
+        from reyn.core.events.agent_identity_generations import (  # noqa: PLC0415
+            AgentIdentityGenerationStore,
+        )
+        return AgentIdentityGenerationStore(
+            self._project_root / ".reyn" / "state" / "agent_identity",
+        )
+
+    def _record_agent_identity_generation(self, name: str, seq: int) -> None:
+        """#2259 PR-1b: persist ``name``'s identity (``create_seq``) + frozen spawn edge as a
+        truncation-surviving generation keyed by its create seq, so a rewind reconstructs the
+        ⊆-parent cap from the generation — NOT from the `agent_created` WAL event, which
+        truncation drops (a dropped lineage edge → resolved_profile_for skips the parent-conjunct
+        → child runs UN-capped). No-op without a WAL (no rewind to reconstruct against)."""
+        if self._state_log is None:
+            return
+        edge = self._spawn_lineage.get(name)
+        self._agent_identity_generation_store().record(
+            name,
+            create_seq=self._agent_create_seq.get(name, seq),
+            spawn_parent=edge[0] if edge else None,
+            spawn_parent_seq=edge[1] if edge else None,
+            seq=seq,
+        )
+
+    def _agent_identity_as_of_cut(
+        self, cut: int,
+    ) -> "dict[str, tuple[int, str | None, int | None]]":
+        """#2259 PR-1b: per-agent identity + frozen lineage as-of-cut from the truncation-
+        surviving generations — the latest generation ≤ cut per agent. Returns
+        ``{name: (create_seq, spawn_parent, spawn_parent_seq)}``. The rewind rebuild prefers
+        this (survives truncation) over the `agent_created` WAL scan."""
+        store = self._agent_identity_generation_store()
+        out: dict[str, tuple[int, str | None, int | None]] = {}
+        for name in store.names():
+            latest = store.latest_at_or_below(name, cut)
+            if latest is None:
+                continue  # first generation after the cut → didn't exist as-of-cut
+            _seq, data = latest
+            out[name] = (
+                int(data.get("create_seq", _seq)),
+                data.get("spawn_parent"),
+                data.get("spawn_parent_seq"),
+            )
+        return out
+
     async def record_config_change(self, rel_path: str, content: dict) -> None:
         """#2259 PR-1: record the FULL post-mutation content of a recovery-core config
         registry as a truncation-surviving generation keyed by the current WAL head. A
@@ -1823,13 +1878,23 @@ class AgentRegistry:
         # purged + REUSED, the reused parent's create_seq differs → the edge reads STALE
         # → resolved_profile_for fail-closes + is_spawn_descendant rejects = no
         # resurrection of the orphan under the reused parent on a forward checkout.
+        #
+        # #2259 PR-1b: identity/lineage comes from the truncation-surviving per-agent
+        # GENERATIONS (latest ≤ cut), with the `agent_created` WAL scan as a fallback for
+        # any agent without a generation. The WAL event is truncated below the floor — so a
+        # long-lived agent's edge would be LOST if rebuilt from the WAL alone, dropping its
+        # ⊆-parent cap on rewind (escalation-on-rewind). The generation is the recovery base.
+        identity = self._agent_identity_as_of_cut(drop_cut)
+        for _n, (_s, _payload, _p, _pseq) in ag_created.items():
+            if _s <= drop_cut:
+                identity.setdefault(_n, (_s, _p, _pseq))
         self._agent_create_seq = {
-            _n: _s for _n, (_s, _payload, _p, _pseq) in ag_created.items()
-            if _s <= drop_cut and _n not in ag_purged and (self._dir / _n).is_dir()
+            _n: _cs for _n, (_cs, _p, _pseq) in identity.items()
+            if _n not in ag_purged and (self._dir / _n).is_dir()
         }
         self._spawn_lineage = {
-            _n: (_p, _pseq) for _n, (_s, _payload, _p, _pseq) in ag_created.items()
-            if _p and _s <= drop_cut and _n not in ag_purged and (self._dir / _n).is_dir()
+            _n: (_p, _pseq) for _n, (_cs, _p, _pseq) in identity.items()
+            if _p and _n not in ag_purged and (self._dir / _n).is_dir()
         }
         # #2125 (b)-split: the runtime reconstruction succeeded — NOW perform the
         # deferred destructive rmtree of the dropped post-cut session dirs. Reaching
@@ -1965,6 +2030,10 @@ class AgentRegistry:
             # per registry, the nearest gen BELOW the floor (the truncation-surviving base),
             # so config-as-of-floor stays reconstructable (the bug the event-replay had).
             self._config_generation_store().prune_below(floor)
+            # #2259 PR-1b: GC agent-identity generations on the same boundary, with the SAME
+            # prune-KEEPS-BASE crux — keep the nearest identity gen BELOW the floor per agent,
+            # so the ⊆-parent cap stays reconstructable on a rewind to the floor.
+            self._agent_identity_generation_store().prune_below(floor)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("Stage 1e generation GC failed (floor=%d): %s", floor, e)
         # #1954 slice 2: WAL-window-bounded auto-purge of archived agents — run

--- a/tests/test_2259_pr1b_agent_identity_truncation_bug.py
+++ b/tests/test_2259_pr1b_agent_identity_truncation_bug.py
@@ -1,0 +1,160 @@
+"""Tier 2: #2259 PR-1b — agent identity/lineage TRUNCATION bug (RED on main, GREEN under fix).
+
+The SECOND truncation data-loss bug of the #2259 class (sibling of PR-1's config bug), and a
+SECURITY bug: rewind rebuilds `_agent_create_seq` + `_spawn_lineage` from the `agent_created`
+WAL events (`_agent_lifecycle` is a WAL scan; registry "the WAL is the trusted source"). The
+WAL is truncated below floor = min(agent applied_seq), and `agent_created` is NOT exempt — so a
+long-lived agent whose `agent_created` fell below the floor loses its lineage edge on rewind.
+A dropped lineage edge → `resolved_profile_for` skips the ⊆-parent conjunct → the child runs
+**UN-CAPPED** = capability escalation-on-rewind.
+
+The fix mirrors PR-1 (config-as-snapshot): identity/lineage is recorded as a per-agent
+truncation-surviving GENERATION (full-state, seq-keyed, prune-KEEPS-BASE), and rewind
+reconstructs identity/lineage from the generation — not from the truncatable WAL event.
+
+These tests assert the CORRECT (capped) as-of-rewind cap. RED on current main (the edge is lost
+→ un-capped); GREEN once identity/lineage survives truncation as a generation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.effective import ContextualPermission, tool_contextually_denied
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _bind_parent_narrowing(tmp_path: Path, *, parent: str, profile: str, body: str) -> None:
+    """Bind ``parent`` to a narrowing capability ``profile`` via a topology (mirrors the
+    #2103 B-core cap test's `_bind`), so ``resolved_profile_for(parent)`` imposes a real
+    deny that a child ⊆ parent must inherit. The parent's AGENT dir is created by
+    ``create_agent`` (not here), so the #2161 parent-existence check sees it present."""
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / f"{parent}.yaml").write_text(
+        f"name: {parent}\nkind: network\nmembers: [{parent}, peer]\n"
+        f"profiles:\n  {parent}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_child_parent_cap_survives_wal_truncation_of_agent_created(tmp_path):
+    """Tier 2: a child spawned ⊆ a narrowing parent must STAY capped after a rewind, even when
+    the agents' `agent_created` events were truncated below the floor. RED on main: the lineage
+    edge is rebuilt from the truncated WAL → gone → `resolved_profile_for(child)` loses the
+    parent-conjunct = UN-capped (security escalation-on-rewind). GREEN: identity/lineage
+    survives truncation as a per-agent generation → the ⊆-parent cap is reconstructed."""
+    _bind_parent_narrowing(
+        tmp_path, parent="parent_a", profile="prole",
+        body="name: prole\ntool_deny: [sandboxed_exec]\n",
+    )
+    reg = _registry(tmp_path)
+    log = reg.state_log
+
+    # parent P (narrowed by its topology binding) + child C spawned ⊆ P — via the REAL
+    # create_agent seam, so the production identity-capture path is exercised.
+    await reg.create_agent("parent_a")
+    await reg.create_agent("child_a", parent="parent_a")
+
+    # SANITY (pre-truncation): the child is capped at ⊆ parent (denies P's sandboxed_exec).
+    pre, _ = reg.resolved_profile_for("child_a")
+    assert isinstance(pre, ContextualPermission)
+    assert tool_contextually_denied(pre, "sandboxed_exec"), "pre-rewind child must be ⊆ parent"
+
+    # the agents advance far past their create seqs (filler → the truncation floor climbs).
+    for i in range(120):
+        await log.append("inbox_put", n=i)
+
+    # GC truncates the WAL below floor 100 → the agents' agent_created@{1,2} are GONE.
+    stats = await log.truncate_below(100)
+    assert stats["dropped"] >= 2, "the early agent_created events should have been truncated"
+    # The SAME-boundary generation GC runs too — it must KEEP the identity base below floor
+    # (prune-KEEPS-BASE); a drop-all-below GC here would re-introduce the bug.
+    await reg._prune_generations_below(100)
+    idstore = reg._agent_identity_generation_store()
+    assert idstore.latest_at_or_below("parent_a", log.current_seq) is not None, (
+        "the parent's identity generation must survive the floor-100 GC (prune-KEEPS-BASE)"
+    )
+
+    # forward-checkout / rewind reconstruction → rebuild identity + lineage as-of-cut.
+    await reg._materialize_rewind(
+        reconstruct_seq=log.current_seq, workspace_at_or_below=log.current_seq,
+    )
+
+    # SECURITY dimension (the load-bearing one): the child is STILL capped at ⊆ parent.
+    after, _ = reg.resolved_profile_for("child_a")
+    assert isinstance(after, ContextualPermission) and tool_contextually_denied(
+        after, "sandboxed_exec"
+    ), (
+        "ESCALATION-ON-REWIND: child runs UN-capped after rewind — the dropped lineage edge "
+        "made resolved_profile_for skip the ⊆-parent conjunct (the security bug). The "
+        "parent-cap must survive via the truncation-surviving identity generation."
+    )
+    # data-loss dimension: the lineage edge itself survives the rewind.
+    assert reg.is_spawn_descendant("child_a", "parent_a"), (
+        "lineage lost on rewind: child's ⊆-parent edge was rebuilt from the truncated "
+        "agent_created WAL event (RED on main; GREEN once identity is a generation)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_identity_generation_survives_but_post_cut_child_is_undone(tmp_path):
+    """Tier 2: the boundary control — a child created AFTER the rewind cut is undone (its cap
+    question is moot), guarding against the rebuild blindly resurrecting every generation
+    regardless of the cut. Identity generations are as-of-cut (latest seq ≤ cut), like config."""
+    _bind_parent_narrowing(
+        tmp_path, parent="parent_a", profile="prole",
+        body="name: prole\ntool_deny: [sandboxed_exec]\n",
+    )
+    reg = _registry(tmp_path)
+    log = reg.state_log
+
+    await reg.create_agent("parent_a")
+    cut = log.current_seq  # rewind target = just after P exists, before C is spawned
+    await reg.create_agent("child_a", parent="parent_a")
+
+    # rewind to BEFORE C was spawned → C did not exist as-of-cut → undone (dropped).
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+
+    assert not (tmp_path / ".reyn" / "agents" / "child_a").is_dir(), (
+        "a child created AFTER the cut must be undone on rewind (not resurrected from its "
+        "post-cut identity generation)"
+    )
+    assert not reg.is_spawn_descendant("child_a", "parent_a"), "post-cut child has no as-of-cut lineage edge"
+
+
+def test_identity_store_prune_keeps_base(tmp_path):
+    """Tier 1: AgentIdentityGenerationStore.prune_below KEEPS the single highest generation
+    below the floor per agent (the truncation-surviving base) and drops the rest — the crux
+    carried over from ConfigGenerationStore. Multi-gen per agent is real (purge + name-reuse
+    re-records identity at the reuse seq). Drop-all-below would re-introduce the escalation bug."""
+    from reyn.core.events.agent_identity_generations import AgentIdentityGenerationStore
+
+    store = AgentIdentityGenerationStore(tmp_path / "gens")
+    for seq in (1, 5, 9):  # three identity generations for one re-created name
+        store.record("agt", create_seq=seq, spawn_parent=None, spawn_parent_seq=None, seq=seq)
+
+    dropped = store.prune_below(7)  # floor 7 → gens {1,5} are below; keep the base (5), drop 1
+    assert dropped == 1
+    # The pre-base history (seq 1) is pruned, but the BASE (5, highest < floor) + the
+    # at/above-floor gen (9) survive — so identity stays reconstructable at any cut ≥ the base.
+    assert store.latest_at_or_below("agt", 4) is None, "below-base history is pruned"
+    assert store.latest_at_or_below("agt", 6)[0] == 5, "the base (highest < floor) survives"
+    assert store.latest_at_or_below("agt", 10)[0] == 9, "the at/above-floor gen survives"


### PR DESCRIPTION
**[e2e-coder]** — #2259 PR-1b (second of the #2259 truncation-bug fixes, sibling of PR-1's config-as-snapshot #2260).

## The bug (data-loss + SECURITY)

Rewind rebuilds `_agent_create_seq` + `_spawn_lineage` from the `agent_created` WAL events (`_agent_lifecycle` is a WAL scan — "the WAL is the trusted source", registry:1872). The WAL is truncated below floor = `min(agent applied_seq)` and **`agent_created` is NOT exempt** (verified: `truncate_below` drops every `seq < floor` with no kind-exemption). So a long-lived agent whose `agent_created` fell below the floor loses its lineage edge on rewind.

A dropped lineage edge → `resolved_profile_for` finds `_spawn_lineage.get(agent) is None` → **skips the ⊆-parent conjunct** (registry:2874, an *absent* edge fails *open*, unlike a stale edge which fails closed) → the child runs **UN-CAPPED** = capability **escalation-on-rewind**, not just data-loss. Same class as the PR-1 config truncation bug.

## The fix (mirrors PR-1 config-as-snapshot)

A dedicated per-agent `AgentIdentityGenerationStore` records identity (`create_seq`) + the frozen spawn edge (`spawn_parent`, `spawn_parent_seq`) as a **full-state, seq-keyed generation** at `create_agent`. Generations are files (a base), not truncatable WAL events → they survive truncation.

- **prune-KEEPS-BASE** — the crux carried over from `ConfigGenerationStore`: GC keeps the single highest gen ≤ floor per agent (the `SnapshotGenerationStore` drop-all-below is unsafe here — there's no guaranteed gen at the floor).
- **Rewind** reconstructs identity/lineage from the generation (latest ≤ cut per agent), with the `agent_created` WAL scan as a fallback for any agent without a generation. The WAL event is kept for profile-rematerialization.
- Per-agent dedicated store (not folded into the per-session `AgentSnapshot`) — resolves the per-agent-vs-per-session data-model mismatch (identity is per-agent set-once; snapshots are per-session mutable). Lead-confirmed seam.
- **#2103 staleness invariant preserved**: frozen-parent-identity vs current-identity, both now generation-sourced.
- New recovery-core path documented in `reyn-dir-layout.md`; satisfies the #2261 truncate-falsify PR gate.

## Files
- `src/reyn/core/events/agent_identity_generations.py` (new) — the store.
- `src/reyn/runtime/registry.py` — store accessor, record at `create_agent`, `_agent_identity_as_of_cut`, rewind-rebuild merge, prune on the GC boundary.
- `tests/test_2259_pr1b_agent_identity_truncation_bug.py` (new) — RED→GREEN.
- `docs/reference/runtime/reyn-dir-layout.md` — the new recovery-core path.

## Test plan
- [x] **RED→GREEN security proof**: child ⊆ narrowing parent → `agent_created` truncated past floor 100 → `_prune_generations_below(100)` (keeps base) → rewind → on main the child is un-capped (`resolved_profile_for` loses the conjunct); GREEN = `tool_contextually_denied(after, "sandboxed_exec")` holds + `is_spawn_descendant` survives. Confirmed RED on pre-fix main, GREEN with the fix.
- [x] **prune-KEEPS-BASE** unit (multi-gen via name-reuse): `prune_below(7)` over gens {1,5,9} drops 1, keeps base 5 + above-floor 9.
- [x] **Boundary control**: a child created *after* the cut is undone (not resurrected from its post-cut generation).
- [x] **No regression**: full #2103/rewind/lineage/lifecycle/truncation suite (38 targeted) + full suite (7478 passed; the 4 failures are pre-existing env quirks — gateway entry-point + reyn.safe relocate — unrelated to this diff).
- [x] **CI gates**: ruff (full-tree `src tests scripts`), `test_tier_audit.py --strict` (3 OK), `verify_module_docstrings.py` all green.

Tracked under #2259; **not done until PR-2 (async-decoupled core) + PR-3 (recovery-semantics)** land. PR-2 then swaps the identity value-source (WAL-seq → in-memory-ID) reusing this generation store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)