### PR TITLE
fix(slash): /clear-history disk-fail partial-clear (#2303-class)

### DIFF
--- a/src/reyn/interfaces/slash/clear_history.py
+++ b/src/reyn/interfaces/slash/clear_history.py
@@ -77,11 +77,15 @@ async def clear_history_cmd(session: "object", args: str) -> None:
 
     cleared_parts: list[str] = []
 
-    if isinstance(history, list):
-        n_turns_before = len(history)
-        history.clear()
-        cleared_parts.append(f"{n_turns_before} history turn(s)")
+    # Snapshot size before any mutation so the report is accurate even if
+    # disk deletion is attempted first.
+    n_turns_before = len(history) if isinstance(history, list) else 0
 
+    # Disk deletion first: if it fails the in-memory state is unchanged and
+    # the next session restart will see a consistent (uncorrupted) history.
+    # Clearing memory first then failing on disk leaves the opposite: the
+    # current session sees empty history but history.jsonl survives and
+    # reloads the old turns on next startup.
     if history_path is not None:
         try:
             history_path.unlink(missing_ok=True)
@@ -91,6 +95,10 @@ async def clear_history_cmd(session: "object", args: str) -> None:
                 f"failed to remove history file {history_path}: {exc}",
             )
             return
+
+    if isinstance(history, list):
+        history.clear()
+        cleared_parts.append(f"{n_turns_before} history turn(s)")
 
     if tracker is not None and hasattr(tracker, "reset"):
         try:

--- a/tests/test_slash_clear_history_cmd.py
+++ b/tests/test_slash_clear_history_cmd.py
@@ -150,3 +150,34 @@ async def test_clear_history_confirm_nothing_to_clear() -> None:
     await clear_history_cmd(session, "confirm")
     text = session.reply_text()
     assert "nothing" in text.lower() or "empty" in text.lower()
+
+
+class _FailingPath:
+    """Stub Path that raises OSError on unlink — simulates a write-protected file."""
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        raise OSError("permission denied")
+
+
+@pytest.mark.asyncio
+async def test_clear_history_disk_fail_leaves_memory_intact() -> None:
+    """Tier 2: when history_path.unlink() fails, in-memory history must NOT be cleared.
+
+    Falsification (old code): the old ordering cleared memory BEFORE the disk
+    deletion attempt.  Under the old code this test would fail because history
+    would be empty even though the disk write failed — a partial-clear that
+    causes history to silently reload on next startup.
+    """
+    history: list = ["turn1", "turn2"]
+    session = _FakeSession(history=history, history_path=_FailingPath())
+    await clear_history_cmd(session, "confirm")
+
+    # Memory must be unchanged — disk failed so nothing was committed.
+    assert history == ["turn1", "turn2"], (
+        "in-memory history was cleared even though disk deletion failed; "
+        "old code cleared memory first then returned on OSError, leaving "
+        "history empty in-memory but history.jsonl intact on disk — "
+        "next startup would silently reload old turns"
+    )
+    # Must have emitted an error reply (not a success).
+    assert session.error_text(), "expected an error reply when unlink raises OSError"


### PR DESCRIPTION
**[tui-coder]** — Real-bug mining arc (#2376/#2377/#2380/#2382 series).

## Bug

`/clear-history confirm` clears `session.history` in-memory **before** attempting `history_path.unlink()`. When the `unlink` raises `OSError` (permission denied, file locked by another process), the handler:

1. Returns an error reply to the user ✓
2. But the in-memory list is already empty ✗
3. `history.jsonl` survived on disk intact ✗

On next session startup, `history.jsonl` reloads and the user sees their "cleared" history back — a silent inconsistency. User action appeared to fail (error shown) but partially succeeded (memory cleared), with the wrong half applied.

**Root-cause class**: same "partial state mutation with no rollback" pattern as #2303 — user sees failure but state is left half-mutated.

## Fix

Swap the operation order: attempt disk deletion **first**, clear in-memory only on success.

```python
# Old (broken): memory cleared → disk fail → return error, memory already gone
history.clear()                    # ← done
history_path.unlink(missing_ok=True)  # ← raises OSError → return

# New (fixed): disk first → only clear memory on success
history_path.unlink(missing_ok=True)  # ← raises OSError → return (memory intact)
history.clear()                    # ← only reached if disk succeeded
```

## Test

`test_clear_history_disk_fail_leaves_memory_intact` in `tests/test_slash_clear_history_cmd.py`:

- Uses a hand-written `_FailingPath` stub (no MagicMock/patch) that raises `OSError` on `unlink`
- Asserts `history == ["turn1", "turn2"]` — would fail with the old ordering (history would be `[]`)
- Asserts an error reply was sent

**Falsification**: under the old code, the test fails with `history == []` despite the disk error — directly exposing the regression.

## CI

- ruff ✓ | tier-audit ✓ | pytest ✓ (all passes, no new failures) | verify_module_docstrings ✓

## Test plan

- [x] `pytest tests/test_slash_clear_history_cmd.py tests/test_clear_history_slash_command.py` — 23 passed
- [x] Full pytest (`--ignore=tests/gateway`) — 8320 passed, 15 skipped, 3 xfailed
- [x] (skipped — disk OSError on `/clear-history` is rare in interactive dogfood; regression is covered by the new test)

**Tier self-check**: new test is Tier 2 (slash handler correctness under error path). No Tier 4 violations.

Part of `#2376 / #2377 / #2380 / #2382` real-bug mining arc.