### PR TITLE
fix(#2497): ⎿ rows show informative summaries for mkdir/move/exec/cron ops

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -395,6 +395,11 @@ def _summarize_result(tool, result) -> str:
             count = result.get("count")
             n = int(count) if isinstance(count, (int, float)) else 0
             return f"{n} match{'es' if n != 1 else ''}"
+        if op == "mkdir":
+            return f"Created {path}" if path else "Created directory"
+        if op == "move":
+            dest = result.get("dest_path")
+            return f"Moved to {dest}" if dest else "Moved"
         saved = result.get("saved")
         if isinstance(saved, str):
             return f"Saved {saved}"
@@ -433,6 +438,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(results, list):
             n = len(results)
             return f"{n} result{'s' if n != 1 else ''}"
+        jobs = result.get("jobs")
+        if isinstance(jobs, list):
+            n = len(jobs)
+            return f"{n} job{'s' if n != 1 else ''}"
         chunks_dropped = result.get("chunks_dropped")
         if isinstance(chunks_dropped, int):
             n = chunks_dropped
@@ -449,6 +458,9 @@ def _summarize_result(tool, result) -> str:
             score = result.get("score")
             pct = f" ({score:.2f})" if isinstance(score, (int, float)) else ""
             return ("Passed" if passed else "Failed") + pct
+        returncode = result.get("returncode")
+        if isinstance(returncode, int) and status == "ok":
+            return f"exit {returncode}"
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -429,3 +429,77 @@ def test_web_search_results_shows_count() -> None:
         {"kind": "web_search", "query": "x", "status": "ok", "results": [{"title": "X"}]},
     )
     assert out1 == "1 result"
+
+
+def test_file_mkdir_shows_created_path() -> None:
+    """Tier 2: file mkdir result (op='mkdir', path=...) shows 'Created {path}'.
+
+    file__mkdir returns {kind, op='mkdir', path, status='ok', created: bool} with
+    no matching op branch; without this fix it falls to status → shows 'ok'.
+    """
+    assert summarize_tool_result(
+        "file__mkdir",
+        {"kind": "file", "op": "mkdir", "path": "src/new/", "status": "ok", "created": True},
+    ) == "Created src/new/"
+    assert summarize_tool_result(
+        "file__mkdir", {"op": "mkdir"}
+    ) == "Created directory"
+
+
+def test_file_move_shows_destination() -> None:
+    """Tier 2: file move result (op='move', dest_path=...) shows 'Moved to {dest}'.
+
+    file__move returns {kind, op='move', path, dest_path, status='ok', moved: True}
+    with no matching op branch; without this fix it falls to status → shows 'ok'.
+    """
+    assert summarize_tool_result(
+        "file__move",
+        {"kind": "file", "op": "move", "path": "old.py", "dest_path": "new.py",
+         "status": "ok", "moved": True},
+    ) == "Moved to new.py"
+    assert summarize_tool_result(
+        "file__move", {"op": "move"}
+    ) == "Moved"
+
+
+def test_cron_list_shows_job_count() -> None:
+    """Tier 2: cron_list result ({status, source, jobs: [...]}) shows 'N jobs'.
+
+    cron_list returns {"status": "ok", "source": "...", "jobs": [...]} — 'jobs' is
+    not in the covered list-key set so without this branch it falls to status → 'ok'.
+    """
+    assert summarize_tool_result(
+        "cron_list",
+        {"status": "ok", "source": "live_scheduler",
+         "jobs": [{"name": "nightly"}, {"name": "weekly"}]},
+    ) == "2 jobs"
+    assert summarize_tool_result(
+        "cron_list", {"status": "ok", "source": "config_file", "jobs": [{"name": "daily"}]}
+    ) == "1 job"
+    assert summarize_tool_result(
+        "cron_list", {"status": "ok", "source": "live_scheduler", "jobs": []}
+    ) == "0 jobs"
+
+
+def test_sandboxed_exec_ok_shows_exit_code() -> None:
+    """Tier 2: sandboxed_exec success (returncode int, status='ok') shows 'exit N'.
+
+    sandboxed_exec returns {kind, status, returncode, stdout, stderr, ...}; for
+    status='ok' (exit 0) the generic 'ok' is unhelpful. 'timeout'/'cancelled' are
+    already informative via the status branch and are not overridden.
+    """
+    assert summarize_tool_result(
+        "sandboxed_exec",
+        {"kind": "sandboxed_exec", "status": "ok", "backend": "subprocess",
+         "returncode": 0, "stdout": "hello", "stderr": "", "truncated": False},
+    ) == "exit 0"
+    assert summarize_tool_result(
+        "sandboxed_exec",
+        {"kind": "sandboxed_exec", "status": "timeout", "backend": "subprocess",
+         "returncode": -1, "stdout": "", "stderr": "", "truncated": False},
+    ) == "timeout"
+    assert summarize_tool_result(
+        "sandboxed_exec",
+        {"kind": "sandboxed_exec", "status": "cancelled", "backend": "subprocess",
+         "returncode": -1, "stdout": "", "stderr": "", "truncated": False},
+    ) == "cancelled"


### PR DESCRIPTION
**[tui-coder]** — part of inline ⎿-row raw-dict leakage mining wave

## Summary

4 branches — all cases where the generic `status → "ok"` fallback fired, burying the useful payload:

- **`op="mkdir"`** → `"Created {path}"` — `file__mkdir` returns `{op, path, status:"ok", created:bool}`; op had no branch, fell to `"ok"`.
- **`op="move"`** → `"Moved to {dest_path}"` — `file__move` returns `{op, path, dest_path, status:"ok", moved:True}`; same gap.
- **`jobs` list key** → `"N jobs"` — `cron_list` returns `{status:"ok", source, jobs:[...]}`;  `"jobs"` was not in the list-key set so status fired showing `"ok"`.
- **`returncode` int + `status=="ok"` guard** → `"exit {returncode}"` — `sandboxed_exec` success always has `returncode=0` but showed `"ok"`. `timeout`/`cancelled`/`error` paths unaffected (their status strings are already informative and returncode guard only fires on `status=="ok"`).

All new branches sit after error guards; no shadowing of existing branches.

36 tests total (+4: `test_file_mkdir_shows_created_path`, `test_file_move_shows_destination`, `test_cron_list_shows_job_count`, `test_sandboxed_exec_ok_shows_exit_code`).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 36 OK, 0 Tier-4
- [x] `pytest` — 6957 passed, 17 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all new tests are Tier 2 (public API `summarize_tool_result`, real dict inputs, no mocks, behavioral not format-pinned).