### PR TITLE
refactor(skill-word): sweep batch B — runtime/ stale skill narrative comments

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -10,7 +10,7 @@ Lifecycle invariants (PR10):
 - Agents are loaded lazily — `start_attached()` is the first time we
   spin up `session.run()` for the named agent.
 - After `attach(B)`, agent A's `session.run()` keeps running in the
-  background (skills can keep progressing); only the REPL's display
+  background (its turns can keep progressing); only the REPL's display
   pointer moves to B.
 
 The registry deliberately knows nothing about prompt_toolkit, renderers,
@@ -87,7 +87,7 @@ _LIFECYCLE_CREATE_KINDS = frozenset({"agent_created", "session_spawned"})
 
 
 def _count_inflight_disposition(tasks: "list") -> "tuple[int, int]":
-    """#2115: classify settled in-flight skill tasks → (cancelled, finished). A task
+    """#2115: classify settled in-flight tasks → (cancelled, finished). A task
     cancelled at an await reports ``cancelled()``; one that RETURNED before the
     cancel landed is ``done()`` and not cancelled = finished (it won the cancel
     race). Powers the TRUTHFUL /rewind summary (vs the old hardcoded "in-flight
@@ -265,7 +265,7 @@ class AgentRegistry:
         # session. Generic session-level listeners (not skill-specific).
         self._focus_chat_listener: "Callable[..., None] | None" = None
         self._focus_intervention_channel: str | None = None
-        # WAL truncation throttle (skill resume design). monotonic ts of last
+        # WAL truncation throttle (WAL-floor design). monotonic ts of last
         # successful truncation attempt; ``None`` means no throttle is active.
         self._last_truncation_ts: float | None = None
         # ADR-0038 Stage 1c-2: set for the duration of a global rewind. While
@@ -1091,9 +1091,10 @@ class AgentRegistry:
         self._rewind_in_progress = True
         try:
             sessions = self._iter_sessions()
-            # #2115: snapshot the in-flight skill tasks BEFORE the cancel, so the
-            # Skill-execution machinery removed (stage1 decouple): no in-flight
-            # skill tasks exist; the summary always reflects 0 cancelled / 0 finished.
+            # #2115: the in-flight-task snapshot would be taken BEFORE the cancel
+            # here, but background run machinery was removed (stage1 decouple):
+            # no in-flight tasks exist; the summary always reflects 0 cancelled /
+            # 0 finished.
             inflight_tasks: list = []
             # 2. all-cancel (stop-world).
             for session in sessions:
@@ -2043,37 +2044,35 @@ class AgentRegistry:
         )
         return {"recovered_target_n": target, "head": head, "agents": agents}
 
-    # ── WAL truncation (skill resume design) ────────────────────────────────
+    # ── WAL truncation (WAL-floor design) ───────────────────────────────────
     #
-    # Trigger policy: semantic boundary — call this after appending a
-    # `skill_phase_advanced` or `skill_completed` event to the WAL. Throttled
-    # to avoid thrashing on bursty phase completions. Size-based safety net
-    # (long-idle skills) is intentionally deferred until we have real WAL
-    # size telemetry from dogfood.
+    # Trigger policy: semantic boundary — call this at a turn/append boundary.
+    # Throttled to avoid thrashing on bursty boundaries. Size-based safety net
+    # (long-idle sessions) backs it up until we have real WAL size telemetry
+    # from dogfood.
     #
-    # Floor calculation: `min(全 agent applied_seq, 全 active skill
-    # last_phase_applied_seq) + 1` — everything strictly below this seq is
-    # universally absorbed and droppable. Replaying from `floor - 1` would
-    # be a no-op for every snapshot, so dropping below it is safe.
+    # Floor calculation: `min(全 agent applied_seq) + 1` — everything strictly
+    # below this seq is universally absorbed and droppable. Replaying from
+    # `floor - 1` would be a no-op for every snapshot, so dropping below it is
+    # safe.
     #
     # Owner rationale: AgentRegistry is the only layer that has both
-    # (a) the StateLog handle, and (b) visibility into all agents' snapshots
-    # + every active skill snapshot under each agent's `state/skills/`
-    # directory. Pushing this into entry points (`reyn chat`, `reyn web`)
+    # (a) the StateLog handle, and (b) visibility into all agents' snapshots.
+    # Pushing this into entry points (`reyn chat`, `reyn web`)
     # would duplicate the orchestration; pushing it into StateLog itself
-    # would force the WAL to know about agent / skill layout.
+    # would force the WAL to know about agent layout.
 
     _TRUNCATION_THROTTLE_SECS: float = 5.0
     # R-D4: size safety net default. Session's chat-turn-boundary
-    # call uses this threshold. Long-idle skills with no semantic
-    # boundary events (= no phase_advanced / skill_completed) would
-    # otherwise let the WAL grow unboundedly between turns.
+    # call uses this threshold. Long-idle sessions with no semantic
+    # boundary events would otherwise let the WAL grow unboundedly
+    # between turns.
     _SIZE_SAFETY_NET_BYTES: int = 1_000_000
 
     async def truncate_wal_if_eligible(
         self, *, bypass_throttle: bool = False,
     ) -> dict | None:
-        """Compute floor across all agents + active skill snapshots, then
+        """Compute floor across all agents' snapshots, then
         truncate the WAL if eligible.
 
         Returns the truncate stats dict, or ``None`` if skipped (no state
@@ -2250,7 +2249,7 @@ class AgentRegistry:
     ) -> bool:
         """Find the upstream waiter agent and force-resolve their chain.
 
-        When a user runs ``/skill discard <run_id>`` on agent B, and that
+        When a run is discarded on agent B, and that
         run was processing a chain registered on agent A's side, A would
         otherwise stay stuck on ``waiting_on={B}`` until the watchdog
         fires (chain_timeout_seconds, often minutes-to-hours in real
@@ -2304,14 +2303,13 @@ class AgentRegistry:
                 )
         return notified
 
-    # R-D16: skills awaiting an intervention longer than this many seconds
-    # are excluded from the WAL truncation floor calc. Without this, a
-    # single skill stuck on ``ask_user`` (e.g. user away from terminal)
-    # pins the floor at its ``last_phase_applied_seq`` indefinitely and
-    # the WAL grows unbounded. Long-await skills accept memo loss for the
-    # awaited window — at resume they fall through to re-execute the op
-    # whose memo was truncated, which is the same behaviour as a memo
-    # cache miss.
+    # R-D16: a run awaiting an intervention longer than this many seconds
+    # is excluded from the WAL truncation floor calc. Without this, a
+    # single run stuck on ``ask_user`` (e.g. user away from terminal)
+    # could pin the floor indefinitely and let the WAL grow unbounded. A
+    # long-await run accepts memo loss for the awaited window — at resume
+    # it falls through to re-execute the op whose memo was truncated,
+    # which is the same behaviour as a memo cache miss.
     _LONG_AWAIT_THRESHOLD_SEC: float = 300.0
 
     def compute_truncate_floor(self) -> int:
@@ -2346,12 +2344,11 @@ class AgentRegistry:
     def _compute_live_floor(self) -> int:
         """Return the lowest seq that MUST remain in the WAL (live floor).
 
-        ``floor = min(全 active session applied_seq, 全 active skill
-        last_phase_applied_seq, 全 active plan last_step_applied_seq) + 1``
+        ``floor = min(全 active session applied_seq) + 1``
 
         PR-N7 (FP-0008): reads watermarks exclusively from in-memory
-        state — session journal snapshots + per-session skill / plan
-        registries — by walking ``self._agents.values()`` and calling
+        state — session journal snapshots — by walking
+        ``self._agents.values()`` and calling
         each session's ``iter_applied_seqs`` public method. The pre-N7
         implementation walked every snapshot file on disk inside the
         async ``truncate_wal_if_eligible`` caller, which blocked the
@@ -2378,12 +2375,11 @@ class AgentRegistry:
           ``ensure`` instantiates a session that immediately registers
           here, and the next floor recompute picks up its watermark.
 
-        R-D16: skills awaiting an intervention for longer than
-        ``_LONG_AWAIT_THRESHOLD_SEC`` are excluded so the WAL can keep
+        R-D16: a run awaiting an intervention for longer than
+        ``_LONG_AWAIT_THRESHOLD_SEC`` is excluded so the WAL can keep
         advancing — the elapsed check is performed in-memory.
 
-        Returns 0 when no watermark is available (no live session, no
-        active skill, no active plan).
+        Returns 0 when no watermark is available (no live session).
         """
         seqs: list[int] = []
         now = time.monotonic()

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -56,7 +56,7 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
 
 # Localized user-facing message when the model returns an empty response
 # (finish_reason=stop, no content, no tool calls). Deterministic i18n so
-# output_language is always honoured.  P7-clean: no skill / tool names.
+# output_language is always honoured.  P7-clean: no tool names.
 # "en" is the global-safe default.
 _EMPTY_RESPONSE_MSG: dict[str, str] = {
     "ja": (
@@ -70,15 +70,15 @@ _EMPTY_RESPONSE_MSG: dict[str, str] = {
 }
 
 
-# Localized OS-level acknowledgment emitted when a skill spawns asynchronously
-# (= invoke_skill / invoke_action returns ``{status: "spawned", ...}``). The
+# Localized OS-level acknowledgment emitted when a request is dispatched
+# asynchronously (= a tool call returns ``{status: "spawned", ...}``). The
 # H3 ablation exits the router loop before any further LLM call, so without
 # this OS-injected message the user sees silence between request and the
 # eventual ``[task_completed]`` arrival. The previous (pre-H3) LLM-composed
-# spawn-ack was hallucinating skill output that hadn't happened yet (B32
+# ack was hallucinating output that hadn't happened yet (B32
 # W3 S1); this deterministic OS message carries the same UX guarantee
 # (= "/tasks" hint) without LLM composition, so the race condition does
-# not re-emerge.  P7-clean: no skill names, no qualified action names.
+# not re-emerge.  P7-clean: no tool names, no qualified action names.
 # #1593 PR-4: the OS-generic synthetic tool-response the RePresent arm appends for
 # an intercepted re-present tool_call (a retrieval search). The scheme's interpret
 # turned the tool_call into a RePresent (it is never dispatched), but the message
@@ -96,15 +96,15 @@ _REPRESENT_ACK = (
 # realistic search-refine sequence. The outer max_iterations is the ultimate cap.
 _MAX_REPRESENT_ROUNDS = 64
 
-# B55 R-7 (2026-05-25): agent-side spawn alignment — symmetric with
-# skill/plan spawn_ack so the LLM sees a structured task lifecycle
-# event for delegate_to_agent / other peer-async tools too. Prior
-# behaviour pushed a generic `dispatched N async requests; awaiting
-# peer reply` status row with no `[task_spawned]` header, leaving
-# the SP TASK_SPAWNED rule un-anchored for the agent path. Now mirrors
-# the skill / plan format: `[task_spawned] kind=agent ...` header +
-# user-facing trailer. Pairs with the `[task_completed] kind=agent
-# ...` injection on peer reply receipt (see inter_agent_messaging).
+# B55 R-7 (2026-05-25): agent-side spawn alignment — the LLM sees a
+# structured task lifecycle event for delegate_to_agent / other
+# peer-async tools too. Prior behaviour pushed a generic `dispatched N
+# async requests; awaiting peer reply` status row with no
+# `[task_spawned]` header, leaving the SP TASK_SPAWNED rule
+# un-anchored for the agent path. Now emits the uniform
+# `[task_spawned] kind=agent ...` header + user-facing trailer. Pairs
+# with the `[task_completed] kind=agent ...` injection on peer reply
+# receipt (see inter_agent_messaging).
 _AGENT_SPAWN_ACK_MSG: dict[str, str] = {
     "ja": (
         "ピアエージェントにリクエストを送信しました。"
@@ -2115,11 +2115,11 @@ class RouterLoop:
                 # tool_calls list, which would inbox_put the same
                 # request twice and double-charge the peer.
                 # G3 fix (dogfood batch 5 B5-M1): extend dedupe to
-                # invoke_skill — same skill + same args in one round
-                # spawns redundant runs (333k tokens / 51 LLM calls
-                # observed). invoke_skill is sync but NOT idempotent
-                # from a cost perspective; deduping is safe because
-                # same args → same deterministic result.
+                # sync tool calls too — same tool + same args in one
+                # round spawns redundant runs (333k tokens / 51 LLM
+                # calls observed). A sync call is NOT idempotent from a
+                # cost perspective; deduping is safe because same args →
+                # same deterministic result.
                 # #1593: execute the Execute round (interpret already ran at the
                 # loop level above → ``interp`` carries the resolved actions). The OS
                 # exclude-gates pre-dispatch inside _run_execute_round → dispatch →
@@ -2829,7 +2829,7 @@ class RouterLoop:
         list/describe via ``_enumerate_category`` + ``_describe_one``, #1455
         invariant; name-sorted; ``parameters`` never None). Async because the
         complete caller-state is built async (caveat-1: a ``ToolContext`` WITHOUT
-        ``router_state`` drops the resource categories — skills/agents/mcp — and
+        ``router_state`` drops the resource categories — agents/mcp — and
         the rag manifest fetch is the genuine await). Maps each generic entry →
         the OpenAI ``{type: function, function: {name, description, parameters}}``
         shape so the flat tools= is uniform with ``base_tools``."""
@@ -3424,7 +3424,7 @@ class RouterLoop:
             describe_agent_fn=self._describe_agent,
             # getattr-guarded (symmetric with ``op_context_factory`` below, #1092
             # PR-C-0): a RouterLoopCore host that is not the chat RouterHostAdapter
-            # (e.g. PhaseRouterLoopHost — a phase has no skills/agents catalog) need
+            # (e.g. PhaseRouterLoopHost — a phase has no agents catalog) need
             # not implement these chat-discovery methods. Without the guard the
             # eager call AttributeError'd every op dispatch on the converged path.
             available_agents=list(getattr(self.host, "list_available_agents", list)()),

--- a/src/reyn/runtime/router_system_prompt.py
+++ b/src/reyn/runtime/router_system_prompt.py
@@ -266,8 +266,8 @@ def build_system_prompt(
         )
         parts.append("")
 
-    # ── 7 & 8. Skills / Agents catalog ──────────────────────────────────────
-    # Wrapper-only path: skill / agent are 2 of the action categories (now
+    # ── 7 & 8. Agents catalog ────────────────────────────────────────────────
+    # Wrapper-only path: agent is one of the action categories (now
     # scheme-owned, no longer rendered by the OS). Dedicated sections would
     # impose a per-category special-case structure that contradicts FP-0034's
     # uniform-invoke design — so they are omitted here. (Resource discovery

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -1,7 +1,7 @@
 """CompactionController — synchronous head/body/tail compaction.
 
 Extracted from Session (FP-0019 Wave 1).  Drives OS-internal compaction
-(PR-N3: direct Python helper, no skill/phase overhead) via
+(PR-N3: a direct Python helper) via
 :meth:`force_compact_now`, the synchronous pre-frame guard path.
 
 #1128 PR-a: the background fire-and-forget path (``spawn_maybe`` →
@@ -66,7 +66,7 @@ def _turn_to_compactor_input(
     Post-PR-E1 (issue #383) the history may contain ``assistant`` entries
     with ``tool_calls``, ``tool`` entries with ``tool_call_id`` + ``name``,
     and ``user``/``assistant`` entries with multimodal ``content`` lists.
-    The compactor skill needs enough structure to reason about tool
+    The compactor needs enough structure to reason about tool
     activity in ``artifacts_referenced`` while staying within token caps.
 
     Shape we emit per turn:
@@ -123,7 +123,7 @@ class CompactionController:
         :class:`~reyn.runtime.chat_message.ChatMessage`, or ``None``.
     compaction_engine:
         :class:`~reyn.services.compaction.engine.CompactionEngine`
-        that owns the single LLM call (PR-N3: OS-internal, no skill/phase).
+        that owns the single LLM call (PR-N3: OS-internal Python helper).
     history_appender:
         Callable ``(ChatMessage) -> None`` that appends a message to the
         persisted history.  Wraps ``Session._append_history``.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1,4 +1,4 @@
-"""Session — long-lived chat loop driving the skill_router stdlib skill."""
+"""Session — long-lived chat loop driving the router turn."""
 from __future__ import annotations
 
 import asyncio
@@ -455,7 +455,7 @@ def _run_short(run_id: str) -> str:
 
 
 def _run_meta(run_id: str | None, actor: str | None) -> dict:
-    """Standard `meta` payload for OutboxMessage produced inside a skill spawn."""
+    """Standard `meta` payload for OutboxMessage produced inside a run."""
     if run_id is None:
         return {"actor": actor} if actor else {}
     return {
@@ -2044,7 +2044,7 @@ class Session:
         V1 boundary: sets the cooperative cancellation flag so the turn's
         run_loop breaks at the next tool-iteration boundary. A slow tool
         already in flight completes before the cancel takes effect (subprocess
-        kill is a follow-up scope). Skills and plans are cancelled immediately
+        kill is a follow-up scope). Any spawned tasks are cancelled immediately
         via asyncio task cancellation (existing behaviour, preserved here).
         """
         self._loop_driver.request_cancel()
@@ -2514,8 +2514,8 @@ class Session:
 
         Surfaces the watermarks AgentRegistry.compute_truncate_floor
         needs from this session, sourced exclusively from in-memory
-        state (= journal snapshot + skill_registry + plan_registry).
-        No disk I/O — preserves the existing reyn architecture choice
+        state (= journal snapshot). No disk I/O — preserves the
+        existing reyn architecture choice
         (event loop friendly, no thread offload, in-memory state is
         event-sourced from WAL apply).
 
@@ -2523,10 +2523,10 @@ class Session:
           - ``journal.snapshot.applied_seq`` when > 0 (dormant agents
             with applied_seq == 0 are skipped — the same skip the
             disk-read path used so behaviour matches)
-          - per active skill: ``last_phase_applied_seq``, with R-D16
-            long-await exclusion (skills awaiting >= long_await_threshold
-            seconds are dropped from the floor so WAL can keep advancing)
-          - per active plan: ``last_step_applied_seq``
+
+        The ``now_ts`` / ``long_await_threshold`` parameters are retained
+        for the caller's uniform signature; there is no longer a per-run
+        registry contributing additional watermarks (stage1 decouple).
         """
         out: list[int] = []
         snap_applied = int(self._journal.snapshot.applied_seq)
@@ -2778,7 +2778,7 @@ class Session:
             the meta key is omitted to keep the storage minimal.
 
         Compaction behaviour (= #398 v4 Q3 decision):
-          state_change entries are NOT consumed by ``chat_compactor``
+          state_change entries are NOT consumed by compaction
           (= CompactionController filters ``role in ("user","agent")``;
           system-role entries are never candidates). Per-event
           preservation is implicit. Phase 2 trigger for threshold-based
@@ -3887,20 +3887,12 @@ class Session:
             await self._put_outbox(OutboxMessage(kind="__end__", text=""))
 
     async def _drain_on_shutdown(self) -> None:
-        """Wait for in-flight skill runs to complete, then cancel stragglers.
+        """Cancel any in-flight background work, then tear down on shutdown.
 
         Memory writes happen inline during each router turn, so there is no
         background extraction to drain — shutdown is teardown of whatever the
         user explicitly launched, plus a final await on the compaction task
         (if any) so the summary entry gets persisted before the process exits.
-
-        B27-H4 fix: give in-flight skill tasks a 30-second grace window to
-        complete naturally before the hard cancel.  Without the grace window,
-        skills whose LLM call is in-progress at session shutdown receive
-        ``asyncio.CancelledError``, which propagates through
-        ``RunOrchestrator.run()`` → ``skill_run_interrupted`` instead of
-        ``skill_run_completed``.  The 30-second limit prevents hanging
-        indefinitely on a stalled LLM call.
 
         #52 fix: also suppress the benign ``coroutine
         'OpenAIChatCompletion.acompletion' was never awaited`` RuntimeWarning
@@ -3932,7 +3924,7 @@ class Session:
         if text.startswith("/"):
             if await self._maybe_handle_slash(text):
                 return
-        # If a spawned skill is waiting on a user intervention (ask_user or
+        # If a spawned run is waiting on a user intervention (ask_user or
         # permission prompt), route this input to that intervention instead of
         # starting a fresh router turn.
         if await self._maybe_answer_oldest_intervention(text):

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1,8 +1,8 @@
 """CompactionEngine — OS-internal LLM-driven chat history compaction.
 
-PR-N3 (FP-0008, 11-axis): replaces the ``chat_compactor`` skill with a
-direct Python helper.  One LLM call is retained but the phase-frame overhead
-(skill loader, artifact YAML, postprocessor sandbox) is gone.
+PR-N3 (FP-0008, 11-axis): a direct Python helper for chat compaction.
+One LLM call is retained, with no phase-frame overhead — the compaction
+prompt and postprocessing are inlined here.
 
 PR-N6 (FP-0008): adds overflow retry loop + adaptive token estimation learner.
 Budget allocation migrated from ratio fields to integer component_weights /


### PR DESCRIPTION
**[lead-sonnet]** — Skill-word cleanup sweep **BATCH B** (runtime/ stale skill NARRATIVE in comments/docstrings). The skill feature is deleted; this reword updates stale comment/docstring references to the removed machinery (SkillRunner, `skill_router` stdlib skill, async skill spawn, `chat_compactor` skill, active-skill WAL-floor watermarks, `/skill discard`) to run/task-neutral framing.

**Comment/docstring ONLY — zero code / signature / logic changes.** Verified: `git diff -U0` touches no Python code lines; all 6 files AST-parse; targeted pytest (632 passed / 9 skipped) green.

### Per-file summary
- **session.py** — module docstring (`skill_router stdlib skill`→`router turn`); `_run_meta` docstring (`skill spawn`→`run`); `cancel_inflight` docstring (`Skills and plans`→`Any spawned tasks`); `iter_applied_seqs` docstring + `_drain_on_shutdown` docstring/summary (dropped the removed `RunOrchestrator`/`skill_run_interrupted`/`skill_run_completed` + per-skill/plan watermark narrative to match the live tombstoned body); `chat_compactor`→`compaction`; `spawned skill is waiting`→`spawned run is waiting`.
- **registry.py** — module docstring (`skills can keep progressing`→`its turns`); `_count_inflight_disposition` (`in-flight skill tasks`→`in-flight tasks`); WAL-truncation design block (`skill resume design`→`WAL-floor design`; dropped `skill_phase_advanced`/`skill_completed`/`active skill last_phase_applied_seq`/`state/skills/` — the live floor calc reads agent applied_seq only); `_LONG_AWAIT_THRESHOLD_SEC` + `_compute_live_floor` + `truncate_wal_if_eligible` docstrings reworded to run-neutral; `/skill discard`→generic run-discard.
- **router_loop.py** — spawn-ack constant comment (async skill spawn → generic async dispatch); `_AGENT_SPAWN_ACK_MSG` cross-ref (`symmetric with skill/plan spawn_ack`→uniform header framing); dedupe comment (`invoke_skill`→sync tool calls); two catalog comments (`skills/agents/mcp`→`agents/mcp`; `no skills/agents catalog`→`no agents catalog`) — `skill` confirmed NOT in live `CATEGORIES`; `P7-clean: no skill / tool names`→`no tool names`.
- **router_system_prompt.py** — section header `Skills / Agents catalog`→`Agents catalog`; `skill / agent are 2 of the action categories`→agent-only.
- **compaction_controller.py** — module docstring + two param docstrings (`no skill/phase overhead`, `compactor skill needs`, `no skill/phase`) → OS-internal Python-helper framing.
- **engine.py** — module docstring (`replaces the chat_compactor skill`/`skill loader, artifact YAML` → direct-Python-helper framing).

### Left as-is (KEEP-guard / live mechanism)
- **router_loop.py `resolve_alias_metadata`** docstring (`skill / agent.peer` aliases, `skill__<name>` step, `skill_metadata_lookup`) and the `category == "skill"` code branch (~1094-1103) — the alias/dispatch code branch is live and reserved for separate judgment; rewording its docstring would desync it from live code. Flagged for the code-branch decision.

### Gates
- `ruff check` (6 files): pass
- `verify_module_docstrings.py` (6 files): pass
- pytest (targeted: compaction/truncat/registry/router_loop): 632 passed, 9 skipped

### Test plan
- [x] (skipped — comment/docstring-only; no behavior change) Manual/visual items — verified via `git diff -U0` = no code lines, AST-parse, targeted pytest green.

part of #2434
