### PR TITLE
fix: repair dangling tool_calls on crash/interrupt (role=tool missing)

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -27,6 +27,51 @@ if TYPE_CHECKING:
 
 # ── Standalone helpers (moved from session.py) ────────────────────────────────
 
+_INTERRUPTED_TOOL_RESULT = json.dumps(
+    {"status": "error", "error": {"kind": "interrupted",
+                                   "message": "Tool execution was interrupted."}},
+)
+
+
+def _repair_dangling_tool_calls(messages: list[dict]) -> list[dict]:
+    """Synthesize error tool_results for any unanswered tool_calls.
+
+    A crash or ctrl-c between the role=assistant+tool_calls append and the
+    corresponding role=tool appends leaves the history in an API-invalid state:
+    every provider requires a tool_result for every tool_call_id. This repair
+    pass ensures the LLM wire format satisfies the pairing invariant without
+    mutating the on-disk history (the caller passes the already-serialised
+    message list, not the raw ChatMessage history).
+
+    Walk: for each assistant message carrying tool_calls, consume the
+    immediately-following role=tool messages, then inject synthetic error
+    results for every tool_call_id that has no matching role=tool entry.
+    """
+    result: list[dict] = []
+    i = 0
+    while i < len(messages):
+        m = messages[i]
+        result.append(m)
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            needed: set[str] = {
+                tc["id"]
+                for tc in m["tool_calls"]
+                if tc.get("id")
+            }
+            i += 1
+            while i < len(messages) and messages[i].get("role") == "tool":
+                needed.discard(messages[i].get("tool_call_id"))
+                result.append(messages[i])
+                i += 1
+            for tc_id in needed:
+                result.append(
+                    {"role": "tool", "tool_call_id": tc_id,
+                     "content": _INTERRUPTED_TOOL_RESULT}
+                )
+        else:
+            i += 1
+    return result
+
 
 def _is_force_close_consolidation(summary: Any) -> bool:
     """#1092 PR-F2a: True iff a ``summary`` turn is a force-close handoff
@@ -329,7 +374,9 @@ class RouterHistoryBuffer:
                 ts=_fc_summary.ts,
             )]
             return self._bound_wire_reasoning(
-                [self._serialise_turn(m) for m in (_bridge + _post)]
+                _repair_dangling_tool_calls(
+                    [self._serialise_turn(m) for m in (_bridge + _post)]
+                )
             )
 
         effective_trigger, head_budget, tail_budget = self._resolve_budgets()
@@ -372,7 +419,9 @@ class RouterHistoryBuffer:
         # are materialised to data URLs **at this boundary** so storage
         # stays light and the LLM sees the inline form it expects.
         return self._bound_wire_reasoning(
-            [self._serialise_turn(m) for m in selected]
+            _repair_dangling_tool_calls(
+                [self._serialise_turn(m) for m in selected]
+            )
         )
 
     def decompose_history_for_retry(
@@ -436,7 +485,9 @@ class RouterHistoryBuffer:
                 summary_dict = structured
         head = [self._serialise_turn(m) for m in head_msgs]
         raw_middle = [self._serialise_turn(m) for m in raw_middle_msgs]
-        tail = [self._serialise_turn(m) for m in tail_msgs]
+        tail = _repair_dangling_tool_calls(
+            [self._serialise_turn(m) for m in tail_msgs]
+        )
         # #1652/②: bound native reasoning across the ordered carriers (the strip
         # is in-place, so the shared dicts in head/raw_middle/tail are bounded).
         self._bound_wire_reasoning(head + raw_middle + tail)

--- a/tests/test_repair_dangling_tool_calls.py
+++ b/tests/test_repair_dangling_tool_calls.py
@@ -1,0 +1,139 @@
+"""Tier 2: _repair_dangling_tool_calls — synthetic tool_result injection.
+
+Crash or ctrl-c between the role=assistant+tool_calls write and the
+role=tool writes leaves the history in an API-invalid state. The repair
+function inserts synthetic interrupted error results for every tool_call_id
+that has no matching role=tool, so the LLM wire format satisfies the
+provider pairing invariant on the next turn.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.runtime.services.router_history_buffer import _repair_dangling_tool_calls
+
+
+def _tc(id: str, name: str = "some_tool") -> dict:
+    return {"id": id, "type": "function", "function": {"name": name, "arguments": "{}"}}
+
+
+def _assistant(tool_call_ids: list[str]) -> dict:
+    return {"role": "assistant", "content": "", "tool_calls": [_tc(i) for i in tool_call_ids]}
+
+
+def _tool(id: str, content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": id, "content": content}
+
+
+def _user(text: str = "hi") -> dict:
+    return {"role": "user", "content": text}
+
+
+def _is_interrupted(m: dict) -> bool:
+    try:
+        d = json.loads(m["content"])
+        return d.get("error", {}).get("kind") == "interrupted"
+    except Exception:
+        return False
+
+
+# ── No tool_calls → pass-through ─────────────────────────────────────────────
+
+
+def test_no_tool_calls_returns_messages_unchanged():
+    """Tier 2: messages with no tool_calls are returned unchanged."""
+    msgs = [_user("hello"), {"role": "assistant", "content": "hi"}]
+    assert _repair_dangling_tool_calls(msgs) == msgs
+
+
+def test_empty_list_returns_empty():
+    """Tier 2: empty input → empty output."""
+    assert _repair_dangling_tool_calls([]) == []
+
+
+# ── Fully answered tool_calls → pass-through ─────────────────────────────────
+
+
+def test_fully_answered_single_tool_call_unchanged():
+    """Tier 2: assistant+tool_calls followed by all matching role=tool → no injection."""
+    msgs = [_assistant(["id-1"]), _tool("id-1")]
+    result = _repair_dangling_tool_calls(msgs)
+    assert result == msgs
+
+
+def test_fully_answered_two_tool_calls_unchanged():
+    """Tier 2: two tool_calls both answered → no injection."""
+    msgs = [_assistant(["a", "b"]), _tool("a"), _tool("b")]
+    result = _repair_dangling_tool_calls(msgs)
+    assert result == msgs
+
+
+# ── Dangling (missing role=tool) → synthetic inserted ────────────────────────
+
+
+def test_single_dangling_tool_call_gets_interrupted_result():
+    """Tier 2: one tool_call with no role=tool → synthetic interrupted result inserted."""
+    msgs = [_assistant(["id-1"])]
+    result = _repair_dangling_tool_calls(msgs)
+    tool_msgs = {m["tool_call_id"]: m for m in result if m.get("role") == "tool"}
+    assert "id-1" in tool_msgs
+    assert _is_interrupted(tool_msgs["id-1"])
+
+
+def test_two_tool_calls_one_missing_injects_only_missing():
+    """Tier 2: two tool_calls, one answered — only the missing id gets synthetic."""
+    msgs = [_assistant(["a", "b"]), _tool("a")]
+    result = _repair_dangling_tool_calls(msgs)
+    tool_by_id = {m["tool_call_id"]: m for m in result if m.get("role") == "tool"}
+    assert "a" in tool_by_id and "b" in tool_by_id
+    assert not _is_interrupted(tool_by_id["a"]), "answered call must not be replaced"
+    assert _is_interrupted(tool_by_id["b"]), "missing call must get synthetic"
+
+
+def test_all_tool_calls_missing_all_get_synthetics():
+    """Tier 2: two tool_calls, none answered → both ids get interrupted synthetics."""
+    msgs = [_assistant(["x", "y"])]
+    result = _repair_dangling_tool_calls(msgs)
+    tool_by_id = {m["tool_call_id"]: m for m in result if m.get("role") == "tool"}
+    assert "x" in tool_by_id and "y" in tool_by_id
+    assert _is_interrupted(tool_by_id["x"])
+    assert _is_interrupted(tool_by_id["y"])
+
+
+# ── Multi-block: earlier blocks complete, last block dangling ─────────────────
+
+
+def test_earlier_block_complete_later_block_dangling():
+    """Tier 2: first assistant+tool_calls fully answered; second block dangling."""
+    msgs = [
+        _user("first"),
+        _assistant(["id-1"]),
+        _tool("id-1"),
+        _user("second"),
+        _assistant(["id-2"]),      # ← dangling (no role=tool follows)
+    ]
+    result = _repair_dangling_tool_calls(msgs)
+    tool_by_id = {m["tool_call_id"]: m for m in result if m.get("role") == "tool"}
+    assert "id-1" in tool_by_id and "id-2" in tool_by_id
+    assert not _is_interrupted(tool_by_id["id-1"]), "answered call must not be replaced"
+    assert _is_interrupted(tool_by_id["id-2"]), "dangling call must get synthetic"
+
+
+def test_synthetics_inserted_before_next_user_turn():
+    """Tier 2: synthetic result appears immediately after the assistant turn, before next user."""
+    msgs = [_assistant(["id-1"]), _user("follow-up")]
+    result = _repair_dangling_tool_calls(msgs)
+    roles = [m["role"] for m in result]
+    assert roles == ["assistant", "tool", "user"]
+
+
+def test_non_tool_call_assistant_between_blocks_not_affected():
+    """Tier 2: an assistant message without tool_calls is left untouched."""
+    msgs = [
+        _assistant(["id-1"]),
+        _tool("id-1"),
+        {"role": "assistant", "content": "plain reply"},
+        _user("next"),
+    ]
+    result = _repair_dangling_tool_calls(msgs)
+    assert result == msgs


### PR DESCRIPTION
**[tui-coder]**

## 問題

ctrl-c / プロセスクラッシュが `role=assistant`+`tool_calls` の history 書き込みと `role=tool` の書き込みの間に発生すると、conversation が API-invalid な状態になる。全プロバイダが「全 tool_call_id に対して tool_result が必要」を要求するため、次の turn で 400 を返し会話継続不可になる。

## 修正

`router_history_buffer.py` に純関数 `_repair_dangling_tool_calls(messages)` を追加:

- tool_calls を持つ assistant メッセージをスキャン
- 直後の role=tool メッセージを消費し、対応が取れていない tool_call_id を検出
- 未対応 id に対して `{"kind": "interrupted"}` のエラー tool_result を合成注入

`build_history()` の全 return 直前 (2 箇所) と `decompose_history_for_retry()` の tail に適用。on-disk の `history.jsonl` は audit log として保全 (非破壊)、LLM wire format のみ修復。

## テスト (Tier 2)

`test_repair_dangling_tool_calls.py`: 純関数の behavioral assertion 10 件
- no tool_calls → 変更なし
- 全件対応済み → 変更なし
- 1件ダングリング → interrupted synthetic 注入
- 複数のうち1件欠け → 欠けた id のみ synthetic、対応済み id は上書きしない
- 複数ブロック、末尾ブロックがダングリング → 末尾のみ synthetic
- synthetic が次 user turn の前に挿入される順序

## Tier self-check

- [x] Tier 2: `_repair_dangling_tool_calls` は pure function、実データ入力、public surface `.get("role")` / `.get("tool_call_id")` で assert、mock なし
- [x] Tier 4 なし: `len(...) == N` は除去済み、ID 存在確認に変換
- [x] ruff / tier-audit / pytest すべて green

part of #1830 (cost warn arc とは別の独立 bugfix)