### PR TITLE
fix(#2500): ⎿ rows show URL, installed server name, and task state

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -471,6 +471,15 @@ def _summarize_result(tool, result) -> str:
         answer = result.get("answer")
         if isinstance(answer, str) and answer:
             return _short(answer, 60)
+        server_name = result.get("server_name")
+        if isinstance(server_name, str) and server_name:
+            return f"Installed {server_name}"
+        url = result.get("url")
+        if isinstance(url, str) and url:
+            return _short(url, 60)
+        state = result.get("state")
+        if isinstance(state, str) and state:
+            return state
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -569,3 +569,60 @@ def test_ask_user_shows_answer_text() -> None:
          "answer": long_answer, "status": "ok"},
     )
     assert "…" in out and "\n" not in out  # long answer is truncated to a single line
+
+
+def test_mcp_install_shows_server_name() -> None:
+    """Tier 2: mcp_install success ({status:"ok", server_name, ...}) shows 'Installed {name}'.
+
+    mcp_install returns {kind:"mcp_install", status:"ok", server_id, server_name, ...};
+    without this branch status fires showing 'ok', losing which server was installed.
+    """
+    assert summarize_tool_result(
+        "mcp_install",
+        {"kind": "mcp_install", "status": "ok", "server_id": "github",
+         "server_name": "GitHub MCP", "scope": "project", "installed_path": "/path"},
+    ) == "Installed GitHub MCP"
+    assert summarize_tool_result(
+        "mcp_install",
+        {"kind": "mcp_install", "status": "ok", "server_id": "s",
+         "server_name": "slack", "scope": "user"},
+    ) == "Installed slack"
+
+
+def test_web_fetch_shows_url() -> None:
+    """Tier 2: web_fetch success ({kind:"web_fetch", url, status:"ok", content, ...}) shows URL.
+
+    web_fetch returns {kind, url, status:"ok", content, ...}; without this branch
+    status fires showing 'ok'. Error paths (blocked/timeout/error) all carry 'error'
+    str which is caught by the error-first guard and are unaffected.
+    """
+    out = summarize_tool_result(
+        "web_fetch",
+        {"kind": "web_fetch", "url": "https://example.com/api/v1",
+         "status": "ok", "status_code": 200, "content": "body text"},
+    )
+    assert "example.com" in out and "{" not in out
+    long_url = "https://example.com/" + "a" * 80
+    out2 = summarize_tool_result(
+        "web_fetch",
+        {"kind": "web_fetch", "url": long_url, "status": "ok", "content": ""},
+    )
+    assert "…" in out2 and "\n" not in out2
+
+
+def test_task_heartbeat_shows_state() -> None:
+    """Tier 2: task.heartbeat result ({state, task_id, status:"ok"}) shows the state.
+
+    task.heartbeat returns {kind:"task.heartbeat", status:"ok", task_id, state, unblocked};
+    showing the state ("running"/"awaiting"/"completed") is more informative than 'ok'.
+    """
+    assert summarize_tool_result(
+        "task__heartbeat",
+        {"kind": "task.heartbeat", "status": "ok",
+         "task_id": "t-abc", "state": "running", "unblocked": False},
+    ) == "running"
+    assert summarize_tool_result(
+        "task__heartbeat",
+        {"kind": "task.heartbeat", "status": "ok",
+         "task_id": "t-def", "state": "awaiting", "unblocked": False},
+    ) == "awaiting"


### PR DESCRIPTION
**[tui-coder]** — part of inline ⎿-row raw-dict leakage mining wave

## Summary

3 branches — all "shows ok" cases where the `status` fallback buried the useful payload:

- **`server_name` str → `"Installed {server_name}"`**: `mcp_install` returns `{kind:"mcp_install", status:"ok", server_name:"...", ...}`. Without this branch the user can't tell which server was installed from the ⎿ row.
- **`url` str → truncated URL**: `web_fetch` success returns `{kind:"web_fetch", url:"...", status:"ok", content:"...", ...}`. The URL is far more informative than `"ok"`. Error paths (`blocked`/`timeout`/`error`) all carry `error` str and are caught by the existing error-first guard — only the ok path reaches this branch.
- **`state` str → task state value**: `task.heartbeat` returns `{kind:"task.heartbeat", status:"ok", task_id:"...", state:"running", ...}`. Showing `"running"` / `"awaiting"` is meaningfully more informative than `"ok"`.

All branches sit after error guards and before `status` fallback. `server_name`, `url`, and `state` are each specific to one tool's return shape.

45 tests total (+3: `test_mcp_install_shows_server_name`, `test_web_fetch_shows_url`, `test_task_heartbeat_shows_state`).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 45 OK, 0 Tier-4
- [x] `pytest` — 6966 passed, 17 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK

Tier self-check: all new tests are Tier 2 (public API `summarize_tool_result`, real dict inputs, no mocks, behavioral not format-pinned).