### PR TITLE
feat(#2289): group-aware compaction trim — prevent tool_call/result pair splits (layer 2)

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -530,6 +530,90 @@ def compute_covers_through_seq(new_turn_seqs: list) -> int:
     return max(int(s) for s in new_turn_seqs)
 
 
+def _turn_role(t) -> "str | None":
+    """The turn's wire role (``agent`` → ``assistant``), from a dict or a ChatMessage."""
+    r = t.get("role") if isinstance(t, dict) else getattr(t, "role", None)
+    return "assistant" if r == "agent" else r
+
+
+def _is_assistant_with_tool_calls(t) -> bool:
+    if _turn_role(t) != "assistant":
+        return False
+    tc = t.get("tool_calls") if isinstance(t, dict) else getattr(t, "tool_calls", None)
+    return bool(tc)
+
+
+def _group_tool_cycles(turns: list) -> "list[list]":
+    """#2289: group each assistant-with-tool_calls turn together with its immediately-following
+    ``role=tool`` result turns into ONE atomic trim unit (a "tool cycle"); every other turn is a
+    singleton group. Trimming at group granularity keeps a tool_call and its results together, so a
+    token boundary can never split the pair (which would reach the wire as a dangling call / orphan
+    result → a provider 400 that the Layer-1 wire-repair then has to re-adjacency/synth/drop). This
+    is the prevention layer: with it, that repair only fires on the genuine edges (an over-budget
+    single cycle, or a rewind/interrupt mid-cycle)."""
+    groups: list[list] = []
+    i = 0
+    n = len(turns)
+    while i < n:
+        t = turns[i]
+        if _is_assistant_with_tool_calls(t):
+            group = [t]
+            j = i + 1
+            while j < n and _turn_role(turns[j]) == "tool":
+                group.append(turns[j])
+                j += 1
+            groups.append(group)
+            i = j
+        else:
+            groups.append([t])
+            i += 1
+    return groups
+
+
+def _emit_over_budget_group(events, group: list, budget: int, group_tokens: int, kind: str) -> None:
+    """A single group alone exceeds ``budget`` and is KEPT WHOLE (never split → no result loss).
+
+    A tool cycle emits ``tool_cycle_kept_whole_over_budget`` (NOT a truncation — the whole cycle
+    survives, over budget). A non-cycle singleton keeps the existing Axis-7 ``turn_too_large_
+    truncated`` (the single turn is included whole; content kept). NOTE (#1909): a tool cycle that
+    exceeds the MODEL's HARD context limit (not merely this compaction budget) cannot be fixed by
+    keep-whole — it would overflow at the provider. That is a tool-RESULT-size problem for op-level
+    result truncation / context-narrowing (#1909), out of scope for this trim."""
+    if events is None:
+        return
+    head = group[0]
+    seq = head.get("seq", 0) if isinstance(head, dict) else getattr(head, "seq", 0)
+    if _is_assistant_with_tool_calls(head):
+        events.emit(
+            "tool_cycle_kept_whole_over_budget",
+            turn_seq=seq, group_tokens=group_tokens, budget=budget, budget_kind=kind,
+        )
+    else:
+        events.emit(
+            "turn_too_large_truncated",
+            turn_seq=seq, original_tokens=group_tokens, kept_tokens=budget, budget_kind=kind,
+        )
+
+
+def _trim_groups(groups: "list[list]", max_tokens: int, model: str, use_chars4: bool,
+                 events, kind: str) -> "list[list]":
+    """Accumulate whole groups until the budget is exceeded — never splitting a group. A single
+    group alone over budget is kept WHOLE (#2289). Returns the kept groups in ``groups`` order."""
+    kept: list[list] = []
+    total = 0
+    for group in groups:
+        g_tokens = sum(estimate_tokens_for_turn(t, model, use_chars4=use_chars4) for t in group)
+        if kept and total + g_tokens > max_tokens:
+            break  # adding this whole group would exceed budget — stop (never split it)
+        if g_tokens > max_tokens:
+            _emit_over_budget_group(events, group, max_tokens, g_tokens, kind)
+            kept.append(group)
+            break
+        kept.append(group)
+        total += g_tokens
+    return kept
+
+
 def trim_head(
     turns: list,
     max_tokens: int,
@@ -540,33 +624,15 @@ def trim_head(
 ) -> list:
     """Return first turns until token budget exceeded — no turn count cap (Axis 3).
 
-    A single turn that alone exceeds max_tokens is truncated (content kept,
-    event emitted) and included in the result (Axis 7).
+    #2289: trims at tool-cycle-GROUP granularity (``_group_tool_cycles``), so a boundary never
+    splits a tool_call from its results. A single group alone exceeding ``max_tokens`` is kept whole
+    (Axis 7 keep-whole — no split, no result loss). For a non-tool history every turn is a singleton
+    group, so this is byte-identical to the message-level behavior.
     """
-    kept = []
-    total = 0
-    for t in turns:
-        t_tokens = estimate_tokens_for_turn(t, model, use_chars4=use_chars4)
-        if kept and total + t_tokens > max_tokens:
-            # Would exceed budget — stop before adding this turn.
-            break
-        if t_tokens > max_tokens:
-            # Single turn exceeds cap — include it, emit event (Axis 7).
-            if events is not None:
-                seq = t.get("seq", 0) if isinstance(t, dict) else getattr(t, "seq", 0)
-                events.emit(
-                    "turn_too_large_truncated",
-                    turn_seq=seq,
-                    original_tokens=t_tokens,
-                    kept_tokens=max_tokens,
-                    budget_kind="head",
-                )
-            kept.append(t)
-            total += max_tokens
-            break
-        kept.append(t)
-        total += t_tokens
-    return kept
+    kept = _trim_groups(
+        _group_tool_cycles(turns), max_tokens, model, use_chars4, events, "head",
+    )
+    return [t for group in kept for t in group]
 
 
 def trim_tail(
@@ -579,32 +645,14 @@ def trim_tail(
 ) -> list:
     """Return last turns until token budget exceeded — no turn count cap (Axis 3).
 
-    Walks from the tail backwards, then reverses the result.
-    A single turn that alone exceeds max_tokens is included and event emitted
-    (Axis 7).
+    #2289: group-aware (see ``trim_head``) — accumulates whole tool-cycle groups from the tail, so
+    a boundary never splits a pair. Byte-identical to message-level for non-tool histories.
     """
-    kept: list = []
-    total = 0
-    for t in reversed(turns):
-        t_tokens = estimate_tokens_for_turn(t, model, use_chars4=use_chars4)
-        if kept and total + t_tokens > max_tokens:
-            break
-        if t_tokens > max_tokens:
-            if events is not None:
-                seq = t.get("seq", 0) if isinstance(t, dict) else getattr(t, "seq", 0)
-                events.emit(
-                    "turn_too_large_truncated",
-                    turn_seq=seq,
-                    original_tokens=t_tokens,
-                    kept_tokens=max_tokens,
-                    budget_kind="tail",
-                )
-            kept.append(t)
-            total += max_tokens
-            break
-        kept.append(t)
-        total += t_tokens
-    return list(reversed(kept))
+    groups = _group_tool_cycles(turns)
+    kept_reversed = _trim_groups(
+        list(reversed(groups)), max_tokens, model, use_chars4, events, "tail",
+    )
+    return [t for group in reversed(kept_reversed) for t in group]
 
 
 def hard_truncate_summary(

--- a/tests/test_group_aware_trim_2289.py
+++ b/tests/test_group_aware_trim_2289.py
@@ -1,0 +1,146 @@
+"""Tier 2: #2289 group-aware compaction trim — the pair-split PREVENTION layer.
+
+trim_head/trim_tail used to trim at MESSAGE granularity, so a token boundary could fall between an
+assistant's tool_calls and its role=tool results — splitting the pair, which reaches the wire as a
+dangling call / orphan result (a provider 400 the Layer-1 wire-repair then has to fix, lossily).
+
+Group-aware trim treats an assistant-with-tool_calls + its adjacent role=tool run as ONE atomic
+trim unit, so a normal boundary can never split a pair: the whole cycle is kept or dropped. A
+single cycle alone over budget is kept WHOLE (no split, no result loss). For a non-tool history
+every turn is a singleton group → byte-identical to the old behavior.
+"""
+from __future__ import annotations
+
+from reyn.core.events.events import EventLog
+from reyn.services.compaction.engine import (
+    _group_tool_cycles,
+    _is_assistant_with_tool_calls,
+    trim_head,
+    trim_tail,
+)
+
+_M = ""  # model (unused with use_chars4)
+
+
+def _user(chars: int, seq: int) -> dict:
+    return {"role": "user", "text": "a" * chars, "seq": seq}
+
+
+def _asst_tc(tc_id: str, chars: int, seq: int) -> dict:
+    return {
+        "role": "assistant", "text": "a" * chars, "seq": seq,
+        "tool_calls": [{"id": tc_id, "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+    }
+
+
+def _tool(tc_id: str, chars: int, seq: int) -> dict:
+    return {"role": "tool", "tool_call_id": tc_id, "text": "a" * chars, "seq": seq}
+
+
+def _no_dangling_cycle(turns: list) -> bool:
+    """No assistant-with-tool_calls is left WITHOUT its immediately-following role=tool result."""
+    for i, t in enumerate(turns):
+        if _is_assistant_with_tool_calls(t):
+            if i + 1 >= len(turns) or turns[i + 1].get("role") != "tool":
+                return False
+    return True
+
+
+# ── grouping ──────────────────────────────────────────────────────────────────────────────────
+
+
+def test_group_tool_cycles_groups_assistant_with_its_results():
+    """Tier 2: an assistant+tool_calls + its adjacent role=tool run is ONE group; others singletons."""
+    turns = [_user(40, 1), _asst_tc("t1", 40, 2), _tool("t1", 40, 3), _tool("t1b", 40, 4), _user(40, 5)]
+    groups = _group_tool_cycles(turns)
+    assert [[t["seq"] for t in g] for g in groups] == [[1], [2, 3, 4], [5]]
+
+
+def test_group_non_tool_history_all_singletons():
+    """Tier 2: with no tool_calls, every turn is its own singleton group (→ old behavior)."""
+    turns = [_user(40, 1), _user(40, 2), _user(40, 3)]
+    assert _group_tool_cycles(turns) == [[turns[0]], [turns[1]], [turns[2]]]
+
+
+# ── the atomicity guarantee (the prevention) ──────────────────────────────────────────────────
+
+
+def test_trim_head_excludes_cycle_rather_than_splitting_it():
+    """Tier 2: THE prevention — at a budget where MESSAGE-level trim would keep [user, assistant]
+    (splitting the pair, leaving the result out), group-aware trim excludes the whole cycle instead:
+    head = [user] only. RED against message-level (which would leave the assistant dangling)."""
+    turns = [_user(40, 1), _asst_tc("t1", 40, 2), _tool("t1", 40, 3), _user(40, 4)]
+    # message-level @25: user(10)+assistant(10)=20 fits, +tool(10)=30 over → [user, assistant] SPLIT.
+    head = trim_head(turns, max_tokens=25, model=_M, use_chars4=True)
+    assert _no_dangling_cycle(head), "no assistant tool_calls without its result"
+    assert not any(_is_assistant_with_tool_calls(t) for t in head), (
+        "the cycle that doesn't fit is excluded WHOLE, not split (the dangling assistant is absent)"
+    )
+    assert [t["seq"] for t in head] == [1]
+
+
+def test_trim_head_includes_whole_cycle_when_it_fits():
+    """Tier 2: when the budget fits the cycle, the whole cycle is kept intact (call + result)."""
+    turns = [_user(40, 1), _asst_tc("t1", 40, 2), _tool("t1", 40, 3), _user(40, 4)]
+    head = trim_head(turns, max_tokens=35, model=_M, use_chars4=True)  # fits user+cycle (30), not +user
+    assert [t["seq"] for t in head] == [1, 2, 3], "whole cycle kept intact"
+    assert _no_dangling_cycle(head)
+
+
+def test_trim_tail_excludes_cycle_rather_than_splitting_it():
+    """Tier 2: symmetric for the tail — a boundary that would keep [tool_result, user] (orphan
+    result, its call trimmed away) instead excludes the whole cycle."""
+    turns = [_user(40, 1), _asst_tc("t1", 40, 2), _tool("t1", 40, 3), _user(40, 4)]
+    # message-level tail @25: user(10)+tool(10)=20 fits, +assistant(10)=30 over → [tool, user] ORPHAN.
+    tail = trim_tail(turns, max_tokens=25, model=_M, use_chars4=True)
+    assert _no_dangling_cycle(tail), "no orphan result (the trimmed-away call would orphan it)"
+    assert all(t.get("role") != "tool" for t in tail), "the split cycle is excluded whole from the tail"
+    assert [t["seq"] for t in tail] == [4]
+
+
+def test_trim_tail_includes_whole_cycle_when_it_fits():
+    """Tier 2: the tail keeps the whole cycle intact when it fits."""
+    turns = [_user(40, 1), _asst_tc("t1", 40, 2), _tool("t1", 40, 3), _user(40, 4)]
+    tail = trim_tail(turns, max_tokens=35, model=_M, use_chars4=True)  # fits cycle(20)+user(10)
+    assert [t["seq"] for t in tail] == [2, 3, 4]
+    assert _no_dangling_cycle(tail)
+
+
+# ── over-budget single cycle: kept WHOLE (keep-whole, not truncated) ───────────────────────────
+
+
+def test_over_budget_single_cycle_kept_whole_with_new_event():
+    """Tier 2: a single tool cycle alone exceeding the budget is kept WHOLE (no split, no result
+    loss) and emits ``tool_cycle_kept_whole_over_budget`` — NOT ``turn_too_large_truncated`` (it is
+    not a truncation)."""
+    turns = [_asst_tc("t1", 80, 1), _tool("t1", 80, 2)]  # 20 + 20 = 40 tokens, alone > 25
+    events = EventLog()
+    head = trim_head(turns, max_tokens=25, model=_M, use_chars4=True, events=events)
+    assert [t["seq"] for t in head] == [1, 2], "the whole cycle survives (call + result), over budget"
+    kinds = [e.type for e in events.all()]
+    assert "tool_cycle_kept_whole_over_budget" in kinds, "the keep-whole event is emitted"
+    assert "turn_too_large_truncated" not in kinds, "it is NOT reported as a truncation (no loss)"
+
+
+def test_over_budget_non_cycle_turn_keeps_legacy_truncated_event():
+    """Tier 2: a single non-cycle turn over budget keeps the existing ``turn_too_large_truncated``
+    event (backward-compat — the group change only adds the cycle case)."""
+    turns = [_user(200, 1)]  # 50 tokens alone > 25
+    events = EventLog()
+    trim_head(turns, max_tokens=25, model=_M, use_chars4=True, events=events)
+    kinds = [e.type for e in events.all()]
+    assert "turn_too_large_truncated" in kinds
+    assert "tool_cycle_kept_whole_over_budget" not in kinds
+
+
+# ── non-tool history is byte-identical to the old message-level behavior ───────────────────────
+
+
+def test_non_tool_history_is_unchanged():
+    """Tier 2: with no tool_calls, group-aware trim is byte-identical to message-level — head is the
+    budget-bounded prefix, tail the budget-bounded suffix."""
+    turns = [_user(40, i + 1) for i in range(8)]  # 10 tokens each
+    head = trim_head(turns, max_tokens=25, model=_M, use_chars4=True)
+    tail = trim_tail(turns, max_tokens=25, model=_M, use_chars4=True)
+    assert head == turns[:2], "head = first two turns (20 ≤ 25, +10 would exceed)"
+    assert tail == turns[-2:], "tail = last two turns"


### PR DESCRIPTION
**[e2e-coder]** — #2289: group-aware compaction trim, the **prevention** layer (2 of 2) for the toolcall/toolresult BadRequest. Layer 1 (the wire-repair safety-net) landed in #2290 (merged). Fast-follow, as planned.

## The split source

`trim_head`/`trim_tail` (compaction/engine.py) trimmed at **message granularity** — each ChatMessage a trim unit — so a token budget boundary could fall between an assistant's `tool_calls` and its following `role=tool` results, **splitting the pair**. On the wire that is a dangling call / orphan result → a provider 400 that the Layer-1 wire-repair then has to fix (lossily: re-adjacency / synth / drop).

## The prevention

- **`_group_tool_cycles`** — an assistant-with-`tool_calls` + its adjacent `role=tool` run is ONE atomic trim unit (a "tool cycle"); every other turn is a singleton group.
- **`trim_head`/`trim_tail` accumulate WHOLE groups** (never splitting one) → a normal boundary can no longer split a pair: the whole cycle is kept or dropped together.
- **Over-budget single cycle → kept WHOLE** (owner-confirmed keep-whole: no split, no result loss — vs truncating, which would reintroduce the lossy split the wire-repair exists for). Emits **`tool_cycle_kept_whole_over_budget`** (group granularity, NOT a truncation); a non-cycle over-budget turn keeps the legacy `turn_too_large_truncated`.
- **Non-tool histories: byte-identical** to the old behavior (every turn is a singleton group) — the existing 179 compaction/trim tests pass unchanged.

With this, the Layer-1 wire-repair now fires only on the **genuine edges** (an over-budget single cycle kept whole; a rewind/interrupt cutting mid-cycle) — the two layers compose as designed.

## Out of scope (#1909)
A single tool cycle exceeding the MODEL's HARD context limit (not merely the compaction budget) can't be fixed by keep-whole — it would overflow at the provider. That is a tool-RESULT-size problem for op-level result truncation / context-narrowing (#1909), out of scope here — noted in the code.

## Test plan

- [x] **Grouping** (`test_group_aware_trim_2289`): assistant+tool_calls + its result run → one group; non-tool history → all singletons.
- [x] **Atomicity (the prevention)**: at a budget where message-level trim would keep `[user, assistant]` (splitting the pair), group-aware trim excludes the whole cycle instead (head = `[user]`, no dangling call); symmetric for the tail (no orphan result). Whole cycle kept intact when it fits. **Falsify-verified: disabling the grouping (→ message-level) REDs the atomicity + grouping + keep-whole tests.**
- [x] **Keep-whole event**: over-budget single cycle → kept whole + `tool_cycle_kept_whole_over_budget` (NOT `turn_too_large_truncated`); non-cycle over-budget turn keeps the legacy event.
- [x] **Byte-identical for non-tool histories** (head = budget prefix, tail = budget suffix).
- [x] **Full suite faulthandler-net'd**: **7566 passed, 0 hang** (277s). The 4 failures are the SAME pre-existing env quirks (gateway entry-point ×3 + reyn.safe relocate) — this PR touches only the compaction trim path.
- [x] **Gates**: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py` green; regression 210 passed (compaction + retry-loop + the #2290 wire-repair intact).

Lead reviews hardest: the group-atomic boundary correctness (head/tail edges) + the keep-whole-vs-truncate event semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
