### PR TITLE
feat: add /clear alias for /clear-history (CC muscle-memory)

### DIFF
--- a/src/reyn/interfaces/slash/clear_history.py
+++ b/src/reyn/interfaces/slash/clear_history.py
@@ -48,6 +48,7 @@ def _format_currently_line(session: "object") -> str:
 
 @slash(
     "clear-history",
+    aliases=("clear",),
     summary=(
         "Clear conversation history + action-usage table (= events, "
         "skill state, profile preserved)"

--- a/tests/test_slash_clear_history_cmd.py
+++ b/tests/test_slash_clear_history_cmd.py
@@ -159,6 +159,15 @@ class _FailingPath:
         raise OSError("permission denied")
 
 
+def test_clear_alias_registered() -> None:
+    """Tier 2: /clear is a registered alias for /clear-history so CC users don't hit
+    'unknown command /clear'."""
+    from reyn.interfaces.slash import REGISTRY
+    cmd = REGISTRY.get("clear")
+    assert cmd is not None, "/clear must resolve via the registry"
+    assert cmd.name == "clear-history", "/clear must resolve to /clear-history handler"
+
+
 @pytest.mark.asyncio
 async def test_clear_history_disk_fail_leaves_memory_intact() -> None:
     """Tier 2: when history_path.unlink() fails, in-memory history must NOT be cleared.


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find

## Summary

- Claude Code users instinctively type `/clear` to wipe the conversation. Without an alias they hit `unknown command /clear; try: /clear-history, ...` — adds friction and forces discovery of a non-obvious name difference
- One-line fix: `aliases=("clear",)` in the `/clear-history` decorator
- `/clear` resolves to the same handler; full confirm-gate flow (`/clear confirm` to actually clear) is unchanged
- Tier 2 test pins the alias registration

## Changed files

- `src/reyn/interfaces/slash/clear_history.py` — `aliases=("clear",)` added
- `tests/test_slash_clear_history_cmd.py` — `test_clear_alias_registered` added

## CI self-check

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_slash_clear_history_cmd.py` — 13 OK, 0 errors
- [x] `pytest tests/test_slash_clear_history_cmd.py` — 13/13 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/clear_history.py` — OK

Tier self-check: all tests Tier 2 (public surface, no mocks, no private state).