### PR TITLE
fix(#2414-I2): propagate CancelledError through intervention dispatch — fix Ctrl-C hang

### DIFF
--- a/src/reyn/runtime/services/intervention_coordinator.py
+++ b/src/reyn/runtime/services/intervention_coordinator.py
@@ -12,7 +12,6 @@ dispatch path and ``ChatInterventionBus`` both consult.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Callable
 
@@ -134,9 +133,6 @@ class InterventionCoordinator:
                 origin_channel_id=iv.origin_channel_id,
             )
             self._registry.park_stalled(iv)
-            try:
-                return await iv.future
-            except asyncio.CancelledError:
-                return InterventionAnswer(text="")
+            return await iv.future
         # Default: route through the regular InterventionHandler.
         return await self._handler.dispatch(iv)

--- a/src/reyn/runtime/services/intervention_registry.py
+++ b/src/reyn/runtime/services/intervention_registry.py
@@ -267,22 +267,21 @@ class InterventionRegistry:
         """Register *iv* in the queue, announce or signal queued status, then
         await the user's response.
 
-        Always removes the entry on exit so a cancelled skill does not leave
-        dangling queue entries.  On ``asyncio.CancelledError`` the future is
-        cancelled and an empty ``InterventionAnswer`` is returned to the
-        caller (same contract as the original ``_dispatch_intervention``).
+        Always removes the entry on exit (via ``finally``) so a cancelled
+        skill does not leave dangling queue entries.  ``asyncio.CancelledError``
+        is re-raised so the calling task is properly cancelled — swallowing it
+        caused the skill to receive an empty answer and re-request the
+        intervention, producing a teardown hang (#2414-I2).
 
         issue #254 Phase 1: when ``enforce_listener_presence=True`` was set
         at construction AND no listener is registered, return an empty
         ``InterventionAnswer`` immediately instead of enqueuing + awaiting
         an unresolvable future. The caller (= ``handle_limit_exceeded`` /
-        permission gate) sees this as a refusal and falls through to abort,
-        matching the existing cancellation contract.
+        permission gate) sees this as a refusal and falls through to abort.
         """
         if self._enforce_listener_presence and not self._listeners:
             # No listener will call deliver_answer → prompt would hang
-            # forever. Match the cancellation contract: return empty answer
-            # so the caller treats it as a refusal.
+            # forever. Return empty answer so the caller treats it as a refusal.
             return InterventionAnswer(text="")
         self._active[iv.id] = iv
         self._order.append(iv.id)
@@ -293,10 +292,7 @@ class InterventionRegistry:
             # announce (or a "queued" status message) is the session's
             # responsibility in wave 2.  The registry itself only calls
             # on_announce for the head intervention.
-            try:
-                return await iv.future
-            except asyncio.CancelledError:
-                return InterventionAnswer(text="")
+            return await iv.future
         finally:
             self._active.pop(iv.id, None)
             try:

--- a/tests/test_intervention_coordinator.py
+++ b/tests/test_intervention_coordinator.py
@@ -171,3 +171,45 @@ async def test_dispatch_routes_to_handler_when_listener_present() -> None:
     assert handler.calls == [iv]
     assert registry.list_stalled() == []
     assert answer.text == "handled"
+
+
+# ── CancelledError propagation (#2414-I2 fix) ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dispatch_cancel_propagates_not_silenced_stalled_path() -> None:
+    """Tier 2: task cancellation propagates through the stalled-path dispatch.
+
+    When an iv is parked stalled and the awaiting task is cancelled,
+    CancelledError must propagate (task.cancelled() True) — swallowing it
+    caused the skill to receive an empty answer and re-request the
+    intervention, producing a teardown hang (#2414-I2)."""
+    coord, _registry, _handler, _events = _coord()
+    iv = _make_iv(origin_channel_id="gone")  # no listener → stalled path
+
+    task = asyncio.ensure_future(coord.dispatch(iv))
+    await asyncio.sleep(0)  # let dispatch reach park + await
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled(), "CancelledError must propagate — task must be cancelled, not complete silently"
+
+
+@pytest.mark.asyncio
+async def test_registry_dispatch_cancel_propagates_not_silenced() -> None:
+    """Tier 2: task cancellation propagates through InterventionRegistry.dispatch.
+
+    The registry's dispatch must re-raise CancelledError so the calling
+    skill task is properly cancelled (#2414-I2). Before the fix, the
+    except-swallow returned an empty answer; after, the task is cancelled."""
+    registry = InterventionRegistry(on_announce=_noop_announce)
+    iv = _make_iv()
+
+    # Drive dispatch: it enqueues iv and blocks at await iv.future.
+    task = asyncio.ensure_future(registry.dispatch(iv))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled(), "CancelledError must propagate — task must be cancelled, not silently return empty"


### PR DESCRIPTION
**[tui-coder]** — fix for #2414 I2 (Ctrl-C teardown hang during ask_user)

## Root cause

`InterventionRegistry.dispatch` and `InterventionCoordinator.dispatch` both had:

```python
except asyncio.CancelledError:
    return InterventionAnswer(text="")
```

When Ctrl-C triggered `cancel_inflight()` → `task.cancel()` during an `ask_user` wait, `CancelledError` was raised at `await iv.future` but caught and swallowed. The skill task received an empty answer and **continued running** — immediately re-requesting the intervention and hanging again. Only `pkill` could end it. Event log: `✗ Cancelling…` → bus resolves `""` → 2nd ask_user → hangs again.

## Fix

Remove the `except asyncio.CancelledError` swallow from both sites. Let it propagate so the skill task is actually cancelled (`task.cancelled() == True`). The registry's `finally:` block still runs cleanup (active pop + order remove + `_maybe_announce_next`).

## Files changed

- `src/reyn/runtime/services/intervention_registry.py` — remove inner `except CancelledError: return empty`; update docstring
- `src/reyn/runtime/services/intervention_coordinator.py` — remove `try/except CancelledError: return empty` around stalled-path `await iv.future`; remove now-unused `import asyncio`
- `tests/test_intervention_coordinator.py` — 2 new Tier-2 tests: `task.cancelled() == True` after cancel (the old swallow made it False)

## Test plan

- [x] `pytest tests/test_intervention_coordinator.py` — 7/7 pass (incl. 2 new tests)
- [x] `pytest tests/test_await_quiescent.py tests/test_intervention_handler_invariants.py tests/test_pending_intervention_268.py tests/test_session_intervention_persistence.py` — 37/37 pass
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — clean
- [x] `python scripts/verify_module_docstrings.py` — clean

## Evidence (how I found this)

Investigating #2414-I2. The `except asyncio.CancelledError: return empty` pattern in long-lived async tasks is the exact anti-pattern from project feedback (`feedback_track_background_verification_hang_not_slow.md`). The old "cancellation contract" in the docstring was wrong: it caused task.cancelled() to be False, meaning the skill was never actually cancelled.

part of #2414

**Tier self-check**: new tests are Tier 2 (OS invariant — intervention dispatch cancellation contract). No Tier 4 violations.