### PR TITLE
refactor(#2542): rename 2 persisted skill-named keys — skill_phase→(deleted), skill_done→model_loaded

### DIFF
--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -31,10 +31,9 @@ class DispatchContext:
     """Per-call context passed into dispatch_tool.
 
     Attributes:
-        caller_kind: "router" for chat agent main loop, "skill_phase" for
-            op-loop execution. Used in event taxonomy for filtering.
-        caller_id: agent_name (router) or f"{actor}.{phase_name}"
-            (skill_phase). Identifies the audit subject.
+        caller_kind: Always "router" — the chat agent main loop.
+            Used in event taxonomy for filtering.
+        caller_id: agent_name. Identifies the audit subject.
         chain_id: optional chain id for multi-hop tracing (PR14).
         tool_catalog: dict[str, dict] mapping tool name → tool definition
             ({"function": {"name", "description", "parameters": <json schema>}}).
@@ -44,7 +43,7 @@ class DispatchContext:
         chain_id is included as an event field automatically.
     """
 
-    caller_kind: Literal["router", "skill_phase"]
+    caller_kind: Literal["router"]
     caller_id: str
     chain_id: str | None
     tool_catalog: dict[str, dict]

--- a/src/reyn/data/embedding/sentence_transformers_provider.py
+++ b/src/reyn/data/embedding/sentence_transformers_provider.py
@@ -68,7 +68,7 @@ from reyn.data.embedding.provider import EmbedBatchResult
 # lazy model load. The provider emits:
 #
 #   ("status",     "<msg>", {model, target_dir, device})   on DL start
-#   ("skill_done", "<msg>", {model, dimension})            on load complete
+#   ("model_loaded", "<msg>", {model, dimension})          on load complete
 #   ("error",      "<msg>", {model, retry_hint})           on load failure
 #
 # The sink is called synchronously from inside ``_load`` (= which itself
@@ -223,7 +223,7 @@ class SentenceTransformersEmbeddingProvider:
           * ``status`` before the load begins, carrying ``model`` /
             ``target_dir`` / ``device`` so the TUI can render a sticky
             status row.
-          * ``skill_done`` after the load succeeds, with the resolved
+          * ``model_loaded`` after the load succeeds, with the resolved
             dimension for cross-checking.
           * ``error`` if the load (or the underlying import) fails,
             with a ``retry_hint`` pointing at the relevant recovery
@@ -288,7 +288,7 @@ class SentenceTransformersEmbeddingProvider:
         except Exception:
             dim = 0
         self._emit(
-            "skill_done",
+            "model_loaded",
             f"loaded embedding model {resolved_model!r} ({dim}d)",
             {"model": resolved_model, "dimension": dim},
         )

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -281,7 +281,7 @@ def test_caller_kind_and_id_propagated_in_events():
         async def invoker(args):
             return None
         ctx, ev = make_ctx(
-            caller_kind="skill_phase",
+            caller_kind="router",
             caller_id="article_writer.write",
             chain_id="cabc",
             catalog=_SAMPLE_CATALOG,
@@ -291,7 +291,7 @@ def test_caller_kind_and_id_propagated_in_events():
             ctx=ctx, invoker=invoker,
         )
         for ev_type, ev_data in ev.events:
-            assert ev_data["caller_kind"] == "skill_phase"
+            assert ev_data["caller_kind"] == "router"
             assert ev_data["caller_id"] == "article_writer.write"
             assert ev_data["chain_id"] == "cabc"
     asyncio.run(main())

--- a/tests/test_embedding_dl_progress_events.py
+++ b/tests/test_embedding_dl_progress_events.py
@@ -14,9 +14,9 @@ What is pinned:
      emits a single ``("error", …, {retry_hint: …})`` event with the
      canonical install command in the hint before raising.
   3. A successful load emits exactly
-        ``status`` → ``skill_done`` (in that order).
+        ``status`` → ``model_loaded`` (in that order).
      ``status.meta`` carries ``model`` / ``target_dir`` / ``device``;
-     ``skill_done.meta`` carries ``model`` / ``dimension``.
+     ``model_loaded.meta`` carries ``model`` / ``dimension``.
   4. A load that fails after the import succeeded (= simulated by a
      SentenceTransformer constructor raising) emits
         ``status`` → ``error``.
@@ -156,14 +156,14 @@ def test_import_error_emits_error_event_with_install_hint(
     assert meta["model"] == "sentence-transformers/all-MiniLM-L6-v2"
 
 
-# ── 3. Successful load emits status → skill_done ─────────────────────────────
+# ── 3. Successful load emits status → model_loaded ─────────────────────────────
 
 
 def test_successful_load_emits_status_then_done(
     monkeypatch, tmp_path,
 ) -> None:
     """Tier 2: load lifecycle = status (with model/target_dir/device) then
-    skill_done (with model/dimension), in that order.
+    model_loaded (with model/dimension), in that order.
     """
     monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path))
     monkeypatch.setenv("REYN_EMBED_DEVICE", "cpu")
@@ -180,8 +180,8 @@ def test_successful_load_emits_status_then_done(
         "sentence-transformers/all-MiniLM-L6-v2",
     ))
     kinds = [k for k, _t, _m in events]
-    assert kinds == ["status", "skill_done"], (
-        f"expected [status, skill_done]; got {kinds}"
+    assert kinds == ["status", "model_loaded"], (
+        f"expected [status, model_loaded]; got {kinds}"
     )
     status_meta = events[0][2]
     done_meta = events[1][2]
@@ -213,7 +213,7 @@ def test_subsequent_load_emits_no_events_when_cached(
     _run(p.embed(["a"], "sentence-transformers/all-MiniLM-L6-v2"))
     _run(p.embed(["b"], "sentence-transformers/all-MiniLM-L6-v2"))
     # Only the first call's two events; second call hits the cache.
-    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+    assert [k for k, _t, _m in events] == ["status", "model_loaded"]
 
 
 # ── 4. Load failure after import emits status → error ───────────────────────
@@ -309,7 +309,7 @@ def test_routing_wrapper_forwards_event_sink_to_st_backend(
     provider = RoutingEmbeddingProvider(config=cfg, event_sink=sink)
     _run(provider.embed(["x"], "local-mini"))
     # Backend was lazily constructed and emitted lifecycle events.
-    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+    assert [k for k, _t, _m in events] == ["status", "model_loaded"]
 
 
 # ── 7. get_provider passes the sink through ──────────────────────────────────
@@ -346,7 +346,7 @@ def test_get_provider_threads_event_sink_through_routing_wrapper(
     )
     provider = get_provider("litellm", cfg, event_sink=sink)
     _run(provider.embed(["x"], "local-mini"))
-    assert [k for k, _t, _m in events] == ["status", "skill_done"]
+    assert [k for k, _t, _m in events] == ["status", "model_loaded"]
 
 
 def test_get_provider_without_event_sink_keeps_backward_compat(


### PR DESCRIPTION
**[lead-sonnet]** — Clean-break rename of two persisted skill-named keys, part of #2542.

## What changed

**Edit 1 — `DispatchContext.caller_kind`: delete dead `"skill_phase"` arm**

- `src/reyn/core/dispatch/dispatcher.py`: `caller_kind: Literal["router", "skill_phase"]` → `Literal["router"]`. Docstring updated to reflect that `caller_kind` is always `"router"` (chat agent main loop) and `caller_id` is always `agent_name`. The `skill_phase` alternative was dead — no production callsite passes it.
- `tests/test_dispatcher.py` (`test_caller_kind_and_id_propagated_in_events`): `caller_kind="skill_phase"` → `"router"`. Test purpose (verify that caller_kind/caller_id/chain_id propagate into all emitted events) is fully preserved; only the string value was updated.

**Edit 2 — `skill_done` event kind → `"model_loaded"`**

- `src/reyn/data/embedding/sentence_transformers_provider.py`: renamed the `skill_done` emit call (line ~291), the EventSink protocol comment block (line ~71), and the `_load()` docstring (line ~226).
- `tests/test_embedding_dl_progress_events.py`: all 9 occurrences of `"skill_done"` updated to `"model_loaded"` (docstring narrative, section header comment, assertion strings, and error messages).

**Paired-event finding**: `git grep -n 'skill' src/reyn/data/embedding/sentence_transformers_provider.py` found only the single `skill_done` event — no paired `skill_start`/`skill_loading` event exists in this file. The event family before this PR was: `status` → `skill_done`. After: `status` → `model_loaded`. No other skill-named events needed renaming here.

## Scope note: types.py / mcp.py / PhaseCallerState deliberately left untouched

`src/reyn/tools/types.py` (`ToolContext.caller_kind: Literal["router", "phase"]`, `PhaseCallerState`, `phase_state`) and the `if ctx.caller_kind == "router":` else-branches in `src/reyn/tools/mcp.py` are out of scope for this PR and were not modified.

## Final `git grep -c skill src/` count

16 files remain with `skill` mentions in `src/` (down from 16 — the 2 removed occurrences were in `src/reyn/core/dispatch/dispatcher.py` and `src/reyn/data/embedding/sentence_transformers_provider.py`).

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `pytest tests/test_dispatcher.py tests/test_embedding_dl_progress_events.py` — 19/19 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_dispatcher.py tests/test_embedding_dl_progress_events.py` — 19 OK, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/dispatch/dispatcher.py src/reyn/data/embedding/sentence_transformers_provider.py` — OK

part of #2542