### PR TITLE
fix: file__read 'not found' shows error not 'Read 0 lines' in ⎿ row

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -361,6 +361,13 @@ def _summarize_result(tool, result) -> str:
         word = "result" if "search" in t else "item"
         return f"{n} {word}{'' if n == 1 else 's'}"
     if isinstance(result, dict):
+        # Error always wins — a dict with "error" is a failure regardless of
+        # any other keys (e.g. file__read returns op="read", content="", error="file
+        # not found: ..." for a missing file; without this guard the read branch
+        # below would short-circuit to "Read 0 lines" and the error is never seen).
+        error = result.get("error")
+        if isinstance(error, str):
+            return _short(error, 80)
         op = result.get("op")
         path = result.get("path")
         status = result.get("status")
@@ -383,9 +390,6 @@ def _summarize_result(tool, result) -> str:
         if isinstance(tasks, list):
             n = len(tasks)
             return f"{n} task{'s' if n != 1 else ''}"
-        error = result.get("error")
-        if isinstance(error, str):
-            return _short(error, 80)
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -114,6 +114,23 @@ def test_dict_with_error_key_shows_error_not_raw_repr() -> None:
     assert "{" not in out, "raw dict repr must not leak into ⎿ row"
 
 
+def test_file_read_not_found_shows_error_not_zero_lines() -> None:
+    """Tier 2: file__read for a missing file shows the error, not 'Read 0 lines'.
+
+    file__read returns {"op": "read", "content": "", "error": "file not found: …"}
+    for a non-existent path.  Without the error-first guard the read branch fires
+    on op=="read" and returns "Read 0 lines" (empty content → 0 lines), which looks
+    identical to an empty file and gives the user no signal that the file is absent.
+    """
+    out = summarize_tool_result(
+        "file__read",
+        {"op": "read", "content": "", "error": "file not found: README.md"},
+    )
+    assert "0 lines" not in out, "missing file must not look like empty file"
+    assert "not found" in out or "README" in out, "must surface the error"
+    assert "{" not in out, "raw dict repr must not leak"
+
+
 def test_dict_with_status_shows_status() -> None:
     """Tier 2: an opaque dict with a status field shows the status."""
     assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"


### PR DESCRIPTION
**[tui-coder]** — dogfood find, part of #1830 surface audit arc

## Problem

When a model calls `file__read` on a non-existent path, the tool returns:

```python
{"op": "read", "content": "", "error": "file not found: README.md"}
```

The `⎿` summary row showed **`Read 0 lines`** — identical to an empty file.
The user has no signal the file is absent.

## Root cause

`_summarize_result` has an error-key check added by #2473, but it sat **after**
the `op == "read"` branch. The read branch returns early on `content == ""`
(zero-length string → 0 lines), so the error check was never reached.

## Fix

Hoist the `error` key check to the **top** of the `isinstance(result, dict)`
block, before all op-specific branches. Error always wins — a result with an
`"error"` key is a failure regardless of what op kind accompanies it.

## Before / After

| Scenario | Before | After |
|---|---|---|
| `file__read` on missing file | `⎿ Read 0 lines` | `⎿ file not found: README.md` |
| `file__list` outside project | `⎿ glob not permitted…` (already ok via fallthrough) | same |
| Successful `file__read` | `⎿ Read 42 lines` | same |

## Test

Tier 2 test added to `test_inline_tool_result_summary.py`:
`test_file_read_not_found_shows_error_not_zero_lines` — verifies that a result
with `{"op": "read", "content": "", "error": "file not found: README.md"}` does
not produce `"0 lines"` and surfaces the error text.

## CI gates (local)

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 18/18 OK
- [x] `pytest tests/test_inline_tool_result_summary.py` — 18/18 passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: Tier 2 (behavioral, public surface, non-default sentinel value, no mock/private-state).