### PR TITLE
refactor(skill-word): sweep batch A — op_runtime/core stale skill comments

### DIFF
--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -1,4 +1,4 @@
-"""Shared dispatch layer for chat router and skill phase tool invocations.
+"""Shared dispatch layer for chat router and op-loop tool invocations.
 
 Wraps any tool invocation with cross-cutting concerns:
   - name validation (against caller's tool catalog)
@@ -32,7 +32,7 @@ class DispatchContext:
 
     Attributes:
         caller_kind: "router" for chat agent main loop, "skill_phase" for
-            skills' op execution. Used in event taxonomy for filtering.
+            op-loop execution. Used in event taxonomy for filtering.
         caller_id: agent_name (router) or f"{actor}.{phase_name}"
             (skill_phase). Identifies the audit subject.
         chain_id: optional chain id for multi-hop tracing (PR14).
@@ -174,7 +174,7 @@ def _compute_args_hash(args: dict) -> str:
     SHA-256 of canonical JSON; safe across Python runs (unlike Python's
     builtin hash() which is randomized).  First 16 hex chars are kept
     (64 bits) — collision risk is acceptable for resume memoization
-    within a single skill run.
+    within a single run.
     """
     import hashlib
     import json
@@ -195,7 +195,7 @@ _LLM_VOLATILE_FRAME_FIELDS: frozenset[str] = frozenset({"current_datetime"})
 # runtime restores ``_history`` from ``snap.history`` on resume — but
 # ``snap.history`` records phase names while normal operation appends
 # transition strings ("draft → review"). The two formats can't be reconciled
-# without a SkillSnapshot schema extension; until R-D11 lands a proper
+# without a snapshot schema extension; until R-D11 lands a proper
 # ``transition_history`` field, ``execution.path`` is treated as informational
 # (it shows in the LLM context but does not affect memo determinism).
 _LLM_VOLATILE_NESTED_FIELDS: frozenset[str] = frozenset({"execution.path"})
@@ -260,11 +260,11 @@ def _compute_llm_args_hash(
 # denied and HOW to allow it without leaving the chat to read source.
 #
 # Names cover both router-tool catalog entries (read_file, web_fetch, …)
-# and skill_phase op kinds (file, shell, web_fetch, …). Unmapped names
+# and op-loop op kinds (file, shell, web_fetch, …). Unmapped names
 # fall back to a generic "see logs / events tab" suffix — better than
 # fabricating a config key the user can't actually find.
 _PERMISSION_CONFIG_HINTS: dict[str, str] = {
-    # File ops — router catalog + skill_phase "file" op kind.
+    # File ops — router catalog + op-loop "file" op kind.
     "file": "permissions.file.read / file.write: allow",
     "read_file": "permissions.file.read: allow",
     "write_file": "permissions.file.write: allow",

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -1,7 +1,7 @@
 """OpContext — execution environment for op handlers.
 
 Bundles the dependencies an op needs from the surrounding frontend
-(workspace, events, permissions, sub-skill resolution helpers) so the
+(workspace, events, permissions, resolver, and sub-run helpers) so the
 handler signatures stay flat. Frontends construct an OpContext once
 and reuse it for the whole phase or act loop.
 """
@@ -45,9 +45,9 @@ class OpContext:
     subscribers: list = field(default_factory=list)
     output_language: str | None = None
 
-    # run_skill state_dir layout strategy
-    # When set, run_skill uses this path verbatim. When None, the handler
-    # computes a layout based on `state_dir_strategy`.
+    # Sub-run state_dir layout strategy.
+    # When set, the sub-run handler uses this path verbatim. When None, the
+    # handler computes a layout based on `state_dir_strategy`.
     sub_state_dir_override: str | None = None
     state_dir_strategy: str = "control_ir"  # "control_ir" or "preprocessor"
     # Used when state_dir_strategy=="preprocessor"
@@ -86,19 +86,18 @@ class OpContext:
     # (control_ir_executor / router_host_adapter); None = unrecorded.
     budget_tracker: object | None = None
 
-    # PR20: caller provenance threaded from the parent Agent so sub-skill
+    # PR20: caller provenance threaded from the parent Agent so sub-run
     # invocations land under the same `events/<caller>/skill_runs/...` tree.
     # Format: "direct" or "agents/<name>" (validated in Agent).
     caller: str = "direct"
 
-    # R-D13: nested skill lineage. The currently-running runtime sets
+    # R-D13: nested run lineage. The currently-running runtime sets
     # this to its own ``run_id`` when constructing OpContext for control
-    # IR execution. ``run_skill`` handlers propagate it to the spawned
-    # child run as ``parent_run_id``, so the per-skill snapshot tree
-    # records the parent / child relationship for ``/skill list``,
-    # debug logs, and future cascade-discard semantics. ``None`` means
-    # "no parent visible" (e.g. preprocessor-spawned sub-skills, or
-    # runtime invocations that don't track a run_id).
+    # IR execution. Sub-run handlers propagate it to the spawned
+    # child run as ``parent_run_id``, so the snapshot tree records the
+    # parent / child relationship for debug logs and future cascade-discard
+    # semantics. ``None`` means "no parent visible" (e.g. preprocessor-spawned
+    # sub-runs, or runtime invocations that don't track a run_id).
     parent_run_id: str | None = None
 
     # FP-0021: the run_id of the currently-executing run.
@@ -111,7 +110,7 @@ class OpContext:
     # #2259 PR-1: the process-shared WAL, threaded so a recovery-core config op
     # (mcp_install / mcp_drop / index_drop) can record a config GENERATION (keyed by the
     # WAL head) after persisting its `.yaml` — making the yaml a derived projection of the
-    # generation truth. None outside a persistence-enabled chat/skill context (tests /
+    # generation truth. None outside a persistence-enabled chat context (tests /
     # non-chat) → the op skips it (the opt-in contract, same as the step-event gate).
     state_log: "StateLog | None" = None
 
@@ -170,11 +169,10 @@ class OpContext:
     # direct-OpContext tests).
     media_store: "MediaStore | None" = None
 
-    # FP-0016 D: per-skill credential scoping. None = unrestricted (= today's
-    # behaviour; preserves backward compat for top-level / chat-router /
-    # CLI-direct OpContext construction). The run_skill handler constructs a
-    # ScopedSecretStore based on the sub-skill's required_credentials and
-    # passes it down through Agent → the ctx-build seams → OpContext.
+    # FP-0016 D: per-run credential scoping. None = unrestricted (= preserves
+    # backward compat for top-level / chat-router / CLI-direct OpContext
+    # construction). When set, restricts secret access to the declared
+    # required_credentials and is passed through Agent → the ctx-build seams.
     secret_store: "ScopedSecretStore | None" = None
 
     # #1470: per-turn asyncio.Event fired by cancel_inflight(). When set,

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -3,7 +3,7 @@
 Destructive op: drops the SQLite backend + removes the SourceManifest entry.
 
 Permission gate: mirrors require_mcp_install pattern (ADR-0029).
-  - Skill must declare `permissions.index_drop: true`.
+  - Caller must declare `permissions.index_drop: true`.
   - Config may hard-allow or hard-deny (permissions.index_drop: allow/deny).
   - Interactive prompt or REYN_INDEX_DROP_AUTO_APPROVE=1 CI escape hatch.
 
@@ -43,7 +43,7 @@ async def handle(
 
     workspace_root = ctx.workspace.base_dir
 
-    # Permission gate (#571 collapse arc Phase 5): the skill must
+    # Permission gate (#571 collapse arc Phase 5): the caller must
     # declare ``file.write: [.reyn/config/index/sources.yaml]``. The
     # bool-axis ``require_index_drop`` per-source prompt is removed;
     # per-source granularity is not preserved (= drop is destructive

--- a/src/reyn/core/op_runtime/judge_output.py
+++ b/src/reyn/core/op_runtime/judge_output.py
@@ -11,7 +11,7 @@ The OS:
 P3: OS does target resolution + LLM call + score parse only; rubric content
     is never interpreted by the OS.
 P6: `tool_executed` event is emitted unconditionally.
-P7: rubric content and `on_fail` vocabulary are kept skill-agnostic.
+P7: rubric content and `on_fail` vocabulary are kept OS-agnostic (no domain concepts).
 """
 from __future__ import annotations
 
@@ -73,8 +73,8 @@ async def handle(
     """
     # ── 1. Resolve target value from artifact ────────────────────────────────
     # Build resolution context: {"artifact": <latest_stored_artifact>}.
-    # Skills store their working artifact via workspace.store_artifact; we read
-    # the most recent entry so "artifact.data.summary" resolves against it.
+    # The workspace stores the working artifact via workspace.store_artifact; we
+    # read the most recent entry so "artifact.data.summary" resolves against it.
     # When no artifact has been stored yet, resolution falls back to an empty
     # dict, which will raise KeyError for any non-trivial target.
     latest: dict[str, Any] = {}
@@ -101,9 +101,9 @@ async def handle(
         }
 
     # ── 2. Resolve model string ───────────────────────────────────────────────
-    # op.model is a class-typed (skill-supplied) field → closed-world gate
-    # (#1454 PR-B): a non-class value falls back to the runtime model rather
-    # than passing through as a literal LiteLLM string that bypasses the proxy.
+    # op.model is a class-typed field → closed-world gate (#1454 PR-B): a
+    # non-class value falls back to the runtime model rather than passing
+    # through as a literal LiteLLM string that bypasses the proxy.
     if ctx.resolver is not None:
         # #1672: op.model (explicit) wins, then the runtime ctx.model, then the
         # configured "judge" purpose class (was an implicit "standard" tier) — so an

--- a/src/reyn/core/op_runtime/registry.py
+++ b/src/reyn/core/op_runtime/registry.py
@@ -24,7 +24,7 @@ is KEPT — fine handlers still build ``FileIROp(kind="file")`` internally.
 Helper:
   - ``is_op_allowed(op_kind, allowed_ops)`` — prefix-wildcard membership
     check (= ADR-0026 Phase 4-2c).  ``COARSE_TO_FINE`` covers ``mcp``
-    and ``run_skill`` coarse→fine mappings (prefix-wildcard).
+    and ``task`` coarse→fine mappings (prefix-wildcard).
 
 Consumers:
   - ``reyn.core.compiler.linter``     — ``ALL_OP_KINDS``
@@ -57,20 +57,18 @@ from reyn.schemas.models import ALL_OP_KINDS
 # ---------------------------------------------------------------------------
 # Coarse → fine prefix-wildcard mapping (ADR-0026 Phase 4)
 # ---------------------------------------------------------------------------
-# Skill frontmatter conventionally declares ``allowed_ops: [file]`` — a
-# coarse name that originally matched ``op.kind == "file"`` 1:1.  As
-# router-side fine-grained names (= read_file / write_file / etc.) become
-# canonical phase-side too, the coarse declaration must continue to match
-# the fine-grained ops by prefix wildcard.  ``is_op_allowed`` consults
-# this map to keep existing skills working without frontmatter migration.
+# A caller may declare ``allowed_ops: [mcp]`` or ``allowed_ops: [task]`` —
+# coarse names that expand to a frozenset of fine-grained op kinds.
+# ``is_op_allowed`` consults this map so callers don't have to enumerate
+# every fine kind when a whole family is intended.
 # ---------------------------------------------------------------------------
 
 COARSE_TO_FINE: dict[str, frozenset[str]] = {
-    # #1240 Wave 2b: "file" entry removed — coarse kind dropped. Skills that
+    # #1240 Wave 2b: "file" entry removed — coarse kind dropped. Callers that
     # still declare allowed_ops: [file] will fail linting (ALL_OP_KINDS no
     # longer includes "file") and should migrate to fine kinds.
     "mcp":       frozenset({"call_mcp_tool", "list_mcp_servers", "list_mcp_tools"}),
-    # #1953 slice 1: coarse "task" → all task.* fine kinds, so a skill can
+    # #1953 slice 1: coarse "task" → all task.* fine kinds, so a caller can
     # declare allowed_ops: [task] to permit the whole Task op family.
     "task": frozenset({
         "task.create", "task.update_status", "task.get", "task.list",
@@ -86,17 +84,13 @@ def is_op_allowed(op_kind: str, allowed_ops: set[str] | frozenset[str]) -> bool:
 
     Membership rules (= ADR-0026 Phase 4):
 
-    1. **Direct match** — ``op_kind in allowed_ops`` (= the legacy 1:1
-       semantics that all existing skill frontmatter relies on).
+    1. **Direct match** — ``op_kind in allowed_ops`` (exact kind name).
     2. **Prefix-wildcard** — when ``allowed_ops`` contains a coarse name
-       (e.g. ``"file"``) and ``op_kind`` is a fine-grained name covered
-       by that coarse (e.g. ``"read_file"``), the op is allowed.
+       (e.g. ``"mcp"``) and ``op_kind`` is a fine-grained name covered
+       by that coarse (e.g. ``"call_mcp_tool"``), the op is allowed.
 
-    This forward-looking helper keeps existing ``allowed_ops: [file]``
-    declarations working as Control IR migrates to fine-grained kinds in
-    later phases.  Today (post Phase 4-2a) phase Control IR still emits
-    coarse ``op.kind`` values, so rule 2 is exercised only by tests and
-    by future migrations.
+    Rule 2 lets callers declare a whole op family (``allowed_ops: [mcp]``,
+    ``allowed_ops: [task]``) without enumerating every fine kind.
     """
     if op_kind in allowed_ops:
         return True


### PR DESCRIPTION
**[lead-sonnet]** —

Comment and docstring-only cleanup across 5 files in `op_runtime/` and `core/dispatch/`. Zero code, signature, or logic changes.

## What changed

Removed or reworded comments/docstrings that referenced the deleted skill machinery:

- **context.py**: module docstring ("sub-skill resolution helpers" → "sub-run helpers"); `sub_state_dir_override` block ("run_skill state_dir layout" → "Sub-run state_dir layout"); `caller` / `parent_run_id` block ("nested skill lineage" / "run_skill handlers" → "nested run lineage" / "sub-run handlers"); `state_log` ("chat/skill context" → "chat context"); `secret_store` ("per-skill credential scoping" / "run_skill handler" → "per-run credential scoping").
- **registry.py**: module docstring COARSE_TO_FINE entry ("run_skill coarse→fine" → "task coarse→fine"); block comment above `COARSE_TO_FINE` ("Skill frontmatter conventionally declares" → "A caller may declare"); inline comments ("Skills that still declare" → "Callers that still declare"; "so a skill can" → "so a caller can"); `is_op_allowed` docstring (removed stale "skill frontmatter relies on" / "existing skills" framing).
- **index_drop.py**: module docstring permission gate ("Skill must declare" → "Caller must declare"); inline permission gate comment ("the skill must declare" → "the caller must declare").
- **judge_output.py**: P7 line ("kept skill-agnostic" → "kept OS-agnostic (no domain concepts)"); artifact comment ("Skills store their working artifact" → "The workspace stores the working artifact"); op.model comment ("skill-supplied field" → removed skill-framing).
- **dispatcher.py**: module docstring ("skill phase tool invocations" → "op-loop tool invocations"); `DispatchContext.caller_kind` docstring ("skills' op execution" → "op-loop execution"); `_compute_args_hash` ("within a single skill run" → "within a single run"); `_LLM_VOLATILE_NESTED_FIELDS` comment ("SkillSnapshot schema extension" → "snapshot schema extension"); `_PERMISSION_CONFIG_HINTS` block comment ("skill_phase op kinds" × 2 → "op-loop op kinds").

## KEEP: left untouched
- `caller_kind: Literal["router","skill_phase"]` in `DispatchContext` — Literal value preserved as instructed.
- `skill_run` / `skill_runs` WAL/events references — not touched (live WAL tree).
- `run_skill` references in events.py, tools/, config/root.py — outside scope of this sweep.

## CI gates
- `ruff check src tests` — passed
- `python scripts/verify_module_docstrings.py <5 files>` — passed
- `pytest` — 6608 passed; pre-existing failures in web/MCP infra confirmed unchanged by running on main before changes.

part of #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)