### PR TITLE
fix(#2344): execute chat-axis stacked tool_calls serially, not via asyncio.gather

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3027,12 +3027,24 @@ class RouterLoop:
         return actions
 
     async def dispatch(self, actions: list[dict]) -> list[dict]:
-        """SchemeOps.dispatch: run the resolved (exclude-cleared) actions in parallel
-        via the OS dispatch substrate (the former gather of _execute_tool's dispatch
-        half)."""
-        results = await asyncio.gather(*[
-            self._dispatch_resolved(a["name"], a["args"]) for a in actions
-        ])
+        """SchemeOps.dispatch: run the resolved (exclude-cleared) actions SERIALLY in
+        declaration order via the OS dispatch substrate.
+
+        #2344 (owner design decision): the chat axis must NOT unilaterally parallelize
+        stacked tool_calls. The LLM API returns tool_calls as an ordered list but does
+        not guarantee they are independent/parallel-safe, and there is no
+        workspace-write lock — a concurrent gather races on order-dependent calls (e.g.
+        write-a-file then read-it-back). The faithful default is serial in declaration
+        order, which also matches the phase axis (``control_ir_executor`` is already a
+        serial ``for op in ops: await``). Ordering (``tool_calls[i]`` ↔
+        ``tool_results[i]``) is unchanged — the append preserves declaration order the
+        same way ``gather`` did. Error semantics are unchanged: ``dispatch_tool``
+        normalizes every exception to ``{status: error}`` and never raises, so serial
+        does not short-circuit (every call still runs). The only thing given up is
+        parallel latency for genuinely-independent calls."""
+        results: list[dict] = []
+        for a in actions:
+            results.append(await self._dispatch_resolved(a["name"], a["args"]))
         # FP-0050/#1822 S2: tag untrusted-source results by the EFFECTIVE resolved
         # name (``a["name"]``). feedback() iterates the raw tool_calls whose name
         # may be the ``invoke_action`` wrapper, so classifying there would miss

--- a/tests/test_serial_tool_dispatch_2344.py
+++ b/tests/test_serial_tool_dispatch_2344.py
@@ -1,0 +1,175 @@
+"""Tier 2: #2344 — the chat axis executes stacked tool_calls SERIALLY (declaration order).
+
+Owner design decision: Reyn must not unilaterally parallelize a round's tool_calls via
+``asyncio.gather``. The LLM API returns tool_calls ordered but not independence-guaranteed, and
+there is no workspace-write lock, so a concurrent gather races on order-dependent calls (write X
+then read X). ``RouterLoop.dispatch`` now runs a serial ``for a in actions: await`` — matching the
+already-serial phase axis. Ordering + no-short-circuit error semantics are preserved.
+
+The order-dependent falsify is deterministic (not scheduling-luck): the writer yields once
+(``await asyncio.sleep(0)``) BEFORE mutating shared state. Under the old gather the reader
+coroutine interleaves at that yield and observes the pre-write state; under serial the writer
+completes fully before the reader starts. No mocks — a RouterLoop subclass overrides the real
+``_dispatch_resolved`` collaborator with ordered, observable handlers (the same real-fake seam as
+the ``llm_caller`` constructor injection).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.dispatch.dispatcher import DispatchContext, dispatch_tool
+from reyn.core.events.events import EventLog
+from reyn.runtime.router_loop import RouterLoop
+from tests._support.router_loop import FakeRouterHost
+
+
+class _OrderedDispatchLoop(RouterLoop):
+    """A RouterLoop whose ``_dispatch_resolved`` routes to ordered, observable handlers.
+
+    ``write`` yields once before setting ``shared["written"]`` — the deterministic seam that
+    exposes gather's interleave. ``read`` reports whether it observed the write. ``boom`` returns
+    a normalized error (``dispatch_tool`` never raises) to check no-short-circuit. ``trace`` records
+    completion order.
+    """
+
+    def __init__(self, *a, **k) -> None:
+        super().__init__(*a, **k)
+        self.shared: dict = {"written": False}
+        self.trace: list[str] = []
+
+    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+        if name == "write":
+            await asyncio.sleep(0)  # yield: under gather the reader runs here, before the write lands
+            self.shared["written"] = True
+            self.trace.append("write")
+            return {"status": "ok", "name": "write"}
+        if name == "read":
+            self.trace.append("read")
+            return {"status": "ok", "name": "read", "saw_write": self.shared["written"]}
+        if name == "boom":
+            self.trace.append("boom")
+            return {"status": "error", "error": {"kind": "x", "message": "boom"}}
+        self.trace.append(name)
+        return {"status": "ok", "name": name}
+
+
+def _loop() -> _OrderedDispatchLoop:
+    return _OrderedDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
+
+
+@pytest.mark.asyncio
+async def test_order_dependent_calls_execute_serially(tmp_path):
+    """Tier 2: write-then-read in one round runs serially → the read OBSERVES the write.
+
+    RED under the old ``asyncio.gather`` (the reader interleaves at the writer's yield and sees
+    ``written=False``); GREEN with the serial for-loop (the writer completes first)."""
+    loop = _loop()
+    results = await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+    assert results[1]["saw_write"] is True, "serial: the read must observe the preceding write"
+    assert loop.trace == ["write", "read"], "completion order is strict declaration order"
+
+
+@pytest.mark.asyncio
+async def test_results_returned_in_declaration_order(tmp_path):
+    """Tier 2: N calls → results[i] aligns with actions[i] (tool_calls[i] ↔ tool_results[i]);
+    the ordering contract is unchanged from gather's index-preservation."""
+    loop = _loop()
+    actions = [{"name": f"t{i}", "args": {}} for i in range(6)]
+    results = await loop.dispatch(actions)
+    assert [r["name"] for r in results] == [a["name"] for a in actions]
+    assert loop.trace == [a["name"] for a in actions]
+
+
+@pytest.mark.asyncio
+async def test_error_call_does_not_short_circuit(tmp_path):
+    """Tier 2: an error result mid-round does NOT stop the rest — every call still runs
+    (dispatch_tool normalizes errors, never raises), same as before."""
+    loop = _loop()
+    results = await loop.dispatch(
+        [{"name": "write", "args": {}}, {"name": "boom", "args": {}}, {"name": "read", "args": {}}]
+    )
+    assert [r["status"] for r in results] == ["ok", "error", "ok"]
+    assert results[2]["saw_write"] is True, "the call after the error still ran (no short-circuit)"
+    assert loop.trace == ["write", "boom", "read"]
+
+
+class _RealEventDispatchLoop(RouterLoop):
+    """Drives the REAL ``dispatch_tool`` per call, emitting the REAL P6 audit events
+    (``tool_called``/``tool_returned``) into a REAL ``EventLog`` (not a stub).
+
+    ``_dispatch_resolved`` reconstructs the chat-branch ``DispatchContext`` (mirrors
+    router_loop.py's ``caller_kind="router"`` path) with ``events=self.event_log`` — a real
+    ``reyn.core.events.events.EventLog``, the same class the production session threads in — and a
+    yield-controllable real invoker. The writer yields once before mutating shared state, exactly
+    where the real ``await invoker`` yield sits between the ``tool_called`` and ``tool_returned``
+    emits. So the append order recorded in the real EventLog is produced by the real dispatch +
+    real emission path — no proxy. Under gather the pairs interleave; serial makes them contiguous.
+    """
+
+    def __init__(self, *a, **k) -> None:
+        super().__init__(*a, **k)
+        self.shared: dict = {"written": False}
+        self.event_log = EventLog()
+
+    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+        async def _invoker(a: dict):
+            if name == "write":
+                await asyncio.sleep(0)  # the real await-invoker yield point
+                self.shared["written"] = True
+                return {"written": True}
+            return {"saw_write": self.shared["written"]}
+
+        dctx = DispatchContext(
+            caller_kind="router", caller_id=self.host.agent_name,
+            chain_id=self.chain_id, tool_catalog={name: {}}, events=self.event_log,
+        )
+        return await dispatch_tool(name=name, args=args, ctx=dctx, invoker=_invoker)
+
+
+def _tool_event_seq(event_log: EventLog) -> list[tuple[str, str]]:
+    """The (type, tool) sequence from the REAL EventLog's append-order replay source
+    (``all()`` — the same list ``to_json()`` and every append-order consumer iterate)."""
+    return [(e.type, e.data.get("tool")) for e in event_log.all()
+            if e.type in ("tool_called", "tool_returned")]
+
+
+@pytest.mark.asyncio
+async def test_audit_event_order_is_declaration_order_contiguous(tmp_path):
+    """Tier 2: #2344 durability — the REAL EventLog appends the P6 audit events in strict
+    declaration order, each call's (tool_called, tool_returned) pair CONTIGUOUS.
+
+    The P6 audit log is append-only + replay-capable; every append-order consumer (forwarders,
+    audit reconstruction, event-derived rewind views) inherits its order. Under the old gather the
+    pairs INTERLEAVE across concurrent calls (nondeterministic completion order → nondeterministic
+    audit append order = a replay/reconstruction divergence risk); serial makes the append order
+    deterministic and tool-call-boundary-clean. RED under gather (interleaved), GREEN under serial.
+    Drives the real dispatch_tool → real EventLog emission (no stub)."""
+    loop = _RealEventDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
+    await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+
+    assert _tool_event_seq(loop.event_log) == [
+        ("tool_called", "write"), ("tool_returned", "write"),
+        ("tool_called", "read"), ("tool_returned", "read"),
+    ], "real EventLog must append the audit events in contiguous declaration order"
+
+
+@pytest.mark.asyncio
+async def test_replay_reproduces_declaration_order(tmp_path):
+    """Tier 2: #2344 durability — the REAL EventLog's replay (append-order iteration of ``all()``,
+    the actual P6 replay semantics for the audit log) reproduces declaration order, and a cut
+    between the two calls lands on a clean tool-call boundary.
+
+    NB scope: chat-axis dispatch emits P6 AUDIT events (this EventLog); it writes NO WAL step, so
+    the WAL-based ``_materialize_rewind`` engine is a separate substrate not on this path — this
+    test drives the real audit-log replay, not a WAL rewind. Serial's contiguity means the pre-cut
+    prefix replays exactly the COMPLETED first call (no half-executed call straddling the cut)."""
+    loop = _RealEventDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
+    await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+
+    # replay = iterate the real EventLog in append order (P6 replay semantics for the audit log).
+    log = _tool_event_seq(loop.event_log)
+    boundary = log.index(("tool_called", "read"))  # the tool-call boundary cut
+    assert log[:boundary] == [("tool_called", "write"), ("tool_returned", "write")], \
+        "the pre-cut prefix replays exactly the completed first call (no straddle)"


### PR DESCRIPTION
**[e2e-coder]** — Closes #2344. Owner design decision: the chat axis must not unilaterally parallelize a round's tool_calls.

## The bug
`RouterLoop.dispatch` (router_loop.py:3033) ran every non-excluded tool call in one LLM response round **concurrently** via `asyncio.gather`. The LLM API returns `tool_calls` as an ordered list but does **not** guarantee independence/parallel-safety, and there is no workspace-write lock — so an order-dependent round (write-a-file then read-it-back) races, and Reyn imposes parallelism the model never asked for.

## The fix (owner-locked, 3 lines)
```python
results = []
for a in actions:
    results.append(await self._dispatch_resolved(a["name"], a["args"]))
```
- **Ordering**: preserved — append = declaration order = gather's index-order; `tool_calls[i]` ↔ `tool_results[i]` unchanged.
- **Error semantics**: unchanged — `dispatch_tool` normalizes every exception to `{status: error}` and never raises, so serial does not short-circuit (every call still runs). Serial is also strictly **safer**: the current no-`return_exceptions` gather cancels in-flight siblings mid-write on a raise.
- Consistent with the **phase axis** (`control_ir_executor`'s `for op in ops: await`, already serial).

## Flow-trace (verified)
- **3033 is the sole tool-dispatch parallel site.** The other `asyncio.create_task` at ~1522 is the background action-embedding-index build (unrelated). No round-timeout / `wait_for` wraps the dispatch.
- Chat-axis dispatch emits **P6 AUDIT events** (`tool_called`/`tool_returned`) via `ctx.events`; it writes **no WAL step** (`state_log` is threaded only for `caller_kind="skill_phase"`).

## Durability (owner's crash-recovery / time-travel constraint)
Serial **improves** determinism. Under gather, each call's `(tool_called, tool_returned)` audit-event pair **interleaves** across concurrent calls → nondeterministic append order → replay/reconstruction divergence risk. Serial makes each pair **contiguous in declaration order** → deterministic, tool-call-boundary-clean append.

**Real-path verification (not a proxy — per the load-bearing durability requirement):** falsify (4) and (5) drive the **real** `dispatch_tool` → emit into a **real `reyn.core.events.events.EventLog`** (the same class production threads in, not the test stub) → assert on its real append-order replay source (`.all()`, the list `to_json()` and every append-order consumer iterate). **Scope note:** chat-axis dispatch writes audit events, not the WAL, so the WAL-based `_materialize_rewind` engine is a *separate substrate not on this path* — these tests drive the real **audit-log** replay + boundary-cut, and do not (cannot honestly) claim to exercise WAL rewind for a path that emits no WAL.

## Test plan (`tests/test_serial_tool_dispatch_2344.py`, Tier 2)
- [x] (1) order-dependent write→read: serial → read observes the write (deterministic via a writer `sleep(0)` yield) — RED under gather
- [x] (2) N calls → results in declaration order (regression guard; gather also preserves index-order → stays green)
- [x] (3) error mid-round does not short-circuit — remaining calls still run
- [x] (4) **real EventLog**: audit events append in contiguous declaration order — RED under gather (interleaved)
- [x] (5) **real EventLog**: append-order replay reproduces declaration order + a tool-call-boundary cut replays exactly the completed first call (no straddle)
- [x] Falsify verified both directions: restore gather → 4/5 RED (index-order guard stays green), serial → 5/5 GREEN
- [x] Existing router-loop suite green incl. `test_parallel_tool_calls_in_one_round` (its assertion IS declaration-order, which serial guarantees)
- [x] ruff / `test_tier_audit.py --strict` (5 OK, 0 Tier-4) / `verify_module_docstrings.py` green
- [x] Full suite: 7935 passed (the 4 pre-existing gateway-entry-point / reyn_api_relocate env failures reproduce on clean main — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
