### PR TITLE
feat(inline): lifecycle markers for compaction_failed + limit_denied

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -148,6 +148,18 @@ class ChatLifecycleForwarder:
 
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
+    def on_compaction_failed(self, data: dict) -> None:
+        """Surface a ``[✗ compaction failed: <reason>]`` error marker.
+
+        ``compaction_controller.py`` emits ``compaction_failed`` when the
+        summarisation LLM call raises. Without this handler the user sees the
+        ``compaction_started`` side-effect (spinner clears) but gets no signal
+        that compaction silently failed — early turns are still unsummarised and
+        context pressure continues unrelieved.
+        """
+        reason = str(data.get("error") or "unknown error")
+        self._enqueue(f"[✗ compaction failed: {reason}]")
+
     def on_compaction_completed(self, data: dict) -> None:
         """Surface a ``[↑ N turns compacted]`` marker in the conv pane.
 
@@ -161,6 +173,24 @@ class ChatLifecycleForwarder:
         else:
             text = "[↑ history compacted]"
         self._enqueue(text)
+
+    # ── Router cap (session.py _handle_router_cap_exceeded) ──────────────
+
+    def on_limit_denied(self, data: dict) -> None:
+        """Surface a ``[✗ router cap hit: N ops (limit L)]`` error marker.
+
+        ``session.py`` emits ``limit_denied`` when the loop's op-count exceeds
+        the operator-configured router cap. Without this handler the user only
+        sees whatever LLM wrap-up text the session synthesises — no inline
+        marker signals that the cap is WHY the turn ended early. ``kind``
+        is ``"router_cap"``; ``count`` and ``cap`` carry the numbers.
+        """
+        count = data.get("count")
+        cap = data.get("cap")
+        if count is not None and cap is not None:
+            self._enqueue(f"[✗ router cap hit: {count} ops (limit {cap})]")
+        else:
+            self._enqueue("[✗ router cap hit]")
 
     def _enqueue(self, text: str) -> None:
         # Fire-and-forget: lifecycle markers are advisory, never block the

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -330,3 +330,76 @@ def test_config_reload_rejected_missing_reason_uses_fallback() -> None:
     (only,) = msgs
     assert "config reload rejected" in only.text
     assert "malformed config" in only.text
+
+
+# ── compaction_failed ────────────────────────────────────────────────────────
+
+
+def test_compaction_failed_emits_error_marker() -> None:
+    """Tier 2: compaction_failed → [✗ compaction failed: <reason>] marker.
+
+    CompactionController emits this when the summarisation LLM call raises.
+    Without a handler the user sees the compaction spinner clear but gets no
+    feedback that context pressure is still unrelieved.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="compaction_failed",
+        data={"error": "LLM returned empty"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "compaction failed" in only.text
+    assert "LLM returned empty" in only.text
+
+
+def test_compaction_failed_missing_error_uses_fallback() -> None:
+    """Tier 2: compaction_failed with no error field → generic fallback text."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_failed", data={}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "compaction failed" in only.text
+    assert "unknown error" in only.text
+
+
+# ── limit_denied (router cap) ────────────────────────────────────────────────
+
+
+def test_limit_denied_emits_cap_marker_with_counts() -> None:
+    """Tier 2: limit_denied with count+cap → [✗ router cap hit: N ops (limit L)].
+
+    session.py emits this when the loop's op-count exceeds the operator-configured
+    router cap. Without a handler the user only sees LLM wrap-up text — no inline
+    marker signals that the cap is WHY the turn ended early.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="limit_denied",
+        data={"kind": "router_cap", "count": 42, "cap": 40, "chain_id": "abc"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "router cap hit" in only.text
+    assert "42" in only.text
+    assert "40" in only.text
+
+
+def test_limit_denied_missing_counts_uses_generic_marker() -> None:
+    """Tier 2: limit_denied without count/cap → generic [✗ router cap hit] marker.
+
+    Forward-compat: future limit_denied sub-kinds that omit numeric fields still
+    surface a marker rather than silently dropping the event.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="limit_denied", data={"kind": "router_cap"}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "router cap hit" in only.text
+    assert "ops" not in only.text


### PR DESCRIPTION
**[tui-coder]**

## Summary

Two UX gaps in `ChatLifecycleForwarder` where events emitted against `_chat_events` had no handler — inline CUI showed nothing to the user:

- **`compaction_failed`**: `CompactionController` emits this when the summarisation LLM call raises. User saw the compaction spinner clear but got no conv-pane feedback that early turns are still unsummarised and context pressure is unrelieved.
  - Marker: `[✗ compaction failed: <reason>]` with generic fallback when error field is absent.

- **`limit_denied`**: `session.py` emits this when the router cap fires before `run_loop` starts. User only saw LLM wrap-up text — no inline signal that the cap is WHY the turn ended early.
  - Marker: `[✗ router cap hit: N ops (limit L)]` with count/cap annotation; degrades to `[✗ router cap hit]` when numeric fields are absent (forward-compat).

Both follow the exact pattern of existing handlers (`on_compaction_completed`, `on_config_reload_rejected`, `on_budget_warn`).

## Files changed

- `src/reyn/runtime/lifecycle_forwarder.py` — `on_compaction_failed`, `on_limit_denied` handlers
- `tests/test_chat_lifecycle_forwarder.py` — 4 new Tier 2 tests (23 total)

## Test plan

- [x] `pytest tests/test_chat_lifecycle_forwarder.py` — 23 passed
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 Tier 4 violations
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] (skipped — no live UI needed; both handlers follow identical pattern to already-live `on_compaction_completed` / `on_config_reload_rejected` which are dogfood-verified)

**Tier self-check**: Tier 2 only — public `.text`/`.kind` surface assertions, no private state, no format pins, no golden files.

part of inline CUI mining arc