### PR TITLE
fix(inline-cui): above-region Escape trap — intervention blocker + command-UI lingering

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -551,11 +551,12 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     )
 
     def above_region_frags() -> list:
+        draw_cursor = above_region.cursor_on_selectable
         out: list = []
         for i, ln in enumerate(above_region.lines()):
             if i:
                 out.append(("", "\n"))
-            if i == above_region.cursor:
+            if draw_cursor and i == above_region.cursor:
                 out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
             else:
                 out.append((f"fg:{_CC_DIM}", f"   {ln}"))
@@ -701,7 +702,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
 
     # Above-region focus navigation (inert until a consumer registers an element,
     # since the region stays invisible + unfocusable while empty). ↑↓ move the
-    # cursor, enter activates the focused row, esc returns to the input.
+    # cursor, enter activates the focused row, esc dismisses (cmd) or is blocked (iv).
     @kb.add("up", filter=has_focus(above_region_win))
     def _region_up(event) -> None:
         above_region.navigate(-1)
@@ -716,7 +717,20 @@ async def run_inline_input(registry, renderer, config=None) -> None:
 
     @kb.add("escape", filter=has_focus(above_region_win))
     def _region_esc(event) -> None:
-        event.app.layout.focus(input_win)
+        # Command-UI (rewind picker etc.): Escape dismisses — clear the pending
+        # request so _sync_region collapses the region on the next poll, then
+        # return focus to the input box.
+        # Intervention (confirm / select): Escape is a no-op. The same-key skip
+        # in _sync_region prevents re-grabbing focus if we move away here, which
+        # would leave the user unable to resolve a blocking intervention.
+        key = region_holder["key"]
+        if key and key.startswith("cmd:"):
+            s = registry.attached_session()
+            if s is not None:
+                s.set_pending_command_ui(None)
+            above_region.clear()
+            region_holder["key"] = None
+            event.app.layout.focus(input_win)
 
     def _show(element, key: str) -> None:
         above_region.clear()


### PR DESCRIPTION
**[tui-coder]** — Two bugs found during bug-mining after #2291 merged.

## Bugs

### 1. Intervention Escape trap (blocking)

Pressing Escape while an intervention was focused in `above_region_win` moved focus to `input_win`, but `_sync_region` uses a same-key skip (`if key != region_holder["key"]`), so it **never re-grabbed focus** for the same pending intervention. The user was left unable to resolve the blocking intervention (no focus, no way to navigate back to the region).

**Fix:** make Escape a no-op for `"iv:"` keys (interventions). The user must select a choice to resolve a blocking intervention. Escape is only meaningful for dismissible elements.

### 2. Command-UI lingering (rewind picker)

Pressing Escape on the `/rewind` picker moved focus to `input_win`, but `pending_command_ui` was **never cleared**. On the next `_sync_region` poll (within 0.15 s), `cmd` was still set → the same-key skip fired → the picker stayed registered in `above_region` → visually present but unfocusable forever.

**Fix:** when Escape is pressed on a `"cmd:"` element, call `s.set_pending_command_ui(None)` and reset `region_holder["key"] = None`. The "Nothing pending" branch in `_sync_region` then fires on the next tick, calling `above_region.clear()` and collapsing the region.

### 3. `above_region_frags` cursor guard (consistency)

`above_region_frags` was drawing a cursor highlight (`i == above_region.cursor`) **without** checking `cursor_on_selectable`, unlike the parallel `dropdown_frags`. With current usage (only selectable elements in `above_region`) this doesn't manifest, but it would draw a false highlight on a read-only `DetailElement`. Fixed to match the `dropdown_frags` pattern.

## Root cause

`_region_esc` previously always moved focus to `input_win`, regardless of whether the element was a dismissible command-UI or a non-dismissible intervention.

## Test plan

- [x] (skipped — interaction-level key binding, Tier 4) Manual: start a `/rewind` with checkpoints → picker appears in above-region → press Escape → picker collapses, focus returns to input. Re-open `/rewind` to confirm it reappears cleanly.
- [x] (skipped — requires a blocking intervention to test live) Manual: trigger a closed-set intervention (confirm / select) → region appears → press Escape → confirm focus does NOT move to input (Escape is a no-op); Enter on a choice still works.
- [x] (skipped — latent path, no triggering surface) `cursor_on_selectable` guard: only visible if a `DetailElement` is registered in `above_region`, which no current code path does.

## CI gates

- `ruff check src/reyn/interfaces/inline/app.py` — clean
- `pytest tests/test_inline_pr3a_app.py` — 11/11 passed
- `python scripts/test_tier_audit.py --strict tests/test_inline_pr3a_app.py` — 11/11 OK, 0 errors
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — OK

Tier self-check: no new tests added (interaction-level key binding = Tier 4; existing 11 tests unchanged).