### PR TITLE
refactor(skill-word): reword stale "stdlib skill" user-facing strings

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -551,10 +551,10 @@ async def _starters() -> list[cl.Starter]:
             message="このプロジェクトに設定されている agent を一覧してください。",
         ),
         cl.Starter(
-            label="reyn の Skill を 1 つ動かしてみる",
+            label="このプロジェクトについて質問してみる",
             message=(
-                "今このプロジェクトで使える stdlib skill を 1 つ選んで、"
-                "短い試走をしてください。 何が起きるか教えてください。"
+                "このプロジェクトで今すぐ試せる簡単なタスクや質問を 1 つ実行してください。"
+                " 何が起きるか教えてください。"
             ),
         ),
         cl.Starter(

--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -209,7 +209,7 @@ def _cmd_show(args: argparse.Namespace) -> None:
     print(f"workspace:   {target}")
     # PR15: allowlist visibility.
     if profile.allowed_skills is None:
-        print("allowed_skills: (unrestricted — all project + stdlib skills)")
+        print("allowed_skills: (unrestricted — no per-agent restriction)")
     elif not profile.allowed_skills:
         print("allowed_skills: (none — router-only, no skill spawn)")
     else:

--- a/src/reyn/interfaces/cli/commands/init.py
+++ b/src/reyn/interfaces/cli/commands/init.py
@@ -81,6 +81,6 @@ def run(args: argparse.Namespace) -> None:
     print("       reyn chat   # then ask a question covered by your indexed docs")
     print()
     print("MCP servers (optional):")
-    print("  To use stdlib skills that depend on MCP, uncomment the mcp:")
+    print("  To use MCP-backed tools/servers, uncomment the mcp:")
     print("  block in reyn.yaml.  Full example: docs/cookbook/configs/with-mcp.yaml")
     print("  Setup guide:          docs/guide/for-skill-authors/use-an-mcp-server.md")


### PR DESCRIPTION
**[lead-sonnet]** — part of the skill-deletion arc (skill feature removed; chat-based system has no user-selectable skills).

## Summary

Three user-facing strings still referenced "stdlib skill" / "project + stdlib skills" after the skill feature was deleted. This PR rewords them to reflect the current chat-based reality.

**Changes (string-only, no logic altered):**

1. `src/reyn/interfaces/chainlit_app/app.py` — `cl.Starter` entry:
   - **Before** label: `"reyn の Skill を 1 つ動かしてみる"` / message: `"今このプロジェクトで使える stdlib skill を 1 つ選んで、短い試走をしてください。 何が起きるか教えてください。"`
   - **After** label: `"このプロジェクトについて質問してみる"` / message: `"このプロジェクトで今すぐ試せる簡単なタスクや質問を 1 つ実行してください。 何が起きるか教えてください。"`

2. `src/reyn/interfaces/cli/commands/agent.py` — `allowed_skills: None` display line:
   - **Before:** `"allowed_skills: (unrestricted — all project + stdlib skills)"`
   - **After:** `"allowed_skills: (unrestricted — no per-agent restriction)"`

3. `src/reyn/interfaces/cli/commands/init.py` — MCP hint line:
   - **Before:** `"  To use stdlib skills that depend on MCP, uncomment the mcp:"`
   - **After:** `"  To use MCP-backed tools/servers, uncomment the mcp:"`

## Gates

- `ruff check src tests`: all checks passed
- `python scripts/verify_module_docstrings.py <changed files>`: OK
- `pytest` (excluding pre-existing fastapi/MCP collection errors): 6615 passed, 37 skipped — no new failures; old strings not pinned in any test

🤖 Generated with [Claude Code](https://claude.com/claude-code)