### PR TITLE
fix(#2296): exempt self-bounded file.read results from generic offload — stop recursion

### DIFF
--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -226,6 +226,16 @@ def offload_control_ir_result(
     Small results (at or below threshold) are returned unchanged (identity).
     No information is lost: the full content is retrievable via the ref path.
     """
+    # #2296: a self-bounded result declares (via a positive flag) that its content is already
+    # bound ≤ the inline cap BY CONSTRUCTION — its over-cap serialized size is envelope-only, so it
+    # must NOT be offloaded (that would contradict #1209's keep-in-decide-context intent AND recurse:
+    # its retrieval read is itself over-cap on envelope → re-offload → loop). Exempt it before the
+    # size check. Generic flag (no op vocabulary) = P7-safe + open-closed: any op that self-bounds
+    # sets it and is exempt without touching this code. The op's own truncation/pagination
+    # (next_offset) is the correct retrieval mechanism, not an offload ref.
+    if result.get("_self_bounded"):
+        return result
+
     serialized = json.dumps(result, ensure_ascii=False)
     size_chars = len(serialized)
     if size_chars <= cap:

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -343,6 +343,10 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "total_lines": len(all_lines),
                 "next_offset": len(shown),
                 "total_chars": len(content),
+                # #2296: content is bound ≤ the inline cap BY CONSTRUCTION (this is the
+                # self-bounding truncated path) → exempt from the generic control_ir offload,
+                # which would otherwise re-offload it on envelope size alone and recurse.
+                "_self_bounded": True,
                 **_enc_field,
             }
         ctx.events.emit("tool_executed", op="read_file", path=op.path)
@@ -352,6 +356,10 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
             "path": op.path,
             "status": "ok",
             "content": content,
+            # #2296: an unbounded read whose content is already ≤ the inline cap (the OK-near-cap
+            # edge: not truncated, but content+envelope can exceed cap) → self-bounded by
+            # construction → exempt from the generic control_ir offload (else re-offload + recurse).
+            "_self_bounded": True,
             **_enc_field,
         }
 

--- a/tests/test_offload_recursion_2296.py
+++ b/tests/test_offload_recursion_2296.py
@@ -1,0 +1,114 @@
+"""Tier 2: #2296 — self-bounded file.read results are exempt from the generic control_ir offload.
+
+file.read self-bounds its content ≤ the inline cap (#1209), but the generic offload triggered on the
+whole-JSON size (content + envelope), so an already-bounded read was offloaded on ENVELOPE alone —
+and retrieving it (an unbounded file.read of the ref) was itself over-cap on envelope → re-offloaded
+→ infinite recursion. Fix: the read op stamps a positive ``_self_bounded`` flag on its self-bounding
+paths; ``offload_control_ir_result`` exempts a flagged result before the size check. The
+explicit-window path (verbatim, can exceed cap) is NOT flagged → still offloaded when huge.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.context_builder import offload_control_ir_result
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+def _make_ctx(tmp_path: Path) -> OpContext:
+    events = EventLog()
+    return OpContext(
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        events=events,
+        permission_decl=PermissionDecl(),
+        skill_name="test_skill",
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── the offload exemption (unit) ──────────────────────────────────────────────────────────────
+
+
+def test_self_bounded_result_exempt_from_offload(tmp_path: Path):
+    """Tier 2: a result flagged ``_self_bounded`` whose serialized JSON exceeds the cap is returned
+    UNCHANGED (no offload) — the over-cap-ness is envelope-only. RED without the exemption (it would
+    be offloaded, gaining ``_offload_ref`` + a ``control_ir_result_offloaded`` event)."""
+    events = EventLog()
+    # content ≤ cap, but content + envelope > cap (the OK-near-cap edge).
+    result = {"kind": "file", "op": "read", "path": "f.py", "status": "ok",
+              "content": "a" * 190, "_self_bounded": True}
+    out = offload_control_ir_result(result, 0, tmp_path, events=events, cap=200)
+    assert out is result, "a self-bounded result is returned unchanged (identity)"
+    assert "_offload_ref" not in out, "no offload ref added"
+    assert [e for e in events.all() if e.type == "control_ir_result_offloaded"] == [], "no offload event"
+
+
+def test_non_self_bounded_large_result_still_offloaded(tmp_path: Path):
+    """Tier 2: the exemption is SCOPED to the flag — an equally-large result WITHOUT ``_self_bounded``
+    (e.g. a python/MCP result) is still offloaded. Proves the fix doesn't disable offload broadly."""
+    events = EventLog()
+    result = {"kind": "python", "op": "exec", "status": "ok", "content": "a" * 190}
+    out = offload_control_ir_result(result, 0, tmp_path, events=events, cap=200)
+    assert out.get("_offload_ref"), "a non-self-bounded oversized result is offloaded"
+    assert [e for e in events.all() if e.type == "control_ir_result_offloaded"], "offload event emitted"
+
+
+# ── file.read stamps the flag on its self-bounding paths (integration) ────────────────────────
+
+
+def test_unbounded_truncated_read_is_self_bounded(tmp_path: Path):
+    """Tier 2: an unbounded read over the cap (truncated path) is stamped ``_self_bounded``."""
+    (tmp_path / "big.py").write_text("x = 1\n" * 20000)  # well over the 8 KB floor
+    res = _run(handle(FileIROp(kind="file", op="read", path="big.py"), _make_ctx(tmp_path), "control_ir"))
+    assert res["status"] == "truncated" and "next_offset" in res
+    assert res.get("_self_bounded") is True, "the truncated self-bounding read is flagged"
+
+
+def test_unbounded_ok_read_is_self_bounded(tmp_path: Path):
+    """Tier 2: an unbounded read whose content is ≤ cap (OK path) is also stamped ``_self_bounded``
+    (the OK-near-cap edge — bounded by construction, not by truncation)."""
+    (tmp_path / "small.py").write_text("hello = 1\n")
+    res = _run(handle(FileIROp(kind="file", op="read", path="small.py"), _make_ctx(tmp_path), "control_ir"))
+    assert res["status"] == "ok" and "next_offset" not in res
+    assert res.get("_self_bounded") is True, "the OK unbounded read is flagged (bounded by construction)"
+
+
+def test_explicit_window_read_is_not_self_bounded(tmp_path: Path):
+    """Tier 2: THE precision — the explicit-window path honors the caller's offset/limit VERBATIM
+    (content can exceed cap), so it is NOT self-bounded and is NOT flagged → a huge explicit-window
+    read is still offloaded (not exempt)."""
+    (tmp_path / "big.py").write_text("x = 1\n" * 20000)
+    res = _run(handle(
+        FileIROp(kind="file", op="read", path="big.py", offset=0, limit=20000),
+        _make_ctx(tmp_path), "control_ir",
+    ))
+    assert res["status"] == "ok", "explicit window → honored verbatim, not auto-truncated"
+    assert "_self_bounded" not in res, "the explicit-window read is NOT self-bounded (can exceed cap)"
+    # and therefore it is still offloaded when huge (path-1 not exempt).
+    out = offload_control_ir_result(res, 0, tmp_path, cap=200)
+    assert out.get("_offload_ref"), "a huge explicit-window read is still offloaded"
+
+
+# ── recursion termination: a self-bounded read is never re-offloaded ──────────────────────────
+
+
+def test_self_bounded_read_terminates_recursion(tmp_path: Path):
+    """Tier 2: a real self-bounded read result (from file.read) passed to the offload is exempt →
+    a retrieval read of any offloaded ref (unbounded → self-bounded) is not re-offloaded → the
+    offload/read recursion terminates at the source (≤1 hop)."""
+    (tmp_path / "big.py").write_text("x = 1\n" * 20000)
+    res = _run(handle(FileIROp(kind="file", op="read", path="big.py"), _make_ctx(tmp_path), "control_ir"))
+    assert res.get("_self_bounded") is True
+    events = EventLog()
+    out = offload_control_ir_result(res, 0, tmp_path, events=events, cap=200)  # tiny cap → would offload
+    assert "_offload_ref" not in out, "the self-bounded read is exempt even under a tiny cap → no re-offload"
+    assert [e for e in events.all() if e.type == "control_ir_result_offloaded"] == []


### PR DESCRIPTION
**[e2e-coder]** — #2296: tool-result offload infinite recursion (owner-reported, roi:high). **Closes #2296.**

## Root cause (lead-diagnosed, flow-trace-confirmed)

`file.read` already self-bounds + self-paginates its content ≤ the inline cap (#1209) — an unbounded read over the cap is truncated to a head window with `next_offset`, keeping it in the model's decide-context. But the generic control_ir offload (`offload_control_ir_result`, context_builder.py) triggers on the **whole-JSON** size (`content` + envelope), and `_read_inline_cap == control_ir_inline_cap` (same cap) — so an already-bounded read's serialized dict exceeds the cap on **envelope alone** → the bounded read is offloaded anyway, contradicting #1209's keep-in-decide-context intent.

**The recursion:** an offloaded read → the LLM's only retrieval is `file.read(_offload_ref)` → the `.json` is > cap → file.py truncates it, and its result dict is again > cap on envelope → re-offloaded → infinite offload/read loop. No exclusion, no recursion cap, no guard existed.

## Fix (bounded-by-construction; positive flag)

- **`file.py` read op stamps `_self_bounded: True`** on its self-bounding paths — the unbounded **truncated** path (content ≤ cap by truncation) and the unbounded **OK-≤-cap** path (the OK-near-cap edge: not truncated, but content+envelope can exceed cap). The **explicit-window path** (`offset`/`limit` honored VERBATIM — content can be any size) is **NOT flagged**.
- **`offload_control_ir_result` exempts a flagged result BEFORE the size check** (`if result.get("_self_bounded"): return result`). The flag is generic (no op vocabulary in OS code) = **P7-safe + open-closed**: any future op that self-bounds sets it and is exempt without touching context_builder.
- **Universality — terminates the loop at the source:** every recursion-relevant retrieval is an unbounded `file.read(ref)` → a self-bounding path → flagged → exempt → no re-offload. Even a legitimately-offloaded non-read result (python/MCP), when retrieved, gets self-bounded by file.py → exempt.
- **The flag is KEPT in the result** (not stripped after the check): it's a benign internal `_`-marker consistent with the existing `_offload_*` fields, and keeping it avoids mutating the shared result dict (a strip would need a copy). Each read re-stamps it, so persistence is harmless.
- **Clean end-state:** no magic-number cap-headroom (owner: no magic numbers). The generic offload still applies to genuinely-large non-self-bounding results.

## Test plan

- [x] **Exemption (unit)**: a `_self_bounded` result whose content+envelope > cap → returned unchanged (no `_offload_ref`, no `control_ir_result_offloaded` event). **Falsify-verified: disabling the exemption → the read is offloaded → RED.**
- [x] **Scoped to the flag**: an equally-large result WITHOUT the flag (python/MCP) is STILL offloaded.
- [x] **file.read stamps the flag (integration)**: unbounded truncated read → flagged; unbounded OK read → flagged; **explicit-window read → NOT flagged → still offloaded when huge** (the path-1 precision).
- [x] **Recursion termination**: a real self-bounded read result under a tiny cap → exempt (no re-offload) = the loop terminates ≤1 hop.
- [x] **Full suite faulthandler-net'd**: **7585 passed, 0 hang** (280s). The 4 failures are the SAME pre-existing env quirks (gateway entry-point ×3 + reyn.safe relocate) — this PR touches only the file-read/offload path.
- [x] **Gates**: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py` green; #1209 read-bounding + existing offload tests stay green (52 in the targeted regression).

## Secondary (tracked separately, NOT this recursion)
The JSON-of-JSON retrieval confound for legitimately-offloaded non-read results remains (the LLM `file.read`s the `.json` and receives the serialized result dict, not clean content) — not recursion, not blocking; a cleaner-retrieval follow-up if the owner wants it.

Lead reviews hardest: the path-1 precision (explicit-window NOT flagged) + the universality (retrieval-read termination) + the P7-clean generic-flag design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
