### PR TITLE
fix(#2427): anchor host workspace_state_dir on project_root (events/WAL base-split)

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -234,7 +234,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # permission zone base), not cwd — else a subdir invocation splits the write-target
                 # base from the approval base. Mirrors build_environment_backend's host return.
                 workspace_base_dir=project_root,
-                workspace_state_dir=None,
+                # #2427: anchor state dir on project_root too — mirrors env_backend host return.
+                workspace_state_dir=project_root / ".reyn",
             )
             s.load_history()
             return s

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -444,7 +444,8 @@ def run_serve(args: argparse.Namespace) -> None:
             # zone base), not cwd — else a subdir invocation splits the write-target base from the
             # approval base. Mirrors build_environment_backend's host return.
             workspace_base_dir=project_root,
-            workspace_state_dir=None,
+            # #2427: anchor state dir on project_root too — mirrors env_backend host return.
+            workspace_state_dir=project_root / ".reyn",
             eager_embedding_build=False,
         )
         s.load_history()

--- a/src/reyn/interfaces/cli/env_backend.py
+++ b/src/reyn/interfaces/cli/env_backend.py
@@ -97,9 +97,12 @@ def build_environment_backend(args: argparse.Namespace, *, launcher=None):
         # #2415 root 3: anchor the host workspace base_dir on the project root (== the resolver's
         # file_zone_root default), so the write-target base and the approval base coincide. Fall
         # back to cwd when there is no reyn.yaml ancestor (no project to anchor to).
+        # #2427: anchor workspace_state_dir (events/WAL) on project_root too — same base-split
+        # class: a subdir invocation (cwd != project_root) landed state under <cwd>/.reyn instead
+        # of <project_root>/.reyn. Mirror the docker-LAUNCH pattern (line below).
         from reyn.config import _find_project_root
         project_root = _find_project_root(Path.cwd()) or Path.cwd()
-        return None, project_root, None, None
+        return None, project_root, project_root / ".reyn", None
 
     if backend_kind == "docker":
         from reyn.environment import DockerEnvironmentBackend

--- a/tests/test_1289_frontend_container_chat.py
+++ b/tests/test_1289_frontend_container_chat.py
@@ -42,10 +42,11 @@ def test_register_env_backend_args_surface() -> None:
 
 
 def test_build_environment_backend_host_is_identity(tmp_path, monkeypatch) -> None:
-    """Tier 2: env_backend=host → HostBackend identity for the backend/state/cleanup slots (None,
-    no container, no cleanup), but the workspace base_dir slot anchors on the PROJECT ROOT (#2415
-    root 3), NOT cwd — so the FS base matches the permission-zone base and a subdir invocation's
-    writes both land and are permitted under the project. (Was (None, None, None, None).)"""
+    """Tier 2: env_backend=host → HostBackend identity for the backend/cleanup slots (None,
+    no container, no cleanup). The workspace base_dir slot anchors on the PROJECT ROOT (#2415
+    root 3) and workspace_state_dir anchors on project_root/.reyn (#2427) — so FS writes,
+    state (events/WAL), AND the permission zone all share the same project root, even for
+    subdir invocations (cwd != project_root)."""
     project_root = tmp_path / "proj"
     project_root.mkdir()
     (project_root / "reyn.yaml").write_text("model: stub/model\n", encoding="utf-8")
@@ -56,8 +57,9 @@ def test_build_environment_backend_host_is_identity(tmp_path, monkeypatch) -> No
     backend, ws_base_dir, ws_state_dir, cleanup = build_environment_backend(
         argparse.Namespace(env_backend="host")
     )
-    assert (backend, ws_state_dir, cleanup) == (None, None, None), "HostBackend identity (no container)"
+    assert (backend, cleanup) == (None, None), "HostBackend identity (no container, no cleanup)"
     assert ws_base_dir == project_root, "host workspace base_dir anchors on project_root, not the cwd subdir"
+    assert ws_state_dir == project_root / ".reyn", "host workspace_state_dir anchors on project_root/.reyn, not cwd"
 
 
 def test_frontend_contract_same_instance_reaches_both_seams(tmp_path: Path) -> None:

--- a/tests/test_2415_root3_workspace_base_project_root.py
+++ b/tests/test_2415_root3_workspace_base_project_root.py
@@ -114,3 +114,39 @@ def test_no_frontend_host_entry_hardcodes_workspace_base_dir_none():
         "frontend host-entry hardcodes workspace_base_dir=None (splits base_dir from the "
         "project_root permission zone — anchor it on project_root): " + ", ".join(offenders)
     )
+
+
+def test_no_frontend_host_entry_hardcodes_workspace_state_dir_none():
+    """Tier 2: completeness guard (#2427) — no frontend host-entry construction may hardcode
+    ``workspace_state_dir=None``, which causes events/WAL to resolve against cwd instead of
+    project_root. Same base-split class as root 3 (workspace_base_dir), different param.
+    Host frontends must use the build_environment_backend funnel value, or an explicit
+    project_root/.reyn (as chainlit / mcp-serve do after #2427). RED if a new frontend
+    reintroduces the split. (Signature defaults are not matched — only call-site keyword form.)"""
+    interfaces = Path(__file__).resolve().parents[1] / "src" / "reyn" / "interfaces"
+    offenders = [
+        f"{py.relative_to(interfaces)}:{i}"
+        for py in interfaces.rglob("*.py")
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1)
+        if "workspace_state_dir=None" in line
+    ]
+    assert not offenders, (
+        "frontend host-entry hardcodes workspace_state_dir=None (splits events/WAL from "
+        "project_root — anchor it on project_root/.reyn): " + ", ".join(offenders)
+    )
+
+
+def test_build_environment_backend_host_state_dir_anchors_on_project_root(tmp_path, monkeypatch):
+    """Tier 2: the funnel (#2427) — host-mode ``build_environment_backend`` returns
+    ws_state_dir == project_root / '.reyn', NOT None. RED before the fix (returned None →
+    SkillRuntime fell back to the relative string '.reyn' → events landed under cwd/.reyn
+    instead of project_root/.reyn for subdir invocations)."""
+    from reyn.interfaces.cli.env_backend import build_environment_backend
+
+    project_root = _project_and_cwd(tmp_path, monkeypatch)
+    _backend, _base, ws_state_dir, _cleanup = build_environment_backend(
+        argparse.Namespace(env_backend="host")
+    )
+    assert ws_state_dir == project_root / ".reyn", (
+        "host workspace_state_dir anchors on project_root/.reyn, not cwd"
+    )

--- a/tests/test_run_container_backend_flags_1115.py
+++ b/tests/test_run_container_backend_flags_1115.py
@@ -72,22 +72,24 @@ def _project_subdir(tmp_path: Path, monkeypatch) -> Path:
 
 
 def test_host_backend_no_container_but_base_dir_is_project_root(tmp_path, monkeypatch) -> None:
-    """Tier 2: --env-backend=host yields no backend + no cleanup, and the workspace base_dir anchors
-    on the PROJECT ROOT (#2415 root 3), not the cwd subdir — so the FS base == the permission-zone
-    base. (Was (None, None, None, None); the base_dir slot now carries project_root.)"""
+    """Tier 2: --env-backend=host yields no backend + no cleanup; workspace base_dir anchors on
+    the PROJECT ROOT (#2415 root 3) and workspace_state_dir anchors on project_root/.reyn (#2427)
+    — FS base, state (events/WAL), and permission zone all share the same project root."""
     project_root = _project_subdir(tmp_path, monkeypatch)
     backend, base_dir, state_dir, cleanup = _build_environment_backend(_args(env_backend="host"))
-    assert (backend, state_dir, cleanup) == (None, None, None), "no backend / dirs / cleanup"
+    assert (backend, cleanup) == (None, None), "no backend / no cleanup"
     assert base_dir == project_root, "host base_dir anchors on project_root, not the cwd subdir"
+    assert state_dir == project_root / ".reyn", "host state_dir anchors on project_root/.reyn"
 
 
 def test_default_is_host(tmp_path, monkeypatch) -> None:
     """Tier 2: a Namespace without env_backend defaults to host (getattr fallback) — same contract:
-    no backend/state/cleanup, base_dir anchored on project_root (#2415 root 3)."""
+    no backend/cleanup, base_dir + state_dir anchored on project_root (#2415 root 3 / #2427)."""
     project_root = _project_subdir(tmp_path, monkeypatch)
     backend, base_dir, state_dir, cleanup = _build_environment_backend(argparse.Namespace())
-    assert (backend, state_dir, cleanup) == (None, None, None)
+    assert (backend, cleanup) == (None, None)
     assert base_dir == project_root
+    assert state_dir == project_root / ".reyn"
 
 
 # ─── docker ATTACH (--container given) ─────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — Live-gate PASSED (2026-07-02).

**[tui-coder]** — fast-follow to #2424 (root 3). Same base-split class, different param + symptom.

## Root cause
`workspace_state_dir=None` → `SkillRuntime` fell back to the relative string `".reyn"` → events/WAL landed under `<cwd>/.reyn/` instead of `<project_root>/.reyn/` for subdir invocations. Caught during the #2424 live-gate: events appeared in `docs/.reyn/events/` while skill files correctly went to `project_root/reyn/local/` (base_dir was already fixed by root 3).

## Fix
Three sites (same pattern as root 3's three-site workspace_base_dir fix):
1. `env_backend.py` host branch: return `project_root / ".reyn"` as `workspace_state_dir` (was `None`)
2. `chainlit_app/app.py`: hardcoded `workspace_state_dir=None` → `project_root / ".reyn"`
3. `cli/commands/mcp.py`: hardcoded `workspace_state_dir=None` → `project_root / ".reyn"`

## Guard (grep-gate, parallel to root 3)
`test_no_frontend_host_entry_hardcodes_workspace_state_dir_none` — scans `src/reyn/interfaces/` for `workspace_state_dir=None` call-site form and asserts none. RED-verified (reverting any of the three sites fails the guard). Parallel to the root-3 `workspace_base_dir=None` guard that caught mcp-serve.

## Tests updated
- `test_1289_frontend_container_chat.py`: updated to expect `project_root / ".reyn"` (not `None`)
- `test_run_container_backend_flags_1115.py`: same update
- `test_2415_root3_workspace_base_project_root.py`: new funnel test + grep-gate added

## CI gates (local)
- `ruff check src tests` ✓
- `python scripts/test_tier_audit.py --strict <changed tests>` ✓ (26 tests)
- `python scripts/verify_module_docstrings.py <changed src>` ✓
- `pytest` (8477 passed, 17 skipped, 3 xfailed) ✓

## Test plan
- [x] **tui-live (merge gate)**: `cwd=tui-coder/docs/` → `reyn run skill_builder "..."` → new event log `2026-07-02T195743_skill_builder.jsonl` appeared in `project_root/.reyn/events/direct/skill_runs/2026-07/` ✓. `docs/.reyn/events/` count stayed at 2 (unchanged from pre-fix runs) ✓.

## Tier self-check
New tests: Tier 2 (funnel contract + grep-gate structural guard). No Tier 4.

Closes #2427

🤖 Generated with [Claude Code](https://claude.com/claude-code)