### PR TITLE
refactor(skill-word): ②b-clean — rename skill_run_id → run_id (within-session threading)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -99,7 +99,7 @@ class OpContext:
     # debug logs, and future cascade-discard semantics. ``None`` means
     # "no parent visible" (e.g. preprocessor-spawned sub-skills, or
     # runtime invocations that don't track a run_id).
-    parent_skill_run_id: str | None = None
+    parent_run_id: str | None = None
 
     # FP-0021: the run_id of the currently-executing run.
     # Threaded from the runtime through the ctx-build seams to OpContext so

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -289,7 +289,7 @@ async def send_to_agent_impl(
         "reply": reply_text,
         "partial": (not idle),
         "agent": agent_name,
-        "running_skill_run_ids": [],
+        "running_run_ids": [],
         "limit_stopped": limit_stopped,
     }
 

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -322,7 +322,7 @@ async def _handle_call_mcp_tool(
             intervention_bus=None,
             current_phase="",
             caller="direct",
-            parent_skill_run_id=None,
+            parent_run_id=None,
         )
         return await mcp_handle(op=op, ctx=legacy_ctx)
 

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -125,7 +125,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         intervention_bus=None,
         current_phase="",
         caller="direct",
-        parent_skill_run_id=None,
+        parent_run_id=None,
         sandbox_config=sandbox_config,
     )
     return await handle_sandboxed_exec(op=op, ctx=legacy_ctx)

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -197,7 +197,7 @@ class PhaseCallerState:
 
     Populated when invoking a ToolDefinition
     handler in phase context. Handlers that need phase-scoped
-    resources (already-built OpContext, skill_run_id, run_visit_count,
+    resources (already-built OpContext, run_id, run_visit_count,
     etc.) consume them via this object.
 
     All fields are Optional. Test contexts may populate only what's
@@ -205,7 +205,7 @@ class PhaseCallerState:
     population (= control_ir_executor wiring) is M4 Phase 3.
     """
     # Phase identity
-    skill_run_id: str | None = None
+    run_id: str | None = None
     phase_name: str | None = None
     run_visit_count: int | None = None
 

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -100,7 +100,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         intervention_bus=None,
         current_phase="",
         caller="direct",
-        parent_skill_run_id=None,
+        parent_run_id=None,
     )
 
     return await handle_web_search(op=op, ctx=legacy_ctx)

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -337,7 +337,7 @@ def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeyp
     # Real injected collaborators (no mocks): a fast agent-send stub so the
     # background run doesn't reach the LLM, and a recording webhook poster.
     async def _stub_send(*_args, **_kwargs):
-        return {"reply": "ok", "partial": False, "running_skill_run_ids": []}
+        return {"reply": "ok", "partial": False, "running_run_ids": []}
 
     monkeypatch.setattr(a2a_mod, "send_to_agent_impl", _stub_send)
     monkeypatch.setattr(

--- a/tests/test_tool_registry_invariants.py
+++ b/tests/test_tool_registry_invariants.py
@@ -436,7 +436,7 @@ def test_router_caller_state_defaults_all_none():
 def test_phase_caller_state_defaults_all_none():
     """Tier 2: PhaseCallerState() with no arguments defaults all fields to None."""
     state = PhaseCallerState()
-    assert state.skill_run_id is None
+    assert state.run_id is None
     assert state.phase_name is None
     assert state.run_visit_count is None
     assert state.op_context is None
@@ -477,7 +477,7 @@ def test_tool_context_with_phase_caller_state():
         pass
 
     state = PhaseCallerState(
-        skill_run_id="run-abc",
+        run_id="run-abc",
         phase_name="analyze",
         run_visit_count=3,
     )
@@ -490,7 +490,7 @@ def test_tool_context_with_phase_caller_state():
     )
     assert ctx.caller_kind == "phase"
     assert ctx.phase_state is state
-    assert ctx.phase_state.skill_run_id == "run-abc"
+    assert ctx.phase_state.run_id == "run-abc"
     assert ctx.phase_state.phase_name == "analyze"
     assert ctx.phase_state.run_visit_count == 3
     assert ctx.router_state is None

--- a/tests/test_web_fetch_unified.py
+++ b/tests/test_web_fetch_unified.py
@@ -465,7 +465,7 @@ def test_phase_dispatch_reuses_op_context_intervention_bus(tmp_path: Path) -> No
     )
 
     phase_state = PhaseCallerState(
-        skill_run_id="run-1",
+        run_id="run-1",
         phase_name="search",
         op_context=op_ctx_with_bus,
     )
@@ -520,7 +520,7 @@ def test_phase_dispatch_without_op_context_falls_back_to_minimal(
 
     # Phase state with no op_context (= test-site shape).
     phase_state = PhaseCallerState(
-        skill_run_id="run-1",
+        run_id="run-1",
         phase_name="search",
         op_context=None,
     )


### PR DESCRIPTION
**[e2e-coder]** — ②b-clean (skill-word purge): rename within-session run-id threading fields to the neutral `run_id` vocabulary. Non-chat-safety (internal field names). Part of the lead-reviewed ② inventory; the split into clean-rename vs the deferred cluster was lead-validated.

## Rename (machinery kept — live, not deleted)
- `PhaseCallerState.skill_run_id` → `run_id` (tools/types.py)
- `OpContext.parent_skill_run_id` → `parent_run_id` (op_runtime/context.py + sandboxed_exec / mcp / web_search kwargs)
- mcp/server.py `"running_skill_run_ids"` → `"running_run_ids"` (+ its test)

Writer + reader + tests in one commit (**rename-completeness**). **No name collisions** verified (PhaseCallerState has no `run_id`; OpContext has no `parent_run_id`). Word-boundary perl applied to targeted files only.

## Not recovery identity
These are within-session run-id threading (op-context, mcp response). A complete writer+reader rename preserves within-session recovery (both sides consistent); cross-version is moot pre-release. **op-kind strings untouched (WAL identity).**

## Deferred to ②d (P5 skill-recovery-state cluster) — verified untouched here
`agent_snapshot.active_skill_run_ids` (durable snapshot key populated/pruned by the deferred `skill_*` WAL events) + the `test_inline` status "skill_run_ids" chip + the agent_snapshot "keyed by skill_run_id" comment — all coupled to the recovery-gated cluster, handled together in ②d with truncate-falsify.

## Test plan
- [x] `ruff` / `test_tier_audit.py` / `verify_module_docstrings.py` — clean
- [x] full `pytest` — **6956 passed, 16 skipped**
- [x] rename-completeness: **0 residual old-name readers** (except the ②d-deferred comment); ②d files verified untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)