### PR TITLE
refactor(control-ir): PR-1 — remove dead LLM-output wrapper models

### DIFF
--- a/src/reyn/schemas/__init__.py
+++ b/src/reyn/schemas/__init__.py
@@ -1,22 +1,18 @@
 """schemas — Pydantic models and DSL schemas for the Reyn OS."""
 from .models import (
-    ActOutput,
     AskUserIROp,
     CandidateOutput,
     # LLM interaction
     ContextFrame,
-    ControlDecision,
     # Control IR ops
     ControlIROp,
     ControlIROpSpec,
-    ControlReason,
     # Events
     Event,
     ExecutionState,
     FileIROp,
     IterateStep,
     LintPlanStep,
-    LLMOutput,
     MCPIROp,
     PreprocessorStep,
     PythonStep,
@@ -30,7 +26,6 @@ from .models import (
 __all__ = [
     "ValidateStep", "IterateStep", "LintPlanStep", "PythonStep", "RunOpStep", "PreprocessorStep",
     "ContextFrame", "ExecutionState", "CandidateOutput", "ControlIROpSpec",
-    "LLMOutput", "ActOutput", "ControlDecision", "ControlReason",
     "ControlIROp", "FileIROp", "WebFetchIROp", "WebSearchIROp",
     "AskUserIROp", "MCPIROp",
     "Event",

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -623,7 +623,7 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "web_search":  WebSearchIROp,
     "mcp_install": MCPInstallIROp,
     # #1983: was registered + documented (control-ir.md) + handled but ABSENT
-    # here → a phase emitting it failed ActOutput validation. Added to restore
+    # here → a phase emitting it failed ControlIROp union validation. Added to restore
     # the control-ir.md ↔ map sync invariant.
     "mcp_drop_server": MCPDropServerIROp,
     "index_query": IndexQueryIROp,
@@ -687,27 +687,6 @@ RunOpStep.model_rebuild()
 IterateStep.model_rebuild()
 
 
-class ControlReason(BaseModel):
-    """Structured reason object — extensible for future fields."""
-    summary: str
-
-
-class ControlDecision(BaseModel):
-    """Routing decision returned by the LLM. Strict contract — no runtime inference."""
-    type: Literal["transition", "finish", "abort", "rollback"]
-    decision: Literal["continue", "finish", "abort"]
-    next_phase: str | None = None  # phase name for transition; None for finish/abort/rollback
-    confidence: float = 1.0
-    reason: ControlReason
-
-    @property
-    def effective_next_phase(self) -> str:
-        """Maps control decision to the candidate_map key ("end" for finish)."""
-        if self.type == "finish":
-            return "end"
-        return self.next_phase or ""
-
-
 class CandidateOutput(BaseModel):
     """A single candidate the LLM may choose for its next step."""
     next_phase: str                                        # phase name, or "end"
@@ -715,23 +694,6 @@ class CandidateOutput(BaseModel):
     schema_name: str                                       # artifact type name
     artifact_schema: dict[str, Any]
     description: str = ""
-
-
-class ActOutput(BaseModel):
-    """Act-turn output: execute ops and be re-called with results."""
-    type: Literal["act"]
-    ops: list[ControlIROp] = Field(default_factory=list)
-
-
-class LLMOutput(BaseModel):
-    """Decide-turn output: routing decision + artifact (+ optional write ops)."""
-    control: ControlDecision
-    artifact: dict[str, Any]
-    ops: list[ControlIROp] = Field(default_factory=list)
-
-    @property
-    def next_phase(self) -> str:
-        return self.control.effective_next_phase
 
 
 class ControlIROpSpec(BaseModel):

--- a/tests/test_control_ir_union_single_source_1983.py
+++ b/tests/test_control_ir_union_single_source_1983.py
@@ -3,7 +3,7 @@
 Finding 3: ``mcp_drop_server`` was registered (universal_dispatch), documented
 (``control-ir.md``), modeled (``MCPDropServerIROp``) and handled by the executor,
 but ABSENT from the hand-listed ``ControlIROp`` discriminated union and from
-``OP_KIND_MODEL_MAP`` — so a phase emitting it failed ``ActOutput`` validation
+``OP_KIND_MODEL_MAP`` — so a phase emitting it failed ``ControlIROp`` union validation
 (advertise-but-don't-enforce; the worst direction of the control-ir.md ↔ map
 sync invariant).
 
@@ -24,7 +24,7 @@ from typing import get_args
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from reyn.schemas.models import ActOutput, ControlIROp
+from reyn.schemas.models import ControlIROp
 
 
 def _union_member_kinds() -> set[str]:
@@ -66,16 +66,15 @@ def test_all_op_kinds_is_exactly_map_keys():
     assert set(ALL_OP_KINDS) == set(OP_KIND_MODEL_MAP)
 
 
-def test_mcp_drop_server_validates_through_act_output():
-    """Tier 2: Finding-3 falsifying — an act turn carrying an ``mcp_drop_server``
-    op validates. PRE-fix (kind absent from the union) this raised
+def test_mcp_drop_server_validates_through_union():
+    """Tier 2: Finding-3 falsifying — an ``mcp_drop_server`` op validates through
+    the ControlIROp union. PRE-fix (kind absent from the union) this raised
     ValidationError — the exact bug: registered + documented + handled but not
     enforceable. Revert the fix and this goes RED."""
-    out = ActOutput.model_validate(
-        {"type": "act", "ops": [{"kind": "mcp_drop_server", "server": "stale_srv"}]}
-    )
-    assert out.ops[0].kind == "mcp_drop_server"
-    assert out.ops[0].server == "stale_srv"
+    adapter = TypeAdapter(ControlIROp)
+    op = adapter.validate_python({"kind": "mcp_drop_server", "server": "stale_srv"})
+    assert op.kind == "mcp_drop_server"
+    assert op.server == "stale_srv"
 
 
 def test_mcp_drop_server_is_a_known_allowed_op():


### PR DESCRIPTION
**[e2e-coder]** — Control IR layer-removal arc, **PR-1** (owner tech-debt GO, lead-endorsed plan). Clean dead-code removal, name-independent.

## What
Removes the dead output-wrapper Pydantic models — the phase-engine's LLM decide/act output shapes — that no live path consumes (schemas-only: definition + re-export):
- `ControlReason` ← `ControlDecision` ← `LLMOutput` (chain) + standalone `ActOutput`

## Scope refinement vs the assessment (audit-first catch)
The assessment listed `CandidateOutput` in PR-1, but it's **coupled to `ContextFrame`** (`candidate_outputs: list[CandidateOutput]` at models.py:762) + `context_builder.build_frame` — both **PR-2** items. Removing it now would leave `ContextFrame` half-broken (no-half-broken guardrail), so it **moves to PR-2**.

## ActOutput test handling
`ActOutput` was used by `test_control_ir_union_single_source_1983` (the **KEEP** #1983 ControlIROp-union-single-source test) only as a vehicle to validate an op through the union. Rewrote that case to validate through `ControlIROp` directly — the #1983 assertion (mcp_drop_server validates through the union; unknown kind rejected) is preserved. Two historical comments naming "ActOutput validation" reworded to "ControlIROp union validation".

## Guardrail
- **`OP_KIND_MODEL_MAP` op-kind string keys + the `ControlIROp` union: untouched** (WAL identity). The diff near the map is only a comment reword; `grep` for `"kind"` key changes = empty.
- `RunOpStep`/preprocessor DSL + `ContextFrame`/`build_frame` untouched (PR-2).

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python -m pytest` — **6945 passed**, 16 skipped, 1 xfailed, 0 failed
- [x] `test_control_ir_union_single_source_1983` (KEEP #1983 union test) — 8 passed, 1 xfailed (union intact)
- [x] `test_tier_audit.py --strict` (changed test) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] `grep` ActOutput/LLMOutput/ControlDecision/ControlReason — zero residual

**Next:** PR-2 (dead `ContextFrame`/`ExecutionState`/`ControlIROpSpec`/`CandidateOutput` + `build_frame`/`call_llm`/`build_phase_messages`) — **gated on the behavior-preservation check** (is the LLM-tracing/JSON-decode-capture behavior that `call_llm`'s tests cover also on the live `call_llm_tools`?), per the finalized plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)