### PR TITLE
docs: add v1+v2 skill feature (SKILL.md registry) docs

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
           - concepts/data-retrieval/chat-compaction.md
       - Tools & integrations:
           - concepts/tools-integrations/mcp.md
+          - concepts/tools-integrations/skills.md
           - concepts/tools-integrations/universal-catalog.md
           - concepts/tools-integrations/tool-use-schemes.md
           - concepts/tools-integrations/codeact.md

--- a/docs/concepts/tools-integrations/skills.ja.md
+++ b/docs/concepts/tools-integrations/skills.ja.md
@@ -1,0 +1,119 @@
+---
+type: concept
+topic: integration
+audience: [human, agent]
+---
+
+# Skills
+
+skill とは、再利用可能でタスク特化型の instruction セット — 業界標準の `SKILL.md` ファイル(YAML frontmatter + Markdown 本文)で、ある手法が*いつ*適用されるか、*どう*実行するかをモデルに伝えます。skill は明示的に登録され、軽量なメニューとしてモデルに提示され、必要になった時点で読み込まれます — MCP ツールと同じ段階的開示の形を、API ではなく instruction に適用したものです。
+
+これは 1.0 以前の `skill.md` 駆動の phase-graph ワークフローエンジン(削除済み — 現行の実行モデルはマルチエージェント / Control IR のドキュメントを参照)とは別の機構です。ここでの「skill」は Claude Skills に近い概念です: OS が実行するプログラムではなく、モデルが読むかどうかを選ぶ instruction フォルダです。
+
+## 登録: 明示的なエントリ、ディレクトリスキャンなし
+
+skill は config 内の `skills.entries` 宣言でのみ登録されます — `mcp.servers` と同じモデルです。ディレクトリスキャンはありません。config エントリの無い `SKILL.md` はどのセッションからも見えません。
+
+```yaml
+# reyn.yaml
+skills:
+  entries:
+    pdf_editing:
+      path: skills/pdf-editing/SKILL.md
+      description: "PDF フォームのフィールドを入力・結合・抽出する"
+      enabled: true
+      auto_invoke: true
+```
+
+| フィールド | 型 | デフォルト | 意味 |
+|-----------|-----|----------|------|
+| `path` | string | 必須 | `SKILL.md`(またはそれを含むディレクトリ)へのパス。project-root 相対または絶対。 |
+| `description` | string | `""` | L1 メニューに表示される一行サマリー。最初の行のみ、200 文字上限で切り詰め。 |
+| `enabled` | bool | `true` | `false` にするとエントリはレジストリから完全に除外されます(単に非表示ではありません)。 |
+| `auto_invoke` | bool | `true` | `false` にすると skill は登録されたままですが L1 システムプロンプトメニューから除外されます — 他の何かがそれを表面化しない限り、モデルはその存在を知らされません。 |
+
+レジストリ自体は `SKILL.md` を読みません — config エントリの `path` と `description` だけが L1 メニューに反映されます。ファイル自体は L2 で、必要になった時点で通常の file-read op によってモデルが読みます。
+
+## Config カスケード
+
+`skills.entries` は他の config セクションと同じ tier をまたいでマージされ、名前が衝突した場合は後の tier が優先します:
+
+1. `~/.reyn/config.yaml` — ユーザーグローバル
+2. `reyn.yaml` — プロジェクト
+3. `reyn.local.yaml` — プロジェクトローカル(gitignore 対象)
+4. `.reyn/config/skills.yaml` — ランタイム動的、`skill_management__install_*` ツールが書き込む
+
+最初の 3 つを手編集するのが skill を登録する通常の方法です。4 つ目は下記のインストールツールが自動的に書き込むもので、セッションが自分自身のためにインストールした内容を反映します。
+
+## `SKILL.md` を書く
+
+```markdown
+---
+name: pdf-editing
+description: PDF フォームのフィールドを入力・結合・抽出する
+---
+
+# PDF editing
+
+フォームフィールド操作には `pypdf` を使用...
+```
+
+`name` と `description` は frontmatter のキーで、下記のインストールツールが `skills.yaml` エントリを事前入力する際に読みます — 実際にモデルに届くのは config エントリ自身の `description` なので、正確かつ短く保ってください(最初の行のみ。詳細は本文に書く)。Markdown 本文は自由形式です: これは OS がパースするスキーマではなく、モデル向けの instruction テキストです。
+
+## 3 層の露出モデル
+
+| レイヤー | モデルが見るもの | 機構 |
+|---------|----------------|------|
+| **L1 — メニュー** | 専用の `## Skills` システムプロンプトブロック。enabled + auto-invoke な skill ごとに 1 行: `name — description [path]`。 | 専用ディスパッチ無しで、ターンごとに 1 回構築。 |
+| **L2 — instruction** | `SKILL.md` の本文全体。モデルが現在のタスクがエントリの description に一致すると判断した時のみ読まれる。 | 通常の `file__read` — 専用の「skill 呼び出し」op は無し。 |
+| **L3 — バンドル資産** | skill の instruction が参照するその他のファイル(テンプレート、スクリプト、参照データ)。`SKILL.md` と同じ場所にある。 | 通常の `file__read`、他のパスと同様に標準パーミッションモデルでゲート。 |
+
+どのレイヤーにも「この skill を実行する」専用プリミティブはありません — skill は L1 で発見され、L2 で読み込まれ、その資産は単なるファイルです。関連性の判断はモデルが L1 の description から行います。OS がゲートするのは「どの skill を読めるか」ではなく「どのパスを読めるか」だけです(標準パーミッションモデル — プロジェクトルート内の読み取りはデフォルト、それ以外は通常の宣言 + 承認が必要)。
+
+## ホットリロード
+
+`.reyn/config/skills.yaml` への編集は次のターン境界で `"skills"` リロードシームを通じて反映されます — セッション再起動不要。`reyn.yaml` / `reyn.local.yaml` を直接編集する場合は、他のセクションと同じ一般的な config ホットリロード経路に従います。[コンセプト: Config ホットリロード](../runtime/config-hot-reload.md) を参照。
+
+## セッションごとの可視性トグル
+
+skill は config を触らずに、単一セッションから非表示にできます — tool / MCP サーバー / カテゴリと同じステータスバー式の可視性オーバーライドを使います: `set_capability_visible("skill", name, visible)`。これは**制限のみ**です — 登録されていない skill 名(またはトポロジー/委譲エンベロープが既に拒否しているもの)をトグルしても静かな no-op になります。可視性は登録済みの範囲を超えて権限を付与することはできません。
+
+## skill のインストール
+
+`skill_management` カテゴリ配下の 2 つの chat 呼び出し可能ツールが `skills.yaml` エントリを書き込みます — v1/v2 に `reyn skill` という CLI 相当は存在しません(skill 管理は chat 駆動の対話内フローです)。
+
+### `skill_management__install_local`
+
+ローカルの skill ディレクトリ(または `SKILL.md` への直接パス)を `.reyn/config/skills.yaml` に登録します:
+
+1. `SKILL.md` を解決(ディレクトリ → `<dir>/SKILL.md`、または直接ファイルパス)。
+2. frontmatter から `name` / `description` を読む(`name` override 引数が優先。frontmatter に無ければディレクトリのベースネームにフォールバック)。
+3. description を脅威スキャン(strict scope) — blocking severity のマッチでブロック。
+4. `skills.yaml` の書き込みを標準の `require_file_write` パーミッションフローでゲート。
+5. エントリを書き込み、config generation を記録(クラッシュリカバリ — WAL truncation を生き延びる)、`skill_installed` P6 イベントを発行、ホットリロードを要求。
+
+### `skill_management__install_source`
+
+git/GitHub URL から skill を取得してクローンをインストールします:
+
+1. ソースホストに対して `require_http_get` をゲート。
+2. リポジトリを shallow-clone(`--depth 1`)して `.reyn/skills/<name>/` へ。URL 末尾の `//subdir` サフィックス(Terraform のモジュール subdir 規約を踏襲)でクローン内のサブディレクトリを選択可能。
+3. クローン内で `SKILL.md` を特定し、ローカルパスと同じ frontmatter 読み取り → 脅威スキャン → ゲート → 書き込み → ホットリロードのパイプラインへ進む。登録される `path` はインストール済みコピーを指す。
+
+**パス安全性の強化**(両ツールとも、解決された名前が `.reyn/skills/` 配下のファイルシステムパスに使われるため): `name` 引数、`SKILL.md` frontmatter、または URL/subdir のベースネームから導出された名前は、単一の安全なパス要素(`[A-Za-z0-9._-]+`、`..` 無し、先頭ドット無し、区切り文字無し)でない限り即座に拒否されます。さらに belt-and-suspenders な containment チェック(`resolve()` + `relative_to()`)が、インストール先が `.reyn/skills/` の外に解決されるケースを拒否します — name チェック自体にギャップがあった場合の保険です。どちらのチェックも安全でない名前を黙って書き換えることはなく、明示的なエラーでインストールを拒否します。
+
+## 現時点でのスコープ外
+
+意図的に現行モデルに含まれていないもの — 今のギャップではなく、将来のレイヤーとして計画されているもの:
+
+- skill ごとのツールパーミッションスコープ(`allowed-tools` 的なアクティベーションスコープ)
+- skill instruction 内での動的シェルコマンド実行構文
+- skill を発見するための marketplace / レジストリインデックス(MCP の公式レジストリとは異なり)
+- `list_skills` / `describe_skill` の introspection ツールや CLI
+
+## 関連情報
+
+- [リファレンス: `reyn.yaml`](../../reference/config/reyn-yaml.md) — `skills:` ブロックのスキーマ
+- [コンセプト: MCP](mcp.md) — 類似の外部ケイパビリティ登録モデル
+- [コンセプト: パーミッションモデル](../runtime/permission-model.md) — skill が使う file-read/file-write ゲート
+- [コンセプト: Config ホットリロード](../runtime/config-hot-reload.md) — 一般的なリロードサイクル

--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -1,0 +1,119 @@
+---
+type: concept
+topic: integration
+audience: [human, agent]
+---
+
+# Skills
+
+A skill is a reusable, task-specific instruction set — an industry-standard `SKILL.md` file (YAML frontmatter + Markdown body) that tells the model *when* a technique applies and *how* to carry it out. Skills are registered explicitly, exposed to the model as a lightweight menu, and read on demand — the same layered-disclosure shape as MCP tools, applied to instructions instead of APIs.
+
+This is a different mechanism from the pre-1.0 `skill.md`-driven phase-graph workflow engine (removed; see the multi-agent / control-IR docs for the current execution model). A "skill" here is closer to a Claude Skill: a folder with instructions the model chooses to read, not a program the OS executes.
+
+## Registration: explicit entries, no directory scan
+
+Skills are registered purely via `skills.entries` declarations in config — the same model as `mcp.servers`. There is no directory scan; a `SKILL.md` file sitting on disk with no config entry is invisible to every session.
+
+```yaml
+# reyn.yaml
+skills:
+  entries:
+    pdf_editing:
+      path: skills/pdf-editing/SKILL.md
+      description: "Fill, merge, and extract fields from PDF forms"
+      enabled: true
+      auto_invoke: true
+```
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `path` | string | required | Path to `SKILL.md` (or its containing directory). Project-root-relative or absolute. |
+| `description` | string | `""` | One-line summary shown in the L1 menu. Truncated to the first line, capped at 200 characters. |
+| `enabled` | bool | `true` | `false` removes the entry from the registry entirely (not just hidden). |
+| `auto_invoke` | bool | `true` | `false` keeps the skill registered but excludes it from the L1 system-prompt menu — the model won't be told it exists unless something else surfaces it. |
+
+The registry never reads `SKILL.md` itself — only `path` and `description` from the config entry populate the L1 menu. The file is read by the model at L2, on demand, via the ordinary file-read op.
+
+## Config cascade
+
+`skills.entries` merges across the same tiers as every other config section, later tiers winning on name collision:
+
+1. `~/.reyn/config.yaml` — user-global
+2. `reyn.yaml` — project
+3. `reyn.local.yaml` — project-local (gitignored)
+4. `.reyn/config/skills.yaml` — runtime-dynamic, written by the `skill_management__install_*` tools
+
+Hand-editing any of the first three is a normal way to register a skill; the fourth is written automatically by the install tools below and reflects what a session installed for itself.
+
+## Writing a `SKILL.md`
+
+```markdown
+---
+name: pdf-editing
+description: Fill, merge, and extract fields from PDF forms
+---
+
+# PDF editing
+
+Use `pypdf` for form-field operations...
+```
+
+`name` and `description` are frontmatter keys read by the install tools (see below) to prefill a `skills.yaml` entry — the config entry's own `description` is what actually reaches the model, so keep it accurate and short (first line only; longer detail belongs in the body). The Markdown body is free-form: this is model-facing instruction text, not a schema the OS parses.
+
+## Three-layer exposure
+
+| Layer | What the model sees | Mechanism |
+|-------|---------------------|-----------|
+| **L1 — menu** | A dedicated `## Skills` system-prompt block, one line per enabled + auto-invoke skill: `name — description [path]`. | Built once per turn from the registry; no dedicated dispatch. |
+| **L2 — instructions** | The full `SKILL.md` body, read only when the model judges the current task matches an entry's description. | Ordinary `file__read` — no dedicated "invoke skill" op. |
+| **L3 — bundled assets** | Any additional files the skill's instructions reference (templates, scripts, reference data) sitting alongside `SKILL.md`. | Ordinary `file__read`, gated by the standard permission model like any other path. |
+
+There is no dedicated "run this skill" primitive at any layer — a skill is discovered via L1, loaded via L2, and its assets are just files. The model decides relevance from the L1 description; the OS does not gate *which* skill the model may read, only *which paths* it may read (the standard permission model — reading inside the project root is a default; outside requires the usual declaration + approval).
+
+## Hot-reload
+
+Edits to `.reyn/config/skills.yaml` take effect at the next turn boundary via the `"skills"` reload seam — no session restart needed. Editing `reyn.yaml` / `reyn.local.yaml` directly follows the same general config hot-reload path as other sections; see [Concepts: Config hot-reload](../runtime/config-hot-reload.md).
+
+## Per-session visibility toggle
+
+A skill can be hidden from a single session without touching config, via the same status-bar-style visibility override used for tools / MCP servers / categories: `set_capability_visible("skill", name, visible)`. This is **restrict-only** — toggling a skill name that isn't in the registered set (or that a topology/delegation envelope already denies) is a silent no-op; visibility can never grant access beyond what's registered.
+
+## Installing skills
+
+Two chat-callable tools under the `skill_management` category write `skills.yaml` entries — there is no `reyn skill` CLI equivalent in v1/v2 (skill management is a chat-driven, in-conversation flow).
+
+### `skill_management__install_local`
+
+Registers a local skill directory (or a direct path to its `SKILL.md`) into `.reyn/config/skills.yaml`:
+
+1. Resolves `SKILL.md` (directory → `<dir>/SKILL.md`, or a direct file path).
+2. Reads `name` / `description` from frontmatter (`name` override argument takes precedence; falls back to the directory basename if frontmatter has none).
+3. Threat-scans the description (strict scope) — blocks on a blocking-severity match.
+4. Gates the `skills.yaml` write through the standard `require_file_write` permission flow.
+5. Writes the entry, records a config generation (crash-recovery — survives WAL truncation), emits a `skill_installed` P6 event, and requests a hot-reload.
+
+### `skill_management__install_source`
+
+Fetches a skill from a git/GitHub URL and installs the clone:
+
+1. Gates `require_http_get` for the source host.
+2. Shallow-clones the repo (`--depth 1`) to `.reyn/skills/<name>/`. A `//subdir` suffix on the URL (mirroring Terraform's module-subdir convention) selects a subdirectory of the clone instead of its root.
+3. Locates `SKILL.md` in the clone, then proceeds through the same frontmatter-read → threat-scan → gate → write → hot-reload pipeline as the local path, with the registered `path` pointing at the installed copy.
+
+**Path-safety hardening** (both tools, since the resolved name feeds a filesystem path under `.reyn/skills/`): the derived name — from the `name` argument, `SKILL.md` frontmatter, or a URL/subdir basename — is rejected outright unless it is a single safe path component (`[A-Za-z0-9._-]+`, no `..`, no leading dot, no separators). A belt-and-suspenders containment check (`resolve()` + `relative_to()`) additionally refuses any install destination that would resolve outside `.reyn/skills/`, guarding against a gap in the name check itself. Neither check silently rewrites an unsafe name — installation is refused with an explicit error instead.
+
+## What's out of scope (for now)
+
+Deliberately not part of the current model — planned for a future layer, not a gap in this one:
+
+- Per-skill tool-permission scoping (an `allowed-tools` style activation scope)
+- Dynamic shell-command execution syntax inside skill instructions
+- A marketplace / registry index for discovering skills (unlike MCP's official registry)
+- `list_skills` / `describe_skill` introspection tools or CLI
+
+## See also
+
+- [Reference: `reyn.yaml`](../../reference/config/reyn-yaml.md) — `skills:` block schema
+- [Concepts: MCP](mcp.md) — the analogous external-capability registration model
+- [Concepts: permission model](../runtime/permission-model.md) — the file-read/file-write gates skills use
+- [Concepts: Config hot-reload](../runtime/config-hot-reload.md) — the general reload cycle

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -144,6 +144,13 @@ mindmap
       Transports
       mcp serve
       mcp install
+    📘 Skills
+      SKILL.md registry
+      Three-layer exposure
+      Hot-reload
+      Session visibility toggle
+      install_local
+      install_source
     🌐 Web and Protocol
       FastAPI gateway
       WebSocket chat
@@ -516,6 +523,22 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | Tool dispatch | Lazy-load and cache `MCPClient` per server connection | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
 
 > **Differentiation vs general agents:** Reyn is both an MCP client (consumes external servers) and an MCP server (exposes its own agents) — standard-protocol interop in both directions, with stdio MCP servers subprocess-sandboxed under Seatbelt.
+
+---
+
+### Skills
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| `SKILL.md` registry | Explicit `skills.entries` declarations (no directory scan) — same registration model as `mcp.servers` | [Concepts: Skills](concepts/tools-integrations/skills.md) |
+| Three-layer exposure | L1 system-prompt `## Skills` menu (`name — description [path]`) → L2 on-demand `SKILL.md` read → L3 bundled-asset file-read, all via the ordinary file-read op | [Concepts: Skills](concepts/tools-integrations/skills.md) |
+| Config cascade | `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ dynamic `.reyn/config/skills.yaml`, later tier wins on name collision | [Reference: `reyn.yaml`](reference/config/reyn-yaml.md) |
+| Hot-reload | `.reyn/config/skills.yaml` edits apply at the next turn boundary via the `"skills"` reload seam | [Concepts: Config hot-reload](concepts/runtime/config-hot-reload.md) |
+| Session visibility toggle | `set_capability_visible("skill", name, visible)` — restrict-only, cannot re-grant beyond the registered set | [Concepts: Skills](concepts/tools-integrations/skills.md) |
+| `skill_management__install_local` | Register a local skill directory into `.reyn/config/skills.yaml`; threat-scanned, permission-gated, config-generation recorded for crash-recovery | [Concepts: Skills](concepts/tools-integrations/skills.md) |
+| `skill_management__install_source` | Fetch + shallow-clone a skill from a git/GitHub URL into `.reyn/skills/<name>/`; same threat-scan/gate/recovery pipeline, plus path-traversal-hardened name sanitization and containment checks | [Concepts: Skills](concepts/tools-integrations/skills.md) |
+
+> **Differentiation vs general agents:** skills are instructions the model chooses to read, not programs the OS executes — the same layered-disclosure shape (menu → on-demand load) as MCP tool discovery, applied to task-specific technique instead of external APIs.
 
 ---
 

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -506,7 +506,7 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | Action embedding index | `ActionEmbeddingIndex` (SQLite-WAL, class-swap detection, cross-process build lock) — backs the `search_actions` tool the chat LLM uses | [Universal catalog § search_actions](concepts/tools-integrations/universal-catalog.md#what-stays-out-of-phase-1) · [`reyn embeddings`](reference/cli/embeddings.md) |
 | Memory CRUD | `list` / `read` / `remember_shared` / `remember_agent` / `forget` | [Memory concepts](concepts/data-retrieval/memory.md) · [reyn memory CLI](reference/cli/memory.md) |
 
-> **Differentiation vs general agents:** beyond chat memory, Reyn ships a RAG *framework* — you declare an indexing strategy as a `skill.md` (LLM-picked chunking + a deterministic embed/write chain) over a pluggable `IndexBackend`, with a credential-free local-embedding option. A foundation to build on, not a fixed memory feature.
+> **Differentiation vs general agents:** beyond chat memory, Reyn ships a RAG *framework* — a safe-mode Python step calls `embed_and_index()` directly (you own the chunking logic) over a pluggable `IndexBackend`, with a credential-free local-embedding option. A foundation to build on, not a fixed memory feature.
 
 ---
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -748,6 +748,31 @@ mcp:
 
 [コンセプト: MCP](../../concepts/tools-integrations/mcp.md) でプロトコル概要を参照してください。
 
+## `skills` ブロック
+
+`SKILL.md` ベースの skill を登録します — `mcp.servers` と同じ明示的登録モデルです(ディレクトリスキャンなし。skill が可視になるにはエントリが存在する必要があります)。
+
+```yaml
+skills:
+  entries:
+    pdf_editing:
+      path: skills/pdf-editing/SKILL.md   # project-root 相対または絶対
+      description: "PDF フォームのフィールドを入力・結合・抽出する"
+      enabled: true
+      auto_invoke: true
+```
+
+| フィールド | 型 | デフォルト | 説明 |
+|-----------|-----|----------|------|
+| `path` | string | 必須 | `SKILL.md`、またはそれを含むディレクトリへのパス。 |
+| `description` | string | `""` | モデル向けの `## Skills` メニューに表示される一行サマリー(最初の行のみ、200 文字上限)。 |
+| `enabled` | bool | `true` | `false` にするとエントリはレジストリから完全に除外されます。 |
+| `auto_invoke` | bool | `true` | `false` にすると skill は登録されたままシステムプロンプトメニューから除外されます。 |
+
+`skills.entries` は `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ 動的な `<project>/.reyn/config/skills.yaml`(`skill_management__install_local` / `skill_management__install_source` chat ツールが書き込む)をまたいでマージされ、名前が衝突した場合は後の tier が優先します — `mcp.servers` と同じマージ形です。
+
+登録モデル全体、3 層の露出モデル(メニュー / オンデマンド読み取り / バンドル資産)、インストールツールについては [コンセプト: Skills](../../concepts/tools-integrations/skills.md) を参照してください。
+
 ## `embedding` ブロック
 
 RAG 埋め込みモデルクラスとバッチ設定。組み込みデフォルトが OpenAI パスをカバーしているため、`OPENAI_API_KEY` を設定した新規インストールでは `reyn.yaml` の変更は不要です。

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1105,6 +1105,31 @@ mcp:
 
 See [Concepts: MCP](../../concepts/tools-integrations/mcp.md) for the protocol overview and How-to: use an MCP server for the end-to-end quickstart.
 
+## `skills` block
+
+Registers `SKILL.md`-based skills — the same explicit-registration model as `mcp.servers` (no directory scan; an entry must exist for a skill to be visible).
+
+```yaml
+skills:
+  entries:
+    pdf_editing:
+      path: skills/pdf-editing/SKILL.md   # project-root-relative or absolute
+      description: "Fill, merge, and extract fields from PDF forms"
+      enabled: true
+      auto_invoke: true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `path` | string | required | Path to `SKILL.md`, or its containing directory. |
+| `description` | string | `""` | One-line summary shown in the model-facing `## Skills` menu (first line only, 200-char cap). |
+| `enabled` | bool | `true` | `false` removes the entry from the registry entirely. |
+| `auto_invoke` | bool | `true` | `false` keeps the skill registered but excludes it from the system-prompt menu. |
+
+`skills.entries` merges across `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ the dynamic `<project>/.reyn/config/skills.yaml` (written by the `skill_management__install_local` / `skill_management__install_source` chat tools), later tiers winning on name collision — the same merge shape as `mcp.servers`.
+
+See [Concepts: Skills](../../concepts/tools-integrations/skills.md) for the full registration model, the three-layer exposure model (menu / on-demand read / bundled assets), and the install tools.
+
 ## `embedding` block
 
 RAG embedding model classes and batch settings. Built-in defaults cover the OpenAI path — no `reyn.yaml` changes are required for a fresh install with `OPENAI_API_KEY`.


### PR DESCRIPTION
**[docs-maintainer]** — owner-triggered dispatch (via lead-coder): skill v1+v2 landed on main (#2548 PR-A through PR-D). Requesting co-vet per lead-coder's ask.

## New files
- `docs/concepts/tools-integrations/skills.md` + `.ja.md` — the full model: registration (no dir-scan), config cascade, `SKILL.md` authoring, three-layer exposure (menu / on-demand read / bundled assets), hot-reload, session visibility toggle, install tools + their security hardening, and an explicit out-of-scope list (mirroring what lead-coder named as v2-deferred).

## Modified
- `docs/reference/config/reyn-yaml.md` + `.ja.md` — new `## skills` block schema section, placed directly after "MCP servers" (same registration pattern; cross-referenced both ways).
- `docs/feature-map.md` — mindmap node (`📘 Skills`) + new `### Skills` feature-index table, placed after `### MCP`.
- `.mkdocs/mkdocs.yml` — nav entry for the new concept doc.

## Every claim verified against `src/`, not summarized from the dispatch
- **Registry** (`data/skills/registry.py`): `build_skill_registry()` only reads `skills.entries` — confirmed the `scan_dirs` key mentioned in `config/root.py`'s comment is **not actually read anywhere**; it's an aspirational comment, not live behavior. `enabled=False` removes an entry from the registry entirely (not just hides it); `auto_invoke=False` keeps it registered but drops it from the L1 menu.
- **Config cascade** (`config/loader.py`): `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ dynamic `.reyn/config/skills.yaml` — same shape as `mcp.servers`.
- **L1** (`tools/schemes/_universal_sp.py`): dedicated `## Skills` system-prompt slot, `name — description [path]`, only enabled+auto_invoke entries, omitted entirely when none qualify.
- **L2/L3**: confirmed **no dedicated dispatch exists** — grepped `universal_catalog.py`'s registered-category tuple: only `skill_management` is registered; `skill__<name>` (per-skill resource dispatch) is a **reserved comment**, not wired. Reading `SKILL.md` and its bundled assets is ordinary `file__read` — the doc says exactly this, not more.
- **Hot-reload**: `"skills"` `ReapplySeam` registered in `runtime/session.py`, turn-boundary.
- **Session visibility**: `set_capability_visible(kind="skill", ...)` is restrict-only — confirmed via its docstring and the `_reapply_skill_visibility` re-derive-from-base logic.
- **Install tools** (`tools/skill_verbs.py`, `core/op_runtime/skill_install.py`): frontmatter extraction, threat-scan (strict, blocking match removes any clone), `require_file_write` gate (+ `require_http_get` for the source host on `install_source`), **config-generation recorded for crash-recovery** — confirmed the CLAUDE.md hard-rule truncate-falsify test exists (`test_skill_install_pr_c.py`'s dedicated test). Path-safety: name sanitization (single safe path component) *plus* a separate `resolve()`+`relative_to()` containment check before any filesystem mutation — documented both layers since the code comments frame them as independent defenses, not redundant.
- **`SKILL.md` shape**: no repo-tracked example file existed to read directly (only the old lowercase `skill.md` format, unrelated) — confirmed the frontmatter shape (`name`/`description` + Markdown body) from `test_skill_install_pr_c.py`'s fixture-generation helper instead.

## Noticed in passing (flagged, not fixed here)
`feature-map.md`'s RAG section "Differentiation vs general agents" callout still describes indexing strategy as *"declared as a `skill.md` (LLM-picked chunking)"* — that's the dead pre-1.0 model PR-B (#2520) already corrected in `rag.md` itself, but `feature-map.md`'s own callout wasn't updated in that pass. Separate, small follow-up.

## CI gates (local)
- `ruff check src tests` — pass
- `pytest tests/test_fp0036_coverage.py` — 23/23 pass
- `mkdocs build --strict` (from `.mkdocs/`) — exit 0, no warnings

## Test plan
- [x] `mkdocs build --strict` exit 0
- [x] fp0036 mirror tests green (23/23)
- [x] ruff clean
- [ ] **Co-vet requested** (per lead-coder's ask) — awaiting accuracy review before merge