### PR TITLE
fix: file__list / file__grep / file__glob ⎿ rows show raw dict instead of summary

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -386,10 +386,22 @@ def _summarize_result(tool, result) -> str:
             return f"Wrote {path}" if path else "Wrote file"
         if op == "edit":
             return f"Edited {path}" if path else "Edited file"
+        if op == "grep":
+            count = result.get("count")
+            n = int(count) if isinstance(count, (int, float)) else 0
+            return f"{n} match{'es' if n != 1 else ''}"
         tasks = result.get("tasks")
         if isinstance(tasks, list):
             n = len(tasks)
             return f"{n} task{'s' if n != 1 else ''}"
+        entries = result.get("entries")
+        if isinstance(entries, list):
+            n = len(entries)
+            return f"Listed {n} {'entry' if n == 1 else 'entries'}"
+        matches = result.get("matches")
+        if isinstance(matches, list):
+            n = len(matches)
+            return f"{n} match{'es' if n != 1 else ''}"
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -131,6 +131,49 @@ def test_file_read_not_found_shows_error_not_zero_lines() -> None:
     assert "{" not in out, "raw dict repr must not leak"
 
 
+def test_file_list_shows_entry_count() -> None:
+    """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
+
+    Without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "file__list", {"path": "src/", "entries": ["a.py", "b.py", "c.py"]}
+    ) == "Listed 3 entries"
+    assert summarize_tool_result(
+        "file__list", {"path": "src/", "entries": ["only.py"]}
+    ) == "Listed 1 entry"
+
+
+def test_file_grep_shows_match_count() -> None:
+    """Tier 2: file__grep result (op='grep', count=N) shows 'N matches'.
+
+    Without this branch grep fell through to status='ok' which is uninformative.
+    """
+    assert summarize_tool_result(
+        "file__grep",
+        {"op": "grep", "status": "ok", "count": 7, "matches": []},
+    ) == "7 matches"
+    assert summarize_tool_result(
+        "file__grep",
+        {"op": "grep", "status": "ok", "count": 1, "matches": []},
+    ) == "1 match"
+
+
+def test_file_glob_shows_match_count() -> None:
+    """Tier 2: file__glob result ({pattern, matches, count}) shows 'N matches'.
+
+    Without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "file__glob",
+        {"pattern": "src/**/*.py", "matches": ["a.py", "b.py"], "count": 2},
+    ) == "2 matches"
+    assert summarize_tool_result(
+        "file__glob",
+        {"pattern": "*.md", "matches": ["README.md"], "count": 1},
+    ) == "1 match"
+
+
 def test_dict_with_status_shows_status() -> None:
     """Tier 2: an opaque dict with a status field shows the status."""
     assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"


### PR DESCRIPTION
**[tui-coder]** — dogfood mining find from inline CUI ⎿ row audit.

## Summary

- `file__list` result `{path, entries}` had no `op` key → `_summarize_result` fell through to `_short(result, 80)` (raw dict repr in ⎿ row)
- `file__grep` result has `op="grep"` but no branch → fell through to `status="ok"` (uninformative — no match count)
- `file__glob` result `{pattern, matches, count}` had no `op` key → same raw dict repr leak

## Fix

Three new branches in `_summarize_result` (`renderer.py`):

| Tool | Result shape | Before | After |
|------|-------------|--------|-------|
| `file__list` | `{path, entries: [...]}` | `{'path': 'src/', 'entries': [...]}` | `Listed 3 entries` |
| `file__grep` | `{op: "grep", count: N, ...}` | `ok` | `7 matches` |
| `file__glob` | `{pattern, matches: [...], count}` | `{'pattern': '*.py', ...}` | `2 matches` |

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 21/21 pass (3 new tests for the 3 fixed shapes)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 0 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: 3 new Tier 2 tests (pure function `summarize_tool_result`, known input→output), no private state, no format pin.