### PR TITLE
refactor(skill-word): sweep batch E — config/security stale skill comments

### DIFF
--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -1,4 +1,4 @@
-"""reyn.config.embedding — embedding + retrieval config: Embedding/SkillSearch/ActionRetrieval. (#1682 #3 split)."""
+"""reyn.config.embedding — embedding + retrieval config: Embedding/ActionRetrieval. (#1682 #3 split)."""
 from __future__ import annotations
 
 import socket

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -489,8 +489,8 @@ class CronJobConfig:
     ``message`` (free-form text). Cron dispatches the message to the target
     agent's inbox with a ``sender="cron:<name>"`` envelope.
 
-    (A bare ``skill`` name is not a valid job shape; an entry without
-    ``to`` + ``message`` is rejected at load with a ValueError naming it.)
+    (A bare name without ``to`` + ``message`` is not a valid job shape;
+    an entry missing those fields is rejected at load with a ValueError naming it.)
     """
 
     name: str
@@ -532,7 +532,7 @@ def _build_cron_config(raw: object) -> CronConfig:
     Validates ``name`` + ``schedule`` are non-empty strings + ``to`` +
     ``message`` are set per entry, raising ``ValueError`` naming the
     offending entry on failure. An entry without the ``to`` + ``message``
-    shape (e.g. a legacy bare ``skill`` name) is rejected with that
+    shape (entry missing ``to`` + ``message``) is rejected with that
     ValueError. Unknown extra fields are ignored (= forward-compatible).
     """
     if raw is None:
@@ -561,8 +561,7 @@ def _build_cron_config(raw: object) -> CronConfig:
                 f"(got {schedule!r})"
             )
         # FP-0041 #489 PR-B: a job must be message-based (to + message). An
-        # entry lacking that shape (e.g. a legacy bare ``skill`` name) is
-        # rejected below.
+        # entry lacking that shape is rejected below.
         to = entry.get("to")
         message = entry.get("message")
         has_message_shape = (

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -120,9 +120,9 @@ class ReynConfig:
     tool_calls_op_loop_skills: list[str] = field(
         default_factory=list,
         metadata={"desc": (
-            "TRANSITIONAL: skill names opted into the native-tools op-loop — the "
+            "TRANSITIONAL: names opted into the native-tools op-loop — the "
             "phase act-loop drives the shared RouterLoop.run_loop (the converged "
-            "op-loop, #1092). Skills not listed use the default json-mode execution "
+            "op-loop, #1092). Names not listed use the default json-mode execution "
             "path, unchanged. Removed once the op-loop becomes the default. (#1092 "
             "PR-C-3 merged the former separate routerloop_convergence_skills gate "
             "into this one — the converged path is now the op-loop's implementation.)"
@@ -262,7 +262,7 @@ class ReynConfig:
     action_retrieval: "ActionRetrievalConfig" = field(
         default_factory=lambda: ActionRetrievalConfig(),
     )
-    # FP-0009 Component B — cron-driven scheduled skill execution.
+    # FP-0009 Component B — cron-driven scheduled message dispatch.
     # Empty by default; operator declares jobs in reyn.yaml ``cron.jobs``.
     cron: CronConfig = field(default_factory=CronConfig)
     # FP-0041 #489 PR-D2 — external chat transport routing (= Slack /

--- a/src/reyn/data/memory/memory.py
+++ b/src/reyn/data/memory/memory.py
@@ -1,6 +1,6 @@
 """Memory store helpers — frontmatter-aware reader, indexer, and resolver.
 
-This module centralizes the on-disk format used by `skill_router` (which
+This module centralizes the on-disk format used by the chat router (which
 writes memories inline as it routes) and the `reyn memory` CLI:
 
   <memory_dir>/

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -53,7 +53,7 @@ class ModelSpec:
     kwargs: dict[str, Any] = field(default_factory=dict)
     # #309 per-class routing (multi-provider). Explicit routing fields (NOT in
     # ``kwargs``) so a class can target its own endpoint/provider while others
-    # use the global default — e.g. router=light on a Gemini proxy + skill=
+    # use the global default — e.g. router=light on a Gemini proxy + strong=
     # capable on Anthropic-direct, simultaneously. Mirrors EmbeddingClassSpec
     # (which carries ``api_base``); ``provider`` is added for the direct-vs-proxy
     # opt-out. NO per-class api_key field by design: a literal secret must never
@@ -348,18 +348,18 @@ class ModelResolver:
     def resolve_class_or_fallback(
         self, requested: str | None, fallback: str | None, *, where: str = "",
     ) -> str:
-        """Resolve a CLASS-TYPED model selection (op/skill-supplied) closed-world.
+        """Resolve a CLASS-TYPED model selection (op- or phase-supplied) closed-world.
 
         #1454 PR-B (the unified class/name rule): a class-typed position is
         closed-world — a ``requested`` value that is NOT a known class is NOT
-        passed through as a literal LiteLLM model (that would let a
-        skill-authored / LLM-injected string bypass the proxy config, which is
+        passed through as a literal LiteLLM model (that would let an
+        LLM-injected string bypass the proxy config, which is
         the single source of truth for model selection). Returns ``requested``
         only when it is a known class; otherwise logs ONE decision-enabling
         warning and returns the trusted ``fallback``.
 
         This is the "standard gate" promotion of :meth:`is_known_class` — every
-        op/skill-supplied model field (``op.model``) routes through here rather
+        op- or phase-supplied model field (``op.model``) routes through here rather
         than each call site re-implementing the guard. Operator-config model
         references (``cfg.model`` etc., from reyn.yaml) deliberately do NOT use
         this gate: literal LiteLLM strings there are an intentional

--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -60,17 +60,17 @@ MCP_SEARCH_THRESHOLD: int = 0
 # conflicts with Reyn's provider-agnostic posture. Set > 0 via reyn.yaml
 # mcp.search_threshold to opt in. Full removal of tool_search_tool is FP-0033.
 
-# ── G12 attractor mitigation (B7 finding: skill description verbosity trigger) ──
+# ── G12 attractor mitigation (B7 finding: description verbosity trigger) ──
 #
-# Empty-stop attractor root cause: skill description verbosity.  B7 finding
+# Empty-stop attractor root cause: description verbosity.  B7 finding
 # B7-G12-context-root-cause.md (commit a62a9dad) confirmed that truncating
-# descriptions to ≤80 chars in list_skills tool_response reduced empty-stop
+# descriptions to ≤80 chars in listing tool_responses reduced empty-stop
 # rate from 100% → 0% (H-b verification).  B7-G12-cross-attractor-pattern.md
 # (commit a947255e) confirmed two trigger paths:
-#   Pattern A: via list_skills tool_response
-#   Pattern C: via system prompt inline skill list
-# Both paths must truncate to the same threshold.  describe_skill returns the
-# full description (details on demand — list is summary only).
+#   Pattern A: via listing tool_response
+#   Pattern C: via system prompt inline catalog entries
+# Both paths must truncate to the same threshold.  Detail is available
+# on-demand (details-on-demand — list is summary only).
 MAX_DESC_LEN_FOR_LISTING: int = 80
 
 # ── ToolSpec — unified tool descriptor ──────────────────────────────────────

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -28,7 +28,7 @@ class BudgetGateway:
     agent_name:
         Name of the owning agent; forwarded to tracker queries.
     default_router_cap:
-        Maximum consecutive skill_router invocations per user turn. Mirrors
+        Maximum consecutive router invocations per user turn. Mirrors
         ``CostConfig.router_invocations_per_turn``.  cap<=0 disables check.
     """
 
@@ -106,7 +106,7 @@ class BudgetGateway:
 
     @property
     def router_cap(self) -> int:
-        """Configured cap on consecutive skill_router invocations per turn."""
+        """Configured cap on consecutive router invocations per turn."""
         return self._router_cap
 
     def reset_router_turn_counter(self) -> None:

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -593,7 +593,7 @@ class PermissionResolver:
     ) -> bool:
         if self._is_config_approved(key):
             return True
-        # Composite keys (e.g. "skill_router/python.safe/./mod.py:fn") accept
+        # Composite keys (e.g. "<actor>/python.safe/./mod.py:fn") accept
         # a kind-level blanket grant in config (e.g. "python.safe: allow").
         # Honor the same config blanket-grant here at the
         # runtime check so config and runtime stay consistent.


### PR DESCRIPTION
**[lead-sonnet]** — part of #2434

## Summary

- Rewrites stale skill-word comments/docstrings in 8 files (config, security, llm/model_resolver, runtime). Zero code/logic changes.

## Revision note

Original PR also touched `src/reyn/llm/llm.py:1049` (the op_catalog LLM-facing text). **Reverted** — e2e determined those lines live inside the `_SYSTEM_BASE` const whose only consumer `_system_prompt` was removed in #2516: the const renders to no live LLM and will be deleted wholesale in a separate residual-cleanup PR. Rewording it was wasted work and would preserve a wrong concept. llm.py is now untouched.

## Per-file summary (8 files)

- **config/embedding.py:1** — module docstring: removed stale `SkillSearch` (class deleted)
- **config/infra.py:492,535,564** — cron job shape docs: replaced "bare `skill` name" wording with shape-neutral description
- **config/root.py:120-129** — `tool_calls_op_loop_skills` desc: "skill names" → "names"; **:265** — "scheduled skill execution" → "scheduled message dispatch"
- **data/memory/memory.py:3** — module docstring: `` `skill_router` (which writes memories) `` → "the chat router (which writes memories)"
- **llm/model_resolver.py:56** — example class name `skill=` → `strong=`; **:351,356,362** — "op/skill-supplied"/"skill-authored / LLM-injected" → "op- or phase-supplied"/"LLM-injected"
- **runtime/router_tools.py:63-72** — `MAX_DESC_LEN_FOR_LISTING` comment: replaced `list_skills`/`describe_skill`/`inline skill list` with generic tool-listing equivalents
- **runtime/services/budget_gateway.py:31,109** — "skill_router invocations" → "router invocations"
- **security/permissions/permissions.py:596** — composite key example: `skill_router/…` → `<actor>/…`

## Excluded (KEPT — live mechanisms)
- `security/threat_patterns.py` `skill.md` regex (~107-108) — live security pattern, untouched
- `security/secrets/store.py` `ScopedSecretStore` docstrings — still accurate (skill execution still exists, `run_skill` boundary still live)

## Test plan

- [x] `ruff check` — all checks passed
- [x] `verify_module_docstrings.py` — OK
- [x] `pytest` — config/security tests relevant to the 8 files pass (35/35 config-loader tests green). Pre-existing environmental failures (missing `mcp` optional dep + web-framework version drift) reproduce on clean HEAD and are unrelated to comment-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)