### PR TITLE
refactor(compat): ① A-1/A-2 — remove skill-dependent cross-version tolerance (budget + cron)

### DIFF
--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -559,9 +559,8 @@ class CronJobConfig:
     ``message`` (free-form text). Cron dispatches the message to the target
     agent's inbox with a ``sender="cron:<name>"`` envelope.
 
-    (Legacy skill-based jobs — a bare ``skill`` name — are no longer
-    supported; the skill runtime was removed. An old on-disk ``cron.yaml``
-    carrying such an entry is warned-and-skipped at load, not rejected.)
+    (A bare ``skill`` name is not a valid job shape; an entry without
+    ``to`` + ``message`` is rejected at load with a ValueError naming it.)
     """
 
     name: str
@@ -602,11 +601,9 @@ def _build_cron_config(raw: object) -> CronConfig:
     ``None`` / missing block / empty dict → ``CronConfig(jobs=[])``.
     Validates ``name`` + ``schedule`` are non-empty strings + ``to`` +
     ``message`` are set per entry, raising ``ValueError`` naming the
-    offending entry on failure. Legacy skill-based entries (a bare
-    ``skill`` name, no ``to``/``message``) are no longer supported: they
-    are warned-and-skipped (degrade-not-raise) so an old on-disk
-    ``cron.yaml`` does not crash startup. Unknown extra fields are ignored
-    (= forward-compatible).
+    offending entry on failure. An entry without the ``to`` + ``message``
+    shape (e.g. a legacy bare ``skill`` name) is rejected with that
+    ValueError. Unknown extra fields are ignored (= forward-compatible).
     """
     if raw is None:
         return CronConfig()
@@ -643,19 +640,6 @@ def _build_cron_config(raw: object) -> CronConfig:
             and bool(message) and isinstance(message, str)
         )
         if not has_message_shape:
-            skill = entry.get("skill")
-            if bool(skill) and isinstance(skill, str):
-                # Degrade-not-raise: an old on-disk cron.yaml may still carry a
-                # skill-based entry. Warn (user-visible) + skip so startup does
-                # not crash on a config that predates the skill-runtime removal.
-                import logging
-                logging.getLogger(__name__).warning(
-                    "cron.jobs[%d] (name=%r): skill-based cron jobs are no "
-                    "longer supported (the skill runtime was removed); "
-                    "skipping this job. Use 'to' + 'message' instead.",
-                    i, name,
-                )
-                continue
             raise ValueError(
                 f"cron.jobs[{i}] (name={name!r}): must set "
                 f"'to' + 'message'."

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -142,11 +142,6 @@ class BudgetLedger:
         {"ts": "2026-05-02T10:23:00+09:00", "agent": "alice",
          "model": "...", "tokens": 300, "cost_usd": 0.0023}
 
-    Legacy note: pre-existing ledgers may also contain skill-spawn records
-    (``{"kind": "spawn", ...}``) written before the per-chain skill-spawn cap
-    was removed. They are no longer written; ``BudgetTracker.hydrate`` skips
-    them on read (see the legacy-tolerance branch there).
-
     Records are fsync'd on append so a process crash cannot roll back a
     completed LLM call and under-count quota usage. This is the cap-critical
     durability layer; the throttled ``budget_state.json`` is a best-effort
@@ -377,14 +372,6 @@ class BudgetTracker:
             try:
                 ts = _parse_iso_ts(ts_str)
             except (ValueError, OSError):
-                continue
-
-            # Legacy tolerance: a pre-existing ledger may contain skill-spawn
-            # records (``kind="spawn"``) written before the per-chain
-            # skill-spawn cap was removed. They carry no tokens/cost — skip
-            # them so an old ledger still hydrates the live LLM counters
-            # (daily / monthly / per-agent / cost) without error.
-            if record.get("kind") == "spawn":
                 continue
 
             tokens = record.get("tokens", 0)

--- a/tests/test_budget_cap_durability_1911.py
+++ b/tests/test_budget_cap_durability_1911.py
@@ -20,7 +20,8 @@ source of truth.
 The final test is a migration-safety gate: the per-chain skill-spawn cap (and
 its ``kind="spawn"`` ledger records) was removed with the skill machinery, but
 a pre-existing on-disk ledger may still contain those legacy records — hydrate
-must skip them without breaking recovery of the kept LLM counters.
+must tolerate them (they contribute nothing) without breaking recovery of the
+kept LLM counters.
 
 FALSIFICATION (verified out-of-band on pre-fix HEAD): with hydrate not
 restoring per-agent, the same scenario recovers agent_tokens=100 (want 280) —
@@ -123,23 +124,27 @@ def test_per_agent_cap_enforced_after_crash(tmp_path):
 
 def test_hydrate_tolerates_legacy_spawn_records(tmp_path):
     """Tier 2c: a pre-existing ledger containing legacy skill-spawn records
-    (``kind="spawn"``, written before the per-chain skill-spawn cap was
-    removed) still hydrates the live LLM counters correctly.
+    (``kind="spawn"``) still hydrates the live LLM counters correctly after
+    the skill-dependent hydrate-tolerance branch was removed.
 
-    Migration-safety gate for the durable-ledger schema change: hydrate must
-    (i) not raise on the legacy spawn records, (ii) reconstruct the per-agent
-    token/cost totals from the LLM-call records only, and (iii) not resurrect
-    any per-chain skill-spawn state in the snapshot.
+    The per-chain skill-spawn cap, its ``append_spawn`` writer, and the
+    ``kind == "spawn"`` skip branch in ``hydrate`` were all removed with the
+    skill machinery (no live producer writes such records any more). This
+    gate proves the removal is safe: the hydrate loop is *natively* robust to
+    the legacy record shape — a record with no ``tokens``/``cost_usd`` and no
+    string ``agent`` contributes 0 and is not aggregated — so an old on-disk
+    ledger still hydrates. hydrate must (i) not raise on the legacy records,
+    (ii) reconstruct the per-agent token/cost totals from the LLM-call records
+    only, and (iii) not resurrect any per-chain skill-spawn state.
 
-    FALSIFICATION: if hydrate lacked the ``kind == "spawn"`` skip branch, an
-    old spawn record would fall through to the LLM aggregation — harmless for
-    tokens (0) here, but the branch guards against a future spawn-record schema
-    that carries a numeric field, and documents the tolerance as intentional.
+    FALSIFICATION: if the hydrate loop were not robust to unknown record
+    shapes (e.g. it indexed a required field), a legacy spawn record would
+    raise here — so this test would go RED, catching an unsafe removal.
     """
     ledger_path = tmp_path / ".reyn" / "state" / "budget_ledger.jsonl"
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
     # Hand-write a legacy ledger: LLM-call records interleaved with legacy
-    # spawn records (the shape BudgetLedger.append_spawn used to write).
+    # spawn records (the shape the removed ``append_spawn`` used to write).
     records = [
         {"ts": "2026-05-02T10:00:00+09:00", "agent": "alpha",
          "model": "gpt-4", "tokens": 100, "cost_usd": 0.01},

--- a/tests/test_fp0009_b_cron_config.py
+++ b/tests/test_fp0009_b_cron_config.py
@@ -4,15 +4,13 @@ These tests verify the public contract of the config-layer dataclasses and
 the reyn.yaml parser for the ``cron:`` block.  No mocking; real config
 loader called with tmp_path YAML files.
 
-Cron jobs are message-based (``to`` + ``message``). Legacy skill-based jobs
-(a bare ``skill`` name) are no longer supported — the skill runtime was
-removed — and are warned-and-skipped at load (degrade-not-raise) so an old
-on-disk cron.yaml does not crash startup. The final test is that
-migration-safety gate.
+Cron jobs are message-based (``to`` + ``message``). A legacy bare ``skill``
+name is not a valid shape — an entry without ``to`` + ``message`` is rejected
+at load with a ValueError naming it (the skill-dependent warn-and-skip
+tolerance was removed). The final test pins that rejection.
 """
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pytest
@@ -213,37 +211,38 @@ def test_cron_block_non_dict_raw() -> None:
     assert result == CronConfig()
 
 
-# ── Migration-safety gate: legacy skill-based jobs degrade-not-raise ─────────
+# ── Legacy skill-based jobs are rejected (skill-dependent tolerance removed) ──
 
 
-def test_legacy_skill_based_job_warned_and_skipped(caplog) -> None:
-    """Tier 1: an old on-disk cron.yaml with a legacy skill-based entry mixed with a
-    message-based entry (i) does not crash, (ii) warns + skips the skill-based job,
-    (iii) loads the message-based job correctly.
+def test_legacy_skill_based_job_rejected() -> None:
+    """Tier 1: a legacy bare-``skill`` cron entry (no ``to`` + ``message``) is
+    rejected at load with a ValueError naming it. The skill-dependent
+    warn-and-skip tolerance was removed (compat cleanup, pre-release): an
+    entry without the message shape now raises rather than silently degrading.
 
-    Migration-safety for the skill-runtime removal: a bare-``skill`` cron entry
-    (valid before the removal) must degrade — warn-and-skip — rather than raise
-    and crash startup for operators whose ``.reyn/config/cron.yaml`` predates it.
+    The kept message-based path is unaffected — a message-only config parses.
+
+    FALSIFICATION: if the removed warn-and-skip branch were still present, the
+    bare-``skill`` entry would be skipped and ``_build_cron_config`` would
+    return without raising — so ``pytest.raises`` would go RED.
     """
-    raw = {
+    # KEEP: a message-based entry parses unaffected.
+    ok = _build_cron_config({
         "jobs": [
-            # Legacy skill-based (no to/message) — must be warned + skipped.
-            {"name": "legacy_index", "skill": "index_events", "schedule": "0 */6 * * *"},
-            # Message-based — must load unaffected.
             {"name": "morning_news", "to": "news_agent",
              "message": "summarise today", "schedule": "0 9 * * *"},
         ]
+    })
+    assert [j.name for j in ok.jobs] == ["morning_news"]
+    assert ok.jobs[0].to == "news_agent"
+    assert ok.jobs[0].message == "summarise today"
+
+    # CHANGE: a legacy bare-``skill`` entry (no to/message) now raises,
+    # naming the offending entry (was warn-and-skip before the removal).
+    raw = {
+        "jobs": [
+            {"name": "legacy_index", "skill": "index_events", "schedule": "0 */6 * * *"},
+        ]
     }
-    with caplog.at_level(logging.WARNING, logger="reyn.config.infra"):
-        cfg = _build_cron_config(raw)  # (i) must not raise
-
-    # (ii) the skill-based job is skipped, with a user-visible warning naming it.
-    assert [j.name for j in cfg.jobs] == ["morning_news"]
-    assert any(
-        "legacy_index" in r.message and "skill-based" in r.message
-        for r in caplog.records
-    ), "expected a WARNING naming the skipped skill-based job"
-
-    # (iii) the message-based job loaded correctly.
-    assert cfg.jobs[0].to == "news_agent"
-    assert cfg.jobs[0].message == "summarise today"
+    with pytest.raises(ValueError, match="legacy_index"):
+        _build_cron_config(raw)


### PR DESCRIPTION
**[e2e-coder]** — ① compat removal, first slice (sites **A-1 + A-2**): remove skill-dependent cross-version tolerance. Skill-*independent* features are protected. Site inventory was reviewed + GO'd by lead; only A-1/A-2 are in scope here.

## A-1 — budget: remove dead skill-spawn hydrate-tolerance
- Removed the `kind == "spawn"` skip branch in `BudgetTracker.hydrate` + the BudgetLedger note.
- **Producer enumeration**: `append_spawn` (the only writer of `{"kind":"spawn"}` ledger records) was removed with the skill machinery → **0 live producers** → dead defensive code future-proofing a removed feature.
- **Falsify-first**: the migration-safety test (legacy spawn records interleaved with real LLM records) **stays GREEN without the branch** → the hydrate loop is natively robust (a record with no tokens/cost_usd and no string agent contributes 0, no KeyError). Test docstring updated to guard removal-safety.

## A-2 — cron: remove legacy skill-based degrade-not-raise
- Removed the warn-and-skip branch for legacy bare-`skill` cron entries; an entry without `to` + `message` now hits the existing `ValueError` naming it.
- **Falsify-first**: the cron config test is rewritten to assert `_build_cron_config` **raises** on a bare-`skill` entry (was warn-skip), while a message-only config still parses (kept path unaffected). infra docstrings updated to "rejected".

## KEEP (skill-independent — untouched)
budget.hydrate loop body (token/cost/per-agent/daily/monthly restore) · cron message-based validation/execution · within-session WAL op-kind recovery.

## Deferred (noted, not this PR)
- **B-3** `skill_run_id` (live run-id threading — durable intervention answers) → ② rename, not delete.
- **C-4** `ChatEventForwarder` (dead skill-phase forwarder) → ②-adjacent dead-code cleanup with full-producer falsify (separate PR).
- **C-5** `LLM_PURPOSES` `"phase"`/`"skill_node_adapt"` → ② after dead-verify. Cron skill-*word* prose (`scheduled skill execution` docstring, runner "not supported" comments) → ②.

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `test_tier_audit.py --strict` (changed test files) — 18 OK, 0 errors
- [x] full `pytest` — **6947 passed, 16 skipped**
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] falsify-first per site (A-1 dead-code stays GREEN without the branch; A-2 asserts the new raise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)