### PR TITLE
feat(#2464): surface summary_resummarize_failed as inline CUI error marker

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -160,6 +160,21 @@ class ChatLifecycleForwarder:
         reason = str(data.get("error") or "unknown error")
         self._enqueue(f"[✗ compaction failed: {reason}]")
 
+    def on_summary_resummarize_failed(self, data: dict) -> None:
+        """Surface a ``[✗ summary re-compress failed: <reason>]`` error marker.
+
+        ``compaction/engine.py`` calls ``_resummarize_topic_arc`` when the
+        produced topic_arc overshoots its body-budget (T2 re-compression
+        pass). When that LLM call raises, the engine catches it, emits
+        ``summary_resummarize_failed``, and falls back to the uncompressed
+        arc — which may still overshoot. Without this handler the user sees
+        ``compaction_completed`` as if everything succeeded, but the stored
+        summary is potentially larger than the budget, degrading future
+        compaction quality silently.
+        """
+        reason = str(data.get("error") or "unknown error")
+        self._enqueue(f"[✗ summary re-compress failed: {reason}]")
+
     def on_compaction_completed(self, data: dict) -> None:
         """Surface a ``[↑ N turns compacted]`` marker in the conv pane.
 

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -403,3 +403,38 @@ def test_limit_denied_missing_counts_uses_generic_marker() -> None:
     (only,) = msgs
     assert "router cap hit" in only.text
     assert "ops" not in only.text
+
+
+# ── summary_resummarize_failed ───────────────────────────────────────────────
+
+
+def test_summary_resummarize_failed_emits_error_marker() -> None:
+    """Tier 2: summary_resummarize_failed → [✗ summary re-compress failed: <reason>].
+
+    CompactionEngine emits this when the T2 re-summarise LLM call raises.
+    Without a handler the user sees compaction_completed as if everything
+    succeeded, but the stored summary may overshoot its body-budget — degrading
+    future compaction quality silently.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="summary_resummarize_failed",
+        data={"error": "context length exceeded"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "summary re-compress failed" in only.text
+    assert "context length exceeded" in only.text
+
+
+def test_summary_resummarize_failed_missing_error_uses_fallback() -> None:
+    """Tier 2: summary_resummarize_failed with no error field → generic fallback text."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="summary_resummarize_failed", data={}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "summary re-compress failed" in only.text
+    assert "unknown error" in only.text


### PR DESCRIPTION
**[tui-coder]** — dogfood mining continuation (forwarder handler gap sweep)

## What

`CompactionEngine._resummarize_topic_arc` (T2 re-compress pass) emits `summary_resummarize_failed` on `_chat_events` when its LLM call raises. `ChatLifecycleForwarder` had no handler, so the failure was silent — the user sees `compaction_completed` as if everything succeeded, but the stored `topic_arc` may overshoot its body-budget.

Adds `on_summary_resummarize_failed` → `[✗ summary re-compress failed: <reason>]` system marker, identical pattern to `on_compaction_failed` (#2463, 1e29755).

## Why this gap matters

The T2 re-compress path runs precisely when compaction output *already overshoots* (T1 fit failed). A silent failure there means:
- The stored summary is known-large
- No user signal → no operator action
- Future compaction quality degrades silently

## Changes

- `src/reyn/runtime/lifecycle_forwarder.py` — `on_summary_resummarize_failed` handler (15 lines)
- `tests/test_chat_lifecycle_forwarder.py` — 2 new Tier 2 tests (25 total)

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_chat_lifecycle_forwarder.py` — 25/25 ✓
- [x] `pytest tests/test_chat_lifecycle_forwarder.py` — 25 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/lifecycle_forwarder.py` — OK

## Tier self-check

All tests are Tier 2 (OS contract invariant). No mocks, no private-state assertions, no format pins. No Tier 4 violations.

part of dogfood mining arc (sibling of #2463)