### PR TITLE
fix(#2279): deflake intervention-persistence 3.12 family — flush barrier for async WAL reads

### DIFF
--- a/tests/test_intervention_handler_invariants.py
+++ b/tests/test_intervention_handler_invariants.py
@@ -245,6 +245,15 @@ async def test_wait_for_answer_returns_intervention_answer(tmp_path, monkeypatch
     )
 
     # Verify WAL has both dispatched and resolved events.
+    # #2279: both are FIRE-AND-FORGET WAL appends (async-decoupled durability, #2259), so poll the
+    # WAL for BOTH before asserting — a REAL barrier on the asserted events. The wait_until above
+    # (line ~215) polled IN-MEMORY pending, NOT the WAL, so it is a FALSE barrier here; a raw read
+    # would race the appends' durability (the 3.12 flake root). This mirrors the file's other
+    # WAL-durability polls (e.g. the dispatched poll earlier).
+    await wait_until(
+        lambda: {"intervention_dispatched", "intervention_resolved"}
+        <= {e["kind"] for e in _wal_events(tmp_path)}
+    )
     events = _wal_events(tmp_path)
     kinds = [e["kind"] for e in events]
     assert "intervention_dispatched" in kinds

--- a/tests/test_session_intervention_persistence.py
+++ b/tests/test_session_intervention_persistence.py
@@ -131,6 +131,12 @@ async def test_deliver_answer_appends_intervention_resolved(tmp_path, monkeypatc
     # finally clause where ``record_intervention_resolved`` fires.
     await asyncio.gather(task, return_exceptions=True)
 
+    # #2279: ``record_intervention_resolved`` is a FIRE-AND-FORGET WAL append (async-decoupled
+    # durability, #2259) — drain the worker so the raw file read below is deterministic. The
+    # pre-existing ``wait_until`` polls the IN-MEMORY pending state, NOT the resolved WAL event, so
+    # it is a FALSE barrier here; ``flush()`` is the bounded-by-construction one (root of the 3.12
+    # flake: the read raced the append's durability).
+    await session._journal.flush()
     events = _wal_events(tmp_path)
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
     assert resolved, "intervention_resolved must be emitted after successful answer"
@@ -158,6 +164,9 @@ async def test_unknown_choice_does_not_emit_resolved(tmp_path, monkeypatch):
     consumed = await session._maybe_answer_oldest_intervention("invalid")
     assert consumed is True  # consumed but not resolved
 
+    # #2279: the ``wait_until`` above polled IN-MEMORY pending, not the WAL — so drain the worker
+    # before the raw read to make ``intervention_dispatched`` durability deterministic (else racy).
+    await session._journal.flush()
     events = _wal_events(tmp_path)
     dispatched = [e for e in events if e["kind"] == "intervention_dispatched"]
     resolved = [e for e in events if e["kind"] == "intervention_resolved"]
@@ -249,3 +258,31 @@ async def test_outstanding_interventions_in_snapshot_after_dispatch(tmp_path, mo
 
     iv.future.set_result(None)
     await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_wal_read_without_flush_races_durability_the_root(tmp_path, monkeypatch):
+    """Tier 2: #2279 the DETERMINISTIC mechanism-falsify (why the flush barrier is required).
+
+    A WAL append is FIRE-AND-FORGET (async-decoupled durability, #2259): it is enqueued to the
+    durability worker and is NOT on disk until the worker drains. A raw file read IMMEDIATELY after
+    — with NO await and NO flush — cannot see it (no yield = no drain), which is exactly the race the
+    flaky intervention tests hit (assert-read before the resolved append is durable; 3.12 scheduling
+    just widens the window). ``flush()`` drains the worker → durable → the read is deterministic.
+
+    Version-independent + scheduling-independent: RED (empty) before flush, GREEN after — the proof
+    that the fix is a structural barrier, not a hard-to-reproduce 3.12 nondeterminism.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    # Fire-and-forget the exact append the flaky test asserts on.
+    session._journal._wal_append_nowait(
+        "intervention_resolved", target="alpha", intervention_id="iv-x",
+    )
+    # RAW read with no await / no flush → the worker has not drained → NOT durable yet (the race).
+    before = [e for e in _wal_events(tmp_path) if e["kind"] == "intervention_resolved"]
+    assert before == [], "read-before-flush: a fire-and-forget append is not yet durable (the race root)"
+    # The flush barrier → drain → durable → deterministic read.
+    await session._journal.flush()
+    after = [e for e in _wal_events(tmp_path) if e["kind"] == "intervention_resolved"]
+    assert after and after[0]["intervention_id"] == "iv-x", "flush() makes the append durable"

--- a/tests/test_session_vanished_emit_2154.py
+++ b/tests/test_session_vanished_emit_2154.py
@@ -69,6 +69,10 @@ async def test_genuine_ephemeral_vanish_emits_session_vanished(tmp_path):
     if eph._vanish_task is not None:
         await eph._vanish_task
 
+    # #2279: session_vanished is a FIRE-AND-FORGET WAL append (async-decoupled durability, #2259) —
+    # drain the worker before the raw WAL read so the presence assert is deterministic (await'ing
+    # the vanish task does not guarantee its WAL append is durable).
+    await reg.state_log.flush()
     assert sid in _vanished_sids(reg.state_log, "alice")  # destroy recorded
 
 


### PR DESCRIPTION
**[e2e-coder]** — #2279: deflake the intervention-persistence 3.12 flaky family (root-cause, structural). **Closes #2279.**

## Root cause

The family flaked **only on 3.12**, nondeterministically, across tui's #1830 coverage batch (20+ PRs) — spurious reds unrelated to those PRs' changes. Root cause: the tests assert a WAL event (`intervention_resolved` / `intervention_dispatched` / `session_vanished`) via a **raw file read**, but those appends are **fire-and-forget** through the durability worker (async-decoupled durability, #2259) — so the read races the append's durability. The pre-existing `wait_until` polled the **in-memory pending state**, NOT the WAL event — a **false barrier**. 3.12's asyncio scheduling just widened the window (3.11 passed; isolation passed 40/40 — it needs full-suite pressure). This family was **missed by PR-2b's flush-cascade** (git log: PR-2b #2273 never touched these files).

## Fix (bounded-by-construction — tighten the race, do NOT loosen the asserts)

- **`test_session_intervention_persistence.py`** — `await session._journal.flush()` before the two racy raw reads (resolved after `gather` at :134; dispatched after a false in-memory `wait_until` at :161). The flush drains the worker → durable → deterministic read.
- **`test_intervention_handler_invariants.py`** (:248) — `wait_until` polling the WAL for BOTH events (a **real** barrier on the asserted events — the file's own safe pattern; `handler`/`registry` here, no `session` handle to flush).
- **`test_session_vanished_emit_2154.py`** (:72) — `await reg.state_log.flush()` before the `session_vanished` presence read.
- **Deterministic MECHANISM-FALSIFY** (new test): a fire-and-forget `_wal_append_nowait` is **empty** on an immediate raw read (the race), **durable after `flush()`** — version- and scheduling-independent RED→GREEN, proving `flush()` is THE barrier (not a hard-to-reproduce 3.12 nondeterminism).

## Sweep (class-close — precise, false-barrier-aware)

A `wait_until` is a valid barrier **only when it polls the SPECIFIC asserted durable WAL event** — not in-memory state (the exact bug here). Audited the intervention-EVENT family per-asserted-event:
- **Racy → fixed**: the 3 above.
- **Verified SAFE (real barriers)**: `test_intervention_restore.py` (200× poll-loop on the resolved WAL event), `test_intervention_resume_e2e.py` (`wait_until` on the resolved WAL event), and the non-racy reads in the fixed files (dispatched-after-real-poll, resolved-after-real-poll, snapshot-after-snapshot-poll).

The broader ~20 non-intervention WAL-read candidates (memo / skill / step events) are a **wider potential class**, but read different events and are NOT this reported flake — a separate sweep if the owner wants (not blindly churned here).

## Test plan

- [x] **Mechanism-falsify** (deterministic): fire-and-forget append empty pre-flush, durable post-flush.
- [x] **The 3 fixed files** pass (13 tests). Local is python 3.12.7; isolation was 40/40 pass (confirming the nondeterminism needs full-suite pressure → the mechanism-falsify is the right proof).
- [x] **Full suite faulthandler-net'd**: **7595 passed, 0 hang** (280s) — the intervention-persistence family passed under full-suite scheduling. The 4 failures are the SAME pre-existing env quirks (gateway entry-point ×3 + reyn.safe relocate), test-only change.
- [x] **Gates**: ruff, `test_tier_audit.py --strict` (13 OK) green.

Closes the tui #1830-batch spurious-red source. Lead reviews hardest: the false-barrier classification (wait_until-on-in-memory ≠ barrier) + the mechanism-falsify as the deterministic proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
