### PR TITLE
refactor(skill-axis): remove dead capability_profile SKILL axis + allowed_skills carry-chain

### DIFF
--- a/docs/deep-dives/spec/openui/schemas/reyn-ui-v1/manifest.yaml
+++ b/docs/deep-dives/spec/openui/schemas/reyn-ui-v1/manifest.yaml
@@ -68,7 +68,6 @@ actions:
       role_prompt: string
       animal: AgentAnimal
       color: string
-      allowed_skills?: string[]
     returns: Agent
 
   agent.remove:

--- a/scripts/df2187_harness.py
+++ b/scripts/df2187_harness.py
@@ -72,7 +72,6 @@ async def _drive(ws: Path, prompt: str, *, worker_sid: str, timeout_s: float) ->
             compaction_config=config.chat.compaction,
             reasoning_config=config.chat.reasoning,
             registry=registry,
-            allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
             task_backend=registry.task_backend,
             events_config=config.events,

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -209,7 +209,6 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 compaction_config=session_cfg.config.chat.compaction,
                 reasoning_config=session_cfg.config.chat.reasoning,  # #1652
                 registry=registry_ref[0],
-                allowed_skills=profile.allowed_skills,
                 allowed_mcp=profile.allowed_mcp,
                 task_backend=None,  # #1953 slice R: behaviour-preserving (op-runtime fallback); per-session rewind opt-in is a follow-up
                 events_config=session_cfg.config.events,

--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -207,15 +207,6 @@ def _cmd_show(args: argparse.Namespace) -> None:
     print(f"name:        {profile.name}")
     print(f"created_at:  {profile.created_at}")
     print(f"workspace:   {target}")
-    # PR15: allowlist visibility.
-    if profile.allowed_skills is None:
-        print("allowed_skills: (unrestricted — no per-agent restriction)")
-    elif not profile.allowed_skills:
-        print("allowed_skills: (none — router-only, no skill spawn)")
-    else:
-        print("allowed_skills:")
-        for s in profile.allowed_skills:
-            print(f"  - {s}")
     print("role:")
     if profile.role:
         for line in profile.role.splitlines():

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -401,7 +401,6 @@ def run(args: argparse.Namespace) -> None:
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652
             registry=registry,  # back-reference for :agents / :attach + PR11 messaging
-            allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
             # #1953 slice R, I-5=(A): sqlite Task backend → in-session task.* ops are
             # durable + rewind with the session (local single-tenant).

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -483,7 +483,6 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652
                 registry=_reg_cell[0] if _reg_cell else None,
-                allowed_skills=profile.allowed_skills,
                 allowed_mcp=profile.allowed_mcp,
                 task_backend=None,  # #1953 slice R: dogfood eval has no WAL/rewind → op-runtime fallback
                 events_config=config.events,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -412,7 +412,6 @@ def run_serve(args: argparse.Namespace) -> None:
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652
             registry=registry,
-            allowed_skills=profile.allowed_skills,
             allowed_mcp=profile.allowed_mcp,
             # #1953 slice R, I-5=(A): stdio-MCP is single-tenant per process, so the
             # agent's sqlite backend (rewind-participating) ≈ the singleton — durable

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -320,7 +320,6 @@ def _get_registry():
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652
                 registry=registry,
-                allowed_skills=profile.allowed_skills,
                 events_config=config.events,
                 state_log=state_log,
                 budget_tracker=budget_tracker,

--- a/src/reyn/interfaces/web/routers/agents.py
+++ b/src/reyn/interfaces/web/routers/agents.py
@@ -27,14 +27,12 @@ class AgentSummary(BaseModel):
     name: str
     role: str
     created_at: str
-    allowed_skills: list[str] | None
     last_activity_at: str | None
 
 
 class CreateAgentRequest(BaseModel):
     name: str
     role: str = ""
-    allowed_skills: list[str] | None = None
 
 
 class AgentDetail(AgentSummary):
@@ -51,7 +49,6 @@ def _profile_to_summary(registry, name: str) -> AgentSummary:
         name=profile.name,
         role=profile.role,
         created_at=profile.created_at,
-        allowed_skills=profile.allowed_skills,
         last_activity_at=last_at.isoformat() if last_at else None,
     )
 
@@ -84,24 +81,10 @@ async def create_agent(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         )
-    # Save allowed_skills if provided.
-    if body.allowed_skills is not None:
-        from reyn.runtime.profile import AgentProfile
-        updated = AgentProfile(
-            name=profile.name,
-            role=profile.role,
-            created_at=profile.created_at,
-            allowed_skills=body.allowed_skills,
-        )
-        agent_dir = registry._dir / profile.name
-        updated.save(agent_dir)
-        profile = updated
-
     return AgentDetail(
         name=profile.name,
         role=profile.role,
         created_at=profile.created_at,
-        allowed_skills=profile.allowed_skills,
         last_activity_at=None,
     )
 

--- a/src/reyn/interfaces/web/routers/web_data.py
+++ b/src/reyn/interfaces/web/routers/web_data.py
@@ -151,7 +151,6 @@ def _build_agents(registry) -> list[dict[str, Any]]:
             "role": role[:20] if role else "Assistant",
             "blurb": f"Agent {name}",
             "role_prompt": role,
-            "allowed_skills": [],
             "last_active": last_at.strftime("%-d %b %H:%M") if last_at else "never",
             "activity": "",
         })

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -1,22 +1,10 @@
 """AgentProfile — per-agent metadata persisted to .reyn/agents/<name>/profile.yaml.
 
 PR10 introduced the file with the minimal schema (`name`, `role`,
-`created_at`). PR15 adds `allowed_skills`: an optional allowlist of
-project skill names this agent may invoke. `skill_router`
-is always available — the allowlist only constrains user-visible skills
-the router would otherwise hand off to. (FP-0011: `skill_narrator` was
-removed; the router LLM narrates inline. PR-N3: `chat_compactor` skill
-retired — compaction is now OS-internal Python.)
-
-Semantics for `allowed_skills`:
-- absent / null  → no restriction (every project skill, default)
-- empty list `[]` → router runs (LLM-only replies) but no skill spawn
-- `[a, b]`        → only those skill names
-
-PR37 adds `allowed_mcp`: an optional allowlist of MCP server names this
+`created_at`). PR37 adds `allowed_mcp`: an optional allowlist of MCP server names this
 agent may access, layered on top of the project-wide `permissions.mcp`
 config. Semantics:
-- absent / null  → no per-agent restriction (inherits project config)
+- absent / null  → no restriction (inherits project config)
 - `"all"`        → same as null but explicit in YAML for audit clarity
 - `[a, b]`       → intersect with project allow-list (per-agent narrowing)
 
@@ -44,10 +32,6 @@ class AgentProfile:
     name: str
     role: str = ""
     created_at: str = ""
-    # PR15: optional skill allowlist. None = unrestricted (default), [] = no
-    # skills at all, [...] = only those names. stdlib router/compactor are NOT
-    # subject to this list. (FP-0011: skill_narrator removed.)
-    allowed_skills: list[str] | None = None
     # PR37: optional MCP server allowlist. None = no per-agent restriction
     # (inherits project config). "all" in YAML normalizes to None here.
     # list[str] = intersect with project allow-list.
@@ -68,12 +52,6 @@ class AgentProfile:
         if not path.is_file():
             raise FileNotFoundError(path)
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-        raw_allowed = data.get("allowed_skills", None)
-        if raw_allowed is None:
-            allowed: list[str] | None = None
-        else:
-            # Accept yaml empty mapping `[]` or list of strings; coerce to list[str].
-            allowed = [str(s) for s in raw_allowed]
         # PR37: parse allowed_mcp — "all" sentinel normalizes to None.
         raw_allowed_mcp = data.get("allowed_mcp", None)
         if raw_allowed_mcp is None or raw_allowed_mcp == "all":
@@ -84,22 +62,19 @@ class AgentProfile:
             name=str(data.get("name", agent_dir.name)),
             role=str(data.get("role", "") or ""),
             created_at=str(data.get("created_at", "") or ""),
-            allowed_skills=allowed,
             allowed_mcp=allowed_mcp,
         )
 
     def save(self, agent_dir: Path) -> None:
         agent_dir.mkdir(parents=True, exist_ok=True)
         path = agent_dir / PROFILE_FILENAME
-        # Hand-roll the dict so absent allowed_skills (None) doesn't appear
+        # Hand-roll the dict so absent allowed_mcp (None) doesn't appear
         # in the yaml as `null` — keep the on-disk shape minimal.
         payload: dict = {
             "name": self.name,
             "role": self.role,
             "created_at": self.created_at,
         }
-        if self.allowed_skills is not None:
-            payload["allowed_skills"] = list(self.allowed_skills)
         if self.allowed_mcp is not None:
             payload["allowed_mcp"] = list(self.allowed_mcp)
         path.write_text(
@@ -109,19 +84,16 @@ class AgentProfile:
 
     def default_profile(self) -> "CapabilityProfile":
         """The agent's default capability spec (#2074 S4a) — the canonical unified
-        representation of this agent's per-agent baseline narrowing.
+        representation of this agent's per-agent baseline narrowing on the MCP axis.
 
-        The profile.yaml user keys stay ``allowed_skills`` / ``allowed_mcp`` (the
-        natural operator surface); this maps them onto the unified spec's
-        ``skill_allow`` / ``mcp_allow`` axes (the INTERNAL representation, no
-        user-facing rename). ``None`` allowlists pass through as ``None`` (= ⊤,
-        unrestricted). #2074 S4b repoints the per-agent ∩ layers to read this spec
-        object so one primitive feeds both binding adapters."""
+        The profile.yaml user key ``allowed_mcp`` maps onto the unified spec's
+        ``mcp_allow`` axis (the INTERNAL representation). ``None`` passes through
+        as ``None`` (= ⊤, unrestricted). #2074 S4b repoints the per-agent ∩ layer
+        to read this spec object so one primitive feeds the MCP binding adapter."""
         from reyn.security.permissions.capability_profile import CapabilityProfile
 
         return CapabilityProfile(
             name=self.name,
-            skill_allow=tuple(self.allowed_skills) if self.allowed_skills is not None else None,
             mcp_allow=tuple(self.allowed_mcp) if self.allowed_mcp is not None else None,
         )
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -682,7 +682,6 @@ class AgentRegistry:
                     "name": profile.name,
                     "role": profile.role,
                     "created_at": profile.created_at,
-                    "allowed_skills": profile.allowed_skills,
                     "allowed_mcp": profile.allowed_mcp,
                 },
             )
@@ -1504,7 +1503,6 @@ class AgentRegistry:
             name=name,
             role=str(profile_payload.get("role", "")),
             created_at=str(profile_payload.get("created_at", "")),
-            allowed_skills=profile_payload.get("allowed_skills"),
             allowed_mcp=profile_payload.get("allowed_mcp"),
         )
         prof.save(self._dir / name)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -651,7 +651,6 @@ class Session:
         compaction_config: "CompactionConfig | None" = None,
         reasoning_config: "ReasoningConfig | None" = None,  # #1652 chat.reasoning
         registry: "AgentRegistry | None" = None,
-        allowed_skills: list[str] | None = None,
         allowed_mcp: list[str] | None = None,
         events_config: EventsConfig | None = None,
         # #2230: the resolved ``cost_warn:`` config so the high-cost model warn /
@@ -1059,13 +1058,6 @@ class Session:
         # since the last human user turn. In-memory only (NOT snapshot-persisted);
         # resets on each user turn (re-arm). Bounds hook self-continuation.
         self._hook_driven_turns: int = 0
-        # PR15: optional skill allowlist sourced from profile.allowed_skills.
-        # None = unrestricted (default, BC). Empty list = router runs but no
-        # skill spawn. stdlib router/compactor are NOT subject to this — they're
-        # always available regardless. (FP-0011: skill_narrator removed.)
-        self._allowed_skills: list[str] | None = (
-            list(allowed_skills) if allowed_skills is not None else None
-        )
         # PR37: optional MCP server allowlist from agent profile. None = no
         # per-agent restriction (inherits project config). list[str] = only
         # these servers pass the per-agent check in require_mcp.
@@ -3302,12 +3294,10 @@ class Session:
             prof = AgentProfile.load(agent_dir)
         except (FileNotFoundError, OSError):
             return False  # single-agent / no profile → nothing per-agent to reapply
-        if prof.allowed_skills == self._allowed_skills and prof.allowed_mcp == self._allowed_mcp:
+        if prof.allowed_mcp == self._allowed_mcp:
             return False  # unchanged
         # Session orchestrates the multi-holder swap (the holders it owns).
-        self._allowed_skills = prof.allowed_skills
         self._allowed_mcp = prof.allowed_mcp
-        self._router_host._allowed_skills = prof.allowed_skills    # SKILL catalog gate
         self._router_host._allowed_mcp = prof.allowed_mcp          # MCP gate (decl source)
         return True
 

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -5,7 +5,7 @@ capabilities, loaded from ``.reyn/capability_profiles/<name>.yaml``. It is the
 **single capability-narrowing primitive** across all #1199 ∩ axes (#2074):
 
 - **authority (enforcement)** → a :class:`ContextualPermission` carrying the
-  TOOL / SKILL / MCP axes (``*_allow`` / ``*_deny``) that ride the live ∩-gate.
+  TOOL / MCP axes (``*_allow`` / ``*_deny``) that ride the live ∩-gate.
 - **visibility (cognitive)** → an ``excluded_categories`` set derived from
   ``categories`` against the canonical catalog.
 
@@ -15,10 +15,10 @@ allowlist baseline, #2074 S2/S4a). Both feed the UNCHANGED ``EffectivePermission
 ∩ — the spec is separated from the binding.
 
 This module is PURE — schema + loader + resolver + compose. Enforcement wiring
-lives in the binding adapters: the TOOL axis rides the live gate today; SKILL /
-MCP axes are carried by the resolver (#2074 S1) and consumed by the per-agent
-adapter (S2) + ContextualLayer (S3). With no profile applied the session is
-byte-identical to pre-#1827.
+lives in the binding adapters: the TOOL axis rides the live gate today; the MCP
+axis is carried by the resolver and consumed by the per-agent adapter (S2) +
+ContextualLayer (S4a). With no profile applied the session is byte-identical to
+pre-#1827.
 
 The resolver never *grants* — both products are restrict-only:
 ``ContextualPermission`` is an ∩ term (never-elevate is the ``all()`` in
@@ -44,11 +44,7 @@ class CapabilityProfile:
       = no visibility narrowing (show everything). An explicit (possibly empty)
       tuple narrows the view to that set.
     - ``tool_allow`` / ``tool_deny`` — the TOOL axis (allow-list / deny-list).
-    - ``skill_allow`` / ``skill_deny`` — the SKILL axis (#2074 S1). ``skill_allow``
-      None = unrestricted; ``()`` = none allowed; a set = only those. This matches
-      ``AgentProfile.allowed_skills`` semantics exactly (None / [] / [a,b]) so the
-      per-agent binding adapter (#2074 S2/S4a) routes through it byte-identically.
-    - ``mcp_allow`` / ``mcp_deny`` — the MCP axis (#2074 S1), same allow/deny shape.
+    - ``mcp_allow`` / ``mcp_deny`` — the MCP axis, same allow/deny shape.
 
     Tuples (not sets) so the dataclass stays frozen/hashable; the resolver
     converts to frozensets.
@@ -59,9 +55,7 @@ class CapabilityProfile:
     categories: "tuple[str, ...] | None" = None
     tool_allow: "tuple[str, ...] | None" = None
     tool_deny: "tuple[str, ...]" = ()
-    # #2074 S1 — the SKILL / MCP axes of the unified spec (additive).
-    skill_allow: "tuple[str, ...] | None" = None
-    skill_deny: "tuple[str, ...]" = ()
+    # #2074 S1 — the MCP axis of the unified spec.
     mcp_allow: "tuple[str, ...] | None" = None
     mcp_deny: "tuple[str, ...]" = ()
 
@@ -93,9 +87,6 @@ def load_capability_profile(path: "str | Path") -> CapabilityProfile:
         categories=_as_tuple(data["categories"]) if "categories" in data else None,
         tool_allow=_as_tuple(data["tool_allow"]) if "tool_allow" in data else None,
         tool_deny=_as_tuple(data.get("tool_deny")) or (),
-        # #2074 S1 — SKILL / MCP axes (additive; absent → None/() = ⊤).
-        skill_allow=_as_tuple(data["skill_allow"]) if "skill_allow" in data else None,
-        skill_deny=_as_tuple(data.get("skill_deny")) or (),
         mcp_allow=_as_tuple(data["mcp_allow"]) if "mcp_allow" in data else None,
         mcp_deny=_as_tuple(data.get("mcp_deny")) or (),
     )
@@ -119,8 +110,8 @@ def resolve_profile(
 ) -> "tuple[ContextualPermission, frozenset[str]]":
     """Resolve a profile into ``(ContextualPermission, excluded_categories)``.
 
-    - enforcement: a ``ContextualPermission`` carrying the TOOL / SKILL / MCP axes
-      (``*_allow`` / ``*_deny``) — the ∩ term (#2074 S1 adds SKILL / MCP).
+    - enforcement: a ``ContextualPermission`` carrying the TOOL / MCP axes
+      (``*_allow`` / ``*_deny``) — the ∩ term.
     - view: ``excluded_categories = CATEGORIES − categories`` when ``categories``
       is set; ``∅`` (no view narrowing) when ``categories is None``.
 
@@ -140,11 +131,6 @@ def resolve_profile(
             if profile.tool_allow is not None else None
         ),
         tool_deny=_expand_tool_forms(profile.tool_deny),
-        # #2074 S1 — SKILL / MCP axes (carried; ContextualLayer enforces them in S3).
-        skill_allow=(
-            frozenset(profile.skill_allow) if profile.skill_allow is not None else None
-        ),
-        skill_deny=frozenset(profile.skill_deny),
         mcp_allow=(
             frozenset(profile.mcp_allow) if profile.mcp_allow is not None else None
         ),
@@ -163,7 +149,7 @@ def compose_resolved(
     """Compose N resolved profiles, most-restrictive-wins (#1827 multi-membership).
 
     Monotonic with the ∩ model: **union of denials, intersection of allows** —
-    applied uniformly to every axis (#2074 S1: TOOL / SKILL / MCP).
+    applied uniformly to every axis (TOOL / MCP).
     - ``*_deny`` → union (any profile's deny wins).
     - ``*_allow`` → intersection of the *set* allow-lists (``None`` = ⊤, skipped);
       a value stays allowed only if every constraining profile allows it.
@@ -188,7 +174,6 @@ def compose_resolved(
         return combined_allow, frozenset(deny)
 
     tool_allow, tool_deny = _compose_axis("tool_allow", "tool_deny")
-    skill_allow, skill_deny = _compose_axis("skill_allow", "skill_deny")
     mcp_allow, mcp_deny = _compose_axis("mcp_allow", "mcp_deny")
     excluded: "set[str]" = set()
     for _c, excl in resolved:
@@ -196,7 +181,6 @@ def compose_resolved(
     return (
         ContextualPermission(
             tool_allow=tool_allow, tool_deny=tool_deny,
-            skill_allow=skill_allow, skill_deny=skill_deny,
             mcp_allow=mcp_allow, mcp_deny=mcp_deny,
         ),
         frozenset(excluded),

--- a/src/reyn/security/permissions/effective.py
+++ b/src/reyn/security/permissions/effective.py
@@ -54,7 +54,6 @@ class CapabilityAxis(Enum):
     NETWORK_HOST = "network_host"
     SUBPROCESS = "subprocess"
     MCP = "mcp"
-    SKILL = "skill"
     SECRET_WRITE = "secret_write"
     PYTHON = "python"
     ENV = "env"
@@ -167,7 +166,7 @@ class AgentLayer:
             return any(
                 (p.module, p.function) == tuple(value) for p in d.python
             )
-        # SKILL / ENV / SUBPROCESS: the decl does not constrain → ⊤.
+        # ENV / SUBPROCESS / SKILL: the decl does not constrain → ⊤.
         # (#1352-L3: the shell-permission SUBPROCESS gate was retired with the
         # shell op; subprocess is now bounded by SandboxLayer.allow_subprocess
         # at the sandboxed_exec seam, not the AgentLayer.)
@@ -207,13 +206,13 @@ class SandboxLayer:
 
 class ProfileLayer:
     """The per-agent ALLOWLIST layer (#2074) — reads the agent's **default
-    capability spec** (a :class:`CapabilityProfile`) on the SKILL / MCP axes, so one
-    primitive (the unified spec) feeds both binding adapters (per-agent + per-context).
+    capability spec** (a :class:`CapabilityProfile`) on the MCP axis, so one
+    primitive (the unified spec) feeds the binding adapter.
 
     The spec is ``AgentProfile.default_profile()`` where the profile is available
     (the canonical source), else built from already-extracted allowlists via
-    :meth:`from_allowlists` (byte-identical — the same ``skill_allow`` / ``mcp_allow``
-    values). A ``None`` spec, or a ``None`` axis allow-list, is unrestricted (⊤)."""
+    :meth:`from_allowlists` (byte-identical — the same ``mcp_allow`` value).
+    A ``None`` spec, or a ``None`` axis allow-list, is unrestricted (⊤)."""
 
     def __init__(self, spec: "CapabilityProfile | None") -> None:
         self._spec = spec
@@ -222,18 +221,14 @@ class ProfileLayer:
     def from_allowlists(
         cls,
         *,
-        allowed_skills: "object | None" = None,
         allowed_mcp: "object | None" = None,
     ) -> "ProfileLayer":
-        """Build a per-agent layer from already-extracted ``allowed_skills`` /
-        ``allowed_mcp`` by wrapping them in the canonical capability spec (#2074 S4b).
-        Byte-identical to ``AgentProfile.default_profile()`` (same skill_allow/
-        mcp_allow values). ``None`` = unrestricted on that axis."""
+        """Build a per-agent layer from already-extracted ``allowed_mcp`` by wrapping
+        it in the canonical capability spec (#2074 S4b). ``None`` = unrestricted."""
         from reyn.security.permissions.capability_profile import CapabilityProfile
 
         return cls(CapabilityProfile(
             name="_per_agent_default",
-            skill_allow=tuple(allowed_skills) if allowed_skills is not None else None,
             mcp_allow=tuple(allowed_mcp) if allowed_mcp is not None else None,
         ))
 
@@ -241,11 +236,9 @@ class ProfileLayer:
         sp = self._spec
         if sp is None:
             return True
-        if axis is CapabilityAxis.SKILL:
-            return sp.skill_allow is None or value in sp.skill_allow
         if axis is CapabilityAxis.MCP:
             return sp.mcp_allow is None or value in sp.mcp_allow
-        return True  # the per-agent spec constrains only skill / mcp (allow-lists)
+        return True  # the per-agent spec constrains only mcp (allow-list)
 
 
 @dataclass(frozen=True)
@@ -255,20 +248,12 @@ class ContextualPermission:
     from a delegation / topology role / ephemeral profile (later slices wire those
     sources) and carried on ``OpContext.contextual_permission``.
 
-    Per-axis ``*_allow`` (None = unconstrained ⊤) ∩ ``¬*_deny``. The TOOL axis is
-    enforced by :class:`ContextualLayer` today; the SKILL / MCP axes are **carried
-    but not yet enforced** by ContextualLayer (the unified-spec resolver #2074 S1
-    populates them; #2074 S3 wires ContextualLayer to consume them — until then
-    this term is ⊤ on SKILL/MCP, so adding the fields changes no gate outcome).
+    Per-axis ``*_allow`` (None = unconstrained ⊤) ∩ ``¬*_deny``. The TOOL and MCP
+    axes are enforced by :class:`ContextualLayer`.
     """
 
     tool_allow: "frozenset[str] | None" = None
     tool_deny: "frozenset[str]" = field(default_factory=frozenset)
-    # #2074 S1 (additive, inert): the SKILL / MCP axes of the unified capability
-    # spec. Carried here so one resolved term covers all axes; ContextualLayer
-    # still enforces only TOOL (S3 wires SKILL/MCP). Inert defaults = ⊤.
-    skill_allow: "frozenset[str] | None" = None
-    skill_deny: "frozenset[str]" = field(default_factory=frozenset)
     mcp_allow: "frozenset[str] | None" = None
     mcp_deny: "frozenset[str]" = field(default_factory=frozenset)
 
@@ -295,12 +280,6 @@ class ContextualLayer:
             in_allow = c.tool_allow is None or value in c.tool_allow
             not_denied = value not in c.tool_deny
             return in_allow and not_denied
-        if axis is CapabilityAxis.SKILL:
-            # #2074 S3: per-context SKILL narrowing. ⊤ when unset (skill_allow=None
-            # + empty skill_deny) → byte-identical for any context that does not
-            # narrow SKILL (= every production context today).
-            in_allow = c.skill_allow is None or value in c.skill_allow
-            return in_allow and value not in c.skill_deny
         if axis is CapabilityAxis.MCP:
             # #2074 S4a: per-context MCP narrowing (paired with the require_mcp
             # gate wiring). ⊤ when unset (mcp_allow=None + empty mcp_deny) →
@@ -329,38 +308,6 @@ def tool_contextually_denied(
     if contextual is None:
         return False
     return not ContextualLayer(contextual).allows(CapabilityAxis.TOOL, effective_name)
-
-
-def skill_allowed(
-    allowed_skills: "object | None",
-    actor: str,
-    *,
-    contextual: "ContextualPermission | None" = None,
-) -> bool:
-    """The single SKILL-axis ∩ decision (#2074 S2/S3).
-
-    Routes the per-agent ``allowed_skills`` allowlist (``ProfileLayer``) AND the
-    per-session contextual narrowing (``ContextualLayer``, #2074 S3) so the
-    skill-spawn gates (skill_runner) AND the catalog filter (router host) share
-    ONE enforcement path — completing #1199's ∩ convergence for the SKILL axis.
-
-    Per-agent (``allowed_skills``) byte-identical to the legacy ``allowed_skills
-    is None or name in allowed_skills``: ``None`` = unrestricted (⊤); ``[]`` =
-    nothing allowed; ``[a,b]`` = only those. ``skill_router`` is never passed here
-    (excluded from the catalog upstream + never a spawn target), preserving its
-    exemption.
-
-    Per-context (``contextual``, #2074 S3): ``None`` or a context that does not
-    narrow SKILL (``skill_allow=None`` + empty ``skill_deny``) → ⊤, so every
-    existing outcome is preserved (the contextual SKILL narrowing is NEW
-    capability that activates only when a bound profile sets it).
-    """
-    layers: "list[LayerView]" = [
-        ProfileLayer.from_allowlists(allowed_skills=allowed_skills)
-    ]
-    if contextual is not None:
-        layers.append(ContextualLayer(contextual))
-    return EffectivePermission(layers).allows(CapabilityAxis.SKILL, actor)
 
 
 def _path_under(path_str: str, root: str) -> bool:

--- a/tests/test_1199_effective_permission.py
+++ b/tests/test_1199_effective_permission.py
@@ -67,14 +67,18 @@ def test_falsification_removing_a_layer_regrants_a_denied_capability() -> None:
     without_sandbox = EffectivePermission([AgentLayer(decl)])
     assert without_sandbox.allows(AX.NETWORK_HOST, "api.example.com") is True  # over-grant
 
-    # Same shape for a profile deny (skill allowlist):
-    prof = AgentProfile(name="a", allowed_skills=["allowed_skill"])
+    # Same shape for a profile deny (mcp allowlist):
+    # The agent declares "blocked_srv" (grants it); the profile allows only "allowed_srv".
+    # Full ∩: AgentLayer grants + ProfileLayer narrows → blocked_srv denied.
+    # Without ProfileLayer: AgentLayer grant stands → blocked_srv re-granted (over-grant).
+    prof = AgentProfile(name="a", allowed_mcp=["allowed_srv"])
+    declared_mcp = PermissionDecl(mcp=["blocked_srv", "allowed_srv"])  # agent grants both
     eff = EffectivePermission(
-        [AgentLayer(PermissionDecl()), ProfileLayer(prof.default_profile())]
+        [AgentLayer(declared_mcp), ProfileLayer(prof.default_profile())]
     )
-    assert eff.allows(AX.SKILL, "blocked_skill") is False
-    assert EffectivePermission([AgentLayer(PermissionDecl())]).allows(
-        AX.SKILL, "blocked_skill"
+    assert eff.allows(AX.MCP, "blocked_srv") is False
+    assert EffectivePermission([AgentLayer(declared_mcp)]).allows(
+        AX.MCP, "blocked_srv"
     ) is True  # remove profile layer → re-granted
 
 
@@ -107,9 +111,9 @@ def test_file_axes_are_decl_less_zone_or_approved() -> None:
 
 def test_unconstrained_axis_is_top() -> None:
     """Tier 2: a layer returns True for axes it doesn't constrain, so it never
-    narrows the ∩ on those axes (the sandbox doesn't gate skills; the profile
+    narrows the ∩ on those axes (the sandbox doesn't gate tools; the profile
     doesn't gate files)."""
-    assert SandboxLayer(SandboxPolicy()).allows(AX.SKILL, "any") is True
+    assert SandboxLayer(SandboxPolicy()).allows(AX.TOOL, "any") is True
     assert ProfileLayer(AgentProfile(name="a").default_profile()).allows(AX.FILE_WRITE, "/x") is True
     # None layers are fully ⊤.
     assert SandboxLayer(None).allows(AX.FILE_WRITE, "/anything") is True

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -78,12 +78,11 @@ async def test_bad_in_set_is_rejected_no_seam_runs(tmp_path: Path) -> None:
 # ── the real reapply seams (real minimal Session) ──────────────────────────
 
 
-def _make_session(tmp_path: Path, *, agent_name: str = "test-agent", allowed_skills=None) -> Session:
+def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     return Session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        allowed_skills=allowed_skills,
     )
 
 

--- a/tests/test_2074_s1_capability_spec_axes.py
+++ b/tests/test_2074_s1_capability_spec_axes.py
@@ -1,11 +1,8 @@
-"""Tier 1: #2074 S1 — the unified capability spec gains SKILL / MCP axes (additive, inert).
+"""Tier 1: #2074 S1 — the unified capability spec carries TOOL / MCP axes.
 
 S1 extends the capability spec (CapabilityProfile) + its resolver/compose + loader
-with the SKILL and MCP axes alongside the existing TOOL / category axes, so ONE
-spec covers all #1199 ∩ axes. It is strictly **additive and inert**: the new axes
-are carried on the resolved ContextualPermission but ``ContextualLayer`` still
-enforces only TOOL (the SKILL/MCP binding is #2074 S2/S3). So a profile that sets
-skill/mcp narrowing changes NO gate outcome yet — proven here.
+with the MCP axis alongside the existing TOOL / category axes, so ONE spec covers
+TOOL and MCP axes. The SKILL axis was removed (dead — zero live enforcement).
 
 No mocks: real CapabilityProfile / ContextualPermission / ContextualLayer + the
 pure resolver/compose/loader functions.
@@ -29,30 +26,25 @@ from reyn.security.permissions.effective import (
 AX = CapabilityAxis
 
 
-# ── resolve: the new axes flow onto the ContextualPermission ────────────────
+# ── resolve: the MCP axis flows onto the ContextualPermission ───────────────
 
 
-def test_resolve_populates_skill_and_mcp_axes() -> None:
-    """Tier 1: resolve_profile carries skill/mcp allow/deny onto the ContextualPermission."""
+def test_resolve_populates_mcp_axes() -> None:
+    """Tier 1: resolve_profile carries mcp allow/deny onto the ContextualPermission."""
     prof = CapabilityProfile(
         name="p",
-        skill_allow=("a", "b"),
-        skill_deny=("c",),
         mcp_allow=("srv1",),
         mcp_deny=("srv2",),
     )
     ctx, _excluded = resolve_profile(prof)
-    assert ctx.skill_allow == frozenset({"a", "b"})
-    assert ctx.skill_deny == frozenset({"c"})
     assert ctx.mcp_allow == frozenset({"srv1"})
     assert ctx.mcp_deny == frozenset({"srv2"})
 
 
-def test_resolve_skill_mcp_default_inert() -> None:
-    """Tier 1: a profile with no skill/mcp keys resolves to ⊤ on those axes
+def test_resolve_mcp_default_inert() -> None:
+    """Tier 1: a profile with no mcp keys resolves to ⊤ on those axes
     (allow=None, deny=∅) — the additive default narrows nothing."""
     ctx, _ = resolve_profile(CapabilityProfile(name="p", tool_deny=("t",)))
-    assert ctx.skill_allow is None and ctx.skill_deny == frozenset()
     assert ctx.mcp_allow is None and ctx.mcp_deny == frozenset()
     # the existing TOOL axis is unaffected
     assert ctx.tool_deny == frozenset({"t"})
@@ -61,42 +53,49 @@ def test_resolve_skill_mcp_default_inert() -> None:
 # ── loader: forward-compat parse of the new keys ────────────────────────────
 
 
-def test_loader_parses_skill_mcp_keys(tmp_path: Path) -> None:
-    """Tier 1: the loader parses skill_allow/skill_deny/mcp_allow/mcp_deny."""
+def test_loader_parses_mcp_keys(tmp_path: Path) -> None:
+    """Tier 1: the loader parses mcp_allow/mcp_deny."""
+    p = tmp_path / "p.yaml"
+    p.write_text(
+        "mcp_allow: [m1]\nmcp_deny: [m2]\n",
+        encoding="utf-8",
+    )
+    prof = load_capability_profile(p)
+    assert prof.mcp_allow == ("m1",)
+    assert prof.mcp_deny == ("m2",)
+
+
+def test_loader_absent_mcp_is_none_empty(tmp_path: Path) -> None:
+    """Tier 1: absent mcp keys → None/() (forward-compat; pre-#2074 yaml unaffected)."""
+    p = tmp_path / "p.yaml"
+    p.write_text("tool_deny: [foo]\n", encoding="utf-8")
+    prof = load_capability_profile(p)
+    assert prof.mcp_allow is None and prof.mcp_deny == ()
+
+
+def test_loader_ignores_skill_keys(tmp_path: Path) -> None:
+    """Tier 1: skill_allow/skill_deny in a YAML file are ignored (forward-compat
+    — the SKILL axis was removed; old files with skill keys load cleanly)."""
     p = tmp_path / "p.yaml"
     p.write_text(
         "skill_allow: [x, y]\nskill_deny: [z]\nmcp_allow: [m1]\nmcp_deny: [m2]\n",
         encoding="utf-8",
     )
     prof = load_capability_profile(p)
-    assert prof.skill_allow == ("x", "y")
-    assert prof.skill_deny == ("z",)
     assert prof.mcp_allow == ("m1",)
     assert prof.mcp_deny == ("m2",)
 
 
-def test_loader_absent_skill_mcp_is_none_empty(tmp_path: Path) -> None:
-    """Tier 1: absent skill/mcp keys → None/() (forward-compat; pre-#2074 yaml unaffected)."""
-    p = tmp_path / "p.yaml"
-    p.write_text("tool_deny: [foo]\n", encoding="utf-8")
-    prof = load_capability_profile(p)
-    assert prof.skill_allow is None and prof.skill_deny == ()
-    assert prof.mcp_allow is None and prof.mcp_deny == ()
+# ── compose: the same monotonic rule applies to MCP ────────────────────────
 
 
-# ── compose: the same monotonic rule applies to the new axes ────────────────
-
-
-def test_compose_unions_denies_and_intersects_allows_per_axis() -> None:
+def test_compose_unions_denies_and_intersects_allows_mcp() -> None:
     """Tier 1: compose_resolved applies union-of-deny + intersection-of-allow to the
-    SKILL/MCP axes, identically to TOOL (most-restrictive-wins across profiles)."""
-    a = resolve_profile(CapabilityProfile(name="a", skill_allow=("x", "y"), skill_deny=("d1",), mcp_deny=("m1",)))
-    b = resolve_profile(CapabilityProfile(name="b", skill_allow=("y", "z"), skill_deny=("d2",), mcp_deny=("m2",)))
+    MCP axis (most-restrictive-wins across profiles)."""
+    a = resolve_profile(CapabilityProfile(name="a", mcp_deny=("m1",)))
+    b = resolve_profile(CapabilityProfile(name="b", mcp_deny=("m2",)))
     composed, _excluded = compose_resolved([a, b])
-    # allow → intersection
-    assert composed.skill_allow == frozenset({"y"})
     # deny → union
-    assert composed.skill_deny == frozenset({"d1", "d2"})
     assert composed.mcp_deny == frozenset({"m1", "m2"})
     # mcp_allow: neither constrained → ⊤
     assert composed.mcp_allow is None
@@ -105,22 +104,16 @@ def test_compose_unions_denies_and_intersects_allows_per_axis() -> None:
 def test_compose_empty_is_inert() -> None:
     """Tier 1: composing nothing yields an inert all-⊤ ContextualPermission."""
     composed, excluded = compose_resolved([])
-    assert composed.skill_allow is None and composed.skill_deny == frozenset()
     assert composed.mcp_allow is None and composed.mcp_deny == frozenset()
     assert composed.tool_allow is None and composed.tool_deny == frozenset()
     assert excluded == frozenset()
 
 
-# ── INERTNESS: ContextualLayer still enforces ONLY TOOL (S1 changes no gate) ─
-
-
-# (The S1 MCP-inertness proof was removed in #2074 S4a, which wires the
-# contextual MCP axis — see test_2074_s4a_mcp_unify.py for the MCP enforcement +
-# ⊤-when-unset tests. SKILL enforcement landed in S3.)
+# ── TOOL enforcement: ContextualLayer still enforces TOOL ──────────────────
 
 
 def test_contextual_layer_still_enforces_tool() -> None:
-    """Tier 1: TOOL enforcement is unchanged by S1 (no regression on the live axis)."""
+    """Tier 1: TOOL enforcement is unchanged (no regression on the live axis)."""
     layer = ContextualLayer(ContextualPermission(tool_deny=frozenset({"danger"})))
     assert layer.allows(AX.TOOL, "danger") is False
     assert layer.allows(AX.TOOL, "safe") is True

--- a/tests/test_2074_s4a_mcp_unify.py
+++ b/tests/test_2074_s4a_mcp_unify.py
@@ -2,15 +2,15 @@
 
 S4a completes the MCP axis of the unification:
 - **MCP source migration**: the per-agent MCP allowlist moves OUT of
-  ``AgentLayer.MCP`` (now grant-only) INTO a ``ProfileLayer`` in ``require_mcp``
-  (symmetric with SKILL). Byte-identical at the gate (∩ associative) — guarded by
-  the existing require_mcp suite (test_permissions.py) + test_1199_s31b_mcp_cutover.
+  ``AgentLayer.MCP`` (now grant-only) INTO a ``ProfileLayer`` in ``require_mcp``.
+  Byte-identical at the gate (∩ associative) — guarded by the existing
+  require_mcp suite (test_permissions.py) + test_1199_s31b_mcp_cutover.
 - **per-context MCP**: ``ContextualLayer`` now enforces the MCP axis, and
   ``require_mcp`` adds it (⊤-when-unset — byte-identical for any context that does
-  not narrow MCP). Mirrors S3's SKILL.
+  not narrow MCP).
 - **identity factor**: ``AgentProfile.default_profile()`` exposes the canonical
-  unified capability spec (maps the user-facing allowed_skills/allowed_mcp onto the
-  internal skill_allow/mcp_allow; no user-facing rename).
+  unified capability spec (maps the user-facing ``allowed_mcp`` onto the internal
+  ``mcp_allow``).
 
 No mocks: real ContextualPermission / ContextualLayer / PermissionResolver (via
 the support factory) / AgentProfile / CapabilityProfile.
@@ -115,11 +115,10 @@ def test_require_mcp_contextual_does_not_regrant_allowlist(tmp_path) -> None:
 
 
 def test_default_profile_maps_allowlists_to_spec() -> None:
-    """Tier 1: default_profile() maps the user-facing allowed_skills/allowed_mcp
-    onto the unified spec's skill_allow/mcp_allow (internal representation)."""
-    prof = AgentProfile(name="a", allowed_skills=["s1", "s2"], allowed_mcp=["m1"])
+    """Tier 1: default_profile() maps the user-facing allowed_mcp onto the unified
+    spec's mcp_allow (internal representation)."""
+    prof = AgentProfile(name="a", allowed_mcp=["m1"])
     spec = prof.default_profile()
-    assert spec.skill_allow == ("s1", "s2")
     assert spec.mcp_allow == ("m1",)
     assert spec.name == "a"
 
@@ -127,7 +126,6 @@ def test_default_profile_maps_allowlists_to_spec() -> None:
 def test_default_profile_none_passthrough() -> None:
     """Tier 1: None allowlists pass through as None (= ⊤, unrestricted)."""
     spec = AgentProfile(name="a").default_profile()
-    assert spec.skill_allow is None
     assert spec.mcp_allow is None
 
 

--- a/tests/test_2074_s4b_spec_read.py
+++ b/tests/test_2074_s4b_spec_read.py
@@ -1,17 +1,12 @@
 """Tier 1: #2074 S4b — the per-agent ProfileLayer reads the unified capability spec.
 
 S4b repoints the per-agent ∩ layer to read ``AgentProfile.default_profile()`` (a
-``CapabilityProfile`` — the single unified primitive) on its ``skill_allow`` /
-``mcp_allow`` axes, instead of the extracted ``allowed_skills`` / ``allowed_mcp``
-values (or the old ``_AllowlistSource``). This completes the one-spec / two-binding
-model: BOTH binding adapters (per-agent ProfileLayer + per-context ContextualLayer)
-now read a ``CapabilityProfile``.
+``CapabilityProfile`` — the single unified primitive) on its ``mcp_allow`` axis,
+instead of the extracted ``allowed_mcp`` values.
 
-**Byte-identical**: ``default_profile().skill_allow == allowed_skills`` (same
+**Byte-identical**: ``default_profile().mcp_allow == allowed_mcp`` (same
 values), so the read-source rewiring changes no outcome — proven by the
-extracted-vs-spec identity below. The falsify is the spec-read itself: breaking
-``ProfileLayer.allows`` (the spec membership) turns the per-agent SKILL/MCP gates
-RED (the existing S2/S4a site + gate oracles).
+extracted-vs-spec identity below.
 
 No mocks: real CapabilityProfile / AgentProfile / ProfileLayer.
 """
@@ -26,18 +21,7 @@ from reyn.security.permissions.effective import CapabilityAxis, ProfileLayer
 AX = CapabilityAxis
 
 
-# ── ProfileLayer reads the spec's skill_allow / mcp_allow ───────────────────
-
-
-def test_profile_layer_reads_spec_skill_axis() -> None:
-    """Tier 1: ProfileLayer reads CapabilityProfile.skill_allow (None = ⊤)."""
-    layer = ProfileLayer(CapabilityProfile(name="p", skill_allow=("a",)))
-    assert layer.allows(AX.SKILL, "a") is True
-    assert layer.allows(AX.SKILL, "b") is False
-    # skill_allow None → unrestricted
-    assert ProfileLayer(CapabilityProfile(name="p")).allows(AX.SKILL, "anything") is True
-    # None spec → ⊤
-    assert ProfileLayer(None).allows(AX.SKILL, "anything") is True
+# ── ProfileLayer reads the spec's mcp_allow ─────────────────────────────────
 
 
 def test_profile_layer_reads_spec_mcp_axis() -> None:
@@ -53,29 +37,14 @@ def test_profile_layer_reads_spec_mcp_axis() -> None:
 
 def test_default_profile_feeds_profile_layer() -> None:
     """Tier 1: ProfileLayer(agent.default_profile()) enforces the agent's
-    allowed_skills/allowed_mcp via the spec's skill_allow/mcp_allow."""
-    agent = AgentProfile(name="a", allowed_skills=["s1"], allowed_mcp=["m1"])
+    allowed_mcp via the spec's mcp_allow."""
+    agent = AgentProfile(name="a", allowed_mcp=["m1"])
     layer = ProfileLayer(agent.default_profile())
-    assert layer.allows(AX.SKILL, "s1") is True
-    assert layer.allows(AX.SKILL, "s2") is False
     assert layer.allows(AX.MCP, "m1") is True
     assert layer.allows(AX.MCP, "m2") is False
 
 
 # ── the read-source rewiring identity (the S4b falsify oracle) ──────────────
-
-
-@pytest.mark.parametrize("allowed", [None, [], ["a"], ["a", "b"]])
-@pytest.mark.parametrize("name", ["a", "b", "z"])
-def test_spec_read_matches_extracted_skill(allowed, name) -> None:
-    """Tier 1: reading the spec (default_profile().skill_allow) is byte-identical to
-    the extracted-allowlist read (from_allowlists) on SKILL — so S4b's layer
-    rewiring is byte-identical. Breaking ProfileLayer's spec-read flips BOTH."""
-    via_spec = ProfileLayer(
-        AgentProfile(name="_", allowed_skills=allowed).default_profile()
-    ).allows(AX.SKILL, name)
-    via_extracted = ProfileLayer.from_allowlists(allowed_skills=allowed).allows(AX.SKILL, name)
-    assert via_spec is via_extracted
 
 
 @pytest.mark.parametrize("allowed", [None, [], ["m1"], ["m1", "m2"]])

--- a/tests/test_skill_axis_removal_falsify.py
+++ b/tests/test_skill_axis_removal_falsify.py
@@ -1,0 +1,83 @@
+"""Tier 2: falsify test — SKILL axis removal is enforcement-safe.
+
+Proves that:
+(a) Loading a capability profile with ONLY ``tool_deny`` + ``mcp_deny`` (no
+    skill keys) does not crash the loader or resolver.
+(b) TOOL enforcement still blocks denied tools after the SKILL axis removal.
+(c) MCP enforcement still blocks denied servers after the SKILL axis removal.
+
+This test goes RED if TOOL or MCP enforcement breaks — proving the removal is
+safe and the live enforcement axes are intact.
+
+No mocks: real CapabilityProfile / ContextualPermission / ContextualLayer /
+load_capability_profile / resolve_profile.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.security.permissions.capability_profile import (
+    CapabilityProfile,
+    load_capability_profile,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import (
+    CapabilityAxis,
+    ContextualLayer,
+)
+
+AX = CapabilityAxis
+
+
+def test_loader_no_skill_keys_clean(tmp_path: Path) -> None:
+    """Tier 2: a profile YAML with only tool_deny + mcp_deny (no skill keys) loads
+    cleanly — the loader does not crash without skill keys."""
+    p = tmp_path / "no_skill.yaml"
+    p.write_text("tool_deny: [danger]\nmcp_deny: [bad-srv]\n", encoding="utf-8")
+    prof = load_capability_profile(p)
+    assert prof.tool_deny == ("danger",)
+    assert prof.mcp_deny == ("bad-srv",)
+
+
+def test_resolver_no_skill_keys_clean() -> None:
+    """Tier 2: resolve_profile on a profile with no skill keys succeeds and
+    produces a ContextualPermission with the TOOL/MCP axes populated."""
+    prof = CapabilityProfile(name="t", tool_deny=("danger",), mcp_deny=("bad-srv",))
+    ctx, excluded = resolve_profile(prof)
+    assert "danger" in ctx.tool_deny
+    assert "bad-srv" in ctx.mcp_deny
+    assert excluded == frozenset()
+
+
+def test_tool_axis_still_blocks_denied_tool() -> None:
+    """Tier 2: ContextualLayer BLOCKS a tool on the TOOL axis after SKILL removal —
+    the live enforcement axis is intact."""
+    prof = CapabilityProfile(name="t", tool_deny=("danger",))
+    ctx, _ = resolve_profile(prof)
+    layer = ContextualLayer(ctx)
+    assert layer.allows(AX.TOOL, "danger") is False, "denied tool must be blocked"
+    assert layer.allows(AX.TOOL, "safe") is True, "non-denied tool must pass"
+
+
+def test_mcp_axis_still_blocks_denied_server() -> None:
+    """Tier 2: ContextualLayer BLOCKS an MCP server on the MCP axis after SKILL
+    removal — the live enforcement axis is intact."""
+    prof = CapabilityProfile(name="t", mcp_deny=("bad-srv",))
+    ctx, _ = resolve_profile(prof)
+    layer = ContextualLayer(ctx)
+    assert layer.allows(AX.MCP, "bad-srv") is False, "denied mcp server must be blocked"
+    assert layer.allows(AX.MCP, "ok-srv") is True, "non-denied server must pass"
+
+
+def test_combined_profile_tool_and_mcp_enforce() -> None:
+    """Tier 2: a profile with ONLY tool_deny + mcp_deny (no skill keys) —
+    both axes enforce correctly (the enforcement-safe removal claim)."""
+    prof = CapabilityProfile(name="t", tool_deny=("danger",), mcp_deny=("bad-srv",))
+    ctx, _ = resolve_profile(prof)
+    layer = ContextualLayer(ctx)
+    # TOOL axis
+    assert layer.allows(AX.TOOL, "danger") is False
+    assert layer.allows(AX.TOOL, "safe") is True
+    # MCP axis
+    assert layer.allows(AX.MCP, "bad-srv") is False
+    assert layer.allows(AX.MCP, "ok-srv") is True

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -169,21 +169,19 @@ async def test_agent_edit_role_persists_to_profile_and_session(tmp_path):
 
 @pytest.mark.asyncio
 async def test_agent_edit_role_preserves_other_profile_fields(tmp_path):
-    """Tier 2: role edit MUST NOT clobber name / created_at / allowed_skills /
-    allowed_mcp."""
+    """Tier 2: role edit MUST NOT clobber name / created_at / allowed_mcp."""
     from reyn.interfaces.slash.agent import _edit_role
     from reyn.runtime.profile import PROFILE_FILENAME, AgentProfile
 
     registry = _build_real_registry(tmp_path)
     registry.create("delta", role="initial")
-    # Hand-write an allowed_skills + allowed_mcp config the create() flow
-    # doesn't set, to verify the edit doesn't drop them.
+    # Hand-write an allowed_mcp config the create() flow doesn't set,
+    # to verify the edit doesn't drop it.
     agent_dir = tmp_path / ".reyn" / "agents" / "delta"
     profile = AgentProfile.load(agent_dir)
     from dataclasses import replace
     enriched = replace(
         profile,
-        allowed_skills=["skill_a", "skill_b"],
         allowed_mcp=["mcp_x"],
     )
     enriched.save(agent_dir)
@@ -196,7 +194,6 @@ async def test_agent_edit_role_preserves_other_profile_fields(tmp_path):
     assert reloaded.role == "edited persona"
     assert reloaded.name == "delta"
     assert reloaded.created_at == original_created_at
-    assert reloaded.allowed_skills == ["skill_a", "skill_b"]
     assert reloaded.allowed_mcp == ["mcp_x"]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — part of the skill-deletion arc (#2104).

## Summary

- Removes the dead SKILL capability axis (`skill_allow`/`skill_deny`) from `CapabilityProfile`, `ContextualPermission`, `ProfileLayer`, and `ContextualLayer`.
- Removes `CapabilityAxis.SKILL` enum member (zero live refs after cleanup).
- Removes `skill_allowed()` function (zero callers).
- Removes `allowed_skills` from `AgentProfile`, `Session.__init__`, and all carry-sites (interfaces, registry, scripts, manifest YAML, CLI agent show command).
- TOOL and MCP axes are fully preserved and still enforce.
- Adds falsify test `test_skill_axis_removal_falsify.py` (Tier 2): loads a profile with ONLY `tool_deny`+`mcp_deny`, no skill keys — asserts clean load + that TOOL and MCP blocking still works. This test goes RED if TOOL/MCP enforcement breaks.

## Pre-flight dead-symbol verification
Each removed symbol was grepped for live (non-test) callers before removal — none found.

## Changed files
- `src/reyn/runtime/profile.py` — removed `allowed_skills` field, load/save blocks, `skill_allow=` in `default_profile()`
- `src/reyn/security/permissions/capability_profile.py` — removed `skill_allow`/`skill_deny` from `CapabilityProfile`, loader, `resolve_profile()`, `compose_resolved()`
- `src/reyn/security/permissions/effective.py` — removed `CapabilityAxis.SKILL`, `ContextualPermission.skill_allow/skill_deny`, SKILL branches from `ProfileLayer.allows()` and `ContextualLayer.allows()`, `ProfileLayer.from_allowlists(allowed_skills=...)`, `skill_allowed()` function
- `src/reyn/runtime/session.py` — removed `allowed_skills` param from `__init__`, `_allowed_skills` assignment, SKILL writes from `_reapply_per_agent_capability`
- `src/reyn/interfaces/chainlit_app/app.py` — removed `allowed_skills=profile.allowed_skills`
- `src/reyn/interfaces/cli/commands/agent.py` — removed `allowed_skills` display block from `_cmd_show`
- `src/reyn/interfaces/cli/commands/chat.py` — removed `allowed_skills=profile.allowed_skills`
- `src/reyn/interfaces/cli/commands/dogfood.py` — removed `allowed_skills=profile.allowed_skills`
- `src/reyn/interfaces/cli/commands/mcp.py` — removed `allowed_skills=profile.allowed_skills`
- `src/reyn/interfaces/web/deps.py` — removed `allowed_skills=profile.allowed_skills`
- `src/reyn/interfaces/web/routers/agents.py` — removed `allowed_skills` from `AgentSummary`/`CreateAgentRequest` + routes
- `src/reyn/interfaces/web/routers/web_data.py` — removed `"allowed_skills": []`
- `src/reyn/runtime/registry.py` — removed `allowed_skills` from identity payload and reconstruct call
- `scripts/df2187_harness.py` — removed `allowed_skills=profile.allowed_skills`
- `docs/deep-dives/spec/openui/schemas/reyn-ui-v1/manifest.yaml` — removed `allowed_skills?: string[]`
- `tests/test_2074_s1_capability_spec_axes.py` — rewrote SKILL-axis tests to MCP-only, added forward-compat test (skill keys in YAML ignored)
- `tests/test_2074_s4b_spec_read.py` — removed SKILL axis tests, kept MCP
- `tests/test_2074_s4a_mcp_unify.py` — removed `allowed_skills`/`skill_allow` assertions
- `tests/test_1199_effective_permission.py` — replaced SKILL falsification with MCP equivalent, replaced `AX.SKILL` with `AX.TOOL` in unconstrained axis test
- `tests/test_2073_s2_reapply_seams.py` — removed `allowed_skills` param from `_make_session`
- `tests/test_slash_agent.py` — removed `allowed_skills` from profile-fields preservation test
- `tests/test_skill_axis_removal_falsify.py` — NEW: Tier 2 falsify test (see Summary)

## Test plan
- [x] Falsify test passes (GREEN = TOOL/MCP enforce, loader doesn't crash without skill keys)
- [x] `ruff check src tests` passes
- [x] `pytest` passes (full suite — pre-existing fastapi/mcp module failures unrelated to this change)
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` passes (47 tests OK)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` passes