### PR TITLE
[tui-coder] feat(inline-cui): distinct per-kind markers + importance-tiered body colour

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -243,10 +243,12 @@ class RichChatRenderer(ChatRenderer):
 
 
 # Claude Code-style accent palette (matches the validated mock).
-_CC_ACCENT = "#d97757"  # terracotta
-_CC_DIM = "#6b7280"
-_CC_DONE = "#7ee787"
-_CC_ERR = "#f97066"
+_CC_ACCENT = "#d97757"  # terracotta — the assistant
+_CC_DIM = "#6b7280"     # low-importance / ambient text
+_CC_DONE = "#7ee787"    # green — completion
+_CC_ERR = "#f97066"     # red — failure
+_CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act
+_CC_USER = "#6cb6ff"    # cool blue — the user's own input marker (vs warm assistant)
 # Subtle background block behind the user's own submitted line (CC styles the
 # user input differently from agent output — a faint highlighted block).
 _CC_USER_BG = "#2b2f37"
@@ -259,14 +261,21 @@ _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # body hang-indents into the body column and never bleeds into the gutter. The
 # agent (LLM) body is rendered as markdown (body_style then unused). Tool-result /
 # trace ⎿ rows nest one level under the parent body column (2-space indent + ⎿).
+#
+# Glyph + colour vary by kind so the eye distinguishes them at a glance, and the
+# body colour encodes importance: HIGH-importance kinds (agent reply, an
+# intervention that needs an answer, an error) keep full-strength body text, while
+# low-importance / ambient kinds (a finished skill, status, trace, tool detail)
+# dim their body text. Distinct glyphs: ⏺ assistant · ◆ needs-you · ✗ error ·
+# ✓ done · > you · · status · ⎿ detail.
 _KIND_LINE = {
-    "user":         ("> ",   _CC_ACCENT, _CC_DIM),
-    "agent":        ("⏺ ",   _CC_ACCENT, ""),
-    "status":       ("· ",   _CC_DIM,    _CC_DIM),
-    "error":        ("✗ ",   _CC_ERR,    _CC_ERR),
-    "intervention": ("⏺ ",   _CC_ACCENT, "bold"),
-    "trace":        ("  ⎿ ", _CC_DIM,    _CC_DIM),
-    "skill_done":   ("⏺ ",   _CC_DONE,   ""),
+    "user":         ("> ",   _CC_USER,   _CC_DIM),   # your input  (cool, + bg block)
+    "agent":        ("⏺ ",   _CC_ACCENT, ""),        # LLM reply   [HIGH] markdown body
+    "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   [HIGH] amber + bold
+    "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # failure     [HIGH] red
+    "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # completed   [low]  dim body
+    "status":       ("· ",   _CC_DIM,    _CC_DIM),   # ambient     [low]
+    "trace":        ("  ⎿ ", _CC_DIM,    _CC_DIM),   # detail      [low]  nested
 }
 
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -103,10 +103,11 @@ def test_trace_line_uses_corner_marker() -> None:
     assert "phase started" in out
 
 
-def test_skill_done_leads_with_dot_marker() -> None:
-    """Tier 2: a skill_done line leads with the ⏺ marker."""
+def test_skill_done_leads_with_check_marker() -> None:
+    """Tier 2: a finished skill leads with the ✓ completion marker (distinct from
+    the ⏺ assistant marker), and keeps its text."""
     out = _plain("skill_done", "skill finished")
-    assert "⏺" in out
+    assert "✓" in out
     assert "skill finished" in out
 
 
@@ -114,6 +115,17 @@ def test_intervention_keeps_question_text() -> None:
     """Tier 2: an intervention line preserves the question text."""
     out = _plain("intervention", "Which file?")
     assert "Which file?" in out
+
+
+def test_kinds_use_distinct_markers() -> None:
+    """Tier 2: message kinds carry distinct glyphs so the eye separates them — the
+    assistant ⏺ is not reused for an intervention (◆) or a finished skill (✓)."""
+    agent = _plain("agent", "x")
+    interv = _plain("intervention", "x")
+    done = _plain("skill_done", "x")
+    assert "⏺" in agent
+    assert "◆" in interv and "⏺" not in interv
+    assert "✓" in done and "⏺" not in done
 
 
 def test_unknown_kind_renders_text_without_marker() -> None:


### PR DESCRIPTION
**[tui-coder]** — owner-flagged: the markers were monotonous (agent / intervention / skill_done all used `⏺`); vary glyph + colour per kind, and dim low-importance message text.

## What

Each kind now carries a distinct glyph + colour, and the **body text colour encodes importance**:

| kind | glyph | colour | importance / body |
|---|---|---|---|
| agent reply | `⏺` | accent | HIGH — full-strength markdown body |
| intervention (needs you) | `◆` | **amber** (new) | HIGH — bold body |
| error | `✗` | red | HIGH |
| finished skill | `✓` | green | low — **dim body** (was `⏺` + full) |
| your input | `>` | **cool blue** (new) | + bg block, distinct from warm assistant |
| status / trace | `·` / `⎿` | dim | low / ambient |

Two palette colours added: `_CC_WARN` (amber, interventions) and `_CC_USER` (cool, the user marker). The `⏺`-overload is resolved — `⏺` is now only the assistant (agent reply + tool calls, CC-faithful); interventions and finished skills get their own glyphs.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] Renderer/inline regression: 110 passed, 2 skipped. Updated the skill_done assertion (`⏺`→`✓`); added a test pinning that the assistant `⏺` is not reused for an intervention (`◆`) or a finished skill (`✓`)
- [x] **Live tmux**: a `/model expensive` cost-warn confirm now leads with `◆` (was `⏺`), visibly distinct from the agent's `⏺` reply above it

## Notes

- Colours aren't visible in a plain tmux text capture (the glyph change is); amber/cool/dim are unit-asserted where styling matters and visible on a truecolor terminal.
- `✓` skill_done is unit-tested (a skill-completion event is awkward to trigger on demand live).
- This stacks cleanly on the merged markdown/gutter renderer (#2265) — same `_KIND_LINE` table, contained to `renderer.py` + its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
