### PR TITLE
refactor(#2434): stage3a-1 — strip skill/phase exports from reyn/ + kernel/ package roots

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -1,46 +1,9 @@
-"""reyn — Agent OS public API (lazy-loaded top-level names).
+"""reyn — Agent OS package root.
 
-The package's public names are resolved lazily via PEP 562 ``__getattr__`` so
-that importing a *submodule* — notably ``reyn.core.kernel._python_harness``, the
-python preprocessor-step child entry point — does NOT eagerly pull the
-agent / llm / httpx chain in through this ``__init__``.
-
-This extends the FP-0008 C4 lazy-litellm fix (which made ``import litellm``
-lazy) one layer down: the harness path now imports only what it needs
-(allowlist + stdlib), so its cold import stays well under the python-step
-timeout. The eager chain (``SkillRuntime`` -> ``llm`` -> ``httpx``) cost ~0.5s,
-which under the in-container venv path on an emulated host inflated past the ~5s
-step timeout and aborted steps. ``from reyn import SkillRuntime`` / ``reyn.SkillRuntime``
-still work — they trigger the lazy load on first access.
+This ``__init__`` performs NO eager imports, so importing a *submodule* —
+notably ``reyn.core.kernel._python_harness``, the python preprocessor-step child
+entry point — does not pull the agent / llm / httpx chain in through the package
+root. (FP-0008 C4: keeping the harness cold-import path well under the
+python-step timeout.)
 """
 from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # import-cost-free hints for type checkers / IDEs
-    from reyn.core.kernel.runtime import RunResult
-    from reyn.schemas.models import Phase, Skill, SkillGraph
-    from reyn.skill.skill_runtime import SkillRuntime
-
-__all__ = ["Skill", "Phase", "SkillGraph", "SkillRuntime", "RunResult"]
-
-_LAZY_ATTRS = {
-    "SkillRuntime": "reyn.skill.skill_runtime",
-    "RunResult": "reyn.core.kernel.runtime",
-    "Phase": "reyn.schemas.models",
-    "Skill": "reyn.schemas.models",
-    "SkillGraph": "reyn.schemas.models",
-}
-
-
-def __getattr__(name: str):
-    import importlib
-
-    module_path = _LAZY_ATTRS.get(name)
-    if module_path is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    return getattr(importlib.import_module(module_path), name)
-
-
-def __dir__():
-    return sorted(__all__)

--- a/src/reyn/core/kernel/__init__.py
+++ b/src/reyn/core/kernel/__init__.py
@@ -1,61 +1,10 @@
-"""kernel — OS runtime engine (P3: context build, LLM call, validation, transitions).
+"""kernel — code-execution runtime submodules (codeact + python-step harness).
 
-Public names are resolved lazily (PEP 562 ``__getattr__``) so that importing a
-kernel *submodule* — notably ``reyn.core.kernel._python_harness``, the python
-preprocessor-step child entry point — does not eagerly pull the runtime / llm
-chain in through this ``__init__``. See ``reyn/__init__.py`` for the rationale
-(FP-0008 C4 lazy-import line extended to the package surface). ``from
-reyn.core.kernel import OSRuntime`` / ``reyn.core.kernel.OSRuntime`` still work via the
-lazy load on first access; submodule imports (``from reyn.core.kernel.normalizer
-import ...``) are unaffected.
+This ``__init__`` performs NO eager imports, so importing a *submodule* —
+notably ``reyn.core.kernel._python_harness``, the python preprocessor-step child
+entry point — does not pull any heavier chain in through this package root.
+Submodule imports (``from reyn.core.kernel.codeact_runner import CodeActRunner``,
+``from reyn.core.kernel.sub_loop_memo_key import ...``) are used directly and are
+unaffected.
 """
 from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # import-cost-free hints for type checkers / IDEs
-    from .control_ir_executor import ControlIRExecutor
-    from .normalizer import (
-        ControlIRValidationError,
-        NormalizationError,
-        NormalizationResult,
-        normalize,
-    )
-    from .preprocessor_executor import PreprocessorExecutor
-    from .runtime import LoopLimitExceededError, OSRuntime, RunResult
-    from .validation import ValidationError, validate_output
-
-__all__ = [
-    "OSRuntime", "RunResult", "LoopLimitExceededError",
-    "validate_output", "ValidationError",
-    "normalize", "NormalizationError", "NormalizationResult", "ControlIRValidationError",
-    "ControlIRExecutor",
-    "PreprocessorExecutor",
-]
-
-_LAZY_ATTRS = {
-    "ControlIRExecutor": ".control_ir_executor",
-    "ControlIRValidationError": ".normalizer",
-    "NormalizationError": ".normalizer",
-    "NormalizationResult": ".normalizer",
-    "normalize": ".normalizer",
-    "PreprocessorExecutor": ".preprocessor_executor",
-    "LoopLimitExceededError": ".runtime",
-    "OSRuntime": ".runtime",
-    "RunResult": ".runtime",
-    "ValidationError": ".validation",
-    "validate_output": ".validation",
-}
-
-
-def __getattr__(name: str):
-    import importlib
-
-    submodule = _LAZY_ATTRS.get(name)
-    if submodule is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    return getattr(importlib.import_module(submodule, __name__), name)
-
-
-def __dir__():
-    return sorted(__all__)

--- a/tests/test_python_harness_no_litellm_import.py
+++ b/tests/test_python_harness_no_litellm_import.py
@@ -68,43 +68,6 @@ def test_harness_import_does_not_load_agent_llm_chain():
     )
 
 
-def test_lazy_public_api_still_resolves():
-    """Tier 2: PEP 562-lazy __init__ still exposes the public names on access.
-
-    Falsification guard for the lazy refactor: ``from reyn import SkillRuntime`` and
-    ``from reyn.core.kernel import OSRuntime`` must still resolve (now triggering the
-    lazy load), and an unknown attribute must raise AttributeError — proving the
-    laziness did not silently drop the public surface.
-    """
-    code = "\n".join(
-        [
-            "import reyn",
-            "from reyn import SkillRuntime, RunResult, Phase, Skill, SkillGraph",
-            "from reyn.core.kernel import OSRuntime, validate_output, normalize",
-            "names = (SkillRuntime, RunResult, Phase, Skill, SkillGraph,",
-            "         OSRuntime, validate_output, normalize)",
-            "assert all(x is not None for x in names), 'a public name resolved to None'",
-            "raised = False",
-            "try:",
-            "    reyn.DoesNotExist",
-            "except AttributeError:",
-            "    raised = True",
-            "assert raised, 'unknown attr did not raise AttributeError'",
-        ]
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert result.returncode == 0, (
-        f"lazy public API did not resolve correctly.\n"
-        f"stdout: {result.stdout}\n"
-        f"stderr: {result.stderr}"
-    )
-
-
 def test_harness_import_time_is_below_ceiling():
     """Tier 2: harness import completes well under the preprocessor timeout ceiling.
 


### PR DESCRIPTION
**[e2e-coder]** — Part of #2434 (skill/phase machinery deletion). **Stage 3a-1**: strip the skill/phase machinery names from the two package-root `__init__` export surfaces, ahead of the machinery bulk-delete (3b).

## What
- **`reyn/__init__`**: drop the lazy `Skill`/`Phase`/`SkillGraph`/`SkillRuntime`/`RunResult` re-exports (all **zero src consumers** — machinery imports from `schemas.models` / `reyn.skill` directly). Package root is now a bare, eager-import-free `__init__` (the `_python_harness` cold-import protection rationale is preserved).
- **`core/kernel/__init__`**: drop the phase-engine lazy exports (`OSRuntime`/`RunResult`/`normalize`/`validate_output`/`ControlIRExecutor`/`PreprocessorExecutor` — **zero `from reyn.core.kernel import` consumers**). The KEEP code-execution submodules (`codeact_runner`, `_codeact_harness`, `_python_harness`, `_python_allowlist`, `sub_loop_memo_key`) are **untouched** (1-byte-identical) and imported directly.

The phase-engine files, `reyn.skill`, and the schema classes stay present and are deleted atomically in **3b**.

## Codeact LIVE-verify (runtime, not import-green)
Per the gate condition: after touching the shared `__init__` surface, the codeact tool + python-step harness **subprocess** still run — `test_codeact_runner` / `_scheme` / `_harness_python` / `_direct_functions` all pass (31 tests). This is real runtime execution, not import-green.

## Obsolete test
Removed `test_lazy_public_api_still_resolves` (asserted the removed lazy public-name surface: `from reyn import SkillRuntime`, `from reyn.core.kernel import OSRuntime`, …). The file's python-harness no-litellm cold-import tests are kept.

## Test plan (all gates green)
- [x] `ruff check` (changed files + full-tree) — clean
- [x] `pytest` (full) — **8263 passed, 17 skipped, 2 xfailed** (exit 0; one fewer than baseline = the removed obsolete test)
- [x] tier-audit `--strict` on changed test — 0 errors, 0 warnings
- [x] `verify_module_docstrings` on changed src — clean
- [x] codeact LIVE-verify (subprocess) — 31 passed

## Follow-ups in this arc (context for review)
- **3a-3**: CLI strip-keep (cron/mcp/audit) + web/server + slash/skills + web/routers — next PR.
- **3b**: Sonnet bulk-delete — CLI skill-only deletes (run/eval/eval_benchmark/skill/skills) + machinery atomic (phase-engine kernel-13 + skill/ + compiler/ + stdlib/skills + op_runtime run_skill/skill_resolve/**lint** + schema classes + control-ir.md doc-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)