### PR TITLE
refactor(skill-word): T4 — schemas/config/api/kernel skill-tail

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -1,7 +1,7 @@
 """reyn — Agent OS package root.
 
 This ``__init__`` performs NO eager imports, so importing a *submodule* —
-notably ``reyn.core.kernel._python_harness``, the python preprocessor-step child
+notably ``reyn.core.kernel._codeact_harness``, the CodeAct sandbox child-process
 entry point — does not pull the agent / llm / httpx chain in through the package
 root. (FP-0008 C4: keeping the harness cold-import path well under the
 python-step timeout.)

--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -37,8 +37,8 @@ After permission grants, ``read`` performs a single full read and
 permission-checked. The permission contract is "may read this path",
 not "may read these bytes".
 
-Permission context is injected by the python harness
-(``src/reyn/kernel/_python_harness.py``) before the user step runs.
+Permission context is injected by the codeact harness
+(``src/reyn/core/kernel/_codeact_harness.py``) before the user step runs.
 Calling these functions outside that context (= bare unit test, ad-hoc
 script) raises a clear ``PermissionError`` explaining how to set up the
 context — see :func:`_set_permission_context` below.
@@ -117,7 +117,7 @@ def _set_permission_context(
 ) -> None:
     """Wire permission paths into this module.
 
-    Called by :mod:`reyn.core.kernel._python_harness` before the user step
+    Called by :mod:`reyn.core.kernel._codeact_harness` before the user step
     runs. Tests that exercise the file API directly may call this to
     establish a controlled context; production code should not.
 

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -19,7 +19,7 @@ skills keep working without an explicit ``http.get`` declaration.
 
 Mirrors :mod:`reyn.api.safe.file`'s permission-context contract: the
 parent process configures the allowlist via :func:`_set_permission_context`
-before the user step runs; the python harness wires that.
+before the user step runs; the codeact harness wires that.
 
 Internal layering
 -----------------
@@ -52,7 +52,7 @@ from reyn._ssrf_pin import _PinnedHTTPHandler, _PinnedHTTPSHandler
 
 # ── Internal state ─────────────────────────────────────────────────────────
 #
-# Set once at python harness start-up via :func:`_set_permission_context`.
+# Set once at codeact harness start-up via :func:`_set_permission_context`.
 # Used by :func:`_check_host` to gate every outbound call. Mirrors
 # ``reyn.api.safe.file``'s module-globals contract.
 
@@ -66,7 +66,7 @@ def _set_permission_context(
 ) -> None:
     """Wire the host allowlist into this module.
 
-    Called by :mod:`reyn.core.kernel._python_harness` before the user step
+    Called by :mod:`reyn.core.kernel._codeact_harness` before the user step
     runs. Tests that exercise the http API directly may call this to
     establish a controlled context; production code should not.
 

--- a/src/reyn/core/__init__.py
+++ b/src/reyn/core/__init__.py
@@ -6,9 +6,7 @@ group (``reyn.data``) and the surface group (``reyn.interfaces``):
 
 - ``kernel``      — context build, LLM call, validation, transitions
 - ``op_runtime``  — Control IR op catalog and dispatch
-- ``compiler``    — skill/phase DSL compilation
-- ``plan``        — phase-graph planning
-- ``registry``    — skill/phase resolution
+- ``registry``    — MCP server registry client and cache
 - ``events``      — append-only event log + replay (P6 audit truth)
 
 This package node is import-only; it deliberately exports nothing so the

--- a/src/reyn/core/kernel/__init__.py
+++ b/src/reyn/core/kernel/__init__.py
@@ -1,7 +1,7 @@
-"""kernel — code-execution runtime submodules (codeact + python-step harness).
+"""kernel — code-execution runtime submodules (codeact harness).
 
 This ``__init__`` performs NO eager imports, so importing a *submodule* —
-notably ``reyn.core.kernel._python_harness``, the python preprocessor-step child
+notably ``reyn.core.kernel._codeact_harness``, the CodeAct sandbox child-process
 entry point — does not pull any heavier chain in through this package root.
 Submodule imports (``from reyn.core.kernel.codeact_runner import CodeActRunner``,
 ``from reyn.core.kernel.sub_loop_memo_key import ...``) are used directly and are


### PR DESCRIPTION
**[lead-sonnet]** — T4 skill-word tail sweep: reword 5 stale docstrings pointing to the deleted `_python_harness` subprocess path and prune a dead subpackage listing.

part of #2434

## Decision table

| file:line | text | decision | reason |
|-----------|------|----------|--------|
| `src/reyn/__init__.py:4` | `_python_harness`, the python preprocessor-step child entry point | REWORD → `_codeact_harness`, the CodeAct sandbox child-process entry point | `_python_harness` no longer has the subprocess entry (deleted with PythonRunner, #2537); `_codeact_harness` is the real child-process entry |
| `src/reyn/core/kernel/__init__.py:1` | `codeact + python-step harness` | REWORD → `codeact harness` | same: no python-step subprocess harness remains |
| `src/reyn/core/kernel/__init__.py:4` | `_python_harness`, the python preprocessor-step child entry point | REWORD → `_codeact_harness`, the CodeAct sandbox child-process entry point | same |
| `src/reyn/api/safe/http.py:22` | `the python harness wires that` | REWORD → `the codeact harness wires that` | _codeact_harness is the actual caller now |
| `src/reyn/api/safe/http.py:55` | `Set once at python harness start-up` | REWORD → `codeact harness start-up` | same |
| `src/reyn/api/safe/http.py:69` | `Called by :mod:reyn.core.kernel._python_harness` | REWORD → `_codeact_harness` | `_python_harness` is now AST helper only; not the permission-wiring subprocess |
| `src/reyn/api/safe/file.py:40-41` | `injected by the python harness (src/reyn/kernel/_python_harness.py)` | REWORD → `codeact harness (src/reyn/core/kernel/_codeact_harness.py)` | stale path + stale harness name |
| `src/reyn/api/safe/file.py:120` | `Called by :mod:reyn.core.kernel._python_harness` | REWORD → `_codeact_harness` | same |
| `src/reyn/core/__init__.py:9` | `compiler — skill/phase DSL compilation` | DELETE (dead subpackage entry) | `reyn.core.compiler` does not exist |
| `src/reyn/core/__init__.py:10` | `plan — phase-graph planning` | DELETE (dead subpackage entry) | `reyn.core.plan` does not exist |
| `src/reyn/core/__init__.py:11` | `registry — skill/phase resolution` | REWORD → `MCP server registry client and cache` | `reyn.core.registry` is the MCP registry HTTP client, not skill/phase resolver |

### KEEP (accurate domain descriptions / P7 comments)
- `src/reyn/api/safe/__init__.py:15,21` — accurate description of permission model
- `src/reyn/api/safe/cache.py:4,19-21` — accurate cross-skill cache description
- `src/reyn/api/safe/file.py:174,253` — user-facing error messages referencing skill.md (accurate)
- `src/reyn/api/safe/http.py:11,18,112` — user-facing permission error + domain-accurate doc
- `src/reyn/api/safe/mcp/registry.py:3` — accurate description of purpose
- `src/reyn/config/root.py:271` — accurate config description
- `src/reyn/core/dispatch/dispatcher.py:34,37` — comments only (see FLAG below for Literal)
- `src/reyn/core/events/agent_snapshot.py:101` — accurate user-facing warning
- `src/reyn/core/events/event_schema.py:71` — P7-accurate comment
- `src/reyn/core/offload/seam.py:19` — accurate-history comment about on-hold phase path
- `src/reyn/core/registry/client.py:106` — accurate description of safe-mode lookup
- `src/reyn/data/memory/memory.py:161` — accurate-history: CLI vs Control IR write path
- `src/reyn/data/workspace/artifact_validator.py:145,190` — P7 note (correct)
- `src/reyn/data/workspace/workspace.py:24,26` — accurate description
- `src/reyn/dev/dogfood/coverage.py:206` — runtime string value in data dict (not stale)
- `src/reyn/environment/container_backend.py:27` / `container_launcher.py:26` — P7 assertions (accurate)
- `src/reyn/hooks/schema.py:8` — accurate-history note re: removed hook points
- `src/reyn/llm/llm.py:1241,1417-1418` — accurate LLM capability/event comments
- `src/reyn/schemas/models.py:56,201,203,224,331` — accurate schema documentation
- `src/reyn/services/compaction/engine.py:706,736,814` — accurate description of catalog reloads
- `src/reyn/services/offload/store.py:7,222` — P7 assertions (accurate)
- `src/reyn/services/turn_budget/engine.py:43` — P7 assertion (accurate)
- `src/reyn/task/backend.py:15-16` — accurate architectural explanation
- `src/reyn/tools/__init__.py:142,199` — accurate comments re: describe_skill mirror + no-spawn
- `src/reyn/tools/cron.py:64` — live tool description string (accurate)
- `src/reyn/tools/hooks.py:16,123-124` — accurate permission/tool description
- `src/reyn/tools/reyn_src.py:5` — accurate audience framing
- `src/reyn/tools/schemes/universal_category.py:16` — accurate invoke_skill reference (op name, still valid)
- `src/reyn/tools/universal_dispatch.py:29` — accurate catalog description
- `src/reyn/_ssrf_guard.py:19` — accurate description of caller types
- `src/reyn/user_intervention.py:188` — accurate description of ask_user op

### FLAG for human lead (on-disk / WAL / event-key names — do not rename without audit)
- `src/reyn/data/embedding/sentence_transformers_provider.py:71,226,291` — `skill_done` event kind: emitted to audit log as `embedding_skill_done`; rename needs event-schema migration consideration
- `src/reyn/reporters/__init__.py:168` — `skill_path` dict key: read from event data payload; on-disk schema field
- `src/reyn/core/events/event_store.py:41` — `_skill_router` filename suffix: appears in on-disk event filenames
- `src/reyn/core/dispatch/dispatcher.py:47` — `Literal["router", "skill_phase"]` caller_kind: emitted to event log as `caller_kind` field; diverges from `tools/types.py` which uses `"phase"` — possible inconsistency worth investigating

## Files taken (T4 scope)
T4 = everything NOT in T1 (security/permissions), T2 (runtime/events/workspace/WAL/recovery), T3 (mcp/interfaces).

Changed: `src/reyn/__init__.py`, `src/reyn/api/safe/file.py`, `src/reyn/api/safe/http.py`, `src/reyn/core/__init__.py`, `src/reyn/core/kernel/__init__.py`

Reviewed and kept unchanged: `src/reyn/api/safe/`, `src/reyn/config/`, `src/reyn/core/dispatch/`, `src/reyn/core/events/`, `src/reyn/core/offload/`, `src/reyn/core/registry/`, `src/reyn/data/`, `src/reyn/dev/`, `src/reyn/environment/`, `src/reyn/hooks/`, `src/reyn/llm/`, `src/reyn/reporters/`, `src/reyn/schemas/`, `src/reyn/services/`, `src/reyn/task/`, `src/reyn/tools/`, `src/reyn/user_intervention.py`, `src/reyn/_ssrf_guard.py`

## Test plan
- [x] `ruff check src tests` — passed
- [x] `python scripts/verify_module_docstrings.py <changed files>` — passed
- [x] `pytest` — 6808 passed, 10 pre-existing failures (missing `mcp` package), 30 skipped; pre-existing failures confirmed identical on origin/main
- [x] (skipped — no test files changed, tier audit not applicable)