### PR TITLE
refactor(skill-word): (B) remove dead invoke_skill dedup + G10 tool_failed cluster

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -24,7 +24,6 @@ from reyn.runtime.router_tools import (
     build_tools,
     get_dispatch_kind,
 )
-from reyn.runtime.session import _TOOL_FAILED_FALLBACK_MSG
 from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
 from reyn.services.turn_budget import wrap_up_system_prompt
 
@@ -2203,42 +2202,6 @@ class RouterLoop:
                     )
                     return self._total_usage
 
-                # G10 / B2-M2 fix: intercept invoke_skill tool_failed results and
-                # emit a deterministic i18n message instead of letting the LLM
-                # generate an English fallback reply. Checked before accumulating
-                # messages so the LLM is never called for this error path.
-                for tc, r in zip(tool_calls, tool_results):
-                    if (
-                        tc["function"]["name"] == "invoke_skill"
-                        and isinstance(r, dict)
-                        and r.get("status") == "error"
-                    ):
-                        try:
-                            args = json.loads(tc["function"].get("arguments", "{}"))
-                        except (json.JSONDecodeError, KeyError):
-                            args = {}
-                        tool_name = args.get("name", "invoke_skill")
-                        err_info = r.get("error", {})
-                        error_msg = (
-                            err_info.get("message", str(r))
-                            if isinstance(err_info, dict)
-                            else str(err_info)
-                        )
-                        lang = getattr(host, "output_language", None)
-                        tmpl = _TOOL_FAILED_FALLBACK_MSG.get(
-                            lang,
-                            _TOOL_FAILED_FALLBACK_MSG["en"],
-                        )
-                        fallback = tmpl.format(
-                            tool_name=tool_name, error=error_msg
-                        )
-                        await host.put_outbox(
-                            kind="agent",
-                            text=fallback,
-                            meta={"chain_id": self.chain_id},
-                        )
-                        return self._total_usage
-
                 # FP-0034 Phase 3: routing_decided P6 event for catalog dispatch audit.
                 # Emitted independently of tracker (tracker=None is valid when
                 # hot_list_n=0, but P6 audit must fire whenever catalog routing
@@ -2515,52 +2478,32 @@ class RouterLoop:
     # -----------------------------------------------------------------------
 
     def _dedupe_tool_calls_round(self, tool_calls: list[dict]) -> list[dict]:
-        """Dedupe duplicate tool_calls within the same round (F5 + G3).
+        """Dedupe duplicate async tool_calls within the same round (F5).
 
-        Covers two categories of duplicates that weak models emit:
-
-        1. Async tools (e.g. `delegate_to_agent`) — F5 fix (batch 1).
-           Duplicates would inbox_put the same request twice, doubling
-           peer cost and confusing the chain.
-
-        2. `invoke_skill` — G3 fix (batch 5 B5-M1).
-           Three identical invoke_skill calls in one round caused 333k
-           tokens / 51 LLM calls. Same skill + same args → same result;
-           only the first call is needed.
+        Async tools (e.g. `delegate_to_agent`) — F5 fix (batch 1).
+        Duplicates would inbox_put the same request twice, doubling peer
+        cost and confusing the chain.
 
         Keyed on (tool_name, arguments_json). The original tool_call_id
         is preserved for the kept copy so the assistant/tool message
-        alignment downstream stays intact.
+        alignment downstream stays intact. Sync tools are deliberately
+        excluded — dupes there are wasteful but correctness-preserving and
+        the tool_call_id count must stay consistent with what the LLM emitted.
 
         Emits a `tool_call_deduped` audit event per suppressed call.
         """
-        # Tools that are dedupe candidates: async tools (by dispatch kind)
-        # and invoke_skill (sync but non-idempotent from a cost standpoint).
-        # Other sync tools (describe_skill, list_skills, read_file, …) are
-        # deliberately excluded — dupes there are wasteful but
-        # correctness-preserving and the tool_call_id count must stay
-        # consistent with what the LLM emitted.
-        _DEDUPE_SYNC_TOOLS: frozenset[str] = frozenset({"invoke_skill"})
-
         deduped: list[dict] = []
         seen: set[tuple[str, str]] = set()
         for tc in tool_calls:
             name = tc["function"]["name"]
-            is_async = get_dispatch_kind(name) == "async"
-            is_dedupe_sync = name in _DEDUPE_SYNC_TOOLS
-            if is_async or is_dedupe_sync:
+            if get_dispatch_kind(name) == "async":
                 key = (name, tc["function"].get("arguments", ""))
                 if key in seen:
-                    reason = (
-                        "duplicate_async_in_round"
-                        if is_async
-                        else "duplicate_invoke_skill_in_round"
-                    )
                     self.host.events.emit(
                         "tool_call_deduped",
                         name=name,
                         chain_id=self.chain_id,
-                        reason=reason,
+                        reason="duplicate_async_in_round",
                     )
                     continue
                 seen.add(key)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -214,21 +214,6 @@ _PEER_REPLY_FAILED_MSG: dict[str, str] = {
     ),
 }
 
-# Localized user-facing message when an invoke_skill tool call fails (G10 / B2-M2).
-# Deterministic i18n replaces LLM-generated fallback on the tool_failed path so
-# output_language is always honoured regardless of LLM default behaviour.
-# "en" is the global-safe default. Placeholders: {tool_name}, {error}.
-_TOOL_FAILED_FALLBACK_MSG: dict[str, str] = {
-    "ja": (
-        "ツール呼び出しに失敗しました ({tool_name}: {error})。"
-        " 別の方法を試すか、リクエストを言い換えてください。"
-    ),
-    "en": (
-        "Tool call failed ({tool_name}: {error})."
-        " Please try a different approach or rephrase the request."
-    ),
-}
-
 
 def _exec_gate_backend_name(sandbox_backend: Any, sandbox_config: Any) -> str | None:
     """#1417: resolve the ``exec`` D14 visibility-gate backend name.

--- a/tests/test_chat_router_i18n.py
+++ b/tests/test_chat_router_i18n.py
@@ -1,4 +1,4 @@
-"""Tier 2: OS invariant — chat router i18n for fallback messages (F8 + F11 + G10).
+"""Tier 2: OS invariant — chat router i18n for fallback messages (F8 + F11).
 
 F8: when the per-turn router retry budget is exhausted, the user-facing fallback
     message must be in the configured output_language, not hardcoded English.
@@ -7,10 +7,6 @@ F11: the system prompt built by router_system_prompt must include an explicit
     language instruction matching the configured output_language, so LLM-generated
     clarifying questions and direct replies land in the right language.
 
-G10: when an invoke_skill tool call fails (tool_failed event), the router must
-    emit a deterministic i18n message in output_language instead of letting the
-    LLM generate an English fallback reply (B2-M2 fix).
-
 Policy: no MagicMock / AsyncMock on collaborators. Real Session and
 build_system_prompt instances. RouterLoop.run() is patched only where strictly
 necessary to avoid network calls (Tier 3 LLM-replay tests are separate).
@@ -18,7 +14,6 @@ necessary to avoid network calls (Tier 3 LLM-replay tests are separate).
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 
 from reyn.llm.llm import LLMToolCallResult
@@ -383,133 +378,3 @@ def test_retry_exhausted_fallback_is_english_when_output_language_is_none(
     )
     # Specifically NOT the ja message.
     assert agent_msgs[0]["text"] != _ROUTER_RETRY_EXHAUSTED_MSG["ja"]
-
-
-# ---------------------------------------------------------------------------
-# G10 tests — tool_failed fallback message language (B2-M2 fix)
-# ---------------------------------------------------------------------------
-
-def _tool_call_result(skill_name: str, tc_id: str = "tc-001") -> LLMToolCallResult:
-    """Return a fake LLMToolCallResult that requests invoke_skill(name=skill_name)."""
-    return LLMToolCallResult(
-        content=None,
-        tool_calls=[
-            {
-                "id": tc_id,
-                "type": "function",
-                "function": {
-                    "name": "invoke_skill",
-                    "arguments": json.dumps({"name": skill_name, "input": {}}),
-                },
-            }
-        ],
-        finish_reason="tool_calls",
-        usage=_EMPTY_USAGE,
-    )
-
-
-def _run_tool_failed_scenario(
-    tmp_path: Path,
-    monkeypatch,
-    *,
-    output_language: str | None,
-    target_skill: str = "nonexistent.skill",
-) -> list:
-    """Drive RouterLoop through one invoke_skill tool_failed round.
-
-    Fakes call_llm_tools to return a single invoke_skill tool call whose
-    target skill does not exist (triggering the ValueError → error dict path
-    in dispatch_tool). Returns list of outbox messages emitted.
-    """
-    monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path, cap=5, output_language=output_language)
-    session.is_attached = True
-
-    call_count = 0
-    _target = target_skill  # capture for closure (avoids shadowing by kwarg)
-
-    async def fake_llm_tools(*, model, messages, tools, tool_choice,
-                              skill_name, budget, budget_agent, **kw):
-        nonlocal call_count
-        call_count += 1
-        # First call: return invoke_skill tool call (will fail).
-        # If a second LLM call somehow fires, return a text reply.
-        if call_count == 1:
-            return _tool_call_result(_target)
-        return _text_result("fallback")
-
-    delivered: list = []
-
-    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm_tools)
-
-    async def run():
-        await session._handle_user_message("テスト", chain_id="chain-g10")
-        # drain outbox
-        while not session.outbox.empty():
-            delivered.append(session.outbox.get_nowait())
-
-    asyncio.run(run())
-    return delivered
-
-
-def test_tool_failed_fallback_is_japanese_when_output_language_ja(tmp_path, monkeypatch):
-    """Tier 2: when output_language=ja and invoke_skill fails (tool_failed),
-    the router emits a Japanese error message without calling the LLM again (G10).
-    """
-    msgs = _run_tool_failed_scenario(tmp_path, monkeypatch, output_language="ja")
-    agent_msgs = [m for m in msgs if m.kind == "agent"]
-    assert agent_msgs, f"Expected agent outbox message; got: {msgs}"
-    text = agent_msgs[0].text
-    assert "ツール呼び出しに失敗しました" in text, (
-        f"Expected Japanese tool_failed message; got: {text!r}"
-    )
-    assert "Tool call failed" not in text, (
-        f"English leak in ja tool_failed fallback: {text!r}"
-    )
-
-
-def test_tool_failed_fallback_is_english_when_output_language_en(tmp_path, monkeypatch):
-    """Tier 2: when output_language=en and invoke_skill fails, the router emits
-    an English error message deterministically (G10).
-    """
-    msgs = _run_tool_failed_scenario(tmp_path, monkeypatch, output_language="en")
-    agent_msgs = [m for m in msgs if m.kind == "agent"]
-    assert agent_msgs, f"Expected agent outbox message; got: {msgs}"
-    text = agent_msgs[0].text
-    assert "Tool call failed" in text, (
-        f"Expected English tool_failed message; got: {text!r}"
-    )
-
-
-def test_tool_failed_fallback_is_english_when_output_language_none(tmp_path, monkeypatch):
-    """Tier 2: when output_language is None (unset), the tool_failed fallback
-    defaults to English — same as the retry-exhausted path (G10).
-    """
-    msgs = _run_tool_failed_scenario(tmp_path, monkeypatch, output_language=None)
-    agent_msgs = [m for m in msgs if m.kind == "agent"]
-    assert agent_msgs, f"Expected agent outbox message; got: {msgs}"
-    text = agent_msgs[0].text
-    assert "Tool call failed" in text, (
-        f"Expected English fallback when output_language=None; got: {text!r}"
-    )
-    assert "ツール呼び出しに失敗しました" not in text, (
-        f"Japanese should not appear when output_language=None: {text!r}"
-    )
-
-
-def test_tool_failed_fallback_includes_tool_name_and_error(tmp_path, monkeypatch):
-    """Tier 2: the tool_failed fallback message includes the skill name and the
-    error description so the user has actionable context (G10).
-    """
-    skill = "my.broken_skill"
-    msgs = _run_tool_failed_scenario(
-        tmp_path, monkeypatch, output_language="en", target_skill=skill
-    )
-    agent_msgs = [m for m in msgs if m.kind == "agent"]
-    assert agent_msgs, f"Expected agent outbox message; got: {msgs}"
-    text = agent_msgs[0].text
-    assert skill in text, (
-        f"Tool name '{skill}' not found in fallback message: {text!r}"
-    )
-    # Error description should be present (error kind or message fragment).
-    assert text.strip(), "Fallback message must not be empty"

--- a/tests/test_router_loop.py
+++ b/tests/test_router_loop.py
@@ -315,14 +315,13 @@ async def test_dedupe_does_not_collapse_distinct_async_args(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dedupe_does_not_apply_to_non_invoke_sync_tool_calls(monkeypatch):
-    """Tier 2: OS invariant — duplicate SYNC tool_calls (other than
-    invoke_skill) in same round are NOT deduped.
+    """Tier 2: OS invariant — duplicate SYNC tool_calls in the same round are
+    NOT deduped.
 
     Sync tool dupes are wasteful but correctness-preserving (same args →
     same result), and deduping them risks tool_call_id mismatches in the
-    follow-up assistant message. Only async tools (delegate_to_agent) and
-    invoke_skill (G3) get the dedupe treatment; describe_skill and other
-    pure-sync tools do not.
+    follow-up assistant message. Only async tools (delegate_to_agent) get the
+    dedupe treatment; sync tools do not.
     """
     host = FakeRouterHost(skills=[{"name": "my_skill", "category": "general"}])
     loop = make_loop(host)
@@ -347,42 +346,6 @@ async def test_dedupe_does_not_apply_to_non_invoke_sync_tool_calls(monkeypatch):
         if e["type"] == "tool_call_deduped"
     ]
     assert not deduped_events
-
-
-# ---------------------------------------------------------------------------
-# G3 fix (dogfood batch 5 B5-M1): dedupe duplicate invoke_skill in same round
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_tool_call_deduped_event_emitted_for_invoke_skill(monkeypatch):
-    """Tier 2: P6 invariant — deduped invoke_skill calls emit
-    `tool_call_deduped` events with correct name and reason fields,
-    making the dedupe visible in the audit log (P6).
-    """
-    host = FakeRouterHost(skills=[
-        {"name": "my_skill", "category": "general"},
-    ])
-    loop = make_loop(host)
-
-    duplicate_round = tool_result([
-        {"id": "tc_a", "name": "invoke_skill",
-         "args": {"name": "my_skill", "input": {"type": "T", "data": {}}}},
-        {"id": "tc_b", "name": "invoke_skill",
-         "args": {"name": "my_skill", "input": {"type": "T", "data": {}}}},
-    ])
-    scripted = _ScriptedLLM([duplicate_round, text_result("done")])
-
-    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
-    await loop.run("run skill", [])
-
-    deduped_events = [
-        e for e in host.events.emitted
-        if e["type"] == "tool_call_deduped"
-    ]
-    (evt,) = deduped_events
-    assert evt["name"] == "invoke_skill"
-    assert evt["reason"] == "duplicate_invoke_skill_in_round"
-    assert evt["chain_id"] == "chain-test"
 
 
 @pytest.mark.asyncio
@@ -577,53 +540,6 @@ async def test_dispatch_tool_emits_tool_failed_on_unknown_tool(monkeypatch):
     assert "tool_failed" in event_types
     failed = next(e for e in host.events.emitted if e["type"] == "tool_failed")
     assert failed["error_kind"] == "unknown_tool"
-
-
-@pytest.mark.asyncio
-async def test_invoke_skill_with_unknown_skill_name_rejected(monkeypatch):
-    """Tier 2: OS invariant — invoke_skill with a hallucinated skill name is rejected
-    and emits a deterministic i18n error message; no skill spawned (G10 / B2-M2 fix).
-
-    Layer A (enum) catches it via jsonschema validation → invalid_args.
-    If somehow enum is bypassed, Layer B raises ValueError → exception kind.
-    Either way, no skill spawn occurs. G10 fix: the router short-circuits and emits
-    a deterministic i18n message instead of passing the error back to the LLM.
-    """
-    host = FakeRouterHost(skills=[{"name": "real_skill", "category": "general"}])
-    loop = make_loop(host)
-
-    rounds = [
-        tool_result([{"name": "invoke_skill", "args": {
-            "name": "ai_article_writer.write_article",  # hallucinated name
-            "input": {"type": "T", "data": {}},
-        }}]),
-        text_result("Ok, trying differently."),  # must NOT be reached after G10 fix
-    ]
-
-    messages_captured: list[list[dict]] = []
-
-    async def mock_llm(*, messages, **kwargs):
-        messages_captured.append(list(messages))
-        return rounds[len(messages_captured) - 1]
-
-    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", mock_llm)
-    await loop.run("run bogus skill", [])
-
-    # No skill should have been spawned
-    assert not host.skill_calls, "No skill must be spawned for unknown name"
-
-    # G10: router exits after the failed tool call — only 1 LLM call (no second round).
-    # Unpacking asserts exactly one call (ValueError if more or fewer).
-    (only_captured,) = messages_captured
-
-    # Outbox must contain a deterministic error message (not the LLM-generated fallback).
-    assert host.outbox, "Expected at least one outbox message"
-    agent_msgs = [m for m in host.outbox if m.get("kind") == "agent"]
-    assert agent_msgs, f"Expected agent-kind outbox message; got: {host.outbox}"
-    text = agent_msgs[0]["text"]
-    assert "Tool call failed" in text, (
-        f"Expected deterministic English error message; got: {text!r}"
-    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** (B)-tail cleanup — remove the dead invoke_skill function-name-check cluster. Non-security, non-recovery-gated (low-risk, 1 PR). Lead-approved scope **(b) full dead cluster**.

## Evidence-first (all producers falsified on fresh main)
②a (`b7f9a0e4`) purged invoke_skill from the LLM-facing catalog → **uncallable**: not in `universal_catalog`, no internal tool_call synthesis, `invoke_action` does NOT unwrap to it, `tools/invoke_skill.py` gone, `list_available_skills` only in docstrings. Every `name == "invoke_skill"` branch is dead.

## REMOVE (verified per-branch)
- `_dedupe_tool_calls_round`: the `_DEDUPE_SYNC_TOOLS={"invoke_skill"}` sync-branch + `"duplicate_invoke_skill_in_round"` reason → now async-only dedupe. **Async-dedupe (delegate_to_agent, F5) stays live.**
- G10/B2-M2 interception: the invoke_skill-only `tool_failed` → i18n fallback block. **The invoke_action `routing_decided` block right after it is separate/live.**
- `_TOOL_FAILED_FALLBACK_MSG` (session.py + its router_loop import) — used only by that G10 block.
- Tests: 4 G10 `test_tool_failed_fallback_*` + helper (test_chat_router_i18n) + 2 invoke_skill dedup/rejection tests (test_router_loop) — removed-feature.

## KEEP (verified)
- `_invoke_skill_args` transform + `_RESOURCE_RULES` `skill__` resource-alias handling — **heterogeneous, woven into the LIVE invoke_action / agent.peer / mcp resource-alias machinery + skill-return roadmap.**
- F8/F11 retry-exhausted + SP-i18n tests (separate live `_ROUTER_RETRY_EXHAUSTED_MSG`); async-dedupe tests (docstring de-invoke_skill'd).

## Test plan
- [x] `ruff check` (changed set) — clean
- [x] `test_tier_audit.py --strict` (changed test files) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] full `pytest` — **6922 passed, 16 skipped** (6 removed-feature tests dropped)
- [x] Falsify LIVE paths unaffected: async-dedupe, invoke_action routing, F8/F11 i18n, skill__ resource-alias all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)