### PR TITLE
[tui-coder] feat(inline-cui): shimmer the working indicator (moving light across "Working…")

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -158,16 +158,28 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
     """Pure: working-row fragments while a turn runs (empty list when idle).
 
     The spinner frame derives from `now` so it advances smoothly regardless of
-    refresh jitter; elapsed is whole seconds since `think_start`.
+    refresh jitter; elapsed is whole seconds since `think_start`. The label carries
+    a shimmer — a bright crest sweeping left→right across the text (a moving light)
+    over a dim base, also clock-driven so it animates on each refresh.
     """
     if not thinking:
         return []
     frame = _SPINNER[int(now * 8) % len(_SPINNER)]
     elapsed = max(0, int(now - think_start))
-    return [
-        (f"fg:{_CC_ACCENT}", f" {frame} "),
-        (f"fg:{_CC_DIM}", f"Working… {elapsed}s"),
-    ]
+    label = f"Working… {elapsed}s"
+    frags = [(f"fg:{_CC_ACCENT}", f" {frame} ")]
+    # The crest sweeps across the label then pauses in a short trailing gap before
+    # restarting, so the light reads as a repeating left→right pass.
+    head = int(now * 16) % (len(label) + 6)
+    for i, ch in enumerate(label):
+        offset = head - i
+        if offset == 0:
+            frags.append((f"fg:{_CC_ACCENT} bold", ch))   # bright crest
+        elif offset == 1:
+            frags.append((f"fg:{_CC_ACCENT}", ch))         # trailing glow
+        else:
+            frags.append((f"fg:{_CC_DIM}", ch))            # dim base
+    return frags
 
 
 def _snapshot(registry):

--- a/tests/test_inline_pr3a_app.py
+++ b/tests/test_inline_pr3a_app.py
@@ -48,6 +48,21 @@ def test_working_line_never_negative_elapsed() -> None:
     assert "-" not in text
 
 
+def test_working_line_has_a_moving_shimmer_crest() -> None:
+    """Tier 2: the label carries a bright shimmer crest whose position sweeps with
+    the clock (it animates), not a static dim line."""
+    def crest_char(now: float):
+        # The crest is the lone bold fragment among the label characters.
+        for style, text in working_line(True, 0.0, now):
+            if "bold" in style and text.strip():
+                return text
+        return None
+    c0 = crest_char(0.0)    # head at char 0
+    c1 = crest_char(0.10)   # head advances → crest on a later char
+    assert c0 is not None and c1 is not None  # a crest exists (shimmer present)
+    assert c0 != c1                            # and it moved (animated)
+
+
 def test_inline_renderer_selects_app_input() -> None:
     """Tier 2: the interactive inline renderer drives input via its own app."""
     assert InlineChatRenderer().uses_app_input() is True


### PR DESCRIPTION
**[tui-coder]** — owner ask: the in-progress indicator should be a spinner (it already is) with the text "色付き＋光移動" (coloured text + moving light).

## What

`working_line` now renders the `Working… Ns` label with a **bright accent crest that sweeps left→right** across it (a moving light) over a dim base — clock-driven like the spinner, so it animates on each refresh. The spinner glyph is unchanged; the label is split per-character to place the moving crest, then it pauses briefly in a trailing gap before restarting.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] `test_inline_pr3a_app.py` — 8 passed. New test: the shimmer crest's char position differs across two clock samples (it animates), and a crest is present while thinking. Existing spinner/label/elapsed assertions hold (joined text unchanged)
- [ ] **Owner live-check**: the shimmer animation + colour are only visible on a live terminal (a static capture shows neither the per-frame motion nor the colour). Pacing/colour tunable on feedback.

## Notes

- This is the working-indicator half of the owner's marker/colour feedback (the marker/colour/spacing half landed in #2268).
- `--cui` follow-up (#2269, give `ConsoleChatRenderer` its own in-flight indicator) is separate; this PR is the inline app's `working_line` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
