### PR TITLE
fix(#2488): file__delete ⎿ row shows 'Deleted {path}' instead of 'ok'

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -386,6 +386,8 @@ def _summarize_result(tool, result) -> str:
             return f"Wrote {path}" if path else "Wrote file"
         if op == "edit":
             return f"Edited {path}" if path else "Edited file"
+        if op == "delete":
+            return f"Deleted {path}" if path else "Deleted file"
         if op == "grep":
             count = result.get("count")
             n = int(count) if isinstance(count, (int, float)) else 0

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -131,6 +131,23 @@ def test_file_read_not_found_shows_error_not_zero_lines() -> None:
     assert "{" not in out, "raw dict repr must not leak"
 
 
+def test_file_delete_shows_deleted_path() -> None:
+    """Tier 2: file__delete result (op='delete', path=...) shows 'Deleted {path}'.
+
+    file__delete returns {"kind": "file", "op": "delete", "path": ..., "status": "ok"}.
+    Without this branch op='delete' misses all op checks, falls through to
+    status='ok' → shows 'ok' with no path, giving the user no signal of what was
+    deleted.
+    """
+    assert summarize_tool_result(
+        "file__delete",
+        {"kind": "file", "op": "delete", "path": "src/old.py", "status": "ok", "deleted": True},
+    ) == "Deleted src/old.py"
+    assert summarize_tool_result(
+        "file__delete", {"op": "delete"}
+    ) == "Deleted file"
+
+
 def test_file_list_shows_entry_count() -> None:
     """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
 


### PR DESCRIPTION
**[tui-coder]** — dogfood mining: ⎿ row summary gap for `file__delete`

## Root cause

`_summarize_result` dispatches on `op=` for write/create/edit/grep but had no
`"delete"` branch. `file__delete` returns `{"kind": "file", "op": "delete", "path": ..., "status": "ok", "deleted": True}` — with no matching branch the dispatcher fell through to `if status: return str(status)` and showed the generic `"ok"` in the ⎿ row, giving no signal about what was deleted.

## Fix

Add `op == "delete"` branch alongside the existing file op dispatch:

```python
if op == "delete":
    return f"Deleted {path}" if path else "Deleted file"
```

Before: `  ⎿ ok`
After:  `  ⎿ Deleted src/old.py`

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 22 passed (added `test_file_delete_shows_deleted_path`)
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 22 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

**Tier self-check**: 1 Tier-2 contract test added; no Tier-4 violations.

part of #2488