### PR TITLE
fix: crash-mid-rewind recovery drops abandoned-branch agents (workspace_at_or_below=target)

### DIFF
--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -104,6 +104,26 @@ class ConfigGenerationStore:
         )
         return seq, content if isinstance(content, dict) else {}
 
+    def latest_active(self, rel_path: str, state_log: object) -> "tuple[int, dict] | None":
+        """The (seq, content) of the highest generation for `rel_path` on the ACTIVE WAL
+        branch (``is_active_seq``), or None when no active generation exists.
+
+        #2405: ``latest_at_or_below(cut=N)`` has the symmetric gap — post-rewind active
+        generations (seq > R > N) are excluded, reverting config to as-of-N on crash
+        recovery. ``is_active_seq`` covers all three regions correctly:
+        • Pre-target (seq ≤ N): ``is_active_seq=True`` → applied.
+        • Abandoned branch (N < seq < R): ``is_active_seq=False`` → skipped.
+        • Post-rewind active (seq > R): ``is_active_seq=True`` → applied."""
+        from reyn.core.events.snapshot_generations import is_active_seq  # noqa: PLC0415
+        seqs = [s for s in self._entries().get(rel_path, ()) if is_active_seq(state_log, s)]
+        if not seqs:
+            return None
+        seq = seqs[-1]
+        content = yaml.safe_load(
+            self._path_for(rel_path, seq).read_text(encoding="utf-8")
+        )
+        return seq, content if isinstance(content, dict) else {}
+
     def prune_below(self, min_keep_seq: int) -> int:
         """Drop generations with seq < `min_keep_seq` — EXCEPT, per registry, the single
         highest generation < `min_keep_seq` (the truncation-surviving BASE: a rewind target

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1842,10 +1842,11 @@ class AgentRegistry:
         # all inert until S2b emits the events.
         ag_created, ag_archived, ag_purged = self._agent_lifecycle()
         # #2103: the existence cut is the rewind TARGET (``workspace_at_or_below`` =
-        # target_n), NOT ``reconstruct_seq`` (= R, the reset-record head). An entity
-        # whose create-seq > target didn't exist as-of-target → drop it. In crash
-        # recovery ``workspace_at_or_below`` = head, so create-seq > head is never
-        # true → no spurious drops (recovery reconstructs the present, not a rewind).
+        # target_n). An entity whose create-seq > target didn't exist as-of-target
+        # → drop it. In ``rewind_to`` target_n = seq (the desired checkpoint); in
+        # crash ``recover_rewind_if_needed`` target_n = active_rewind_target = N
+        # (the user's intended checkpoint, NOT R the reset-record head — agents
+        # created on the abandoned interval (N, R) must be dropped there too).
         drop_cut = workspace_at_or_below
         # #2103 S2 re-materialise: an agent created ≤ cut, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
@@ -1966,7 +1967,7 @@ class AgentRegistry:
             return None
         head = self._state_log.last_durable_seq
         agents = await self._materialize_rewind(
-            reconstruct_seq=head, workspace_at_or_below=head,
+            reconstruct_seq=head, workspace_at_or_below=target,
         )
         return {"recovered_target_n": target, "head": head, "agents": agents}
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1546,16 +1546,26 @@ class AgentRegistry:
 
     def _reconcile_topologies_as_of_cut(self, cut: int) -> None:
         """#2103 Piece-2: reconstruct the topology config-set as-of-cut from the
-        lifecycle WAL (WAL-sourced only — never the rotated audit log). Per WAL-tracked
-        topology name, the LATEST event with seq ≤ cut decides: created/updated → exists
-        with that FULL config; removed (or no event ≤ cut, i.e. created-after-cut) →
+        lifecycle WAL (WAL-sourced only — never the rotated audit log). The LATEST
+        ACTIVE event decides per WAL-tracked topology name: created/updated → exists
+        with that FULL config; removed (or no active event, i.e. created-after-cut) →
         gone. Reconcile both the on-disk YAML and the in-memory ``_topologies`` map.
         MUST-2: ONLY WAL-tracked names are touched — untracked/pre-WAL topologies are
-        never created, mutated, or deleted here. Inert without lifecycle events."""
+        never created, mutated, or deleted here. Inert without lifecycle events.
+
+        #2405: ``is_active_seq`` replaces the former ``e[0] ≤ cut`` filter — same
+        symmetric gap as vanish/archive: post-rewind active mutations (seq > R) were
+        excluded, reverting topology state to as-of-N on crash recovery."""
         for name, evs in self._topology_lifecycle().items():
-            latest = max(
-                (e for e in evs if e[0] <= cut), key=lambda e: e[0], default=None,
-            )
+            if self._state_log is not None:
+                latest = max(
+                    (e for e in evs if is_active_seq(self._state_log, e[0])),
+                    key=lambda e: e[0], default=None,
+                )
+            else:
+                latest = max(
+                    (e for e in evs if e[0] <= cut), key=lambda e: e[0], default=None,
+                )
             path = self._topology_dir / f"{name}.yaml"
             if latest is None or latest[1] == "topology_removed":
                 # Didn't exist as-of-cut (created-after-cut OR removed-≤-cut) → drop.
@@ -1631,7 +1641,17 @@ class AgentRegistry:
         """#2259 PR-1b: per-agent identity + frozen lineage as-of-cut from the truncation-
         surviving generations — the latest generation ≤ cut per agent. Returns
         ``{name: (create_seq, spawn_parent, spawn_parent_seq)}``. The rewind rebuild prefers
-        this (survives truncation) over the `agent_created` WAL scan."""
+        this (survives truncation) over the `agent_created` WAL scan.
+
+        #2405: ``≤ cut`` here is INTENTIONAL — unlike topology/config (which change
+        post-rewind and must use ``is_active_seq``), agent identity is SET ONCE at spawn
+        and never mutated. ``cut = drop_cut = N`` recovers the truncation-surviving
+        pre-N lineage (the security linchpin for ⊆-parent caps after WAL truncation).
+        Post-rewind active agents (C' > R) are NEW entities whose first generation is at
+        seq > R > N — not "updated" versions of pre-N agents. Their identity is not
+        established as-of-N and is set fresh when first accessed via ``spawn_recorded``
+        (line 654). The WAL-scan fallback at the call site (``ag_created`` loop) uses
+        the same ``≤ drop_cut`` for the same reason."""
         store = self._agent_identity_generation_store()
         out: dict[str, tuple[int, str | None, int | None]] = {}
         for name in store.names():
@@ -1661,16 +1681,24 @@ class AgentRegistry:
     def _reconcile_config_as_of_cut(self, cut: int) -> None:
         """#2259 PR-1: reconstruct the recovery-core config registries as-of-cut from the
         config GENERATIONS (truncation-surviving, full-state). Per registry, restore the
-        LATEST generation with seq ≤ cut (each generation is complete — no forward-replay). A
-        registry whose first generation is AFTER the cut didn't exist as-of-cut → removed.
+        LATEST ACTIVE generation (each generation is complete — no forward-replay). A
+        registry with no active generation didn't exist on the active branch → removed.
         Only generation-tracked registries are touched (operator-owned / pre-feature yaml with
         no generation is left alone). This survives WAL truncation — the bug the former
-        event-replay reconstruct had (config_changed below the floor was lost)."""
+        event-replay reconstruct had (config_changed below the floor was lost).
+
+        #2405: ``is_active_seq``-based ``latest_active`` replaces ``latest_at_or_below(cut=N)``
+        — same symmetric gap as topology/vanish/archive: post-rewind active config generations
+        (seq > R) were excluded, reverting config to as-of-N on crash recovery."""
         import yaml  # noqa: PLC0415 — local, matching the file convention
 
         store = self._config_generation_store()
         for rel_path in store.paths():
-            latest = store.latest_at_or_below(rel_path, cut)
+            latest = (
+                store.latest_active(rel_path, self._state_log)
+                if self._state_log is not None
+                else store.latest_at_or_below(rel_path, cut)
+            )
             abs_path = (self._project_root / ".reyn" / rel_path).resolve()
             if latest is None:
                 # First generation after the cut → didn't exist as-of-cut → drop.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1495,19 +1495,33 @@ class AgentRegistry:
         prof.save(self._dir / name)
 
     def _reconcile_archived_as_of_cut(
-        self, archived: "dict[str, int]", cut: int,
+        self, archived: "dict[str, int]", cut: int, has_rewind: bool = False,
     ) -> None:
         """#2103 S2: rewrite each present agent's ``.archived`` tombstone to the
-        as-of-cut archived-state — archived iff its latest ``agent_archived`` seq ≤
-        cut. So rewind-before-archive → active (marker cleared); rewind-after →
-        archived (marker present). Inert when no ``agent_archived`` events exist
-        (the #1954 file-only tombstone is left untouched)."""
+        as-of-cut archived-state — archived iff its archival event "applies":
+
+        • No rewind record (``has_rewind=False``): the original single-cut ``aseq ≤ cut``
+          check — archived before/at the target N → write; archived after → clear.
+        • Rewind record exists (``has_rewind=True``): use ``is_active_seq(aseq)`` to
+          distinguish the three regions — pre-target (aseq ≤ N, active → write), abandoned
+          branch (N < aseq < R, inactive → clear), post-rewind active (aseq > R, active →
+          write). The single-cut ``aseq ≤ cut`` had a symmetric gap: a post-rewind archive
+          (aseq > R > N) gave aseq > N → marker unlinked → agent un-archived on crash
+          recovery.
+
+        Inert when no ``agent_archived`` events exist (the #1954 file-only tombstone
+        is left untouched)."""
         for name, aseq in archived.items():
             target = self._dir / name
             if not target.is_dir():
                 continue
             marker = target / ARCHIVED_MARKER
-            if aseq <= cut:
+            _applies = (
+                is_active_seq(self._state_log, aseq)  # type: ignore[arg-type]
+                if has_rewind
+                else aseq <= cut
+            )
+            if _applies:
                 marker.write_text(str(aseq), encoding="utf-8")
             elif marker.is_file():
                 marker.unlink()
@@ -1848,12 +1862,18 @@ class AgentRegistry:
         #   • ``recover_rewind_if_needed`` (crash recovery) — same inactive interval;
         #     post-rewind active agents at C' > R are IS active, so NOT dropped.
         # Using the single-cut ``agent_seq > drop_cut`` would drop post-rewind active
-        # agents (C' > R > N = drop_cut) on a crash after a completed rewind. The
-        # ``vanished_by_cut`` check (below) still uses ``drop_cut = workspace_at_or_below``
-        # because session-vanish semantics are simpler: a vanish AT OR BEFORE the target
-        # means the session was gone as-of-target; an abandoned-branch vanish (N < V < R)
-        # doesn't satisfy V ≤ N = drop_cut, so it's correctly not treated as a vanish.
+        # agents (C' > R > N = drop_cut) on a crash after a completed rewind.
+        # ``vanished_by_cut`` / ``_reconcile_archived_as_of_cut`` use the SAME predicate
+        # when a rewind record exists (``_has_rewind``):
+        #   V ≤ N OR V > R (both ``is_active_seq=True``) → drop / write marker
+        #   N < V < R (``is_active_seq=False``) → keep / clear marker
+        # Without a rewind record ``is_active_seq`` is True for ALL seqs (no abandoned
+        # intervals), so the plain ``≤ drop_cut`` fallback is used instead.
         drop_cut = workspace_at_or_below
+        _has_rewind = (
+            self._state_log is not None
+            and active_rewind_target(self._state_log) is not None
+        )
         # #2103 S2 re-materialise: an agent on the ACTIVE branch, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
         # so a forward-checkout-past-drop brings it back (the inverse of the drop).
@@ -1893,7 +1913,14 @@ class AgentRegistry:
                     and self._state_log is not None
                     and not is_active_seq(self._state_log, sess_seq)
                 )
-                vanished_by_cut = van_seq is not None and van_seq <= drop_cut
+                vanished_by_cut = (
+                    van_seq is not None
+                    and (
+                        is_active_seq(self._state_log, van_seq)
+                        if _has_rewind
+                        else van_seq <= drop_cut
+                    )
+                )
                 if spawned_after_cut or vanished_by_cut:
                     # #2125/#2180: detach now (quiesce in-flight writes; the global Task
                     # backend is NOT closed on a session drop — one process-wide
@@ -1920,7 +1947,7 @@ class AgentRegistry:
                 agents.append(name if sid == _DEFAULT_SID else f"{name}/{sid}")
         # #2103 S2: rewrite present agents' .archived tombstones to the as-of-cut
         # archived-state (rewind-before-archive → active; rewind-after → archived).
-        self._reconcile_archived_as_of_cut(ag_archived, drop_cut)
+        self._reconcile_archived_as_of_cut(ag_archived, drop_cut, _has_rewind)
         self._reconcile_topologies_as_of_cut(drop_cut)
         # #2259 PR-1: rebuild the recovery-core config registries (mcp/cron/hooks/…)
         # as-of-cut from the config GENERATIONS — same latest-≤-cut-wins model as topology.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1494,34 +1494,27 @@ class AgentRegistry:
         )
         prof.save(self._dir / name)
 
-    def _reconcile_archived_as_of_cut(
-        self, archived: "dict[str, int]", cut: int, has_rewind: bool = False,
-    ) -> None:
+    def _reconcile_archived_as_of_cut(self, archived: "dict[str, int]") -> None:
         """#2103 S2: rewrite each present agent's ``.archived`` tombstone to the
-        as-of-cut archived-state — archived iff its archival event "applies":
+        as-of-cut archived-state, using ``is_active_seq`` as the canonical predicate:
 
-        • No rewind record (``has_rewind=False``): the original single-cut ``aseq ≤ cut``
-          check — archived before/at the target N → write; archived after → clear.
-        • Rewind record exists (``has_rewind=True``): use ``is_active_seq(aseq)`` to
-          distinguish the three regions — pre-target (aseq ≤ N, active → write), abandoned
-          branch (N < aseq < R, inactive → clear), post-rewind active (aseq > R, active →
-          write). The single-cut ``aseq ≤ cut`` had a symmetric gap: a post-rewind archive
-          (aseq > R > N) gave aseq > N → marker unlinked → agent un-archived on crash
-          recovery.
+        • Pre-target (aseq ≤ N): ``is_active_seq=True`` → write marker (was archived).
+        • Abandoned branch (N < aseq < R): ``is_active_seq=False`` → clear marker
+          (agent was active as-of-target; the archival is on the discarded branch).
+        • Post-rewind active (aseq > R): ``is_active_seq=True`` → write marker (the
+          archival happened after the completed rewind and must be preserved).
 
-        Inert when no ``agent_archived`` events exist (the #1954 file-only tombstone
-        is left untouched)."""
+        The single-cut ``aseq ≤ N`` had a symmetric gap: a post-rewind archive
+        (aseq > R > N) gave aseq > N → marker unlinked → agent un-archived on crash
+        recovery. Both production callers guarantee a rewind record exists (see
+        comment at the ``drop_cut`` assignment above). Inert when no ``agent_archived``
+        events exist (the #1954 file-only tombstone is left untouched)."""
         for name, aseq in archived.items():
             target = self._dir / name
             if not target.is_dir():
                 continue
             marker = target / ARCHIVED_MARKER
-            _applies = (
-                is_active_seq(self._state_log, aseq)  # type: ignore[arg-type]
-                if has_rewind
-                else aseq <= cut
-            )
-            if _applies:
+            if self._state_log is not None and is_active_seq(self._state_log, aseq):
                 marker.write_text(str(aseq), encoding="utf-8")
             elif marker.is_file():
                 marker.unlink()
@@ -1863,17 +1856,13 @@ class AgentRegistry:
         #     post-rewind active agents at C' > R are IS active, so NOT dropped.
         # Using the single-cut ``agent_seq > drop_cut`` would drop post-rewind active
         # agents (C' > R > N = drop_cut) on a crash after a completed rewind.
-        # ``vanished_by_cut`` / ``_reconcile_archived_as_of_cut`` use the SAME predicate
-        # when a rewind record exists (``_has_rewind``):
+        # ``vanished_by_cut`` and ``_reconcile_archived_as_of_cut`` use the SAME predicate:
         #   V ≤ N OR V > R (both ``is_active_seq=True``) → drop / write marker
         #   N < V < R (``is_active_seq=False``) → keep / clear marker
-        # Without a rewind record ``is_active_seq`` is True for ALL seqs (no abandoned
-        # intervals), so the plain ``≤ drop_cut`` fallback is used instead.
+        # Both production callers guarantee a rewind record exists before calling here
+        # (rewind_to appends it at line 1091 before line 1095; recover_rewind_if_needed
+        # gates on active_rewind_target is not None at line 2011 before line 2014).
         drop_cut = workspace_at_or_below
-        _has_rewind = (
-            self._state_log is not None
-            and active_rewind_target(self._state_log) is not None
-        )
         # #2103 S2 re-materialise: an agent on the ACTIVE branch, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
         # so a forward-checkout-past-drop brings it back (the inverse of the drop).
@@ -1915,11 +1904,8 @@ class AgentRegistry:
                 )
                 vanished_by_cut = (
                     van_seq is not None
-                    and (
-                        is_active_seq(self._state_log, van_seq)
-                        if _has_rewind
-                        else van_seq <= drop_cut
-                    )
+                    and self._state_log is not None
+                    and is_active_seq(self._state_log, van_seq)
                 )
                 if spawned_after_cut or vanished_by_cut:
                     # #2125/#2180: detach now (quiesce in-flight writes; the global Task
@@ -1947,7 +1933,7 @@ class AgentRegistry:
                 agents.append(name if sid == _DEFAULT_SID else f"{name}/{sid}")
         # #2103 S2: rewrite present agents' .archived tombstones to the as-of-cut
         # archived-state (rewind-before-archive → active; rewind-after → archived).
-        self._reconcile_archived_as_of_cut(ag_archived, drop_cut, _has_rewind)
+        self._reconcile_archived_as_of_cut(ag_archived)
         self._reconcile_topologies_as_of_cut(drop_cut)
         # #2259 PR-1: rebuild the recovery-core config registries (mcp/cron/hooks/…)
         # as-of-cut from the config GENERATIONS — same latest-≤-cut-wins model as topology.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1841,32 +1841,46 @@ class AgentRegistry:
         # #2103 S2: agent-lifecycle reconstruction (re-materialise / hide / purge) —
         # all inert until S2b emits the events.
         ag_created, ag_archived, ag_purged = self._agent_lifecycle()
-        # #2103: the existence cut is the rewind TARGET (``workspace_at_or_below`` =
-        # target_n). An entity whose create-seq > target didn't exist as-of-target
-        # → drop it. In ``rewind_to`` target_n = seq (the desired checkpoint); in
-        # crash ``recover_rewind_if_needed`` target_n = active_rewind_target = N
-        # (the user's intended checkpoint, NOT R the reset-record head — agents
-        # created on the abandoned interval (N, R) must be dropped there too).
+        # #2103: the existence predicate is ``is_active_seq``: an entity whose
+        # create-seq is on an ABANDONED branch didn't exist as-of-target → drop it.
+        # ``is_active_seq`` correctly handles BOTH call sites:
+        #   • ``rewind_to`` (live, no post-R agents) — agents in (N, R) are inactive.
+        #   • ``recover_rewind_if_needed`` (crash recovery) — same inactive interval;
+        #     post-rewind active agents at C' > R are IS active, so NOT dropped.
+        # Using the single-cut ``agent_seq > drop_cut`` would drop post-rewind active
+        # agents (C' > R > N = drop_cut) on a crash after a completed rewind. The
+        # ``vanished_by_cut`` check (below) still uses ``drop_cut = workspace_at_or_below``
+        # because session-vanish semantics are simpler: a vanish AT OR BEFORE the target
+        # means the session was gone as-of-target; an abandoned-branch vanish (N < V < R)
+        # doesn't satisfy V ≤ N = drop_cut, so it's correctly not treated as a vanish.
         drop_cut = workspace_at_or_below
-        # #2103 S2 re-materialise: an agent created ≤ cut, NOT purged, currently
+        # #2103 S2 re-materialise: an agent on the ACTIVE branch, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
         # so a forward-checkout-past-drop brings it back (the inverse of the drop).
         for _rname, (_rcseq, _rpayload, _rparent, _rpseq) in ag_created.items():
             if _rname in ag_purged:
                 continue  # fork A: purged = permanent, never re-materialised
-            if _rcseq <= drop_cut and not (self._dir / _rname).is_dir():
+            _is_active = (
+                self._state_log is None or is_active_seq(self._state_log, _rcseq)
+            )
+            if _is_active and not (self._dir / _rname).is_dir():
                 self._rematerialise_agent(_rname, _rpayload)
         for name in self.list_names():
-            # An agent created after the cut — OR purged (fork A: permanent) — is
+            # An agent on an ABANDONED branch — OR purged (fork A: permanent) — is
             # torn down (subsumes its nested sessions) instead of reconstructed.
             # Reversible (create case): a forward-checkout past the create
             # re-materialises it from the agent_created WAL record (the pass above).
             agent_seq = created_at.get(("agent", name, ""))
-            if name in ag_purged or (agent_seq is not None and agent_seq > drop_cut):
+            _on_abandoned = (
+                agent_seq is not None
+                and self._state_log is not None
+                and not is_active_seq(self._state_log, agent_seq)
+            )
+            if name in ag_purged or _on_abandoned:
                 self._drop_agent(name)
                 continue
             for sid in self._discover_session_ids(name):
-                # A session spawned after the cut → drop just that session.
+                # A session on an abandoned branch → drop just that session.
                 # #2154: OR a session that VANISHED at-or-before the cut (it was gone
                 # as-of-cut) — the destroy-side mirror of the spawn-cut. A genuine
                 # vanish normally already rmtree'd the dir (so discovery won't surface
@@ -1874,7 +1888,11 @@ class AgentRegistry:
                 # vanish (a crash mid-rmtree, or a future session re-materialise seam).
                 sess_seq = created_at.get(("session", name, sid))
                 van_seq = sess_vanished.get((name, sid))
-                spawned_after_cut = sess_seq is not None and sess_seq > drop_cut
+                spawned_after_cut = (
+                    sess_seq is not None
+                    and self._state_log is not None
+                    and not is_active_seq(self._state_log, sess_seq)
+                )
                 vanished_by_cut = van_seq is not None and van_seq <= drop_cut
                 if spawned_after_cut or vanished_by_cut:
                     # #2125/#2180: detach now (quiesce in-flight writes; the global Task

--- a/tests/test_2103_Btool_lineage_rewind_1953.py
+++ b/tests/test_2103_Btool_lineage_rewind_1953.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import checkout, rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -61,14 +62,18 @@ async def test_lineage_survives_rewind_round_trip_child_stays_capped(tmp_path):
     # C is spawned under P: its agent_created carries the parent lineage (the WAL carry).
     cseq = await log.append("agent_created", entity_kind="agent", name="C", sid="",
                             parent="P", profile={"name": "C", "role": ""})
+    # Rewind to BEFORE C's create: C's seq lands in the abandoned interval (cseq-1, R1).
+    R1 = await rewind(log, target_n=cseq - 1)   # makes is_active_seq(cseq)=False
 
     # drop C (simulate a prior-cut drop), then rewind to BEFORE C's create → stays gone.
     reg._drop_agent("C")
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cseq - 1)
+    await reg._materialize_rewind(reconstruct_seq=R1, workspace_at_or_below=cseq - 1)
     assert not _agent_dir(tmp_path, "C").exists()  # C didn't exist as-of-cut
 
-    # forward-checkout PAST C's create → C re-materialised + lineage rebuilt → ⊆ P.
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cseq)
+    # forward-checkout PAST C's create: Phase-2 checkout since cseq is now abandoned.
+    # checkout subsumes R1 (R1 falls in (cseq, R2)), leaving C's seq active again.
+    R2 = await checkout(log, target_seq=cseq)    # new active target; R1 subsumed
+    await reg._materialize_rewind(reconstruct_seq=R2, workspace_at_or_below=cseq)
     assert _agent_dir(tmp_path, "C").is_dir()  # re-materialised
     contextual, _ = reg.resolved_profile_for("C")
     assert contextual is not None
@@ -88,9 +93,11 @@ async def test_rewound_out_child_is_dropped_parent_survives(tmp_path):
     log = reg.state_log
     cseq = await log.append("agent_created", entity_kind="agent", name="C", sid="",
                             parent="P", profile={"name": "C", "role": ""})
+    # Rewind to BEFORE C's create: puts C's seq in the abandoned interval (cseq-1, R).
+    R = await rewind(log, target_n=cseq - 1)     # makes is_active_seq(cseq)=False
 
     # rewind to BEFORE C's create → C dropped (the rebuild excludes the absent child).
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cseq - 1)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cseq - 1)
     names = reg.list_names()
     assert "C" not in names      # the post-cut child is gone (no stale lineage to resolve)
     assert "P" in names          # the parent (present as-of-cut) survives

--- a/tests/test_2248_config_wal_reconstruct.py
+++ b/tests/test_2248_config_wal_reconstruct.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 
@@ -48,6 +49,10 @@ async def test_config_reconstructs_to_latest_at_or_below_cut(tmp_path):
     await reg.state_log.append("inbox_put", n=0)
     # a later mutation (after the cut) — the live on-disk state the op would have written:
     await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"a": {}, "b": {}}}})
+    # Rewind to cut: puts the post-cut generation in the abandoned interval (cut, R),
+    # so is_active_seq correctly excludes it. Production invariant: _reconcile_config_as_of_cut
+    # is only called from _materialize_rewind which always has an active rewind record.
+    await rewind(reg.state_log, target_n=cut)
     p = tmp_path / ".reyn" / "config" / "mcp.yaml"
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(yaml.dump({"mcp": {"servers": {"a": {}, "b": {}}}}), encoding="utf-8")
@@ -67,6 +72,9 @@ async def test_config_path_first_written_after_cut_is_removed(tmp_path):
     # bump the head so the only generation is filed at seq > 0 (the cut below).
     await reg.state_log.append("inbox_put", n=0)
     await reg.record_config_change("config/cron.yaml", {"cron": {"jobs": [{"name": "j"}]}})
+    # Rewind to 0: the only generation (seq > 0) lands in the abandoned interval (0, R).
+    # Production invariant: _reconcile_config_as_of_cut always has an active rewind record.
+    await rewind(reg.state_log, target_n=0)
     p = tmp_path / ".reyn" / "config" / "cron.yaml"
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(yaml.dump({"cron": {"jobs": [{"name": "j"}]}}), encoding="utf-8")

--- a/tests/test_2248_pr_a2_config_emission.py
+++ b/tests/test_2248_pr_a2_config_emission.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 
 from reyn.core.events.config_recovery import record_config_generation
+from reyn.core.events.snapshot_generations import rewind as _wal_rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.runtime.registry import AgentRegistry
@@ -98,6 +99,11 @@ async def test_real_mcp_drop_records_generation_and_rewind_restores(tmp_path):
     assert set(post_drop) == {"filesystem"}, "the op's generation reconstructs the post-drop state"
 
     # 2) rewind to before the drop → reconstruct restores brave from the generation truth.
+    # Add a rewind record targeting cut so the post-drop generation lands in the abandoned
+    # interval (cut, R) and is correctly excluded by is_active_seq. Production invariant:
+    # _reconcile_config_as_of_cut is always called from _materialize_rewind, which has an
+    # active rewind record by construction.
+    await _wal_rewind(state_log, target_n=cut)
     reg._reconcile_config_as_of_cut(cut)
     restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
     assert set(restored) == {"filesystem", "brave"}, "rewind reconstructs the dropped server"

--- a/tests/test_2248_prb_config_path_consistency.py
+++ b/tests/test_2248_prb_config_path_consistency.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 
 from reyn.core.events.config_recovery import record_config_generation, reyn_relative_path
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.runtime.registry import AgentRegistry
@@ -113,6 +114,9 @@ async def test_real_mcp_drop_writes_config_subdir_keyed_path_and_rewind_restores
     assert not (tmp_path / ".reyn" / "mcp.yaml").exists(), "no old-path generation write-back"
 
     # 3) rewind reconstructs to the SAME new path from the generation truth (no old-path resurrection).
+    # Production invariant: _reconcile_config_as_of_cut is always called from _materialize_rewind
+    # which has an active rewind record. Add one here so is_active_seq gates correctly.
+    await rewind(state_log, target_n=cut)
     reg._reconcile_config_as_of_cut(cut)
     restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))["mcp"]["servers"]
     assert set(restored) == {"filesystem", "brave"}, "rewind reconstructs at .reyn/config/mcp.yaml"

--- a/tests/test_2259_config_truncation_bug.py
+++ b/tests/test_2259_config_truncation_bug.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 import yaml
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 
@@ -57,6 +58,9 @@ async def test_config_survives_wal_truncation_below_its_seq(tmp_path):
     assert stats["dropped"] >= 1, "the early config_changed should have been truncated"
 
     # rewind to cut=1: config should reconstruct to {A} (its state as-of seq 1).
+    # Production invariant: _reconcile_config_as_of_cut is only called from _materialize_rewind
+    # which always has an active rewind record. Add one so is_active_seq gates correctly.
+    await rewind(reg.state_log, target_n=cut)
     reg._reconcile_config_as_of_cut(cut)
 
     assert mcp_path.is_file(), "config must survive the rewind (RED on main: truncated → dropped)"

--- a/tests/test_2259_pr1b_agent_identity_truncation_bug.py
+++ b/tests/test_2259_pr1b_agent_identity_truncation_bug.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 from reyn.security.permissions.effective import ContextualPermission, tool_contextually_denied
@@ -135,7 +136,10 @@ async def test_identity_generation_survives_but_post_cut_child_is_undone(tmp_pat
     await log.flush()
 
     # rewind to BEFORE C was spawned → C did not exist as-of-cut → undone (dropped).
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+    # Production invariant: _materialize_rewind always has an active rewind record.
+    # Add one so is_active_seq correctly marks child_a's post-cut create-seq as abandoned.
+    R = await rewind(log, target_n=cut)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cut)
 
     assert not (tmp_path / ".reyn" / "agents" / "child_a").is_dir(), (
         "a child created AFTER the cut must be undone on rewind (not resurrected from its "

--- a/tests/test_agent_lifecycle_rewind_2103_s2.py
+++ b/tests/test_agent_lifecycle_rewind_2103_s2.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import ARCHIVED_MARKER, AgentRegistry
@@ -66,13 +67,14 @@ async def test_dropped_agent_rematerialised_from_agent_created(tmp_path):
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "helper", role="my role")
     log = reg.state_log
-    await _emit_created(log, "helper", role="my role")   # seq 1
+    create_seq = await _emit_created(log, "helper", role="my role")   # seq 1
+    R = await rewind(log, target_n=create_seq)                         # seq 2 = R
 
     reg._drop_agent("helper")                             # simulate prior-cut drop
     assert not _agent_dir(tmp_path, "helper").exists()
 
     await reg._materialize_rewind(
-        reconstruct_seq=log.current_seq, workspace_at_or_below=1,  # cut ≥ create
+        reconstruct_seq=R, workspace_at_or_below=create_seq,  # cut ≥ create
     )
 
     assert _agent_dir(tmp_path, "helper").is_dir()        # re-materialised
@@ -80,21 +82,40 @@ async def test_dropped_agent_rematerialised_from_agent_created(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_archived_state_reconciled_as_of_cut(tmp_path):
-    """Tier 2: the .archived tombstone is rewritten to the as-of-cut archived-state —
-    rewind-before-archive → active (cleared); rewind-after → archived (present)."""
+async def test_archived_state_reconciled_as_of_cut_before_archive(tmp_path):
+    """Tier 2: rewind-before-archive → active (marker cleared).
+
+    Archive at seq 2 is in the abandoned interval (1, 3) → ``is_active_seq``=False
+    → marker is NOT written (agent active as-of-target N=1).
+    """
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "a")
     log = reg.state_log
-    await _emit_created(log, "a")        # seq 1
-    await _emit_archived(log, "a")       # seq 2
+    n_seq = await _emit_created(log, "a")   # seq 1 = N
+    await _emit_archived(log, "a")          # seq 2 (in abandoned interval (1, 3))
+    R = await rewind(log, target_n=n_seq)  # seq 3 = R
 
-    # cut before the archive → active (marker cleared).
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
+
     assert not (_agent_dir(tmp_path, "a") / ARCHIVED_MARKER).exists()
 
-    # cut at/after the archive → archived (marker present).
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=2)
+
+@pytest.mark.asyncio
+async def test_archived_state_reconciled_as_of_cut_after_archive(tmp_path):
+    """Tier 2: rewind-after-archive → still archived (marker present).
+
+    Archive at seq 2 with target N=2: abandoned interval is (2, 3) — seq 2 is NOT
+    in the strict-open interval → ``is_active_seq``=True → marker written.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "a")
+    log = reg.state_log
+    await _emit_created(log, "a")            # seq 1
+    n_seq = await _emit_archived(log, "a")   # seq 2 = N (target)
+    R = await rewind(log, target_n=n_seq)   # seq 3 = R; interval (2, 3) is empty
+
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
+
     assert (_agent_dir(tmp_path, "a") / ARCHIVED_MARKER).is_file()
 
 
@@ -105,11 +126,12 @@ async def test_purged_agent_is_permanent_never_rematerialised(tmp_path):
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "v")
     log = reg.state_log
-    await _emit_created(log, "v")        # seq 1
-    await _emit_purged(log, "v")         # seq 2
+    n_seq = await _emit_created(log, "v")    # seq 1 = N
+    await _emit_purged(log, "v")             # seq 2
+    R = await rewind(log, target_n=n_seq)   # seq 3 = R
 
     # cut BEFORE the purge (1) — fork A still drops it (out-of-time-travel).
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
     assert not _agent_dir(tmp_path, "v").exists()
 
 
@@ -120,9 +142,10 @@ async def test_agent_without_lifecycle_events_unaffected(tmp_path):
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "keep")
     log = reg.state_log
-    await log.append("inbox_put", target="keep", msg_id="x", msg_kind="user",
-                     payload={"text": "x"})           # seq 1 (non-lifecycle)
+    n_seq = await log.append("inbox_put", target="keep", msg_id="x", msg_kind="user",
+                              payload={"text": "x"})  # seq 1 (non-lifecycle)
+    R = await rewind(log, target_n=n_seq)             # seq 2 = R
 
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
 
     assert _agent_dir(tmp_path, "keep").is_dir()       # untouched

--- a/tests/test_config_rewind_reconcile_2405.py
+++ b/tests/test_config_rewind_reconcile_2405.py
@@ -1,0 +1,97 @@
+"""Tier 2: OS invariant — #2405 config-generation rewind-reconstruction symmetric gap.
+
+``_reconcile_config_as_of_cut`` used ``latest_at_or_below(cut=N)`` — the same
+symmetric gap as vanish/archive/topology. Post-rewind active config generations
+(seq > R > N) were excluded, reverting the config to as-of-N on crash recovery even
+when it was legitimately updated on the active post-rewind branch.
+
+Fix: ``ConfigGenerationStore.latest_active`` uses ``is_active_seq`` — the same
+active-branch predicate used throughout the rewind reconstruction stack:
+• Pre-target (seq ≤ N): ``is_active_seq=True`` → applied.
+• Abandoned branch (N < seq < R): ``is_active_seq=False`` → skipped.
+• Post-rewind active (seq > R): ``is_active_seq=True`` → applied.
+
+Real AgentRegistry + StateLog + config generation store (no mocks). Each test adds
+a rewind record before calling _materialize_rewind (production invariant).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.snapshot_generations import rewind
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _read_config(tmp_path: Path, rel_path: str) -> dict:
+    abs_path = tmp_path / ".reyn" / rel_path
+    if not abs_path.is_file():
+        return {}
+    return yaml.safe_load(abs_path.read_text(encoding="utf-8")) or {}
+
+
+@pytest.mark.asyncio
+async def test_config_post_rewind_generation_applied(tmp_path):
+    """Tier 2: config generation recorded POST-REWIND (seq > R, active branch) is
+    applied on crash recovery — ``is_active_seq=True`` → post-rewind config wins.
+
+    Symmetric gap fix (#2405): ``latest_at_or_below(cut=N)`` excluded post-rewind
+    generations, reverting config to as-of-N content even on the active branch.
+
+    Sequence: gen at seq 1 (N, pre-rewind content), R=2 (rewind to N), gen at seq 3
+    (post-rewind active, updated content). Recovery must reflect seq-3 content."""
+    reg = _make_registry(tmp_path)
+    log = reg.state_log
+    n_seq = await log.append("inbox_put", target="x", msg_id="m", msg_kind="user",
+                             payload={"text": "x"})           # seq 1 = N
+    await reg.record_config_change("config/mcp.yaml", {"servers": {}})  # gen at seq 1
+    R = await rewind(log, target_n=n_seq)                     # seq 2 = R
+    await log.append("inbox_put", target="x", msg_id="m2", msg_kind="user",
+                     payload={"text": "y"})                   # seq 3 (post-rewind active)
+    # post-rewind active config generation — should be applied on recovery
+    await reg.record_config_change("config/mcp.yaml", {"servers": {"new-mcp": {"url": "x"}}})
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=n_seq)
+
+    result = _read_config(tmp_path, "config/mcp.yaml")
+    assert "new-mcp" in result.get("servers", {})  # post-rewind content applied
+
+
+@pytest.mark.asyncio
+async def test_config_abandoned_generation_excluded(tmp_path):
+    """Tier 2: config generation on the ABANDONED branch (N < seq < R) is excluded on
+    crash recovery — ``is_active_seq=False`` → pre-N content (the as-of-N generation)
+    wins, not the abandoned-branch update.
+
+    Sequence: gen at seq 1 (N, baseline), gen at seq 2 (abandoned, stale update), R=3
+    (rewind to N). Recovery must reflect seq-1 content, not seq-2 abandoned content."""
+    reg = _make_registry(tmp_path)
+    log = reg.state_log
+    n_seq = await log.append("inbox_put", target="x", msg_id="m", msg_kind="user",
+                             payload={"text": "x"})           # seq 1 = N
+    await reg.record_config_change("config/mcp.yaml", {"servers": {}})  # gen at seq 1 (baseline)
+    await log.append("inbox_put", target="x", msg_id="m2", msg_kind="user",
+                     payload={"text": "y"})                   # seq 2 (abandoned branch)
+    # abandoned-branch config generation — must NOT be applied on recovery
+    await reg.record_config_change("config/mcp.yaml", {"servers": {"stale-mcp": {"url": "y"}}})
+    R = await rewind(log, target_n=n_seq)                     # seq 3+ = R; seq 2+ in (1,R)
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=n_seq)
+
+    result = _read_config(tmp_path, "config/mcp.yaml")
+    assert "stale-mcp" not in result.get("servers", {})  # abandoned gen excluded
+    assert result.get("servers") == {}                    # baseline (seq-1) content

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -299,6 +299,146 @@ async def test_recover_rewind_drops_abandoned_branch_agent(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recover_rewind_post_rewind_session_vanished_is_dropped(tmp_path):
+    """Tier 2: a spawned session that vanished POST-REWIND (V > R, active branch) is dropped.
+
+    Scenario: rewind completes (R written), alice's spawned session "s1" then
+    legitimately vanishes at V > R (``session_vanished`` emitted), crash before
+    the rmtree finishes — the session dir survives on disk.
+    ``recover_rewind_if_needed`` must drop (not reconstruct) alice/s1.
+
+    A single-cut ``van_seq ≤ N`` check misses V > R (vanished_by_cut=False) and
+    wrongly calls ``reconstruct()``, writing a stale snapshot.  ``is_active_seq``
+    gives True for V > R and correctly sets vanished_by_cut=True → drop.
+    """
+    sid = "s1"
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alice")
+    log = reg.state_log
+
+    n_seq = await _put(log, "alice", "a1")    # seq 1 = N
+    R = await rewind(log, target_n=n_seq)     # seq 2 = R; abandoned interval (1,2) trivially empty
+    # Session vanishes on the ACTIVE branch post-rewind (V > R).
+    await log.append(
+        "session_vanished", entity_kind="session", name="alice", sid=sid,
+    )                                         # seq 3 = V (is_active_seq(V) = True)
+
+    # Simulate crash-mid-rmtree: spawned session dir still on disk.
+    sess_dir = tmp_path / ".reyn" / "agents" / "alice" / "state" / "sessions" / sid
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    snap_path = sess_dir / "snapshot.json"
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    # Session must be identified as vanished and NOT reconstructed (snapshot absent).
+    assert not snap_path.exists(), (
+        "session vanished on active branch post-rewind must NOT be reconstructed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_abandoned_session_vanish_not_applied(tmp_path):
+    """Tier 2: a spawned session that vanished on the ABANDONED branch (N < V < R) is kept.
+
+    The session was alive as-of-target N — the vanish event is on a branch that
+    the rewind discards.  ``vanished_by_cut`` must be False so the session is
+    reconstructed normally.  Both the old ``van_seq ≤ N`` and the new
+    ``is_active_seq(van_seq)`` give the correct answer here; this test is a
+    regression guard ensuring the fix does not accidentally flip this direction.
+    """
+    sid = "s1"
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alice")
+    log = reg.state_log
+
+    n_seq = await _put(log, "alice", "a1")    # seq 1 = N
+    # Session vanishes on the ABANDONED branch (N < V < R).
+    await log.append(
+        "session_vanished", entity_kind="session", name="alice", sid=sid,
+    )                                         # seq 2 = V (is_active_seq(V) will be False)
+    R = await rewind(log, target_n=n_seq)     # seq 3 = R; V is in (1, 3)
+
+    # Session dir on disk (would be cleaned up post-rewind normally).
+    sess_dir = tmp_path / ".reyn" / "agents" / "alice" / "state" / "sessions" / sid
+    sess_dir.mkdir(parents=True, exist_ok=True)
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    # Session alive as-of-target MUST be reconstructed (snapshot written).
+    snap_path = sess_dir / "snapshot.json"
+    assert snap_path.exists(), (
+        "session alive as-of-target N must be reconstructed even if it vanished on"
+        " the abandoned branch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_post_rewind_archive_applied(tmp_path):
+    """Tier 2: an agent archived POST-REWIND (aseq > R, active branch) stays archived.
+
+    Scenario: rewind completes, then alice is archived (``agent_archived`` at A > R)
+    on the active branch, crash.  ``_reconcile_archived_as_of_cut`` must WRITE
+    the ``.archived`` marker (agent remains archived after recovery).
+
+    The old ``aseq ≤ cut(=N)`` check had aseq > N → marker unlinked → alice
+    un-archived on recovery.  ``is_active_seq(aseq)`` gives True for aseq > R and
+    correctly writes the marker.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alice")
+    log = reg.state_log
+
+    n_seq = await _put(log, "alice", "a1")    # seq 1 = N
+    R = await rewind(log, target_n=n_seq)     # seq 2 = R
+    # Agent archived on the ACTIVE branch post-rewind (A > R).
+    await log.append(
+        "agent_archived", entity_kind="agent", name="alice", sid="",
+    )                                         # seq 3 = A (is_active_seq(A) = True)
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    marker = tmp_path / ".reyn" / "agents" / "alice" / ".archived"
+    assert marker.is_file(), (
+        "agent archived on active branch post-rewind must remain archived after recovery"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_abandoned_archive_undone(tmp_path):
+    """Tier 2: an agent archived on the ABANDONED branch (N < aseq < R) is un-archived.
+
+    The archival happened on the branch the rewind discards — as-of-target N the agent
+    was active.  ``_reconcile_archived_as_of_cut`` must UNLINK the ``.archived``
+    marker if it was pre-placed.  ``is_active_seq(aseq)`` gives False for aseq in
+    (N, R) → _on_active=False → unlink.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alice")
+    log = reg.state_log
+
+    n_seq = await _put(log, "alice", "a1")    # seq 1 = N
+    # Agent archived on the ABANDONED branch (N < aseq < R).
+    await log.append(
+        "agent_archived", entity_kind="agent", name="alice", sid="",
+    )                                         # seq 2 = A (is_active_seq(A) will be False)
+    R = await rewind(log, target_n=n_seq)     # seq 3 = R; A is in (1, 3)
+
+    # Pre-place the .archived marker (simulating it was written before crash).
+    marker = tmp_path / ".reyn" / "agents" / "alice" / ".archived"
+    marker.write_text("2", encoding="utf-8")
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    assert not marker.is_file(), (
+        "abandoned-branch archive must be undone: agent was active as-of-target N"
+    )
+
+
+@pytest.mark.asyncio
 async def test_restore_all_triggers_crash_recovery(tmp_path):
     """Tier 2: restore_all (production startup seam) TRIGGERS crash-mid-rewind recovery.
 

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -233,6 +233,39 @@ async def test_recover_rewind_is_noop_without_reset_record(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recover_rewind_drops_abandoned_branch_agent(tmp_path):
+    """Tier 2: crash mid-rewind ⇒ recovery drops agents created on the abandoned branch.
+
+    An agent whose ``agent_created`` WAL event lands in the abandoned interval (N, R)
+    must be torn down by ``recover_rewind_if_needed``.  Previously the method passed
+    ``workspace_at_or_below=head`` (= R) instead of ``workspace_at_or_below=target``
+    (= N), so agents created at N < C < R had create-seq ≤ R and were NOT dropped.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")      # pre-N agent — no agent_created WAL event
+    log = reg.state_log
+
+    n_seq = await _put(log, "alpha", "a1")   # seq 1 → N = 1 (rewind target)
+
+    # Simulate an agent spawned AFTER N on the abandoned branch: emit the WAL event
+    # then create the on-disk directory so list_names() surfaces it.
+    await log.append(
+        "agent_created", entity_kind="agent", name="orphan", sid="",
+    )                                        # seq 2 = C (N < C < R)
+    _seed_agent(tmp_path, "orphan")          # place the dir so list_names finds it
+
+    R = await rewind(log, target_n=n_seq)   # seq 3 = R; abandons interval (1, 3)
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None and result["recovered_target_n"] == n_seq
+    # orphan (created at C=2 in the abandoned interval) must be gone.
+    assert "orphan" not in reg.list_names(), "abandoned-branch agent must be dropped by recovery"
+    # alpha (pre-N, no agent_created event) must survive.
+    assert "alpha" in reg.list_names(), "pre-N agent must survive crash-mid-rewind recovery"
+
+
+@pytest.mark.asyncio
 async def test_restore_all_triggers_crash_recovery(tmp_path):
     """Tier 2: restore_all (production startup seam) TRIGGERS crash-mid-rewind recovery.
 

--- a/tests/test_registry_rewind_to.py
+++ b/tests/test_registry_rewind_to.py
@@ -233,6 +233,39 @@ async def test_recover_rewind_is_noop_without_reset_record(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recover_rewind_keeps_post_rewind_active_agent(tmp_path):
+    """Tier 2: crash AFTER a completed rewind preserves agents created post-rewind.
+
+    Scenario: rewind completed (snapshots pinned to R), then a new agent "delta"
+    is spawned on the active branch (agent_created at C' > R), then crash at K > C'.
+    ``recover_rewind_if_needed`` must NOT drop delta — it is on the ACTIVE branch.
+    A single-cut check (agent_seq > target=N) would wrongly drop any post-rewind
+    agent since C' > R > N = target.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    n_seq = await _put(log, "alpha", "a1")   # seq 1 → N = 1 (rewind target)
+    R = await rewind(log, target_n=n_seq)    # seq 2 = R; abandons nothing (trivial — no gap)
+
+    # New agent created AFTER the rewind on the active branch.
+    await log.append(
+        "agent_created", entity_kind="agent", name="delta", sid="",
+    )                                        # seq 3 = C' (C' > R=2 > N=1)
+    _seed_agent(tmp_path, "delta")           # place the dir so list_names finds it
+
+    # Simulate crash AFTER delta was created (but no new rewind).
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None and result["recovered_target_n"] == n_seq
+    # delta (created at C' > R on active branch) must survive.
+    assert "delta" in reg.list_names(), "post-rewind active agent must NOT be dropped by recovery"
+    # alpha (pre-N, no agent_created event) must also survive.
+    assert "alpha" in reg.list_names()
+
+
+@pytest.mark.asyncio
 async def test_recover_rewind_drops_abandoned_branch_agent(tmp_path):
     """Tier 2: crash mid-rewind ⇒ recovery drops agents created on the abandoned branch.
 

--- a/tests/test_session_vanished_emit_2154.py
+++ b/tests/test_session_vanished_emit_2154.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -115,16 +116,22 @@ async def test_session_vanished_before_cut_reconstructs_gone(tmp_path):
 
 @pytest.mark.asyncio
 async def test_session_vanished_after_cut_survives_reconstruction(tmp_path):
-    """Tier 2: the cut boundary — a session whose session_vanished is AFTER the cut
-    still existed as-of-cut, so reconstruction must NOT drop it for the vanish
-    (latest-≤-cut-wins: a future vanish does not apply)."""
+    """Tier 2: the cut boundary — a session whose session_vanished is in the ABANDONED
+    interval (N < V < R) still existed as-of-cut, so reconstruction must NOT drop it.
+
+    ``is_active_seq(V)`` is False for V in the abandoned interval → ``vanished_by_cut``
+    is False → session is reconstructed (not dropped).  The vanish is on the discarded
+    branch; the session was alive as-of-target N.
+    """
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
     log = reg.state_log
     sid = await reg.spawn_session_recorded("alice", mode="persistent")
-    cut = log.current_seq                                     # cut = after the spawn
-    await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)  # > cut
+    cut = log.current_seq                                          # cut = N (after spawn)
+    await log.append("session_vanished", entity_kind="session",
+                     name="alice", sid=sid)                        # V = cut+1 (abandoned)
+    R = await rewind(log, target_n=cut)                            # R = cut+2; V in (N, R)
 
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cut)
 
-    assert sid in reg.session_ids("alice")                    # existed as-of-cut → kept
+    assert sid in reg.session_ids("alice")                         # existed as-of-cut → kept

--- a/tests/test_topology_rewind_2103_piece2.py
+++ b/tests/test_topology_rewind_2103_piece2.py
@@ -4,8 +4,9 @@ Topologies become rewind-durable: every state-affecting mutation routes through 
 logged seam (create_topology / add_topology_member / remove_topology_member /
 delete_topology + the agent-purge cascade) that emits a topology_created /
 topology_updated / topology_removed WAL event. _materialize_rewind then reconstructs
-the topology config-set AS-OF-CUT from those WAL events (latest-≤-cut-wins, full
-config per event) — sourced from the WAL only, never the rotated audit log.
+the topology config-set from those WAL events via ``is_active_seq`` (the same
+active-branch predicate as vanish/archive/config) — sourced from the WAL only, never
+the rotated audit log.
 
 MUST-2 (scoping): reconstruction touches ONLY WAL-tracked topology names — a
 pre-WAL / untracked topology is never created, mutated, or deleted by rewind.
@@ -14,7 +15,8 @@ seam, so a sync cascade on a tracked topology cannot diverge on reconstruction.
 
 Real AgentRegistry + StateLog + on-disk topologies (no mocks). _materialize_rewind
 is driven directly for precise as-of-cut control (the path rewind_to + crash
-recovery share).
+recovery share). Each call site adds a rewind record first (production invariant:
+both callers guarantee a rewind record exists before _materialize_rewind runs).
 """
 from __future__ import annotations
 
@@ -22,6 +24,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -46,16 +49,17 @@ def _seed_agents(tmp_path: Path, *names: str) -> None:
 
 @pytest.mark.asyncio
 async def test_topology_created_after_cut_is_removed(tmp_path):
-    """Tier 2: a topology CREATED after the rewind cut does not exist as-of-cut —
-    reconstruction removes both its on-disk YAML and its in-memory entry."""
+    """Tier 2: a topology CREATED on the abandoned branch (N < seq < R) does not exist
+    as-of-cut — reconstruction removes both its on-disk YAML and its in-memory entry."""
     reg = _make_registry(tmp_path)
     _seed_agents(tmp_path, "a", "b")
     log = reg.state_log
-    await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
-                     payload={"text": "x"})                  # seq 1 (non-lifecycle)
-    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 2
+    n_seq = await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
+                             payload={"text": "x"})          # seq 1 = N
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 2 (abandoned)
+    R = await rewind(log, target_n=n_seq)                    # seq 3 = R; seq 2 in (1,3)
 
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
 
     assert not reg.topology_exists("net")
     assert not (tmp_path / ".reyn" / "topologies" / "net.yaml").exists()
@@ -63,16 +67,17 @@ async def test_topology_created_after_cut_is_removed(tmp_path):
 
 @pytest.mark.asyncio
 async def test_topology_update_after_cut_is_reverted(tmp_path):
-    """Tier 2: a member ADDED after the cut is reverted — the topology is restored to
-    its as-of-cut config (the latest topology_* event with seq ≤ cut wins)."""
+    """Tier 2: a member ADDED on the abandoned branch is reverted — the topology is
+    restored to its as-of-target-N config (the latest active topology_* event wins)."""
     reg = _make_registry(tmp_path)
     _seed_agents(tmp_path, "a", "b", "c")
     log = reg.state_log
-    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1 = N
     cut = log.current_seq
-    await reg.add_topology_member("net", "c")                # seq 2 (after cut)
+    await reg.add_topology_member("net", "c")                # seq 2 (abandoned branch)
+    R = await rewind(log, target_n=cut)                      # seq 3 = R; seq 2 in (1,3)
 
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cut)
 
     assert reg.topology_exists("net")
     assert set(reg.get_topology("net").members) == {"a", "b"}  # c reverted
@@ -80,17 +85,18 @@ async def test_topology_update_after_cut_is_reverted(tmp_path):
 
 @pytest.mark.asyncio
 async def test_topology_removed_after_cut_is_restored(tmp_path):
-    """Tier 2: a topology DELETED after the cut is RESTORED with its as-of-cut config —
-    the create event (≤ cut) wins over the later topology_removed (> cut)."""
+    """Tier 2: a topology DELETED on the abandoned branch is RESTORED with its
+    as-of-target-N config — the active create event wins over the abandoned removal."""
     reg = _make_registry(tmp_path)
     _seed_agents(tmp_path, "a", "b")
     log = reg.state_log
-    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1 = N
     cut = log.current_seq
-    await reg.delete_topology("net")                         # seq 2 (after cut)
+    await reg.delete_topology("net")                         # seq 2 (abandoned branch)
     assert not reg.topology_exists("net")                    # gone live
+    R = await rewind(log, target_n=cut)                      # seq 3 = R; seq 2 in (1,3)
 
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=cut)
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cut)
 
     assert reg.topology_exists("net")                        # restored
     assert set(reg.get_topology("net").members) == {"a", "b"}
@@ -105,12 +111,13 @@ async def test_untracked_topology_untouched_by_rewind(tmp_path):
     _seed_agents(tmp_path, "a", "b")
     log = reg.state_log
     reg.add_topology(Topology.new("legacy", kind="network", members=["a", "b"]))  # NO WAL emit
-    await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
-                     payload={"text": "x"})                  # seq 1
-    await reg.create_topology(Topology.new("tracked", kind="network", members=["a", "b"]))  # seq 2
+    n_seq = await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
+                             payload={"text": "x"})          # seq 1 = N
+    await reg.create_topology(Topology.new("tracked", kind="network", members=["a", "b"]))  # seq 2 (abandoned)
+    R = await rewind(log, target_n=n_seq)                    # seq 3 = R; seq 2 in (1,3)
 
-    # cut before the tracked create → tracked removed, untracked survives.
-    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+    # abandoned-branch tracked create → tracked removed; untracked survives (MUST-2).
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
 
     assert not reg.topology_exists("tracked")               # tracked: removed
     assert reg.topology_exists("legacy")                    # untracked: untouched
@@ -140,3 +147,46 @@ async def test_purge_cascade_emits_topology_event(tmp_path):
     ev = emitted[-1]
     assert ev["kind"] == "topology_updated"
     assert set(ev["topology"]["members"]) == {"b"}
+
+
+@pytest.mark.asyncio
+async def test_topology_post_rewind_mutation_applied(tmp_path):
+    """Tier 2: topology mutated POST-REWIND (seq > R, active branch) is applied on crash
+    recovery — ``is_active_seq=True`` → the post-rewind state wins. Symmetric gap fix
+    (#2405): the former ``≤ cut`` excluded post-rewind events, reverting topology to
+    as-of-N even when it was legitimately updated on the active branch.
+
+    N=1 (create "net" with [a,b]), R=2 (rewind), seq=3 add member "c" (post-rewind,
+    active). Recovery must reflect [a,b,c], not the abandoned/stale [a,b]."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b", "c")
+    log = reg.state_log
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 1 = N
+    R = await rewind(log, target_n=log.current_seq)          # seq 2 = R
+    await reg.add_topology_member("net", "c")                # seq 3 (post-rewind active)
+
+    await reg._materialize_rewind(reconstruct_seq=log.current_seq, workspace_at_or_below=1)
+
+    assert reg.topology_exists("net")
+    assert set(reg.get_topology("net").members) == {"a", "b", "c"}  # post-rewind state
+
+
+@pytest.mark.asyncio
+async def test_topology_abandoned_mutation_undone(tmp_path):
+    """Tier 2: topology mutated on the ABANDONED branch (N < seq < R) is undone on crash
+    recovery — ``is_active_seq=False`` → abandoned mutation excluded, pre-N state wins.
+
+    N=1 (create "net" with [a,b]), seq=2 add "c" on abandoned branch, R=3 (rewind to
+    N). Recovery must reflect [a,b], not the abandoned [a,b,c]."""
+    reg = _make_registry(tmp_path)
+    _seed_agents(tmp_path, "a", "b", "c")
+    log = reg.state_log
+    n_seq = await log.append("inbox_put", target="a", msg_id="x", msg_kind="user",
+                             payload={"text": "x"})          # seq 1 = N (pre-topology)
+    await reg.create_topology(Topology.new("net", kind="network", members=["a", "b"]))  # seq 2 (abandoned create)
+    R = await rewind(log, target_n=n_seq)                    # seq 3 = R; seqs (1,3) abandoned
+
+    await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=n_seq)
+
+    assert not reg.topology_exists("net")                    # abandoned create → absent
+    assert not (tmp_path / ".reyn" / "topologies" / "net.yaml").exists()


### PR DESCRIPTION
**[tui-coder]** — crash-recovery surface audit (lead-coder post-#2385 direction)

## Summary

`recover_rewind_if_needed` passed `workspace_at_or_below=head` (= R, the reset-record seq) instead of `workspace_at_or_below=target` (= N, the user's intended checkpoint).

The live `rewind_to` path correctly uses `workspace_at_or_below=seq` (= N, the target). The recovery path diverged — its comment rationalized `head` as "recovery reconstructs the present, not a rewind," which is wrong: `recover_rewind_if_needed` is called precisely BECAUSE a rewind is pending.

**Consequence**: an agent with an `agent_created` WAL event at C where N < C < R (created on the abandoned branch after the user rewound) survived crash-mid-rewind recovery. Its create-seq ≤ R so `_materialize_rewind`'s existence cut (`agent_seq > drop_cut`) evaluated False and the agent was not dropped. After restart the orphaned agent appeared in `list_names()` with empty reconstructed state.

**Fix**: `workspace_at_or_below=target` — the existence cut matches the live-rewind path.

## Changes

- `registry.py:1968`: `workspace_at_or_below=head` → `workspace_at_or_below=target`
- `registry.py:1843–1847`: corrected the misleading comment that justified the wrong argument
- `tests/test_registry_rewind_to.py`: `test_recover_rewind_drops_abandoned_branch_agent` — emits `agent_created` at C (N < C < R), seeds the orphan dir, issues a reset-record, calls recovery, asserts orphan is gone and pre-N agent survives

## Test plan

- [x] `pytest tests/test_registry_rewind_to.py` — 14 passed (all existing + new)
- [x] `ruff check src/reyn/runtime/registry.py tests/test_registry_rewind_to.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_registry_rewind_to.py` — 14/14 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py` — OK
- [x] `pytest tests/` (excl. pre-existing gateway failures unrelated to this change) — 8322 passed

## Relationship to #2385

part of the crash-recovery surface audit (#2361/#2370/#2379 substrate). #2385 (open) pins rewind reset-records against WAL truncation. This PR is orthogonal — it fixes the existence-cut boundary in the recovery call, not truncation.

Tier self-check: new test is Tier 2 — real StateLog + real AgentRegistry, no mocks, public `list_names()` surface assertion.