### PR TITLE
fix(mcp): structural client-scope — robust-by-construction teardown + same-task guard (B)

### DIFF
--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -17,6 +17,8 @@ handlers are preserved (they run inside the invoker).
 """
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -160,7 +162,11 @@ class ControlIRExecutor:
         self._perm = permission_resolver
         self._skill_name = skill_name
         self._mcp_servers: dict = (mcp_servers or {}).get("servers", {})
-        self._mcp_clients: dict = {}  # cached across ops
+        self._mcp_clients: dict = {}  # cached across ops (subprocess reuse within a run)
+        # #B-hardening: the task that owns the MCP client scope for the current run. Set by
+        # ``mcp_client_scope`` (entered once per run in the run-owning task); the op handler's
+        # same-task guard reads it. None outside a scope (e.g. the chat per-call path).
+        self._mcp_scope_owner_task: "asyncio.Task | None" = None
         self._caller = caller
         self._chain_id = chain_id
         # FP-0021: run_id of the currently-executing OSRuntime run.
@@ -478,6 +484,9 @@ class ControlIRExecutor:
             state_dir_strategy="control_ir",
             mcp_servers=self._mcp_servers,
             mcp_clients=self._mcp_clients,
+            # #B-hardening: the run-owning task, so the op handler can fail-fast if a client is
+            # opened from a different task (the cross-task cancel-scope hazard). None outside a scope.
+            mcp_owner_task=self._mcp_scope_owner_task,
             intervention_bus=self._intervention_bus,
             # #1190 stage (ii): cost recorder for LLM-calling ops (judge_output).
             budget_tracker=self._budget_tracker,
@@ -524,6 +533,34 @@ class ControlIRExecutor:
             # FP-0016 D: per-skill credential scoping.
             secret_store=self._secret_store,
         )
+
+    @property
+    def mcp_scope_owner_task(self) -> "asyncio.Task | None":
+        """The task that owns the MCP client scope (None outside a scope). Read by the op handler's
+        same-task guard (op_runtime/mcp.py) to fail-fast on a cross-task client open."""
+        return self._mcp_scope_owner_task
+
+    @asynccontextmanager
+    async def mcp_client_scope(self):
+        """#B-hardening (robust-by-construction): own the cached MCP clients' lifecycle.
+
+        Entered ONCE per run, in the run-owning task (see runtime.py wrapping ``RunOrchestrator.run``).
+        Records that task, and on exit — success, exception, OR cancellation — closes every cached
+        client in THAT task. This replaces the manual ``teardown_mcp_clients()`` call in the run
+        finally: a single close site bound to the scope's ``__aexit__``, which cannot be forgotten or
+        duplicated (was: a discipline-dependent line that a future edit could move/drop). Combined
+        with the same-task guard in op_runtime/mcp.py (which reads ``mcp_scope_owner_task``), a client
+        opened from a NON-owning task fails fast at open rather than crashing at teardown with the
+        anyio "cancel scope crossed task boundary" error. Subprocess reuse is preserved — the cache
+        still lives for the whole run."""
+        self._mcp_scope_owner_task = asyncio.current_task()
+        try:
+            yield
+        finally:
+            try:
+                await self.teardown_mcp_clients()
+            finally:
+                self._mcp_scope_owner_task = None
 
     async def teardown_mcp_clients(self) -> None:
         """Close all cached MCP clients in the **same asyncio task** as the caller.

--- a/src/reyn/core/kernel/run_orchestrator.py
+++ b/src/reyn/core/kernel/run_orchestrator.py
@@ -15,6 +15,7 @@ This is the final layer in the 4-component decomposition:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -439,6 +440,12 @@ class RunOrchestrator:
 
     # ── Main loop ─────────────────────────────────────────────────────────────
 
+    def mcp_client_scope(self):
+        """#B-hardening: the run-scoped MCP client lifecycle CM (delegates to the control_ir
+        executor). runtime.py wraps the ``run()`` call in this so the cached MCP clients open + close
+        in the run-owning task — structural teardown, not a discipline-dependent finally line."""
+        return self._phase_executor._control_ir_executor.mcp_client_scope()
+
     async def run(
         self,
         initial_input: dict,
@@ -453,6 +460,15 @@ class RunOrchestrator:
         Returns RunResult with status="finished" or status="loop_limit_exceeded".
         Raises WorkflowAbortedError on unrecoverable LLM abort.
         """
+        # #B-hardening: this run MUST execute inside mcp_client_scope() (runtime.py wraps the call),
+        # so any MCP client opened during the run is closed in THIS task at scope exit. Fail fast if a
+        # caller bypassed the wrap — else the cross-task teardown hazard returns and clients leak.
+        _executor = self._phase_executor._control_ir_executor
+        if _executor.mcp_scope_owner_task is not asyncio.current_task():
+            raise RuntimeError(
+                "RunOrchestrator.run must execute inside mcp_client_scope() (the run-owning task). "
+                "Wrap the call: `async with orchestrator.mcp_client_scope(): await orchestrator.run(...)`."
+            )
         if self._perm:
             # B49 W2-S5 fix (2026-05-22): pass intervention_bus as-is; it
             # may be None in non-interactive contexts (= preprocessor
@@ -870,11 +886,10 @@ class RunOrchestrator:
             raise
 
         finally:
-            # G11 fix (hypothesis A+B): close MCP clients in the same asyncio
-            # task that opened them.  Deferring to GC lets the AsyncExitStack
-            # be finalised from an unrelated context, which causes anyio
-            # cancel-scope task-affinity RuntimeErrors in stderr.
-            await self._phase_executor._control_ir_executor.teardown_mcp_clients()
+            # #B-hardening: MCP client teardown is no longer a manual line here — it moved to the
+            # structural ``mcp_client_scope()`` __aexit__ that runtime.py wraps this run in (G11's
+            # "close in the same task that opened them", now robust-by-construction: single close
+            # site, can't be forgotten/duplicated, + the op handler fails fast on a cross-task open).
 
             # R-D1: exception-aware completion. The finally clause must
             # distinguish between "this run is finished" and "this run was

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -793,11 +793,18 @@ class OSRuntime:
         Returns RunResult with status="finished" or status="loop_limit_exceeded".
         Raises WorkflowAbortedError on unrecoverable LLM abort.
         """
-        return await self._orchestrator.run(
-            initial_input=initial_input,
-            output_language=output_language,
-            max_phase_retries=max_phase_retries,
-        )
+        # #B-hardening: own the MCP client lifecycle structurally for this run. The scope records
+        # the run-owning task (this one) and closes every cached MCP client in it on exit — success,
+        # exception, or cancellation — replacing the old manual teardown_mcp_clients() finally line
+        # in RunOrchestrator.run. All runs (incl. tests via OSRuntime.run) flow through here, so the
+        # scope is always active; RunOrchestrator.run asserts this + the op handler fails fast on a
+        # cross-task client open.
+        async with self._orchestrator.mcp_client_scope():
+            return await self._orchestrator.run(
+                initial_input=initial_input,
+                output_language=output_language,
+                max_phase_retries=max_phase_retries,
+            )
 
     # ── _validate_phase_output — kept as backward-compat shim ─────────────────
     # Tests that call _validate_phase_output directly on OSRuntime continue to

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -61,6 +61,11 @@ class OpContext:
     mcp_servers: dict = field(default_factory=dict)
     # Mutable cache for MCP HTTP clients keyed by server name
     mcp_clients: dict = field(default_factory=dict)
+    # #B-hardening: the task that owns the mcp_clients lifecycle (set by the control_ir executor's
+    # mcp_client_scope). The mcp op handler fails fast if a client is opened from a different task
+    # (the cross-task cancel-scope hazard). None = unscoped (e.g. the chat per-call path, which
+    # opens+closes in its own task) → guard is skipped.
+    mcp_owner_task: "object | None" = None
     # FP-0016 Component E: agent identity for X-Reyn-Agent-Id header on
     # outgoing MCP / external HTTP calls. Plumbed from Session's
     # ReynConfig.agent.id (= `reyn/<hostname>` by default). None

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -7,6 +7,7 @@ with pre-PR32 reyn.yaml files.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Literal
 
 from reyn.schemas.models import MCPIROp
@@ -35,6 +36,19 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     if "type" not in expanded:
         if expanded.get("url"):
             expanded = {**expanded, "type": "http"}
+
+    # #B-hardening: fail fast if this op runs in a task OTHER than the one that owns the client
+    # scope. A client initialized (anyio stdio_client cancel-scope) in a non-owner task would later
+    # be closed by the owner task at scope teardown → "cancel scope crossed task boundary". Guarding
+    # at open/use time turns that latent cross-task crash into a loud, immediate error. The unscoped
+    # (chat per-call) path has mcp_owner_task=None and opens+closes in its own task → guard skipped.
+    owner_task = getattr(ctx, "mcp_owner_task", None)
+    if owner_task is not None and asyncio.current_task() is not owner_task:
+        raise RuntimeError(
+            "MCP op executed in a task other than the client-scope owner — this would leak an anyio "
+            "cancel-scope across tasks (see control_ir_executor.mcp_client_scope). Run MCP ops in "
+            "the run-owning task, or open a per-call client in this task."
+        )
 
     if op.server not in ctx.mcp_clients:
         try:

--- a/tests/test_mcp_client_scope_hardening.py
+++ b/tests/test_mcp_client_scope_hardening.py
@@ -1,0 +1,151 @@
+"""Tier 2: MCP client-scope hardening — structural teardown + same-task fail-fast guard (#B).
+
+Robust-by-construction replacement for the discipline-dependent ``teardown_mcp_clients()`` finally
+line:
+- ``ControlIRExecutor.mcp_client_scope()`` records the run-owning task on enter and closes every
+  cached client in THAT task on exit — success, exception, or cancellation (single close site).
+- ``op_runtime/mcp.py`` fails FAST if an MCP op runs in a task other than the scope owner (a
+  cross-task client open would leak an anyio cancel-scope → the "cancel scope crossed task boundary"
+  crash — the whole point of the same-task discipline). The unscoped chat per-call path
+  (mcp_owner_task=None) is exempt.
+Subprocess reuse (the cache) is preserved. Real executor + real ``_execute`` + injected fake client.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import reyn.mcp.client as mcp_client_mod
+from reyn.core.events.events import EventLog
+from reyn.core.kernel.control_ir_executor import ControlIRExecutor
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+class _FakeMCPClient:
+    """Real (not mocked) stand-in recording close + the task it ran in."""
+
+    instances: list = []
+
+    def __init__(self, config, *, agent_id=None) -> None:
+        self.closed = False
+        self.close_task = None
+        _FakeMCPClient.instances.append(self)
+
+    async def initialize(self) -> None:
+        pass
+
+    async def list_tools(self):
+        return [{"name": "t"}]
+
+    async def call_tool(self, name, args, *, progress_callback=None, timeout_seconds=None):
+        return {"content": [{"type": "text", "text": "ok"}], "isError": False,
+                "structuredContent": None}
+
+    async def close(self) -> None:
+        self.closed = True
+        self.close_task = asyncio.current_task()
+
+
+def _executor() -> ControlIRExecutor:
+    events = EventLog()
+    return ControlIRExecutor(workspace=Workspace(events=events), events=events)
+
+
+# ── scope CM: records owner + structural teardown (success + exception) ──────────
+
+@pytest.mark.asyncio
+async def test_scope_records_owner_and_closes_on_exit():
+    """Tier 2: the scope records the owning task on enter and closes every cached client in that
+    task on exit, clearing the cache + resetting the owner."""
+    ex = _executor()
+    assert ex.mcp_scope_owner_task is None
+    fake = _FakeMCPClient({})
+    async with ex.mcp_client_scope():
+        assert ex.mcp_scope_owner_task is asyncio.current_task()
+        ex._mcp_clients["srv"] = fake  # simulate a client opened during the run
+
+    assert fake.closed is True, "scope exit closes cached clients"
+    assert fake.close_task is asyncio.current_task(), "closed in the OWNING task"
+    assert ex.mcp_scope_owner_task is None, "owner reset after scope"
+
+
+@pytest.mark.asyncio
+async def test_scope_closes_on_exception():
+    """Tier 2: the scope closes clients even when the body raises (structural teardown covers the
+    error/cancellation path — the old finally line did too, but as a discipline-dependent call)."""
+    ex = _executor()
+    fake = _FakeMCPClient({})
+    with pytest.raises(RuntimeError, match="boom"):
+        async with ex.mcp_client_scope():
+            ex._mcp_clients["srv"] = fake
+            raise RuntimeError("boom")
+    assert fake.closed is True, "scope closes clients on the exception path"
+    assert ex.mcp_scope_owner_task is None
+
+
+# ── fail-fast guard + reuse (op handler) ─────────────────────────────────────────
+
+def _ctx(*, owner_task) -> OpContext:
+    events = EventLog()
+    return OpContext(
+        workspace=Workspace(events=events), events=events,
+        permission_decl=PermissionDecl(), permission_resolver=None,
+        mcp_servers={"srv": {"type": "stdio", "command": "x"}},
+        mcp_clients={}, mcp_owner_task=owner_task,
+    )
+
+
+@pytest.mark.asyncio
+async def test_op_fails_fast_in_non_owner_task(monkeypatch):
+    """Tier 2: CORE — an MCP op running in a task OTHER than the scope owner raises immediately
+    (loud fail), instead of leaking a cross-task cancel-scope that crashes at teardown."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+
+    async def _noop():
+        await asyncio.sleep(0)
+    other_task = asyncio.create_task(_noop())  # a DIFFERENT task = the scope owner
+    ctx = _ctx(owner_task=other_task)
+    op = MCPIROp(kind="mcp", server="srv", tool="t", args={})
+    with pytest.raises(RuntimeError, match="task other than the client-scope owner"):
+        await _execute(op, ctx)
+    await other_task
+
+
+@pytest.mark.asyncio
+async def test_op_proceeds_in_owner_task_and_reuses_client(monkeypatch):
+    """Tier 2: in the owning task the op proceeds (byte-identical result), and a 2nd op to the same
+    server REUSES the cached client — subprocess reuse preserved (no re-spawn), no N× spawn."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+    _FakeMCPClient.instances = []
+
+    ctx = _ctx(owner_task=asyncio.current_task())  # owner == this task → guard passes
+    op = MCPIROp(kind="mcp", server="srv", tool="t", args={})
+
+    result = await _execute(op, ctx)
+    assert result["status"] == "ok", "op proceeds + result byte-identical"
+    client1 = ctx.mcp_clients["srv"]  # the client cached after call 1
+    await _execute(op, ctx)  # 2nd call, same server
+    assert ctx.mcp_clients["srv"] is client1, (
+        "the SAME cached client is reused on the 2nd call — subprocess reuse preserved, not re-spawned"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unscoped_chat_path_is_exempt(monkeypatch):
+    """Tier 2: the unscoped per-call path (mcp_owner_task=None, e.g. chat _mcp_call_tool) skips the
+    guard — it opens+closes in its own task, so no owner is recorded."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+
+    ctx = _ctx(owner_task=None)  # unscoped
+    op = MCPIROp(kind="mcp", server="srv", tool="t", args={})
+    result = await _execute(op, ctx)
+    assert result["status"] == "ok", "unscoped path proceeds (guard skipped)"


### PR DESCRIPTION
**[e2e-coder]** — MCP-lifecycle fix B (owner-directed structural hardening). Off clean main. Completes the task-affinity arc (A #2401 / C #2402 fixed the active bugs; B hardens the shared control_ir path robust-by-construction). Approach (c), lead-GO'd after plan-first.

## Why (not an active bug — a hardening)
Flow-trace showed B's crash class was already closed by the prior **G11 fix** (same-task teardown): control_ir ops run sequentially in the run-loop task, `teardown_mcp_clients()` has a single call site in that task's finally, chat closes in its own finally. Owner then directed: make it **robust-by-construction** rather than discipline-dependent. The cache exists for **subprocess reuse** (idempotent `initialize()` keeps the stdio subprocess alive across ops in a run), so full per-call (re-spawn) was rejected on perf grounds; approach (c) keeps reuse.

## Approach (c)
- **`ControlIRExecutor.mcp_client_scope()`** — an async CM entered ONCE per run in the run-owning task (`runtime.py` wraps `RunOrchestrator.run`). Records the owning task; on exit (success / exception / cancellation) closes every cached client in THAT task. Single close site bound to `__aexit__` — replaces the manual `teardown_mcp_clients()` finally line (can't be forgotten/duplicated). **Reuse preserved** (cache lives for the run).
- **op_runtime/mcp.py same-task guard** — fails FAST if an MCP op runs in a task other than the scope owner (a cross-task client open would leak an anyio cancel-scope → the "cancel scope crossed task boundary" crash). Latent hazard → loud immediate error. Unscoped chat per-call path (`mcp_owner_task=None`) is exempt.
- **`RunOrchestrator.run` asserts the scope is active** (fail-fast on a future caller bypassing the wrap). All runs flow through `OSRuntime.run`, which now wraps (verified: sole caller; tests use `rt.run`).

## Equivalence (broader change — shared handler + teardown contract)
- `call_mcp_tool` byte-identical (result shape unchanged; the guard is a pre-check that passes in the owner task).
- Teardown moves from the run `finally` to the scope `__aexit__` (after the run returns, **same task**; `complete()`/resume don't touch clients — functionally equivalent).
- Chat `_mcp_call_tool` (its own per-call finally, `mcp_owner_task=None`) unaffected.

## Falsify (real executor + real `_execute` + injected fake client, RED-verified)
- scope records the owner + closes on exit **in the owning task** + resets owner;
- scope closes on the **exception** path;
- op **fails fast** in a non-owner task (RED: strip guard → no raise);
- op **reuses** the cached client in the owner task (same instance — reuse preserved);
- unscoped path exempt.
Stripping the guard / the scope teardown fails the respective tests.

## CI gates
- ruff clean · tier-audit OK (0 Tier-4) · docstrings clean
- 760 mcp/control_ir/orchestrator/runtime tests pass + 9 run-orchestrator invariants
- pytest (full rootdir): running — confirm green before merge

## Test plan
- [x] 4-point falsify + RED-verified (guard + scope teardown)
- [x] equivalence: run-orchestrator + mcp suites green
- [ ] full suite green (running)

part of the MCP-lifecycle arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)