### PR TITLE
fix(#2415 root 3): host workspace base_dir anchors on project_root (align write-target + approval base)

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -230,7 +230,10 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 non_interactive=False,  # #1439 Fix #1: interactive UI = byte-identical
                 environment_backend=None,
                 sandbox_backend=None,
-                workspace_base_dir=None,
+                # #2415 root 3: host workspace base_dir anchors on the project root (== the
+                # permission zone base), not cwd — else a subdir invocation splits the write-target
+                # base from the approval base. Mirrors build_environment_backend's host return.
+                workspace_base_dir=project_root,
                 workspace_state_dir=None,
             )
             s.load_history()

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -440,7 +440,10 @@ def run_serve(args: argparse.Namespace) -> None:
             non_interactive=False,  # #1439 Fix #1: stdio-MCP byte-identical (run-once-only fix)
             environment_backend=None,  # gap: MCP-serve lacks env-backend / container-rooting
             sandbox_backend=None,
-            workspace_base_dir=None,
+            # #2415 root 3: host workspace base_dir anchors on the project root (== the permission
+            # zone base), not cwd — else a subdir invocation splits the write-target base from the
+            # approval base. Mirrors build_environment_backend's host return.
+            workspace_base_dir=project_root,
             workspace_state_dir=None,
             eager_embedding_build=False,
         )

--- a/src/reyn/interfaces/cli/env_backend.py
+++ b/src/reyn/interfaces/cli/env_backend.py
@@ -73,7 +73,14 @@ def build_environment_backend(args: argparse.Namespace, *, launcher=None):
 
     Returns ``(backend, workspace_base_dir, workspace_state_dir, cleanup)``:
 
-    - host (default): ``(None, None, None, None)`` — identity HostBackend.
+    - host (default): ``(None, project_root, None, None)`` — identity HostBackend with the
+      workspace base_dir anchored on the **project root** (the reyn.yaml ancestor), NOT the
+      invocation cwd. #2415 root 3: the permission zone (``file_zone_root``) already anchors on
+      project_root, so a subdir invocation whose ``base_dir`` was cwd split the two bases — a
+      write target resolved under cwd while its approval resolved under project_root → silently
+      denied AND landed in the wrong dir. Returning project_root here (the host analogue of the
+      container's repo root) keeps base_dir == file_zone_root, so writes both land and are permitted
+      under project_root. Falls back to cwd when no reyn.yaml is found up-tree (no project to anchor).
     - docker ATTACH (``--container`` given): a ``DockerEnvironmentBackend`` over
       the existing container; base_dir = the in-container ``--repo-dir``; no
       cleanup (the operator owns the container).
@@ -87,7 +94,12 @@ def build_environment_backend(args: argparse.Namespace, *, launcher=None):
     """
     backend_kind = getattr(args, "env_backend", "host")
     if backend_kind == "host":
-        return None, None, None, None
+        # #2415 root 3: anchor the host workspace base_dir on the project root (== the resolver's
+        # file_zone_root default), so the write-target base and the approval base coincide. Fall
+        # back to cwd when there is no reyn.yaml ancestor (no project to anchor to).
+        from reyn.config import _find_project_root
+        project_root = _find_project_root(Path.cwd()) or Path.cwd()
+        return None, project_root, None, None
 
     if backend_kind == "docker":
         from reyn.environment import DockerEnvironmentBackend

--- a/src/reyn/tools/op_context_bridge.py
+++ b/src/reyn/tools/op_context_bridge.py
@@ -62,7 +62,19 @@ def build_legacy_op_context(ctx: "ToolContext") -> Any:
             else PermissionDecl()
         ),
         permission_resolver=ctx.permission_resolver,
-        skill_name="",
+        # #2415 root 4: propagate skill_name + intervention_bus from the phase
+        # OpContext so permission checks key correctly on the calling skill's
+        # approval prefix (``{skill}/file.write/{path}``) and the JIT prompt
+        # fires when approval is needed. Without this, skill_name="" → prefix
+        # ``/file.write/`` → no saved approval matches → PermissionError even
+        # when the operator already approved the path.  intervention_bus=None
+        # suppressed the JIT fallback prompt, giving no recovery path.
+        skill_name=(
+            phase_op_ctx.skill_name if phase_op_ctx is not None else ""
+        ),
+        intervention_bus=(
+            phase_op_ctx.intervention_bus if phase_op_ctx is not None else None
+        ),
         # #1673: thread the config-aware resolver + "tool" purpose class so this
         # ONE shared bridge gives every delegating tool a real resolver instead of
         # the OpContext default resolver=None (+ literal "standard"). Eliminates the

--- a/tests/test_1289_frontend_container_chat.py
+++ b/tests/test_1289_frontend_container_chat.py
@@ -41,12 +41,23 @@ def test_register_env_backend_args_surface() -> None:
     assert ns2.repo_dir == "/repo" and ns2.keep_container is True
 
 
-def test_build_environment_backend_host_is_identity() -> None:
-    """Tier 2: env_backend=host → (None, None, None, None) = the HostBackend
-    identity path (no container, no cleanup) — frontends stay byte-identical
-    unless --env-backend=docker is passed."""
-    ns = argparse.Namespace(env_backend="host")
-    assert build_environment_backend(ns) == (None, None, None, None)
+def test_build_environment_backend_host_is_identity(tmp_path, monkeypatch) -> None:
+    """Tier 2: env_backend=host → HostBackend identity for the backend/state/cleanup slots (None,
+    no container, no cleanup), but the workspace base_dir slot anchors on the PROJECT ROOT (#2415
+    root 3), NOT cwd — so the FS base matches the permission-zone base and a subdir invocation's
+    writes both land and are permitted under the project. (Was (None, None, None, None).)"""
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "reyn.yaml").write_text("model: stub/model\n", encoding="utf-8")
+    subdir = project_root / "docs"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+
+    backend, ws_base_dir, ws_state_dir, cleanup = build_environment_backend(
+        argparse.Namespace(env_backend="host")
+    )
+    assert (backend, ws_state_dir, cleanup) == (None, None, None), "HostBackend identity (no container)"
+    assert ws_base_dir == project_root, "host workspace base_dir anchors on project_root, not the cwd subdir"
 
 
 def test_frontend_contract_same_instance_reaches_both_seams(tmp_path: Path) -> None:

--- a/tests/test_2415_root3_workspace_base_project_root.py
+++ b/tests/test_2415_root3_workspace_base_project_root.py
@@ -1,0 +1,94 @@
+"""Tier 2: #2415 root 3 — host workspace base_dir anchors on project_root, so the write TARGET and
+the approval KEY resolve against the SAME base (full chain, cwd != project_root).
+
+Roots 1/2 (#2420) fixed the approval-KEY base (project_root) + honored the declared recursive scope,
+but the check-TARGET still resolved against ``workspace.base_dir`` which defaulted to CWD in host
+mode — so a subdir invocation (cwd != project_root) split the two bases: ``file.py`` resolved the
+write target under CWD while the approval resolved under project_root → the write was DENIED and,
+worse, would have LANDED under CWD (wrong dir). Fix: ``build_environment_backend`` host mode returns
+``ws_base_dir = project_root`` (== the permission zone base), aligning the write-location base with
+the approval base.
+
+These tests replicate the FULL chain (the prior root-1/2 tests used a relative target that resolved
+via project_root and masked this): the funnel value → a real ``Workspace(base_dir=…)`` → the real
+``file.py`` write op → the gate, with cwd != project_root.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.intervention_choices import RECURSIVE
+from reyn.user_intervention import InterventionAnswer
+
+
+def _project_and_cwd(tmp_path: Path, monkeypatch) -> Path:
+    """A reyn project at tmp/project + cwd at a SUBDIR (tmp/project/docs) — the root-3 case: a
+    subdir invocation where ``_find_project_root`` walks UP to the reyn.yaml ancestor, so cwd !=
+    project_root but project_root IS discoverable."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "reyn.yaml").write_text("model: stub/model\n", encoding="utf-8")
+    subdir = project_root / "docs"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    return project_root
+
+
+def test_build_environment_backend_host_anchors_on_project_root(tmp_path, monkeypatch):
+    """Tier 2: the funnel — host-mode ``build_environment_backend`` returns ws_base_dir == the project
+    root (the reyn.yaml ancestor), NOT cwd. RED before the fix (returned None → Workspace default cwd)."""
+    from reyn.interfaces.cli.env_backend import build_environment_backend
+
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    _backend, ws_base_dir, _state, _cleanup = build_environment_backend(argparse.Namespace(env_backend="host"))
+    assert ws_base_dir == project_root, "host workspace base_dir anchors on project_root, not cwd"
+
+
+class _Bus:
+    async def request(self, iv):  # noqa: ANN001
+        return InterventionAnswer(choice_id=RECURSIVE)
+
+
+def test_full_chain_write_lands_and_is_permitted_under_project_root(tmp_path, monkeypatch):
+    """Tier 2: CORE full-chain — with the funnel's project_root base_dir, a real file.py write op to a
+    reyn/local subpath (approved recursively) is PERMITTED and the file LANDS under project_root, with
+    cwd != project_root. RED before the fix: base_dir=cwd → target resolves under cwd → not covered by
+    the project_root approval (denied) and would land in the wrong dir."""
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.core.op_runtime.file import handle
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.interfaces.cli.env_backend import build_environment_backend
+    from reyn.schemas.models import FileIROp, Phase, Skill, SkillGraph
+    from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    _backend, ws_base_dir, _s, _c = build_environment_backend(argparse.Namespace(env_backend="host"))
+
+    resolver = PermissionResolver(config_permissions={}, project_root=project_root,
+                                  file_zone_root=ws_base_dir, interactive=True)
+    # approve skill_builder's declared reyn/local recursive write (root-1/2 path)
+    ph = Phase(name="b", instructions="x", input_schema={"type": "object", "properties": {}},
+               allowed_ops=["write_file"])
+    skill = Skill(name="skill_builder", entry_phase="b", phases={"b": ph},
+                  graph=SkillGraph(transitions={}, can_finish_phases=["b"]),
+                  final_output_schema={"type": "object", "properties": {}}, final_output_name="r",
+                  permissions=PermissionDecl.from_dict({"file.write": [{"path": "reyn/local", "scope": "recursive"}]}))
+    asyncio.run(resolver.startup_guard(skill, "skill_builder", _Bus()))
+
+    events = EventLog()
+    ws = Workspace(events, permission_resolver=resolver, skill_name="skill_builder", base_dir=ws_base_dir)
+    ctx = OpContext(workspace=ws, events=events, permission_decl=skill.permissions,
+                    permission_resolver=resolver, skill_name="skill_builder")
+    op = FileIROp(kind="file", op="write", path="reyn/local/my_new_skill/skill.md", content="entry: x\n")
+    result = asyncio.run(handle(op, ctx, "control_ir"))
+
+    assert result.get("status") == "ok", "the write is PERMITTED (target base == approval base)"
+    landed = project_root / "reyn" / "local" / "my_new_skill" / "skill.md"
+    assert landed.exists(), "the file LANDS under project_root/reyn/local, not cwd"
+    assert not (Path.cwd() / "reyn" / "local" / "my_new_skill" / "skill.md").exists(), \
+        "the file did NOT land under cwd (the root-3 wrong-dir bug)"

--- a/tests/test_2415_root3_workspace_base_project_root.py
+++ b/tests/test_2415_root3_workspace_base_project_root.py
@@ -92,3 +92,25 @@ def test_full_chain_write_lands_and_is_permitted_under_project_root(tmp_path, mo
     assert landed.exists(), "the file LANDS under project_root/reyn/local, not cwd"
     assert not (Path.cwd() / "reyn" / "local" / "my_new_skill" / "skill.md").exists(), \
         "the file did NOT land under cwd (the root-3 wrong-dir bug)"
+
+
+def test_no_frontend_host_entry_hardcodes_workspace_base_dir_none():
+    """Tier 2: completeness guard (#2415 root 3) — no frontend host-entry construction may hardcode
+    ``workspace_base_dir=None``, which splits the write-target base (→ cwd) from the project_root-
+    anchored permission zone. Host frontends must anchor base_dir on project_root (the
+    build_environment_backend funnel value, or an explicit project_root as chainlit / mcp-serve do).
+    This is the robust-by-construction regression guard (MCP-seam grep-gate pattern) — it caught the
+    mcp-serve session factory the initial two-site sweep missed. RED if a new frontend reintroduces
+    the split. (Signature defaults ``workspace_base_dir: "Path | None" = None`` are not matched — the
+    call-site keyword form is contiguous ``workspace_base_dir=None``.)"""
+    interfaces = Path(__file__).resolve().parents[1] / "src" / "reyn" / "interfaces"
+    offenders = [
+        f"{py.relative_to(interfaces)}:{i}"
+        for py in interfaces.rglob("*.py")
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1)
+        if "workspace_base_dir=None" in line
+    ]
+    assert not offenders, (
+        "frontend host-entry hardcodes workspace_base_dir=None (splits base_dir from the "
+        "project_root permission zone — anchor it on project_root): " + ", ".join(offenders)
+    )

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -61,20 +61,33 @@ class _FakeLauncher:
 # ─── host (default) ────────────────────────────────────────────────────────────
 
 
-def test_host_backend_returns_none_quad() -> None:
-    """Tier 2: --env-backend=host yields no backend + default dirs + no cleanup."""
-    backend, base_dir, state_dir, cleanup = _build_environment_backend(
-        _args(env_backend="host")
-    )
-    assert (backend, base_dir, state_dir, cleanup) == (None, None, None, None)
+def _project_subdir(tmp_path: Path, monkeypatch) -> Path:
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "reyn.yaml").write_text("model: stub/model\n", encoding="utf-8")
+    subdir = project_root / "docs"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    return project_root
 
 
-def test_default_is_host() -> None:
-    """Tier 2: a Namespace without env_backend defaults to host (getattr fallback)."""
-    backend, base_dir, state_dir, cleanup = _build_environment_backend(
-        argparse.Namespace()
-    )
-    assert (backend, base_dir, state_dir, cleanup) == (None, None, None, None)
+def test_host_backend_no_container_but_base_dir_is_project_root(tmp_path, monkeypatch) -> None:
+    """Tier 2: --env-backend=host yields no backend + no cleanup, and the workspace base_dir anchors
+    on the PROJECT ROOT (#2415 root 3), not the cwd subdir — so the FS base == the permission-zone
+    base. (Was (None, None, None, None); the base_dir slot now carries project_root.)"""
+    project_root = _project_subdir(tmp_path, monkeypatch)
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(_args(env_backend="host"))
+    assert (backend, state_dir, cleanup) == (None, None, None), "no backend / dirs / cleanup"
+    assert base_dir == project_root, "host base_dir anchors on project_root, not the cwd subdir"
+
+
+def test_default_is_host(tmp_path, monkeypatch) -> None:
+    """Tier 2: a Namespace without env_backend defaults to host (getattr fallback) — same contract:
+    no backend/state/cleanup, base_dir anchored on project_root (#2415 root 3)."""
+    project_root = _project_subdir(tmp_path, monkeypatch)
+    backend, base_dir, state_dir, cleanup = _build_environment_backend(argparse.Namespace())
+    assert (backend, state_dir, cleanup) == (None, None, None)
+    assert base_dir == project_root
 
 
 # ─── docker ATTACH (--container given) ─────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — Live-gate PASSED (2026-07-02). Two fixes in this PR, both needed to close the gate.

**[e2e-coder]** — the **third** base-mismatch layer of the skill_builder permission bug (tui live-caught after #2420). skill_builder writing `reyn/local/{name}/` **from a subdirectory** was still broken on main.

## Root 3 (e2e-coder)
Roots 1/2 (#2420) fixed the approval-**KEY** base (project_root) + honored the declared recursive scope. But the check-**TARGET** still resolved against `workspace.base_dir`, which defaults to **CWD** in host mode. A subdir invocation (`cwd != project_root`) split the two bases: `file.py` resolved the write target under CWD while the approval resolved under project_root → the write was **DENIED** and, worse, would have **LANDED under CWD** (wrong dir). The `#1414` split (`file_zone_root` = project_root, `base_dir` = cwd) is correct for *container* mode (both = /testbed) but left *host* mode inconsistent.

## Fix (b) — align the bases at the funnel
`build_environment_backend` host mode now returns `ws_base_dir = project_root` (the reyn.yaml ancestor, or cwd if none) — the host analogue of the container's repo root — so **`base_dir == file_zone_root`**. This is the universal funnel for `reyn run` / `chat` / `dogfood` / `web` (all get `ws_base_dir` from it); chainlit's hardcoded `workspace_base_dir=None` outlier is aligned too.

Owner **GO'd the semantic**: host relative file I/O is now project-root-relative (consistent with the project-scoped `.reyn/` / approvals / permission-zone). The accidental cwd default was the inconsistency.

## Root 4 — op_context_bridge skill_name="" bug (tui-coder, exposed by root 3)
Root 3 fixed the write **target** (where files land). But when tui live-gated, permission still failed: `build_legacy_op_context` hardcoded `skill_name=""` and omitted `intervention_bus`. With root 3's fix, the approval check keyed on `"/file.write/reyn/local/"` (empty skill prefix) → no match for saved `"skill_builder/file.write/reyn/local/"` → PermissionError. `intervention_bus=None` suppressed the JIT prompt fallback.

Fix: propagate `skill_name` and `intervention_bus` from `phase_op_ctx` (= `phase_state.op_context`, which already carries the correct values from `control_ir_executor._invoker`). Commit fb434cfd.

## Full-chain test (the prior root-1/2 tests used a relative target that masked this)
`test_2415_root3_workspace_base_project_root.py` replicates the real chain: the funnel value → a real `Workspace(base_dir=…)` → the real `file.py` write op → the gate, with **cwd = a subdir of project_root**. Asserts the write is **PERMITTED** and the file **LANDS under project_root/reyn/local** (not cwd). **RED-verified** against the `None`-return revert (denied + wrong-dir). The `#1289` / `#1115` host-identity tests are updated to the new contract (backend/state/cleanup None; base_dir = project_root).

## Note
`test_1289_frontend_container_chat.py` has a **pre-existing** circular-import that errors only when it's the *first* module to import `host_backend` (in isolation); the full suite / CI import it early via another module → fine. Verified present on clean origin/main, not introduced here.

## CI gates (local)
- `ruff check src tests scripts` ✓
- `python scripts/test_tier_audit.py --strict` ✓
- full `pytest` ✓ (8456 passed)
- `python scripts/verify_module_docstrings.py` ✓

## Test plan
- [x] **tui-live (merge gate)**: `reyn run skill_builder` from `tui-coder/docs/` (cwd != project_root) → skill files at `project_root/reyn/local/live_gate_skill/`, 0 `permission_denied` events, 6 `permission_granted` with `skill=skill_builder`. Events log: `2026-07-02T194017_skill_builder.jsonl`.

## Tier self-check
- op_context_bridge.py change: no new tests added (behavioral change covered by existing `test_tool_opcontext_bridge_permission_decl.py` bridge contract tests + live gate as primary evidence).

part of #2415 (roots 3 + 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)