### PR TITLE
fix(inline-cui): widen free-text intervention routing to choices-shape

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -948,11 +948,12 @@ async def _submit(registry, text: str) -> None:
     # field clear with no response — a silent failure. Contain it: log + surface a
     # visible error line via the outbox the output loop already drains.
     try:
-        # Route free-text input to a pending ask_user intervention rather than
-        # starting a new chat turn. Approval interventions (Python/HTTP) are
-        # handled by the region dropdown and never reach this path.
+        # Route free-text input to any pending free-text intervention rather than
+        # starting a new chat turn. Free-text = no choices (ask_user, mcp_install.secret,
+        # etc.). Closed-set interventions (choices non-empty) are handled by the region
+        # dropdown and never reach this path — matching build_intervention_element logic.
         head = s.interventions.head()
-        if head is not None and head.kind == "ask_user":
+        if head is not None and not head.choices:
             await s.answer_oldest_intervention_text(text)
             return
         await s.submit_user_text(text)

--- a/tests/test_inline_intervention_region.py
+++ b/tests/test_inline_intervention_region.py
@@ -189,23 +189,20 @@ async def test_answer_oldest_intervention_text_delivers_free_text(
     assert answer.text == "Alice"
 
 
-@pytest.mark.asyncio
-async def test_submit_routes_to_intervention_bus_when_ask_user_pending() -> None:
-    """Tier 2: ``_submit`` routes free-text to ``answer_oldest_intervention_text``
-    (not ``submit_user_text``) when the head pending intervention is ask_user.
-
-    RED-verify: removing the ``head.kind == "ask_user"`` routing check would
-    call ``submit_user_text`` instead — this test fails in that case.
-    """
+def _stub_registry(*, choices: list) -> SimpleNamespace:
+    """Build a minimal registry stub with a head intervention of given choices."""
     answered: list[str] = []
     submitted: list[str] = []
 
     class _StubIntervention:
-        kind = "ask_user"
+        pass
+
+    iv = _StubIntervention()
+    iv.choices = choices  # type: ignore[attr-defined]
 
     class _StubInterventions:
         def head(self):
-            return _StubIntervention()
+            return iv
 
     class _StubSession:
         interventions = _StubInterventions()
@@ -218,7 +215,38 @@ async def test_submit_routes_to_intervention_bus_when_ask_user_pending() -> None
             submitted.append(text)
 
     registry = SimpleNamespace(attached_session=lambda: _StubSession())
+    return registry, answered, submitted
+
+
+@pytest.mark.asyncio
+async def test_submit_routes_to_intervention_bus_when_ask_user_pending() -> None:
+    """Tier 2: ``_submit`` routes free-text to ``answer_oldest_intervention_text``
+    (not ``submit_user_text``) when the head pending intervention has no choices
+    (ask_user is the canonical case).
+
+    RED-verify: replacing ``not head.choices`` with a kind-name check like
+    ``head.kind == "ask_user"`` would pass for ask_user but fail for other
+    free-text kinds (mcp_install.secret). Widened to choices-shape to match
+    build_intervention_element logic.
+    """
+    registry, answered, submitted = _stub_registry(choices=[])
     await _submit(registry, "hello ask_user")
 
     assert answered == ["hello ask_user"], "text must reach intervention bus"
-    assert submitted == [], "submit_user_text must NOT be called while ask_user pending"
+    assert submitted == [], "submit_user_text must NOT be called while free-text iv pending"
+
+
+@pytest.mark.asyncio
+async def test_submit_routes_to_intervention_bus_for_mcp_install_secret() -> None:
+    """Tier 2: ``_submit`` routes free-text to the intervention bus for
+    ``mcp_install.secret`` (choices=[]) — the same free-text class as ask_user.
+
+    RED-verify: ``head.kind == "ask_user"`` silently misses mcp_install.secret
+    and calls ``submit_user_text`` instead, leaving the MCP install awaiting a
+    secret that never arrives.
+    """
+    registry, answered, submitted = _stub_registry(choices=[])
+    await _submit(registry, "mysecretvalue")
+
+    assert answered == ["mysecretvalue"], "secret must reach intervention bus"
+    assert submitted == [], "submit_user_text must NOT be called for mcp_install.secret"


### PR DESCRIPTION
**[tui-coder]** — found via dogfood mining of the I1/I2 intervention fixes (#2416/#2419).

## Root cause

`_submit` (the inline CUI input dispatcher) routed free-text answers to `answer_oldest_intervention_text` only when `head.kind == "ask_user"`. This missed other free-text intervention kinds with `choices=[]`, specifically `mcp_install.secret` — the prompt the MCP install op raises when a required environment variable/secret is needed.

When an MCP install prompts for a secret, the user types at the `❯` bar and submits. The `kind == "ask_user"` check fails → the answer falls through to `submit_user_text` as a new chat turn → the MCP install waits forever for a secret that never arrives (same I1 class, different kind).

## Fix

Changed the condition from `head.kind == "ask_user"` to `not head.choices` — matching `build_intervention_element`'s own closed-set detection. The invariant is:
- `choices=[]` → free-text intervention → input field → routes to intervention bus
- `choices non-empty` → closed-set → region dropdown → never reaches `_submit`

## Changes

- `app.py`: `head.kind == "ask_user"` → `not head.choices` + updated comment
- `test_inline_intervention_region.py`: extracted `_stub_registry()` helper; updated existing stub to include `choices=[]`; added `mcp_install.secret` RED-verify case

## Test plan

- [x] `pytest tests/test_inline_intervention_region.py` — 11 passed
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_intervention_region.py` — all OK
- [x] (skipped — no TTY) Live MCP install with secret prompt: `mcp_install.secret` iv routing

Tier self-check: Tier 2 (routing logic via stub). No Tier 4 violations.

part of #2414