### PR TITLE
refactor(control-ir): PR-4 — rename the ControlIROp union to Op

### DIFF
--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -1,4 +1,4 @@
-"""Op runtime — shared backend for executing ControlIROp.
+"""Op runtime — shared backend for executing Op.
 
 The router/chat tool path dispatches through `execute_op` here. The op kind
 catalog and per-op semantics live in this package; the caller decides *when*
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from reyn.schemas.models import ControlIROp
+from reyn.schemas.models import Op
 
 from .context import OpContext
 from .result import OpDenied, OpResult, OpSkipped
@@ -25,10 +25,10 @@ class OpDispatchError(RuntimeError):
 
 
 async def execute_op(
-    op: ControlIROp,
+    op: Op,
     ctx: OpContext,
 ) -> dict:
-    """Dispatch a ControlIROp to its handler and return a result dict.
+    """Dispatch a Op to its handler and return a result dict.
 
     Returns a JSON-serializable dict in the same shape callers have
     historically appended to `control_ir_results`. Errors are captured

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 from enum import Enum
 
 # #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS relocated to schemas/models.py
-# (co-located with the IROp model classes + the now-derived ControlIROp union =
+# (co-located with the IROp model classes + the now-derived Op union =
 # single source; the map lived here before, but registry imports those model
 # classes, so models.py could not derive the union from the map without a cycle).
 # registry keeps the *purity* classification (OP_PURITY) and re-imports
@@ -83,7 +83,7 @@ class OpPurity(str, Enum):
 
 
 # #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS now live in schemas/models.py — the
-# single source (the ControlIROp discriminated union derives from the map there,
+# single source (the Op discriminated union derives from the map there,
 # completeness-by-construction). Add a new op kind in models.py; ALL_OP_KINDS is
 # imported above (used by ALL_TOOL_NAMES below). registry owns only OP_PURITY.
 
@@ -247,10 +247,10 @@ ALL_TOOL_NAMES: frozenset[str] = ALL_OP_KINDS
 # The phase-advertised chat name "call_mcp_tool" aliases to the canonical
 # execution op kind "mcp".  The phase frame shows the chat name so phase =
 # chat-tools subset (catalog-axis goal); parse boundaries in op_loop +
-# json-mode rewrite it to the op kind BEFORE ControlIROp validation.  The
+# json-mode rewrite it to the op kind BEFORE Op validation.  The
 # the allowed-ops filter applies this alias so allowed_ops=[mcp]
 # matches the advertised call_mcp_tool spec.  The execution backend
-# (op_runtime/mcp.py) and ControlIROp model (MCPIROp) use the op-kind name.
+# (op_runtime/mcp.py) and Op model (MCPIROp) use the op-kind name.
 # ---------------------------------------------------------------------------
 
 _PHASE_TOOL_NAME_ALIAS: dict[str, str] = {
@@ -274,7 +274,7 @@ def split_tool_name(tool_name: str) -> tuple[str, str | None]:
 
 
 def is_op_instance_allowed(op: object, allowed_ops: set[str] | frozenset[str]) -> bool:
-    """Gate a ControlIROp instance against an ``allowed_ops`` set.
+    """Gate a Op instance against an ``allowed_ops`` set.
 
     Delegates to ``is_op_allowed(op.kind, allowed_ops)`` for all op kinds.
     The D7 file-verb-granular special-case (``file__read``-style) is retired

--- a/src/reyn/schemas/__init__.py
+++ b/src/reyn/schemas/__init__.py
@@ -1,14 +1,14 @@
 """schemas — Pydantic models and DSL schemas for the Reyn OS."""
 from .models import (
     AskUserIROp,
-    # Control IR ops
-    ControlIROp,
     # Events
     Event,
     FileIROp,
     IterateStep,
     LintPlanStep,
     MCPIROp,
+    # Control IR ops
+    Op,
     PreprocessorStep,
     PythonStep,
     RunOpStep,
@@ -20,7 +20,7 @@ from .models import (
 
 __all__ = [
     "ValidateStep", "IterateStep", "LintPlanStep", "PythonStep", "RunOpStep", "PreprocessorStep",
-    "ControlIROp", "FileIROp", "WebFetchIROp", "WebSearchIROp",
+    "Op", "FileIROp", "WebFetchIROp", "WebSearchIROp",
     "AskUserIROp", "MCPIROp",
     "Event",
 ]

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -53,9 +53,9 @@ class PythonStep(BaseModel):
 
 
 class RunOpStep(BaseModel):
-    """Invoke any ControlIROp from the static (preprocessor) frontend.
+    """Invoke any Op from the static (preprocessor) frontend.
 
-    `op` is a literal ControlIROp embedded directly. `args_from` lets
+    `op` is a literal Op embedded directly. `args_from` lets
     selected fields be replaced with values pulled from dot-paths in the
     input artifact at execution time (useful inside `iterate`, where
     each item's data needs to flow into the op).
@@ -64,7 +64,7 @@ class RunOpStep(BaseModel):
     it because static execution can't pause for user input.
     """
     type: Literal["run_op"]
-    op: "ControlIROp"
+    op: "Op"
     into: str | None = None
     args_from: dict[str, str] = Field(default_factory=dict)
     on_error: Literal["fail", "skip", "empty"] = "fail"
@@ -91,7 +91,7 @@ PreprocessorStep = Annotated[
 ProcessorStep = PreprocessorStep
 
 # IterateStep / RunOpStep both use forward refs that resolve only after
-# ControlIROp is defined further down. The rebuild is performed at the
+# Op is defined further down. The rebuild is performed at the
 # bottom of this file once all referenced types are in scope.
 
 
@@ -598,7 +598,7 @@ class TaskAssignIROp(BaseModel):
 
 # ── Op-kind registry — the single source for the Control IR op surface ───────
 # #1983: OP_KIND_MODEL_MAP is co-located HERE (relocated from
-# op_runtime/registry.py) so the ControlIROp union, ALL_OP_KINDS, and
+# op_runtime/registry.py) so the Op union, ALL_OP_KINDS, and
 # op_runtime's purity / op_catalog all derive from ONE map. Previously the map
 # lived in registry.py — which imports these model classes — so models.py could
 # not derive the union from it without a cycle; that dual-source (hand-listed
@@ -623,7 +623,7 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "web_search":  WebSearchIROp,
     "mcp_install": MCPInstallIROp,
     # #1983: was registered + documented (control-ir.md) + handled but ABSENT
-    # here → a phase emitting it failed ControlIROp union validation. Added to restore
+    # here → a phase emitting it failed Op union validation. Added to restore
     # the control-ir.md ↔ map sync invariant.
     "mcp_drop_server": MCPDropServerIROp,
     "index_query": IndexQueryIROp,
@@ -658,7 +658,7 @@ if TYPE_CHECKING:
     # Union. The RUNTIME value derives from the map (below); this list is NOT the
     # source of truth and is pinned in sync by the completeness-invariant test
     # ({union kinds} == ALL_OP_KINDS ∪ {"file"}).
-    ControlIROp = Annotated[
+    Op = Annotated[
         Union[
             FileIROp,
             ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
@@ -677,12 +677,12 @@ if TYPE_CHECKING:
         Field(discriminator="kind"),
     ]
 else:
-    ControlIROp = Annotated[
+    Op = Annotated[
         Union[tuple([FileIROp, *OP_KIND_MODEL_MAP.values()])],
         Field(discriminator="kind"),
     ]
 
-# Resolve forward references now that ControlIROp is in scope.
+# Resolve forward references now that Op is in scope.
 RunOpStep.model_rebuild()
 IterateStep.model_rebuild()
 

--- a/tests/test_control_ir_union_single_source_1983.py
+++ b/tests/test_control_ir_union_single_source_1983.py
@@ -1,9 +1,9 @@
-"""Tier 2: #1983 — the ControlIROp union is single-sourced from OP_KIND_MODEL_MAP.
+"""Tier 2: #1983 — the Op union is single-sourced from OP_KIND_MODEL_MAP.
 
 Finding 3: ``mcp_drop_server`` was registered (universal_dispatch), documented
 (``control-ir.md``), modeled (``MCPDropServerIROp``) and handled by the executor,
-but ABSENT from the hand-listed ``ControlIROp`` discriminated union and from
-``OP_KIND_MODEL_MAP`` — so a phase emitting it failed ``ControlIROp`` union validation
+but ABSENT from the hand-listed ``Op`` discriminated union and from
+``OP_KIND_MODEL_MAP`` — so a phase emitting it failed ``Op`` union validation
 (advertise-but-don't-enforce; the worst direction of the control-ir.md ↔ map
 sync invariant).
 
@@ -24,17 +24,17 @@ from typing import get_args
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from reyn.schemas.models import ControlIROp
+from reyn.schemas.models import Op
 
 
 def _union_member_kinds() -> set[str]:
-    """The literal ``kind`` of every member of the ControlIROp discriminated union.
+    """The literal ``kind`` of every member of the Op discriminated union.
 
-    ``ControlIROp == Annotated[Union[...], Field(discriminator="kind")]`` →
+    ``Op == Annotated[Union[...], Field(discriminator="kind")]`` →
     ``get_args(...)[0]`` is the ``Union``; its args are the member models; each
     member's ``kind`` field is a ``Literal["<kind>"]``.
     """
-    union = get_args(ControlIROp)[0]
+    union = get_args(Op)[0]
     kinds: set[str] = set()
     for member in get_args(union):
         kind_ann = member.model_fields["kind"].annotation
@@ -68,10 +68,10 @@ def test_all_op_kinds_is_exactly_map_keys():
 
 def test_mcp_drop_server_validates_through_union():
     """Tier 2: Finding-3 falsifying — an ``mcp_drop_server`` op validates through
-    the ControlIROp union. PRE-fix (kind absent from the union) this raised
+    the Op union. PRE-fix (kind absent from the union) this raised
     ValidationError — the exact bug: registered + documented + handled but not
     enforceable. Revert the fix and this goes RED."""
-    adapter = TypeAdapter(ControlIROp)
+    adapter = TypeAdapter(Op)
     op = adapter.validate_python({"kind": "mcp_drop_server", "server": "stale_srv"})
     assert op.kind == "mcp_drop_server"
     assert op.server == "stale_srv"
@@ -92,6 +92,6 @@ def test_mcp_drop_server_is_a_known_allowed_op():
 def test_derived_union_still_rejects_unknown_kind():
     """Tier 2: deriving the union from the map did NOT open the discriminator to
     arbitrary kinds — an unknown kind is still rejected (closed-set invariant)."""
-    adapter = TypeAdapter(ControlIROp)
+    adapter = TypeAdapter(Op)
     with pytest.raises(ValidationError):
         adapter.validate_python({"kind": "no_such_op_kind_xyz", "server": "x"})

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -1,6 +1,6 @@
 """Tier 1/2: #1953 slice 1 — Task op interface contract surface.
 
-The ``task.*`` Control IR ops exist, validate through the ControlIROp union, are
+The ``task.*`` Control IR ops exist, validate through the Op union, are
 registered + gated (completeness), and round-trip through the in-memory backend.
 Enforcement (single-writer CAS, abort quiescence, cascade, cycle-check,
 predicate-eval) lands in later slices — this slice is the contract surface.
@@ -22,7 +22,7 @@ from reyn.core.op_runtime import available_kinds
 from reyn.core.op_runtime import task as taskmod
 from reyn.core.op_runtime.contextual_gate import _OP_KIND_ALIASES
 from reyn.core.op_runtime.registry import OP_PURITY
-from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, ControlIROp
+from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, Op
 from reyn.task import InMemoryTaskBackend, Task, TaskState
 from reyn.task.subscription import SubscriptionRegistry
 from tests._support.task_subscription import SubscriptionBackend
@@ -65,8 +65,8 @@ def test_contextual_gate_covers_every_task_kind():
 
 
 def test_union_validates_every_task_kind():
-    """Tier 1: each task op kind round-trips through the ControlIROp union."""
-    adapter = TypeAdapter(ControlIROp)
+    """Tier 1: each task op kind round-trips through the Op union."""
+    adapter = TypeAdapter(Op)
     samples = {
         "task.create": {"kind": "task.create", "name": "n"},
         "task.update_status": {"kind": "task.update_status", "task_id": "t", "status": "running"},


### PR DESCRIPTION
**[e2e-coder]** — Control IR arc **PR-4** (owner-confirmed name = `Op`). Rename-only, dispatch logic unchanged = low-risk (CI-green + 精読 per lead).

## What
Renames the discriminated union type `ControlIROp` → `Op`, removing "Control IR" from the surviving type vocabulary. Word-boundary rename across **6 files** (`schemas/models`, `schemas/__init__`, `op_runtime/__init__`, `op_runtime/registry` + the two union tests) — imports, annotations, the union definition, comments/docstrings.

## Scope (owner default)
**ONLY the union alias is renamed.** The 33 individual `*IROp` model classes (`FileIROp`, `WebFetchIROp`, `MCPIROp`, …) are **NOT** renamed — the ~280-site cosmetic `*IROp→*Op` sweep is deliberately skipped (high churn, low value). Live type definitions stay; only the union's name changes.

## Guardrail (verified)
The **op-kind STRING keys are untouched** — `OP_KIND_MODEL_MAP` keys, `kind: Literal["read_file"]` / `kind="file"` literals, `ALL_OP_KINDS` (30 kinds) byte-identical. **WAL identity preserved** (the union is DERIVED from the map by construction — #1983 — the map is the identity source). Rename is the TYPE NAME only. `Op` had **zero collision**.

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python -m pytest` — **6943 passed**, 16 skipped, 0 failed
- [x] `test_control_ir_union_single_source_1983` + `test_task_ops_interface_1953` (union under new name `Op`) — 16 passed
- [x] guardrail: `OP_KIND_MODEL_MAP` (30 kinds) + op-kind string literals untouched; `import Op` + `OP_KIND_MODEL_MAP` OK
- [x] `test_tier_audit.py --strict` (renamed test files) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] `grep ControlIROp` — zero residual

*Rename-only: no dispatch behavior change; tui-live-verify optional per lead (dispatch logic unchanged).*

**Next:** PR-5 (purity FULL removal — the most-critical live gate: emission-behavior-identical test + tui-live-verify) → PR-6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)