### PR TITLE
refactor(skill-word): remove dead _system_prompt + call_llm_tools skill params (Cluster 2/3)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1065,44 +1065,6 @@ Artifact rules:
 """
 
 
-def _system_prompt(
-    skill_name: str = "",
-    skill_description: str = "",
-    phase_role: str | None = None,
-    project_context: str = "",
-    agent_role: str = "",
-) -> str:
-    """Compose the system prompt: format contract + skill goal + role + project context.
-
-    Stable, persona-bearing fields live here (system) so the LLM treats them
-    as authoritative role definitions; volatile per-phase data stays in the
-    user-turn JSON.
-
-    `agent_role` (multi-agent: PR10) is the persona text from
-    `.reyn/agents/<name>/profile.yaml`. It applies to every phase the agent
-    runs and sits between the project context and the per-phase role so the
-    agent's overall persona doesn't shadow phase-specific responsibilities.
-    """
-    sections: list[str] = [_SYSTEM_BASE]
-    if skill_name or skill_description:
-        sections.append(
-            f"━━━ SKILL ━━━\n{skill_name}\n{skill_description}".strip()
-        )
-    if phase_role:
-        sections.append(
-            f"━━━ ROLE ━━━\nYou are acting as: {phase_role}"
-        )
-    if project_context:
-        sections.append(
-            f"━━━ PROJECT CONTEXT ━━━\n{project_context.strip()}"
-        )
-    if agent_role:
-        sections.append(
-            f"━━━ AGENT ROLE ━━━\n{agent_role.strip()}"
-        )
-    return "\n\n".join(sections)
-
-
 def _extract_json(text: str) -> str:
     """
     Strip markdown code fences wrapping the entire response.
@@ -1802,8 +1764,6 @@ async def call_llm_tools(
     tool_choice: str = "auto",       # "auto" | "required" | "none" (note: "none" not Gemini-safe)
     timeout: float | None = None,
     max_retries: int = 1,
-    skill_name: str = "router",      # for budget/event tagging
-    skill_description: str = "",
     prompt_cache_enabled: bool = True,
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1937,7 +1937,6 @@ class RouterLoop:
                         messages=messages,
                         tools=tools,
                         tool_choice="auto",
-                        skill_name="router",
                         budget=self.budget,
                         budget_agent=host.agent_name,
                         trace_caller="router",
@@ -2588,7 +2587,6 @@ class RouterLoop:
             messages=wrap_messages,
             tools=[],            # continuation suppression: no tool to call
             tool_choice="auto",  # omitted by call_llm_tools when tools=[] (Gemini fix)
-            skill_name="router",
             budget=self.budget,
             budget_agent=self.host.agent_name,
             trace_caller="router_force_close",

--- a/tests/test_chat_router_i18n.py
+++ b/tests/test_chat_router_i18n.py
@@ -260,7 +260,7 @@ def test_router_loop_passes_output_language_to_system_prompt(tmp_path, monkeypat
     captured_prompts: list[str] = []
 
     async def fake_llm_tools(*, model, messages, tools, tool_choice,
-                              skill_name, budget, budget_agent, **kwargs):
+                              budget, budget_agent, **kwargs):
         # Capture the system message (first in messages list).
         for msg in messages:
             if msg.get("role") == "system":


### PR DESCRIPTION
**[lead-sonnet]** —

Both verified dead on origin/main: `_system_prompt` has zero callers; `call_llm_tools` `skill_name`/`skill_description` are unread stub params. De-entangled (no cross-effect). Removes function + params + 2 call-sites.

part of the skill-deletion arc (skill-word cluster cleanup).

## Changes

- **`src/reyn/llm/llm.py`** (-38 lines): Remove entire `_system_prompt` function (def + body, the `━━━ SKILL ━━━` block). Zero callers confirmed by `git grep -n "_system_prompt(" src/` returning only the def line.
- **`src/reyn/llm/llm.py`** (-2 lines): Remove `skill_name: str = "router"` and `skill_description: str = ""` params from `call_llm_tools` signature. Neither is referenced in the function body.
- **`src/reyn/runtime/router_loop.py`** (-2 lines): Remove `skill_name="router"` kwarg from both call-sites (line ~1940, line ~2591).
- **`tests/test_chat_router_i18n.py`** (-1/+1): Remove `skill_name` from fake's explicit param list (it was pinning the now-removed param; the call from router_loop no longer passes it).

## Pre-removal verification (primary evidence)

- `git grep -n "_system_prompt(" src/` → single result: the def line only. Zero callers.
- `grep -n "skill_name\|skill_description" src/reyn/llm/llm.py` → lines 1805-1806 (signature only). Neither appears in body.
- Call-sites: `src/reyn/runtime/router_loop.py:1940` and `:2591` — both pass `skill_name="router"` only (no `skill_description`).

## Gate results

- `ruff check src tests` → **All checks passed!**
- `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py src/reyn/runtime/router_loop.py` → **OK**
- `python scripts/test_tier_audit.py --strict tests/test_chat_router_i18n.py` → **12/12 OK, 0 errors**
- `pytest` (excluding `fastapi`-missing env errors pre-existing on origin/main): baseline 8 failed / after 8 failed — net zero regression. The `test_chat_router_i18n.py` fake-signature fix restores that test from a new failure to passing.

## Test plan

- [x] `ruff check src tests` — green
- [x] `pytest` — no regressions introduced (pre-existing fastapi-import failures unchanged)
- [x] `verify_module_docstrings` — green
- [x] Tier audit on changed test file — 12/12 OK