### PR TITLE
test(#1830): Tier 2 coverage — _ssrf_guard + snapshot_generations pure helpers

### DIFF
--- a/tests/test_snapshot_generations_pure_helpers.py
+++ b/tests/test_snapshot_generations_pure_helpers.py
@@ -1,0 +1,145 @@
+"""Tier 2: pure helpers in snapshot_generations.py.
+
+  ``_abandoned_intervals(rewinds)``  — open intervals abandoned by the rewind chain
+  ``_branch_of_seq(seq, abandoned)`` — branch_id owning a given seq
+  ``_make_is_active(abandoned)``     — closure returning is-active predicate
+
+These helpers underpin ADR-0038 Stage 1b–1e (time-travel correctness) and the
+derived branch tree (Phase-2, #1533). All take plain Python lists; no disk I/O.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.core.events.snapshot_generations import (
+    ACTIVE_BRANCH_ID,
+    _abandoned_intervals,
+    _branch_of_seq,
+    _make_is_active,
+)
+
+# ---------------------------------------------------------------------------
+# _abandoned_intervals
+# ---------------------------------------------------------------------------
+
+
+def test_abandoned_intervals_empty_rewinds() -> None:
+    """Tier 2: no rewinds → no abandoned intervals."""
+    assert _abandoned_intervals([]) == []
+
+
+def test_abandoned_intervals_single_rewind() -> None:
+    """Tier 2: one rewind (R=10, N=5) → interval (5, 10)."""
+    result = _abandoned_intervals([(10, 5)])
+    assert (5, 10) in result
+
+
+def test_abandoned_intervals_two_independent_rewinds() -> None:
+    """Tier 2: two non-overlapping rewinds produce two independent intervals.
+
+    (R=5, N=2) and (R=15, N=12) do not overlap — R=5 is not inside (12, 15).
+    Both intervals are kept.
+    """
+    result = _abandoned_intervals([(5, 2), (15, 12)])
+    assert (2, 5) in result
+    assert (12, 15) in result
+
+
+def test_abandoned_intervals_inner_rewind_subsumed_by_outer() -> None:
+    """Tier 2: inner rewind whose R falls inside an outer interval is dropped.
+
+    (R=20, N=3) abandons (3, 20).  Then (R=10, N=5): R=10 is inside (3, 20)
+    → subsumed → only (3, 20) survives.
+    """
+    result = _abandoned_intervals([(10, 5), (20, 3)])
+    assert (3, 20) in result
+    assert (5, 10) not in result
+
+
+def test_abandoned_intervals_returns_open_intervals() -> None:
+    """Tier 2: interval endpoints are exclusive — the record seq itself (R) is NOT abandoned."""
+    result = _abandoned_intervals([(10, 5)])
+    assert (5, 10) in result
+
+
+# ---------------------------------------------------------------------------
+# _make_is_active
+# ---------------------------------------------------------------------------
+
+
+def test_make_is_active_no_abandoned_all_active() -> None:
+    """Tier 2: no abandoned intervals → every seq is active."""
+    is_active = _make_is_active([])
+    for seq in (1, 5, 10, 100):
+        assert is_active(seq) is True
+
+
+def test_make_is_active_seq_inside_interval_not_active() -> None:
+    """Tier 2: seq strictly inside an abandoned interval is not active."""
+    is_active = _make_is_active([(5, 10)])
+    assert is_active(7) is False
+
+
+def test_make_is_active_seq_at_lower_boundary_is_active() -> None:
+    """Tier 2: seq == lo boundary (open interval) is active."""
+    is_active = _make_is_active([(5, 10)])
+    assert is_active(5) is True
+
+
+def test_make_is_active_seq_at_upper_boundary_is_active() -> None:
+    """Tier 2: seq == hi boundary (open interval) is active."""
+    is_active = _make_is_active([(5, 10)])
+    assert is_active(10) is True
+
+
+def test_make_is_active_seq_outside_interval_is_active() -> None:
+    """Tier 2: seq before or after the interval is active."""
+    is_active = _make_is_active([(5, 10)])
+    assert is_active(3) is True
+    assert is_active(12) is True
+
+
+# ---------------------------------------------------------------------------
+# _branch_of_seq
+# ---------------------------------------------------------------------------
+
+
+def test_branch_of_seq_no_abandoned_is_active_branch() -> None:
+    """Tier 2: no intervals → all seqs belong to the active branch (id 0)."""
+    for seq in (1, 7, 50):
+        assert _branch_of_seq(seq, []) == ACTIVE_BRANCH_ID
+
+
+def test_branch_of_seq_outside_interval_is_active() -> None:
+    """Tier 2: seq outside all intervals belongs to active branch."""
+    abandoned = [(5, 10)]
+    assert _branch_of_seq(3, abandoned) == ACTIVE_BRANCH_ID
+    assert _branch_of_seq(11, abandoned) == ACTIVE_BRANCH_ID
+
+
+def test_branch_of_seq_inside_interval_returns_r() -> None:
+    """Tier 2: seq inside (N=5, R=10) → branch_id = R = 10."""
+    abandoned = [(5, 10)]
+    assert _branch_of_seq(7, abandoned) == 10
+
+
+def test_branch_of_seq_at_boundary_is_active() -> None:
+    """Tier 2: open interval endpoints (lo/hi) belong to active branch."""
+    abandoned = [(5, 10)]
+    assert _branch_of_seq(5, abandoned) == ACTIVE_BRANCH_ID
+    assert _branch_of_seq(10, abandoned) == ACTIVE_BRANCH_ID
+
+
+def test_branch_of_seq_nested_intervals_returns_tightest() -> None:
+    """Tier 2: seq in nested intervals returns the innermost (max N) branch.
+
+    Outer interval (2, 20, R=20), inner interval (8, 12, R=12).
+    seq=10 is inside both; tightest has max N=8 → R=12.
+    """
+    abandoned = [(2, 20), (8, 12)]
+    assert _branch_of_seq(10, abandoned) == 12

--- a/tests/test_ssrf_guard_pure_helpers.py
+++ b/tests/test_ssrf_guard_pure_helpers.py
@@ -1,0 +1,129 @@
+"""Tier 2: pure helpers in _ssrf_guard.py — normalise and deny_reason.
+
+  ``_normalise(ip)``  — collapses IPv4-mapped IPv6 to its IPv4 form
+  ``_deny_reason(ip, allow_private)`` — returns a deny-reason string or None
+"""
+from __future__ import annotations
+
+import ipaddress
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn._ssrf_guard import _deny_reason, _normalise
+
+
+def _ip4(s: str) -> ipaddress.IPv4Address:
+    return ipaddress.IPv4Address(s)
+
+
+def _ip6(s: str) -> ipaddress.IPv6Address:
+    return ipaddress.IPv6Address(s)
+
+
+# ---------------------------------------------------------------------------
+# _normalise
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_plain_ipv4_passthrough() -> None:
+    """Tier 2: plain IPv4 address is returned unchanged."""
+    ip = _ip4("8.8.8.8")
+    assert _normalise(ip) == ip
+
+
+def test_normalise_plain_ipv6_passthrough() -> None:
+    """Tier 2: non-mapped IPv6 address is returned unchanged."""
+    ip = _ip6("2001:db8::1")
+    assert _normalise(ip) == ip
+
+
+def test_normalise_ipv4_mapped_ipv6_collapses_to_ipv4() -> None:
+    """Tier 2: ::ffff:x.x.x.x collapses to the IPv4 form."""
+    mapped = _ip6("::ffff:192.168.1.1")
+    result = _normalise(mapped)
+    assert isinstance(result, ipaddress.IPv4Address)
+    assert result == _ip4("192.168.1.1")
+
+
+def test_normalise_ipv4_mapped_metadata_collapses() -> None:
+    """Tier 2: ::ffff:169.254.169.254 collapses to the metadata IPv4."""
+    mapped = _ip6("::ffff:169.254.169.254")
+    result = _normalise(mapped)
+    assert isinstance(result, ipaddress.IPv4Address)
+    assert result == _ip4("169.254.169.254")
+
+
+# ---------------------------------------------------------------------------
+# _deny_reason
+# ---------------------------------------------------------------------------
+
+
+def test_deny_reason_public_ip_allowed() -> None:
+    """Tier 2: public routable IP has no deny reason."""
+    assert _deny_reason(_ip4("8.8.8.8"), allow_private=False) is None
+
+
+def test_deny_reason_metadata_ipv4() -> None:
+    """Tier 2: cloud-metadata 169.254.169.254 is always denied."""
+    result = _deny_reason(_ip4("169.254.169.254"), allow_private=True)
+    assert result is not None
+    assert "metadata" in result
+
+
+def test_deny_reason_metadata_ipv6() -> None:
+    """Tier 2: cloud-metadata fd00:ec2::254 is always denied."""
+    result = _deny_reason(_ip6("fd00:ec2::254"), allow_private=True)
+    assert result is not None
+    assert "metadata" in result
+
+
+def test_deny_reason_loopback_ipv4() -> None:
+    """Tier 2: 127.0.0.1 is denied as loopback."""
+    result = _deny_reason(_ip4("127.0.0.1"), allow_private=False)
+    assert result is not None
+    assert "loopback" in result
+
+
+def test_deny_reason_loopback_ipv6() -> None:
+    """Tier 2: ::1 is denied as loopback."""
+    result = _deny_reason(_ip6("::1"), allow_private=False)
+    assert result is not None
+    assert "loopback" in result
+
+
+def test_deny_reason_link_local_non_metadata() -> None:
+    """Tier 2: link-local address (not metadata) is denied as link-local."""
+    result = _deny_reason(_ip4("169.254.0.1"), allow_private=False)
+    assert result is not None
+    assert "link-local" in result
+
+
+def test_deny_reason_multicast() -> None:
+    """Tier 2: multicast address is denied."""
+    result = _deny_reason(_ip4("224.0.0.1"), allow_private=False)
+    assert result is not None
+    assert "multicast" in result
+
+
+def test_deny_reason_private_denied_when_not_allowed() -> None:
+    """Tier 2: RFC1918 private IP is denied when allow_private=False."""
+    result = _deny_reason(_ip4("192.168.1.1"), allow_private=False)
+    assert result is not None
+    assert "private" in result.lower() or "RFC1918" in result
+
+
+def test_deny_reason_private_allowed_when_flag_set() -> None:
+    """Tier 2: RFC1918 private IP is allowed when allow_private=True."""
+    assert _deny_reason(_ip4("192.168.1.1"), allow_private=True) is None
+
+
+def test_deny_reason_ipv4_mapped_metadata_denied() -> None:
+    """Tier 2: IPv4-mapped metadata address is denied after normalisation."""
+    mapped = _ip6("::ffff:169.254.169.254")
+    result = _deny_reason(mapped, allow_private=True)
+    assert result is not None
+    assert "metadata" in result


### PR DESCRIPTION
**[tui-coder]** — #1830 Tier 2 coverage mining.

## Summary

29 Tier 2 tests across 4 stateless pure helpers:

**`_ssrf_guard.py`** (14 tests)
- `_normalise(ip)` — IPv4/non-mapped IPv6 passthrough; `::ffff:x.x.x.x` collapses to IPv4; mapped metadata collapses correctly
- `_deny_reason(ip, allow_private)` — public IP → None; cloud-metadata IPv4/IPv6; loopback IPv4/IPv6; link-local (non-metadata); multicast; RFC1918 denied/allowed by flag; IPv4-mapped metadata denied after normalisation

**`snapshot_generations.py`** (15 tests)
- `_abandoned_intervals(rewinds)` — empty → `[]`; single rewind; two independent intervals both kept; inner rewind subsumed by outer dropped; open-interval semantics (boundaries not in range)
- `_make_is_active(abandoned)` — no intervals → all active; inside → not active; lo/hi boundary → active; outside → active
- `_branch_of_seq(seq, abandoned)` — no intervals → 0; outside → 0; inside → R; boundary → 0; nested → innermost (max N)

None of these had any prior test coverage.

Part of #1830.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_ssrf_guard_pure_helpers.py tests/test_snapshot_generations_pure_helpers.py` — 29 OK, 0 errors (fixed 2 `len()==N` format-pin violations caught on first pass)
- [x] `pytest tests/test_ssrf_guard_pure_helpers.py tests/test_snapshot_generations_pure_helpers.py` — 29/29 passed

Tier self-check: Tier 2 — direct function calls, real `ipaddress` objects, plain list inputs, assert on return values only, no private-state reads, no format pins.
