### PR TITLE
refactor(skill-word): T2 — runtime skill-tail (delete/rename/reword)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2092,7 +2092,7 @@ class AgentRegistry:
 
         On computation or rewrite failure, the exception is caught and
         logged; the next trigger naturally retries. We never let truncation
-        bubble up to disturb the caller's hot path (phase advance / skill
+        bubble up to disturb the caller's hot path (phase advance / run
         completion).
         """
         if self._state_log is None:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -934,7 +934,7 @@ def _build_hot_list_aliases(
         # external sites") and refuses, or hallucinates control-character
         # tool-call text. The FP-0034 D2 "hot list direct alias は full
         # schema 提供" intent is realised here for the passthrough
-        # categories; resource categories (skill__X / agent.peer__X /
+        # categories; resource categories (agent.peer__X /
         # mcp.tool__X.Y / memory_entry__X / rag_corpus__X) need per-
         # resource schema introspection and are out of scope for D2-min.
         rich = _operation_alias_metadata(name) or _resource_alias_metadata(
@@ -1377,7 +1377,7 @@ class RouterLoop:
         host = self.host
         # #1092 PR-A (FD1, ADR-0036): catalog-source REPLACE seam. A phase host
         # supplies its op tool catalog (allowed_ops via _build_phase_tool_catalog),
-        # which REPLACES chat-discovery — a phase has no skills/agents/mcp/universal
+        # which REPLACES chat-discovery — a phase has no actions/agents/mcp/universal
         # (#1212 PR3 decision A). getattr-fallback so chat / plan-step hosts (no such
         # method) keep the existing chat-discovery tool-build byte-identically.
         _phase_op_catalog_getter = getattr(host, "get_phase_op_catalog", None)
@@ -1537,7 +1537,7 @@ class RouterLoop:
                 # B38 W2: registry-existence check — filter names that pass
                 # structural validation but no longer resolve to a real action
                 # in the current session registry. Runs after get_top_n so
-                # RouterState (skill / mcp / agent registry) is available.
+                # RouterState (mcp / agent registry) is available.
                 _top_names = _filter_ghost_names_by_registry(
                     _top_names,
                     mcp_tool_map=_mcp_tool_map or None,
@@ -2100,7 +2100,7 @@ class RouterLoop:
                 if async_count:
                     # B55 R-7 (2026-05-25): non-plan async dispatch (=
                     # delegate_to_agent or other peer-async tools). Mirror
-                    # skill / plan spawn_ack format: `[task_spawned]
+                    # task / plan spawn_ack format: `[task_spawned]
                     # kind=agent ...` header + user-facing trailer so the
                     # SP TASK_SPAWNED rule covers this path too. Prior
                     # behaviour pushed a generic `status` row with no
@@ -2802,7 +2802,7 @@ class RouterLoop:
             caller_kind="router",
             router_state=rs,
             # #1673: thread the config-aware resolver so a tool handler that spawns
-            # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
+            # a sub-run hands the spawned OpContext a real resolver
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
             hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
@@ -3482,7 +3482,7 @@ class RouterLoop:
             caller_kind="router",
             router_state=rs,
             # #1673: thread the config-aware resolver so a tool handler that spawns
-            # a sub-run (invoke_skill) hands the spawned OpContext a real resolver
+            # a sub-run hands the spawned OpContext a real resolver
             # instead of resolver=None (→ literal "standard" → litellm BadRequestError).
             resolver=getattr(self.host, "resolver", None),
             hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -241,7 +241,7 @@ class InterventionHandler:
             from reyn.security.content_guard import fence_if_enabled
             history_text = fence_if_enabled(text, self._threat_scan)
         meta = {
-            "answered_skill": iv.actor or "",
+            "answered_actor": iv.actor or "",
             "answered_run_id": iv.run_id or "",
             "intervention_id": iv.id,
             "intervention_kind": iv.kind,
@@ -259,7 +259,7 @@ class InterventionHandler:
             intervention_id=iv.id,
             kind=iv.kind,
             run_id=iv.run_id,
-            skill=iv.actor,
+            actor=iv.actor,
             choice_id=choice.id if choice else None,
             answer_text=text if not iv.choices else "",
         )
@@ -268,8 +268,9 @@ class InterventionHandler:
     async def announce(self, iv: UserIntervention) -> None:
         """Format and publish an intervention to the outbox for the renderer.
 
-        Skill / run_id provenance lives in ``meta`` — the renderer prepends a
-        ``[skill#abcd]`` tag, so we don't repeat it in ``text``.
+        Actor / run_id provenance lives in ``meta`` — the renderer prepends a
+        ``[actor#abcd]`` tag via ``meta["actor"]`` + ``meta["run_id_short"]``,
+        so we don't repeat it in ``text``.
 
         Corresponds to session._announce_intervention.
         """

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1568,7 +1568,7 @@ class Session:
         )
 
         # #2073 S2: register the per-component hot-reload reapply seams now that the
-        # sub-components they orchestrate (skill_runner / router_host) exist. Each
+        # sub-components they orchestrate (router_host etc.) exist. Each
         # seam reapplies one IN-set component live at the turn boundary; the Session
         # owns + orchestrates them (the multi-holder per-agent swap is one method
         # here, not scattered captures). Hooks → S2b. Set validate-before-apply too.
@@ -3147,10 +3147,11 @@ class Session:
 
     def _register_hot_reload_seams(self) -> None:
         """Register the per-component reapply seams + validate-before-apply on the
-        HotReloader (#2073 S2). Called once at construction after skill_runner +
-        router_host exist. Each seam reapplies one IN-set component live at the turn
-        boundary; the Session orchestrates them (it owns the sub-components). Hooks =
-        S2b (global .reyn/hooks.yaml); per-agent-hooks add-on = a separate decision."""
+        HotReloader (#2073 S2). Called once at construction after router_host and
+        other sub-components exist. Each seam reapplies one IN-set component live at
+        the turn boundary; the Session orchestrates them (it owns the sub-components).
+        Hooks = S2b (global .reyn/hooks.yaml); per-agent-hooks add-on = a separate
+        decision."""
         hr = self._hot_reloader
         # validate-before-apply is the HotReloader's built-in structural check
         # (hot_reload.validate_in_set) — no per-Session override needed.
@@ -3284,8 +3285,8 @@ class Session:
 
     async def _reapply_per_agent_capability(self, in_set: dict) -> bool:
         """Reapply the per-agent capability (#2073 S2) — Session-orchestrated. Re-read
-        .reyn/agents/<name>/profile.yaml and update the per-agent allowlists on the 3
-        holders the Session owns (itself / skill_runner / router_host) from the new
+        .reyn/agents/<name>/profile.yaml and update the per-agent allowlists on the
+        holders the Session owns (itself / router_host) from the new
         AgentProfile (the #2074 unified per-agent spec). No profile / no change →
         no-op. (Single-source-of-truth is a beauty-follow-up, out of hot-reload scope.)"""
         from reyn.runtime.profile import AgentProfile
@@ -4630,7 +4631,7 @@ class Session:
         # Branch 3: user_channel — emit route decision + delegate to
         # ``_dispatch_intervention``. issue #268 Phase 2 continuation
         # moved the origin-pin stall check INTO ``_dispatch_intervention``
-        # so it fires uniformly for the bus-emit path too (= skill
+        # so it fires uniformly for the bus-emit path too (= an op
         # ask_user via ChatInterventionBus.deliver bypasses
         # ``handle_intervention``); when the check fires, it emits its
         # own ``user_channel_stalled`` event so the audit trail remains
@@ -4777,7 +4778,7 @@ class Session:
         self, *, chain_id: str, peer: str, reason: str,
     ) -> None:
         """R-D14: AgentRegistry calls this when a peer agent's
-        skill_run for ``chain_id`` was discarded by the user.
+        run for ``chain_id`` was discarded by the user.
 
         Mirrors ``_on_chain_timeout_fire`` but for the discard path:
         force-resolves the pending chain immediately, emits a
@@ -4794,7 +4795,7 @@ class Session:
         waiting = sorted(pending.waiting_on)
         error_text = (
             f"chain interrupted: peer agent {peer!r} discarded its "
-            f"skill_run ({reason}); waiting_on={waiting}"
+            f"run ({reason}); waiting_on={waiting}"
         )
         self._chat_events.emit(
             "chain_peer_discarded",

--- a/tests/test_untrusted_profile_1827_s4.py
+++ b/tests/test_untrusted_profile_1827_s4.py
@@ -74,7 +74,7 @@ def test_load_untrusted_malformed_falls_back_to_builtin(tmp_path: Path):
 def test_metas_have_untrusted_detects_marker():
     """Tier 2: the marker is detected regardless of which seam stamped it."""
     assert metas_have_untrusted([{"x": 1}, {UNTRUSTED_META_KEY: True}]) is True
-    assert metas_have_untrusted([{"x": 1}, {"answered_skill": "s"}]) is False
+    assert metas_have_untrusted([{"x": 1}, {"answered_actor": "s"}]) is False
     assert metas_have_untrusted([]) is False
     assert metas_have_untrusted(None) is False  # non-iterable is safe
 


### PR DESCRIPTION
**[lead-sonnet]** — Final skill-word sweep over the 7 owned runtime files.

## Summary

- **intervention_handler.py**: rename `skill=` event field → `actor=` in `user_answered_intervention` (no live consumers of the old field); rename history meta key `answered_skill` → `answered_actor`; reword `announce()` docstring from `[skill#abcd]` to `[actor#abcd]` (matches the live `_meta_prefix` renderer)
- **router_loop.py**: drop dead `skill__X` resource category from comment (no live producer in codebase); reword `skills/agents/mcp/universal` → `actions/agents/mcp/universal` in phase catalog comment; drop stale `skill` from `RouterState` comment (no `skill_registry` field on `RouterCallerState`); replace `invoke_skill` (file removed) with generic `"sub-run"` in two `#1673` resolver comments; reword `skill/plan spawn_ack` → `task/plan spawn_ack`
- **session.py**: reword three `skill_runner/router_host` construction comments (SkillRunner removed stage1 decouple); reword `"skill ask_user"` → `"op ask_user"` in Branch 3 comment; rename `skill_run` → `run` in docstring and error message of `_on_chain_peer_discarded`; keep two accurate-history comments (`Skill-execution removed` / `SkillRunner removed`)
- **registry.py**: reword `"skill completion"` → `"run completion"` in truncation docstring
- **tests**: update `answered_skill` example key → `answered_actor` in `test_metas_have_untrusted_detects_marker`

## Decision table

| File | Location | Kind | Verdict | Evidence |
|------|----------|------|---------|----------|
| intervention_handler.py | L244 `answered_skill` meta key | LIVE WORDING | RENAME → `answered_actor` | No consumer reads this key (grep: single write site + one negative test) |
| intervention_handler.py | L262 `skill=iv.actor` event field | LIVE WORDING | RENAME → `actor=iv.actor` | No consumer reads `skill` from `user_answered_intervention` |
| intervention_handler.py | L271 `[skill#abcd]` comment | LIVE WORDING | REWORD | Live renderer uses `meta["actor"]`, not a `skill` field |
| router_loop.py | L937 `skill__X` category | DEAD NAME | DELETE from comment | No `skill__` qualified name exists anywhere in codebase |
| router_loop.py | L1380 `skills/agents/mcp` | LIVE WORDING | REWORD | Skills removed; current catalog has `actions/agents/mcp` |
| router_loop.py | L1476 `Skill enumeration removed` | ACCURATE HISTORY | KEEP | Correctly describes the stage1 decouple removal |
| router_loop.py | L1540 `skill / mcp / agent registry` | LIVE WORDING | REWORD | `RouterCallerState` has no `skill_registry` field |
| router_loop.py | L2103 `skill / plan spawn_ack` | LIVE WORDING | REWORD | No skill spawn path; task/plan is current |
| router_loop.py | L2805, L3485 `invoke_skill` | DEAD REFERENCE | REWORD | `src/reyn/tools/invoke_skill.py` was removed |
| session.py | L1571, L3150, L3288 `skill_runner` | LIVE WORDING | REWORD | SkillRunner removed (stage1 decouple) |
| session.py | L2535 `Skill-execution machinery removed` | ACCURATE HISTORY | KEEP | Correctly describes current state |
| session.py | L3908 `SkillRunner removed` | ACCURATE HISTORY | KEEP | Correct removal notice |
| session.py | L4633 `skill ask_user` | LIVE WORDING | REWORD → `op ask_user` | ask_user is now an op, not skill machinery |
| session.py | L4780, L4797 `skill_run` | LIVE WORDING | REWORD → `run` | No skill_run concept; this is a peer agent's run |
| registry.py | L100, L1170 `no skill/domain strings` | ACCURATE P7 METADATA | KEEP | Correctly describes what WAL_EVENT_KINDS excludes |
| registry.py | L2095 `skill completion` | LIVE WORDING | REWORD → `run completion` | No skill completion concept |

## WAL/on-disk flagged for lead judgment

`skill_run` as a WAL tree directory name — grep found no live producer in the 7 owned files or `src/reyn/core/`. The only references are in `runtime/services/chain_manager.py` and `runtime/services/snapshot_journal.py` (both out of scope) as comments. Did not delete unilaterally per task brief.

## Test plan

- [x] `ruff check src tests` — all passed
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed source files — OK
- [x] `python scripts/test_tier_audit.py --strict tests/test_untrusted_profile_1827_s4.py` — 7/7 OK
- [x] `pytest` — 9 failed / 6797 passed (identical to origin/main baseline; zero new failures introduced)

part of #2434