### PR TITLE
refactor(#2439): remove dead startup_guard skill-preflight permission path

### DIFF
--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -100,7 +100,7 @@ def build_router_op_context(
         mcp=mcp_names,
         allowed_mcp=allowed_mcp,
         # #571 Phase 7: wildcard http.get (per-host 4-layer prompt at runtime) +
-        # the MCP registry host specifically (mcp_install startup_guard pre-approval).
+        # the MCP registry host specifically (mcp_install pre-approval).
         http_get=[
             {"host": "registry.modelcontextprotocol.io"},
             {"host": "*"},

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -135,7 +135,7 @@ class AgentLayer:
             # #1199 S3.1b-2c-2: faithful to require_http_get's membership decision —
             # a specific declared host OR the "*" wildcard (host set unknown at
             # write-time). The intricate resolution flow (config-deny tiers /
-            # startup_guard host-prompt / legacy compat / per-host persistence)
+            # runtime host-prompt / legacy compat / per-host persistence)
             # stays in require_http_get as the non-∩ flow; this axis is just the
             # decl membership (so S3.1c can ∩ SandboxLayer.network).
             return (

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -49,8 +49,6 @@ from reyn.user_intervention import (
 if TYPE_CHECKING:
     from reyn.security.sandbox.policy import SandboxPolicy
 
-    from .models import Skill
-
 
 _DEFAULT_WRITE_ZONES = (".reyn",)
 
@@ -390,7 +388,7 @@ class PermissionResolver:
     Resolves permission requests against config, saved approvals, and a
     ``RequestBus`` for user prompts.
 
-    The bus is supplied per-call (`require_*`, `startup_guard`, …) by the
+    The bus is supplied per-call (`require_*`) by the
     caller, since the bus is tied to the Agent that's running while the
     resolver is shared across runs in long-lived sessions (chat).
     """
@@ -597,8 +595,8 @@ class PermissionResolver:
             return True
         # Composite keys (e.g. "skill_router/python.safe/./mod.py:fn") accept
         # a kind-level blanket grant in config (e.g. "python.safe: allow").
-        # The startup_guard already honors this; mirror the behavior at the
-        # runtime check so config and startup are consistent.
+        # Honor the same config blanket-grant here at the
+        # runtime check so config and runtime stay consistent.
         for part in key.split("/"):
             if "." in part and self._is_config_approved(part):
                 return True
@@ -742,9 +740,9 @@ class PermissionResolver:
     ) -> None:
         """Mark `path` as approved for this session only (not persisted).
 
-        Used to suppress startup_guard prompts for paths a stdlib skill
-        declares but the caller wants to silently approve up-front (avoids an
-        interactive prompt before the chat REPL takes over stdin).
+        Used to suppress the runtime prompt for paths the caller wants to
+        silently approve up-front (avoids an interactive prompt before the
+        chat REPL takes over stdin).
 
         kind: "file.read" or "file.write". When recursive=True the approval
         covers the directory and everything beneath it.
@@ -804,7 +802,7 @@ class PermissionResolver:
         answer = await bus.request(iv)
         choice = answer.choice_id
         # #2415: honor the DECLARED scope on approval. When the skill declared this path as
-        # ``recursive`` (startup_guard confirming a declared grant), an affirmative approval grants
+        # ``recursive`` (confirming a declared grant), an affirmative approval grants
         # the declared RECURSIVE dir — the operator approves/denies the declared grant, they do not
         # re-scope it narrower. Otherwise (a JIT prompt, or a ``just_path`` declaration) an
         # affirmative grants the exact path. Without this, a skill that declares ``reyn/local``
@@ -822,243 +820,6 @@ class PermissionResolver:
             return True
         # NO or unknown → deny (session-only)
         self._session[f"{skill_name}/{kind}/{path}"] = False
-        return False
-
-    async def _prompt_file_write(
-        self, path: str, scope: str, skill_name: str, bus: RequestBus,
-    ) -> bool:
-        return await self._prompt_file_access(path, scope, skill_name, "file.write", bus)
-
-    async def startup_guard(
-        self, skill: "Skill", skill_name: str, bus: "RequestBus | None",
-    ) -> None:
-        """
-        Pre-flight permission check: scan all phase declarations, collect paths that
-        fall outside the default zones, and ask the user to approve them before
-        execution starts. Already-approved and config-approved paths are skipped.
-
-        Non-interactive runs require approvals to be in place beforehand: either
-        pre-approved in reyn.yaml / reyn.local.yaml (layer 3) or persisted to
-        .reyn/approvals.yaml from a prior interactive run (layer 2).
-
-        B49 W2-S5 fix (2026-05-22): ``bus`` may be ``None`` when the caller
-        is a non-interactive context (e.g. a preprocessor sub-skill run
-        invoked via ``run_skill`` op from inside ``iterate`` /
-        ``run_op``). If all permissions are already approved or the skill
-        declares none that need approval, the guard returns without using
-        the bus. If unapproved permissions are found and ``bus is None``,
-        a ``RuntimeError`` is raised with a clear message naming the
-        pending permissions so the caller can surface the
-        mis-configuration. Previously, ``run_orchestrator`` had an
-        unconditional pre-check ``if intervention_bus is None: raise``
-        that blocked any preprocessor sub-skill call when the resolver
-        was configured, regardless of whether prompts were actually
-        needed; that pre-check is removed and the None-handling moves
-        here, where it can branch on actual prompt necessity.
-        """
-        write_requests: list[dict] = []
-        read_requests: list[dict] = []
-        write_seen: set[tuple] = set()
-        read_seen: set[tuple] = set()
-
-        decl = skill.permissions  # aggregated upper bound across all phases
-        for entry in decl.file_write:
-            path = entry.get("path", "")
-            scope = entry.get("scope", "just_path")
-            if not path:
-                continue
-            if _in_default_write_zone(path, self._file_zone_root):  # #1414
-                continue
-            if self._is_config_approved("file.write"):
-                continue
-            if self._is_path_approved_for(path, skill_name, "file.write"):
-                continue
-            key = (path, scope)
-            if key not in write_seen:
-                write_seen.add(key)
-                write_requests.append({"path": path, "scope": scope})
-
-        for entry in decl.file_read:
-            path = entry.get("path", "")
-            scope = entry.get("scope", "just_path")
-            if not path:
-                continue
-            if _in_default_read_zone(path, self._file_zone_root):  # #1414
-                continue
-            if self._is_config_approved("file.read"):
-                continue
-            if self._is_path_approved_for(path, skill_name, "file.read"):
-                continue
-            key = (path, scope)
-            if key not in read_seen:
-                read_seen.add(key)
-                read_requests.append({"path": path, "scope": scope})
-
-        # Python preprocessor steps — both safe and unsafe require approval.
-        # Unsafe additionally needs unsafe_python_allowed (checked here so the
-        # user is told why their startup is being aborted before any prompts fire).
-        python_requests: list[dict] = []
-        python_seen: set[tuple] = set()
-        for entry in decl.python:
-            key = (entry.module, entry.function)
-            if key in python_seen:
-                continue
-            python_seen.add(key)
-            kind = "python.unsafe" if entry.mode == "unsafe" else "python.safe"
-            if self._is_config_approved(kind):
-                continue
-            approval_key = f"{skill_name}/{kind}/{entry.module}:{entry.function}"
-            if approval_key in self._saved or approval_key in self._session:
-                continue
-            python_requests.append({
-                "module": entry.module, "function": entry.function,
-                "mode": entry.mode,
-            })
-
-        # Hard-fail before prompting if an unsafe step appears without the flag.
-        for req in python_requests:
-            if req["mode"] == "unsafe" and not self._unsafe_python_allowed:
-                raise PermissionError(
-                    f"Skill '{skill_name}' declares an unsafe "
-                    f"python step ({req['module']}:{req['function']}) but "
-                    f"--allow-unsafe-python was not provided. Re-run with the flag "
-                    f"to enable unsafe-mode Python preprocessor steps."
-                )
-
-        # #571 Phase 7: http.get specific declarations follow the
-        # file.write pattern — startup_guard prompts the operator once
-        # per skill+host and persists under ``<skill>/http.get/<host>``.
-        # Wildcard ``"*"`` entries are skipped here; their prompt fires
-        # JIT in ``require_http_get`` at the actual host gate.
-        http_get_requests: list[dict] = []
-        http_get_seen: set[str] = set()
-        for entry in decl.http_get:
-            if not isinstance(entry, dict):
-                continue
-            host = entry.get("host", "")
-            if not host or host == "*":
-                continue
-            if host in http_get_seen:
-                continue
-            if self._is_config_approved("web.fetch"):
-                continue
-            if self._is_config_approved(f"http.get.{host}"):
-                continue
-            if self._is_host_approved_for(host, skill_name, "http.get"):
-                continue
-            http_get_seen.add(host)
-            http_get_requests.append({"host": host})
-
-        if not (write_requests or read_requests or python_requests or http_get_requests):
-            return
-
-        # B49 W2-S5 fix (2026-05-22): bus may be None in non-interactive
-        # contexts (= preprocessor sub-skill run). If we reach here,
-        # prompts are needed but no bus is available — surface a clear
-        # error rather than silently skipping approvals or crashing
-        # inside _prompt_*.
-        if bus is None:
-            pending = (
-                [f"file.read:{r['path']}" for r in read_requests]
-                + [f"file.write:{r['path']}" for r in write_requests]
-                + [f"python:{r['module']}:{r['function']}" for r in python_requests]
-                + [f"http.get:{r['host']}" for r in http_get_requests]
-            )
-            raise RuntimeError(
-                f"Skill '{skill_name}' has unapproved permissions "
-                f"({', '.join(pending)}) but no intervention_bus is "
-                f"available to prompt the user. Pre-approve via "
-                f"reyn.yaml or an interactive run before using this "
-                f"skill non-interactively."
-            )
-
-        for req in read_requests:
-            await self._prompt_file_access(
-                req["path"], req["scope"], skill_name, "file.read", bus,
-            )
-        for req in write_requests:
-            await self._prompt_file_access(
-                req["path"], req["scope"], skill_name, "file.write", bus,
-            )
-        for req in python_requests:
-            kind = "python.unsafe" if req["mode"] == "unsafe" else "python.safe"
-            key = f"{skill_name}/{kind}/{req['module']}:{req['function']}"
-            await self._prompt_python(key, req["module"], req["function"], req["mode"], bus)
-        for req in http_get_requests:
-            await self._prompt_http_get(req["host"], skill_name, bus)
-
-    async def _prompt_http_get(
-        self, host: str, skill_name: str, bus: RequestBus,
-    ) -> bool:
-        """Approve a specific http.get host at startup; persist on yes.
-
-        #571 Phase 7: mirrors ``_prompt_file_access`` for HTTP host
-        approvals. Uses the generic yes/no/always choice set (= host
-        has no scope axis, so the file-access ``just_path`` /
-        ``recursive`` choice doesn't apply). Persistence key is
-        ``<skill>/http.get/<host>``.
-        """
-        if not self._interactive:
-            self._session[f"{skill_name}/http.get/{host}"] = False
-            return False
-        iv = UserIntervention(
-            kind="permission.http.get",
-            prompt=f"Allow fetching from {host!r}?",
-            detail=f"skill {skill_name!r} requests http.get for host {host!r}",
-            choices=generic_yn_choices(),
-        )
-        answer = await bus.request(iv)
-        choice = answer.choice_id
-        key = f"{skill_name}/http.get/{host}"
-        if choice == YES:
-            self._session[key] = True
-            return True
-        if choice == ALWAYS:
-            self._persist(key, True)
-            return True
-        # NO or unknown → deny (session-only)
-        self._session[key] = False
-        return False
-
-    async def _prompt_python(
-        self, key: str, module: str, function: str, mode: str, bus: RequestBus,
-    ) -> bool:
-        """Approve a python step; persist on yes."""
-        if not self._interactive:
-            # stdlib skills set unsafe_python_allowed=True — their python steps
-            # are safe by construction and must auto-approve even in non-interactive
-            # mode (--non-interactive).  User-supplied unsafe steps without the
-            # flag are already hard-rejected in startup_guard before this point.
-            #
-            # Apply the auto-allow to BOTH unsafe and safe modes. `safe` is the
-            # more-restricted capability (per _python_allowlist.py), so any
-            # context that auto-allows unsafe MUST auto-allow safe — otherwise
-            # stdlib `mode: safe` is strictly more locked-down than stdlib
-            # `mode: unsafe`, which is semantically backwards. Pre-seeding the
-            # session here also primes the matching require_python check at
-            # runtime so the two code paths agree.
-            if self._unsafe_python_allowed:
-                self._session[key] = True
-                return True
-            self._session[key] = False
-            return False
-        verb = "UNSAFE" if mode == "unsafe" else "safe"
-        iv = UserIntervention(
-            kind="permission.python",
-            prompt=f"Python step ({verb}): {module}:{function}",
-            detail=f"approval key: {key}",
-            choices=python_choices(),
-        )
-        answer = await bus.request(iv)
-        choice = answer.choice_id
-        if choice == YES:
-            self._session[key] = True
-            return True
-        if choice == ALWAYS:
-            self._persist(key, True)
-            return True
-        # NO or unknown → deny (session-only)
-        self._session[key] = False
         return False
 
     # ── Public check methods ──────────────────────────────────────────────────
@@ -1206,10 +967,10 @@ class PermissionResolver:
         known:
 
         - **Specific declared host** (``http.get: [{host: "api.github.com"}]``):
-          ``startup_guard`` prompts the operator once per skill+host
-          at startup and persists the decision to approvals.yaml under
-          ``<skill>/http.get/<host>``. Runtime is then silent — this
-          method finds the persisted approval and passes.
+          the runtime prompt fires once per host and persists the
+          decision to approvals.yaml under ``<skill>/http.get/<host>``.
+          A subsequent run is then silent — this method finds the
+          persisted approval and passes.
         - **Wildcard** (``http.get: [{host: "*"}]`` or ``["*"]``): host
           set is unknown at write-time (= LLM picks at runtime), so
           the prompt fires here at the actual host gate. Same
@@ -1274,8 +1035,8 @@ class PermissionResolver:
         if self._is_config_approved(f"http.get.{host}"):
             return
 
-        # Persisted per-host approval (= startup_guard for specific,
-        # prior runtime decision for wildcard).
+        # Persisted per-host approval (from a prior interactive
+        # runtime prompt, specific or wildcard).
         if skill_name and self._is_host_approved_for(host, skill_name, "http.get"):
             return
         # Legacy session/saved ``web.fetch`` approval still authorises
@@ -1303,15 +1064,14 @@ class PermissionResolver:
         if EffectivePermission([AgentLayer(decl)]).allows(
             CapabilityAxis.NETWORK_HOST, host
         ):
-            # Need to prompt — either startup_guard was skipped (=
-            # non-interactive run with a still-unapproved specific decl)
-            # or this is the wildcard JIT path.
+            # Need to prompt — a still-unapproved host (a specific decl
+            # not yet approved, or the wildcard JIT path).
             if bus is None:
                 raise PermissionError(
                     f"HTTP access to host {host!r} requires an interactive "
                     f"prompt but no bus is available. Pre-approve via "
                     f"reyn.yaml (`permissions.web.fetch: allow` for blanket, "
-                    f"or run interactively so startup_guard can collect "
+                    f"or run interactively so the prompt can collect "
                     f"approvals)."
                 )
             approval_key = f"{skill_name}/http.get/{host}"
@@ -1545,7 +1305,7 @@ class PermissionResolver:
         """Resolve which python permission entry applies; raise if denied.
 
         Lookup is by (module, function). Safe-mode steps need a one-time
-        startup_guard approval (saved per skill+module:function). Unsafe-mode
+        interactive approval (saved per skill+module:function). Unsafe-mode
         steps additionally require unsafe_python_allowed=True (set by the
         --allow-unsafe-python CLI flag).
 

--- a/tests/test_1199_s31b2c2_http_get.py
+++ b/tests/test_1199_s31b2c2_http_get.py
@@ -3,7 +3,7 @@
 require_http_get's host-MEMBERSHIP decision (has_specific OR has_wildcard) routes
 through the model (NETWORK_HOST axis, decl-membership only — no approval_check, as
 the config/persisted/legacy approvals are separate disjuncts). The intricate
-resolution flow (config-deny tiers / startup_guard prompt / legacy compat) stays.
+resolution flow (config-deny tiers / interactive prompt / legacy compat) stays.
 The broad byte-identical guard is the http_get/web_fetch suites; these pin the
 NETWORK_HOST wildcard + the membership routing (via the bus=None raise paths).
 python is deliberately NOT routed (resolves+returns a PythonPermission).

--- a/tests/test_permission_collapse_phase2.py
+++ b/tests/test_permission_collapse_phase2.py
@@ -99,11 +99,11 @@ async def test_require_file_write_rejects_approvals_yaml(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_require_file_write_accepts_canonical_after_session_approval(tmp_path, monkeypatch):
-    """Tier 2: require_file_write passes when path was approved at startup_guard time.
+    """Tier 2: require_file_write passes when path was approved via a prior interactive prompt.
 
     Phase 2 does not change require_file_write semantics — declaration alone
-    does NOT pass; operator must approve (via startup_guard or persisted
-    approval). This test simulates the post-startup-guard state.
+    does NOT pass; operator must approve (via the interactive prompt or persisted
+    approval). This test simulates the post-approval state.
     """
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
@@ -111,7 +111,7 @@ async def test_require_file_write_accepts_canonical_after_session_approval(tmp_p
         file_write=[{"path": ".reyn/config/index/sources.yaml", "scope": "just_path"}]
     )
     resolver.session_approve_path(".reyn/config/index/sources.yaml", "skill_x", "file.write")
-    # Should not raise — startup_guard's session approval covers the path.
+    # Should not raise — the session approval covers the path.
     await resolver.require_file_write(decl, ".reyn/config/index/sources.yaml", "skill_x")
 
 
@@ -144,7 +144,7 @@ def test_canonical_path_via_explicit_file_write_requires_startup_approval(tmp_pa
     Phase 5 removed the "skip canonical when bool axis set" carve-out
     because the bool axes themselves are gone. Now every file.write
     entry that's outside the default zone — including canonical paths
-    — flows through the standard startup_guard prompt.
+    — flows through the standard interactive prompt.
     """
     monkeypatch.chdir(tmp_path)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)

--- a/tests/test_permission_collapse_phase3.py
+++ b/tests/test_permission_collapse_phase3.py
@@ -115,10 +115,10 @@ def test_require_http_get_raises_for_undeclared_host(tmp_path):
 def test_require_http_get_passes_for_declared_host(tmp_path):
     """Tier 2: require_http_get passes silently for a persisted approval.
 
-    #571 Phase 7: specific declarations expect to be approved at
-    startup_guard time. This test simulates that via the public
+    #571 Phase 7: specific declarations expect to be approved via an
+    interactive prompt. This test simulates that via the public
     session_approve_path() API (= same persistence write that
-    startup_guard's prompt would do), then verifies runtime
+    the prompt would do), then verifies runtime
     require_http_get passes silently.
     """
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)

--- a/tests/test_permission_prompt_phrasing.py
+++ b/tests/test_permission_prompt_phrasing.py
@@ -132,7 +132,7 @@ async def test_announce_meta_carries_natural_prompt() -> None:
 # require_cron_register were removed alongside the bool-axis resolver
 # methods themselves. Authorisation flows through ``require_file_write``
 # (no interactive prompt at runtime) — operator consent is collected
-# at startup_guard time for the canonical file.write paths.
+# via the runtime prompt for the canonical file.write paths.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #2439 item#2, security-delicate. Root-cause audit-first, same rigor as the stage1 session.py surgery.

## What
`startup_guard()` scanned a `Skill`'s aggregated phase permission declarations and pre-collected operator approvals *before* a skill run started. With the skill/phase machinery deleted it has **zero functional callers** (`grep '.startup_guard(' src tests` = empty). Removed as a coherent unit; the **KEEP chat permission gate is untouched**.

## Audit (budget-lesson method: attribute + string-literal + test-coverage)
| symbol | functional callers | verdict |
|--------|-------------------|---------|
| `startup_guard` (832-989) | **0** (`.startup_guard(` empty) | remove |
| `_prompt_http_get` | 1 — startup_guard:988 only | remove (exclusive) |
| `_prompt_python` | 1 — startup_guard:986 only | remove (exclusive) |
| `_prompt_file_write` | **0** repo-wide (already dead) | remove (cleanup) |
| `from .models import Skill` | dangling (`permissions/models.py` gone) | remove |
| `_prompt_file_access`, `_is_*_approved_for`, `_is_config_approved` | chat gate | **KEEP (shared)** |
| `require_http_get` (1193) / `require_python` (1540) | chat gate | **KEEP** — prompt inline via bus, **not** via the removed `_prompt_*` |

Key separation check: the two removed prompt collectors were startup_guard-exclusive; the surviving `require_http_get`/`require_python` do their own bus prompting inline (verified — the removed helpers had no other caller).

## Prose / user-facing text
Reworded the 9 `startup_guard` refs in `permissions.py` + `effective.py` + `router_op_context.py` + 4 test docstrings to the surviving mechanisms (config pre-approval / persisted approvals / JIT `require_*` prompt). **Includes the `require_http_get` `PermissionError`** (was "run interactively so *startup_guard* can collect approvals" → "so the prompt can collect approvals"). The broader `SkillRuntime`/`SkillRunner` stale-prose sweep (#2439 item#3) is left to its own PR.

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] permission suite (collapse phase2/3, prompt-phrasing, http_get) — **42 passed** (chat gate intact)
- [x] `python -m pytest` — **6970 passed**, 16 skipped, 1 xfailed, 0 failed (delta-0 test count — prose-only test edits, no test removed)
- [x] `test_tier_audit.py --strict` (4 changed test files) — OK: 42, 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] `grep startup_guard src tests` — **zero residual**

🤖 Generated with [Claude Code](https://claude.com/claude-code)