### PR TITLE
fix: surface [✗ model switch declined] when block confirm rejected

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -94,6 +94,20 @@ class ChatLifecycleForwarder:
         suffix = f" — {cost_str}" if cost_str else ""
         self._enqueue(f"[⚠ high-cost model: {model}{suffix}]")
 
+    def on_model_cost_block(self, data: dict) -> None:
+        """Surface a ``[✗ model switch declined: …]`` marker when the user
+        rejects the high-cost model confirm (#1867 / FP-0052 S4).
+
+        Only fires on ``reason="declined"`` (= the user said No). Approved
+        switches need no extra message — the status-bar chip updates to show
+        the new model. Non-interactive fail-closed (no human present) is also
+        silent.
+        """
+        if data.get("reason") != "declined":
+            return
+        model = str(data.get("model") or data.get("model_class") or "unknown")
+        self._enqueue(f"[✗ model switch declined: {model}]")
+
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
     def on_compaction_completed(self, data: dict) -> None:

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -179,3 +179,64 @@ def test_budget_warn_zero_hard_drops_pct_safely() -> None:
     ))
     msgs = _drain(q)
     assert msgs[0].text == "[↑ budget warn: daily_tokens]"
+
+
+# ── model_cost_block (#1867 / FP-0052 S4) ────────────────────────────────────
+
+
+def test_model_cost_block_declined_emits_marker() -> None:
+    """Tier 2: model_cost_block with reason=declined → [✗ model switch declined:] marker.
+
+    Without this handler, a user who says No to the high-cost confirm gets no
+    feedback — the model chip stays unchanged but nothing explains why.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="model_cost_block",
+        data={"model": "gpt-4o", "model_class": "gpt4o", "reason": "declined"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "model switch declined" in only.text
+    assert "gpt-4o" in only.text
+
+
+def test_model_cost_block_approved_emits_nothing() -> None:
+    """Tier 2: model_cost_block with reason=approved → no outbox message.
+
+    The status-bar chip updates to the new model; no extra marker is needed.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="model_cost_block",
+        data={"model": "gpt-4o", "reason": "approved"},
+    ))
+    assert _drain(q) == []
+
+
+def test_model_cost_block_non_interactive_emits_nothing() -> None:
+    """Tier 2: model_cost_block with reason=non_interactive_fail_closed → no message.
+
+    No human present; the operator discovers the block via the calling exception.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="model_cost_block",
+        data={"model": "gpt-4o", "reason": "non_interactive_fail_closed"},
+    ))
+    assert _drain(q) == []
+
+
+def test_model_cost_block_missing_reason_emits_nothing() -> None:
+    """Tier 2: model_cost_block with no reason field → no message (forward-compat).
+
+    Future event-shape additions must not accidentally trigger the declined marker.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="model_cost_block", data={"model": "gpt-4o"}))
+    assert _drain(q) == []


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find: silent UX gap when the user rejects the high-cost model block confirm.

## Root cause

`maybe_block_high_cost_model` (#1867 / FP-0052 S4) emits `model_cost_block` in three cases:
- `reason="declined"` — user said No to the confirm
- `reason="approved"` — user said Yes
- `reason="non_interactive_fail_closed"` — session is non-interactive, switch denied

`ChatLifecycleForwarder` had `on_model_cost_warn` (for the warn-only path) but **no `on_model_cost_block`**. The event had no subscriber — all three cases were silently dropped.

The user-visible symptom: select a high-cost model from the `/model` picker → confirm dialog appears in the above-region → user presses No → region closes → **nothing**. The model chip stays unchanged with no explanation.

## Fix

Add `on_model_cost_block` to `ChatLifecycleForwarder`:
- `reason="declined"` → `[✗ model switch declined: {model}]` system marker in the conv pane
- `reason="approved"` → no message (status chip updates to the new model — sufficient feedback)
- `reason="non_interactive_fail_closed"` → no message (no human present)

## Test plan

- [x] `pytest tests/test_chat_lifecycle_forwarder.py` — 14 passed (4 new cases)
- [x] `ruff check src/reyn/runtime/lifecycle_forwarder.py tests/test_chat_lifecycle_forwarder.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_chat_lifecycle_forwarder.py` — 14/14 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/lifecycle_forwarder.py` — OK

Tier self-check: Tier 2 (contract tests, real `ChatLifecycleForwarder` instance, public outbox surface). No mocks, no private state, no format pins.

part of #1830