### PR TITLE
fix(#2501): ⎿ rows show informative summaries for regen-index, mcp-drop, cron enable/disable

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -400,6 +400,8 @@ def _summarize_result(tool, result) -> str:
         if op == "move":
             dest = result.get("dest_path")
             return f"Moved to {dest}" if dest else "Moved"
+        if op == "regenerate_index":
+            return f"Indexed {path}" if path else "Indexed"
         saved = result.get("saved")
         if isinstance(saved, str):
             return f"Saved {saved}"
@@ -480,6 +482,14 @@ def _summarize_result(tool, result) -> str:
         state = result.get("state")
         if isinstance(state, str) and state:
             return state
+        server = result.get("server")
+        if isinstance(server, str) and server and status == "ok" and result.get("kind") == "mcp_drop_server":
+            return f"Removed {server}"
+        enabled = result.get("enabled")
+        if isinstance(enabled, bool):
+            name_val = result.get("name") or ""
+            verb = "Enabled" if enabled else "Disabled"
+            return f"{verb} {name_val}" if name_val else verb
         if status:
             return str(status)
     return _short(result, 80)

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -626,3 +626,55 @@ def test_task_heartbeat_shows_state() -> None:
         {"kind": "task.heartbeat", "status": "ok",
          "task_id": "t-def", "state": "awaiting", "unblocked": False},
     ) == "awaiting"
+
+
+def test_file_regenerate_index_shows_indexed_path() -> None:
+    """Tier 2: file regenerate_index result shows 'Indexed <path>' not raw dict.
+
+    file op='regenerate_index' returns {kind:"file", op:"regenerate_index", path, status:"ok",
+    entries:int} — 'entries' is an int (not a list) so no list branch fires; without the
+    op branch this falls through to the status branch and shows 'ok'.
+    """
+    assert summarize_tool_result(
+        "file__regenerate_index",
+        {"kind": "file", "op": "regenerate_index", "path": "/repo/.reyn/index",
+         "status": "ok", "entries": 42},
+    ) == "Indexed /repo/.reyn/index"
+    assert summarize_tool_result(
+        "file__regenerate_index",
+        {"kind": "file", "op": "regenerate_index", "path": None, "status": "ok"},
+    ) == "Indexed"
+
+
+def test_mcp_drop_server_shows_removed_name() -> None:
+    """Tier 2: mcp_drop_server success shows 'Removed <server>' not 'ok'.
+
+    mcp_drop_server returns {kind:"mcp_drop_server", status:"ok", server:str, ...};
+    without a branch this falls through to status='ok'. not_found result has status
+    'not_found' and should NOT match (stays as 'not_found' via the status fallback).
+    """
+    assert summarize_tool_result(
+        "mcp__drop_server",
+        {"kind": "mcp_drop_server", "status": "ok", "server": "my-mcp"},
+    ) == "Removed my-mcp"
+    assert summarize_tool_result(
+        "mcp__drop_server",
+        {"kind": "mcp_drop_server", "status": "not_found", "server": "missing-mcp"},
+    ) == "not_found"
+
+
+def test_cron_enable_disable_shows_verb_and_name() -> None:
+    """Tier 2: cron_enable/disable shows 'Enabled/Disabled <name>' not 'ok'.
+
+    cron_enable returns {status:"ok", name:str, enabled:True};
+    cron_disable returns {status:"ok", name:str, enabled:False}.
+    Both currently fall through to the status branch showing 'ok'.
+    """
+    assert summarize_tool_result(
+        "cron__enable",
+        {"status": "ok", "name": "daily-sync", "enabled": True},
+    ) == "Enabled daily-sync"
+    assert summarize_tool_result(
+        "cron__disable",
+        {"status": "ok", "name": "daily-sync", "enabled": False},
+    ) == "Disabled daily-sync"


### PR DESCRIPTION
**[tui-coder]** part of #1830 (inline CUI ⎿ row summary mining)

## Summary

Three remaining raw-dict / "shows ok" gaps in `_summarize_result`:

- `op='regenerate_index'` → `"Indexed <path>"` (file op; was falling to `status='ok'`)
- `mcp_drop_server` success → `"Removed <server>"` (was `'ok'`); `not_found` stays as `'not_found'` via status fallback
- `cron_enable`/`cron_disable` → `"Enabled/Disabled <name>"` (was `'ok'`)

**Key implementation note**: the `server` key branch requires `kind == 'mcp_drop_server'` guard because MCP tool results also carry a `server` field (the MCP server name). Without the guard, MCP results with empty content would show `"Removed slack"` etc. instead of `"ok"`.

## Files changed

- `src/reyn/interfaces/repl/renderer.py` — 3 new branches in `_summarize_result`
- `tests/test_inline_tool_result_summary.py` — 3 new Tier-2 tests (48 total)

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 48 passed
- [x] `ruff check src/reyn/interfaces/repl/renderer.py tests/test_inline_tool_result_summary.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 48 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK
- [x] Full `pytest` — 6969 passed, 17 skipped

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshot tests. All 3 new tests are Tier 2.