### PR TITLE
fix(#2505): slash command error shows exception type + message, not just 'see logs'

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4932,7 +4932,7 @@ class Session:
         pre_size = self.outbox.qsize()
         try:
             await slash_cmd.handler(self, args)
-        except Exception:
+        except Exception as e:
             # A slash handler raising must not kill the session run loop: run()'s
             # `while await run_one_iteration()` has no `except`, so an uncaught
             # error here ends session.run() and silently drops every later inbox
@@ -4940,8 +4940,11 @@ class Session:
             # Surface a clean error and treat the command as consumed so the loop
             # continues. (CancelledError is BaseException → shutdown still cancels.)
             logger.exception("slash handler /%s failed", cmd)
+            detail = f"{type(e).__name__}: {e}"
+            if len(detail) > 72:
+                detail = detail[:69] + "…"
             await self._put_outbox(OutboxMessage(
-                kind="error", text=f"/{cmd} failed (see logs)",
+                kind="error", text=f"/{cmd} failed: {detail}",
             ))
             return True
         try:

--- a/tests/test_slash_handler_crash_containment.py
+++ b/tests/test_slash_handler_crash_containment.py
@@ -56,4 +56,9 @@ async def test_raising_slash_handler_is_contained_not_fatal(
     # Before the fix this raised RuntimeError out of dispatch (→ killed run()).
     consumed = await session._maybe_handle_slash("/__f3boom__")
     assert consumed is True  # handled → the run loop continues
-    assert any(m.kind == "error" for m in _drain_outbox(session))
+    msgs = _drain_outbox(session)
+    err = next(m for m in msgs if m.kind == "error")
+    # Exception type + message must appear in the error text so the user sees
+    # what went wrong without needing developer log access.
+    assert "RuntimeError" in err.text
+    assert "handler exploded" in err.text


### PR DESCRIPTION
**[tui-coder]** error-path display mining

## Problem

When a slash handler raises an exception, the error shown to the user was:
```
✗ /__f3boom__ failed (see logs)
```

"See logs" is only actionable for developers with log access. End users get no signal about what went wrong.

## Fix

`session.py:4935` — changed `except Exception:` to `except Exception as e:` and format the exception:

```
✗ /__f3boom__ failed: RuntimeError: handler exploded
```

Detail is capped at 72 chars with `…` so long messages don't overflow the error line. Stack trace still goes to the logger (unchanged).

## Implementation note

The original `except Exception:` (no binding) was what caused `NameError: name 'e' is not defined` in a first attempt — the `except` clause had to be updated to `except Exception as e:`.

## Files changed

- `src/reyn/runtime/session.py` — `except Exception:` → `except Exception as e:` + format detail
- `tests/test_slash_handler_crash_containment.py` — updated assertions to verify exception type + message appear in error text

## Test plan

- [x] `pytest tests/test_slash_handler_crash_containment.py` — 1 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_slash_handler_crash_containment.py` — 1 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] Full `pytest` — 6973 passed, 17 skipped

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshots.