### PR TITLE
[tui-coder] feat(inline-cui): slash-command autocomplete + context-aware Down key

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -23,11 +23,14 @@ import time
 
 from prompt_toolkit.application import Application, get_app
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.filters import Condition, has_focus
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.filters import Condition, has_completions, has_focus
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import (
     ConditionalContainer,
+    Float,
+    FloatContainer,
     HSplit,
     Layout,
     VSplit,
@@ -35,6 +38,7 @@ from prompt_toolkit.layout import (
 )
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.inline.intervention_region import build_intervention_element
@@ -44,8 +48,32 @@ from reyn.interfaces.inline.region_command import (
     build_rewind_command_ui,
 )
 from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
+from reyn.interfaces.slash import slash_command_completions
 
 logger = logging.getLogger(__name__)
+
+
+class _SlashCompleter(Completer):
+    """Autocomplete a leading ``/command`` token from the slash registry.
+
+    Only the command word is completed — once a space is typed (args begin) the
+    completer goes quiet, so ``/model standard`` doesn't keep suggesting commands.
+    Each completion shows ``/name`` with the command's one-line summary as meta.
+    """
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        if not text.startswith("/") or " " in text:
+            return
+        prefix = text[1:]
+        for name, summary in slash_command_completions(prefix):
+            yield Completion(
+                name, start_position=-len(prefix),
+                display=f"/{name}", display_meta=summary,
+            )
+
+
+_SLASH_COMPLETER = _SlashCompleter()
 
 # Status-row chips, in display order.
 _CHIPS = ["model", "agents", "skills", "cost", "ctx"]
@@ -183,7 +211,10 @@ async def run_inline_input(registry, renderer) -> None:
     """
     attached = registry.attached_session()
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
-    buf = Buffer(multiline=False, history=history)
+    buf = Buffer(
+        multiline=False, history=history,
+        completer=_SLASH_COMPLETER, complete_while_typing=True,
+    )
     # sel: which chip; open: detail/picker shown. The dropdown's selectable
     # cursor lives in `menu_region` (the below-input Region hosting the opened
     # chip's element), not here — the same selection mechanism as the above-input
@@ -334,9 +365,17 @@ async def run_inline_input(registry, renderer) -> None:
             registry.repl_outbox.put_nowait(OutboxMessage(kind="user", text=stripped))
             event.app.create_background_task(_submit(registry, stripped))
 
-    @kb.add("down", filter=has_focus(input_win))
-    def _to_menu(event) -> None:
-        event.app.layout.focus(status_win)
+    @kb.add("down", filter=has_focus(input_win) & ~has_completions)
+    def _down(event) -> None:
+        # With text in the box, ↓ is history navigation (forward, shell-like) so
+        # it doesn't yank focus away mid-edit. With an empty box, ↓ drops into the
+        # status menu (its discoverable affordance). ↑ stays history either way.
+        # Gated on ~has_completions so that while the slash menu is open ↓ falls
+        # through to the default binding (navigate the completion list).
+        if buf.text:
+            buf.history_forward()
+        else:
+            event.app.layout.focus(status_win)
 
     def _actionable_open() -> bool:
         # Open AND the opened chip's element is the selectable model picker (a
@@ -497,8 +536,17 @@ async def run_inline_input(registry, renderer) -> None:
         [working, above_region_box, top_rule, inputrow, bottom_rule, status_win,
          dropdown]
     )
+    # FloatContainer so the slash-command completions menu can float at the cursor
+    # (typing `/` opens it; ↑↓ navigate, Tab/Enter accept — see _SlashCompleter).
+    root = FloatContainer(
+        content=body,
+        floats=[Float(
+            xcursor=True, ycursor=True,
+            content=CompletionsMenu(max_height=8, scroll_offset=1),
+        )],
+    )
     app: Application = Application(
-        layout=Layout(body, focused_element=input_win),
+        layout=Layout(root, focused_element=input_win),
         key_bindings=kb,
         full_screen=False,
         refresh_interval=0.1,

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -160,6 +160,25 @@ def suggest_for_unknown(cmd: str, *, names: list[str] | None = None) -> list[str
     return out
 
 
+def slash_command_completions(
+    prefix: str, *, commands: "list[SlashCommand] | None" = None
+) -> list[tuple[str, str]]:
+    """``(name, summary)`` pairs for the inline ``/`` autocomplete.
+
+    Returns non-hidden commands whose name starts with ``prefix`` (the text typed
+    after the leading ``/``), sorted by name. Hidden commands (donut / matrix /
+    zen) are still dispatchable by name but never surface in the completion menu.
+    Pure (no I/O) so it's directly testable.
+    """
+    cmds = commands if commands is not None else REGISTRY.all_commands()
+    out = [
+        (c.name, c.summary)
+        for c in cmds
+        if not c.hidden and c.name.startswith(prefix)
+    ]
+    return sorted(out)
+
+
 # ── decorator ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_slash_command_completions.py
+++ b/tests/test_slash_command_completions.py
@@ -1,0 +1,53 @@
+"""Tier 2: ``slash_command_completions`` — the inline CUI's ``/`` autocomplete.
+
+Typing ``/`` in the inline input opens a completions menu fed by this helper:
+non-hidden commands whose name starts with the typed prefix, each with its
+one-line summary. Hidden easter-egg commands stay dispatchable by name but never
+surface in the menu. Pure registry query, asserted on the public surface.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash import SlashCommand, slash_command_completions
+
+
+async def _noop(session, args) -> None:  # pragma: no cover - fixture handler
+    return None
+
+
+_FIXTURE = [
+    SlashCommand(name="model", summary="Override the model class", handler=_noop),
+    SlashCommand(name="memory", summary="Memory ops", handler=_noop),
+    SlashCommand(name="agents", summary="List agents", handler=_noop),
+    SlashCommand(name="zen", summary="easter egg", handler=_noop, hidden=True),
+]
+
+
+def test_prefix_filters_and_carries_the_summary() -> None:
+    """Tier 2: only commands whose name starts with the prefix are returned, each
+    paired with its summary."""
+    out = slash_command_completions("m", commands=_FIXTURE)
+    names = [n for n, _ in out]
+    assert "model" in names and "memory" in names
+    assert "agents" not in names                       # prefix filtered out
+    assert dict(out)["model"] == "Override the model class"
+
+
+def test_hidden_commands_never_surface() -> None:
+    """Tier 2: hidden commands are excluded even with an empty prefix (they stay
+    dispatchable by name, just not offered in the menu)."""
+    names = [n for n, _ in slash_command_completions("", commands=_FIXTURE)]
+    assert "zen" not in names
+    assert "model" in names and "agents" in names
+
+
+def test_no_prefix_match_yields_nothing() -> None:
+    """Tier 2: a prefix matching no command returns an empty list (menu closes)."""
+    assert slash_command_completions("zzz", commands=_FIXTURE) == []
+
+
+def test_live_registry_smoke() -> None:
+    """Tier 2: against the live REGISTRY, ``/mo`` offers ``model`` and the hidden
+    easter eggs (donut / matrix / zen) never appear."""
+    assert "model" in [n for n, _ in slash_command_completions("mo")]
+    allnames = [n for n, _ in slash_command_completions("")]
+    assert not ({"donut", "matrix", "zen"} & set(allnames))


### PR DESCRIPTION
**[tui-coder]** — two owner-flagged inline-input UX fixes (given together; coupled because the Down gating depends on whether the completion menu is open).

## What

1. **Slash autocomplete** (owner: "補完が出てこない") — typing `/` never opened a completions menu because the input `Buffer` had no `completer` and the layout had no menu float. Now:
   - `_SlashCompleter` yields non-hidden commands whose name matches the typed prefix, each as `/name` + its one-line summary (`display_meta`), backed by a pure `slash_command_completions(prefix)` registry query.
   - Wired via `Buffer(completer=…, complete_while_typing=True)` + a `CompletionsMenu` `Float` at the cursor.
   - Hidden easter eggs (donut / matrix / zen) stay dispatchable by name but never surface in the menu.
2. **Context-aware Down** (owner: text→history, empty→menu) — `↓` always jumped focus to the status menu. Now: with text in the box `↓` navigates input history (forward, shell-like); only an **empty** box drops into the status menu. Gated on `~has_completions` so while the slash menu is open `↓` falls through to navigate the completion list (and `↑` stays history either way).

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] `slash_command_completions` unit tests (prefix filter, hidden excluded, summary carried, empty→[], live-registry smoke) + inline/slash/repl regression: 326 passed
- [x] **Live tmux**: `/` opens the menu (`/agent`, `/agents`, … + summaries); `/mo` filters to `/model  Show or override the model class…`; `↓` on an empty box focuses the status menu (hint flips to `[↑ input · ←→ …]`); `↓` with text "abc" stays in the input (hint stays `[↓ menu · ↑ hist…]`, no menu jump)

## Note

The key bindings + completions menu are interactive (a live prompt_toolkit Application), so they're verified live rather than unit-tested; only the pure `slash_command_completions` query is unit-pinned — matching how the inline app's other bindings are validated.

## Tier self-check

Tier 2: `slash_command_completions` asserted on the public surface with real `SlashCommand` fixtures + the live registry; membership/exclusion asserts, no mocks, no size/format pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
