### PR TITLE
test(renderer): add tool_call_completed/failed rendering + wants_separator coverage

### DIFF
--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -144,6 +144,29 @@ def test_kinds_use_distinct_markers() -> None:
     assert "▸" in tool and "⏺" not in tool
 
 
+def test_tool_call_completed_renders_corner_marker_and_summary() -> None:
+    """Tier 2: a tool_call_completed result renders with the ⎿ nested marker
+    and the summarize_tool_result one-liner (e.g. 'Read 3 lines')."""
+    out = _plain(
+        "tool_call_completed", "",
+        meta={"tool": "file__read", "result": {"op": "read", "status": "ok", "content": "a\nb\nc"}},
+    )
+    assert "⎿" in out
+    assert "Read 3 lines" in out
+
+
+def test_tool_call_failed_renders_corner_marker_and_error() -> None:
+    """Tier 2: a tool_call_failed result renders with the ⎿ nested marker and
+    the error text, prefixed with ✗."""
+    out = _plain(
+        "tool_call_failed", "",
+        meta={"error_message": "file not found"},
+    )
+    assert "⎿" in out
+    assert "✗" in out
+    assert "file not found" in out
+
+
 def test_wants_separator_skips_first_nested_and_transient() -> None:
     """Tier 2: a blank line separates top-level message blocks (but not before the
     first); never before a nested ⎿ detail row (tool result), nor before a
@@ -152,6 +175,7 @@ def test_wants_separator_skips_first_nested_and_transient() -> None:
     assert wants_separator("agent", seen_message=False) is False           # first
     assert wants_separator("agent", seen_message=True) is True             # block gap
     assert wants_separator("tool_call_completed", seen_message=True) is False  # nested
+    assert wants_separator("tool_call_failed", seen_message=True) is False     # nested
     assert wants_separator("status", seen_message=True) is False           # transient
     assert wants_separator("trace", seen_message=True) is False            # transient+nested
 


### PR DESCRIPTION
**[tui-coder]** — idle-mining test coverage gap.

## Summary

- `test_inline_renderer_cutover.py` had no rendering tests for `tool_call_completed` or `tool_call_failed` — only `tool_call_started` was covered by `test_kinds_use_distinct_markers`, and only `wants_separator("tool_call_completed")` was tested (not the actual rendered output)
- `wants_separator("tool_call_failed")` was also missing (both are in `_NESTED_KINDS`)
- Adds:
  - `test_tool_call_completed_renders_corner_marker_and_summary` — verifies `⎿` marker + `summarize_tool_result` text ("Read 3 lines")
  - `test_tool_call_failed_renders_corner_marker_and_error` — verifies `⎿` marker + `✗` prefix + error text
  - `wants_separator("tool_call_failed")` assertion in the existing separator test

## Test plan

- [x] `pytest tests/test_inline_renderer_cutover.py` — 19/19 passed (2 new tests)
- [x] `ruff check` — no issues
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_renderer_cutover.py` — 19 OK, 0 Tier 4

Tier self-check: both new tests are Tier 2 (real `format_inline_message` call, public `.plain` rendered output, no mocks, no format-pin on exact whitespace).

part of #1830