### PR TITLE
fix: status bar hint when above-region picker is focused

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -90,6 +90,20 @@ _SLASH_COMPLETER = _SlashCompleter()
 _ABOVE_REGION_MAX_HEIGHT = 12
 
 
+def _picker_hint(has_picker_focus: bool, key: str | None) -> str:
+    """Return the status-bar hint for the above-region picker state.
+
+    Pure function so the focus-dependent and hint-selection logic are
+    separately testable: the caller resolves ``has_picker_focus`` from
+    ``get_app().layout.has_focus()`` and passes the result in.
+    """
+    if not has_picker_focus:
+        return "  [↓ menu · ↑ history · /quit]"
+    if key and key.startswith("iv:"):
+        return "  [↑↓ select · enter confirm]"
+    return "  [↑↓ select · enter · esc cancel]"
+
+
 @dataclass(frozen=True)
 class ChipSpec:
     """One status-bar chip: label + live value + optional expansion element.
@@ -589,7 +603,10 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             if i < len(_CHIP_SPECS) - 1:
                 frags.append((f"fg:{_CC_DIM}", "│"))
         if not focused:
-            hint = "  [↓ menu · ↑ history · /quit]"
+            hint = _picker_hint(
+                get_app().layout.has_focus(above_region_win),
+                region_holder["key"],
+            )
         elif menu["open"] and menu_region.cursor_on_selectable:
             hint = "  [↑↓ select · enter switch · esc close]"
         elif menu["open"]:

--- a/tests/test_inline_picker_hint.py
+++ b/tests/test_inline_picker_hint.py
@@ -1,0 +1,30 @@
+"""Tier 2: _picker_hint — pure status-bar hint selector for the above-region picker.
+
+The hint text shown in the status bar depends on whether the above-region
+picker has focus and, if so, which kind of element is active (intervention
+vs. command-UI). ``_picker_hint`` is extracted as a pure function so the
+focus-resolution (``get_app().layout.has_focus``) stays in the PT layer while
+the selection logic is unit-testable here.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.app import _picker_hint
+
+
+def test_picker_hint_no_focus_returns_default():
+    """Tier 2: when the above-region has no focus, return the default nav hint."""
+    assert _picker_hint(False, None) == "  [↓ menu · ↑ history · /quit]"
+
+
+def test_picker_hint_intervention_omits_esc():
+    """Tier 2: intervention picker (iv: key) shows enter-confirm hint without esc.
+
+    Escape is intentionally blocked for interventions — the session blocks
+    until the user resolves the choice, so the hint must not suggest esc.
+    """
+    assert _picker_hint(True, "iv:abc123") == "  [↑↓ select · enter confirm]"
+
+
+def test_picker_hint_command_ui_includes_esc():
+    """Tier 2: command-UI picker (cmd: key) shows cancel hint with esc."""
+    assert _picker_hint(True, "cmd:rewind-001") == "  [↑↓ select · enter · esc cancel]"


### PR DESCRIPTION
**[tui-coder]** — Dogfood mining fix

## Problem

When the above-input region picker was focused (either the `/rewind` turn-picker or a closed-set intervention picker like grant/deny), the status bar continued showing the default `[↓ menu · ↑ history · /quit]` hint — the user had no indication of ↑↓ select / enter / esc semantics.

Observed during live dogfood of the `/rewind` picker: picker rows appeared, cursor highlighted, but status bar gave no signal about ↑↓ / Enter / Escape.

## Fix

Extracted `_picker_hint(has_picker_focus: bool, key: str | None) -> str` as a pure module-level function (seam split: focus-resolution stays in PT layer, hint selection is now pure + testable). `status_fragments()` calls it with the evaluated focus bool.

Hint variants:
- **No focus on above-region**: `[↓ menu · ↑ history · /quit]` (unchanged default)
- **Command-UI picker** (`cmd:…` key, e.g. `/rewind`): `[↑↓ select · enter · esc cancel]`
- **Intervention picker** (`iv:…` key, grant/deny choices): `[↑↓ select · enter confirm]` — Escape is intentionally blocked for interventions (session blocks until resolved), so `esc` is omitted

## Files changed

- `src/reyn/interfaces/inline/app.py` — extract `_picker_hint`, call from `status_fragments()`
- `tests/test_inline_picker_hint.py` — 3 Tier 2 tests (no-focus / iv: / cmd:)

## CI gates (pre-push)

- [x] `ruff check src tests` — clean
- [x] `pytest` — green (3 new tests pass)
- [x] `verify_module_docstrings` — clean
- [x] `test_tier_audit.py --strict tests/test_inline_picker_hint.py` — 3 OK, 0 violations

## Test plan

- [x] `tests/test_inline_picker_hint.py` — 3 Tier 2 behavioral tests on pure `_picker_hint`
- [x] (skipped — PT live app; not automatable to Tier 2) `/rewind` picker open → status bar shows `[↑↓ select · enter · esc cancel]`
- [x] (skipped — same reason) Grant/deny intervention picker → status bar shows `[↑↓ select · enter confirm]`
- [x] (skipped — same reason) Normal input focus → status bar shows `[↓ menu · ↑ history · /quit]` (unchanged)

**Tier self-check**: 3 new Tier 2 tests; pure function, real values, no mocks.