### PR TITLE
chore(mcp): a359 P3 — TEMPORARY Windows-verification diagnostic + procedure

### DIFF
--- a/docs/dev/mcp-a359-windows-verification.md
+++ b/docs/dev/mcp-a359-windows-verification.md
@@ -55,6 +55,8 @@ a359-diag: closed MCP client server=<s> open_task=<T> close_task=<T> outcome=ok
   (owner req), not a crash.
 
 ## After confirmation
+<!-- TODO(a359-cleanup): remove this doc + the a359-DIAG block + the P3 diag test after owner
+confirms the Windows crash is gone. `grep -rn "a359-cleanup"` finds every removal point. -->
 Post the harness output + the `a359-diag` lines on the arc issue. Then the follow-up PR removes:
 - the `a359-DIAG` block + the `_diag_log` / `_open_tasks` / `_task_name` diagnostics in
   `src/reyn/mcp/pool.py`, and

--- a/docs/dev/mcp-a359-windows-verification.md
+++ b/docs/dev/mcp-a359-windows-verification.md
@@ -1,0 +1,63 @@
+# a359 — MCP task-affinity crash: Windows verification (P3)
+
+**Status: TEMPORARY diagnostic phase.** This doc + the `reyn.mcp.a359diag` logging in
+`src/reyn/mcp/pool.py` exist ONLY to confirm, on the owner's Windows environment, that the
+`BaseExceptionGroup` / `BrokenResourceError` / `ConnectionReset` crash on `list_mcp_tools` (and MCP
+tool calls) is gone after the structured-client fix (P1 #2405 + P2 #2406). **Once confirmed, a
+follow-up PR removes this doc + the `a359-DIAG` logging block** (owner asked for its removal on
+resolution).
+
+## Why Windows-only
+The root cause (a359) is `MCPClient`'s deferred `AsyncExitStack` closing the SDK `stdio_client` /
+`ClientSession` internal anyio task-group scopes **cross-task**. On Unix (`SelectorEventLoop`) the
+cross-task teardown is *tolerated* — every repro scenario SURVIVES, so the crash **cannot be
+RED-verified on Unix**. It manifests only on the Windows `ProactorEventLoop` (subprocess/job-object
+teardown ordering). Hence the fix's *sufficiency* must be shown on Windows.
+
+## Procedure 1 — the repro harness (fastest signal)
+On Windows, from the repo root, on the fixed `main`:
+
+```
+python scripts/mcp_stdio_repro.py
+```
+
+It prints the platform + event loop (expect `platform=win32 loop=ProactorEventLoop`), then runs each
+lifecycle scenario and reports `SURVIVED` or `CRASHED` + any owner-keyword match
+(`BaseExceptionGroup` / `cancel scope` / `BrokenResource` / `ConnectionReset` / ...).
+
+- **Expected on the FIXED code:** every scenario `SURVIVED`, no owner-keyword match — including
+  `cross_task_close` and `no_close_gc_teardown` (the ones most likely to CRASH on Proactor with the
+  pre-fix lifecycle).
+- **To see the contrast** (optional): run the same harness on a pre-fix commit (before #2405) — the
+  `cross_task_close` / `no_close_gc_teardown` arms should `CRASHED` with an owner-keyword match on
+  Proactor. That contrast is the RED→GREEN evidence Unix can't provide.
+
+## Procedure 2 — the real crash path (`list_mcp_tools`) with diagnostic logging
+Reproduce the owner's original crash path with an MCP server configured, capturing the temporary
+`reyn.mcp.a359diag` logger at INFO (add to logging config, or set the logger level):
+
+```python
+import logging
+logging.getLogger("reyn.mcp.a359diag").setLevel(logging.INFO)
+```
+
+Then run the interactive `list_mcp_tools` (and a tool call). The diagnostic emits, per client:
+
+```
+a359-diag: opened MCP client server=<s> open_task=<T>
+a359-diag: closed MCP client server=<s> open_task=<T> close_task=<T> outcome=ok
+```
+
+- **Expected on the FIXED code:** `open_task == close_task` and `outcome=ok` for every client, and
+  **no** `BaseExceptionGroup` / `BrokenResourceError` crash surfaces to the user.
+- If a transport fault occurs, the line reads `teardown-fault=<repr>` and it is **contained** (logged,
+  not crashing the loop) — and an MCP tool call fault surfaces to the LLM as a contained error result
+  (owner req), not a crash.
+
+## After confirmation
+Post the harness output + the `a359-diag` lines on the arc issue. Then the follow-up PR removes:
+- the `a359-DIAG` block + the `_diag_log` / `_open_tasks` / `_task_name` diagnostics in
+  `src/reyn/mcp/pool.py`, and
+- this doc.
+
+The structured pool + fault-isolation (P1/P2) stay — only the temporary instrumentation is removed.

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -24,6 +24,22 @@ from reyn.mcp.client import MCPClient
 
 logger = logging.getLogger(__name__)
 
+# ─────────────────────────────────────────────────────────────────────────────
+# a359-DIAG — TEMPORARY Windows-verification instrumentation. Owner-authorised to
+# confirm the BaseExceptionGroup / BrokenResourceError / ConnectionReset crash is
+# GONE on the Proactor event loop (the crash cannot be RED-verified on Unix — it
+# tolerates the cross-task teardown). REMOVE this diagnostic block in the
+# follow-up once owner confirms the crash is gone. Emits at INFO on the
+# "reyn.mcp.a359diag" logger so owner can capture it with the list_mcp_tools
+# repro without turning on all-DEBUG. See docs/dev/mcp-a359-windows-verification.md.
+_diag_log = logging.getLogger("reyn.mcp.a359diag")
+
+
+def _task_name() -> str:
+    t = asyncio.current_task()
+    return getattr(t, "get_name", lambda: repr(t))() if t is not None else "<no-task>"
+# ─────────────────────────────────────────────────────────────────────────────
+
 
 def describe_fault(exc: BaseException, *, limit: int = 600) -> str:
     """Summarise a caught fault as ``Type: message`` for an LLM-facing error tool-result.
@@ -77,6 +93,7 @@ class MCPClientPool:
     def __init__(self) -> None:
         self._clients: dict[str, MCPClient] = {}
         self._owner_task: "asyncio.Task | None" = None
+        self._open_tasks: dict[str, str] = {}  # a359-DIAG (TEMPORARY): server → open-task name
 
     async def __aenter__(self) -> "MCPClientPool":
         self._owner_task = asyncio.current_task()
@@ -102,16 +119,33 @@ class MCPClientPool:
             client = MCPClient(config, agent_id=agent_id)
             await client.__aenter__()  # enter (initialize) in the pool's task
             self._clients[server] = client
+            # a359-DIAG (TEMPORARY): record + log the OPEN task, so the Windows repro shows the
+            # client was opened and (below) closed in the SAME task.
+            self._open_tasks[server] = _task_name()
+            _diag_log.info("a359-diag: opened MCP client server=%s open_task=%s", server, self._open_tasks[server])
         return self._clients[server]
 
     async def __aexit__(self, *exc_info) -> None:
         clients = list(self._clients.items())
         self._clients.clear()
         self._owner_task = None
+        open_tasks = self._open_tasks  # a359-DIAG (TEMPORARY)
+        self._open_tasks = {}          # a359-DIAG (TEMPORARY)
         for name, client in clients:
+            # a359-DIAG (TEMPORARY): log the close task vs the recorded open task — on Windows the
+            # owner's repro should show open_task == close_task and outcome=ok (no BaseExceptionGroup).
+            _close_task = _task_name()
             try:
                 await client.__aexit__(None, None, None)  # close in the pool's (owning) task
+                _diag_log.info(
+                    "a359-diag: closed MCP client server=%s open_task=%s close_task=%s outcome=ok",
+                    name, open_tasks.get(name), _close_task,
+                )
             except BaseException as exc:  # noqa: BLE001 — fault isolation (control flow re-raised)
+                _diag_log.info(
+                    "a359-diag: MCP client server=%s open_task=%s close_task=%s teardown-fault=%r",
+                    name, open_tasks.get(name), _close_task, exc,
+                )
                 if is_or_contains_control_flow(exc):
                     raise
                 logger.warning("MCP client %s teardown fault contained: %r", name, exc)

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -25,6 +25,8 @@ from reyn.mcp.client import MCPClient
 logger = logging.getLogger(__name__)
 
 # ─────────────────────────────────────────────────────────────────────────────
+# TODO(a359-cleanup): remove this a359-DIAG block after owner confirms the Windows crash is gone.
+#   grep -rn "a359-cleanup" to find every removal point (this block, the P3 test, the doc).
 # a359-DIAG — TEMPORARY Windows-verification instrumentation. Owner-authorised to
 # confirm the BaseExceptionGroup / BrokenResourceError / ConnectionReset crash is
 # GONE on the Proactor event loop (the crash cannot be RED-verified on Unix — it

--- a/tests/test_mcp_a359_diag_p3.py
+++ b/tests/test_mcp_a359_diag_p3.py
@@ -1,0 +1,38 @@
+"""Tier 2: a359 P3 — the TEMPORARY Windows-verification diagnostic emits correctly.
+
+The owner's Windows run relies on the ``reyn.mcp.a359diag`` INFO lines to confirm each MCP client is
+opened AND closed in the SAME task with ``outcome=ok`` (no BaseExceptionGroup). This pins that the
+instrumentation actually emits those lines on a normal pool cycle, so owner gets a real signal (a
+silently-broken diagnostic would give false confidence). REMOVED in the follow-up together with the
+a359-DIAG block (see docs/dev/mcp-a359-windows-verification.md).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import reyn.mcp.pool as pool_mod
+from reyn.mcp.pool import MCPClientPool
+
+
+class _OKClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_a359_diag_emits_open_and_close_same_task(monkeypatch, caplog):
+    """Tier 2: a normal pool cycle emits the a359-diag open + close lines, with the same open/close
+    task and outcome=ok — the signal owner reads on Windows to confirm the fix."""
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: _OKClient())
+    with caplog.at_level(logging.INFO, logger="reyn.mcp.a359diag"):
+        async with MCPClientPool() as pool:
+            await pool.get("srv", {"type": "stdio", "command": "x"})
+
+    text = "\n".join(r.getMessage() for r in caplog.records if r.name == "reyn.mcp.a359diag")
+    assert "opened MCP client server=srv" in text, "open diagnostic emitted"
+    assert "closed MCP client server=srv" in text and "outcome=ok" in text, "close diagnostic emitted"

--- a/tests/test_mcp_a359_diag_p3.py
+++ b/tests/test_mcp_a359_diag_p3.py
@@ -5,6 +5,9 @@ opened AND closed in the SAME task with ``outcome=ok`` (no BaseExceptionGroup). 
 instrumentation actually emits those lines on a normal pool cycle, so owner gets a real signal (a
 silently-broken diagnostic would give false confidence). REMOVED in the follow-up together with the
 a359-DIAG block (see docs/dev/mcp-a359-windows-verification.md).
+
+TODO(a359-cleanup): remove this test with the a359-DIAG block once owner confirms the Windows crash
+is gone. ``grep -rn "a359-cleanup"`` finds every removal point.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — final stage of the a359 MCP task-affinity arc. P1 (#2405 MCPClient async-CM) + P2 (#2406 structured pool + fault-isolation) are **the fix**; P3 is the **owner-Windows sufficiency check**, since the crash manifests only on the Proactor event loop (Unix tolerates the cross-task teardown → the crash can't be RED-verified here).

## ⚠️ TEMPORARY — removed on resolution
Owner authorized this diagnostic **and asked for its removal once the Windows crash is confirmed gone**. A follow-up PR removes the `a359-DIAG` block + the doc + the diag test (the structured pool + fault-isolation stay). Flagging so it's not mistaken for permanent instrumentation.

## What
- **`reyn/mcp/pool.py`** — an `a359-DIAG` block logs (`reyn.mcp.a359diag`, INFO) each MCP client's **open task** + **close task** + outcome, so the owner's `list_mcp_tools` repro shows `open_task == close_task`, `outcome=ok`, and **no `BaseExceptionGroup`**. Heavily tagged for removal.
- **`docs/dev/mcp-a359-windows-verification.md`** — the Windows procedure: run `scripts/mcp_stdio_repro.py` (expect every scenario `SURVIVED` on `ProactorEventLoop`, incl. `cross_task_close`/`no_close_gc` — CRASHED pre-fix), + the real `list_mcp_tools` path with the diagnostic.
- **test** that the diagnostic actually emits (owner relies on it — a silently-broken diag = false confidence).

## Acceptance (Unix — necessary, NOT sufficient)
- `test_a359_diag_emits_open_and_close_same_task` — the diagnostic emits open+close with the same task + `outcome=ok`.
- **Sufficiency is owner-Windows** (Procedure 1/2 in the doc) — the crash-gone confirmation Unix cannot produce.

## CI gates
- ruff clean · tier-audit OK · docstrings clean · full suite running.

## Test plan
- [x] diagnostic emits correctly (Unix)
- [ ] full suite green (running)
- [ ] **owner-Windows**: harness all-SURVIVED on Proactor + `list_mcp_tools` shows same-task/ok, no BaseExceptionGroup (owner runs; then the removal follow-up)

part of the MCP task-affinity arc (a359) · P3 of 3 (temporary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)