### PR TITLE
fix(inline-cui): task__list tool result shows count instead of ok

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -378,6 +378,10 @@ def _summarize_result(tool, result) -> str:
             return f"Wrote {path}" if path else "Wrote file"
         if op == "edit":
             return f"Edited {path}" if path else "Edited file"
+        tasks = result.get("tasks")
+        if isinstance(tasks, list):
+            n = len(tasks)
+            return f"{n} task{'s' if n != 1 else ''}"
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -87,6 +87,19 @@ def test_generic_list_counts_items_with_pluralisation() -> None:
     assert summarize_tool_result("anything", ["only"]) == "1 item"
 
 
+def test_task_list_result_shows_count() -> None:
+    """Tier 2: task__list result counts tasks rather than falling through to 'ok'."""
+    assert summarize_tool_result(
+        "task__list", {"kind": "task.list", "status": "ok", "tasks": []}
+    ) == "0 tasks"
+    assert summarize_tool_result(
+        "task__list", {"kind": "task.list", "status": "ok", "tasks": [{"id": "t1"}]}
+    ) == "1 task"
+    assert summarize_tool_result(
+        "task__list", {"kind": "task.list", "status": "ok", "tasks": [{"id": "t1"}, {"id": "t2"}]}
+    ) == "2 tasks"
+
+
 def test_dict_with_status_shows_status() -> None:
     """Tier 2: an opaque dict with a status field shows the status."""
     assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find

## Summary

- `_summarize_result` in `renderer.py` now detects a `tasks` list in the result dict and renders `"N tasks"` (e.g. `0 tasks`, `1 task`, `2 tasks`) instead of falling through to the generic `str(status)` → `"ok"`
- Consistent with `/tasks` slash output which shows `· (no running tasks)` for empty task list

## Root cause

`task.list` op returns `{"kind": "task.list", "status": "ok", "tasks": [...]}`. The renderer's `_summarize_result` didn't have a `tasks`-key branch, so it fell through to `if status: return str(status)` → `"ok"`. The fix adds a `isinstance(tasks, list)` check before the `status` fallthrough.

## Before / after

Before: `▸ task__list()` / `⎿ ok`
After:  `▸ task__list()` / `⎿ 0 tasks`

## Test plan

- [x] 16/16 unit tests pass (`test_inline_tool_result_summary.py`)
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` 0 violations
- [x] `verify_module_docstrings.py` clean
- [x] (skipped — live dogfood session already confirmed the before state; the fix is a pure-function change verified by unit tests)

Tier self-check: all 3 new assertions are Tier 2 (public API, real instances, behavioral assertion on `.plain`-equivalent string output). No Tier 4 violations.

part of #1830