### PR TITLE
fix(repl): exit cost summary undercounts multi-session agents

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -384,21 +384,11 @@ def _snapshot(registry, task_cache=None, config=None):
     if s is None:
         return None
     u = s.total_usage
-    # Cost breakdown (all via public sync accessors). Sum across ALL sessions
-    # (every sid), not just each agent's "main" — a spawned sub-session accrues
-    # cost too. Nested: session ≤ agent (all the attached agent's sids) ≤ total
-    # (all agents, all sids).
-    def _agent_cost(name: str) -> float:
-        total = 0.0
-        for sid in registry.session_ids(name):
-            sess = registry.get_session(name, sid)
-            if sess is not None:
-                total += sess.total_cost_usd
-        return total
-
-    cost_total = sum(_agent_cost(name) for name in registry.loaded_names())
+    # Cost breakdown (all via registry.agent_cost_usd — the single source of
+    # truth for per-agent cost aggregation across all sids).
+    cost_total = sum(registry.agent_cost_usd(name) for name in registry.loaded_names())
     cost_agent = (
-        _agent_cost(registry.attached_name)
+        registry.agent_cost_usd(registry.attached_name)
         if registry.attached_name else s.total_cost_usd
     )
     return {

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -281,14 +281,15 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)
-        # Aggregate cost from all loaded agents
+        # Aggregate cost from all loaded agents across all sids (not just "main").
         from reyn.llm.pricing import TokenUsage
         total_usage = TokenUsage()
         total_cost = 0.0
         for name in registry.loaded_names():
-            session = registry.get_session(name)
-            if session is None:
-                continue
-            total_usage += session.total_usage
-            total_cost += session.total_cost_usd
+            for sid in registry.session_ids(name):
+                session = registry.get_session(name, sid)
+                if session is None:
+                    continue
+                total_usage += session.total_usage
+                total_cost += session.total_cost_usd
         renderer.cost_summary(total_usage, total_cost if total_cost > 0 else None)

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -281,15 +281,10 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)
-        # Aggregate cost from all loaded agents across all sids (not just "main").
         from reyn.llm.pricing import TokenUsage
         total_usage = TokenUsage()
         total_cost = 0.0
         for name in registry.loaded_names():
-            for sid in registry.session_ids(name):
-                session = registry.get_session(name, sid)
-                if session is None:
-                    continue
-                total_usage += session.total_usage
-                total_cost += session.total_cost_usd
+            total_cost += registry.agent_cost_usd(name)
+            total_usage += registry.agent_total_usage(name)
         renderer.cost_summary(total_usage, total_cost if total_cost > 0 else None)

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -407,6 +407,30 @@ class AgentRegistry:
         spawned ids thereafter."""
         return list(self._sessions.get(name, {}).keys())
 
+    def agent_cost_usd(self, name: str) -> float:
+        """Total cost in USD across ALL sessions of agent ``name``.
+
+        Single source of truth for per-agent cost aggregation — used by both
+        the inline status bar and the run_repl exit summary so they never drift
+        when sessions are spawned via /session new.
+        """
+        total = 0.0
+        for sid in self.session_ids(name):
+            sess = self.get_session(name, sid)
+            if sess is not None:
+                total += sess.total_cost_usd
+        return total
+
+    def agent_total_usage(self, name: str) -> "object":
+        """Aggregate TokenUsage across ALL sessions of agent ``name``."""
+        from reyn.llm.pricing import TokenUsage
+        total: "TokenUsage" = TokenUsage()
+        for sid in self.session_ids(name):
+            sess = self.get_session(name, sid)
+            if sess is not None:
+                total += sess.total_usage
+        return total
+
     def resolve_session(
         self,
         agent_name: str,

--- a/tests/test_registry_multi_session_1726.py
+++ b/tests/test_registry_multi_session_1726.py
@@ -99,3 +99,32 @@ async def test_attach_session_focuses_existing_and_rejects_unknown(tmp_path) -> 
     finally:
         for task in reg.running_tasks():
             task.cancel()
+
+
+def test_agent_cost_usd_aggregates_all_sessions(tmp_path):
+    """Tier 2: agent_cost_usd() sums cost across ALL sids, not just 'main'.
+
+    Regression: the exit cost summary in run_repl called get_session(name) without
+    a sid (defaulting to 'main'), silently missing sessions spawned via /session new.
+    agent_cost_usd() is the single source of truth used by both the inline status
+    bar and the run_repl exit summary.
+
+    Falsification: if agent_cost_usd() only read the main session, the assertion
+    total == pytest.approx(0.15) would return 0.10 and fail.
+    """
+    import types
+
+    reg = _registry(tmp_path)
+    main = reg.get_or_load("default")
+    sid2 = reg.spawn_session("default")
+    extra = reg.get_session("default", sid2)
+
+    assert extra is not None
+    # Inject cost via public accumulate() with a duck-typed result object.
+    main._budget.accumulate(types.SimpleNamespace(token_usage=None, cost_usd=0.10))
+    extra._budget.accumulate(types.SimpleNamespace(token_usage=None, cost_usd=0.05))
+
+    total = reg.agent_cost_usd("default")
+    assert total == pytest.approx(0.15), (
+        "agent_cost_usd must sum ALL session costs, not just 'main'"
+    )


### PR DESCRIPTION
**[tui-coder]** — real-bug mining find (#2303 class: silent undercount)

## Bug

`run_repl`'s exit cost summary called `registry.get_session(name)` without a `sid` argument (defaults to `"main"`). Sessions spawned via `/session new` were silently excluded — cost from session B never appeared in the exit summary.

`app.py`'s `_snapshot()` had a correct `_agent_cost()` closure that iterated all sids, but it was a local closure and `repl.py` didn't use it — a single DRY violation waiting to drift.

## Fix

Adds `AgentRegistry.agent_cost_usd(name)` and `agent_total_usage(name)` as the **single source of truth** for per-agent cost/usage aggregation across all sids. Both `app.py` and `repl.py` now call the registry methods — no duplicate logic, no future drift risk.

```python
# registry.py — new methods
def agent_cost_usd(self, name: str) -> float:
    total = 0.0
    for sid in self.session_ids(name):
        sess = self.get_session(name, sid)
        if sess is not None:
            total += sess.total_cost_usd
    return total

# repl.py — exit summary (was: get_session(name) only "main")
for name in registry.loaded_names():
    total_cost += registry.agent_cost_usd(name)
    total_usage += registry.agent_total_usage(name)

# app.py — _snapshot() cost (was: _agent_cost local closure with same logic)
cost_total = sum(registry.agent_cost_usd(name) for name in registry.loaded_names())
```

## Test

Added Tier 2 falsifiable test in `test_registry_multi_session_1726.py`:
- Creates an agent with main + spawned session
- Injects cost into each via `BudgetGateway.accumulate()`
- Asserts `registry.agent_cost_usd()` returns the sum (not just main's cost)
- RED without the new method (returns 0.10, not 0.15)

## Test plan

- [x] `python scripts/test_tier_audit.py --strict tests/test_registry_multi_session_1726.py` — 5/5 OK
- [x] `python -m pytest tests/test_registry_multi_session_1726.py -v` — 5/5 passed
- [x] Full suite: 8290 passed (2 pre-existing gateway failures unrelated to this change)
- [x] ruff + verify_module_docstrings — clean

**Tier self-check:** added Tier 2 test, no Tier 4 violations.

part of #1830 (bug mining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)