### PR TITLE
fix(inline): model picker ▸ marker never shown when no model override set

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -108,8 +108,12 @@ def _model_expansion(snap, dispatch):
     classes = list(snap.get("model_classes") or [])
     if not classes:
         return DetailElement(lambda: [f"current: {snap['model']}", "change with /model"])
-    model = snap["model"]
-    rows = [f"▸ {c}" if c == model else f"  {c}" for c in classes]
+    # Use the pre-resolved class name: when no override is set, snap["model"] is
+    # the full LiteLLM model ID (e.g. "claude-opus-4-8") which never matches any
+    # class name ("opus") → the ▸ marker never appeared. active_model_class()
+    # reverse-looks up the class so the active entry is always highlighted.
+    active = snap.get("model_active_class") or snap["model"]
+    rows = [f"▸ {c}" if c == active else f"  {c}" for c in classes]
     return CommandUIElement(rows, [f"/model {c}" for c in classes], dispatch)
 
 
@@ -399,6 +403,7 @@ def _snapshot(registry, task_cache=None, config=None):
     )
     return {
         "model": s.model,
+        "model_active_class": s.active_model_class(),
         "model_classes": list(s.known_model_classes()),
         "agent_names": list(registry.loaded_names()),
         "attached_name": registry.attached_name,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2039,6 +2039,25 @@ class Session:
         """
         return self._resolver.known_classes()
 
+    def active_model_class(self) -> str | None:
+        """Return the class name for the currently-active model, or None.
+
+        When a ``/model`` override is active the override IS already a class name.
+        When no override is set ``session.model`` is the full LiteLLM model ID
+        (e.g. ``"claude-opus-4-8"``); this reverse-looks up which configured
+        class maps to that ID so callers (e.g. the model picker) can highlight
+        the active entry without knowing about the resolver internals.
+        Returns None when the current model ID is not found in any configured
+        class (= custom/passthrough model not declared in reyn.yaml).
+        """
+        if self._model_override is not None:
+            return self._model_override
+        model_id = self._agent.model
+        for cls in self._resolver.known_classes():
+            if self._resolver.resolve(cls).model == model_id:
+                return cls
+        return None
+
     def _rebuild_turn_budget_engine_for_model(self) -> None:
         """#1752: rebuild the chat turn_budget engine for the active model.
 

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -146,6 +146,46 @@ def test_session_model_override_cleared_returns_agent_default(tmp_path):
     assert session.model == "standard"  # agent default restored
 
 
+def test_session_active_model_class_returns_override_when_set(tmp_path):
+    """Tier 2: active_model_class() returns the override class name when set.
+
+    Falsification: if the method did not short-circuit on _model_override, the
+    reverse-lookup loop would run and might return a different value (or None).
+    """
+    session = _make_session(tmp_path, model="standard")
+    session._resolver = _make_resolver()
+    session._model_override = "light"
+    assert session.active_model_class() == "light"
+
+
+def test_session_active_model_class_reverse_lookup_no_override(tmp_path):
+    """Tier 2: active_model_class() reverse-looks up the class when no override.
+
+    The agent's model is the full LiteLLM model ID "openai/gpt-4o"; the resolver
+    maps "standard" → "openai/gpt-4o". Pre-fix, callers compared this full ID
+    against class names and got no match (▸ never appeared in the model picker).
+
+    Falsification: if the reverse-lookup were absent (returning None unconditionally
+    on no-override), this assertion would fail.
+    """
+    session = _make_session(tmp_path, model="openai/gpt-4o")
+    session._resolver = _make_resolver()  # "standard" → "openai/gpt-4o"
+    # No override set — fresh session has no model_override by construction.
+    assert session.active_model_class() == "standard"
+
+
+def test_session_active_model_class_returns_none_for_unknown_model(tmp_path):
+    """Tier 2: active_model_class() returns None when the agent model is not in
+    any configured class (= passthrough / custom model).
+
+    Falsification: if the method returned the raw model ID instead of None, the
+    model picker would show a phantom ▸ on a non-class entry.
+    """
+    session = _make_session(tmp_path, model="custom/bespoke-model-v9")
+    session._resolver = _make_resolver()  # no "custom/bespoke-model-v9" entry
+    assert session.active_model_class() is None
+
+
 # ===========================================================================
 # Group B1: no-arg display — real Session (reads session.model)
 # ===========================================================================


### PR DESCRIPTION
**[tui-coder]** — bug mining find (inline CUI UX)

## Root cause

`_model_expansion()` in `src/reyn/interfaces/inline/app.py` compares
`snap["model"]` against class names from `snap["model_classes"]`:

```python
model = snap["model"]  # "claude-opus-4-8" (no override)
rows = [f"▸ {c}" if c == model else f"  {c}" for c in classes]
# classes = ["haiku", "opus", "sonnet"]
# "opus" == "claude-opus-4-8" → False — ▸ never appears
```

`snap["model"]` is `session.model` which returns the full LiteLLM model ID
(`"claude-opus-4-8"`) when no `/model` override is active. Class names are
short strings (`"opus"`). The comparison always fails → the active-model
`▸` marker is invisible to users who haven't run `/model` (= most users).

When an override IS set, `session.model` = class name = comparison works.

## Fix

1. **`Session.active_model_class()`** (new public method) — returns the class
   name for the current model:
   - Override active → returns the override (it IS already a class name)
   - No override → reverse-looks up which configured class maps to the agent's
     full model ID via `ModelResolver.known_classes()` + `resolve(cls).model`
   - Unknown/passthrough model → returns `None` (no `▸` shown)

2. **`_snapshot()` adds `"model_active_class"`** — populated via
   `s.active_model_class()` so the UI has the pre-resolved class name.

3. **`_model_expansion()` uses `model_active_class`** — `active = snap.get("model_active_class") or snap["model"]` for the comparison.

## Tests

3 new Tier 2 tests added to `tests/test_slash_model.py` Group A:
- `test_session_active_model_class_returns_override_when_set` — override → class name
- `test_session_active_model_class_reverse_lookup_no_override` — no override + match → class
- `test_session_active_model_class_returns_none_for_unknown_model` — passthrough → None

## Test plan

- [x] `ruff check src/reyn/runtime/session.py src/reyn/interfaces/inline/app.py tests/test_slash_model.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_slash_model.py` — OK (12/12, no Tier 4)
- [x] `pytest tests/test_slash_model.py` — 12 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/interfaces/inline/app.py` — OK

Tier self-check: 3 new Tier 2 tests, real `Session` instances, public surface assert, first docstring declares Tier. No Tier 4.

part of bug-mining wave (lead-coder directive)