### PR TITLE
test(tier2): audit._is_out_of_zone + events._filename_start_date + eval._hash_display

### DIFF
--- a/tests/test_audit_events_eval_pure_helpers.py
+++ b/tests/test_audit_events_eval_pure_helpers.py
@@ -1,0 +1,118 @@
+"""Tier 2: audit._is_out_of_zone + events._filename_start_date + eval._hash_display.
+
+Three untested pure helpers across three CLI command modules:
+
+- audit._is_out_of_zone(path): returns True when a literal preprocessor
+  file-op path is absolute or escapes upward via ".."; False otherwise.
+  Non-string / empty / None inputs return False safely.
+
+- events._filename_start_date(name): extracts a date from a JSONL event
+  filename prefix (format: YYYY-MM-DD[THHMMSS]…); returns None for
+  non-matching names.
+
+- eval._hash_display(h): truncates a version hash to 8 chars; "unknown" /
+  empty string → "unknown".
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from reyn.interfaces.cli.commands.audit import _is_out_of_zone
+from reyn.interfaces.cli.commands.eval import _hash_display
+from reyn.interfaces.cli.commands.events import _filename_start_date
+
+# ── _is_out_of_zone ───────────────────────────────────────────────────────────
+
+
+def test_is_out_of_zone_none_returns_false() -> None:
+    """Tier 2: None is not a string → returns False."""
+    assert _is_out_of_zone(None) is False
+
+
+def test_is_out_of_zone_empty_string_returns_false() -> None:
+    """Tier 2: empty string → returns False."""
+    assert _is_out_of_zone("") is False
+
+
+def test_is_out_of_zone_relative_safe_path_returns_false() -> None:
+    """Tier 2: normal relative path with no '..' → within zone, returns False."""
+    assert _is_out_of_zone("workspace/data/file.txt") is False
+
+
+def test_is_out_of_zone_absolute_path_returns_true() -> None:
+    """Tier 2: absolute path → out of zone, returns True."""
+    assert _is_out_of_zone("/etc/passwd") is True
+
+
+def test_is_out_of_zone_dotdot_escape_returns_true() -> None:
+    """Tier 2: path with '..' component → out of zone, returns True."""
+    assert _is_out_of_zone("../escape") is True
+
+
+def test_is_out_of_zone_embedded_dotdot_returns_true() -> None:
+    """Tier 2: path with embedded '..' → out of zone, returns True."""
+    assert _is_out_of_zone("subdir/../../../etc/secret") is True
+
+
+def test_is_out_of_zone_non_string_int_returns_false() -> None:
+    """Tier 2: non-string (int) is not a path → returns False."""
+    assert _is_out_of_zone(42) is False
+
+
+# ── _filename_start_date ──────────────────────────────────────────────────────
+
+
+def test_filename_start_date_with_timestamp_suffix() -> None:
+    """Tier 2: filename with YYYY-MM-DDTHHmmss prefix → correct date."""
+    result = _filename_start_date("2026-05-14T213000.jsonl")
+    assert result == date(2026, 5, 14)
+
+
+def test_filename_start_date_date_only_prefix() -> None:
+    """Tier 2: filename with YYYY-MM-DD prefix (no time component) → correct date."""
+    result = _filename_start_date("2026-01-31.jsonl")
+    assert result == date(2026, 1, 31)
+
+
+def test_filename_start_date_with_underscore_suffix() -> None:
+    """Tier 2: filename with YYYY-MM-DD_suffix form → date extracted from prefix."""
+    result = _filename_start_date("2026-05-14_agent_session.jsonl")
+    assert result == date(2026, 5, 14)
+
+
+def test_filename_start_date_non_matching_returns_none() -> None:
+    """Tier 2: filename not starting with date pattern → None."""
+    result = _filename_start_date("session_notes.txt")
+    assert result is None
+
+
+def test_filename_start_date_empty_string_returns_none() -> None:
+    """Tier 2: empty filename → None."""
+    result = _filename_start_date("")
+    assert result is None
+
+
+# ── _hash_display ─────────────────────────────────────────────────────────────
+
+
+def test_hash_display_empty_string_returns_unknown() -> None:
+    """Tier 2: empty hash → 'unknown'."""
+    assert _hash_display("") == "unknown"
+
+
+def test_hash_display_unknown_literal_returns_unknown() -> None:
+    """Tier 2: literal 'unknown' → 'unknown'."""
+    assert _hash_display("unknown") == "unknown"
+
+
+def test_hash_display_truncates_to_eight_chars() -> None:
+    """Tier 2: hash longer than 8 chars → first 8 chars returned."""
+    h = "abcdef1234567890"
+    result = _hash_display(h)
+    assert result == "abcdef12"
+
+
+def test_hash_display_short_hash_returned_as_is() -> None:
+    """Tier 2: hash of exactly 8 chars → returned unchanged."""
+    h = "abcdef12"
+    assert _hash_display(h) == h

--- a/tests/test_support_bundle_topology_pure_helpers.py
+++ b/tests/test_support_bundle_topology_pure_helpers.py
@@ -1,0 +1,174 @@
+"""Tier 2: support_bundle._rec_time + _line_included; topology._format_members.
+
+support_bundle._rec_time: extracts a timezone-aware datetime from a JSON record
+by scanning a fixed priority list of timestamp field names.  Returns None when
+no recognised field is present.
+
+support_bundle._line_included: best-effort filter — includes a record unless it
+clearly fails a `since` (time) or `session` filter.  Favours completeness: a
+record with no parseable timestamp is INCLUDED even when a `since` filter is set.
+
+topology._format_members: pure string formatter for a Topology's member list —
+team uses ``*`` on the leader, pipeline uses `` → ``, network uses ``, ``.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reyn.interfaces.cli.commands.support_bundle import _line_included, _rec_time
+from reyn.interfaces.cli.commands.topology import _format_members
+from reyn.runtime.topology import Topology
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _dt(iso: str) -> datetime:
+    """Parse an ISO timestamp; attach UTC if naive."""
+    dt = datetime.fromisoformat(iso)
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+# ── _rec_time ─────────────────────────────────────────────────────────────────
+
+
+def test_rec_time_timestamp_field() -> None:
+    """Tier 2: 'timestamp' key with ISO value → correct datetime."""
+    rec = {"timestamp": "2026-05-14T21:30:00+00:00"}
+    result = _rec_time(rec)
+    assert result == _dt("2026-05-14T21:30:00+00:00")
+
+
+def test_rec_time_ts_field() -> None:
+    """Tier 2: 'ts' key is recognised (second in priority list)."""
+    rec = {"ts": "2026-06-01T12:00:00+00:00"}
+    result = _rec_time(rec)
+    assert result == _dt("2026-06-01T12:00:00+00:00")
+
+
+def test_rec_time_sent_at_iso_field() -> None:
+    """Tier 2: 'sent_at_iso' key is recognised."""
+    rec = {"sent_at_iso": "2026-03-10T08:00:00+00:00"}
+    result = _rec_time(rec)
+    assert result == _dt("2026-03-10T08:00:00+00:00")
+
+
+def test_rec_time_no_known_fields_returns_none() -> None:
+    """Tier 2: record with no recognised timestamp field → None."""
+    result = _rec_time({"event_type": "turn_started", "data": {}})
+    assert result is None
+
+
+def test_rec_time_non_string_timestamp_skipped() -> None:
+    """Tier 2: integer value in 'timestamp' field is skipped → None (no next field)."""
+    result = _rec_time({"timestamp": 1234567890})
+    assert result is None
+
+
+def test_rec_time_naive_datetime_gets_utc() -> None:
+    """Tier 2: timezone-naive ISO string → UTC-aware datetime attached."""
+    rec = {"timestamp": "2026-05-14T21:30:00"}
+    result = _rec_time(rec)
+    assert result is not None
+    assert result.tzinfo is not None
+
+
+def test_rec_time_malformed_value_skipped_tries_next() -> None:
+    """Tier 2: malformed 'timestamp' → skipped; 'ts' is tried next."""
+    rec = {"timestamp": "not-a-date", "ts": "2026-05-01T10:00:00+00:00"}
+    result = _rec_time(rec)
+    assert result == _dt("2026-05-01T10:00:00+00:00")
+
+
+# ── _line_included ────────────────────────────────────────────────────────────
+
+
+def test_line_included_no_filters() -> None:
+    """Tier 2: no since / session filters → always included."""
+    assert _line_included({"timestamp": "2026-01-01T00:00:00Z"}, None, None) is True
+
+
+def test_line_included_since_filter_old_record_excluded() -> None:
+    """Tier 2: since set and record is before since → excluded."""
+    since = _dt("2026-06-01T00:00:00+00:00")
+    rec = {"timestamp": "2026-05-01T00:00:00+00:00"}
+    assert _line_included(rec, since, None) is False
+
+
+def test_line_included_since_filter_newer_record_included() -> None:
+    """Tier 2: since set and record is at/after since → included."""
+    since = _dt("2026-05-01T00:00:00+00:00")
+    rec = {"timestamp": "2026-06-01T00:00:00+00:00"}
+    assert _line_included(rec, since, None) is True
+
+
+def test_line_included_since_filter_no_timestamp_included() -> None:
+    """Tier 2: since set but record has no parseable timestamp → included (completeness bias)."""
+    since = _dt("2026-06-01T00:00:00+00:00")
+    assert _line_included({"event_type": "turn"}, since, None) is True
+
+
+def test_line_included_session_filter_match_included() -> None:
+    """Tier 2: session filter set and session_id matches → included."""
+    assert _line_included({"session_id": "sess-abc"}, None, "sess-abc") is True
+
+
+def test_line_included_session_filter_no_match_excluded() -> None:
+    """Tier 2: session filter set and no session field matches → excluded."""
+    assert _line_included({"session_id": "sess-xyz"}, None, "sess-abc") is False
+
+
+def test_line_included_session_filter_no_session_fields_included() -> None:
+    """Tier 2: session filter set but record has none of the recognised session fields → included."""
+    assert _line_included({"unrelated_key": "value"}, None, "sess-abc") is True
+
+
+# ── _format_members ───────────────────────────────────────────────────────────
+
+
+def test_format_members_team_marks_leader() -> None:
+    """Tier 2: team topology → leader name has '*' suffix; others don't."""
+    topo = Topology(
+        name="squad", kind="team",
+        members=("alice", "bob", "carol"), leader="alice",
+    )
+    result = _format_members(topo)
+    assert "alice*" in result
+    assert "bob" in result
+    assert "carol" in result
+
+
+def test_format_members_team_non_leader_has_no_star() -> None:
+    """Tier 2: team members who are not leader have no '*'."""
+    topo = Topology(
+        name="squad", kind="team",
+        members=("alice", "bob"), leader="bob",
+    )
+    result = _format_members(topo)
+    assert "alice*" not in result
+    assert "bob*" in result
+
+
+def test_format_members_pipeline_uses_arrow() -> None:
+    """Tier 2: pipeline topology → members joined with ' → '."""
+    topo = Topology(
+        name="pipe", kind="pipeline",
+        members=("stage1", "stage2", "stage3"),
+    )
+    result = _format_members(topo)
+    assert " → " in result
+    assert "stage1" in result
+    assert "stage3" in result
+
+
+def test_format_members_network_uses_comma() -> None:
+    """Tier 2: network topology → members joined with ', '."""
+    topo = Topology(
+        name="net", kind="network",
+        members=("a", "b", "c"),
+    )
+    result = _format_members(topo)
+    assert " → " not in result
+    parts = [p.strip() for p in result.split(",")]
+    assert "a" in parts
+    assert "b" in parts


### PR DESCRIPTION
**[tui-coder]** — Tier 2 coverage mining, part of #1830 idle arc.

## Summary

34 Tier 2 tests across five untested pure helpers in three CLI modules:

**Commit 1 — audit/events/eval helpers (16 tests):**
- **`audit._is_out_of_zone(path)`** (7 tests): None/empty/int → `False`; normal relative path → `False`; absolute path → `True`; `..` component → `True`; embedded `..` → `True`.
- **`events._filename_start_date(name)`** (5 tests): `YYYY-MM-DDTHHmmss` → date; date-only prefix → date; underscore-suffix form → date; non-matching → `None`; empty → `None`.
- **`eval._hash_display(h)`** (4 tests): empty → `"unknown"`; literal `"unknown"` → `"unknown"`; long hash → first 8 chars; 8-char hash unchanged.

**Commit 2 — support_bundle + topology helpers (18 tests):**
- **`support_bundle._rec_time(rec)`** (7 tests): `timestamp`/`ts`/`sent_at_iso` fields parsed; non-string/malformed skipped with fallback; naive ISO gets UTC; no known fields → None.
- **`support_bundle._line_included(rec, since, session)`** (7 tests): no filters → True; since filter excludes old/includes newer; no-timestamp record → included; session match → True; mismatch → False; no session fields → True.
- **`topology._format_members(topo)`** (4 tests): team marks leader with `*`; pipeline joins with ` → `; network joins with `, `.

No src changes.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_audit_events_eval_pure_helpers.py tests/test_support_bundle_topology_pure_helpers.py` — 34 OK, 0 violations
- [x] `pytest tests/test_audit_events_eval_pure_helpers.py tests/test_support_bundle_topology_pure_helpers.py` — 34 passed

Tier self-check: all tests are Tier 2 (pure helper behavioral contracts, no mocks, no private-state asserts, no format pins).