### PR TITLE
fix(cost-restart): status-bar per-agent cost/tokens read the durable tracker (layer 1: backend)

### DIFF
--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -953,6 +953,18 @@ class BudgetTracker:
             context={"model": model, "current": used, "hard": cap},
         )
 
+    def agent_cost_usd(self, agent: str) -> float:
+        """All-time cumulative USD cost for ``agent`` — the durable per-agent total (ledger-hydrated,
+        restart-surviving). The single source of truth read by ``/cost`` and, via
+        ``registry.agent_cost_usd`` (#cost-restart), the inline status bar. One counter per agent
+        (summed across all its sessions in ``record_llm``), so it never N×-counts multiple sessions."""
+        return self._agent_cost_usd.get(agent, 0.0)
+
+    def agent_tokens(self, agent: str) -> int:
+        """All-time cumulative TOTAL tokens for ``agent`` (durable, ledger-hydrated). Total only —
+        the prompt/completion breakdown is not persisted per ledger record (only ``total_tokens``)."""
+        return self._agent_tokens.get(agent, 0)
+
     def _agent_context(self, agent: str | None) -> dict:
         if agent is None:
             return {}

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -408,19 +408,38 @@ class AgentRegistry:
         spawned ids thereafter."""
         return list(self._sessions.get(name, {}).keys())
 
-    def agent_cost_usd(self, name: str) -> float:
-        """Total cost in USD across ALL sessions of agent ``name``.
+    def _shared_budget_tracker(self) -> "object | None":
+        """The process-shared BudgetTracker, reached via any loaded session's gateway (all sessions
+        of all agents share ONE tracker in production). ``None`` when no session is loaded / no
+        tracker is wired. Because it is process-shared, reading it via any one session yields the
+        durable per-agent totals for EVERY agent — including agents with no currently-live session
+        (the ledger-hydrated counters persist regardless)."""
+        for a_name in self.loaded_names():
+            for sid in self.session_ids(a_name):
+                sess = self.get_session(a_name, sid)
+                tracker = getattr(getattr(sess, "_budget", None), "tracker", None)
+                if tracker is not None:
+                    return tracker
+        return None
 
-        Single source of truth for per-agent cost aggregation — used by both
-        the inline status bar and the run_repl exit summary so they never drift
-        when sessions are spawned via /session new.
-        """
-        total = 0.0
-        for sid in self.session_ids(name):
-            sess = self.get_session(name, sid)
-            if sess is not None:
-                total += sess.total_cost_usd
-        return total
+    def agent_cost_usd(self, name: str) -> float:
+        """All-time cumulative USD cost for agent ``name``, read from the DURABLE process-shared
+        BudgetTracker (ledger-hydrated).
+
+        Single source of truth for per-agent cost aggregation — used by the inline status bar and the
+        run_repl exit summary. Reading the durable tracker (one per-agent counter) makes this survive
+        restart and byte-align with ``/cost``. (Was: a SUM over per-session gateways — this-process
+        only, so it reset to 0 on restart AND N×-counted an agent's cost across ``/session new``
+        sessions, since each gateway held the full per-agent seed. #cost-restart.)"""
+        tracker = self._shared_budget_tracker()
+        return tracker.agent_cost_usd(name) if tracker is not None else 0.0
+
+    def agent_tokens(self, name: str) -> int:
+        """All-time cumulative TOTAL tokens for agent ``name`` from the durable tracker (restart-
+        surviving companion to ``agent_cost_usd``). Total only — the prompt/completion breakdown is
+        not persisted per ledger record. #cost-restart."""
+        tracker = self._shared_budget_tracker()
+        return tracker.agent_tokens(name) if tracker is not None else 0
 
     def agent_total_usage(self, name: str) -> "object":
         """Aggregate TokenUsage across ALL sessions of agent ``name``."""

--- a/tests/test_registry_multi_session_1726.py
+++ b/tests/test_registry_multi_session_1726.py
@@ -18,7 +18,11 @@ from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from reyn.runtime.session import Session
 
 
-def _registry(tmp_path):
+def _registry(tmp_path, tracker: "BudgetTracker | None" = None):
+    # ONE shared BudgetTracker across all sessions — matches production (created + hydrated once at
+    # the entry point, threaded to every session). agent_cost_usd reads this durable per-agent total.
+    shared = tracker if tracker is not None else BudgetTracker(CostConfig())
+
     def factory(profile: AgentProfile):
         agent_dir = tmp_path / ".reyn" / "agents" / profile.name
         agent_dir.mkdir(parents=True, exist_ok=True)
@@ -26,7 +30,7 @@ def _registry(tmp_path):
             agent_name=profile.name,
             agent_role=profile.role,
             output_language="en",
-            budget_tracker=BudgetTracker(CostConfig()),
+            budget_tracker=shared,
             snapshot_path=agent_dir / "state" / "snapshot.json",
         )
 
@@ -101,30 +105,67 @@ async def test_attach_session_focuses_existing_and_rejects_unknown(tmp_path) -> 
             task.cancel()
 
 
-def test_agent_cost_usd_aggregates_all_sessions(tmp_path):
-    """Tier 2: agent_cost_usd() sums cost across ALL sids, not just 'main'.
+def test_agent_cost_usd_reads_durable_per_agent_total(tmp_path):
+    """Tier 2: agent_cost_usd() reads the DURABLE per-agent total (ledger-hydrated BudgetTracker) —
+    ONE counter that already reflects cost across ALL sessions of the agent. So it (a) survives
+    restart (the counter is ledger-derived, not live-gateway) and (b) does NOT N×-count multiple
+    sessions (still one counter, not a sum over per-session gateways).
 
-    Regression: the exit cost summary in run_repl called get_session(name) without
-    a sid (defaulting to 'main'), silently missing sessions spawned via /session new.
-    agent_cost_usd() is the single source of truth used by both the inline status
-    bar and the run_repl exit summary.
+    Falsification: on the pre-fix impl (a SUM over per-session ``sess.total_cost_usd`` gateways),
+    this ledger-only cost reports 0.0 (no live gateway accumulation) → the 0.15 assert fails; and a
+    per-session-seed variant would report 0.30 across the two sessions (N×)."""
+    import json
+    from datetime import datetime, timezone
 
-    Falsification: if agent_cost_usd() only read the main session, the assertion
-    total == pytest.approx(0.15) would return 0.10 and fail.
-    """
-    import types
+    # A ledger with two recorded LLM calls for agent "default" (all-time cumulative 0.10 + 0.05).
+    ledger = tmp_path / ".reyn" / "state" / "budget_ledger.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).isoformat()
+    ledger.write_text(
+        json.dumps({"ts": ts, "agent": "default", "tokens": 100, "cost_usd": 0.10}) + "\n"
+        + json.dumps({"ts": ts, "agent": "default", "tokens": 50, "cost_usd": 0.05}) + "\n",
+        encoding="utf-8",
+    )
+    tracker = BudgetTracker(CostConfig())
+    tracker.hydrate(ledger)  # = the restart restore path
 
-    reg = _registry(tmp_path)
-    main = reg.get_or_load("default")
-    sid2 = reg.spawn_session("default")
-    extra = reg.get_session("default", sid2)
+    reg = _registry(tmp_path, tracker=tracker)
+    reg.get_or_load("default")
+    reg.spawn_session("default")  # a 2nd session — must NOT double the reported per-agent cost
 
-    assert extra is not None
-    # Inject cost via public accumulate() with a duck-typed result object.
-    main._budget.accumulate(types.SimpleNamespace(token_usage=None, cost_usd=0.10))
-    extra._budget.accumulate(types.SimpleNamespace(token_usage=None, cost_usd=0.05))
+    assert reg.agent_cost_usd("default") == pytest.approx(0.15), (
+        "durable per-agent total (all sessions, one counter) — not reset to 0, not N×-summed"
+    )
+    assert reg.agent_tokens("default") == 150, "durable per-agent total tokens (companion accessor)"
 
-    total = reg.agent_cost_usd("default")
-    assert total == pytest.approx(0.15), (
-        "agent_cost_usd must sum ALL session costs, not just 'main'"
+
+def test_agent_cost_usd_survives_restart_and_byte_aligns_no_ntimes(tmp_path):
+    """Tier 2: the fix's core (owner bug) — cost recorded pre-restart SURVIVES a restart (a fresh
+    tracker hydrated from the persisted ledger = the real restore path) and byte-aligns with the
+    tracker's own per-agent total (= what ``/cost`` reads), with NO N× across sessions.
+
+    Falsification: the pre-fix summed live per-session gateways → 0.0 after restart (RED), and a
+    per-session-seed variant → 3× across the three sessions (RED)."""
+    import json
+    from datetime import datetime, timezone
+
+    ledger = tmp_path / ".reyn" / "state" / "budget_ledger.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).isoformat()
+    ledger.write_text(
+        json.dumps({"ts": ts, "agent": "default", "tokens": 200, "cost_usd": 0.42}) + "\n",
+        encoding="utf-8",
+    )
+    # "Restart": a brand-new tracker hydrated from the persisted ledger.
+    restarted = BudgetTracker(CostConfig())
+    restarted.hydrate(ledger)
+
+    reg = _registry(tmp_path, tracker=restarted)
+    reg.get_or_load("default")
+    reg.spawn_session("default")
+    reg.spawn_session("default")  # 3 sessions total — must not multiply the per-agent cost
+
+    assert reg.agent_cost_usd("default") == pytest.approx(0.42), "survives restart (not 0), no N×"
+    assert reg.agent_cost_usd("default") == restarted.agent_cost_usd("default"), (
+        "status-bar per-agent cost byte-aligns with the /cost source (the durable tracker)"
     )


### PR DESCRIPTION
**[e2e-coder]** — owner-priority: status-bar cost resets to $0 on restart. Off clean main. **Layer 1 of 2** (backend data; layer 2 = tui's render).

## Root-cause (flow-trace verified)
The status-bar's per-agent cost went to 0 on restart because `registry.agent_cost_usd(name)` **SUMMED per-session gateway costs** (`BudgetGateway._total_cost_usd`) — an in-memory field, `0.0` at construction, never seeded from persist. The DURABLE per-agent total lives in the ledger-hydrated `BudgetTracker` (what `/cost` reads). Summing per-session gateways also **N×-counted** an agent's cost across `/session new` sessions.

(Note: this is the durable-read fix, NOT the originally-proposed "seed each gateway from the per-agent total" — that would have N×-counted across sessions, since `agent_cost_usd` sums the gateways. Flagged + rejected in review.)

## Fix — layer 1 (backend, no backward-compat shim)
- `registry.agent_cost_usd(name)` → reads the **durable process-shared `BudgetTracker`** (one per-agent counter) via `_shared_budget_tracker()` → survives restart, byte-aligns with `/cost`, **no N×**.
- Add `registry.agent_tokens(name)` — durable per-agent total tokens (breakdown not persisted per ledger record, only `total_tokens`).
- Add public `BudgetTracker.agent_cost_usd(agent)` / `agent_tokens(agent)` accessors.

## Falsify (real ledger → hydrate = the restart restore path; RED-verified)
- `test_agent_cost_usd_reads_durable_per_agent_total` — hydrate a tracker from a 2-record ledger → `agent_cost_usd == 0.15` across 2 sessions (durable, no N×) + `agent_tokens == 150`.
- `test_agent_cost_usd_survives_restart_and_byte_aligns_no_ntimes` — a FRESH tracker hydrated from the persisted ledger (= restart) → reports the pre-restart cumulative (not 0), byte-aligns with the tracker (`/cost` source), no N× across 3 sessions.
- **RED-verified**: reverting `agent_cost_usd` to the old gateway-sum → both durable tests fail (0.0 for ledger-only cost). Test harness now shares ONE tracker (production wiring); the old `accumulate()`-into-gateways aggregation test is rewritten to the durable contract.

## CI gates
- ruff clean · tier-audit OK · docstrings clean
- 47 budget/cost + 189 inline/status-bar tests pass (semantic-change blast radius)
- pytest (full rootdir): running — confirm green before merge

## Layer 2 (tui-coder, app.py)
Point the main cost chip at durable `cost_agent` (currently per-session `cost_usd`) + the token total at `registry.agent_tokens`. Accessor shapes delivered to tui; they wire the render once this lands.

## Test plan
- [x] Durable-read + restart + no-N× falsify, RED-verified
- [x] budget/status-bar blast-radius tests pass
- [ ] full suite green (running)

part of #cost-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)