### PR TITLE
[tui-coder] feat(inline-cui): agent chip = agent/session tree + attach switch (#2271 Phase 2)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -117,14 +117,26 @@ def _cost_expansion(snap, dispatch):
 
 
 def _agent_expansion(snap, dispatch):
-    # Phase 1: read-only agent list. Phase 2 = agent/session tree + attach switch.
-    def lines():
-        names = snap["agent_names"]
-        if not names:
-            return ["(none)"]
-        attached = snap["attached_name"]
-        return [f"▸ {n}" if n == attached else f"  {n}" for n in names]
-    return DetailElement(lines)
+    # Phase 2: agent/session tree; selecting a row attaches / switches.
+    tree = snap.get("session_tree") or []
+    rows: list[str] = []
+    cmds: list[str] = []
+    for agent in tree:
+        amark = "▸" if agent["attached"] else " "
+        rows.append(f"{amark} {agent['agent']}")
+        cmds.append(f"/attach {agent['agent']}")
+        for sess in agent["sessions"]:
+            smark = "▸" if sess["attached"] else " "
+            rows.append(f"    {smark} {sess['sid']}")
+            # switch the session when its agent is already attached; otherwise
+            # attach the agent first (the user can then switch session).
+            if agent["attached"]:
+                cmds.append(f"/session switch {sess['sid']}")
+            else:
+                cmds.append(f"/attach {agent['agent']}")
+    if not rows:
+        return DetailElement(lambda: ["(no agents)"])
+    return CommandUIElement(rows, cmds, dispatch)
 
 
 def _task_expansion(snap, dispatch):
@@ -186,6 +198,7 @@ def _snapshot(registry):
         "model_classes": list(s.known_model_classes()),
         "agent_names": list(registry.loaded_names()),
         "attached_name": registry.attached_name,
+        "session_tree": registry.session_tree(),
         "skill_run_ids": list(s.running_skills.keys()),
         "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
         "cost_usd": s.total_cost_usd,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2740,6 +2740,26 @@ class AgentRegistry:
     def loaded_names(self) -> list[str]:
         return list(self._sessions.keys())
 
+    def session_tree(self) -> "list[dict]":
+        """Snapshot of the agent→session tree for the status-bar agent menu.
+
+        A read-only, freshly-built copy (no handle to live registry state): agents in
+        load order, each with its sessions (sids, sorted) and which (agent, sid) is the
+        current attach focus.
+        """
+        out: list[dict] = []
+        for name in self.loaded_names():
+            sids = sorted((self._sessions.get(name) or {}).keys())
+            out.append({
+                "agent": name,
+                "attached": self._attached is not None and self._attached[0] == name,
+                "sessions": [
+                    {"sid": sid, "attached": self._attached == (name, sid)}
+                    for sid in sids
+                ],
+            })
+        return out
+
     def iter_other_agents(self, self_name: str) -> list[dict]:
         """List `{name, role}` for every agent except `self_name`.
 

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -25,6 +25,7 @@ def _snap(**over):
         "model_classes": ["light", "standard", "strong"],
         "agent_names": ["default"],
         "attached_name": "default",
+        "session_tree": [],
         "skill_run_ids": [],
         "usage": (0, 0, 0),
         "cost_usd": 0.0,
@@ -183,33 +184,116 @@ def test_cost_expansion_breaks_down_total_agent_session() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _agent_expansion
+# _agent_expansion  (Phase 2: agent/session tree + attach/switch on select)
 # ---------------------------------------------------------------------------
 
+_TREE_SNAP = [
+    {
+        "agent": "default",
+        "attached": True,
+        "sessions": [
+            {"sid": "main", "attached": True},
+            {"sid": "sub1", "attached": False},
+        ],
+    },
+    {
+        "agent": "researcher",
+        "attached": False,
+        "sessions": [
+            {"sid": "main", "attached": False},
+        ],
+    },
+]
 
-def test_agent_expansion_is_detail_element() -> None:
-    """Tier 2: _agent_expansion returns a read-only DetailElement."""
-    snap = _snap(agent_names=["default"], attached_name="default")
+
+def test_agent_expansion_with_tree_is_command_ui() -> None:
+    """Tier 2: with a non-empty session_tree, _agent_expansion returns a CommandUIElement."""
+    snap = _snap(session_tree=_TREE_SNAP)
     el = _agent_expansion(snap, lambda _: None)
-    assert isinstance(el, DetailElement)
-    assert el.selectable is False
+    assert isinstance(el, CommandUIElement)
 
 
-def test_agent_expansion_marks_attached_agent() -> None:
-    """Tier 2: the attached agent row starts with ▸; others do not."""
-    snap = _snap(agent_names=["default", "researcher"], attached_name="default")
+def test_agent_expansion_rows_include_agents_and_sessions() -> None:
+    """Tier 2: rows contain agent names and indented session sids."""
+    snap = _snap(session_tree=_TREE_SNAP)
+    el = _agent_expansion(snap, lambda _: None)
+    rows = el.lines()
+    joined = " ".join(rows)
+    assert "default" in joined
+    assert "researcher" in joined
+    assert "sub1" in joined
+    # session rows are indented
+    assert any("main" in r and r.startswith("    ") for r in rows)
+
+
+def test_agent_expansion_attached_agent_marked_with_arrow() -> None:
+    """Tier 2: the attached agent row starts with ▸; unattached agents do not."""
+    snap = _snap(session_tree=_TREE_SNAP)
     el = _agent_expansion(snap, lambda _: None)
     rows = el.lines()
     assert any(r.startswith("▸") and "default" in r for r in rows)
     assert any("researcher" in r and not r.startswith("▸") for r in rows)
 
 
-def test_agent_expansion_empty_shows_none_message() -> None:
-    """Tier 2: with no agents, the expansion shows a '(none)' line."""
-    snap = _snap(agent_names=[], attached_name=None)
+def test_agent_expansion_attached_session_marked_with_arrow() -> None:
+    """Tier 2: the attached session row carries ▸; others do not."""
+    snap = _snap(session_tree=_TREE_SNAP)
     el = _agent_expansion(snap, lambda _: None)
     rows = el.lines()
-    assert any("none" in r for r in rows)
+    # "main" under "default" is attached → must have ▸ in its row
+    main_rows = [r for r in rows if "main" in r and "default" not in r]
+    assert any("▸" in r for r in main_rows)
+
+
+def test_agent_expansion_selecting_agent_row_submits_attach(tmp_path) -> None:
+    """Tier 2: selecting an agent row submits /attach <agent>."""
+    submitted: list[str] = []
+    snap = _snap(session_tree=_TREE_SNAP)
+    el = _agent_expansion(snap, submitted.append)
+    # Row 0 is the "default" agent row.
+    el.on_select(0)
+    assert submitted == ["/attach default"]
+
+
+def test_agent_expansion_selecting_attached_session_submits_switch(tmp_path) -> None:
+    """Tier 2: selecting a session row under the attached agent submits /session switch."""
+    submitted: list[str] = []
+    snap = _snap(session_tree=_TREE_SNAP)
+    el = _agent_expansion(snap, submitted.append)
+    rows = el.lines()
+    # Find the index of the "main" session row under default (first agent).
+    main_idx = next(i for i, r in enumerate(rows) if "main" in r and r.startswith("    "))
+    submitted.clear()
+    el.on_select(main_idx)
+    assert submitted == ["/session switch main"]
+
+
+def test_agent_expansion_selecting_non_attached_agent_session_submits_attach(tmp_path) -> None:
+    """Tier 2: selecting a session of a non-attached agent submits /attach <agent>."""
+    submitted: list[str] = []
+    snap = _snap(session_tree=_TREE_SNAP)
+    el = _agent_expansion(snap, submitted.append)
+    rows = el.lines()
+    # Find researcher's session row (last row in the tree).
+    researcher_sess_idx = next(
+        i for i, r in enumerate(rows)
+        if "main" in r and r.startswith("    ") and
+        # researcher is after default's rows; find the one NOT in the default block.
+        # We look for the last "main" session row.
+        i > next(j for j, rr in enumerate(rows) if "researcher" in rr)
+    )
+    submitted.clear()
+    el.on_select(researcher_sess_idx)
+    assert submitted == ["/attach researcher"]
+
+
+def test_agent_expansion_empty_tree_returns_detail_element() -> None:
+    """Tier 2: empty session_tree → a non-selectable DetailElement with '(no agents)'."""
+    snap = _snap(session_tree=[])
+    el = _agent_expansion(snap, lambda _: None)
+    assert isinstance(el, DetailElement)
+    assert el.selectable is False
+    assert any("no agents" in r for r in el.lines())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_session_tree.py
+++ b/tests/test_registry_session_tree.py
@@ -1,36 +1,38 @@
 """Tier 2: AgentRegistry.session_tree() — read-only snapshot accessor.
 
-Exercises the public surface of ``session_tree()`` using a real AgentRegistry
-and real AgentProfile instances (no mocks). Covers the shape contract,
-attached-marking at both agent and session levels, and snapshot isolation.
+Exercises ``session_tree()`` against a REAL AgentRegistry with REAL Sessions
+loaded through the public sync path (``get_or_load`` / ``spawn_session`` + a real
+session factory — same pattern as test_registry_multi_session_1726). State is
+never set up by mutating private attrs. Covers the shape contract, multi-agent /
+multi-session listing, sid sorting, the unattached (all-false) marking, and
+snapshot isolation. Attached=True *rendering* (the ▸ marker) is covered by the
+``_agent_expansion`` test in test_inline_pr3b_status_menu.py.
 """
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
-import pytest
-
-_SRC = Path(__file__).parent.parent / "src"
-if str(_SRC) not in sys.path:
-    sys.path.insert(0, str(_SRC))
-
-from reyn.core.events.state_log import StateLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
-
-
-def _no_factory(_profile):
-    raise AssertionError("session factory must not be called in these tests")
+from reyn.runtime.session import Session
 
 
 def _make_registry(tmp_path: Path) -> AgentRegistry:
-    """Build a real AgentRegistry with a WAL but no sessions loaded."""
-    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
-    reg = AgentRegistry(
-        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
-    )
-    # Create a second agent profile so the registry has multiple on disk.
+    """A real AgentRegistry whose factory builds real Sessions on demand."""
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return Session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=BudgetTracker(CostConfig()),
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    # A second agent on disk so multi-agent listing is reachable via get_or_load.
     AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
     return reg
 
@@ -38,126 +40,92 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 def test_session_tree_empty_when_no_sessions_loaded(tmp_path: Path) -> None:
     """Tier 2: session_tree() returns [] when no sessions are loaded."""
     reg = _make_registry(tmp_path)
-    tree = reg.session_tree()
-    assert tree == []
+    assert reg.session_tree() == []
 
 
-def test_session_tree_shape_with_attached_session(tmp_path: Path) -> None:
-    """Tier 2: session_tree() entry has 'agent', 'attached', 'sessions' keys."""
+def test_session_tree_entry_shape_for_loaded_agent(tmp_path: Path) -> None:
+    """Tier 2: a loaded agent's entry has 'agent', 'attached', 'sessions' keys; with
+    nothing attached its flag is False and its 'main' session is listed."""
     reg = _make_registry(tmp_path)
-    # Manually inject a session record as _sessions uses dict keying.
-    reg._sessions["default"] = {"main": object()}
-    reg._attached = ("default", "main")
+    reg.get_or_load("default")
 
-    tree = reg.session_tree()
-    # There is exactly one entry for "default" — verify by name lookup, not count.
-    by_name = {e["agent"]: e for e in tree}
+    by_name = {e["agent"]: e for e in reg.session_tree()}
     assert "default" in by_name
     entry = by_name["default"]
     assert set(entry.keys()) == {"agent", "attached", "sessions"}
-    assert entry["attached"] is True
-    assert isinstance(entry["sessions"], list)
+    assert entry["attached"] is False          # nothing attached yet
+    by_sid = {s["sid"]: s for s in entry["sessions"]}
+    assert "main" in by_sid
 
 
 def test_session_tree_session_entry_shape(tmp_path: Path) -> None:
-    """Tier 2: each session entry in the tree has 'sid' and 'attached' keys."""
+    """Tier 2: each session entry has exactly 'sid' and 'attached' keys."""
     reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object()}
-    reg._attached = ("default", "main")
+    reg.get_or_load("default")
 
-    tree = reg.session_tree()
-    by_name = {e["agent"]: e for e in tree}
-    sess_list = by_name["default"]["sessions"]
-    # Verify the "main" session entry shape by looking it up by sid, not by index.
+    sess_list = reg.session_tree()[0]["sessions"]
     by_sid = {s["sid"]: s for s in sess_list}
-    assert "main" in by_sid
-    sess = by_sid["main"]
-    assert set(sess.keys()) == {"sid", "attached"}
-    assert sess["attached"] is True
+    assert set(by_sid["main"].keys()) == {"sid", "attached"}
 
 
-def test_session_tree_non_attached_agent_marked_false(tmp_path: Path) -> None:
-    """Tier 2: agents that are not the attached one have attached=False."""
+def test_session_tree_lists_multiple_agents(tmp_path: Path) -> None:
+    """Tier 2: each loaded agent appears once, in loaded_names() order."""
     reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object()}
-    reg._sessions["alpha"] = {"main": object()}
-    reg._attached = ("default", "main")
+    reg.get_or_load("default")
+    reg.get_or_load("alpha")
 
-    tree = reg.session_tree()
-    # Order follows loaded_names() which is insertion order of _sessions dict.
-    by_name = {e["agent"]: e for e in tree}
-    assert by_name["default"]["attached"] is True
-    assert by_name["alpha"]["attached"] is False
+    names = [e["agent"] for e in reg.session_tree()]
+    assert names == reg.loaded_names()
+    assert set(names) == {"default", "alpha"}
 
 
-def test_session_tree_non_attached_session_marked_false(tmp_path: Path) -> None:
-    """Tier 2: sessions that are not the attached sid have attached=False."""
+def test_session_tree_lists_spawned_sessions(tmp_path: Path) -> None:
+    """Tier 2: a spawned session shows up alongside 'main' under the same agent."""
     reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object(), "sub1": object()}
-    reg._attached = ("default", "main")
+    reg.get_or_load("default")
+    sid = reg.spawn_session("default", "sub1")
 
-    tree = reg.session_tree()
-    entry = tree[0]
-    by_sid = {s["sid"]: s for s in entry["sessions"]}
-    assert by_sid["main"]["attached"] is True
-    assert by_sid["sub1"]["attached"] is False
-
-
-def test_session_tree_attached_none_all_false(tmp_path: Path) -> None:
-    """Tier 2: when no agent is attached (fresh registry), all attached flags are False."""
-    reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object()}
-    # A fresh registry has no attached agent — verify via the public accessor.
-    assert reg.attached_name is None
-
-    tree = reg.session_tree()
-    by_name = {e["agent"]: e for e in tree}
-    assert by_name["default"]["attached"] is False
-    by_sid = {s["sid"]: s for s in by_name["default"]["sessions"]}
-    assert by_sid["main"]["attached"] is False
+    sids = {s["sid"] for s in reg.session_tree()[0]["sessions"]}
+    assert {"main", sid} <= sids
 
 
 def test_session_tree_sids_sorted(tmp_path: Path) -> None:
-    """Tier 2: sessions within an agent are sorted by sid."""
+    """Tier 2: sessions within an agent are sorted by sid regardless of spawn order."""
     reg = _make_registry(tmp_path)
-    # Insert in non-sorted order.
-    reg._sessions["default"] = {"zz": object(), "aa": object(), "main": object()}
-    reg._attached = None
+    reg.get_or_load("default")
+    reg.spawn_session("default", "zz")
+    reg.spawn_session("default", "aa")
 
-    tree = reg.session_tree()
-    sids = [s["sid"] for s in tree[0]["sessions"]]
+    sids = [s["sid"] for s in reg.session_tree()[0]["sessions"]]
     assert sids == sorted(sids)
 
 
-def test_session_tree_returns_snapshot_copy(tmp_path: Path) -> None:
-    """Tier 2: mutating the returned list/dicts does not affect a second call."""
+def test_session_tree_all_false_when_nothing_attached(tmp_path: Path) -> None:
+    """Tier 2: with no attached agent (fresh registry) every flag is False, at both
+    the agent and session level."""
     reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object()}
-    reg._attached = ("default", "main")
+    reg.get_or_load("default")
+    reg.spawn_session("default", "sub1")
+    assert reg.attached_name is None           # public-surface precondition
+
+    entry = reg.session_tree()[0]
+    assert entry["attached"] is False
+    assert all(s["attached"] is False for s in entry["sessions"])
+
+
+def test_session_tree_returns_snapshot_copy(tmp_path: Path) -> None:
+    """Tier 2: the returned structure is a snapshot — mutating it does not corrupt a
+    second call (it must NOT hand out a handle to live registry state)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("default")
 
     first = reg.session_tree()
-    # Mutate the returned structure.
     first[0]["agent"] = "MUTATED"
     first[0]["sessions"][0]["sid"] = "MUTATED"
     first.append({"bogus": True})
 
-    second = reg.session_tree()
-    # The second call must reflect the live registry state, not the mutated copy.
-    by_name = {e["agent"]: e for e in second}
-    assert "default" in by_name, "second call still shows 'default' agent"
+    by_name = {e["agent"]: e for e in reg.session_tree()}
+    assert "default" in by_name, "second call still reflects live 'default'"
     by_sid = {s["sid"]: s for s in by_name["default"]["sessions"]}
-    assert "main" in by_sid, "second call still shows 'main' session"
-    # 'bogus' was appended to the first snapshot copy — it must not appear in the second.
-    assert all("bogus" not in e for e in second)
-
-
-def test_session_tree_order_follows_loaded_names(tmp_path: Path) -> None:
-    """Tier 2: tree order matches loaded_names() insertion order."""
-    reg = _make_registry(tmp_path)
-    reg._sessions["default"] = {"main": object()}
-    reg._sessions["alpha"] = {"main": object()}
-    reg._attached = None
-
-    tree = reg.session_tree()
-    names_from_tree = [e["agent"] for e in tree]
-    assert names_from_tree == reg.loaded_names()
+    assert "main" in by_sid, "second call still reflects live 'main' session"
+    assert all("bogus" not in e for e in by_name.values())

--- a/tests/test_registry_session_tree.py
+++ b/tests/test_registry_session_tree.py
@@ -1,0 +1,163 @@
+"""Tier 2: AgentRegistry.session_tree() — read-only snapshot accessor.
+
+Exercises the public surface of ``session_tree()`` using a real AgentRegistry
+and real AgentProfile instances (no mocks). Covers the shape contract,
+attached-marking at both agent and session levels, and snapshot isolation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """Build a real AgentRegistry with a WAL but no sessions loaded."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    # Create a second agent profile so the registry has multiple on disk.
+    AgentProfile.new("alpha", role="").save(tmp_path / ".reyn" / "agents" / "alpha")
+    return reg
+
+
+def test_session_tree_empty_when_no_sessions_loaded(tmp_path: Path) -> None:
+    """Tier 2: session_tree() returns [] when no sessions are loaded."""
+    reg = _make_registry(tmp_path)
+    tree = reg.session_tree()
+    assert tree == []
+
+
+def test_session_tree_shape_with_attached_session(tmp_path: Path) -> None:
+    """Tier 2: session_tree() entry has 'agent', 'attached', 'sessions' keys."""
+    reg = _make_registry(tmp_path)
+    # Manually inject a session record as _sessions uses dict keying.
+    reg._sessions["default"] = {"main": object()}
+    reg._attached = ("default", "main")
+
+    tree = reg.session_tree()
+    # There is exactly one entry for "default" — verify by name lookup, not count.
+    by_name = {e["agent"]: e for e in tree}
+    assert "default" in by_name
+    entry = by_name["default"]
+    assert set(entry.keys()) == {"agent", "attached", "sessions"}
+    assert entry["attached"] is True
+    assert isinstance(entry["sessions"], list)
+
+
+def test_session_tree_session_entry_shape(tmp_path: Path) -> None:
+    """Tier 2: each session entry in the tree has 'sid' and 'attached' keys."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object()}
+    reg._attached = ("default", "main")
+
+    tree = reg.session_tree()
+    by_name = {e["agent"]: e for e in tree}
+    sess_list = by_name["default"]["sessions"]
+    # Verify the "main" session entry shape by looking it up by sid, not by index.
+    by_sid = {s["sid"]: s for s in sess_list}
+    assert "main" in by_sid
+    sess = by_sid["main"]
+    assert set(sess.keys()) == {"sid", "attached"}
+    assert sess["attached"] is True
+
+
+def test_session_tree_non_attached_agent_marked_false(tmp_path: Path) -> None:
+    """Tier 2: agents that are not the attached one have attached=False."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object()}
+    reg._sessions["alpha"] = {"main": object()}
+    reg._attached = ("default", "main")
+
+    tree = reg.session_tree()
+    # Order follows loaded_names() which is insertion order of _sessions dict.
+    by_name = {e["agent"]: e for e in tree}
+    assert by_name["default"]["attached"] is True
+    assert by_name["alpha"]["attached"] is False
+
+
+def test_session_tree_non_attached_session_marked_false(tmp_path: Path) -> None:
+    """Tier 2: sessions that are not the attached sid have attached=False."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object(), "sub1": object()}
+    reg._attached = ("default", "main")
+
+    tree = reg.session_tree()
+    entry = tree[0]
+    by_sid = {s["sid"]: s for s in entry["sessions"]}
+    assert by_sid["main"]["attached"] is True
+    assert by_sid["sub1"]["attached"] is False
+
+
+def test_session_tree_attached_none_all_false(tmp_path: Path) -> None:
+    """Tier 2: when no agent is attached (fresh registry), all attached flags are False."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object()}
+    # A fresh registry has no attached agent — verify via the public accessor.
+    assert reg.attached_name is None
+
+    tree = reg.session_tree()
+    by_name = {e["agent"]: e for e in tree}
+    assert by_name["default"]["attached"] is False
+    by_sid = {s["sid"]: s for s in by_name["default"]["sessions"]}
+    assert by_sid["main"]["attached"] is False
+
+
+def test_session_tree_sids_sorted(tmp_path: Path) -> None:
+    """Tier 2: sessions within an agent are sorted by sid."""
+    reg = _make_registry(tmp_path)
+    # Insert in non-sorted order.
+    reg._sessions["default"] = {"zz": object(), "aa": object(), "main": object()}
+    reg._attached = None
+
+    tree = reg.session_tree()
+    sids = [s["sid"] for s in tree[0]["sessions"]]
+    assert sids == sorted(sids)
+
+
+def test_session_tree_returns_snapshot_copy(tmp_path: Path) -> None:
+    """Tier 2: mutating the returned list/dicts does not affect a second call."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object()}
+    reg._attached = ("default", "main")
+
+    first = reg.session_tree()
+    # Mutate the returned structure.
+    first[0]["agent"] = "MUTATED"
+    first[0]["sessions"][0]["sid"] = "MUTATED"
+    first.append({"bogus": True})
+
+    second = reg.session_tree()
+    # The second call must reflect the live registry state, not the mutated copy.
+    by_name = {e["agent"]: e for e in second}
+    assert "default" in by_name, "second call still shows 'default' agent"
+    by_sid = {s["sid"]: s for s in by_name["default"]["sessions"]}
+    assert "main" in by_sid, "second call still shows 'main' session"
+    # 'bogus' was appended to the first snapshot copy — it must not appear in the second.
+    assert all("bogus" not in e for e in second)
+
+
+def test_session_tree_order_follows_loaded_names(tmp_path: Path) -> None:
+    """Tier 2: tree order matches loaded_names() insertion order."""
+    reg = _make_registry(tmp_path)
+    reg._sessions["default"] = {"main": object()}
+    reg._sessions["alpha"] = {"main": object()}
+    reg._attached = None
+
+    tree = reg.session_tree()
+    names_from_tree = [e["agent"] for e in tree]
+    assert names_from_tree == reg.loaded_names()


### PR DESCRIPTION
**[tui-coder]** — Phase 2 of #2271, **stacked on Phase 1 (#2272)** — base is the Phase-1 branch so this diff is Phase 2 only (retarget to main once #2272 merges).

## What

The **agent** chip's expansion is now an **agent/session tree with attach/switch on select**.

- **`AgentRegistry.session_tree()`** — public, **snapshot-style read-only** accessor (freshly-built copy of plain dicts, no handle to live `_sessions`/`_attached` — per the design note): agents in load order, each with sorted sessions + the attached `(agent, sid)` marked.
- **`_agent_expansion`** builds indented tree rows (agents + their sessions, attached marked `▸`) and **reuses `CommandUIElement`** — *no new element type* — so selecting a row dispatches `/attach <agent>` (or `/session switch <sid>` when that agent is already attached) through the normal slash path. Empty → `DetailElement`.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean (re-verified by me)
- [x] Regression: 134 passed, 2 skipped. New `test_registry_session_tree` (real `AgentRegistry`: shape, attached-marking, load order, sid sort, **snapshot isolation** = mutating the result doesn't change the registry, no mocks); agent-expansion tests moved to the tree form (CommandUIElement, `▸` at agent+session level, the 3 command variants, empty→DetailElement). No size/format pins.
- [x] **Live tmux**: `/agent new researcher` → status bar `agent researcher`; opened the agent chip → indented tree rendered (`default`/`researcher` + sessions, attached `▸`); selecting the `default` row dispatched `/attach default` and the bar switched to it.

## Note
`session_tree` touches `registry.py` (a small read-only accessor, snapshot-style per lead-coder's note). Mechanical impl by a Sonnet sub-agent against a precise spec; I re-ran gates + read `session_tree`/`_agent_expansion` + live-verified the switch myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
