### PR TITLE
test(#1830): Tier 2 coverage — artifact_validator._resolve_path pure helper

### DIFF
--- a/tests/test_artifact_validator_resolve_path.py
+++ b/tests/test_artifact_validator_resolve_path.py
@@ -1,0 +1,82 @@
+"""Tier 2: data/workspace/artifact_validator.py _resolve_path pure helper.
+
+_resolve_path(context, path) traverses a nested dict using a dotted-path
+expression and returns (members, ok). Supports plain key access ('a.b')
+and wildcard array iteration ('a.items[*].name'). Returns ([], False) for
+empty paths, missing keys, or wrong-type values.
+"""
+from __future__ import annotations
+
+from reyn.data.workspace.artifact_validator import _resolve_path
+
+
+def test_resolve_path_simple_nested_key() -> None:
+    """Tier 2: 'a.b' resolves to context['a']['b'] wrapped in a list."""
+    members, ok = _resolve_path({"a": {"b": "value"}}, "a.b")
+    assert ok is True
+    assert members == ["value"]
+
+
+def test_resolve_path_single_key() -> None:
+    """Tier 2: single-segment path returns the value at that key."""
+    members, ok = _resolve_path({"x": 42}, "x")
+    assert ok is True
+    assert members == [42]
+
+
+def test_resolve_path_list_value_at_leaf() -> None:
+    """Tier 2: list value at the leaf is returned as the members list."""
+    members, ok = _resolve_path({"a": [1, 2, 3]}, "a")
+    assert ok is True
+    assert members == [1, 2, 3]
+
+
+def test_resolve_path_wildcard_collects_field_from_each_item() -> None:
+    """Tier 2: 'items[*].name' collects the 'name' field from each array element."""
+    ctx = {"items": [{"name": "alpha"}, {"name": "beta"}]}
+    members, ok = _resolve_path(ctx, "items[*].name")
+    assert ok is True
+    assert members == ["alpha", "beta"]
+
+
+def test_resolve_path_wildcard_nested_under_key() -> None:
+    """Tier 2: wildcard can appear at any nesting level ('a.items[*].n')."""
+    ctx = {"a": {"items": [{"n": "x"}, {"n": "y"}]}}
+    members, ok = _resolve_path(ctx, "a.items[*].n")
+    assert ok is True
+    assert members == ["x", "y"]
+
+
+def test_resolve_path_missing_key_returns_false() -> None:
+    """Tier 2: path that traverses a missing key returns ([], False)."""
+    members, ok = _resolve_path({"a": {"c": 1}}, "a.b")
+    assert ok is False
+    assert members == []
+
+
+def test_resolve_path_non_dict_intermediate_returns_false() -> None:
+    """Tier 2: scalar at a non-leaf position returns ([], False)."""
+    members, ok = _resolve_path({"a": 42}, "a.b")
+    assert ok is False
+    assert members == []
+
+
+def test_resolve_path_empty_path_returns_false() -> None:
+    """Tier 2: empty path string returns ([], False)."""
+    members, ok = _resolve_path({"a": 1}, "")
+    assert ok is False
+    assert members == []
+
+
+def test_resolve_path_empty_context_missing_key_returns_false() -> None:
+    """Tier 2: path into empty context returns ([], False)."""
+    members, ok = _resolve_path({}, "a.b")
+    assert ok is False
+    assert members == []
+
+
+def test_resolve_path_wildcard_on_non_list_returns_false() -> None:
+    """Tier 2: '[*]' on a non-list value returns ([], False)."""
+    members, ok = _resolve_path({"items": "not-a-list"}, "items[*].name")
+    assert ok is False
+    assert members == []


### PR DESCRIPTION
**[tui-coder]** part of #1830 — idle-mining Tier 2 coverage.

## What

10 Tier 2 tests for the untested `_resolve_path(context, path)` helper in `src/reyn/data/workspace/artifact_validator.py`.

This function traverses a nested context dict using a dotted-path expression and returns `(members, ok)`. It powers the `x-reyn-members-of` schema constraint used to validate artifact field membership against context values.

**Happy paths:**
- `"a.b"` → `(["value"], True)` (simple nested key)
- Single segment `"x"` → `([42], True)`
- List leaf `"a"` → `([1, 2, 3], True)` (list passthrough)
- `"items[*].name"` → `(["alpha", "beta"], True)` (wildcard array iteration)
- Nested wildcard `"a.items[*].n"` also works

**Error paths:**
- Missing key → `([], False)`
- Scalar at non-leaf position → `([], False)`
- Empty path `""` → `([], False)`
- Empty context with any path → `([], False)`
- `[*]` on non-list value → `([], False)`

## Tier self-check

- No `MagicMock`/`AsyncMock`/`patch` ✓
- No format pins ✓
- All docstrings declare `Tier 2:` ✓
- 4-gate CI: ruff ✓ / tier_audit --strict ✓ / pytest 10/10 ✓

## Test plan

- [x] `ruff check tests/test_artifact_validator_resolve_path.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_artifact_validator_resolve_path.py` — 10 OK / 0 errors
- [x] `pytest tests/test_artifact_validator_resolve_path.py -q` — 10 passed