### PR TITLE
fix: exclude hidden slash commands from unknown-cmd suggestions

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -103,8 +103,8 @@ class SlashRegistry:
         return list(self._commands.values())
 
     def names(self) -> list[str]:
-        """Sorted canonical command names (no aliases) for /help and palette."""
-        return sorted(self._commands.keys())
+        """Sorted visible canonical command names (no aliases, no hidden) for /help and palette."""
+        return sorted(k for k, v in self._commands.items() if not v.hidden)
 
 
 REGISTRY: SlashRegistry = SlashRegistry()

--- a/tests/test_slash_suggest_for_unknown.py
+++ b/tests/test_slash_suggest_for_unknown.py
@@ -114,3 +114,18 @@ def test_real_registry_returns_meaningful_suggestions() -> None:
     # ``list`` should be a close fuzzy match for ``lis``.
     assert "list" in suggestions
     assert "help" in suggestions
+
+
+def test_hidden_commands_excluded_from_suggestions() -> None:
+    """Tier 2: hidden slash commands (e.g. /matrix) must not leak into
+    unknown-command suggestion output — they are easter eggs, not user-facing
+    help targets.
+    """
+    from reyn.interfaces.slash import REGISTRY
+
+    hidden = [c.name for c in REGISTRY.all_commands() if c.hidden]
+    if not hidden:
+        return  # no hidden commands registered — nothing to assert
+    suggestions = suggest_for_unknown("clear")
+    for h in hidden:
+        assert h not in suggestions, f"hidden command /{h!r} leaked into suggestions"


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find

## Summary

- `/matrix` (hidden easter egg) was leaking into "try: ..." suggestion output when users typed unknown slash commands (observed: `/clear` → `try: /clear-history, /memory, /matrix, /help`)
- `REGISTRY.names()` returned all registered names including `hidden=True` ones; `suggest_for_unknown` consumed this list directly
- Fix: `names()` now filters to visible-only (matching the docstring "for /help and palette" + what `slash_command_completions` already does)
- Tier 2 test asserts no hidden command appears in live-registry suggestions

## Changed files

- `src/reyn/interfaces/slash/__init__.py` — `names()` filters `hidden=True` commands
- `tests/test_slash_suggest_for_unknown.py` — new test `test_hidden_commands_excluded_from_suggestions`

## CI self-check

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_slash_suggest_for_unknown.py` — 8 OK, 0 errors
- [x] `pytest tests/test_slash_suggest_for_unknown.py tests/test_slash_suggest_prefix_bias.py tests/test_slash_help_per_command.py` — 21/21 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/__init__.py` — OK

Tier self-check: all tests Tier 2 (public surface, no mocks, no private state).