### PR TITLE
fix(#2352): gen-store _encode enforces the '__'-free invariant (collision-safe keying, no migration)

### DIFF
--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -23,7 +23,23 @@ _GEN_RE = re.compile(r"^(?P<rel>.+)@(?P<seq>\d+)\.yaml$")
 
 
 def _encode(rel_path: str) -> str:
-    """`config/mcp.yaml` → `config__mcp.yaml` (path-segment-safe single filename)."""
+    """`config/mcp.yaml` → `config__mcp.yaml` (path-segment-safe single filename).
+
+    #2352: the encoding maps ``/`` → ``__`` and is injective ONLY for paths with NO ``__``
+    in any segment — ``_decode`` reverses EVERY ``__`` to ``/``, so ``_decode(_encode("a__b/c"))``
+    would yield ``"a/b/c"`` ≠ the original. Config-registry rel_paths are ``__``-free by
+    construction (``.reyn``-relative config file names like ``config/mcp.yaml``), so this
+    enforces that invariant LOUD rather than silently colliding two distinct paths onto one
+    ``<safe-rel>@<seq>.yaml`` generation file — which would return the wrong generation on
+    config-rewind / time-travel (a durability keying corruption). Raising (not asserting) so
+    ``-O`` cannot strip the guard. Existing generation file names are unchanged (no migration):
+    every real path stays ``__``-free, so its encoding is byte-identical to before.
+    """
+    if "__" in rel_path:
+        raise ValueError(
+            f"config-generation rel_path must not contain '__' (it collides with the '/' → '__' "
+            f"encoding and would round-trip wrong): {rel_path!r}"
+        )
     return rel_path.replace("/", "__")
 
 

--- a/tests/test_events_pure_helpers.py
+++ b/tests/test_events_pure_helpers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _SRC = Path(__file__).parent.parent / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
@@ -63,6 +65,18 @@ def test_encode_decode_roundtrip_nested() -> None:
     """Tier 2: round-trip preserves a nested path whose segments contain no '__'."""
     path = "a/b/c/d.yaml"
     assert _decode(_encode(path)) == path
+
+
+def test_encode_rejects_double_underscore_in_path() -> None:
+    """Tier 2: #2352 — _encode RAISES on a rel_path containing '__'. The encoding maps '/' → '__'
+    and is injective ONLY for '__'-free paths, so a segment with '__' would silently collide two
+    distinct config paths onto one generation file (wrong generation on config-rewind = a
+    durability keying corruption). The guard enforces the '__'-free invariant loud. RED before the
+    guard: _encode('a__b/c.yaml') silently returned 'a__b__c.yaml' → _decode → 'a/b/c.yaml' ≠ the
+    original. Real config-registry paths stay '__'-free, so existing generation file names are
+    unchanged (no migration)."""
+    with pytest.raises(ValueError, match="must not contain '__'"):
+        _encode("a__b/c.yaml")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — Closes #2352. Found during review of #2350: the gen-store path encoding is not collision-safe.

## The collision (primary-verified, `core/events/config_generations.py`)
```python
def _encode(rel_path): return rel_path.replace("/", "__")
def _decode(safe_rel): return safe_rel.replace("__", "/")
```
`_encode` maps `/` → `__` without escaping any `__` already present, so it is not injective:
- `_encode("a__b/c.yaml")` → `"a__b__c.yaml"` → `_decode` → `"a/b/c.yaml"` ≠ the original.

`_encode` keys the generation file (`<safe-rel>@<seq>.yaml`); two distinct config paths could map to the same generation file → the **wrong generation on config-rewind / time-travel** (a durability keying corruption). It is LATENT today (config-registry rel_paths — `.reyn`-relative config file names like `config/mcp.yaml` — are `__`-free by construction), but the encoding made an unguarded, undocumented assumption.

## Fix (option c — enforce the invariant; no migration)
Percent-encoding (option b) would rename every existing generation file (migration). Since the rel_paths are `__`-free **by construction** and the constraint is "existing generation files keep their names", the proportionate fix is to **document the invariant + enforce it loud**: `_encode` raises `ValueError` when `rel_path` contains `__`. This converts a silent collision into a clear failure, changes **no** existing file names (every real path stays `__`-free → byte-identical encoding), and needs no migration. Raising (not `assert`) so `-O` cannot strip the guard.

## Falsify
- `_encode("a__b/c.yaml")` raises `ValueError` (GREEN; RED before the guard — it silently returned `"a__b__c.yaml"`).
- All existing `/`-only round-trips stay green (`config/mcp.yaml`, `a/b/c/d.yaml`, flat filenames).
- Falsify-verified: strip the guard → the raise test REDs.

Note: #2350's docstring over-claim (`decode(_encode(x)) == x` "for any path") — the existing `test_decode_reverses_encode` already scopes it to `__`-free paths; this issue fixes the underlying encoding.


## rel_path source verified ('__'-free by construction — the guard never fires in practice)
All 5 `record_config_generation` call sites (the only producers of `_encode`'s `rel_path`) pass a FIXED config-file path:
- `mcp_install` / `mcp_drop_server` → `.reyn/config/mcp.yaml`
- `cron` tool → `.reyn/config/cron.yaml`
- `hooks` tool → `.reyn/config/hooks.yaml`
- `index_drop` → `.reyn/config/index/sources.yaml` (the **canonical manifest** — source names are keys *inside* the yaml, never in the file path)

`config_recovery._rel_path` strips the `.reyn/` prefix → `config/mcp.yaml`, `config/cron.yaml`, `config/hooks.yaml`, `config/index/sources.yaml` — all fixed, no user/agent-derived segment, all `__`-free. So the raise is a **pure safety-net for the invariant** (never fires today); it exists to fail loud if a future producer ever introduces a `__` path, instead of silently corrupting the keying.

## Test plan (`tests/test_events_pure_helpers.py`, Tier 2)
- [x] `_encode` raises on a `__`-containing path (new)
- [x] existing `/`-round-trips unchanged (green)
- [x] Falsify-verified (guard stripped → RED)
- [x] ruff / tier-audit (20 OK) / verify_module_docstrings green; config-generation/recovery regression (23) green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
