### PR TITLE
fix(#2504): on_limit_denied distinguishes iteration limit from router cap

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -186,23 +186,36 @@ class ChatLifecycleForwarder:
             text = "[↑ history compacted]"
         self._enqueue(text)
 
-    # ── Router cap (session.py _handle_router_cap_exceeded) ──────────────
+    # ── Router cap / iteration limit ─────────────────────────────────────
+    # Two distinct ``limit_denied`` sources:
+    #   kind="router_cap"     — session.py, op-count exceeds operator cap
+    #   kind="max_iterations" — router_loop.py, iteration ceiling reached
 
     def on_limit_denied(self, data: dict) -> None:
-        """Surface a ``[✗ router cap hit: N ops (limit L)]`` error marker.
+        """Surface a ``[✗ … limit hit]`` marker distinguishing the two cap kinds.
 
-        ``session.py`` emits ``limit_denied`` when the loop's op-count exceeds
-        the operator-configured router cap. Without this handler the user only
-        sees whatever LLM wrap-up text the session synthesises — no inline
-        marker signals that the cap is WHY the turn ended early. ``kind``
-        is ``"router_cap"``; ``count`` and ``cap`` carry the numbers.
+        ``router_cap`` fires when the loop's tool-call count exceeds the
+        operator-configured cap (``safety.router_cap``); ``count`` and ``cap``
+        carry the numbers. ``max_iterations`` fires when the router's iteration
+        ceiling is hit; ``limit`` carries the configured maximum. Without this
+        handler the user only sees whatever LLM wrap-up text the session
+        synthesises — no inline marker signals that the cap is WHY the turn
+        ended early.
         """
-        count = data.get("count")
-        cap = data.get("cap")
-        if count is not None and cap is not None:
-            self._enqueue(f"[✗ router cap hit: {count} ops (limit {cap})]")
+        kind = data.get("kind", "")
+        if kind == "max_iterations":
+            limit = data.get("limit")
+            if limit is not None:
+                self._enqueue(f"[✗ iteration limit hit: {limit} iterations]")
+            else:
+                self._enqueue("[✗ iteration limit hit]")
         else:
-            self._enqueue("[✗ router cap hit]")
+            count = data.get("count")
+            cap = data.get("cap")
+            if count is not None and cap is not None:
+                self._enqueue(f"[✗ router cap hit: {count} ops (limit {cap})]")
+            else:
+                self._enqueue("[✗ router cap hit]")
 
     def _enqueue(self, text: str) -> None:
         # Fire-and-forget: lifecycle markers are advisory, never block the

--- a/tests/test_chat_lifecycle_forwarder.py
+++ b/tests/test_chat_lifecycle_forwarder.py
@@ -405,6 +405,42 @@ def test_limit_denied_missing_counts_uses_generic_marker() -> None:
     assert "ops" not in only.text
 
 
+def test_limit_denied_max_iterations_shows_iteration_limit_not_router_cap() -> None:
+    """Tier 2: limit_denied kind='max_iterations' → 'iteration limit hit', not 'router cap hit'.
+
+    router_loop.py emits limit_denied with kind='max_iterations' and limit=N when the
+    iteration ceiling is reached. Previously on_limit_denied always said 'router cap hit'
+    regardless of kind, conflating two distinct stop reasons — a user who hit the iteration
+    limit saw the same marker as one who hit the op-count cap.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="limit_denied",
+        data={"kind": "max_iterations", "limit": 20, "chain_id": "xyz"},
+    ))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert only.kind == "system"
+    assert "iteration limit" in only.text, "must say 'iteration limit', not 'router cap'"
+    assert "20" in only.text
+    assert "router cap" not in only.text, "must not conflate with router cap"
+
+
+def test_limit_denied_max_iterations_without_limit_uses_generic() -> None:
+    """Tier 2: limit_denied kind='max_iterations' without limit field → generic marker.
+
+    Forward-compat: still surfaces a marker even if limit is missing.
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="limit_denied", data={"kind": "max_iterations"}))
+    msgs = _drain(q)
+    (only,) = msgs
+    assert "iteration limit" in only.text
+    assert "router cap" not in only.text
+
+
 # ── summary_resummarize_failed ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
**[tui-coder]** error-path display mining

## Problem

`on_limit_denied` in `lifecycle_forwarder.py` always emitted `[✗ router cap hit]` for both `limit_denied` kinds:

- `kind="router_cap"` — from `session.py`, op-count exceeds operator-configured `safety.router_cap`
- `kind="max_iterations"` — from `router_loop.py`, iteration ceiling reached

A user who hit the iteration limit saw `"router cap hit"` — the wrong cause. Both limit types are distinct: router cap is about tool-call volume; max_iterations is about the loop depth. They have different config knobs and different implications.

## Fix

Branch on `data["kind"]` in `on_limit_denied`:

- `kind="max_iterations"` → `[✗ iteration limit hit: 20 iterations]`
- `kind="router_cap"` (or unknown) → `[✗ router cap hit: N ops (limit L)]` (existing behaviour, unchanged)

## Files changed

- `src/reyn/runtime/lifecycle_forwarder.py` — branching in `on_limit_denied` + updated docstring
- `tests/test_chat_lifecycle_forwarder.py` — 2 new Tier-2 tests (27 total)

## Test plan

- [x] `pytest tests/test_chat_lifecycle_forwarder.py` — 27 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_chat_lifecycle_forwarder.py` — 27 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/lifecycle_forwarder.py` — OK
- [x] Full `pytest` — 6973 passed, 17 skipped

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshots. All new tests are Tier 2.