### PR TITLE
fix(#2491): recall chunks + error_message ⎿ rows stop leaking raw dicts

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -368,6 +368,9 @@ def _summarize_result(tool, result) -> str:
         error = result.get("error")
         if isinstance(error, str):
             return _short(error, 80)
+        error_message = result.get("error_message")
+        if isinstance(error_message, str):
+            return _short(error_message, 80)
         op = result.get("op")
         path = result.get("path")
         status = result.get("status")
@@ -402,6 +405,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(matches, list):
             n = len(matches)
             return f"{n} match{'es' if n != 1 else ''}"
+        chunks = result.get("chunks")
+        if isinstance(chunks, list):
+            n = len(chunks)
+            return f"{n} chunk{'s' if n != 1 else ''}"
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -131,6 +131,47 @@ def test_file_read_not_found_shows_error_not_zero_lines() -> None:
     assert "{" not in out, "raw dict repr must not leak"
 
 
+def test_recall_success_shows_chunk_count() -> None:
+    """Tier 2: rag_operation__recall success ({chunks, mode}) shows 'N chunks'.
+
+    recall returns {"chunks": [...], "mode": "recall"} with no op/status/matches/
+    entries key, so without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [{"text": "a"}, {"text": "b"}, {"text": "c"}], "mode": "recall"},
+    ) == "3 chunks"
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [{"text": "only"}], "mode": "recall"},
+    ) == "1 chunk"
+    assert summarize_tool_result(
+        "rag_operation__recall",
+        {"chunks": [], "mode": "fallback"},
+    ) == "0 chunks"
+
+
+def test_error_message_field_shown_not_raw_dict() -> None:
+    """Tier 2: dicts with 'error_message' (no 'error' key) show the message.
+
+    recall validation errors return {"ok": False, "error_kind": ..., "error_message": ...}
+    and task_ops returns the same shape for invalid-args/no-context errors.
+    Without the error_message fallback both fell through to raw dict repr.
+    """
+    out = summarize_tool_result(
+        "rag_operation__recall",
+        {
+            "ok": False,
+            "error_kind": "missing_required_arg",
+            "error_message": "recall requires ['query']. Available sources are listed …",
+            "missing": ["query"],
+        },
+    )
+    assert "recall requires" in out
+    assert "{" not in out, "raw dict repr must not leak"
+    assert "ok" not in out.lower() or "False" not in out, "must not dump raw repr"
+
+
 def test_file_list_shows_entry_count() -> None:
     """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
 


### PR DESCRIPTION
**[tui-coder]** — dogfood mining: ⎿ row summary leakage, two gaps

## Gap 1 — `rag_operation__recall` success: `chunks` list not handled

`execute_op` returns `{"chunks": [...], "mode": "recall"}` with no `op`, `status`, `matches`, `entries`, or `tasks` key — fell through to `_short(repr(result), 80)`.

**Fix**: add `chunks` list branch after `matches`:
```python
chunks = result.get("chunks")
if isinstance(chunks, list):
    n = len(chunks)
    return f"{n} chunk{'s' if n != 1 else ''}"
```

## Gap 2 — `error_message` key not checked (recall validation + task_ops arg errors)

`recall` returns `{"ok": False, "error_kind": ..., "error_message": "..."}` on invalid args. `task_ops` returns the same shape for pydantic/no-context errors. The existing guard only checks `result.get("error")` (a different key) so these fell through to raw repr.

**Fix**: add `error_message` str fallback immediately after the `error` check:
```python
error_message = result.get("error_message")
if isinstance(error_message, str):
    return _short(error_message, 80)
```

Before: `  ⎿ {'ok': False, 'error_kind': 'missing_required_arg', 'error_me…`
After:  `  ⎿ recall requires ['query']. Available sources are listed …`

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 23 passed (added `test_recall_success_shows_chunk_count`, `test_error_message_field_shown_not_raw_dict`)
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 23 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

**Tier self-check**: 2 Tier-2 contract tests added; no Tier-4 violations.

part of #2491