### PR TITLE
test: deflake test_restored_intervention (snapshot-durability barrier) + document stale-artifact env-friction

### DIFF
--- a/tests/gateway/test_entry_points.py
+++ b/tests/gateway/test_entry_points.py
@@ -10,6 +10,12 @@ resolution, so CI stayed green while inbound webhook plugins were broken.
 This pins resolution against the installed entry-point metadata: ``ep.load()``
 raises ``ModuleNotFoundError`` if the target module is wrong, so a future rename
 that forgets the entry points fails here instead of silently in production.
+
+Local dev note (#2374 follow-up): a STALE editable install can false-fail this. If
+``src/reyn.egg-info/entry_points.txt`` predates the #1807 rename it still lists
+``reyn.plugins.*`` and duplicates the fresh dist-info, so ``entry_points()`` returns
+BOTH and the ``eps[0]`` pick may be the stale one. ``pip install -e .`` regenerates it.
+CI is unaffected (it installs clean).
 """
 from __future__ import annotations
 

--- a/tests/test_intervention_restore.py
+++ b/tests/test_intervention_restore.py
@@ -196,8 +196,25 @@ async def test_restored_intervention_can_be_answered(tmp_path, monkeypatch):
     # WAL has the resolve event
     assert "iv_to_answer" in _resolved_ids()
 
-    # Snapshot pruned (path was the one passed to _make_session)
+    # Snapshot pruned. #2279/#2339: the snapshot save that prunes ``outstanding_interventions`` is a
+    # SEPARATE fire-and-forget durable write from the WAL event polled above — polling the WAL event
+    # is NOT a barrier for it, so an immediate snapshot read raced the save and spuriously red'd this
+    # assert under CI load (the #2279-family residual). Poll the SPECIFIC durable artifact the assert
+    # reads (the on-disk snapshot state), not a proxy/other write.
     snap_path = tmp_path / "alpha_snapshot.json"
+
+    def _snapshot_pruned() -> bool:
+        try:
+            raw = json.loads(snap_path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            return False
+        return "iv_to_answer" not in raw.get("outstanding_interventions", {})
+
+    for _ in range(200):
+        if _snapshot_pruned():
+            break
+        await asyncio.sleep(0.01)
+
     raw = json.loads(snap_path.read_text())
     assert "iv_to_answer" not in raw.get("outstanding_interventions", {})
 

--- a/tests/test_reyn_api_relocate_311.py
+++ b/tests/test_reyn_api_relocate_311.py
@@ -7,6 +7,12 @@ canonical reyn.api.* imports work; the old paths no longer import; and the
 safe-mode allowlist is allow-of-one (only reyn.api.safe.*; everything else,
 incl reyn.api.unsafe.* and the removed reyn.safe.*/reyn.unsafe.*, is
 default-deny).
+
+Local dev note (#2374 follow-up): a stale UNTRACKED ``src/reyn/safe/`` (or
+``src/reyn/plugins/``) dir — only ``__pycache__`` left from before the relocate — is
+picked up as a PEP-420 namespace package, so ``import reyn.safe`` SUCCEEDS and the
+clean-break assert here false-fails. ``rm -rf`` the stale untracked dirs. CI is
+unaffected (clean checkout).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — Deflakes the last CI-recurring intervention-durability residual + documents the local stale-artifact env-friction (env-test root-cause follow-up).

## Root-cause of the recurring CI flaky (primary data, not the assumed cause)
The recurring flaky that spurious-red'd #2371/#2368 was assumed to be http_get/a2a/oauth/network. Fetching the actual CI tracebacks (`gh run view --log-failed` over 6 failed runs) showed **zero** network failures — all were the **intervention/postprocessor async-durability family**:
- `test_postprocessor_mid_run_chain_timeout_fires` (dominant, 4/6 runs) — **already fixed** by #2373 (#2339).
- `test_deliver_answer_appends_intervention_resolved` — **already fixed** on main by #2279 (it has the `_journal.flush()` barrier; the CI failures were on branches predating the merge). Verified 20/20. No change.
- `test_restored_intervention_can_be_answered` — **genuine residual** (this PR).

## The residual + fix
`test_restored_intervention_can_be_answered` polled the WAL for the `intervention_resolved` **event** (correct) but then read the **snapshot** immediately (`:202`). The snapshot prune is a **separate fire-and-forget durable write** from the WAL event (async-decoupled durability, #2259) — polling the WAL event is not a barrier for it, so the immediate snapshot read raced its durability and spuriously red'd the `outstanding_interventions` assert under CI load (the #2279-family residual #2279 didn't fully close).

Fix (the #2279/#2339 discipline — wait on the *specific durable artifact the assert reads*): added a bounded poll of the on-disk snapshot state before the `:202` assert. The WAL-event poll stays (the resolve append fires in a **background** dispatch coroutine, so `_journal.flush()` alone doesn't cover it — flush doesn't wait for the coroutine to *reach* the write; verified `_journal.flush()`-only fails 0/20).

## Class-A: local stale-artifact env-friction (docstring notes)
The "4 pre-existing env fails" I'd reported each full-suite run (gateway-entrypoint ×3 + reyn_api_relocate ×1) were **my local stale build artifacts**, not codebase bugs (CI clean-green): a pre-#1807 `src/reyn.egg-info` (`reyn.plugins.*` entry points, duplicating the fresh dist-info) + untracked `src/reyn/{safe,plugins}/__pycache__` dirs picked up as PEP-420 namespace packages. `pip install -e .` + `rm -rf` the stale dirs → all 4 GREEN. This PR adds a 1-line dev-note to the gateway/relocate test docstrings so the next dev doesn't repeat the root-cause loop.

## Test plan
- [x] `test_restored_intervention_can_be_answered`: 20/20 consecutive green with the snapshot-poll barrier (was CI-flaky; `_journal.flush()`-only fails 0/20 — the wrong barrier)
- [x] `test_deliver_answer`: verified already-fixed (20/20, structural flush barrier) — no change
- [x] Class-A docstring notes on gateway/relocate tests
- [x] ruff / tier-audit green
- [ ] Full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
