### PR TITLE
refactor(control-ir): PR-5 — remove the dead OpPurity machinery

### DIFF
--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -73,10 +73,8 @@ async def dispatch_tool(
 
     Events emitted (via ctx.events.emit):
         - tool_called (caller_kind, caller_id, tool, chain_id, args, args_hash)
-            Skipped for ``pure`` op kinds (no side effect to disambiguate)
-            and for ``world`` / ``llm`` purity (no side effect ambiguity).
         - tool_returned (caller_kind, caller_id, tool, chain_id, result, args_hash)
-            on success.  Skipped for ``pure``.
+            on success.
         - tool_failed (caller_kind, caller_id, tool, chain_id, error_kind, message)
             on error.
 
@@ -84,7 +82,6 @@ async def dispatch_tool(
     raw result (any JSON-serializable value). PermissionError raised
     inside invoker becomes a "permission_denied" error result.
     """
-    from reyn.core.op_runtime.registry import OpPurity, get_op_purity
 
     # 1. Name validation
     if name not in ctx.tool_catalog:
@@ -113,24 +110,18 @@ async def dispatch_tool(
         except InvalidArgsError as e:
             return _error(ctx, name, "invalid_args", str(e))
 
-    # Determine purity (controls event emission; defaults to side_effect).
-    # Note: tool catalog entries from the chat router are not "ops" in the
-    # IR-op sense (memory/file/mcp tool entries here are wrappers around
-    # multiple op kinds). For chat-router callers, fall back to side_effect.
-    purity = get_op_purity(name) if ctx.caller_kind == "skill_phase" else OpPurity.side_effect
     args_hash = _compute_args_hash(args)
 
-    # 3. Pre-event (skip for pure / world / llm — no side-effect ambiguity)
-    if purity in (OpPurity.side_effect, OpPurity.external):
-        ctx.events.emit(
-            "tool_called",
-            caller_kind=ctx.caller_kind,
-            caller_id=ctx.caller_id,
-            tool=name,
-            chain_id=ctx.chain_id,
-            args=args,
-            args_hash=args_hash,
-        )
+    # 3. Pre-event: record the tool call.
+    ctx.events.emit(
+        "tool_called",
+        caller_kind=ctx.caller_kind,
+        caller_id=ctx.caller_id,
+        tool=name,
+        chain_id=ctx.chain_id,
+        args=args,
+        args_hash=args_hash,
+    )
 
     # 4. Invoke (with structured error handling)
     try:
@@ -164,18 +155,16 @@ async def dispatch_tool(
                 "error": {"kind": "exception",
                           "message": f"{type(e).__name__}: {e}"}}
 
-    # 5. Post-event with result (skipped for ``pure``: re-execution is safe
-    #    and cheap, no need to record).
-    if purity != OpPurity.pure:
-        ctx.events.emit(
-            "tool_returned",
-            caller_kind=ctx.caller_kind,
-            caller_id=ctx.caller_id,
-            tool=name,
-            chain_id=ctx.chain_id,
-            args_hash=args_hash,
-            result=result,
-        )
+    # 5. Post-event: record the result.
+    ctx.events.emit(
+        "tool_returned",
+        caller_kind=ctx.caller_kind,
+        caller_id=ctx.caller_id,
+        tool=name,
+        chain_id=ctx.chain_id,
+        args_hash=args_hash,
+        result=result,
+    )
     return {"status": "ok", "data": result}
 
 

--- a/src/reyn/core/op_runtime/compact.py
+++ b/src/reyn/core/op_runtime/compact.py
@@ -12,7 +12,7 @@ consistently about "should I compact" and "what fits now".
 P7/P8: no skill-specific strings. The op is OS-level vocabulary only; the
 optional ``reason`` is model-supplied audit text the OS never interprets.
 
-OpPurity: external (LLM cost + history mutation; the inner compaction engine
+Macro op (LLM cost + history mutation; the inner compaction engine
 emits its own events).
 """
 from __future__ import annotations

--- a/src/reyn/core/op_runtime/recall.py
+++ b/src/reyn/core/op_runtime/recall.py
@@ -4,7 +4,7 @@ The query embedding is computed **provider-direct** (#1303 S-I.4 — mirrors
 ``ActionEmbeddingIndex``); it no longer dispatches an ``embed`` sub-op. The
 ``index_query`` sub-ops still go through ``execute_op`` (P6 per-source events).
 
-ADR-0033 §2.1: macro op, OpPurity.external.
+ADR-0033 §2.1: macro op.
 """
 from __future__ import annotations
 

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -1,6 +1,6 @@
 """Op kind registry — op kind classification (ADR-0026 Phase 4 steady state).
 
-This module holds three classifications keyed by **op kind**
+This module holds two classifications keyed by **op kind**
 (= the ``op.kind`` values phase Control IR emits today:
 ``read_file`` / ``write_file`` / ``edit_file`` / ``delete_file`` /
 ``glob_files`` / ``grep_files`` / ``mcp`` / ``shell`` /
@@ -16,15 +16,10 @@ is KEPT — fine handlers still build ``FileIROp(kind="file")`` internally.
      classes; registry re-imports ``ALL_OP_KINDS`` from there).
      Schema derivation is done by ``reyn.tools.ToolRegistry``
      entries (= ADR-0026 Phase 4-3); the map remains the stable target
-     for ``ALL_OP_KINDS`` and purity classification.
+     for ``ALL_OP_KINDS``.
 
   2. ``ALL_OP_KINDS`` — frozenset of op kinds.  Used by the DSL
-     linter to flag misspelled ``allowed_ops`` entries; also drives
-     ``OP_PURITY`` coverage tests.
-
-  3. ``OP_PURITY`` — determinism classification.  See ``OpPurity`` enum
-     below.  Used by ``dispatch_tool`` to decide whether to emit step
-     events for resume.
+     linter to flag misspelled ``allowed_ops`` entries.
 
 Helper:
   - ``is_op_allowed(op_kind, allowed_ops)`` — prefix-wildcard membership
@@ -33,7 +28,6 @@ Helper:
 
 Consumers:
   - ``reyn.core.compiler.linter``     — ``ALL_OP_KINDS``
-  - ``reyn.core.dispatch.dispatcher`` — ``OP_PURITY`` (skip emission for ``pure``)
   - ``reyn.core.kernel.control_ir_executor`` — ``is_op_allowed`` for the
     ``allowed_ops`` filter
 
@@ -43,131 +37,18 @@ op kinds.  They are a different concern and intentionally stay local.
 """
 from __future__ import annotations
 
-from enum import Enum
-
 # #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS relocated to schemas/models.py
 # (co-located with the IROp model classes + the now-derived Op union =
 # single source; the map lived here before, but registry imports those model
 # classes, so models.py could not derive the union from the map without a cycle).
-# registry keeps the *purity* classification (OP_PURITY) and re-imports
-# ALL_OP_KINDS from models for ALL_TOOL_NAMES — an intentional op-runtime-view
-# convenience, NOT a migration shim.
+# registry re-imports ALL_OP_KINDS from models for ALL_TOOL_NAMES — an
+# intentional op-runtime-view convenience, NOT a migration shim.
 from reyn.schemas.models import ALL_OP_KINDS
-
-
-class OpPurity(str, Enum):
-    """Determinism classification for ops, used by skill resume design.
-
-    - ``pure``: same args → same result, no external state, no side effects.
-      Resume can re-execute safely; step event emission is **skipped** to
-      reduce WAL volume.
-    - ``world``: depends on external state (filesystem, network reads),
-      but no side effects.  Result varies across calls; step event must
-      record the result so resume uses cached value, not re-execute.
-    - ``side_effect``: writes to local state (workspace, filesystem).
-      Both ``step_started`` and ``step_completed`` are emitted so a crash
-      between them surfaces as an ambiguous state on resume.
-    - ``external``: invokes external systems with potential side effects
-      (mcp/call_tool, shell, run_skill).  Same emission policy as
-      ``side_effect``; the distinction is audit metadata.
-    - ``llm``: language-model call.  Cost side effect + non-deterministic
-      output.  ``step_completed`` records the output; ``step_started`` is
-      not emitted (no externally-observable side effect to disambiguate).
-    """
-
-    pure = "pure"
-    world = "world"
-    side_effect = "side_effect"
-    external = "external"
-    llm = "llm"
-
 
 # #1983: OP_KIND_MODEL_MAP + ALL_OP_KINDS now live in schemas/models.py — the
 # single source (the Op discriminated union derives from the map there,
 # completeness-by-construction). Add a new op kind in models.py; ALL_OP_KINDS is
-# imported above (used by ALL_TOOL_NAMES below). registry owns only OP_PURITY.
-
-# ---------------------------------------------------------------------------
-# OP_PURITY
-# ---------------------------------------------------------------------------
-# Determinism classification per op kind.  Default is ``side_effect`` (safe
-# side: emit both events) for any kind not explicitly listed.  Sub-types
-# (e.g. file/read vs file/write) cannot be distinguished here; for kinds
-# whose behavior varies by sub-op (file, mcp), ``side_effect`` is chosen
-# as the conservative default and finer-grained classification belongs
-# inside the op handler.
-# ---------------------------------------------------------------------------
-
-OP_PURITY: dict[str, OpPurity] = {
-    # World-state dependent (read APIs).
-    "web_fetch":   OpPurity.world,
-    "web_search":  OpPurity.world,
-    # Side effect (workspace mutation; file write/delete fall here).
-    # #1240 Wave 2b: coarse "file" purity entry dropped (coarse kind removed).
-    # #1240 Wave 1: fine-grained file kinds. Conservative side_effect stance
-    # (matches the former coarse "file" classification). A read_file→world
-    # accuracy refinement is a separate decision, out of pivot scope.
-    "read_file":   OpPurity.side_effect,
-    "write_file":  OpPurity.side_effect,
-    "edit_file":   OpPurity.side_effect,
-    "delete_file": OpPurity.side_effect,
-    # #1240 Wave 1.5: glob_files / grep_files. Same conservative stance as
-    # Wave 1 fine kinds — match the coarse "file" side_effect classification.
-    "glob_files":  OpPurity.side_effect,
-    "grep_files":  OpPurity.side_effect,
-    # External / unknown side-effecting.
-    "mcp":         OpPurity.external,
-    # User interaction (state-changing for the user).
-    "ask_user":    OpPurity.side_effect,
-    # MCP server install: writes config + secrets, runs registry fetch.
-    "mcp_install": OpPurity.side_effect,
-    # #1983: MCP server drop — mutates config (removes a server entry).
-    "mcp_drop_server": OpPurity.side_effect,
-    # ADR-0033 RAG ops (#1303 Stage I: embed + index_write deleted):
-    # - index_query: read-only, depends on backend state (= world).
-    "index_query": OpPurity.world,
-    # - recall: macro op — embeds the query provider-direct, then dispatches
-    #   index_query sub-ops (which emit their own events); external.
-    "recall":      OpPurity.external,
-    # - index_drop: deletes backend collection + manifest entry.
-    "index_drop":  OpPurity.side_effect,
-    # FP-0017: sandboxed_exec — same external side-effect class as shell.
-    "sandboxed_exec": OpPurity.external,
-    # FP-0007 Component D: LLM call with token cost side effect.
-    "judge_output": OpPurity.llm,
-    # #272/#1128: compact triggers a compaction LLM call (cost) AND mutates
-    # history/state; like `recall` it is a macro whose inner compaction engine
-    # emits its own events. external = emit both started+completed so a crash
-    # mid-compaction surfaces as ambiguous on resume.
-    "compact": OpPurity.external,
-    # #1953 slice 1: Task ops. Reads = world (backend state); mutations =
-    # side_effect (backend write). Conservative; finer attempt-vs-task purity
-    # is not needed for resume since the Task backend is its own source of truth.
-    "task.get": OpPurity.world,
-    "task.list": OpPurity.world,
-    "task.create": OpPurity.side_effect,
-    "task.update_status": OpPurity.side_effect,
-    "task.add_dependency": OpPurity.side_effect,
-    "task.remove_dependency": OpPurity.side_effect,
-    "task.repoint_dependency": OpPurity.side_effect,
-    "task.abort": OpPurity.side_effect,
-    "task.heartbeat": OpPurity.side_effect,
-    "task.register_unblock_predicate": OpPurity.side_effect,
-    "task.comment": OpPurity.side_effect,
-    "task.assign": OpPurity.side_effect,
-}
-
-
-def get_op_purity(op_kind: str) -> OpPurity:
-    """Return the purity classification for an op kind.
-
-    Defaults to ``side_effect`` (conservative — emit both step events) for
-    unknown kinds.  Future skill resume dispatcher uses this to decide
-    whether to emit ``tool_called`` ahead of execution and whether to
-    record the result in ``tool_returned``.
-    """
-    return OP_PURITY.get(op_kind, OpPurity.side_effect)
-
+# imported above (used by ALL_TOOL_NAMES below).
 
 # ALL_OP_KINDS is imported from schemas/models.py above (single source, #1983);
 # it remains importable from this module for back-compat (intentional convenience).

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -488,7 +488,7 @@ class TaskAssignIROp(BaseModel):
 # not derive the union from it without a cycle; that dual-source (hand-listed
 # union vs the map) was #1983's root cause. Add a new op kind HERE (kind → IROp
 # model); the union + ALL_OP_KINDS follow by construction. op_runtime/registry.py
-# keeps the *purity* classification (OP_PURITY) and re-imports ALL_OP_KINDS from
+# re-imports ALL_OP_KINDS from
 # here (intentional convenience, not a migration shim).
 #
 # NOTE: the coarse "file" kind is intentionally NOT in the map (#1240 Wave 2b
@@ -530,7 +530,7 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "task.assign": TaskAssignIROp,
 }
 
-# Frozenset of op kinds — DSL linter, OP_PURITY coverage, contextual gate.
+# Frozenset of op kinds — DSL linter, contextual gate.
 ALL_OP_KINDS: frozenset[str] = frozenset(OP_KIND_MODEL_MAP.keys())
 
 # Discriminated union — DERIVED from OP_KIND_MODEL_MAP (#1983, completeness-by-

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -6,7 +6,7 @@ Verifies:
 - NoopBackend.run(["echo", "hi"], ...) returns expected output.
 - sandboxed_exec op dispatches through `execute_op` and emits P6 events.
 - Wall-clock timeout enforces via subprocess timeout.
-- registry: OP_KIND_MODEL_MAP and OP_PURITY include "sandboxed_exec".
+- registry: OP_KIND_MODEL_MAP includes "sandboxed_exec".
 
 No mocks of collaborators — real EventLog, Workspace, NoopBackend, dispatcher.
 """
@@ -19,7 +19,6 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime import execute_op
 from reyn.core.op_runtime.context import OpContext
-from reyn.core.op_runtime.registry import OP_PURITY, OpPurity
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, SandboxedExecIROp
 from reyn.security.permissions.permissions import PermissionDecl
@@ -133,11 +132,6 @@ def test_registry_includes_sandboxed_exec():
     assert "sandboxed_exec" in OP_KIND_MODEL_MAP
     assert OP_KIND_MODEL_MAP["sandboxed_exec"] is SandboxedExecIROp
     assert "sandboxed_exec" in ALL_OP_KINDS
-
-
-def test_op_purity_includes_sandboxed_exec():
-    """Tier 2: OP_PURITY classifies sandboxed_exec as external (= same as shell)."""
-    assert OP_PURITY["sandboxed_exec"] == OpPurity.external
 
 
 # ─── 4. Op dispatch + events ──────────────────────────────────────────────────

--- a/tests/test_task_ops_interface_1953.py
+++ b/tests/test_task_ops_interface_1953.py
@@ -21,7 +21,6 @@ from pydantic import TypeAdapter
 from reyn.core.op_runtime import available_kinds
 from reyn.core.op_runtime import task as taskmod
 from reyn.core.op_runtime.contextual_gate import _OP_KIND_ALIASES
-from reyn.core.op_runtime.registry import OP_PURITY
 from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, Op
 from reyn.task import InMemoryTaskBackend, Task, TaskState
 from reyn.task.subscription import SubscriptionRegistry
@@ -46,13 +45,12 @@ def _reset_backend():
 # ── registry / gate completeness (Tier 1 contract) ──────────────────────────
 
 
-def test_all_task_kinds_present_in_registry_and_purity():
-    """Tier 1: every task op kind has a model + purity + handler (no half-wiring)."""
+def test_all_task_kinds_present_in_registry():
+    """Tier 1: every task op kind has a model + handler (no half-wiring)."""
     assert _TASK_KINDS  # non-empty; the exact set is pinned in the union test
     handlers = set(available_kinds())
     for kind in _TASK_KINDS:
         assert kind in OP_KIND_MODEL_MAP
-        assert kind in OP_PURITY
         assert kind in handlers
 
 


### PR DESCRIPTION
**[e2e-coder]** — Control IR arc **PR-5** (the purity FULL removal). ⚠️ **Most-critical dispatch-emit-path change → owner requires tui-live-verify before merge** (chat/tool-call/permission/codeact + emission intact), not just CI.

## What
Removes the `OpPurity` classification abstraction, which is **dead**: it was only consulted on the `caller_kind == "skill_phase"` branch of `dispatch_tool`, and `skill_phase` has had **zero producers since resume-runtime B (#2456)**. So `purity` was ALWAYS `side_effect` for the live chat/router path → the emit conditionals were always-true.

- **dispatcher.py**: drop the `purity = get_op_purity(...) if skill_phase else side_effect` line + the `OpPurity`/`get_op_purity` import; collapse the two emit gates (`if purity in (side_effect, external)` / `if purity != pure`) to **UNCONDITIONAL** emits. The live path always emitted both `tool_called` and `tool_returned` → byte-identical.
- **registry.py**: remove the `OpPurity` enum, the `OP_PURITY` map, `get_op_purity` (+ the now-unused `from enum import Enum`); docstring drops the purity classification.
- OpPurity docstring mentions (models/compact/recall) reworded; 2 obsolete purity tests removed.

## Behavior-preservation (gate 2)
Guarded by the pre-existing `test_dispatcher::test_happy_path_emits_called_then_returned` — a successful dispatch emits `["tool_called", "tool_returned"]`. Every chat op was already `side_effect`, so all emitted both; the collapse preserves that exactly.

## Guardrail
`OP_PURITY` is a **SEPARATE** dict from `OP_KIND_MODEL_MAP` (the WAL identity source in models.py) — removing it does not touch op-kind string keys. `OP_KIND_MODEL_MAP` + `ALL_OP_KINDS` byte-identical; `#1983` union green (5 passed).

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python -m pytest` — **6944 passed**, 16 skipped, 0 failed
- [x] emission gate `test_happy_path_emits_called_then_returned` + dispatcher/task/sandboxed suites — 37 passed
- [x] `#1983` union guardrail — 5 passed; `OP_KIND_MODEL_MAP`/`ALL_OP_KINDS` intact
- [x] `test_tier_audit.py --strict` (changed tests) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] `grep OP_PURITY/OpPurity/get_op_purity` — zero residual
- [ ] **tui-live-verify (dispatch emit path)** — owner gate, pending lead's tui dispatch

**Next:** PR-6 (docs) — closes the Control IR arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)