### PR TITLE
feat(inline-cui): /rewind picker polish — anchor truncation + scroll hint

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -643,11 +643,19 @@ async def run_inline_input(registry, renderer, config=None) -> None:
                 out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
             else:
                 out.append((f"fg:{_CC_DIM}", f"   {ln}"))
+        items_below = len(lines) - scroll - _ABOVE_REGION_MAX_HEIGHT
+        if items_below > 0:
+            out.append(("", "\n"))
+            out.append((f"fg:{_CC_DIM}", f"   ↓ {items_below} more"))
         return out
 
     def above_region_height() -> Dimension:
-        n = min(len(above_region.lines()), _ABOVE_REGION_MAX_HEIGHT)
-        return Dimension.exact(n)
+        lines = above_region.lines()
+        n = len(lines)
+        scroll = above_region.scroll
+        visible = min(n, _ABOVE_REGION_MAX_HEIGHT)
+        hint = 1 if n > scroll + _ABOVE_REGION_MAX_HEIGHT else 0
+        return Dimension.exact(visible + hint)
 
     above_region_win = Window(
         FormattedTextControl(above_region_frags, focusable=True),

--- a/src/reyn/interfaces/inline/region_command.py
+++ b/src/reyn/interfaces/inline/region_command.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+_ANCHOR_MAX_LEN = 50
+
 
 class CommandUIElement:
     """A RegionElement for a slash-command selector.
@@ -55,7 +57,8 @@ def rewind_rows(points: list[dict]) -> tuple[list[str], list[str]]:
         anchor = p.get("anchor")
         label = f"seq {seq} · {kind}"
         if anchor:
-            label += f" ({anchor})"
+            a = anchor if len(anchor) <= _ANCHOR_MAX_LEN else anchor[:_ANCHOR_MAX_LEN - 1] + "…"
+            label += f" ({a})"
         rows.append(label)
         submit_texts.append(f"/rewind {seq}")
     return rows, submit_texts

--- a/tests/test_inline_region_command_f4.py
+++ b/tests/test_inline_region_command_f4.py
@@ -7,6 +7,7 @@ command UIs (and F5's status bar) reuse it.
 from __future__ import annotations
 
 from reyn.interfaces.inline.region_command import (
+    _ANCHOR_MAX_LEN,
     CommandUIElement,
     build_rewind_command_ui,
     rewind_rows,
@@ -46,6 +47,26 @@ def test_build_rewind_command_ui_select_submits_rewind_seq() -> None:
     assert el.lines() == ["seq 42 · turn", "seq 38 · turn"]
     el.on_select(0)
     assert submitted == ["/rewind 42"]
+
+
+def test_rewind_rows_truncates_long_anchors() -> None:
+    """Tier 2: anchors longer than _ANCHOR_MAX_LEN are truncated to max-1 chars + '…'
+    so the picker rows stay readable in a typical terminal width."""
+    long_anchor = "x" * (_ANCHOR_MAX_LEN + 20)
+    rows, _ = rewind_rows([{"seq": 1, "kind": "turn", "anchor": long_anchor}])
+    label = rows[0]
+    # The anchor in parens should be at most _ANCHOR_MAX_LEN chars + parens.
+    # Extract the anchor portion from "seq 1 · turn (<anchor>)".
+    inner = label[label.index("(") + 1 : label.rindex(")")]
+    assert len(inner) == _ANCHOR_MAX_LEN, f"expected {_ANCHOR_MAX_LEN} chars, got {len(inner)}"
+    assert inner.endswith("…"), "truncated anchor must end with ellipsis"
+
+
+def test_rewind_rows_short_anchor_is_unchanged() -> None:
+    """Tier 2: an anchor at or under _ANCHOR_MAX_LEN is passed through verbatim."""
+    short = "a" * _ANCHOR_MAX_LEN
+    rows, _ = rewind_rows([{"seq": 1, "kind": "turn", "anchor": short}])
+    assert f"({short})" in rows[0]
 
 
 def test_rewind_rows_preserves_caller_order() -> None:


### PR DESCRIPTION
**[tui-coder]** — Polish PR following #2449 (/rewind "Window too small" fix).

## Summary

- **Anchor truncation**: `rewind_rows()` now caps anchor text at `_ANCHOR_MAX_LEN = 50` chars, appending `…` for longer strings. Before: a long checkpoint anchor could overflow the picker row. After: `seq 1066 · turn (echo "TMUX_MCP_START"; /rewind; echo "TMUX_MCP_DO…)`.
- **Scroll hint**: `above_region_frags()` appends a dim `↓ N more` row when checkpoints extend below the 12-row viewport cap, so users know there are more items to scroll through.
- **Tests**: 2 new Tier 2 cases in `test_inline_region_command_f4.py` — `test_rewind_rows_truncates_long_anchors` (boundary at exactly `_ANCHOR_MAX_LEN`) and `test_rewind_rows_short_anchor_is_unchanged` (verbatim pass-through).

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_region_command_f4.py` — 6 tests OK, 0 Tier 4
- [x] `pytest` — 6952 passed, 0 failures
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] Dogfood verified: `/rewind` in 339-checkpoint WAL shows truncated anchors + `↓ 64 more` hint rendered correctly in dogfood session

## Tier self-check

New tests: Tier 2 (behavioral contract on pure `rewind_rows()` function, no mocks, no private-state assertions, no format pins). ✓

Part of #2449.