### PR TITLE
fix(#2492): MCP tool ⎿ rows show content first line instead of generic 'ok'

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -417,6 +417,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(chunks, list):
             n = len(chunks)
             return f"{n} chunk{'s' if n != 1 else ''}"
+        if result.get("kind") == "mcp":
+            mcp_content = result.get("content")
+            if isinstance(mcp_content, str) and mcp_content:
+                return _short(mcp_content.split("\n")[0], 60)
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -213,6 +213,26 @@ def test_error_message_field_shown_not_raw_dict() -> None:
     assert "ok" not in out.lower() or "False" not in out, "must not dump raw repr"
 
 
+def test_mcp_result_shows_content_first_line() -> None:
+    """Tier 2: MCP tool result (kind='mcp', content='...') shows first content line.
+
+    MCP op results carry {"kind": "mcp", "status": "ok", "content": <joined text>}.
+    Without this branch the status fallback shows the generic 'ok' with no hint of
+    what the MCP tool returned.  The first line of content is the minimal useful
+    preview — it degrades to 'ok' when content is absent or empty.
+    """
+    assert summarize_tool_result(
+        "mcp__github__get_issue",
+        {"kind": "mcp", "status": "ok", "server": "github", "tool": "get_issue",
+         "content": "Issue #42: Fix the thing\nBody: more detail here", "media_blocks": []},
+    ) == "Issue #42: Fix the thing"
+    assert summarize_tool_result(
+        "mcp__slack__get_message",
+        {"kind": "mcp", "status": "ok", "server": "slack", "tool": "get_message",
+         "content": "", "media_blocks": []},
+    ) == "ok"
+
+
 def test_file_list_shows_entry_count() -> None:
     """Tier 2: file__list result ({path, entries}) shows 'Listed N entries'.
 


### PR DESCRIPTION
**[tui-coder]** — dogfood mining: MCP tool ⎿ row UX gap

## Root cause

MCP op results carry `{"kind": "mcp", "status": "ok", "content": <joined MCP text>}`. No existing branch in `_summarize_result` matched the MCP shape, so every non-error MCP tool call fell through to `if status: return str(status)` and showed the generic `"ok"`, giving the user no signal of what the MCP tool actually returned.

## Fix

Add a `kind == "mcp"` guard before the `status` fallback:

```python
if result.get("kind") == "mcp":
    mcp_content = result.get("content")
    if isinstance(mcp_content, str) and mcp_content:
        return _short(mcp_content.split("\n")[0], 60)
```

This shows the first line of the MCP response, truncated at 60 chars. Degrades cleanly to `"ok"` (via status fallback) when content is absent or empty.

Before: `  ⎿ ok`
After:  `  ⎿ Issue #42: Fix the thing`

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 22 passed (added `test_mcp_result_shows_content_first_line`)
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 22 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

**Tier self-check**: 1 Tier-2 contract test added; no Tier-4 violations.

part of #2492