### PR TITLE
fix(#2397): uniform capper signature — remove backward-compat split (MCP router-fail hotfix)

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3129,17 +3129,16 @@ class RouterLoop:
             _scan = getattr(host, "scan_tool_result", None)
             if _scan is not None:
                 _scan(content_str)
-            # #1128: cap oversized tool results once at this chokepoint.
+            # #1128: cap oversized tool results once at this chokepoint. #2397-followup: uniform
+            # call — every capper accepts (content_str, *, clean_value, payload_field), so we always
+            # pass the clean-payload kwargs (both None when not an envelope → capper does a plain cap).
+            # No if/else backward-compat branch (that split let the wired Session._cap_tool_result be
+            # missed → MCP router-fail; owner: backward-compat = debt).
             _cap = getattr(host, "cap_tool_result", None)
             if _cap is not None:
-                if payload_field is not None:
-                    content_str = _cap(
-                        content_str, clean_value=clean_value, payload_field=payload_field
-                    )
-                else:
-                    # No clean-payload → call with the plain (content_str) signature so a host/capper
-                    # without the #2394-followup kwargs (legacy / tests) is unaffected.
-                    content_str = _cap(content_str)
+                content_str = _cap(
+                    content_str, clean_value=clean_value, payload_field=payload_field
+                )
             # FP-0050/#1822 S2: fence untrusted-source content AFTER cap (so
             # truncation can't sever the end marker). Trusted-internal = scan-only.
             if external_source:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -500,19 +500,19 @@ class RouterHostAdapter:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
         (which offloads the full body via the #385 store + returns a bounded
-        preview); identity when no capper was wired (= legacy / test paths).
+        preview); identity when no capper was wired.
 
-        #2394-followup: ``clean_value`` / ``payload_field`` carry the OS dispatch envelope's inner
-        op-result + its sole-oversized payload field. Forwarded ONLY when clean-payload applies, so a
-        capper with the plain ``(content_str)`` signature (legacy / tests) is called exactly as before.
+        ``clean_value`` / ``payload_field`` carry the OS dispatch envelope's inner op-result + its
+        sole-oversized payload field (clean-payload). #2397-followup: every capper has the UNIFORM
+        signature ``(content_str, *, clean_value=None, payload_field=None)``, so we always forward —
+        no backward-compat branch. (The prior "forward only when payload_field is not None" split was
+        the debt that let the wired ``Session._cap_tool_result`` be missed → MCP router-fail.)
         """
         if self._cap_tool_result is None:
             return content_str
-        if payload_field is not None:
-            return self._cap_tool_result(
-                content_str, clean_value=clean_value, payload_field=payload_field
-            )
-        return self._cap_tool_result(content_str)
+        return self._cap_tool_result(
+            content_str, clean_value=clean_value, payload_field=payload_field
+        )
 
     def media_followup_budget(self, tool_content: str) -> int | None:
         """#272 media axis: tokens left for a tool turn's media follow-up after

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5904,9 +5904,19 @@ class Session:
 
     # --- RouterLoop orchestration ---
 
-    def _cap_tool_result(self, content_str: str) -> str:
-        """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1)."""
-        return self._budget_advisor.cap_tool_result(content_str)
+    def _cap_tool_result(
+        self, content_str: str, *, clean_value=None, payload_field=None
+    ) -> str:
+        """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1).
+
+        #2397-followup: this is the capper actually wired into the router host (session.py:1750),
+        so it MUST accept + forward the clean-payload kwargs (``clean_value`` / ``payload_field``)
+        the router chokepoint passes when an envelope declares a sole-oversized field — else the
+        interactive/MCP path raises ``TypeError: unexpected keyword argument 'clean_value'`` and the
+        router fails. The advisor already accepts them; this method was the missed sibling capper."""
+        return self._budget_advisor.cap_tool_result(
+            content_str, clean_value=clean_value, payload_field=payload_field
+        )
 
     def _media_followup_budget(self, tool_content: str) -> int:
         """Forwarding → ContextBudgetAdvisor.media_followup_budget (PR-1)."""

--- a/tests/test_cap_tool_result_regression_2397.py
+++ b/tests/test_cap_tool_result_regression_2397.py
@@ -1,0 +1,94 @@
+"""Tier 2: #2397-followup — uniform capper signature (removes the backward-compat split that crashed).
+
+#2397 threaded ``clean_value`` / ``payload_field`` through the cap chain but left a backward-compat
+SPLIT: the router called ``_cap(...)`` WITH the kwargs only for a clean-payload envelope, else the
+plain ``_cap(content_str)`` — and it MISSED ``Session._cap_tool_result`` (the capper actually WIRED
+into the router host, session.py:1750). So the interactive/MCP path raised ``TypeError: got an
+unexpected keyword argument 'clean_value'`` → router fail (owner-facing).
+
+Clean fix (owner: backward-compat = debt): EVERY capper takes the UNIFORM signature
+``(content_str, *, clean_value=None, payload_field=None)`` and the router ALWAYS passes the kwargs —
+no if/else branch. A missed capper is then a signature mismatch caught structurally, not a runtime
+crash on one path. Real AgentRegistry + real Session; + a signature-sweep completeness guard.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+async def _session(tmp_path) -> Session:
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    return reg.get_session("alice", sid)
+
+
+@pytest.mark.asyncio
+async def test_session_cap_tool_result_accepts_clean_payload_kwargs(tmp_path, monkeypatch):
+    """Tier 2: CORE regression — the REAL wired capper ``Session._cap_tool_result`` accepts the
+    clean-payload kwargs the router now always passes. RED on the pre-fix main: ``TypeError:
+    unexpected keyword argument 'clean_value'`` → router fail on the interactive/MCP path."""
+    monkeypatch.chdir(tmp_path)
+    sess = await _session(tmp_path)
+
+    out = sess._cap_tool_result(
+        "small tool result",
+        clean_value={"content": "small tool result", "_offload_payload_field": "content"},
+        payload_field="content",
+    )
+    assert out == "small tool result", (
+        "under-cap → identity, and (critically) NO TypeError on the clean-payload kwargs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cap_tool_result_uniform_call_non_envelope(tmp_path, monkeypatch):
+    """Tier 2: the router's UNIFORM call with both kwargs None (non-envelope result) behaves like a
+    plain cap — no branch needed. Mirrors what router_loop now always does."""
+    monkeypatch.chdir(tmp_path)
+    sess = await _session(tmp_path)
+
+    out = sess._cap_tool_result("plain result", clean_value=None, payload_field=None)
+    assert out == "plain result"
+
+
+def test_all_cappers_share_uniform_clean_payload_signature():
+    """Tier 2: sweep-completeness — EVERY capper accepts ``clean_value`` + ``payload_field``, so the
+    router's uniform call can never hit a capper that rejects the kwargs (the #2397 missed-capper
+    regression class, eliminated structurally). RED on main: ``Session._cap_tool_result`` lacked them."""
+    cappers = (
+        Session._cap_tool_result,
+        ContextBudgetAdvisor.cap_tool_result,
+        RouterHostAdapter.cap_tool_result,
+        cap_tool_result_content,
+    )
+    for fn in cappers:
+        params = inspect.signature(fn).parameters
+        assert "clean_value" in params, f"{fn.__qualname__} missing clean_value kwarg"
+        assert "payload_field" in params, f"{fn.__qualname__} missing payload_field kwarg"


### PR DESCRIPTION
**[e2e-coder]** — URGENT hotfix for an owner-facing regression from #2397 (my miss). Off clean main.

## The regression
#2397 threaded `clean_value`/`payload_field` through the cap chain but left a backward-compat **split**: `router_loop` passed the kwargs only for a clean-payload envelope (else a plain `_cap(content_str)`), and I updated `ContextBudgetAdvisor` + `RouterHostAdapter` + `cap_tool_result_content` but **missed `Session._cap_tool_result`** — the capper actually WIRED into the router host (`session.py:1750 cap_tool_result=self._cap_tool_result`). So on the interactive/MCP path, when a result is an envelope with a sole-oversized field, the router called `_cap(content_str, clean_value=…, payload_field=…)` → `Session._cap_tool_result` (which took only `content_str`) → **`TypeError: unexpected keyword argument 'clean_value'` → router fail.** (My #2397 test used a stand-in `_CapHost`, not the real wired capper — that's how it slipped through.)

## Clean fix (owner: backward-compat = debt — and it was the root cause here)
Instead of only patching the missed capper, remove the split:
- **Every capper takes the UNIFORM signature** `(content_str, *, clean_value=None, payload_field=None)`: `Session._cap_tool_result` (the missed one) + `ContextBudgetAdvisor.cap_tool_result` + `RouterHostAdapter.cap_tool_result` (drop its forward-only-when-set guard) + `cap_tool_result_content`.
- **`router_loop` always passes the kwargs** (both `None` when not an envelope → capper does a plain cap); no `if/else` branch.

A future missed capper is now a signature mismatch, not a one-path runtime crash.

## Falsify (real Session, RED-verified)
- `test_session_cap_tool_result_accepts_clean_payload_kwargs` — the REAL wired `Session._cap_tool_result` accepts the kwargs (RED on main: `TypeError` → router fail).
- `test_session_cap_tool_result_uniform_call_non_envelope` — the uniform call with both `None` behaves like a plain cap.
- `test_all_cappers_share_uniform_clean_payload_signature` — **sweep-completeness**: `inspect.signature` over all four cappers asserts each has `clean_value` + `payload_field` (structurally prevents the missed-capper class). RED on main (`Session._cap_tool_result` lacked them).

## CI gates
- ruff: clean · tier-audit: OK (0 Tier-4) · docstrings: clean
- pytest (full rootdir): running — will confirm green before merge
- Existing cap + #2397 chat-offload tests (16) pass.

## Test plan
- [x] Real-Session regression test + RED-verified against main
- [x] Signature-sweep completeness guard (all cappers uniform)
- [ ] full suite green (running) — confirm before merge

part of #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)