### PR TITLE
feat(inline-cui): … overflow chip = read-only cron/mcp/hooks listing (#2271 Phase 5a)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -540,6 +540,6 @@ def run(args: argparse.Namespace) -> None:
             if _once_result.get("limit_stopped"):
                 sys.exit(2)
             return
-        await run_repl(registry, renderer=renderer)
+        await run_repl(registry, renderer=renderer, config=session_cfg.config)
 
     run_async(_main_chat())

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -206,12 +206,51 @@ def _task_expansion(snap, dispatch):
     return DetailElement(lambda: rows)
 
 
+def _more_expansion(snap, dispatch):
+    """Read-only overflow panel: cron jobs / mcp servers / hooks from config.
+
+    Renders a sectioned listing — one header per category (always shown, even
+    when the section is empty) with indented item rows. No actions, no dispatch
+    calls — purely informational. Toggles are a separate OS-lane design (#2285).
+    """
+    cron_jobs = snap.get("cron_jobs") or []
+    mcp_servers = snap.get("mcp_servers") or []
+    hooks = snap.get("hooks") or []
+
+    lines: list[str] = []
+
+    lines.append(f"cron  ({len(cron_jobs)})")
+    if cron_jobs:
+        for j in cron_jobs:
+            marker = "on" if j["enabled"] else "off"
+            lines.append(f"  [{marker}] {j['name']}  {j['schedule']}")
+    else:
+        lines.append("  (none)")
+
+    lines.append(f"mcp  ({len(mcp_servers)})")
+    if mcp_servers:
+        for s in mcp_servers:
+            lines.append(f"  {s['name']}")
+    else:
+        lines.append("  (none)")
+
+    lines.append(f"hooks  ({len(hooks)})")
+    if hooks:
+        for h in hooks:
+            lines.append(f"  {h['label']}")
+    else:
+        lines.append("  (none)")
+
+    captured = lines[:]
+    return DetailElement(lambda: captured)
+
+
 _CHIP_SPECS = [
     ChipSpec("model", "model", lambda s: str(s["model"]), _model_expansion),
     ChipSpec("cost",  "cost",  lambda s: f"${s['cost_usd']:.4f}", _cost_expansion),
     ChipSpec("agent", "agent", lambda s: str(s["attached_name"] or "—"), _agent_expansion),
     ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion),
-    ChipSpec("more",  "",      lambda s: "…", None),   # overflow submenu — Phase 5
+    ChipSpec("more",  "",      lambda s: "…", _more_expansion),   # overflow submenu — Phase 5a
 ]
 
 
@@ -231,7 +270,71 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
     ]
 
 
-def _snapshot(registry, task_cache=None):
+def _extract_cron_jobs(config) -> list[dict]:
+    """Extract cron job dicts from config. Returns [] on any missing/malformed section."""
+    cron = getattr(config, "cron", None)
+    jobs = getattr(cron, "jobs", None) if cron is not None else None
+    if not jobs:
+        return []
+    result = []
+    for j in jobs:
+        try:
+            result.append({
+                "name": j.name,
+                "schedule": j.schedule,
+                "enabled": bool(j.enabled),
+            })
+        except Exception:  # noqa: BLE001
+            pass
+    return result
+
+
+def _extract_mcp_servers(config) -> list[dict]:
+    """Extract mcp server name dicts from config. Returns [] on any missing/malformed section."""
+    mcp = getattr(config, "mcp", None)
+    if mcp is None:
+        return []
+    # mcp may be a dict with a "servers" sub-key, or a flat {name: cfg} dict.
+    if isinstance(mcp, dict):
+        servers = mcp.get("servers", None)
+        if isinstance(servers, dict):
+            source = servers
+        else:
+            # Flat dict — values should be dicts (server configs).
+            source = {k: v for k, v in mcp.items() if isinstance(v, dict)}
+    else:
+        return []
+    return [{"name": name} for name in source]
+
+
+def _extract_hooks(config) -> list[dict]:
+    """Extract hook label dicts from config. Returns [] on any missing/malformed section."""
+    hooks_raw = getattr(config, "hooks", None)
+    if not hooks_raw:
+        return []
+    result = []
+    _HOOK_EVENT_KEYS = frozenset({
+        "event", "hook", "on", "trigger", "type", "name", "hook_point",
+    })
+    for i, entry in enumerate(hooks_raw):
+        try:
+            if isinstance(entry, dict):
+                # Best-effort label: prefer a hook-point/event-ish key.
+                label_key = next(
+                    (k for k in _HOOK_EVENT_KEYS if k in entry), None
+                )
+                if label_key is None:
+                    label_key = next(iter(entry), None)
+                label = str(entry[label_key])[:40] if label_key else f"hook {i}"
+            else:
+                label = str(entry)[:40]
+        except Exception:  # noqa: BLE001
+            label = f"hook {i}"
+        result.append({"label": label})
+    return result
+
+
+def _snapshot(registry, task_cache=None, config=None):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
     if s is None:
@@ -267,14 +370,22 @@ def _snapshot(registry, task_cache=None):
         "cost_agent": cost_agent,
         "task_count": task_cache["count"] if task_cache else 0,
         "task_tree": task_cache["tree"] if task_cache else [],
+        "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
+        "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
+        "hooks": _extract_hooks(config) if config is not None else [],
     }
 
 
-async def run_inline_input(registry, renderer) -> None:
+async def run_inline_input(registry, renderer, config=None) -> None:
     """Run the interactive inline input Application until the user quits.
 
     Returns on quit (Ctrl-C/D/Q or /quit /exit) so run_repl can tear down (cost
     summary) via its FIRST_COMPLETED wait.
+
+    ``config`` is the loaded ReynConfig (or None), threaded read-only into
+    ``_snapshot`` so the ``…`` overflow chip can list cron jobs / mcp servers /
+    hooks. When None (--cui / non-inline path) the overflow panel shows empty
+    sections — backward-compatible.
     """
     attached = registry.attached_session()
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
@@ -328,7 +439,7 @@ async def run_inline_input(registry, renderer) -> None:
     inputrow = VSplit([prompt_sym, input_win])
 
     def status_fragments() -> list:
-        snap = _snapshot(registry, task_cache)
+        snap = _snapshot(registry, task_cache, config)
         if snap is None:
             return [(f"fg:{_CC_DIM}", " /quit to exit · ↑ history")]
         focused = get_app().layout.has_focus(status_win)
@@ -469,7 +580,7 @@ async def run_inline_input(registry, renderer) -> None:
         spec = _CHIP_SPECS[menu["sel"]]
         menu_region.clear()
         if spec.expansion is not None:
-            el = spec.expansion(_snapshot(registry, task_cache), _menu_submit)
+            el = spec.expansion(_snapshot(registry, task_cache, config), _menu_submit)
             menu_region.register(el)
         menu["open"] = True
 

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -205,11 +205,16 @@ def _simple_status(text: str):
     return OutboxMessage(kind="status", text=text)
 
 
-async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
+async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=None) -> None:
     """Attach to the default agent (or pre-attached one) and run the REPL.
 
     Caller is expected to have called `await registry.attach(name)` before
     invoking this function so the user lands on a known agent.
+
+    ``config`` is the loaded ReynConfig (or None). When supplied it is threaded
+    read-only to ``run_inline_input`` so the ``…`` overflow chip can surface
+    cron / mcp / hooks state. The --cui / non-TTY path is not affected (it uses
+    ``_input_loop`` and never receives ``config``).
     """
     attached = registry.attached_session()
     if attached is None:
@@ -248,7 +253,7 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer) -> None:
     # run_in_terminal prints above whichever input is live.
     if renderer.uses_app_input() and sys.stdin.isatty():
         from reyn.interfaces.inline.app import run_inline_input
-        inputs = asyncio.create_task(run_inline_input(registry, renderer))
+        inputs = asyncio.create_task(run_inline_input(registry, renderer, config))
     else:
         from prompt_toolkit.styles import Style
         prompt_session: PromptSession[str] = PromptSession(

--- a/tests/test_inline_pr3b_status_menu.py
+++ b/tests/test_inline_pr3b_status_menu.py
@@ -3,7 +3,8 @@
 The status bar is now declarative: each chip is a ``ChipSpec`` with a key,
 label, value function, and optional expansion builder. Tests exercise the
 public surface (``_CHIP_SPECS``, ``_model_expansion``, ``_cost_expansion``,
-``_agent_expansion``, ``_task_expansion``) using real instances; no mocks.
+``_agent_expansion``, ``_task_expansion``, ``_more_expansion``) using real
+instances; no mocks.
 """
 from __future__ import annotations
 
@@ -13,6 +14,7 @@ from reyn.interfaces.inline.app import (
     _build_task_tree,
     _cost_expansion,
     _model_expansion,
+    _more_expansion,
     _task_expansion,
 )
 from reyn.interfaces.inline.region import DetailElement
@@ -32,6 +34,9 @@ def _snap(**over):
         "cost_usd": 0.0,
         "task_count": 0,
         "task_tree": [],
+        "cron_jobs": [],
+        "mcp_servers": [],
+        "hooks": [],
     }
     base.update(over)
     return base
@@ -81,10 +86,85 @@ def test_task_chip_value_returns_count_string() -> None:
     assert spec.value(_snap(task_count=0)) == "0"
 
 
-def test_more_chip_has_no_expansion() -> None:
-    """Tier 2: the 'more' chip has no expansion (Phase 5 placeholder)."""
+def test_more_chip_has_expansion() -> None:
+    """Tier 2: the 'more' chip has a non-None expansion (Phase 5a)."""
     spec = next(s for s in _CHIP_SPECS if s.key == "more")
-    assert spec.expansion is None
+    assert spec.expansion is not None
+
+
+# ---------------------------------------------------------------------------
+# _more_expansion (Phase 5a: read-only cron/mcp/hooks overflow panel)
+# ---------------------------------------------------------------------------
+
+
+def test_more_expansion_empty_returns_detail_element() -> None:
+    """Tier 2: _more_expansion with empty config sections returns a read-only DetailElement."""
+    el = _more_expansion(_snap(), lambda _: None)
+    assert isinstance(el, DetailElement)
+    assert el.selectable is False
+
+
+def test_more_expansion_empty_shows_all_section_headers_with_zero() -> None:
+    """Tier 2: empty snap shows cron/mcp/hooks headers with (0) and a (none) line each."""
+    el = _more_expansion(_snap(), lambda _: None)
+    joined = " ".join(el.lines())
+    assert "cron" in joined
+    assert "mcp" in joined
+    assert "hooks" in joined
+    assert "(0)" in joined
+    assert "(none)" in joined
+
+
+def test_more_expansion_empty_all_three_sections_each_have_none_line() -> None:
+    """Tier 2: each of the three sections contains a '(none)' indicator when empty."""
+    el = _more_expansion(_snap(), lambda _: None)
+    lines = el.lines()
+    # There should be a (none) line following each header.
+    none_lines = [ln for ln in lines if "(none)" in ln]
+    # At minimum one (none) per section — i.e. three total when all empty.
+    assert none_lines
+
+
+def test_more_expansion_populated_cron_shows_on_off_markers() -> None:
+    """Tier 2: populated cron_jobs render nightly with 'on' and paused with 'off'."""
+    snap = _snap(
+        cron_jobs=[
+            {"name": "nightly", "schedule": "0 0 * * *", "enabled": True},
+            {"name": "paused",  "schedule": "0 * * * *", "enabled": False},
+        ],
+        mcp_servers=[{"name": "github"}],
+        hooks=[{"label": "on_push"}],
+    )
+    el = _more_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
+    assert "nightly" in joined
+    assert "on" in joined       # enabled marker for nightly
+    assert "paused" in joined
+    assert "off" in joined      # disabled marker for paused
+
+
+def test_more_expansion_populated_mcp_shows_server_name() -> None:
+    """Tier 2: populated mcp_servers renders the server name."""
+    snap = _snap(
+        cron_jobs=[],
+        mcp_servers=[{"name": "github"}],
+        hooks=[],
+    )
+    el = _more_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
+    assert "github" in joined
+
+
+def test_more_expansion_populated_hooks_shows_label() -> None:
+    """Tier 2: populated hooks renders the hook label."""
+    snap = _snap(
+        cron_jobs=[],
+        mcp_servers=[],
+        hooks=[{"label": "on_push"}],
+    )
+    el = _more_expansion(snap, lambda _: None)
+    joined = " ".join(el.lines())
+    assert "on_push" in joined
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — Status-bar #2271 **Phase 5a**: the `…` overflow chip opens a READ-ONLY submenu listing config-registered cron jobs / mcp servers / hooks with state. **No toggles, no config writes** — the enable/disable wiring is the separate OS-lane design in **#2285** (gated on owner intent, since the config layer is non-uniform: only cron has a clean `enabled` flag).

## What
The `…` chip dropdown now shows:
```
cron  (2)
  [on] nightly-report  0 0 * * *
  [off] paused-job  0 * * * *
mcp  (0)
  (none)
hooks  (0)
  (none)
```
A sectioned, read-only listing. Skills are intentionally omitted (filesystem-resolved, not config enable/disable-able — part of the #2285 design).

## How (the seam)
The loaded `ReynConfig` is threaded **read-only** from chat.py (`session_cfg.config`) → `run_repl(…, config=…)` → `run_inline_input(…, config)` → `_snapshot(registry, task_cache, config)`. `config` is keyword-only with a `None` default, so the plain `--cui` / non-TTY path (which uses `_input_loop`, never receives config) is unaffected. `_snapshot` reads `config.cron.jobs` / `config.mcp` / `config.hooks` via defensive extract helpers (every access guarded → `[]` on any malformed/missing section; handles mcp's wrapped `servers` form). `_more_expansion` renders the read-only `DetailElement`.

This is the extensible foundation: adding a category = one extract helper + one section.

## Verification
- [x] `ruff` clean; `test_tier_audit --strict` 0 errors; `verify_module_docstrings` clean
- [x] `pytest` inline + repl/chat sweep (`-k "repl or chat_cli or inline"`) — 380 passed, 2 skipped (the `config=None` default keeps the plain path green)
- [x] **Live** (tmux, litellm proxy): added two cron jobs (one enabled, one disabled) to a test config → the `…` chip opens and renders `cron (2)` with correct `[on]`/`[off]` markers + schedules, `mcp (0)` / `hooks (0)` empty sections; no crash; plain path unaffected. Test config reverted after.
- [x] (owner live-look) folds into the cumulative status-bar one-glance with #2276 + #2270

## Tier self-check
New tests Tier 2 (behavioral, real instances, public rendered surface, no mocks, no format pins). First docstring line `Tier 2:`. `test_more_chip_has_no_expansion` was updated (the `…` chip intentionally gained an expansion).

Part of #2271. Toggles (5b) tracked in #2285 (OS-lane, owner-intent-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
