### PR TITLE
docs(control-ir): PR-6 — sync docs to the Control IR layer removal (arc close)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ deep dives via the references at the bottom.
 
 ## Hard rules
 
-- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `ControlIROp` union derives from the same map). New op kinds get a section in the reference in the same PR.
+- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `Op` union derives from the same map). New op kinds get a section in the reference in the same PR.
 - **Recovery-feature PR gate**: any PR adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths) MUST include a truncate-falsify test verifying the reconstruction source survives WAL truncation below its source events (set X → truncate past X's events → reconstruct → assert X survives). WAL-event-derived recovery state that isn't snapshot-backed is a silent data-loss vector. Same PR, not a follow-up. (Motivated by #2259/#2260.)
 
 ## Testing policy (READ BEFORE WRITING TESTS)

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -27,16 +27,6 @@ mindmap
         Next-phase allowlist
         Artifact schema
         Normalization retry
-      ⏩ Preprocessor
-        run_op
-        iterate
-        validate
-        lint_plan
-        python
-      ⏪ Postprocessor
-        Same step types
-        Skill-finish transform
-        Step memoization
       🗂️ Workspace P5
         Artifact storage
         Permission-gated IO
@@ -241,22 +231,6 @@ mindmap
 | Next-phase allowlist | Transition target must appear in the skill graph candidates | [LLM Output Contract](reference/runtime/llm-output-contract.md) · Graph |
 | Artifact schema validation | `data` validated against the target phase's `input_schema` | Artifact YAML |
 | Normalization retry | Minor JSON errors healed before rejecting, up to `llm_max_retries` | [LLM Output Contract](reference/runtime/llm-output-contract.md) |
-
-#### Preprocessor
-| Feature | Description | Documentation |
-|---------|-------------|---------------|
-| `run_op` step | Invoke any Control IR op deterministically before the LLM call | Preprocessor DSL |
-| `iterate` step | Fan-out `run_op` over array field elements | Preprocessor DSL |
-| `validate` step | JSON Schema check on artifact data | Preprocessor DSL |
-| `lint_plan` step | Structural check on plan-shaped artifacts | Preprocessor DSL |
-| `python` step | User function in sandboxed subprocess (safe/unsafe mode) | Preprocessor DSL |
-
-#### Postprocessor
-| Feature | Description | Documentation |
-|---------|-------------|---------------|
-| Skill-finish transform | Convert LLM `final_output` to caller artifact schema | Postprocessor DSL · Concepts: Postprocessor |
-| Same step types | `run_op` / `iterate` / `validate` / `lint_plan` / `python` | Postprocessor DSL |
-| Step memoization | Skip re-execution on crash resume if step already committed | Postprocessor DSL · Skill Resume |
 
 #### Workspace (P5)
 | Feature | Description | Documentation |

--- a/docs/guide/for-reyn-developers/add-an-op-kind.md
+++ b/docs/guide/for-reyn-developers/add-an-op-kind.md
@@ -14,8 +14,8 @@ files or adding skill-specific strings anywhere.
 
 **P7 in practice.** The OS's skill-agnostic guarantee (P7) is what makes this
 possible. Op kind strings appear in exactly one place — `OP_KIND_MODEL_MAP` in
-`schemas/models.py`. Every other mechanism (`ControlIRExecutor`,
-`ALL_OP_KINDS`, `_build_phase_tool_catalog`) derives from that single source.
+`schemas/models.py`. Every other mechanism (`ALL_OP_KINDS`, the op dispatcher
+`execute_op`, the `reyn.tools` catalog) derives from that single source.
 Adding a new entry to the map is sufficient; no scattered string literals to
 track down.
 
@@ -229,9 +229,8 @@ async def test_notify_handler_emits_events():
 allowed_ops: [read_file, notify]
 ```
 
-The LLM's system prompt will include the `notify` op schema (via
-`_build_phase_tool_catalog`), and the LLM can now emit `notify` ops in its
-`control_ir` list.
+The LLM's system prompt will include the `notify` op schema (via the
+`reyn.tools` catalog), and the LLM can now emit `notify` ops.
 
 ---
 
@@ -242,8 +241,8 @@ After these four steps, no further OS changes are needed:
 | Mechanism | How it picks up your op |
 |---|---|
 | `ALL_OP_KINDS` | Derived from `OP_KIND_MODEL_MAP.keys()` — updated automatically |
-| `ControlIRExecutor` | Reads `_HANDLERS` which was populated by `register("notify", handle)` at import time |
-| LLM system prompt | `_build_phase_tool_catalog` iterates `OP_KIND_MODEL_MAP` and derives JSON Schema from `NotifyIROp` |
+| `execute_op` (op_runtime) | Reads `_HANDLERS` which was populated by `register("notify", handle)` at import time |
+| LLM system prompt | the `reyn.tools` catalog iterates `OP_KIND_MODEL_MAP` and derives JSON Schema from `NotifyIROp` |
 | DSL linter | Validates `allowed_ops` entries against `ALL_OP_KINDS` |
 
 The OS contains no `"notify"` string outside `schemas/models.py`. Any future skill

--- a/docs/guide/for-reyn-developers/add-an-op-kind.md
+++ b/docs/guide/for-reyn-developers/add-an-op-kind.md
@@ -14,7 +14,7 @@ files or adding skill-specific strings anywhere.
 
 **P7 in practice.** The OS's skill-agnostic guarantee (P7) is what makes this
 possible. Op kind strings appear in exactly one place — `OP_KIND_MODEL_MAP` in
-`op_runtime/registry.py`. Every other mechanism (`ControlIRExecutor`,
+`schemas/models.py`. Every other mechanism (`ControlIRExecutor`,
 `ALL_OP_KINDS`, `_build_phase_tool_catalog`) derives from that single source.
 Adding a new entry to the map is sufficient; no scattered string literals to
 track down.
@@ -34,7 +34,7 @@ for fundamentally different execution semantics.
 
 Every op kind has a typed Pydantic model that doubles as its JSON Schema for
 the LLM. Add your model alongside the existing ones and include it in the
-`ControlIROp` discriminated union.
+`Op` discriminated union.
 
 ```python
 # src/reyn/schemas/models.py
@@ -46,7 +46,7 @@ class NotifyIROp(BaseModel):
     severity: str = "info"   # "info" | "warning" | "error"
 
 # Update the union — append NotifyIROp:
-ControlIROp = Annotated[
+Op = Annotated[
     Union[
         FileIROp, MCPIROp, AskUserIROp, ShellIROp, LintIROp,
         RunSkillIROp, WebFetchIROp, WebSearchIROp,
@@ -64,17 +64,13 @@ Rules for the model:
 
 ---
 
-## Step 2 — Register in the op registry (`op_runtime/registry.py`)
+## Step 2 — Add to the op-kind map (`schemas/models.py`)
 
-Two dicts need an entry. Add the import and the two entries:
+`OP_KIND_MODEL_MAP` lives in the same file as the model (#1983 co-location).
+Add your kind alongside the model you defined in Step 1:
 
 ```python
-# src/reyn/core/op_runtime/registry.py
-
-from reyn.schemas.models import (
-    ...,
-    NotifyIROp,   # ← new import
-)
+# src/reyn/schemas/models.py
 
 OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # The coarse "file" kind was retired in #1240 Wave 2b — file ops are now
@@ -90,43 +86,17 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "web_search": WebSearchIROp,
     "notify":     NotifyIROp,   # ← new
 }
-
-OP_PURITY: dict[str, OpPurity] = {
-    "lint":       OpPurity.pure,
-    "web_fetch":  OpPurity.world,
-    "web_search": OpPurity.world,
-    "read_file":  OpPurity.side_effect,
-    "mcp":        OpPurity.external,
-    "shell":      OpPurity.external,
-    "run_skill":  OpPurity.external,
-    "ask_user":   OpPurity.side_effect,
-    "notify":     OpPurity.external,   # ← new
-}
 ```
 
 `ALL_OP_KINDS` is derived from `OP_KIND_MODEL_MAP.keys()` at module load — you
 do not need to touch it.
-
-### Choosing OpPurity
-
-Pick the classification that best describes what your handler actually does:
-
-| Classification | When to use |
-|---|---|
-| `pure` | Pure computation, no I/O (e.g. `lint`) — memo is permanent, resume skips re-execution |
-| `world` | Reads external state without side effects (e.g. `web_fetch`) — result recorded so resume uses cached value |
-| `side_effect` | Writes to local/workspace state (e.g. `file`, `ask_user`) — both step events emitted; crash between them surfaces as ambiguous on resume |
-| `external` | Calls external systems with potential side effects (e.g. `shell`, `mcp`, `run_skill`) — same emission policy as `side_effect`; distinction is audit metadata |
-
-If in doubt, default to `external` (conservative). The cost is a few extra
-events; the risk of under-classifying is silent data loss on resume.
 
 ---
 
 ## Step 3 — Implement the handler (`op_runtime/notify.py`)
 
 Create a new file under `src/reyn/core/op_runtime/`. The handler is an `async`
-function that takes the typed op, an `OpContext`, and a `caller` literal.
+function that takes the typed op and an `OpContext`.
 It must return a JSON-serializable dict. Register it at module level so the
 self-registration mechanism picks it up.
 
@@ -134,8 +104,6 @@ self-registration mechanism picks it up.
 # src/reyn/core/op_runtime/notify.py
 """notify op handler — send a notification to an external channel."""
 from __future__ import annotations
-
-from typing import Literal
 
 from reyn.schemas.models import NotifyIROp
 
@@ -146,7 +114,6 @@ from .context import OpContext
 async def handle(
     op: NotifyIROp,
     ctx: OpContext,
-    caller: Literal["preprocessor", "control_ir"],
 ) -> dict:
     ctx.events.emit("notify_started", channel=op.channel, severity=op.severity)
 
@@ -186,18 +153,6 @@ self-registers at startup:
 # src/reyn/core/op_runtime/__init__.py (end of file, with the other handler imports)
 from . import notify as _notify  # noqa: F401, E402
 ```
-
-### Preprocessor restriction (optional)
-
-If your op cannot be invoked from a phase's `preprocessor` (e.g. it requires
-interactive input similar to `ask_user`), add it to
-`_PREPROCESSOR_FORBIDDEN_KINDS` in `__init__.py`:
-
-```python
-_PREPROCESSOR_FORBIDDEN_KINDS = frozenset({"ask_user", "notify"})
-```
-
-Most ops do not need this restriction.
 
 ---
 
@@ -260,7 +215,7 @@ reyn lint reyn/local/my_skill
 async def test_notify_handler_emits_events():
     ctx = make_real_op_context()   # from your test helpers
     op = NotifyIROp(kind="notify", channel="test", message="hello")
-    result = await execute_op(op, ctx, caller="control_ir")
+    result = await execute_op(op, ctx)
     assert result["status"] in ("ok", "error")  # depends on stub behaviour
     event_kinds = [e.kind for e in ctx.events.to_list()]
     assert "notify_started" in event_kinds
@@ -289,10 +244,9 @@ After these four steps, no further OS changes are needed:
 | `ALL_OP_KINDS` | Derived from `OP_KIND_MODEL_MAP.keys()` — updated automatically |
 | `ControlIRExecutor` | Reads `_HANDLERS` which was populated by `register("notify", handle)` at import time |
 | LLM system prompt | `_build_phase_tool_catalog` iterates `OP_KIND_MODEL_MAP` and derives JSON Schema from `NotifyIROp` |
-| Resume purity | `get_op_purity("notify")` reads `OP_PURITY` and drives step-event emission policy |
 | DSL linter | Validates `allowed_ops` entries against `ALL_OP_KINDS` |
 
-The OS contains no `"notify"` string outside `registry.py`. Any future skill
+The OS contains no `"notify"` string outside `schemas/models.py`. Any future skill
 that wants to use notifications just adds `notify` to its `allowed_ops` — no
 OS code changes, no new files outside the three touch points above.
 

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -53,15 +53,11 @@ The OS (`kernel/runtime.py`) is the only thing that calls the LLM, executes Cont
 
 | File | What it does |
 |---|---|
-| `src/reyn/core/kernel/runtime.py` | Main OS loop — LLM call, validation, op execution, events |
-| `src/reyn/core/kernel/control_ir_executor.py` | Dispatches Control IR ops from the OS to op handlers |
 | `src/reyn/core/op_runtime/registry.py` | Single source of truth for op kinds, Pydantic models |
 | `src/reyn/core/context_builder.py` | Builds the ContextFrame injected into every LLM call (P4 candidates here) |
 | `src/reyn/schemas/models.py` | All Pydantic models — Phase, Skill, SkillGraph, Op |
 | `src/reyn/core/events/events.py` | Append-only EventLog (P6) |
 | `src/reyn/data/workspace/workspace.py` | Workspace read/write with permission gating (P5) |
-| `src/reyn/core/compiler/linter.py` | Static validation — graph cycles, allowed_ops spelling, P7 checks |
-| `src/reyn/core/compiler/expander.py` | Loads and expands Skill + Phase from `.md` + `.yaml` files |
 
 ---
 

--- a/docs/guide/for-reyn-developers/index.md
+++ b/docs/guide/for-reyn-developers/index.md
@@ -55,9 +55,9 @@ The OS (`kernel/runtime.py`) is the only thing that calls the LLM, executes Cont
 |---|---|
 | `src/reyn/core/kernel/runtime.py` | Main OS loop — LLM call, validation, op execution, events |
 | `src/reyn/core/kernel/control_ir_executor.py` | Dispatches Control IR ops from the OS to op handlers |
-| `src/reyn/core/op_runtime/registry.py` | Single source of truth for op kinds, Pydantic models, purity classification |
+| `src/reyn/core/op_runtime/registry.py` | Single source of truth for op kinds, Pydantic models |
 | `src/reyn/core/context_builder.py` | Builds the ContextFrame injected into every LLM call (P4 candidates here) |
-| `src/reyn/schemas/models.py` | All Pydantic models — Phase, Skill, SkillGraph, ControlIROp, CandidateOutput |
+| `src/reyn/schemas/models.py` | All Pydantic models — Phase, Skill, SkillGraph, Op |
 | `src/reyn/core/events/events.py` | Append-only EventLog (P6) |
 | `src/reyn/data/workspace/workspace.py` | Workspace read/write with permission gating (P5) |
 | `src/reyn/core/compiler/linter.py` | Static validation — graph cycles, allowed_ops spelling, P7 checks |

--- a/docs/guide/for-reyn-developers/principles-and-code.md
+++ b/docs/guide/for-reyn-developers/principles-and-code.md
@@ -169,8 +169,8 @@ class MyOpIROp(BaseModel):
     target: str
     options: dict = {}
 
-# Add to the ControlIROp union:
-ControlIROp = Annotated[
+# Add to the Op union:
+Op = Annotated[
     FileIROp | MCPIROp | ... | MyOpIROp,
     Field(discriminator="kind")
 ]
@@ -184,11 +184,6 @@ from reyn.schemas.models import MyOpIROp
 OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     ...
     "my_op": MyOpIROp,
-}
-
-OP_PURITY: dict[str, OpPurity] = {
-    ...
-    "my_op": OpPurity.side_effect,  # or pure / world / external
 }
 ```
 

--- a/docs/guide/for-reyn-developers/write-replay-tests.md
+++ b/docs/guide/for-reyn-developers/write-replay-tests.md
@@ -56,8 +56,9 @@ AttributeError) rather than in production.
 | 3 — LLM-replay | Behavior of LLM-dependent paths via recorded fixtures | Yes (`LLMReplay`) |
 | 4 — Don't write | Everything else | — |
 
-This tutorial covers **Tier 3a**: single LLM call per test, single phase. If
-you are not testing an LLM-dependent path, check the decision flow in
+This tutorial covers **Tier 3a**: a single LLM call per test. The LLM tool-call
+path is reached through `call_llm_tools` (the tool_use wrapper the chat router
+drives). If you are not testing an LLM-dependent path, check the decision flow in
 [testing.md](../../deep-dives/contributing/testing.md#decision-flow) first.
 
 ---
@@ -72,63 +73,43 @@ you are not testing an LLM-dependent path, check the decision flow in
 
 ### Write the test first (without a fixture)
 
-Create your test file. Use `@pytest.mark.replay` with a path relative to
-`tests/`:
+Create your test file. Mark the test with `@pytest.mark.replay`, passing a
+fixture path relative to `tests/`, and drive the real `call_llm_tools`
+boundary. There is no frame or context object to build — you pass the plain
+`messages` and `tools` dicts that go to litellm:
 
 ```python
 # tests/test_replay_my_area.py
 
-import asyncio
 import pytest
-from reyn.llm.llm import call_llm
-from reyn.schemas.models import ContextFrame, ExecutionState, PhaseConstraints
-from reyn.testing.replay import REPLAY_DATETIME
 
-MODEL = "gemini-2.5-flash-lite"
+from reyn.llm.llm import call_llm_tools
 
-@pytest.mark.replay("fixtures/llm/my_area/happy_path.jsonl")
-def test_my_phase_happy_path():
-    """Tier 3a: my_phase transitions to next_phase on valid input."""
-    frame = ContextFrame(
-        current_phase="my_phase",
-        current_phase_role="my_role",
-        instructions="... the phase instructions ...",
-        candidate_outputs=[],   # fill in from the real skill
-        finish_criteria=[],
-        constraints=PhaseConstraints(),
-        available_control_ops=[],
-        op_catalog=[],
-        output_language="en",
-        model="standard",
-        model_resolved=MODEL,
-        input_artifact={"type": "my_input", "data": {"field": "value"}},
-        execution=ExecutionState(path=["start → my_phase"], current_visit=1, total_steps=1),
-        control_ir_results=[],
-        remaining_act_turns=0,
-        current_datetime=REPLAY_DATETIME,  # REQUIRED — see below
-    )
+MODEL = "gemini-2.5-flash-lite"   # bare name — the proxy strips any prefix on
+                                  # record, so the replay key matches
+MESSAGES = [{"role": "user", "content": "hi"}]
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_skill",
+            "description": "run a skill",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
 
-    result = asyncio.run(
-        call_llm(
-            MODEL,
-            frame,
-            prompt_cache_enabled=False,
-            skill_name="my_skill",
-            skill_description="...",
-            phase_role="my_role",
-        )
-    )
 
-    assert result.data["type"] == "decide"
-    assert result.data["control"]["type"] == "transition"
-    assert result.data["control"]["next_phase"] == "next_phase"
+@pytest.mark.replay("fixtures/llm/my_area/text_only.jsonl")
+@pytest.mark.asyncio
+async def test_my_call_returns_text_when_no_tool_calls():
+    """Tier 3a: when the LLM returns plain text, result.content reflects it."""
+    result = await call_llm_tools(model=MODEL, messages=MESSAGES, tools=TOOLS)
+
+    assert isinstance(result.content, str)
+    assert len(result.content) > 0
+    assert result.tool_calls == []
 ```
-
-**Why `REPLAY_DATETIME` is required**: the `ContextFrame` is serialised into
-the prompt, and every field contributes to the SHA-256 fixture key. If you use
-`datetime.now()`, the key changes every second and no fixture will ever match.
-`REPLAY_DATETIME` is a fixed sentinel (`2026-01-01T00:00:00Z`) that keeps the
-key stable across runs.
 
 ### Run once to record
 
@@ -136,11 +117,11 @@ When the fixture file does not exist, `conftest.py` switches to record mode
 automatically:
 
 ```bash
-python -m pytest tests/test_replay_my_area.py::test_my_phase_happy_path -v
+python -m pytest tests/test_replay_my_area.py::test_my_call_returns_text_when_no_tool_calls -v
 ```
 
 This calls the real LLM, records the response, and writes
-`tests/fixtures/llm/my_area/happy_path.jsonl`. The test also passes on this
+`tests/fixtures/llm/my_area/text_only.jsonl`. The test also passes on this
 first run.
 
 After recording, run the test again without a live LLM to confirm it replays
@@ -148,7 +129,7 @@ correctly:
 
 ```bash
 # Stop the proxy, then:
-python -m pytest tests/test_replay_my_area.py::test_my_phase_happy_path -v
+python -m pytest tests/test_replay_my_area.py::test_my_call_returns_text_when_no_tool_calls -v
 ```
 
 Commit the fixture file alongside the test.
@@ -157,146 +138,102 @@ Commit the fixture file alongside the test.
 
 ## Step 2: Write the test body
 
-### Build the ContextFrame accurately
+### Keep the inputs deterministic
 
-The fixture key is derived from the exact serialised `(model, messages)` that
-`call_llm` sends to litellm. **Every field in `ContextFrame` contributes**,
-including:
+The fixture key is the SHA-256 of the exact `(model, messages, tools,
+tool_choice)` that `call_llm_tools` sends to litellm. **Every byte of the
+serialised inputs contributes to the key.** Two consequences:
 
-- `instructions` — must be the real phase instructions, not a placeholder
-- `candidate_outputs` — must reflect what the OS would inject at runtime
-- `input_artifact` — must match the artifact shape the phase receives
-
-The easiest way to get this right is to load the skill from disk using
-`load_dsl_skill` and pull the phase and its schema directly:
-
-```python
-from pathlib import Path
-from reyn.core.compiler.loader import load_dsl_skill
-from reyn.schemas.models import CandidateOutput
-
-_SKILL_PATH = Path(__file__).parent.parent / "src" / "reyn" / "stdlib" / "skills" / "my_skill" / "skill.md"
-
-def _load_skill():
-    return load_dsl_skill(_SKILL_PATH)
-
-def _make_frame(skill) -> ContextFrame:
-    phase = skill.phases["my_phase"]
-    next_phase = skill.phases["next_phase"]
-    candidate = CandidateOutput(
-        next_phase="next_phase",
-        control_type="transition",
-        schema_name=next_phase.input_schema_name,
-        artifact_schema=next_phase.input_schema,
-        description="Transition to next_phase",
-    )
-    return ContextFrame(
-        current_phase="my_phase",
-        instructions=phase.instructions,
-        candidate_outputs=[candidate],
-        # ... other fields ...
-        current_datetime=REPLAY_DATETIME,
-    )
-```
-
-Loading from disk has two benefits: the fixture stays in sync when the skill
-evolves (the key changes and `MissingFixture` fires, signalling a re-record),
-and the test documents the real call path rather than a synthetic approximation.
+- Build `messages` and `tools` from stable, literal values. Do **not** inject
+  volatile data (timestamps, UUIDs, `datetime.now()`, random ids) into the
+  prompt — the key would change every run and no fixture would ever match.
+- Because the key is a pure function of the inputs, two tests that pass the
+  *same* `(model, messages, tools, tool_choice)` share one fixture file. Reuse
+  a fixture across tests that exercise the same call.
 
 ### Assert on structure, not wording
 
-Good assertions check the OS-level contract:
+`call_llm_tools` returns a result with a `.content` string and a normalized
+`.tool_calls` list (plain dicts, not litellm internals). Good assertions check
+that shape, not the model's free text:
 
 ```python
-# Good — structural contract
-assert result.data["control"]["type"] == "transition"
-assert result.data["control"]["decision"] == "continue"
-assert result.data["control"]["next_phase"] == "run_and_eval"
+@pytest.mark.replay("fixtures/llm/my_area/tool_call.jsonl")
+@pytest.mark.asyncio
+async def test_tool_calls_are_normalized():
+    """Tier 3a: tool_calls are normalized to plain dicts."""
+    messages = [{"role": "user", "content": "call the run_skill tool with skill=hello"}]
+    result = await call_llm_tools(
+        model=MODEL, messages=messages, tools=TOOLS, tool_choice="required"
+    )
+
+    assert len(result.tool_calls) >= 1
+    tc = result.tool_calls[0]
+    assert isinstance(tc, dict)                       # not a litellm object
+    assert tc["type"] == "function"
+    assert isinstance(tc["function"]["arguments"], str)   # JSON string, not dict
 ```
 
-Avoid asserting on free-text fields like `reason.summary` unless the field
-content is part of the contract you are pinning. Wording varies across model
-versions and causes unnecessary re-records.
-
-One exception: when the test is explicitly verifying that the LLM *read* a
-specific field, a `in reason_summary.lower()` assertion is appropriate (see
-`test_copy_to_work_validation_judgment.py` for an example).
+Avoid asserting on free-text `.content` wording unless the exact content is the
+contract you are pinning. Wording varies across model versions and causes
+unnecessary re-records.
 
 ---
 
 ## Step 3: Add a drift detection test
 
-Every Tier 3a area needs one test that asserts `MissingFixture` is raised when
-the input does not match any fixture entry. This is the mechanism that catches
-accidental prompt drift — if someone changes the phase instructions or the
-`ContextFrame` shape, the test fails loudly rather than silently passing with
-stale fixture data.
+`LLMReplay` raises `MissingFixture` in replay mode when the call's key matches
+no fixture entry. That is the mechanism that catches accidental prompt drift —
+if someone changes the messages or tool catalog the OS sends, the key changes,
+no fixture matches, and the test fails loudly rather than passing on stale data.
 
 ```python
-from reyn.testing.replay import MissingFixture
+from reyn.dev.testing.replay import MissingFixture
 
-@pytest.mark.replay("fixtures/llm/my_area/happy_path.jsonl")
-def test_drift_detection_raises_missing_fixture():
-    """Tier 3a drift detection: prompt changes must be reflected in re-recorded fixtures."""
-    frame = ContextFrame(
-        current_phase="my_phase",
-        instructions="intentionally not in the fixture — drift sentinel",
-        candidate_outputs=[],
-        finish_criteria=[],
-        constraints=PhaseConstraints(),
-        available_control_ops=[],
-        op_catalog=[],
-        output_language="en",
-        model="standard",
-        model_resolved=MODEL,
-        input_artifact={"type": "my_input", "data": {}},
-        execution=ExecutionState(path=[], current_visit=1, total_steps=1),
-        control_ir_results=[],
-        remaining_act_turns=0,
-        current_datetime=REPLAY_DATETIME,
-    )
 
+@pytest.mark.replay("fixtures/llm/my_area/text_only.jsonl")
+@pytest.mark.asyncio
+async def test_drift_detection_raises_missing_fixture():
+    """Tier 3a drift detection: input changes must be reflected in re-recorded fixtures."""
+    drift_messages = [{"role": "user", "content": "not in the fixture — drift sentinel"}]
     with pytest.raises(MissingFixture):
-        asyncio.run(
-            call_llm(MODEL, frame, prompt_cache_enabled=False,
-                     skill_name="my_skill", skill_description="...", phase_role="my_role")
-        )
+        await call_llm_tools(model=MODEL, messages=drift_messages, tools=TOOLS)
 ```
 
-The drift detection test re-uses the same fixture file as the happy-path test.
-A frame with different instructions produces a different SHA-256 key, which is
-not in the fixture, so `MissingFixture` is raised.
+The drift test re-uses the same fixture file as the happy path. Different
+`messages` produce a different SHA-256 key, which is not in the fixture, so
+`MissingFixture` is raised.
 
 ---
 
-## Step 4: Update fixtures after intentional prompt changes
+## Step 4: Update fixtures after intentional input changes
 
-When you intentionally change phase instructions, the fixture key changes.
-Replay mode will raise `MissingFixture`. This is expected and correct behavior.
+When you intentionally change the messages or tool catalog, the fixture key
+changes and replay mode raises `MissingFixture`. This is expected and correct.
 
 Re-record by deleting the fixture and running with `REYN_LLM_RECORD=1`:
 
 ```bash
-rm tests/fixtures/llm/my_area/happy_path.jsonl
+rm tests/fixtures/llm/my_area/text_only.jsonl
 REYN_LLM_RECORD=1 python -m pytest tests/test_replay_my_area.py -v
 ```
 
 Or delete and let conftest auto-detect the missing file:
 
 ```bash
-rm tests/fixtures/llm/my_area/happy_path.jsonl
+rm tests/fixtures/llm/my_area/text_only.jsonl
 python -m pytest tests/test_replay_my_area.py -v
 # conftest sees file missing → switches to record mode automatically
 ```
 
-Commit the new fixture alongside the prompt change. Reviewers can diff the
+Commit the new fixture alongside the change. Reviewers can diff the
 `prompt_preview` field in the JSONL to see what changed.
 
 > **Warning — `-k` filtered runs exclude replay tests.** If your local test run uses
 > `-k some_keyword` that does not match replay test names, replay tests are silently
 > skipped and the run appears green. This masks broken fixtures until CI runs the
-> full suite. Always run the full replay suite (`pytest tests/test_replay_*.py -v`)
-> after any change to phase instructions, tool catalog, or LLM-call boundaries.
+> full suite. Always run the full replay suite after any change to the tool catalog
+> or LLM-call boundaries.
 
 ---
 
@@ -321,147 +258,28 @@ Use `@pytest.mark.replay` with a real recorded fixture instead.
 ```python
 # FORBIDDEN — Tier 4
 assert runtime._last_llm_response["id"] == "chatcmpl-abc"
-assert skill_node._cached_frame is not None
 ```
 
-Assert on the public return value of the function under test.
+Assert on the public return value of the function under test
+(`result.content`, `result.tool_calls`).
 
-**Do not use `datetime.now()` in `ContextFrame`.**
+**Do not inject volatile values into the prompt.**
 
 ```python
-# FORBIDDEN — breaks fixture keys
-frame = ContextFrame(current_datetime=datetime.now(), ...)
-
-# Required
-from reyn.testing.replay import REPLAY_DATETIME
-frame = ContextFrame(current_datetime=REPLAY_DATETIME, ...)
+# FORBIDDEN — breaks fixture keys (key changes every run)
+messages = [{"role": "user", "content": f"now is {datetime.now()}"}]
 ```
+
+Build `messages` and `tools` from stable literals so the SHA-256 key is
+reproducible.
 
 **Do not write Tier 4 tests.** Common Tier 4 traps:
 
-- Testing that `result.data["reason"]["summary"]` contains a specific
-  sentence — this pins LLM output wording, which drifts with every model
-  update.
+- Asserting that `.content` contains a specific sentence — this pins LLM output
+  wording, which drifts with every model update.
 - Testing internal cache state or flag values (`_state_loaded`, `_initialized`).
 - Adding a test for "this specific bug we fixed" unless it represents a
   genuine P1–P8 invariant.
-
----
-
-## Complete example
-
-The following is drawn from the actual `test_copy_to_work_validation_judgment.py`
-in the test suite. It tests two LLM judgment cases in the `copy_to_work` phase
-of the `skill_improver` stdlib skill.
-
-```python
-"""Tier 3a: copy_to_work phase validation judgment behavior.
-
-Two cases are pinned:
-  - Case 1 (validation.ok=True):  LLM must transition to run_and_eval.
-  - Case 2 (validation.ok=False): LLM must abort.
-"""
-from __future__ import annotations
-
-import asyncio
-from pathlib import Path
-
-import pytest
-
-from reyn.core.compiler.loader import load_dsl_skill
-from reyn.llm.llm import call_llm
-from reyn.schemas.models import (
-    CandidateOutput,
-    ContextFrame,
-    ExecutionState,
-    PhaseConstraints,
-)
-from reyn.testing.replay import REPLAY_DATETIME
-
-MODEL = "gemini-2.5-flash-lite"
-SKILL_NAME = "skill_improver"
-PHASE_ROLE = "workspace_initializer"
-
-_SKILL_PATH = (
-    Path(__file__).parent.parent
-    / "src" / "reyn" / "stdlib" / "skills" / "skill_improver" / "skill.md"
-)
-
-
-def _make_frame(skill, validation_ok: bool) -> ContextFrame:
-    phase = skill.phases["copy_to_work"]
-    next_phase = skill.phases["run_and_eval"]
-    candidate = CandidateOutput(
-        next_phase="run_and_eval",
-        control_type="transition",
-        schema_name=next_phase.input_schema_name,
-        artifact_schema=next_phase.input_schema,
-        description="Transition to run_and_eval",
-    )
-    return ContextFrame(
-        current_phase="copy_to_work",
-        current_phase_role=PHASE_ROLE,
-        instructions=phase.instructions,
-        candidate_outputs=[candidate],
-        finish_criteria=[],
-        constraints=PhaseConstraints(),
-        available_control_ops=[],
-        op_catalog=[],
-        output_language="en",
-        model="standard",
-        model_resolved=MODEL,
-        input_artifact={
-            "type": "improvement_session",
-            "data": {
-                "target_skill": "direct_llm",
-                "validation": {
-                    "ok": validation_ok,
-                    "files_written": 2 if validation_ok else 0,
-                    "files_expected": 2,
-                },
-            },
-        },
-        execution=ExecutionState(
-            path=["prepare → copy_to_work"], current_visit=1, total_steps=1
-        ),
-        control_ir_results=[],
-        remaining_act_turns=0,
-        current_datetime=REPLAY_DATETIME,
-    )
-
-
-@pytest.mark.replay("fixtures/llm/copy_to_work_validation/validation_ok.jsonl")
-def test_copy_to_work_transitions_when_validation_ok():
-    """Tier 3a (LLM replay): copy_to_work transitions to run_and_eval when validation.ok=True."""
-    skill = load_dsl_skill(_SKILL_PATH)
-    frame = _make_frame(skill, validation_ok=True)
-
-    result = asyncio.run(
-        call_llm(MODEL, frame, prompt_cache_enabled=False,
-                 skill_name=SKILL_NAME, skill_description="...", phase_role=PHASE_ROLE)
-    )
-
-    ctrl = result.data["control"]
-    assert ctrl["type"] == "transition"
-    assert ctrl["next_phase"] == "run_and_eval"
-    assert ctrl["decision"] == "continue"
-
-
-@pytest.mark.replay("fixtures/llm/copy_to_work_validation/validation_fail.jsonl")
-def test_copy_to_work_aborts_when_validation_fails():
-    """Tier 3a (LLM replay): copy_to_work aborts when validation.ok=False."""
-    skill = load_dsl_skill(_SKILL_PATH)
-    frame = _make_frame(skill, validation_ok=False)
-
-    result = asyncio.run(
-        call_llm(MODEL, frame, prompt_cache_enabled=False,
-                 skill_name=SKILL_NAME, skill_description="...", phase_role=PHASE_ROLE)
-    )
-
-    ctrl = result.data["control"]
-    assert ctrl["type"] == "abort"
-    assert ctrl["decision"] == "abort"
-```
 
 ---
 
@@ -472,7 +290,7 @@ When adding a new LLM-dependent OS path, verify:
 - [ ] One Tier 3a test for the canonical happy path
 - [ ] One Tier 3a test for a boundary or error case (optional but recommended)
 - [ ] One drift detection test (`MissingFixture` assertion) per fixture file
-- [ ] `current_datetime=REPLAY_DATETIME` in every `ContextFrame`
+- [ ] `messages` / `tools` built from stable literals (no volatile values)
 - [ ] Each test docstring starts with `"""Tier 3a: ...`
 - [ ] Fixture file committed alongside the test
 - [ ] No `MagicMock` / `AsyncMock` / `patch` anywhere in the file
@@ -485,5 +303,5 @@ When adding a new LLM-dependent OS path, verify:
 - Full LLMReplay API: [docs/reference/testing/replay.md](../../reference/testing/replay.md)
 - Full testing policy (Tier definitions, NEVER rules, decision flow): [docs/deep-dives/contributing/testing.md](../../deep-dives/contributing/testing.md)
 - Live examples in the codebase:
-  - `tests/test_copy_to_work_validation_judgment.py` — two judgment cases with `load_dsl_skill`
-  - `tests/conftest.py` — `_llm_replay` autouse fixture and mode resolution
+  - `tests/test_llm_tools.py` — the canonical `@pytest.mark.replay` tests for `call_llm_tools`
+  - `tests/conftest.py` — the `_llm_replay` autouse fixture and record/replay mode resolution

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -401,8 +401,6 @@ Returns:
 
 **Permission**: none required (LLM cost only). Voluntary and independent of the involuntary `retry_loop` backstop, which always runs regardless.
 
-**OpPurity**: `external` (LLM cost + history/state mutation; like `recall`, a macro whose inner engine emits its own events).
-
 **Visibility**: advertised to the LLM (tool / `available_control_ops`) only when the window is filling — paired with the context-size signal — so it is not offered when there is nothing to compact (mirrors the `search_actions` visibility gate). The permission gate stays "allow"; only *when surfaced* is gated.
 
 **Axis scope (chat vs phase)**: the `compact` op is available on **both** axes. On the **chat** axis, it routes to `force_compact_now`; on the **phase** axis, it routes to the `compact_control_ir_results` on-demand seam wired by the phase runtime (in addition to the automatic per-frame compaction that fires regardless). In both cases the OS wires `ctx.compact_now`; the op handler itself is axis-agnostic. Both axes also inject the paired context-size signal so the model knows when to emit `compact`.

--- a/docs/reference/testing/replay.md
+++ b/docs/reference/testing/replay.md
@@ -1,20 +1,10 @@
-# `reyn.testing.LLMReplay` API
+# `reyn.dev.testing.LLMReplay` API
 
-`LLMReplay` is the core class powering `@pytest.mark.replay`. It monkeypatches `litellm.acompletion` at the boundary shared by all Reyn LLM calls (`reyn.llm.llm.call_llm` and `reyn.skill.skill_node_runner._adapt_artifact`).
-
-```python
-from reyn.testing.replay import LLMReplay, MissingFixture, REPLAY_DATETIME
-```
-
----
-
-## `REPLAY_DATETIME`
+`LLMReplay` is the core class powering `@pytest.mark.replay`. It monkeypatches `litellm.acompletion` — the async boundary every Reyn LLM call passes through (reached via `reyn.llm.llm.call_llm_tools`, the tool_use wrapper the chat router drives).
 
 ```python
-REPLAY_DATETIME: datetime  # datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+from reyn.dev.testing.replay import LLMReplay, MissingFixture
 ```
-
-Fixed UTC datetime to pass as `current_datetime` when constructing `ContextFrame` objects in replay tests. Without this, `ContextFrame.current_datetime` defaults to `datetime.now()`, which changes every run and invalidates the SHA-256 fixture key.
 
 ---
 
@@ -53,7 +43,7 @@ Writes pending record-mode entries to `fixture_path`. Appends to the existing fi
 
 ```python
 with LLMReplay(fixture_path, mode="replay") as replay:
-    result = asyncio.run(call_llm(...))
+    result = await call_llm_tools(...)
 ```
 
 `__exit__` calls `restore()` and, if `mode="record"`, `flush()`.
@@ -62,7 +52,7 @@ with LLMReplay(fixture_path, mode="replay") as replay:
 
 ## `class MissingFixture(Exception)`
 
-Raised in replay mode when no fixture entry matches the SHA-256 key for the current `(model, messages)` combination. The error message includes:
+Raised in replay mode when no fixture entry matches the SHA-256 key for the current `(model, messages, tools, tool_choice)` combination. The error message includes:
 
 - The model name
 - A 200-character preview of the last user-turn message
@@ -73,17 +63,23 @@ Raised in replay mode when no fixture entry matches the SHA-256 key for the curr
 
 ## Key computation
 
+The key depends on whether the call carries tools. `canonical(x)` is
+`json.dumps(x, sort_keys=True, ensure_ascii=False)`:
+
 ```python
-key = SHA256(model.encode() + canonical_json(messages).encode())
+# No tools and no tool_choice (legacy form — preserves pre-tools fixture keys):
+key = SHA256(model.encode() + canonical(messages).encode())
+
+# With tools or tool_choice:
+key = SHA256(f"{model}|{canonical(messages)}|{canonical(tools)}|{tool_choice or ''}".encode())
 ```
 
-Where `canonical_json` is `json.dumps(messages, sort_keys=True, ensure_ascii=False)`.
-
-**Every field in `messages` contributes to the key.** This includes:
-- The full system prompt (skill name, description, phase role, project context, agent role)
-- The serialised `ContextFrame` (all fields, including `current_datetime`)
-
-Changing any of these invalidates the key and causes `MissingFixture` in replay mode. This is intentional — it makes prompt drift explicit.
+**Every byte of the serialised inputs contributes to the key** — the full
+system prompt, the message list, and (when present) the tool catalog and
+`tool_choice`. Changing any of them invalidates the key and causes
+`MissingFixture` in replay mode. This is intentional — it makes prompt drift
+explicit. Keep test inputs free of volatile values (timestamps, uuids) so the
+key stays reproducible.
 
 ---
 
@@ -107,7 +103,7 @@ JSONL file, one JSON object per line:
         "finish_reason": "stop",
         "index": 0,
         "message": {
-          "content": "{\"type\": \"decide\", ...}",
+          "content": "Sure — here is the result ...",
           "role": "assistant",
           "tool_calls": null,
           "function_call": null
@@ -139,7 +135,7 @@ The `response` dict is the output of `litellm.ModelResponse.model_dump()`. On re
 
 Reyn uses `litellm.acompletion` (async) for all LLM calls. `LLMReplay` monkeypatches the async variant only. `litellm.completion` (sync) is not patched and is never used by Reyn's production paths.
 
-Tests call `asyncio.get_event_loop().run_until_complete(coro)` to drive async coroutines synchronously, matching the style of the existing `test_budget_persistent.py` test suite.
+Replay tests are `async def` and marked `@pytest.mark.asyncio`, awaiting the coroutine under test directly (`result = await call_llm_tools(...)`).
 
 ---
 


### PR DESCRIPTION
**[e2e-coder]** — PR-6 (final) closes the **Control IR layer-removal arc**: docs sync. PR-1..PR-5 (all merged) removed the dead output wrappers, ContextFrame/phase-LLM, preprocessor DSL, `ControlIROp`→`Op` rename, and the `OpPurity` machinery. This PR brings the docs into line — surgically, touching only Control-IR-arc tokens + arc-close dead-ref hygiene.

## Tier A — mechanical rename/removal
- **CLAUDE.md** hard-rule: `ControlIROp union` → `Op union`
- **control-ir.md**: drop the removed `OpPurity` annotation (doc kept, still synced to `OP_KIND_MODEL_MAP` per the hard rule)
- **add-an-op-kind.md**: `Op` union rename; remove `OpPurity` map + Choosing-OpPurity section + `caller` param + preprocessor-DSL restriction; fix the #1983 `OP_KIND_MODEL_MAP` location (`op_runtime/registry.py` → `schemas/models.py`); scrub deleted dispatch symbols (`ControlIRExecutor`→`execute_op`, `_build_phase_tool_catalog`→the `reyn.tools` catalog)
- **principles-and-code.md**, **index.md**: `ControlIROp`→`Op`; drop removed `CandidateOutput`/`OpPurity` refs; **index.md file-map**: remove 4 dead-file rows (kernel/runtime.py, kernel/control_ir_executor.py, compiler/linter.py, compiler/expander.py — all deleted on main; deletion-only, no repoint)
- **feature-map.md**: remove the dead Preprocessor/Postprocessor DSL feature sections + ASCII diagram block

## Tier B — verify-first rewrite of the replay-test guides
The old guides taught the **removed** `call_llm`+`ContextFrame`+`REPLAY_DATETIME`+`load_dsl_skill` phase-replay pattern. Rewritten to the live `call_llm_tools`+`@pytest.mark.replay` idiom, byte-mirrored from `tests/test_llm_tools.py` + `tests/conftest.py`.
- **write-replay-tests.md**, **reference/testing/replay.md**

## Deliberately deferred — architecture-principles deletion-only pass (owner-decided, separate PR)
Dead references to removed phase/skill machinery that live in **principle / OS-framing PROSE** (not scrubbed here — owner-territory, deletion-only-pass will handle coherently):
- **index.md:31** (OS-description prose naming `kernel/runtime.py`), **index.md:57/59** (`ContextFrame` row + context_builder "P4 candidates")
- **principles-and-code.md** P1–P8 sections (L20–154) + the P7 op-kind example (L214–215) — `kernel/runtime.py`, `compiler/linter.py`, `compiler/expander.py`, `ControlIRExecutor`, `_build_phase_tool_catalog`, `build_frame`
- **llm-invocation-surfaces.md** ContextFrame/preprocessor concept prose

Also deferred: deep #1983 derived-union **pedagogy** restructure → #1983-doc-sync (docs-maintainer).

## Test plan
- [x] `ruff check src tests` — clean (no `.py` changed)
- [x] full `pytest` — **6946 passed, 16 skipped** (docs-only; fp0036 `parse_feature_map` matrix + #1983 `control-ir.md` ref green)
- [x] docs build (strict) CI — pass (no broken markdown/links)
- [x] docs-maintainer cross-reference audit — zero dangling inbound links
- [x] primary-evidence: scrubbed dead symbols/files verified 0-def/deleted on main; replacements (`execute_op`, `reyn.tools` catalog) verified live
- [x] (skipped — N/A) `test_tier_audit.py` / `verify_module_docstrings.py` — no test/src `.py` files changed

Closes the Control IR layer-removal arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)