### PR TITLE
test(#1830): Tier 2 coverage — config/loader.py pure helpers

### DIFF
--- a/tests/test_config_loader_pure_helpers.py
+++ b/tests/test_config_loader_pure_helpers.py
@@ -1,0 +1,196 @@
+"""Tier 2: pure helpers in config/loader.py.
+
+``_as_config_dict(val, key)``   — coerce to dict, default {} on wrong type
+``_as_config_list(val, key)``   — coerce to list, default [] on wrong type
+``_parse_mcp_search_threshold`` — extract int from mcp dict, clamp negatives
+``_merge(base, override)``      — None values skip; unknown key overrides;
+                                   models/permissions shallow-merge
+``_find_project_root(start)``   — walk up until reyn.yaml found or root hit
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from reyn.config.loader import (
+    _as_config_dict,
+    _as_config_list,
+    _find_project_root,
+    _merge,
+    _parse_mcp_search_threshold,
+)
+
+# ---------------------------------------------------------------------------
+# _as_config_dict
+# ---------------------------------------------------------------------------
+
+
+def test_as_config_dict_none_returns_empty() -> None:
+    """Tier 2: None → empty dict (missing key graceful default)."""
+    assert _as_config_dict(None, "models") == {}
+
+
+def test_as_config_dict_dict_passthrough() -> None:
+    """Tier 2: dict value is returned as-is."""
+    d = {"foo": "bar"}
+    assert _as_config_dict(d, "models") is d
+
+
+def test_as_config_dict_string_returns_empty() -> None:
+    """Tier 2: scalar string → {} (user typo: models: standard_string)."""
+    assert _as_config_dict("standard", "models") == {}
+
+
+def test_as_config_dict_list_returns_empty() -> None:
+    """Tier 2: list → {} (malformed config block)."""
+    assert _as_config_dict(["a", "b"], "permissions") == {}
+
+
+def test_as_config_dict_int_returns_empty() -> None:
+    """Tier 2: integer → {}."""
+    assert _as_config_dict(42, "models") == {}
+
+
+# ---------------------------------------------------------------------------
+# _as_config_list
+# ---------------------------------------------------------------------------
+
+
+def test_as_config_list_none_returns_empty() -> None:
+    """Tier 2: None → empty list."""
+    assert _as_config_list(None, "tool_calls_op_loop_skills") == []
+
+
+def test_as_config_list_list_passthrough() -> None:
+    """Tier 2: list value is returned as-is."""
+    lst = ["a", "b"]
+    assert _as_config_list(lst, "tool_calls_op_loop_skills") is lst
+
+
+def test_as_config_list_string_returns_empty() -> None:
+    """Tier 2: string → [] (prevent per-character iteration)."""
+    assert _as_config_list("skill_router", "tool_calls_op_loop_skills") == []
+
+
+def test_as_config_list_dict_returns_empty() -> None:
+    """Tier 2: dict → []."""
+    assert _as_config_list({"a": 1}, "tool_calls_op_loop_skills") == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_mcp_search_threshold
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mcp_search_threshold_none_section_returns_default() -> None:
+    """Tier 2: absent mcp section → default 30."""
+    assert _parse_mcp_search_threshold(None) == 30
+
+
+def test_parse_mcp_search_threshold_missing_key_returns_default() -> None:
+    """Tier 2: dict without search_threshold key → default 30."""
+    assert _parse_mcp_search_threshold({"servers": {}}) == 30
+
+
+def test_parse_mcp_search_threshold_explicit_value() -> None:
+    """Tier 2: explicit integer value is returned."""
+    assert _parse_mcp_search_threshold({"search_threshold": 88}) == 88
+
+
+def test_parse_mcp_search_threshold_zero_allowed() -> None:
+    """Tier 2: zero disables the switch and is accepted (not clamped to default)."""
+    assert _parse_mcp_search_threshold({"search_threshold": 0}) == 0
+
+
+def test_parse_mcp_search_threshold_negative_clamped_to_zero() -> None:
+    """Tier 2: negative value is clamped to 0."""
+    assert _parse_mcp_search_threshold({"search_threshold": -5}) == 0
+
+
+def test_parse_mcp_search_threshold_string_non_numeric_returns_default() -> None:
+    """Tier 2: non-numeric string → default 30."""
+    assert _parse_mcp_search_threshold({"search_threshold": "high"}) == 30
+
+
+def test_parse_mcp_search_threshold_numeric_string_coerces() -> None:
+    """Tier 2: numeric string like '50' is coerced to int."""
+    assert _parse_mcp_search_threshold({"search_threshold": "50"}) == 50
+
+
+# ---------------------------------------------------------------------------
+# _merge — basic invariants
+# ---------------------------------------------------------------------------
+
+
+def test_merge_unknown_key_overrides() -> None:
+    """Tier 2: plain keys in override replace base value."""
+    result = _merge({"model": "lite"}, {"model": "standard"})
+    assert result["model"] == "standard"
+
+
+def test_merge_none_value_skips() -> None:
+    """Tier 2: None value in override does NOT overwrite existing base value."""
+    result = _merge({"model": "lite"}, {"model": None})
+    assert result["model"] == "lite"
+
+
+def test_merge_new_key_added() -> None:
+    """Tier 2: key present only in override is added to result."""
+    result = _merge({"model": "lite"}, {"debug": True})
+    assert result["debug"] is True
+    assert result["model"] == "lite"
+
+
+def test_merge_models_shallow_merged() -> None:
+    """Tier 2: 'models' dict is shallow-merged, not replaced."""
+    base = {"models": {"lite": "openai/gpt-4o-mini"}}
+    override = {"models": {"standard": "openai/gpt-4o"}}
+    result = _merge(base, override)
+    assert "lite" in result["models"]
+    assert "standard" in result["models"]
+
+
+def test_merge_permissions_shallow_merged() -> None:
+    """Tier 2: 'permissions' dict is shallow-merged."""
+    base = {"permissions": {"allow": ["file_read"]}}
+    override = {"permissions": {"deny": ["file_write"]}}
+    result = _merge(base, override)
+    assert result["permissions"]["allow"] == ["file_read"]
+    assert result["permissions"]["deny"] == ["file_write"]
+
+
+def test_merge_base_unchanged() -> None:
+    """Tier 2: _merge returns a new dict; base is not mutated."""
+    base = {"model": "lite"}
+    _merge(base, {"model": "standard"})
+    assert base["model"] == "lite"
+
+
+# ---------------------------------------------------------------------------
+# _find_project_root
+# ---------------------------------------------------------------------------
+
+
+def test_find_project_root_finds_reyn_yaml(tmp_path: Path) -> None:
+    """Tier 2: walking up finds the nearest reyn.yaml directory."""
+    (tmp_path / "reyn.yaml").write_text("", encoding="utf-8")
+    sub = tmp_path / "a" / "b"
+    sub.mkdir(parents=True)
+    assert _find_project_root(sub) == tmp_path
+
+
+def test_find_project_root_exact_match(tmp_path: Path) -> None:
+    """Tier 2: start dir containing reyn.yaml is returned immediately."""
+    (tmp_path / "reyn.yaml").write_text("", encoding="utf-8")
+    assert _find_project_root(tmp_path) == tmp_path
+
+
+def test_find_project_root_no_reyn_yaml_returns_none(tmp_path: Path) -> None:
+    """Tier 2: no reyn.yaml in tree → None."""
+    sub = tmp_path / "nested"
+    sub.mkdir()
+    assert _find_project_root(sub) is None


### PR DESCRIPTION
**[tui-coder]** part of #1830

## Summary

25 Tier 2 tests for five pure helpers in `src/reyn/config/loader.py`.

### `_as_config_dict(val, key)`
Coerces a top-level config value to dict; returns `{}` on None, scalar, or wrong-collection type. Guards against `AttributeError` from user typos like `models: standard_string`.
- None → `{}`
- dict passthrough
- string, list, int → `{}`

### `_as_config_list(val, key)`
Sibling coercer for list-valued keys. Returns `[]` on None, dict, or string (prevents per-character iteration on a string value).
- None → `[]`
- list passthrough
- string, dict → `[]`

### `_parse_mcp_search_threshold(raw_mcp)`
Extracts `mcp.search_threshold` from the raw mcp dict. Default 30 when absent/invalid; clamps negatives to 0; coerces numeric strings.
- None/missing key → 30
- explicit value returned
- zero allowed
- negative → 0
- non-numeric string → 30
- numeric string coerces to int

### `_merge(base, override)` — basic invariants
Tests the invariants not yet directly covered (the existing `test_config_mcp_merge_1146.py` exercises the `mcp` branch through `load_config`):
- None value in override skips (doesn't overwrite base)
- plain key overrides
- new key added
- `models` dict shallow-merged (both layers' keys present)
- `permissions` dict shallow-merged
- base not mutated

### `_find_project_root(start)`
Walks up the directory tree to find `reyn.yaml`.
- mid-tree search finds root
- exact dir match
- no `reyn.yaml` in tree → None

## CI gates (all green)
- `ruff check tests/test_config_loader_pure_helpers.py` ✓
- `python scripts/test_tier_audit.py --strict tests/test_config_loader_pure_helpers.py` ✓ (25 OK, 0 errors)
- `pytest tests/test_config_loader_pure_helpers.py -q` ✓ (25 passed)

## Tier self-check
All 25 tests: Tier 2 contract. No `MagicMock`/`AsyncMock`/`patch`. No private-state assertions. No `len()==N` format pins. No wording pins.