### PR TITLE
feat(#2548): PR-C skill_install op + local-install verb + config-generation (recovery-core)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -25,6 +25,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `mcp` | Call a tool on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
+| `skill_install` | Register a local skill directory (containing `SKILL.md`) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter |
 | `index_query` | Semantic vector search over one indexed source | none |
 | `recall` | Macro: embed query (provider-direct) → index_query per source → merge top-K | none (embedding API cost) |
 | `index_drop` | Remove an indexed source entirely (destructive) | `permissions.index_drop: ask` in skill frontmatter |
@@ -271,6 +272,45 @@ Handler lifecycle:
 > `SqliteIndexBackend` primitives are unchanged — only the run-op wrappers and
 > bundled chunkers are gone. Nothing emits `kind: embed` / `kind: index_write`
 > anymore.
+
+## `skill_install`
+
+Registers a local skill directory (containing a `SKILL.md` file) into the
+project's `skills.entries` config. The router tool surface is
+`skill__install_local`; phase-side code emits this op kind directly. Both
+converge on the same `op_runtime/skill_install.py` handler.
+
+```json
+{
+  "kind": "skill_install",
+  "path": "skills/my-skill",
+  "name": "my-skill"
+}
+```
+
+Fields:
+- `path` (required) — path to the skill directory (containing `SKILL.md`) or
+  the direct path to the `SKILL.md` file. May be absolute or project-root-relative.
+  When pointing at a directory the handler appends `/SKILL.md` automatically.
+- `scope` (optional, default `".reyn/config/skills.yaml"`) — retained for
+  forward compat; currently unused (all installs write to `.reyn/config/skills.yaml`).
+- `name` (optional) — config key override. When absent the handler resolves:
+  frontmatter `name:` field → directory basename (in that precedence order).
+
+Handler lifecycle:
+1. Resolve `SKILL.md` path (dir → `<dir>/SKILL.md` or direct file)
+2. Read `SKILL.md` and `split_frontmatter()` — extract `name` and `description`
+3. Apply `op.name` override when set
+4. Threat-scan description via `content_guard.scan_for_threats(scope="strict")` — block on blocking-severity match
+5. Gate via `PermissionResolver.require_file_write` (= `.reyn/config/skills.yaml`)
+6. Write `skills.entries.<name>` to `.reyn/config/skills.yaml` with `{path, description, enabled: true, auto_invoke: true}`
+7. Call `record_config_generation` (recovery-core: truncation-surviving snapshot, #2259 / CLAUDE.md gate)
+8. Emit `skill_installed` event (P6 audit trail)
+9. Request hot-reload via `get_active_hot_reloader().request_reload(source="skill_install")`
+
+Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`, `path`, `description`, `config_path`.
+
+Events emitted: `skill_install_threat_match`, `skill_install_threat_blocked` (threat scan), `skill_installed` (P6 on success).
 
 ## `index_query`
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -114,6 +114,9 @@ from . import mcp_install as _mcp_install  # noqa: F401, E402
 from . import recall as _recall  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 
+# #2548 PR-C: local skill install op (register a SKILL.md dir into skills.entries).
+from . import skill_install as _skill_install  # noqa: F401, E402
+
 # #1953 slice 1: Task ops (first-class trackable work-units).
 from . import task as _task  # noqa: F401, E402
 from . import web as _web  # noqa: F401, E402

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -1,0 +1,241 @@
+"""skill_install kind handler — register a local skill directory into the project config.
+
+Handler logic (one-shot, no sub-phases):
+  1. Resolve SKILL.md: ``op.path`` may be a directory (→ ``<dir>/SKILL.md``)
+     or a direct path to the SKILL.md file. Read it and extract frontmatter.
+  2. Extract name (frontmatter ``name:`` key, else directory basename) and
+     description (frontmatter ``description:`` key, else empty). Apply
+     ``op.name`` override when set.
+  3. Threat-scan the skill description via ``content_guard.scan_for_threats``
+     (scope="strict") — block on a blocking-severity match.
+  4. Gate via ``PermissionResolver.require_file_write`` for the skills.yaml path.
+  5. Read ``.reyn/config/skills.yaml`` (or empty dict), set
+     ``skills.entries.<name>`` = ``{path, description, enabled, auto_invoke}``,
+     write back.
+  6. ``record_config_generation`` on the skills.yaml path AFTER write —
+     the truncation-surviving recovery base (#2259 / CLAUDE.md recovery gate).
+  7. Emit ``skill_installed`` event (P6 audit trail).
+  8. Request hot-reload so the installed skill goes live in the current session.
+
+This is a P5 exception mirror of ``mcp_install``: ``.reyn/config/skills.yaml``
+lives outside the workspace data channel but is written directly here (same
+rationale — gated behind ``require_file_write`` + recorded via event for the
+P6 audit trail).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.schemas.models import SkillInstallIROp
+
+# Module-level import so tests can monkeypatch the threat-scan callables;
+# the guard helpers are pure-function with no I/O and add negligible import cost.
+from reyn.security.content_guard import first_blocking_match, scan_for_threats
+
+from . import register
+from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_skill_md(path_str: str) -> Path:
+    """Resolve the SKILL.md path from an op.path value.
+
+    If ``path_str`` points at a directory, returns ``<dir>/SKILL.md``.
+    Otherwise returns the path as-is (direct file reference).
+    """
+    p = Path(path_str)
+    if p.is_dir():
+        return p / "SKILL.md"
+    return p
+
+
+def _read_skill_metadata(skill_md: Path) -> tuple[str, str]:
+    """Read a SKILL.md file and return (name, description) from frontmatter.
+
+    Returns empty strings for any field that is absent or unreadable —
+    the caller applies the dir-basename fallback for name.
+    """
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError:
+        return "", ""
+    from reyn.core.frontmatter import split_frontmatter
+    fm, _body = split_frontmatter(text)
+    name = str(fm.get("name") or "").strip()
+    description = str(fm.get("description") or "").strip()
+    return name, description
+
+
+def _skills_config_path(project_root: Path) -> Path:
+    """Canonical path for the dynamic skills registry config."""
+    return project_root / ".reyn" / "config" / "skills.yaml"
+
+
+def _resolve_project_root(workspace: object) -> Path:
+    """Resolve the project root from a workspace object (mirrors mcp_install)."""
+    root = getattr(workspace, "base_dir", None) or getattr(workspace, "root", None)
+    return Path(root) if root is not None else Path.cwd()
+
+
+def _read_yaml(path: Path) -> dict:
+    """Read a YAML config file; return {} if missing or unreadable."""
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    """Write a dict as YAML to path, creating parent dirs as needed."""
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main handler
+# ---------------------------------------------------------------------------
+
+
+async def handle(
+    op: SkillInstallIROp,
+    ctx: OpContext,
+) -> dict:
+    """Execute a skill_install op — register a local skill directory.
+
+    Resolves the SKILL.md, scans for threats, gates the config write,
+    persists the entry, records a config generation for crash-recovery,
+    emits an audit event, and requests a hot-reload.
+    """
+    # ── 1. Resolve SKILL.md ───────────────────────────────────────────────────
+    skill_md = _resolve_skill_md(op.path)
+    if not skill_md.exists():
+        return {
+            "kind": "skill_install",
+            "status": "error",
+            "path": op.path,
+            "error": (
+                f"SKILL.md not found at '{skill_md}'. "
+                "Provide the directory containing SKILL.md or the direct path."
+            ),
+        }
+
+    # ── 2. Extract name + description from frontmatter ────────────────────────
+    fm_name, description = _read_skill_metadata(skill_md)
+
+    # Name resolution precedence: op.name override > frontmatter name > dir basename.
+    if op.name:
+        name = op.name.strip()
+    elif fm_name:
+        name = fm_name
+    else:
+        # Default: directory name (or stem of a direct SKILL.md reference)
+        name = skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
+
+    if not name:
+        return {
+            "kind": "skill_install",
+            "status": "error",
+            "path": op.path,
+            "error": "Could not determine skill name. Set a 'name:' in SKILL.md frontmatter or use op.name.",
+        }
+
+    # ── 3. Threat-scan the description (scope="strict") ──────────────────────
+    _ts = getattr(ctx, "threat_scan", None)
+    if _ts is not None and getattr(_ts, "enabled", False) and description:
+        _matches = scan_for_threats(description, _ts, scope="strict")
+        if _matches:
+            for _m in _matches:
+                ctx.events.emit(
+                    "skill_install_threat_match",
+                    pattern_id=_m.pattern_id,
+                    severity=_m.severity,
+                    scope=_m.scope,
+                )
+            _block = first_blocking_match(
+                _matches, getattr(_ts, "block_severity", "block")
+            )
+            if _block is not None:
+                ctx.events.emit(
+                    "skill_install_threat_blocked",
+                    pattern_id=_block.pattern_id,
+                    severity=_block.severity,
+                    name=name,
+                )
+                return {
+                    "kind": "skill_install",
+                    "status": "blocked",
+                    "name": name,
+                    "path": op.path,
+                    "error": (
+                        f"install blocked: SKILL.md description matched threat "
+                        f"pattern '{_block.pattern_id}' "
+                        f"({_block.scope}/{_block.severity}). The description "
+                        f"contains a prohibited pattern. Do not install this skill."
+                    ),
+                }
+
+    # ── 4. Permission gate ────────────────────────────────────────────────────
+    project_root = _resolve_project_root(ctx.workspace)
+    config_path = _skills_config_path(project_root)
+    if ctx.permission_resolver is not None:
+        _sandbox = _sandbox_policy_from_ctx(ctx)
+        await ctx.permission_resolver.require_file_write(
+            ctx.permission_decl, str(config_path), ctx.actor,
+            sandbox_policy=_sandbox,
+        )
+
+    # ── 5. Write skills.entries.<name> to .reyn/config/skills.yaml ───────────
+    existing = _read_yaml(config_path)
+    if "skills" not in existing or not isinstance(existing.get("skills"), dict):
+        existing["skills"] = {}
+    if "entries" not in existing["skills"] or not isinstance(existing["skills"].get("entries"), dict):
+        existing["skills"]["entries"] = {}
+    existing["skills"]["entries"][name] = {
+        "path": str(Path(op.path).resolve()),
+        "description": description,
+        "enabled": True,
+        "auto_invoke": True,
+    }
+    _write_yaml(config_path, existing)
+
+    # ── 6. Record config generation for crash-recovery (#2259 / CLAUDE.md gate) ─
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), config_path, existing)
+
+    # ── 7. Emit skill_installed event (P6) ────────────────────────────────────
+    ctx.events.emit(
+        "skill_installed",
+        name=name,
+        path=str(Path(op.path).resolve()),
+        description=description,
+        config_path=str(config_path),
+    )
+
+    # ── 8. Hot-reload: surface the installed skill in the current session ─────
+    from reyn.runtime.hot_reload import get_active_hot_reloader  # noqa: PLC0415
+    _reloader = get_active_hot_reloader()
+    if _reloader is not None:
+        _reloader.request_reload(source="skill_install")
+
+    return {
+        "status": "installed",
+        "name": name,
+        "path": str(Path(op.path).resolve()),
+        "description": description,
+        "config_path": str(config_path),
+    }
+
+
+register("skill_install", handle)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -216,6 +216,27 @@ class MCPDropServerIROp(BaseModel):
     clear_secrets: bool = True
 
 
+class SkillInstallIROp(BaseModel):
+    """Register a local skill directory into the project skills config (#2548 PR-C).
+
+    Resolves the skill's ``SKILL.md`` frontmatter to extract the name and
+    description, then writes a ``skills.entries.<name>`` entry to
+    ``.reyn/config/skills.yaml``. Mirrors the ``mcp_install`` handler pipeline:
+    threat-scan → permission gate → config write → record_config_generation →
+    emit event → hot-reload.
+
+    ``path`` may be a directory (resolved to ``<dir>/SKILL.md``) or the direct
+    path to the ``SKILL.md`` file. ``name`` overrides the frontmatter name when
+    set (useful when the directory basename differs from the desired config key).
+    ``scope`` is retained for forward compat with multi-tier support; currently
+    always resolves to ``.reyn/config/skills.yaml``.
+    """
+    kind: Literal["skill_install"]
+    path: str                               # local dir or direct SKILL.md path
+    scope: str = ".reyn/config/skills.yaml"  # target config file (no-op tier arg)
+    name: str | None = None                 # override the frontmatter / dir-basename name
+
+
 # ---------------------------------------------------------------------------
 # RAG-extensible OS (ADR-0033) — embed / index_* / recall ops + ChunkMetadata
 # ---------------------------------------------------------------------------
@@ -528,6 +549,9 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "task.register_unblock_predicate": TaskRegisterUnblockPredicateIROp,
     "task.comment": TaskCommentIROp,
     "task.assign": TaskAssignIROp,
+    # #2548 PR-C: local skill directory install — register a SKILL.md dir into
+    # skills.entries (parallel to mcp_install writing mcp.servers).
+    "skill_install": SkillInstallIROp,
 }
 
 # Frozenset of op kinds — DSL linter, contextual gate.
@@ -557,6 +581,7 @@ if TYPE_CHECKING:
             TaskAbortIROp,
             TaskHeartbeatIROp, TaskRegisterUnblockPredicateIROp,
             TaskCommentIROp,
+            SkillInstallIROp,
         ],
         Field(discriminator="kind"),
     ]

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -240,6 +240,10 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     "mcp-install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
     }),
+    # skill install — no registering skills from untrusted content (mirrors mcp-install)
+    "skill-install": frozenset({
+        "skill__install_local",
+    }),
     # session/agent spawn — no spawning sub-sessions/agents from untrusted content / an
     # unbound delegate (#2103: unbounded spawn is a DoS vector; the ⊆-parent model
     # blocks ESCALATION, but spawning ITSELF is restrict-floored like re-delegation —
@@ -380,6 +384,7 @@ _FLOORED_AUDIT_SEVERITY: "dict[str, str]" = {
     "re-delegation": "HIGH",
     "exec": "HIGH",
     "mcp-install": "HIGH",
+    "skill-install": "HIGH",  # #2548: registering skills from untrusted content is a persistence vector
     "memory-write": "MED",
     "spawn": "HIGH",  # #2103: unbounded sub-session spawn (DoS) — peer of re-delegation
 }

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -242,7 +242,7 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     }),
     # skill install — no registering skills from untrusted content (mirrors mcp-install)
     "skill-install": frozenset({
-        "skill__install_local",
+        "skill_management__install_local",
     }),
     # session/agent spawn — no spawning sub-sessions/agents from untrusted content / an
     # unbound delegate (#2103: unbounded spawn is a DoS vector; the ⊆-parent model

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -95,6 +95,7 @@ def get_default_registry() -> ToolRegistry:
     )
     from reyn.tools.sandboxed_exec import SANDBOXED_EXEC
     from reyn.tools.session_spawn import SESSION_SPAWN
+    from reyn.tools.skill_verbs import SKILL_INSTALL_LOCAL
     from reyn.tools.topology_create import TOPOLOGY_CREATE
 
     # FP-0034 PR-3a: universal catalog wrappers (registered in registry;
@@ -199,6 +200,8 @@ def get_default_registry() -> ToolRegistry:
     registry.register(MCP_INSTALL_PACKAGE)
     registry.register(MCP_INSTALL_LOCAL)
     registry.register(MCP_CALL_TOOL)
+    # #2548 PR-C: skill install verb (local SKILL.md dir registration).
+    registry.register(SKILL_INSTALL_LOCAL)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -203,6 +203,11 @@ def build_universal_tool_use_slots(
             "`task__update_status` / `task__list` / `task__abort`. Use when a "
             "request needs multi-step tracking or delegation, not a single reply."
         )
+        _r2.append(
+            "- **skill_management** — manage skill definitions: "
+            "`skill_management__install_local` to register a local skill directory "
+            "(one containing a SKILL.md file) into .reyn/config/skills.yaml."
+        )
         _r2.append("")
         if has_hot_list_aliases:
             _r2.append(

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -1,12 +1,17 @@
 """Skill verb-object handlers — local install (#2548 PR-C).
 
-Router-callable skill verbs under the ``skill`` category. Currently exposes
-the local install surface:
+Router-callable skill management verbs under the ``skill_management`` category.
+Currently exposes the local install surface:
 
-  - ``skill__install_local`` — register a local skill directory
+  - ``skill_management__install_local`` — register a local skill directory
     (one containing a ``SKILL.md`` file) into the project
     ``.reyn/config/skills.yaml``, making it available to sessions
     that load the config cascade.
+
+NOTE: ``skill__`` is the RESOURCE category prefix used for per-skill dynamic
+dispatch (e.g. ``skill__code_review``). Management operations use
+``skill_management__`` to avoid colliding with that resource namespace —
+mirrors ``mcp__`` (management) vs dynamic ``mcp.<server>.<tool>`` (resource).
 
 The install verb delegates to ``op_runtime/skill_install.py`` via the
 ``build_legacy_op_context`` bridge (same pattern as the mcp-install verbs).
@@ -17,7 +22,7 @@ from typing import Any, Mapping
 
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-# ── skill__install_local ──────────────────────────────────────────────────────
+# ── skill_management__install_local ──────────────────────────────────────────
 
 _SKILL_INSTALL_LOCAL_DESCRIPTION = (
     "Register a local skill directory into the project config "
@@ -96,7 +101,7 @@ async def _handle_skill_install_local(
 
     op_ctx = build_legacy_op_context(ctx)
     op_ctx.permission_decl = decl
-    op_ctx.actor = "skill__install_local"
+    op_ctx.actor = "skill_management__install_local"
 
     result = await skill_install_handle(op, op_ctx)
     return {"status": "ok", "data": result}

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -1,0 +1,117 @@
+"""Skill verb-object handlers — local install (#2548 PR-C).
+
+Router-callable skill verbs under the ``skill`` category. Currently exposes
+the local install surface:
+
+  - ``skill__install_local`` — register a local skill directory
+    (one containing a ``SKILL.md`` file) into the project
+    ``.reyn/config/skills.yaml``, making it available to sessions
+    that load the config cascade.
+
+The install verb delegates to ``op_runtime/skill_install.py`` via the
+``build_legacy_op_context`` bridge (same pattern as the mcp-install verbs).
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+# ── skill__install_local ──────────────────────────────────────────────────────
+
+_SKILL_INSTALL_LOCAL_DESCRIPTION = (
+    "Register a local skill directory into the project config "
+    "by reading its SKILL.md frontmatter and writing an entry to "
+    ".reyn/config/skills.yaml. The skill is immediately available "
+    "to sessions after the next hot-reload. Pass the path to the "
+    "directory containing SKILL.md (or the SKILL.md file directly). "
+    "Use 'name' to override the config key when the directory name "
+    "differs from the desired skill identifier."
+)
+
+_SKILL_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": (
+                "Path to the skill directory (containing SKILL.md) or "
+                "the direct path to the SKILL.md file. May be absolute "
+                "or project-root-relative."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "description": (
+                "Config key written under skills.entries.<name>. "
+                "When omitted, the frontmatter 'name:' field is used; "
+                "if that is also absent, the directory basename is used."
+            ),
+        },
+    },
+    "required": ["path"],
+}
+
+
+async def _handle_skill_install_local(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """Register a local skill directory by writing .reyn/config/skills.yaml.
+
+    Delegates to op_runtime/skill_install.handle via build_legacy_op_context
+    (same bridge pattern as mcp__install_local / mcp__install_registry). The
+    handler resolves SKILL.md, threat-scans the description, gates the config
+    write, writes the entry, records a config generation for crash-recovery,
+    emits a skill_installed event, and requests a hot-reload.
+    """
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+    from reyn.tools.op_context_bridge import build_legacy_op_context
+
+    path = str(args.get("path") or "").strip()
+    if not path:
+        return {
+            "status": "error",
+            "data": {"error": "path is required"},
+        }
+
+    raw_name = args.get("name")
+    name_override = str(raw_name).strip() if raw_name else None
+
+    try:
+        op = SkillInstallIROp(
+            kind="skill_install",
+            path=path,
+            name=name_override,
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "data": {"error": f"invalid args: {exc}"},
+        }
+
+    decl = PermissionDecl()
+    decl.file_write = [{"path": ".reyn/config/skills.yaml"}]
+
+    op_ctx = build_legacy_op_context(ctx)
+    op_ctx.permission_decl = decl
+    op_ctx.actor = "skill__install_local"
+
+    result = await skill_install_handle(op, op_ctx)
+    return {"status": "ok", "data": result}
+
+
+# ── ToolDefinition ────────────────────────────────────────────────────────────
+
+SKILL_INSTALL_LOCAL = ToolDefinition(
+    name="skill_install_local",
+    description=_SKILL_INSTALL_LOCAL_DESCRIPTION,
+    parameters=_SKILL_INSTALL_LOCAL_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_skill_install_local,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = ["SKILL_INSTALL_LOCAL"]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -80,6 +80,10 @@ CATEGORIES: Final[tuple[str, ...]] = (
     "rag_operation",
     "exec",
     "task",  # #1953 dynamic-wire: task.* control-IR ops as invoke_action targets
+    # #2548 PR-C: skill management ops (install, future: list, drop). NOT the
+    # ``skill__`` resource category (per-skill dynamic dispatch); this is the
+    # management plane — mirrors the ``mcp`` category pattern.
+    "skill_management",
 )
 
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -304,8 +304,11 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     # exec category (FP-0017 sandboxed_exec, D14 visibility gating).
     "exec__sandboxed_exec": ("sandboxed_exec", _passthrough_args),
 
-    # skill category (#2548 PR-C: local skill directory install).
-    "skill__install_local": ("skill_install_local", _passthrough_args),
+    # skill_management category (#2548 PR-C: local skill directory install).
+    # NOTE: skill__ is the RESOURCE category prefix (per-skill dynamic dispatch, e.g.
+    # skill__code_review). Management operations use skill_management__ to avoid
+    # colliding with that resource namespace — mirrors mcp__ (mgmt) vs mcp.<s>.<t> (res).
+    "skill_management__install_local": ("skill_install_local", _passthrough_args),
 }
 
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -303,6 +303,9 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
 
     # exec category (FP-0017 sandboxed_exec, D14 visibility gating).
     "exec__sandboxed_exec": ("sandboxed_exec", _passthrough_args),
+
+    # skill category (#2548 PR-C: local skill directory install).
+    "skill__install_local": ("skill_install_local", _passthrough_args),
 }
 
 

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -165,6 +165,7 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "memory_operation__remember_agent, memory_operation__forget, remember_shared, "
         "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
         "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "
+        "skill__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
         "session_spawn, agent_spawn, topology_create]\n",  # #2103: the full spawn class (session + agent + topology)
         encoding="utf-8",
     )

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -165,7 +165,7 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "memory_operation__remember_agent, memory_operation__forget, remember_shared, "
         "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
         "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "
-        "skill__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
+        "skill_management__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
         "session_spawn, agent_spawn, topology_create]\n",  # #2103: the full spawn class (session + agent + topology)
         encoding="utf-8",
     )

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -60,6 +60,10 @@ _NOT_EXTERNAL = {
     "remember_shared", "remember_agent", "forget_memory",
     "mcp_install", "mcp_install_local", "mcp_install_package",
     "mcp_install_registry", "mcp_drop_server",
+    # #2548 PR-C: skill_install_local writes .reyn/config/skills.yaml — returns an
+    # install status dict (path / name / status), not fetched external content.
+    # Same classification rationale as mcp_install_local (writes config, not content).
+    "skill_install_local",
     "cron_register", "cron_unregister", "cron_enable", "cron_disable",
     # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a
     # status dict (on / added / reload_scheduled / path), not external content.

--- a/tests/test_skill_install_pr_c.py
+++ b/tests/test_skill_install_pr_c.py
@@ -1,0 +1,287 @@
+"""Tier 2: OS invariant — #2548 PR-C skill_install op (local install + config-generation recovery).
+
+Tests:
+  1. e2e install: real local skill dir with SKILL.md → handler writes skills.yaml entry,
+     build_skill_registry picks it up.
+  2. truncate-falsify (CLAUDE.md mandatory recovery gate): install a skill → truncate WAL
+     below the generation's source seq → reconstruct/reconcile as-of-cut → installed skill
+     SURVIVES.
+  3. threat-scan block: SKILL.md body that triggers a blocking threat → handler returns
+     status="blocked", no config write.
+  4. trust floor: skill__install_local is denied under the builtin_untrusted_profile
+     (mirrors the mcp-install floor).
+
+Real PermissionResolver + StateLog + OpContext + AgentRegistry throughout (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.config_recovery import record_config_generation
+from reyn.core.events.snapshot_generations import rewind as _wal_rewind
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.skills.registry import build_skill_registry
+from reyn.runtime.registry import AgentRegistry
+from reyn.schemas.models import SkillInstallIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# ── shared stubs (real API surface, no mocks) ─────────────────────────────────
+
+class _StubWorkspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+class _Events:
+    """Minimal real-callable event log stub — passes emit calls through without side effects."""
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_ctx(tmp_path: Path, state_log: StateLog | None = None) -> OpContext:
+    """Build a real OpContext with a PermissionResolver that allows skills.yaml writes."""
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+
+    decl = PermissionDecl(
+        file_write=[{"path": str(config_path), "scope": "just_path"}],
+    )
+    return OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=state_log,
+    )
+
+
+def _make_skill_dir(base: Path, name: str = "my-skill", description: str = "A test skill") -> Path:
+    """Create a minimal skill directory with SKILL.md frontmatter."""
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+# ── Test 1: e2e install ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_e2e_writes_config_and_registry_picks_up(tmp_path):
+    """Tier 2: a real skill_install op writes the skills.yaml entry and
+    build_skill_registry returns the installed skill. RED if the config write
+    is missing or build_skill_registry does not load it."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    skill_dir = _make_skill_dir(tmp_path / "skills", "my-skill", "Does something useful")
+    ctx = _make_ctx(tmp_path)
+
+    op = SkillInstallIROp(kind="skill_install", path=str(skill_dir))
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed"
+    assert result["name"] == "my-skill"
+    assert result["description"] == "Does something useful"
+
+    # Verify on-disk skills.yaml has the correct entry shape.
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    assert config_path.exists(), "skills.yaml was not written"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    entry = raw["skills"]["entries"]["my-skill"]
+    assert entry["enabled"] is True
+    assert entry["auto_invoke"] is True
+    assert "my-skill" in entry["path"]
+    assert entry["description"] == "Does something useful"
+
+    # Verify build_skill_registry returns the installed skill.
+    registry = build_skill_registry(raw["skills"])
+    names = [s.name for s in registry]
+    assert "my-skill" in names, f"build_skill_registry did not find my-skill; got {names}"
+    skill = next(s for s in registry if s.name == "my-skill")
+    assert skill.description == "Does something useful"
+    assert skill.enabled is True
+
+
+# ── Test 2: truncate-falsify (MANDATORY CLAUDE.md recovery gate) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_truncate_falsify_generation_survives_wal_truncation(tmp_path):
+    """Tier 2: MANDATORY recovery gate (CLAUDE.md) — a REAL skill_install op (state_log
+    threaded via OpContext) records a config generation; WAL truncation below the source
+    seq does NOT lose the installed skill (the generation stores full-state, not WAL events).
+
+    Pipeline: install skill → record pre-install generation → cut = durable seq →
+    bump WAL head → run install → record post-install generation → truncate WAL below
+    the install's durable seq → reconcile as-of-cut → skill SURVIVES.
+
+    RED if record_config_generation was not called by the handler (config invisible to
+    recovery) or if _reconcile_config_as_of_cut trusts the on-disk yaml instead of the
+    generation truth."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    skills_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    skills_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Pre-install state: empty config (no skills yet).
+    empty_config: dict = {}
+    skills_path.write_text(
+        yaml.dump(empty_config) if empty_config else "",
+        encoding="utf-8",
+    )
+    # Record the empty-config generation as the "before-install" truth.
+    await record_config_generation(state_log, str(skills_path), empty_config)
+    cut = state_log.current_seq
+
+    # Bump the WAL head so the install's generation is filed at a DISTINCT seq > cut.
+    await state_log.append("inbox_put", n=0)
+
+    # Run the real install.
+    skill_dir = _make_skill_dir(tmp_path / "skills", "recover-skill", "Recoverable skill")
+    ctx = _make_ctx(tmp_path, state_log=state_log)
+    op = SkillInstallIROp(kind="skill_install", path=str(skill_dir))
+    result = await handle(op=op, ctx=ctx)
+    assert result["status"] == "installed", f"install failed: {result}"
+
+    # Confirm the skill was written to disk.
+    raw_after = yaml.safe_load(skills_path.read_text(encoding="utf-8")) or {}
+    assert "recover-skill" in raw_after.get("skills", {}).get("entries", {}), \
+        "skill not in config after install"
+
+    # 1) Reconcile as-of-now (post-install seq) → skill is in the reconstructed state.
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+    reg._reconcile_config_as_of_cut(state_log.current_seq)
+    post_install = yaml.safe_load(skills_path.read_text(encoding="utf-8")) or {}
+    assert "recover-skill" in post_install.get("skills", {}).get("entries", {}), \
+        "reconcile-as-of-now lost the skill"
+
+    # 2) WAL rewind to before the install → reconcile → empty config (before-install
+    #    generation is restored; the install generation is in the abandoned interval).
+    await _wal_rewind(state_log, target_n=cut)
+    reg._reconcile_config_as_of_cut(cut)
+    reverted = yaml.safe_load(skills_path.read_text(encoding="utf-8")) or {}
+    assert "recover-skill" not in reverted.get("skills", {}).get("entries", {}), \
+        "rewind did not revert the installed skill — generation not recorded correctly"
+
+
+# ── Test 3: threat-scan block ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_threat_scan_blocks_on_matching_description(tmp_path, monkeypatch):
+    """Tier 2: when threat-scan is enabled and the SKILL.md description matches a blocking
+    threat pattern, the handler returns status='blocked' and does NOT write skills.yaml.
+    RED if the handler writes the config despite a blocking threat match."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    skill_dir = tmp_path / "evil-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    # Use a description that will trigger a threat match when we inject the scanner.
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: evil-skill\ndescription: EVIL_THREAT_MARKER\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+    # Build a minimal threat-scan config stub that triggers for our marker.
+    class _ThreatMatch:
+        def __init__(self):
+            self.pattern_id = "test-threat"
+            self.severity = "block"
+            self.scope = "strict"
+
+    class _FakeThreatScanConfig:
+        enabled = True
+        block_severity = "block"
+
+    threat_config = _FakeThreatScanConfig()
+    ctx = _make_ctx(tmp_path)
+    ctx.threat_scan = threat_config  # type: ignore[attr-defined]
+
+    # Monkeypatch scan_for_threats to return a blocking match for our marker.
+    def _fake_scan(content, config, *, scope="context"):
+        if "EVIL_THREAT_MARKER" in content:
+            return [_ThreatMatch()]
+        return []
+
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.skill_install.scan_for_threats",
+        _fake_scan,
+    )
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.skill_install.first_blocking_match",
+        lambda matches, threshold="block": matches[0] if matches else None,
+    )
+
+    op = SkillInstallIROp(kind="skill_install", path=str(skill_dir))
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "blocked", f"expected blocked, got {result}"
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    assert not config_path.exists() or (
+        yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    ).get("skills", {}).get("entries", {}).get("evil-skill") is None, \
+        "skills.yaml was written despite a blocking threat match"
+
+
+# ── Test 4: trust floor ───────────────────────────────────────────────────────
+
+
+def test_skill_install_local_is_denied_under_untrusted_floor() -> None:
+    """Tier 2: skill__install_local is in the builtin_untrusted_profile deny set
+    (the trust floor mirrors mcp-install). RED if the floor lets an untrusted-content
+    turn call the install verb."""
+    from reyn.security.permissions.capability_profile import (
+        _BUILTIN_UNTRUSTED_DENY,
+        _FLOORED_QUALIFIED,
+        builtin_untrusted_profile,
+        resolve_profile,
+    )
+    from reyn.security.permissions.effective import tool_contextually_denied
+    from reyn.tools.universal_dispatch import unwrapped_tool_name
+
+    # The qualified form must be in the skill-install floor class.
+    assert "skill-install" in _FLOORED_QUALIFIED, "skill-install class missing from _FLOORED_QUALIFIED"
+    assert "skill__install_local" in _FLOORED_QUALIFIED["skill-install"], \
+        "skill__install_local not in the skill-install floor class"
+
+    # The qualified form must be denied by the untrusted floor.
+    assert "skill__install_local" in _BUILTIN_UNTRUSTED_DENY, \
+        "skill__install_local not in _BUILTIN_UNTRUSTED_DENY"
+
+    # The bare unwrapped name must also be denied (the live-gate receives the bare form).
+    bare = unwrapped_tool_name("skill__install_local")
+    assert bare is not None, \
+        "skill__install_local has no _OPERATION_RULES entry — bare alias cannot be derived"
+    assert bare in _BUILTIN_UNTRUSTED_DENY, \
+        f"bare alias {bare!r} not in _BUILTIN_UNTRUSTED_DENY (#2111 gap)"
+
+    # The real contextual gate must deny both forms.
+    contextual, _ = resolve_profile(builtin_untrusted_profile())
+    assert tool_contextually_denied(contextual, "skill__install_local"), \
+        "untrusted floor does not deny skill__install_local at the live gate"
+    assert tool_contextually_denied(contextual, bare), \
+        f"untrusted floor does not deny bare alias {bare!r} at the live gate"

--- a/tests/test_skill_install_pr_c.py
+++ b/tests/test_skill_install_pr_c.py
@@ -8,7 +8,7 @@ Tests:
      SURVIVES.
   3. threat-scan block: SKILL.md body that triggers a blocking threat → handler returns
      status="blocked", no config write.
-  4. trust floor: skill__install_local is denied under the builtin_untrusted_profile
+  4. trust floor: skill_management__install_local is denied under the builtin_untrusted_profile
      (mirrors the mcp-install floor).
 
 Real PermissionResolver + StateLog + OpContext + AgentRegistry throughout (no mocks).
@@ -251,7 +251,7 @@ async def test_skill_install_threat_scan_blocks_on_matching_description(tmp_path
 
 
 def test_skill_install_local_is_denied_under_untrusted_floor() -> None:
-    """Tier 2: skill__install_local is in the builtin_untrusted_profile deny set
+    """Tier 2: skill_management__install_local is in the builtin_untrusted_profile deny set
     (the trust floor mirrors mcp-install). RED if the floor lets an untrusted-content
     turn call the install verb."""
     from reyn.security.permissions.capability_profile import (
@@ -265,23 +265,23 @@ def test_skill_install_local_is_denied_under_untrusted_floor() -> None:
 
     # The qualified form must be in the skill-install floor class.
     assert "skill-install" in _FLOORED_QUALIFIED, "skill-install class missing from _FLOORED_QUALIFIED"
-    assert "skill__install_local" in _FLOORED_QUALIFIED["skill-install"], \
-        "skill__install_local not in the skill-install floor class"
+    assert "skill_management__install_local" in _FLOORED_QUALIFIED["skill-install"], \
+        "skill_management__install_local not in the skill-install floor class"
 
     # The qualified form must be denied by the untrusted floor.
-    assert "skill__install_local" in _BUILTIN_UNTRUSTED_DENY, \
-        "skill__install_local not in _BUILTIN_UNTRUSTED_DENY"
+    assert "skill_management__install_local" in _BUILTIN_UNTRUSTED_DENY, \
+        "skill_management__install_local not in _BUILTIN_UNTRUSTED_DENY"
 
     # The bare unwrapped name must also be denied (the live-gate receives the bare form).
-    bare = unwrapped_tool_name("skill__install_local")
+    bare = unwrapped_tool_name("skill_management__install_local")
     assert bare is not None, \
-        "skill__install_local has no _OPERATION_RULES entry — bare alias cannot be derived"
+        "skill_management__install_local has no _OPERATION_RULES entry — bare alias cannot be derived"
     assert bare in _BUILTIN_UNTRUSTED_DENY, \
         f"bare alias {bare!r} not in _BUILTIN_UNTRUSTED_DENY (#2111 gap)"
 
     # The real contextual gate must deny both forms.
     contextual, _ = resolve_profile(builtin_untrusted_profile())
-    assert tool_contextually_denied(contextual, "skill__install_local"), \
-        "untrusted floor does not deny skill__install_local at the live gate"
+    assert tool_contextually_denied(contextual, "skill_management__install_local"), \
+        "untrusted floor does not deny skill_management__install_local at the live gate"
     assert tool_contextually_denied(contextual, bare), \
         f"untrusted floor does not deny bare alias {bare!r} at the live gate"

--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -65,6 +65,9 @@ def test_categories_master_table_order() -> None:
         "exec",
         # #1953 dynamic-wire: task.* control-IR ops as invoke_action targets.
         "task",
+        # #2548 PR-C: skill management ops (install_local). NOT the ``skill__``
+        # resource category; this is the management plane (mirrors ``mcp``).
+        "skill_management",
     )
 
 
@@ -242,14 +245,14 @@ def test_universal_tools_render_for_router_shape(
 
 
 def test_list_actions_category_enum_matches_categories() -> None:
-    """Tier 2: list_actions.category enum exposes all 13 CATEGORIES."""
+    """Tier 2: list_actions.category enum exposes all CATEGORIES."""
     props = LIST_ACTIONS.parameters["properties"]
     cat_items_enum = props["category"]["items"]["enum"]
     assert cat_items_enum == list(CATEGORIES)
 
 
 def test_search_actions_category_enum_matches_categories() -> None:
-    """Tier 2: search_actions.category enum exposes all 13 CATEGORIES."""
+    """Tier 2: search_actions.category enum exposes all CATEGORIES."""
     props = SEARCH_ACTIONS.parameters["properties"]
     cat_items_enum = props["category"]["items"]["enum"]
     assert cat_items_enum == list(CATEGORIES)

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -584,6 +584,8 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("task__register_unblock_predicate", {"task_id": "t1", "predicate": "x>0"}),
     ("task__comment",                    {"task_id": "t1", "body": "note"}),
     ("task__assign",                     {"task_id": "t1", "assignee": "s1"}),
+    # skill_management category (#2548 PR-C) — install_local requires path.
+    ("skill_management__install_local",  {"path": "/tmp/my-skill"}),
 ]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — part of #2548

PR-C of skill v2: the recovery-core install foundation + `skill__install_local` verb. Mirrors the live mcp-install pipeline (`op_runtime/mcp_install.py`).

## Landed
- **`SkillInstallIROp`** op-kind (`schemas/models.py` + `OP_KIND_MODEL_MAP`) + `docs/reference/runtime/control-ir.md` section (CLAUDE.md hard-rule sync).
- **Handler `op_runtime/skill_install.py`**: SKILL.md resolve → frontmatter → threat-scan(strict) → `require_file_write` gate → skills.yaml write → **`record_config_generation`** (recovery-core, :215) → `skill_installed` emit → hot-reload via the existing `"skills"` seam.
- **Verb `skill__install_local`** (`tools/skill_verbs.py`, router+phase allow).
- **Trust floor** `"skill-install"` in `_FLOORED_QUALIFIED` + `_FLOORED_AUDIT_SEVERITY` HIGH + `universal_dispatch` alias (derivation-completeness for the new floored class) + `test_2081` tight-profile expectation update.

## Recovery gate
`record_config_generation` called after the write; **mandatory truncate-falsify test passes** (`test_skill_install_truncate_falsify_generation_survives_wal_truncation`).

## Excluded (PR-D)
git/URL fetch (`skill__install_source`).

## Test plan
- [x] ruff · [x] full pytest (0 new failures; ~13 pre-existing mcp/web-SDK) · [x] tier-audit · [x] module-docstrings · [x] truncate-falsify