### PR TITLE
fix(#2409): _make_router_op_context forwards media_store (chat-router MCP images path-ref'd)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5725,6 +5725,12 @@ class Session:
                 else None
             ),
             agent_id=self._agent_id,
+            # #2409: forward the media store (the public twin RouterHostAdapter.make_router_op_context
+            # already does — session.py:1826). Without it the chat-router MCP path got media_store=None
+            # → MCP ImageContent couldn't be saved as a path-ref → a large image was inlined as
+            # base64 to the LLM instead of a small path-ref (the clean-payload/offload gate needs the
+            # image out of the inline body).
+            media_store=self._media_store,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
             current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)

--- a/tests/test_router_ctx_media_store_2409.py
+++ b/tests/test_router_ctx_media_store_2409.py
@@ -1,0 +1,66 @@
+"""Tier 2: #2409 — the chat-router op context forwards media_store (parity with the public twin).
+
+`Session._make_router_op_context` → `build_router_op_context` omitted `media_store`, so a chat-router
+MCP op got `ctx.media_store=None`: MCP ImageContent could not be saved as a `.reyn/media/` path-ref
+and a large image was inlined as base64 into the LLM body (tui's ~400KB repro). The public twin
+`RouterHostAdapter.make_router_op_context` already forwards it — this closes the construction-forwarding
+parity gap. Real AgentRegistry + Session (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+async def _session(tmp_path) -> Session:
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    sid = await reg.spawn_session_recorded("alice")
+    return reg.get_session("alice", sid)
+
+
+@pytest.mark.asyncio
+async def test_make_router_op_context_forwards_media_store(tmp_path, monkeypatch):
+    """Tier 2: CORE — the router op context carries the session's media_store (not None). RED on the
+    pre-fix code: `_make_router_op_context` never passed `media_store` → ctx.media_store was None
+    regardless of the session's store → MCP images inlined as base64 instead of a path-ref."""
+    monkeypatch.chdir(tmp_path)
+    sess = await _session(tmp_path)
+
+    sentinel = object()
+    sess._media_store = sentinel  # type: ignore[assignment]
+    ctx = sess._make_router_op_context()
+    assert ctx.media_store is sentinel, "router op context forwards the session's media_store"
+
+
+@pytest.mark.asyncio
+async def test_router_ctx_media_store_none_when_session_has_none(tmp_path, monkeypatch):
+    """Tier 2: parity/no-regression — when the session has no media store, the ctx's is None too
+    (the forward is faithful, not a fabricated store)."""
+    monkeypatch.chdir(tmp_path)
+    sess = await _session(tmp_path)
+
+    sess._media_store = None  # type: ignore[assignment]
+    ctx = sess._make_router_op_context()
+    assert ctx.media_store is None


### PR DESCRIPTION
**[e2e-coder]** — construction-forwarding gap (tui S6 dogfood, primary evidence). Separate from the a359 arc. Off clean main. Small (1 forward + tests).

## The gap
A chat-router MCP tool returning a large `ImageContent` inlined ~400KB base64 into the LLM body. Root: `Session._make_router_op_context` → `build_router_op_context` **omitted `media_store`**, so the chat-router op context had `media_store=None` → the mcp op handler couldn't save images to `.reyn/media/` as path-refs → base64 inlined. The **public twin** `RouterHostAdapter.make_router_op_context` already forwards `self._media_store` (session.py:1826) — this is a parity gap in the private builder.

## Fix
Pass `media_store=self._media_store` in `_make_router_op_context` (the builder already accepts + forwards it to `OpContext`). Now a chat-router MCP `ImageContent` is saved as a `.reyn/media/` path-ref → `media_blocks` stays small → the offload/clean-payload gate works → the LLM gets a path-ref, not a base64 blob.

## Falsify (real Session, RED-verified)
- `test_make_router_op_context_forwards_media_store` — the ctx carries the session's `media_store` (sentinel), not None. Reverting the forward fails it (RED).
- `test_router_ctx_media_store_none_when_session_has_none` — faithful None (no fabricated store).
- tui's ~400KB image repro is the live back-test (image → path-ref, not inline base64).

## CI gates
- ruff clean · tier-audit OK · docstrings clean · 11 focused (router-ctx + mcp-multimodal) pass · full suite running.

## Test plan
- [x] media_store forwarded (real Session) + RED-verified
- [ ] full suite green (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)