### PR TITLE
fix(mcp): MCPClient structured async-context lifecycle (a359 P1 — root-cause fix, part 1)

### DIFF
--- a/scripts/mcp_stdio_repro.py
+++ b/scripts/mcp_stdio_repro.py
@@ -1,0 +1,155 @@
+"""Live-stdio MCP repro harness (#B / a359) — SCRATCH investigation tool (not a committed test).
+
+Spawns a REAL minimal stdio MCP server subprocess and drives reyn's actual ``MCPClient`` lifecycle,
+to (1) reproduce the ``stdio_client`` internal-anyio-task-group crash the fake-client tests were
+blind to, (2) split platform-independent vs Windows-only, and (3) empirically answer
+cacheable-vs-per-call (does a cached client survive a 2nd call + close without the task-boundary
+crash?). Owner crash keywords: BaseExceptionGroup / cancel scope crossed task boundary /
+BrokenResourceError / ConnectionReset.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+_SERVER_SRC = textwrap.dedent(
+    '''
+    from mcp.server.fastmcp import FastMCP
+    mcp = FastMCP("repro")
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return text
+
+    if __name__ == "__main__":
+        mcp.run(transport="stdio")
+    '''
+)
+
+_KEYWORDS = ("baseexceptiongroup", "cancel scope", "task boundary",
+             "brokenresource", "connectionreset", "connection lost", "unhandled errors in a task group")
+
+
+def _cfg(server_path: str) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [server_path]}
+
+
+async def scenario_same_task(server_path: str):
+    """#2401's model: open + list_tools + close in ONE task. If this crashes, the SDK-internal task
+    group violates task-affinity even under reyn's same-task close (= #2401 insufficient)."""
+    from reyn.mcp.client import MCPClient
+    client = MCPClient(_cfg(server_path))
+    try:
+        return {"tools": len(await client.list_tools())}
+    finally:
+        await client.close()
+
+
+async def scenario_cacheable(server_path: str):
+    """Cacheable test: open + call the tool TWICE (reuse) + close, all in one task. If it survives,
+    a cached client IS reusable → #2403's (c) cache+scope holds. If it crashes on the 2nd call or
+    close, per-call (a) is required."""
+    from reyn.mcp.client import MCPClient
+    client = MCPClient(_cfg(server_path))
+    try:
+        await client.list_tools()
+        r1 = await client.call_tool("echo", {"text": "a"})
+        r2 = await client.call_tool("echo", {"text": "b"})  # 2nd call = reuse the cached client
+        return {"call1": bool(r1), "call2": bool(r2)}
+    finally:
+        await client.close()
+
+
+async def scenario_cross_task(server_path: str):
+    """Baseline: open in this task, close in a DIFFERENT task → the known cross-task hazard."""
+    from reyn.mcp.client import MCPClient
+    client = MCPClient(_cfg(server_path))
+    await client.list_tools()
+
+    async def _close_elsewhere():
+        await client.close()
+
+    await asyncio.create_task(_close_elsewhere())
+    return {"closed_in": "other_task"}
+
+
+async def scenario_no_close_gc(server_path: str):
+    """Harshest: open + list_tools, then RETURN WITHOUT close → the AsyncExitStack is finalised by
+    GC / loop teardown from an unrelated context (the exact case the G11 comment warned about). Most
+    likely to trip 'cancel scope crossed task boundary' if anything does."""
+    from reyn.mcp.client import MCPClient
+    client = MCPClient(_cfg(server_path))
+    tools = await client.list_tools()
+    return {"tools": len(tools), "closed": False}  # intentionally leak → GC teardown
+
+
+async def scenario_real_session_list_tools(server_path: str):
+    """The ACTUAL owner path: Session._mcp_list_tools (post-#2401 finally-close) against a real
+    stdio subprocess."""
+    import tempfile as _tf
+
+    from reyn.core.events.state_log import StateLog
+    from reyn.runtime.profile import AgentProfile
+    from reyn.runtime.registry import AgentRegistry
+    from reyn.runtime.session import Session
+
+    d = _tf.mkdtemp()
+    sl = StateLog(Path(d) / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile):
+        s = Session(agent_name=profile.name, state_log=sl, registry=holder.get("reg"))
+        s.register_intervention_listener("t")
+        return s
+
+    reg = AgentRegistry(project_root=Path(d), session_factory=_factory, state_log=sl)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(Path(d) / ".reyn" / "agents" / "alice")
+    sess = reg.get_or_load("alice")
+    sess._mcp_servers_flat = lambda: {"srv": _cfg(server_path)}  # type: ignore
+    tools = await sess._mcp_list_tools("srv")
+    return {"tools": tools if isinstance(tools, list) and tools and "error" in tools[0] else len(tools)}
+
+
+async def scenario_fault_server_death(_server_path: str):
+    """Fault-injection (owner req): a server that DIES on startup. reyn must CONTAIN it (a catchable
+    error the callers wrap → error result), not an uncontained crash. Structured `async with` path."""
+    from reyn.mcp.client import MCPClient
+    dead = {"type": "stdio", "command": sys.executable, "args": ["-c", "import sys; sys.exit(1)"]}
+    try:
+        async with MCPClient(dead) as client:
+            await client.list_tools()
+        return {"contained": False, "note": "unexpected: no error"}
+    except Exception as exc:  # noqa: BLE001 — a CONTAINABLE error (callers wrap → error result)
+        return {"contained": True, "error_type": type(exc).__name__}
+
+
+def _run_isolated(name: str, make_coro, server_path: str) -> None:
+    """Each scenario in its OWN fresh event loop (asyncio.run) so a leaked task/scope from one
+    scenario can't contaminate the next — clean per-scenario verdict."""
+    try:
+        result = asyncio.run(make_coro(server_path))
+        print(f"[{name}] SURVIVED: {result}")
+    except BaseException as exc:  # noqa: BLE001 — investigation: catch everything incl. groups
+        text = f"{type(exc).__name__}: {exc}"
+        print(f"[{name}] CRASHED: {text}")
+        hits = [k for k in _KEYWORDS if k in text.lower()]
+        if hits:
+            print(f"    → owner-keyword match: {hits}")
+
+
+if __name__ == "__main__":
+    loop_cls = type(asyncio.new_event_loop()).__name__
+    print(f"python={sys.version.split()[0]} platform={sys.platform} loop={loop_cls}")
+    with tempfile.TemporaryDirectory() as _d:
+        _server = str(Path(_d) / "repro_server.py")
+        Path(_server).write_text(_SERVER_SRC, encoding="utf-8")
+        _run_isolated("same_task_open_close", scenario_same_task, _server)
+        _run_isolated("cacheable_2calls_close", scenario_cacheable, _server)
+        _run_isolated("cross_task_close", scenario_cross_task, _server)
+        _run_isolated("no_close_gc_teardown", scenario_no_close_gc, _server)
+        _run_isolated("real_session_list_tools", scenario_real_session_list_tools, _server)
+        _run_isolated("fault_server_death", scenario_fault_server_death, _server)

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -998,24 +998,15 @@ def _probe_status(name: str, cfg: dict) -> str:
     from reyn.llm.llm import run_async as _run_async
 
     async def _handshake() -> str:
-        # MCPClient takes ONE positional ``config: dict`` (no async-CM protocol). The old
-        # ``MCPClient(name, cfg)`` + ``async with client`` passed the name as config → ValueError,
-        # reported as a bogus "error: ..." status for every server. Correct: construct with cfg,
-        # ``initialize()`` (the handshake the async-with was meant to do), close in the same task.
+        # #a359 P1: structured lifecycle — ``async with MCPClient(cfg)`` runs the initialize handshake
+        # in __aenter__ and closes in __aexit__, same task/scope (supersedes C's construct +
+        # initialize + finally-close). MCPClient(cfg): config-first dict.
         from reyn.mcp.client import MCPClient
-        client = None
         try:
-            client = MCPClient(cfg)
-            await client.initialize()
-            return "ready"
+            async with MCPClient(cfg):
+                return "ready"
         except Exception as exc:
             return f"error: {exc}"
-        finally:
-            if client is not None:
-                try:
-                    await client.close()
-                except Exception:  # noqa: BLE001 — best-effort teardown
-                    pass
 
     try:
         return _run_async(_handshake())
@@ -1259,27 +1250,19 @@ async def _probe_server_tools(
 
     from reyn.mcp.client import MCPClient
 
-    # MCPClient has NO async-context-manager protocol and takes ONE positional ``config: dict``
-    # (agent_id is keyword-only). The old ``async with MCPClient(server_name, cfg)`` passed the
-    # server NAME as ``config`` → ValueError, swallowed by the bare except → EVERY probe returned an
-    # empty tool list (installed servers showed no tools = the hot-reload gap). Correct: construct
-    # with the cfg dict, ``list_tools()`` (which auto-initializes), and close in ``finally`` in this
-    # same task (the anyio cancel-scope is task-affine — same discipline as _mcp_list_tools).
-    client = None
+    # #a359 P1: structured lifecycle — open+use+close within ONE ``async with`` block in this task,
+    # so the SDK stdio_client / ClientSession internal task-group scopes are entered AND exited here
+    # (supersedes C's construct + finally-close, which still deferred the scope teardown to a separate
+    # close()). MCPClient(cfg): config-first dict (fixes the old ``MCPClient(server_name, cfg)`` that
+    # passed the name as config → ValueError → empty tool list); ``list_tools()`` auto-initializes.
     try:
         async with asyncio.timeout(per_server_timeout):
-            client = MCPClient(cfg)
-            raw = await client.list_tools()
+            async with MCPClient(cfg) as client:
+                raw = await client.list_tools()
     except (TimeoutError, asyncio.TimeoutError):
         return server_name, []
     except Exception:  # noqa: BLE001
         return server_name, []
-    finally:
-        if client is not None:
-            try:
-                await client.close()
-            except Exception:  # noqa: BLE001 — best-effort teardown
-                pass
     cleaned = [
         t for t in (raw or [])
         if isinstance(t, dict) and "error" not in t and t.get("name")

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -177,6 +177,21 @@ class MCPClient:
         self._session = session
         self._initialized = True
 
+    async def __aenter__(self) -> "MCPClient":
+        """#a359: structured lifecycle. ``initialize()`` here + ``close()`` in ``__aexit__`` run in
+        the SAME task/scope — so the transport + session (whose SDK stdio_client / ClientSession hold
+        internal anyio task-group scopes that MUST be exited in the task that entered them) open and
+        close within one ``async with`` block. Callers use ``async with MCPClient(cfg) as c:`` instead
+        of a lazy ``initialize()`` + a deferred ``self._stack`` closed by a later ``close()`` in a
+        possibly-different task — that deferral was the root cause of the cross-task 'cancel scope
+        crossed task boundary' error (Windows: BrokenResource / BaseExceptionGroup during subprocess
+        teardown)."""
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.close()
+
     async def call_tool(
         self,
         name: str,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5841,28 +5841,18 @@ class Session:
         if "type" not in expanded and expanded.get("url"):
             expanded = {**expanded, "type": "http"}
 
-        client = None
+        # #a359 P1: structured lifecycle — the client's whole life is one ``async with`` block in
+        # this task, so its SDK stdio_client / ClientSession internal task-group scopes are entered
+        # AND exited here. This supersedes A's (#2401) finally-close: even a same-task close via a
+        # deferred self._stack crosses the SDK's INTERNAL sub-task scope (the real cross-task crash);
+        # binding open+close in one async-with block restores the SDK's intended structured usage.
         try:
-            client = MCPClient(expanded, agent_id=self._agent_id)
-            return await client.list_tools()
+            async with MCPClient(expanded, agent_id=self._agent_id) as client:
+                return await client.list_tools()
         except MCPError as exc:
             return [{"error": str(exc)}]
         except Exception as exc:
             return [{"error": str(exc)}]
-        finally:
-            # Close in the SAME task that opened it, on EVERY exit path — success, MCPError,
-            # Exception, AND cancellation. The old code closed only after a successful list_tools(),
-            # so a raise (or cancel) leaked the anyio stdio_client cancel-scope → a later teardown in
-            # a different task raised "cancel scope crossed task boundary" (owner's list_mcp_tools
-            # crash). ``finally`` runs for BaseException (incl. CancelledError) too, which a trailing
-            # close after ``except Exception`` would miss. Best-effort (mirrors _mcp_call_tool).
-            if client is not None:
-                try:
-                    await client.close()
-                except Exception:  # noqa: BLE001 — best-effort teardown; original result stands
-                    logger.debug(
-                        "mcp client close failed in _mcp_list_tools", exc_info=True
-                    )
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Invoke an MCP tool and return its result.

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -60,6 +60,13 @@ class _FakeMCPClient:
         self._raises = getattr(_FakeMCPClient, "_next_raises", True)
         _FakeMCPClient.instances.append(self)
 
+    async def __aenter__(self):
+        # #a359 P1: mirror the real MCPClient's async-CM protocol (callers now use `async with`).
+        return self
+
+    async def __aexit__(self, *exc_info):
+        await self.close()
+
     async def list_tools(self):
         self.list_task = asyncio.current_task()
         if self._raises:

--- a/tests/test_mcp_probe_client_lifecycle.py
+++ b/tests/test_mcp_probe_client_lifecycle.py
@@ -31,6 +31,13 @@ class _FakeMCPClient:
     async def initialize(self) -> None:
         pass
 
+    async def __aenter__(self):
+        # #a359 P1: mirror the real MCPClient's async-CM protocol (probe now uses `async with`).
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.close()
+
     async def list_tools(self):
         return [{"name": "tool_a"}, {"name": "tool_b"}, {"error": "skip"}, {"no_name": 1}]
 

--- a/tests/test_mcp_structured_client_p1.py
+++ b/tests/test_mcp_structured_client_p1.py
@@ -1,0 +1,84 @@
+"""Tier 2: #a359 P1 — MCPClient structured async-context lifecycle (real stdio subprocess).
+
+Root cause (a359): MCPClient's deferred ``self._stack`` (``initialize()`` stashes it; a later
+``close()`` — possibly in a different task — does ``stack.aclose()``) exits the SDK stdio_client /
+ClientSession INTERNAL anyio task-group scopes cross-task → "cancel scope crossed task boundary"
+(Windows: BrokenResource / BaseExceptionGroup during subprocess teardown).
+
+Fix: MCPClient is an async context manager — ``async with MCPClient(cfg) as c:`` opens (__aenter__)
+and closes (__aexit__) in ONE task/scope, restoring the SDK's intended structured usage. This test
+is the UNIX acceptance: the structured lifecycle works end-to-end against a REAL stdio subprocess and
+completes cleanly. The Windows crash manifestation is Proactor-specific (owner-env diagnostic = P3),
+so Unix survival is NECESSARY, not sufficient — hence a live subprocess, not a fake (the fake was
+structurally blind to the SDK-internal task group that actually crashes).
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SERVER_SRC = textwrap.dedent(
+    '''
+    from mcp.server.fastmcp import FastMCP
+    mcp = FastMCP("p1acceptance")
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return text
+
+    if __name__ == "__main__":
+        mcp.run(transport="stdio")
+    '''
+)
+
+
+@pytest.fixture()
+def stdio_cfg(tmp_path):
+    server = tmp_path / "p1_server.py"
+    server.write_text(_SERVER_SRC, encoding="utf-8")
+    return {"type": "stdio", "command": sys.executable, "args": [str(server)]}
+
+
+@pytest.mark.asyncio
+async def test_async_with_lifecycle_lists_tools(stdio_cfg):
+    """Tier 2: `async with MCPClient(cfg) as c` opens + lists tools + closes in one task/scope,
+    against a real stdio subprocess. Structured lifecycle survives (Unix acceptance)."""
+    from reyn.mcp.client import MCPClient
+
+    async with MCPClient(stdio_cfg) as client:
+        tools = await client.list_tools()
+    names = {t.get("name") for t in tools if isinstance(t, dict)}
+    assert "echo" in names, "the real server's tool is listed via the structured lifecycle"
+
+
+@pytest.mark.asyncio
+async def test_async_with_calls_tool_and_reopens_cleanly(stdio_cfg):
+    """Tier 2: a tool call works within the scope, and a SECOND independent `async with` opens+closes
+    cleanly afterward — i.e. the first block fully tore down (no lingering scope prevents re-open)."""
+    from reyn.mcp.client import MCPClient
+
+    async with MCPClient(stdio_cfg) as client:
+        result = await client.call_tool("echo", {"text": "hi"})
+    assert result is not None
+
+    # a fresh structured block after the first fully closed → a clean subprocess re-spawn
+    async with MCPClient(stdio_cfg) as client2:
+        tools = await client2.list_tools()
+    assert any(t.get("name") == "echo" for t in tools if isinstance(t, dict))
+
+
+@pytest.mark.asyncio
+async def test_server_death_is_contained_not_uncontained_crash():
+    """Tier 2: fault isolation (owner req) — an MCP server that DIES on startup surfaces a contained
+    error through the real probe (empty tool list), it does NOT crash the caller. (P1 covers the
+    simple-site error path via ``except Exception``; the per-turn-pool exception boundary for
+    teardown BaseExceptionGroups — the transport-signature faults — is P2.)"""
+    from reyn.interfaces.cli.commands.mcp import _probe_server_tools
+
+    dead_cfg = {"type": "stdio", "command": sys.executable, "args": ["-c", "import sys; sys.exit(1)"]}
+    name, tools = await _probe_server_tools("dead", dead_cfg)
+    assert (name, tools) == ("dead", []), "server death is contained → empty result, not a crash"


### PR DESCRIPTION
**[e2e-coder]** — the TRUE root-cause fix for the MCP task-affinity arc (a359), staged. P1 of 3. Off clean main.

## Root cause (a359 + my live-repro)
`MCPClient`'s **deferred `self._stack`**: `initialize()` stashes the `AsyncExitStack` (stdio_client + ClientSession, each holding an internal anyio task group in sub-tasks); a later `close()` does `stack.aclose()`, exiting those **SDK-internal scopes cross-task** → "cancel scope crossed task boundary" (Windows: `BrokenResourceError` / `BaseExceptionGroup` during subprocess/job-object teardown). This is why **A (#2401 finally-close) and C (#2402) were insufficient** — even a same-task reyn close crosses the SDK's *internal* sub-task scope. My live-repro (real stdio subprocess) confirmed: on macOS/Unix all lifecycle scenarios survive (Unix tolerates the cross-task mechanism) → the crash is Proactor/Windows-specific.

## P1 (staged: P2 = per-turn structured pool for op/executor + #2403 absorb; P3 = owner-Windows diagnostic)
- **MCPClient is an async context manager** — `__aenter__` = initialize, `__aexit__` = close → a client's whole life is one `async with` block in one task/scope (the SDK's intended structured usage; the deferred `self._stack` is no longer closed across frames).
- **Migrate the one-shot sites** to `async with MCPClient(cfg)`: `Session._mcp_list_tools` (supersedes A's finally-close), cli `_probe_server_tools` + `_probe_status` (supersedes C's construct+finally-close).
- **Fault-isolation (owner req)** — a misbehaving/dying MCP server surfaces a CONTAINED error (callers' `except` → error result), not a crash.

## Acceptance = REAL stdio subprocess (FastMCP), not a fake
The fakes (A/B/C) were structurally blind to the SDK-internal task group that crashes — hence a live subprocess:
- `test_async_with_lifecycle_lists_tools`, `test_async_with_calls_tool_and_reopens_cleanly` — structured lifecycle works end-to-end + re-opens cleanly.
- `test_server_death_is_contained_not_uncontained_crash` — fault isolation.
- A's + C's test fakes updated to mirror the new async-CM protocol.
- Live-repro harness committed (`scripts/mcp_stdio_repro.py`) as acceptance infra (+ a fault_server_death arm).

**Honest scope (over-conclude caution):** on Unix the *crash* can't be RED-verified (Unix tolerates the old code), so **P1's Unix acceptance is NECESSARY-not-sufficient** (structured lifecycle + fault containment). The teardown `BaseExceptionGroup` boundary is P2's pool; **Windows sufficiency is P3** (owner-env diagnostic — the crash is Proactor-specific). No bad-response root claimed; fault-isolation covers both teardown + bad-response.

## CI gates
- ruff clean · tier-audit OK · docstrings clean
- pytest (full rootdir): running — confirm green before merge

## Test plan
- [x] structured lifecycle + fault-isolation acceptance (real subprocess)
- [x] A/C fakes migrated to the CM protocol
- [ ] full suite green (running)

part of the MCP task-affinity arc (a359) · P1 of 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)