### PR TITLE
fix: Windows subprocess broken-pipe — thread-based drain + killpg fallback

### DIFF
--- a/src/reyn/security/sandbox/_subprocess_io.py
+++ b/src/reyn/security/sandbox/_subprocess_io.py
@@ -20,6 +20,8 @@ import os
 import select as _select
 import selectors
 import subprocess
+import sys
+import threading
 import time
 
 # 10 MiB — single source for the per-stream subprocess-output ceiling. Distinct
@@ -47,7 +49,117 @@ def communicate_capped(
     :class:`subprocess.TimeoutExpired` (carrying the partial captured output) if
     ``timeout`` elapses before both streams close — parity with
     ``communicate(timeout=)``; the caller kills the process and handles it.
+
+    Platform dispatch: the POSIX selectors path uses ``select()``, which on Windows only polls
+    SOCKETS, not pipe fds (``OSError [WinError 10038] not a socket``) — so on Windows we drain via
+    a thread per stream instead (mirroring CPython's own Windows ``Popen._communicate`` branch).
+    The two paths are contract-identical: same per-stream cap→``truncated``, same drain-and-discard
+    past the cap (child never blocks on a full pipe), same ``TimeoutExpired`` (partial output).
     """
+    if sys.platform == "win32":
+        return _communicate_capped_threads(
+            proc, input=input, max_bytes=max_bytes, timeout=timeout
+        )
+    return _communicate_capped_selectors(
+        proc, input=input, max_bytes=max_bytes, timeout=timeout
+    )
+
+
+def _communicate_capped_threads(
+    proc: subprocess.Popen,
+    *,
+    input: bytes | None,
+    max_bytes: int,
+    timeout: float | None,
+) -> tuple[bytes, bytes, bool]:
+    """Windows drain: one daemon thread per stream (``select()`` can't poll pipe fds on Windows).
+
+    Contract-identical to the selectors path: per-stream cap→``truncated``; drain-and-discard past
+    the cap (the reader keeps consuming so the child never blocks on a full pipe = drain-safe); a
+    still-running reader at the deadline → ``TimeoutExpired`` carrying the partial output. Mirrors
+    CPython's Windows ``Popen._communicate`` (threads reading each stream to EOF), plus the cap.
+    """
+    stdout_buf = bytearray()
+    stderr_buf = bytearray()
+    state = {"truncated": False}
+    deadline = (time.monotonic() + timeout) if timeout is not None else None
+
+    def _timed_out() -> subprocess.TimeoutExpired:
+        return subprocess.TimeoutExpired(
+            proc.args, timeout, output=bytes(stdout_buf), stderr=bytes(stderr_buf)
+        )
+
+    def _drain(stream, buf: bytearray) -> None:
+        try:
+            while True:
+                data = stream.read1(_READ_CHUNK)
+                if not data:  # EOF
+                    break
+                room = max_bytes - len(buf)
+                if room > 0:
+                    buf += data[:room]
+                    if len(data) > room:
+                        state["truncated"] = True
+                else:
+                    state["truncated"] = True  # at cap → drain-and-discard (keep reading)
+        except (BrokenPipeError, OSError):
+            pass
+        finally:
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+    def _write_stdin(stream, data: bytes) -> None:
+        try:
+            stream.write(data)
+        except (BrokenPipeError, OSError):
+            pass  # child exited early — its return code is preserved
+        finally:
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+    threads: list[threading.Thread] = []
+    if proc.stdout is not None:
+        threads.append(threading.Thread(target=_drain, args=(proc.stdout, stdout_buf), daemon=True))
+    if proc.stderr is not None:
+        threads.append(threading.Thread(target=_drain, args=(proc.stderr, stderr_buf), daemon=True))
+    if proc.stdin is not None:
+        if input:
+            threads.append(
+                threading.Thread(target=_write_stdin, args=(proc.stdin, input), daemon=True)
+            )
+        else:
+            proc.stdin.close()
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+        t.join(remaining)
+        if t.is_alive():  # still draining at the deadline → timeout (partial output captured)
+            raise _timed_out()
+
+    try:
+        remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+        proc.wait(timeout=None if remaining is None else remaining)
+    except subprocess.TimeoutExpired:
+        raise _timed_out() from None
+    return bytes(stdout_buf), bytes(stderr_buf), state["truncated"]
+
+
+def _communicate_capped_selectors(
+    proc: subprocess.Popen,
+    *,
+    input: bytes | None = None,
+    max_bytes: int = MAX_SUBPROCESS_OUTPUT_BYTES,
+    timeout: float | None = None,
+) -> tuple[bytes, bytes, bool]:
+    """POSIX drain via a selectors loop (3-way stdin/stdout/stderr concurrency), per-stream capped.
+    The proven reference path (CPython POSIX ``Popen._communicate`` structure); see the public
+    ``communicate_capped`` docstring for the contract."""
     stdout_buf = bytearray()
     stderr_buf = bytearray()
     truncated = False

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -54,21 +54,45 @@ def _build_env(policy: SandboxPolicy) -> dict[str, str]:
 
 
 async def _kill_proc_group(proc: subprocess.Popen, grace_seconds: float = 2.0) -> None:
-    """SIGTERM the process group, then SIGKILL after grace_seconds if still alive."""
-    try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-    except (ProcessLookupError, OSError):
-        return
-    try:
-        await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(None, proc.wait),
-            timeout=grace_seconds,
-        )
-    except (asyncio.TimeoutError, Exception):
+    """SIGTERM the process group, then SIGKILL after grace_seconds if still alive.
+
+    Windows has no process groups / ``os.killpg`` — fall back to ``proc.terminate()`` then
+    ``proc.kill()`` on the process itself. KNOWN LIMITATION (Windows, tracked #2292): terminate/kill
+    hits the process, NOT its child tree — a sandboxed process that spawns grandchildren can leave
+    orphans on cancel. A Job-object-based tree-kill is out of scope for the broken-pipe fix.
+    """
+    async def _wait_grace() -> bool:
+        """Return True if the process exited within the grace window."""
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            await asyncio.wait_for(
+                asyncio.get_running_loop().run_in_executor(None, proc.wait),
+                timeout=grace_seconds,
+            )
+            return True
+        except (asyncio.TimeoutError, Exception):
+            return False
+
+    if hasattr(os, "killpg"):
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         except (ProcessLookupError, OSError):
-            pass
+            return
+        if not await _wait_grace():
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+    else:
+        # Windows: no process groups → terminate the process, escalate to kill after the grace.
+        try:
+            proc.terminate()
+        except OSError:
+            return
+        if not await _wait_grace():
+            try:
+                proc.kill()
+            except OSError:
+                pass
 
 
 class NoopBackend:

--- a/tests/test_windows_subprocess_broken_pipe.py
+++ b/tests/test_windows_subprocess_broken_pipe.py
@@ -1,0 +1,150 @@
+"""Tier 2: Windows broken-pipe fix — thread-based subprocess drain + killpg fallback.
+
+On Windows ``select()`` cannot poll pipe fds (``OSError [WinError 10038] not a socket``), so
+``communicate_capped`` drains via one thread per stream instead of the POSIX selectors loop. The
+thread-reader is CONTRACT-IDENTICAL to the selectors path (per-stream cap→truncated, drain-and-
+discard past the cap so the child never blocks, ``TimeoutExpired`` carrying partial output) — the
+reader is cross-platform, so parity is asserted DIRECTLY on the dev env. The real-Windows check
+(the actual broken-pipe gone) is the OWNER'S real-env gate; it is NOT faked with importorskip.
+
+Also: ``_kill_proc_group`` falls back to ``proc.terminate()``/``kill()`` when ``os.killpg`` is
+absent (Windows).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from reyn.security.sandbox import _subprocess_io
+from reyn.security.sandbox._subprocess_io import (
+    _communicate_capped_selectors,
+    _communicate_capped_threads,
+    communicate_capped,
+)
+
+
+def _popen(code: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+
+
+# ── the thread-reader (cross-platform, exercised directly on the dev env) ─────────────────────
+
+
+def test_threads_drain_full_output():
+    """Tier 2: the thread-reader drains stdout + stderr fully (under cap), rc preserved."""
+    p = _popen("import sys; sys.stdout.write('hello'); sys.stderr.write('world')")
+    out, err, trunc = _communicate_capped_threads(p, input=None, max_bytes=10**7, timeout=None)
+    assert (out, err, trunc) == (b"hello", b"world", False)
+    assert p.returncode == 0
+
+
+def test_threads_caps_per_stream_and_is_drain_safe():
+    """Tier 2: each stream is capped independently; past the cap the reader keeps draining-and-
+    discarding so the child never blocks on a full pipe → its return code is preserved."""
+    p = _popen("import sys; sys.stdout.write('A' * 100000); sys.stderr.write('B' * 50)")
+    out, err, trunc = _communicate_capped_threads(p, input=None, max_bytes=1000, timeout=None)
+    assert out == b"A" * 1000, "stdout capped to the first max_bytes (cap keeps the prefix)"
+    assert err == b"B" * 50, "stderr under its own cap → full"
+    assert trunc is True, "truncated flag set when a stream exceeds the cap"
+    assert p.returncode == 0, "drain-safe: the 100k-writing child did not deadlock on a full pipe"
+
+
+def test_threads_stdin_write():
+    """Tier 2: the stdin-write thread feeds input without deadlocking the concurrent reads."""
+    p = _popen("import sys; sys.stdout.write(sys.stdin.read().upper())")
+    out, _err, _trunc = _communicate_capped_threads(p, input=b"abc", max_bytes=10**7, timeout=None)
+    assert out == b"ABC"
+
+
+def test_threads_timeout_raises_with_partial_output():
+    """Tier 2: a still-draining stream at the deadline → TimeoutExpired carrying the partial output
+    (parity with the selectors path)."""
+    p = _popen("import sys, time; sys.stdout.write('partial'); sys.stdout.flush(); time.sleep(30)")
+    try:
+        with pytest.raises(subprocess.TimeoutExpired) as ei:
+            _communicate_capped_threads(p, input=None, max_bytes=10**7, timeout=0.5)
+        assert b"partial" in (ei.value.output or b""), "partial output must be carried on timeout"
+    finally:
+        p.kill()
+        p.wait()
+
+
+# ── contract parity: thread path == selectors path (lead's required guard) ────────────────────
+
+
+@pytest.mark.parametrize("max_bytes,expect_trunc", [(2000, True), (10**7, False)])
+def test_parity_threads_match_selectors(max_bytes, expect_trunc):
+    """Tier 2: the thread path and the selectors path produce IDENTICAL (stdout, stderr, truncated)
+    for the same child — so the Windows path behaves exactly like POSIX, just via threads."""
+    code = "import sys; sys.stdout.write('X' * 5000); sys.stderr.write('Y' * 30)"
+    r_threads = _communicate_capped_threads(_popen(code), input=None, max_bytes=max_bytes, timeout=None)
+    r_selectors = _communicate_capped_selectors(_popen(code), input=None, max_bytes=max_bytes, timeout=None)
+    assert r_threads == r_selectors, (
+        f"thread path must match selectors exactly; threads={r_threads} selectors={r_selectors}"
+    )
+    assert r_threads[2] is expect_trunc
+
+
+# ── platform dispatch ─────────────────────────────────────────────────────────────────────────
+
+
+def test_dispatch_win32_uses_thread_reader(monkeypatch):
+    """Tier 2: on win32, communicate_capped routes to the thread-reader (NOT the pipe-incompatible
+    selectors path). Spy delegates to the real reader — not a mock."""
+    called: dict[str, bool] = {}
+    real = _subprocess_io._communicate_capped_threads
+
+    def spy(*a, **k):
+        called["threads"] = True
+        return real(*a, **k)
+
+    monkeypatch.setattr(_subprocess_io, "_communicate_capped_threads", spy)
+    monkeypatch.setattr(_subprocess_io.sys, "platform", "win32")
+    out, _err, _trunc = communicate_capped(_popen("print('ok')"), max_bytes=10**7)
+    assert called.get("threads"), "win32 MUST use the thread-reader"
+    assert out.strip() == b"ok"
+
+
+def test_dispatch_posix_keeps_selectors(monkeypatch):
+    """Tier 2: on POSIX, communicate_capped keeps the proven selectors path (no thread overhead)."""
+    called: dict[str, bool] = {}
+    real = _subprocess_io._communicate_capped_selectors
+
+    def spy(*a, **k):
+        called["selectors"] = True
+        return real(*a, **k)
+
+    monkeypatch.setattr(_subprocess_io, "_communicate_capped_selectors", spy)
+    monkeypatch.setattr(_subprocess_io.sys, "platform", "linux")
+    communicate_capped(_popen("print('ok')"), max_bytes=10**7)
+    assert called.get("selectors"), "POSIX MUST keep the selectors path"
+
+
+# ── _kill_proc_group: killpg (POSIX) vs terminate/kill (no-killpg / Windows) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_kill_proc_group_posix_uses_killpg():
+    """Tier 2: with os.killpg present (POSIX), the process is killed via the group."""
+    from reyn.security.sandbox.noop_backend import _kill_proc_group
+    p = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"], start_new_session=True,
+    )
+    await _kill_proc_group(p, grace_seconds=1.0)
+    assert p.poll() is not None, "the process must be killed via killpg"
+
+
+@pytest.mark.asyncio
+async def test_kill_proc_group_without_killpg_falls_back_to_terminate(monkeypatch):
+    """Tier 2: when os.killpg is absent (Windows), fall back to proc.terminate()/kill(). RED if the
+    guard weren't present (os.killpg would AttributeError and the process would never be killed)."""
+    from reyn.security.sandbox import noop_backend
+    monkeypatch.delattr(noop_backend.os, "killpg", raising=False)
+    p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    await noop_backend._kill_proc_group(p, grace_seconds=1.0)
+    assert p.poll() is not None, "without killpg, terminate/kill must still kill the process"


### PR DESCRIPTION
**[e2e-coder]** — owner-priority: the Windows git-bash subprocess broken-pipe. Two POSIX-only assumptions in the sandbox subprocess path.

## Root cause (lead + Sonnet static diagnosis, flow-trace-confirmed)

- **PRIMARY** — `_subprocess_io.communicate_capped` drains the child pipes via `selectors.DefaultSelector`, which on Windows is `SelectSelector` = `select.select()` — and Windows `select()` polls **only SOCKETS, not pipe fds** → registering a pipe fd raises `OSError [WinError 10038] not a socket` = the broken-pipe. The module mirrors CPython's POSIX `Popen._communicate` selectors path and was never ported to Windows.
- **SECONDARY** — `noop_backend._kill_proc_group` uses `os.killpg(os.getpgid(pid), …)`, neither of which exists on Windows (`AttributeError`) — so the cancel/timeout path also crashes there.

## Fix

- **`communicate_capped` dispatches on `sys.platform`**: POSIX keeps the **proven selectors path** (unchanged, renamed `_communicate_capped_selectors` — no thread overhead on the hot POSIX path); Windows uses **`_communicate_capped_threads`** — one daemon thread per stream (stdout/stderr drain via `read1`, a stdin-write thread), mirroring CPython's own Windows `Popen._communicate`. It is **contract-identical** to the selectors path: per-stream cap→`truncated`, drain-and-discard past the cap (the child never blocks on a full pipe = drain-safe), `TimeoutExpired` carrying partial output.
- **`_kill_proc_group` guards `os.killpg`** with `hasattr` → `proc.terminate()` → `proc.kill()` on Windows.

## Known limitation (tracked #2292)
Windows `terminate()`/`kill()` hits the process, NOT its child tree (no process groups). A sandboxed process that spawns grandchildren can leave orphans on cancel. Job-object tree-kill is out of scope for the broken-pipe fix — flagged in a code comment + tracked in #2292.

## Test plan

- [x] **Thread-reader** (`test_windows_subprocess_broken_pipe`, exercised directly on the dev env — the reader is cross-platform): full drain; per-stream cap + **drain-safe** (100k-writing child does not deadlock, rc preserved); stdin-write; timeout→`TimeoutExpired` + partial output.
- [x] **Contract parity** (lead's required guard): `_communicate_capped_threads` == `_communicate_capped_selectors` on the same child, for both a capping and a non-capping `max_bytes` — so the Windows path behaves identically to POSIX, just via threads.
- [x] **Platform dispatch**: win32 → thread-reader; POSIX → selectors (spies that delegate to the real impls, not mocks).
- [x] **killpg guard both branches**: POSIX killpg kills the group; `os.killpg` deleted → terminate/kill still kills the process. Falsify-verified: stripping the `hasattr` guard → `AttributeError` → RED.
- [ ] **REAL-Windows verification** (the actual git-bash broken-pipe gone + a real cancel) — the **owner's real-env gate**. NOT faked with `importorskip`; flagged explicitly, like the litellm-proxy limitation.
- [x] **Full suite faulthandler-net'd**: **7567 passed, 0 hang** (276s). The 4 failures are the SAME pre-existing env quirks (gateway entry-point ×3 + reyn.safe relocate) — this PR touches only the sandbox subprocess path.
- [x] **Gates**: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py` — green; sandbox regression (171 passed, selectors path + noop backend intact).

Lead reviews hardest: the thread-reader cap/timeout PARITY with the selectors path + the stdin-write-thread deadlock-safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
