### PR TITLE
docs(#2285): correct stale 'not persisted (step1)' toggle text (step2 landed)

### DIFF
--- a/src/reyn/interfaces/slash/hook.py
+++ b/src/reyn/interfaces/slash/hook.py
@@ -2,7 +2,7 @@
 
 The status-bar hook rows submit this command; it maps 1:1 to ``Session.set_hook_enabled``. Disabling
 a hook skips it at dispatch for THIS session (live, next dispatch) — session-scoped, so a hook
-disabled here still fires in the agent's other sessions. Not persisted (step1).
+disabled here still fires in the agent's other sessions. Persists across restart (step2).
 """
 from __future__ import annotations
 
@@ -34,5 +34,5 @@ async def hook_cmd(session: "Session", args: str) -> None:
     await reply(
         session,
         f"hook {name!r} is now {'enabled' if on else 'disabled'} for this session "
-        f"(applies next dispatch; session-scoped, not persisted)",
+        f"(applies next dispatch; session-scoped; persists across restart)",
     )

--- a/src/reyn/interfaces/slash/visibility.py
+++ b/src/reyn/interfaces/slash/visibility.py
@@ -4,7 +4,7 @@ The status-bar rows submit this command; it maps 1:1 to ``Session.set_capability
 capability removes it from the LLM catalog on the next turn; showing it restores it — but only UP TO
 the agent's authorized envelope (toggling ON a capability the envelope denies is a no-op; the
 re-resolve-from-base gate stops at the envelope, so ``visible ⊆ authorized`` always holds).
-Session-scoped (this session only); live next turn; not persisted (step1).
+Session-scoped (this session only); live next turn; persists across restart (step2).
 """
 from __future__ import annotations
 
@@ -44,5 +44,5 @@ async def visibility_cmd(session: "Session", args: str) -> None:
     await reply(
         session,
         f"{kind} {name!r} is now {'visible' if on else 'hidden'} for this session "
-        f"(applies next turn; session-scoped, not persisted)",
+        f"(applies next turn; session-scoped; persists across restart)",
     )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2480,7 +2480,7 @@ class Session:
         ``visible=False`` hides it from the LLM catalog next turn; ``visible=True`` restores it —
         but only UP TO the agent envelope (toggling ON a capability the envelope denies is a no-op
         for visibility: ``_reapply_visibility_override`` re-resolves from base, which still denies
-        it). Session-scoped (this sid only); live next turn; not persisted (step1)."""
+        it). Session-scoped (this sid only); live next turn; persists across restart (step2)."""
         if kind not in self._visibility_override:
             raise ValueError(
                 f"unknown capability kind {kind!r} (expected tool / skill / mcp / category)"
@@ -2543,7 +2543,7 @@ class Session:
 
         Live at the next dispatch — the per-session HookDispatcher gate consults ``_disabled_hooks``.
         Session-scoped by construction: each session owns its dispatcher + disabled-set, so S1's
-        disable does NOT affect S2 (even though hook CONFIG is shared). Not persisted (step1)."""
+        disable does NOT affect S2 (even though hook CONFIG is shared). Persists across restart (step2)."""
         if enabled:
             self._disabled_hooks.discard(name)
         else:


### PR DESCRIPTION
**[e2e-coder]** — small user-facing correctness follow-up to the #2285 arc (lead GO'd). Off clean main (b211de4c). Text-only, no logic change.

## Why
inc-4 (step2 persist, #2393) made session visibility + hook toggles survive restart. But the `/visibility` and `/hook` slash **reply text** + docstrings — and the two `Session` method docstrings — still said "not persisted (step1)". That is user-facing drift: it tells the user a toggle is lost on restart when it now persists. Corrected to "persists across restart (step2)".

## Changed (6 occurrences, all text)
- `interfaces/slash/visibility.py`: module docstring + the `/visibility` reply line
- `interfaces/slash/hook.py`: module docstring + the `/hook` reply line
- `runtime/session.py`: `set_capability_visible` + `set_hook_enabled` docstrings

Left `session.py:909` untouched — that "not persisted" refers to `_model_override` (the `/model` command), which is genuinely in-memory-only. tui confirmed no such note on the status-bar side, so only these files.

## Gates
- ruff: clean
- `verify_module_docstrings.py`: clean
- focused toggle/slash suites (16 tests): pass
- pytest (full rootdir): running — will confirm green before this is merged
- (no test files changed → tier-audit N/A)

## Test plan
- [x] ruff + module-docstring gates clean
- [x] 16 focused #2285 toggle/slash tests pass
- [ ] full suite green (running) — confirm before merge
- [x] verified no test pins the old "not persisted" string

part of #2285

🤖 Generated with [Claude Code](https://claude.com/claude-code)