### PR TITLE
feat(#264): re-home on_mcp_progress → ChatLifecycleForwarder

### DIFF
--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -50,9 +50,10 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     # issue #264 — wire MCP SDK progress + per-call timeout:
     #
     #   progress: forward server-emitted notifications/progress as
-    #   ``mcp_progress`` events on the run's EventLog so a subscriber can
-    #   surface them in the TUI sticky status (= long-running MCP call
-    #   visibility, the A2A PR #253 analogue for the client side).
+    #   ``mcp_progress`` events on the run's EventLog so
+    #   ChatLifecycleForwarder.on_mcp_progress can surface them in the
+    #   sticky status bar (= long-running MCP call visibility, the A2A
+    #   PR #253 analogue for the client side).
     #
     #   timeout: per-server ``call_timeout_seconds`` from the raw config
     #   dict; absent → SDK default applies (= no behaviour change for

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -307,5 +307,79 @@ class ChatLifecycleForwarder:
         except asyncio.QueueFull:
             pass
 
+    # ── MCP tool progress (issue #264) ───────────────────────────────────────
+    # ``op_runtime/mcp.py`` emits ``mcp_progress`` each time the MCP SDK
+    # delivers a ``notifications/progress`` callback during a tool call.
+    # Source schema: {server, tool, progress, total, message}
 
-__all__ = ["ChatLifecycleForwarder"]
+    def on_mcp_progress(self, data: dict) -> None:
+        """Bridge ``mcp_progress`` into a ``status`` outbox message.
+
+        Emits ``kind="status"`` with ``meta.source="mcp"`` so the sticky
+        status bar shows live MCP tool progress during a long-running call.
+        ``meta.source`` discriminates MCP status from other status sources
+        for future per-source styling.
+        """
+        server = str(data.get("server") or "?")
+        tool = str(data.get("tool") or "?")
+        progress = data.get("progress")
+        total = data.get("total")
+        message = data.get("message")
+
+        text = _format_mcp_progress(server, tool, progress, total, message)
+
+        meta: dict = {
+            "source": "mcp",
+            "server": server,
+            "tool": tool,
+        }
+        if progress is not None:
+            meta["progress"] = progress
+        if total is not None:
+            meta["total"] = total
+        if message:
+            meta["progress_text"] = message
+
+        try:
+            self.outbox.put_nowait(OutboxMessage(kind="status", text=text, meta=meta))
+        except asyncio.QueueFull:
+            pass
+
+
+def _format_mcp_progress(
+    server: str,
+    tool: str,
+    progress: object,
+    total: object,
+    message: object,
+) -> str:
+    """Build the human-readable sticky-status text for an MCP progress event.
+
+    Branches:
+      - progress + total both numeric and total > 0 → percentage
+      - progress numeric, total absent / zero        → raw progress value
+      - neither                                      → bare ``[mcp/<server>] <tool>``
+      - message present                              → appended as ``· <message>``
+    """
+    head = f"[mcp/{server}] {tool}"
+    body = ""
+    try:
+        prog_f: float | None = float(progress) if progress is not None else None
+    except (TypeError, ValueError):
+        prog_f = None
+    try:
+        tot_f: float | None = float(total) if total is not None else None
+    except (TypeError, ValueError):
+        tot_f = None
+    if prog_f is not None and tot_f is not None and tot_f > 0:
+        pct = (prog_f / tot_f) * 100
+        body = f" · {pct:.0f}%"
+    elif prog_f is not None:
+        body = f" · progress={prog_f:g}"
+    text = head + body
+    if message:
+        text += f" · {message}"
+    return text
+
+
+__all__ = ["ChatLifecycleForwarder", "_format_mcp_progress"]

--- a/tests/test_lifecycle_forwarder_mcp_progress.py
+++ b/tests/test_lifecycle_forwarder_mcp_progress.py
@@ -1,0 +1,136 @@
+"""Tier 2: ChatLifecycleForwarder.on_mcp_progress — MCP tool progress surfacing.
+
+``op_runtime/mcp.py`` emits ``mcp_progress`` events for each
+``notifications/progress`` callback during a tool call (issue #264).
+``ChatLifecycleForwarder`` must bridge these into ``kind="status"`` outbox
+messages so the sticky status bar shows live progress.
+
+Pins:
+  1. progress + total → percentage text in ``[mcp/<server>] <tool> · N%``
+  2. progress only (no total) → raw progress value
+  3. neither → bare ``[mcp/<server>] <tool>``
+  4. message present → appended as ``· <message>``
+  5. Output kind is ``"status"`` (not ``"system"``)
+  6. meta contains source="mcp", server, tool
+  7. Unrelated events are not forwarded
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder, _format_mcp_progress
+from reyn.schemas.models import Event
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+# ── _format_mcp_progress pure function ───────────────────────────────────────
+
+def test_format_mcp_progress_percentage_when_both_numeric() -> None:
+    """Tier 2: progress + total → percentage in the status text."""
+    text = _format_mcp_progress("my-server", "search", 3, 10, None)
+    assert "[mcp/my-server] search" in text
+    assert "30%" in text
+
+
+def test_format_mcp_progress_raw_when_no_total() -> None:
+    """Tier 2: progress without total → raw progress value."""
+    text = _format_mcp_progress("srv", "list", 7, None, None)
+    assert "progress=7" in text
+    assert "%" not in text
+
+
+def test_format_mcp_progress_bare_when_no_progress() -> None:
+    """Tier 2: no progress or total → bare server+tool indicator."""
+    text = _format_mcp_progress("srv", "tool", None, None, None)
+    assert text == "[mcp/srv] tool"
+
+
+def test_format_mcp_progress_message_appended() -> None:
+    """Tier 2: message is appended after the progress part."""
+    text = _format_mcp_progress("srv", "tool", 1, 2, "indexing files")
+    assert "indexing files" in text
+    assert text.endswith("· indexing files")
+
+
+def test_format_mcp_progress_zero_total_no_pct() -> None:
+    """Tier 2: total=0 is treated as absent (no division by zero)."""
+    text = _format_mcp_progress("srv", "tool", 5, 0, None)
+    assert "%" not in text
+    assert "progress=5" in text
+
+
+# ── ChatLifecycleForwarder.on_mcp_progress ───────────────────────────────────
+
+def test_mcp_progress_event_emits_status_kind() -> None:
+    """Tier 2: mcp_progress event produces kind='status' outbox message."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="mcp_progress", data={
+        "server": "search-srv", "tool": "web_search",
+        "progress": 5, "total": 10, "message": None,
+    }))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "status"
+
+
+def test_mcp_progress_meta_source_and_fields() -> None:
+    """Tier 2: mcp_progress meta carries source='mcp', server, tool."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="mcp_progress", data={
+        "server": "my-server", "tool": "my-tool",
+        "progress": 2, "total": 4, "message": "running",
+    }))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.meta["source"] == "mcp"
+    assert only.meta["server"] == "my-server"
+    assert only.meta["tool"] == "my-tool"
+    assert only.meta["progress"] == 2
+    assert only.meta["total"] == 4
+    assert only.meta["progress_text"] == "running"
+
+
+def test_mcp_progress_text_contains_percentage() -> None:
+    """Tier 2: status text surfaces the computed percentage."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="mcp_progress", data={
+        "server": "srv", "tool": "fetch",
+        "progress": 1, "total": 4, "message": None,
+    }))
+    msgs = _drain(q)
+    assert "25%" in msgs[0].text
+
+
+def test_mcp_progress_unrelated_event_dropped() -> None:
+    """Tier 2: unrelated events produce no outbox messages."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="some_other_event", data={"x": 1}))
+    assert q.empty()
+
+
+@pytest.mark.parametrize("progress,total,expected_in_text", [
+    (3, 10, "30%"),
+    (1, 1, "100%"),
+    (0, 5, "0%"),
+    (7, None, "progress=7"),
+    (None, None, "[mcp/s] t"),
+])
+def test_format_mcp_progress_parametrised(
+    progress: object, total: object, expected_in_text: str,
+) -> None:
+    """Tier 2: parametrised coverage of the key _format_mcp_progress branches."""
+    text = _format_mcp_progress("s", "t", progress, total, None)
+    assert expected_in_text in text


### PR DESCRIPTION
**[tui-coder]** — C-4 (#2479) deleted `ChatEventForwarder.on_mcp_progress`. Re-homing to `ChatLifecycleForwarder`.

## What

`op_runtime/mcp.py:67` emits `mcp_progress` events for each `notifications/progress` callback during an MCP tool call (issue #264). Before C-4 these were surfaced in the sticky status bar via `ChatEventForwarder`. After C-4 that handler was deleted and the events silently drop.

This PR adds `on_mcp_progress` to `ChatLifecycleForwarder` (the correct home for session-level non-skill events) to restore the behavior.

## Event shape (verified fresh from source)

```python
ctx.events.emit("mcp_progress", server=..., tool=..., progress=..., total=..., message=...)
```

## Output

`kind="status"`, `meta.source="mcp"` so the sticky bar shows `[mcp/<server>] <tool> · N%` during a long-running MCP call. Pure `_format_mcp_progress` helper (module-level) handles all branches:

- progress + total → percentage (`30%`)
- progress only → raw (`progress=7`)
- neither → bare `[mcp/srv] tool`
- message present → appended as `· <message>`

## Tests

10 Tier 2 tests in `test_lifecycle_forwarder_mcp_progress.py` — formatter branch coverage + forwarder event routing (kind/meta/text/unrelated-drop).

## CI gates

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_lifecycle_forwarder_mcp_progress.py` — 10/10 pass
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/lifecycle_forwarder.py` — OK
- [x] `pytest tests/test_lifecycle_forwarder_mcp_progress.py tests/test_chat_lifecycle_forwarder.py tests/test_lifecycle_forwarder_tool_call_events.py` — 46/46 pass

## Test plan

- [x] (skipped — live MCP server required to observe sticky status; handler correctness is fully exercised by the 10 Tier 2 tests covering all format branches and event routing)

Tier self-check: Tier 2 (real forwarder instance, asyncio.Queue, Event, no mocks, behavioral assertion on public outbox surface).
part of #264