### PR TITLE
docs(claude-md): add closing-keyword caution to PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,16 @@ Three rules then keep multi-session work coherent:
 
    In one line: **broker = hint, PR = contract**.
 
+4. **Closing-keyword caution (sub-PR arcs).** GitHub `closes/fixes/resolves #N`
+   keywords match **literally** regardless of sentence context — a sub-PR body
+   containing `closes #X` auto-closes `#X` on merge even if the sentence reads
+   "this PR partially closes #X". For sub-PRs in a multi-PR arc, use `part of
+   #X` or `toward #X`. Only the final PR that actually completes the umbrella
+   issue should use `Closes #X`.
+   **Reviewer recovery angle:** an unexpected issue auto-close triggered by a
+   sub-PR merge is almost always a closing-keyword false positive. Reopen the
+   issue and verify the arc is not half-done before assuming completion.
+
 ## Pre-conclusion observation checklist (READ BEFORE WRITING ANY FINDING / 結論)
 
 **Active trigger**: when you are about to write any of the following — **STOP**


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- Adds rule 4 to CLAUDE.md § "PR workflow": closing-keyword caution for sub-PR arcs
- GitHub `closes/fixes/resolves #N` matches **literally** regardless of sentence context — auto-closed #2259 twice (#2264, #2273) and cost real reopen/investigate cycles
- Author-facing: use `part of #X` / `toward #X` on sub-PRs; only the arc-closing PR uses `Closes #X`
- Reviewer-facing: unexpected issue auto-close on sub-PR merge = almost always a false positive; reopen + verify arc completeness

## Test plan

- [x] `ruff check src tests` — no src/tests files changed, N/A
- [x] `pytest` — no code changes, N/A
- [x] `python scripts/verify_module_docstrings.py` — no src files changed, N/A
- [x] Visual: CLAUDE.md diff reviewed above — wording is tight, both angles covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)