### PR TITLE
fix: file_read truncates oversized reads (LLM-visible) instead of offload-duplicating

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -296,34 +296,38 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
         # byte-identical (no `encoding` field) for the common case.
         _enc_field = {"encoding": _detected_encoding} if _detected_encoding else {}
         # #2335: read MODE. An explicit LINE window (offset/limit given, no char_offset) is honored
-        # VERBATIM — the LLM's line-based read contract, byte-identical (a huge explicit window is
-        # NOT self-bounded → the generic offload handles it; consistent + non-recursing since its
-        # retrieval is an unbounded read → self-bounding → exempt). Otherwise (an unbounded read, OR
-        # a char_offset mid-line RESUME) the read is SELF-BOUNDING.
+        # VERBATIM — the LLM's line-based read contract, byte-identical — AS LONG AS its slice fits
+        # the inline cap. Otherwise (an unbounded read, a char_offset mid-line RESUME, OR an explicit
+        # window whose slice exceeds the cap) the read is SELF-BOUNDING (truncate + re-read hint).
+        cap = _read_inline_cap(ctx)
         explicit_line_window = (
             op.offset is not None or op.limit is not None
         ) and op.char_offset is None
         if explicit_line_window:
-            # Caller asked for an explicit LINE window — honor it verbatim.
             lines = content.splitlines(keepends=True)
             start = op.offset or 0
             sliced = lines[start:start + op.limit] if op.limit is not None else lines[start:]
-            ctx.events.emit("tool_executed", op="read_file", path=op.path)
-            return {
-                "kind": "file",
-                "op": "read",
-                "path": op.path,
-                "status": "ok",
-                "content": "".join(sliced),
-                **_enc_field,
-            }
+            joined = "".join(sliced)
+            # A window that fits the cap is honored verbatim. An OVERSIZED window is NOT offloaded:
+            # file_read's source already lives on disk at op.path, so duplicating it into an offload
+            # file is wasteful (owner steer). Fall through to the self-bounding truncation below —
+            # truncate inline + surface a re-read hint; the full content stays at op.path.
+            if len(joined) <= cap:
+                ctx.events.emit("tool_executed", op="read_file", path=op.path)
+                return {
+                    "kind": "file",
+                    "op": "read",
+                    "path": op.path,
+                    "status": "ok",
+                    "content": joined,
+                    **_enc_field,
+                }
 
         # #1209 read-bounding (keep-in-decide-context, not offloaded-out-of-view) + #2335 char-level
         # truncation. Accumulate WHOLE lines from (start_line, start_char); a multi-line overflow
         # stops at the LINE boundary (byte-identical to pre-#2335 — next_char_offset stays absent);
         # a SINGLE line/segment that alone exceeds the cap is CHAR-truncated so `content` is
         # GENUINELY ≤ cap (honest `_self_bounded`, #2335 fix), its tail paged via next_char_offset.
-        cap = _read_inline_cap(ctx)
         all_lines = content.splitlines(keepends=True)
         start_line = op.offset or 0
         start_char = op.char_offset or 0
@@ -368,6 +372,15 @@ async def handle(op: FileIROp, ctx: OpContext, caller: Literal["preprocessor", "
                 "total_lines": len(all_lines),
                 "next_offset": next_offset,
                 "total_chars": len(content),
+                # Owner: the LLM must recognize the content was cut (not the whole file). Explicit
+                # marker + a plain re-read hint pointing at the on-disk source — no offload copy is
+                # made for a file_read (the full content already lives at op.path).
+                "_truncated": True,
+                "note": (
+                    f"content truncated to fit context ({len(''.join(shown))} of {len(content)} "
+                    f"chars shown); the full file is on disk at {op.path!r} — re-read from "
+                    f"offset {next_offset} to continue."
+                ),
                 # #2296: content bound ≤ the inline cap BY CONSTRUCTION → exempt from the generic
                 # control_ir offload (else re-offload on envelope size alone and recurse).
                 "_self_bounded": True,

--- a/tests/test_file_read_truncate_marker.py
+++ b/tests/test_file_read_truncate_marker.py
@@ -1,0 +1,72 @@
+"""Tier 2: file_read truncation is LLM-visible and never offload-duplicates the on-disk source.
+
+Owner steer: a file_read's source already exists on disk, so offloading a duplicate copy is wasteful
+— truncate inline instead, and make the truncation RECOGNIZABLE to the LLM (an explicit
+``_truncated`` marker + a plain ``note`` pointing at the on-disk path + a re-read offset hint) so the
+model knows it holds a PART and can re-read the original file. Real Workspace + real ``handle`` +
+real ``offload_control_ir_result`` (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.context_builder import offload_control_ir_result
+
+
+def _read(tmp_path: Path, text: str, *, offset: int | None = None, limit: int | None = None) -> dict:
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.core.op_runtime.file import handle
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.schemas.models import FileIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    (tmp_path / "big.txt").write_text(text, encoding="utf-8")
+    events = EventLog()
+    ctx = OpContext(
+        workspace=Workspace(base_dir=tmp_path, events=events),
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+    )
+    op = FileIROp(kind="file", op="read", path="big.txt", offset=offset, limit=limit)
+    return asyncio.run(handle(op, ctx, "control_ir"))
+
+
+def test_large_read_is_truncated_with_llm_visible_marker(tmp_path, monkeypatch):
+    """Tier 2: CORE — a large (unbounded) file_read is truncated and carries an LLM-visible marker:
+    ``_truncated`` + a ``note`` that names the on-disk path and the re-read offset. RED before the
+    marker: no ``_truncated`` / ``note`` fields."""
+    monkeypatch.chdir(tmp_path)
+    res = _read(tmp_path, "some line of text here\n" * 50000)
+
+    assert res["status"] == "truncated"
+    assert res["_truncated"] is True, "explicit LLM-visible truncation marker"
+    assert res["_self_bounded"] is True, "truncated read is self-bounded (offload-exempt)"
+    assert res["next_offset"] is not None, "a re-read continuation offset is provided"
+    note = res["note"]
+    assert "big.txt" in note, "the note names the on-disk source path"
+    assert "offset" in note and "truncated" in note, "the note tells the LLM it is partial + how to continue"
+
+
+def test_truncated_read_is_not_offloaded_no_duplicate(tmp_path, monkeypatch):
+    """Tier 2: a truncated file_read is NOT offloaded — no duplicate copy of an on-disk file (owner
+    steer). The generic offload returns it unchanged (self-bounded exempt) and writes no file."""
+    monkeypatch.chdir(tmp_path)
+    res = _read(tmp_path, "some line of text here\n" * 50000)
+
+    out = offload_control_ir_result(res, 0, tmp_path, cap=200)
+    assert "_offload_ref" not in out, "a self-bounded file_read is never offloaded"
+    offload_dir = tmp_path / ".reyn" / "control_ir_offload"
+    assert not offload_dir.exists() or not list(offload_dir.glob("*")), "no duplicate offload file written"
+
+
+def test_small_read_has_no_truncation_marker_no_regression(tmp_path, monkeypatch):
+    """Tier 2: a small file read is complete — no ``_truncated`` / ``note`` fields (the common path
+    stays clean)."""
+    monkeypatch.chdir(tmp_path)
+    res = _read(tmp_path, "hello = 1\nworld = 2\n")
+
+    assert res["status"] == "ok"
+    assert "_truncated" not in res and "note" not in res, "no truncation marker on a complete read"

--- a/tests/test_offload_recursion_2296.py
+++ b/tests/test_offload_recursion_2296.py
@@ -4,8 +4,10 @@ file.read self-bounds its content ≤ the inline cap (#1209), but the generic of
 whole-JSON size (content + envelope), so an already-bounded read was offloaded on ENVELOPE alone —
 and retrieving it (an unbounded file.read of the ref) was itself over-cap on envelope → re-offloaded
 → infinite recursion. Fix: the read op stamps a positive ``_self_bounded`` flag on its self-bounding
-paths; ``offload_control_ir_result`` exempts a flagged result before the size check. The
-explicit-window path (verbatim, can exceed cap) is NOT flagged → still offloaded when huge.
+paths; ``offload_control_ir_result`` exempts a flagged result before the size check. Per the later
+owner steer (file_read never offload-duplicates its on-disk source), an OVERSIZED explicit window is
+also self-bounded (truncated) now → ALL file reads are exempt, so a read can never start the offload
+recursion.
 """
 from __future__ import annotations
 
@@ -82,20 +84,22 @@ def test_unbounded_ok_read_is_self_bounded(tmp_path: Path):
     assert res.get("_self_bounded") is True, "the OK unbounded read is flagged (bounded by construction)"
 
 
-def test_explicit_window_read_is_not_self_bounded(tmp_path: Path):
-    """Tier 2: THE precision — the explicit-window path honors the caller's offset/limit VERBATIM
-    (content can exceed cap), so it is NOT self-bounded and is NOT flagged → a huge explicit-window
-    read is still offloaded (not exempt)."""
+def test_oversized_explicit_window_read_is_self_bounded_and_exempt(tmp_path: Path):
+    """Tier 2: owner steer — an OVERSIZED explicit-window file_read is now SELF-BOUNDED (truncated),
+    so it is EXEMPT from the generic offload (no duplicate copy of an on-disk file). This strengthens
+    the #2296 recursion-termination guarantee: a file_read never offloads → it can never start the
+    offload/read recursion. Supersedes the prior verbatim-then-offloaded explicit-window contract."""
     (tmp_path / "big.py").write_text("x = 1\n" * 20000)
     res = _run(handle(
         FileIROp(kind="file", op="read", path="big.py", offset=0, limit=20000),
         _make_ctx(tmp_path), "control_ir",
     ))
-    assert res["status"] == "ok", "explicit window → honored verbatim, not auto-truncated"
-    assert "_self_bounded" not in res, "the explicit-window read is NOT self-bounded (can exceed cap)"
-    # and therefore it is still offloaded when huge (path-1 not exempt).
+    assert res["status"] == "truncated", "an oversized explicit window is truncated, not verbatim"
+    assert res["_self_bounded"] is True, "the oversized explicit-window read is self-bounded"
+    assert res["_truncated"] is True, "LLM-visible truncation marker"
+    # and therefore it is NOT offloaded — no duplicate file for an already-on-disk source.
     out = offload_control_ir_result(res, 0, tmp_path, cap=200)
-    assert out.get("_offload_ref"), "a huge explicit-window read is still offloaded"
+    assert "_offload_ref" not in out, "a self-bounded file_read is never offloaded (no duplicate copy)"
 
 
 # ── recursion termination: a self-bounded read is never re-offloaded ──────────────────────────

--- a/tests/test_read_single_line_char_truncation_2335.py
+++ b/tests/test_read_single_line_char_truncation_2335.py
@@ -74,16 +74,29 @@ def test_multi_line_over_cap_unchanged(tmp_path: Path):
     assert len(res["content"]) <= CAP
 
 
-def test_explicit_line_window_stays_verbatim_not_self_bounded(tmp_path: Path):
-    """Tier 2: an explicit LINE window (offset+limit, no char_offset) is honored VERBATIM — NOT
-    self-bounded, NOT char-truncated (a huge explicit window → the generic offload handles it;
-    consistent + non-recursing since its retrieval is unbounded → self-bounding → exempt)."""
+def test_small_explicit_line_window_stays_verbatim(tmp_path: Path):
+    """Tier 2: a SMALL explicit LINE window (≤ cap) is honored VERBATIM — byte-identical, not
+    self-bounded (the common #2335 line-read contract)."""
+    (tmp_path / "s.txt").write_text("l0\nl1\nl2\n")
+    res = _read(tmp_path, path="s.txt", offset=1, limit=1)  # just line 1
+    assert res["status"] == "ok"
+    assert res["content"] == "l1\n"
+    assert "_self_bounded" not in res, "a small explicit window is verbatim, not self-bounded"
+
+
+def test_oversized_explicit_line_window_is_truncated_not_offloaded(tmp_path: Path):
+    """Tier 2: owner steer — file_read never offload-duplicates its (on-disk) source. An explicit
+    LINE window whose slice EXCEEDS the cap is now SELF-BOUNDED (truncated + LLM-visible marker +
+    on-disk path + re-read hint), NOT returned verbatim for the generic offload. Supersedes the prior
+    #2335/#2296 verbatim-then-offload contract."""
     huge_line = "z" * (CAP + 5000)
     (tmp_path / "f.txt").write_text("a\n" + huge_line + "\nb\n")
-    res = _read(tmp_path, path="f.txt", offset=1, limit=1)  # the huge line, verbatim
-    assert res["status"] == "ok"
-    assert "_self_bounded" not in res, "an explicit line window is verbatim, not self-bounded"
-    assert len(res["content"]) > CAP, "verbatim honors the caller's explicit window even when huge"
+    res = _read(tmp_path, path="f.txt", offset=1, limit=1)  # the huge line
+    assert res["status"] == "truncated"
+    assert res["_self_bounded"] is True, "an oversized explicit window is self-bounded (no offload copy)"
+    assert res["_truncated"] is True, "LLM-visible truncation marker"
+    assert len(res["content"]) <= CAP, "content is cut to fit the cap (full source stays on disk)"
+    assert res["path"] == "f.txt", "the on-disk source path is surfaced for re-read"
 
 
 def test_small_read_unchanged(tmp_path: Path):


### PR DESCRIPTION
**[e2e-coder]** — owner design steer on file_read offloading.

## The steer
Owner: a file_read's source **already lives on disk**, so offloading a *duplicate* copy of it is wasteful. A file_read should **truncate inline + reference the on-disk path**; only transient results (web fetch / exec — no source on disk) keep offloading. (This withdraws the earlier `_offload_payload_field: "content"` proposal — clean text, but still a duplicate copy.)

## Change (`op_runtime/file.py`)
An explicit LINE window whose slice **exceeds the inline cap** no longer returns verbatim (which then flowed to the generic control_ir offload, duplicating the file). It now **falls through to the self-bounding truncation path** — truncate to the cap, mark `_self_bounded` (offload-exempt), and surface a `next_offset` re-read continuation. Small explicit windows are still honored **verbatim** (byte-identical, #2335 common case).

## Owner requirement: truncation must be LLM-visible
The truncated result now carries an explicit **`_truncated: true`** marker plus a plain **`note`** naming the on-disk path and the re-read offset:
> `content truncated to fit context (N of M chars shown); the full file is on disk at 'path' — re-read from offset K to continue.`

So the model knows it holds a PART and can re-read the original file.

## Supersedes prior #2335/#2296 contract
Previously an explicit window was honored verbatim → handed to the generic offload when huge. Now **all file reads are self-bounded / offload-exempt**, which also **strengthens the #2296 recursion-termination guarantee** (a file_read can never start the offload/read recursion). The two existing tests that pinned the old verbatim-then-offload behavior are updated to the new owner-directed contract (docstrings note the supersession).

## Tests (Tier 2 — real Workspace + real `handle` + real `offload_control_ir_result`, no mocks)
- `test_file_read_truncate_marker.py` (new): large unbounded read → `_truncated` + `note` (names path + offset); truncated read is NOT offloaded (no duplicate file); small read has no marker (no regression).
- `test_read_single_line_char_truncation_2335.py`: small explicit window still verbatim; oversized explicit window now truncated + self-bounded + marker.
- `test_offload_recursion_2296.py`: oversized explicit-window read is now self-bounded → offload-exempt (no duplicate).

**RED-when-stripped verified**: removing the `_truncated`/`note` marker fails the CORE marker test.

## CI gates (all green locally)
- `ruff check src tests scripts` ✓
- `python scripts/test_tier_audit.py --strict` ✓ (15 tests)
- full `pytest` ✓ (8459 passed, 17 skipped, 3 xfailed)
- `python scripts/verify_module_docstrings.py` ✓

## Note
This is the **file_read (disk-backed) truncate** half. The **MCP holistic seam redesign** (whack-a-mole resolution, [1]-[4] contain-all) is a separate design-first assessment I'm presenting to lead next (GO-gated).

## Test plan
- [ ] Manual: interactive read of a large file → LLM receives a truncated result with a clear "truncated, full at <path>, re-read from offset N" note, and no duplicate offload file is written for the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)