### PR TITLE
feat(inline-cui): task chip = task tree via async-poll snapshot cache (#2271 Phase 3)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -139,10 +139,71 @@ def _agent_expansion(snap, dispatch):
     return CommandUIElement(rows, cmds, dispatch)
 
 
+def _build_task_tree(task_dicts: list[dict]) -> list[dict]:
+    """Build a nested task tree from a flat list of Task.to_dict() projections.
+
+    Roots are tasks whose requester_kind is not "task" or whose requester is
+    not the task_id of any task in the input. Children are tasks with
+    requester_kind == "task" and requester == parent task_id. Siblings are
+    sorted by task_id for determinism. Cycles are guarded by tracking visited
+    task_ids so no task appears twice.
+    """
+    by_id: dict[str, dict] = {d["task_id"]: d for d in task_dicts}
+    task_ids: frozenset[str] = frozenset(by_id)
+
+    def _is_root(d: dict) -> bool:
+        return d.get("requester_kind") != "task" or d.get("requester") not in task_ids
+
+    def _children_of(parent_id: str, visited: set[str]) -> list[dict]:
+        kids = [
+            d for d in task_dicts
+            if d.get("requester_kind") == "task"
+            and d.get("requester") == parent_id
+            and d["task_id"] not in visited
+        ]
+        kids.sort(key=lambda d: d["task_id"])
+        result = []
+        for k in kids:
+            visited.add(k["task_id"])
+            result.append({
+                "task_id": k["task_id"],
+                "name": k["name"],
+                "status": k["status"],
+                "children": _children_of(k["task_id"], visited),
+            })
+        return result
+
+    roots = sorted(
+        [d for d in task_dicts if _is_root(d)],
+        key=lambda d: d["task_id"],
+    )
+    visited: set[str] = {d["task_id"] for d in roots}
+    return [
+        {
+            "task_id": r["task_id"],
+            "name": r["name"],
+            "status": r["status"],
+            "children": _children_of(r["task_id"], visited),
+        }
+        for r in roots
+    ]
+
+
 def _task_expansion(snap, dispatch):
-    # Phase 1: count only. Phase 3 = task tree.
-    n = snap.get("task_count", 0)
-    return DetailElement(lambda: [f"{n} active task{'' if n == 1 else 's'}"])
+    # Phase 3: task tree. Depth-first indented rows (2 spaces per depth).
+    tree = snap.get("task_tree") or []
+    if not tree:
+        return DetailElement(lambda: ["(no active tasks)"])
+
+    def _rows(nodes: list[dict], depth: int) -> list[str]:
+        out = []
+        for node in nodes:
+            out.append(f"{'  ' * depth}{node['status']}  {node['name']}")
+            out.extend(_rows(node["children"], depth + 1))
+        return out
+
+    rows = _rows(tree, 0)
+    return DetailElement(lambda: rows)
 
 
 _CHIP_SPECS = [
@@ -170,7 +231,7 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
     ]
 
 
-def _snapshot(registry):
+def _snapshot(registry, task_cache=None):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
     if s is None:
@@ -204,7 +265,8 @@ def _snapshot(registry):
         "cost_usd": s.total_cost_usd,
         "cost_total": cost_total,
         "cost_agent": cost_agent,
-        "task_count": 0,
+        "task_count": task_cache["count"] if task_cache else 0,
+        "task_tree": task_cache["tree"] if task_cache else [],
     }
 
 
@@ -225,6 +287,9 @@ async def run_inline_input(registry, renderer) -> None:
     # chip's element), not here — the same selection mechanism as the above-input
     # region (interventions / the /rewind picker), unified in F5.
     menu = {"sel": 0, "open": False}
+    # Async-polled task cache: updated every ~1 s by _task_poll; read by
+    # _snapshot so the status bar and dropdown reflect live active tasks.
+    task_cache: dict = {"tree": [], "count": 0}
     # Below-input region: hosts the opened chip's dropdown as a region element —
     # a CommandUIElement model picker (selectable) or a read-only DetailElement
     # (live detail, no cursor). Empty (cleared) while the menu is closed.
@@ -263,7 +328,7 @@ async def run_inline_input(registry, renderer) -> None:
     inputrow = VSplit([prompt_sym, input_win])
 
     def status_fragments() -> list:
-        snap = _snapshot(registry)
+        snap = _snapshot(registry, task_cache)
         if snap is None:
             return [(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]
         focused = get_app().layout.has_focus(status_win)
@@ -404,7 +469,7 @@ async def run_inline_input(registry, renderer) -> None:
         spec = _CHIP_SPECS[menu["sel"]]
         menu_region.clear()
         if spec.expansion is not None:
-            el = spec.expansion(_snapshot(registry), _menu_submit)
+            el = spec.expansion(_snapshot(registry, task_cache), _menu_submit)
             menu_region.register(el)
         menu["open"] = True
 
@@ -524,6 +589,18 @@ async def run_inline_input(registry, renderer) -> None:
             region_holder["key"] = None
             app.layout.focus(input_win)
 
+    async def _task_poll() -> None:
+        while True:
+            await asyncio.sleep(1.0)
+            try:
+                tasks = await registry.task_backend.list()
+                dicts = [t.to_dict() for t in tasks]
+                active = [d for d in dicts if d["status"] not in ("done", "failed", "aborted")]
+                task_cache["tree"] = _build_task_tree(active)
+                task_cache["count"] = len(active)
+            except Exception:
+                logger.debug("task poll failed", exc_info=True)
+
     async def _intervention_poll() -> None:
         while True:
             await asyncio.sleep(0.15)
@@ -557,11 +634,13 @@ async def run_inline_input(registry, renderer) -> None:
     # PromptSession path. Renderer output (sys.__stdout__ via run_in_terminal in
     # _output_loop) is unaffected.
     poll_task = asyncio.create_task(_intervention_poll())
+    task_poll_task = asyncio.create_task(_task_poll())
     try:
         with patch_stdout():
             await app.run_async()
     finally:
         poll_task.cancel()
+        task_poll_task.cancel()
 
 
 async def _deliver_intervention_choice(registry, choice_id: str, label: str) -> None:

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from reyn.interfaces.inline.app import (
     _CHIP_SPECS,
     _agent_expansion,
+    _build_task_tree,
     _cost_expansion,
     _model_expansion,
     _task_expansion,
@@ -30,6 +31,7 @@ def _snap(**over):
         "usage": (0, 0, 0),
         "cost_usd": 0.0,
         "task_count": 0,
+        "task_tree": [],
     }
     base.update(over)
     return base
@@ -297,24 +299,91 @@ def test_agent_expansion_empty_tree_returns_detail_element() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _build_task_tree
+# ---------------------------------------------------------------------------
+
+_ROOT_DICT = {
+    "task_id": "t-root",
+    "name": "Root Task",
+    "status": "running",
+    "requester": "session-1",
+    "requester_kind": "session",
+}
+_CHILD_DICT = {
+    "task_id": "t-child",
+    "name": "Child Task",
+    "status": "ready",
+    "requester": "t-root",
+    "requester_kind": "task",
+}
+
+
+def test_build_task_tree_child_nests_under_root() -> None:
+    """Tier 2: a task with requester_kind='task' and requester=<root id> nests under root."""
+    tree = _build_task_tree([_ROOT_DICT, _CHILD_DICT])
+    assert tree, "expected at least one root node"
+    root = next((n for n in tree if n["task_id"] == "t-root"), None)
+    assert root is not None
+    child_ids = [c["task_id"] for c in root["children"]]
+    assert "t-child" in child_ids
+
+
+def test_build_task_tree_session_owned_task_is_root() -> None:
+    """Tier 2: a task with requester_kind='session' appears at the top level (is a root)."""
+    tree = _build_task_tree([_ROOT_DICT])
+    root_ids = [n["task_id"] for n in tree]
+    assert "t-root" in root_ids
+
+
+def test_build_task_tree_returns_plain_dicts() -> None:
+    """Tier 2: _build_task_tree returns plain dicts; mutating the result does not raise."""
+    tree = _build_task_tree([_ROOT_DICT, _CHILD_DICT])
+    assert tree
+    node = tree[0]
+    assert isinstance(node, dict)
+    # Mutating should be fine — plain dict, not a frozen dataclass or Task instance.
+    node["_test_key"] = "ok"
+
+
+# ---------------------------------------------------------------------------
 # _task_expansion
 # ---------------------------------------------------------------------------
 
 
-def test_task_expansion_is_detail_element() -> None:
-    """Tier 2: _task_expansion returns a read-only DetailElement."""
-    snap = _snap(task_count=2)
+def test_task_expansion_empty_tree_is_detail_element() -> None:
+    """Tier 2: _task_expansion with empty task_tree returns a non-selectable DetailElement."""
+    snap = _snap(task_tree=[])
     el = _task_expansion(snap, lambda _: None)
     assert isinstance(el, DetailElement)
     assert el.selectable is False
 
 
-def test_task_expansion_shows_count_and_pluralises() -> None:
-    """Tier 2: task expansion line includes the count; plural for N≠1."""
-    snap_1 = _snap(task_count=1)
-    el_1 = _task_expansion(snap_1, lambda _: None)
-    assert "1 active task" in " ".join(el_1.lines())
-    # plural
-    snap_3 = _snap(task_count=3)
-    el_3 = _task_expansion(snap_3, lambda _: None)
-    assert "tasks" in " ".join(el_3.lines())
+def test_task_expansion_empty_tree_shows_no_active_tasks_message() -> None:
+    """Tier 2: empty task_tree expansion contains a 'no active task' message."""
+    snap = _snap(task_tree=[])
+    el = _task_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
+    assert "no active task" in joined
+
+
+def test_task_expansion_populated_shows_parent_and_child_names() -> None:
+    """Tier 2: populated task_tree renders both parent and child task names."""
+    tree = _build_task_tree([_ROOT_DICT, _CHILD_DICT])
+    snap = _snap(task_tree=tree)
+    el = _task_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
+    assert "Root Task" in joined
+    assert "Child Task" in joined
+
+
+def test_task_expansion_child_row_more_indented_than_parent() -> None:
+    """Tier 2: in a populated tree, the child row has more leading whitespace than the root."""
+    tree = _build_task_tree([_ROOT_DICT, _CHILD_DICT])
+    snap = _snap(task_tree=tree)
+    el = _task_expansion(snap, lambda _: None)
+    rows = el.lines()
+    root_row = next(r for r in rows if "Root Task" in r)
+    child_row = next(r for r in rows if "Child Task" in r)
+    root_indent = len(root_row) - len(root_row.lstrip())
+    child_indent = len(child_row) - len(child_row.lstrip())
+    assert child_indent > root_indent


### PR DESCRIPTION
**[tui-coder]** — Status-bar #2271 **Phase 3**: the `task` chip dropdown shows the live task tree instead of a bare count.

## Design (resolves the async-vs-sync fork; no OS change)
The `TaskBackend` is fully async (sqlite I/O), but `_snapshot` renders
synchronously. Bridge, per lead-coder's steer (snapshot-style immutable copy,
like `session_tree()`):
- An async `_task_poll()` sibling to the existing `_intervention_poll()` awaits
  the EXISTING `registry.task_backend.list()` every ~1 s and caches an
  **immutable** tree snapshot (plain dicts from `Task.to_dict()`, never live
  `Task` handles).
- Sync `_snapshot(registry, task_cache)` reads the cache → `task_count` +
  `task_tree`.
- `_build_task_tree` (pure) nests via the **requester edge** (`requester_kind ==
  "task"` + `requester == parent_id`; session-owned tasks are roots),
  cycle-guarded, deterministic sibling sort.
- `_task_expansion` renders depth-indented `status  name` rows (read-only).

No OS files touched — uses the existing async backend. The poller catches
`Exception` only (CancelledError propagates) and is cancelled in the same
`finally` as the intervention poller.

## Verification
- [x] `ruff` clean; `test_tier_audit --strict` 0 errors; `pytest` inline suite 54 passed
- [x] **Integration probe** with real `Task` objects + `InMemoryTaskBackend`:
  `to_dict()` → `_build_task_tree` nests a child under its parent, excludes a
  `done` task from active, renders `running  parent` / `  ready  child`
- [x] **Live** (tmux, litellm proxy): app launches, poller runs without crashing
  (`task 0`), the task chip opens and shows `(no active tasks)` empty state
- [x] (owner live-look) the populated tree's visual is batched into the
  cumulative status-bar one-glance with #2276 + #2270 (per lead-coder pacing)

## Tier self-check
New tests Tier 2 (behavioral, real instances, public rendered surface, no mocks,
no format pins). First docstring line `Tier 2:`.

Part of #2271. Phase 5 (overflow + mcp/skill/cron/hook toggles, OS-lane) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
