### PR TITLE
feat(#2285): session-toggle step2 persist — separate-store (increment 4)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2416,6 +2416,12 @@ class AgentRegistry:
         profile = self.load_profile(name)
         session = self._construct_session(profile, is_delegate=is_delegate)
         self._store_session(name, session)
+        # #2285 step2: restore persisted visibility/hook toggles for the MAIN session (spawned
+        # sessions load in spawn_session after the per-session path re-key). First-construction only
+        # — cache-hits return above — so this runs once per session lifetime, incl. on restart.
+        loader = getattr(session, "load_persisted_toggles", None)
+        if callable(loader):
+            loader()
         return session
 
     def _construct_session(
@@ -2518,6 +2524,12 @@ class AgentRegistry:
         # freshness for the CURRENT conversation is already supplied separately by the
         # live overlay (this session's uncompacted calls layered on each turn). So it is
         # correctly shared across the agent's sessions, not per-conversation state.
+        # #2285 step2: now that the per-session state dir is finalized (snapshot re-key above),
+        # restore any persisted visibility/hook toggles for this (name, sid) — the loaded override
+        # composes atop the authoritative envelope, so visible ⊆ authorized survives across restart.
+        loader = getattr(session, "load_persisted_toggles", None)
+        if callable(loader):
+            loader()
         self._sessions.setdefault(name, {})[new_sid] = session
         return new_sid
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2490,6 +2490,7 @@ class Session:
         else:
             self._visibility_override[kind].add(name)
         self._reapply_visibility_override()
+        self._persist_visibility_override()  # #2285 step2 — survive restart (best-effort)
 
     def capability_visibility_state(self) -> dict:
         """#2285: the status-bar's read model.
@@ -2547,6 +2548,96 @@ class Session:
             self._disabled_hooks.discard(name)
         else:
             self._disabled_hooks.add(name)
+        self._persist_hook_disabled()  # #2285 step2 — survive restart (best-effort)
+
+    # ── #2285 step2: persist / restore the session toggles (SEPARATE from the envelope floor) ──
+
+    def _toggle_store_dir(self) -> Path:
+        """The per-session state dir holding the toggle stores (parent of the snapshot path — set
+        per (name, sid) by spawn_session; the agent state dir for the main session)."""
+        return Path(self._snapshot_path).parent
+
+    def _persist_visibility_override(self) -> None:
+        """#2285 step2: persist the visibility override to ``<state dir>/visibility.yaml`` — a store
+        DISTINCT from the config.yaml spawner-narrowing (the authorized floor). Keeping it separate is
+        load-bearing: a toggle-ON must never edit the floor's denies (that would re-widen past
+        authorized). Best-effort: a write failure logs, never breaks the already-applied live toggle."""
+        import yaml
+        try:
+            data = {k: sorted(v) for k, v in self._visibility_override.items() if v}
+            path = self._toggle_store_dir() / "visibility.yaml"
+            if data:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(yaml.safe_dump(data), encoding="utf-8")
+            elif path.exists():
+                path.unlink(missing_ok=True)
+        except Exception as exc:  # noqa: BLE001 — persist is best-effort (live toggle already applied)
+            logger.warning("#2285: persist visibility override failed: %r", exc)
+
+    def _persist_hook_disabled(self) -> None:
+        """#2285 step2: persist the hook disabled-set to ``<state dir>/hooks.yaml``'s ``disabled:``
+        list — distinct from that file's session-DEFINED ``hooks:`` (the 4th config layer). Preserves
+        the ``hooks:`` section. Best-effort."""
+        import yaml
+        try:
+            path = self._toggle_store_dir() / "hooks.yaml"
+            data: dict = {}
+            if path.is_file():
+                try:
+                    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+                    data = loaded if isinstance(loaded, dict) else {}
+                except Exception:  # noqa: BLE001
+                    data = {}
+            if self._disabled_hooks:
+                data["disabled"] = sorted(self._disabled_hooks)
+            else:
+                data.pop("disabled", None)
+            if data:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(yaml.safe_dump(data), encoding="utf-8")
+            elif path.exists():
+                path.unlink(missing_ok=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("#2285: persist hook disabled-set failed: %r", exc)
+
+    def load_persisted_toggles(self) -> None:
+        """#2285 step2: restore the persisted visibility override + hook disabled-set from the
+        per-session stores into the in-memory sets, then re-apply visibility. Called at BOTH
+        session-creation paths (spawn fixup + construction/restore) so a restarted session recovers
+        its toggles. The loaded override composes ON TOP of the authoritative envelope exactly like
+        the live path (just file-sourced) → visible ⊆ authorized survives persist + reload (the floor
+        is re-resolved fresh from ``resolved_profile_for``; the loaded override never touches it).
+        Best-effort."""
+        import yaml
+        state_dir = self._toggle_store_dir()
+        # Reset to a clean baseline first so the load fully re-derives from THIS (final) state dir —
+        # idempotent + leak-free if called more than once or after the per-session dir is re-keyed.
+        self._visibility_override = {"tool": set(), "skill": set(), "mcp": set(), "category": set()}
+        self._disabled_hooks = set()
+        loaded_visibility = False
+        try:
+            vpath = state_dir / "visibility.yaml"
+            if vpath.is_file():
+                data = yaml.safe_load(vpath.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    for kind in ("tool", "skill", "mcp", "category"):
+                        vals = data.get(kind)
+                        if isinstance(vals, list):
+                            self._visibility_override[kind] = {str(v) for v in vals}
+                            loaded_visibility = True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("#2285: load visibility override failed: %r", exc)
+        try:
+            hpath = state_dir / "hooks.yaml"
+            if hpath.is_file():
+                data = yaml.safe_load(hpath.read_text(encoding="utf-8"))
+                disabled = data.get("disabled") if isinstance(data, dict) else None
+                if isinstance(disabled, list):
+                    self._disabled_hooks = {str(n) for n in disabled}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("#2285: load hook disabled-set failed: %r", exc)
+        if loaded_visibility:
+            self._reapply_visibility_override()  # only re-resolve when something was actually loaded
 
     def hook_state(self) -> "list[dict]":
         """#2285: the status-bar's hook read model — each NAMED hook in this session's merged

--- a/tests/test_visibility_persist_2285.py
+++ b/tests/test_visibility_persist_2285.py
@@ -1,0 +1,178 @@
+"""Tier 2: #2285 step2 — persist/restore the session visibility + hook toggles (SEPARATE store).
+
+The visibility override persists to ``<session state dir>/visibility.yaml`` and the hook disabled-set
+to ``hooks.yaml``'s ``disabled:`` list — both DISTINCT from ``config.yaml`` (the spawner-narrowing
+capability floor = part of the authorized envelope). On a fresh session over the same state dir
+(= restart), ``load_persisted_toggles`` restores them + composes the override ON TOP of the
+authoritative envelope (re-resolved from ``config.yaml``). The CRITICAL invariant carried across
+restart: a persisted override can NEVER re-widen past the floor — persist-hiding a spawner-DENIED
+tool then toggling it ON after reload STILL denies it (``visible ⊆ authorized`` survives persist +
+reload; the override never touches the floor). Real AgentRegistry + a SECOND registry over the same
+root reconstructing the (alice, sid) session via ``spawn_session(sid=sid)`` = the real restart path
+(registry.py ``restore_all`` line 999). No mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not (tmp_path / ".reyn" / "agents" / "alice").exists():
+        AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _allows_tool(session: Session, name: str) -> bool:
+    return ContextualLayer(session._contextual_permission).allows(CapabilityAxis.TOOL, name)
+
+
+def _write_agent_hook(tmp_path: Path, name: str) -> None:
+    p = tmp_path / ".reyn" / "agents" / "alice" / "hooks.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        yaml.safe_dump({"hooks": [
+            {"on": "turn_end", "name": name, "template_push": {"message": "ping", "wake": True}},
+        ]}),
+        encoding="utf-8",
+    )
+
+
+def _reload_spawned(tmp_path: Path, sid: str) -> Session:
+    """Simulate a restart: a FRESH registry over the same root reconstructs the (alice, sid) spawned
+    session via ``spawn_session(sid=sid)`` — the exact restart path (registry.py ``restore_all``
+    line 999), which re-keys the per-session dir + fires ``load_persisted_toggles``. The config.yaml
+    floor + visibility.yaml override both persist on disk, so the reload re-derives them."""
+    reg2 = _make_registry(tmp_path)
+    reg2.get_or_load("alice")
+    reg2.spawn_session("alice", sid=sid)
+    return reg2.get_session("alice", sid)
+
+
+@pytest.mark.asyncio
+async def test_persisted_override_cannot_rewiden_spawner_floor_after_reload(tmp_path, monkeypatch):
+    """Tier 2: CRITICAL — a persisted visibility override NEVER re-widens past the spawner floor.
+    Persist-hide a spawner-DENIED tool → reload (fresh registry over the same root) → toggle it ON →
+    STILL denied. The reloaded override composes atop the re-resolved envelope (config.yaml floor), so
+    visible ⊆ authorized survives persist + reload. RED if load restored the override as an authority
+    over the floor, or if the persist wrote into config.yaml (dropping the floor's deny)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    session = reg.get_session("alice", sid)
+    assert _allows_tool(session, "delete_file") is False  # spawner floor denies it
+
+    # persist-hide the (already floor-denied) tool → writes visibility.yaml alongside config.yaml
+    session.set_capability_visible("tool", "delete_file", False)
+
+    # reload: a fresh registry reconstructs from disk (config.yaml floor + visibility.yaml override)
+    reloaded = _reload_spawned(tmp_path, sid)
+    assert _allows_tool(reloaded, "delete_file") is False, "floor still denies after reload"
+
+    # toggle it ON after reload → the override discards it, but the floor STILL denies it
+    reloaded.set_capability_visible("tool", "delete_file", True)
+    assert _allows_tool(reloaded, "delete_file") is False, (
+        "persisted override MUST NOT re-widen past the spawner floor after reload "
+        "(visible ⊆ authorized survives persist + reload)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_visibility_override_round_trips_across_reload(tmp_path, monkeypatch):
+    """Tier 2: a toggle-OFF on an envelope-ALLOWED tool survives restart — hidden after reload, and
+    toggle-ON after reload restores it. Round-trips a non-default override value."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")  # no narrowing → envelope allows all tools
+    session = reg.get_session("alice", sid)
+    assert _allows_tool(session, "read_file") is True
+
+    session.set_capability_visible("tool", "read_file", False)  # hide + persist
+
+    reloaded = _reload_spawned(tmp_path, sid)
+    assert _allows_tool(reloaded, "read_file") is False, "toggle-OFF survives reload (persisted)"
+
+    reloaded.set_capability_visible("tool", "read_file", True)
+    assert _allows_tool(reloaded, "read_file") is True, "toggle-ON after reload restores it"
+
+
+@pytest.mark.asyncio
+async def test_hidden_set_round_trips_exact_value(tmp_path, monkeypatch):
+    """Tier 2: the exact hidden-set (a non-default multi-entry value) round-trips through the store —
+    the reloaded session reports the same hidden_by_session as before restart."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    session = reg.get_session("alice", sid)
+    session.set_capability_visible("tool", "read_file", False)
+    session.set_capability_visible("tool", "ask_user", False)
+    before = sorted(
+        tuple(sorted(i.items())) for i in session.capability_visibility_state()["hidden_by_session"]
+    )
+
+    reloaded = _reload_spawned(tmp_path, sid)
+    after = sorted(
+        tuple(sorted(i.items())) for i in reloaded.capability_visibility_state()["hidden_by_session"]
+    )
+    assert after == before, "the exact hidden-set round-trips through visibility.yaml"
+    assert {"kind": "tool", "name": "read_file"} in reloaded.capability_visibility_state()["hidden_by_session"]
+
+
+@pytest.mark.asyncio
+async def test_hook_disabled_set_survives_reload(tmp_path, monkeypatch):
+    """Tier 2: a disabled hook survives restart — disable a shared per-agent hook, reload, the
+    reloaded session still reports it disabled (the disabled-set persisted to hooks.yaml's
+    ``disabled:`` list, distinct from any session-defined ``hooks:``)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    _write_agent_hook(tmp_path, "myhook")  # shared per-agent hook (built into every session registry)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    session = reg.get_session("alice", sid)
+    assert any(h["name"] == "myhook" and h["enabled"] for h in session.hook_state())
+
+    session.set_hook_enabled("myhook", False)  # disable + persist to hooks.yaml disabled:
+
+    reloaded = _reload_spawned(tmp_path, sid)
+    states = {h["name"]: h["enabled"] for h in reloaded.hook_state()}
+    assert states.get("myhook") is False, \
+        "disabled hook survives reload (persisted to hooks.yaml `disabled:`)"
+
+
+@pytest.mark.asyncio
+async def test_clearing_override_removes_persisted_store(tmp_path, monkeypatch):
+    """Tier 2: toggling the last override back ON leaves no stale persisted hidden-set — a reload
+    after re-enabling everything restores an empty override (the store is pruned, not left dirty)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    session = reg.get_session("alice", sid)
+    session.set_capability_visible("tool", "read_file", False)
+    session.set_capability_visible("tool", "read_file", True)  # back to default → store pruned
+
+    reloaded = _reload_spawned(tmp_path, sid)
+    assert reloaded.capability_visibility_state()["hidden_by_session"] == [], \
+        "no stale persisted override after clearing it"
+    assert _allows_tool(reloaded, "read_file") is True


### PR DESCRIPTION
**[e2e-coder]** — #2285 increment 4 (step2 persist), off clean main (73ccc41c, inc-1/2/3 merged).

## What
Persist the session visibility override + hook disabled-set so they survive restart — in a store **DISTINCT** from `config.yaml` (the spawner-narrowing capability floor = part of the authorized envelope):
- visibility override → `<session state dir>/visibility.yaml`
- hook disabled-set → `hooks.yaml`'s `disabled:` list (distinct from that file's session-DEFINED `hooks:`)

`load_persisted_toggles()` restores them at **both** session-creation paths — `get_or_load` (main session) + `spawn_session` (spawned, incl. the `restore_all` restart path, registry.py:999) — and composes the loaded override **on top of the re-resolved authoritative envelope** exactly like the live path (just file-sourced). Writes are best-effort (a persist failure logs, never breaks the already-applied live toggle).

## Why the separate store is load-bearing (the design catch)
The original #2285 design comment said "persist the override into config.yaml". That is **UNSAFE**: `config.yaml` holds the spawner's #2103 narrowing (the authorized floor). Conflating the user's session override with the floor would (a) break re-widen and (b) risk a toggle-ON removing a floor `deny` → **breach of `visible ⊆ authorized`**. Keeping the override in a separate store means the floor is always re-resolved fresh from `config.yaml` and the loaded override can only restrict on top of it. (lead confirmed the config.yaml design was unsafe; separate-store GO'd.)

## Falsify (RED-verified)
- **CRITICAL** `test_persisted_override_cannot_rewiden_spawner_floor_after_reload`: persist-hide a spawner-DENIED tool → reload (fresh registry over the same root) → toggle it ON → **STILL denied**. `visible ⊆ authorized` survives persist + reload.
- `test_visibility_override_round_trips_across_reload`: toggle-OFF an allowed tool → survives reload; toggle-ON after reload restores it.
- `test_hidden_set_round_trips_exact_value`: exact multi-entry hidden-set round-trips.
- `test_hook_disabled_set_survives_reload`: a disabled hook stays disabled after reload.
- `test_clearing_override_removes_persisted_store`: clearing the last override prunes the store (no stale state).
- **RED-when-stripped**: removing the `_persist_visibility_override()` call turns the 3 round-trip/floor-safety tests RED → the persist is load-bearing.

Real `AgentRegistry` + a **second registry over the same root** reconstructing `(alice, sid)` via `spawn_session(sid=sid)` = the real restart path. No mocks.

## CI gates (all green locally)
- ruff: clean
- `test_tier_audit.py --strict`: 5/5 OK
- pytest (full rootdir): **8400 passed**, 17 skipped, 3 xfailed
- `verify_module_docstrings.py`: clean

## Test plan
- [x] Full suite green (8400 passed)
- [x] CRITICAL falsify passes + RED-when-stripped verified
- [x] (manual) confirmed `_snapshot_path.parent` = the per-session dir (alongside config.yaml) — persist target verified against `spawn_session` re-key

This completes the #2285 step1/step2 arc. Toggles are now transparent to the tui (the "(session only)" note becomes removable — they survive restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)