### PR TITLE
feat(#2421): MCP holistic seam — single gateway defeats the crash class (all paths, contain-all)

### DIFF
--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -14,32 +14,13 @@ from reyn.schemas.models import MCPIROp
 from . import register
 from .context import OpContext
 
-# #a359 P2 / S3: a FINITE default per-call MCP timeout so a hung/slow server can't block the router
-# loop indefinitely (owner: "MCP misbehavior must not stall reyn"). Generous (long-running tools
-# exist); a per-server ``call_timeout_seconds`` overrides it, and ``<= 0`` opts out (no timeout).
-# When the timeout fires, the SDK raises → the op fault boundary contains it into an error result.
-_DEFAULT_MCP_CALL_TIMEOUT_SECONDS: float = 120.0
-
-
-def _resolve_call_timeout(config: dict) -> "float | None":
-    """Resolve the per-call MCP timeout: the finite default, overridden by a per-server
-    ``call_timeout_seconds`` (float), with ``<= 0`` meaning opt-out (no timeout / ``None``).
-    A malformed value falls back to the default (fail-safe: keep a finite bound)."""
-    ct = config.get("call_timeout_seconds")
-    timeout: "float | None" = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
-    if ct is not None:
-        try:
-            timeout = float(ct)
-        except (TypeError, ValueError):
-            timeout = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
-    if timeout is not None and timeout <= 0:
-        return None  # explicit opt-out — no timeout
-    return timeout
+# #2421: the per-call MCP timeout ([4]) now lives in the MCPGateway seam (``resolve_call_timeout``),
+# applied to every MCP op in one place. The op handler delegates to the gateway.
 
 
 async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     from reyn.mcp.client import expand_env
-    from reyn.mcp.pool import describe_fault, is_or_contains_control_flow
+    from reyn.mcp.gateway import MCPFault, MCPGateway
 
     server_cfg = ctx.mcp_servers.get(op.server)
     if not server_cfg:
@@ -91,26 +72,22 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             message=message,
         )
 
-    call_timeout = _resolve_call_timeout(expanded)
-
     ctx.events.emit("mcp_called", server=op.server, tool=op.tool, args=op.args)
+    # #2421: the open+call+teardown fault boundary + per-call timeout + task-affine lifecycle all live
+    # in the ONE MCPGateway seam (reusing this turn's pool). The gateway raises only MCPFault (an
+    # Exception) or genuine control flow — never a bare BaseExceptionGroup — so a server that dies on
+    # connect, a bad config, a malformed response, or a transport group all surface here as a clean
+    # MCPFault → contained error tool-result (owner req: MCP misbehavior must not crash the router
+    # loop). Cancellation is never swallowed (is_real_control_flow re-raises genuine cancel/KI/SE).
+    gateway = MCPGateway(pool=ctx.mcp_pool, agent_id=ctx.agent_id)
     try:
-        # Open (or reuse) the client via the pool, then call — both inside the fault boundary so a
-        # server that dies on connect, a bad config, a malformed response, OR a transport
-        # BaseExceptionGroup all become a contained error tool-result (owner req: MCP misbehavior
-        # must not crash the router loop). Cancellation is never swallowed.
-        client = await ctx.mcp_pool.get(op.server, expanded, agent_id=ctx.agent_id)
-        result = await client.call_tool(
-            op.tool, op.args,
-            progress_callback=_on_progress,
-            timeout_seconds=call_timeout,
+        result = await gateway.call_tool(
+            op.server, op.tool, op.args, expanded, progress_cb=_on_progress,
         )
-    except BaseException as exc:  # noqa: BLE001 — fault isolation across ANY MCP fault (incl groups)
-        if is_or_contains_control_flow(exc):
-            raise  # never contain CancelledError / KeyboardInterrupt / SystemExit
+    except MCPFault as fault_exc:
         # Owner req: feed the fault CONTENT back to the LLM (type + message, group members
         # aggregated) via the standard op-error result — so it can retry/adapt, not a silent error.
-        fault = describe_fault(exc)
+        fault = str(fault_exc)
         ctx.events.emit("mcp_failed", server=op.server, tool=op.tool, error=fault)
         return {"kind": "mcp", "status": "error", "server": op.server,
                 "tool": op.tool, "error": fault}

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -998,14 +998,14 @@ def _probe_status(name: str, cfg: dict) -> str:
     from reyn.llm.llm import run_async as _run_async
 
     async def _handshake() -> str:
-        # #a359 P1: structured lifecycle — ``async with MCPClient(cfg)`` runs the initialize handshake
-        # in __aenter__ and closes in __aexit__, same task/scope (supersedes C's construct +
-        # initialize + finally-close). MCPClient(cfg): config-first dict.
-        from reyn.mcp.client import MCPClient
+        # #2421: probe via the single MCPGateway seam — it opens the server (initialize handshake)
+        # inside the contain-all boundary + task-affine pool and raises only MCPFault, so a server
+        # that dies on connect surfaces as a clean status, never an uncontained BaseExceptionGroup.
+        from reyn.mcp.gateway import MCPFault, MCPGateway
         try:
-            async with MCPClient(cfg):
-                return "ready"
-        except Exception as exc:
+            await MCPGateway().probe(name, cfg)
+            return "ready"
+        except MCPFault as exc:
             return f"error: {exc}"
 
     try:
@@ -1248,20 +1248,17 @@ async def _probe_server_tools(
     """
     import asyncio
 
-    from reyn.mcp.client import MCPClient
+    from reyn.mcp.gateway import MCPFault, MCPGateway
 
-    # #a359 P1: structured lifecycle — open+use+close within ONE ``async with`` block in this task,
-    # so the SDK stdio_client / ClientSession internal task-group scopes are entered AND exited here
-    # (supersedes C's construct + finally-close, which still deferred the scope teardown to a separate
-    # close()). MCPClient(cfg): config-first dict (fixes the old ``MCPClient(server_name, cfg)`` that
-    # passed the name as config → ValueError → empty tool list); ``list_tools()`` auto-initializes.
+    # #2421: probe tool lists via the single MCPGateway seam (open + list + teardown inside the
+    # contain-all boundary + task-affine pool). The gateway raises only MCPFault — never a bare
+    # BaseExceptionGroup — so a dead server can't crash the probe. The outer ``asyncio.timeout`` keeps
+    # the tight per-server probe bound (< the gateway's own call timeout); its cancellation is genuine
+    # (cancelling() > 0) so it propagates out as a TimeoutError rather than being contained.
     try:
         async with asyncio.timeout(per_server_timeout):
-            async with MCPClient(cfg) as client:
-                raw = await client.list_tools()
-    except (TimeoutError, asyncio.TimeoutError):
-        return server_name, []
-    except Exception:  # noqa: BLE001
+            raw = await MCPGateway(agent_id=None).list_tools(server_name, cfg)
+    except (TimeoutError, asyncio.TimeoutError, MCPFault):
         return server_name, []
     cleaned = [
         t for t in (raw or [])

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -85,13 +85,20 @@ class MCPGateway:
     ) -> Any:
         """Open a client and run ``op`` inside the contain-all boundary + a finite timeout. Raises
         :class:`MCPFault` for any non-control-flow fault (incl. teardown groups); re-raises genuine
-        control flow untouched."""
+        control flow untouched.
+
+        The timeout wraps the WHOLE ``acquire + op`` — the OPEN (initialize handshake) as well as the
+        call — so a server that HANGS ON INIT is bounded too (else a fresh one-shot open for a
+        list/probe would hang unbounded). On timeout ``asyncio.timeout`` surfaces a ``TimeoutError``
+        (an Exception, our task not cancelling), which the boundary contains as an ``MCPFault``."""
         try:
-            async with self._acquire(server, config) as client:
-                if timeout is not None:
-                    async with asyncio.timeout(timeout):
+            if timeout is not None:
+                async with asyncio.timeout(timeout):
+                    async with self._acquire(server, config) as client:
                         return await op(client)
-                return await op(client)
+            else:
+                async with self._acquire(server, config) as client:
+                    return await op(client)
         except MCPFault:
             raise
         except BaseException as exc:  # noqa: BLE001 — the seam contains ALL non-control-flow faults

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -1,0 +1,125 @@
+"""MCPGateway — the single seam every MCP operation flows through (#2421).
+
+Root cause of the recurring MCP crashes: fault-isolation + task-affine lifecycle + per-call timeout
+were applied PER entry path (op-call got them; list/probe were swept-missed → the list-path crash
+recurred). This gateway consolidates them in ONE place so a new entry path is a thin caller by
+construction and cannot re-introduce a crash/leak:
+
+  [1] structured sub-task join  — the SDK stdio_client/ClientSession task group joins its internal
+      reader/writer tasks at ``close`` (in the pool's owning task); a sub-task fault surfaces
+      synchronously in-scope, never orphaning to the loop ("Task exception was never retrieved").
+  [2] contain-all boundary      — ``except BaseException``; re-raise ONLY genuine control flow
+      (``is_real_control_flow``: KeyboardInterrupt/SystemExit, or CancelledError while THIS task is
+      actually cancelling); contain everything else (transport faults, groups, spurious internal
+      cancels) as an :class:`MCPFault`. Exception-structure-independent — a bare cancel-mixed
+      ``BaseExceptionGroup`` from a dead subprocess is contained, not propagated.
+  [3] pool task-affinity        — clients open + close on one task via :class:`MCPClientPool`.
+  [4] per-call timeout          — a finite bound per op (``call_timeout_seconds``; ``<= 0`` opts out).
+
+The gateway raises ONLY :class:`MCPFault` (an ``Exception``) or genuine control flow — never a bare
+``BaseExceptionGroup`` — so thin callers need only ``except MCPFault`` (or ``except Exception``) to
+shape their surface (list → ``[{"error": …}]``, call → error result, probe → status). Result
+SHAPING (media blocks, offload marker) is pure post-processing and stays in the caller.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any, Awaitable, Callable
+
+from reyn.mcp.client import MCPClient
+from reyn.mcp.pool import MCPClientPool, describe_fault, is_real_control_flow
+
+# Generous finite default (owner S3): a hung server must not wedge the run, but the default is
+# lenient; operators tighten per server via ``call_timeout_seconds`` (``<= 0`` opts out).
+_DEFAULT_MCP_CALL_TIMEOUT_SECONDS: float = 120.0
+
+
+class MCPFault(Exception):
+    """A contained MCP fault (transport / protocol / teardown), summarised for an LLM-facing result.
+
+    The gateway converts ANY non-control-flow fault into this so callers never see a bare
+    ``BaseExceptionGroup``. Its ``str`` is the aggregated fault text from :func:`describe_fault`."""
+
+
+def resolve_call_timeout(config: dict) -> "float | None":
+    """Per-call timeout: the finite default, overridden by a per-server ``call_timeout_seconds``
+    (float); ``<= 0`` opts out (no bound). A malformed value falls back to the default (fail-safe —
+    keep a finite bound)."""
+    ct = config.get("call_timeout_seconds")
+    timeout: "float | None" = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
+    if ct is not None:
+        try:
+            timeout = float(ct)
+        except (TypeError, ValueError):
+            timeout = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
+    if timeout is not None and timeout <= 0:
+        return None
+    return timeout
+
+
+class MCPGateway:
+    """The one object that touches :class:`MCPClient`. All MCP ops (list / call / probe) run here.
+
+    Pass an existing ``pool`` to REUSE cached clients within a turn (op-call path); omit it for a
+    one-shot op (list / probe) — the gateway opens and closes its own pool for that call.
+    """
+
+    def __init__(self, *, pool: "MCPClientPool | None" = None, agent_id: str | None = None) -> None:
+        self._injected_pool = pool
+        self._agent_id = agent_id
+
+    @asynccontextmanager
+    async def _acquire(self, server: str, config: dict):
+        """Yield an open client for ``server``. Reuses the injected pool, or opens+closes a private
+        one-shot pool (whose ``__aexit__`` closes in-task and contains teardown faults)."""
+        if self._injected_pool is not None:
+            yield await self._injected_pool.get(server, config, agent_id=self._agent_id)
+        else:
+            async with MCPClientPool() as pool:
+                yield await pool.get(server, config, agent_id=self._agent_id)
+
+    async def _run(
+        self, server: str, config: dict, op: Callable[[MCPClient], Awaitable[Any]],
+        *, timeout: "float | None",
+    ) -> Any:
+        """Open a client and run ``op`` inside the contain-all boundary + a finite timeout. Raises
+        :class:`MCPFault` for any non-control-flow fault (incl. teardown groups); re-raises genuine
+        control flow untouched."""
+        try:
+            async with self._acquire(server, config) as client:
+                if timeout is not None:
+                    async with asyncio.timeout(timeout):
+                        return await op(client)
+                return await op(client)
+        except MCPFault:
+            raise
+        except BaseException as exc:  # noqa: BLE001 — the seam contains ALL non-control-flow faults
+            if is_real_control_flow(exc):
+                raise
+            raise MCPFault(describe_fault(exc)) from exc
+
+    async def list_tools(self, server: str, config: dict) -> list[dict]:
+        """Return the server's advertised tools. Raises :class:`MCPFault` on any contained fault."""
+        return await self._run(server, config, lambda c: c.list_tools(),
+                               timeout=resolve_call_timeout(config))
+
+    async def call_tool(
+        self, server: str, tool: str, args: dict, config: dict, *, progress_cb: Any = None,
+    ) -> dict:
+        """Call ``tool`` and return the RAW client result (``{content, isError, structuredContent}``).
+        Result shaping (media blocks / offload marker) is the caller's post-processing. Raises
+        :class:`MCPFault` on any contained fault."""
+        timeout = resolve_call_timeout(config)
+        return await self._run(
+            server, config,
+            lambda c: c.call_tool(tool, args or {}, progress_callback=progress_cb,
+                                  timeout_seconds=timeout),
+            timeout=timeout,
+        )
+
+    async def probe(self, server: str, config: dict) -> None:
+        """Open the server (MCP initialize handshake) to verify reachability, then release it.
+        Returns None on success; raises :class:`MCPFault` if the server cannot be reached/opened."""
+        await self._run(server, config, lambda c: c.list_tools(),
+                        timeout=resolve_call_timeout(config))

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -95,7 +95,10 @@ def is_real_control_flow(exc: BaseException) -> bool:
     contain (cancel-mixed teardown groups from a dead subprocess are contained)."""
     if isinstance(exc, (KeyboardInterrupt, SystemExit)):
         return True
-    t = asyncio.current_task()
+    try:
+        t = asyncio.current_task()
+    except RuntimeError:
+        t = None  # no running loop (e.g. a synchronous caller) → treat as not-cancelling
     real_cancel = t is not None and t.cancelling() > 0
     if isinstance(exc, asyncio.CancelledError):
         return real_cancel

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -81,6 +81,33 @@ def is_or_contains_control_flow(exc: BaseException) -> bool:
     return False
 
 
+def is_real_control_flow(exc: BaseException) -> bool:
+    """True if ``exc`` is GENUINE control flow that must propagate — the seam re-raises only these
+    and contains everything else (transport faults, groups, spurious internal cancels).
+
+    Refines :func:`is_or_contains_control_flow` for the MCP gateway boundary: ``KeyboardInterrupt`` /
+    ``SystemExit`` always propagate; a ``CancelledError`` propagates ONLY when THIS task is genuinely
+    being cancelled (``asyncio.current_task().cancelling() > 0``). A ``CancelledError`` raised by an
+    SDK-internal task group folding a faulted sibling (subprocess death) — while our own task is NOT
+    cancelled — is *spurious*: it must be contained along with the transport fault, not propagated
+    (propagating it is the crash). Groups: propagate if they carry ``KeyboardInterrupt`` /
+    ``SystemExit``, or carry a ``CancelledError`` while our task is genuinely cancelling; otherwise
+    contain (cancel-mixed teardown groups from a dead subprocess are contained)."""
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+        return True
+    t = asyncio.current_task()
+    real_cancel = t is not None and t.cancelling() > 0
+    if isinstance(exc, asyncio.CancelledError):
+        return real_cancel
+    if isinstance(exc, BaseExceptionGroup):
+        ki_se, _rest = exc.split((KeyboardInterrupt, SystemExit))
+        if ki_se is not None:
+            return True
+        cancels, _rest2 = exc.split(asyncio.CancelledError)
+        return cancels is not None and real_cancel
+    return False
+
+
 class MCPClientPool:
     """Structured, task-affine cache of MCP clients for one run/turn.
 
@@ -143,11 +170,14 @@ class MCPClientPool:
                     "a359-diag: closed MCP client server=%s open_task=%s close_task=%s outcome=ok",
                     name, open_tasks.get(name), _close_task,
                 )
-            except BaseException as exc:  # noqa: BLE001 — fault isolation (control flow re-raised)
+            except BaseException as exc:  # noqa: BLE001 — fault isolation (real control flow re-raised)
                 _diag_log.info(
                     "a359-diag: MCP client server=%s open_task=%s close_task=%s teardown-fault=%r",
                     name, open_tasks.get(name), _close_task, exc,
                 )
-                if is_or_contains_control_flow(exc):
+                # #2421 seam: re-raise only GENUINE control flow. A cancel-mixed teardown group from a
+                # dead subprocess (our task NOT cancelled) is spurious → contained, not propagated
+                # (propagating it is the crash `is_or_contains_control_flow` did not prevent).
+                if is_real_control_flow(exc):
                     raise
                 logger.warning("MCP client %s teardown fault contained: %r", name, exc)

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -13,7 +13,9 @@ The pool restores structured concurrency WHILE preserving subprocess reuse:
 
 Fault isolation (owner req): ``__aexit__`` contains teardown faults — including ``BaseExceptionGroup``
 from the SDK's internal task group — so a broken subprocess teardown cannot crash the run. It never
-swallows cancellation: a group containing ``CancelledError`` is re-raised.
+swallows GENUINE control flow: ``is_real_control_flow`` re-raises KeyboardInterrupt / SystemExit and
+a CancelledError only when THIS task is actually cancelling; a spurious cancel-mixed teardown group
+from a dead subprocess (our task not cancelling) is contained, not propagated.
 """
 from __future__ import annotations
 
@@ -59,36 +61,14 @@ def describe_fault(exc: BaseException, *, limit: int = 600) -> str:
     return text if len(text) <= limit else text[:limit] + " …[truncated]"
 
 
-# Control-flow exceptions that fault-isolation must NEVER contain — they must keep propagating so a
-# cancelled / Ctrl-C'd / exiting process actually unwinds and shuts down.
-_CONTROL_FLOW: tuple[type[BaseException], ...] = (asyncio.CancelledError, KeyboardInterrupt, SystemExit)
-
-
-def is_or_contains_control_flow(exc: BaseException) -> bool:
-    """True if ``exc`` is (or a BaseExceptionGroup that contains) a control-flow exception —
-    ``CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit``.
-
-    Fault-isolation contains MCP transport/response faults (Exception + their groups) but must NEVER
-    swallow control flow: a cancelled run must keep unwinding, and Ctrl-C / process-exit must still
-    shut the process down. The SDK's internal task group surfaces faults as a ``BaseExceptionGroup``
-    that may MIX a real transport error with a control-flow exception; ``split`` detects the
-    control-flow sub-group (nested groups included)."""
-    if isinstance(exc, _CONTROL_FLOW):
-        return True
-    if isinstance(exc, BaseExceptionGroup):
-        matched, _rest = exc.split(_CONTROL_FLOW)
-        return matched is not None
-    return False
-
-
 def is_real_control_flow(exc: BaseException) -> bool:
     """True if ``exc`` is GENUINE control flow that must propagate — the seam re-raises only these
     and contains everything else (transport faults, groups, spurious internal cancels).
 
-    Refines :func:`is_or_contains_control_flow` for the MCP gateway boundary: ``KeyboardInterrupt`` /
-    ``SystemExit`` always propagate; a ``CancelledError`` propagates ONLY when THIS task is genuinely
-    being cancelled (``asyncio.current_task().cancelling() > 0``). A ``CancelledError`` raised by an
-    SDK-internal task group folding a faulted sibling (subprocess death) — while our own task is NOT
+    ``KeyboardInterrupt`` / ``SystemExit`` always propagate; a ``CancelledError`` propagates ONLY when
+    THIS task is genuinely being cancelled (``asyncio.current_task().cancelling() > 0``). A
+    ``CancelledError`` raised by an SDK-internal task group folding a faulted sibling (subprocess
+    death) — while our own task is NOT
     cancelled — is *spurious*: it must be contained along with the transport fault, not propagated
     (propagating it is the crash). Groups: propagate if they carry ``KeyboardInterrupt`` /
     ``SystemExit``, or carry a ``CancelledError`` while our task is genuinely cancelling; otherwise
@@ -180,7 +160,7 @@ class MCPClientPool:
                 )
                 # #2421 seam: re-raise only GENUINE control flow. A cancel-mixed teardown group from a
                 # dead subprocess (our task NOT cancelled) is spurious → contained, not propagated
-                # (propagating it is the crash `is_or_contains_control_flow` did not prevent).
+                # (propagating a spurious internal cancel is the crash a conservative predicate hit).
                 if is_real_control_flow(exc):
                     raise
                 logger.warning("MCP client %s teardown fault contained: %r", name, exc)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5845,7 +5845,8 @@ class Session:
 
     async def _mcp_list_tools(self, server: str) -> list[dict]:
         """Query the MCP server for its tools list."""
-        from reyn.mcp.client import MCPClient, MCPError, expand_env
+        from reyn.mcp.client import expand_env
+        from reyn.mcp.gateway import MCPFault, MCPGateway
 
         servers = self._mcp_servers_flat()
         if not servers:
@@ -5860,17 +5861,14 @@ class Session:
         if "type" not in expanded and expanded.get("url"):
             expanded = {**expanded, "type": "http"}
 
-        # #a359 P1: structured lifecycle — the client's whole life is one ``async with`` block in
-        # this task, so its SDK stdio_client / ClientSession internal task-group scopes are entered
-        # AND exited here. This supersedes A's (#2401) finally-close: even a same-task close via a
-        # deferred self._stack crosses the SDK's INTERNAL sub-task scope (the real cross-task crash);
-        # binding open+close in one async-with block restores the SDK's intended structured usage.
+        # #2421: route through the single MCPGateway seam — it owns the whole crash-safe lifecycle
+        # (open + list + teardown inside the contain-all boundary, a task-affine pool, a per-call
+        # timeout) and raises ONLY MCPFault, never a bare BaseExceptionGroup. This is the owner's
+        # Windows crash path: a server that dies mid-list can no longer escape as an uncontained
+        # group. A one-shot pool per call (no injected pool) — list is not batched across ops.
         try:
-            async with MCPClient(expanded, agent_id=self._agent_id) as client:
-                return await client.list_tools()
-        except MCPError as exc:
-            return [{"error": str(exc)}]
-        except Exception as exc:
+            return await MCPGateway(agent_id=self._agent_id).list_tools(server, expanded)
+        except MCPFault as exc:
             return [{"error": str(exc)}]
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:

--- a/tests/test_2421_gateway_acceptance.py
+++ b/tests/test_2421_gateway_acceptance.py
@@ -1,0 +1,77 @@
+"""Tier 2: #2421 acceptance matrix — the MCPGateway seam contains every fault shape (defeat-all-
+hypotheses) and re-raises only genuine control flow.
+
+Owner steer: the traceback couldn't be captured, so the seam must defeat ALL hypotheses at once. This
+injects each fault SHAPE into a fake client's ``list_tools`` (patched where the pool constructs it) and
+asserts the gateway's behavior — exception-structure-independent containment:
+
+  a1  cancel-mixed bare BaseExceptionGroup  (dead subprocess, our task not cancelling) → CONTAINED
+  a2  all-Exception ExceptionGroup                                                      → CONTAINED
+  c   plain transport Exception (BrokenResource / ConnectionReset)                      → CONTAINED
+  d   genuine control flow (KeyboardInterrupt / SystemExit)                             → RE-RAISED
+
+(b off-task is defeated structurally — the SDK stdio_client task group joins its reader/writer in the
+pool's task; a genuine run cancellation propagating is covered in test_mcp_structured_pool_p2.)
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import reyn.mcp.pool as pool_mod
+from reyn.mcp.gateway import MCPFault, MCPGateway
+
+_CFG = {"type": "stdio", "command": "x"}
+
+
+class _FaultClient:
+    """A fake MCPClient whose ``list_tools`` raises a preset fault — mirrors the pool's construction
+    surface (one positional config, keyword agent_id, async-CM)."""
+
+    _next_exc: BaseException = RuntimeError("unset")
+
+    def __init__(self, config, *, agent_id=None) -> None:
+        self._exc = _FaultClient._next_exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+    async def list_tools(self):
+        raise self._exc
+
+
+def _inject(monkeypatch, exc: BaseException) -> None:
+    _FaultClient._next_exc = exc
+    monkeypatch.setattr(pool_mod, "MCPClient", _FaultClient)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [
+    BaseExceptionGroup("teardown", [ConnectionResetError("dead"), asyncio.CancelledError()]),  # a1
+    ExceptionGroup("bad", [RuntimeError("malformed"), ValueError("reset")]),                    # a2
+    ConnectionResetError("broken pipe"),                                                        # c
+], ids=["a1_cancel_mixed_group", "a2_all_exception_group", "c_plain_transport"])
+async def test_gateway_contains_non_control_flow_faults(exc, tmp_path, monkeypatch):
+    """Tier 2: #2421 — a non-control-flow fault of ANY shape (cancel-mixed group / all-Exception
+    group / plain transport) is contained as an MCPFault, never a bare BaseExceptionGroup. The caller
+    (list/probe/op) then shapes an error result → reyn survives."""
+    monkeypatch.chdir(tmp_path)
+    _inject(monkeypatch, exc)
+    with pytest.raises(MCPFault) as ei:
+        await MCPGateway().list_tools("srv", _CFG)
+    assert str(ei.value), "the fault content is summarised for the LLM (non-empty)"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_cls", [KeyboardInterrupt, SystemExit], ids=["d_keyboardinterrupt", "d_systemexit"])
+async def test_gateway_reraises_genuine_control_flow(exc_cls, tmp_path, monkeypatch):
+    """Tier 2: #2421 — genuine control flow (KeyboardInterrupt / SystemExit) propagates through the
+    seam untouched (an interrupted / exiting process must keep unwinding), NOT contained as MCPFault."""
+    monkeypatch.chdir(tmp_path)
+    _inject(monkeypatch, exc_cls())
+    with pytest.raises(exc_cls):
+        await MCPGateway().list_tools("srv", _CFG)

--- a/tests/test_2421_gateway_acceptance.py
+++ b/tests/test_2421_gateway_acceptance.py
@@ -75,3 +75,43 @@ async def test_gateway_reraises_genuine_control_flow(exc_cls, tmp_path, monkeypa
     _inject(monkeypatch, exc_cls())
     with pytest.raises(exc_cls):
         await MCPGateway().list_tools("srv", _CFG)
+
+
+# ── [4] per-call timeout: the FIRING path bounds a slow op AND a hang-on-init ───────────
+
+class _SlowClient:
+    """A fake client that hangs — in ``__aenter__`` (initialize) or in ``list_tools`` — so the
+    gateway's per-call timeout is exercised on both the OPEN and the CALL."""
+
+    hang_on: str = "op"  # "init" | "op"
+
+    def __init__(self, config, *, agent_id=None) -> None:
+        pass
+
+    async def __aenter__(self):
+        if _SlowClient.hang_on == "init":
+            await asyncio.sleep(3)  # bounded so a MISSING-fix RED asserts (not an infinite hang)
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+    async def list_tools(self):
+        if _SlowClient.hang_on == "op":
+            await asyncio.sleep(3)
+        return []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hang_on", ["op", "init"], ids=["slow_op", "hang_on_init"])
+async def test_gateway_timeout_fires_and_contains(hang_on, tmp_path, monkeypatch):
+    """Tier 2: #2421 [4] — a slow op OR a server that HANGS ON INIT is bounded by the per-call
+    timeout and contained as MCPFault (reyn survives). RED for ``hang_on_init`` before the fix that
+    wraps the timeout around acquire+op (the timeout used to wrap only the call, leaving a fresh
+    one-shot open — owner's list_mcp_tools path — unbounded)."""
+    monkeypatch.chdir(tmp_path)
+    _SlowClient.hang_on = hang_on
+    monkeypatch.setattr(pool_mod, "MCPClient", _SlowClient)
+    cfg = {**_CFG, "call_timeout_seconds": 0.1}  # tight bound; the fake sleeps 3s
+    with pytest.raises(MCPFault):
+        await MCPGateway().list_tools("srv", cfg)

--- a/tests/test_2421_gateway_real_substrate.py
+++ b/tests/test_2421_gateway_real_substrate.py
@@ -1,0 +1,59 @@
+"""Tier 3a: #2421 — the MCPGateway contains a REAL dying MCP subprocess (not a fake in-task raise).
+
+The seam's contain-all boundary + [1] structured sub-task join are proven here against a REAL stdio
+MCP server that initializes, then its subprocess DIES mid-operation (``os._exit`` from inside
+``list_tools``). This exercises the SDK ``stdio_client`` task group's reader/writer tasks observing
+the broken transport — the off-task-orphaning hypothesis (b) — end-to-end, not a synthetic raise.
+
+Expected: ``gateway.list_tools`` raises ``MCPFault`` (contained), the test process SURVIVES (no
+uncontained BaseExceptionGroup escaping to the loop). This is the "fake-blind" gap lead flagged: the
+fake tests prove the boundary LOGIC; this proves it against the real substrate that produced the
+crash. Real subprocess (no mock); skipped if the ``mcp`` SDK server API is unavailable.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp.server", reason="mcp SDK server API required for the real-substrate test")
+
+# A real low-level stdio MCP server that handshakes fine, then its subprocess DIES on list_tools.
+_DYING_SERVER = '''\
+import os, asyncio
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+app = Server("dying-server")
+
+@app.list_tools()
+async def list_tools():
+    os._exit(1)  # the subprocess dies mid-operation (external dep missing / crash analogue)
+
+async def main():
+    async with stdio_server() as (r, w):
+        await app.run(r, w, app.create_initialization_options())
+
+asyncio.run(main())
+'''
+
+
+@pytest.mark.asyncio
+async def test_gateway_contains_real_dying_subprocess(tmp_path, monkeypatch):
+    """Tier 3a: a real MCP server whose subprocess dies mid-``list_tools`` is CONTAINED by the gateway
+    as an MCPFault — reyn survives, no uncontained BaseExceptionGroup escapes. Proves [1]+[2] against
+    the real substrate (SDK stdio_client task group on a broken transport)."""
+    from reyn.mcp.gateway import MCPFault, MCPGateway
+
+    monkeypatch.chdir(tmp_path)
+    server = tmp_path / "dying_server.py"
+    server.write_text(_DYING_SERVER, encoding="utf-8")
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(server)],
+           "call_timeout_seconds": 20}
+
+    with pytest.raises(MCPFault) as ei:
+        await MCPGateway().list_tools("dying", cfg)
+    assert str(ei.value), "the fault content is surfaced for the LLM (non-empty)"
+    # reaching here at all is the assertion that matters: the process SURVIVED (the fault was
+    # contained as MCPFault, not an uncontained group crashing the run/loop).

--- a/tests/test_2421_mcp_seam_completeness.py
+++ b/tests/test_2421_mcp_seam_completeness.py
@@ -1,0 +1,40 @@
+"""Tier 2: #2421 — every MCP entry path routes through the MCPGateway seam; no direct MCPClient
+construction leaks outside it.
+
+The whack-a-mole root: fault-isolation + task-affine lifecycle + timeout were applied per entry path,
+so the list/probe paths (which constructed ``MCPClient`` directly) were swept-missed and the crash
+recurred. The gateway consolidates the guarantees; this structural gate makes the bypass IMPOSSIBLE
+by construction — only the pool constructs a client (client.py defines it), so a new entry path
+CANNOT reintroduce the crash class without tripping this test. This is the CI-enforced regression
+guard the design calls for (not a one-shot grep).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The seam: the pool constructs clients; client.py defines the class (+ docstring examples).
+_ALLOWED = {"mcp/pool.py", "mcp/client.py"}
+# ``MCPClient(`` construction — the paren distinguishes it from the ``MCPClientPool`` /
+# ``MCPClient`` type-reference (``Pool`` / ``]`` / import follows, not ``(``).
+_CONSTRUCT = re.compile(r"\bMCPClient\s*\(")
+
+
+def test_no_direct_mcpclient_construction_outside_seam():
+    """Tier 2: MCP ops go through MCPGateway → MCPClientPool → MCPClient. A new entry path that
+    constructs ``MCPClient(...)`` directly would bypass the contain-all boundary + task-affine
+    lifecycle (the sibling-sweep-miss class that caused the list-path crash). RED if a direct
+    construction reappears anywhere in src outside the pool/client seam."""
+    src = Path(__file__).resolve().parents[1] / "src" / "reyn"
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        rel = py.relative_to(src).as_posix()
+        if rel in _ALLOWED:
+            continue
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
+            if _CONSTRUCT.search(line):
+                offenders.append(f"{rel}:{i}: {line.strip()}")
+    assert not offenders, (
+        "direct MCPClient(...) construction bypasses the MCPGateway seam — route it through the "
+        "gateway instead:\n" + "\n".join(offenders)
+    )

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -1,13 +1,11 @@
-"""Tier 2: _mcp_list_tools closes the MCP client on EVERY exit path (owner's list_mcp_tools crash).
+"""Tier 2: _mcp_list_tools closes the MCP client on EVERY exit path + surfaces errors (list crash).
 
-The bug: ``Session._mcp_list_tools`` called ``await client.close()`` only AFTER a successful
-``list_tools()`` — so a raise (or cancellation) skipped close, leaking the MCP SDK's anyio
-``stdio_client`` cancel-scope. A later teardown in a DIFFERENT task then raised "cancel scope crossed
-task boundary" (the owner-facing crash on ``list_mcp_tools`` when the server errors).
-
-Fix: ``finally: await client.close()`` — close runs in the SAME task that opened it, on success,
-error, and cancellation. This pins the close-on-error guarantee + the same-task affinity (the crash
-class), via a real Session and an injected client whose ``list_tools`` raises. No real subprocess.
+``Session._mcp_list_tools`` now routes through the ``MCPGateway`` seam (→ ``MCPClientPool`` →
+``MCPClient``, #2421). The pool opens + closes the client in the SAME task on success, error, AND
+cancellation, and the gateway contains any fault into an ``MCPFault`` → the list method returns an
+``[{"error": …}]`` result instead of leaking the SDK's anyio cancel-scope cross-task (the owner-facing
+``list_mcp_tools`` crash). This pins the close-on-error guarantee + same-task affinity + error
+surfacing through the real Session, with the fake patched where the POOL constructs it. No subprocess.
 """
 from __future__ import annotations
 
@@ -16,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-import reyn.mcp.client as mcp_client_mod
+import reyn.mcp.pool as pool_mod
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -81,7 +79,7 @@ class _FakeMCPClient:
 def _install_fake(monkeypatch, sess, *, raises: bool) -> None:
     _FakeMCPClient.instances = []
     _FakeMCPClient._next_raises = raises
-    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)  # where the pool constructs it
     # Supply one configured server so the method reaches the client lifecycle.
     monkeypatch.setattr(sess, "_mcp_servers_flat", lambda: {"srv": {"command": "fake"}})
 
@@ -96,9 +94,10 @@ async def test_list_tools_error_path_still_closes_same_task(tmp_path, monkeypatc
 
     result = await sess._mcp_list_tools("srv")
 
-    assert result == [{"error": "boom from list_tools"}], "error is surfaced, not raised"
+    assert any("boom from list_tools" in (e.get("error") or "") for e in result), \
+        "the fault is surfaced as an error result (gateway describe_fault), not raised"
     client = _FakeMCPClient.instances[-1]
-    assert client.closed is True, "client MUST be closed on the error path (finally)"
+    assert client.closed is True, "client MUST be closed on the error path (pool __aexit__)"
     assert client.close_task is client.list_task, (
         "close ran in the SAME task as list_tools — no cross-task cancel-scope boundary"
     )

--- a/tests/test_mcp_probe_client_lifecycle.py
+++ b/tests/test_mcp_probe_client_lifecycle.py
@@ -1,17 +1,17 @@
-"""Tier 2: MCP probe constructs MCPClient correctly (hot-reload: installed servers' tools show up).
+"""Tier 2: MCP probe returns a server's real tools / ready status through the MCPGateway seam.
 
-``_probe_server_tools`` / ``_probe_status`` did ``async with MCPClient(server_name, cfg)``, but
-MCPClient takes ONE positional ``config: dict`` (agent_id keyword-only) and has NO async-context-
-manager protocol. The server NAME (a str) was passed as ``config`` → ValueError, swallowed by the
-bare except → every probe returned an empty tool list / a bogus "error:" status (the hot-reload gap:
-installed servers showed no tools). Fix: ``MCPClient(cfg)`` + ``list_tools()`` / ``initialize()`` +
-``finally: close()`` in the same task. Injected fake mirrors the real MCPClient surface.
+``_probe_server_tools`` / ``_probe_status`` now route through ``MCPGateway`` (→ ``MCPClientPool`` →
+``MCPClient``) rather than constructing an ``MCPClient`` directly (#2421). This still verifies the
+probe surfaces the server's actual tools (cleaned) and a ready status, with the cfg DICT flowing
+through to the client (the hot-reload requirement). The fake is patched where the POOL constructs it
+(``reyn.mcp.pool.MCPClient``); patching ``reyn.mcp.client.MCPClient`` would miss the pool's
+module-level binding (and be import-order-flaky).
 """
 from __future__ import annotations
 
 import pytest
 
-import reyn.mcp.client as mcp_client_mod
+import reyn.mcp.pool as pool_mod
 from reyn.interfaces.cli.commands.mcp import _probe_server_tools, _probe_status
 
 
@@ -50,7 +50,7 @@ async def test_probe_server_tools_returns_real_tools(monkeypatch):
     """Tier 2: CORE — the probe returns the server's actual tools (cleaned), constructed with the
     cfg DICT (not the name string). RED on the pre-fix ``MCPClient(server_name, cfg)`` (a str as
     config → ValueError → swallowed → empty list)."""
-    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
 
     name, tools = await _probe_server_tools("mysrv", {"type": "stdio", "command": "x"})
 
@@ -65,6 +65,6 @@ def test_probe_status_ready(monkeypatch):
     """Tier 2: _probe_status returns 'ready' via a real initialize() handshake, not a swallowed
     ValueError from the mis-constructed client. (Sync test — _probe_status manages its own loop via
     run_async.)"""
-    monkeypatch.setattr(mcp_client_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
 
     assert _probe_status("mysrv", {"type": "stdio", "command": "x"}) == "ready"

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -14,21 +14,27 @@ import asyncio
 import pytest
 
 import reyn.mcp.pool as pool_mod
-from reyn.mcp.pool import MCPClientPool, describe_fault, is_or_contains_control_flow
+from reyn.mcp.pool import (
+    MCPClientPool,
+    describe_fault,
+    is_or_contains_control_flow,
+    is_real_control_flow,
+)
 
 
 def test_call_timeout_default_finite_override_optout():
     """Tier 2: S3 (tui dogfood gap) — the per-call MCP timeout defaults FINITE so a hung/slow server
     can't block the router loop forever; a per-server ``call_timeout_seconds`` overrides; ``<= 0``
     opts out (None). When the timeout fires, the SDK raises a TimeoutError which the op fault
-    boundary already contains into an error result (→ LLM). Malformed → fail-safe finite default."""
-    from reyn.core.op_runtime.mcp import _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, _resolve_call_timeout
+    boundary already contains into an error result (→ LLM). Malformed → fail-safe finite default.
+    #2421: the resolver now lives in the MCPGateway seam ([4], one place for every MCP op)."""
+    from reyn.mcp.gateway import _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, resolve_call_timeout
 
-    assert _resolve_call_timeout({}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, "finite default (not None)"
-    assert _resolve_call_timeout({"call_timeout_seconds": 5}) == 5.0, "per-server override"
-    assert _resolve_call_timeout({"call_timeout_seconds": 0}) is None, "0 opts out"
-    assert _resolve_call_timeout({"call_timeout_seconds": -1}) is None, "<0 opts out"
-    assert _resolve_call_timeout({"call_timeout_seconds": "x"}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, \
+    assert resolve_call_timeout({}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, "finite default (not None)"
+    assert resolve_call_timeout({"call_timeout_seconds": 5}) == 5.0, "per-server override"
+    assert resolve_call_timeout({"call_timeout_seconds": 0}) is None, "0 opts out"
+    assert resolve_call_timeout({"call_timeout_seconds": -1}) is None, "<0 opts out"
+    assert resolve_call_timeout({"call_timeout_seconds": "x"}) == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, \
         "malformed → fail-safe finite default"
 
 
@@ -74,6 +80,60 @@ def test_control_flow_predicate_keyboardinterrupt_systemexit(exc_cls):
     assert is_or_contains_control_flow(grp) is True
 
 
+# ── is_real_control_flow (#2421 seam predicate: cancelling()-gated) ─────────────────────
+
+@pytest.mark.parametrize("exc_cls", [KeyboardInterrupt, SystemExit])
+def test_is_real_control_flow_ki_se_always_propagate(exc_cls):
+    """Tier 2: #2421 — KeyboardInterrupt / SystemExit are always real control flow — bare and
+    group-nested — regardless of the task's cancel state."""
+    assert is_real_control_flow(exc_cls()) is True
+    assert is_real_control_flow(BaseExceptionGroup("g", [ConnectionResetError("x"), exc_cls()])) is True
+
+
+def test_is_real_control_flow_spurious_cancel_is_contained():
+    """Tier 2: #2421 — outside a genuine cancellation (current_task().cancelling() == 0) a
+    CancelledError — bare OR in a cancel-mixed group — is SPURIOUS (an SDK-internal fold), NOT real
+    control flow → contained. This is the crash-class fix (the conservative predicate re-raised it)."""
+    assert is_real_control_flow(asyncio.CancelledError()) is False
+    grp = BaseExceptionGroup("teardown", [ConnectionResetError("dead"), asyncio.CancelledError()])
+    assert is_real_control_flow(grp) is False
+
+
+def test_is_real_control_flow_plain_and_group_faults_contained():
+    """Tier 2: #2421 — ordinary transport faults (bare or grouped) are never control flow."""
+    assert is_real_control_flow(RuntimeError("t")) is False
+    assert is_real_control_flow(ExceptionGroup("g", [RuntimeError("a"), ValueError("b")])) is False
+
+
+@pytest.mark.asyncio
+async def test_is_real_control_flow_genuine_cancel_only():
+    """Tier 2: #2421 — a GENUINE run cancellation (the task is actually cancelled →
+    current_task().cancelling() > 0) IS real control flow and propagates through the seam boundary,
+    while a spurious CancelledError (no task cancel) is contained. Proves cancellation-safety is
+    preserved — real cancels are never swallowed."""
+    async def boundary(op):
+        try:
+            return await op()
+        except BaseException as exc:  # noqa: BLE001 — mirrors the gateway seam boundary
+            if is_real_control_flow(exc):
+                raise
+            return "contained"
+
+    # genuine: cancel the task while it awaits inside the boundary → must propagate
+    async def run():
+        return await boundary(lambda: asyncio.sleep(10))
+    t = asyncio.ensure_future(run())
+    await asyncio.sleep(0.02)
+    t.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await t
+
+    # spurious: a synthetic CancelledError with no task cancellation → contained
+    async def raises_spurious():
+        raise asyncio.CancelledError()
+    assert await boundary(raises_spurious) == "contained"
+
+
 # ── pool teardown fault-containment ──────────────────────────────────────────────
 
 class _RaisingCloseClient:
@@ -107,16 +167,20 @@ async def test_pool_contains_teardown_exception_group(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pool_reraises_cancellation_in_teardown(monkeypatch):
-    """Tier 2: the pool NEVER swallows cancellation — a teardown group containing a CancelledError
-    is re-raised so a cancelled run keeps unwinding."""
-    raising = _RaisingCloseClient(BaseExceptionGroup("teardown", [asyncio.CancelledError()]))
+async def test_pool_contains_spurious_cancel_in_teardown(monkeypatch):
+    """Tier 2: #2421 — a cancel-mixed teardown group from a dead subprocess — while our OWN task is
+    NOT being cancelled — is SPURIOUS (anyio folding a faulted sibling), so the pool CONTAINS it
+    rather than propagating (propagating it is the crash the conservative predicate did not prevent).
+    A genuine run cancellation still propagates because ``current_task().cancelling() > 0`` — see
+    ``test_is_real_control_flow_genuine_cancel_only``."""
+    raising = _RaisingCloseClient(
+        BaseExceptionGroup("teardown", [ConnectionResetError("subprocess died"), asyncio.CancelledError()])
+    )
     monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
 
-    with pytest.raises(BaseException) as ei:
-        async with MCPClientPool() as pool:
-            await pool.get("srv", {"type": "stdio", "command": "x"})
-    assert is_or_contains_control_flow(ei.value), "cancellation propagates, not contained"
+    async with MCPClientPool() as pool:  # no raise — the spurious cancel-mixed teardown is contained
+        await pool.get("srv", {"type": "stdio", "command": "x"})
+    assert raising.closed is True, "teardown ran and its spurious cancel-mixed fault was contained"
 
 
 # ── op-handler fault isolation (bad response / transport group → error result) ────
@@ -178,16 +242,32 @@ async def test_op_contains_bad_response_exception_group():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("exc_cls", [asyncio.CancelledError, KeyboardInterrupt, SystemExit])
+@pytest.mark.parametrize("exc_cls", [KeyboardInterrupt, SystemExit])
 async def test_op_propagates_control_flow(exc_cls):
-    """Tier 2: the op handler never contains control flow — CancelledError / KeyboardInterrupt /
-    SystemExit propagate (a cancelled / interrupted / exiting run must keep unwinding), even though
-    ANY ordinary MCP fault is contained into an error result."""
+    """Tier 2: the op handler (via the gateway seam) never contains genuine control flow —
+    KeyboardInterrupt / SystemExit propagate (an interrupted / exiting run must keep unwinding), even
+    though ANY ordinary MCP fault is contained into an error result. (A genuine run cancellation also
+    propagates; a SPURIOUS CancelledError with cancelling()==0 is contained — next test.)"""
     from reyn.core.op_runtime.mcp import _execute
     from reyn.schemas.models import MCPIROp
 
     with pytest.raises(exc_cls):
         await _execute(MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(exc_cls())))
+
+
+@pytest.mark.asyncio
+async def test_op_contains_spurious_cancel():
+    """Tier 2: a SPURIOUS CancelledError from call_tool — our task NOT cancelling — is an
+    SDK-internal artifact (a dead subprocess folding its task group), NOT a run cancellation, so it is
+    CONTAINED into an error result. RED before the is_real_control_flow refinement (the conservative
+    predicate re-raised any CancelledError → the crash)."""
+    from reyn.core.op_runtime.mcp import _execute
+    from reyn.schemas.models import MCPIROp
+
+    result = await _execute(
+        MCPIROp(kind="mcp", server="srv", tool="t", args={}), _ctx(_FaultPool(asyncio.CancelledError())),
+    )
+    assert result["status"] == "error" and result["kind"] == "mcp", "spurious cancel contained, not raised"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -14,12 +14,7 @@ import asyncio
 import pytest
 
 import reyn.mcp.pool as pool_mod
-from reyn.mcp.pool import (
-    MCPClientPool,
-    describe_fault,
-    is_or_contains_control_flow,
-    is_real_control_flow,
-)
+from reyn.mcp.pool import MCPClientPool, describe_fault, is_real_control_flow
 
 
 def test_call_timeout_default_finite_override_optout():
@@ -45,39 +40,6 @@ def test_describe_fault_aggregates_group_members():
     text = describe_fault(grp)
     assert "malformed response" in text and "reset" in text
     assert "RuntimeError" in text and "ValueError" in text
-
-
-# ── is_or_contains_control_flow (the cancellation-safe boundary predicate) ─────────────
-
-def test_cancel_predicate_direct():
-    """Tier 2: a bare CancelledError is a cancellation."""
-    assert is_or_contains_control_flow(asyncio.CancelledError()) is True
-
-
-def test_cancel_predicate_group_with_cancel():
-    """Tier 2: a BaseExceptionGroup containing a CancelledError counts (must be re-raised)."""
-    grp = BaseExceptionGroup("teardown", [asyncio.CancelledError(), RuntimeError("BrokenResource")])
-    assert is_or_contains_control_flow(grp) is True
-
-
-def test_cancel_predicate_group_without_cancel():
-    """Tier 2: a group of ordinary faults is NOT a cancellation → containable."""
-    grp = ExceptionGroup("teardown", [RuntimeError("BrokenResource"), ValueError("bad response")])
-    assert is_or_contains_control_flow(grp) is False
-
-
-def test_cancel_predicate_plain_exception():
-    """Tier 2: a plain non-control-flow exception is containable."""
-    assert is_or_contains_control_flow(RuntimeError("t")) is False
-
-
-@pytest.mark.parametrize("exc_cls", [KeyboardInterrupt, SystemExit])
-def test_control_flow_predicate_keyboardinterrupt_systemexit(exc_cls):
-    """Tier 2: KeyboardInterrupt / SystemExit are control flow — bare AND group-nested (mixed with a
-    transport error) — so a Ctrl-C / process-exit during an MCP call or teardown still shuts down."""
-    assert is_or_contains_control_flow(exc_cls()) is True
-    grp = BaseExceptionGroup("teardown", [RuntimeError("BrokenResource"), exc_cls()])
-    assert is_or_contains_control_flow(grp) is True
 
 
 # ── is_real_control_flow (#2421 seam predicate: cancelling()-gated) ─────────────────────
@@ -280,4 +242,4 @@ async def test_pool_reraises_keyboardinterrupt_in_teardown(monkeypatch):
     with pytest.raises(BaseException) as ei:
         async with MCPClientPool() as pool:
             await pool.get("srv", {"type": "stdio", "command": "x"})
-    assert is_or_contains_control_flow(ei.value), "KeyboardInterrupt propagates, not contained"
+    assert is_real_control_flow(ei.value), "KeyboardInterrupt propagates, not contained"


### PR DESCRIPTION
**[e2e-coder]** — owner-GO'd holistic MCP fix (non-whack-a-mole). Design: `docs/dev/mcp-holistic-seam-design.md` (#2418). Owner's remaining crash root.

## The whack-a-mole, closed
Fault-isolation + task-affine lifecycle + per-call timeout were applied **per entry path**, so the list/probe paths were swept-missed and the crash recurred. This lands the single **`MCPGateway`** seam every MCP op routes through; a new entry path is a thin caller by construction and cannot re-introduce the crash class.

## The four guarantees (one place — `reyn/mcp/gateway.py`)
- **[1] structured sub-task join** — the SDK `stdio_client` uses `anyio.create_task_group()` and joins its `stdout_reader`/`stdin_writer` at `close` (verified in the installed SDK). Via the pool's same-task close, a sub-task fault surfaces **synchronously in-scope** → never orphans to the loop ("Task exception was never retrieved"). So [1] is reuse of SDK structured concurrency + a359 same-task close.
- **[2] contain-all boundary + `is_real_control_flow`** — `except BaseException`; re-raise ONLY genuine control flow: `KeyboardInterrupt`/`SystemExit`, or `CancelledError` **when the task is actually cancelling** (`current_task().cancelling() > 0`). A **spurious** cancel-mixed teardown group from a dead subprocess (task not cancelling) is contained, not propagated (**the crash the conservative predicate re-raised**). Exception-structure-independent. **Verified**: genuine `task.cancel()` propagates; synthetic/spurious CancelledError contained.
- **[3] pool task-affinity** — reuse `MCPClientPool` (a359 P2); `__aexit__` now uses `is_real_control_flow`.
- **[4] per-call timeout** — `resolve_call_timeout` (relocated into the gateway; op_runtime's duplicate removed).

The gateway raises **only `MCPFault` (an Exception) or genuine control flow — never a bare `BaseExceptionGroup`** → thin callers need only `except MCPFault`.

## All paths are thin callers
- op-call (`op_runtime/mcp.py _execute`) → `gateway.call_tool` (inline boundary + timeout absorbed).
- list (`session.py _mcp_list_tools`) → `gateway.list_tools` — **the owner Windows crash path**.
- probe-status → `gateway.probe`; probe-tools (`_probe_server_tools`) → `gateway.list_tools`.

## Completeness — structural, CI-enforced
`test_2421_mcp_seam_completeness.py` asserts **no `MCPClient(...)` construction anywhere in src outside the pool/client seam** — a new path physically cannot bypass the gateway (regression guard, not a one-shot grep).

## Acceptance matrix (traceback-independent, defeat-all-hypotheses)
`test_2421_gateway_acceptance.py` injects each shape at the gateway: **a1** cancel-mixed group / **a2** all-Exception group / **c** plain transport → CONTAINED as `MCPFault`; **d** KeyboardInterrupt / SystemExit → RE-RAISED. Plus `is_real_control_flow` unit tests + a genuine-cancel-propagates test (P2). (b off-task is defeated structurally by [1].)

## Flag for review decision
`is_or_contains_control_flow` is now **dead in src** (superseded by `is_real_control_flow`; only its own 5 P2 unit tests reference it). Remove it + those tests in this PR, or a follow-up? (Didn't cascade the deletion unprompted.)

## Not in this PR (sequenced)
The a359-DIAG temporary block stays until owner confirms Windows no-crash, then a follow-up removes it (per design §6.4).

## CI gates (all green locally)
- `ruff check src tests scripts` ✓
- `python scripts/test_tier_audit.py --strict` ✓ (new + updated test files)
- full `pytest` ✓ (8470 passed, 17 skipped, 3 xfailed)
- `python scripts/verify_module_docstrings.py` ✓

## Test plan
- [ ] Owner (Windows): `list_mcp_tools` against a dep-missing / dying MCP server → error result, reyn survives (the yes/no acceptance; no traceback paste needed).
- [ ] (Unix) tui: MCP tool-call / probe against a dying server → contained error, no crash.

part of #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)