### PR TITLE
feat(#2548): PR-D skill install_source (git/URL) — completes skill v2 install

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -313,11 +313,18 @@ Fields:
   forward compat; currently unused (all installs write to `.reyn/config/skills.yaml`).
 - `name` (optional) — config key override. When absent the handler resolves:
   frontmatter `name:` field → directory basename → repo/subdir basename (in that order).
+  The resolved name is **sanitized to a single safe path component** (`[A-Za-z0-9._-]`;
+  no `/`, `\`, `..`, or leading `.`) — an unsafe name (from caller `op.name` OR third-party
+  SKILL.md frontmatter) is **rejected** with `status="error"`, never used to build a path.
 
 Handler lifecycle (source path inserts steps 0a–0d before step 1):
-0. **Source path only**: (a) Gate `require_http_get` for the source host. (b) Shallow-clone
-   repo to `.reyn/skills/<candidate_name>/`. (c) Locate `SKILL.md` in root or subdir.
-   (d) After name is resolved from frontmatter, rename clone dir if name ≠ candidate.
+0. **Source path only**: (a) Gate `require_http_get` for the source host. (b) Sanitize the
+   candidate name (`_safe_skill_name`) + verify the clone destination is contained under
+   `.reyn/skills/` (`_contained_under`) — refuse before any filesystem mutation if either
+   fails (path-traversal → arbitrary-rmtree guard). Shallow-clone repo to
+   `.reyn/skills/<candidate_name>/`. (c) Locate `SKILL.md` in root or subdir.
+   (d) After the frontmatter name is resolved AND sanitized, containment-check + rename
+   clone dir if name ≠ candidate.
 1. Resolve `SKILL.md` path (dir → `<dir>/SKILL.md` or direct file)
 2. Read `SKILL.md` and `split_frontmatter()` — extract `name` and `description`
 3. Apply `op.name` override when set

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -25,7 +25,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `mcp` | Call a tool on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
-| `skill_install` | Register a local skill directory (containing `SKILL.md`) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter |
+| `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
 | `index_query` | Semantic vector search over one indexed source | none |
 | `recall` | Macro: embed query (provider-direct) → index_query per source → merge top-K | none (embedding API cost) |
 | `index_drop` | Remove an indexed source entirely (destructive) | `permissions.index_drop: ask` in skill frontmatter |
@@ -275,11 +275,12 @@ Handler lifecycle:
 
 ## `skill_install`
 
-Registers a local skill directory (containing a `SKILL.md` file) into the
-project's `skills.entries` config. The router tool surface is
-`skill__install_local`; phase-side code emits this op kind directly. Both
-converge on the same `op_runtime/skill_install.py` handler.
+Registers a skill (from a local directory or a git/GitHub source URL) into the
+project's `skills.entries` config. Two tool surface verbs converge on the same
+`op_runtime/skill_install.py` handler: `skill_management__install_local` (local
+path) and `skill_management__install_source` (git/URL, PR-D, #2548).
 
+Local-path example:
 ```json
 {
   "kind": "skill_install",
@@ -288,29 +289,52 @@ converge on the same `op_runtime/skill_install.py` handler.
 }
 ```
 
+Source/git example:
+```json
+{
+  "kind": "skill_install",
+  "source": "https://github.com/user/skill-repo",
+  "name": "my-skill"
+}
+```
+
+Subdir convention (mirrors Terraform): `"https://github.com/user/repo//skills/my-skill"`
+selects the `skills/my-skill` subdirectory inside the cloned repo.
+
 Fields:
-- `path` (required) — path to the skill directory (containing `SKILL.md`) or
-  the direct path to the `SKILL.md` file. May be absolute or project-root-relative.
-  When pointing at a directory the handler appends `/SKILL.md` automatically.
+- `path` (required when `source` is absent) — path to the skill directory (containing
+  `SKILL.md`) or the direct path to the `SKILL.md` file. May be absolute or
+  project-root-relative. When pointing at a directory the handler appends `/SKILL.md`.
+  Ignored when `source` is set.
+- `source` (optional, PR-D) — git or GitHub URL. The handler shallow-clones the repo
+  to `.reyn/skills/<name>/`. Subdir inside the repo is specified via `//` separator.
+  Requires `http.get: [{host: <source_host>}]` in the caller's permission declaration.
 - `scope` (optional, default `".reyn/config/skills.yaml"`) — retained for
   forward compat; currently unused (all installs write to `.reyn/config/skills.yaml`).
 - `name` (optional) — config key override. When absent the handler resolves:
-  frontmatter `name:` field → directory basename (in that precedence order).
+  frontmatter `name:` field → directory basename → repo/subdir basename (in that order).
 
-Handler lifecycle:
+Handler lifecycle (source path inserts steps 0a–0d before step 1):
+0. **Source path only**: (a) Gate `require_http_get` for the source host. (b) Shallow-clone
+   repo to `.reyn/skills/<candidate_name>/`. (c) Locate `SKILL.md` in root or subdir.
+   (d) After name is resolved from frontmatter, rename clone dir if name ≠ candidate.
 1. Resolve `SKILL.md` path (dir → `<dir>/SKILL.md` or direct file)
 2. Read `SKILL.md` and `split_frontmatter()` — extract `name` and `description`
 3. Apply `op.name` override when set
-4. Threat-scan description via `content_guard.scan_for_threats(scope="strict")` — block on blocking-severity match
+4. Threat-scan description via `content_guard.scan_for_threats(scope="strict")` — block on
+   blocking-severity match (source path: removes clone on block)
 5. Gate via `PermissionResolver.require_file_write` (= `.reyn/config/skills.yaml`)
-6. Write `skills.entries.<name>` to `.reyn/config/skills.yaml` with `{path, description, enabled: true, auto_invoke: true}`
+6. Write `skills.entries.<name>` to `.reyn/config/skills.yaml` with
+   `{path, description, enabled: true, auto_invoke: true}` (+ `source: <url>` when set)
 7. Call `record_config_generation` (recovery-core: truncation-surviving snapshot, #2259 / CLAUDE.md gate)
 8. Emit `skill_installed` event (P6 audit trail)
 9. Request hot-reload via `get_active_hot_reloader().request_reload(source="skill_install")`
 
-Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`, `path`, `description`, `config_path`.
+Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`, `path`,
+`description`, `config_path`, `source` (empty string for local installs).
 
-Events emitted: `skill_install_threat_match`, `skill_install_threat_blocked` (threat scan), `skill_installed` (P6 on success).
+Events emitted: `skill_install_threat_match`, `skill_install_threat_blocked` (threat scan),
+`skill_installed` (P6 on success).
 
 ## `index_query`
 

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -119,6 +119,62 @@ def _write_yaml(path: Path, data: dict) -> None:
     )
 
 
+def _safe_skill_name(raw: str) -> str | None:
+    """Reduce a raw skill name to a safe SINGLE path component, or None if unsafe.
+
+    Third-party content (SKILL.md frontmatter ``name:``) and caller-supplied
+    ``op.name`` both flow into the ``.reyn/skills/<name>/`` clone destination,
+    which is then ``shutil.rmtree``-d and cloned into. An unsanitized ``name``
+    like ``../../../../tmp/victim`` escapes ``.reyn/skills/`` and deletes an
+    arbitrary directory (path-traversal → arbitrary rmtree). This helper is the
+    FIRST line of defence: it rejects any name that is not a plain slug.
+
+    Rules (all must hold; else return None):
+      - non-empty after ``strip()``
+      - no path separators (``/`` or ``\\``)
+      - no ``..`` anywhere (traversal), no leading ``.`` (hidden / ``.``/``..``)
+      - charset restricted to ``[A-Za-z0-9._-]`` (no NUL, no whitespace, no
+        shell metacharacters, no unicode homoglyphs)
+      - not a reserved single/double dot component
+
+    Returns the name UNCHANGED when it is already safe (deterministic; no
+    silent slugification that could collide two distinct skills). Callers that
+    get None must refuse the install with a clear error — never construct a
+    filesystem path from an unsafe name.
+    """
+    import re
+
+    name = (raw or "").strip()
+    if not name:
+        return None
+    # Reject path separators and traversal outright (defence-in-depth: the
+    # charset check below also catches "/" and "\\", but ".." is within charset).
+    if "/" in name or "\\" in name or ".." in name:
+        return None
+    # Reject leading dot ("." / hidden files) — keeps the component non-special.
+    if name.startswith("."):
+        return None
+    # Restrict to a conservative slug charset.
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", name):
+        return None
+    return name
+
+
+def _contained_under(candidate: Path, root: Path) -> bool:
+    """Return True iff ``candidate`` resolves to a path inside ``root``.
+
+    Belt-and-suspenders containment check performed BEFORE any rmtree / clone /
+    rename, so even a gap in ``_safe_skill_name`` cannot let a filesystem
+    mutation escape ``.reyn/skills/``. Both paths are ``resolve()``-d (symlinks
+    + ``..`` collapsed) before the relativity test.
+    """
+    try:
+        candidate.resolve().relative_to(root.resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
 def _parse_source_spec(source: str) -> tuple[str, str]:
     """Split a source specifier into (git_url, subdir).
 
@@ -237,9 +293,42 @@ async def handle(
         _url_basename = git_url.rstrip("/").split("/")[-1]
         if _url_basename.endswith(".git"):
             _url_basename = _url_basename[:-4]
-        _candidate_name = (op.name or "").strip() or (subdir.split("/")[-1] if subdir else _url_basename)
+        _raw_candidate = (op.name or "").strip() or (subdir.split("/")[-1] if subdir else _url_basename)
 
-        clone_dest = project_root / ".reyn" / "skills" / _candidate_name
+        # SECURITY: sanitize the candidate name BEFORE any path construction.
+        # op.name is caller-controlled and the URL basename is attacker-influenced;
+        # an unsafe name would let clone_dest escape .reyn/skills/ (path-traversal
+        # → arbitrary rmtree). Reject rather than silently rewrite.
+        _candidate_name = _safe_skill_name(_raw_candidate)
+        if _candidate_name is None:
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "source": op.source,
+                "error": (
+                    f"invalid skill name derived from source: {_raw_candidate!r}. "
+                    "The install destination name must be a single path component "
+                    "(letters, digits, '.', '_', '-'; no '/', '\\', '..', or leading '.'). "
+                    "Set a safe 'name' or use a repo/subdir with a valid basename."
+                ),
+            }
+
+        _skills_root = project_root / ".reyn" / "skills"
+        clone_dest = _skills_root / _candidate_name
+
+        # SECURITY: belt-and-suspenders containment — refuse if clone_dest escapes
+        # .reyn/skills/ even after sanitization (guards a sanitizer gap). No
+        # filesystem mutation happens before this check passes.
+        if not _contained_under(clone_dest, _skills_root):
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "source": op.source,
+                "error": (
+                    f"refused: install destination for {_candidate_name!r} escapes "
+                    ".reyn/skills/. This is a path-containment violation."
+                ),
+            }
 
         # 0c. Shallow-clone the repo.
         clone_err = _shallow_clone(git_url, clone_dest)
@@ -290,14 +379,19 @@ async def handle(
 
     # Name resolution precedence: op.name override > frontmatter name > dir basename.
     if op.name:
-        name = op.name.strip()
+        raw_name = op.name.strip()
     elif fm_name:
-        name = fm_name
+        raw_name = fm_name
     else:
         # Default: directory name (or stem of a direct SKILL.md reference)
-        name = skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
+        raw_name = skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
 
-    if not name:
+    # SECURITY: sanitize the resolved name BEFORE it is used as a config key OR
+    # (for source installs) a filesystem path component. The frontmatter ``name:``
+    # is third-party content — a malicious ``name: ../../../evil`` would escape
+    # .reyn/skills/ at the rename step (path-traversal → arbitrary rmtree).
+    name = _safe_skill_name(raw_name)
+    if name is None:
         if op.source:
             shutil.rmtree(clone_dest, ignore_errors=True)
         return {
@@ -305,13 +399,30 @@ async def handle(
             "status": "error",
             "path": op.path,
             "source": op.source or "",
-            "error": "Could not determine skill name. Set a 'name:' in SKILL.md frontmatter or use op.name.",
+            "error": (
+                f"invalid skill name {raw_name!r}. The name must be a single path "
+                "component (letters, digits, '.', '_', '-'; no '/', '\\', '..', or "
+                "leading '.'). Fix the SKILL.md 'name:' frontmatter or pass a safe 'name'."
+            ),
         }
 
     # For source installs: if the resolved name differs from the candidate we used
     # for the clone destination, rename the clone dir to the resolved name.
     if op.source and name != _candidate_name:
-        new_dest = project_root / ".reyn" / "skills" / name
+        new_dest = _skills_root / name
+        # SECURITY: containment check BEFORE any rmtree/rename — refuse if new_dest
+        # escapes .reyn/skills/ even after sanitization (guards a sanitizer gap).
+        if not _contained_under(new_dest, _skills_root):
+            shutil.rmtree(clone_dest, ignore_errors=True)
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "source": op.source or "",
+                "error": (
+                    f"refused: install destination for {name!r} escapes .reyn/skills/. "
+                    "This is a path-containment violation."
+                ),
+            }
         if new_dest.exists():
             shutil.rmtree(new_dest)
         clone_dest.rename(new_dest)

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -1,6 +1,8 @@
-"""skill_install kind handler — register a local skill directory into the project config.
+"""skill_install kind handler — register a skill (local or from git/URL) into the project config.
 
 Handler logic (one-shot, no sub-phases):
+
+Local-path install (``op.source is None``):
   1. Resolve SKILL.md: ``op.path`` may be a directory (→ ``<dir>/SKILL.md``)
      or a direct path to the SKILL.md file. Read it and extract frontmatter.
   2. Extract name (frontmatter ``name:`` key, else directory basename) and
@@ -17,6 +19,17 @@ Handler logic (one-shot, no sub-phases):
   7. Emit ``skill_installed`` event (P6 audit trail).
   8. Request hot-reload so the installed skill goes live in the current session.
 
+Source/git install (``op.source`` set — #2548 PR-D):
+  Same pipeline as local, but step 0 fetches the skill first:
+  0a. Gate ``require_http_get`` for the source host (mirrors mcp_install.py).
+  0b. Shallow-clone the git repo (or subdir via ``//`` separator) to
+      ``.reyn/skills/<name>/``. Subdir convention: a ``"//subdir"`` suffix
+      in the source URL selects ``subdir`` inside the cloned repo; if absent,
+      the repo root is used.
+  0c. Locate the SKILL.md in the cloned dir (same dir-or-file resolution).
+  Steps 1–8 then proceed against the cloned SKILL.md path; the registered
+  ``path`` points at the installed copy under ``.reyn/skills/<name>/``.
+
 This is a P5 exception mirror of ``mcp_install``: ``.reyn/config/skills.yaml``
 lives outside the workspace data channel but is written directly here (same
 rationale — gated behind ``require_file_write`` + recorded via event for the
@@ -24,7 +37,10 @@ P6 audit trail).
 """
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 from reyn.schemas.models import SkillInstallIROp
 
@@ -103,6 +119,79 @@ def _write_yaml(path: Path, data: dict) -> None:
     )
 
 
+def _parse_source_spec(source: str) -> tuple[str, str]:
+    """Split a source specifier into (git_url, subdir).
+
+    Convention: ``"https://github.com/user/repo"`` → ``(url, "")``.
+    ``"https://github.com/user/repo//skills/my-skill"`` → ``(url_without_subdir, "skills/my-skill")``.
+
+    The ``//`` separator was chosen to mirror the Terraform module subdir
+    convention — it is not a valid part of a URL path and therefore unambiguous.
+    """
+    if "//" in source:
+        # Split on the FIRST "//" that appears after the scheme+host portion.
+        # For "https://github.com/user/repo//subdir", rfind gives us the last "//",
+        # which is exactly what we want for the Terraform-style subdir convention.
+        double_slash_idx = source.find("//", source.find("//") + 2)
+        if double_slash_idx != -1:
+            git_url = source[:double_slash_idx]
+            subdir = source[double_slash_idx + 2:].strip("/")
+            return git_url, subdir
+    return source, ""
+
+
+def _source_host(git_url: str) -> str | None:
+    """Extract the hostname from a git URL for permission gating.
+
+    Handles https:// and ssh:// URLs and git@host:path SSH URLs.
+    Returns ``None`` for local schemes (``file://``) where no HTTP gate is needed.
+    Returns the raw URL string as a fallback when parsing fails (safe for gate checks).
+    """
+    if git_url.startswith("git@"):
+        # git@github.com:user/repo.git → github.com
+        rest = git_url[4:]
+        return rest.split(":")[0]
+    try:
+        parsed = urlparse(git_url)
+        # Local file:// refs do not require an HTTP permission gate.
+        if parsed.scheme == "file":
+            return None
+        return parsed.hostname or git_url
+    except Exception:
+        return git_url
+
+
+def _shallow_clone(git_url: str, dest: Path) -> str | None:
+    """Shallow-clone a git repo to ``dest``.
+
+    Returns ``None`` on success, or an error message string on failure.
+    The destination directory is REMOVED before cloning so this function
+    is idempotent (re-install overwrites the previous clone).
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "clone", "--depth", "1", "--", git_url, str(dest)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            return (
+                f"git clone failed (exit {result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return None
+    except FileNotFoundError:
+        return "git is not installed or not in PATH. Install git and retry."
+    except subprocess.TimeoutExpired:
+        return "git clone timed out after 120 s. The repository may be unreachable."
+    except Exception as exc:  # noqa: BLE001
+        return f"git clone error: {exc}"
+
+
 # ---------------------------------------------------------------------------
 # Main handler
 # ---------------------------------------------------------------------------
@@ -112,24 +201,89 @@ async def handle(
     op: SkillInstallIROp,
     ctx: OpContext,
 ) -> dict:
-    """Execute a skill_install op — register a local skill directory.
+    """Execute a skill_install op — register a local or source-fetched skill.
 
-    Resolves the SKILL.md, scans for threats, gates the config write,
-    persists the entry, records a config generation for crash-recovery,
-    emits an audit event, and requests a hot-reload.
+    Local path (``op.source is None``): resolves SKILL.md from ``op.path``,
+    scans for threats, gates the config write, persists the entry, records a
+    config generation for crash-recovery, emits an audit event, and requests
+    a hot-reload.
+
+    Source/git path (``op.source`` set): additionally gates the source host
+    via ``require_http_get`` and shallow-clones the repo before the same
+    pipeline; the registered path points at the installed clone.
     """
-    # ── 1. Resolve SKILL.md ───────────────────────────────────────────────────
-    skill_md = _resolve_skill_md(op.path)
-    if not skill_md.exists():
-        return {
-            "kind": "skill_install",
-            "status": "error",
-            "path": op.path,
-            "error": (
-                f"SKILL.md not found at '{skill_md}'. "
-                "Provide the directory containing SKILL.md or the direct path."
-            ),
-        }
+    project_root = _resolve_project_root(ctx.workspace)
+
+    # ── 0. Source-fetch path (PR-D: git/GitHub URL) ───────────────────────────
+    if op.source:
+        git_url, subdir = _parse_source_spec(op.source)
+        host = _source_host(git_url)
+
+        # 0a. Permission gate: require_http_get for the source host.
+        # Skipped for local file:// refs (host is None) — no HTTP gate needed.
+        if ctx.permission_resolver is not None and host is not None:
+            _sandbox = _sandbox_policy_from_ctx(ctx)
+            await ctx.permission_resolver.require_http_get(
+                ctx.permission_decl,
+                host,
+                ctx.intervention_bus,
+                ctx.actor,
+                sandbox_policy=_sandbox,
+            )
+
+        # 0b. Determine install destination — a stable name under .reyn/skills/.
+        # Use op.name override if set; otherwise derive a candidate from the URL
+        # (last path segment without .git); will be overridden after SKILL.md read.
+        _url_basename = git_url.rstrip("/").split("/")[-1]
+        if _url_basename.endswith(".git"):
+            _url_basename = _url_basename[:-4]
+        _candidate_name = (op.name or "").strip() or (subdir.split("/")[-1] if subdir else _url_basename)
+
+        clone_dest = project_root / ".reyn" / "skills" / _candidate_name
+
+        # 0c. Shallow-clone the repo.
+        clone_err = _shallow_clone(git_url, clone_dest)
+        if clone_err:
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "source": op.source,
+                "error": clone_err,
+            }
+
+        # 0d. Locate the SKILL.md inside the clone (root or subdir).
+        skill_root = clone_dest / subdir if subdir else clone_dest
+        skill_md = _resolve_skill_md(str(skill_root))
+
+        if not skill_md.exists():
+            shutil.rmtree(clone_dest, ignore_errors=True)
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "source": op.source,
+                "error": (
+                    f"SKILL.md not found in cloned repo at '{skill_md}'. "
+                    "The repo root (or specified subdir) must contain a SKILL.md file."
+                ),
+            }
+
+        # Steps 1–8 now proceed using the cloned SKILL.md path.
+        install_path = str(skill_md.parent.resolve())
+
+    else:
+        # ── 1. Resolve SKILL.md (local path) ─────────────────────────────────
+        skill_md = _resolve_skill_md(op.path)
+        if not skill_md.exists():
+            return {
+                "kind": "skill_install",
+                "status": "error",
+                "path": op.path,
+                "error": (
+                    f"SKILL.md not found at '{skill_md}'. "
+                    "Provide the directory containing SKILL.md or the direct path."
+                ),
+            }
+        install_path = str(Path(op.path).resolve())
 
     # ── 2. Extract name + description from frontmatter ────────────────────────
     fm_name, description = _read_skill_metadata(skill_md)
@@ -144,12 +298,25 @@ async def handle(
         name = skill_md.parent.name if skill_md.name == "SKILL.md" else skill_md.stem
 
     if not name:
+        if op.source:
+            shutil.rmtree(clone_dest, ignore_errors=True)
         return {
             "kind": "skill_install",
             "status": "error",
             "path": op.path,
+            "source": op.source or "",
             "error": "Could not determine skill name. Set a 'name:' in SKILL.md frontmatter or use op.name.",
         }
+
+    # For source installs: if the resolved name differs from the candidate we used
+    # for the clone destination, rename the clone dir to the resolved name.
+    if op.source and name != _candidate_name:
+        new_dest = project_root / ".reyn" / "skills" / name
+        if new_dest.exists():
+            shutil.rmtree(new_dest)
+        clone_dest.rename(new_dest)
+        clone_dest = new_dest
+        install_path = str((new_dest / subdir if subdir else new_dest).resolve())
 
     # ── 3. Threat-scan the description (scope="strict") ──────────────────────
     _ts = getattr(ctx, "threat_scan", None)
@@ -173,11 +340,15 @@ async def handle(
                     severity=_block.severity,
                     name=name,
                 )
+                # Remove the clone on block — don't leave untrusted content on disk.
+                if op.source:
+                    shutil.rmtree(clone_dest, ignore_errors=True)
                 return {
                     "kind": "skill_install",
                     "status": "blocked",
                     "name": name,
-                    "path": op.path,
+                    "source": op.source or "",
+                    "path": install_path,
                     "error": (
                         f"install blocked: SKILL.md description matched threat "
                         f"pattern '{_block.pattern_id}' "
@@ -186,8 +357,7 @@ async def handle(
                     ),
                 }
 
-    # ── 4. Permission gate ────────────────────────────────────────────────────
-    project_root = _resolve_project_root(ctx.workspace)
+    # ── 4. Permission gate: skills.yaml write (+.reyn/skills/ for source) ────
     config_path = _skills_config_path(project_root)
     if ctx.permission_resolver is not None:
         _sandbox = _sandbox_policy_from_ctx(ctx)
@@ -202,12 +372,15 @@ async def handle(
         existing["skills"] = {}
     if "entries" not in existing["skills"] or not isinstance(existing["skills"].get("entries"), dict):
         existing["skills"]["entries"] = {}
-    existing["skills"]["entries"][name] = {
-        "path": str(Path(op.path).resolve()),
+    entry: dict = {
+        "path": install_path,
         "description": description,
         "enabled": True,
         "auto_invoke": True,
     }
+    if op.source:
+        entry["source"] = op.source
+    existing["skills"]["entries"][name] = entry
     _write_yaml(config_path, existing)
 
     # ── 6. Record config generation for crash-recovery (#2259 / CLAUDE.md gate) ─
@@ -218,9 +391,10 @@ async def handle(
     ctx.events.emit(
         "skill_installed",
         name=name,
-        path=str(Path(op.path).resolve()),
+        path=install_path,
         description=description,
         config_path=str(config_path),
+        source=op.source or "",
     )
 
     # ── 8. Hot-reload: surface the installed skill in the current session ─────
@@ -232,9 +406,10 @@ async def handle(
     return {
         "status": "installed",
         "name": name,
-        "path": str(Path(op.path).resolve()),
+        "path": install_path,
         "description": description,
         "config_path": str(config_path),
+        "source": op.source or "",
     }
 
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -217,7 +217,7 @@ class MCPDropServerIROp(BaseModel):
 
 
 class SkillInstallIROp(BaseModel):
-    """Register a local skill directory into the project skills config (#2548 PR-C).
+    """Register a skill into the project skills config (#2548 PR-C/PR-D).
 
     Resolves the skill's ``SKILL.md`` frontmatter to extract the name and
     description, then writes a ``skills.entries.<name>`` entry to
@@ -225,16 +225,27 @@ class SkillInstallIROp(BaseModel):
     threat-scan → permission gate → config write → record_config_generation →
     emit event → hot-reload.
 
-    ``path`` may be a directory (resolved to ``<dir>/SKILL.md``) or the direct
-    path to the ``SKILL.md`` file. ``name`` overrides the frontmatter name when
-    set (useful when the directory basename differs from the desired config key).
-    ``scope`` is retained for forward compat with multi-tier support; currently
-    always resolves to ``.reyn/config/skills.yaml``.
+    Two install paths:
+    - **Local path** (``source is None``): ``path`` points at a local directory
+      (resolved to ``<dir>/SKILL.md``) or a direct SKILL.md file.
+    - **Source path** (``source`` set): ``source`` is a git URL or GitHub URL.
+      The handler shallow-clones the repo to ``.reyn/skills/<name>/``, reads the
+      SKILL.md from that clone, and registers the installed copy's path.
+      ``path`` is ignored when ``source`` is set.
+
+    ``name`` overrides the frontmatter name when set (useful when the directory
+    basename differs from the desired config key). ``scope`` is retained for
+    forward compat with multi-tier support; currently always resolves to
+    ``.reyn/config/skills.yaml``.
     """
     kind: Literal["skill_install"]
-    path: str                               # local dir or direct SKILL.md path
+    path: str = ""                          # local dir or direct SKILL.md path (ignored when source set)
     scope: str = ".reyn/config/skills.yaml"  # target config file (no-op tier arg)
     name: str | None = None                 # override the frontmatter / dir-basename name
+    # When set, the skill is fetched from this git/GitHub URL (registry fetch skipped).
+    # Supports optional subdir via "//": "https://github.com/user/repo" (root) or
+    # "https://github.com/user/repo//skills/my-skill" (skills/my-skill subdir).
+    source: str | None = None              # git/GitHub URL (installs to .reyn/skills/<name>/)
 
 
 # ---------------------------------------------------------------------------

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -240,9 +240,12 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     "mcp-install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
     }),
-    # skill install — no registering skills from untrusted content (mirrors mcp-install)
+    # skill install — no registering skills from untrusted content (mirrors mcp-install).
+    # PR-D adds install_source (git/GitHub fetch) — same threat surface as install_local,
+    # and higher (remote fetch adds a new HTTP trust boundary).
     "skill-install": frozenset({
         "skill_management__install_local",
+        "skill_management__install_source",
     }),
     # session/agent spawn — no spawning sub-sessions/agents from untrusted content / an
     # unbound delegate (#2103: unbounded spawn is a DoS vector; the ⊆-parent model

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -95,7 +95,7 @@ def get_default_registry() -> ToolRegistry:
     )
     from reyn.tools.sandboxed_exec import SANDBOXED_EXEC
     from reyn.tools.session_spawn import SESSION_SPAWN
-    from reyn.tools.skill_verbs import SKILL_INSTALL_LOCAL
+    from reyn.tools.skill_verbs import SKILL_INSTALL_LOCAL, SKILL_INSTALL_SOURCE
     from reyn.tools.topology_create import TOPOLOGY_CREATE
 
     # FP-0034 PR-3a: universal catalog wrappers (registered in registry;
@@ -202,6 +202,8 @@ def get_default_registry() -> ToolRegistry:
     registry.register(MCP_CALL_TOOL)
     # #2548 PR-C: skill install verb (local SKILL.md dir registration).
     registry.register(SKILL_INSTALL_LOCAL)
+    # #2548 PR-D: skill install verb (git/GitHub URL source fetch).
+    registry.register(SKILL_INSTALL_SOURCE)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -206,7 +206,9 @@ def build_universal_tool_use_slots(
         _r2.append(
             "- **skill_management** — manage skill definitions: "
             "`skill_management__install_local` to register a local skill directory "
-            "(one containing a SKILL.md file) into .reyn/config/skills.yaml."
+            "(one containing a SKILL.md file) into .reyn/config/skills.yaml; "
+            "`skill_management__install_source` to fetch and install a skill from "
+            "a git/GitHub URL (shallow-clones to .reyn/skills/<name>/)."
         )
         _r2.append("")
         if has_hot_list_aliases:

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -1,19 +1,24 @@
-"""Skill verb-object handlers — local install (#2548 PR-C).
+"""Skill verb-object handlers — local install (#2548 PR-C) + source/git install (#2548 PR-D).
 
 Router-callable skill management verbs under the ``skill_management`` category.
-Currently exposes the local install surface:
+Exposes two install verbs:
 
   - ``skill_management__install_local`` — register a local skill directory
     (one containing a ``SKILL.md`` file) into the project
     ``.reyn/config/skills.yaml``, making it available to sessions
     that load the config cascade.
 
+  - ``skill_management__install_source`` — fetch a skill from a git/GitHub URL,
+    install it into ``.reyn/skills/<name>/``, and register the installed copy.
+    Requires a ``require_http_get`` gate for the source host + the
+    ``require_file_write`` gate for skills.yaml.
+
 NOTE: ``skill__`` is the RESOURCE category prefix used for per-skill dynamic
 dispatch (e.g. ``skill__code_review``). Management operations use
 ``skill_management__`` to avoid colliding with that resource namespace —
 mirrors ``mcp__`` (management) vs dynamic ``mcp.<server>.<tool>`` (resource).
 
-The install verb delegates to ``op_runtime/skill_install.py`` via the
+Both verbs delegate to ``op_runtime/skill_install.py`` via the
 ``build_legacy_op_context`` bridge (same pattern as the mcp-install verbs).
 """
 from __future__ import annotations
@@ -107,7 +112,103 @@ async def _handle_skill_install_local(
     return {"status": "ok", "data": result}
 
 
-# ── ToolDefinition ────────────────────────────────────────────────────────────
+# ── skill_management__install_source ─────────────────────────────────────────
+
+_SKILL_INSTALL_SOURCE_DESCRIPTION = (
+    "Fetch a skill from a git/GitHub URL and install it into the project. "
+    "The repo is shallow-cloned to .reyn/skills/<name>/, the SKILL.md is "
+    "threat-scanned, and an entry is written to .reyn/config/skills.yaml. "
+    "The skill is immediately available to sessions after the next hot-reload. "
+    "Requires http.get permission for the source host in the skill's frontmatter. "
+    "Source format: 'https://github.com/user/repo' (repo root must contain SKILL.md) "
+    "or 'https://github.com/user/repo//path/to/skill' (subdir with SKILL.md). "
+    "Use 'name' to override the config key when the default (from SKILL.md frontmatter "
+    "or repo/subdir basename) differs from the desired skill identifier."
+)
+
+_SKILL_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "source": {
+            "type": "string",
+            "description": (
+                "Git or GitHub URL of the skill repo. The root (or subdir "
+                "specified via '//' separator) must contain a SKILL.md file. "
+                "Examples: 'https://github.com/user/skill-repo' or "
+                "'https://github.com/user/monorepo//skills/my-skill'."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "description": (
+                "Config key written under skills.entries.<name>. "
+                "When omitted, the frontmatter 'name:' field is used; "
+                "if that is also absent, the repo/subdir basename is used."
+            ),
+        },
+    },
+    "required": ["source"],
+}
+
+
+async def _handle_skill_install_source(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """Fetch and install a skill from a git/GitHub URL.
+
+    Delegates to op_runtime/skill_install.handle via build_legacy_op_context
+    (same bridge pattern as mcp__install_package). The handler:
+      1. Gates require_http_get for the source host.
+      2. Shallow-clones the repo to .reyn/skills/<name>/.
+      3. Reads SKILL.md frontmatter from the clone (root or subdir via //).
+      4. Threat-scans the description (scope=strict; block on blocking match).
+      5. Gates require_file_write for .reyn/config/skills.yaml.
+      6. Writes the skills.yaml entry with the installed clone path + source URL.
+      7. Records a config generation for crash-recovery.
+      8. Emits skill_installed event and requests a hot-reload.
+    """
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+    from reyn.tools.op_context_bridge import build_legacy_op_context
+
+    source = str(args.get("source") or "").strip()
+    if not source:
+        return {
+            "status": "error",
+            "data": {"error": "source is required"},
+        }
+
+    raw_name = args.get("name")
+    name_override = str(raw_name).strip() if raw_name else None
+
+    try:
+        op = SkillInstallIROp(
+            kind="skill_install",
+            source=source,
+            name=name_override,
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "data": {"error": f"invalid args: {exc}"},
+        }
+
+    decl = PermissionDecl()
+    decl.file_write = [{"path": ".reyn/config/skills.yaml"}]
+    # Declare http.get with wildcard — the source host is determined at call time.
+    # The resolver gates the actual host via the wildcard path (= JIT prompt).
+    decl.http_get = [{"host": "*"}]
+
+    op_ctx = build_legacy_op_context(ctx)
+    op_ctx.permission_decl = decl
+    op_ctx.actor = "skill_management__install_source"
+
+    result = await skill_install_handle(op, op_ctx)
+    return {"status": "ok", "data": result}
+
+
+# ── ToolDefinitions ───────────────────────────────────────────────────────────
 
 SKILL_INSTALL_LOCAL = ToolDefinition(
     name="skill_install_local",
@@ -119,4 +220,14 @@ SKILL_INSTALL_LOCAL = ToolDefinition(
     purity="side_effect",
 )
 
-__all__ = ["SKILL_INSTALL_LOCAL"]
+SKILL_INSTALL_SOURCE = ToolDefinition(
+    name="skill_install_source",
+    description=_SKILL_INSTALL_SOURCE_DESCRIPTION,
+    parameters=_SKILL_INSTALL_SOURCE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_skill_install_source,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = ["SKILL_INSTALL_LOCAL", "SKILL_INSTALL_SOURCE"]

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -304,11 +304,12 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     # exec category (FP-0017 sandboxed_exec, D14 visibility gating).
     "exec__sandboxed_exec": ("sandboxed_exec", _passthrough_args),
 
-    # skill_management category (#2548 PR-C: local skill directory install).
+    # skill_management category (#2548 PR-C/PR-D: skill directory install verbs).
     # NOTE: skill__ is the RESOURCE category prefix (per-skill dynamic dispatch, e.g.
     # skill__code_review). Management operations use skill_management__ to avoid
     # colliding with that resource namespace — mirrors mcp__ (mgmt) vs mcp.<s>.<t> (res).
-    "skill_management__install_local": ("skill_install_local", _passthrough_args),
+    "skill_management__install_local":  ("skill_install_local",  _passthrough_args),
+    "skill_management__install_source": ("skill_install_source", _passthrough_args),
 }
 
 

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -166,6 +166,7 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
         "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "
         "skill_management__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
+        "skill_management__install_source, skill_install_source, "  # #2548 PR-D: source install
         "session_spawn, agent_spawn, topology_create]\n",  # #2103: the full spawn class (session + agent + topology)
         encoding="utf-8",
     )

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -64,6 +64,12 @@ _NOT_EXTERNAL = {
     # install status dict (path / name / status), not fetched external content.
     # Same classification rationale as mcp_install_local (writes config, not content).
     "skill_install_local",
+    # #2548 PR-D: skill_install_source shallow-clones a git repo and writes
+    # .reyn/config/skills.yaml — returns an install status dict, not the fetched
+    # repo content. The cloned SKILL.md is threat-scanned before registration;
+    # the scan result is internal OS state, not forwarded external content.
+    # Same classification rationale as mcp_install_package (installs, does not relay).
+    "skill_install_source",
     "cron_register", "cron_unregister", "cron_enable", "cron_disable",
     # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a
     # status dict (on / added / reload_scheduled / path), not external content.

--- a/tests/test_skill_install_pr_c.py
+++ b/tests/test_skill_install_pr_c.py
@@ -285,3 +285,36 @@ def test_skill_install_local_is_denied_under_untrusted_floor() -> None:
         "untrusted floor does not deny skill_management__install_local at the live gate"
     assert tool_contextually_denied(contextual, bare), \
         f"untrusted floor does not deny bare alias {bare!r} at the live gate"
+
+
+def test_skill_install_source_is_denied_under_untrusted_floor() -> None:
+    """Tier 2: skill_management__install_source is in the builtin_untrusted_profile deny set
+    (#2548 PR-D: source/git install — higher risk than local, adds HTTP trust boundary).
+    RED if the floor lets an untrusted-content turn call the source install verb."""
+    from reyn.security.permissions.capability_profile import (
+        _BUILTIN_UNTRUSTED_DENY,
+        _FLOORED_QUALIFIED,
+        builtin_untrusted_profile,
+        resolve_profile,
+    )
+    from reyn.security.permissions.effective import tool_contextually_denied
+    from reyn.tools.universal_dispatch import unwrapped_tool_name
+
+    assert "skill-install" in _FLOORED_QUALIFIED, "skill-install class missing from _FLOORED_QUALIFIED"
+    assert "skill_management__install_source" in _FLOORED_QUALIFIED["skill-install"], \
+        "skill_management__install_source not in the skill-install floor class"
+
+    assert "skill_management__install_source" in _BUILTIN_UNTRUSTED_DENY, \
+        "skill_management__install_source not in _BUILTIN_UNTRUSTED_DENY"
+
+    bare = unwrapped_tool_name("skill_management__install_source")
+    assert bare is not None, \
+        "skill_management__install_source has no _OPERATION_RULES entry — bare alias cannot be derived"
+    assert bare in _BUILTIN_UNTRUSTED_DENY, \
+        f"bare alias {bare!r} not in _BUILTIN_UNTRUSTED_DENY (#2111 gap)"
+
+    contextual, _ = resolve_profile(builtin_untrusted_profile())
+    assert tool_contextually_denied(contextual, "skill_management__install_source"), \
+        "untrusted floor does not deny skill_management__install_source at the live gate"
+    assert tool_contextually_denied(contextual, bare), \
+        f"untrusted floor does not deny bare alias {bare!r} at the live gate"

--- a/tests/test_skill_install_pr_d.py
+++ b/tests/test_skill_install_pr_d.py
@@ -10,6 +10,10 @@ Tests:
      the cloned repo.
   5. config-generation smoke: source install records a config generation (handler
      calls record_config_generation — same recovery contract as install_local).
+  6/7. SECURITY: path-traversal → arbitrary rmtree is refused for both the
+     frontmatter ``name:`` (third-party content) and caller ``op.name`` — a sentinel
+     dir outside .reyn/skills/ survives the attempted install.
+  8. _safe_skill_name unit: rejects traversal / separators / hidden names.
 
 Real PermissionResolver + StateLog + OpContext throughout (no mocks for
 collaborators; monkeypatch used only for the threat-scan scan_for_threats callable
@@ -328,3 +332,107 @@ async def test_skill_install_source_records_config_generation(tmp_path):
     gen_files = list(gen_dir.glob("*.yaml"))
     assert gen_files, \
         f"no generation files in {gen_dir} — record_config_generation did not write a snapshot"
+
+
+# ── Test 6/7: SECURITY — path-traversal → arbitrary rmtree is refused ─────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_frontmatter_name_traversal_refused(tmp_path):
+    """Tier 2: SECURITY — a malicious SKILL.md frontmatter ``name: ../../../evil``
+    (third-party content) must NOT let the install escape .reyn/skills/. The
+    install is refused (status='error') and a sentinel directory OUTSIDE
+    .reyn/skills/ is neither created nor removed.
+
+    RED against the pre-fix code (unsanitized frontmatter name flows into
+    new_dest → shutil.rmtree of an arbitrary directory)."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    # Sentinel dir OUTSIDE .reyn/skills/ — the traversal target would land here.
+    sentinel = tmp_path / "victim"
+    sentinel.mkdir(parents=True, exist_ok=True)
+    (sentinel / "important.txt").write_text("do not delete me", encoding="utf-8")
+
+    # A git repo whose SKILL.md frontmatter name traverses up to the sentinel.
+    # ../../../../<tmp>/victim would, unsanitized, resolve to the sentinel dir.
+    malicious_name = "../../../../victim"
+    repo = _make_git_skill_repo(
+        tmp_path / "repos", name=malicious_name, description="Traversal attack",
+    )
+    source_url = repo.as_uri()
+
+    ctx, _events = _make_ctx(tmp_path)
+    # Pass op.name that is safe so the candidate/clone step succeeds, then the
+    # MALICIOUS frontmatter name is picked up at the rename step (the vuln point).
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    # Frontmatter name wins over the URL basename in precedence; the malicious
+    # name must be rejected → status='error', not 'installed'.
+    assert result["status"] == "error", f"traversal name was not refused: {result}"
+    assert "invalid skill name" in result.get("error", "").lower() or \
+           "escapes" in result.get("error", "").lower(), \
+        f"error did not indicate name rejection / containment: {result}"
+
+    # The sentinel dir and its file MUST still exist (no arbitrary rmtree).
+    assert sentinel.exists(), "SECURITY: sentinel directory was deleted (arbitrary rmtree)"
+    assert (sentinel / "important.txt").exists(), \
+        "SECURITY: sentinel file was deleted (path-traversal succeeded)"
+
+    # No skills.yaml entry for the malicious name.
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    entries = (raw or {}).get("skills", {}).get("entries", {})
+    assert not any(".." in k for k in entries), \
+        f"SECURITY: a traversal-named entry was registered: {list(entries)}"
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_op_name_traversal_refused(tmp_path):
+    """Tier 2: SECURITY — a caller-supplied ``op.name = '../../x'`` must NOT let
+    the clone destination escape .reyn/skills/. The install is refused and a
+    sentinel directory outside .reyn/skills/ is neither created nor removed.
+
+    RED against the pre-fix code (unsanitized op.name flows into _candidate_name
+    → clone_dest → shutil.rmtree in _shallow_clone)."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    sentinel = tmp_path / "victim2"
+    sentinel.mkdir(parents=True, exist_ok=True)
+    (sentinel / "keep.txt").write_text("keep", encoding="utf-8")
+
+    repo = _make_git_skill_repo(tmp_path / "repos", name="benign", description="Benign")
+    source_url = repo.as_uri()
+
+    ctx, _events = _make_ctx(tmp_path)
+    op = SkillInstallIROp(
+        kind="skill_install", source=source_url, name="../../../../victim2",
+    )
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "error", f"op.name traversal was not refused: {result}"
+    assert "invalid skill name" in result.get("error", "").lower() or \
+           "escapes" in result.get("error", "").lower(), \
+        f"error did not indicate name rejection / containment: {result}"
+
+    # Sentinel must survive — no clone dir was created there and nothing removed.
+    assert sentinel.exists(), "SECURITY: sentinel2 directory was deleted (arbitrary rmtree)"
+    assert (sentinel / "keep.txt").exists(), \
+        "SECURITY: sentinel2 file was deleted (path-traversal via op.name succeeded)"
+
+
+def test_safe_skill_name_rejects_traversal_and_separators():
+    """Tier 2: SECURITY — _safe_skill_name rejects traversal / separator / hidden
+    names and accepts plain slugs. Direct unit coverage of the sanitizer contract."""
+    from reyn.core.op_runtime.skill_install import _safe_skill_name
+
+    # Unsafe → None.
+    for unsafe in [
+        "", "   ", "..", ".", "../evil", "../../x", "a/b", "a\\b",
+        ".hidden", "foo/../bar", "a b", "na\x00me", "évil",  # non-ascii homoglyph
+    ]:
+        assert _safe_skill_name(unsafe) is None, f"expected None for unsafe name {unsafe!r}"
+
+    # Safe → unchanged.
+    for safe in ["my-skill", "code_review", "skill.v2", "ABC123", "a-b_c.d"]:
+        assert _safe_skill_name(safe) == safe, f"expected {safe!r} accepted unchanged"

--- a/tests/test_skill_install_pr_d.py
+++ b/tests/test_skill_install_pr_d.py
@@ -1,0 +1,330 @@
+"""Tier 2: OS invariant — #2548 PR-D skill_install source/git install.
+
+Tests:
+  1. e2e source install: a local git repo (file:// URL) as the source → handler
+     clones it, writes skills.yaml entry, entry path points under .reyn/skills/.
+  2. Threat-scan block on a fetched SKILL.md with a malicious description →
+     status="blocked", clone removed, no config write.
+  3. require_http_get gate is exercised on the source host.
+  4. Subdir convention: "file:///path/to/repo//subdir" selects a subdirectory inside
+     the cloned repo.
+  5. config-generation smoke: source install records a config generation (handler
+     calls record_config_generation — same recovery contract as install_local).
+
+Real PermissionResolver + StateLog + OpContext throughout (no mocks for
+collaborators; monkeypatch used only for the threat-scan scan_for_threats callable
+in the threat-block test, which is the documented testing idiom from PR-C).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.runtime.registry import AgentRegistry
+from reyn.schemas.models import SkillInstallIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# ── shared stubs (mirrors test_skill_install_pr_c.py) ─────────────────────────
+
+
+class _StubWorkspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+class _Events:
+    """Minimal real-callable event log stub — records emitted events for assertion."""
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, kind: str, **kwargs) -> None:
+        self.emitted.append((kind, kwargs))
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    state_log: StateLog | None = None,
+    http_get_approved: bool = True,
+) -> tuple[OpContext, _Events]:
+    """Build a real OpContext with a PermissionResolver that approves skills.yaml writes
+    and (optionally) http.get for the source host."""
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+    if http_get_approved:
+        # Pre-approve http.get for all hosts (= wildcard approval for test isolation).
+        # The live gate still runs the resolver path; this bypasses the interactive
+        # prompt so tests don't block on stdin.
+        resolver.session_approve_host("*", "test")
+
+    decl = PermissionDecl(
+        file_write=[{"path": str(config_path), "scope": "just_path"}],
+        http_get=[{"host": "*"}],
+    )
+    events = _Events()
+    ctx = OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=events,
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=state_log,
+    )
+    return ctx, events
+
+
+def _make_git_skill_repo(base: Path, name: str = "source-skill", description: str = "From git") -> Path:
+    """Create a minimal git repo containing a SKILL.md at the root."""
+    repo = base / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    skill_md = repo / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, check=True)
+    return repo
+
+
+def _make_git_skill_repo_with_subdir(
+    base: Path,
+    subdir: str = "skills/my-skill",
+    name: str = "subdir-skill",
+    description: str = "In a subdir",
+) -> Path:
+    """Create a git repo with the SKILL.md under a subdirectory."""
+    repo = base / "monorepo"
+    skill_dir = repo / subdir
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, check=True)
+    return repo
+
+
+# ── Test 1: e2e source install via local file:// git remote ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_e2e_clones_and_registers(tmp_path):
+    """Tier 2: a real skill_install op with source= clones the git repo to
+    .reyn/skills/<name>/, writes skills.yaml, and the entry path points to the
+    installed clone. RED if the clone is absent or skills.yaml lacks the entry."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    repo = _make_git_skill_repo(tmp_path / "repos", "source-skill", "A git-sourced skill")
+    source_url = repo.as_uri()  # file:///...
+
+    ctx, events = _make_ctx(tmp_path)
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed", f"expected installed, got {result}"
+    assert result["name"] == "source-skill"
+    assert result["description"] == "A git-sourced skill"
+    assert result["source"] == source_url
+
+    # The install path must be under .reyn/skills/, not the original repo.
+    install_path = Path(result["path"])
+    assert ".reyn" in install_path.parts or ".reyn" in str(install_path), \
+        f"installed path not under .reyn/: {install_path}"
+    assert (install_path / "SKILL.md").exists() or (install_path.parent / "SKILL.md").exists() or \
+           Path(result["path"]).exists(), \
+        f"SKILL.md not found at installed path {result['path']}"
+
+    # skills.yaml must have the entry with source field.
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    assert config_path.exists(), "skills.yaml was not written"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    entry = raw["skills"]["entries"]["source-skill"]
+    assert entry["enabled"] is True
+    assert entry["auto_invoke"] is True
+    assert entry["source"] == source_url
+    assert ".reyn" in entry["path"] or str(tmp_path) in entry["path"]
+
+    # skill_installed event must be emitted.
+    kinds = [k for k, _ in events.emitted]
+    assert "skill_installed" in kinds, f"skill_installed event not emitted; got {kinds}"
+
+
+# ── Test 2: threat-scan block on fetched SKILL.md ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_threat_scan_blocks_and_removes_clone(tmp_path, monkeypatch):
+    """Tier 2: when the fetched SKILL.md description triggers a blocking threat,
+    the handler returns status='blocked', the clone is removed, and skills.yaml
+    is NOT written. RED if the handler writes config or leaves the clone on disk."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    repo = _make_git_skill_repo(tmp_path / "repos", "evil-skill", "EVIL_THREAT_MARKER")
+    source_url = repo.as_uri()
+
+    class _ThreatMatch:
+        def __init__(self):
+            self.pattern_id = "test-threat"
+            self.severity = "block"
+            self.scope = "strict"
+
+    class _FakeThreatScanConfig:
+        enabled = True
+        block_severity = "block"
+
+    ctx, _events = _make_ctx(tmp_path)
+    ctx.threat_scan = _FakeThreatScanConfig()  # type: ignore[attr-defined]
+
+    def _fake_scan(content, config, *, scope="context"):
+        if "EVIL_THREAT_MARKER" in content:
+            return [_ThreatMatch()]
+        return []
+
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.skill_install.scan_for_threats",
+        _fake_scan,
+    )
+    monkeypatch.setattr(
+        "reyn.core.op_runtime.skill_install.first_blocking_match",
+        lambda matches, threshold="block": matches[0] if matches else None,
+    )
+
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "blocked", f"expected blocked, got {result}"
+
+    # skills.yaml must NOT have an entry for evil-skill.
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    assert (raw or {}).get("skills", {}).get("entries", {}).get("evil-skill") is None, \
+        "skills.yaml was written despite a blocking threat match"
+
+    # The clone must be removed after a block.
+    clone_dir = tmp_path / ".reyn" / "skills" / "evil-skill"
+    assert not clone_dir.exists(), \
+        f"clone directory {clone_dir} was not removed after threat block"
+
+
+# ── Test 3: require_http_get gate is exercised ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_gates_http_get(tmp_path, monkeypatch):
+    """Tier 2: the handler calls require_http_get for non-local (https/ssh) sources.
+    When http.get is NOT approved and a non-file source URL is given, a PermissionError
+    is raised before any clone. file:// refs skip the gate (local only, no HTTP).
+
+    Uses monkeypatch on _shallow_clone so the test does not require network access.
+    The gate fires before the clone call, so the clone stub is never reached on deny."""
+    from reyn.core.op_runtime import skill_install as _si_mod
+    from reyn.core.op_runtime.skill_install import handle
+
+    # Monkeypatch _shallow_clone to succeed (would only be reached on allow; on deny
+    # the gate raises before clone). This avoids real network calls for https sources.
+    def _fake_clone(git_url, dest):
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "SKILL.md").write_text(
+            "---\nname: gated-skill\ndescription: Gated\n---\nBody.\n",
+            encoding="utf-8",
+        )
+        return None  # success
+
+    monkeypatch.setattr(_si_mod, "_shallow_clone", _fake_clone)
+
+    # Non-file source — https host will be gate-checked.
+    source_url = "https://github.com/example/gated-skill"
+
+    # Create ctx WITHOUT http_get approval (http_get_approved=False).
+    ctx, _events = _make_ctx(tmp_path, http_get_approved=False)
+
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    with pytest.raises(PermissionError):
+        await handle(op=op, ctx=ctx)
+
+    # No clone should exist (gate fired before clone).
+    clone_dir = tmp_path / ".reyn" / "skills" / "gated-skill"
+    assert not clone_dir.exists(), "clone was created despite missing http.get permission"
+
+
+# ── Test 4: subdir convention (// separator) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_subdir_convention(tmp_path):
+    """Tier 2: a source URL with '//' subdir separator installs the skill from
+    the specified subdirectory. RED if the handler uses the repo root or fails."""
+    from reyn.core.op_runtime.skill_install import handle
+
+    repo = _make_git_skill_repo_with_subdir(
+        tmp_path / "repos",
+        subdir="skills/my-skill",
+        name="subdir-skill",
+        description="Lives in a subdir",
+    )
+    # Subdir convention: repo_url//skills/my-skill
+    source_url = repo.as_uri() + "//skills/my-skill"
+
+    ctx, _events = _make_ctx(tmp_path)
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed", f"expected installed, got {result}"
+    assert result["name"] == "subdir-skill"
+    assert result["description"] == "Lives in a subdir"
+
+
+# ── Test 5: config-generation smoke (recovery contract) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_install_source_records_config_generation(tmp_path):
+    """Tier 2: a source install calls record_config_generation — the recovery
+    contract (CLAUDE.md gate) applies to source installs just as to local ones.
+    Smoke check: a config generation file is written under .reyn/config/generations/
+    after the install (mirrors test_skill_install_pr_c truncate-falsify contract)."""
+    from reyn.core.events.config_generations import ConfigGenerationStore
+    from reyn.core.events.config_recovery import config_generations_dir
+    from reyn.core.op_runtime.skill_install import handle
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    repo = _make_git_skill_repo(tmp_path / "repos", "recover-source-skill", "Recoverable source skill")
+    source_url = repo.as_uri()
+
+    ctx, _events = _make_ctx(tmp_path, state_log=state_log)
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed", f"install failed: {result}"
+
+    # A config generation file must exist under .reyn/config/generations/ — this is
+    # the truncation-surviving recovery base. The store writes rel@seq.yaml files.
+    gen_dir = config_generations_dir(tmp_path / ".reyn")
+    assert gen_dir.exists(), "config generations dir was not created — record_config_generation not called"
+    gen_files = list(gen_dir.glob("*.yaml"))
+    assert gen_files, \
+        f"no generation files in {gen_dir} — record_config_generation did not write a snapshot"

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -586,6 +586,8 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("task__assign",                     {"task_id": "t1", "assignee": "s1"}),
     # skill_management category (#2548 PR-C) — install_local requires path.
     ("skill_management__install_local",  {"path": "/tmp/my-skill"}),
+    # skill_management category (#2548 PR-D) — install_source requires source URL.
+    ("skill_management__install_source", {"source": "https://github.com/user/skill-repo"}),
 ]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — part of #2548

## Summary

- **Extends `SkillInstallIROp`** with `source: str | None` field (mirrors `MCPInstallIROp.source`): when set, the handler shallow-clones the git/GitHub URL to `.reyn/skills/<name>/` instead of using a local path.
- **Fetch mechanism**: `git clone --depth 1` via `subprocess`. Subdir convention: `https://github.com/user/repo//skills/my-skill` (Terraform-style `//` separator selects a subdir inside the clone). `file://` URLs skip the http_get gate (local refs, used in tests).
- **Permission gates**: `require_http_get(<source_host>)` fires BEFORE the clone; `require_file_write(.reyn/config/skills.yaml)` unchanged. `file://` scheme returns `None` host and skips the HTTP gate.
- **Threat-scan**: fetched SKILL.md description is threat-scanned (scope="strict") before registration; clone is removed on block.
- **skills.yaml entry**: same shape as local install + `source: <url>` field.
- **New verb** `skill_management__install_source` / `SKILL_INSTALL_SOURCE` in `skill_verbs.py`.

## Dispatch-completeness entries added

All of these were added to keep exhaustive-enumeration invariants green:

1. `universal_dispatch.py` `_OPERATION_RULES`: `"skill_management__install_source": ("skill_install_source", _passthrough_args)`
2. `test_returns_external_content_flagset_1822.py` `_NOT_EXTERNAL`: `"skill_install_source"` (returns install status dict, not fetched content)
3. `test_universal_dispatch.py` `_ROUTE_CONTRACT_SAMPLES`: `("skill_management__install_source", {"source": "https://github.com/user/skill-repo"})`
4. `capability_profile.py` `_FLOORED_QUALIFIED["skill-install"]`: `"skill_management__install_source"` (denied under untrusted floor — higher risk than local: adds HTTP trust boundary)
5. `test_skill_install_pr_c.py`: new `test_skill_install_source_is_denied_under_untrusted_floor` test (mirrors local verb trust-floor test)
6. `test_2081_s3_delegation_audit.py`: added `skill_management__install_source, skill_install_source` to the delegation audit tight-profile deny string

## Tests

New `tests/test_skill_install_pr_d.py` (5 Tier 2 tests):
1. e2e clone-and-register via `file://` local git repo
2. threat-scan block → clone removed, no skills.yaml write
3. `require_http_get` gate: https source without approval raises `PermissionError` before clone
4. subdir convention (`//` separator) selects inner directory
5. config-generation smoke: `record_config_generation` writes a snapshot to `.reyn/config/generations/`

## CI gates

- `ruff check src tests` — ✓ all pass
- `python scripts/test_tier_audit.py --strict <changed test files>` — ✓ 10/10 pass
- `pytest` — `10 failed, 6861 passed, 30 skipped` (10 pre-existing failures in mcp/a2a/uvicorn — 0 new failures)
- `python scripts/verify_module_docstrings.py <changed src files>` — ✓ pass

## Ambiguities flagged

- **SSH git URLs** (`git@github.com:user/repo.git`): supported via `_source_host` parsing, but shallow-clone only works with network access. Tests use `file://` to avoid real network.
- **Re-install idempotency**: existing clone is `rmtree`-d and re-cloned on re-install (simple; no version pinning beyond shallow clone tip). Future work: `version` field for tag/ref pinning.
- **`path` field default**: changed from `str` (required) to `str = ""` to allow `source`-only ops. `path=""` is ignored when `source` is set; backward compat preserved (existing callers always pass `path`).

## Test plan

- [x] e2e clone via local `file://` repo — passes
- [x] threat-scan block — passes, clone removed
- [x] http_get gate (https URL, no approval) — raises `PermissionError`
- [x] subdir `//` convention — passes
- [x] config-generation snapshot written — passes
- [x] PR-C trust-floor tests unmodified and green
- [x] Full pytest: 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)