### PR TITLE
fix(mcp): per-turn structured MCPClientPool + fault-isolation boundary (a359 P2)

### DIFF
--- a/src/reyn/core/kernel/control_ir_executor.py
+++ b/src/reyn/core/kernel/control_ir_executor.py
@@ -31,6 +31,7 @@ from reyn.core.op_runtime import execute_op
 from reyn.core.op_runtime.context import OpContext
 from reyn.data.workspace.workspace import Workspace
 from reyn.llm.model_resolver import ModelResolver
+from reyn.mcp.pool import MCPClientPool
 from reyn.schemas.models import (
     ALL_OP_KINDS,
     OP_KIND_MODEL_MAP,
@@ -160,7 +161,10 @@ class ControlIRExecutor:
         self._perm = permission_resolver
         self._skill_name = skill_name
         self._mcp_servers: dict = (mcp_servers or {}).get("servers", {})
-        self._mcp_clients: dict = {}  # cached across ops
+        # #a359 P2: the per-turn structured MCP client pool (subprocess reuse within the run, opened
+        # + closed in the run-owning task via `async with`). Replaces the raw `_mcp_clients` dict +
+        # `teardown_mcp_clients()` — runtime.py wraps the run in this pool (see mcp_client_scope).
+        self._mcp_pool = MCPClientPool()
         self._caller = caller
         self._chain_id = chain_id
         # FP-0021: run_id of the currently-executing OSRuntime run.
@@ -220,14 +224,10 @@ class ControlIRExecutor:
         return self._resume_plan
 
     @property
-    def mcp_clients(self) -> dict:
-        """Read-only accessor for the cached MCP client map (server name →
-        client). Tests inspect this to verify the teardown lifecycle
-        (= ``teardown_mcp_clients`` empties the dict). Production
-        callers continue to use ``self._mcp_clients`` for the write
-        side (= ops cache new clients there).
-        """
-        return self._mcp_clients
+    def mcp_pool(self) -> "MCPClientPool":
+        """The per-turn structured MCP client pool. runtime.py enters it (``async with``) around the
+        run so clients open + close in the run-owning task; the op handler calls ``pool.get()``."""
+        return self._mcp_pool
 
     @property
     def secret_store(self):
@@ -477,7 +477,7 @@ class ControlIRExecutor:
             sub_state_dir_override=None,
             state_dir_strategy="control_ir",
             mcp_servers=self._mcp_servers,
-            mcp_clients=self._mcp_clients,
+            mcp_pool=self._mcp_pool,
             intervention_bus=self._intervention_bus,
             # #1190 stage (ii): cost recorder for LLM-calling ops (judge_output).
             budget_tracker=self._budget_tracker,
@@ -525,25 +525,10 @@ class ControlIRExecutor:
             secret_store=self._secret_store,
         )
 
-    async def teardown_mcp_clients(self) -> None:
-        """Close all cached MCP clients in the **same asyncio task** as the caller.
-
-        Must be called from the same task that ran ``execute()``.  Calling
-        ``close()`` here — rather than letting the ``AsyncExitStack`` be
-        finalised by the GC — prevents anyio cancel-scope task-affinity
-        violations (G11 hypothesis A+B): the stack's context managers
-        (``stdio_client`` / ``ClientSession``) were entered in this task and
-        must be exited in this task.
-        """
-        import logging
-        _log = logging.getLogger(__name__)
-        clients = list(self._mcp_clients.items())
-        self._mcp_clients.clear()
-        for name, client in clients:
-            try:
-                await client.close()
-            except Exception as exc:  # noqa: BLE001
-                _log.warning("MCP client %s close error: %s", name, exc)
+    # #a359 P2: `teardown_mcp_clients()` is gone — the MCPClientPool's `__aexit__` closes every
+    # cached client in the run-owning task (structurally, and fault-contained incl.
+    # BaseExceptionGroup), replacing the manual same-task teardown. runtime.py wraps the run in the
+    # pool; the op handler opens clients via `pool.get()` in that task.
 
     async def execute(
         self,

--- a/src/reyn/core/kernel/preprocessor_executor.py
+++ b/src/reyn/core/kernel/preprocessor_executor.py
@@ -181,7 +181,6 @@ class PreprocessorExecutor:
             preprocessor_phase_name=phase.name,
             preprocessor_step_index=step_index,
             mcp_servers={},
-            mcp_clients={},
             intervention_bus=None,  # ask_user is forbidden in preprocessor
             current_phase=phase.name,
             caller=self._caller,

--- a/src/reyn/core/kernel/run_orchestrator.py
+++ b/src/reyn/core/kernel/run_orchestrator.py
@@ -15,6 +15,7 @@ This is the final layer in the 4-component decomposition:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -439,6 +440,13 @@ class RunOrchestrator:
 
     # ── Main loop ─────────────────────────────────────────────────────────────
 
+    def mcp_client_scope(self):
+        """#a359 P2: the run-scoped MCPClientPool (delegates to the control_ir executor). runtime.py
+        wraps the ``run()`` call in this (``async with``) so the run's MCP clients open + close in the
+        run-owning task — structural, fault-contained teardown (absorbs #2403's run-scope idea, now
+        with the clients themselves structured in the pool's task)."""
+        return self._phase_executor._control_ir_executor.mcp_pool
+
     async def run(
         self,
         initial_input: dict,
@@ -453,6 +461,15 @@ class RunOrchestrator:
         Returns RunResult with status="finished" or status="loop_limit_exceeded".
         Raises WorkflowAbortedError on unrecoverable LLM abort.
         """
+        # #a359 P2: this run MUST execute inside mcp_client_scope() (runtime.py wraps the call), so
+        # any MCP client opened during the run is opened AND closed in this task (the pool owns it).
+        # Fail fast if a caller bypassed the wrap — else the cross-SDK-task teardown hazard returns.
+        _pool = self._phase_executor._control_ir_executor.mcp_pool
+        if _pool.owner_task is not asyncio.current_task():
+            raise RuntimeError(
+                "RunOrchestrator.run must execute inside mcp_client_scope() (the run-owning task). "
+                "Wrap the call: `async with orchestrator.mcp_client_scope(): await orchestrator.run(...)`."
+            )
         if self._perm:
             # B49 W2-S5 fix (2026-05-22): pass intervention_bus as-is; it
             # may be None in non-interactive contexts (= preprocessor
@@ -870,11 +887,12 @@ class RunOrchestrator:
             raise
 
         finally:
-            # G11 fix (hypothesis A+B): close MCP clients in the same asyncio
-            # task that opened them.  Deferring to GC lets the AsyncExitStack
-            # be finalised from an unrelated context, which causes anyio
-            # cancel-scope task-affinity RuntimeErrors in stderr.
-            await self._phase_executor._control_ir_executor.teardown_mcp_clients()
+            # #a359 P2: MCP client teardown is no longer a manual call here — it moved to the
+            # MCPClientPool's `__aexit__` that runtime.py wraps this run in (structural, same task,
+            # fault-contained incl. BaseExceptionGroup). G11's "close in the task that opened them"
+            # is now robust-by-construction; the pool also OPENS clients in that task (op handler →
+            # pool.get()), closing the cross-SDK-task hazard the old dict + teardown left latent.
+            pass
 
             # R-D1: exception-aware completion. The finally clause must
             # distinguish between "this run is finished" and "this run was

--- a/src/reyn/core/kernel/run_orchestrator.py
+++ b/src/reyn/core/kernel/run_orchestrator.py
@@ -892,7 +892,6 @@ class RunOrchestrator:
             # fault-contained incl. BaseExceptionGroup). G11's "close in the task that opened them"
             # is now robust-by-construction; the pool also OPENS clients in that task (op handler →
             # pool.get()), closing the cross-SDK-task hazard the old dict + teardown left latent.
-            pass
 
             # R-D1: exception-aware completion. The finally clause must
             # distinguish between "this run is finished" and "this run was

--- a/src/reyn/core/kernel/runtime.py
+++ b/src/reyn/core/kernel/runtime.py
@@ -793,11 +793,17 @@ class OSRuntime:
         Returns RunResult with status="finished" or status="loop_limit_exceeded".
         Raises WorkflowAbortedError on unrecoverable LLM abort.
         """
-        return await self._orchestrator.run(
-            initial_input=initial_input,
-            output_language=output_language,
-            max_phase_retries=max_phase_retries,
-        )
+        # #a359 P2: own the run's MCP client lifecycle structurally. The pool records this
+        # (run-owning) task and closes every client opened during the run in it — on success,
+        # exception, or cancellation — fault-contained (incl. BaseExceptionGroup). All runs (incl.
+        # tests via OSRuntime.run) flow through here, so the pool is always active; RunOrchestrator.run
+        # asserts it, and the op handler opens clients via pool.get() in this task.
+        async with self._orchestrator.mcp_client_scope():
+            return await self._orchestrator.run(
+                initial_input=initial_input,
+                output_language=output_language,
+                max_phase_retries=max_phase_retries,
+            )
 
     # ── _validate_phase_output — kept as backward-compat shim ─────────────────
     # Tests that call _validate_phase_output directly on OSRuntime continue to

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from reyn.data.workspace.media_store import MediaStore
     from reyn.data.workspace.workspace import Workspace
     from reyn.llm.model_resolver import ModelResolver
+    from reyn.mcp.pool import MCPClientPool
     from reyn.schemas.models import Skill
     from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
     from reyn.security.sandbox import SandboxBackend
@@ -59,8 +60,11 @@ class OpContext:
 
     # MCP
     mcp_servers: dict = field(default_factory=dict)
-    # Mutable cache for MCP HTTP clients keyed by server name
-    mcp_clients: dict = field(default_factory=dict)
+    # #a359 P2: the per-turn structured MCP client pool (owns open+reuse+close in one task). Replaces
+    # the old raw ``mcp_clients`` dict (lazily filled by the op handler, closed by a separate teardown
+    # in a possibly-different task → the cross-SDK-task cancel-scope crash). None outside an MCP
+    # context (non-MCP ops never invoke the mcp handler).
+    mcp_pool: "MCPClientPool | None" = None
     # FP-0016 Component E: agent identity for X-Reyn-Agent-Id header on
     # outgoing MCP / external HTTP calls. Plumbed from Session's
     # ReynConfig.agent.id (= `reyn/<hostname>` by default). None

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -16,7 +16,8 @@ from .context import OpContext
 
 
 async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
-    from reyn.mcp.client import MCPClient, MCPError, expand_env
+    from reyn.mcp.client import expand_env
+    from reyn.mcp.pool import describe_fault, is_or_contains_cancel
 
     server_cfg = ctx.mcp_servers.get(op.server)
     if not server_cfg:
@@ -36,15 +37,12 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
         if expanded.get("url"):
             expanded = {**expanded, "type": "http"}
 
-    if op.server not in ctx.mcp_clients:
-        try:
-            # FP-0016 E: thread agent_id so X-Reyn-Agent-Id is added to
-            # outgoing MCP HTTP requests.
-            ctx.mcp_clients[op.server] = MCPClient(expanded, agent_id=ctx.agent_id)
-        except ValueError as exc:
-            return {"kind": "mcp", "status": "error", "server": op.server,
-                    "tool": op.tool, "error": str(exc)}
-    client = ctx.mcp_clients[op.server]
+    # #a359 P2: the client comes from the per-turn structured pool (opened + closed in the pool's
+    # owning task — no cross-SDK-task teardown). None = no pool wired on this ctx (a non-MCP
+    # OpContext should never reach the mcp handler; guard defensively).
+    if ctx.mcp_pool is None:
+        return {"kind": "mcp", "status": "error", "server": op.server,
+                "tool": op.tool, "error": "no MCP client pool on this context"}
 
     # issue #264 — wire MCP SDK progress + per-call timeout:
     #
@@ -83,15 +81,25 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
 
     ctx.events.emit("mcp_called", server=op.server, tool=op.tool, args=op.args)
     try:
+        # Open (or reuse) the client via the pool, then call — both inside the fault boundary so a
+        # server that dies on connect, a bad config, a malformed response, OR a transport
+        # BaseExceptionGroup all become a contained error tool-result (owner req: MCP misbehavior
+        # must not crash the router loop). Cancellation is never swallowed.
+        client = await ctx.mcp_pool.get(op.server, expanded, agent_id=ctx.agent_id)
         result = await client.call_tool(
             op.tool, op.args,
             progress_callback=_on_progress,
             timeout_seconds=call_timeout,
         )
-    except MCPError as exc:
-        ctx.events.emit("mcp_failed", server=op.server, tool=op.tool, error=str(exc))
+    except BaseException as exc:  # noqa: BLE001 — fault isolation across ANY MCP fault (incl groups)
+        if is_or_contains_cancel(exc):
+            raise
+        # Owner req: feed the fault CONTENT back to the LLM (type + message, group members
+        # aggregated) via the standard op-error result — so it can retry/adapt, not a silent error.
+        fault = describe_fault(exc)
+        ctx.events.emit("mcp_failed", server=op.server, tool=op.tool, error=fault)
         return {"kind": "mcp", "status": "error", "server": op.server,
-                "tool": op.tool, "error": str(exc)}
+                "tool": op.tool, "error": fault}
 
     content_items = result.get("content", [])
     if isinstance(content_items, list):

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -14,6 +14,28 @@ from reyn.schemas.models import MCPIROp
 from . import register
 from .context import OpContext
 
+# #a359 P2 / S3: a FINITE default per-call MCP timeout so a hung/slow server can't block the router
+# loop indefinitely (owner: "MCP misbehavior must not stall reyn"). Generous (long-running tools
+# exist); a per-server ``call_timeout_seconds`` overrides it, and ``<= 0`` opts out (no timeout).
+# When the timeout fires, the SDK raises → the op fault boundary contains it into an error result.
+_DEFAULT_MCP_CALL_TIMEOUT_SECONDS: float = 120.0
+
+
+def _resolve_call_timeout(config: dict) -> "float | None":
+    """Resolve the per-call MCP timeout: the finite default, overridden by a per-server
+    ``call_timeout_seconds`` (float), with ``<= 0`` meaning opt-out (no timeout / ``None``).
+    A malformed value falls back to the default (fail-safe: keep a finite bound)."""
+    ct = config.get("call_timeout_seconds")
+    timeout: "float | None" = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
+    if ct is not None:
+        try:
+            timeout = float(ct)
+        except (TypeError, ValueError):
+            timeout = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
+    if timeout is not None and timeout <= 0:
+        return None  # explicit opt-out — no timeout
+    return timeout
+
 
 async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     from reyn.mcp.client import expand_env
@@ -69,15 +91,7 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             message=message,
         )
 
-    call_timeout = None
-    try:
-        ct = expanded.get("call_timeout_seconds")
-        if ct is not None:
-            call_timeout = float(ct)
-            if call_timeout <= 0:
-                call_timeout = None
-    except (TypeError, ValueError):
-        call_timeout = None
+    call_timeout = _resolve_call_timeout(expanded)
 
     ctx.events.emit("mcp_called", server=op.server, tool=op.tool, args=op.args)
     try:

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -17,7 +17,7 @@ from .context import OpContext
 
 async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     from reyn.mcp.client import expand_env
-    from reyn.mcp.pool import describe_fault, is_or_contains_cancel
+    from reyn.mcp.pool import describe_fault, is_or_contains_control_flow
 
     server_cfg = ctx.mcp_servers.get(op.server)
     if not server_cfg:
@@ -92,8 +92,8 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             timeout_seconds=call_timeout,
         )
     except BaseException as exc:  # noqa: BLE001 — fault isolation across ANY MCP fault (incl groups)
-        if is_or_contains_cancel(exc):
-            raise
+        if is_or_contains_control_flow(exc):
+            raise  # never contain CancelledError / KeyboardInterrupt / SystemExit
         # Owner req: feed the fault CONTENT back to the LLM (type + message, group members
         # aggregated) via the standard op-error result — so it can retry/adapt, not a silent error.
         fault = describe_fault(exc)

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -1,0 +1,110 @@
+"""MCPClientPool — per-turn structured owner of MCP clients (a359 P2).
+
+The a359 root cause: a cached ``MCPClient`` opened (initialized) lazily in whatever task ran an op,
+then closed by a separate teardown in a possibly-different task, exits the SDK stdio_client /
+ClientSession internal anyio task-group scopes cross-task → "cancel scope crossed task boundary"
+(Windows: BrokenResourceError / BaseExceptionGroup during subprocess teardown).
+
+The pool restores structured concurrency WHILE preserving subprocess reuse:
+- entered once per run/turn in the run-owning task (``async with pool:``);
+- ``get(server, cfg)`` opens the client (``MCPClient.__aenter__`` = initialize) IN THE POOL'S TASK
+  and caches it for the scope (reuse across ops), failing fast if called from a different task;
+- ``__aexit__`` closes every cached client in the pool's (owning) task — same task that opened them.
+
+Fault isolation (owner req): ``__aexit__`` contains teardown faults — including ``BaseExceptionGroup``
+from the SDK's internal task group — so a broken subprocess teardown cannot crash the run. It never
+swallows cancellation: a group containing ``CancelledError`` is re-raised.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from reyn.mcp.client import MCPClient
+
+logger = logging.getLogger(__name__)
+
+
+def describe_fault(exc: BaseException, *, limit: int = 600) -> str:
+    """Summarise a caught fault as ``Type: message`` for an LLM-facing error tool-result.
+
+    Owner req (a359 P2 fault-isolation): when an MCP call fails, the LLM must receive the fault
+    CONTENT (so it can retry / adapt / report) — not an empty/silent error. For a
+    ``BaseExceptionGroup`` (the SDK's internal task group surfaces faults this way), the member
+    exceptions are aggregated (type + message each) rather than dumping a raw traceback; the result
+    is truncated to ``limit`` chars. Generic — no MCP-specific vocabulary (P7-safe)."""
+    if isinstance(exc, BaseExceptionGroup):
+        parts = [f"{type(sub).__name__}: {sub}" for sub in exc.exceptions]
+        text = f"{type(exc).__name__}({exc.message}): " + " | ".join(parts)
+    else:
+        text = f"{type(exc).__name__}: {exc}"
+    return text if len(text) <= limit else text[:limit] + " …[truncated]"
+
+
+def is_or_contains_cancel(exc: BaseException) -> bool:
+    """True if ``exc`` is a CancelledError or a BaseExceptionGroup that contains one.
+
+    Fault-isolation must contain MCP transport/response faults but NEVER swallow cancellation — a
+    cancelled run must keep unwinding. The SDK's internal task group surfaces faults as a
+    ``BaseExceptionGroup``, which may mix a real transport error with a CancelledError; ``split``
+    detects the cancellation sub-group."""
+    if isinstance(exc, asyncio.CancelledError):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        cancels, _rest = exc.split(asyncio.CancelledError)
+        return cancels is not None
+    return False
+
+
+class MCPClientPool:
+    """Structured, task-affine cache of MCP clients for one run/turn.
+
+    Usage (in the run-owning task)::
+
+        async with MCPClientPool() as pool:
+            client = await pool.get("srv", cfg, agent_id=...)
+            await client.list_tools()
+        # every cached client is closed here, in this task
+    """
+
+    def __init__(self) -> None:
+        self._clients: dict[str, MCPClient] = {}
+        self._owner_task: "asyncio.Task | None" = None
+
+    async def __aenter__(self) -> "MCPClientPool":
+        self._owner_task = asyncio.current_task()
+        return self
+
+    @property
+    def owner_task(self) -> "asyncio.Task | None":
+        """The task that owns this pool (None outside the scope)."""
+        return self._owner_task
+
+    async def get(self, server: str, config: dict, *, agent_id: str | None = None) -> MCPClient:
+        """Return a cached client for ``server``, opening (and caching) it on first use IN THE
+        POOL'S TASK. Fails fast if called from a different task than the pool owner — opening a
+        client's SDK task-group scope off the owning task is the cross-task hazard this pool exists
+        to prevent (it would crash at ``__aexit__`` teardown instead of here, loudly)."""
+        if self._owner_task is not None and asyncio.current_task() is not self._owner_task:
+            raise RuntimeError(
+                "MCPClientPool.get called from a task other than the pool owner — opening an MCP "
+                "client off the owning task would leak an anyio cancel-scope across tasks. Run MCP "
+                "ops in the pool's owning task."
+            )
+        if server not in self._clients:
+            client = MCPClient(config, agent_id=agent_id)
+            await client.__aenter__()  # enter (initialize) in the pool's task
+            self._clients[server] = client
+        return self._clients[server]
+
+    async def __aexit__(self, *exc_info) -> None:
+        clients = list(self._clients.items())
+        self._clients.clear()
+        self._owner_task = None
+        for name, client in clients:
+            try:
+                await client.__aexit__(None, None, None)  # close in the pool's (owning) task
+            except BaseException as exc:  # noqa: BLE001 — fault isolation (see is_or_contains_cancel)
+                if is_or_contains_cancel(exc):
+                    raise
+                logger.warning("MCP client %s teardown fault contained: %r", name, exc)

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -41,18 +41,25 @@ def describe_fault(exc: BaseException, *, limit: int = 600) -> str:
     return text if len(text) <= limit else text[:limit] + " …[truncated]"
 
 
-def is_or_contains_cancel(exc: BaseException) -> bool:
-    """True if ``exc`` is a CancelledError or a BaseExceptionGroup that contains one.
+# Control-flow exceptions that fault-isolation must NEVER contain — they must keep propagating so a
+# cancelled / Ctrl-C'd / exiting process actually unwinds and shuts down.
+_CONTROL_FLOW: tuple[type[BaseException], ...] = (asyncio.CancelledError, KeyboardInterrupt, SystemExit)
 
-    Fault-isolation must contain MCP transport/response faults but NEVER swallow cancellation — a
-    cancelled run must keep unwinding. The SDK's internal task group surfaces faults as a
-    ``BaseExceptionGroup``, which may mix a real transport error with a CancelledError; ``split``
-    detects the cancellation sub-group."""
-    if isinstance(exc, asyncio.CancelledError):
+
+def is_or_contains_control_flow(exc: BaseException) -> bool:
+    """True if ``exc`` is (or a BaseExceptionGroup that contains) a control-flow exception —
+    ``CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit``.
+
+    Fault-isolation contains MCP transport/response faults (Exception + their groups) but must NEVER
+    swallow control flow: a cancelled run must keep unwinding, and Ctrl-C / process-exit must still
+    shut the process down. The SDK's internal task group surfaces faults as a ``BaseExceptionGroup``
+    that may MIX a real transport error with a control-flow exception; ``split`` detects the
+    control-flow sub-group (nested groups included)."""
+    if isinstance(exc, _CONTROL_FLOW):
         return True
     if isinstance(exc, BaseExceptionGroup):
-        cancels, _rest = exc.split(asyncio.CancelledError)
-        return cancels is not None
+        matched, _rest = exc.split(_CONTROL_FLOW)
+        return matched is not None
     return False
 
 
@@ -104,7 +111,7 @@ class MCPClientPool:
         for name, client in clients:
             try:
                 await client.__aexit__(None, None, None)  # close in the pool's (owning) task
-            except BaseException as exc:  # noqa: BLE001 — fault isolation (see is_or_contains_cancel)
-                if is_or_contains_cancel(exc):
+            except BaseException as exc:  # noqa: BLE001 — fault isolation (control flow re-raised)
+                if is_or_contains_control_flow(exc):
                     raise
                 logger.warning("MCP client %s teardown fault contained: %r", name, exc)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5888,22 +5888,14 @@ class Session:
             file_write=ctx.permission_decl.file_write,
             mcp=[server],
         )
-        try:
+        # #a359 P2: a per-call structured pool — the client opens (pool.get in the op handler) AND
+        # closes (pool __aexit__) in THIS task, and teardown faults (incl. BaseExceptionGroup) are
+        # contained. Replaces the manual finally-close over ``ctx.mcp_clients`` (which closed a
+        # client whose SDK task-group scope could have been entered lazily elsewhere).
+        from reyn.mcp.pool import MCPClientPool
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
             return await execute_op(op, ctx, caller="control_ir")
-        finally:
-            # Close every MCPClient that op_runtime/mcp.py cached on
-            # ``ctx.mcp_clients`` during this call. Failures are
-            # swallowed — best-effort; the op result is already
-            # captured at this point.
-            for client in list(ctx.mcp_clients.values()):
-                try:
-                    await client.close()
-                except Exception:  # noqa: BLE001 — best-effort teardown
-                    logger.debug(
-                        "mcp client close failed for chat router",
-                        exc_info=True,
-                    )
-            ctx.mcp_clients.clear()
 
     # --- RouterLoop orchestration ---
 

--- a/src/reyn/tools/invoke_skill.py
+++ b/src/reyn/tools/invoke_skill.py
@@ -196,7 +196,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
         mcp_servers={},
-        mcp_clients={},
         intervention_bus=getattr(phase_op_ctx, "intervention_bus", None),
         current_phase="",
         caller="direct",

--- a/src/reyn/tools/lint.py
+++ b/src/reyn/tools/lint.py
@@ -92,7 +92,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
         mcp_servers={},
-        mcp_clients={},
         intervention_bus=getattr(phase_op_ctx, "intervention_bus", None),
         current_phase="",
         caller="direct",

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -295,8 +295,13 @@ async def _handle_call_mcp_tool(
         else None
     )
     if _op_ctx is not None and isinstance(_op_ctx, OpContext):
-        legacy_ctx = _op_ctx
-    else:
+        # The phase's OpContext already carries the run's structured mcp_pool.
+        return await mcp_handle(op=op, ctx=_op_ctx, caller="control_ir")
+
+    # #a359 P2: direct (non-phase) call → a per-call structured pool, opened + closed in THIS task,
+    # so the mcp handler's client lifecycle stays task-affine (no cross-SDK-task teardown).
+    from reyn.mcp.pool import MCPClientPool
+    async with MCPClientPool() as pool:
         legacy_ctx = OpContext(
             workspace=ctx.workspace,
             events=ctx.events,
@@ -315,14 +320,13 @@ async def _handle_call_mcp_tool(
             sub_state_dir_override=None,
             state_dir_strategy="control_ir",
             mcp_servers={},
-            mcp_clients={},
+            mcp_pool=pool,
             intervention_bus=None,
             current_phase="",
             caller="direct",
             parent_skill_run_id=None,
         )
-
-    return await mcp_handle(op=op, ctx=legacy_ctx, caller="control_ir")
+        return await mcp_handle(op=op, ctx=legacy_ctx, caller="control_ir")
 
 
 # ── Private helpers ───────────────────────────────────────────────────────────

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -124,7 +124,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
         mcp_servers={},
-        mcp_clients={},
         intervention_bus=None,
         current_phase="",
         caller="direct",

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -99,7 +99,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         sub_state_dir_override=None,
         state_dir_strategy="control_ir",
         mcp_servers={},
-        mcp_clients={},
         intervention_bus=None,
         current_phase="",
         caller="direct",

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -301,85 +301,48 @@ def test_sse_not_implemented(patched_sdk):
     asyncio.run(_run_it())
 
 
-# ── G11 hypothesis A+B: teardown_mcp_clients invariants ──────────────────────
-# These two tests pin the same-task explicit-close path added to
-# ControlIRExecutor.teardown_mcp_clients() as the fix for G11.
-# They use real MCPClient instances (no MagicMock) to verify the public
-# is_initialized() surface — not private _stack/_session attributes.
+# ── a359 P2: MCPClientPool same-task close-all + reuse ───────────────────────
+# The pool replaces ControlIRExecutor.teardown_mcp_clients(): its __aexit__ closes every client
+# opened via get() in the pool's (run-owning) task. Real MCPClient (no MagicMock); verified via the
+# public is_initialized() surface. (Fault-containment incl. BaseExceptionGroup is pinned in the P2
+# acceptance test.)
 
 
-def test_teardown_mcp_clients_closes_all_clients(patched_sdk):
-    """Tier 2: OS invariant — teardown_mcp_clients() calls close() on every cached
-    MCP client (verified via is_initialized() == False on each client after teardown).
-
-    G11 fix: the explicit close must happen in the same asyncio task that
-    opened the clients so anyio cancel-scope task-affinity is honoured.
-    """
-    from reyn.core.events.events import EventLog
-    from reyn.core.kernel.control_ir_executor import ControlIRExecutor
-    from reyn.data.workspace.workspace import Workspace
+def test_pool_closes_all_clients_on_scope_exit(patched_sdk):
+    """Tier 2: MCPClientPool.__aexit__ closes every client opened via get() in the pool's owning
+    task — the a359 P2 replacement for teardown_mcp_clients (same-task close, robust-by-construction)."""
+    from reyn.mcp.pool import MCPClientPool
 
     cfg_a = {"type": "http", "url": "http://a/mcp"}
     cfg_b = {"type": "http", "url": "http://b/mcp"}
 
     async def _run_it():
-        events = EventLog()
-        ws = Workspace(events=events)
-        executor = ControlIRExecutor(workspace=ws, events=events)
-
-        # Populate _mcp_clients with two initialized clients (same task).
-        client_a = MCPClient(cfg_a)
-        await client_a.initialize()
-        client_b = MCPClient(cfg_b)
-        await client_b.initialize()
-        executor._mcp_clients["a"] = client_a
-        executor._mcp_clients["b"] = client_b
-
-        assert client_a.is_initialized() is True
-        assert client_b.is_initialized() is True
-
-        # teardown_mcp_clients must close both in the same task.
-        await executor.teardown_mcp_clients()
-
-        # Both clients must report as closed via the public accessor.
-        assert client_a.is_initialized() is False, "client_a should be closed after teardown"
-        assert client_b.is_initialized() is False, "client_b should be closed after teardown"
+        pool = MCPClientPool()
+        async with pool:
+            client_a = await pool.get("a", cfg_a)
+            client_b = await pool.get("b", cfg_b)
+            assert client_a.is_initialized() is True
+            assert client_b.is_initialized() is True
+        # after the scope exits, every client is closed (same task)
+        assert client_a.is_initialized() is False, "client_a closed on scope exit"
+        assert client_b.is_initialized() is False, "client_b closed on scope exit"
 
     asyncio.run(_run_it())
 
 
-def test_teardown_mcp_clients_empties_dict(patched_sdk):
-    """Tier 2: OS invariant — teardown_mcp_clients() clears _mcp_clients so
-    subsequent teardown calls are no-ops and the executor does not hold
-    stale references (prevents double-close on GC).
-
-    Verifies the dict is empty after teardown via the public-equivalent
-    available_ops() path (which does not depend on _mcp_clients contents),
-    plus a second teardown call that must not raise.
-    """
-    from reyn.core.events.events import EventLog
-    from reyn.core.kernel.control_ir_executor import ControlIRExecutor
-    from reyn.data.workspace.workspace import Workspace
+def test_pool_reuses_cached_client_within_scope(patched_sdk):
+    """Tier 2: a 2nd get() for the same server reuses the cached client (subprocess reuse preserved,
+    no re-spawn) — the whole reason the pool caches rather than opening per call."""
+    from reyn.mcp.pool import MCPClientPool
 
     cfg = {"type": "http", "url": "http://x/mcp"}
 
     async def _run_it():
-        events = EventLog()
-        ws = Workspace(events=events)
-        executor = ControlIRExecutor(workspace=ws, events=events)
+        async with MCPClientPool() as pool:
+            c1 = await pool.get("x", cfg)
+            c2 = await pool.get("x", cfg)
+            assert c1 is c2, "same cached client reused within the scope"
 
-        client = MCPClient(cfg)
-        await client.initialize()
-        executor._mcp_clients["x"] = client
-
-        await executor.teardown_mcp_clients()
-
-        # The dict must be empty — no stale refs that could be GC-finalised
-        # cross-task after this point.
-        assert not executor.mcp_clients, "_mcp_clients must be empty after teardown"
-
-        # Second call is a no-op (nothing to close, no exception).
-        await executor.teardown_mcp_clients()
-        assert not executor.mcp_clients
+    asyncio.run(_run_it())
 
     asyncio.run(_run_it())

--- a/tests/test_mcp_multimodal_forwarding.py
+++ b/tests/test_mcp_multimodal_forwarding.py
@@ -56,8 +56,29 @@ def _make_ctx(tmp_path, mcp_client: _FakeMCPClient) -> Any:
         permission_decl=PermissionDecl(),
         permission_resolver=None,  # bypass permission gate
         mcp_servers={"testsrv": {"type": "stdio", "command": "fake"}},
-        mcp_clients={"testsrv": mcp_client},  # type: ignore[dict-item]
+        mcp_pool=_StubPool(mcp_client),  # #a359 P2: pool returns the pre-set fake
     )
+
+
+class _StubPool:
+    """Test double for MCPClientPool — ``get`` returns a pre-set client (no real subprocess). A real
+    Fake (not a mock): implements the pool contract the op handler calls."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    @property
+    def owner_task(self):
+        return None
+
+    async def get(self, server, config, *, agent_id=None):
+        return self._client
 
 
 def test_op_result_preserves_image_blocks(tmp_path, monkeypatch):

--- a/tests/test_mcp_offload_raw_2336.py
+++ b/tests/test_mcp_offload_raw_2336.py
@@ -23,6 +23,16 @@ from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES as CAP
 from reyn.core.context_builder import _oversized_fields, offload_control_ir_result
 from reyn.services.offload.store import read_offloaded
 
+
+class _StubPool:
+    """Test double for MCPClientPool — get() returns a pre-set client (a359 P2). Real Fake."""
+    def __init__(self, client): self._client = client
+    async def __aenter__(self): return self
+    async def __aexit__(self, *e): return None
+    @property
+    def owner_task(self): return None
+    async def get(self, server, config, *, agent_id=None): return self._client
+
 # A multi-line text payload well over the per-field offload threshold — mirrors a big MCP tool dump.
 _BIG_TEXT = "\n".join(f"row {i}: " + "d" * 80 for i in range((CAP // 40) + 200))
 
@@ -53,7 +63,7 @@ def _make_ctx(tmp_path: Path, mcp_client: _FakeMCPClient) -> Any:
         permission_decl=PermissionDecl(),
         permission_resolver=None,  # bypass permission gate
         mcp_servers={"testsrv": {"type": "stdio", "command": "fake"}},
-        mcp_clients={"testsrv": mcp_client},  # type: ignore[dict-item]
+        mcp_pool=_StubPool(mcp_client),  # #a359 P2
     )
 
 

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -289,23 +289,22 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
     assert read_to == timedelta(seconds=7.5)
 
 
-def test_op_handler_treats_missing_or_invalid_call_timeout_as_unset() -> None:
-    """Tier 2: when the config omits ``call_timeout_seconds`` OR sets it
-    to a non-positive / non-numeric value, the op handler forwards
-    ``timeout_seconds=None`` so the SDK default applies.
-
-    Pinning the defensive handling here avoids surprising fail-fasts
-    from typos like ``call_timeout_seconds: -1`` or ``"slow"``.
+def test_op_handler_call_timeout_default_finite_and_optout() -> None:
+    """Tier 2: #a359 S3 — a hung server must not block reyn, so the op handler forwards a FINITE
+    default ``read_timeout_seconds`` when the config omits ``call_timeout_seconds`` (or sets a
+    malformed value → fail-safe default). ONLY an explicit opt-out (``<= 0``) forwards no timeout
+    (SDK default / unbounded). (Was: missing/invalid → unset, which let tui's slow_response=30s hang.)
     """
     from reyn.core.op_runtime import mcp as mcp_op_handler
 
-    cases: list[dict[str, Any]] = [
-        {"type": "stdio", "command": "/bin/true"},  # missing key
-        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 0},
-        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": -1},
-        {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": "slow"},
+    # (cfg, expect_timeout_forwarded): opt-out (<=0) → no read_timeout_seconds; else finite default.
+    cases: list[tuple[dict[str, Any], bool]] = [
+        ({"type": "stdio", "command": "/bin/true"}, True),                              # missing → default
+        ({"type": "stdio", "command": "/bin/true", "call_timeout_seconds": "slow"}, True),  # invalid → fail-safe default
+        ({"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 0}, False),  # explicit opt-out
+        ({"type": "stdio", "command": "/bin/true", "call_timeout_seconds": -1}, False),  # explicit opt-out
     ]
-    for cfg in cases:
+    for cfg, expect_forwarded in cases:
         captured: dict[str, Any] = {}
 
         class _FakeResult:
@@ -341,11 +340,16 @@ def test_op_handler_treats_missing_or_invalid_call_timeout_as_unset() -> None:
         op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
         asyncio.run(mcp_op_handler._execute(op, ctx))
 
-        # SDK was called with no read_timeout_seconds → default applies.
-        assert "read_timeout_seconds" not in captured["kwargs"], (
-            f"cfg {cfg!r} should NOT yield read_timeout_seconds (= unset → SDK default), "
-            f"got kwargs={captured['kwargs']}"
-        )
+        if expect_forwarded:
+            assert "read_timeout_seconds" in captured["kwargs"], (
+                f"cfg {cfg!r} should forward a FINITE default read_timeout_seconds (hung-server "
+                f"guard), got kwargs={captured['kwargs']}"
+            )
+        else:
+            assert "read_timeout_seconds" not in captured["kwargs"], (
+                f"cfg {cfg!r} is an explicit opt-out (<=0) → NO read_timeout_seconds, "
+                f"got kwargs={captured['kwargs']}"
+            )
 
 
 # ── 3. ChatEventForwarder.on_mcp_progress turns events into outbox msgs ─

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -39,6 +39,16 @@ from reyn.runtime.forwarder import ChatEventForwarder
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import MCPIROp
 
+
+class _StubPool:
+    """Test double for MCPClientPool — get() returns a pre-set client (a359 P2). Real Fake."""
+    def __init__(self, client): self._client = client
+    async def __aenter__(self): return self
+    async def __aexit__(self, *e): return None
+    @property
+    def owner_task(self): return None
+    async def get(self, server, config, *, agent_id=None): return self._client
+
 # ── 1. MCPClient.call_tool signature accepts the new kwargs ────────────
 
 
@@ -192,13 +202,12 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
         permission_decl=PermissionDecl(),
         permission_resolver=None,
         mcp_servers={"demo": {"type": "stdio", "command": "/bin/true"}},
-        mcp_clients={},
     )
     # Pre-install a fake client so MCPClient construction is skipped.
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
     client._initialized = True
     client._session = _CapturingSession()
-    ctx.mcp_clients["demo"] = client
+    ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
@@ -264,14 +273,13 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
                 "call_timeout_seconds": 7.5,
             },
         },
-        mcp_clients={},
     )
     client = MCPClient(
         {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 7.5},
     )
     client._initialized = True
     client._session = _CapturingSession()
-    ctx.mcp_clients["demo"] = client
+    ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
@@ -324,12 +332,11 @@ def test_op_handler_treats_missing_or_invalid_call_timeout_as_unset() -> None:
             permission_decl=PermissionDecl(),
             permission_resolver=None,
             mcp_servers={"demo": cfg},
-            mcp_clients={},
-        )
+            )
         client = MCPClient(cfg)
         client._initialized = True
         client._session = _CapturingSession()
-        ctx.mcp_clients["demo"] = client
+        ctx.mcp_pool = _StubPool(client)
 
         op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
         asyncio.run(mcp_op_handler._execute(op, ctx))

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -17,6 +17,21 @@ import reyn.mcp.pool as pool_mod
 from reyn.mcp.pool import MCPClientPool, describe_fault, is_or_contains_control_flow
 
 
+def test_call_timeout_default_finite_override_optout():
+    """Tier 2: S3 (tui dogfood gap) — the per-call MCP timeout defaults FINITE so a hung/slow server
+    can't block the router loop forever; a per-server ``call_timeout_seconds`` overrides; ``<= 0``
+    opts out (None). When the timeout fires, the SDK raises a TimeoutError which the op fault
+    boundary already contains into an error result (→ LLM). Malformed → fail-safe finite default."""
+    from reyn.core.op_runtime.mcp import _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, _resolve_call_timeout
+
+    assert _resolve_call_timeout({}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, "finite default (not None)"
+    assert _resolve_call_timeout({"call_timeout_seconds": 5}) == 5.0, "per-server override"
+    assert _resolve_call_timeout({"call_timeout_seconds": 0}) is None, "0 opts out"
+    assert _resolve_call_timeout({"call_timeout_seconds": -1}) is None, "<0 opts out"
+    assert _resolve_call_timeout({"call_timeout_seconds": "x"}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, \
+        "malformed → fail-safe finite default"
+
+
 def test_describe_fault_aggregates_group_members():
     """Tier 2: describe_fault summarises a group's members (type+message) for the LLM — not empty,
     not a raw traceback (owner req: the LLM must see WHAT failed)."""

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -14,7 +14,7 @@ import asyncio
 import pytest
 
 import reyn.mcp.pool as pool_mod
-from reyn.mcp.pool import MCPClientPool, describe_fault, is_or_contains_cancel
+from reyn.mcp.pool import MCPClientPool, describe_fault, is_or_contains_control_flow
 
 
 def test_describe_fault_aggregates_group_members():
@@ -26,28 +26,37 @@ def test_describe_fault_aggregates_group_members():
     assert "RuntimeError" in text and "ValueError" in text
 
 
-# ── is_or_contains_cancel (the cancellation-safe boundary predicate) ─────────────
+# ── is_or_contains_control_flow (the cancellation-safe boundary predicate) ─────────────
 
 def test_cancel_predicate_direct():
     """Tier 2: a bare CancelledError is a cancellation."""
-    assert is_or_contains_cancel(asyncio.CancelledError()) is True
+    assert is_or_contains_control_flow(asyncio.CancelledError()) is True
 
 
 def test_cancel_predicate_group_with_cancel():
     """Tier 2: a BaseExceptionGroup containing a CancelledError counts (must be re-raised)."""
     grp = BaseExceptionGroup("teardown", [asyncio.CancelledError(), RuntimeError("BrokenResource")])
-    assert is_or_contains_cancel(grp) is True
+    assert is_or_contains_control_flow(grp) is True
 
 
 def test_cancel_predicate_group_without_cancel():
     """Tier 2: a group of ordinary faults is NOT a cancellation → containable."""
     grp = ExceptionGroup("teardown", [RuntimeError("BrokenResource"), ValueError("bad response")])
-    assert is_or_contains_cancel(grp) is False
+    assert is_or_contains_control_flow(grp) is False
 
 
 def test_cancel_predicate_plain_exception():
-    """Tier 2: a plain non-cancel exception is containable (not a cancellation)."""
-    assert is_or_contains_cancel(RuntimeError("t")) is False
+    """Tier 2: a plain non-control-flow exception is containable."""
+    assert is_or_contains_control_flow(RuntimeError("t")) is False
+
+
+@pytest.mark.parametrize("exc_cls", [KeyboardInterrupt, SystemExit])
+def test_control_flow_predicate_keyboardinterrupt_systemexit(exc_cls):
+    """Tier 2: KeyboardInterrupt / SystemExit are control flow — bare AND group-nested (mixed with a
+    transport error) — so a Ctrl-C / process-exit during an MCP call or teardown still shuts down."""
+    assert is_or_contains_control_flow(exc_cls()) is True
+    grp = BaseExceptionGroup("teardown", [RuntimeError("BrokenResource"), exc_cls()])
+    assert is_or_contains_control_flow(grp) is True
 
 
 # ── pool teardown fault-containment ──────────────────────────────────────────────
@@ -92,7 +101,7 @@ async def test_pool_reraises_cancellation_in_teardown(monkeypatch):
     with pytest.raises(BaseException) as ei:
         async with MCPClientPool() as pool:
             await pool.get("srv", {"type": "stdio", "command": "x"})
-    assert is_or_contains_cancel(ei.value), "cancellation propagates, not contained"
+    assert is_or_contains_control_flow(ei.value), "cancellation propagates, not contained"
 
 
 # ── op-handler fault isolation (bad response / transport group → error result) ────
@@ -154,10 +163,26 @@ async def test_op_contains_bad_response_exception_group():
 
 
 @pytest.mark.asyncio
-async def test_op_propagates_cancellation():
-    """Tier 2: the op handler never swallows cancellation."""
+@pytest.mark.parametrize("exc_cls", [asyncio.CancelledError, KeyboardInterrupt, SystemExit])
+async def test_op_propagates_control_flow(exc_cls):
+    """Tier 2: the op handler never contains control flow — CancelledError / KeyboardInterrupt /
+    SystemExit propagate (a cancelled / interrupted / exiting run must keep unwinding), even though
+    ANY ordinary MCP fault is contained into an error result."""
     from reyn.core.op_runtime.mcp import _execute
     from reyn.schemas.models import MCPIROp
 
-    with pytest.raises(asyncio.CancelledError):
-        await _execute(MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(asyncio.CancelledError())))
+    with pytest.raises(exc_cls):
+        await _execute(MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(exc_cls())))
+
+
+@pytest.mark.asyncio
+async def test_pool_reraises_keyboardinterrupt_in_teardown(monkeypatch):
+    """Tier 2: the pool re-raises a KeyboardInterrupt-containing teardown group (control flow is
+    never contained) — the required refinement beyond cancellation."""
+    raising = _RaisingCloseClient(BaseExceptionGroup("teardown", [KeyboardInterrupt()]))
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+
+    with pytest.raises(BaseException) as ei:
+        async with MCPClientPool() as pool:
+            await pool.get("srv", {"type": "stdio", "command": "x"})
+    assert is_or_contains_control_flow(ei.value), "KeyboardInterrupt propagates, not contained"

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -1,0 +1,163 @@
+"""Tier 2: a359 P2 — structured MCPClientPool + fault-isolation boundary.
+
+The pool opens + reuses clients in the run-owning task and closes them there on scope exit
+(structural teardown). Fault isolation (owner req): teardown faults — including a
+``BaseExceptionGroup`` from the SDK's internal task group — are CONTAINED so a broken subprocess
+teardown can't crash the run; and the op handler turns ANY MCP call fault (bad response / transport
+group / server death) into an error tool-result so MCP misbehavior never crashes the router loop.
+Neither ever swallows cancellation. Real pool + real op handler; injected raising client (no mock).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import reyn.mcp.pool as pool_mod
+from reyn.mcp.pool import MCPClientPool, describe_fault, is_or_contains_cancel
+
+
+def test_describe_fault_aggregates_group_members():
+    """Tier 2: describe_fault summarises a group's members (type+message) for the LLM — not empty,
+    not a raw traceback (owner req: the LLM must see WHAT failed)."""
+    grp = ExceptionGroup("teardown", [RuntimeError("malformed response"), ValueError("reset")])
+    text = describe_fault(grp)
+    assert "malformed response" in text and "reset" in text
+    assert "RuntimeError" in text and "ValueError" in text
+
+
+# ── is_or_contains_cancel (the cancellation-safe boundary predicate) ─────────────
+
+def test_cancel_predicate_direct():
+    """Tier 2: a bare CancelledError is a cancellation."""
+    assert is_or_contains_cancel(asyncio.CancelledError()) is True
+
+
+def test_cancel_predicate_group_with_cancel():
+    """Tier 2: a BaseExceptionGroup containing a CancelledError counts (must be re-raised)."""
+    grp = BaseExceptionGroup("teardown", [asyncio.CancelledError(), RuntimeError("BrokenResource")])
+    assert is_or_contains_cancel(grp) is True
+
+
+def test_cancel_predicate_group_without_cancel():
+    """Tier 2: a group of ordinary faults is NOT a cancellation → containable."""
+    grp = ExceptionGroup("teardown", [RuntimeError("BrokenResource"), ValueError("bad response")])
+    assert is_or_contains_cancel(grp) is False
+
+
+def test_cancel_predicate_plain_exception():
+    """Tier 2: a plain non-cancel exception is containable (not a cancellation)."""
+    assert is_or_contains_cancel(RuntimeError("t")) is False
+
+
+# ── pool teardown fault-containment ──────────────────────────────────────────────
+
+class _RaisingCloseClient:
+    """A client whose close (``__aexit__``) raises — models the SDK teardown fault."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        self.closed = True
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_pool_contains_teardown_exception_group(monkeypatch):
+    """Tier 2: CORE fault-isolation — a client whose teardown raises a transport BaseExceptionGroup
+    is CONTAINED by the pool's __aexit__ (the run survives), not propagated as an uncontained crash."""
+    raising = _RaisingCloseClient(
+        BaseExceptionGroup("teardown", [RuntimeError("BrokenResourceError"), RuntimeError("ConnectionReset")])
+    )
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+
+    async with MCPClientPool() as pool:
+        await pool.get("srv", {"type": "stdio", "command": "x"})
+    # reached here → the teardown group was contained (no crash out of the scope)
+    assert raising.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pool_reraises_cancellation_in_teardown(monkeypatch):
+    """Tier 2: the pool NEVER swallows cancellation — a teardown group containing a CancelledError
+    is re-raised so a cancelled run keeps unwinding."""
+    raising = _RaisingCloseClient(BaseExceptionGroup("teardown", [asyncio.CancelledError()]))
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+
+    with pytest.raises(BaseException) as ei:
+        async with MCPClientPool() as pool:
+            await pool.get("srv", {"type": "stdio", "command": "x"})
+    assert is_or_contains_cancel(ei.value), "cancellation propagates, not contained"
+
+
+# ── op-handler fault isolation (bad response / transport group → error result) ────
+
+class _FaultPool:
+    """A pool whose get() returns a client whose call_tool raises ``exc`` — to exercise the op
+    handler's fault boundary."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *e):
+        return None
+
+    @property
+    def owner_task(self):
+        return None
+
+    async def get(self, server, config, *, agent_id=None):
+        exc = self._exc
+
+        class _C:
+            async def call_tool(self, name, args, *, progress_callback=None, timeout_seconds=None):
+                raise exc
+        return _C()
+
+
+def _ctx(pool):
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.security.permissions.permissions import PermissionDecl
+    events = EventLog()
+    return OpContext(
+        workspace=Workspace(events=events), events=events,
+        permission_decl=PermissionDecl(), permission_resolver=None,
+        mcp_servers={"srv": {"type": "stdio", "command": "x"}}, mcp_pool=pool,
+    )
+
+
+@pytest.mark.asyncio
+async def test_op_contains_bad_response_exception_group():
+    """Tier 2: a transport/bad-response BaseExceptionGroup from call_tool → a contained error
+    tool-result (owner req: MCP misbehavior must not crash the loop). RED if the boundary only
+    caught `except Exception` (a BaseExceptionGroup would escape uncontained)."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    grp = BaseExceptionGroup("bad", [RuntimeError("malformed response"), RuntimeError("reset")])
+    result = await _execute(MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(grp)))
+    assert result["status"] == "error", "MCP fault surfaced as an error result, not a crash"
+    assert result["kind"] == "mcp"
+    # owner req: the fault CONTENT reaches the LLM (non-empty; group members aggregated)
+    assert result["error"], "error content is non-empty (fed to the LLM)"
+    assert "malformed response" in result["error"] and "reset" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_op_propagates_cancellation():
+    """Tier 2: the op handler never swallows cancellation."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    with pytest.raises(asyncio.CancelledError):
+        await _execute(MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(asyncio.CancelledError())))


### PR DESCRIPTION
**[e2e-coder]** — a359 P2 (P1 = MCPClient async-CM #2405; P3 = owner-Windows diagnostic). Off P1-merged main. **Absorbs the closed #2403** — its reyn-task run-scope idea, now with the clients themselves structured in the pool's task (the piece #2403 alone missed).

## What
- **`MCPClientPool`** (`reyn/mcp/pool.py`): entered once per run in the run-owning task; `get(server, cfg)` opens (`MCPClient.__aenter__`) + caches the client **in the pool's task** (subprocess reuse preserved), failing fast if called off the owning task; `__aexit__` closes every client in that task. Replaces the raw `ctx.mcp_clients` dict + `ControlIRExecutor.teardown_mcp_clients()` (removed) + chat `_mcp_call_tool`'s finally-close + `tools/mcp.py`'s legacy construct.
- **Fault isolation (owner req):** teardown faults incl. `BaseExceptionGroup` are CONTAINED in `__aexit__` (never swallowing cancellation — `is_or_contains_cancel`); the op handler turns ANY MCP call fault (bad response / transport group / server death) into a contained error tool-result AND **feeds the fault CONTENT back to the LLM** (`describe_fault` aggregates group members: type+message, truncated) so it can retry/adapt. **LLM-facing paths only** (chat `_mcp_call_tool`, op `call_mcp_tool`); probe/UI paths unchanged (empty on fault).
- **Wiring:** `OpContext.mcp_clients` → `mcp_pool`; `runtime.py` wraps `RunOrchestrator.run` in the pool (`async with`); `run()` asserts the scope is active (fail-fast on bypass); ~6 non-MCP construction sites drop the `mcp_clients={}` kwarg. **P7-safe:** OS-level keys only (`status`/`data`/`error`), no MCP literal in OS code.

## Falsify (RED-verified; real pool + real op handler + injected raising client, no mock)
- `is_or_contains_cancel`: direct / group-with-cancel / group-without / plain.
- pool: closes-all-same-task (`test_mcp_client`), reuses cached client, **contains a teardown `BaseExceptionGroup`**, **re-raises a cancel-containing group**.
- op handler: a bad-response `BaseExceptionGroup` → **error result WITH the fault content** (owner req: LLM sees what failed), cancellation propagates.
- `describe_fault` aggregates group members.
- **RED**: narrowing the op `except` (so the group escapes) fails the contain-test.

## Test migration (the `ctx.mcp_clients` contract change)
The op-handler tests (progress/timeout, multimodal, offload_raw) migrated their fake injection to a small real `_StubPool` (Fake, not mock); the G11 `teardown_mcp_clients` tests were replaced with pool `__aexit__` tests (same intent, new mechanism).

## CI gates
- ruff clean · tier-audit OK · docstrings clean · 776 mcp/kernel tests pass · full suite running.

## Test plan
- [x] pool + fault-isolation + fault-content acceptance, RED-verified
- [x] op-handler contract-migration tests + G11→pool tests
- [ ] full suite green (running)

part of the MCP task-affinity arc (a359) · P2 of 3 · absorbs #2403

🤖 Generated with [Claude Code](https://claude.com/claude-code)