### PR TITLE
fix(#2357): dogfood action_usage wipe targets the live per-agent path (not a stale no-op)

### DIFF
--- a/scripts/dogfood_fresh_reset.sh
+++ b/scripts/dogfood_fresh_reset.sh
@@ -5,7 +5,6 @@
 # starts from DEFAULT_HOT_LIST_SEED with no carry-over.
 #
 # What this script wipes:
-#   .reyn/state/action_usage.jsonl  — hot-list frequency/recency history
 #   .reyn/state/wal.jsonl           — plan-resume substrate (if present)
 #   .reyn/state/history.jsonl       — session-summary carry-over (if present)
 #   .reyn/state/plans/              — stale decomposition artifacts (if present)
@@ -16,6 +15,10 @@
 #   .reyn/agents/*/events           — per-agent event log; same constraint
 #   .reyn/agents/*/history.jsonl    — per-agent conversation history; requires knowing
 #                                     the agent name — callers must wipe this separately
+#   .reyn/agents/*/action_usage.json — per-agent hot-list ledger; requires the agent name,
+#                                     so the runner wipes it per-scenario (#2357). The old
+#                                     .reyn/state/action_usage.jsonl path never existed (the
+#                                     live ledger is per-agent) — wiping it here was a no-op.
 #
 # Rationale: §6.7 of docs/deep-dives/contributing/dogfood-discipline.md.
 # Cross-batch V comparison is only valid when all batches start from the same
@@ -53,8 +56,10 @@ _remove_dir() {
     fi
 }
 
-# Hot-list usage history — the primary measurement confound (B37 F2 / B38 §6)
-_remove_file ".reyn/state/action_usage.jsonl"
+# #2357: the hot-list ledger (the primary measurement confound, B37 F2 / B38 §6) is per-agent
+# (.reyn/agents/<name>/action_usage.json) — this script has no agent name, so the runner wipes it
+# per-scenario. The old `_remove_file ".reyn/state/action_usage.jsonl"` targeted a path that never
+# existed (silent no-op) and is removed here.
 
 # Plan-resume substrate
 _remove_file ".reyn/state/wal.jsonl"

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -254,6 +254,21 @@ def _runs_dir() -> Path:
     return _dogfood_base_dir() / "runs"
 
 
+def _scenario_state_targets(project_root: Path, agent_name: str) -> "dict[str, Path]":
+    """#2357: the per-scenario ephemeral state the dogfood runner wipes between scenarios so each
+    run starts clean. The action_usage ledger MUST be the LIVE ``ActionUsageTracker`` persist path
+    (``.reyn/agents/<name>/action_usage.json`` — session.py); the previous ``.reyn/state/
+    action_usage.jsonl`` never existed, so the unlink was a silent no-op and hot-list frequency
+    counts bled across scenarios (measurement contamination). Kept as a pure, testable helper so the
+    wipe target can't silently drift from the tracker's real path again."""
+    agent_dir = project_root / ".reyn" / "agents" / agent_name
+    return {
+        "events_chat_dir": project_root / ".reyn" / "events" / "agents" / agent_name / "chat",
+        "action_usage": agent_dir / "action_usage.json",
+        "history": agent_dir / "history.jsonl",
+    }
+
+
 def _baselines_dir() -> Path:
     return _dogfood_base_dir() / "baselines"
 
@@ -520,23 +535,17 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
 
     def _wipe_scenario_state() -> None:
         """Delete per-scenario ephemeral state so each run starts clean."""
+        targets = _scenario_state_targets(project_root, agent_name)
         # Wipe the agent's chat event files so EventStore.iter_all() only
         # returns events from this scenario's turns.
-        events_chat_dir = project_root / ".reyn" / "events" / "agents" / agent_name / "chat"
-        if events_chat_dir.is_dir():
-            shutil.rmtree(events_chat_dir, ignore_errors=True)
-        # Wipe action_usage ledger to prevent hot-list bleed across scenarios.
-        action_usage_path = project_root / ".reyn" / "state" / "action_usage.jsonl"
-        action_usage_path.unlink(missing_ok=True)
-        # Wipe per-agent chat history so prior scenarios' user/assistant
-        # turns are NOT injected into the LLM context for this scenario.
-        # Session.load_history() (called by the session factory) reads
-        # this file unconditionally; without the wipe, scenario N sees
-        # scenarios 1..N-1's messages. dogfood_fresh_reset.sh intentionally
-        # defers this wipe to callers because it requires knowing the
-        # agent name (which the script doesn't); the runner has it.
-        history_path = project_root / ".reyn" / "agents" / agent_name / "history.jsonl"
-        history_path.unlink(missing_ok=True)
+        if targets["events_chat_dir"].is_dir():
+            shutil.rmtree(targets["events_chat_dir"], ignore_errors=True)
+        # Wipe the action_usage ledger (prevents hot-list frequency bleed) + the per-agent chat
+        # history (prevents prior scenarios' turns leaking into this scenario's LLM context —
+        # Session.load_history reads it unconditionally). dogfood_fresh_reset.sh defers the history
+        # wipe to the runner because it needs the agent name (which the script doesn't have).
+        targets["action_usage"].unlink(missing_ok=True)
+        targets["history"].unlink(missing_ok=True)
 
     def _collect_events(registry: AgentRegistry) -> list[dict]:
         """Harvest events emitted during the scenario from the EventStore."""

--- a/src/reyn/interfaces/slash/clear_history.py
+++ b/src/reyn/interfaces/slash/clear_history.py
@@ -4,7 +4,7 @@ Sibling to ``/reset`` (skill state) at a different scope: this command
 clears the conversation thread (``Session.history`` + per-agent
 ``history.jsonl``) and the action-usage tracker (= the ranking that
 backs the Memory tab's hot-list augmentation, persisted at
-``.reyn/state/action_usage.jsonl``). Everything else stays intact:
+``.reyn/agents/<name>/action_usage.json`` — #2357 docstring-drift fix). Everything else stays intact:
 
 - ``.reyn/events/``                (P6 audit truth — never touched)
 - ``.reyn/state/wal.jsonl``        (skill resume — preserved)

--- a/tests/test_dogfood_action_usage_wipe_2357.py
+++ b/tests/test_dogfood_action_usage_wipe_2357.py
@@ -1,0 +1,36 @@
+"""Tier 2: #2357 — the dogfood per-scenario wipe targets the LIVE action_usage ledger path.
+
+The live ActionUsageTracker persists to ``.reyn/agents/<name>/action_usage.json`` (session.py). The
+dogfood harness's per-scenario wipe previously ``unlink``ed ``.reyn/state/action_usage.jsonl`` — a
+stale path that never existed → a silent no-op → hot-list frequency counts BLED across dogfood
+scenarios (measurement contamination). The wipe target now comes from a pure ``_scenario_state_targets``
+helper so it can't silently drift from the tracker's real path again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.dogfood import _scenario_state_targets
+
+
+def test_wipe_action_usage_targets_live_per_agent_path(tmp_path):
+    """Tier 2: #2357 — the wipe's action_usage target is the LIVE per-agent path
+    (.reyn/agents/<name>/action_usage.json), NOT the stale .reyn/state/action_usage.jsonl. RED under
+    the stale path (the unlink was a silent no-op → hot-list bled)."""
+    targets = _scenario_state_targets(tmp_path, "alice")
+    assert targets["action_usage"] == tmp_path / ".reyn" / "agents" / "alice" / "action_usage.json"
+    # the live tracker's convention (session.py): .json under .reyn/agents/<name>/, NOT .reyn/state/
+    rel = targets["action_usage"].relative_to(tmp_path).parts
+    assert "state" not in rel and targets["action_usage"].suffix == ".json"
+    # co-located with the per-agent history (the live agent home the runner already wipes correctly)
+    assert targets["action_usage"].parent == targets["history"].parent
+
+
+def test_wipe_removes_seeded_ledger_at_live_path(tmp_path):
+    """Tier 2: #2357 — a ledger seeded at the wipe's target path is actually removed (behavioral:
+    pre-fix the stale-path unlink left a live-path ledger in place → cross-scenario bleed)."""
+    p = _scenario_state_targets(tmp_path, "alice")["action_usage"]
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text('{"grep": 5}', encoding="utf-8")
+    p.unlink(missing_ok=True)  # the exact op the wipe performs on this target
+    assert not p.exists()

--- a/tests/test_dogfood_fresh_mode.py
+++ b/tests/test_dogfood_fresh_mode.py
@@ -43,8 +43,9 @@ def _seed_workspace(root: Path) -> dict[str, Path]:
     state_dir = root / ".reyn" / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
 
-    # Files that MUST be wiped by the reset script
-    for name in ("action_usage.jsonl", "wal.jsonl", "history.jsonl"):
+    # Files that MUST be wiped by the reset script. #2357: the hot-list ledger is NOT here — it's
+    # per-agent (.reyn/agents/<name>/action_usage.json), wiped by the runner, not this script.
+    for name in ("wal.jsonl", "history.jsonl"):
         p = state_dir / name
         p.write_text('{"dummy": true}\n', encoding="utf-8")
         files[name] = p
@@ -83,13 +84,6 @@ def _run_reset(workspace: Path) -> subprocess.CompletedProcess:
 # ---------------------------------------------------------------------------
 
 class TestDogfoodFreshResetScript:
-    def test_wipes_action_usage(self, tmp_path: Path) -> None:
-        """Tier 2: reset script removes action_usage.jsonl from seeded workspace."""
-        files = _seed_workspace(tmp_path)
-        result = _run_reset(tmp_path)
-        assert result.returncode == 0, result.stderr
-        assert not files["action_usage.jsonl"].exists()
-
     def test_wipes_wal(self, tmp_path: Path) -> None:
         """Tier 2: reset script removes wal.jsonl from seeded workspace."""
         files = _seed_workspace(tmp_path)
@@ -137,7 +131,6 @@ class TestDogfoodFreshResetScript:
         _seed_workspace(tmp_path)
         result = _run_reset(tmp_path)
         assert result.returncode == 0, result.stderr
-        assert "action_usage.jsonl" in result.stdout
         assert "wal.jsonl" in result.stdout
         assert "history.jsonl" in result.stdout
 
@@ -151,7 +144,7 @@ class TestDogfoodFreshResetScript:
             cwd=str(tmp_path),
         )
         assert result.returncode == 0, result.stderr
-        assert not (tmp_path / ".reyn" / "state" / "action_usage.jsonl").exists()
+        assert not (tmp_path / ".reyn" / "state" / "wal.jsonl").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — Closes #2357. Found during the #2348 same-class sweep: the dogfood per-scenario ledger wipe targets a stale path → silent no-op → hot-list frequency bleeds across scenarios.

## Bug
The live `ActionUsageTracker` persists to `.reyn/agents/<name>/action_usage.json` (session.py). But the dogfood per-scenario wipe (`dogfood.py`) `unlink`ed `.reyn/state/action_usage.jsonl` — a stale path that never existed → a silent no-op → the hot-list frequency counter DID bleed across dogfood scenarios (measurement contamination). The `/clear-history` docstring (`clear_history.py`) referenced the same stale path (docstring drift only — the command clears the live tracker object, so it works).

## Fix
- **dogfood wipe** → the live path `.reyn/agents/<name>/action_usage.json`. Extracted the wipe's paths into a pure, testable `_scenario_state_targets(project_root, agent_name)` helper so the wipe target can't silently drift from the tracker's real path again (this drift *was* the bug). The closure now iterates the helper's targets — behavior otherwise unchanged (events dir rmtree, action_usage + history unlink).
- **`/clear-history` docstring** → the live path (docstring-drift fix; behavior already correct).

## Falsify (`tests/test_dogfood_action_usage_wipe_2357.py`, Tier 2)
- [x] the wipe's action_usage target is the live per-agent path (not `.reyn/state/`; `.json`; co-located with the per-agent history) — RED under the stale path
- [x] a ledger seeded at the wipe target is actually removed
- [x] Falsify-verified: revert the helper to the stale path → the path-correctness test REDs
- [x] ruff / tier-audit (2 OK) / verify_module_docstrings green; 168-test dogfood regression green

## Same-class parallel — FOLDED (close the class fully, per triage)
`scripts/dogfood_fresh_reset.sh` had the same stale-path assumption (`_remove_file ".reyn/state/action_usage.jsonl"` — a no-op) and `test_dogfood_fresh_mode.py` asserted it (a stale-path assertion = false confidence). Since the live ledger is per-agent (needs the agent name), it belongs — exactly like the per-agent history/events the script ALREADY defers — with the runner's per-scenario wipe (the fix above). Removed the dead `_remove_file` line + moved action_usage to the script's "does NOT wipe (deferred to the runner)" header; removed action_usage from the test's seed set, deleted the now-obsolete `test_wipes_action_usage`, and dropped the 2 stale assertions. Remaining `action_usage` references are documentation only. `bash -n` OK; 16 dogfood tests green. The stale `.reyn/state/action_usage.jsonl` reference no longer exists anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
