### PR TITLE
fix(inline-cui): left-align markdown headings + one-keypress history from status bar

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -743,10 +743,18 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         # read-only panel has no cursor, so ↑ simply closes it.
         if _actionable_open() and not menu_region.at_first_selectable:
             menu_region.navigate(-1)
-        else:
-            if menu["open"]:
-                _menu_close()
+        elif menu["open"]:
+            # dropdown is open but not navigable (at top / read-only): close it
+            # and return to input — don't also navigate history since the user
+            # was browsing a dropdown, not requesting history recall.
+            _menu_close()
             event.app.layout.focus(input_win)
+        else:
+            # No dropdown open — user is browsing chips in the status bar.
+            # ↑ returns to input AND navigates one step back in history so the
+            # experience feels like a single "go up" rather than two keypresses.
+            event.app.layout.focus(input_win)
+            buf.history_backward()
 
     @kb.add("down", filter=has_focus(status_win))
     def _menu_down(event) -> None:

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -467,14 +467,24 @@ def _harden_soft_breaks(text: str) -> str:
 
 def _body_renderable(kind: str, text: str, body_style: str):
     """The body cell: markdown for agent (LLM) output, a styled Text otherwise."""
-    from rich.markdown import Markdown
+    from rich.markdown import Heading, Markdown
     from rich.text import Text
+
     if kind == "agent":
+        # rich.Markdown centers H1 by default (LEVEL_ALIGN = {"h1": "center"}).
+        # In a gutter-grid chat context that produces heavy leading whitespace —
+        # "⏺                          My Heading". Override to left for all levels.
+        class _LeftHeading(Heading):
+            LEVEL_ALIGN = {tag: "left" for tag in Heading.LEVEL_ALIGN}
+
+        class _ChatMarkdown(Markdown):
+            elements = {**Markdown.elements, "heading_open": _LeftHeading}
+
         # Render the LLM reply as markdown (headings / bold / lists / code) like
         # Claude Code. Single newlines are hardened to CommonMark hard line breaks
         # so the model's per-line output is preserved rather than collapsed to one
         # paragraph — matching how CC displays LLM output.
-        return Markdown(_harden_soft_breaks(text or ""))
+        return _ChatMarkdown(_harden_soft_breaks(text or ""))
     return Text(text, style=body_style)
 
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -55,6 +55,25 @@ def test_agent_body_renders_markdown_not_raw_source() -> None:
     assert "•" in out               # list rendered as bullets
 
 
+def test_agent_heading_renders_left_not_centered() -> None:
+    """Tier 2: a markdown H1 in an agent reply renders left-aligned, not centered.
+
+    rich.Markdown centers H1 by default (LEVEL_ALIGN = {"h1": "center"}) which
+    produces many leading spaces inside the gutter-grid body column:
+    "⏺                          My Heading". The _ChatMarkdown override makes all
+    heading levels left-aligned so headings sit at the left edge of the body column,
+    matching the CC chat aesthetic."""
+    out = _plain("agent", "# Heading Title\nsome text", width=80)
+    heading_line = next((ln for ln in out.split("\n") if "Heading Title" in ln), None)
+    assert heading_line is not None, "heading line not found in output"
+    # Left-aligned: the heading text follows the gutter marker (⏺) with at most
+    # a small indent. Centered: ~30+ spaces precede the text in an 80-wide render.
+    leading = len(heading_line) - len(heading_line.lstrip())
+    assert leading < 10, (
+        f"heading has {leading} leading spaces — looks centered, not left-aligned: {heading_line!r}"
+    )
+
+
 def test_wrapped_agent_body_hang_indents_clear_of_the_gutter() -> None:
     """Tier 2: a wrapped body continues INDENTED in the body column, never bleeding
     back into the 2-cell marker gutter (the reserved-gutter contract)."""


### PR DESCRIPTION
**[tui-coder]** — PR3 残件 2件: markdown 改善 + Up history 強化

## Summary

- **markdown 改善**: `rich.Markdown` centers H1 by default (`LEVEL_ALIGN = {"h1": "center"}`), producing heavy leading whitespace in the gutter-grid chat layout: `⏺                          My Heading`. Introduced `_ChatMarkdown` subclass with `_LeftHeading` overriding `LEVEL_ALIGN` so all heading levels render left-aligned, matching the CC chat aesthetic. Dogfood-confirmed before/after.
- **Up history 強化**: Pressing ↑ from the status bar (chips browsing, no dropdown open) previously required two keypresses — one to refocus `input_win`, then another to trigger `history_backward`. Now a single ↑ from the closed-menu status bar both refocuses the input and navigates one step back in history. When a dropdown IS open and the cursor is at the top/non-navigable, ↑ still only closes the dropdown (no history nav — the user was browsing options).

## Files changed

- `src/reyn/interfaces/repl/renderer.py`: `_ChatMarkdown` + `_LeftHeading` in `_body_renderable`
- `src/reyn/interfaces/inline/app.py`: split `_menu_up` else-branch into open-menu vs chip-browsing paths
- `tests/test_inline_renderer_cutover.py`: `test_agent_heading_renders_left_not_centered` (Tier 2)

## Test plan

- [x] `pytest tests/test_inline_renderer_cutover.py` — 32 passed
- [x] `ruff check` — clean
- [x] `test_tier_audit.py --strict` — 32 OK, 0 Tier 4
- [x] `verify_module_docstrings.py` — OK
- [x] (skipped — dogfood confirmed heading renders flush-left, Up history not testable via rawMode due to implicit-CR artifact, verified by code review)

Tier self-check: Tier 2 test added for heading alignment fix. No Tier 4 violations. ✓

part of #1154