### PR TITLE
refactor(skill-word): ① stage1 — remove skill_* WAL kinds (recovery-gated)

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -62,7 +62,7 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # turn_started: emitted in Session.run_one_iteration() after the trigger
     #   is consumed from the inbox and before dispatch to _handle_*.
     # kind: the inbox message kind that triggered this turn (e.g. "user",
-    #   "skill_completed", "task_ready"). Lets subscribers distinguish human
+    #   "agent_response", "task_ready"). Lets subscribers distinguish human
     #   triggers from automated ones without parsing the payload.
     "turn_started": frozenset({"kind"}),
     # turn_completed: emitted in Session._run_router_loop() immediately after

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -14,15 +14,11 @@ like LLM calls live in the audit log under `.reyn/events/`):
   chain_update        — pending_chain's waiting_on shrunk
   chain_resolve       — pending_chain completed
   chain_timeout_fired — PR18 watchdog fired
-  skill_started       — skill execution begun; creates per-skill snapshot
-  skill_phase_advanced — skill transitioned to next phase
-  step_started        — a step within a phase has begun
+  step_started        — a plan step has begun
   step_completed      — a step completed successfully (result stored)
   step_failed         — a step failed (error stored)
   intervention_dispatched — ask_user / permission request emitted
   intervention_resolved   — intervention answered
-  skill_resumed       — audit marker; no agent-level state mutation
-  skill_completed     — skill execution finished; deletes per-skill snapshot
 
 Per P7: this is OS-level generic infrastructure — `kind` strings and
 field names live here, not in any skill/domain code.
@@ -56,18 +52,12 @@ WAL_EVENT_KINDS = (
     "chain_update",
     "chain_resolve",
     "chain_timeout_fired",
-    # NEW (skill resume design — PR-state-foundation)
-    "skill_started",
-    "skill_phase_advanced",
+    # plan-step lifecycle (read by the replay/rewind analysis)
     "step_started",
     "step_completed",
     "step_failed",
     "intervention_dispatched",
     "intervention_resolved",
-    "skill_resumed",
-    "skill_completed",
-    # NEW (PR-resume-ux β U1) — skill discarded by user via prompt or /skill discard
-    "skill_discarded",
     # NEW (R-D12) — durable buffered intervention answer that survives a
     # second crash before the resuming skill consumes it
     "intervention_answer_buffered",

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1170,7 +1170,6 @@ class AgentRegistry:
         boundary derived from the WAL entry kind (P7-safe — all source kinds
         live in ``WAL_EVENT_KINDS``, none are skill/domain strings):
 
-          - ``skill_phase_advanced``                      → ``phase``
           - ``step_completed`` / ``step_failed``          → ``plan-step``
           - anything else (``inbox_consume``, …)           → ``turn``
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -105,9 +105,7 @@ _REWIND_PLAN_STEP_KINDS = frozenset({
 
 
 def _rewind_point_kind(wal_kind: str) -> str:
-    """Map a WAL entry kind to a rewind-point boundary label (turn / plan-step / phase)."""
-    if wal_kind == "skill_phase_advanced":
-        return "phase"
+    """Map a WAL entry kind to a rewind-point boundary label (turn / plan-step)."""
     if wal_kind in _REWIND_PLAN_STEP_KINDS:
         return "plan-step"
     return "turn"

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3839,7 +3839,7 @@ class Session:
             self._current_task_id = meta.get("task_id")
         elif kind == WAKE_REQUESTER_KIND:
             self._current_task_id = meta.get("managing_task_id")
-        elif kind in (HOOK_INBOX_KIND, "agent_response", "skill_completed"):
+        elif kind in (HOOK_INBOX_KIND, "agent_response"):
             pass  # PRESERVE: self-continuation / response to the agent's own action
         else:
             self._current_task_id = None  # user / agent_request / unknown → new context

--- a/tests/test_2107_B15_preserve_self_continuation_1953.py
+++ b/tests/test_2107_B15_preserve_self_continuation_1953.py
@@ -10,7 +10,7 @@ B1.5 classifies EVERY trigger kind run_one_iteration dispatches (complete-by-
 construction), in three bands:
   - SET (a task wake introduces the context): task_ready, task_dependency_aborted.
   - PRESERVE (a self-continuation / a response to the agent's OWN prior action — not a
-    new context): hook, agent_response, skill_completed.
+    new context): hook, agent_response.
   - RESET→None (a genuinely NEW external context): user, agent_request (+ unknown,
     fail-safe to session-owned).
 Interleaving-safe: only a task_ready switches tasks, so the PRESERVE bands cannot
@@ -81,8 +81,8 @@ async def test_hook_self_continuation_create_is_owned_by_executing_task(tmp_path
 async def test_stamp_classifies_every_trigger_kind_complete_by_construction(tmp_path):
     """Tier 2: §16 B1.5 — EVERY trigger kind run_one_iteration dispatches is classified
     (no kind falls into the wrong band). Asserts on the built op-ctx (public output).
-    SET on task wakes, PRESERVE on self-continuations (hook/agent_response/
-    skill_completed), RESET on new contexts (user/agent_request) + an unknown
+    SET on task wakes, PRESERVE on self-continuations (hook/agent_response),
+    RESET on new contexts (user/agent_request) + a removed/unknown kind
     (fail-safe to session-owned)."""
     s = _session(tmp_path)
 
@@ -94,12 +94,15 @@ async def test_stamp_classifies_every_trigger_kind_complete_by_construction(tmp_
     assert current() == "T"
 
     # PRESERVE: self-continuations keep T (the B1.5 fix).
-    for k in (HOOK_INBOX_KIND, "agent_response", "skill_completed"):
+    for k in (HOOK_INBOX_KIND, "agent_response"):
         s._stamp_execution_context(k, {})
         assert current() == "T", f"{k} must PRESERVE the execution context"
 
     # RESET: a genuinely new external context clears to session-owned.
-    for k in ("user", "agent_request", "some_unknown_future_kind"):
+    # ("skill_completed" was a self-continuation kind, but the skill runtime is
+    #  gone — a legacy/removed kind now fails safe to session-owned like any
+    #  unknown kind.)
+    for k in ("user", "agent_request", "skill_completed", "some_unknown_future_kind"):
         s._stamp_execution_context(WAKE_READY_KIND, {"meta": {"task_id": "T"}})  # re-arm
         s._stamp_execution_context(k, {})
         assert current() is None, f"{k} must RESET to session-owned"

--- a/tests/test_registry_list_rewind_points_1f.py
+++ b/tests/test_registry_list_rewind_points_1f.py
@@ -9,8 +9,7 @@ audit EventStore is intentionally NOT consulted (WAL and audit stay decoupled).
 Pins:
 - boundary seqs come from the generation store (not every WAL seq);
 - ts + kind are read from the WAL entry at each boundary seq;
-- WAL kind → label mapping (skill_phase_advanced→phase, step_*→plan-step,
-  else→turn);
+- WAL kind → label mapping (step_*→plan-step, else→turn);
 - abandoned (rewound-past) boundaries are filtered out (is_active_seq);
 - rows are ascending by seq.
 
@@ -55,12 +54,14 @@ def _record_gen(reg: AgentRegistry, name: str, seq: int) -> None:
 
 
 def test_rewind_point_kind_mapping() -> None:
-    """Tier 2: WAL entry kind → boundary label (turn / plan-step / phase)."""
-    assert _rewind_point_kind("skill_phase_advanced") == "phase"
+    """Tier 2: WAL entry kind → boundary label (turn / plan-step)."""
     assert _rewind_point_kind("step_completed") == "plan-step"
     assert _rewind_point_kind("step_failed") == "plan-step"
     assert _rewind_point_kind("inbox_consume") == "turn"
     assert _rewind_point_kind("") == "turn"
+    # the skill "phase" boundary was removed with the skill replay/rewind
+    # analysis — a legacy skill_phase_advanced kind now falls through to "turn".
+    assert _rewind_point_kind("skill_phase_advanced") == "turn"
 
 
 # ── integration: enumeration ──────────────────────────────────────────────────
@@ -70,9 +71,8 @@ def test_rewind_point_kind_mapping() -> None:
 async def test_list_rewind_points_reads_ts_and_kind_from_wal(tmp_path) -> None:
     """Tier 2: each boundary seq → {seq, ts, kind} read from the WAL entry.
 
-    Generations cut at seqs 1 (inbox_consume→turn), 2 (step_completed→plan-step),
-    3 (skill_phase_advanced→phase). The returned rows carry the WAL ts + the
-    derived kind, ascending by seq.
+    Generations cut at seqs 1 (inbox_consume→turn) and 2 (step_completed→plan-step).
+    The returned rows carry the WAL ts + the derived kind, ascending by seq.
     """
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
@@ -80,14 +80,13 @@ async def test_list_rewind_points_reads_ts_and_kind_from_wal(tmp_path) -> None:
 
     s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
     s2 = await log.append("step_completed", run_id="r1", step="s")
-    s3 = await log.append("skill_phase_advanced", run_id="r1", phase="p")
-    for s in (s1, s2, s3):
+    for s in (s1, s2):
         _record_gen(reg, "alpha", s)
 
     rows = reg.list_rewind_points()
 
-    assert [r["seq"] for r in rows] == [s1, s2, s3]  # ascending
-    assert [r["kind"] for r in rows] == ["turn", "plan-step", "phase"]
+    assert [r["seq"] for r in rows] == [s1, s2]  # ascending
+    assert [r["kind"] for r in rows] == ["turn", "plan-step"]
     # ts is the WAL entry's timestamp — non-empty ISO string for each.
     assert all(r["ts"] for r in rows)
 

--- a/tests/test_rewind_inflight_disposition_2115.py
+++ b/tests/test_rewind_inflight_disposition_2115.py
@@ -5,7 +5,7 @@ re-drain (no WAL append lands past the reset-record).
     task vs a finished-before-the-cancel-landed task (vs the old hardcoded
     "in-flight cancelled" literal that lied about finished runs).
 (2) Re-drain: await_quiescent loops to a fixpoint, so an append SCHEDULED DURING
-    the join (the join↔append race that let a skill_completed leak past the
+    the join (the join↔append race that let a WAL append leak past the
     reset-record) is still joined before quiescence returns — vector-agnostic.
 
 Real Session + StateLog (no mocks).

--- a/tests/test_state_log_truncate.py
+++ b/tests/test_state_log_truncate.py
@@ -214,3 +214,53 @@ def test_truncate_then_iter_from_returns_only_survivors(tmp_path):
     asyncio.run(go())
     seen = list(log.iter_from(0))
     assert {e["seq"] for e in seen} == {4, 5, 6, 7}
+
+
+def test_removed_skill_wal_kinds_recovery_safe(tmp_path):
+    """Tier 2c: removing the skill_* kinds from WAL_EVENT_KINDS is crash-recovery-safe.
+
+    (a) WRITE side — append REJECTS a removed skill_* kind (0 live writers, so live
+        emit is unaffected; a stale/typo writer cannot silently fragment the vocab).
+    (b) READ side — iter_from still READS a legacy skill_* WAL line written by a
+        pre-removal build. The read path does NOT validate against WAL_EVENT_KINDS,
+        so an old on-disk WAL carrying skill_* entries still replays without raising
+        or dropping — and, crucially, the KEPT entry that comes AFTER the legacy
+        line is not lost.
+
+    FALSIFICATION: had the removal gated the READ path on WAL_EVENT_KINDS too, the
+    legacy skill_started line would raise/drop on iter_from and every kept entry
+    after it in the same WAL would be lost on recovery (a #2259/#2260-class
+    data-loss vector). The reconstruction-side fall-through + snapshot-backed
+    truncate-survival (a kept state applied before a snapshot survives WAL
+    truncation below its seq, with a WAL-only control) is covered by
+    ``test_agent_snapshot::test_truncate_falsify_snapshot_backed_kept_state_survives``.
+    """
+    wal = tmp_path / "wal.jsonl"
+    log = StateLog(wal)
+
+    async def scenario() -> int:
+        # (a) WRITE-side: every removed skill_* kind is rejected at append.
+        for dead in ("skill_started", "skill_phase_advanced", "skill_completed",
+                     "skill_discarded", "skill_resumed"):
+            try:
+                await log.append(dead, run_id="r1")
+            except ValueError as exc:
+                assert "unknown WAL event kind" in str(exc)
+            else:
+                raise AssertionError(f"append({dead!r}) must reject a removed kind")
+        s1 = await log.append("step_started", run_id="r1", op="file/read")
+        await log.flush()
+        return s1
+
+    s1 = asyncio.run(scenario())
+
+    # (b) READ-side: a legacy skill_started line written by a pre-removal build
+    #     (bypassing the now-rejecting append), followed by a KEPT entry.
+    with wal.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"seq": s1 + 1, "kind": "skill_started", "run_id": "r1"}) + "\n")
+        f.write(json.dumps({"seq": s1 + 2, "kind": "step_completed", "run_id": "r1"}) + "\n")
+
+    kinds = [e.get("kind") for e in log.iter_from(0)]
+    assert "step_started" in kinds       # the appended kept entry reads
+    assert "skill_started" in kinds      # legacy removed-kind line reads (no reject/drop)
+    assert "step_completed" in kinds     # the KEPT entry AFTER the legacy line is NOT lost


### PR DESCRIPTION
**[e2e-coder]** — ① stage1 of removing the skill-scoped replay/rewind analysis feature (owner GO, telegram「1番は削除で」). Stage split per lead: **stage1 = recovery-gated** (WAL kinds + their non-ReplayEngine readers, this PR); **stage2 = dev-tool** (ReplayEngine phase/skill_run scopes + skill-frame handling + `dogfood_trace --scope` CLI, separate PR).

## Scope (stage1)
- **state_log.py** — remove `skill_started/skill_phase_advanced/skill_resumed/skill_completed/skill_discarded` from `WAL_EVENT_KINDS` (+ the docstring lines). **0 live writers** (skill machinery already gone) → no live emit change. `step_*` / `intervention_*` KEPT.
- **registry.py** — drop the `skill_phase_advanced -> "phase"` rewind-point branch (that label was `skill_phase_advanced`-only, 0 writers). `_rewind_point_kind` now: plan-step-kinds → `"plan-step"`, else → `"turn"`. `/rewind` (`list_rewind_points`/`rewind_to`) keeps working on turn / plan-step.
- **session.py** — drop `"skill_completed"` from the task-context-preserve list.
- **event_schema.py** — `turn_started` comment example `skill_completed` → `agent_response`.

## Recovery gate (CLAUDE.md #2259/#2260) — close review please
`tests/test_state_log_truncate.py::test_removed_skill_wal_kinds_recovery_safe` (Tier 2c) proves removal is crash-recovery-safe by exercising **both WAL sides**:
- **(a) WRITE** — `append()` **REJECTS** every removed `skill_*` kind (`ValueError "unknown WAL event kind"`); a stale/typo writer cannot silently fragment the vocab.
- **(b) READ** — a **legacy** `skill_started` line (written directly, bypassing the now-rejecting `append`) still **reads** via `iter_from`, AND the **KEPT `step_completed` entry AFTER it is not lost** — the read path does not validate against `WAL_EVENT_KINDS`, so old on-disk WALs recover with no data-loss below the legacy entry.

Non-triviality: had the removal gated the READ path too, the legacy line would raise/drop and every kept entry after it would be lost on recovery (a #2259/#2260-class vector) — that's the falsification the test forces. The reconstruction fall-through + **snapshot-backed truncate-survival with a WAL-only control** is the ②d test `test_agent_snapshot::test_truncate_falsify_snapshot_backed_kept_state_survives` (still passing → `apply_events` does not validate `WAL_EVENT_KINDS`).

## Test-producers (found via **full-suite** sweep, not the -k affected run)
- `test_registry_list_rewind_points_1f` — `_rewind_point_kind("skill_phase_advanced") == "turn"` (fall-through; phase rewind-point removed) + the row test uses `inbox_consume→turn` / `step_completed→plan-step`.
- `test_2107_B15_preserve_self_continuation_1953` — the context-preserve completeness test now RESETs on `skill_completed` (a removed kind fails safe to session-owned like any unknown kind).
- two docstrings (`test_rewind_inflight_disposition_2115`, mapping docstring).

## Test plan
- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` (changed test files) — 0 errors
- [x] `python scripts/verify_module_docstrings.py` (changed src) — OK
- [x] full `pytest` from repo root — **6989 passed, 16 skipped**
- [x] recovery gate: `test_removed_skill_wal_kinds_recovery_safe` exercises write-reject + read-tolerate-with-downstream-entry (not trivially-pass)

part of the ① skill-scoped replay/rewind analysis removal (stage2 to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)