### PR TITLE
fix(#2496): ⎿ rows stop leaking raw dicts for judge_output + web_search results

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -429,6 +429,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(items, list):
             n = len(items)
             return f"{n} item{'s' if n != 1 else ''}"
+        results = result.get("results")
+        if isinstance(results, list):
+            n = len(results)
+            return f"{n} result{'s' if n != 1 else ''}"
         chunks_dropped = result.get("chunks_dropped")
         if isinstance(chunks_dropped, int):
             n = chunks_dropped
@@ -440,6 +444,11 @@ def _summarize_result(tool, result) -> str:
             mcp_content = result.get("content")
             if isinstance(mcp_content, str) and mcp_content:
                 return _short(mcp_content.split("\n")[0], 60)
+        passed = result.get("passed")
+        if isinstance(passed, bool):
+            score = result.get("score")
+            pct = f" ({score:.2f})" if isinstance(score, (int, float)) else ""
+            return ("Passed" if passed else "Failed") + pct
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -384,3 +384,48 @@ def test_unknown_shape_degrades_without_raising() -> None:
     weird = {"op": object(), "nested": [object()]}
     out = summarize_tool_result("x", weird)
     assert isinstance(out, str) and out  # some non-empty summary, no crash
+
+
+def test_judge_output_passed_shows_score() -> None:
+    """Tier 2: judge_output pass result shows 'Passed (score)' not raw dict.
+
+    judge_output returns {kind, score, passed, reason, threshold, on_fail} with no
+    status key; without this branch the raw dict repr leaked into the ⎿ row.
+    """
+    out = summarize_tool_result(
+        "judge_output",
+        {"kind": "judge_output", "score": 0.85, "passed": True,
+         "reason": "looks good", "threshold": 0.7, "on_fail": "retry"},
+    )
+    assert out == "Passed (0.85)"
+    assert "{" not in out
+
+
+def test_judge_output_failed_shows_score() -> None:
+    """Tier 2: judge_output fail result shows 'Failed (score)' not raw dict."""
+    out = summarize_tool_result(
+        "judge_output",
+        {"kind": "judge_output", "score": 0.23, "passed": False,
+         "reason": "incomplete", "threshold": 0.7, "on_fail": "retry"},
+    )
+    assert out == "Failed (0.23)"
+    assert "{" not in out
+
+
+def test_web_search_results_shows_count() -> None:
+    """Tier 2: web_search result ({kind, query, status, results: [...]}) shows 'N results'.
+
+    web_search returns {"kind": "web_search", "results": [...], "status": "ok"};
+    adding the 'results' list key means N results is shown rather than the generic 'ok'.
+    """
+    out = summarize_tool_result(
+        "web_search",
+        {"kind": "web_search", "query": "python asyncio", "backend": "brave",
+         "status": "ok", "results": [{"title": "A"}, {"title": "B"}, {"title": "C"}]},
+    )
+    assert out == "3 results"
+    out1 = summarize_tool_result(
+        "web_search",
+        {"kind": "web_search", "query": "x", "status": "ok", "results": [{"title": "X"}]},
+    )
+    assert out1 == "1 result"


### PR DESCRIPTION
**[tui-coder]** — part of inline ⎿-row raw-dict leakage mining wave

## Summary

Two gaps found by systematic tool-shape scan after #2494 merged:

- **`judge_output` success** — `{kind, score, passed, reason, threshold, on_fail}` has **no `status` key**, so fell straight to `_short(result, 80)` repr in the ⎿ row. New `passed` bool branch shows `"Passed (0.85)"` / `"Failed (0.23)"`.
- **`web_search` results list** — `{kind, query, status: "ok", results: [...]}` was showing `"ok"` via the generic status branch. New `results` list key is now handled before `status` fires, showing `"N results"` instead.

Both branches sit after error guards and before the `status` fallback — no shadowing with existing branches.

35 tests total (+3: `test_judge_output_passed_shows_score`, `test_judge_output_failed_shows_score`, `test_web_search_results_shows_count`).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 35 OK, 0 Tier-4
- [x] `pytest` — 6958 passed, 17 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all new tests are Tier 2 (public API `summarize_tool_result`, real dict inputs, no mocks, behavioral not format-pinned).