### PR TITLE
docs(#2439): sweep stale prose referencing deleted skill/phase machinery

### DIFF
--- a/src/reyn/core/op_runtime/ask_user.py
+++ b/src/reyn/core/op_runtime/ask_user.py
@@ -36,7 +36,7 @@ async def handle(op: AskUserIROp, ctx: OpContext, caller: Literal["preprocessor"
         raise RuntimeError(
             "ask_user invoked without an intervention_bus on OpContext. "
             "Wire a bus (StdinInterventionBus for CLI, ChatInterventionBus "
-            "for chat) when constructing the SkillRuntime."
+            "for chat) when constructing the OpContext."
         )
 
     choices = _options_to_choices(op.options or [])

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -91,19 +91,19 @@ class OpContext:
     # Format: "direct" or "agents/<name>" (validated in Agent).
     caller: str = "direct"
 
-    # R-D13: nested skill lineage. The currently-running OSRuntime sets
+    # R-D13: nested skill lineage. The currently-running runtime sets
     # this to its own ``run_id`` when constructing OpContext for control
     # IR execution. ``run_skill`` handlers propagate it to the spawned
     # child run as ``parent_run_id``, so the per-skill snapshot tree
     # records the parent / child relationship for ``/skill list``,
     # debug logs, and future cascade-discard semantics. ``None`` means
     # "no parent visible" (e.g. preprocessor-spawned sub-skills, or
-    # OSRuntime invocations that don't track a run_id).
+    # runtime invocations that don't track a run_id).
     parent_skill_run_id: str | None = None
 
-    # FP-0021: the run_id of the currently-executing OSRuntime run.
-    # Threaded from OSRuntime → ControlIRExecutor / PreprocessorExecutor →
-    # OpContext so event emit helpers can stamp every event with the correct
+    # FP-0021: the run_id of the currently-executing run.
+    # Threaded from the runtime through the ctx-build seams to OpContext so
+    # event emit helpers can stamp every event with the correct
     # run scope. None when the OpContext is created outside a run scope
     # (e.g. chat router, CLI commands).
     run_id: str | None = None
@@ -174,7 +174,7 @@ class OpContext:
     # behaviour; preserves backward compat for top-level / chat-router /
     # CLI-direct OpContext construction). The run_skill handler constructs a
     # ScopedSecretStore based on the sub-skill's required_credentials and
-    # passes it down through Agent → OSRuntime → executors → OpContext.
+    # passes it down through Agent → the ctx-build seams → OpContext.
     secret_store: "ScopedSecretStore | None" = None
 
     # #1470: per-turn asyncio.Event fired by cancel_inflight(). When set,
@@ -185,7 +185,7 @@ class OpContext:
 
     # #1953 slice 3a: the config-selected, session-scoped Task backend instance.
     # Threaded from the Session (which owns the session-scoped db path) down
-    # through SkillRuntime → OSRuntime → executors, exactly like sandbox_backend.
+    # through the ctx-build seams to OpContext, exactly like sandbox_backend.
     # The task.* op handlers use this when set; None → the op-runtime falls back
     # to its process-local in-memory backend (slice-1 stub for tests / direct
     # OpContext construction). Mirrors the contextual_permission (#1912) chain
@@ -195,13 +195,13 @@ class OpContext:
     # #1953 slice 6-ext: the OS TaskWaker driver (parallel to task_backend). The
     # abort/failed → parent-routing hub calls it to wake the parent's session to
     # decide recovery. None = no-op stub here (slice 7 wires the real TaskWaker +
-    # threads it through the same Session → SkillRuntime → OSRuntime chain). Tests
+    # threads it through the same Session → OpContext chain). Tests
     # inject a recording waker to verify the call-site fires.
     task_waker: "object | None" = None
 
     # #2187 backend-master: the Task SUBSCRIPTION writer (a SubscriptionWriter; parallel
-    # to task_backend / task_waker, threaded down the SAME Session → SkillRuntime →
-    # OSRuntime chain). The mutating task ops (create / reassign) call it to append the
+    # to task_backend / task_waker, threaded down the SAME Session → OpContext
+    # chain). The mutating task ops (create / reassign) call it to append the
     # task↔session BINDING to the WAL (the Reyn-internal subscription — what Reyn owns +
     # rewinds; the backend keeps task-STATE). None = no-op (direct/test construction or
     # no state_log) → the op skips the append (the opt-in contract). Tests inject a

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -244,15 +244,13 @@ ALL_TOOL_NAMES: frozenset[str] = ALL_OP_KINDS
 # ---------------------------------------------------------------------------
 # _PHASE_TOOL_NAME_ALIAS — chat-name → op-kind mapping (#1240 Wave 2b)
 # ---------------------------------------------------------------------------
-# Phase-advertised chat names ("invoke_skill" / "call_mcp_tool") alias to the
-# canonical execution op kinds ("run_skill" / "mcp").  The phase frame shows
-# the chat names so phase = chat-tools subset (catalog-axis goal); parse
-# boundaries in op_loop + json-mode rewrite them to the op kind BEFORE
-# ControlIROp validation.  The build_frame allowed-ops filter applies this
-# alias so allowed_ops=[run_skill] matches the advertised invoke_skill spec.
-# Execution backends (op_runtime/run_skill.py, op_runtime/mcp.py) and
-# ControlIROp models (RunSkillIROp, MCPIROp) are UNCHANGED — they continue
-# to use the op-kind names.
+# The phase-advertised chat name "call_mcp_tool" aliases to the canonical
+# execution op kind "mcp".  The phase frame shows the chat name so phase =
+# chat-tools subset (catalog-axis goal); parse boundaries in op_loop +
+# json-mode rewrite it to the op kind BEFORE ControlIROp validation.  The
+# build_frame allowed-ops filter applies this alias so allowed_ops=[mcp]
+# matches the advertised call_mcp_tool spec.  The execution backend
+# (op_runtime/mcp.py) and ControlIROp model (MCPIROp) use the op-kind name.
 # ---------------------------------------------------------------------------
 
 _PHASE_TOOL_NAME_ALIAS: dict[str, str] = {

--- a/src/reyn/interfaces/cli/env_backend.py
+++ b/src/reyn/interfaces/cli/env_backend.py
@@ -1,6 +1,6 @@
 """Shared CLI helper: --env-backend arg registration + EnvironmentBackend build.
 
-#1289: per-frontend container-chat activation. `reyn run` (the Agent/OSRuntime
+#1289: per-frontend container-chat activation. `reyn run` (the Agent
 entry) originally owned the `--env-backend` args + builder; chat / dogfood now
 reuse the SAME helper so any CLI frontend can launch/attach a container and pass
 the resulting backend uniformly. The single-shared-sandbox invariant (#1200) is

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -319,7 +319,7 @@ class ModelResolver:
         existing model source when no override is set. The CompactionEngine sites
         need exactly this: their model source today is the chat session's model
         (``self.model``) / the plan router model, which can diverge from
-        ``default_class`` under an ``SkillRuntime(model=…)`` override — so feeding
+        ``default_class`` under a per-run model override — so feeding
         ``default_class`` would silently move compaction OFF the agent's chosen
         model. With ``default`` = the site's existing source, wiring is
         byte-identical until ``model_class_by_purpose.compaction`` is set, at which

--- a/src/reyn/reporters/__init__.py
+++ b/src/reyn/reporters/__init__.py
@@ -1,7 +1,7 @@
 """
 ConsoleLogger — event subscriber that renders OS events as human-readable console output.
 
-Wire up by passing an instance as a subscriber to EventLog or SkillRuntime.
+Wire up by passing an instance as a subscriber to EventLog.
 """
 from __future__ import annotations
 

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -34,7 +34,7 @@ from reyn.llm.pricing import TokenUsage, estimate_cost
 
 
 class BudgetExceeded(Exception):
-    """Raised by OSRuntime when a pre-call check refuses the LLM call."""
+    """Raised when a pre-call budget check refuses the LLM call."""
 
     def __init__(self, dimension: str, detail: str) -> None:
         super().__init__(detail)

--- a/src/reyn/runtime/limits/limit_handler.py
+++ b/src/reyn/runtime/limits/limit_handler.py
@@ -2,7 +2,7 @@
 
 Four sites in the codebase raise on a safety limit hit:
 
-  - F (phase_seconds)         — ``OSRuntime._check_phase_budget``
+  - F (phase_seconds)         — the phase-budget check
   - C (router_cap)            — ``BudgetGateway.check_and_increment_router_cap``
   - E (max_hop_depth)         — ``Session._send_to_agent``
   - G (chain_seconds)         — ``ChainManager`` watchdog fire path
@@ -72,7 +72,7 @@ _auto_extend_used: dict[tuple[str, str], int] = {}
 def reset_run_extensions(run_id: str) -> None:
     """Reset auto_extend bookkeeping for ``run_id``.
 
-    Call at the start of a run (= ``OSRuntime.run`` entry,
+    Call at the start of a run (= the run entry,
     ``Session`` turn boundary). After this, ``auto_extend_times``
     grants are fresh.
     """
@@ -153,7 +153,7 @@ async def handle_limit_exceeded(
               for event audit + as part of the ``UserIntervention.kind``
               namespace (``safety.limit.<kind>``).
         run_id: Stable run identifier used for the auto_extend counter.
-                Pass the OSRuntime run_id or chain_id —
+                Pass the run_id or chain_id —
                 whichever scopes the extension correctly for this site.
         prompt: User-facing question text.
         detail: Optional second line of context (= specifics like

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2385,9 +2385,7 @@ class AgentRegistry:
 
         R-D16: skills awaiting an intervention for longer than
         ``_LONG_AWAIT_THRESHOLD_SEC`` are excluded so the WAL can keep
-        advancing — delegated to
-        :meth:`SkillRegistry.iter_applied_phase_seqs` which performs
-        the elapsed check in-memory.
+        advancing — the elapsed check is performed in-memory.
 
         Returns 0 when no watermark is available (no live session, no
         active skill, no active plan).

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -156,8 +156,7 @@ class BudgetGateway:
 
         Used by the safety-limit checkpoint flow when the user / auto-extend
         approves a continuation past the original cap. Returns the new
-        effective cap. ``additional <= 0`` is a no-op (mirrors
-        ``BudgetTracker.extend_chain_calls`` / FP-0003 semantics).
+        effective cap. ``additional <= 0`` is a no-op (FP-0003 semantics).
         """
         if additional <= 0:
             return self._router_cap

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -4,9 +4,8 @@ Extracted from Session (FP-0019 Wave 2 part 1).  Owns the
 ask_user dispatch path, intervention announcement to outbox, and
 answer delivery coordination.
 
-Depends on FP-0019 Wave 1b SkillRunner (commit 9ae66fa) for skill-
-spawn coordination.  Depends on InterventionRegistry (pre-FP-0019
-extraction, snapshot_journal).
+Depends on InterventionRegistry (pre-FP-0019 extraction,
+snapshot_journal).
 
 Design constraints (same pattern as other Wave 1/1b services):
 - Injected deps at construction (typed + Callable callbacks).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -684,7 +684,7 @@ class Session:
         hooks_config: "object | None" = None,
         # #1200 PR-F1 (agent-level-uniform backend, FS seam): the agent's
         # EnvironmentBackend INSTANCE, threaded to the chat Workspace so chat's
-        # file ops run on the SAME backend as the OSRuntime path. None → HostBackend (the
+        # file ops run on the SAME backend as the phase path. None → HostBackend (the
         # workspace's own default) → unchanged behaviour. The sibling exec seam
         # (sandbox_backend string via sandbox_config) already flows agent-level.
         environment_backend: "EnvironmentBackend | None" = None,
@@ -692,7 +692,7 @@ class Session:
         workspace_state_dir: "Path | None" = None,  # #187: host-side OS state dir, decoupled from a container base_dir (survives container death)
         # #1200 PR-F2 (exec seam): the agent's SandboxBackend INSTANCE, set on the
         # chat router OpContext so sandboxed_exec runs on the SAME backend as the
-        # OSRuntime path (sandboxed_exec.py: `ctx.sandbox_backend or
+        # phase path (sandboxed_exec.py: `ctx.sandbox_backend or
         # get_default_backend(...)`). REQUIRED — without it chat falls to
         # get_default_backend (rebuild-per-call, no docker) → a DIFFERENT backend
         # than the FS seam → single-shared-sandbox violation. For a docker agent
@@ -714,7 +714,7 @@ class Session:
         eager_embedding_build: bool = False,
         # #1829 S3b: reyn.yaml llm.router.* — set on the LLM chokepoint's
         # ContextVar at construction (mirrors set_llm_request_event_log). None →
-        # the chokepoint's env+default fallback (back-compat). Skill OSRuntimes
+        # the chokepoint's env+default fallback (back-compat). Runs
         # spawned within this session inherit the ContextVar (propagation).
         router_config: "RouterConfig | None" = None,
         retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.* timing config
@@ -787,7 +787,7 @@ class Session:
         # (RouterLoop) + control-IR OpContext. None = no narrowing (byte-identical).
         self._contextual_permission = contextual_permission
         # #1953 slice 3a: session-scoped Task backend instance, threaded down to the
-        # task.* op handlers via SkillRuntime → OSRuntime → executors → OpContext
+        # task.* op handlers via the ctx-build seams → OpContext
         # (mirrors contextual_permission). Injected by the session factory (the
         # session-scoped sqlite db path is finalized with §24); None → the op-runtime
         # falls back to its in-memory backend (tests / direct construction).
@@ -1653,7 +1653,7 @@ class Session:
                 # fail (dead-end-critical).
                 # #1679: honor a documented model_class_by_purpose.compaction
                 # override when set; otherwise keep self.model (byte-identical to
-                # the former hardcode, incl. an SkillRuntime(model=…) override).
+                # the former hardcode, incl. a per-run model override).
                 model=self._resolver.purpose_class_or("compaction", self.model),
                 events=self._chat_events,
                 system_prompt_provider=self._history_buffer.build_system_prompt,
@@ -4267,7 +4267,7 @@ class Session:
     ) -> "LimitDecision":
         """FP-0005: chat-side wrapper for ``handle_limit_exceeded``.
 
-        Mirrors ``OSRuntime._handle_limit_checkpoint`` but uses the
+        Mirrors the phase-side limit checkpoint but uses the
         Session's intervention dispatcher (= ``_dispatch_intervention``,
         which records the WAL ``intervention_dispatched`` event before
         delivering the prompt) + on_limit + a session-stable run_id
@@ -5161,10 +5161,6 @@ class Session:
                 "entries": result.get("entries", 0),
             }
         return {"error": result.get("error", "regenerate_index failed")}
-
-    # NOTE: ``_run_skill_awaitable`` moved to
-    # SkillRunner.run_skill_awaitable (RunSpawner wave). The
-    # RouterHostAdapter wiring in __init__ now binds the method directly.
 
     async def _mcp_list_servers(self) -> list[dict]:
         """Returns the configured MCP server list with descriptions."""

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -63,7 +63,7 @@ class ChatInterventionBus:
     so the chat session can drop pending interventions when the spawn is
     cancelled. Interventions emitted by ops carry their own `skill_name` from
     `OpContext`; this bus only fills in `run_id` (which the OS layer doesn't
-    have, since chat tracks runs separately from `SkillRuntime.run_id`).
+    have, since chat tracks runs separately from the runtime's run_id).
 
     Phase 2 (issue #254): the canonical method is ``deliver`` (= the
     Agent↔User contract).  ``request`` is retained as an alias so

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -780,7 +780,7 @@ class ContextFrame(BaseModel):
     # ── volatile across act-turns ──────────────────────────────────────────────
     # Populated when a previous control_ir op in this phase produced a result
     # (file read content, ask_user answer, etc.). Empty on first LLM call for the phase.
-    # Each entry is the raw result dict returned by ControlIRExecutor.execute().
+    # Each entry is the raw result dict returned by the control-IR op executor.
     control_ir_results: list[dict] = Field(default_factory=list)
     # #1212 reasoning-continuity: the model's own inline content emitted on prior
     # op-loop act turns (alongside tool_calls), carried forward so a capable model

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -15,8 +15,7 @@ closure so the registry advertises memory write as phase-eligible.
 Status (post-FP-0039 audit, 2026-05-18): coarse-kind phase dispatch
 (= file / mcp / ask_user / web_fetch /
 web_search / mcp_install / recall / sandboxed_exec) is wired through
-``invoke_tool(get_default_registry(), op.kind, ...)`` in
-``ControlIRExecutor._invoker``.  The fine-grained memory names
+``invoke_tool(get_default_registry(), op.kind, ...)``.  The fine-grained memory names
 (``list_memory`` / ``read_memory_body`` / ``remember_*`` / ``forget_memory``)
 are NOT in ``OP_KIND_MODEL_MAP``, so phase Control IR cannot emit them
 today — the phase=allow gate is reachable only if Control IR schema is

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -195,7 +195,7 @@ class RouterCallerState:
 class PhaseCallerState:
     """Per-protocol state that phase-style invocations need access to.
 
-    Populated by ControlIRExecutor when invoking a ToolDefinition
+    Populated when invoking a ToolDefinition
     handler in phase context. Handlers that need phase-scoped
     resources (already-built OpContext, skill_run_id, run_visit_count,
     etc.) consume them via this object.


### PR DESCRIPTION
**[e2e-coder]** — #2439 item#3, comment/docstring-only P7-accuracy sweep. Lead-cleared (generalize, no-fabrication).

## What
The skill/phase engine classes (`SkillRuntime`, `SkillRunner`, `SkillRegistry`, `OSRuntime`, `PreprocessorExecutor`, `ControlIRExecutor`, `RunSkillIROp`) were deleted in the machinery removal, but **~22 comments/docstrings across 16 files** still named them as live mechanisms. Reworded each.

## Approach (lead-confirmed: generalize, don't fabricate)
Per observe-before-speculate — since the deleted chains (`Session → SkillRuntime → OSRuntime → executors`) are entirely gone and I have not observed the exact current flow, I generalized to the **still-true level** rather than invent a replacement chain:
- deleted-class chains → "the ctx-build seams" / "the runtime" / "OpContext threading"
- specific gone methods (`OSRuntime._check_phase_budget`, `ControlIRExecutor.execute`, `SkillRegistry.iter_applied_phase_seqs`) → their behavior, unnamed
- the `op_runtime/registry` alias comment → **aligned to the code** (the `invoke_skill→run_skill` alias is already gone; `_PHASE_TOOL_NAME_ALIAS` is mcp-only)
- folds lead's **budget_gateway:160** nit (stale `extend_chain_calls` ref)

## Excluded (intentional)
- The accurate "SkillRunner removed; no background skills to drain" decouple note (`session.py:3930`) — kept (it correctly states the removal).
- The **cron skill-execution prose** (`config/infra.py` + `cron/`) — entangled with the **deferred `CronJob.skill` subsystem removal** (a recovery-aware unit with a legacy-tolerance gate, tracked alongside skill_resume, pending audit→GO).
- The KEEP-5 kernel files (byte-identical invariant).

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python -m pytest` — **6965 passed**, 16 skipped, 1 xfailed, 0 failed (comment-only → no test-count delta)
- [x] `verify_module_docstrings.py` (changed module-docstring files) — OK (current-state, no refactor narrative)
- [x] import sanity — OK
- [x] `grep` deleted-class terms in src (non-cron, non-kernel) — zero residual
- [x] diff verified comment/docstring-only (+ one intentional user-facing error-string reword in `ask_user.py`)
- [x] tier-audit — N/A (no test files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)