### PR TITLE
feat(#2336): offload clean-payload format — store the dominant field raw, not JSON-of-JSON

### DIFF
--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -242,17 +242,30 @@ def offload_control_ir_result(
         return result
 
     offload_filename = f"{result_idx:04d}_{uuid.uuid4().hex[:8]}.json"
+    # #2336: producer-declares-payload. When the op result declares a dominant
+    # ``_offload_payload_field`` AND that field is the SOLE oversized field, store it
+    # CLEAN (raw text with real newlines / a clean array) instead of a JSON-of-JSON
+    # whole-dict envelope. Multi-large-field → whole-dict fallback (payload_field=None)
+    # so a non-dominant large field's full content is never dropped to preview-only
+    # (zero data-loss). P7-safe: the marker is op-supplied data, no op literal here.
+    declared_payload_field = result.get("_offload_payload_field")
+    use_clean_payload = bool(declared_payload_field) and _oversized_fields(result) == [declared_payload_field]
     offload_result = offload_value(
         result,
         store_dir=offload_dir,
         preview_strategy=_phase_preview_strategy,
         filename=offload_filename,
+        payload_field=declared_payload_field if use_clean_payload else None,
     )
 
     # The preview dict produced by _phase_preview_strategy is our inline.
     inline: dict = offload_result.preview
     # Attach content_hash for verified read-back (new in Phase 1).
     inline["_offload_content_hash"] = offload_result.content_hash
+    if use_clean_payload:
+        # Tell the reader the ref holds the raw field value (not the whole-dict envelope).
+        inline["_offload_payload_field"] = declared_payload_field
+        inline["_offload_ref_format"] = "raw_field"
     # #1209 (2): explicit machine-readable truncation status as a SEPARATE field
     # (the per-field previews already carry head+tail + total chars; this flags
     # the result as truncated without the model having to parse the content).

--- a/src/reyn/core/op_runtime/index_query.py
+++ b/src/reyn/core/op_runtime/index_query.py
@@ -102,7 +102,8 @@ async def handle(
         ) from exc
 
     mode = "semantic" if chunks else "fallback"
-    return {"chunks": [dict(c) for c in chunks], "mode": mode}
+    # #2336: offload the chunks array as a clean JSON array, not a whole-dict envelope.
+    return {"chunks": [dict(c) for c in chunks], "mode": mode, "_offload_payload_field": "chunks"}
 
 
 register("index_query", handle)

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -151,6 +151,9 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
         "content": text,
         "media_blocks": media_blocks,
         "raw": result,
+        # #2336: offload the joined text (what the LLM acts on) CLEAN. If ``raw`` is
+        # also oversized, the caller falls back to whole-dict (both preserved).
+        "_offload_payload_field": "content",
     }
 
 

--- a/src/reyn/core/op_runtime/recall.py
+++ b/src/reyn/core/op_runtime/recall.py
@@ -124,7 +124,8 @@ async def handle(
     else:
         mode = "mixed"
 
-    return {"chunks": stripped_chunks, "mode": mode}
+    # #2336: offload the chunks array as a clean JSON array, not a whole-dict envelope.
+    return {"chunks": stripped_chunks, "mode": mode, "_offload_payload_field": "chunks"}
 
 
 register("recall", handle)

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -134,6 +134,9 @@ async def handle(
         "stdout": stdout_text,
         "stderr": stderr_text,
         "truncated": result.truncated,
+        # #2336: offload stdout CLEAN. If stderr is also oversized (a huge crash
+        # trace), the caller falls back to whole-dict so stderr is not lost.
+        "_offload_payload_field": "stdout",
     }
 
 

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -499,6 +499,9 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext, caller: Literal["pr
         "start_index": op.start_index,
         "next_start": next_start,
         "total_length": total_length,
+        # #2336: if this result is offloaded, store the fetched text CLEAN (real
+        # newlines) rather than a JSON-of-JSON whole-dict envelope.
+        "_offload_payload_field": "content",
     }
 
 
@@ -531,6 +534,8 @@ async def handle_web_search(op: WebSearchIROp, ctx: OpContext, caller: Literal["
         "backend": op.backend,
         "status": "ok",
         "results": results,
+        # #2336: offload the results array as a clean JSON array, not a whole-dict envelope.
+        "_offload_payload_field": "results",
     }
 
 

--- a/src/reyn/services/offload/store.py
+++ b/src/reyn/services/offload/store.py
@@ -79,6 +79,7 @@ def offload_value(
     store_dir: Path,
     preview_strategy: Callable[[Any, str], Any] | None = None,
     filename: str | None = None,
+    payload_field: str | None = None,
 ) -> OffloadResult:
     """Write *value* to *store_dir* and return preview + path_ref + content_hash.
 
@@ -102,6 +103,19 @@ def offload_value(
                           ★ three-party preview-bound contract for details.
         filename:         Optional explicit filename. When omitted a unique name
                           is derived from a UUID fragment.
+        payload_field:    #2336 (producer-declares-payload). When set AND *value* is
+                          a dict carrying that field, the file stores THAT field's
+                          value CLEAN — a str payload is written raw (real newlines,
+                          not a JSON-escaped ``\\n`` inside a dict envelope; fixes the
+                          "JSON-of-JSON" read-back), a non-str payload is
+                          ``json.dumps``'d (a clean array/object, not the whole dict).
+                          The caller passes this only when the payload field is the
+                          sole oversized field (single-dominant); a multi-large-field
+                          result falls back to the whole-dict path (caller passes
+                          ``None``) so no non-dominant field's full content is lost.
+                          Absent / field missing → the whole-value serialisation.
+                          The preview (and thus the inline envelope) is always built
+                          over the WHOLE *value*, unchanged.
 
     Returns:
         :class:`OffloadResult` with preview (or ``None``), path_ref, content_hash.
@@ -113,7 +127,11 @@ def offload_value(
         filename = f"{uid}.json"
 
     dest = store_dir / filename
-    serialized = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
+    if payload_field is not None and isinstance(value, dict) and payload_field in value:
+        payload = value[payload_field]
+        serialized = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+    else:
+        serialized = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
     dest.write_text(serialized, encoding="utf-8")
 
     path_ref = str(dest)

--- a/tests/test_offload_payload_field_2336.py
+++ b/tests/test_offload_payload_field_2336.py
@@ -1,0 +1,110 @@
+"""Tier 2: #2336 — an offloaded op result stores the CLEAN dominant payload, not a JSON-of-JSON.
+
+The offloaded file used to hold ``json.dumps(whole_result_dict)`` — reading the ref gave a JSON
+envelope with the content collapsed to escaped ``\\n`` (owner concern 2). Fix (producer-declares-
+payload, mirrors #2296 ``_self_bounded`` — P7-safe): an op result declares ``_offload_payload_field``;
+when that field is the SOLE oversized field the file stores it CLEAN (a str raw with real newlines,
+a list/dict as a clean array/object). Multi-large-field → whole-dict fallback (zero data-loss: a
+non-dominant large field's full content is never dropped to preview-only).
+
+``read_offloaded`` is unchanged (reads text + verifies hash → clean content). The inline envelope +
+per-field preview are unchanged.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES as CAP
+from reyn.core.context_builder import offload_control_ir_result
+from reyn.services.offload.store import read_offloaded
+
+_BIG = "x" * (CAP + 4000)  # a single field well over the 8 KB per-field threshold
+
+
+def _offload(result: dict, tmp_path: Path) -> dict:
+    return offload_control_ir_result(result, 0, tmp_path)  # default cap = the 8 KB floor
+
+
+def _raw(inline: dict) -> str:
+    return Path(inline["_offload_ref"]).read_text(encoding="utf-8")
+
+
+def test_marker_str_payload_stored_raw_not_json_envelope(tmp_path):
+    """Tier 2: a marker + oversized str → the offload file is RAW content, not a ``{"kind":...}``
+    whole-dict envelope. RED on main (whole-dict), GREEN after."""
+    result = {"kind": "web_fetch", "url": "http://x", "status": "ok",
+              "content": _BIG, "_offload_payload_field": "content"}
+    inline = _offload(result, tmp_path)
+    raw = _raw(inline)
+    assert not raw.startswith("{"), "the file must be raw content, not a JSON dict envelope"
+    assert raw == _BIG, "the file is exactly the clean payload"
+    assert inline["_offload_ref_format"] == "raw_field"
+    assert inline["_offload_payload_field"] == "content"
+
+
+def test_read_back_returns_clean_content(tmp_path):
+    """Tier 2: read_offloaded returns the clean content (hash-verified), with no dict envelope."""
+    result = {"kind": "web_fetch", "url": "http://x", "status": "ok",
+              "content": _BIG, "_offload_payload_field": "content"}
+    inline = _offload(result, tmp_path)
+    content, _ = read_offloaded(
+        inline["_offload_ref"], base_dir=tmp_path, content_hash=inline["_offload_content_hash"],
+    )
+    assert content == _BIG
+    assert '"kind"' not in content, "clean payload, no whole-dict envelope"
+
+
+def test_list_payload_stored_as_clean_json_array(tmp_path):
+    """Tier 2: a list payload → the file is a clean JSON array (not a whole-dict envelope)."""
+    results = [{"title": f"t{i}", "body": "b" * 400} for i in range(40)]
+    result = {"kind": "web_search", "query": "q", "status": "ok",
+              "results": results, "_offload_payload_field": "results"}
+    inline = _offload(result, tmp_path)
+    raw = _raw(inline)
+    parsed = json.loads(raw)
+    assert parsed == results, "the file is the clean results array (round-trips), not a whole-dict"
+    assert not raw.lstrip().startswith("{"), "no whole-dict envelope wrapping the array"
+
+
+def test_no_marker_falls_back_to_whole_dict(tmp_path):
+    """Tier 2: a result with NO marker keeps the existing whole-dict json fallback (unchanged)."""
+    result = {"kind": "custom", "status": "ok", "blob": _BIG}  # no _offload_payload_field
+    inline = _offload(result, tmp_path)
+    raw = _raw(inline)
+    assert raw.startswith("{") and '"kind"' in raw, "whole-dict fallback preserved"
+    assert "_offload_ref_format" not in inline
+
+
+def test_inline_keeps_envelope_and_preview_not_full_payload(tmp_path):
+    """Tier 2: the inline still carries the envelope fields + a bounded content PREVIEW (not the
+    full payload)."""
+    result = {"kind": "web_fetch", "url": "http://x", "status": "ok",
+              "content": _BIG, "_offload_payload_field": "content"}
+    inline = _offload(result, tmp_path)
+    assert inline["kind"] == "web_fetch" and inline["status"] == "ok" and inline["url"] == "http://x"
+    assert len(json.dumps(inline)) <= CAP, "inline is bounded (a preview, not the full payload)"
+    assert inline.get("content", "") != _BIG, "the full payload is not inlined"
+
+
+def test_multiline_str_payload_has_real_newlines(tmp_path):
+    """Tier 2: owner concern 2 — a multi-line str payload → the file has REAL newlines, not escaped
+    ``\\n`` inside a JSON string."""
+    content = "".join(f"line {i}\n" for i in range(2000))  # ~ many real newlines, > cap
+    result = {"kind": "web_fetch", "url": "http://x", "status": "ok",
+              "content": content, "_offload_payload_field": "content"}
+    raw = _raw(_offload(result, tmp_path))
+    assert raw.count("\n") == content.count("\n"), "real newlines preserved (not collapsed)"
+    assert "\\n" not in raw, "no JSON-escaped newlines (the JSON-of-JSON symptom)"
+
+
+def test_multi_large_field_falls_back_to_whole_dict_no_data_loss(tmp_path):
+    """Tier 2: when 2+ fields are oversized, fall back to whole-dict so the NON-dominant large
+    field's full content is preserved (zero data-loss), even with a marker."""
+    result = {"kind": "mcp", "status": "ok", "content": "C" * (CAP + 2000),
+              "raw": {"big": "R" * (CAP + 2000)}, "_offload_payload_field": "content"}
+    inline = _offload(result, tmp_path)
+    raw = _raw(inline)
+    assert raw.startswith("{") and '"kind"' in raw, "multi-large → whole-dict envelope"
+    assert "C" * (CAP + 2000) in raw and "R" * (CAP + 2000) in raw, "BOTH large fields preserved full"
+    assert "_offload_ref_format" not in inline, "not the raw-field format (fell back)"


### PR DESCRIPTION
**[e2e-coder]** — Closes #2336. Owner-approved: the offloaded file should store the CLEAN payload (raw text, real newlines), not a JSON-of-JSON whole-dict.

## The gap
When a control_ir op result is offloaded, the file stored `json.dumps(whole_result_dict)` — reading the ref gave a JSON envelope with the content collapsed to escaped `\n` (owner concern 2), and list/dict payloads wrapped in the whole dict.

## Design (producer-declares-payload — P7-safe, mirrors #2296 `_self_bounded`)
An op result declares `"_offload_payload_field": "<field>"`. The generic OS offload reads it (the field NAME is op-supplied data — no op literal in OS code) and, **when that field is the sole oversized field**, writes THAT field's value clean:
- **str** payload → raw UTF-8 (real newlines — fixes owner concern 2)
- **list/dict** payload → `json.dumps(payload)` (a clean array/object, not the whole dict)

**Multi-large-field → whole-dict fallback (lead decision, zero data-loss):** if 2+ fields are oversized (e.g. a huge `stdout` AND a huge `stderr`, or mcp `content` + `raw`), the whole-dict path is kept so the non-dominant large field's full content is never dropped to preview-only. The single-dominant case (the common case) is strictly better; the multi-large edge loses nothing.

## Changes
- `services/offload/store.py` `offload_value`: new `payload_field` param — writes the clean field when set + present; else the existing whole-value serialisation. `content_hash` = sha256 of the clean bytes. The preview (inline envelope) is always built over the WHOLE value, unchanged. `read_offloaded` unchanged.
- `core/context_builder.py` `offload_control_ir_result`: `use_clean_payload = marker present AND _oversized_fields(result) == [marker]` (the single-dominant guard); passes `payload_field` to `offload_value`; adds `inline["_offload_payload_field"]` + `inline["_offload_ref_format"]="raw_field"` so the reader knows the ref holds the raw field. (In production `cap ≥ 8 KB floor = _FIELD_KEEP_THRESHOLD`, so "oversized" and "over cap" coincide.)
- Per-op markers: web_fetch (`content`, text path only — the binary path returns `content:""`), web_search (`results`), mcp (`content`; `raw` stays inline-previewed), sandboxed_exec (`stdout`; `stderr` inline), recall / index_query (`chunks`). `file.read` is `_self_bounded` (never offloads) → no marker. run_skill/task/judge omit the marker → whole-dict fallback.

## Test plan (`tests/test_offload_payload_field_2336.py`, Tier 2)
- [x] marker + oversized str → file is RAW content, `_offload_ref_format=="raw_field"` (RED on main)
- [x] read-back returns clean content (hash-verified), no envelope
- [x] list payload → clean JSON array (round-trips), no envelope
- [x] no marker → whole-dict json fallback preserved
- [x] inline keeps envelope (kind/url/status) + bounded content PREVIEW (not full payload)
- [x] owner concern 2: multi-line str payload → REAL newlines in the file (no escaped `\n`)
- [x] multi-large-field → whole-dict fallback, BOTH large fields preserved full (zero data-loss)
- [x] Falsify-verified: disabling the clean path → the 4 clean-payload tests RED
- [x] ruff / tier-audit (strict, 7 OK) / verify_module_docstrings green; 293-test offload/op regression green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
