### PR TITLE
fix(#2498): ⎿ rows show task name, freed tokens, and ask_user answer

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -410,6 +410,10 @@ def _summarize_result(tool, result) -> str:
         if isinstance(tasks, list):
             n = len(tasks)
             return f"{n} task{'s' if n != 1 else ''}"
+        task_record = result.get("task")
+        if isinstance(task_record, dict):
+            name = task_record.get("name") or task_record.get("task_id") or "task"
+            return _short(str(name), 60)
         entries = result.get("entries")
         if isinstance(entries, list):
             n = len(entries)
@@ -461,6 +465,12 @@ def _summarize_result(tool, result) -> str:
         returncode = result.get("returncode")
         if isinstance(returncode, int) and status == "ok":
             return f"exit {returncode}"
+        freed_tokens = result.get("freed_tokens")
+        if isinstance(freed_tokens, int):
+            return f"Freed {freed_tokens} token{'s' if freed_tokens != 1 else ''}"
+        answer = result.get("answer")
+        if isinstance(answer, str) and answer:
+            return _short(answer, 60)
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -503,3 +503,69 @@ def test_sandboxed_exec_ok_shows_exit_code() -> None:
         {"kind": "sandboxed_exec", "status": "cancelled", "backend": "subprocess",
          "returncode": -1, "stdout": "", "stderr": "", "truncated": False},
     ) == "cancelled"
+
+
+def test_task_op_shows_task_name() -> None:
+    """Tier 2: task op result ({kind, status, task: {name, ...}}) shows the task name.
+
+    task.create/get/update_status/abort/assign/add_dependency/... all return a
+    nested 'task' dict; without this branch they fall to status → 'ok', losing
+    the identity of which task was acted on.
+    """
+    assert summarize_tool_result(
+        "task__create",
+        {"kind": "task.create", "status": "ok",
+         "task": {"task_id": "t1", "name": "Add user auth", "status": "open"}},
+    ) == "Add user auth"
+    assert summarize_tool_result(
+        "task__update_status",
+        {"kind": "task.update_status", "status": "ok",
+         "task": {"task_id": "t2", "name": "Fix login bug", "status": "done"}},
+    ) == "Fix login bug"
+    assert summarize_tool_result(
+        "task__get",
+        {"kind": "task.get", "status": "ok",
+         "task": {"task_id": "abc-123", "name": "", "status": "open"}},
+    ) == "abc-123"
+
+
+def test_compact_shows_freed_tokens() -> None:
+    """Tier 2: compact success ({kind, status, freed_tokens, ...}) shows 'Freed N tokens'.
+
+    compact returns {"kind": "compact", "status": "ok", "freed_tokens": int, ...};
+    without this branch status fires showing 'ok' with no context of how much was freed.
+    """
+    assert summarize_tool_result(
+        "compact",
+        {"kind": "compact", "status": "ok", "freed_tokens": 8200,
+         "free_window_after": 50000, "summarized_turns": 12},
+    ) == "Freed 8200 tokens"
+    assert summarize_tool_result(
+        "compact",
+        {"kind": "compact", "status": "ok", "freed_tokens": 1,
+         "free_window_after": 10000},
+    ) == "Freed 1 token"
+    assert summarize_tool_result(
+        "compact",
+        {"kind": "compact", "status": "ok", "freed_tokens": 0},
+    ) == "Freed 0 tokens"
+
+
+def test_ask_user_shows_answer_text() -> None:
+    """Tier 2: ask_user result ({kind, question, answer, status}) shows the answer.
+
+    ask_user returns {"kind": "ask_user", "question": "...", "answer": "...", "status": "ok"};
+    showing the answer text is more informative than the generic 'ok'.
+    """
+    assert summarize_tool_result(
+        "ask_user",
+        {"kind": "ask_user", "question": "Which environment?",
+         "answer": "production", "status": "ok"},
+    ) == "production"
+    long_answer = "yes " * 30
+    out = summarize_tool_result(
+        "ask_user",
+        {"kind": "ask_user", "question": "Are you sure?",
+         "answer": long_answer, "status": "ok"},
+    )
+    assert "…" in out and "\n" not in out  # long answer is truncated to a single line


### PR DESCRIPTION
**[tui-coder]** — part of inline ⎿-row raw-dict leakage mining wave

## Summary

3 branches — all cases showing the uninformative generic `"ok"` via the status fallback:

- **`task` nested dict → task name**: `task.create/get/update_status/abort/assign/add_dependency/remove_dependency/repoint_dependency` all return `{"kind": "task.*", "status": "ok", "task": {"name": "...", ...}}`. Without this branch every task op shows `"ok"` with no identity of which task was acted on. Now shows the task name (falls back to `task_id` if name is empty).
- **`freed_tokens` int → "Freed N tokens"**: `compact` returns `{"kind": "compact", "status": "ok", "freed_tokens": int, ...}`. The token count is the meaningful signal; `"ok"` alone gives no context.
- **`answer` str → answer text**: `ask_user` returns `{"kind": "ask_user", "answer": "production", "status": "ok"}`. Showing the user's actual answer in the ⎿ row is far more informative than `"ok"`.

All new branches sit after error guards and before the `status` fallback. `task_record` dict check placed after `tasks` list (no shadowing — `tasks` list and `task` singular dict are distinct keys).

42 tests total (+3: `test_task_op_shows_task_name`, `test_compact_shows_freed_tokens`, `test_ask_user_shows_answer_text`).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 42 OK, 0 Tier-4 (caught + fixed a `len(out) <= 65` size-pin during authoring)
- [x] `pytest` — 6963 passed, 17 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all new tests are Tier 2 (public API `summarize_tool_result`, real dict inputs, no mocks, behavioral not format-pinned).