### PR TITLE
fix(#2506): 'see logs' and bare exc strings show type + capped detail in error messages

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -1011,12 +1011,15 @@ async def _submit(registry, text: str) -> None:
             await s.answer_oldest_intervention_text(text)
             return
         await s.submit_user_text(text)
-    except Exception:
+    except Exception as e:
         logger.exception("inline submit failed")
+        detail = f"{type(e).__name__}: {e}"
+        if len(detail) > 72:
+            detail = detail[:69] + "…"
         try:
             from reyn.runtime.outbox import OutboxMessage
             registry.repl_outbox.put_nowait(
-                OutboxMessage(kind="error", text="input could not be submitted (see logs)")
+                OutboxMessage(kind="error", text=f"input could not be submitted: {detail}")
             )
         except Exception:
             pass

--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -434,8 +434,11 @@ class InterAgentMessaging:
             )
             return
         except Exception as exc:
+            _detail = f"{type(exc).__name__}: {exc}"
+            if len(_detail) > 72:
+                _detail = _detail[:69] + "…"
             await self._put_outbox(OutboxMessage(
-                kind="error", text=f"router failed (agent_request): {exc}",
+                kind="error", text=f"router failed (agent_request): {_detail}",
                 meta={"chain_id": chain_id},
             ))
             # F6/F7 fix: send a structured failure marker so the requester
@@ -611,8 +614,11 @@ class InterAgentMessaging:
             await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
             return
         except Exception as exc:
+            _detail = f"{type(exc).__name__}: {exc}"
+            if len(_detail) > 72:
+                _detail = _detail[:69] + "…"
             await self._put_outbox(OutboxMessage(
-                kind="error", text=f"router failed (agent_response): {exc}",
+                kind="error", text=f"router failed (agent_response): {_detail}",
                 meta={"chain_id": chain_id},
             ))
             return
@@ -699,9 +705,12 @@ class InterAgentMessaging:
             await self._chains.resolve(chain_id)
             return
         except Exception as exc:
+            _detail = f"{type(exc).__name__}: {exc}"
+            if len(_detail) > 72:
+                _detail = _detail[:69] + "…"
             await self._put_outbox(OutboxMessage(
                 kind="error",
-                text=f"router failed (chain resolve): {exc}",
+                text=f"router failed (chain resolve): {_detail}",
                 meta={"chain_id": chain_id},
             ))
             # F6/F7 fix: structured marker upstream, not "".


### PR DESCRIPTION
**[tui-coder]** error-path display mining — cleanup round

## Summary

Four sites using opaque error text, same pattern as #2505 slash fix:

**`inline/app.py:1014`** — input submission failure:
- Before: `"input could not be submitted (see logs)"`
- After: `"input could not be submitted: ConnectionError: [Errno 111]…"` (72-char cap)
- Fix: `except Exception:` → `except Exception as e:` + detail format

**`inter_agent_messaging.py:438,616,704`** — router failures during inter-agent comms:
- Before: `f"router failed (agent_request): {exc}"` — bare `str(exc)`, unbounded
- After: `f"router failed (agent_request): ExcType: message"` (72-char cap)
- Fix: already had `except Exception as exc:` binding; just needed type prefix + cap

All four sites now match the `"ExcType: message (72 cap)"` convention established in #2505.

## No new tests

Both paths require triggering exceptions in infrastructure that has no real-instance trigger path without mocks (submit_user_text failing, multi-agent router failing mid-call). Tests would be Tier 4. Code change is pure text-formatting — the crash-containment logic is unchanged and already tested.

## Files changed

- `src/reyn/interfaces/inline/app.py` — 4 lines
- `src/reyn/runtime/services/inter_agent_messaging.py` — 9 lines (3 sites × 3 lines each)

## Test plan

- [x] `ruff check` changed files — clean
- [x] `python scripts/verify_module_docstrings.py` changed files — OK
- [x] Full `pytest` — 6973 passed, 17 skipped

## Tier self-check

No new tests (untestable paths without mocks). No mocks, no private-state asserts, no format/size pins, no snapshots in existing tests.