### PR TITLE
refactor: relocate frontmatter splitter to core/frontmatter (skill-deletion PR-0)

### DIFF
--- a/src/reyn/core/frontmatter.py
+++ b/src/reyn/core/frontmatter.py
@@ -1,0 +1,26 @@
+"""Markdown YAML-frontmatter splitting utility.
+
+Splits a Markdown document into its leading ``---``-delimited YAML frontmatter
+block and the remaining body. Shared by any subsystem that reads structured
+metadata from Markdown files (file tools, memory store).
+"""
+from __future__ import annotations
+
+import yaml
+
+
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    """Split a Markdown file into (frontmatter dict, body string).
+
+    Returns ``({}, text)`` unchanged when the text has no leading ``---``
+    frontmatter block or the block is never closed.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+    end = next((i for i, l in enumerate(lines[1:], 1) if l.strip() == "---"), None)
+    if end is None:
+        return {}, text
+    fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    body = "\n".join(lines[end + 1:]).strip()
+    return fm, body

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -675,7 +675,7 @@ def regenerate_index_impl(
     - Scans direct children of `dir_path` matching `*.md`, sorted by name.
     - Skips any file whose basename equals `output_path.name` so the index
       doesn't include itself.
-    - Parses YAML frontmatter via `_split_frontmatter`. Files with no /
+    - Parses YAML frontmatter via `split_frontmatter`. Files with no /
       malformed frontmatter are skipped silently.
     - Substitutes `entry_template` placeholders against frontmatter keys
       plus `slug` (= filename without `.md`). Missing placeholders fall
@@ -683,7 +683,7 @@ def regenerate_index_impl(
     - Writes `header + "\\n".join(entries) + "\\n"` (trailing newline only
       when entries exist).
     """
-    from reyn.core.compiler.parser import _split_frontmatter
+    from reyn.core.frontmatter import split_frontmatter
 
     output_basename = output_path.name
     entries: list[str] = []
@@ -695,7 +695,7 @@ def regenerate_index_impl(
                 content = child.read_text(encoding="utf-8")
             except OSError:
                 continue
-            fm, _body = _split_frontmatter(content)
+            fm, _body = split_frontmatter(content)
             if not isinstance(fm, dict) or not fm:
                 # No / malformed frontmatter — skip rather than emit a
                 # placeholder-empty entry like `- []() — `.

--- a/src/reyn/data/memory/memory.py
+++ b/src/reyn/data/memory/memory.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from reyn.core.compiler.parser import _split_frontmatter
+from reyn.core.frontmatter import split_frontmatter
 from reyn.data.memory.memory_paths import memory_dir
 
 VALID_TYPES = ("user", "feedback", "project", "reference")
@@ -47,7 +47,7 @@ def read_entry(path: Path) -> MemoryEntry | None:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return None
-    fm, body = _split_frontmatter(text)
+    fm, body = split_frontmatter(text)
     description_raw = str(fm.get("description") or "").strip()
     description = description_raw.splitlines()[0] if description_raw else ""
     return MemoryEntry(


### PR DESCRIPTION
**[e2e-coder]** — Skill/phase machinery deletion, **PR-0** (prerequisite groundwork). Part of the owner-GO'd, lead-coordinated skill-deletion arc (no umbrella issue filed yet — flagged to lead).

## What
Relocate the generic Markdown YAML-frontmatter splitter out of the skill compiler into a standalone util module, so the compiler can later be deleted without stranding its only non-skill dependency.

- **New**: `src/reyn/core/frontmatter.py` → `split_frontmatter(text) -> (dict, str)` (behavior-identical to the old `core/compiler/parser._split_frontmatter`).
- **Repointed** the two non-skill consumers:
  - `src/reyn/core/op_runtime/file.py` (index builder)
  - `src/reyn/data/memory/memory.py` (memory store)

## Why
`_split_frontmatter` is the **only** piece of `core/compiler/` that non-skill code depends on. Extracting it is the clean-break prerequisite for deleting `core/compiler/` with the rest of the skill/phase machinery (PR-1+).

## No-dup note
The compiler keeps its own internal `_split_frontmatter` (used by `parse_phase`/`parse_skill`) until the compiler itself is deleted in a later stage — so there is **no duplication for consumers**: external consumers use the new `core/frontmatter`, the compiler uses its own copy until it is removed wholesale. The skill-surface consumers (`web/routers/skills.py`, `cli/commands/skills.py`) are left on the compiler import since they are deleted with the skill machinery; `session.py`'s usages are CUT in PR-1.

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/verify_module_docstrings.py` on all 3 changed src files — clean (no refactor narrative)
- [x] Targeted: `pytest -k "memory or frontmatter or index_events or file_index or build_index"` — 213 passed
- [x] Full `pytest` — 8489 passed, 17 skipped, 3 xfailed (exit 0)
- [x] Import smoke: `split_frontmatter('---\na: 1\n---\nbody')` → `({'a': 1}, 'body')`

No test files changed (pure relocation, existing suites exercise it) → tier-audit N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)