### PR TITLE
refactor(#2439): remove dead self_improvement + skill_search config

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -36,9 +36,7 @@ models:
 | `chat` | マップ | チャットセッションの Head/Body/Tail 圧縮設定。以下参照。 |
 | `voice` | マップ | チャット TUI の音声入力（Whisper）設定。以下参照。 |
 | `events` | マップ | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
-| `skill_search` | マップ | BM25 Skill 事前フィルター設定。以下参照。 |
 | `skill_resume` | マップ | 再起動時の曖昧なステップに対するレジューム ポリシー。以下参照。 |
-| `self_improvement` | マップ | `skill_improver` の適用ゲートとバージョン上限。以下参照。 |
 | `mcp` | マップ | MCP サーバー定義と `search_threshold`。以下参照。 |
 | `python` | マップ | Python preprocessor の追加許可モジュール。以下参照。 |
 | `agent` | マップ | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
@@ -922,23 +920,6 @@ voice:
 | `num_workers` | int | `1` | 並列転写ストリーム数。`1` でメモリとスレッド使用量を低く保ちます。 |
 | `max_duration_s` | float | `300.0` | この秒数を超える録音を自動キャンセル。放置録音によるメモリ増大を防ぎます。 |
 
-## `skill_search` ブロック
-
-BM25 Skill 事前フィルター設定。カタログが `threshold` を超える Skill 数になると、ルーターは `tools=` を構築する前に上位 `top_k` の BM25 キーワードマッチに利用可能 Skill の列挙を絞り込みます。BM25 が 0 件を返した場合は全列挙にフォールバック — Skill が見えなくなることはありません。
-
-```yaml
-skill_search:
-  threshold: 20    # BM25 が有効化されるカタログサイズ; 0 = 常にフィルター
-  top_k: 5         # BM25 が返す Skill 数
-  backend: bm25    # bm25（デフォルト）; embedding / hybrid は将来のフェーズ向けに予約
-```
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `threshold` | int | `20` | BM25 事前フィルタリングが有効化されるカタログサイズ。`0` で常にフィルタリング; 大きな数値で実質的に無効化。 |
-| `top_k` | int | `5` | BM25 が返す最良マッチ Skill 数。最小値 `1`。 |
-| `backend` | 文字列 | `bm25` | 検索バックエンド。`bm25` が唯一のアクティブバックエンド。`embedding` と `hybrid` は将来のフェーズ向けに予約。 |
-
 ## `skill_resume` ブロック
 
 ステップ途中で中断された Skill 実行のレジューム ポリシー。*曖昧なステップ* とは `step_started` WAL イベントに対応する `step_completed` / `step_failed` がないもので、op が外部で確定している可能性があります。
@@ -962,21 +943,6 @@ skill_resume:
 |-------|------|---------|-------------|
 | `default` | 文字列 | `retry` | 全 Skill のデフォルトレジューム ポリシー。 |
 | `per_skill` | マップ | `{}` | Skill ごとのポリシーオーバーライド。キーは Skill 名、値は上記ポリシーのいずれか。 |
-
-## `self_improvement` ブロック
-
-`skill_improver` の動作設定。Skill 改善提案をソースに適用する方法を制御します。
-
-```yaml
-self_improvement:
-  on_propose: ask_user   # ask_user | auto | disabled
-  max_versions: 10       # 保持する v<N>.md スナップショットの上限; 0 = 制限なし
-```
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `on_propose` | 文字列 | `ask_user` | 改善を適用しようとする際の動作。`ask_user` — intervention `RequestBus` 経由でユーザーに確認（安全なデフォルト）。`auto` — プロンプトをスキップして直接適用（CI / 無人実行向け）。`disabled` — `skill_improvement_dry_run` イベントをログに記録し変更を適用しない。 |
-| `max_versions` | int | `10` | `.reyn/skill-versions/<name>/` に保持する `v<N>.md` スナップショットの上限。上限を超えると最古バージョンが削除されます（current バージョンは削除されません）。`0` でプルーニングを無効化。 |
 
 ## `python` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -38,10 +38,8 @@ models:
 | `chat` | map | Chat-session compaction settings. See below. |
 | `voice` | map | Voice input (Whisper) settings for the chat TUI. See below. |
 | `events` | map | Audit-log rotation policy for chat-session event files. See below. |
-| `skill_search` | map | BM25 skill pre-filter settings. See below. |
 | `skill_resume` | map | Resume policy for ambiguous steps on restart. See below. |
 | `tool_use` | map | Per-layer tool-use scheme selector (chat/step/phase). See below. |
-| `self_improvement` | map | `skill_improver` apply-gate and version cap. See below. |
 | `mcp` | map | MCP server definitions and `search_threshold`. See below. |
 | `python` | map | Python preprocessor additional allowed-modules. See below. |
 | `agent` | map | Agent identity for P6 event audit trail and outgoing HTTP header. See below. |
@@ -1293,23 +1291,6 @@ voice:
 | `num_workers` | int | `1` | Parallel transcription streams. `1` keeps memory + thread usage low. |
 | `max_duration_s` | float | `300.0` | Auto-cancel recordings longer than this (seconds). Prevents runaway memory growth from unattended recordings. |
 
-## `skill_search` block
-
-BM25 skill pre-filter settings. When the catalogue exceeds `threshold` skills, the router narrows the available skill enum to the top `top_k` BM25 keyword matches before building `tools=`. Falls through to the full enum when BM25 returns zero results — no skill is ever silently hidden.
-
-```yaml
-skill_search:
-  threshold: 20    # catalogue size at which BM25 activates; 0 = always filter
-  top_k: 5         # number of skills returned by BM25
-  backend: bm25    # bm25 (default); embedding / hybrid reserved for future phases
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `threshold` | int | `20` | Catalogue size at which BM25 pre-filtering activates. Set `0` to always pre-filter; set a high number to effectively disable. |
-| `top_k` | int | `5` | Number of best-matching skills returned by BM25. Minimum `1`. |
-| `backend` | string | `bm25` | Search backend. `bm25` is the only active backend; `embedding` and `hybrid` are reserved for future phases. |
-
 ## `skill_resume` block
 
 Resume policy for skill runs interrupted mid-step. An *ambiguous step* is one whose `step_started` WAL event has no matching `step_completed` / `step_failed` — the op may have committed externally.
@@ -1333,21 +1314,6 @@ skill_resume:
 |-------|------|---------|-------------|
 | `default` | string | `retry` | Default resume policy for all skills. |
 | `per_skill` | map | `{}` | Per-skill policy overrides. Key is the skill name; value is one of the policies above. |
-
-## `self_improvement` block
-
-`skill_improver` behavior knobs. Controls how the skill improver applies proposed changes back to the skill source.
-
-```yaml
-self_improvement:
-  on_propose: ask_user   # ask_user | auto | disabled
-  max_versions: 10       # max v<N>.md snapshots kept; 0 = no pruning
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `on_propose` | string | `ask_user` | What `skill_improver` does when about to apply improvements. `ask_user` — pause and prompt the user via the intervention `RequestBus` (safe default). `auto` — skip the prompt and apply directly (for CI / unattended runs). `disabled` — log a `skill_improvement_dry_run` event and do NOT apply changes. |
-| `max_versions` | int | `10` | Maximum `v<N>.md` snapshots kept under `.reyn/skill-versions/<name>/`. Oldest version is deleted when the cap is exceeded (the current version is never deleted). `0` = disable pruning. |
 
 ## `python` block
 

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -234,55 +234,6 @@ def _build_embedding_config(raw: object) -> EmbeddingConfig:
 
 
 @dataclass
-class SkillSearchConfig:
-    """`skill_search:` — BM25 skill pre-filter settings (FP-0024 Component A).
-
-    When the catalogue exceeds ``threshold`` skills, the router narrows
-    ``invoke_skill.name`` enum to the top-``top_k`` BM25 keyword matches
-    before building the tools list.  Falls through to full enum on 0 BM25
-    results (= no skill made invisible).
-
-    Fields:
-        threshold:  Catalogue size at which BM25 activates. Default 20.
-                    Set 0 to always pre-filter; set a high number to disable.
-        top_k:      Number of skills returned by BM25. Default 5.
-        backend:    ``'bm25'`` (default). ``'embedding'`` / ``'hybrid'``
-                    reserved for Component C/D.
-    """
-
-    threshold: int = 20
-    top_k: int = 5
-    backend: str = "bm25"
-
-
-def _build_skill_search_config(raw: object) -> "SkillSearchConfig":
-    """Parse the ``skill_search:`` section. Empty / missing returns defaults."""
-    defaults = SkillSearchConfig()
-    if not isinstance(raw, dict):
-        return defaults
-    threshold_raw = raw.get("threshold", defaults.threshold)
-    top_k_raw = raw.get("top_k", defaults.top_k)
-    backend_raw = raw.get("backend", defaults.backend)
-    try:
-        threshold = int(threshold_raw)
-        if threshold < 0:
-            threshold = 0
-    except (TypeError, ValueError):
-        threshold = defaults.threshold
-    try:
-        top_k = int(top_k_raw)
-        if top_k < 1:
-            top_k = 1
-    except (TypeError, ValueError):
-        top_k = defaults.top_k
-    return SkillSearchConfig(
-        threshold=threshold,
-        top_k=int(top_k),
-        backend=str(backend_raw),
-    )
-
-
-@dataclass
 class ActionRetrievalConfig:
     """`action_retrieval:` — FP-0034 universal catalog + retrieval settings.
 

--- a/src/reyn/config/execution.py
+++ b/src/reyn/config/execution.py
@@ -15,64 +15,6 @@ SKILL_RESUME_POLICIES = ("prompt", "retry", "skip", "discard_skill")
 
 
 @dataclass
-class SelfImprovementConfig:
-    """`self_improvement:` — skill_improver behavior knobs (FP-0006).
-
-    Fields:
-        on_propose:
-            What skill_improver does when it is about to apply improvements
-            back to the original skill directory:
-
-            - ``ask_user`` (default): pause and prompt the user via the
-              InterventionBus (summarise score + changes, wait for approval
-              before writing). Safe default — the user is in the loop.
-            - ``auto``: skip the prompt and apply directly. Intended for CI /
-              unattended runs where the operator trusts the eval gate.
-            - ``disabled``: do NOT apply the changes. Log a
-              ``skill_improvement_dry_run`` event noting what would have been
-              applied. Useful for "what would improve this skill?" exploration
-              without modifying the source.
-
-        max_versions:
-            Maximum number of v<N>.md snapshot files kept in
-            ``.reyn/skill-versions/<name>/``.  When the cap is exceeded the
-            OLDEST version is deleted (the version pointed to by ``current``
-            is never deleted).  Default 10.  Set 0 to disable pruning.
-    """
-
-    on_propose: Literal["ask_user", "auto", "disabled"] = "ask_user"
-    max_versions: int = 10
-
-    def __post_init__(self) -> None:
-        _VALID_ON_PROPOSE = {"ask_user", "auto", "disabled"}
-        if self.on_propose not in _VALID_ON_PROPOSE:
-            raise ValueError(
-                f"self_improvement.on_propose {self.on_propose!r} is not one of "
-                f"{sorted(_VALID_ON_PROPOSE)}"
-            )
-        if self.max_versions < 0:
-            raise ValueError(
-                f"self_improvement.max_versions must be >= 0, got {self.max_versions}"
-            )
-
-
-def _build_self_improvement_config(raw: object) -> "SelfImprovementConfig":
-    """Parse the ``self_improvement:`` section. Empty / missing returns defaults."""
-    defaults = SelfImprovementConfig()
-    if not isinstance(raw, dict):
-        return defaults
-    on_propose_raw = raw.get("on_propose", defaults.on_propose)
-    on_propose = str(on_propose_raw) if on_propose_raw is not None else defaults.on_propose
-    max_versions_raw = raw.get("max_versions", defaults.max_versions)
-    try:
-        max_versions = int(max_versions_raw)
-    except (TypeError, ValueError):
-        max_versions = defaults.max_versions
-    # Validation is delegated to __post_init__ — raises ValueError with clear message.
-    return SelfImprovementConfig(on_propose=on_propose, max_versions=max_versions)
-
-
-@dataclass
 class SkillResumeConfig:
     """`skill_resume:` — policy for handling ambiguous steps on resume.
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -16,10 +16,8 @@ from reyn.config.embedding import (  # #1682 #3 cross-section
     ActionRetrievalConfig,
     _build_action_retrieval_config,
     _build_embedding_config,
-    _build_skill_search_config,
 )
 from reyn.config.execution import (  # #1682 #3 cross-section
-    _build_self_improvement_config,
     _build_skill_resume_config,
     _build_tool_use_config,
 )
@@ -478,13 +476,11 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         cost_warn=cost_warn,
         web=_build_web_config(merged.get("web")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),
-        skill_search=_build_skill_search_config(merged.get("skill_search")),
         eval=_build_eval_config(merged.get("eval")),
         sandbox=_build_sandbox_config(merged.get("sandbox")),
         # #1800 slice 5b: the raw ``hooks:`` block, passed through (parsed by
         # ``load_hooks`` at Session construction). None/absent → empty list.
         hooks=merged.get("hooks") or [],
-        self_improvement=_build_self_improvement_config(merged.get("self_improvement")),
         action_retrieval=_build_action_retrieval_config(merged.get("action_retrieval")),
         cron=_build_cron_config(merged.get("cron")),
         external_transports=_build_external_transports_config(

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -39,10 +39,8 @@ from reyn.config.chat import (
 from reyn.config.embedding import (
     ActionRetrievalConfig,
     EmbeddingConfig,
-    SkillSearchConfig,
 )
 from reyn.config.execution import (
-    SelfImprovementConfig,
     SkillResumeConfig,
     ToolUseConfig,
 )
@@ -188,11 +186,6 @@ class ReynConfig:
     # ``reyn config set/get/fields`` and the doc-mirror guard don't advertise
     # a key the set/get path can't honor.
     mcp_search_threshold: int = field(default=30, metadata={"schema_internal": True})
-    # FP-0024 Component A — BM25 skill pre-filter settings.
-    # Below threshold: full enum. Above threshold: BM25 top-K filter.
-    # Default 20 — current stdlib (~30-50 skills) stays at full enum unless
-    # the operator explicitly lowers the threshold.
-    skill_search: SkillSearchConfig = field(default_factory=SkillSearchConfig)
     # Python preprocessor step settings.
     python: PythonConfig = field(default_factory=PythonConfig)
     # FP-0016 Component E — agent identity for audit trail + HTTP header
@@ -270,8 +263,6 @@ class ReynConfig:
     # here and parsed via ``load_hooks`` at Session construction. Empty (default)
     # → empty registry → the HookDispatcher is a no-op.
     hooks: list = field(default_factory=list)
-    # FP-0006 B+D: skill_improver behavior knobs (on_propose gate + max_versions cap).
-    self_improvement: SelfImprovementConfig = field(default_factory=SelfImprovementConfig)
     # FP-0034: universal catalog gating + action retrieval (D13 / D14).
     # Default-off so existing chat behaviour is byte-identical until the
     # operator explicitly opts in; will flip in PR-3b-iii after LLMReplay


### PR DESCRIPTION
**[e2e-coder]** — #2439-config fix-class, self_improvement group (audit-first, lead-GO'd).

## What
Removes two dead skill-configs whose consumers were deleted with the skill/phase machinery, code + `reyn-yaml.md`/`.ja.md` mirror-coupled in one PR:

- **`self_improvement`** (FP-0006 skill_improver knobs) — `skill_improver` skill gone; `on_propose`/`max_versions` have no reader.
- **`skill_search`** (FP-0024 BM25 skill pre-filter) — router-narrowing consumer gone; `.skill_search` has zero attribute reads.

## Audit (budget-lesson method)
Per-config read-only audit: attribute-access grep **+** string-literal `getattr` consumer **+** test-coverage.

| config | `.attr` reads | live method caller | tests | verdict |
|--------|---------------|--------------------|-------|---------|
| `self_improvement` | 0 | 0 | **0** | cleanly dead → **remove** |
| `skill_search` | 0 | 0 | 1 *(name-collision)* | cleanly dead → **remove** |
| `skill_resume` | 0 | `policy_for` 0 callers | dedicated `test_config_skill_resume.py` + `per_skill` subsystem | test-covered subsystem → **defer #2439** |

- `skill_search`'s only test ref (`test_multi_agent_p7` `_KNOWN_SKILL_NAMES`) is a **name-collision** on the deleted stdlib *skill* `"skill_search"`, not the config → not real coverage.
- `skill_resume` **retained** here (dedicated config-parse test + `policy_for`/`per_skill` method surface) — deferred to the #2439 follow-up per the "test-covered/subsystem → defer" rule.

## Removed surface
`config/execution.py` (SelfImprovementConfig class + builder), `config/embedding.py` (SkillSearchConfig class + builder), `config/root.py` (imports + ReynConfig fields), `config/loader.py` (imports + assignments), `reyn-yaml.md` + `reyn-yaml.ja.md` (table rows + blocks). `skill_resume` block kept intact in all four.

## Unblocks
The #2441 docs arc (docs-maintainer): `--max-phase-visits` CLI-flag prose already stripped (commit 7b686851); this removes the self_improvement/skill_search **config-doc** sections mirror-coupled with the code.

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python -m pytest` — 7006 passed, 16 skipped, 1 xfailed (baseline preserved)
- [x] `test_config_mirror_coverage_1056` — 13 passed (code↔doc parity confirmed post-strip)
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] tier-audit — N/A (no test files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)