### PR TITLE
test(#1830): Tier 2 coverage — ws/chat._serialize + _decode_inbound_frame pure helpers

### DIFF
--- a/tests/test_ws_chat_pure_helpers.py
+++ b/tests/test_ws_chat_pure_helpers.py
@@ -1,0 +1,115 @@
+"""Tier 2: pure helpers in interfaces/web/ws/chat.py.
+
+  ``_serialize(msg, *, session)``      — OutboxMessage → JSON wire frame string
+  ``_decode_inbound_frame(raw)``       — raw WS text → dict | None
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from reyn.interfaces.web.ws.chat import _decode_inbound_frame, _serialize
+
+# ---------------------------------------------------------------------------
+# _serialize
+# ---------------------------------------------------------------------------
+
+
+def _msg(kind: str, text: str = "", meta: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(kind=kind, text=text, meta=meta)
+
+
+def test_serialize_basic_structure() -> None:
+    """Tier 2: serialized frame has kind, text, meta keys."""
+    raw = _serialize(_msg("agent", "hello"))
+    data = json.loads(raw)
+    assert data["kind"] == "agent"
+    assert data["text"] == "hello"
+    assert "meta" in data
+
+
+def test_serialize_none_meta_becomes_empty_dict() -> None:
+    """Tier 2: None meta is serialized as an empty object."""
+    raw = _serialize(_msg("status", "", meta=None))
+    data = json.loads(raw)
+    assert data["meta"] == {}
+
+
+def test_serialize_meta_passthrough() -> None:
+    """Tier 2: non-None meta dict is included verbatim."""
+    raw = _serialize(_msg("agent", "hi", meta={"run_id": "abc"}))
+    data = json.loads(raw)
+    assert data["meta"]["run_id"] == "abc"
+
+
+def test_serialize_intervention_without_session_no_queued_count() -> None:
+    """Tier 2: intervention kind without session does not add queued_count."""
+    raw = _serialize(_msg("intervention", "ask?"), session=None)
+    data = json.loads(raw)
+    assert "queued_count" not in data["meta"]
+
+
+def test_serialize_intervention_with_session_adds_queued_count() -> None:
+    """Tier 2: intervention kind with session injects queued_count from registry."""
+    interventions = SimpleNamespace(queued_count=lambda: 3)
+    session = SimpleNamespace(_interventions=interventions)
+    raw = _serialize(_msg("intervention", "ask?"), session=session)
+    data = json.loads(raw)
+    assert data["meta"]["queued_count"] == 3
+
+
+def test_serialize_intervention_does_not_overwrite_existing_queued_count() -> None:
+    """Tier 2: existing queued_count in meta is preserved, not overwritten."""
+    interventions = SimpleNamespace(queued_count=lambda: 5)
+    session = SimpleNamespace(_interventions=interventions)
+    raw = _serialize(
+        _msg("intervention", "ask?", meta={"queued_count": 1}),
+        session=session,
+    )
+    data = json.loads(raw)
+    assert data["meta"]["queued_count"] == 1
+
+
+def test_serialize_non_intervention_kind_no_queued_count() -> None:
+    """Tier 2: non-intervention kind does not inject queued_count even with session."""
+    session = SimpleNamespace(_interventions=SimpleNamespace(queued_count=lambda: 2))
+    raw = _serialize(_msg("agent", "text"), session=session)
+    data = json.loads(raw)
+    assert "queued_count" not in data["meta"]
+
+
+# ---------------------------------------------------------------------------
+# _decode_inbound_frame
+# ---------------------------------------------------------------------------
+
+
+def test_decode_inbound_frame_valid_object() -> None:
+    """Tier 2: valid JSON object returns a dict."""
+    raw = json.dumps({"action": "submit", "text": "hello"})
+    result = _decode_inbound_frame(raw)
+    assert result == {"action": "submit", "text": "hello"}
+
+
+def test_decode_inbound_frame_invalid_json_returns_none() -> None:
+    """Tier 2: malformed JSON returns None."""
+    assert _decode_inbound_frame("{not valid json}") is None
+
+
+def test_decode_inbound_frame_json_array_returns_none() -> None:
+    """Tier 2: JSON array (not an object) returns None."""
+    assert _decode_inbound_frame("[1, 2, 3]") is None
+
+
+def test_decode_inbound_frame_json_string_returns_none() -> None:
+    """Tier 2: JSON string scalar returns None."""
+    assert _decode_inbound_frame('"hello"') is None
+
+
+def test_decode_inbound_frame_json_null_returns_none() -> None:
+    """Tier 2: JSON null returns None."""
+    assert _decode_inbound_frame("null") is None
+
+
+def test_decode_inbound_frame_empty_object_is_valid() -> None:
+    """Tier 2: empty JSON object {} returns empty dict (valid frame)."""
+    assert _decode_inbound_frame("{}") == {}


### PR DESCRIPTION
**[tui-coder]** part of #1830

## Summary

- 13 Tier 2 tests for two pure helpers in `src/reyn/interfaces/web/ws/chat.py`
- `_serialize(msg, *, session)` — serialises an `OutboxMessage`-like object to JSON string; injects `queued_count` into `meta` for intervention messages when a session is attached
- `_decode_inbound_frame(raw)` — parses raw bytes/str to dict; returns `None` for invalid JSON, JSON arrays, JSON strings, JSON nulls

## Test coverage

`_serialize`:
- frame structure (kind/text keys present)
- `None` meta → `{}`
- meta passthrough
- intervention + no session → no `queued_count` injected
- intervention + session → `queued_count` injected from `_interventions.queued_count()`
- existing `queued_count` in meta preserved (not overwritten)
- non-intervention message not augmented with `queued_count`

`_decode_inbound_frame`:
- valid JSON object → dict
- invalid JSON → `None`
- JSON array → `None`
- JSON string → `None`
- JSON null → `None`
- empty object → `{}`

## CI gates (all green)
- `ruff check tests/test_ws_chat_pure_helpers.py` ✓
- `python scripts/test_tier_audit.py --strict tests/test_ws_chat_pure_helpers.py` ✓ (13 OK, 0 errors)
- `pytest tests/test_ws_chat_pure_helpers.py -q` ✓ (13 passed)

## Tier self-check
All 13 tests: Tier 2 contract. No `MagicMock`/`AsyncMock`/`patch`. No private-state access. No `len()==N` format pins. No display-verb/wording pins. `SimpleNamespace` stubs for attribute access only.