### PR TITLE
feat(inline-cui): ctrl-c during active turn cancels it, not quits (#2205 ②)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -269,16 +269,28 @@ _CHIP_SPECS = [
 ]
 
 
-def working_line(thinking: bool, think_start: float, now: float) -> list:
+def working_line(
+    thinking: bool,
+    think_start: float,
+    now: float,
+    *,
+    cancelling: bool = False,
+) -> list:
     """Pure: working-row fragments while a turn runs (empty list when idle).
 
     The spinner frame derives from `now` so it advances smoothly regardless of
     refresh jitter; elapsed is whole seconds since `think_start`. The label carries
     a shimmer — a bright crest sweeping left→right across the text (a moving light)
     over a dim base, also clock-driven so it animates on each refresh.
+
+    When ``cancelling=True`` (ctrl-c was pressed mid-turn), the shimmer is replaced
+    by a static "Cancelling…" indicator — the cancel is cooperative so the turn
+    completes at the next tool boundary; the indicator reassures the user it's noted.
     """
     if not thinking:
         return []
+    if cancelling:
+        return [(f"fg:{_CC_WARN}", " ✗ Cancelling…")]
     frame = _SPINNER[int(now * 8) % len(_SPINNER)]
     elapsed = max(0, int(now - think_start))
     label = f"Working… {elapsed}s"
@@ -294,6 +306,7 @@ def working_line(thinking: bool, think_start: float, now: float) -> list:
             frags.append((f"fg:{_CC_ACCENT}", ch))         # trailing glow
         else:
             frags.append((f"fg:{_CC_DIM}", ch))            # dim base
+    frags.append((f"fg:{_CC_DIM}", " · ctrl-c to interrupt"))
     return frags
 
 
@@ -437,6 +450,10 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     # app.exit() — the second raises "Return value already set". _quit checks+sets
     # this before its first await, so only one ever runs to app.exit().
     quitting: dict = {}
+    # Set when the user pressed ctrl-c during an active turn (cancel_inflight
+    # requested). Cleared automatically when the turn ends (thinking→False).
+    # While set, the working indicator shows "Cancelling…" instead of the shimmer.
+    cancelling: dict = {}
     # Above-input interactive region: hosts the active closed-set intervention
     # (confirm / select / grant-deny) as a selectable list, poll-driven off the
     # session head (like the status chips). Free-text interventions keep using the
@@ -447,10 +464,14 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     region_holder: dict = {"key": None}
 
     def _working_frags() -> list:
+        thinking = getattr(renderer, "_thinking", False)
+        if not thinking:
+            cancelling.clear()   # auto-clear once the turn ends
         return working_line(
-            getattr(renderer, "_thinking", False),
+            thinking,
             getattr(renderer, "_think_start", 0.0),
             time.monotonic(),
+            cancelling=bool(cancelling),
         )
 
     working = ConditionalContainer(
@@ -662,6 +683,17 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             _menu_open()
 
     @kb.add("c-c")
+    def _interrupt_or_quit(event) -> None:
+        # During an active turn, first ctrl-c cancels the turn cooperatively.
+        # A second ctrl-c (while still "thinking" / cancelling) falls through to
+        # quit, matching the standard "ctrl-c to interrupt, ctrl-c again to exit"
+        # pattern. Ctrl-D/Q always quit regardless of turn state.
+        if getattr(renderer, "_thinking", False) and not cancelling:
+            cancelling["requested"] = True
+            event.app.create_background_task(_cancel_turn(registry))
+        else:
+            event.app.create_background_task(_quit(registry, event.app, quitting))
+
     @kb.add("c-d")
     @kb.add("c-q")
     def _quit_key(event) -> None:
@@ -829,6 +861,19 @@ async def _submit(registry, text: str) -> None:
             )
         except Exception:
             pass
+
+
+async def _cancel_turn(registry) -> None:
+    """Cancel the in-flight turn via session.cancel_inflight() — cooperative seam."""
+    s = registry.attached_session()
+    if s is None:
+        return
+    cancel_fn = getattr(s, "cancel_inflight", None)
+    if callable(cancel_fn):
+        try:
+            await cancel_fn()
+        except Exception:
+            logger.exception("cancel_inflight failed")
 
 
 async def _quit(registry, app, state: dict) -> None:

--- a/tests/test_inline_pr3a_app.py
+++ b/tests/test_inline_pr3a_app.py
@@ -45,7 +45,7 @@ def test_working_line_never_negative_elapsed() -> None:
     """Tier 2: a clock skew (now < start) clamps elapsed to 0, not negative."""
     text = "".join(t for _, t in working_line(True, 10.0, 9.0))
     assert "0s" in text
-    assert "-" not in text
+    assert "Working… -" not in text  # no negative sign before elapsed seconds
 
 
 def test_working_line_has_a_moving_shimmer_crest() -> None:
@@ -83,3 +83,27 @@ def test_turn_settled_clears_indicator_after_short_circuit_turn() -> None:
     # A slash turn ends with turn_settled (no turn_completed) — must clear.
     r.on_chat_event(_evt("turn_settled"))
     assert r.bottom_toolbar() is None
+
+
+# ── working_line cancelling-state tests ─────────────────────────────────────
+
+
+def test_working_line_normal_shows_interrupt_affordance() -> None:
+    """Tier 2: normal working row includes 'ctrl-c to interrupt' hint."""
+    text = "".join(t for _, t in working_line(True, 0.0, 3.0))
+    assert "ctrl-c" in text
+
+
+def test_working_line_cancelling_shows_cancelling_text() -> None:
+    """Tier 2: when cancelling=True the row shows 'Cancelling' not the shimmer."""
+    frags = working_line(True, 0.0, 3.0, cancelling=True)
+    text = "".join(t for _, t in frags)
+    assert "Cancelling" in text
+    # Shimmer elements gone: no spinner, no elapsed seconds.
+    assert "Working" not in text
+    assert "ctrl-c" not in text
+
+
+def test_working_line_idle_cancelling_is_empty() -> None:
+    """Tier 2: idle (thinking=False) returns [] even when cancelling=True."""
+    assert working_line(False, 0.0, 3.0, cancelling=True) == []


### PR DESCRIPTION
**[tui-coder]** — #2205 follow-up ② (esc-interrupt). PR #2206 dropped the "esc to interrupt" affordance because no wiring existed; this PR adds the real wiring.

## Changes

**`src/reyn/interfaces/inline/app.py`**
- `working_line` gains a `cancelling: bool = False` keyword parameter:
  - Normal: "Working… Ns · ctrl-c to interrupt" (adds affordance hint)
  - `cancelling=True`: "✗ Cancelling…" (static, replaces shimmer — reassures user the signal was received)
- `run_inline_input`: adds `cancelling: dict = {}` closure guard
- `_working_frags()` passes `cancelling=bool(cancelling)`; auto-clears `cancelling` when the turn ends (`_thinking → False`)
- Ctrl-C handler split:
  - `_interrupt_or_quit`: during active turn + not yet cancelling → `cancel_inflight()`; otherwise → quit
  - `_quit_key`: Ctrl-D / Ctrl-Q → always quit (unchanged)
- New `_cancel_turn(registry)` async helper (getattr-guarded like other session calls)

**`tests/test_inline_pr3a_app.py`**
- 3 new Tier-2 tests: `cancelling=True` shows "Cancelling", `cancelling=False` shows "ctrl-c", idle+cancelling returns `[]`
- Fixed existing `test_working_line_never_negative_elapsed`: `"-" not in text` → `"Working… -" not in text` (the prior assert false-fired on the new "ctrl-c" hint text)

## Behaviour

| State | ctrl-c | Ctrl-D/Q |
|---|---|---|
| Idle | quit | quit |
| Active turn, not yet cancelling | `cancel_inflight()` + show "✗ Cancelling…" | quit |
| Active turn, cancelling (2nd ctrl-c) | quit | quit |

`cancel_inflight()` is cooperative: the turn stops at the next tool-iteration boundary (the running tool finishes first). "✗ Cancelling…" reassures the user the signal was received.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 11 tests OK, 0 errors
- [x] `pytest` (full suite) — green
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Live: start a reyn chat, run a long tool (e.g. web_fetch), press ctrl-c mid-turn → "✗ Cancelling…" appears, turn stops at next boundary, prompt returns. Verified via tmux: `tmux send-keys C-c` during active 132s turn (phase-grep multi-tool call) — "✗ Cancelling…" confirmed in pane capture, prompt returned to `❯`.

Part of #2205.

Tier self-check: 3 new behavioral Tier-2 tests (public return value assertions, no format-pinning, no mocks). 1 existing test tightened to fix false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
