### PR TITLE
refactor(skill-word): ② rename permission approval-scope key skill_name → actor

### DIFF
--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -33,7 +33,7 @@ class DispatchContext:
     Attributes:
         caller_kind: "router" for chat agent main loop, "skill_phase" for
             skills' op execution. Used in event taxonomy for filtering.
-        caller_id: agent_name (router) or f"{skill_name}.{phase_name}"
+        caller_id: agent_name (router) or f"{actor}.{phase_name}"
             (skill_phase). Identifies the audit subject.
         chain_id: optional chain id for multi-hop tracing (PR14).
         tool_catalog: dict[str, dict] mapping tool name → tool definition

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -23,11 +23,11 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     "llm_called": frozenset({"model"}),
     "llm_response_received": frozenset({"prompt_tokens", "completion_tokens", "cost_usd"}),
     # Permission events (op_runtime/__init__.py)
-    "permission_granted": frozenset({"run_id", "skill", "phase"}),
-    "permission_denied": frozenset({"run_id", "skill", "phase"}),
+    "permission_granted": frozenset({"run_id", "actor", "phase"}),
+    "permission_denied": frozenset({"run_id", "actor", "phase"}),
     # User intervention (op_runtime/ask_user.py)
-    "user_intervention_requested": frozenset({"run_id", "skill", "intervention_id"}),
-    "user_intervention_received": frozenset({"run_id", "skill", "intervention_id"}),
+    "user_intervention_requested": frozenset({"run_id", "actor", "intervention_id"}),
+    "user_intervention_received": frozenset({"run_id", "actor", "intervention_id"}),
     # MCP tool-search deferred loading (chat/router_tools.py — FP-0024 Component D)
     # Emitted by the router when the LLM invokes the tool_search_tool meta-tool.
     # mcp_search_invoked: LLM called tool_search; query + result count recorded.

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -53,7 +53,7 @@ async def execute_op(
         ctx.events.emit(
             "permission_granted",
             run_id=ctx.run_id,
-            skill=ctx.skill_name,
+            actor=ctx.actor,
             phase=ctx.current_phase,
             kind=op.kind,
             path=path,
@@ -64,7 +64,7 @@ async def execute_op(
         ctx.events.emit(
             "permission_denied",
             run_id=ctx.run_id,
-            skill=ctx.skill_name,
+            actor=ctx.actor,
             phase=ctx.current_phase,
             kind=op.kind,
             path=path,

--- a/src/reyn/core/op_runtime/ask_user.py
+++ b/src/reyn/core/op_runtime/ask_user.py
@@ -46,14 +46,14 @@ async def handle(op: AskUserIROp, ctx: OpContext) -> dict:
         suggestions=op.suggestions or [],
         choices=choices,
         input_type="select" if choices else "",
-        skill_name=ctx.skill_name or None,
+        actor=ctx.actor or None,
         run_id=None,  # set by chat session if it tracks runs; CLI ignores
     )
 
     ctx.events.emit(
         "user_intervention_requested",
         run_id=ctx.run_id,
-        skill=ctx.skill_name,
+        actor=ctx.actor,
         phase=ctx.current_phase,
         question=op.question,
         intervention_id=iv.id,
@@ -71,7 +71,7 @@ async def handle(op: AskUserIROp, ctx: OpContext) -> dict:
     ctx.events.emit(
         "user_intervention_received",
         run_id=ctx.run_id,
-        skill=ctx.skill_name,
+        actor=ctx.actor,
         phase=ctx.current_phase,
         answer=text,
         intervention_id=iv.id,

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -38,7 +38,7 @@ class OpContext:
     # Permissions
     permission_decl: "PermissionDecl"
     permission_resolver: "PermissionResolver | None" = None
-    skill_name: str = ""
+    actor: str = ""
 
     model: str = "standard"
     resolver: "ModelResolver | None" = None

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -169,7 +169,7 @@ def _read_inline_cap(ctx: OpContext) -> int:
             model_str = ctx.resolver.resolve(ctx.model).model
         except Exception:
             model_str = None
-    return control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.skill_name)
+    return control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.actor)
 
 
 def _resolve_for_gate(ctx: OpContext, path_str: str) -> str:
@@ -209,20 +209,20 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         if op.op in _WRITE_OPS:
             write_target = op.output_path if op.op == "regenerate_index" and op.output_path else op.path
             await ctx.permission_resolver.require_file_write(
-                ctx.permission_decl, _resolve_for_gate(ctx, write_target), ctx.skill_name,
+                ctx.permission_decl, _resolve_for_gate(ctx, write_target), ctx.actor,
                 sandbox_policy=_sandbox, bus=ctx.intervention_bus,
             )
             # move also writes to dest_path — gate both source (= the file
             # being effectively deleted) and dest (= the file being created).
             if op.op == "move" and op.dest_path:
                 await ctx.permission_resolver.require_file_write(
-                    ctx.permission_decl, _resolve_for_gate(ctx, op.dest_path), ctx.skill_name,
+                    ctx.permission_decl, _resolve_for_gate(ctx, op.dest_path), ctx.actor,
                     sandbox_policy=_sandbox, bus=ctx.intervention_bus,
                 )
         elif op.op in _READ_OPS:
             # read / glob / grep / stat — gate against read scope
             await ctx.permission_resolver.require_file_read(
-                ctx.permission_decl, _resolve_for_gate(ctx, op.path), ctx.skill_name,
+                ctx.permission_decl, _resolve_for_gate(ctx, op.path), ctx.actor,
                 sandbox_policy=_sandbox, bus=ctx.intervention_bus,
             )
 

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -53,7 +53,7 @@ async def handle(
         sandbox_policy = sandbox_policy_from_ctx(ctx)
         sources_yaml = workspace_root / ".reyn" / "config" / "index" / "sources.yaml"
         await ctx.permission_resolver.require_file_write(
-            ctx.permission_decl, str(sources_yaml), ctx.skill_name,
+            ctx.permission_decl, str(sources_yaml), ctx.actor,
             sandbox_policy=sandbox_policy,
         )
         # #1199 S3.4 Part1: gate the actual deletion target — the source dir —
@@ -62,7 +62,7 @@ async def handle(
         # host-direct; the gate fires before backend.drop opens/removes it.
         source_dir = workspace_root / ".reyn" / "cache" / "index" / op.source
         await ctx.permission_resolver.require_file_write(
-            ctx.permission_decl, str(source_dir), ctx.skill_name,
+            ctx.permission_decl, str(source_dir), ctx.actor,
             sandbox_policy=sandbox_policy,
         )
 

--- a/src/reyn/core/op_runtime/index_query.py
+++ b/src/reyn/core/op_runtime/index_query.py
@@ -80,7 +80,7 @@ async def handle(
     if ctx.permission_resolver is not None:
         db_path = workspace_root / ".reyn" / "cache" / "index" / op.source / "index.db"
         await ctx.permission_resolver.require_file_read(
-            ctx.permission_decl, str(db_path), ctx.skill_name,
+            ctx.permission_decl, str(db_path), ctx.actor,
             sandbox_policy=sandbox_policy_from_ctx(ctx),
         )
 

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -220,7 +220,7 @@ async def handle(
         # #1352-C: thread the agent/operator sandbox policy (SandboxLayer ∩),
         # same as op_runtime/file.py — was missing here (permission-only gap).
         await ctx.permission_resolver.require_file_write(
-            ctx.permission_decl, str(config_path), ctx.skill_name,
+            ctx.permission_decl, str(config_path), ctx.actor,
             sandbox_policy=_sandbox_policy_from_ctx(ctx),
         )
 

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -363,7 +363,7 @@ async def handle(
         # ran permission-only (SandboxLayer ⊤). None → ⊤ (unchanged).
         _sandbox = _sandbox_policy_from_ctx(ctx)
         await ctx.permission_resolver.require_file_write(
-            ctx.permission_decl, str(config_path), ctx.skill_name,
+            ctx.permission_decl, str(config_path), ctx.actor,
             sandbox_policy=_sandbox,
         )
         # Registry fetch happened via RegistryClient above — gate the
@@ -375,7 +375,7 @@ async def handle(
                 ctx.permission_decl,
                 "registry.modelcontextprotocol.io",
                 ctx.intervention_bus,
-                ctx.skill_name,
+                ctx.actor,
                 sandbox_policy=_sandbox,
             )
 
@@ -400,7 +400,7 @@ async def handle(
     def _save_with_gate(key: str, value: str) -> None:
         if ctx.permission_resolver is not None:
             ctx.permission_resolver.require_secret_write(
-                ctx.permission_decl, key, ctx.skill_name,
+                ctx.permission_decl, key, ctx.actor,
             )
         from reyn.security.secrets.store import save_secret
         save_secret(key, value)

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -243,7 +243,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext) -> dict:
         # network:false vetoes the fetch. Re-run on EVERY hop (not just initial).
         if ctx.permission_resolver is not None:
             await ctx.permission_resolver.require_http_get(
-                ctx.permission_decl, host, ctx.intervention_bus, ctx.skill_name,
+                ctx.permission_decl, host, ctx.intervention_bus, ctx.actor,
                 sandbox_policy=_sandbox_policy_from_ctx(ctx),
             )
         # L2 — SSRF IP-deny (always; independent of the permission system).

--- a/src/reyn/data/workspace/workspace.py
+++ b/src/reyn/data/workspace/workspace.py
@@ -30,7 +30,7 @@ class Workspace:
         self,
         events: EventLog,
         permission_resolver: "PermissionResolver | None" = None,
-        skill_name: str = "",
+        actor: str = "",
         base_dir: "Path | None" = None,
         state_dir: "Path | None" = None,
         environment_backend: "EnvironmentBackend | None" = None,
@@ -68,7 +68,7 @@ class Workspace:
         self.state_dir.mkdir(parents=True, exist_ok=True)
         (self.state_dir / "artifacts").mkdir(exist_ok=True)
         self._perm = permission_resolver
-        self._skill_name = skill_name
+        self._actor = actor
 
     @property
     def backend(self) -> "EnvironmentBackend":
@@ -97,7 +97,7 @@ class Workspace:
         resolved = (self.base_dir / p).resolve() if not p.is_absolute() else p.resolve()
         if resolved.is_relative_to(self.base_dir):
             return resolved
-        if self._perm and self._perm.is_read_allowed(str(resolved), self._skill_name):
+        if self._perm and self._perm.is_read_allowed(str(resolved), self._actor):
             return resolved
         raise PermissionError(f"read not permitted: {path_str!r} (outside project)")
 
@@ -122,7 +122,7 @@ class Workspace:
         p = Path(path_str).expanduser()
         if p.is_absolute():
             resolved = p.resolve()
-            if self._perm and self._perm.is_write_allowed(str(resolved), self._skill_name):
+            if self._perm and self._perm.is_write_allowed(str(resolved), self._actor):
                 return resolved
             raise PermissionError(
                 f"write not permitted: {path_str!r} (absolute paths are read-only)"
@@ -130,7 +130,7 @@ class Workspace:
         resolved = (self.base_dir / p).resolve()
         if resolved.is_relative_to(self.base_dir):
             return resolved
-        if self._perm and self._perm.is_write_allowed(str(resolved), self._skill_name):
+        if self._perm and self._perm.is_write_allowed(str(resolved), self._actor):
             return resolved
         raise PermissionError(f"path escapes project: {path_str!r}")
 
@@ -256,7 +256,7 @@ class Workspace:
                 base_for_check = str(Path(*concrete_parts)) if concrete_parts else pattern_str
                 if not (
                     self._perm is not None
-                    and self._perm.is_read_allowed(base_for_check, self._skill_name)
+                    and self._perm.is_read_allowed(base_for_check, self._actor)
                 ):
                     raise PermissionError(
                         f"glob not permitted: {pattern!r} (outside project, no read permission)"
@@ -326,11 +326,11 @@ class Workspace:
         phase: str,
         artifact: dict,
         *,
-        skill_name: str = "_unknown",
+        actor: str = "_unknown",
         visit: int = 1,
     ) -> str:
         """
-        Persist artifact to state_dir/artifacts/{skill_name}/{phase}/v{visit}_{type}.json.
+        Persist artifact to state_dir/artifacts/{actor}/{phase}/v{visit}_{type}.json.
         Returns the state_dir-relative path.
         """
         artifact_type = artifact.get("type", "unknown")
@@ -339,7 +339,7 @@ class Workspace:
             return s.replace("/", "_").replace(" ", "_")
 
         rel = (
-            f"artifacts/{_safe(skill_name)}/{_safe(phase)}"
+            f"artifacts/{_safe(actor)}/{_safe(phase)}"
             f"/v{visit:02d}_{_safe(artifact_type)}.json"
         )
         abs_path = self.state_dir / rel

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -744,7 +744,7 @@ def _run_install_from_source(
         events=events,
         permission_decl=decl,
         permission_resolver=perm_resolver,
-        skill_name="mcp_install_source",
+        actor="mcp_install_source",
         intervention_bus=bus,
     )
 

--- a/src/reyn/interfaces/cli/commands/source.py
+++ b/src/reyn/interfaces/cli/commands/source.py
@@ -228,7 +228,7 @@ async def _cmd_rm_async(args: argparse.Namespace) -> int:
         events=events,
         permission_decl=decl,
         permission_resolver=perm_resolver,
-        skill_name="reyn_source_rm",
+        actor="reyn_source_rm",
         intervention_bus=bus,
     )
 

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -13,12 +13,12 @@ from reyn.runtime.outbox import OutboxMessage
 
 
 def _meta_prefix(meta: dict) -> str:
-    """Build a `[skill_name#abcd] ` prefix from meta provenance, if present.
+    """Build a `[actor#abcd] ` prefix from meta provenance, if present.
 
-    Returns "" when neither skill_name nor run_id_short is set, so generic
+    Returns "" when neither actor nor run_id_short is set, so generic
     status / error messages stay clean.
     """
-    skill = meta.get("skill_name")
+    skill = meta.get("actor")
     short = meta.get("run_id_short")
     if skill and short:
         return f"[{skill}#{short}] "
@@ -63,7 +63,7 @@ class ChatRenderer:
         """Render one outbox item.
 
         msg.kind ∈ {"agent","status","error","intervention","trace","skill_done"}
-        msg.meta carries provenance (skill_name, run_id, run_id_short, ...)
+        msg.meta carries provenance (actor, run_id, run_id_short, ...)
         """
 
     def prompt_text(self) -> AnyFormattedText:
@@ -639,9 +639,9 @@ def format_inline_message(msg: OutboxMessage):
     # renders as literal text inside the agent markdown body.
     # Intervention is user-facing: suppress the cryptic run_id_short hash — the
     # user doesn't need disambiguation for a prompt that has one active caller.
-    # skill_name context (e.g. "[skill_builder] ") is still shown if present.
+    # actor context (e.g. "[skill_builder] ") is still shown if present.
     if kind == "intervention":
-        skill = meta.get("skill_name")
+        skill = meta.get("actor")
         _pfx = f"[{skill}] " if skill else ""
     else:
         _pfx = _meta_prefix(meta)

--- a/src/reyn/interfaces/slash/chat.py
+++ b/src/reyn/interfaces/slash/chat.py
@@ -20,7 +20,7 @@ async def list_cmd(session: "Session", args: str) -> None:
             short = (iv.run_id[-4:] if iv.run_id else "----")
             lines.append(
                 f"  {iv.id[:8]}  {iv.kind:<20}  "
-                f"{iv.skill_name or '?'}#{short}"
+                f"{iv.actor or '?'}#{short}"
             )
     await reply(session, "\n".join(lines))
 

--- a/src/reyn/interfaces/web/routers/runs.py
+++ b/src/reyn/interfaces/web/routers/runs.py
@@ -107,7 +107,7 @@ def _read_events(path: Path) -> list[dict]:
 
 class RunSummary(BaseModel):
     run_id: str
-    skill_name: str | None
+    actor: str | None
     started_at: str | None
     # status, cost etc. could be added once we agree on a stable first-event schema.
     # For now surface only what the filename reliably tells us.
@@ -126,7 +126,7 @@ async def list_runs(
         # run_id format: 20260501T103200Z_skill_name
         parts = run_id.split("_", 1)
         started_at_raw = parts[0] if parts else None
-        skill_name = parts[1] if len(parts) > 1 else None
+        actor = parts[1] if len(parts) > 1 else None
         # Parse ts into ISO-8601
         started_at: str | None = None
         if started_at_raw and len(started_at_raw) == 16:  # YYYYMMDDTHHMMSSz
@@ -138,7 +138,7 @@ async def list_runs(
                 started_at = started_at_raw
         results.append(RunSummary(
             run_id=run_id,
-            skill_name=skill_name,
+            actor=actor,
             started_at=started_at,
         ))
     return results

--- a/src/reyn/interfaces/web/ws/chat.py
+++ b/src/reyn/interfaces/web/ws/chat.py
@@ -13,7 +13,7 @@ Protocol (server → client):
     {
         "kind": "<kind>",     # agent | status | error | intervention | trace | skill_done
         "text": "<text>",
-        "meta": {             # optional provenance: run_id, run_id_short, skill_name,
+        "meta": {             # optional provenance: run_id, run_id_short, actor,
                               # intervention_id, intervention_kind, choices, ...
             ...
         }

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -289,7 +289,7 @@ class ChatLifecycleForwarder:
     ) -> None:
         """Shared enqueue path for the three tool-call lifecycle outbox kinds.
 
-        Session-level forwarder has no own ``run_id`` / ``skill_name`` to
+        Session-level forwarder has no own ``run_id`` / ``actor`` to
         contribute — every meta field is sourced from the event payload
         itself. Consumers (= the conv pane's ``_on_tool_call_*``) read
         ``meta["op_id"]`` (= the deterministic ``args_hash``) to pair

--- a/src/reyn/runtime/limits/limit_handler.py
+++ b/src/reyn/runtime/limits/limit_handler.py
@@ -128,7 +128,7 @@ async def handle_limit_exceeded(
     prompt: str,
     detail: str = "",
     extension_amount: float = 1.0,
-    skill_name: str | None = None,
+    actor: str | None = None,
     non_interactive: bool = False,
 ) -> LimitDecision:
     """Generic safety-limit checkpoint dispatcher (FP-0005).
@@ -159,7 +159,7 @@ async def handle_limit_exceeded(
         detail: Optional second line of context (= specifics like
                 "Phase 'revise' visit count 25 / 25").
         extension_amount: How much to extend the counter by on approval.
-        skill_name: Optional skill name for /list / TUI display.
+        actor: Optional skill name for /list / TUI display.
 
     Returns:
         LimitDecision describing the outcome. Caller is responsible for
@@ -207,7 +207,7 @@ async def handle_limit_exceeded(
         detail=detail,
         choices=_yes_no_choices(),
         run_id=run_id,
-        skill_name=skill_name,
+        actor=actor,
     )
     try:
         if on_limit.ask_timeout_seconds > 0:

--- a/src/reyn/runtime/outbox.py
+++ b/src/reyn/runtime/outbox.py
@@ -1,7 +1,7 @@
 """OutboxMessage — structured payload for Session's display stream.
 
 Replaces the previous (kind, text) tuple. Provenance fields (run_id,
-skill_name, intervention_id, …) live in `meta: dict` rather than as fixed
+actor, intervention_id, …) live in `meta: dict` rather than as fixed
 attributes, so future additions (e.g. `agent_id` for multi-agent sessions)
 don't require dataclass schema changes. This mirrors the `ChatMessage.meta`
 convention already used for history entries.
@@ -30,7 +30,7 @@ class OutboxMessage:
     Common keys:
       run_id           full chat-side run id (e.g. "20260501T...Z_skill_foo_abcd")
       run_id_short     trailing 4 chars of run_id, used in display prefix
-      skill_name       human-friendly skill name for [skill#abcd] prefix
+      actor       human-friendly skill name for [skill#abcd] prefix
       intervention_id  for kind="intervention", which UI is being announced
 
     Future keys (multi-agent):

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -717,7 +717,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
     # Builds a permission-aware OpContext with the operator-declared
-    # PermissionDecl + Workspace(skill_name="chat_router") + mcp_servers,
+    # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,
     # so handlers in src/reyn/tools/{file,mcp,web*}.py can delegate to
     # op_runtime with the same gating the legacy router branches had.
     def make_router_op_context(self) -> Any: ...

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -1,6 +1,6 @@
 """#1412: single-source the chat-router OpContext construction.
 
-Two hosts built the ``skill_name="chat_router"`` OpContext with ~95% identical
+Two hosts built the ``actor="chat_router"`` OpContext with ~95% identical
 code: ``Session._make_router_op_context`` (session.py) and
 ``RouterHostAdapter.make_router_op_context`` (services/router_host_adapter.py).
 They drifted — #1410/#1411 threaded ``base_dir`` to one and lagged the other
@@ -117,7 +117,7 @@ def build_router_op_context(
     workspace = Workspace(
         events=events,
         permission_resolver=permission_resolver,
-        skill_name="chat_router",
+        actor="chat_router",
         # #187: chat OpContext FS root = the container repo root with a container
         # env-backend (e.g. /testbed); state_dir stays host-side. None → cwd default.
         base_dir=workspace_base_dir,
@@ -129,7 +129,7 @@ def build_router_op_context(
         events=events,
         permission_decl=decl,
         permission_resolver=permission_resolver,
-        skill_name="chat_router",
+        actor="chat_router",
         mcp_servers=mcp_servers_flat,
         run_id=run_id,
         agent_id=agent_id,

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -87,8 +87,8 @@ def _iv_meta(iv: UserIntervention) -> dict:
     if iv.run_id:
         out["run_id"] = iv.run_id
         out["run_id_short"] = iv.run_id[-4:] if iv.run_id else ""
-    if iv.skill_name:
-        out["skill_name"] = iv.skill_name
+    if iv.actor:
+        out["actor"] = iv.actor
     if iv.choices:
         out["choices"] = [
             {"id": c.id, "label": c.label, "hotkey": c.hotkey}
@@ -241,7 +241,7 @@ class InterventionHandler:
             from reyn.security.content_guard import fence_if_enabled
             history_text = fence_if_enabled(text, self._threat_scan)
         meta = {
-            "answered_skill": iv.skill_name or "",
+            "answered_skill": iv.actor or "",
             "answered_run_id": iv.run_id or "",
             "intervention_id": iv.id,
             "intervention_kind": iv.kind,
@@ -259,7 +259,7 @@ class InterventionHandler:
             intervention_id=iv.id,
             kind=iv.kind,
             run_id=iv.run_id,
-            skill=iv.skill_name,
+            skill=iv.actor,
             choice_id=choice.id if choice else None,
             answer_text=text if not iv.choices else "",
         )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -200,7 +200,7 @@ class RouterHostAdapter:
         # router-initiated tools that need the 4-layer approval flow
         # (web_fetch interactive prompt, mcp install / drop ask gates).
         # Session passes a factory that wraps ``ChatInterventionBus(
-        # session, run_id=None, skill_name="chat_router")``; tests can
+        # session, run_id=None, actor="chat_router")``; tests can
         # pass None and the OpContext gets ``intervention_bus=None`` (=
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
@@ -1745,11 +1745,11 @@ class RouterHostAdapter:
         Public method (ADR-0026 Phase 3.5): the unified registry handlers
         in ``src/reyn/tools/`` delegate to op_runtime via this factory so
         the OpContext carries the operator-declared PermissionDecl and the
-        Workspace with ``skill_name="chat_router"``. Without this, handlers
+        Workspace with ``actor="chat_router"``. Without this, handlers
         would synthesize a ``PermissionDecl()`` empty default and op_runtime
         permission gates would deny operations.
 
-        Uses the injected events log and permission resolver. The skill_name
+        Uses the injected events log and permission resolver. The actor
         ``"chat_router"`` is used for permission key lookups. PermissionDecl
         is populated from the agent's effective permissions so that op_runtime
         layer permission checks actually gate access.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -454,14 +454,14 @@ def _run_short(run_id: str) -> str:
     return run_id[-4:] if run_id else ""
 
 
-def _run_meta(run_id: str | None, skill_name: str | None) -> dict:
+def _run_meta(run_id: str | None, actor: str | None) -> dict:
     """Standard `meta` payload for OutboxMessage produced inside a skill spawn."""
     if run_id is None:
-        return {"skill_name": skill_name} if skill_name else {}
+        return {"actor": actor} if actor else {}
     return {
         "run_id": run_id,
         "run_id_short": _run_short(run_id),
-        "skill_name": skill_name,
+        "actor": actor,
     }
 
 
@@ -560,8 +560,8 @@ def _iv_meta(iv: "UserIntervention") -> dict:
     if iv.run_id:
         out["run_id"] = iv.run_id
         out["run_id_short"] = _run_short(iv.run_id)
-    if iv.skill_name:
-        out["skill_name"] = iv.skill_name
+    if iv.actor:
+        out["actor"] = iv.actor
     if iv.choices:
         out["choices"] = [
             {"id": c.id, "label": c.label, "hotkey": c.hotkey}
@@ -1563,7 +1563,7 @@ class Session:
             # — short-lived, scoped to the chat_router skill, identical
             # to what session._mcp_call_tool wires manually today.
             intervention_bus_factory=lambda: ChatInterventionBus(
-                self, run_id=None, skill_name="chat_router",
+                self, run_id=None, actor="chat_router",
                 channel_id=DEFAULT_CHAT_CHANNEL_ID,
             ),
             # FP-0037 S2: yaml mtime watch needs the project root to resolve
@@ -5030,7 +5030,7 @@ class Session:
     def _make_router_op_context(self) -> "OpContext":
         """Build a minimal OpContext for router-initiated file/MCP ops.
 
-        Uses the session's events log and permission resolver. The skill_name
+        Uses the session's events log and permission resolver. The actor
         "chat_router" is used for permission key lookups — it matches what the
         PermissionResolver uses to gate paths. All .reyn/ paths are in the
         default write zone so memory ops pass without additional approval.
@@ -5217,7 +5217,7 @@ class Session:
         ctx = self._make_router_op_context()
         # MCP handler requires intervention_bus; wire the session's bus
         ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, skill_name="chat_router",
+            self, run_id=None, actor="chat_router",
             channel_id=DEFAULT_CHAT_CHANNEL_ID,
         )
         # Narrow mcp scope to just this server while preserving file perms from the

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -59,9 +59,9 @@ class ChatInterventionBus:
     """``UserChannel`` implementation that routes through Session's
     outbox/inbox to the attached TUI listener.
 
-    One instance per skill spawn — captures `run_id` and a default `skill_name`
+    One instance per skill spawn — captures `run_id` and a default `actor`
     so the chat session can drop pending interventions when the spawn is
-    cancelled. Interventions emitted by ops carry their own `skill_name` from
+    cancelled. Interventions emitted by ops carry their own `actor` from
     `OpContext`; this bus only fills in `run_id` (which the OS layer doesn't
     have, since chat tracks runs separately from the runtime's run_id).
 
@@ -78,13 +78,13 @@ class ChatInterventionBus:
         self,
         session: "Session",
         run_id: str | None,
-        skill_name: str | None,
+        actor: str | None,
         *,
         channel_id: str | None = None,
     ) -> None:
         self._session = session
         self._run_id = run_id
-        self._skill_name = skill_name
+        self._actor = actor
         # issue #268 Phase 2 continuation: optional channel_id stamping.
         # Production wiring (= Session._build_intervention_bus_for_skill)
         # passes the session's canonical channel_id (e.g. "tui") so
@@ -122,8 +122,8 @@ class ChatInterventionBus:
             iv.origin_channel_id = self._channel_id
         if iv.run_id is None:
             iv.run_id = self._run_id
-        if not iv.skill_name:
-            iv.skill_name = self._skill_name
+        if not iv.actor:
+            iv.actor = self._actor
         # PR-intervention-link L6: short-circuit if a previous (crashed-then-
         # restored) run's intervention was already answered post-restart.
         # The L5 watcher buffered the answer keyed by run_id; the resuming

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -333,7 +333,7 @@ def tool_contextually_denied(
 
 def skill_allowed(
     allowed_skills: "object | None",
-    skill_name: str,
+    actor: str,
     *,
     contextual: "ContextualPermission | None" = None,
 ) -> bool:
@@ -360,7 +360,7 @@ def skill_allowed(
     ]
     if contextual is not None:
         layers.append(ContextualLayer(contextual))
-    return EffectivePermission(layers).allows(CapabilityAxis.SKILL, skill_name)
+    return EffectivePermission(layers).allows(CapabilityAxis.SKILL, actor)
 
 
 def _path_under(path_str: str, root: str) -> bool:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -17,9 +17,9 @@ Approval choices (shown once at startup before execution starts):
   [r]ecursive from parent      — persist approval for the parent directory + skill (covers all files under it)
   [N]o                         — deny
 
-Approval keys are skill-scoped to prevent external skill privilege escalation:
-  "{skill_name}/file.write/{path}"   (just_path)
-  "{skill_name}/file.write/{dir}/"   (recursive, trailing slash signals recursive)
+Approval keys are actor-scoped to prevent external-actor privilege escalation:
+  "{actor}/file.write/{path}"   (just_path)
+  "{actor}/file.write/{dir}/"   (recursive, trailing slash signals recursive)
 
 Config pre-approval (reyn.yaml / reyn.local.yaml):
   permissions:
@@ -647,7 +647,7 @@ class PermissionResolver:
 
     # ── File access approval (read + write) ───────────────────────────────────
 
-    def _is_path_approved_for(self, path: str, skill_name: str, kind: str) -> bool:
+    def _is_path_approved_for(self, path: str, actor: str, kind: str) -> bool:
         """Return True if path is covered by any saved/session approval for this skill+kind.
 
         kind is "file.read" or "file.write".
@@ -655,7 +655,7 @@ class PermissionResolver:
         base = self._project_root
         p = Path(path).expanduser()
         p_resolved = (base / p).resolve() if not p.is_absolute() else p.resolve()
-        prefix = f"{skill_name}/{kind}/"
+        prefix = f"{actor}/{kind}/"
         combined = {**self._saved, **self._session}
         for key, approved in combined.items():
             if not approved or not key.startswith(prefix):
@@ -684,8 +684,8 @@ class PermissionResolver:
         return False
 
     # Backwards-compatible alias used by older write-class call sites.
-    def _is_path_approved(self, path: str, skill_name: str) -> bool:
-        return self._is_path_approved_for(path, skill_name, "file.write")
+    def _is_path_approved(self, path: str, actor: str) -> bool:
+        return self._is_path_approved_for(path, actor, "file.write")
 
     def _resolve_for_offload(self, path: str) -> str:
         """Resolve ``path`` to an absolute string (same convention as the gate)."""
@@ -716,12 +716,12 @@ class PermissionResolver:
         live here — a single source both gates call, so the offload-grant
         decision cannot diverge (the merged D12 bug: only one gate had it). The
         per-skill path-approval term differs (is_read_allowed guards it on a
-        non-empty skill_name) and stays inline in each gate.
+        non-empty actor) and stays inline in each gate.
         """
         return self._is_config_approved("file.read") or self._is_offload_read_granted(path)
 
     def _is_host_approved_for(
-        self, host: str, skill_name: str, kind: str = "http.get",
+        self, host: str, actor: str, kind: str = "http.get",
     ) -> bool:
         """Return True if ``host`` is covered by a saved/session approval.
 
@@ -730,13 +730,13 @@ class PermissionResolver:
         :meth:`_is_path_approved_for` but skips the filesystem
         resolution because hosts are network identifiers, not paths.
         """
-        if not skill_name or not host:
+        if not actor or not host:
             return False
-        key = f"{skill_name}/{kind}/{host}"
+        key = f"{actor}/{kind}/{host}"
         return bool(self._saved.get(key) or self._session.get(key))
 
     def session_approve_path(
-        self, path: str, skill_name: str, kind: str, recursive: bool = False,
+        self, path: str, actor: str, kind: str, recursive: bool = False,
     ) -> None:
         """Mark `path` as approved for this session only (not persisted).
 
@@ -756,10 +756,10 @@ class PermissionResolver:
         p = str(raw.resolve() if raw.is_absolute() else (self._project_root / raw).resolve())
         if recursive:
             p = p.rstrip("/") + "/"
-        self._session[f"{skill_name}/{kind}/{p}"] = True
+        self._session[f"{actor}/{kind}/{p}"] = True
 
     def session_approve_host(
-        self, host: str, skill_name: str, kind: str = "http.get",
+        self, host: str, actor: str, kind: str = "http.get",
     ) -> None:
         """Mark ``host`` as approved for this session only (not persisted).
 
@@ -770,12 +770,12 @@ class PermissionResolver:
         and operator-startup code can pre-seed approvals via this public
         surface instead of mutating ``_session`` directly.
         """
-        if not skill_name or not host:
+        if not actor or not host:
             return
-        self._session[f"{skill_name}/{kind}/{host}"] = True
+        self._session[f"{actor}/{kind}/{host}"] = True
 
     async def _prompt_file_access(
-        self, path: str, scope: str, skill_name: str, kind: str, bus: RequestBus,
+        self, path: str, scope: str, actor: str, kind: str, bus: RequestBus,
     ) -> bool:
         """Prompt the user to approve a file access. Returns True if approved.
 
@@ -810,16 +810,16 @@ class PermissionResolver:
         # operator happened to pick [r] — the declared recursive intent was not honored (skill_builder).
         affirmative_key = recursive_target if scope == "recursive" else path
         if choice == YES:
-            self._session[f"{skill_name}/{kind}/{affirmative_key}"] = True
+            self._session[f"{actor}/{kind}/{affirmative_key}"] = True
             return True
         if choice == JUST_PATH:
-            self._persist(f"{skill_name}/{kind}/{affirmative_key}", True)
+            self._persist(f"{actor}/{kind}/{affirmative_key}", True)
             return True
         if choice == RECURSIVE:
-            self._persist(f"{skill_name}/{kind}/{recursive_target}", True)
+            self._persist(f"{actor}/{kind}/{recursive_target}", True)
             return True
         # NO or unknown → deny (session-only)
-        self._session[f"{skill_name}/{kind}/{path}"] = False
+        self._session[f"{actor}/{kind}/{path}"] = False
         return False
 
     # ── Public check methods ──────────────────────────────────────────────────
@@ -828,7 +828,7 @@ class PermissionResolver:
         self,
         decl: PermissionDecl,
         path: str,
-        skill_name: str = "",
+        actor: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
         bus: "RequestBus | None" = None,
@@ -865,7 +865,7 @@ class PermissionResolver:
             # #1383: config + offload grant via the shared base (kept in sync with
             # is_read_allowed); per-skill path-approval inline.
             return self._read_base_approved(str(value)) or self._is_path_approved_for(
-                str(value), skill_name, "file.read"
+                str(value), actor, "file.read"
             )
 
         if EffectivePermission([
@@ -876,7 +876,7 @@ class PermissionResolver:
 
         # JIT ask: outside zone, not yet approved. Mirrors require_http_get wildcard path.
         if bus is not None:
-            if await self._prompt_file_access(path, "just_path", skill_name, "file.read", bus):
+            if await self._prompt_file_access(path, "just_path", actor, "file.read", bus):
                 return
 
         raise PermissionError(
@@ -892,7 +892,7 @@ class PermissionResolver:
         self,
         decl: PermissionDecl,
         path: str,
-        skill_name: str = "",
+        actor: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
         bus: "RequestBus | None" = None,
@@ -927,7 +927,7 @@ class PermissionResolver:
 
         def _approved(axis: object, value: object) -> bool:
             return self._is_config_approved("file.write") or self._is_path_approved_for(
-                str(value), skill_name, "file.write"
+                str(value), actor, "file.write"
             )
 
         if EffectivePermission([
@@ -938,7 +938,7 @@ class PermissionResolver:
 
         # JIT ask: outside zone, not yet approved. Mirrors require_http_get wildcard path.
         if bus is not None:
-            if await self._prompt_file_access(path, "just_path", skill_name, "file.write", bus):
+            if await self._prompt_file_access(path, "just_path", actor, "file.write", bus):
                 return
 
         raise PermissionError(
@@ -956,7 +956,7 @@ class PermissionResolver:
         decl: PermissionDecl,
         host: str,
         bus: "RequestBus | None" = None,
-        skill_name: str = "",
+        actor: str = "",
         *,
         sandbox_policy: "SandboxPolicy | None" = None,
     ) -> None:
@@ -1037,7 +1037,7 @@ class PermissionResolver:
 
         # Persisted per-host approval (from a prior interactive
         # runtime prompt, specific or wildcard).
-        if skill_name and self._is_host_approved_for(host, skill_name, "http.get"):
+        if actor and self._is_host_approved_for(host, actor, "http.get"):
             return
         # Legacy session/saved ``web.fetch`` approval still authorises
         # every host while the deprecation window is open.
@@ -1074,7 +1074,7 @@ class PermissionResolver:
                     f"or run interactively so the prompt can collect "
                     f"approvals)."
                 )
-            approval_key = f"{skill_name}/http.get/{host}"
+            approval_key = f"{actor}/http.get/{host}"
             label = (
                 f"web fetch from host: {host!r}"
                 if has_wildcard
@@ -1096,7 +1096,7 @@ class PermissionResolver:
         # while we wait for them to declare ``http.get`` explicitly.
         import warnings
         warnings.warn(
-            f"HTTP access to host {host!r} from skill {skill_name!r} "
+            f"HTTP access to host {host!r} from skill {actor!r} "
             f"without an http.get declaration. This will become a hard "
             f"error in a future release. Add to skill.md:\n"
             f"  permissions:\n"
@@ -1123,7 +1123,7 @@ class PermissionResolver:
             )
 
     def require_secret_write(
-        self, decl: PermissionDecl, key: str, skill_name: str = "",
+        self, decl: PermissionDecl, key: str, actor: str = "",
     ) -> None:
         """Raise PermissionError if secret-store write of ``key`` is not declared.
 
@@ -1171,7 +1171,7 @@ class PermissionResolver:
             f"      - '*'\n"
         )
 
-    def is_read_allowed(self, path: str, skill_name: str = "") -> bool:
+    def is_read_allowed(self, path: str, actor: str = "") -> bool:
         """Check if reading `path` is allowed.
 
         Allowed if: the path is in the default read zone (under CWD), OR config
@@ -1194,10 +1194,10 @@ class PermissionResolver:
             # source as require_file_read → the offload decision cannot diverge;
             # the merged D12 bug was this gate lacking the offload grant, leaving
             # astropy-13236 denied at Workspace._resolve_read). Per-skill
-            # path-approval inline (guarded on a non-empty skill_name here).
+            # path-approval inline (guarded on a non-empty actor here).
             return self._read_base_approved(str(value)) or (
-                bool(skill_name)
-                and self._is_path_approved_for(str(value), skill_name, "file.read")
+                bool(actor)
+                and self._is_path_approved_for(str(value), actor, "file.read")
             )
 
         return EffectivePermission([
@@ -1205,7 +1205,7 @@ class PermissionResolver:
                        file_zone_root=self._file_zone_root)  # #1414
         ]).allows(CapabilityAxis.FILE_READ, path)
 
-    def is_write_allowed(self, path: str, skill_name: str = "") -> bool:
+    def is_write_allowed(self, path: str, actor: str = "") -> bool:
         """Check if writing `path` is allowed.
 
         Allowed if: default write zone, OR config grants `file.write: allow`, OR
@@ -1226,8 +1226,8 @@ class PermissionResolver:
 
         def _approved(axis: object, value: object) -> bool:
             return self._is_config_approved("file.write") or (
-                bool(skill_name)
-                and self._is_path_approved_for(str(value), skill_name, "file.write")
+                bool(actor)
+                and self._is_path_approved_for(str(value), actor, "file.write")
             )
 
         return EffectivePermission([
@@ -1300,7 +1300,7 @@ class PermissionResolver:
     async def require_python(
         self, decl: PermissionDecl, module: str, function: str,
         bus: "RequestBus | None",
-        skill_name: str = "",
+        actor: str = "",
     ) -> PythonPermission:
         """Resolve which python permission entry applies; raise if denied.
 
@@ -1342,7 +1342,7 @@ class PermissionResolver:
                     f"Unsafe python runs unrestricted user code; pass the flag "
                     f"only when you trust the skill source."
                 )
-            key = f"{skill_name}/python.unsafe/{module}:{function}"
+            key = f"{actor}/python.unsafe/{module}:{function}"
             # Non-interactive + unsafe_python_allowed=True (stdlib skills) must
             # auto-approve without a prompt.  Pre-seed the session key so _approve()
             # returns True instead of auto-denying the non-interactive branch.
@@ -1359,7 +1359,7 @@ class PermissionResolver:
                 )
             return perm
         # safe mode
-        key = f"{skill_name}/python.safe/{module}:{function}"
+        key = f"{actor}/python.safe/{module}:{function}"
         # Mirror the unsafe-mode stdlib auto-allow path. Safe mode is more
         # restricted (per _python_allowlist.py), so any context that auto-allows
         # unsafe MUST auto-allow safe. Without this, stdlib skills declaring

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -72,7 +72,7 @@ async def _handle_compact(args: Mapping[str, Any], ctx: ToolContext) -> ToolResu
             events=ctx.events,
             permission_decl=PermissionDecl(),
             permission_resolver=ctx.permission_resolver,
-            skill_name="",
+            actor="",
             subscribers=getattr(ctx.events, "subscribers", []),
             # #1673: never resolver=None (the bug-class invariant). This minimal
             # path returns compaction_unavailable (no LLM call), but the uniform

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -95,7 +95,7 @@ async def _handle_drop_source(
                 file_write=[{"path": canonical_manifest, "scope": "just_path"}],
             ),
             permission_resolver=ctx.permission_resolver,
-            skill_name="drop_source",
+            actor="drop_source",
             state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -307,7 +307,7 @@ async def _handle_call_mcp_tool(
             events=ctx.events,
             permission_decl=PermissionDecl(mcp=[server]),
             permission_resolver=ctx.permission_resolver,
-            skill_name="",
+            actor="",
             # #1673: real resolver + "tool" purpose class (was None + literal
             # "standard") — eliminates the resolver=None → litellm-BadRequestError
             # class by construction (uniform; this handler makes no LLM call).

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -131,7 +131,7 @@ async def _handle_mcp_drop_server_op(
             events=ctx.events,
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
-            skill_name="mcp_drop_server",
+            actor="mcp_drop_server",
             state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
             intervention_bus=None,
             subscribers=getattr(ctx.events, "subscribers", []),

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -123,7 +123,7 @@ async def _handle_mcp_install_op(
             events=ctx.events,
             permission_decl=synth_decl,
             permission_resolver=ctx.permission_resolver,
-            skill_name="mcp_install",
+            actor="mcp_install",
             state_log=getattr(ctx, "state_log", None),  # #2259 PR-1: config generation emit
         )
 

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -201,10 +201,10 @@ async def _handle_mcp_install_registry(
     # one file/compact/recall/web_fetch/sandboxed_exec use), not a hand-built one.
     # On the chat-router path this yields the real Workspace rooted at the agent's
     # workspace_base_dir; hand-building from ctx.workspace (None there) wrote the
-    # config to cwd. Only the install-specific decl + skill_name are overridden.
+    # config to cwd. Only the install-specific decl + actor are overridden.
     op_ctx = build_legacy_op_context(ctx)
     op_ctx.permission_decl = decl
-    op_ctx.skill_name = "mcp__install_registry"
+    op_ctx.actor = "mcp__install_registry"
 
     result = await mcp_install_handle(op, op_ctx)
     return {"status": "ok", "data": result}
@@ -333,7 +333,7 @@ async def _handle_mcp_install_package(
     # real Workspace on the chat path; override only the install-specific fields.
     op_ctx = build_legacy_op_context(ctx)
     op_ctx.permission_decl = decl
-    op_ctx.skill_name = "mcp__install_package"
+    op_ctx.actor = "mcp__install_package"
 
     result = await mcp_install_handle(op, op_ctx)
     return {"status": "ok", "data": result}

--- a/src/reyn/tools/op_context_bridge.py
+++ b/src/reyn/tools/op_context_bridge.py
@@ -62,15 +62,15 @@ def build_legacy_op_context(ctx: "ToolContext") -> Any:
             else PermissionDecl()
         ),
         permission_resolver=ctx.permission_resolver,
-        # #2415 root 4: propagate skill_name + intervention_bus from the phase
+        # #2415 root 4: propagate actor + intervention_bus from the phase
         # OpContext so permission checks key correctly on the calling skill's
         # approval prefix (``{skill}/file.write/{path}``) and the JIT prompt
-        # fires when approval is needed. Without this, skill_name="" → prefix
+        # fires when approval is needed. Without this, actor="" → prefix
         # ``/file.write/`` → no saved approval matches → PermissionError even
         # when the operator already approved the path.  intervention_bus=None
         # suppressed the JIT fallback prompt, giving no recovery path.
-        skill_name=(
-            phase_op_ctx.skill_name if phase_op_ctx is not None else ""
+        actor=(
+            phase_op_ctx.actor if phase_op_ctx is not None else ""
         ),
         intervention_bus=(
             phase_op_ctx.intervention_bus if phase_op_ctx is not None else None

--- a/src/reyn/tools/recall.py
+++ b/src/reyn/tools/recall.py
@@ -178,7 +178,7 @@ async def _handle_recall(args: Mapping[str, Any], ctx: ToolContext) -> ToolResul
                 else PermissionDecl()
             ),
             permission_resolver=ctx.permission_resolver,
-            skill_name="",
+            actor="",
             subscribers=getattr(ctx.events, "subscribers", []),
             # #1673: thread the config-aware resolver so this OpContext is never
             # resolver=None (the bug-class invariant). recall uses op.embedding_model

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -110,7 +110,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         events=ctx.events,
         permission_decl=PermissionDecl(),
         permission_resolver=ctx.permission_resolver,
-        skill_name="",
+        actor="",
         # #1673: real config-aware resolver + "tool" purpose class (was None +
         # literal "standard"). This handler makes no LLM call, but threading the
         # resolver eliminates the resolver=None → litellm-BadRequestError class by

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -113,7 +113,7 @@ class RouterCallerState:
     # OpContext factory (= for file / mcp / web handlers that delegate
     # to op_runtime).  Bound by RouterLoop to ``host.make_router_op_context``
     # so handlers can build a permission-aware OpContext (= populated
-    # PermissionDecl + Workspace + skill_name="chat_router") matching the
+    # PermissionDecl + Workspace + actor="chat_router") matching the
     # legacy router branch behavior.  When None, handlers fall back to
     # minimal OpContext synthesis (= test sites / phase-side).
     op_context_factory: Callable[[], Any] | None = None

--- a/src/reyn/tools/web_fetch.py
+++ b/src/reyn/tools/web_fetch.py
@@ -99,7 +99,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             events=ctx.events,
             permission_decl=PermissionDecl(),
             permission_resolver=ctx.permission_resolver,
-            skill_name="",
+            actor="",
             subscribers=getattr(ctx.events, "subscribers", []),
             # #1673: never resolver=None (the bug-class invariant). web_fetch makes
             # no LLM call, but the uniform threading keeps the invariant provable.

--- a/src/reyn/tools/web_search.py
+++ b/src/reyn/tools/web_search.py
@@ -86,7 +86,7 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             else PermissionDecl()
         ),
         permission_resolver=ctx.permission_resolver,
-        skill_name="",
+        actor="",
         # #1673: real resolver + "tool" purpose class (was None + literal
         # "standard") — eliminates the resolver=None → litellm-BadRequestError class
         # by construction (uniform with invoke_skill; this handler makes no LLM call).

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -82,7 +82,7 @@ class UserIntervention:
     # a closed-set selector). Backward-compatible: existing callers leave it "".
     input_type: str = ""
     run_id: str | None = None
-    skill_name: str | None = None
+    actor: str | None = None
     # issue #268: identifies the channel that initiated this intervention
     # (= "tui:<session>" / "a2a:<run_id>" / etc.). When the origin channel
     # closes while the iv is unresolved, the iv becomes **stalled** in
@@ -129,7 +129,7 @@ class UserIntervention:
             ],
             "suggestions": list(self.suggestions),
             "run_id": self.run_id,
-            "skill_name": self.skill_name,
+            "actor": self.actor,
             "id": self.id,
         }
         if self.input_type:
@@ -160,7 +160,7 @@ class UserIntervention:
             suggestions=list(data.get("suggestions") or []),
             input_type=data.get("input_type", ""),
             run_id=data.get("run_id"),
-            skill_name=data.get("skill_name"),
+            actor=data.get("actor"),
             origin_channel_id=data.get("origin_channel_id"),
             id=data.get("id") or uuid.uuid4().hex,
         )
@@ -286,7 +286,7 @@ class StdinInterventionBus:
     @staticmethod
     def _render_prompt(iv: UserIntervention) -> str:
         lines: list[str] = []
-        prefix = f"[{iv.skill_name}] " if iv.skill_name else ""
+        prefix = f"[{iv.actor}] " if iv.actor else ""
         lines.append(f"{prefix}{iv.prompt}")
         if iv.detail:
             lines.append(f"  {iv.detail}")

--- a/tests/test_1199_s34_part1_fs_op_gate.py
+++ b/tests/test_1199_s34_part1_fs_op_gate.py
@@ -127,7 +127,7 @@ def _ctx(tmp_path: Path, *, sandbox_policy: dict | None) -> OpContext:
     )
     return OpContext(
         workspace=ws, events=events, permission_decl=PermissionDecl(),
-        permission_resolver=resolver, skill_name="s",
+        permission_resolver=resolver, actor="s",
         default_sandbox_policy=sandbox_policy,
     )
 

--- a/tests/test_1503_mcp_install_error_surface.py
+++ b/tests/test_1503_mcp_install_error_surface.py
@@ -78,7 +78,7 @@ def _make_op_ctx(
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,
-        skill_name="mcp_install_test",
+        actor="mcp_install_test",
         intervention_bus=_AutoApproveInterventionBus(),
     )
 

--- a/tests/test_2248_pr_a2_config_emission.py
+++ b/tests/test_2248_pr_a2_config_emission.py
@@ -75,7 +75,7 @@ async def test_real_mcp_drop_records_generation_and_rewind_restores(tmp_path):
             file_write=[{"path": canonical, "scope": "just_path"}],
         ),
         permission_resolver=resolver,
-        skill_name="test",
+        actor="test",
         intervention_bus=None,
         subscribers=[],
         state_log=state_log,  # the PR-A2 threading under test

--- a/tests/test_2248_pr_a2_emit_index_sources.py
+++ b/tests/test_2248_pr_a2_emit_index_sources.py
@@ -61,7 +61,7 @@ async def test_index_drop_records_generation_full_sources(tmp_path):
         events=_Events(),
         permission_decl=None,
         permission_resolver=None,  # no gate in this unit-test context
-        skill_name="test",
+        actor="test",
         intervention_bus=None,
         subscribers=[],
         state_log=state_log,

--- a/tests/test_2248_prb_config_path_consistency.py
+++ b/tests/test_2248_prb_config_path_consistency.py
@@ -88,7 +88,7 @@ async def test_real_mcp_drop_writes_config_subdir_keyed_path_and_rewind_restores
             file_write=[{"path": canonical, "scope": "just_path"}],
         ),
         permission_resolver=resolver,
-        skill_name="test",
+        actor="test",
         intervention_bus=None,
         subscribers=[],
         state_log=state_log,

--- a/tests/test_2259_pr3_recovery_semantics_falsify.py
+++ b/tests/test_2259_pr3_recovery_semantics_falsify.py
@@ -96,7 +96,7 @@ def _make_registry(tmp_path: Path, wal: Path) -> tuple[AgentRegistry, StateLog]:
 def _iv_dict(iv_id: str, run_id: str) -> dict:
     return {
         "kind": "ask_user", "prompt": f"Q-{iv_id}?", "detail": "", "choices": [],
-        "suggestions": [], "run_id": run_id, "skill_name": "demo", "id": iv_id,
+        "suggestions": [], "run_id": run_id, "actor": "demo", "id": iv_id,
     }
 
 

--- a/tests/test_a2a_restart_resume_292.py
+++ b/tests/test_a2a_restart_resume_292.py
@@ -118,7 +118,7 @@ def test_a2a_restart_resume_round_trip_ask_user(tmp_path: Path) -> None:
         "choices": [],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
         "origin_channel_id": f"a2a:{run_id}",  # stamped by A2A bus pre-crash
     }
@@ -160,7 +160,7 @@ def test_a2a_restart_resume_round_trip_ask_user(tmp_path: Path) -> None:
         # A fresh ChatInterventionBus simulates what a re-spawned skill
         # would do via its OpContext-injected bus.
         resumed_bus = ChatInterventionBus(
-            session, run_id=run_id, skill_name="demo",
+            session, run_id=run_id, actor="demo",
             channel_id=DEFAULT_CHAT_CHANNEL_ID,
         )
         # The skill emits a fresh iv (= it doesn't know about the
@@ -168,7 +168,7 @@ def test_a2a_restart_resume_round_trip_ask_user(tmp_path: Path) -> None:
         # circuits dispatch.
         fresh_iv = UserIntervention(
             kind="ask_user", prompt="What is your name?",
-            run_id=run_id, skill_name="demo",
+            run_id=run_id, actor="demo",
         )
         answer = await resumed_bus.deliver(fresh_iv)
         assert answer.text == "Alice"
@@ -205,7 +205,7 @@ def test_a2a_restart_resume_round_trip_with_choice_id(tmp_path: Path) -> None:
         ],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
         "origin_channel_id": f"a2a:{run_id}",
     }
@@ -236,7 +236,7 @@ def test_a2a_restart_resume_round_trip_with_choice_id(tmp_path: Path) -> None:
 
         # Skill resume picks it up unchanged.
         resumed_bus = ChatInterventionBus(
-            session, run_id=run_id, skill_name="demo",
+            session, run_id=run_id, actor="demo",
             channel_id=DEFAULT_CHAT_CHANNEL_ID,
         )
         fresh_iv = UserIntervention(
@@ -247,7 +247,7 @@ def test_a2a_restart_resume_round_trip_with_choice_id(tmp_path: Path) -> None:
                 InterventionChoice(id="always", label="[A]lways", hotkey="a"),
                 InterventionChoice(id="no", label="[N]o", hotkey="n"),
             ],
-            run_id=run_id, skill_name="demo",
+            run_id=run_id, actor="demo",
         )
         answer = await resumed_bus.deliver(fresh_iv)
         assert answer.text == "always"
@@ -295,7 +295,7 @@ def test_answer_pending_intervention_returns_false_when_future_done(
         "choices": [],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
     }
     snap = _build_post_crash_snapshot(

--- a/tests/test_ask_user_options_f3.py
+++ b/tests/test_ask_user_options_f3.py
@@ -45,7 +45,7 @@ class _RecordingBus:
 
 
 def _ctx(bus) -> OpContext:
-    # ask_user's handler only reads events / intervention_bus / skill_name /
+    # ask_user's handler only reads events / intervention_bus / actor /
     # run_id / current_phase, so workspace + permission_decl are unused dummies.
     return OpContext(
         workspace=None, events=_RecordingEvents(),

--- a/tests/test_cli_chat_trusted_python.py
+++ b/tests/test_cli_chat_trusted_python.py
@@ -117,7 +117,7 @@ def test_unsafe_python_blocked_without_flag(tmp_path):
     bus = _AutoApproveInterventionBus()
 
     with pytest.raises(PermissionError, match="--allow-unsafe-python"):
-        _run(resolver.require_python(decl, "my.module", "run", bus, skill_name="s"))
+        _run(resolver.require_python(decl, "my.module", "run", bus, actor="s"))
 
 
 def test_unsafe_python_allowed_with_flag(tmp_path):
@@ -129,5 +129,5 @@ def test_unsafe_python_allowed_with_flag(tmp_path):
     decl = _make_unsafe_decl()
     bus = _AutoApproveInterventionBus()
 
-    perm = _run(resolver.require_python(decl, "my.module", "run", bus, skill_name="s"))
+    perm = _run(resolver.require_python(decl, "my.module", "run", bus, actor="s"))
     assert perm.mode == "unsafe"

--- a/tests/test_compact_op_272.py
+++ b/tests/test_compact_op_272.py
@@ -42,7 +42,7 @@ def _ctx(compact_now=None) -> OpContext:
         events=_Events(),
         permission_decl=PermissionDecl(),
         permission_resolver=None,
-        skill_name="",
+        actor="",
         compact_now=compact_now,
     )
 

--- a/tests/test_environment_backend_1115_stage1.py
+++ b/tests/test_environment_backend_1115_stage1.py
@@ -157,7 +157,7 @@ def test_state_dir_artifacts_not_routed_through_repo_backend(tmp_path: Path) -> 
     backend = _RecordingBackend()
     ws = Workspace(events=EventLog(), base_dir=tmp_path, environment_backend=backend)
 
-    handle = ws.store_artifact("p", {"type": "demo", "data": {"v": 1}}, skill_name="s")
+    handle = ws.store_artifact("p", {"type": "demo", "data": {"v": 1}}, actor="s")
     # store_artifact wrote the file without going through the repo-FS backend.
     assert "write_bytes" not in backend.calls
     assert ws.resolve_artifact_handle(handle).is_file()

--- a/tests/test_file_read_binary_media.py
+++ b/tests/test_file_read_binary_media.py
@@ -55,7 +55,7 @@ def _ctx(tmp_path: Path, *, multimodal: MultimodalConfig | None, bus_answer: str
         events=events,
         permission_decl=PermissionDecl(),
         permission_resolver=resolver,
-        skill_name="test",
+        actor="test",
         intervention_bus=_FakeBus(bus_answer),  # type: ignore[arg-type]
         multimodal_config=multimodal,
     )

--- a/tests/test_fp0016_d_opcontext_field.py
+++ b/tests/test_fp0016_d_opcontext_field.py
@@ -36,7 +36,7 @@ class _StubScopedSecretStore:
 
 def _make_context(**kwargs: object) -> OpContext:
     """Construct a minimal real OpContext for test use."""
-    ws = Workspace(events=EventLog(), skill_name="test_skill")
+    ws = Workspace(events=EventLog(), actor="test_skill")
     return OpContext(
         workspace=ws,
         events=EventLog(),

--- a/tests/test_fp0016_e_agent_id.py
+++ b/tests/test_fp0016_e_agent_id.py
@@ -196,7 +196,7 @@ def test_op_context_agent_id_default_is_none() -> None:
     from reyn.data.workspace.workspace import Workspace
     from reyn.security.permissions.permissions import PermissionDecl
 
-    ws = Workspace(events=EventLog(), skill_name="t")
+    ws = Workspace(events=EventLog(), actor="t")
     ctx = OpContext(
         workspace=ws,
         events=EventLog(),
@@ -211,7 +211,7 @@ def test_op_context_agent_id_flows_through() -> None:
     from reyn.data.workspace.workspace import Workspace
     from reyn.security.permissions.permissions import PermissionDecl
 
-    ws = Workspace(events=EventLog(), skill_name="t")
+    ws = Workspace(events=EventLog(), actor="t")
     ctx = OpContext(
         workspace=ws,
         events=EventLog(),

--- a/tests/test_fp0036_scenarios_loader.py
+++ b/tests/test_fp0036_scenarios_loader.py
@@ -774,14 +774,14 @@ def test_event_assertion_payload_stored(tmp_path: Path) -> None:
                 must_emit:
                   - type: skill_run_completed
                     payload:
-                      skill_name: direct_llm
+                      actor: direct_llm
                       status: success
         """,
     )
     ss = load_scenario_set(p)
     ea = ss.scenarios[0].expected_events
     assert ea is not None
-    assert ea.must_emit[0].payload == {"skill_name": "direct_llm", "status": "success"}
+    assert ea.must_emit[0].payload == {"actor": "direct_llm", "status": "success"}
 
 
 # ── events sequence ───────────────────────────────────────────────────────

--- a/tests/test_fp0042_stdlib_safe_only.py
+++ b/tests/test_fp0042_stdlib_safe_only.py
@@ -32,7 +32,7 @@ import yaml
 # Documented exemptions — keep in lock-step with python-safe-mode.md
 # ---------------------------------------------------------------------------
 #
-# Each entry: (skill_name, function_name).
+# Each entry: (actor, function_name).
 # Rationale for each is documented in the safe-mode concept page.
 # Adding an entry here is a deliberate decision — pair it with a doc update.
 
@@ -129,8 +129,8 @@ def _collect_unsafe_python_entries() -> set[tuple[str, str]]:
         fm = _parse_skill_md_frontmatter(skill_md)
         if fm is None:
             continue
-        skill_name = str(fm.get("name") or "")
-        if not skill_name:
+        actor = str(fm.get("name") or "")
+        if not actor:
             continue
         perms = fm.get("permissions") or {}
         for entry in perms.get("python") or []:
@@ -139,7 +139,7 @@ def _collect_unsafe_python_entries() -> set[tuple[str, str]]:
             if entry.get("mode") == "unsafe":
                 fn = str(entry.get("function") or "")
                 if fn:
-                    found.add((skill_name, fn))
+                    found.add((actor, fn))
     return found
 
 

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -158,12 +158,12 @@ def test_intervention_suppresses_run_id_short_prefix() -> None:
     assert "Confirm?" in out
 
 
-def test_intervention_keeps_skill_name_prefix_when_present() -> None:
-    """Tier 2: skill_name context is retained on interventions so the user sees which
-    skill is asking — only run_id_short (the cryptic hash) is suppressed."""
+def test_intervention_keeps_actor_prefix_when_present() -> None:
+    """Tier 2: actor context is retained on interventions so the user sees which
+    actor is asking — only run_id_short (the cryptic hash) is suppressed."""
     out = _plain(
         "intervention", "Confirm?",
-        meta={"skill_name": "skill_builder", "run_id_short": "ab12"},
+        meta={"actor": "skill_builder", "run_id_short": "ab12"},
     )
     assert "skill_builder" in out
     assert "#ab12" not in out
@@ -247,10 +247,10 @@ def test_unknown_kind_renders_text_without_marker() -> None:
 
 
 def test_meta_skill_prefix_is_applied() -> None:
-    """Tier 2: skill_name + run_id_short surface as a [skill#abcd] prefix."""
+    """Tier 2: actor + run_id_short surface as a [skill#abcd] prefix."""
     out = _plain(
         "agent", "done",
-        meta={"skill_name": "skill_builder", "run_id_short": "ab12"},
+        meta={"actor": "skill_builder", "run_id_short": "ab12"},
     )
     assert "[skill_builder#ab12]" in out
     assert "done" in out

--- a/tests/test_intervention_bus_protocols.py
+++ b/tests/test_intervention_bus_protocols.py
@@ -100,7 +100,7 @@ def test_stdin_intervention_bus_satisfies_both_protocols() -> None:
 def test_chat_intervention_bus_satisfies_both_protocols(tmp_path: Path) -> None:
     """Tier 2: ``ChatInterventionBus`` satisfies both Protocols."""
     session = Session(agent_name="t")
-    bus = ChatInterventionBus(session, run_id="r1", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="r1", actor="demo")
     assert isinstance(bus, RequestBus)
     assert isinstance(bus, UserChannel)
 
@@ -199,7 +199,7 @@ def test_outbox_intervention_meta_shape_is_stable() -> None:
       - ``detail``: present iff the iv carries a non-empty detail
       - ``choices``: present iff the iv carries choices, each a
         ``{"id", "label", "hotkey"}`` dict
-      - ``run_id`` / ``run_id_short`` / ``skill_name``: opt-in fields
+      - ``run_id`` / ``run_id_short`` / ``actor``: opt-in fields
 
     If a Phase 2+ refactor renames any of these keys, TUI's outbox
     consumer breaks — this test fails first.
@@ -219,7 +219,7 @@ def test_outbox_intervention_meta_shape_is_stable() -> None:
         prompt="Run ls?",
         detail="cmd: ls -la",
         run_id="r-1234",
-        skill_name="demo",
+        actor="demo",
         choices=[
             InterventionChoice(id="yes", label="[Y]es", hotkey="y"),
             InterventionChoice(id="no", label="[N]o", hotkey="n"),
@@ -232,7 +232,7 @@ def test_outbox_intervention_meta_shape_is_stable() -> None:
     assert meta_rich["detail"] == "cmd: ls -la"
     assert meta_rich["run_id"] == "r-1234"
     assert meta_rich["run_id_short"] == "1234"
-    assert meta_rich["skill_name"] == "demo"
+    assert meta_rich["actor"] == "demo"
     assert meta_rich["choices"] == [
         {"id": "yes", "label": "[Y]es", "hotkey": "y"},
         {"id": "no", "label": "[N]o", "hotkey": "n"},

--- a/tests/test_intervention_restore.py
+++ b/tests/test_intervention_restore.py
@@ -62,7 +62,7 @@ def _snapshot_with_intervention(
         "choices": [],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
     }
     snap.applied_seq = 5
@@ -240,7 +240,7 @@ async def test_multiple_restored_interventions_preserve_order(tmp_path, monkeypa
             "choices": [],
             "suggestions": [],
             "run_id": "rA",
-            "skill_name": "demo",
+            "actor": "demo",
             "id": iv_id,
         }
     snap.applied_seq = 10

--- a/tests/test_intervention_resume_e2e.py
+++ b/tests/test_intervention_resume_e2e.py
@@ -77,7 +77,7 @@ def _snapshot_with_intervention(
         "choices": [],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
     }
     snap.applied_seq = 5
@@ -123,7 +123,7 @@ async def test_bus_returns_buffered_answer_without_dispatching(tmp_path, monkeyp
         session.outbox.get_nowait()
 
     # Now the actual contract under test:
-    bus = ChatInterventionBus(session, run_id="rResume", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rResume", actor="demo")
     iv = UserIntervention(kind="ask_user", prompt="Fresh Q?")
     iv.future = asyncio.get_running_loop().create_future()
     answer = await bus.request(iv)
@@ -145,7 +145,7 @@ async def test_bus_falls_through_to_dispatch_when_no_buffer(tmp_path, monkeypatc
     session = _make_session(tmp_path)
     session.is_attached = True
 
-    bus = ChatInterventionBus(session, run_id="rFresh", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rFresh", actor="demo")
     iv = UserIntervention(kind="ask_user", prompt="What's up?")
     iv.future = asyncio.get_running_loop().create_future()
 
@@ -178,7 +178,7 @@ async def test_buffer_is_single_use(tmp_path, monkeypatch):
     await session._maybe_answer_oldest_intervention("first")
     await wait_until(lambda: bool(session.buffered_intervention_answers))
 
-    bus = ChatInterventionBus(session, run_id="rOnce", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rOnce", actor="demo")
     iv1 = UserIntervention(kind="ask_user", prompt="Q1?")
     iv1.future = asyncio.get_running_loop().create_future()
     a1 = await bus.request(iv1)
@@ -225,7 +225,7 @@ async def test_watcher_buffers_answer_when_restored_iv_resolves(tmp_path, monkey
     await wait_until(lambda: bool(session.buffered_intervention_answers))
 
     # Bus.request reaches the answer without dispatching
-    bus = ChatInterventionBus(session, run_id="rW", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rW", actor="demo")
     fresh_iv = UserIntervention(kind="ask_user", prompt="Skill resumes")
     fresh_iv.future = asyncio.get_running_loop().create_future()
     answer = await bus.request(fresh_iv)
@@ -276,7 +276,7 @@ async def test_e2e_skill_resume_picks_up_user_answer(tmp_path, monkeypatch):
     assert "iv_crashed" in resolved_ids
 
     # Phase 3: skill resumes — bus.request with the same run_id finds buffer
-    bus = ChatInterventionBus(session, run_id="rE2E", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rE2E", actor="demo")
     fresh_iv = UserIntervention(kind="ask_user", prompt="What's your name?")
     fresh_iv.future = asyncio.get_running_loop().create_future()
     answer = await bus.request(fresh_iv)
@@ -323,7 +323,7 @@ async def test_e2e_choice_intervention_round_trip(tmp_path, monkeypatch):
         ],
         "suggestions": [],
         "run_id": "rChoice",
-        "skill_name": "demo",
+        "actor": "demo",
         "id": "iv_choice",
     }
     snap.applied_seq = 1
@@ -336,7 +336,7 @@ async def test_e2e_choice_intervention_round_trip(tmp_path, monkeypatch):
     for _ in range(3):
         await asyncio.sleep(0)
 
-    bus = ChatInterventionBus(session, run_id="rChoice", skill_name="demo")
+    bus = ChatInterventionBus(session, run_id="rChoice", actor="demo")
     fresh_iv = UserIntervention(
         kind="permission.generic", prompt="Allow?",
         choices=[

--- a/tests/test_mcp_drop_server.py
+++ b/tests/test_mcp_drop_server.py
@@ -150,7 +150,7 @@ def _make_op_ctx(
         events=events or _CapturingEvents(),
         permission_decl=effective_decl,
         permission_resolver=resolver,
-        skill_name="test_mcp_drop_server",
+        actor="test_mcp_drop_server",
         intervention_bus=bus,
         subscribers=[],
     )

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -172,7 +172,7 @@ def _make_op_ctx(
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,
-        skill_name="mcp_install_test",
+        actor="mcp_install_test",
         intervention_bus=bus,
     )
 

--- a/tests/test_mcp_install_threat_scan_1863.py
+++ b/tests/test_mcp_install_threat_scan_1863.py
@@ -152,7 +152,7 @@ def _make_ctx(tmp_path: Path, threat_scan: object | None) -> OpContext:
         events=EventLog(),
         permission_decl=decl,
         permission_resolver=resolver,
-        skill_name="mcp_install_threat_test",
+        actor="mcp_install_threat_test",
         intervention_bus=_AutoApproveBus(),
         threat_scan=threat_scan,
     )

--- a/tests/test_mcp_install_workspace_1442.py
+++ b/tests/test_mcp_install_workspace_1442.py
@@ -180,4 +180,4 @@ def test_chat_path_uses_factory_workspace_not_cwd(tmp_path, monkeypatch):
     assert _resolve_write_root(op_ctx.workspace) != Path.cwd()
     # the install-specific decl was overridden onto the factory's ctx.
     assert op_ctx.permission_decl.file_write == [{"path": ".reyn/config/mcp.yaml"}]
-    assert op_ctx.skill_name == "mcp__install_registry"
+    assert op_ctx.actor == "mcp__install_registry"

--- a/tests/test_mcp_source_install.py
+++ b/tests/test_mcp_source_install.py
@@ -239,7 +239,7 @@ def _make_op_ctx(
         events=events,
         permission_decl=decl,
         permission_resolver=resolver,
-        skill_name="mcp_install_source_test",
+        actor="mcp_install_source_test",
         intervention_bus=bus,
     )
 

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -288,12 +288,12 @@ def test_os_topology_dispatch_has_no_skill_specific_strings():
             continue
 
         # Check 1: known skill name literals
-        for skill_name in _KNOWN_SKILL_NAMES:
-            # Match as a quoted string literal: "skill_name" or 'skill_name'
-            if f'"{skill_name}"' in source or f"'{skill_name}'" in source:
+        for actor in _KNOWN_SKILL_NAMES:
+            # Match as a quoted string literal: "actor" or 'actor'
+            if f'"{actor}"' in source or f"'{actor}'" in source:
                 violations.append(
                     f"P7 violation: {rel_path} contains skill name literal "
-                    f"{skill_name!r}"
+                    f"{actor!r}"
                 )
 
         # Check 2: phase-name pattern literals (e.g. "analyze_phase")

--- a/tests/test_multi_session_restore.py
+++ b/tests/test_multi_session_restore.py
@@ -58,7 +58,7 @@ def _iv_dict(iv_id: str, run_id: str) -> dict:
         "choices": [],
         "suggestions": [],
         "run_id": run_id,
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iv_id,
     }
 

--- a/tests/test_offload_read_grant_1383.py
+++ b/tests/test_offload_read_grant_1383.py
@@ -201,7 +201,7 @@ def test_workspace_read_gate_honors_offload_grant_end_to_end(tmp_path: Path) -> 
     offloaded.write_text("INPUT-CONTENT")
     base = (tmp_path / "proj").resolve()
     ws = Workspace(
-        EventLog(), permission_resolver=r, skill_name="swe_bench", base_dir=base
+        EventLog(), permission_resolver=r, actor="swe_bench", base_dir=base
     )
     with pytest.raises(PermissionError):
         ws.read_file(str(offloaded))  # gate-2: outside project, no grant

--- a/tests/test_offload_recursion_2296.py
+++ b/tests/test_offload_recursion_2296.py
@@ -29,7 +29,7 @@ def _make_ctx(tmp_path: Path) -> OpContext:
         workspace=Workspace(events=events, base_dir=tmp_path),
         events=events,
         permission_decl=PermissionDecl(),
-        skill_name="test_skill",
+        actor="test_skill",
     )
 
 

--- a/tests/test_op_index_drop.py
+++ b/tests/test_op_index_drop.py
@@ -49,7 +49,7 @@ def _make_ctx(
         events=events,
         permission_decl=permission_decl or PermissionDecl(),
         permission_resolver=permission_resolver,
-        skill_name="test_op_index_drop",
+        actor="test_op_index_drop",
     )
 
 
@@ -152,7 +152,7 @@ async def test_drop_emits_p6_event(tmp_path: Path, monkeypatch: pytest.MonkeyPat
             events=events,
             permission_decl=_phase5_index_drop_decl(resolver, tmp_path),
             permission_resolver=resolver,
-            skill_name="test_op_index_drop",
+            actor="test_op_index_drop",
         )
 
         op = IndexDropIROp(kind="index_drop", source="audit_src")

--- a/tests/test_op_runtime_file_mkdir_move_stat.py
+++ b/tests/test_op_runtime_file_mkdir_move_stat.py
@@ -38,7 +38,7 @@ def _make_ctx(
         events=events,
         permission_decl=permission_decl or PermissionDecl(),
         permission_resolver=permission_resolver,
-        skill_name="test_skill",
+        actor="test_skill",
     )
 
 

--- a/tests/test_op_runtime_file_not_found_suggestions.py
+++ b/tests/test_op_runtime_file_not_found_suggestions.py
@@ -28,7 +28,7 @@ def _make_ctx(tmp_path: Path) -> OpContext:
         events=events,
         permission_decl=PermissionDecl(),
         permission_resolver=None,  # skip op-level perm; covered in test_op_runtime_file_permissions.py
-        skill_name="test_skill",
+        actor="test_skill",
     )
 
 

--- a/tests/test_op_runtime_file_permissions.py
+++ b/tests/test_op_runtime_file_permissions.py
@@ -29,7 +29,7 @@ def _make_ctx(
     *,
     permission_resolver: PermissionResolver | None,
     permission_decl: PermissionDecl | None = None,
-    skill_name: str = "test_skill",
+    actor: str = "test_skill",
 ) -> OpContext:
     events = EventLog()
     ws = Workspace(events=events)
@@ -38,7 +38,7 @@ def _make_ctx(
         events=events,
         permission_decl=permission_decl or PermissionDecl(),
         permission_resolver=permission_resolver,
-        skill_name=skill_name,
+        actor=actor,
     )
 
 

--- a/tests/test_op_runtime_index_workspace_guard.py
+++ b/tests/test_op_runtime_index_workspace_guard.py
@@ -58,7 +58,7 @@ def _make_ctx_no_workspace() -> OpContext:
         events=_NullEventLog(),
         permission_decl=PermissionDecl(),
         permission_resolver=None,
-        skill_name="",
+        actor="",
     )
 
 

--- a/tests/test_permission_actor_scope_isolation.py
+++ b/tests/test_permission_actor_scope_isolation.py
@@ -1,0 +1,89 @@
+"""Tier 2: OS invariant — approval keys are actor-scoped (privilege isolation).
+
+A path approval granted under one actor MUST NOT be honored for a different
+actor. The approval key's first segment (``{actor}/{kind}/{path}``) is the
+privilege-isolation boundary that prevents an external actor from inheriting
+another actor's grants.
+
+This is the enforcement-equivalence guard for the ``skill_name``→``actor``
+rename: only the identifier changed — the actor VALUE still scopes every
+approval, so a grant never leaks across actors. The test goes RED if the actor
+segment is dropped from the key (the rename would then collapse the isolation).
+
+Real PermissionResolver, no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.security.permissions.permissions import PermissionResolver
+
+# The actor categories the field carries in production. Non-empty actors
+# (session-router, router, tool-verb name) scope approvals; the empty actor is
+# unscoped and can never hold a grant (see test_empty_actor_is_never_approved).
+_GRANTABLE_ACTORS = ["chat_router", "router", "drop_source"]
+
+
+def _resolver(project_root: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False
+    )
+
+
+def _out_of_zone(tmp_path: Path) -> tuple[PermissionResolver, str]:
+    """A resolver plus a write path OUTSIDE the default write zone (needs approval)."""
+    proj = (tmp_path / "proj").resolve()
+    proj.mkdir(parents=True)
+    outside = (tmp_path / "state" / "secret.json").resolve()
+    outside.parent.mkdir(parents=True)
+    return _resolver(proj), str(outside)
+
+
+@pytest.mark.parametrize("granted_actor", _GRANTABLE_ACTORS)
+def test_write_grant_does_not_leak_across_actors(tmp_path: Path, granted_actor: str) -> None:
+    """Tier 2: a write approval granted for one actor is honored for THAT actor
+    only — every other actor (and the unscoped empty actor) is still denied
+    (no cross-actor privilege leak)."""
+    r, path = _out_of_zone(tmp_path)
+
+    # Before any grant, the out-of-zone write is denied for every actor.
+    assert r.is_write_allowed(path, granted_actor) is False
+
+    # Grant the write for one actor.
+    r.session_approve_path(path, actor=granted_actor, kind="file.write")
+
+    # The granted actor is now allowed…
+    assert r.is_write_allowed(path, granted_actor) is True
+
+    # …but no OTHER actor inherits the grant (the isolation invariant).
+    for other in _GRANTABLE_ACTORS + [""]:
+        if other == granted_actor:
+            continue
+        assert r.is_write_allowed(path, other) is False, (
+            f"grant for {granted_actor!r} leaked to {other!r} — actor isolation broken"
+        )
+
+
+def test_empty_actor_is_never_approved(tmp_path: Path) -> None:
+    """Tier 2: the empty (unscoped) actor cannot hold an approval — even an
+    explicit grant under "" leaves the out-of-zone write denied, so an
+    unscoped caller never gains persisted privileges."""
+    r, path = _out_of_zone(tmp_path)
+    r.session_approve_path(path, actor="", kind="file.write")
+    assert r.is_write_allowed(path, "") is False
+
+
+def test_recursive_grant_is_actor_scoped(tmp_path: Path) -> None:
+    """Tier 2: a recursive (directory) grant under one actor covers children for
+    that actor only — a different actor is denied a child path."""
+    r, _ = _out_of_zone(tmp_path)
+    base = (tmp_path / "state" / "dir").resolve()
+    base.mkdir(parents=True)
+    child = str(base / "nested" / "file.json")
+
+    r.session_approve_path(str(base), actor="chat_router", kind="file.write", recursive=True)
+
+    assert r.is_write_allowed(child, "chat_router") is True
+    assert r.is_write_allowed(child, "drop_source") is False

--- a/tests/test_permission_collapse_phase3.py
+++ b/tests/test_permission_collapse_phase3.py
@@ -124,7 +124,7 @@ def test_require_http_get_passes_for_declared_host(tmp_path):
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     decl = PermissionDecl(http_get=[{"host": "api.github.com"}])
     resolver.session_approve_host("api.github.com", "test_skill")
-    asyncio.run(resolver.require_http_get(decl, "api.github.com", skill_name="test_skill"))
+    asyncio.run(resolver.require_http_get(decl, "api.github.com", actor="test_skill"))
 
 
 def test_require_http_get_passes_via_explicit_decl(tmp_path):
@@ -135,7 +135,7 @@ def test_require_http_get_passes_via_explicit_decl(tmp_path):
     })
     resolver.session_approve_host("registry.modelcontextprotocol.io", "mcp_install")
     asyncio.run(resolver.require_http_get(
-        decl, "registry.modelcontextprotocol.io", skill_name="mcp_install",
+        decl, "registry.modelcontextprotocol.io", actor="mcp_install",
     ))
 
 

--- a/tests/test_permission_denied_audit.py
+++ b/tests/test_permission_denied_audit.py
@@ -49,7 +49,7 @@ def _make_ctx(
     *,
     resolver: PermissionResolver | None,
     decl: PermissionDecl | None = None,
-    skill_name: str = "test_skill",
+    actor: str = "test_skill",
 ) -> OpContext:
     ws = Workspace(events=events)
     return OpContext(
@@ -57,7 +57,7 @@ def _make_ctx(
         events=events,
         permission_decl=decl or PermissionDecl(),
         permission_resolver=resolver,
-        skill_name=skill_name,
+        actor=actor,
     )
 
 

--- a/tests/test_permission_prompt_phrasing.py
+++ b/tests/test_permission_prompt_phrasing.py
@@ -115,7 +115,7 @@ async def test_announce_meta_carries_natural_prompt() -> None:
         detail="web fetch: https://example.com",
         choices=generic_yn_choices(),
         run_id="r1",
-        skill_name="chat_router",
+        actor="chat_router",
     )
     msg = await _capture_announce(iv)
     assert msg.meta["prompt"] == "Allow fetching this URL?"

--- a/tests/test_permission_python_safe_auto_allow.py
+++ b/tests/test_permission_python_safe_auto_allow.py
@@ -64,7 +64,7 @@ def test_safe_python_auto_allowed_in_stdlib_non_interactive(tmp_path: Path) -> N
     bus = _AutoDenyBus()
 
     # Must NOT raise — safe step auto-approved on the stdlib non-interactive path.
-    result = _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, skill_name="ops_report"))
+    result = _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, actor="ops_report"))
     assert result is not None
     assert result.mode == "safe"
     # No prompt was issued (non-interactive auto-allow must not touch the bus).
@@ -87,7 +87,7 @@ def test_safe_python_denied_in_non_stdlib_non_interactive(tmp_path: Path) -> Non
     bus = _AutoDenyBus()
 
     with pytest.raises(PermissionError, match="denied by user"):
-        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, skill_name="ops_report"))
+        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, actor="ops_report"))
 
 
 def test_safe_python_explicit_deny_overrides_auto_allow(tmp_path: Path) -> None:
@@ -113,7 +113,7 @@ def test_safe_python_explicit_deny_overrides_auto_allow(tmp_path: Path) -> None:
 
     # The explicit deny must survive — auto-allow must not clobber it.
     with pytest.raises(PermissionError, match="denied by user"):
-        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, skill_name="ops_report"))
+        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, actor="ops_report"))
 
 
 def test_safe_python_still_requires_approval_when_interactive(tmp_path: Path) -> None:
@@ -139,7 +139,7 @@ def test_safe_python_still_requires_approval_when_interactive(tmp_path: Path) ->
 
     # In interactive mode the auto-deny bus causes a denial, so PermissionError is raised.
     with pytest.raises(PermissionError, match="denied by user"):
-        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, skill_name="ops_report"))
+        _run(resolver.require_python(decl, "./aggregate.py", "collect", bus, actor="ops_report"))
 
     # The key assertion: the bus was consulted (proves routing went through _prompt,
     # not the non-interactive auto-allow shortcut).

--- a/tests/test_read_bounding_structural_signal_1209.py
+++ b/tests/test_read_bounding_structural_signal_1209.py
@@ -40,7 +40,7 @@ def _make_ctx(tmp_path: Path) -> OpContext:
         workspace=ws,
         events=events,
         permission_decl=PermissionDecl(),
-        skill_name="test_skill",
+        actor="test_skill",
     )
 
 

--- a/tests/test_read_single_line_char_truncation_2335.py
+++ b/tests/test_read_single_line_char_truncation_2335.py
@@ -24,7 +24,7 @@ def _ctx(tmp_path: Path) -> OpContext:
     ev = EventLog()
     return OpContext(
         workspace=Workspace(events=ev, base_dir=tmp_path),
-        events=ev, permission_decl=PermissionDecl(), skill_name="t",
+        events=ev, permission_decl=PermissionDecl(), actor="t",
     )
 
 

--- a/tests/test_renderer_meta_prefix.py
+++ b/tests/test_renderer_meta_prefix.py
@@ -1,6 +1,6 @@
 """Tier 2: renderer _meta_prefix — provenance-prefix helper contracts.
 
-`_meta_prefix` builds a `[skill_name#run_id_short] ` prefix from outbox message
+`_meta_prefix` builds a `[actor#run_id_short] ` prefix from outbox message
 meta.  It has four branches (both present / skill only / short only / neither) all
 used by `format_inline_message`.  Pinning them independently of the full renderer
 prevents a silent branch-removal from collapsing provenance labels.
@@ -11,17 +11,17 @@ from reyn.interfaces.repl.renderer import _meta_prefix
 
 
 def test_meta_prefix_both_skill_and_short() -> None:
-    """Tier 2: both skill_name and run_id_short → '[skill#short] '."""
-    assert _meta_prefix({"skill_name": "builder", "run_id_short": "ab12"}) == "[builder#ab12] "
+    """Tier 2: both actor and run_id_short → '[skill#short] '."""
+    assert _meta_prefix({"actor": "builder", "run_id_short": "ab12"}) == "[builder#ab12] "
 
 
 def test_meta_prefix_skill_only() -> None:
-    """Tier 2: skill_name only (no run_id_short) → '[skill] '."""
-    assert _meta_prefix({"skill_name": "planner"}) == "[planner] "
+    """Tier 2: actor only (no run_id_short) → '[skill] '."""
+    assert _meta_prefix({"actor": "planner"}) == "[planner] "
 
 
 def test_meta_prefix_short_only() -> None:
-    """Tier 2: run_id_short only (no skill_name) → '[#short] '."""
+    """Tier 2: run_id_short only (no actor) → '[#short] '."""
     assert _meta_prefix({"run_id_short": "cd34"}) == "[#cd34] "
 
 

--- a/tests/test_repl_renderer_pure_helpers.py
+++ b/tests/test_repl_renderer_pure_helpers.py
@@ -27,17 +27,17 @@ from reyn.interfaces.repl.renderer import (
 
 
 def test_meta_prefix_both_skill_and_run_id() -> None:
-    """Tier 2: skill_name + run_id_short → '[skill#abcd] ' prefix."""
-    assert _meta_prefix({"skill_name": "research", "run_id_short": "ab12"}) == "[research#ab12] "
+    """Tier 2: actor + run_id_short → '[skill#abcd] ' prefix."""
+    assert _meta_prefix({"actor": "research", "run_id_short": "ab12"}) == "[research#ab12] "
 
 
 def test_meta_prefix_skill_only() -> None:
-    """Tier 2: skill_name without run_id_short → '[skill] ' prefix."""
-    assert _meta_prefix({"skill_name": "finder"}) == "[finder] "
+    """Tier 2: actor without run_id_short → '[skill] ' prefix."""
+    assert _meta_prefix({"actor": "finder"}) == "[finder] "
 
 
 def test_meta_prefix_run_id_only() -> None:
-    """Tier 2: run_id_short without skill_name → '[#abcd] ' prefix."""
+    """Tier 2: run_id_short without actor → '[#abcd] ' prefix."""
     assert _meta_prefix({"run_id_short": "cd34"}) == "[#cd34] "
 
 
@@ -47,7 +47,7 @@ def test_meta_prefix_empty_meta() -> None:
 
 
 def test_meta_prefix_unrelated_keys_ignored() -> None:
-    """Tier 2: keys other than skill_name/run_id_short produce empty string."""
+    """Tier 2: keys other than actor/run_id_short produce empty string."""
     assert _meta_prefix({"status": "done", "turn_id": "42"}) == ""
 
 

--- a/tests/test_resolve_session_routing.py
+++ b/tests/test_resolve_session_routing.py
@@ -47,7 +47,7 @@ def _seed(tmp_path: Path, name: str) -> None:
 def _iv_dict(iv_id: str) -> dict:
     return {
         "kind": "ask_user", "prompt": "Q?", "detail": "", "choices": [],
-        "suggestions": [], "run_id": "r", "skill_name": "demo", "id": iv_id,
+        "suggestions": [], "run_id": "r", "actor": "demo", "id": iv_id,
     }
 
 

--- a/tests/test_router_op_context_single_source_1412.py
+++ b/tests/test_router_op_context_single_source_1412.py
@@ -2,14 +2,14 @@
 
 ``Session._make_router_op_context`` and
 ``RouterHostAdapter.make_router_op_context`` built the
-``skill_name="chat_router"`` OpContext with ~95% identical code and drifted
+``actor="chat_router"`` OpContext with ~95% identical code and drifted
 (#1410/#1411 threaded base_dir to one, lagged the other — the #187 wrong-FS
 class). The fix routes both through ``build_router_op_context``
 (reyn/runtime/router_op_context.py).
 
 Pinned invariants (src-wide AST, the #1402 sole-construction pattern):
 
-- An ``OpContext(..., skill_name="chat_router", ...)`` is constructed ONLY in
+- An ``OpContext(..., actor="chat_router", ...)`` is constructed ONLY in
   ``router_op_context.py`` anywhere in ``src/reyn``. A second chat-router
   OpContext construction re-opens the drift class → this fails, naming
   file:line (incl. hidden sites).
@@ -41,7 +41,7 @@ def _chat_router_opcontext_sites() -> list[str]:
                 continue
             for kw in node.keywords:
                 if (
-                    kw.arg == "skill_name"
+                    kw.arg == "actor"
                     and isinstance(kw.value, ast.Constant)
                     and kw.value.value == "chat_router"
                 ):
@@ -67,9 +67,9 @@ def test_chat_router_opcontext_built_only_in_factory() -> None:
     inline chat-router OpContext construction fails this, naming file:line."""
     sites = _chat_router_opcontext_sites()
     offenders = [s for s in sites if not s.startswith(_FACTORY_REL + ":")]
-    assert sites, "no OpContext(skill_name='chat_router') found at all (factory missing?)"
+    assert sites, "no OpContext(actor='chat_router') found at all (factory missing?)"
     assert not offenders, (
-        "OpContext(skill_name='chat_router') built outside router_op_context.py "
+        "OpContext(actor='chat_router') built outside router_op_context.py "
         "— re-opens the #1412 drift class; route through build_router_op_context: "
         f"{offenders}"
     )

--- a/tests/test_snapshot_journal_intervention.py
+++ b/tests/test_snapshot_journal_intervention.py
@@ -47,7 +47,7 @@ def _iv_dict(iid: str, **overrides) -> dict:
         "choices": [],
         "suggestions": [],
         "run_id": "run_alpha_001",
-        "skill_name": "demo",
+        "actor": "demo",
         "id": iid,
         **overrides,
     }

--- a/tests/test_state_dir_read_routing_1390.py
+++ b/tests/test_state_dir_read_routing_1390.py
@@ -85,7 +85,7 @@ def _ws(tmp_path: Path, backend, state_dir: Path, *, grant: Path | None = None) 
         base_dir=repo,
         state_dir=state_dir,
         permission_resolver=perm,
-        skill_name="swe_bench",
+        actor="swe_bench",
         environment_backend=backend,
     )
 

--- a/tests/test_tool_opcontext_bridge_permission_decl.py
+++ b/tests/test_tool_opcontext_bridge_permission_decl.py
@@ -61,7 +61,7 @@ def _build_phase_state(perm_decl: PermissionDecl) -> PhaseCallerState:
         events=events,
         permission_decl=perm_decl,
         permission_resolver=None,
-        skill_name="test_skill",
+        actor="test_skill",
     )
     return PhaseCallerState(
         phase_name="test_phase",
@@ -112,7 +112,7 @@ def _shell_legacy_ctx(ctx: ToolContext) -> OpContext:
             else PermissionDecl()
         ),
         permission_resolver=ctx.permission_resolver,
-        skill_name="",
+        actor="",
     )
 
 

--- a/tests/test_user_intervention_serialization.py
+++ b/tests/test_user_intervention_serialization.py
@@ -8,7 +8,7 @@ volatile and the restored intervention gets a fresh future when re-enqueued.
 
 Round-trip invariants:
   - All persistent fields (kind, prompt, detail, choices, suggestions,
-    run_id, skill_name, id) survive a to_dict → from_dict cycle.
+    run_id, actor, id) survive a to_dict → from_dict cycle.
   - InterventionChoice nested objects serialize / deserialize correctly.
   - The dict shape is JSON-safe (only str / list / dict / None values)
     so it can flow through ``AgentSnapshot.outstanding_interventions``
@@ -43,7 +43,7 @@ def _sample_iv(*, with_choices: bool = False) -> UserIntervention:
         choices=choices,
         suggestions=["yes", "no"],
         run_id="run_alpha_001",
-        skill_name="my_skill",
+        actor="my_skill",
     )
 
 
@@ -60,7 +60,7 @@ def test_to_dict_returns_json_safe_dict():
     assert d["prompt"] == "Allow file/write to /tmp/foo?"
     assert d["detail"] == "Reason: skill X requested it"
     assert d["run_id"] == "run_alpha_001"
-    assert d["skill_name"] == "my_skill"
+    assert d["actor"] == "my_skill"
     assert d["id"] == iv.id
     assert d["suggestions"] == ["yes", "no"]
     assert d["choices"], "expected choices to be non-empty"
@@ -79,7 +79,7 @@ def test_from_dict_round_trip_preserves_persistent_fields():
     assert iv2.detail == iv.detail
     assert iv2.suggestions == iv.suggestions
     assert iv2.run_id == iv.run_id
-    assert iv2.skill_name == iv.skill_name
+    assert iv2.actor == iv.actor
     assert iv2.id == iv.id
     assert iv2.choices == iv.choices
 
@@ -111,18 +111,18 @@ def test_from_dict_handles_empty_choices_and_suggestions():
     assert iv2.choices == []
     assert iv2.suggestions == []
     assert iv2.kind == "ask_user"
-    assert iv2.skill_name is None  # default None preserved
+    assert iv2.actor is None  # default None preserved
 
 
-def test_from_dict_handles_none_run_id_and_skill_name():
+def test_from_dict_handles_none_run_id_and_actor():
     """Tier 2: intervention created before bus fills metadata round-trips."""
     iv = UserIntervention(kind="ask_user", prompt="Q?")
     d = iv.to_dict()
     assert d["run_id"] is None
-    assert d["skill_name"] is None
+    assert d["actor"] is None
     iv2 = UserIntervention.from_dict(d)
     assert iv2.run_id is None
-    assert iv2.skill_name is None
+    assert iv2.actor is None
 
 
 def test_to_dict_choices_preserve_none_hotkey():

--- a/tests/test_web_fetch_unified.py
+++ b/tests/test_web_fetch_unified.py
@@ -297,14 +297,14 @@ def _make_router_op_ctx_factory(resolver, bus, events):
         ws = Workspace(
             events=events,
             permission_resolver=resolver,
-            skill_name="chat_router",
+            actor="chat_router",
         )
         return OpContext(
             workspace=ws,
             events=events,
             permission_decl=PermissionDecl(),
             permission_resolver=resolver,
-            skill_name="chat_router",
+            actor="chat_router",
             intervention_bus=bus,
         )
 
@@ -453,14 +453,14 @@ def test_phase_dispatch_reuses_op_context_intervention_bus(tmp_path: Path) -> No
     workspace = Workspace(
         events=events,
         permission_resolver=resolver,
-        skill_name="skill_importer",
+        actor="skill_importer",
     )
     op_ctx_with_bus = OpContext(
         workspace=workspace,
         events=events,
         permission_decl=PermissionDecl(),
         permission_resolver=resolver,
-        skill_name="skill_importer",
+        actor="skill_importer",
         intervention_bus=bus,
     )
 

--- a/tests/test_web_python_unsafe_config.py
+++ b/tests/test_web_python_unsafe_config.py
@@ -95,7 +95,7 @@ def test_web_resolver_allows_unsafe_python_when_config_set(tmp_path):
     bus = _AutoApproveInterventionBus()
 
     # Must not raise — unsafe step is allowed.
-    perm = _run(resolver.require_python(decl, "my.module", "run", bus, skill_name="s"))
+    perm = _run(resolver.require_python(decl, "my.module", "run", bus, actor="s"))
     assert perm.mode == "unsafe"
 
 
@@ -126,4 +126,4 @@ def test_web_resolver_denies_unsafe_python_when_config_absent(tmp_path):
     bus = _AutoApproveInterventionBus()
 
     with pytest.raises(PermissionError):
-        _run(resolver.require_python(decl, "my.module", "run", bus, skill_name="s"))
+        _run(resolver.require_python(decl, "my.module", "run", bus, actor="s"))

--- a/tests/test_web_search_unified.py
+++ b/tests/test_web_search_unified.py
@@ -218,13 +218,13 @@ def _make_op_context(config_permissions: dict, tmp_path: Path):
         project_root=tmp_path,
         interactive=False,  # no prompts — config is the only gate
     )
-    workspace = Workspace(events=events, permission_resolver=resolver, skill_name="test")
+    workspace = Workspace(events=events, permission_resolver=resolver, actor="test")
     return OpContext(
         workspace=workspace,
         events=events,
         permission_decl=PermissionDecl(),
         permission_resolver=resolver,
-        skill_name="test",
+        actor="test",
     )
 
 

--- a/tests/test_workspace_glob_stdlib_perm.py
+++ b/tests/test_workspace_glob_stdlib_perm.py
@@ -24,13 +24,13 @@ def _make_workspace(
     *,
     project_root: Path,
     permission_resolver: PermissionResolver | None = None,
-    skill_name: str = "test_skill",
+    actor: str = "test_skill",
 ) -> Workspace:
     events = EventLog()
     ws = Workspace(
         events=events,
         permission_resolver=permission_resolver,
-        skill_name=skill_name,
+        actor=actor,
     )
     # Override base_dir / state_dir to match the tmp project root
     ws.base_dir = project_root.resolve()
@@ -90,12 +90,12 @@ def test_outside_project_glob_with_permission_succeeds(tmp_path):
     (phases_dir / "phase_one.md").write_text("# phase")
     (phases_dir / "phase_two.md").write_text("# phase 2")
 
-    skill_name = "skill_improver"
+    actor = "skill_improver"
     perm = _resolver(tmp_path)
     # Session-approve the stdlib skill directory recursively
-    perm.session_approve_path(str(skill_dir), skill_name, "file.read", recursive=True)
+    perm.session_approve_path(str(skill_dir), actor, "file.read", recursive=True)
 
-    ws = _make_workspace(project_root=tmp_path, permission_resolver=perm, skill_name=skill_name)
+    ws = _make_workspace(project_root=tmp_path, permission_resolver=perm, actor=actor)
 
     # Glob for all .md files under the skill dir
     results = ws.glob_files(str(phases_dir / "*.md"))

--- a/tests/test_workspace_state_dir_decouple_1115.py
+++ b/tests/test_workspace_state_dir_decouple_1115.py
@@ -60,7 +60,7 @@ def test_store_artifact_returns_state_dir_relative_handle(tmp_path: Path) -> Non
     ws = Workspace(events=EventLog(), base_dir=base, state_dir=state)
 
     artifact = {"type": "demo", "data": {"x": 1, "y": "two"}}
-    handle = ws.store_artifact("phase_a", artifact, skill_name="demo_skill")
+    handle = ws.store_artifact("phase_a", artifact, actor="demo_skill")
 
     assert not Path(handle).is_absolute(), f"handle must be relative: {handle!r}"
     assert handle.startswith("artifacts/"), (


### PR DESCRIPTION
**[e2e-coder]** ② — rename the misnamed permission approval-scope key `skill_name` → **`actor`** (owner-confirmed name). Security-critical; **for your 実 test review** (enforcement-equivalence + rename-completeness, not trivially-pass).

## Why `actor`
The approval-scope key never held a skill — it carries the calling **actor**: session-router (`"chat_router"`/`"router"`), a tool-verb name (`"drop_source"`, …), or the unscoped empty actor. Owner picked `actor` after `caller` was rejected — **`caller` collides** with the existing `OpContext.caller` (PR20 event provenance, `events/<caller>/skill_runs/`), a different concept (caught pre-commit via a duplicate-kwarg error).

## (a) Pure NAME rename — enforcement byte-identical by construction
The param name never appears in the key string (`f"{actor}/{kind}/{path}"`) — only the actor VALUE does — so keys are byte-identical and deny/allow verdicts unchanged. The renamed permission/audit suites stay green.

## Scope = Cluster 1 (approval-scope key) ONLY
- `OpContext.skill_name` field + ~10 key-generators + permission-gate params + ~30 op-ctx builders/callers + `InterventionRequest.skill_name` + serialization.
- **item2 audit field**: permission_granted/denied + user_intervention_* now emit `actor=` (was `skill=`); `EVENT_AUDIT_REQUIREMENTS` keys → `"actor"` (no other consumer reads the field).
- docstrings/comments (`permissions.py` "actor-scoped"; router_loop comment).

## Excluded (separate tails — verified, untouched)
- **Cluster 2/3**: llm.py `call_llm_tools`/`recorded_acompletion` budget-tag + `_system_prompt` `━━━ SKILL ━━━` content block (entangled with `skill_description`; Cluster 3 needs a liveness verify as a straggler).
- **Cluster 4**: eval `result_loader`/`eval_report` results-dir skill (→ item1).
- **Cluster 5**: `known_skill_names` skill catalog. **capability_profile** SKILL axis (owner: keep).

## Enforcement-equivalence falsify (new)
`test_permission_actor_scope_isolation.py` (Tier 2): a write grant under one actor is honored for THAT actor only — every other actor (and the unscoped empty actor, which can never be granted) is denied. Parametrized over the actor categories. **Verified RED when the actor segment is stripped from the key** (4/5 fail); green on revert.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` (all changed test files) — 0 errors
- [x] `verify_module_docstrings.py` (changed src) — OK
- [x] full `pytest` — **6927 passed, 16 skipped** (incl. 5 new isolation tests)
- [x] falsify: strip actor from key ⇒ isolation test RED; revert ⇒ green
- [x] completeness: no `skill_name` remains outside the excluded cluster-2/3/4/5 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)