### PR TITLE
refactor(skill-word): (B) item3 — event_schema llm_* audit-req matches live emit

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -1,9 +1,9 @@
 """Event schema registry — declares required fields per event kind.
 
 Used by Tier 2 invariant tests to enforce audit completeness (FP-0021).
-NOT enforced at emit() runtime (to keep production overhead zero); the
-test in tests/test_event_audit_invariants.py validates that all listed
-events carry the declared required fields.
+NOT enforced at emit() runtime (to keep production overhead zero); each
+feature's invariant test asserts that its event kinds are declared here
+with the required fields.
 
 P7 note: kind names here are OS-level event kinds, not skill-specific
 identifiers, so this file stays within the OS layer's allowed vocabulary.
@@ -16,9 +16,12 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # Workflow lifecycle (runtime.py)
     "workflow_started": frozenset({"run_id", "skill"}),
     "workflow_finished": frozenset({"run_id", "skill"}),
-    # LLM call lifecycle (runtime.py)
-    "llm_called": frozenset({"run_id", "skill"}),
-    "llm_response_received": frozenset({"run_id", "skill"}),
+    # LLM cost events (llm.py _emit_chat_cost_events — cost-tab observability).
+    # Minimal fields: llm_called carries model, llm_response_received carries the
+    # usage/cost figures. skill is derived from the events file path (not an event
+    # field), and run_id is not threaded on this path.
+    "llm_called": frozenset({"model"}),
+    "llm_response_received": frozenset({"prompt_tokens", "completion_tokens", "cost_usd"}),
     # Permission events (op_runtime/__init__.py)
     "permission_granted": frozenset({"run_id", "skill", "phase"}),
     "permission_denied": frozenset({"run_id", "skill", "phase"}),


### PR DESCRIPTION
**[e2e-coder]** (B) event_schema item3 — non-owner-gated small cleanup (lead-approved). Aligns the stale `llm_called` / `llm_response_received` audit requirements with the actual live emit + drops a reference to a removed test.

## Evidence
Sole production emitter of both events = `llm.py _emit_chat_cost_events` (cost-tab observability): `llm_called` carries `model`; `llm_response_received` carries usage/cost. Neither carries `run_id`/`skill` — the cost tab derives `skill` from the events file path (llm.py:1540), and the kernel `LLMCallRecorder` that once emitted these with run_id/skill was **removed in #2434** (remaining refs are stale comments). The validating test the schema docstring cited (`tests/test_event_audit_invariants.py`) is also gone.

## Changes (src-only, event_schema.py)
- `llm_called`: `{run_id, skill}` → `{model}`.
- `llm_response_received`: `{run_id, skill}` → `{prompt_tokens, completion_tokens, cost_usd}`.
- Module docstring: drop the removed-test reference; per-feature invariant tests assert their own kinds.

## Explicitly NOT touched (separate tracks)
- `workflow_started`/`workflow_finished` + `EventExportDispatcher` — a live eval-export trigger with **0 production producers/wiring** (dead-subsystem vs silent-defect) → **owner-adjacent, escalated separately** (lead → owner).
- `permission_*`/`user_intervention_*` `skill=ctx.skill_name` audit field — the same caller-misnomer as the permission `skill_name→caller` rename → **folded into ②**.

## Test plan
- [x] `ruff check` — clean
- [x] `verify_module_docstrings.py` — OK
- [x] full `pytest` — **6922 passed, 16 skipped**
- [x] tier-audit — n/a (no test files changed)
- [x] EVENT_AUDIT_REQUIREMENTS consumer tests (chat_turn_completed_inline / mcp_search / session_lifecycle / event_export) green; no test pins the old llm_* requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)