### PR TITLE
fix(#2360): rewind the conversation, not just runtime state (WAL-anchored visible-prefix, tool-cycle-aware)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1797,7 +1797,7 @@ class Session:
         # compaction_controller=None here; patched below after construction.
         from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
         self._history_buffer = RouterHistoryBuffer(
-            history_fn=lambda: self.history,
+            history_fn=self._active_branch_history,
             compaction=self._compaction,
             compaction_controller=None,  # patched after CompactionController below
             # #1752: live resolved model — a /model override changes the context
@@ -2614,9 +2614,61 @@ class Session:
         if msg.role in ("user", "agent") and msg.seq == 0:
             msg.seq = self._next_seq
             self._next_seq += 1
+        # #2360: anchor each turn to the WAL seq at append time so the conversation
+        # rides the GLOBAL rewind/branch derivation (is_active_seq). Time-travel is
+        # global (checkout jumps the whole world's active cut), so a rewound world
+        # must hide conversation turns whose anchor is on an abandoned branch — else
+        # runtime state rewinds but the LLM still sees post-cut turns. meta is
+        # excluded from the wire dicts build_history emits, so wal_seq never reaches
+        # the LLM. Guarded on state_log presence (no WAL → no rewind → always visible)
+        # and skipped if already anchored (a re-append keeps its original anchor).
+        if self._state_log is not None and "wal_seq" not in msg.meta:
+            msg.meta["wal_seq"] = self._state_log.current_seq
         self.history.append(msg)
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
+
+    def _active_branch_history(self) -> "list[ChatMessage]":
+        """#2360: the conversation turns visible on the current active branch.
+
+        The LLM-facing ``build_history`` slices whatever this returns, so filtering
+        here makes the conversation follow the GLOBAL time-travel cut without
+        touching the append-only ``history.jsonl``. Each turn carries a WAL anchor
+        (``meta['wal_seq']``, stamped at append); a turn is visible iff its anchor is
+        on the active branch as-of the current rewind cut — reusing the WAL
+        branch-derivation (``is_active_seq``). Rewind moves the cut back (higher
+        anchors drop out); fork-switch makes an alternate branch's anchors active;
+        the future/other-branch turns stay in the file, just outside the visible
+        prefix. Turns without an anchor (pre-#2360 entries, or no state_log) are
+        always visible (backward-compatible, no migration)."""
+        if self._state_log is None:
+            return self.history
+        from reyn.core.events.snapshot_generations import is_active_seq
+
+        def _active(seq: "int | None") -> bool:
+            return seq is None or is_active_seq(self._state_log, seq)
+
+        # #2360 (tool-cycle-aware): a GLOBAL cut lands at a WAL seq that may be a turn boundary for
+        # the rewound session but fall MID-tool-cycle for another session's conversation (the
+        # assistant tool_calls turn's anchor ≤ cut while its tool result turns' anchors > cut, or
+        # the reverse). A flat per-turn filter would then emit a dangling tool_calls-without-results
+        # or tool-result-without-tool_calls → provider BadRequest (the #2290/#2289 adjacency class).
+        # So a tool cycle (an assistant tool_calls turn + its immediately-following tool result
+        # turns) is ONE atomic visible unit, governed by the assistant turn's anchor: the whole
+        # cycle is visible iff that anchor is active. Well-formed by construction.
+        out: list[ChatMessage] = []
+        governing_seq: "int | None" = None  # the open cycle's assistant-tool_calls anchor
+        cycle_open = False
+        for m in self.history:
+            if m.role == "tool" and cycle_open:
+                eff = governing_seq  # a tool result inherits its cycle's visibility
+            else:
+                eff = m.meta.get("wal_seq")
+                cycle_open = m.role == "assistant" and bool(m.tool_calls)
+                governing_seq = eff if cycle_open else None
+            if _active(eff):
+                out.append(m)
+        return out
 
     def _handle_sender_attribution(self, payload: object) -> None:
         """Surface a sender transition to the LLM as a state_change entry

--- a/tests/test_conversation_rewind_2360.py
+++ b/tests/test_conversation_rewind_2360.py
@@ -1,0 +1,208 @@
+"""Tier 2: #2360 — time-travel rewinds the CONVERSATION, not just runtime state.
+
+The append-only + branch/generation time-travel machinery existed only for the agent RUNTIME
+state; the conversation (``self.history`` / ``history.jsonl``) was outside it, so after ``/rewind``
+or fork-switch the LLM still saw post-cut turns. Fix (option 2, faithful to append-only): each turn
+is anchored to the WAL seq at append (``meta['wal_seq']``), and the LLM-facing ``build_history``
+source (``_active_branch_history``) filters turns to those whose anchor is on the ACTIVE branch
+as-of the current GLOBAL cut — reusing the WAL branch-derivation (``is_active_seq``).
+
+Rewind is GLOBAL (``checkout`` jumps the whole world's active cut; the reset-record has no
+session_id), so the conversation follows the same global cut the runtime state does — coherent.
+``history.jsonl`` stays append-only: futures/other-branches remain in the file, just outside the
+visible prefix.
+
+Real seam: real ``Session`` + real ``StateLog`` + the real ``checkout`` reset-record primitive (the
+same one ``AgentRegistry.checkout`` appends) driving the real ``is_active_seq`` derivation — no proxy.
+The WAL is advanced by a real ``step_completed`` append between turns so anchors differ (a bare
+history append does not advance the WAL), mirroring a real turn's WAL activity.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+
+
+def _session(tmp_path: Path, name: str, state_log: StateLog) -> Session:
+    s = Session(
+        agent_name=name, state_log=state_log,
+        snapshot_path=tmp_path / f"{name}_snapshot.json",
+    )
+    s.register_intervention_listener("test")
+    return s
+
+
+def _visible(session: Session) -> list[str]:
+    """The user/text turns the LLM actually sees — via the public build_history (the wire output
+    RouterLoop consumes), not the private filter, so the assertion rides the real end-to-end path."""
+    return [
+        m.get("content") for m in session._history_buffer.build_history()
+        if m.get("role") in ("user", "assistant") and isinstance(m.get("content"), str) and m.get("content")
+    ]
+
+
+def _dangling(wire: list[dict]) -> set:
+    """Tool_call ids and tool_call_ids in the wire payload that have no partner — the provider
+    BadRequest set (an assistant tool_calls turn without its results, or a tool result without its
+    call). Empty = well-formed."""
+    call_ids = {tc.get("id") for m in wire for tc in (m.get("tool_calls") or [])}
+    result_ids = {m.get("tool_call_id") for m in wire if m.get("role") == "tool"}
+    return call_ids ^ result_ids
+
+
+async def _tool_cycle(session: Session, state_log: StateLog, tc_id: str) -> tuple[int, int]:
+    """Append an assistant tool_calls turn then (after the WAL advances = the tool running) its
+    tool result turn. Returns (call_anchor, result_anchor) with result_anchor > call_anchor, so a
+    cut can land BETWEEN them (the mid-tool-cycle case)."""
+    await state_log.append("step_completed")
+    session._append_history(ChatMessage(
+        role="assistant", content="",
+        tool_calls=[{"id": tc_id, "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+    ))
+    call_anchor = session.history[-1].meta["wal_seq"]
+    await state_log.append("step_completed")  # the tool runs → WAL advances → later anchor
+    session._append_history(ChatMessage(role="tool", tool_call_id=tc_id, content="tool output"))
+    return call_anchor, session.history[-1].meta["wal_seq"]
+
+
+async def _turn(session: Session, state_log: StateLog, text: str) -> int:
+    """Simulate a real conversational turn: advance the WAL (turn processing), then append the
+    turn (stamped with the current WAL seq). Returns the turn's anchor."""
+    await state_log.append("step_completed")  # a real WAL kind → advances current_seq
+    session._append_history(ChatMessage(role="user", content=text))
+    return session.history[-1].meta["wal_seq"]
+
+
+@pytest.mark.asyncio
+async def test_rewind_hides_post_cut_turns_exactly(tmp_path, monkeypatch):
+    """Tier 2: rewind to after turn 3 → build_history's source shows EXACTLY turns 1,2,3 (4,5 hidden;
+    3 not over-hidden, 6 n/a). Anchor precision verified against the real is_active derivation."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 6)]
+
+    assert _visible(s) == [f"turn {i}" for i in range(1, 6)]  # all visible pre-rewind
+
+    await checkout(state_log, target_seq=anchors[2])  # keep through turn 3
+
+    assert _visible(s) == ["turn 1", "turn 2", "turn 3"], "exact prefix, 4/5 hidden"
+
+
+@pytest.mark.asyncio
+async def test_history_file_stays_append_only(tmp_path, monkeypatch):
+    """Tier 2: the hidden (post-cut) turns remain in history.jsonl — the rewind hides them from the
+    LLM but never truncates the append-only file (P6 audit + no-discard)."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 6)]
+    await checkout(state_log, target_seq=anchors[2])
+
+    raw = s.history_path.read_text()
+    assert "turn 4" in raw and "turn 5" in raw, "append-only: hidden turns still on disk"
+
+
+@pytest.mark.asyncio
+async def test_fork_switch_and_no_discard(tmp_path, monkeypatch):
+    """Tier 2: fork-switch + no-discard. Rewind to turn 3, add a new branch (6,7) → active shows
+    1,2,3,6,7. Switch BACK to the old tip (turn 5, on the now-abandoned branch → checkout revives
+    it) → active shows 1..5, and the 6,7 branch survives in the file (no discard)."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 6)]
+
+    await checkout(state_log, target_seq=anchors[2])  # rewind to after turn 3
+    await _turn(s, state_log, "turn 6")
+    await _turn(s, state_log, "turn 7")
+    assert _visible(s) == ["turn 1", "turn 2", "turn 3", "turn 6", "turn 7"]
+
+    await checkout(state_log, target_seq=anchors[4])  # switch back to the old tip (turn 5)
+    assert _visible(s) == [f"turn {i}" for i in range(1, 6)], "old future revived"
+    raw = s.history_path.read_text()
+    assert "turn 6" in raw and "turn 7" in raw, "no discard: the alternate branch survives in the file"
+
+
+@pytest.mark.asyncio
+async def test_global_cut_filters_each_session_own_view(tmp_path, monkeypatch):
+    """Tier 2: reframed (1) — rewind is GLOBAL, so a single world-cut filters EACH session's own
+    per-session history by that session's own anchors. Two sessions interleave turns; a global
+    checkout hides each session's post-cut turns (no session's history escapes the world-cut, and
+    each shows exactly its own anchored ≤ cut)."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    a = _session(tmp_path, "alice", state_log)
+    b = _session(tmp_path, "bob", state_log)
+
+    await _turn(a, state_log, "A1")
+    b1 = await _turn(b, state_log, "B1")
+    await _turn(a, state_log, "A2")
+    await _turn(b, state_log, "B2")
+
+    await checkout(state_log, target_seq=b1)  # world-cut just after B1 (A1 < B1 < A2 < B2)
+
+    assert _visible(a) == ["A1"], "alice: only her ≤-cut turn"
+    assert _visible(b) == ["B1"], "bob: only his ≤-cut turn"
+
+
+@pytest.mark.asyncio
+async def test_unanchored_turns_always_visible(tmp_path, monkeypatch):
+    """Tier 2: backward-compat — a turn with no wal_seq anchor (pre-#2360 entry, or no state_log) is
+    always visible, so existing history is unaffected and no migration is needed."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    a1 = await _turn(s, state_log, "anchored-1")
+    s.history.append(ChatMessage(role="user", content="legacy-no-anchor"))  # no wal_seq in meta
+    await _turn(s, state_log, "anchored-2")
+
+    await checkout(state_log, target_seq=a1)  # hides anchored-2
+
+    visible = _visible(s)
+    assert "legacy-no-anchor" in visible, "unanchored turns stay visible (no migration)"
+    assert "anchored-1" in visible and "anchored-2" not in visible
+
+
+@pytest.mark.asyncio
+async def test_mid_tool_cycle_cut_leaves_no_dangling(tmp_path, monkeypatch):
+    """Tier 2: #2360 tool-cycle-aware — a GLOBAL cut landing MID-tool-cycle (call anchor ≤ cut <
+    result anchor) must NOT emit a dangling tool_calls-without-results (provider BadRequest, the
+    #2290 class). The cycle is atomic: governed by the assistant tool_calls anchor, so an active
+    call pulls its later-anchored result into the visible payload. Real checkout + real build_history
+    wire output."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    u1 = await _turn(s, state_log, "please call the tool")
+    call_anchor, result_anchor = await _tool_cycle(s, state_log, "tc1")
+    assert result_anchor > call_anchor  # the cut can fall strictly between call and result
+
+    # cut lands mid-cycle (at the call anchor; the result's anchor is beyond it)
+    await checkout(state_log, target_seq=call_anchor)
+    wire = s._history_buffer.build_history()
+    assert _dangling(wire) == set(), "mid-cycle cut must leave a well-formed (dangling-free) payload"
+    assert any(m.get("role") == "tool" and m.get("tool_call_id") == "tc1" for m in wire), \
+        "the active call pulls its later-anchored result into the visible payload (cycle atomic)"
+
+
+@pytest.mark.asyncio
+async def test_cut_before_tool_cycle_hides_whole_cycle_no_dangling(tmp_path, monkeypatch):
+    """Tier 2: #2360 tool-cycle-aware — a cut BEFORE the assistant tool_calls turn hides the WHOLE
+    cycle (call + result), never a dangling tool result. The other direction of the same atomicity."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+    u1 = await _turn(s, state_log, "hello")
+    await _tool_cycle(s, state_log, "tc1")
+
+    await checkout(state_log, target_seq=u1)  # cut before the cycle
+    wire = s._history_buffer.build_history()
+    assert _dangling(wire) == set(), "cut before the cycle must leave no dangling tool result"
+    assert not any(m.get("role") == "tool" for m in wire), "the whole cycle is hidden (call+result)"


### PR DESCRIPTION
**[e2e-coder]** — Closes #2360. Owner design gap: time-travel rewinds runtime state but NOT the conversation.

## The gap (primary-verified)
The append-only + branch/generation time-travel machinery (`checkout` → reset-record → `is_active_seq` derivation → per-session `reconstruct`) existed only for the agent RUNTIME state (`AgentSnapshot`). The conversation lives on a separate flat `history.jsonl` outside that substrate — `AgentSnapshot` has no conversation field, `reset_for_rewind`/`restore_state` never touch `self.history`, and `build_history` re-reads the full `self.history`. **Consequence:** after `/rewind` or fork-switch, runtime state moves to as-of-N but the LLM still sees every post-cut turn.

## Load-bearing findings surfaced during flow-trace (both corrected the initial approach)
1. **Seq-space mismatch:** the conversation `_next_seq` is a per-session ordinal, NOT the WAL seq the branch-derivation (`is_active_seq`) operates on. So "reuse is_active on the conversation seq" is meaningless — each turn must be **anchored to a WAL seq**.
2. **Rewind is GLOBAL, not per-session:** `checkout` is "a global consistent-cut ... the whole world's active cut"; the reset-record has no session_id; every session reconstructs to the one cut. So the conversation must follow the *same global cut* the runtime state does — coherent (leaving one session's conversation in the future while its runtime rewound would be inconsistent). Per-session independent conversation rewind would be a large, incoherent separate change.

## Fix (option 2 — faithful to append-only)
- **Anchor** each turn at `_append_history`: `msg.meta["wal_seq"] = self._state_log.current_seq` (meta is excluded from the wire dicts `build_history` emits → never reaches the LLM; guarded on `state_log` presence; skipped if already anchored).
- **Filter** the LLM-facing `build_history` source (`_active_branch_history`) to turns whose anchor is active as-of the current cut — reusing the WAL `is_active_seq` derivation. `history.jsonl` stays **append-only**: rewound futures / other branches remain in the file, just outside the visible prefix. Rewind = move the cut back; fork-switch = the alternate branch's anchors become the visible prefix; no discard.
- **Backward-compat:** turns with no anchor (pre-#2360, or no `state_log`) are always visible — no migration.

## Tool-cycle-aware (owner's sharp addition — dangling-free by construction)
A global cut at a WAL seq may be a turn boundary for the rewound session but fall **mid-tool-cycle** for another session's conversation (the assistant `tool_calls` turn's anchor ≤ cut while its tool-result turns' anchors > cut). A flat per-turn filter would then emit a dangling `tool_calls`-without-results → provider BadRequest (the #2290/#2289 adjacency class). So the filter treats **an assistant `tool_calls` turn + its immediately-following tool-result turns as ONE atomic unit**, governed by the assistant turn's anchor — the whole cycle is visible or hidden together. Well-formed by construction.
- **Defense-in-depth (verified):** `build_history`'s output flows through `recorded_acompletion`, which calls `repair_tool_call_pairing` (`llm.py:1647`) — the LLM chokepoint repairs any residual dangling.

## Test plan (`tests/test_conversation_rewind_2360.py`, Tier 2 — real Session + real StateLog + real `checkout` reset-record → real `is_active` derivation, asserted through the public `build_history` wire output)
- [x] Rewind to after turn 3 → LLM sees EXACTLY turns 1,2,3 (anchor precision; 4,5 hidden, 3 not over-hidden)
- [x] `history.jsonl` stays append-only (hidden turns still on disk)
- [x] Fork-switch + no-discard (new branch visible; switch back revives the old future; the alternate branch survives in the file)
- [x] Global cut filters EACH session's own view (reframed item 1 — two sessions, one world-cut, each shows its own anchored ≤ cut)
- [x] Unanchored turns always visible (backward-compat, no migration)
- [x] **Mid-tool-cycle cut → no dangling** (the active call pulls its later-anchored result into the payload)
- [x] **Cut before a tool cycle → whole cycle hidden**, no dangling tool result
- [x] Falsify-verified both mechanisms: strip the filter → 4 RED; strip cycle-awareness → the mid-cycle dangling test RED
- [x] ruff / tier-audit (strict) / verify_module_docstrings green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
