### PR TITLE
refactor(skill-word): final dead-code tail — Reporter callbacks + dead skill branch

### DIFF
--- a/src/reyn/reporters/__init__.py
+++ b/src/reyn/reporters/__init__.py
@@ -36,35 +36,12 @@ class ConsoleLogger:
 
     # ── Phase lifecycle ────────────────────────────────────────────────────────
 
-    def on_phase_started(self, data: dict) -> None:
-        print(f"[phase:{data['phase']}] started (visit #{data['visit_count']})")
-
     def on_phase_retry(self, data: dict) -> None:
         error = data.get("error", "")
         print(
             f"[phase:{data['phase']}] retry {data['attempt']}/{data['max_retries']}"
             f" — {error[:120]}"
         )
-
-    def on_phase_completed(self, data: dict) -> None:
-        phase = data["phase"]
-        next_phase = data.get("next", "?")
-        confidence = data.get("confidence", 0.0)
-        was_normalized = data.get("was_normalized", False)
-        was_inferred = data.get("was_inferred", False)
-        retries = data.get("retries", 0)
-        artifact_path = data.get("artifact_path", "")
-
-        norm = (
-            " (inferred)" if was_inferred
-            else f" (normalized from '{data.get('original_raw_type')}')" if was_normalized
-            else ""
-        )
-        retry_str = (
-            f" [{retries} retr{'y' if retries == 1 else 'ies'}]" if retries else ""
-        )
-        path_str = f"  → {artifact_path}" if artifact_path else ""
-        print(f"[phase:{phase}] → {next_phase}{norm}{retry_str}  (confidence={confidence}){path_str}")
 
     def on_artifact_created(self, data: dict) -> None:
         phase = data.get("phase", "?")

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -756,26 +756,22 @@ _UNIVERSAL_WRAPPER_NAMES: frozenset[str] = frozenset({
 
 def _filter_ghost_names_by_registry(
     names: "list[str]",
-    skill_meta_map: "dict[str, dict] | None",
     mcp_tool_map: "dict[str, dict] | None",
     available_agents: "list[dict] | None",
     *,
-    known_skill_names: "frozenset[str] | None" = None,
     known_memory_entries: "frozenset[str]",
     _warned: "set[str] | None" = None,
 ) -> "list[str]":
     """Filter hot-list names that pass structural check but don't exist in the registry.
 
     B38 W2 finding: ``_is_valid_qualified_name`` only validates shape
-    (= category + separator + entry). A renamed skill like
-    ``skill__create_skill`` passes structural check but is a ghost — the
-    skill no longer exists under that name. This filter adds the
-    existence check at hot-list materialization time, when session
-    registry data is available.
+    (= category + separator + entry). A stale alias (e.g. a renamed MCP
+    tool) passes structural check but is a ghost — it no longer resolves
+    in the current registry. This filter adds the existence check at
+    hot-list materialization time, when session registry data is
+    available.
 
     Categories and their existence signals:
-    - ``skill__*`` → must be a key in ``skill_meta_map``
-      (= resolved skill list from ``host.list_available_skills()``).
     - ``agent.peer__*`` → must match a name in ``available_agents``.
     - ``mcp.tool__*`` / ``mcp.server__*`` → must be a key in ``mcp_tool_map``
       (or any server name prefix for ``mcp.server__*``).
@@ -807,13 +803,6 @@ def _filter_ghost_names_by_registry(
         _warned = set()
 
     # Build existence sets from session state.
-    # Skills: use the broader ``known_skill_names`` set when provided
-    # (= covers empty-input-schema skills too); fall back to
-    # ``skill_meta_map`` keys for backwards-compat.
-    if known_skill_names is not None:
-        known_skills: frozenset[str] = known_skill_names
-    else:
-        known_skills = frozenset(skill_meta_map or {})
     known_mcp_tools: frozenset[str] = frozenset(mcp_tool_map or {})
     # Extract MCP server names from mcp_tool_map keys (mcp.tool__<server>.<tool>)
     known_mcp_servers: set[str] = set()
@@ -840,9 +829,7 @@ def _filter_ghost_names_by_registry(
             continue
 
         exists = True
-        if category == "skill":
-            exists = name in known_skills
-        elif category == "mcp.tool":
+        if category == "mcp.tool":
             exists = name in known_mcp_tools
         elif category == "mcp.server":
             exists = entry_name in known_mcp_servers
@@ -1041,11 +1028,6 @@ def _resource_alias_metadata(
       - ``rag_corpus__<name>`` (step 1) — accepts ``{query, top_k?, ...}``;
         rule curries ``sources=[<name>]``. Source: ``recall`` parameters
         minus ``sources``.
-      - ``skill__<name>`` (step 2) — caller supplies ``skill_metadata_lookup``
-        keyed by qualified name with ``{description?, input_schema?,
-        input_wrapped?}``. The transform ``_invoke_skill_args`` wraps caller
-        args under the artifact ``data`` slot, so the alias's parameters
-        are the artifact's data schema directly (= ``input_schema``).
       - ``mcp.tool__<server>.<tool>`` (step 3) — caller supplies
         ``mcp_tool_lookup`` keyed by qualified name with ``{description?,
         input_schema?}`` from the MCP server's declared tool schema.
@@ -1055,6 +1037,9 @@ def _resource_alias_metadata(
         ``_read_memory_body_args`` transform sends ``{name: entry}`` but
         the target ``read_memory_body`` expects ``{layer, slug}``;
         pre-existing dispatch shape mismatch, surface separately.
+      - ``skill__<name>`` — skill enumeration was removed (stage1 decouple);
+        ``skill_metadata_lookup`` is never populated with ``skill__*`` entries
+        at runtime, so this branch always returned ``None``.
     """
     from reyn.tools import get_default_registry
     from reyn.tools.universal_catalog import split_qualified_name
@@ -1090,19 +1075,6 @@ def _resource_alias_metadata(
             f"Single-source variant of: {first_line}"
         )
         return description, params
-
-    if category == "skill":
-        meta = (skill_metadata_lookup or {}).get(qualified_name)
-        if not meta or "input_schema" not in meta:
-            return None
-        schema = dict(meta["input_schema"])
-        desc_body = meta.get("description") or f"Skill {entry_name!r}"
-        description = (
-            f"{desc_body}. Hot-list direct alias for skill {entry_name!r} "
-            f"— pass the skill's input fields as args; the dispatcher wraps "
-            f"them into the input artifact for invoke_skill."
-        )
-        return description, schema
 
     if category == "mcp.tool":
         meta = (mcp_tool_lookup or {}).get(qualified_name)
@@ -1510,11 +1482,9 @@ class RouterLoop:
         _mcp_tool_map: dict[str, dict] = {}
         if _univ_enabled:
             # Skill enumeration removed (stage1 decouple): the short-description
-            # and known-skill-name maps stay declared (empty) because downstream
-            # hot-list / ghost-filter code still reads them for the memory_entry
-            # and mcp branches.
+            # map stays declared (empty) because downstream hot-list code still
+            # reads it for the memory_entry alias descriptions.
             _short_desc_map: dict[str, str] = {}
-            _known_skill_names: set[str] = set()
             # Issue #879: per-mcp-tool aliases (``mcp.tool__<srv>.<tool>``)
             # were removed when the mcp surface collapsed to six verb
             # actions. LLMs now dispatch tool calls through
@@ -1579,10 +1549,8 @@ class RouterLoop:
                 # RouterState (skill / mcp / agent registry) is available.
                 _top_names = _filter_ghost_names_by_registry(
                     _top_names,
-                    skill_meta_map=_skill_meta_map or None,
                     mcp_tool_map=_mcp_tool_map or None,
                     available_agents=host.list_available_agents() or None,
-                    known_skill_names=frozenset(_known_skill_names) or None,
                     # Dynamic memory_entry__<slug> names enumerated above
                     # from .reyn/memory/*.md. Empty set means "no entries
                     # exist this session" — filter rejects any stale

--- a/tests/test_hot_list_ghost_registry_check.py
+++ b/tests/test_hot_list_ghost_registry_check.py
@@ -1,9 +1,9 @@
 """Tier 2: Ghost alias registry-existence check at hot-list materialization.
 
 B38 W2 finding: ``_is_valid_qualified_name`` only validates structural shape
-(category + separator + entry). A renamed skill like ``skill__create_skill``
-passes structural check but is a ghost — the skill no longer exists under
-that name. ``_filter_ghost_names_by_registry`` adds the existence check at
+(category + separator + entry). A stale alias (e.g. a renamed MCP tool) passes
+structural check but is a ghost — it no longer resolves in the current
+registry. ``_filter_ghost_names_by_registry`` adds the existence check at
 hot-list materialization time, when session registry data is available.
 
 This is additive to structural rejection (``test_hot_list_ghost_alias_rejection.py``).
@@ -11,24 +11,17 @@ Names must pass BOTH structural check AND registry-existence check to enter
 the hot list.
 
 Test plan:
-  R1. skill ghost (passes structural, absent from skill_meta_map) is filtered.
-  R2. valid skill alias (present in skill_meta_map) passes through.
   R3. valid static-op alias (in KNOWN_STATIC_QUALIFIED_NAMES) passes through.
   R4. ghost static-op (structurally valid category, not in static ops) is filtered.
-  R5. agent.peer ghost (not in available_agents) is filtered.
-  R6. valid agent.peer (in available_agents) passes through.
   R7. mcp.tool ghost (not in mcp_tool_map) is filtered.
   R8. valid mcp.tool (in mcp_tool_map) passes through.
-  R9. Warning logged once per unique ghost name (deduplication).
-  R10. Integration: ActionUsageTracker freq-loaded jsonl with 1 valid skill +
-       1 ghost skill → hot-list excludes ghost.
   R11. memory_entry name in known_memory_entries passes through (dynamic
        enumeration from .reyn/memory/*.md).
   R12. memory_entry name NOT in known_memory_entries is filtered (stale name
        from action_usage tracker after the entry was deleted).
 
-No mocks. Uses real _filter_ghost_names_by_registry + real ActionUsageTracker
-+ real KNOWN_STATIC_QUALIFIED_NAMES. No RouterLoop instantiation required.
+No mocks. Uses real _filter_ghost_names_by_registry + real
+KNOWN_STATIC_QUALIFIED_NAMES. No RouterLoop instantiation required.
 """
 from __future__ import annotations
 
@@ -40,7 +33,6 @@ from reyn.tools.universal_dispatch import KNOWN_STATIC_QUALIFIED_NAMES
 
 def _call_filter(
     names: list[str],
-    skill_meta_map: dict | None = None,
     mcp_tool_map: dict | None = None,
     available_agents: list[dict] | None = None,
     known_memory_entries: frozenset[str] | None = None,
@@ -54,27 +46,10 @@ def _call_filter(
     """
     return _filter_ghost_names_by_registry(
         names,
-        skill_meta_map=skill_meta_map,
         mcp_tool_map=mcp_tool_map,
         available_agents=available_agents,
         known_memory_entries=known_memory_entries if known_memory_entries is not None else frozenset(),
     )
-
-
-# ── R2. valid skill alias passes ─────────────────────────────────────────────
-
-
-def test_r2_valid_skill_alias_passes_registry_check() -> None:
-    """Tier 2: a skill alias present in skill_meta_map passes registry check."""
-    skill_meta_map = {
-        "skill__word_stats_demo": {
-            "description": "Word statistics demo",
-            "input_schema": {"type": "object", "properties": {"text": {"type": "string"}}},
-        },
-    }
-    result = _call_filter(["skill__word_stats_demo"], skill_meta_map=skill_meta_map)
-
-    assert "skill__word_stats_demo" in result
 
 
 # ── R3. valid static-op alias passes ─────────────────────────────────────────
@@ -163,7 +138,6 @@ def test_r11_memory_entry_passes_when_in_known_set() -> None:
     """
     filtered = _filter_ghost_names_by_registry(
         ["memory_entry__user_project_phoenix"],
-        skill_meta_map=None,
         mcp_tool_map=None,
         available_agents=None,
         known_memory_entries=frozenset({"memory_entry__user_project_phoenix"}),
@@ -186,7 +160,6 @@ def test_r12_memory_entry_filtered_when_absent_from_known_set() -> None:
     """
     filtered = _filter_ghost_names_by_registry(
         ["memory_entry__deleted_slug"],
-        skill_meta_map=None,
         mcp_tool_map=None,
         available_agents=None,
         known_memory_entries=frozenset(),  # zero entries this session


### PR DESCRIPTION
**[lead-sonnet]** — part of #2434

## Summary

Removes confirmed-dead items from the skill-word arc final tail.

**1. `ConsoleLogger.on_phase_started` / `on_phase_completed` (removed)**

Dead-confirmed: grep of all src/ confirms `phase_started` / `phase_completed` event types are **never emitted** in production code (`grep -rn '"phase_started"' src/` returns only `server.py` / `a2a.py` subscriber filters — not emitters — plus `reporters/__init__.py` itself). Files: `src/reyn/reporters/__init__.py`.

**2. `require_python` (RETAINED — see finding)**

Zero src/ callers confirmed (`grep -rn "require_python" src/` → single definition only). However, removing `require_python` + its 4 test files would leave `AgentLayer.allows(CapabilityAxis.PYTHON)` at `effective.py:164` with **zero** separate test coverage (`grep -rn "CapabilityAxis.PYTHON" tests/` → no hits outside those 4 files). Per the task gate: DO NOT remove. Follow-up: add a standalone PYTHON-axis `AgentLayer.allows()` test, then remove `require_python`.

**3. BOTH dead `category == "skill"` branches (removed — fix-class completeness)**

- `_resource_alias_metadata` (~1094): `_skill_meta_map` declared empty (comment: "Skill enumeration removed (stage1 decouple)"), only ever populated with `memory_entry__*` keys. Branch always returned `None`.
- `_filter_ghost_names_by_registry` (~843): sibling ghost-filter branch `if category == "skill": exists = name in known_skills`. `category` can never be `"skill"` (no skill aliases produced) and `known_skills` is always empty → unreachable.

**Dead-plumbing sweep after the ghost-filter branch removal:** `known_skills` had exactly one reader (the removed branch). Its feeders — the `known_skill_names` param, the `skill_meta_map` param (used only for the `known_skills` fallback), the `_known_skill_names` local, and the two call-site kwargs — all became unused and were removed. **`_skill_meta_map` the LOCAL is retained** (still feeds `_build_hot_list_aliases` → the live memory_entry branch). `test_hot_list_ghost_registry_check.py` updated: dead R2 skill-alias test + `skill_meta_map` helper param removed; mcp / static-op / memory_entry coverage survives (5 tests pass). Both function docstrings updated.

## Gate results

- `ruff check src tests` — All checks passed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py` — OK
- `python scripts/test_tier_audit.py --strict tests/test_hot_list_ghost_registry_check.py` — 5 OK, 0 errors
- `pytest` (FULL) — 6829 passed, 30 skipped. 11 failures + 10 errors are **pre-existing** (missing `mcp` module + a FastAPI `_IncludedRouter.path` version incompat); verified by reproducing them on the clean committed tree via `git stash`. Zero new failures.

## Test plan

- [x] `ruff check src tests` — green
- [x] `pytest` (FULL) — green (pre-existing infra failures only, verified via stash)
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — green
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — green