### PR TITLE
fix(inline-cui): _quit finally-guard + run_inline_input None-session guard

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -428,6 +428,8 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     sections — backward-compatible.
     """
     attached = registry.attached_session()
+    if attached is None:
+        raise RuntimeError("run_inline_input: no session attached (call registry.attach() first)")
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
     buf = Buffer(
         multiline=False, history=history,
@@ -898,4 +900,9 @@ async def _quit(registry, app, state: dict) -> None:
         # Log and suppress — a shutdown exception must not prevent app.exit()
         # from running (the PT app would hang with no escape path).
         logger.exception("registry shutdown failed during quit")
-    app.exit()
+    finally:
+        # asyncio.CancelledError (BaseException, not caught by `except Exception`
+        # above) must also reach app.exit() — without finally, a cancelled _quit
+        # task leaves state["quitting"]=True with app.exit() never called, hanging
+        # the PT application with no escape path.
+        app.exit()


### PR DESCRIPTION
**[tui-coder]** — Two defensive robustness fixes found during idle bug mining.

## Bug 1: `_quit()` hangs app when task is cancelled (CancelledError)

**Location:** `app.py:895–901`, `_quit()`

**Before:**
```python
state["quitting"] = True
try:
    await registry.shutdown()
except Exception:
    logger.exception("registry shutdown failed during quit")
app.exit()  # ← skipped on CancelledError
```

`asyncio.CancelledError` is a `BaseException`, not caught by `except Exception`. If the background task running `_quit` is cancelled mid-`await registry.shutdown()`, `state["quitting"]` stays `True` and `app.exit()` is never called. The idempotency guard on the next quit attempt then returns early (flag is set), leaving the PT application hung with no escape path.

**After:** `finally: app.exit()` ensures `app.exit()` fires regardless of whether shutdown raised a regular exception OR was interrupted by CancelledError.

---

## Bug 2: `run_inline_input()` AttributeError on None session

**Location:** `app.py:430–431`, `run_inline_input()`

**Before:**
```python
attached = registry.attached_session()
history = FileHistory(str(attached.workspace_dir / ".input_history"))
# ↑ AttributeError if attached is None
```

`run_repl` guards `attached_session()` at startup, but between `create_task(run_inline_input(...))` and the task actually running, a registry detach or shutdown could make `attached_session()` return `None`, crashing with `AttributeError` instead of a meaningful error.

**After:** explicit `if attached is None: raise RuntimeError(...)` guard, mirroring the pattern already used in `run_repl` and `_cancel_turn`.

---

## CI

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py` — N/A (no test files changed)
- [x] `pytest --ignore=tests/gateway` — passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — OK

## Test plan

- [x] (skipped — both fixes are PT-Application-level lifecycle guards; testing the `_quit` finally-path requires triggering CancelledError mid-shutdown against a real PT Application, which is Tier 4. The None-guard is a one-line structural check. No Tier 1–3 test form available without mocks.)

Tier self-check: no test file changed — N/A.