### PR TITLE
feat(#2259 PR-2b): async-decoupled durability contract (seq-in-worker, non-blocking)

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -135,13 +135,12 @@ class AgentSnapshot:
             ),
         )
 
-    def serialize(self) -> str:
-        """Serialise to a JSON string — SYNCHRONOUS, so it captures a consistent view of the
-        mutable state (inbox / chains / …) at the call instant. #1765 1a-ii splits this from
-        the durable write so an off-loop save snapshots the state here (sync) and only the
-        write+fsync runs off the event loop, with no risk of the state being mutated mid-write.
-        """
-        payload = {
+    def to_payload(self) -> dict:
+        """The serialisable payload dict (references to the live mutable state). ``serialize``
+        json.dumps this immediately (so it is a consistent capture). #2259 PR-2b's ``save_nowait``
+        deep-copies it for a CONSISTENT sync capture and stamps ``applied_seq`` from the
+        worker-assigned WAL seq in the durable job (the seq is not known on the task loop)."""
+        return {
             "version": SNAPSHOT_VERSION,
             "session_id": self.session_id,  # FP-0043 S5 (additive; legacy load → "main")
             "applied_seq": self.applied_seq,
@@ -152,6 +151,19 @@ class AgentSnapshot:
             "buffered_intervention_answers": self.buffered_intervention_answers,
             "next_turn_context": self.next_turn_context,
         }
+
+    def serialize(self) -> str:
+        """Serialise to a JSON string — SYNCHRONOUS, so it captures a consistent view of the
+        mutable state (inbox / chains / …) at the call instant. #1765 1a-ii splits this from
+        the durable write so an off-loop save snapshots the state here (sync) and only the
+        write+fsync runs off the event loop, with no risk of the state being mutated mid-write.
+        """
+        return json.dumps(self.to_payload(), ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def serialize_payload(payload: dict) -> str:
+        """Serialise a pre-captured payload dict (#2259 PR-2b: ``save_nowait`` stamps the
+        worker-assigned ``applied_seq`` into a deep-copied payload, then serialises here)."""
         return json.dumps(payload, ensure_ascii=False, indent=2)
 
     @staticmethod

--- a/src/reyn/core/events/config_recovery.py
+++ b/src/reyn/core/events/config_recovery.py
@@ -48,10 +48,17 @@ def config_generations_dir(reyn_dir: "Path") -> "Path":
 async def record_config_generation(
     state_log: "StateLog | None", config_abs_path, content: dict,
 ) -> None:
-    """Record the FULL config state as a generation keyed by the current WAL head — the
-    truncation-surviving recovery base for this registry. No-op when ``state_log`` is None
-    (the opt-in / non-persistence contract) or the path is not under ``.reyn/``. Call it
-    AFTER the `.yaml` is persisted. (Async to match the call sites; the write is synchronous.)"""
+    """Record the FULL config state as a generation keyed by the DURABLE WAL head
+    (``last_durable_seq``) — the truncation-surviving recovery base for this registry. #2259
+    PR-2b: keyed at the DURABLE watermark, not the live ``current_seq`` — a config op has no WAL
+    entry of its own (it emits a P6 audit event, not ``state_log.append``), so it tags the
+    durable WAL position it is consistent with; keying at a non-durable seq would let a crash
+    leave the config-gen referencing a WAL position past the durable tail (a hole, the truncation
+    class). Two config ops between WAL entries share the same durable seq → the 2nd overwrites
+    the 1st at ``{rel}@{seq}.yaml``; harmless because config-gen stores FULL post-state (the
+    latest write at that seq is the complete correct config; no distinct rewind target is lost).
+    No-op when ``state_log`` is None (the opt-in / non-persistence contract) or the path is not
+    under ``.reyn/``. Call it AFTER the `.yaml` is persisted."""
     if state_log is None:
         return
     rel = reyn_relative_path(config_abs_path)
@@ -60,5 +67,5 @@ async def record_config_generation(
         return
     from reyn.core.events.config_generations import ConfigGenerationStore  # noqa: PLC0415
     ConfigGenerationStore(config_generations_dir(root)).record(
-        rel, content, state_log.current_seq,
+        rel, content, state_log.last_durable_seq,
     )

--- a/src/reyn/core/events/durability_worker.py
+++ b/src/reyn/core/events/durability_worker.py
@@ -63,21 +63,31 @@ class DurabilityWorker:
         self._queue: "asyncio.Queue | None" = None
         self._drainer: "asyncio.Task | None" = None
         self._loop: "asyncio.AbstractEventLoop | None" = None
+        # #2259 PR-2b: a fire-and-forget (non-blocking) durable write that fails PERSISTENTLY
+        # (§4 retry-exhausted) has no submitter to re-raise to, so its escalation is a
+        # health-signal: this latches True + a CRITICAL log. The system is no longer durably
+        # persisting — a supervisor reads `durability_failed` to fail-stop. Never auto-cleared.
+        self._durability_failed = False
 
-    def _ensure_runtime(self) -> "asyncio.Queue":
-        """Bind (or rebind) the queue + drainer to the RUNNING loop. A new loop (a fresh test, a
-        re-init) gets a fresh queue + drainer — the old loop is gone, so its queue/task are inert
-        and dropped (in production there is one loop; any in-flight write already completed under
-        ``aclose``). Idempotent within a loop: a live drainer is reused."""
+    def _ensure_queue(self) -> "asyncio.Queue":
+        """Bind (or rebind) the queue to the RUNNING loop and return it. A new loop (a fresh test,
+        a re-init) gets a fresh queue + resets the drainer to None (the old loop's task is
+        abandoned — inert; in production there is one loop). Does NOT start the drainer — callers
+        enqueue FIRST, then ``_kick``, so the (self-terminating) drainer never sees an empty queue
+        before the item lands."""
         loop = asyncio.get_running_loop()
         if self._loop is not loop:
             self._queue = asyncio.Queue()
             self._loop = loop
-            self._drainer = loop.create_task(self._drain())
-        elif self._drainer is None or self._drainer.done():
-            self._drainer = loop.create_task(self._drain())
+            self._drainer = None  # old drainer (old loop) abandoned; _kick starts a fresh one
         assert self._queue is not None
         return self._queue
+
+    def _kick(self) -> None:
+        """Start the self-terminating drainer if it is not currently running. Called AFTER the
+        item is enqueued, so the drainer is guaranteed to see it."""
+        if self._drainer is None or self._drainer.done():
+            self._drainer = self._loop.create_task(self._drain())  # type: ignore[union-attr]
 
     async def submit(self, do_durable_write: DurableWrite) -> None:
         """Run a durable-write task, serialised with every other submit (FIFO = durability
@@ -85,40 +95,88 @@ class DurabilityWorker:
         off-loop fsync keeps the event loop free for non-durability work; other submits wait
         their turn. A transient ``OSError`` is retried with bounded backoff (§4); on exhaustion
         the persistent failure is re-raised here (same as an inline write, now after retry)."""
-        queue = self._ensure_runtime()
+        queue = self._ensure_queue()
         fut: "asyncio.Future[None]" = self._loop.create_future()  # type: ignore[union-attr]
         queue.put_nowait((do_durable_write, fut))
+        self._kick()
         await fut
 
-    async def _drain(self) -> None:
-        """The single background drainer: process ``(task, future)`` items one at a time in
-        enqueue order (FIFO = durability order), resolving each future with the task's result or
-        its (post-retry) failure. Runs until cancelled (``aclose`` / event-loop teardown).
+    def submit_nowait(self, do_durable_write: DurableWrite) -> None:
+        """#2259 PR-2b: enqueue a durable write FIRE-AND-FORGET — return IMMEDIATELY, do NOT
+        await durability (the in-memory mutation already happened on the task loop; this is the
+        relaxed-durability window). SYNCHRONOUS enqueue (``put_nowait``), so a (WAL, snapshot)
+        pair submitted back-to-back with no ``await`` between them is atomic on the event loop —
+        no concurrent mutation's job can interleave between the pair (invariant: ``snap_N`` reads
+        the seq ``WAL_N`` assigned, never a later one). The drainer runs it serially (FIFO =
+        durability order); a persistent (§4-exhausted) failure has no submitter to raise to, so it
+        latches ``durability_failed`` + CRITICAL-logs (health-signal escalation)."""
+        queue = self._ensure_queue()
+        queue.put_nowait((do_durable_write, None))
+        self._kick()
 
-        ``CancelledError`` MUST propagate (terminate the drainer) — it is NOT a write failure.
-        Swallowing it (catching ``BaseException``) made the drainer immortal: a cancel landing
-        mid-write was caught, the loop continued to an empty ``get()``, and ``asyncio.run``'s
-        ``_cancel_all_tasks`` teardown then hung forever waiting for the task to finish. So a
-        cancel resolves the in-flight future (the submitter is unblocked) and re-raises; only a
-        real ``Exception`` (a write failure) is surfaced to the submitter."""
+    @property
+    def durability_failed(self) -> bool:
+        """True once a fire-and-forget durable write failed PERSISTENTLY (§4-exhausted). The
+        system is no longer durably persisting — a supervisor fail-stops on this. Latched."""
+        return self._durability_failed
+
+    async def _drain(self) -> None:
+        """The SELF-TERMINATING drainer: process queued ``(task, future)`` items in FIFO order
+        (= durability order) until the queue is EMPTY, then exit. It does NOT block on a perpetual
+        ``await queue.get()`` — a perpetual drainer leaks across an event-loop teardown (a test
+        that never ``aclose``s it): at loop close, asyncio cancels the pending ``get()`` and its
+        internal getter ``call_soon`` raises "Event loop is closed". Draining via ``get_nowait``
+        and exiting on empty avoids the leak entirely.
+
+        No-stranding: the ``QueueEmpty`` check + ``return`` are atomic (no ``await`` between), so a
+        concurrent ``submit`` cannot interleave there — an item enqueued while a prior one is
+        processing is seen on the next iteration; an item enqueued after the drainer exits is
+        picked up when the next submit re-kicks it (``_ensure_runtime`` restarts a ``done()``
+        drainer).
+
+        ``CancelledError`` MUST propagate (terminate the drainer): it is NOT a write failure.
+        Swallowing it (catching ``BaseException``) made an earlier drainer immortal — a cancel
+        landing mid-write was caught + the loop continued, and ``_cancel_all_tasks`` teardown hung
+        forever. So a cancel resolves the in-flight future + re-raises; only a real ``Exception``
+        (a write failure) is surfaced (to the submitter, or as the health-signal)."""
         assert self._queue is not None
         while True:
-            do_durable_write, fut = await self._queue.get()
+            try:
+                do_durable_write, fut = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return  # drained → self-terminate (atomic with the check: no await between)
             try:
                 await self._run_with_retry(do_durable_write)
             except asyncio.CancelledError:
-                if not fut.done():
+                if fut is not None and not fut.done():
                     fut.cancel()
                 self._queue.task_done()
                 raise
-            except Exception as e:  # noqa: BLE001 — a real write failure → surface to the submitter
-                if not fut.done():
-                    fut.set_exception(e)
+            except Exception as e:  # noqa: BLE001 — a real write failure → surface it
+                self._on_write_failure(fut, e)
                 self._queue.task_done()
             else:
-                if not fut.done():
+                if fut is not None and not fut.done():
                     fut.set_result(None)
                 self._queue.task_done()
+
+    def _on_write_failure(self, fut: "asyncio.Future | None", e: Exception) -> None:
+        """Surface a persistent (§4-exhausted) durable-write failure. A BLOCKING submit (``fut``
+        present) re-raises to the awaiting caller (PR-2a contract). A FIRE-AND-FORGET submit
+        (``fut is None``, PR-2b) has no caller — so the escalation MUST surface out-of-band, never
+        be swallowed (the owner's "no silent unbounded loss": in-memory must not race ahead while
+        durability is silently dead): latch ``durability_failed`` + CRITICAL-log."""
+        if fut is not None:
+            if not fut.done():
+                fut.set_exception(e)
+            return
+        self._durability_failed = True
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).critical(
+            "DURABILITY FAILURE (fire-and-forget, §4-exhausted): a durable write failed "
+            "persistently — the system is no longer durably persisting; fail-stop required. %s",
+            e,
+        )
 
     async def _run_with_retry(self, do_durable_write: DurableWrite) -> None:
         """§4: run the durable write, retrying a TRANSIENT ``OSError`` with bounded exponential
@@ -138,13 +196,25 @@ class DurabilityWorker:
                 attempt += 1
 
     async def aclose(self) -> None:
-        """Graceful shutdown. Drain every enqueued task (so no in-flight write is lost), then
-        cancel the idle drainer. A no-op if never used (no loop bound)."""
-        if self._drainer is None or self._queue is None:
+        """Graceful shutdown. Drain every enqueued task (no in-flight write lost), then stop. The
+        self-terminating drainer may already have exited, so KICK it if the queue is non-empty,
+        ``join`` to wait out the drain, then cancel any still-running drainer. A no-op if never
+        used, or if called on a different loop than the one the queue is bound to (a dead loop —
+        nothing to drain there)."""
+        if self._queue is None or self._loop is None:
             return
-        await self._queue.join()
-        self._drainer.cancel()
         try:
-            await self._drainer
-        except asyncio.CancelledError:
-            pass
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is not self._loop:
+            return
+        if not self._queue.empty():
+            self._kick()
+        await self._queue.join()
+        if self._drainer is not None and not self._drainer.done():
+            self._drainer.cancel()
+            try:
+                await self._drainer
+            except asyncio.CancelledError:
+                pass

--- a/src/reyn/core/events/durability_worker.py
+++ b/src/reyn/core/events/durability_worker.py
@@ -195,6 +195,23 @@ class DurabilityWorker:
                 )
                 attempt += 1
 
+    async def flush(self) -> None:
+        """#2259 PR-2b: wait until every currently-enqueued durable write has DRAINED — WITHOUT
+        closing the worker (it stays usable). For any caller that must observe a fire-and-forget
+        write's effect (e.g. a test asserting a truncate's result, or a deliberate barrier).
+        Same loop-guard as ``aclose``; a no-op if never used or called on a different loop."""
+        if self._queue is None or self._loop is None:
+            return
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is not self._loop:
+            return
+        if not self._queue.empty():
+            self._kick()
+        await self._queue.join()
+
     async def aclose(self) -> None:
         """Graceful shutdown. Drain every enqueued task (no in-flight write lost), then stop. The
         self-terminating drainer may already have exited, so KICK it if the queue is non-empty,

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -54,6 +54,15 @@ class SnapshotGenerationStore:
         snapshot.save(path)  # tmp → fsync → rename
         return path
 
+    def record_payload(self, payload: dict, seq: int) -> Path:
+        """#2259 PR-2b: record a pre-captured payload dict (with ``applied_seq`` stamped to
+        ``seq``) as the generation at ``seq`` — the worker-job counterpart of ``record``. So
+        ``cut_generation`` captures content SYNC + stamps the worker-assigned seq in the durable
+        job (content + applied_seq consistent, never a live-ahead-of-durable gen)."""
+        path = self._path_for(seq)
+        AgentSnapshot.write_durable(path, AgentSnapshot.serialize_payload(payload))
+        return path
+
     def seqs(self) -> list[int]:
         """Sorted list of generation boundary seqs present on disk."""
         if not self._dir.is_dir():

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -372,9 +372,11 @@ def reconstruct(
 
     With no rewind records every seq is active, so this is identical to the
     Stage-1a behavior (backward compatible). Crash recovery is
-    ``reconstruct(head)`` where ``head = state_log.current_seq`` — which, after a
-    rewind, yields the current active-branch state (and collapses to as-of-N when
-    the rewind reset-record is itself head).
+    ``reconstruct(head)`` where ``head = state_log.last_durable_seq`` (#2259 PR-2b:
+    the DURABLE watermark, not the live ``current_seq`` — recovery operates only on
+    durable state, so the un-durable tail is cleanly dropped = recover-to-last-durable)
+    — which, after a rewind, yields the current active-branch state (and collapses to
+    as-of-N when the rewind reset-record is itself head).
     """
     abandoned = _abandoned_intervals(_rewind_records(state_log))
     is_active = _make_is_active(abandoned)

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -241,7 +241,7 @@ def list_branches(state_log: StateLog) -> list[Branch]:
     branch owning N (active or an enclosing dead branch → nesting). Returns the
     active branch first, then dead branches ascending by id. Empty WAL → [].
     """
-    head = state_log.current_seq
+    head = state_log.last_durable_seq  # #2259 PR-2b: durable head (operates on durable state)
     if head <= 0:
         return []
     abandoned = _abandoned_intervals(_rewind_records(state_log))

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -196,49 +196,47 @@ class StateLog:
         (off-loop) fsync. Post-append observers fire in the durable-write job, after the fsync
         (best-effort, #1560).
         """
-        seq, entry, kind, fields = self._assign_entry(kind, fields)
-        await self._worker.submit(self._durable_wal_write(entry, kind, fields))
-        return seq
-
-    def append_nowait(self, kind: str, **fields) -> int:
-        """#2259 PR-2b: append NON-BLOCKING — assign the seq synchronously (so `current_seq`
-        is immediately correct) and fire-and-forget the durable WRITE (the relaxed-durability
-        window: the in-memory mutation already happened on the task loop, durability catches up
-        async). Returns the assigned seq (available synchronously — the seq IS sync; only
-        durability is deferred), but the journal mutation does NOT depend on it for correctness:
-        it pairs a synchronous ``save_nowait`` that reads ``last_assigned_seq``. SYNCHRONOUS
-        enqueue, so an (append_nowait, save_nowait) pair with no ``await`` between is atomic on
-        the loop (no concurrent mutation interleaves → the snapshot reads THIS append's seq)."""
-        seq, entry, kind, fields = self._assign_entry(kind, fields)
-        self._worker.submit_nowait(self._durable_wal_write(entry, kind, fields))
-        return seq
-
-    def _assign_entry(self, kind: str, fields: dict):
-        """Synchronously assign the next seq + build the WAL entry (no await — atomic on the
-        loop, so the counter never races + `current_seq` is correct immediately). Shared by the
-        blocking `append` and the non-blocking `append_nowait`."""
         if kind not in WAL_EVENT_KINDS:
             raise ValueError(f"unknown WAL event kind: {kind!r}")
-        self._counter += 1
-        seq = self._counter
-        self._last_assigned_seq = seq
-        entry = {"seq": seq, "ts": datetime.now().isoformat(), "kind": kind}
-        entry.update(fields)
-        return seq, entry, kind, fields
+        holder: dict = {}
+        await self._worker.submit(self._wal_write_job(kind, fields, holder))
+        return holder["seq"]
 
-    def _durable_wal_write(self, entry: dict, kind: str, fields: dict):
-        """Build the durable-write task for `entry` (run by the DurabilityWorker, serially —
-        the single serial venue, so no lock). Writes the line, fsyncs OFF the event loop, then
-        advances `_last_durable_seq` — strictly AFTER the fsync, so the watermark never names a
-        non-durable entry. `_inflight_seq` (the one entry mid-fsync — the worker is serial, so
-        only ever one) keeps `iter_from` from exposing it. Post-append observers fire here, after
-        the durable write (so they fire post-fsync for BOTH the blocking + fire-and-forget paths,
-        with the assigned seq)."""
+    def append_nowait(self, kind: str, **fields) -> None:
+        """#2259 PR-2b: append NON-BLOCKING + NO-RETURN. The seq is assigned IN the worker (the
+        WAL job, serial → monotonic = durability order), NEVER on the task loop — so no consumer
+        can key a durable artifact at a not-yet-durable seq (the hole the sync-seq had; the owner
+        caught it). The paired ``save_nowait``'s snapshot job reads ``last_assigned_seq`` (set by
+        the WAL job, which the worker's FIFO runs first). SYNCHRONOUS enqueue, so an
+        (append_nowait, save_nowait) pair with NO ``await`` between is atomic on the loop — no
+        concurrent mutation's WAL job interleaves between the pair → ``snap_N`` reads ``WAL_N``'s
+        seq, never a later one (invariant #2). The hot path NEVER awaits durability (the
+        blocking-invariant: submit-and-proceed)."""
+        if kind not in WAL_EVENT_KINDS:
+            raise ValueError(f"unknown WAL event kind: {kind!r}")
+        self._worker.submit_nowait(self._wal_write_job(kind, fields, None))
+
+    def _wal_write_job(self, kind: str, fields: dict, holder: "dict | None"):
+        """The durable WAL-write job (run by the DurabilityWorker, serially — the single serial
+        venue, so no lock). At drain it ASSIGNS the seq (``++_counter`` — serial, so monotonic =
+        durability order, never racing) and sets ``_last_assigned_seq`` (the paired snapshot job,
+        FIFO-after, reads it to stamp ``applied_seq``); writes the line + fsyncs OFF the loop;
+        then advances ``_last_durable_seq`` strictly AFTER the fsync (the watermark never names a
+        non-durable entry). ``_inflight_seq`` (the one entry mid-fsync — the worker is serial, so
+        only ever one) keeps ``iter_from`` from exposing it. Post-append observers fire after the
+        durable write. A blocking ``append`` passes a per-call ``holder`` to receive the seq."""
         async def _task() -> None:
+            self._counter += 1
+            seq = self._counter
+            self._last_assigned_seq = seq
+            if holder is not None:
+                holder["seq"] = seq
+            entry = {"seq": seq, "ts": datetime.now().isoformat(), "kind": kind}
+            entry.update(fields)
             # Mark this entry in-flight BEFORE it appears in the file, so a concurrent
-            # `iter_from` during the fsync skips it (it is written but not yet durable);
-            # cleared only AFTER the fsync, when it is durable + readable.
-            self._inflight_seq = entry["seq"]
+            # `iter_from` during the fsync skips it (written but not yet durable); cleared
+            # only AFTER the fsync, when it is durable + readable.
+            self._inflight_seq = seq
             try:
                 payload = json.dumps(entry, ensure_ascii=False) + "\n"
                 # Defensive lead-newline (a prior run may have crashed mid-write so the file
@@ -253,8 +251,8 @@ class StateLog:
                     await asyncio.to_thread(os.fsync, f.fileno())
             finally:
                 self._inflight_seq = None
-            self._last_durable_seq = entry["seq"]  # durable now → the watermark advances
-            await self._fire_post_append(kind, entry["seq"], fields)
+            self._last_durable_seq = seq  # durable now → the watermark advances
+            await self._fire_post_append(kind, seq, fields)
         return _task
 
     async def submit_durable(self, do_durable_write) -> None:

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -139,6 +139,12 @@ class StateLog:
         # outrun durability. Both seed from the recovered max (every scanned entry is durable).
         self._last_assigned_seq = self._counter
         self._last_durable_seq = self._counter
+        # #2259 PR-2b: truncate_below is FIRE-AND-FORGET (the blocking-invariant), so its stats
+        # are recorded here (post-drain readable via `last_truncate_stats` / after `flush`)
+        # instead of returned — the caller doesn't wait on the worker.
+        self._last_truncate_stats: dict = {
+            "dropped": 0, "kept": 0, "min_kept_seq": None, "max_kept_seq": None,
+        }
         # #1765 Step 1a: the off-loop durability worker (shared with other substrates so all
         # durable writes serialise at one point — the cross-substrate ordering). `_inflight_seq`
         # is the seq THIS log's worker is writing RIGHT NOW (between its file-write and its
@@ -181,6 +187,19 @@ class StateLog:
         in-memory `current_seq`), so truncation can never outrun durability (drop a WAL entry a
         not-yet-durable snapshot still needs)."""
         return self._last_durable_seq
+
+    @property
+    def last_truncate_stats(self) -> dict:
+        """#2259 PR-2b: the stats of the most recent `truncate_below` (dropped / kept /
+        min_kept_seq / max_kept_seq). Since truncate is fire-and-forget, read this AFTER `flush`
+        (or `aclose`) to observe a truncate's result — it is not returned synchronously."""
+        return self._last_truncate_stats
+
+    async def flush(self) -> None:
+        """#2259 PR-2b: wait until every enqueued durable write (WAL appends, snapshot saves,
+        a truncate rewrite) has drained — without closing the worker. A barrier for callers that
+        must observe a fire-and-forget write's durable effect (tests; deliberate sync points)."""
+        await self._worker.flush()
 
     async def append(self, kind: str, **fields) -> int:
         """Append a new entry, fsync (off the event loop), return its seq — BLOCKING (awaits
@@ -352,7 +371,7 @@ class StateLog:
                     continue
                 yield entry
 
-    async def truncate_below(self, min_keep_seq: int) -> dict:
+    async def truncate_below(self, min_keep_seq: int) -> None:
         """Atomically rewrite the WAL keeping only entries with ``seq >= min_keep_seq``.
 
         Drop policy: ``seq < min_keep_seq`` entries are dropped. Caller computes
@@ -367,25 +386,28 @@ class StateLog:
           3. A mid-rewrite crash leaves the original ``wal.jsonl`` intact
              — incomplete ``.tmp`` is ignored at next startup.
 
-        Returns a stats dict ``{"dropped": int, "kept": int, "min_kept_seq":
-        int|None, "max_kept_seq": int|None}``. ``min_keep_seq <= 1`` is a
-        no-op (everything would be kept).
+        Records a stats dict on ``last_truncate_stats`` (``{"dropped", "kept",
+        "min_kept_seq", "max_kept_seq"}``) — read it after ``flush`` (the rewrite is
+        fire-and-forget). ``min_keep_seq <= 1`` is a no-op (everything would be kept).
 
-        #2259 PR-2b crash safety: the rewrite runs as a WORKER job (the single serial venue),
-        so it is FIFO-serialised with every WAL write job — no append's write overlaps the
-        rename. The rewrite itself runs off the event loop (``to_thread``). ``truncate_below``
-        awaits the job (blocking — the caller needs the stats).
+        #2259 PR-2b: FIRE-AND-FORGET (the blocking-invariant — the GC caller does not await the
+        worker). The rewrite runs as a worker job (FIFO-serialised with every WAL write job — no
+        append's write overlaps the rename — and off the event loop via ``to_thread``); a failure
+        is handled by the worker's §4 retry → health-signal (no caller to raise to). The stats
+        land on ``last_truncate_stats`` (read after ``flush``), not a return value.
         """
         if min_keep_seq <= 1:
-            return {"dropped": 0, "kept": 0,
-                    "min_kept_seq": None, "max_kept_seq": None}
-        result: dict = {}
+            self._last_truncate_stats = {
+                "dropped": 0, "kept": 0, "min_kept_seq": None, "max_kept_seq": None,
+            }
+            return
 
         async def _job() -> None:
-            result.update(await asyncio.to_thread(self._do_truncate, min_keep_seq))
+            self._last_truncate_stats = await asyncio.to_thread(
+                self._do_truncate, min_keep_seq,
+            )
 
-        await self._worker.submit(_job)
-        return result
+        self._worker.submit_nowait(_job)
 
     def _do_truncate(self, min_keep_seq: int) -> dict:
         """The synchronous WAL rewrite (run off-loop, serialised by the worker — see

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -125,8 +125,20 @@ class StateLog:
     def __init__(self, path: Path, worker: "DurabilityWorker | None" = None) -> None:
         self._path = Path(path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = asyncio.Lock()
         self._counter = self._scan_max_seq()
+        # #2259 PR-2b: the seq COUNTER is assigned SYNCHRONOUSLY on the event loop (so
+        # `current_seq` is immediately correct for the 7 synchronous consumers — config-gen
+        # keying etc.; an async-assigned seq would key a config gen at a stale head and re-open
+        # the PR-1 truncation bug), and only the WAL WRITE is async (off-loop, fire-and-forget
+        # via the worker). No `asyncio.Lock`: the worker is the SINGLE serial venue — every WAL
+        # write AND `truncate_below` runs as a worker job, so they serialise by FIFO (the seq
+        # increment itself is sync-atomic, no await across it). `_last_assigned_seq` = the seq
+        # the most recent append assigned (the paired snapshot save reads it to stamp
+        # applied_seq); `_last_durable_seq` = the highest seq DURABLY written (set after fsync) —
+        # the (a)=(ii) durable watermark the truncate floor + cut_generation read so they never
+        # outrun durability. Both seed from the recovered max (every scanned entry is durable).
+        self._last_assigned_seq = self._counter
+        self._last_durable_seq = self._counter
         # #1765 Step 1a: the off-loop durability worker (shared with other substrates so all
         # durable writes serialise at one point — the cross-substrate ordering). `_inflight_seq`
         # is the seq THIS log's worker is writing RIGHT NOW (between its file-write and its
@@ -155,40 +167,73 @@ class StateLog:
     def current_seq(self) -> int:
         return self._counter
 
+    @property
+    def last_assigned_seq(self) -> int:
+        """#2259 PR-2b: the seq the most recent append assigned (sync). A paired
+        ``save_nowait`` reads this (with no ``await`` between the two enqueues) to stamp the
+        snapshot's ``applied_seq`` — so the snapshot records exactly its WAL entry's seq."""
+        return self._last_assigned_seq
+
+    @property
+    def last_durable_seq(self) -> int:
+        """#2259 PR-2b: the (a)=(ii) durable watermark — the highest seq DURABLY written
+        (advanced after each fsync). The truncate floor + cut_generation read this (never the
+        in-memory `current_seq`), so truncation can never outrun durability (drop a WAL entry a
+        not-yet-durable snapshot still needs)."""
+        return self._last_durable_seq
+
     async def append(self, kind: str, **fields) -> int:
-        """Append a new entry, fsync (off the event loop), return its seq.
+        """Append a new entry, fsync (off the event loop), return its seq — BLOCKING (awaits
+        durability). The non-blocking counterpart is `append_nowait`.
 
         `kind` must be one of WAL_EVENT_KINDS — caught at write time so a
         typo doesn't silently fragment the recovery vocabulary.
 
-        The seq is assigned under the lock; the worker write+fsync is submitted while the
-        lock is held (so the seq order = the file write order, and `truncate_below` — which
-        also holds the lock — never overlaps a write). `append` returns only after its entry
-        is durable: the per-append crash-recovery contract is unchanged, but the loop is free
-        during the (off-loop) fsync. Post-append observers fire after the durable write,
-        outside the lock (best-effort, #1560).
+        #2259 PR-2b: the seq is assigned SYNCHRONOUSLY (sync-atomic on the loop — no lock; the
+        worker is the single serial venue serialising the write + `truncate_below`), then the
+        write+fsync runs in the worker. `append` AWAITS it, so its per-append crash-recovery
+        contract is unchanged (returns only once durable) while the loop is free during the
+        (off-loop) fsync. Post-append observers fire in the durable-write job, after the fsync
+        (best-effort, #1560).
         """
-        if kind not in WAL_EVENT_KINDS:
-            raise ValueError(f"unknown WAL event kind: {kind!r}")
-        async with self._lock:
-            self._counter += 1
-            seq = self._counter
-            entry = {
-                "seq": seq,
-                "ts": datetime.now().isoformat(),
-                "kind": kind,
-            }
-            entry.update(fields)
-            await self._worker.submit(self._durable_wal_write(entry))
-        await self._fire_post_append(kind, seq, fields)
+        seq, entry, kind, fields = self._assign_entry(kind, fields)
+        await self._worker.submit(self._durable_wal_write(entry, kind, fields))
         return seq
 
-    def _durable_wal_write(self, entry: dict):
-        """Build the durable-write task for `entry` (run by the DurabilityWorker, serially).
-        Writes the line, fsyncs OFF the event loop, then bumps `_durable_seq` — strictly
-        AFTER the fsync, so `iter_from` (seq <= `_durable_seq`) never exposes a non-durable
-        entry. No lock here: the submitting `append` holds `self._lock` across the submit, so
-        this runs exclusively (serialised with other appends + `truncate_below`)."""
+    def append_nowait(self, kind: str, **fields) -> int:
+        """#2259 PR-2b: append NON-BLOCKING — assign the seq synchronously (so `current_seq`
+        is immediately correct) and fire-and-forget the durable WRITE (the relaxed-durability
+        window: the in-memory mutation already happened on the task loop, durability catches up
+        async). Returns the assigned seq (available synchronously — the seq IS sync; only
+        durability is deferred), but the journal mutation does NOT depend on it for correctness:
+        it pairs a synchronous ``save_nowait`` that reads ``last_assigned_seq``. SYNCHRONOUS
+        enqueue, so an (append_nowait, save_nowait) pair with no ``await`` between is atomic on
+        the loop (no concurrent mutation interleaves → the snapshot reads THIS append's seq)."""
+        seq, entry, kind, fields = self._assign_entry(kind, fields)
+        self._worker.submit_nowait(self._durable_wal_write(entry, kind, fields))
+        return seq
+
+    def _assign_entry(self, kind: str, fields: dict):
+        """Synchronously assign the next seq + build the WAL entry (no await — atomic on the
+        loop, so the counter never races + `current_seq` is correct immediately). Shared by the
+        blocking `append` and the non-blocking `append_nowait`."""
+        if kind not in WAL_EVENT_KINDS:
+            raise ValueError(f"unknown WAL event kind: {kind!r}")
+        self._counter += 1
+        seq = self._counter
+        self._last_assigned_seq = seq
+        entry = {"seq": seq, "ts": datetime.now().isoformat(), "kind": kind}
+        entry.update(fields)
+        return seq, entry, kind, fields
+
+    def _durable_wal_write(self, entry: dict, kind: str, fields: dict):
+        """Build the durable-write task for `entry` (run by the DurabilityWorker, serially —
+        the single serial venue, so no lock). Writes the line, fsyncs OFF the event loop, then
+        advances `_last_durable_seq` — strictly AFTER the fsync, so the watermark never names a
+        non-durable entry. `_inflight_seq` (the one entry mid-fsync — the worker is serial, so
+        only ever one) keeps `iter_from` from exposing it. Post-append observers fire here, after
+        the durable write (so they fire post-fsync for BOTH the blocking + fire-and-forget paths,
+        with the assigned seq)."""
         async def _task() -> None:
             # Mark this entry in-flight BEFORE it appears in the file, so a concurrent
             # `iter_from` during the fsync skips it (it is written but not yet durable);
@@ -208,6 +253,8 @@ class StateLog:
                     await asyncio.to_thread(os.fsync, f.fileno())
             finally:
                 self._inflight_seq = None
+            self._last_durable_seq = entry["seq"]  # durable now → the watermark advances
+            await self._fire_post_append(kind, entry["seq"], fields)
         return _task
 
     async def submit_durable(self, do_durable_write) -> None:
@@ -215,6 +262,14 @@ class StateLog:
         save) to the SAME worker, so it serialises with WAL writes — the single cross-substrate
         ordering point. Blocking (awaits durability), like `append`."""
         await self._worker.submit(do_durable_write)
+
+    def submit_durable_nowait(self, do_durable_write) -> None:
+        """#2259 PR-2b: submit a durable write from another substrate (a snapshot save)
+        FIRE-AND-FORGET — the non-blocking counterpart of `submit_durable`. Used by
+        `save_nowait` so the (WAL append_nowait, snapshot save_nowait) pair is two synchronous
+        enqueues with no await between (atomic on the loop). Serialises with WAL writes (same
+        worker, FIFO = durability order)."""
+        self._worker.submit_nowait(do_durable_write)
 
     async def aclose(self) -> None:
         """Drain + stop the durability worker (graceful shutdown — no in-flight write lost)."""
@@ -318,85 +373,98 @@ class StateLog:
         int|None, "max_kept_seq": int|None}``. ``min_keep_seq <= 1`` is a
         no-op (everything would be kept).
 
-        Crash safety: holds ``self._lock`` for the duration so concurrent
-        ``append`` calls are serialized — the rename is safe even on
-        platforms where ``rename`` over an open handle would fail (we don't
-        keep the destination open).
+        #2259 PR-2b crash safety: the rewrite runs as a WORKER job (the single serial venue),
+        so it is FIFO-serialised with every WAL write job — no append's write overlaps the
+        rename. The rewrite itself runs off the event loop (``to_thread``). ``truncate_below``
+        awaits the job (blocking — the caller needs the stats).
         """
         if min_keep_seq <= 1:
             return {"dropped": 0, "kept": 0,
                     "min_kept_seq": None, "max_kept_seq": None}
-        async with self._lock:
-            if not self._path.is_file():
-                return {"dropped": 0, "kept": 0,
-                        "min_kept_seq": None, "max_kept_seq": None}
-            # Two-pass: first pass identifies the highest seq actually present
-            # so we never drop *all* entries (next-startup ``_scan_max_seq``
-            # would reset the counter and re-issue already-used seqs into the
-            # audit log). Second pass writes survivors + the watermark entry.
-            highest_seq: int | None = None
-            with self._path.open("r", encoding="utf-8") as src:
-                for line in src:
-                    raw = line.strip()
-                    if not raw:
-                        continue
-                    try:
-                        entry = json.loads(raw)
-                    except json.JSONDecodeError:
-                        continue
-                    if not isinstance(entry, dict):
-                        continue
-                    seq = entry.get("seq")
-                    if not isinstance(seq, int):
-                        continue
-                    if highest_seq is None or seq > highest_seq:
-                        highest_seq = seq
-            # Effective floor: never drop the highest seq present, even if
-            # caller asked us to. This preserves the counter watermark.
-            effective_floor = min_keep_seq
-            if highest_seq is not None and effective_floor > highest_seq:
-                effective_floor = highest_seq
+        result: dict = {}
 
-            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-            dropped = 0
-            kept = 0
-            min_kept: int | None = None
-            max_kept: int | None = None
-            with self._path.open("r", encoding="utf-8") as src, \
-                    tmp.open("w", encoding="utf-8") as dst:
-                for line in src:
-                    raw = line.strip()
-                    if not raw:
-                        continue
-                    try:
-                        entry = json.loads(raw)
-                    except json.JSONDecodeError:
-                        # Torn fragment from prior crash — drop on rewrite.
-                        dropped += 1
-                        continue
-                    if not isinstance(entry, dict):
-                        dropped += 1
-                        continue
-                    seq = entry.get("seq")
-                    if not isinstance(seq, int):
-                        dropped += 1
-                        continue
-                    if seq < effective_floor:
-                        dropped += 1
-                        continue
-                    dst.write(raw + "\n")
-                    kept += 1
-                    if min_kept is None or seq < min_kept:
-                        min_kept = seq
-                    if max_kept is None or seq > max_kept:
-                        max_kept = seq
-                dst.flush()
-                os.fsync(dst.fileno())
-            tmp.replace(self._path)
-            # Counter (next-seq source) must remain ≥ max seq ever issued;
-            # truncation does NOT reset it (would re-issue dropped seqs).
-            return {"dropped": dropped, "kept": kept,
-                    "min_kept_seq": min_kept, "max_kept_seq": max_kept}
+        async def _job() -> None:
+            result.update(await asyncio.to_thread(self._do_truncate, min_keep_seq))
+
+        await self._worker.submit(_job)
+        return result
+
+    def _do_truncate(self, min_keep_seq: int) -> dict:
+        """The synchronous WAL rewrite (run off-loop, serialised by the worker — see
+        `truncate_below`). Two-pass: identify the highest seq present (never drop ALL entries —
+        that would let `_scan_max_seq` reset the counter + re-issue used seqs), then write the
+        survivors to a `.tmp` and atomically rename. A mid-rewrite crash leaves the original
+        intact (the incomplete `.tmp` is ignored at next startup)."""
+        if not self._path.is_file():
+            return {"dropped": 0, "kept": 0,
+                    "min_kept_seq": None, "max_kept_seq": None}
+        # Two-pass: first pass identifies the highest seq actually present
+        # so we never drop *all* entries (next-startup ``_scan_max_seq``
+        # would reset the counter and re-issue already-used seqs into the
+        # audit log). Second pass writes survivors + the watermark entry.
+        highest_seq: int | None = None
+        with self._path.open("r", encoding="utf-8") as src:
+            for line in src:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                seq = entry.get("seq")
+                if not isinstance(seq, int):
+                    continue
+                if highest_seq is None or seq > highest_seq:
+                    highest_seq = seq
+        # Effective floor: never drop the highest seq present, even if
+        # caller asked us to. This preserves the counter watermark.
+        effective_floor = min_keep_seq
+        if highest_seq is not None and effective_floor > highest_seq:
+            effective_floor = highest_seq
+
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        dropped = 0
+        kept = 0
+        min_kept: int | None = None
+        max_kept: int | None = None
+        with self._path.open("r", encoding="utf-8") as src, \
+                tmp.open("w", encoding="utf-8") as dst:
+            for line in src:
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    # Torn fragment from prior crash — drop on rewrite.
+                    dropped += 1
+                    continue
+                if not isinstance(entry, dict):
+                    dropped += 1
+                    continue
+                seq = entry.get("seq")
+                if not isinstance(seq, int):
+                    dropped += 1
+                    continue
+                if seq < effective_floor:
+                    dropped += 1
+                    continue
+                dst.write(raw + "\n")
+                kept += 1
+                if min_kept is None or seq < min_kept:
+                    min_kept = seq
+                if max_kept is None or seq > max_kept:
+                    max_kept = seq
+            dst.flush()
+            os.fsync(dst.fileno())
+        tmp.replace(self._path)
+        # Counter (next-seq source) must remain ≥ max seq ever issued;
+        # truncation does NOT reset it (would re-issue dropped seqs).
+        return {"dropped": dropped, "kept": kept,
+                "min_kept_seq": min_kept, "max_kept_seq": max_kept}
 
     def _scan_max_seq(self) -> int:
         """Initialize the counter from the highest seq present in the WAL.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -613,11 +613,25 @@ class AgentRegistry:
         # parent-identity-AT-SPAWN (not the latest), so a rewind across a purge+name-reuse
         # does not resurrect this child under the reused parent.
         parent_seq = self._agent_create_seq.get(parent) if parent is not None else None
+        # #2259 PR-2b + #2103 C2b(b): the agent's stable identity is an IN-MEMORY ID assigned
+        # SYNCHRONOUSLY at spawn — NOT the WAL seq (now worker-assigned async, so unavailable
+        # synchronously; a child spawn must read the parent's identity NOW for the ⊆-parent cap).
+        # The worker links id↔seq in the durable `agent_created` record, and the identity
+        # generation (keyed by the durable worker seq, truncation-surviving) stores this id as
+        # ``create_seq`` — so rewind reconstructs identity/lineage from the gen (the owner-
+        # corrected model: no consumer reads a live/non-durable seq).
+        self._spawn_create_counter += 1
+        agent_id = self._spawn_create_counter
+        self._agent_create_seq[name] = agent_id
         if self._state_log is not None:
-            seq = await self._state_log.append(
+            # Non-blocking (the blocking-invariant): append_nowait + the identity-gen job are a
+            # synchronous pair (no await between → atomic enqueue; the gen job is FIFO-after the
+            # agent_created WAL job, so it stamps the gen at that durable seq, invariant #2).
+            self._state_log.append_nowait(
                 "agent_created", entity_kind="agent", name=name, sid="",
                 parent=parent,  # #2103 B: lineage for rewind-reconstruction
                 parent_seq=parent_seq,  # #2103 C2b: parent identity-at-spawn (rewind)
+                agent_id=agent_id,  # #2259 PR-2b: the in-memory identity (links to the seq)
                 profile={
                     "name": profile.name,
                     "role": profile.role,
@@ -626,19 +640,7 @@ class AgentRegistry:
                     "allowed_mcp": profile.allowed_mcp,
                 },
             )
-            # #2103 C2b: this agent's stable identity = its agent_created WAL seq.
-            self._agent_create_seq[name] = seq
-            # #2259 PR-1b: ALSO persist identity + lineage as a truncation-surviving
-            # generation — the `agent_created` event above is dropped when the WAL is
-            # truncated below the floor, which would lose the ⊆-parent cap on rewind
-            # (escalation-on-rewind). The generation is the recovery base for identity.
-            self._record_agent_identity_generation(name, seq)
-        else:
-            # #2103 C2b Q1: no-WAL fallback — a monotonic counter (no rewind to
-            # reconstruct against here), so a create_agent parent is ALWAYS identity-
-            # tracked and name-reuse is detected even without a state_log.
-            self._spawn_create_counter += 1
-            self._agent_create_seq[name] = self._spawn_create_counter
+            self._record_agent_identity_generation(name)
         return profile
 
     def remove(self, name: str, *, purge: bool = False) -> "list[tuple[str, Topology | None]]":
@@ -1557,22 +1559,35 @@ class AgentRegistry:
             self._project_root / ".reyn" / "state" / "agent_identity",
         )
 
-    def _record_agent_identity_generation(self, name: str, seq: int) -> None:
-        """#2259 PR-1b: persist ``name``'s identity (``create_seq``) + frozen spawn edge as a
-        truncation-surviving generation keyed by its create seq, so a rewind reconstructs the
-        ⊆-parent cap from the generation — NOT from the `agent_created` WAL event, which
-        truncation drops (a dropped lineage edge → resolved_profile_for skips the parent-conjunct
-        → child runs UN-capped). No-op without a WAL (no rewind to reconstruct against)."""
+    def _record_agent_identity_generation(self, name: str) -> None:
+        """#2259 PR-1b + PR-2b: persist ``name``'s identity (``create_seq`` = its in-memory id) +
+        frozen spawn edge as a truncation-surviving generation, keyed by the DURABLE
+        ``agent_created`` WAL seq — so a rewind reconstructs the ⊆-parent cap from the generation,
+        NOT from the `agent_created` WAL event (truncation drops it → escalation-on-rewind).
+
+        PR-2b: the keying seq is assigned in the worker (seq-in-worker), so the gen record runs
+        in a worker job that reads ``last_assigned_seq`` (= the paired ``agent_created`` append's
+        seq, FIFO-before this job). No await between the append_nowait + this call → atomic pair
+        (invariant #2). No-op without a WAL."""
         if self._state_log is None:
             return
         edge = self._spawn_lineage.get(name)
-        self._agent_identity_generation_store().record(
-            name,
-            create_seq=self._agent_create_seq.get(name, seq),
-            spawn_parent=edge[0] if edge else None,
-            spawn_parent_seq=edge[1] if edge else None,
-            seq=seq,
-        )
+        create_id = self._agent_create_seq.get(name, 0)
+        spawn_parent = edge[0] if edge else None
+        spawn_parent_seq = edge[1] if edge else None
+        log = self._state_log
+        store = self._agent_identity_generation_store()
+
+        async def _record() -> None:
+            store.record(
+                name,
+                create_seq=create_id,
+                spawn_parent=spawn_parent,
+                spawn_parent_seq=spawn_parent_seq,
+                seq=log.last_assigned_seq,
+            )
+
+        log.submit_durable_nowait(_record)
 
     def _agent_identity_as_of_cut(
         self, cut: int,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -689,7 +689,7 @@ class AgentRegistry:
             # _default_topology) skip archived members so it stays dormant. The
             # WAL-window GC hard-purges + cascades once the archival seq leaves the
             # window (slice 2).
-            seq = self._state_log.current_seq if self._state_log is not None else 0
+            seq = self._state_log.last_durable_seq if self._state_log is not None else 0
             (target / ARCHIVED_MARKER).write_text(str(seq), encoding="utf-8")
         return []  # archive does not cascade — topology membership preserved (#1954)
 
@@ -1056,7 +1056,7 @@ class AgentRegistry:
             for session in sessions:
                 await session.await_quiescent()
             # 4. single global reset-record; supersedes = prior active head (audit).
-            prior_head = self._state_log.current_seq
+            prior_head = self._state_log.last_durable_seq
             reset_seq = await _append_reset_record(
                 self._state_log, target_seq=seq, supersedes=prior_head,
             )
@@ -1604,7 +1604,7 @@ class AgentRegistry:
         if self._state_log is None:
             return
         self._config_generation_store().record(
-            rel_path, content, self._state_log.current_seq,
+            rel_path, content, self._state_log.last_durable_seq,
         )
 
     def _reconcile_config_as_of_cut(self, cut: int) -> None:
@@ -1920,7 +1920,7 @@ class AgentRegistry:
         target = active_rewind_target(self._state_log)
         if target is None:
             return None
-        head = self._state_log.current_seq
+        head = self._state_log.last_durable_seq
         agents = await self._materialize_rewind(
             reconstruct_seq=head, workspace_at_or_below=head,
         )

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -209,9 +209,11 @@ class AgentRegistry:
         # mismatches → the edge is STALE → resolved_profile_for #2161-fail-closes and
         # is_spawn_descendant rejects (fixes both consumers from one identity check;
         # composes with #2161's absent-parent existence-check). The identity is minted
-        # in create_agent (the spawn seam): the agent_created WAL seq when a state_log
-        # is present, else an in-memory monotonic counter (Q1: every create_agent parent
-        # is identity-tracked → name-reuse always detected for real spawn lineages; a
+        # in create_agent (the spawn seam) as an IN-MEMORY monotonic counter (#2259 PR-2b
+        # owner (b) model: agent identity = in-memory id synced at spawn; the WAL seq is now
+        # worker-assigned async + unavailable synchronously, so the counter IS the identity —
+        # the worker links id↔seq in the durable agent_created record). (Q1: every create_agent
+        # parent is identity-tracked → name-reuse always detected for real spawn lineages; a
         # bare-``create()`` non-spawn parent has no identity → None → #2161 existence
         # fallback, no false-positive, Q2).
         self._spawn_lineage: "dict[str, tuple[str, int | None]]" = {}
@@ -219,8 +221,10 @@ class AgentRegistry:
         # Rebuilt as-of-cut on rewind (_materialize_rewind). A name-reused agent has a
         # NEW token here, so a stored edge carrying the OLD token reads as stale.
         self._agent_create_seq: "dict[str, int]" = {}
-        # #2103 C2b: the no-WAL identity source (monotonic; only used when state_log is
-        # None — there is no rewind to reconstruct against in that mode).
+        # #2103 C2b + #2259 PR-2b: the monotonic in-memory identity source — now the identity
+        # for EVERY create_agent (the WAL seq is worker-assigned async, so the in-memory id is
+        # what a child reads synchronously at spawn for the ⊆-parent cap; the worker links
+        # id↔seq in the durable agent_created record + the truncation-surviving identity gen).
         self._spawn_create_counter: int = 0
         # #2081: delegation policy. ``deny`` narrows an UNBOUND delegate with the
         # restrictive _delegate floor; ``inherit`` (default) = byte-identical to

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1995,7 +1995,9 @@ class AgentRegistry:
         if floor <= 0:
             return None
         try:
-            stats = await self._state_log.truncate_below(floor)
+            # #2259 PR-2b: fire-and-forget (the GC does not await the worker); the rewrite +
+            # any failure are handled in the worker (stats on last_truncate_stats, post-drain).
+            await self._state_log.truncate_below(floor)
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("WAL truncation: rewrite failed (floor=%d): %s", floor, e)
             return None
@@ -2007,7 +2009,10 @@ class AgentRegistry:
         # floor — generations >= floor stay reconstructable, so this never drops
         # rewind history within the retention window.
         await self._prune_generations_below(floor)
-        return stats
+        # #2259 PR-2b: truncate is fire-and-forget, so this returns the last-recorded stats
+        # (a non-None dict = "truncation triggered"; the actual rewrite drains in the worker).
+        # The caller only uses not-None as the trigger signal (we don't gate on dropped==0).
+        return self._state_log.last_truncate_stats
 
     async def _prune_generations_below(self, floor: int) -> None:
         """Drop snapshot generations below ``floor`` (Stage 1e GC).

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -6,6 +6,7 @@ All WAL-recorded mutations go through here; in-memory readers go via the
 from __future__ import annotations
 
 import asyncio
+import copy
 import uuid
 from pathlib import Path
 
@@ -439,25 +440,31 @@ class SnapshotJournal:
         """#2259 PR-2b: persist the snapshot NON-BLOCKING — the fire-and-forget counterpart of
         `save()`, paired with `_wal_append_nowait`.
 
-        SYNCHRONOUS (no await): (1) stamp `applied_seq` from `state_log.last_assigned_seq` — the
-        seq the PAIRED `_wal_append_nowait` just assigned (read here, with no await between the
-        two enqueues, so it is THIS mutation's WAL seq, never a later one — invariant #2);
-        (2) serialize a CONSISTENT view of the mutable state at this instant (serialize-sync-at-
-        submit, criterion #3); (3) fire-and-forget the durable write through the SAME serial
-        worker, AFTER the WAL append (FIFO → snapshot.applied_seq becomes durable only after its
-        WAL seq — the FIFO lag, criterion #1; a crash mid-pair → recovery replays the WAL entry
-        onto the prior snapshot = consistent prefix, criterion #2).
+        (1) DEEP-COPY the payload SYNCHRONOUSLY (serialize-sync-at-submit, criterion #3 — a
+        consistent view of the mutable state at this instant, immune to a later in-place mutation
+        e.g. `chain["waiting_on"]=…`); (2) in the durable JOB, stamp `applied_seq` from
+        `state_log.last_assigned_seq` — the seq the PAIRED `_wal_append_nowait`'s WAL job assigned
+        IN THE WORKER. The pair was enqueued atomically (the journal mutation calls
+        `_wal_append_nowait` then `save_nowait` with NO await between), so the worker's FIFO runs
+        WAL_N then snap_N with no other WAL job between → snap_N reads WAL_N's seq, never a later
+        one (invariant #2), and the seq is worker-assigned (a durable WAL seq, never a non-durable
+        sync value — the hole the sync-seq had). (3) fire-and-forget through the SAME serial worker
+        AFTER the WAL append (FIFO lag → applied_seq ≤ durable-WAL-seq, criterion #1; a crash
+        mid-pair → recovery replays the WAL entry onto the prior snapshot = consistent prefix,
+        criterion #2). The hot path NEVER awaits durability (the blocking-invariant).
 
-        No WAL (`state_log is None`: tests / non-chat) → the original synchronous save (the
-        in-memory `applied_seq` is left as the caller set it)."""
+        No WAL (`state_log is None`: tests / non-chat) → the original synchronous save."""
         if self._state_log is None:
             self._snapshot.save(self._snapshot_path)
             return
-        self._snapshot.applied_seq = self._state_log.last_assigned_seq
-        data = self._snapshot.serialize()  # sync: consistent state + the stamped applied_seq
+        payload = copy.deepcopy(self._snapshot.to_payload())  # sync consistent capture
         path = self._snapshot_path
+        log = self._state_log
 
         async def _write() -> None:
-            await asyncio.to_thread(AgentSnapshot.write_durable, path, data)
+            payload["applied_seq"] = log.last_assigned_seq  # worker-assigned seq, read in the job
+            await asyncio.to_thread(
+                AgentSnapshot.write_durable, path, AgentSnapshot.serialize_payload(payload),
+            )
 
-        self._state_log.submit_durable_nowait(_write)
+        log.submit_durable_nowait(_write)

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -73,17 +73,18 @@ class SnapshotJournal:
         log = self._state_log  # local so the funnel replace doesn't recurse into this call
         return await log.append(kind, session_id=self._session_id, **fields)
 
-    def _wal_append_nowait(self, kind: str, **fields) -> "int | None":
-        """#2259 PR-2b: the NON-BLOCKING WAL-append chokepoint — assigns the seq synchronously +
-        fire-and-forgets the durable write. Same session-tagging funnel as `_wal_append`. Returns
-        the assigned seq (sync), but the caller does NOT depend on it: the paired `save_nowait`
-        reads `state_log.last_assigned_seq` to stamp the snapshot. Pairs with `save_nowait` —
-        called back-to-back with NO await between, so the (WAL, snapshot) enqueue is atomic on the
-        loop (invariant #2). No-op without a WAL."""
+    def _wal_append_nowait(self, kind: str, **fields) -> None:
+        """#2259 PR-2b: the NON-BLOCKING WAL-append chokepoint — fire-and-forgets the durable write
+        through the worker. Same session-tagging funnel as `_wal_append`. Returns nothing: the seq
+        is assigned IN the worker's WAL job (seq-in-worker — never synchronously on the loop, so no
+        durable artifact can reference a not-yet-durable seq). The paired `save_nowait` reads
+        `state_log.last_assigned_seq` (the seq this WAL job assigned) to stamp the snapshot. Pairs
+        with `save_nowait` — called back-to-back with NO await between, so the (WAL, snapshot) enqueue
+        is atomic on the loop (invariant #2). No-op without a WAL."""
         if self._state_log is None:
-            return None
+            return
         log = self._state_log
-        return log.append_nowait(kind, session_id=self._session_id, **fields)
+        log.append_nowait(kind, session_id=self._session_id, **fields)
 
     def set_session_id(self, session_id: str) -> None:
         """FP-0043 Stage 5: set the conversation session id post-construction

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -136,11 +136,33 @@ class SnapshotJournal:
         """
         if self._generation_store is None or self._state_log is None:
             return
-        self._generation_store.record(self._snapshot)
-        if self._anchor_store is not None and anchor:
-            self._anchor_store.capture(
-                self._snapshot.applied_seq, anchor, full=full_message,
-            )
+        # #2259 PR-2b: capture the content SYNC (consistent at this boundary), then record the
+        # generation in a worker job that stamps applied_seq from the worker-assigned seq — so
+        # the gen is (content-at-cut, seq-at-cut), never a live snapshot whose content is AHEAD
+        # of its (last-durable) applied_seq (which a rewind would replay+double-apply). The job
+        # is FIFO-after the pre-cut mutations' WAL jobs and before any post-cut one, so
+        # last_assigned_seq = the last pre-cut mutation's seq, matching the captured content.
+        payload = copy.deepcopy(self._snapshot.to_payload())
+        store = self._generation_store
+        log = self._state_log
+        anchor_store = self._anchor_store
+
+        async def _record() -> None:
+            seq = log.last_assigned_seq
+            payload["applied_seq"] = seq
+            store.record_payload(payload, seq)
+            if anchor_store is not None and anchor:
+                anchor_store.capture(seq, anchor, full=full_message)
+
+        log.submit_durable_nowait(_record)
+
+    async def flush(self) -> None:
+        """#2259 PR-2b: drain every enqueued durable write (WAL + snapshot + gen) for this
+        journal's worker, WITHOUT closing it — a barrier so a caller (or test) can observe a
+        fire-and-forget mutation's durable effect (applied_seq stamped, snapshot/gen on disk).
+        No-op without a WAL."""
+        if self._state_log is not None:
+            await self._state_log.flush()
 
     # ── public read access ────────────────────────────────────────────────
 
@@ -162,15 +184,14 @@ class SnapshotJournal:
         msg_id = uuid.uuid4().hex[:8]
         full_payload = {**payload, "_msg_id": msg_id}
         if self._state_log is not None:
-            seq = await self._wal_append(
+            self._wal_append_nowait(
                 "inbox_put", target=self._agent_name,
                 msg_id=msg_id, msg_kind=kind, payload=full_payload,
             )
-            self._snapshot.applied_seq = seq
             self._snapshot.inbox.append({
                 "id": msg_id, "kind": kind, "payload": full_payload,
             })
-            await self.save()
+            self.save_nowait()
         return msg_id
 
     async def consume_inbox(self, *, msg_id: str) -> None:
@@ -181,14 +202,13 @@ class SnapshotJournal:
         """
         if self._state_log is None or msg_id is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "inbox_consume", agent=self._agent_name, msg_id=msg_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.inbox = [
             m for m in self._snapshot.inbox if m.get("id") != msg_id
         ]
-        await self.save()
+        self.save_nowait()
 
     async def record_chain_register(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_register`` to WAL and create the pending_chains entry.
@@ -199,16 +219,15 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "chain_register", agent=self._agent_name, chain_id=chain_id,
             **fields,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.pending_chains[chain_id] = {
             "chain_id": chain_id,
             **{k: (list(v) if k == "waiting_on" else v) for k, v in fields.items()},
         }
-        await self.save()
+        self.save_nowait()
 
     async def record_chain_update(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_update`` to WAL and update waiting_on in snapshot.
@@ -218,16 +237,15 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "chain_update", agent=self._agent_name, chain_id=chain_id,
             **fields,
         )
-        self._snapshot.applied_seq = seq
         chain = self._snapshot.pending_chains.get(chain_id)
         if chain is not None:
             waiting_on = fields.get("waiting_on", [])
             chain["waiting_on"] = list(waiting_on)
-        await self.save()
+        self.save_nowait()
 
     async def record_chain_resolve(self, *, chain_id: str) -> None:
         """Append ``chain_resolve`` to WAL and remove the pending_chains entry.
@@ -236,12 +254,11 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "chain_resolve", agent=self._agent_name, chain_id=chain_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.pending_chains.pop(chain_id, None)
-        await self.save()
+        self.save_nowait()
 
     async def record_chain_timeout_fired(self, *, chain_id: str) -> None:
         """Append ``chain_timeout_fired`` to WAL and remove the pending_chains entry.
@@ -250,12 +267,11 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "chain_timeout_fired", agent=self._agent_name, chain_id=chain_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.pending_chains.pop(chain_id, None)
-        await self.save()
+        self.save_nowait()
 
     # ── intervention persistence (PR-intervention-link L2) ────────────────
 
@@ -274,15 +290,14 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "intervention_dispatched",
             target=self._agent_name,
             intervention_id=intervention_id,
             iv_dict=iv_dict,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.outstanding_interventions[intervention_id] = iv_dict
-        await self.save()
+        self.save_nowait()
 
     async def record_intervention_resolved(
         self, *, intervention_id: str,
@@ -294,14 +309,13 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "intervention_resolved",
             target=self._agent_name,
             intervention_id=intervention_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.outstanding_interventions.pop(intervention_id, None)
-        await self.save()
+        self.save_nowait()
 
     async def record_intervention_answer_buffered(
         self, *, run_id: str, text: str, choice_id: str | None,
@@ -316,18 +330,17 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "intervention_answer_buffered",
             target=self._agent_name,
             run_id=run_id,
             text=text,
             choice_id=choice_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.buffered_intervention_answers[run_id] = {
             "text": text, "choice_id": choice_id,
         }
-        await self.save()
+        self.save_nowait()
 
     async def record_intervention_answer_consumed(
         self, *, run_id: str,
@@ -343,14 +356,13 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "intervention_answer_consumed",
             target=self._agent_name,
             run_id=run_id,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.buffered_intervention_answers.pop(run_id, None)
-        await self.save()
+        self.save_nowait()
 
     async def record_next_turn_context_staged(
         self, *, kind: str, payload: dict,
@@ -364,14 +376,13 @@ class SnapshotJournal:
         if self._state_log is None:
             return
         entry = {"kind": kind, "payload": payload}
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "next_turn_context_staged",
             target=self._agent_name,
             entry=entry,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.next_turn_context.append(entry)
-        await self.save()
+        self.save_nowait()
 
     async def record_next_turn_context_cleared(self) -> None:
         """Append ``next_turn_context_cleared`` to WAL + clear the buffer (#1800-4b).
@@ -382,13 +393,12 @@ class SnapshotJournal:
         """
         if self._state_log is None:
             return
-        seq = await self._wal_append(
+        self._wal_append_nowait(
             "next_turn_context_cleared",
             target=self._agent_name,
         )
-        self._snapshot.applied_seq = seq
         self._snapshot.next_turn_context.clear()
-        await self.save()
+        self.save_nowait()
 
     # ── restore / persist ─────────────────────────────────────────────────
 
@@ -460,11 +470,19 @@ class SnapshotJournal:
         payload = copy.deepcopy(self._snapshot.to_payload())  # sync consistent capture
         path = self._snapshot_path
         log = self._state_log
+        snapshot = self._snapshot
 
         async def _write() -> None:
-            payload["applied_seq"] = log.last_assigned_seq  # worker-assigned seq, read in the job
+            seq = log.last_assigned_seq  # worker-assigned seq, read in the job (after the WAL job)
+            payload["applied_seq"] = seq
             await asyncio.to_thread(
                 AgentSnapshot.write_durable, path, AgentSnapshot.serialize_payload(payload),
             )
+            # #2259 PR-2b: track the DURABLE seq on the in-memory snapshot AFTER the write — the
+            # truncate floor (`compute_truncate_floor` → min agent applied_seq) reads this in-memory
+            # value, so it must equal the last-DURABLE seq (never ahead of durability, or the floor
+            # could drop a WAL entry a not-yet-durable snapshot still needs). Set post-write = lags
+            # toward durable = conservative + correct. Atomic int assign on the loop (no race).
+            snapshot.applied_seq = seq
 
         log.submit_durable_nowait(_write)

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -72,6 +72,18 @@ class SnapshotJournal:
         log = self._state_log  # local so the funnel replace doesn't recurse into this call
         return await log.append(kind, session_id=self._session_id, **fields)
 
+    def _wal_append_nowait(self, kind: str, **fields) -> "int | None":
+        """#2259 PR-2b: the NON-BLOCKING WAL-append chokepoint — assigns the seq synchronously +
+        fire-and-forgets the durable write. Same session-tagging funnel as `_wal_append`. Returns
+        the assigned seq (sync), but the caller does NOT depend on it: the paired `save_nowait`
+        reads `state_log.last_assigned_seq` to stamp the snapshot. Pairs with `save_nowait` —
+        called back-to-back with NO await between, so the (WAL, snapshot) enqueue is atomic on the
+        loop (invariant #2). No-op without a WAL."""
+        if self._state_log is None:
+            return None
+        log = self._state_log
+        return log.append_nowait(kind, session_id=self._session_id, **fields)
+
     def set_session_id(self, session_id: str) -> None:
         """FP-0043 Stage 5: set the conversation session id post-construction
         (spawn_session uses this for a spawned session, before its run-loop goes
@@ -422,3 +434,30 @@ class SnapshotJournal:
             await asyncio.to_thread(AgentSnapshot.write_durable, path, data)
 
         await self._state_log.submit_durable(_write)
+
+    def save_nowait(self) -> None:
+        """#2259 PR-2b: persist the snapshot NON-BLOCKING — the fire-and-forget counterpart of
+        `save()`, paired with `_wal_append_nowait`.
+
+        SYNCHRONOUS (no await): (1) stamp `applied_seq` from `state_log.last_assigned_seq` — the
+        seq the PAIRED `_wal_append_nowait` just assigned (read here, with no await between the
+        two enqueues, so it is THIS mutation's WAL seq, never a later one — invariant #2);
+        (2) serialize a CONSISTENT view of the mutable state at this instant (serialize-sync-at-
+        submit, criterion #3); (3) fire-and-forget the durable write through the SAME serial
+        worker, AFTER the WAL append (FIFO → snapshot.applied_seq becomes durable only after its
+        WAL seq — the FIFO lag, criterion #1; a crash mid-pair → recovery replays the WAL entry
+        onto the prior snapshot = consistent prefix, criterion #2).
+
+        No WAL (`state_log is None`: tests / non-chat) → the original synchronous save (the
+        in-memory `applied_seq` is left as the caller set it)."""
+        if self._state_log is None:
+            self._snapshot.save(self._snapshot_path)
+            return
+        self._snapshot.applied_seq = self._state_log.last_assigned_seq
+        data = self._snapshot.serialize()  # sync: consistent state + the stamped applied_seq
+        path = self._snapshot_path
+
+        async def _write() -> None:
+            await asyncio.to_thread(AgentSnapshot.write_durable, path, data)
+
+        self._state_log.submit_durable_nowait(_write)

--- a/src/reyn/skill/skill_registry.py
+++ b/src/reyn/skill/skill_registry.py
@@ -29,6 +29,8 @@ Design invariants:
 """
 from __future__ import annotations
 
+import asyncio
+import copy
 import logging
 import time
 from pathlib import Path
@@ -106,6 +108,15 @@ class SkillRegistry:
         log = self._state_log  # local so the funnel replace doesn't recurse here
         return await log.append(kind, session_id=self._session_id, **fields)
 
+    def _wal_append_nowait(self, kind: str, **fields):
+        """#2259 PR-2b: the NON-BLOCKING WAL-append chokepoint (no-return) — assigns the seq in
+        the worker, fire-and-forgets the write. Pairs with ``_save_nowait`` (called back-to-back,
+        no await between → atomic enqueue, invariant #2). No-op without a WAL."""
+        if self._state_log is None:
+            return None
+        log = self._state_log
+        return log.append_nowait(kind, session_id=self._session_id, **fields)
+
     def set_session_id(self, session_id: str) -> None:
         """FP-0043 Stage 5: set the conversation session id post-construction
         (spawn_session, before the spawned session's run-loop goes live)."""
@@ -173,7 +184,9 @@ class SkillRegistry:
         snap = SkillSnapshot.empty(run_id, skill_name, skill_input)
         snap.parent_run_id = parent_run_id
         if self._state_log is not None:
-            seq = await self._wal_append(
+            # #2259 PR-2b: non-blocking pair — append_nowait + save_nowait (no await between, so
+            # the WAL + skill-snapshot enqueue is atomic; the seqs are stamped in the save job).
+            self._wal_append_nowait(
                 "skill_started",
                 target=self._agent_name,
                 agent=self._agent_name,
@@ -182,11 +195,7 @@ class SkillRegistry:
                 skill_input=skill_input,
                 parent_run_id=parent_run_id,
             )
-            snap.applied_seq = seq
-            # Stamp the phase-window watermark too: anything before this
-            # seq is irrelevant to this run (run hadn't started yet).
-            snap.last_phase_applied_seq = seq
-        self._save(snap)
+        self._save_nowait(snap)
         self._snapshots[run_id] = snap
         # #2068: a (re)entry begins a fresh run-SEGMENT → re-arm the skill_end
         # exactly-once guard so this segment's eventual exit fires skill_end (resume
@@ -228,7 +237,7 @@ class SkillRegistry:
             )
             return
         if self._state_log is not None:
-            seq = await self._wal_append(
+            self._wal_append_nowait(
                 "skill_phase_advanced",
                 target=self._agent_name,
                 agent=self._agent_name,
@@ -236,13 +245,11 @@ class SkillRegistry:
                 next_phase=next_phase,
                 last_phase_artifact_path=last_phase_artifact_path,
             )
-            snap.applied_seq = seq
-            snap.last_phase_applied_seq = seq
         snap.current_phase = next_phase
         snap.history.append(next_phase)
         snap.visit_counts[next_phase] = snap.visit_counts.get(next_phase, 0) + 1
         snap.last_phase_artifact_path = last_phase_artifact_path
-        self._save(snap)
+        self._save_nowait(snap)  # #2259 PR-2b: non-blocking pair (seqs stamped in the save job)
         await self._fire_truncate_hook(trigger="skill_phase_advanced")
 
     async def complete(
@@ -275,7 +282,7 @@ class SkillRegistry:
                 f"expected 'completed' or 'discarded'",
             )
         if self._state_log is not None:
-            await self._wal_append(
+            self._wal_append_nowait(  # #2259 PR-2b: non-blocking (WAL-only; snapshot torn down)
                 kind,
                 target=self._agent_name,
                 agent=self._agent_name,
@@ -289,13 +296,24 @@ class SkillRegistry:
         # interrupt/error paths via interrupt(), closing the start↔end asymmetry.
         await self._dispatch_skill_end(run_id, status)
         snap_path = self._skills_dir / f"{run_id}.snapshot.json"
-        try:
-            snap_path.unlink(missing_ok=True)
-        except OSError as e:
-            logger.warning(
-                "complete: cannot remove skill snapshot %s: %s",
-                snap_path, e,
-            )
+
+        def _unlink_snap() -> None:
+            try:
+                snap_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.warning(
+                    "complete: cannot remove skill snapshot %s: %s", snap_path, e,
+                )
+
+        if self._state_log is not None:
+            # #2259 PR-2b: route the delete through the worker so it runs FIFO-AFTER any queued
+            # save_nowait for this run — else a not-yet-drained start/advance save would re-create
+            # the file after this delete (the same serialization the WAL-then-snapshot pair has).
+            async def _delete_job() -> None:
+                _unlink_snap()
+            self._state_log.submit_durable_nowait(_delete_job)
+        else:
+            _unlink_snap()
         # R-D10: also remove the per-run llm_results/ side directory, if
         # any large LLM responses were written to disk during this run.
         # Lifecycle is bound to the snapshot — deleting them together
@@ -376,7 +394,7 @@ class SkillRegistry:
             return
         snap.awaiting_since = time.monotonic()
         snap.awaiting_intervention_id = intervention_id
-        self._save(snap)
+        self._persist_nowait(snap)  # #2259 PR-2b: through the worker (no race, no seq re-stamp)
 
     def clear_awaiting(self, *, run_id: str) -> None:
         """Reset awaiting state — called when an intervention is resolved.
@@ -396,7 +414,7 @@ class SkillRegistry:
             return
         snap.awaiting_since = None
         snap.awaiting_intervention_id = None
-        self._save(snap)
+        self._persist_nowait(snap)  # #2259 PR-2b: through the worker (no race, no seq re-stamp)
 
     # ── read access ──────────────────────────────────────────────────────
 
@@ -464,3 +482,46 @@ class SkillRegistry:
     def _save(self, snap: SkillSnapshot) -> None:
         path = self._skills_dir / f"{snap.skill_run_id}.snapshot.json"
         snap.save(path)
+
+    def _save_nowait(self, snap: SkillSnapshot) -> None:
+        """#2259 PR-2b: persist the skill snapshot NON-BLOCKING — fire-and-forget, stamping
+        ``applied_seq`` + ``last_phase_applied_seq`` from the worker-assigned seq in the durable
+        job (paired with ``_wal_append_nowait``). Captures the payload SYNC (serialize-sync-at-
+        submit), and sets the in-memory seqs AFTER the durable write — the truncate floor reads
+        ``last_phase_applied_seq``, so it must lag-toward-durable (never ahead). No WAL → sync save."""
+        if self._state_log is None:
+            self._save(snap)
+            return
+        path = self._skills_dir / f"{snap.skill_run_id}.snapshot.json"
+        payload = copy.deepcopy(snap.to_payload())
+        log = self._state_log
+
+        async def _write() -> None:
+            seq = log.last_assigned_seq
+            payload["applied_seq"] = seq
+            payload["last_phase_applied_seq"] = seq
+            await asyncio.to_thread(
+                SkillSnapshot.write_durable, path, SkillSnapshot.serialize_payload(payload),
+            )
+            snap.applied_seq = seq
+            snap.last_phase_applied_seq = seq
+
+        log.submit_durable_nowait(_write)
+
+    def _persist_nowait(self, snap: SkillSnapshot) -> None:
+        """#2259 PR-2b: persist a snapshot-only update (no paired WAL append → no seq change)
+        through the worker, NON-BLOCKING. Routes the write through the SAME serial worker as the
+        WAL/save jobs so it never races a concurrent ``_save_nowait`` writing the same file; does
+        NOT re-stamp applied_seq (there is no new event). No WAL → sync save."""
+        if self._state_log is None:
+            self._save(snap)
+            return
+        path = self._skills_dir / f"{snap.skill_run_id}.snapshot.json"
+        payload = copy.deepcopy(snap.to_payload())
+
+        async def _write() -> None:
+            await asyncio.to_thread(
+                SkillSnapshot.write_durable, path, SkillSnapshot.serialize_payload(payload),
+            )
+
+        self._state_log.submit_durable_nowait(_write)

--- a/src/reyn/skill/skill_snapshot.py
+++ b/src/reyn/skill/skill_snapshot.py
@@ -127,15 +127,11 @@ class SkillSnapshot:
             parent_run_id=data.get("parent_run_id"),
         )
 
-    def save(self, path: Path) -> None:
-        """Persist atomically: write to ``.tmp``, fsync, rename.
-
-        A mid-write crash leaves the previous file intact.
-        """
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        payload = {
+    def to_payload(self) -> dict:
+        """The serialisable payload dict. #2259 PR-2b: ``_save_nowait`` deep-copies this for a
+        consistent sync capture, then stamps ``applied_seq`` + ``last_phase_applied_seq`` from
+        the worker-assigned seq in the durable job (the seq is not known on the task loop)."""
+        return {
             "version": SKILL_SNAPSHOT_VERSION,
             "skill_run_id": self.skill_run_id,
             "skill_name": self.skill_name,
@@ -151,8 +147,27 @@ class SkillSnapshot:
             "last_committed_step_id": self.last_committed_step_id,
             "parent_run_id": self.parent_run_id,
         }
+
+    @staticmethod
+    def write_durable(path: Path, data: str) -> None:
+        """Atomically + durably write pre-serialised ``data`` (tmp → fsync → rename). Pure I/O
+        (no mutable-state access), so it is safe to run OFF the event loop (#2259 PR-2b)."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
         with tmp.open("w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.write(data)
             f.flush()
             os.fsync(f.fileno())
         tmp.replace(path)
+
+    @staticmethod
+    def serialize_payload(payload: dict) -> str:
+        return json.dumps(payload, ensure_ascii=False, indent=2)
+
+    def save(self, path: Path) -> None:
+        """Persist atomically: write to ``.tmp``, fsync, rename.
+
+        A mid-write crash leaves the previous file intact.
+        """
+        self.write_durable(path, self.serialize_payload(self.to_payload()))

--- a/tests/chat/services/test_snapshot_journal.py
+++ b/tests/chat/services/test_snapshot_journal.py
@@ -50,6 +50,7 @@ async def test_consume_inbox_no_wal_is_noop(tmp_path):
     j = make_journal(tmp_path, with_state_log=False)
     # should not raise
     await j.consume_inbox(msg_id="deadbeef")
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq == 0
 
 
@@ -70,6 +71,7 @@ async def test_chain_methods_no_wal_are_noops(tmp_path):
     await j.record_chain_update(chain_id="c1", fields={"waiting_on": []})
     await j.record_chain_resolve(chain_id="c1")
     await j.record_chain_timeout_fired(chain_id="c1")
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq == 0
 
 
@@ -88,6 +90,7 @@ async def test_append_inbox_returns_msg_id_and_updates_snapshot(tmp_path):
     assert entry["id"] == msg_id
     assert entry["kind"] == "user_message"
     assert entry["payload"]["_msg_id"] == msg_id
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq >= 1
 
 
@@ -101,6 +104,7 @@ async def test_consume_inbox_removes_entry_from_snapshot(tmp_path):
     await j.consume_inbox(msg_id=msg_id)
 
     assert j.snapshot.inbox == []
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq >= 2
 
 
@@ -122,6 +126,7 @@ async def test_chain_register_adds_to_pending_chains(tmp_path):
     assert chain["chain_id"] == "chain-1"
     assert chain["origin_agent"] == "root"
     assert chain["waiting_on"] == ["child_a", "child_b"]
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq >= 1
 
 
@@ -198,6 +203,7 @@ async def test_install_replaces_snapshot_and_persists(tmp_path):
 
     j.install(external)
 
+    await j.flush()  # #2259 PR-2b: durability is async
     assert j.snapshot.applied_seq == 42
     assert j.snapshot.inbox[0]["id"] == "aabbccdd"
     assert snapshot_path.exists()
@@ -212,6 +218,7 @@ async def test_save_writes_snapshot_to_disk(tmp_path):
     snapshot_path = tmp_path / "snapshot.json"
 
     await j.append_inbox(kind="user_message", payload={"x": 1})
+    await j.flush()  # #2259 PR-2b: the durable snapshot write is async
     # save() is called internally; check it round-trips correctly
     persisted = json.loads(snapshot_path.read_text())
     assert persisted["inbox"] != []
@@ -225,10 +232,12 @@ async def test_applied_seq_monotonically_increases(tmp_path):
     seqs: list[int] = []
 
     await j.append_inbox(kind="msg", payload={})
+    await j.flush()  # #2259 PR-2b: durability (+ applied_seq stamp) is async
     seqs.append(j.snapshot.applied_seq)
 
     msg_id = j.snapshot.inbox[0]["id"]
     await j.consume_inbox(msg_id=msg_id)
+    await j.flush()
     seqs.append(j.snapshot.applied_seq)
 
     await j.record_chain_register(
@@ -240,9 +249,11 @@ async def test_applied_seq_monotonically_increases(tmp_path):
             "waiting_on": ["x"],
         },
     )
+    await j.flush()
     seqs.append(j.snapshot.applied_seq)
 
     await j.record_chain_resolve(chain_id="cx")
+    await j.flush()
     seqs.append(j.snapshot.applied_seq)
 
     # strict monotonic increase
@@ -280,5 +291,6 @@ async def test_cut_generation_records_runtime_generation_at_boundary_seq(tmp_pat
     journal.snapshot.applied_seq = seq   # simulate the boundary snapshot
 
     await journal.cut_generation()
+    await journal.flush()  # #2259 PR-2b: the gen-record runs in a worker job
 
-    assert seq in gen_store.seqs()        # runtime generation recorded (sync gen store)
+    assert seq in gen_store.seqs()        # runtime generation recorded at the worker-assigned seq

--- a/tests/test_1765_snapshot_journal_off_loop.py
+++ b/tests/test_1765_snapshot_journal_off_loop.py
@@ -71,6 +71,7 @@ async def test_snapshot_save_keeps_event_loop_free(tmp_path, monkeypatch):
 
     ticker = asyncio.create_task(_ticker())
     await j.append_inbox(kind="msg", payload={"text": "hi"})
+    await j.flush()  # #2259 PR-2b: drain the fire-and-forget slow save (off-loop → ticker runs)
     assert ticks > 0, "the loop must keep running during the slow off-loop snapshot write"
     await ticker
     await sl.aclose()
@@ -102,6 +103,7 @@ async def test_snapshot_durable_only_after_its_wal_seq(tmp_path, monkeypatch):
                 "original_request": "r", "waiting_on": ["x"]},
     )
     await j.consume_inbox(msg_id=j.snapshot.inbox[0]["id"] if j.snapshot.inbox else "none")
+    await j.flush()  # #2259 PR-2b: drain the async WAL+snapshot writes (collect observations)
 
     assert observations, "snapshot saves must have run through the off-loop write"
     for applied_seq, wal_at_write in observations:

--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -119,6 +119,7 @@ async def _run_n_turns_then_shutdown(
     except asyncio.TimeoutError:
         run_task.cancel()
         await asyncio.gather(run_task, return_exceptions=True)
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +251,7 @@ async def test_c_staging_persist_and_restore(tmp_path) -> None:
     )
 
     # Verify the snapshot file contains the staged entry.
+    await session._journal.flush()  # #2259 PR-2b: drain async snapshot write before the load
     snapshot_on_disk = AgentSnapshot.load(
         session.agent_name, session._snapshot_path,
     )

--- a/tests/test_1800_wake_drain.py
+++ b/tests/test_1800_wake_drain.py
@@ -98,6 +98,7 @@ async def _run_n_turns_then_shutdown(
     except asyncio.TimeoutError:
         run_task.cancel()
         await asyncio.gather(run_task, return_exceptions=True)
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot before the sync read
 
 
 # ---------------------------------------------------------------------------
@@ -328,6 +329,7 @@ async def test_drain_to_wake_inbox_consume_per_message(tmp_path) -> None:
 
     assert trigger is not None
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
     events = _wal_events(tmp_path)
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
 
@@ -389,6 +391,7 @@ async def test_drain_to_wake_only_wake_false_then_trigger_arrives(
     )
 
     # WAL must record inbox_consume for all 3 messages (2 ride-alongs + 1 trigger).
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
     events = _wal_events(tmp_path)
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
     n_consume = len(consume_events)

--- a/tests/test_2259_config_truncation_bug.py
+++ b/tests/test_2259_config_truncation_bug.py
@@ -51,7 +51,9 @@ async def test_config_survives_wal_truncation_below_its_seq(tmp_path):
     )
 
     # GC truncates the WAL below floor 100 (= min agent applied_seq) → config_changed@1 GONE.
-    stats = await sl.truncate_below(100)
+    await sl.truncate_below(100)
+    await sl.flush()
+    stats = sl.last_truncate_stats
     assert stats["dropped"] >= 1, "the early config_changed should have been truncated"
 
     # rewind to cut=1: config should reconstruct to {A} (its state as-of seq 1).

--- a/tests/test_2259_pr1b_agent_identity_truncation_bug.py
+++ b/tests/test_2259_pr1b_agent_identity_truncation_bug.py
@@ -83,7 +83,9 @@ async def test_child_parent_cap_survives_wal_truncation_of_agent_created(tmp_pat
         await log.append("inbox_put", n=i)
 
     # GC truncates the WAL below floor 100 → the agents' agent_created@{1,2} are GONE.
-    stats = await log.truncate_below(100)
+    await log.truncate_below(100)
+    await log.flush()
+    stats = log.last_truncate_stats
     assert stats["dropped"] >= 2, "the early agent_created events should have been truncated"
     # The SAME-boundary generation GC runs too — it must KEEP the identity base below floor
     # (prune-KEEPS-BASE); a drop-all-below GC here would re-introduce the bug.

--- a/tests/test_2259_pr1b_agent_identity_truncation_bug.py
+++ b/tests/test_2259_pr1b_agent_identity_truncation_bug.py
@@ -129,8 +129,10 @@ async def test_identity_generation_survives_but_post_cut_child_is_undone(tmp_pat
     log = reg.state_log
 
     await reg.create_agent("parent_a")
+    await log.flush()  # #2259 PR-2b: create_agent is async — drain so current_seq + gen are durable
     cut = log.current_seq  # rewind target = just after P exists, before C is spawned
     await reg.create_agent("child_a", parent="parent_a")
+    await log.flush()
 
     # rewind to BEFORE C was spawned → C did not exist as-of-cut → undone (dropped).
     await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)

--- a/tests/test_2259_pr2a_worker_retry.py
+++ b/tests/test_2259_pr2a_worker_retry.py
@@ -130,6 +130,43 @@ async def test_fifo_preserved_across_a_retrying_task():
     await w.aclose()
 
 
+@pytest.mark.asyncio
+async def test_submit_nowait_is_non_blocking_and_eventually_persists():
+    """Tier 2: #2259 PR-2b — `submit_nowait` returns BEFORE the durable write runs
+    (fire-and-forget = the relaxed-durability window), and the write still happens (drained
+    serially). RED if submit_nowait awaited the write (defeating the non-blocking win)."""
+    w = DurabilityWorker()
+    ran = asyncio.Event()
+
+    async def _slow() -> None:
+        await asyncio.sleep(0.05)
+        ran.set()
+
+    w.submit_nowait(_slow)
+    assert not ran.is_set(), "submit_nowait must return before the write runs (non-blocking)"
+    await w.aclose()  # drains the fire-and-forget job
+    assert ran.is_set(), "the fire-and-forget write must still have run (drained on aclose)"
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_persistent_failure_latches_health_signal():
+    """Tier 2: #2259 PR-2b — a fire-and-forget write that fails PERSISTENTLY (§4-exhausted) has
+    no submitter to raise to, so it must latch `durability_failed` (health-signal escalation),
+    NOT be silently swallowed (the owner's no-silent-unbounded-loss: in-memory must not race
+    ahead while durability is silently dead). RED if the failure vanished (flag stays False)."""
+    w = _fast_worker(max_attempts=2)
+
+    async def _always_fail() -> None:
+        raise OSError("disk full")
+
+    assert w.durability_failed is False
+    w.submit_nowait(_always_fail)
+    await w.aclose()  # drains the fire-and-forget job (which fails persistently)
+    assert w.durability_failed is True, (
+        "a persistent fire-and-forget failure must latch the health-signal, not be swallowed"
+    )
+
+
 def test_loop_teardown_with_inflight_write_does_not_hang():
     """Tier 2: ``asyncio.run`` teardown (``_cancel_all_tasks``) must TERMINATE the background
     drainer even when it is cancelled MID-WRITE — the drainer must propagate ``CancelledError``,

--- a/tests/test_2259_pr2b_crash_recovery_falsify.py
+++ b/tests/test_2259_pr2b_crash_recovery_falsify.py
@@ -1,0 +1,104 @@
+"""Tier 2: #2259 PR-2b item 7 — recover-to-last-durable consistent-prefix (the truncate-falsify).
+
+The async-decoupled model writes the WAL entry, then (FIFO-after) its snapshot. A crash can land:
+  (a) AFTER WAL_N is durable, BEFORE its snapshot → recovery REPLAYS WAL_N onto the prior
+      snapshot = state N (this is exactly the snapshot.applied_seq ≤ durable-WAL-seq lag, resolved
+      on recovery — the FIFO-lag is benign, never a hole);
+  (b) BEFORE WAL_N is durable → the un-durable tail is cleanly LOST = state N-1.
+Both land on a CONSISTENT PREFIX — never a torn / half-applied state. This is the owner's
+recover-to-last-durable model. A GENUINE crash (a real WAL+reconstruct), not a stats-only proxy
+(per the CLAUDE.md #2261 recovery-feature truncate-falsify gate).
+
+Real StateLog + SnapshotGenerationStore + SnapshotJournal + reconstruct (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+AGENT = "alpha"
+
+
+def _journal(tmp_path: Path):
+    log = StateLog(tmp_path / "state.wal")
+    store = SnapshotGenerationStore(AGENT, tmp_path / "generations")
+    journal = SnapshotJournal(
+        agent_name=AGENT, snapshot_path=tmp_path / "snapshot.json",
+        state_log=log, generation_store=store,
+    )
+    return log, store, journal
+
+
+def _crash_mid_pair_wal_only(journal) -> None:
+    """Simulate a crash BETWEEN a mutation's WAL job and its snapshot job: the in-memory mutation
+    + the WAL append land, but the paired snapshot save never runs. (A WAL-only append — the
+    snapshot/generation stay at the prior seq.)"""
+    journal.snapshot.inbox.append({"id": "b", "kind": "user", "payload": {"text": "b"}})
+    journal._wal_append_nowait(
+        "inbox_put", target=AGENT, msg_id="b", msg_kind="user", payload={"text": "b"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_crash_between_wal_and_snapshot_replays_to_state_n(tmp_path):
+    """Tier 2: crash AFTER WAL_N durable, BEFORE snap_N → recovery replays WAL_N onto snap_{N-1}
+    = state N. RED if reconstruct lost WAL_N (snapshot ahead = a hole) or double-applied it."""
+    log, store, journal = _journal(tmp_path)
+    # mutation 1: full durable pair + a generation cut → gen@1 has inbox=[a].
+    await journal.append_inbox(kind="user", payload={"text": "a"})
+    await journal.cut_generation()
+    await journal.flush()  # WAL_1 + snap_1 + gen_1 all durable
+
+    _crash_mid_pair_wal_only(journal)
+    await journal.flush()  # WAL_2 becomes durable; the snapshot/generation are still at seq 1
+
+    # recovery: reconstruct from the durable gen (seq 1) + replay the durable WAL in (1, head].
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
+    texts = [m["payload"].get("text") for m in rebuilt.inbox]
+    assert texts == ["a", "b"], (
+        "crash mid-pair: WAL_2 (durable) must replay onto snap_1 → state 2 (consistent prefix); "
+        f"got {texts}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_crash_before_wal_durable_loses_the_undurable_tail(tmp_path):
+    """Tier 2: crash BEFORE WAL_N is durable → mutation N is cleanly LOST (recover-to-last-durable)
+    = state N-1, a consistent prefix. RED if a non-durable mutation survived recovery."""
+    log, store, journal = _journal(tmp_path)
+    await journal.append_inbox(kind="user", payload={"text": "a"})
+    await journal.cut_generation()
+    await journal.flush()  # state 1 durable
+
+    _crash_mid_pair_wal_only(journal)
+    # NO flush — the WAL_2 job never drains (the crash). The durable WAL stays at seq 1. There is
+    # no await between the submit and the reconstruct, so the drainer cannot sneak the write in.
+
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
+    texts = [m["payload"].get("text") for m in rebuilt.inbox]
+    assert texts == ["a"], (
+        "crash before durable: the un-durable mutation 2 must be LOST = state 1 (consistent "
+        f"prefix, recover-to-last-durable); got {texts}"
+    )
+    await journal.flush()  # clean up the pending job
+
+
+@pytest.mark.asyncio
+async def test_durable_snapshot_never_leads_the_wal(tmp_path):
+    """Tier 2: the FIFO-lag invariant — at every drained point, the snapshot's applied_seq is
+    ≤ the durable WAL head (the snapshot never records a seq past a not-yet-durable WAL entry).
+    RED if save_nowait stamped applied_seq before its WAL entry was durable."""
+    log, store, journal = _journal(tmp_path)
+    for i in range(5):
+        await journal.append_inbox(kind="user", payload={"n": i})
+        await journal.flush()
+        # after each drained mutation: the snapshot's applied_seq is durable in the WAL.
+        assert journal.snapshot.applied_seq <= log.last_durable_seq, (
+            f"snapshot.applied_seq={journal.snapshot.applied_seq} leads durable WAL "
+            f"head={log.last_durable_seq}"
+        )

--- a/tests/test_2259_pr2b_crash_recovery_falsify.py
+++ b/tests/test_2259_pr2b_crash_recovery_falsify.py
@@ -13,6 +13,7 @@ Real StateLog + SnapshotGenerationStore + SnapshotJournal + reconstruct (no mock
 """
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,54 @@ async def test_crash_before_wal_durable_loses_the_undurable_tail(tmp_path):
         f"prefix, recover-to-last-durable); got {texts}"
     )
     await journal.flush()  # clean up the pending job
+
+
+@pytest.mark.asyncio
+async def test_concurrent_journals_each_snapshot_keyed_to_own_wal_seq(tmp_path):
+    """Tier 2: invariant #2 under CONCURRENCY — two journals sharing one durability worker mutate
+    interleaved; each journal's snapshot.applied_seq == the seq of ITS OWN last WAL entry, never a
+    peer's interleaved entry. The (`_wal_append_nowait`, `save_nowait`) pair is enqueued with no
+    await between, so the worker can never slot a peer's WAL job between a journal's pair → the snap
+    job's `last_assigned_seq` read is always its own paired WAL seq. RED if a save_nowait stamped
+    applied_seq from a peer's interleaved last_assigned_seq."""
+    log = StateLog(tmp_path / "shared.wal")
+    store_a = SnapshotGenerationStore("a1", tmp_path / "gen_a")
+    store_b = SnapshotGenerationStore("a2", tmp_path / "gen_b")
+    ja = SnapshotJournal(
+        agent_name="a1", snapshot_path=tmp_path / "a1.json",
+        state_log=log, generation_store=store_a,
+    )
+    jb = SnapshotJournal(
+        agent_name="a2", snapshot_path=tmp_path / "a2.json",
+        state_log=log, generation_store=store_b,
+    )
+
+    async def hammer(journal, tag):
+        for i in range(6):
+            await journal.append_inbox(kind="user", payload={"text": f"{tag}{i}"})
+            await asyncio.sleep(0)  # yield so the two streams interleave on the shared worker
+
+    await asyncio.gather(hammer(ja, "a"), hammer(jb, "b"))
+    await log.flush()
+
+    entries = list(log.iter_from(0))
+    a_seqs = [e["seq"] for e in entries if e.get("target") == "a1"]
+    b_seqs = [e["seq"] for e in entries if e.get("target") == "a2"]
+    assert a_seqs and b_seqs and set(a_seqs).isdisjoint(b_seqs)
+    # confirm the streams TRULY interleaved on the shared WAL (not a-block then b-block) — else the
+    # cross-contamination window never opened and the test would pass vacuously.
+    order = [e["target"] for e in entries if e.get("target") in ("a1", "a2")]
+    assert "a1" in order[:3] and "a2" in order[:3], f"streams did not interleave: {order}"
+
+    # each journal's snapshot is keyed to its OWN last WAL entry — no peer seq bled across the pair.
+    assert ja.snapshot.applied_seq == max(a_seqs), (
+        f"a1 snapshot applied_seq={ja.snapshot.applied_seq} must == a1's own last WAL seq "
+        f"{max(a_seqs)} (no cross-contamination from a2's interleaved pair)"
+    )
+    assert jb.snapshot.applied_seq == max(b_seqs), (
+        f"a2 snapshot applied_seq={jb.snapshot.applied_seq} must == a2's own last WAL seq "
+        f"{max(b_seqs)}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_2259_pr2b_state_log_nowait.py
+++ b/tests/test_2259_pr2b_state_log_nowait.py
@@ -1,0 +1,64 @@
+"""Tier 2: #2259 PR-2b — StateLog.append_nowait (sync-seq / async-durability / no-lock).
+
+The async-decoupled contract: the seq COUNTER is assigned SYNCHRONOUSLY (so `current_seq` is
+correct immediately — the 7 synchronous consumers, e.g. config-gen keying, must not see a stale
+head), while only the WAL WRITE is deferred off-loop (fire-and-forget via the worker). No
+`asyncio.Lock`: the worker is the single serial venue, so the sync-atomic seq increment never
+races and durable-order = submit-order = seq-order (FIFO). The durable watermark
+(`last_durable_seq`) advances only after fsync — so a reader/truncate never outruns durability.
+
+Real StateLog + DurabilityWorker (no mocks).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+
+
+@pytest.mark.asyncio
+async def test_append_nowait_is_sync_seq_async_durability(tmp_path):
+    """Tier 2: append_nowait assigns the seq SYNCHRONOUSLY (current_seq advances immediately)
+    but DEFERS the durable write (last_durable_seq lags until drained). RED if append_nowait
+    blocked on durability (last_durable_seq would already be 1) or current_seq lagged."""
+    sl = StateLog(tmp_path / "wal.jsonl")
+    assert sl.current_seq == 0 and sl.last_durable_seq == 0
+
+    seq = sl.append_nowait("inbox_put", n=1)
+    # seq + current_seq are correct SYNCHRONOUSLY (no await happened yet).
+    assert seq == 1
+    assert sl.current_seq == 1, "the seq is assigned synchronously (current_seq is immediate)"
+    assert sl.last_assigned_seq == 1
+    # durability is DEFERRED — the drainer has not run (we have not awaited), so the watermark
+    # has not advanced: append_nowait did not block on the write (the non-blocking win).
+    assert sl.last_durable_seq == 0, "the durable write is deferred (append_nowait non-blocking)"
+
+    await sl.aclose()  # drain the fire-and-forget write
+    assert sl.last_durable_seq == 1, "after draining, the write is durable (watermark advanced)"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_append_nowait_seqs_monotonic_without_lock(tmp_path):
+    """Tier 2: synchronous seq assignment (no lock) yields strictly monotonic, gap-free seqs,
+    and the durable order = seq order (worker FIFO). RED if the counter raced (dup/gap) or the
+    writes landed out of order."""
+    sl = StateLog(tmp_path / "wal.jsonl")
+    seqs = [sl.append_nowait("inbox_put", n=i) for i in range(10)]
+    assert seqs == list(range(1, 11)), "sync-atomic assignment → monotonic, gap-free, no lock"
+
+    await sl.aclose()
+    assert sl.last_durable_seq == 10
+    durable = [e["seq"] for e in sl.iter_from(1)]
+    assert durable == list(range(1, 11)), "durable order = submit order = seq order (FIFO)"
+
+
+@pytest.mark.asyncio
+async def test_append_blocking_still_durable_on_return(tmp_path):
+    """Tier 2: the blocking `append` (kept for callers that need durable-on-return) still awaits
+    durability — last_durable_seq has advanced by the time it returns. Guards that the sync-seq
+    refactor didn't accidentally make `append` non-blocking too."""
+    sl = StateLog(tmp_path / "wal.jsonl")
+    seq = await sl.append("inbox_put", n=1)
+    assert seq == 1
+    assert sl.last_durable_seq == 1, "blocking append returns only AFTER its write is durable"
+    await sl.aclose()

--- a/tests/test_2259_pr2b_state_log_nowait.py
+++ b/tests/test_2259_pr2b_state_log_nowait.py
@@ -1,11 +1,11 @@
-"""Tier 2: #2259 PR-2b — StateLog.append_nowait (sync-seq / async-durability / no-lock).
+"""Tier 2: #2259 PR-2b — StateLog.append_nowait (seq-in-worker / async-durability / no-lock).
 
-The async-decoupled contract: the seq COUNTER is assigned SYNCHRONOUSLY (so `current_seq` is
-correct immediately — the 7 synchronous consumers, e.g. config-gen keying, must not see a stale
-head), while only the WAL WRITE is deferred off-loop (fire-and-forget via the worker). No
-`asyncio.Lock`: the worker is the single serial venue, so the sync-atomic seq increment never
-races and durable-order = submit-order = seq-order (FIFO). The durable watermark
-(`last_durable_seq`) advances only after fsync — so a reader/truncate never outruns durability.
+The async-decoupled contract: the seq is assigned IN the worker (the WAL job, serial → monotonic
+= durability order), NEVER on the task loop — so no consumer can key a durable artifact at a
+not-yet-durable seq (the hole the sync-seq had; the owner caught it). append_nowait is no-return
++ non-blocking (the hot path never awaits durability). The durable watermark (`last_durable_seq`)
+advances only after fsync; `last_assigned_seq` is set by the WAL job (the paired snapshot job
+reads it). No `asyncio.Lock`: the worker is the single serial venue.
 
 Real StateLog + DurabilityWorker (no mocks).
 """
@@ -17,48 +17,45 @@ from reyn.core.events.state_log import StateLog
 
 
 @pytest.mark.asyncio
-async def test_append_nowait_is_sync_seq_async_durability(tmp_path):
-    """Tier 2: append_nowait assigns the seq SYNCHRONOUSLY (current_seq advances immediately)
-    but DEFERS the durable write (last_durable_seq lags until drained). RED if append_nowait
-    blocked on durability (last_durable_seq would already be 1) or current_seq lagged."""
+async def test_append_nowait_is_non_blocking_and_seq_in_worker(tmp_path):
+    """Tier 2: append_nowait returns immediately (no-return, non-blocking) and the seq is
+    assigned IN the worker — so `last_durable_seq` lags until the write drains. RED if
+    append_nowait blocked on durability (last_durable_seq would already be advanced)."""
     sl = StateLog(tmp_path / "wal.jsonl")
     assert sl.current_seq == 0 and sl.last_durable_seq == 0
 
-    seq = sl.append_nowait("inbox_put", n=1)
-    # seq + current_seq are correct SYNCHRONOUSLY (no await happened yet).
-    assert seq == 1
-    assert sl.current_seq == 1, "the seq is assigned synchronously (current_seq is immediate)"
-    assert sl.last_assigned_seq == 1
-    # durability is DEFERRED — the drainer has not run (we have not awaited), so the watermark
+    ret = sl.append_nowait("inbox_put", n=1)
+    assert ret is None, "append_nowait is no-return (the seq lives in the worker)"
+    # durability is DEFERRED — the WAL job has not drained (we have not awaited), so the watermark
     # has not advanced: append_nowait did not block on the write (the non-blocking win).
     assert sl.last_durable_seq == 0, "the durable write is deferred (append_nowait non-blocking)"
 
     await sl.aclose()  # drain the fire-and-forget write
     assert sl.last_durable_seq == 1, "after draining, the write is durable (watermark advanced)"
+    assert sl.last_assigned_seq == 1, "the WAL job assigned the seq in the worker"
 
 
 @pytest.mark.asyncio
-async def test_concurrent_append_nowait_seqs_monotonic_without_lock(tmp_path):
-    """Tier 2: synchronous seq assignment (no lock) yields strictly monotonic, gap-free seqs,
-    and the durable order = seq order (worker FIFO). RED if the counter raced (dup/gap) or the
-    writes landed out of order."""
+async def test_sequential_append_nowait_seqs_monotonic_durable_in_order(tmp_path):
+    """Tier 2: the worker assigns seqs serially (FIFO) → strictly monotonic, gap-free, and the
+    durable order = submit order = seq order. RED if the worker assigned out of order or raced."""
     sl = StateLog(tmp_path / "wal.jsonl")
-    seqs = [sl.append_nowait("inbox_put", n=i) for i in range(10)]
-    assert seqs == list(range(1, 11)), "sync-atomic assignment → monotonic, gap-free, no lock"
+    for i in range(10):
+        sl.append_nowait("inbox_put", n=i)
 
     await sl.aclose()
     assert sl.last_durable_seq == 10
     durable = [e["seq"] for e in sl.iter_from(1)]
-    assert durable == list(range(1, 11)), "durable order = submit order = seq order (FIFO)"
+    assert durable == list(range(1, 11)), "durable order = submit order = seq order (worker FIFO)"
 
 
 @pytest.mark.asyncio
-async def test_append_blocking_still_durable_on_return(tmp_path):
-    """Tier 2: the blocking `append` (kept for callers that need durable-on-return) still awaits
-    durability — last_durable_seq has advanced by the time it returns. Guards that the sync-seq
-    refactor didn't accidentally make `append` non-blocking too."""
+async def test_append_blocking_still_durable_on_return_with_worker_assigned_seq(tmp_path):
+    """Tier 2: the blocking `append` (kept for callers that need durable-on-return) returns the
+    WORKER-assigned seq via a per-call holder, and only AFTER its write is durable. Guards that
+    the seq-in-worker refactor didn't break the blocking contract."""
     sl = StateLog(tmp_path / "wal.jsonl")
     seq = await sl.append("inbox_put", n=1)
-    assert seq == 1
+    assert seq == 1, "blocking append returns the worker-assigned seq"
     assert sl.last_durable_seq == 1, "blocking append returns only AFTER its write is durable"
     await sl.aclose()

--- a/tests/test_agent_lifecycle_emit_2103_s2b.py
+++ b/tests/test_agent_lifecycle_emit_2103_s2b.py
@@ -54,6 +54,7 @@ async def test_create_agent_emits_agent_created_with_config(tmp_path):
     carrying the profile config — the record rewind re-materialises from."""
     reg = _make_registry(tmp_path)
     await reg.create_agent("helper", role="my role")
+    await reg._state_log.flush()  # #2259 PR-2b: create_agent's agent_created append is async
 
     assert _agent_dir(tmp_path, "helper").is_dir()
     created = _events(reg, "agent_created")

--- a/tests/test_anchor_full_message_2c.py
+++ b/tests/test_anchor_full_message_2c.py
@@ -88,6 +88,7 @@ async def test_cut_generation_captures_full_message(tmp_path):
     journal.snapshot.applied_seq = seq
 
     await journal.cut_generation(anchor="trunc…", full_message="the full original message")
+    await journal.flush()  # #2259 PR-2b: the cut_generation anchor capture runs in a worker job
     assert anchors.get(seq) == "trunc…"
     assert anchors.get_full(seq) == "the full original message"
 

--- a/tests/test_anchor_text_1547.py
+++ b/tests/test_anchor_text_1547.py
@@ -72,12 +72,14 @@ async def test_cut_generation_captures_anchor(tmp_path):
     journal.snapshot.applied_seq = seq
 
     await journal.cut_generation(anchor="rewind me here")
+    await journal.flush()  # #2259 PR-2b: the cut_generation anchor capture runs in a worker job
     assert anchors.get(seq) == "rewind me here"
 
     # a later cut with no anchor (e.g. plan-step) leaves the slot empty.
     seq2 = await log.append("inbox_put", target="a", msg_id="n", msg_kind="user", payload={})
     journal.snapshot.applied_seq = seq2
     await journal.cut_generation()           # no anchor
+    await journal.flush()
     assert anchors.get(seq2) == ""
 
 

--- a/tests/test_chain_peer_discarded_notify.py
+++ b/tests/test_chain_peer_discarded_notify.py
@@ -111,6 +111,7 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
             reason="user_discarded_skill_run",
         )
 
+        await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())
     # Chain is gone
     assert sess_a.chains.find_chain("X-001") is None
@@ -134,6 +135,7 @@ def test_handler_is_idempotent_when_chain_already_resolved(tmp_path: Path):
             chain_id="never_registered", peer="B", reason="x",
         )
 
+        await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())  # No exception is the assertion
 
 
@@ -258,6 +260,7 @@ def test_slash_discard_notifies_upstream_chain_waiter(tmp_path: Path, monkeypatc
         for _ in range(3):
             await asyncio.sleep(0)
 
+        await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())
 
     # Verifications:
@@ -312,6 +315,7 @@ def test_slash_discard_no_chain_does_not_notify(tmp_path: Path, monkeypatch):
         for _ in range(2):
             await asyncio.sleep(0)
 
+        await sess_b._journal.flush()  # #2259 PR-2b: drain async WAL in-context
     asyncio.run(go())
 
     # notify_chain_discarded was never called — no chain to notify

--- a/tests/test_concurrent_multiagent_rewind_1580.py
+++ b/tests/test_concurrent_multiagent_rewind_1580.py
@@ -93,12 +93,16 @@ async def test_concurrent_2agent_rewind_is_global_consistent_cut(tmp_path):
     reg, alpha, beta = _two_agent_registry(tmp_path)
 
     await alpha._run_router_loop("a1", "c1")
+    await alpha._journal.flush()  # #2259 PR-2b: drain before rewind/read
     seq_a1 = alpha.current_snapshot.applied_seq
     await beta._run_router_loop("b1", "c1")
+    await beta._journal.flush()  # #2259 PR-2b: drain before rewind/read
     seq_b1 = beta.current_snapshot.applied_seq
     await alpha._run_router_loop("a2", "c1")
+    await alpha._journal.flush()  # #2259 PR-2b: drain before rewind/read
     seq_a2 = alpha.current_snapshot.applied_seq
     await beta._run_router_loop("b2", "c1")
+    await beta._journal.flush()  # #2259 PR-2b: drain before rewind/read
 
     # interleaved, distinct global seqs (the owner's "different boundary seqs").
     assert seq_a1 < seq_b1 < seq_a2
@@ -128,6 +132,7 @@ async def test_both_agents_resume_after_concurrent_rewind(tmp_path):
     reg, alpha, beta = _two_agent_registry(tmp_path)
 
     await alpha._run_router_loop("a1", "c1")
+    await alpha._journal.flush()  # #2259 PR-2b: drain before rewind/read
     seq_a1 = alpha.current_snapshot.applied_seq
     await beta._run_router_loop("b1", "c1")          # > seq_a1, abandoned by the rewind
 
@@ -137,7 +142,9 @@ async def test_both_agents_resume_after_concurrent_rewind(tmp_path):
 
     # both resume through the real loop on the post-rewind active branch.
     await alpha._run_router_loop("a3", "c1")
+    await alpha._journal.flush()  # #2259 PR-2b: drain before rewind/read
     await beta._run_router_loop("b3", "c1")
+    await beta._journal.flush()  # #2259 PR-2b: drain before rewind/read
     assert _markers(alpha.current_snapshot) == ["a1", "a3"]
     assert _markers(beta.current_snapshot) == ["b3"]
 
@@ -163,6 +170,7 @@ async def test_single_agent_inflight_skill_plan_intervention_drained_by_rewind(t
     state_log = reg.state_log
 
     await alpha._run_router_loop("a1", "c1")
+    await alpha._journal.flush()  # #2259 PR-2b: drain before rewind/read
     seq_a1 = alpha.current_snapshot.applied_seq
 
     # Inject in-flight, append-capable tasks parked BEFORE their append (in-flight

--- a/tests/test_durable_answer_buffer.py
+++ b/tests/test_durable_answer_buffer.py
@@ -157,6 +157,7 @@ def test_journal_records_consumed_event(tmp_path: Path):
             run_id="run_x", text="hello", choice_id=None,
         )
         await journal.record_intervention_answer_consumed(run_id="run_x")
+        await journal.flush()  # #2259 PR-2b: drain the async WAL writes in-context
 
     asyncio.run(go())
 

--- a/tests/test_live_fork_gate.py
+++ b/tests/test_live_fork_gate.py
@@ -86,9 +86,11 @@ async def test_live_fork_checkout_back_follows_lineage_runtime(tmp_path):
 
     # turn A → runtime [A]; genuine cut_generation @ seqA.
     await session._run_router_loop("turn A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
     # turn B → runtime [A, B]; auto-captures @ seqB.
     await session._run_router_loop("turn B", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_b = session.current_snapshot.applied_seq
 
     # pre-fork sanity: the runtime substrate at B.
@@ -101,6 +103,7 @@ async def test_live_fork_checkout_back_follows_lineage_runtime(tmp_path):
     # ── turn C: a REAL turn through the production loop on the post-undo branch ──
     # (genuine new coverage — the session must be live-usable after a rewind).
     await session._run_router_loop("turn C", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_c = session.current_snapshot.applied_seq
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn C"]
 

--- a/tests/test_live_rewind_gate.py
+++ b/tests/test_live_rewind_gate.py
@@ -88,6 +88,7 @@ async def test_live_rewind_reverts_runtime_to_as_of_n(tmp_path):
 
     # turn A → runtime [A]; genuine cut_generation auto-captures @ seqA.
     await session._run_router_loop("turn A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot+gen (applied_seq durable)
     seq_a = session.current_snapshot.applied_seq
     # turn B → runtime [A, B]; auto-captures @ seqB.
     await session._run_router_loop("turn B", "c1")
@@ -96,6 +97,7 @@ async def test_live_rewind_reverts_runtime_to_as_of_n(tmp_path):
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]
 
     # ── global rewind to the turn-A checkpoint ──
+    await session._journal.flush()  # #2259 PR-2b: WAL+gens durable before the rewind reads them
     await reg.rewind_to(seq_a)
 
     # runtime substrate, DISK location: persisted snapshot is as-of-A.

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -186,6 +186,7 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
     assert not sess_a.chains.has(chain_ac)
 
     # WAL must have two chain_register and two chain_resolve events.
+    await sess_a._journal.flush()  # #2259 PR-2b: drain async WAL writes before the read
     wal_entries = list(state_log.iter_from(0))
     register_events = [e for e in wal_entries if e.get("kind") == "chain_register"]
     resolve_events = [e for e in wal_entries if e.get("kind") == "chain_resolve"]

--- a/tests/test_multi_session_restore.py
+++ b/tests/test_multi_session_restore.py
@@ -100,6 +100,7 @@ async def test_multi_session_restore_is_per_session_independent(tmp_path, monkey
     await spawned1.journal.record_intervention_dispatched(
         intervention_id="iv_spawn", iv_dict=_iv_dict("iv_spawn", "rS"),
     )
+    await main1.journal.flush()  # #2259 PR-2b: drain async WAL+snapshot (shared worker → both)
 
     # per-session snapshots persist to DISTINCT paths (no collision).
     main_path = agent_dir / "state" / "snapshot.json"

--- a/tests/test_registry_list_rewind_points_1f.py
+++ b/tests/test_registry_list_rewind_points_1f.py
@@ -162,6 +162,7 @@ async def test_list_rewind_points_excludes_truncated_seqs(tmp_path) -> None:
 
     # Drop seq 1; oldest kept becomes seq 2.  s2 and s3 remain as the watermark.
     await log.truncate_below(2)
+    await log.flush()
 
     rows = reg.list_rewind_points()
     listed_seqs = [r["seq"] for r in rows]
@@ -195,6 +196,7 @@ async def test_list_rewind_points_keeps_seqs_at_or_above_wal_floor(tmp_path) -> 
 
     # Drop seq 1; oldest kept = seq 2.
     await log.truncate_below(2)
+    await log.flush()
 
     rows = reg.list_rewind_points()
     listed_seqs = [r["seq"] for r in rows]

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -348,6 +348,7 @@ async def test_rewind_to_rejects_target_truncated_out_of_wal(tmp_path):
     await _put(log, "alpha", "b")          # seq 2
     await _put(log, "alpha", "c")          # seq 3
     await log.truncate_below(3)            # drop seq 1, 2; oldest kept = 3
+    await log.flush()                      # #2259 PR-2b: truncate is fire-and-forget
 
     with pytest.raises(RewindBeyondRetentionError):
         await reg.rewind_to(2)             # seq 2 truncated → outside retention window

--- a/tests/test_registry_wal_size_safety_net.py
+++ b/tests/test_registry_wal_size_safety_net.py
@@ -235,6 +235,7 @@ def test_size_safety_net_protects_active_skill_events(tmp_path: Path):
         # Size-triggered truncate
         result = await registry.maybe_truncate_for_size(threshold_bytes=50_000)
         assert result is not None, "expected size-triggered truncate to run"
+        await registry._state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
         # Floor = min(10_000, 50) + 1 = 51. Events with seq < 51 dropped,
         # seq >= 51 kept (active skill protection).
         events = list(registry._state_log.iter_from(0))
@@ -244,9 +245,11 @@ def test_size_safety_net_protects_active_skill_events(tmp_path: Path):
             f"active skill floor (51) violated; min kept seq = {min(kept_seqs)}"
         )
         # And events below the floor really were dropped (= we inflated way more
-        # than 50 entries, so dropping below 51 must have removed dozens).
-        assert result["dropped"] > 0, (
-            f"expected drops below floor; stats={result}"
+        # than 50 entries, so dropping below 51 must have removed dozens). #2259 PR-2b:
+        # truncate is fire-and-forget, so read the stats from last_truncate_stats post-flush.
+        stats = registry._state_log.last_truncate_stats
+        assert stats["dropped"] > 0, (
+            f"expected drops below floor; stats={stats}"
         )
 
     asyncio.run(go())

--- a/tests/test_registry_wal_truncate.py
+++ b/tests/test_registry_wal_truncate.py
@@ -230,10 +230,12 @@ def test_truncate_eligible_drops_below_floor_and_returns_stats(tmp_path):
         # Append 10 WAL entries
         for i in range(1, 11):
             await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
-        return await registry.truncate_wal_if_eligible()
+        triggered = await registry.truncate_wal_if_eligible()
+        await registry.state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
+        return triggered, registry.state_log.last_truncate_stats
 
-    stats = asyncio.run(go())
-    assert stats is not None
+    triggered, stats = asyncio.run(go())
+    assert triggered is not None  # truncation was triggered
     # alpha applied_seq=8 → floor = 9; drop seq 1..8, keep 9, 10
     assert stats["dropped"] == 8
     assert stats["kept"] == 2
@@ -311,14 +313,18 @@ def test_truncate_advances_seqs_across_active_skill_completion(tmp_path):
         for i in range(1, 21):
             await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
         # First truncation: floor = min(10, 3) + 1 = 4 → drop 1..3
-        first = await registry.truncate_wal_if_eligible()
+        await registry.truncate_wal_if_eligible()
+        await registry.state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
+        first = registry.state_log.last_truncate_stats
         # Skill phase-advances to seq 15 — replace the watermark in the shim
         # (mirrors SkillRegistry.advance_phase mutating its in-memory snapshot).
         shim._seqs = [10, 15]
         # Wait past throttle window
         registry._last_truncation_ts = None
         # Second truncation: floor = min(10, 15) + 1 = 11 → drop 4..10
-        second = await registry.truncate_wal_if_eligible()
+        await registry.truncate_wal_if_eligible()
+        await registry.state_log.flush()
+        second = registry.state_log.last_truncate_stats
         return first, second
 
     first, second = asyncio.run(go())

--- a/tests/test_registry_wal_truncate_floor_nonblocking.py
+++ b/tests/test_registry_wal_truncate_floor_nonblocking.py
@@ -212,10 +212,12 @@ def test_truncate_wal_if_eligible_uses_in_memory_floor(tmp_path):
     async def go():
         for i in range(1, 12):  # seqs 1..11
             await registry.state_log.append("inbox_put", target=f"a{i}", payload={})
-        return await registry.truncate_wal_if_eligible()
+        triggered = await registry.truncate_wal_if_eligible()
+        await registry.state_log.flush()  # #2259 PR-2b: truncate is fire-and-forget
+        return triggered, registry.state_log.last_truncate_stats
 
-    stats = asyncio.run(go())
-    assert stats is not None, "truncate must fire when floor > 1"
+    triggered, stats = asyncio.run(go())
+    assert triggered is not None, "truncate must fire when floor > 1"
     # floor = 9 → keep seqs 9..11 (3 entries), drop 1..8 (8 entries)
     assert stats["dropped"] == 8
     assert stats["kept"] == 3

--- a/tests/test_resolve_session_routing.py
+++ b/tests/test_resolve_session_routing.py
@@ -124,6 +124,7 @@ async def test_resolve_session_path_round_trip_arbitrary_native_id(tmp_path, mon
     await s.journal.record_intervention_dispatched(
         intervention_id="iv1", iv_dict=_iv_dict("iv1"),
     )
+    await s.journal.flush()  # #2259 PR-2b: drain async WAL+snapshot (durable before restart)
 
     # the '/' in native_id must NOT have created a nested dir tree (the failure mode
     # the encoding prevents) — verbatim it would be sessions/webhook:a/b:c/.

--- a/tests/test_resume_auto_e2e.py
+++ b/tests/test_resume_auto_e2e.py
@@ -183,9 +183,11 @@ def test_e2e_chatsession_auto_resume_completes_crashed_skill(tmp_path: Path, mon
         assert rt.executed_phases == ["review"]
 
     async def go():
-        return await session._auto_resume_active_skills(
+        result = await session._auto_resume_active_skills(
             launcher=stub_launcher,
         )
+        await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot in-context
+        return result
 
     decisions = asyncio.run(go())
 

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -221,8 +221,13 @@ def test_e2e_crash_during_phase2_then_resume_to_completion(tmp_path, monkeypatch
     rt1 = _CrashAfterFirstPhase(
         skill, skill_registry=registry, state_log=state_log,
     )
+    async def _go1():
+        try:
+            await rt1.run({"type": "input", "data": {"x": 1}})
+        finally:
+            await state_log.flush()  # #2259 PR-2b: drain phase writes before the crash assertions
     with pytest.raises(RuntimeError, match="simulated crash"):
-        asyncio.run(rt1.run({"type": "input", "data": {"x": 1}}))
+        asyncio.run(_go1())
 
     # WAL invariants post-crash (R-D1):
     #   - skill_started + skill_phase_advanced are in the WAL
@@ -267,7 +272,12 @@ def test_e2e_crash_during_phase2_then_resume_to_completion(tmp_path, monkeypatch
         skill_registry=registry2,
         state_log=state_log2,
     )
-    result = asyncio.run(rt2.run({"type": "input", "data": {"x": 1}}))
+    async def _go2():
+        try:
+            return await rt2.run({"type": "input", "data": {"x": 1}})
+        finally:
+            await state_log2.flush()  # #2259 PR-2b: drain resume writes before the read
+    result = asyncio.run(_go2())
 
     assert isinstance(result, RunResult)
     assert result.ok, f"expected finished, got {result.status}"

--- a/tests/test_retention_floor.py
+++ b/tests/test_retention_floor.py
@@ -155,6 +155,7 @@ async def test_retained_checkpoints_reconstructable_across_rewind(tmp_path):
     # keep last 2 checkpoints (2, 4); the rewind record @3 sits within [floor, head]
     assert floor == 2
     await log.truncate_below(floor)
+    await log.flush()
 
     # active-branch reconstruct at head: a (kept) + d (post-rewind), b abandoned.
     assert _ids(reconstruct(AGENT, store, log, log.current_seq)) == ["a", "d"]

--- a/tests/test_run_orchestrator_invariants.py
+++ b/tests/test_run_orchestrator_invariants.py
@@ -165,7 +165,12 @@ def test_run_calls_skill_registry_start_complete(tmp_path, monkeypatch):
         skill_registry=registry,
         state_log=state_log,
     )
-    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+
+    async def _go():
+        r = await rt.run({"type": "input", "data": {}})
+        await state_log.flush()  # #2259 PR-2b: drain async skill WAL writes in-context
+        return r
+    result = asyncio.run(_go())
     assert result.ok, f"expected finished, got {result.status}"
 
     # After clean exit the snapshot file must be gone (complete() removes it)

--- a/tests/test_runtime_crash_lifecycle.py
+++ b/tests/test_runtime_crash_lifecycle.py
@@ -138,6 +138,17 @@ def _setup(tmp_path: Path) -> tuple[SkillRegistry, StateLog, Path]:
     return registry, log, snap_path
 
 
+def _run_durable(rt, log, msg):
+    """#2259 PR-2b: run the runtime + flush its worker in-context so the run's async WAL+snapshot
+    writes drain before the (sync) test asserts their durable effect."""
+    async def _go():
+        try:
+            return await rt.run(msg)
+        finally:
+            await log.flush()  # drain even on error/interrupt (snapshot-preserve cases)
+    return asyncio.run(_go())
+
+
 # ---------------------------------------------------------------------------
 # complete() called: normal exit / deliberate abort / budget exceeded
 # ---------------------------------------------------------------------------
@@ -149,7 +160,7 @@ def test_normal_completion_calls_complete(tmp_path: Path):
     rt = _StubRuntime(
         _make_skill(), skill_registry=registry, state_log=log,
     )
-    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+    result = _run_durable(rt, log, {"type": "input", "data": {}})
 
     assert isinstance(result, RunResult) and result.ok
     kinds = [e["kind"] for e in log.iter_from(0)]
@@ -174,7 +185,7 @@ def test_workflow_aborted_calls_complete(tmp_path: Path):
     )
 
     with pytest.raises(WorkflowAbortedError):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
 
     kinds = [e["kind"] for e in log.iter_from(0)]
     assert "skill_completed" in kinds
@@ -196,7 +207,7 @@ def test_budget_exceeded_calls_complete(tmp_path: Path):
         ),
     )
 
-    result = asyncio.run(rt.run({"type": "input", "data": {}}))
+    result = _run_durable(rt, log, {"type": "input", "data": {}})
     assert result.status == "budget_exceeded"
     kinds = [e["kind"] for e in log.iter_from(0)]
     assert "skill_completed" in kinds
@@ -221,7 +232,7 @@ def test_cancelled_error_preserves_snapshot(tmp_path: Path):
     )
 
     with pytest.raises(asyncio.CancelledError):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
 
     kinds = [e["kind"] for e in log.iter_from(0)]
     assert "skill_completed" not in kinds, (
@@ -247,7 +258,7 @@ def test_keyboard_interrupt_preserves_snapshot(tmp_path: Path):
     )
 
     with pytest.raises(KeyboardInterrupt):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
 
     kinds = [e["kind"] for e in log.iter_from(0)]
     assert "skill_completed" not in kinds
@@ -274,7 +285,7 @@ def test_runtime_error_preserves_snapshot(tmp_path: Path):
     )
 
     with pytest.raises(RuntimeError, match="transient blip"):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
 
     kinds = [e["kind"] for e in log.iter_from(0)]
     assert "skill_completed" not in kinds
@@ -328,7 +339,7 @@ def test_cancelled_error_fires_skill_end_interrupted(tmp_path: Path):
         raise_on_first_phase=asyncio.CancelledError(),
     )
     with pytest.raises(asyncio.CancelledError):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
     assert "skill_start" in rec.points and "skill_end" in rec.points
     end_vars = [v for (p, v) in rec.dispatched if p == "skill_end"]
     assert end_vars and end_vars[0]["status"] == "interrupted"
@@ -343,7 +354,7 @@ def test_runtime_error_fires_skill_end_interrupted(tmp_path: Path):
         raise_on_first_phase=RuntimeError("transient blip"),
     )
     with pytest.raises(RuntimeError, match="transient blip"):
-        asyncio.run(rt.run({"type": "input", "data": {}}))
+        _run_durable(rt, log, {"type": "input", "data": {}})
     end_vars = [v for (p, v) in rec.dispatched if p == "skill_end"]
     assert end_vars and end_vars[0]["status"] == "interrupted"
     assert snap_path.exists()

--- a/tests/test_session_auto_resume.py
+++ b/tests/test_session_auto_resume.py
@@ -174,10 +174,12 @@ def test_auto_resume_discards_skill_with_discard_policy(tmp_path: Path, monkeypa
     from reyn.config import SkillResumeConfig
 
     async def go():
-        return await session._auto_resume_active_skills(
+        result = await session._auto_resume_active_skills(
             launcher=fake_launcher,
             config=SkillResumeConfig(default="discard_skill"),
         )
+        await session._journal.flush()  # #2259 PR-2b: drain async WAL+snapshot-delete in-context
+        return result
 
     decisions = asyncio.run(go())
     # No remaining decisions returned (all discarded)

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -244,6 +244,7 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
         "chain_id": "chain-reg-001",
     })
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     register_events = [e for e in events if e.get("kind") == "chain_register"]
 
@@ -324,6 +325,7 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     )
 
     # WAL must have register before resolve (intermediate updates are OK).
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     kinds = [e.get("kind") for e in events if e.get("chain_id") == "chain-res-001"]
     assert "chain_register" in kinds, f"chain_register missing from WAL: {kinds}"
@@ -396,6 +398,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     await asyncio.sleep(0.2)
 
     # WAL must contain chain_register → chain_timeout_fired.
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     chain_events = [
         e for e in events if e.get("chain_id") == "chain-timeout-001"
@@ -530,6 +533,7 @@ async def test_inbox_put_consume_emits_wal_events_with_monotonic_seq(tmp_path, m
 
     await _run_one_turn()
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     put_events = [e for e in events if e.get("kind") == "inbox_put"]
     consume_events = [e for e in events if e.get("kind") == "inbox_consume"]
@@ -584,6 +588,7 @@ async def test_shutdown_signal_bypasses_wal(tmp_path, monkeypatch):
 
     await _run_with_shutdown()
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = _wal_events(tmp_path)
     shutdown_put = [
         e for e in events
@@ -823,6 +828,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     assert resolved_chain is not None, "resolve must return the chain"
 
     # ── WAL read: verify P6 invariant ─────────────────────────────────────
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     wal_entries = _wal_events(tmp_path)
     kinds_present = {e["kind"] for e in wal_entries}
     required_kinds = {"inbox_put", "inbox_consume", "chain_register", "chain_resolve"}

--- a/tests/test_skill_discard_action.py
+++ b/tests/test_skill_discard_action.py
@@ -30,8 +30,19 @@ def _registry(tmp_path: Path) -> tuple[SkillRegistry, StateLog, Path]:
     return reg, sl, state_dir
 
 
+def _run_durable(reg, coro):
+    """#2259 PR-2b: run a skill-registry op + flush its worker in-context (try/finally) so the
+    op's async WAL+snapshot writes drain before the (sync) test asserts their durable effect."""
+    async def _go():
+        try:
+            return await coro
+        finally:
+            await reg._state_log.flush()
+    return asyncio.run(_go())
+
+
 def _start_skill(reg: SkillRegistry, run_id: str = "run_disc") -> None:
-    asyncio.run(reg.start(
+    _run_durable(reg, reg.start(
         run_id=run_id, skill_name="demo",
         skill_input={"type": "input", "data": {}},
     ))
@@ -41,7 +52,7 @@ def test_complete_with_status_discarded_emits_skill_discarded(tmp_path):
     """Tier 2: status='discarded' → WAL ``skill_discarded`` event (not ``skill_completed``)."""
     reg, sl, _ = _registry(tmp_path)
     _start_skill(reg)
-    asyncio.run(reg.complete(run_id="run_disc", status="discarded"))
+    _run_durable(reg, reg.complete(run_id="run_disc", status="discarded"))
 
     events = list(sl.iter_from(0))
     discarded = [e for e in events if e["kind"] == "skill_discarded"]
@@ -60,7 +71,7 @@ def test_complete_default_status_still_emits_skill_completed(tmp_path):
     """Tier 2: backward compat — no status param → skill_completed (existing behavior)."""
     reg, sl, _ = _registry(tmp_path)
     _start_skill(reg, run_id="run_normal")
-    asyncio.run(reg.complete(run_id="run_normal"))
+    _run_durable(reg, reg.complete(run_id="run_normal"))
 
     events = list(sl.iter_from(0))
     completed = [e for e in events if e["kind"] == "skill_completed"]
@@ -74,7 +85,7 @@ def test_complete_with_status_discarded_deletes_snapshot_file(tmp_path):
     snap_path = state_dir / "skills" / "run_to_unlink.snapshot.json"
     assert snap_path.is_file(), "start must have written the snapshot"
 
-    asyncio.run(reg.complete(run_id="run_to_unlink", status="discarded"))
+    _run_durable(reg, reg.complete(run_id="run_to_unlink", status="discarded"))
 
     assert not snap_path.exists(), "discard must remove the per-skill snapshot file"
 
@@ -121,4 +132,4 @@ def test_complete_status_invalid_raises(tmp_path):
     reg, _, _ = _registry(tmp_path)
     _start_skill(reg, run_id="run_typo")
     with pytest.raises(ValueError, match="status"):
-        asyncio.run(reg.complete(run_id="run_typo", status="discard"))  # typo
+        _run_durable(reg, reg.complete(run_id="run_typo", status="discard"))  # typo

--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -305,6 +305,7 @@ def test_postprocessor_mid_run_discard_notifies_upstream(
         # Allow the async notify path to propagate to A
         for _ in range(5):
             await asyncio.sleep(0)
+        await state_log.flush()  # #2259 PR-2b: drain async WAL writes in-context
 
     asyncio.run(go())
 

--- a/tests/test_skill_postprocessor_resume.py
+++ b/tests/test_skill_postprocessor_resume.py
@@ -595,8 +595,13 @@ def test_workflow_aborted_error_removes_snapshot(tmp_path, monkeypatch):
         skill_registry=registry,
         state_log=state_log,
     )
+    async def _go():
+        try:
+            await rt.run({"type": "in_art", "data": {}})
+        finally:
+            await state_log.flush()  # #2259 PR-2b: drain the async snapshot-delete on abort
     with pytest.raises(WorkflowAbortedError):
-        asyncio.run(rt.run({"type": "in_art", "data": {}}))
+        asyncio.run(_go())
 
     # Snapshot must be removed (WorkflowAbortedError = skill decided to abort,
     # not a transient crash — per ADR-0013 / R-D1).

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -54,9 +54,11 @@ def test_start_appends_skill_started_and_creates_snapshot(tmp_path):
     reg, log = _make_registry(tmp_path)
 
     async def go():
-        return await reg.start(
+        snap = await reg.start(
             run_id="run_a", skill_name="demo", skill_input={"x": 1},
         )
+        await log.flush()  # #2259 PR-2b: drain async WAL+snapshot (applied_seq stamped)
+        return snap
 
     snap = asyncio.run(go())
     assert snap.skill_run_id == "run_a"
@@ -110,6 +112,7 @@ def test_advance_phase_updates_snapshot_and_appends_event(tmp_path):
             run_id="r", next_phase="review",
             last_phase_artifact_path="ws/v2.json",
         )
+        await log.flush()  # #2259 PR-2b: drain async WAL+snapshot
         return reg.get("r")
 
     snap = asyncio.run(go())
@@ -163,6 +166,7 @@ def test_complete_appends_event_and_removes_snapshot(tmp_path):
     async def go():
         await reg.start(run_id="r", skill_name="s", skill_input={})
         await reg.complete(run_id="r")
+        await log.flush()  # #2259 PR-2b: drain async WAL + snapshot delete
 
     asyncio.run(go())
     assert _wal_kinds(log) == ["skill_started", "skill_completed"]
@@ -194,12 +198,13 @@ def test_complete_unknown_run_id_still_appends_event(tmp_path):
 
 def test_load_active_repopulates_cache_from_disk(tmp_path):
     """Tier 2: load_active() rehydrates the in-memory cache from on-disk snapshots."""
-    reg, _ = _make_registry(tmp_path)
+    reg, log = _make_registry(tmp_path)
 
     async def setup():
         await reg.start(run_id="r1", skill_name="s", skill_input={"x": 1})
         await reg.start(run_id="r2", skill_name="s", skill_input={"x": 2})
         await reg.advance_phase(run_id="r1", next_phase="draft")
+        await log.flush()  # #2259 PR-2b: drain async snapshots before the restart reads them
 
     asyncio.run(setup())
 
@@ -225,10 +230,11 @@ def test_load_active_skips_corrupt_snapshot(tmp_path):
     appears in the cache. This test pins that behavior so later refactors
     can decide whether to harden it.
     """
-    reg, _ = _make_registry(tmp_path)
+    reg, log = _make_registry(tmp_path)
 
     async def setup():
         await reg.start(run_id="good", skill_name="s", skill_input={})
+        await log.flush()  # #2259 PR-2b: drain async snapshot before the restart reads it
 
     asyncio.run(setup())
 

--- a/tests/test_skill_resume_applier.py
+++ b/tests/test_skill_resume_applier.py
@@ -96,6 +96,7 @@ def test_discard_action_calls_skill_registry_complete(tmp_path: Path):
         remaining = await coord.apply_decisions(
             [decision], skill_registry=registry,
         )
+        await log.flush()  # #2259 PR-2b: drain async skill WAL writes
         return remaining
 
     remaining = asyncio.run(go())
@@ -286,9 +287,11 @@ def test_apply_decisions_mixed_batch(tmp_path: Path):
             ResumeDecision(plan=_plan(run_id="run_b"), action="discard"),
             ResumeDecision(plan=_plan(run_id="run_c"), action="retry"),
         ]
-        return await coord.apply_decisions(
+        remaining = await coord.apply_decisions(
             decisions, skill_registry=registry,
         )
+        await log.flush()  # #2259 PR-2b: drain async skill WAL writes
+        return remaining
 
     remaining = asyncio.run(go())
     actions = [d.action for d in remaining]

--- a/tests/test_skill_slash_command.py
+++ b/tests/test_skill_slash_command.py
@@ -125,7 +125,9 @@ async def test_skill_discard_completes_with_discarded_status(tmp_path, monkeypat
     )
     assert consumed is True
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     log = StateLog(tmp_path / "state.wal")
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = list(log.iter_from(0))
     discarded = [e for e in events if e["kind"] == "skill_discarded"]
     assert discarded, "expected at least one skill_discarded event"
@@ -155,7 +157,9 @@ async def test_skill_discard_without_force_is_confirmation_only(tmp_path, monkey
     assert consumed is True
 
     # WAL must NOT contain a skill_discarded event yet
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     log = StateLog(tmp_path / "state.wal")
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = list(log.iter_from(0))
     discarded = [e for e in events if e["kind"] == "skill_discarded"]
     assert discarded == [], (
@@ -232,7 +236,9 @@ async def test_skill_discard_force_flag_order_independent(tmp_path, monkeypatch)
     )
     assert consumed is True
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     log = StateLog(tmp_path / "state.wal")
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = list(log.iter_from(0))
     discarded = [e for e in events if e["kind"] == "skill_discarded"]
     assert discarded, "expected at least one skill_discarded event"
@@ -315,7 +321,9 @@ async def test_skill_discard_drops_interventions(tmp_path, monkeypatch):
     for _ in range(3):
         await asyncio.sleep(0)
 
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     log = StateLog(tmp_path / "state.wal")
+    await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
     events = list(log.iter_from(0))
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
     assert any(e["intervention_id"] == iv.id for e in resolved), (

--- a/tests/test_snapshot_generation_recording.py
+++ b/tests/test_snapshot_generation_recording.py
@@ -43,6 +43,7 @@ async def test_cut_generation_records_current_snapshot(tmp_path):
     await journal.append_inbox(kind="user", payload={"text": "hi"})
     assert store.seqs() == []          # state change alone does not cut
     await journal.cut_generation()           # turn boundary
+    await journal.flush()              # #2259 PR-2b: the gen-record runs in a worker job
     seq = journal.snapshot.applied_seq
     assert store.seqs() == [seq]
     assert store.load(seq) == journal.snapshot
@@ -60,7 +61,12 @@ async def test_reconstruct_head_equals_live_snapshot(tmp_path):
     await journal.append_inbox(kind="user", payload={"text": "a"})
     await journal.cut_generation()
     await journal.append_inbox(kind="user", payload={"text": "b"})  # past the gen
-    rebuilt = reconstruct(AGENT, store, log, log.current_seq)
+    # #2259 PR-2b: under relaxed durability, reconstruct gives the recover-to-last-durable
+    # prefix; the live snapshot is ahead until drained. So FLUSH, then reconstruct at the
+    # durable head == live (the consistent-prefix parity; "reconstruct(current_seq) == live"
+    # was the synchronous-durability assumption, correctly retired).
+    await journal.flush()
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
     assert rebuilt == journal.snapshot
 
 
@@ -75,4 +81,5 @@ async def test_no_store_is_noop_no_behavior_change(tmp_path):
     assert store is None
     await journal.append_inbox(kind="user", payload={"text": "x"})
     await journal.cut_generation()  # must not raise
+    await journal.flush()  # #2259 PR-2b: the snapshot save is async
     assert (tmp_path / "snapshot.json").is_file()

--- a/tests/test_snapshot_journal_intervention.py
+++ b/tests/test_snapshot_journal_intervention.py
@@ -53,6 +53,15 @@ def _iv_dict(iid: str, **overrides) -> dict:
     }
 
 
+def _run_durable(j, coro):
+    """#2259 PR-2b: run a journal mutation coro + flush in-context so its async WAL+snapshot
+    writes drain before the (sync) test asserts their durable effect."""
+    async def _r():
+        await coro
+        await j.flush()
+    asyncio.run(_r())
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -64,7 +73,10 @@ def test_record_intervention_dispatched_appends_wal_and_snapshot(tmp_path):
     iid = "iv_abcd"
     iv = _iv_dict(iid)
 
-    asyncio.run(j.record_intervention_dispatched(intervention_id=iid, iv_dict=iv))
+    async def _run():  # #2259 PR-2b: flush in-context so the async WAL+snapshot drain
+        await j.record_intervention_dispatched(intervention_id=iid, iv_dict=iv)
+        await j.flush()
+    asyncio.run(_run())
 
     # WAL has the event
     events = [e for e in sl.iter_from(0) if e["kind"] == "intervention_dispatched"]
@@ -82,12 +94,12 @@ def test_record_intervention_resolved_removes_from_snapshot(tmp_path):
     """Tier 2: WAL ``intervention_resolved`` + snapshot entry removed."""
     j, sl = _journal(tmp_path)
     iid = "iv_to_resolve"
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id=iid, iv_dict=_iv_dict(iid),
     ))
     assert iid in j.snapshot.outstanding_interventions
 
-    asyncio.run(j.record_intervention_resolved(intervention_id=iid))
+    _run_durable(j, j.record_intervention_resolved(intervention_id=iid))
 
     # WAL has the resolve event
     events = [e for e in sl.iter_from(0) if e["kind"] == "intervention_resolved"]
@@ -102,7 +114,7 @@ def test_record_intervention_resolved_removes_from_snapshot(tmp_path):
 def test_record_intervention_dispatched_noop_when_state_log_none(tmp_path):
     """Tier 2: backward compat — no state_log → no WAL, no mutation."""
     j, _ = _journal(tmp_path, with_state_log=False)
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_x", iv_dict=_iv_dict("iv_x"),
     ))
     # Nothing recorded
@@ -113,25 +125,25 @@ def test_record_intervention_resolved_noop_when_state_log_none(tmp_path):
     """Tier 2: backward compat — resolve no-op when state_log is None."""
     j, _ = _journal(tmp_path, with_state_log=False)
     # Should not raise even if id is unknown
-    asyncio.run(j.record_intervention_resolved(intervention_id="iv_unknown"))
+    _run_durable(j, j.record_intervention_resolved(intervention_id="iv_unknown"))
     assert j.snapshot.outstanding_interventions == {}
 
 
 def test_multiple_dispatches_accumulate_and_partial_resolves(tmp_path):
     """Tier 2: many in-flight interventions → resolve one → others intact."""
     j, sl = _journal(tmp_path)
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_1", iv_dict=_iv_dict("iv_1", prompt="Q1"),
     ))
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_2", iv_dict=_iv_dict("iv_2", prompt="Q2"),
     ))
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_3", iv_dict=_iv_dict("iv_3", prompt="Q3"),
     ))
 
     # Resolve the middle one
-    asyncio.run(j.record_intervention_resolved(intervention_id="iv_2"))
+    _run_durable(j, j.record_intervention_resolved(intervention_id="iv_2"))
 
     assert set(j.snapshot.outstanding_interventions) == {"iv_1", "iv_3"}
     assert j.snapshot.outstanding_interventions["iv_1"]["prompt"] == "Q1"
@@ -142,15 +154,15 @@ def test_applied_seq_advances_monotonically(tmp_path):
     """Tier 2: every WAL-recorded mutation bumps applied_seq forward."""
     j, _ = _journal(tmp_path)
     seqs = []
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_a", iv_dict=_iv_dict("iv_a"),
     ))
     seqs.append(j.snapshot.applied_seq)
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_b", iv_dict=_iv_dict("iv_b"),
     ))
     seqs.append(j.snapshot.applied_seq)
-    asyncio.run(j.record_intervention_resolved(intervention_id="iv_a"))
+    _run_durable(j, j.record_intervention_resolved(intervention_id="iv_a"))
     seqs.append(j.snapshot.applied_seq)
     assert seqs == sorted(seqs)
     assert len(set(seqs)) == 3, "each mutation must advance applied_seq"
@@ -163,14 +175,14 @@ def test_resolve_unknown_id_does_not_raise(tmp_path):
     when the entry was already pruned by an earlier replay.
     """
     j, _ = _journal(tmp_path)
-    asyncio.run(j.record_intervention_resolved(intervention_id="iv_unknown"))
+    _run_durable(j, j.record_intervention_resolved(intervention_id="iv_unknown"))
     assert j.snapshot.outstanding_interventions == {}
 
 
 def test_snapshot_persists_to_disk_on_dispatch(tmp_path):
     """Tier 2: snapshot is saved to disk after each mutation (crash safety)."""
     j, _ = _journal(tmp_path)
-    asyncio.run(j.record_intervention_dispatched(
+    _run_durable(j, j.record_intervention_dispatched(
         intervention_id="iv_disk", iv_dict=_iv_dict("iv_disk"),
     ))
     snap_path = tmp_path / ".reyn" / "agents" / "alpha" / "state" / "snapshot.json"

--- a/tests/test_state_log_truncate.py
+++ b/tests/test_state_log_truncate.py
@@ -43,7 +43,9 @@ def test_truncate_drops_below_min_keep_seq(tmp_path):
         for i in range(1, 11):
             await log.append("inbox_put", target=f"agent_{i}", payload={"i": i})
         # Drop seq 1..4, keep 5..10
-        return await log.truncate_below(5)
+        await log.truncate_below(5)
+        await log.flush()
+        return log.last_truncate_stats
 
     stats = asyncio.run(setup_and_truncate())
 
@@ -63,7 +65,12 @@ def test_truncate_noop_when_min_keep_seq_le_one(tmp_path):
     async def go():
         for i in range(1, 6):
             await log.append("inbox_put", target=f"a{i}", payload={})
-        return await log.truncate_below(1), await log.truncate_below(0)
+        # min_keep_seq <= 1 is a no-op → last_truncate_stats set synchronously (no worker).
+        await log.truncate_below(1)
+        s1 = log.last_truncate_stats
+        await log.truncate_below(0)
+        s0 = log.last_truncate_stats
+        return s1, s0
 
     (s1, s0) = asyncio.run(go())
     assert s1 == {"dropped": 0, "kept": 0, "min_kept_seq": None, "max_kept_seq": None}
@@ -83,7 +90,9 @@ def test_truncate_preserves_highest_seq_as_watermark(tmp_path):
         for i in range(1, 6):
             await log.append("inbox_put", target=f"a{i}", payload={})
         # Caller asks to drop everything (min_keep_seq beyond all existing seqs).
-        return await log.truncate_below(100)
+        await log.truncate_below(100)
+        await log.flush()
+        return log.last_truncate_stats
 
     stats = asyncio.run(go())
 
@@ -107,6 +116,7 @@ def test_truncate_counter_survives_restart(tmp_path):
             await log.append("inbox_put", target=f"a{i}", payload={})
         # Drop 1..7, keep 8..10
         await log.truncate_below(8)
+        await log.flush()
 
     asyncio.run(go1())
 
@@ -136,6 +146,7 @@ def test_truncate_atomic_no_partial_state_on_disk(tmp_path):
         for i in range(1, 6):
             await log.append("inbox_put", target=f"a{i}", payload={})
         await log.truncate_below(3)
+        await log.flush()
 
     asyncio.run(go())
 
@@ -162,7 +173,9 @@ def test_truncate_skips_torn_lines(tmp_path):
         f.write('{"seq": 9, "kind": "in')  # torn — no closing brace, no newline
 
     async def truncate():
-        return await log.truncate_below(2)
+        await log.truncate_below(2)
+        await log.flush()
+        return log.last_truncate_stats
 
     stats = asyncio.run(truncate())
     survivors = _read_all(path)
@@ -178,7 +191,9 @@ def test_truncate_on_missing_file_is_noop(tmp_path):
     log = StateLog(path)
 
     async def go():
-        return await log.truncate_below(5)
+        await log.truncate_below(5)
+        await log.flush()
+        return log.last_truncate_stats
 
     stats = asyncio.run(go())
     assert stats == {"dropped": 0, "kept": 0,
@@ -194,6 +209,7 @@ def test_truncate_then_iter_from_returns_only_survivors(tmp_path):
         for i in range(1, 8):
             await log.append("inbox_put", target=f"a{i}", payload={"i": i})
         await log.truncate_below(4)
+        await log.flush()
 
     asyncio.run(go())
     seen = list(log.iter_from(0))

--- a/tests/test_web_edit_fork_gate_2d.py
+++ b/tests/test_web_edit_fork_gate_2d.py
@@ -80,8 +80,10 @@ async def test_web_edit_makes_new_fork_original_inactive(tmp_path) -> None:
     )
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
     await session._run_router_loop("B", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_b = session.current_snapshot.applied_seq
 
     # Resolve the edit target for B: predecessor TURN = A.
@@ -119,12 +121,15 @@ async def test_web_edit_cross_fork_point_resolves_parent_turn(tmp_path) -> None:
     )
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
     await session._run_router_loop("B", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
 
     # Fork: rewind to A, then run C → C is the FIRST turn of a new branch off A.
     await reg.checkout(seq_a)
     await session._run_router_loop("C", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_c = session.current_snapshot.applied_seq
 
     info = resolve_edit_target(reg, seq_c)
@@ -144,6 +149,7 @@ async def test_web_edit_first_turn_rejected(tmp_path) -> None:
     session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "vA"})
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
 
     info = resolve_edit_target(reg, seq_a)

--- a/tests/test_web_rewind_attach_seam_2d.py
+++ b/tests/test_web_rewind_attach_seam_2d.py
@@ -65,10 +65,12 @@ async def test_web_path_session_checkout_restores_runtime(tmp_path) -> None:
     session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "v1", "B": "v2"})
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
     await session._run_router_loop("B", "c1")
 
     # Web checkout (the unified primitive) to seq A → the runtime substrate reverts.
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     await reg.checkout(seq_a)
     markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
     assert markers == ["A"]                                            # runtime reverted
@@ -92,6 +94,7 @@ async def test_web_path_session_records_anchor_for_picker(tmp_path) -> None:
     session._loop_driver = _FakeTurnDriver(session, tmp_path, {"A": "v1"})
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
 
     # The anchor store (auto-attached) recorded this boundary — both the

--- a/tests/test_workspace_capture_optout_1582.py
+++ b/tests/test_workspace_capture_optout_1582.py
@@ -73,10 +73,12 @@ async def test_rewind_reverts_runtime_not_workspace(tmp_path) -> None:
     (tmp_path / _WS_FILE).write_text("vB", encoding="utf-8")
 
     await session._run_router_loop("A", "c1")
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     seq_a = session.current_snapshot.applied_seq
     await session._run_router_loop("B", "c1")
 
     # Runtime checkout works (consistent-cut on the runtime substrate alone).
+    await session._journal.flush()  # #2259 PR-2b: drain before durable read
     await reg.checkout(seq_a)
     markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
     assert markers == ["A"]                                  # runtime reverted


### PR DESCRIPTION
**[e2e-coder]** — #2259 PR-2b: the async-decoupled durability contract. **part of #2259** (PR-3 recovery-semantics closes it). Builds on PR-1 (config-as-snapshot #2260), PR-1b (identity-as-snapshot #2262), PR-2a (worker queue+drainer + §4 retry #2264).

## What

In-memory state mutates immediately on the task loop; durability is async (fire-and-forget through the serial worker). For the migrated durable-**RECORD** writes (snapshot/journal/skill/registry) the hot path NEVER awaits the worker (the only worker-await is `aclose`). Recovery is **recover-to-last-durable** (consistent prefix).

> **Scope note (lead-caught → #2275):** the dispatcher/kernel **step-event** WAL appends (`step_started`/`completed`/`failed`, llm_call) remain BLOCKING by design. `step_started` must be durable *before* the op's side-effect (`dispatcher.py:222`→`:228`) so a crash-mid-op leaves a durable orphan → ambiguity detection (`skill_resume_analyzer.py:191`) for non-idempotent ops — naively migrating it is a safety regression, not a perf win. The reducible parts (fire-and-forget completed/failed via FIFO-coalesce; selective step_started for idempotent ops) are tracked in **#2275**.

**The owner-corrected seq design (the load-bearing seam):** the seq is assigned IN the worker (the WAL job, serial → durability order), never synchronously on the task loop — so no durable artifact can reference a not-yet-durable seq (the truncation-class hole). Durable-artifact creators (config-gen, identity-gen, snapshot-gen) get their seq from the worker (created durable-together with the WAL entry); read-heads use `last_durable_seq`; the agent identity is an in-memory id (links to the seq in the durable record).

## The 7 layers
1. **Worker**: `submit_nowait` (fire-and-forget) + §4 persistent-failure health-signal (`durability_failed`, never swallowed); self-terminating drainer (no leak/hang).
2. **StateLog**: `append_nowait` (no-return, non-blocking, seq-in-worker), no lock (the worker is the single serial venue), `flush()` barrier, durable watermark (`last_durable_seq`).
3. **Journal**: `save_nowait` — deep-copy `to_payload` sync (serialize-sync-at-submit), stamp `applied_seq` from the worker seq IN the snapshot job (atomic pair, invariant #2); sets in-memory `applied_seq`=durable post-write (the truncate floor reads it → must lag-toward-durable). `cut_generation` reworked to the same pattern (no content-ahead-of-key double-apply).
4. **The 15 sites** migrated (12 journal + 2 skill_registry + registry agent_created) to mutate-in-memory → `_wal_append_nowait` → `save_nowait`.
5. **Read-heads + config-gen → `last_durable_seq`** (the uniform invariant: a durable artifact is keyed at the durable WAL position it's consistent with). rewind-target param untouched.
6. **agent_created → in-memory-ID** (owner's (b) model); identity-gen keyed by the durable seq in a worker job.
7. **truncate_below → fire-and-forget**; the **truncate-falsify** (#2261 gate).

## Caller-audit catches (the merge-gate)
- truncate floor reads the in-memory `applied_seq` → save_nowait sets it = durable-seq post-write (never ahead).
- `cut_generation` recorded the live snapshot keyed by a lagging seq → content-ahead double-apply; fixed via the save_nowait pattern + `record_payload`.
- `complete`'s sync snapshot-delete raced the queued save → routed the delete through the worker (FIFO-after → final state deleted).
- skill snapshot-only updates (mark/clear_awaiting) → `_persist_nowait` (through the worker, no re-stamp, no file race).

## Test plan
- [x] **The truncate-falsify** (`test_2259_pr2b_crash_recovery_falsify`, the #2261 gate): GENUINE crash + reconstruct — crash mid-pair (WAL_N durable, snap_N not) → recovery replays WAL_N onto snap_{N-1} = state N (RED if reconstruct lost WAL_N = snapshot-ahead hole, or double-applied); crash before WAL_N durable → un-durable tail cleanly lost = state N-1; FIFO-lag invariant `applied_seq ≤ last_durable_seq` at every drained point. Not a stats proxy.
- [x] **Worker §4** (5 tests): transient-retried / persistent-escalate-after-bounded-N / non-OSError-fast-fail / drainer-survives-escalation / FIFO-across-retry; + the teardown-hang regression (daemon-thread + join-timeout).
- [x] **StateLog non-blocking** (3): seq-in-worker / async-durability / monotonic-without-lock.
- [x] **Caller-audit cross-checked**: the full journal-unit + 20-test integration cascade (sessions/rewind/restore/skill/resume) — flush-then-assert (= the recover-to-last-durable model).
- [x] **Full suite faulthandler-net'd, actually-progressing**: 7492 passed, **0 hang** (274s; faulthandler_timeout=60, 0 timeouts). The 4 failures are pre-existing env quirks (gateway entry-point + reyn.safe relocate — same 4 as PR-1/1b/2a, PR-2b touches none of those files).
- [x] **CI gates**: ruff full-tree, `test_tier_audit.py --strict` (14 OK), `verify_module_docstrings.py` all green.

Lead reviews hardest: the async-contract + failure-path + the truncate-falsify (all in). Then **PR-3 (recovery-semantics) finalizes #2259 (the GitHub closing-keyword is intentionally avoided here so this sub-PR does not auto-close the umbrella)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)