### PR TITLE
feat(lifecycle): config hot-reload lifecycle markers

### DIFF
--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -142,8 +142,10 @@ class HotReloader:
         in_set = load_hot_reload_config(self._project_root)
 
         # Validate-before-apply (atomicity): a malformed IN-set is REJECTED whole —
-        # no seam runs, the live config is unchanged (rollback). config_reloaded is
-        # NOT emitted (no state change occurred), only a warning.
+        # no seam runs, the live config is unchanged (rollback). Emit a
+        # ``config_reload_rejected`` event so the conv pane can surface the error
+        # (the user typed /reload and expects feedback on failure, not just a log
+        # warning they'll never see in the inline CUI).
         if self._validate is not None:
             reason = self._validate(in_set)
             if reason:
@@ -151,6 +153,12 @@ class HotReloader:
                     "hot-reload REJECTED (invalid IN-set): %s — live config unchanged",
                     reason,
                 )
+                if self._events is not None:
+                    self._events.emit(
+                        "config_reload_rejected",
+                        source=source or "unknown",
+                        reason=reason,
+                    )
                 return {"source": source, "rejected": reason, "applied": [], "failed": []}
 
         applied: list[str] = []

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -108,6 +108,44 @@ class ChatLifecycleForwarder:
         model = str(data.get("model") or data.get("model_class") or "unknown")
         self._enqueue(f"[✗ model switch declined: {model}]")
 
+    # ── Config hot-reload (#2073) ──────────────────────────────────────────
+
+    def on_config_reloaded(self, data: dict) -> None:
+        """Surface a ``[↻ config reloaded: <components>]`` marker in the conv pane.
+
+        Fires after a hot-reload applies at the turn boundary (#2073 S1). A user
+        who ran ``/reload`` gets confirmation that the reload completed and which
+        components changed. Silenced when no component reported a change AND no
+        seam failed — a reload that touched nothing is already confirmed by the
+        ``/reload`` reply; a second no-op marker would be noise.
+
+        ``data["components"]`` is the list of seam names that reported a change
+        (e.g. ``["hooks", "mcp"]``). ``data["failed"]`` is the list of seams
+        that raised an exception.
+        """
+        applied = list(data.get("components") or [])
+        failed = list(data.get("failed") or [])
+        if not applied and not failed:
+            return
+        parts: list[str] = []
+        if applied:
+            parts.append(", ".join(applied))
+        if failed:
+            parts.append(f"✗ failed: {', '.join(failed)}")
+        self._enqueue(f"[↻ config reloaded: {'; '.join(parts)}]")
+
+    def on_config_reload_rejected(self, data: dict) -> None:
+        """Surface a ``[✗ config reload rejected: <reason>]`` error marker.
+
+        Fires when the validate-before-apply step rejects the IN-set as
+        malformed (#2073 S2). Without this marker, the user sees the ``/reload``
+        "scheduled" confirmation and then nothing — the next turn silently
+        runs under the OLD config, with only a ``_log.warning`` that is never
+        visible in the inline CUI.
+        """
+        reason = str(data.get("reason") or "malformed config")
+        self._enqueue(f"[✗ config reload rejected: {reason}]")
+
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
     def on_compaction_completed(self, data: dict) -> None:

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -240,3 +240,93 @@ def test_model_cost_block_missing_reason_emits_nothing() -> None:
     fwd = ChatLifecycleForwarder(q)
     fwd(Event(type="model_cost_block", data={"model": "gpt-4o"}))
     assert _drain(q) == []
+
+
+# ── config hot-reload (#2073) ─────────────────────────────────────────────────
+
+
+def test_config_reloaded_with_components_emits_marker() -> None:
+    """Tier 2: config_reloaded with changed components → [↻ config reloaded: <names>] marker.
+
+    Without this handler, a user who ran /reload gets no confirmation that the
+    reload completed or which components changed — only the /reload "scheduled"
+    message from earlier in the turn.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="config_reloaded",
+        data={"components": ["hooks", "mcp"], "failed": [], "source": "operator"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "config reloaded" in only.text
+    assert "hooks" in only.text
+    assert "mcp" in only.text
+
+
+def test_config_reloaded_with_no_changes_emits_nothing() -> None:
+    """Tier 2: config_reloaded with empty components+failed → no outbox marker.
+
+    A reload that touched nothing is already confirmed by the /reload reply;
+    a redundant "nothing changed" marker would be noise.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="config_reloaded",
+        data={"components": [], "failed": [], "source": "operator"},
+    ))
+    assert _drain(q) == []
+
+
+def test_config_reloaded_with_failed_seams_includes_failure_note() -> None:
+    """Tier 2: config_reloaded with failed seams → marker includes failure names.
+
+    A seam failure is otherwise silently logged; surfacing it in the conv pane
+    lets the user know the reload was partial.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="config_reloaded",
+        data={"components": ["hooks"], "failed": ["cron"], "source": "operator"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "config reloaded" in only.text
+    assert "hooks" in only.text
+    assert "cron" in only.text
+    assert "failed" in only.text
+
+
+def test_config_reload_rejected_emits_error_marker() -> None:
+    """Tier 2: config_reload_rejected → [✗ config reload rejected: <reason>] marker.
+
+    Without this event the user sees the /reload "scheduled" confirmation but
+    then nothing when the validate-before-apply step rejects the malformed
+    IN-set — the next turn silently runs under the old config.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="config_reload_rejected",
+        data={"reason": "cron.jobs must be a list", "source": "operator"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "config reload rejected" in only.text
+    assert "cron.jobs must be a list" in only.text
+
+
+def test_config_reload_rejected_missing_reason_uses_fallback() -> None:
+    """Tier 2: config_reload_rejected with no reason field → generic fallback text."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="config_reload_rejected", data={}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "config reload rejected" in only.text
+    assert "malformed config" in only.text


### PR DESCRIPTION
**[tui-coder]** — dogfood bug-mining, continuation of lifecycle-marker series.

## Summary

Two UX gaps in the `/reload` flow:

**Gap 1 — Rejected reload was silent (worse)**: when `validate-before-apply` rejects a malformed `.reyn/*.yaml`, only `_log.warning` fires. The user sees the `/reload` "Config reload scheduled" confirmation, then nothing — the next turn silently runs under the OLD config with no explanation. This is a silent failure on a user-triggered operation.

**Gap 2 — Successful reload had no completion marker**: `config_reloaded` was already emitted to `_chat_events` (P6 audit) but had no lifecycle forwarder handler. The user knew the reload was "scheduled" but got no "it completed + which components changed" signal.

### Fixes

- `hot_reload.py`: emit `config_reload_rejected` event in the rejected path (alongside the existing `_log.warning`)
- `lifecycle_forwarder.py`: add `on_config_reloaded` + `on_config_reload_rejected` handlers
  - `[↻ config reloaded: hooks, mcp]` — only when at least one component changed or failed (empty = no-op = no marker noise)
  - `[↻ config reloaded: hooks; ✗ failed: cron]` — surfaces partial-failure seam names
  - `[✗ config reload rejected: cron.jobs must be a list]` — surfaces the validation reason

### Pattern consistency

Both handlers follow the existing lifecycle-marker pattern:
- `on_compaction_completed` → `[↑ N turns compacted]`
- `on_budget_warn` → `[↑ budget warn: daily_tokens (80%)]`
- `on_model_cost_warn` → `[⚠ high-cost model: gpt-4o]`
- `on_model_cost_block` → `[✗ model switch declined: gpt-4o]` (PR #2457)

## Files changed

- `src/reyn/runtime/hot_reload.py` — emit `config_reload_rejected` event on validation failure
- `src/reyn/runtime/lifecycle_forwarder.py` — `on_config_reloaded` + `on_config_reload_rejected`
- `tests/test_chat_lifecycle_forwarder.py` — 5 new Tier 2 tests (19 total, up from 14)

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_chat_lifecycle_forwarder.py` — 19/19 ✓
- [x] `pytest` — 6939 passed, 17 skipped, 1 xfailed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/hot_reload.py src/reyn/runtime/lifecycle_forwarder.py` — OK
- [x] (skipped — triggered by /reload with malformed .reyn/hooks.yaml; runtime-only change, no interactive session available)

**Tier self-check**: 5 new tests, all Tier 2 behavioral assertions on public outbox surface (`kind`, `text`). No Tier 4 violations.

part of #2073