### PR TITLE
feat(#2285): session-scoped hook applicability toggle + 4th per-session hooks layer (step1-live B, increment 3)

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -64,8 +64,15 @@ class HookDispatcher:
         emit_event: "Callable[..., Any] | None" = None,
         cross_session_put: "Callable[..., Any] | None" = None,
         current_session_id: "str | None" = None,
+        is_hook_disabled: "Callable[[HookDef], bool] | None" = None,
     ) -> None:
         self._registry = registry
+        # #2285: per-session hook APPLICABILITY gate — consulted at dispatch time (live) so a hook
+        # disabled for THIS session is skipped. Deferred (a callable, not a snapshot) so a toggle
+        # applies to the next dispatch without rebuilding the dispatcher. ``None`` → no gate
+        # (byte-identical to pre-#2285). Per-session by construction: each session's dispatcher gets
+        # its own predicate over its own disabled-set.
+        self._is_hook_disabled = is_hook_disabled
         self._put_inbox = put_inbox
         self._stage_next_turn_context = stage_next_turn_context
         # #2072: cross-session push routing. ``cross_session_put(target_sid, kind, payload,
@@ -120,6 +127,8 @@ class HookDispatcher:
         Empty registry → the loop body never runs → byte-identical no-op.
         """
         for hook in self._registry.hooks_for(point):
+            if self._is_hook_disabled is not None and self._is_hook_disabled(hook):
+                continue  # #2285: hook disabled for THIS session (live applicability toggle)
             try:
                 await self._dispatch_one(hook, point, template_vars)
             except Exception as exc:  # noqa: BLE001 — per-hook isolation boundary

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -260,6 +260,7 @@ from reyn.interfaces.slash import concept as _concept_mod  # noqa: E402, F401
 from reyn.interfaces.slash import copy as _copy_mod  # noqa: E402, F401
 from reyn.interfaces.slash import donut as _donut_mod  # noqa: E402, F401
 from reyn.interfaces.slash import help as _help_mod  # noqa: E402, F401
+from reyn.interfaces.slash import hook as _hook_mod  # noqa: E402, F401
 from reyn.interfaces.slash import image as _image_mod  # noqa: E402, F401
 from reyn.interfaces.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/hook.py
+++ b/src/reyn/interfaces/slash/hook.py
@@ -1,0 +1,38 @@
+"""``/hook`` — toggle this session's applicability of a hook (#2285).
+
+The status-bar hook rows submit this command; it maps 1:1 to ``Session.set_hook_enabled``. Disabling
+a hook skips it at dispatch for THIS session (live, next dispatch) — session-scoped, so a hook
+disabled here still fires in the agent's other sessions. Not persisted (step1).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reyn.interfaces.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+
+@slash(
+    "hook",
+    summary="Enable/disable a hook for this session",
+    usage="/hook on|off <name>",
+)
+async def hook_cmd(session: "Session", args: str) -> None:
+    """``/hook on|off <name>`` — enable/disable a named hook for THIS session (live next dispatch)."""
+    parts = args.split()
+    if len(parts) != 2 or parts[0] not in ("on", "off"):
+        await reply_error(session, "usage: /hook on|off <name>")
+        return
+    on, name = parts[0] == "on", parts[1]
+    setter = getattr(session, "set_hook_enabled", None)
+    if setter is None:
+        await reply_error(session, "hook toggle is not available in this session")
+        return
+    setter(name, on)
+    await reply(
+        session,
+        f"hook {name!r} is now {'enabled' if on else 'disabled'} for this session "
+        f"(applies next dispatch; session-scoped, not persisted)",
+    )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -969,6 +969,12 @@ class Session:
         self._visibility_override: "dict[str, set[str]]" = {
             "tool": set(), "skill": set(), "mcp": set(), "category": set(),
         }
+        # #2285: session-scoped hook APPLICABILITY override — hook names the user disabled via the
+        # status-bar. The HookDispatcher (per-session) skips a hook whose name is in this set at
+        # dispatch time (live). Per-session by construction: each Session owns its own dispatcher +
+        # this set, so disabling a hook in session S1 does NOT affect S2 (even though the hook config
+        # is shared). In-memory (step1 live); step2 will persist to the per-session hooks.yaml.
+        self._disabled_hooks: "set[str]" = set()
         # #187: per-message tool-call budget for the MAIN chat RouterLoop. The
         # interactive default (5) suits a human turn; an autonomous one-shot run
         # (`reyn chat --once` for SWE) needs far more (explore→edit→verify rounds),
@@ -1323,6 +1329,9 @@ class Session:
             # (cross-session); `current_session_id` keeps a self/unnamed push local.
             cross_session_put=self._cross_session_hook_put,
             current_session_id=self._session_id,
+            # #2285: per-session hook applicability gate — skip a hook this session disabled. A
+            # callable (not a snapshot) so a toggle applies live to the next dispatch.
+            is_hook_disabled=lambda hook: hook.name is not None and hook.name in self._disabled_hooks,
             sandbox_config=self._sandbox_config,
             sandbox_backend=self._sandbox_backend,
             # #2095: route a not-yet-allowlisted shell-hook's consent prompt
@@ -2526,6 +2535,57 @@ class Session:
         ]
         return {"authorized": authorized, "hidden_by_session": hidden}
 
+    # ── #2285: session-scoped hook APPLICABILITY toggle (the status-bar seam) ──────────────
+
+    def set_hook_enabled(self, name: str, enabled: bool) -> None:
+        """#2285: enable/disable a hook by name for THIS session (status-bar seam).
+
+        Live at the next dispatch — the per-session HookDispatcher gate consults ``_disabled_hooks``.
+        Session-scoped by construction: each session owns its dispatcher + disabled-set, so S1's
+        disable does NOT affect S2 (even though hook CONFIG is shared). Not persisted (step1)."""
+        if enabled:
+            self._disabled_hooks.discard(name)
+        else:
+            self._disabled_hooks.add(name)
+
+    def hook_state(self) -> "list[dict]":
+        """#2285: the status-bar's hook read model — each NAMED hook in this session's merged
+        registry (startup ∪ runtime ∪ per-agent ∪ per-session) as ``{name, scope, enabled}``.
+        ``scope`` = the most-specific layer that defines the name; a hook with no name is omitted
+        (it can't be individually toggled). ``enabled`` = not in this session's disabled-set."""
+        runtime_hooks: list = []
+        try:
+            from reyn.runtime.hot_reload import load_hot_reload_config
+            runtime_hooks = (load_hot_reload_config(self._hot_reload_project_root()) or {}).get("hooks") or []
+        except Exception:  # noqa: BLE001 — scope is best-effort display metadata
+            runtime_hooks = []
+        scope_by_name: "dict[str, str]" = {}
+        for scope, raw in (
+            ("startup", self._startup_hooks_raw),
+            ("runtime", runtime_hooks),
+            ("per-agent", self._read_per_agent_hooks()),
+            ("per-session", self._read_per_session_hooks()),
+        ):
+            for hook_cfg in (raw or []):
+                n = hook_cfg.get("name") if isinstance(hook_cfg, dict) else None
+                if n:
+                    scope_by_name[n] = scope  # more-specific layer wins (later in this order)
+
+        registry = getattr(self._hook_dispatcher, "_registry", None)
+        out: "list[dict]" = []
+        seen: "set[str]" = set()
+        for hook in getattr(registry, "_defs", []) if registry is not None else []:
+            n = getattr(hook, "name", None)
+            if n is None or n in seen:
+                continue
+            seen.add(n)
+            out.append({
+                "name": n,
+                "scope": scope_by_name.get(n, "unknown"),
+                "enabled": n not in self._disabled_hooks,
+            })
+        return out
+
     @property
     def current_snapshot(self) -> "AgentSnapshot":
         """Read-only view of the live in-memory AgentSnapshot (ADR-0038).
@@ -3384,9 +3444,14 @@ class Session:
         runtime = (in_set or {}).get("hooks") or []
         runtime_list = list(runtime) if isinstance(runtime, list) else []
         per_agent_list = self._read_per_agent_hooks()
+        per_session_list = self._read_per_session_hooks()  # #2285: the 4th, most-specific layer
         combined = list(self._startup_hooks_raw)
         registry = load_hooks(combined)  # trusted startup must load — else fail loud
-        for label, layer in (("runtime", runtime_list), ("per-agent", per_agent_list)):
+        for label, layer in (
+            ("runtime", runtime_list),
+            ("per-agent", per_agent_list),
+            ("per-session", per_session_list),  # #2285: session-defined hooks (try-add like untrusted)
+        ):
             if not layer:
                 continue
             try:
@@ -3405,6 +3470,23 @@ class Session:
         profile.yaml, not via the top-level IN-set loader). ``[]`` when absent."""
         from reyn.config.loader import load_per_agent_hooks
         return load_per_agent_hooks(self._hot_reload_project_root(), self.agent_name)
+
+    def _read_per_session_hooks(self) -> list:
+        """#2285: read the per-SESSION hooks layer — ``<per-session state dir>/hooks.yaml`` (the 4th,
+        most-specific COMBINE layer). The per-session dir is the parent of this session's snapshot
+        path (set per (name, sid) by spawn_session). A hook defined here is visible ONLY to this
+        session. ``[]`` when absent (or the file is malformed — the loader's per-layer resilience
+        also guards)."""
+        import yaml
+        path = Path(self._snapshot_path).parent / "hooks.yaml"
+        if not path.is_file():
+            return []
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — malformed → treat as absent
+            return []
+        hooks = data.get("hooks") if isinstance(data, dict) else None
+        return list(hooks) if isinstance(hooks, list) else []
 
     async def _reapply_hooks(self, in_set: dict) -> bool:
         """Reapply the hook layers (#2073 S2b + per-agent add-on) — re-read the global

--- a/tests/test_hook_applicability_2285.py
+++ b/tests/test_hook_applicability_2285.py
@@ -1,0 +1,138 @@
+"""Tier 2: #2285 increment 3 — session-scoped hook APPLICABILITY toggle + the 4th per-session layer.
+
+set_hook_enabled(name, enabled) mutates a per-session disabled-set; the per-session HookDispatcher
+skips a disabled hook at dispatch (live). Per-session by construction: each Session owns its own
+dispatcher + disabled-set, so disabling a hook in S1 does NOT affect S2 — even though the hook
+CONFIG is shared. _build_hook_registry gains a 4th per-session layer
+(<session state dir>/hooks.yaml) so a hook can be defined at session scope. Real AgentRegistry +
+real Sessions + real HookDispatcher.dispatch (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _write_agent_hook(tmp_path: Path, name: str) -> None:
+    p = tmp_path / ".reyn" / "agents" / "alice" / "hooks.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        yaml.safe_dump({"hooks": [
+            {"on": "turn_end", "name": name, "template_push": {"message": "ping", "wake": True}},
+        ]}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_hook_disable_is_per_session(tmp_path, monkeypatch):
+    """Tier 2: CORE — disabling a shared hook in session S1 skips it for S1 but NOT S2 (per-session
+    applicability despite shared config; each session's own dispatcher + disabled-set)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    _write_agent_hook(tmp_path, "myhook")  # shared per-agent hook, before the sessions build registries
+    reg.get_or_load("alice")
+    s1 = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s2 = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+
+    s1.set_hook_enabled("myhook", False)  # disable in S1 only
+
+    await s1._hook_dispatcher.dispatch("turn_end", {})
+    await s2._hook_dispatcher.dispatch("turn_end", {})
+
+    assert s1.inbox.qsize() == 0, "S1 disabled the hook → it did NOT fire"
+    assert s2.inbox.qsize() >= 1, "S2 did not disable it → the same hook fired (per-session isolation)"
+
+
+@pytest.mark.asyncio
+async def test_hook_toggle_off_then_on(tmp_path, monkeypatch):
+    """Tier 2: both directions — disable skips the hook at dispatch, enable restores firing."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    _write_agent_hook(tmp_path, "myhook")
+    reg.get_or_load("alice")
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+
+    s.set_hook_enabled("myhook", False)
+    await s._hook_dispatcher.dispatch("turn_end", {})
+    assert s.inbox.qsize() == 0, "disabled → not fired"
+
+    s.set_hook_enabled("myhook", True)
+    await s._hook_dispatcher.dispatch("turn_end", {})
+    assert s.inbox.qsize() >= 1, "re-enabled → fires again"
+
+
+@pytest.mark.asyncio
+async def test_per_session_hooks_yaml_is_a_4th_layer(tmp_path, monkeypatch):
+    """Tier 2: a hook defined in the per-session hooks.yaml (4th layer) appears in THIS session's
+    merged registry with scope 'per-session' — session-scoped hook definition."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+
+    # write a per-session hook at this session's state dir, then re-build the registry
+    per_session = Path(s._snapshot_path).parent / "hooks.yaml"
+    per_session.write_text(
+        yaml.safe_dump({"hooks": [
+            {"on": "turn_start", "name": "sesshook", "template_push": {"message": "x", "wake": True}},
+        ]}),
+        encoding="utf-8",
+    )
+    await s._reapply_hooks({})  # re-read all layers + swap the registry
+
+    state = {h["name"]: h for h in s.hook_state()}
+    assert "sesshook" in state, "the per-session hook is in the merged set"
+    assert state["sesshook"]["scope"] == "per-session"
+    assert state["sesshook"]["enabled"] is True
+
+
+def test_hook_slash_is_registered():
+    """Tier 2: /hook is registered on import (status-bar can dispatch it)."""
+    from reyn.interfaces.slash import REGISTRY
+    assert REGISTRY.get("hook") is not None
+
+
+@pytest.mark.asyncio
+async def test_hook_slash_disables_via_public_state(tmp_path, monkeypatch):
+    """Tier 2: /hook off <name> disables the hook (reflected in the public hook_state); malformed
+    args → reply_error, no change."""
+    from reyn.interfaces.slash.hook import hook_cmd
+
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    _write_agent_hook(tmp_path, "myhook")
+    reg.get_or_load("alice")
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s.is_attached = True
+
+    await hook_cmd(s, "off myhook")
+    assert {h["name"]: h["enabled"] for h in s.hook_state()}.get("myhook") is False
+
+    await hook_cmd(s, "on myhook")
+    assert {h["name"]: h["enabled"] for h in s.hook_state()}.get("myhook") is True
+
+    await hook_cmd(s, "garbage")  # malformed → no crash, no change
+    assert {h["name"]: h["enabled"] for h in s.hook_state()}.get("myhook") is True


### PR DESCRIPTION
**[e2e-coder]** — #2285 backend, step1-live increment 3/N (OS-lane): the session-scoped hook APPLICABILITY toggle + the 4th per-session hooks-config layer. Independent of inc-1/inc-2 (touches the hook path); off clean main.

## What this lands (B, step1-live, hooks)
- **Applicability gate (live)**: `Session.set_hook_enabled(name, enabled)` mutates a per-session `_disabled_hooks` set; `HookDispatcher.dispatch` skips a hook whose name is in it (new injectable `is_hook_disabled` predicate, consulted at dispatch — a callable, so a toggle applies to the next dispatch, no rebuild). **Per-session by construction**: each Session owns its dispatcher + disabled-set, so disabling a hook in S1 does NOT affect S2 — even though hook CONFIG is shared.
- **4th config layer**: `_build_hook_registry` gains a per-session layer (`<session state dir>/hooks.yaml`) try-added like the untrusted layers → `startup ∪ runtime ∪ per-agent ∪ per-session`. A hook can now be defined at session scope (visible only to that session).
- **Read model**: `Session.hook_state()` -> `[{name, scope, enabled}]` (scope = the most-specific layer defining the name; `enabled` = not in the session disabled-set) — the status-bar's hooks panel model (contract locked with tui).
- **`/hook on|off <name>`** slash — the status-bar row → `set_hook_enabled` seam (thin parse, registered on import).

## Falsify (`tests/test_hook_applicability_2285.py`, Tier 2 — real AgentRegistry + real Sessions + real HookDispatcher.dispatch, no mocks)
- [x] **CORE per-session isolation**: a shared per-agent hook disabled in S1 does NOT fire on S1's `dispatch("turn_end")` but DOES fire on S2's (observed via each session's inbox). **RED-verified**: removing the dispatch gate → both the isolation + the toggle test RED (the disabled hook fires anyway) — proving the gate is load-bearing.
- [x] both directions: disable skips at dispatch, enable restores firing.
- [x] 4th-layer merge: a per-session `hooks.yaml` hook appears in `hook_state()` with `scope=="per-session"`.
- [x] `/hook` registered on import + toggles via the public `hook_state`; malformed args → `reply_error`, no change.
- [x] ruff / tier-audit / verify_module_docstrings green; 325-test hooks/dispatcher regression green.

## Arc (remaining)
- step2: persist the visibility override + the hook disabled-set to the per-session `config.yaml` / `hooks.yaml` (survives restart) — increment 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
