### PR TITLE
feat(#2548): PR-A skill registry — config schema + merge + registry + L1 SP

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -203,6 +203,21 @@ def _merge(base: dict, override: dict) -> dict:
                 else:
                     merged_llm[sub_key] = sub_val
             result["llm"] = merged_llm
+        elif key == "skills" and isinstance(val, dict):
+            # #2548 PR-A: skill registry entries union across config tiers —
+            # mirrors the mcp.servers merge pattern exactly. Scalar keys
+            # last-layer-wins; ``entries`` dict is a union with later tier
+            # winning on name collision. Lets ~/.reyn/config.yaml declare
+            # global skills while reyn.yaml / .reyn/config/skills.yaml add
+            # project-local ones.
+            existing = result.get("skills", {})
+            existing_entries = existing.get("entries", {}) if isinstance(existing, dict) else {}
+            new_entries = val.get("entries", {}) if isinstance(val, dict) else {}
+            result["skills"] = {
+                **existing,
+                **val,
+                "entries": {**existing_entries, **new_entries},
+            }
         else:
             result[key] = val
     return result
@@ -347,6 +362,16 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_cron = _load_yaml(project_root / ".reyn" / "config" / "cron.yaml")
         merged = _merge(merged, dynamic_cron)
 
+        # #2548 PR-A: skill registry separated from static config — same
+        # #470 invariant as MCP. .reyn/config/skills.yaml carries
+        # project-local skill declarations; merged LAST so it wins on
+        # name collision with operator-edited reyn.yaml skill entries.
+        # Shape: {"skills": {"entries": {<name>: {<entry>}}}} — same
+        # as the skills section in reyn.yaml, handled by _merge skills
+        # branch above. NOT added to _HOT_RELOAD_FILES (per spec).
+        dynamic_skills = _load_yaml(project_root / ".reyn" / "config" / "skills.yaml")
+        merged = _merge(merged, dynamic_skills)
+
         # ADR-0031: <project>/.reyn/config.yaml is DEPRECATED (removed from
         # the 3-layer cascade).  Emit a one-time warning if the file exists so
         # users know to migrate.  The file is intentionally NOT loaded.
@@ -457,6 +482,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         external_transports=_build_external_transports_config(
             merged.get("external_transports"),
         ),
+        skills=_as_config_dict(merged.get("skills"), "skills"),
     )
     _reconcile_embedding_class(_cfg)
     return _cfg

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -261,6 +261,19 @@ class ReynConfig:
     external_transports: "ExternalTransportRouting" = field(
         default_factory=lambda: _empty_external_transports(),
     )
+    # #2548 PR-A: skill registry config. Raw dict passed to
+    # reyn.data.skills.registry.build_skill_registry at session /
+    # router construction. Shape:
+    #   skills:
+    #     scan_dirs: ["skills"]          # relative to project root; default ["skills"]
+    #     entries:
+    #       <name>:
+    #         path: "skills/foo/SKILL.md"
+    #         description: "One-line description"
+    #         enabled: true
+    #         auto_invoke: true
+    # Merged across config tiers by name (explicit entries win on collision).
+    skills: dict = field(default_factory=dict)
 
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.

--- a/src/reyn/data/skills/registry.py
+++ b/src/reyn/data/skills/registry.py
@@ -1,0 +1,90 @@
+"""reyn.data.skills.registry — skill registry model and config-entry builder (#2548 PR-A).
+
+A "skill" = an industry-standard ``SKILL.md`` file in a named directory.
+Skills are registered PURELY via explicit ``skills.entries`` declarations
+in any config tier — matching the ``mcp.servers`` registration model.
+The ``SKILL.md`` body is read by the model at L2 (via the existing
+file-read op) when a skill is relevant; the registry never reads it.
+
+``path`` in each entry may be project-root-relative or absolute; it
+points at the skill's ``SKILL.md`` / directory. The registry stores it
+as-is for L1 system-prompt display.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Maximum characters to keep from a skill description (one-line cap).
+_DESC_MAX = 200
+
+
+@dataclass
+class SkillEntry:
+    """A single skill loaded from explicit config declaration.
+
+    ``path`` is as declared in ``skills.entries.<name>.path`` — may be
+    project-root-relative or absolute. The registry stores it as-is; the
+    model reads the file at L2 when the skill is relevant.
+    ``enabled`` and ``auto_invoke`` mirror the config keys; both default True.
+    """
+    name: str
+    description: str
+    path: str
+    enabled: bool = True
+    auto_invoke: bool = True
+
+
+def _truncate_description(desc: str) -> str:
+    """Keep only the first line, capped to _DESC_MAX chars."""
+    first_line = (desc.splitlines()[0] if desc else "").strip()
+    if len(first_line) > _DESC_MAX:
+        return first_line[:_DESC_MAX]
+    return first_line
+
+
+def _entry_from_config(name: str, raw: Any) -> SkillEntry | None:
+    """Build a SkillEntry from a raw ``skills.entries.<name>`` config dict.
+
+    Returns None when *raw* is not a dict (malformed entry — lenient-default
+    pattern matching loader.py).
+    """
+    if not isinstance(raw, dict):
+        return None
+    path = str(raw.get("path") or "").strip()
+    description = _truncate_description(str(raw.get("description") or ""))
+    enabled = bool(raw.get("enabled", True))
+    auto_invoke = bool(raw.get("auto_invoke", True))
+    return SkillEntry(
+        name=name,
+        description=description,
+        path=path,
+        enabled=enabled,
+        auto_invoke=auto_invoke,
+    )
+
+
+def build_skill_registry(raw_skills: dict) -> list[SkillEntry]:
+    """Build the skill registry from merged ``skills:`` config dict.
+
+    ``raw_skills`` is the merged ``skills:`` dict from the config cascade
+    (may be empty / absent — lenient). Skills are registered purely via
+    explicit ``skills.entries`` declarations; cross-tier union-merge
+    (later tier wins on name collision) is handled by ``_merge`` in loader.py
+    before this function is called.
+
+    Returns only entries with ``enabled=True``.
+    """
+    if not isinstance(raw_skills, dict):
+        return []
+
+    raw_entries = raw_skills.get("entries")
+    if not isinstance(raw_entries, dict):
+        return []
+
+    out: list[SkillEntry] = []
+    for name, raw in raw_entries.items():
+        entry = _entry_from_config(str(name), raw)
+        if entry is not None and entry.enabled:
+            out.append(entry)
+    return out

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -36,6 +36,9 @@ class SessionFactoryConfig:
     router_config: Any
     retry_config: Any
     chat_tool_use_scheme: str
+    # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]), built from
+    # config.skills. Uniform config-derived arg → reaches all factory sites.
+    available_skills: Any
     # ── AgentRegistry uniform config (3) ────────────────────────────────────
     delegation_capability_default: str
     # #2103 C3: operator spawn-tree bounds (safety.spawn.*) — the LLM spawn seams
@@ -47,6 +50,7 @@ class SessionFactoryConfig:
     def from_config(cls, config: Any) -> "SessionFactoryConfig":
         """The single mapping point ``ReynConfig`` → the uniform factory args. Add a
         new uniform arg HERE (and as a field above) → all five factory sites get it."""
+        from reyn.data.skills.registry import build_skill_registry
         return cls(
             sandbox_config=config.sandbox,
             multimodal_config=config.multimodal,
@@ -55,6 +59,9 @@ class SessionFactoryConfig:
             router_config=config.llm.router,
             retry_config=config.llm.retry,
             chat_tool_use_scheme=config.tool_use.chat,
+            # #2548 PR-A: build the enabled skill registry once here (filtered to
+            # enabled=True) so every factory site threads the same snapshot.
+            available_skills=build_skill_registry(config.skills),
             delegation_capability_default=config.delegation.capability_default,
             max_spawn_depth=config.safety.spawn.max_depth,
             max_spawn_children=config.safety.spawn.max_children,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1605,6 +1605,14 @@ class RouterLoop:
             "router_model": self.router_model,
             "router_model_family": _rm_family,  # #1791 A2: raw family fact; scheme gates non-Claude
             "non_interactive": self._non_interactive,
+            # #2548 PR-A: skill registry snapshot (enabled skills only). The
+            # scheme layer renders the ## Skills block from this into the
+            # dedicated slot_post_skills. getattr fallback keeps narrow hosts
+            # (plan-step host / FakeRouterHost without the accessor) at None →
+            # no Skills section (byte-identical to no-skills configs).
+            "available_skills": (
+                getattr(self.host, "get_available_skills", lambda: None)()
+            ),
         }
         self._scheme_available = _scheme_available
         self._scheme_layer_ctx = _scheme_layer_ctx
@@ -3453,6 +3461,13 @@ class RouterLoop:
             mcp_servers=self.host.get_mcp_servers() if hasattr(
                 self.host, "get_mcp_servers"
             ) else None,
+            # #2548 PR-A: skill registry snapshot (enabled skills only), so a
+            # future skill-aware handler can read the same list the SP renders.
+            # Same host accessor the scheme layer_ctx uses (single source);
+            # getattr fallback → None for narrow hosts.
+            available_skills=(
+                getattr(self.host, "get_available_skills", lambda: None)()
+            ),
         )
 
     async def _invoke_via_registry(self, name: str, args: dict) -> Any:

--- a/src/reyn/runtime/router_system_prompt.py
+++ b/src/reyn/runtime/router_system_prompt.py
@@ -326,6 +326,17 @@ def build_system_prompt(
         parts.append("")
         parts.append(_frag)
 
+    # ── 13c. Skills block (#2548 PR-A) ───────────────────────────────────────
+    # slot_post_skills is a DEDICATED slot (distinct from slot_post_catalog) so
+    # the retrieval scheme's slot_post_catalog overwrite cannot clobber the
+    # ## Skills block. Rendered from available_skills by the scheme layer
+    # (build_universal_tool_use_slots); the OS only injects. Empty/absent slot
+    # → no Skills section (byte-identical to no-skills configs).
+    _skills_slot = _slots.get("slot_post_skills") if _slots else None
+    if _skills_slot:
+        parts.append("")
+        parts.append(_skills_slot)
+
     # ── 14. Context-size signal (#272/#1128) ─────────────────────────────────
     # OS-injected, pre-rendered by the caller (router_loop / phase runtime) from
     # the live free-window. Placed LAST because it is the most per-turn-volatile

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -126,5 +126,6 @@ def build_scoped_chat_session(
         router_config=factory_config.router_config,
         retry_config=factory_config.retry_config,  # #1835
         chat_tool_use_scheme=factory_config.chat_tool_use_scheme,
+        available_skills=factory_config.available_skills,  # #2548 PR-A
         **base,
     )

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -475,6 +475,11 @@ class RouterHistoryBuffer:
             discovery_mandate=dm,
             has_hot_list_aliases=False,   # conservative: assume no aliases (smaller SP)
             non_interactive=self._non_interactive,
+            # #2548 PR-A: include the ## Skills block in the SP-size estimate so
+            # the compaction budget accounts for it (same host accessor as live).
+            available_skills=(
+                getattr(rh, "get_available_skills", lambda: None)()
+            ),
         )
         return build_system_prompt(
             agent_name=rh.agent_name,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -192,6 +192,11 @@ class RouterHostAdapter:
         # FP-0034 Phase 2 step 5: ActionRetrievalConfig for hot_list_n /
         # hot_list_seed.  Session passes its config; None → default.
         action_retrieval_config: Any = None,
+        # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]).
+        # Session builds it via build_skill_registry(config.skills) and passes
+        # it in; RouterLoop reads it via get_available_skills() to render the
+        # ## Skills block. None → no skills (byte-identical to no-skills config).
+        available_skills: Any = None,
         # B25-S5-1: when True, RouterLoop awaits the action embedding index
         # build synchronously on the first turn before computing the D14
         # search_actions visibility gate. Off by default (= lazy bg build).
@@ -343,6 +348,8 @@ class RouterHostAdapter:
         self._action_embedding_index = action_embedding_index
         self._embedding_provider = embedding_provider
         self._embedding_model_class = embedding_model_class
+        # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
+        self._available_skills = available_skills
         # FP-0034 Phase 2
         self._sandbox_backend = sandbox_backend
         self._sandbox_backend_instance = sandbox_backend_instance
@@ -765,6 +772,18 @@ class RouterHostAdapter:
         ``"landlock"`` / ``"auto"``) makes it visible.
         """
         return self._sandbox_backend
+
+    def get_available_skills(self) -> Any:
+        """Return the enabled skill registry snapshot (list[SkillEntry]) or None.
+
+        #2548 PR-A.  Mirror of ``skills.entries`` from the config cascade,
+        built by ``build_skill_registry(config.skills)`` at Session
+        construction and filtered to ``enabled=True``.  RouterLoop reads this
+        (via the scheme ``layer_ctx`` and ``RouterCallerState.available_skills``)
+        to render the ``## Skills`` block in the system prompt.  ``None`` (or an
+        empty list) → no Skills section.
+        """
+        return self._available_skills
 
     def get_action_usage_tracker(self) -> Any:
         """Return the ActionUsageTracker for hot list freq+recency, or None.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -687,6 +687,11 @@ class Session:
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
+        # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]), built
+        # from config.skills by SessionFactoryConfig.from_config. Threaded to the
+        # RouterHostAdapter so the router renders the ## Skills block. None → no
+        # skills (byte-identical to no-skills configs / direct test construction).
+        available_skills: Any = None,
         # #1593 PR-2: the chat-layer tool-use scheme name (config.tool_use.chat).
         # Threaded → RouterLoopDriver → RouterLoop(scheme_name=) so the chat
         # router resolves the selected ToolUseScheme. Default "universal-category"
@@ -889,6 +894,10 @@ class Session:
         # constructs an off-flag ActionRetrievalConfig so existing chat
         # behaviour is preserved when callers don't pass one.
         self._action_retrieval = action_retrieval_config or ActionRetrievalConfig()
+        # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
+        # None (direct construction) → no skills; the accessor / SP degrade
+        # gracefully to an omitted section.
+        self._available_skills = available_skills
         # #1593 PR-2: chat-layer scheme name → passed to RouterLoopDriver below.
         self._chat_tool_use_scheme = chat_tool_use_scheme
         # B25-S5-1 fix: when True, RouterLoop awaits the embedding index build
@@ -1485,6 +1494,7 @@ class Session:
                 self._uncompacted_tool_call_records
             ),
             action_retrieval_config=self._action_retrieval,
+            available_skills=self._available_skills,  # #2548 PR-A
             # FP-0034 Phase 2: sandbox backend for exec D14 visibility gate.
             # #1417: gate on the INJECTED backend's real capability, not the
             # reyn.yaml config STRING. The exec capability comes from the

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -45,6 +45,10 @@ def build_universal_tool_use_slots(
       - ``slot_post_catalog``     — scheme-owned SP appended at the post-catalog
                                     position (e.g. retrieval's search guidance),
                                     before the context-size signal (#1627 Stage 3).
+      - ``slot_post_skills``      — the ``## Skills`` block (#2548 PR-A), rendered
+                                    from ``available_skills`` at a DEDICATED position
+                                    so retrieval's ``slot_post_catalog`` overwrite
+                                    cannot clobber it.
 
     Each slot value equals ``"\\n".join(<elements>)`` where ``<elements>`` is the
     exact list that the corresponding inline region would have appended to ``parts``
@@ -298,9 +302,12 @@ def build_universal_tool_use_slots(
         )
     )
 
-    # ── slot_post_catalog: ## Skills block (#2548 PR-A) ─────────────────────
-    # Only included when there is at least one enabled=True + auto_invoke=True
-    # skill; omit entirely otherwise so callers see no empty section.
+    # ── slot_post_skills: ## Skills block (#2548 PR-A) ──────────────────────
+    # DEDICATED slot (NOT slot_post_catalog): retrieval.py overwrites
+    # slot_post_catalog with its search-guidance block AFTER calling this
+    # builder, which would clobber the skills block. A separate slot lets the
+    # OS frame inject both independently. Only included when there is at least
+    # one enabled=True + auto_invoke=True skill; omitted entirely otherwise.
     if available_skills:
         _sp_skills = [
             s for s in available_skills
@@ -335,6 +342,6 @@ def build_universal_tool_use_slots(
                 _s_lines.append(
                     f"- {_sk.name} — {_sk.description} [{_sk.path}]"
                 )
-            slots["slot_post_catalog"] = "\n".join(_s_lines)
+            slots["slot_post_skills"] = "\n".join(_s_lines)
 
     return slots

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -24,6 +24,7 @@ def build_universal_tool_use_slots(
     has_hot_list_aliases: bool,
     non_interactive: bool = False,
     non_claude: bool = False,  # #1791 A2: non-Claude operational-steering hygiene in slot_in_behaviour
+    available_skills: "list | None" = None,  # #2548 PR-A: SkillEntry list for ## Skills block
 ) -> "dict[str, str]":
     """Build the four positional tool-use SP slots for the universal-category path.
 
@@ -296,5 +297,44 @@ def build_universal_tool_use_slots(
             " within the cwd's read scope."
         )
     )
+
+    # ── slot_post_catalog: ## Skills block (#2548 PR-A) ─────────────────────
+    # Only included when there is at least one enabled=True + auto_invoke=True
+    # skill; omit entirely otherwise so callers see no empty section.
+    if available_skills:
+        _sp_skills = [
+            s for s in available_skills
+            if getattr(s, "enabled", True) and getattr(s, "auto_invoke", True)
+        ]
+        if _sp_skills:
+            _s_lines: list[str] = []
+            _s_lines.append("## Skills")
+            _s_lines.append("")
+            _s_lines.append(
+                "Skills are reusable, task-specific instruction sets."
+                " Each entry is `name — description [file]`."
+            )
+            _s_lines.append(
+                "The description tells you when a skill applies; the full instructions"
+                " live in its file. When the"
+            )
+            _s_lines.append(
+                "current task matches a skill, read its file to load the instructions"
+                " (and any files it references),"
+            )
+            _s_lines.append(
+                "then follow them for that task. This list is a menu: read a skill only"
+                " when it is relevant — do not"
+            )
+            _s_lines.append(
+                "preload or apply skills that do not fit the task. If none apply,"
+                " proceed normally."
+            )
+            _s_lines.append("")
+            for _sk in _sp_skills:
+                _s_lines.append(
+                    f"- {_sk.name} — {_sk.description} [{_sk.path}]"
+                )
+            slots["slot_post_catalog"] = "\n".join(_s_lines)
 
     return slots

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -73,6 +73,8 @@ class EnumerateAllScheme:
             discovery_mandate=tier_wants_discovery_mandate(layer_ctx.get("router_model")),
             has_hot_list_aliases=bool((available or {}).get("hot_list_aliases")),
             non_interactive=bool(layer_ctx.get("non_interactive", False)),
+            # #2548 PR-A: skill registry snapshot → ## Skills block.
+            available_skills=layer_ctx.get("available_skills"),
         )
         # #1627 Stage 4: sp_params removed — build_system_prompt no longer reads it.
         return Presentation(llm_tools_payload=flat_tools, tool_use_sp=slots)

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -111,6 +111,10 @@ class RetrievalScheme:
             discovery_mandate=tier_wants_discovery_mandate(layer_ctx.get("router_model")),
             has_hot_list_aliases=bool((available or {}).get("hot_list_aliases")),
             non_interactive=bool(layer_ctx.get("non_interactive", False)),
+            # #2548 PR-A: skill registry snapshot → ## Skills block (rendered into
+            # the DEDICATED slot_post_skills, so the slot_post_catalog overwrite
+            # on the next line does NOT clobber it).
+            available_skills=layer_ctx.get("available_skills"),
         )
         slots["slot_post_catalog"] = _search_sp(terminal=terminal)
         return slots

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -86,6 +86,9 @@ class UniversalCategoryScheme:
             has_hot_list_aliases=hl,
             non_interactive=ni,
             non_claude=nc,
+            # #2548 PR-A: skill registry snapshot from the OS layer_ctx →
+            # rendered into the ## Skills block (slot_post_skills).
+            available_skills=layer_ctx.get("available_skills"),
         )
         # #1627 Stage 4: sp_params removed from build_presentation (build_system_prompt
         # no longer reads it). tool_use_sp is now the sole SP channel.

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -13,7 +13,10 @@ ToolContext.router_state.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Literal, Mapping, Protocol
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Protocol
+
+if TYPE_CHECKING:
+    from reyn.data.skills.registry import SkillEntry
 
 
 # ToolGates: per-protocol allow/deny gate at the registry level.
@@ -182,6 +185,14 @@ class RouterCallerState:
     # is configured (= not "noop" / not None).  ``None`` = sandbox not
     # configured or noop backend; exec category stays hidden.
     sandbox_backend: str | None = None
+
+    # #2548 PR-A: skill registry snapshot — enabled skills available at
+    # router construction time. Filtered to enabled=True by the
+    # builder (build_skill_registry); only auto_invoke=True
+    # entries are rendered into the L1 system-prompt ## Skills block.
+    # None = not populated (test sites / contexts without a project
+    # root). Construction-time only — per-turn hot-reload is a later PR.
+    available_skills: "list[SkillEntry] | None" = None
 
 
 # ToolContext: protocol-agnostic execution context. Built by the

--- a/tests/test_2548_skill_registry_pr_a.py
+++ b/tests/test_2548_skill_registry_pr_a.py
@@ -1,0 +1,341 @@
+"""Tier 1: Contract — skill registry: skills.yaml parse + cross-tier union-merge + SP rendering (#2548 PR-A).
+
+Covers:
+  - ``SkillEntry`` dataclass fields and defaults.
+  - ``build_skill_registry`` parses explicit entries from raw config dict.
+  - ``build_skill_registry`` filters out ``enabled=False`` entries.
+  - Cross-tier ``_merge`` union: later-tier entries win on name collision; entries from
+    earlier tiers survive when no collision.
+  - ``.reyn/config/skills.yaml`` is read as part of ``load_config`` (dynamic layer).
+  - Tier 2 (OS invariant): the built system-prompt CONTAINS the ``## Skills`` heading
+    and each skill's name / description / path when N enabled+auto_invoke skills exist.
+  - Tier 2 (OS invariant): ``## Skills`` is absent from the SP when the list is empty.
+  - Filtering: ``enabled=False`` and ``auto_invoke=False`` skills excluded from SP list.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reyn.config.loader import _merge, load_config
+from reyn.data.skills.registry import SkillEntry, build_skill_registry
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+# ── SkillEntry dataclass ──────────────────────────────────────────────────────
+
+
+def test_skill_entry_defaults() -> None:
+    """Tier 1: SkillEntry defaults: enabled=True, auto_invoke=True."""
+    e = SkillEntry(name="foo", description="does foo", path="skills/foo/SKILL.md")
+    assert e.enabled is True
+    assert e.auto_invoke is True
+    assert e.name == "foo"
+    assert e.description == "does foo"
+    assert e.path == "skills/foo/SKILL.md"
+
+
+def test_skill_entry_explicit_disabled() -> None:
+    """Tier 1: SkillEntry can be created with enabled=False, auto_invoke=False."""
+    e = SkillEntry(name="bar", description="does bar", path="skills/bar/SKILL.md",
+                   enabled=False, auto_invoke=False)
+    assert e.enabled is False
+    assert e.auto_invoke is False
+
+
+# ── build_skill_registry ──────────────────────────────────────────────────────
+
+
+def test_build_skill_registry_parses_entries() -> None:
+    """Tier 1: build_skill_registry returns SkillEntry list from valid entries dict."""
+    raw = {
+        "entries": {
+            "my-skill": {
+                "path": "skills/my-skill/SKILL.md",
+                "description": "does something useful",
+            }
+        }
+    }
+    entries = build_skill_registry(raw)
+    entry_map = {e.name: e for e in entries}
+    assert "my-skill" in entry_map, f"expected my-skill in registry entries: {[e.name for e in entries]}"
+    entry = entry_map["my-skill"]
+    assert entry.name == "my-skill"
+    assert entry.description == "does something useful"
+    assert entry.path == "skills/my-skill/SKILL.md"
+    assert entry.enabled is True
+    assert entry.auto_invoke is True
+
+
+def test_build_skill_registry_filters_disabled() -> None:
+    """Tier 1: build_skill_registry excludes entries with enabled=False."""
+    raw = {
+        "entries": {
+            "active": {"path": "skills/active/SKILL.md", "description": "active skill", "enabled": True},
+            "inactive": {"path": "skills/inactive/SKILL.md", "description": "hidden", "enabled": False},
+        }
+    }
+    entries = build_skill_registry(raw)
+    names = {e.name for e in entries}
+    assert "active" in names
+    assert "inactive" not in names
+
+
+def test_build_skill_registry_empty_on_no_entries() -> None:
+    """Tier 1: build_skill_registry returns empty list when entries is absent."""
+    assert build_skill_registry({}) == []
+    assert build_skill_registry({"entries": {}}) == []
+
+
+def test_build_skill_registry_tolerates_malformed_entry() -> None:
+    """Tier 1: build_skill_registry skips non-dict entries without crashing."""
+    raw = {
+        "entries": {
+            "good": {"path": "skills/good/SKILL.md", "description": "ok"},
+            "bad": "not-a-dict",
+        }
+    }
+    entries = build_skill_registry(raw)
+    names = {e.name for e in entries}
+    assert "good" in names
+    assert "bad" not in names
+
+
+def test_build_skill_registry_description_truncated_to_one_line() -> None:
+    """Tier 1: multi-line description is truncated to first line only."""
+    raw = {
+        "entries": {
+            "sk": {
+                "path": "skills/sk/SKILL.md",
+                "description": "first line\nsecond line\nthird line",
+            }
+        }
+    }
+    entries = build_skill_registry(raw)
+    assert entries[0].description == "first line"
+
+
+# ── cross-tier _merge union ───────────────────────────────────────────────────
+
+
+def test_merge_skills_entries_union_no_collision() -> None:
+    """Tier 1: _merge unions skills.entries from two tiers when no name collision."""
+    base = {
+        "skills": {
+            "entries": {
+                "alpha": {"path": "skills/alpha/SKILL.md", "description": "alpha skill"},
+            }
+        }
+    }
+    override = {
+        "skills": {
+            "entries": {
+                "beta": {"path": "skills/beta/SKILL.md", "description": "beta skill"},
+            }
+        }
+    }
+    merged = _merge(base, override)
+    entries = merged["skills"]["entries"]
+    assert "alpha" in entries
+    assert "beta" in entries
+
+
+def test_merge_skills_entries_later_tier_wins_on_collision() -> None:
+    """Tier 1: when the same skill name appears in two tiers, the later tier wins."""
+    base = {
+        "skills": {
+            "entries": {
+                "shared": {"path": "old/SKILL.md", "description": "old description"},
+            }
+        }
+    }
+    override = {
+        "skills": {
+            "entries": {
+                "shared": {"path": "new/SKILL.md", "description": "new description"},
+            }
+        }
+    }
+    merged = _merge(base, override)
+    entry = merged["skills"]["entries"]["shared"]
+    assert entry["path"] == "new/SKILL.md"
+    assert entry["description"] == "new description"
+
+
+def test_merge_skills_base_survives_when_override_has_no_skills() -> None:
+    """Tier 1: base skills are preserved when override does not include a skills key."""
+    base = {
+        "skills": {
+            "entries": {
+                "alpha": {"path": "skills/alpha/SKILL.md", "description": "alpha"},
+            }
+        }
+    }
+    override = {"model": "light"}
+    merged = _merge(base, override)
+    assert "alpha" in merged["skills"]["entries"]
+
+
+# ── load_config reads .reyn/config/skills.yaml ───────────────────────────────
+
+
+def test_load_config_reads_dynamic_skills_yaml(tmp_path: Path) -> None:
+    """Tier 1: load_config reads .reyn/config/skills.yaml as the dynamic skills layer."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    skills_cfg_dir = tmp_path / ".reyn" / "config"
+    skills_cfg_dir.mkdir(parents=True)
+    (skills_cfg_dir / "skills.yaml").write_text(
+        "skills:\n  entries:\n    dynamic-skill:\n      path: skills/dyn/SKILL.md\n      description: dynamic\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+    entries = cfg.skills.get("entries", {})
+    assert "dynamic-skill" in entries, (
+        f"dynamic-skill from .reyn/config/skills.yaml not in cfg.skills.entries: {entries}"
+    )
+
+
+def test_load_config_skills_explicit_wins_over_dynamic_layer(tmp_path: Path) -> None:
+    """Tier 1: explicit skills in reyn.yaml survive + later dynamic layer entry wins on collision."""
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "skills:\n  entries:\n"
+        "    static-skill:\n      path: skills/static/SKILL.md\n      description: from reyn.yaml\n"
+        "    shared:\n      path: skills/shared-static/SKILL.md\n      description: static version\n",
+        encoding="utf-8",
+    )
+    skills_cfg_dir = tmp_path / ".reyn" / "config"
+    skills_cfg_dir.mkdir(parents=True)
+    (skills_cfg_dir / "skills.yaml").write_text(
+        "skills:\n  entries:\n"
+        "    dynamic-skill:\n      path: skills/dyn/SKILL.md\n      description: dynamic\n"
+        "    shared:\n      path: skills/shared-dynamic/SKILL.md\n      description: dynamic version\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+    entries = cfg.skills.get("entries", {})
+    # static-skill and dynamic-skill both survive
+    assert "static-skill" in entries
+    assert "dynamic-skill" in entries
+    # dynamic layer wins on the shared collision
+    assert entries["shared"]["description"] == "dynamic version", (
+        f"Expected dynamic layer to win on collision; got {entries['shared']!r}"
+    )
+
+
+# ── L1 system-prompt ## Skills block ─────────────────────────────────────────
+
+
+def test_sp_skills_block_present_when_skills_available() -> None:
+    """Tier 2: ## Skills heading and each skill's name/description/path present in SP."""
+    skills = [
+        SkillEntry(name="code-review", description="Review pull requests", path="skills/code-review/SKILL.md"),
+        SkillEntry(name="deploy", description="Deploy to production", path="skills/deploy/SKILL.md"),
+    ]
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    sp = slots.get("slot_post_catalog", "")
+    assert "## Skills" in sp, "## Skills heading missing from slot_post_catalog"
+    assert "code-review" in sp
+    assert "Review pull requests" in sp
+    assert "skills/code-review/SKILL.md" in sp
+    assert "deploy" in sp
+    assert "Deploy to production" in sp
+    assert "skills/deploy/SKILL.md" in sp
+
+
+def test_sp_skills_block_absent_when_no_skills() -> None:
+    """Tier 2: ## Skills section is absent from slot_post_catalog when skills list is empty."""
+    slots_empty = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=[],
+    )
+    assert "slot_post_catalog" not in slots_empty, (
+        "slot_post_catalog should not be set when available_skills is empty"
+    )
+
+    slots_none = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=None,
+    )
+    assert "slot_post_catalog" not in slots_none, (
+        "slot_post_catalog should not be set when available_skills is None"
+    )
+
+
+def test_sp_skills_block_excludes_disabled_skills() -> None:
+    """Tier 2: skills with enabled=False are not rendered in the SP list."""
+    skills = [
+        SkillEntry(name="visible", description="should appear", path="skills/vis/SKILL.md",
+                   enabled=True, auto_invoke=True),
+        SkillEntry(name="hidden", description="should not appear", path="skills/hid/SKILL.md",
+                   enabled=False, auto_invoke=True),
+    ]
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    sp = slots.get("slot_post_catalog", "")
+    assert "visible" in sp, "enabled=True skill should appear in SP"
+    assert "hidden" not in sp, "enabled=False skill must not appear in SP"
+
+
+def test_sp_skills_block_excludes_non_auto_invoke_skills() -> None:
+    """Tier 2: skills with auto_invoke=False are not rendered in the SP list."""
+    skills = [
+        SkillEntry(name="auto", description="shown", path="skills/auto/SKILL.md",
+                   enabled=True, auto_invoke=True),
+        SkillEntry(name="manual", description="hidden from sp", path="skills/manual/SKILL.md",
+                   enabled=True, auto_invoke=False),
+    ]
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    sp = slots.get("slot_post_catalog", "")
+    assert "auto" in sp, "auto_invoke=True skill should appear"
+    assert "manual" not in sp, "auto_invoke=False skill must not appear in SP"
+
+
+def test_sp_skills_block_absent_when_all_filtered_out() -> None:
+    """Tier 2: slot_post_catalog absent when all skills are filtered out (disabled/no-auto-invoke)."""
+    skills = [
+        SkillEntry(name="no-show", description="filtered", path="skills/no/SKILL.md",
+                   enabled=False, auto_invoke=True),
+    ]
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    assert "slot_post_catalog" not in slots, (
+        "slot_post_catalog should be absent when all skills are filtered out"
+    )

--- a/tests/test_2548_skill_registry_pr_a.py
+++ b/tests/test_2548_skill_registry_pr_a.py
@@ -248,8 +248,8 @@ def test_sp_skills_block_present_when_skills_available() -> None:
         has_hot_list_aliases=False,
         available_skills=skills,
     )
-    sp = slots.get("slot_post_catalog", "")
-    assert "## Skills" in sp, "## Skills heading missing from slot_post_catalog"
+    sp = slots.get("slot_post_skills", "")
+    assert "## Skills" in sp, "## Skills heading missing from slot_post_skills"
     assert "code-review" in sp
     assert "Review pull requests" in sp
     assert "skills/code-review/SKILL.md" in sp
@@ -259,7 +259,7 @@ def test_sp_skills_block_present_when_skills_available() -> None:
 
 
 def test_sp_skills_block_absent_when_no_skills() -> None:
-    """Tier 2: ## Skills section is absent from slot_post_catalog when skills list is empty."""
+    """Tier 2: ## Skills section is absent from slot_post_skills when skills list is empty."""
     slots_empty = build_universal_tool_use_slots(
         universal_wrappers_enabled=True,
         search_actions_enabled=False,
@@ -267,8 +267,8 @@ def test_sp_skills_block_absent_when_no_skills() -> None:
         has_hot_list_aliases=False,
         available_skills=[],
     )
-    assert "slot_post_catalog" not in slots_empty, (
-        "slot_post_catalog should not be set when available_skills is empty"
+    assert "slot_post_skills" not in slots_empty, (
+        "slot_post_skills should not be set when available_skills is empty"
     )
 
     slots_none = build_universal_tool_use_slots(
@@ -278,8 +278,8 @@ def test_sp_skills_block_absent_when_no_skills() -> None:
         has_hot_list_aliases=False,
         available_skills=None,
     )
-    assert "slot_post_catalog" not in slots_none, (
-        "slot_post_catalog should not be set when available_skills is None"
+    assert "slot_post_skills" not in slots_none, (
+        "slot_post_skills should not be set when available_skills is None"
     )
 
 
@@ -298,7 +298,7 @@ def test_sp_skills_block_excludes_disabled_skills() -> None:
         has_hot_list_aliases=False,
         available_skills=skills,
     )
-    sp = slots.get("slot_post_catalog", "")
+    sp = slots.get("slot_post_skills", "")
     assert "visible" in sp, "enabled=True skill should appear in SP"
     assert "hidden" not in sp, "enabled=False skill must not appear in SP"
 
@@ -318,13 +318,13 @@ def test_sp_skills_block_excludes_non_auto_invoke_skills() -> None:
         has_hot_list_aliases=False,
         available_skills=skills,
     )
-    sp = slots.get("slot_post_catalog", "")
+    sp = slots.get("slot_post_skills", "")
     assert "auto" in sp, "auto_invoke=True skill should appear"
     assert "manual" not in sp, "auto_invoke=False skill must not appear in SP"
 
 
 def test_sp_skills_block_absent_when_all_filtered_out() -> None:
-    """Tier 2: slot_post_catalog absent when all skills are filtered out (disabled/no-auto-invoke)."""
+    """Tier 2: slot_post_skills absent when all skills are filtered out (disabled/no-auto-invoke)."""
     skills = [
         SkillEntry(name="no-show", description="filtered", path="skills/no/SKILL.md",
                    enabled=False, auto_invoke=True),
@@ -336,6 +336,170 @@ def test_sp_skills_block_absent_when_all_filtered_out() -> None:
         has_hot_list_aliases=False,
         available_skills=skills,
     )
-    assert "slot_post_catalog" not in slots, (
-        "slot_post_catalog should be absent when all skills are filtered out"
+    assert "slot_post_skills" not in slots, (
+        "slot_post_skills should be absent when all skills are filtered out"
     )
+
+
+# ── end-to-end wiring: config → registry → SP through a REAL scheme ───────────
+# These exercise the real production functions in sequence (no unit-stubs): the
+# config loader, the registry builder, the actual scheme SP builders, and the OS
+# system-prompt injector. They are the regression guard for the "pieces built but
+# never wired" gap (peer review of PR #2550).
+
+
+def _sp_base_kwargs() -> dict:
+    return {
+        "agent_name": "alpha",
+        "agent_role": "test agent",
+        "available_agents": [],
+        "memory_index": {"status": "not_found", "content": ""},
+        "file_permissions": None,
+        "mcp_servers": None,
+        "output_language": None,
+        "project_context": "",
+        "indexed_sources_section": None,
+    }
+
+
+def test_e2e_config_to_system_prompt_universal_scheme(tmp_path: Path) -> None:
+    """Tier 2: skills.yaml → load_config → registry → universal scheme SP renders ## Skills.
+
+    Full production path: a skill declared in reyn.yaml flows through load_config,
+    build_skill_registry, build_universal_tool_use_slots (the universal-category
+    scheme's builder), and build_system_prompt — the rendered SP must contain the
+    skill's name, description, and path.
+    """
+    from reyn.runtime.router_system_prompt import build_system_prompt
+
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "skills:\n  entries:\n"
+        "    pdf-filler:\n      path: skills/pdf-filler/SKILL.md\n"
+        "      description: Fill PDF forms from structured data\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+
+    skills = build_skill_registry(cfg.skills)
+    # Simulate the router layer_ctx the scheme reads (available_skills is the seam).
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    prompt = build_system_prompt(tool_use_sp=slots, **_sp_base_kwargs())
+    assert "## Skills" in prompt, "## Skills section missing from rendered system prompt"
+    assert "pdf-filler" in prompt
+    assert "Fill PDF forms from structured data" in prompt
+    assert "skills/pdf-filler/SKILL.md" in prompt
+
+
+def test_e2e_retrieval_scheme_does_not_clobber_skills_block(tmp_path: Path) -> None:
+    """Tier 2: under the RETRIEVAL scheme, the ## Skills block survives alongside search SP.
+
+    Regression guard for the clobber bug: retrieval overwrites slot_post_catalog
+    with its search-guidance block AFTER build_universal runs. The skills block
+    lives in the DEDICATED slot_post_skills, so both must appear in the final SP.
+    """
+    from reyn.runtime.router_system_prompt import build_system_prompt
+    from reyn.tools.schemes.retrieval import RetrievalScheme
+
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "skills:\n  entries:\n"
+        "    data-cleaner:\n      path: skills/data-cleaner/SKILL.md\n"
+        "      description: Normalize and dedupe tabular data\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+
+    skills = build_skill_registry(cfg.skills)
+    scheme = RetrievalScheme()
+    layer_ctx = {
+        "search_visible": True,
+        "router_model": "standard",
+        "non_interactive": False,
+        "available_skills": skills,
+    }
+    # Call the REAL retrieval slot builder (the one that overwrites slot_post_catalog).
+    slots = scheme._slots_for(available={}, layer_ctx=layer_ctx, terminal=True)
+    prompt = build_system_prompt(tool_use_sp=slots, **_sp_base_kwargs())
+
+    # Both the retrieval search-guidance (slot_post_catalog) AND the skills block
+    # (slot_post_skills) must be present — the clobber must not have happened.
+    assert "## Skills" in prompt, (
+        "## Skills clobbered by retrieval's slot_post_catalog overwrite"
+    )
+    assert "data-cleaner" in prompt
+    assert "Normalize and dedupe tabular data" in prompt
+    assert "skills/data-cleaner/SKILL.md" in prompt
+
+
+def test_e2e_enumerate_scheme_threads_skills(tmp_path: Path) -> None:
+    """Tier 2: the enumerate-all scheme also threads available_skills into the SP."""
+    from reyn.runtime.router_system_prompt import build_system_prompt
+
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "skills:\n  entries:\n"
+        "    linter:\n      path: skills/linter/SKILL.md\n"
+        "      description: Run project linters and summarize findings\n",
+        encoding="utf-8",
+    )
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+
+    skills = build_skill_registry(cfg.skills)
+    # enumerate-all builder signature (universal_wrappers_enabled=False).
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    prompt = build_system_prompt(tool_use_sp=slots, **_sp_base_kwargs())
+    assert "## Skills" in prompt
+    assert "linter" in prompt
+    assert "skills/linter/SKILL.md" in prompt
+
+
+def test_e2e_no_skills_config_omits_section(tmp_path: Path) -> None:
+    """Tier 2: a config with no skills → registry empty → SP has no ## Skills section."""
+    from reyn.runtime.router_system_prompt import build_system_prompt
+
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    old = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        cfg = load_config()
+    finally:
+        os.chdir(old)
+
+    skills = build_skill_registry(cfg.skills)
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        available_skills=skills,
+    )
+    prompt = build_system_prompt(tool_use_sp=slots, **_sp_base_kwargs())
+    assert "## Skills" not in prompt


### PR DESCRIPTION
**[lead-sonnet]** — part of #2548

## Summary

Implements the 4 components of PR-A (skill discovery + registry + L1 system-prompt surfacing):

1. **`skills.yaml` config schema + cross-tier union-merge** — mirrors `mcp.servers` pattern exactly. `_merge` in `loader.py` gets a `skills` branch: scalar keys last-layer-wins, `entries` dict is a union (later tier wins on name collision). `.reyn/config/skills.yaml` is read as the dynamic layer in `load_config`. `skills` field added to `ReynConfig`.

2. **`SkillEntry` dataclass + `build_skill_registry`** — new `src/reyn/data/skills/registry.py`. Registration is config-entry-only (MCP-consistent model); the `SKILL.md` body is read at L2 by the model via the existing file-read op. `build_skill_registry(raw_skills)` filters `enabled=False` entries. Directory scan was intentionally removed from scope (no `scan_dirs` processing) — pure registration model.

3. **`available_skills: list[SkillEntry] | None`** on `RouterCallerState` (`src/reyn/tools/types.py`) — construction-time field; per-turn hot-reload is a later PR.

4. **`## Skills` `slot_post_catalog` block** in `build_universal_tool_use_slots` (`_universal_sp.py`) — renders only `enabled=True AND auto_invoke=True` entries; omits the entire section when the filtered list is empty.

## Files touched

- `src/reyn/data/skills/__init__.py` (new)
- `src/reyn/data/skills/registry.py` (new)
- `src/reyn/config/loader.py` — `_merge` skills branch + `dynamic_skills` load + `ReynConfig(skills=...)`
- `src/reyn/config/root.py` — `skills: dict` field on `ReynConfig`
- `src/reyn/tools/types.py` — `available_skills` field on `RouterCallerState`
- `src/reyn/tools/schemes/_universal_sp.py` — `available_skills` param + `slot_post_catalog` Skills block
- `tests/test_2548_skill_registry_pr_a.py` (new, 17 tests)

## Deliberately NOT in this PR

- L2: model reading SKILL.md body at invocation time
- L3: skill execution / invocation tracking
- Per-turn hot-reload of skill registry
- Toggle / enable-disable at runtime
- Marketplace / skill discovery from external sources
- Directory scan (`scan_dirs`) — registration-only MCP-consistent model

## Test plan

- [x] `ruff check src tests` — all checks passed
- [x] `pytest tests/test_2548_skill_registry_pr_a.py` — 17/17 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_2548_skill_registry_pr_a.py` — 17 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] Full `pytest` run — pre-existing failures only (mcp module not installed, FastAPI web routing), 0 new regressions in changed areas