### PR TITLE
test(#2374): verify the hot-reload two-path contract for cron/hooks/skills (already-live; two-path doc)

### DIFF
--- a/tests/test_hotreload_cron_hooks_skills_2374.py
+++ b/tests/test_hotreload_cron_hooks_skills_2374.py
@@ -1,0 +1,97 @@
+"""Tier 2: #2374 — the hot-reload two-path contract for cron / hooks / skills.
+
+The two-path principle (settled with owner, established by #2372 MCP): a config edit's reload
+behavior depends on WHO edits it —
+  - CLI edit (`reyn ...`) → writes the OUT-set (reyn.yaml) → restart to take effect.
+  - LLM-tool / slash edit → writes the IN-set (.reyn/config/{cron,hooks}.yaml, or a skill file) →
+    live within the same session (next turn), no restart.
+
+The MCP roster-frozen gap (#2372) was MCP-SPECIFIC (the server roster was cached at ctor and gated
+the enumeration). cron / hooks / skills satisfy the tool/slash-live intent via their OWN mechanisms
+— so this is verify-first: each test proves the domain takes effect mid-session without restart
+(GREEN = already live, the regression guard + two-path documentation). A RED would mark a genuine
+MCP-class gap to fix. These tests upgrade the flow-trace inference to run-verified.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.runtime.cron.scheduler import CronScheduler, set_active_scheduler
+from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
+from reyn.runtime.session import enumerate_available_skills
+from reyn.tools.cron import _handle_cron_register
+from reyn.tools.hooks import _handle_hooks_add
+from reyn.tools.types import ToolContext
+
+
+def _names(entries: list[dict]) -> set[str]:
+    return {e["name"] for e in entries}
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(
+        events=EventLog(), permission_resolver=None,
+        workspace=SimpleNamespace(base_dir=tmp_path, root=tmp_path), caller_kind="router",
+    )
+
+
+def test_skills_are_filesystem_live_no_reload(tmp_path, monkeypatch):
+    """Tier 2: a skill authored mid-session (a new skill.md under reyn/project) is enumerated on the
+    NEXT enumeration WITHOUT any reload — skills resolve filesystem-live (enumerate_available_skills
+    walks reyn/project → reyn/local → stdlib per call), like agent discovery. No config.yaml, no
+    ctor-frozen roster → no MCP-class gap. GREEN = already live (the two-path 'tool-side' behavior)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn" / "project").mkdir(parents=True)
+    assert "hotskill" not in _names(enumerate_available_skills(set()))  # absent before authoring
+
+    d = tmp_path / "reyn" / "project" / "hotskill"
+    d.mkdir()
+    (d / "skill.md").write_text(
+        "---\nname: hotskill\ndescription: a mid-session skill\n---\n# body\n", encoding="utf-8",
+    )
+
+    # no reload / no request_reload — the very next enumeration sees it (filesystem-live)
+    assert "hotskill" in _names(enumerate_available_skills(set())), \
+        "a new skill file must be visible next turn without a restart (filesystem-live)"
+
+
+@pytest.mark.asyncio
+async def test_cron_tool_add_is_live_via_scheduler_no_restart(tmp_path, monkeypatch):
+    """Tier 2: a cron job added by the tool mid-session is registered LIVE on the active scheduler
+    (next fire reflects it, no restart) AND persisted to the IN-set .reyn/config/cron.yaml. cron's
+    own mechanism (direct get_active_scheduler().add_job) satisfies the tool/slash-live intent — no
+    MCP-class roster-freeze. GREEN = already live. (CLI edits reyn.yaml → restart, unchanged.)"""
+    monkeypatch.chdir(tmp_path)
+    sched = CronScheduler([])
+    set_active_scheduler(sched)
+    try:
+        res = await _handle_cron_register(
+            {"name": "j1", "to": "alice", "message": "hi", "schedule": "* * * * *"}, _ctx(tmp_path),
+        )
+        assert (tmp_path / ".reyn" / "config" / "cron.yaml").exists(), "IN-set write"
+        assert sched.get_job("j1") is not None, "the scheduler has the job LIVE (no restart)"
+        assert res["live_update_applied"] is True
+    finally:
+        set_active_scheduler(None)
+
+
+@pytest.mark.asyncio
+async def test_hooks_tool_add_writes_inset_and_schedules_reload(tmp_path, monkeypatch):
+    """Tier 2: a hook added by the tool mid-session is persisted to the IN-set .reyn/config/hooks.yaml
+    (structurally cannot target reyn.yaml) AND schedules a hot-reload (request_reload → next-turn
+    apply_pending → _reapply_hooks rebuilds the live registry). hooks already wires the MCP-style
+    trigger. GREEN = already live. (CLI-equivalent startup hooks in reyn.yaml → restart, unchanged.)"""
+    monkeypatch.chdir(tmp_path)
+    reloader = HotReloader(project_root=tmp_path, events=None)
+    set_active_hot_reloader(reloader)
+    try:
+        res = await _handle_hooks_add({"on": "turn_end", "message": "continue"}, _ctx(tmp_path))
+        assert res.get("status") != "error", res
+        assert (tmp_path / ".reyn" / "config" / "hooks.yaml").exists(), "IN-set write"
+        assert reloader.pending is True, "the tool-edit scheduled a hot-reload (no restart)"
+    finally:
+        set_active_hot_reloader(None)


### PR DESCRIPTION
**[e2e-coder]** — Closes #2374. Owner directive: extend the MCP hot-reload two-path principle to cron / hooks / skills. **Verify-first outcome: all three already satisfy the intent — no production change; three regression-guard tests + the two-path contract documented.**

## The two-path contract (settled with owner; established by #2372 MCP)
A config edit's reload behavior depends on **who** edits it:
- **CLI edit** (`reyn ...`) → writes the OUT-set (`reyn.yaml`) → **restart** to take effect.
- **LLM-tool / slash edit** → writes the IN-set (`.reyn/config/{cron,hooks}.yaml`, or a skill file) → **live within the same session (next turn), no restart**.

## Why this is verify-first (not a re-wire)
The #2372 MCP roster-frozen gap was **MCP-specific**: the server roster was cached at ctor and gated the enumeration, so a mid-session install wasn't visible. cron / hooks / skills satisfy the tool/slash-live intent via their **own** mechanisms — so re-wiring them uniformly to `request_reload` would churn working code with no behavior change (owner's intent is "tool-edit is live", not "unified via one mechanism"). Flow-trace found the differentiation is *evidenced* (each domain's mechanism confirmed), and this PR upgrades that inference to **run-verified**.

## Per-domain (run-verified)
| domain | tool/slash write | live mechanism | result |
|---|---|---|---|
| **skills** | authors a `skill.md` under `reyn/project`/`reyn/local` | `enumerate_available_skills` walks the dirs **per call** (filesystem-live, like agent discovery) | new skill visible next turn, no reload |
| **cron** | `_handle_cron_register` → IN-set `.reyn/config/cron.yaml` | direct `get_active_scheduler().add_job` (`live_update_applied=True`) | job live on the scheduler, no restart |
| **hooks** | `_handle_hooks_add` → IN-set `.reyn/config/hooks.yaml` (structurally can't target reyn.yaml) | `request_reload` → next-turn `apply_pending` → `_reapply_hooks` rebuilds the registry | reload scheduled, next-turn live |

Write-targets correct (IN-set for tool/slash, `reyn.yaml` for CLI = restart), triggers present, re-reads live for all three.

## #2088 / #2089 (traced)
- **#2089** ("route existing mcp/cron write-ops through the HotReloader — unify the reapply path") is the exact uniform re-wire this PR declines as churn — cron already live-updates via the direct scheduler; unifying adds a mechanism with no behavior change. **Closed by lead-coder as obviated** (functional goal already met).
- **#2088** ("scope-aware `hooks_add` — write the per-agent `.reyn/agents/<name>/hooks.yaml` layer") is a genuine **residual**, but it is a missing **feature** (per-agent write scope), not a hot-reload gap — the global hooks path IS live (verified). **Keep open, separate feature, out of #2374 scope.**

## Test plan (`tests/test_hotreload_cron_hooks_skills_2374.py`, Tier 2)
- [x] skills filesystem-live (new skill.md enumerated without reload)
- [x] cron tool-add → IN-set write + live on the active scheduler (no restart)
- [x] hooks tool-add → IN-set write + hot-reload scheduled (no restart)
- [x] ruff / tier-audit (strict, 3 OK) green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
