### PR TITLE
fix(#2243): suppress run_id_short prefix on intervention messages

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -437,7 +437,15 @@ def format_inline_message(msg: OutboxMessage):
     gutter, gutter_style, body_style = line
     # A provenance prefix ([skill#id]) is kept inline (rare for agent replies); it
     # renders as literal text inside the agent markdown body.
-    body_text = f"{_meta_prefix(meta)}{msg.text}"
+    # Intervention is user-facing: suppress the cryptic run_id_short hash — the
+    # user doesn't need disambiguation for a prompt that has one active caller.
+    # skill_name context (e.g. "[skill_builder] ") is still shown if present.
+    if kind == "intervention":
+        skill = meta.get("skill_name")
+        _pfx = f"[{skill}] " if skill else ""
+    else:
+        _pfx = _meta_prefix(meta)
+    body_text = f"{_pfx}{msg.text}"
     if kind == "user":
         # The user's own submitted line: echoed into scrollback (the inline input
         # clears on submit) AND given a faint background block so it reads as a

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -130,6 +130,26 @@ def test_intervention_keeps_question_text() -> None:
     assert "Which file?" in out
 
 
+def test_intervention_suppresses_run_id_short_prefix() -> None:
+    """Tier 2: intervention drops the [#short] run-id hash — it is cryptic noise on
+    an interactive user-facing prompt where disambiguation is unnecessary (#2243)."""
+    out = _plain("intervention", "Confirm?", meta={"run_id_short": "ab12"})
+    assert "#ab12" not in out
+    assert "Confirm?" in out
+
+
+def test_intervention_keeps_skill_name_prefix_when_present() -> None:
+    """Tier 2: skill_name context is retained on interventions so the user sees which
+    skill is asking — only run_id_short (the cryptic hash) is suppressed."""
+    out = _plain(
+        "intervention", "Confirm?",
+        meta={"skill_name": "skill_builder", "run_id_short": "ab12"},
+    )
+    assert "skill_builder" in out
+    assert "#ab12" not in out
+    assert "Confirm?" in out
+
+
 def test_kinds_use_distinct_markers() -> None:
     """Tier 2: message kinds carry distinct glyphs so the eye separates them — the
     assistant ⏺ is not reused for an intervention (◆), a finished skill (✓), or a


### PR DESCRIPTION
**[tui-coder]** — fixes #2243

## Summary

- Intervention messages (cost-warn confirm, ask_user, permission prompts) showed a cryptic `[#ault]`-style run-id hash prefix — readable as `[#{run_id_short}]` via `_meta_prefix()`
- Useful for multi-run/multi-agent disambiguation, but noise on a user-facing interactive prompt where only one caller is active
- Fix in `format_inline_message`: for `kind=intervention`, build prefix from `skill_name` only (suppresses `run_id_short`), so `[skill_builder]` is still shown but `[#ault]` is gone

## Test plan

- [x] Tier 2: `test_intervention_suppresses_run_id_short_prefix` — `[#ab12]` not in output when `run_id_short=ab12`
- [x] Tier 2: `test_intervention_keeps_skill_name_prefix_when_present` — `skill_builder` in output, `#ab12` not
- [x] 4 CI gates: `ruff check` ✓ · `test_tier_audit.py --strict` ✓ · renderer + pure-helper tests 49 passed ✓ · `verify_module_docstrings.py` ✓
- [x] (skipped — live dogfood confirms UX; #2243 was dogfood-observed; the Tier 2 tests pin the new contract)

**Tier self-check**: tests use public `_plain()` helper (format_inline_message via Console → string); no private state access; no mocks.

Closes #2243