### PR TITLE
[tui-coder] feat(inline-cui): markdown LLM output + reserved 2-cell marker gutter + user-input block

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -247,21 +247,26 @@ _CC_ACCENT = "#d97757"  # terracotta
 _CC_DIM = "#6b7280"
 _CC_DONE = "#7ee787"
 _CC_ERR = "#f97066"
+# Subtle background block behind the user's own submitted line (CC styles the
+# user input differently from agent output — a faint highlighted block).
+_CC_USER_BG = "#2b2f37"
 
 # Braille spinner frames for the working indicator (bottom toolbar).
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
-# Per-kind leading marker for the inline CC-style stream. The agent / skill /
-# intervention lines lead with ⏺; tool/trace detail lines lead with ⎿; the user's
-# own submitted line is echoed with the > input marker.
-_CC_MARKER = {
-    "user": " > ",
-    "agent": " ⏺ ",
-    "status": " · ",
-    "error": " ✗ ",
-    "intervention": " ⏺ ",
-    "trace": "   ⎿ ",
-    "skill_done": " ⏺ ",
+# Per-kind line layout: (gutter, gutter_style, body_style). A CC-style 2-cell
+# marker gutter (glyph + space) sits in its own column so a wrapped / multi-line
+# body hang-indents into the body column and never bleeds into the gutter. The
+# agent (LLM) body is rendered as markdown (body_style then unused). Tool-result /
+# trace ⎿ rows nest one level under the parent body column (2-space indent + ⎿).
+_KIND_LINE = {
+    "user":         ("> ",   _CC_ACCENT, _CC_DIM),
+    "agent":        ("⏺ ",   _CC_ACCENT, ""),
+    "status":       ("· ",   _CC_DIM,    _CC_DIM),
+    "error":        ("✗ ",   _CC_ERR,    _CC_ERR),
+    "intervention": ("⏺ ",   _CC_ACCENT, "bold"),
+    "trace":        ("  ⎿ ", _CC_DIM,    _CC_DIM),
+    "skill_done":   ("⏺ ",   _CC_DONE,   ""),
 }
 
 
@@ -328,55 +333,81 @@ def _summarize_result(tool, result) -> str:
     return _short(result, 80)
 
 
-def format_inline_message(msg: OutboxMessage):
-    """Pure formatter: OutboxMessage → rich Text (the inline CC-style line).
+def _gutter_grid(gutter: str, gutter_style: str, body, *, row_style: str = "",
+                 expand: bool = False):
+    """A 2-column grid: a reserved marker gutter + a wrapping body column.
 
-    Kept separate from rendering so the kind→marker+text mapping is testable on
-    the public `.plain` surface without driving a live terminal.
+    Continuation lines of a wrapped / multi-line body stay in the body column, so
+    the CC-style gutter (glyph + space) is never bled into — unlike a single Text
+    that wraps back to column 0. ``row_style`` paints a background behind the whole
+    line; ``expand`` stretches the body column to the full width so that background
+    fills the line edge-to-edge (the user-input block).
+    """
+    from rich.table import Table
+    from rich.text import Text
+    g = Text(gutter, style=gutter_style)
+    grid = Table.grid(padding=0, expand=expand)
+    grid.add_column(width=g.cell_len, no_wrap=True)
+    grid.add_column(ratio=1 if expand else None)
+    grid.add_row(g, body, style=row_style or None)
+    return grid
+
+
+def _body_renderable(kind: str, text: str, body_style: str):
+    """The body cell: markdown for agent (LLM) output, a styled Text otherwise."""
+    from rich.markdown import Markdown
+    from rich.text import Text
+    if kind == "agent":
+        # Render the LLM reply as markdown (headings / bold / lists / code) like
+        # Claude Code, instead of showing the raw markdown source.
+        return Markdown(text or "")
+    return Text(text, style=body_style)
+
+
+def format_inline_message(msg: OutboxMessage):
+    """Pure formatter: OutboxMessage → a rich renderable (the inline CC-style line).
+
+    A 2-cell marker gutter (glyph + space) sits in its own column; the body wraps
+    in a second column so multi-line / wrapped output hang-indents under the body
+    and never bleeds into the gutter. The agent (LLM) body renders as markdown; the
+    user's own line gets a faint background block. Kept separate from rendering so
+    the mapping stays testable.
     """
     from rich.text import Text
     kind = msg.kind
     meta = msg.meta or {}
 
-    # Tool-call rows. The tool_call_* OutboxMessages arrive already in the pipe
-    # (ChatLifecycleForwarder); meta carries tool / args / result / error.
-    # PR2 renders every tool call; a noise filter (skip low-level read ops) is a
-    # tracked follow-up if dogfood shows it's too chatty (see #2198).
+    # Tool-call rows. The ⎿ result / failure rows nest one level under the ⏺ call
+    # (2-space indent), so they read as sub-items of the call above them.
     if kind == "tool_call_started":
         tool = str(meta.get("tool", msg.text))
         args = _summarize_args(meta.get("args"))
-        return Text.assemble(
-            (" ⏺ ", _CC_ACCENT), (tool, "bold"), (f"({args})", _CC_DIM)
-        )
+        body = Text.assemble((tool, "bold"), (f"({args})", _CC_DIM))
+        return _gutter_grid("⏺ ", _CC_ACCENT, body)
     if kind == "tool_call_completed":
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
-        return Text.assemble(("   ⎿ ", _CC_DIM), (summary, _CC_DIM))
+        return _gutter_grid("  ⎿ ", _CC_DIM, Text(summary, style=_CC_DIM))
     if kind == "tool_call_failed":
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
-        return Text.assemble(
-            ("   ⎿ ✗ ", _CC_ERR), (_short(err, 80), _CC_ERR)
-        )
+        return _gutter_grid("  ⎿ ", _CC_ERR, Text(f"✗ {_short(err, 80)}", style=_CC_ERR))
 
-    text = f"{_meta_prefix(meta)}{msg.text}"
-    marker = _CC_MARKER.get(kind)
-    if marker is None:
-        return Text(text)
+    line = _KIND_LINE.get(kind)
+    if line is None:
+        return Text(f"{_meta_prefix(meta)}{msg.text}")
+    gutter, gutter_style, body_style = line
+    # A provenance prefix ([skill#id]) is kept inline (rare for agent replies); it
+    # renders as literal text inside the agent markdown body.
+    body_text = f"{_meta_prefix(meta)}{msg.text}"
     if kind == "user":
-        # The user's own submitted line, echoed into the scrollback (the inline
-        # input field clears on submit, so without this the message vanishes).
-        return Text.assemble((marker, _CC_ACCENT), (text, _CC_DIM))
-    if kind == "agent":
-        return Text.assemble((marker, _CC_ACCENT), (text, ""))
-    if kind == "status":
-        return Text.assemble((marker, _CC_DIM), (text, _CC_DIM))
-    if kind == "error":
-        return Text.assemble((marker, _CC_ERR), (text, _CC_ERR))
-    if kind == "intervention":
-        return Text.assemble((marker, _CC_ACCENT), (text, "bold"))
-    if kind == "trace":
-        return Text.assemble((marker, _CC_DIM), (text, _CC_DIM))
-    # skill_done
-    return Text.assemble((marker, _CC_DONE), (text, ""))
+        # The user's own submitted line: echoed into scrollback (the inline input
+        # clears on submit) AND given a faint background block so it reads as a
+        # distinct "you said this" line, like Claude Code.
+        bg = f"on {_CC_USER_BG}"
+        return _gutter_grid(
+            gutter, f"{gutter_style} {bg}",
+            Text(body_text, style=f"{body_style} {bg}"), row_style=bg, expand=True,
+        )
+    return _gutter_grid(gutter, gutter_style, _body_renderable(kind, body_text, body_style))
 
 
 class InlineChatRenderer(ChatRenderer):

--- a/tests/test_inline_pr2_tool_rows.py
+++ b/tests/test_inline_pr2_tool_rows.py
@@ -6,7 +6,10 @@ public surfaces (`.plain`, `bottom_toolbar()`), not whitespace or private state.
 """
 from __future__ import annotations
 
+import io
 from datetime import datetime, timezone
+
+from rich.console import Console
 
 from reyn.interfaces.repl.renderer import (
     InlineChatRenderer,
@@ -17,9 +20,12 @@ from reyn.schemas.models import Event
 
 
 def _plain(kind: str, text: str, meta: dict) -> str:
-    return format_inline_message(
-        OutboxMessage(kind=kind, text=text, meta=meta)
-    ).plain
+    """Render a message to plain text — the renderable is now a gutter grid (not a
+    bare Text), so we render it to assert the marker/content contract. Wide width
+    avoids wrapping confounding the one-line assertions."""
+    console = Console(width=120, file=io.StringIO(), color_system=None)
+    console.print(format_inline_message(OutboxMessage(kind=kind, text=text, meta=meta)))
+    return console.file.getvalue()
 
 
 def test_tool_started_shows_dot_tool_and_args() -> None:
@@ -52,9 +58,9 @@ def test_long_result_is_truncated_to_one_line() -> None:
     """Tier 2: an overlong / multiline result is collapsed to a one-line summary."""
     out = _plain("tool_call_completed", "web_search",
                  {"tool": "web_search", "result": "x" * 500 + "\nsecond line"})
-    assert "\n" not in out          # collapsed to one line
-    assert "…" in out               # and truncated
-    assert "second line" not in out  # the tail past the cap is dropped
+    assert out.strip().count("\n") == 0  # collapsed to one rendered line
+    assert "…" in out                    # and truncated
+    assert "second line" not in out      # the tail past the cap is dropped
 
 
 def test_started_with_no_args_renders_empty_parens() -> None:

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -1,11 +1,16 @@
 """Tier 2: inline CC-style renderer — kind→marker+text contract + factory wiring.
 
 The inline renderer is the default interactive `reyn chat` surface after the
-Textual cutover. These assert the OutboxMessage→line mapping on the public
-`.plain` surface (markers present, text preserved, meta prefix applied) — not
-exact whitespace, so formatting tweaks don't break the test.
+Textual cutover. Each message renders as a 2-cell marker gutter + a wrapping body
+column (the agent body as markdown); these assert the rendered-text contract
+(markers present, text preserved, meta prefix applied, gutter reserved on wrap,
+markdown parsed) — not exact whitespace, so formatting tweaks don't break them.
 """
 from __future__ import annotations
+
+import io
+
+from rich.console import Console
 
 from reyn.interfaces.cli.logger_factory import (
     make_chat_renderer,
@@ -20,10 +25,52 @@ from reyn.interfaces.repl.renderer import (
 from reyn.runtime.outbox import OutboxMessage
 
 
-def _plain(kind: str, text: str, meta: dict | None = None) -> str:
-    return format_inline_message(
-        OutboxMessage(kind=kind, text=text, meta=meta or {})
-    ).plain
+def _plain(kind: str, text: str, meta: dict | None = None, *, width: int = 80) -> str:
+    """Render a message to plain text. The renderable is now a gutter grid (not a
+    bare Text), so we render it through a Console to assert the marker/body
+    contract on the visible output."""
+    console = Console(width=width, file=io.StringIO(), color_system=None)
+    console.print(format_inline_message(OutboxMessage(kind=kind, text=text, meta=meta or {})))
+    return console.file.getvalue()
+
+
+def _render_ansi(kind: str, text: str, *, width: int = 30) -> str:
+    """Render with truecolor ANSI on, to assert styling (e.g. the user-input
+    background block emits a ``48;2;`` background SGR)."""
+    console = Console(width=width, file=io.StringIO(), force_terminal=True,
+                      color_system="truecolor")
+    console.print(format_inline_message(OutboxMessage(kind=kind, text=text)))
+    return console.file.getvalue()
+
+
+def test_agent_body_renders_markdown_not_raw_source() -> None:
+    """Tier 2: the agent (LLM) body renders as markdown — **bold** becomes styled
+    text (the ** source is consumed) and list items become bullets, like CC."""
+    out = _plain("agent", "Some **bold** words:\n- one\n- two")
+    assert "**" not in out          # markdown parsed, not shown as raw source
+    assert "bold" in out
+    assert "one" in out and "two" in out
+    assert "•" in out               # list rendered as bullets
+
+
+def test_wrapped_agent_body_hang_indents_clear_of_the_gutter() -> None:
+    """Tier 2: a wrapped body continues INDENTED in the body column, never bleeding
+    back into the 2-cell marker gutter (the reserved-gutter contract)."""
+    out = _plain("agent", "word " * 40, width=40)
+    lines = [ln for ln in out.split("\n") if ln.strip()]
+    # a wrapped continuation line exists, indented into the body column with no
+    # marker → the long body did wrap AND hang-indented clear of the gutter
+    assert any(c.startswith("  ") and "⏺" not in c for c in lines)
+    # the marker only ever LEADS a line (it never appears inside the body / in the
+    # gutter of a continuation line)
+    assert all(("⏺" not in c) or c.startswith("⏺") for c in lines)
+
+
+def test_user_line_carries_a_background_block() -> None:
+    """Tier 2: the user's own line gets a background block (CC-style 'you said
+    this' design); the plain agent line does not."""
+    assert "48;2;" in _render_ansi("user", "my message")      # bg SGR present
+    assert "48;2;" not in _render_ansi("agent", "plain reply")  # none on agent
 
 
 def test_user_echo_leads_with_input_marker_and_keeps_text() -> None:


### PR DESCRIPTION
**[tui-coder]** — three owner-requested CC-style rendering upgrades to the inline message line, all contained in `format_inline_message`.

## What (owner asks)

1. **Markdown LLM output** — the agent (LLM) body renders through `rich.markdown` (headings / bold / lists / code) instead of showing raw markdown source. (`**bold**` was printing literally before.)
2. **Reserved 2-cell marker gutter** — every line is now a 2-column grid: a fixed **2-cell** gutter (glyph + space, per CC — shrunk from the old 3-cell `" ⏺ "`) + a wrapping body column. A wrapped / multi-line body **hang-indents in the body column and never bleeds into the marker gutter**. (Before: a single `Text` wrapped to column 0, so continuation lines sat under the marker.)
3. **User-input block** — the user's echoed line gets a faint **full-width background block** (`expand=True` grid + row bg) — a distinct "you said this" design like CC, instead of plain dim text.

Tool-result `⎿` rows nest one level under the parent `⏺` call.

## How

`format_inline_message` now returns a gutter-grid renderable (was a bare `Text`). Two small helpers: `_gutter_grid(gutter, style, body, *, row_style, expand)` and `_body_renderable(kind, text, style)` (markdown for agent, styled `Text` otherwise). Per-kind layout moved into a `_KIND_LINE` table.

Only `console.print` (renderable-agnostic) + the two renderer test files consume `format_inline_message`, so the return-type change is contained.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean (rephrased a size-pin to a behavioral assert)
- [x] Renderer/inline/repl regression: 113 passed, 2 skipped
- [x] New behavioral tests: markdown parsed (`**` consumed, lists→bullets), wrapped body hang-indents clear of the gutter (marker only ever leads a line), user line carries a `48;2;` background SGR the agent line does not
- [x] **Live tmux (litellm proxy)** — primary evidence:
  ```
  > Reply in GitHub markdown only: a level-2 heading "Fruits", one sentence with
    the word delicious in bold, then a bullet list of apple, banana, cherry.
  ⏺ Fruits

    This is delicious!

     • apple
     • banana
     • cherry
  > Reply with exactly: hello world
  ⏺ hello world
  ```
  Markdown renders (heading / bold consumed / bullets); the user continuation line hang-indents to col 2 (gutter reserved); a plain reply stays a clean single line.

## Notes

- `rich.markdown` inserts blank lines between blocks (heading→para→list), so multi-block replies are slightly airy; single-paragraph replies have no extra spacing. Tightening that is a possible follow-up if the owner wants it more compact.
- The user-bg block colour isn't visible in a plain tmux text capture; it's unit-asserted (`48;2;` SGR) + smoke-confirmed full-width, and visible on a truecolor terminal.

## Tier self-check

Tier 2: real `OutboxMessage` rendered through a `Console`, behavioral asserts on the visible output (markers / text / markdown / hang-indent / bg SGR), no mocks, no size/whitespace pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
