### PR TITLE
[tui-coder] feat(inline-cui): bold + per-chip colour for status-bar values

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -49,7 +49,14 @@ from reyn.interfaces.inline.region_command import (
     CommandUIElement,
     build_rewind_command_ui,
 )
-from reyn.interfaces.repl.renderer import _CC_ACCENT, _CC_DIM, _CC_DONE, _SPINNER
+from reyn.interfaces.repl.renderer import (
+    _CC_ACCENT,
+    _CC_COOL,
+    _CC_DIM,
+    _CC_DONE,
+    _CC_WARN,
+    _SPINNER,
+)
 from reyn.interfaces.slash import slash_command_completions
 
 logger = logging.getLogger(__name__)
@@ -92,6 +99,9 @@ class ChipSpec:
     label: str
     value: Callable[[dict], str]
     expansion: "Callable[[dict, Callable[[str], None]], object] | None" = None
+    # Colour for the chip's (bold) value text; the label stays dim. Per-chip so the
+    # eye separates them at a glance.
+    value_color: str = _CC_DIM
 
 
 def _model_expansion(snap, dispatch):
@@ -246,11 +256,16 @@ def _more_expansion(snap, dispatch):
 
 
 _CHIP_SPECS = [
-    ChipSpec("model", "model", lambda s: str(s["model"]), _model_expansion),
-    ChipSpec("cost",  "cost",  lambda s: f"${s['cost_usd']:.4f}", _cost_expansion),
-    ChipSpec("agent", "agent", lambda s: str(s["attached_name"] or "—"), _agent_expansion),
-    ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion),
-    ChipSpec("more",  "",      lambda s: "…", _more_expansion),   # overflow submenu — Phase 5a
+    ChipSpec("model", "model", lambda s: str(s["model"]), _model_expansion,
+             value_color=_CC_ACCENT),
+    ChipSpec("cost",  "cost",  lambda s: f"${s['cost_usd']:.4f}", _cost_expansion,
+             value_color=_CC_DONE),
+    ChipSpec("agent", "agent", lambda s: str(s["attached_name"] or "—"), _agent_expansion,
+             value_color=_CC_COOL),
+    ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion,
+             value_color=_CC_WARN),
+    ChipSpec("more",  "",      lambda s: "…", _more_expansion,
+             value_color=_CC_DIM),
 ]
 
 
@@ -458,17 +473,18 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         frags: list = []
         for i, spec in enumerate(_CHIP_SPECS):
             val = spec.value(snap)
-            if spec.label:
-                text = f" {spec.label} {val} "
-            else:
-                text = f" {val} "
             selected = focused and i == menu["sel"]
-            if selected and menu["open"]:
-                text = text.rstrip() + " ▾ "
             if selected:
-                frags.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", text))
+                # the focused chip is reverse-highlighted as one block.
+                mark = " ▾" if menu["open"] else ""
+                label = f" {spec.label} " if spec.label else " "
+                frags.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f"{label}{val}{mark} "))
             else:
-                frags.append((f"fg:{_CC_DIM}", text))
+                # label stays dim; the value is bold in the chip's own colour, so
+                # the eye separates the chips at a glance.
+                frags.append((f"fg:{_CC_DIM}", f" {spec.label} " if spec.label else " "))
+                frags.append((f"fg:{spec.value_color} bold", val))
+                frags.append((f"fg:{_CC_DIM}", " "))
             if i < len(_CHIP_SPECS) - 1:
                 frags.append((f"fg:{_CC_DIM}", "│"))
         if not focused:

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -251,6 +251,7 @@ _CC_DONE = "#7ee787"    # green — completion
 _CC_ERR = "#f97066"     # red — failure
 _CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act
 _CC_ACCENT = "#d97757"  # terracotta — spinner / accents
+_CC_COOL = "#6cb6ff"    # cool blue — a secondary accent (status-bar agent value)
 # Subtle background block behind the user's own submitted line (CC styles the
 # user input differently from agent output — a faint highlighted block).
 _CC_USER_BG = "#2b2f37"

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -53,6 +53,16 @@ def test_chip_specs_has_required_keys_in_order() -> None:
     assert keys == ["model", "cost", "agent", "task", "more"]
 
 
+def test_chips_carry_per_item_value_colours() -> None:
+    """Tier 2: each chip has a value_color (the value renders bold in that colour),
+    and they vary per item so the eye separates the chips (owner: bold + per-item
+    colour). Not asserting exact hex — just that they're set and differ."""
+    by = {s.key: s.value_color for s in _CHIP_SPECS}
+    assert all(by.values())                  # every chip has a colour
+    assert by["model"] != by["agent"]        # per-item variation, not uniform
+    assert by["cost"] != by["task"]
+
+
 def test_model_chip_value_returns_model_name() -> None:
     """Tier 2: the model chip's value() returns the model string."""
     spec = next(s for s in _CHIP_SPECS if s.key == "model")


### PR DESCRIPTION
**[tui-coder]** — owner: status-bar chip **values** should be **bold + a per-item colour** (labels stay as-is). Small visual change on the merged Phase-1 framework (#2272).

## What

- `ChipSpec` gains a `value_color`; `status_fragments` renders an unselected chip as a **dim label + the value bold in the chip's own colour** (selected chip keeps the reverse-highlight). So values pop and the eye separates the chips at a glance.
- Colours: model = terracotta · cost = green · agent = cool blue (new `_CC_COOL`) · task = amber · `…` = dim.

## Test plan

- [x] `ruff` / `verify_module_docstrings` / `test_tier_audit --strict` — clean
- [x] inline/status_menu regression: 120→121 passed. New test: each chip has a `value_color` and they vary per item (behavioural, no exact-hex pin)
- [x] **Live tmux**: the `│` bar renders with bold values, no breakage (colours/bold show on a live terminal; a plain capture strips them — this is a NEW visible change, flagged for the owner's live look)

## Note
Independent of the Phase-2/3 chip expansions (touches `ChipSpec` + `status_fragments` rendering only). cost magnitude-driven colour (green→amber→red) is a possible follow-up; this PR is fixed-per-chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
