### PR TITLE
docs: reword P7 skill/workflow-specific -> domain-specific

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ modifying tests: [`docs/deep-dives/contributing/testing.ja.md`](../docs/deep-div
 
 - [ ] Tests pass locally (`pytest`).
 - [ ] Lint / format clean.
-- [ ] No skill-specific strings (phase names, artifact types, fields)
+- [ ] No domain-specific strings (phase names, artifact types, fields)
       added to OS code (P7).
 - [ ] P1-P8 invariants respected (see `CLAUDE.md`).
 - [ ] `CHANGELOG.md` updated if the change is user-visible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,9 +102,10 @@ hard rules:
 - **P5** All inter-phase data lives in the workspace. Phases read and write
   only through Control IR.
 - **P6** Every state change emits an event. The event log is append-only.
-- **P7** OS code must not contain skill-specific strings (phase names, artifact
-  types, field names). This is the most commonly violated rule — read the
-  detection guidance in `CLAUDE.md` before touching `src/reyn/`.
+- **P7** OS code must not contain domain-specific strings (phase names, artifact
+  types, field names). This is the most commonly violated rule — grep for a
+  literal naming a specific phase, artifact type, or field before touching
+  `src/reyn/`.
 - **P8** Phase instructions describe what/when/domain rules. They must not
   enumerate output artifact fields or describe Control IR format.
 

--- a/docs/concepts/architecture/care-boundary.ja.md
+++ b/docs/concepts/architecture/care-boundary.ja.md
@@ -145,9 +145,9 @@ Reyn は OS 層に一連の raw primitive を公開する:
 
 ### なぜこれが意図的なものか
 
-P7 は OS コードがワークフロー固有の文字列を含んではならないと定める。同じロジックが一段上にも適用される: OS はあらゆる隣接 product ニーズを吸収してはならない。吸収された機能はそれぞれ、OS が何かしらワークフロー固有あるいは consumer 固有のことを知ることを要求し、Reyn を拡張可能にしている抽象を破壊する。
+P7 は OS コードがドメイン固有の文字列を含んではならないと定める。同じロジックが一段上にも適用される: OS はあらゆる隣接 product ニーズを吸収してはならない。吸収された機能はそれぞれ、OS が何かしらドメイン固有あるいは consumer 固有のことを知ることを要求し、Reyn を拡張可能にしている抽象を破壊する。
 
-したがって care boundary は上述の LLM-behavior split だけを意味するのではない — 上位 product が自分で build すべきものの下方限界も定義する。Reyn を基盤として使えるほど小さく保つことが、基盤としての有用性を守る。analytics platform であり deployment runtime であり eval service でもある OS は、あらゆる場面でワークフロー固有の知識を必要とし — P7 違反の連鎖を生む。
+したがって care boundary は上述の LLM-behavior split だけを意味するのではない — 上位 product が自分で build すべきものの下方限界も定義する。Reyn を基盤として使えるほど小さく保つことが、基盤としての有用性を守る。analytics platform であり deployment runtime であり eval service でもある OS は、あらゆる場面でドメイン固有の知識を必要とし — P7 違反の連鎖を生む。
 
 ### Landscape からの具体例
 
@@ -181,7 +181,7 @@ pre-1.0 の安定性注意書きが適用される: これらの contract はま
 
 ### contributor へのソフトな境界線
 
-新機能を評価するとき、問う: 「これを提供するために Reyn はワークフロー固有あるいは consumer 固有のことを知る必要があるか?」
+新機能を評価するとき、問う: 「これを提供するために Reyn はドメイン固有あるいは consumer 固有のことを知る必要があるか?」
 
 もし yes なら — 「成功した会話」が何を意味するかを OS が理解する必要がある、あるいはどの consumer のためにどの event を集計するかを知る必要がある、あるいはどの deployment 環境にどの retry policy が合うかを知る必要がある — それは downstream layer に属し、OS には属さない。これはニーズの否定ではない; 責任の正しい割り当てだ。OS が primitive を提供し、downstream layer が product を提供する。
 

--- a/docs/concepts/architecture/care-boundary.md
+++ b/docs/concepts/architecture/care-boundary.md
@@ -145,9 +145,9 @@ These primitives are sufficient for a range of downstream products that the LLM-
 
 ### Why this is intentional, not accidental
 
-P7 says OS code must not contain workflow-specific strings. The same logic extends one level up: the OS must not absorb every adjacent product need. Each absorbed feature would require the OS to know something workflow-specific or consumer-specific in order to provide it, defeating the abstraction that makes Reyn extensible.
+P7 says OS code must not contain domain-specific strings. The same logic extends one level up: the OS must not absorb every adjacent product need. Each absorbed feature would require the OS to know something domain-specific or consumer-specific in order to provide it, defeating the abstraction that makes Reyn extensible.
 
-The care boundary is therefore not just about the LLM-behavior split described above — it also defines the downward limit of what upstream products are expected to build themselves. Keeping Reyn small enough to be a foundation is what preserves the foundation's usefulness. An OS that tries to be the analytics platform, the deployment runtime, and the eval service simultaneously would need workflow-specific knowledge at every turn — a cascade of P7 violations.
+The care boundary is therefore not just about the LLM-behavior split described above — it also defines the downward limit of what upstream products are expected to build themselves. Keeping Reyn small enough to be a foundation is what preserves the foundation's usefulness. An OS that tries to be the analytics platform, the deployment runtime, and the eval service simultaneously would need domain-specific knowledge at every turn — a cascade of P7 violations.
 
 ### Concrete examples from the landscape
 
@@ -181,7 +181,7 @@ The pre-1.0 stability caveat applies: these contracts are not yet frozen. But th
 
 ### A soft boundary line for contributors
 
-When evaluating a proposed feature, ask: "Does providing this require Reyn to know workflow-specific or consumer-specific things?"
+When evaluating a proposed feature, ask: "Does providing this require Reyn to know domain-specific or consumer-specific things?"
 
 If yes — if the feature would require the OS to understand what a "successful conversation" means, or which events to aggregate for which consumer, or what retry policy fits which deployment environment — it belongs in a downstream layer, not in the OS. That is not a rejection of the need; it is a correct assignment of responsibility. The OS provides the primitive; the downstream layer provides the product.
 

--- a/docs/concepts/architecture/llm-invocation-surfaces.ja.md
+++ b/docs/concepts/architecture/llm-invocation-surfaces.ja.md
@@ -189,7 +189,7 @@ Type B には Option 2 の役割分離を採用しつつ、3つの Type C conven
 
 **P4（LLM は制約された決定エンジン）** — 両 invocation kind は厳選された candidate set を提示する。router LLM は `build_tools()` で組み立てられた固定ツールリストを見る。Phase LLM は Phase の `allowed_ops` から構築された `available_control_ops` を見る。Doctrine は各 kind がどの候補を見るかについてであり、P4 は両側に等しく適用される。
 
-**P7（OS はワークフローに依存しない）** — どちらの surface もワークフロー固有の知識を埋め込むべきではない。stdlib ワークフローを通じて Type C ギャップを閉じる（Option 3 パス）ことで P7 を保全する — OS は汎用の `memory` op や `run_skill` 機構を公開し、ワークフローオーサーがそれを使用するかどうかを決める。ワークフロー固有のメモリキーやカタログパスを OS 層に埋め込むことは P7 違反となる。
+**P7（OS はドメインに依存しない）** — どちらの surface もドメイン固有の知識を埋め込むべきではない。stdlib ワークフローを通じて Type C ギャップを閉じる（Option 3 パス）ことで P7 を保全する — OS は汎用の `memory` op や `run_skill` 機構を公開し、ワークフローオーサーがそれを使用するかどうかを決める。ドメイン固有のメモリキーやカタログパスを OS 層に埋め込むことは P7 違反となる。
 
 ---
 

--- a/docs/concepts/architecture/llm-invocation-surfaces.md
+++ b/docs/concepts/architecture/llm-invocation-surfaces.md
@@ -191,7 +191,7 @@ Adopt Option 2's role separation for Type B, but explicitly close the three Type
 
 **P4 (LLM is a constrained decision engine)** — both invocation kinds present a curated candidate set. The router LLM sees a fixed tool list assembled by `build_tools()`. The phase LLM sees `available_control_ops` built from the phase's `allowed_ops`. Doctrine is about which candidates each kind sees; P4 applies to both sides equally.
 
-**P7 (OS workflow-agnostic)** — neither surface should embed workflow-specific knowledge. Closing Type C gaps via stdlib workflows (Option 3 path) preserves P7: the OS exposes a general `memory` op or `run_skill` mechanism; the workflow author decides whether to use it. Embedding workflow-specific memory keys or catalog paths in the OS layer would violate P7.
+**P7 (OS domain-agnostic)** — neither surface should embed domain-specific knowledge. Closing Type C gaps via stdlib workflows (Option 3 path) preserves P7: the OS exposes a general `memory` op or `run_skill` mechanism; the workflow author decides whether to use it. Embedding domain-specific memory keys or catalog paths in the OS layer would violate P7.
 
 ---
 

--- a/docs/guide/for-reyn-developers/add-an-op-kind.md
+++ b/docs/guide/for-reyn-developers/add-an-op-kind.md
@@ -10,9 +10,9 @@ This tutorial walks through adding a new op kind to the Reyn OS end-to-end.
 The goal is to make the 3-touch-point constraint tangible: after you finish,
 the OS dispatches your op, the linter validates it in workflow frontmatter, and
 the LLM sees its schema in the system prompt — all without touching any workflow
-files or adding workflow-specific strings anywhere.
+files or adding domain-specific strings anywhere.
 
-**P7 in practice.** The OS's workflow-agnostic guarantee (P7) is what makes this
+**P7 in practice.** The OS's domain-agnostic guarantee (P7) is what makes this
 possible. Op kind strings appear in exactly one place — `OP_KIND_MODEL_MAP` in
 `schemas/models.py`. Every other mechanism (`ALL_OP_KINDS`, the op dispatcher
 `execute_op`, the `reyn.tools` catalog) derives from that single source.
@@ -58,7 +58,7 @@ Op = Annotated[
 
 Rules for the model:
 - `kind` must be a `Literal["<your_kind>"]`. This is the discriminator field.
-- Field names must be generic (not workflow-specific) — `channel`, `message`,
+- Field names must be generic (not domain-specific) — `channel`, `message`,
   `severity` rather than `slack_channel`, `alert_text`, `reyn_severity`.
 - Default values for optional fields keep the LLM's minimal form short.
 
@@ -143,8 +143,8 @@ Handler conventions:
 - Catch exceptions and return `{"kind": op.kind, "status": "error", "error": str(exc)}`
   rather than raising — `execute_op` in `__init__.py` has a catch-all, but
   explicit handling produces cleaner events.
-- Never import workflow-specific modules or reference workflow-specific strings
-  (P7 — the OS must remain workflow-agnostic).
+- Never import domain-specific modules or reference domain-specific strings
+  (P7 — the OS must remain domain-agnostic).
 
 Then add the import to `src/reyn/core/op_runtime/__init__.py` so the module
 self-registers at startup:

--- a/docs/guide/for-reyn-developers/principles-and-code.md
+++ b/docs/guide/for-reyn-developers/principles-and-code.md
@@ -22,7 +22,7 @@ This page focuses on the *how*; the conceptual rationale is in CLAUDE.md.
 | P4 — LLM picks from candidates | `_build_candidates()` gates choices; normalizer rejects unknown | `context_builder.py`, `kernel/runtime.py` |
 | P5 — Workspace is SSoT | All writes go through `Workspace` with permission gate | `workspace/workspace.py`, `op_runtime/file.py` |
 | P6 — Events are audit truth | `EventLog` is append-only; state recovery reads events | `events/events.py`, `events/state_log.py` |
-| P7 — OS is workflow-agnostic | `OP_KIND_MODEL_MAP` is the only op catalogue; linter rejects workflow-specific strings | `op_runtime/registry.py`, `compiler/linter.py` |
+| P7 — OS is domain-agnostic | `OP_KIND_MODEL_MAP` is the only op catalogue; linter rejects domain-specific strings | `op_runtime/registry.py`, `compiler/linter.py` |
 | P8 — Instructions don't list fields | Schema is injected via `candidate_outputs`, not baked into instructions | `context_builder.py`, `kernel/runtime.py` |
 
 ---
@@ -127,7 +127,7 @@ output = normalizer.normalize(raw, allowed_candidates=candidates)
 
 ---
 
-## P7 — OS code contains no workflow-specific strings
+## P7 — OS code contains no domain-specific strings
 
 **What it means**: No phase name, artifact type, or domain-specific field name appears as a literal in OS code.
 
@@ -139,7 +139,7 @@ output = normalizer.normalize(raw, allowed_candidates=candidates)
 
 `kernel/control_ir_executor.py` — `_build_phase_tool_catalog()` derives the tool schema for the LLM *from the Pydantic model* (`OP_KIND_MODEL_MAP[kind]`), not from any hardcoded field list.
 
-**Detection rule (from CLAUDE.md)**: if a literal naming a specific phase, artifact type, or field appears in OS code — it's a P7 violation.
+**Detection rule (from CONTRIBUTING.md)**: if a literal naming a specific phase, artifact type, or field appears in OS code — it's a P7 violation.
 
 ---
 

--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -14,11 +14,12 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 
 ```json
 {
-  "ts": "2026-04-30T10:00:00.123Z",
-  "kind": "<event_kind>",
-  "phase": "<current_phase>",
-  "run_id": "<uuid>",
-  ... // kind 固有のペイロード
+  "type": "<event_kind>",
+  "timestamp": "2026-04-30T10:00:00.123456+00:00",
+  "data": {
+    ... // kind 固有のペイロード。発行元の EventLog が設定されていれば
+        // agent_id / run_id を含むことがある(下記参照)
+  }
 }
 ```
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -14,11 +14,12 @@ Every event has:
 
 ```json
 {
-  "ts": "2026-04-30T10:00:00.123Z",
-  "kind": "<event_kind>",
-  "phase": "<current_phase>",
-  "run_id": "<uuid>",
-  ... // kind-specific payload
+  "type": "<event_kind>",
+  "timestamp": "2026-04-30T10:00:00.123456+00:00",
+  "data": {
+    ... // kind-specific payload; may include agent_id / run_id when the
+        // emitting EventLog was configured with them (see below)
+  }
 }
 ```
 


### PR DESCRIPTION
**[docs-maintainer]** — owner-approved dispatch (via lead-coder), following the src-side #2538 reword. Wording-only fix; the P7 invariant itself is unchanged.

## Scope correction (confirmed with lead-coder before editing)
The dispatch originally named `CLAUDE.md` and `docs/concepts/architecture/principles.md` — neither exists with this content (`CLAUDE.md` has zero P7 mentions; `principles.md` doesn't exist at all). The actual normative P7 definitions live in `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`. Confirmed with lead-coder before touching anything.

## Files (8 — 6 confirmed by lead-coder + 2 JA-parity files found in the same pass)
- **`CONTRIBUTING.md`** / **`.github/PULL_REQUEST_TEMPLATE.md`** — the two files that actually define P7 ("OS code must not contain skill-specific strings"). Also removed `CONTRIBUTING.md`'s dangling "read the detection guidance in `CLAUDE.md`" pointer (verified zero P7 content in `CLAUDE.md`) in favor of the detection rule already stated inline in the same sentence.
- **`docs/guide/for-reyn-developers/principles-and-code.md`** — its own dedicated "P7 — OS code contains no workflow-specific strings" section (heading + quick-reference table row + body). Also fixed the same dangling "(from CLAUDE.md)" attribution on its detection rule to point at `CONTRIBUTING.md` instead, since that's where P7 is actually defined (also lead-coder-confirmed, since it's the same P7 section already being touched).
- **`docs/concepts/architecture/care-boundary.md`/`.ja.md`**, **`llm-invocation-surfaces.md`/`.ja.md`**, **`docs/guide/for-reyn-developers/add-an-op-kind.md`** — "workflow-specific" → "domain-specific" (same underlying P7 vocabulary, different word choice than "skill-specific"). The two `.ja.md` files had the same drift (「ワークフロー固有」) not originally listed in the dispatch — found via grep in the same pass, fixed for EN/JA parity (same class as earlier PR-B/PR-A findings this arc).

## Explicitly out of scope (flagged, not touched)
Per lead-coder direction, this PR touches **only the P7 wording**, not other stale content in the same files:
- `add-an-op-kind.md`'s "none in any workflow" prose
- `principles-and-code.md`'s own "the conceptual rationale is in CLAUDE.md" pointer (line 11)
- `CONTRIBUTING.md`'s dangling `docs/concepts/principles.md` link (line 91 — points to a file that doesn't exist)
- `.github/PULL_REQUEST_TEMPLATE.md`'s separate "P1-P8 invariants respected (see `CLAUDE.md`)" line — same CLAUDE.md-attribution-drift class as the ones fixed here, but a different bullet not part of the specific P7 rewording

Lead-coder noted there may be more "CLAUDE.md reference drift" elsewhere in the docs tree — out of scope here, to be grepped and flagged separately if found.

## History docs (KEEP, untouched)
`decisions/`/`journal/`/`proposals/`/`research/` mentions of "skill-specific" are historical record — not touched, per keep-history convention.

## CI gates (local)
- `ruff check src tests` — pass
- `pytest tests/test_fp0036_coverage.py` — 23/23 pass
- `mkdocs build --strict` (from `.mkdocs/`) — exit 0, no warnings

## Test plan
- [x] `mkdocs build --strict` exit 0
- [x] fp0036 mirror tests green (23/23)
- [x] ruff clean
- [x] exhaustive re-grep for `skill-specific`/`workflow-specific`/`ワークフロー固有` across all 8 touched files — zero remaining