### PR TITLE
[tui-coder] feat(inline-cui): ❯ prompt/echo, distinct tool glyph, state-driven colour, message spacing

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -252,7 +252,7 @@ async def run_inline_input(registry, renderer) -> None:
     top_rule = Window(height=1, char="─", style=f"fg:{_CC_DIM}")
     bottom_rule = Window(height=1, char="─", style=f"fg:{_CC_DIM}")
     prompt_sym = Window(
-        FormattedTextControl([(f"fg:{_CC_ACCENT} bold", "> ")]), width=2, height=1
+        FormattedTextControl([(f"fg:{_CC_ACCENT} bold", "❯ ")]), width=2, height=1
     )
     input_win = Window(BufferControl(buffer=buf), height=1)
     inputrow = VSplit([prompt_sym, input_win])

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -245,7 +245,7 @@ class RichChatRenderer(ChatRenderer):
 # Claude Code-style palette. Default is plain text (_CC_TEXT); colour is reserved
 # to signal STATE — error (red), needs-action (amber), done (green), ambient/low
 # (dim) — so a coloured glyph always means "something to notice".
-_CC_TEXT = "#e6edf3"    # default near-white — normal text + markers
+_CC_TEXT = "default"    # terminal default fg — normal text + markers (no forced colour)
 _CC_DIM = "#6b7280"     # low-importance / ambient
 _CC_DONE = "#7ee787"    # green — completion
 _CC_ERR = "#f97066"     # red — failure
@@ -287,11 +287,20 @@ _NESTED_KINDS = frozenset({"tool_call_completed", "tool_call_failed", "trace"})
 def wants_separator(kind: str, seen_message: bool) -> bool:
     """Pure: whether a blank line should precede this message in the scrollback.
 
-    One blank line separates top-level message blocks (user / agent / tool call /
-    status / …) for breathing room, but never before a nested ⎿ detail row (which
-    belongs to the block above it) or before the very first message.
+    One blank line separates top-level message blocks for breathing room, but not:
+    - before the very first message;
+    - before a nested ⎿ detail row (it belongs to the block above it);
+    - before a TRANSIENT status/trace line. A transient is cleared in place by the
+      next message, so a separator before it would be orphaned as a stray blank.
+      This is what made an agent reply show two blanks: the per-turn "thinking…"
+      status got a separator, was cleared, and left its blank behind — then the
+      reply added its own. Skipping transients leaves exactly one.
     """
-    return seen_message and kind not in _NESTED_KINDS
+    return (
+        seen_message
+        and kind not in _NESTED_KINDS
+        and kind not in _TRANSIENT_KINDS
+    )
 
 
 def _short(v, n: int = 60) -> str:

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -242,13 +242,15 @@ class RichChatRenderer(ChatRenderer):
         self._flush()
 
 
-# Claude Code-style accent palette (matches the validated mock).
-_CC_ACCENT = "#d97757"  # terracotta — the assistant
-_CC_DIM = "#6b7280"     # low-importance / ambient text
+# Claude Code-style palette. Default is plain text (_CC_TEXT); colour is reserved
+# to signal STATE — error (red), needs-action (amber), done (green), ambient/low
+# (dim) — so a coloured glyph always means "something to notice".
+_CC_TEXT = "#e6edf3"    # default near-white — normal text + markers
+_CC_DIM = "#6b7280"     # low-importance / ambient
 _CC_DONE = "#7ee787"    # green — completion
 _CC_ERR = "#f97066"     # red — failure
 _CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act
-_CC_USER = "#6cb6ff"    # cool blue — the user's own input marker (vs warm assistant)
+_CC_ACCENT = "#d97757"  # terracotta — spinner / accents
 # Subtle background block behind the user's own submitted line (CC styles the
 # user input differently from agent output — a faint highlighted block).
 _CC_USER_BG = "#2b2f37"
@@ -262,21 +264,34 @@ _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # agent (LLM) body is rendered as markdown (body_style then unused). Tool-result /
 # trace ⎿ rows nest one level under the parent body column (2-space indent + ⎿).
 #
-# Glyph + colour vary by kind so the eye distinguishes them at a glance, and the
-# body colour encodes importance: HIGH-importance kinds (agent reply, an
-# intervention that needs an answer, an error) keep full-strength body text, while
-# low-importance / ambient kinds (a finished skill, status, trace, tool detail)
-# dim their body text. Distinct glyphs: ⏺ assistant · ◆ needs-you · ✗ error ·
-# ✓ done · > you · · status · ⎿ detail.
+# Glyphs are distinct per kind so the eye separates them; colour is reserved for
+# STATE — default near-white (_CC_TEXT), then amber=needs-you, red=error,
+# green=done, dim=ambient/low — so a coloured glyph always signals something to
+# notice. Distinct glyphs: ⏺ assistant · ❯ you · ▸ tool · ◆ needs-you · ✗ error ·
+# ✓ done · · status · ⎿ detail.
 _KIND_LINE = {
-    "user":         ("> ",   _CC_USER,   _CC_DIM),   # your input  (cool, + bg block)
-    "agent":        ("⏺ ",   _CC_ACCENT, ""),        # LLM reply   [HIGH] markdown body
-    "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   [HIGH] amber + bold
-    "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # failure     [HIGH] red
-    "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # completed   [low]  dim body
-    "status":       ("· ",   _CC_DIM,    _CC_DIM),   # ambient     [low]
+    "user":         ("❯ ",   _CC_TEXT,   _CC_DIM),   # your input  (white, + bg block)
+    "agent":        ("⏺ ",   _CC_TEXT,   _CC_TEXT),  # normal reply — default white
+    "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   — amber
+    "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # error       — red
+    "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # done        — green glyph, dim body
+    "status":       ("· ",   _CC_DIM,    _CC_DIM),   # ambient     — dim
     "trace":        ("  ⎿ ", _CC_DIM,    _CC_DIM),   # detail      [low]  nested
 }
+
+# ⎿ detail rows nest under the line above them, so no blank-line separator goes
+# before these — a tool call and its result stay grouped as one block.
+_NESTED_KINDS = frozenset({"tool_call_completed", "tool_call_failed", "trace"})
+
+
+def wants_separator(kind: str, seen_message: bool) -> bool:
+    """Pure: whether a blank line should precede this message in the scrollback.
+
+    One blank line separates top-level message blocks (user / agent / tool call /
+    status / …) for breathing room, but never before a nested ⎿ detail row (which
+    belongs to the block above it) or before the very first message.
+    """
+    return seen_message and kind not in _NESTED_KINDS
 
 
 def _short(v, n: int = 60) -> str:
@@ -386,13 +401,13 @@ def format_inline_message(msg: OutboxMessage):
     kind = msg.kind
     meta = msg.meta or {}
 
-    # Tool-call rows. The ⎿ result / failure rows nest one level under the ⏺ call
-    # (2-space indent), so they read as sub-items of the call above them.
+    # Tool-call rows. ▸ marks an invocation (distinct from the ⏺ assistant reply);
+    # the ⎿ result / failure rows nest one level under it (2-space indent).
     if kind == "tool_call_started":
         tool = str(meta.get("tool", msg.text))
         args = _summarize_args(meta.get("args"))
         body = Text.assemble((tool, "bold"), (f"({args})", _CC_DIM))
-        return _gutter_grid("⏺ ", _CC_ACCENT, body)
+        return _gutter_grid("▸ ", _CC_TEXT, body)
     if kind == "tool_call_completed":
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
         return _gutter_grid("  ⎿ ", _CC_DIM, Text(summary, style=_CC_DIM))
@@ -442,6 +457,9 @@ class InlineChatRenderer(ChatRenderer):
             highlight=False, file=self._buffer, force_terminal=True,
         )
         self._transient_active = False
+        # True once any message has been rendered → drives the blank-line separator
+        # between message blocks (none before the first).
+        self._seen_message = False
         # Working-indicator state, driven by on_chat_event (turn_started/completed).
         self._thinking = False
         self._think_start = 0.0
@@ -498,12 +516,15 @@ class InlineChatRenderer(ChatRenderer):
 
     def message(self, msg: OutboxMessage) -> None:
         self._clear_transient()
+        if wants_separator(msg.kind, self._seen_message):
+            self._console.print()  # blank line between message blocks
         self._console.print(format_inline_message(msg))
+        self._seen_message = True
         self._flush()
         self._transient_active = msg.kind in _TRANSIENT_KINDS
 
     def prompt_text(self) -> AnyFormattedText:
-        return HTML(f'<style fg="{_CC_ACCENT}"><b>&gt;</b></style> ')
+        return HTML(f'<style fg="{_CC_ACCENT}"><b>❯</b></style> ')
 
     def cost_summary(self, usage: TokenUsage, cost_usd: float | None) -> None:
         self._clear_transient()

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -265,13 +265,13 @@ _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # trace ⎿ rows nest one level under the parent body column (2-space indent + ⎿).
 #
 # Glyphs are distinct per kind so the eye separates them; colour is reserved for
-# STATE — default near-white (_CC_TEXT), then amber=needs-you, red=error,
+# STATE — default terminal fg (_CC_TEXT), then amber=needs-you, red=error,
 # green=done, dim=ambient/low — so a coloured glyph always signals something to
 # notice. Distinct glyphs: ⏺ assistant · ❯ you · ▸ tool · ◆ needs-you · ✗ error ·
 # ✓ done · · status · ⎿ detail.
 _KIND_LINE = {
-    "user":         ("❯ ",   _CC_TEXT,   _CC_DIM),   # your input  (white, + bg block)
-    "agent":        ("⏺ ",   _CC_TEXT,   _CC_TEXT),  # normal reply — default white
+    "user":         ("❯ ",   _CC_TEXT,   _CC_DIM),   # your input  (default fg, + bg block)
+    "agent":        ("⏺ ",   _CC_TEXT,   _CC_TEXT),  # normal reply — terminal default fg
     "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   — amber
     "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # error       — red
     "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # done        — green glyph, dim body

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3910,9 +3910,12 @@ class Session:
             "user_message_received", text=text, chain_id=chain_id,
             media_block_count=len(attached_media),
         )
-        await self._put_outbox(OutboxMessage(
-            kind="status", text="thinking…", meta={"chain_id": chain_id},
-        ))
+        # NOTE: no "thinking…" status is emitted here. The turn-in-progress signal
+        # is the event-driven working indicator (turn_started → turn_settled, via
+        # ChatRenderer.on_chat_event), so a separate "thinking…" status line is a
+        # redundant double-display (the inline CUI showed both "· thinking…" and
+        # the "Working…" spinner). It was also the source of an orphaned blank line
+        # before each reply (a cleared transient leaving its separator behind).
 
         # Reset the per-turn router cap counter at the top of each fresh
         # user turn. Subsequent in-chain re-invocations (agent_response on

--- a/tests/test_inline_pr2_tool_rows.py
+++ b/tests/test_inline_pr2_tool_rows.py
@@ -28,11 +28,12 @@ def _plain(kind: str, text: str, meta: dict) -> str:
     return console.file.getvalue()
 
 
-def test_tool_started_shows_dot_tool_and_args() -> None:
-    """Tier 2: tool_call_started → ⏺ marker + tool name + arg summary."""
+def test_tool_started_shows_invoke_marker_tool_and_args() -> None:
+    """Tier 2: tool_call_started → ▸ invocation marker (distinct from the ⏺
+    assistant reply) + tool name + arg summary."""
     out = _plain("tool_call_started", "read_file",
                  {"tool": "read_file", "args": {"path": "docs/x.md"}})
-    assert "⏺" in out
+    assert "▸" in out
     assert "read_file" in out
     assert "docs/x.md" in out
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -21,6 +21,7 @@ from reyn.interfaces.repl.renderer import (
     ConsoleChatRenderer,
     InlineChatRenderer,
     format_inline_message,
+    wants_separator,
 )
 from reyn.runtime.outbox import OutboxMessage
 
@@ -74,11 +75,11 @@ def test_user_line_carries_a_background_block() -> None:
 
 
 def test_user_echo_leads_with_input_marker_and_keeps_text() -> None:
-    """Tier 2: the user's own submitted line is echoed with the > input marker
-    and its text — so the message stays visible in the conversation after the
-    inline input field clears on submit."""
+    """Tier 2: the user's own submitted line is echoed with the ❯ input marker
+    (same chevron CC uses for the prompt) and its text — so the message stays
+    visible in the conversation after the inline input field clears on submit."""
     out = _plain("user", "what files changed?")
-    assert ">" in out
+    assert "❯" in out
     assert "what files changed?" in out
 
 
@@ -119,13 +120,26 @@ def test_intervention_keeps_question_text() -> None:
 
 def test_kinds_use_distinct_markers() -> None:
     """Tier 2: message kinds carry distinct glyphs so the eye separates them — the
-    assistant ⏺ is not reused for an intervention (◆) or a finished skill (✓)."""
+    assistant ⏺ is not reused for an intervention (◆), a finished skill (✓), or a
+    tool invocation (▸)."""
     agent = _plain("agent", "x")
     interv = _plain("intervention", "x")
     done = _plain("skill_done", "x")
+    tool = _plain("tool_call_started", "", {"tool": "Bash", "args": {}})
     assert "⏺" in agent
     assert "◆" in interv and "⏺" not in interv
     assert "✓" in done and "⏺" not in done
+    assert "▸" in tool and "⏺" not in tool
+
+
+def test_wants_separator_between_blocks_not_before_nested_or_first() -> None:
+    """Tier 2: a blank line separates top-level message blocks (but not before the
+    first), and never before a nested ⎿ detail row (tool result / trace) — so a
+    tool call and its result stay grouped."""
+    assert wants_separator("agent", seen_message=False) is False          # first
+    assert wants_separator("agent", seen_message=True) is True            # block gap
+    assert wants_separator("tool_call_completed", seen_message=True) is False  # nested
+    assert wants_separator("trace", seen_message=True) is False           # nested detail
 
 
 def test_unknown_kind_renders_text_without_marker() -> None:

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -132,14 +132,16 @@ def test_kinds_use_distinct_markers() -> None:
     assert "▸" in tool and "⏺" not in tool
 
 
-def test_wants_separator_between_blocks_not_before_nested_or_first() -> None:
+def test_wants_separator_skips_first_nested_and_transient() -> None:
     """Tier 2: a blank line separates top-level message blocks (but not before the
-    first), and never before a nested ⎿ detail row (tool result / trace) — so a
-    tool call and its result stay grouped."""
-    assert wants_separator("agent", seen_message=False) is False          # first
-    assert wants_separator("agent", seen_message=True) is True            # block gap
+    first); never before a nested ⎿ detail row (tool result), nor before a
+    TRANSIENT status/trace — a transient is cleared in place, so a separator before
+    it would orphan as a stray blank (the old 2-blank-before-reply bug)."""
+    assert wants_separator("agent", seen_message=False) is False           # first
+    assert wants_separator("agent", seen_message=True) is True             # block gap
     assert wants_separator("tool_call_completed", seen_message=True) is False  # nested
-    assert wants_separator("trace", seen_message=True) is False           # nested detail
+    assert wants_separator("status", seen_message=True) is False           # transient
+    assert wants_separator("trace", seen_message=True) is False            # transient+nested
 
 
 def test_unknown_kind_renders_text_without_marker() -> None:


### PR DESCRIPTION
**[tui-coder]** — owner-directed visual refinements toward Claude Code (rapid live feedback this session). Updated after revisions d7de4f3e + the comment-alignment commit.

## What

- **`❯` chevron** — the user echo marker AND the input prompt use `❯` (the wider chevron CC uses for both "You" and the prompt), replacing `>`.
- **Tool invocation glyph** — `tool_call_started` leads with `▸` (an invocation), distinct from the `⏺` assistant reply.
- **State-driven colour** — default is the **terminal default fg** (`_CC_TEXT="default"` — owner: "白そのものよりデフォルト色"); colour is reserved to **signal state**: amber = needs-you (intervention), red = error, green = done, dim = ambient/low. A coloured glyph always means "something to notice".
- **One blank line between message blocks** — `wants_separator(kind, seen)`; never before the first message, a nested `⎿` detail row, or a **transient** status/trace.
- **Removed the redundant `thinking…` status** (`session.py`) — owner: "thinking… と Working… 二重表示、意味がわからない". It double-displayed with the event-driven `Working…` spinner AND, as a cleared transient, orphaned a blank line before every reply. The working indicator is now the sole in-progress signal.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] Renderer/inline/session/repl regression: 399 passed, 2 skipped. Updated glyph assertions (`>`→`❯`, tool `⏺`→`▸`), distinct-markers guard, `wants_separator` (skips first/nested/**transient**)
- [x] **Live tmux**: `❯` prompt + echo; `▸` tool rows; **exactly one** blank line between the user line and the reply; **no `thinking…` line** (spinner is the sole in-progress cue)

## Notes

- **`session.py` touch** (the `thinking…` removal): a clean removal of one UI status emission — no OS logic, no P6 event change (`user_message_received` still fires), no P7 concern. lead-coder judged it fine in this PR (no OS-coder review needed).
- **`--cui` follow-up**: `ConsoleChatRenderer` (no working indicator) loses its only in-flight cue with `thinking…` gone — the plain fallback path. Tracked in **#2269** (roi:low) to give `--cui` its own indicator if wanted.
- The 2-blank-before-reply originally flagged here is **root-fixed** in d7de4f3e (not a disclosed-accept).

## Stacking

Builds on the merged renderer (#2265/#2267) — same `_KIND_LINE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)