### PR TITLE
refactor(skill-word): ②-comments-1 — de-skill universal_catalog docstrings + agent_snapshot comment

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -54,10 +54,10 @@ class AgentSnapshot:
     pending_chains: dict[str, dict] = field(default_factory=dict)
     # Outstanding (unresolved) interventions keyed by intervention_id.
     outstanding_interventions: dict[str, dict] = field(default_factory=dict)
-    # R-D12: durable buffered intervention answers keyed by skill_run_id.
+    # R-D12: durable buffered intervention answers keyed by run_id.
     # Populated when the user answers an intervention post-restart but
-    # before the resuming skill consumes it. Survives a *second* crash
-    # so the answer is replayed when the skill finally resumes (the
+    # before the resuming run consumes it. Survives a *second* crash
+    # so the answer is replayed when the run finally resumes (the
     # in-memory ``_buffered_intervention_answers`` dict in Session
     # is the runtime cache; this field is its on-disk durable form).
     # Each value is ``{"text": str, "choice_id": str | None}``.

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -6,7 +6,7 @@ This module defines the 4 universal wrapper ToolDefinitions
 canonical 13-category enum that FP-0034 establishes.
 
 Per FP-0034 §D1, the universal catalog replaces the per-category
-discover ops (= ``list_skills`` / ``list_mcp_tools`` / ``list_memory``
+discover ops (= ``list_mcp_tools`` / ``list_memory``
 etc.) with 4 wrappers that cover all 13 categories uniformly. Per
 §D18, qualified names use ``<category>__<entry_name>`` format with
 ``__`` (double underscore) as the separator. Inside ``entry_name``
@@ -532,7 +532,7 @@ def _enumerate_static_category(category: str) -> list[dict[str, str]]:
     universal_dispatch._OPERATION_RULES. Their short_description comes
     from the target ToolDefinition in the registry.
 
-    Resource categories (skill / agent.peer / mcp.{server,tool} /
+    Resource categories (agent.peer / mcp.{server,tool} /
     memory_entry / rag_corpus) are NOT handled here — they need caller
     state (= ctx.router_state.available_*). See _enumerate_category.
     """
@@ -617,7 +617,7 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
         reyn_source / rag_operation / mcp.operation) →
         _enumerate_static_category (= populated via universal_dispatch's
         ``_OPERATION_RULES`` table)
-      - Resource categories → consult ctx.router_state (skills /
+      - Resource categories → consult ctx.router_state (
         agents / mcp_servers / mcp_servers[*].tools / list_memory_fn /
         available_rag_sources)
       - Categories without state-binding yet (exec) →
@@ -1117,7 +1117,7 @@ def catalog_entries(ctx: ToolContext) -> list[dict[str, Any]]:
 
     Deterministic ``name`` sort (stable ``tools=`` ordering → replay-fixture
     stability). **Pass a ``ToolContext`` with ``router_state`` populated** or the
-    resource categories (skills / agents / mcp_servers / …) enumerate empty and
+    resource categories (agents / mcp_servers / …) enumerate empty and
     only static categories survive (the "usable this session" semantics).
     """
     from reyn.tools import get_default_registry
@@ -1154,9 +1154,9 @@ async def _handle_describe_action(
     ``.parameters`` directly — which is correct for operation-category
     actions (web__fetch / file__read / …) whose target IS the action.
 
-    For resource-category actions (``skill__X``, ``agent.peer__X``,
+    For resource-category actions (``agent.peer__X``,
     ``mcp.tool__X.Y``, ``mcp.server__X``, ``rag_corpus__X``) the target
-    is a generic dispatcher (``invoke_skill`` / ``delegate_to_agent`` /
+    is a generic dispatcher (``delegate_to_agent`` /
     ``call_mcp_tool`` / …) whose ``.parameters`` is the dispatcher's
     own args shape, NOT the resource's actual input schema. D2-full
     extends the handler to look up the per-resource schema via
@@ -1278,8 +1278,6 @@ def _resource_input_schema(
     parameters).
 
     Covered:
-      - ``skill__<name>`` — uses ``ctx.router_state.host.list_available_skills()``
-        which carries ``input_schema`` after FP-0034 D2-full.
       - ``agent.peer__<name>`` — ``delegate_to_agent`` parameters minus ``to``.
       - ``mcp.server__<name>`` — empty object (``list_mcp_tools`` takes
         only the curried ``server`` arg).
@@ -1340,8 +1338,6 @@ def _resource_description(
 
     Covered (= categories with per-resource description metadata on the
     host side):
-      - ``skill__<name>`` — pulls ``description`` from
-        ``ctx.router_state.host.list_available_skills()``.
       - ``agent.peer__<name>`` — pulls ``description`` (or ``role``
         fallback) from ``ctx.router_state.host.list_available_agents()``.
       - ``mcp__<server>__<tool>`` — pulls ``description`` from the tool's
@@ -1361,7 +1357,7 @@ def _resource_description(
         already the correct per-action text.
 
     Coverage delta vs ``_resource_input_schema``: that helper covers
-    5 categories (skill / agent.peer / mcp.server / **rag_corpus** /
+    4 categories (agent.peer / mcp.server / **rag_corpus** /
     mcp.tool). This helper covers 4 (= same set minus rag_corpus) because
     the host-side per-corpus description surface doesn't exist; if a
     ``list_available_corpora()`` surface is added later, this helper
@@ -1449,7 +1445,7 @@ def _augment_suggestions(
 
     The PR-2 default suggestion pool is the static catalogue
     (= KNOWN_STATIC_QUALIFIED_NAMES, 13 names). When ``ctx.router_state``
-    is populated, we widen the pool with dynamic items (= skills /
+    is populated, we widen the pool with dynamic items (= 
     agents / mcp.tool / mcp.server / memory_entry) so the suggestion
     surfaces names the LLM can actually invoke. Falls back to the
     original exception unchanged when no dynamic items exist.


### PR DESCRIPTION
**[e2e-coder]** — ②-comments-1: the **clear-dead subset** of the ②-comments prose sweep (rewrite/rename, **no logic change**). Part (A) of the lead-approved staged split; the nuanced part (B) is lead-tracked.

## Changes
- **universal_catalog.py** (internal docstrings): drop dead skill references — the `skill__<name>` "Covered" entries (which referenced the **undefined** `list_available_skills()`), the resource-category lists (`skill` / `skills` / `skill__X`), the generic-dispatcher example (`invoke_skill`/delegate → delegate), and the module docstring's dead `list_skills` discover-op.
- **agent_snapshot.py** (comments): `buffered_intervention_answers` "keyed by skill_run_id" → "keyed by run_id" (post-②b rename) + "resuming skill" → "resuming run".

## KEEP
op-kind strings / skill_* WAL kinds / step_* (live identity/reader). Historical #879 comment (mcp category collapse) left as accurate history.

## Finding — invoke_skill surface is heterogeneous → (B), not a rushed sweep
The `invoke_skill` comment surface is **not** uniformly "clear dead-prose":
- **router_loop.py has LIVE string literals**: `_DEDUPE_SYNC_TOOLS = frozenset({"invoke_skill"})`, error kind `"duplicate_invoke_skill_in_round"`, and the `tc["function"]["name"] == "invoke_skill"` check — live code referencing a dead tool name (behavior-bearing, careful).
- tools/ has machinery-description comments (sub-run, name-enum, handling) that need per-comment care.

So the `invoke_skill` surface belongs in the **tracked (B) careful pass** (with permissions skill-scope + event_schema skill-fields), not this low-risk slice.

## Test plan
- [x] `ruff` — clean · `verify_module_docstrings.py` — OK
- [x] full `pytest` — **6968 passed, 16 skipped**
- [x] import-check + no logic change (docstrings/comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)