### PR TITLE
[#2425 案B step1a+b] offload canonical foundation: to_canonical + seam (unwired)

### DIFF
--- a/src/reyn/core/offload/__init__.py
+++ b/src/reyn/core/offload/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical tool-result normalization + the single offload seam (#2425 案B)."""

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1,0 +1,90 @@
+"""Canonical tool-result shape — the #2425 案B spec fix (guessing-free offload).
+
+The spec hole (owner): tool results are heterogeneous per tool, so the offload layer GUESSED which
+field is the LLM body (per-op ``_offload_payload_field`` marker + ``decide_payload_field``'s
+sole-oversized rule) and broke whenever a result had a second large field (owner's chat-MCP
+whole-envelope: a large ``structuredContent`` alongside ``content``).
+
+案B normalizes every tool result at the boundary into ONE canonical shape the offloader never has to
+interpret:
+
+- ``text``        — the single canonical LLM-readable body (the ONLY thing the offloader truncates).
+- ``attachments`` — typed non-text kept OUT of the offload decision so a large one never competes with
+                    ``text``: ``{"kind": "media"|"structured", ...}``. A large ``structured`` is
+                    separately referenced (not dropped, not mixed into ``text``, retrievable by ref).
+- ``source_ref``  — the re-fetch origin for an on-disk body (``{"path": …, "offset": …}``); ``None``
+                    for a transient body (MCP/web/exec) — which must therefore be offload-stored (the
+                    tool cannot be meaningfully re-run for more).
+- ``meta``        — small structured status the LLM reads inline (``status``, ``server``/``url``,
+                    ``returncode``, …).
+
+Each op maps its dict → canonical ONCE, at its boundary (``to_canonical``). ``decide_payload_field``,
+``_oversized_fields``, the sole-oversized condition, and the six per-op markers then disappear —
+``text`` is the payload by construction. #2417's file_read truncate is this rule for the file case.
+
+P7: the op-kind → canonical mapping is OS-level (no skill vocabulary). The deref / paging / offload
+store machinery is reused unchanged — 案B removes only the field-guessing.
+"""
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class CanonicalToolResult(TypedDict, total=False):
+    """The single shape all tool results are normalized to before offload (see module docstring)."""
+
+    text: str
+    attachments: list[dict]
+    source_ref: "dict | None"
+    meta: dict
+
+
+def _mcp_to_canonical(result: dict) -> CanonicalToolResult:
+    """MCP result → canonical. ``content`` (joined text) → ``text``; ``structured``
+    (structuredContent) + ``media_blocks`` → typed ``attachments`` (a large ``structured`` is
+    separately referenced, never competing with ``text`` in the offload decision — the owner
+    whole-envelope root); ``status`` / ``server`` / ``tool`` / ``isError`` → ``meta``. source_ref is
+    None (transient: an MCP call can't be meaningfully re-run for more, so its body is offload-stored).
+    Forward-complete: every field is assigned somewhere (nothing dropped)."""
+    attachments: list[dict] = []
+    structured = result.get("structured")
+    if structured is not None:
+        attachments.append({"kind": "structured", "data": structured})
+    for block in result.get("media_blocks") or []:
+        attachments.append({"kind": "media", "block": block})
+    meta = {
+        k: v for k, v in result.items()
+        if k in ("kind", "status", "server", "tool", "isError", "error")
+    }
+    return CanonicalToolResult(
+        text=result.get("content", "") or "",
+        attachments=attachments,
+        source_ref=None,
+        meta=meta,
+    )
+
+
+# op-kind → canonical mapper. New ops register here (or return canonical directly); a raw dict with no
+# registered mapper falls back to a whole-dict wrap so nothing is ever lost (see ``to_canonical``).
+_MAPPERS: dict[str, Any] = {
+    "mcp": _mcp_to_canonical,
+}
+
+
+def to_canonical(result: dict) -> CanonicalToolResult:
+    """Normalize an op result dict to :class:`CanonicalToolResult`. Dispatches on ``result["kind"]``;
+    an unregistered kind falls back to a whole-dict wrap (``text`` = the JSON, no attachments/source)
+    so migration is incremental and lossless — an op is canonicalized by adding its mapper, and until
+    then it round-trips through the fallback unchanged in spirit."""
+    kind = result.get("kind")
+    mapper = _MAPPERS.get(kind) if isinstance(kind, str) else None
+    if mapper is not None:
+        return mapper(result)
+    # Fallback: not yet migrated. Keep the whole dict as the body (lossless); meta carries the kind.
+    import json
+    return CanonicalToolResult(
+        text=json.dumps(result, ensure_ascii=False),
+        attachments=[],
+        source_ref=None,
+        meta={"kind": kind} if kind is not None else {},
+    )

--- a/src/reyn/core/offload/seam.py
+++ b/src/reyn/core/offload/seam.py
@@ -1,0 +1,71 @@
+"""The single offload seam — build a tool-result body from a canonical result (#2425 案B step1b).
+
+Given a :class:`~reyn.core.offload.canonical.CanonicalToolResult`, produce the inline tool-message
+body the caller caps, plus the media blocks for the caller's vision follow-up. The crux of 案B lives
+here: ``text`` is the SOLE offload payload; ``structured`` / ``media`` are attachments handled OUT of
+the text-offload decision, so a large ``structured`` can NEVER become a second oversized field that
+collapses the offload to a whole-dict JSON envelope (the owner chat-MCP whole-envelope bug).
+
+- **media** attachments → returned as raw blocks for the caller's existing vision follow-up (byte
+  path unchanged; this replaces the per-op ``media_blocks`` extraction at the chat chokepoint).
+- **structured** attachments → kept as data when small; when large, offloaded to their OWN ref via
+  ``save_fn`` (preserved + retrievable, not dropped, not competing with ``text``). This also folds in
+  the tui-found miss (``structured`` used to slip past the media-strip and reach the offload decision).
+- **text** → the body's payload; the caller caps ``json.dumps(body)`` with ``payload_field="text"`` so
+  the offloaded ref holds the text CLEAN (real newlines), never a whole-dict envelope.
+
+Store-parameterized (``save_fn``) so the same seam serves chat (``MediaStore.save_tool_result``) and,
+if the phase path is retained, the phase axis — but only the chat integration is wired now (#2425
+re-scope: the phase-side integration is on hold pending the skill/phase-deletion decision).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from reyn.core.offload.canonical import CanonicalToolResult
+
+# A structured attachment larger than this (serialized chars) is offloaded to its own ref rather than
+# kept inline — so it never bloats the body or competes with ``text`` in the offload decision.
+STRUCTURED_INLINE_MAX_CHARS: int = 2_000
+_STRUCTURED_PREVIEW_CHARS: int = 600
+
+
+def build_offload_body(
+    canonical: CanonicalToolResult,
+    *,
+    save_fn: Callable[..., dict],
+) -> tuple[dict, list[dict]]:
+    """Return ``(body, media_blocks)`` for a canonical tool result.
+
+    ``body`` = ``{**meta, "text": text[, "attachments": [<small structured | structured refs>]]}`` —
+    the caller serialises + caps it with ``payload_field="text"``. ``media_blocks`` = the raw media
+    blocks for the caller's vision follow-up. Large structured attachments are offloaded to their own
+    ref via ``save_fn`` (preserved, non-competing)."""
+    media_blocks: list[dict] = []
+    structured_inline: list[dict] = []
+    for att in canonical.get("attachments", []) or []:
+        kind = att.get("kind")
+        if kind == "media":
+            block = att.get("block")
+            if isinstance(block, dict):
+                media_blocks.append(block)
+        elif kind == "structured":
+            data = att.get("data")
+            serialized = json.dumps(data, ensure_ascii=False, default=str)
+            if len(serialized) > STRUCTURED_INLINE_MAX_CHARS:
+                stored = save_fn(serialized)
+                structured_inline.append({
+                    "kind": "structured",
+                    "_offload_ref": stored.get("path", ""),
+                    "_offload_content_hash": stored.get("content_hash", ""),
+                    "_offload_total_chars": len(serialized),
+                    "_offload_preview": serialized[:_STRUCTURED_PREVIEW_CHARS],
+                })
+            else:
+                structured_inline.append({"kind": "structured", "data": data})
+
+    body: dict[str, Any] = {**(canonical.get("meta") or {}), "text": canonical.get("text", "")}
+    if structured_inline:
+        body["attachments"] = structured_inline
+    return body, media_blocks

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3107,21 +3107,48 @@ class RouterLoop:
             if isinstance(r, dict) and r.get("_external_source"):
                 external_source = True
                 r = {k: v for k, v in r.items() if k != "_external_source"}
-            # #2394-followup clean-payload: if r is the OS dispatch envelope {status, data:<dict>}
-            # and data declares a SOLE-oversized payload field (shared decide_payload_field — same
-            # decision the control_ir offloader uses), pass the inner op-result + field to the cap so
-            # the offloaded file holds THAT field CLEAN (real newlines), not the whole-envelope
-            # single-line JSON. P7-safe: OS-level keys only (status/data + the op-supplied marker);
-            # generalises to every payload-field op (mcp/web/exec). Mirrors phase_executor's unwrap
-            # check. When it doesn't apply, cap behaves byte-identically to before.
             clean_value = None
             payload_field = None
-            if (isinstance(r, dict) and isinstance(r.get("data"), dict)
-                    and set(r) <= {"status", "data", "error"}):
-                payload_field = decide_payload_field(r["data"])
-                if payload_field is not None:
-                    clean_value = r["data"]
-            content_str = json.dumps(r, default=str)
+            _is_envelope = (isinstance(r, dict) and isinstance(r.get("data"), dict)
+                            and set(r) <= {"status", "data", "error"})
+            _inner = r["data"] if _is_envelope else r
+            _media_store = getattr(host, "media_store", None)
+            if (isinstance(_inner, dict) and _inner.get("kind") == "mcp"
+                    and _media_store is not None):
+                # #2425 案B: an MCP tool result normalises to a canonical shape so ``text`` (the joined
+                # content) is the SOLE offload payload and ``structured``/media are attachments held OUT
+                # of the offload decision — a large ``structuredContent`` can no longer become a second
+                # oversized field that collapses the offload to a whole-dict single-line JSON envelope
+                # (owner chat-MCP bug). It also lifts media/structured from INSIDE ``data`` (which the
+                # top-level media-strip above misses on the {status,data} envelope). The whole-inline
+                # envelope is preserved (data becomes the canonical body) and ``text`` is the clean
+                # payload the cap stores. Non-MCP ops stay on the current path below (byte-identical —
+                # canonical's whole-dict fallback would regress web/exec's own field offload).
+                from reyn.core.offload.canonical import to_canonical
+                from reyn.core.offload.seam import build_offload_body
+                _body, _mcp_media = build_offload_body(
+                    to_canonical(_inner), save_fn=_media_store.save_tool_result,
+                )
+                if _mcp_media:
+                    media_blocks = _mcp_media  # media from INSIDE data (the top-level strip missed it)
+                content_str = json.dumps(
+                    {"status": r.get("status", "ok"), "data": _body} if _is_envelope else _body,
+                    default=str,
+                )
+                clean_value = _body
+                payload_field = "text"
+            else:
+                # #2394-followup clean-payload (non-MCP): if r is the OS dispatch envelope
+                # {status, data:<dict>} and data declares a SOLE-oversized payload field (shared
+                # decide_payload_field — same decision the control_ir offloader uses), pass the inner
+                # op-result + field to the cap so the offloaded file holds THAT field CLEAN (real
+                # newlines), not the whole-envelope single-line JSON. P7-safe: OS-level keys only.
+                # Byte-identical to before for every non-MCP op.
+                if _is_envelope:
+                    payload_field = decide_payload_field(r["data"])
+                    if payload_field is not None:
+                        clean_value = r["data"]
+                content_str = json.dumps(r, default=str)
             if post_text:
                 content_str = f"{content_str}\n\n---\n{post_text}"
             # FP-0050/#1822 S2: scan-all on the FULL content BEFORE cap truncates

--- a/tests/test_2425_canonical_tool_result.py
+++ b/tests/test_2425_canonical_tool_result.py
@@ -1,0 +1,50 @@
+"""Tier 2: #2425 案B — canonical tool-result normalization removes the offload field-guess.
+
+The spec hole was that offload GUESSED the payload field (per-op marker + sole-oversized), breaking on
+a 2nd large field (owner's chat-MCP whole-envelope: a large ``structuredContent`` alongside
+``content``). ``to_canonical`` maps each result to ``{text, attachments, source_ref, meta}`` so ``text``
+is the payload by construction and non-text (structured/media) is an ``attachment`` kept OUT of the
+offload decision — so the whole-envelope case cannot structurally occur.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.core.offload.canonical import to_canonical
+
+
+def test_mcp_content_becomes_text_structured_and_media_become_attachments():
+    """Tier 2: CORE — an MCP result with a large ``content`` AND a large ``structured`` (the owner
+    whole-envelope root) normalizes so ``text`` = the content body and BOTH structured + media are
+    typed attachments (out of the offload decision) — no field to guess, no whole-dict fallback."""
+    mcp = {
+        "kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+        "content": "the body text", "structured": {"rows": [1, 2, 3]},
+        "media_blocks": [{"type": "image", "data": "..."}],
+    }
+    c = to_canonical(mcp)
+
+    assert c["text"] == "the body text", "content → the single offload payload (text)"
+    kinds = [a["kind"] for a in c["attachments"]]
+    assert "structured" in kinds and "media" in kinds, "structured + media are typed attachments"
+    assert any(a.get("data") == {"rows": [1, 2, 3]} for a in c["attachments"]), "structured preserved (not dropped)"
+    assert c["source_ref"] is None, "MCP is transient → no on-disk origin → its body must be stored"
+    assert c["meta"].get("status") == "ok" and c["meta"].get("server") == "s", "small status → meta (inline)"
+
+
+def test_mcp_without_structured_has_no_structured_attachment():
+    """Tier 2: the common case — an MCP result with only text has ``text`` set and no structured
+    attachment (clean end-state, no shim)."""
+    c = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "hi",
+                      "media_blocks": []})
+    assert c["text"] == "hi"
+    assert not any(a["kind"] == "structured" for a in c["attachments"])
+
+
+def test_unregistered_kind_falls_back_losslessly():
+    """Tier 2: an op not yet migrated to a canonical mapper round-trips through a whole-dict fallback
+    (``text`` = the JSON) — migration is incremental and lossless, never a data-loss."""
+    result = {"kind": "web_fetch", "status": "ok", "content": "page", "results": [1, 2]}
+    c = to_canonical(result)
+    assert json.loads(c["text"]) == result, "the whole dict is preserved as text until the op migrates"
+    assert c["attachments"] == [] and c["source_ref"] is None

--- a/tests/test_2425_offload_seam.py
+++ b/tests/test_2425_offload_seam.py
@@ -1,0 +1,73 @@
+"""Tier 2: #2425 案B step1b — the offload seam builds a body where text is the sole payload.
+
+``build_offload_body`` turns a canonical result into ``(body, media_blocks)``: media → the vision
+follow-up; large structured → its OWN offload ref (preserved, non-competing); text → the body payload
+the caller caps with ``payload_field="text"``. This is why the whole-envelope collapse cannot occur:
+a large structured is a separate ref, never a second oversized field in the text-offload decision.
+"""
+from __future__ import annotations
+
+from reyn.core.offload.canonical import to_canonical
+from reyn.core.offload.seam import build_offload_body
+
+
+def _fake_save(value, **_kw) -> dict:
+    """Records what was stored; returns a path-ref block like MediaStore.save_tool_result."""
+    _fake_save.stored.append(value)
+    return {"path": f".reyn/tool-results/{len(_fake_save.stored):04d}.txt", "content_hash": "h"}
+
+
+_fake_save.stored = []
+
+
+def test_large_structured_is_offloaded_to_own_ref_not_competing_with_text():
+    """Tier 2: CORE — a canonical result with text AND a LARGE structured attachment: the structured
+    is offloaded to its own ref (preview + _offload_ref), NOT inlined and NOT merged into the text
+    payload. So ``text`` stays the sole offload payload — the whole-envelope root is gone by shape."""
+    _fake_save.stored = []
+    canonical = to_canonical({
+        "kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+        "content": "the body text",
+        "structured": {"rows": ["x" * 3000]},  # large → its own ref
+    })
+    body, media = build_offload_body(canonical, save_fn=_fake_save)
+
+    assert body["text"] == "the body text", "text is the body payload (offloaded via payload_field=text)"
+    atts = body.get("attachments", [])
+    assert any(a.get("kind") == "structured" and a.get("_offload_ref") for a in atts), \
+        "the large structured is offloaded to its OWN ref (preserved, not dropped)"
+    assert _fake_save.stored, "the large structured body was stored (retrievable)"
+    # it is NOT inlined as raw data (would bloat the body) and NOT part of text
+    assert not any(a.get("data") for a in atts), "large structured is a ref, not inline data"
+    assert media == [], "no media in this result"
+
+
+def test_small_structured_stays_inline():
+    """Tier 2: a small structured attachment is kept inline (no offload) — cheap, no ref churn."""
+    _fake_save.stored = []
+    canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+                              "content": "hi", "structured": {"n": 1}})
+    body, _media = build_offload_body(canonical, save_fn=_fake_save)
+    atts = body.get("attachments", [])
+    assert any(a.get("data") == {"n": 1} for a in atts), "small structured stays inline"
+    assert _fake_save.stored == [], "no offload for a small structured"
+
+
+def test_media_blocks_returned_for_followup_not_in_body():
+    """Tier 2: media attachments are returned as raw blocks for the caller's vision follow-up and are
+    NOT left in the body (preserves the existing image-forwarding byte path)."""
+    _fake_save.stored = []
+    canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+                              "content": "hi", "media_blocks": [{"type": "image", "data": "b64"}]})
+    body, media = build_offload_body(canonical, save_fn=_fake_save)
+    assert media == [{"type": "image", "data": "b64"}], "media returned for the vision follow-up"
+    assert "attachments" not in body or all(a.get("kind") != "media" for a in body.get("attachments", [])), \
+        "media is not left in the tool-message body"
+
+
+def test_meta_is_inline_and_text_present():
+    """Tier 2: small meta (status/server/tool) is inline in the body; text is present as the payload."""
+    _fake_save.stored = []
+    canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "srv", "tool": "t", "content": "body"})
+    body, _media = build_offload_body(canonical, save_fn=_fake_save)
+    assert body["text"] == "body" and body.get("status") == "ok" and body.get("server") == "srv"

--- a/tests/test_2425_step1c_chat_chokepoint.py
+++ b/tests/test_2425_step1c_chat_chokepoint.py
@@ -1,0 +1,103 @@
+"""Tier 3a: #2425 案B step1c — the chat chokepoint canonicalizes MCP results (whole-envelope FIXED).
+
+router_loop.feedback (the chat tool-result chokepoint) now normalizes an MCP result via to_canonical
++ the offload seam: ``text`` (content) is the sole offload payload; ``structured``/media are
+attachments held OUT of the offload decision. So the owner chat-MCP whole-envelope (a large content
+AND a large structuredContent → the whole ``{status,data}`` dict stored as one JSON line) can no
+longer occur. Non-MCP ops stay byte-identical (the current decide_payload_field path). Real MediaStore
++ real RouterLoop.feedback (no mocks); the host provides the media_store the seam stores through.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.data.workspace.media_store import MediaStore
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.tools.scheme import ExecutionResult
+
+_MODEL = "gpt-4o"
+_BIG = "\n".join(f"line {i}: " + "z" * 60 for i in range(400))  # well over the offload trigger
+
+
+class _CanonicalHost:
+    """RouterLoopHost surface with the cap AND the media_store the #2425 MCP path stores through."""
+
+    def __init__(self, store: MediaStore) -> None:
+        self.media_store = store
+
+    def cap_tool_result(self, content_str: str, *, clean_value=None, payload_field=None) -> str:
+        return cap_tool_result_content(
+            content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
+            use_chars4=True, clean_value=clean_value, payload_field=payload_field,
+        )
+
+    def media_followup_budget(self, _content_str: str) -> int:
+        return 500
+
+
+def _mcp_env(**data_extra) -> dict:
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "", "media_blocks": []}
+    data.update(data_extra)
+    return {"status": "ok", "data": data}
+
+
+def _feedback(env: dict, tmp_path: Path):
+    store = MediaStore(project_root=tmp_path)
+    loop = RouterLoop(host=_CanonicalHost(store), chain_id="c1", router_model=_MODEL)
+    result = ExecutionResult(
+        tool_results=[env],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+    return loop.feedback(result), store
+
+
+def _stored_body(tool_content: str, tmp_path: Path) -> str:
+    return (tmp_path / json.loads(tool_content)["_offload_ref"]).read_text(encoding="utf-8")
+
+
+def test_a_single_payload_mcp_offloads_content_clean(tmp_path):
+    """Tier 3a: (a) a single-payload MCP result (only content large) offloads the content CLEAN — the
+    LLM-reachable body is exactly the content (fit-equivalent to the current path)."""
+    msgs, _store = _feedback(_mcp_env(content=_BIG), tmp_path)
+    tool_msg = next(m for m in msgs if m["role"] == "tool")
+    assert _stored_body(tool_msg["content"], tmp_path) == _BIG, "content offloaded clean (text = sole payload)"
+    assert json.loads(tool_msg["content"]).get("_offload_payload_field") == "text"
+
+
+def test_b_multi_field_whole_envelope_is_fixed(tmp_path):
+    """Tier 3a: (b) CORE — an MCP result with a large content AND a large structuredContent no longer
+    whole-envelopes. The offloaded body is the content CLEAN (not a JSON dict of the envelope); the
+    structured is a separate attachment, never a second oversized field. RED-verify: reverting the MCP
+    branch stores the whole {status,data} envelope (body starts with '{', structured JSON-escaped)."""
+    env = _mcp_env(content=_BIG, structured={"rows": ["x" * 4000]})
+    msgs, _store = _feedback(env, tmp_path)
+    tool_msg = next(m for m in msgs if m["role"] == "tool")
+    body = _stored_body(tool_msg["content"], tmp_path)
+    assert body == _BIG, "the offloaded body is the CLEAN content — the whole-envelope collapse is gone"
+    assert not body.lstrip().startswith("{"), "not a whole-dict JSON envelope"
+    assert "\\n" not in body, "real newlines, no JSON-of-JSON (structured did not force a whole-dict fallback)"
+
+
+def test_c_media_blocks_inside_data_are_forwarded(tmp_path):
+    """Tier 3a: (c) media blocks nested INSIDE data (which the top-level strip missed) are lifted and
+    forwarded as a multimodal follow-up — the canonical path fixes the previously-missed MCP media."""
+    env = _mcp_env(content="small", media_blocks=[{"type": "image", "data": "aGVsbG8="}])
+    msgs, _store = _feedback(env, tmp_path)
+    # a follow-up user message beyond the assistant + tool messages carries the media
+    followups = [m for m in msgs if m.get("role") == "user"]
+    assert followups, "a media follow-up message is produced (MCP image lifted from data + forwarded)"
+
+
+def test_e_non_mcp_op_stays_on_current_payload_path(tmp_path):
+    """Tier 3a: (e) a non-MCP op (exec) stays on the current decide_payload_field path — its declared
+    stdout is offloaded clean via its own marker, unchanged by the MCP branch (a permanent invariant:
+    canonicalization is MCP-only, so web/exec keep their field offload)."""
+    env = {"status": "ok", "data": {"kind": "sandboxed_exec", "status": "ok", "stdout": _BIG,
+                                     "_offload_payload_field": "stdout"}}
+    msgs, _store = _feedback(env, tmp_path)
+    tool_msg = next(m for m in msgs if m["role"] == "tool")
+    assert _stored_body(tool_msg["content"], tmp_path) == _BIG, "exec stdout offloaded clean (unchanged path)"
+    assert json.loads(tool_msg["content"]).get("_offload_payload_field") == "stdout", "current marker, not text"


### PR DESCRIPTION
**[e2e-coder]** — offload spec-fix (案B) **foundation** — the verified building blocks, **unwired (no behavior change)**. The load-bearing chat-chokepoint wiring + the whole-envelope-FIXED RED-verify land in the follow-up (step1c). Draft until step1c is ready; opened now for early review of the canonical shape + seam.

## What this is
The recurring offload bug (owner's chat-MCP whole-envelope 1-line JSON) is a **spec hole**: offload GUESSES the payload field (per-op marker + sole-oversized) and breaks on a 2nd large field (a large `structuredContent`). 案B normalizes to a canonical shape so there's nothing to guess.

- **step1a — `reyn/core/offload/canonical.py`**: `CanonicalToolResult {text, attachments, source_ref, meta}` + `to_canonical` (op-kind dispatch). MCP mapper: `content`→`text` (sole offload payload); `structured`+`media_blocks`→typed `attachments` (kept OUT of the offload decision); `status/server/tool`→`meta`; `source_ref=None` (transient→store). Unregistered kind → **lossless whole-dict fallback** (incremental migration). P7-safe.
- **step1b — `reyn/core/offload/seam.py`**: `build_offload_body(canonical, save_fn)` → `(body, media_blocks)`. Large `structured` → its **own** offload ref (preserved, non-competing); `media` → the caller's vision follow-up; `text` → the body payload (caller caps with `payload_field="text"`). **This is why the whole-envelope can't occur by shape** — a large structured is a separate ref, never a 2nd oversized field.

## Tests (Tier 2, 7 total — all green)
- canonical: whole-envelope-**dissolution** (content+structured both large → text+attachments, no whole-dict) / common case / lossless fallback.
- seam: large-structured→own-ref non-competing / small-structured inline / media→followup not in body / meta inline.

## Scope note (re-scope)
**Chat-side only.** The phase-side integration is **on HOLD** pending owner's skill/phase-deletion decision (the phase-offload path may be removed). Non-MCP/phase ops stay on the current `decide_payload_field` path (byte-identical). The seam's `save_fn` is store-generic but only chat is wired next.

## Next (step1c, load-bearing — separate close-review)
Wire the chat chokepoint (`router_loop.py:3092-3174`): **branch on `kind=="mcp"`** — MCP→canonical (fix + media/structured handling folds in the tui media-strip miss), non-MCP→current path (byte-identical, avoids regressing web/exec clean-offload). Full chat test matrix (a)-(e) + **RED-verify** (whole-envelope revival must fail).

part of #2425