### PR TITLE
refactor(skill-word): T3 — mcp/interfaces skill-tail

### DIFF
--- a/src/reyn/api/safe/mcp/registry.py
+++ b/src/reyn/api/safe/mcp/registry.py
@@ -1,6 +1,6 @@
 """Back-compat shim (#1682): the MCP registry-lookup impl moved to
 ``reyn.mcp.registry``. ``reyn.api.safe.mcp.registry`` remains as the public allowlist
-surface for skills (FP-0042) — mirroring how ``reyn.api.safe.cache`` re-exports
+surface for safe-mode python steps (FP-0042) — mirroring how ``reyn.api.safe.cache`` re-exports
 ``reyn.core.registry.cache``. Repointing the allowlist + removing this shim is part of
 the separate safe/ cleanup (#1).
 

--- a/src/reyn/interfaces/chainlit_app/adapter.py
+++ b/src/reyn/interfaces/chainlit_app/adapter.py
@@ -24,7 +24,7 @@ Kind coverage:
 - anything else            → author "ℹ system", type "system_message"
 
 The author labels carry visible emoji prefixes so the chainlit UI
-renders distinct avatars + glyphs for the tool / system / skill
+renders distinct avatars + glyphs for the tool / system / status
 streams — without the prefix every author got the same generic
 auto-avatar and tool rows looked indistinguishable from assistant
 prose (user dogfood 2026-05-25 observation).
@@ -93,7 +93,7 @@ _AUTHOR_FALLBACK = "ℹ system"
 # #1642: char caps (NOT byte — multibyte/JA-safe; Python str slicing is char-based)
 # so a large arg/result doesn't fill the conversation (full content out of scope for
 # this inline row). args ~120 / result ~200 per lead; cross-surface-aligned with the
-# TUI renderer (skill_activity.py). _TOOL_VALUE_LIMIT caps one arg value so a single
+# TUI renderer. _TOOL_VALUE_LIMIT caps one arg value so a single
 # big arg can't dominate the whole-args preview.
 _TOOL_ARGS_LIMIT = 120
 _TOOL_RESULT_LIMIT = 200

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -16,7 +16,7 @@ PoC scope (= explicitly out of scope for this PR, follow-ons):
   no ``cl.AskUserMessage`` round-trip wiring yet.
 - streaming: ``__stream_*__`` incremental frames are dropped; only the
   final ``agent`` kind reaches the browser.
-- skill selection / per-agent attach / cost panel: none of the right-panel
+- per-agent attach / cost panel: none of the right-panel
   TUI affordances exist; only the central chat thread.
 """
 from __future__ import annotations
@@ -730,8 +730,8 @@ async def _on_settings_update(settings: dict) -> None:
     """Apply the gear-icon settings panel updates to the attached session.
 
     Currently only handles ``output_language``. Future per-session knobs
-    (= e.g. ``REYN_CHAINLIT_HISTORY_CAP`` mid-session change, allowed
-    skill filter) plug into this same dispatcher.
+    (= e.g. ``REYN_CHAINLIT_HISTORY_CAP`` mid-session change, tool
+    filter) plug into this same dispatcher.
     """
     registry = await _get_or_build_registry()
     session = _current_session()

--- a/src/reyn/interfaces/chainlit_app/intervention.py
+++ b/src/reyn/interfaces/chainlit_app/intervention.py
@@ -5,7 +5,7 @@ The reyn-side ``UserIntervention`` carries one of two shapes:
   - **closed-set choices**: e.g. permission gates with
     ``[A]llow once / [B]lock``. Chainlit's ``AskActionMessage`` is the
     right surface (= clickable buttons, no free-text needed).
-  - **free-text**: e.g. ``ask_user`` skill ops with optional
+  - **free-text**: e.g. ``ask_user`` ops with optional
     suggestions. Chainlit's ``AskUserMessage`` (= input box prompt).
 
 This pure helper builds the structured args (= content string +
@@ -39,9 +39,9 @@ class InterventionPrompt:
       then answers via ``session._deliver_answer_to(iv, text,
       choice_id_override=...)``. ``None`` only for malformed meta —
       caller falls back to a plain-text render.
-    - ``run_id`` is the skill's run id when the IV originated from a
-      running skill (= ``ask_user``); ``None`` for permission gates
-      (= ``_prompt`` constructs IVs without a skill context). Not
+    - ``run_id`` is the agent turn run-id when the IV originated from
+      a running agent turn (= ``ask_user``); ``None`` for permission
+      gates (= ``_prompt`` constructs IVs without a turn context). Not
       used for answer dispatch — keep for diagnostic / future use.
     - ``content`` is the rendered text body (prompt + detail +
       suggestions hint, in that order).

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -76,7 +76,7 @@ def register(sub) -> None:
         action="store_true",
         default=False,
         help=(
-            "Skip restoring in-flight skill state from disk this run. "
+            "Skip restoring in-flight agent state from disk this run. "
             "Useful for debugging or starting a clean session without "
             "discarding the persisted state (it will be loaded on next run)."
         ),
@@ -86,7 +86,7 @@ def register(sub) -> None:
         action="store_true",
         default=False,
         help=(
-            "Wipe in-flight skill state (snapshots + WAL) before starting. "
+            "Wipe in-flight agent state (snapshots + WAL) before starting. "
             "Audit logs in .reyn/events/ are preserved. "
             "Asks for confirmation before deleting."
         ),
@@ -108,9 +108,10 @@ def register(sub) -> None:
     # resolver layer; the effective scope is bounded by the sandbox write_paths
     # ∩ (the env-backend's repo/workspace zone), so a non-interactive / scripted
     # agent can edit a working tree without a permission prompt but cannot escape
-    # it. General capability (any chat session), not domain-specific — unlike a
-    # skill run, a chat agent has no skill declaring `file.read`, so the flag
-    # grants both read and write (mirrors the eval path, eval_benchmark.py:742).
+    # it. General capability (any chat session), not domain-specific — the chat
+    # agent has no explicit `file.read` permission declaration (unlike the old
+    # skill-declared permission model), so the flag grants both read and write
+    # (mirrors the eval path, eval_benchmark.py:742).
     p.add_argument(
         "--grant-file-write",
         dest="grant_file_write",
@@ -320,7 +321,7 @@ def run(args: argparse.Namespace) -> None:
     budget_tracker = BudgetTracker(session_cfg.config.cost)
     # PR25: hydrate daily / monthly counters from the persistent ledger.
     budget_tracker.hydrate(project_root / ".reyn" / "state" / "budget_ledger.jsonl")
-    # R-D8: restore in-memory counters (per-agent / per-chain-skill) from
+    # R-D8: restore in-memory counters (per-agent / per-sub-agent) from
     # the state snapshot written by the previous run. Together with PR25
     # ledger hydration, this makes cap enforcement survive crash + restart.
     budget_state_path = project_root / ".reyn" / "state" / "budget_state.json"
@@ -412,7 +413,7 @@ def run(args: argparse.Namespace) -> None:
             hooks_config=session_cfg.config.hooks,  # #1800 slice 5b (pass-through, not bundled)
             # #2093: the uniform reyn.yaml-derived per-session config bundle (sandbox /
             # multimodal / action_retrieval / embedding / router / retry /
-            # op-loop-skills / tool-use-scheme) — one source point for all five sites.
+            # tool-use-scheme) — one source point for all five sites.
             factory_config=SessionFactoryConfig.from_config(session_cfg.config),
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
@@ -447,7 +448,7 @@ def run(args: argparse.Namespace) -> None:
         # the sole rehydration path (mcp_server.py:15-16); skipping it starts the
         # one-shot with an empty history. Otherwise a one-shot would inherit the
         # `default` agent's stale history (unrelated prior context → the agent
-        # recalled an old skill + hallucinated a fix with 0 edits). Interactive
+        # hallucinated a fix based on prior session context with 0 edits). Interactive
         # chat (no `fresh`) loads history as before. Scoping (env/exclude/grant) is
         # independent of history, so it is unaffected.
         if not getattr(args, "fresh", False):
@@ -479,8 +480,8 @@ def run(args: argparse.Namespace) -> None:
     skip_restore = getattr(args, "no_restore", False)
     if skip_restore:
         print(
-            "⚠ --no-restore: skill state on disk is NOT loaded this run. "
-            "Rerun without --no-restore to resume in-flight skills.",
+            "⚠ --no-restore: agent state on disk is NOT loaded this run. "
+            "Rerun without --no-restore to resume in-flight agent sessions.",
             file=sys.stderr,
         )
 

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -461,7 +461,7 @@ def run_serve(args: argparse.Namespace) -> None:
     timeout = float(getattr(args, "timeout", 60.0) or 60.0)
 
     async def _main() -> None:
-        # Replay WAL into per-agent snapshots so any stranded in-flight skills
+        # Replay WAL into per-agent snapshots so any stranded in-flight sessions
         # resume cleanly, the same as `reyn chat` startup. Schema mismatch
         # surfaces a clean stderr line and exits non-zero.
         from reyn.core.events.agent_snapshot import SchemaVersionError
@@ -482,7 +482,7 @@ def run_serve(args: argparse.Namespace) -> None:
 def run_search(args: argparse.Namespace) -> None:
     """Search the MCP registry and display results as a rich table.
 
-    This is a thin CLI wrapper over RegistryClient.search().  No LLM or skill
+    This is a thin CLI wrapper over RegistryClient.search().  No LLM
     invocation is required for the discovery step.
     """
     from reyn.core.registry.client import RegistryClient, RegistryError
@@ -712,7 +712,7 @@ def _run_install_from_source(
         config_permissions=perm_config,
         project_root=project_root,
         interactive=not non_interactive and sys.stdin.isatty(),
-        unsafe_python_allowed=True,  # OS-level install path, no user skill code
+        unsafe_python_allowed=True,  # OS-level install path, no user python step code
     )
 
     events = EventLog()

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -148,7 +148,7 @@ class ConsoleChatRenderer(ChatRenderer):
         kind_prefix = self._PREFIX.get(msg.kind, "")
         meta_prefix = _meta_prefix(msg.meta)
         # Inject meta prefix between kind tag and text so logs read
-        # "[trace] [skill_builder#abcd] phase started: ..."
+        # "[trace] [default#abcd] llm_called: ..."
         if kind_prefix:
             line = f"{kind_prefix} {meta_prefix}{msg.text}\n"
         else:
@@ -633,7 +633,7 @@ def format_inline_message(msg: OutboxMessage):
     # renders as literal text inside the agent markdown body.
     # Intervention is user-facing: suppress the cryptic run_id_short hash — the
     # user doesn't need disambiguation for a prompt that has one active caller.
-    # actor context (e.g. "[skill_builder] ") is still shown if present.
+    # actor context (e.g. "[default] ") is still shown if present.
     if kind == "intervention":
         actor = meta.get("actor")
         _pfx = f"[{actor}] " if actor else ""

--- a/src/reyn/interfaces/slash/budget.py
+++ b/src/reyn/interfaces/slash/budget.py
@@ -38,7 +38,7 @@ async def cost_cmd(session: "Session", args: str) -> None:
 async def budget_cmd(session: "Session", args: str) -> None:
     """``/budget`` (full breakdown) or ``/budget reset`` (clear counters).
 
-    ``reset`` clears per-process counters (agent tokens / cost, chain skill
+    ``reset`` clears per-process counters (agent tokens / cost, sub-agent
     calls, rate-limit window) but leaves daily / monthly counters alone —
     those auto-reset at period boundary and are backed by a persistent
     ledger that the user shouldn't be able to wipe via a chat command.

--- a/src/reyn/interfaces/slash/pending.py
+++ b/src/reyn/interfaces/slash/pending.py
@@ -165,7 +165,7 @@ async def _discard(session: "Session", supplied_id: str) -> None:
         # First invocation — show warning with iv context, require confirm.
         # Retrieve iv details from the stalled list for the warning line.
         kind_hint = ""
-        skill_hint = ""
+        summary_hint = ""
         try:
             ops = session.list_stalled_interventions()
             match = next(
@@ -174,14 +174,14 @@ async def _discard(session: "Session", supplied_id: str) -> None:
             )
             if match is not None:
                 kind_hint = getattr(match, "kind", "") or ""
-                skill_hint = getattr(match, "summary", "") or ""
+                summary_hint = getattr(match, "summary", "") or ""
         except Exception:  # noqa: BLE001 — best-effort
             pass
         context = ""
         if kind_hint:
             context = f" ({kind_hint}"
-            if skill_hint:
-                context += f": {skill_hint[:40]}"
+            if summary_hint:
+                context += f": {summary_hint[:40]}"
             context += ")"
         await reply(
             session,

--- a/src/reyn/interfaces/web/routers/agents.py
+++ b/src/reyn/interfaces/web/routers/agents.py
@@ -2,7 +2,7 @@
 
 Wraps AgentRegistry and AgentProfile. The gateway treats agent data as
 opaque structured values: it passes profile fields through without
-interpreting skill-domain semantics (P7).
+interpreting agent-domain semantics (P7).
 
 Routes:
     GET  /api/agents            — list all agents

--- a/src/reyn/interfaces/web/routers/permissions.py
+++ b/src/reyn/interfaces/web/routers/permissions.py
@@ -2,7 +2,7 @@
 
 Wraps .reyn/approvals.yaml (per-process permission approval store).
 All approval keys and values are passed through as-is (P7): the gateway
-never interprets the semantics of approval keys (which encode skill-name
+never interprets the semantics of approval keys (which encode actor
 and path scoping from the engine's permission system).
 
 Routes:

--- a/src/reyn/interfaces/web/routers/web_data.py
+++ b/src/reyn/interfaces/web/routers/web_data.py
@@ -19,8 +19,8 @@ Field populate strategy:
     PERMISSIONS       — approvals.yaml keys (live)
     COPY              — hardcoded en/ja full I18nKeys
 
-Per P7: no domain-specific strings in this module.  Agent names / skill
-names are read from disk and passed through opaquely.
+Per P7: no domain-specific strings in this module.  Agent names are
+read from disk and passed through opaquely.
 """
 from __future__ import annotations
 

--- a/src/reyn/mcp/registry.py
+++ b/src/reyn/mcp/registry.py
@@ -25,7 +25,7 @@ var from the parent process automatically.
 
 This mirrors the resolution chain used by
 :class:`reyn.core.registry.client.RegistryClient`, so both surfaces — the
-async op-handler client and this safe-mode skill-internal lookup —
+async op-handler client and this safe-mode python-step lookup —
 agree on which registries to try and in what order.
 
 Multi-registry semantics
@@ -41,11 +41,11 @@ URL fails the final error is re-raised.
 Threat model
 ------------
 
-Registry lookup remains an *ambient* operation from the skill author's
-perspective — there is no per-skill ``http.get`` declaration required
-for this module's surface. The URLs are operator-trusted via the env
-var / config; the operator setting them is what carries the
-authorisation, not the skill code that calls in.
+Registry lookup remains an *ambient* operation from the python-step
+author's perspective — there is no per-step ``http.get`` declaration
+required for this module's surface. The URLs are operator-trusted via
+the env var / config; the operator setting them is what carries the
+authorisation, not the step code that calls in.
 
 Internal layering
 -----------------
@@ -59,8 +59,8 @@ Public API (returned dict shape)
 --------------------------------
 
 Both ``search`` and ``lookup`` return plain dicts (= JSON-friendly, no
-dataclasses) so safe-mode skills can pass results through artifact
-boundaries without translation:
+dataclasses) so safe-mode python steps can pass results through
+artifact boundaries without translation:
 
 ::
 
@@ -141,7 +141,7 @@ class _SSRFRedirectHandler(urllib.request.HTTPRedirectHandler):
     """#1956 SSRF: re-validate the host (IP-deny) on each redirect hop. Registry
     URLs are operator-configured, but a malicious / compromised registry could
     redirect to an internal IP — Layer 2 stops that reach. No allowlist here
-    (operator URL, not a per-skill http.get axis)."""
+    (operator URL, not a per-step http.get axis)."""
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         _ssrf_guard.assert_fetch_host_allowed(

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -21,8 +21,8 @@ inline.  Pumping from the same task eliminates the anyio stdio-starvation
 failure mode (FP-0013 §ADR-A).
 
 P7: tool names + tool semantics are OS-level (agent / message). No
-domain-specific strings are baked in — what skills an agent runs in
-response to a message is its own internal decision.
+domain-specific strings are baked in — how the agent handles a message
+is its own internal decision.
 """
 from __future__ import annotations
 
@@ -45,13 +45,13 @@ if TYPE_CHECKING:
 DEFAULT_SEND_TIMEOUT_SECONDS: float = 60.0
 
 # Polling interval while waiting for the agent's run loop to drain its
-# inbox + finish any spawned skills. Small enough that latency feels
-# instant; large enough that the loop is essentially free.
+# inbox and return to idle. Small enough that latency feels instant;
+# large enough that the loop is essentially free.
 _IDLE_POLL_INTERVAL_SECONDS: float = 0.05
 
-# Brief grace period AFTER inbox is empty + skills are idle, before we
-# declare the turn done. Without it we can race the router and miss the
-# final ``kind="agent"`` outbox push.
+# Brief grace period AFTER inbox is empty, before we declare the turn
+# done. Without it we can race the router and miss the final
+# ``kind="agent"`` outbox push.
 _IDLE_GRACE_SECONDS: float = 0.05
 
 
@@ -122,8 +122,8 @@ async def _await_turn_complete(
 ) -> bool:
     """Wait until the agent has produced at least one new ``role="agent"``
     history entry past ``baseline`` AND the run loop is back to idle
-    (inbox empty + no running skills). Returns True on completion, False
-    on timeout.
+    (inbox empty, run loop back to idle). Returns True on completion,
+    False on timeout.
 
     The negative-signal-only approach (= "looks idle, no work in flight")
     used to false-positive: between ``submit_user_text`` returning and
@@ -656,7 +656,7 @@ async def _make_mcp_intervention_bus(
     """Build an MCP iv-observer for the duration of one ``send_to_agent``
     call (issue #270 Phase B).
 
-    issue #292 α extended to MCP: when a skill spawned via
+    issue #292 α extended to MCP: when a request handled via
     ``send_to_agent_impl`` emits a ``UserIntervention``, that iv lands
     in ``Session._interventions._active`` and ``handler.dispatch``
     awaits its future. Pre-#270 Phase B the MCP transport had no
@@ -702,8 +702,8 @@ class _MCPInterventionBus:
       - Pushes an iv-payload notification to the MCP peer (= the
         client that opened the ``send_to_agent`` request) so the
         peer's UI can render the question + collect the answer.
-      - Does NOT await ``iv.future``. The handler awaits on the
-        skill's behalf; the peer answers via the
+      - Does NOT await ``iv.future``. The handler awaits for the
+        in-flight turn; the peer answers via the
         ``answer_intervention`` MCP tool which routes to
         ``Session.answer_pending_intervention``.
 
@@ -982,7 +982,9 @@ async def serve_stdio(
     #   - experimental ``reyn.progress.skill_lifecycle``: PR #279 wired
     #     ``_MCPProgressBridge`` to subscribe chat_events + emit
     #     ``notifications/progress`` for phase_started / llm_called /
-    #     act_executed during send_to_agent.
+    #     act_executed during send_to_agent. Name is a legacy artifact
+    #     from the skill-based era; the key is a published wire-protocol
+    #     string so it is kept as-is for client compatibility.
     #   - experimental ``reyn.cancellation.cooperative``: PR #279 wired
     #     ``notifications/cancelled`` propagation through
     #     asyncio.CancelledError → in-flight agent turn interruption.

--- a/tests/test_budget_persistence.py
+++ b/tests/test_budget_persistence.py
@@ -2,7 +2,7 @@
 
 PR22's BudgetTracker is in-memory; PR25 added daily/monthly persistence
 via budget_ledger.jsonl. R-D8 closes the gap for the remaining
-in-memory counters (per-agent tokens/cost, per-chain-skill calls/tokens)
+in-memory counters (per-agent tokens/cost, per-sub-agent calls/tokens)
 so cap enforcement survives a crash + restart cycle.
 
 The state file (``.reyn/state/budget_state.json``) is overwritten

--- a/tests/test_chat_cli_flags.py
+++ b/tests/test_chat_cli_flags.py
@@ -2,7 +2,7 @@
 
 Two new flags exposed on ``reyn chat``:
   --no-restore      Skip restore_all this run (state stays on disk for next).
-  --reset           Wipe in-flight skill state (snapshots + WAL) before
+  --reset           Wipe in-flight agent state (snapshots + WAL) before
                     starting; events/ is preserved (P6 audit truth).
 
 Implementation is split between argparse (flag definition) and a helper


### PR DESCRIPTION
**[lead-sonnet]** — Batch T3 of the skill-word sweep (#2434). Final tail pass over mcp/ + interfaces/.

## Scope

Owned files: `mcp/server.py`, `mcp/registry.py`, `api/safe/mcp/registry.py`, `interfaces/cli/commands/mcp.py`, `interfaces/cli/commands/chat.py`, `interfaces/slash/*.py`, `interfaces/chainlit_app/*.py`, `interfaces/repl/*.py`, `interfaces/web/routers/*.py` (except `a2a.py`).

`interfaces/web/routers/a2a.py` — untouched (external A2A protocol `"skills"` field, separate keep).

## Per-occurrence decision table

| File | Line(s) | Decision | Rationale |
|------|---------|----------|-----------|
| `mcp/server.py` | 24 | REWORD | Module docstring P7 comment — "what skills an agent runs" → "how the agent handles a message" |
| `mcp/server.py` | 48–55 | REWORD | Idle-poll comments — `running_skills` counter no longer exists; idle is now inbox-only |
| `mcp/server.py` | 125 | REWORD | `_await_turn_complete` docstring — same idle-check reality |
| `mcp/server.py` | 659 | REWORD | IV bus docstring — "skill spawned via" → "request handled via" |
| `mcp/server.py` | 706 | REWORD | IV bus "awaits on the skill's behalf" → "awaits for the in-flight turn" |
| `mcp/server.py` | 982, 998 | KEEP (wire-protocol) | `reyn.progress.skill_lifecycle` is a published MCP experimental-capability key pinned by tests; rename = breaking change. Added legacy-name note. |
| `mcp/registry.py` | 28, 44–48, 62, 144 | REWORD | Docstring "skill-internal lookup / skill author / skill code / per-skill" → python-step equivalents |
| `api/safe/mcp/registry.py` | 3 | REWORD | Shim docstring "surface for skills" → "surface for safe-mode python steps" |
| `interfaces/cli/commands/chat.py` | 79, 89 | REWORD | User-facing `--no-restore` / `--reset` help text: "skill state" → "agent state" |
| `interfaces/cli/commands/chat.py` | 112 | REWORD | Comment about `file.read` permission model; added accurate-history note about old skill-declared model |
| `interfaces/cli/commands/chat.py` | 323 | REWORD | "per-chain-skill" → "per-sub-agent" |
| `interfaces/cli/commands/chat.py` | 415 | REWORD | "op-loop-skills" removed from factory-config bundle comment |
| `interfaces/cli/commands/chat.py` | 450 | REWORD | "recalled an old skill" → "hallucinated a fix based on prior session context" |
| `interfaces/cli/commands/chat.py` | 482–483 | REWORD | User-facing `--no-restore` warning: "skill state" / "in-flight skills" → "agent state" / "in-flight agent sessions" |
| `interfaces/cli/commands/mcp.py` | 464 | REWORD | "stranded in-flight skills" → "stranded in-flight sessions" |
| `interfaces/cli/commands/mcp.py` | 485 | REWORD | "No LLM or skill invocation" → "No LLM invocation" |
| `interfaces/cli/commands/mcp.py` | 715 | REWORD | "no user skill code" → "no user python step code" |
| `interfaces/slash/budget.py` | 41 | REWORD | "chain skill calls" → "sub-agent calls" |
| `interfaces/chainlit_app/adapter.py` | 27 | REWORD | "tool / system / skill streams" → "tool / system / status streams" |
| `interfaces/chainlit_app/adapter.py` | 96 | REWORD | Stale `skill_activity.py` reference (file deleted) → generic "TUI renderer" |
| `interfaces/chainlit_app/intervention.py` | 8 | REWORD | "ask_user skill ops" → "ask_user ops" |
| `interfaces/chainlit_app/intervention.py` | 42–44 | REWORD | "skill's run id / running skill / skill context" → agent-turn equivalents |
| `interfaces/chainlit_app/app.py` | 19 | REWORD | "skill selection / per-agent attach" → "per-agent attach" (skill selection is gone) |
| `interfaces/chainlit_app/app.py` | 734 | REWORD | "allowed skill filter" → "tool filter" |
| `interfaces/repl/renderer.py` | 151 | REWORD | Example log prefix `[skill_builder#abcd]` → `[default#abcd]` |
| `interfaces/repl/renderer.py` | 636 | REWORD | Example actor context `[skill_builder]` → `[default]` |
| `interfaces/slash/pending.py` | 168, 177, 183–184 | RENAME (var) | `skill_hint` local variable → `summary_hint` |
| `interfaces/web/routers/agents.py` | 5 | REWORD | "skill-domain semantics" → "agent-domain semantics" |
| `interfaces/web/routers/web_data.py` | 22–23 | REWORD | "Agent names / skill names" → "Agent names" |
| `interfaces/web/routers/web_data.py` | 160 | KEEP (accurate-history) | "former skill-based approach" — documents the removal |
| `interfaces/web/routers/permissions.py` | 5–6 | REWORD | "encode skill-name" → "encode actor" (verified approval keys encode actor, not skill name) |
| `tests/test_chat_cli_flags.py` | 5 | UPDATE | Sync docstring with updated `--reset` help text |
| `tests/test_budget_persistence.py` | 5 | UPDATE | Sync docstring ("per-chain-skill" → "per-sub-agent") |

## Test plan

- [x] `ruff check` — all changed files pass
- [x] `verify_module_docstrings.py` — all changed src files pass
- [x] `test_tier_audit.py --strict` — changed test files pass (14 tests, 0 violations)
- [x] `pytest tests/test_chat_cli_flags.py tests/test_budget_persistence.py tests/test_mcp_capability_advertising_271_m3.py` — 14 passed, 1 skipped
- [x] Full `pytest` — identical failure profile to main (10 failed / 8 errors, all pre-existing `mcp` module-not-found)
- [x] `a2a.py` — confirmed untouched

part of #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)