### PR TITLE
fix(#2503): error tool results render red in ⎿ row — '✗' prefix + _CC_ERR styling

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -367,10 +367,10 @@ def _summarize_result(tool, result) -> str:
         # below would short-circuit to "Read 0 lines" and the error is never seen).
         error = result.get("error")
         if isinstance(error, str):
-            return _short(error, 80)
+            return f"✗ {_short(error, 78)}"
         error_message = result.get("error_message")
         if isinstance(error_message, str):
-            return _short(error_message, 80)
+            return f"✗ {_short(error_message, 78)}"
         op = result.get("op")
         path = result.get("path")
         status = result.get("status")
@@ -624,7 +624,9 @@ def format_inline_message(msg: OutboxMessage):
         return _gutter_grid("▸ ", _CC_TEXT, body)
     if kind == "tool_call_completed":
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
-        return _gutter_grid("  ⎿ ", _CC_DIM, Text(summary, style=_CC_DIM))
+        err_style = summary.startswith("✗")
+        s = _CC_ERR if err_style else _CC_DIM
+        return _gutter_grid("  ⎿ ", s, Text(summary, style=s))
     if kind == "tool_call_failed":
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
         return _gutter_grid("  ⎿ ", _CC_ERR, Text(f"✗ {_short(err, 80)}", style=_CC_ERR))

--- a/tests/test_inline_tool_result_summary.py
+++ b/tests/test_inline_tool_result_summary.py
@@ -101,31 +101,35 @@ def test_task_list_result_shows_count() -> None:
 
 
 def test_dict_with_error_key_shows_error_not_raw_repr() -> None:
-    """Tier 2: a dict with an 'error' key shows the error message, not raw repr.
+    """Tier 2: a dict with an 'error' key shows '✗ <error message>', not raw repr.
 
     `file__list` outside the project returns `{'error': 'glob not permitted…'}`.
-    The summarizer must surface the error string, not dump the raw dict.
+    The summarizer must surface the error string with a '✗' failure prefix so the
+    ⎿ row renders in red (not dim grey), distinguishing failure from success.
     """
     out = summarize_tool_result(
         "file__list",
         {"error": "glob not permitted: '/tmp/*' (outside project, no read permission)"},
     )
+    assert out.startswith("✗"), "error result must carry '✗' failure prefix"
     assert "glob not permitted" in out
     assert "{" not in out, "raw dict repr must not leak into ⎿ row"
 
 
 def test_file_read_not_found_shows_error_not_zero_lines() -> None:
-    """Tier 2: file__read for a missing file shows the error, not 'Read 0 lines'.
+    """Tier 2: file__read for a missing file shows '✗ <error>', not 'Read 0 lines'.
 
     file__read returns {"op": "read", "content": "", "error": "file not found: …"}
     for a non-existent path.  Without the error-first guard the read branch fires
     on op=="read" and returns "Read 0 lines" (empty content → 0 lines), which looks
     identical to an empty file and gives the user no signal that the file is absent.
+    The '✗' prefix ensures the ⎿ row renders in red (tool_call_completed + ✗ → _CC_ERR).
     """
     out = summarize_tool_result(
         "file__read",
         {"op": "read", "content": "", "error": "file not found: README.md"},
     )
+    assert out.startswith("✗"), "error result must carry '✗' failure prefix"
     assert "0 lines" not in out, "missing file must not look like empty file"
     assert "not found" in out or "README" in out, "must surface the error"
     assert "{" not in out, "raw dict repr must not leak"
@@ -193,11 +197,12 @@ def test_recall_success_shows_chunk_count() -> None:
 
 
 def test_error_message_field_shown_not_raw_dict() -> None:
-    """Tier 2: dicts with 'error_message' (no 'error' key) show the message.
+    """Tier 2: dicts with 'error_message' (no 'error' key) show '✗ <message>'.
 
     recall validation errors return {"ok": False, "error_kind": ..., "error_message": ...}
     and task_ops returns the same shape for invalid-args/no-context errors.
     Without the error_message fallback both fell through to raw dict repr.
+    The '✗' prefix ensures the ⎿ row renders in red (tool_call_completed + ✗ → _CC_ERR).
     """
     out = summarize_tool_result(
         "rag_operation__recall",
@@ -208,6 +213,7 @@ def test_error_message_field_shown_not_raw_dict() -> None:
             "missing": ["query"],
         },
     )
+    assert out.startswith("✗"), "error_message result must carry '✗' failure prefix"
     assert "recall requires" in out
     assert "{" not in out, "raw dict repr must not leak"
     assert "ok" not in out.lower() or "False" not in out, "must not dump raw repr"


### PR DESCRIPTION
**[tui-coder]** error/interrupt display mining — part of #1830 error-path surface

## Problem

`tool_call_completed` ⎿ rows always rendered in `_CC_DIM` (dim grey) regardless of content. This meant:
- `{"error": "file not found"}` → `"  ⎿ file not found"` in **grey** (same as success)
- `{"error_message": "recall requires ['query']"}` → grey
- `"✗ cancelled (exit -9)"` (from #2502) → grey despite the `✗` prefix

Users couldn't visually distinguish a failed tool result from a successful one at a glance.

## Fix

**Two-part:**

1. **`_summarize_result` error branches** (`renderer.py:369–373`): prefix `error`/`error_message` summaries with `"✗ "`. This signals failure in the summary text itself.

2. **`format_inline_message` `tool_call_completed` branch** (`renderer.py:625–628`): detect `summary.startswith("✗")` and apply `_CC_ERR` (red `#f97066`) instead of `_CC_DIM`. Gutter and body both go red — matching `tool_call_failed` visual weight, without changing the outbox routing.

**After this PR**, failure-state tool results look like:
```
  ⎿ ✗ file not found: README.md        ← red (was dim grey)
  ⎿ ✗ cancelled (exit -9)              ← red (was dim grey, #2502)
  ⎿ Read 42 lines                      ← dim grey (unchanged)
```

Successful results stay dim grey; only `✗`-prefixed summaries trigger red.

## Files changed

- `src/reyn/interfaces/repl/renderer.py` — 5-line change across 2 locations
- `tests/test_inline_tool_result_summary.py` — updated 3 error-dict tests to assert `out.startswith("✗")` (50 total, all pass)

## Test plan

- [x] `pytest tests/test_inline_tool_result_summary.py` — 50 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_tool_result_summary.py` — 50 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK
- [x] Full `pytest` — 6971 passed, 17 skipped

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshots. `out.startswith("✗")` is a behavioral assertion (failure signal), not a format pin.