### PR TITLE
fix: rewind reset-records must survive WAL truncation (abandoned history turns reappear)

### DIFF
--- a/src/reyn/core/events/retention.py
+++ b/src/reyn/core/events/retention.py
@@ -75,8 +75,9 @@ def compute_retention_floor(
     ``wal_seq`` anchors from ``history.jsonl`` that may be below the floor
     (abandoned-branch turns). Dropping a rewind record below the floor therefore
     lets abandoned conversation turns reappear in the LLM context. Fix: callers
-    of ``truncate_below`` pass ``always_keep_kinds=frozenset({"rewind"})`` so
-    reset-records survive truncation regardless of the floor.
+    of ``truncate_below`` pass ``always_keep_kinds=frozenset({REWIND_KIND})``
+    (``snapshot_generations.REWIND_KIND``) so reset-records survive truncation
+    regardless of the floor.
     """
     if policy.is_live or policy.keep_generations is None:
         return live_floor

--- a/src/reyn/core/events/retention.py
+++ b/src/reyn/core/events/retention.py
@@ -65,15 +65,18 @@ def compute_retention_floor(
     the gen base WAL replay starts from); the floor is clamped *down* to it so the
     last N checkpoints stay reconstructable.
 
-    **Rewind records are retained automatically** (no separate floor term): a
-    rewind record at seq ``R`` abandons ``(N, R)``; for it to affect a retained
-    seq ``S >= floor`` we need ``N < S < R``, hence ``R > S >= floor`` — so any
-    rewind record whose abandoned interval touches the retained window has
-    ``R >= floor`` and is kept (its ``target_n`` rides in the record's data).
-    Rewind records below the floor only abandon intervals entirely below it, so
-    dropping them cannot corrupt ``is_active`` for retained points. (This is why
-    Q2's "oldest in-window rewind record" term is subsumed by the gen-base term;
-    the reconstructability invariant test pins it.)
+    **Rewind records and the floor**: a rewind record at seq ``R`` abandons
+    ``(N, R)``; for it to affect a retained seq ``S >= floor`` we need
+    ``N < S < R``, hence ``R > S >= floor`` — so any rewind record whose
+    abandoned interval touches the retained window has ``R >= floor`` and is kept.
+    This argument is correct for runtime-state reconstruction (WAL replay uses
+    only seqs >= floor), but ``history.jsonl`` is append-only and never
+    floor-truncated: ``_active_branch_history`` calls ``is_active_seq`` with
+    ``wal_seq`` anchors from ``history.jsonl`` that may be below the floor
+    (abandoned-branch turns). Dropping a rewind record below the floor therefore
+    lets abandoned conversation turns reappear in the LLM context. Fix: callers
+    of ``truncate_below`` pass ``always_keep_kinds=frozenset({"rewind"})`` so
+    reset-records survive truncation regardless of the floor.
     """
     if policy.is_live or policy.keep_generations is None:
         return live_floor

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -392,7 +392,8 @@ class StateLog:
         last universally-absorbed seq).
 
         ``always_keep_kinds``: entries whose ``kind`` is in this set are kept
-        unconditionally regardless of seq. Pass ``frozenset({"rewind"})`` to
+        unconditionally regardless of seq. Pass
+        ``frozenset({REWIND_KIND})`` (``snapshot_generations.REWIND_KIND``) to
         protect reset-records from being dropped: ``_active_branch_history`` calls
         ``is_active_seq`` with ``wal_seq`` values from ``history.jsonl`` (which are
         append-only and can be below the floor), so dropping a rewind record causes

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -378,13 +378,25 @@ class StateLog:
                     continue
                 yield entry
 
-    async def truncate_below(self, min_keep_seq: int) -> None:
+    async def truncate_below(
+        self,
+        min_keep_seq: int,
+        *,
+        always_keep_kinds: "frozenset[str] | None" = None,
+    ) -> None:
         """Atomically rewrite the WAL keeping only entries with ``seq >= min_keep_seq``.
 
         Drop policy: ``seq < min_keep_seq`` entries are dropped. Caller computes
         ``min_keep_seq`` as ``min(全 agent applied_seq, 全 active skill
         last_phase_applied_seq) + 1`` (i.e. drop everything strictly below the
         last universally-absorbed seq).
+
+        ``always_keep_kinds``: entries whose ``kind`` is in this set are kept
+        unconditionally regardless of seq. Pass ``frozenset({"rewind"})`` to
+        protect reset-records from being dropped: ``_active_branch_history`` calls
+        ``is_active_seq`` with ``wal_seq`` values from ``history.jsonl`` (which are
+        append-only and can be below the floor), so dropping a rewind record causes
+        abandoned conversation turns to reappear in the LLM context.
 
         Atomic strategy (mirrors per-snapshot atomic save):
           1. Stream-read current ``wal.jsonl``, write surviving entries to
@@ -403,7 +415,7 @@ class StateLog:
         is handled by the worker's §4 retry → health-signal (no caller to raise to). The stats
         land on ``last_truncate_stats`` (read after ``flush``), not a return value.
         """
-        if min_keep_seq <= 1:
+        if min_keep_seq <= 1 and not always_keep_kinds:
             self._last_truncate_stats = {
                 "dropped": 0, "kept": 0, "min_kept_seq": None, "max_kept_seq": None,
             }
@@ -411,12 +423,16 @@ class StateLog:
 
         async def _job() -> None:
             self._last_truncate_stats = await asyncio.to_thread(
-                self._do_truncate, min_keep_seq,
+                self._do_truncate, min_keep_seq, always_keep_kinds,
             )
 
         self._worker.submit_nowait(_job)
 
-    def _do_truncate(self, min_keep_seq: int) -> dict:
+    def _do_truncate(
+        self,
+        min_keep_seq: int,
+        always_keep_kinds: "frozenset[str] | None" = None,
+    ) -> dict:
         """The synchronous WAL rewrite (run off-loop, serialised by the worker — see
         `truncate_below`). Two-pass: identify the highest seq present (never drop ALL entries —
         that would let `_scan_max_seq` reset the counter + re-issue used seqs), then write the
@@ -477,8 +493,16 @@ class StateLog:
                     dropped += 1
                     continue
                 if seq < effective_floor:
-                    dropped += 1
-                    continue
+                    # always_keep_kinds entries (e.g. "rewind" reset-records) survive
+                    # truncation regardless of seq: _active_branch_history queries
+                    # is_active_seq with wal_seq anchors from history.jsonl (append-only,
+                    # never truncated), so dropping a rewind record below the floor lets
+                    # abandoned conversation turns reappear in the LLM context.
+                    if always_keep_kinds and entry.get("kind") in always_keep_kinds:
+                        pass  # keep despite being below floor
+                    else:
+                        dropped += 1
+                        continue
                 dst.write(raw + "\n")
                 kept += 1
                 if min_kept is None or seq < min_kept:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2016,7 +2016,13 @@ class AgentRegistry:
         try:
             # #2259 PR-2b: fire-and-forget (the GC does not await the worker); the rewrite +
             # any failure are handled in the worker (stats on last_truncate_stats, post-drain).
-            await self._state_log.truncate_below(floor)
+            # always_keep_kinds="rewind": reset-records must outlive the floor so
+            # _active_branch_history can call is_active_seq on history.jsonl wal_seq anchors
+            # that fall below the floor (abandoned conversation turns — the append-only file
+            # is never truncated, so the wal_seq references must remain resolvable).
+            await self._state_log.truncate_below(
+                floor, always_keep_kinds=frozenset({"rewind"}),
+            )
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("WAL truncation: rewrite failed (floor=%d): %s", floor, e)
             return None

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -39,6 +39,7 @@ from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.anchor_store import AnchorStore
 from reyn.core.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.core.events.snapshot_generations import (
+    REWIND_KIND,
     Branch,
     RewindBeyondRetentionError,
     RewindIntoAbandonedError,
@@ -2021,7 +2022,7 @@ class AgentRegistry:
             # that fall below the floor (abandoned conversation turns — the append-only file
             # is never truncated, so the wal_seq references must remain resolvable).
             await self._state_log.truncate_below(
-                floor, always_keep_kinds=frozenset({"rewind"}),
+                floor, always_keep_kinds=frozenset({REWIND_KIND}),
             )
         except Exception as e:  # noqa: BLE001 — defensive; never fail caller
             logger.warning("WAL truncation: rewrite failed (floor=%d): %s", floor, e)

--- a/tests/test_conversation_rewind_2360.py
+++ b/tests/test_conversation_rewind_2360.py
@@ -193,6 +193,52 @@ async def test_mid_tool_cycle_cut_leaves_no_dangling(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_rewind_record_survives_wal_truncation(tmp_path, monkeypatch):
+    """Tier 2: truncate-falsify — abandoned turns stay hidden after WAL truncation below
+    the rewind reset-record (CLAUDE.md recovery PR gate: set X → truncate past X's events
+    → reconstruct → assert X survives).
+
+    Scenario: rewind hides turns 2 and 3. Many new turns advance applied_seq well past the
+    rewind reset-record seq R. A WAL truncation with floor > R would drop the rewind record
+    without always_keep_kinds protection, causing _active_branch_history / is_active_seq to
+    treat (N, R) as active — abandoned turns 2 and 3 reappear in the LLM context.
+    With always_keep_kinds=frozenset({"rewind"}) the reset-record survives and the filter holds.
+    """
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, "alice", state_log)
+
+    # Three turns; rewind to after turn 1 (abandons turns 2 and 3).
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 4)]
+    reset_seq = await checkout(state_log, target_seq=anchors[0])
+
+    # New turns on the active branch — these advance applied_seq past the reset record.
+    for i in range(4, 10):
+        await _turn(s, state_log, f"turn {i}")
+
+    # Truncate with floor > reset_seq so the rewind record is below the floor.
+    # always_keep_kinds=frozenset({"rewind"}) (what AgentRegistry.truncate_wal_if_eligible
+    # passes) must keep the reset-record despite it being below floor.
+    floor = reset_seq + 5  # well past the reset record
+    await state_log.truncate_below(floor, always_keep_kinds=frozenset({"rewind"}))
+    await state_log.flush()
+
+    # Rewind record must survive in the WAL (directly verifiable).
+    surviving_kinds = [e.get("kind") for e in state_log.iter_from(1)]
+    assert "rewind" in surviving_kinds, (
+        "reset-record must survive WAL truncation so is_active_seq can still classify "
+        "abandoned-branch wal_seq values from history.jsonl"
+    )
+
+    # Abandoned turns must stay hidden from the LLM.
+    visible = _visible(s)
+    assert "turn 1" in visible, "turn 1 (before rewind target) must be visible"
+    assert "turn 2" not in visible, "abandoned turn must stay hidden after WAL truncation"
+    assert "turn 3" not in visible, "abandoned turn must stay hidden after WAL truncation"
+    assert "turn 4" in visible, "first post-rewind turn must be visible"
+
+
+@pytest.mark.asyncio
 async def test_cut_before_tool_cycle_hides_whole_cycle_no_dangling(tmp_path, monkeypatch):
     """Tier 2: #2360 tool-cycle-aware — a cut BEFORE the assistant tool_calls turn hides the WHOLE
     cycle (call + result), never a dangling tool result. The other direction of the same atomicity."""


### PR DESCRIPTION
**[tui-coder]** — crash-recovery / WAL reconstruction deep-dive per lead-coder direction.

## Bug

After `rewind_to` / `checkout`, the WAL contains a reset-record at seq `R` marking the abandoned interval `(N, R)`. `_active_branch_history` calls `is_active_seq(state_log, wal_seq)` for each entry in `history.jsonl` to filter out abandoned-branch conversation turns.

**Problem**: once the live floor advances past `R` (after K new turns: `applied_seq = R+K`, floor = `R+K+1`), `truncate_below` dropped the reset-record. After truncation, `_rewind_records(state_log)` returned `[]`, making `is_active_seq` return True for ALL seqs — including abandoned-branch wal_seq values in `(N, R)`. Abandoned conversation turns **reappeared in the LLM context**.

**Why the `retention.py` comment was wrong**: The "rewind records retained automatically" argument says "a rewind record below the floor only abandons an interval entirely below the floor, so dropping it cannot corrupt `is_active` for retained points." This is correct for WAL runtime-state reconstruction (which only uses seqs ≥ floor). It is **not correct for `_active_branch_history`**: `history.jsonl` is append-only and never floor-truncated — its entries carry `wal_seq` anchors that can be BELOW the floor (the abandoned-branch turns are there permanently). Dropping the rewind record made `is_active_seq` return True for those below-floor anchors.

## Fix

`StateLog.truncate_below` gains an `always_keep_kinds: frozenset[str] | None` parameter. `AgentRegistry.truncate_wal_if_eligible` passes `frozenset({"rewind"})`, keeping reset-records in the WAL regardless of the floor. The `retention.py` docstring is corrected.

## Test (CLAUDE.md recovery PR gate)

`test_rewind_record_survives_wal_truncation` — the mandated truncate-falsify test:
1. Rewind to abandon turns 2 and 3 (reset-record at seq R)
2. Advance WAL past R with new turns
3. `truncate_below(floor > R, always_keep_kinds=frozenset({"rewind"}))` + flush
4. Assert `"rewind"` still in WAL (record survived)
5. Assert abandoned turns 2 and 3 are not in `_visible(s)` (filtered correctly)

## Evidence chain

- `state_log.py:_do_truncate` — second-pass now skips drop for entries whose `kind` is in `always_keep_kinds`
- `registry.py:truncate_wal_if_eligible` — passes `frozenset({"rewind"})` to every `truncate_below` call
- `session.py:_active_branch_history` (lines 2688-2715) — unchanged; the fix is in the WAL layer
- `snapshot_generations.py:_rewind_records` (lines 133-139) — unchanged; reads `kind == "rewind"` from WAL

## CI

- `ruff check` ✓
- `test_tier_audit.py --strict` ✓ (8/8 tests Tier 2)
- `pytest` ✓ (8298 passed; 3 pre-existing gateway entry-point failures unrelated to this change)
- `verify_module_docstrings.py` ✓

## Test plan

- [x] `pytest tests/test_conversation_rewind_2360.py` — 8 passed (includes new truncate-falsify)
- [x] `pytest tests/test_rewind_reset_record.py tests/test_state_log_truncate.py tests/test_registry_rewind_to.py tests/test_retention_floor.py tests/test_registry_wal_truncate.py` — 61 passed
- [x] (skipped — UI: no TUI surface changed, no interactive verification path)

part of crash-recovery / WAL reconstruction audit (lead-coder direction post-#2370/#2361/#2379)

Tier self-check: 1 new Tier 2 test (truncate-falsify per CLAUDE.md gate). No Tier 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)