### PR TITLE
feat(#2548): PR-B skill hot-reload + per-session enable/disable toggle

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -368,7 +368,8 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # name collision with operator-edited reyn.yaml skill entries.
         # Shape: {"skills": {"entries": {<name>: {<entry>}}}} — same
         # as the skills section in reyn.yaml, handled by _merge skills
-        # branch above. NOT added to _HOT_RELOAD_FILES (per spec).
+        # branch above. #2548 PR-B: this file is also in _HOT_RELOAD_FILES
+        # (the IN-set) so skill declarations hot-reload at the turn boundary.
         dynamic_skills = _load_yaml(project_root / ".reyn" / "config" / "skills.yaml")
         merged = _merge(merged, dynamic_skills)
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -499,6 +499,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
 # write-gate boundary (owner-confirmed #2073). Keep this list narrow + explicit.
 _HOT_RELOAD_FILES: tuple[str, ...] = (
     "config/mcp.yaml", "config/cron.yaml", "config/hooks.yaml",
+    "config/skills.yaml",  # #2548 PR-B: skills IN-set hot-reload
 )
 
 

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -58,6 +58,13 @@ def validate_in_set(in_set: "dict") -> "str | None":
     mcp = in_set.get("mcp")
     if mcp is not None and not isinstance(mcp, dict):
         return "mcp section must be a mapping"
+    skills = in_set.get("skills")
+    if skills is not None:
+        if not isinstance(skills, dict):
+            return "skills section must be a mapping"
+        entries = skills.get("entries")
+        if entries is not None and not isinstance(entries, dict):
+            return "skills.entries must be a mapping"
     hooks = in_set.get("hooks")
     if hooks is not None:
         # #2073 S2b: validate the runtime hooks shape via the real loader so a

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -810,7 +810,7 @@ class Session:
         # authorized set — visible ⊆ authorized by construction. In-memory (step1 live); step2 will
         # persist it to the per-session config.yaml so resolved_profile_for(sid) re-derives it.
         self._visibility_override: "dict[str, set[str]]" = {
-            "tool": set(), "mcp": set(), "category": set(),
+            "tool": set(), "mcp": set(), "category": set(), "skill": set(),
         }
         # #2285: session-scoped hook APPLICABILITY override — hook names the user disabled via the
         # status-bar. The HookDispatcher (per-session) skips a hook whose name is in this set at
@@ -2228,22 +2228,43 @@ class Session:
         self._contextual_permission = final_ctx
         self._excluded_categories = final_excl
 
+    def _reapply_skill_visibility(self) -> None:
+        """#2548 PR-B: recompute the live skill list from the base registered set minus the session override.
+
+        Mutates ``_router_host._available_skills`` so the next turn's ``get_available_skills()``
+        returns the filtered view. Re-derives from ``self._available_skills`` (the base registered
+        set captured at construction / reapply) so toggle-ON correctly restores a skill — it is NOT
+        a union of the current view, which would lose previously-disabled skills."""
+        base = self._available_skills or []
+        disabled = self._visibility_override.get("skill", set())
+        filtered = [s for s in base if s.name not in disabled]
+        self._router_host._available_skills = filtered or None
+
     def set_capability_visible(self, kind: str, name: str, visible: bool) -> None:
-        """#2285: toggle the session-visibility of a tool / mcp / category (status-bar seam).
+        """#2285: toggle the session-visibility of a tool / mcp / category / skill (status-bar seam).
 
         ``visible=False`` hides it from the LLM catalog next turn; ``visible=True`` restores it —
         but only UP TO the agent envelope (toggling ON a capability the envelope denies is a no-op
         for visibility: ``_reapply_visibility_override`` re-resolves from base, which still denies
-        it). Session-scoped (this sid only); live next turn; persists across restart (step2)."""
+        it). Session-scoped (this sid only); live next turn; persists across restart (step2).
+
+        For ``kind="skill"``: restrict-only within the registered set — disabling a skill name not
+        in the registered set is silently ignored (no error; the override is a no-op). Enabling a
+        skill name not in the registered set is also silently ignored (can never re-grant beyond the
+        registered set). ``_reapply_skill_visibility`` re-derives the filtered list from
+        ``_available_skills`` (the base registered set) each time."""
         if kind not in self._visibility_override:
             raise ValueError(
-                f"unknown capability kind {kind!r} (expected tool / mcp / category)"
+                f"unknown capability kind {kind!r} (expected tool / mcp / category / skill)"
             )
         if visible:
             self._visibility_override[kind].discard(name)
         else:
             self._visibility_override[kind].add(name)
-        self._reapply_visibility_override()
+        if kind == "skill":
+            self._reapply_skill_visibility()
+        else:
+            self._reapply_visibility_override()
         self._persist_visibility_override()  # #2285 step2 — survive restart (best-effort)
 
     def capability_visibility_state(self) -> dict:
@@ -2253,9 +2274,9 @@ class Session:
         delegate ∩ per-session config, WITHOUT the visibility override) — the full togglable
         universe. ``hidden_by_session`` = the override set (what the user turned OFF). The UI renders
         ``on = item not in hidden_by_session``. authorized is computed from the live catalogs
-        (tools / mcp / categories) filtered by the envelope's ``allows`` — so it always
+        (tools / mcp / categories / skills) filtered by the envelope's ``allows`` — so it always
         reflects visible ⊆ authorized (nothing outside the envelope is ever togglable).
-        Kind ∈ tool / mcp / category."""
+        Kind ∈ tool / mcp / category / skill."""
         from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
         from reyn.tools import get_default_registry
         from reyn.tools.universal_catalog import CATEGORIES
@@ -2279,6 +2300,9 @@ class Session:
         for category in CATEGORIES:
             if category not in base_excl:
                 authorized.append({"kind": "category", "name": category})
+        # #2548 PR-B: skills are togglable per-session; the registered base set is the envelope.
+        for entry in (self._available_skills or []):
+            authorized.append({"kind": "skill", "name": entry.name})
 
         hidden = [
             {"kind": kind, "name": name}
@@ -2363,9 +2387,10 @@ class Session:
         state_dir = self._toggle_store_dir()
         # Reset to a clean baseline first so the load fully re-derives from THIS (final) state dir —
         # idempotent + leak-free if called more than once or after the per-session dir is re-keyed.
-        self._visibility_override = {"tool": set(), "mcp": set(), "category": set()}
+        self._visibility_override = {"tool": set(), "mcp": set(), "category": set(), "skill": set()}
         self._disabled_hooks = set()
         loaded_visibility = False
+        loaded_skill_visibility = False
         try:
             vpath = state_dir / "visibility.yaml"
             if vpath.is_file():
@@ -2376,6 +2401,11 @@ class Session:
                         if isinstance(vals, list):
                             self._visibility_override[kind] = {str(v) for v in vals}
                             loaded_visibility = True
+                    # #2548 PR-B: restore skill visibility override
+                    skill_vals = data.get("skill")
+                    if isinstance(skill_vals, list):
+                        self._visibility_override["skill"] = {str(v) for v in skill_vals}
+                        loaded_skill_visibility = True
         except Exception as exc:  # noqa: BLE001
             logger.warning("#2285: load visibility override failed: %r", exc)
         try:
@@ -2389,6 +2419,8 @@ class Session:
             logger.warning("#2285: load hook disabled-set failed: %r", exc)
         if loaded_visibility:
             self._reapply_visibility_override()  # only re-resolve when something was actually loaded
+        if loaded_skill_visibility:
+            self._reapply_skill_visibility()  # #2548 PR-B: restore skill filter on the host
 
     def hook_state(self) -> "list[dict]":
         """#2285: the status-bar's hook read model — each NAMED hook in this session's merged
@@ -3170,6 +3202,7 @@ class Session:
         hr.register_seam("per_agent_capability", self._reapply_per_agent_capability)
         hr.register_seam("new_agent", self._reapply_new_agent)
         hr.register_seam("hooks", self._reapply_hooks)  # #2073 S2b (global hooks)
+        hr.register_seam("skills", self._reapply_skills)  # #2548 PR-B: skills hot-reload
 
     def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
         """Build the LAYERED hook registry — the three-layer COMBINE (#2073 S2b + the
@@ -3292,6 +3325,45 @@ class Session:
         in-memory tool cache changed."""
         result = await self.refresh_mcp_servers()
         return bool(result.get("refreshed"))
+
+    async def _reapply_skills(self, in_set: dict) -> bool:
+        """Reapply the skill registry (#2548 PR-B) — re-read the full config cascade
+        (OUT-set reyn.yaml ∪ IN-set .reyn/config/skills.yaml) to rebuild the merged skill
+        list, then update the LIVE available_skills on BOTH holders the Session owns
+        (self._available_skills = base registered set; self._router_host._available_skills =
+        filtered view after the per-session visibility override).
+
+        The OUT-set (reyn.yaml-declared skills) survives because the full cascade merge
+        in load_config() always includes it — the hot-reload never drops OUT-set entries.
+
+        ``in_set`` is ignored; the full cascade re-read is the correct source (same pattern
+        as refresh_mcp_servers roster re-read for the MCP roster gap fix). Returns True
+        iff the base registered set actually changed."""
+        from reyn.config.loader import load_config
+        from reyn.data.skills.registry import build_skill_registry
+        try:
+            fresh_cfg = load_config(self._hot_reload_project_root())
+            new_skills = build_skill_registry(fresh_cfg.skills)
+        except Exception as exc:  # noqa: BLE001 — skills re-read is best-effort
+            logger.warning("_reapply_skills: config re-read failed: %r", exc)
+            return False
+        old_names = {s.name for s in (self._available_skills or [])}
+        new_names = {s.name for s in new_skills}
+        if old_names == new_names:
+            # Check if any entry fields changed (description / path / enabled / auto_invoke).
+            old_map = {s.name: s for s in (self._available_skills or [])}
+            if all(
+                new_s.description == old_map[new_s.name].description
+                and new_s.path == old_map[new_s.name].path
+                and new_s.enabled == old_map[new_s.name].enabled
+                and new_s.auto_invoke == old_map[new_s.name].auto_invoke
+                for new_s in new_skills
+            ):
+                return False  # no change
+        # Update the base registered set (Session) + the filtered view (router_host).
+        self._available_skills = new_skills or None
+        self._reapply_skill_visibility()  # re-derives router_host._available_skills from new base
+        return True
 
     async def _reapply_per_agent_capability(self, in_set: dict) -> bool:
         """Reapply the per-agent capability (#2073 S2) — Session-orchestrated. Re-read

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -88,10 +88,10 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
 
 def test_seams_registered_on_the_reloader(tmp_path: Path) -> None:
     """Tier 2: the Session registers its reapply seams on the HotReloader (the 4 S2
-    seams + the S2b hooks seam)."""
+    seams + the S2b hooks seam + the #2548 PR-B skills seam)."""
     session = _make_session(tmp_path)
     names = [name for (name, _fn) in session._hot_reloader._seams]
-    assert names == ["cron", "mcp", "per_agent_capability", "new_agent", "hooks"]
+    assert names == ["cron", "mcp", "per_agent_capability", "new_agent", "hooks", "skills"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_2103_C3_spawn_limits_1953.py
+++ b/tests/test_2103_C3_spawn_limits_1953.py
@@ -39,9 +39,10 @@ def test_safety_spawn_is_restart_only_not_self_raisable():
     from reyn.config.loader import _HOT_RELOAD_FILES
     assert "reyn.yaml" not in _HOT_RELOAD_FILES
     assert "reyn.local.yaml" not in _HOT_RELOAD_FILES
-    # the hot-reload set is the narrow IN-layer (mcp/cron/hooks) — none carry safety.*
+    # the hot-reload set is the narrow IN-layer (mcp/cron/hooks/skills) — none carry safety.*
     assert set(_HOT_RELOAD_FILES) == {
         "config/mcp.yaml", "config/cron.yaml", "config/hooks.yaml",
+        "config/skills.yaml",
     }
 
 

--- a/tests/test_2548_skill_hotreload_toggle_pr_b.py
+++ b/tests/test_2548_skill_hotreload_toggle_pr_b.py
@@ -1,0 +1,380 @@
+"""Tier 2: #2548 PR-B — skill hot-reload + per-session enable/disable toggle.
+
+Three invariants:
+
+1. **Hot-reload e2e** (Tier 2c): writing a new skill to .reyn/config/skills.yaml and
+   applying the hot-reload seam updates the LIVE ``get_available_skills()`` on the
+   RouterHostAdapter — not a local copy.  The next turn's system prompt reflects the
+   change.
+
+2. **Toggle e2e** (Tier 2b): ``set_capability_visible("skill", name, False)`` removes
+   the named skill from the list ``get_available_skills()`` returns; re-enabling it with
+   ``True`` restores it.  Disabling an unregistered skill name is a no-op (restrict-only
+   invariant).
+
+3. **Persistence** (Tier 2b): the skill toggle persists to ``visibility.yaml`` (in the
+   per-session state dir) and is restored by ``load_persisted_toggles()``, which
+   re-applies the filter on the live host.
+
+No mocks.  Real Session + real RouterHostAdapter + real HotReloader throughout.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.data.skills.registry import SkillEntry
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
+    """Minimal real Session in *tmp_path*.  Monkeypatch cwd before calling so
+    ``load_config`` resolves ``.reyn/config/skills.yaml`` correctly.
+
+    Builds ``available_skills`` from ``load_config`` so that skills declared in
+    ``.reyn/config/skills.yaml`` (written before this call) are included — mirroring
+    what ``SessionFactoryConfig.from_config`` does in production."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    from reyn.config.loader import load_config
+    from reyn.data.skills.registry import build_skill_registry
+    cfg = load_config()
+    available_skills = build_skill_registry(cfg.skills) or None
+    return Session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=available_skills,
+    )
+
+
+def _skills_yaml_path(tmp_path: Path) -> Path:
+    p = tmp_path / ".reyn" / "config" / "skills.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _write_skills(tmp_path: Path, entries: dict) -> None:
+    """Write an entries dict to .reyn/config/skills.yaml."""
+    _skills_yaml_path(tmp_path).write_text(
+        yaml.safe_dump({"skills": {"entries": entries}}),
+        encoding="utf-8",
+    )
+
+
+def _skill_names(session: Session) -> "list[str]":
+    """Read skill names via the LIVE public surface (RouterHostAdapter)."""
+    skills = session._router_host.get_available_skills()
+    if not skills:
+        return []
+    return [s.name for s in skills]
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload e2e: changing .reyn/config/skills.yaml updates LIVE available_skills
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_hotreload_adds_skill_to_live_available_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: hot-reload seam updates the LIVE get_available_skills() on the
+    RouterHostAdapter — not a dead local variable — when a skill is added to
+    .reyn/config/skills.yaml."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    # No skills before the file is written.
+    assert "hot-fix" not in _skill_names(session)
+
+    # Write a skill to the IN-set.
+    _write_skills(tmp_path, {
+        "hot-fix": {"path": "skills/hot-fix/SKILL.md", "description": "quick hot-fix workflow"},
+    })
+
+    # Apply the seam — the same path the HotReloader fires at the turn boundary.
+    changed = await session._reapply_skills({})
+
+    assert changed is True
+    assert "hot-fix" in _skill_names(session), (
+        "get_available_skills() must reflect the newly written skill after _reapply_skills"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hotreload_removes_skill_from_live_available_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: hot-reload seam removes a skill from get_available_skills() when it
+    is removed from .reyn/config/skills.yaml (handles deletion, not just addition)."""
+    monkeypatch.chdir(tmp_path)
+    # Start with a skill present.
+    _write_skills(tmp_path, {
+        "old-skill": {"path": "skills/old/SKILL.md", "description": "old"},
+    })
+    session = _make_session(tmp_path)
+    assert "old-skill" in _skill_names(session)
+
+    # Remove the skill from the IN-set.
+    _skills_yaml_path(tmp_path).write_text(
+        yaml.safe_dump({"skills": {"entries": {}}}), encoding="utf-8",
+    )
+
+    changed = await session._reapply_skills({})
+
+    assert changed is True
+    assert "old-skill" not in _skill_names(session), (
+        "get_available_skills() must no longer include the removed skill after _reapply_skills"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hotreload_noop_when_skills_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: _reapply_skills returns False (no change) when .reyn/config/skills.yaml
+    has not changed between two reload calls."""
+    monkeypatch.chdir(tmp_path)
+    _write_skills(tmp_path, {
+        "stable": {"path": "skills/stable/SKILL.md", "description": "stable"},
+    })
+    session = _make_session(tmp_path)
+
+    # First apply picks up the change from startup state.
+    await session._reapply_skills({})
+    # Second apply with identical file → no change.
+    changed = await session._reapply_skills({})
+
+    assert changed is False
+
+
+@pytest.mark.asyncio
+async def test_hotreload_seam_registered(tmp_path: Path) -> None:
+    """Tier 2: the Session registers the skills seam on the HotReloader."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    seam_names = [name for (name, _fn) in session._hot_reloader._seams]
+    assert "skills" in seam_names
+
+
+# ---------------------------------------------------------------------------
+# Toggle e2e: set_capability_visible("skill", ...) filters get_available_skills()
+# ---------------------------------------------------------------------------
+
+def test_toggle_disable_skill_removes_from_live_list(tmp_path: Path) -> None:
+    """Tier 2: set_capability_visible("skill", name, False) removes the skill from
+    get_available_skills() immediately (live next turn — no restart needed)."""
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=[
+            SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
+            SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
+        ],
+    )
+    assert "deploy" in _skill_names(session)
+
+    session.set_capability_visible("skill", "deploy", False)
+
+    assert "deploy" not in _skill_names(session), (
+        "disabled skill must be absent from get_available_skills()"
+    )
+    assert "review" in _skill_names(session), (
+        "non-disabled skill must remain in get_available_skills()"
+    )
+
+
+def test_toggle_reenable_skill_restores_to_live_list(tmp_path: Path) -> None:
+    """Tier 2: set_capability_visible("skill", name, True) restores the skill to
+    get_available_skills() — toggle-ON reverses a prior toggle-OFF."""
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=[
+            SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
+        ],
+    )
+    session.set_capability_visible("skill", "deploy", False)
+    assert "deploy" not in _skill_names(session)
+
+    session.set_capability_visible("skill", "deploy", True)
+
+    assert "deploy" in _skill_names(session), (
+        "re-enabled skill must reappear in get_available_skills()"
+    )
+
+
+def test_toggle_disable_unregistered_skill_is_noop(tmp_path: Path) -> None:
+    """Tier 2: disabling a skill name not in the registered set is a no-op — the
+    restrict-only invariant: toggle can only hide within the registered set."""
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=[
+            SkillEntry(name="real-skill", description="real", path="skills/real/SKILL.md"),
+        ],
+    )
+    # Disable a name that is NOT in the registered set.
+    session.set_capability_visible("skill", "nonexistent-skill", False)
+
+    # The registered skill must still be present.
+    assert "real-skill" in _skill_names(session), (
+        "disabling an unregistered skill must not affect the registered set"
+    )
+
+
+def test_toggle_unknown_kind_raises(tmp_path: Path) -> None:
+    """Tier 2: set_capability_visible with an unknown kind raises ValueError."""
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    with pytest.raises(ValueError, match="unknown capability kind"):
+        session.set_capability_visible("bogus", "something", False)
+
+
+def test_capability_visibility_state_includes_skill_kind(tmp_path: Path) -> None:
+    """Tier 2: capability_visibility_state() reports skill kind in authorized + hidden."""
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=[
+            SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
+        ],
+    )
+    state = session.capability_visibility_state()
+    authorized_skills = [e for e in state["authorized"] if e["kind"] == "skill"]
+    assert {"kind": "skill", "name": "review"} in authorized_skills, (
+        "registered skill must appear in capability_visibility_state authorized list"
+    )
+
+    session.set_capability_visible("skill", "review", False)
+
+    state2 = session.capability_visibility_state()
+    hidden_skills = [e for e in state2["hidden_by_session"] if e["kind"] == "skill"]
+    assert {"kind": "skill", "name": "review"} in hidden_skills, (
+        "disabled skill must appear in hidden_by_session"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence: toggle survives persist + restore via load_persisted_toggles
+# ---------------------------------------------------------------------------
+
+def test_skill_toggle_persists_to_visibility_yaml(tmp_path: Path) -> None:
+    """Tier 2: set_capability_visible("skill", ...) persists the disabled name to
+    visibility.yaml in the per-session state dir."""
+    snap = tmp_path / "snap.json"
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=snap,
+        available_skills=[
+            SkillEntry(name="linter", description="lint", path="skills/linter/SKILL.md"),
+        ],
+    )
+    session.set_capability_visible("skill", "linter", False)
+
+    vpath = snap.parent / "visibility.yaml"
+    assert vpath.is_file(), "visibility.yaml must be written after a skill toggle"
+    data = yaml.safe_load(vpath.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    assert "linter" in (data.get("skill") or []), (
+        "disabled skill name must be stored in visibility.yaml under 'skill' key"
+    )
+
+
+def test_skill_toggle_restored_by_load_persisted_toggles(tmp_path: Path) -> None:
+    """Tier 2: load_persisted_toggles() restores a persisted skill toggle and
+    re-applies the filter on the live RouterHostAdapter — the skill is absent from
+    get_available_skills() after restore, exactly as after the original toggle."""
+    snap = tmp_path / "snap.json"
+    # Session A: disable the skill and persist.
+    session_a = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s_a.wal"),
+        snapshot_path=snap,
+        available_skills=[
+            SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
+            SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
+        ],
+    )
+    session_a.set_capability_visible("skill", "deploy", False)
+
+    # Session B: same state dir, same available_skills — simulate a restart.
+    session_b = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s_b.wal"),
+        snapshot_path=snap,
+        available_skills=[
+            SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
+            SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
+        ],
+    )
+    # Before restore the full set is visible (persisted toggle not yet applied).
+    assert "deploy" in _skill_names(session_b)
+
+    session_b.load_persisted_toggles()
+
+    # After restore, the disabled skill must be absent.
+    assert "deploy" not in _skill_names(session_b), (
+        "load_persisted_toggles must restore the skill disable filter on the live host"
+    )
+    assert "review" in _skill_names(session_b), (
+        "non-disabled skill must remain after load_persisted_toggles"
+    )
+
+
+def test_skill_toggle_persist_clears_when_reenabled(tmp_path: Path) -> None:
+    """Tier 2: re-enabling a skill removes the name from visibility.yaml (or removes
+    the file when no overrides remain) — the stored state matches the current toggle."""
+    snap = tmp_path / "snap.json"
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=snap,
+        available_skills=[
+            SkillEntry(name="linter", description="lint", path="skills/linter/SKILL.md"),
+        ],
+    )
+    session.set_capability_visible("skill", "linter", False)
+    vpath = snap.parent / "visibility.yaml"
+    assert vpath.is_file()
+
+    session.set_capability_visible("skill", "linter", True)
+
+    # The visibility.yaml must no longer contain the skill name.
+    if vpath.is_file():
+        data = yaml.safe_load(vpath.read_text(encoding="utf-8")) or {}
+        assert "linter" not in (data.get("skill") or []), (
+            "re-enabled skill must be removed from visibility.yaml"
+        )
+
+
+# ---------------------------------------------------------------------------
+# validate_in_set: skills section validation
+# ---------------------------------------------------------------------------
+
+def test_validate_in_set_accepts_valid_skills_section() -> None:
+    """Tier 2: validate_in_set accepts a well-formed skills section."""
+    from reyn.runtime.hot_reload import validate_in_set
+    assert validate_in_set({}) is None
+    assert validate_in_set({"skills": {}}) is None
+    assert validate_in_set({"skills": {"entries": {}}}) is None
+    assert validate_in_set({"skills": {"entries": {
+        "my-skill": {"path": "skills/my/SKILL.md", "description": "ok"},
+    }}}) is None
+
+
+def test_validate_in_set_rejects_malformed_skills_section() -> None:
+    """Tier 2: validate_in_set rejects a skills section that is not a mapping."""
+    from reyn.runtime.hot_reload import validate_in_set
+    reason = validate_in_set({"skills": "not-a-dict"})
+    assert reason is not None and "mapping" in reason
+
+    reason2 = validate_in_set({"skills": {"entries": "not-a-dict"}})
+    assert reason2 is not None and "mapping" in reason2


### PR DESCRIPTION
**[lead-sonnet]** — PR-B of the lightweight skill feature (design #2548). part of #2548

## Summary

- **Hot-reload**: adds `config/skills.yaml` to `_HOT_RELOAD_FILES`; registers `_reapply_skills` seam on the HotReloader. The seam re-reads the full config cascade (OUT-set reyn.yaml ∪ IN-set `.reyn/config/skills.yaml`), rebuilds via `build_skill_registry`, and mutates **both** holders the Session owns: `Session._available_skills` (the base registered set) and `RouterHostAdapter._available_skills` (the filtered view after the per-session visibility override). The next turn's `get_available_skills()` reflects the change.
- **Per-session skill disable**: adds `"skill"` as a 4th kind in `_visibility_override`. `set_capability_visible("skill", name, False)` adds the name to the override set and calls `_reapply_skill_visibility`, which re-derives `RouterHostAdapter._available_skills = [s for s in base if s.name not in disabled]`. Restrict-only: disabling an unregistered skill name is a no-op; enabling beyond the registered set is also a no-op.
- **Persistence**: `_persist_visibility_override` already serializes all override keys (now includes `skill`); `load_persisted_toggles` restores the `skill` key and calls `_reapply_skill_visibility`.
- **Validation**: `validate_in_set` in `hot_reload.py` rejects a malformed `skills` section (not a dict / entries not a dict) atomically before any seam runs.
- `capability_visibility_state()` updated to include skill kind in `authorized` and `hidden_by_session`.

## Seam wiring details

`_reapply_skills(in_set)` ignores `in_set` (the skills dict from the reloader) and instead re-reads `load_config()` — this is the correct IN/OUT-set merge: the full cascade always includes the OUT-set (reyn.yaml-declared skills), so OUT-set entries are never dropped. The same pattern is used by `refresh_mcp_servers` for the MCP roster gap fix (#2372).

## Skill-disable filter location

The filter is applied in `_reapply_skill_visibility()`, which sets `RouterHostAdapter._available_skills` to the filtered list. `get_available_skills()` on the adapter returns this filtered value directly. The Session's `_available_skills` field is the base registered set (preserved across toggles so toggle-ON correctly restores without union tricks).

## Test plan

- [x] `test_hotreload_adds_skill_to_live_available_skills` — proves LIVE `get_available_skills()` changes after `_reapply_skills`, not a local var
- [x] `test_hotreload_removes_skill_from_live_available_skills` — proves removal handled
- [x] `test_hotreload_noop_when_skills_unchanged` — proves idempotency
- [x] `test_hotreload_seam_registered` — proves the seam is wired on construction
- [x] `test_toggle_disable_skill_removes_from_live_list` — e2e toggle disable
- [x] `test_toggle_reenable_skill_restores_to_live_list` — e2e toggle re-enable
- [x] `test_toggle_disable_unregistered_skill_is_noop` — restrict-only invariant
- [x] `test_toggle_unknown_kind_raises` — error surface
- [x] `test_capability_visibility_state_includes_skill_kind` — state read model
- [x] `test_skill_toggle_persists_to_visibility_yaml` — persistence write
- [x] `test_skill_toggle_restored_by_load_persisted_toggles` — persistence restore (LIVE host updated)
- [x] `test_skill_toggle_persist_clears_when_reenabled` — persistence cleanup
- [x] `test_validate_in_set_accepts_valid_skills_section` — validation accepts
- [x] `test_validate_in_set_rejects_malformed_skills_section` — validation rejects

## Gate results

- `ruff check src tests` — OK
- `python scripts/test_tier_audit.py --strict tests/test_2548_skill_hotreload_toggle_pr_b.py` — 14/14 OK, 0 errors
- `pytest` — 6833 passed, 12 pre-existing MCP-SDK failures unrelated to this change, 0 new failures
- `python scripts/verify_module_docstrings.py src/reyn/config/loader.py src/reyn/runtime/hot_reload.py src/reyn/runtime/session.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)