### PR TITLE
refactor(compat): C-5 — remove dead 'phase'/'skill_node_adapt' LLM_PURPOSES

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1390,7 +1390,7 @@ def routing_for_spec(spec: "ModelSpec | None") -> dict | None:
 # recorded_acompletion call must tag one so /cost can break spend down by where
 # the LLM call originated. ``dogfood`` covers test/trace sites (recorder=None).
 LLM_PURPOSES: tuple[str, ...] = (
-    "main", "phase", "compaction", "judge", "skill_node_adapt", "dogfood",
+    "main", "compaction", "judge", "dogfood",
 )
 
 

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -172,7 +172,7 @@ class BudgetLedger:
         """Append one LLM-call record and fsync.
 
         ``purpose`` (#1190) is the cost-attribution bucket
-        (main/phase/compaction/judge/skill_node_adapt/dogfood). It is omitted
+        (main/compaction/judge/dogfood). It is omitted
         from the record when None so pre-existing ledger lines stay
         byte-identical.
         """
@@ -305,8 +305,8 @@ class BudgetTracker:
         self._config = config
         self._agent_tokens: dict[str, int] = defaultdict(int)
         self._agent_cost_usd: dict[str, float] = defaultdict(float)
-        # #1190 stage (iii): per-purpose cost attribution (main/phase/compaction/
-        # judge/skill_node_adapt/dogfood) for the /budget breakdown payoff.
+        # #1190 stage (iii): per-purpose cost attribution
+        # (main/compaction/judge/dogfood) for the /budget breakdown payoff.
         self._purpose_tokens: dict[str, int] = defaultdict(int)
         self._purpose_cost_usd: dict[str, float] = defaultdict(float)
         self._call_window: dict[str, deque[float]] = defaultdict(deque)
@@ -1114,7 +1114,7 @@ def format_budget_full(snapshot: dict, attached: str | None) -> str:
         lines.append("")
 
     # #1190 stage (iii): per-purpose cost attribution — where the spend went
-    # (main / phase / compaction / judge / skill_node_adapt / dogfood).
+    # (main / compaction / judge / dogfood).
     purpose_tokens = snapshot.get("purpose_tokens") or {}
     purpose_cost = snapshot.get("purpose_cost_usd") or {}
     if purpose_tokens or purpose_cost:

--- a/tests/test_cost_chokepoint_1190.py
+++ b/tests/test_cost_chokepoint_1190.py
@@ -138,11 +138,11 @@ def test_ledger_persists_purpose_and_omits_when_none(tmp_path: Path) -> None:
     """Tier 2: the budget ledger persists `purpose` when given, and omits the
     field entirely when None (pre-#1190 lines stay byte-identical)."""
     ledger = BudgetLedger(tmp_path / "ledger.jsonl")
-    ledger.append(agent="a", model="m", tokens=10, cost_usd=0.0, purpose="phase")
+    ledger.append(agent="a", model="m", tokens=10, cost_usd=0.0, purpose="judge")
     ledger.append(agent="a", model="m", tokens=5, cost_usd=0.0)  # no purpose
 
     lines = [json.loads(line) for line in (tmp_path / "ledger.jsonl").read_text().splitlines() if line.strip()]
-    assert lines[0]["purpose"] == "phase"
+    assert lines[0]["purpose"] == "judge"
     assert "purpose" not in lines[1], "None purpose must be omitted (legacy byte-identical)"
 
 
@@ -160,8 +160,7 @@ def test_recorded_acompletion_rejects_unknown_purpose() -> None:
         ))
     # every advertised purpose is accepted (guards against the list drifting out
     # of sync with the assert).
-    assert set(LLM_PURPOSES) >= {"main", "phase", "compaction", "judge",
-                                 "skill_node_adapt", "dogfood"}
+    assert set(LLM_PURPOSES) >= {"main", "compaction", "judge", "dogfood"}
 
 
 def test_compaction_engine_threads_agent(monkeypatch) -> None:


### PR DESCRIPTION
**[e2e-coder]** — C-5: remove the two dead cost-attribution purposes from `LLM_PURPOSES`. Final slice of the ①-arc dead-code cleanup before ② (skill-word purge).

## Dead-verify (fresh refs, per lead's stale-ref caution)
`git fetch` first, then verified on fresh main: **zero live callers** pass `purpose="phase"` or `purpose="skill_node_adapt"` (literal or variable). `phase` was the phase-LLM bucket and `skill_node_adapt` the skill-node LLM-adaptation bucket — both for machinery removed with skills/phases. The live purposes actually tagged are `main` / `compaction` / `judge` / `dogfood`.

## Changes
- `llm.py`: `LLM_PURPOSES` → `("main", "compaction", "judge", "dogfood")`.
- `test_cost_chokepoint_1190.py`: **test-producer check (per the C-4 lesson) caught two usages** — the `LLM_PURPOSES` membership assertion (updated to the live set) and an arbitrary `purpose="phase"` test value (retargeted to `judge`). Without this check, a naive tuple edit would have red-failed the test.
- `budget.py`: 3 comments enumerating the purpose set updated.

## Falsify-first
- full `pytest` — **6938 passed, 16 skipped**.
- The `recorded_acompletion` chokepoint still rejects unknown purposes — now including the two removed ones, which have zero live callers (so no production impact).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` (changed test) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] full `pytest` — 6938 passed, 16 skipped
- [x] fresh-ref dead-verify (0 live callers) + test-producer check (2 caught + handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)