### PR TITLE
docs(time-travel): qualify WAL durability semantics post-#2259

### DIFF
--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -63,7 +63,7 @@ Each checkpoint stores an **AgentSnapshot** — a point-in-time snapshot of the 
 1. The snapshot at or before the target seq is located.
 2. The WAL (`StateLog`, `.reyn/state/wal.jsonl`) events between the snapshot and the target seq are applied as a diff — replaying only the delta, not the full history.
 
-The WAL is a **synchronous-durability log** (fsync'd per append), separate from the P6 audit event log. See [Events](events.md) for the WAL vs audit-event distinction.
+The WAL is an **fsync-per-append log**: each entry is durably written via `DurabilityWorker` off the task loop. Task-loop writes are fire-and-forget except `step_started`, which blocks until durable (durable-before-side-effect invariant). Recovery restores to the last durable entry; an un-durable tail at crash is a consistent-prefix loss. Separate from the P6 audit event log — see [Events](events.md) for the WAL vs audit-event distinction.
 
 ### Global single-seq WAL and consistent-cut
 
@@ -113,9 +113,9 @@ The WAL (`StateLog`, `.reyn/state/wal.jsonl`) and the P6 audit event log (`Event
 | | WAL (StateLog) | Audit log (EventStore) |
 |--|--|--|
 | Purpose | Crash recovery and time-travel reconstruct | Audit trail and replay |
-| Durability | fsync per append (synchronous) | Rotation-based (not per-append fsync) |
+| Durability | fsync per append (via `DurabilityWorker`; `step_started` blocks task loop, others FAF) | Rotation-based (not per-append fsync) |
 | Lifecycle | Truncatable after snapshot | Append-only, rotation-based |
-| Unification | **Prohibited** — sync durability requirements differ | — |
+| Unification | **Prohibited** — durability-contract requirements differ | — |
 
 Do not conflate or merge the two logs. See [Events](events.md) for details.
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary

- Fixes misleading "synchronous-durability log" label in `docs/concepts/runtime/time-travel.md` (lines 66 and 116)
- Post-#2259 the label is inaccurate: `DurabilityWorker` fsync IS synchronous within the worker, but the task loop submits writes **fire-and-forget** — only `step_started` blocks the task loop (durable-before-side-effect invariant)
- Adds recovery semantics: restores to last durable entry; un-durable tail at crash = consistent-prefix loss

**Drift detected during #2259 arc coordination** (cross-ref review with e2e-coder; PR-3 / #2283 confirmed the final model, unblocking this pass).

## Changes

| Location | Before | After |
|---|---|---|
| Line 66 | "synchronous-durability log (fsync'd per append)" | accurate DurabilityWorker off-loop + FAF + step_started exception + consistent-prefix loss |
| Table Durability row | "fsync per append (synchronous)" | "fsync per append (via `DurabilityWorker`; `step_started` blocks task loop, others FAF)" |
| Table Unification row | "sync durability requirements differ" | "durability-contract requirements differ" |

Note: `time-travel.ja.md` parity pass is deferred (low-priority, existing parity debt accepted in this repo).

## Test plan

- [x] `ruff check src tests` — no src/tests changed, N/A
- [x] `pytest` — no code changes, N/A
- [x] `python scripts/verify_module_docstrings.py` — no src files changed, N/A
- [x] Prose consistency: new description cross-checked against feature-map.md #2283 rows and #2259 PR-3 semantics ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)