### PR TITLE
fix(inline-cui): style system lifecycle markers with dim gutter

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -277,6 +277,7 @@ _KIND_LINE = {
     "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # error       — red
     "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # done        — green glyph, dim body
     "status":       ("· ",   _CC_DIM,    _CC_DIM),   # ambient     — dim
+    "system":       ("· ",   _CC_DIM,    _CC_DIM),   # lifecycle marker (compaction / budget / cost-warn)
     "trace":        ("  ⎿ ", _CC_DIM,    _CC_DIM),   # detail      [low]  nested
 }
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -156,6 +156,16 @@ def test_wants_separator_skips_first_nested_and_transient() -> None:
     assert wants_separator("trace", seen_message=True) is False            # transient+nested
 
 
+def test_system_lifecycle_marker_has_dim_gutter() -> None:
+    """Tier 2: system kind (compaction / budget-warn / cost-warn markers) renders
+    with a dim '· ' gutter instead of falling through to raw unstyled plain text.
+    Compaction, budget, and cost-warn all use kind='system'; without the _KIND_LINE
+    entry they rendered identically to unknown kinds — no visual hierarchy."""
+    out = _plain("system", "[↑ 5 turns compacted]")
+    assert "·" in out
+    assert "[↑ 5 turns compacted]" in out
+
+
 def test_unknown_kind_renders_text_without_marker() -> None:
     """Tier 2: an unrecognised kind falls back to plain text (no kind marker)."""
     out = _plain("totally_new_kind", "raw payload")


### PR DESCRIPTION
**[tui-coder]** — Cosmetic fix for lifecycle markers in the inline CUI.

## Problem

`kind="system"` was not in `_KIND_LINE`, so lifecycle markers emitted by `ChatLifecycleForwarder._enqueue()` — compaction (`[↑ N turns compacted]`), budget-warn (`[↑ budget warn: …]`), and cost-warn (`[⚠ high-cost model: …]`) — fell through to `format_inline_message`'s unknown-kind handler, rendering as raw unstyled plain text with no gutter character. This made them visually identical to unknown kinds, blending in with the conversation without any ambient marker.

## Fix

Add `"system": ("· ", _CC_DIM, _CC_DIM)` to `_KIND_LINE`. This gives lifecycle markers:
- `· ` dim gutter (same visual weight as status, but persistent — not transient)
- Dim body text
- Blank-line separator before them (already provided by `wants_separator`, since `system` is neither nested nor transient)

## Not changed

- `system` is not added to `_TRANSIENT_KINDS` — lifecycle markers stay in the scrollback (not overwritten by next status write)
- `ConsoleChatRenderer` and `RichChatRenderer` are unaffected (`_KIND_LINE` is only used by `format_inline_message` → `InlineChatRenderer`)

## Test plan
- [x] `test_system_lifecycle_marker_has_dim_gutter` added to `test_inline_renderer_cutover.py`
- [x] All CI gates green: ruff ✓, tier-audit ✓, pytest 17/17 ✓, verify_module_docstrings ✓

Tier self-check: 1 Tier 2 behavioral assertion (gutter char present + text preserved) ✓ | part of #2205 inline CUI bug-mining