### PR TITLE
test(#1830): Tier 2 coverage — llm/llm.py G12-signal pure helpers

### DIFF
--- a/tests/test_llm_g12_pure_helpers.py
+++ b/tests/test_llm_g12_pure_helpers.py
@@ -1,0 +1,111 @@
+"""Tier 2: llm/llm.py G12-signal pure helper contracts.
+
+_is_g12_error_status(status) classifies a dispatch-result status string as
+an explicit error.
+
+_trailing_tool_is_error(content) classifies a JSON tool-result payload as
+an error, checking the dispatch-level status and the nested data.status.
+Both are used by the G12 signal to distinguish errored trailing tool calls
+from successful ones.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.llm.llm import _is_g12_error_status, _trailing_tool_is_error
+
+# ── _is_g12_error_status ──────────────────────────────────────────────────────
+
+
+def test_is_g12_error_status_error() -> None:
+    """Tier 2: 'error' is in the G12 error set."""
+    assert _is_g12_error_status("error") is True
+
+
+def test_is_g12_error_status_denied() -> None:
+    """Tier 2: 'denied' is in the G12 error set."""
+    assert _is_g12_error_status("denied") is True
+
+
+def test_is_g12_error_status_not_found() -> None:
+    """Tier 2: 'not_found' is in the G12 error set."""
+    assert _is_g12_error_status("not_found") is True
+
+
+def test_is_g12_error_status_failed() -> None:
+    """Tier 2: 'failed' is in the G12 error set."""
+    assert _is_g12_error_status("failed") is True
+
+
+def test_is_g12_error_status_case_insensitive() -> None:
+    """Tier 2: matching is case-insensitive ('ERROR' → True)."""
+    assert _is_g12_error_status("ERROR") is True
+    assert _is_g12_error_status("Denied") is True
+
+
+def test_is_g12_error_status_ok_returns_false() -> None:
+    """Tier 2: 'ok' is not an error status."""
+    assert _is_g12_error_status("ok") is False
+
+
+def test_is_g12_error_status_none_returns_false() -> None:
+    """Tier 2: None is not a string — returns False without raising."""
+    assert _is_g12_error_status(None) is False
+
+
+def test_is_g12_error_status_non_string_returns_false() -> None:
+    """Tier 2: integer input returns False (isinstance guard)."""
+    assert _is_g12_error_status(42) is False
+
+
+# ── _trailing_tool_is_error ───────────────────────────────────────────────────
+
+
+def test_trailing_tool_is_error_dispatch_level_error() -> None:
+    """Tier 2: top-level status='error' is detected."""
+    payload = json.dumps({"status": "error", "data": {}})
+    assert _trailing_tool_is_error(payload) is True
+
+
+def test_trailing_tool_is_error_dispatch_level_denied() -> None:
+    """Tier 2: top-level status='denied' is detected."""
+    payload = json.dumps({"status": "denied"})
+    assert _trailing_tool_is_error(payload) is True
+
+
+def test_trailing_tool_is_error_nested_data_error() -> None:
+    """Tier 2: op-execution error nested under data.status is detected."""
+    payload = json.dumps({"status": "ok", "data": {"status": "error", "path": "x"}})
+    assert _trailing_tool_is_error(payload) is True
+
+
+def test_trailing_tool_is_error_nested_data_not_found() -> None:
+    """Tier 2: data.status='not_found' (e.g. file read failure) is detected."""
+    payload = json.dumps({"status": "ok", "data": {"status": "not_found"}})
+    assert _trailing_tool_is_error(payload) is True
+
+
+def test_trailing_tool_is_error_ok_at_both_levels_returns_false() -> None:
+    """Tier 2: status='ok' at both levels → False (success cell)."""
+    payload = json.dumps({"status": "ok", "data": {"status": "ok"}})
+    assert _trailing_tool_is_error(payload) is False
+
+
+def test_trailing_tool_is_error_non_json_returns_false() -> None:
+    """Tier 2: non-JSON content returns False without raising."""
+    assert _trailing_tool_is_error("plain text result") is False
+
+
+def test_trailing_tool_is_error_not_starting_with_brace_returns_false() -> None:
+    """Tier 2: content not starting with '{' returns False (fast-path guard)."""
+    assert _trailing_tool_is_error("some text {status: error}") is False
+
+
+def test_trailing_tool_is_error_malformed_json_returns_false() -> None:
+    """Tier 2: malformed JSON starting with '{' returns False without raising."""
+    assert _trailing_tool_is_error("{invalid json") is False
+
+
+def test_trailing_tool_is_error_empty_returns_false() -> None:
+    """Tier 2: empty string returns False."""
+    assert _trailing_tool_is_error("") is False


### PR DESCRIPTION
**[tui-coder]** part of #1830 — idle-mining Tier 2 coverage.

## What

17 Tier 2 tests for two untested pure helpers in `src/reyn/llm/llm.py`:

**`_is_g12_error_status(status: object) → bool`**
- All four error tokens: `"error"`, `"denied"`, `"not_found"`, `"failed"` → `True`
- Case-insensitive: `"ERROR"`, `"Denied"` → `True`
- Non-error value `"ok"` → `False`
- `None` → `False` (isinstance guard)
- Integer `42` → `False`

**`_trailing_tool_is_error(content: str) → bool`**
- Dispatch-level `status="error"` → `True`
- Dispatch-level `status="denied"` → `True`
- Nested `data.status="error"` (op-execution error, the common production case) → `True`
- Nested `data.status="not_found"` (file read failure) → `True`
- `status="ok"` at both levels → `False` (success cell)
- Non-JSON string → `False`
- Content not starting with `{` → `False` (fast-path guard)
- Malformed JSON starting with `{` → `False`
- Empty string → `False`

## Tier self-check

- No `MagicMock`/`AsyncMock`/`patch` ✓
- No format pins ✓
- All docstrings declare `Tier 2:` ✓
- 4-gate CI: ruff ✓ / tier_audit --strict ✓ / pytest 17/17 ✓

## Test plan

- [x] `ruff check tests/test_llm_g12_pure_helpers.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_g12_pure_helpers.py` — 17 OK / 0 errors
- [x] `pytest tests/test_llm_g12_pure_helpers.py -q` — 17 passed