### PR TITLE
docs: rewrite permission-model.md's dead run_skill/skill.md declaration flow

### DIFF
--- a/docs/concepts/runtime/permission-model.ja.md
+++ b/docs/concepts/runtime/permission-model.ja.md
@@ -14,9 +14,9 @@ reyn のパーミッションシステムは 4 種類のケイパビリティを
 ┌──────────────────────────────┐  常に許可。宣言不要
 │  デフォルト（読み取り専用プロジェクト）│
 └──────────────────────────────┘
-             ↓ Skill がさらに必要とする場合
-┌──────────────────────────────┐  skill.md frontmatter で宣言。ユーザーが承認
-│  Skill 宣言                  │  承認は .reyn/approvals.yaml に永続化
+             ↓ actor がさらに必要とする場合
+┌──────────────────────────────┐  reyn.yaml `permissions:` で宣言。実際の使用時
+│  宣言されたケイパビリティ      │  点で 1 回プロンプト（起動時ではない）
 └──────────────────────────────┘
              ↓ プロジェクトを広く信頼する場合
 ┌──────────────────────────────┐  reyn.yaml: permissions.<key>: allow
@@ -28,21 +28,23 @@ reyn のパーミッションシステムは 4 種類のケイパビリティを
 
 プロジェクトルート配下のどこでも読み取り/glob/grep。書き込み/編集/削除は `.reyn/` 配下のみ。シェル、MCP、Python は不可。
 
-### レイヤー 2：ワークフロー宣言
+### レイヤー 2：宣言されたケイパビリティ
 
-デフォルト外のものが必要なワークフローは `skill.md` frontmatter でパーミッションを宣言します。ワークフローの起動時、ランタイムは単一の承認プロンプトを表示します：
+デフォルト外のものが必要な actor は `reyn.yaml` の `permissions:` ブロック（`PermissionDecl`、`permissions.file.write` / `file.read` / `mcp` / `tool` / `http.get` / `secret.write` リストから構築）で宣言します。パスを宣言してもそれ自体はアクセスを付与しません — ランタイムがその actor がそのパスを必要とし得ることを認識するだけです。プロンプトは実際にそのパスへアクセスする時点（起動時ではない）で just-in-time に発火します：
 
 ```
-[approval] my_skill/file.write needs:
+[approval] chat_router/file.write needs:
   /tmp/output (just_path)
 
   [y] この実行のみ許可
-  [j] この正確なパス + Skill について永続化
-  [r] 親ディレクトリ（再帰的）+ Skill について永続化
+  [j] この正確なパス + actor について永続化
+  [r] 親ディレクトリ（再帰的）+ actor について永続化
   [N] 拒否
 ```
 
-永続的な選択は `.reyn/approvals.yaml` に `<skill>/<op>/<path>` のキーで保存されます。キーは Skill スコープです。ある Skill の承認が別の Skill に漏れることはありません。
+永続的な選択は `.reyn/approvals.yaml` に `<actor>/<op>/<path>`（例: `chat_router/file.write//tmp/output`）のキーで保存されます。キーは actor スコープです。ある actor の承認が別の actor に漏れることはありません（`security/permissions/permissions.py`: "Approval keys are actor-scoped to prevent external-actor privilege escalation"）。`actor` は呼び出し元サブシステムを識別します(例: LLM ルーター駆動の op パスなら `chat_router`、バックグラウンド呼び出しなら `hooks`/`cron` など) — 個々の named agent ではありません。
+
+呼び出しに intervention bus が配線されていない場合（`bus=None` — 非インタラクティブなコンテキスト）、JIT プロンプトはスキップされ、ゾーン外アクセスは保留せずに拒否されます。
 
 ### レイヤー 3：プロジェクト全体の事前承認
 
@@ -61,15 +63,15 @@ permissions:
 
 ## 非インタラクティブ実行
 
-`reyn eval` はプロンプトなしで実行されます。承認は事前に整っている必要があります。`reyn.yaml` で事前承認されているか、以前のインタラクティブ実行から `.reyn/approvals.yaml` に永続化されているかです。
+intervention bus が配線されていない実行(CI、スクリプト自動化、インタラクティブな TTY の無いコンテキスト)はプロンプトなしで進みます。承認は事前に整っている必要があります。`reyn.yaml` で事前承認されているか、以前のインタラクティブ実行から `.reyn/approvals.yaml` に永続化されているかです。
 
-これは同じ信頼モデルです。eval が何が安全かを決めるのではなく、あなたが事前に決めます。
+これは同じ信頼モデルです。自動化側が何が安全かを決めるのではなく、あなたが事前に決めます。
 
-## なぜ Skill スコープのキーなのか
+## なぜ actor スコープのキーなのか
 
-承認はグローバルではなく Skill でキー付けされます。Skill A が「`/tmp/foo` に書き込んでよいか？」と尋ね、それを承認しても、Skill B に同じアクセスを付与することにはなりません。
+承認はグローバルではなく actor でキー付けされます。actor A が「`/tmp/foo` に書き込んでよいか？」と尋ね、それを承認しても、actor B に同じアクセスを付与することにはなりません。
 
-理由はコンポジションの安全性です。Skill A は信頼されているかもしれません。Skill A が（`run_skill` を通じて）サブスキル B を呼び出しても、B のパーミッションが推移的に付与されるわけではありません。B は自分自身のために求める必要があります。
+理由はコンポジションの安全性です: ある actor の承認済みケイパビリティが別の actor のアクセスを推移的に解放してはいけません — 各 actor は自分自身のために求める必要があります。
 
 ## `mcp_install` パーミッション {#mcp_install-パーミッション}
 
@@ -134,10 +136,10 @@ grep '"mcp_server_installed"' .reyn/events.jsonl
 
 Reyn のパーミッションは 2 つの軸で機能します：
 
-**軸 1 — 使用宣言** (skill.md frontmatter の `permissions:` ブロック):
-ワークフローの作者が使用する op を宣言します。宣言されていない op は即座に `PermissionError`
-を発生させます（Android のマニフェストに登録されていない API を呼び出した場合の
-`SecurityException` に相当）。
+**軸 1 — 使用宣言** (`reyn.yaml` の `permissions:` ブロック、`PermissionDecl` にパース):
+オペレーターが actor がデフォルト外で到達できる範囲を宣言します。宣言されていないゾーン外の
+op は `PermissionError` を発生させます（Android のマニフェストに登録されていない API を
+呼び出した場合の `SecurityException` に相当）。
 
 **軸 2 — 認可** (オペレーター / ユーザーによるアクセス付与):
 `PermissionResolver._approve()` の 4 層解決：
@@ -153,7 +155,7 @@ Reyn のパーミッションは 2 つの軸で機能します：
 
 | Tier | 代表的な op | 宣言 | デフォルト | 設定制限 |
 |---|---|---|---|---|
-| 0 | `run_skill`, `ask_user` | 不要 | 無条件パス | 不可 |
+| 0 | `ask_user` | 不要 | 無条件パス | 不可 |
 | 1 | `web_search`, `web_fetch` | 不要 | allow | `deny` でブロック |
 | 2 | `mcp` | 必須 | ask (4 層) | `allow` で事前承認 |
 | 3 | `shell`, `file` (ゾーン外) | 必須 | ✅ ask（JIT — `bus≠None` でゲート時プロンプト; `bus=None` で deny） | `allow` で事前承認; `deny` はデフォルトゾーンも含めブロック |
@@ -351,85 +353,22 @@ Phase 7 は `http.get` 軸を `file.write` と同じ prompt model に揃えて a
 
 `PURE_STDLIB_ALLOWLIST` は `src/reyn/core/kernel/_python_allowlist.py` で定義されています。`__future__` はコンパイラディレクティブとして一覧に含まれており、ランタイムのケイパビリティを持ちません。
 
-**非インタラクティブ自動許可**: stdlib ワークフローが `reyn run`（非インタラクティブコンテキスト）経由で呼び出される場合、`mode: safe` と `mode: unsafe` の両方の python ステップはプロンプトなしで自動許可されます。これは eval / CI 実行で他の op に既に適用されている非インタラクティブ動作と同等です。
+**非インタラクティブ自動許可**: 非インタラクティブなコンテキスト（intervention bus 未配線）では、`mode: safe` と `mode: unsafe` の両方の python ステップはプロンプトなしで自動許可されます。これは CI 実行で他の op に既に適用されている非インタラクティブ動作と同等です。
 
 **`mode: safe` の形式的契約**（= "ambient sources only"）は allowlist の根拠・コンテキスト別の safe/unsafe 自動許可ルール・unsafe ステップを safe に変換するリファクタリングパターンを網羅しています。
 
-## スキルごとのクレデンシャルスコーピング (FP-0016 D)
+## クレデンシャルスコーピング（トリガーポイントは削除済み）
 
-### 脅威モデル：Confused Deputy
-
-親スキルが `run_skill` でサブスキルを呼び出す際、スコーピングが適用されていないと
-サブスキルは親の全権限で実行されます。サブスキルが処理する悪意あるドキュメントが、
-正当なアクセス権のないクレデンシャルを読み取り、その内容を出力に含めるよう
-サブスキルに指示する可能性があります。これは OS が攻撃者のために自身の権限を
-悪用させられる古典的な **Confused Deputy** 攻撃です。
-
-### `required_credentials` の宣言
-
-サブスキルは `skill.md` フロントマターでクレデンシャルの必要性を宣言します：
-
-```yaml
-# skill.md
-name: github_pr_reviewer
-required_credentials:
-  - github_token
-  - atlassian_token
-```
-
-`required_credentials` が省略された場合のデフォルトは `["*"]` で、完全なクレデンシャル委譲を意味します。
-FP-0016 以前に記述された既存ワークフローとの後方互換性を保つためです。
-
-クレデンシャルが一切不要なワークフローを明示的に宣言するには、空リストを使います：
-
-```yaml
-required_credentials: []
-```
-
-### `run_skill` によるスコープの絞り込み
-
-`run_skill` の境界で、OS はサブスキルの `required_credentials` 宣言から
-`ScopedSecretStore` を構築し、親のスコープ済みストアと交差（intersection）します。
-サブスキルが親自身が保持しないクレデンシャルを取得することはできません：
-
-```
-親のスコープ: {"github_token", "stripe_key", "datadog_key"}
-サブスキルの宣言: ["github_token", "slack_token"]
-有効スコープ: {"github_token"}  ← 交差結果; slack_token は親になし
-```
-
-親ストアが非制限（`["*"]`）の場合は、サブスキルの宣言リストがそのまま採用されます
-（交差は不要）。
-
-### `CredentialScopeError`
-
-サブスキルが有効な許可セット外のクレデンシャルを読み取ろうとすると、
-`CredentialScopeError`（`PermissionError` のサブクラス）が発生します。
-列挙操作もブロックされます。`list_visible_keys()` は許可かつ存在するキーのみを返し、
-スコープ外のキーは「読めない」のではなく「見えない」状態になります。
-
-```python
-from reyn.secrets import ScopedSecretStore, CredentialScopeError
-
-store = ScopedSecretStore(allowed_keys=["github_token"], path=secrets_path)
-store.get("github_token")    # OK — 値を返す
-store.get("stripe_key")      # CredentialScopeError を発生
-"stripe_key" in store        # False — 例外なし、漏洩なし
-store.list_visible_keys()    # ["github_token"] のみ
-```
-
-### 監査証跡
-
-すべての `run_skill` 呼び出しは、その呼び出しで有効な許可キーセットを記録した
-`sub_skill_credential_scope` P6 イベントを発行します：
-
-```bash
-grep '"sub_skill_credential_scope"' .reyn/events.jsonl
-```
-
-イベントペイロードには `skill`（サブスキル名）と `allowed_keys`
-（ソート済みリスト、または非制限の場合 `["*"]`）が含まれます。
-これにより、すべてのサブスキルへのクレデンシャル付与が監査可能かつリプレイ可能になります（P6）。
+FP-0016 Component D は、当時 `run_skill` op（現在は削除済み）経由で spawn されるサブスキルに対する
+呼び出し単位のクレデンシャルスコーピングを導入しました: サブスキルは自身が宣言した
+`required_credentials` にスコープされ、親のスコープと交差した `ScopedSecretStore` を受け取る
+（Confused Deputy 対策）という仕組みでした。そのトリガーポイントは `run_skill` と共に
+消滅しており(#2104)、現在他のどの呼び出し箇所も `ScopedSecretStore` を構築していません
+— `security/secrets/store.py` の `ScopedSecretStore` / `CredentialScopeError` クラス自体は
+まだ存在しますが、`OpContext.secret_store` は現行ランタイムで常に `None` です。現在
+クレデンシャルスコーピングの enforcement は機能していません。シークレットアクセスは
+[`secret.write` 宣言軸](#宣言軸の-taxonomy) と `~/.reyn/secrets.env` に対する
+OS レベルのファイルパーミッションでのみゲートされています。
 
 ## パーミッションシステムではないもの
 

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -16,10 +16,10 @@ reyn's permission system gates four kinds of capability: file paths, shell, MCP 
 ┌──────────────────────────────┐  always allowed; nothing to declare
 │  defaults (read-only project)│
 └──────────────────────────────┘
-             ↓ if skill needs more
-┌──────────────────────────────┐  declare in skill.md frontmatter; user approves
-│  skill declarations          │  approval persists to .reyn/approvals.yaml
-└──────────────────────────────┘
+             ↓ if the actor needs more
+┌──────────────────────────────┐  declared in reyn.yaml `permissions:` (e.g. a
+│  declared capability         │  file.write path list); prompted once at the
+└──────────────────────────────┘  point of actual use, not at startup
              ↓ if you trust the project broadly
 ┌──────────────────────────────┐  reyn.yaml: permissions.<key>: allow
 │  project-wide pre-approval   │  bypasses the prompt for that capability
@@ -40,27 +40,29 @@ Read/glob/grep anywhere under the project root. Write/edit/delete only under `.r
 **Protect-at-use (principle).** A config-write carve-out is *redundant* when the capability it configures is gated downstream at use time. `.reyn/mcp.yaml` and `.reyn/cron.yaml` were therefore **removed** from the carve-out:
 
 - `.reyn/mcp.yaml` — writing it (installing a server) grants nothing on its own. *Using* a server still passes a per-server check at call time (`require_mcp`), so download + execute of the server package is gated regardless of who wrote the config.
-- `.reyn/cron.yaml` — registering a job goes through the standard tool gate (`require_cron_register` / `require_file_write`); fired jobs run only under a user-launched in-process scheduler, and each fired op is itself permission-gated.
+- `.reyn/cron.yaml` — registering a job goes through the standard `require_file_write` gate against the canonical config path; fired jobs run only under a user-launched in-process scheduler, and each fired op is itself permission-gated.
 
-A workflow that legitimately needs to write a *still-protected* path must declare it explicitly (e.g. `file.write: [{path: ".reyn/index/sources.yaml"}]` in `skill.md` frontmatter) and obtain the corresponding approval. The intended route remains the appropriate gated op handler — not direct file writes.
+An actor that legitimately needs to write a *still-protected* path must declare it explicitly (e.g. `permissions.file.write: [{path: ".reyn/index/sources.yaml"}]` in `reyn.yaml`) and obtain the corresponding approval. The intended route remains the appropriate gated op handler — not direct file writes.
 
 **Residual risk.** With mcp/cron at protect-at-use, a safe-mode step *can* now write `.reyn/mcp.yaml` / `.reyn/cron.yaml` directly via the broad `.reyn/` zone. This is intentional and bounded: the write changes only inert configuration. The authority it appears to grant (an MCP server, a cron job) is not realized until the gated use path (`require_mcp` / scheduler + op gates) is crossed, which a config write cannot bypass. The approval store keeps its carve-out precisely because it has no such downstream gate.
 
-### Layer 2: workflow declarations
+### Layer 2: declared capability
 
-A workflow that needs something outside the defaults declares it in its `skill.md` frontmatter. At workflow startup, the runtime shows a single approval prompt:
+An actor that needs something outside the defaults is declared in `reyn.yaml`'s `permissions:` block (`PermissionDecl`, built from `permissions.file.write` / `file.read` / `mcp` / `tool` / `http.get` / `secret.write` lists). Declaring a path doesn't itself grant access — it just makes the runtime aware the actor may need it. The prompt fires just-in-time, at the point the path is actually accessed (not at startup):
 
 ```
-[approval] my_skill/file.write needs:
+[approval] chat_router/file.write needs:
   /tmp/output (just_path)
 
   [y] allow this run only
-  [j] persist for this exact path + skill
-  [r] persist for the parent dir (recursive) + skill
+  [j] persist for this exact path + actor
+  [r] persist for the parent dir (recursive) + actor
   [N] deny
 ```
 
-Persistent choices land in `.reyn/approvals.yaml` keyed by `<skill>/<op>/<path>`. Keys are skill-scoped — one skill's approval doesn't leak to another.
+Persistent choices land in `.reyn/approvals.yaml` keyed by `<actor>/<op>/<path>` (e.g. `chat_router/file.write//tmp/output`). Keys are actor-scoped — one actor's approval doesn't leak to another (`security/permissions/permissions.py`: "Approval keys are actor-scoped to prevent external-actor privilege escalation"). `actor` identifies the calling subsystem (e.g. `chat_router` for the LLM-router-driven op path, or a background caller like `hooks`/`cron`), not an individual named agent.
+
+When no intervention bus is wired for the call (`bus=None` — a non-interactive context), the JIT prompt is skipped and outside-zone access is denied outright rather than left pending.
 
 ### Layer 3: project-wide pre-approval
 
@@ -79,9 +81,9 @@ Use sparingly — `allow` removes the prompt entirely.
 
 ## Non-interactive runs
 
-`reyn eval` runs without prompts. Approvals must be in place beforehand: either pre-approved in `reyn.yaml` or persisted to `.reyn/approvals.yaml` from a prior interactive run.
+A run with no intervention bus wired (CI, scripted automation, any context without an interactive TTY) proceeds without prompts. Approvals must be in place beforehand: either pre-approved in `reyn.yaml` or persisted to `.reyn/approvals.yaml` from a prior interactive run.
 
-This is the same trust model: the eval doesn't get to decide what's safe; you do, in advance.
+This is the same trust model: the automation doesn't get to decide what's safe; you do, in advance.
 
 ### reyn.local.yaml for operator-local pre-approval
 
@@ -102,11 +104,11 @@ This grants project-wide pre-approval for the local environment without affectin
 committed `reyn.yaml` or production users.  Interactive TTY runs elsewhere still see
 startup_guard prompts as documented.
 
-## Why skill-scoped keys
+## Why actor-scoped keys
 
-Approvals are keyed by skill, not globally. If skill A asks "can you write to `/tmp/foo`?", granting it doesn't grant skill B the same access.
+Approvals are keyed by actor, not globally. If actor A asks "can you write to `/tmp/foo`?", granting it doesn't grant actor B the same access.
 
-The reason is composition safety. Skill A might be trusted; skill A invoking sub-skill B (via `run_skill`) doesn't transitively grant B's permissions. B has to ask for its own.
+The reason is composition safety: one actor's approved capability must not transitively unlock another actor's access — each actor has to ask for its own.
 
 ## `mcp_install` permission {#mcp_install-permission}
 
@@ -171,10 +173,11 @@ grep '"mcp_server_installed"' .reyn/events.jsonl
 
 Reyn permissions operate on two axes:
 
-**Axis 1 — Usage Declaration** (skill.md frontmatter `permissions:` block):
-The workflow author declares what ops the workflow intends to use. An undeclared
-op raises `PermissionError` immediately (analogous to Android `SecurityException`
-when calling an API not in the manifest).
+**Axis 1 — Usage Declaration** (`reyn.yaml` `permissions:` block, parsed into a
+`PermissionDecl`): the operator declares what an actor is allowed to reach
+outside the defaults. An undeclared, out-of-zone op raises `PermissionError`
+(analogous to Android `SecurityException` when calling an API not in the
+manifest).
 
 **Axis 2 — Authorization** (operator / user grants access):
 Four resolution layers in `PermissionResolver._approve()`:
@@ -190,7 +193,7 @@ Four resolution layers in `PermissionResolver._approve()`:
 
 | Tier | Example ops | Declaration | Default | Config restriction |
 |---|---|---|---|---|
-| 0 | `run_skill`, `ask_user` | not required | unconditional pass | not possible |
+| 0 | `ask_user` | not required | unconditional pass | not possible |
 | 1 | `web_search`, `web_fetch` | not required | allow | `deny` blocks |
 | 2 | `mcp` | required | ask (4-layer) | `allow` pre-approves |
 | 3 | `shell`, `file` (outside zone) | required | ✅ ask (JIT — `bus≠None` prompt at gate time; `bus=None` deny) | `allow` pre-approves; `deny` blocks even the default zone |
@@ -410,87 +413,23 @@ The `python` permission has two levels:
 
 `PURE_STDLIB_ALLOWLIST` is defined in `src/reyn/core/kernel/_python_allowlist.py`. `__future__` is in the list as a compiler directive — it carries no runtime capability.
 
-**Non-interactive auto-allow**: when a stdlib workflow is invoked via `reyn run` (non-interactive context), both `mode: safe` and `mode: unsafe` python steps are auto-allowed without a prompt. This mirrors the same non-interactive behavior already in place for other ops in eval/CI runs.
+**Non-interactive auto-allow**: in a non-interactive context (no intervention bus wired), both `mode: safe` and `mode: unsafe` python steps are auto-allowed without a prompt. This mirrors the same non-interactive behavior already in place for other ops in CI runs.
 
 **The formal contract for `mode: safe`** (= "ambient sources only") covers the full allowlist rationale, the safe-vs-unsafe auto-allow rules by context, and the refactor pattern for converting unsafe steps to safe.
 
-## Per-skill credential scoping (FP-0016 D)
+## Credential scoping (removed trigger point)
 
-### Threat model: Confused Deputy
-
-When a parent skill invokes a sub-skill via `run_skill`, the sub-skill executes
-with the parent's full authority if no scoping is applied. A malicious document
-processed by the sub-skill could instruct it to read credentials it has no
-legitimate need for and include them in its output — a classic **Confused Deputy**
-attack where the OS is tricked into using its authority on behalf of an adversary.
-
-### `required_credentials` declaration
-
-Sub-skills declare their credential needs in `skill.md` frontmatter:
-
-```yaml
-# skill.md
-name: github_pr_reviewer
-required_credentials:
-  - github_token
-  - atlassian_token
-```
-
-The default — when `required_credentials` is omitted — is `["*"]`, which grants
-full credential delegation. This preserves backward compatibility for existing
-workflows written before FP-0016.
-
-To explicitly declare that a workflow needs no credentials at all, use an empty list:
-
-```yaml
-required_credentials: []
-```
-
-### How `run_skill` narrows the scope
-
-At the `run_skill` boundary, the OS constructs a `ScopedSecretStore` from the
-sub-skill's `required_credentials` declaration and intersects it with the
-parent's already-scoped store. A sub-skill can never gain credentials the parent
-does not itself hold:
-
-```
-parent scope: {"github_token", "stripe_key", "datadog_key"}
-sub-skill declares: ["github_token", "slack_token"]
-effective scope: {"github_token"}  ← intersection; slack_token not in parent
-```
-
-If the parent store is unrestricted (`["*"]`), the sub-skill's declared list is
-honoured as-is (no intersection needed).
-
-### `CredentialScopeError`
-
-Any attempt by the sub-skill to read a credential outside its effective allowed
-set raises `CredentialScopeError` (a `PermissionError` subclass). Enumeration is
-also blocked: `list_visible_keys()` returns only keys that are both allowed and
-present — out-of-scope keys are invisible, not just unreadable.
-
-```python
-from reyn.secrets import ScopedSecretStore, CredentialScopeError
-
-store = ScopedSecretStore(allowed_keys=["github_token"], path=secrets_path)
-store.get("github_token")    # ok — returns value
-store.get("stripe_key")      # raises CredentialScopeError
-"stripe_key" in store        # False — no raise, no leak
-store.list_visible_keys()    # ["github_token"] only
-```
-
-### Audit trail
-
-Every `run_skill` invocation emits a `sub_skill_credential_scope` P6 event
-recording the effective allowed key set for that invocation:
-
-```bash
-grep '"sub_skill_credential_scope"' .reyn/events.jsonl
-```
-
-The event payload contains `skill` (sub-skill name) and `allowed_keys` (sorted
-list, or `["*"]` for unrestricted). This makes every sub-skill credential grant
-auditable and replay-capable (P6).
+FP-0016 Component D introduced per-invocation credential scoping: a sub-skill,
+spawned via the now-removed `run_skill` op, would receive a `ScopedSecretStore`
+scoped to its declared `required_credentials`, intersected with the parent's
+own scope (a Confused Deputy mitigation). That trigger point is gone along
+with `run_skill` (#2104), and no other call site constructs a
+`ScopedSecretStore` today — `security/secrets/store.py`'s `ScopedSecretStore`
+and `CredentialScopeError` classes still exist, but `OpContext.secret_store`
+is unconditionally `None` in the current runtime. There is currently no
+credential-scoping enforcement in effect; secret access is gated only by the
+[`secret.write` declaration axis](#declaration-axis-taxonomy) and OS-level file
+permissions on `~/.reyn/secrets.env`.
 
 ## Effective permission: conjunctive restrict model {#effective-permission-conjunctive-restrict-model}
 


### PR DESCRIPTION
**[docs-maintainer]** — dispatched by lead-coder (reconciliation-audit finding: stale `run_skill` refs). Security-sensitive doc — **requesting co-vet before merge**, per lead-coder direction.

## Why this grew from "5 lines" to a full rewrite
The flagged lines (~109/193/421/449/451) were symptoms of a bigger issue: the doc's entire "workflow declares capabilities in `skill.md` frontmatter → single startup approval prompt" model predates `run_skill`'s removal (#2104) and is described throughout as the *current* mechanism. Confirmed with lead-coder before expanding scope (this is a security-concept doc — accuracy over patch-size).

## Verified against `src/reyn/security/permissions/permissions.py`, not inferred
- **Declaration**: `reyn.yaml`'s `permissions:` block, parsed into `PermissionDecl` (module docstring: *"Permissions declared for an actor (via reyn.yaml `permissions:` or programmatically)"*). Zero live code parses `skill.md` as a permission-decl source.
- **Approval keys are actor-scoped**: `<actor>/<op>/<path>` (docstring: *"Approval keys are actor-scoped to prevent external-actor privilege escalation"*) — matches the #2511 `skill_name`→`actor` rename. `actor` identifies the calling **subsystem** (`chat_router`, `hooks`, `cron` — confirmed via call-site grep), not an individual named agent.
- **Prompt timing**: JIT at actual access time (`require_file_write`), not a separate declaration-time prompt — that step doesn't exist. `bus=None` (non-interactive) denies outright rather than prompting.
- `require_cron_register` was removed; cron registration now gates through plain `require_file_write` against the canonical config path (confirmed via `tools/cron.py`'s `_gate()` docstring).

## Changes
- "Layer 2: workflow declarations" → "Layer 2: declared capability" — rewritten around the verified `reyn.yaml`/actor/JIT-prompt flow.
- "Why skill-scoped keys" → "Why actor-scoped keys".
- Op tier table: dropped `run_skill` from the Tier-0 row (no replacement invented — `ask_user` alone is still accurate).
- "Axis 1 — Usage Declaration": `skill.md` frontmatter → `reyn.yaml` `permissions:` block.
- **Credential scoping (FP-0016 D) section** — the biggest change: verified `ScopedSecretStore`/`CredentialScopeError` classes still exist in `security/secrets/store.py`, but **zero non-test call sites construct `ScopedSecretStore` anywhere** — `OpContext.secret_store` is unconditionally `None`. Replaced the full `run_skill`-based walkthrough (Confused Deputy threat model, `required_credentials` `skill.md` example, scope-narrowing algorithm, code sample, `sub_skill_credential_scope` P6-event audit trail) with a short note stating the actual current state: **no credential-scoping enforcement is in effect today**.
- Also fixed two directly-adjacent dead references found in the same pass: `reyn eval`/`reyn run` non-interactive-behavior mentions (both commands don't exist) → generic "no intervention bus wired" framing, consistent with the rest of the doc.
- **`permission-model.ja.md`** mirrors every fix for EN/JA parity (same drift pattern found throughout this arc — e.g. PR-B, the P7 reword PR).

## Explicitly out of scope (flagged, not touched)
`docs/reference/config/permissions.md` has the **identical disease** — the same `skill.md` frontmatter declaration model, the same `[approval] my_skill/file.write needs:` example, "grants ALL write-class ops for ALL skills" wording. It's the file this doc's Layer-2 example was originally mirroring. Separate file, separate PR — flagging here since it's the same defect class.

## CI gates (local)
- `ruff check src tests` — pass
- `pytest tests/test_fp0036_coverage.py` — 23/23 pass
- `mkdocs build --strict` (from `.mkdocs/`) — exit 0, no warnings (including the new JA anchor `#宣言軸の-taxonomy`)

## Test plan
- [x] `mkdocs build --strict` exit 0
- [x] fp0036 mirror tests green (23/23)
- [x] ruff clean
- [x] exhaustive re-grep for `run_skill`/`skill.md`/`skill-scoped`/dead-command mentions across both EN/JA files — zero remaining (except correctly-historical "#2104"-framed references)
- [ ] **Security co-vet** — awaiting lead-coder / security-reviewer pass before merge (doc-only, no code changes, but describes the live permission-gating model)