### PR TITLE
fix(#2493): ⎿ rows stop leaking raw dicts for mcp/catalog/index ops

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -417,6 +417,25 @@ def _summarize_result(tool, result) -> str:
         if isinstance(chunks, list):
             n = len(chunks)
             return f"{n} chunk{'s' if n != 1 else ''}"
+        servers = result.get("servers")
+        if isinstance(servers, list):
+            n = len(servers)
+            return f"{n} server{'s' if n != 1 else ''}"
+        mcp_tools = result.get("mcp_tools")
+        if isinstance(mcp_tools, list):
+            n = len(mcp_tools)
+            return f"{n} tool{'s' if n != 1 else ''}"
+        items = result.get("items")
+        if isinstance(items, list):
+            n = len(items)
+            return f"{n} item{'s' if n != 1 else ''}"
+        chunks_dropped = result.get("chunks_dropped")
+        if isinstance(chunks_dropped, int):
+            n = chunks_dropped
+            return f"Dropped {n} chunk{'s' if n != 1 else ''}"
+        if isinstance(result.get("input_schema"), dict):
+            name_or_desc = result.get("name") or result.get("description") or ""
+            return _short(str(name_or_desc), 60)
         if result.get("kind") == "mcp":
             mcp_content = result.get("content")
             if isinstance(mcp_content, str) and mcp_content:

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -276,6 +276,90 @@ def test_file_glob_shows_match_count() -> None:
     ) == "1 match"
 
 
+def test_list_mcp_servers_shows_server_count() -> None:
+    """Tier 2: list_mcp_servers result ({servers: [...]}) shows 'N servers'.
+
+    list_mcp_servers returns {"servers": [...]} with no op/status/error key;
+    without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "list_mcp_servers", {"servers": ["github", "slack", "linear"]}
+    ) == "3 servers"
+    assert summarize_tool_result(
+        "list_mcp_servers", {"servers": ["only"]}
+    ) == "1 server"
+    assert summarize_tool_result(
+        "list_mcp_servers", {"servers": []}
+    ) == "0 servers"
+
+
+def test_list_mcp_tools_shows_tool_count() -> None:
+    """Tier 2: list_mcp_tools result ({mcp_tools: [...]}) shows 'N tools'.
+
+    list_mcp_tools returns {"mcp_tools": [...]} with no op/status/error key;
+    without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "list_mcp_tools",
+        {"mcp_tools": [{"name": "github__get_issue"}, {"name": "github__list_prs"}]},
+    ) == "2 tools"
+    assert summarize_tool_result(
+        "list_mcp_tools", {"mcp_tools": [{"name": "slack__send_message"}]}
+    ) == "1 tool"
+
+
+def test_search_actions_shows_item_count() -> None:
+    """Tier 2: search_actions/list_actions result ({items: [...], total: N}) shows 'N items'.
+
+    Both search_actions and list_actions return {"items": [...], "total": N} with no
+    op/status/error key; without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "search_actions", {"items": [{"qualified_name": "file__read"}, {"qualified_name": "file__write"}], "total": 2}
+    ) == "2 items"
+    assert summarize_tool_result(
+        "list_actions", {"items": [], "total": 0}
+    ) == "0 items"
+    assert summarize_tool_result(
+        "search_actions", {"items": [{"qualified_name": "recall"}], "total": 1}
+    ) == "1 item"
+
+
+def test_index_drop_shows_chunks_dropped() -> None:
+    """Tier 2: index_drop result ({removed: bool, chunks_dropped: int}) shows 'Dropped N chunks'.
+
+    index_drop returns {"removed": bool, "chunks_dropped": int} with no op/status/error key;
+    without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "index_drop", {"removed": True, "chunks_dropped": 7}
+    ) == "Dropped 7 chunks"
+    assert summarize_tool_result(
+        "index_drop", {"removed": True, "chunks_dropped": 1}
+    ) == "Dropped 1 chunk"
+    assert summarize_tool_result(
+        "index_drop", {"removed": False, "chunks_dropped": 0}
+    ) == "Dropped 0 chunks"
+
+
+def test_describe_tool_shows_name_not_raw_dict() -> None:
+    """Tier 2: describe_action/describe_mcp_tool result ({input_schema, name/description}) shows name.
+
+    Both tools return a dict with an 'input_schema' key (dict) and a 'name' or 'description'
+    key.  Without this branch the raw schema dict leaked into the ⎿ row.
+    """
+    assert summarize_tool_result(
+        "describe_mcp_tool",
+        {"name": "get_issue", "description": "Get a GitHub issue", "input_schema": {"type": "object"}},
+    ) == "get_issue"
+    out = summarize_tool_result(
+        "describe_action",
+        {"description": "Lists actions by category", "input_schema": {"properties": {}}},
+    )
+    assert "Lists actions" in out
+    assert "{" not in out, "raw dict repr must not leak"
+
+
 def test_dict_with_status_shows_status() -> None:
     """Tier 2: an opaque dict with a status field shows the status."""
     assert summarize_tool_result("mcp__call", {"status": "ok", "x": 1}) == "ok"


### PR DESCRIPTION
**[tui-coder]** — part of inline `_summarize_result` dogfood mining arc.

## What

Five remaining raw-dict leakage gaps in `_summarize_result` — result shapes with no `op`/`status`/`error` key that fell through to `_short(result, 80)` and emitted raw dict repr into ⎿ rows:

| Tool | Result shape | Before | After |
|---|---|---|---|
| `list_mcp_servers` | `{servers: list}` | `{'servers': ['github', ...]}` | `3 servers` |
| `list_mcp_tools` | `{mcp_tools: list}` | `{'mcp_tools': [...]}` | `2 tools` |
| `search_actions` / `list_actions` | `{items: list, total: N}` | `{'items': [...], 'total': 5}` | `5 items` |
| `index_drop` | `{removed: bool, chunks_dropped: int}` | `{'removed': True, 'chunks_dropped': 7}` | `Dropped 7 chunks` |
| `describe_mcp_tool` / `describe_action` | `{input_schema: dict, name/description: str}` | `{'name': 'get_issue', 'description': '...', 'input_schema': {...}}` | `get_issue` |

## How

Added 5 new branches in `_summarize_result` (after `chunks` list, before `kind=="mcp"` check):
- `servers` list → `"N server(s)"`
- `mcp_tools` list → `"N tool(s)"`
- `items` list → `"N item(s)"`
- `chunks_dropped` int → `"Dropped N chunk(s)"`
- `input_schema` dict guard → name or description preview (for describe-type results)

All branches sit below the `error`/`error_message` guard and above the `status` fallback. No shadowing with existing op/kind branches.

## Tests

5 Tier-2 tests added (suite: 27 → 32):
- `test_list_mcp_servers_shows_server_count`
- `test_list_mcp_tools_shows_tool_count`
- `test_search_actions_shows_item_count`
- `test_index_drop_shows_chunks_dropped`
- `test_describe_tool_shows_name_not_raw_dict`

## CI gates (all green locally)
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py`
- [x] `pytest tests/test_inline_tool_result_summary.py` (32/32)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py`

**Tier self-check**: 5 Tier-2 tests added; no Tier-4 violations.