### PR TITLE
fix: /session switch error message — explain full-ID/name requirement

### DIFF
--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -66,7 +66,10 @@ async def session_cmd(session: "Session", args: str) -> None:
             return
         if reg.get_session(name, rest) is None:
             await reply_error(
-                session, f"no session {rest!r} for {name!r}; try /session list"
+                session,
+                f"no session {rest!r} for {name!r}"
+                " — use the session name (e.g. 'main') or full session ID;"
+                " partial prefixes are not supported. Try /session list.",
             )
             return
         # Visible breadcrumb; the actual focus flip is driven by the sentinel

--- a/tests/test_slash_session_1726.py
+++ b/tests/test_slash_session_1726.py
@@ -89,14 +89,18 @@ async def test_session_switch_known_posts_sentinel():
 
 @pytest.mark.asyncio
 async def test_session_switch_unknown_is_graceful():
-    """Tier 2: #1726 — `/session switch <unknown>` replies an error and posts NO
-    sentinel (no crash — lead completeness pt 1)."""
+    """Tier 2: #1726 — `/session switch <unknown>` replies a decision-enabling error
+    (names the bad sid, explains full-ID/name requirement, no prefix support) and
+    posts NO sentinel (no crash)."""
     reg = _StubRegistry(sids=("main",))
     s = _FakeSession(reg)
     await session_cmd(s, "switch nope")
     assert not [m for m in s.outbox_calls if m.kind == "__session_switch_request__"]
-    assert "nope" in s.reply_text(), "user-facing error names the bad sid"
+    err = s.reply_text()
+    assert "nope" in err, "user-facing error names the bad sid"
     assert any(m.kind == "error" for m in s.outbox_calls), "replied as an error"
+    assert "partial" in err.lower(), "tells user partial prefix is not supported"
+    assert "session name" in err.lower() or "full" in err.lower(), "guides toward name/full-ID"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — part of #1830 dogfood mining wave

## Summary

- `/session switch <prefix>` previously said only `no session 'X' for 'Y'; try /session list` — not decision-enabling
- Now tells the user: use the session **name** (e.g. `'main'`) or **full session ID**; partial prefixes are not supported
- Tier 2 test extended to assert the guidance text is present in the error

## Changed files

- `src/reyn/interfaces/slash/session.py` — error message at switch-not-found path
- `tests/test_slash_session_1726.py` — existing graceful-error test now also asserts `partial` + `full/session name` in error body

## CI self-check

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_slash_session_1726.py` — 5 OK, 0 errors
- [x] `pytest tests/test_slash_session_1726.py` — 5/5 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/session.py` — OK

Tier self-check: all tests are Tier 2 (public surface behavioral assertions, no mocks, no private state).