### PR TITLE
fix(renderer): 'Read 1 lines' → 'Read 1 line' singular grammar

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -353,7 +353,7 @@ def _summarize_result(tool, result) -> str:
             if isinstance(content, str):
                 lines = content.count("\n") + (1 if content else 0)
                 more = " (truncated)" if status == "truncated" else ""
-                return f"Read {lines} lines{more}"
+                return f"Read {lines} line{'s' if lines != 1 else ''}{more}"
             # A read whose content wasn't a usable string (e.g. None on an error
             # result): prefer the status (handled below) if any, else a clean
             # note — never fall through to dumping the raw dict repr.

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -33,6 +33,14 @@ def test_read_with_none_content_but_status_shows_status() -> None:
     assert out == "error"
 
 
+def test_file_read_singular_line() -> None:
+    """Tier 2: a single-line read says 'Read 1 line', not 'Read 1 lines'."""
+    out = summarize_tool_result(
+        "file__read", {"op": "read", "status": "ok", "content": "only one line"}
+    )
+    assert out == "Read 1 line"
+
+
 def test_file_read_truncated_is_flagged() -> None:
     """Tier 2: a truncated read says so."""
     out = summarize_tool_result(


### PR DESCRIPTION
**[tui-coder]** — idle-mining fix from the #2300/#2303 wave.

## Summary

- `summarize_tool_result` at `renderer.py:356` always produced "lines" (plural) — "Read 1 lines" on a single-line file read
- Applied the same `{'' if n == 1 else 's'}` pattern already used by the list-result path (line 346)
- Added `test_file_read_singular_line` to `test_inline_tool_result_summary.py` — was RED before fix, GREEN after

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 12/12 passed (new test is the falsify-flip)
- [x] `ruff check` — no issues
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 12 OK, 0 Tier 4

Tier self-check: new test is Tier 2 (real `summarize_tool_result` call, public return-value assert, no mocks, no format-pin on exact whitespace or structure).

part of #1830