### PR TITLE
refactor(skill-word): ②c-1 — rewrite residual skill-word prose in budget/cron

### DIFF
--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -382,7 +382,7 @@ class EventsConfig:
     `.reyn/events/agents/<name>/chat/<YYYY-MM>/` and rotated when either
     the active file's size exceeds `max_bytes` OR its age (or local date)
     exceeds `max_age_seconds`. Setting both to 0 disables rotation, which
-    is the mode skill_run uses (1 run = 1 file).
+    is the single-run mode (1 run = 1 file).
 
     `cleanup_period_days` documents how long closed files should be kept
     before `reyn events purge` may delete them. `null` (default) disables
@@ -574,9 +574,9 @@ class CronJobConfig:
 
 @dataclass
 class CronConfig:
-    """``cron:`` — scheduled skill execution (FP-0009 Component B).
+    """``cron:`` — scheduled message dispatch (FP-0009 Component B).
 
-    Each entry under ``cron.jobs`` triggers a stdlib or project skill
+    Each entry under ``cron.jobs`` dispatches a message to a target agent
     on a cron schedule via ``CronScheduler`` (= attached to
     ``app.state.cron_scheduler`` in web mode, or run foreground via
     ``reyn cron run``).
@@ -630,9 +630,9 @@ def _build_cron_config(raw: object) -> CronConfig:
                 f"cron.jobs[{i}] (name={name!r}): 'schedule' must be a non-empty string "
                 f"(got {schedule!r})"
             )
-        # FP-0041 #489 PR-B: message-based shape (to + message). Legacy
-        # skill-based jobs (a bare ``skill`` name) are no longer supported —
-        # the skill runtime was removed.
+        # FP-0041 #489 PR-B: a job must be message-based (to + message). An
+        # entry lacking that shape (e.g. a legacy bare ``skill`` name) is
+        # rejected below.
         to = entry.get("to")
         message = entry.get("message")
         has_message_shape = (

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -16,7 +16,7 @@ Hybrid cap behavior:
     pushed to the user as a status message and recorded in events.jsonl
 
 Per P7: this is OS-level generic infrastructure — the dimension names
-are not tied to any specific skill or domain.
+are not tied to any specific domain.
 """
 from __future__ import annotations
 
@@ -548,7 +548,7 @@ class BudgetTracker:
         writes the state file (subject to throttle).
 
         ``throttle_secs`` collapses rapid consecutive writes (LLM call paths
-        are hot in multi-skill scenarios — a per-call fsync would dominate).
+        are hot in multi-agent scenarios — a per-call fsync would dominate).
         Default 1 second. Set to 0 in tests for deterministic save semantics.
         """
         self._state_path = Path(path)

--- a/src/reyn/runtime/cron/runners.py
+++ b/src/reyn/runtime/cron/runners.py
@@ -6,8 +6,8 @@ runner pushes an envelope into the target agent's inbox with
 ``sender="cron:<name>"`` attribution, and the agent's router_loop
 consumes it as a normal attributed turn from a scheduled trigger.
 
-(Legacy skill-based jobs are no longer supported; the skill runtime was
-removed. Config parsing warns-and-skips any surviving ``skill`` entry.)
+(A cron job must be message-based: ``to`` + ``message``. A config entry
+lacking that shape — e.g. a legacy bare ``skill`` name — is rejected at load.)
 
 The transport collaborator is injected (= keeps this factory transport-agnostic):
 
@@ -71,8 +71,8 @@ def build_default_runner(
 
     async def _runner(job: "CronJob") -> str:
         if not job.is_message_based():
-            # All cron jobs are message-based; config warns-and-skips any legacy
-            # skill-based entry. A non-message job here is malformed.
+            # All cron jobs are message-based; config rejects any legacy
+            # non-message entry at load. A non-message job here is malformed.
             logger.warning(
                 "Cron job %r is not message-based (to=%r, message set=%s) — "
                 "skipping. Set both 'to' and 'message'.",

--- a/src/reyn/runtime/cron/scheduler.py
+++ b/src/reyn/runtime/cron/scheduler.py
@@ -22,8 +22,8 @@ class CronJob:
     message to the agent's inbox with ``sender="cron:<name>"`` so the LLM
     reads it as a normal attributed turn from a scheduled trigger.
 
-    (Legacy skill-based jobs are no longer supported; the skill runtime was
-    removed. Config parsing warns-and-skips any surviving ``skill`` entry.)
+    (A cron job must be message-based: ``to`` + ``message``. A config entry
+    lacking that shape — e.g. a legacy bare ``skill`` name — is rejected at load.)
 
     Mutable on the scheduler side: ``last_run_at`` / ``last_run_status``
     / ``last_run_error`` / ``next_run_at`` are updated after each fire.


### PR DESCRIPTION
**[e2e-coder]** — ②c-1 (skill-word purge): rewrite residual skill-word prose in budget/cron docstrings + comments. **Prose-only, no logic change.** Part of the reviewed ② inventory; the /concept glossary relocate is the follow-up ②c-2.

## Changes
- **infra.py** (CronConfig): "scheduled skill execution" → "scheduled message dispatch"; "triggers a stdlib or project skill" → "dispatches a message to a target agent"; "skill_run mode" → "single-run mode"; parse comment "skill-based jobs ... skill runtime removed" → "rejected below".
- **budget.py**: "any specific skill or domain" → "domain"; "multi-skill scenarios" → "multi-agent scenarios".
- **cron/runners.py + scheduler.py**: "Legacy skill-based jobs ... warns-and-skips any surviving skill entry" → "must be message-based; a legacy bare skill name is rejected at load".

Also **corrects a staleness**: the cron comments still said warns-and-skips, but ① A-2 changed that behavior to reject-at-load — the prose now matches impl.

## Not in this PR (tracked)
②c-2: /concept glossary relocate (`docs/guide/for-skill-authors/...` → `docs/reference/glossary.md`) + dead skill/phase content-purge + `_GLOSSARY_REL`/test repoint (keep /concept). The glossary is heavily skill/phase vocab, so it's a focused follow-up.

## Test plan
- [x] `ruff check src tests` — clean
- [x] full `pytest` — see result below
- [x] no test pins the changed docstrings (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)