### PR TITLE
fix(#2303): /pending claim re-stall regression — use DEFAULT_CHAT_CHANNEL_ID

### DIFF
--- a/src/reyn/interfaces/slash/pending.py
+++ b/src/reyn/interfaces/slash/pending.py
@@ -241,8 +241,14 @@ async def _claim(session: "Session", supplied_id: str) -> None:
         await reply_error(session, err)
         return
     assert iv_id is not None
-    # Channel id matches the Pending tab's claim path (= ``tui:<agent>``).
-    channel_id = f"tui:{getattr(session, 'agent_name', 'default')}"
+    # Use the canonical REPL listener channel so the re-dispatched iv is NOT
+    # immediately re-parked stalled by InterventionCoordinator (it checks
+    # has_listener(iv.origin_channel_id) and only routes through
+    # InterventionHandler when the claimed channel matches a registered listener).
+    # The old f"tui:{agent_name}" was the Textual TUI's per-agent convention;
+    # the current REPL registers DEFAULT_CHAT_CHANNEL_ID ("tui").
+    from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+    channel_id = DEFAULT_CHAT_CHANNEL_ID
     try:
         view = await session.claim_pending_intervention(iv_id, channel_id)
     except Exception as exc:

--- a/tests/cli/test_pending_slash_command.py
+++ b/tests/cli/test_pending_slash_command.py
@@ -183,7 +183,14 @@ async def test_pending_discard_resolves_short_prefix_id() -> None:
 @pytest.mark.asyncio
 async def test_pending_claim_invokes_session_api_with_tui_channel() -> None:
     """Tier 2b: ``/pending claim <id>`` calls ``claim_pending_intervention``
-    with ``new_channel_id="tui:<agent>"``."""
+    with ``new_channel_id=DEFAULT_CHAT_CHANNEL_ID`` ("tui").
+
+    Regression: the old code used f"tui:{agent_name}" (Textual TUI convention).
+    After TUI removal the REPL listener is "tui"; passing "tui:research" causes
+    InterventionCoordinator to immediately re-park the iv stalled.
+    """
+    from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+
     sess = _StubSession(
         pending_ops=[
             _PendingOpStub(
@@ -194,12 +201,12 @@ async def test_pending_claim_invokes_session_api_with_tui_channel() -> None:
         agent_name="research",
         claim_result=_PendingOpStub(
             id="iv-abcd1234", kind="intervention",
-            origin_channel_id="tui:research", summary="claim me",
+            origin_channel_id=DEFAULT_CHAT_CHANNEL_ID, summary="claim me",
         ),
     )
     cmd = _get_pending_cmd()
     await cmd.handler(sess, "claim iv-abcd1234")
-    assert sess.claim_calls == [("iv-abcd1234", "tui:research")]
+    assert sess.claim_calls == [("iv-abcd1234", DEFAULT_CHAT_CHANNEL_ID)]
     reply_msgs = [m for m in sess.outbox_messages if m.kind == "system"]
     assert any("claimed" in m.text for m in reply_msgs)
 

--- a/tests/test_slash_pending_claim_channel.py
+++ b/tests/test_slash_pending_claim_channel.py
@@ -1,0 +1,78 @@
+"""Tier 2: /pending claim must pass DEFAULT_CHAT_CHANNEL_ID to claim_pending_intervention.
+
+After the Textual TUI removal, the REPL listener is registered as
+DEFAULT_CHAT_CHANNEL_ID ("tui").  The old code hardcoded f"tui:{agent_name}"
+(the Textual TUI's per-agent naming convention).
+
+InterventionCoordinator.dispatch checks has_listener(iv.origin_channel_id) and
+parks the iv as stalled when it returns False.  Passing "tui:default" when the
+only registered listener is "tui" caused the iv to be immediately re-parked stalled
+after a claim — the user saw "claimed ..." but the intervention never reappeared.
+
+Falsification: if _claim passed f"tui:{agent_name}" the assertion
+    recorded_channel_id == "tui"
+would fail with "tui:default", directly exposing the regression.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.slash.pending import _claim
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+
+
+class _ClaimStubSession:
+    """Minimal session stub that records the channel_id passed to claim."""
+
+    def __init__(self, *, agent_name: str = "default") -> None:
+        self.agent_name = agent_name
+        self.outbox_messages: list[OutboxMessage] = []
+        self.recorded_channel_id: str | None = None
+
+    async def _put_outbox(self, msg: OutboxMessage) -> None:
+        self.outbox_messages.append(msg)
+
+    def list_stalled_interventions(self) -> list:
+        from types import SimpleNamespace
+        return [SimpleNamespace(id="iv-abc12345", kind="ask_user", summary="Allow?")]
+
+    async def claim_pending_intervention(self, iv_id: str, channel_id: str):
+        self.recorded_channel_id = channel_id
+        from types import SimpleNamespace
+        return SimpleNamespace(summary="Allow?")
+
+
+@pytest.mark.asyncio
+async def test_claim_passes_default_chat_channel_id() -> None:
+    """Tier 2: _claim passes DEFAULT_CHAT_CHANNEL_ID not f"tui:{agent_name}".
+
+    Regression guard: old code used f"tui:{agent_name}" (Textual TUI convention),
+    which mismatches the registered REPL listener "tui" →
+    InterventionCoordinator.dispatch immediately re-parks the iv stalled.
+    """
+    sess = _ClaimStubSession(agent_name="default")
+    await _claim(sess, "iv-abc12345")
+
+    assert sess.recorded_channel_id == DEFAULT_CHAT_CHANNEL_ID, (
+        f"_claim must pass DEFAULT_CHAT_CHANNEL_ID={DEFAULT_CHAT_CHANNEL_ID!r} "
+        f"not the old Textual TUI-style 'tui:<agent>'; "
+        f"got {sess.recorded_channel_id!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_channel_is_not_agent_namespaced() -> None:
+    """Tier 2: claimed channel must NOT be f"tui:{agent_name}".
+
+    The old value "tui:default" has no registered listener in the current REPL
+    (listener = "tui"), causing the iv to be re-parked stalled on re-dispatch.
+    """
+    sess = _ClaimStubSession(agent_name="myagent")
+    await _claim(sess, "iv-abc12345")
+
+    # Must not be the old Textual-TUI agent-namespaced form.
+    assert sess.recorded_channel_id != f"tui:{sess.agent_name}", (
+        "claimed channel must not use agent-namespaced form 'tui:<agent>'; "
+        "use DEFAULT_CHAT_CHANNEL_ID instead"
+    )


### PR DESCRIPTION
**[tui-coder]** — post-Textual-removal regression in `/pending claim`

## Root cause

`_claim` in `slash/pending.py` hardcoded:
```python
channel_id = f"tui:{getattr(session, 'agent_name', 'default')}"
```
This was the Textual TUI's per-agent listener naming convention. After the Textual TUI removal (PR #2195), the REPL registers its intervention listener as `DEFAULT_CHAT_CHANNEL_ID = "tui"` via `bind_focus_listeners`.

`InterventionCoordinator.dispatch` checks `has_listener(iv.origin_channel_id)` — a **specific** string lookup in `_listeners`. When the claimed channel is `"tui:default"` but only `"tui"` is registered, the check fails and the iv is immediately re-parked stalled via `park_stalled(iv)`. The user receives "claimed tui:default" but the intervention never reappears. Silent fail.

## Fix

Use `DEFAULT_CHAT_CHANNEL_ID` (imported lazily to avoid circular import):
```python
from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
channel_id = DEFAULT_CHAT_CHANNEL_ID
```

## Test

`tests/test_slash_pending_claim_channel.py` — 2 Tier 2 falsifiable behavioral assertions:
- `test_claim_passes_default_chat_channel_id`: recorded channel must equal `DEFAULT_CHAT_CHANNEL_ID`
- `test_claim_channel_is_not_agent_namespaced`: must not be `f"tui:{agent_name}"` (the old form)

Both would fail with the pre-fix code, exposing the regression directly.

## CI gates (all local green)
- `ruff check src/reyn/interfaces/slash/pending.py tests/test_slash_pending_claim_channel.py` ✓
- `python scripts/test_tier_audit.py --strict tests/test_slash_pending_claim_channel.py` ✓ (2 Tier 2)
- `pytest tests/test_slash_pending_claim_channel.py tests/test_slash_pending_render_helpers.py tests/test_slash_destructive_confirm_parity.py` ✓ 18/18 passed
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/pending.py` ✓

Tier self-check: Tier 2 — real stub class (no MagicMock/patch), no private state assertions, no format pins. ✓

Part of #2303 class (silent action failure).