### PR TITLE
feat(inline-cui): status-bar cost breakdown — total/agent/session (#2271 Phase 4)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -106,8 +106,11 @@ def _model_expansion(snap, dispatch):
 def _cost_expansion(snap, dispatch):
     def lines():
         p, c, t = snap["usage"]
+        session = snap["cost_usd"]
         return [
-            f"total    ${snap['cost_usd']:.4f}",
+            f"total    ${snap.get('cost_total', session):.4f}",
+            f"agent    ${snap.get('cost_agent', session):.4f}",
+            f"session  ${session:.4f}",
             f"tokens   prompt {p} · completion {c} · total {t}",
         ]
     return DetailElement(lines)
@@ -161,6 +164,20 @@ def _snapshot(registry):
     if s is None:
         return None
     u = s.total_usage
+    # Cost breakdown (all via public sync accessors): total across loaded agents,
+    # the attached agent, and the attached session.
+    cost_total = 0.0
+    for name in registry.loaded_names():
+        agent_sess = registry.get_session(name)
+        if agent_sess is not None:
+            cost_total += agent_sess.total_cost_usd
+    attached_sess = (
+        registry.get_session(registry.attached_name)
+        if registry.attached_name else None
+    )
+    cost_agent = (
+        attached_sess.total_cost_usd if attached_sess is not None else s.total_cost_usd
+    )
     return {
         "model": s.model,
         "model_classes": list(s.known_model_classes()),
@@ -169,6 +186,8 @@ def _snapshot(registry):
         "skill_run_ids": list(s.running_skills.keys()),
         "usage": (u.prompt_tokens, u.completion_tokens, u.total_tokens),
         "cost_usd": s.total_cost_usd,
+        "cost_total": cost_total,
+        "cost_agent": cost_agent,
         "task_count": 0,
     }
 

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -164,19 +164,22 @@ def _snapshot(registry):
     if s is None:
         return None
     u = s.total_usage
-    # Cost breakdown (all via public sync accessors): total across loaded agents,
-    # the attached agent, and the attached session.
-    cost_total = 0.0
-    for name in registry.loaded_names():
-        agent_sess = registry.get_session(name)
-        if agent_sess is not None:
-            cost_total += agent_sess.total_cost_usd
-    attached_sess = (
-        registry.get_session(registry.attached_name)
-        if registry.attached_name else None
-    )
+    # Cost breakdown (all via public sync accessors). Sum across ALL sessions
+    # (every sid), not just each agent's "main" — a spawned sub-session accrues
+    # cost too. Nested: session ≤ agent (all the attached agent's sids) ≤ total
+    # (all agents, all sids).
+    def _agent_cost(name: str) -> float:
+        total = 0.0
+        for sid in registry.session_ids(name):
+            sess = registry.get_session(name, sid)
+            if sess is not None:
+                total += sess.total_cost_usd
+        return total
+
+    cost_total = sum(_agent_cost(name) for name in registry.loaded_names())
     cost_agent = (
-        attached_sess.total_cost_usd if attached_sess is not None else s.total_cost_usd
+        _agent_cost(registry.attached_name)
+        if registry.attached_name else s.total_cost_usd
     )
     return {
         "model": s.model,

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -168,6 +168,20 @@ def test_cost_expansion_shows_total_cost_and_token_breakdown() -> None:
     assert "total 209" in joined
 
 
+def test_cost_expansion_breaks_down_total_agent_session() -> None:
+    """Tier 2: cost expansion shows distinct total / agent / session amounts when
+    multiple agents/sessions accrue cost (total across agents ≥ the attached
+    session). Each level renders its own dollar amount, not one collapsed total."""
+    snap = _snap(cost_usd=0.0100, cost_agent=0.0100, cost_total=0.0750)
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    by_label = {ln.split()[0]: ln for ln in lines if ln.split()}
+    assert {"total", "agent", "session"} <= set(by_label)
+    assert "0.0750" in by_label["total"]      # sum across loaded agents
+    assert "0.0100" in by_label["session"]    # the attached session
+    # the breakdown is not collapsed: total reflects the cross-agent sum
+    assert by_label["total"] != by_label["session"]
+
+
 # ---------------------------------------------------------------------------
 # _agent_expansion
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — Status-bar #2271 **Phase 4**: cost chip dropdown breakdown.

## What
The cost chip dropdown showed one line labeled `total` that was actually the
**attached session's** cost. Now it shows a real three-level breakdown:

```
total    $0.0750     ← summed across all loaded agents
agent    $0.0100     ← the attached agent
session  $0.0100     ← the attached session
tokens   prompt 200 · completion 9 · total 209
```

All computed via **public sync accessors** in `_snapshot` (`registry.loaded_names()`
+ `registry.get_session(name).total_cost_usd`) — no async fork (unlike Phase 3
task tree), no OS change.

## Why
Owner spec for the status-bar redesign: "cost = total + per-agent + per-session".
The old single line was both incomplete and mislabeled.

## Test plan
- [x] `pytest tests/test_inline_pr3b_status_menu.py` — 21 passed (incl. new
  `test_cost_expansion_breaks_down_total_agent_session`)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_pr3b_status_menu.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — clean
- [x] full `pytest` — 7490 passed; 3 pre-existing gateway entry-point failures
  (`No module named 'reyn.plugins.sample_slack'`) confirmed identical on clean
  main with this diff stashed — unrelated local install-state, not this PR
- [x] (skipped — live color/layout is owner's batched live-look) visual check of the dropdown in a terminal

## Tier self-check
New test is Tier 2 (behavioral, real instances, public surface, no mocks, no
format/hex pins). Docstring first line declares `Tier 2:`.

Part of #2271 — Phases 3 (task tree, async design fork flagged to lead-coder)
and 5 (overflow + mcp/skill/cron/hook toggles, OS-lane) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
