### PR TITLE
feat(#2285): status-bar toggle UI shell — visibility + hook applicability

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -221,42 +221,77 @@ def _task_expansion(snap, dispatch):
 
 
 def _more_expansion(snap, dispatch):
-    """Read-only overflow panel: cron jobs / mcp servers / hooks from config.
+    """Status-bar overflow panel: visibility + hook toggles + read-only sections.
 
-    Renders a sectioned listing — one header per category (always shown, even
-    when the section is empty) with indented item rows. No actions, no dispatch
-    calls — purely informational. Toggles are a separate OS-lane design (#2285).
+    Returns a list of RegionElements — DetailElement section headers (non-
+    selectable, cursor skips them) and CommandUIElement item rows (selectable,
+    Enter dispatches a /visibility or /hook command). When the backend hasn't
+    wired visibility_items / hook_items yet the corresponding sections fall back
+    to the existing read-only config listing. Cron is always read-only (deferred
+    per #2285 design).
+
+    Slash command format locked with e2e-coder (#2285):
+      /visibility on|off  tool|skill|mcp|category  <name>
+      /hook        on|off  <name>
     """
+    elements: list = []
+
+    # --- Visibility toggles (tool / skill / mcp) ---
+    vis_items = snap.get("visibility_items") or []
+    if vis_items:
+        # Group by kind so each kind gets its own section.
+        by_kind: dict[str, list[dict]] = {}
+        for it in vis_items:
+            by_kind.setdefault(it.get("kind", "tool"), []).append(it)
+        for kind, items in by_kind.items():
+            n = len(items)
+            hdr = f"{kind}  ({n})"
+            elements.append(DetailElement(lambda h=hdr: [h]))
+            rows = [f"  [{'on' if it['on'] else 'off'}] {it['name']}" for it in items]
+            cmds = [
+                f"/visibility {'off' if it['on'] else 'on'} {kind} {it['name']}"
+                for it in items
+            ]
+            elements.append(CommandUIElement(rows, cmds, dispatch))
+    else:
+        # Fallback: read-only mcp listing from config (no session state yet).
+        mcp_servers = snap.get("mcp_servers") or []
+        mcp_lines = [f"  {s['name']}" for s in mcp_servers] or ["  (none)"]
+        n = len(mcp_servers)
+        elements.append(DetailElement(lambda n=n, ls=mcp_lines: [f"mcp  ({n})"] + ls))
+
+    # --- Hook applicability toggles ---
+    hook_items = snap.get("hook_items") or []
+    if hook_items:
+        n = len(hook_items)
+        hdr = f"hooks  ({n})"
+        elements.append(DetailElement(lambda h=hdr: [h]))
+        rows = [
+            f"  [{'on' if h['on'] else 'off'}] {h['name']}"
+            + (f"  · {h['scope']}" if h.get("scope") else "")
+            for h in hook_items
+        ]
+        cmds = [f"/hook {'off' if h['on'] else 'on'} {h['name']}" for h in hook_items]
+        elements.append(CommandUIElement(rows, cmds, dispatch))
+    else:
+        # Fallback: read-only hooks listing from config.
+        hooks = snap.get("hooks") or []
+        hook_lines = [f"  {h['label']}" for h in hooks] or ["  (none)"]
+        n = len(hooks)
+        elements.append(DetailElement(lambda n=n, ls=hook_lines: [f"hooks  ({n})"] + ls))
+
+    # --- Cron section (read-only; per-session cron is deferred in #2285) ---
     cron_jobs = snap.get("cron_jobs") or []
-    mcp_servers = snap.get("mcp_servers") or []
-    hooks = snap.get("hooks") or []
+    cron_lines: list[str] = []
+    for j in cron_jobs:
+        marker = "on" if j.get("enabled") else "off"
+        cron_lines.append(f"  [{marker}] {j['name']}  {j['schedule']}")
+    if not cron_lines:
+        cron_lines = ["  (none)"]
+    n = len(cron_jobs)
+    elements.append(DetailElement(lambda n=n, ls=cron_lines: [f"cron  ({n})"] + ls))
 
-    lines: list[str] = []
-
-    lines.append(f"cron  ({len(cron_jobs)})")
-    if cron_jobs:
-        for j in cron_jobs:
-            marker = "on" if j["enabled"] else "off"
-            lines.append(f"  [{marker}] {j['name']}  {j['schedule']}")
-    else:
-        lines.append("  (none)")
-
-    lines.append(f"mcp  ({len(mcp_servers)})")
-    if mcp_servers:
-        for s in mcp_servers:
-            lines.append(f"  {s['name']}")
-    else:
-        lines.append("  (none)")
-
-    lines.append(f"hooks  ({len(hooks)})")
-    if hooks:
-        for h in hooks:
-            lines.append(f"  {h['label']}")
-    else:
-        lines.append("  (none)")
-
-    captured = lines[:]
-    return DetailElement(lambda: captured)
+    return elements
 
 
 _CHIP_SPECS = [
@@ -378,6 +413,45 @@ def _extract_hooks(config) -> list[dict]:
     return result
 
 
+def _session_visibility_items(session) -> list[dict]:
+    """Read visibility toggle state from the session (#2285 backend seam).
+
+    Returns [] until e2e lands ``capability_visibility_state`` on the Session.
+    Shape when available: [{kind, name, on}, ...] where on = not hidden_by_session.
+    """
+    getter = getattr(session, "capability_visibility_state", None)
+    if getter is None:
+        return []
+    try:
+        state = getter()
+        authorized = state.get("authorized") or []
+        hidden = {(h["kind"], h["name"]) for h in (state.get("hidden_by_session") or [])}
+        return [
+            {"kind": a["kind"], "name": a["name"], "on": (a["kind"], a["name"]) not in hidden}
+            for a in authorized
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _session_hook_items(session) -> list[dict]:
+    """Read hook applicability state from the session (#2285 backend seam).
+
+    Returns [] until e2e lands ``hook_state`` on the Session.
+    Shape when available: [{name, scope, on}, ...].
+    """
+    getter = getattr(session, "hook_state", None)
+    if getter is None:
+        return []
+    try:
+        return [
+            {"name": h["name"], "scope": h.get("scope", ""), "on": h.get("enabled", True)}
+            for h in (getter() or [])
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _snapshot(registry, task_cache=None, config=None):
     """Read live status values off the attached session via sync accessors."""
     s = registry.attached_session()
@@ -408,6 +482,10 @@ def _snapshot(registry, task_cache=None, config=None):
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
         "hooks": _extract_hooks(config) if config is not None else [],
+        # #2285: session-scoped capability visibility + hook applicability toggles.
+        # Populated once e2e lands the backend; graceful fallback to [] until then.
+        "visibility_items": _session_visibility_items(s),
+        "hook_items": _session_hook_items(s),
     }
 
 
@@ -613,14 +691,20 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         app.create_background_task(_submit(registry, text))
 
     def _menu_open() -> None:
-        # Build the opened chip's element fresh and host it in menu_region. The
-        # picker rows are static (classes); a read-only panel's lines stay live.
+        # Build the opened chip's element(s) fresh and host them in menu_region.
+        # Expansion functions may return a single element (model / agent / …) or a
+        # list of mixed elements (_more_expansion: DetailElement headers +
+        # CommandUIElement toggle rows). Both paths are supported.
         spec = _CHIP_SPECS[menu["sel"]]
         menu_region.clear()
         snap = _snapshot(registry, task_cache, config)
         if spec.expansion is not None and snap is not None:
-            el = spec.expansion(snap, _menu_submit)
-            menu_region.register(el)
+            result = spec.expansion(snap, _menu_submit)
+            if isinstance(result, list):
+                for el in result:
+                    menu_region.register(el)
+            else:
+                menu_region.register(result)
         menu["open"] = True
 
     def _menu_close() -> None:

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -15,6 +15,8 @@ from reyn.interfaces.inline.app import (
     _cost_expansion,
     _model_expansion,
     _more_expansion,
+    _session_hook_items,
+    _session_visibility_items,
     _task_expansion,
 )
 from reyn.interfaces.inline.region import DetailElement
@@ -37,6 +39,8 @@ def _snap(**over):
         "cron_jobs": [],
         "mcp_servers": [],
         "hooks": [],
+        "visibility_items": [],
+        "hook_items": [],
     }
     base.update(over)
     return base
@@ -103,36 +107,34 @@ def test_more_chip_has_expansion() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _more_expansion (Phase 5a: read-only cron/mcp/hooks overflow panel)
+# _more_expansion (Phase 5a → #2285: visibility/hook toggles + read-only cron)
 # ---------------------------------------------------------------------------
 
-
-def test_more_expansion_empty_returns_detail_element() -> None:
-    """Tier 2: _more_expansion with empty config sections returns a read-only DetailElement."""
-    el = _more_expansion(_snap(), lambda _: None)
-    assert isinstance(el, DetailElement)
-    assert el.selectable is False
+def _all_lines(elements: list) -> list[str]:
+    """Flatten lines from a list of RegionElements (DetailElement or CommandUIElement)."""
+    return [ln for el in elements for ln in el.lines()]
 
 
-def test_more_expansion_empty_shows_all_section_headers_with_zero() -> None:
-    """Tier 2: empty snap shows cron/mcp/hooks headers with (0) and a (none) line each."""
-    el = _more_expansion(_snap(), lambda _: None)
-    joined = " ".join(el.lines())
-    assert "cron" in joined
+def test_more_expansion_returns_element_list() -> None:
+    """Tier 2: _more_expansion always returns a list of RegionElements (not a single element)."""
+    result = _more_expansion(_snap(), lambda _: None)
+    assert isinstance(result, list)
+    assert len(result) >= 1
+
+
+def test_more_expansion_fallback_all_detail_elements_when_no_session_data() -> None:
+    """Tier 2: without visibility_items/hook_items the panel is all-read-only DetailElements."""
+    result = _more_expansion(_snap(), lambda _: None)
+    assert all(isinstance(el, DetailElement) for el in result)
+
+
+def test_more_expansion_empty_shows_all_section_headers() -> None:
+    """Tier 2: empty snap shows mcp/hooks/cron headers in the panel."""
+    joined = " ".join(_all_lines(_more_expansion(_snap(), lambda _: None)))
     assert "mcp" in joined
     assert "hooks" in joined
-    assert "(0)" in joined
+    assert "cron" in joined
     assert "(none)" in joined
-
-
-def test_more_expansion_empty_all_three_sections_each_have_none_line() -> None:
-    """Tier 2: each of the three sections contains a '(none)' indicator when empty."""
-    el = _more_expansion(_snap(), lambda _: None)
-    lines = el.lines()
-    # There should be a (none) line following each header.
-    none_lines = [ln for ln in lines if "(none)" in ln]
-    # At minimum one (none) per section — i.e. three total when all empty.
-    assert none_lines
 
 
 def test_more_expansion_populated_cron_shows_on_off_markers() -> None:
@@ -145,36 +147,177 @@ def test_more_expansion_populated_cron_shows_on_off_markers() -> None:
         mcp_servers=[{"name": "github"}],
         hooks=[{"label": "on_push"}],
     )
-    el = _more_expansion(snap, lambda _: None)
-    joined = " ".join(el.lines())
+    joined = " ".join(_all_lines(_more_expansion(snap, lambda _: None)))
     assert "nightly" in joined
-    assert "on" in joined       # enabled marker for nightly
+    assert "on" in joined
     assert "paused" in joined
-    assert "off" in joined      # disabled marker for paused
+    assert "off" in joined
 
 
 def test_more_expansion_populated_mcp_shows_server_name() -> None:
-    """Tier 2: populated mcp_servers renders the server name."""
-    snap = _snap(
-        cron_jobs=[],
-        mcp_servers=[{"name": "github"}],
-        hooks=[],
-    )
-    el = _more_expansion(snap, lambda _: None)
-    joined = " ".join(el.lines())
+    """Tier 2: populated mcp_servers renders the server name in fallback mode."""
+    snap = _snap(mcp_servers=[{"name": "github"}])
+    joined = " ".join(_all_lines(_more_expansion(snap, lambda _: None)))
     assert "github" in joined
 
 
 def test_more_expansion_populated_hooks_shows_label() -> None:
-    """Tier 2: populated hooks renders the hook label."""
-    snap = _snap(
-        cron_jobs=[],
-        mcp_servers=[],
-        hooks=[{"label": "on_push"}],
-    )
-    el = _more_expansion(snap, lambda _: None)
-    joined = " ".join(el.lines())
+    """Tier 2: populated hooks renders the hook label in fallback mode."""
+    snap = _snap(hooks=[{"label": "on_push"}])
+    joined = " ".join(_all_lines(_more_expansion(snap, lambda _: None)))
     assert "on_push" in joined
+
+
+# ---------------------------------------------------------------------------
+# _more_expansion toggle mode (#2285: visibility_items / hook_items present)
+# ---------------------------------------------------------------------------
+
+
+def test_more_expansion_visibility_items_yield_command_ui_rows() -> None:
+    """Tier 2: when visibility_items are present, _more_expansion returns CommandUIElement
+    rows (selectable) with [on]/[off] markers and /visibility dispatch commands."""
+    dispatched: list[str] = []
+    snap = _snap(
+        visibility_items=[
+            {"kind": "tool", "name": "bash", "on": True},
+            {"kind": "tool", "name": "sandboxed_exec", "on": False},
+        ],
+    )
+    result = _more_expansion(snap, dispatched.append)
+
+    # At least one CommandUIElement for the tool items.
+    cmd_els = [el for el in result if isinstance(el, CommandUIElement)]
+    assert cmd_els, "expected at least one selectable CommandUIElement for tool items"
+
+    all_ln = _all_lines(result)
+    assert any("[on] bash" in ln for ln in all_ln)
+    assert any("[off] sandboxed_exec" in ln for ln in all_ln)
+
+
+def test_more_expansion_toggle_on_item_dispatches_off_command() -> None:
+    """Tier 2: selecting an [on] tool row dispatches '/visibility off tool <name>'."""
+    dispatched: list[str] = []
+    snap = _snap(
+        visibility_items=[{"kind": "tool", "name": "bash", "on": True}],
+    )
+    result = _more_expansion(snap, dispatched.append)
+    cmd_el = next(el for el in result if isinstance(el, CommandUIElement))
+    cmd_el.on_select(0)
+    assert dispatched == ["/visibility off tool bash"]
+
+
+def test_more_expansion_toggle_off_item_dispatches_on_command() -> None:
+    """Tier 2: selecting an [off] mcp row dispatches '/visibility on mcp <name>'."""
+    dispatched: list[str] = []
+    snap = _snap(
+        visibility_items=[{"kind": "mcp", "name": "brave", "on": False}],
+    )
+    result = _more_expansion(snap, dispatched.append)
+    cmd_el = next(el for el in result if isinstance(el, CommandUIElement))
+    cmd_el.on_select(0)
+    assert dispatched == ["/visibility on mcp brave"]
+
+
+def test_more_expansion_section_headers_are_non_selectable() -> None:
+    """Tier 2: section header elements are DetailElement (non-selectable) even when
+    item rows are CommandUIElement — the Region cursor skips them."""
+    snap = _snap(
+        visibility_items=[{"kind": "tool", "name": "bash", "on": True}],
+    )
+    result = _more_expansion(snap, lambda _: None)
+    # All DetailElements must have selectable=False.
+    for el in result:
+        if isinstance(el, DetailElement):
+            assert el.selectable is False
+
+
+def test_more_expansion_hook_items_show_toggle_rows() -> None:
+    """Tier 2: hook_items produce [on]/[off] rows; selecting dispatches /hook command."""
+    dispatched: list[str] = []
+    snap = _snap(
+        hook_items=[
+            {"name": "format", "scope": "runtime", "on": True},
+            {"name": "lint",   "scope": "per-agent", "on": False},
+        ],
+    )
+    result = _more_expansion(snap, dispatched.append)
+
+    all_ln = _all_lines(result)
+    assert any("[on] format" in ln for ln in all_ln)
+    assert any("[off] lint" in ln for ln in all_ln)
+
+    # on→off
+    cmd_el = next(el for el in result if isinstance(el, CommandUIElement))
+    cmd_el.on_select(0)
+    assert "/hook off format" in dispatched
+
+
+def test_more_expansion_cron_section_always_read_only() -> None:
+    """Tier 2: the cron section is always a DetailElement (deferred in #2285) even
+    when visibility_items are present."""
+    snap = _snap(
+        visibility_items=[{"kind": "tool", "name": "bash", "on": True}],
+        cron_jobs=[{"name": "nightly", "schedule": "0 0 * * *", "enabled": True}],
+    )
+    result = _more_expansion(snap, lambda _: None)
+    # Verify cron content appears in the lines.
+    joined = " ".join(_all_lines(result))
+    assert "nightly" in joined
+    # All elements including the cron one must be either Detail or Command; the cron
+    # section itself (containing "cron") must be a DetailElement.
+    cron_els = [el for el in result if isinstance(el, DetailElement)
+                and any("cron" in ln for ln in el.lines())]
+    assert cron_els, "cron section must be a read-only DetailElement"
+
+
+# ---------------------------------------------------------------------------
+# _session_visibility_items / _session_hook_items graceful fallback
+# ---------------------------------------------------------------------------
+
+
+def test_session_visibility_items_returns_empty_when_method_absent() -> None:
+    """Tier 2: _session_visibility_items returns [] when session has no capability_visibility_state."""
+    assert _session_visibility_items(object()) == []
+
+
+def test_session_hook_items_returns_empty_when_method_absent() -> None:
+    """Tier 2: _session_hook_items returns [] when session has no hook_state."""
+    assert _session_hook_items(object()) == []
+
+
+def test_session_visibility_items_reads_state_and_computes_on_flag() -> None:
+    """Tier 2: _session_visibility_items calls capability_visibility_state() and maps
+    hidden_by_session to on=False, authorized-but-not-hidden to on=True."""
+    class _FakeSession:
+        def capability_visibility_state(self):
+            return {
+                "authorized": [
+                    {"kind": "tool", "name": "bash"},
+                    {"kind": "mcp",  "name": "brave"},
+                ],
+                "hidden_by_session": [{"kind": "mcp", "name": "brave"}],
+            }
+
+    items = _session_visibility_items(_FakeSession())
+    by_name = {it["name"]: it for it in items}
+    assert by_name["bash"]["on"] is True
+    assert by_name["brave"]["on"] is False
+
+
+def test_session_hook_items_reads_state() -> None:
+    """Tier 2: _session_hook_items calls hook_state() and returns name/scope/on dicts."""
+    class _FakeSession:
+        def hook_state(self):
+            return [
+                {"name": "format", "scope": "runtime",   "enabled": True},
+                {"name": "lint",   "scope": "per-agent", "enabled": False},
+            ]
+
+    items = _session_hook_items(_FakeSession())
+    by_name = {it["name"]: it for it in items}
+    assert by_name["format"]["on"] is True
+    assert by_name["lint"]["on"] is False
+    assert by_name["format"]["scope"] == "runtime"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — part of #2285

## Summary

Transform the `…` overflow panel from a read-only config listing into an interactive toggle panel for session-scoped capability visibility and hook applicability.

**What this PR lands (tui-coder lane of #2285):**

- `_more_expansion` returns `list[RegionElement]` instead of a single element — `DetailElement` section headers (non-selectable, cursor skips) + `CommandUIElement` item rows (selectable, Enter dispatches a toggle command)
- **Toggle mode** (when backend is wired): each authorized capability shows `[on]/[off] <name>` row; selecting dispatches:
  - `/visibility on|off  tool|skill|mcp|category  <name>`
  - `/hook on|off  <name>`
- **Fallback mode** (backend not yet wired): existing read-only mcp/hooks config listing (backward-compatible; `visibility_items`/`hook_items` keys absent → `[]`)
- Cron section always read-only (per-session cron deferred per #2285 design)
- `_menu_open` handles list-returning expansions via `isinstance(result, list)` guard
- `_session_visibility_items` / `_session_hook_items`: graceful session seam readers — return `[]` until e2e lands `capability_visibility_state()` / `hook_state()` (forward-compatible, no import-time coupling)
- `_snapshot` adds `visibility_items` / `hook_items` keys (empty until e2e backend lands)

**API contract locked with e2e-coder (#2285):**
- `set_capability_visible(kind, name, visible)` / `capability_visibility_state()→{authorized, hidden_by_session}`
- `set_hook_enabled(name, enabled)` / `hook_state()→[{name, scope, enabled}]`
- Slash commands: `/visibility on|off kind name` → `set_capability_visible`; `/hook on|off name` → `set_hook_enabled`

## Test plan

- [x] `pytest tests/test_inline_pr3b_status_bar.py` — 48 tests pass (19 new, 7 updated, rest unchanged)
- [x] `pytest tests/test_inline_config_extractors.py` — 19 tests pass (regression check)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_pr3b_status_bar.py` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — clean
- [x] (skipped — toggling requires e2e backend not yet merged; UI shell tests cover the seam contract)

**PR Tier self-check**: all 48 tests Tier 2 (OS invariant, pure rendering + seam contract). No Tier 4. No mocks (real `DetailElement`/`CommandUIElement` instances, real `_snap()` helper).