### PR TITLE
fix(#2285): surface contract-mismatch errors in visibility/hook seam readers

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -431,6 +431,7 @@ def _session_visibility_items(session) -> list[dict]:
             for a in authorized
         ]
     except Exception:  # noqa: BLE001
+        logger.warning("capability_visibility_state() raised; visibility panel degraded to []", exc_info=True)
         return []
 
 
@@ -449,6 +450,7 @@ def _session_hook_items(session) -> list[dict]:
             for h in (getter() or [])
         ]
     except Exception:  # noqa: BLE001
+        logger.warning("hook_state() raised; hooks panel degraded to []", exc_info=True)
         return []
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #2285

## Summary

After e2e's backend PRs (#2389–#2391) merged, the `except Exception: return []` silent swallows in `_session_visibility_items` and `_session_hook_items` can now mask real contract mismatches: if the method exists and raises (e.g. wrong return shape), the toggle panel silently degrades to empty with no signal.

**Change**: add `logger.warning(..., exc_info=True)` to both exception handlers so contract mismatches are visible in logs while the graceful-`[]` fallback is preserved.

The getter-is-None fast-path (pre-backend) is unchanged and still inert — the warning only fires when the method exists but raises.

This was noted as a minor (non-blocking) in #2388's review and scheduled for the backend integration pass.

## Test plan

- [x] `pytest tests/test_inline_pr3b_status_bar.py` — 48 passed (no behavioral change to assert on: the warning is a side effect, existing tests cover the [] return path)
- [x] `ruff check src/reyn/interfaces/inline/app.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_pr3b_status_bar.py` — clean (0 Tier 4)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — clean

**PR Tier self-check**: no new tests needed (warning is a non-behavioral side effect; existing Tier 2 fallback tests still exercise the [] return path unchanged).