### PR TITLE
test(tier2): CLI format_tokens_and_cost + /memory dispatch-only paths

### DIFF
--- a/tests/test_cli_summary_format.py
+++ b/tests/test_cli_summary_format.py
@@ -1,0 +1,55 @@
+"""Tier 2: CLI summary formatter — format_tokens_and_cost pure function contracts.
+
+`format_tokens_and_cost` is the single source of truth for how token usage and
+cost are formatted for both `reyn run` and `reyn eval` output.  It has two
+branches (cost present / absent) and uses comma-formatted numbers.  Pinning it
+prevents a silent format change from breaking the CLI's cost reporting surface.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.cli.summary import format_tokens_and_cost
+from reyn.llm.pricing import TokenUsage
+
+
+def _usage(prompt: int, completion: int) -> TokenUsage:
+    return TokenUsage(prompt_tokens=prompt, completion_tokens=completion)
+
+
+def test_format_includes_prompt_and_completion() -> None:
+    """Tier 2: output contains both prompt and completion token counts."""
+    out = format_tokens_and_cost(_usage(100, 50), None)
+    assert "100" in out
+    assert "50" in out
+
+
+def test_format_total_is_sum() -> None:
+    """Tier 2: total_tokens = prompt + completion surfaces in output."""
+    out = format_tokens_and_cost(_usage(100, 50), None)
+    assert "150" in out
+
+
+def test_format_with_no_cost_omits_dollar_sign() -> None:
+    """Tier 2: cost_usd=None → no cost suffix in output."""
+    out = format_tokens_and_cost(_usage(100, 50), None)
+    assert "$" not in out
+
+
+def test_format_with_zero_cost_omits_dollar_sign() -> None:
+    """Tier 2: cost_usd=0 (falsy cost) → no cost suffix in output."""
+    out = format_tokens_and_cost(_usage(100, 50), 0.0)
+    assert "$" not in out
+
+
+def test_format_with_positive_cost_includes_cost() -> None:
+    """Tier 2: positive cost_usd → '~$N.NNNN' suffix included."""
+    out = format_tokens_and_cost(_usage(100, 50), 0.0125)
+    assert "$" in out
+    assert "0.0125" in out
+
+
+def test_format_comma_separates_large_numbers() -> None:
+    """Tier 2: token counts ≥ 1000 use comma formatting."""
+    out = format_tokens_and_cost(_usage(10_000, 5_000), None)
+    assert "10,000" in out
+    assert "5,000" in out
+    assert "15,000" in out

--- a/tests/test_slash_memory_dispatch.py
+++ b/tests/test_slash_memory_dispatch.py
@@ -1,0 +1,46 @@
+"""Tier 2: /memory slash — dispatch paths that don't reach the data store.
+
+The 'list' and 'view' subcommand paths call into ``reyn.data.memory`` which
+requires a real filesystem.  This file covers the two paths that short-circuit
+before touching the store: no-args (→ usage text) and unknown sub (→ error).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.slash.memory import memory_cmd
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self._outbox: list[OutboxMessage] = []
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self._outbox.append(msg)
+
+    def reply_text(self) -> str:
+        return " ".join(m.text for m in self._outbox if m.kind == "system")
+
+    def error_text(self) -> str:
+        return " ".join(m.text for m in self._outbox if m.kind == "error")
+
+
+@pytest.mark.asyncio
+async def test_memory_no_args_shows_usage() -> None:
+    """Tier 2: /memory with no args → usage hint (not an error)."""
+    session = _FakeSession()
+    await memory_cmd(session, "")  # type: ignore[arg-type]
+    text = session.reply_text()
+    assert "list" in text.lower()
+    assert "view" in text.lower()
+    assert not session.error_text()
+
+
+@pytest.mark.asyncio
+async def test_memory_unknown_sub_replies_error() -> None:
+    """Tier 2: /memory with an unrecognised sub-command → usage error."""
+    session = _FakeSession()
+    await memory_cmd(session, "delete foo")  # type: ignore[arg-type]
+    assert session.error_text()
+    assert not session.reply_text()


### PR DESCRIPTION
**[tui-coder]** — coverage mining, part of #2302 idle wave

## Summary

8 Tier 2 tests across two previously uncovered areas:

**`format_tokens_and_cost`** in `interfaces/cli/summary.py` (6 tests): prompt + completion counts present; total = sum; `cost_usd=None` omits `$`; `cost_usd=0` omits `$`; positive cost → `~$N.NNNN` suffix; large numbers comma-formatted. This is the single source of truth for `reyn run` / `reyn eval` cost reporting.

**`/memory` dispatch** (2 tests): no-args → usage hint as system reply (not an error); unrecognised sub (`delete`, etc.) → usage error. Both paths short-circuit before touching `reyn.data.memory` so they require no filesystem fixture.

## Test plan

- [x] `ruff check tests/test_cli_summary_format.py tests/test_slash_memory_dispatch.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_cli_summary_format.py tests/test_slash_memory_dispatch.py` — 8/8 OK, 0 violations
- [x] `pytest tests/test_cli_summary_format.py tests/test_slash_memory_dispatch.py` — 8 passed
- [x] (skipped — no src changes) `python scripts/verify_module_docstrings.py`

Tier self-check: no mocks, no private-state reads, no `len()==N` format-pins.