### PR TITLE
fix(#2336): chat tool-result offload — envelope-aware clean-payload (Option 3, #2396 Step 1)

### DIFF
--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -148,6 +148,22 @@ def _oversized_fields(result: dict) -> list[str]:
     ]
 
 
+def decide_payload_field(result: dict) -> str | None:
+    """#2336: the clean-payload DECISION — the single source of truth shared by the control_ir
+    offloader (below) AND the chat tool-result cap (#2394-followup, via router_loop).
+
+    Return the op result's declared ``_offload_payload_field`` IFF it is the SOLE oversized field
+    (so the offloader can store that field CLEAN — raw text with real newlines — instead of a
+    whole-dict JSON envelope). Return ``None`` otherwise: no marker, or a multi-large result whose
+    non-dominant large field must not be dropped to preview-only (→ whole-dict fallback, zero
+    data-loss). Extracting this means the two offload paths can never diverge on the decision again
+    (the divergence that let the chat path lag the control_ir fix in #2394)."""
+    declared = result.get("_offload_payload_field")
+    if not declared:
+        return None
+    return declared if _oversized_fields(result) == [declared] else None
+
+
 def _phase_preview_strategy(result: dict, ref_path: str) -> dict:
     """Phase-axis preview strategy: type-aware per-field previews + hard-bound fallback.
 
@@ -248,8 +264,8 @@ def offload_control_ir_result(
     # whole-dict envelope. Multi-large-field → whole-dict fallback (payload_field=None)
     # so a non-dominant large field's full content is never dropped to preview-only
     # (zero data-loss). P7-safe: the marker is op-supplied data, no op literal here.
-    declared_payload_field = result.get("_offload_payload_field")
-    use_clean_payload = bool(declared_payload_field) and _oversized_fields(result) == [declared_payload_field]
+    declared_payload_field = decide_payload_field(result)
+    use_clean_payload = declared_payload_field is not None
     offload_result = offload_value(
         result,
         store_dir=offload_dir,

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -294,12 +294,13 @@ class MediaStore:
 
     def save_tool_result(
         self,
-        content: str,
+        content: "str | dict",
         *,
         mime_type: str = "text/plain",
         chain_id: str = "",
         tool: str = "tool",
         seq: int = 1,
+        payload_field: str | None = None,
     ) -> dict:
         """Write a tool result text dump to ``tool_results_dir`` and
         return a path-ref block (= ``{"type": "tool_result_ref", "path":
@@ -309,6 +310,13 @@ class MediaStore:
         ``services/offload/store.py`` (Phase 2 of the offload-dedup effort,
         FP-0008 C5 #223).  The return block shape is IDENTICAL to the
         pre-migration contract — callers are unaffected.
+
+        #2394-followup clean-payload: when ``content`` is the op-result dict and
+        ``payload_field`` names its sole-oversized field, ``offload_value`` stores
+        THAT field's value CLEAN (raw text with real newlines) instead of the whole
+        dict — the chat path uses this so an offloaded MCP/web/exec result is clean
+        content, not a ``{"status":...,"data":{...}}`` single-line envelope. When
+        ``content`` is a string (the default), behaviour is byte-identical to before.
 
         Preview-bound note: ``preview_strategy=None`` is passed so the
         common service performs no preview bounding.  The preview is built
@@ -326,6 +334,7 @@ class MediaStore:
             store_dir=self._tool_results_dir,
             preview_strategy=None,
             filename=filename,
+            payload_field=payload_field,
         )
 
         # Convert absolute path_ref to project-relative path for the block.

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3086,6 +3086,9 @@ class RouterLoop:
                 meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
                 tool_calls=result.tool_calls,
             )
+        # #2394-followup: the shared clean-payload decision (same helper the control_ir offloader
+        # uses) — lazy import to avoid any import cycle with context_builder.
+        from reyn.core.context_builder import decide_payload_field
         for tc, r in zip(result.tool_calls, result.tool_results):
             # B41-NF-W7-1: _post_text → appended outside the JSON body.
             post_text: str | None = None
@@ -3104,6 +3107,20 @@ class RouterLoop:
             if isinstance(r, dict) and r.get("_external_source"):
                 external_source = True
                 r = {k: v for k, v in r.items() if k != "_external_source"}
+            # #2394-followup clean-payload: if r is the OS dispatch envelope {status, data:<dict>}
+            # and data declares a SOLE-oversized payload field (shared decide_payload_field — same
+            # decision the control_ir offloader uses), pass the inner op-result + field to the cap so
+            # the offloaded file holds THAT field CLEAN (real newlines), not the whole-envelope
+            # single-line JSON. P7-safe: OS-level keys only (status/data + the op-supplied marker);
+            # generalises to every payload-field op (mcp/web/exec). Mirrors phase_executor's unwrap
+            # check. When it doesn't apply, cap behaves byte-identically to before.
+            clean_value = None
+            payload_field = None
+            if (isinstance(r, dict) and isinstance(r.get("data"), dict)
+                    and set(r) <= {"status", "data", "error"}):
+                payload_field = decide_payload_field(r["data"])
+                if payload_field is not None:
+                    clean_value = r["data"]
             content_str = json.dumps(r, default=str)
             if post_text:
                 content_str = f"{content_str}\n\n---\n{post_text}"
@@ -3115,7 +3132,14 @@ class RouterLoop:
             # #1128: cap oversized tool results once at this chokepoint.
             _cap = getattr(host, "cap_tool_result", None)
             if _cap is not None:
-                content_str = _cap(content_str)
+                if payload_field is not None:
+                    content_str = _cap(
+                        content_str, clean_value=clean_value, payload_field=payload_field
+                    )
+                else:
+                    # No clean-payload → call with the plain (content_str) signature so a host/capper
+                    # without the #2394-followup kwargs (legacy / tests) is unaffected.
+                    content_str = _cap(content_str)
             # FP-0050/#1822 S2: fence untrusted-source content AFTER cap (so
             # truncation can't sever the end marker). Trusted-internal = scan-only.
             if external_source:

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -98,10 +98,18 @@ class ContextBudgetAdvisor:
         from reyn.runtime.services.tool_result_cap import compute_cap_tokens
         return compute_cap_tokens(self._get_effective_trigger())
 
-    def cap_tool_result(self, content_str: str) -> str:
+    def cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        clean_value: "Any" = None,
+        payload_field: str | None = None,
+    ) -> str:
         """Cap an oversized chat tool result (#1128 size axis).
 
-        No-op when no media_store is configured.
+        No-op when no media_store is configured. ``clean_value`` / ``payload_field`` (#2394-followup)
+        carry the OS dispatch envelope's inner op-result + its sole-oversized payload field so the
+        stored body is that field CLEAN, not the whole envelope string (default None = unchanged).
         """
         store = self._media_store
         if store is None:
@@ -116,6 +124,8 @@ class ContextBudgetAdvisor:
             save_fn=store.save_tool_result,
             use_chars4=use_chars4,
             events=self._events,
+            clean_value=clean_value,
+            payload_field=payload_field,
         )
 
     def media_followup_budget(self, tool_content: str) -> int:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -490,14 +490,28 @@ class RouterHostAdapter:
 
     # --- RouterLoopHost identity attributes ---
 
-    def cap_tool_result(self, content_str: str) -> str:
+    def cap_tool_result(
+        self,
+        content_str: str,
+        *,
+        clean_value: Any = None,
+        payload_field: str | None = None,
+    ) -> str:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
         (which offloads the full body via the #385 store + returns a bounded
         preview); identity when no capper was wired (= legacy / test paths).
+
+        #2394-followup: ``clean_value`` / ``payload_field`` carry the OS dispatch envelope's inner
+        op-result + its sole-oversized payload field. Forwarded ONLY when clean-payload applies, so a
+        capper with the plain ``(content_str)`` signature (legacy / tests) is called exactly as before.
         """
         if self._cap_tool_result is None:
             return content_str
+        if payload_field is not None:
+            return self._cap_tool_result(
+                content_str, clean_value=clean_value, payload_field=payload_field
+            )
         return self._cap_tool_result(content_str)
 
     def media_followup_budget(self, tool_content: str) -> int | None:

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -68,9 +68,11 @@ def cap_tool_result_content(
     *,
     cap_tokens: int,
     model: str,
-    save_fn: Callable[[str], dict],
+    save_fn: Callable[..., dict],
     use_chars4: bool = False,
     events: Any = None,
+    clean_value: Any = None,
+    payload_field: str | None = None,
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded preview.
 
@@ -101,7 +103,23 @@ def cap_tool_result_content(
     if estimate_tokens(content_str, model, use_chars4=use_chars4) <= cap_tokens:
         return content_str
 
-    block = save_fn(content_str)
+    # #2394-followup clean-payload: when the result is the OS dispatch envelope whose ``data``
+    # declares a sole-oversized field (``payload_field`` from the shared ``decide_payload_field``),
+    # store THAT field's value CLEAN (raw text, real newlines) — not the whole ``{status, data:{…}}``
+    # single-line envelope — and preview FROM it. Mirrors the control_ir offloader; only the STORED
+    # body + preview source change, the token-fit machinery below is identical. When no clean-payload
+    # (the default), behaviour is byte-identical to before.
+    clean = payload_field is not None and isinstance(clean_value, dict)
+    if clean:
+        block = save_fn(clean_value, payload_field=payload_field)
+        _field_val = clean_value.get(payload_field)
+        preview_source = (
+            _field_val if isinstance(_field_val, str)
+            else json.dumps(_field_val, ensure_ascii=False, default=str)
+        )
+    else:
+        block = save_fn(content_str)
+        preview_source = content_str
     ref = block.get("path", "")
     content_hash = block.get("content_hash", "")
 
@@ -118,8 +136,9 @@ def cap_tool_result_content(
 
     head_chars, tail_chars = _PREVIEW_HEAD_CHARS, _PREVIEW_TAIL_CHARS
     preview = _build_preview(
-        content_str, ref=ref, content_hash=content_hash,
+        preview_source, ref=ref, content_hash=content_hash,
         head_chars=head_chars, tail_chars=tail_chars,
+        payload_field=payload_field if clean else None,
     )
     # Shrink head/tail symmetrically until the preview fits cap_tokens. Floor at
     # 0 (= a bare lossless ref-marker) so even a tiny cap converges rather than
@@ -128,14 +147,15 @@ def cap_tool_result_content(
         head_chars = head_chars // 2 if head_chars > 64 else 0
         tail_chars = tail_chars // 2 if tail_chars > 64 else 0
         preview = _build_preview(
-            content_str, ref=ref, content_hash=content_hash,
+            preview_source, ref=ref, content_hash=content_hash,
             head_chars=head_chars, tail_chars=tail_chars,
+            payload_field=payload_field if clean else None,
         )
 
     if events is not None:
         events.emit(
             "tool_result_offloaded",
-            total_chars=len(content_str),
+            total_chars=len(preview_source),
             cap_tokens=cap_tokens,
             ref=ref,
             content_hash=content_hash,
@@ -150,19 +170,26 @@ def _build_preview(
     content_hash: str,
     head_chars: int,
     tail_chars: int,
+    payload_field: str | None = None,
 ) -> str:
-    """Build the bounded inline preview JSON for an offloaded tool result."""
-    return json.dumps(
-        {
-            "_offload_ref": ref,
-            "_offload_content_hash": content_hash,
-            "_offload_total_chars": len(content_str),
-            "_offload_note": (
-                f"Tool result offloaded ({len(content_str)} chars); read the full "
-                f"body via read_tool_result({ref!r})."
-            ),
-            "_offload_head": content_str[:head_chars] if head_chars > 0 else "",
-            "_offload_tail": content_str[-tail_chars:] if tail_chars > 0 else "",
-        },
-        ensure_ascii=False,
-    )
+    """Build the bounded inline preview JSON for an offloaded tool result.
+
+    When ``payload_field`` is set (#2394-followup clean-payload), the ref holds the CLEAN field
+    value (raw text) rather than the whole-dict envelope, so the inline signals that to the reader
+    via ``_offload_ref_format`` / ``_offload_payload_field`` — matching the control_ir offloader's
+    inline markers so both paths read back identically."""
+    inline: dict = {
+        "_offload_ref": ref,
+        "_offload_content_hash": content_hash,
+        "_offload_total_chars": len(content_str),
+        "_offload_note": (
+            f"Tool result offloaded ({len(content_str)} chars); read the full "
+            f"body via read_tool_result({ref!r})."
+        ),
+        "_offload_head": content_str[:head_chars] if head_chars > 0 else "",
+        "_offload_tail": content_str[-tail_chars:] if tail_chars > 0 else "",
+    }
+    if payload_field is not None:
+        inline["_offload_ref_format"] = "raw_field"
+        inline["_offload_payload_field"] = payload_field
+    return json.dumps(inline, ensure_ascii=False)

--- a/tests/test_chat_offload_envelope_2336.py
+++ b/tests/test_chat_offload_envelope_2336.py
@@ -1,0 +1,153 @@
+"""Tier 2: #2394-followup — the CHAT tool-result offloader stores CLEAN content, not the envelope.
+
+#2394 fixed the control_ir (dict-based) offload path, but owner's chat path uses a separate
+STRING-based offloader (router_loop.feedback → cap_tool_result → cap_tool_result_content →
+MediaStore.save_tool_result → .reyn/tool-results/). It serialised the whole OS dispatch envelope
+`{"status":"ok","data":{...}}` to one line and stored THAT — so a large MCP result's offloaded file
+was a nested single-line envelope (owner's observation).
+
+Option 3 (#2396 Step 1): the clean-payload DECISION is now ONE shared helper (`decide_payload_field`)
+called by BOTH offload paths — so they can never diverge again — and the chat cap is envelope-aware:
+when `data` declares a sole-oversized payload field, it stores `data[field]` CLEAN (real newlines)
+via the already-shared `offload_value(payload_field=...)`. P7-safe (OS-level keys only) → generalises
+to every payload-field op (mcp/web/exec). Real MediaStore + real RouterLoop.feedback (no mocks).
+Verified on the CHAT path (not op-runtime).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.core.context_builder import decide_payload_field
+from reyn.data.workspace.media_store import MediaStore
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.tools.scheme import ExecutionResult
+
+_MODEL = "gpt-4o"
+# A multi-line payload well over the offload trigger.
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))
+
+
+def _envelope(payload_field: str = "content", **data_extra) -> dict:
+    """The OS dispatch envelope {status, data:<op-result>} as it reaches router_loop.feedback."""
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+            "media_blocks": [], "_offload_payload_field": payload_field}
+    data.update(data_extra)
+    return {"status": "ok", "data": data}
+
+
+def _cap(content_str: str, store: MediaStore, **kw) -> str:
+    return cap_tool_result_content(
+        content_str, cap_tokens=100, model=_MODEL,
+        save_fn=store.save_tool_result, use_chars4=True, **kw,
+    )
+
+
+def _stored_body(preview_str: str, tmp_path: Path) -> str:
+    # ref is a project-relative path (MediaStore stores relative to project_root=tmp_path).
+    ref = json.loads(preview_str)["_offload_ref"]
+    return (tmp_path / ref).read_text(encoding="utf-8")
+
+
+def test_chat_cap_stores_clean_content_not_envelope(tmp_path):
+    """Tier 2: CORE — the chat offloader stores `data[field]` CLEAN (real newlines), not the
+    whole `{status,data}` envelope single-line. RED on main: it stored `json.dumps(envelope)`."""
+    store = MediaStore(project_root=tmp_path)
+    env = _envelope(content=_BIG)
+    preview = _cap(json.dumps(env), store, clean_value=env["data"], payload_field="content")
+
+    body = _stored_body(preview, tmp_path)
+    assert body == _BIG, "the offloaded file is exactly the clean payload field"
+    assert not body.lstrip().startswith("{"), "not a JSON dict/envelope"
+    assert "\\n" not in body and body.count("\n") == _BIG.count("\n"), "real newlines, no JSON-of-JSON"
+
+
+def test_inline_preview_carries_raw_field_markers(tmp_path):
+    """Tier 2: the inline preview signals raw_field format + the payload field (so the reader knows
+    the ref holds the clean field, matching the control_ir offloader's markers)."""
+    store = MediaStore(project_root=tmp_path)
+    env = _envelope(content=_BIG)
+    preview = json.loads(_cap(json.dumps(env), store, clean_value=env["data"], payload_field="content"))
+    assert preview["_offload_ref_format"] == "raw_field"
+    assert preview["_offload_payload_field"] == "content"
+
+
+def test_generalizes_to_web_and_exec_payload_fields(tmp_path):
+    """Tier 2: P7-safe generalisation — the same envelope-aware path cleans a web `results` list and
+    an exec `stdout` string (no MCP/content literal anywhere)."""
+    store = MediaStore(project_root=tmp_path)
+    big_results = [{"url": f"http://x/{i}", "text": "w" * 200} for i in range(200)]
+    env_web = {"status": "ok", "data": {"kind": "web", "results": big_results,
+                                        "_offload_payload_field": "results"}}
+    body_web = _stored_body(
+        _cap(json.dumps(env_web), store, clean_value=env_web["data"], payload_field="results"), tmp_path
+    )
+    assert json.loads(body_web) == big_results, "web results stored as a clean JSON array"
+
+    env_exec = {"status": "ok", "data": {"kind": "exec", "stdout": _BIG,
+                                         "_offload_payload_field": "stdout"}}
+    body_exec = _stored_body(
+        _cap(json.dumps(env_exec), store, clean_value=env_exec["data"], payload_field="stdout"), tmp_path
+    )
+    assert body_exec == _BIG, "exec stdout stored clean"
+
+
+def test_no_regression_whole_envelope_when_not_clean_payload(tmp_path):
+    """Tier 2: no-regression — with no clean-payload (plain string path), the stored body is the
+    whole content unchanged (the pre-fix behaviour for non-envelope / multi-large results)."""
+    store = MediaStore(project_root=tmp_path)
+    env = _envelope(content=_BIG)
+    preview = _cap(json.dumps(env), store)  # no clean_value/payload_field
+    body = _stored_body(preview, tmp_path)
+    assert body.lstrip().startswith("{") and '"status"' in body, "whole envelope stored (unchanged)"
+
+
+def test_decide_payload_field_shared_decision(tmp_path):
+    """Tier 2: the shared decision helper — sole-oversized marker → the field; a SECOND large field
+    → None (multi-large whole-dict fallback, zero data-loss). This is the SAME helper router_loop and
+    the control_ir offloader call, so the two paths can never diverge on the decision."""
+    assert decide_payload_field(_envelope(content=_BIG)["data"]) == "content"
+    # a second oversized field → not sole → None
+    two_big = _envelope(content=_BIG)["data"]
+    two_big["other"] = _BIG
+    assert decide_payload_field(two_big) is None
+    # no marker → None
+    assert decide_payload_field({"kind": "x", "content": _BIG}) is None
+
+
+class _CapHost:
+    """A real (not mocked) RouterLoopHost surface with only the cap wired to a real MediaStore — the
+    single collaborator router_loop.feedback needs for the offload chokepoint. append_history_entry /
+    scan_tool_result are absent so feedback's getattr-guards skip them."""
+
+    def __init__(self, store: MediaStore) -> None:
+        self._store = store
+
+    def cap_tool_result(self, content_str: str, *, clean_value=None, payload_field=None) -> str:
+        return cap_tool_result_content(
+            content_str, cap_tokens=100, model=_MODEL,
+            save_fn=self._store.save_tool_result, use_chars4=True,
+            clean_value=clean_value, payload_field=payload_field,
+        )
+
+
+def test_live_chat_feedback_detects_envelope_and_stores_clean(tmp_path):
+    """Tier 2: the LIVE chat path — RouterLoop.feedback detects the `{status,data}` envelope, applies
+    the shared decision, and the tool message's offloaded file is CLEAN content. Exercises the real
+    router_loop envelope-detection + cap wiring (not op-runtime). RED on main (whole envelope stored)."""
+    store = MediaStore(project_root=tmp_path)
+    loop = RouterLoop(host=_CapHost(store), chain_id="c1", router_model=_MODEL)
+    env = _envelope(content=_BIG)
+    exec_result = ExecutionResult(
+        tool_results=[env],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+
+    msgs = loop.feedback(exec_result)
+
+    tool_msg = next(m for m in msgs if m["role"] == "tool")
+    body = _stored_body(tool_msg["content"], tmp_path)
+    assert body == _BIG, "feedback stored the clean content field (envelope detected + cleaned)"
+    assert json.loads(tool_msg["content"])["_offload_ref_format"] == "raw_field"


### PR DESCRIPTION
**[e2e-coder]** — owner-priority chat-path offload bug (the #2394 miss). Off clean main. Implements #2396 **Step 1 (Option 3)**, owner-approved as the foundation of the 4-step convergence to one offload path. op-side + chat-cap only; dispatcher.py untouched (P7-safe).

## The bug (chat path, distinct from #2394)
#2394 fixed the control_ir (dict-based) offloader. But owner's CHAT path uses a separate STRING-based offloader: `router_loop.feedback` → `json.dumps(r)` (r = the `{status,data}` dispatch envelope) → `cap_tool_result` → `cap_tool_result_content` → `MediaStore.save_tool_result` → `.reyn/tool-results/`. It stored the **whole serialized envelope**, so a large MCP result offloaded as a nested single-line envelope (owner's observation). The clean-payload gate never ran on this path.

## Fix (Option 3 — shared decision + envelope-aware chat, per #2396)
- **Extract the clean-payload DECISION into one shared helper** `decide_payload_field(op_result) -> field|None` (context_builder.py) — called by BOTH the control_ir offloader AND the chat path, so the decision can never diverge again (the exact divergence that let chat lag #2394). This helper is the reused endpoint for #2396 Step 3, so the extraction is convergence groundwork, not throwaway.
- **Make the chat cap envelope-aware**: `router_loop.feedback` detects the OS envelope `{status, data:<dict>}` (mirroring phase_executor's `set(...) <= {status,data,error}` unwrap check) and, when `data` declares a sole-oversized payload field, stores `data[field]` **CLEAN** via the already-shared `offload_value(payload_field=...)` with a `raw_field` inline.
- **Essential divergence kept**: chat's token-fit + inline-string machinery is unchanged; only the *stored body* changes from envelope-string to the clean field. (The trigger/inline-shape divergence is essential — string-message-body vs ContextFrame-dict; #2396 Steps 2-4 pursue the deeper pipeline convergence separately.)
- **P7-safe**: envelope detection uses OS-level keys only (`status`/`data` + the op-supplied marker), no MCP/content literal → **generalizes** to every payload-field op (web `results`, exec `stdout`, …).
- Threaded `clean_value`/`payload_field` through `router_loop → RouterHostAdapter → ContextBudgetAdvisor → cap_tool_result_content → MediaStore.save_tool_result`, all backward-compatible: the kwargs are forwarded ONLY when clean-payload applies, so a legacy/test capper with the plain `(content_str)` signature is called exactly as before.

## Falsify — LIVE chat path (not op-runtime), RED-verified
Real `MediaStore` + real `RouterLoop.feedback()` (no mocks):
- `test_live_chat_feedback_detects_envelope_and_stores_clean` — drives real `RouterLoop.feedback()` with a `{status,data}` envelope → the tool message's offloaded `.reyn/tool-results/` file is CLEAN content (envelope detected + cleaned end-to-end).
- `test_chat_cap_stores_clean_content_not_envelope` — the chat offloader stores the clean field (real newlines, not a `{...}` envelope).
- `test_generalizes_to_web_and_exec_payload_fields` — web `results` list + exec `stdout` cleaned via the same envelope-aware path.
- `test_no_regression_whole_envelope_when_not_clean_payload` — no clean-payload → whole envelope stored (unchanged).
- `test_inline_preview_carries_raw_field_markers` + `test_decide_payload_field_shared_decision` (sole-oversized → field; multi-large → None).
- **RED-when-stripped**: forcing the clean branch off fails the 4 clean-payload tests; the no-regression + shared-decision tests correctly still pass → the fix is load-bearing.

## CI gates (all green locally)
- ruff: clean
- `test_tier_audit.py --strict`: 6/6 OK
- pytest (full rootdir): **8411 passed**, 17 skipped, 3 xfailed
- `verify_module_docstrings.py`: clean

## Test plan
- [x] Full suite green (8411 passed)
- [x] LIVE chat-path falsify (real RouterLoop.feedback + real MediaStore) + RED-when-stripped verified
- [x] `decide_payload_field` called from BOTH control_ir + chat (convergence endpoint)
- [x] envelope detection uses OS-level keys only (P7); generalizes to web/exec
- [x] 45 directly-affected existing tests pass

part of #2336 · #2396 Step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)