### PR TITLE
fix(inline-cui): task dropdown live-reads task_cache, not frozen snapshot

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -209,21 +209,22 @@ def _build_task_tree(task_dicts: list[dict]) -> list[dict]:
     ]
 
 
+def _task_rows(nodes: list[dict], depth: int) -> list[str]:
+    out = []
+    for node in nodes:
+        out.append(f"{'  ' * depth}{node['status']}  {node['name']}")
+        out.extend(_task_rows(node["children"], depth + 1))
+    return out
+
+
 def _task_expansion(snap, dispatch):
     # Phase 3: task tree. Depth-first indented rows (2 spaces per depth).
+    # NOTE: tree is a snapshot captured at call time — callers that need live
+    # updates (e.g. the open dropdown) should substitute a live-reading element.
     tree = snap.get("task_tree") or []
     if not tree:
         return DetailElement(lambda: ["(no active tasks)"])
-
-    def _rows(nodes: list[dict], depth: int) -> list[str]:
-        out = []
-        for node in nodes:
-            out.append(f"{'  ' * depth}{node['status']}  {node['name']}")
-            out.extend(_rows(node["children"], depth + 1))
-        return out
-
-    rows = _rows(tree, 0)
-    return DetailElement(lambda: rows)
+    return DetailElement(lambda: _task_rows(tree, 0))
 
 
 def _more_expansion(snap, dispatch):
@@ -726,6 +727,14 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         snap = _snapshot(registry, task_cache, config)
         if spec.expansion is not None and snap is not None:
             result = spec.expansion(snap, _menu_submit)
+            # Task chip: snap["task_tree"] is frozen at open time but task_cache
+            # updates every second (_task_poll). Swap in a live-reading provider
+            # so the dropdown reflects task state changes while it stays open.
+            if spec.key == "task" and isinstance(result, DetailElement):
+                _tc = task_cache
+                def _live_tasks() -> list[str]:
+                    return _task_rows(_tc.get("tree") or [], 0) or ["(no active tasks)"]
+                result = DetailElement(_live_tasks)
             if isinstance(result, list):
                 for el in result:
                     menu_region.register(el)

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -18,6 +18,7 @@ from reyn.interfaces.inline.app import (
     _session_hook_items,
     _session_visibility_items,
     _task_expansion,
+    _task_rows,
 )
 from reyn.interfaces.inline.region import DetailElement
 from reyn.interfaces.inline.region_command import CommandUIElement
@@ -651,3 +652,35 @@ def test_task_expansion_child_row_more_indented_than_parent() -> None:
     root_indent = len(root_row) - len(root_row.lstrip())
     child_indent = len(child_row) - len(child_row.lstrip())
     assert child_indent > root_indent
+
+
+# _task_rows live-reading contract
+# ---------------------------------------------------------------------------
+
+
+def test_task_rows_dict_replacement_is_visible_through_lambda() -> None:
+    """Tier 2: live-reading DetailElement over task_cache re-reads the dict on every lines() call.
+
+    _menu_open creates DetailElement(lambda: _task_rows(tc.get("tree") or [], 0) …)
+    so that the open task dropdown reflects _task_poll's updates. The key contract:
+    replacing tc["tree"] (as _task_poll does — it assigns a new list, not in-place)
+    is immediately visible in the next lines() call, unlike a snapshot-time pre-compute.
+    """
+    tc: dict = {"tree": [{"task_id": "a", "name": "Task A", "status": "running", "children": []}]}
+    el = DetailElement(lambda: _task_rows(tc.get("tree") or [], 0) or ["(no active tasks)"])
+    assert any("Task A" in ln for ln in el.lines())
+
+    # Simulate _task_poll replacing the tree with a new list (not in-place mutation):
+    tc["tree"] = [{"task_id": "b", "name": "Task B", "status": "done", "children": []}]
+    assert any("Task B" in ln for ln in el.lines())
+    assert not any("Task A" in ln for ln in el.lines())
+
+
+def test_task_rows_empty_tree_replacement_shows_fallback() -> None:
+    """Tier 2: when _task_poll clears the tree, the live element shows the empty-state fallback."""
+    tc: dict = {"tree": [{"task_id": "a", "name": "Task A", "status": "running", "children": []}]}
+    el = DetailElement(lambda: _task_rows(tc.get("tree") or [], 0) or ["(no active tasks)"])
+    assert any("Task A" in ln for ln in el.lines())
+
+    tc["tree"] = []
+    assert el.lines() == ["(no active tasks)"]


### PR DESCRIPTION
**[tui-coder]** — inline CUI dogfood mining

## Bug

`_task_expansion` built `rows = _rows(tree, 0)` eagerly at menu-open time and `DetailElement(lambda: rows)` closed over the frozen list. `_task_poll` replaces `task_cache["tree"]` with a **new list** every second, so the snapshot captured at open time goes stale immediately after the first poll cycle — the user sees outdated task names and statuses while the dropdown stays open.

## Root cause

`_menu_open` calls `_snapshot(registry, task_cache, config)` once on Enter. `snap["task_tree"]` captures the reference to the old list. After `_task_poll` runs `task_cache["tree"] = _build_task_tree(active)`, the old reference (held by `snap["task_tree"]` and `rows`) still points to the pre-poll state.

## Fix

1. Extract `_task_rows(nodes, depth)` as a module-level helper (removes inner-function duplication).
2. In `_menu_open`, for the task chip, replace the expansion's `DetailElement` with a live-reading provider: `lambda: _task_rows(task_cache.get("tree") or [], 0)` — this reads `task_cache["tree"]` on every `lines()` call, so dict-value replacement is immediately visible.
3. `_task_expansion` itself is simplified (no more eager pre-compute); the `NOTE` comment explains why callers that need live data should substitute.

## Tests

+2 Tier 2 tests in `test_inline_pr3b_status_bar.py`:
- `test_task_rows_dict_replacement_is_visible_through_lambda` — pins that replacing `tc["tree"]` is visible on the next `lines()` call
- `test_task_rows_empty_tree_replacement_shows_fallback` — pins the empty-state fallback after the tree is cleared

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_pr3b_status_bar.py` — 53/53 ✓
- [x] `pytest tests/test_inline_pr3b_status_bar.py` — 53 passed
- [x] `pytest` (full suite) — 6932 passed, 17 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — OK

## Tier self-check

New tests are Tier 2 (OS contract invariant): real `DetailElement` + real `_task_rows`, no mocks, public-surface `el.lines()` assertions, no format pins. No Tier 4 violations.