### PR TITLE
fix(mcp): probe constructs MCPClient correctly (hot-reload — installed servers' tools appear)

### DIFF
--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -998,13 +998,24 @@ def _probe_status(name: str, cfg: dict) -> str:
     from reyn.llm.llm import run_async as _run_async
 
     async def _handshake() -> str:
+        # MCPClient takes ONE positional ``config: dict`` (no async-CM protocol). The old
+        # ``MCPClient(name, cfg)`` + ``async with client`` passed the name as config → ValueError,
+        # reported as a bogus "error: ..." status for every server. Correct: construct with cfg,
+        # ``initialize()`` (the handshake the async-with was meant to do), close in the same task.
+        from reyn.mcp.client import MCPClient
+        client = None
         try:
-            from reyn.mcp.client import MCPClient
-            client = MCPClient(name, cfg)
-            async with client:
-                return "ready"
+            client = MCPClient(cfg)
+            await client.initialize()
+            return "ready"
         except Exception as exc:
             return f"error: {exc}"
+        finally:
+            if client is not None:
+                try:
+                    await client.close()
+                except Exception:  # noqa: BLE001 — best-effort teardown
+                    pass
 
     try:
         return _run_async(_handshake())
@@ -1248,14 +1259,27 @@ async def _probe_server_tools(
 
     from reyn.mcp.client import MCPClient
 
+    # MCPClient has NO async-context-manager protocol and takes ONE positional ``config: dict``
+    # (agent_id is keyword-only). The old ``async with MCPClient(server_name, cfg)`` passed the
+    # server NAME as ``config`` → ValueError, swallowed by the bare except → EVERY probe returned an
+    # empty tool list (installed servers showed no tools = the hot-reload gap). Correct: construct
+    # with the cfg dict, ``list_tools()`` (which auto-initializes), and close in ``finally`` in this
+    # same task (the anyio cancel-scope is task-affine — same discipline as _mcp_list_tools).
+    client = None
     try:
         async with asyncio.timeout(per_server_timeout):
-            async with MCPClient(server_name, cfg) as client:
-                raw = await client.list_tools()
+            client = MCPClient(cfg)
+            raw = await client.list_tools()
     except (TimeoutError, asyncio.TimeoutError):
         return server_name, []
     except Exception:  # noqa: BLE001
         return server_name, []
+    finally:
+        if client is not None:
+            try:
+                await client.close()
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
     cleaned = [
         t for t in (raw or [])
         if isinstance(t, dict) and "error" not in t and t.get("name")

--- a/tests/test_mcp_probe_client_lifecycle.py
+++ b/tests/test_mcp_probe_client_lifecycle.py
@@ -1,0 +1,63 @@
+"""Tier 2: MCP probe constructs MCPClient correctly (hot-reload: installed servers' tools show up).
+
+``_probe_server_tools`` / ``_probe_status`` did ``async with MCPClient(server_name, cfg)``, but
+MCPClient takes ONE positional ``config: dict`` (agent_id keyword-only) and has NO async-context-
+manager protocol. The server NAME (a str) was passed as ``config`` → ValueError, swallowed by the
+bare except → every probe returned an empty tool list / a bogus "error:" status (the hot-reload gap:
+installed servers showed no tools). Fix: ``MCPClient(cfg)`` + ``list_tools()`` / ``initialize()`` +
+``finally: close()`` in the same task. Injected fake mirrors the real MCPClient surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+import reyn.mcp.client as mcp_client_mod
+from reyn.interfaces.cli.commands.mcp import _probe_server_tools, _probe_status
+
+
+class _FakeMCPClient:
+    """Mirrors the real MCPClient: ONE positional ``config: dict``, keyword-only ``agent_id``, and
+    NO async-context-manager protocol — so the old ``MCPClient(name, cfg)`` + ``async with`` fails
+    exactly as the real client did (a str is not a dict / 2 positionals)."""
+
+    last_config = None
+
+    def __init__(self, config, *, agent_id=None) -> None:
+        if not isinstance(config, dict):
+            raise ValueError("MCP server config must be a dict")
+        _FakeMCPClient.last_config = config
+        self.closed = False
+
+    async def initialize(self) -> None:
+        pass
+
+    async def list_tools(self):
+        return [{"name": "tool_a"}, {"name": "tool_b"}, {"error": "skip"}, {"no_name": 1}]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_probe_server_tools_returns_real_tools(monkeypatch):
+    """Tier 2: CORE — the probe returns the server's actual tools (cleaned), constructed with the
+    cfg DICT (not the name string). RED on the pre-fix ``MCPClient(server_name, cfg)`` (a str as
+    config → ValueError → swallowed → empty list)."""
+    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+
+    name, tools = await _probe_server_tools("mysrv", {"type": "stdio", "command": "x"})
+
+    assert name == "mysrv"
+    assert tools == [{"name": "tool_a"}, {"name": "tool_b"}], "real tools returned + cleaned"
+    assert _FakeMCPClient.last_config == {"type": "stdio", "command": "x"}, (
+        "constructed with the cfg DICT (config-first), not the server name"
+    )
+
+
+def test_probe_status_ready(monkeypatch):
+    """Tier 2: _probe_status returns 'ready' via a real initialize() handshake, not a swallowed
+    ValueError from the mis-constructed client. (Sync test — _probe_status manages its own loop via
+    run_async.)"""
+    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+
+    assert _probe_status("mysrv", {"type": "stdio", "command": "x"}) == "ready"


### PR DESCRIPTION
**[e2e-coder]** — MCP-lifecycle fix C (hot-reload gap, owner's other bug). Off clean main. Fix B (cross-task cache) is plan-first next.

## The gap
`_probe_server_tools` (mcp.py) + `_probe_status` did `async with MCPClient(server_name, cfg)`, but `MCPClient` takes ONE positional `config: dict` (`agent_id` keyword-only) and has **no** `__aenter__`/`__aexit__`. So the server NAME (a `str`) was passed as `config` → `ValueError`, **swallowed by the bare except** → every probe returned an **empty tool list** / a bogus `"error:"` status. Net effect: an installed MCP server's tools never appeared (the hot-reload gap owner hit).

## Fix
Construct with the cfg **dict** (config-first), call `list_tools()` (which auto-initializes) / `initialize()` (the handshake the `async with` was meant to do), and `close()` in a **`finally`** in the SAME task — the anyio cancel-scope is task-affine, same discipline as fix A (`_mcp_list_tools`).

## Falsify (fake mirroring the real MCPClient surface — one positional dict, no async-CM; RED-verified BOTH sites)
- `test_probe_server_tools_returns_real_tools` — the probe returns the server's real tools (cleaned) AND is constructed with the cfg **dict**, not the name string. RED on the pre-fix `MCPClient(server_name, cfg)` (str-as-config → ValueError → swallowed → empty).
- `test_probe_status_ready` — `_probe_status` returns `"ready"` via a real `initialize()` handshake.
- Reintroducing `MCPClient(name, cfg)` at each site fails its test.

## CI gates
- ruff clean · tier-audit OK · docstrings clean
- 257 mcp cli/refresh/probe/status tests pass
- pytest (full rootdir): running — confirm green before merge

## Arc
- A (#2401) — `_mcp_list_tools` finally-close — **merged**.
- **C — this PR** (probe args + finally-close).
- B — `op_runtime/mcp.py` cross-task cached-client close (call_mcp_tool same crash class) — **plan-first next**.

## Test plan
- [x] Both probes return real data, RED-verified each site
- [x] 257 mcp cli tests pass
- [ ] full suite green (running)

part of the MCP-lifecycle arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)