### PR TITLE
fix(#2335): char-truncate a single over-cap line so _self_bounded is honest

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -295,45 +295,70 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         # charset-normalizer); the plain-UTF-8 fast path keeps the result shape
         # byte-identical (no `encoding` field) for the common case.
         _enc_field = {"encoding": _detected_encoding} if _detected_encoding else {}
-        explicit_bounded = op.offset is not None or op.limit is not None
-        if explicit_bounded:
-            # Caller asked for an explicit window — honor it verbatim.
+        # #2335: read MODE. An explicit LINE window (offset/limit given, no char_offset) is honored
+        # VERBATIM — the LLM's line-based read contract, byte-identical (a huge explicit window is
+        # NOT self-bounded → the generic offload handles it; consistent + non-recursing since its
+        # retrieval is an unbounded read → self-bounding → exempt). Otherwise (an unbounded read, OR
+        # a char_offset mid-line RESUME) the read is SELF-BOUNDING.
+        explicit_line_window = (
+            op.offset is not None or op.limit is not None
+        ) and op.char_offset is None
+        if explicit_line_window:
+            # Caller asked for an explicit LINE window — honor it verbatim.
             lines = content.splitlines(keepends=True)
             start = op.offset or 0
             sliced = lines[start:start + op.limit] if op.limit is not None else lines[start:]
-            content = "".join(sliced)
             ctx.events.emit("tool_executed", op="read_file", path=op.path)
             return {
                 "kind": "file",
                 "op": "read",
                 "path": op.path,
                 "status": "ok",
-                "content": content,
+                "content": "".join(sliced),
                 **_enc_field,
             }
 
-        # #1209 (1) read-bounding, bound-only-when-over: an UNBOUNDED read whose
-        # content exceeds the window-derived inline cap is truncated to a head
-        # window and flagged with a STRUCTURAL truncation signal in SEPARATE
-        # fields (not embedded in `content`). This keeps the content in the
-        # model's decide context instead of being offloaded out of view (the
-        # apply-starvation root cause, #1209); the model pages the rest via
-        # `next_offset`. Small reads are returned unchanged.
+        # #1209 read-bounding (keep-in-decide-context, not offloaded-out-of-view) + #2335 char-level
+        # truncation. Accumulate WHOLE lines from (start_line, start_char); a multi-line overflow
+        # stops at the LINE boundary (byte-identical to pre-#2335 — next_char_offset stays absent);
+        # a SINGLE line/segment that alone exceeds the cap is CHAR-truncated so `content` is
+        # GENUINELY ≤ cap (honest `_self_bounded`, #2335 fix), its tail paged via next_char_offset.
         cap = _read_inline_cap(ctx)
-        if len(content) > cap:
-            all_lines = content.splitlines(keepends=True)
-            shown: list[str] = []
-            acc = 0
-            for line in all_lines:
-                if shown and acc + len(line) > cap:
-                    break
-                shown.append(line)
-                acc += len(line)
+        all_lines = content.splitlines(keepends=True)
+        start_line = op.offset or 0
+        start_char = op.char_offset or 0
+        shown: list[str] = []
+        acc = 0
+        next_offset: "int | None" = None
+        next_char_offset: "int | None" = None
+        i = start_line
+        seg_start = start_char
+        while i < len(all_lines):
+            seg = all_lines[i][seg_start:]
+            if shown and acc + len(seg) > cap:
+                # A subsequent line overflows → stop at the LINE boundary (exclude it; the
+                # continuation is a normal line read at its start). Pre-#2335 behavior.
+                next_offset = i
+                break
+            if not shown and len(seg) > cap:
+                # #2335: a single line/segment ALONE exceeds the cap → char-truncate for an honest
+                # bound; its tail resumes mid-line via next_char_offset.
+                shown.append(seg[:cap])
+                acc += cap
+                next_offset = i
+                next_char_offset = seg_start + cap
+                break
+            shown.append(seg)
+            acc += len(seg)
+            i += 1
+            seg_start = 0
+
+        if next_offset is not None:
             ctx.events.emit(
                 "tool_executed", op="read_file", path=op.path,
                 truncated=True, shown_lines=len(shown), total_lines=len(all_lines),
             )
-            return {
+            result: dict = {
                 "kind": "file",
                 "op": "read",
                 "path": op.path,
@@ -341,24 +366,26 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "content": "".join(shown),
                 "shown_lines": len(shown),
                 "total_lines": len(all_lines),
-                "next_offset": len(shown),
+                "next_offset": next_offset,
                 "total_chars": len(content),
-                # #2296: content is bound ≤ the inline cap BY CONSTRUCTION (this is the
-                # self-bounding truncated path) → exempt from the generic control_ir offload,
-                # which would otherwise re-offload it on envelope size alone and recurse.
+                # #2296: content bound ≤ the inline cap BY CONSTRUCTION → exempt from the generic
+                # control_ir offload (else re-offload on envelope size alone and recurse).
                 "_self_bounded": True,
                 **_enc_field,
             }
+            if next_char_offset is not None:
+                # #2335: mid-line resume position (set ONLY when a single line was char-truncated).
+                result["next_char_offset"] = next_char_offset
+            return result
+
         ctx.events.emit("tool_executed", op="read_file", path=op.path)
         return {
             "kind": "file",
             "op": "read",
             "path": op.path,
             "status": "ok",
-            "content": content,
-            # #2296: an unbounded read whose content is already ≤ the inline cap (the OK-near-cap
-            # edge: not truncated, but content+envelope can exceed cap) → self-bounded by
-            # construction → exempt from the generic control_ir offload (else re-offload + recurse).
+            "content": "".join(shown),
+            # #2296: content ≤ the inline cap by construction → exempt from the generic offload.
             "_self_bounded": True,
             **_enc_field,
         }

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -235,6 +235,7 @@ class FileIROp(BaseModel):
     # read-specific
     offset: int | None = None        # line number to start reading from (0-indexed); None = beginning
     limit: int | None = None         # number of lines to read; None = all
+    char_offset: int | None = None   # #2335: char position WITHIN line `offset` to resume from (paging a single line longer than the inline cap); None = start of the line
     # grep-specific
     pattern: str | None = None       # regex pattern to search for
     glob: str | None = None          # file filter glob pattern (e.g. "**/*.py"); default searches all files
@@ -275,6 +276,7 @@ class ReadFileIROp(BaseModel):
     path: str
     offset: int | None = None        # line number to start reading from (0-indexed); None = beginning
     limit: int | None = None         # number of lines to read; None = all
+    char_offset: int | None = None   # #2335: char position WITHIN line `offset` to resume from (paging a single over-cap line); None = start of the line
 
 
 class WriteFileIROp(BaseModel):

--- a/tests/test_read_single_line_char_truncation_2335.py
+++ b/tests/test_read_single_line_char_truncation_2335.py
@@ -1,0 +1,97 @@
+"""Tier 2: #2335 — a single line exceeding the inline cap is CHAR-truncated (honest _self_bounded).
+
+#2296 exempts self-bounded reads from the generic offload, trusting `_self_bounded` = "content ≤ cap
+by construction". But the line-based read-bounding always included the FIRST line whole, so a single
+line > cap → content > cap yet `_self_bounded: True` (dishonest) → the huge line ESCAPED offload =
+context bloat. Fix: char-truncate the overflowing line, page its tail via (next_offset,
+next_char_offset). The LLM's line-based offset/limit contract is preserved (char_offset is edge-only).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES as CAP
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+def _ctx(tmp_path: Path) -> OpContext:
+    ev = EventLog()
+    return OpContext(
+        workspace=Workspace(events=ev, base_dir=tmp_path),
+        events=ev, permission_decl=PermissionDecl(), skill_name="t",
+    )
+
+
+def _read(tmp_path: Path, **kw) -> dict:
+    return asyncio.run(handle(FileIROp(kind="file", op="read", **kw), _ctx(tmp_path), "control_ir"))
+
+
+def test_single_line_over_cap_is_char_truncated_and_honest(tmp_path: Path):
+    """Tier 2: a file whose FIRST line alone exceeds the cap → content is CHAR-truncated to ≤ cap
+    (honest `_self_bounded`), NOT included whole. RED without the fix (content > cap yet
+    `_self_bounded` True = the dishonest state #2296's tests missed)."""
+    huge = "x" * (CAP + 5000)  # a single line (no newline), well over the 8 KB floor cap
+    (tmp_path / "min.js").write_text(huge)
+    res = _read(tmp_path, path="min.js")
+    assert res["status"] == "truncated"
+    assert res["_self_bounded"] is True
+    assert len(res["content"]) <= CAP, "content must be GENUINELY ≤ cap (honest self-bounded)"
+    assert "next_char_offset" in res, "a char-truncated line pages its tail via next_char_offset"
+    assert res["total_chars"] == len(huge), "total_chars reports the full size"
+
+
+def test_single_line_tail_round_trips_via_char_offset(tmp_path: Path):
+    """Tier 2: the truncated line's TAIL is fully recovered by follow-up reads at (next_offset,
+    next_char_offset) — the round-trip, no data loss."""
+    huge = "".join(f"{i:06d}" for i in range(6000))  # one 36000-char line (no newlines)
+    (tmp_path / "data.txt").write_text(huge)
+    page = _read(tmp_path, path="data.txt")
+    assert page["status"] == "truncated" and "next_char_offset" in page
+    recovered = page["content"]
+    for _ in range(500):  # bounded-by-construction: char_offset advances monotonically
+        if page["status"] != "truncated" or "next_char_offset" not in page:
+            break
+        page = _read(tmp_path, path="data.txt", offset=page["next_offset"], char_offset=page["next_char_offset"])
+        recovered += page["content"]
+    assert recovered == huge, "the full single line must be recoverable via char-offset paging (no tail loss)"
+
+
+def test_multi_line_over_cap_unchanged(tmp_path: Path):
+    """Tier 2: regression — a multi-line file over cap stops at the LINE boundary (pre-#2335), with
+    whole lines and NO next_char_offset (the line-based continuation contract, byte-identical)."""
+    lines = ["line%04d " % i + "y" * 100 + "\n" for i in range(300)]  # ~110 chars each, many lines
+    (tmp_path / "multi.txt").write_text("".join(lines))
+    res = _read(tmp_path, path="multi.txt")
+    assert res["status"] == "truncated"
+    assert "next_char_offset" not in res, "multi-line overflow stops at a LINE boundary — no mid-line resume"
+    assert res["content"] == "".join(lines[: res["shown_lines"]]), "whole lines only (byte-identical to pre-#2335)"
+    assert len(res["content"]) <= CAP
+
+
+def test_explicit_line_window_stays_verbatim_not_self_bounded(tmp_path: Path):
+    """Tier 2: an explicit LINE window (offset+limit, no char_offset) is honored VERBATIM — NOT
+    self-bounded, NOT char-truncated (a huge explicit window → the generic offload handles it;
+    consistent + non-recursing since its retrieval is unbounded → self-bounding → exempt)."""
+    huge_line = "z" * (CAP + 5000)
+    (tmp_path / "f.txt").write_text("a\n" + huge_line + "\nb\n")
+    res = _read(tmp_path, path="f.txt", offset=1, limit=1)  # the huge line, verbatim
+    assert res["status"] == "ok"
+    assert "_self_bounded" not in res, "an explicit line window is verbatim, not self-bounded"
+    assert len(res["content"]) > CAP, "verbatim honors the caller's explicit window even when huge"
+
+
+def test_small_read_unchanged(tmp_path: Path):
+    """Tier 2: a small file (≤ cap) is returned whole, self-bounded, no truncation fields (the
+    common path, byte-identical)."""
+    (tmp_path / "small.py").write_text("hello = 1\nworld = 2\n")
+    res = _read(tmp_path, path="small.py")
+    assert res["status"] == "ok"
+    assert res["content"] == "hello = 1\nworld = 2\n"
+    assert res["_self_bounded"] is True
+    assert "next_offset" not in res and "next_char_offset" not in res


### PR DESCRIPTION
**[e2e-coder]** — Closes #2335. Self-verified correctness gap in my own #2296 offload fix.

## The gap
#2296 exempts `_self_bounded` read results from the generic offload — trusting the flag to mean "content ≤ cap by construction". But the #1209 read-bounding loop always included the **first line whole** (`if shown and acc+len(line) > cap: break` never fires on the first line because `shown` is empty). So a file whose **single first line exceeds the inline cap** returned `content > cap` yet stamped `_self_bounded: True` — a **dishonest flag** that let the huge line escape offload → context bloat. #2296's own tests didn't exercise a single-over-cap-line, so the gap shipped.

## Fix (lead-approved, two parts)
- **Part 1 — honesty**: when the first/only segment alone exceeds the cap, char-truncate it to `seg[:cap]` so returned content is **genuinely ≤ cap**.
- **Part 2 — char-capable pagination (scheme B, line+char hybrid)**: the LLM's line-based `offset`/`limit` contract is **unchanged**; a new edge-only `char_offset` resumes a truncated line mid-line. A char-truncated read pages its tail via `(next_offset, next_char_offset)`.
  - Multi-line-over-cap still stops at a **LINE** boundary — byte-identical, no `next_char_offset`.
  - An explicit line window (`offset`/`limit`, no `char_offset`) stays **verbatim** — a huge explicit window is handled by the generic offload (non-recursing: its retrieval is unbounded → self-bounds → exempt).

Scheme B chosen over A (pure char offsets) because the line-based offset contract is valuable + intuitive to the LLM, and the huge-single-line is an EDGE — the common path stays untouched.

## Falsify
Disabling the char-truncation branch (`if False and ...`) REDs both the honesty test (`content > cap` + status flip) and the round-trip test — verified RED→GREEN.

## Test plan
- [x] `tests/test_read_single_line_char_truncation_2335.py` — 5 tests: single-over-cap char-truncated+honest, tail round-trips via `char_offset`, multi-line-over-cap unchanged, explicit window verbatim, small read unchanged
- [x] #1209 + #2296 regression green (multi-line + exemption byte-identical)
- [x] Falsify RED→GREEN (char-truncation stripped → honesty+round-trip RED)
- [x] ruff / `test_tier_audit.py --strict` / `verify_module_docstrings.py` all green
- [x] Full suite: 7935 passed (4 pre-existing gateway-entry-point / reyn_api_relocate env failures reproduce on clean main with my changes stashed — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
