### PR TITLE
feat(#2040): /tasks done-clutter — fold DONE tasks into +N done summary

### DIFF
--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -126,22 +126,23 @@ async def _resolve_task(
 
 async def _list_tasks(session: "Session") -> None:
     skill_lines = _list_skill_lines(session)
-    task_lines = await _list_dynamic_task_lines(session)
-    if not skill_lines and not task_lines:
+    task_lines, done_count = await _list_dynamic_task_lines(session)
+    if not skill_lines and not task_lines and not done_count:
         await reply(session, "(no running tasks)")
         return
 
-    # "task(s)" not "running task(s)": the Tasks section now shows the full plan
-    # incl completed (#2036), so the count spans running skill runs + persistent
-    # tasks of any non-archived status.
-    total = len(skill_lines) + len(task_lines)
-    out: list[str] = [f"{total} task(s):"]
+    active_count = len(skill_lines) + len(task_lines)
+    out: list[str] = []
+    if active_count:
+        out.append(f"{active_count} task(s):")
     if skill_lines:
         out.append("  Skills:")
         out.extend(f"    {ln}" for ln in skill_lines)
-    if task_lines:
+    if task_lines or done_count:
         out.append("  Tasks:")
         out.extend(f"    {ln}" for ln in task_lines)
+        if done_count:
+            out.append(f"    +{done_count} done")
     await reply(session, "\n".join(out))
 
 
@@ -179,34 +180,35 @@ def _list_skill_lines(session: "Session") -> list[str]:
 # intentional (#2036 review).
 
 
-async def _list_dynamic_task_lines(session: "Session") -> list[str]:
+async def _list_dynamic_task_lines(session: "Session") -> tuple[list[str], int]:
     """Render the dynamic Tasks (``task__create`` work-units) for /tasks.
 
-    Reads ``session.task_backend`` (#1953 slice R). Returns ``[]`` when the
-    session carries no backend. Shows the full plan WITH status (active +
-    completed + failed) so the user sees progress + intact deps; only
-    SOFT-DELETED tasks (``archived_at`` set, #2187) are hidden. Each task is
-    formatted in the same idiom as ``_list_skill_lines``.
+    Reads ``session.task_backend`` (#1953 slice R). Returns ``([], 0)`` when
+    the session carries no backend. Active tasks (non-DONE, non-archived) are
+    returned as formatted lines; DONE tasks are folded into a count so a long
+    session does not accumulate stale completed-task clutter (#2040). Only
+    SOFT-DELETED tasks (``archived_at`` set, #2187) are hidden entirely.
     """
     backend = getattr(session, "task_backend", None)
     if backend is None:
-        return []
+        return [], 0
     tasks = await backend.list()
     lines: list[str] = []
+    done_count = 0
     for task in tasks:
         status = getattr(task.status, "value", task.status)
         if getattr(task, "archived_at", None) is not None:  # soft-deleted (retention) — hidden
             continue
+        if status == "done":
+            done_count += 1
+            continue
         deps = list(getattr(task, "deps", []) or [])
-        if deps:
-            deps_summary = ", ".join(d[:8] for d in deps)
-        else:
-            deps_summary = "(none)"
+        deps_summary = ", ".join(d[:8] for d in deps) if deps else "(none)"
         lines.append(
             f"{task.name}  [{task.task_id[:8]}]  status: {status}  "
             f"deps: {deps_summary}"
         )
-    return lines
+    return lines, done_count
 
 
 # ── /tasks status ────────────────────────────────────────────────────────────

--- a/tests/cli/test_tasks_slash_dynamic_view.py
+++ b/tests/cli/test_tasks_slash_dynamic_view.py
@@ -147,12 +147,10 @@ async def test_tasks_list_no_backend_falls_back_to_skill_only():
 
 
 @pytest.mark.asyncio
-async def test_tasks_list_shows_done_hides_soft_deleted():
-    """Tier 2: the Tasks section shows the full plan WITH status (#2036) — a
-    DONE task is SHOWN (so the user sees "done" progress + deps to it stay
-    intact); only a SOFT-DELETED task (``archived_at`` set, #2187 — the orthogonal
-    retention marker abort() sets) is hidden. The split is intentional vs the
-    skill-runs section's running-only filter."""
+async def test_tasks_list_done_folded_soft_deleted_hidden():
+    """Tier 2: DONE tasks are folded into '+N done' summary (#2040) — they are
+    not listed individually. SOFT-DELETED tasks (``archived_at`` set, #2187)
+    remain hidden entirely. Both are distinct from active tasks which list in full."""
     backend = InMemoryTaskBackend()
     # deps-less tasks → the backend honors the given status (no readiness derive).
     await backend.create(Task(
@@ -169,12 +167,41 @@ async def test_tasks_list_shows_done_hides_soft_deleted():
     await _list_tasks(session)
 
     out = session.replies[-1]
-    # DONE task surfaces WITH its status (progress visibility).
-    assert "done-step" in out
-    assert "status: done" in out
-    # SOFT-DELETED task (archived_at set) is hidden.
+    # DONE task is folded into the summary, NOT listed individually.
+    assert "done-step" not in out
+    assert "status: done" not in out
+    assert "+1 done" in out
+    # SOFT-DELETED task (archived_at set) is hidden entirely (unchanged).
     assert "archived-step" not in out
     assert "arch-ddd" not in out
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_done_summary_alongside_active():
+    """Tier 2: active + done tasks → active shown in full, done folded into '+N done' (#2040)."""
+    backend = InMemoryTaskBackend()
+    await backend.create(Task(
+        task_id="run-eeeeeeee-0005", name="active-step", assignee="sess-1",
+        requester="req", status=TaskState.RUNNING,
+    ))
+    await backend.create(Task(
+        task_id="done-ffffffff-0006", name="done-step-1", assignee="sess-1",
+        requester="req", status=TaskState.DONE,
+    ))
+    await backend.create(Task(
+        task_id="done-gggggggg-0007", name="done-step-2", assignee="sess-1",
+        requester="req", status=TaskState.DONE,
+    ))
+    session = _CaptureSession(task_backend=backend)
+
+    await _list_tasks(session)
+
+    out = session.replies[-1]
+    assert "active-step" in out            # active task shown in full
+    assert "done-step-1" not in out        # done tasks NOT individually listed
+    assert "done-step-2" not in out
+    assert "+2 done" in out                # done count summarised
+    assert "1 task(s)" in out             # header counts only active tasks
 
 
 @pytest.mark.asyncio

--- a/tests/test_slash_tasks_helpers.py
+++ b/tests/test_slash_tasks_helpers.py
@@ -86,10 +86,11 @@ class _FakeSession:
 
 @pytest.mark.asyncio
 async def test_list_dynamic_no_backend_returns_empty() -> None:
-    """Tier 2: session without task_backend → empty list (no crash)."""
+    """Tier 2: session without task_backend → empty list + 0 done count (no crash)."""
     session = _FakeSession(backend=None)
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    lines, done_count = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
     assert lines == []
+    assert done_count == 0
 
 
 @pytest.mark.asyncio
@@ -98,7 +99,7 @@ async def test_list_dynamic_archived_tasks_hidden() -> None:
     archived = _stub_task("old", "task-aaa", archived_at="2026-01-01")
     active = _stub_task("active", "task-bbb")
     session = _FakeSession(backend=_FakeBackend([archived, active]))
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    lines, done_count = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
     assert any("active" in ln for ln in lines)
     assert not any("old" in ln for ln in lines)
 
@@ -108,7 +109,7 @@ async def test_list_dynamic_no_deps_shows_none() -> None:
     """Tier 2: task with no deps shows '(none)' in deps field."""
     task = _stub_task("t1", "task-ccc", deps=[])
     session = _FakeSession(backend=_FakeBackend([task]))
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    lines, _ = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
     assert any("(none)" in ln for ln in lines)
 
 
@@ -117,23 +118,48 @@ async def test_list_dynamic_deps_shown_truncated() -> None:
     """Tier 2: task with deps shows first 8 chars of each dep id."""
     task = _stub_task("t2", "task-ddd", deps=["dep-long-id-1", "dep-long-id-2"])
     session = _FakeSession(backend=_FakeBackend([task]))
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    lines, _ = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
     assert any("dep-long" in ln for ln in lines)
     assert not any("dep-long-id-1" in ln for ln in lines)  # truncated to 8 chars
 
 
 @pytest.mark.asyncio
 async def test_list_dynamic_status_shown() -> None:
-    """Tier 2: task status value surfaces in the output line."""
-    task = _stub_task("t3", "task-eee", status="completed")
+    """Tier 2: task status value surfaces in the output line for non-done tasks."""
+    task = _stub_task("t3", "task-eee", status="running")
     session = _FakeSession(backend=_FakeBackend([task]))
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
-    assert any("completed" in ln for ln in lines)
+    lines, _ = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    assert any("running" in ln for ln in lines)
 
 
 @pytest.mark.asyncio
 async def test_list_dynamic_empty_backend_returns_empty() -> None:
-    """Tier 2: backend with no tasks → empty lines list."""
+    """Tier 2: backend with no tasks → empty lines list + 0 done count."""
     session = _FakeSession(backend=_FakeBackend([]))
-    lines = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    lines, done_count = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
     assert lines == []
+    assert done_count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_dynamic_done_tasks_folded_into_count() -> None:
+    """Tier 2: DONE tasks are excluded from active lines and counted separately (#2040)."""
+    active = _stub_task("active", "task-fff", status="running")
+    done1 = _stub_task("done1", "task-ggg", status="done")
+    done2 = _stub_task("done2", "task-hhh", status="done")
+    session = _FakeSession(backend=_FakeBackend([active, done1, done2]))
+    lines, done_count = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    assert any("active" in ln for ln in lines)
+    assert not any("done1" in ln for ln in lines)
+    assert not any("done2" in ln for ln in lines)
+    assert done_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_dynamic_all_done_returns_empty_lines_nonzero_count() -> None:
+    """Tier 2: all tasks DONE → empty active lines, nonzero done_count (#2040)."""
+    done = _stub_task("step", "task-iii", status="done")
+    session = _FakeSession(backend=_FakeBackend([done]))
+    lines, done_count = await _list_dynamic_task_lines(session)  # type: ignore[arg-type]
+    assert lines == []
+    assert done_count == 1


### PR DESCRIPTION
**[tui-coder]** — Part of #2040 (item 2: `/tasks` completed-clutter).

## Summary

- DONE tasks in `/tasks list` are now folded into a `+N done` summary line instead of being listed individually
- Active tasks (UNASSIGNED, BLOCKED, READY, RUNNING, FAILED) still show in full with status + deps
- SOFT-DELETED tasks (`archived_at` set, #2187) remain hidden entirely — unchanged
- Header count (`N task(s):`) reflects active tasks only; `+N done` appears as the last item in the Tasks section
- `_list_dynamic_task_lines` return type changed from `list[str]` to `tuple[list[str], int]`

Before (all tasks listed):
```
2 task(s):
  Tasks:
    plan  [plan-aaa]  status: running  deps: (none)
    done-step  [done-ccc]  status: done  deps: (none)
```

After (done folded):
```
1 task(s):
  Tasks:
    plan  [plan-aaa]  status: running  deps: (none)
    +1 done
```

## Changed files

- `src/reyn/interfaces/slash/tasks.py` — `_list_dynamic_task_lines` returns `(lines, done_count)`, `_list_tasks` renders the `+N done` summary
- `tests/test_slash_tasks_helpers.py` — updated 6 existing tests to unpack tuple; added 2 new Tier 2 tests for folding + all-done case
- `tests/cli/test_tasks_slash_dynamic_view.py` — updated done-visibility test to assert folded behavior; added `test_tasks_list_done_summary_alongside_active`

## Test plan

- [x] `pytest tests/test_slash_tasks_helpers.py tests/cli/test_tasks_slash_dynamic_view.py` — 19 passed
- [x] `ruff check` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict` — 19 OK, 0 Tier 4 violations
- [x] `python scripts/verify_module_docstrings.py` — OK

Tier self-check: Tier 2 only. No Tier 4 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)