### PR TITLE
fix: add 'reasoning' kind to _KIND_LINE (styled dim gutter)

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -288,6 +288,7 @@ _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 _KIND_LINE = {
     "user":         ("❯ ",   _CC_TEXT,   _CC_DIM),   # your input  (default fg, + bg block)
     "agent":        ("⏺ ",   _CC_TEXT,   _CC_TEXT),  # normal reply — terminal default fg
+    "reasoning":    ("· ",   _CC_DIM,    _CC_DIM),   # model thinking (dim; only shown when chat.reasoning.display=true)
     "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   — amber
     "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # error       — red
     "skill_done":   ("✓ ",   _CC_DONE,   _CC_DIM),   # done        — green glyph, dim body

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -230,6 +230,16 @@ def test_system_lifecycle_marker_has_dim_gutter() -> None:
     assert "[↑ 5 turns compacted]" in out
 
 
+def test_reasoning_kind_renders_with_dim_gutter() -> None:
+    """Tier 2: reasoning kind (model thinking, gated on chat.reasoning.display=true)
+    renders with a dim '· ' gutter — not as raw unstyled plain text — so thinking
+    content has visual hierarchy instead of being indistinguishable from an unknown kind.
+    """
+    out = _plain("reasoning", "I should first check the file...")
+    assert "·" in out
+    assert "I should first check the file..." in out
+
+
 def test_unknown_kind_renders_text_without_marker() -> None:
     """Tier 2: an unrecognised kind falls back to plain text (no kind marker)."""
     out = _plain("totally_new_kind", "raw payload")


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find (renderer surface audit)

## Summary

- `kind="reasoning"` (model thinking content, emitted when `chat.reasoning.display=true`) was missing from `_KIND_LINE` in the InlineChatRenderer
- Fell through to `Text(msg.text)` — plain unstyled text, visually indistinguishable from `test_unknown_kind_renders_text_without_marker`
- Fix: added `"reasoning": ("· ", _CC_DIM, _CC_DIM)` — same low-salience dim style as `status`/`system`, appropriate for thinking content that's ambient rather than action-requiring
- Tier 2 test added next to `test_system_lifecycle_marker_has_dim_gutter`

## Changed files

- `src/reyn/interfaces/repl/renderer.py` — `_KIND_LINE`: add `"reasoning"` dim entry
- `tests/test_inline_renderer_cutover.py` — `test_reasoning_kind_renders_with_dim_gutter`

## CI self-check

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_renderer_cutover.py` — 33 OK, 0 errors
- [x] `pytest tests/test_inline_renderer_cutover.py` — 33/33 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all tests Tier 2 (public surface behavioral assertions, no mocks, no private state).