### PR TITLE
fix(#2490/#2491): inline ⎿ summary — memory ops, recall chunks, error_message

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -368,6 +368,9 @@ def _summarize_result(tool, result) -> str:
         error = result.get("error")
         if isinstance(error, str):
             return _short(error, 80)
+        error_message = result.get("error_message")
+        if isinstance(error_message, str):
+            return _short(error_message, 80)
         op = result.get("op")
         path = result.get("path")
         status = result.get("status")
@@ -410,6 +413,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(matches, list):
             n = len(matches)
             return f"{n} match{'es' if n != 1 else ''}"
+        chunks = result.get("chunks")
+        if isinstance(chunks, list):
+            n = len(chunks)
+            return f"{n} chunk{'s' if n != 1 else ''}"
         if status:
             return str(status)
     return _short(result, 80)

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -392,6 +392,12 @@ def _summarize_result(tool, result) -> str:
             count = result.get("count")
             n = int(count) if isinstance(count, (int, float)) else 0
             return f"{n} match{'es' if n != 1 else ''}"
+        saved = result.get("saved")
+        if isinstance(saved, str):
+            return f"Saved {saved}"
+        forgotten = result.get("deleted")
+        if isinstance(forgotten, str):
+            return f"Forgot {forgotten}"
         tasks = result.get("tasks")
         if isinstance(tasks, list):
             n = len(tasks)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -148,6 +148,30 @@ def test_file_delete_shows_deleted_path() -> None:
     ) == "Deleted file"
 
 
+def test_memory_remember_shows_saved_slug() -> None:
+    """Tier 2: memory_operation__remember_* result ({saved, layer, path}) shows 'Saved {slug}'.
+
+    Without this branch the raw dict repr leaked into the ⎿ row; the result
+    has no 'op', 'status', 'tasks', 'entries', or 'matches' key.
+    """
+    assert summarize_tool_result(
+        "memory_operation__remember_agent",
+        {"saved": "my-memory-slug", "layer": "agent", "path": "/.reyn/memory/agent/my-memory-slug.md"},
+    ) == "Saved my-memory-slug"
+
+
+def test_memory_forget_shows_forgot_slug() -> None:
+    """Tier 2: memory_operation__forget result ({deleted, layer}) shows 'Forgot {slug}'.
+
+    Without this branch the raw dict repr leaked into the ⎿ row; same missing-key
+    condition as the remember case (no 'op', 'status', or list keys).
+    """
+    assert summarize_tool_result(
+        "memory_operation__forget",
+        {"deleted": "old-memory-slug", "layer": "shared"},
+    ) == "Forgot old-memory-slug"
+
+
 def test_file_list_shows_entry_count() -> None:
     """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
 

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -172,6 +172,47 @@ def test_memory_forget_shows_forgot_slug() -> None:
     ) == "Forgot old-memory-slug"
 
 
+def test_recall_success_shows_chunk_count() -> None:
+    """Tier 2: rag_operation__recall success ({chunks, mode}) shows 'N chunks'.
+
+    recall returns {"chunks": [...], "mode": "recall"} with no op/status/matches/
+    entries key, so without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [{"text": "a"}, {"text": "b"}, {"text": "c"}], "mode": "recall"},
+    ) == "3 chunks"
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [{"text": "only"}], "mode": "recall"},
+    ) == "1 chunk"
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [], "mode": "fallback"},
+    ) == "0 chunks"
+
+
+def test_error_message_field_shown_not_raw_dict() -> None:
+    """Tier 2: dicts with 'error_message' (no 'error' key) show the message.
+
+    recall validation errors return {"ok": False, "error_kind": ..., "error_message": ...}
+    and task_ops returns the same shape for invalid-args/no-context errors.
+    Without the error_message fallback both fell through to raw dict repr.
+    """
+    out = summarize_tool_result(
+        "rag_operation__recall",
+        {
+            "ok": False,
+            "error_kind": "missing_required_arg",
+            "error_message": "recall requires ['query']. Available sources are listed …",
+            "missing": ["query"],
+        },
+    )
+    assert "recall requires" in out
+    assert "{" not in out, "raw dict repr must not leak"
+    assert "ok" not in out.lower() or "False" not in out, "must not dump raw repr"
+
+
 def test_file_list_shows_entry_count() -> None:
     """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
 


### PR DESCRIPTION
**[tui-coder]** — dogfood mining: consolidated ⎿ row summary gaps (memory + recall)

Consolidates #2490 (memory remember/forget) and #2491 (recall chunks + error_message) into one PR per lead-coder request to avoid serial rebase churn on the same function.

## Changes

### 1. `memory_operation__remember_*` — `{saved, layer, path}` → "Saved {slug}"

Returns no `op`/`status`/`tasks`/`entries`/`matches` key → fell through to raw repr.
Add `str`-typed `saved` key check.

### 2. `memory_operation__forget` — `{deleted, layer}` → "Forgot {slug}"

Same missing-key condition. Add `str`-typed `deleted` key check (`isinstance(forgotten, str)` is False for the bool `deleted=True` in file__delete results, so no collision).

### 3. `rag_operation__recall` success — `{chunks, mode}` → "N chunks"

No `op`/`status`/`matches` key → raw repr. Add `chunks` list branch.

### 4. `error_message` str fallback — recall validation + task_ops arg errors

These return `{"ok": False, "error_kind": ..., "error_message": "..."}` with no `error` key. The existing guard only checks `result.get("error")`. Add `error_message` str fallback immediately after.

## Composition safety

Branch order in `_summarize_result` (after #2488):
1. `error` str → early exit (error wins)
2. **new**: `error_message` str → early exit
3. `op == "read"` / `"read" in t + "content"` → "Read N lines"
4. `op == write/create` → "Wrote ..."
5. `op == edit` → "Edited ..."
6. `op == delete` (#2488) → "Deleted ..." (runs before saved/deleted str checks)
7. `op == grep` → "N matches"
8. **new**: `saved` str → "Saved ..."
9. **new**: `forgotten` (deleted) str → "Forgot ..." — `isinstance(str)` False for file__delete's bool `deleted=True`, safe
10. `tasks` list → "N tasks"
11. `entries` list → "Listed N entries"
12. `matches` list → "N matches"
13. **new**: `chunks` list → "N chunks"
14. `kind == "mcp"` + content → first line (#2492 separate PR)
15. `status` → str(status) fallback

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 26 passed (added 4 tests: memory remember, memory forget, recall chunks, error_message)
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 26 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

**Tier self-check**: 4 Tier-2 contract tests; no Tier-4 violations.

Closes #2491 (consolidated here)
part of #2490