### PR TITLE
test: summarize_tool_result — create op + write/edit no-path fallback (#2308)

### DIFF
--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -47,6 +47,27 @@ def test_file_write_and_edit_name_the_path() -> None:
     assert summarize_tool_result("file__edit", {"op": "edit", "path": "g.py"}) == "Edited g.py"
 
 
+def test_file_create_treated_same_as_write() -> None:
+    """Tier 2: op='create' uses the same 'Wrote …' branch as 'write'.
+
+    A create op arriving from an MCP tool (or a future OS create op) must
+    not fall through to the raw-repr fallback — it shares the 'write|create'
+    branch. Pinning this prevents the branch being silently narrowed to
+    write-only.
+    """
+    assert summarize_tool_result("file__create", {"op": "create", "path": "new.py"}) == "Wrote new.py"
+
+
+def test_write_without_path_degrades_cleanly() -> None:
+    """Tier 2: a write result with no path field → 'Wrote file', not a crash."""
+    assert summarize_tool_result("file__write", {"op": "write"}) == "Wrote file"
+
+
+def test_edit_without_path_degrades_cleanly() -> None:
+    """Tier 2: an edit result with no path field → 'Edited file', not a crash."""
+    assert summarize_tool_result("file__edit", {"op": "edit"}) == "Edited file"
+
+
 def test_web_search_counts_results() -> None:
     """Tier 2: a search list summarises to 'N results'."""
     assert summarize_tool_result("web__search", ["a", "b", "c"]) == "3 results"


### PR DESCRIPTION
**[tui-coder]**

idle-mining coverage PR

## What

Three untested branches in `_summarize_result` (`src/reyn/interfaces/repl/renderer.py`):

| Op | Path | Before | After |
|----|------|--------|-------|
| `op='create'` | present | ❌ no test | ✅ "Wrote new.py" |
| `op='write'` | absent | ❌ no test | ✅ "Wrote file" |
| `op='edit'` | absent | ❌ no test | ✅ "Edited file" |

Adds 3 tests to `tests/test_inline_tool_result_summary.py`.

## Why `op='create'` matters

The branch is `if op in ("write", "create")`. A simplification to `if op == "write"` would silently fall through to `_short(result, 80)` — dumping a raw dict repr in the tool-call row. The falsify-flip test pins that `create` stays in the branch.

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 14/14 green
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 14 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — clean

Tier self-check: Tier 2 — pure function, exact behavioral assertions, no mocks, no private state.