### PR TITLE
[tui-coder] feat(inline-cui): status-bar ChipSpec framework + 5-chip │ layout (#2271 Phase 1)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
+from typing import Callable
 
 from prompt_toolkit.application import Application, get_app
 from prompt_toolkit.buffer import Buffer
@@ -75,57 +77,66 @@ class _SlashCompleter(Completer):
 
 _SLASH_COMPLETER = _SlashCompleter()
 
-# Status-row chips, in display order.
-_CHIPS = ["model", "agents", "skills", "cost", "ctx"]
-# Chips whose dropdown is an actionable picker (↑↓ a row, enter applies) rather
-# than a read-only detail panel. Today only the model picker.
-_ACTIONABLE = frozenset({"model"})
 
+@dataclass(frozen=True)
+class ChipSpec:
+    """One status-bar chip: label + live value + optional expansion element.
 
-def is_actionable_picker(label: str, model_classes) -> bool:
-    """Pure: whether a chip's open dropdown is an actionable picker right now.
-
-    The model chip is a picker only when it actually has classes to pick; with
-    none configured its dropdown is the read-only current-model fallback, which
-    has no selectable rows — so no cursor must be drawn on it (otherwise the
-    fallback lines look selectable but Enter does nothing).
+    The status bar renders by iterating the registered specs, so a new chip is one
+    spec — no per-chip branching in the renderer or key bindings. ``expansion`` is
+    called with ``(snapshot, dispatch)`` and returns a region element (DetailElement
+    / CommandUIElement / future Tree/Toggle), or None for a value-only chip.
     """
-    return label in _ACTIONABLE and bool(model_classes)
+
+    key: str
+    label: str
+    value: Callable[[dict], str]
+    expansion: "Callable[[dict, Callable[[str], None]], object] | None" = None
 
 
-def build_status_dropdown_element(label: str, *, snapshot_fn, on_submit):
-    """Build the region element for an opened status chip's dropdown.
+def _model_expansion(snap, dispatch):
+    classes = list(snap.get("model_classes") or [])
+    if not classes:
+        return DetailElement(lambda: [f"current: {snap['model']}", "change with /model"])
+    model = snap["model"]
+    rows = [f"▸ {c}" if c == model else f"  {c}" for c in classes]
+    return CommandUIElement(rows, [f"/model {c}" for c in classes], dispatch)
 
-    The model chip with configured classes → a :class:`CommandUIElement` picker
-    (each row submits ``/model <class>`` through the normal slash path — cost-warn
-    confirm + budget rebuild reused), so it shares the region's selection
-    mechanism with the /rewind picker and interventions. Every other chip (and
-    the model chip with no classes) → a read-only :class:`DetailElement` whose
-    rows are recomputed live from ``snapshot_fn`` (so cost / ctx / agents stay
-    current while the panel is open) and carry no cursor.
-    """
-    snap = snapshot_fn()
-    classes = list(snap["model_classes"]) if snap else []
-    if is_actionable_picker(label, classes):
-        rows = dropdown_lines(
-            label, model=snap["model"], agent_names=snap["agent_names"],
-            attached_name=snap["attached_name"], skill_run_ids=snap["skill_run_ids"],
-            usage=snap["usage"], cost_usd=snap["cost_usd"], model_classes=classes,
-        )
-        submit_texts = [f"/model {c}" for c in classes]
-        return CommandUIElement(rows, submit_texts, on_submit)
 
-    def detail_lines() -> list:
-        s = snapshot_fn()
-        if s is None:
-            return []
-        return dropdown_lines(
-            label, model=s["model"], agent_names=s["agent_names"],
-            attached_name=s["attached_name"], skill_run_ids=s["skill_run_ids"],
-            usage=s["usage"], cost_usd=s["cost_usd"], model_classes=s["model_classes"],
-        )
+def _cost_expansion(snap, dispatch):
+    def lines():
+        p, c, t = snap["usage"]
+        return [
+            f"total    ${snap['cost_usd']:.4f}",
+            f"tokens   prompt {p} · completion {c} · total {t}",
+        ]
+    return DetailElement(lines)
 
-    return DetailElement(detail_lines)
+
+def _agent_expansion(snap, dispatch):
+    # Phase 1: read-only agent list. Phase 2 = agent/session tree + attach switch.
+    def lines():
+        names = snap["agent_names"]
+        if not names:
+            return ["(none)"]
+        attached = snap["attached_name"]
+        return [f"▸ {n}" if n == attached else f"  {n}" for n in names]
+    return DetailElement(lines)
+
+
+def _task_expansion(snap, dispatch):
+    # Phase 1: count only. Phase 3 = task tree.
+    n = snap.get("task_count", 0)
+    return DetailElement(lambda: [f"{n} active task{'' if n == 1 else 's'}"])
+
+
+_CHIP_SPECS = [
+    ChipSpec("model", "model", lambda s: str(s["model"]), _model_expansion),
+    ChipSpec("cost",  "cost",  lambda s: f"${s['cost_usd']:.4f}", _cost_expansion),
+    ChipSpec("agent", "agent", lambda s: str(s["attached_name"] or "—"), _agent_expansion),
+    ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion),
+    ChipSpec("more",  "",      lambda s: "…", None),   # overflow submenu — Phase 5
+]
 
 
 def working_line(thinking: bool, think_start: float, now: float) -> list:
@@ -144,48 +155,6 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
     ]
 
 
-def status_chips(model: str, n_agents: int, n_skills: int, cost_usd: float,
-                 total_tokens: int) -> list:
-    """Pure: (label, value) status chips from plain live values."""
-    ctx = f"{total_tokens // 1000}k" if total_tokens >= 1000 else str(total_tokens)
-    return [
-        ("model", str(model)),
-        ("agents", str(n_agents)),
-        ("skills", str(n_skills)),
-        ("cost", f"${cost_usd:.4f}"),
-        ("ctx", ctx),
-    ]
-
-
-def dropdown_lines(label: str, *, model: str, agent_names: list, attached_name,
-                   skill_run_ids: list, usage: tuple, cost_usd: float,
-                   model_classes: list | None = None) -> list:
-    """Pure: detail/picker lines for an opened status chip.
-
-    Lines starting with ``▸`` mark the focused/attached/current entry. `usage` is
-    ``(prompt, completion, total)`` token counts. For ``model`` the lines are the
-    selectable classes (current marked ``▸``); with no configured classes it
-    falls back to the read-only current-model hint.
-    """
-    if label == "agents":
-        if not agent_names:
-            return ["(none)"]
-        return [f"▸ {n}" if n == attached_name else f"  {n}" for n in agent_names]
-    if label == "skills":
-        return [f"  {r}" for r in skill_run_ids] or ["(no running skills)"]
-    if label in ("cost", "ctx"):
-        p, c, t = usage
-        return [
-            f"prompt {p}", f"completion {c}", f"total {t}",
-            f"cost ${cost_usd:.4f}",
-        ]
-    if label == "model":
-        if not model_classes:
-            return [f"current: {model}", "change with /model"]
-        return [f"▸ {c}" if c == model else f"  {c}" for c in model_classes]
-    return ["(no detail)"]
-
-
 def _snapshot(registry):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
@@ -200,6 +169,7 @@ def _snapshot(registry):
         "skill_run_ids": list(s.running_skills.keys()),
         "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
         "cost_usd": s.total_cost_usd,
+        "task_count": 0,
     }
 
 
@@ -261,23 +231,26 @@ async def run_inline_input(registry, renderer) -> None:
         snap = _snapshot(registry)
         if snap is None:
             return [(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]
-        chips = status_chips(
-            snap["model"], len(snap["agent_names"]), len(snap["skill_run_ids"]),
-            snap["cost_usd"], snap["usage"][2],
-        )
         focused = get_app().layout.has_focus(status_win)
         frags: list = []
-        for i, (label, val) in enumerate(chips):
-            open_mark = " ▾" if (focused and menu["open"] and i == menu["sel"]) else ""
-            text = f" {label} {val}{open_mark} "
-            if focused and i == menu["sel"]:
+        for i, spec in enumerate(_CHIP_SPECS):
+            val = spec.value(snap)
+            if spec.label:
+                text = f" {spec.label} {val} "
+            else:
+                text = f" {val} "
+            selected = focused and i == menu["sel"]
+            if selected and menu["open"]:
+                text = text.rstrip() + " ▾ "
+            if selected:
                 frags.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", text))
             else:
                 frags.append((f"fg:{_CC_DIM}", text))
-            frags.append(("", " "))
+            if i < len(_CHIP_SPECS) - 1:
+                frags.append((f"fg:{_CC_DIM}", "│"))
         if not focused:
             hint = "  [↓ menu · ↑ history · /quit]"
-        elif menu["open"] and _CHIPS[menu["sel"]] in _ACTIONABLE:
+        elif menu["open"] and menu_region.cursor_on_selectable:
             hint = "  [↑↓ select · enter switch · esc close]"
         elif menu["open"]:
             hint = "  [esc / ↑ close]"
@@ -379,14 +352,10 @@ async def run_inline_input(registry, renderer) -> None:
 
     def _actionable_open() -> bool:
         # Open AND the opened chip's element is the selectable model picker (a
-        # CommandUIElement). Mirrors build_status_dropdown_element: only the model
-        # chip WITH configured classes builds a picker — every other chip (and the
-        # model chip with none) is a read-only DetailElement.
-        if not menu["open"]:
-            return False
-        snap = _snapshot(registry)
-        classes = snap["model_classes"] if snap else []
-        return is_actionable_picker(_CHIPS[menu["sel"]], classes)
+        # CommandUIElement). Check the live menu_region cursor state — a selectable
+        # element (CommandUIElement with classes) reports True; a read-only
+        # DetailElement always reports False.
+        return menu["open"] and menu_region.cursor_on_selectable
 
     def _menu_submit(text: str) -> None:
         # A picker row was selected → close the menu and run /model <class> via the
@@ -397,15 +366,12 @@ async def run_inline_input(registry, renderer) -> None:
     def _menu_open() -> None:
         # Build the opened chip's element fresh and host it in menu_region. The
         # picker rows are static (classes); a read-only panel's lines stay live.
-        menu["open"] = True
+        spec = _CHIP_SPECS[menu["sel"]]
         menu_region.clear()
-        menu_region.register(
-            build_status_dropdown_element(
-                _CHIPS[menu["sel"]],
-                snapshot_fn=lambda: _snapshot(registry),
-                on_submit=_menu_submit,
-            )
-        )
+        if spec.expansion is not None:
+            el = spec.expansion(_snapshot(registry), _menu_submit)
+            menu_region.register(el)
+        menu["open"] = True
 
     def _menu_close() -> None:
         menu["open"] = False
@@ -437,12 +403,12 @@ async def run_inline_input(registry, renderer) -> None:
     @kb.add("left", filter=has_focus(status_win))
     def _menu_left(event) -> None:
         if not menu["open"]:
-            menu["sel"] = (menu["sel"] - 1) % len(_CHIPS)
+            menu["sel"] = (menu["sel"] - 1) % len(_CHIP_SPECS)
 
     @kb.add("right", filter=has_focus(status_win))
     def _menu_right(event) -> None:
         if not menu["open"]:
-            menu["sel"] = (menu["sel"] + 1) % len(_CHIPS)
+            menu["sel"] = (menu["sel"] + 1) % len(_CHIP_SPECS)
 
     @kb.add("enter", filter=has_focus(status_win))
     def _menu_enter(event) -> None:

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -1,159 +1,222 @@
-"""Tier 2: inline status-menu pure builders — chips + dropdown lines + picker.
+"""Tier 2: ChipSpec framework — spec registry + expansion builders.
 
-The navigable menu / focus handling is interactive (verified live, e2e); here we
-pin the pure data→display mapping that feeds the status row, each chip's detail
-dropdown, and the model picker's row→/model command. Plain-value inputs keep
-these decoupled from the Session.
+The status bar is now declarative: each chip is a ``ChipSpec`` with a key,
+label, value function, and optional expansion builder. Tests exercise the
+public surface (``_CHIP_SPECS``, ``_model_expansion``, ``_cost_expansion``,
+``_agent_expansion``, ``_task_expansion``) using real instances; no mocks.
 """
 from __future__ import annotations
 
 from reyn.interfaces.inline.app import (
-    build_status_dropdown_element,
-    dropdown_lines,
-    is_actionable_picker,
-    status_chips,
+    _CHIP_SPECS,
+    _agent_expansion,
+    _cost_expansion,
+    _model_expansion,
+    _task_expansion,
 )
+from reyn.interfaces.inline.region import DetailElement
+from reyn.interfaces.inline.region_command import CommandUIElement
 
 
 def _snap(**over):
-    """A status snapshot dict (build_status_dropdown_element's input)."""
+    """A status snapshot dict covering all chip value/expansion inputs."""
     base = {
         "model": "standard",
         "model_classes": ["light", "standard", "strong"],
-        "agent_names": ["default"], "attached_name": "default",
-        "skill_run_ids": [], "usage": (0, 0, 0), "cost_usd": 0.0,
+        "agent_names": ["default"],
+        "attached_name": "default",
+        "skill_run_ids": [],
+        "usage": (0, 0, 0),
+        "cost_usd": 0.0,
+        "task_count": 0,
     }
     base.update(over)
     return base
 
 
-def test_model_chip_is_a_picker_only_with_classes() -> None:
-    """Tier 2: the model dropdown is an actionable picker (gets a cursor) only
-    when it has classes to pick; with none it's the read-only fallback."""
-    assert is_actionable_picker("model", ["light", "standard"]) is True
-    assert is_actionable_picker("model", []) is False  # fallback, no cursor
-    assert is_actionable_picker("agents", ["default"]) is False  # not actionable
+# ---------------------------------------------------------------------------
+# Registry contract
+# ---------------------------------------------------------------------------
 
 
-def test_status_chips_has_five_labelled_values() -> None:
-    """Tier 2: the status row exposes model/agents/skills/cost/ctx with values."""
-    chips = status_chips("flash-lite", 2, 1, 0.0123, 12800)
-    labels = [lbl for lbl, _ in chips]
-    assert labels == ["model", "agents", "skills", "cost", "ctx"]
-    by = dict(chips)
-    assert by["model"] == "flash-lite"
-    assert by["agents"] == "2"
-    assert by["skills"] == "1"
-    assert by["cost"] == "$0.0123"
+def test_chip_specs_has_required_keys_in_order() -> None:
+    """Tier 2: the registry exposes model/cost/agent/task/more in that order."""
+    keys = [s.key for s in _CHIP_SPECS]
+    assert keys == ["model", "cost", "agent", "task", "more"]
 
 
-def test_ctx_abbreviates_thousands_but_not_small_counts() -> None:
-    """Tier 2: ctx shows 'Nk' at >=1000 tokens, the raw count below."""
-    assert dict(status_chips("m", 0, 0, 0.0, 12800))["ctx"] == "12k"
-    assert dict(status_chips("m", 0, 0, 0.0, 500))["ctx"] == "500"
+def test_model_chip_value_returns_model_name() -> None:
+    """Tier 2: the model chip's value() returns the model string."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "model")
+    assert spec.value(_snap(model="flash-lite")) == "flash-lite"
 
 
-def test_agents_dropdown_marks_attached() -> None:
-    """Tier 2: the agents panel marks the attached agent with ▸."""
-    lines = dropdown_lines(
-        "agents", model="m", agent_names=["default", "researcher"],
-        attached_name="default", skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
-    )
-    assert any(ln.startswith("▸") and "default" in ln for ln in lines)
-    assert any("researcher" in ln and not ln.startswith("▸") for ln in lines)
+def test_cost_chip_value_returns_formatted_dollars() -> None:
+    """Tier 2: the cost chip's value() returns a dollar-formatted string."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "cost")
+    result = spec.value(_snap(cost_usd=0.0123))
+    assert result.startswith("$")
+    assert "0123" in result or "0.0123" in result
 
 
-def test_skills_dropdown_lists_runs_or_empty_message() -> None:
-    """Tier 2: skills panel lists run ids, or a clear empty message."""
-    lines = dropdown_lines(
-        "skills", model="m", agent_names=[], attached_name=None,
-        skill_run_ids=["run_abcd", "run_ef01"], usage=(0, 0, 0), cost_usd=0.0,
-    )
-    assert any("run_abcd" in ln for ln in lines)
-    empty = dropdown_lines(
-        "skills", model="m", agent_names=[], attached_name=None,
-        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
-    )
-    assert any("no running skills" in ln for ln in empty)
+def test_agent_chip_value_returns_attached_name() -> None:
+    """Tier 2: the agent chip's value() returns the attached agent name."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "agent")
+    assert spec.value(_snap(attached_name="researcher")) == "researcher"
 
 
-def test_cost_dropdown_shows_token_breakdown() -> None:
-    """Tier 2: cost/ctx panel shows the prompt/completion/total breakdown."""
-    lines = dropdown_lines(
-        "cost", model="m", agent_names=[], attached_name=None,
-        skill_run_ids=[], usage=(100, 5, 105), cost_usd=0.01,
-    )
-    joined = " ".join(lines)
-    assert "prompt 100" in joined
-    assert "completion 5" in joined
-    assert "total 105" in joined
+def test_agent_chip_value_returns_dash_when_none() -> None:
+    """Tier 2: the agent chip's value() returns '—' when no agent is attached."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "agent")
+    assert spec.value(_snap(attached_name=None)) == "—"
 
 
-def test_model_dropdown_shows_current_and_change_hint() -> None:
-    """Tier 2: with no configured classes, model panel falls back to the current
-    class + how to change it."""
-    lines = dropdown_lines(
-        "model", model="flash-lite", agent_names=[], attached_name=None,
-        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
-    )
-    joined = " ".join(lines)
+def test_task_chip_value_returns_count_string() -> None:
+    """Tier 2: the task chip's value() returns the task count as a string."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "task")
+    assert spec.value(_snap(task_count=3)) == "3"
+    assert spec.value(_snap(task_count=0)) == "0"
+
+
+def test_more_chip_has_no_expansion() -> None:
+    """Tier 2: the 'more' chip has no expansion (Phase 5 placeholder)."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "more")
+    assert spec.expansion is None
+
+
+# ---------------------------------------------------------------------------
+# _model_expansion
+# ---------------------------------------------------------------------------
+
+
+def test_model_expansion_with_classes_is_command_ui() -> None:
+    """Tier 2: with classes, _model_expansion returns a CommandUIElement picker."""
+    submitted: list[str] = []
+    snap = _snap(model="standard", model_classes=["light", "standard", "strong"])
+    el = _model_expansion(snap, submitted.append)
+    assert isinstance(el, CommandUIElement)
+
+
+def test_model_expansion_picker_submits_slash_model_on_select() -> None:
+    """Tier 2: selecting row N in the model picker submits '/model <classN>'."""
+    submitted: list[str] = []
+    snap = _snap(model="standard", model_classes=["light", "standard", "strong"])
+    el = _model_expansion(snap, submitted.append)
+    el.on_select(0)
+    el.on_select(2)
+    assert submitted == ["/model light", "/model strong"]
+
+
+def test_model_expansion_picker_out_of_range_does_not_submit() -> None:
+    """Tier 2: on_select with an out-of-range index does not call the callback."""
+    submitted: list[str] = []
+    snap = _snap(model="standard", model_classes=["light", "standard"])
+    el = _model_expansion(snap, submitted.append)
+    el.on_select(9)
+    assert submitted == []
+
+
+def test_model_expansion_picker_marks_current_with_arrow() -> None:
+    """Tier 2: the current model row starts with ▸; others do not."""
+    snap = _snap(model="standard", model_classes=["light", "standard", "strong"])
+    el = _model_expansion(snap, lambda _: None)
+    rows = el.lines()
+    assert any(r.startswith("▸") and "standard" in r for r in rows)
+    assert any("light" in r and not r.startswith("▸") for r in rows)
+    assert any("strong" in r and not r.startswith("▸") for r in rows)
+
+
+def test_model_expansion_without_classes_is_detail_element() -> None:
+    """Tier 2: with no classes, _model_expansion returns a non-selectable DetailElement."""
+    snap = _snap(model="flash-lite", model_classes=[])
+    el = _model_expansion(snap, lambda _: None)
+    assert isinstance(el, DetailElement)
+    assert el.selectable is False
+
+
+def test_model_expansion_without_classes_shows_current_and_hint() -> None:
+    """Tier 2: the no-classes fallback detail shows the model name and /model hint."""
+    snap = _snap(model="flash-lite", model_classes=[])
+    el = _model_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
     assert "flash-lite" in joined
     assert "/model" in joined
 
 
-def test_model_picker_lists_classes_marking_current() -> None:
-    """Tier 2: with configured classes, the model panel is a picker — one row
-    per class, the current class marked ▸, others not."""
-    lines = dropdown_lines(
-        "model", model="standard", agent_names=[], attached_name=None,
-        skill_run_ids=[], usage=(0, 0, 0), cost_usd=0.0,
-        model_classes=["light", "standard", "strong"],
-    )
-    assert any(ln.startswith("▸") and "standard" in ln for ln in lines)
-    assert any("light" in ln and not ln.startswith("▸") for ln in lines)
-    assert any("strong" in ln and not ln.startswith("▸") for ln in lines)
-    # the picker (one row per class), not the no-classes fallback hint
-    assert not any("change with" in ln for ln in lines)
+# ---------------------------------------------------------------------------
+# _cost_expansion
+# ---------------------------------------------------------------------------
 
 
-def test_model_picker_element_submits_model_slash_on_select() -> None:
-    """Tier 2: F5 — the model chip with classes builds a selectable picker
-    element (a region CommandUIElement); selecting row N submits ``/model
-    <classN>`` through the slash path, sharing the region's selection mechanism
-    with the /rewind picker."""
-    submitted: list[str] = []
-    el = build_status_dropdown_element(
-        "model", snapshot_fn=_snap, on_submit=submitted.append,
-    )
-    assert any(ln.startswith("▸") and "standard" in ln for ln in el.lines())
-    el.on_select(0)
-    el.on_select(2)
-    assert submitted == ["/model light", "/model strong"]
-    el.on_select(9)  # out of range → no submit
-    assert submitted == ["/model light", "/model strong"]
-
-
-def test_read_only_chip_builds_non_selectable_live_detail() -> None:
-    """Tier 2: F5 — a non-picker chip builds a read-only DetailElement — no
-    cursor (selectable=False), inert on select, rows recomputed live from the
-    snapshot so the panel reflects current values while open."""
-    box = {"snap": _snap(cost_usd=0.01, usage=(100, 5, 105))}
-    el = build_status_dropdown_element(
-        "cost", snapshot_fn=lambda: box["snap"], on_submit=lambda _t: None,
-    )
+def test_cost_expansion_is_detail_element() -> None:
+    """Tier 2: _cost_expansion returns a read-only DetailElement."""
+    snap = _snap(cost_usd=0.01, usage=(100, 5, 105))
+    el = _cost_expansion(snap, lambda _: None)
+    assert isinstance(el, DetailElement)
     assert el.selectable is False
-    assert any("total 105" in ln for ln in el.lines())
-    el.on_select(0)  # inert — no exception, nothing to submit
-    box["snap"] = _snap(cost_usd=0.02, usage=(200, 9, 209))
-    assert any("total 209" in ln for ln in el.lines())  # live
 
 
-def test_model_chip_without_classes_is_read_only_fallback() -> None:
-    """Tier 2: F5 — the model chip with no configured classes builds the
-    read-only fallback (non-selectable), not a picker."""
-    el = build_status_dropdown_element(
-        "model", snapshot_fn=lambda: _snap(model_classes=[]),
-        on_submit=lambda _t: None,
-    )
-    assert getattr(el, "selectable", True) is False
-    assert any("/model" in ln for ln in el.lines())
+def test_cost_expansion_shows_total_cost_and_token_breakdown() -> None:
+    """Tier 2: cost expansion lines contain a total cost line and a token line."""
+    snap = _snap(cost_usd=0.0123, usage=(200, 9, 209))
+    el = _cost_expansion(snap, lambda _: None)
+    lines = el.lines()
+    joined = " ".join(lines)
+    assert "0.0123" in joined
+    assert "prompt 200" in joined
+    assert "completion 9" in joined
+    assert "total 209" in joined
+
+
+# ---------------------------------------------------------------------------
+# _agent_expansion
+# ---------------------------------------------------------------------------
+
+
+def test_agent_expansion_is_detail_element() -> None:
+    """Tier 2: _agent_expansion returns a read-only DetailElement."""
+    snap = _snap(agent_names=["default"], attached_name="default")
+    el = _agent_expansion(snap, lambda _: None)
+    assert isinstance(el, DetailElement)
+    assert el.selectable is False
+
+
+def test_agent_expansion_marks_attached_agent() -> None:
+    """Tier 2: the attached agent row starts with ▸; others do not."""
+    snap = _snap(agent_names=["default", "researcher"], attached_name="default")
+    el = _agent_expansion(snap, lambda _: None)
+    rows = el.lines()
+    assert any(r.startswith("▸") and "default" in r for r in rows)
+    assert any("researcher" in r and not r.startswith("▸") for r in rows)
+
+
+def test_agent_expansion_empty_shows_none_message() -> None:
+    """Tier 2: with no agents, the expansion shows a '(none)' line."""
+    snap = _snap(agent_names=[], attached_name=None)
+    el = _agent_expansion(snap, lambda _: None)
+    rows = el.lines()
+    assert any("none" in r for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# _task_expansion
+# ---------------------------------------------------------------------------
+
+
+def test_task_expansion_is_detail_element() -> None:
+    """Tier 2: _task_expansion returns a read-only DetailElement."""
+    snap = _snap(task_count=2)
+    el = _task_expansion(snap, lambda _: None)
+    assert isinstance(el, DetailElement)
+    assert el.selectable is False
+
+
+def test_task_expansion_shows_count_and_pluralises() -> None:
+    """Tier 2: task expansion line includes the count; plural for N≠1."""
+    snap_1 = _snap(task_count=1)
+    el_1 = _task_expansion(snap_1, lambda _: None)
+    assert "1 active task" in " ".join(el_1.lines())
+    # plural
+    snap_3 = _snap(task_count=3)
+    el_3 = _task_expansion(snap_3, lambda _: None)
+    assert "tasks" in " ".join(el_3.lines())


### PR DESCRIPTION
**[tui-coder]** — Phase 1 of the extensible status-bar redesign (**#2271**). The framework foundation; later phases (agent/session tree, task tree, cost breakdown, overflow toggles) build on it.

## What

Replaces the hardcoded per-chip `if/elif` (`_CHIPS` / `is_actionable_picker` / `status_chips` / `dropdown_lines` / `build_status_dropdown_element`) with a **declarative `ChipSpec` registry** — a new chip is one spec, no per-chip branching in the renderer or bindings (the framework-ize-for-extensibility the owner asked for).

- **`ChipSpec(key, label, value(snapshot)->str, expansion(snapshot, dispatch)->element)`**; the bar renders by iterating `_CHIP_SPECS`.
- **New chip set**: `model │ cost │ agent │ task │ …` — `│`-separated, label-value pairs, **no icons**, **agent = agent name**, `…` = overflow chip (owner spec).
- **Expansions reuse the region element types**: model → `CommandUIElement` picker (`/model`); cost / agent / task → `DetailElement`. Phase 2 → agent tree + attach; Phase 3 → task tree; Phase 5 → `…` submenu toggles.
- `_actionable_open` now reads `menu_region.cursor_on_selectable` (no per-key table); `task_count` is a Phase-1 placeholder (0) in `_snapshot`.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean (re-verified by me, not just the subagent)
- [x] inline/status_menu regression: 120 passed, 2 skipped. `test_inline_pr3b_status_menu` rewritten onto the framework (spec key order, each `value()`, each expansion builder — model picker submits `/model<class>`, cost/agent/task detail), real instances, no mocks, no pins
- [x] **Live tmux**: the 5-chip `│` bar renders (`model standard │ cost $0.0000 │ agent default │ task 0 │ …`); `↓` focus → `←→` nav → `enter` opens a chip's expansion (agent → `▸ default` list)

## Design notes (baked in for later phases, per lead-coder)

- The read-only accessors coming in Phases 2–4 (`registry.session_tree`, task tree-snapshot, config lists) will return **snapshot-style immutable copies**, not handles to live registry state.
- The mcp/skill/hook **toggle** wiring (Phase 5) routes through config + the permission system → gets OS-lane review (cron is live-ready). Flagged when those phases land.

## Implementation note

The mechanical refactor was done by a Sonnet sub-agent against a precise spec; I re-ran all gates + read the rewired sections (`status_fragments` / `_menu_open` / `_actionable_open`) + did the live tmux verify myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
