### PR TITLE
fix: summarize_tool_result shows error message not raw dict repr

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -382,6 +382,9 @@ def _summarize_result(tool, result) -> str:
         if isinstance(tasks, list):
             n = len(tasks)
             return f"{n} task{'s' if n != 1 else ''}"
+        error = result.get("error")
+        if isinstance(error, str):
+            return _short(error, 80)
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -100,6 +100,20 @@ def test_task_list_result_shows_count() -> None:
     ) == "2 tasks"
 
 
+def test_dict_with_error_key_shows_error_not_raw_repr() -> None:
+    """Tier 2: a dict with an 'error' key shows the error message, not raw repr.
+
+    `file__list` outside the project returns `{'error': 'glob not permitted…'}`.
+    The summarizer must surface the error string, not dump the raw dict.
+    """
+    out = summarize_tool_result(
+        "file__list",
+        {"error": "glob not permitted: '/tmp/*' (outside project, no read permission)"},
+    )
+    assert "glob not permitted" in out
+    assert "{" not in out, "raw dict repr must not leak into ⎿ row"
+
+
 def test_dict_with_status_shows_status() -> None:
     """Tier 2: an opaque dict with a status field shows the status."""
     assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find

## Summary

- `file__list` (and any op returning `{"error": "..."}`) was showing raw dict repr in the `⎿` result row: `⎿ {'error': "glob not permitted: '/tmp/*'..."}`
- `_summarize_result` had no `error`-key branch; fell through to `_short(result, 80)` = `str(result)`
- Fix: check `result.get("error")` before the raw-fallback, surface the error string directly
- Tier 2 test added: asserts error message text in output + no `{` raw-repr leakage

## Changed files

- `src/reyn/interfaces/repl/renderer.py` — `_summarize_result`: add `error` key branch before `_short` fallback
- `tests/test_inline_tool_result_summary.py` — `test_dict_with_error_key_shows_error_not_raw_repr`

## CI self-check

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 17 OK, 0 errors
- [x] `pytest tests/test_inline_tool_result_summary.py` — 17/17 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all tests Tier 2 (public surface behavioral assertions, no mocks, no private state).