### PR TITLE
fix(inline-cui): fold long unbreakable tokens in markdown instead of truncating

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -375,13 +375,18 @@ def _gutter_grid(gutter: str, gutter_style: str, body, *, row_style: str = "",
     that wraps back to column 0. ``row_style`` paints a background behind the whole
     line; ``expand`` stretches the body column to the full width so that background
     fills the line edge-to-edge (the user-input block).
+
+    The body column sets ``overflow="fold"`` so a long unbreakable token (a path,
+    identifier, hash, URL) folds onto the next line instead of being truncated at
+    the right edge with an ellipsis — rich Table columns default to
+    ``overflow="ellipsis"``, which would crop such tokens.
     """
     from rich.table import Table
     from rich.text import Text
     g = Text(gutter, style=gutter_style)
     grid = Table.grid(padding=0, expand=expand)
     grid.add_column(width=g.cell_len, no_wrap=True)
-    grid.add_column(ratio=1 if expand else None)
+    grid.add_column(ratio=1 if expand else None, overflow="fold")
     grid.add_row(g, body, style=row_style or None)
     return grid
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -67,6 +67,18 @@ def test_wrapped_agent_body_hang_indents_clear_of_the_gutter() -> None:
     assert all(("⏺" not in c) or c.startswith("⏺") for c in lines)
 
 
+def test_long_unbreakable_token_folds_instead_of_truncating() -> None:
+    """Tier 2: a long unbreakable token (path / identifier / URL) folds onto a
+    continuation line rather than being cropped at the right edge with an ellipsis.
+    rich Table columns default to overflow='ellipsis'; the body column overrides to
+    'fold' so the whole token survives — its tail is still present and no '…' crop
+    marker appears."""
+    token = "/x/" + "segment_" * 12 + "TOKENTAIL"
+    out = _plain("agent", f"Path: {token}", width=40)
+    assert "…" not in out                 # not ellipsis-truncated
+    assert "TOKENTAIL" in out             # the token tail survived the fold
+
+
 def test_user_line_carries_a_background_block() -> None:
     """Tier 2: the user's own line gets a background block (CC-style 'you said
     this' design); the plain agent line does not."""


### PR DESCRIPTION
**[tui-coder]** — markdown right-edge truncation reported by the owner.

## Root cause (rich-native, not a width workaround)
The agent markdown body renders inside a `Table.grid` cell (marker gutter + body
column). **rich Table columns default to `overflow="ellipsis"`**, so a long
*unbreakable* token — a path, identifier, hash, or URL — was cropped at the right
edge with `…` instead of wrapping. Prose with spaces wrapped fine, so only some
output looked truncated.

I first suspected a fixed-80 Console width, but verified that's wrong: rich
detects width from the process std streams, and wrapping is correct at every
width I tested (bare renderer **and** the real prompt_toolkit `run_in_terminal`
path). The actual culprit is the column overflow mode.

## Fix
Set the body column's `overflow="fold"` in `_gutter_grid` — a first-class rich
option. Long tokens now fold onto the next line and survive intact. Applies to
every kind routed through `_gutter_grid` (agent markdown, tool rows, user echo).

Before / after (width 40):
```
/very/long/path/segment_segment_segment_segment_segment_seg…   ← ellipsis crop
/very/long/path/segment_segment_segment_segment_segment_segm
ent_segment_segment_segment_segment_end                        ← fold (fixed)
```

## Test plan
- [x] `pytest tests/test_inline_renderer_cutover.py` — 16 passed (incl. new
  `test_long_unbreakable_token_folds_instead_of_truncating`)
- [x] `ruff check` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` — clean
- [x] live-verified through the real prompt_toolkit `run_in_terminal` path: a long
  path token + long identifier fold across lines with no `…` crop

## Tier self-check
New test is Tier 2 (behavioral, real `format_inline_message` + Console, public
rendered-text surface, no mocks, no format pins). Docstring first line declares
`Tier 2:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
