### PR TITLE
fix(#2502): cancel ack persists in scrollback; exec cancelled/timeout show failure text

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -467,6 +467,8 @@ def _summarize_result(tool, result) -> str:
         returncode = result.get("returncode")
         if isinstance(returncode, int) and status == "ok":
             return f"exit {returncode}"
+        if isinstance(returncode, int) and status in ("cancelled", "timeout"):
+            return f"✗ {status} (exit {returncode})"
         freed_tokens = result.get("freed_tokens")
         if isinstance(freed_tokens, int):
             return f"Freed {freed_tokens} token{'s' if freed_tokens != 1 else ''}"

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2443,7 +2443,7 @@ class RouterLoop:
         # message is cancel-only.
         if _loop_cancelled:
             await self.host.put_outbox(
-                kind="status",
+                kind="system",
                 text="✗ turn interrupted",
                 meta={"chain_id": self.chain_id},
             )

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -485,24 +485,14 @@ def test_sandboxed_exec_ok_shows_exit_code() -> None:
     """Tier 2: sandboxed_exec success (returncode int, status='ok') shows 'exit N'.
 
     sandboxed_exec returns {kind, status, returncode, stdout, stderr, ...}; for
-    status='ok' (exit 0) the generic 'ok' is unhelpful. 'timeout'/'cancelled' are
-    already informative via the status branch and are not overridden.
+    status='ok' the generic 'ok' is unhelpful. 'timeout'/'cancelled' get a '✗' prefix
+    with the exit code so failure is visually distinct from a successful result row.
     """
     assert summarize_tool_result(
         "sandboxed_exec",
         {"kind": "sandboxed_exec", "status": "ok", "backend": "subprocess",
          "returncode": 0, "stdout": "hello", "stderr": "", "truncated": False},
     ) == "exit 0"
-    assert summarize_tool_result(
-        "sandboxed_exec",
-        {"kind": "sandboxed_exec", "status": "timeout", "backend": "subprocess",
-         "returncode": -1, "stdout": "", "stderr": "", "truncated": False},
-    ) == "timeout"
-    assert summarize_tool_result(
-        "sandboxed_exec",
-        {"kind": "sandboxed_exec", "status": "cancelled", "backend": "subprocess",
-         "returncode": -1, "stdout": "", "stderr": "", "truncated": False},
-    ) == "cancelled"
 
 
 def test_task_op_shows_task_name() -> None:
@@ -678,3 +668,31 @@ def test_cron_enable_disable_shows_verb_and_name() -> None:
         "cron__disable",
         {"status": "ok", "name": "daily-sync", "enabled": False},
     ) == "Disabled daily-sync"
+
+
+def test_sandboxed_exec_cancelled_shows_failure_text() -> None:
+    """Tier 2: sandboxed_exec cancelled result shows '✗ cancelled (exit N)' not plain 'cancelled'.
+
+    sandboxed_exec returns {kind:"sandboxed_exec", status:"cancelled", returncode:int, ...}
+    when the subprocess is killed. Without a branch, the status fallback returns the bare
+    string 'cancelled' with no visual failure signal.
+    """
+    assert summarize_tool_result(
+        "sandboxed_exec",
+        {"kind": "sandboxed_exec", "status": "cancelled",
+         "backend": "local", "returncode": -9, "stdout": "", "stderr": ""},
+    ) == "✗ cancelled (exit -9)"
+
+
+def test_sandboxed_exec_timeout_shows_failure_text() -> None:
+    """Tier 2: sandboxed_exec timeout result shows '✗ timeout (exit N)' not plain 'timeout'.
+
+    sandboxed_exec returns {kind:"sandboxed_exec", status:"timeout", returncode:-1, ...}
+    when the subprocess exceeds the deadline. The bare 'timeout' string is indistinguishable
+    from a successful result in the ⎿ row without an explicit failure prefix.
+    """
+    assert summarize_tool_result(
+        "sandboxed_exec",
+        {"kind": "sandboxed_exec", "status": "timeout",
+         "backend": "local", "returncode": -1, "stdout": "partial", "stderr": ""},
+    ) == "✗ timeout (exit -1)"

--- a/tests/test_turn_cancel_1468.py
+++ b/tests/test_turn_cancel_1468.py
@@ -128,10 +128,11 @@ async def test_cancel_surfaces_interrupted_ack_not_max_iterations_error() -> Non
         tools=[],
         _univ_enabled=False,
     )
-    # A cancel acknowledgement was surfaced (status, not error)...
+    # A cancel acknowledgement was surfaced as a persistent system message (not
+    # a transient status that gets erased, and not an error)...
     ack = [m for m in host.outbox if "interrupted" in m["text"].lower()]
     assert ack, f"expected a 'turn interrupted' ack, got {host.outbox}"
-    assert ack[0]["kind"] == "status"
+    assert ack[0]["kind"] == "system"
     # ...and NOT the misleading max_iterations error (the copy-paste bug).
     assert not any("max iteration" in m["text"].lower() for m in host.outbox)
     assert not any(m["kind"] == "error" for m in host.outbox)


### PR DESCRIPTION
**[tui-coder]** error/interrupt/timeout display mining

## Summary

Two display gaps in error/interrupt paths:

**Gap 1 — Cancel acknowledgement was transient (got erased)**
`router_loop.py`: changed `kind="status"` → `kind="system"` for the "✗ turn interrupted" outbox message. `status` is in `_TRANSIENT_KINDS` so it was overwritten by the next render pass — the only visible Ctrl-C confirmation disappeared before the user could read it. `system` is identical in appearance (`"· "` dim gutter) but not transient.

**Gap 2 — `sandboxed_exec` cancelled/timeout result rows were visually indistinguishable from success**
`renderer.py`: added branch in `_summarize_result` for `returncode (int) + status in ("cancelled", "timeout")` → `"✗ cancelled (exit N)"` / `"✗ timeout (exit N)"`. Previously the bare `"cancelled"` / `"timeout"` string fell through to the `if status: return str(status)` fallback, rendering with the same dim `⎿` success styling. The `"✗"` prefix makes failure immediately visible without changing the routing (tool result still comes through `tool_call_completed`).

Note: `web_fetch` timeout is unaffected — its dict already has an `"error"` key caught by the error-first guard.

## Files changed

- `src/reyn/runtime/router_loop.py` — `kind="status"` → `kind="system"` (1 line)
- `src/reyn/interfaces/repl/renderer.py` — new `cancelled`/`timeout` branch in `_summarize_result`
- `tests/test_turn_cancel_1468.py` — updated `kind` assertion to `"system"` (was `"status"`)
- `tests/test_inline_tool_result_summary.py` — 2 new Tier-2 tests; updated pre-existing `test_sandboxed_exec_ok_shows_exit_code` (50 total)

## Test plan

- [x] `pytest tests/test_turn_cancel_1468.py tests/test_inline_tool_result_summary.py` — 58 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_turn_cancel_1468.py tests/test_inline_tool_result_summary.py` — 58 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` changed src files — OK
- [x] Full `pytest` — 6970 passed, 17 skipped (1 failure was the pre-amended test; post-amend: clean)

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshots. All new/updated tests are Tier 2.