### PR TITLE
fix(#2415): honor declared recursive scope + project_root-anchor approved-path checks

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -115,11 +115,6 @@ def _normalize_paths(v: object) -> list[str]:
     return [str(x) for x in v]
 
 
-def _expand(path_str: str) -> Path:
-    """Expand ~ and resolve a path string to an absolute Path."""
-    return Path(path_str).expanduser().resolve()
-
-
 def _is_canonical_protected_write(path_str: str, base: "Path | None" = None) -> bool:
     """Return True if ``path_str`` resolves to one of the #571 protected paths.
 
@@ -668,7 +663,17 @@ class PermissionResolver:
             if not approved or not key.startswith(prefix):
                 continue
             approved_str = key[len(prefix):]
-            approved_p = _expand(approved_str.rstrip("/"))
+            # #2415: resolve the approved key against the SAME base as the check target
+            # (``self._project_root``), NOT the CWD. approvals.yaml is project-scoped (under
+            # ``.reyn/``), so a persisted relative grant like ``reyn/local/`` means "under the
+            # project root". ``_expand`` resolved it CWD-relative, so a run whose cwd != project_root
+            # (e.g. launched from a subdirectory) failed the ``relative_to`` match even with the
+            # grant present in-memory — the recursive grant was silently not honored (skill_builder).
+            approved_raw = Path(approved_str.rstrip("/")).expanduser()
+            approved_p = (
+                approved_raw.resolve() if approved_raw.is_absolute()
+                else (base / approved_raw).resolve()
+            )
             if approved_str.endswith("/"):
                 try:
                     p_resolved.relative_to(approved_p)
@@ -744,7 +749,13 @@ class PermissionResolver:
         kind: "file.read" or "file.write". When recursive=True the approval
         covers the directory and everything beneath it.
         """
-        p = str(_expand(path))
+        # #2415: resolve against ``self._project_root`` (the base ``_is_path_approved_for`` uses),
+        # NOT the CWD. A relative path (e.g. a project-scoped declared grant) resolved CWD-relative
+        # would store a key that never matches the project_root-anchored check target when
+        # cwd != project_root — the same cwd-anchor class fixed in ``_is_path_approved_for``. Absolute
+        # inputs are unchanged (already CWD-independent).
+        raw = Path(path).expanduser()
+        p = str(raw.resolve() if raw.is_absolute() else (self._project_root / raw).resolve())
         if recursive:
             p = p.rstrip("/") + "/"
         self._session[f"{skill_name}/{kind}/{p}"] = True
@@ -792,11 +803,19 @@ class PermissionResolver:
         )
         answer = await bus.request(iv)
         choice = answer.choice_id
+        # #2415: honor the DECLARED scope on approval. When the skill declared this path as
+        # ``recursive`` (startup_guard confirming a declared grant), an affirmative approval grants
+        # the declared RECURSIVE dir — the operator approves/denies the declared grant, they do not
+        # re-scope it narrower. Otherwise (a JIT prompt, or a ``just_path`` declaration) an
+        # affirmative grants the exact path. Without this, a skill that declares ``reyn/local``
+        # recursive but writes ``reyn/local/{name}/…`` (a SUBPATH) was silently denied unless the
+        # operator happened to pick [r] — the declared recursive intent was not honored (skill_builder).
+        affirmative_key = recursive_target if scope == "recursive" else path
         if choice == YES:
-            self._session[f"{skill_name}/{kind}/{path}"] = True
+            self._session[f"{skill_name}/{kind}/{affirmative_key}"] = True
             return True
         if choice == JUST_PATH:
-            self._persist(f"{skill_name}/{kind}/{path}", True)
+            self._persist(f"{skill_name}/{kind}/{affirmative_key}", True)
             return True
         if choice == RECURSIVE:
             self._persist(f"{skill_name}/{kind}/{recursive_target}", True)

--- a/tests/test_2415_honor_declared_recursive_scope.py
+++ b/tests/test_2415_honor_declared_recursive_scope.py
@@ -1,0 +1,126 @@
+"""Tier 2: #2415 gap — a declared ``scope: recursive`` write grant is honored on approval so SUBPATH
+writes are covered, on the SAME running resolver, even when cwd != project_root.
+
+The #2415 grant made startup_guard PROMPT for skill_builder's ``reyn/local`` write, but the write
+still hit ``permission_denied: declared but not granted``. tui's live evidence isolated TWO roots:
+
+  #1 (choice): an affirmative [y]/[j] persisted the EXACT declared path ``reyn/local``, which does
+     not cover the real write target ``reyn/local/{name}/skill.md`` (a SUBPATH). Only [r] worked.
+  #2 (path-resolution): even the persisted recursive grant (``reyn/local/``) was denied on the SAME
+     run because ``_is_path_approved_for`` resolved the approved KEY relative to CWD (``_expand``)
+     while resolving the check target relative to ``project_root`` — a run launched from a
+     subdirectory (cwd != project_root) failed the ``relative_to`` match even with the grant in
+     ``_saved``.
+
+Fixes: (#1) honor the declared recursive scope on any affirmative approval; (#2) resolve the approved
+key against ``project_root`` (approvals.yaml is project-scoped), matching the check target's base.
+
+The original #2415 test used an approving bus on ONE resolver with cwd==project_root and an exact-path
+expectation — it masked BOTH roots (fake-backend-misses-integration). This test drives the REAL flow:
+real startup_guard → real persist/session → require_file_write of a subpath, on the SAME resolver,
+with **cwd != project_root** (mirroring the live Direct-CLI run).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.compiler.parser import _split_frontmatter
+from reyn.intervention_choices import JUST_PATH, NO, RECURSIVE, YES
+from reyn.schemas.models import Phase, Skill, SkillGraph
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.skill.skill_paths import resolve_skill_path
+from reyn.user_intervention import InterventionAnswer
+
+_SUBPATH = "reyn/local/my_new_skill/skill.md"  # a SUBPATH of the declared reyn/local dir
+
+
+class _Bus:
+    def __init__(self, choice: str) -> None:
+        self.choice = choice
+
+    async def request(self, iv):  # noqa: ANN001 — RequestBus.request
+        return InterventionAnswer(choice_id=self.choice)
+
+
+def _recursive_skill() -> Skill:
+    ph = Phase(name="build", instructions="x",
+               input_schema={"type": "object", "properties": {}}, allowed_ops=["write_file"])
+    return Skill(name="skill_builder", entry_phase="build", phases={"build": ph},
+                 graph=SkillGraph(transitions={}, can_finish_phases=["build"]),
+                 final_output_schema={"type": "object", "properties": {}}, final_output_name="r",
+                 permissions=PermissionDecl.from_dict({"file.write": [{"path": "reyn/local", "scope": "recursive"}]}))
+
+
+def _project_and_cwd(tmp_path: Path, monkeypatch) -> Path:
+    """Set up cwd != project_root (the live Direct-CLI condition #2 needs). Returns project_root."""
+    project_root = tmp_path / "project"
+    other_cwd = tmp_path / "elsewhere"
+    project_root.mkdir()
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)  # cwd != project_root
+    return project_root
+
+
+def _resolver(project_root: Path) -> PermissionResolver:
+    return PermissionResolver(config_permissions={}, project_root=project_root, interactive=True)
+
+
+@pytest.mark.parametrize("choice", [YES, JUST_PATH, RECURSIVE])
+@pytest.mark.asyncio
+async def test_affirmative_approval_covers_subpath_same_resolver_cwd_differs(choice, tmp_path, monkeypatch):
+    """Tier 2: CORE — ANY affirmative approval (y/j/r) of a recursive-declared grant lets the skill
+    write a SUBPATH, on the SAME running resolver, with cwd != project_root (the live condition).
+    RED before the fixes: [y]/[j] grant the exact path (#1); and even [r] is denied because the
+    approved key is resolved CWD-relative while the target is project_root-relative (#2)."""
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    r = _resolver(project_root)  # ONE resolver, as run_orchestrator threads self._perm
+    await r.startup_guard(_recursive_skill(), "skill_builder", _Bus(choice))
+    # subpath write, non-interactive gate on the SAME resolver — must not raise
+    await r.require_file_write(_recursive_skill().permissions, _SUBPATH, "skill_builder", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_deny_still_denies_the_subpath(tmp_path, monkeypatch):
+    """Tier 2: the fixes do not over-grant — a [N]o answer still denies the subpath write."""
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    r = _resolver(project_root)
+    await r.startup_guard(_recursive_skill(), "skill_builder", _Bus(NO))
+    with pytest.raises(PermissionError):
+        await r.require_file_write(_recursive_skill().permissions, _SUBPATH, "skill_builder", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_recursive_grant_does_not_widen_to_siblings_or_parent(tmp_path, monkeypatch):
+    """Tier 2: no access-widening — approving reyn/local recursive covers ONLY paths under it. A
+    sibling (reyn/other/…) and the project root itself stay denied. Guards the #2 anchor change from
+    accidentally matching a broader path."""
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    r = _resolver(project_root)
+    await r.startup_guard(_recursive_skill(), "skill_builder", _Bus(RECURSIVE))
+    for outside in ("reyn/other/x.md", "reyn/localX/x.md", "top.md"):
+        with pytest.raises(PermissionError):
+            await r.require_file_write(_recursive_skill().permissions, outside, "skill_builder", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_session_approve_path_relative_honored_when_cwd_differs(tmp_path, monkeypatch):
+    """Tier 2: sibling fix (fold-in) — ``session_approve_path`` (the up-front prompt-suppress writer)
+    resolves a RELATIVE project-scoped grant against project_root too, so it is honored when
+    cwd != project_root. RED before: it stored a CWD-resolved key that never matched the
+    project_root-anchored check target (the same cwd-anchor class as _is_path_approved_for)."""
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    r = _resolver(project_root)
+    r.session_approve_path("reyn/local", "skill_builder", "file.write", recursive=True)
+    await r.require_file_write(_recursive_skill().permissions, _SUBPATH, "skill_builder", bus=None)
+
+
+def test_skill_builder_really_declares_reyn_local_recursive():
+    """Tier 2: anchor — the real skill_builder skill.md declares reyn/local as a RECURSIVE write, so
+    honor-declared-recursive is the mechanism that unblocks its subpath DSL writes."""
+    skill_dir, _ = resolve_skill_path("skill_builder")
+    fm, _ = _split_frontmatter((Path(skill_dir) / "skill.md").read_text(encoding="utf-8"))
+    decl = PermissionDecl.from_dict(fm.get("permissions") or {})
+    assert any(e.get("path") == "reyn/local" and e.get("scope") == "recursive" for e in decl.file_write), \
+        "skill_builder declares reyn/local as a recursive write grant"


### PR DESCRIPTION
**[e2e-coder]** — #2415 follow-up (tui live-caught). skill_builder was broken on main: startup_guard prompted for its `reyn/local` write, but build_skill writes still hit `permission_denied: declared but not granted`.

## Two roots (both primary-evidence confirmed, cwd-varying repro)
**#1 — choice (non-recursive under-grants):** an affirmative `[y]`/`[j]` approval of a *recursive-declared* grant persisted the **exact** declared path `reyn/local`, which does not cover the real write target `reyn/local/{name}/skill.md` (a **subpath**). Only `[r]` worked. **Fix:** honor the declared scope — an affirmative approval of a `scope: recursive` declared request grants the recursive dir (the operator approves/denies the *declared* grant, not a narrower re-scope).

**#2 — path-resolution base mismatch:** `_is_path_approved_for` resolved the check target against `self._project_root` but resolved the approved **key** via `_expand` (**CWD-relative**). A run with `cwd != project_root` (e.g. launched from a subdirectory) failed the `relative_to` match **even with the grant in `_saved`** — the recursive grant was silently not honored. **Fix:** resolve the approved key against `project_root` (approvals.yaml is project-scoped), matching the check target's base. Applies to **both** file.read and file.write approvals.

## Fold-in (fix-class-completeness)
`session_approve_path` (the up-front prompt-suppress writer) had the same CWD-anchor for relative inputs → resolved against `project_root` too. Leaving one latent cwd-anchor sibling would repeat the sibling-sweep-miss class that caused the list-path crash. Dead `_expand` (now unreferenced) removed.

## Security confirms (lead-requested)
- **Callers/regression:** `_is_path_approved_for` is the sole path-approval method (read×3 + write×3 call sites) → the anchor fix corrects both consistently; other axes (host/mcp/secret) don't resolve paths. 205-test permission suite (incl. offload-read approvals) green → no regression.
- **Key format:** keys are mixed — startup_guard persists a project-relative declared path; JIT persists a resolved absolute path. The fix handles both (absolute → `resolve()` idempotent; relative → `project_root/<key>`).
- **No access-widening:** the anchor change affects only relative keys, resolving to `project_root/<key>` (the actual write scope), never broader — a test asserts siblings (`reyn/other`, `reyn/localX`) and the parent stay denied after the recursive grant.

## Test — real flow, both roots RED-reproduced
The original #2415 test used an approving bus on **one** resolver with `cwd==project_root` + an exact-path expectation — it **masked both roots** (fake-backend-misses-integration). The new test drives the **real** `startup_guard → persist → require_file_write` flow on the **same** resolver with **`cwd != project_root`** (mirroring the live Direct-CLI run), across all 3 affirmative choices + deny + no-widening + the session_approve_path sibling. **RED-verified:** reverting the fixes fails all 3 affirmative choices; reverting the sibling fix fails the sibling test.

## CI gates (all green locally)
- `ruff check src tests scripts` ✓
- `python scripts/test_tier_audit.py --strict` ✓
- full `pytest` ✓ (8466 passed, 17 skipped, 3 xfailed)
- `python scripts/verify_module_docstrings.py` ✓

## Acceptance
tui's Direct-CLI run (`cwd != project_root`) is the #2 live acceptance; #2417 verify is done. skill_builder can now write `reyn/local/{name}/` after approving its declared grant, regardless of which affirmative choice or the launch directory.

Closes #2415 (gap follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)