### PR TITLE
fix(#2336): MCP offload — drop content-duplicating raw so content is the sole oversized field

### DIFF
--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -143,18 +143,29 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
         "mcp_completed", server=op.server, tool=op.tool, is_error=is_error,
         media_block_count=len(media_blocks),
     )
-    return {
+    out = {
         "kind": "mcp",
         "status": "error" if is_error else "ok",
         "server": op.server,
         "tool": op.tool,
         "content": text,
         "media_blocks": media_blocks,
-        "raw": result,
-        # #2336: offload the joined text (what the LLM acts on) CLEAN. If ``raw`` is
-        # also oversized, the caller falls back to whole-dict (both preserved).
+        # #2336: declare the joined text as the offload payload so an oversized result is stored
+        # CLEAN (real newlines, not a whole-dict single-line JSON envelope). This ONLY fires when
+        # ``content`` is the SOLE oversized field. We dropped the former ``raw`` (the full flattened
+        # CallToolResult): it re-carried the same oversized ``content``, so both went oversized →
+        # gate missed → whole-dict fallback (the bug). ``isError`` is already surfaced as ``status``
+        # and the joined text is ``content``; ``structuredContent`` is the only non-duplicate SDK
+        # field, so it is preserved as ``structured`` below when present (never re-carries ``content``,
+        # so it stays a legitimate — and usually absent — second field).
         "_offload_payload_field": "content",
     }
+    # Preserve a real MCP structured-output only when the tool actually returned one (None by
+    # default) — absent → no field (clean end-state, no shim); present → the LLM keeps the data.
+    structured = result.get("structuredContent")
+    if structured is not None:
+        out["structured"] = structured
+    return out
 
 
 async def handle(op: MCPIROp, ctx: OpContext, caller: Literal["preprocessor", "control_ir"]) -> dict:

--- a/tests/test_mcp_offload_raw_2336.py
+++ b/tests/test_mcp_offload_raw_2336.py
@@ -1,0 +1,127 @@
+"""Tier 2: #2336 follow-up — a large MCP op result offloads CLEAN, not a whole-dict single-line.
+
+The op result used to carry ``raw`` (the full flattened CallToolResult), which re-carried the same
+oversized ``content`` text. So a large result had TWO oversized fields (``content`` + ``raw``) →
+``_oversized_fields != [_offload_payload_field]`` → the clean-payload gate missed → the whole dict
+was stored as one indent-less JSON line (owner's offload file was a nested single-line envelope).
+webfetch was unaffected only because ``content`` was its sole large field.
+
+Fix (op-side ``mcp.py`` only, P7-safe — OS/context_builder/store untouched): drop ``raw`` (``isError``
+is already ``status``, the joined text is already ``content``), and preserve the only non-duplicate
+SDK field — ``structuredContent`` — as ``structured`` ONLY when present. Now ``content`` is the sole
+oversized field → the clean-payload gate fires → the offload file holds clean text with real
+newlines. Real ``_execute`` via a stubbed MCP client (no subprocess); real ``offload_control_ir_result``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES as CAP
+from reyn.core.context_builder import _oversized_fields, offload_control_ir_result
+from reyn.services.offload.store import read_offloaded
+
+# A multi-line text payload well over the per-field offload threshold — mirrors a big MCP tool dump.
+_BIG_TEXT = "\n".join(f"row {i}: " + "d" * 80 for i in range((CAP // 40) + 200))
+
+
+class _FakeMCPClient:
+    """Stand-in for ``reyn.mcp.client.MCPClient`` — returns a canned ``call_tool`` result (the
+    flattened ``{content, isError, structuredContent}`` shape) without spawning a subprocess."""
+
+    def __init__(self, content: list[dict], *, is_error: bool = False, structured: Any = None) -> None:
+        self._content = content
+        self._is_error = is_error
+        self._structured = structured
+
+    async def call_tool(self, name: str, args: dict, *, progress_callback=None, timeout_seconds=None) -> dict:
+        return {"content": self._content, "isError": self._is_error, "structuredContent": self._structured}
+
+
+def _make_ctx(tmp_path: Path, mcp_client: _FakeMCPClient) -> Any:
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    return OpContext(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,  # bypass permission gate
+        mcp_servers={"testsrv": {"type": "stdio", "command": "fake"}},
+        mcp_clients={"testsrv": mcp_client},  # type: ignore[dict-item]
+    )
+
+
+def _run(content: list[dict], tmp_path: Path, **kw) -> dict:
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    ctx = _make_ctx(tmp_path, _FakeMCPClient(content, **kw))
+    op = MCPIROp(kind="mcp", server="testsrv", tool="dump", args={})
+    return asyncio.run(_execute(op, ctx))
+
+
+def test_no_raw_field_content_is_sole_oversized(tmp_path, monkeypatch):
+    """Tier 2: CORE — a large MCP result has NO ``raw`` field, so ``content`` is the sole oversized
+    field. RED on main: ``raw`` re-carried ``content`` → ``_oversized_fields == ["content", "raw"]``."""
+    monkeypatch.chdir(tmp_path)
+    result = _run([{"type": "text", "text": _BIG_TEXT}], tmp_path)
+
+    assert "raw" not in result, "the content-duplicating `raw` field is dropped"
+    assert _oversized_fields(result) == ["content"], \
+        "content is the SOLE oversized field (clean-payload gate can fire)"
+
+
+def test_large_mcp_result_offloads_clean_content(tmp_path, monkeypatch):
+    """Tier 2: the bug — a large MCP result offloads as CLEAN text (real newlines), not a whole-dict
+    single-line JSON envelope. RED on main (whole-dict fallback because content+raw both oversized)."""
+    monkeypatch.chdir(tmp_path)
+    result = _run([{"type": "text", "text": _BIG_TEXT}], tmp_path)
+
+    inline = offload_control_ir_result(result, 0, tmp_path)
+    stored = Path(inline["_offload_ref"]).read_text(encoding="utf-8")
+
+    assert not stored.lstrip().startswith("{"), "offload file is clean content, not a JSON dict envelope"
+    assert stored == _BIG_TEXT, "the file is exactly the clean joined text"
+    assert "\\n" not in stored, "real newlines (not JSON-escaped) — no JSON-of-JSON symptom"
+    assert stored.count("\n") == _BIG_TEXT.count("\n"), "all newlines preserved"
+    text, _ = read_offloaded(inline["_offload_ref"], base_dir=tmp_path)
+    assert text == _BIG_TEXT, "read-back via the store returns the clean payload"
+
+
+def test_structured_content_preserved_when_present(tmp_path, monkeypatch):
+    """Tier 2: a real MCP structured output is preserved as ``structured`` (no in-context data loss),
+    and it does not re-carry ``content`` — so ``content`` stays the sole oversized field."""
+    monkeypatch.chdir(tmp_path)
+    structured = {"rows": [1, 2, 3], "schema": "v1"}
+    result = _run([{"type": "text", "text": _BIG_TEXT}], tmp_path, structured=structured)
+
+    assert result["structured"] == structured, "structuredContent preserved as `structured`"
+    assert _oversized_fields(result) == ["content"], "structured (small) does not add a second oversized field"
+
+
+def test_structured_absent_when_none(tmp_path, monkeypatch):
+    """Tier 2: when the tool returns no structured output (the default), there is NO ``structured``
+    field — clean end-state, no shim key."""
+    monkeypatch.chdir(tmp_path)
+    result = _run([{"type": "text", "text": "small"}], tmp_path)  # structured defaults to None
+
+    assert "structured" not in result, "no `structured` field when structuredContent is None"
+    assert "raw" not in result
+
+
+def test_small_mcp_result_not_offloaded_no_regression(tmp_path, monkeypatch):
+    """Tier 2: a small MCP result is not oversized → not offloaded (inline unchanged). No regression
+    for the common case."""
+    monkeypatch.chdir(tmp_path)
+    result = _run([{"type": "text", "text": "hello world"}], tmp_path)
+
+    assert _oversized_fields(result) == [], "small content is not oversized"
+    inline = offload_control_ir_result(result, 0, tmp_path)
+    assert "_offload_ref" not in inline, "small result is not offloaded"
+    assert inline["content"] == "hello world", "content stays inline"


### PR DESCRIPTION
**[e2e-coder]** — owner-priority live bug (offload arc follow-up). Off clean main. op-side `mcp.py` only; OS / context_builder / store untouched (P7-safe).

## The bug
The owner's MCP offload file was a nested single-line JSON envelope (content collapsed to escaped `\n`) instead of clean text. Root cause: the mcp op result carried `raw` (the full flattened `CallToolResult`), which **re-carried the same oversized `content` text**. So a large result had TWO oversized fields — `content` AND `raw` — → `_oversized_fields(result) == ["content", "raw"]` → the clean-payload gate (fires only when the declared `_offload_payload_field` is the *sole* oversized field) missed → whole-dict fallback (indent-less `json.dumps`). webfetch was unaffected only because `content` is its sole large field.

## The fix
Drop `raw` from the op result:
- `isError` → already surfaced as top-level `status` (mcp.py:141).
- the joined text → already the top-level `content` (what the LLM acts on).
- `structuredContent` → the only non-duplicate SDK field → preserved as `structured` **only when present** (None by default → no field, clean end-state, no shim).

Now `content` is the sole oversized field → clean-payload gate fires → the offload file holds clean text with real newlines.

## Consumer investigation (why dropping `raw` is safe)
Plain `grep -rn` across src/ + tests/: the mcp op result's `raw` has **zero code consumers**. No test asserts the op result contains `raw` (test_offload_payload_field_2336.py uses synthetic dicts, not the mcp op). Confirmed with lead before implementing.

## Consistency with #2371 (multi-large fallback)
`structured` never re-carries `content`, so it's a legitimate second field — if a tool ever returns a *large* structured output, the whole-dict fallback engages with zero data-loss (exactly #2371's intent), not a regression.

## Falsify (RED-verified)
Real `_execute` via a stubbed MCP client (no subprocess) + real `offload_control_ir_result`:
- `test_no_raw_field_content_is_sole_oversized` (CORE): large result → no `raw`, `_oversized_fields == ["content"]`.
- `test_large_mcp_result_offloads_clean_content` (the bug): offload file is clean text, real newlines, `== _BIG_TEXT`, no `\n`-escaping; read-back via the store returns the clean payload.
- `test_structured_content_preserved_when_present`: `structured` carries the SDK structured output; still sole oversized.
- `test_structured_absent_when_none`: no `structured` field when None.
- `test_small_mcp_result_not_offloaded_no_regression`: small result inline, not offloaded.
- **RED-when-reverted**: re-adding `"raw": result` fails 4 of 5 tests → the drop is load-bearing.

## CI gates (all green locally)
- ruff: clean
- `test_tier_audit.py --strict`: 5/5 OK
- pytest (full rootdir): **8400 passed**, 17 skipped, 3 xfailed
- `verify_module_docstrings.py`: clean

## Test plan
- [x] Full suite green (8400 passed)
- [x] Clean-content offload falsify passes + RED-when-reverted verified
- [x] Consumer-grep: `raw` has zero consumers (drop is safe)

part of #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)