### PR TITLE
fix(#2300): remove orphaned TUI-only outbox sentinels at source (4 of 6)

### DIFF
--- a/src/reyn/interfaces/slash/donut.py
+++ b/src/reyn/interfaces/slash/donut.py
@@ -1,18 +1,12 @@
 """/donut — hidden easter egg. Andy Sloane's spinning ASCII torus.
 
-Not listed in /help or the Tab palette. Type `/donut` to invoke. Sends
-the special outbox kind `__donut__`; the TUI app intercepts it and
-pushes the modal screen. CUI mode silently ignores the unknown kind.
+Not listed in /help or the Tab palette. Type `/donut` to invoke.
 """
 from __future__ import annotations
 
-from reyn.interfaces.slash import slash
-from reyn.runtime.outbox import OutboxMessage
+from reyn.interfaces.slash import reply, slash
 
 
 @slash("donut", summary="Andy Sloane's spinning ASCII donut", hidden=True)
 async def donut_cmd(session: "object", args: str) -> None:
-    await session._put_outbox(OutboxMessage(
-        kind="__donut__",
-        text="",
-    ))
+    await reply(session, "🍩")

--- a/src/reyn/interfaces/slash/matrix.py
+++ b/src/reyn/interfaces/slash/matrix.py
@@ -1,19 +1,12 @@
-"""/matrix — hidden easter egg. Triggers the Matrix rain modal in the TUI.
+"""/matrix — hidden easter egg.
 
-Not listed in /help or the Tab palette. Type `/matrix` to invoke. Sends
-a special outbox kind that the TUI app intercepts (`__matrix__`) so this
-module stays decoupled from the renderer — `reyn chat --cui` falls back
-to a friendly inline message.
+Not listed in /help or the Tab palette. Type `/matrix` to invoke.
 """
 from __future__ import annotations
 
-from reyn.interfaces.slash import slash
-from reyn.runtime.outbox import OutboxMessage
+from reyn.interfaces.slash import reply, slash
 
 
 @slash("matrix", summary="Wake up, Neo.", hidden=True)
 async def matrix_cmd(session: "object", args: str) -> None:
-    await session._put_outbox(OutboxMessage(
-        kind="__matrix__",
-        text="There is no spoon.",
-    ))
+    await reply(session, "There is no spoon.")

--- a/src/reyn/interfaces/slash/quit.py
+++ b/src/reyn/interfaces/slash/quit.py
@@ -1,39 +1,21 @@
-"""``/quit`` (and ``/exit`` alias) — exit the chat from inside the TUI.
+"""``/quit`` (and ``/exit`` alias) — exit the chat.
 
-Wave-2 finding P3. Previously these were tracked only in ``help.py``'s
-``_BUILTIN_HINTS`` because the TUI / REPL intercepted them before the
-slash registry ever saw them — but the slash *palette* reads from the
-registry, so typing ``/q`` (looking for ``/quit``) produced an empty
-picker. Users who knew ``/quit`` existed from ``/help`` couldn't
-discover it through the palette autocomplete that they'd just learned
-from ``/help`` itself.
+Both the inline CUI (``_accept``) and the plain REPL (``_input_loop``)
+intercept ``/quit`` and ``/exit`` before ``submit_user_text`` — quit is
+handled at the input level.  These registry entries exist solely so both
+names appear in the palette and ``/help``; the handler itself is a no-op.
 
-Register both names as registry commands. Each sends a sentinel
-``OutboxMessage(kind="__quit__")`` that ``app_outbox._on_quit`` routes
-to the App's existing ``action_quit_tui`` coroutine — the same path
-Ctrl+D fires, so the shutdown semantics stay identical.
-
-Two separate ``@slash`` registrations (not the ``aliases=`` field)
-because the palette's prefix-match loop reads ``c.name`` only — an
-alias entry would not surface on ``/ex`` input. Two separate
-canonical commands cost nothing schema-wise and give both names
-first-class palette + ``/help`` visibility.
+Two separate ``@slash`` registrations (not the ``aliases=`` field) keep
+the palette's ``c.name.startswith(token)`` filter happy for ``/q`` and
+``/ex`` prefixes.
 """
 from __future__ import annotations
 
 from reyn.interfaces.slash import slash
-from reyn.runtime.outbox import OutboxMessage
 
 
 async def _quit_handler(session: "object", args: str) -> None:
-    """Dispatch the quit sentinel to the TUI / REPL outbox.
-
-    ``args`` is ignored — quit takes no arguments. A future "exit with
-    summary" or "exit code" feature could read it; for now any value
-    is silently discarded, mirroring how Ctrl+D ignores any in-flight
-    input.
-    """
-    await session._put_outbox(OutboxMessage(kind="__quit__", text=""))
+    """No-op — quit is intercepted at the input level before this fires."""
 
 
 # Both names get a registry entry. Using two ``@slash``-style

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -264,15 +264,6 @@ class InterventionHandler:
             choice_id=choice.id if choice else None,
             answer_text=text if not iv.choices else "",
         )
-        # Signal the TUI to remove the intervention widget (handles the case
-        # where the user answered via text input rather than clicking a chip
-        # button — the chip path calls InterventionWidget._submit which calls
-        # self.remove() itself; the text-input path skips that code path).
-        await self._put_outbox(OutboxMessage(
-            kind="intervention_resolved",
-            text="",
-            meta={"iv_id": iv.id, "run_id": iv.run_id or ""},
-        ))
         return True
 
     async def announce(self, iv: UserIntervention) -> None:

--- a/tests/test_intervention_handler_invariants.py
+++ b/tests/test_intervention_handler_invariants.py
@@ -233,13 +233,15 @@ async def test_wait_for_answer_returns_intervention_answer(tmp_path, monkeypatch
     assert history[0]["text"] == "Tokyo"
     assert history[0]["meta"]["intervention_id"] == iv.id
 
-    # Verify outbox: intervention announcement + intervention_resolved.
+    # Verify outbox: intervention announcement is present; intervention_resolved
+    # is NOT emitted (it was TUI-only widget-removal scaffolding; the inline CUI
+    # detects resolution via poll — emitting it leaks as two blank lines).
     outbox_kinds = [m.kind for m in outbox]
     assert "intervention" in outbox_kinds, (
         "announce must put an 'intervention' message in outbox"
     )
-    assert "intervention_resolved" in outbox_kinds, (
-        "successful answer must put 'intervention_resolved' in outbox"
+    assert "intervention_resolved" not in outbox_kinds, (
+        "intervention_resolved must NOT reach the outbox — no live consumer"
     )
 
     # Verify WAL has both dispatched and resolved events.

--- a/tests/test_orphaned_tui_sentinel_source_fixes.py
+++ b/tests/test_orphaned_tui_sentinel_source_fixes.py
@@ -1,0 +1,152 @@
+"""Tier 2: orphaned TUI-only outbox sentinels are removed at source.
+
+Four slash-command / handler emit sites that previously emitted kinds with
+no live consumer in the inline CUI (``__quit__``, ``__donut__``,
+``__matrix__``, ``intervention_resolved``) have been fixed.  These tests
+are *falsify-flip*: each assertion was RED before the fix and GREEN after.
+Flipping an assertion back to the old expected value would make it fail
+again, proving the sentinel has been removed from the outbox path.
+
+Consumer analysis (why zero-consumer):
+- ``__quit__`` was consumed by ``app_outbox._on_quit`` (Textual TUI, deleted).
+  The inline CUI intercepts ``/quit`` / ``/exit`` at ``_accept()`` before
+  ``submit_user_text`` — the handler is dead code in normal paths.
+- ``__donut__`` / ``__matrix__`` were consumed by Textual modal screens
+  (deleted).  Unknown kinds fall through ``format_inline_message`` to
+  ``Text(msg.text)`` — empty text prints two blank lines; ``__donut__``
+  produced a blank-line artefact.
+- ``intervention_resolved`` was consumed by a Textual widget callback
+  (deleted).  The inline CUI detects resolution via ``_sync_region()``
+  poll on ``session.interventions.head()`` — no signal needed.
+
+``intervention_resolved`` is covered in
+``test_intervention_handler_invariants.py``; the remaining three are
+covered here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+
+
+def _drain_outbox(session: Session) -> list:
+    out = []
+    while not session.outbox.empty():
+        out.append(session.outbox.get_nowait())
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quit_handler_emits_no_quit_sentinel(tmp_path, monkeypatch) -> None:
+    """Tier 2: /quit handler is a no-op — ``__quit__`` never reaches the outbox.
+
+    The inline CUI intercepts ``/quit`` / ``/exit`` at ``_accept()`` before
+    ``submit_user_text``.  The handler was dead code; it now emits nothing.
+    Falsify-flip: asserting ``__quit__`` IS in outbox_kinds would fail with
+    the current fix, proving the sentinel has been removed at source.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/quit")
+    assert consumed is True
+
+    outbox_kinds = [m.kind for m in _drain_outbox(session)]
+    assert "__quit__" not in outbox_kinds, (
+        "__quit__ must NOT reach the outbox — no live consumer; "
+        "the inline CUI intercepts quit at the input level"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exit_handler_emits_no_quit_sentinel(tmp_path, monkeypatch) -> None:
+    """Tier 2: /exit alias is also a no-op — ``__quit__`` never reaches outbox.
+
+    Both ``/quit`` and ``/exit`` share the same no-op handler.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/exit")
+    assert consumed is True
+
+    outbox_kinds = [m.kind for m in _drain_outbox(session)]
+    assert "__quit__" not in outbox_kinds, (
+        "__quit__ must NOT reach the outbox via /exit either"
+    )
+
+
+@pytest.mark.asyncio
+async def test_donut_emits_system_reply_not_tui_sentinel(tmp_path, monkeypatch) -> None:
+    """Tier 2: /donut emits a ``system`` reply — ``__donut__`` never reaches outbox.
+
+    The Textual donut modal consumer is deleted.  The easter egg is preserved
+    as an inline ``reply()`` (kind=``system``).  Falsify-flip: asserting
+    ``__donut__`` IS in outbox_kinds would fail, proving the sentinel is gone.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/donut")
+    assert consumed is True
+
+    messages = _drain_outbox(session)
+    outbox_kinds = [m.kind for m in messages]
+    assert "__donut__" not in outbox_kinds, (
+        "__donut__ must NOT reach the outbox — no live consumer"
+    )
+    assert "system" in outbox_kinds, (
+        "/donut must emit a system-kind reply so the easter egg is visible inline"
+    )
+
+
+@pytest.mark.asyncio
+async def test_matrix_emits_system_reply_not_tui_sentinel(tmp_path, monkeypatch) -> None:
+    """Tier 2: /matrix emits a ``system`` reply — ``__matrix__`` never reaches outbox.
+
+    The Textual matrix-rain modal consumer is deleted.  The easter egg text
+    ("There is no spoon.") is preserved as an inline ``reply()`` (kind=``system``).
+    Falsify-flip: asserting ``__matrix__`` IS in outbox_kinds would fail.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    consumed = await session._maybe_handle_slash("/matrix")
+    assert consumed is True
+
+    messages = _drain_outbox(session)
+    outbox_kinds = [m.kind for m in messages]
+    assert "__matrix__" not in outbox_kinds, (
+        "__matrix__ must NOT reach the outbox — no live consumer"
+    )
+    assert "system" in outbox_kinds, (
+        "/matrix must emit a system-kind reply so the easter egg is visible inline"
+    )
+    assert any(m.text == "There is no spoon." for m in messages), (
+        "/matrix reply must preserve the easter egg text"
+    )


### PR DESCRIPTION
**[tui-coder]** — Source-fix for orphaned TUI-only outbox kinds that have no live consumer in the inline CUI.

## Problem

After the Textual TUI deletion, 6 `OutboxMessage` kinds became orphaned (emitted but no consumer). Unknown kinds fall through `format_inline_message` to `Text(msg.text)` — empty-text kinds produce two blank lines per occurrence.

Lead-coder ran a definitive sweep (origin/main-explicit, all OutboxMessage kinds × consumer cross-check). Complete orphaned set: **6 kinds**.

## This PR: 4 of 6 (clear-disposition fixes)

### 1. `intervention_resolved` — **remove emit** (commit 1)
- `intervention_handler.py:_deliver_answer_to` — was signalling a Textual widget; inline CUI detects resolution via `_sync_region()` poll on `session.interventions.head()` at 150ms — no signal needed.
- Test: `test_intervention_handler_invariants.py::test_wait_for_answer_returns_intervention_answer` (falsify-flip: `intervention_resolved NOT in outbox_kinds`)

### 2. `__quit__` — **remove emit / no-op handler** (commit 2)
- `slash/quit.py` — both the inline CUI (`_accept`) and plain REPL (`_input_loop`) intercept `/quit`/`/exit` before `submit_user_text`. The handler was dead code. Registration kept for palette + `/help` visibility.

### 3. `__donut__` — **→ `reply(session, "🍩")`** (commit 2)
- `slash/donut.py` — Textual donut modal consumer deleted. Easter egg preserved as inline `system` kind reply.

### 4. `__matrix__` — **→ `reply(session, "There is no spoon.")`** (commit 2)
- `slash/matrix.py` — Textual matrix-rain modal consumer deleted. Original docstring already said "CUI mode falls back to friendly inline message" — this fix makes that real.

## Not in this PR: 2 owner-gated kinds (tracked in #2302)

- `__cost_inline_toggle__` (`slash/cost_inline.py`) — TUI feature toggle, currently no-op. Silent removal = zero UX feedback on `/cost_inline` invocation (worse than blank line).
- `__docs_filter__` (`slash/docs_filter.py`) — TUI right-panel filter, currently no-op. Same: product decision needed (rewire / unsupported-reply / remove-command).

## Tests

New file: `tests/test_orphaned_tui_sentinel_source_fixes.py` — 4 falsify-flip Tier 2 tests:
- `test_quit_handler_emits_no_quit_sentinel`
- `test_exit_handler_emits_no_quit_sentinel`
- `test_donut_emits_system_reply_not_tui_sentinel` (also asserts `system` kind present + text preserved)
- `test_matrix_emits_system_reply_not_tui_sentinel`

`intervention_resolved` falsify-flip is in `test_intervention_handler_invariants.py`.

## CI

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed>` — 4/4 OK
- [x] `pytest` — 7578 passed, 3 pre-existing gateway failures (not this diff)
- [x] `python scripts/verify_module_docstrings.py <changed>` — OK

## Test plan

- [x] All 4 new tests pass locally
- [x] Existing intervention handler tests (7 total) pass
- [x] `reyn chat` started cleanly with inline CUI (litellm proxy)
- [x] `/donut` now shows 🍩 inline (system kind, formatted)
- [x] `/matrix` now shows "There is no spoon." inline (system kind, formatted)
- [x] `/quit` still intercepted at input level before handler fires

Tier self-check: all new tests are Tier 2 (real instances, public surface, no mocks, no private state, no format pins).

part of #2300