### PR TITLE
feat(#2259 PR-2a): DurabilityWorker queue+drainer + §4 durable-write retry

### DIFF
--- a/src/reyn/core/events/durability_worker.py
+++ b/src/reyn/core/events/durability_worker.py
@@ -7,46 +7,144 @@ task (a coroutine that writes + ``await asyncio.to_thread(os.fsync, …)``), the
 serially, and ``submit`` awaits its completion — so the caller's durability contract is
 UNCHANGED (it returns only once durable) while the loop stays free DURING the fsync.
 
+#2259 PR-2a. The serial point evolved from an ``asyncio.Lock`` to a **queue + background
+drainer** — the structural prerequisite for the #2259 PR-2b non-blocking (fire-and-forget)
+submit — but BEHIND THE SAME ``submit``-awaits contract: ``submit`` enqueues a task + awaits a
+per-task future the drainer resolves, so enqueue order = durability order (FIFO) and the caller
+still returns only once durable (all callers untouched). PR-2a also adds the §4 durable-write
+RETRY: a transient ``OSError`` (disk full / EIO / a momentary fs hiccup) is retried with bounded
+exponential backoff; on retry-exhaustion the failure is PERSISTENT and re-raised to the submitter
+(fail-stop escalation — the same "a failure is re-raised here" contract, now after bounded retry).
+
 Substrate-agnostic by construction (P7): the worker holds no WAL / snapshot / workspace
 knowledge — the injected write callable carries all of it (including any post-write bookkeeping
 such as a durable-seq watermark). Its one structural guarantee is **serial FIFO**: tasks run
 one at a time in submit order, so *enqueue order = durability order*. That single ordering point
 is what later steps build on — the cross-substrate write-ahead ordering (a depended-upon
-substrate submitted before the WAL event that references it) and, in #1765 Step 2, non-blocking
+substrate submitted before the WAL event that references it) and, in #2259 PR-2b, non-blocking
 writes (``submit`` returns before the task runs, with a barrier awaiting only where an external
-effect is gated). For Step 1a ``submit`` always awaits (no relaxed-durability window).
+effect is gated). For PR-2a ``submit`` always awaits (no relaxed-durability window).
 """
 from __future__ import annotations
 
 import asyncio
 from typing import Awaitable, Callable
 
+from reyn.core.retry import backoff_s
+
 DurableWrite = Callable[[], Awaitable[None]]
+
+# §4 durable-write retry bounds (standard bounded exponential backoff; short — a durable write
+# is local I/O, not a network call). Persistent failure past these attempts = fail-stop escalate.
+_WRITE_RETRY_BASE_S = 0.05
+_WRITE_RETRY_MAX_S = 2.0
+_WRITE_MAX_ATTEMPTS = 5
 
 
 class DurabilityWorker:
     """A single serialisation point for off-loop durable writes (see module docstring).
 
-    Step 1a uses a fair ``asyncio.Lock`` as the serial point: ``submit`` acquires it (FIFO —
-    asyncio locks grant in acquisition order, so submit order = durability order), runs the
-    task (its ``await to_thread(os.fsync)`` keeps the loop free), and releases. No background
-    task → nothing to leak between event loops. Step 2 (non-blocking writes) evolves the
-    INTERNALS to a queue + drainer behind this SAME ``submit`` contract — so the substrate
-    routing built on it is not throwaway."""
+    The serial point is a queue drained by ONE background task: ``submit`` enqueues ``(task,
+    future)`` and awaits the future (FIFO — the drainer runs tasks in enqueue order, so submit
+    order = durability order), and the task's ``await to_thread(os.fsync)`` keeps the loop free;
+    other submits wait their turn. The queue + drainer are (re)bound lazily to the running loop
+    on first submit, so a default-constructed worker holds nothing until used and survives a
+    fresh event loop (tests / re-init) without leaking a stale task. #2259 PR-2b flips ``submit``
+    to non-blocking behind this SAME structure — so the substrate routing built on it is not
+    throwaway."""
 
-    def __init__(self) -> None:
-        self._lock = asyncio.Lock()
+    def __init__(
+        self, *, max_write_attempts: int = _WRITE_MAX_ATTEMPTS,
+        retry_base_s: float = _WRITE_RETRY_BASE_S, retry_max_s: float = _WRITE_RETRY_MAX_S,
+    ) -> None:
+        self._max_write_attempts = max_write_attempts
+        self._retry_base_s = retry_base_s
+        self._retry_max_s = retry_max_s
+        self._queue: "asyncio.Queue | None" = None
+        self._drainer: "asyncio.Task | None" = None
+        self._loop: "asyncio.AbstractEventLoop | None" = None
+
+    def _ensure_runtime(self) -> "asyncio.Queue":
+        """Bind (or rebind) the queue + drainer to the RUNNING loop. A new loop (a fresh test, a
+        re-init) gets a fresh queue + drainer — the old loop is gone, so its queue/task are inert
+        and dropped (in production there is one loop; any in-flight write already completed under
+        ``aclose``). Idempotent within a loop: a live drainer is reused."""
+        loop = asyncio.get_running_loop()
+        if self._loop is not loop:
+            self._queue = asyncio.Queue()
+            self._loop = loop
+            self._drainer = loop.create_task(self._drain())
+        elif self._drainer is None or self._drainer.done():
+            self._drainer = loop.create_task(self._drain())
+        assert self._queue is not None
+        return self._queue
 
     async def submit(self, do_durable_write: DurableWrite) -> None:
         """Run a durable-write task, serialised with every other submit (FIFO = durability
-        order), and AWAIT it (#1765 Step 1a — blocking: no relaxed-durability window). The
-        task's off-loop fsync keeps the event loop free for non-durability work; other submits
-        wait their turn. A failure inside the task is re-raised here (same as an inline write)."""
-        async with self._lock:
-            await do_durable_write()
+        order), and AWAIT it (#2259 PR-2a — blocking: no relaxed-durability window). The task's
+        off-loop fsync keeps the event loop free for non-durability work; other submits wait
+        their turn. A transient ``OSError`` is retried with bounded backoff (§4); on exhaustion
+        the persistent failure is re-raised here (same as an inline write, now after retry)."""
+        queue = self._ensure_runtime()
+        fut: "asyncio.Future[None]" = self._loop.create_future()  # type: ignore[union-attr]
+        queue.put_nowait((do_durable_write, fut))
+        await fut
+
+    async def _drain(self) -> None:
+        """The single background drainer: process ``(task, future)`` items one at a time in
+        enqueue order (FIFO = durability order), resolving each future with the task's result or
+        its (post-retry) failure. Runs until cancelled (``aclose`` / event-loop teardown).
+
+        ``CancelledError`` MUST propagate (terminate the drainer) — it is NOT a write failure.
+        Swallowing it (catching ``BaseException``) made the drainer immortal: a cancel landing
+        mid-write was caught, the loop continued to an empty ``get()``, and ``asyncio.run``'s
+        ``_cancel_all_tasks`` teardown then hung forever waiting for the task to finish. So a
+        cancel resolves the in-flight future (the submitter is unblocked) and re-raises; only a
+        real ``Exception`` (a write failure) is surfaced to the submitter."""
+        assert self._queue is not None
+        while True:
+            do_durable_write, fut = await self._queue.get()
+            try:
+                await self._run_with_retry(do_durable_write)
+            except asyncio.CancelledError:
+                if not fut.done():
+                    fut.cancel()
+                self._queue.task_done()
+                raise
+            except Exception as e:  # noqa: BLE001 — a real write failure → surface to the submitter
+                if not fut.done():
+                    fut.set_exception(e)
+                self._queue.task_done()
+            else:
+                if not fut.done():
+                    fut.set_result(None)
+                self._queue.task_done()
+
+    async def _run_with_retry(self, do_durable_write: DurableWrite) -> None:
+        """§4: run the durable write, retrying a TRANSIENT ``OSError`` with bounded exponential
+        backoff. On retry-exhaustion the failure is PERSISTENT → re-raise (fail-stop escalation).
+        A non-``OSError`` (a programming error — retrying cannot help) is raised immediately."""
+        attempt = 0
+        while True:
+            try:
+                await do_durable_write()
+                return
+            except OSError:
+                if attempt >= self._max_write_attempts - 1:
+                    raise  # persistent (retry-exhausted) → escalate to the submitter
+                await asyncio.sleep(
+                    backoff_s(attempt, base_s=self._retry_base_s, max_s=self._retry_max_s)
+                )
+                attempt += 1
 
     async def aclose(self) -> None:
-        """Graceful shutdown. No background task in Step 1a, so this only waits for any
-        in-flight submit to finish (acquire→release the lock); a no-op otherwise."""
-        async with self._lock:
+        """Graceful shutdown. Drain every enqueued task (so no in-flight write is lost), then
+        cancel the idle drainer. A no-op if never used (no loop bound)."""
+        if self._drainer is None or self._queue is None:
+            return
+        await self._queue.join()
+        self._drainer.cancel()
+        try:
+            await self._drainer
+        except asyncio.CancelledError:
             pass

--- a/src/reyn/core/retry.py
+++ b/src/reyn/core/retry.py
@@ -1,0 +1,29 @@
+"""Generic exponential-backoff timing — the single backoff formula shared across retry paths.
+
+#2259 PR-2a. The LLM-call retry (``reyn.llm.llm._backoff_s``) and the durability worker's
+durable-write retry (#2259 §4) need the SAME backoff curve; this is that one formula, parameter-
+ised so each caller injects its own base/cap/jitter (the LLM path from its ``RetryConfig``, the
+write path from the worker's bounds). One shared timing formula, no per-path reinvention.
+"""
+from __future__ import annotations
+
+import random
+
+
+def backoff_s(attempt: int, *, base_s: float, max_s: float, jitter: bool = True) -> float:
+    """Exponential backoff with optional equal jitter, capped at ``max_s``.
+
+    ``attempt`` is 0-indexed (attempt 0 = the first retry, after the initial call failed).
+    Pure exponential is ``base_s * 2**attempt`` capped at ``max_s``. With ``jitter`` (the
+    default), AWS-style equal jitter is applied: ``sleep = base/2 + uniform(0, base/2)`` — i.e.
+    a value in ``[base/2, base]`` — which decorrelates concurrent retriers. ``attempt < 0`` (a
+    defensive caller) yields a small non-negative wait, never a negative sleep.
+    """
+    exp = base_s * (2 ** attempt) if attempt >= 0 else base_s
+    base = min(exp, max_s)
+    if jitter:
+        return base / 2 + random.uniform(0, base / 2)
+    return base
+
+
+__all__ = ["backoff_s"]

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -3,7 +3,6 @@ import contextvars
 import json
 import logging
 import os
-import random
 import re
 import sys
 import uuid
@@ -835,11 +834,13 @@ def _backoff_s(attempt: int) -> float:
     ``attempt`` is 0-indexed (attempt 0 = first retry, after initial call fails).
     Min 0.0 — never negative on a negative index.
     """
-    base = min(_LLM_RETRY_BASE_S * (2 ** attempt), _LLM_RETRY_MAX_BACKOFF_S)
-    if _resolved_retry_config().jitter:
-        # Equal jitter: half fixed + half random. Range [base/2, base].
-        return base / 2 + random.uniform(0, base / 2)
-    return base
+    # #2259 PR-2a: the timing curve is the shared `backoff_s` formula (one formula across the
+    # LLM-call + durable-write retry paths); the LLM path injects its base/cap + config jitter.
+    from reyn.core.retry import backoff_s  # noqa: PLC0415
+    return backoff_s(
+        attempt, base_s=_LLM_RETRY_BASE_S, max_s=_LLM_RETRY_MAX_BACKOFF_S,
+        jitter=_resolved_retry_config().jitter,
+    )
 
 
 def _extract_retry_after(exc: BaseException) -> float | None:

--- a/tests/test_2259_pr2a_worker_retry.py
+++ b/tests/test_2259_pr2a_worker_retry.py
@@ -1,0 +1,159 @@
+"""Tier 2: #2259 PR-2a §4 — the DurabilityWorker durable-write RETRY (transient → escalate).
+
+The worker's §4 failure contract (owner-decided): a TRANSIENT durable-write failure (an
+``OSError`` — disk full / EIO / a momentary fs hiccup) is retried with bounded exponential
+backoff; a PERSISTENT failure (retry-exhausted) is re-raised to the submitter = fail-stop
+escalation. A non-``OSError`` (a programming error retrying cannot fix) is raised immediately.
+The serial-FIFO ordering (enqueue order = durability order) holds even while a task is retrying
+— a retry occupies the single drainer, so the next task waits.
+
+Real DurabilityWorker (no mocks); plain async callables are the injected write tasks, with
+small injected retry bounds + fast backoff for speed. The existing #1765 worker tests cover the
+unchanged contract (FIFO / submit-awaits / loop-free / failure-surfaces) under the new
+queue+drainer internals; this file covers the NEW retry behaviour.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from reyn.core.events.durability_worker import DurabilityWorker
+
+
+def _fast_worker(max_attempts: int) -> DurabilityWorker:
+    return DurabilityWorker(
+        max_write_attempts=max_attempts, retry_base_s=0.001, retry_max_s=0.005,
+    )
+
+
+@pytest.mark.asyncio
+async def test_transient_oserror_is_retried_then_succeeds():
+    """Tier 2: a transient OSError is retried until the write succeeds — submit does NOT raise.
+    RED if the worker did not retry (the first OSError would surface as a spurious failure)."""
+    w = _fast_worker(max_attempts=4)
+    attempts = {"n": 0}
+
+    async def _flaky() -> None:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise OSError("transient disk hiccup")
+        # succeeds on the 3rd attempt
+
+    await w.submit(_flaky)  # must NOT raise — the transient failure was retried away
+    assert attempts["n"] == 3, "the transient OSError must be retried until it succeeds"
+    await w.aclose()
+
+
+@pytest.mark.asyncio
+async def test_persistent_oserror_escalates_after_bounded_retries():
+    """Tier 2: a PERSISTENT OSError (always failing) is retried a BOUNDED number of times, then
+    re-raised to the submitter = fail-stop escalation. RED if it retried forever (no bound) or
+    did not retry at all (escalated on the first failure)."""
+    w = _fast_worker(max_attempts=5)
+    attempts = {"n": 0}
+
+    async def _always_fail() -> None:
+        attempts["n"] += 1
+        raise OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        await w.submit(_always_fail)
+    assert attempts["n"] == 5, "exactly max_write_attempts tries, THEN escalate (persistent)"
+    await w.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_oserror_is_not_retried():
+    """Tier 2: a non-OSError (a programming bug — retrying cannot help) is raised IMMEDIATELY,
+    not retried. RED if the worker retried it (wasting the bounded budget on an unfixable bug)."""
+    w = _fast_worker(max_attempts=5)
+    attempts = {"n": 0}
+
+    async def _bug() -> None:
+        attempts["n"] += 1
+        raise ValueError("a programming error")
+
+    with pytest.raises(ValueError, match="a programming error"):
+        await w.submit(_bug)
+    assert attempts["n"] == 1, "a non-OSError must fail fast (single attempt, no retry)"
+    await w.aclose()
+
+
+@pytest.mark.asyncio
+async def test_worker_survives_an_escalation_and_serves_the_next():
+    """Tier 2: after a persistent failure escalates, the drainer keeps serving — the next task
+    runs. RED if the escalation killed the drainer (a failed write would wedge all durability)."""
+    w = _fast_worker(max_attempts=2)
+
+    async def _always_fail() -> None:
+        raise OSError("disk full")
+
+    with pytest.raises(OSError):
+        await w.submit(_always_fail)
+
+    ran = False
+
+    async def _ok() -> None:
+        nonlocal ran
+        ran = True
+
+    await w.submit(_ok)  # the drainer survived the escalation
+    assert ran is True
+    await w.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fifo_preserved_across_a_retrying_task():
+    """Tier 2: serial-FIFO holds even while a task is retrying — the retry occupies the single
+    drainer, so a later-submitted task runs only AFTER the retrying task completes. RED if a
+    retry yielded the drainer to the next task (reordering durability)."""
+    w = _fast_worker(max_attempts=4)
+    order: list[str] = []
+    first = {"n": 0}
+
+    async def _retries_then_ok() -> None:
+        first["n"] += 1
+        if first["n"] < 3:
+            raise OSError("hiccup")
+        order.append("a")
+
+    async def _b() -> None:
+        order.append("b")
+
+    ta = asyncio.create_task(w.submit(_retries_then_ok))
+    await asyncio.sleep(0)  # let `a` enqueue first (FIFO setup)
+    tb = asyncio.create_task(w.submit(_b))
+    await asyncio.gather(ta, tb)
+    assert order == ["a", "b"], "a retrying task still completes before the next (serial FIFO)"
+    await w.aclose()
+
+
+def test_loop_teardown_with_inflight_write_does_not_hang():
+    """Tier 2: ``asyncio.run`` teardown (``_cancel_all_tasks``) must TERMINATE the background
+    drainer even when it is cancelled MID-WRITE — the drainer must propagate ``CancelledError``,
+    not swallow it + loop forever. This reproduces the full-suite hang (test_a2a_restart_resume's
+    teardown hung in ``_cancel_all_tasks`` → ``select`` forever): a fire-and-forget submit leaves
+    the drainer inside a still-running write when the loop tears down. Run in a daemon thread
+    with a join timeout so a REGRESSION fails fast (assert) instead of hanging the suite."""
+    def _run() -> None:
+        async def _body() -> None:
+            w = DurabilityWorker()
+
+            async def _slow() -> None:
+                await asyncio.sleep(30)  # still running when the loop tears down
+
+            asyncio.ensure_future(w.submit(_slow))  # fire-and-forget → drainer goes mid-write
+            await asyncio.sleep(0.05)               # let the drainer enter the write
+            # return WITHOUT aclose → asyncio.run runs _cancel_all_tasks → must not hang
+
+        asyncio.run(_body())
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout=10)
+    assert not t.is_alive(), (
+        "event-loop teardown HUNG — the drainer swallowed CancelledError + looped on an empty "
+        "queue, so _cancel_all_tasks never completed (the full-suite hang regression)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #2259 PR-2a (first of the 2-way PR-2 split: worker internals + §4, **no contract change**). PR-2b will be the load-bearing async-decoupling contract diff.

## What

The DurabilityWorker serial point evolves from an `asyncio.Lock` to a **queue + background drainer** (the structural prerequisite for PR-2b's non-blocking submit) — but **behind the SAME submit-awaits contract**: `submit` enqueues `(task, future)` and awaits a per-task future the drainer resolves, so enqueue order = durability order (FIFO) and the caller still returns only once durable. All 15 Class-A callers are untouched and green **by construction** (the existing #1765 worker tests pass unchanged).

Plus the **§4 durable-write retry** (owner-decided): a transient `OSError` → bounded exponential backoff; persistent (retry-exhausted) → re-raised = fail-stop escalation; a non-`OSError` (a bug) → fail-fast. The backoff curve is the generic `backoff_s` formula (new `src/reyn/core/retry.py`), shared with `llm._backoff_s` (one formula, no reinvention — the owner's constraint).

## Files
- `src/reyn/core/retry.py` (new) — generic `backoff_s(attempt, *, base_s, max_s, jitter)`.
- `src/reyn/core/events/durability_worker.py` — queue + drainer + §4 retry.
- `src/reyn/llm/llm.py` — `_backoff_s` delegates to `backoff_s` (drops the now-unused `random` import).
- `tests/test_2259_pr2a_worker_retry.py` (new) — §4 + the teardown-hang regression.

## A hang bug, found + fixed in-PR (owner-caught during review)
The first full-suite run **hung** (`test_a2a_restart_resume`'s `asyncio.run` teardown stuck in `_cancel_all_tasks → select` forever). Root cause (faulthandler dump): the drainer caught `CancelledError` (via `except BaseException`), so a cancel landing **mid-write** was swallowed, the loop continued to an empty `get()`, and `_cancel_all_tasks` waited forever. **Fix:** the drainer catches only `Exception` (real write failures → the submitter) and **re-raises `CancelledError`** (after resolving the in-flight future) so it terminates. Regression test runs the teardown in a daemon thread with a join timeout so any regression **fails fast** instead of hanging the suite.

## Test plan
- [x] **Contract preserved by construction**: the 4 existing #1765 worker tests (FIFO / submit-awaits / loop-free / failure-surfaces) green under the new internals — the zero-caller-change claim is proven, not asserted.
- [x] **§4 retry matrix** (5 tests): transient-OSError-retried-then-succeeds / persistent-escalates-after-bounded-N / non-OSError-fast-fail / drainer-survives-an-escalation-and-serves-next / FIFO-preserved-across-a-retrying-task.
- [x] **Teardown-hang regression**: `asyncio.run` teardown terminates a mid-write drainer (daemon-thread + join-timeout → fails fast on regression). Reproduced the original hang pre-fix; green post-fix.
- [x] **The previously-hung `test_a2a_restart_resume_292.py`** now passes.
- [x] **121 LLM retry/backoff tests** green after the `_backoff_s` refactor.
- [x] **Full suite**: 7484 passed, no hang (271s, was hanging 44+ min), faulthandler safety-net 0 timeouts; the 4 failures are pre-existing env quirks (gateway entry-point + reyn.safe relocate), unrelated to this diff.
- [x] **CI gates**: ruff full-tree, `test_tier_audit.py --strict` (6 OK), `verify_module_docstrings.py` green.

Tracked under #2259; **PR-2b** (the async-decoupling contract change) is the load-bearing piece next, then **PR-3** (recovery-semantics) closes #2259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)