### PR TITLE
test(#2339): deflake test_postprocessor_mid_run_chain_timeout_fires (durable-WAL-event wait)

### DIFF
--- a/tests/test_skill_postprocessor_chain.py
+++ b/tests/test_skill_postprocessor_chain.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper (#2339 deflake)
 
 from reyn.config import SafetyConfig, TimeoutConfig
 from reyn.core.events.state_log import StateLog
@@ -426,8 +427,24 @@ def test_postprocessor_mid_run_chain_timeout_fires(
         # Stash chain_id (as spawn path would)
         sess_b.running_skills_chain["run_b_timeout_001"] = "chain-timeout-post-001"
 
-        # Wait for the watchdog to fire (0.05s + a small margin)
-        await asyncio.sleep(0.15)
+        # #2339: poll until the watchdog has fully fired, instead of a fixed 0.15s magic margin
+        # (chain_seconds=0.05 + slack) that races the timer under CI load. The predicate is the
+        # DURABLE chain_timeout_fired WAL event — the SPECIFIC condition the WAL assert below pins
+        # (#2279 discipline). Empirically two things race, not one: (a) the 0.05s timer firing LATE
+        # vs the 0.15s sleep (the chain force-resolve), AND (b) the watchdog's chain_timeout_fired
+        # WAL append being fire-and-forget — asyncio.run(go())'s shutdown does NOT reliably drain
+        # it (3/15 spurious reds on the WAL assert even after fixing (a) alone). Waiting on the
+        # durable WAL event covers BOTH: the event is emitted with the force-resolve, so its
+        # presence implies the chain is resolved too. Bounded; on a genuine stall wait_until returns
+        # False and both asserts still fail truthfully.
+        def _timeout_fired_durable() -> bool:
+            return any(
+                e.get("kind") == "chain_timeout_fired"
+                and e.get("chain_id") == "chain-timeout-post-001"
+                for e in state_log.iter_from(0)
+            )
+
+        await wait_until(_timeout_fired_durable)
 
     asyncio.run(go())
 


### PR DESCRIPTION
**[e2e-coder]** — Closes #2339. Deflakes `test_postprocessor_mid_run_chain_timeout_fires` (blocks #2312).

## What the issue diagnosed
`await asyncio.sleep(0.15)` waits for a `chain_seconds=0.05` watchdog; under CI load the timer fires late (>0.15s) → the chain isn't force-resolved at the assert → spurious red. The issue proposed `wait_until(chain force-resolved)` and stated "the WAL read is NOT racy (drained by `asyncio.run(go())`'s shutdown)".

## What I found (empirically — the diagnosis was incomplete)
There are **two** races, not one. Replacing the sleep with `wait_until(sess_a.chains.find_chain(...) is None)` — the in-memory chain-resolve — **still failed 3/15**, and on the **WAL assert** (line 454, `chain_timeout_fired` missing), not the chain assert:
- **(a)** the 0.05s timer firing late vs the 0.15s sleep → chain not resolved (the diagnosed race).
- **(b)** the watchdog's `chain_timeout_fired` WAL append is **fire-and-forget**; `asyncio.run(go())`'s shutdown does **not** reliably drain it.

Worse, the in-memory-proxy fix **returns earlier** than the old 0.15s sleep, giving the fire-and-forget append even less time → it made (b) *more* frequent. This is exactly the #2279 false-barrier: an in-memory proxy is not the durable condition the assert pins.

## Fix (correct per the #2279 discipline)
The `wait_until` predicate is the **durable `chain_timeout_fired` WAL event itself** — poll `state_log.iter_from(0)` until the specific asserted event is durable. It covers both races (the event is emitted with the force-resolve, so its presence implies the chain is resolved). Bounded (5s); on a genuine stall `wait_until` returns False and both asserts fail truthfully. The asserts are unchanged (tightened the wait, not loosened the check).

## Falsify
- Original `sleep(0.15)`: flaky (timer race).
- Naive `wait_until(chain resolved in-memory)`: **3/15 fail** on the WAL assert (the second race, worsened).
- `wait_until(chain_timeout_fired durable)`: **20/20 consecutive green**.

## Test plan
- [x] 20/20 consecutive green (was 3/15 fail with the in-memory predicate)
- [x] Full file green (3 tests); ruff / tier-audit (strict, 3 OK) green
- [ ] Full suite (running) — test-only change (1 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
