### PR TITLE
fix(#2269): ConsoleChatRenderer working indicator — on_chat_event + bottom_toolbar

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -113,6 +113,20 @@ class ConsoleChatRenderer(ChatRenderer):
         # Tracks whether the last write left a single-line transient on screen
         # that the next write should overwrite.
         self._transient_active = False
+        self._thinking = False  # driven by on_chat_event
+
+    def on_chat_event(self, event) -> None:
+        etype = event.type
+        if etype == "turn_started":
+            self._thinking = True
+        elif etype in ("turn_settled", "turn_completed", "turn_cancelled"):
+            self._thinking = False
+
+    def bottom_toolbar(self):
+        if not self._thinking:
+            return None
+        frame = _SPINNER[int(time.monotonic() * 8) % len(_SPINNER)]
+        return f" {frame} working…"
 
     def _write(self, s: str) -> None:
         # Bypass patch_stdout's proxy: it renders ANSI bytes (including cursor

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -218,3 +218,53 @@ def test_plain_factory_returns_console_renderer() -> None:
     r = make_chat_renderer()
     assert isinstance(r, ConsoleChatRenderer)
     assert isinstance(r, ChatRenderer)
+
+
+# ---------------------------------------------------------------------------
+# ConsoleChatRenderer working indicator (#2269 fix)
+# ---------------------------------------------------------------------------
+
+
+class _Ev:
+    def __init__(self, type_: str) -> None:
+        self.type = type_
+
+
+def test_console_renderer_bottom_toolbar_none_at_init() -> None:
+    """Tier 2: bottom_toolbar() returns None when no turn is in flight (default state)."""
+    r = ConsoleChatRenderer()
+    assert r.bottom_toolbar() is None
+
+
+def test_console_renderer_bottom_toolbar_non_none_after_turn_started() -> None:
+    """Tier 2: on_chat_event(turn_started) → bottom_toolbar() returns a non-None
+    working indicator string (the in-flight cue #2268 removed)."""
+    r = ConsoleChatRenderer()
+    r.on_chat_event(_Ev("turn_started"))
+    result = r.bottom_toolbar()
+    assert result is not None
+    assert "working" in result
+
+
+def test_console_renderer_bottom_toolbar_clears_on_turn_settled() -> None:
+    """Tier 2: on_chat_event(turn_settled) after turn_started → bottom_toolbar() is None."""
+    r = ConsoleChatRenderer()
+    r.on_chat_event(_Ev("turn_started"))
+    r.on_chat_event(_Ev("turn_settled"))
+    assert r.bottom_toolbar() is None
+
+
+def test_console_renderer_bottom_toolbar_clears_on_turn_completed() -> None:
+    """Tier 2: on_chat_event(turn_completed) after turn_started → bottom_toolbar() is None."""
+    r = ConsoleChatRenderer()
+    r.on_chat_event(_Ev("turn_started"))
+    r.on_chat_event(_Ev("turn_completed"))
+    assert r.bottom_toolbar() is None
+
+
+def test_console_renderer_bottom_toolbar_clears_on_turn_cancelled() -> None:
+    """Tier 2: on_chat_event(turn_cancelled) after turn_started → bottom_toolbar() is None."""
+    r = ConsoleChatRenderer()
+    r.on_chat_event(_Ev("turn_started"))
+    r.on_chat_event(_Ev("turn_cancelled"))
+    assert r.bottom_toolbar() is None


### PR DESCRIPTION
**[tui-coder]** — fixes #2269

## Summary

- `ConsoleChatRenderer` (`--cui` / plain console path) lost its in-flight cue when #2268 removed the per-turn `thinking…` status emission from `session.py`
- The `thinking…` status was the plain renderer's ONLY working indicator; the inline CUI was unaffected (it has its own event-driven spinner)
- Fix: override `on_chat_event` and `bottom_toolbar` on `ConsoleChatRenderer` using the same `turn_started → turn_settled/completed/cancelled` pattern as `InlineChatRenderer`
- `bottom_toolbar` returns a braille-spinner `working…` string while a turn is in flight; prompt_toolkit's `refresh_interval=0.1` drives the animation — no direct stdout writes needed

## Test plan

- [x] Tier 2: `bottom_toolbar()` returns None at init; non-None after `turn_started`; None after `turn_settled`, `turn_completed`, `turn_cancelled` (5 tests added to `test_inline_renderer_cutover.py`)
- [x] 4 CI gates: `ruff check` ✓ · `test_tier_audit.py --strict` ✓ · `pytest` 8454 passed ✓ · `verify_module_docstrings.py` ✓
- [x] (skipped — live --cui test requires a TTY + running LLM; covered by the Tier 2 on_chat_event/bottom_toolbar contract)

**Tier self-check**: tests are Tier 2 (public surface `bottom_toolbar()` asserts; no private `_thinking` access; no mocks).

part of #2205