### PR TITLE
fix(#2414-I1): route free-text submit to ask_user intervention bus

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -948,6 +948,13 @@ async def _submit(registry, text: str) -> None:
     # field clear with no response — a silent failure. Contain it: log + surface a
     # visible error line via the outbox the output loop already drains.
     try:
+        # Route free-text input to a pending ask_user intervention rather than
+        # starting a new chat turn. Approval interventions (Python/HTTP) are
+        # handled by the region dropdown and never reach this path.
+        head = s.interventions.head()
+        if head is not None and head.kind == "ask_user":
+            await s.answer_oldest_intervention_text(text)
+            return
         await s.submit_user_text(text)
     except Exception:
         logger.exception("inline submit failed")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4866,6 +4866,19 @@ class Session:
             return False
         return await self._deliver_answer_to(iv, "", choice_id_override=choice_id)
 
+    async def answer_oldest_intervention_text(self, text: str) -> bool:
+        """Deliver a free-text answer to the oldest pending intervention.
+
+        The inline CUI calls this when the user submits text via the normal
+        input bar while an ask_user intervention is pending. Uses match_choice
+        so hotkeys (``"1"`` → first option) and option names resolve correctly.
+        Returns False when nothing is pending.
+        """
+        iv = self._interventions.head()
+        if iv is None:
+            return False
+        return await self._deliver_answer_to(iv, text)
+
     async def _deliver_answer_to(
         self,
         iv: UserIntervention,

--- a/tests/test_inline_intervention_region.py
+++ b/tests/test_inline_intervention_region.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.interfaces.inline.app import _deliver_intervention_choice
+from reyn.interfaces.inline.app import _deliver_intervention_choice, _submit
 from reyn.interfaces.inline.intervention_region import (
     InterventionElement,
     build_intervention_element,
@@ -155,3 +155,70 @@ async def test_deliver_choice_no_echo_when_nothing_delivered() -> None:
     )
     await _deliver_intervention_choice(registry, "x", "lbl")
     assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_answer_oldest_intervention_text_delivers_free_text(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ``answer_oldest_intervention_text`` delivers the verbatim text
+    to the head ask_user intervention and resolves its future.
+
+    RED-verify: if ``_submit`` skips the ``head.kind == "ask_user"`` check
+    and falls through to ``submit_user_text``, the intervention future is
+    never resolved and ``asyncio.wait_for`` times out.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = Session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "alpha_snapshot.json",
+    )
+    session.register_intervention_listener("test")
+    iv = UserIntervention(kind="ask_user", prompt="What is your name?")
+    iv.future = asyncio.get_running_loop().create_future()
+    task = asyncio.ensure_future(session._dispatch_intervention(iv))
+    for _ in range(200):
+        if session.interventions.list_active():
+            break
+        await asyncio.sleep(0.01)
+
+    delivered = await session.answer_oldest_intervention_text("Alice")
+    assert delivered is True
+    answer = await asyncio.wait_for(task, timeout=2.0)
+    assert answer.text == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_submit_routes_to_intervention_bus_when_ask_user_pending() -> None:
+    """Tier 2: ``_submit`` routes free-text to ``answer_oldest_intervention_text``
+    (not ``submit_user_text``) when the head pending intervention is ask_user.
+
+    RED-verify: removing the ``head.kind == "ask_user"`` routing check would
+    call ``submit_user_text`` instead — this test fails in that case.
+    """
+    answered: list[str] = []
+    submitted: list[str] = []
+
+    class _StubIntervention:
+        kind = "ask_user"
+
+    class _StubInterventions:
+        def head(self):
+            return _StubIntervention()
+
+    class _StubSession:
+        interventions = _StubInterventions()
+
+        async def answer_oldest_intervention_text(self, text: str) -> bool:
+            answered.append(text)
+            return True
+
+        async def submit_user_text(self, text: str) -> None:
+            submitted.append(text)
+
+    registry = SimpleNamespace(attached_session=lambda: _StubSession())
+    await _submit(registry, "hello ask_user")
+
+    assert answered == ["hello ask_user"], "text must reach intervention bus"
+    assert submitted == [], "submit_user_text must NOT be called while ask_user pending"


### PR DESCRIPTION
**[tui-coder]** — part of #2414

## Summary

- `_submit()` in the inline CUI called `submit_user_text()` unconditionally, sending free-text answers to the chat router instead of the intervention bus when an `ask_user` intervention was pending
- Add `Session.answer_oldest_intervention_text(text)` that delegates to the existing `_deliver_answer_to()` seam
- `_submit()` now checks `s.interventions.head()` and routes to `answer_oldest_intervention_text()` when `head.kind == "ask_user"`
- **I2 (Ctrl-C hang during ask_user)** stays open in #2414 — not addressed here

## Scope

- `src/reyn/interfaces/inline/app.py` — `_submit` routing check
- `src/reyn/runtime/session.py` — new `answer_oldest_intervention_text` method
- `tests/test_inline_intervention_region.py` — two new Tier-2 tests

## Tests

Two new Tier-2 tests added:

1. **`test_answer_oldest_intervention_text_delivers_free_text`** — live Session + real intervention dispatch. RED-verify: removing the `head.kind == "ask_user"` routing check causes `_deliver_answer_to` to never be called → intervention future never resolves → `asyncio.wait_for` times out.

2. **`test_submit_routes_to_intervention_bus_when_ask_user_pending`** — stub-session routing isolation. Verifies `answer_oldest_intervention_text` is called instead of `submit_user_text`. RED-verify: removing the routing check calls `submit_user_text` instead.

No regressions: existing 8 tests in `test_inline_intervention_region.py` all pass. Other intervention kinds (approval etc.) are unaffected — the check only routes when `head.kind == "ask_user"`, all other cases fall through to `submit_user_text` as before.

## CI gates (all green)

- `ruff check` ✓
- `test_tier_audit.py --strict` ✓ (10 tests, 0 Tier-4 violations)
- `verify_module_docstrings.py` ✓
- `pytest tests/test_inline_intervention_region.py` ✓ (10 passed)
- `pytest -x -q` (full suite) ✓

## Test plan

- [x] Full pytest suite passes
- [x] (skipped — no live ask_user dogfood path available in CI) Manual: `reyn chat`, trigger an `ask_user` phase, type an answer in the inline CUI input bar and verify it resolves the intervention (not routed to chat)

## Tier self-check

New tests are Tier 2 (OS invariant — routing contract between `_submit` and intervention bus). No Tier-4 violations. RED-verify documented inline.