### PR TITLE
feat(#2285): /visibility slash — status-bar row → set_capability_visible seam (step1-live A, increment 2)

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -273,6 +273,7 @@ from reyn.interfaces.slash import session as _session_mod  # noqa: E402, F401
 from reyn.interfaces.slash import skill as _skill_mod  # noqa: E402, F401
 from reyn.interfaces.slash import skills as _skills_mod  # noqa: E402, F401
 from reyn.interfaces.slash import tasks as _tasks_mod  # noqa: E402, F401
+from reyn.interfaces.slash import visibility as _visibility_mod  # noqa: E402, F401
 from reyn.interfaces.slash import zen as _zen_mod  # noqa: E402, F401
 
 __all__ = [

--- a/src/reyn/interfaces/slash/visibility.py
+++ b/src/reyn/interfaces/slash/visibility.py
@@ -1,0 +1,48 @@
+"""``/visibility`` — toggle this session's LLM tool-visibility (#2285).
+
+The status-bar rows submit this command; it maps 1:1 to ``Session.set_capability_visible``. Hiding a
+capability removes it from the LLM catalog on the next turn; showing it restores it — but only UP TO
+the agent's authorized envelope (toggling ON a capability the envelope denies is a no-op; the
+re-resolve-from-base gate stops at the envelope, so ``visible ⊆ authorized`` always holds).
+Session-scoped (this session only); live next turn; not persisted (step1).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.interfaces.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+_KINDS = ("tool", "skill", "mcp", "category")
+
+
+@slash(
+    "visibility",
+    summary="Toggle this session's visibility of a tool / skill / mcp / category",
+    usage="/visibility on|off <tool|skill|mcp|category> <name>",
+)
+async def visibility_cmd(session: "Session", args: str) -> None:
+    """``/visibility on|off <kind> <name>`` — hide/show a capability from the LLM for THIS session.
+
+    ``off`` hides it next turn; ``on`` restores it (up to the agent envelope — an envelope-denied
+    capability stays hidden). Kind ∈ tool / skill / mcp / category."""
+    parts = args.split()
+    if len(parts) != 3 or parts[0] not in ("on", "off") or parts[1] not in _KINDS:
+        await reply_error(
+            session, "usage: /visibility on|off <tool|skill|mcp|category> <name>",
+        )
+        return
+    on = parts[0] == "on"
+    kind, name = parts[1], parts[2]
+    setter = getattr(session, "set_capability_visible", None)
+    if setter is None:
+        await reply_error(session, "visibility toggle is not available in this session")
+        return
+    setter(kind, name, on)
+    await reply(
+        session,
+        f"{kind} {name!r} is now {'visible' if on else 'hidden'} for this session "
+        f"(applies next turn; session-scoped, not persisted)",
+    )

--- a/tests/test_visibility_slash_2285.py
+++ b/tests/test_visibility_slash_2285.py
@@ -1,0 +1,78 @@
+"""Tier 2: #2285 increment 2 — the /visibility slash dispatches to set_capability_visible.
+
+`/visibility on|off <kind> <name>` is the status-bar row → Session API seam. It maps 1:1 to
+Session.set_capability_visible, preserving visible ⊆ authorized (the mechanism enforces it; the
+slash is a thin parse). Real AgentRegistry + Session (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.slash import REGISTRY
+from reyn.interfaces.slash.visibility import visibility_cmd
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _allows(session: Session, name: str) -> bool:
+    return ContextualLayer(session._contextual_permission).allows(CapabilityAxis.TOOL, name)
+
+
+async def _session(tmp_path) -> Session:
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    session = reg.get_session("alice", sid)
+    session.is_attached = True
+    return session
+
+
+def test_visibility_command_is_registered():
+    """Tier 2: the /visibility command is registered on import (status-bar can dispatch it)."""
+    assert REGISTRY.get("visibility") is not None
+
+
+@pytest.mark.asyncio
+async def test_slash_off_then_on_toggles_capability(tmp_path, monkeypatch):
+    """Tier 2: `/visibility off tool <name>` hides it, `/visibility on tool <name>` restores it —
+    the slash drives set_capability_visible, so the live gate changes both directions."""
+    monkeypatch.chdir(tmp_path)
+    session = await _session(tmp_path)
+    assert _allows(session, "delete_file") is True  # envelope allows
+
+    await visibility_cmd(session, "off tool delete_file")
+    assert _allows(session, "delete_file") is False, "/visibility off hides it"
+
+    await visibility_cmd(session, "on tool delete_file")
+    assert _allows(session, "delete_file") is True, "/visibility on restores it"
+
+
+@pytest.mark.asyncio
+async def test_slash_bad_args_no_crash_no_state_change(tmp_path, monkeypatch):
+    """Tier 2: malformed args → reply_error, no exception, no visibility change."""
+    monkeypatch.chdir(tmp_path)
+    session = await _session(tmp_path)
+    await visibility_cmd(session, "garbage")            # wrong arity
+    await visibility_cmd(session, "maybe tool x")       # bad on/off
+    await visibility_cmd(session, "off widget x")       # bad kind
+    assert session.capability_visibility_state()["hidden_by_session"] == [], "no toggle on malformed args"


### PR DESCRIPTION
**[e2e-coder]** — #2285 backend, step1-live increment 2/N (OS-lane): the `/visibility` slash — the status-bar row → `set_capability_visible` invocation seam. **Stacks on #2389** (increment 1, the toggle mechanism); rebase onto main after #2389 lands.

## What this lands
- `src/reyn/interfaces/slash/visibility.py` — `/visibility on|off <tool|skill|mcp|category> <name>`, a thin parse that maps 1:1 to `Session.set_capability_visible(kind, name, on)`. Registered on import (added to `slash/__init__`). Malformed args → `reply_error`, no crash, no state change.
- This activates tui's status-bar visibility rows: their rows already submit `/visibility on|off kind name` verbatim (contract locked via broker), so the panel goes live end-to-end once this merges — zero shell change on their side.

The slash is intentionally thin: the security invariant (`visible ⊆ authorized`) lives in the mechanism (`_reapply_visibility_override`, #2389), not the parse — the slash can only call `set_capability_visible`, which can't revive an envelope-denied capability.

## Test plan (`tests/test_visibility_slash_2285.py`, Tier 2 — real AgentRegistry + Session, no mocks)
- [x] `/visibility` is registered on import (status-bar can dispatch it)
- [x] `/visibility off tool <name>` hides it, `/visibility on tool <name>` restores it (drives the live gate both directions)
- [x] malformed args (wrong arity / bad on-off / bad kind) → `reply_error`, no exception, no visibility change (asserted via the public `capability_visibility_state`)
- [x] ruff / tier-audit / verify_module_docstrings green; 861-test slash regression green

## Arc (remaining, same seam)
- B: hooks 4th per-session layer + applicability gate + `/hook` slash (increment 3).
- step2: persist the override to the per-session `config.yaml` (increment 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
