### PR TITLE
refactor(#2439): remove dead OpContext.skill field (skill-deletion residual 1/4)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from reyn.data.workspace.workspace import Workspace
     from reyn.llm.model_resolver import ModelResolver
     from reyn.mcp.pool import MCPClientPool
-    from reyn.schemas.models import Skill
     from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
     from reyn.security.sandbox import SandboxBackend
     from reyn.security.sandbox.policy import SandboxPolicy
@@ -41,8 +40,6 @@ class OpContext:
     permission_resolver: "PermissionResolver | None" = None
     skill_name: str = ""
 
-    # Sub-skill invocation
-    skill: "Skill | None" = None  # current skill (for preloaded preprocessor sub-skills)
     model: str = "standard"
     resolver: "ModelResolver | None" = None
     subscribers: list = field(default_factory=list)

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -308,7 +308,6 @@ async def _handle_call_mcp_tool(
             permission_decl=PermissionDecl(mcp=[server]),
             permission_resolver=ctx.permission_resolver,
             skill_name="",
-            skill=None,
             # #1673: real resolver + "tool" purpose class (was None + literal
             # "standard") — eliminates the resolver=None → litellm-BadRequestError
             # class by construction (uniform; this handler makes no LLM call).

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -111,7 +111,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         permission_decl=PermissionDecl(),
         permission_resolver=ctx.permission_resolver,
         skill_name="",
-        skill=None,
         # #1673: real config-aware resolver + "tool" purpose class (was None +
         # literal "standard"). This handler makes no LLM call, but threading the
         # resolver eliminates the resolver=None → litellm-BadRequestError class by

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -87,7 +87,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         ),
         permission_resolver=ctx.permission_resolver,
         skill_name="",
-        skill=None,
         # #1673: real resolver + "tool" purpose class (was None + literal
         # "standard") — eliminates the resolver=None → litellm-BadRequestError class
         # by construction (uniform with invoke_skill; this handler makes no LLM call).


### PR DESCRIPTION
**[e2e-coder]** — Part of #2439 (stage3-residual cleanup after the #2434 machinery deletion). **Item 1 of 4 — the bounded/safe one.**

## What
The `skill: "Skill | None"` field on `OpContext` was **write-only** after the #2434 machinery deletion — set to `None` by 3 op handlers (`sandboxed_exec` / `mcp` / `web_search`), **never read** (the phase/skill executors that read it are deleted). It also carried the **last dangling `TYPE_CHECKING` import of the deleted `Skill` schema class** in `op_runtime/context.py`.

- Remove the `OpContext.skill` field + its `TYPE_CHECKING` `Skill` import + the 3 `skill=None` kwargs.
- Bounded, non-breaking (write-only field, zero readers — verified by grep: no `ctx.skill`/`context.skill` reader).

## Test plan
- [x] `grep` — no `OpContext.skill` reader, no remaining `skill=None`/`Skill` import
- [x] `ruff check src tests scripts` — clean
- [x] `pytest` (full) — **7006 passed** (exit 0)
- [x] Targeted (op_runtime + 3 handlers) — 231 passed

## #2439 scope note (context for review)
This is the safe item. The remaining 3 are tracked in #2439 for **careful follow-up** (not rushed, per lead's directive):
- **PhaseConstraints / max_phase_visits** — investigated: it's **dead** (phase-visit enforcement was in the deleted phase executor; `ContextFrame.constraints` is write-only, no KEEP op-loop enforces `max_phase_visits`). BUT removal is a **wide cascade + owner-adjacent** (it removes the `safety.loop.max_phase_visits` reyn.yaml config knob) → needs a lead/owner ruling before removal.
- **permissions.startup_guard** — dead (zero callers) but security-adjacent + intermixed with the KEEP chat gate → careful separation.
- **stale prose** (~10 files, excluding session.py which is tui's stage3.5 `running_skills` domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)