### PR TITLE
fix(#2348): isolate per-session history + chat events (multi-session conversation bleed)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2404,6 +2404,29 @@ class AgentRegistry:
         session._generation_store = per_session_generations  # rewind path reads this
         session._journal.set_snapshot_path(per_session_snapshot)
         session._journal.set_generation_store(per_session_generations)
+        # #2348: re-key the conversation transcript + chat audit events per-session
+        # too — they were keyed name-only (session.py: history_path / events_dir),
+        # so sessions of the same agent shared one history.jsonl (conversations bled
+        # across sessions) and one events/agents/<name>/chat tree. history.jsonl is an
+        # independent durable transcript (not WAL-reconstructed, outside snapshot/rewind
+        # scope); chat events are the P6 audit log. Isolating both aligns them with the
+        # already-per-session WAL/snapshot above. "main" (_DEFAULT_SID) never reaches
+        # this fixup (it comes through get_or_load), so single-session agents keep the
+        # legacy name-only paths byte-identical — no migration.
+        session.history_path = session_dir / "history.jsonl"
+        # _append_history opens the file directly (no mkdir), mirroring __init__'s
+        # workspace_dir.mkdir — the per-session dir must exist. (EventStore creates its
+        # own dir lazily on first write, so events need no explicit mkdir.)
+        session.history_path.parent.mkdir(parents=True, exist_ok=True)
+        session.set_events_dir(
+            session.events_dir.parent / "sessions" / self._encode_sid_for_dir(new_sid) / "chat"
+        )
+        # action_usage.json stays agent-wide by design (name-only, NOT re-keyed): it is
+        # the agent's tool-habit ranking (writer = compactor, reader = RouterLoop's
+        # per-turn hot-list cold-start hint), an agent-knowledge tier — and per-turn
+        # freshness for the CURRENT conversation is already supplied separately by the
+        # live overlay (this session's uncompacted calls layered on each turn). So it is
+        # correctly shared across the agent's sessions, not per-conversation state.
         self._sessions.setdefault(name, {})[new_sid] = session
         return new_sid
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1982,6 +1982,31 @@ class Session:
         """Remove a callback registered via :meth:`subscribe_chat_events`."""
         return self._chat_events.remove_subscriber(cb)
 
+    def set_events_dir(self, events_dir: Path) -> None:
+        """#2348: re-point this session's chat EventStore to a per-session directory.
+
+        Spawned sessions share the agent identity (and thus the name-only
+        ``events_dir`` built in ``__init__``), so the chat audit events of all of an
+        agent's sessions bled into one ``events/agents/<name>/chat`` tree. The
+        registry's ``spawn_session`` fixup calls this — parallel to the snapshot/WAL
+        re-key — before the run-loop goes live, so no event lands in the shared tree.
+
+        Swaps ONLY the ``EventStore`` subscriber on ``_chat_events`` (remove old, add
+        new); every OTHER subscriber (the ``ChatLifecycleForwarder`` outbox bridge, the
+        state-change converter, any attach-time focus listener) is preserved. A rebuild
+        of the subscriber list would silently drop them and chat events would stop
+        reaching the outbox / TUI — so the swap is surgical, not a reconstruction.
+        """
+        new_store = EventStore(
+            events_dir,
+            max_bytes=self._events_config.max_bytes,
+            max_age_seconds=self._events_config.max_age_seconds,
+        )
+        self._chat_events.remove_subscriber(self._event_store)
+        self._chat_events.add_subscriber(new_store)
+        self.events_dir = events_dir
+        self._event_store = new_store
+
     @property
     def total_usage(self):
         return self._budget.total_usage

--- a/tests/test_multisession_history_isolation_2348.py
+++ b/tests/test_multisession_history_isolation_2348.py
@@ -1,0 +1,152 @@
+"""Tier 2: #2348 — sessions of the same agent get ISOLATED history + chat events.
+
+Spawned sessions share the agent's identity object, so ``history_path`` (name-only) and
+``events_dir`` (name-only) collided across every session of one agent — conversation A's messages
+bled into B's ``load_history()``, and both wrote one ``events/agents/<name>/chat`` tree.
+``spawn_session``'s fixup now re-keys both per (name, sid), parallel to the already-per-session
+snapshot/WAL. "main" (``get_or_load``, not ``spawn_session``) keeps the legacy name-only paths
+byte-identical — single-session agents unchanged, no migration.
+
+Durability scoping (owner constraint), primary-verified:
+- history.jsonl is an INDEPENDENT durable transcript (``load_history`` reads it directly; it is not
+  WAL-reconstructed and is outside the snapshot/rewind field-map) → per-session isolation aligns it
+  with the already-per-session WAL; each session's transcript restores from its OWN file.
+- rewind does NOT touch the transcript at all (``reset_for_rewind`` clears runtime state, never
+  ``self.history``) — a documented, in-scope-adjacent finding surfaced here.
+
+Real seam: real ``AgentRegistry`` + real ``spawn_session`` (no mocks), mirroring the production
+factory. ``monkeypatch.chdir`` because Session derives ``.reyn/...`` paths relative to cwd.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_spawned_sessions_have_isolated_history(tmp_path, monkeypatch):
+    """Tier 2: two sessions of one agent get distinct history_path; A's appended message does NOT
+    appear in B's load_history(). RED today (shared name-only path), GREEN after the per-sid re-key."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    a = reg.get_session("alice", reg.spawn_session("alice"))
+    b = reg.get_session("alice", reg.spawn_session("alice"))
+
+    assert a.history_path != b.history_path, "spawned sessions must have isolated history paths"
+    a._append_history(ChatMessage(role="user", content="secret from A"))
+    b.load_history()
+    assert all("secret from A" not in str(m.content) for m in b.history), \
+        "session B must not see session A's conversation"
+
+
+@pytest.mark.asyncio
+async def test_spawned_events_isolated_and_forwarder_survives_rewire(tmp_path, monkeypatch):
+    """Tier 2: #2348 — the chat events of a spawned session land in its OWN per-session events dir
+    (not the shared/main tree), AND the set_events_dir subscriber swap preserves the other
+    subscribers (the ChatLifecycleForwarder still bridges to the outbox — a naive rebuild would
+    drop it and events would stop reaching the outbox/TUI)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    main = reg.get_or_load("alice")
+    a = reg.get_session("alice", reg.spawn_session("alice"))
+
+    assert a.events_dir != main.events_dir, "spawned session must have an isolated events dir"
+
+    a._chat_events.emit("budget_warn", dimension="daily_tokens")
+
+    # subscriber completeness: the forwarder survived the swap → the outbox got the marker.
+    msg = a.outbox.get_nowait()
+    assert "budget warn" in msg.text, "ChatLifecycleForwarder must survive set_events_dir (no drop)"
+
+    # the event reached A's NEW per-session store, and did NOT leak into main's shared tree.
+    a_blob = "".join(p.read_text() for p in a.events_dir.rglob("*.jsonl"))
+    assert "budget_warn" in a_blob, "event must be written to A's per-session events store"
+    main_blob = "".join(p.read_text() for p in main.events_dir.rglob("*.jsonl")) \
+        if main.events_dir.exists() else ""
+    assert "budget_warn" not in main_blob, "A's event must not leak into main's shared events dir"
+
+
+@pytest.mark.asyncio
+async def test_crash_recovery_restores_each_session_own_history(tmp_path, monkeypatch):
+    """Tier 2: #2348 durability — after a simulated crash (drop in-memory, reload from disk), each
+    session's history restores from its OWN per-session file with no cross-session bleed. history is
+    the durable source (file-based, not WAL-reconstructed); the WAL is already per-session."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    a = reg.get_session("alice", reg.spawn_session("alice"))
+    b = reg.get_session("alice", reg.spawn_session("alice"))
+    a._append_history(ChatMessage(role="user", content="A-only"))
+    b._append_history(ChatMessage(role="user", content="B-only"))
+
+    # simulate crash-recovery: clear in-memory, reload each from its own durable file.
+    a.history.clear()
+    b.history.clear()
+    a.load_history()
+    b.load_history()
+
+    assert any("A-only" in str(m.content) for m in a.history)
+    assert all("B-only" not in str(m.content) for m in a.history), "no bleed from B into A"
+    assert any("B-only" in str(m.content) for m in b.history)
+    assert all("A-only" not in str(m.content) for m in b.history), "no bleed from A into B"
+
+
+@pytest.mark.asyncio
+async def test_rewind_reset_does_not_touch_other_sessions_transcript(tmp_path, monkeypatch):
+    """Tier 2: #2348 durability — a rewind reset on session A leaves session B's transcript file
+    physically untouched (disjoint per-session paths). Also surfaces a finding: rewind does NOT
+    currently rewind the transcript — A's own history survives its own reset_for_rewind. Owner
+    intends conversations to rewind (append-only branch-tree time-travel, under separate
+    investigation); this per-session isolation is compatible with a future branch-view and does not
+    pre-empt it — the assertion below pins TODAY's behaviour, not a desired end-state."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    a = reg.get_session("alice", reg.spawn_session("alice"))
+    b = reg.get_session("alice", reg.spawn_session("alice"))
+    a._append_history(ChatMessage(role="user", content="A-msg"))
+    b._append_history(ChatMessage(role="user", content="B-msg"))
+    b_before = b.history_path.read_text()
+
+    await a.reset_for_rewind()  # the real in-memory rewind reset for session A
+
+    assert b.history_path.read_text() == b_before, "B's transcript file must be untouched by A's rewind"
+    b.history.clear()
+    b.load_history()
+    assert any("B-msg" in str(m.content) for m in b.history)
+    # documented finding: the transcript is outside rewind scope — A's own file persists.
+    assert a.history_path.read_text(), "A's transcript persists across its own rewind reset (finding)"
+
+
+def test_main_session_keeps_legacy_name_only_paths(tmp_path, monkeypatch):
+    """Tier 2: #2348 regression — the "main" session (via get_or_load, never spawn_session) keeps
+    the legacy name-only history_path + events_dir unchanged. Single-session agents unchanged,
+    no migration."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    main = reg.get_or_load("alice")
+    assert main.history_path == Path(".reyn") / "agents" / "alice" / "history.jsonl"
+    assert main.events_dir == Path(".reyn") / "events" / "agents" / "alice" / "chat"


### PR DESCRIPTION
**[e2e-coder]** — Closes #2348. Owner-reported design bug: sessions of the same agent shared one conversation.

## The bug
Spawned sessions share the agent's identity object, so `session.history_path` (`session.py:1378`, `.reyn/agents/<name>/history.jsonl`) and `events_dir` (`session.py:1381`, `.reyn/events/agents/<name>/chat`) were keyed by **agent-name only** — identical across every session of an agent. `spawn_session`'s fixup re-keyed the snapshot/WAL/generations per `(name, sid)` but **never** history or events. Result: session A appends → session B's `load_history()` reads A's messages; both write one shared chat-events tree.

## Same-class completeness
A full sweep of Session-persisted artifacts confirms **exactly three** name-only conversation-content artifacts: `history.jsonl`, chat events, `action_usage.json`. Everything else is correctly isolated (snapshot/generations/WAL/skill_registry) or correctly shared (memory/profile/media/action_index/workspace FS). This PR closes the conversation-content set:
- **history + events** — isolated per `(name, sid)` (the fix).
- **action_usage.json** — stays **agent-wide by design** (writer = compactor, reader = RouterLoop's per-turn hot-list cold-start hint; per-turn freshness for the current conversation is already supplied by the live overlay). Not re-keyed; rationale in an inline comment.
- (`.input_history` is operator-REPL keystroke history, not conversation content → out of scope.)

## The fix (minimal, clean-end-state, no migration)
- **`registry.spawn_session` fixup**: `session.history_path = session_dir / "history.jsonl"` (+ `parent.mkdir` — `_append_history` opens the file directly with no lazy mkdir, unlike EventStore) and `session.set_events_dir(<per-session chat dir>)`, parallel to the existing snapshot re-key.
- **New `Session.set_events_dir(path)`**: a **surgical** subscriber swap — rebuild the `EventStore` and `remove_subscriber(old)` / `add_subscriber(new)` on `_chat_events`, **preserving every other subscriber**. `_chat_events` is *not* sole-subscriber (`ChatLifecycleForwarder` outbox bridge, the state-change converter, attach-time focus listeners) — a rebuild of the subscriber list would silently drop them and events would stop reaching the outbox/TUI.
- **"main"** (`_DEFAULT_SID`) comes through `get_or_load`, never `spawn_session`, so single-session agents keep the legacy name-only paths unchanged — **no migration**.

## Durability (owner's crash-recovery / time-travel constraint), primary-verified
- `history.jsonl` is an **independent durable transcript**: `load_history()` reads it directly; it is **not** WAL-reconstructed and is **outside** the snapshot/rewind field-map (`reset_for_rewind`/`restore_state` never touch `self.history`). Per-session isolation therefore *aligns* history with the already-per-session WAL — recovery restores each session's transcript from its own file, consistent with its own WAL.
- Chat events are the P6 audit log — per-session isolation aligns them too.
- **Finding (separate issue, under investigation — NOT intentional spec):** rewind does **not** currently rewind the transcript at all — a session's `history.jsonl` survives its own `reset_for_rewind`. Owner intends conversations *to* rewind (append-only branch-tree time-travel: rewind/fork/switch to any branch tip without discarding futures), under separate investigation. This PR's per-session isolation is **compatible** with a future conversation-branch-view and does not pre-empt it; the rewind test pins *today's* behaviour, not a desired end-state.

## Test plan (`tests/test_multisession_history_isolation_2348.py`, Tier 2, real AgentRegistry + real spawn_session)
- [x] Spawned sessions get isolated `history_path`; A's message absent from B's `load_history()`
- [x] Spawned events isolated + **subscriber completeness**: emit `budget_warn` → outbox marker received (ChatLifecycleForwarder survived the swap) + event in A's per-session dir + **not** in main's shared dir
- [x] Crash-recovery: each session restores its OWN history from its own file, no cross-session bleed
- [x] Rewind reset on A leaves B's transcript file untouched (+ surfaces the transcript-not-rewound finding)
- [x] "main" session keeps legacy name-only history_path + events_dir (regression)
- [x] Falsify verified: disabling the re-key → the 3 isolation/recovery tests RED
- [x] ruff / tier-audit (strict) / verify_module_docstrings green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
