### PR TITLE
refactor(skill-word): ②d — remove dead active_skill_run_ids (recovery-gated, truncate-falsify)

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -52,9 +52,6 @@ class AgentSnapshot:
     # field set serialized as a dict ({chain_id, origin_agent, origin_depth,
     # original_request, waiting_on: list}).
     pending_chains: dict[str, dict] = field(default_factory=dict)
-    # NEW (skill resume design — PR-state-foundation):
-    # run_ids of skills currently executing under this agent.
-    active_skill_run_ids: list[str] = field(default_factory=list)
     # Outstanding (unresolved) interventions keyed by intervention_id.
     outstanding_interventions: dict[str, dict] = field(default_factory=dict)
     # R-D12: durable buffered intervention answers keyed by skill_run_id.
@@ -121,9 +118,6 @@ class AgentSnapshot:
             applied_seq=_coerce_int(data.get("applied_seq", 0)),
             inbox=list(data.get("inbox", []) or []),
             pending_chains=dict(data.get("pending_chains", {}) or {}),
-            active_skill_run_ids=list(
-                data.get("active_skill_run_ids", []) or []
-            ),
             outstanding_interventions=dict(
                 data.get("outstanding_interventions", {}) or {}
             ),
@@ -146,7 +140,6 @@ class AgentSnapshot:
             "applied_seq": self.applied_seq,
             "inbox": self.inbox,
             "pending_chains": self.pending_chains,
-            "active_skill_run_ids": self.active_skill_run_ids,
             "outstanding_interventions": self.outstanding_interventions,
             "buffered_intervention_answers": self.buffered_intervention_answers,
             "next_turn_context": self.next_turn_context,
@@ -240,18 +233,11 @@ class AgentSnapshot:
                 chain["waiting_on"] = list(event.get("waiting_on", []))
         elif kind in ("chain_resolve", "chain_timeout_fired"):
             self.pending_chains.pop(event.get("chain_id"), None)
-        # ── skill resume kinds (PR-state-foundation) ────────────────────
-        elif kind == "skill_started":
-            run_id = event.get("run_id")
-            if run_id and run_id not in self.active_skill_run_ids:
-                self.active_skill_run_ids.append(run_id)
-        elif kind in ("skill_completed", "skill_discarded"):
-            # PR-resume-ux β: skill_discarded prunes active_skill_run_ids
-            # the same way skill_completed does — both are terminal states
-            # from the agent-snapshot perspective.
-            run_id = event.get("run_id")
-            if run_id and run_id in self.active_skill_run_ids:
-                self.active_skill_run_ids.remove(run_id)
+        # Note: skill_started / skill_completed / skill_discarded are still
+        # valid WAL kinds (read by the replay/rewind engine) but no longer
+        # mutate agent-snapshot state — the per-skill run-id tracking they
+        # populated was removed with the skill runtime. An old-WAL skill_*
+        # entry therefore falls through here (no-op) on reconstruction.
         elif kind == "intervention_dispatched":
             iv_id = event.get("intervention_id")
             if iv_id:

--- a/tests/test_agent_snapshot.py
+++ b/tests/test_agent_snapshot.py
@@ -17,23 +17,20 @@ def _event(kind: str, seq: int = 1, **fields) -> dict:
 # ── new field round-trip ──────────────────────────────────────────────────────
 
 def test_new_fields_default_values():
-    """Tier 2: new fields default to empty list / empty dict."""
+    """Tier 2: outstanding_interventions defaults to empty dict."""
     snap = AgentSnapshot.empty("agent_new")
-    assert snap.active_skill_run_ids == []
     assert snap.outstanding_interventions == {}
 
 
 def test_new_fields_save_load_roundtrip(tmp_path: Path):
-    """Tier 2: active_skill_run_ids and outstanding_interventions survive save/load."""
+    """Tier 2: outstanding_interventions survives save/load."""
     path = tmp_path / "snapshot.json"
     snap = AgentSnapshot.empty("agent_y")
-    snap.active_skill_run_ids = ["run-1", "run-2"]
     snap.outstanding_interventions = {"iv-A": {"question": "ok?"}}
 
     snap.save(path)
     loaded = AgentSnapshot.load("agent_y", path)
 
-    assert loaded.active_skill_run_ids == ["run-1", "run-2"]
     assert loaded.outstanding_interventions == {"iv-A": {"question": "ok?"}}
 
 
@@ -51,45 +48,33 @@ def test_old_snapshot_without_new_fields_loads_with_defaults(tmp_path: Path):
 
     snap = AgentSnapshot.load("agent_old", path)
     assert snap.applied_seq == 7
-    assert snap.active_skill_run_ids == []
     assert snap.outstanding_interventions == {}
 
 
-# ── apply_events: skill_started / skill_completed ───────────────────────────
+# ── legacy skill-run snapshot field is ignored (② skill-recovery-state removal) ──
 
-def test_apply_skill_started_adds_run_id():
-    """Tier 2: skill_started event appends run_id to active_skill_run_ids."""
-    snap = _snap()
-    snap.apply_events([_event("skill_started", seq=1, run_id="run-abc")])
-    assert "run-abc" in snap.active_skill_run_ids
+def test_old_snapshot_with_legacy_active_skill_run_ids_ignored(tmp_path: Path):
+    """Tier 2c: a pre-existing snapshot carrying the removed ``active_skill_run_ids``
+    key deserialises without error — the removed field is silently ignored while
+    the kept fields still load. Migration-safety for the field removal (the
+    skill runtime that populated it is gone; nothing consumes the field)."""
+    path = tmp_path / "snapshot_legacy.json"
+    legacy_payload = {
+        "version": 1,
+        "applied_seq": 3,
+        "inbox": [],
+        "pending_chains": {},
+        # removed field still present in an old on-disk snapshot:
+        "active_skill_run_ids": ["run-legacy-1", "run-legacy-2"],
+        "outstanding_interventions": {"iv-keep": {"q": "?"}},
+    }
+    path.write_text(json.dumps(legacy_payload), encoding="utf-8")
 
-
-def test_apply_skill_started_idempotent():
-    """Tier 2: duplicate skill_started events don't add run_id twice."""
-    snap = _snap()
-    snap.apply_events([
-        _event("skill_started", seq=1, run_id="run-dup"),
-        _event("skill_started", seq=2, run_id="run-dup"),
-    ])
-    assert snap.active_skill_run_ids.count("run-dup") == 1
-    assert snap.applied_seq == 2
-
-
-def test_apply_skill_completed_removes_run_id():
-    """Tier 2: skill_completed removes run_id from active_skill_run_ids."""
-    snap = _snap()
-    snap.apply_events([
-        _event("skill_started", seq=1, run_id="run-xyz"),
-        _event("skill_completed", seq=2, run_id="run-xyz"),
-    ])
-    assert "run-xyz" not in snap.active_skill_run_ids
-
-
-def test_apply_skill_completed_unknown_run_id_noop():
-    """Tier 2: skill_completed for unknown run_id is a no-op (no KeyError)."""
-    snap = _snap()
-    snap.apply_events([_event("skill_completed", seq=1, run_id="ghost")])
-    assert snap.active_skill_run_ids == []
+    snap = AgentSnapshot.load("agent_legacy", path)  # must not raise
+    assert not hasattr(snap, "active_skill_run_ids")  # field is gone
+    # kept fields load correctly; the removed key is silently dropped
+    assert snap.applied_seq == 3
+    assert snap.outstanding_interventions == {"iv-keep": {"q": "?"}}
 
 
 # ── apply_events: intervention_dispatched / intervention_resolved ─────────────
@@ -135,18 +120,84 @@ def test_apply_intervention_resolved_unknown_noop():
 
 # ── skill-internal kinds don't mutate agent snapshot ─────────────────────────
 
-def test_skill_internal_kinds_are_noop():
-    """Tier 2: skill_phase_advanced, step_* and skill_resumed don't raise or mutate agent fields."""
+def test_skill_kinds_are_snapshot_noop():
+    """Tier 2: every skill_* kind (skill_started/phase_advanced/completed/discarded/
+    resumed) and step_* is still a valid WAL kind — read by the replay/rewind engine —
+    but does NOT mutate agent-snapshot state on reconstruction. So an old-WAL
+    skill_started (which previously populated the removed active_skill_run_ids)
+    now falls through cleanly: no raise, no mutation. This is the reconstruction-
+    safety guarantee for the per-skill run-id-tracking removal."""
     snap = _snap()
     events = [
-        _event("skill_phase_advanced", seq=1, run_id="r", next_phase="p2"),
-        _event("step_started", seq=2, run_id="r", op="file/read"),
-        _event("step_completed", seq=3, run_id="r", op="file/read", result="ok"),
-        _event("step_failed", seq=4, run_id="r", op="mcp/tool", error="timeout"),
-        _event("skill_resumed", seq=5, run_id="r"),
+        _event("skill_started", seq=1, run_id="r"),
+        _event("skill_phase_advanced", seq=2, run_id="r", next_phase="p2"),
+        _event("step_started", seq=3, run_id="r", op="file/read"),
+        _event("step_completed", seq=4, run_id="r", op="file/read", result="ok"),
+        _event("step_failed", seq=5, run_id="r", op="mcp/tool", error="timeout"),
+        _event("skill_resumed", seq=6, run_id="r"),
+        _event("skill_completed", seq=7, run_id="r"),
+        _event("skill_discarded", seq=8, run_id="r"),
     ]
-    snap.apply_events(events)
-    # Agent-level tracking fields remain untouched
-    assert snap.active_skill_run_ids == []
+    snap.apply_events(events)  # must not raise on any skill_* kind
+    # Agent-level state is untouched by every skill_* / step_* kind
     assert snap.outstanding_interventions == {}
-    assert snap.applied_seq == 5
+    assert snap.pending_chains == {}
+    assert snap.applied_seq == 8
+
+
+# ── recovery gate: truncate-falsify for the active_skill_run_ids removal ──────
+
+def test_truncate_falsify_snapshot_backed_kept_state_survives(tmp_path: Path):
+    """Tier 2c: removing active_skill_run_ids does not regress crash-recovery
+    (CLAUDE.md recovery gate) — a SNAPSHOT-BACKED kept state survives WAL
+    truncation below its source seq, and an old-WAL skill_started falls through.
+
+    Per #2259/#2260 ([[feedback_recovery_source_must_survive_truncation_review_gate]]):
+    ONLY snapshot-backed reconstruction survives truncation; a WAL-only state is
+    lost. This test's survival assertion is meaningful precisely because the kept
+    state (``outstanding_interventions``) is APPLIED BEFORE ``serialize()`` — so
+    ``applied_seq`` bakes it INTO the snapshot. The WAL-only control at the end
+    proves the assertion is not trivially passing.
+    """
+    # 1. Apply, BEFORE serialize: a legacy skill_started (dead → no-op) + the KEPT
+    #    intervention. Both land at seq<=2 → baked into applied_seq=2 (snapshot).
+    snap = _snap()
+    snap.apply_events([
+        _event("skill_started", seq=1, run_id="legacy-run"),
+        _event("intervention_dispatched", seq=2, intervention_id="iv-keep",
+               iv_dict={"q": "resume?"}),
+    ])
+    assert snap.applied_seq == 2
+    assert "iv-keep" in snap.outstanding_interventions
+
+    # 2. Serialize → the snapshot carries the intervention + applied_seq=2.
+    snap.save(tmp_path / "snap.json")
+    reloaded = AgentSnapshot.load("agent_x", tmp_path / "snap.json")
+    assert reloaded.applied_seq == 2                       # baked-in seq
+    assert "iv-keep" in reloaded.outstanding_interventions  # snapshot-backed
+
+    # 3. TRUNCATE: the source WAL entries at seq<=2 (the legacy skill_started AND
+    #    the intervention_dispatched) are gone. Replaying them is a no-op because
+    #    apply_events skips seq<=applied_seq — so the intervention survives ONLY
+    #    via the snapshot, and the legacy skill_started never raises.
+    reloaded.apply_events([
+        _event("skill_started", seq=1, run_id="legacy-run"),
+        _event("intervention_dispatched", seq=2, intervention_id="iv-keep",
+               iv_dict={"q": "resume?"}),
+    ])
+    assert "iv-keep" in reloaded.outstanding_interventions   # survived truncation
+    assert not hasattr(reloaded, "active_skill_run_ids")     # removed field gone
+
+    # 4. WAL-only CONTROL — proves the step-3 survival is snapshot-backed, not
+    #    trivial. A chain_register at seq=3 lands AFTER the snapshot (applied_seq=2)
+    #    = WAL-only. It is PRESENT when its WAL entry is replayed, but LOST when
+    #    reconstruction truncates that WAL entry — the opposite of the snapshot-
+    #    backed intervention, which survived the SAME truncation.
+    chain_ev = _event("chain_register", seq=3, chain_id="c-walonly",
+                      origin_agent="a", origin_depth=0, original_request="x")
+    replayed = AgentSnapshot.load("agent_x", tmp_path / "snap.json")  # applied_seq=2
+    replayed.apply_events([chain_ev])                 # WAL entry replayed
+    assert "c-walonly" in replayed.pending_chains     # present WITH its WAL entry
+    truncated = AgentSnapshot.load("agent_x", tmp_path / "snap.json")  # applied_seq=2
+    truncated.apply_events([])                         # chain@seq3 WAL entry truncated
+    assert "c-walonly" not in truncated.pending_chains  # WAL-only state LOST

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -88,7 +88,6 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
         "applied_seq": "replaced wholesale by journal.install (no separate holder)",
         "inbox": "session.inbox drained",
         "pending_chains": "session._chains.reset()",
-        "active_skill_run_ids": "session.running_skills (+ started_at / chain) cleared",
         "outstanding_interventions": "session._interventions.clear() + restore tasks",
         "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
         "next_turn_context": "session._next_turn_context cleared",


### PR DESCRIPTION
**[e2e-coder]** — ②d (final skill-word slice, **recovery-gated**): remove the dead `active_skill_run_ids` AgentSnapshot field. Evidence was lead-reviewed; this narrowed scope followed a **self-caught evidence gap** (see below). **Lead requested reviewing the actual truncate-falsify test (not-trivially-pass).**

## What & why
`active_skill_run_ids` was a durable snapshot field populated ONLY by the skill_started/completed/discarded reconstruction branches. The skill runtime is gone → **0 live writers** of those WAL events, and **nothing consumes the field** (write-only dead state).

## Scope (narrowed after self-caught gap)
- **Remove**: the `active_skill_run_ids` field + to_payload/from_dict serialization + the skill_started/completed/discarded apply_events branches.
- **KEEP**: skill_* WAL kinds (`state_log.py` unchanged) — they have **live readers** (ReplayEngine skill-frames, registry rewind-point "phase", session context-preserve), exactly like step_*. An old-WAL skill_started now **falls through cleanly** on reconstruction (no raise, no mutation). `buffered_intervention_answers` KEPT (separate live intervention field).
- **Self-catch**: my first ②d evidence said "remove the skill_* WAL cluster" — I'd checked writers + agent_snapshot reconstruction but **missed the replay/rewind readers**. Caught it *before any edit*, corrected the evidence, lead re-scoped to active_skill_run_ids-only. Zero wrong removal.

## Recovery gate — the truncate-falsify test (please scrutinise)
`test_truncate_falsify_snapshot_backed_kept_state_survives`:
- Applies a KEPT `outstanding_interventions` (intervention_dispatched) **BEFORE serialize** → `applied_seq=2` bakes it into the snapshot.
- Reconstructs from the snapshot with the seq≤2 WAL entries **truncated** (skipped on re-apply) → the intervention **survives via the snapshot**; the legacy skill_started never raises.
- **WAL-only control**: a `chain_register` at seq=3 (after the snapshot) is **present when its WAL entry is replayed** but **LOST when truncated** — proving the survival assertion is snapshot-backed, not trivial (#2259/#2260, [[feedback_recovery_source_must_survive_truncation_review_gate]]).
- Plus: old-snapshot-carrying-the-removed-key deserialises cleanly; every skill_* kind is a reconstruction no-op.

## NOT in this PR (owner-escalate, lead-tracked)
Removing the skill_* WAL kinds + their reader code (ReplayEngine/registry/session) = skill-scoped replay/rewind **analysis feature** removal, not dead-code cleanup.

## Test plan
- [x] `ruff` — clean · `tier-audit` — 0 errors · `module-docstrings` — OK
- [x] full `pytest` — **6962 passed, 16 skipped**
- [x] truncate-falsify with snapshot-backed KEPT state + WAL-only control (non-trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)