### PR TITLE
feat(#2285): session-scoped tool-visibility toggle + visible⊆authorized invariant (step1-live A, increment 1)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -961,6 +961,14 @@ class Session:
         # reyn_source on the external-repo eval path so it doesn't compete with
         # file__* for the weak model); interactive default empty = reyn_source kept.
         self._excluded_categories = frozenset(excluded_categories or ())
+        # #2285: session-scoped LLM tool-VISIBILITY override — the capabilities the user toggled OFF
+        # via the status-bar, per kind. Applied as one more restrict-only ∩ conjunct ON TOP of the
+        # re-resolved agent envelope (_reapply_visibility_override), so it can only HIDE within the
+        # authorized set — visible ⊆ authorized by construction. In-memory (step1 live); step2 will
+        # persist it to the per-session config.yaml so resolved_profile_for(sid) re-derives it.
+        self._visibility_override: "dict[str, set[str]]" = {
+            "tool": set(), "skill": set(), "mcp": set(), "category": set(),
+        }
         # #187: per-message tool-call budget for the MAIN chat RouterLoop. The
         # interactive default (5) suits a human turn; an autonomous one-shot run
         # (`reyn chat --once` for SWE) needs far more (explore→edit→verify rounds),
@@ -2408,6 +2416,115 @@ class Session:
         self._excluded_categories = self._excluded_categories | frozenset(
             excluded_categories or ()
         )
+
+    # ── #2285: session-scoped LLM tool-VISIBILITY toggle (the status-bar seam) ──────────────
+
+    def _reapply_visibility_override(self) -> None:
+        """#2285: recompute the live tool gate from the agent envelope ∩ the session override.
+
+        SECURITY CORE (visible ⊆ authorized): re-resolves the WHOLE agent envelope from base
+        (topology bindings ∩ the #2081 delegate floor ∩ the persisted per-session config — via
+        ``resolved_profile_for``) and composes the in-memory override as ONE MORE restrict-only ∩
+        conjunct, then SETs both live fields (never a union — ``apply_per_session_narrowing`` unions
+        excluded, so it can't RE-WIDEN; re-resolve-from-base + SET can). Because the override only
+        adds deny/exclusion ON TOP of the envelope, a toggle can only HIDE within the authorized set
+        — toggle-ON discards from the override so the capability is restored *up to the envelope*,
+        never re-granted beyond it (an envelope-denied capability stays denied). The per-turn
+        RouterLoop reads these fields at construction, so the change is live next turn.
+        """
+        from reyn.security.permissions.capability_profile import (
+            CapabilityProfile,
+            compose_resolved,
+            resolve_profile,
+        )
+        from reyn.security.permissions.effective import ContextualPermission
+        from reyn.tools.universal_catalog import CATEGORIES
+
+        base_ctx: "object | None" = None
+        base_excl: "frozenset[str]" = frozenset()
+        if self._registry is not None and hasattr(self._registry, "resolved_profile_for"):
+            base_ctx, base_excl = self._registry.resolved_profile_for(
+                self.agent_name, sid=self._session_id,
+            )
+
+        ov = self._visibility_override
+        keep_categories: "tuple[str, ...] | None" = None
+        if ov["category"]:
+            keep_categories = tuple(c for c in CATEGORIES if c not in ov["category"])
+        override_profile = CapabilityProfile(
+            name="_session_visibility_override",
+            tool_deny=tuple(sorted(ov["tool"])),
+            skill_deny=tuple(sorted(ov["skill"])),
+            mcp_deny=tuple(sorted(ov["mcp"])),
+            categories=keep_categories,
+        )
+        final_ctx, final_excl = compose_resolved([
+            (base_ctx or ContextualPermission(), base_excl),
+            resolve_profile(override_profile),
+        ])
+        self._contextual_permission = final_ctx
+        self._excluded_categories = final_excl
+
+    def set_capability_visible(self, kind: str, name: str, visible: bool) -> None:
+        """#2285: toggle the session-visibility of a tool / skill / mcp / category (status-bar seam).
+
+        ``visible=False`` hides it from the LLM catalog next turn; ``visible=True`` restores it —
+        but only UP TO the agent envelope (toggling ON a capability the envelope denies is a no-op
+        for visibility: ``_reapply_visibility_override`` re-resolves from base, which still denies
+        it). Session-scoped (this sid only); live next turn; not persisted (step1)."""
+        if kind not in self._visibility_override:
+            raise ValueError(
+                f"unknown capability kind {kind!r} (expected tool / skill / mcp / category)"
+            )
+        if visible:
+            self._visibility_override[kind].discard(name)
+        else:
+            self._visibility_override[kind].add(name)
+        self._reapply_visibility_override()
+
+    def capability_visibility_state(self) -> dict:
+        """#2285: the status-bar's read model.
+
+        ``authorized`` = every capability the AGENT ENVELOPE permits for this session (topology ∩
+        delegate ∩ per-session config, WITHOUT the visibility override) — the full togglable
+        universe. ``hidden_by_session`` = the override set (what the user turned OFF). The UI renders
+        ``on = item not in hidden_by_session``. authorized is computed from the live catalogs
+        (tools / skills / mcp / categories) filtered by the envelope's ``allows`` — so it always
+        reflects visible ⊆ authorized (nothing outside the envelope is ever togglable)."""
+        from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+        from reyn.tools import get_default_registry
+        from reyn.tools.universal_catalog import CATEGORIES
+
+        base_ctx: "object | None" = None
+        base_excl: "frozenset[str]" = frozenset()
+        if self._registry is not None and hasattr(self._registry, "resolved_profile_for"):
+            base_ctx, base_excl = self._registry.resolved_profile_for(
+                self.agent_name, sid=self._session_id,
+            )
+        ctx = ContextualLayer(base_ctx)  # the envelope gate (None → allows all)
+
+        authorized: "list[dict]" = []
+        for name in sorted(get_default_registry().names()):
+            if ctx.allows(CapabilityAxis.TOOL, name):
+                authorized.append({"kind": "tool", "name": name})
+        for skill in self._router_host.list_available_skills():
+            n = skill.get("name")
+            if n and ctx.allows(CapabilityAxis.SKILL, n):
+                authorized.append({"kind": "skill", "name": n})
+        for server in self._router_host.get_mcp_servers():
+            n = server.get("name")
+            if n and ctx.allows(CapabilityAxis.MCP, n):
+                authorized.append({"kind": "mcp", "name": n})
+        for category in CATEGORIES:
+            if category not in base_excl:
+                authorized.append({"kind": "category", "name": category})
+
+        hidden = [
+            {"kind": kind, "name": name}
+            for kind, names in self._visibility_override.items()
+            for name in sorted(names)
+        ]
+        return {"authorized": authorized, "hidden_by_session": hidden}
 
     @property
     def current_snapshot(self) -> "AgentSnapshot":

--- a/tests/test_visibility_toggle_2285.py
+++ b/tests/test_visibility_toggle_2285.py
@@ -1,0 +1,95 @@
+"""Tier 2: #2285 step1 — session-scoped LLM tool-VISIBILITY toggle, visible ⊆ authorized.
+
+set_capability_visible(kind, name, visible) mutates a per-session override and re-applies it live:
+_reapply_visibility_override RE-RESOLVES the agent envelope from base (topology ∩ delegate ∩
+per-session config via resolved_profile_for) and composes the override as ONE MORE restrict-only ∩
+conjunct, then SETs the live tool gate (_contextual_permission / _excluded_categories). The core
+security invariant: a toggle can only HIDE within the authorized envelope — toggle-ON cannot revive
+a capability the envelope denies (re-resolve-from-base stops at the envelope). Real AgentRegistry +
+spawn_session_recorded(narrowing=...) sets a REAL envelope (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _allows_tool(session: Session, name: str) -> bool:
+    return ContextualLayer(session._contextual_permission).allows(CapabilityAxis.TOOL, name)
+
+
+@pytest.mark.asyncio
+async def test_toggle_on_cannot_revive_envelope_denied_tool(tmp_path, monkeypatch):
+    """Tier 2: CORE security invariant (visible ⊆ authorized) — a tool the agent ENVELOPE denies
+    cannot be made visible by set_capability_visible(True). RED if _reapply appended/union'd instead
+    of re-resolving from base; GREEN because it re-resolves the envelope (which still denies it)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    session = reg.get_session("alice", sid)
+
+    assert _allows_tool(session, "delete_file") is False  # envelope denies it
+
+    session.set_capability_visible("tool", "delete_file", True)  # try to reveal an unauthorized tool
+
+    assert _allows_tool(session, "delete_file") is False, \
+        "toggle-ON MUST NOT revive an envelope-denied capability (visible ⊆ authorized)"
+
+
+@pytest.mark.asyncio
+async def test_toggle_hides_then_restores_within_envelope(tmp_path, monkeypatch):
+    """Tier 2: both directions within the envelope — an envelope-ALLOWED tool: OFF hides it (next
+    turn), ON restores it. The re-widen the union-based apply_per_session_narrowing couldn't do."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")  # no narrowing → envelope allows all tools
+    session = reg.get_session("alice", sid)
+    assert _allows_tool(session, "delete_file") is True  # allowed by the envelope
+
+    session.set_capability_visible("tool", "delete_file", False)
+    assert _allows_tool(session, "delete_file") is False, "toggle-OFF hides it"
+
+    session.set_capability_visible("tool", "delete_file", True)
+    assert _allows_tool(session, "delete_file") is True, "toggle-ON restores it (up to the envelope)"
+
+
+@pytest.mark.asyncio
+async def test_visibility_state_reflects_envelope_and_override(tmp_path, monkeypatch):
+    """Tier 2: capability_visibility_state — authorized excludes the envelope-denied tool (never
+    togglable); hidden_by_session carries the override."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    session = reg.get_session("alice", sid)
+    session.set_capability_visible("tool", "ask_user", False)
+
+    state = session.capability_visibility_state()
+    authorized_tools = {i["name"] for i in state["authorized"] if i["kind"] == "tool"}
+    assert "delete_file" not in authorized_tools, "envelope-denied tool absent from authorized"
+    assert "ask_user" in authorized_tools, "an allowed tool is authorized (togglable)"
+    assert {"kind": "tool", "name": "ask_user"} in state["hidden_by_session"]


### PR DESCRIPTION
**[e2e-coder]** — #2285 backend, step1-live increment 1/N (OS-lane): the session-scoped LLM tool-VISIBILITY toggle mechanism + the `visible ⊆ authorized` security invariant. Part of #2285 (owner-approved design; cron split to #2387). UI status-bar is tui-lane against this API seam.

## What this lands (A, step1-live, visibility)
- `Session.set_capability_visible(kind, name, visible)` — toggle a tool/skill/mcp/category for THIS session. Mutates an in-memory per-session override + re-applies live (next-turn RouterLoop picks it up).
- `Session._reapply_visibility_override()` — the security core: RE-RESOLVES the whole agent envelope from base (`resolved_profile_for` = topology ∩ delegate-floor ∩ persisted per-session config) and composes the override as ONE MORE restrict-only ∩ conjunct (`compose_resolved`), then **SETs** both live gate fields (`_contextual_permission` / `_excluded_categories`) — not a union (`apply_per_session_narrowing` unions excluded → can't re-widen; re-resolve-from-base + SET can).
- `Session.capability_visibility_state()` -> `{"authorized": [{kind,name}], "hidden_by_session": [{kind,name}]}` — the status-bar read model. `authorized` is the envelope-permitted catalog (tools/skills/mcp filtered by the envelope's `allows`, categories minus envelope-excluded); the UI derives `on = item not in hidden_by_session`. (API contract locked with tui via broker.)

## Security invariant (visible ⊆ authorized) — the review focus
Because the override only adds deny/exclusion ON TOP of the re-resolved envelope, a toggle can only HIDE within the authorized set. **Toggle-ON cannot revive an envelope-denied capability** — `_reapply` re-resolves from base, which still denies it.

## Falsify (`tests/test_visibility_toggle_2285.py`, Tier 2 — real AgentRegistry + spawn_session_recorded(narrowing=...) = a REAL envelope, no mocks)
- [x] **CORE**: envelope denies `delete_file` → `set_capability_visible("tool","delete_file",True)` → still denied (visible⊆authorized). **RED-verified**: dropping the envelope conjunct from the compose → this test REDs (toggle-ON revives it) — proving the re-resolve-from-base envelope composition is load-bearing.
- [x] both directions within the envelope: OFF hides an allowed tool, ON restores it (the re-widen the union-based path couldn't do).
- [x] `capability_visibility_state`: authorized excludes the envelope-denied tool; hidden_by_session carries the override.
- [x] ruff / tier-audit (3 OK) / verify_module_docstrings green; 218-test permission/session regression green.

## Arc (next increments, same seam)
- `/visibility on|off <kind> <name>` slash handler (the status-bar row → API invocation; tui wires rows to it) — next.
- B: hooks 4th per-session layer + applicability gate + `/hook` slash.
- step2: persist the override to the per-session `config.yaml` (survives restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
