### PR TITLE
fix(#2372): MCP hot-reload — installed server's tools go live same-session (roster re-read + install trigger)

### DIFF
--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -540,6 +540,18 @@ async def handle(
         # NOTE: env values are NOT emitted — only key names for audit
     )
 
+    # ── 7. #2372: schedule a hot-reload so the installed server's tools go live in the
+    # SAME chat session (no restart). The mcp seam (_reapply_mcp → refresh_mcp_servers)
+    # re-reads the roster from the config cascade — which merges the IN-set just written —
+    # and re-probes tools at the next turn boundary. Next-turn is the effective granularity:
+    # the LLM tool catalog is rebuilt per-turn, so same-turn would buy nothing. Best-effort:
+    # no active reloader (CLI `reyn mcp install` runs in a separate process; a phase/tool
+    # ctx has none) → no-op, and a restart / yaml mtime-watch still surfaces it.
+    from reyn.runtime.hot_reload import get_active_hot_reloader  # noqa: PLC0415
+    _reloader = get_active_hot_reloader()
+    if _reloader is not None:
+        _reloader.request_reload(source="mcp_install")
+
     return {
         "kind": "mcp_install",
         "status": "ok",

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3072,6 +3072,24 @@ class Session:
         # Snapshot the cache before the chain so we can detect a swap.
         snapshot_before = self._router_host.mcp_tools_cache_snapshot
 
+        # #2372: re-read the server ROSTER from the config cascade BEFORE the tool-probe
+        # chain. Refreshing the tools cache alone is insufficient — the LLM-facing
+        # enumeration (_get_mcp_servers_for_router → _mcp_servers_flat) gates on the roster,
+        # which is otherwise frozen at ctor (self._mcp_servers → adapter). A server installed
+        # mid-session (mcp_install writes the IN-set .reyn/config/mcp.yaml) has no roster entry
+        # to attach its tools to → never enumerated. load_config's cascade MERGES that IN-set
+        # (loader.py: dynamic_mcp), so re-reading here picks up the install. Multi-holder swap
+        # (mirrors _reapply_per_agent_capability): the Session field AND the adapter's roster —
+        # the enumeration reads the adapter's. Best-effort: a re-read failure keeps the old
+        # roster (never breaks the refresh).
+        try:
+            from reyn.config.loader import load_config
+            fresh_roster = load_config(self._hot_reload_project_root()).mcp
+            self._mcp_servers = fresh_roster
+            self._router_host._mcp_servers = fresh_roster
+        except Exception as exc:  # noqa: BLE001 — roster re-read is best-effort
+            logger.warning("refresh_mcp_servers: roster re-read failed: %r", exc)
+
         try:
             # Step 1 (S2): yaml mtime watch — re-probes when any yaml changed.
             await self._router_host.maybe_refresh_mcp_tools_from_yaml()

--- a/tests/test_mcp_hot_reload_2372.py
+++ b/tests/test_mcp_hot_reload_2372.py
@@ -1,0 +1,89 @@
+"""Tier 2: #2372 — installing an MCP server surfaces its tools within the same session (no restart).
+
+Two gaps made MCP install require a restart: (1) mcp_install triggered no refresh, and (2) the
+server ROSTER (`RouterHostAdapter._mcp_servers`, gating the LLM-facing enumeration) was frozen at
+ctor. Fix: `refresh_mcp_servers` re-reads the roster from the config cascade (which merges the
+IN-set `.reyn/config/mcp.yaml` that mcp_install writes) BEFORE the tool-probe chain, swapping both
+the Session field and the adapter's roster; and mcp_install schedules a hot-reload so the mcp seam
+(`_reapply_mcp` → `refresh_mcp_servers`) runs at the next turn boundary. Refreshing the tools cache
+alone is insufficient — a server absent from the roster has no entry to attach its tools to.
+
+The falsify exercises the roster re-read directly (the load-bearing gap-2 fix): a server written to
+the IN-set mid-session appears in the router enumeration after `refresh_mcp_servers`, no restart.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+
+
+def _session(tmp_path: Path) -> Session:
+    # load_config resolves the project root by walking up for reyn.yaml (the marker gating the
+    # dynamic .reyn/config/mcp.yaml read); a Reyn project always has one.
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    s = Session(
+        agent_name="alice", state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    s.register_intervention_listener("test")
+    return s
+
+
+def _install_server_in_config(tmp_path: Path, name: str) -> None:
+    """Write a new MCP server to the IN-set `.reyn/config/mcp.yaml` (where mcp_install writes)."""
+    cfg = tmp_path / ".reyn" / "config" / "mcp.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        yaml.safe_dump({"mcp": {"servers": {name: {"command": "/nonexistent", "description": "d"}}}}),
+        encoding="utf-8",
+    )
+
+
+def _server_names(session: Session) -> list[str]:
+    return [s["name"] for s in session._router_host.get_mcp_servers()]
+
+
+@pytest.mark.asyncio
+async def test_installed_server_appears_after_refresh_without_restart(tmp_path, monkeypatch):
+    """Tier 2: a server installed mid-session (written to the IN-set) is enumerated by the router
+    after refresh_mcp_servers — no restart. RED today (roster frozen at ctor → not enumerated),
+    GREEN after (roster re-read from the cascade)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session(tmp_path)
+    assert "gh" not in _server_names(session)  # absent before install
+
+    _install_server_in_config(tmp_path, "gh")
+    await session.refresh_mcp_servers()
+
+    assert "gh" in _server_names(session), "the installed server must be enumerated without a restart"
+
+
+@pytest.mark.asyncio
+async def test_install_is_additive_existing_servers_survive(tmp_path, monkeypatch):
+    """Tier 2: installing a second server does NOT drop the first — the roster re-read is the full
+    cascade, so a mid-session install is additive (no regression to already-configured servers)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session(tmp_path)
+
+    _install_server_in_config(tmp_path, "srv1")
+    await session.refresh_mcp_servers()
+    assert _server_names(session) == ["srv1"] or "srv1" in _server_names(session)
+
+    # a second install adds to the file (mirrors mcp_install's merge) → both must enumerate
+    cfg = tmp_path / ".reyn" / "config" / "mcp.yaml"
+    cfg.write_text(
+        yaml.safe_dump({"mcp": {"servers": {
+            "srv1": {"command": "/nonexistent", "description": "d1"},
+            "srv2": {"command": "/nonexistent", "description": "d2"},
+        }}}),
+        encoding="utf-8",
+    )
+    await session.refresh_mcp_servers()
+
+    names = _server_names(session)
+    assert "srv1" in names and "srv2" in names, "install is additive — existing servers survive"


### PR DESCRIPTION
**[e2e-coder]** — Closes #2372. Owner-reported: installing an MCP server from within Reyn didn't surface its tools until a restart.

## Two gaps (primary-verified)
1. **Install triggered no refresh** — `mcp_install` writes the server into the IN-set `.reyn/config/mcp.yaml` + emits `mcp_server_installed`, but never requested a reload/refresh.
2. **The server ROSTER was frozen at ctor** — `self._mcp_servers` (session.py) → `RouterHostAdapter._mcp_servers` is set once at construction. The LLM-facing enumeration (`_get_mcp_servers_for_router` → `_mcp_servers_flat`) gates on that roster, so a server installed after startup had no roster entry to attach its tools to → never enumerated, even though the tools *cache* refreshes each turn.

## Fix
- **Roster re-read in `refresh_mcp_servers`** (before the tool-probe chain): `load_config(project_root).mcp` re-reads the full config cascade — which merges the IN-set `.reyn/config/mcp.yaml` the install wrote (loader.py `dynamic_mcp`) — and swaps **both** the Session field and the adapter's roster (multi-holder, mirroring `_reapply_per_agent_capability`; the enumeration reads the adapter's). Refreshing the tools cache alone was insufficient.
  - *IN/OUT nuance (verified):* the HotReloader's `apply_pending` re-reads only the IN-set and its `_reapply_mcp` seam calls `refresh_mcp_servers()` with no `in_set` arg — so the roster re-read is independent (`load_config` full cascade), correctly picking up the install.
- **Trigger from `mcp_install`**: after the config write, `get_active_hot_reloader().request_reload(source="mcp_install")` schedules the mcp seam at the next turn boundary. **Next-turn is the effective granularity** — the LLM tool catalog is rebuilt per turn, so same-turn would buy nothing (chosen over a new synchronous handle: option A, lead-confirmed). Best-effort: no active reloader (CLI `reyn mcp install` runs in a separate process; a phase/tool ctx has none) → no-op.

## Scope notes
- **No independent slash MCP-install path exists** (owner ask): the only in-session install is the `mcp_install` op (LLM-driven); `reyn mcp install` is a thin CLI wrapper that forwards to the same op in a separate `reyn run` process (cross-process → restart/mtime-watch domain, out of scope). So covering the op trigger covers in-session install.
- **Separate latent gap (out of scope):** the per-turn `maybe_refresh_mcp_tools_from_yaml` mtime-watch refreshes only the tools cache and watches the OUT-set, not the IN-set `.reyn/config/mcp.yaml` — so an install picked up via mtime (not the explicit trigger) wouldn't refresh the roster. The explicit trigger fixes the install case deterministically.

## Test plan (`tests/test_mcp_hot_reload_2372.py`, Tier 2)
- [x] Server installed mid-session (written to the IN-set) → enumerated by the router after `refresh_mcp_servers`, no restart (RED today — roster frozen)
- [x] Install is additive — a second install doesn't drop the first (no regression)
- [x] Falsify-verified: disable the roster re-read → both tests RED
- [x] ruff / tier-audit (strict, 2 OK) / verify_module_docstrings green; 593-test mcp regression green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
