### PR TITLE
docs: correct events.md envelope example to match actual Event schema (#2521 follow-up)

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -14,11 +14,12 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 
 ```json
 {
-  "ts": "2026-04-30T10:00:00.123Z",
-  "kind": "<event_kind>",
-  "phase": "<current_phase>",
-  "run_id": "<uuid>",
-  ... // kind 固有のペイロード
+  "type": "<event_kind>",
+  "timestamp": "2026-04-30T10:00:00.123456+00:00",
+  "data": {
+    ... // kind 固有のペイロード。発行元の EventLog が設定されていれば
+        // agent_id / run_id を含むことがある(下記参照)
+  }
 }
 ```
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -14,11 +14,12 @@ Every event has:
 
 ```json
 {
-  "ts": "2026-04-30T10:00:00.123Z",
-  "kind": "<event_kind>",
-  "phase": "<current_phase>",
-  "run_id": "<uuid>",
-  ... // kind-specific payload
+  "type": "<event_kind>",
+  "timestamp": "2026-04-30T10:00:00.123456+00:00",
+  "data": {
+    ... // kind-specific payload; may include agent_id / run_id when the
+        // emitting EventLog was configured with them (see below)
+  }
 }
 ```
 


### PR DESCRIPTION
**[docs-maintainer]** — PR② of 2 (envelope-schema correction, split from PR① dead-kind removal per lead-coder direction: https://github.com/tya5/reyn/pull/2525).

## The bug
`events.md`'s "Event envelope" example showed:
```json
{"ts": "...", "kind": "<event_kind>", "phase": "...", "run_id": "...", ...payload}
```
This doesn't match the actual on-disk format at all.

## Verified against 3 independent sites in `src/`
- `src/reyn/schemas/models.py:571` — `Event` model has exactly `type` / `timestamp` / `data` fields, nothing else at the top level.
- `src/reyn/core/events/event_store.py:59` — writes `event.model_dump(mode="json")` straight to the JSONL file, no reshaping in between.
- `src/reyn/interfaces/cli/commands/events.py:115` — the `reyn events` replay reader itself does `raw.get("type", "")`, not `"kind"`.

## Fix
Corrected the example in `events.md`/`.ja.md` to:
```json
{"type": "<event_kind>", "timestamp": "2026-04-30T10:00:00.123456+00:00", "data": {...}}
```
`agent_id`/`run_id` (when the emitting `EventLog` is configured with them) live inside `data`, not at the top level — per `EventLog.emit()`'s merge logic (`data = {**data, "agent_id": self._agent_id}`).

## False positive ruled out
`docs/reference/config/budget.md`/`.ja.md` were flagged in the original discovery as possibly affected by the same `"ts"`/`"kind"` pattern, but on inspection this is a **different, independently-formatted file** — `.reyn/state/budget_ledger.jsonl` genuinely uses `"ts"` as its real field name (confirmed at `src/reyn/runtime/budget/budget.py:180`, which literally writes `"ts": self._now_iso()`). Not part of the P6 event envelope at all. No change needed there.

Table column headers throughout `events.md` ("Kind" as a human-readable label for "the kind of event") are left as-is — that's prose labeling, not a claim about the literal JSON field name, so no rename needed.

## CI gates (local)
- `ruff check src tests` — pass
- `pytest tests/test_fp0036_coverage.py` — 23/23 pass
- `mkdocs build --strict` (from `.mkdocs/`) — exit 0, no warnings

## Note on merge order
This branches from `main` before PR① (#2525) merges — both touch `events.md`/`.ja.md` but in non-overlapping sections (PR① removes dead table rows; PR② only touches the envelope example near the top of the file). Happy to rebase after PR① lands if needed.

## Test plan
- [x] `mkdocs build --strict` exit 0
- [x] fp0036 mirror tests green (23/23)
- [x] ruff clean
- [x] confirmed `budget.md`/`.ja.md`'s similar-looking `"ts"`/`"kind"` strings are an unrelated, correctly-documented ledger format — no change needed